### PR TITLE
fix(store): purge per-file editor and git-huge state on worktree removal

### DIFF
--- a/src/renderer/src/store/slices/editor-state-worktree-purge-leak.test.ts
+++ b/src/renderer/src/store/slices/editor-state-worktree-purge-leak.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Memory-leak regression: per-file and per-worktree editor state must be purged
+ * when a worktree is removed.
+ *
+ * `editorCursorLine` and `editorViewMode` are keyed by fileId and
+ * `gitStatusHugeByWorktree` is keyed by worktreeId. Both worktree-removal paths
+ * — the bulk `purgeWorktreeTerminalState` (used by the authoritative-scan
+ * reconcile) and the single `removeWorktree` — failed to drop these entries, so
+ * they accumulated one record per file/worktree for the lifetime of the
+ * renderer session.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+const mockApi = {
+  worktrees: {
+    list: vi.fn().mockResolvedValue([]),
+    remove: vi.fn().mockResolvedValue(undefined),
+    forceDeletePreservedBranch: vi.fn().mockResolvedValue({ deleted: true }),
+    updateMeta: vi.fn().mockResolvedValue({})
+  },
+  pty: { kill: vi.fn().mockResolvedValue(undefined) },
+  runtimeEnvironments: { call: vi.fn().mockResolvedValue({ ok: true, result: {} }) }
+}
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: mockApi }
+
+import { createTestStore, seedStore, makeWorktree, makeOpenFile } from './store-test-helpers'
+
+const WT = 'repo1::/path/wt1'
+const FILE_A = '/path/wt1/a.ts'
+const FILE_B = '/path/wt1/b.ts'
+
+function seedEditorState(store: ReturnType<typeof createTestStore>): void {
+  seedStore(store, {
+    worktreesByRepo: {
+      repo1: [makeWorktree({ id: WT, repoId: 'repo1', path: '/path/wt1' })]
+    },
+    openFiles: [
+      makeOpenFile({ id: FILE_A, worktreeId: WT }),
+      makeOpenFile({ id: FILE_B, worktreeId: WT })
+    ],
+    editorCursorLine: { [FILE_A]: 12, [FILE_B]: 4 },
+    editorViewMode: { [FILE_A]: 'changes', [FILE_B]: 'edit' },
+    gitStatusHugeByWorktree: { [WT]: { limit: 1000 } }
+  })
+}
+
+describe('worktree removal purges per-file editor + git-huge state (leak regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.worktrees.remove.mockResolvedValue(undefined)
+  })
+
+  it('bulk purgeWorktreeTerminalState drops editor + git-huge state for the removed worktree', () => {
+    const store = createTestStore()
+    seedEditorState(store)
+
+    store.getState().purgeWorktreeTerminalState([WT])
+
+    const s = store.getState()
+    expect(s.editorCursorLine[FILE_A]).toBeUndefined()
+    expect(s.editorCursorLine[FILE_B]).toBeUndefined()
+    expect(s.editorViewMode[FILE_A]).toBeUndefined()
+    expect(s.editorViewMode[FILE_B]).toBeUndefined()
+    expect(s.gitStatusHugeByWorktree[WT]).toBeUndefined()
+  })
+
+  it('single removeWorktree drops editor + git-huge state for the removed worktree', async () => {
+    const store = createTestStore()
+    seedEditorState(store)
+
+    const result = await store.getState().removeWorktree(WT)
+    expect(result).toEqual({ ok: true })
+
+    const s = store.getState()
+    expect(s.editorCursorLine[FILE_A]).toBeUndefined()
+    expect(s.editorCursorLine[FILE_B]).toBeUndefined()
+    expect(s.editorViewMode[FILE_A]).toBeUndefined()
+    expect(s.gitStatusHugeByWorktree[WT]).toBeUndefined()
+  })
+
+  it('keeps editor + git-huge state for worktrees that are NOT removed', () => {
+    const store = createTestStore()
+    const OTHER = 'repo1::/path/wt2'
+    const OTHER_FILE = '/path/wt2/keep.ts'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: WT, repoId: 'repo1', path: '/path/wt1' }),
+          makeWorktree({ id: OTHER, repoId: 'repo1', path: '/path/wt2' })
+        ]
+      },
+      openFiles: [
+        makeOpenFile({ id: FILE_A, worktreeId: WT }),
+        makeOpenFile({ id: OTHER_FILE, worktreeId: OTHER })
+      ],
+      editorCursorLine: { [FILE_A]: 12, [OTHER_FILE]: 7 },
+      editorViewMode: { [FILE_A]: 'changes', [OTHER_FILE]: 'edit' },
+      gitStatusHugeByWorktree: { [WT]: { limit: 1000 }, [OTHER]: { limit: 2000 } }
+    })
+
+    store.getState().purgeWorktreeTerminalState([WT])
+
+    const s = store.getState()
+    expect(s.editorCursorLine[OTHER_FILE]).toBe(7)
+    expect(s.editorViewMode[OTHER_FILE]).toBe('edit')
+    expect(s.gitStatusHugeByWorktree[OTHER]).toEqual({ limit: 2000 })
+  })
+})

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1191,12 +1191,19 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     gitBranchCompareRequestStatusHeadByWorktree: omitByWorktree(
       s.gitBranchCompareRequestStatusHeadByWorktree
     ),
+    // Why: keyed by worktreeId; without this it leaks a huge-status marker per
+    // removed worktree for the rest of the session.
+    gitStatusHugeByWorktree: omitByWorktree(s.gitStatusHugeByWorktree),
     showDotfilesByWorktree: omitByWorktree(s.showDotfilesByWorktree),
     expandedDirs: omitByWorktree(s.expandedDirs),
     // Per-file editor state for removed files
     editorDrafts: omitByFileId(s.editorDrafts),
     markdownViewMode: omitByFileId(s.markdownViewMode),
     markdownFrontmatterVisible: omitByFileId(s.markdownFrontmatterVisible),
