### PR TITLE
fix(store): evict PR & commit-message generation records on worktree removal

### DIFF
--- a/src/renderer/src/store/slices/generation-records-worktree-removal-leak.test.ts
+++ b/src/renderer/src/store/slices/generation-records-worktree-removal-leak.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Memory-leak regression: PR-generation and commit-message-generation records
+ * must be evicted when their worktree is removed.
+ *
+ * Both records are keyed by worktree (the PR map by a composite
+ * [repoId, worktreeKey, branch] key, the commit map by worktreeKey) and each
+ * retains generated title/body/message text. The slices ship tested
+ * `prunePullRequestGenerationRecords` / `pruneCommitMessageGenerationRecords`
+ * actions, but nothing in production called them on worktree removal, so the
+ * records accumulated one entry per worktree for the renderer session.
+ * `removeWorktree` now prunes both maps to the surviving worktree set.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+const mockApi = {
+  worktrees: {
+    list: vi.fn().mockResolvedValue([]),
+    remove: vi.fn().mockResolvedValue(undefined),
+    forceDeletePreservedBranch: vi.fn().mockResolvedValue({ deleted: true }),
+    updateMeta: vi.fn().mockResolvedValue({})
+  },
+  pty: { kill: vi.fn().mockResolvedValue(undefined) },
+  runtimeEnvironments: { call: vi.fn() }
+}
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: mockApi }
+
+import { createTestStore, seedStore, makeWorktree } from './store-test-helpers'
+import {
+  getPullRequestGenerationRecordKey,
+  type PullRequestGenerationRecord
+} from './pull-request-generation'
+import {
+  getCommitMessageGenerationRecordKey,
+  type CommitMessageGenerationRecord
+} from './commit-message-generation'
+
+const REPO = 'repo1'
+const WT = 'repo1::/path/wt1'
+const WT_PATH = '/path/wt1'
+const OTHER = 'repo1::/path/wt2'
+const OTHER_PATH = '/path/wt2'
+const BRANCH = 'refs/heads/feature'
+
+function prRecord(worktreeId: string, worktreePath: string): PullRequestGenerationRecord {
+  return {
+    context: { worktreeId, worktreePath, requestId: 1, repoId: REPO, branch: BRANCH },
+    seed: { base: 'main', title: 'Title', body: 'Body', draft: false },
+    seedFieldRevisions: { base: 0, title: 0, body: 0, draft: 0 },
+    status: 'succeeded',
+    result: null,
+    error: null,
+    hydrated: true
+  }
+}
+
+function commitRecord(worktreeId: string, worktreePath: string): CommitMessageGenerationRecord {
+  return {
+    context: { worktreeId, worktreePath, requestId: 1 },
+    status: 'succeeded',
+    message: 'a generated commit message',
+    error: null,
+    hydrated: true
+  }
+}
+
+function prKey(worktreeId: string, worktreePath: string): string {
+  const key = getPullRequestGenerationRecordKey({
+    worktreeId,
+    worktreePath,
+    repoId: REPO,
+    branch: BRANCH
+  })
+  if (!key) {
+    throw new Error('expected a PR generation key')
+  }
+  return key
+}
+
+function commitKey(worktreeId: string, worktreePath: string): string {
+  const key = getCommitMessageGenerationRecordKey(worktreeId, worktreePath)
+  if (!key) {
+    throw new Error('expected a commit generation key')
+  }
+  return key
+}
+
+describe('worktree removal evicts generation records (leak regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.worktrees.remove.mockResolvedValue(undefined)
+  })
+
+  it('removes PR + commit generation records for the removed worktree and keeps others', async () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: WT, repoId: REPO, path: WT_PATH }),
+          makeWorktree({ id: OTHER, repoId: REPO, path: OTHER_PATH })
+        ]
+      }
+    })
+    store.getState().setPullRequestGenerationRecord(prKey(WT, WT_PATH), prRecord(WT, WT_PATH))
+    store
+      .getState()
+      .setPullRequestGenerationRecord(prKey(OTHER, OTHER_PATH), prRecord(OTHER, OTHER_PATH))
+    store
+      .getState()
+      .setCommitMessageGenerationRecord(commitKey(WT, WT_PATH), commitRecord(WT, WT_PATH))
+    store
+      .getState()
+      .setCommitMessageGenerationRecord(
+        commitKey(OTHER, OTHER_PATH),
+        commitRecord(OTHER, OTHER_PATH)
+      )
+
+    const result = await store.getState().removeWorktree(WT)
+    expect(result).toEqual({ ok: true })
+
+    const s = store.getState()
+    // Removed worktree's records are gone (the leak).
+    expect(s.pullRequestGenerationRecords[prKey(WT, WT_PATH)]).toBeUndefined()
+    expect(s.commitMessageGenerationRecords[commitKey(WT, WT_PATH)]).toBeUndefined()
+    // Surviving worktree's records are preserved (no over-pruning).
+    expect(s.pullRequestGenerationRecords[prKey(OTHER, OTHER_PATH)]).toBeDefined()
+    expect(s.commitMessageGenerationRecords[commitKey(OTHER, OTHER_PATH)]).toBeDefined()
+  })
+})

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2110,6 +2110,19 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         }
       })
       get().removeWorkspaceSpaceWorktrees?.([worktreeId])
