### PR TITLE
Make shortcuts discoverable from the Jump palette

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -68,8 +68,17 @@ import {
   buildCmdJSettingsResults,
   rankCmdJMiddleResults,
   type CmdJActionResult,
-  type CmdJSettingsResult
+  type CmdJSettingsResult,
+  type CmdJShortcutResult
 } from '@/components/cmd-j/palette-results'
+import { buildCmdJShortcutResults } from '@/components/cmd-j/shortcut-results'
+import {
+  buildShortcutBindingSearchText,
+  buildShortcutPaletteItems,
+  getShortcutSettingsTarget,
+  ShortcutPaletteCommandItem,
+  type ShortcutPaletteItem
+} from '@/components/cmd-j/shortcut-palette-items'
 import {
   buildCmdJQuickActionContext,
   captureCmdJActiveGroupSnapshot,
@@ -80,6 +89,7 @@ import {
   getCmdJQuickActions,
   CREATE_WORKSPACE_QUICK_ACTION_ID
 } from '@/components/cmd-j/quick-actions'
+import { groupDefinitions } from '@/components/settings/shortcut-groups'
 import {
   getComposerEligibleRepos,
   resolveComposerGitRepoId
@@ -149,6 +159,7 @@ type PaletteItem =
   | WorktreePaletteItem
   | SettingsPaletteItem
   | QuickActionPaletteItem
+  | ShortcutPaletteItem
   | BrowserPaletteItem
   | SimulatorPaletteItem
 
@@ -319,6 +330,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const activeGroupIdByWorktree = useAppStore((s) => s.activeGroupIdByWorktree)
   const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
   const settings = useAppStore((s) => s.settings)
+  const keybindings = useAppStore((s) => s.keybindings)
   const sshTargetLabels = useAppStore((s) => s.sshTargetLabels)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
@@ -651,6 +663,21 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     () => buildCmdJSettingsResults(settingsSections),
     [settingsSections]
   )
+  const shortcutDefinitions = useMemo(
+    () => groupDefinitions(settings?.disabledTuiAgents ?? []).flatMap((group) => group.items),
+    [settings?.disabledTuiAgents]
+  )
+  const shortcutResults = useMemo(
+    () =>
+      buildCmdJShortcutResults({
+        definitions: shortcutDefinitions,
+        bindingSearchTextByActionId: buildShortcutBindingSearchText(
+          shortcutDefinitions,
+          keybindings
+        )
+      }),
+    [keybindings, shortcutDefinitions]
+  )
   const actionResults = useMemo(() => buildCmdJActionResults(getCmdJQuickActions()), [])
 
   const prefetchCreateWorkspaceBaseForComposer = useCallback((initialRepoId?: string): void => {
@@ -708,21 +735,48 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
   const quickActionContext = buildQuickActionContext()
 
-  const middleItems = useMemo<(SettingsPaletteItem | QuickActionPaletteItem)[]>(
-    () =>
-      rankCmdJMiddleResults({
-        query: deferredQuery,
-        settingsResults,
-        actionResults: actionResults.filter(
-          (action) => action.isAvailable(quickActionContext).available
-        )
-      }).map((result) =>
-        result.kind === 'settings'
-          ? { id: result.id, type: 'settings' as const, result }
-          : { id: `quick-action:${result.id}`, type: 'quick-action' as const, result }
-      ),
-    [actionResults, deferredQuery, quickActionContext, settingsResults]
-  )
+  const middleItems = useMemo<
+    (SettingsPaletteItem | QuickActionPaletteItem | ShortcutPaletteItem)[]
+  >(() => {
+    const rankedResults = rankCmdJMiddleResults({
+      query: deferredQuery,
+      settingsResults,
+      shortcutResults,
+      actionResults: actionResults.filter(
+        (action) => action.isAvailable(quickActionContext).available
+      )
+    })
+    const shortcutItemsById = new Map(
+      buildShortcutPaletteItems({
+        results: rankedResults.filter(
+          (result): result is CmdJShortcutResult => result.kind === 'shortcut'
+        ),
+        keybindings
+      }).map((item) => [item.id, item])
+    )
+
+    return rankedResults
+      .map((result) => {
+        if (result.kind === 'settings') {
+          return { id: result.id, type: 'settings' as const, result }
+        }
+        if (result.kind === 'shortcut') {
+          return shortcutItemsById.get(result.id) ?? null
+        }
+        return { id: `quick-action:${result.id}`, type: 'quick-action' as const, result }
+      })
+      .filter(
+        (item): item is SettingsPaletteItem | QuickActionPaletteItem | ShortcutPaletteItem =>
+          item !== null
+      )
+  }, [
+    actionResults,
+    deferredQuery,
+    keybindings,
+    quickActionContext,
+    settingsResults,
+    shortcutResults
+  ])
 
   // Why: on empty query we cap the worktree section (not open tabs) so the
   // OPEN TABS header + ≥1 tab row stays visible above the fold — users
@@ -1123,6 +1177,17 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     [closeModal, openSettingsPage, openSettingsTarget, recordFeatureInteraction]
   )
 
+  const handleSelectShortcut = useCallback(
+    (result: CmdJShortcutResult) => {
+      skipRestoreFocusRef.current = true
+      closeModal()
+      setSelectedItemId('')
+      openSettingsTarget(getShortcutSettingsTarget(result.actionId))
+      openSettingsPage()
+    },
+    [closeModal, openSettingsPage, openSettingsTarget]
+  )
+
   const handleSelectQuickAction = useCallback(
     (action: CmdJActionResult) => {
       skipRestoreFocusRef.current = true
@@ -1154,6 +1219,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         handleSelectSimulatorTab(item.result)
       } else if (item.type === 'settings') {
         handleSelectSettings(item.result)
+      } else if (item.type === 'shortcut') {
+        handleSelectShortcut(item.result)
       } else {
         handleSelectQuickAction(item.result)
       }
@@ -1161,6 +1228,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     [
       handleSelectBrowserPage,
       handleSelectQuickAction,
+      handleSelectShortcut,
       handleSelectSettings,
       handleSelectSimulatorTab,
       handleSelectWorktree
@@ -1384,7 +1452,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         ),
         subtitle: translate(
           'auto.components.WorktreeJumpPalette.c4afa68159',
-          'Try a worktree, setting, action, page title, emulator, URL, PR, or port.'
+          'Try a worktree, shortcut, setting, action, page title, emulator, URL, PR, or port.'
         )
       }
     }
@@ -1400,14 +1468,14 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         ),
         subtitle: translate(
           'auto.components.WorktreeJumpPalette.b781ae05e3',
-          'Type to search worktrees, settings, tabs, and actions.'
+          'Type to search worktrees, shortcuts, settings, tabs, and actions.'
         )
       }
     }
     return {
       title: translate(
         'auto.components.WorktreeJumpPalette.1628fd7dfa',
-        'No active worktrees, settings, actions, or open tabs'
+        'No active worktrees, shortcuts, settings, actions, or open tabs'
       ),
       subtitle: translate(
         'auto.components.WorktreeJumpPalette.f7fda8d562',
@@ -1426,7 +1494,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       title={translate('auto.components.WorktreeJumpPalette.4ee378034d', 'Jump to...')}
       description={translate(
         'auto.components.WorktreeJumpPalette.4e4ff044d5',
-        'Search worktrees, settings, tabs, and actions'
+        'Search worktrees, shortcuts, settings, tabs, and actions'
       )}
       overlayClassName="bg-black/55 backdrop-blur-[2px]"
       contentClassName="top-[13%] w-[736px] max-w-[94vw] overflow-hidden rounded-xl border border-border/70 bg-background/96 shadow-[0_26px_84px_rgba(0,0,0,0.32)] backdrop-blur-xl"
@@ -1440,7 +1508,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       <CommandInput
         placeholder={translate(
           'auto.components.WorktreeJumpPalette.1ebe225fee',
-          'Search worktrees, settings, tabs, and actions...'
+          'Search worktrees, shortcuts, settings, tabs, and actions...'
         )}
         value={query}
         onValueChange={handleQueryChange}
@@ -1654,6 +1722,16 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                       </div>
                     </div>
                   </CommandItem>
+                )
+              }
+
+              if (entry.type === 'shortcut') {
+                return (
+                  <ShortcutPaletteCommandItem
+                    key={entry.id}
+                    item={entry}
+                    onSelect={() => handleSelectItem(entry)}
+                  />
                 )
               }
 

