### PR TITLE
fix(store): evict runtime detected-agent caches when environments are removed

### DIFF
--- a/src/renderer/src/store/slices/detected-agents-environment-prune-leak.test.ts
+++ b/src/renderer/src/store/slices/detected-agents-environment-prune-leak.test.ts
@@ -8,8 +8,9 @@
  * caller, so removed environments leaked their entries for the renderer session.
  * `setRuntimeEnvironments` now prunes them to the surviving environment set.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import type * as AgentStatusModule from '@/lib/agent-status'
+import type * as RuntimeRpcClientModule from '@/runtime/runtime-rpc-client'
 import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
 
 vi.mock('sonner', () => ({
@@ -24,6 +25,26 @@ vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
 vi.mock('@/lib/agent-status', async (importOriginal) => {
   const actual = await importOriginal<typeof AgentStatusModule>()
   return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+// Controllable runtime RPC so a detect can be held in flight, then resolved or
+// rejected after the environment is pruned.
+const rpcControl = vi.hoisted(() => {
+  const deferreds: { resolve: (value: unknown) => void; reject: (error: unknown) => void }[] = []
+  return {
+    deferreds,
+    callRuntimeRpc: vi.fn(
+      () =>
+        new Promise((resolve, reject) => {
+          deferreds.push({ resolve, reject })
+        })
+    )
+  }
+})
+
+vi.mock('@/runtime/runtime-rpc-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof RuntimeRpcClientModule>()
+  return { ...actual, callRuntimeRpc: rpcControl.callRuntimeRpc }
 })
 
 // @ts-expect-error -- minimal window.api stub for the store under test
@@ -66,5 +87,45 @@ describe('runtime detected-agents pruned on environment removal (leak regression
     const s = store.getState()
     expect(Object.keys(s.runtimeDetectedAgentIds)).toEqual(['b'])
     expect(Object.keys(s.isDetectingRuntimeAgents)).toEqual(['b'])
+  })
+})
+
+describe('detect resolving after the environment was pruned does not re-leak', () => {
+  beforeEach(() => {
+    rpcControl.deferreds.length = 0
+    rpcControl.callRuntimeRpc.mockClear()
+  })
+
+  it('does not re-add an entry when an in-flight detect REJECTS after pruning', async () => {
+    const store = createTestStore()
+    const pending = store.getState().ensureRuntimeDetectedAgents('env-1')
+    expect(store.getState().isDetectingRuntimeAgents['env-1']).toBe(true)
+    expect(rpcControl.deferreds).toHaveLength(1)
+
+    // Environment removed while the detect is still in flight.
+    store.getState().retainRuntimeDetectedAgents([])
+    expect(store.getState().isDetectingRuntimeAgents).not.toHaveProperty('env-1')
+
+    // The probe then fails — the unguarded .catch would re-add isDetecting=false.
+    rpcControl.deferreds[0].reject(new Error('disconnected'))
+    await pending
+
+    expect(store.getState().isDetectingRuntimeAgents).not.toHaveProperty('env-1')
+    expect(store.getState().runtimeDetectedAgentIds).not.toHaveProperty('env-1')
+  })
+
+  it('does not re-add an entry when an in-flight detect RESOLVES after pruning', async () => {
+    const store = createTestStore()
+    const pending = store.getState().ensureRuntimeDetectedAgents('env-2')
+    expect(rpcControl.deferreds).toHaveLength(1)
+
+    store.getState().retainRuntimeDetectedAgents([])
+    expect(store.getState().runtimeDetectedAgentIds).not.toHaveProperty('env-2')
+
+    rpcControl.deferreds[0].resolve([])
+    await pending
+
+    expect(store.getState().runtimeDetectedAgentIds).not.toHaveProperty('env-2')
+    expect(store.getState().isDetectingRuntimeAgents).not.toHaveProperty('env-2')
   })
 })

--- a/src/renderer/src/store/slices/detected-agents-environment-prune-leak.test.ts
+++ b/src/renderer/src/store/slices/detected-agents-environment-prune-leak.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Memory-leak regression: runtime detected-agent caches must be evicted when a
+ * runtime environment is removed.
+ *
+ * `runtimeDetectedAgentIds` and `isDetectingRuntimeAgents` are keyed by runtime
+ * environmentId and gain an entry per environment that opens its tab-bar launch
+ * menu. The only removal action (`clearRuntimeDetectedAgents`) had no production
+ * caller, so removed environments leaked their entries for the renderer session.
+ * `setRuntimeEnvironments` now prunes them to the surviving environment set.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: {} }
+
+import { createTestStore } from './store-test-helpers'
+
+function env(id: string): PublicKnownRuntimeEnvironment {
+  return { id } as unknown as PublicKnownRuntimeEnvironment
+}
+
+describe('runtime detected-agents pruned on environment removal (leak regression)', () => {
+  it('drops detected-agent caches for environments that no longer exist', () => {
+    const store = createTestStore()
+    store.setState({
+      runtimeDetectedAgentIds: { 'env-1': [], 'env-2': [] },
+      isDetectingRuntimeAgents: { 'env-1': false, 'env-2': true }
+    })
+
+    // env-2 is removed from the runtime environment list.
+    store.getState().setRuntimeEnvironments([env('env-1')])
+
+    const s = store.getState()
+    expect(s.runtimeDetectedAgentIds).not.toHaveProperty('env-2')
+    expect(s.isDetectingRuntimeAgents).not.toHaveProperty('env-2')
+    // Surviving environment is preserved.
+    expect(s.runtimeDetectedAgentIds).toHaveProperty('env-1')
+    expect(s.isDetectingRuntimeAgents['env-1']).toBe(false)
+  })
+
+  it('retainRuntimeDetectedAgents keeps only the listed environments', () => {
+    const store = createTestStore()
+    store.setState({
+      runtimeDetectedAgentIds: { a: [], b: [], c: [] },
+      isDetectingRuntimeAgents: { a: false, b: false, c: false }
+    })
+
+    store.getState().retainRuntimeDetectedAgents(['b'])
+
+    const s = store.getState()
+    expect(Object.keys(s.runtimeDetectedAgentIds)).toEqual(['b'])
+    expect(Object.keys(s.isDetectingRuntimeAgents)).toEqual(['b'])
+  })
+})

