### PR TITLE
Add auto-switch for rate-limited agent accounts

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -4507,6 +4507,10 @@ export class Store {
     if ('minimizeToTrayOnClose' in updates) {
       sanitizedUpdates.minimizeToTrayOnClose = updates.minimizeToTrayOnClose === true
     }
+    if ('autoSwitchRateLimitedAccounts' in updates) {
+      sanitizedUpdates.autoSwitchRateLimitedAccounts =
+        updates.autoSwitchRateLimitedAccounts === true
+    }
     if ('disabledTuiAgents' in updates) {
       sanitizedUpdates.disabledTuiAgents = normalizeDisabledTuiAgents(updates.disabledTuiAgents)
     }

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -21,6 +21,7 @@ import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from '../status-ba
 import { toast } from 'sonner'
 import {
   getAccountsClaudeSearchEntries,
+  getAccountsAutoSwitchSearchEntries,
   getAccountsCodexSearchEntries,
   getAccountsGeminiSearchEntries,
   getAccountsLocationSearchEntries,
@@ -565,6 +566,54 @@ export function AccountsPane({
   }
 
   const visibleSections = [
+    matchesSettingsSearch(searchQuery, getAccountsAutoSwitchSearchEntries()) ? (
+      <section key="auto-switch-limits" id="accounts-auto-switch" className="space-y-3 scroll-mt-6">
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.AccountsPane.b28bb41f63',
+            'Auto-switch Limited Agents'
+          )}
+          description={translate(
+            'auto.components.settings.AccountsPane.7d2634bfa1',
+            'When a live Claude or Codex session hits an account limit, Orca can switch to another managed account and resume the same session.'
+          )}
+          keywords={getAccountsAutoSwitchSearchEntries().flatMap((entry) => [
+            entry.title,
+            entry.description ?? '',
+            ...(entry.keywords ?? [])
+          ])}
+        >
+          <SettingsRow
+            label={translate(
+              'auto.components.settings.AccountsPane.b28bb41f63',
+              'Auto-switch Limited Agents'
+            )}
+            alignTop
+            description={translate(
+              'auto.components.settings.AccountsPane.5d6a7e20ef',
+              'Exits the limited Claude or Codex agent, selects a managed account with available quota, resumes the provider session, then sends continue.'
+            )}
+            control={
+              <Button
+                variant={settings.autoSwitchRateLimitedAccounts ? 'default' : 'outline'}
+                size="sm"
+                onClick={() =>
+                  updateSettings({
+                    autoSwitchRateLimitedAccounts: !settings.autoSwitchRateLimitedAccounts
+                  })
+                }
+                className="w-24 gap-1.5"
+              >
+                <RefreshCw className="size-3" />
+                {settings.autoSwitchRateLimitedAccounts
+                  ? translate('auto.components.settings.AccountsPane.0f9197cfde', 'Enabled')
+                  : translate('auto.components.settings.AccountsPane.a103114594', 'Enable')}
+              </Button>
+            }
+          />
+        </SearchableSetting>
+      </section>
+    ) : null,
     wslSupportedPlatform &&
     matchesSettingsSearch(searchQuery, getAccountsLocationSearchEntries()) ? (
       <section key="account-runtime" id="accounts-runtime" className="space-y-3 scroll-mt-6">

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -22,6 +22,32 @@ export const getAccountsLocationSearchEntries = createLocalizedCatalog(() => [
   }
 ])
 
+export const getAccountsAutoSwitchSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate(
+      'auto.components.settings.accounts.search.0b0fd87891',
+      'Auto-switch Limited Agents'
+    ),
+    description: translate(
+      'auto.components.settings.accounts.search.3d76b94f10',
+      'Resume Claude and Codex sessions on another managed account when the active account hits a limit.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.accounts.search.06662af91e', 'account'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.5b3f18ef4a', 'switch'),
+      ...translateSearchKeyword(
+        'auto.components.settings.accounts.search.e949b08ffb',
+        'rate limit'
+      ),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.c759741d77', 'quota'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.e14049e1a8', 'claude'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.70d1b8def5', 'codex'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.4de7da808a', 'continue'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.0df8d33e19', 'resume')
+    ]
+  }
+])
+
 export const getAccountsClaudeSearchEntries = createLocalizedCatalog(() => [
   {
     title: translate('auto.components.settings.accounts.search.75682e1b62', 'Claude Accounts'),
@@ -173,6 +199,7 @@ export const getAccountsOpencodeSearchEntries = createLocalizedCatalog(() => [
 
 export const getAccountsPaneSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   ...getAccountsLocationSearchEntries(),
+  ...getAccountsAutoSwitchSearchEntries(),
   ...getAccountsClaudeSearchEntries(),
   ...getAccountsCodexSearchEntries(),
   ...getAccountsGeminiSearchEntries(),

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 import type { CSSProperties } from 'react'
 import type { IDisposable } from '@xterm/xterm'
 import { X } from 'lucide-react'
+import { toast } from 'sonner'
 import { useAppStore } from '../../store'
 import { isUnifiedTabPinned } from '@/store/pinned-tab-close-guard'
 import { Button } from '@/components/ui/button'
@@ -109,6 +110,9 @@ import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
 import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-paste-recovery'
 import { restoreTerminalFitToDesktop, restoreTerminalFitsToDesktop } from './terminal-fit-restore'
+import type { AutoSwitchRateLimitAgent } from '../../../../shared/agent-rate-limit-detection'
+import type { AgentProviderSessionMetadata } from '../../../../shared/agent-session-resume'
+import { runAgentRateLimitAutoSwitch } from '@/lib/agent-rate-limit-auto-switch-runner'
 
 // Why: registry lives in a leaf module so the store slice can import it
 // without re-entering the `slice → TerminalPane → store → slice` cycle
@@ -371,6 +375,7 @@ export default function TerminalPane({
   paneTitlesRef.current = paneTitles
   const removedTitleLeafIdsRef = useRef<Set<string>>(new Set())
   const clearedScrollbackLeafIdsRef = useRef<Set<string>>(new Set())
+  const autoSwitchingPaneKeysRef = useRef<Set<string>>(new Set())
   const [renamingPaneId, setRenamingPaneId] = useState<number | null>(null)
   const [renameValue, setRenameValue] = useState('')
   const renameInputRef = useRef<HTMLInputElement>(null)
@@ -591,6 +596,100 @@ export default function TerminalPane({
   const systemPrefersDark = useSystemPrefersDark()
   const dispatchNotification = useNotificationDispatch(worktreeId)
   const setCacheTimerStartedAt = useAppStore((store) => store.setCacheTimerStartedAt)
+
+  const handleAgentRateLimitDetected = useCallback(
+    (event: {
+      paneId: number
+      paneKey: string
+      ptyId: string
+      agent: AutoSwitchRateLimitAgent
+      providerSession: AgentProviderSessionMetadata
+    }): void => {
+      if (autoSwitchingPaneKeysRef.current.has(event.paneKey)) {
+        return
+      }
+      const transport = paneTransportsRef.current.get(event.paneId)
+      if (!transport || transport.getPtyId() !== event.ptyId) {
+        return
+      }
+      if (useAppStore.getState().settings?.autoSwitchRateLimitedAccounts !== true) {
+        return
+      }
+
+      autoSwitchingPaneKeysRef.current.add(event.paneKey)
+      const agentLabel = event.agent === 'claude' ? 'Claude' : 'Codex'
+      toast.info(
+        translate(
+          'auto.components.terminalPane.TerminalPane.34f715e07e',
+          '{{value0}} account limit detected.',
+          { value0: agentLabel }
+        ),
+        {
+          description: translate(
+            'auto.components.terminalPane.TerminalPane.3200325804',
+            'Switching managed accounts and resuming the same session.'
+          )
+        }
+      )
+
+      void runAgentRateLimitAutoSwitch({
+        ptyId: event.ptyId,
+        agent: event.agent,
+        providerSession: event.providerSession,
+        connectionId: getConnectionId(worktreeId) ?? null
+      })
+        .then((result) => {
+          if (result.ok) {
+            toast.success(
+              translate(
+                'auto.components.terminalPane.TerminalPane.e0e6981a0e',
+                '{{value0}} session resumed.',
+                { value0: agentLabel }
+              ),
+              {
+                description: translate(
+                  'auto.components.terminalPane.TerminalPane.f8d8f16aca',
+                  'Switched to {{value0}} and sent continue.',
+                  { value0: result.accountLabel }
+                )
+              }
+            )
+            return
+          }
+          if (result.reason === 'disabled') {
+            return
+          }
+          const toastFn =
+            result.reason === 'no-account' || result.reason === 'ssh' ? toast.info : toast.error
+          toastFn(
+            translate(
+              'auto.components.terminalPane.TerminalPane.816627b20e',
+              '{{value0}} auto-switch skipped.',
+              { value0: agentLabel }
+            ),
+            {
+              description: result.message
+            }
+          )
+        })
+        .catch((error) => {
+          toast.error(
+            translate(
+              'auto.components.terminalPane.TerminalPane.8bb13ef78d',
+              '{{value0}} auto-switch failed.',
+              { value0: agentLabel }
+            ),
+            {
+              description: error instanceof Error ? error.message : String(error)
+            }
+          )
+        })
+        .finally(() => {
+          autoSwitchingPaneKeysRef.current.delete(event.paneKey)
+        })
+    },
+    [paneTransportsRef, worktreeId]
+  )
 
   // Memoized with useCallback so downstream hooks (useTerminalKeyboardShortcuts,
   // useTerminalPaneLifecycle, createExpandCollapseActions) don't tear down and
@@ -949,6 +1048,7 @@ export default function TerminalPane({
     isVisibleRef,
     onPtyExitRef,
     onPtyErrorRef,
+    onAgentRateLimitDetected: handleAgentRateLimitDetected,
     clearTabPtyId,
     consumeSuppressedPtyExit: useAppStore((store) => store.consumeSuppressedPtyExit),
     updateTabTitle,
@@ -1166,6 +1266,7 @@ export default function TerminalPane({
         isVisibleRef,
         onPtyExitRef,
         onPtyErrorRef,
+        onAgentRateLimitDetected: handleAgentRateLimitDetected,
         clearTabPtyId,
         consumeSuppressedPtyExit: useAppStore.getState().consumeSuppressedPtyExit,
         updateTabTitle,
@@ -1192,6 +1293,7 @@ export default function TerminalPane({
       clearTabPtyId,
       cwd,
       dispatchNotification,
+      handleAgentRateLimitDetected,
       markWorktreeUnread,
       markTerminalTabUnread,
       markTerminalPaneUnread,

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -5,6 +5,8 @@ import type { EventProps } from '../../../../shared/telemetry-events'
 import type { TerminalColorSchemeMode } from '../../../../shared/terminal-color-scheme-protocol'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
 import type { TuiAgent } from '../../../../shared/types'
+import type { AutoSwitchRateLimitAgent } from '../../../../shared/agent-rate-limit-detection'
+import type { AgentProviderSessionMetadata } from '../../../../shared/agent-session-resume'
 
 export type PtyConnectionDeps = {
   tabId: string
@@ -35,6 +37,13 @@ export type PtyConnectionDeps = {
   isVisibleRef: React.RefObject<boolean>
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
+  onAgentRateLimitDetected?: (event: {
+    paneId: number
+    paneKey: string
+    ptyId: string
+    agent: AutoSwitchRateLimitAgent
+    providerSession: AgentProviderSessionMetadata
+  }) => void
   clearTabPtyId: (tabId: string, ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   updateTabTitle: (tabId: string, title: string) => void

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -106,6 +106,11 @@ import {
   isResumableTuiAgent,
   normalizeAgentProviderSession
 } from '../../../../shared/agent-session-resume'
+import {
+  detectAgentRateLimitOutput,
+  isAutoSwitchRateLimitAgent,
+  type AgentRateLimitDetectionState
+} from '../../../../shared/agent-rate-limit-detection'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
@@ -838,6 +843,9 @@ export function connectPanePty(
   // Use the stable layout leaf UUID, not the renderer-local numeric pane id.
   const cacheKey = makePaneKey(deps.tabId, pane.leafId)
   const pendingSpawnKey = cacheKey
+  const rateLimitDetectionState: AgentRateLimitDetectionState = { tail: '' }
+  let lastRateLimitDetectionKey: string | null = null
+  let rateLimitDetectionPtyId: string | null = null
   const neutralTerminalTitle = (): string => {
     const state = useAppStore.getState()
     const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find(
@@ -3035,6 +3043,39 @@ export function connectPanePty(
         data = scanned.output
       }
       resetHiddenOutputRestoreIfPtyChanged()
+      const currentPtyId = transport.getPtyId()
+      if (currentPtyId !== rateLimitDetectionPtyId) {
+        // Why: pane bindings can swap PTYs; stale split output must not trigger a new session.
+        rateLimitDetectionPtyId = currentPtyId
+        rateLimitDetectionState.tail = ''
+        lastRateLimitDetectionKey = null
+      }
+      if (
+        currentPtyId &&
+        deps.onAgentRateLimitDetected &&
+        useAppStore.getState().settings?.autoSwitchRateLimitedAccounts === true
+      ) {
+        const entry = useAppStore.getState().agentStatusByPaneKey[cacheKey]
+        const agent = entry?.agentType
+        const providerSession = normalizeAgentProviderSession(entry?.providerSession)
+        if (
+          isAutoSwitchRateLimitAgent(agent) &&
+          providerSession &&
+          detectAgentRateLimitOutput(agent, data, rateLimitDetectionState)
+        ) {
+          const detectionKey = `${currentPtyId}:${agent}:${providerSession.key}:${providerSession.id}`
+          if (lastRateLimitDetectionKey !== detectionKey) {
+            lastRateLimitDetectionKey = detectionKey
+            deps.onAgentRateLimitDetected({
+              paneId: pane.id,
+              paneKey: cacheKey,
+              ptyId: currentPtyId,
+              agent,
+              providerSession
+            })
+          }
+        }
+      }
       respondToTerminalPixelSizeQueries(data)
       observeTerminalBracketedPasteModeOutput(pane.terminal, data)
       for (const link of observeTerminalGitHubPRLink(data)) {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -29,6 +29,8 @@ import type {
 import type { TerminalPaneSplitSource } from '../../../../shared/feature-education-telemetry'
 import type { EventProps } from '../../../../shared/telemetry-events'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
+import type { AutoSwitchRateLimitAgent } from '../../../../shared/agent-rate-limit-detection'
+import type { AgentProviderSessionMetadata } from '../../../../shared/agent-session-resume'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import {
   buildFontFamily,
@@ -171,6 +173,13 @@ type UseTerminalPaneLifecycleDeps = {
   isVisibleRef: React.RefObject<boolean>
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
+  onAgentRateLimitDetected?: (event: {
+    paneId: number
+    paneKey: string
+    ptyId: string
+    agent: AutoSwitchRateLimitAgent
+    providerSession: AgentProviderSessionMetadata
+  }) => void
   clearTabPtyId: (tabId: string, ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   updateTabTitle: (tabId: string, title: string) => void
@@ -354,6 +363,7 @@ export function useTerminalPaneLifecycle({
   isVisibleRef,
   onPtyExitRef,
   onPtyErrorRef,
+  onAgentRateLimitDetected,
   clearTabPtyId,
   consumeSuppressedPtyExit,
   updateTabTitle,
@@ -541,6 +551,7 @@ export function useTerminalPaneLifecycle({
       isVisibleRef,
       onPtyExitRef,
       onPtyErrorRef,
+      onAgentRateLimitDetected,
       clearTabPtyId,
       consumeSuppressedPtyExit,
       updateTabTitle,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -508,6 +508,18 @@
         "distroRequired": "Select a WSL distro for this project before installing this skill.",
         "distroMissing": "The selected WSL distro is unavailable. Choose an available distro or switch this project to Windows.",
         "wslDefault": "WSL default"
+      },
+      "agentRateLimitAutoSwitchRunner": {
+        "07ff1f8806": "Auto-switch is disabled.",
+        "7e5d87791a": "Auto-switch is not available for SSH terminals because account auth lives on the remote host.",
+        "d823b157d5": "No managed {{value0}} account with available quota was found.",
+        "79751c2c2d": "Could not build a resume command for the limited agent session.",
+        "13668a6034": "The limited agent did not exit after Ctrl+C, so Orca left the terminal untouched.",
+        "9553d26436": "The terminal did not accept the resume command after switching accounts.",
+        "13ccffb514": "The resumed agent did not take over the terminal in time.",
+        "65d1f14b75": "The resumed agent did not accept the continue command.",
+        "65e8e278a4": "Could not inspect managed accounts: {{value0}}",
+        "a939f58b30": "Could not resolve the resume platform: {{value0}}"
       }
     },
     "hooks": {
@@ -4305,7 +4317,12 @@
           "75ca9b718e": "Codex reported that the active account needs a fresh sign-in. Re-authenticate it before starting new Codex sessions.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "Use your current {{value0}} Claude login."
+          "e05d0ff737": "Use your current {{value0}} Claude login.",
+          "b28bb41f63": "Auto-switch Limited Agents",
+          "7d2634bfa1": "When a live Claude or Codex session hits an account limit, Orca can switch to another managed account and resume the same session.",
+          "5d6a7e20ef": "Exits the limited Claude or Codex agent, selects a managed account with available quota, resumes the provider session, then sends continue.",
+          "0f9197cfde": "Enabled",
+          "a103114594": "Enable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",
@@ -6391,7 +6408,9 @@
             "bdbd1e668e": "windows",
             "593720c17f": "location",
             "b84a5b0c8a": "Choose whether provider accounts are inspected and added on this device or in WSL.",
-            "d09fb5ca92": "Account Location"
+            "d09fb5ca92": "Account Location",
+            "0b0fd87891": "Auto-switch Limited Agents",
+            "3d76b94f10": "Resume Claude and Codex sessions on another managed account when the active account hits a limit."
           }
         },
         "advanced": {
@@ -11533,6 +11552,16 @@
             "dismiss": "Dismiss",
             "later": "Later"
           }
+        }
+      },
+      "terminalPane": {
+        "TerminalPane": {
+          "3200325804": "Switching managed accounts and resuming the same session.",
+          "34f715e07e": "{{value0}} account limit detected.",
+          "e0e6981a0e": "{{value0}} session resumed.",
+          "f8d8f16aca": "Switched to {{value0}} and sent continue.",
+          "816627b20e": "{{value0}} auto-switch skipped.",
+          "8bb13ef78d": "{{value0}} auto-switch failed."
         }
       }
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -508,6 +508,18 @@
         "distroRequired": "Select a WSL distro for this project before installing this skill.",
         "distroMissing": "The selected WSL distro is unavailable. Choose an available distro or switch this project to Windows.",
         "wslDefault": "WSL default"
+      },
+      "agentRateLimitAutoSwitchRunner": {
+        "07ff1f8806": "Auto-switch is disabled.",
+        "7e5d87791a": "Auto-switch is not available for SSH terminals because account auth lives on the remote host.",
+        "d823b157d5": "No managed {{value0}} account with available quota was found.",
+        "79751c2c2d": "Could not build a resume command for the limited agent session.",
+        "13668a6034": "The limited agent did not exit after Ctrl+C, so Orca left the terminal untouched.",
+        "9553d26436": "The terminal did not accept the resume command after switching accounts.",
+        "13ccffb514": "The resumed agent did not take over the terminal in time.",
+        "65d1f14b75": "The resumed agent did not accept the continue command.",
+        "65e8e278a4": "Could not inspect managed accounts: {{value0}}",
+        "a939f58b30": "Could not resolve the resume platform: {{value0}}"
       }
     },
     "hooks": {
@@ -4305,7 +4317,12 @@
           "75ca9b718e": "Codex informó que la cuenta activa necesita un nuevo inicio de sesión. Vuelva a autenticarlo antes de iniciar nuevas sesiones del Codex.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Usa tu actual",
-          "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude."
+          "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude.",
+          "b28bb41f63": "Auto-switch Limited Agents",
+          "7d2634bfa1": "When a live Claude or Codex session hits an account limit, Orca can switch to another managed account and resume the same session.",
+          "5d6a7e20ef": "Exits the limited Claude or Codex agent, selects a managed account with available quota, resumes the provider session, then sends continue.",
+          "0f9197cfde": "Enabled",
+          "a103114594": "Enable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reanudar",
@@ -6354,7 +6371,9 @@
             "bdbd1e668e": "ventanas",
             "593720c17f": "ubicación",
             "b84a5b0c8a": "Elija si las cuentas de proveedor se inspeccionan y agregan en este dispositivo o en WSL.",
-            "d09fb5ca92": "Ubicación de la cuenta"
+            "d09fb5ca92": "Ubicación de la cuenta",
+            "0b0fd87891": "Auto-switch Limited Agents",
+            "3d76b94f10": "Resume Claude and Codex sessions on another managed account when the active account hits a limit."
           }
         },
         "advanced": {
@@ -11533,6 +11552,16 @@
             "dismiss": "Dismiss",
             "later": "Later"
           }
+        }
+      },
+      "terminalPane": {
+        "TerminalPane": {
+          "3200325804": "Switching managed accounts and resuming the same session.",
+          "34f715e07e": "{{value0}} account limit detected.",
+          "e0e6981a0e": "{{value0}} session resumed.",
+          "f8d8f16aca": "Switched to {{value0}} and sent continue.",
+          "816627b20e": "{{value0}} auto-switch skipped.",
+          "8bb13ef78d": "{{value0}} auto-switch failed."
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -508,6 +508,18 @@
         "distroRequired": "Select a WSL distro for this project before installing this skill.",
         "distroMissing": "The selected WSL distro is unavailable. Choose an available distro or switch this project to Windows.",
         "wslDefault": "WSL default"
+      },
+      "agentRateLimitAutoSwitchRunner": {
+        "07ff1f8806": "Auto-switch is disabled.",
+        "7e5d87791a": "Auto-switch is not available for SSH terminals because account auth lives on the remote host.",
+        "d823b157d5": "No managed {{value0}} account with available quota was found.",
+        "79751c2c2d": "Could not build a resume command for the limited agent session.",
+        "13668a6034": "The limited agent did not exit after Ctrl+C, so Orca left the terminal untouched.",
+        "9553d26436": "The terminal did not accept the resume command after switching accounts.",
+        "13ccffb514": "The resumed agent did not take over the terminal in time.",
+        "65d1f14b75": "The resumed agent did not accept the continue command.",
+        "65e8e278a4": "Could not inspect managed accounts: {{value0}}",
+        "a939f58b30": "Could not resolve the resume platform: {{value0}}"
       }
     },
     "hooks": {
@@ -4290,7 +4302,12 @@
           "75ca9b718e": "Codex は、アクティブなアカウントには新たにサインインする必要があると報告しました。新規 Codex セッションを開始する前に、再認証してください。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。"
+          "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。",
+          "b28bb41f63": "Auto-switch Limited Agents",
+          "7d2634bfa1": "When a live Claude or Codex session hits an account limit, Orca can switch to another managed account and resume the same session.",
+          "5d6a7e20ef": "Exits the limited Claude or Codex agent, selects a managed account with available quota, resumes the provider session, then sends continue.",
+          "0f9197cfde": "Enabled",
+          "a103114594": "Enable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",
@@ -6376,7 +6393,9 @@
             "bdbd1e668e": "窓",
             "593720c17f": "場所",
             "b84a5b0c8a": "プロバイダー アカウントをこのデバイスまたは WSL で検査および追加するかどうかを選択します。",
-            "d09fb5ca92": "アカウントの場所"
+            "d09fb5ca92": "アカウントの場所",
+            "0b0fd87891": "Auto-switch Limited Agents",
+            "3d76b94f10": "Resume Claude and Codex sessions on another managed account when the active account hits a limit."
           }
         },
         "advanced": {
@@ -11533,6 +11552,16 @@
             "dismiss": "Dismiss",
             "later": "Later"
           }
+        }
+      },
+      "terminalPane": {
+        "TerminalPane": {
+          "3200325804": "Switching managed accounts and resuming the same session.",
+          "34f715e07e": "{{value0}} account limit detected.",
+          "e0e6981a0e": "{{value0}} session resumed.",
+          "f8d8f16aca": "Switched to {{value0}} and sent continue.",
+          "816627b20e": "{{value0}} auto-switch skipped.",
+          "8bb13ef78d": "{{value0}} auto-switch failed."
         }
       }
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -508,6 +508,18 @@
         "distroRequired": "Select a WSL distro for this project before installing this skill.",
         "distroMissing": "The selected WSL distro is unavailable. Choose an available distro or switch this project to Windows.",
         "wslDefault": "WSL default"
+      },
+      "agentRateLimitAutoSwitchRunner": {
+        "07ff1f8806": "Auto-switch is disabled.",
+        "7e5d87791a": "Auto-switch is not available for SSH terminals because account auth lives on the remote host.",
+        "d823b157d5": "No managed {{value0}} account with available quota was found.",
+        "79751c2c2d": "Could not build a resume command for the limited agent session.",
+        "13668a6034": "The limited agent did not exit after Ctrl+C, so Orca left the terminal untouched.",
+        "9553d26436": "The terminal did not accept the resume command after switching accounts.",
+        "13ccffb514": "The resumed agent did not take over the terminal in time.",
+        "65d1f14b75": "The resumed agent did not accept the continue command.",
+        "65e8e278a4": "Could not inspect managed accounts: {{value0}}",
+        "a939f58b30": "Could not resolve the resume platform: {{value0}}"
       }
     },
     "hooks": {
@@ -4290,7 +4302,12 @@
           "75ca9b718e": "Codex는 활성 계정에 새로 로그인해야 한다고 보고했습니다. 새 Codex 세션을 시작하기 전에 다시 인증하세요.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요."
+          "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요.",
+          "b28bb41f63": "Auto-switch Limited Agents",
+          "7d2634bfa1": "When a live Claude or Codex session hits an account limit, Orca can switch to another managed account and resume the same session.",
+          "5d6a7e20ef": "Exits the limited Claude or Codex agent, selects a managed account with available quota, resumes the provider session, then sends continue.",
+          "0f9197cfde": "Enabled",
+          "a103114594": "Enable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "다시 시작",
@@ -6339,7 +6356,9 @@
             "bdbd1e668e": "창문들",
             "593720c17f": "위치",
             "b84a5b0c8a": "이 장치 또는 WSL에서 공급자 계정을 검사하고 추가할지 선택합니다.",
-            "d09fb5ca92": "계정 위치"
+            "d09fb5ca92": "계정 위치",
+            "0b0fd87891": "Auto-switch Limited Agents",
+            "3d76b94f10": "Resume Claude and Codex sessions on another managed account when the active account hits a limit."
           }
         },
         "advanced": {
@@ -11533,6 +11552,16 @@
             "dismiss": "닫기",
             "later": "Later"
           }
+        }
+      },
+      "terminalPane": {
+        "TerminalPane": {
+          "3200325804": "Switching managed accounts and resuming the same session.",
+          "34f715e07e": "{{value0}} account limit detected.",
+          "e0e6981a0e": "{{value0}} session resumed.",
+          "f8d8f16aca": "Switched to {{value0}} and sent continue.",
+          "816627b20e": "{{value0}} auto-switch skipped.",
+          "8bb13ef78d": "{{value0}} auto-switch failed."
         }
       }
     },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -508,6 +508,18 @@
         "distroRequired": "Select a WSL distro for this project before installing this skill.",
         "distroMissing": "The selected WSL distro is unavailable. Choose an available distro or switch this project to Windows.",
         "wslDefault": "WSL default"
+      },
+      "agentRateLimitAutoSwitchRunner": {
+        "07ff1f8806": "Auto-switch is disabled.",
+        "7e5d87791a": "Auto-switch is not available for SSH terminals because account auth lives on the remote host.",
+        "d823b157d5": "No managed {{value0}} account with available quota was found.",
+        "79751c2c2d": "Could not build a resume command for the limited agent session.",
+        "13668a6034": "The limited agent did not exit after Ctrl+C, so Orca left the terminal untouched.",
+        "9553d26436": "The terminal did not accept the resume command after switching accounts.",
+        "13ccffb514": "The resumed agent did not take over the terminal in time.",
+        "65d1f14b75": "The resumed agent did not accept the continue command.",
+        "65e8e278a4": "Could not inspect managed accounts: {{value0}}",
+        "a939f58b30": "Could not resolve the resume platform: {{value0}}"
       }
     },
     "hooks": {
@@ -4290,7 +4302,12 @@
           "75ca9b718e": "Codex 报告活动账户需要重新登录。在开始新的 Codex 会话之前重新对其进行身份验证。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。"
+          "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。",
+          "b28bb41f63": "Auto-switch Limited Agents",
+          "7d2634bfa1": "When a live Claude or Codex session hits an account limit, Orca can switch to another managed account and resume the same session.",
+          "5d6a7e20ef": "Exits the limited Claude or Codex agent, selects a managed account with available quota, resumes the provider session, then sends continue.",
+          "0f9197cfde": "Enabled",
+          "a103114594": "Enable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "重新启动",
@@ -6339,7 +6356,9 @@
             "bdbd1e668e": "视窗",
             "593720c17f": "位置",
             "b84a5b0c8a": "选择是否在此设备上或 WSL 中检查和添加提供商账户。",
-            "d09fb5ca92": "账户位置"
+            "d09fb5ca92": "账户位置",
+            "0b0fd87891": "Auto-switch Limited Agents",
+            "3d76b94f10": "Resume Claude and Codex sessions on another managed account when the active account hits a limit."
           }
         },
         "advanced": {
@@ -11533,6 +11552,16 @@
             "dismiss": "Dismiss",
             "later": "Later"
           }
+        }
+      },
+      "terminalPane": {
+        "TerminalPane": {
+          "3200325804": "Switching managed accounts and resuming the same session.",
+          "34f715e07e": "{{value0}} account limit detected.",
+          "e0e6981a0e": "{{value0}} session resumed.",
+          "f8d8f16aca": "Switched to {{value0}} and sent continue.",
+          "816627b20e": "{{value0}} auto-switch skipped.",
+          "8bb13ef78d": "{{value0}} auto-switch failed."
         }
       }
     },

--- a/src/renderer/src/lib/agent-rate-limit-auto-switch-runner.ts
+++ b/src/renderer/src/lib/agent-rate-limit-auto-switch-runner.ts
@@ -1,0 +1,299 @@
+import type { AutoSwitchRateLimitAgent } from '../../../shared/agent-rate-limit-detection'
+import type { AgentProviderSessionMetadata } from '../../../shared/agent-session-resume'
+import {
+  resolveTuiAgentLaunchArgs,
+  resolveTuiAgentLaunchEnv
+} from '../../../shared/tui-agent-launch-defaults'
+import { useAppStore } from '@/store'
+import { sendRuntimePtyInputVerified } from '@/runtime/runtime-terminal-inspection'
+import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
+import { callRuntimeRpc, type RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
+import { translate } from '@/i18n/i18n'
+import { buildAgentResumeStartupPlan } from './tui-agent-startup'
+import {
+  selectAutoSwitchAccount,
+  type AutoSwitchAccountCandidate,
+  type AutoSwitchAccountsSnapshot
+} from './agent-rate-limit-auto-switch'
+import {
+  stopForegroundAgent,
+  waitForAgentReadyInput,
+  waitForResumedAgent
+} from './agent-rate-limit-terminal-control'
+import { resolveAgentRateLimitResumePlatform } from './agent-rate-limit-resume-platform'
+
+export type AgentRateLimitAutoSwitchResult =
+  | { ok: true; agent: AutoSwitchRateLimitAgent; accountLabel: string }
+  | {
+      ok: false
+      reason:
+        | 'disabled'
+        | 'ssh'
+        | 'no-account'
+        | 'stop-failed'
+        | 'resume-failed'
+        | 'continue-failed'
+        | 'switch-failed'
+      message: string
+    }
+
+type AccountsSnapshotResult = {
+  accounts: AutoSwitchAccountsSnapshot
+  target: RuntimeClientTarget
+}
+
+/** Formats unknown async failures for toast-safe structured runner results. */
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/** Refreshes local inactive-account quota data before selecting an auto-switch target. */
+async function loadLocalAccountsSnapshot(agent: AutoSwitchRateLimitAgent): Promise<{
+  accounts: AutoSwitchAccountsSnapshot
+  target: RuntimeClientTarget
+}> {
+  const fetchInactive =
+    agent === 'claude'
+      ? window.api.rateLimits.fetchInactiveClaudeAccounts
+      : window.api.rateLimits.fetchInactiveCodexAccounts
+  await fetchInactive()
+  const [claude, codex, rateLimits] = await Promise.all([
+    window.api.claudeAccounts.list(),
+    window.api.codexAccounts.list(),
+    window.api.rateLimits.get()
+  ])
+  useAppStore.getState().setRateLimitsFromPush(rateLimits)
+  return { accounts: { claude, codex, rateLimits }, target: { kind: 'local' } }
+}
+
+/** Loads managed-account and quota state from the PTY-owning runtime. */
+async function loadAccountsSnapshot(args: {
+  agent: AutoSwitchRateLimitAgent
+  ptyId: string
+}): Promise<AccountsSnapshotResult> {
+  const environmentId = getRemoteRuntimePtyEnvironmentId(args.ptyId)
+  if (!environmentId) {
+    return loadLocalAccountsSnapshot(args.agent)
+  }
+  const target = { kind: 'environment', environmentId } as const
+  const accounts = await callRuntimeRpc<AutoSwitchAccountsSnapshot>(
+    target,
+    'accounts.list',
+    undefined,
+    { timeoutMs: 30_000 }
+  )
+  return { accounts, target }
+}
+
+/** Selects the chosen managed account in the same runtime where the PTY is running. */
+async function selectAccount(args: {
+  agent: AutoSwitchRateLimitAgent
+  runtimeTarget: RuntimeClientTarget
+  candidate: AutoSwitchAccountCandidate
+}): Promise<void> {
+  if (args.runtimeTarget.kind === 'environment') {
+    await callRuntimeRpc(
+      args.runtimeTarget,
+      args.agent === 'claude' ? 'accounts.selectClaude' : 'accounts.selectCodex',
+      { accountId: args.candidate.accountId },
+      { timeoutMs: 30_000 }
+    )
+    return
+  }
+
+  const selection = {
+    accountId: args.candidate.accountId,
+    runtime: args.candidate.target.runtime,
+    wslDistro: args.candidate.target.wslDistro
+  }
+  const selectManagedAccount =
+    args.agent === 'claude' ? window.api.claudeAccounts.select : window.api.codexAccounts.select
+  await selectManagedAccount(selection)
+  await useAppStore.getState().fetchSettings()
+}
+
+/** Runs the stop/switch/resume/continue flow for a detected account-limit event. */
+export async function runAgentRateLimitAutoSwitch(args: {
+  ptyId: string
+  agent: AutoSwitchRateLimitAgent
+  providerSession: AgentProviderSessionMetadata
+  connectionId: string | null
+}): Promise<AgentRateLimitAutoSwitchResult> {
+  const settings = useAppStore.getState().settings
+  if (settings?.autoSwitchRateLimitedAccounts !== true) {
+    return {
+      ok: false,
+      reason: 'disabled',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.07ff1f8806',
+        'Auto-switch is disabled.'
+      )
+    }
+  }
+  if (args.connectionId) {
+    return {
+      ok: false,
+      reason: 'ssh',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.7e5d87791a',
+        'Auto-switch is not available for SSH terminals because account auth lives on the remote host.'
+      )
+    }
+  }
+
+  let snapshot: AccountsSnapshotResult
+  try {
+    snapshot = await loadAccountsSnapshot({ agent: args.agent, ptyId: args.ptyId })
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'switch-failed',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.65e8e278a4',
+        'Could not inspect managed accounts: {{value0}}',
+        { value0: errorMessage(error) }
+      )
+    }
+  }
+  const providerTarget =
+    args.agent === 'claude'
+      ? snapshot.accounts.rateLimits.claudeTarget
+      : snapshot.accounts.rateLimits.codexTarget
+  const candidate = selectAutoSwitchAccount({
+    agent: args.agent,
+    accounts: snapshot.accounts,
+    target:
+      snapshot.target.kind === 'environment' ? { runtime: 'host', wslDistro: null } : providerTarget
+  })
+  if (!candidate) {
+    return {
+      ok: false,
+      reason: 'no-account',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.d823b157d5',
+        'No managed {{value0}} account with available quota was found.',
+        { value0: args.agent === 'claude' ? 'Claude' : 'Codex' }
+      )
+    }
+  }
+
+  let platform: NodeJS.Platform
+  try {
+    platform = await resolveAgentRateLimitResumePlatform({
+      target: snapshot.target,
+      accountTarget: candidate.target
+    })
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'resume-failed',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.a939f58b30',
+        'Could not resolve the resume platform: {{value0}}',
+        { value0: errorMessage(error) }
+      )
+    }
+  }
+  const localSettings = snapshot.target.kind === 'local' ? settings : null
+  const resumePlan = buildAgentResumeStartupPlan({
+    agent: args.agent,
+    providerSession: args.providerSession,
+    cmdOverrides: localSettings?.agentCmdOverrides ?? {},
+    agentArgs: resolveTuiAgentLaunchArgs(args.agent, localSettings?.agentDefaultArgs),
+    agentEnv: resolveTuiAgentLaunchEnv(args.agent, localSettings?.agentDefaultEnv),
+    platform
+  })
+  if (!resumePlan) {
+    return {
+      ok: false,
+      reason: 'resume-failed',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.79751c2c2d',
+        'Could not build a resume command for the limited agent session.'
+      )
+    }
+  }
+
+  const stopped = await stopForegroundAgent({
+    settings,
+    ptyId: args.ptyId,
+    agent: args.agent,
+    expectedProcess: resumePlan.expectedProcess
+  })
+  if (!stopped) {
+    return {
+      ok: false,
+      reason: 'stop-failed',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.13668a6034',
+        'The limited agent did not exit after Ctrl+C, so Orca left the terminal untouched.'
+      )
+    }
+  }
+
+  try {
+    await selectAccount({
+      agent: args.agent,
+      runtimeTarget: snapshot.target,
+      candidate
+    })
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'switch-failed',
+      message: error instanceof Error ? error.message : String(error)
+    }
+  }
+
+  const launched = await sendRuntimePtyInputVerified(
+    useAppStore.getState().settings,
+    args.ptyId,
+    `${resumePlan.launchCommand}\r`
+  )
+  if (!launched) {
+    return {
+      ok: false,
+      reason: 'resume-failed',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.9553d26436',
+        'The terminal did not accept the resume command after switching accounts.'
+      )
+    }
+  }
+
+  const resumed = await waitForResumedAgent({
+    settings: useAppStore.getState().settings,
+    ptyId: args.ptyId,
+    agent: args.agent,
+    expectedProcess: resumePlan.expectedProcess
+  })
+  if (!resumed) {
+    return {
+      ok: false,
+      reason: 'resume-failed',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.13ccffb514',
+        'The resumed agent did not take over the terminal in time.'
+      )
+    }
+  }
+
+  await waitForAgentReadyInput()
+  const continued = await sendRuntimePtyInputVerified(
+    useAppStore.getState().settings,
+    args.ptyId,
+    'continue\r'
+  )
+  if (!continued) {
+    return {
+      ok: false,
+      reason: 'continue-failed',
+      message: translate(
+        'auto.lib.agentRateLimitAutoSwitchRunner.65d1f14b75',
+        'The resumed agent did not accept the continue command.'
+      )
+    }
+  }
+
+  return { ok: true, agent: args.agent, accountLabel: candidate.label }
+}

