### PR TITLE
Allow hiding Orca Mobile sidebar button once a device is paired

### DIFF
--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -1300,6 +1300,9 @@
   color: var(--m-text-primary);
   font-size: 13px;
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .mobile-page-root .mp-resume-sub {
@@ -1309,6 +1312,15 @@
   margin-top: 2px;
   color: var(--m-text-secondary);
   font-size: 11px;
+  min-width: 0;
+}
+
+/* Why: keep long repo/branch labels inside the phone frame (matches RN numberOfLines={1}). */
+.mobile-page-root .mp-resume-sub > span:not(.mp-repo-dot) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .mobile-page-root .mp-repo-dot {

--- a/src/renderer/src/components/mobile/MobileHeroPairedDevices.tsx
+++ b/src/renderer/src/components/mobile/MobileHeroPairedDevices.tsx
@@ -1,12 +1,8 @@
 import { Smartphone, Trash2 } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
+import type { PairedMobileDevice } from './paired-mobile-devices'
 
-export type PairedDevice = {
-  deviceId: string
-  name: string
-  pairedAt: number
-  lastSeenAt: number
-}
+export type PairedDevice = PairedMobileDevice
 
 type HeroPairedProps = {
   devices: readonly PairedDevice[]

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -2,26 +2,21 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { useAppStore } from '@/store'
-import type { PairedDevice, Platform, StepIndex } from './MobileHero'
+import type { Platform, StepIndex } from './MobileHero'
 import type { IosChannel } from './mobile-platform-copy'
 import {
   selectRefreshedNetworkAddress,
   type MobileNetworkInterface
 } from '../settings/mobile-network-interface-selection'
-import { useMobilePairingDevicePolling } from '../settings/mobile-pairing-device-polling'
-import {
-  shouldShowPairedAfterDeviceRefresh,
-  type MobilePageStage as FlowStage
-} from './mobile-page-stage'
 import { translate } from '@/i18n/i18n'
 import { useMobilePageEscape } from './use-mobile-page-escape'
 import { MobilePageContent } from './MobilePageContent'
 import { useMobileInstallQr } from './use-mobile-install-qr'
 import type { MobilePairingConnectionMode } from '../../../../shared/mobile-pairing-connection-mode'
 import { useMobileInstallActions } from './use-mobile-install-actions'
+import { useMobilePagePairedDevices } from './use-mobile-page-paired-devices'
 
 export default function MobilePage(): React.JSX.Element {
-  const [stage, setStage] = useState<FlowStage | null>(null)
   const [stepIdx, setStepIdx] = useState<StepIndex>(0)
 
   const [platform, setPlatform] = useState<Platform>('ios')
@@ -43,133 +38,25 @@ export default function MobilePage(): React.JSX.Element {
   // refresh path can keep their choice instead of snapping back to LAN.
   const [addressIsManual, setAddressIsManual] = useState(false)
   const [refreshingNetworkInterfaces, setRefreshingNetworkInterfaces] = useState(false)
-  const [devices, setDevices] = useState<PairedDevice[]>([])
-  const [revokingDeviceIds, setRevokingDeviceIds] = useState<string[]>([])
-  const [deviceCountAtPairStart, setDeviceCountAtPairStart] = useState<number | null>(null)
   const hasGeneratedRef = useRef(false)
   const pairingRequestIdRef = useRef(0)
   const wasSignedInRef = useRef(signedIn)
   const mountedRef = useMountedRef()
-  const stageRef = useRef<FlowStage | null>(null)
-  const deviceCountAtPairStartRef = useRef<number | null>(null)
   const closeMobilePage = useAppStore((s) => s.closeMobilePage)
   const showMobileButton = useAppStore((s) => s.settings?.showMobileButton !== false)
   const updateSettings = useAppStore((s) => s.updateSettings)
+  const {
+    devices,
+    enterFlow: showFirstPairingFlow,
+    handleBack,
+    pairAnotherDevice: showPairAnotherDeviceFlow,
+    revokeDevice,
+    revokingDeviceIds,
+    showPairedDevices,
+    stage
+  } = useMobilePagePairedDevices({ stepIdx, setStepIdx })
   const installQrUrl = useMobileInstallQr(stage, platform, iosChannel)
   const { copyInstallUrl, openInstallUrl } = useMobileInstallActions(platform, iosChannel)
-
-  const setPairingDeviceBaseline = useCallback(
-    (count: number | null): void => {
-      deviceCountAtPairStartRef.current = count
-      if (mountedRef.current) {
-        setDeviceCountAtPairStart(count)
-      }
-    },
-    [mountedRef]
-  )
-
-  const showStage = useCallback(
-    (nextStage: FlowStage | null): void => {
-      stageRef.current = nextStage
-      if (mountedRef.current) {
-        setStage(nextStage)
-      }
-    },
-    [mountedRef]
-  )
-
-  const showPairedDevices = useCallback(
-    (deviceCount: number): void => {
-      // Why: paired-view polling uses this baseline; setting it with the
-      // transition avoids the render-plus-Effect gap where polling stops.
-      setPairingDeviceBaseline(deviceCount)
-      showStage('paired')
-    },
-    [setPairingDeviceBaseline, showStage]
-  )
-
-  const loadDevices = useCallback(async (): Promise<PairedDevice[]> => {
-    try {
-      const result = await window.api.mobile.listDevices()
-      if (mountedRef.current) {
-        setDevices(result.devices)
-        if (
-          shouldShowPairedAfterDeviceRefresh({
-            stage: stageRef.current,
-            deviceCountAtPairStart: deviceCountAtPairStartRef.current,
-            nextDeviceCount: result.devices.length
-          })
-        ) {
-          showPairedDevices(result.devices.length)
-        }
-      }
-      return result.devices
-    } catch (err) {
-      // Log so a transient IPC failure (which routes the user to 'intro') is
-      // observable; keep returning [] so callers' behavior is unchanged.
-      console.error('mobile.listDevices failed', err)
-      return []
-    }
-  }, [mountedRef, showPairedDevices])
-
-  // Why: pick the initial stage based on whether any devices are already
-  // paired so returning users don't see the marketing intro every time.
-  useEffect(() => {
-    let cancelled = false
-    void (async () => {
-      const initialDevices = await loadDevices()
-      if (cancelled) {
-        return
-      }
-      if (initialDevices.length > 0) {
-        showPairedDevices(initialDevices.length)
-      } else {
-        showStage('intro')
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [loadDevices, showPairedDevices, showStage])
-
-  const revokeDevice = useCallback(
-    async (deviceId: string) => {
-      // Dedupe rapid double-clicks: if a revoke for this id is already in
-      // flight, bail before issuing a second IPC call.
-      let alreadyRevoking = false
-      setRevokingDeviceIds((prev) => {
-        if (prev.includes(deviceId)) {
-          alreadyRevoking = true
-          return prev
-        }
-        return [...prev, deviceId]
-      })
-      if (alreadyRevoking) {
-        return
-      }
-      try {
-        await window.api.mobile.revokeDevice({ deviceId })
-        const remaining = await loadDevices()
-        if (mountedRef.current) {
-          toast.success(translate('auto.components.mobile.MobilePage.255372e6e8', 'Device revoked'))
-        }
-        if (remaining.length === 0 && mountedRef.current) {
-          showStage('intro')
-        }
-      } catch {
-        if (mountedRef.current) {
-          toast.error(
-            translate('auto.components.mobile.MobilePage.4e1eb5d55c', 'Failed to revoke device')
-          )
-        }
-      } finally {
-        if (mountedRef.current) {
-          setRevokingDeviceIds((prev) => prev.filter((id) => id !== deviceId))
-        }
-      }
-    },
-    [loadDevices, mountedRef, showStage]
-  )
 
   const generatePairing = useCallback(
     async (
@@ -354,52 +241,24 @@ export default function MobilePage(): React.JSX.Element {
     void generatePairing(false)
   }, [stage, stepIdx, generatePairing])
 
-  // Why: poll for new pairings while the user is on Step 2 so we can
-  // auto-transition to the paired summary the moment their phone connects.
-  const polledLoadDevices = useCallback(async () => {
-    await loadDevices()
-  }, [loadDevices])
-
-  // Why: poll for new pairings on Step 2 (waiting for the first pair) and
-  // also on the paired view (so additional phones that finish pairing while
-  // the user is reading the list show up without a manual refresh).
-  useMobilePairingDevicePolling({
-    deviceCountAtQr:
-      (stage === 'flow' && stepIdx === 1) || stage === 'paired' ? deviceCountAtPairStart : null,
-    currentDeviceCount: devices.length,
-    loadDevices: polledLoadDevices
-  })
-
   const enterFlow = (): void => {
-    setStepIdx(0)
-    setPairingDeviceBaseline(devices.length)
     // Force the auto-generate effect to mint a fresh pairing token on next
     // entry into Step 2, and clear stale QR state so we never flash an
     // expired code from a previous session.
     hasGeneratedRef.current = false
     setPairQrDataUrl(null)
     setPairingUrl(null)
-    showStage('flow')
+    showFirstPairingFlow()
   }
 
   // Why: from the paired summary, "Pair another device" jumps straight to
   // Step 2 since the app is presumably already installed on the user's phone.
   const pairAnotherDevice = (): void => {
-    setStepIdx(1)
-    setPairingDeviceBaseline(devices.length)
     // Same reset as enterFlow — re-entering must mint a fresh pairing offer.
     hasGeneratedRef.current = false
     setPairQrDataUrl(null)
     setPairingUrl(null)
-    showStage('flow')
-  }
-
-  const handleBack = (): void => {
-    if (stepIdx === 1) {
-      setStepIdx(0)
-    } else {
-      showStage('intro')
-    }
+    showPairAnotherDeviceFlow()
   }
 
   const handleContinue = (): void => {

--- a/src/renderer/src/components/mobile/MobilePageContent.tsx
+++ b/src/renderer/src/components/mobile/MobilePageContent.tsx
@@ -12,7 +12,7 @@ type MobilePageContentProps = {
   closeMobilePage: () => void
   copyInstallUrl: () => void
   copyPairingCode: () => void
-  devices: PairedDevice[]
+  devices: readonly PairedDevice[]
   enterFlow: () => void
   generatePairing: (rotate: boolean) => void
   handleAddressChange: (address: string) => void
@@ -33,7 +33,7 @@ type MobilePageContentProps = {
   platform: Platform
   refreshingNetworkInterfaces: boolean
   revokeDevice: (id: string) => void
-  revokingDeviceIds: string[]
+  revokingDeviceIds: readonly string[]
   selectedAddress: string | undefined
   setPlatform: (platform: Platform) => void
   showMobileButton: boolean

--- a/src/renderer/src/components/mobile/paired-mobile-devices.test.ts
+++ b/src/renderer/src/components/mobile/paired-mobile-devices.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  _resetPairedMobileDevicesCacheForTests,
+  replacePairedMobileDevices,
+  refreshPairedMobileDevices
+} from './paired-mobile-devices'
+
+const listDevices = vi.fn()
+
+describe('paired mobile devices', () => {
+  beforeEach(() => {
+    _resetPairedMobileDevicesCacheForTests()
+    listDevices.mockReset()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        mobile: {
+          listDevices
+        }
+      }
+    })
+  })
+
+  it('coalesces concurrent refreshes onto one mobile device IPC call', async () => {
+    let resolveLookup: (value: { devices: [] }) => void = () => {}
+    const lookup = new Promise<{ devices: [] }>((resolve) => {
+      resolveLookup = resolve
+    })
+    listDevices.mockReturnValueOnce(lookup)
+
+    const first = refreshPairedMobileDevices()
+    const second = refreshPairedMobileDevices()
+
+    expect(listDevices).toHaveBeenCalledTimes(1)
+
+    resolveLookup({ devices: [] })
+    await expect(Promise.all([first, second])).resolves.toEqual([[], []])
+  })
+
+  it('returns the current cache when a newer write supersedes an in-flight refresh', async () => {
+    const staleDevice = { deviceId: 'old-phone', name: 'Old phone', pairedAt: 1, lastSeenAt: 2 }
+    const currentDevice = { deviceId: 'new-phone', name: 'New phone', pairedAt: 3, lastSeenAt: 4 }
+    let resolveLookup: (value: { devices: [typeof staleDevice] }) => void = () => {}
+    const lookup = new Promise<{ devices: [typeof staleDevice] }>((resolve) => {
+      resolveLookup = resolve
+    })
+    listDevices.mockReturnValueOnce(lookup)
+
+    const refresh = refreshPairedMobileDevices()
+    replacePairedMobileDevices([currentDevice])
+
+    resolveLookup({ devices: [staleDevice] })
+
+    await expect(refresh).resolves.toEqual([currentDevice])
+  })
+
+  it('returns the newer refresh when a superseded refresh fails', async () => {
+    const currentDevice = { deviceId: 'new-phone', name: 'New phone', pairedAt: 3, lastSeenAt: 4 }
+    let rejectStaleLookup: (reason?: unknown) => void = () => {}
+    let resolveCurrentLookup: (value: { devices: [typeof currentDevice] }) => void = () => {}
+    const staleLookup = new Promise<{ devices: [] }>((_, reject) => {
+      rejectStaleLookup = reject
+    })
+    const currentLookup = new Promise<{ devices: [typeof currentDevice] }>((resolve) => {
+      resolveCurrentLookup = resolve
+    })
+    listDevices.mockReturnValueOnce(staleLookup).mockReturnValueOnce(currentLookup)
+
+    const staleRefresh = refreshPairedMobileDevices()
+    const currentRefresh = refreshPairedMobileDevices({ force: true })
+    const staleExpectation = expect(staleRefresh).resolves.toEqual([currentDevice])
+
+    rejectStaleLookup(new Error('stale failure'))
+    resolveCurrentLookup({ devices: [currentDevice] })
+
+    await expect(currentRefresh).resolves.toEqual([currentDevice])
+    await staleExpectation
+  })
+})

--- a/src/renderer/src/components/mobile/paired-mobile-devices.ts
+++ b/src/renderer/src/components/mobile/paired-mobile-devices.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
+
+export type PairedMobileDevice = {
+  deviceId: string
+  name: string
+  pairedAt: number
+  lastSeenAt: number
+}
+
+type PairedMobileDevicesSnapshot = {
+  devices: readonly PairedMobileDevice[]
+  loaded: boolean
+  loading: boolean
+}
+
+const EMPTY_SNAPSHOT: PairedMobileDevicesSnapshot = {
+  devices: [],
+  loaded: false,
+  loading: false
+}
+
+let snapshot = EMPTY_SNAPSHOT
+// Why: Sidebar, Mobile page, and Settings can mount together; share one
+// device-list request so slow IPC does not fan out across surfaces.
+let activeRequest: {
+  id: number
+  promise: Promise<readonly PairedMobileDevice[]>
+} | null = null
+let latestRequestId = 0
+
+const listeners = new Set<() => void>()
+
+function publish(nextSnapshot: PairedMobileDevicesSnapshot): void {
+  snapshot = nextSnapshot
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function getSnapshot(): PairedMobileDevicesSnapshot {
+  return snapshot
+}
+
+export function replacePairedMobileDevices(devices: readonly PairedMobileDevice[]): void {
+  latestRequestId += 1
+  activeRequest = null
+  publish({
+    devices: [...devices],
+    loaded: true,
+    loading: false
+  })
+}
+
+export function refreshPairedMobileDevices({
+  force = false
+}: {
+  force?: boolean
+} = {}): Promise<readonly PairedMobileDevice[]> {
+  if (activeRequest && !force) {
+    return activeRequest.promise
+  }
+
+  const requestId = latestRequestId + 1
+  latestRequestId = requestId
+  publish({ ...snapshot, loading: true })
+
+  const promise = window.api.mobile
+    .listDevices()
+    .then((result) => {
+      const devices = [...result.devices]
+      if (requestId !== latestRequestId) {
+        // Why: callers use the returned list for navigation decisions; don't
+        // hand them data from a request the shared cache already ignored.
+        return activeRequest?.promise ?? snapshot.devices
+      }
+      publish({
+        devices,
+        loaded: true,
+        loading: false
+      })
+      return devices
+    })
+    .catch((error: unknown) => {
+      if (requestId !== latestRequestId) {
+        // Why: stale failures should not make callers route from an ignored
+        // request when a newer refresh/write owns the shared cache.
+        return activeRequest?.promise ?? snapshot.devices
+      }
+      if (requestId === latestRequestId) {
+        publish({
+          ...snapshot,
+          loaded: true,
+          loading: false
+        })
+      }
+      throw error
+    })
+    .finally(() => {
+      if (activeRequest?.id === requestId) {
+        activeRequest = null
+      }
+    })
+
+  activeRequest = { id: requestId, promise }
+  return promise
+}
+
+export function usePairedMobileDevices({
+  enabled = true,
+  refreshOnMount = true
+}: {
+  enabled?: boolean
+  refreshOnMount?: boolean
+} = {}): {
+  devices: readonly PairedMobileDevice[]
+  loaded: boolean
+  loading: boolean
+  hasPairedDevice: boolean
+  refresh: typeof refreshPairedMobileDevices
+} {
+  const currentSnapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const refresh = useCallback(refreshPairedMobileDevices, [])
+
+  useEffect(() => {
+    if (!enabled || !refreshOnMount || currentSnapshot.loaded || currentSnapshot.loading) {
+      return
+    }
+    void refreshPairedMobileDevices().catch(() => {
+      // Callers that need visible error handling perform explicit refreshes.
+    })
+  }, [currentSnapshot.loaded, currentSnapshot.loading, enabled, refreshOnMount])
+
+  return {
+    ...currentSnapshot,
+    hasPairedDevice: currentSnapshot.devices.length > 0,
+    refresh
+  }
+}
+
+export function _resetPairedMobileDevicesCacheForTests(): void {
+  latestRequestId += 1
+  activeRequest = null
+  publish(EMPTY_SNAPSHOT)
+}

--- a/src/renderer/src/components/mobile/paired-mobile-devices.ts
+++ b/src/renderer/src/components/mobile/paired-mobile-devices.ts
@@ -110,9 +110,9 @@ export function refreshPairedMobileDevices({
       if (requestId !== latestRequestId) {
         return supersededResult()
       }
-      // Why: keep loaded:true so the loaded-gated mount effect can't refire into
-      // a retry loop, but flag error so consumers can tell a failed load apart
-      // from "no devices" and recover (see usePairedMobileDevices focus/online).
+      // Why: keep loaded:true so the loaded-gated mount effect can't refire into a
+      // retry loop; flag error so consumers can distinguish a failed load from "no
+      // devices" and recover.
       publish({
         ...snapshot,
         loaded: true,
@@ -129,6 +129,33 @@ export function refreshPairedMobileDevices({
 
   activeRequest = { id: requestId, promise }
   return promise
+}
+
+// Why: recover a failed shared load on window focus/reconnect without a polling
+// timer. A single module-level listener (shared across every consumer) fires one
+// forced refresh, instead of each mounted consumer registering its own listener
+// and fanning out one forced listDevices IPC per consumer on every focus event.
+let enabledConsumerCount = 0
+
+function recoverPairedMobileDevicesOnReconnect(): void {
+  if (enabledConsumerCount > 0 && snapshot.error) {
+    void refreshPairedMobileDevices({ force: true }).catch(() => {})
+  }
+}
+
+function addRecoveryConsumer(): () => void {
+  if (enabledConsumerCount === 0) {
+    window.addEventListener('focus', recoverPairedMobileDevicesOnReconnect)
+    window.addEventListener('online', recoverPairedMobileDevicesOnReconnect)
+  }
+  enabledConsumerCount += 1
+  return () => {
+    enabledConsumerCount -= 1
+    if (enabledConsumerCount === 0) {
+      window.removeEventListener('focus', recoverPairedMobileDevicesOnReconnect)
+      window.removeEventListener('online', recoverPairedMobileDevicesOnReconnect)
+    }
+  }
 }
 
 export function usePairedMobileDevices({
@@ -158,23 +185,15 @@ export function usePairedMobileDevices({
   }, [currentSnapshot.loaded, currentSnapshot.loading, enabled, refreshOnMount])
 
   // Why: a failed load parks the shared cache in an error state the loaded-gated
-  // mount effect above can't retry (it would loop). Recover on window focus or
-  // reconnect — enough to un-wedge a persistent consumer like the sidebar after
-  // a transient startup IPC failure, without a polling timer.
+  // mount effect above can't retry (it would loop). While mounted, register as a
+  // recovery consumer so the shared focus/online listener can un-wedge a
+  // persistent consumer like the sidebar after a transient startup IPC failure.
   useEffect(() => {
-    if (!enabled || !currentSnapshot.error) {
+    if (!enabled) {
       return
     }
-    const retry = (): void => {
-      void refreshPairedMobileDevices({ force: true }).catch(() => {})
-    }
-    window.addEventListener('focus', retry)
-    window.addEventListener('online', retry)
-    return () => {
-      window.removeEventListener('focus', retry)
-      window.removeEventListener('online', retry)
-    }
-  }, [enabled, currentSnapshot.error])
+    return addRecoveryConsumer()
+  }, [enabled])
 
   return {
     ...currentSnapshot,
@@ -186,5 +205,10 @@ export function usePairedMobileDevices({
 export function _resetPairedMobileDevicesCacheForTests(): void {
   latestRequestId += 1
   activeRequest = null
+  if (enabledConsumerCount > 0) {
+    window.removeEventListener('focus', recoverPairedMobileDevicesOnReconnect)
+    window.removeEventListener('online', recoverPairedMobileDevicesOnReconnect)
+  }
+  enabledConsumerCount = 0
   publish(EMPTY_SNAPSHOT)
 }

--- a/src/renderer/src/components/mobile/paired-mobile-devices.ts
+++ b/src/renderer/src/components/mobile/paired-mobile-devices.ts
@@ -11,12 +11,16 @@ type PairedMobileDevicesSnapshot = {
   devices: readonly PairedMobileDevice[]
   loaded: boolean
   loading: boolean
+  // Why: distinguishes "load failed" from "zero devices paired" — both leave
+  // devices empty, but only the former should be retried/recovered.
+  error: boolean
 }
 
 const EMPTY_SNAPSHOT: PairedMobileDevicesSnapshot = {
   devices: [],
   loaded: false,
-  loading: false
+  loading: false,
+  error: false
 }
 
 let snapshot = EMPTY_SNAPSHOT
@@ -48,13 +52,29 @@ function getSnapshot(): PairedMobileDevicesSnapshot {
   return snapshot
 }
 
+// Why: a superseded request must hand back whatever now owns the shared cache —
+// the newer in-flight request's promise, or the current published devices —
+// never the stale data the store already ignored.
+function supersededResult():
+  | Promise<readonly PairedMobileDevice[]>
+  | readonly PairedMobileDevice[] {
+  return activeRequest?.promise ?? snapshot.devices
+}
+
+// Why: lets callers read the up-to-the-moment device list synchronously inside
+// callbacks/closures without hand-mirroring the store into a local ref.
+export function getPairedMobileDevicesSnapshot(): readonly PairedMobileDevice[] {
+  return snapshot.devices
+}
+
 export function replacePairedMobileDevices(devices: readonly PairedMobileDevice[]): void {
   latestRequestId += 1
   activeRequest = null
   publish({
     devices: [...devices],
     loaded: true,
-    loading: false
+    loading: false,
+    error: false
   })
 }
 
@@ -76,30 +96,29 @@ export function refreshPairedMobileDevices({
     .then((result) => {
       const devices = [...result.devices]
       if (requestId !== latestRequestId) {
-        // Why: callers use the returned list for navigation decisions; don't
-        // hand them data from a request the shared cache already ignored.
-        return activeRequest?.promise ?? snapshot.devices
+        return supersededResult()
       }
       publish({
         devices,
         loaded: true,
-        loading: false
+        loading: false,
+        error: false
       })
       return devices
     })
     .catch((error: unknown) => {
       if (requestId !== latestRequestId) {
-        // Why: stale failures should not make callers route from an ignored
-        // request when a newer refresh/write owns the shared cache.
-        return activeRequest?.promise ?? snapshot.devices
+        return supersededResult()
       }
-      if (requestId === latestRequestId) {
-        publish({
-          ...snapshot,
-          loaded: true,
-          loading: false
-        })
-      }
+      // Why: keep loaded:true so the loaded-gated mount effect can't refire into
+      // a retry loop, but flag error so consumers can tell a failed load apart
+      // from "no devices" and recover (see usePairedMobileDevices focus/online).
+      publish({
+        ...snapshot,
+        loaded: true,
+        loading: false,
+        error: true
+      })
       throw error
     })
     .finally(() => {
@@ -122,6 +141,7 @@ export function usePairedMobileDevices({
   devices: readonly PairedMobileDevice[]
   loaded: boolean
   loading: boolean
+  error: boolean
   hasPairedDevice: boolean
   refresh: typeof refreshPairedMobileDevices
 } {
@@ -136,6 +156,25 @@ export function usePairedMobileDevices({
       // Callers that need visible error handling perform explicit refreshes.
     })
   }, [currentSnapshot.loaded, currentSnapshot.loading, enabled, refreshOnMount])
+
+  // Why: a failed load parks the shared cache in an error state the loaded-gated
+  // mount effect above can't retry (it would loop). Recover on window focus or
+  // reconnect — enough to un-wedge a persistent consumer like the sidebar after
+  // a transient startup IPC failure, without a polling timer.
+  useEffect(() => {
+    if (!enabled || !currentSnapshot.error) {
+      return
+    }
+    const retry = (): void => {
+      void refreshPairedMobileDevices({ force: true }).catch(() => {})
+    }
+    window.addEventListener('focus', retry)
+    window.addEventListener('online', retry)
+    return () => {
+      window.removeEventListener('focus', retry)
+      window.removeEventListener('online', retry)
+    }
+  }, [enabled, currentSnapshot.error])
 
   return {
     ...currentSnapshot,

--- a/src/renderer/src/components/mobile/slides/HomeSlide.tsx
+++ b/src/renderer/src/components/mobile/slides/HomeSlide.tsx
@@ -107,7 +107,8 @@ export function HomeSlide({ tapping }: { tapping: boolean }): React.JSX.Element 
               <span>
                 {translate(
                   'auto.components.mobile.slides.HomeSlide.d33d7a9c29',
-                  'orca&nbsp;&nbsp;·&nbsp;&nbsp;feat/mobile-page'
+                  // Why: plain spaces (not &nbsp;) — React text nodes render HTML entities literally.
+                  'orca  ·  feat/mobile-page'
                 )}
               </span>
             </div>

--- a/src/renderer/src/components/mobile/use-mobile-page-paired-devices.test.ts
+++ b/src/renderer/src/components/mobile/use-mobile-page-paired-devices.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment happy-dom
+
+import { act, createElement, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _resetPairedMobileDevicesCacheForTests } from './paired-mobile-devices'
+import type { StepIndex } from './MobileHero'
+
+const mocks = vi.hoisted(() => ({
+  listDevices: vi.fn(),
+  revokeDevice: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess
+  }
+}))
+
+// Polling drives its own timers/IPC that are out of scope here; stub it out so
+// the only listDevices calls are the ones this hook makes directly.
+vi.mock('../settings/mobile-pairing-device-polling', () => ({
+  useMobilePairingDevicePolling: (): void => {}
+}))
+
+import { useMobilePagePairedDevices } from './use-mobile-page-paired-devices'
+
+type HookApi = ReturnType<typeof useMobilePagePairedDevices>
+
+let latest: HookApi | null = null
+let latestStep: StepIndex | null = null
+
+function Probe(): null {
+  const [stepIdx, setStepIdx] = useState<StepIndex>(0)
+  latestStep = stepIdx
+  latest = useMobilePagePairedDevices({ stepIdx, setStepIdx })
+  return null
+}
+
+const mountedRoots: Root[] = []
+
+function device(deviceId: string): {
+  deviceId: string
+  name: string
+  pairedAt: number
+  lastSeenAt: number
+} {
+  return { deviceId, name: deviceId, pairedAt: 1, lastSeenAt: 2 }
+}
+
+async function renderProbe(): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  await act(async () => {
+    root.render(createElement(Probe))
+  })
+}
+
+async function unmountProbes(): Promise<void> {
+  await act(async () => {
+    for (const root of mountedRoots.splice(0)) {
+      root.unmount()
+    }
+  })
+}
+
+describe('useMobilePagePairedDevices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    latest = null
+    latestStep = null
+    _resetPairedMobileDevicesCacheForTests()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        mobile: {
+          listDevices: mocks.listDevices,
+          revokeDevice: mocks.revokeDevice
+        }
+      }
+    })
+  })
+
+  afterEach(async () => {
+    await unmountProbes()
+    document.body.innerHTML = ''
+  })
+
+  it('resolves to the paired stage when a device is already paired', async () => {
+    mocks.listDevices.mockResolvedValue({ devices: [device('phone-1')] })
+
+    await renderProbe()
+
+    await vi.waitFor(() => expect(latest?.stage).toBe('paired'))
+    expect(latest?.devices.map((d) => d.deviceId)).toEqual(['phone-1'])
+  })
+
+  it('returns to the paired summary from step 0 while devices exist', async () => {
+    mocks.listDevices.mockResolvedValue({ devices: [device('phone-1')] })
+
+    await renderProbe()
+    await vi.waitFor(() => expect(latest?.stage).toBe('paired'))
+
+    await act(async () => {
+      latest?.enterFlow()
+    })
+    expect(latest?.stage).toBe('flow')
+
+    await act(async () => {
+      latest?.handleBack()
+    })
+    expect(latest?.stage).toBe('paired')
+  })
+
+  it('returns to intro from step 0 when no devices exist', async () => {
+    mocks.listDevices.mockResolvedValue({ devices: [] })
+
+    await renderProbe()
+    await vi.waitFor(() => expect(latest?.stage).toBe('intro'))
+
+    await act(async () => {
+      latest?.enterFlow()
+    })
+    expect(latest?.stage).toBe('flow')
+
+    await act(async () => {
+      latest?.handleBack()
+    })
+    expect(latest?.stage).toBe('intro')
+  })
+
+  it('steps back to step 0 from step 1 without leaving the flow', async () => {
+    mocks.listDevices.mockResolvedValue({ devices: [device('phone-1')] })
+
+    await renderProbe()
+    await vi.waitFor(() => expect(latest?.stage).toBe('paired'))
+
+    await act(async () => {
+      latest?.pairAnotherDevice()
+    })
+    expect(latestStep).toBe(1)
+    expect(latest?.stage).toBe('flow')
+
+    await act(async () => {
+      latest?.handleBack()
+    })
+    expect(latestStep).toBe(0)
+    expect(latest?.stage).toBe('flow')
+  })
+
+  it('keeps the device and shows an error when revoke returns revoked:false', async () => {
+    mocks.listDevices.mockResolvedValue({ devices: [device('phone-1')] })
+    mocks.revokeDevice.mockResolvedValue({ revoked: false })
+
+    await renderProbe()
+    await vi.waitFor(() => expect(latest?.stage).toBe('paired'))
+
+    await act(async () => {
+      await latest?.revokeDevice('phone-1')
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+    // A revoke that did not happen must not fire a second (refresh) IPC call.
+    expect(mocks.listDevices).toHaveBeenCalledTimes(1)
+    expect(latest?.devices.map((d) => d.deviceId)).toEqual(['phone-1'])
+  })
+
+  it('routes to intro after revoking the last device', async () => {
+    mocks.listDevices
+      .mockResolvedValueOnce({ devices: [device('phone-1')] })
+      .mockResolvedValueOnce({ devices: [] })
+    mocks.revokeDevice.mockResolvedValue({ revoked: true })
+
+    await renderProbe()
+    await vi.waitFor(() => expect(latest?.stage).toBe('paired'))
+
+    await act(async () => {
+      await latest?.revokeDevice('phone-1')
+    })
+
+    expect(mocks.revokeDevice).toHaveBeenCalledWith({ deviceId: 'phone-1' })
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => expect(latest?.stage).toBe('intro'))
+    expect(latest?.devices).toEqual([])
+  })
+
+  it('optimistically drops the device and still succeeds when the post-revoke refresh fails', async () => {
+    mocks.listDevices
+      .mockResolvedValueOnce({ devices: [device('phone-1')] })
+      .mockRejectedValueOnce(new Error('refresh failed'))
+    mocks.revokeDevice.mockResolvedValue({ revoked: true })
+
+    await renderProbe()
+    await vi.waitFor(() => expect(latest?.stage).toBe('paired'))
+
+    await act(async () => {
+      await latest?.revokeDevice('phone-1')
+    })
+
+    // Revoke succeeded server-side, so success is reported and the device is
+    // dropped optimistically even though the reload failed — no false error.
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1)
+    expect(mocks.toastError).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(latest?.devices).toEqual([]))
+    await vi.waitFor(() => expect(latest?.stage).toBe('intro'))
+  })
+})

--- a/src/renderer/src/components/mobile/use-mobile-page-paired-devices.ts
+++ b/src/renderer/src/components/mobile/use-mobile-page-paired-devices.ts
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import { toast } from 'sonner'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { useMobilePairingDevicePolling } from '../settings/mobile-pairing-device-polling'
+import type { PairedDevice, StepIndex } from './MobileHero'
+import {
+  shouldShowPairedAfterDeviceRefresh,
+  type MobilePageStage as FlowStage
+} from './mobile-page-stage'
+import { usePairedMobileDevices } from './paired-mobile-devices'
+import { translate } from '@/i18n/i18n'
+
+export function useMobilePagePairedDevices({
+  stepIdx,
+  setStepIdx
+}: {
+  stepIdx: StepIndex
+  setStepIdx: Dispatch<SetStateAction<StepIndex>>
+}): {
+  devices: readonly PairedDevice[]
+  stage: FlowStage | null
+  revokingDeviceIds: readonly string[]
+  enterFlow: () => void
+  handleBack: () => void
+  pairAnotherDevice: () => void
+  revokeDevice: (deviceId: string) => Promise<void>
+  showPairedDevices: (deviceCount: number) => void
+} {
+  // Why: stage starts unresolved so we don't flash the intro before we know
+  // whether any devices are already paired.
+  const [stage, setStage] = useState<FlowStage | null>(null)
+  const [revokingDeviceIds, setRevokingDeviceIds] = useState<string[]>([])
+  const [deviceCountAtPairStart, setDeviceCountAtPairStart] = useState<number | null>(null)
+  const mountedRef = useMountedRef()
+  const stageRef = useRef<FlowStage | null>(null)
+  const deviceCountAtPairStartRef = useRef<number | null>(null)
+  const { devices, refresh: refreshDevices } = usePairedMobileDevices({ refreshOnMount: false })
+
+  const setPairingDeviceBaseline = useCallback(
+    (count: number | null): void => {
+      deviceCountAtPairStartRef.current = count
+      if (mountedRef.current) {
+        setDeviceCountAtPairStart(count)
+      }
+    },
+    [mountedRef]
+  )
+
+  const showStage = useCallback(
+    (nextStage: FlowStage | null): void => {
+      stageRef.current = nextStage
+      if (mountedRef.current) {
+        setStage(nextStage)
+      }
+    },
+    [mountedRef]
+  )
+
+  const showPairedDevices = useCallback(
+    (deviceCount: number): void => {
+      // Why: paired-view polling uses this baseline; setting it with the
+      // transition avoids the render-plus-Effect gap where polling stops.
+      setPairingDeviceBaseline(deviceCount)
+      showStage('paired')
+    },
+    [setPairingDeviceBaseline, showStage]
+  )
+
+  const loadDevices = useCallback(
+    async (
+      opts: {
+        force?: boolean
+      } = {}
+    ): Promise<readonly PairedDevice[]> => {
+      try {
+        const nextDevices = await refreshDevices(opts)
+        if (mountedRef.current) {
+          if (
+            shouldShowPairedAfterDeviceRefresh({
+              stage: stageRef.current,
+              deviceCountAtPairStart: deviceCountAtPairStartRef.current,
+              nextDeviceCount: nextDevices.length
+            })
+          ) {
+            showPairedDevices(nextDevices.length)
+          }
+        }
+        return nextDevices
+      } catch (err) {
+        // Log so a transient IPC failure (which routes the user to 'intro') is
+        // observable; keep returning [] so callers' behavior is unchanged.
+        console.error('mobile.listDevices failed', err)
+        return []
+      }
+    },
+    [mountedRef, refreshDevices, showPairedDevices]
+  )
+
+  // Why: pick the initial stage based on whether any devices are already
+  // paired so returning users don't see the marketing intro every time.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      const initialDevices = await loadDevices()
+      if (cancelled) {
+        return
+      }
+      if (initialDevices.length > 0) {
+        showPairedDevices(initialDevices.length)
+      } else {
+        showStage('intro')
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [loadDevices, showPairedDevices, showStage])
+
+  const revokeDevice = useCallback(
+    async (deviceId: string) => {
+      // Dedupe rapid double-clicks: if a revoke for this id is already in
+      // flight, bail before issuing a second IPC call.
+      let alreadyRevoking = false
+      setRevokingDeviceIds((prev) => {
+        if (prev.includes(deviceId)) {
+          alreadyRevoking = true
+          return prev
+        }
+        return [...prev, deviceId]
+      })
+      if (alreadyRevoking) {
+        return
+      }
+      try {
+        await window.api.mobile.revokeDevice({ deviceId })
+        const remaining = await loadDevices({ force: true })
+        if (mountedRef.current) {
+          toast.success(translate('auto.components.mobile.MobilePage.255372e6e8', 'Device revoked'))
+        }
+        if (remaining.length === 0 && mountedRef.current) {
+          showStage('intro')
+        }
+      } catch {
+        if (mountedRef.current) {
+          toast.error(
+            translate('auto.components.mobile.MobilePage.4e1eb5d55c', 'Failed to revoke device')
+          )
+        }
+      } finally {
+        if (mountedRef.current) {
+          setRevokingDeviceIds((prev) => prev.filter((id) => id !== deviceId))
+        }
+      }
+    },
+    [loadDevices, mountedRef, showStage]
+  )
+
+  const polledLoadDevices = useCallback(async () => {
+    await loadDevices()
+  }, [loadDevices])
+
+  // Why: poll for new pairings on Step 2 (waiting for the first pair) and
+  // also on the paired view (so additional phones that finish pairing while
+  // the user is reading the list show up without a manual refresh).
+  useMobilePairingDevicePolling({
+    deviceCountAtQr:
+      (stage === 'flow' && stepIdx === 1) || stage === 'paired' ? deviceCountAtPairStart : null,
+    currentDeviceCount: devices.length,
+    loadDevices: polledLoadDevices
+  })
+
+  const enterFlow = (): void => {
+    setStepIdx(0)
+    setPairingDeviceBaseline(devices.length)
+    showStage('flow')
+  }
+
+  const pairAnotherDevice = (): void => {
+    setStepIdx(1)
+    setPairingDeviceBaseline(devices.length)
+    showStage('flow')
+  }
+
+  const handleBack = (): void => {
+    if (stepIdx === 1) {
+      setStepIdx(0)
+    } else {
+      showStage('intro')
+    }
+  }
+
+  return {
+    devices,
+    stage,
+    revokingDeviceIds,
+    enterFlow,
+    handleBack,
+    pairAnotherDevice,
+    revokeDevice,
+    showPairedDevices
+  }
+}

--- a/src/renderer/src/components/mobile/use-mobile-page-paired-devices.ts
+++ b/src/renderer/src/components/mobile/use-mobile-page-paired-devices.ts
@@ -7,7 +7,11 @@ import {
   shouldShowPairedAfterDeviceRefresh,
   type MobilePageStage as FlowStage
 } from './mobile-page-stage'
-import { usePairedMobileDevices } from './paired-mobile-devices'
+import {
+  getPairedMobileDevicesSnapshot,
+  replacePairedMobileDevices,
+  usePairedMobileDevices
+} from './paired-mobile-devices'
 import { translate } from '@/i18n/i18n'
 
 export function useMobilePagePairedDevices({
@@ -139,9 +143,19 @@ export function useMobilePagePairedDevices({
         if (!revoked) {
           throw new Error('mobile.revokeDevice returned revoked=false')
         }
-        // Why: use the raw refresh so a failed reload throws (error toast)
-        // instead of loadDevices' [] fallback wrongly routing to intro.
-        const remaining = await refreshDevices({ force: true })
+        // Why: revoke already succeeded server-side, so a failed post-revoke
+        // reload must not flash "Failed to revoke". Optimistically drop the
+        // revoked device from the last-known list (not loadDevices' bogus [] from
+        // a failed reload), keeping success + intro-routing correct. Mirrors
+        // MobilePane's revoke fallback.
+        let remaining: readonly PairedDevice[]
+        try {
+          remaining = await refreshDevices({ force: true })
+        } catch (err) {
+          console.error('mobile.listDevices failed after revoke', err)
+          remaining = getPairedMobileDevicesSnapshot().filter((d) => d.deviceId !== deviceId)
+          replacePairedMobileDevices(remaining)
+        }
         if (mountedRef.current) {
           toast.success(translate('auto.components.mobile.MobilePage.255372e6e8', 'Device revoked'))
         }

--- a/src/renderer/src/components/mobile/use-mobile-page-paired-devices.ts
+++ b/src/renderer/src/components/mobile/use-mobile-page-paired-devices.ts
@@ -132,8 +132,16 @@ export function useMobilePagePairedDevices({
         return
       }
       try {
-        await window.api.mobile.revokeDevice({ deviceId })
-        const remaining = await loadDevices({ force: true })
+        const { revoked } = await window.api.mobile.revokeDevice({ deviceId })
+        // Why: the backend can resolve revoked=false without removing anything;
+        // treat it as a failure BEFORE refreshing or routing, so a revoke that
+        // didn't happen can't flash a success toast or drop the user to intro.
+        if (!revoked) {
+          throw new Error('mobile.revokeDevice returned revoked=false')
+        }
+        // Why: use the raw refresh so a failed reload throws (error toast)
+        // instead of loadDevices' [] fallback wrongly routing to intro.
+        const remaining = await refreshDevices({ force: true })
         if (mountedRef.current) {
           toast.success(translate('auto.components.mobile.MobilePage.255372e6e8', 'Device revoked'))
         }
@@ -152,7 +160,7 @@ export function useMobilePagePairedDevices({
         }
       }
     },
-    [loadDevices, mountedRef, showStage]
+    [mountedRef, refreshDevices, showStage]
   )
 
   const polledLoadDevices = useCallback(async () => {
@@ -184,6 +192,10 @@ export function useMobilePagePairedDevices({
   const handleBack = (): void => {
     if (stepIdx === 1) {
       setStepIdx(0)
+    } else if (devices.length > 0) {
+      // Why: "Pair another device" can start from the paired summary; Back on
+      // step 0 should return there rather than the intro while devices exist.
+      showPairedDevices(devices.length)
     } else {
       showStage('intro')
     }

--- a/src/renderer/src/components/settings/MobilePairedDevicesSection.tsx
+++ b/src/renderer/src/components/settings/MobilePairedDevicesSection.tsx
@@ -1,16 +1,12 @@
 import { Trash2 } from 'lucide-react'
 import { Button } from '../ui/button'
 import { translate } from '@/i18n/i18n'
+import type { PairedMobileDevice } from '../mobile/paired-mobile-devices'
 
-export type PairedDevice = {
-  deviceId: string
-  name: string
-  pairedAt: number
-  lastSeenAt: number
-}
+export type PairedDevice = PairedMobileDevice
 
 type MobilePairedDevicesSectionProps = {
-  devices: PairedDevice[]
+  devices: readonly PairedDevice[]
   hasQrCode: boolean
   onRevokeDevice: (deviceId: string) => void
 }

--- a/src/renderer/src/components/settings/MobilePane.test.tsx
+++ b/src/renderer/src/components/settings/MobilePane.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _resetPairedMobileDevicesCacheForTests } from '../mobile/paired-mobile-devices'
+
+type PairedDevice = {
+  deviceId: string
+  name: string
+  pairedAt: number
+  lastSeenAt: number
+}
+
+type PairedDevicesProps = {
+  devices: readonly PairedDevice[]
+  hasQrCode: boolean
+  onRevokeDevice: (deviceId: string) => void
+}
+
+type StoreState = {
+  settings: {
+    mobileAutoRestoreFitMs: number | null
+  }
+  updateSettings: (settings: { mobileAutoRestoreFitMs: number | null }) => void
+}
+
+const mocks = vi.hoisted(() => ({
+  latestPairedDevicesProps: null as PairedDevicesProps | null,
+  listDevices: vi.fn(),
+  listNetworkInterfaces: vi.fn(),
+  revokeDevice: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  updateSettings: vi.fn()
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: StoreState) => unknown) =>
+    selector({
+      settings: { mobileAutoRestoreFitMs: null },
+      updateSettings: mocks.updateSettings
+    })
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess
+  }
+}))
+
+vi.mock('./MobileNetworkInterfaceSection', () => ({
+  MobileNetworkInterfaceSection: () => null
+}))
+
+vi.mock('./MobilePairingSetupSection', () => ({
+  MobilePairingSetupSection: () => null
+}))
+
+vi.mock('./MobilePairingQrSection', () => ({
+  MobilePairingQrSection: () => null
+}))
+
+vi.mock('./MobileAutoRestoreFitSection', () => ({
+  MobileAutoRestoreFitSection: () => null
+}))
+
+vi.mock('./MobilePairedDevicesSection', () => ({
+  MobilePairedDevicesSection: (props: PairedDevicesProps) => {
+    mocks.latestPairedDevicesProps = props
+    return <div data-testid="paired-devices">{props.devices.map((d) => d.deviceId).join(',')}</div>
+  }
+}))
+
+import { MobilePane } from './MobilePane'
+
+const mountedRoots: Root[] = []
+
+function pairedDevice(deviceId: string): PairedDevice {
+  return {
+    deviceId,
+    name: deviceId,
+    pairedAt: 1,
+    lastSeenAt: 2
+  }
+}
+
+async function renderMobilePane(): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  await act(async () => {
+    root.render(<MobilePane />)
+  })
+}
+
+async function unmountMobilePaneRoots(): Promise<void> {
+  await act(async () => {
+    for (const root of mountedRoots.splice(0)) {
+      root.unmount()
+    }
+  })
+}
+
+describe('MobilePane', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.latestPairedDevicesProps = null
+    _resetPairedMobileDevicesCacheForTests()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        mobile: {
+          listDevices: mocks.listDevices,
+          listNetworkInterfaces: mocks.listNetworkInterfaces,
+          revokeDevice: mocks.revokeDevice
+        }
+      }
+    })
+    mocks.listNetworkInterfaces.mockResolvedValue({ interfaces: [] })
+  })
+
+  afterEach(async () => {
+    await unmountMobilePaneRoots()
+    document.body.innerHTML = ''
+  })
+
+  it('refreshes paired devices from the backend after revoking one', async () => {
+    mocks.listDevices
+      .mockResolvedValueOnce({ devices: [pairedDevice('phone-1')] })
+      .mockResolvedValueOnce({ devices: [pairedDevice('phone-2')] })
+    mocks.revokeDevice.mockResolvedValue(undefined)
+
+    await renderMobilePane()
+
+    await vi.waitFor(() =>
+      expect(mocks.latestPairedDevicesProps?.devices.map((d) => d.deviceId)).toEqual(['phone-1'])
+    )
+
+    await act(async () => {
+      mocks.latestPairedDevicesProps?.onRevokeDevice('phone-1')
+    })
+
+    await vi.waitFor(() => expect(mocks.revokeDevice).toHaveBeenCalledWith({ deviceId: 'phone-1' }))
+    await vi.waitFor(() =>
+      expect(mocks.latestPairedDevicesProps?.devices.map((d) => d.deviceId)).toEqual(['phone-2'])
+    )
+  })
+
+  it('does not show revoke success after unmounting during the refresh', async () => {
+    let resolveRefreshAfterRevoke: (value: { devices: [] }) => void = () => {}
+    const refreshAfterRevoke = new Promise<{ devices: [] }>((resolve) => {
+      resolveRefreshAfterRevoke = resolve
+    })
+    mocks.listDevices
+      .mockResolvedValueOnce({ devices: [pairedDevice('phone-1')] })
+      .mockReturnValueOnce(refreshAfterRevoke)
+    mocks.revokeDevice.mockResolvedValue(undefined)
+
+    await renderMobilePane()
+
+    await vi.waitFor(() =>
+      expect(mocks.latestPairedDevicesProps?.devices.map((d) => d.deviceId)).toEqual(['phone-1'])
+    )
+
+    await act(async () => {
+      mocks.latestPairedDevicesProps?.onRevokeDevice('phone-1')
+    })
+
+    await vi.waitFor(() => expect(mocks.listDevices).toHaveBeenCalledTimes(2))
+    await unmountMobilePaneRoots()
+
+    await act(async () => {
+      resolveRefreshAfterRevoke({ devices: [] })
+    })
+
+    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/settings/MobilePane.test.tsx
+++ b/src/renderer/src/components/settings/MobilePane.test.tsx
@@ -3,14 +3,12 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { _resetPairedMobileDevicesCacheForTests } from '../mobile/paired-mobile-devices'
+import {
+  _resetPairedMobileDevicesCacheForTests,
+  type PairedMobileDevice
+} from '../mobile/paired-mobile-devices'
 
-type PairedDevice = {
-  deviceId: string
-  name: string
-  pairedAt: number
-  lastSeenAt: number
-}
+type PairedDevice = PairedMobileDevice
 
 type PairedDevicesProps = {
   devices: readonly PairedDevice[]
@@ -131,7 +129,7 @@ describe('MobilePane', () => {
     mocks.listDevices
       .mockResolvedValueOnce({ devices: [pairedDevice('phone-1')] })
       .mockResolvedValueOnce({ devices: [pairedDevice('phone-2')] })
-    mocks.revokeDevice.mockResolvedValue(undefined)
+    mocks.revokeDevice.mockResolvedValue({ revoked: true })
 
     await renderMobilePane()
 
@@ -147,6 +145,57 @@ describe('MobilePane', () => {
     await vi.waitFor(() =>
       expect(mocks.latestPairedDevicesProps?.devices.map((d) => d.deviceId)).toEqual(['phone-2'])
     )
+    // Positive control so the unmount test below can't stay green if the
+    // success toast is ever dropped from the revoke path.
+    await vi.waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledTimes(1))
+  })
+
+  it('shows an error and keeps the device when revoke returns revoked:false', async () => {
+    mocks.listDevices.mockResolvedValue({ devices: [pairedDevice('phone-1')] })
+    mocks.revokeDevice.mockResolvedValue({ revoked: false })
+
+    await renderMobilePane()
+
+    await vi.waitFor(() =>
+      expect(mocks.latestPairedDevicesProps?.devices.map((d) => d.deviceId)).toEqual(['phone-1'])
+    )
+
+    await act(async () => {
+      mocks.latestPairedDevicesProps?.onRevokeDevice('phone-1')
+    })
+
+    await vi.waitFor(() => expect(mocks.toastError).toHaveBeenCalledTimes(1))
+    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+    // A revoke that did not happen must not fire a second (refresh) IPC call.
+    expect(mocks.listDevices).toHaveBeenCalledTimes(1)
+    expect(mocks.latestPairedDevicesProps?.devices.map((d) => d.deviceId)).toEqual(['phone-1'])
+  })
+
+  it('optimistically drops the revoked device when the post-revoke refresh fails', async () => {
+    mocks.listDevices
+      .mockResolvedValueOnce({ devices: [pairedDevice('phone-1'), pairedDevice('phone-2')] })
+      .mockRejectedValueOnce(new Error('refresh failed'))
+    mocks.revokeDevice.mockResolvedValue({ revoked: true })
+
+    await renderMobilePane()
+
+    await vi.waitFor(() =>
+      expect(mocks.latestPairedDevicesProps?.devices.map((d) => d.deviceId)).toEqual([
+        'phone-1',
+        'phone-2'
+      ])
+    )
+
+    await act(async () => {
+      mocks.latestPairedDevicesProps?.onRevokeDevice('phone-1')
+    })
+
+    // Refresh rejected, so the fallback republishes the optimistic list without
+    // the revoked device, and success is still reported.
+    await vi.waitFor(() =>
+      expect(mocks.latestPairedDevicesProps?.devices.map((d) => d.deviceId)).toEqual(['phone-2'])
+    )
+    await vi.waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledTimes(1))
   })
 
   it('does not show revoke success after unmounting during the refresh', async () => {
@@ -157,7 +206,7 @@ describe('MobilePane', () => {
     mocks.listDevices
       .mockResolvedValueOnce({ devices: [pairedDevice('phone-1')] })
       .mockReturnValueOnce(refreshAfterRevoke)
-    mocks.revokeDevice.mockResolvedValue(undefined)
+    mocks.revokeDevice.mockResolvedValue({ revoked: true })
 
     await renderMobilePane()
 

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -2,13 +2,18 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '../../store'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import {
+  replacePairedMobileDevices,
+  usePairedMobileDevices,
+  type PairedMobileDevice
+} from '../mobile/paired-mobile-devices'
 import { useMobilePairingDevicePolling } from './mobile-pairing-device-polling'
 import {
   selectRefreshedNetworkAddress,
   type MobileNetworkInterface
 } from './mobile-network-interface-selection'
 import { MobilePairingQrSection } from './MobilePairingQrSection'
-import { MobilePairedDevicesSection, type PairedDevice } from './MobilePairedDevicesSection'
+import { MobilePairedDevicesSection } from './MobilePairedDevicesSection'
 import { MobileAutoRestoreFitSection } from './MobileAutoRestoreFitSection'
 import { MobilePairingConnectionOptions } from './MobilePairingConnectionOptions'
 import { MobilePairingSetupSection } from './MobilePairingSetupSection'
@@ -24,7 +29,6 @@ export function MobilePane(): React.JSX.Element {
   const [pairingUrl, setPairingUrl] = useState<string | null>(null)
   const [endpoint, setEndpoint] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
-  const [devices, setDevices] = useState<PairedDevice[]>([])
   const [qrEnlarged, setQrEnlarged] = useState(false)
   const [networkInterfaces, setNetworkInterfaces] = useState<MobileNetworkInterface[]>([])
   const [selectedAddress, setSelectedAddress] = useState<string | undefined>(undefined)
@@ -36,10 +40,11 @@ export function MobilePane(): React.JSX.Element {
   // TestFlight preview and Android APK.
   const [connectionMode, setConnectionMode] = useState<MobilePairingConnectionMode>('local-only')
   const [rotateNextQr, setRotateNextQr] = useState(false)
-  const devicesRef = useRef<PairedDevice[]>([])
+  const devicesRef = useRef<readonly PairedMobileDevice[]>([])
   const wasSignedInRef = useRef(signedIn)
   const codeCopiedResetTimerRef = useRef<number | null>(null)
   const mountedRef = useMountedRef()
+  const { devices, refresh: refreshDevices } = usePairedMobileDevices({ refreshOnMount: false })
 
   const clearCodeCopiedResetTimer = useCallback((): void => {
     if (codeCopiedResetTimerRef.current !== null) {
@@ -48,17 +53,17 @@ export function MobilePane(): React.JSX.Element {
     }
   }, [])
 
+  useEffect(() => {
+    devicesRef.current = devices
+  }, [devices])
+
   const loadDevices = useCallback(async () => {
     try {
-      const result = await window.api.mobile.listDevices()
-      if (mountedRef.current) {
-        devicesRef.current = result.devices
-        setDevices(result.devices)
-      }
+      devicesRef.current = await refreshDevices()
     } catch {
       // Silently fail — device list is non-critical
     }
-  }, [mountedRef])
+  }, [refreshDevices])
 
   const loadNetworkInterfaces = useCallback(
     async (opts: { notifyOnError?: boolean } = {}) => {
@@ -185,12 +190,17 @@ export function MobilePane(): React.JSX.Element {
   async function revokeDevice(deviceId: string) {
     try {
       await window.api.mobile.revokeDevice({ deviceId })
+      try {
+        // Why: the backend may have learned about another phone while Settings
+        // was open, so refresh from source-of-truth after mutating it.
+        devicesRef.current = await refreshDevices({ force: true })
+      } catch (err) {
+        console.error('mobile.listDevices failed after revoke', err)
+        const nextDevices = devicesRef.current.filter((d) => d.deviceId !== deviceId)
+        devicesRef.current = nextDevices
+        replacePairedMobileDevices(nextDevices)
+      }
       if (mountedRef.current) {
-        setDevices((prev) => {
-          const nextDevices = prev.filter((d) => d.deviceId !== deviceId)
-          devicesRef.current = nextDevices
-          return nextDevices
-        })
         toast.success(translate('auto.components.settings.MobilePane.2e3dd0bc29', 'Device revoked'))
       }
     } catch {

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -3,9 +3,9 @@ import { toast } from 'sonner'
 import { useAppStore } from '../../store'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import {
+  getPairedMobileDevicesSnapshot,
   replacePairedMobileDevices,
-  usePairedMobileDevices,
-  type PairedMobileDevice
+  usePairedMobileDevices
 } from '../mobile/paired-mobile-devices'
 import { useMobilePairingDevicePolling } from './mobile-pairing-device-polling'
 import {
@@ -40,11 +40,14 @@ export function MobilePane(): React.JSX.Element {
   // TestFlight preview and Android APK.
   const [connectionMode, setConnectionMode] = useState<MobilePairingConnectionMode>('local-only')
   const [rotateNextQr, setRotateNextQr] = useState(false)
-  const devicesRef = useRef<readonly PairedMobileDevice[]>([])
   const wasSignedInRef = useRef(signedIn)
   const codeCopiedResetTimerRef = useRef<number | null>(null)
   const mountedRef = useMountedRef()
-  const { devices, refresh: refreshDevices } = usePairedMobileDevices({ refreshOnMount: false })
+  const {
+    devices,
+    loaded: devicesLoaded,
+    refresh: refreshDevices
+  } = usePairedMobileDevices({ refreshOnMount: false })
 
   const clearCodeCopiedResetTimer = useCallback((): void => {
     if (codeCopiedResetTimerRef.current !== null) {
@@ -53,13 +56,9 @@ export function MobilePane(): React.JSX.Element {
     }
   }, [])
 
-  useEffect(() => {
-    devicesRef.current = devices
-  }, [devices])
-
   const loadDevices = useCallback(async () => {
     try {
-      devicesRef.current = await refreshDevices()
+      await refreshDevices()
     } catch {
       // Silently fail — device list is non-critical
     }
@@ -109,7 +108,7 @@ export function MobilePane(): React.JSX.Element {
             setQrDataUrl(result.qrDataUrl)
             setPairingUrl(result.pairingUrl)
             setEndpoint(result.endpoint)
-            setDeviceCountAtQr(devicesRef.current.length)
+            setDeviceCountAtQr(getPairedMobileDevicesSnapshot().length)
             clearCodeCopiedResetTimer()
             setCodeCopied(false)
             setRotateNextQr(false)
@@ -169,9 +168,16 @@ export function MobilePane(): React.JSX.Element {
   )
 
   useEffect(() => {
-    void loadDevices()
     void loadNetworkInterfaces()
-  }, [loadDevices, loadNetworkInterfaces])
+  }, [loadNetworkInterfaces])
+
+  // Why: another surface (e.g. the sidebar) may have already populated the
+  // shared cache; only fetch on mount when it hasn't loaded yet.
+  useEffect(() => {
+    if (!devicesLoaded) {
+      void loadDevices()
+    }
+  }, [devicesLoaded, loadDevices])
 
   useEffect(() => {
     const wasSignedIn = wasSignedInRef.current
@@ -189,15 +195,19 @@ export function MobilePane(): React.JSX.Element {
 
   async function revokeDevice(deviceId: string) {
     try {
-      await window.api.mobile.revokeDevice({ deviceId })
+      const { revoked } = await window.api.mobile.revokeDevice({ deviceId })
+      // Why: the backend can resolve revoked=false without removing the device;
+      // surface that as an error instead of a false "Device revoked".
+      if (!revoked) {
+        throw new Error('mobile.revokeDevice returned revoked=false')
+      }
       try {
         // Why: the backend may have learned about another phone while Settings
         // was open, so refresh from source-of-truth after mutating it.
-        devicesRef.current = await refreshDevices({ force: true })
+        await refreshDevices({ force: true })
       } catch (err) {
         console.error('mobile.listDevices failed after revoke', err)
-        const nextDevices = devicesRef.current.filter((d) => d.deviceId !== deviceId)
-        devicesRef.current = nextDevices
+        const nextDevices = getPairedMobileDevicesSnapshot().filter((d) => d.deviceId !== deviceId)
         replacePairedMobileDevices(nextDevices)
       }
       if (mountedRef.current) {

--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -261,9 +261,12 @@ describe('SidebarNav', () => {
     expect(queryButtonByText(container, '[Orca Mobile]')).not.toBeNull()
   })
 
-  it('keeps Mobile visible after pairing and offers an inline hide control', async () => {
-    mocks.hasPairedMobileDevice = true
+  it('shows the inline hide control only once a device is paired', async () => {
+    const beforePairing = await renderSidebarNav()
+    expect(queryButtonByText(beforePairing, 'Orca Mobile')).not.toBeNull()
+    expect(beforePairing.querySelector('button[aria-label="Hide from sidebar"]')).toBeNull()
 
+    mocks.hasPairedMobileDevice = true
     const container = await renderSidebarNav()
     const hideButton = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Hide from sidebar"]'

--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -3,6 +3,7 @@
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { getDefaultSettings } from '../../../../shared/constants'
 import type { GlobalSettings, Repo } from '../../../../shared/types'
 import { i18n } from '../../i18n/i18n'
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   updateSettings: vi.fn(),
   refreshPreflightStatus: vi.fn(),
   checkLinearConnection: vi.fn(),
+  hasPairedMobileDevice: false,
   dismissMobileOnboardingBadge: vi.fn(),
   setSetupGuideSidebarDismissed: vi.fn()
 }))
@@ -44,6 +46,7 @@ vi.mock('@/hooks/useShortcutLabel', () => ({
 vi.mock('./mobile-sidebar-onboarding-badge', () => ({
   useMobileSidebarOnboardingBadge: () => ({
     visible: false,
+    hasPairedDevice: mocks.hasPairedMobileDevice,
     dismiss: mocks.dismissMobileOnboardingBadge
   })
 }))
@@ -143,7 +146,11 @@ async function renderSidebarNav(): Promise<HTMLDivElement> {
   const root = createRoot(container)
   mountedRoots.push(root)
   await act(async () => {
-    root.render(<SidebarNav />)
+    root.render(
+      <TooltipProvider>
+        <SidebarNav />
+      </TooltipProvider>
+    )
   })
   return container
 }
@@ -194,6 +201,7 @@ describe('SidebarNav', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     await i18n.changeLanguage('en')
+    mocks.hasPairedMobileDevice = false
     setSidebarState()
   })
 
@@ -251,6 +259,24 @@ describe('SidebarNav', () => {
 
     expect(queryButtonByText(container, '[Automations]')).not.toBeNull()
     expect(queryButtonByText(container, '[Orca Mobile]')).not.toBeNull()
+  })
+
+  it('keeps Mobile visible after pairing and offers an inline hide control', async () => {
+    mocks.hasPairedMobileDevice = true
+
+    const container = await renderSidebarNav()
+    const hideButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Hide from sidebar"]'
+    )
+
+    expect(queryButtonByText(container, 'Orca Mobile')).not.toBeNull()
+    expect(hideButton).not.toBeNull()
+    expect(hideButton?.querySelector('svg')).not.toBeNull()
+
+    await clickButton(hideButton as HTMLButtonElement)
+
+    expect(mocks.updateSettings).toHaveBeenCalledWith({ showMobileButton: false })
+    expect(mocks.openMobilePage).not.toHaveBeenCalled()
   })
 
   it('shows the Automations entry by default for older settings', () => {

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Bell, CalendarClock, Search, Smartphone } from 'lucide-react'
+import { Bell, CalendarClock, EyeOff, Search, Smartphone } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -9,6 +9,8 @@ import { useShortcutKeyComboDetails } from '@/hooks/useShortcutLabel'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { useMobileSidebarOnboardingBadge } from './mobile-sidebar-onboarding-badge'
 import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { SetupGuideSidebarEntry } from './SetupGuideSidebarEntry'
 import { SidebarTaskNavButton } from './SidebarTaskNavButton'
 import { HideSidebarMenu } from './sidebar-nav-controls'
@@ -128,36 +130,72 @@ const SidebarNav = React.memo(function SidebarNav() {
       {showMobileButton ? (
         <ContextMenu>
           <ContextMenuTrigger asChild>
-            <button
-              type="button"
-              onClick={() => {
-                mobileOnboardingBadge.dismiss()
-                openMobilePage()
-              }}
-              aria-current={mobileActive ? 'page' : undefined}
+            <div
               className={cn(
-                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
+                'group flex w-full items-center rounded-md text-[13px] font-medium tracking-tight transition-colors',
                 mobileActive
                   ? 'bg-worktree-sidebar-accent text-worktree-sidebar-accent-foreground'
                   : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-foreground/8'
               )}
             >
-              <Smartphone
-                className={cn(
-                  'size-4 shrink-0',
-                  !mobileActive && 'text-worktree-sidebar-foreground/30'
-                )}
-                strokeWidth={mobileActive ? 2.25 : 1.75}
-              />
-              <span className="flex-1">
-                {translate('auto.components.sidebar.SidebarNav.1b5c41caee', 'Orca Mobile')}
-              </span>
-              {mobileOnboardingBadge.visible ? (
-                <span className="rounded-full bg-primary px-1.5 py-px text-[10px] font-semibold text-primary-foreground">
-                  {translate('auto.components.sidebar.SidebarNav.c86d83b5c3', 'New')}
+              <button
+                type="button"
+                onClick={() => {
+                  mobileOnboardingBadge.dismiss()
+                  openMobilePage()
+                }}
+                aria-current={mobileActive ? 'page' : undefined}
+                className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left"
+              >
+                <Smartphone
+                  className={cn(
+                    'size-4 shrink-0',
+                    !mobileActive && 'text-worktree-sidebar-foreground/30'
+                  )}
+                  strokeWidth={mobileActive ? 2.25 : 1.75}
+                />
+                <span className="min-w-0 flex-1 truncate">
+                  {translate('auto.components.sidebar.SidebarNav.1b5c41caee', 'Orca Mobile')}
                 </span>
+                {mobileOnboardingBadge.visible ? (
+                  <span className="shrink-0 rounded-full bg-primary px-1.5 py-px text-[10px] font-semibold text-primary-foreground">
+                    {translate('auto.components.sidebar.SidebarNav.c86d83b5c3', 'New')}
+                  </span>
+                ) : null}
+              </button>
+              {mobileOnboardingBadge.hasPairedDevice ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      className={cn(
+                        'mr-1 text-worktree-sidebar-foreground/55 hover:bg-worktree-sidebar-foreground/10 hover:text-worktree-sidebar-foreground',
+                        mobileActive &&
+                          'text-worktree-sidebar-accent-foreground/70 hover:text-worktree-sidebar-accent-foreground'
+                      )}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        hideMobileButton()
+                      }}
+                      aria-label={translate(
+                        'auto.components.sidebar.SidebarNav.d599269755',
+                        'Hide from sidebar'
+                      )}
+                    >
+                      <EyeOff className="size-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" sideOffset={4}>
+                    {translate(
+                      'auto.components.sidebar.SidebarNav.d599269755',
+                      'Hide from sidebar'
+                    )}
+                  </TooltipContent>
+                </Tooltip>
               ) : null}
-            </button>
+            </div>
           </ContextMenuTrigger>
           <HideSidebarMenu onHide={hideMobileButton} />
         </ContextMenu>

--- a/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.test.ts
+++ b/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.test.ts
@@ -1,13 +1,92 @@
-import { describe, expect, it } from 'vitest'
-import { shouldLoadMobileSidebarOnboardingBadge } from './mobile-sidebar-onboarding-badge'
+// @vitest-environment happy-dom
+
+import { act, createElement, type ComponentProps } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  shouldShowMobileSidebarOnboardingBadge,
+  useMobileSidebarOnboardingBadge
+} from './mobile-sidebar-onboarding-badge'
+import {
+  _resetPairedMobileDevicesCacheForTests,
+  replacePairedMobileDevices
+} from '../mobile/paired-mobile-devices'
+
+type HookState = ReturnType<typeof useMobileSidebarOnboardingBadge>
+
+let latestHookState: HookState | null = null
+
+function HookProbe({ enabled = true }: { enabled?: boolean }): null {
+  latestHookState = useMobileSidebarOnboardingBadge(enabled)
+  return null
+}
+
+const mountedRoots: Root[] = []
+const listDevices = vi.fn()
+
+async function renderHookProbe(props: ComponentProps<typeof HookProbe> = {}): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  await act(async () => {
+    root.render(createElement(HookProbe, props))
+  })
+}
 
 describe('mobile sidebar onboarding badge', () => {
-  it('does not query mobile devices when the sidebar button is hidden', () => {
-    expect(shouldLoadMobileSidebarOnboardingBadge(false, false)).toBe(false)
+  beforeEach(() => {
+    vi.useRealTimers()
+    latestHookState = null
+    listDevices.mockReset()
+    _resetPairedMobileDevicesCacheForTests()
+    window.localStorage.clear()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        mobile: {
+          listDevices
+        }
+      }
+    })
   })
 
-  it('queries mobile devices only while visible and undismissed', () => {
-    expect(shouldLoadMobileSidebarOnboardingBadge(true, false)).toBe(true)
-    expect(shouldLoadMobileSidebarOnboardingBadge(true, true)).toBe(false)
+  afterEach(async () => {
+    await act(async () => {
+      for (const root of mountedRoots.splice(0)) {
+        root.unmount()
+      }
+    })
+    document.body.innerHTML = ''
+    vi.useRealTimers()
+  })
+
+  it('does not show when the sidebar button is hidden', () => {
+    expect(shouldShowMobileSidebarOnboardingBadge(false, false)).toBe(false)
+  })
+
+  it('shows only while enabled and undismissed', () => {
+    expect(shouldShowMobileSidebarOnboardingBadge(true, false)).toBe(true)
+    expect(shouldShowMobileSidebarOnboardingBadge(true, true)).toBe(false)
+  })
+
+  it('marks a paired device after shared mobile devices load', async () => {
+    listDevices.mockResolvedValue({
+      devices: [{ deviceId: 'phone-1', name: 'Phone', pairedAt: 1, lastSeenAt: 2 }]
+    })
+
+    await renderHookProbe()
+
+    await vi.waitFor(() => expect(latestHookState?.hasPairedDevice).toBe(true))
+    expect(latestHookState?.visible).toBe(false)
+  })
+
+  it('shows the badge after shared mobile devices load empty', async () => {
+    replacePairedMobileDevices([])
+
+    await renderHookProbe()
+
+    expect(latestHookState?.visible).toBe(true)
+    expect(latestHookState?.hasPairedDevice).toBe(false)
   })
 })

--- a/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.test.ts
+++ b/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.test.ts
@@ -89,4 +89,25 @@ describe('mobile sidebar onboarding badge', () => {
     expect(latestHookState?.visible).toBe(true)
     expect(latestHookState?.hasPairedDevice).toBe(false)
   })
+
+  it('does not show the badge on a failed load and recovers on window focus', async () => {
+    listDevices.mockRejectedValueOnce(new Error('startup race')).mockResolvedValueOnce({
+      devices: [{ deviceId: 'phone-1', name: 'Phone', pairedAt: 1, lastSeenAt: 2 }]
+    })
+
+    await renderHookProbe()
+
+    // Failed initial load: loaded flips true but the error flag suppresses the
+    // onboarding badge so it can't masquerade as "no devices paired".
+    await vi.waitFor(() => expect(listDevices).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(latestHookState?.visible).toBe(false))
+    expect(latestHookState?.hasPairedDevice).toBe(false)
+
+    // Regaining focus re-fetches and un-wedges the persistent sidebar consumer.
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    await vi.waitFor(() => expect(latestHookState?.hasPairedDevice).toBe(true))
+  })
 })

--- a/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.ts
+++ b/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { usePairedMobileDevices } from '../mobile/paired-mobile-devices'
 
 const DISMISS_KEY = 'orca.mobile.sidebar-onboarding-dismissed'
 
@@ -10,7 +11,7 @@ function readDismissed(): boolean {
   }
 }
 
-export function shouldLoadMobileSidebarOnboardingBadge(
+export function shouldShowMobileSidebarOnboardingBadge(
   enabled: boolean,
   dismissed: boolean
 ): boolean {
@@ -22,32 +23,11 @@ export function shouldLoadMobileSidebarOnboardingBadge(
 // permanently, mirroring the once-and-done feel of an inbox unread dot.
 export function useMobileSidebarOnboardingBadge(enabled = true): {
   visible: boolean
+  hasPairedDevice: boolean
   dismiss: () => void
 } {
   const [dismissed, setDismissed] = useState<boolean>(() => readDismissed())
-  const [hasPairedDevice, setHasPairedDevice] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    if (!shouldLoadMobileSidebarOnboardingBadge(enabled, dismissed)) {
-      return
-    }
-    let cancelled = false
-    void (async () => {
-      try {
-        const result = await window.api.mobile.listDevices()
-        if (!cancelled) {
-          setHasPairedDevice(result.devices.length > 0)
-        }
-      } catch {
-        if (!cancelled) {
-          setHasPairedDevice(false)
-        }
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [dismissed, enabled])
+  const mobileDevices = usePairedMobileDevices({ enabled })
 
   const dismiss = useCallback(() => {
     if (dismissed) {
@@ -62,7 +42,11 @@ export function useMobileSidebarOnboardingBadge(enabled = true): {
   }, [dismissed])
 
   return {
-    visible: enabled && !dismissed && hasPairedDevice === false,
+    visible:
+      shouldShowMobileSidebarOnboardingBadge(enabled, dismissed) &&
+      mobileDevices.loaded &&
+      !mobileDevices.hasPairedDevice,
+    hasPairedDevice: mobileDevices.hasPairedDevice,
     dismiss
   }
 }

--- a/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.ts
+++ b/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.ts
@@ -45,6 +45,9 @@ export function useMobileSidebarOnboardingBadge(enabled = true): {
     visible:
       shouldShowMobileSidebarOnboardingBadge(enabled, dismissed) &&
       mobileDevices.loaded &&
+      // Why: a failed load also lands loaded:true with no devices; don't show
+      // the onboarding badge until we actually know the device list is empty.
+      !mobileDevices.error &&
       !mobileDevices.hasPairedDevice,
     hasPairedDevice: mobileDevices.hasPairedDevice,
     dismiss

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10797,7 +10797,7 @@
             "0bad5b07c8": "GitHub and Linear",
             "d047197480": "GitHub · Linear",
             "a4c3f7b7aa": "Tasks",
-            "d33d7a9c29": "orca&nbsp;&nbsp;·&nbsp;&nbsp;feat/mobile-page",
+            "d33d7a9c29": "orca  ·  feat/mobile-page",
             "25d6e8a491": "feat/mobile-page",
             "c791677f2f": "Resume",
             "cf3f98fa3f": "Disconnected",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10774,7 +10774,7 @@
             "0bad5b07c8": "GitHub と Linear",
             "d047197480": "GitHub · Linear",
             "a4c3f7b7aa": "タスク",
-            "d33d7a9c29": "orca&nbsp;&nbsp;·&nbsp;&nbsp;feat/mobile-page",
+            "d33d7a9c29": "orca  ·  feat/mobile-page",
             "25d6e8a491": "feat/mobile-page",
             "c791677f2f": "再開する",
             "cf3f98fa3f": "切断されました",


### PR DESCRIPTION
## Summary

Allows hiding the Orca Mobile sidebar button once a device has been paired.
- Adds a shared state/cache manager for paired mobile devices (`paired-mobile-devices.ts`) to avoid duplicate IPC calls when the Sidebar, Settings pane, and Mobile page mount concurrently.
- Introduces a "Hide from sidebar" option (an inline `EyeOff` button with a tooltip) next to the "Orca Mobile" sidebar link when at least one paired device is present.
- Extracts MobilePage's pairing stage/revoke/polling state logic into a custom hook `useMobilePagePairedDevices`.
- Integrates the new shared paired devices state/hook into `MobilePane` (Settings) and `SidebarNav`.

## Screenshots

- Added an inline "Hide from sidebar" button next to the "Orca Mobile" sidebar item once a device is paired.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

*Added unit tests in `paired-mobile-devices.test.ts` to cover caching and coalescing logic, added integration/rendering tests in `MobilePane.test.tsx` to verify refresh/unmount flows, and updated `SidebarNav.test.tsx` to verify the inline sidebar hide control.*

## AI Review Report

The code review with the AI coding agent focused on:
1. **Concurrency and Caching**: Checked that concurrent `listDevices` calls coalesce correctly to a single IPC call and that stale/superseded requests are ignored properly, preventing race conditions or flashing UI state.
2. **Component Lifecycle & Memory Leaks**: Verified that if a component (like `MobilePane`) unmounts while an IPC call is in flight, state updates (e.g., toast notifications) do not execute on unmounted components.
3. **Cross-Platform Compatibility**: Confirmed that the UI components rely on global Electron API channels (such as `window.api.mobile` and `window.api.ui.writeClipboardText`) and platform-agnostic layout structures. No hardcoded or platform-specific file paths or shortcuts were introduced or modified.

## Security Audit

1. **IPC & Input Handling**: Reviewed the revocation call (`window.api.mobile.revokeDevice({ deviceId })`). It passes an existing `deviceId` sourced from paired devices list, mitigating injection risks.
2. **Clipboard Access**: Verified that clipboard writes use the established `window.api.ui.writeClipboardText` utility.
3. **Information Disclosure**: The local caching mechanism only stores basic device info in-memory on the renderer side and does not leak or persist any authentication secrets.

## Notes

No platform-specific regressions are expected; behavior is uniform across macOS, Windows, and Linux.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5785">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->