--- a/src/renderer/src/store/slices/detected-agents.ts
+++ b/src/renderer/src/store/slices/detected-agents.ts
@@ -40,6 +40,10 @@ export type DetectedAgentsSlice = {
   isDetectingRuntimeAgents: Record<string, boolean>
   ensureRuntimeDetectedAgents: (environmentId: string) => Promise<TuiAgent[]>
   clearRuntimeDetectedAgents: (environmentId: string) => void
+  /** Drops runtime detected-agent caches for environments not in the kept set.
+   *  Wired into setRuntimeEnvironments so removed environments don't leak their
+   *  detected-agent entries for the renderer session. */
+  retainRuntimeDetectedAgents: (environmentIds: Iterable<string>) => void
 }
 
 // Why: these are module-scoped (not in the store) so we can deduplicate
@@ -256,10 +260,15 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
     )
       .then((ids) => {
         const typed = ids as TuiAgent[]
-        set((s) => ({
-          runtimeDetectedAgentIds: { ...s.runtimeDetectedAgentIds, [environmentId]: typed },
-          isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [environmentId]: false }
-        }))
+        // Why: skip committing if the environment was removed (retained out)
+        // while the detect was in flight — otherwise it re-adds a stale entry
+        // that retainRuntimeDetectedAgents just pruned.
+        if (runtimeDetectPromises.get(environmentId) === pending) {
+          set((s) => ({
+            runtimeDetectedAgentIds: { ...s.runtimeDetectedAgentIds, [environmentId]: typed },
+            isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [environmentId]: false }
+          }))
+        }
         return typed
       })
       .catch(() => {
@@ -286,6 +295,35 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
       const { [environmentId]: _, ...restAgents } = s.runtimeDetectedAgentIds
       const { [environmentId]: __, ...restLoading } = s.isDetectingRuntimeAgents
       return { runtimeDetectedAgentIds: restAgents, isDetectingRuntimeAgents: restLoading }
+    })
+  },
+
+  retainRuntimeDetectedAgents: (environmentIds: Iterable<string>) => {
+    const keep = new Set(environmentIds)
+    for (const id of runtimeDetectPromises.keys()) {
+      if (!keep.has(id)) {
+        runtimeDetectPromises.delete(id)
+      }
+    }
+    set((s) => {
+      let changed = false
+      const nextAgents = { ...s.runtimeDetectedAgentIds }
+      const nextLoading = { ...s.isDetectingRuntimeAgents }
+      for (const id of Object.keys(nextAgents)) {
+        if (!keep.has(id)) {
+          delete nextAgents[id]
+          changed = true
+        }
+      }
+      for (const id of Object.keys(nextLoading)) {
+        if (!keep.has(id)) {
+          delete nextLoading[id]
+          changed = true
+        }
+      }
+      return changed
+        ? { runtimeDetectedAgentIds: nextAgents, isDetectingRuntimeAgents: nextLoading }
+        : s
     })
   }
 })

