### PR TITLE
fix(store): bound prRefreshSequences with an LRU cap

### DIFF
--- a/src/renderer/src/store/slices/github-pr-refresh-sequences-leak.test.ts
+++ b/src/renderer/src/store/slices/github-pr-refresh-sequences-leak.test.ts
@@ -88,4 +88,30 @@ describe('prRefreshSequences stays bounded (leak regression)', () => {
     })
     expect(store.getState().prRefreshSequences['only-key']).toBe(3)
   })
+
+  it('keeps a refreshed older key by moving it to most-recent before capping', () => {
+    const store = createTestStore()
+    const seeded: Record<string, number> = {}
+    const seedCount = MAX_CACHE_ENTRIES + 100
+    for (let i = 0; i < seedCount; i++) {
+      seeded[`seed-${i}`] = 1
+    }
+    store.setState({ prRefreshSequences: seeded })
+
+    // Refresh the OLDEST key. The writer moves it to most-recent (delete+set),
+    // so capping must evict the next-oldest keys, not this freshly-touched one.
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 9,
+      reason: 'visible',
+      status: 'in-flight',
+      aliases: [{ cacheKey: 'seed-0', repoPath: '/repo/0', branch: 'branch-0' }]
+    })
+
+    const sequences = store.getState().prRefreshSequences
+    expect(Object.keys(sequences)).toHaveLength(MAX_CACHE_ENTRIES)
+    // Survives with its updated sequence; without move-to-end it would be evicted.
+    expect(sequences['seed-0']).toBe(9)
+    // The next-oldest key is the one evicted instead.
+    expect(sequences['seed-1']).toBeUndefined()
+  })
 })

--- a/src/renderer/src/store/slices/github-pr-refresh-sequences-leak.test.ts
+++ b/src/renderer/src/store/slices/github-pr-refresh-sequences-leak.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Memory-leak regression: prRefreshSequences must stay bounded.
+ *
+ * `prRefreshSequences` is a Record keyed by PR cache key (repo/branch/execution
+ * host). `applyGitHubPRRefreshEvent` only ever wrote entries and never removed
+ * them, so the map grew monotonically with the number of distinct (host, repo,
+ * branch) tuples observed — branches are ephemeral and unbounded over a long
+ * session. The fix caps it to MAX_CACHE_ENTRIES, evicting the oldest-touched
+ * keys (the writer moves each touched key to the most-recent position).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { create } from 'zustand'
+import { createGitHubSlice } from './github'
+import { createHostedReviewSlice } from './hosted-review'
+import type { AppState } from '../types'
+
+// MAX_CACHE_ENTRIES is module-private; mirror its value here.
+const MAX_CACHE_ENTRIES = 500
+
+const mockApi = {
+  gh: {
+    prForBranch: vi.fn().mockResolvedValue(null),
+    refreshPRNow: vi.fn(),
+    enqueuePRRefresh: vi.fn().mockResolvedValue(undefined),
+    issue: vi.fn().mockResolvedValue(null),
+    prChecks: vi.fn().mockResolvedValue([])
+  },
+  hostedReview: { forBranch: vi.fn().mockResolvedValue(null) },
+  runtimeEnvironments: { call: vi.fn() },
+  cache: {
+    getGitHub: vi.fn().mockResolvedValue(null),
+    setGitHub: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+// @ts-expect-error -- minimal window.api stub for the slice under test
+globalThis.window = { api: mockApi }
+
+function createTestStore() {
+  return create<AppState>()(
+    (...a) =>
+      ({
+        ...createGitHubSlice(...a),
+        ...createHostedReviewSlice(...a)
+      }) as AppState
+  )
+}
+
+describe('prRefreshSequences stays bounded (leak regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('caps prRefreshSequences and keeps the most recently touched key', () => {
+    const store = createTestStore()
+
+    // Seed more sequence entries than the cap allows.
+    const seeded: Record<string, number> = {}
+    const seedCount = MAX_CACHE_ENTRIES + 100
+    for (let i = 0; i < seedCount; i++) {
+      seeded[`seed-${i}`] = 1
+    }
+    store.setState({ prRefreshSequences: seeded })
+
+    // One more refresh event for a brand-new PR cache key pushes over the cap.
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 1,
+      reason: 'visible',
+      status: 'in-flight',
+      aliases: [{ cacheKey: 'key-new', repoPath: '/repo/new', branch: 'branch-new' }]
+    })
+
+    const sequences = store.getState().prRefreshSequences
+    // Bounded — not seedCount + 1.
+    expect(Object.keys(sequences)).toHaveLength(MAX_CACHE_ENTRIES)
+    // The just-touched key survives; the oldest seeded key is evicted.
+    expect(sequences['key-new']).toBe(1)
+    expect(sequences['seed-0']).toBeUndefined()
+  })
+
+  it('does not evict anything while under the cap', () => {
+    const store = createTestStore()
+    store.getState().applyGitHubPRRefreshEvent({
+      sequence: 3,
+      reason: 'visible',
+      status: 'in-flight',
+      aliases: [{ cacheKey: 'only-key', repoPath: '/repo', branch: 'b' }]
+    })
+    expect(store.getState().prRefreshSequences['only-key']).toBe(3)
+  })
+})

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1365,6 +1365,27 @@ function withBoundedCacheEntry<T extends { fetchedAt: number }>(
   return evictStaleEntries({ ...cache, [key]: entry })
 }
 