+      // Why: PR/commit-message generation records are keyed by worktree and were
+      // never evicted on removal — they leaked one record (title/body text) per
+      // worktree for the session. Prune to the surviving worktree set, reusing
+      // the generation slices' tested prune actions.
+      const liveWorktreeKeys = new Set(
+        get()
+          .allWorktrees()
+          .map((w) => w.id)
+      )
+      // Optional-chained like removeWorkspaceSpaceWorktrees above: minimal store
+      // assemblies (some unit tests) omit the generation slices.
+      get().prunePullRequestGenerationRecords?.(liveWorktreeKeys)
+      get().pruneCommitMessageGenerationRecords?.(liveWorktreeKeys)
       const preservedBranch = removalResult?.preservedBranch
       if (preservedBranch) {
         showPreservedBranchToast(removalResult, worktreeBeforeRemoval, (branch, expectedHead) => {


### PR DESCRIPTION
## Summary

Two Zustand store maps that hold AI-generated text were never evicted when their worktree was removed:

- `pullRequestGenerationRecords` — keyed by `[repoId, worktreeKey, branch]`; each record retains generated PR `title` + `body` (plus seed revisions).
- `commitMessageGenerationRecords` — keyed by worktree; each retains a generated commit `message`.

Both slices already ship tested prune actions (`prunePullRequestGenerationRecords` / `pruneCommitMessageGenerationRecords`), but **no production code ever called them** — they were dead cleanup functions. So every worktree that ran PR/commit generation left a record behind for the lifetime of the renderer session.

`removeWorktree` now prunes both maps to the surviving worktree set, reusing those existing tested actions. The calls are optional-chained exactly like the adjacent `removeWorkspaceSpaceWorktrees?.(...)` call, because minimal unit-test store assemblies omit the generation slices.

No visual change.

## Evidence

**Leak reproduced (before fix).** New regression test seeds PR + commit records for two worktrees, removes one, and asserts its records are gone. On the unfixed code the removed worktree's record (with its full title/body payload) is retained:

```
× removes PR + commit generation records for the removed worktree and keeps others
AssertionError: expected { context: {…}, … } to be undefined
+ Received: { context: { worktreeId: "repo1::/path/wt1", branch: "refs/heads/feature", … },
             seed: { title: "Title", body: "Body", … }, status: "succeeded" }
```

**Resolved (after fix).**

```
Test Files  1 passed (1)
     Tests  1 passed (1)
```

The same test also asserts the *other* worktree's records survive (no over-pruning).

**No functional regression.** Worktree-removal suites stay green:

```
✓ store-cascades.test.ts ✓ worktrees.test.ts
Test Files  2 passed (2)
     Tests  234 passed (234)
```

Plus `oxlint` clean and renderer typecheck (`tsgo -p config/tsconfig.tc.web.json`) passes.

## Testing

- [x] `pnpm test` (new test + 2 worktree-removal suites, 235 passing)
- [x] `pnpm typecheck` (renderer project)
- [x] `pnpm lint` (oxlint on changed files; pre-commit hook clean)
- [x] Added a regression test that fails before the fix and passes after

## AI Review Report

Found by an adversarial multi-agent memory-leak audit (dead-cleanup / collection-growth lens) and verified by tracing every caller of the prune actions (only tests/mocks before this change). Risk reviewed: over-pruning records for live worktrees (covered by the negative assertion) and calling actions absent in minimal store assemblies (handled with optional chaining, matching the adjacent call). Cross-platform: pure in-memory store logic — no platform-specific paths, shortcuts, or IPC.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or IPC changes. Renderer store cleanup only.

## Notes

`removeWorktree` is the explicit user-facing "delete worktree" path. In-memory only (resets on restart); impact is steady growth of retained generated text across a long multi-worktree session.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5784">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->