--- a/src/renderer/src/components/cmd-j/palette-results.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-results.test.ts
@@ -6,7 +6,10 @@ import {
   buildCmdJSettingsResults,
   rankCmdJMiddleResults
 } from './palette-results'
+import { buildCmdJShortcutResults } from './shortcut-results'
 import type { SettingsNavSection } from '@/lib/settings-navigation-types'
+import type { KeybindingDefinition } from '../../../../shared/keybindings'
+import { groupDefinitions } from '@/components/settings/shortcut-groups'
 
 const noopRun: CmdJQuickAction['run'] = async () => ({ status: 'ok' })
 const available: CmdJQuickAction['isAvailable'] = () => ({ available: true })
@@ -132,6 +135,14 @@ const sections: SettingsNavSection[] = [
     group: 'interface'
   },
   {
+    id: 'shortcuts',
+    title: 'Shortcuts',
+    description: 'Keyboard shortcuts.',
+    icon: Settings,
+    searchEntries: [{ title: 'Keyboard Shortcuts' }],
+    group: 'interface'
+  },
+  {
     id: 'agents',
     title: 'Agents',
     description: 'Manage AI agents.',
@@ -149,10 +160,54 @@ const sections: SettingsNavSection[] = [
   }
 ]
 
+const shortcutDefinitions: KeybindingDefinition[] = [
+  {
+    id: 'terminal.splitRight',
+    title: 'Split terminal right',
+    group: 'Terminal',
+    scope: 'terminal',
+    searchKeywords: ['pane', 'split', 'right'],
+    defaultBindings: {
+      darwin: ['Mod+Backslash'],
+      linux: ['Mod+Shift+Backslash'],
+      win32: ['Mod+Shift+Backslash']
+    }
+  },
+  {
+    id: 'tab.newTerminal',
+    title: 'New Terminal',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['terminal', 'tab'],
+    defaultBindings: {
+      darwin: ['Mod+T'],
+      linux: ['Mod+T'],
+      win32: ['Mod+T']
+    }
+  }
+]
+
 function top(query: string): string | undefined {
   return rankCmdJMiddleResults({
     query,
     settingsResults: buildCmdJSettingsResults(sections),
+    actionResults: buildCmdJActionResults(actions)
+  })[0]?.id
+}
+
+function topWithShortcuts(
+  query: string,
+  bindingSearchTextByActionId: Parameters<
+    typeof buildCmdJShortcutResults
+  >[0]['bindingSearchTextByActionId'] = {}
+): string | undefined {
+  return rankCmdJMiddleResults({
+    query,
+    settingsResults: buildCmdJSettingsResults(sections),
+    shortcutResults: buildCmdJShortcutResults({
+      definitions: shortcutDefinitions,
+      bindingSearchTextByActionId
+    }),
     actionResults: buildCmdJActionResults(actions)
   })[0]?.id
 }
