### PR TITLE
fix: dismiss stuck browser address bar autocomplete on webview click

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.test.tsx
@@ -141,4 +141,41 @@ describe('BrowserAddressBar autocomplete preview', () => {
     expect(onNavigate).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
   })
+
+  it('dismisses suggestions when focus moves into an Electron webview guest', async () => {
+    const onNavigate = vi.fn()
+    const onSubmit = vi.fn()
+    const webview = document.createElement('webview')
+    document.body.appendChild(webview)
+
+    await act(async () => {
+      root.render(
+        <AddressBarHarness initialValue="local" onNavigate={onNavigate} onSubmit={onSubmit} />
+      )
+    })
+
+    const input = container.querySelector<HTMLInputElement>('input[data-orca-browser-address-bar]')
+    expect(input).not.toBeNull()
+
+    await act(async () => {
+      input?.focus()
+    })
+    await act(async () => {
+      input?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
+
+    expect(container.querySelector('[data-current-address-value="true"]')?.textContent).toBe(
+      'http://localhost:3000/review-one'
+    )
+
+    await act(async () => {
+      webview.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+    })
+
+    expect(container.querySelector('[data-current-address-value="true"]')?.textContent).toBe(
+      'local'
+    )
+    expect(onNavigate).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.test.tsx
@@ -142,6 +142,76 @@ describe('BrowserAddressBar autocomplete preview', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
+  it('dismisses suggestions when the window blurs', async () => {
+    const onNavigate = vi.fn()
+    const onSubmit = vi.fn()
+
+    await act(async () => {
+      root.render(
+        <AddressBarHarness initialValue="local" onNavigate={onNavigate} onSubmit={onSubmit} />
+      )
+    })
+
+    const input = container.querySelector<HTMLInputElement>('input[data-orca-browser-address-bar]')
+    expect(input).not.toBeNull()
+
+    await act(async () => {
+      input?.focus()
+    })
+    await act(async () => {
+      input?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
+
+    expect(container.querySelector('[data-current-address-value="true"]')?.textContent).toBe(
+      'http://localhost:3000/review-one'
+    )
+
+    await act(async () => {
+      window.dispatchEvent(new Event('blur'))
+    })
+
+    expect(container.querySelector('[data-current-address-value="true"]')?.textContent).toBe(
+      'local'
+    )
+    expect(onNavigate).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('dismisses suggestions when Escape is pressed outside React input handling', async () => {
+    const onNavigate = vi.fn()
+    const onSubmit = vi.fn()
+
+    await act(async () => {
+      root.render(
+        <AddressBarHarness initialValue="local" onNavigate={onNavigate} onSubmit={onSubmit} />
+      )
+    })
+
+    const input = container.querySelector<HTMLInputElement>('input[data-orca-browser-address-bar]')
+    expect(input).not.toBeNull()
+
+    await act(async () => {
+      input?.focus()
+    })
+    await act(async () => {
+      input?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
+
+    expect(container.querySelector('[data-current-address-value="true"]')?.textContent).toBe(
+      'http://localhost:3000/review-one'
+    )
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+
+    expect(container.querySelector('[data-current-address-value="true"]')?.textContent).toBe(
+      'local'
+    )
+    expect(onNavigate).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
   it('dismisses suggestions when focus moves into an Electron webview guest', async () => {
     const onNavigate = vi.fn()
     const onSubmit = vi.fn()

--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -14,6 +14,7 @@ type BrowserAddressBarProps = {
   onSubmit: () => void
   onNavigate: (url: string) => void
   inputRef: React.RefObject<HTMLInputElement | null>
+  dismissSuggestionsRef?: React.MutableRefObject<(() => void) | null>
 }
 
 export default function BrowserAddressBar({
@@ -21,7 +22,8 @@ export default function BrowserAddressBar({
   onChange,
   onSubmit,
   onNavigate,
-  inputRef
+  inputRef,
+  dismissSuggestionsRef
 }: BrowserAddressBarProps): React.ReactElement {
   const [open, setOpen] = useState(false)
   const [selectedValueOverride, setSelectedValueOverride] = useState<string | null>(null)
@@ -131,10 +133,18 @@ export default function BrowserAddressBar({
     onChange(typed)
   }, [onChange])
 
-  const cancelSuggestionPreview = useCallback((): void => {
+  const dismissSuggestions = useCallback((): void => {
+    if (blurCloseTimerRef.current !== null) {
+      window.clearTimeout(blurCloseTimerRef.current)
+      blurCloseTimerRef.current = null
+    }
     restoreTypedQuery()
     setOpen(false)
   }, [restoreTypedQuery])
+
+  const cancelSuggestionPreview = useCallback((): void => {
+    dismissSuggestions()
+  }, [dismissSuggestions])
 
   const selectedValue =
     selectedValueOverride &&
@@ -272,13 +282,64 @@ export default function BrowserAddressBar({
       if (inputRef.current && document.activeElement === inputRef.current) {
         return
       }
-      restoreTypedQuery()
-      setOpen(false)
+      dismissSuggestions()
     }
-  }, [open, suggestions.length, inputRef, restoreTypedQuery])
+  }, [dismissSuggestions, open, suggestions.length, inputRef])
+
+  // Why: Electron <webview> guests run in a separate process, so clicking the
+  // page never dispatches pointerdown on the renderer document and Radix cannot
+  // detect an outside dismiss. Window blur and focus moves into the guest (the
+  // host <webview> tag) close the dropdown the same way BrowserImportHintButton
+  // does for its popover.
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const handleWindowBlur = (): void => {
+      dismissSuggestions()
+    }
+
+    const handleFocusIn = (event: FocusEvent): void => {
+      const target = event.target
+      if (!(target instanceof HTMLElement) || target.tagName !== 'WEBVIEW') {
+        return
+      }
+      dismissSuggestions()
+    }
+
+    const handleEscape = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') {
+        return
+      }
+      dismissSuggestions()
+      event.preventDefault()
+      event.stopImmediatePropagation()
+    }
+
+    window.addEventListener('blur', handleWindowBlur)
+    document.addEventListener('focusin', handleFocusIn, true)
+    window.addEventListener('keydown', handleEscape, true)
+    return () => {
+      window.removeEventListener('blur', handleWindowBlur)
+      document.removeEventListener('focusin', handleFocusIn, true)
+      window.removeEventListener('keydown', handleEscape, true)
+    }
+  }, [dismissSuggestions, inputRef, open])
+
+  useEffect(() => {
+    if (!dismissSuggestionsRef) {
+      return
+    }
+    dismissSuggestionsRef.current = dismissSuggestions
+    return () => {
+      dismissSuggestionsRef.current = null
+    }
+  }, [dismissSuggestions, dismissSuggestionsRef])
 
   return (
     <Popover
+      modal={false}
       open={open}
       onOpenChange={(next) => {
         // Why: Radix fires onOpenChange(false) when it detects an outside

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -2614,6 +2614,7 @@ function BrowserPagePane({
     clearTimeout(browserZoomFeedbackTimerRef.current)
   }, [])
   const addressBarInputRef = useRef<HTMLInputElement | null>(null)
+  const dismissAddressBarSuggestionsRef = useRef<(() => void) | null>(null)
   const webviewRef = useRef<Electron.WebviewTag | null>(null)
   const browserTabIdRef = useRef(browserTab.id)
   browserTabIdRef.current = browserTab.id
@@ -3503,6 +3504,10 @@ function BrowserPagePane({
 
     webviewRef.current = webview
 
+    const dismissAddressBarSuggestions = (): void => {
+      dismissAddressBarSuggestionsRef.current?.()
+    }
+
     const handleDomReady = (): void => {
       const webContentsId = webview.getWebContentsId()
       let queuedAnnotationViewportBridgeSync = false
@@ -3737,6 +3742,7 @@ function BrowserPagePane({
     }
 
     webview.addEventListener('dom-ready', handleDomReady)
+    webview.addEventListener('focus', dismissAddressBarSuggestions)
     webview.addEventListener('did-start-loading', handleDidStartLoading)
     webview.addEventListener('did-stop-loading', handleDidStopLoading)
     // Why: separate handler registered only on 'did-navigate' (full page loads),
@@ -3769,6 +3775,7 @@ function BrowserPagePane({
 
     return () => {
       webview.removeEventListener('dom-ready', handleDomReady)
+      webview.removeEventListener('focus', dismissAddressBarSuggestions)
       webview.removeEventListener('did-start-loading', handleDidStartLoading)
       webview.removeEventListener('did-stop-loading', handleDidStopLoading)
       webview.removeEventListener('did-navigate', handleDidNavigate)
@@ -4705,6 +4712,7 @@ function BrowserPagePane({
           onSubmit={submitAddressBar}
           onNavigate={navigateToUrl}
           inputRef={addressBarInputRef}
+          dismissSuggestionsRef={dismissAddressBarSuggestionsRef}
         />
 
         <BrowserImportHintButton profileId={sessionProfileId} />


### PR DESCRIPTION
## Summary

Clicking the loaded page in a browser tab could leave the address bar history dropdown stuck under the toolbar, with no way to dismiss it except refocusing the address bar and pressing Escape. The dropdown now closes when you click into the page, switch away from Orca, or press Escape.

Electron `<webview>` guests run in a separate process, so clicks inside the page never reach the renderer's outside-click handlers that Radix popovers rely on. The fix listens for focus entering the webview guest, window blur, and Escape — matching the pattern already used by the browser import hint popover — and wires a backup dismiss path from `BrowserPane` when the webview element receives focus.

## Demo

Before

https://github.com/user-attachments/assets/224cd237-af33-4396-8666-84b9b3db0a9b

After

https://github.com/user-attachments/assets/422037bd-dbef-4ebf-8252-542c7cfbb61d



## Test plan

- [ ] Open a browser tab, focus the address bar to show history suggestions, then click the page — dropdown should close
- [ ] Press Escape while suggestions are open — dropdown should close and restore the typed query
- [ ] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/BrowserAddressBar.test.tsx`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Composer 2.5 Fast](https://img.shields.io/badge/Composer_2.5_Fast-6366f1?logo=cursor&logoColor=white)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->