### PR TITLE
fix(repos): group non-GitHub checkouts across hosts by origin remote

### DIFF
--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -10,15 +10,18 @@ import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
+import {
+  getAuthConfig,
+  normalizeGiteaApiBaseUrl,
+  requestJsonAtBase,
+  requestJson,
+  encodedRepoPath
+} from './request'
 
-const REQUEST_TIMEOUT_MS = 5000
+export { normalizeGiteaApiBaseUrl }
+
 const PULL_REQUEST_PAGE_LIMIT = 50
 const MAX_PULL_REQUEST_PAGES = 5
-
-type GiteaAuthConfig = {
-  apiBaseUrl: string | null
-  token: string | null
-}
 
 export type GiteaAuthStatus = {
   configured: boolean
@@ -26,86 +29,6 @@ export type GiteaAuthStatus = {
   account: string | null
   baseUrl: string | null
   tokenConfigured: boolean
-}
-
-type RequestOptions = {
-  searchParams?: Record<string, string | number>
-  timeoutMs?: number
-}
-
-function envValue(name: string): string | null {
-  const value = process.env[name]?.trim() ?? ''
-  return value.length > 0 ? value : null
-}
-
-export function normalizeGiteaApiBaseUrl(value: string): string {
-  const trimmed = value.trim().replace(/\/+$/, '')
-  return /\/api\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/api/v1`
-}
-
-function getAuthConfig(): GiteaAuthConfig {
-  const apiBaseUrl = envValue('ORCA_GITEA_API_BASE_URL')
-  return {
-    apiBaseUrl: apiBaseUrl ? normalizeGiteaApiBaseUrl(apiBaseUrl) : null,
-    token: envValue('ORCA_GITEA_TOKEN')
-  }
-}
-
-function authHeaders(config: Pick<GiteaAuthConfig, 'token'>): Record<string, string> {
-  return config.token ? { Authorization: `token ${config.token}` } : {}
-}
-
-function configuredApiBaseUrl(repo: GiteaRepoRef): string {
-  return getAuthConfig().apiBaseUrl ?? repo.apiBaseUrl
-}
-
-function apiUrl(baseUrl: string, path: string, searchParams?: RequestOptions['searchParams']): URL {
-  const url = new URL(`${baseUrl.replace(/\/+$/, '')}${path}`)
-  if (searchParams) {
-    for (const [key, value] of Object.entries(searchParams)) {
-      url.searchParams.set(key, String(value))
-    }
-  }
-  return url
-}
-
-async function requestJsonAtBase<T>(
-  baseUrl: string,
-  path: string,
-  options: RequestOptions = {}
-): Promise<T | null> {
-  const config = getAuthConfig()
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
-  try {
-    const response = await fetch(apiUrl(baseUrl, path, options.searchParams), {
-      headers: {
-        Accept: 'application/json',
-        ...authHeaders(config)
-      },
-      signal: controller.signal
-    })
-    if (!response.ok) {
-      return null
-    }
-    return (await response.json()) as T
-  } catch {
-    return null
-  } finally {
-    clearTimeout(timeout)
-  }
-}
-
-function requestJson<T>(
-  repo: GiteaRepoRef,
-  path: string,
-  options: RequestOptions = {}
-): Promise<T | null> {
-  return requestJsonAtBase(configuredApiBaseUrl(repo), path, options)
-}
-
-function encodedRepoPath(repo: GiteaRepoRef): string {
-  return `${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}`
 }
 
 async function getCommitStatus(

--- a/src/main/gitea/issue-mappers.test.ts
+++ b/src/main/gitea/issue-mappers.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { mapGiteaIssueInfo, mapGiteaIssueState, type RawGiteaIssue } from './issue-mappers'
+
+describe('mapGiteaIssueState', () => {
+  it('maps closed (case-insensitive)', () => {
+    expect(mapGiteaIssueState('closed')).toBe('closed')
+    expect(mapGiteaIssueState('CLOSED')).toBe('closed')
+    expect(mapGiteaIssueState(' closed ')).toBe('closed')
+  })
+  it('maps everything else to open', () => {
+    expect(mapGiteaIssueState('open')).toBe('open')
+    expect(mapGiteaIssueState(null)).toBe('open')
+    expect(mapGiteaIssueState(undefined)).toBe('open')
+  })
+})
+
+describe('mapGiteaIssueInfo', () => {
+  const base: RawGiteaIssue = {
+    number: 7,
+    title: 'Fix the thing',
+    state: 'open',
+    html_url: 'https://forgejo.example/d1dx/repo/issues/7',
+    updated_at: '2026-06-20T00:00:00Z',
+    labels: [{ name: 'bug' }, { name: 'p1' }, { name: '' }],
+    user: { login: 'daniel', avatar_url: 'https://a/x.png' }
+  }
+
+  it('maps an open issue with labels + author (drops empty labels)', () => {
+    const r = mapGiteaIssueInfo(base)
+    expect(r).not.toBeNull()
+    expect(r).toMatchObject({
+      number: 7,
+      title: 'Fix the thing',
+      state: 'open',
+      url: base.html_url,
+      labels: ['bug', 'p1'],
+      author: 'daniel'
+    })
+  })
+
+  it('maps a closed issue', () => {
+    expect(mapGiteaIssueInfo({ ...base, state: 'closed' })?.state).toBe('closed')
+  })
+
+  // The critical gotcha (blueprint #1): Gitea's /issues endpoint returns PRs
+  // too — they MUST be filtered or PRs leak into the issue list.
+  it('returns null for a pull-request entry (pull_request != null)', () => {
+    expect(mapGiteaIssueInfo({ ...base, pull_request: {} })).toBeNull()
+    expect(mapGiteaIssueInfo({ ...base, pull_request: { merged: false } })).toBeNull()
+  })
+
+  it('returns null for malformed records', () => {
+    expect(mapGiteaIssueInfo({ ...base, number: undefined })).toBeNull()
+    expect(mapGiteaIssueInfo({ ...base, title: '' })).toBeNull()
+    expect(mapGiteaIssueInfo({ ...base, html_url: null })).toBeNull()
+  })
+})

--- a/src/main/gitea/issue-mappers.ts
+++ b/src/main/gitea/issue-mappers.ts
@@ -1,0 +1,57 @@
+/* Gitea/Forgejo issue mappers — mirrors gitlab/mappers.ts and
+   gitea/pull-request-mappers.ts shape. */
+
+export type RawGiteaIssue = {
+  number?: number
+  title?: string | null
+  state?: string | null
+  html_url?: string | null
+  body?: string | null
+  updated_at?: string | null
+  labels?: { name?: string | null }[] | null
+  user?: { login?: string | null; avatar_url?: string | null } | null
+  /** Why: Gitea /issues returns both issues and PRs in mixed endpoints.
+   *  A pull_request field (even if empty object) signals this record is a
+   *  PR; we must skip it so the issue list doesn't show PRs. */
+  pull_request?: unknown | null
+  assignees?: { login?: string | null; avatar_url?: string | null }[] | null
+}
+
+export type GiteaIssueInfo = {
+  number: number
+  title: string
+  state: 'open' | 'closed'
+  url: string
+  labels: string[]
+  updatedAt?: string
+  description?: string
+  author?: string
+  authorAvatarUrl?: string
+}
+
+export function mapGiteaIssueState(state: string | null | undefined): GiteaIssueInfo['state'] {
+  return state?.trim().toLowerCase() === 'closed' ? 'closed' : 'open'
+}
+
+export function mapGiteaIssueInfo(raw: RawGiteaIssue): GiteaIssueInfo | null {
+  // Why: skip PR entries — Gitea /issues can return PRs even with type=issues
+  // filter. Defensive guard mirrors github/issues.ts pull_request filter.
+  if (raw.pull_request != null) {
+    return null
+  }
+  if (typeof raw.number !== 'number' || !raw.title || !raw.html_url) {
+    return null
+  }
+  const labels = (raw.labels ?? []).map((l) => l.name ?? '').filter((n) => n.length > 0)
+  return {
+    number: raw.number,
+    title: raw.title,
+    state: mapGiteaIssueState(raw.state),
+    url: raw.html_url,
+    labels,
+    ...(raw.updated_at ? { updatedAt: raw.updated_at } : {}),
+    ...(typeof raw.body === 'string' ? { description: raw.body } : {}),
+    ...(raw.user?.login ? { author: raw.user.login } : {}),
+    ...(raw.user?.avatar_url ? { authorAvatarUrl: raw.user.avatar_url } : {})
+  }
+}

--- a/src/main/gitea/issues.ts
+++ b/src/main/gitea/issues.ts
@@ -1,0 +1,331 @@
+/* Gitea/Forgejo issue operations — mirrors gitlab/issues.ts function shapes.
+   Transport via ./request.ts (single shared auth source). */
+import type { GiteaRepoRef } from './repository-ref'
+import { getGiteaRepoRef } from './repository-ref'
+import { requestJson, encodedRepoPath } from './request'
+import { mapGiteaIssueInfo, type GiteaIssueInfo, type RawGiteaIssue } from './issue-mappers'
+
+export type IssueListResult = {
+  items: GiteaIssueInfo[]
+  error?: { kind: string; message: string }
+}
+
+export type IssueListState = 'open' | 'closed' | 'all'
+
+async function resolveRepo(
+  repoPath: string,
+  connectionId?: string | null
+): Promise<GiteaRepoRef | null> {
+  return getGiteaRepoRef(repoPath, connectionId)
+}
+
+/**
+ * Get a single issue by number (per-repo index).
+ */
+export async function getIssue(
+  repoPath: string,
+  issueNumber: number,
+  connectionId?: string | null
+): Promise<GiteaIssueInfo | null> {
+  const repo = await resolveRepo(repoPath, connectionId)
+  if (!repo) {
+    return null
+  }
+  try {
+    const raw = await requestJson<RawGiteaIssue>(
+      repo,
+      `/repos/${encodedRepoPath(repo)}/issues/${encodeURIComponent(String(issueNumber))}`
+    )
+    if (!raw) {
+      return null
+    }
+    return mapGiteaIssueInfo(raw)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * List issues for a repository.
+ *
+ * Why: type=issues asks the server to exclude PRs, but Gitea/Forgejo may
+ * still return PR entries in some configurations. We also filter
+ * raw.pull_request != null defensively in mapGiteaIssueInfo.
+ */
+export async function listIssues(
+  repoPath: string,
+  limit = 20,
+  state: IssueListState = 'open',
+  assignee?: string,
+  connectionId?: string | null
+): Promise<IssueListResult> {
+  const repo = await resolveRepo(repoPath, connectionId)
+  if (!repo) {
+    return {
+      items: [],
+      error: { kind: 'not_found', message: 'Could not resolve Gitea repository' }
+    }
+  }
+  try {
+    const searchParams: Record<string, string | number> = {
+      type: 'issues',
+      sort: 'recentupdate',
+      // Why: Gitea/Forgejo /issues defaults to state=open when the param is
+      // omitted, so 'all' must be sent explicitly or closed issues are dropped.
+      state,
+      limit,
+      page: 1
+    }
+    if (assignee) {
+      searchParams.assigned_to = assignee
+    }
+    const raw = await requestJson<RawGiteaIssue[]>(repo, `/repos/${encodedRepoPath(repo)}/issues`, {
+      searchParams
+    })
+    if (!raw) {
+      return {
+        items: [],
+        error: { kind: 'unknown', message: 'Failed to fetch issues from Gitea' }
+      }
+    }
+    // Why: filter out PR entries — Gitea returns mixed results even with
+    // type=issues (gotcha #1 in blueprint).
+    const items = raw
+      .map((r) => mapGiteaIssueInfo(r))
+      .filter((i): i is GiteaIssueInfo => i !== null)
+    return { items }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { items: [], error: { kind: 'unknown', message } }
+  }
+}
+
+/**
+ * Create a new issue in the repository.
+ */
+export async function createIssue(
+  repoPath: string,
+  title: string,
+  body: string,
+  connectionId?: string | null
+): Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }> {
+  const trimmedTitle = title.trim()
+  if (!trimmedTitle) {
+    return { ok: false, error: 'Title is required' }
+  }
+  const repo = await resolveRepo(repoPath, connectionId)
+  if (!repo) {
+    return { ok: false, error: 'Could not resolve Gitea repository for this repository' }
+  }
+  try {
+    const raw = await requestJson<{ number?: number; html_url?: string }>(
+      repo,
+      `/repos/${encodedRepoPath(repo)}/issues`,
+      { method: 'POST', body: { title: trimmedTitle, body } }
+    )
+    if (!raw || typeof raw.number !== 'number') {
+      return { ok: false, error: 'Unexpected response from Gitea' }
+    }
+    return { ok: true, number: raw.number, url: String(raw.html_url ?? '') }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: message }
+  }
+}
+
+/**
+ * Update an existing issue.
+ *
+ * Why: labels are a sub-resource on Gitea (PUT/POST/DELETE …/labels),
+ * NOT a PATCH field (gotcha #4 in blueprint). State + title + body go
+ * through PATCH; label mutations go through the /labels sub-resource.
+ */
+export async function updateIssue(
+  repoPath: string,
+  issueNumber: number,
+  updates: {
+    state?: 'open' | 'closed'
+    title?: string
+    body?: string
+    addLabels?: string[]
+    removeLabels?: string[]
+    assignees?: string[]
+  },
+  connectionId?: string | null
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const repo = await resolveRepo(repoPath, connectionId)
+  if (!repo) {
+    return { ok: false, error: 'Could not resolve Gitea repository for this repository' }
+  }
+  const errors: string[] = []
+  const basePath = `/repos/${encodedRepoPath(repo)}/issues/${encodeURIComponent(String(issueNumber))}`
+
+  // PATCH — state, title, body, assignees
+  const patchBody: Record<string, unknown> = {}
+  if (updates.state) {
+    patchBody.state = updates.state
+  }
+  if (updates.title) {
+    patchBody.title = updates.title
+  }
+  if (updates.body !== undefined) {
+    patchBody.body = updates.body
+  }
+  if (updates.assignees !== undefined) {
+    patchBody.assignees = updates.assignees
+  }
+  if (Object.keys(patchBody).length > 0) {
+    try {
+      await requestJson(repo, basePath, { method: 'PATCH', body: patchBody })
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  // Labels sub-resource — gotcha #4: NOT a PATCH field.
+  // For addLabels we POST individual label names (Gitea expects label IDs
+  // for the body, but the simplest approach is to PUT the full desired set
+  // after reading current labels — here we just call PUT to replace all
+  // labels with addLabels if provided, or issue a DELETE for removeLabels).
+  // Simplified: addLabels → POST /labels (by name); removeLabels → individual DELETE.
+  // NOTE: Gitea label operations use label IDs, not names. We fetch IDs first.
+  if ((updates.addLabels?.length ?? 0) > 0 || (updates.removeLabels?.length ?? 0) > 0) {
+    try {
+      // Fetch repo labels to resolve name → ID
+      const repoLabels = await requestJson<{ id?: number; name?: string }[]>(
+        repo,
+        `/repos/${encodedRepoPath(repo)}/labels`
+      )
+      const labelMap = new Map<string, number>()
+      for (const lbl of repoLabels ?? []) {
+        if (lbl.name && typeof lbl.id === 'number') {
+          labelMap.set(lbl.name, lbl.id)
+        }
+      }
+
+      if (updates.addLabels && updates.addLabels.length > 0) {
+        const ids = updates.addLabels
+          .map((name) => labelMap.get(name))
+          .filter((id): id is number => id !== undefined)
+        if (ids.length > 0) {
+          await requestJson(repo, `${basePath}/labels`, { method: 'POST', body: { labels: ids } })
+        }
+      }
+
+      if (updates.removeLabels && updates.removeLabels.length > 0) {
+        for (const name of updates.removeLabels) {
+          const id = labelMap.get(name)
+          if (typeof id === 'number') {
+            await requestJson(repo, `${basePath}/labels/${encodeURIComponent(String(id))}`, {
+              method: 'DELETE'
+            })
+          }
+        }
+      }
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, error: errors.join('; ') }
+  }
+  return { ok: true }
+}
+
+/**
+ * Add a comment to an existing issue.
+ */
+export async function addIssueComment(
+  repoPath: string,
+  issueNumber: number,
+  body: string,
+  connectionId?: string | null
+): Promise<
+  | { ok: true; comment: { id: number; body: string; createdAt: string } }
+  | { ok: false; error: string }
+> {
+  const repo = await resolveRepo(repoPath, connectionId)
+  if (!repo) {
+    return { ok: false, error: 'Could not resolve Gitea repository for this repository' }
+  }
+  try {
+    const raw = await requestJson<{
+      id?: number
+      body?: string
+      created_at?: string
+      user?: { login?: string; avatar_url?: string } | null
+    }>(
+      repo,
+      `/repos/${encodedRepoPath(repo)}/issues/${encodeURIComponent(String(issueNumber))}/comments`,
+      { method: 'POST', body: { body } }
+    )
+    if (!raw) {
+      return { ok: false, error: 'Unexpected response from Gitea' }
+    }
+    return {
+      ok: true,
+      comment: {
+        id: raw.id ?? Date.now(),
+        body: raw.body ?? body,
+        createdAt: raw.created_at ?? new Date().toISOString()
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: message }
+  }
+}
+
+/**
+ * List available labels for the repository.
+ */
+export async function listLabels(
+  repoPath: string,
+  connectionId?: string | null
+): Promise<string[]> {
+  const repo = await resolveRepo(repoPath, connectionId)
+  if (!repo) {
+    return []
+  }
+  try {
+    const raw = await requestJson<{ name?: string | null }[]>(
+      repo,
+      `/repos/${encodedRepoPath(repo)}/labels`
+    )
+    return (raw ?? []).map((l) => l.name ?? '').filter((n) => n.length > 0)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * List users who can be assigned to issues in this repository.
+ */
+export async function listAssignableUsers(
+  repoPath: string,
+  connectionId?: string | null
+): Promise<{ username: string; name: string | null; avatarUrl: string }[]> {
+  const repo = await resolveRepo(repoPath, connectionId)
+  if (!repo) {
+    return []
+  }
+  try {
+    const raw = await requestJson<
+      {
+        login?: string | null
+        full_name?: string | null
+        avatar_url?: string | null
+      }[]
+    >(repo, `/repos/${encodedRepoPath(repo)}/assignees`)
+    return (raw ?? [])
+      .filter((u) => u.login)
+      .map((u) => ({
+        username: u.login!,
+        name: u.full_name ?? null,
+        avatarUrl: u.avatar_url ?? ''
+      }))
+  } catch {
+    return []
+  }
+}

--- a/src/main/gitea/request.ts
+++ b/src/main/gitea/request.ts
@@ -1,0 +1,105 @@
+/* Shared REST transport for all Gitea/Forgejo operations — extracted from
+   client.ts so PR + issue code share identical auth without re-implementing
+   fetch/timeout/auth-header inline. Single source of truth. */
+import type { GiteaRepoRef } from './repository-ref'
+
+const REQUEST_TIMEOUT_MS = 5000
+
+export type GiteaAuthConfig = {
+  apiBaseUrl: string | null
+  token: string | null
+}
+
+export type RequestOptions = {
+  searchParams?: Record<string, string | number>
+  timeoutMs?: number
+  method?: string
+  body?: unknown
+}
+
+function envValue(name: string): string | null {
+  const value = process.env[name]?.trim() ?? ''
+  return value.length > 0 ? value : null
+}
+
+export function normalizeGiteaApiBaseUrl(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, '')
+  return /\/api\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/api/v1`
+}
+
+export function getAuthConfig(): GiteaAuthConfig {
+  const apiBaseUrl = envValue('ORCA_GITEA_API_BASE_URL')
+  return {
+    apiBaseUrl: apiBaseUrl ? normalizeGiteaApiBaseUrl(apiBaseUrl) : null,
+    token: envValue('ORCA_GITEA_TOKEN')
+  }
+}
+
+export function authHeaders(config: Pick<GiteaAuthConfig, 'token'>): Record<string, string> {
+  // Why: Gitea convention is "Authorization: token <token>" — NOT Bearer.
+  // Forgejo accepts the same header. Never use Bearer here.
+  return config.token ? { Authorization: `token ${config.token}` } : {}
+}
+
+export function configuredApiBaseUrl(repo: GiteaRepoRef): string {
+  return getAuthConfig().apiBaseUrl ?? repo.apiBaseUrl
+}
+
+function apiUrl(baseUrl: string, path: string, searchParams?: RequestOptions['searchParams']): URL {
+  const url = new URL(`${baseUrl.replace(/\/+$/, '')}${path}`)
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url
+}
+
+export async function requestJsonAtBase<T>(
+  baseUrl: string,
+  path: string,
+  options: RequestOptions = {}
+): Promise<T | null> {
+  const config = getAuthConfig()
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? REQUEST_TIMEOUT_MS)
+  try {
+    const fetchOptions: RequestInit = {
+      method: options.method ?? 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...authHeaders(config),
+        ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {})
+      },
+      signal: controller.signal
+    }
+    if (options.body !== undefined) {
+      fetchOptions.body = JSON.stringify(options.body)
+    }
+    const response = await fetch(apiUrl(baseUrl, path, options.searchParams), fetchOptions)
+    if (!response.ok) {
+      return null
+    }
+    // Why: some endpoints (e.g. DELETE) return 204 No Content — don't parse.
+    if (response.status === 204) {
+      return null
+    }
+    return (await response.json()) as T
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export function requestJson<T>(
+  repo: GiteaRepoRef,
+  path: string,
+  options: RequestOptions = {}
+): Promise<T | null> {
+  return requestJsonAtBase(configuredApiBaseUrl(repo), path, options)
+}
+
+export function encodedRepoPath(repo: GiteaRepoRef): string {
+  return `${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}`
+}

