### PR TITLE
feat(worktree): reuse an existing branch when creating a worktree (#5181)

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1027,6 +1027,66 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('reuses an existing local branch when the worktree folder is renamed (#5181)', async () => {
+    // Why: the reuse checkbox keeps branchNameOverride pinned to the selected
+    // branch while the worktree folder is named independently. The backend must
+    // still check out that exact branch (no -b) into the renamed folder.
+    listWorktreesMock
+      .mockResolvedValueOnce([
+        {
+          path: '/workspace/repo',
+          head: 'main',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          path: '/workspace/repo',
+          head: 'main',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: '/workspace/my-folder',
+          head: 'abc123',
+          branch: 'refs/heads/fix/bug-0',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+
+    const result = await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'my-folder',
+      baseBranch: 'fix/bug-0',
+      branchNameOverride: 'fix/bug-0'
+    })
+
+    expect(getBranchConflictKindMock).not.toHaveBeenCalled()
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/my-folder',
+      'fix/bug-0',
+      'fix/bug-0',
+      false,
+      false,
+      { checkoutExistingBranch: true }
+    )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-1::/workspace/my-folder',
+      expect.objectContaining({ preserveBranchOnDelete: true })
+    )
+    expect(result).toMatchObject({
+      worktree: expect.objectContaining({
+        path: '/workspace/my-folder',
+        branch: 'refs/heads/fix/bug-0'
+      })
+    })
+  })
+
   it('suffixes only the path when an existing local branch checkout path already exists', async () => {
     const mainWorktree = {
       path: '/workspace/repo',

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -208,19 +208,25 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
     expect(current.container.querySelectorAll('[data-testid="project-combobox"]')).toHaveLength(1)
   })
 
-  it('shows the reuse-branch checkbox only when a local branch is reusable', () => {
-    current = renderCard({ advancedOpen: true, canReuseSelectedBranch: false })
-    expect(current.container.textContent).not.toContain('Reuse branch')
+  it('keeps the reuse-branch row collapsed until a local branch is reusable', () => {
+    // Why: the row stays mounted (for the smooth height transition) but is
+    // collapsed + aria-hidden when reuse isn't possible.
+    current = renderCard({ canReuseSelectedBranch: false })
+    const collapsedReuse = [...current.container.querySelectorAll('[aria-hidden="true"]')].find(
+      (el) => el.textContent?.includes('Reuse branch')
+    )
+    expect(collapsedReuse).toBeTruthy()
 
     act(() => current?.root.unmount())
     current?.container.remove()
 
-    current = renderCard({
-      advancedOpen: true,
-      canReuseSelectedBranch: true,
-      reuseSelectedBranch: true
-    })
-    expect(current.container.textContent).toContain('Reuse branch')
+    current = renderCard({ canReuseSelectedBranch: true, reuseSelectedBranch: true })
+    const reuseLabel = [...current.container.querySelectorAll('label')].find((label) =>
+      label.textContent?.includes('Reuse branch')
+    )
+    expect(reuseLabel).toBeTruthy()
+    // Visible: not inside an aria-hidden (collapsed) wrapper.
+    expect(reuseLabel?.closest('[aria-hidden="true"]')).toBeNull()
     expect(current.container.textContent).toContain(
       'Check out the existing branch instead of creating a new one from it.'
     )

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -132,6 +132,9 @@ function renderCard(
         onSmartLinearIssueSelect={() => {}}
         smartNameSelection={null}
         onClearSmartNameSelection={() => {}}
+        canReuseSelectedBranch={false}
+        reuseSelectedBranch={false}
+        onReuseSelectedBranchChange={() => {}}
         forkPushWarning={null}
         detectedAgentIds={null}
         onOpenAgentSettings={() => {}}
@@ -203,6 +206,41 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
     ).toBe('Repo A,Repo B')
     expect(current.container.querySelector('[data-testid="repo-backed-source-trigger"]')).toBeNull()
     expect(current.container.querySelectorAll('[data-testid="project-combobox"]')).toHaveLength(1)
+  })
+
+  it('shows the reuse-branch checkbox only when a local branch is reusable', () => {
+    current = renderCard({ advancedOpen: true, canReuseSelectedBranch: false })
+    expect(current.container.textContent).not.toContain('Reuse this branch')
+
+    act(() => current?.root.unmount())
+    current?.container.remove()
+
+    current = renderCard({
+      advancedOpen: true,
+      canReuseSelectedBranch: true,
+      reuseSelectedBranch: true
+    })
+    expect(current.container.textContent).toContain('Reuse this branch')
+    expect(current.container.textContent).toContain(
+      'Check out the existing branch instead of creating a new one from it.'
+    )
+  })
+
+  it('invokes onReuseSelectedBranchChange when the reuse checkbox is toggled', () => {
+    const changes: boolean[] = []
+    current = renderCard({
+      advancedOpen: true,
+      canReuseSelectedBranch: true,
+      reuseSelectedBranch: true,
+      onReuseSelectedBranchChange: (next) => changes.push(next)
+    })
+    const reuseLabel = [...current.container.querySelectorAll('label')].find((label) =>
+      label.textContent?.includes('Reuse this branch')
+    )
+    const checkbox = reuseLabel?.querySelector<HTMLInputElement>('input[type="checkbox"]')
+    expect(checkbox).toBeTruthy()
+    act(() => checkbox?.click())
+    expect(changes).toEqual([false])
   })
 
   it('does not disable folder workspace creation when only source lookup needs SSH', () => {

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -232,21 +232,38 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
     )
   })
 
-  it('invokes onReuseSelectedBranchChange when the reuse checkbox is toggled', () => {
-    const changes: boolean[] = []
+  it('emits the toggled value from the reuse checkbox in both directions', () => {
+    const clickReuseCheckbox = (): void => {
+      const reuseLabel = [...(current?.container.querySelectorAll('label') ?? [])].find((label) =>
+        label.textContent?.includes('Reuse branch')
+      )
+      const checkbox = reuseLabel?.querySelector<HTMLInputElement>('input[type="checkbox"]')
+      expect(checkbox).toBeTruthy()
+      act(() => checkbox?.click())
+    }
+
+    // Checked -> unchecked (opting out of reuse).
+    const offChanges: boolean[] = []
     current = renderCard({
-      advancedOpen: true,
       canReuseSelectedBranch: true,
       reuseSelectedBranch: true,
-      onReuseSelectedBranchChange: (next) => changes.push(next)
+      onReuseSelectedBranchChange: (next) => offChanges.push(next)
     })
-    const reuseLabel = [...current.container.querySelectorAll('label')].find((label) =>
-      label.textContent?.includes('Reuse branch')
-    )
-    const checkbox = reuseLabel?.querySelector<HTMLInputElement>('input[type="checkbox"]')
-    expect(checkbox).toBeTruthy()
-    act(() => checkbox?.click())
-    expect(changes).toEqual([false])
+    clickReuseCheckbox()
+    expect(offChanges).toEqual([false])
+
+    act(() => current?.root.unmount())
+    current?.container.remove()
+
+    // Unchecked -> checked (opting into reuse — the action that pins the branch).
+    const onChanges: boolean[] = []
+    current = renderCard({
+      canReuseSelectedBranch: true,
+      reuseSelectedBranch: false,
+      onReuseSelectedBranchChange: (next) => onChanges.push(next)
+    })
+    clickReuseCheckbox()
+    expect(onChanges).toEqual([true])
   })
 
   it('does not disable folder workspace creation when only source lookup needs SSH', () => {

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -210,7 +210,7 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
 
   it('shows the reuse-branch checkbox only when a local branch is reusable', () => {
     current = renderCard({ advancedOpen: true, canReuseSelectedBranch: false })
-    expect(current.container.textContent).not.toContain('Reuse this branch')
+    expect(current.container.textContent).not.toContain('Reuse branch')
 
     act(() => current?.root.unmount())
     current?.container.remove()
@@ -220,7 +220,7 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
       canReuseSelectedBranch: true,
       reuseSelectedBranch: true
     })
-    expect(current.container.textContent).toContain('Reuse this branch')
+    expect(current.container.textContent).toContain('Reuse branch')
     expect(current.container.textContent).toContain(
       'Check out the existing branch instead of creating a new one from it.'
     )
@@ -235,7 +235,7 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
       onReuseSelectedBranchChange: (next) => changes.push(next)
     })
     const reuseLabel = [...current.container.querySelectorAll('label')].find((label) =>
-      label.textContent?.includes('Reuse this branch')
+      label.textContent?.includes('Reuse branch')
     )
     const checkbox = reuseLabel?.querySelector<HTMLInputElement>('input[type="checkbox"]')
     expect(checkbox).toBeTruthy()

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -84,6 +84,10 @@ type NewWorkspaceComposerCardProps = {
   onSmartLinearIssueSelect: (issue: LinearIssue) => void
   smartNameSelection: SmartWorkspaceNameSelection | null
   onClearSmartNameSelection: () => void
+  /** True when an existing local branch is selected and can be reused. */
+  canReuseSelectedBranch: boolean
+  reuseSelectedBranch: boolean
+  onReuseSelectedBranchChange: (next: boolean) => void
   smartNameGitHubSourceContext?: TaskSourceContext | null
   /** Advisory shown under the name field when a fork PR can't accept maintainer pushes. */
   forkPushWarning: string | null
@@ -317,6 +321,9 @@ export default function NewWorkspaceComposerCard({
   onSmartLinearIssueSelect,
   smartNameSelection,
   onClearSmartNameSelection,
+  canReuseSelectedBranch,
+  reuseSelectedBranch,
+  onReuseSelectedBranchChange,
   smartNameGitHubSourceContext,
   forkPushWarning,
   detectedAgentIds,
@@ -761,6 +768,49 @@ export default function NewWorkspaceComposerCard({
                     )}
                     className="w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
                   />
+                </div>
+              ) : null}
+
+              {canReuseSelectedBranch ? (
+                // Why (#5181): when an existing local branch is selected, let the
+                // user reuse it (check it out) instead of branching off it, and
+                // make that choice explicit + durable across worktree-name edits.
+                <div className="space-y-1">
+                  <label className="group flex items-center gap-2 text-xs text-foreground">
+                    <span
+                      className={cn(
+                        'flex size-4 items-center justify-center rounded-[3px] border shadow-sm transition',
+                        reuseSelectedBranch
+                          ? 'border-emerald-500/60 bg-emerald-500 text-white'
+                          : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
+                      )}
+                    >
+                      <Check
+                        className={cn(
+                          'size-3 transition-opacity',
+                          reuseSelectedBranch ? 'opacity-100' : 'opacity-0'
+                        )}
+                      />
+                    </span>
+                    <input
+                      type="checkbox"
+                      checked={reuseSelectedBranch}
+                      onChange={(event) => onReuseSelectedBranchChange(event.target.checked)}
+                      className="sr-only"
+                    />
+                    <span>
+                      {translate(
+                        'auto.components.NewWorkspaceComposerCard.reuseExistingBranch',
+                        'Reuse this branch'
+                      )}
+                    </span>
+                  </label>
+                  <p className="pl-6 text-[11px] text-muted-foreground">
+                    {translate(
+                      'auto.components.NewWorkspaceComposerCard.reuseExistingBranchHint',
+                      'Check out the existing branch instead of creating a new one from it.'
+                    )}
+                  </p>
                 </div>
               ) : null}
 

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -665,50 +665,63 @@ export default function NewWorkspaceComposerCard({
               <span>{forkPushWarning}</span>
             </p>
           ) : null}
-          {canReuseSelectedBranch ? (
-            // Why (#5181): sits right under the branch selection (not the Name
-            // field, which can differ from the branch) so reusing the picked
-            // branch is an explicit, discoverable choice. Only shown when reuse
-            // is actually possible — an existing local branch not already
-            // checked out in another worktree.
-            <div className="space-y-1 pt-1">
-              <label className="group flex w-fit items-center gap-2 text-xs text-foreground">
-                <span
-                  className={cn(
-                    'flex size-4 items-center justify-center rounded-[3px] border shadow-sm transition',
-                    reuseSelectedBranch
-                      ? 'border-emerald-500/60 bg-emerald-500 text-white'
-                      : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
-                  )}
-                >
-                  <Check
+          {/* Why (#5181): sits right under the branch selection (not the Name
+              field, which can differ from the branch) so reusing the picked
+              branch is an explicit, discoverable choice. Stays mounted and
+              collapses via a grid-rows transition (matching the Advanced
+              drawer) so the dialog grows/shrinks smoothly as the option
+              appears. Only offered when reuse is possible — an existing local
+              branch not already checked out in another worktree. */}
+          <div
+            className={cn(
+              'grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out',
+              canReuseSelectedBranch ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+            )}
+            aria-hidden={!canReuseSelectedBranch}
+          >
+            <div className="min-h-0">
+              <div className="space-y-1 pt-1">
+                <label className="group flex w-fit items-center gap-2 text-xs text-foreground">
+                  <span
                     className={cn(
-                      'size-3 transition-opacity',
-                      reuseSelectedBranch ? 'opacity-100' : 'opacity-0'
+                      'flex size-4 items-center justify-center rounded-[3px] border shadow-sm transition',
+                      reuseSelectedBranch
+                        ? 'border-emerald-500/60 bg-emerald-500 text-white'
+                        : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
                     )}
+                  >
+                    <Check
+                      className={cn(
+                        'size-3 transition-opacity',
+                        reuseSelectedBranch ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                  </span>
+                  <input
+                    type="checkbox"
+                    checked={reuseSelectedBranch}
+                    onChange={(event) => onReuseSelectedBranchChange(event.target.checked)}
+                    // Why: kept out of the tab order while collapsed so users can't
+                    // focus a hidden control on non-reusable branches.
+                    tabIndex={canReuseSelectedBranch ? undefined : -1}
+                    className="sr-only"
                   />
-                </span>
-                <input
-                  type="checkbox"
-                  checked={reuseSelectedBranch}
-                  onChange={(event) => onReuseSelectedBranchChange(event.target.checked)}
-                  className="sr-only"
-                />
-                <span>
+                  <span>
+                    {translate(
+                      'auto.components.NewWorkspaceComposerCard.reuseExistingBranch',
+                      'Reuse branch'
+                    )}
+                  </span>
+                </label>
+                <p className="pl-6 text-[11px] text-muted-foreground">
                   {translate(
-                    'auto.components.NewWorkspaceComposerCard.reuseExistingBranch',
-                    'Reuse branch'
+                    'auto.components.NewWorkspaceComposerCard.reuseExistingBranchHint',
+                    'Check out the existing branch instead of creating a new one from it.'
                   )}
-                </span>
-              </label>
-              <p className="pl-6 text-[11px] text-muted-foreground">
-                {translate(
-                  'auto.components.NewWorkspaceComposerCard.reuseExistingBranchHint',
-                  'Check out the existing branch instead of creating a new one from it.'
-                )}
-              </p>
+                </p>
+              </div>
             </div>
-          ) : null}
+          </div>
         </div>
 
         <div className="space-y-1" data-contextual-tour-target="workspace-creation-agent">

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -701,9 +701,10 @@ export default function NewWorkspaceComposerCard({
                     type="checkbox"
                     checked={reuseSelectedBranch}
                     onChange={(event) => onReuseSelectedBranchChange(event.target.checked)}
-                    // Why: kept out of the tab order while collapsed so users can't
-                    // focus a hidden control on non-reusable branches.
-                    tabIndex={canReuseSelectedBranch ? undefined : -1}
+                    // Why: while collapsed the row is aria-hidden, so disable the
+                    // input too — keeps a hidden control out of the tab order and
+                    // fully inert (no focusable control inside an aria-hidden tree).
+                    disabled={!canReuseSelectedBranch}
                     className="sr-only"
                   />
                   <span>

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -665,6 +665,50 @@ export default function NewWorkspaceComposerCard({
               <span>{forkPushWarning}</span>
             </p>
           ) : null}
+          {canReuseSelectedBranch ? (
+            // Why (#5181): sits right under the branch selection (not the Name
+            // field, which can differ from the branch) so reusing the picked
+            // branch is an explicit, discoverable choice. Only shown when reuse
+            // is actually possible — an existing local branch not already
+            // checked out in another worktree.
+            <div className="space-y-1 pt-1">
+              <label className="group flex w-fit items-center gap-2 text-xs text-foreground">
+                <span
+                  className={cn(
+                    'flex size-4 items-center justify-center rounded-[3px] border shadow-sm transition',
+                    reuseSelectedBranch
+                      ? 'border-emerald-500/60 bg-emerald-500 text-white'
+                      : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
+                  )}
+                >
+                  <Check
+                    className={cn(
+                      'size-3 transition-opacity',
+                      reuseSelectedBranch ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                </span>
+                <input
+                  type="checkbox"
+                  checked={reuseSelectedBranch}
+                  onChange={(event) => onReuseSelectedBranchChange(event.target.checked)}
+                  className="sr-only"
+                />
+                <span>
+                  {translate(
+                    'auto.components.NewWorkspaceComposerCard.reuseExistingBranch',
+                    'Reuse branch'
+                  )}
+                </span>
+              </label>
+              <p className="pl-6 text-[11px] text-muted-foreground">
+                {translate(
+                  'auto.components.NewWorkspaceComposerCard.reuseExistingBranchHint',
+                  'Check out the existing branch instead of creating a new one from it.'
+                )}
+              </p>
+            </div>
+          ) : null}
         </div>
 
         <div className="space-y-1" data-contextual-tour-target="workspace-creation-agent">
@@ -768,49 +812,6 @@ export default function NewWorkspaceComposerCard({
                     )}
                     className="w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
                   />
-                </div>
-              ) : null}
-
-              {canReuseSelectedBranch ? (
-                // Why (#5181): when an existing local branch is selected, let the
-                // user reuse it (check it out) instead of branching off it, and
-                // make that choice explicit + durable across worktree-name edits.
-                <div className="space-y-1">
-                  <label className="group flex items-center gap-2 text-xs text-foreground">
-                    <span
-                      className={cn(
-                        'flex size-4 items-center justify-center rounded-[3px] border shadow-sm transition',
-                        reuseSelectedBranch
-                          ? 'border-emerald-500/60 bg-emerald-500 text-white'
-                          : 'border-foreground/20 bg-background dark:border-white/20 dark:bg-muted/10'
-                      )}
-                    >
-                      <Check
-                        className={cn(
-                          'size-3 transition-opacity',
-                          reuseSelectedBranch ? 'opacity-100' : 'opacity-0'
-                        )}
-                      />
-                    </span>
-                    <input
-                      type="checkbox"
-                      checked={reuseSelectedBranch}
-                      onChange={(event) => onReuseSelectedBranchChange(event.target.checked)}
-                      className="sr-only"
-                    />
-                    <span>
-                      {translate(
-                        'auto.components.NewWorkspaceComposerCard.reuseExistingBranch',
-                        'Reuse this branch'
-                      )}
-                    </span>
-                  </label>
-                  <p className="pl-6 text-[11px] text-muted-foreground">
-                    {translate(
-                      'auto.components.NewWorkspaceComposerCard.reuseExistingBranchHint',
-                      'Check out the existing branch instead of creating a new one from it.'
-                    )}
-                  </p>
                 </div>
               ) : null}
 

--- a/src/renderer/src/hooks/composer-branch-selection.test.ts
+++ b/src/renderer/src/hooks/composer-branch-selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   resolveComposerBranchNameOverrideForCreate,
+  resolveComposerBranchReuse,
   resolveComposerBranchSelection
 } from './composer-branch-selection'
 
@@ -74,5 +75,49 @@ describe('resolveComposerBranchSelection', () => {
         preserveWorkspaceNameEdits: false
       })
     ).toBeUndefined()
+  })
+})
+
+describe('resolveComposerBranchReuse', () => {
+  it('marks an existing local branch reusable and defaults reuse ON for an auto-derived name', () => {
+    expect(
+      resolveComposerBranchReuse({
+        refName: 'feature-x',
+        localBranchName: 'feature-x',
+        selectionProducedOverride: true
+      })
+    ).toEqual({ reuseEligibleBranch: 'feature-x', defaultReuse: true })
+  })
+
+  it('treats a slash-containing local branch as reusable (ref equals local name)', () => {
+    expect(
+      resolveComposerBranchReuse({
+        refName: 'fix/bug-0',
+        localBranchName: 'fix/bug-0',
+        selectionProducedOverride: true
+      })
+    ).toEqual({ reuseEligibleBranch: 'fix/bug-0', defaultReuse: true })
+  })
+
+  it('does not offer reuse for a remote-only ref (ref carries an origin/ prefix)', () => {
+    expect(
+      resolveComposerBranchReuse({
+        refName: 'origin/feature/something',
+        localBranchName: 'feature/something',
+        selectionProducedOverride: true
+      })
+    ).toEqual({ reuseEligibleBranch: null, defaultReuse: false })
+  })
+
+  it('keeps a local branch reuse-eligible but defaults reuse OFF when the user typed a custom name', () => {
+    // Why: no override means the user is branching off the ref with a custom
+    // worktree name; reuse stays opt-in (checkbox still shown via eligibility).
+    expect(
+      resolveComposerBranchReuse({
+        refName: 'feature-x',
+        localBranchName: 'feature-x',
+        selectionProducedOverride: false
+      })
+    ).toEqual({ reuseEligibleBranch: 'feature-x', defaultReuse: false })
   })
 })

--- a/src/renderer/src/hooks/composer-branch-selection.test.ts
+++ b/src/renderer/src/hooks/composer-branch-selection.test.ts
@@ -3,7 +3,8 @@ import {
   isBranchCheckedOutInWorktrees,
   resolveComposerBranchNameOverrideForCreate,
   resolveComposerBranchReuse,
-  resolveComposerBranchSelection
+  resolveComposerBranchSelection,
+  resolveComposerReuseOverride
 } from './composer-branch-selection'
 
 describe('resolveComposerBranchSelection', () => {
@@ -86,6 +87,45 @@ describe('isBranchCheckedOutInWorktrees', () => {
     ).toBe(true)
     expect(isBranchCheckedOutInWorktrees('feature-x', ['feature-x'])).toBe(true)
     expect(isBranchCheckedOutInWorktrees('feature-x', ['refs/heads/main', ''])).toBe(false)
+    expect(isBranchCheckedOutInWorktrees('feature-x', [])).toBe(false)
+  })
+})
+
+describe('resolveComposerReuseOverride', () => {
+  it('keeps the selection override for a reusable (non-busy) local branch', () => {
+    expect(
+      resolveComposerReuseOverride({
+        refName: 'feature-x',
+        localBranchName: 'feature-x',
+        branchNameOverride: 'feature-x',
+        branchCheckedOutElsewhere: false
+      })
+    ).toBe('feature-x')
+  })
+
+  it('drops the override for a local branch checked out in another worktree', () => {
+    // Why: pinning a busy branch would collide and produce a suffixed branch.
+    expect(
+      resolveComposerReuseOverride({
+        refName: 'feature-x',
+        localBranchName: 'feature-x',
+        branchNameOverride: 'feature-x',
+        branchCheckedOutElsewhere: true
+      })
+    ).toBeUndefined()
+  })
+
+  it('keeps the override for a remote-only ref even if its local name is busy', () => {
+    // Why: a remote-only ref (ref !== local name) creates a fresh local tracking
+    // branch, so the busy check on the local name must not drop its override.
+    expect(
+      resolveComposerReuseOverride({
+        refName: 'origin/feature-x',
+        localBranchName: 'feature-x',
+        branchNameOverride: 'feature-x',
+        branchCheckedOutElsewhere: true
+      })
+    ).toBe('feature-x')
   })
 })
 

--- a/src/renderer/src/hooks/composer-branch-selection.test.ts
+++ b/src/renderer/src/hooks/composer-branch-selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isBranchCheckedOutInWorktrees,
   resolveComposerBranchNameOverrideForCreate,
   resolveComposerBranchReuse,
   resolveComposerBranchSelection
@@ -78,13 +79,24 @@ describe('resolveComposerBranchSelection', () => {
   })
 })
 
