### PR TITLE
feat(shortcuts): make Select Tab/Workspace 1–9 remappable

### DIFF
--- a/src/renderer/src/components/settings/ShortcutBindingRow.tsx
+++ b/src/renderer/src/components/settings/ShortcutBindingRow.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import { Ban, Plus, RotateCcw, Terminal } from 'lucide-react'
 import {
   formatKeybinding,
+  isDigitIndexActionId,
   isDoubleTapBinding,
   type KeybindingActionId,
   type KeybindingDefinition,
@@ -41,6 +42,16 @@ type ShortcutBindingRowProps = {
 export type ShortcutTerminalStatus = {
   label: string
   description: string
+}
+
+// Why: digit-index rows store one representative chord (e.g. ⌘1) but fire for
+// 1-9, so the trailing number cap renders the whole range.
+function toDigitRangeKeys(keys: string[]): string[] {
+  const last = keys.at(-1)
+  if (last === undefined || !/^[1-9]$/.test(last)) {
+    return keys
+  }
+  return [...keys.slice(0, -1), `${last}–9`]
 }
 
 export function ShortcutBindingRow({
@@ -172,6 +183,8 @@ export function ShortcutBindingRow({
     : hasBinding
       ? `Change shortcut for ${item.title}`
       : `Add shortcut for ${item.title}`
+
+  const isDigitIndex = isDigitIndexActionId(item.id)
 
   return (
     <SearchableSetting
@@ -315,13 +328,16 @@ export function ShortcutBindingRow({
                 </span>
               ) : hasBinding ? (
                 <span className="flex flex-wrap items-center justify-end gap-1.5">
-                  {effective.map((binding) => (
-                    <ShortcutKeyCombo
-                      key={binding}
-                      keys={formatKeybinding(binding, platform)}
-                      doubleTap={isDoubleTapBinding(binding)}
-                    />
-                  ))}
+                  {effective.map((binding) => {
+                    const keys = formatKeybinding(binding, platform)
+                    return (
+                      <ShortcutKeyCombo
+                        key={binding}
+                        keys={isDigitIndex ? toDigitRangeKeys(keys) : keys}
+                        doubleTap={isDoubleTapBinding(binding)}
+                      />
+                    )
+                  })}
                 </span>
               ) : (
                 <span className="flex items-center gap-1">

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -1158,6 +1158,30 @@ describe('digit-index shortcuts', () => {
     ).toMatchObject({ ok: false })
   })
 
+  it('allows extra modifiers (e.g. Shift) on a digit-index chord', () => {
+    expect(
+      keybindingFromInputForAction(
+        'tab.selectByIndex',
+        digitInput('5', { control: true, shift: true }),
+        'darwin'
+      )
+    ).toEqual({ ok: true, value: 'Ctrl+Shift+1' })
+    expect(normalizeKeybindingListForAction('workspace.selectByIndex', 'Mod+Shift+5')).toEqual([
+      'Mod+Shift+1'
+    ])
+  })
+
+  it('matches via the physical-code fallback when the key value is unavailable', () => {
+    // macOS/IME edge cases can leave key empty while code carries the digit.
+    expect(
+      matchKeybindingDigitIndex(
+        'tab.selectByIndex',
+        { key: '', code: 'Digit5', meta: false, control: true, alt: false, shift: false },
+        'darwin'
+      )
+    ).toBe(4)
+  })
+
   it('canonicalizes stored bindings and rejects non-number chords', () => {
     expect(normalizeKeybindingListForAction('workspace.selectByIndex', 'Mod+5')).toEqual(['Mod+1'])
     expect(normalizeKeybindingArrayForAction('tab.selectByIndex', ['Ctrl+9'])).toEqual(['Ctrl+1'])

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -9,12 +9,15 @@ import {
   formatKeybinding,
   formatKeybindingList,
   getEffectiveKeybindingsForAction,
+  isDigitIndexActionId,
   isDoubleTapBinding,
   keybindingFromInput,
   keybindingFromInputForAction,
   keybindingMatchesAction,
   keybindingMatchesInput,
+  matchKeybindingDigitIndex,
   normalizeKeybinding,
+  normalizeKeybindingArrayForAction,
   normalizeKeybindingListForAction,
   normalizeKeybindingList
 } from './keybindings'
@@ -1004,6 +1007,172 @@ describe('keybindings', () => {
     expect(
       findKeybindingConflicts('linux', {
         'worktree.quickOpen': ['DoubleTap+Mod', 'DoubleTap+Ctrl']
+      })
+    ).toEqual([])
+  })
+})
+
+describe('digit-index shortcuts', () => {
+  const digitInput = (
+    digit: string,
+    modifiers: { meta?: boolean; control?: boolean; alt?: boolean; shift?: boolean }
+  ): Parameters<typeof matchKeybindingDigitIndex>[1] => ({
+    key: digit,
+    code: `Digit${digit}`,
+    meta: Boolean(modifiers.meta),
+    control: Boolean(modifiers.control),
+    alt: Boolean(modifiers.alt),
+    shift: Boolean(modifiers.shift)
+  })
+
+  it('flags the two ranged actions as digit-index rows', () => {
+    expect(isDigitIndexActionId('tab.selectByIndex')).toBe(true)
+    expect(isDigitIndexActionId('workspace.selectByIndex')).toBe(true)
+    expect(isDigitIndexActionId('tab.newTerminal')).toBe(false)
+  })
+
+  it('resolves the default ranges per platform', () => {
+    // macOS: workspace = Cmd+1-9, tab = Ctrl+1-9.
+    expect(
+      matchKeybindingDigitIndex(
+        'workspace.selectByIndex',
+        digitInput('3', { meta: true }),
+        'darwin'
+      )
+    ).toBe(2)
+    expect(
+      matchKeybindingDigitIndex('tab.selectByIndex', digitInput('3', { meta: true }), 'darwin')
+    ).toBeNull()
+    expect(
+      matchKeybindingDigitIndex('tab.selectByIndex', digitInput('3', { control: true }), 'darwin')
+    ).toBe(2)
+
+    // Windows/Linux: workspace = Ctrl+1-9, tab = Alt+1-9.
+    expect(
+      matchKeybindingDigitIndex(
+        'workspace.selectByIndex',
+        digitInput('4', { control: true }),
+        'linux'
+      )
+    ).toBe(3)
+    expect(
+      matchKeybindingDigitIndex('tab.selectByIndex', digitInput('4', { alt: true }), 'linux')
+    ).toBe(3)
+  })
+
+  it('ignores non-range presses and extra modifiers', () => {
+    expect(
+      matchKeybindingDigitIndex(
+        'workspace.selectByIndex',
+        digitInput('3', { meta: true, shift: true }),
+        'darwin'
+      )
+    ).toBeNull()
+    expect(
+      matchKeybindingDigitIndex(
+        'tab.selectByIndex',
+        { key: 'p', code: 'KeyP', meta: false, control: true, alt: false, shift: false },
+        'darwin'
+      )
+    ).toBeNull()
+  })
+
+  it('honors custom bindings, including swapping tab and workspace modifiers', () => {
+    const swapped = {
+      'tab.selectByIndex': ['Mod+1'],
+      'workspace.selectByIndex': ['Ctrl+1']
+    }
+    expect(
+      matchKeybindingDigitIndex(
+        'tab.selectByIndex',
+        digitInput('5', { meta: true }),
+        'darwin',
+        swapped
+      )
+    ).toBe(4)
+    expect(
+      matchKeybindingDigitIndex(
+        'workspace.selectByIndex',
+        digitInput('5', { control: true }),
+        'darwin',
+        swapped
+      )
+    ).toBe(4)
+    // A disabled (empty) override never fires.
+    expect(
+      matchKeybindingDigitIndex('tab.selectByIndex', digitInput('5', { control: true }), 'darwin', {
+        'tab.selectByIndex': []
+      })
+    ).toBeNull()
+  })
+
+  it('respects the terminal-first context gate', () => {
+    expect(
+      matchKeybindingDigitIndex(
+        'tab.selectByIndex',
+        digitInput('2', { control: true }),
+        'darwin',
+        undefined,
+        {
+          context: 'terminal',
+          terminalShortcutPolicy: 'terminal-first'
+        }
+      )
+    ).toBeNull()
+    expect(
+      matchKeybindingDigitIndex(
+        'tab.selectByIndex',
+        digitInput('2', { control: true }),
+        'darwin',
+        undefined,
+        {
+          context: 'terminal',
+          terminalShortcutPolicy: 'orca-first'
+        }
+      )
+    ).toBe(1)
+  })
+
+  it('canonicalizes a captured chord to the digit-1 representative', () => {
+    expect(
+      keybindingFromInputForAction(
+        'workspace.selectByIndex',
+        digitInput('7', { meta: true }),
+        'darwin'
+      )
+    ).toEqual({ ok: true, value: 'Mod+1' })
+    expect(
+      keybindingFromInputForAction(
+        'tab.selectByIndex',
+        digitInput('9', { control: true }),
+        'darwin'
+      )
+    ).toEqual({ ok: true, value: 'Ctrl+1' })
+    // A non-number chord is rejected with guidance.
+    expect(
+      keybindingFromInputForAction(
+        'tab.selectByIndex',
+        { key: 'p', code: 'KeyP', meta: true, control: false, alt: false, shift: false },
+        'darwin'
+      )
+    ).toMatchObject({ ok: false })
+  })
+
+  it('canonicalizes stored bindings and rejects non-number chords', () => {
+    expect(normalizeKeybindingListForAction('workspace.selectByIndex', 'Mod+5')).toEqual(['Mod+1'])
+    expect(normalizeKeybindingArrayForAction('tab.selectByIndex', ['Ctrl+9'])).toEqual(['Ctrl+1'])
+    expect(normalizeKeybindingListForAction('tab.selectByIndex', 'Mod+P')).toMatchObject({
+      ok: false
+    })
+  })
+
+  it('lets the two ranges swap modifiers without a false conflict', () => {
+    // The headline use case: tab → Cmd, workspace → Ctrl. They live in
+    // different scopes, so neither edit is blocked as a conflict.
+    expect(
+      findKeybindingConflicts('darwin', {
+        'tab.selectByIndex': ['Mod+1'],
+        'workspace.selectByIndex': ['Ctrl+1']
       })
     ).toEqual([])
   })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -931,6 +931,9 @@ export const DIGIT_INDEX_ACTION_IDS: readonly KeybindingActionId[] = [
 
 const DIGIT_INDEX_ACTION_ID_SET = new Set<KeybindingActionId>(DIGIT_INDEX_ACTION_IDS)
 
+// The representative key for a digit-index chord is a single 1-9 number key.
+const DIGIT_INDEX_KEY_PATTERN = /^[1-9]$/
+
 export function isDigitIndexActionId(actionId: KeybindingActionId): boolean {
   return DIGIT_INDEX_ACTION_ID_SET.has(actionId)
 }
@@ -1288,10 +1291,12 @@ function normalizeOptionsForAction(actionId: KeybindingActionId): NormalizeKeybi
 
 // Why: a digit-index row stores one representative chord. Rewrite the key to 1
 // so display and conflict detection stay stable across the 1-9 range, and
-// reject anything that is not a modifier + number key.
+// reject anything that is not a number key 1-9. Extra modifiers (e.g. Shift) are
+// intentionally allowed — only the key must be a digit; parseKeybinding has
+// already enforced that at least one modifier is present.
 function canonicalizeDigitIndexBinding(binding: string): KeybindingValidationResult {
   const parsed = parseKeybinding(binding)
-  if (!parsed || parsed.doubleTapModifier || parsed.key < '1' || parsed.key > '9') {
+  if (!parsed || parsed.doubleTapModifier || !DIGIT_INDEX_KEY_PATTERN.test(parsed.key)) {
     return {
       ok: false,
       error: 'Pick a number key 1–9 with a modifier, like Cmd+1 or Ctrl+1.'
@@ -1560,6 +1565,19 @@ export function getEffectiveKeybindingsForAction(
   }
   const override = overrides?.[actionId]
   if (Array.isArray(override)) {
+    // Why: digit-index overrides resolve to their canonical <mods>+1 representative
+    // (deduped) so effective bindings stay consistent for display and conflict
+    // detection even if a hand-edited file stored a different digit.
+    if (isDigitIndexActionId(actionId)) {
+      const canonical: string[] = []
+      for (const binding of override) {
+        const normalized = canonicalizeDigitIndexBinding(binding)
+        if (normalized.ok && !canonical.includes(normalized.value)) {
+          canonical.push(normalized.value)
+        }
+      }
+      return canonical
+    }
     return override.flatMap((binding) => {
       const normalized = normalizeKeybindingWithOptions(
         binding,
@@ -1849,6 +1867,8 @@ function digitFromInput(input: KeybindingInput): string | null {
 // Why: digit-index rows bind a representative chord but fire for 1-9. Reuse the
 // representative's modifier set with the pressed digit, then match it through the
 // normal input matcher so Mod/Cmd resolution and layout fallbacks stay shared.
+// Honors keybindingIsActiveInContext, so terminal-first focus disables the range
+// just like the scope-based gating for every other shortcut.
 export function matchKeybindingDigitIndex(
   actionId: KeybindingActionId,
   input: KeybindingInput,
@@ -1866,7 +1886,7 @@ export function matchKeybindingDigitIndex(
   }
   for (const binding of getEffectiveKeybindingsForAction(actionId, platform, overrides)) {
     const parsed = parseKeybinding(binding)
-    if (!parsed || parsed.doubleTapModifier || parsed.key < '1' || parsed.key > '9') {
+    if (!parsed || parsed.doubleTapModifier || !DIGIT_INDEX_KEY_PATTERN.test(parsed.key)) {
       continue
     }
     const candidate = canonicalizeParsedKeybinding({ ...parsed, key: digit })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -38,6 +38,7 @@ export type KeybindingActionId =
   | 'workspace.rename'
   | 'workspace.delete'
   | 'workspace.openBoard'
+  | 'workspace.selectByIndex'
   | 'voice.dictation'
   | 'view.tasks'
   | 'sidebar.left.toggle'
@@ -72,6 +73,7 @@ export type KeybindingActionId =
   | 'tab.previousRecent'
   | 'tab.nextTerminal'
   | 'tab.previousTerminal'
+  | 'tab.selectByIndex'
   | 'browser.find'
   | 'browser.back'
   | 'browser.forward'
@@ -290,6 +292,28 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     // terminal/browser/editor users by default.
     defaultBindings: platformBindings([]),
     allowInTerminal: true
+  },
+  {
+    id: 'workspace.selectByIndex',
+    title: 'Select Workspace 1–9',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: [
+      'shortcut',
+      'global',
+      'workspace',
+      'worktree',
+      'select',
+      'switch',
+      'number',
+      'digit',
+      '1-9',
+      'index'
+    ],
+    // Why: one remappable row for the whole 1-9 range. The stored chord is a
+    // representative — its digit normalizes to 1, but the modifier set is what
+    // matters and any of 1-9 fires it. mac Cmd+1-9, Windows/Linux Ctrl+1-9 → Mod+1.
+    defaultBindings: platformBindings(['Mod+1'])
   },
   {
     id: 'voice.dictation',
@@ -585,6 +609,25 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     allowInTerminal: true
   },
   {
+    id: 'tab.selectByIndex',
+    title: 'Select Tab 1–9',
+    group: 'Tab Navigation',
+    scope: 'tabs',
+    // Why: deliberately no shared conflictGroup with workspace.selectByIndex.
+    // They live in different scopes, so swapping their modifiers (the headline
+    // use case) is never blocked as a false conflict; runtime stays deterministic
+    // because resolveWindowShortcutAction checks the workspace range first.
+    searchKeywords: ['shortcut', 'tab', 'select', 'switch', 'number', 'digit', '1-9', 'index'],
+    // Why: representative chord for the 1-9 range (see workspace.selectByIndex).
+    // mac Ctrl+1-9 (Cmd+1-9 is the workspace jump); Windows/Linux Alt+1-9
+    // (Ctrl+1-9 is the workspace jump), so each platform gets a free chord.
+    defaultBindings: {
+      darwin: ['Ctrl+1'],
+      linux: ['Alt+1'],
+      win32: ['Alt+1']
+    }
+  },
+  {
     id: 'browser.find',
     title: 'Find in Browser',
     group: 'Browser',
@@ -877,6 +920,20 @@ const DEFINITIONS_BY_ID = new Map<KeybindingActionId, KeybindingDefinition>(
 const DEFINITION_IDS = new Set<KeybindingActionId>(
   KEYBINDING_DEFINITIONS.map((definition) => definition.id)
 )
+
+// Why: "Select Tab 1-9" / "Select Workspace 1-9" are single remappable rows
+// whose chord is a representative — the digit is canonicalized to 1, but the
+// binding fires for any of 1-9. These ids opt into that range behavior.
+export const DIGIT_INDEX_ACTION_IDS: readonly KeybindingActionId[] = [
+  'tab.selectByIndex',
+  'workspace.selectByIndex'
+]
+
+const DIGIT_INDEX_ACTION_ID_SET = new Set<KeybindingActionId>(DIGIT_INDEX_ACTION_IDS)
+
+export function isDigitIndexActionId(actionId: KeybindingActionId): boolean {
+  return DIGIT_INDEX_ACTION_ID_SET.has(actionId)
+}
 
 function platformBindings(bindings: readonly string[]): PlatformBindings {
   return {
@@ -1229,18 +1286,58 @@ function normalizeOptionsForAction(actionId: KeybindingActionId): NormalizeKeybi
   }
 }
 
+// Why: a digit-index row stores one representative chord. Rewrite the key to 1
+// so display and conflict detection stay stable across the 1-9 range, and
+// reject anything that is not a modifier + number key.
+function canonicalizeDigitIndexBinding(binding: string): KeybindingValidationResult {
+  const parsed = parseKeybinding(binding)
+  if (!parsed || parsed.doubleTapModifier || parsed.key < '1' || parsed.key > '9') {
+    return {
+      ok: false,
+      error: 'Pick a number key 1–9 with a modifier, like Cmd+1 or Ctrl+1.'
+    }
+  }
+  return { ok: true, value: canonicalizeParsedKeybinding({ ...parsed, key: '1' }) }
+}
+
+function finalizeDigitIndexBindings(
+  actionId: KeybindingActionId,
+  result: KeybindingValidationResult | string[]
+): KeybindingValidationResult | string[] {
+  if (!isDigitIndexActionId(actionId) || !Array.isArray(result)) {
+    return result
+  }
+  const canonical: string[] = []
+  for (const binding of result) {
+    const normalized = canonicalizeDigitIndexBinding(binding)
+    if (!normalized.ok) {
+      return normalized
+    }
+    if (!canonical.includes(normalized.value)) {
+      canonical.push(normalized.value)
+    }
+  }
+  return canonical
+}
+
 export function normalizeKeybindingListForAction(
   actionId: KeybindingActionId,
   input: string
 ): KeybindingValidationResult | string[] {
-  return normalizeKeybindingListWithOptions(input, normalizeOptionsForAction(actionId))
+  return finalizeDigitIndexBindings(
+    actionId,
+    normalizeKeybindingListWithOptions(input, normalizeOptionsForAction(actionId))
+  )
 }
 
 export function normalizeKeybindingArrayForAction(
   actionId: KeybindingActionId,
   input: readonly string[]
 ): KeybindingValidationResult | string[] {
-  return normalizeKeybindingArrayWithOptions(input, normalizeOptionsForAction(actionId))
+  return finalizeDigitIndexBindings(
+    actionId,
+    normalizeKeybindingArrayWithOptions(input, normalizeOptionsForAction(actionId))
+  )
 }
 
 const MODIFIER_KEYS = new Set([
@@ -1432,7 +1529,15 @@ export function keybindingFromInputForAction(
   input: KeybindingInput,
   platform: NodeJS.Platform
 ): KeybindingValidationResult {
-  return keybindingFromInputWithOptions(input, platform, normalizeOptionsForAction(actionId))
+  const result = keybindingFromInputWithOptions(
+    input,
+    platform,
+    normalizeOptionsForAction(actionId)
+  )
+  if (!result.ok || !isDigitIndexActionId(actionId)) {
+    return result
+  }
+  return canonicalizeDigitIndexBinding(result.value)
 }
 
 function getDefaultBindings(definition: KeybindingDefinition, platform: NodeJS.Platform): string[] {
@@ -1729,6 +1834,47 @@ export function keybindingMatchesAction(
   return getEffectiveKeybindingsForAction(actionId, platform, overrides).some((binding) =>
     keybindingMatchesInput(binding, input, platform)
   )
+}
+
+function digitFromInput(input: KeybindingInput): string | null {
+  for (let value = 1; value <= 9; value++) {
+    const digit = String(value)
+    if (digitKeyMatches(input, digit)) {
+      return digit
+    }
+  }
+  return null
+}
+
+// Why: digit-index rows bind a representative chord but fire for 1-9. Reuse the
+// representative's modifier set with the pressed digit, then match it through the
+// normal input matcher so Mod/Cmd resolution and layout fallbacks stay shared.
+export function matchKeybindingDigitIndex(
+  actionId: KeybindingActionId,
+  input: KeybindingInput,
+  platform: NodeJS.Platform,
+  overrides?: KeybindingOverrides,
+  options: KeybindingMatchOptions = {}
+): number | null {
+  const definition = DEFINITIONS_BY_ID.get(actionId)
+  if (!definition || !keybindingIsActiveInContext(definition, options)) {
+    return null
+  }
+  const digit = digitFromInput(input)
+  if (!digit) {
+    return null
+  }
+  for (const binding of getEffectiveKeybindingsForAction(actionId, platform, overrides)) {
+    const parsed = parseKeybinding(binding)
+    if (!parsed || parsed.doubleTapModifier || parsed.key < '1' || parsed.key > '9') {
+      continue
+    }
+    const candidate = canonicalizeParsedKeybinding({ ...parsed, key: digit })
+    if (keybindingMatchesInput(candidate, input, platform)) {
+      return Number(digit) - 1
+    }
+  }
+  return null
 }
 
 function formatModifierGlyph(modifier: ModifierToken, isMac: boolean): string {

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -142,6 +142,26 @@ describe('resolveWindowShortcutAction', () => {
         { 'workspace.selectByIndex': [] }
       )
     ).toBeNull()
+
+    // Both ranges disabled: neither the workspace nor the tab digit chord resolves.
+    const bothDisabled: KeybindingOverrides = {
+      'workspace.selectByIndex': [],
+      'tab.selectByIndex': []
+    }
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'Digit3', key: '3', meta: true, control: false, alt: false, shift: false },
+        'darwin',
+        bothDisabled
+      )
+    ).toBeNull()
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'Digit3', key: '3', meta: false, control: true, alt: false, shift: false },
+        'darwin',
+        bothDisabled
+      )
+    ).toBeNull()
   })
 
   it('keeps Orca-first active in terminal context but lets Terminal-first pass risky app chords', () => {

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -104,6 +104,46 @@ describe('resolveWindowShortcutAction', () => {
     ).toBeNull()
   })
 
+  it('honors remapped tab/workspace number ranges, including swapping the modifiers', () => {
+    // Swap on macOS: tab now uses Cmd+1-9, workspace uses Ctrl+1-9.
+    const swapped: KeybindingOverrides = {
+      'tab.selectByIndex': ['Mod+1'],
+      'workspace.selectByIndex': ['Ctrl+1']
+    }
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'Digit3', key: '3', meta: true, control: false, alt: false, shift: false },
+        'darwin',
+        swapped
+      )
+    ).toEqual({ type: 'jumpToTabIndex', index: 2 })
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'Digit3', key: '3', meta: false, control: true, alt: false, shift: false },
+        'darwin',
+        swapped
+      )
+    ).toEqual({ type: 'jumpToWorktreeIndex', index: 2 })
+
+    // A custom chord with an extra modifier also resolves.
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'Digit2', key: '2', meta: false, control: true, alt: false, shift: true },
+        'linux',
+        { 'tab.selectByIndex': ['Mod+Shift+1'] }
+      )
+    ).toEqual({ type: 'jumpToTabIndex', index: 1 })
+
+    // Disabling the range leaves the chord unclaimed.
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'Digit3', key: '3', meta: false, control: true, alt: false, shift: false },
+        'linux',
+        { 'workspace.selectByIndex': [] }
+      )
+    ).toBeNull()
+  })
+
   it('keeps Orca-first active in terminal context but lets Terminal-first pass risky app chords', () => {
     const macWorktreePalette = {
       code: 'KeyJ',

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -222,9 +222,10 @@ export function resolveWindowShortcutAction(
     return { type: 'switchRecentTab' }
   }
 
-  // Why: workspace jumps are checked first so that if a user maps both ranges
-  // onto the same modifier, the workspace chord wins deterministically (matching
-  // the historical Cmd-before-Ctrl precedence on macOS).
+  // Why: the two ranges live in different scopes (no shared conflictGroup), so a
+  // user is free to map both onto the same modifier without it being blocked as a
+  // conflict. Checking workspace first gives that overlap deterministic
+  // precedence — workspace wins — matching the historical Cmd-before-Ctrl order.
   const worktreeIndex = matchKeybindingDigitIndex(
     'workspace.selectByIndex',
     input,

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -3,7 +3,7 @@ import {
   isKeybindingAllowedInTerminal,
   isKeybindingPotentialTerminalConflict,
   keybindingMatchesAction,
-  normalizeTerminalShortcutPolicy,
+  matchKeybindingDigitIndex,
   type KeybindingActionId,
   type KeybindingMatchOptions,
   type KeybindingOverrides,
@@ -132,28 +132,6 @@ function actionMatches(
   return keybindingMatchesAction(actionId, input, platform, keybindings, options)
 }
 
-function implicitWorktreeIndexShortcutAllowed(options: WindowShortcutResolveOptions): boolean {
-  if (options.context !== 'terminal') {
-    return true
-  }
-  return normalizeTerminalShortcutPolicy(options.terminalShortcutPolicy) === 'orca-first'
-}
-
-function implicitTabIndexShortcutAllowed(options: WindowShortcutResolveOptions): boolean {
-  return implicitWorktreeIndexShortcutAllowed(options)
-}
-
-function tabIndexModifierPressed(input: WindowShortcutInput, platform: NodeJS.Platform): boolean {
-  const meta = Boolean(input.meta ?? input.metaKey)
-  const control = Boolean(input.control ?? input.ctrlKey)
-  const alt = Boolean(input.alt ?? input.altKey)
-
-  // Why: Ctrl+1-9 is free on macOS because workspace jumps use Cmd+1-9.
-  // On Windows/Linux Ctrl+1-9 is already the workspace jump, so Alt+1-9
-  // gives tab indexing a non-conflicting hardcoded chord.
-  return platform === 'darwin' ? control && !meta && !alt : alt && !meta && !control
-}
-
 export function resolveWindowShortcutAction(
   input: WindowShortcutInput,
   platform: NodeJS.Platform,
@@ -244,27 +222,29 @@ export function resolveWindowShortcutAction(
     return { type: 'switchRecentTab' }
   }
 
-  if (
-    implicitWorktreeIndexShortcutAllowed(options) &&
-    platformPrimaryModifier(input, platform) &&
-    !input.alt &&
-    !input.shift &&
-    input.key &&
-    input.key >= '1' &&
-    input.key <= '9'
-  ) {
-    return { type: 'jumpToWorktreeIndex', index: parseInt(input.key, 10) - 1 }
+  // Why: workspace jumps are checked first so that if a user maps both ranges
+  // onto the same modifier, the workspace chord wins deterministically (matching
+  // the historical Cmd-before-Ctrl precedence on macOS).
+  const worktreeIndex = matchKeybindingDigitIndex(
+    'workspace.selectByIndex',
+    input,
+    platform,
+    keybindings,
+    options
+  )
+  if (worktreeIndex !== null) {
+    return { type: 'jumpToWorktreeIndex', index: worktreeIndex }
   }
 
-  if (
-    implicitTabIndexShortcutAllowed(options) &&
-    tabIndexModifierPressed(input, platform) &&
-    !input.shift &&
-    input.key &&
-    input.key >= '1' &&
-    input.key <= '9'
-  ) {
-    return { type: 'jumpToTabIndex', index: parseInt(input.key, 10) - 1 }
+  const tabIndex = matchKeybindingDigitIndex(
+    'tab.selectByIndex',
+    input,
+    platform,
+    keybindings,
+    options
+  )
+  if (tabIndex !== null) {
+    return { type: 'jumpToTabIndex', index: tabIndex }
   }
 
   // Why: this helper is the explicit allowlist for main-process interception.
@@ -311,15 +291,13 @@ export function getWindowShortcutActionId(action: WindowShortcutAction): Keybind
     case 'dictationKeyDown':
       return 'voice.dictation'
     case 'jumpToWorktreeIndex':
+      return 'workspace.selectByIndex'
     case 'jumpToTabIndex':
-      return null
+      return 'tab.selectByIndex'
   }
 }
 
 export function windowShortcutActionCapturesTerminal(action: WindowShortcutAction): boolean {
-  if (action.type === 'jumpToWorktreeIndex' || action.type === 'jumpToTabIndex') {
-    return true
-  }
   const actionId = getWindowShortcutActionId(action)
   if (!actionId) {
     return false


### PR DESCRIPTION
Closes #5741

## What

Exposes **Select Tab 1–9** and **Select Workspace 1–9** as remappable shortcuts in **Settings → Shortcuts**. Previously both chords were hardcoded in `window-shortcut-policy.ts` and had no entry in the Shortcuts UI, so there was no way to remap them (the original ask in #5741: "I'd like to swap them, but there's no way to remap those shortcuts today").

## Approach

Each range is modeled as a **single remappable row** (matching the cmux "Select Surface 1…9" reference in the issue), not 18 per-digit rows. The stored chord is a representative whose digit is canonicalized to `1`, but it fires for any of **1–9**. This makes the headline use case — *swapping* the tab/workspace modifiers — a **2-rebind** operation instead of 18.

- New registry actions `tab.selectByIndex` and `workspace.selectByIndex` in `src/shared/keybindings.ts`, with a digit-agnostic matcher (`matchKeybindingDigitIndex`) and digit canonicalization wired into the shared validation chokepoints (capture, save, and on-disk `keybindings.json` parsing).
- `window-shortcut-policy.ts` now resolves these via the registry (honoring user overrides + the terminal-shortcut policy), replacing the hardcoded digit blocks.
- The two actions intentionally share **no** `conflictGroup` (they live in different scopes), so swapping their modifiers is never blocked as a false conflict; runtime stays deterministic because the workspace range is checked first.
- `ShortcutBindingRow` renders the representative chord's trailing cap as the full `1–9` range.

**Defaults reproduce existing behavior exactly:**

| | macOS | Windows/Linux |
|---|---|---|
| Select Workspace 1–9 | ⌘1–9 | Ctrl+1–9 |
| Select Tab 1–9 | ⌃1–9 | Alt+1–9 |

## Testing

- Full unit suite: **18,4xx passed, 0 failed** (incl. new coverage for default ranges per platform, custom/swapped bindings, digit canonicalization, conflict behavior, and terminal-context gating).
- Typecheck (node/web/cli), oxlint + switch-exhaustiveness, and localization checks all pass.
- Verified live in a dev Electron build — both rows render with correct labels, and recording a chord persists the canonicalized override. Screenshot in a comment below.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5789">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->