### PR TITLE
Use platform Orca CLI command for Agent Teams

### DIFF
--- a/src/main/runtime/claude-agent-teams-shim-env.ts
+++ b/src/main/runtime/claude-agent-teams-shim-env.ts
@@ -8,6 +8,7 @@ import {
   isDirectClaudeCommand,
   type ClaudeAgentTeamsMode
 } from '../../shared/claude-agent-teams-tmux-compat'
+import { getOrcaCliCommandNameForPlatform } from '../../shared/orca-cli-command-name'
 
 export type ClaudeAgentTeamsLaunchPlan = {
   command: string
@@ -62,8 +63,8 @@ export function resolveClaudeAgentTeamsShimBin(
   }
   return (
     findExecutableOnPath(process.platform === 'win32' ? 'orca-dev.cmd' : 'orca-dev', env.PATH) ??
-    findExecutableOnPath(platformCliCommandName(), env.PATH) ??
-    platformCliCommandName()
+    findExecutableOnPath(getOrcaCliCommandNameForPlatform(process.platform), env.PATH) ??
+    getOrcaCliCommandNameForPlatform(process.platform)
   )
 }
 
@@ -85,16 +86,6 @@ function bundledLauncherPath(): string | null {
     return join(process.resourcesPath, 'bin', 'orca.cmd')
   }
   return null
