### PR TITLE
fix(terminal): keep scrollback when restoring an alternate-screen pane

### DIFF
--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2067,6 +2067,7 @@ export function registerPtyHandlers(
       lastTitle?: string
       seq?: number
       source?: 'headless' | 'renderer'
+      alternateScreen?: boolean
     } | null> => {
       if (!runtime || typeof args?.id !== 'string' || args.id.length === 0) {
         return null

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -4975,6 +4975,25 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('reports alternateScreen on main snapshots so the desktop restore can preserve scrollback (#5723)', async () => {
+    const runtime = createRuntime()
+    syncSinglePty(runtime, 'pty-1')
+
+    runtime.onPtyData('pty-1', 'normal-buffer line\r\n', 100)
+    const normalSnapshot = await runtime.serializeMainTerminalBuffer('pty-1', {
+      scrollbackRows: 1000
+    })
+    expect(normalSnapshot?.alternateScreen).toBe(false)
+
+    // A TUI takes the alternate screen — the snapshot now carries no scrollback,
+    // so it must advertise that so the renderer skips its destructive clear.
+    runtime.onPtyData('pty-1', '\x1b[?1049h\x1b[2JALT', 200)
+    const altSnapshot = await runtime.serializeMainTerminalBuffer('pty-1', {
+      scrollbackRows: 1000
+    })
+    expect(altSnapshot?.alternateScreen).toBe(true)
+  })
+
   it('emits explicit OSC 9999 agent status from runtime PTY data', () => {
     const statuses: RuntimeTerminalAgentStatusEvent[] = []
     const runtime = new OrcaRuntimeService(store, undefined, {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4147,6 +4147,7 @@ export class OrcaRuntimeService {
     lastTitle?: string
     seq?: number
     source?: 'headless' | 'renderer'
+    alternateScreen?: boolean
   } | null> {
     return this.serializeHeadlessTerminalBuffer(ptyId, { ...opts, includeEmpty: true })
   }
@@ -4473,6 +4474,7 @@ export class OrcaRuntimeService {
     lastTitle?: string
     seq?: number
     source?: 'headless'
+    alternateScreen?: boolean
   } | null> {
     const state = this.headlessTerminals.get(ptyId)
     if (!state) {
@@ -4498,7 +4500,11 @@ export class OrcaRuntimeService {
           cwd: snapshot.cwd,
           lastTitle: snapshot.lastTitle,
           seq: state.outputSequence,
-          source: 'headless'
+          source: 'headless',
+          // Why: lets the desktop hidden-restore know this snapshot holds no
+          // normal-buffer scrollback (alt screen) so it won't clear the
+          // renderer's existing scrollback when replaying it (#5723).
+          alternateScreen: snapshot.modes.alternateScreen
         }
       : null
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4136,6 +4136,9 @@ export class OrcaRuntimeService {
     return this.serializeTerminalBufferFromAvailableState(ptyId, opts)
   }
 
+  /** Serialize a local PTY's headless main buffer for the desktop hidden-output
+   *  restore (pty:getMainBufferSnapshot), including empty snapshots so a blank
+   *  pane can still be reconciled. Reports `alternateScreen` for the restore guard. */
   serializeMainTerminalBuffer(
     ptyId: string,
     opts: { scrollbackRows?: number } = {}
@@ -4463,6 +4466,9 @@ export class OrcaRuntimeService {
     }
   }
 
+  /** Serialize the runtime's headless emulator for a PTY into replayable ANSI,
+   *  reporting `alternateScreen` so the desktop restore knows the snapshot
+   *  carries no normal-buffer scrollback and must not clear the renderer's. */
   private async serializeHeadlessTerminalBuffer(
     ptyId: string,
     opts: { scrollbackRows?: number; includeEmpty?: boolean } = {}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1066,6 +1066,7 @@ export type PreloadApi = {
       cwd?: string | null
       seq?: number
       source?: 'headless' | 'renderer'
+      alternateScreen?: boolean
     } | null>
     getRendererDeliveryDebugSnapshot: () => Promise<{
       pendingPtyCount: number

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -772,6 +772,7 @@ const api = {
       cwd?: string | null
       seq?: number
       source?: 'headless' | 'renderer'
+      alternateScreen?: boolean
     } | null> => ipcRenderer.invoke('pty:getMainBufferSnapshot', { id, opts }),
 
     getRendererDeliveryDebugSnapshot: (): Promise<{

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4852,6 +4852,61 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('skips the destructive scrollback clear when restoring an alternate-screen snapshot (#5723)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const live = 'visible-after\r\n'
+    // An alt-screen snapshot enters the alternate buffer itself (?1049h) and
+    // carries no normal-buffer scrollback.
+    const altSnapshot = '\x1b[?1049h\x1b[HALT SCREEN BODY'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: altSnapshot,
+      cols: 100,
+      rows: 30,
+      seq: hidden.length + live.length,
+      alternateScreen: true
+    })
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false }
+    })
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+    // Clearing scrollback (ESC[3J) before replaying a scrollback-less alt-screen
+    // snapshot is exactly what wiped the renderer's history in #5723. The guard
+    // must skip it; the snapshot's own ?1049h still gives a clean alt buffer.
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+      '\x1b[2J\x1b[3J\x1b[H',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).toHaveBeenCalledWith(altSnapshot, expect.any(Function))
+    disposable.dispose()
+  })
+
   it('ignores an async hidden-backlog snapshot if the pane changes PTYs first', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('old-pty-id')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2791,6 +2791,7 @@ export function connectPanePty(
       cols: number
       rows: number
       seq?: number
+      alternateScreen?: boolean
     }): void {
       const scrollState = captureScrollStateForSnapshotReplay()
       discardTerminalOutput(pane.terminal)
@@ -2805,7 +2806,14 @@ export function connectPanePty(
         // dimensions. Replay at those dimensions first, then fit back below.
         pane.terminal.resize(snapshot.cols, snapshot.rows)
       }
-      writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+      // Why: an alternate-screen snapshot carries no normal-buffer scrollback
+      // (the headless serializer strips it). Clearing the renderer's scrollback
+      // with ESC[3J before replaying it wipes history the user can still scroll;
+      // the snapshot's own ?1049h enters a clean alt buffer, and the safeFit +
+      // SIGWINCH below force the TUI to repaint. (#5723)
+      if (!snapshot.alternateScreen) {
+        writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+      }
       writeReplayData(snapshot.data)
       writeReplayData(POST_REPLAY_LIVE_SNAPSHOT_RESET)
       hiddenRendererStateDirty = false

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2786,6 +2786,9 @@ export function connectPanePty(
       restoreScrollStateAfterLayout(pane.terminal, state)
     }
 
+    /** Replay a daemon main-buffer snapshot into the pane during hidden-output
+     *  restore. Skips the destructive scrollback clear for alternate-screen
+     *  snapshots so the renderer keeps history it can't otherwise recover (#5723). */
     function applyMainBufferSnapshot(snapshot: {
       data: string
       cols: number

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -26,6 +26,10 @@ export type PtyBufferSnapshot = {
   rows: number
   seq?: number
   source?: 'headless' | 'renderer'
+  /** True when captured while a TUI held the alternate screen, so the snapshot
+   *  carries no normal-buffer scrollback. The hidden-output restore uses this to
+   *  skip the destructive ESC[3J clear and keep the renderer's history (#5723). */
+  alternateScreen?: boolean
 }
 
 export const ptyDataHandlers = new Map<string, (data: string, meta?: PtyDataMeta) => void>()


### PR DESCRIPTION
## What this fixes

Fixes #5723 — on Windows, a terminal pane running an agent TUI (Claude Code, Codex, etc.) sometimes loses the ability to scroll above the visible viewport even though the backend still has the full history (`orca terminal read` returns it). The scrollbar disappears entirely.

## Root cause

When a pane goes non-foreground while streaming (on Windows the whole Electron document going hidden counts), output is queued and, past the 2 MB hidden-backlog cap, dropped. On return to foreground, `applyMainBufferSnapshot` clears the renderer's xterm with `ESC[2J ESC[3J ESC[H` (the `3J` clears scrollback) and replays a fresh daemon snapshot.

The renderer's *existing* scrollback is intact at that point (only the newly-queued bytes were dropped). But the replacement snapshot can be **structurally scrollback-free**: when the headless emulator is on the alternate screen, `serializeHeadlessTerminalBuffer` forces `scrollbackRows = 0` *and* `normalizeSnapshotAnsiForModes` slices everything before the last `?1049h`. So the destructive `3J` wipes the real history and replaces it with nothing → no scrollbar, can't scroll. The daemon's independent tail buffer keeps the history, which is why `orca terminal read` still works (the desync reported in the issue).

## The change

Don't destroy the renderer's scrollback when the restore snapshot has none to give:

- Thread an `alternateScreen` flag onto the main-buffer snapshot (`HeadlessEmulator.getSnapshot` already exposes `modes.alternateScreen`): `serializeHeadlessTerminalBuffer` / `serializeMainTerminalBuffer` → `pty:getMainBufferSnapshot` IPC → preload types → `PtyBufferSnapshot`.
- In `applyMainBufferSnapshot`, **skip the `ESC[2J ESC[3J ESC[H` clear when the snapshot is an alternate-screen snapshot.** The snapshot's own `?1049h` enters a clean alternate buffer, and the existing `safeFit` + `SIGWINCH` make the TUI repaint — all while the normal-buffer scrollback survives. Normal-buffer snapshots are unchanged (still cleared + replayed).

## Tests

- `pty-connection.test.ts`: a hidden-backlog overflow restore with an alternate-screen snapshot must **not** emit `ESC[2J ESC[3J ESC[H` (scrollback preserved); the existing normal-snapshot overflow test still asserts the clear (no regression).
- `orca-runtime.test.ts`: `serializeMainTerminalBuffer` reports `alternateScreen` correctly for normal vs alternate buffers.

## AI code-review summary

- **Cross-platform:** main-process / renderer logic with no OS branches; no `path` or shell assumptions. The bug manifests on Windows (WebGL/ConPTY amplify it) but the fix is platform-neutral.
- **SSH / remote:** remote PTYs take the renderer-serializer fallback in `serializeHiddenOutputSnapshot` (not `getMainBufferSnapshot`), so `alternateScreen` is `undefined` there and the clear still happens — i.e. behavior for remote/SSH is unchanged. This fix targets local PTYs (the reported case); extending the flag to the remote serializer is a possible follow-up.
- **Agents / integrations:** applies to any alternate-screen TUI (Claude Code, Codex, vim, etc.); no agent-specific branching.
- **Performance:** no new work in hot paths — one boolean on an existing snapshot and a single conditional in a path that already only runs on hidden→visible restore.
- **UI quality:** restores expected scroll-back behavior; the alternate screen still has no scrollback by terminal semantics while a full-screen TUI holds it (unavoidable), but the user's normal-buffer history is no longer destroyed.
- **Security:** no new IPC surface, inputs, or data flows; one optional boolean added to an existing snapshot payload.

## Testing notes / honesty

Repro is intermittent (needs a hidden-while-streaming moment plus enough TUI output to overflow the hidden-backlog cap, on Windows). The regression is covered by the unit tests above. A live before/after screen capture is pending a reproducible session.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5786">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->