+describe('isBranchCheckedOutInWorktrees', () => {
+  it('matches a branch against both refs/heads-qualified and short worktree refs', () => {
+    expect(
+      isBranchCheckedOutInWorktrees('feature-x', ['refs/heads/main', 'refs/heads/feature-x'])
+    ).toBe(true)
+    expect(isBranchCheckedOutInWorktrees('feature-x', ['feature-x'])).toBe(true)
+    expect(isBranchCheckedOutInWorktrees('feature-x', ['refs/heads/main', ''])).toBe(false)
+  })
+})
+
 describe('resolveComposerBranchReuse', () => {
   it('marks an existing local branch reusable and defaults reuse ON for an auto-derived name', () => {
     expect(
       resolveComposerBranchReuse({
         refName: 'feature-x',
         localBranchName: 'feature-x',
-        selectionProducedOverride: true
+        selectionProducedOverride: true,
+        branchCheckedOutElsewhere: false
       })
     ).toEqual({ reuseEligibleBranch: 'feature-x', defaultReuse: true })
   })
@@ -94,7 +106,8 @@ describe('resolveComposerBranchReuse', () => {
       resolveComposerBranchReuse({
         refName: 'fix/bug-0',
         localBranchName: 'fix/bug-0',
-        selectionProducedOverride: true
+        selectionProducedOverride: true,
+        branchCheckedOutElsewhere: false
       })
     ).toEqual({ reuseEligibleBranch: 'fix/bug-0', defaultReuse: true })
   })
@@ -104,7 +117,20 @@ describe('resolveComposerBranchReuse', () => {
       resolveComposerBranchReuse({
         refName: 'origin/feature/something',
         localBranchName: 'feature/something',
-        selectionProducedOverride: true
+        selectionProducedOverride: true,
+        branchCheckedOutElsewhere: false
+      })
+    ).toEqual({ reuseEligibleBranch: null, defaultReuse: false })
+  })
+
+  it('does not offer reuse when the branch is already checked out in another worktree', () => {
+    // Why: git refuses a branch in two worktrees, so reuse is impossible here.
+    expect(
+      resolveComposerBranchReuse({
+        refName: 'feature-x',
+        localBranchName: 'feature-x',
+        selectionProducedOverride: true,
+        branchCheckedOutElsewhere: true
       })
     ).toEqual({ reuseEligibleBranch: null, defaultReuse: false })
   })
