### PR TITLE
fix(sidebar): tidy Live Ports card header

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react'
-import { Plug, Copy, ExternalLink, FolderOpen, Trash2 } from 'lucide-react'
+import { Plug, Copy, ExternalLink, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
@@ -11,7 +11,6 @@ import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner
 import {
   canStopWorkspacePort,
   getPortOpenBrowserTooltipLabel,
-  goToWorkspacePortOwner,
   killWorkspacePortForTarget,
   openWorkspacePortInBrowser,
   refreshWorkspacePortScanAfterStop,
@@ -293,44 +292,22 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
 export function WorktreeCardPortsDetails({
   ports
 }: WorktreeCardPortsProps): React.JSX.Element | null {
-  const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
-  const handleGoToWorktree = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
-      event.stopPropagation()
-      recordFeatureInteraction('ports')
-      const ownerPort = ports[0]
-      if (!ownerPort || !goToWorkspacePortOwner(ownerPort)) {
-        toast.error(
-          translate('auto.components.sidebar.WorktreeCardPorts.3e5f66564e', 'Workspace unavailable')
-        )
-      }
-    },
-    [ports, recordFeatureInteraction]
-  )
-
   if (ports.length === 0) {
     return null
   }
 
   return (
     <WorktreeCardDetailSection>
+      {/* Count lives inline after the label (not on the right, which is the action zone);
+          the "Go to Worktree" action is omitted here since the card is already scoped to its worktree. */}
       <div className="flex items-center gap-1.5 px-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
         <Plug className="size-3" />
         <span>
-          {translate('auto.components.sidebar.WorktreeCardPorts.3240f320d7', 'Live Ports')}
+          {translate('auto.components.sidebar.WorktreeCardPorts.3240f320d7', 'Live Ports')}{' '}
+          <span className="font-normal tabular-nums text-muted-foreground/70">
+            ({ports.length})
+          </span>
         </span>
-        <div className="ml-auto flex items-center gap-1">
-          <PortAction
-            label={translate(
-              'auto.components.sidebar.WorktreeCardPorts.34f733dda2',
-              'Go to Worktree'
-            )}
-            onClick={handleGoToWorktree}
-          >
-            <FolderOpen className="size-3" />
-          </PortAction>
-          <span className="font-normal tabular-nums text-muted-foreground/70">{ports.length}</span>
-        </div>
       </div>
       <WorktreeCardDetailSectionContent className="space-y-0.5">
         {ports.map((port) => (


### PR DESCRIPTION
## What

In the worktree sidebar card's hover view, the **Live Ports** section header had two odd UX choices:

1. A **Go to Worktree** (open workspace) action — pointless here, since the card is already scoped to its own worktree. It still makes sense in the status-bar port viewer, which is a different surface and is untouched.
2. The **port count** sat on the far right — but that area is the action zone. It now lives inline, in parens, right after the `LIVE PORTS` label.

## Change

`WorktreeCardPortsDetails` header in `src/renderer/src/components/sidebar/WorktreeCardPorts.tsx`:
- Removed the `Go to Worktree` `PortAction` (and the now-unused `FolderOpen` icon + `goToWorkspacePortOwner` import).
- Count moved to `LIVE PORTS (n)` on the left; the right-hand action zone is now empty.

Per-port row actions (open / copy / stop on hover) are unchanged.

## Verification

- `tsgo` typecheck (web config): clean
- `oxlint`: clean
- `vitest` `WorktreeCard.compact-hover` + `WorktreeCard.pr-display`: 29/29 pass
- Exercised in a real Orca dev build (this branch) — screenshot below.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->