+// Why: prRefreshSequences only ever grows — one entry per PR cache key
+// (repo/branch/execution-host) ever observed, and branches are ephemeral and
+// unbounded over a long session. It has no `fetchedAt` to sort by, so bound it
+// by insertion order (oldest-touched keys evicted first; the writer moves each
+// touched key to the end). An evicted long-idle branch simply restarts sequence
+// comparison from 0, which is acceptable.
+function capPrRefreshSequences(
+  sequences: Record<string, number>,
+  maxEntries = MAX_CACHE_ENTRIES
+): Record<string, number> {
+  const keys = Object.keys(sequences)
+  if (keys.length <= maxEntries) {
+    return sequences
+  }
+  const capped: Record<string, number> = {}
+  for (const key of keys.slice(keys.length - maxEntries)) {
+    capped[key] = sequences[key]
+  }
+  return capped
+}
+
 function shouldRefreshIssueDecorations(state: AppState): boolean {
   return (state.worktreeCardProperties ?? []).includes('issue')
 }
@@ -3361,6 +3382,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           }
           continue
         }
+        // Why: delete-then-set moves this key to the end of insertion order so
+        // capPrRefreshSequences evicts genuinely idle keys, not active ones.
+        delete nextSequences[alias.cacheKey]
         nextSequences[alias.cacheKey] = event.sequence
         changed = true
 
@@ -3510,7 +3534,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
       return changed
         ? {
-            prRefreshSequences: nextSequences,
+            prRefreshSequences: capPrRefreshSequences(nextSequences),
             prRefreshStates: nextStates,
             prCache: nextPRCache,
             hostedReviewCache: nextHostedReviewCache


### PR DESCRIPTION
## Summary

`prRefreshSequences` (`Record<cacheKey, number>`, keyed by `[executionHost::]repoId::branch`) tracks the last refresh sequence per PR so out-of-order refresh events can be rejected. `applyGitHubPRRefreshEvent` only ever **wrote** entries and never removed them, so the map grew monotonically with the number of distinct (host, repo, branch) tuples observed — branches are ephemeral and effectively unbounded over a long session.

The sibling `prRefreshStates` is pruned on settle, but `prRefreshSequences` can't be: its retained values back the `event.sequence <= previousSequence` out-of-order guard, so delete-on-settle would weaken that guard. Instead this caps the map to `MAX_CACHE_ENTRIES` (500, the same cap used for the PR/issue caches), evicting the oldest-touched keys. The writer now moves each touched key to the most-recent position (`delete`-then-set), so active branches are never evicted; an evicted long-idle branch simply restarts sequence comparison from 0 (acceptable).

No visual change.

## Evidence

**Leak reproduced (before fix).** The new regression test seeds an over-cap map and drives one refresh event; on the unfixed code the map keeps growing:

```
× caps prRefreshSequences and keeps the most recently touched key
AssertionError: expected [ Array(601) ] to have a length of 500 but got 601
```

**Resolved (after fix).**

```
Test Files  1 passed (1)
     Tests  2 passed (2)
```

The second test asserts no eviction happens while under the cap (control).

**No functional regression.** GitHub slice suites stay green:

```
✓ github.test.ts ✓ github-checks-cache.test.ts
Test Files  2 passed (2)
     Tests  120 passed (120)
```

Plus `oxlint` clean and renderer typecheck (`tsgo -p config/tsconfig.tc.web.json`) passes.

## Testing

- [x] `pnpm test` (new test + 2 github suites, 122 passing)
- [x] `pnpm typecheck` (renderer project)
- [x] `pnpm lint` (oxlint clean; pre-commit hook clean)
- [x] Added a regression test that fails before the fix and passes after

## AI Review Report

Found by an adversarial multi-agent memory-leak audit (collection-growth lens) and verified by grepping every operation on `prRefreshSequences` (only decl, init, and read/write — no delete). Risks reviewed: evicting an active branch's sequence (mitigated by moving touched keys to the most-recent position before capping); weakening the out-of-order guard (an evicted key restarts from 0, which only affects long-idle branches). Cross-platform: pure in-memory store logic — no platform-specific paths, shortcuts, or IPC.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or IPC changes. Renderer store cleanup only.

## Notes

In-memory only (resets on restart). The 500-entry cap matches the existing `MAX_CACHE_ENTRIES` used by the PR/issue/checks caches.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5792">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->