@@ -116,7 +142,8 @@ describe('resolveComposerBranchReuse', () => {
       resolveComposerBranchReuse({
         refName: 'feature-x',
         localBranchName: 'feature-x',
-        selectionProducedOverride: false
+        selectionProducedOverride: false,
+        branchCheckedOutElsewhere: false
       })
     ).toEqual({ reuseEligibleBranch: 'feature-x', defaultReuse: false })
   })

--- a/src/renderer/src/hooks/composer-branch-selection.ts
+++ b/src/renderer/src/hooks/composer-branch-selection.ts
@@ -1,5 +1,6 @@
 export {
   resolveComposerBranchNameOverrideForCreate,
+  resolveComposerBranchReuse,
   resolveComposerBranchSelection,
   type ComposerBranchSelection
 } from '../../../shared/composer-branch-selection'

--- a/src/renderer/src/hooks/composer-branch-selection.ts
+++ b/src/renderer/src/hooks/composer-branch-selection.ts
@@ -3,5 +3,6 @@ export {
   resolveComposerBranchNameOverrideForCreate,
   resolveComposerBranchReuse,
   resolveComposerBranchSelection,
+  resolveComposerReuseOverride,
   type ComposerBranchSelection
 } from '../../../shared/composer-branch-selection'

--- a/src/renderer/src/hooks/composer-branch-selection.ts
+++ b/src/renderer/src/hooks/composer-branch-selection.ts
@@ -1,4 +1,5 @@
 export {
+  isBranchCheckedOutInWorktrees,
   resolveComposerBranchNameOverrideForCreate,
   resolveComposerBranchReuse,
   resolveComposerBranchSelection,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -152,6 +152,7 @@ import {
 import type { SshConnectionStatus } from '../../../shared/ssh-types'
 import {
   resolveComposerBranchNameOverrideForCreate,
+  resolveComposerBranchReuse,
   resolveComposerBranchSelection
 } from './composer-branch-selection'
 import { translate } from '@/i18n/i18n'
@@ -242,6 +243,13 @@ export type ComposerCardProps = {
   ) => void
   smartNameSelection: SmartWorkspaceNameSelection | null
   onClearSmartNameSelection: () => void
+  /** True when the selected source is an existing LOCAL branch that can be
+   *  reused (checked out) instead of branched off — gates the reuse checkbox. */
+  canReuseSelectedBranch: boolean
+  /** Whether the selected existing local branch will be reused (checked out)
+   *  rather than used as the base for a new branch. */
+  reuseSelectedBranch: boolean
+  onReuseSelectedBranchChange: (next: boolean) => void
   agentPrompt: string
   onAgentPromptChange: (value: string) => void
   /** Rendered issueCommand template to preview inside the empty prompt
@@ -810,6 +818,13 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const [branchNameOverride, setBranchNameOverride] = useState<string | undefined>(undefined)
   const [branchNameOverridePreservesNameEdits, setBranchNameOverridePreservesNameEdits] =
     useState(false)
+  // Why (#5181): when the user picks an existing LOCAL branch, let them reuse it
+  // (check it out) instead of creating a new branch from it. `reuseEligibleBranch`
+  // is the local branch name eligible for reuse (null = not a reusable local
+  // branch, e.g. a remote-only ref or non-branch source); `reuseSelectedBranch`
+  // is the explicit checkbox value driving whether reuse actually happens.
+  const [reuseEligibleBranch, setReuseEligibleBranch] = useState<string | null>(null)
+  const [reuseSelectedBranch, setReuseSelectedBranch] = useState(false)
   const [pushTarget, setPushTarget] = useState<GitPushTarget | undefined>(undefined)
   // Why: when a repo switch wipes a prior Start-from selection, surface the
   // reset inline (e.g. "was PR #8778") so the change is recoverable visually
@@ -2277,6 +2292,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     setCompareBaseRef(undefined)
     setPushTarget(undefined)
     setBranchNameOverride(undefined)
+    // Why (#5181): the Start-from picker means "create a new branch from this
+    // base", so it never offers branch reuse — clear any reuse state left over
+    // from a prior smart-field branch pick.
+    setBranchNameOverridePreservesNameEdits(false)
+    setReuseEligibleBranch(null)
+    setReuseSelectedBranch(false)
     setForkPushWarning(null)
     branchAutoNameRef.current = ''
     setStartFromResetHint(null)
@@ -2531,7 +2552,19 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setPushTarget(undefined)
       setStartFromResetHint(null)
       setForkPushWarning(null)
-      setBranchNameOverridePreservesNameEdits(false)
+      // Why (#5181): reuse an existing local branch (check it out) instead of
+      // branching off it. Default reuse ON when the worktree name was
+      // auto-derived from the branch, and preserve name edits so reuse survives
+      // renaming the worktree folder.
+      const { reuseEligibleBranch: nextReuseEligibleBranch, defaultReuse } =
+        resolveComposerBranchReuse({
+          refName,
+          localBranchName,
+          selectionProducedOverride: selection.branchNameOverride !== undefined
+        })
+      setReuseEligibleBranch(nextReuseEligibleBranch)
+      setReuseSelectedBranch(defaultReuse)
+      setBranchNameOverridePreservesNameEdits(defaultReuse)
       if (selection.name !== undefined && selection.lastAutoName !== undefined) {
         setName(selection.name)
         lastAutoNameRef.current = selection.lastAutoName
@@ -2543,6 +2576,25 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       }
     },
     [name]
+  )
+
+  const handleReuseSelectedBranchChange = useCallback(
+    (next: boolean): void => {
+      if (!reuseEligibleBranch) {
+        return
+      }
+      setReuseSelectedBranch(next)
+      // Why (#5181): reuse pins the exact existing branch as the override and
+      // preserves it across worktree-name edits, so the folder can be named
+      // independently while the branch is checked out. Opting out drops the
+      // override so a fresh branch is created from the selected ref as base.
+      setBranchNameOverridePreservesNameEdits(next)
+      setBranchNameOverride(next ? reuseEligibleBranch : undefined)
+      if (next) {
+        branchAutoNameRef.current = reuseEligibleBranch
+      }
+    },
+    [reuseEligibleBranch]
   )
 
   const handleSmartLinearIssueSelect = useCallback(
@@ -2604,6 +2656,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     setCompareBaseRef(undefined)
     setPushTarget(undefined)
     setBranchNameOverride(undefined)
+    setBranchNameOverridePreservesNameEdits(false)
+    setReuseEligibleBranch(null)
+    setReuseSelectedBranch(false)
     setForkPushWarning(null)
     branchAutoNameRef.current = ''
     setStartFromResetHint(null)
@@ -3528,6 +3583,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     smartNameGitHubSourceContext: selectedRepoGitHubSourceContext,
     smartNameSelection,
     onClearSmartNameSelection: handleClearSmartNameSelection,
+    canReuseSelectedBranch:
+      !isProjectGroupTarget &&
+      reuseEligibleBranch !== null &&
+      smartNameSelection?.kind === 'branch',
+    reuseSelectedBranch,
+    onReuseSelectedBranchChange: handleReuseSelectedBranchChange,
     agentPrompt,
     onAgentPromptChange: setAgentPrompt,
     linkedOnlyTemplatePreview: shouldApplyLinkedOnlyTemplate ? linkedOnlyTemplatePrompt : null,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -154,7 +154,8 @@ import {
   isBranchCheckedOutInWorktrees,
   resolveComposerBranchNameOverrideForCreate,
   resolveComposerBranchReuse,
-  resolveComposerBranchSelection
+  resolveComposerBranchSelection,
+  resolveComposerReuseOverride
 } from './composer-branch-selection'
 import { translate } from '@/i18n/i18n'
 
@@ -2159,6 +2160,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         setCompareBaseRef(undefined)
         setPushTarget(undefined)
         setBranchNameOverride(undefined)
+        // Why (#5181): reuse state is branch-scoped, so a repo switch must clear
+        // it alongside the branch override (matches the other reset paths).
+        setBranchNameOverridePreservesNameEdits(false)
+        setReuseEligibleBranch(null)
+        setReuseSelectedBranch(false)
         setForkPushWarning(null)
         setStartFromResetHint(hint)
       }
@@ -2230,6 +2236,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         setBaseBranch(undefined)
         setPushTarget(undefined)
         setBranchNameOverride(undefined)
+        // Why (#5181): clear branch-scoped reuse state on a project switch too.
+        setBranchNameOverridePreservesNameEdits(false)
+        setReuseEligibleBranch(null)
+        setReuseSelectedBranch(false)
         setForkPushWarning(null)
         setStartFromResetHint(null)
         return
@@ -2559,6 +2569,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       // renaming the worktree folder. Reuse is impossible when the branch is
       // already checked out in another worktree (git allows it in only one), so
       // gate eligibility on that and don't pin the override to a busy branch.
+      // Note: worktreesByRepo only covers visible worktrees; a branch busy only
+      // in a hidden external worktree falls through to the backend conflict
+      // check, which rejects it with a clear "already exists locally" error.
       const branchCheckedOutElsewhere = isBranchCheckedOutInWorktrees(
         localBranchName,
         (worktreesByRepo[repoId] ?? []).map((worktree) => worktree.branch)
@@ -2573,13 +2586,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setReuseEligibleBranch(nextReuseEligibleBranch)
       setReuseSelectedBranch(defaultReuse)
       setBranchNameOverridePreservesNameEdits(defaultReuse)
-      // Why: a busy local branch can't be reused — keeping it as the override
-      // would collide and silently produce a suffixed branch, so drop it and let
-      // the worktree name derive a fresh branch from the selected ref as base.
-      const effectiveOverride =
-        branchCheckedOutElsewhere && refName === localBranchName
-          ? undefined
-          : selection.branchNameOverride
+      const effectiveOverride = resolveComposerReuseOverride({
+        refName,
+        localBranchName,
+        branchNameOverride: selection.branchNameOverride,
+        branchCheckedOutElsewhere
+      })
       if (selection.name !== undefined && selection.lastAutoName !== undefined) {
         setName(selection.name)
         lastAutoNameRef.current = selection.lastAutoName

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -151,6 +151,7 @@ import {
 } from '@/lib/workspace-create-error-format'
 import type { SshConnectionStatus } from '../../../shared/ssh-types'
 import {
+  isBranchCheckedOutInWorktrees,
   resolveComposerBranchNameOverrideForCreate,
   resolveComposerBranchReuse,
   resolveComposerBranchSelection
@@ -2555,27 +2556,41 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       // Why (#5181): reuse an existing local branch (check it out) instead of
       // branching off it. Default reuse ON when the worktree name was
       // auto-derived from the branch, and preserve name edits so reuse survives
-      // renaming the worktree folder.
+      // renaming the worktree folder. Reuse is impossible when the branch is
+      // already checked out in another worktree (git allows it in only one), so
+      // gate eligibility on that and don't pin the override to a busy branch.
+      const branchCheckedOutElsewhere = isBranchCheckedOutInWorktrees(
+        localBranchName,
+        (worktreesByRepo[repoId] ?? []).map((worktree) => worktree.branch)
+      )
       const { reuseEligibleBranch: nextReuseEligibleBranch, defaultReuse } =
         resolveComposerBranchReuse({
           refName,
           localBranchName,
-          selectionProducedOverride: selection.branchNameOverride !== undefined
+          selectionProducedOverride: selection.branchNameOverride !== undefined,
+          branchCheckedOutElsewhere
         })
       setReuseEligibleBranch(nextReuseEligibleBranch)
       setReuseSelectedBranch(defaultReuse)
       setBranchNameOverridePreservesNameEdits(defaultReuse)
+      // Why: a busy local branch can't be reused — keeping it as the override
+      // would collide and silently produce a suffixed branch, so drop it and let
+      // the worktree name derive a fresh branch from the selected ref as base.
+      const effectiveOverride =
+        branchCheckedOutElsewhere && refName === localBranchName
+          ? undefined
+          : selection.branchNameOverride
       if (selection.name !== undefined && selection.lastAutoName !== undefined) {
         setName(selection.name)
         lastAutoNameRef.current = selection.lastAutoName
-        branchAutoNameRef.current = selection.branchAutoName
-        setBranchNameOverride(selection.branchNameOverride)
+        branchAutoNameRef.current = effectiveOverride ? selection.branchAutoName : ''
+        setBranchNameOverride(effectiveOverride)
       } else {
-        setBranchNameOverride(selection.branchNameOverride)
-        branchAutoNameRef.current = selection.branchAutoName
+        setBranchNameOverride(effectiveOverride)
+        branchAutoNameRef.current = effectiveOverride ? selection.branchAutoName : ''
       }
     },
-    [name]
+    [name, worktreesByRepo, repoId]
   )
 
   const handleReuseSelectedBranchChange = useCallback(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1024,6 +1024,8 @@
         "d71cd3003e": "+ Assignee"
       },
       "NewWorkspaceComposerCard": {
+        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it.",
         "cbb47ee0dc": "Only available for local Git projects.",
         "d861de981b": "Sparse checkout",
         "090cfedeb4": "Write a note",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1024,7 +1024,7 @@
         "d71cd3003e": "+ Assignee"
       },
       "NewWorkspaceComposerCard": {
-        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranch": "Reuse branch",
         "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it.",
         "cbb47ee0dc": "Only available for local Git projects.",
         "d861de981b": "Sparse checkout",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1076,7 +1076,9 @@
         "setupKindFolder": "Folder",
         "setupHostExistingFolderHelp": "Link a checkout that already exists there, then create this workspace on that host.",
         "importingHostSetup": "Importing...",
-        "importHostSetup": "Import"
+        "importHostSetup": "Import",
+        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it."
       },
       "NewWorkspaceComposerModal": {
         "fa90f739a5": "Elija el proyecto, el nombre del espacio de trabajo y el agente antes de crear el espacio de trabajo."

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1077,7 +1077,7 @@
         "setupHostExistingFolderHelp": "Link a checkout that already exists there, then create this workspace on that host.",
         "importingHostSetup": "Importing...",
         "importHostSetup": "Import",
-        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranch": "Reuse branch",
         "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it."
       },
       "NewWorkspaceComposerModal": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1076,7 +1076,9 @@
         "setupKindFolder": "Folder",
         "setupHostExistingFolderHelp": "Link a checkout that already exists there, then create this workspace on that host.",
         "importingHostSetup": "Importing...",
-        "importHostSetup": "インポート"
+        "importHostSetup": "インポート",
+        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it."
       },
       "NewWorkspaceComposerModal": {
         "fa90f739a5": "ワークスペースを作成する前に、プロジェクト、ワークスペース名、および agent を選択します。"

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1077,7 +1077,7 @@
         "setupHostExistingFolderHelp": "Link a checkout that already exists there, then create this workspace on that host.",
         "importingHostSetup": "Importing...",
         "importHostSetup": "インポート",
-        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranch": "Reuse branch",
         "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it."
       },
       "NewWorkspaceComposerModal": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1076,7 +1076,9 @@
         "setupKindFolder": "Folder",
         "setupHostExistingFolderHelp": "Link a checkout that already exists there, then create this workspace on that host.",
         "importingHostSetup": "Importing...",
-        "importHostSetup": "가져오기"
+        "importHostSetup": "가져오기",
+        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it."
       },
       "NewWorkspaceComposerModal": {
         "fa90f739a5": "워크스페이스를 생성하기 전에 프로젝트, 워크스페이스 이름, agent를 선택하세요."
@@ -4375,10 +4377,10 @@
           "5f5142a62a": "이전 아이콘"
         },
         "AppearancePane": {
+          "3057983501": "할당되지 않음",
           "872af9556e": "시스템 트레이",
           "2edf606c46": "닫을 때 트레이로 최소화",
           "b707773a0d": "활성화하면 창을 닫아도 Orca가 종료되지 않고 시스템 트레이에서 계속 실행됩니다.",
-          "3057983501": "할당되지 않음",
           "0cd9b8228f": "Dock 및 창 전환기에 표시된 앱 아이콘을 선택합니다.",
           "ca1590d42f": "앱 아이콘",
           "61d842eca0": "사이드바에 Orca Mobile 바로가기를 표시합니다. 도구 상자에서는 계속 사용할 수 있습니다.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1077,7 +1077,7 @@
         "setupHostExistingFolderHelp": "Link a checkout that already exists there, then create this workspace on that host.",
         "importingHostSetup": "Importing...",
         "importHostSetup": "가져오기",
-        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranch": "Reuse branch",
         "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it."
       },
       "NewWorkspaceComposerModal": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1076,7 +1076,9 @@
         "setupKindFolder": "文件夹",
         "setupHostExistingFolderHelp": "链接已存在的检出目录，然后在该主机上创建此工作区。",
         "importingHostSetup": "导入中...",
-        "importHostSetup": "导入"
+        "importHostSetup": "导入",
+        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it."
       },
       "NewWorkspaceComposerModal": {
         "fa90f739a5": "创建工作区之前选择项目、工作区名称和 Agent。"

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1077,7 +1077,7 @@
         "setupHostExistingFolderHelp": "链接已存在的检出目录，然后在该主机上创建此工作区。",
         "importingHostSetup": "导入中...",
         "importHostSetup": "导入",
-        "reuseExistingBranch": "Reuse this branch",
+        "reuseExistingBranch": "Reuse branch",
         "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it."
       },
       "NewWorkspaceComposerModal": {

--- a/src/shared/composer-branch-selection.ts
+++ b/src/shared/composer-branch-selection.ts
@@ -36,6 +36,30 @@ export function resolveComposerBranchSelection(args: {
   }
 }
 
+/**
+ * Issue #5181: decide whether a picked branch row is an existing LOCAL branch
+ * that can be reused (checked out) instead of branched off, and whether reuse
+ * should default ON.
+ *
+ * A branch is local when its ref and local name match — remote-only refs carry
+ * an `origin/`-style prefix (e.g. refName `origin/foo`, localBranchName `foo`),
+ * so they are not reusable as-is. Reuse defaults ON only when the worktree name
+ * was auto-derived from the branch (the selection produced a branch-name
+ * override); a user who typed a custom worktree name first is branching off the
+ * ref, so reuse stays OFF unless they opt in.
+ */
+export function resolveComposerBranchReuse(args: {
+  refName: string
+  localBranchName: string
+  selectionProducedOverride: boolean
+}): { reuseEligibleBranch: string | null; defaultReuse: boolean } {
+  const reuseEligibleBranch = args.refName === args.localBranchName ? args.localBranchName : null
+  return {
+    reuseEligibleBranch,
+    defaultReuse: reuseEligibleBranch !== null && args.selectionProducedOverride
+  }
+}
+
 export function resolveComposerBranchNameOverrideForCreate(args: {
   branchNameOverride: string | undefined
   branchAutoName: string

--- a/src/shared/composer-branch-selection.ts
+++ b/src/shared/composer-branch-selection.ts
@@ -77,6 +77,26 @@ export function resolveComposerBranchReuse(args: {
   }
 }
 
+/**
+ * Issue #5181: the branch-name override to apply for a picked branch. A local
+ * branch already checked out in another worktree can't be reused, so it must
+ * NOT be pinned as the override — pinning it would collide and silently produce
+ * a suffixed branch. In that case fall back to letting the worktree name derive
+ * a fresh branch from the selected ref as base; otherwise use the selection's
+ * override unchanged.
+ */
+export function resolveComposerReuseOverride(args: {
+  refName: string
+  localBranchName: string
+  branchNameOverride: string | undefined
+  branchCheckedOutElsewhere: boolean
+}): string | undefined {
+  if (args.branchCheckedOutElsewhere && args.refName === args.localBranchName) {
+    return undefined
+  }
+  return args.branchNameOverride
+}
+
 export function resolveComposerBranchNameOverrideForCreate(args: {
   branchNameOverride: string | undefined
   branchAutoName: string

--- a/src/shared/composer-branch-selection.ts
+++ b/src/shared/composer-branch-selection.ts
@@ -37,23 +37,40 @@ export function resolveComposerBranchSelection(args: {
 }
 
 /**
+ * True when `branchName` is already checked out in one of the given worktree
+ * branch refs (which may be `refs/heads/foo` or short `foo`). Git refuses to
+ * check out a branch in two worktrees, so such a branch cannot be reused.
+ */
+export function isBranchCheckedOutInWorktrees(
+  branchName: string,
+  worktreeBranches: readonly string[]
+): boolean {
+  return worktreeBranches.some((ref) => ref.replace(/^refs\/heads\//, '') === branchName)
+}
+
+/**
  * Issue #5181: decide whether a picked branch row is an existing LOCAL branch
  * that can be reused (checked out) instead of branched off, and whether reuse
  * should default ON.
  *
- * A branch is local when its ref and local name match — remote-only refs carry
- * an `origin/`-style prefix (e.g. refName `origin/foo`, localBranchName `foo`),
- * so they are not reusable as-is. Reuse defaults ON only when the worktree name
- * was auto-derived from the branch (the selection produced a branch-name
- * override); a user who typed a custom worktree name first is branching off the
- * ref, so reuse stays OFF unless they opt in.
+ * Reuse is only possible for a LOCAL branch (ref === local name; remote-only
+ * refs carry an `origin/`-style prefix) that is NOT already checked out in
+ * another worktree — git allows a branch in only one worktree at a time. Reuse
+ * defaults ON only when the worktree name was auto-derived from the branch (the
+ * selection produced a branch-name override); a user who typed a custom
+ * worktree name first is branching off the ref, so reuse stays OFF unless they
+ * opt in.
  */
 export function resolveComposerBranchReuse(args: {
   refName: string
   localBranchName: string
   selectionProducedOverride: boolean
+  branchCheckedOutElsewhere: boolean
 }): { reuseEligibleBranch: string | null; defaultReuse: boolean } {
-  const reuseEligibleBranch = args.refName === args.localBranchName ? args.localBranchName : null
+  const reuseEligibleBranch =
+    args.refName === args.localBranchName && !args.branchCheckedOutElsewhere
+      ? args.localBranchName
+      : null
   return {
     reuseEligibleBranch,
     defaultReuse: reuseEligibleBranch !== null && args.selectionProducedOverride


### PR DESCRIPTION
## Summary

Fixes #5181 — adds an explicit, discoverable way to **reuse an existing branch** when creating a worktree, instead of always creating a new branch from it.

When you select an existing **local** branch in the new‑worktree composer, a **"Reuse branch"** checkbox appears directly under the branch selection (defaults on). With it checked, Orca checks that branch out into the new worktree; unchecking it creates a fresh branch from the selected ref as base.

### Why it's valid
A `checkoutExistingBranch` path shipped in #2543, but it was **implicit**: reuse only triggered when the auto‑filled worktree name stayed equal to the branch, and **editing the worktree name silently reverted to "create a new branch"** with no feedback. There was no discoverable control — the reporter filed this 3 weeks later saying it was "impossible." This PR makes it explicit and durable.

## Approach (renderer‑only)

Picking an existing local branch already sets `baseBranch === branchNameOverride === <branch>`, so the existing backend reuse path (`git worktree add <path> <branch>`, `preserveBranchOnDelete`) checks the branch out across **local, SSH, and runtime** — no backend/IPC/schema changes. The checkbox pins that override via the existing `branchNameOverridePreservesNameEdits` flag so reuse survives renaming the worktree folder (the folder name lives in Advanced and can differ from the branch).

### UX details
- The checkbox sits under the branch (smart) field, labelled **"Reuse branch"**, visible without expanding Advanced.
- **Dynamic eligibility:** hidden for remote‑only refs (`origin/…`) and for a branch already checked out in another worktree (git allows a branch in only one worktree). When a busy branch is picked, the override isn't pinned, so creation cleanly falls back to a new branch from that ref.
- The row collapses via a grid‑rows transition (matching the Advanced drawer) so the dialog height changes smoothly when the option appears/disappears.

## Verification
- Real‑git proof of diverged‑branch reuse into an independently‑named folder; pure helpers (`resolveComposerBranchReuse`, `isBranchCheckedOutInWorktrees`, `resolveComposerReuseOverride`) unit‑tested; component render tests (checkbox shown/collapsed, both‑direction toggle); backend integration test (renamed folder still reuses → `checkoutExistingBranch` + `preserveBranchOnDelete`).
- Full typecheck (node/cli/web), oxlint, localization catalog all clean; no regressions.
- Verified live in an Electron dev build; screenshots in the PR comments.
- Multi‑dimensional review run to clean (6 low‑severity nits found and fixed: state resets on repo/project switch, collapsed‑checkbox `disabled`, override‑helper extraction + tests).
