### PR TITLE
fix(runtime): stop leaking orphaned runtime-client-event subscriptions

### DIFF
--- a/src/renderer/src/hooks/runtime-client-events-sync.test.ts
+++ b/src/renderer/src/hooks/runtime-client-events-sync.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createRuntimeClientEventsSync,
+  type RuntimeClientEventSubscriptionHandle
+} from './runtime-client-events-sync'
+
+type SubscribeRecord = {
+  environmentId: string
+  resolveWith: () => void
+  unsubscribe: ReturnType<typeof vi.fn>
+}
+
+function makeHarness(initialDesired: string[]) {
+  let desired = initialDesired
+  const records: SubscribeRecord[] = []
+  const subscribe = vi.fn(
+    (environmentId: string): Promise<RuntimeClientEventSubscriptionHandle> => {
+      const unsubscribe = vi.fn()
+      let resolveFn!: (handle: RuntimeClientEventSubscriptionHandle) => void
+      const promise = new Promise<RuntimeClientEventSubscriptionHandle>((resolve) => {
+        resolveFn = resolve
+      })
+      records.push({ environmentId, resolveWith: () => resolveFn({ unsubscribe }), unsubscribe })
+      return promise
+    }
+  )
+  const sync = createRuntimeClientEventsSync({
+    getDesiredEnvironmentIds: () => desired,
+    subscribe,
+    onEvent: vi.fn()
+  })
+  return {
+    sync,
+    records,
+    subscribe,
+    setDesired: (next: string[]) => {
+      desired = next
+    },
+    recordsFor: (environmentId: string) =>
+      records.filter((record) => record.environmentId === environmentId)
+  }
+}
+
+// Lets all pending subscribe `.then` microtasks settle.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('createRuntimeClientEventsSync', () => {
+  it('subscribes desired environments and unsubscribes ones that leave the set', async () => {
+    const h = makeHarness(['A'])
+    h.sync.sync()
+    h.recordsFor('A')[0].resolveWith()
+    await flush()
+
+    h.setDesired([])
+    h.sync.sync()
+
+    expect(h.recordsFor('A')[0].unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not leak an orphaned subscription when an env is toggled off then on mid-subscribe', async () => {
+    // 'B' stays subscribed throughout so subscriptions is never empty — this is
+    // what prevents the generation from bumping and exposes the overwrite race.
+    const h = makeHarness(['B'])
+    h.sync.sync()
+    h.recordsFor('B')[0].resolveWith()
+    await flush()
+
+    // 'A' becomes desired — first subscribe starts (kept in flight).
+    h.setDesired(['A', 'B'])
+    h.sync.sync()
+
+    // 'A' removed while its subscribe is in flight (generation does NOT bump
+    // because 'B' keeps subscriptions non-empty).
+    h.setDesired(['B'])
+    h.sync.sync()
+
+    // 'A' desired again before the first subscribe resolved — the de-dupe guard
+    // sees no live subscription and no pending entry, so it subscribes AGAIN.
+    h.setDesired(['A', 'B'])
+    h.sync.sync()
+
+    const aRecords = h.recordsFor('A')
+    expect(aRecords).toHaveLength(2) // the duplicate subscribe really happened
+
+    // Resolve both A subscribes.
+    aRecords[0].resolveWith()
+    await flush()
+    aRecords[1].resolveWith()
+    await flush()
+
+    // Exactly one of the two duplicate subscriptions is unsubscribed (the loser);
+    // the other is retained in the map. Before the fix the second resolution
+    // overwrote the first's unsubscribe in the map, leaking it (0 unsubscribes).
+    const aUnsubscribed = aRecords.filter(
+      (record) => record.unsubscribe.mock.calls.length > 0
+    ).length
+    expect(aUnsubscribed).toBe(1)
+
+    // 'B' is untouched.
+    expect(h.recordsFor('B')[0].unsubscribe).not.toHaveBeenCalled()
+  })
+
+  it('stop() unsubscribes everything and ignores in-flight resolutions', async () => {
+    const h = makeHarness(['A'])
+    h.sync.sync()
+    h.recordsFor('A')[0].resolveWith()
+    await flush()
+
+    h.sync.stop()
+    expect(h.recordsFor('A')[0].unsubscribe).toHaveBeenCalledTimes(1)
+
+    // A subscribe that resolves after stop() must not re-register; it unsubscribes.
+    h.setDesired(['C'])
+    h.sync.sync()
+    h.sync.stop()
+    h.recordsFor('C')[0].resolveWith()
+    await flush()
+    expect(h.recordsFor('C')[0].unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/hooks/runtime-client-events-sync.ts
+++ b/src/renderer/src/hooks/runtime-client-events-sync.ts
@@ -1,0 +1,123 @@
+import type { RuntimeClientEvent } from '../../../shared/runtime-client-events'
+
+export type RuntimeClientEventSubscriptionHandle = {
+  unsubscribe: () => void
+}
+
+export type RuntimeClientEventsSyncDeps = {
+  /** Current set of runtime environment ids that should have a live client-event
+   *  subscription. Re-read on every sync and at subscribe-resolution time. */
+  getDesiredEnvironmentIds: () => string[]
+  subscribe: (
+    environmentId: string,
+    onEvent: (event: RuntimeClientEvent) => void,
+    onError: (error: unknown) => void
+  ) => Promise<RuntimeClientEventSubscriptionHandle>
+  onEvent: (environmentId: string, event: RuntimeClientEvent) => void
+}
+
+export type RuntimeClientEventsSync = {
+  /** Reconciles live subscriptions to the desired environment set. */
+  sync: () => void
+  /** Tears down all subscriptions and bumps the generation so in-flight
+   *  subscribes resolve into a no-op. */
+  stop: () => void
+}
+
+/**
+ * Manages runtime-client-event subscriptions, one per desired environment.
+ *
+ * Extracted from useIpcEvents so the async reconciliation — and in particular
+ * the overwrite-orphan race below — is unit-testable.
+ *
+ * The race: a subscribe is async. If an environment id is removed from the
+ * desired set while its subscribe promise is in flight (and another live
+ * subscription keeps the generation from bumping), then re-added before the
+ * original promise resolves, the de-dupe guard sees neither a live subscription
+ * nor a pending entry and starts a SECOND subscribe. Both resolve and the second
+ * `set()` previously overwrote the first's unsubscribe in the map — leaking the
+ * first subscription's preload handle forever. The resolution guard keeps the
+ * first winner and unsubscribes any later duplicate.
+ */
+export function createRuntimeClientEventsSync(
+  deps: RuntimeClientEventsSyncDeps
+): RuntimeClientEventsSync {
+  const subscriptions = new Map<string, () => void>()
+  const pending = new Set<string>()
+  let generation = 0
+
+  const stop = (): void => {
+    generation += 1
+    for (const unsubscribe of subscriptions.values()) {
+      unsubscribe()
+    }
+    subscriptions.clear()
+    pending.clear()
+  }
+
+  const sync = (): void => {
+    const desiredIds = new Set(deps.getDesiredEnvironmentIds())
+
+    for (const [environmentId, unsubscribe] of subscriptions) {
+      if (desiredIds.has(environmentId)) {
+        continue
+      }
+      unsubscribe()
+      subscriptions.delete(environmentId)
+    }
+
+    for (const environmentId of desiredIds) {
+      if (subscriptions.has(environmentId) || pending.has(environmentId)) {
+        continue
+      }
+      pending.add(environmentId)
+      const subscribeGeneration = generation
+      void deps
+        .subscribe(
+          environmentId,
+          (event) => deps.onEvent(environmentId, event),
+          (error) => {
+            console.warn('[runtime-client-events] subscription error:', error)
+          }
+        )
+        .then((subscription) => {
+          pending.delete(environmentId)
+          if (
+            subscribeGeneration !== generation ||
+            !deps.getDesiredEnvironmentIds().includes(environmentId)
+          ) {
+            subscription.unsubscribe()
+            return
+          }
+          // Why: a concurrent subscribe for this environment already won the
+          // overwrite-orphan race. Keep the existing subscription and unsubscribe
+          // this duplicate — overwriting would lose the existing unsubscribe and
+          // leak its preload handle forever.
+          if (subscriptions.has(environmentId)) {
+            subscription.unsubscribe()
+            return
+          }
+          subscriptions.set(environmentId, subscription.unsubscribe)
+        })
+        .catch((error) => {
+          pending.delete(environmentId)
+          if (subscribeGeneration === generation) {
+            console.warn('[runtime-client-events] failed to subscribe:', error)
+          }
+        })
+    }
+
+    for (const environmentId of pending) {
+      if (desiredIds.has(environmentId)) {
+        continue
+      }
+      pending.delete(environmentId)
+    }
+
+    if (desiredIds.size === 0 && subscriptions.size === 0) {
+      generation += 1
+    }
+  }
+
+  return { sync, stop }
+}

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -79,6 +79,7 @@ import {
 } from '@/components/browser-pane/browser-automation-visibility'
 import { attachMobileMarkdownBridge } from '@/runtime/mobile-markdown-bridge'
 import { subscribeRuntimeClientEvents } from '@/runtime/runtime-client-events'
+import { createRuntimeClientEventsSync } from './runtime-client-events-sync'
 import { detectLanguage } from '@/lib/language-detect'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import { collectLeafIdsInOrder } from '@/components/terminal-pane/layout-serialization'
@@ -725,9 +726,6 @@ export function useIpcEvents(): void {
     type AgentStatusApplyResult = 'applied' | 'pending' | 'dropped'
     const pendingAgentStatusEvents: PendingAgentStatusEvent[] = []
     let pendingAgentStatusRetryTimer: ReturnType<typeof setTimeout> | null = null
-    const runtimeClientEventsSubscriptions = new Map<string, () => void>()
-    const runtimeClientEventsPending = new Set<string>()
-    let runtimeClientEventsGeneration = 0
 
     unsubs.push(attachMobileMarkdownBridge())
 
@@ -881,76 +879,15 @@ export function useIpcEvents(): void {
         })
     }
 
-    const stopRuntimeClientEvents = (): void => {
-      runtimeClientEventsGeneration += 1
-      for (const unsubscribe of runtimeClientEventsSubscriptions.values()) {
-        unsubscribe()
-      }
-      runtimeClientEventsSubscriptions.clear()
-      runtimeClientEventsPending.clear()
-    }
+    const runtimeClientEventsSync = createRuntimeClientEventsSync({
+      getDesiredEnvironmentIds: getRuntimeClientEventEnvironmentIds,
+      subscribe: subscribeRuntimeClientEvents,
+      onEvent: handleRuntimeClientEvent
+    })
 
-    const syncRuntimeClientEventsSubscription = (): void => {
-      const desiredIds = new Set(getRuntimeClientEventEnvironmentIds())
-      for (const [environmentId, unsubscribe] of runtimeClientEventsSubscriptions) {
-        if (desiredIds.has(environmentId)) {
-          continue
-        }
-        unsubscribe()
-        runtimeClientEventsSubscriptions.delete(environmentId)
-      }
-      for (const environmentId of desiredIds) {
-        if (
-          runtimeClientEventsSubscriptions.has(environmentId) ||
-          runtimeClientEventsPending.has(environmentId)
-        ) {
-          continue
-        }
-        runtimeClientEventsPending.add(environmentId)
-        const generation = runtimeClientEventsGeneration
-        void subscribeRuntimeClientEvents(
-          environmentId,
-          (event) => handleRuntimeClientEvent(environmentId, event),
-          (error) => {
-            console.warn('[runtime-client-events] subscription error:', error)
-          }
-        )
-          .then((subscription) => {
-            runtimeClientEventsPending.delete(environmentId)
-            if (
-              generation !== runtimeClientEventsGeneration ||
-              !getRuntimeClientEventEnvironmentIds().includes(environmentId)
-            ) {
-              subscription.unsubscribe()
-              return
-            }
-            runtimeClientEventsSubscriptions.set(environmentId, subscription.unsubscribe)
-          })
-          .catch((error) => {
-            runtimeClientEventsPending.delete(environmentId)
-            if (generation === runtimeClientEventsGeneration) {
-              console.warn('[runtime-client-events] failed to subscribe:', error)
-            }
-          })
-      }
-      for (const environmentId of runtimeClientEventsPending) {
-        if (desiredIds.has(environmentId)) {
-          continue
-        }
-        runtimeClientEventsPending.delete(environmentId)
-      }
-      if (desiredIds.size === 0 && runtimeClientEventsSubscriptions.size === 0) {
-        runtimeClientEventsGeneration += 1
-      }
-    }
-
-    const unsubscribeRuntimeClientEventsSubscription = (): void => {
-      stopRuntimeClientEvents()
-    }
-
-    syncRuntimeClientEventsSubscription()
-    unsubs.push(useAppStore.subscribe(syncRuntimeClientEventsSubscription))
-    unsubs.push(unsubscribeRuntimeClientEventsSubscription)
+    runtimeClientEventsSync.sync()
+    unsubs.push(useAppStore.subscribe(runtimeClientEventsSync.sync))
+    unsubs.push(runtimeClientEventsSync.stop)
 
     unsubs.push(
       window.api.repos.onChanged(() => {


### PR DESCRIPTION
## Summary

The runtime-client-event subscription manager (inside `useIpcEvents`) had an **overwrite-orphan race**. A subscribe is async. If an environment id is removed from the desired set while its subscribe promise is in flight — and another live subscription keeps the generation counter from bumping — then re-added before the original promise resolves, the de-dupe guard sees neither a live subscription nor a pending entry and starts a **second** subscribe. Both resolve, and the second `subscriptions.set(env, unsubscribe)` overwrote the first's unsubscribe in the map, leaking the first subscription's preload handle (a live `runtime.clientEvents.subscribe` stream) for the renderer's lifetime.

This PR:
1. **Extracts** the ~60-line async sync from the 5k-line `useIpcEvents` hook into a unit-testable `createRuntimeClientEventsSync` module (this path previously had **zero** test coverage).
2. **Fixes** the race: at subscribe-resolution time, if a subscription for that env already exists, unsubscribe the duplicate instead of overwriting — the first winner is kept, later duplicates self-unsubscribe.

No visual change.

## Evidence

**Leak reproduced (before fix).** The new test deterministically drives the race (B stays subscribed so the generation can't bump; A is toggled off→on mid-subscribe, forcing a duplicate subscribe) and asserts exactly one of the two duplicate A subscriptions is unsubscribed. Without the guard, the orphan is never unsubscribed:

```
× does not leak an orphaned subscription when an env is toggled off then on mid-subscribe
AssertionError: expected +0 to be 1   // 0 unsubscribes → first subscription orphaned
```

**Resolved (after fix).**

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

The other two tests cover the basic subscribe/unsubscribe lifecycle and `stop()` ignoring in-flight resolutions (regression coverage for the extraction).

**No functional regression.** The full `useIpcEvents` suite passes against the refactored hook (the sync runs on mount, so a broken extraction would fail the ~10 tests that render the hook):

```
✓ runtime-client-events-sync.test.ts ✓ useIpcEvents.test.ts
Test Files  2 passed (2)
     Tests  56 passed (56)
```

Plus `oxlint` clean and renderer typecheck (`tsgo -p config/tsconfig.tc.web.json`) passes.

## Testing

- [x] `pnpm test` (new module test + full useIpcEvents suite, 56 passing)
- [x] `pnpm typecheck` (renderer project)
- [x] `pnpm lint` (oxlint clean; pre-commit hook clean)
- [x] Added a deterministic regression test that fails before the fix and passes after, plus lifecycle coverage for the extracted module

## AI Review Report

Found by an adversarial multi-agent memory-leak audit (subscription-orphan lens) and verified by reading the full effect closure, the subscribe primitive, and the desired-id source. Risks reviewed: behavior drift from extracting a critical hook path (mitigated — faithful move verified by the full useIpcEvents suite plus new lifecycle tests, and the path had no prior coverage); the guard incorrectly dropping a valid subscription (it only unsubscribes when an entry for the same env already exists, i.e. a genuine duplicate). Cross-platform: pure renderer/runtime-RPC logic — no platform-specific paths, shortcuts, or IPC channels touched.

## Security Audit

No input handling, command execution, path handling, auth, or secrets changes. The change reduces leaked IPC subscriptions (fewer dangling preload stream handles); subscription semantics are otherwise unchanged.

## Notes

Narrow timing-dependent race, but the orphaned handle persists for the whole session. The extraction also adds first-ever unit coverage to this subscription manager.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5793">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->