### PR TITLE
fix(mobile-emulator): keep "+" menu open on intro actions; auto-dismiss hidden toast

### DIFF
--- a/src/renderer/src/components/emulator-pane/MobileEmulatorTabIntroCallout.test.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorTabIntroCallout.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MobileEmulatorTabIntroCallout } from './MobileEmulatorTabIntroCallout'
+
+const { keepIntro, hideIntro, dismissIntro } = vi.hoisted(() => ({
+  keepIntro: vi.fn(),
+  hideIntro: vi.fn(),
+  dismissIntro: vi.fn()
+}))
+
+vi.mock('./use-mobile-emulator-tab-intro-actions', () => ({
+  useMobileEmulatorTabIntroActions: () => ({ keepIntro, hideIntro, dismissIntro })
+}))
+
+// Why: the Tooltip primitive needs a provider/portal we don't care about here;
+// render its trigger children directly so the test stays focused on wiring.
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => children,
+  TooltipContent: () => null
+}))
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+beforeEach(async () => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<MobileEmulatorTabIntroCallout />)
+  })
+})
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root?.unmount()
+    })
+  }
+  root = null
+  container?.remove()
+  container = null
+  vi.clearAllMocks()
+})
+
+function click(matcher: string): void {
+  const button = Array.from(container?.querySelectorAll('button') ?? []).find(
+    (el) => el.textContent?.trim() === matcher || el.getAttribute('aria-label') === matcher
+  )
+  if (!button) {
+    throw new Error(`button not found: ${matcher}`)
+  }
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+describe('MobileEmulatorTabIntroCallout', () => {
+  it('runs keepIntro when Keep is clicked', () => {
+    click('Keep')
+    expect(keepIntro).toHaveBeenCalledTimes(1)
+    expect(hideIntro).not.toHaveBeenCalled()
+    expect(dismissIntro).not.toHaveBeenCalled()
+  })
+
+  it('runs hideIntro when Hide is clicked', () => {
+    click('Hide')
+    expect(hideIntro).toHaveBeenCalledTimes(1)
+    expect(keepIntro).not.toHaveBeenCalled()
+    expect(dismissIntro).not.toHaveBeenCalled()
+  })
+
+  it('runs dismissIntro when the X is clicked', () => {
+    click('Dismiss')
+    expect(dismissIntro).toHaveBeenCalledTimes(1)
+    expect(keepIntro).not.toHaveBeenCalled()
+    expect(hideIntro).not.toHaveBeenCalled()
+  })
+
+  it('exposes no menu-closing prop, so reintroducing Issue 1 is a compile error', () => {
+    // Why: Issue 1's root cause was a parent-supplied close callback
+    // (onAction={() => setNewTabMenuOpen(false)}). The callout must accept no
+    // such prop — re-adding one fails this typechecked file's @ts-expect-error.
+    // @ts-expect-error - MobileEmulatorTabIntroCallout intentionally takes no props
+    const reintroduced = <MobileEmulatorTabIntroCallout onAction={() => undefined} />
+    expect(reintroduced).toBeDefined()
+  })
+
+  it('prevents the default pointer-down so the dropdown menu stays open', () => {
+    const callout = container?.querySelector('.mobile-emulator-tab-intro-callout--menu')
+    expect(callout).not.toBeNull()
+    const event = new MouseEvent('pointerdown', { bubbles: true, cancelable: true })
+    act(() => {
+      callout?.dispatchEvent(event)
+    })
+    expect(event.defaultPrevented).toBe(true)
+  })
+})

--- a/src/renderer/src/components/emulator-pane/MobileEmulatorTabIntroCallout.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorTabIntroCallout.tsx
@@ -4,25 +4,15 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { translate } from '@/i18n/i18n'
 import { useMobileEmulatorTabIntroActions } from './use-mobile-emulator-tab-intro-actions'
 
-type MobileEmulatorTabIntroCalloutProps = {
-  onAction?: () => void
-}
-
-export function MobileEmulatorTabIntroCallout({
-  onAction
-}: MobileEmulatorTabIntroCalloutProps): React.JSX.Element {
+export function MobileEmulatorTabIntroCallout(): React.JSX.Element {
   const { keepIntro, hideIntro, dismissIntro } = useMobileEmulatorTabIntroActions()
-
-  const runAndNotify = (action: () => void): void => {
-    action()
-    onAction?.()
-  }
 
   return (
     <div
       className="mobile-emulator-tab-intro-callout--menu mt-1 flex items-center gap-2 rounded-lg border-x border-b border-border/70 bg-muted px-2 py-1.5 dark:bg-accent/80"
       // Why: Radix dropdown treats pointer-down inside custom panels as an
-      // outside-select; keep the menu open while the user reads or clicks Keep/Hide.
+      // outside-select; keep the menu open while the user reads or acts on the
+      // Keep/Hide/Dismiss controls (the actions intentionally leave it open).
       onPointerDown={(event) => event.preventDefault()}
     >
       <p className="min-w-0 flex-1 text-[11px] leading-4 text-foreground/85">
@@ -37,7 +27,7 @@ export function MobileEmulatorTabIntroCallout({
           size="sm"
           variant="outline"
           className="h-6 px-2 text-[11px]"
-          onClick={() => runAndNotify(keepIntro)}
+          onClick={keepIntro}
         >
           {translate(
             'auto.components.emulator.pane.MobileEmulatorTabIntroCallout.8014b4b80b',
@@ -49,7 +39,7 @@ export function MobileEmulatorTabIntroCallout({
           size="sm"
           variant="ghost"
           className="h-6 px-2 text-[11px] text-muted-foreground"
-          onClick={() => runAndNotify(hideIntro)}
+          onClick={hideIntro}
         >
           {translate(
             'auto.components.emulator.pane.MobileEmulatorTabIntroCallout.6e051a40b7',
@@ -67,7 +57,7 @@ export function MobileEmulatorTabIntroCallout({
                 'Dismiss'
               )}
               className="size-6 text-muted-foreground"
-              onClick={() => runAndNotify(dismissIntro)}
+              onClick={dismissIntro}
             >
               <X className="size-3" />
             </Button>

--- a/src/renderer/src/components/emulator-pane/mobile-emulator-hidden-toast.test.tsx
+++ b/src/renderer/src/components/emulator-pane/mobile-emulator-hidden-toast.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import type { AppState } from '@/store/types'
+import { showMobileEmulatorHiddenToast } from './mobile-emulator-hidden-toast'
+
+vi.mock('sonner', () => ({
+  toast: {
+    dismiss: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('showMobileEmulatorHiddenToast', () => {
+  it('auto-dismisses after 30s while staying dismissible', () => {
+    showMobileEmulatorHiddenToast({
+      openSettingsPage: vi.fn() as unknown as AppState['openSettingsPage'],
+      openSettingsTarget: vi.fn() as unknown as AppState['openSettingsTarget']
+    })
+
+    const infoMock = vi.mocked(toast.info)
+    expect(infoMock).toHaveBeenCalledTimes(1)
+    const options = infoMock.mock.calls[0]?.[1]
+    // Why: a finite duration is the fix for the toast lingering forever; assert
+    // the exact value so a regression to Infinity is caught.
+    expect(options).toMatchObject({
+      id: 'mobile-emulator-hidden',
+      duration: 30_000,
+      dismissible: true
+    })
+  })
+})

--- a/src/renderer/src/components/emulator-pane/mobile-emulator-hidden-toast.tsx
+++ b/src/renderer/src/components/emulator-pane/mobile-emulator-hidden-toast.tsx
@@ -3,6 +3,9 @@ import type { AppState } from '@/store/types'
 import { translate } from '@/i18n/i18n'
 
 const MOBILE_EMULATOR_HIDDEN_TOAST_ID = 'mobile-emulator-hidden'
+// Why: auto-dismiss the nudge after 30s so it can't linger forever; it stays
+// dismissible early and the Settings re-enable link is reachable until then.
+const MOBILE_EMULATOR_HIDDEN_TOAST_DURATION_MS = 30_000
 
 type MobileEmulatorHiddenToastDeps = {
   openSettingsPage: AppState['openSettingsPage']
@@ -10,8 +13,6 @@ type MobileEmulatorHiddenToastDeps = {
 }
 
 export function showMobileEmulatorHiddenToast(deps: MobileEmulatorHiddenToastDeps): void {
-  // Why: matches other one-time opt-out nudges — stay on screen until the user
-  // dismisses it so the Settings re-enable path is easy to find.
   toast.info(
     translate(
       'auto.components.emulator.pane.mobile.emulator.hidden.toast.e8f098a870',
@@ -42,7 +43,7 @@ export function showMobileEmulatorHiddenToast(deps: MobileEmulatorHiddenToastDep
           .
         </p>
       ),
-      duration: Infinity,
+      duration: MOBILE_EMULATOR_HIDDEN_TOAST_DURATION_MS,
       dismissible: true
     }
   )

--- a/src/renderer/src/components/emulator-pane/use-mobile-emulator-tab-intro-actions.test.tsx
+++ b/src/renderer/src/components/emulator-pane/use-mobile-emulator-tab-intro-actions.test.tsx
@@ -121,7 +121,7 @@ describe('useMobileEmulatorTabIntroActions', () => {
     expect(closeUnifiedTab).toHaveBeenCalledWith('simulator-tab')
     expect(toast.info).toHaveBeenCalledWith(
       'Mobile Emulator hidden',
-      expect.objectContaining({ id: 'mobile-emulator-hidden' })
+      expect.objectContaining({ id: 'mobile-emulator-hidden', duration: 30_000 })
     )
     expect(toast.error).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -769,7 +769,7 @@ function TabBarInner({
     isMacOs &&
     mobileEmulatorEnabled &&
     onNewSimulatorTab ? (
-      <MobileEmulatorTabIntroCallout onAction={() => setNewTabMenuOpen(false)} />
+      <MobileEmulatorTabIntroCallout />
     ) : null
   const standardCreateMenuItems =
     newTabMenuOrder === 'markdown-first' ? (
@@ -1193,7 +1193,14 @@ function TabBarInner({
           </TooltipContent>
         </Tooltip>
       ) : null}
-      <DropdownMenu open={newTabMenuOpen} onOpenChange={setNewTabMenuOpen}>
+      <DropdownMenu
+        open={newTabMenuOpen}
+        onOpenChange={setNewTabMenuOpen}
+        // Why: this menu can stay open after the Mobile Emulator "Hide" action,
+        // which shows a toast with a re-enable link; modal would disable body
+        // pointer events and make that toast (and other outside UI) unclickable.
+        modal={false}
+      >
         <DropdownMenuTrigger asChild>
           <button
             className="ml-2 my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"


### PR DESCRIPTION
## What & why

Two fixes for the **Mobile Emulator intro callout** that appears inside the new-tab (`+`) dropdown menu.

### Issue 1 — the `+` menu closed when you clicked a callout action
Clicking **Keep / Hide / Dismiss** on the callout collapsed the entire `+` dropdown. The cause was the `onAction={() => setNewTabMenuOpen(false)}` wiring in `TabBar.tsx` plus the `runAndNotify` indirection in the callout. Now the buttons call their actions directly and the dropdown stays open:
- After **Hide**, `mobileEmulatorEnabled` flips to `false`, so the callout and the "New Mobile Emulator" item simply disappear from the still-open menu.
- After **Keep / Dismiss**, the callout disappears and the rest of the menu is untouched.

Removing the `onAction` prop also makes reintroducing the close a **compile error** (the component now accepts no props) — locked in by a `@ts-expect-error` guard in the test.

### Issue 2 — the "Mobile Emulator hidden" toast never went away
The toast used `duration: Infinity`. It now auto-dismisses after **30s** (`MOBILE_EMULATOR_HIDDEN_TOAST_DURATION_MS`), still dismissible early.

### Follow-on fix found in review — modal dropdown blocked the toast link
Because the menu now stays open after **Hide**, the Radix dropdown's default `modal={true}` (`body { pointer-events: none }`) made the toast's **"Settings › Mobile Emulator"** re-enable link unclickable for up to 30s. The new-tab dropdown is now `modal={false}` (the dominant pattern across this codebase), so the toast — and other outside UI — stays interactive while the menu is open. Bonus: clicking the re-enable link now naturally closes the menu and opens Settings.

## Testing
- `MobileEmulatorTabIntroCallout.test.tsx` (new): Keep/Hide/Dismiss button wiring, pointer-down `preventDefault` guard, and a compile-time guard that the callout exposes no menu-closing prop.
- `mobile-emulator-hidden-toast.test.tsx` (new): asserts `duration: 30_000` + `dismissible`.
- `use-mobile-emulator-tab-intro-actions.test.tsx`: now asserts the 30s duration.
- `pnpm test` (touched suites: 149 passing), `typecheck` (clean), full `lint` gate (oxlint, switch-exhaustiveness, styled-scrollbars, localization catalog + coverage) — all green.

### Live verification (Electron dev build, macOS, CDP)
- Opened `+` menu → callout shown → clicked **Hide**: menu **stayed open**, "New Mobile Emulator" item + callout vanished, toast appeared with the re-enable link, and `document.body.style.pointerEvents` was **unset** (confirming `modal={false}`).
- Re-ran the real hide flow and polled the toast: present at t+0/8/16/24s, **gone by t+31s** — auto-dismissing ~30s as intended (no longer infinite).

## Scope / platform notes
- The intro callout is macOS-only (`isMacOs`) — unchanged.
- No translation keys added/removed; localization catalog + coverage pass.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5800">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->