-}
-
-function platformCliCommandName(): string {
-  if (process.platform === 'linux') {
-    return 'orca-ide'
-  }
-  if (process.platform === 'win32') {
-    return 'orca.cmd'
-  }
-  return 'orca'
 }
 
 function findExecutableOnPath(command: string, pathValue: string | undefined): string | null {
@@ -126,7 +117,7 @@ function unixShimScript(): string {
   return [
     '#!/usr/bin/env sh',
     'set -eu',
-    'exec "${ORCA_AGENT_TEAMS_SHIM_BIN:-orca}" agent-teams-tmux "$@"',
+    `exec "\${ORCA_AGENT_TEAMS_SHIM_BIN:-${getOrcaCliCommandNameForPlatform(process.platform)}}" agent-teams-tmux "$@"`,
     ''
   ].join('\n')
 }
@@ -136,7 +127,7 @@ function windowsShimScript(): string {
     '@echo off',
     'setlocal',
     'if "%ORCA_AGENT_TEAMS_SHIM_BIN%"=="" (',
-    '  set "ORCA_AGENT_TEAMS_SHIM_BIN=orca"',
+    `  set "ORCA_AGENT_TEAMS_SHIM_BIN=${getOrcaCliCommandNameForPlatform(process.platform)}"`,
     ')',
     '"%ORCA_AGENT_TEAMS_SHIM_BIN%" agent-teams-tmux %*',
     ''

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -2,6 +2,7 @@ import type React from 'react'
 import { ClaudeIcon, DroidIcon, OpenAIIcon } from '@/components/status-bar/icons'
 import openClaudeLogoUrl from '../../../../resources/openclaude-logo.png?url'
 import type { TuiAgent } from '../../../shared/types'
+import { getTuiAgentLaunchCommand, TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import {
   AgentLetterIcon,
   AiderIcon,
@@ -26,6 +27,20 @@ export type AgentCatalogEntry = {
   homepageUrl: string
 }
 
+function getCatalogPlatform(): NodeJS.Platform {
+  const userAgent = typeof navigator === 'undefined' ? '' : navigator.userAgent
+  if (userAgent.includes('Windows')) {
+    return 'win32'
+  }
+  if (userAgent.includes('Mac')) {
+    return 'darwin'
+  }
+  if (userAgent) {
+    return 'linux'
+  }
+  return typeof process === 'undefined' ? 'linux' : process.platform
+}
+
 export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] => [
   {
     id: 'claude',
@@ -36,7 +51,7 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
   {
     id: 'claude-agent-teams',
     label: translate('auto.lib.agent.catalog.bf53f09bf8', 'Claude Agent Teams'),
-    cmd: 'orca claude-teams',
+    cmd: getTuiAgentLaunchCommand(TUI_AGENT_CONFIG['claude-agent-teams'], getCatalogPlatform()),
     homepageUrl: 'https://code.claude.com/docs/agent-teams'
   },
   {

--- a/src/shared/orca-cli-command-name.ts
+++ b/src/shared/orca-cli-command-name.ts
@@ -1,0 +1,9 @@
+export function getOrcaCliCommandNameForPlatform(platform: NodeJS.Platform): string {
+  if (platform === 'linux') {
+    return 'orca-ide'
+  }
+  if (platform === 'win32') {
+    return 'orca.cmd'
+  }
+  return 'orca'
+}

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -1,4 +1,5 @@
 import type { TuiAgent } from './types'
+import { getOrcaCliCommandNameForPlatform } from './orca-cli-command-name'
 
 export type AgentPromptInjectionMode =
   | 'argv'
@@ -14,6 +15,8 @@ export type TuiAgentConfig = {
   /** Additional executable names that identify the same agent on PATH. */
   detectCmdAliases?: readonly string[]
   launchCmd: string
+  /** Platform-specific launch command when the public binary name differs. */
+  launchCmdByPlatform?: Partial<Record<NodeJS.Platform, string>>
   expectedProcess: string
   promptInjectionMode: AgentPromptInjectionMode
   /** Why: flag that launches the TUI with the given text already in the
@@ -70,6 +73,10 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     detectCmd: 'orca',
     detectCmdAliases: ['orca-dev', 'orca-ide'],
     launchCmd: 'orca claude-teams',
+    launchCmdByPlatform: {
+      linux: `${getOrcaCliCommandNameForPlatform('linux')} claude-teams`,
+      win32: `${getOrcaCliCommandNameForPlatform('win32')} claude-teams`
+    },
     expectedProcess: 'claude',
     promptInjectionMode: 'stdin-after-start'
   },
@@ -329,4 +336,11 @@ export function isTuiAgent(value: unknown): value is TuiAgent {
 
 export function getTuiAgentDetectCommands(config: TuiAgentConfig): string[] {
   return [config.detectCmd, ...(config.detectCmdAliases ?? [])]
+}
+
+export function getTuiAgentLaunchCommand(
+  config: TuiAgentConfig,
+  platform: NodeJS.Platform
+): string {
+  return config.launchCmdByPlatform?.[platform] ?? config.launchCmd
 }

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -89,6 +89,18 @@ describe('tui agent startup plans', () => {
     expect(plan?.launchCommand).not.toContain('--settings')
   })
 
+  it('uses the Linux Orca CLI command for Claude Agent Teams launches', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'claude-agent-teams',
+      prompt: '',
+      cmdOverrides: {},
+      platform: 'linux',
+      allowEmptyPromptLaunch: true
+    })
+
+    expect(plan?.launchCommand).toBe('orca-ide claude-teams')
+  })
+
   it('launches OpenClaude as a distinct argv agent', () => {
     const plan = buildAgentStartupPlan({
       agent: 'openclaude',

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -5,7 +5,7 @@ import {
   type ResumableTuiAgent
 } from './agent-session-resume'
 import { tokenizeCustomCommandTemplate } from './commit-message-prompt'
-import { TUI_AGENT_CONFIG } from './tui-agent-config'
+import { getTuiAgentLaunchCommand, TUI_AGENT_CONFIG } from './tui-agent-config'
 import type { StartupCommandDelivery } from './codex-startup-delivery'
 import type { TuiAgent } from './types'
 
@@ -88,11 +88,12 @@ export function planAgentCliArgsSuffix(
 function resolveBaseCommand(args: {
   agent: TuiAgent
   cmdOverrides: Partial<Record<TuiAgent, string>>
+  platform: NodeJS.Platform
   shell: AgentStartupShell
   agentArgs?: string | null
 }): { ok: true; command: string } | { ok: false; error: string } {
   const override = args.cmdOverrides[args.agent]
-  const command = override || TUI_AGENT_CONFIG[args.agent].launchCmd
+  const command = override || getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[args.agent], args.platform)
   const suffix = planAgentCliArgsSuffix(args.agentArgs, args.shell)
   if (!suffix.ok) {
     return suffix
@@ -119,6 +120,7 @@ export function buildAgentStartupPlan(args: {
   const baseCommand = resolveBaseCommand({
     agent,
     cmdOverrides,
+    platform,
     shell,
     agentArgs: args.agentArgs
   })
@@ -209,6 +211,7 @@ export function buildAgentResumeStartupPlan(args: {
   const baseCommand = resolveBaseCommand({
     agent: args.agent,
     cmdOverrides: args.cmdOverrides,
+    platform: args.platform,
     shell,
     agentArgs: args.agentArgs
   })
@@ -272,6 +275,7 @@ export function buildAgentDraftLaunchPlan(args: {
   const baseCommand = resolveBaseCommand({
     agent,
     cmdOverrides,
+    platform,
     shell,
     agentArgs: args.agentArgs
   })


### PR DESCRIPTION
## Summary
- Resolve Orca's CLI command name from the target launch platform for Claude Agent Teams
- Launch `orca-ide claude-teams` on Linux instead of hardcoding `orca claude-teams`
- Keep the Agent Teams shim fallback and catalog command display aligned with the same platform command-name helper

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/tui-agent-startup.test.ts src/main/runtime/claude-agent-teams-shim-env.test.ts src/main/cli/cli-installer.test.ts src/main/cli/packaged-cli-assets.test.ts src/renderer/src/lib/agent-picker-search.test.ts`
- `pnpm exec oxlint src/shared/orca-cli-command-name.ts src/shared/tui-agent-config.ts src/shared/tui-agent-startup.ts src/shared/tui-agent-startup.test.ts src/renderer/src/lib/agent-catalog.tsx src/main/runtime/claude-agent-teams-shim-env.ts src/main/index.ts`
- `git diff --check`
- `pnpm run typecheck:node`
- `pnpm run typecheck:cli`
- `pnpm run typecheck:web`

Fixes #5763

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5773">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->