@@ -200,5 +255,57 @@ describe('Cmd+J palette middle-band ranking', () => {
   it('does not match settings on one-character or description-only queries', () => {
     expect(top('t')).toBeUndefined()
     expect(top('cookie import')).toBeUndefined()
+  })
+
+  it('builds shortcut rows from keybinding definitions', () => {
+    expect(buildCmdJShortcutResults({ definitions: shortcutDefinitions })[0]).toMatchObject({
+      id: 'shortcut:terminal.splitRight',
+      kind: 'shortcut',
+      title: 'Split terminal right',
+      description: 'Terminal shortcut',
+      actionId: 'terminal.splitRight'
+    })
+  })
+
+  it.each([
+    ['terminal shortcut', 'shortcut:terminal.splitRight'],
+    ['split terminal right shortcut', 'shortcut:terminal.splitRight'],
+    ['new terminal shortcut', 'shortcut:tab.newTerminal'],
+    ['keyboard shortcut terminal', 'shortcut:terminal.splitRight']
+  ])('ranks shortcut query %s first', (query, expectedId) => {
+    expect(topWithShortcuts(query)).toBe(expectedId)
+  })
+
+  it('uses caller-provided binding labels for shortcut ranking', () => {
+    expect(topWithShortcuts('ctrl shift backslash')).toBeUndefined()
+    expect(
+      topWithShortcuts('ctrl shift backslash', {
+        'terminal.splitRight': ['Ctrl+Shift+\\', 'Ctrl Shift \\']
+      })
+    ).toBe('shortcut:terminal.splitRight')
+  })
+
+  it('keeps pure settings queries ahead of shortcut rows', () => {
+    expect(topWithShortcuts('terminal')).toBe('settings:terminal')
+  })
+
+  it.each([
+    ['shortcut', 'settings:shortcuts'],
+    ['keybinding', 'settings:shortcuts']
+  ])('keeps generic %s query on the Shortcuts settings pane', (query, expectedId) => {
+    expect(topWithShortcuts(query)).toBe(expectedId)
+  })
+
+  it('honors disabled-agent filtering before building shortcut results', () => {
+    const filteredDefinitions = groupDefinitions(['codex']).flatMap((group) => group.items)
+    const resultIds = buildCmdJShortcutResults({ definitions: filteredDefinitions }).map(
+      (result) => result.actionId
+    )
+
+    expect(resultIds).not.toContain('tab.newAgent.codex')
+  })
+
+  it('does not return shortcut rows on one-character queries', () => {
+    expect(topWithShortcuts('s')).toBeUndefined()
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-results.ts
+++ b/src/renderer/src/components/cmd-j/palette-results.ts
@@ -1,5 +1,8 @@
 import type { SettingsNavIcon, SettingsNavSection } from '@/lib/settings-navigation-types'
 import type { CmdJQuickAction } from './quick-actions'
+import type { CmdJShortcutResult } from './shortcut-results'
+
+export type { CmdJShortcutResult } from './shortcut-results'
 
 export type CmdJSettingsResult = {
   id: string
@@ -17,7 +20,7 @@ export type CmdJActionResult = CmdJQuickAction & {
   order: number
 }
 
-export type CmdJMiddleResult = CmdJSettingsResult | CmdJActionResult
+export type CmdJMiddleResult = CmdJSettingsResult | CmdJActionResult | CmdJShortcutResult
 
 type RankedResult = {
   result: CmdJMiddleResult
@@ -29,7 +32,7 @@ const SETTINGS_ALIASES: Record<string, string[]> = {
   browser: ['browser settings'],
   terminal: ['terminal settings'],
   ssh: ['ssh'],
-  shortcuts: ['keyboard shortcuts'],
+  shortcuts: ['keyboard shortcuts', 'keybinding', 'keybindings'],
   appearance: ['theme', 'themes'],
   agents: ['ai agents'],
   'quick-commands': ['quick commands', 'quick command'],
@@ -143,6 +146,28 @@ function tokenScore(query: string, values: readonly string[]): number {
   return score
 }
 
+function hasShortcutIntent(query: string): boolean {
+  const queryTokens = new Set(tokenize(query))
+  return (
+    queryTokens.has('shortcut') ||
+    queryTokens.has('shortcuts') ||
+    queryTokens.has('keybinding') ||
+    queryTokens.has('keybindings') ||
+    query.includes('keyboard shortcut')
+  )
+}
+
+function isGenericShortcutQuery(query: string): boolean {
+  return [
+    'shortcut',
+    'shortcuts',
+    'keyboard shortcut',
+    'keyboard shortcuts',
+    'keybinding',
+    'keybindings'
+  ].includes(query)
+}
+
 function rankingForCandidate(
   query: string,
   candidate: CmdJMiddleResult,
@@ -173,26 +198,42 @@ function rankingForCandidate(
   }
 
   if (
+    candidate.kind === 'shortcut' &&
+    !isGenericShortcutQuery(query) &&
+    candidate.configKeywords.some((keyword) => query === keyword)
+  ) {
+    return { result: candidate, rule: 4, score: 0 }
+  }
+
+  if (
     candidate.kind === 'action' &&
     candidate.verbKeywords.some((keyword) => startsOrIsStartedBy(query, keyword)) &&
     !settingsConfigKeywords.some((keyword) => query.endsWith(keyword))
   ) {
-    return { result: candidate, rule: 4, score: 0 }
+    return { result: candidate, rule: 5, score: 0 }
   }
 
   if (
     candidate.kind === 'settings' &&
     candidate.configKeywords.some((keyword) => keyword.startsWith(query) && keyword !== query)
   ) {
-    return { result: candidate, rule: 5, score: 0 }
+    return { result: candidate, rule: 6, score: 0 }
   }
 
   const values =
     candidate.kind === 'settings'
       ? [candidate.title, ...candidate.configKeywords]
-      : [candidate.title, ...candidate.verbKeywords]
+      : candidate.kind === 'shortcut'
+        ? [candidate.title, ...candidate.configKeywords]
+        : [candidate.title, ...candidate.verbKeywords]
   const score = tokenScore(query, values)
-  return score > 0 ? { result: candidate, rule: 6, score } : null
+  if (score === 0) {
+    return null
+  }
+  if (candidate.kind === 'shortcut' && hasShortcutIntent(query)) {
+    return { result: candidate, rule: 7, score: score + 2 }
+  }
+  return { result: candidate, rule: 8, score }
 }
 
 function compareRanked(a: RankedResult, b: RankedResult): number {
@@ -202,8 +243,16 @@ function compareRanked(a: RankedResult, b: RankedResult): number {
   if (a.rule === 6 && a.score !== b.score) {
     return b.score - a.score
   }
+  if ((a.rule === 7 || a.rule === 8) && a.score !== b.score) {
+    return b.score - a.score
+  }
   if (a.result.kind !== b.result.kind) {
-    return a.result.kind === 'settings' ? -1 : 1
+    const kindOrder: Record<CmdJMiddleResult['kind'], number> = {
+      settings: 0,
+      shortcut: 1,
+      action: 2
+    }
+    return kindOrder[a.result.kind] - kindOrder[b.result.kind]
   }
   if (a.result.order !== b.result.order) {
     return a.result.order - b.result.order
@@ -214,11 +263,13 @@ function compareRanked(a: RankedResult, b: RankedResult): number {
 export function rankCmdJMiddleResults({
   query,
   settingsResults,
-  actionResults
+  actionResults,
+  shortcutResults = []
 }: {
   query: string
   settingsResults: readonly CmdJSettingsResult[]
   actionResults: readonly CmdJActionResult[]
+  shortcutResults?: readonly CmdJShortcutResult[]
 }): CmdJMiddleResult[] {
   const normalizedQuery = normalizeQuery(query)
   if (normalizedQuery.length < 2) {
@@ -226,10 +277,11 @@ export function rankCmdJMiddleResults({
   }
   const settings = settingsResults
   const actions = actionResults
+  const shortcuts = shortcutResults
   const actionVerbKeywords = actions.flatMap((action) => action.verbKeywords)
   const settingsConfigKeywords = settings.flatMap((setting) => setting.configKeywords)
 
-  return [...settings, ...actions]
+  return [...settings, ...shortcuts, ...actions]
     .map((candidate) =>
       rankingForCandidate(normalizedQuery, candidate, actionVerbKeywords, settingsConfigKeywords)
     )

--- a/src/renderer/src/components/cmd-j/shortcut-palette-items.test.ts
+++ b/src/renderer/src/components/cmd-j/shortcut-palette-items.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { getShortcutSettingsTarget } from './shortcut-palette-items'
+
+describe('shortcut palette item selection', () => {
+  it('builds an action-specific Shortcuts settings target', () => {
+    expect(getShortcutSettingsTarget('terminal.splitRight')).toEqual({
+      pane: 'shortcuts',
+      repoId: null,
+      intent: 'shortcut-action',
+      actionId: 'terminal.splitRight'
+    })
+  })
+})

--- a/src/renderer/src/components/cmd-j/shortcut-palette-items.tsx
+++ b/src/renderer/src/components/cmd-j/shortcut-palette-items.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import {
+  formatKeybinding,
+  getEffectiveKeybindingsForAction,
+  isDoubleTapBinding,
+  type KeybindingDefinition,
+  type KeybindingOverrides
+} from '../../../../shared/keybindings'
+import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { cn } from '@/lib/utils'
+import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+import { CommandItem } from '@/components/ui/command'
+import { translate } from '@/i18n/i18n'
+import type { CmdJShortcutResult } from './shortcut-results'
+
+export function getShortcutSettingsTarget(actionId: CmdJShortcutResult['actionId']): {
+  pane: 'shortcuts'
+  repoId: null
+  intent: 'shortcut-action'
+  actionId: CmdJShortcutResult['actionId']
+} {
+  return {
+    pane: 'shortcuts',
+    repoId: null,
+    intent: 'shortcut-action',
+    actionId
+  }
+}
+
+export type ShortcutPaletteItem = {
+  id: string
+  type: 'shortcut'
+  result: CmdJShortcutResult
+  effectiveBindings: readonly string[]
+}
+
+export function buildShortcutBindingSearchText(
+  definitions: readonly KeybindingDefinition[],
+  keybindings: KeybindingOverrides
+): Partial<Record<CmdJShortcutResult['actionId'], readonly string[]>> {
+  const platform = getShortcutPlatform()
+  const labelsByActionId: Partial<Record<CmdJShortcutResult['actionId'], readonly string[]>> = {}
+  for (const definition of definitions) {
+    const effective = getEffectiveKeybindingsForAction(definition.id, platform, keybindings)
+    labelsByActionId[definition.id] = effective.flatMap((binding) => [
+      binding,
+      formatKeybinding(binding, platform).join(platform === 'darwin' ? '' : '+'),
+      formatKeybinding(binding, platform).join(' ')
+    ])
+  }
+  return labelsByActionId
+}
+
+export function buildShortcutPaletteItems({
+  results,
+  keybindings
+}: {
+  results: readonly CmdJShortcutResult[]
+  keybindings: KeybindingOverrides
+}): ShortcutPaletteItem[] {
+  const platform = getShortcutPlatform()
+  return results.map((result) => ({
+    id: result.id,
+    type: 'shortcut',
+    result,
+    effectiveBindings: getEffectiveKeybindingsForAction(result.actionId, platform, keybindings)
+  }))
+}
+
+export function ShortcutPaletteCommandItem({
+  item,
+  onSelect
+}: {
+  item: ShortcutPaletteItem
+  onSelect: () => void
+}): React.JSX.Element {
+  const platform = getShortcutPlatform()
+  const firstBinding = item.effectiveBindings[0]
+
+  return (
+    <CommandItem
+      value={item.id}
+      onSelect={onSelect}
+      className={cn(
+        'group mx-0.5 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 text-left outline-none transition-[background-color,border-color,box-shadow]',
+        'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-[14px] font-semibold text-foreground">
+              {item.result.title}
+            </span>
+            <span className="shrink-0 rounded-[6px] border border-border/60 bg-background/45 px-1.5 py-px text-[9px] font-medium leading-normal text-muted-foreground/88">
+              {translate('auto.components.cmd-j.shortcutPaletteItems.shortcutBadge', 'Shortcut')}
+            </span>
+          </div>
+          <div className="mt-1 truncate text-[12px] leading-5 text-muted-foreground/88">
+            {item.result.description}
+          </div>
+        </div>
+        <div className="shrink-0">
+          {firstBinding ? (
+            <ShortcutKeyCombo
+              keys={formatKeybinding(firstBinding, platform)}
+              doubleTap={isDoubleTapBinding(firstBinding)}
+              keyCapClassName="bg-background/70"
+            />
+          ) : (
+            <span className="inline-flex h-7 items-center rounded-md border border-dashed border-border/70 px-2 text-xs font-medium text-muted-foreground">
+              {translate('auto.components.cmd-j.shortcutPaletteItems.unassigned', 'Unassigned')}
+            </span>
+          )}
+        </div>
+      </div>
+    </CommandItem>
+  )
+}

--- a/src/renderer/src/components/cmd-j/shortcut-results.ts
+++ b/src/renderer/src/components/cmd-j/shortcut-results.ts
@@ -1,0 +1,61 @@
+import type { KeybindingActionId, KeybindingDefinition } from '../../../../shared/keybindings'
+import { translate } from '@/i18n/i18n'
+
+export type CmdJShortcutResult = {
+  id: string
+  kind: 'shortcut'
+  title: string
+  description: string
+  actionId: KeybindingActionId
+  order: number
+  configKeywords: string[]
+}
+
+function normalizeQuery(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+function uniqueNormalized(values: readonly string[]): string[] {
+  return [...new Set(values.map(normalizeQuery).filter(Boolean))]
+}
+
+export function buildCmdJShortcutResults({
+  definitions,
+  bindingSearchTextByActionId = {}
+}: {
+  definitions: readonly KeybindingDefinition[]
+  bindingSearchTextByActionId?: Partial<Record<KeybindingActionId, readonly string[]>>
+}): CmdJShortcutResult[] {
+  return definitions.map((definition, order) => ({
+    id: `shortcut:${definition.id}`,
+    kind: 'shortcut',
+    title: definition.title,
+    description: translate(
+      'auto.components.cmd-j.shortcutResults.description',
+      '{{value0}} shortcut',
+      {
+        value0: definition.group
+      }
+    ),
+    actionId: definition.id,
+    order,
+    configKeywords: uniqueNormalized([
+      definition.id,
+      definition.title,
+      definition.group,
+      definition.scope,
+      `${definition.title} shortcut`,
+      `${definition.title} keyboard shortcut`,
+      `${definition.group} shortcut`,
+      `${definition.scope} shortcut`,
+      'shortcut',
+      'shortcuts',
+      'keyboard shortcut',
+      'keyboard shortcuts',
+      'keybinding',
+      'keybindings',
+      ...definition.searchKeywords,
+      ...(bindingSearchTextByActionId[definition.id] ?? [])
+    ])
+  }))
+}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -90,6 +90,11 @@ import {
 } from './settings-load-performance'
 import { translate } from '@/i18n/i18n'
 import { getProjectHostSetupProjectionFromState } from '../../store/selectors'
+import {
+  getShortcutActionIntentSignal,
+  isShortcutActionIntentTarget,
+  type ShortcutActionIntentSignal
+} from './settings-shortcut-intent'
 
 const SETTINGS_NAV_GROUPS = [
   {
@@ -290,6 +295,8 @@ function Settings(): React.JSX.Element {
   )
   const [pendingNavRequestTick, setPendingNavRequestTick] = useState(0)
   const [quickCommandAddIntentSignal, setQuickCommandAddIntentSignal] = useState(0)
+  const [shortcutActionIntent, setShortcutActionIntent] =
+    useState<ShortcutActionIntentSignal | null>(null)
   const [hasUnsavedCommitPromptChanges, setHasUnsavedCommitPromptChanges] = useState(false)
   const [hasUnsavedBranchPromptChanges, setHasUnsavedBranchPromptChanges] = useState(false)
   const [sourceControlAiPromptDiscardSignal, setSourceControlAiPromptDiscardSignal] = useState(0)
@@ -543,6 +550,11 @@ function Settings(): React.JSX.Element {
     pendingScrollTargetRef.current = settingsNavigationTarget.sectionId ?? paneSectionId
     if (settingsNavigationTarget.intent === 'add-quick-command') {
       setQuickCommandAddIntentSignal((signal) => signal + 1)
+    }
+    if (isShortcutActionIntentTarget(settingsNavigationTarget)) {
+      setShortcutActionIntent((current) =>
+        getShortcutActionIntentSignal(settingsNavigationTarget, current)
+      )
     }
     setMountedSectionIds((previous) => {
       if (previous.has(paneSectionId)) {
@@ -1405,7 +1417,9 @@ function Settings(): React.JSX.Element {
                     isFocusedShortcutsPane ? 'min-h-0 flex-1 overflow-hidden' : undefined
                   }
                 >
-                  {isSectionMounted('shortcuts') ? <ShortcutsPane /> : null}
+                  {isSectionMounted('shortcuts') ? (
+                    <ShortcutsPane shortcutActionIntent={shortcutActionIntent} />
+                  ) : null}
                 </SettingsSection>
 
                 <SettingsSection

--- a/src/renderer/src/components/settings/ShortcutBindingRow.tsx
+++ b/src/renderer/src/components/settings/ShortcutBindingRow.tsx
@@ -175,6 +175,7 @@ export function ShortcutBindingRow({
 
   return (
     <SearchableSetting
+      id={`shortcut-${item.id}`}
       title={item.title}
       description={translate(
         'auto.components.settings.ShortcutBindingRow.3b11ef3a43',

--- a/src/renderer/src/components/settings/ShortcutsPane.test.ts
+++ b/src/renderer/src/components/settings/ShortcutsPane.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { getShortcutActionIntentState } from './ShortcutsPane'
+import { getShortcutActionIntentSignal } from './settings-shortcut-intent'
+
+describe('ShortcutsPane shortcut action intent', () => {
+  it('sets local search to the action title and resets the status filter', () => {
+    expect(getShortcutActionIntentState('terminal.splitRight')).toEqual({
+      query: 'Split terminal right',
+      filter: 'all'
+    })
+  })
+
+  it('falls back to the action id if the definition disappeared', () => {
+    const missingActionId = 'missing.action' as Parameters<typeof getShortcutActionIntentState>[0]
+
+    expect(getShortcutActionIntentState(missingActionId)).toEqual({
+      query: 'missing.action',
+      filter: 'all'
+    })
+  })
+
+  it('preserves repeated Settings shortcut-action targets with a new request signal', () => {
+    const first = getShortcutActionIntentSignal(
+      {
+        pane: 'shortcuts',
+        repoId: null,
+        intent: 'shortcut-action',
+        actionId: 'terminal.splitRight'
+      },
+      null
+    )
+    const second = getShortcutActionIntentSignal(
+      {
+        pane: 'shortcuts',
+        repoId: null,
+        intent: 'shortcut-action',
+        actionId: 'terminal.splitRight'
+      },
+      first
+    )
+
+    expect(first).toEqual({ actionId: 'terminal.splitRight', requestId: 1 })
+    expect(second).toEqual({ actionId: 'terminal.splitRight', requestId: 2 })
+  })
+
+  it('ignores non-shortcut Settings targets before ShortcutsPane handoff', () => {
+    expect(
+      getShortcutActionIntentSignal(
+        {
+          pane: 'quick-commands',
+          repoId: null,
+          intent: 'add-quick-command'
+        },
+        { actionId: 'terminal.splitRight', requestId: 1 }
+      )
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -1,19 +1,14 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import {
   findKeybindingConflicts,
   formatKeybindingList,
   getEffectiveKeybindingsForAction,
   getKeybindingDefinition,
-  isKeybindingAllowedInTerminal,
-  isKeybindingPotentialTerminalConflict,
   keybindingFromInputForAction,
-  keybindingIsActiveInContext,
   normalizeKeybindingListForAction,
   type KeybindingActionId,
-  type KeybindingDefinition,
   type KeybindingInput,
-  type KeybindingOverrides,
-  type TerminalShortcutPolicy
+  type KeybindingOverrides
 } from '../../../../shared/keybindings'
 import {
   EMPTY_DISABLED_TUI_AGENTS,
@@ -23,7 +18,6 @@ import {
 import { useAppStore } from '../../store'
 import { KeybindingsFileActions } from './KeybindingsFileActions'
 import { SettingsSubsectionHeader } from './SettingsFormControls'
-import type { ShortcutTerminalStatus } from './ShortcutBindingRow'
 import {
   getShortcutSearchEntry,
   matchesShortcutFilter,
@@ -38,6 +32,8 @@ import { getTerminalShortcutPolicySearchEntry } from './shortcuts-search'
 import { matchesSettingsSearch, normalizeSettingsSearchQuery } from './settings-search'
 import { clearRecordingActionForShortcutMutation } from './shortcut-recording-state'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import type { ShortcutActionIntentSignal } from './settings-shortcut-intent'
+import { getShortcutTerminalStatus } from './shortcut-terminal-status'
 import { translate } from '@/i18n/i18n'
 
 const isMac = navigator.userAgent.includes('Mac')
@@ -46,6 +42,16 @@ const platform: NodeJS.Platform = isMac
   : navigator.userAgent.includes('Windows')
     ? 'win32'
     : 'linux'
+
+export function getShortcutActionIntentState(actionId: KeybindingActionId): {
+  query: string
+  filter: ShortcutFilter
+} {
+  return {
+    query: getKeybindingDefinition(actionId)?.title ?? actionId,
+    filter: 'all'
+  }
+}
 
 function sameBindings(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((binding, index) => binding === b[index])
@@ -74,57 +80,11 @@ function hasCommonBindingOverride(
   return hasOwnBindingOverride(snapshot?.commonOverrides ?? {}, actionId)
 }
 
-function getShortcutTerminalStatus(
-  definition: KeybindingDefinition,
-  terminalShortcutPolicy: TerminalShortcutPolicy,
-  hasEffectiveBinding: boolean
-): ShortcutTerminalStatus | undefined {
-  if (!hasEffectiveBinding) {
-    return undefined
-  }
-  if (definition.scope === 'terminal') {
-    return {
-      label: translate('auto.components.settings.ShortcutsPane.cb02e00202', 'Terminal'),
-      description: translate(
-        'auto.components.settings.ShortcutsPane.781cb74d22',
-        'Runs from terminal panes.'
-      )
-    }
-  }
-  if (isKeybindingAllowedInTerminal(definition)) {
-    return {
-      label: translate('auto.components.settings.ShortcutsPane.25b0004fbf', 'Terminal active'),
-      description: translate(
-        'auto.components.settings.ShortcutsPane.3c0fac059a',
-        'Still runs while a terminal has keyboard focus.'
-      )
-    }
-  }
-  if (!isKeybindingPotentialTerminalConflict(definition)) {
-    return undefined
-  }
-  const activeInTerminal = keybindingIsActiveInContext(definition, {
-    context: 'terminal',
-    terminalShortcutPolicy
-  })
-  return activeInTerminal
-    ? {
-        label: translate('auto.components.settings.ShortcutsPane.2a0e8aeccf', 'Orca first'),
-        description: translate(
-          'auto.components.settings.ShortcutsPane.dfa8ff612f',
-          'Also runs while a terminal or TUI has keyboard focus.'
-        )
-      }
-    : {
-        label: translate('auto.components.settings.ShortcutsPane.5c65d5db9d', 'Terminal first'),
-        description: translate(
-          'auto.components.settings.ShortcutsPane.f0b35b0b2e',
-          'Disabled while a terminal or TUI has keyboard focus.'
-        )
-      }
-}
-
-export function ShortcutsPane(): React.JSX.Element {
+export function ShortcutsPane({
+  shortcutActionIntent
+}: {
+  shortcutActionIntent?: ShortcutActionIntentSignal | null
+}): React.JSX.Element {
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
   const terminalShortcutPolicy = useAppStore(
     (state) => state.settings?.terminalShortcutPolicy ?? 'orca-first'
@@ -143,6 +103,7 @@ export function ShortcutsPane(): React.JSX.Element {
   const [recordingActionId, setRecordingActionId] = useState<KeybindingActionId | null>(null)
   const [shortcutQuery, setShortcutQuery] = useState('')
   const [shortcutFilter, setShortcutFilter] = useState<ShortcutFilter>('all')
+  const shortcutFocusFrameRef = useRef<number | null>(null)
 
   const groups = useMemo(() => groupDefinitions(disabledTuiAgents), [disabledTuiAgents])
   const ignoredConflictActionIds = useMemo(
@@ -217,6 +178,35 @@ export function ShortcutsPane(): React.JSX.Element {
   const visibleShortcutCount = visibleShortcutGroups.reduce(
     (sum, group) => sum + group.rows.length,
     0
+  )
+
+  useEffect(() => {
+    if (!shortcutActionIntent) {
+      return
+    }
+    const intentState = getShortcutActionIntentState(shortcutActionIntent.actionId)
+    setShortcutQuery(intentState.query)
+    setShortcutFilter(intentState.filter)
+    if (shortcutFocusFrameRef.current !== null) {
+      cancelAnimationFrame(shortcutFocusFrameRef.current)
+    }
+    shortcutFocusFrameRef.current = requestAnimationFrame(() => {
+      shortcutFocusFrameRef.current = requestAnimationFrame(() => {
+        shortcutFocusFrameRef.current = null
+        const row = document.getElementById(`shortcut-${shortcutActionIntent.actionId}`)
+        row?.scrollIntoView({ block: 'center' })
+        row?.querySelector<HTMLButtonElement>('[data-shortcut-recorder]')?.focus()
+      })
+    })
+  }, [shortcutActionIntent])
+
+  useEffect(
+    () => () => {
+      if (shortcutFocusFrameRef.current !== null) {
+        cancelAnimationFrame(shortcutFocusFrameRef.current)
+      }
+    },
+    []
   )
 
   const saveBindings = async (

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -190,6 +190,7 @@ export function ShortcutsPane({
     if (shortcutFocusFrameRef.current !== null) {
       cancelAnimationFrame(shortcutFocusFrameRef.current)
     }
+    // Why: applying the query/filter can remount rows, so focus waits until the target exists.
     shortcutFocusFrameRef.current = requestAnimationFrame(() => {
       shortcutFocusFrameRef.current = requestAnimationFrame(() => {
         shortcutFocusFrameRef.current = null

--- a/src/renderer/src/components/settings/settings-shortcut-intent.ts
+++ b/src/renderer/src/components/settings/settings-shortcut-intent.ts
@@ -1,0 +1,34 @@
+import type { KeybindingActionId } from '../../../../shared/keybindings'
+
+export type ShortcutActionIntentSignal = {
+  actionId: KeybindingActionId
+  requestId: number
+}
+
+type ShortcutActionIntentTarget = {
+  intent?: string
+  actionId?: KeybindingActionId
+  [key: string]: unknown
+}
+
+export function isShortcutActionIntentTarget(
+  target: ShortcutActionIntentTarget | null | undefined
+): target is ShortcutActionIntentTarget & {
+  intent: 'shortcut-action'
+  actionId: KeybindingActionId
+} {
+  return target?.intent === 'shortcut-action' && target.actionId !== undefined
+}
+
+export function getShortcutActionIntentSignal(
+  target: ShortcutActionIntentTarget,
+  current: ShortcutActionIntentSignal | null
+): ShortcutActionIntentSignal | null {
+  if (!isShortcutActionIntentTarget(target)) {
+    return null
+  }
+  return {
+    actionId: target.actionId,
+    requestId: (current?.requestId ?? 0) + 1
+  }
+}

--- a/src/renderer/src/components/settings/shortcut-terminal-status.ts
+++ b/src/renderer/src/components/settings/shortcut-terminal-status.ts
@@ -1,0 +1,59 @@
+import {
+  isKeybindingAllowedInTerminal,
+  isKeybindingPotentialTerminalConflict,
+  keybindingIsActiveInContext,
+  type KeybindingDefinition,
+  type TerminalShortcutPolicy
+} from '../../../../shared/keybindings'
+import { translate } from '@/i18n/i18n'
+import type { ShortcutTerminalStatus } from './ShortcutBindingRow'
+
+export function getShortcutTerminalStatus(
+  definition: KeybindingDefinition,
+  terminalShortcutPolicy: TerminalShortcutPolicy,
+  hasEffectiveBinding: boolean
+): ShortcutTerminalStatus | undefined {
+  if (!hasEffectiveBinding) {
+    return undefined
+  }
+  if (definition.scope === 'terminal') {
+    return {
+      label: translate('auto.components.settings.ShortcutsPane.cb02e00202', 'Terminal'),
+      description: translate(
+        'auto.components.settings.ShortcutsPane.781cb74d22',
+        'Runs from terminal panes.'
+      )
+    }
+  }
+  if (isKeybindingAllowedInTerminal(definition)) {
+    return {
+      label: translate('auto.components.settings.ShortcutsPane.25b0004fbf', 'Terminal active'),
+      description: translate(
+        'auto.components.settings.ShortcutsPane.3c0fac059a',
+        'Still runs while a terminal has keyboard focus.'
+      )
+    }
+  }
+  if (!isKeybindingPotentialTerminalConflict(definition)) {
+    return undefined
+  }
+  const activeInTerminal = keybindingIsActiveInContext(definition, {
+    context: 'terminal',
+    terminalShortcutPolicy
+  })
+  return activeInTerminal
+    ? {
+        label: translate('auto.components.settings.ShortcutsPane.2a0e8aeccf', 'Orca first'),
+        description: translate(
+          'auto.components.settings.ShortcutsPane.dfa8ff612f',
+          'Also runs while a terminal or TUI has keyboard focus.'
+        )
+      }
+    : {
+        label: translate('auto.components.settings.ShortcutsPane.5c65d5db9d', 'Terminal first'),
+        description: translate(
+          'auto.components.settings.ShortcutsPane.f0b35b0b2e',
+          'Disabled while a terminal or TUI has keyboard focus.'
+        )
+      }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3668,7 +3668,6 @@
           "1a0eec0d35": "Status",
           "b5536d5a88": "Tasks",
           "8d62c68b35": "Notes",
-          "automation": "Automation",
           "2d74665a56": "Ports",
           "65a9820bd1": "Agent statuses",
           "219ebf1961": "Branch name"
@@ -11391,7 +11390,15 @@
           "openReviewExternally": "Open {{value0}} externally",
           "summary": "{{value0}} attached · {{value1}} with PR/MR · {{value2}} attention · {{value3}} pending · {{value4}} passing · {{value5}} no PR · {{value6}} unknown",
           "showDetails": "Show {{value0}} PR check details",
-          "hideDetails": "Hide {{value0}} PR check details"
+          "hideDetails": "Hide {{value0}} PR check details",
+          "reviewChecks": "Review checks",
+          "allChecksPassing": "all checks passing",
+          "oneWorktree": "1 worktree",
+          "worktreeCount": "{{value0}} worktrees",
+          "oneFailing": "1 failing",
+          "failingCount": "{{value0}} failing",
+          "onePending": "1 pending",
+          "pendingCount": "{{value0}} pending"
         },
         "parentPrChecks": {
           "rowSummary": {
@@ -11510,6 +11517,15 @@
             "dismiss": "Dismiss",
             "later": "Later"
           }
+        }
+      },
+      "cmd-j": {
+        "shortcutPaletteItems": {
+          "shortcutBadge": "Shortcut",
+          "unassigned": "Unassigned"
+        },
+        "shortcutResults": {
+          "description": "{{value0}} shortcut"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3656,8 +3656,7 @@
           "automation": "Automation",
           "2d74665a56": "Puertos",
           "65a9820bd1": "Estados del agente",
-          "219ebf1961": "Nombre de rama",
-          "automation": "Automation"
+          "219ebf1961": "Nombre de rama"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "Conectando...",
@@ -11391,7 +11390,15 @@
           "openReviewExternally": "Abrir {{value0}} externamente",
           "summary": "{{value0}} adjuntos · {{value1}} con PR/MR · {{value2}} requieren atención · {{value3}} pendientes · {{value4}} correctos · {{value5}} sin PR · {{value6}} desconocidos",
           "showDetails": "Mostrar detalles de comprobaciones de PR de {{value0}}",
-          "hideDetails": "Ocultar detalles de comprobaciones de PR de {{value0}}"
+          "hideDetails": "Ocultar detalles de comprobaciones de PR de {{value0}}",
+          "reviewChecks": "Review checks",
+          "allChecksPassing": "all checks passing",
+          "oneWorktree": "1 worktree",
+          "worktreeCount": "{{value0}} worktrees",
+          "oneFailing": "1 failing",
+          "failingCount": "{{value0}} failing",
+          "onePending": "1 pending",
+          "pendingCount": "{{value0}} pending"
         },
         "parentPrChecks": {
           "rowSummary": {
@@ -11510,6 +11517,15 @@
             "dismiss": "Dismiss",
             "later": "Later"
           }
+        }
+      },
+      "cmd-j": {
+        "shortcutPaletteItems": {
+          "shortcutBadge": "Shortcut",
+          "unassigned": "Unassigned"
+        },
+        "shortcutResults": {
+          "description": "{{value0}} shortcut"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11390,7 +11390,15 @@
           "openReviewExternally": "{{value0}} を外部で開く",
           "summary": "{{value0}} 件添付 · PR/MR あり {{value1}} 件 · 要対応 {{value2}} 件 · 保留中 {{value3}} 件 · 成功 {{value4}} 件 · PR なし {{value5}} 件 · 不明 {{value6}} 件",
           "showDetails": "{{value0}} の PR チェック詳細を表示",
-          "hideDetails": "{{value0}} の PR チェック詳細を非表示"
+          "hideDetails": "{{value0}} の PR チェック詳細を非表示",
+          "reviewChecks": "Review checks",
+          "allChecksPassing": "all checks passing",
+          "oneWorktree": "1 worktree",
+          "worktreeCount": "{{value0}} worktrees",
+          "oneFailing": "1 failing",
+          "failingCount": "{{value0}} failing",
+          "onePending": "1 pending",
+          "pendingCount": "{{value0}} pending"
         },
         "parentPrChecks": {
           "rowSummary": {
@@ -11509,6 +11517,15 @@
             "dismiss": "Dismiss",
             "later": "Later"
           }
+        }
+      },
+      "cmd-j": {
+        "shortcutPaletteItems": {
+          "shortcutBadge": "Shortcut",
+          "unassigned": "Unassigned"
+        },
+        "shortcutResults": {
+          "description": "{{value0}} shortcut"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11390,7 +11390,15 @@
           "openReviewExternally": "{{value0}} 외부에서 열기",
           "summary": "{{value0}}개 연결됨 · PR/MR 있음 {{value1}}개 · 주의 필요 {{value2}}개 · 대기 중 {{value3}}개 · 통과 {{value4}}개 · PR 없음 {{value5}}개 · 알 수 없음 {{value6}}개",
           "showDetails": "{{value0}} PR 검사 세부 정보 표시",
-          "hideDetails": "{{value0}} PR 검사 세부 정보 숨기기"
+          "hideDetails": "{{value0}} PR 검사 세부 정보 숨기기",
+          "reviewChecks": "Review checks",
+          "allChecksPassing": "all checks passing",
+          "oneWorktree": "1 worktree",
+          "worktreeCount": "{{value0}} worktrees",
+          "oneFailing": "1 failing",
+          "failingCount": "{{value0}} failing",
+          "onePending": "1 pending",
+          "pendingCount": "{{value0}} pending"
         },
         "parentPrChecks": {
           "rowSummary": {
@@ -11509,6 +11517,15 @@
             "dismiss": "Dismiss",
             "later": "Later"
           }
+        }
+      },
+      "cmd-j": {
+        "shortcutPaletteItems": {
+          "shortcutBadge": "Shortcut",
+          "unassigned": "Unassigned"
+        },
+        "shortcutResults": {
+          "description": "{{value0}} shortcut"
         }
       }
     },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11390,7 +11390,15 @@
           "openReviewExternally": "在外部打开 {{value0}}",
           "summary": "已附加 {{value0}} 个 · 有 PR/MR {{value1}} 个 · 需注意 {{value2}} 个 · 等待中 {{value3}} 个 · 通过 {{value4}} 个 · 无 PR {{value5}} 个 · 未知 {{value6}} 个",
           "showDetails": "显示 {{value0}} 的 PR 检查详情",
-          "hideDetails": "隐藏 {{value0}} 的 PR 检查详情"
+          "hideDetails": "隐藏 {{value0}} 的 PR 检查详情",
+          "reviewChecks": "Review checks",
+          "allChecksPassing": "all checks passing",
+          "oneWorktree": "1 worktree",
+          "worktreeCount": "{{value0}} worktrees",
+          "oneFailing": "1 failing",
+          "failingCount": "{{value0}} failing",
+          "onePending": "1 pending",
+          "pendingCount": "{{value0}} pending"
         },
         "parentPrChecks": {
           "rowSummary": {
@@ -11509,6 +11517,15 @@
             "dismiss": "Dismiss",
             "later": "Later"
           }
+        }
+      },
+      "cmd-j": {
+        "shortcutPaletteItems": {
+          "shortcutBadge": "Shortcut",
+          "unassigned": "Unassigned"
+        },
+        "shortcutResults": {
+          "description": "{{value0}} shortcut"
         }
       }
     },

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -87,6 +87,7 @@ import { clampMarkdownTocPanelWidth } from '../../../../shared/markdown-toc-pane
 import { normalizeKagiSessionLink } from '../../../../shared/browser-url'
 import type { OrcaHookScriptKind } from '../../lib/orca-hook-trust'
 import type { SettingsNavTarget } from '@/lib/settings-navigation-types'
+import type { KeybindingActionId } from '../../../../shared/keybindings'
 import {
   filterSetupScriptPromptDismissalsToValidRepos,
   getSetupScriptPromptDismissalKey
@@ -691,7 +692,8 @@ export type UISlice = {
     pane: SettingsNavTarget
     repoId: string | null
     sectionId?: string
-    intent?: 'add-quick-command'
+    intent?: 'add-quick-command' | 'shortcut-action'
+    actionId?: KeybindingActionId
   } | null
   openSettingsTarget: (target: NonNullable<UISlice['settingsNavigationTarget']>) => void
   clearSettingsTarget: () => void


### PR DESCRIPTION
## Summary
- Adds shortcut discovery rows to the existing Jump palette using Orca's keybinding registry as the source of truth.
- Shows the effective platform/user binding in the palette, or an `Unassigned` badge when no binding is active.
- Routes selected shortcut rows into Settings > Shortcuts with an action-specific filter/focus intent so users can learn or rebind the shortcut in the authoritative settings surface.

## Design Approach
The scoped design improves shortcut discoverability without building a full command execution palette. Shortcut metadata stays derived from the existing registry, disabled per-agent shortcuts remain filtered through the existing Settings grouping path, and Settings > Shortcuts remains the editing surface. Full command execution from the palette remains follow-up scope.

## Design Review
Delegated design review completed in three iterations and returned clean after tightening the typed Settings shortcut intent, cross-platform copy, disabled-agent filtering path, and repeated-selection/focus behavior.

## Implementation
Implemented shortcut result construction, ranking, and rendering for the Jump palette, plus a typed Settings navigation intent that carries an action id into the Shortcuts pane. The implementation also extracts shortcut palette row rendering and terminal-status logic into concrete modules to keep existing files focused.

## Completeness Verification
Delegated completeness verification initially found missing coverage for shortcut row selection and Settings handoff; focused tests were added for those paths. Follow-up verification returned clean.

## Code Review Loop
Two-reviewer code review loop completed. Round 1 found actionable localization/generic-query/max-lines issues; those were fixed. Round 2 completed with both reviewers clean.

## AI Review Report
CodeRabbit initially posted one actionable minor comment requesting a short why-comment for the double-frame shortcut-row focus scheduling. Addressed in commit `b48fc68`, reran local `git diff --check` and `pnpm run lint`, pushed the fix, waited another required 8 minutes, and confirmed CodeRabbit's refreshed review reported no actionable comments.

## Brennan Test Changes
Final verdict: `land`.

Validated in Electron against `/Users/thebr/source/repos/Stably/demo-project` from this exact branch/root. The validation confirmed generic `shortcut` / `keybinding` searches keep Shortcuts Settings preferred over arbitrary shortcut rows, action-specific `split terminal right shortcut` shows the Split terminal right shortcut row with the macOS `⌘ D` binding chip, and selecting it opens Settings > Shortcuts filtered/focused to that row. No SSH/remoting live pass was required because the touched behavior is renderer-local shortcut discovery/settings navigation.

Validation report: `notes/artifacts/sta115-final-validation.md`.

## Screenshots
Screenshot evidence captured locally and kept out of the repository:
- `notes/artifacts/sta115-jump-palette-shortcut-generic.png`
- `notes/artifacts/sta115-jump-palette-split-terminal-right.png`
- `notes/artifacts/sta115-settings-shortcuts-after-select.png`

## Tests
- [x] `git diff --check`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run verify:localization-catalog`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/cmd-j/palette-results.test.ts src/renderer/src/components/cmd-j/shortcut-palette-items.test.ts src/renderer/src/components/settings/ShortcutsPane.test.ts`
- [x] Electron validation with demo-project and screenshot evidence
- [x] GitHub `verify` check passed after the final push

Known local warning: pnpm reports `/Users/thebr/.npmrc` could not replace `${GITHUB_TOKEN}`, but all checks above passed.

## Security Audit
No network, auth, provider, SSH, filesystem mutation, or agent-execution behavior was added. The change is renderer-local shortcut discovery and Settings navigation over existing keybinding metadata.

## Post-PR Stabilization
Completed. Waited 8 minutes after opening the PR, inspected CodeRabbit and CI, fixed the one actionable CodeRabbit comment, pushed the follow-up commit, waited another 8 minutes, then confirmed refreshed CodeRabbit had no actionable comments and GitHub `verify` passed.

## Assumptions And Risks
- Shortcut execution from the palette is intentionally out of scope; selecting a shortcut row opens Settings > Shortcuts.
- UI labels and binding chips use the existing platform-aware keybinding display paths.
- No agent-facing prompt text was added.