+    // Why: keyed by fileId; the bulk reconcile path previously kept these,
+    // leaking a cursor-line / view-mode entry per file of every removed worktree.
+    editorCursorLine: omitByFileId(s.editorCursorLine),
+    editorViewMode: omitByFileId(s.editorViewMode),
     // Top-level actives
     openFiles: nextOpenFiles,
     everActivatedWorktreeIds: nextEverActivatedWorktreeIds,
@@ -2010,18 +2017,27 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           removedFileIds.size > 0
             ? { ...s.markdownFrontmatterVisible }
             : s.markdownFrontmatterVisible
+        // Why: editorCursorLine is keyed by fileId and must be cleared with the
+        // other per-file editor state so it does not leak per removed file.
+        const nextEditorCursorLine =
+          removedFileIds.size > 0 ? { ...s.editorCursorLine } : s.editorCursorLine
         if (removedFileIds.size > 0) {
           for (const fileId of removedFileIds) {
             delete nextEditorDrafts[fileId]
             delete nextMarkdownViewMode[fileId]
             delete nextEditorViewMode[fileId]
             delete nextMarkdownFrontmatterVisible[fileId]
+            delete nextEditorCursorLine[fileId]
           }
         }
         const nextExpandedDirs = { ...s.expandedDirs }
         delete nextExpandedDirs[worktreeId]
         const nextShowDotfilesByWorktree = { ...s.showDotfilesByWorktree }
         delete nextShowDotfilesByWorktree[worktreeId]
+        // Why: keyed by worktreeId; clear the huge-status marker so it does not
+        // linger after the worktree is gone.
+        const nextGitStatusHugeByWorktree = { ...s.gitStatusHugeByWorktree }
+        delete nextGitStatusHugeByWorktree[worktreeId]
         const nextRightSidebarExplorerViewByWorktree = {
           ...s.rightSidebarExplorerViewByWorktree
         }
@@ -2089,8 +2105,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           markdownViewMode: nextMarkdownViewMode,
           editorViewMode: nextEditorViewMode,
           markdownFrontmatterVisible: nextMarkdownFrontmatterVisible,
+          editorCursorLine: nextEditorCursorLine,
           showDotfilesByWorktree: nextShowDotfilesByWorktree,
           expandedDirs: nextExpandedDirs,
+          gitStatusHugeByWorktree: nextGitStatusHugeByWorktree,
           gitStatusByWorktree: nextGitStatusByWorktree,
           gitStatusHeadByWorktree: nextGitStatusHeadByWorktree,
           gitIgnoredPathsByWorktree: nextGitIgnoredPathsByWorktree,


### PR DESCRIPTION
## Summary

Three Zustand store records were never dropped when a worktree was removed, so they accumulated one entry per file/worktree for the lifetime of the renderer session (a long-running desktop app):

- `editorCursorLine` — `Record<fileId, number>`
- `editorViewMode` — `Record<fileId, 'edit' | 'changes'>`
- `gitStatusHugeByWorktree` — `Record<worktreeId, { limit }>`

There are two worktree-removal paths. The **bulk** path (`buildWorktreePurgeState`, used by the authoritative-scan reconcile via `purgeWorktreeTerminalState`) omitted **all three**. The **single** path (`removeWorktree`) omitted `editorCursorLine` and `gitStatusHugeByWorktree` (it already handled `editorViewMode`). This fix adds the missing fields to both paths, mirroring the existing per-file (`omitByFileId`) and per-worktree (`omitByWorktree`) cleanup already applied to sibling maps right next to them.

No visual change.

## Evidence

**Leak reproduced (before fix).** The new regression test seeds editor state for a worktree, removes the worktree, and asserts the records are gone. On the unfixed code:

```
× bulk purgeWorktreeTerminalState drops editor + git-huge state for the removed worktree
× single removeWorktree drops editor + git-huge state for the removed worktree
AssertionError: expected 12 to be undefined   // editorCursorLine[file] retained
```

The third test ("keeps editor + git-huge state for worktrees that are NOT removed") **passed before and after**, confirming the harness only asserts removal of the *removed* worktree's entries (no over-pruning).

**Resolved (after fix).**

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

**No functional regression.** Existing suites covering these paths stay green:

```
✓ worktrees.test.ts ✓ store-cascades.test.ts ✓ workspace-cleanup.test.ts ✓ pinned-tab-close-guard.test.ts
Test Files  4 passed (4)
     Tests  254 passed (254)
```

Plus `oxlint` clean on the changed files and renderer typecheck (`tsgo -p config/tsconfig.tc.web.json`) passes.

## Testing

- [x] `pnpm test` (targeted: new test + 4 related suites, 257 passing)
- [x] `pnpm typecheck` (renderer project)
- [x] `pnpm lint` (oxlint on changed files; pre-commit hook clean)
- [x] Added a high-quality regression test that fails before the fix and passes after

## AI Review Report

Found by an adversarial multi-agent memory-leak audit (collection-growth lens), then independently verified by reading both removal paths in `worktrees.ts`. Risk reviewed: over-pruning (dropping state for the wrong worktree) — covered by the negative-control test. Cross-platform: pure in-memory store logic, no platform-specific behavior, paths, shortcuts, or IPC touched.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or IPC changes. Pure renderer store state cleanup.

## Notes

Part of a series of independently-reviewable memory-leak fixes. In-memory only (resets on app restart); impact is steady growth across a long multi-worktree session.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5782">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->