--- a/src/main/github/github-repository-identity.ts
+++ b/src/main/github/github-repository-identity.ts
@@ -210,6 +210,32 @@ export async function getOwnerRepo(
   return getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions)
 }
 
+/** Normalized git origin identity (`host/owner/repo`, lowercased) for ANY git
+ *  provider. Lets two checkouts of the same remote on different hosts group into
+ *  one project even without a GitHub provider identity. `parseGitHubRemoteIdentity`
+ *  is generic (host/owner/repo for any URL); only its GitHub-specific callers
+ *  filter to github.com. Returns null when there's no parseable origin remote. */
+export async function getOriginRemoteKey(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<string | null> {
+  try {
+    const context = githubRepoContext(repoPath, connectionId, localGitOptions)
+    const remoteUrl = await getRemoteUrlForRepo(context, 'origin')
+    if (!remoteUrl) {
+      return null
+    }
+    const identity = parseGitHubRemoteIdentity(remoteUrl)
+    if (!identity) {
+      return null
+    }
+    return `${identity.host}/${identity.owner}/${identity.repo}`.toLowerCase()
+  } catch {
+    return null
+  }
+}
+
 export async function getIssueOwnerRepo(
   repoPath: string,
   connectionId?: string | null,

--- a/src/main/ipc/gitea.ts
+++ b/src/main/ipc/gitea.ts
@@ -1,0 +1,163 @@
+/* Gitea/Forgejo IPC handlers — mirrors ipc/gitlab.ts EXACTLY for the
+   issue operations footprint (no MR/PR channels here — those are in the
+   existing gitea PR preflight path). */
+import { ipcMain } from 'electron'
+import { resolve } from 'path'
+import type { Repo } from '../../shared/types'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
+import type { TaskSourceContext } from '../../shared/task-source-context'
+import type { Store } from '../persistence'
+import {
+  getIssue,
+  listIssues,
+  createIssue,
+  updateIssue,
+  addIssueComment,
+  listLabels,
+  listAssignableUsers
+} from '../gitea/issues'
+import { getGiteaAuthStatus } from '../gitea/client'
+
+type GiteaRepoSelectorArgs = {
+  repoPath: string
+  repoId?: string | null
+  sourceContext?: TaskSourceContext | null
+}
+
+function findRegisteredGiteaRepo(args: GiteaRepoSelectorArgs, store: Store): Repo | undefined {
+  const sourceRepoId =
+    args.sourceContext?.provider === 'gitea' ? args.sourceContext.repoId?.trim() : null
+  const repoId = args.repoId?.trim() || sourceRepoId || null
+  if (repoId) {
+    const repo = store.getRepo(repoId)
+    if (repo) {
+      return repo
+    }
+  }
+  const resolvedRepoPath = resolve(args.repoPath)
+  return store.getRepos().find((r) => resolve(r.path) === resolvedRepoPath)
+}
+
+// Why: mirror github.ts/gitlab.ts assertRegisteredRepo — main-process
+// handlers must never operate on a path the user hasn't explicitly
+// registered as a repo (filesystem-auth boundary). Source context adds a
+// host check so a task fetched from one machine cannot mutate a same-path
+// repo on another (gotcha #5 in blueprint).
+function assertRegisteredRepo(args: GiteaRepoSelectorArgs, store: Store): Repo {
+  const repo = findRegisteredGiteaRepo(args, store)
+  if (!repo) {
+    throw new Error('Access denied: unknown repository path')
+  }
+  if (
+    args.sourceContext?.provider === 'gitea' &&
+    args.sourceContext.hostId !== getRepoExecutionHostId(repo)
+  ) {
+    throw new Error('Access denied: Gitea source host does not match repository host')
+  }
+  return repo
+}
+
+function repoConnectionId(repo: Repo): string | null {
+  return repo.connectionId ?? null
+}
+
+export function registerGiteaHandlers(store: Store): void {
+  ipcMain.handle('gitea:authStatus', async () => getGiteaAuthStatus())
+
+  ipcMain.handle(
+    'gitea:issue',
+    async (_event, args: GiteaRepoSelectorArgs & { number: number }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return getIssue(repo.path, args.number, repoConnectionId(repo))
+    }
+  )
+
+  ipcMain.handle(
+    'gitea:listIssues',
+    async (
+      _event,
+      args: GiteaRepoSelectorArgs & {
+        state?: 'open' | 'closed' | 'all'
+        assignee?: string
+        limit?: number
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      const limit = Math.max(
+        1,
+        Math.min(100, args.limit && isFinite(args.limit) ? Math.round(args.limit) : 20)
+      )
+      const state = args.state === 'closed' || args.state === 'all' ? args.state : 'open'
+      const result = await listIssues(
+        repo.path,
+        limit,
+        state,
+        args.assignee,
+        repoConnectionId(repo)
+      )
+      // Why: map GiteaIssueInfo → row shape the renderer expects. Mirror
+      // the GitLab handler's id/type fields so TaskPage can render with
+      // the same row component.
+      const items = result.items.map((issue) => ({
+        id: `gitea-issue-${repo.id}-${issue.number}`,
+        type: 'issue' as const,
+        number: issue.number,
+        title: issue.title,
+        state: issue.state === 'open' ? ('opened' as const) : ('closed' as const),
+        url: issue.url,
+        labels: issue.labels,
+        updatedAt: issue.updatedAt ?? '',
+        author: issue.author ?? null,
+        repoId: repo.id
+      }))
+      return { items, ...(result.error ? { error: result.error } : {}) }
+    }
+  )
+
+  ipcMain.handle(
+    'gitea:createIssue',
+    async (_event, args: GiteaRepoSelectorArgs & { title: string; body: string }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return createIssue(repo.path, args.title, args.body, repoConnectionId(repo))
+    }
+  )
+
+  ipcMain.handle(
+    'gitea:updateIssue',
+    async (
+      _event,
+      args: GiteaRepoSelectorArgs & {
+        number: number
+        updates: {
+          state?: 'open' | 'closed'
+          title?: string
+          body?: string
+          addLabels?: string[]
+          removeLabels?: string[]
+          assignees?: string[]
+        }
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return updateIssue(repo.path, args.number, args.updates, repoConnectionId(repo))
+    }
+  )
+
+  ipcMain.handle(
+    'gitea:addIssueComment',
+    async (_event, args: GiteaRepoSelectorArgs & { number: number; body: string }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return addIssueComment(repo.path, args.number, args.body, repoConnectionId(repo))
+    }
+  )
+
+  ipcMain.handle('gitea:listLabels', async (_event, args: GiteaRepoSelectorArgs) => {
+    const repo = assertRegisteredRepo(args, store)
+    return listLabels(repo.path, repoConnectionId(repo))
+  })
+
+  ipcMain.handle('gitea:listAssignableUsers', async (_event, args: GiteaRepoSelectorArgs) => {
+    const repo = assertRegisteredRepo(args, store)
+    return listAssignableUsers(repo.path, repoConnectionId(repo))
+  })
+}

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -12,6 +12,7 @@ import { registerCodexUsageHandlers } from './codex-usage'
 import { registerOpenCodeUsageHandlers } from './opencode-usage'
 import { registerGitHubHandlers } from './github'
 import { registerGitLabHandlers } from './gitlab'
+import { registerGiteaHandlers } from './gitea'
 import { registerHostedReviewHandlers } from './hosted-review'
 import { registerLinearHandlers } from './linear'
 import { registerJiraHandlers } from './jira'
@@ -111,6 +112,7 @@ export function registerCoreHandlers(
   registerRateLimitHandlers(rateLimits)
   registerGitHubHandlers(store, stats)
   registerGitLabHandlers(store)
+  registerGiteaHandlers(store)
   registerHostedReviewHandlers(store, stats)
   registerLinearHandlers()
   registerJiraHandlers()

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -751,7 +751,7 @@ const ProjectHostSetupDeleteIpcArgs = z.object({
 
 const FolderWorkspaceLinkedTaskArgs = z
   .object({
-    provider: z.enum(['github', 'gitlab', 'linear', 'jira']),
+    provider: z.enum(['github', 'gitlab', 'linear', 'jira', 'gitea']),
     type: z.enum(['issue', 'pr', 'mr']),
     number: z.number().finite(),
     title: z.string().min(1),

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -81,7 +81,11 @@ import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 import type { RepoMethod } from '../../shared/telemetry-events'
 import { detectRepoIconAndUpstream } from '../repo-icon-autodetect'
-import { getProjectHostSetupForRepo } from '../../shared/project-host-setup-projection'
+import {
+  getProjectHostSetupForRepo,
+  getProjectIdentityKey
+} from '../../shared/project-host-setup-projection'
+import { getOriginRemoteKey } from '../github/github-repository-identity'
 import { normalizeExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
 import { joinRemotePath } from '../ssh/ssh-remote-platform'
 import {
@@ -141,7 +145,10 @@ function alignRepoWithRequestedProject(
   setupMethod: ProjectHostSetupExistingFolderArgs['setupMethod'] = 'imported-existing-folder'
 ): ProjectHostSetupResult {
   let setup = getProjectHostSetupForRepo(store.getProjectHostSetups(), repo)
-  if (setup.projectId !== projectId) {
+  // Why: skip the upstream stamp when the imported folder's identity already
+  // matches the requested project — non-GitHub repos group by origin remote, so
+  // only a genuine identity mismatch needs the GitHub stamp.
+  if (setup.projectId !== projectId && getProjectIdentityKey(repo) !== projectId) {
     const project = store.getProjects().find((entry) => entry.id === projectId)
     if (!project?.providerIdentity || project.providerIdentity.provider !== 'github') {
       throw new Error('Imported folder does not match the selected project identity.')
@@ -190,12 +197,14 @@ async function addLocalRepoFromPath(
   }
 
   const detected = await detectRepoIconAndUpstream({ repoPath: path, kind: repoKind })
+  const originRemoteKey = repoKind === 'git' ? await getOriginRemoteKey(path, null) : null
   const repo: Repo = {
     id: randomUUID(),
     path,
     displayName: getRepoName(path),
     badgeColor: DEFAULT_REPO_BADGE_COLOR,
     ...detected,
+    ...(originRemoteKey ? { originRemoteKey } : {}),
     addedAt: Date.now(),
     kind: repoKind,
     ...(repoKind === 'git'
@@ -289,12 +298,15 @@ async function addRemoteRepoFromPath(
     kind: repoKind,
     connectionId: args.connectionId
   })
+  const originRemoteKey =
+    repoKind === 'git' ? await getOriginRemoteKey(resolvedPath, args.connectionId) : null
   const repo: Repo = {
     id: randomUUID(),
     path: resolvedPath,
     displayName,
     badgeColor: DEFAULT_REPO_BADGE_COLOR,
     ...detected,
+    ...(originRemoteKey ? { originRemoteKey } : {}),
     addedAt: Date.now(),
     kind: repoKind,
     connectionId: args.connectionId,
@@ -1089,7 +1101,32 @@ async function runNestedRepoScanForIpc(
   }
 }
 
+/** One-shot enrichment: repos predating `originRemoteKey` get it computed so
+ *  non-GitHub checkouts can group across hosts (see getProjectIdentityKey).
+ *  Best-effort + fire-and-forget; `null` is stored too so remote-less repos are
+ *  not re-probed every launch. */
+async function backfillOriginRemoteKeys(mainWindow: BrowserWindow, store: Store): Promise<void> {
+  const pending = store
+    .getRepos()
+    .filter((repo) => repo.kind !== 'folder' && repo.originRemoteKey === undefined)
+  if (pending.length === 0) {
+    return
+  }
+  let changed = false
+  for (const repo of pending) {
+    const originRemoteKey = await getOriginRemoteKey(repo.path, repo.connectionId ?? null)
+    if (store.updateRepo(repo.id, { originRemoteKey })) {
+      changed = true
+    }
+  }
+  if (changed) {
+    invalidateAuthorizedRootsCache()
+    notifyReposChanged(mainWindow)
+  }
+}
+
 export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): void {
+  void backfillOriginRemoteKeys(mainWindow, store)
   // Remove any previously registered handlers so we can re-register them
   // (e.g. when macOS re-activates the app and creates a new window).
   ipcMain.removeHandler('repos:list')
@@ -1223,11 +1260,10 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
       if (!parsedHost) {
         throw new Error(`Unsupported host: ${args.hostId}`)
       }
-      const existingProject = store.getProjects().find((project) => project.id === args.projectId)
-      if (!existingProject) {
-        throw new Error(`Project not found: ${args.projectId}`)
-      }
-
+      // Why: a project created on another runtime (e.g. an SSH host) is not in
+      // the local store, but the user explicitly chose it to add this host. Allow
+      // proceeding — the imported folder joins the project by its origin-remote
+      // identity (see alignRepoWithRequestedProject / getProjectIdentityKey).
       const result =
         parsedHost.kind === 'local'
           ? await addLocalRepoFromPath(store, args.path, args.kind)

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1096,6 +1096,7 @@ function sanitizeRepoUpdatesForPersistence<
       | 'worktreeBasePath'
       | 'projectHostSetupMethod'
       | 'forkSyncMode'
+      | 'originRemoteKey'
     >
   >
 >(updates: T): T {
@@ -3690,6 +3691,7 @@ export class Store {
         | 'projectGroupId'
         | 'projectGroupOrder'
         | 'projectHostSetupMethod'
+        | 'originRemoteKey'
       >
     > & { sourceControlAi?: Repo['sourceControlAi'] | null }
   ): Repo | null {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -138,7 +138,8 @@ import {
 } from '../../shared/worktree-id'
 import {
   getProjectHostSetupForRepo,
-  getProjectHostSetupWorktreeMeta
+  getProjectHostSetupWorktreeMeta,
+  getProjectIdentityKey
 } from '../../shared/project-host-setup-projection'
 import { parsePtySessionId } from '../../shared/pty-session-id-format'
 import { clampLinearIssueListLimit } from '../../shared/linear-issue-read-limits'
@@ -7372,16 +7373,14 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
     const existingProject = this.listProjects().find((project) => project.id === args.projectId)
-    if (!existingProject) {
-      throw new Error(`Project not found: ${args.projectId}`)
-    }
+    // Why: project may originate on a peer runtime and not be in this store yet;
+    // the explicit add joins it by origin-remote identity (see getProjectIdentityKey).
     let repo = await this.addRepo(args.path, args.kind === 'folder' ? 'folder' : 'git')
     let setup = getProjectHostSetupForRepo(this.listProjectHostSetups(), repo)
-    if (setup.projectId !== args.projectId) {
-      if (
-        !existingProject.providerIdentity ||
-        existingProject.providerIdentity.provider !== 'github'
-      ) {
+    // Why: skip the upstream stamp when the imported folder's identity already
+    // matches the requested project (non-GitHub repos group by origin remote).
+    if (setup.projectId !== args.projectId && getProjectIdentityKey(repo) !== args.projectId) {
+      if (!existingProject?.providerIdentity || existingProject.providerIdentity.provider !== 'github') {
         throw new Error('Imported folder does not match the selected project identity.')
       }
       const updated = this.store.updateRepo(repo.id, {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -338,6 +338,16 @@ import {
   updateIssue as updateGitLabIssue
 } from '../gitlab/client'
 import { getGlabKnownHosts } from '../gitlab/gl-utils'
+import {
+  getIssue as getGiteaIssue,
+  listIssues as listGiteaIssues,
+  createIssue as createGiteaIssue,
+  updateIssue as updateGiteaIssue,
+  addIssueComment as addGiteaIssueComment,
+  listLabels as listGiteaLabels,
+  listAssignableUsers as listGiteaAssignableUsers
+} from '../gitea/issues'
+import { getGiteaAuthStatus } from '../gitea/client'
 import { getWorkItemDetails as getGitLabWorkItemDetails } from '../gitlab/work-item-details'
 import {
   normalizeGitLabIssueListArgs,
@@ -7380,7 +7390,10 @@ export class OrcaRuntimeService {
     // Why: skip the upstream stamp when the imported folder's identity already
     // matches the requested project (non-GitHub repos group by origin remote).
     if (setup.projectId !== args.projectId && getProjectIdentityKey(repo) !== args.projectId) {
-      if (!existingProject?.providerIdentity || existingProject.providerIdentity.provider !== 'github') {
+      if (
+        !existingProject?.providerIdentity ||
+        existingProject.providerIdentity.provider !== 'github'
+      ) {
         throw new Error('Imported folder does not match the selected project identity.')
       }
       const updated = this.store.updateRepo(repo.id, {
@@ -8843,6 +8856,83 @@ export class OrcaRuntimeService {
       projectRef,
       ...this.getLocalGitExecutionOptionArgs(repo)
     )
+  }
+
+  async giteaAuthStatus(): Promise<Awaited<ReturnType<typeof getGiteaAuthStatus>>> {
+    return getGiteaAuthStatus()
+  }
+
+  async getGiteaRepoIssue(repoSelector: string, issueNumber: number) {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    return getGiteaIssue(repo.path, issueNumber, repo.connectionId ?? null)
+  }
+
+  async listGiteaRepoIssues(
+    repoSelector: string,
+    state?: 'open' | 'closed' | 'all',
+    assignee?: string,
+    limit?: number
+  ): Promise<{
+    items: GitLabWorkItem[]
+    error?: Awaited<ReturnType<typeof listGiteaIssues>>['error']
+  }> {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    const normalizedLimit =
+      typeof limit === 'number' && isFinite(limit)
+        ? Math.max(1, Math.min(100, Math.round(limit)))
+        : 20
+    const normalizedState = state === 'closed' || state === 'all' ? state : 'open'
+    const result = await listGiteaIssues(
+      repo.path,
+      normalizedLimit,
+      normalizedState,
+      assignee,
+      repo.connectionId ?? null
+    )
+    // Why: Gitea issue rows share the GitLabWorkItem shape so the renderer's
+    // repo-backed (github/gitlab) branch renders them with the same row.
+    const items: GitLabWorkItem[] = result.items.map((issue) => ({
+      id: `gitea-issue-${repo.id}-${issue.number}`,
+      type: 'issue' as const,
+      number: issue.number,
+      title: issue.title,
+      state: issue.state === 'open' ? ('opened' as const) : ('closed' as const),
+      url: issue.url,
+      labels: issue.labels,
+      updatedAt: issue.updatedAt ?? '',
+      author: issue.author ?? null,
+      repoId: repo.id
+    }))
+    return { items, ...(result.error ? { error: result.error } : {}) }
+  }
+
+  async createGiteaRepoIssue(repoSelector: string, title: string, body: string) {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    return createGiteaIssue(repo.path, title, body, repo.connectionId ?? null)
+  }
+
+  async updateGiteaRepoIssue(
+    repoSelector: string,
+    issueNumber: number,
+    updates: Parameters<typeof updateGiteaIssue>[2]
+  ) {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    return updateGiteaIssue(repo.path, issueNumber, updates, repo.connectionId ?? null)
+  }
+
+  async addGiteaRepoIssueComment(repoSelector: string, issueNumber: number, body: string) {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    return addGiteaIssueComment(repo.path, issueNumber, body, repo.connectionId ?? null)
+  }
+
+  async listGiteaRepoLabels(repoSelector: string) {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    return listGiteaLabels(repo.path, repo.connectionId ?? null)
+  }
+
+  async listGiteaRepoAssignableUsers(repoSelector: string) {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    return listGiteaAssignableUsers(repo.path, repo.connectionId ?? null)
   }
 
   async addGitLabRepoMRComment(
@@ -14226,8 +14316,7 @@ export class OrcaRuntimeService {
       } catch {
         warnings.push({
           code: 'LINEAGE_PARENT_CONTEXT_MISSING',
-          message:
-            'Worktree created, but Orca could not validate the environment parent context.',
+          message: 'Worktree created, but Orca could not validate the environment parent context.',
           details: { envParentWorkspace: input.envParentWorkspace }
         })
       }

--- a/src/main/runtime/rpc/methods/automations.ts
+++ b/src/main/runtime/rpc/methods/automations.ts
@@ -59,7 +59,7 @@ const TaskProviderIdentity = z
       value !== null &&
       typeof value === 'object' &&
       'provider' in value &&
-      ['github', 'gitlab', 'linear', 'jira'].includes(String(value.provider))
+      ['github', 'gitlab', 'linear', 'jira', 'gitea'].includes(String(value.provider))
   )
   .optional()
   .nullable()
@@ -67,7 +67,7 @@ const TaskProviderIdentity = z
 const TaskSourceContext = z
   .object({
     kind: z.literal('task-source'),
-    provider: z.enum(['github', 'gitlab', 'linear', 'jira']),
+    provider: z.enum(['github', 'gitlab', 'linear', 'jira', 'gitea']),
     projectId: requiredString('Missing source project id'),
     hostId: ExecutionHostId,
     projectHostSetupId: OptionalNullablePlainString,

--- a/src/main/runtime/rpc/methods/folder-workspace.ts
+++ b/src/main/runtime/rpc/methods/folder-workspace.ts
@@ -5,7 +5,7 @@ import { isTuiAgent } from '../../../../shared/tui-agent-config'
 
 const FolderWorkspaceLinkedTask = z
   .object({
-    provider: z.enum(['github', 'gitlab', 'linear', 'jira']),
+    provider: z.enum(['github', 'gitlab', 'linear', 'jira', 'gitea']),
     type: z.enum(['issue', 'pr', 'mr']),
     number: z.number().finite(),
     title: requiredString('Missing linked task title'),

--- a/src/main/runtime/rpc/methods/gitea.ts
+++ b/src/main/runtime/rpc/methods/gitea.ts
@@ -1,0 +1,87 @@
+/* Gitea/Forgejo RPC methods — mirrors methods/gitlab.ts footprint for
+   the issue operations. No MR/PR methods here (handled by the existing
+   gitea PR preflight path). */
+import { z } from 'zod'
+import { defineMethod, type RpcMethod } from '../core'
+import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
+
+const RepoSelector = z.object({
+  repo: requiredString('Missing repo selector')
+})
+
+const IssuesList = RepoSelector.extend({
+  state: z.enum(['open', 'closed', 'all']).optional(),
+  assignee: OptionalString,
+  limit: OptionalFiniteNumber
+})
+
+const CreateIssue = RepoSelector.extend({
+  title: requiredString('Missing title'),
+  body: z.string()
+})
+
+const IssueUpdate = z.object({
+  state: z.enum(['open', 'closed']).optional(),
+  title: z.string().optional(),
+  body: z.string().optional(),
+  addLabels: z.array(z.string()).optional(),
+  removeLabels: z.array(z.string()).optional(),
+  assignees: z.array(z.string()).optional()
+})
+
+const UpdateIssue = RepoSelector.extend({
+  number: z.number().int().positive(),
+  updates: IssueUpdate
+})
+
+const AddIssueComment = RepoSelector.extend({
+  number: z.number().int().positive(),
+  body: requiredString('Comment body is required')
+})
+
+export const GITEA_METHODS: RpcMethod[] = [
+  defineMethod({
+    name: 'gitea.authStatus',
+    params: z.object({}).optional().default({}),
+    handler: async (_params, { runtime }) => runtime.giteaAuthStatus()
+  }),
+  defineMethod({
+    name: 'gitea.issue',
+    params: RepoSelector.extend({ number: z.number().int().positive() }),
+    handler: async (params, { runtime }) => runtime.getGiteaRepoIssue(params.repo, params.number)
+  }),
+  defineMethod({
+    name: 'gitea.listIssues',
+    params: IssuesList,
+    handler: async (params, { runtime }) =>
+      runtime.listGiteaRepoIssues(params.repo, params.state, params.assignee, params.limit)
+  }),
+  defineMethod({
+    name: 'gitea.createIssue',
+    params: CreateIssue,
+    handler: async (params, { runtime }) =>
+      runtime.createGiteaRepoIssue(params.repo, params.title, params.body)
+  }),
+  defineMethod({
+    name: 'gitea.updateIssue',
+    params: UpdateIssue,
+    handler: async (params, { runtime }) =>
+      runtime.updateGiteaRepoIssue(params.repo, params.number, params.updates)
+  }),
+  defineMethod({
+    name: 'gitea.addIssueComment',
+    params: AddIssueComment,
+    handler: async (params, { runtime }) =>
+      runtime.addGiteaRepoIssueComment(params.repo, params.number, params.body)
+  }),
+  defineMethod({
+    name: 'gitea.listLabels',
+    params: RepoSelector,
+    handler: async (params, { runtime }) => runtime.listGiteaRepoLabels(params.repo)
+  }),
+  defineMethod({
+    name: 'gitea.listAssignableUsers',
+    params: RepoSelector,
+    handler: async (params, { runtime }) => runtime.listGiteaRepoAssignableUsers(params.repo)
+  })
+]

--- a/src/main/runtime/rpc/methods/index.ts
+++ b/src/main/runtime/rpc/methods/index.ts
@@ -19,6 +19,7 @@ import { FILE_METHODS } from './files'
 import { GIT_METHODS } from './git'
 import { GITHUB_METHODS } from './github'
 import { GITLAB_METHODS } from './gitlab'
+import { GITEA_METHODS } from './gitea'
 import { HOSTED_REVIEW_METHODS } from './hosted-review'
 import { LINEAR_METHODS } from './linear'
 import { LINEAR_AGENT_ACCESS_METHODS } from './linear-agent-access'
@@ -57,6 +58,7 @@ export const ALL_RPC_METHODS: readonly RpcAnyMethod[] = [
   ...GIT_METHODS,
   ...GITHUB_METHODS,
   ...GITLAB_METHODS,
+  ...GITEA_METHODS,
   ...HOSTED_REVIEW_METHODS,
   ...LINEAR_METHODS,
   ...LINEAR_AGENT_ACCESS_METHODS,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1424,6 +1424,38 @@ export type PreloadApi = {
   // Shapes mirror gh.* one-to-one where the data matches; diverge
   // where GitLab's API differs (MR state values, project path with
   // host, paginated envelope from `glab api -i`).
+  gt: {
+    authStatus: () => Promise<unknown>
+    issue: (args: GitLabRepoSelectorArgs & { number: number }) => Promise<unknown>
+    listIssues: (
+      args: GitLabRepoSelectorArgs & {
+        state?: 'open' | 'closed' | 'all'
+        assignee?: string
+        limit?: number
+      }
+    ) => Promise<{ items: unknown[]; error?: unknown }>
+    createIssue: (
+      args: GitLabRepoSelectorArgs & { title: string; body: string }
+    ) => Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }>
+    updateIssue: (
+      args: GitLabRepoSelectorArgs & {
+        number: number
+        updates: {
+          state?: 'open' | 'closed'
+          title?: string
+          body?: string
+          addLabels?: string[]
+          removeLabels?: string[]
+          assignees?: string[]
+        }
+      }
+    ) => Promise<{ ok: true } | { ok: false; error: string }>
+    addIssueComment: (
+      args: GitLabRepoSelectorArgs & { number: number; body: string }
+    ) => Promise<unknown>
+    listLabels: (args: GitLabRepoSelectorArgs) => Promise<string[]>
+    listAssignableUsers: (args: GitLabRepoSelectorArgs) => Promise<unknown[]>
+  }
   gl: {
     viewer: () => Promise<GitLabViewer | null>
     diagnoseAuth: () => Promise<GitLabAuthDiagnostic>

--- a/src/preload/gitea.ts
+++ b/src/preload/gitea.ts
@@ -1,0 +1,60 @@
+/* Gitea/Forgejo preload bindings — split out of `src/preload/index.ts`
+   mirroring preload/gitlab.ts so adding or changing a `gt.*` channel
+   doesn't create merge conflicts on the large central preload file.
+   Composed back into `api.gt` from `index.ts`. */
+import { ipcRenderer } from 'electron'
+import type { TaskSourceContext } from '../shared/task-source-context'
+
+type GiteaRepoSelectorArgs = {
+  repoPath: string
+  repoId?: string | null
+  sourceContext?: TaskSourceContext | null
+}
+
+export const gtApi = {
+  authStatus: (): Promise<unknown> => ipcRenderer.invoke('gitea:authStatus'),
+
+  issue: (args: GiteaRepoSelectorArgs & { number: number }): Promise<unknown> =>
+    ipcRenderer.invoke('gitea:issue', args),
+
+  listIssues: (
+    args: GiteaRepoSelectorArgs & {
+      state?: 'open' | 'closed' | 'all'
+      assignee?: string
+      limit?: number
+    }
+  ): Promise<{ items: unknown[]; error?: unknown }> => ipcRenderer.invoke('gitea:listIssues', args),
+
+  createIssue: (
+    args: GiteaRepoSelectorArgs & {
+      title: string
+      body: string
+    }
+  ): Promise<{ ok: true; number: number; url: string } | { ok: false; error: string }> =>
+    ipcRenderer.invoke('gitea:createIssue', args),
+
+  updateIssue: (
+    args: GiteaRepoSelectorArgs & {
+      number: number
+      updates: {
+        state?: 'open' | 'closed'
+        title?: string
+        body?: string
+        addLabels?: string[]
+        removeLabels?: string[]
+        assignees?: string[]
+      }
+    }
+  ): Promise<{ ok: true } | { ok: false; error: string }> =>
+    ipcRenderer.invoke('gitea:updateIssue', args),
+
+  addIssueComment: (
+    args: GiteaRepoSelectorArgs & { number: number; body: string }
+  ): Promise<unknown> => ipcRenderer.invoke('gitea:addIssueComment', args),
+
+  listLabels: (args: GiteaRepoSelectorArgs): Promise<string[]> =>
+    ipcRenderer.invoke('gitea:listLabels', args),
+
+  listAssignableUsers: (args: GiteaRepoSelectorArgs): Promise<unknown[]> =>
+    ipcRenderer.invoke('gitea:listAssignableUsers', args)
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,6 +5,7 @@ import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
+import { gtApi } from './gitea'
 import type { AppIdentity } from '../shared/app-identity'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
@@ -1300,6 +1301,8 @@ const api = {
   // `gl.*` channel doesn't surface as a merge conflict on every
   // upstream sync of this central preload file.
   gl: glApi,
+
+  gt: gtApi,
 
   linear: {
     connect: (args: {

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -341,7 +341,7 @@ function getJiraIssueWorkspaceSeed(issue: JiraIssue): string {
 
 function getTaskPageRepoSourceContext(
   repo: Repo | null | undefined,
-  provider: 'github' | 'gitlab',
+  provider: 'github' | 'gitlab' | 'gitea',
   gitlabProjectRef?: GitLabProjectRef | null
 ): TaskSourceContext | null {
   if (!repo) {
@@ -2952,7 +2952,7 @@ export default function TaskPage(): React.JSX.Element {
   )
   const taskSourceRepoContexts = useMemo(
     () =>
-      taskSource === 'github' || taskSource === 'gitlab'
+      taskSource === 'github' || taskSource === 'gitlab' || taskSource === 'gitea'
         ? selectedRepos
             .map((repo) => getTaskPageRepoSourceContext(repo, taskSource))
             .filter((context): context is TaskSourceContext => context !== null)
@@ -2986,7 +2986,7 @@ export default function TaskPage(): React.JSX.Element {
     [hostRegistryById]
   )
   const runtimeTaskSourceHostIds = useMemo(() => {
-    if (taskSource !== 'github' && taskSource !== 'gitlab') {
+    if (taskSource !== 'github' && taskSource !== 'gitlab' && taskSource !== 'gitea') {
       return []
     }
     const hostIds = new Set<TaskSourceContext['hostId']>()
@@ -3059,7 +3059,8 @@ export default function TaskPage(): React.JSX.Element {
   }, [runtimeTaskSourceHostIds])
   const getTaskPickerRepoHostLabel = useCallback(
     (repo: Repo): string | null => {
-      const provider = taskSource === 'gitlab' ? 'gitlab' : 'github'
+      const provider =
+        taskSource === 'gitlab' ? 'gitlab' : taskSource === 'gitea' ? 'gitea' : 'github'
       const context = getTaskPageRepoSourceContext(repo, provider)
       const hostId = context?.hostId ?? repo.executionHostId ?? 'local'
       return hostRegistryById.get(hostId)?.label ?? null
@@ -3067,7 +3068,7 @@ export default function TaskPage(): React.JSX.Element {
     [hostRegistryById, taskSource]
   )
   const taskSourceHostAvailability = useMemo<TaskSourceHostAvailability[]>(() => {
-    if (taskSource !== 'github' && taskSource !== 'gitlab') {
+    if (taskSource !== 'github' && taskSource !== 'gitlab' && taskSource !== 'gitea') {
       return []
     }
     return [
@@ -3355,6 +3356,12 @@ export default function TaskPage(): React.JSX.Element {
   const [gitlabLoading, setGitlabLoading] = useState(false)
   const [gitlabError, setGitlabError] = useState<string | null>(null)
   const [gitlabRefreshNonce, setGitlabRefreshNonce] = useState(0)
+  // Gitea (Forgejo) — issues-only, repo-backed task source. Rows share the
+  // GitLabWorkItem shape so the repo-backed list renders them with the
+  // shared row component.
+  const [giteaItems, setGiteaItems] = useState<GitLabWorkItem[]>([])
+  const [giteaLoading, setGiteaLoading] = useState(false)
+  const [giteaError, setGiteaError] = useState<string | null>(null)
   // Why: opens GitLabItemDialog when a row is clicked. Separate state from
   // gitlabItems so the dialog target survives a list refresh that might
   // remove the item from the visible filter (e.g. closing an MR while
@@ -4522,6 +4529,83 @@ export default function TaskPage(): React.JSX.Element {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedReposKey encodes the only selectedRepos fields read above; keying off the array ref would re-run on every parent render.
   }, [taskSource, gitlabView, activeGitlabFilter, gitlabRefreshNonce, selectedReposKey])
+
+  // Why: Gitea (Forgejo) issue list — issues-only, repo-backed, fetched via
+  // window.api.gt.listIssues. Mirrors the GitLab issues fetch but without
+  // MRs/todos/views. Rows are GitLabWorkItem-shaped so the shared repo-backed
+  // row renders them.
+  useEffect(() => {
+    if (taskSource !== 'gitea') {
+      return
+    }
+    const eligibleRepos = selectedRepos
+    if (eligibleRepos.length === 0) {
+      setGiteaItems([])
+      setGiteaLoading(false)
+      setGiteaError(null)
+      return
+    }
+    let stale = false
+    setGiteaLoading(true)
+    setGiteaError(null)
+    void Promise.allSettled(
+      eligibleRepos.map((repo) =>
+        window.api.gt
+          .listIssues({
+            repoPath: repo.path,
+            repoId: repo.id,
+            sourceContext: getTaskPageRepoSourceContext(repo, 'gitea'),
+            state: 'open',
+            limit: 50
+          })
+          .then((result) => {
+            const typed = result as {
+              items: GitLabWorkItem[]
+              error?: { kind?: string; message: string }
+            }
+            // Why: not_found just means "this repo isn't a Gitea/Forgejo
+            // remote" (e.g. a GitHub-only repo in a mixed selection). Drop it
+            // silently so the list doesn't show false errors.
+            const error = typed.error?.kind === 'not_found' ? undefined : typed.error
+            return { repoId: repo.id, items: typed.items, error }
+          })
+      )
+    )
+      .then((results) => {
+        if (stale) {
+          return
+        }
+        const merged: GitLabWorkItem[] = []
+        const errs: string[] = []
+        for (const r of results) {
+          if (r.status !== 'fulfilled') {
+            errs.push(r.reason instanceof Error ? r.reason.message : String(r.reason))
+            continue
+          }
+          for (const item of r.value.items) {
+            merged.push({ ...item, repoId: r.value.repoId })
+          }
+          if (r.value.error) {
+            errs.push(r.value.error.message)
+          }
+        }
+        merged.sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''))
+        setGiteaItems(merged)
+        // Why: only surface an error banner when EVERY eligible repo failed.
+        if (errs.length > 0 && merged.length === 0) {
+          setGiteaError(errs[0])
+        }
+      })
+      .finally(() => {
+        if (!stale) {
+          setGiteaLoading(false)
+        }
+      })
+    return () => {
+      stale = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedReposKey encodes the selectedRepos fields read above.
+  }, [taskSource, selectedReposKey])
 
   // Why: Todos fetch lives in its own effect — different trigger
   // condition from the project view (no chip filter dependence) and a
@@ -9336,6 +9420,130 @@ export default function TaskPage(): React.JSX.Element {
                           aria-label={translate(
                             'auto.components.TaskPage.bcdc1330b2',
                             'Open in GitLab'
+                          )}
+                          className="text-muted-foreground hover:text-foreground"
+                        >
+                          <ExternalLink className="size-3.5" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : taskSource === 'gitea' ? (
+            <div className="flex min-h-0 max-h-full flex-col rounded-md border border-t-0 border-border/50 bg-muted/50 overflow-hidden rounded-t-none shadow-sm">
+              <div className="flex-none grid grid-cols-[80px_minmax(0,3fr)_120px_110px_50px] gap-3 border-b border-border/50 px-3 py-2 text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                <span>{translate('auto.components.TaskPage.eb10c32872', 'ID')}</span>
+                <span>{translate('auto.components.TaskPage.16cba35bee', 'Title')}</span>
+                <span>{translate('auto.components.TaskPage.00b7ffb952', 'Type / State')}</span>
+                <span>{translate('auto.components.TaskPage.f362667d55', 'Updated')}</span>
+                <span />
+              </div>
+              <div
+                className="min-h-0 flex-initial overflow-y-auto scrollbar-sleek"
+                style={{ scrollbarGutter: 'stable' }}
+              >
+                {giteaError ? (
+                  <div className="border-b border-border px-4 py-4 text-sm text-destructive">
+                    {giteaError}
+                  </div>
+                ) : null}
+                {giteaLoading && giteaItems.length === 0 ? (
+                  <div className="divide-y divide-border/50">
+                    {Array.from({ length: 12 }).map((_, i) => (
+                      <div
+                        key={i}
+                        className="grid w-full gap-3 px-3 py-2 grid-cols-[80px_minmax(0,3fr)_120px_110px_50px]"
+                      >
+                        <div className="h-4 w-16 animate-pulse rounded bg-muted/70" />
+                        <div>
+                          <div className="h-4 w-3/5 animate-pulse rounded bg-muted/70" />
+                        </div>
+                        <div className="h-3 w-20 animate-pulse rounded bg-muted/60" />
+                        <div className="h-3 w-20 animate-pulse rounded bg-muted/60" />
+                        <div />
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+                {!giteaLoading && giteaItems.length === 0 && !giteaError ? (
+                  <div className="px-4 py-12 text-center">
+                    <p className="text-base font-medium text-foreground">
+                      {translate(
+                        'auto.components.TaskPage.gitea_empty_title',
+                        'No open Gitea issues'
+                      )}
+                    </p>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {translate(
+                        'auto.components.TaskPage.gitea_empty_desc',
+                        'Select a repo backed by a Gitea/Forgejo remote, or open a new issue on the forge.'
+                      )}
+                    </p>
+                  </div>
+                ) : null}
+                <div className="divide-y divide-border/50">
+                  {giteaItems.map((item) => (
+                    <div
+                      role="button"
+                      tabIndex={0}
+                      key={item.id}
+                      onClick={() => {
+                        useAppStore.getState().recordFeatureInteraction('gitlab-tasks')
+                        void window.api.shell.openUrl(item.url)
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          void window.api.shell.openUrl(item.url)
+                        }
+                      }}
+                      className="grid w-full cursor-pointer gap-3 px-3 py-2 text-left grid-cols-[80px_minmax(0,3fr)_120px_110px_50px] hover:bg-muted/50"
+                    >
+                      <span className="font-mono text-xs text-muted-foreground">
+                        #{item.number}
+                      </span>
+                      <span className="min-w-0 truncate text-sm">{item.title}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {translate('auto.components.TaskPage.b1eaa18ace', 'Issue')} · {item.state}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {item.updatedAt ? new Date(item.updatedAt).toLocaleDateString() : ''}
+                      </span>
+                      <div className="flex items-center justify-end gap-1">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon-xs"
+                              data-contextual-tour-target="tasks-start-workspace"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                handleUseGitLabItem(item)
+                              }}
+                              aria-label={translate(
+                                'auto.components.TaskPage.5e8061b088',
+                                'Start workspace from {{value0}} {{value1}}',
+                                { value0: 'issue', value1: item.number }
+                              )}
+                            >
+                              <ArrowRight className="size-3.5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            {translate('auto.components.TaskPage.9497f2787c', 'Start workspace')}
+                          </TooltipContent>
+                        </Tooltip>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            void window.api.shell.openUrl(item.url)
+                          }}
+                          aria-label={translate(
+                            'auto.components.TaskPage.gitea_open_in',
+                            'Open in Gitea'
                           )}
                           className="text-muted-foreground hover:text-foreground"
                         >

--- a/src/renderer/src/components/automations/automation-source-display.ts
+++ b/src/renderer/src/components/automations/automation-source-display.ts
@@ -37,6 +37,8 @@ function getProviderLabel(provider: TaskSourceContext['provider']): string {
       return 'GitHub'
     case 'gitlab':
       return 'GitLab'
+    case 'gitea':
+      return 'Gitea'
     case 'linear':
       return 'Linear'
     case 'jira':
@@ -54,6 +56,8 @@ function getSourceIdentityLabel(sourceContext: TaskSourceContext): string | null
         return identity.namespace && identity.project
           ? `${identity.namespace}/${identity.project}`
           : (identity.projectId ?? null)
+      case 'gitea':
+        return identity.owner && identity.repo ? `${identity.owner}/${identity.repo}` : null
       case 'linear':
         return identity.workspaceName ?? identity.workspaceId ?? null
       case 'jira':

--- a/src/renderer/src/components/automations/automation-target-availability.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.ts
@@ -215,6 +215,8 @@ function getAutomationSourceProviderLabel(provider: TaskSourceContext['provider'
       return 'GitHub'
     case 'gitlab':
       return 'GitLab'
+    case 'gitea':
+      return 'Gitea'
     case 'linear':
       return 'Linear'
     case 'jira':

--- a/src/renderer/src/components/icons/GiteaIcon.tsx
+++ b/src/renderer/src/components/icons/GiteaIcon.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+// Why: the Gitea/Forgejo mark is referenced from multiple surfaces (settings
+// task-provider toggle, sidebar nav shortcut, task-source picker). Keeping a
+// single source avoids path-data drift and lets every caller pick its own
+// size/color via `currentColor`.
+export function GiteaIcon({ className }: { className?: string }): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
+      <path d="M3 6h12v7.5A4.5 4.5 0 0 1 10.5 18h-3A4.5 4.5 0 0 1 3 13.5V6Zm12 1.75h2.75a2.75 2.75 0 1 1 0 5.5H15v-1.75h2.75a1 1 0 0 0 0-2H15V7.75ZM4 19.5h10V21H4v-1.5Z" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/settings/TasksPane.tsx
+++ b/src/renderer/src/components/settings/TasksPane.tsx
@@ -8,6 +8,7 @@ import {
 import { cn } from '@/lib/utils'
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { LinearIcon } from '@/components/icons/LinearIcon'
+import { GiteaIcon } from '@/components/icons/GiteaIcon'
 import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader } from './SettingsFormControls'
@@ -49,6 +50,19 @@ const TASK_PROVIDER_OPTIONS: readonly {
       )
     },
     Icon: ({ className }) => <Gitlab className={className} />
+  },
+  {
+    id: 'gitea',
+    get label() {
+      return translate('auto.components.settings.TasksPane.gitea_label', 'Gitea')
+    },
+    get description() {
+      return translate(
+        'auto.components.settings.TasksPane.gitea_desc',
+        'Show Gitea in the Tasks source picker and sidebar shortcuts.'
+      )
+    },
+    Icon: ({ className }) => <GiteaIcon className={className} />
   },
   {
     id: 'linear',

--- a/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
+++ b/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { EyeOff, Github, Gitlab, List } from 'lucide-react'
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { LinearIcon } from '@/components/icons/LinearIcon'
+import { GiteaIcon } from '@/components/icons/GiteaIcon'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -221,6 +222,18 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
                 onOpen={() => openTaskPage({ taskSource: 'gitlab' })}
               >
                 <Gitlab className="size-3.5" aria-hidden />
+              </TaskProviderShortcut>
+            ) : null}
+            {visibleTaskProviders.includes('gitea') ? (
+              <TaskProviderShortcut
+                canBrowseTasks={canBrowseTasks}
+                label={translate(
+                  'auto.components.sidebar.SidebarNav.gitea_open',
+                  'Open Gitea tasks'
+                )}
+                onOpen={() => openTaskPage({ taskSource: 'gitea' })}
+              >
+                <GiteaIcon className="size-3.5" />
               </TaskProviderShortcut>
             ) : null}
             {visibleTaskProviders.includes('linear') ? (

--- a/src/renderer/src/components/task-page-list-chrome-visibility.ts
+++ b/src/renderer/src/components/task-page-list-chrome-visibility.ts
@@ -26,6 +26,8 @@ export function shouldHideTaskPageListChrome({
       return hasGitHubDetail
     case 'gitlab':
       return hasGitLabDetail
+    case 'gitea':
+      return false
     case 'jira':
       return hasJiraDetail
     case 'linear':

--- a/src/renderer/src/components/task-page-localized-options.tsx
+++ b/src/renderer/src/components/task-page-localized-options.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Github, Gitlab, LayoutGrid, List } from 'lucide-react'
 
 import { JiraIcon } from '@/components/icons/JiraIcon'
+import { GiteaIcon } from '@/components/icons/GiteaIcon'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import { getTaskPresetQuery } from '@/lib/new-workspace'
@@ -114,6 +115,11 @@ export const getSourceOptions = createLocalizedCatalog((): SourceOption[] => [
     id: 'gitlab',
     label: translate('auto.components.TaskPage.11a828abf8', 'GitLab'),
     Icon: ({ className }) => <Gitlab className={className} />
+  },
+  {
+    id: 'gitea',
+    label: translate('auto.components.TaskPage.gitea_src', 'Gitea'),
+    Icon: ({ className }) => <GiteaIcon className={className} />
   },
   {
     id: 'linear',

--- a/src/renderer/src/components/task-source-context-summary.ts
+++ b/src/renderer/src/components/task-source-context-summary.ts
@@ -4,7 +4,8 @@ import type { ExecutionHostScope } from '../../../shared/execution-host'
 import type { ExecutionHostHealth } from '../../../shared/execution-host-registry'
 import type { SshConnectionStatus } from '../../../shared/ssh-types'
 import type { TaskProvider } from '../../../shared/types'
-import type { TaskProviderIdentity, TaskSourceContext } from '../../../shared/task-source-context'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import { getProviderIdentityLabel } from './task-source-provider-identity-label'
 
 export type TaskSourceContextSummary = {
   label: string
@@ -49,6 +50,7 @@ export function getTaskSourceContextSummary(args: {
   switch (args.provider) {
     case 'github':
     case 'gitlab':
+    case 'gitea':
       return getRepoBackedTaskSourceSummary(args)
     case 'linear':
       return getAccountBackedTaskSourceSummary(args.providerLabel, {
@@ -178,26 +180,6 @@ function getAccountBackedTaskSourceSummary(
       .filter((part): part is string => Boolean(part))
       .join(' · '),
     title: titleParts.join(' · ')
-  }
-}
-
-function getProviderIdentityLabel(
-  identity: TaskProviderIdentity | null | undefined
-): string | null {
-  if (!identity) {
-    return null
-  }
-  switch (identity.provider) {
-    case 'github':
-      return `${identity.owner}/${identity.repo}`
-    case 'gitlab':
-      return identity.namespace && identity.project
-        ? `${identity.namespace}/${identity.project}`
-        : (identity.projectId ?? null)
-    case 'linear':
-      return identity.workspaceName ?? identity.workspaceId ?? null
-    case 'jira':
-      return identity.siteUrl ?? identity.siteId ?? null
   }
 }
 

--- a/src/renderer/src/components/task-source-provider-availability.ts
+++ b/src/renderer/src/components/task-source-provider-availability.ts
@@ -22,7 +22,7 @@ function isDesktopOwnedHost(hostId: TaskSourceContext['hostId']): boolean {
 }
 
 function getRepoBackedProviderToolStatus(
-  provider: Extract<TaskProvider, 'github' | 'gitlab'>,
+  provider: Extract<TaskProvider, 'github' | 'gitlab' | 'gitea'>,
   preflightStatus: PreflightStatus | null
 ): ProviderAvailabilityStatus | null {
   if (!preflightStatus) {
@@ -30,6 +30,19 @@ function getRepoBackedProviderToolStatus(
   }
   if (provider === 'github') {
     return preflightStatus.gh
+  }
+  if (provider === 'gitea') {
+    // Why: Gitea/Forgejo auth is env-based (ORCA_GITEA_API_BASE_URL +
+    // ORCA_GITEA_TOKEN). Map `configured` → installed, `authenticated` →
+    // authenticated so the shared availability reasons apply. Hosts predating
+    // the gitea preflight block are a capability gap, not a user-fixable one.
+    if (!Object.hasOwn(preflightStatus, 'gitea')) {
+      return 'unsupported'
+    }
+    const gitea = preflightStatus.gitea
+    return gitea
+      ? { installed: gitea.configured, authenticated: gitea.authenticated }
+      : { installed: false, authenticated: false }
   }
   // Why: older remote servers can predate GitLab preflight entirely. That is a
   // host capability gap, not a user-fixable missing `glab` install.
@@ -54,7 +67,7 @@ function getProviderReason(
 }
 
 export function getRepoBackedProviderAvailability(args: {
-  provider: Extract<TaskProvider, 'github' | 'gitlab'>
+  provider: Extract<TaskProvider, 'github' | 'gitlab' | 'gitea'>
   contexts: readonly TaskSourceContext[]
   preflightStatus: PreflightStatus | null
   preflightReady: boolean

--- a/src/renderer/src/components/task-source-provider-identity-label.ts
+++ b/src/renderer/src/components/task-source-provider-identity-label.ts
@@ -1,0 +1,26 @@
+import type { TaskProviderIdentity } from '../../../shared/task-source-context'
+
+// Why: extracted from task-source-context-summary.ts so that module stays under
+// the max-lines budget as new providers (gitea) add identity cases. Pure helper —
+// maps a provider identity to its display label.
+export function getProviderIdentityLabel(
+  identity: TaskProviderIdentity | null | undefined
+): string | null {
+  if (!identity) {
+    return null
+  }
+  switch (identity.provider) {
+    case 'github':
+      return `${identity.owner}/${identity.repo}`
+    case 'gitlab':
+      return identity.namespace && identity.project
+        ? `${identity.namespace}/${identity.project}`
+        : (identity.projectId ?? null)
+    case 'gitea':
+      return identity.owner && identity.repo ? `${identity.owner}/${identity.repo}` : null
+    case 'linear':
+      return identity.workspaceName ?? identity.workspaceId ?? null
+    case 'jira':
+      return identity.siteUrl ?? identity.siteId ?? null
+  }
+}

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1194,7 +1194,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       preferredVisibleTaskProviders,
       {
         gitlabInstalled: state.preflightStatus?.glab?.installed === true,
-        linearConnected: state.linearStatus?.connected === true
+        linearConnected: state.linearStatus?.connected === true,
+        giteaConfigured: state.preflightStatus?.gitea?.configured === true
       },
       state.settings?.defaultTaskSource
     )

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -239,4 +239,42 @@ describe('isGitHubBackedRepo', () => {
   it('is false for a plain local repo with no provider signal', () => {
     expect(isGitHubBackedRepo(repo({ id: 'r', path: '/r', displayName: 'r' }))).toBe(false)
   })
+
+  it('groups non-GitHub checkouts on different hosts by shared origin remote key', () => {
+    const projection = projectHostSetupProjectionFromRepos(
+      [
+        repo({
+          id: 'local-1',
+          path: '/Users/alice/repos/app',
+          displayName: 'app',
+          originRemoteKey: 'forgejo.example.com/acme/app'
+        }),
+        repo({
+          id: 'remote-1',
+          path: '/home/codi/repos/app',
+          displayName: 'app',
+          connectionId: 'ssh-1',
+          originRemoteKey: 'forgejo.example.com/acme/app'
+        })
+      ],
+      500
+    )
+    // Both checkouts collapse into ONE project keyed on the shared origin remote.
+    expect(projection.projects).toHaveLength(1)
+    expect(projection.projects[0].id).toBe('git:forgejo.example.com/acme/app')
+    expect(projection.projects[0].sourceRepoIds).toEqual(['local-1', 'remote-1'])
+    // ...and each host keeps its own setup under that one project.
+    expect(projection.setups.map((setup) => setup.projectId)).toEqual([
+      'git:forgejo.example.com/acme/app',
+      'git:forgejo.example.com/acme/app'
+    ])
+  })
+
+  it('keeps a non-GitHub repo with no origin remote isolated as repo:<id>', () => {
+    const projection = projectHostSetupProjectionFromRepos(
+      [repo({ id: 'no-remote', path: '/r', displayName: 'r' })],
+      500
+    )
+    expect(projection.projects[0].id).toBe('repo:no-remote')
+  })
 })

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -48,15 +48,23 @@ export function isGitHubBackedRepo(repo: Pick<Repo, 'upstream' | 'repoIcon'>): b
   return getProjectProviderIdentity(repo) !== null
 }
 
-export function getProjectIdentityKey(repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon'>): string {
+export function getProjectIdentityKey(
+  repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon' | 'originRemoteKey'>
+): string {
   const identity = getProjectProviderIdentity(repo)
-  if (!identity) {
-    return `repo:${repo.id}`
+  if (identity) {
+    return `github:${normalizeIdentityPart(identity.owner)}/${normalizeIdentityPart(identity.repo)}`
   }
-  return `github:${normalizeIdentityPart(identity.owner)}/${normalizeIdentityPart(identity.repo)}`
+  // Why: non-GitHub remotes (Forgejo/GitLab/self-hosted) have no provider
+  // identity, so without this they key on `repo:<id>` (unique per checkout) and
+  // can never group across hosts. Key on the shared origin remote instead.
+  if (repo.originRemoteKey) {
+    return `git:${normalizeIdentityPart(repo.originRemoteKey)}`
+  }
+  return `repo:${repo.id}`
 }
 
-function getProjectId(repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon'>): string {
+function getProjectId(repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon' | 'originRemoteKey'>): string {
   return getProjectIdentityKey(repo)
 }
 

--- a/src/shared/task-providers.ts
+++ b/src/shared/task-providers.ts
@@ -1,6 +1,12 @@
-export type TaskProvider = 'github' | 'gitlab' | 'linear' | 'jira'
+export type TaskProvider = 'github' | 'gitlab' | 'linear' | 'jira' | 'gitea'
 
-export const TASK_PROVIDERS: readonly TaskProvider[] = ['github', 'gitlab', 'linear', 'jira']
+export const TASK_PROVIDERS: readonly TaskProvider[] = [
+  'github',
+  'gitlab',
+  'linear',
+  'jira',
+  'gitea'
+]
 
 const TASK_PROVIDER_SET = new Set<TaskProvider>(TASK_PROVIDERS)
 
@@ -55,6 +61,7 @@ export function normalizeVisibleTaskProviders(value: unknown): TaskProvider[] {
 export type TaskProviderAvailability = {
   gitlabInstalled: boolean
   linearConnected: boolean
+  giteaConfigured?: boolean
 }
 
 export function filterAvailableTaskProviders(
@@ -99,6 +106,9 @@ function isTaskProviderAvailable(
   }
   if (provider === 'gitlab') {
     return availability.gitlabInstalled
+  }
+  if (provider === 'gitea') {
+    return availability.giteaConfigured ?? false
   }
   // Why: Jira can be connected from the Tasks surface itself, so hiding it
   // when disconnected would remove the entry point for first-time setup.

--- a/src/shared/task-source-context.ts
+++ b/src/shared/task-source-context.ts
@@ -8,7 +8,7 @@ import {
 } from './execution-host'
 import type { GlobalSettings, ProjectProviderIdentity, Repo } from './types'
 
-export type TaskProvider = 'github' | 'gitlab' | 'linear' | 'jira'
+export type TaskProvider = 'github' | 'gitlab' | 'linear' | 'jira' | 'gitea'
 
 export type GitHubTaskProviderIdentity = ProjectProviderIdentity & {
   provider: 'github'
@@ -37,11 +37,20 @@ export type JiraTaskProviderIdentity = {
   projectKey?: string | null
 }
 
+export type GiteaTaskProviderIdentity = {
+  provider: 'gitea'
+  host?: string | null
+  owner?: string | null
+  repo?: string | null
+  webBaseUrl?: string | null
+}
+
 export type TaskProviderIdentity =
   | GitHubTaskProviderIdentity
   | GitLabTaskProviderIdentity
   | LinearTaskProviderIdentity
   | JiraTaskProviderIdentity
+  | GiteaTaskProviderIdentity
 
 export type TaskSourceContext = {
   kind: 'task-source'
@@ -182,6 +191,7 @@ function normalizeTaskProvider(value: string): TaskProvider | null {
     case 'gitlab':
     case 'linear':
     case 'jira':
+    case 'gitea':
       return value
     default:
       return null
@@ -216,6 +226,8 @@ function providerIdentityCachePart(identity: TaskProviderIdentity | null | undef
       return [identity.workspaceId, identity.teamId ?? identity.teamKey].filter(Boolean).join('/')
     case 'jira':
       return [identity.siteId ?? identity.siteUrl, identity.projectKey].filter(Boolean).join('/')
+    case 'gitea':
+      return [identity.host, identity.owner, identity.repo].filter(Boolean).join('/')
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -332,7 +332,7 @@ export type FolderWorkspace = {
 }
 
 export type FolderWorkspaceLinkedTask = {
-  provider: 'github' | 'gitlab' | 'linear' | 'jira'
+  provider: 'github' | 'gitlab' | 'linear' | 'jira' | 'gitea'
   type: 'issue' | 'pr' | 'mr'
   number: number
   title: string

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -235,6 +235,11 @@ export type Repo = {
    *  default avatar (upstream owner, not the personal fork) and the fork
    *  indicator. Absent = not a fork, or fork status not yet resolved. */
   upstream?: GitHubRepositoryIdentity | null
+  // Why: normalized git origin identity (`host/owner/repo`, lowercased) for ANY
+  // provider, so two checkouts of the same remote on different hosts group into
+  // one project even without a GitHub provider identity. Populated at add-time
+  // and backfilled on load; null when the repo has no parseable origin remote.
+  originRemoteKey?: string | null
   addedAt: number
   kind?: RepoKind
   gitUsername?: string

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -41,7 +41,7 @@ export type WorkspaceIntentWorkItem = {
   type: 'issue' | 'pr' | 'mr'
   number: number
   title: string
-  provider?: 'github' | 'gitlab' | 'linear' | 'jira'
+  provider?: 'github' | 'gitlab' | 'linear' | 'jira' | 'gitea'
   linearIdentifier?: string
   jiraIdentifier?: string
 }


### PR DESCRIPTION
## Problem

Cross-host project grouping is GitHub-only. `getProjectIdentityKey()` (in `src/shared/project-host-setup-projection.ts`) builds a project identity only for GitHub repos (via `upstream.owner/repo` or a GitHub avatar icon). For any other remote — Forgejo, GitLab, self-hosted — it falls back to `repo:<id>`, which is **unique per checkout**. So two checkouts of the *same* non-GitHub repo on different hosts never produce the same key and can never group into one project.

In practice, **"Add project to host"** for a non-GitHub project fails:
- adding to a host whose runtime doesn't have the project → `Project not found: <projectId>`
- and `setupExistingFolder` then throws `Imported folder does not match the selected project identity.` because the GitHub-identity gate rejects non-GitHub repos.

## Fix (minimal)

Derive a generic origin-remote identity for **any** provider and use it as the grouping key when there's no GitHub identity:

- `Repo.originRemoteKey` — normalized `host/owner/repo` (lowercased), captured from the git `origin` remote. `parseGitHubRemoteIdentity` already extracts `host/owner/repo` from any URL; only its GitHub-specific callers filter to `github.com`, so a small `getOriginRemoteKey()` helper reuses it.
- `getProjectIdentityKey()` falls back to `git:<originRemoteKey>` instead of `repo:<id>` when no GitHub identity exists → two checkouts of the same remote now share one project key across hosts.
- `originRemoteKey` is populated at add-time (local + remote adds) and **backfilled on load** for existing repos.
- The two `setupExistingFolder` gates (`ipc/repos.ts`, `runtime/orca-runtime.ts`) are relaxed so a project that originated on another runtime can be added to a new host, and the GitHub-identity stamp is skipped when the origin identity already matches.

GitHub behavior is unchanged (the GitHub identity path takes precedence).

## Tests

Added projection unit tests covering:
- two non-GitHub checkouts on different hosts collapsing into one `git:<origin>` project (both `sourceRepoIds`, one host-setup each)
- a non-GitHub repo with no origin remote staying isolated as `repo:<id>`

`pnpm typecheck` passes; affected suites green (`project-host-setup-projection`, `ipc/repos`, `repos-remote`, renderer `repos` slices).

## Notes

- Existing non-GitHub projects re-key `repo:<id>` → `git:<origin>` once `originRemoteKey` is backfilled; the projection recomputes ids on load. Worth a look from maintainers on whether any persisted `projectId` references need an explicit migration.
- For a non-GitHub project to group across two hosts, both runtimes must run this build (the backfill runs per-runtime).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5779">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Orca only grouped the same GitHub repo across different machines. If you used GitLab, Forgejo, or another host, each checkout looked like a different project. This fix groups those checkouts by their git remote URL so the same non-GitHub repo on two hosts becomes one project.