--- a/src/renderer/src/store/slices/detected-agents.ts
+++ b/src/renderer/src/store/slices/detected-agents.ts
@@ -274,9 +274,15 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
       .catch(() => {
         // Why: a remote runtime may be disconnected or version-incompatible.
         // Keep the menu retryable instead of pinning a failed probe forever.
-        set((s) => ({
-          isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [environmentId]: false }
-        }))
+        // Same in-flight guard as the .then() above: if the environment was
+        // retained out mid-detect, don't re-add the isDetecting entry that
+        // retainRuntimeDetectedAgents just pruned (and don't clobber a freshly
+        // started detect's spinner).
+        if (runtimeDetectPromises.get(environmentId) === pending) {
+          set((s) => ({
+            isDetectingRuntimeAgents: { ...s.isDetectingRuntimeAgents, [environmentId]: false }
+          }))
+        }
         return [] as TuiAgent[]
       })
       .finally(() => {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -42,7 +42,7 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
   runtimeEnvironments: [],
   runtimeStatusByEnvironmentId: new Map(),
 
-  setRuntimeEnvironments: (environments) =>
+  setRuntimeEnvironments: (environments) => {
     set((s) => {
       const keep = new Set(environments.map((environment) => environment.id))
       const nextStatuses = new Map(s.runtimeStatusByEnvironmentId)
@@ -57,7 +57,13 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
         runtimeEnvironments: environments,
         ...(statusesChanged ? { runtimeStatusByEnvironmentId: nextStatuses } : {})
       }
-    }),
+    })
+    // Why: evict detected-agent caches for environments that no longer exist so
+    // they don't leak per-environment entries for the renderer session.
+    // Optional-chained: minimal store assemblies (some unit tests) omit the
+    // detected-agents slice.
+    get().retainRuntimeDetectedAgents?.(environments.map((environment) => environment.id))
+  },
 
   setRuntimeEnvironmentStatus: (environmentId, status) =>
     set((s) => {


### PR DESCRIPTION
## Summary

`runtimeDetectedAgentIds` (`Record<environmentId, TuiAgent[] | null>`) and `isDetectingRuntimeAgents` (`Record<environmentId, boolean>`) gain an entry whenever a runtime environment's tab-bar launch menu probes for agents. The slice's only removal action, `clearRuntimeDetectedAgents`, had **no production caller**, so when a runtime environment was removed its detected-agent entries leaked for the renderer session.

This adds a `retainRuntimeDetectedAgents(keepIds)` action — mirroring the sibling `retainRuntimeEnvironmentStatuses` in the runtime-status slice — and calls it from `setRuntimeEnvironments`, so the caches are pruned to the surviving environment set on every environment-list change (centralized; can't be bypassed). It also guards the in-flight detect resolve so an environment removed mid-detect is not re-added (re-using the existing `runtimeDetectPromises === pending` idiom).

No visual change.

## Evidence

**Leak reproduced (before fix).** The new regression test seeds detected-agent caches for two environments, removes one via `setRuntimeEnvironments`, and asserts its entries are gone. On the unfixed code the removed environment's entry is retained:

```
× drops detected-agent caches for environments that no longer exist
AssertionError: expected { 'env-1': [], 'env-2': [] } to not have property "env-2"
× retainRuntimeDetectedAgents keeps only the listed environments
TypeError: store.getState(...).retainRuntimeDetectedAgents is not a function   // didn't exist
```

**Resolved (after fix).**

```
Test Files  1 passed (1)
     Tests  2 passed (2)
```

**No functional regression.** Detected-agents + runtime-status suites stay green:

```
✓ detected-agents.test.ts ✓ runtime-status.test.ts ✓ (new) detected-agents-environment-prune-leak.test.ts
Test Files  3 passed (3)
     Tests  25 passed (25)
```

Plus `oxlint` clean and renderer typecheck (`tsgo -p config/tsconfig.tc.web.json`) passes.

## Testing

- [x] `pnpm test` (new test + 2 related suites, 25 passing)
- [x] `pnpm typecheck` (renderer project)
- [x] `pnpm lint` (oxlint clean; pre-commit hook clean)
- [x] Added a regression test that fails before the fix and passes after

## AI Review Report

Found by an adversarial multi-agent memory-leak audit (dead-cleanup lens) and verified by grepping all callers of `clearRuntimeDetectedAgents` (only tests before this change). Risks reviewed: over-pruning live environments (covered by the keep-`env-1` assertion); calling an action absent in minimal store assemblies (optional-chained, matching PR pattern); re-adding a removed environment whose detect was in flight (guarded). Cross-platform: pure in-memory store logic — no platform-specific paths, shortcuts, or IPC.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or IPC changes. Renderer store cleanup only.

## Notes

In-memory only (resets on restart); growth is bounded by the number of distinct runtime environments probed over a session. `runtimeDetectPromises` already self-cleans on resolve; the leak was the two state maps.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5791">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->