--- a/src/renderer/src/lib/agent-rate-limit-auto-switch.test.ts
+++ b/src/renderer/src/lib/agent-rate-limit-auto-switch.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest'
+import type { ProviderRateLimits, RateLimitState } from '../../../shared/rate-limit-types'
+import type {
+  ClaudeRateLimitAccountsState,
+  CodexRateLimitAccountsState
+} from '../../../shared/types'
+import { selectAutoSwitchAccount } from './agent-rate-limit-auto-switch'
+
+function limits(provider: 'claude' | 'codex', usedPercent: number): ProviderRateLimits {
+  return {
+    provider,
+    session: {
+      usedPercent,
+      windowMinutes: 300,
+      resetsAt: null,
+      resetDescription: null
+    },
+    weekly: null,
+    updatedAt: 1,
+    error: null,
+    status: 'ok'
+  }
+}
+
+function unavailableLimits(provider: 'claude' | 'codex'): ProviderRateLimits {
+  return {
+    provider,
+    session: null,
+    weekly: null,
+    updatedAt: 1,
+    error: 'sign in',
+    status: 'error'
+  }
+}
+
+const emptyClaude: ClaudeRateLimitAccountsState = {
+  accounts: [],
+  activeAccountId: null,
+  activeAccountIdsByRuntime: { host: null, wsl: {} }
+}
+
+const emptyCodex: CodexRateLimitAccountsState = {
+  accounts: [],
+  activeAccountId: null,
+  activeAccountIdsByRuntime: { host: null, wsl: {} }
+}
+
+function rateLimitState(overrides: Partial<RateLimitState>): RateLimitState {
+  return {
+    claude: null,
+    codex: null,
+    gemini: null,
+    opencodeGo: null,
+    kimi: null,
+    claudeTarget: { runtime: 'host', wslDistro: null },
+    codexTarget: { runtime: 'host', wslDistro: null },
+    inactiveClaudeAccounts: [],
+    inactiveCodexAccounts: [],
+    ...overrides
+  }
+}
+
+describe('selectAutoSwitchAccount', () => {
+  it('selects the lowest-usage inactive Codex account for the same runtime', () => {
+    const result = selectAutoSwitchAccount({
+      agent: 'codex',
+      target: { runtime: 'host', wslDistro: null },
+      accounts: {
+        claude: emptyClaude,
+        codex: {
+          accounts: [
+            {
+              id: 'active',
+              email: 'active@example.com',
+              managedHomeRuntime: 'host',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            },
+            {
+              id: 'busy',
+              email: 'busy@example.com',
+              managedHomeRuntime: 'host',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            },
+            {
+              id: 'free',
+              email: 'free@example.com',
+              managedHomeRuntime: 'host',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            }
+          ],
+          activeAccountId: 'active',
+          activeAccountIdsByRuntime: { host: 'active', wsl: {} }
+        },
+        rateLimits: rateLimitState({
+          inactiveCodexAccounts: [
+            { accountId: 'busy', rateLimits: limits('codex', 95), updatedAt: 1, isFetching: false },
+            { accountId: 'free', rateLimits: limits('codex', 12), updatedAt: 1, isFetching: false }
+          ]
+        })
+      }
+    })
+
+    expect(result).toMatchObject({
+      accountId: 'free',
+      label: 'free@example.com',
+      usedPercent: 12
+    })
+  })
+
+  it('skips unavailable and exhausted Claude accounts', () => {
+    const result = selectAutoSwitchAccount({
+      agent: 'claude',
+      target: { runtime: 'host', wslDistro: null },
+      accounts: {
+        claude: {
+          accounts: [
+            {
+              id: 'active',
+              email: 'active@example.com',
+              managedAuthRuntime: 'host',
+              authMethod: 'subscription-oauth',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            },
+            {
+              id: 'bad',
+              email: 'bad@example.com',
+              managedAuthRuntime: 'host',
+              authMethod: 'subscription-oauth',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            },
+            {
+              id: 'full',
+              email: 'full@example.com',
+              managedAuthRuntime: 'host',
+              authMethod: 'subscription-oauth',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            }
+          ],
+          activeAccountId: 'active',
+          activeAccountIdsByRuntime: { host: 'active', wsl: {} }
+        },
+        codex: emptyCodex,
+        rateLimits: rateLimitState({
+          inactiveClaudeAccounts: [
+            {
+              accountId: 'bad',
+              rateLimits: unavailableLimits('claude'),
+              updatedAt: 1,
+              isFetching: false
+            },
+            {
+              accountId: 'full',
+              rateLimits: limits('claude', 100),
+              updatedAt: 1,
+              isFetching: false
+            }
+          ]
+        })
+      }
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('keeps WSL account selection scoped to the same distro', () => {
+    const result = selectAutoSwitchAccount({
+      agent: 'codex',
+      target: { runtime: 'wsl', wslDistro: 'Ubuntu' },
+      accounts: {
+        claude: emptyClaude,
+        codex: {
+          accounts: [
+            {
+              id: 'active',
+              email: 'active@example.com',
+              managedHomeRuntime: 'wsl',
+              wslDistro: 'Ubuntu',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            },
+            {
+              id: 'debian',
+              email: 'debian@example.com',
+              managedHomeRuntime: 'wsl',
+              wslDistro: 'Debian',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            },
+            {
+              id: 'ubuntu',
+              email: 'ubuntu@example.com',
+              managedHomeRuntime: 'wsl',
+              wslDistro: 'Ubuntu',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            }
+          ],
+          activeAccountId: null,
+          activeAccountIdsByRuntime: { host: null, wsl: { Ubuntu: 'active' } }
+        },
+        rateLimits: rateLimitState({
+          inactiveCodexAccounts: [
+            {
+              accountId: 'debian',
+              rateLimits: limits('codex', 1),
+              updatedAt: 1,
+              isFetching: false
+            },
+            {
+              accountId: 'ubuntu',
+              rateLimits: limits('codex', 20),
+              updatedAt: 1,
+              isFetching: false
+            }
+          ]
+        })
+      }
+    })
+
+    expect(result?.accountId).toBe('ubuntu')
+  })
+})

--- a/src/renderer/src/lib/agent-rate-limit-auto-switch.ts
+++ b/src/renderer/src/lib/agent-rate-limit-auto-switch.ts
@@ -1,0 +1,156 @@
+import type { AutoSwitchRateLimitAgent } from '../../../shared/agent-rate-limit-detection'
+import type {
+  InactiveAccountUsage,
+  ProviderRateLimits,
+  RateLimitWindow,
+  RateLimitRuntimeTarget,
+  RateLimitState
+} from '../../../shared/rate-limit-types'
+import type {
+  ClaudeRateLimitAccountsState,
+  CodexRateLimitAccountsState
+} from '../../../shared/types'
+
+export type AutoSwitchAccountsSnapshot = {
+  claude: ClaudeRateLimitAccountsState
+  codex: CodexRateLimitAccountsState
+  rateLimits: RateLimitState
+}
+
+export type AutoSwitchAccountCandidate = {
+  accountId: string
+  label: string
+  target: RateLimitRuntimeTarget
+  usedPercent: number
+}
+
+type ProviderAccount =
+  | ClaudeRateLimitAccountsState['accounts'][number]
+  | CodexRateLimitAccountsState['accounts'][number]
+
+type ProviderAccountsState = ClaudeRateLimitAccountsState | CodexRateLimitAccountsState
+
+/** Produces a stable key for matching managed accounts to the active runtime scope. */
+function getRuntimeKey(target: RateLimitRuntimeTarget): string {
+  return target.runtime === 'wsl' ? (target.wslDistro ?? '__default__') : 'host'
+}
+
+/** Reads the provider-specific managed-account runtime shape as a generic target. */
+function getAccountRuntime(
+  agent: AutoSwitchRateLimitAgent,
+  account: ProviderAccount
+): RateLimitRuntimeTarget {
+  if (agent === 'claude') {
+    const claudeAccount = account as ClaudeRateLimitAccountsState['accounts'][number]
+    return {
+      runtime: claudeAccount.managedAuthRuntime === 'wsl' ? 'wsl' : 'host',
+      wslDistro:
+        claudeAccount.managedAuthRuntime === 'wsl' ? (claudeAccount.wslDistro ?? null) : null
+    }
+  }
+
+  const codexAccount = account as CodexRateLimitAccountsState['accounts'][number]
+  return {
+    runtime: codexAccount.managedHomeRuntime === 'wsl' ? 'wsl' : 'host',
+    wslDistro: codexAccount.managedHomeRuntime === 'wsl' ? (codexAccount.wslDistro ?? null) : null
+  }
+}
+
+/** Keeps auto-switch within the same host or exact WSL distro as the limited session. */
+function accountMatchesTarget(
+  agent: AutoSwitchRateLimitAgent,
+  account: ProviderAccount,
+  target: RateLimitRuntimeTarget
+): boolean {
+  const accountRuntime = getAccountRuntime(agent, account)
+  if (accountRuntime.runtime !== target.runtime) {
+    return false
+  }
+  if (target.runtime === 'host') {
+    return true
+  }
+  return getRuntimeKey(accountRuntime) === getRuntimeKey(target)
+}
+
+/** Resolves the active account for the target runtime, preserving legacy host fallback. */
+function getActiveAccountId(
+  state: ProviderAccountsState,
+  target: RateLimitRuntimeTarget
+): string | null {
+  const selection = state.activeAccountIdsByRuntime
+  if (target.runtime === 'host') {
+    return selection?.host ?? state.activeAccountId ?? null
+  }
+  const runtimeKey = getRuntimeKey(target)
+  const exact = selection?.wsl?.[runtimeKey]
+  if (target.wslDistro || exact) {
+    return exact ?? null
+  }
+  const selectedIds = Array.from(new Set(Object.values(selection?.wsl ?? {}).filter(Boolean)))
+  return selectedIds.length === 1 ? selectedIds[0] : null
+}
+
+/** Scores an inactive account by its tightest reported quota window. */
+function getUsageScore(limits: ProviderRateLimits | null | undefined): number | null {
+  if (!limits || limits.status !== 'ok') {
+    return null
+  }
+  const windows = [
+    limits.session,
+    limits.weekly,
+    limits.monthly ?? null,
+    ...(limits.buckets ?? [])
+  ].filter((window): window is RateLimitWindow => window !== null)
+  if (windows.length === 0) {
+    return null
+  }
+  const usedPercent = Math.max(...windows.map((window) => window.usedPercent))
+  return usedPercent < 100 ? usedPercent : null
+}
+
+/** Indexes only usable inactive accounts; exhausted or errored accounts are omitted. */
+function getInactiveUsageByAccountId(usages: readonly InactiveAccountUsage[]): Map<string, number> {
+  const result = new Map<string, number>()
+  for (const usage of usages) {
+    const score = getUsageScore(usage.rateLimits)
+    if (score !== null) {
+      result.set(usage.accountId, score)
+    }
+  }
+  return result
+}
+
+/** Chooses the lowest-usage inactive managed account for the current provider/runtime. */
+export function selectAutoSwitchAccount(args: {
+  agent: AutoSwitchRateLimitAgent
+  accounts: AutoSwitchAccountsSnapshot
+  target: RateLimitRuntimeTarget
+}): AutoSwitchAccountCandidate | null {
+  const providerAccounts = args.agent === 'claude' ? args.accounts.claude : args.accounts.codex
+  const inactiveUsage =
+    args.agent === 'claude'
+      ? args.accounts.rateLimits.inactiveClaudeAccounts
+      : args.accounts.rateLimits.inactiveCodexAccounts
+  const activeAccountId = getActiveAccountId(providerAccounts, args.target)
+  const usageByAccountId = getInactiveUsageByAccountId(inactiveUsage)
+
+  const candidates = providerAccounts.accounts
+    .filter((account) => account.id !== activeAccountId)
+    .filter((account) => accountMatchesTarget(args.agent, account, args.target))
+    .map((account) => {
+      const usedPercent = usageByAccountId.get(account.id)
+      if (usedPercent === undefined) {
+        return null
+      }
+      return {
+        accountId: account.id,
+        label: account.email,
+        target: getAccountRuntime(args.agent, account),
+        usedPercent
+      } satisfies AutoSwitchAccountCandidate
+    })
+    .filter((candidate): candidate is AutoSwitchAccountCandidate => candidate !== null)
+    .sort((left, right) => left.usedPercent - right.usedPercent)
+
+  return candidates[0] ?? null
+}

--- a/src/renderer/src/lib/agent-rate-limit-resume-platform.ts
+++ b/src/renderer/src/lib/agent-rate-limit-resume-platform.ts
@@ -1,0 +1,32 @@
+import type { RateLimitRuntimeTarget } from '../../../shared/rate-limit-types'
+import { callRuntimeRpc, type RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
+import { CLIENT_PLATFORM } from '@/lib/new-workspace'
+
+/** Resolves the host platform used for quoting resume commands on remote runtimes. */
+async function getRemoteHostPlatform(target: RuntimeClientTarget): Promise<NodeJS.Platform> {
+  if (target.kind !== 'environment') {
+    return CLIENT_PLATFORM
+  }
+  try {
+    const result = await callRuntimeRpc<{ platform: NodeJS.Platform }>(
+      target,
+      'host.platform',
+      undefined,
+      { timeoutMs: 5000 }
+    )
+    return result.platform
+  } catch {
+    return 'linux'
+  }
+}
+
+/** Uses Linux shell quoting for WSL accounts and host quoting for everything else. */
+export async function resolveAgentRateLimitResumePlatform(args: {
+  target: RuntimeClientTarget
+  accountTarget: RateLimitRuntimeTarget
+}): Promise<NodeJS.Platform> {
+  if (args.accountTarget.runtime === 'wsl') {
+    return 'linux'
+  }
+  return getRemoteHostPlatform(args.target)
+}

--- a/src/renderer/src/lib/agent-rate-limit-terminal-control.ts
+++ b/src/renderer/src/lib/agent-rate-limit-terminal-control.ts
@@ -1,0 +1,88 @@
+import type { AutoSwitchRateLimitAgent } from '../../../shared/agent-rate-limit-detection'
+import type { GlobalSettings } from '../../../shared/types'
+import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
+import {
+  inspectRuntimeTerminalProcess,
+  sendRuntimePtyInputVerified
+} from '@/runtime/runtime-terminal-inspection'
+
+const AGENT_STOP_ATTEMPTS = 3
+const AGENT_STOP_WAIT_MS = 1400
+const AGENT_RESUME_WAIT_MS = 6000
+const AGENT_READY_INPUT_DELAY_MS = 800
+
+/** Uses the browser timer so renderer tests and Electron share the same scheduling path. */
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms))
+}
+
+/** Matches the foreground process against the expected resumed provider command. */
+function isForegroundAgent(
+  foregroundProcess: string | null | undefined,
+  agent: AutoSwitchRateLimitAgent,
+  expectedProcess: string
+): boolean {
+  if (isExpectedAgentProcess(foregroundProcess, expectedProcess)) {
+    return true
+  }
+  const normalized = foregroundProcess?.trim().toLowerCase() ?? ''
+  return agent === 'codex' ? normalized.startsWith('codex-') : normalized === 'claude'
+}
+
+/** Inspects the PTY without mutating it, so stop/resume decisions stay terminal-safe. */
+async function isAgentStillForeground(args: {
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+  ptyId: string
+  agent: AutoSwitchRateLimitAgent
+  expectedProcess: string
+}): Promise<boolean> {
+  const process = await inspectRuntimeTerminalProcess(args.settings, args.ptyId)
+  return isForegroundAgent(process.foregroundProcess, args.agent, args.expectedProcess)
+}
+
+/** Exits only the foreground agent process by sending Ctrl+C to the existing PTY. */
+export async function stopForegroundAgent(args: {
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+  ptyId: string
+  agent: AutoSwitchRateLimitAgent
+  expectedProcess: string
+}): Promise<boolean> {
+  if (!(await isAgentStillForeground(args))) {
+    return true
+  }
+
+  for (let attempt = 0; attempt < AGENT_STOP_ATTEMPTS; attempt += 1) {
+    const sent = await sendRuntimePtyInputVerified(args.settings, args.ptyId, '\x03')
+    if (!sent) {
+      return false
+    }
+    await wait(AGENT_STOP_WAIT_MS)
+    if (!(await isAgentStillForeground(args))) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/** Waits for the resumed provider process to take foreground control of the same PTY. */
+export async function waitForResumedAgent(args: {
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+  ptyId: string
+  agent: AutoSwitchRateLimitAgent
+  expectedProcess: string
+}): Promise<boolean> {
+  const deadline = Date.now() + AGENT_RESUME_WAIT_MS
+  while (Date.now() < deadline) {
+    if (await isAgentStillForeground(args)) {
+      return true
+    }
+    await wait(150)
+  }
+  return false
+}
+
+/** Leaves a short settle window before sending the continuation prompt to the TUI. */
+export async function waitForAgentReadyInput(): Promise<void> {
+  await wait(AGENT_READY_INPUT_DELAY_MS)
+}

--- a/src/shared/agent-rate-limit-detection.test.ts
+++ b/src/shared/agent-rate-limit-detection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  detectAgentRateLimitOutput,
+  type AgentRateLimitDetectionState
+} from './agent-rate-limit-detection'
+
+function createState(): AgentRateLimitDetectionState {
+  return { tail: '' }
+}
+
+describe('agent rate limit detection', () => {
+  it('detects split Codex account limit output', () => {
+    const state = createState()
+
+    expect(detectAgentRateLimitOutput('codex', 'Error: rate ', state)).toBe(false)
+    expect(detectAgentRateLimitOutput('codex', 'limit exceeded. Try later.', state)).toBe(true)
+  })
+
+  it('detects ANSI-wrapped Claude usage limit output', () => {
+    expect(
+      detectAgentRateLimitOutput(
+        'claude',
+        '\x1b[31mYou have reached your weekly usage limit\x1b[0m',
+        createState()
+      )
+    ).toBe(true)
+  })
+
+  it('does not treat context window limits as account limits', () => {
+    expect(
+      detectAgentRateLimitOutput(
+        'codex',
+        'The conversation is too long for the current context window.',
+        createState()
+      )
+    ).toBe(false)
+  })
+})

--- a/src/shared/agent-rate-limit-detection.ts
+++ b/src/shared/agent-rate-limit-detection.ts
@@ -1,0 +1,73 @@
+/* eslint-disable no-control-regex -- Why: terminal quota detection must strip ANSI and control bytes before matching provider output. */
+import type { ResumableTuiAgent } from './agent-session-resume'
+
+export type AutoSwitchRateLimitAgent = Extract<ResumableTuiAgent, 'claude' | 'codex'>
+
+export type AgentRateLimitDetectionState = {
+  tail: string
+}
+
+const DETECTION_TAIL_LIMIT = 4000
+
+const ANSI_SEQUENCE_RE =
+  /\x1b(?:\][\s\S]*?(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~]|[PX^_][\s\S]*?\x1b\\|[@-_])/g
+const CONTROL_CHARACTER_RE = /[\x00-\x08\x0b-\x1f\x7f]/g
+
+const NON_ACCOUNT_LIMIT_PATTERNS = [
+  /\bcontext\s+(?:length|limit|window)\b/i,
+  /\b(?:maximum|max)\s+(?:context|token|tokens)\b/i,
+  /\btoken\s+limit\b/i,
+  /\boutput\s+limit\b/i,
+  /\bconversation\s+(?:is\s+)?too\s+long\b/i,
+  /\binput\s+too\s+long\b/i
+] as const
+
+const ACCOUNT_LIMIT_PATTERNS = [
+  /\brate\s+limited\b/i,
+  /\b(?:rate|usage|quota)\s+(?:limit\s+)?(?:exceeded|reached|hit)\b/i,
+  /\b(?:limit|quota)\s+(?:exceeded|reached|hit)\b/i,
+  /\btoo\s+many\s+requests\b/i,
+  /\b(?:http|status|error)\s*429\b/i,
+  /\b(?:you(?:'ve|\s+have)|we(?:'ve|\s+have))\s+(?:reached|hit)\s+(?:your|the)?[\s\S]{0,80}\b(?:rate|usage|quota)\s+limit\b/i,
+  /\b(?:daily|weekly|monthly|5-hour|five-hour)\s+(?:limit|quota)\s+(?:exceeded|reached|hit)\b/i
+] as const
+
+const AUTO_SWITCH_RATE_LIMIT_AGENTS = new Set<string>(['claude', 'codex'])
+
+/** Narrows live terminal agent ids to providers Orca can both resume and account-switch. */
+export function isAutoSwitchRateLimitAgent(value: unknown): value is AutoSwitchRateLimitAgent {
+  return typeof value === 'string' && AUTO_SWITCH_RATE_LIMIT_AGENTS.has(value)
+}
+
+/** Removes terminal control bytes so quota patterns can match rendered provider text. */
+function normalizeTerminalOutput(value: string): string {
+  return value
+    .replace(ANSI_SEQUENCE_RE, ' ')
+    .replace(CONTROL_CHARACTER_RE, ' ')
+    .replace(/\s+/g, ' ')
+}
+
+/** Keeps enough previous output to detect rate-limit phrases split across PTY chunks. */
+function rememberTail(state: AgentRateLimitDetectionState, value: string): string {
+  const next = `${state.tail}${value}`
+  state.tail = next.length > DETECTION_TAIL_LIMIT ? next.slice(-DETECTION_TAIL_LIMIT) : next
+  return state.tail
+}
+
+/** Detects provider account-limit output while filtering context/token-limit messages. */
+export function detectAgentRateLimitOutput(
+  agent: AutoSwitchRateLimitAgent,
+  chunk: string,
+  state: AgentRateLimitDetectionState
+): boolean {
+  if (!isAutoSwitchRateLimitAgent(agent) || chunk.length === 0) {
+    return false
+  }
+
+  const normalized = normalizeTerminalOutput(rememberTail(state, chunk))
+  if (NON_ACCOUNT_LIMIT_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return false
+  }
+
+  return ACCOUNT_LIMIT_PATTERNS.some((pattern) => pattern.test(normalized))
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -289,6 +289,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} },
     claudeManagedAccounts: [],
     activeClaudeManagedAccountId: null,
+    autoSwitchRateLimitedAccounts: false,
     terminalScopeHistoryByWorktree: true,
     defaultTuiAgent: null,
     disabledTuiAgents: [...DEFAULT_DISABLED_TUI_AGENTS],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2561,6 +2561,10 @@ export type GlobalSettings = {
   claudeManagedAccounts: ClaudeManagedAccount[]
   activeClaudeManagedAccountId: string | null
   activeClaudeManagedAccountIdsByRuntime?: ClaudeManagedAccountRuntimeSelection
+  /** When enabled, Orca exits a rate-limited managed Claude/Codex session,
+   *  switches to another managed account with available quota, resumes the
+   *  same provider session, then sends "continue". */
+  autoSwitchRateLimitedAccounts?: boolean
   /** When true, each worktree gets its own shell history file so ArrowUp
    *  does not surface commands from other worktrees. Defaults to true.
    *  Disable to revert to shared global shell history. */


### PR DESCRIPTION
## Summary
- Add an Accounts setting to enable auto-switching for rate-limited managed Claude/Codex sessions.
- Detect account-limit output from live agent terminals while filtering context/token-limit messages.
- Stop only the foreground agent with Ctrl+C, switch to an available managed account for the same runtime, resume the captured provider session, then send `continue`.
- Skip SSH terminals because account auth lives on the remote host and cannot be switched safely from the desktop.

## Screenshots
No screenshot attached. The visible UI change is a single Accounts settings row using existing `SettingsRow` and `Button` primitives.

## Testing
- [x] `corepack pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-rate-limit-detection.test.ts src/renderer/src/lib/agent-rate-limit-auto-switch.test.ts`
- [x] `corepack pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json`
- [x] `corepack pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
- [x] `corepack pnpm exec tsgo --noEmit -p config/tsconfig.tc.cli.json`
- [x] `corepack pnpm exec oxlint`
- [x] `corepack pnpm exec oxlint --type-aware --config config/oxlint-switch-exhaustiveness.json src/main src/preload src/shared src/relay src/cli src/renderer/src config tests --quiet`
- [x] `corepack pnpm exec node config/scripts/check-styled-scrollbars.mjs`
- [x] `corepack pnpm exec node config/scripts/verify-localization-catalog.mjs`
- [x] `corepack pnpm exec node config/scripts/audit-localization-coverage.mjs --check`
- [x] Added focused unit tests for rate-limit detection and account selection.
- [x] `pnpm build` was not run locally.

## AI Review Report
Reviewed the flow for terminal safety, false-positive rate-limit detection, account/runtime scoping, WSL distro matching, stale PTY parser state, disabled-setting notifications, and structured error handling. The review flagged stale parser state across PTY swaps and a misleading disabled-state toast; both were fixed in the current branch. It also flagged unstructured async failures around snapshot/platform loading, which are now returned as structured runner results.

Cross-platform compatibility was checked for macOS, Linux, and Windows concerns touched by this PR: shell quoting is delegated to the existing resume startup planner, WSL accounts force Linux quoting, host runtime platform is resolved through the existing runtime RPC, paths are not manually concatenated, and no keyboard shortcut or platform-label behavior was changed.

## Security Audit
Reviewed terminal output parsing, command construction, account switching, IPC/runtime RPC usage, and auth boundaries. Terminal output is normalized and bounded before matching; provider session ids continue to use existing normalization before resume commands are built; resume commands use the existing quoting path instead of ad hoc shell string construction. No new dependencies or secret storage were added. SSH terminals are intentionally skipped because switching desktop-managed auth on a remote host would be unsafe and misleading.

## Notes
- Auto-switch currently applies only to managed Claude and Codex accounts because those are the providers with account inventory, quota probes, account selection, and resume support in Orca.
- Remote runtime account switching is scoped to the runtime host account APIs currently exposed by Orca.
- Full `pnpm build` was not run locally; targeted tests, typechecks, lint, localization, and whitespace checks passed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5778">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

When a managed Claude or Codex account hits its rate limit, Orca can automatically stop that agent, switch to another managed account, and continue the session. You turn this on in Accounts settings. SSH terminals are skipped because account login lives on the remote machine.
