### PR TITLE
Add experimental setting for larger sidebar sections

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1124,27 +1124,30 @@ computeWorktreePathMock.mockImplementation(
 ensurePathWithinWorkspaceMock.mockImplementation((targetPath: string) => targetPath)
 
 describe('OrcaRuntimeService', () => {
-  it('projects worktree card display settings to paired clients', () => {
+  it('projects sidebar worktree display settings to paired clients', () => {
     const runtime = new OrcaRuntimeService({
       ...store,
       getSettings: () => ({
         ...store.getSettings(),
         experimentalNewWorktreeCardStyle: true,
-        compactWorktreeCards: true
+        compactWorktreeCards: true,
+        experimentalLargerSidebarSections: true
       })
     } as never)
 
     expect(runtime.getClientSettings()).toMatchObject({
       experimentalNewWorktreeCardStyle: true,
-      compactWorktreeCards: true
+      compactWorktreeCards: true,
+      experimentalLargerSidebarSections: true
     })
   })
 
-  it('accepts worktree card display setting updates from paired clients', () => {
+  it('accepts sidebar worktree display setting updates from paired clients', () => {
     let settings = {
       ...store.getSettings(),
       experimentalNewWorktreeCardStyle: false,
-      compactWorktreeCards: false
+      compactWorktreeCards: false,
+      experimentalLargerSidebarSections: false
     }
     const updateSettings = vi.fn((updates: Partial<typeof settings>) => {
       settings = { ...settings, ...updates }
@@ -1159,19 +1162,26 @@ describe('OrcaRuntimeService', () => {
     expect(
       runtime.updateClientSettings({
         experimentalNewWorktreeCardStyle: true,
-        compactWorktreeCards: true
+        compactWorktreeCards: true,
+        experimentalLargerSidebarSections: true
       })
     ).toMatchObject({
       experimentalNewWorktreeCardStyle: true,
-      compactWorktreeCards: true
+      compactWorktreeCards: true,
+      experimentalLargerSidebarSections: true
     })
     expect(updateSettings).toHaveBeenCalledWith(
-      { experimentalNewWorktreeCardStyle: true, compactWorktreeCards: true },
+      {
+        experimentalNewWorktreeCardStyle: true,
+        compactWorktreeCards: true,
+        experimentalLargerSidebarSections: true
+      },
       { notifyListeners: true }
     )
     expect(runtime.getClientSettings()).toMatchObject({
       experimentalNewWorktreeCardStyle: true,
-      compactWorktreeCards: true
+      compactWorktreeCards: true,
+      experimentalLargerSidebarSections: true
     })
   })
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -747,6 +747,7 @@ type RuntimeStore = {
     githubProjects?: GlobalSettings['githubProjects']
     experimentalNewWorktreeCardStyle?: GlobalSettings['experimentalNewWorktreeCardStyle']
     compactWorktreeCards?: GlobalSettings['compactWorktreeCards']
+    experimentalLargerSidebarSections?: GlobalSettings['experimentalLargerSidebarSections']
     gitlabProjects?: GlobalSettings['gitlabProjects']
     experimentalWorktreeSymlinks?: boolean
     mobileAutoRestoreFitMs?: number | null
@@ -2121,6 +2122,7 @@ export class OrcaRuntimeService {
     | 'githubProjects'
     | 'experimentalNewWorktreeCardStyle'
     | 'compactWorktreeCards'
+    | 'experimentalLargerSidebarSections'
   > {
     if (!this.store?.getSettings) {
       throw new Error('runtime_unavailable')
@@ -2140,7 +2142,8 @@ export class OrcaRuntimeService {
       defaultLinearTeamSelection: settings.defaultLinearTeamSelection ?? null,
       githubProjects: settings.githubProjects,
       experimentalNewWorktreeCardStyle: settings.experimentalNewWorktreeCardStyle === true,
-      compactWorktreeCards: settings.compactWorktreeCards === true
+      compactWorktreeCards: settings.compactWorktreeCards === true,
+      experimentalLargerSidebarSections: settings.experimentalLargerSidebarSections === true
     }
   }
 
@@ -2160,6 +2163,7 @@ export class OrcaRuntimeService {
       | 'githubProjects'
       | 'experimentalNewWorktreeCardStyle'
       | 'compactWorktreeCards'
+      | 'experimentalLargerSidebarSections'
     >
   ): Pick<
     GlobalSettings,
@@ -2177,6 +2181,7 @@ export class OrcaRuntimeService {
     | 'githubProjects'
     | 'experimentalNewWorktreeCardStyle'
     | 'compactWorktreeCards'
+    | 'experimentalLargerSidebarSections'
   > {
     if (!this.store?.getSettings || !this.store.updateSettings) {
       throw new Error('runtime_unavailable')

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -53,6 +53,7 @@ describe('client UI RPC methods', () => {
       defaultLinearTeamSelection: ['team-1', 'team-2'],
       experimentalNewWorktreeCardStyle: true,
       compactWorktreeCards: true,
+      experimentalLargerSidebarSections: true,
       githubProjects: {
         pinned: [],
         recent: [],
@@ -77,6 +78,7 @@ describe('client UI RPC methods', () => {
         defaultTaskViewPreset: 'my-prs',
         experimentalNewWorktreeCardStyle: true,
         compactWorktreeCards: true,
+        experimentalLargerSidebarSections: true,
         defaultRepoSelection: settings.defaultRepoSelection,
         defaultLinearTeamSelection: ['team-1', 'team-2'],
         githubProjects: settings.githubProjects
@@ -91,6 +93,7 @@ describe('client UI RPC methods', () => {
       defaultTaskViewPreset: 'my-prs',
       experimentalNewWorktreeCardStyle: true,
       compactWorktreeCards: true,
+      experimentalLargerSidebarSections: true,
       defaultRepoSelection: settings.defaultRepoSelection,
       defaultLinearTeamSelection: ['team-1', 'team-2'],
       githubProjects: settings.githubProjects

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -138,6 +138,7 @@ const SettingsUpdate = z
       .enum(['issues', 'my-issues', 'prs', 'my-prs', 'review', 'all'])
       .optional(),
     experimentalNewWorktreeCardStyle: z.boolean().optional(),
+    experimentalLargerSidebarSections: z.boolean().optional(),
     agentStatusHooksEnabled: z.boolean().optional(),
     defaultRepoSelection: z.array(z.string()).nullable().optional(),
     defaultLinearTeamSelection: z.array(z.string()).nullable().optional(),

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -119,6 +119,39 @@ describe('ExperimentalPane', () => {
     root.unmount()
   })
 
+  it('renders larger sidebar sections as an off-by-default searchable experimental switch', () => {
+    const settings = getDefaultSettings('/tmp')
+    const markup = renderToStaticMarkup(
+      <ExperimentalPane settings={settings} updateSettings={vi.fn()} />
+    )
+
+    expect(settings.experimentalLargerSidebarSections).toBe(false)
+    expect(markup).toContain('Larger sidebar sections')
+    expect(markup).toContain('aria-checked="false"')
+    expect(getExperimentalPaneSearchEntries().map((entry) => entry.title)).toContain(
+      'Larger sidebar sections'
+    )
+  })
+
+  it('enables larger sidebar sections through the experimental switch', async () => {
+    const updateSettings = vi.fn()
+    const { root, container } = await renderExperimentalPane({ updateSettings })
+
+    const switchButton = container.querySelector<HTMLButtonElement>(
+      '#experimental-larger-sidebar-sections button[role="switch"]'
+    )
+    if (!switchButton) {
+      throw new Error('Larger sidebar sections switch was not rendered')
+    }
+
+    await act(async () => {
+      switchButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ experimentalLargerSidebarSections: true })
+    root.unmount()
+  })
+
   it('enables new card style through the experimental switch', async () => {
     const updateSettings = vi.fn()
     const { root, container } = await renderExperimentalPane({ updateSettings })

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -6,6 +6,7 @@ import { matchesSettingsSearch } from './settings-search'
 import { getExperimentalPaneSearchEntries, getExperimentalSearchEntry } from './experimental-search'
 import { HiddenExperimentalGroup } from './HiddenExperimentalGroup'
 import { NumberField, SettingsSwitch } from './SettingsFormControls'
+import { LargerSidebarSectionsSetting } from './LargerSidebarSectionsSetting'
 import { translate } from '@/i18n/i18n'
 import {
   MAX_AGENT_HIBERNATION_IDLE_MS,
@@ -47,8 +48,12 @@ export function ExperimentalPane({
   const showNewWorktreeCardStyle = matchesSettingsSearch(searchQuery, [
     getExperimentalSearchEntry().newWorktreeCardStyle
   ])
+  const showLargerSidebarSections = matchesSettingsSearch(searchQuery, [
+    getExperimentalSearchEntry().largerSidebarSections
+  ])
   const agentHibernationEnabled = settings.experimentalAgentHibernation === true
   const newWorktreeCardStyleEnabled = settings.experimentalNewWorktreeCardStyle === true
+  const largerSidebarSectionsEnabled = settings.experimentalLargerSidebarSections === true
   // Why: the planner owns ms-based bounds/defaults; the UI edits minutes
   // while displaying the same effective clamped value the planner will use.
   const agentHibernationIdleMinutes = Math.round(
@@ -311,6 +316,17 @@ export function ExperimentalPane({
             />
           </div>
         </SearchableSetting>
+      ) : null}
+
+      {showLargerSidebarSections ? (
+        <LargerSidebarSectionsSetting
+          enabled={largerSidebarSectionsEnabled}
+          onToggle={() =>
+            updateSettings({
+              experimentalLargerSidebarSections: !largerSidebarSectionsEnabled
+            })
+          }
+        />
       ) : null}
 
       {showWorktreeSymlinks ? (

--- a/src/renderer/src/components/settings/LargerSidebarSectionsSetting.tsx
+++ b/src/renderer/src/components/settings/LargerSidebarSectionsSetting.tsx
@@ -1,0 +1,56 @@
+import { translate } from '@/i18n/i18n'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+import { getExperimentalSearchEntry } from './experimental-search'
+import { SettingsSwitch } from './SettingsFormControls'
+
+type LargerSidebarSectionsSettingProps = {
+  enabled: boolean
+  onToggle: () => void
+}
+
+export function LargerSidebarSectionsSetting({
+  enabled,
+  onToggle
+}: LargerSidebarSectionsSettingProps): React.JSX.Element {
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.ExperimentalPane.largerSidebarSections.title',
+        'Larger sidebar sections'
+      )}
+      description={translate(
+        'auto.components.settings.ExperimentalPane.largerSidebarSections.description',
+        'Preview larger project and section headers in the worktree sidebar.'
+      )}
+      keywords={getExperimentalSearchEntry().largerSidebarSections.keywords}
+      className="space-y-3 py-2"
+      id="experimental-larger-sidebar-sections"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 shrink space-y-0.5">
+          <Label>
+            {translate(
+              'auto.components.settings.ExperimentalPane.largerSidebarSections.title',
+              'Larger sidebar sections'
+            )}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.ExperimentalPane.largerSidebarSections.copy',
+              'Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.'
+            )}
+          </p>
+        </div>
+        <SettingsSwitch
+          checked={enabled}
+          ariaLabel={translate(
+            'auto.components.settings.ExperimentalPane.largerSidebarSections.toggleLabel',
+            'Toggle larger sidebar sections'
+          )}
+          onChange={onToggle}
+        />
+      </div>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -3,6 +3,7 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getNewWorktreeCardStyleSearchEntry } from './new-worktree-card-style-search-entry'
+import { getLargerSidebarSectionsSearchEntry } from './larger-sidebar-sections-search-entry'
 
 export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
@@ -182,6 +183,7 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
       ]
     },
     getNewWorktreeCardStyleSearchEntry(),
+    getLargerSidebarSectionsSearchEntry(),
     {
       title: translate(
         'auto.components.settings.experimental.search.78c2a8dc74',
@@ -264,6 +266,12 @@ export function getExperimentalSearchEntry() {
       translate(
         'auto.components.settings.experimental.search.newWorktreeCardStyle.title',
         'New card style'
+      )
+    ),
+    largerSidebarSections: findEntry(
+      translate(
+        'auto.components.settings.experimental.search.largerSidebarSections.title',
+        'Larger sidebar sections'
       )
     ),
     symlinksOnWorktrees: findEntry(

--- a/src/renderer/src/components/settings/larger-sidebar-sections-search-entry.ts
+++ b/src/renderer/src/components/settings/larger-sidebar-sections-search-entry.ts
@@ -1,0 +1,50 @@
+import type { SettingsSearchEntry } from './settings-search'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getLargerSidebarSectionsSearchEntry(): SettingsSearchEntry {
+  return {
+    title: translate(
+      'auto.components.settings.experimental.search.largerSidebarSections.title',
+      'Larger sidebar sections'
+    ),
+    description: translate(
+      'auto.components.settings.experimental.search.largerSidebarSections.description',
+      'Preview larger project and section headers in the worktree sidebar, including repo icons.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.0d24759f14',
+        'experimental'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.largerSidebarSections.sidebar',
+        'sidebar'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.largerSidebarSections.sections',
+        'sections'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.largerSidebarSections.projects',
+        'projects'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.largerSidebarSections.headers',
+        'headers'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.largerSidebarSections.typography',
+        'typography'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.largerSidebarSections.icons',
+        'icons'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.largerSidebarSections.repo',
+        'repo'
+      )
+    ]
+  }
+}

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -7,6 +7,7 @@ import SidebarWorkspaceOptionsMenu from './SidebarWorkspaceOptionsMenu'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { openWorkspaceCreationComposerWithTourHandoff } from '../contextual-tours/workspace-creation-tour-handoff'
 import { translate } from '@/i18n/i18n'
+import { getSidebarTopSectionTitleClassName } from './sidebar-section-header-appearance'
 
 type SidebarHeaderProps = {
   onWorkspaceBoardMenuOpenChange: (open: boolean) => void
@@ -19,13 +20,16 @@ const SidebarHeader = React.memo(function SidebarHeader({
   const newWorktreeShortcutLabel = useShortcutLabel('workspace.create')
   const groupBy = useAppStore((s) => s.groupBy)
   const canCreateWorkspace = useAppStore((s) => s.repos.length > 0)
+  const largerSidebarSections = useAppStore(
+    (s) => s.settings?.experimentalLargerSidebarSections === true
+  )
   const sidebarTitle = groupBy === 'repo' ? 'Projects' : 'Workspaces'
 
   return (
     <div className="mt-2 flex h-8 items-center justify-between px-2 gap-2">
       <div className="flex min-w-0 items-center gap-1">
         <span
-          className="pl-2 pr-0.5 text-xs font-semibold text-muted-foreground/80 select-none"
+          className={getSidebarTopSectionTitleClassName(largerSidebarSections)}
           data-sidebar-section-title={groupBy === 'repo' ? 'projects' : 'workspaces'}
         >
           {sidebarTitle}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -63,6 +63,7 @@ import {
 import { DetachedHeadBadge } from '@/components/DetachedHeadBadge'
 import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { getFlushWorktreeCardPaddingLeft } from './worktree-list-indentation'
+import { resolveSidebarSectionHeaderAppearance } from './sidebar-section-header-appearance'
 import { translate } from '@/i18n/i18n'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-diagnostics'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../../shared/workspace-scope'
@@ -1141,8 +1142,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
       : undefined
   // Why: sidebar rows need a small surface inset, while their content remains
   // aligned with the pre-inset layout and the repo header hierarchy.
+  const flushCardContentPullback =
+    resolveSidebarSectionHeaderAppearance(settings).flushCardContentPullback
   const cardPaddingLeft = flushSurface
-    ? getFlushWorktreeCardPaddingLeft(contentIndent)
+    ? getFlushWorktreeCardPaddingLeft(contentIndent, flushCardContentPullback)
     : contentIndent > 0
       ? `calc(0.125rem + ${contentIndent}px)`
       : null

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -22,6 +22,7 @@ import {
 import { buildAgentRowLineageTree } from '@/components/dashboard/agent-row-lineage-model'
 import { DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE } from '../../../../shared/constants'
 import { revealElementInScrollContainer } from './worktree-sidebar-reveal'
+import { resolveSidebarSectionHeaderAppearance } from './sidebar-section-header-appearance'
 import { translate } from '@/i18n/i18n'
 
 export const SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT =
@@ -37,7 +38,10 @@ function revealCompactAgentCard(agentListRoot: HTMLElement | null): void {
   if (!(sidebarElement instanceof HTMLElement) || !worktreeOptionElement) {
     return
   }
-  revealElementInScrollContainer(sidebarElement, worktreeOptionElement, 'auto')
+  const topInset = resolveSidebarSectionHeaderAppearance(
+    useAppStore.getState().settings
+  ).revealTopInset
+  revealElementInScrollContainer(sidebarElement, worktreeOptionElement, 'auto', topInset)
 }
 
 type Props = {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -90,10 +90,7 @@ import {
   shouldUseHeaderTopSpacing,
   type RenderRow
 } from './worktree-list-virtual-rows'
-import {
-  revealElementInScrollContainer,
-  WORKTREE_SIDEBAR_REVEAL_TOP_INSET
-} from './worktree-sidebar-reveal'
+import { revealElementInScrollContainer } from './worktree-sidebar-reveal'
 import {
   getWorkspaceStatus,
   getWorkspaceStatusFromGroupKey,
@@ -235,6 +232,12 @@ import { HostSectionHeaderMenu } from './HostSectionHeaderMenu'
 import { ProjectHeaderActions } from './ProjectHeaderActions'
 import { translate } from '@/i18n/i18n'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import {
+  getHostSectionHeaderTitleClassName,
+  getSidebarSectionHeaderTitleClassName,
+  resolveSidebarSectionHeaderAppearance,
+  SHOW_SIDEBAR_ACTIVE_REPO_HIGHLIGHT
+} from './sidebar-section-header-appearance'
 import { getHostDisplayLabelOverrides } from '../../../../shared/host-setting-overrides'
 import {
   isConfirmedStaleFolderPathStatus,
@@ -423,7 +426,8 @@ function revealMountedWorktreeElement(
   container: HTMLElement,
   worktreeId: string,
   behavior: ScrollBehavior,
-  optionId?: string
+  optionId?: string,
+  topInset?: number
 ): HTMLElement | null {
   const element = optionId
     ? document.getElementById(optionId)
@@ -431,7 +435,7 @@ function revealMountedWorktreeElement(
   if (!element || !container.contains(element)) {
     return null
   }
-  return revealElementInScrollContainer(container, element, behavior) ? element : null
+  return revealElementInScrollContainer(container, element, behavior, topInset) ? element : null
 }
 
 function getWorktreeVisibilityMenuLabel(repo: Repo): string {
@@ -446,6 +450,7 @@ const SIDEBAR_POINTER_DRAG_THRESHOLD_PX = 4
 type VirtualizedWorktreeViewportProps = {
   rows: HostSectionRow[]
   activeWorktreeId: string | null
+  activeRepoId: string | null
   currentWorktreeId: string | null
   groupBy: WorktreeGroupBy
   projectOrderBy: ProjectOrderBy
@@ -613,12 +618,14 @@ function HostSectionHeader({
   row,
   onToggle,
   onDragPointerDown,
-  dragging
+  dragging,
+  largerSidebarSections
 }: {
   row: HostHeaderRow
   onToggle: () => void
   onDragPointerDown?: (event: React.PointerEvent<HTMLElement>) => void
   dragging?: boolean
+  largerSidebarSections: boolean
 }): React.JSX.Element {
   const isBlocked = row.health === 'blocked'
   const isDisconnected = row.health === 'disconnected'
@@ -663,7 +670,7 @@ function HostSectionHeader({
         <div className="flex min-w-0 flex-1 items-baseline gap-1.5">
           <span
             className={cn(
-              'min-w-0 truncate text-[12px] font-semibold leading-none',
+              getHostSectionHeaderTitleClassName(largerSidebarSections),
               isDisconnected ? 'text-muted-foreground' : 'text-foreground'
             )}
           >
@@ -1072,6 +1079,7 @@ function getVirtualRowKey(element: Element): string | null {
 const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewport({
   rows,
   activeWorktreeId,
+  activeRepoId,
   currentWorktreeId,
   groupBy,
   projectOrderBy,
@@ -1212,6 +1220,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const prVisibleRefreshGeneration = useAppStore((s) => s.prVisibleRefreshGeneration)
   const settings = useAppStore((s) => s.settings)
   const newCardStyle = settings?.experimentalNewWorktreeCardStyle === true
+  const sidebarSectionAppearance = useMemo(
+    () => resolveSidebarSectionHeaderAppearance(settings),
+    [settings]
+  )
   const reorderRepos = useAppStore((s) => s.reorderRepos)
 
   useEffect(
@@ -1628,7 +1640,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             renderRowsRef.current,
             index ?? -1,
             firstHeaderIndexRef.current,
-            activeStickyHeaderIndexRef.current
+            activeStickyHeaderIndexRef.current,
+            sidebarSectionAppearance.headerRowHeight
           )
         )
       }
@@ -1642,12 +1655,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           renderRowsRef.current,
           index,
           firstHeaderIndexRef.current,
-          activeStickyHeaderIndexRef.current
+          activeStickyHeaderIndexRef.current,
+          sidebarSectionAppearance.headerRowHeight
         )
       }
       return measureVirtualElementSize(element, entry, instance)
     },
-    [isCurrentVirtualRowElement]
+    [isCurrentVirtualRowElement, sidebarSectionAppearance.headerRowHeight]
   )
   const markScrollMovement = useCallback(() => {
     suppressMeasurementAdjustmentUntilRef.current =
@@ -1677,7 +1691,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         renderRows,
         index,
         firstHeaderIndex,
-        activeStickyHeaderIndexRef.current
+        activeStickyHeaderIndexRef.current,
+        sidebarSectionAppearance.headerRowHeight
       ),
     measureElement: measureCurrentVirtualRowElement,
     // Why: TanStack memoizes range extraction by function identity. Header
@@ -1698,7 +1713,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     gap: 6,
     // Why: the active sticky group header is rendered inside the virtual list,
     // so TanStack's scroll math needs the same top inset as the exact DOM reveal.
-    scrollPaddingStart: WORKTREE_SIDEBAR_REVEAL_TOP_INSET,
+    scrollPaddingStart: sidebarSectionAppearance.revealTopInset,
     isScrollingResetDelay: USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS,
     // Why: the sidebar rows are rich cards. Flushing their React render inside
     // TanStack's native scroll listener can make wheel input wait on card work;
@@ -1848,7 +1863,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               container,
               pendingRevealWorktree.worktreeId,
               pendingRevealWorktree.behavior,
-              getRenderRowOptionId(targetRow, pendingRevealWorktree.worktreeId)
+              getRenderRowOptionId(targetRow, pendingRevealWorktree.worktreeId),
+              sidebarSectionAppearance.revealTopInset
             )
           : null
         if (revealedOption) {
@@ -1919,7 +1935,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     flashRevealedWorktree,
     setRenamingWorktreeId,
     schedulePendingRevealFrame,
-    cancelPendingRevealFrames
+    cancelPendingRevealFrames,
+    sidebarSectionAppearance.revealTopInset
   ])
 
   const prCacheLen = useAppStore((s) => countRecordKeysByReference(s.prCache))
@@ -3603,6 +3620,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         : undefined
                     }
                     dragging={hostDrag.state.draggingHostId === row.hostId}
+                    largerSidebarSections={sidebarSectionAppearance.enabled}
                   />
                 </div>
               )
@@ -3686,6 +3704,24 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 isRepoHeader || isProjectGroupHeader
                   ? getProjectGroupHeaderPaddingLeft(projectGroupDepth)
                   : WORKTREE_SECTION_HEADER_PADDING_LEFT
+              const isActiveRepoHeader =
+                SHOW_SIDEBAR_ACTIVE_REPO_HIGHLIGHT &&
+                sidebarSectionAppearance.enabled &&
+                isRepoHeader &&
+                activeRepoId !== null &&
+                row.repo?.id === activeRepoId
+              const sectionHeaderIconShellClassName = sidebarSectionAppearance.enabled
+                ? 'size-5'
+                : 'size-4'
+              const sectionHeaderRepoIconClassName = sidebarSectionAppearance.enabled
+                ? 'size-5'
+                : 'size-4'
+              const sectionHeaderRepoIconGlyphClassName = sidebarSectionAppearance.enabled
+                ? 'size-4'
+                : 'size-3.5'
+              const sectionHeaderLucideIconClassName = sidebarSectionAppearance.enabled
+                ? 'size-4'
+                : 'size-3'
               return (
                 <div
                   key={vItem.key}
@@ -3722,12 +3758,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     data-repo-header-id={projectIdForHeader}
                     data-repo-header-index={repoHeaderIndex}
                     data-repo-header-bucket={repoHeaderBucketKey}
+                    data-current={isActiveRepoHeader ? 'true' : undefined}
+                    aria-current={isActiveRepoHeader ? 'true' : undefined}
                     data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
                     data-workspace-status={headerWorkspaceStatus ?? undefined}
                     data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
                     className={cn(
-                      'group relative flex h-7 w-full items-center gap-1.5 pr-2 text-left transition-all',
+                      'group relative flex w-full items-center gap-1.5 pr-2 text-left transition-all',
+                      sidebarSectionAppearance.enabled ? 'h-8' : 'h-7',
                       'cursor-pointer',
+                      // Why: inset shadow keeps the left accent without border width
+                      // shifting header icons/text away from workspace cards.
+                      isActiveRepoHeader &&
+                        'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground shadow-[inset_2px_0_0_0_var(--worktree-sidebar-ring)]',
                       isDraggingThis &&
                         'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
                       headerWorkspaceStatus &&
@@ -3778,7 +3821,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       <div
                         data-repo-header-drag-handle={isDraggableRepoHeader ? '' : undefined}
                         className={cn(
-                          'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
+                          'flex shrink-0 items-center justify-center rounded-[4px]',
+                          sectionHeaderIconShellClassName,
                           repoHeaderColor ? 'text-muted-foreground' : row.tone,
                           isDraggableRepoHeader && 'hover:cursor-grab active:cursor-grabbing'
                         )}
@@ -3792,18 +3836,22 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                           <RepoIconGlyph
                             repoIcon={row.repo.repoIcon}
                             color={repoHeaderColor}
-                            className="size-4"
-                            iconClassName="size-3.5"
+                            className={sectionHeaderRepoIconClassName}
+                            iconClassName={sectionHeaderRepoIconGlyphClassName}
                           />
                         ) : (
-                          <row.icon className="size-3" />
+                          <row.icon className={sectionHeaderLucideIconClassName} />
                         )}
                       </div>
                     ) : null}
 
                     <div className="min-w-0 flex-1">
                       <div className="flex min-w-0 items-center gap-1.5">
-                        <div className="min-w-0 truncate text-[13px] font-semibold leading-none">
+                        <div
+                          className={getSidebarSectionHeaderTitleClassName(
+                            sidebarSectionAppearance.enabled
+                          )}
+                        >
                           {row.label}
                         </div>
                         <RepoForkIndicator upstream={row.repo?.upstream} />
@@ -4599,6 +4647,7 @@ const WorktreeList = React.memo(function WorktreeList({
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const detectedWorktreesByRepo = useAppStore((s) => s.detectedWorktreesByRepo)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const activeRepoId = useAppStore((s) => s.activeRepoId)
   const currentSidebarWorktreeId = activeWorktreeId
   const groupBy = useAppStore((s) => s.groupBy)
   const workspaceHostScope = useAppStore((s) => s.workspaceHostScope)
@@ -6009,6 +6058,7 @@ const WorktreeList = React.memo(function WorktreeList({
         key={viewportResetKey}
         rows={sectionRows}
         activeWorktreeId={selectedSidebarWorktreeId}
+        activeRepoId={activeRepoId}
         currentWorktreeId={currentSidebarWorktreeId}
         groupBy={groupBy}
         projectOrderBy={projectOrderBy}

--- a/src/renderer/src/components/sidebar/sidebar-section-header-appearance.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-section-header-appearance.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_FLUSH_CARD_CONTENT_PULLBACK,
+  DEFAULT_SIDEBAR_SECTION_HEADER_ROW_HEIGHT,
+  LARGER_FLUSH_CARD_CONTENT_PULLBACK,
+  LARGER_SIDEBAR_SECTION_HEADER_ROW_HEIGHT,
+  getSidebarSectionHeaderTitleClassName,
+  resolveSidebarSectionHeaderAppearance
+} from './sidebar-section-header-appearance'
+
+describe('sidebar section header appearance', () => {
+  it('keeps the legacy sidebar section sizing off by default', () => {
+    expect(resolveSidebarSectionHeaderAppearance(null)).toEqual({
+      enabled: false,
+      headerRowHeight: DEFAULT_SIDEBAR_SECTION_HEADER_ROW_HEIGHT,
+      flushCardContentPullback: DEFAULT_FLUSH_CARD_CONTENT_PULLBACK,
+      revealTopInset: DEFAULT_SIDEBAR_SECTION_HEADER_ROW_HEIGHT + 6
+    })
+  })
+
+  it('enables the larger sidebar section treatment when the experimental flag is on', () => {
+    expect(
+      resolveSidebarSectionHeaderAppearance({ experimentalLargerSidebarSections: true })
+    ).toEqual({
+      enabled: true,
+      headerRowHeight: LARGER_SIDEBAR_SECTION_HEADER_ROW_HEIGHT,
+      flushCardContentPullback: LARGER_FLUSH_CARD_CONTENT_PULLBACK,
+      revealTopInset: LARGER_SIDEBAR_SECTION_HEADER_ROW_HEIGHT + 6
+    })
+  })
+
+  it('uses the larger title class only when the experimental flag is on', () => {
+    expect(getSidebarSectionHeaderTitleClassName(false)).toContain('text-[13px]')
+    expect(getSidebarSectionHeaderTitleClassName(true)).toContain('text-sm')
+  })
+})

--- a/src/renderer/src/components/sidebar/sidebar-section-header-appearance.ts
+++ b/src/renderer/src/components/sidebar/sidebar-section-header-appearance.ts
@@ -1,11 +1,12 @@
 import type { GlobalSettings } from '../../../../shared/types'
+import { FLUSH_CARD_CONTENT_PULLBACK } from './worktree-list-indentation'
 
 // Why: evaluate larger section typography on its own before shipping selection chrome.
 export const SHOW_SIDEBAR_ACTIVE_REPO_HIGHLIGHT = false
 
 export const DEFAULT_SIDEBAR_SECTION_HEADER_ROW_HEIGHT = 28
 export const LARGER_SIDEBAR_SECTION_HEADER_ROW_HEIGHT = 32
-export const DEFAULT_FLUSH_CARD_CONTENT_PULLBACK = 4
+export const DEFAULT_FLUSH_CARD_CONTENT_PULLBACK = FLUSH_CARD_CONTENT_PULLBACK
 export const LARGER_FLUSH_CARD_CONTENT_PULLBACK = 8
 const WORKTREE_REVEAL_TOP_CLEARANCE = 6
 

--- a/src/renderer/src/components/sidebar/sidebar-section-header-appearance.ts
+++ b/src/renderer/src/components/sidebar/sidebar-section-header-appearance.ts
@@ -1,0 +1,52 @@
+import type { GlobalSettings } from '../../../../shared/types'
+
+// Why: evaluate larger section typography on its own before shipping selection chrome.
+export const SHOW_SIDEBAR_ACTIVE_REPO_HIGHLIGHT = false
+
+export const DEFAULT_SIDEBAR_SECTION_HEADER_ROW_HEIGHT = 28
+export const LARGER_SIDEBAR_SECTION_HEADER_ROW_HEIGHT = 32
+export const DEFAULT_FLUSH_CARD_CONTENT_PULLBACK = 4
+export const LARGER_FLUSH_CARD_CONTENT_PULLBACK = 8
+const WORKTREE_REVEAL_TOP_CLEARANCE = 6
+
+export type SidebarSectionHeaderAppearance = {
+  enabled: boolean
+  headerRowHeight: number
+  flushCardContentPullback: number
+  revealTopInset: number
+}
+
+export function resolveSidebarSectionHeaderAppearance(
+  settings: Pick<GlobalSettings, 'experimentalLargerSidebarSections'> | null | undefined
+): SidebarSectionHeaderAppearance {
+  const enabled = settings?.experimentalLargerSidebarSections === true
+  const headerRowHeight = enabled
+    ? LARGER_SIDEBAR_SECTION_HEADER_ROW_HEIGHT
+    : DEFAULT_SIDEBAR_SECTION_HEADER_ROW_HEIGHT
+  return {
+    enabled,
+    headerRowHeight,
+    flushCardContentPullback: enabled
+      ? LARGER_FLUSH_CARD_CONTENT_PULLBACK
+      : DEFAULT_FLUSH_CARD_CONTENT_PULLBACK,
+    revealTopInset: headerRowHeight + WORKTREE_REVEAL_TOP_CLEARANCE
+  }
+}
+
+export function getSidebarSectionHeaderTitleClassName(enabled: boolean): string {
+  return enabled
+    ? 'min-w-0 truncate text-sm font-semibold leading-none'
+    : 'min-w-0 truncate text-[13px] font-semibold leading-none'
+}
+
+export function getSidebarTopSectionTitleClassName(enabled: boolean): string {
+  return enabled
+    ? 'pl-2 pr-0.5 text-sm font-semibold text-muted-foreground/80 select-none'
+    : 'pl-2 pr-0.5 text-xs font-semibold text-muted-foreground/80 select-none'
+}
+
+export function getHostSectionHeaderTitleClassName(enabled: boolean): string {
+  return enabled
+    ? 'min-w-0 truncate text-sm font-semibold leading-none'
+    : 'min-w-0 truncate text-[12px] font-semibold leading-none'
+}

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
@@ -62,6 +62,7 @@ describe('worktree list indentation', () => {
 
   it('pulls flush card content back by the tuned inset gap', () => {
     expect(getFlushWorktreeCardPaddingLeft(20)).toBe('max(2px, calc(20px - 4px))')
+    expect(getFlushWorktreeCardPaddingLeft(20, 8)).toBe('max(2px, calc(20px - 8px))')
   })
 
   it('keeps flush card content off the sidebar edge without indentation', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.ts
@@ -55,9 +55,12 @@ export function getWorktreeCardSurfaceInset(args: {
   return args.isGrouped ? clampDepth(args.groupDepth) * GROUPED_WORKTREE_CARD_SURFACE_INDENT : 0
 }
 
-export function getFlushWorktreeCardPaddingLeft(contentIndent: number): string {
+export function getFlushWorktreeCardPaddingLeft(
+  contentIndent: number,
+  contentPullback = FLUSH_CARD_CONTENT_PULLBACK
+): string {
   return contentIndent > 0
-    ? `max(${FLUSH_CARD_MIN_CONTENT_INSET}px, calc(${contentIndent}px - ${FLUSH_CARD_CONTENT_PULLBACK}px))`
+    ? `max(${FLUSH_CARD_MIN_CONTENT_INSET}px, calc(${contentIndent}px - ${contentPullback}px))`
     : `${FLUSH_CARD_MIN_CONTENT_INSET}px`
 }
 

--- a/src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts
@@ -219,6 +219,12 @@ describe('estimateRenderRowSize', () => {
     expect(activeSize).toBe(32)
   })
 
+  it('uses the larger experimental section header height when requested', () => {
+    const rows = [makeHeaderRow('first'), makeHeaderRow('second')]
+
+    expect(estimateRenderRowSize(rows, 1, 0, null, 32)).toBe(36)
+  })
+
   it('estimates imported worktree line rows with a stable compact height', () => {
     const rows = [makeHeaderRow('repo:repo-1'), makeImportedCardRow()]
 

--- a/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
@@ -1,9 +1,10 @@
 import { defaultRangeExtractor } from '@tanstack/react-virtual'
 import type { Range, VirtualItem } from '@tanstack/react-virtual'
 import type { HostSectionRow } from './host-section-rows'
+import { DEFAULT_SIDEBAR_SECTION_HEADER_ROW_HEIGHT } from './sidebar-section-header-appearance'
 import { PINNED_GROUP_KEY } from './worktree-list-groups'
 
-export const GROUP_HEADER_ROW_HEIGHT = 28
+export const GROUP_HEADER_ROW_HEIGHT = DEFAULT_SIDEBAR_SECTION_HEADER_ROW_HEIGHT
 export const HOST_HEADER_ROW_HEIGHT = 32
 const SECONDARY_GROUP_HEADER_TOP_MARGIN = 4
 const IMPORTED_WORKTREES_LINE_ROW_HEIGHT = 36
@@ -30,7 +31,8 @@ export function estimateRenderRowSize(
   rows: readonly RenderRow[],
   index: number,
   firstHeaderIndex: number,
-  _activeStickyHeaderIndex: number | null
+  _activeStickyHeaderIndex: number | null,
+  groupHeaderRowHeight = GROUP_HEADER_ROW_HEIGHT
 ): number {
   const row = rows[index]
   if (row?.type === 'host-header') {
@@ -47,7 +49,7 @@ export function estimateRenderRowSize(
   }
   if (row?.type === 'header') {
     return (
-      GROUP_HEADER_ROW_HEIGHT +
+      groupHeaderRowHeight +
       (shouldUseHeaderTopSpacing({
         rows,
         index,

--- a/src/renderer/src/components/sidebar/worktree-sidebar-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-reveal.ts
@@ -1,8 +1,7 @@
-import { GROUP_HEADER_ROW_HEIGHT } from './worktree-list-virtual-rows'
+import { resolveSidebarSectionHeaderAppearance } from './sidebar-section-header-appearance'
 
-const WORKTREE_REVEAL_TOP_CLEARANCE = 6
 export const WORKTREE_SIDEBAR_REVEAL_TOP_INSET =
-  GROUP_HEADER_ROW_HEIGHT + WORKTREE_REVEAL_TOP_CLEARANCE
+  resolveSidebarSectionHeaderAppearance(null).revealTopInset
 
 type SidebarRevealBounds = {
   start: number
@@ -38,7 +37,8 @@ export function getScrollTopToRevealBounds(
 export function revealElementInScrollContainer(
   container: HTMLElement,
   element: Element,
-  behavior: ScrollBehavior
+  behavior: ScrollBehavior,
+  topInset = WORKTREE_SIDEBAR_REVEAL_TOP_INSET
 ): boolean {
   if (!container.contains(element)) {
     return false
@@ -46,7 +46,7 @@ export function revealElementInScrollContainer(
   const nextScrollTop = getScrollTopToRevealBounds(
     container,
     getElementScrollBounds(container, element),
-    WORKTREE_SIDEBAR_REVEAL_TOP_INSET
+    topInset
   )
   if (nextScrollTop !== null) {
     container.scrollTo({ top: Math.max(0, nextScrollTop), behavior })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4820,9 +4820,9 @@
           "dd6f0a1d45": "Pet",
           "0e89a574ae": "Floating animated pet in the bottom-right corner.",
           "largerSidebarSections": {
-            "title": "Larger sidebar sections",
-            "description": "Preview larger project and section headers in the worktree sidebar.",
             "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
+            "description": "Preview larger project and section headers in the worktree sidebar.",
+            "title": "Larger sidebar sections",
             "toggleLabel": "Toggle larger sidebar sections"
           }
         },
@@ -6940,8 +6940,15 @@
             "6b5a56ac35": "Floating animated pet in the bottom-right corner.",
             "87d99e634b": "Pet",
             "largerSidebarSections": {
+              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons.",
+              "headers": "headers",
+              "icons": "icons",
+              "projects": "projects",
+              "repo": "repo",
+              "sections": "sections",
+              "sidebar": "sidebar",
               "title": "Larger sidebar sections",
-              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
+              "typography": "typography"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4818,7 +4818,13 @@
           },
           "ca2219fe5e": "Shows a small animated pet pinned to the bottom-right corner. Pick a character (Claudino, OpenCode, Gremlin) or upload your own PNG, APNG, GIF, WebP, JPG, or SVG from the status-bar pet menu. Hide it any time from the same menu without disabling this setting.",
           "dd6f0a1d45": "Pet",
-          "0e89a574ae": "Floating animated pet in the bottom-right corner."
+          "0e89a574ae": "Floating animated pet in the bottom-right corner.",
+          "largerSidebarSections": {
+            "title": "Larger sidebar sections",
+            "description": "Preview larger project and section headers in the worktree sidebar.",
+            "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
+            "toggleLabel": "Toggle larger sidebar sections"
+          }
         },
         "FloatingWorkspacePane": {
           "aeaf76fda9": "Status Bar",
@@ -6932,7 +6938,11 @@
             "b54cea709b": "sidekick",
             "051203d37c": "pet",
             "6b5a56ac35": "Floating animated pet in the bottom-right corner.",
-            "87d99e634b": "Pet"
+            "87d99e634b": "Pet",
+            "largerSidebarSections": {
+              "title": "Larger sidebar sections",
+              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
+            }
           }
         },
         "floating": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4820,10 +4820,10 @@
             "toggleLabel": "Alternar nuevo estilo de tarjeta"
           },
           "largerSidebarSections": {
-            "title": "Larger sidebar sections",
-            "description": "Preview larger project and section headers in the worktree sidebar.",
-            "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
-            "toggleLabel": "Toggle larger sidebar sections"
+            "copy": "Aumenta el tamaño del texto de los encabezados de proyecto y sección, los iconos de repositorio y desplaza ligeramente a la izquierda las tarjetas de espacios de trabajo agrupadas.",
+            "description": "Previsualiza encabezados de proyecto y sección más grandes en la barra lateral de worktrees.",
+            "title": "Secciones más grandes en la barra lateral",
+            "toggleLabel": "Alternar secciones más grandes en la barra lateral"
           }
         },
         "FloatingWorkspacePane": {
@@ -6903,8 +6903,15 @@
               "worktrees": "worktrees"
             },
             "largerSidebarSections": {
-              "title": "Larger sidebar sections",
-              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
+              "description": "Previsualiza encabezados de proyecto y sección más grandes en la barra lateral de worktrees, incluidos los iconos de repositorio.",
+              "headers": "encabezados",
+              "icons": "iconos",
+              "projects": "proyectos",
+              "repo": "repositorio",
+              "sections": "secciones",
+              "sidebar": "barra lateral",
+              "title": "Secciones más grandes en la barra lateral",
+              "typography": "tipografía"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4818,6 +4818,12 @@
             "description": "Previsualiza el diseño actualizado de tarjetas de worktree, la ubicación de metadatos, las opciones del menú de visualización de tarjeta y la presentación de estado.",
             "title": "Nuevo estilo de tarjeta",
             "toggleLabel": "Alternar nuevo estilo de tarjeta"
+          },
+          "largerSidebarSections": {
+            "title": "Larger sidebar sections",
+            "description": "Preview larger project and section headers in the worktree sidebar.",
+            "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
+            "toggleLabel": "Toggle larger sidebar sections"
           }
         },
         "FloatingWorkspacePane": {
@@ -6895,6 +6901,10 @@
               "title": "Nuevo estilo de tarjeta",
               "worktree": "worktree",
               "worktrees": "worktrees"
+            },
+            "largerSidebarSections": {
+              "title": "Larger sidebar sections",
+              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4805,10 +4805,10 @@
             "toggleLabel": "新しいカードスタイルを切り替え"
           },
           "largerSidebarSections": {
-            "title": "Larger sidebar sections",
-            "description": "Preview larger project and section headers in the worktree sidebar.",
-            "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
-            "toggleLabel": "Toggle larger sidebar sections"
+            "copy": "プロジェクトとセクションのヘッダー文字、リポジトリアイコンを大きくし、グループ化されたワークスペースカードを少し左に寄せます。",
+            "description": "worktree サイドバーで大きめのプロジェクトヘッダーとセクションヘッダーをプレビューします。",
+            "title": "サイドバーセクションを大きく表示",
+            "toggleLabel": "サイドバーセクションの大きめ表示を切り替え"
           }
         },
         "FloatingWorkspacePane": {
@@ -6925,8 +6925,15 @@
               "worktrees": "worktrees"
             },
             "largerSidebarSections": {
-              "title": "Larger sidebar sections",
-              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
+              "description": "worktree サイドバーでリポジトリアイコンを含む大きめのプロジェクトヘッダーとセクションヘッダーをプレビューします。",
+              "headers": "ヘッダー",
+              "icons": "アイコン",
+              "projects": "プロジェクト",
+              "repo": "リポジトリ",
+              "sections": "セクション",
+              "sidebar": "サイドバー",
+              "title": "サイドバーセクションを大きく表示",
+              "typography": "タイポグラフィ"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4803,6 +4803,12 @@
             "description": "更新された worktree カードのレイアウト、メタデータ配置、カード表示メニュー項目、ステータス表示をプレビューします。",
             "title": "新しいカードスタイル",
             "toggleLabel": "新しいカードスタイルを切り替え"
+          },
+          "largerSidebarSections": {
+            "title": "Larger sidebar sections",
+            "description": "Preview larger project and section headers in the worktree sidebar.",
+            "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
+            "toggleLabel": "Toggle larger sidebar sections"
           }
         },
         "FloatingWorkspacePane": {
@@ -6917,6 +6923,10 @@
               "title": "新しいカードスタイル",
               "worktree": "worktree",
               "worktrees": "worktrees"
+            },
+            "largerSidebarSections": {
+              "title": "Larger sidebar sections",
+              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4805,10 +4805,10 @@
             "toggleLabel": "새 카드 스타일 전환"
           },
           "largerSidebarSections": {
-            "title": "Larger sidebar sections",
-            "description": "Preview larger project and section headers in the worktree sidebar.",
-            "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
-            "toggleLabel": "Toggle larger sidebar sections"
+            "copy": "프로젝트 및 섹션 헤더 글자와 저장소 아이콘을 키우고, 그룹화된 워크스페이스 카드를 약간 왼쪽으로 당깁니다.",
+            "description": "worktree 사이드바에서 더 큰 프로젝트 및 섹션 헤더를 미리 봅니다.",
+            "title": "더 큰 사이드바 섹션",
+            "toggleLabel": "더 큰 사이드바 섹션 전환"
           }
         },
         "FloatingWorkspacePane": {
@@ -6888,8 +6888,15 @@
               "worktrees": "worktrees"
             },
             "largerSidebarSections": {
-              "title": "Larger sidebar sections",
-              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
+              "description": "worktree 사이드바에서 저장소 아이콘을 포함한 더 큰 프로젝트 및 섹션 헤더를 미리 봅니다.",
+              "headers": "헤더",
+              "icons": "아이콘",
+              "projects": "프로젝트",
+              "repo": "저장소",
+              "sections": "섹션",
+              "sidebar": "사이드바",
+              "title": "더 큰 사이드바 섹션",
+              "typography": "타이포그래피"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4803,6 +4803,12 @@
             "description": "업데이트된 워크트리 카드 레이아웃, 메타데이터 배치, 카드 표시 메뉴 옵션 및 상태 표시를 미리 봅니다.",
             "title": "새 카드 스타일",
             "toggleLabel": "새 카드 스타일 전환"
+          },
+          "largerSidebarSections": {
+            "title": "Larger sidebar sections",
+            "description": "Preview larger project and section headers in the worktree sidebar.",
+            "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
+            "toggleLabel": "Toggle larger sidebar sections"
           }
         },
         "FloatingWorkspacePane": {
@@ -6880,6 +6886,10 @@
               "title": "새 카드 스타일",
               "worktree": "worktree",
               "worktrees": "worktrees"
+            },
+            "largerSidebarSections": {
+              "title": "Larger sidebar sections",
+              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4805,10 +4805,10 @@
             "toggleLabel": "切换新卡片样式"
           },
           "largerSidebarSections": {
-            "title": "Larger sidebar sections",
-            "description": "Preview larger project and section headers in the worktree sidebar.",
-            "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
-            "toggleLabel": "Toggle larger sidebar sections"
+            "copy": "增大项目和分区标题文字、仓库图标，并将分组工作区卡片略微向左对齐。",
+            "description": "在 worktree 侧边栏中预览更大的项目和分区标题。",
+            "title": "更大的侧边栏分区",
+            "toggleLabel": "切换更大的侧边栏分区"
           }
         },
         "FloatingWorkspacePane": {
@@ -6888,8 +6888,15 @@
               "worktrees": "worktrees"
             },
             "largerSidebarSections": {
-              "title": "Larger sidebar sections",
-              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
+              "description": "在 worktree 侧边栏中预览更大的项目和分区标题，包括仓库图标。",
+              "headers": "标题",
+              "icons": "图标",
+              "projects": "项目",
+              "repo": "仓库",
+              "sections": "分区",
+              "sidebar": "侧边栏",
+              "title": "更大的侧边栏分区",
+              "typography": "排版"
             }
           }
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4803,6 +4803,12 @@
             "description": "预览更新后的 worktree 卡片布局、元数据位置、卡片显示菜单选项和状态呈现。",
             "title": "新卡片样式",
             "toggleLabel": "切换新卡片样式"
+          },
+          "largerSidebarSections": {
+            "title": "Larger sidebar sections",
+            "description": "Preview larger project and section headers in the worktree sidebar.",
+            "copy": "Increases project and section header type, repo icons, and slightly pulls grouped workspace cards left.",
+            "toggleLabel": "Toggle larger sidebar sections"
           }
         },
         "FloatingWorkspacePane": {
@@ -6880,6 +6886,10 @@
               "title": "新卡片样式",
               "worktree": "worktree",
               "worktrees": "worktrees"
+            },
+            "largerSidebarSections": {
+              "title": "Larger sidebar sections",
+              "description": "Preview larger project and section headers in the worktree sidebar, including repo icons."
             }
           }
         },

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -377,7 +377,7 @@ describe('web settings preload API', () => {
     expect(runtimeCalls).toEqual([{ method: 'settings.get', params: undefined }])
   }, 15_000)
 
-  it('hydrates new worktree card style from a paired runtime', async () => {
+  it('hydrates sidebar appearance experimental settings from a paired runtime', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {
@@ -386,7 +386,12 @@ describe('web settings preload API', () => {
           return Promise.resolve({
             id: `call-${runtimeCalls.length}`,
             ok: true,
-            result: { settings: { experimentalNewWorktreeCardStyle: true } },
+            result: {
+              settings: {
+                experimentalNewWorktreeCardStyle: true,
+                experimentalLargerSidebarSections: true
+              }
+            },
             _meta: { runtimeId: 'runtime-1' }
           })
         }
@@ -403,10 +408,13 @@ describe('web settings preload API', () => {
     const settings = await globals.window.api.settings.get()
     const stored = JSON.parse(globals.storage.getItem('orca.web.settings.v1') ?? '{}') as {
       experimentalNewWorktreeCardStyle?: boolean
+      experimentalLargerSidebarSections?: boolean
     }
 
     expect(settings.experimentalNewWorktreeCardStyle).toBe(true)
+    expect(settings.experimentalLargerSidebarSections).toBe(true)
     expect(stored.experimentalNewWorktreeCardStyle).toBe(true)
+    expect(stored.experimentalLargerSidebarSections).toBe(true)
     expect(runtimeCalls).toEqual([{ method: 'settings.get', params: undefined }])
   })
 
@@ -446,7 +454,7 @@ describe('web settings preload API', () => {
     ])
   }, 15_000)
 
-  it('forwards new worktree card style updates to a paired runtime', async () => {
+  it('forwards sidebar appearance experimental updates to a paired runtime', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {
@@ -455,7 +463,12 @@ describe('web settings preload API', () => {
           return Promise.resolve({
             id: `call-${runtimeCalls.length}`,
             ok: true,
-            result: { settings: { experimentalNewWorktreeCardStyle: true } },
+            result: {
+              settings: {
+                experimentalNewWorktreeCardStyle: true,
+                experimentalLargerSidebarSections: true
+              }
+            },
             _meta: { runtimeId: 'runtime-1' }
           })
         }
@@ -470,12 +483,20 @@ describe('web settings preload API', () => {
     installWebPreloadApi()
 
     const settings = await globals.window.api.settings.set({
-      experimentalNewWorktreeCardStyle: true
+      experimentalNewWorktreeCardStyle: true,
+      experimentalLargerSidebarSections: true
     })
 
     expect(settings.experimentalNewWorktreeCardStyle).toBe(true)
+    expect(settings.experimentalLargerSidebarSections).toBe(true)
     expect(runtimeCalls).toEqual([
-      { method: 'settings.update', params: { experimentalNewWorktreeCardStyle: true } }
+      {
+        method: 'settings.update',
+        params: {
+          experimentalNewWorktreeCardStyle: true,
+          experimentalLargerSidebarSections: true
+        }
+      }
     ])
   })
 })

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2695,6 +2695,10 @@ async function getRuntimeBackedStoredSettings(): Promise<GlobalSettings> {
     if (typeof result.settings.compactWorktreeCards === 'boolean') {
       runtimeSettings.compactWorktreeCards = result.settings.compactWorktreeCards
     }
+    if (typeof result.settings.experimentalLargerSidebarSections === 'boolean') {
+      runtimeSettings.experimentalLargerSidebarSections =
+        result.settings.experimentalLargerSidebarSections
+    }
     const next = mergeSettings(local, runtimeSettings)
     writeJson(SETTINGS_STORAGE_KEY, next)
     return next
@@ -2717,6 +2721,9 @@ async function syncRuntimeBackedSettings(
   }
   if (typeof updates.compactWorktreeCards === 'boolean') {
     runtimeUpdates.compactWorktreeCards = updates.compactWorktreeCards
+  }
+  if (typeof updates.experimentalLargerSidebarSections === 'boolean') {
+    runtimeUpdates.experimentalLargerSidebarSections = updates.experimentalLargerSidebarSections
   }
   if (Object.keys(runtimeUpdates).length === 0) {
     return localNext

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -341,6 +341,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     experimentalAgentHibernation: false,
     agentHibernationIdleMs: 30 * 60 * 1000,
     experimentalNewWorktreeCardStyle: false,
+    experimentalLargerSidebarSections: false,
     compactWorktreeCards: false,
     experimentalWorktreeSymlinks: false,
     // Why: local desktop remains the default server until the user explicitly

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -296,6 +296,7 @@ export const SETTINGS_CHANGED_WHITELIST = [
   'experimentalTerminalAttention',
   'experimentalAgentHibernation',
   'experimentalWorktreeSymlinks',
+  'experimentalLargerSidebarSections',
   'geminiCliOAuthEnabled'
 ] as const satisfies readonly BooleanGlobalSettingsKey[]
 export const settingsChangedKeySchema = z.enum(SETTINGS_CHANGED_WHITELIST)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2710,6 +2710,8 @@ export type GlobalSettings = {
   agentHibernationIdleMs?: number
   /** Experimental: opt-in preview of the updated worktree-card layout and metadata behavior. */
   experimentalNewWorktreeCardStyle?: boolean
+  /** Experimental: larger project/section headers in the worktree sidebar. */
+  experimentalLargerSidebarSections?: boolean
   /** Compact worktree cards by hiding a redundant metadata row when the title
    *  and branch already say the same thing. */
   compactWorktreeCards: boolean


### PR DESCRIPTION
## Summary

Adds an experimental setting `experimentalLargerSidebarSections` ("Larger sidebar sections") to the settings pane. Toggling this increases typography size, repository icons, and section header heights in the worktree sidebar, while slightly pulling grouped workspace cards to the left.

## Screenshots

- (TODO: Add screenshots of the larger sidebar sections layout compared to the default layout)

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Unit tests were added/updated to verify style property resolution, runtime settings projection, indentation calculations, and list scroll-measure adjustments.

## AI Review Report

Verified that the feature is fully encapsulated behind runtime settings checks (`experimentalLargerSidebarSections`), ensuring no unexpected behavior on default installs. The changes only affect styling and layout sizing (padding, heights) in the renderer, which are cross-platform by design (supported seamlessly on macOS, Linux, and Windows) and touch no platform-specific APIs, keyboard shortcuts, or filesystem paths.

## Security Audit

No security vulnerabilities identified. The IPC boundaries (via RPC schemas in `client-ui.ts`) were safely updated to support the optional boolean parameter `experimentalLargerSidebarSections`, preventing any invalid payload structures. No file path traversal, command execution, or authorization logic is touched.

## Notes

None. Layout scales cleanly on macOS, Linux, and Windows.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5771">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->