### PR TITLE
Show host context in projects pane

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
@@ -527,4 +527,43 @@ describe('WorktreeCard compact hover details', () => {
     expect(markup).toContain('data-worktree-card-meta-row=""')
     expect(markup).toContain('feature/local-branch')
   })
+
+  it('shows host context in the detailed metadata row with accessible text', async () => {
+    settings = { compactWorktreeCards: false }
+    worktreeCardProperties = ['status']
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree()}
+        repo={makeRepo()}
+        isActive={false}
+        hideRepoBadge
+        hostContextLabel="gpu-vm"
+        hostContextDescription="SSH host: gpu-vm"
+      />
+    )
+
+    expect(markup).toContain('data-worktree-card-meta-row=""')
+    expect(markup).toContain('aria-label="SSH host: gpu-vm"')
+    expect(markup).toContain('gpu-vm')
+  })
+
+  it('does not duplicate host context on compact cards', async () => {
+    settings = { compactWorktreeCards: true }
+    worktreeCardProperties = ['status']
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree()}
+        repo={makeRepo()}
+        isActive={false}
+        hostContextLabel="gpu-vm"
+        hostContextDescription="SSH host: gpu-vm"
+      />
+    )
+
+    expect(markup).not.toContain('SSH host: gpu-vm')
+  })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -88,6 +88,7 @@ type WorktreeCardProps = {
   selectedWorktrees?: readonly Worktree[]
   hideRepoBadge?: boolean
   hostContextLabel?: string
+  hostContextDescription?: string
   inPinnedSection?: boolean
   activationRowKey?: string
   renameRowKey?: string
@@ -192,6 +193,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   nativeDragEnabled = true,
   hideRepoBadge,
   hostContextLabel,
+  hostContextDescription,
   inPinnedSection = false,
   activationRowKey,
   renameRowKey,
@@ -1495,12 +1497,21 @@ const WorktreeCard = React.memo(function WorktreeCard({
               )}
 
               {showHostContextBadge && (
-                <Badge
-                  variant="secondary"
-                  className="h-[16px] max-w-[7rem] shrink-0 rounded border border-border bg-accent px-1.5 text-[10px] font-medium leading-none text-muted-foreground dark:bg-accent/80 dark:border-border/50"
-                >
-                  <span className="truncate">{hostContextLabel}</span>
-                </Badge>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge
+                      variant="secondary"
+                      className="h-[16px] max-w-[7rem] shrink-0 rounded border border-border bg-accent px-1.5 text-[10px] font-medium leading-none text-muted-foreground dark:bg-accent/80 dark:border-border/50"
+                      aria-label={hostContextDescription ?? hostContextLabel}
+                    >
+                      <Server className="size-2.5 shrink-0" />
+                      <span className="truncate">{hostContextLabel}</span>
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    {hostContextDescription ?? hostContextLabel}
+                  </TooltipContent>
+                </Tooltip>
               )}
 
               {isFolder ? (

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -549,6 +549,36 @@ function SectionMetricsBadge({ count }: { count: number }): React.JSX.Element {
   )
 }
 
+function HostContextBadge({
+  label,
+  description
+}: {
+  label: string | undefined
+  description: string | undefined
+}): React.JSX.Element | null {
+  if (!label) {
+    return null
+  }
+  const accessibleLabel = description ?? label
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          data-host-context-badge=""
+          className="inline-flex h-4 max-w-[7.5rem] shrink-0 items-center gap-1 overflow-hidden rounded border border-worktree-sidebar-border bg-worktree-sidebar-accent/60 px-1.5 text-[10px] font-medium leading-none text-muted-foreground"
+          aria-label={accessibleLabel}
+        >
+          <Server className="size-2.5 shrink-0" />
+          <span className="truncate">{label}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {accessibleLabel}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
 function HostHeaderHealthIcon({
   health
 }: {
@@ -3598,6 +3628,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         <div className="min-w-0 truncate text-[13px] font-semibold leading-none">
                           {row.label}
                         </div>
+                        <HostContextBadge
+                          label={row.hostContextLabel}
+                          description={row.hostContextDescription}
+                        />
                         <RepoForkIndicator upstream={row.repo?.upstream} />
                         <FolderPathStatusIndicator status={projectGroupPathStatus} />
                       </div>
@@ -4074,6 +4108,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     // Why: pinned worktrees also render in their natural group;
                     // only the overlay row is the mixed-repo section needing icons.
                     hostContextLabel={itemRow.hostContextLabel}
+                    hostContextDescription={itemRow.hostContextDescription}
                     inPinnedSection={isPinnedOverlayRow}
                     renameRowKey={itemRow.rowKey}
                     lineageChildCount={itemRow.lineageChildCount}
@@ -4277,6 +4312,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       activationRowKey={folderWorktree.id}
                       onSelectionGesture={onSelectionGesture}
                       onContextMenuSelect={onContextMenuSelect}
+                      hostContextLabel={folderWorkspaceRow.hostContextLabel}
+                      hostContextDescription={folderWorkspaceRow.hostContextDescription}
                     />
                     <div className="pointer-events-auto absolute right-3 top-1.5">
                       <FolderPathStatusIndicator status={folderWorkspacePathStatus} />

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -355,7 +355,14 @@ describe('buildRows with pinned worktrees', () => {
     )
 
     expect(rows).toMatchObject([
-      { type: 'header', key: 'project:github:stablyai/orca', label: 'Orca', count: 2 },
+      {
+        type: 'header',
+        key: 'project:github:stablyai/orca',
+        label: 'Orca',
+        count: 2,
+        hostContextLabel: 'Multiple hosts',
+        hostContextDescription: `Multiple hosts: ${LOCAL_HOST_LABEL}, gpu-vm`
+      },
       { type: 'item', worktree: { id: worktree.id }, hostContextLabel: LOCAL_HOST_LABEL },
       { type: 'item', worktree: { id: remoteWorktree.id }, hostContextLabel: 'gpu-vm' }
     ])
@@ -477,13 +484,20 @@ describe('buildRows with pinned worktrees', () => {
     )
 
     expect(rows).toMatchObject([
-      { type: 'header', key: 'project:github:stablyai/orca', label: 'Orca', count: 2 },
+      {
+        type: 'header',
+        key: 'project:github:stablyai/orca',
+        label: 'Orca',
+        count: 2,
+        hostContextLabel: 'Multiple hosts',
+        hostContextDescription: `Multiple hosts: ${LOCAL_HOST_LABEL}, dev box`
+      },
       { type: 'item', worktree: { id: worktree.id }, hostContextLabel: LOCAL_HOST_LABEL },
       { type: 'item', worktree: { id: runtimeWorktree.id }, hostContextLabel: 'dev box' }
     ])
   })
 
-  it('omits host context labels when a project group only has one host', () => {
+  it('omits host context labels for local-only projects without other hosts', () => {
     const secondLocalWorktree: Worktree = {
       ...worktree,
       id: 'wt-local-2',
@@ -525,6 +539,84 @@ describe('buildRows with pinned worktrees', () => {
         expect(row.hostContextLabel).toBeUndefined()
       }
     }
+  })
+
+  it('shows the local host label when another host exists in sidebar context', () => {
+    const rows = buildRows(
+      'repo',
+      [worktree],
+      new Map([[repo.id, repo]]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([[worktree.id, worktree]]),
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      [],
+      {
+        projects: [{ ...project, sourceRepoIds: [repo.id] }],
+        projectHostSetups: [projectHostSetups[0]]
+      },
+      [],
+      new Map([
+        ['local', LOCAL_HOST_LABEL],
+        ['ssh:gpu-vm', 'gpu-vm']
+      ])
+    )
+
+    expect(rows[0]).toMatchObject({
+      type: 'header',
+      key: 'project:github:stablyai/orca',
+      hostContextLabel: LOCAL_HOST_LABEL,
+      hostContextDescription: `Local: ${LOCAL_HOST_LABEL}`
+    })
+  })
+
+  it('shows host context for remote-only projects', () => {
+    const rows = buildRows(
+      'repo',
+      [remoteWorktree],
+      new Map([[remoteRepo.id, remoteRepo]]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([[remoteWorktree.id, remoteWorktree]]),
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      [],
+      {
+        projects: [{ ...project, sourceRepoIds: [remoteRepo.id] }],
+        projectHostSetups: [projectHostSetups[1]!]
+      },
+      [],
+      new Map([
+        ['local', LOCAL_HOST_LABEL],
+        ['ssh:gpu-vm', 'gpu-vm']
+      ])
+    )
+
+    expect(rows).toMatchObject([
+      {
+        type: 'header',
+        key: 'project:github:stablyai/orca',
+        label: 'Orca',
+        hostContextLabel: 'gpu-vm',
+        hostContextDescription: 'SSH host: gpu-vm'
+      },
+      { type: 'item', worktree: { id: remoteWorktree.id } }
+    ])
   })
 
   it('keeps same-named repos separate without project setup identity', () => {
@@ -1690,6 +1782,77 @@ describe('project groups', () => {
         folderWorkspace: { id: 'folder-workspace-1' },
         projectGroup: { id: 'group-root' },
         groupDepth: 1
+      }
+    ])
+  })
+
+  it('shows host context for remote folder-backed Project Groups and folder workspaces', () => {
+    const group: ProjectGroup = {
+      id: 'group-root',
+      name: 'Platform',
+      parentPath: '/monorepo',
+      connectionId: 'gpu-vm',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const folderWorkspace: FolderWorkspace = {
+      id: 'folder-workspace-remote',
+      projectGroupId: group.id,
+      name: 'Remote folder work',
+      folderPath: '/monorepo',
+      linkedTask: null,
+      comment: '',
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 10,
+      lastActivityAt: 0,
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    const rows = buildRows(
+      'repo',
+      [],
+      new Map(),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      undefined,
+      [group],
+      new Set(),
+      new Map(),
+      [],
+      undefined,
+      [folderWorkspace],
+      new Map([
+        ['local', LOCAL_HOST_LABEL],
+        ['ssh:gpu-vm', 'gpu-vm']
+      ])
+    )
+
+    expect(rows).toMatchObject([
+      {
+        type: 'header',
+        key: 'project-group:group-root',
+        hostContextLabel: 'gpu-vm',
+        hostContextDescription: 'SSH host: gpu-vm'
+      },
+      {
+        type: 'folder-workspace',
+        folderWorkspace: { id: 'folder-workspace-remote' },
+        hostContextLabel: 'gpu-vm',
+        hostContextDescription: 'SSH host: gpu-vm'
       }
     ])
   })

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -31,7 +31,15 @@ import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from '../../store/slic
 import { UNGROUPED_PROJECT_GROUP_KEY } from '../../../../shared/project-groups'
 import { getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
 import { translate } from '@/i18n/i18n'
-import { getExecutionHostLabel, getRepoExecutionHostId } from '../../../../shared/execution-host'
+import {
+  getExecutionHostLabel,
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
+  parseExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
 
 export { branchName }
 
@@ -47,6 +55,8 @@ export type GroupHeaderRow = {
   repo?: Repo
   projectGroup?: ProjectGroup | { id: null; name: 'Ungrouped'; tabOrder: number }
   projectGroupDepth?: number
+  hostContextLabel?: string
+  hostContextDescription?: string
 }
 
 export type WorktreeRow = {
@@ -63,6 +73,7 @@ export type WorktreeRow = {
   lineageGroupKey?: string
   lineageCollapsed?: boolean
   hostContextLabel?: string
+  hostContextDescription?: string
 }
 
 export type ImportedWorktreesCardCandidate = {
@@ -92,6 +103,8 @@ export type FolderWorkspaceRow = {
   projectGroup: ProjectGroup
   depth: number
   groupDepth: number
+  hostContextLabel?: string
+  hostContextDescription?: string
 }
 
 /** Minimal shape buildRows needs for an in-flight create. Deliberately not the
@@ -448,6 +461,7 @@ function buildWorktreeRow(
     lineageChildCount: number
     lineageCollapsed: boolean
     hostContextLabel?: string
+    hostContextDescription?: string
   }
 ): WorktreeRow {
   return {
@@ -462,6 +476,9 @@ function buildWorktreeRow(
     isLastLineageChild: options.isLastLineageChild,
     lineageChildCount: options.lineageChildCount,
     ...(options.hostContextLabel ? { hostContextLabel: options.hostContextLabel } : {}),
+    ...(options.hostContextDescription
+      ? { hostContextDescription: options.hostContextDescription }
+      : {}),
     ...(options.lineageChildCount > 0 ? { lineageGroupKey: getLineageGroupKey(worktree.id) } : {}),
     ...(options.lineageChildCount > 0 ? { lineageCollapsed: options.lineageCollapsed } : {})
   }
@@ -479,9 +496,17 @@ function appendWorktreeRows(
     groupDepth: number
     sectionKey: string
     hostContextLabelByRepoId?: ReadonlyMap<string, string>
+    hostContextDescriptionByRepoId?: ReadonlyMap<string, string>
   }
 ): void {
-  const { nestLineage, collapsedGroups, groupDepth, sectionKey, hostContextLabelByRepoId } = options
+  const {
+    nestLineage,
+    collapsedGroups,
+    groupDepth,
+    sectionKey,
+    hostContextLabelByRepoId,
+    hostContextDescriptionByRepoId
+  } = options
   if (!nestLineage) {
     for (const worktree of worktrees) {
       result.push(
@@ -494,7 +519,8 @@ function appendWorktreeRows(
           isLastLineageChild: false,
           lineageChildCount: 0,
           lineageCollapsed: false,
-          hostContextLabel: hostContextLabelByRepoId?.get(worktree.repoId)
+          hostContextLabel: hostContextLabelByRepoId?.get(worktree.repoId),
+          hostContextDescription: hostContextDescriptionByRepoId?.get(worktree.repoId)
         })
       )
     }
@@ -539,7 +565,8 @@ function appendWorktreeRows(
         isLastLineageChild: isLastChild,
         lineageChildCount: children.length,
         lineageCollapsed,
-        hostContextLabel: hostContextLabelByRepoId?.get(worktree.repoId)
+        hostContextLabel: hostContextLabelByRepoId?.get(worktree.repoId),
+        hostContextDescription: hostContextDescriptionByRepoId?.get(worktree.repoId)
       })
     )
     if (lineageCollapsed) {
@@ -588,6 +615,124 @@ function getRepoHostLabel(
   return hostLabelById?.get(hostId) ?? getExecutionHostLabel(hostId)
 }
 
+function getRepoHostId(
+  repoId: string,
+  repoMap: Map<string, Repo>,
+  projectIndex: ProjectGroupingIndex | null
+): ExecutionHostId | null {
+  const setup = projectIndex?.setupByRepoId.get(repoId)
+  if (setup) {
+    return setup.hostId
+  }
+  const repo = repoMap.get(repoId)
+  return repo ? getRepoExecutionHostId(repo) : null
+}
+
+function getHostKindDescription(hostId: ExecutionHostId): string {
+  const parsed = parseExecutionHostId(hostId)
+  switch (parsed?.kind) {
+    case 'local':
+      return 'Local'
+    case 'ssh':
+      return 'SSH host'
+    case 'runtime':
+      return 'Runtime host'
+    default:
+      return 'Host'
+  }
+}
+
+function hasNonLocalHostContext(hostLabelById: ReadonlyMap<string, string> | undefined): boolean {
+  if (!hostLabelById) {
+    return false
+  }
+  for (const hostId of hostLabelById.keys()) {
+    if (hostId !== LOCAL_EXECUTION_HOST_ID) {
+      return true
+    }
+  }
+  return false
+}
+
+function getHostContext(
+  hostId: ExecutionHostId,
+  hostLabelById: ReadonlyMap<string, string> | undefined
+): { label: string; description: string } {
+  const label = hostLabelById?.get(hostId) ?? getExecutionHostLabel(hostId)
+  return {
+    label,
+    description: `${getHostKindDescription(hostId)}: ${label}`
+  }
+}
+
+function getProjectGroupHostId(projectGroup: ProjectGroup): ExecutionHostId {
+  const executionHostId = normalizeExecutionHostId(projectGroup.executionHostId)
+  if (executionHostId) {
+    return executionHostId
+  }
+  return projectGroup.connectionId
+    ? toSshExecutionHostId(projectGroup.connectionId)
+    : LOCAL_EXECUTION_HOST_ID
+}
+
+function getFolderWorkspaceHostId(
+  folderWorkspace: FolderWorkspace,
+  projectGroup: ProjectGroup
+): ExecutionHostId {
+  const explicitProjectGroupHostId = normalizeExecutionHostId(projectGroup.executionHostId)
+  if (explicitProjectGroupHostId) {
+    return explicitProjectGroupHostId
+  }
+  const projectGroupHostId = getProjectGroupHostId(projectGroup)
+  if (projectGroupHostId !== LOCAL_EXECUTION_HOST_ID || !folderWorkspace.connectionId) {
+    return projectGroupHostId
+  }
+  return toSshExecutionHostId(folderWorkspace.connectionId)
+}
+
+function getSingleHostContext(
+  hostId: ExecutionHostId,
+  hostLabelById: ReadonlyMap<string, string> | undefined
+): { label: string; description: string } | undefined {
+  if (hostId === LOCAL_EXECUTION_HOST_ID && !hasNonLocalHostContext(hostLabelById)) {
+    return undefined
+  }
+  return getHostContext(hostId, hostLabelById)
+}
+
+function getProjectHeaderHostContext(
+  group: WorktreeGroupEntry,
+  repoMap: Map<string, Repo>,
+  projectIndex: ProjectGroupingIndex | null,
+  hostLabelById: ReadonlyMap<string, string> | undefined
+): { label: string; description: string } | undefined {
+  const hostIds = new Set<ExecutionHostId>()
+  for (const repoId of group.repoIds) {
+    const hostId = getRepoHostId(repoId, repoMap, projectIndex)
+    if (hostId) {
+      hostIds.add(hostId)
+    }
+  }
+  if (hostIds.size === 0) {
+    return undefined
+  }
+  if (hostIds.size === 1) {
+    return getSingleHostContext([...hostIds][0]!, hostLabelById)
+  }
+  const labels = [...hostIds].map((hostId) => getHostContext(hostId, hostLabelById).label)
+  return {
+    label: 'Multiple hosts',
+    description: `Multiple hosts: ${labels.join(', ')}`
+  }
+}
+
+function getRowHostContext(
+  hostId: ExecutionHostId,
+  hostLabelById: ReadonlyMap<string, string> | undefined
+): { label: string; description: string } | undefined {
+  return getSingleHostContext(hostId, hostLabelById)
+}
+
 function getMixedHostContextLabels(
   group: WorktreeGroupEntry,
   repoMap: Map<string, Repo>,
@@ -605,6 +750,25 @@ function getMixedHostContextLabels(
     uniqueLabels.add(label)
   }
   return uniqueLabels.size > 1 ? labelsByRepoId : undefined
+}
+
+function getMixedHostContextDescriptions(
+  group: WorktreeGroupEntry,
+  repoMap: Map<string, Repo>,
+  projectIndex: ProjectGroupingIndex | null,
+  hostLabelById: ReadonlyMap<string, string> | undefined
+): Map<string, string> | undefined {
+  const descriptionsByRepoId = new Map<string, string>()
+  const uniqueHostIds = new Set<ExecutionHostId>()
+  for (const repoId of group.repoIds) {
+    const hostId = getRepoHostId(repoId, repoMap, projectIndex)
+    if (!hostId) {
+      continue
+    }
+    uniqueHostIds.add(hostId)
+    descriptionsByRepoId.set(repoId, getHostContext(hostId, hostLabelById).description)
+  }
+  return uniqueHostIds.size > 1 ? descriptionsByRepoId : undefined
 }
 
 function orderMainWorktreeFirst(worktrees: Worktree[]): Worktree[] {
@@ -921,16 +1085,30 @@ export function buildRows(
       const repo = group.repo
       const header =
         groupBy === 'repo'
-          ? {
-              type: 'header' as const,
-              key,
-              label: group.label,
-              count: group.items.length,
-              tone: PROJECT_GROUP_META.tone,
-              icon: PROJECT_GROUP_META.icon,
-              repo,
-              projectGroupDepth
-            }
+          ? (() => {
+              const hostContext = getProjectHeaderHostContext(
+                group,
+                repoMap,
+                projectIndex,
+                hostLabelById
+              )
+              return {
+                type: 'header' as const,
+                key,
+                label: group.label,
+                count: group.items.length,
+                tone: PROJECT_GROUP_META.tone,
+                icon: PROJECT_GROUP_META.icon,
+                repo,
+                projectGroupDepth,
+                ...(hostContext
+                  ? {
+                      hostContextLabel: hostContext.label,
+                      hostContextDescription: hostContext.description
+                    }
+                  : {})
+              }
+            })()
           : groupBy === 'workspace-status'
             ? (() => {
                 const workspaceStatus =
@@ -992,12 +1170,17 @@ export function buildRows(
           groupBy === 'repo'
             ? getMixedHostContextLabels(group, repoMap, projectIndex, hostLabelById)
             : undefined
+        const hostContextDescriptionByRepoId =
+          groupBy === 'repo' && hostContextLabelByRepoId
+            ? getMixedHostContextDescriptions(group, repoMap, projectIndex, hostLabelById)
+            : undefined
         appendWorktreeRows(result, items, repoMap, lineageById, worktreeMap, {
           nestLineage,
           collapsedGroups,
           groupDepth: projectGroupDepth,
           sectionKey: key,
-          hostContextLabelByRepoId
+          hostContextLabelByRepoId,
+          hostContextDescriptionByRepoId
         })
       }
     }
@@ -1096,17 +1279,36 @@ export function buildRows(
       tone: PROJECT_GROUP_META.tone,
       icon: PROJECT_GROUP_META.icon,
       projectGroup,
-      projectGroupDepth: depth
+      projectGroupDepth: depth,
+      ...(() => {
+        const hostContext = getRowHostContext(getProjectGroupHostId(projectGroup), hostLabelById)
+        return hostContext
+          ? {
+              hostContextLabel: hostContext.label,
+              hostContextDescription: hostContext.description
+            }
+          : {}
+      })()
     })
     if (!collapsedGroups.has(key)) {
       for (const folderWorkspace of folderWorkspacesByProjectGroupId.get(projectGroup.id) ?? []) {
+        const hostContext = getRowHostContext(
+          getFolderWorkspaceHostId(folderWorkspace, projectGroup),
+          hostLabelById
+        )
         result.push({
           type: 'folder-workspace',
           key: `folder-workspace:${folderWorkspace.id}`,
           folderWorkspace,
           projectGroup,
           depth: 0,
-          groupDepth: depth + 1
+          groupDepth: depth + 1,
+          ...(hostContext
+            ? {
+                hostContextLabel: hostContext.label,
+                hostContextDescription: hostContext.description
+              }
+            : {})
         })
       }
       appendOrderedGroups(withRepoSectionDisplayLabels(repoEntries), depth + 1)


### PR DESCRIPTION
## Summary

Show host context directly in the Projects pane so users can tell when a project/workspace is local, on SSH, on a runtime host, or spread across multiple hosts.

- Remote-only projects now show their host on the project header.
- Mixed-host projects show `Multiple hosts` on the project header and keep per-workspace host badges for row-level disambiguation.
- Local-only projects stay visually quiet unless another non-local host exists in the sidebar context.
- Folder-backed project groups and folder workspaces now use the same host-context model.

## Screenshots

Screenshot not captured in this headless environment. This is a visual change: it adds a small token-based host badge to project headers and extends the existing worktree host badge tooltip/ARIA text.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Ran:

```bash
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
pnpm run typecheck:web
pnpm exec oxlint src/renderer/src/components/sidebar/worktree-list-groups.ts src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
```

Notes:

- `pnpm install` completed.
- Electron postinstall could not extract the Electron binary because `unzip` is not installed in this environment, so full Electron/UI screenshot validation was not available here.
- An initial `pnpm test -- <files>` attempt forwarded incorrectly and started the full suite; it was stopped after environment-driven failures. The intended targeted Vitest command above passed.

## AI Review Report

Reviewed the change for:

- Cross-platform compatibility: no platform-specific shortcuts, labels, path separators, shell behavior, or Electron platform APIs were introduced.
- SSH/remote/local compatibility: host context now resolves from repo `connectionId` / `executionHostId`, project host setups, project-group host stamps, and folder workspace connections. The UI no longer assumes projects are local when default project grouping suppresses host section headers.
- Runtime host compatibility: runtime `executionHostId` labels are routed through existing host-label overrides and tested.
- Git provider compatibility: no GitHub-only review/source-control behavior was added.
- UI quality: badge styling uses existing sidebar/worktree tokens and lucide icons, with tooltip and `aria-label` text.
- Performance risk: host context is derived while building the existing flat row model; no additional render-time store subscriptions or network calls were added.

The review found one alignment issue for folder workspaces: explicit project-group `executionHostId` needed to win before falling back to folder workspace SSH connection. That was fixed to match the existing host-filtering behavior.

## Security Audit

No new command execution, IPC routes, filesystem access, auth flow, secret handling, or dependency changes were introduced.

Security-relevant checks:

- Host labels are rendered as React text, not raw HTML.
- Tooltip/ARIA text uses derived host labels only and does not expose credentials.
- No new trust boundary is added; data comes from existing repo/project host metadata already present in renderer state.
- No path handling changes beyond reading existing host stamps from project/folder records.

Follow-up needed: none identified.

## Notes

- Branch: `features/projects-pane-host-context`
- X handle: not provided.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

The Projects pane now shows where each project lives: local, SSH, a runtime host, or multiple hosts. Remote-only projects show the host on the header; mixed-host ones say “Multiple hosts.” Local-only projects stay simple unless other hosts are in the sidebar.
