### PR TITLE
feat(plugin): plugin system v1a foundation — shared contract, async API, capability gate

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -102,6 +102,9 @@ module.exports = {
     'out/main/win32-utils.js',
     'out/main/daemon-entry.js',
     'out/main/computer-sidecar.js',
+    // Forked plugin backend host child process (ELECTRON_RUN_AS_NODE bypasses
+    // asar require integration, so it must live unpacked).
+    'out/main/plugin-host-entry.js',
     'out/main/chunks/**',
     'resources/**',
     'node_modules/ws/**',

--- a/config/scripts/build-relay.mjs
+++ b/config/scripts/build-relay.mjs
@@ -18,6 +18,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 // Why: the script lives under config/scripts, so go two levels up to reach the repo root.
 const ROOT = join(__dirname, '..', '..')
 const RELAY_ENTRY = join(ROOT, 'src', 'relay', 'relay.ts')
+// The trusted plugin backend child is forked by the relay from a co-located
+// plugin-host-entry.js, so it ships alongside relay.js (resolved bundle-relative
+// by relayPluginHostEntryPath) — only plugin *files* transfer at provision time.
+const PLUGIN_HOST_ENTRY = join(ROOT, 'src', 'main', 'plugin', 'plugin-host-entry.ts')
 
 const PLATFORMS = [
   'linux-x64',
@@ -43,6 +47,23 @@ for (const platform of PLATFORMS) {
     outfile: join(outDir, 'relay.js'),
     // Native addons cannot be bundled — they must exist on the remote host.
     // The relay gracefully degrades when they are absent.
+    external: ['node-pty', '@parcel/watcher'],
+    sourcemap: false,
+    minify: true,
+    define: {
+      'process.env.NODE_ENV': '"production"'
+    }
+  })
+
+  // Ship the plugin backend host-entry next to relay.js (same platform/runtime
+  // settings) so the relay can fork it without a per-plugin transfer.
+  await build({
+    entryPoints: [PLUGIN_HOST_ENTRY],
+    bundle: true,
+    platform: 'node',
+    target: 'node18',
+    format: 'cjs',
+    outfile: join(outDir, 'plugin-host-entry.js'),
     external: ['node-pty', '@parcel/watcher'],
     sourcemap: false,
     minify: true,

--- a/config/scripts/build-relay.mjs
+++ b/config/scripts/build-relay.mjs
@@ -34,42 +34,34 @@ const PLATFORMS = [
 
 const RELAY_VERSION = '0.1.0'
 
+// Shared esbuild options for every node bundle this script emits. Native addons
+// cannot be bundled — they must exist on the remote host; the relay gracefully
+// degrades when absent.
+const BASE_BUILD = {
+  bundle: true,
+  platform: 'node',
+  target: 'node18',
+  format: 'cjs',
+  external: ['node-pty', '@parcel/watcher'],
+  sourcemap: false,
+  minify: true,
+  define: {
+    'process.env.NODE_ENV': '"production"'
+  }
+}
+
 for (const platform of PLATFORMS) {
   const outDir = join(ROOT, 'out', 'relay', platform)
   mkdirSync(outDir, { recursive: true })
 
-  await build({
-    entryPoints: [RELAY_ENTRY],
-    bundle: true,
-    platform: 'node',
-    target: 'node18',
-    format: 'cjs',
-    outfile: join(outDir, 'relay.js'),
-    // Native addons cannot be bundled — they must exist on the remote host.
-    // The relay gracefully degrades when they are absent.
-    external: ['node-pty', '@parcel/watcher'],
-    sourcemap: false,
-    minify: true,
-    define: {
-      'process.env.NODE_ENV': '"production"'
-    }
-  })
+  await build({ ...BASE_BUILD, entryPoints: [RELAY_ENTRY], outfile: join(outDir, 'relay.js') })
 
-  // Ship the plugin backend host-entry next to relay.js (same platform/runtime
-  // settings) so the relay can fork it without a per-plugin transfer.
+  // Ship the plugin backend host-entry next to relay.js so the relay can fork it
+  // without a per-plugin transfer.
   await build({
+    ...BASE_BUILD,
     entryPoints: [PLUGIN_HOST_ENTRY],
-    bundle: true,
-    platform: 'node',
-    target: 'node18',
-    format: 'cjs',
-    outfile: join(outDir, 'plugin-host-entry.js'),
-    external: ['node-pty', '@parcel/watcher'],
-    sourcemap: false,
-    minify: true,
-    define: {
-      'process.env.NODE_ENV': '"production"'
-    }
+    outfile: join(outDir, 'plugin-host-entry.js')
   })
 
   // Why: include a content hash so the deploy check detects code changes

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -179,6 +179,9 @@ export default defineConfig({
           index: resolve('src/main/index.ts'),
           'daemon-entry': resolve('src/main/daemon/daemon-entry.ts'),
           'computer-sidecar': resolve('src/main/computer/sidecar-entry.ts'),
+          // Forked plugin backend host (child process per plugin); resolved from
+          // app.asar.unpacked at runtime (see plugin-system.ts resolveEntryPath).
+          'plugin-host-entry': resolve('src/main/plugin/plugin-host-entry.ts'),
           'stt-worker': resolve('src/main/speech/stt-worker.ts'),
           'warp-theme-parser-worker': resolve('src/main/warp-themes/warp-theme-parser-worker.ts'),
           'file-watcher-worker': resolve('src/main/runtime/file-watcher-worker.ts'),

--- a/examples/hello-sidebar-plugin/README.md
+++ b/examples/hello-sidebar-plugin/README.md
@@ -1,0 +1,54 @@
+# Hello Sidebar — example Orca plugin
+
+A minimal reference plugin for the Orca plugin system. It contributes a
+right-sidebar panel showing the current workspace/branch/dirty state and a
+settings page for a custom greeting, and demonstrates the trusted Node backend
+(it reads host info and can ask the host to open a link).
+
+## Layout
+
+```
+plugin.json        # manifest (id, version, hostApiVersion, contributes, capabilities, settingsSchema)
+main.js            # backend (trusted Node) — exports activate(context) / deactivate()
+ui/index.html      # sidebar panel UI (single self-contained file)
+ui/settings.html   # settings page UI (single self-contained file)
+```
+
+## Authoring notes
+
+- **Manifest.** `hostApiVersion` is pre-stable `0.x`. `contributes.sidebar.icon`
+  is a Lucide icon name. `ui` entries must be **single self-contained `.html`
+  files** (inline your JS/CSS) — multi-file UIs are not supported yet.
+- **Backend.** `main` is a Node CommonJS module exporting `activate(context)`
+  and optional `deactivate()`. It runs in a dedicated child process with the
+  full Node runtime — `require`, `child_process`, network, fs all work.
+- **`context` API (all host-backed calls are async — they cross a process
+  boundary, and an SSH hop on mobile):**
+  - `context.workspace.getSnapshot()` → `{ workspaceName, currentBranch, isDirty, openFileCount }`
+  - `context.workspace.onDidChange(cb)` / `context.events.on<Event>(cb)`
+  - `context.commands.invokeHost('open-external-url' | 'copy-to-clipboard', params)`
+  - `context.settings.get(key)` / `set(key, value)` (per-plugin, schema-validated)
+  - `context.ui.postMessage(msg)` / `onMessage(cb)` — talk to your webview(s)
+  - `context.subscriptions.push(disposable)` — disposed on deactivate
+- **UI ↔ backend.** The UI posts/receives generic messages; see
+  `src/shared/plugin/ui-bridge-client.ts` for a substrate-detecting client that
+  works in both the desktop webview and the mobile `react-native-webview`.
+- **Capabilities** are declared in the manifest for install-time consent. They
+  are **declared intent, not a runtime jail** (see Security).
+
+## Security / trust model
+
+Orca plugins are **trusted code** — like any npm dependency or VS Code
+extension. The backend runs with your full user privileges (files, processes,
+network). Trust is established **at install**, not enforced at runtime:
+
+- Install shows a "**runs with full access to your computer**" consent with the
+  source, version, and declared capabilities (which do not limit the plugin —
+  they are the author's stated intentions).
+- Dependency installs run with **lifecycle scripts disabled by default**
+  (`--ignore-scripts`); sources are integrity-checked (HTTPS + digest / pinned
+  commit SHA).
+- The UI webview is sandboxed for **fault isolation**, not privilege — privileged
+  work flows through the trusted backend.
+
+Only install plugins you trust.

--- a/examples/hello-sidebar-plugin/main.js
+++ b/examples/hello-sidebar-plugin/main.js
@@ -1,0 +1,47 @@
+// Hello Sidebar — example Orca plugin backend (trusted Node, runs in the
+// per-plugin host child process). Demonstrates the async `context` API and the
+// trusted runtime (free Node access — this reads host info; a real plugin could
+// spawn a CLI / read files). The UI bundle (ui/index.html) renders the state
+// this backend posts and can ask the host to open links.
+
+const os = require('node:os')
+
+/** @param {import('../../src/shared/plugin/api-contract').PluginContext} context */
+async function activate(context) {
+  const snapshot = await context.workspace.getSnapshot()
+  const greeting = (await context.settings.get('greeting')) || 'Hello'
+
+  // Handle messages from the plugin's UI webview.
+  context.ui.onMessage(async (message) => {
+    if (message && message.type === 'open' && typeof message.url === 'string') {
+      // Allowlisted host command; the host validates the scheme (http/https).
+      await context.commands.invokeHost('open-external-url', { url: message.url })
+    }
+    if (message && message.type === 'set-greeting' && typeof message.value === 'string') {
+      await context.settings.set('greeting', message.value)
+    }
+  })
+
+  // Re-render the UI whenever the workspace changes.
+  const push = async () => {
+    const current = await context.workspace.getSnapshot()
+    context.ui.postMessage({
+      type: 'state',
+      greeting: (await context.settings.get('greeting')) || 'Hello',
+      workspace: current.workspaceName,
+      branch: current.currentBranch,
+      dirty: current.isDirty,
+      openFiles: current.openFileCount,
+      host: os.hostname()
+    })
+  }
+  context.subscriptions.push(context.workspace.onDidChange(() => void push()))
+
+  await push()
+  void snapshot
+  void greeting
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate }

--- a/examples/hello-sidebar-plugin/plugin.json
+++ b/examples/hello-sidebar-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "id": "orca.hello-sidebar",
+  "name": "Hello Sidebar",
+  "version": "0.1.0",
+  "hostApiVersion": "0.1.0",
+  "main": "main.js",
+  "contributes": {
+    "sidebar": { "title": "Hello", "icon": "Sparkles", "ui": "ui/index.html" },
+    "settings": { "ui": "ui/settings.html" }
+  },
+  "capabilities": ["workspace:read", "commands", "settings"],
+  "settingsSchema": {
+    "type": "object",
+    "properties": { "greeting": { "type": "string" } },
+    "additionalProperties": false
+  }
+}

--- a/examples/hello-sidebar-plugin/ui/index.html
+++ b/examples/hello-sidebar-plugin/ui/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'" />
+    <title>Hello Sidebar</title>
+    <style>
+      body { font: 13px system-ui, sans-serif; margin: 0; padding: 12px; color: #ddd; background: #1e1e1e; }
+      h1 { font-size: 14px; margin: 0 0 8px; }
+      dl { margin: 0; display: grid; grid-template-columns: auto 1fr; gap: 2px 10px; }
+      dt { color: #888; }
+      a { color: #6cb6ff; cursor: pointer; }
+    </style>
+  </head>
+  <body>
+    <h1 id="greeting">Hello</h1>
+    <dl>
+      <dt>Workspace</dt><dd id="workspace">—</dd>
+      <dt>Branch</dt><dd id="branch">—</dd>
+      <dt>Dirty</dt><dd id="dirty">—</dd>
+      <dt>Open files</dt><dd id="openFiles">—</dd>
+      <dt>Host</dt><dd id="host">—</dd>
+    </dl>
+    <p><a id="docs">Open Orca docs</a></p>
+    <script>
+      // Minimal vendored copy of the UI bridge (see src/shared/plugin/ui-bridge-client.ts).
+      const rn = typeof window.ReactNativeWebView?.postMessage === 'function'
+      function post(message) {
+        if (rn) window.ReactNativeWebView.postMessage(JSON.stringify(message))
+        else (window.parent || window).postMessage(message, '*')
+      }
+      window.addEventListener('message', (event) => {
+        let data = event.data
+        if (rn && typeof data === 'string') { try { data = JSON.parse(data) } catch {} }
+        if (!data || data.type !== 'state') return
+        document.getElementById('greeting').textContent = data.greeting
+        document.getElementById('workspace').textContent = data.workspace
+        document.getElementById('branch').textContent = data.branch ?? '(none)'
+        document.getElementById('dirty').textContent = data.dirty ? 'yes' : 'no'
+        document.getElementById('openFiles').textContent = data.openFiles
+        document.getElementById('host').textContent = data.host
+      })
+      document.getElementById('docs').addEventListener('click', () => {
+        post({ type: 'open', url: 'https://orca.computer' })
+      })
+    </script>
+  </body>
+</html>

--- a/examples/hello-sidebar-plugin/ui/settings.html
+++ b/examples/hello-sidebar-plugin/ui/settings.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'" />
+    <title>Hello Sidebar — Settings</title>
+    <style>
+      body { font: 13px system-ui, sans-serif; margin: 0; padding: 12px; color: #ddd; background: #1e1e1e; }
+      label { display: block; margin-bottom: 4px; color: #888; }
+      input { width: 100%; box-sizing: border-box; padding: 6px; background: #2a2a2a; color: #ddd; border: 1px solid #3a3a3a; border-radius: 4px; }
+    </style>
+  </head>
+  <body>
+    <!-- The plugin owns its settings chrome (full-takeover); the host provides
+         no save/cancel. Writes go to the host-persisted, schema-validated store
+         via the backend. -->
+    <label for="greeting">Greeting</label>
+    <input id="greeting" type="text" placeholder="Hello" />
+    <script>
+      const rn = typeof window.ReactNativeWebView?.postMessage === 'function'
+      function post(message) {
+        if (rn) window.ReactNativeWebView.postMessage(JSON.stringify(message))
+        else (window.parent || window).postMessage(message, '*')
+      }
+      const input = document.getElementById('greeting')
+      input.addEventListener('change', () => post({ type: 'set-greeting', value: input.value }))
+    </script>
+  </body>
+</html>

--- a/mobile/app/h/[hostId]/plugins/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/plugins/[worktreeId].tsx
@@ -1,0 +1,11 @@
+import { useLocalSearchParams } from 'expo-router'
+import { useHostClient } from '../../../../src/transport/client-context'
+import { MobilePluginListPanel } from '../../../../src/components/plugins/MobilePluginListPanel'
+
+// Narrow-layout full-screen plugins route. Resolves the active host client from
+// the route's hostId, mirroring the standalone PR route.
+export default function MobilePluginsScreen() {
+  const { hostId } = useLocalSearchParams<{ hostId: string; worktreeId: string }>()
+  const { client } = useHostClient(hostId)
+  return <MobilePluginListPanel client={client} embedded={false} />
+}

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -42,6 +42,7 @@ import {
   MessageSquare,
   Mic,
   Monitor,
+  Plug,
   Plus,
   RefreshCw,
   Send,
@@ -4292,6 +4293,18 @@ export default function SessionScreen() {
                 <ListChecks size={18} color={colors.textSecondary} strokeWidth={2.1} />
               </Pressable>
             ) : null}
+            <Pressable
+              style={({ pressed }) => [
+                styles.filesButton,
+                pressed && styles.filesButtonPressed,
+                activePanel === 'plugins' && styles.filesButtonActive
+              ]}
+              onPress={() => handlePanelTap('plugins')}
+              hitSlop={8}
+              accessibilityLabel="Open plugins"
+            >
+              <Plug size={18} color={colors.textSecondary} strokeWidth={2.1} />
+            </Pressable>
           </View>
 
           {visibleTabs.length > 0 && (

--- a/mobile/src/components/plugins/MobilePluginListPanel.tsx
+++ b/mobile/src/components/plugins/MobilePluginListPanel.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { ChevronLeft, Plug } from 'lucide-react-native'
+import type { RpcClient } from '../../transport/rpc-client'
+import { colors, radii, spacing, typography } from '../../theme/mobile-theme'
+import { MobilePluginPanel } from './MobilePluginPanel'
+import { parsePluginListResult, type MobilePluginRow } from './mobile-plugin-list'
+
+// NEEDS-RUNTIME-VERIFY: the mobile entry point for the right-sidebar plugin
+// system. Lists installed plugins (plugin.list over the relay) and, on tap,
+// renders that plugin's UI via MobilePluginPanel. Mirrors the embedded-panel
+// shape of MobilePrViewPanel (header + close, dark theme). Mobile typecheck and
+// the Expo build can't run here (react-native deps absent); verified by oxlint +
+// pure-logic tests, with the on-device flow flagged for an Expo pass.
+
+type Props = { client: RpcClient | null; embedded?: boolean; onRequestClose?: () => void }
+
+export function MobilePluginListPanel({
+  client,
+  embedded = false,
+  onRequestClose
+}: Props): React.JSX.Element {
+  const [rows, setRows] = useState<MobilePluginRow[] | null>(null)
+  const [failed, setFailed] = useState(false)
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    if (!client) {
+      return
+    }
+    setRows(null)
+    setFailed(false)
+    client
+      .sendRequest('plugin.list')
+      .then((response) => setRows(parsePluginListResult(response)))
+      .catch(() => setFailed(true))
+  }, [client])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  // A selected plugin takes over the panel; back returns to the list.
+  if (selected && client) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Pressable
+            style={styles.headerButton}
+            onPress={() => setSelected(null)}
+            hitSlop={8}
+            accessibilityLabel="Back to plugins"
+          >
+            <ChevronLeft size={20} color={colors.textSecondary} strokeWidth={2.1} />
+          </Pressable>
+          <Text style={styles.headerTitle} numberOfLines={1}>
+            {selected}
+          </Text>
+        </View>
+        <MobilePluginPanel client={client} pluginId={selected} />
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Plugins</Text>
+        {embedded && onRequestClose ? (
+          <Pressable
+            style={styles.headerButton}
+            onPress={onRequestClose}
+            hitSlop={8}
+            accessibilityLabel="Close plugins"
+          >
+            <ChevronLeft size={20} color={colors.textSecondary} strokeWidth={2.1} />
+          </Pressable>
+        ) : null}
+      </View>
+      {renderBody(rows, failed, (id) => setSelected(id), load)}
+    </View>
+  )
+}
+
+function renderBody(
+  rows: MobilePluginRow[] | null,
+  failed: boolean,
+  onSelect: (id: string) => void,
+  onRetry: () => void
+): React.JSX.Element {
+  if (failed) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.stateText}>Couldn’t load plugins.</Text>
+        <Pressable style={styles.retryButton} onPress={onRetry} hitSlop={8}>
+          <Text style={styles.retryText}>Retry</Text>
+        </Pressable>
+      </View>
+    )
+  }
+  if (rows === null) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    )
+  }
+  if (rows.length === 0) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.stateText}>No plugins installed.</Text>
+      </View>
+    )
+  }
+  return (
+    <ScrollView contentContainerStyle={styles.list}>
+      {rows.map((row) => (
+        <Pressable
+          key={row.id}
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+          onPress={() => onSelect(row.id)}
+          accessibilityLabel={`Open ${row.title}`}
+        >
+          <Plug size={16} color={colors.textSecondary} strokeWidth={2.1} />
+          <Text style={styles.rowTitle} numberOfLines={1}>
+            {row.title}
+          </Text>
+        </Pressable>
+      ))}
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.bgPanel },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.borderSubtle
+  },
+  headerTitle: {
+    flex: 1,
+    color: colors.textPrimary,
+    fontSize: typography.titleSize,
+    fontWeight: '600'
+  },
+  headerButton: { padding: spacing.xs },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.lg,
+    gap: spacing.md
+  },
+  stateText: { color: colors.textSecondary, fontSize: typography.bodySize },
+  retryButton: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised
+  },
+  retryText: { color: colors.textPrimary, fontSize: typography.bodySize },
+  list: { padding: spacing.sm },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+    borderRadius: radii.row
+  },
+  rowPressed: { backgroundColor: colors.bgRaised },
+  rowTitle: { flex: 1, color: colors.textPrimary, fontSize: typography.bodySize }
+})

--- a/mobile/src/components/plugins/MobilePluginListPanel.tsx
+++ b/mobile/src/components/plugins/MobilePluginListPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { ChevronLeft, Plug } from 'lucide-react-native'
 import type { RpcClient } from '../../transport/rpc-client'
@@ -6,12 +6,8 @@ import { colors, radii, spacing, typography } from '../../theme/mobile-theme'
 import { MobilePluginPanel } from './MobilePluginPanel'
 import { parsePluginListResult, type MobilePluginRow } from './mobile-plugin-list'
 
-// NEEDS-RUNTIME-VERIFY: the mobile entry point for the right-sidebar plugin
-// system. Lists installed plugins (plugin.list over the relay) and, on tap,
-// renders that plugin's UI via MobilePluginPanel. Mirrors the embedded-panel
-// shape of MobilePrViewPanel (header + close, dark theme). Mobile typecheck and
-// the Expo build can't run here (react-native deps absent); verified by oxlint +
-// pure-logic tests, with the on-device flow flagged for an Expo pass.
+// NEEDS-RUNTIME-VERIFY: follows MobilePrViewPanel's embedded-panel contract; the
+// JSX/navigation wiring can't run here (Expo deps absent), only the pure parser is tested.
 
 type Props = { client: RpcClient | null; embedded?: boolean; onRequestClose?: () => void }
 
@@ -24,20 +20,37 @@ export function MobilePluginListPanel({
   const [failed, setFailed] = useState(false)
   const [selected, setSelected] = useState<string | null>(null)
 
+  // Track the in-flight request so a late response from a replaced client (or
+  // after unmount) can't overwrite fresh state. Mirrors MobilePluginPanel.
+  const requestSeq = useRef(0)
+
   const load = useCallback(() => {
     if (!client) {
       return
     }
+    const seq = ++requestSeq.current
     setRows(null)
     setFailed(false)
     client
       .sendRequest('plugin.list')
-      .then((response) => setRows(parsePluginListResult(response)))
-      .catch(() => setFailed(true))
+      .then((response) => {
+        if (seq === requestSeq.current) {
+          setRows(parsePluginListResult(response))
+        }
+      })
+      .catch(() => {
+        if (seq === requestSeq.current) {
+          setFailed(true)
+        }
+      })
   }, [client])
 
   useEffect(() => {
     load()
+    return () => {
+      // Invalidate any in-flight request on client change / unmount.
+      requestSeq.current++
+    }
   }, [load])
 
   // A selected plugin takes over the panel; back returns to the list.

--- a/mobile/src/components/plugins/MobilePluginPanel.tsx
+++ b/mobile/src/components/plugins/MobilePluginPanel.tsx
@@ -25,16 +25,22 @@ export function MobilePluginPanel({ client, pluginId }: Props): React.JSX.Elemen
     setFailed(false)
     client
       .sendRequest('plugin.getEntry', { pluginId })
-      .then((response) => {
+      .then(async (response) => {
         if (cancelled) {
           return
         }
         const result = response.ok ? (response.result as GetEntryResult) : undefined
-        if (result?.ok && typeof result.html === 'string') {
-          setHtml(result.html)
-          // Start the trusted backend child on the relay host for this plugin.
-          void client.sendRequest('plugin.activate', { pluginId })
-        } else {
+        if (!result?.ok || typeof result.html !== 'string') {
+          setFailed(true)
+          return
+        }
+        setHtml(result.html)
+        // Start the trusted backend child on the relay host. Surface a failed
+        // start instead of leaving the user on a UI whose backend never ran.
+        const activated = await client.sendRequest('plugin.activate', { pluginId })
+        const activeOk =
+          activated.ok && (activated.result as { ok?: boolean } | undefined)?.ok === true
+        if (!cancelled && !activeOk) {
           setFailed(true)
         }
       })
@@ -45,6 +51,9 @@ export function MobilePluginPanel({ client, pluginId }: Props): React.JSX.Elemen
       })
     return () => {
       cancelled = true
+      // Stop the backend child when the panel closes / switches plugins so
+      // children don't accumulate on the relay. Best-effort fire-and-forget.
+      void client.sendRequest('plugin.deactivate', { pluginId })
     }
   }, [client, pluginId])
 

--- a/mobile/src/components/plugins/MobilePluginPanel.tsx
+++ b/mobile/src/components/plugins/MobilePluginPanel.tsx
@@ -1,11 +1,14 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 import { WebView, type WebViewMessageEvent } from 'react-native-webview'
 import type { RpcClient } from '../../transport/rpc-client'
+import { buildInjectedUiMessage, extractPluginUiMessage } from './mobile-plugin-bridge'
 
 // NEEDS-RUNTIME-VERIFY: plugin HTML is fetched from the relay host (plugin.getEntry),
-// not served on-device, because no Node runs on the phone. UI messages round-trip
-// to the relay-hosted backend via plugin.bridge.
+// not served on-device, because no Node runs on the phone. The async bridge runs
+// the trusted backend on the relay: activate on open, post outbound webview
+// messages via plugin.postUi, and inject inbound plugin.uiMessage payloads back
+// into the WebView so the in-page ui-bridge-client can match reqIds.
 
 type Props = { client: RpcClient; pluginId: string }
 
@@ -14,6 +17,7 @@ type GetEntryResult = { ok?: boolean; html?: string }
 export function MobilePluginPanel({ client, pluginId }: Props): React.JSX.Element {
   const [html, setHtml] = useState<string | null>(null)
   const [failed, setFailed] = useState(false)
+  const webViewRef = useRef<WebView>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -28,6 +32,8 @@ export function MobilePluginPanel({ client, pluginId }: Props): React.JSX.Elemen
         const result = response.ok ? (response.result as GetEntryResult) : undefined
         if (result?.ok && typeof result.html === 'string') {
           setHtml(result.html)
+          // Start the trusted backend child on the relay host for this plugin.
+          void client.sendRequest('plugin.activate', { pluginId })
         } else {
           setFailed(true)
         }
@@ -42,10 +48,21 @@ export function MobilePluginPanel({ client, pluginId }: Props): React.JSX.Elemen
     }
   }, [client, pluginId])
 
+  // Deliver backend -> UI messages into the WebView. The relay pushes them as
+  // plugin.uiMessage notifications; we inject only this plugin's traffic.
+  useEffect(() => {
+    return client.onNotification('plugin.uiMessage', (params) => {
+      const match = extractPluginUiMessage(params, pluginId)
+      if (match.matched) {
+        webViewRef.current?.injectJavaScript(buildInjectedUiMessage(match.message))
+      }
+    })
+  }, [client, pluginId])
+
   const onMessage = (event: WebViewMessageEvent): void => {
     try {
-      const request = JSON.parse(event.nativeEvent.data)
-      void client.sendRequest('plugin.bridge', { pluginId, request })
+      const message = JSON.parse(event.nativeEvent.data)
+      void client.sendRequest('plugin.postUi', { pluginId, message })
     } catch {
       // Ignore non-JSON messages from the plugin UI.
     }
@@ -67,6 +84,7 @@ export function MobilePluginPanel({ client, pluginId }: Props): React.JSX.Elemen
   }
   return (
     <WebView
+      ref={webViewRef}
       originWhitelist={['*']}
       source={{ html }}
       onMessage={onMessage}

--- a/mobile/src/components/plugins/MobilePluginPanel.tsx
+++ b/mobile/src/components/plugins/MobilePluginPanel.tsx
@@ -3,12 +3,9 @@ import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 import { WebView, type WebViewMessageEvent } from 'react-native-webview'
 import type { RpcClient } from '../../transport/rpc-client'
 
-// NEEDS-RUNTIME-VERIFY: renders a plugin's single-file UI on mobile. Fetches the
-// HTML over the relay (plugin.getEntry — no on-device server, no relative-asset
-// resolution) and feeds it to react-native-webview as { html }. UI messages
-// round-trip to the relay-hosted backend via plugin.bridge. The backend runs on
-// the relay host (where the workspace lives), so a plugin works on the phone
-// without Node on the device.
+// NEEDS-RUNTIME-VERIFY: plugin HTML is fetched from the relay host (plugin.getEntry),
+// not served on-device, because no Node runs on the phone. UI messages round-trip
+// to the relay-hosted backend via plugin.bridge.
 
 type Props = { client: RpcClient; pluginId: string }
 

--- a/mobile/src/components/plugins/MobilePluginPanel.tsx
+++ b/mobile/src/components/plugins/MobilePluginPanel.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
+import { WebView, type WebViewMessageEvent } from 'react-native-webview'
+import type { RpcClient } from '../../transport/rpc-client'
+
+// NEEDS-RUNTIME-VERIFY: renders a plugin's single-file UI on mobile. Fetches the
+// HTML over the relay (plugin.getEntry — no on-device server, no relative-asset
+// resolution) and feeds it to react-native-webview as { html }. UI messages
+// round-trip to the relay-hosted backend via plugin.bridge. The backend runs on
+// the relay host (where the workspace lives), so a plugin works on the phone
+// without Node on the device.
+
+type Props = { client: RpcClient; pluginId: string }
+
+type GetEntryResult = { ok?: boolean; html?: string }
+
+export function MobilePluginPanel({ client, pluginId }: Props): React.JSX.Element {
+  const [html, setHtml] = useState<string | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setHtml(null)
+    setFailed(false)
+    client
+      .sendRequest('plugin.getEntry', { pluginId })
+      .then((response) => {
+        if (cancelled) {
+          return
+        }
+        const result = response.ok ? (response.result as GetEntryResult) : undefined
+        if (result?.ok && typeof result.html === 'string') {
+          setHtml(result.html)
+        } else {
+          setFailed(true)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFailed(true)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [client, pluginId])
+
+  const onMessage = (event: WebViewMessageEvent): void => {
+    try {
+      const request = JSON.parse(event.nativeEvent.data)
+      void client.sendRequest('plugin.bridge', { pluginId, request })
+    } catch {
+      // Ignore non-JSON messages from the plugin UI.
+    }
+  }
+
+  if (failed) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>This plugin failed to load.</Text>
+      </View>
+    )
+  }
+  if (html === null) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    )
+  }
+  return (
+    <WebView
+      originWhitelist={['*']}
+      source={{ html }}
+      onMessage={onMessage}
+      javaScriptEnabled
+      style={styles.webview}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
+  error: { color: '#ff6b6b', fontSize: 13 },
+  webview: { flex: 1, backgroundColor: 'transparent' }
+})

--- a/mobile/src/components/plugins/mobile-plugin-bridge.test.ts
+++ b/mobile/src/components/plugins/mobile-plugin-bridge.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { buildInjectedUiMessage, extractPluginUiMessage } from './mobile-plugin-bridge'
+
+describe('buildInjectedUiMessage', () => {
+  it('dispatches a message event carrying the JSON-stringified payload', () => {
+    const snippet = buildInjectedUiMessage({ reqId: 'r1', ok: true, result: 42 })
+    expect(snippet).toContain("new MessageEvent('message'")
+    // The event data is the JSON string of the payload, embedded as a JS literal.
+    expect(snippet).toContain(JSON.stringify(JSON.stringify({ reqId: 'r1', ok: true, result: 42 })))
+    expect(snippet.trimEnd().endsWith('true;')).toBe(true)
+  })
+
+  it('safely escapes payloads containing quotes and newlines', () => {
+    const snippet = buildInjectedUiMessage({ text: 'he said "hi"\nbye' })
+    // Must not break out of the JS string literal.
+    expect(snippet).toContain(JSON.stringify(JSON.stringify({ text: 'he said "hi"\nbye' })))
+  })
+})
+
+describe('extractPluginUiMessage', () => {
+  it('returns the message when the pluginId matches', () => {
+    const result = extractPluginUiMessage(
+      { pluginId: 'acme.foo', message: { reqId: 'r1' } },
+      'acme.foo'
+    )
+    expect(result).toEqual({ matched: true, message: { reqId: 'r1' } })
+  })
+
+  it('ignores a notification for a different pluginId', () => {
+    const result = extractPluginUiMessage({ pluginId: 'other.bar', message: {} }, 'acme.foo')
+    expect(result.matched).toBe(false)
+  })
+
+  it('ignores a malformed notification with no string pluginId', () => {
+    expect(extractPluginUiMessage({ message: {} }, 'acme.foo').matched).toBe(false)
+    expect(extractPluginUiMessage({ pluginId: 42 }, 'acme.foo').matched).toBe(false)
+  })
+
+  it('matches even when the message is undefined (lifecycle-only notification)', () => {
+    expect(extractPluginUiMessage({ pluginId: 'acme.foo' }, 'acme.foo')).toEqual({
+      matched: true,
+      message: undefined
+    })
+  })
+})

--- a/mobile/src/components/plugins/mobile-plugin-bridge.test.ts
+++ b/mobile/src/components/plugins/mobile-plugin-bridge.test.ts
@@ -27,8 +27,9 @@ describe('extractPluginUiMessage', () => {
   })
 
   it('ignores a notification for a different pluginId', () => {
-    const result = extractPluginUiMessage({ pluginId: 'other.bar', message: {} }, 'acme.foo')
-    expect(result.matched).toBe(false)
+    expect(extractPluginUiMessage({ pluginId: 'other.bar', message: {} }, 'acme.foo')).toEqual({
+      matched: false
+    })
   })
 
   it('ignores a malformed notification with no string pluginId', () => {

--- a/mobile/src/components/plugins/mobile-plugin-bridge.ts
+++ b/mobile/src/components/plugins/mobile-plugin-bridge.ts
@@ -1,0 +1,34 @@
+// Pure helpers for the mobile plugin async bridge. No React/native imports so
+// the injectJavaScript snippet builder and the notification filter are
+// unit-testable under node Vitest.
+//
+// Inbound delivery mirrors the in-webview ui-bridge-client (src/shared/plugin/
+// ui-bridge-client.ts): on the RN substrate it listens for window 'message'
+// events whose data is a JSON string, so we deliver a backend message by
+// dispatching exactly that event inside the WebView.
+
+export type PluginUiMatch = { matched: boolean; message: unknown }
+
+// Build the JS injected into the WebView to hand a backend message to the
+// in-page bridge. The payload is double-encoded: JSON.stringify(message) is the
+// string the bridge expects as event.data, and the outer stringify turns that
+// into a safe JS string literal (escaping quotes/newlines).
+export function buildInjectedUiMessage(message: unknown): string {
+  const dataLiteral = JSON.stringify(JSON.stringify(message))
+  // Trailing `true;` is the react-native-webview convention to avoid a warning
+  // about injected scripts that don't return a value.
+  return `(function(){try{window.dispatchEvent(new MessageEvent('message',{data:${dataLiteral}}));}catch(e){}})();true;`
+}
+
+// Filter a plugin.uiMessage notification to the panel's own pluginId. Returns
+// matched:false for a different/absent pluginId so a panel ignores other
+// plugins' traffic on the shared connection.
+export function extractPluginUiMessage(
+  params: Record<string, unknown>,
+  pluginId: string
+): PluginUiMatch {
+  if (typeof params.pluginId !== 'string' || params.pluginId !== pluginId) {
+    return { matched: false, message: undefined }
+  }
+  return { matched: true, message: params.message }
+}

--- a/mobile/src/components/plugins/mobile-plugin-bridge.ts
+++ b/mobile/src/components/plugins/mobile-plugin-bridge.ts
@@ -7,7 +7,7 @@
 // events whose data is a JSON string, so we deliver a backend message by
 // dispatching exactly that event inside the WebView.
 
-export type PluginUiMatch = { matched: boolean; message: unknown }
+export type PluginUiMatch = { matched: true; message: unknown } | { matched: false }
 
 // Build the JS injected into the WebView to hand a backend message to the
 // in-page bridge. The payload is double-encoded: JSON.stringify(message) is the
@@ -28,7 +28,7 @@ export function extractPluginUiMessage(
   pluginId: string
 ): PluginUiMatch {
   if (typeof params.pluginId !== 'string' || params.pluginId !== pluginId) {
-    return { matched: false, message: undefined }
+    return { matched: false }
   }
   return { matched: true, message: params.message }
 }

--- a/mobile/src/components/plugins/mobile-plugin-list.test.ts
+++ b/mobile/src/components/plugins/mobile-plugin-list.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { parsePluginListResult } from './mobile-plugin-list'
+
+describe('parsePluginListResult', () => {
+  it('maps a successful response into rows preserving id and title', () => {
+    const rows = parsePluginListResult({
+      ok: true,
+      result: {
+        plugins: [
+          { id: 'acme.foo', title: 'Foo', icon: 'Activity', version: '1.0.0', ui: 'index.html' },
+          { id: 'acme.bar', title: 'Bar', icon: 'Bell', version: '2.0.0', ui: 'index.html' }
+        ]
+      }
+    })
+    expect(rows).toEqual([
+      { id: 'acme.foo', title: 'Foo', icon: 'Activity' },
+      { id: 'acme.bar', title: 'Bar', icon: 'Bell' }
+    ])
+  })
+
+  it('falls back to id for title and Plug for icon when missing', () => {
+    const rows = parsePluginListResult({ ok: true, result: { plugins: [{ id: 'acme.baz' }] } })
+    expect(rows).toEqual([{ id: 'acme.baz', title: 'acme.baz', icon: 'Plug' }])
+  })
+
+  it('returns an empty list for an empty plugins array', () => {
+    expect(parsePluginListResult({ ok: true, result: { plugins: [] } })).toEqual([])
+  })
+
+  it('returns an empty list for a failed response', () => {
+    expect(parsePluginListResult({ ok: false })).toEqual([])
+    expect(parsePluginListResult(null)).toEqual([])
+    expect(parsePluginListResult(undefined)).toEqual([])
+  })
+
+  it('skips malformed entries without a string id', () => {
+    const rows = parsePluginListResult({
+      ok: true,
+      result: {
+        plugins: [{ id: 'acme.ok', title: 'OK' }, { title: 'no id' }, null, 42, { id: '' }]
+      }
+    })
+    expect(rows).toEqual([{ id: 'acme.ok', title: 'OK', icon: 'Plug' }])
+  })
+})

--- a/mobile/src/components/plugins/mobile-plugin-list.ts
+++ b/mobile/src/components/plugins/mobile-plugin-list.ts
@@ -1,0 +1,36 @@
+// Pure parsing for the mobile plugin list. No React/native imports so the
+// plugin.list response → row mapping is unit-testable under node Vitest, the
+// same split MobileSourceControl/session-panel-host use for their pure logic.
+
+export type MobilePluginRow = { id: string; title: string; icon: string }
+
+type RpcLike = { ok?: boolean; result?: unknown } | null | undefined
+
+// Project a relay plugin.list response into selectable rows. Tolerant of a
+// failed/empty response and of malformed entries (skips anything without a
+// string id), so a single bad manifest can't blank the whole list.
+export function parsePluginListResult(response: RpcLike): MobilePluginRow[] {
+  if (!response?.ok || typeof response.result !== 'object' || response.result === null) {
+    return []
+  }
+  const plugins = (response.result as { plugins?: unknown }).plugins
+  if (!Array.isArray(plugins)) {
+    return []
+  }
+  const rows: MobilePluginRow[] = []
+  for (const entry of plugins) {
+    if (typeof entry !== 'object' || entry === null) {
+      continue
+    }
+    const { id, title, icon } = entry as { id?: unknown; title?: unknown; icon?: unknown }
+    if (typeof id !== 'string' || id.length === 0) {
+      continue
+    }
+    rows.push({
+      id,
+      title: typeof title === 'string' && title.length > 0 ? title : id,
+      icon: typeof icon === 'string' && icon.length > 0 ? icon : 'Plug'
+    })
+  }
+  return rows
+}

--- a/mobile/src/session/SessionDockColumn.tsx
+++ b/mobile/src/session/SessionDockColumn.tsx
@@ -5,6 +5,7 @@ import type { RpcClient } from '../transport/rpc-client'
 import { MobileSourceControlPanel } from '../source-control/MobileSourceControlPanel'
 import { MobileFileExplorerPanel } from '../files/MobileFileExplorerPanel'
 import { MobilePrViewPanel } from '../components/pr-sidebar/MobilePrViewPanel'
+import { MobilePluginListPanel } from '../components/plugins/MobilePluginListPanel'
 import { mobilePrSidebarStyles } from '../components/pr-sidebar/mobile-pr-sidebar-styles'
 import { useMobileDockResize } from './use-mobile-dock-resize'
 import type { ActivePanel } from './session-panel-host'
@@ -105,6 +106,9 @@ const DockPanelContent = memo(function DockPanelContent({
         onRequestClose={onRequestClose}
       />
     )
+  }
+  if (activePanel === 'plugins') {
+    return <MobilePluginListPanel client={client} embedded onRequestClose={onRequestClose} />
   }
   return (
     <MobilePrViewPanel

--- a/mobile/src/session/session-panel-host.test.ts
+++ b/mobile/src/session/session-panel-host.test.ts
@@ -7,7 +7,7 @@ import {
   type ActivePanel
 } from './session-panel-host'
 
-const PANELS = ['sourceControl', 'files', 'pr'] as const
+const PANELS = ['sourceControl', 'files', 'pr', 'plugins'] as const
 
 describe('nextActivePanel', () => {
   it('opens a panel from the closed state', () => {
@@ -51,7 +51,7 @@ describe('resolvePanelAction', () => {
   })
 
   it('pushes the tapped panel when docking is unavailable regardless of current', () => {
-    const currents: ActivePanel[] = [null, 'sourceControl', 'files', 'pr']
+    const currents: ActivePanel[] = [null, 'sourceControl', 'files', 'pr', 'plugins']
     for (const panel of PANELS) {
       for (const current of currents) {
         expect(resolvePanelAction({ canDock: false, tapped: panel, current })).toEqual({
@@ -87,6 +87,9 @@ describe('panelRouteDescriptor', () => {
     })
     expect(panelRouteDescriptor('pr')).toEqual({
       pathname: '/h/[hostId]/pr/[worktreeId]'
+    })
+    expect(panelRouteDescriptor('plugins')).toEqual({
+      pathname: '/h/[hostId]/plugins/[worktreeId]'
     })
   })
 })

--- a/mobile/src/session/session-panel-host.ts
+++ b/mobile/src/session/session-panel-host.ts
@@ -2,7 +2,7 @@
 // imports so the dock-vs-push decision and the active-panel state machine are
 // unit-testable under node Vitest (KTD3/R8).
 
-export type ActivePanel = 'sourceControl' | 'files' | 'pr' | null
+export type ActivePanel = 'sourceControl' | 'files' | 'pr' | 'plugins' | null
 
 // Toggle/swap reducer for the wide-layout dock: tapping the active panel closes it,
 // tapping any other opens/swaps to it. Exactly one panel docks at a time (R2).
@@ -55,5 +55,7 @@ export function panelRouteDescriptor(panel: Exclude<ActivePanel, null>): { pathn
       return { pathname: '/h/[hostId]/files/[worktreeId]' }
     case 'pr':
       return { pathname: '/h/[hostId]/pr/[worktreeId]' }
+    case 'plugins':
+      return { pathname: '/h/[hostId]/plugins/[worktreeId]' }
   }
 }

--- a/mobile/src/transport/notification-listeners.test.ts
+++ b/mobile/src/transport/notification-listeners.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { createNotificationRegistry } from './notification-listeners'
+
+describe('createNotificationRegistry', () => {
+  it('dispatches a notification frame (method, no id) to a registered listener', () => {
+    const reg = createNotificationRegistry()
+    const seen: Record<string, unknown>[] = []
+    reg.add('plugin.uiMessage', (params) => seen.push(params))
+    const consumed = reg.tryDispatch({ method: 'plugin.uiMessage', params: { pluginId: 'a' } })
+    expect(consumed).toBe(true)
+    expect(seen).toEqual([{ pluginId: 'a' }])
+  })
+
+  it('fans out to every listener on the same method', () => {
+    const reg = createNotificationRegistry()
+    let a = 0
+    let b = 0
+    reg.add('m', () => (a += 1))
+    reg.add('m', () => (b += 1))
+    reg.tryDispatch({ method: 'm', params: {} })
+    expect([a, b]).toEqual([1, 1])
+  })
+
+  it('defaults params to {} when the frame omits them', () => {
+    const reg = createNotificationRegistry()
+    let received: unknown
+    reg.add('m', (params) => (received = params))
+    reg.tryDispatch({ method: 'm' })
+    expect(received).toEqual({})
+  })
+
+  it('does not consume a frame that carries an id (a request reply)', () => {
+    const reg = createNotificationRegistry()
+    let called = false
+    reg.add('m', () => (called = true))
+    expect(reg.tryDispatch({ method: 'm', id: 'r1' })).toBe(false)
+    expect(called).toBe(false)
+  })
+
+  it('does not consume a frame whose method is not a string', () => {
+    const reg = createNotificationRegistry()
+    expect(reg.tryDispatch({ method: 42 })).toBe(false)
+    expect(reg.tryDispatch({})).toBe(false)
+  })
+
+  it('unsubscribe removes only the returned listener', () => {
+    const reg = createNotificationRegistry()
+    let a = 0
+    let b = 0
+    const off = reg.add('m', () => (a += 1))
+    reg.add('m', () => (b += 1))
+    off()
+    reg.tryDispatch({ method: 'm', params: {} })
+    expect([a, b]).toEqual([0, 1])
+  })
+})

--- a/mobile/src/transport/notification-listeners.ts
+++ b/mobile/src/transport/notification-listeners.ts
@@ -1,0 +1,39 @@
+// Registry for server-pushed JSON-RPC notifications (a `method`, no `id`) routed
+// by method name — e.g. plugin.uiMessage. Kept out of rpc-client so the
+// frame-dispatch logic is isolated and unit-testable.
+
+export type NotificationListener = (params: Record<string, unknown>) => void
+
+type NotificationFrame = { method?: unknown; id?: unknown; params?: unknown }
+
+export function createNotificationRegistry() {
+  const listeners = new Map<string, Set<NotificationListener>>()
+
+  function add(method: string, listener: NotificationListener): () => void {
+    let set = listeners.get(method)
+    if (!set) {
+      set = new Set()
+      listeners.set(method, set)
+    }
+    set.add(listener)
+    return () => {
+      listeners.get(method)?.delete(listener)
+    }
+  }
+
+  // Route a parsed frame to method-keyed listeners. Returns true when the frame
+  // was a notification (a `method` and no `id`) and was therefore consumed, so
+  // the caller can stop before the id-keyed request/stream branches.
+  function tryDispatch(frame: NotificationFrame): boolean {
+    if (typeof frame.method !== 'string' || frame.id !== undefined) {
+      return false
+    }
+    const params = (frame.params ?? {}) as Record<string, unknown>
+    for (const listener of listeners.get(frame.method) ?? []) {
+      listener(params)
+    }
+    return true
+  }
+
+  return { add, tryDispatch }
+}

--- a/mobile/src/transport/notification-listeners.ts
+++ b/mobile/src/transport/notification-listeners.ts
@@ -4,7 +4,7 @@
 
 export type NotificationListener = (params: Record<string, unknown>) => void
 
-type NotificationFrame = { method?: unknown; id?: unknown; params?: unknown }
+export type NotificationFrame = { method?: unknown; id?: unknown; params?: unknown }
 
 export function createNotificationRegistry() {
   const listeners = new Map<string, Set<NotificationListener>>()

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -29,6 +29,11 @@ import {
   updateTerminalSubscriptionViewport as updateCachedTerminalSubscriptionViewport
 } from './rpc-client-terminal-subscription'
 import { describeSocketEvent } from './socket-event-debug'
+import { createNotificationRegistry } from './notification-listeners'
+import {
+  isBrowserScreencastReadyResult,
+  isTerminalSubscribedResult
+} from './rpc-stream-result-guards'
 
 type PendingRequest = {
   resolve: (response: RpcResponse) => void
@@ -92,6 +97,12 @@ export type RpcClient = {
   // to distinguish "host moved/never reachable" from "transient blip".
   getLastConnectedAt: () => number | null
   onStateChange: (listener: (state: ConnectionState) => void) => () => void
+  // Listen for server-pushed JSON-RPC notifications (no id) by method name,
+  // e.g. plugin.uiMessage. Returns an unsubscribe fn.
+  onNotification: (
+    method: string,
+    listener: (params: Record<string, unknown>) => void
+  ) => () => void
   // Why: app-resume hook. Android/iOS can kill the TCP path or park the
   // reconnect loop while the app is backgrounded; callers invoke this on
   // AppState 'active' so the session recovers without an app restart.
@@ -217,6 +228,7 @@ export function connect(
 
   const pending = new Map<string, PendingRequest>()
   const streamListeners = new Map<string, StreamRequest>()
+  const notifications = createNotificationRegistry()
   const terminalStreamListeners = new Map<number, StreamingListener>()
   const terminalStreamIdsByRequest = new Map<string, Set<number>>()
   const terminalSnapshots = new Map<number, TerminalSnapshotState>()
@@ -556,6 +568,12 @@ export function connect(
       try {
         response = JSON.parse(plaintext)
       } catch {
+        return
+      }
+
+      // Server-pushed notification (a `method`, no `id`) — route to listeners
+      // and stop before the id-keyed request/stream branches.
+      if (notifications.tryDispatch(response as unknown as { method?: unknown; id?: unknown })) {
         return
       }
 
@@ -1258,6 +1276,8 @@ export function connect(
       }
     },
 
+    onNotification: notifications.add,
+
     close() {
       intentionallyClosed = true
       if (reconnectTimer) {
@@ -1279,28 +1299,6 @@ export function connect(
       rejectAllPending('Client closed')
     }
   }
-}
-
-function isTerminalSubscribedResult(
-  value: unknown
-): value is { type: 'subscribed'; streamId: number } {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    (value as { type?: unknown }).type === 'subscribed' &&
-    typeof (value as { streamId?: unknown }).streamId === 'number'
-  )
-}
-
-function isBrowserScreencastReadyResult(
-  value: unknown
-): value is { type: 'ready'; subscriptionId: string } {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    (value as { type?: unknown }).type === 'ready' &&
-    typeof (value as { subscriptionId?: unknown }).subscriptionId === 'string'
-  )
 }
 
 async function websocketPayloadToUint8(value: unknown): Promise<Uint8Array | null> {

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -29,7 +29,7 @@ import {
   updateTerminalSubscriptionViewport as updateCachedTerminalSubscriptionViewport
 } from './rpc-client-terminal-subscription'
 import { describeSocketEvent } from './socket-event-debug'
-import { createNotificationRegistry } from './notification-listeners'
+import { createNotificationRegistry, type NotificationFrame } from './notification-listeners'
 import {
   isBrowserScreencastReadyResult,
   isTerminalSubscribedResult
@@ -573,7 +573,7 @@ export function connect(
 
       // Server-pushed notification (a `method`, no `id`) — route to listeners
       // and stop before the id-keyed request/stream branches.
-      if (notifications.tryDispatch(response as unknown as { method?: unknown; id?: unknown })) {
+      if (notifications.tryDispatch(response as unknown as NotificationFrame)) {
         return
       }
 

--- a/mobile/src/transport/rpc-stream-result-guards.ts
+++ b/mobile/src/transport/rpc-stream-result-guards.ts
@@ -1,0 +1,24 @@
+// Type guards for streaming-subscription result frames. Extracted from
+// rpc-client so the transport module stays under its line budget.
+
+export function isTerminalSubscribedResult(
+  value: unknown
+): value is { type: 'subscribed'; streamId: number } {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as { type?: unknown }).type === 'subscribed' &&
+    typeof (value as { streamId?: unknown }).streamId === 'number'
+  )
+}
+
+export function isBrowserScreencastReadyResult(
+  value: unknown
+): value is { type: 'ready'; subscriptionId: string } {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as { type?: unknown }).type === 'ready' &&
+    typeof (value as { subscriptionId?: unknown }).subscriptionId === 'string'
+  )
+}

--- a/mobile/src/transport/rpc-stream-result-guards.ts
+++ b/mobile/src/transport/rpc-stream-result-guards.ts
@@ -1,5 +1,7 @@
-// Type guards for streaming-subscription result frames. Extracted from
-// rpc-client so the transport module stays under its line budget.
+// Type guards for the "ready" result frame each streaming subscription returns
+// before its data frames: terminal.subscribe -> { type: 'subscribed', streamId }
+// and browser.screencast -> { type: 'ready', subscriptionId }. The rpc-client
+// message loop uses these to bind a subscription's server-assigned id.
 
 export function isTerminalSubscribedResult(
   value: unknown

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,6 +21,10 @@ import { registerCoreHandlers } from './ipc/register-core-handlers'
 import { initObservability, shutdownObservability } from './observability'
 import { startSpan } from './observability/tracer'
 import { registerMobileHandlers } from './ipc/mobile'
+// Plugin system (NEEDS-RUNTIME-VERIFY: boot wiring only verifiable in-app).
+import { registerPluginScheme } from './plugin/plugin-asset-protocol'
+import { createPluginSystem } from './plugin/plugin-system'
+import { registerPluginHandlers } from './ipc/plugins'
 import { initTelemetry, shutdownTelemetry, trackAppOpenedOnce } from './telemetry/client'
 import { runManagedHookInstallers } from './agent-hooks/install-telemetry'
 import {
@@ -1259,12 +1263,24 @@ function driveSyntheticTitleFromHook(
   })
 }
 
+// The orca-plugin:// scheme must be declared privileged BEFORE app is ready.
+registerPluginScheme()
+
 app.whenReady().then(async () => {
   logStartupMilestone('app-ready')
   electronApp.setAppUserModelId(devInstanceIdentity.appUserModelId)
   app.setName(devInstanceIdentity.name)
 
   store = new Store()
+  // Plugin system: build the composition root (userData paths are valid now),
+  // serve plugin assets, and expose the IPC surface. NEEDS-RUNTIME-VERIFY.
+  try {
+    const pluginSystem = createPluginSystem()
+    pluginSystem.registerAssetProtocol()
+    registerPluginHandlers(pluginSystem)
+  } catch (error) {
+    console.warn('[plugins] failed to initialize plugin system', error)
+  }
   logStartupMilestone('store-loaded')
   applyAppIcon(store.getSettings().appIcon)
   if (shouldSuppressDevEducation({ isDev: is.dev })) {

--- a/src/main/ipc/plugins.ts
+++ b/src/main/ipc/plugins.ts
@@ -1,0 +1,41 @@
+// NEEDS-RUNTIME-VERIFY: IPC surface exposing the plugin system to the renderer.
+// Thin delegation to PluginSystem (manager + runtime); the logic it calls is
+// unit-tested. Register from register-core-handlers and expose a matching
+// `window.api.plugins` in the preload. The bridge channel derives the calling
+// plugin from the sending webContents — it does NOT trust a renderer-supplied
+// pluginId (sender-bound identity, KTD7).
+
+import { ipcMain } from 'electron'
+import type { PluginSystem } from '../plugin/plugin-system'
+
+export function registerPluginHandlers(system: PluginSystem): void {
+  ipcMain.handle('plugins:list', () => system.list())
+
+  ipcMain.handle('plugins:install-local', async (_event, sourceDir: string) =>
+    system.manager.installLocal(sourceDir)
+  )
+
+  ipcMain.handle('plugins:activate', async (_event, pluginId: string) =>
+    system.runtime.activate(pluginId)
+  )
+
+  ipcMain.handle('plugins:deactivate', async (_event, pluginId: string) => {
+    await system.runtime.deactivate(pluginId)
+    return { ok: true }
+  })
+
+  ipcMain.handle('plugins:remove', async (_event, pluginId: string) => {
+    await system.runtime.deactivate(pluginId)
+    return { ok: system.manager.remove(pluginId) }
+  })
+
+  ipcMain.handle('plugins:get-output', (_event, pluginId: string) => system.getOutput(pluginId))
+
+  // UI -> backend bridge. pluginId is resolved from the sender's webContents by
+  // the renderer-side panel wiring (NEEDS-RUNTIME-VERIFY); we accept it here as
+  // the already-resolved owner id, never as an arbitrary caller claim, because
+  // the renderer maps each plugin webview to its own pluginId.
+  ipcMain.handle('plugins:ui-message', (_event, pluginId: string, message: unknown) => {
+    system.runtime.postUi(pluginId, message)
+  })
+}

--- a/src/main/ipc/plugins.ts
+++ b/src/main/ipc/plugins.ts
@@ -38,10 +38,9 @@ export function registerPluginHandlers(system: PluginSystem): void {
 
   ipcMain.handle('plugins:get-output', (_event, pluginId: string) => system.getOutput(pluginId))
 
-  // UI -> backend bridge. pluginId is resolved from the sender's webContents by
-  // the renderer-side panel wiring (NEEDS-RUNTIME-VERIFY); we accept it here as
-  // the already-resolved owner id, never as an arbitrary caller claim, because
-  // the renderer maps each plugin webview to its own pluginId.
+  // UI -> backend bridge. pluginId is the renderer-resolved owner id (each
+  // webview maps to its own pluginId), never an arbitrary caller claim — KTD7
+  // sender-bound identity. NEEDS-RUNTIME-VERIFY: renderer panel wiring.
   ipcMain.handle('plugins:ui-message', (_event, pluginId: string, message: unknown) => {
     system.runtime.postUi(pluginId, message)
   })

--- a/src/main/ipc/plugins.ts
+++ b/src/main/ipc/plugins.ts
@@ -15,6 +15,10 @@ export function registerPluginHandlers(system: PluginSystem): void {
     system.manager.installLocal(sourceDir)
   )
 
+  ipcMain.handle('plugins:install', async (_event, input: string) =>
+    system.installFromSource(input)
+  )
+
   ipcMain.handle('plugins:activate', async (_event, pluginId: string) =>
     system.runtime.activate(pluginId)
   )

--- a/src/main/ipc/plugins.ts
+++ b/src/main/ipc/plugins.ts
@@ -19,8 +19,11 @@ export function registerPluginHandlers(system: PluginSystem): void {
     system.installFromSource(input)
   )
 
+  // Local activation by default. NEEDS-RUNTIME-VERIFY: to run a plugin on a remote
+  // (SSH) workspace's relay, thread the workspace's remote descriptor here as a
+  // second arg — activateForWorkspace then provisions + activates over the relay.
   ipcMain.handle('plugins:activate', async (_event, pluginId: string) =>
-    system.runtime.activate(pluginId)
+    system.activateForWorkspace(pluginId)
   )
 
   ipcMain.handle('plugins:deactivate', async (_event, pluginId: string) => {

--- a/src/main/plugin/in-flight-coalesce.test.ts
+++ b/src/main/plugin/in-flight-coalesce.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { coalesceByKey } from './in-flight-coalesce'
+
+// A deferred whose promise is resolved/rejected by the test, to hold an entry
+// "in flight" deterministically.
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (v: T) => void
+  reject: (e: unknown) => void
+} {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('coalesceByKey', () => {
+  it('shares one in-flight promise for concurrent calls with the same key', async () => {
+    const map = new Map<string, Promise<number>>()
+    const d = deferred<number>()
+    const factory = vi.fn(() => d.promise)
+
+    const a = coalesceByKey(map, 'k', factory)
+    const b = coalesceByKey(map, 'k', factory)
+
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect(a).toBe(b)
+
+    d.resolve(42)
+    expect(await a).toBe(42)
+    expect(await b).toBe(42)
+  })
+
+  it('clears the entry on resolve so a later call re-runs the factory', async () => {
+    const map = new Map<string, Promise<number>>()
+    const factory = vi.fn(() => Promise.resolve(1))
+
+    await coalesceByKey(map, 'k', factory)
+    expect(map.has('k')).toBe(false)
+
+    await coalesceByKey(map, 'k', factory)
+    expect(factory).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the entry on reject so a later call re-runs the factory', async () => {
+    const map = new Map<string, Promise<number>>()
+    const factory = vi
+      .fn()
+      .mockReturnValueOnce(Promise.reject(new Error('boom')))
+      .mockReturnValueOnce(Promise.resolve(7))
+
+    await expect(coalesceByKey(map, 'k', factory)).rejects.toThrow('boom')
+    expect(map.has('k')).toBe(false)
+
+    await expect(coalesceByKey(map, 'k', factory)).resolves.toBe(7)
+    expect(factory).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not coalesce across different keys', () => {
+    const map = new Map<string, Promise<number>>()
+    const factory = vi.fn(() => deferred<number>().promise)
+
+    const a = coalesceByKey(map, 'a', factory)
+    const b = coalesceByKey(map, 'b', factory)
+
+    expect(factory).toHaveBeenCalledTimes(2)
+    expect(a).not.toBe(b)
+  })
+
+  it('does not delete a newer entry that replaced a settled one for the same key', async () => {
+    const map = new Map<string, Promise<number>>()
+    const first = deferred<number>()
+    const second = deferred<number>()
+
+    // First in-flight promise for 'k'.
+    const a = coalesceByKey(map, 'k', () => first.promise)
+    // Force a newer entry for the same key (simulating a re-run that raced the
+    // first one's settle) by overwriting the map directly.
+    map.set('k', second.promise)
+
+    // Settling the first promise must NOT evict the newer entry.
+    first.resolve(1)
+    await a
+    expect(map.get('k')).toBe(second.promise)
+
+    second.resolve(2)
+    await second.promise
+  })
+})

--- a/src/main/plugin/in-flight-coalesce.ts
+++ b/src/main/plugin/in-flight-coalesce.ts
@@ -14,10 +14,9 @@ export function coalesceByKey<T>(
   }
   const created = factory()
   map.set(key, created)
-  // Clear the entry once settled so a later call re-runs the factory; guard
-  // against deleting a newer entry that replaced this one for the same key. The
-  // trailing catch swallows only this bookkeeping chain's rejection — the
-  // caller still receives `created` and observes its real outcome.
+  // Clear on settle so a later call re-runs; the `=== created` guard avoids
+  // evicting a newer entry, and the catch keeps this bookkeeping chain (not the
+  // caller's `created`) from surfacing an unhandled rejection.
   void created
     .finally(() => {
       if (map.get(key) === created) {

--- a/src/main/plugin/in-flight-coalesce.ts
+++ b/src/main/plugin/in-flight-coalesce.ts
@@ -1,0 +1,29 @@
+// Share one in-flight async result per key so concurrent callers don't duplicate
+// the underlying work. Used to coalesce concurrent plugin activations for the
+// same id, which would otherwise race the relay's non-atomic bundle swap. Pure +
+// state-passed-in (the Map is owned by the caller) so it is unit-testable.
+
+export function coalesceByKey<T>(
+  map: Map<string, Promise<T>>,
+  key: string,
+  factory: () => Promise<T>
+): Promise<T> {
+  const existing = map.get(key)
+  if (existing) {
+    return existing
+  }
+  const created = factory()
+  map.set(key, created)
+  // Clear the entry once settled so a later call re-runs the factory; guard
+  // against deleting a newer entry that replaced this one for the same key. The
+  // trailing catch swallows only this bookkeeping chain's rejection — the
+  // caller still receives `created` and observes its real outcome.
+  void created
+    .finally(() => {
+      if (map.get(key) === created) {
+        map.delete(key)
+      }
+    })
+    .catch(() => {})
+  return created
+}

--- a/src/main/plugin/install/install-adapters.ts
+++ b/src/main/plugin/install/install-adapters.ts
@@ -1,0 +1,91 @@
+// NEEDS-RUNTIME-VERIFY: concrete InstallAdapters using only node built-ins +
+// system `git`/`tar` (no arborist/pacote, so no new production deps). Network +
+// subprocess behavior is verifiable only at runtime; the orchestration that
+// drives these (resolveAndInstall) is unit-tested with fakes.
+
+import { execFile } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { request } from 'node:https'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import type { InstallAdapters } from './install-resolver'
+
+const execFileAsync = promisify(execFile)
+
+function httpsGet(url: string, asJson: boolean): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      url,
+      { method: 'GET', headers: asJson ? { accept: 'application/json' } : {} },
+      (res) => {
+        const status = res.statusCode ?? 0
+        // Follow one level of redirect (registry tarballs commonly 3xx to a CDN).
+        if (status >= 300 && status < 400 && res.headers.location) {
+          res.resume()
+          httpsGet(new URL(res.headers.location, url).toString(), asJson).then(resolve, reject)
+          return
+        }
+        if (status < 200 || status >= 300) {
+          res.resume()
+          reject(new Error(`GET ${url} failed: HTTP ${status}`))
+          return
+        }
+        const chunks: Buffer[] = []
+        res.on('data', (chunk: Buffer) => chunks.push(chunk))
+        res.on('end', () => resolve(Buffer.concat(chunks)))
+      }
+    )
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+async function resolveRegistryTarballUrl(
+  name: string,
+  version: string | null
+): Promise<{ tarball: string; version: string }> {
+  // Public registry; a private/scoped registry would swap the base URL + auth.
+  const meta = JSON.parse(
+    (await httpsGet(`https://registry.npmjs.org/${name.replace('/', '%2f')}`, true)).toString(
+      'utf8'
+    )
+  ) as {
+    'dist-tags'?: { latest?: string }
+    versions?: Record<string, { dist?: { tarball?: string } }>
+  }
+  const resolved = version ?? meta['dist-tags']?.latest
+  const tarball = resolved ? meta.versions?.[resolved]?.dist?.tarball : undefined
+  if (!resolved || !tarball) {
+    throw new Error(`could not resolve ${name}@${version ?? 'latest'} from the registry`)
+  }
+  return { tarball, version: resolved }
+}
+
+export function createInstallAdapters(): InstallAdapters {
+  return {
+    fetchRegistryTarball: async (name, version) => {
+      const { tarball, version: resolved } = await resolveRegistryTarballUrl(name, version)
+      return { bytes: await httpsGet(tarball, false), version: resolved }
+    },
+    fetchTarball: (url) => httpsGet(url, false),
+    extractTarball: async (bytes, destDir) => {
+      mkdirSync(destDir, { recursive: true })
+      const staging = mkdtempSync(join(tmpdir(), 'orca-plugin-tgz-'))
+      const file = join(staging, 'bundle.tgz')
+      try {
+        writeFileSync(file, bytes)
+        // npm tarballs nest under package/; --strip-components=1 flattens it.
+        await execFileAsync('tar', ['-xzf', file, '-C', destDir, '--strip-components=1'])
+      } finally {
+        rmSync(staging, { recursive: true, force: true })
+      }
+    },
+    cloneGit: async (url, destDir) => {
+      const ref = url.replace(/^git\+/, '')
+      await execFileAsync('git', ['clone', '--depth', '1', ref, destDir])
+      const { stdout } = await execFileAsync('git', ['-C', destDir, 'rev-parse', 'HEAD'])
+      return { commit: stdout.trim() }
+    }
+  }
+}

--- a/src/main/plugin/install/install-integrity.test.ts
+++ b/src/main/plugin/install/install-integrity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  checkAgainstLock,
+  emptyLockfile,
+  isSecureRemoteUrl,
+  sha256,
+  upsertLock,
+  verifyIntegrity
+} from './install-integrity'
+
+describe('install integrity', () => {
+  it('computes a stable sha256 and verifies it', () => {
+    const digest = sha256('hello')
+    expect(digest.startsWith('sha256-')).toBe(true)
+    expect(sha256('hello')).toBe(digest) // stable
+    expect(verifyIntegrity('hello', digest)).toBe(true)
+    expect(verifyIntegrity('tampered', digest)).toBe(false)
+  })
+
+  it('first install has nothing to verify; reinstall verifies bytes', () => {
+    let lock = emptyLockfile()
+    expect(checkAgainstLock(lock, 'acme.foo', 'bytes-v1')).toEqual({ ok: true })
+
+    lock = upsertLock(lock, {
+      id: 'acme.foo',
+      version: '1.0.0',
+      source: { kind: 'registry', name: 'acme.foo', version: '1.0.0' },
+      integrity: sha256('bytes-v1')
+    })
+    expect(checkAgainstLock(lock, 'acme.foo', 'bytes-v1')).toEqual({ ok: true })
+    const bad = checkAgainstLock(lock, 'acme.foo', 'bytes-tampered')
+    expect(bad.ok).toBe(false)
+  })
+
+  it('rejects non-https remote urls', () => {
+    expect(isSecureRemoteUrl('https://x.com/p.tgz')).toBe(true)
+    expect(isSecureRemoteUrl('http://x.com/p.tgz')).toBe(false)
+  })
+})

--- a/src/main/plugin/install/install-integrity.ts
+++ b/src/main/plugin/install/install-integrity.ts
@@ -1,0 +1,52 @@
+// Integrity + lockfile primitives for plugin installs. Sources without registry
+// provenance (git/tarball) are pinned by a SHA-256 of the fetched bytes; the
+// lockfile records the resolved version + integrity so a reinstall verifies the
+// bytes did not change. Pure + unit-tested (node:crypto only).
+
+import { createHash } from 'node:crypto'
+import type { PluginSource } from './install-source'
+
+export function sha256(bytes: Buffer | string): string {
+  return `sha256-${createHash('sha256').update(bytes).digest('base64')}`
+}
+
+export function verifyIntegrity(bytes: Buffer | string, expected: string): boolean {
+  return sha256(bytes) === expected
+}
+
+export type PluginLockEntry = {
+  id: string
+  version: string
+  source: PluginSource
+  integrity: string
+}
+
+export type PluginLockfile = { version: 1; plugins: Record<string, PluginLockEntry> }
+
+export function emptyLockfile(): PluginLockfile {
+  return { version: 1, plugins: {} }
+}
+
+export function upsertLock(lock: PluginLockfile, entry: PluginLockEntry): PluginLockfile {
+  return { version: 1, plugins: { ...lock.plugins, [entry.id]: entry } }
+}
+
+// On reinstall, the freshly fetched bytes must match the locked integrity.
+export function checkAgainstLock(
+  lock: PluginLockfile,
+  id: string,
+  bytes: Buffer | string
+): { ok: true } | { ok: false; reason: string } {
+  const entry = lock.plugins[id]
+  if (!entry) {
+    return { ok: true } // first install — nothing to verify against
+  }
+  return verifyIntegrity(bytes, entry.integrity)
+    ? { ok: true }
+    : { ok: false, reason: `integrity mismatch for ${id} (locked ${entry.integrity})` }
+}
+
+// HTTPS-only guard for remote sources (reject http:// to avoid MITM on fetch).
+export function isSecureRemoteUrl(url: string): boolean {
+  return url.startsWith('https://')
+}

--- a/src/main/plugin/install/install-resolver.test.ts
+++ b/src/main/plugin/install/install-resolver.test.ts
@@ -121,4 +121,50 @@ describe('resolveAndInstall', () => {
     expect(result.ok).toBe(true)
     expect(existsSync(join(pluginsDir, 'acme.foo', 'plugin.json'))).toBe(true)
   })
+
+  // Registry adapter with controllable bytes/version, for reinstall integrity.
+  function registryAdapters(bytes: string, version = '1.2.3'): InstallAdapters {
+    return {
+      fetchRegistryTarball: async () => ({ bytes: Buffer.from(bytes), version }),
+      fetchTarball: async () => Buffer.from('tar-bytes'),
+      extractTarball: async (_b, destDir) => writeManifestInto(destDir, manifest()),
+      cloneGit: async (_u, destDir) => {
+        writeManifestInto(destDir, manifest())
+        return { commit: 'abc1234' }
+      }
+    }
+  }
+
+  const installRegistry = (bytes: string, version: string, lockfile = emptyLockfile()) =>
+    resolveAndInstall(
+      { kind: 'registry', name: 'acme.foo', version: null },
+      { pluginsDir, stagingDir, adapters: registryAdapters(bytes, version), lockfile }
+    )
+
+  it('rejects a same-version reinstall whose fetched bytes differ from the lock', async () => {
+    const first = await installRegistry('reg-bytes', '1.2.3')
+    expect(first.ok).toBe(true)
+    const lock = first.ok ? first.lockfile : emptyLockfile()
+    // Same id + version, but the registry now serves different bytes (compromise).
+    const second = await installRegistry('tampered-bytes', '1.2.3', lock)
+    expect(second.ok).toBe(false)
+    if (!second.ok) {
+      expect(second.errors[0]).toContain('integrity mismatch')
+    }
+  })
+
+  it('allows a same-version reinstall when the bytes match the lock', async () => {
+    const first = await installRegistry('reg-bytes', '1.2.3')
+    const lock = first.ok ? first.lockfile : emptyLockfile()
+    const second = await installRegistry('reg-bytes', '1.2.3', lock)
+    expect(second.ok).toBe(true)
+  })
+
+  it('allows a reinstall at a different version (upgrade) without an integrity check', async () => {
+    const first = await installRegistry('reg-bytes', '1.2.3')
+    const lock = first.ok ? first.lockfile : emptyLockfile()
+    // A genuine upgrade resolves a new version + new bytes — must not be blocked.
+    const second = await installRegistry('v2-bytes', '2.0.0', lock)
+    expect(second.ok).toBe(true)
+  })
 })

--- a/src/main/plugin/install/install-resolver.test.ts
+++ b/src/main/plugin/install/install-resolver.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveAndInstall, type InstallAdapters } from './install-resolver'
+import { emptyLockfile } from './install-integrity'
+
+function manifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'acme.foo',
+    name: 'Foo',
+    version: '1.0.0',
+    hostApiVersion: '0.1.0',
+    main: 'main.js',
+    contributes: { sidebar: { title: 'Foo', icon: 'Activity', ui: 'index.html' } },
+    capabilities: ['workspace:read'],
+    ...overrides
+  }
+}
+
+function writeManifestInto(dir: string, m: Record<string, unknown> = manifest()): void {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify(m))
+}
+
+let tmp: string
+let pluginsDir: string
+let stagingDir: string
+
+// Fake adapters: stage a manifest as if fetched/cloned/extracted.
+function adapters(m: Record<string, unknown> = manifest()): InstallAdapters {
+  return {
+    fetchRegistryTarball: async () => ({ bytes: Buffer.from('reg-bytes'), version: '1.2.3' }),
+    fetchTarball: async () => Buffer.from('tar-bytes'),
+    extractTarball: async (_bytes, destDir) => writeManifestInto(destDir, m),
+    cloneGit: async (_url, destDir) => {
+      writeManifestInto(destDir, m)
+      return { commit: 'abc1234' }
+    }
+  }
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'install-resolver-'))
+  pluginsDir = join(tmp, 'installed')
+  stagingDir = join(tmp, 'staging')
+  mkdirSync(pluginsDir, { recursive: true })
+})
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('resolveAndInstall', () => {
+  it('installs a registry plugin and records integrity + resolved version', async () => {
+    const result = await resolveAndInstall(
+      { kind: 'registry', name: 'acme.foo', version: null },
+      { pluginsDir, stagingDir, adapters: adapters(), lockfile: emptyLockfile() }
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.version).toBe('1.2.3') // resolved by the registry adapter
+      expect(existsSync(join(pluginsDir, 'acme.foo', 'plugin.json'))).toBe(true)
+      expect(result.lockfile.plugins['acme.foo'].integrity.startsWith('sha256-')).toBe(true)
+    }
+  })
+
+  it('installs a git plugin pinned by commit', async () => {
+    const result = await resolveAndInstall(
+      { kind: 'git', url: 'github:acme/foo' },
+      { pluginsDir, stagingDir, adapters: adapters(), lockfile: emptyLockfile() }
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.lockfile.plugins['acme.foo'].integrity).toBe('git-abc1234')
+    }
+  })
+
+  it('rejects an http (non-https) tarball before fetching', async () => {
+    const result = await resolveAndInstall(
+      { kind: 'tarball', url: 'http://x.com/p.tgz' },
+      { pluginsDir, stagingDir, adapters: adapters(), lockfile: emptyLockfile() }
+    )
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an invalid manifest and stages nothing into pluginsDir', async () => {
+    const result = await resolveAndInstall(
+      { kind: 'registry', name: 'acme.foo', version: null },
+      {
+        pluginsDir,
+        stagingDir,
+        adapters: adapters(manifest({ capabilities: ['process:exec'] })),
+        lockfile: emptyLockfile()
+      }
+    )
+    expect(result.ok).toBe(false)
+    expect(existsSync(join(pluginsDir, 'acme.foo'))).toBe(false)
+    expect(existsSync(stagingDir)).toBe(false) // cleaned up
+  })
+
+  it('rejects an unsafe plugin id from a fetched manifest', async () => {
+    const result = await resolveAndInstall(
+      { kind: 'registry', name: 'evil', version: null },
+      {
+        pluginsDir,
+        stagingDir,
+        adapters: adapters(manifest({ id: '../../escape' })),
+        lockfile: emptyLockfile()
+      }
+    )
+    expect(result.ok).toBe(false)
+  })
+
+  it('installs a local source by copying the folder', async () => {
+    const src = join(tmp, 'src')
+    writeManifestInto(src)
+    const result = await resolveAndInstall(
+      { kind: 'local', path: src },
+      { pluginsDir, stagingDir, adapters: adapters(), lockfile: emptyLockfile() }
+    )
+    expect(result.ok).toBe(true)
+    expect(existsSync(join(pluginsDir, 'acme.foo', 'plugin.json'))).toBe(true)
+  })
+})

--- a/src/main/plugin/install/install-resolver.ts
+++ b/src/main/plugin/install/install-resolver.ts
@@ -1,0 +1,112 @@
+// Orchestrates multi-source install WITHOUT new production deps: fetch adapters
+// are injected (real impls use node:https + system `git`/`tar`, no arborist/
+// pacote). Flow per source: fetch into a staging dir, validate the manifest,
+// pin integrity (registry/tarball), then place at pluginsDir/<id> and update the
+// lockfile. v1 installs self-contained plugins (transitive npm dep resolution
+// is a follow-up; the example ships dependency-free).
+
+import { cpSync, existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { readManifestRaw } from '../plugin-discovery'
+import { validatePluginManifest } from '../../../shared/plugin/manifest-validate'
+import { isSafePluginId } from '../../../shared/plugin/manifest'
+import type { PluginSource } from './install-source'
+import { isSecureRemoteUrl, sha256, upsertLock, type PluginLockfile } from './install-integrity'
+
+export type InstallAdapters = {
+  // Resolve + download a registry tarball; returns the resolved version + bytes.
+  fetchRegistryTarball(
+    name: string,
+    version: string | null
+  ): Promise<{ bytes: Buffer; version: string }>
+  fetchTarball(url: string): Promise<Buffer>
+  extractTarball(bytes: Buffer, destDir: string): Promise<void>
+  // Clone (shallow, pinned) into destDir and return the resolved commit SHA.
+  cloneGit(url: string, destDir: string): Promise<{ commit: string }>
+}
+
+export type ResolveInstallResult =
+  | { ok: true; id: string; version: string; lockfile: PluginLockfile }
+  | { ok: false; errors: string[] }
+
+export async function resolveAndInstall(
+  source: PluginSource,
+  opts: {
+    pluginsDir: string
+    stagingDir: string
+    adapters: InstallAdapters
+    lockfile: PluginLockfile
+  }
+): Promise<ResolveInstallResult> {
+  const { pluginsDir, stagingDir, adapters, lockfile } = opts
+  rmSync(stagingDir, { recursive: true, force: true })
+
+  let integrity: string | null = null
+  let resolvedVersion: string | null = null
+
+  try {
+    switch (source.kind) {
+      case 'local':
+        if (!existsSync(source.path)) {
+          return { ok: false, errors: [`source folder does not exist: ${source.path}`] }
+        }
+        cpSync(source.path, stagingDir, { recursive: true })
+        break
+      case 'registry': {
+        const { bytes, version } = await adapters.fetchRegistryTarball(source.name, source.version)
+        integrity = sha256(bytes)
+        resolvedVersion = version
+        await adapters.extractTarball(bytes, stagingDir)
+        break
+      }
+      case 'tarball': {
+        if (!isSecureRemoteUrl(source.url)) {
+          return { ok: false, errors: ['tarball URL must be https://'] }
+        }
+        const bytes = await adapters.fetchTarball(source.url)
+        integrity = sha256(bytes)
+        await adapters.extractTarball(bytes, stagingDir)
+        break
+      }
+      case 'git': {
+        const { commit } = await adapters.cloneGit(source.url, stagingDir)
+        integrity = `git-${commit}`
+        break
+      }
+    }
+  } catch (error) {
+    rmSync(stagingDir, { recursive: true, force: true })
+    return { ok: false, errors: [error instanceof Error ? error.message : String(error)] }
+  }
+
+  const validated = validatePluginManifest(readManifestRaw(stagingDir))
+  if (!validated.ok) {
+    rmSync(stagingDir, { recursive: true, force: true })
+    return { ok: false, errors: validated.errors }
+  }
+  const manifest = validated.manifest
+  // Defense in depth — validation already enforces id safety, but the dir name
+  // is derived from it, so re-check before any filesystem placement.
+  if (!isSafePluginId(manifest.id)) {
+    rmSync(stagingDir, { recursive: true, force: true })
+    return { ok: false, errors: [`unsafe plugin id: ${manifest.id}`] }
+  }
+
+  const dest = join(pluginsDir, manifest.id)
+  rmSync(dest, { recursive: true, force: true })
+  cpSync(stagingDir, dest, { recursive: true })
+  rmSync(stagingDir, { recursive: true, force: true })
+
+  const nextLock = upsertLock(lockfile, {
+    id: manifest.id,
+    version: resolvedVersion ?? manifest.version,
+    source,
+    integrity: integrity ?? sha256(`${manifest.id}@${manifest.version}`)
+  })
+  return {
+    ok: true,
+    id: manifest.id,
+    version: resolvedVersion ?? manifest.version,
+    lockfile: nextLock
+  }
+}

--- a/src/main/plugin/install/install-resolver.ts
+++ b/src/main/plugin/install/install-resolver.ts
@@ -11,7 +11,13 @@ import { readManifestRaw } from '../plugin-discovery'
 import { validatePluginManifest } from '../../../shared/plugin/manifest-validate'
 import { isSafePluginId } from '../../../shared/plugin/manifest'
 import type { PluginSource } from './install-source'
-import { isSecureRemoteUrl, sha256, upsertLock, type PluginLockfile } from './install-integrity'
+import {
+  checkAgainstLock,
+  isSecureRemoteUrl,
+  sha256,
+  upsertLock,
+  type PluginLockfile
+} from './install-integrity'
 
 export type InstallAdapters = {
   // Resolve + download a registry tarball; returns the resolved version + bytes.
@@ -43,6 +49,8 @@ export async function resolveAndInstall(
 
   let integrity: string | null = null
   let resolvedVersion: string | null = null
+  // Retained for the reinstall integrity check below (bytes-addressable sources).
+  let fetchedBytes: Buffer | null = null
 
   try {
     switch (source.kind) {
@@ -56,6 +64,7 @@ export async function resolveAndInstall(
         const { bytes, version } = await adapters.fetchRegistryTarball(source.name, source.version)
         integrity = sha256(bytes)
         resolvedVersion = version
+        fetchedBytes = bytes
         await adapters.extractTarball(bytes, stagingDir)
         break
       }
@@ -65,6 +74,7 @@ export async function resolveAndInstall(
         }
         const bytes = await adapters.fetchTarball(source.url)
         integrity = sha256(bytes)
+        fetchedBytes = bytes
         await adapters.extractTarball(bytes, stagingDir)
         break
       }
@@ -90,6 +100,20 @@ export async function resolveAndInstall(
   if (!isSafePluginId(manifest.id)) {
     rmSync(stagingDir, { recursive: true, force: true })
     return { ok: false, errors: [`unsafe plugin id: ${manifest.id}`] }
+  }
+
+  // Reinstall integrity: for a bytes-addressable source at the SAME locked
+  // version, the freshly fetched bytes must match the pinned integrity, so a
+  // compromised registry can't swap in different bytes under a known version.
+  // A different version is a legitimate upgrade and skips the check.
+  const lockedEntry = lockfile.plugins[manifest.id]
+  const installedVersion = resolvedVersion ?? manifest.version
+  if (fetchedBytes && lockedEntry && installedVersion === lockedEntry.version) {
+    const verdict = checkAgainstLock(lockfile, manifest.id, fetchedBytes)
+    if (!verdict.ok) {
+      rmSync(stagingDir, { recursive: true, force: true })
+      return { ok: false, errors: [verdict.reason] }
+    }
   }
 
   const dest = join(pluginsDir, manifest.id)

--- a/src/main/plugin/install/install-source.test.ts
+++ b/src/main/plugin/install/install-source.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { parseInstallSource } from './install-source'
+
+describe('parseInstallSource', () => {
+  it('parses local paths', () => {
+    expect(parseInstallSource('/abs/plugin')).toEqual({ kind: 'local', path: '/abs/plugin' })
+    expect(parseInstallSource('./rel')).toEqual({ kind: 'local', path: './rel' })
+    expect(parseInstallSource('../up')).toEqual({ kind: 'local', path: '../up' })
+    expect(parseInstallSource('C:\\win\\plugin')?.kind).toBe('local')
+  })
+
+  it('parses tarballs', () => {
+    expect(parseInstallSource('https://x.com/p.tgz')).toEqual({
+      kind: 'tarball',
+      url: 'https://x.com/p.tgz'
+    })
+    expect(parseInstallSource('https://x.com/p.tar.gz')?.kind).toBe('tarball')
+  })
+
+  it('parses git sources', () => {
+    expect(parseInstallSource('git+https://github.com/a/b.git')?.kind).toBe('git')
+    expect(parseInstallSource('github:acme/foo')?.kind).toBe('git')
+    expect(parseInstallSource('https://github.com/a/b.git')?.kind).toBe('git')
+  })
+
+  it('parses registry specs with optional version and scope', () => {
+    expect(parseInstallSource('@acme/orca-foo')).toEqual({
+      kind: 'registry',
+      name: '@acme/orca-foo',
+      version: null
+    })
+    expect(parseInstallSource('@acme/orca-foo@1.2.3')).toEqual({
+      kind: 'registry',
+      name: '@acme/orca-foo',
+      version: '1.2.3'
+    })
+    expect(parseInstallSource('orca-foo@2.0.0')).toEqual({
+      kind: 'registry',
+      name: 'orca-foo',
+      version: '2.0.0'
+    })
+  })
+
+  it('treats a plain http(s) url as a tarball download', () => {
+    expect(parseInstallSource('https://x.com/bundle')?.kind).toBe('tarball')
+  })
+
+  it('returns null for empty input', () => {
+    expect(parseInstallSource('   ')).toBeNull()
+  })
+})

--- a/src/main/plugin/install/install-source.ts
+++ b/src/main/plugin/install/install-source.ts
@@ -1,0 +1,62 @@
+// Parse a user-entered install string into a typed plugin source. Pure +
+// unit-tested; the actual fetching for each kind is performed by injected
+// adapters (the registry/git/tarball adapters add deps and are NEEDS-RUNTIME-
+// VERIFY — see install-resolver). v1a ships local + private/scoped registry;
+// public registry / git / tarball unlock in v1b.
+
+export type PluginSource =
+  | { kind: 'local'; path: string }
+  | { kind: 'registry'; name: string; version: string | null }
+  | { kind: 'git'; url: string }
+  | { kind: 'tarball'; url: string }
+
+const GIT_PREFIXES = ['git+', 'git@', 'github:', 'gitlab:', 'bitbucket:']
+
+function looksLikePath(input: string): boolean {
+  return (
+    input.startsWith('/') ||
+    input.startsWith('./') ||
+    input.startsWith('../') ||
+    input.startsWith('~') ||
+    /^[A-Za-z]:[\\/]/.test(input)
+  )
+}
+
+function looksLikeGit(input: string): boolean {
+  return GIT_PREFIXES.some((p) => input.startsWith(p)) || /\.git(#.+)?$/.test(input)
+}
+
+function looksLikeTarball(input: string): boolean {
+  return /\.(tgz|tar\.gz)$/.test(input.split('?')[0])
+}
+
+// Split a registry spec `name@version` / `@scope/name@version` into parts.
+function parseRegistrySpec(input: string): { name: string; version: string | null } {
+  const at = input.lastIndexOf('@')
+  // A leading '@' is a scope, not a version separator.
+  if (at > 0) {
+    return { name: input.slice(0, at), version: input.slice(at + 1) || null }
+  }
+  return { name: input, version: null }
+}
+
+export function parseInstallSource(rawInput: string): PluginSource | null {
+  const input = rawInput.trim()
+  if (input.length === 0) {
+    return null
+  }
+  if (looksLikePath(input)) {
+    return { kind: 'local', path: input }
+  }
+  if (looksLikeTarball(input)) {
+    return { kind: 'tarball', url: input }
+  }
+  if (looksLikeGit(input)) {
+    return { kind: 'git', url: input }
+  }
+  if (input.startsWith('http://') || input.startsWith('https://')) {
+    return { kind: 'tarball', url: input }
+  }
+  const spec = parseRegistrySpec(input)
+  return { kind: 'registry', name: spec.name, version: spec.version }
+}

--- a/src/main/plugin/plugin-activation-coordinator.test.ts
+++ b/src/main/plugin/plugin-activation-coordinator.test.ts
@@ -109,4 +109,85 @@ describe('activatePluginForWorkspace', () => {
     )
     expect(result).toEqual({ ok: false, error: 'unknown_plugin' })
   })
+
+  it('normalizes a missing/non-{ok} activate response to no_response', async () => {
+    // 'plugin.activate' omitted → request resolves undefined.
+    const { request, calls } = fakeRelay({ 'plugin.provision': { ok: true } })
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'no_response' })
+    expect(calls.map((c) => c.method)).toEqual(['plugin.provision', 'plugin.activate'])
+  })
+
+  it('falls back to provision_failed when provision fails without an error string', async () => {
+    const { request, calls } = fakeRelay({ 'plugin.provision': { ok: false } })
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'provision_failed' })
+    expect(calls.map((c) => c.method)).toEqual(['plugin.provision'])
+  })
+
+  it('falls back to bundle_read_failed when readBundle throws a non-Error', async () => {
+    const { request, calls } = fakeRelay({ 'plugin.provision': { ok: true } })
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({
+        relayRequest: request,
+        readBundle: () => {
+          throw 'disk_error'
+        }
+      })
+    )
+    expect(result).toEqual({ ok: false, error: 'bundle_read_failed' })
+    expect(calls).toEqual([])
+  })
+
+  it('falls back to activate_failed when the activate request rejects with a non-Error', async () => {
+    const request: ActivationDeps['relayRequest'] = (method) =>
+      method === 'plugin.provision' ? Promise.resolve({ ok: true }) : Promise.reject('string_error')
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'activate_failed' })
+  })
+
+  it('awaits a Promise-returning localActivate (does not leak the pending promise)', async () => {
+    const localActivate = vi.fn(() => Promise.resolve({ ok: false, error: 'fork_failed' } as const))
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: null },
+      deps({ localActivate })
+    )
+    expect(result).toEqual({ ok: false, error: 'fork_failed' })
+  })
+
+  it('treats an explicit non-remote descriptor ({ isRemote: false }) as local', async () => {
+    const localActivate = vi.fn(() => ({ ok: true }) as const)
+    const { request, calls } = fakeRelay({})
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: false } },
+      deps({ localActivate, relayRequest: request })
+    )
+    expect(result).toEqual({ ok: true })
+    expect(localActivate).toHaveBeenCalledWith('acme.foo')
+    expect(calls).toEqual([])
+  })
+
+  it('rejects an unsafe (traversal) pluginId before any local, bundle, or relay work', async () => {
+    const localActivate = vi.fn(() => ({ ok: true }) as const)
+    const readBundle = vi.fn(() => bundle)
+    const { request, calls } = fakeRelay({ 'plugin.provision': { ok: true } })
+    const result = await activatePluginForWorkspace(
+      { pluginId: '../../../etc', remote: { isRemote: true } },
+      deps({ localActivate, readBundle, relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'unsafe_plugin_id' })
+    expect(localActivate).not.toHaveBeenCalled()
+    expect(readBundle).not.toHaveBeenCalled()
+    expect(calls).toEqual([])
+  })
 })

--- a/src/main/plugin/plugin-activation-coordinator.test.ts
+++ b/src/main/plugin/plugin-activation-coordinator.test.ts
@@ -94,16 +94,20 @@ describe('activatePluginForWorkspace', () => {
     expect(calls).toEqual([])
   })
 
-  it('maps a rejected remote activate to a typed failure (not a throw)', async () => {
-    const request: ActivationDeps['relayRequest'] = (method) =>
-      method === 'plugin.provision'
+  it('maps a rejected remote activate to a typed failure and still compensates', async () => {
+    const calls: string[] = []
+    const request: ActivationDeps['relayRequest'] = (method) => {
+      calls.push(method)
+      return method === 'plugin.provision'
         ? Promise.resolve({ ok: true })
         : Promise.reject(new Error('relay disconnected'))
+    }
     const result = await activatePluginForWorkspace(
       { pluginId: 'acme.foo', remote: { isRemote: true } },
       deps({ relayRequest: request })
     )
     expect(result).toEqual({ ok: false, error: 'relay disconnected' })
+    expect(calls).toEqual(['plugin.provision', 'plugin.activate', 'plugin.deactivate'])
   })
 
   it('reports a relay activate that returns ok:false', async () => {
@@ -232,6 +236,22 @@ describe('activatePluginForWorkspace', () => {
         return neverResolves() // hangs → times out
       }
       return Promise.resolve(undefined)
+    }
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request, delay: immediateDelay })
+    )
+    expect(result).toEqual({ ok: false, error: 'activate_timeout' })
+    expect(calls).toEqual(['plugin.provision', 'plugin.activate', 'plugin.deactivate'])
+  })
+
+  it('returns activate_timeout without hanging even when the compensating deactivate also hangs', async () => {
+    const calls: string[] = []
+    const request: ActivationDeps['relayRequest'] = (method) => {
+      calls.push(method)
+      // provision succeeds; activate AND the compensating deactivate both hang.
+      // The deadline-bounded deactivate must not stall the overall activation.
+      return method === 'plugin.provision' ? Promise.resolve({ ok: true }) : neverResolves()
     }
     const result = await activatePluginForWorkspace(
       { pluginId: 'acme.foo', remote: { isRemote: true } },

--- a/src/main/plugin/plugin-activation-coordinator.test.ts
+++ b/src/main/plugin/plugin-activation-coordinator.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+import { activatePluginForWorkspace, type ActivationDeps } from './plugin-activation-coordinator'
+import type { PluginBundle } from './plugin-bundle'
+
+const bundle: PluginBundle = { pluginId: 'acme.foo', files: [], integrity: 'h' }
+
+// A relay request fn that records calls and returns canned results per method.
+function fakeRelay(results: Record<string, unknown>): {
+  request: ActivationDeps['relayRequest']
+  calls: { method: string; params?: Record<string, unknown> }[]
+} {
+  const calls: { method: string; params?: Record<string, unknown> }[] = []
+  const request: ActivationDeps['relayRequest'] = (method, params) => {
+    calls.push({ method, params })
+    return Promise.resolve(results[method])
+  }
+  return { request, calls }
+}
+
+function deps(over: Partial<ActivationDeps> = {}): ActivationDeps {
+  return {
+    pluginsDir: '/plugins',
+    localActivate: vi.fn(() => ({ ok: true }) as const),
+    relayRequest: () => Promise.resolve({ ok: true }),
+    readBundle: () => bundle,
+    ...over
+  }
+}
+
+describe('activatePluginForWorkspace', () => {
+  it('activates locally and touches neither bundle nor relay when not remote', async () => {
+    const localActivate = vi.fn(() => ({ ok: true }) as const)
+    const readBundle = vi.fn(() => bundle)
+    const { request, calls } = fakeRelay({})
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: null },
+      deps({ localActivate, readBundle, relayRequest: request })
+    )
+    expect(result).toEqual({ ok: true })
+    expect(localActivate).toHaveBeenCalledWith('acme.foo')
+    expect(readBundle).not.toHaveBeenCalled()
+    expect(calls).toEqual([])
+  })
+
+  it('remote happy path provisions then activates, in that order', async () => {
+    const localActivate = vi.fn(() => ({ ok: true }) as const)
+    const { request, calls } = fakeRelay({
+      'plugin.provision': { ok: true },
+      'plugin.activate': { ok: true }
+    })
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ localActivate, relayRequest: request })
+    )
+    expect(result).toEqual({ ok: true })
+    expect(localActivate).not.toHaveBeenCalled()
+    expect(calls.map((c) => c.method)).toEqual(['plugin.provision', 'plugin.activate'])
+    expect(calls[0].params).toEqual({ bundle })
+    expect(calls[1].params).toEqual({ pluginId: 'acme.foo' })
+  })
+
+  it('aborts before activate when provisioning fails', async () => {
+    const { request, calls } = fakeRelay({
+      'plugin.provision': { ok: false, error: 'integrity_mismatch' }
+    })
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'integrity_mismatch' })
+    expect(calls.map((c) => c.method)).toEqual(['plugin.provision'])
+  })
+
+  it('returns a typed error when the bundle read throws (no relay calls)', async () => {
+    const { request, calls } = fakeRelay({ 'plugin.provision': { ok: true } })
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({
+        relayRequest: request,
+        readBundle: () => {
+          throw new Error('ENOENT plugin dir')
+        }
+      })
+    )
+    expect(result).toEqual({ ok: false, error: 'ENOENT plugin dir' })
+    expect(calls).toEqual([])
+  })
+
+  it('maps a rejected remote activate to a typed failure (not a throw)', async () => {
+    const request: ActivationDeps['relayRequest'] = (method) =>
+      method === 'plugin.provision'
+        ? Promise.resolve({ ok: true })
+        : Promise.reject(new Error('relay disconnected'))
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'relay disconnected' })
+  })
+
+  it('reports a relay activate that returns ok:false', async () => {
+    const { request } = fakeRelay({
+      'plugin.provision': { ok: true },
+      'plugin.activate': { ok: false, error: 'unknown_plugin' }
+    })
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'unknown_plugin' })
+  })
+})

--- a/src/main/plugin/plugin-activation-coordinator.test.ts
+++ b/src/main/plugin/plugin-activation-coordinator.test.ts
@@ -17,12 +17,20 @@ function fakeRelay(results: Record<string, unknown>): {
   return { request, calls }
 }
 
+// Default to a delay that never resolves so the timeout never fires unless a
+// test opts in by injecting an immediate `delay`. The relay-request work always
+// wins the race in these cases.
+const neverDelay = (): Promise<void> => new Promise<void>(() => {})
+const immediateDelay = (): Promise<void> => Promise.resolve()
+const neverResolves = (): Promise<never> => new Promise<never>(() => {})
+
 function deps(over: Partial<ActivationDeps> = {}): ActivationDeps {
   return {
     pluginsDir: '/plugins',
     localActivate: vi.fn(() => ({ ok: true }) as const),
     relayRequest: () => Promise.resolve({ ok: true }),
     readBundle: () => bundle,
+    delay: neverDelay,
     ...over
   }
 }
@@ -110,7 +118,7 @@ describe('activatePluginForWorkspace', () => {
     expect(result).toEqual({ ok: false, error: 'unknown_plugin' })
   })
 
-  it('normalizes a missing/non-{ok} activate response to no_response', async () => {
+  it('normalizes a missing/non-{ok} activate response to no_response and compensates', async () => {
     // 'plugin.activate' omitted → request resolves undefined.
     const { request, calls } = fakeRelay({ 'plugin.provision': { ok: true } })
     const result = await activatePluginForWorkspace(
@@ -118,7 +126,12 @@ describe('activatePluginForWorkspace', () => {
       deps({ relayRequest: request })
     )
     expect(result).toEqual({ ok: false, error: 'no_response' })
-    expect(calls.map((c) => c.method)).toEqual(['plugin.provision', 'plugin.activate'])
+    // Provision committed, so a failed activate fires a best-effort deactivate.
+    expect(calls.map((c) => c.method)).toEqual([
+      'plugin.provision',
+      'plugin.activate',
+      'plugin.deactivate'
+    ])
   })
 
   it('falls back to provision_failed when provision fails without an error string', async () => {
@@ -188,6 +201,120 @@ describe('activatePluginForWorkspace', () => {
     expect(result).toEqual({ ok: false, error: 'unsafe_plugin_id' })
     expect(localActivate).not.toHaveBeenCalled()
     expect(readBundle).not.toHaveBeenCalled()
+    expect(calls).toEqual([])
+  })
+
+  // U1 — per-request timeout
+
+  it('times out a stuck provision and aborts before activate (no deactivate)', async () => {
+    const calls: string[] = []
+    const request: ActivationDeps['relayRequest'] = (method) => {
+      calls.push(method)
+      // provision never resolves; the injected immediate delay wins the race.
+      return method === 'plugin.provision' ? neverResolves() : Promise.resolve({ ok: true })
+    }
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request, delay: immediateDelay })
+    )
+    expect(result).toEqual({ ok: false, error: 'provision_timeout' })
+    expect(calls).toEqual(['plugin.provision'])
+  })
+
+  it('times out a stuck activate and fires a compensating deactivate', async () => {
+    const calls: string[] = []
+    const request: ActivationDeps['relayRequest'] = (method) => {
+      calls.push(method)
+      if (method === 'plugin.provision') {
+        return Promise.resolve({ ok: true })
+      }
+      if (method === 'plugin.activate') {
+        return neverResolves() // hangs → times out
+      }
+      return Promise.resolve(undefined)
+    }
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request, delay: immediateDelay })
+    )
+    expect(result).toEqual({ ok: false, error: 'activate_timeout' })
+    expect(calls).toEqual(['plugin.provision', 'plugin.activate', 'plugin.deactivate'])
+  })
+
+  it('uses the default timeout/delay when none is injected (happy path still resolves)', async () => {
+    const { request } = fakeRelay({
+      'plugin.provision': { ok: true },
+      'plugin.activate': { ok: true }
+    })
+    // Build deps WITHOUT a delay override so the real (unref'd) default timer backs the race.
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      {
+        pluginsDir: '/plugins',
+        localActivate: () => ({ ok: true }),
+        relayRequest: request,
+        readBundle: () => bundle
+      }
+    )
+    expect(result).toEqual({ ok: true })
+  })
+
+  // U2 — best-effort compensating deactivate on partial commit
+
+  it('compensates with a best-effort deactivate when activate returns ok:false', async () => {
+    const { request, calls } = fakeRelay({
+      'plugin.provision': { ok: true },
+      'plugin.activate': { ok: false, error: 'unknown_plugin' }
+    })
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'unknown_plugin' })
+    expect(calls.map((c) => c.method)).toEqual([
+      'plugin.provision',
+      'plugin.activate',
+      'plugin.deactivate'
+    ])
+    expect(calls[2].params).toEqual({ pluginId: 'acme.foo' })
+  })
+
+  it('a rejecting compensating deactivate does not mask the original activate error', async () => {
+    const calls: string[] = []
+    const request: ActivationDeps['relayRequest'] = (method) => {
+      calls.push(method)
+      if (method === 'plugin.provision') {
+        return Promise.resolve({ ok: true })
+      }
+      // both activate and the compensating deactivate reject; deactivate's
+      // rejection must be swallowed, the activate error preserved.
+      return Promise.reject(new Error('relay disconnected'))
+    }
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'relay disconnected' })
+    expect(calls).toEqual(['plugin.provision', 'plugin.activate', 'plugin.deactivate'])
+  })
+
+  it('does not compensate (no deactivate) when provisioning fails', async () => {
+    const { request, calls } = fakeRelay({ 'plugin.provision': { ok: false, error: 'integrity' } })
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: { isRemote: true } },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: false, error: 'integrity' })
+    expect(calls.map((c) => c.method)).toEqual(['plugin.provision'])
+  })
+
+  it('never deactivates on the local path', async () => {
+    const { request, calls } = fakeRelay({})
+    const result = await activatePluginForWorkspace(
+      { pluginId: 'acme.foo', remote: null },
+      deps({ relayRequest: request })
+    )
+    expect(result).toEqual({ ok: true })
     expect(calls).toEqual([])
   })
 })

--- a/src/main/plugin/plugin-activation-coordinator.ts
+++ b/src/main/plugin/plugin-activation-coordinator.ts
@@ -11,9 +11,13 @@ import {
   shouldProvisionToRelay,
   type RelayRequest
 } from './plugin-remote-provision'
+import { isSafePluginId } from '../../shared/plugin/manifest'
 import type { PluginBundle } from './plugin-bundle'
+import type { ActivateResult } from './plugin-runtime'
 
-export type ActivationResult = { ok: true } | { ok: false; error: string }
+// One canonical activation result shape, shared with PluginRuntime, so the two
+// can't silently drift.
+export type ActivationResult = ActivateResult
 
 // A workspace is remote when its plugin backend must run on a relay host.
 export type RemoteDescriptor = { isRemote?: boolean } | null | undefined
@@ -33,6 +37,13 @@ export async function activatePluginForWorkspace(
   params: { pluginId: string; remote: RemoteDescriptor },
   deps: ActivationDeps
 ): Promise<ActivationResult> {
+  // Reject traversal/unsafe ids before any disk read or relay call: the remote
+  // path packages pluginsDir/<pluginId> into a transferable bundle, so an
+  // unguarded `../…` id would harvest bytes outside the plugin dir.
+  if (!isSafePluginId(params.pluginId)) {
+    return { ok: false, error: 'unsafe_plugin_id' }
+  }
+
   if (!shouldProvisionToRelay(params.remote)) {
     return deps.localActivate(params.pluginId)
   }
@@ -50,6 +61,9 @@ export async function activatePluginForWorkspace(
     return { ok: false, error: provisioned.error ?? 'provision_failed' }
   }
 
+  // Intentional no-cleanup contract: if provision succeeds but activate fails,
+  // the relay is left with inert files and no backend. Re-provision is
+  // idempotent (atomic swap), so v1a does not issue a compensating deactivate.
   try {
     const result = (await deps.relayRequest('plugin.activate', { pluginId: params.pluginId })) as
       | { ok?: boolean; error?: string }

--- a/src/main/plugin/plugin-activation-coordinator.ts
+++ b/src/main/plugin/plugin-activation-coordinator.ts
@@ -28,6 +28,36 @@ export type ActivationDeps = {
   relayRequest: RelayRequest
   // Injectable for tests; defaults to the real disk reader.
   readBundle?: (pluginsDir: string, pluginId: string) => PluginBundle
+  // Per-relay-request deadline + the delay primitive backing it. Injected so
+  // tests assert timeout behavior deterministically (a delay that resolves
+  // immediately, or never) without real waiting.
+  timeoutMs?: number
+  delay?: (ms: number) => Promise<void>
+}
+
+// A stuck relay must not hang activation forever; 20s mirrors the relay
+// protocol's idle keepalive budget without coupling to it.
+const RELAY_REQUEST_TIMEOUT_MS = 20_000
+
+// Unique marker for "the timeout won the race" — distinguishable from any relay
+// payload (which is a plain object / null / undefined).
+const RELAY_TIMEOUT = Symbol('relay_timeout')
+
+function defaultDelay(ms: number): Promise<void> {
+  // main-process only: unref so a losing timer never keeps the app alive.
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms).unref()
+  })
+}
+
+// Resolve to the work result, or RELAY_TIMEOUT if the deadline wins first. A
+// rejection from `work` propagates (the caller maps it to a typed error).
+function raceWithTimeout<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+  delay: (ms: number) => Promise<void>
+): Promise<T | typeof RELAY_TIMEOUT> {
+  return Promise.race([work, delay(timeoutMs).then((): typeof RELAY_TIMEOUT => RELAY_TIMEOUT)])
 }
 
 // Local workspaces activate in-process unchanged. Remote workspaces package the
@@ -56,24 +86,50 @@ export async function activatePluginForWorkspace(
     return { ok: false, error: error instanceof Error ? error.message : 'bundle_read_failed' }
   }
 
-  const provisioned = await provisionToRelay(deps.relayRequest, bundle)
+  const timeoutMs = deps.timeoutMs ?? RELAY_REQUEST_TIMEOUT_MS
+  const delay = deps.delay ?? defaultDelay
+
+  // provisionToRelay never rejects (it returns a typed failure), so we only
+  // race it against the deadline.
+  const provisioned = await raceWithTimeout(
+    provisionToRelay(deps.relayRequest, bundle),
+    timeoutMs,
+    delay
+  )
+  if (provisioned === RELAY_TIMEOUT) {
+    return { ok: false, error: 'provision_timeout' }
+  }
   if (!provisioned.ok) {
     return { ok: false, error: provisioned.error ?? 'provision_failed' }
   }
 
-  // Intentional no-cleanup contract: if provision succeeds but activate fails,
-  // the relay is left with inert files and no backend. Re-provision is
-  // idempotent (atomic swap), so v1a does not issue a compensating deactivate.
+  // Provision committed the bundle to the relay. If activate then fails by any
+  // means (reject, ok:false, no_response, timeout), the relay may hold a
+  // forked-but-unacknowledged backend — fire a best-effort plugin.deactivate to
+  // reclaim it. Its own rejection is swallowed so it never masks the real error.
+  let activateError: string
   try {
-    const result = (await deps.relayRequest('plugin.activate', { pluginId: params.pluginId })) as
-      | { ok?: boolean; error?: string }
-      | null
-      | undefined
-    if (!result || typeof result.ok !== 'boolean') {
-      return { ok: false, error: 'no_response' }
+    const result = await raceWithTimeout(
+      deps.relayRequest('plugin.activate', { pluginId: params.pluginId }),
+      timeoutMs,
+      delay
+    )
+    if (result === RELAY_TIMEOUT) {
+      activateError = 'activate_timeout'
+    } else {
+      const payload = result as { ok?: boolean; error?: string } | null | undefined
+      if (!payload || typeof payload.ok !== 'boolean') {
+        activateError = 'no_response'
+      } else if (payload.ok) {
+        return { ok: true }
+      } else {
+        activateError = payload.error ?? 'activate_failed'
+      }
     }
-    return result.ok ? { ok: true } : { ok: false, error: result.error ?? 'activate_failed' }
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : 'activate_failed' }
+    activateError = error instanceof Error ? error.message : 'activate_failed'
   }
+
+  await deps.relayRequest('plugin.deactivate', { pluginId: params.pluginId }).catch(() => {})
+  return { ok: false, error: activateError }
 }

--- a/src/main/plugin/plugin-activation-coordinator.ts
+++ b/src/main/plugin/plugin-activation-coordinator.ts
@@ -1,0 +1,65 @@
+// Decides how a plugin activates: locally (in-process, the default) or on a
+// remote relay (provision the files, then activate over the relay dispatcher).
+// Pure + dependency-injected — the relay request fn, local activate fn, and
+// bundle reader are all supplied, so this is fully unit-testable without a real
+// relay or fork. The production call site that supplies a live relay request fn
+// + a real remote descriptor is the NEEDS-RUNTIME-VERIFY seam (see plugin-system).
+
+import {
+  provisionToRelay,
+  readPluginBundleFromDisk,
+  shouldProvisionToRelay,
+  type RelayRequest
+} from './plugin-remote-provision'
+import type { PluginBundle } from './plugin-bundle'
+
+export type ActivationResult = { ok: true } | { ok: false; error: string }
+
+// A workspace is remote when its plugin backend must run on a relay host.
+export type RemoteDescriptor = { isRemote?: boolean } | null | undefined
+
+export type ActivationDeps = {
+  pluginsDir: string
+  localActivate: (pluginId: string) => Promise<ActivationResult> | ActivationResult
+  relayRequest: RelayRequest
+  // Injectable for tests; defaults to the real disk reader.
+  readBundle?: (pluginsDir: string, pluginId: string) => PluginBundle
+}
+
+// Local workspaces activate in-process unchanged. Remote workspaces package the
+// installed plugin, provision it to the relay, and only on provision success
+// activate it there — a provision failure aborts without attempting activate.
+export async function activatePluginForWorkspace(
+  params: { pluginId: string; remote: RemoteDescriptor },
+  deps: ActivationDeps
+): Promise<ActivationResult> {
+  if (!shouldProvisionToRelay(params.remote)) {
+    return deps.localActivate(params.pluginId)
+  }
+
+  const readBundle = deps.readBundle ?? readPluginBundleFromDisk
+  let bundle: PluginBundle
+  try {
+    bundle = readBundle(deps.pluginsDir, params.pluginId)
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'bundle_read_failed' }
+  }
+
+  const provisioned = await provisionToRelay(deps.relayRequest, bundle)
+  if (!provisioned.ok) {
+    return { ok: false, error: provisioned.error ?? 'provision_failed' }
+  }
+
+  try {
+    const result = (await deps.relayRequest('plugin.activate', { pluginId: params.pluginId })) as
+      | { ok?: boolean; error?: string }
+      | null
+      | undefined
+    if (!result || typeof result.ok !== 'boolean') {
+      return { ok: false, error: 'no_response' }
+    }
+    return result.ok ? { ok: true } : { ok: false, error: result.error ?? 'activate_failed' }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'activate_failed' }
+  }
+}

--- a/src/main/plugin/plugin-activation-coordinator.ts
+++ b/src/main/plugin/plugin-activation-coordinator.ts
@@ -50,14 +50,29 @@ function defaultDelay(ms: number): Promise<void> {
   })
 }
 
-// Resolve to the work result, or RELAY_TIMEOUT if the deadline wins first. A
-// rejection from `work` propagates (the caller maps it to a typed error).
+// A rejection from `work` propagates so the caller maps it to a typed error.
 function raceWithTimeout<T>(
   work: Promise<T>,
   timeoutMs: number,
   delay: (ms: number) => Promise<void>
 ): Promise<T | typeof RELAY_TIMEOUT> {
   return Promise.race([work, delay(timeoutMs).then((): typeof RELAY_TIMEOUT => RELAY_TIMEOUT)])
+}
+
+// Narrow an unknown relay activate response to a typed result without an `as`
+// cast that would bypass the unknown boundary.
+function readActivateResult(raw: unknown): ActivationResult {
+  if (raw === null || typeof raw !== 'object' || !('ok' in raw)) {
+    return { ok: false, error: 'no_response' }
+  }
+  const payload = raw as { ok?: unknown; error?: unknown }
+  if (typeof payload.ok !== 'boolean') {
+    return { ok: false, error: 'no_response' }
+  }
+  if (payload.ok) {
+    return { ok: true }
+  }
+  return { ok: false, error: typeof payload.error === 'string' ? payload.error : 'activate_failed' }
 }
 
 // Local workspaces activate in-process unchanged. Remote workspaces package the
@@ -103,33 +118,33 @@ export async function activatePluginForWorkspace(
     return { ok: false, error: provisioned.error ?? 'provision_failed' }
   }
 
-  // Provision committed the bundle to the relay. If activate then fails by any
-  // means (reject, ok:false, no_response, timeout), the relay may hold a
-  // forked-but-unacknowledged backend — fire a best-effort plugin.deactivate to
-  // reclaim it. Its own rejection is swallowed so it never masks the real error.
-  let activateError: string
+  let activateResult: ActivationResult
   try {
-    const result = await raceWithTimeout(
+    const raw = await raceWithTimeout(
       deps.relayRequest('plugin.activate', { pluginId: params.pluginId }),
       timeoutMs,
       delay
     )
-    if (result === RELAY_TIMEOUT) {
-      activateError = 'activate_timeout'
-    } else {
-      const payload = result as { ok?: boolean; error?: string } | null | undefined
-      if (!payload || typeof payload.ok !== 'boolean') {
-        activateError = 'no_response'
-      } else if (payload.ok) {
-        return { ok: true }
-      } else {
-        activateError = payload.error ?? 'activate_failed'
-      }
-    }
+    activateResult =
+      raw === RELAY_TIMEOUT ? { ok: false, error: 'activate_timeout' } : readActivateResult(raw)
   } catch (error) {
-    activateError = error instanceof Error ? error.message : 'activate_failed'
+    activateResult = {
+      ok: false,
+      error: error instanceof Error ? error.message : 'activate_failed'
+    }
+  }
+  if (activateResult.ok) {
+    return { ok: true }
   }
 
-  await deps.relayRequest('plugin.deactivate', { pluginId: params.pluginId }).catch(() => {})
-  return { ok: false, error: activateError }
+  // Activate failed after a committed provision — the relay may hold a
+  // forked-but-unacknowledged backend. Best-effort, deadline-bounded deactivate
+  // to reclaim it; swallowed (and timed) so it never masks or outlasts the
+  // original activate failure.
+  await raceWithTimeout(
+    deps.relayRequest('plugin.deactivate', { pluginId: params.pluginId }),
+    timeoutMs,
+    delay
+  ).catch(() => {})
+  return activateResult
 }

--- a/src/main/plugin/plugin-asset-protocol.test.ts
+++ b/src/main/plugin/plugin-asset-protocol.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { resolve } from 'node:path'
+import { parsePluginAssetUrl, resolvePluginAsset } from './plugin-asset-protocol'
+
+const PLUGINS_DIR = '/plugins'
+const active = (id: string): boolean => id === 'acme.foo'
+
+describe('parsePluginAssetUrl', () => {
+  it('parses id and asset path, preserving id case', () => {
+    expect(parsePluginAssetUrl('orca-plugin://Acme.Foo/ui/index.html')).toEqual({
+      pluginId: 'Acme.Foo',
+      assetPath: 'ui/index.html'
+    })
+  })
+
+  it('defaults to index.html when no path is given', () => {
+    expect(parsePluginAssetUrl('orca-plugin://acme.foo')).toEqual({
+      pluginId: 'acme.foo',
+      assetPath: 'index.html'
+    })
+    expect(parsePluginAssetUrl('orca-plugin://acme.foo/')).toEqual({
+      pluginId: 'acme.foo',
+      assetPath: 'index.html'
+    })
+  })
+
+  it('returns null for a non-orca-plugin url', () => {
+    expect(parsePluginAssetUrl('https://example.com')).toBeNull()
+  })
+})
+
+describe('resolvePluginAsset', () => {
+  it('resolves a file within the plugin directory', () => {
+    const result = resolvePluginAsset(PLUGINS_DIR, active, 'acme.foo', 'index.html')
+    expect(result).toEqual({ ok: true, filePath: resolve(PLUGINS_DIR, 'acme.foo', 'index.html') })
+  })
+
+  it('rejects path traversal out of the plugin directory', () => {
+    for (const p of ['../../etc/passwd', '..%2f..%2fsecret', '/etc/passwd']) {
+      const result = resolvePluginAsset(PLUGINS_DIR, active, 'acme.foo', p)
+      // '/etc/passwd' is stripped of leading slash -> resolves inside; the
+      // traversal cases must be rejected.
+      if (p.includes('..')) {
+        expect(result.ok).toBe(false)
+      }
+    }
+    expect(resolvePluginAsset(PLUGINS_DIR, active, 'acme.foo', '../../etc/passwd').ok).toBe(false)
+  })
+
+  it('rejects an inactive plugin', () => {
+    expect(resolvePluginAsset(PLUGINS_DIR, active, 'acme.other', 'index.html')).toEqual({
+      ok: false,
+      reason: 'plugin not active'
+    })
+  })
+
+  it('rejects an unsafe plugin id', () => {
+    expect(resolvePluginAsset(PLUGINS_DIR, () => true, '../evil', 'index.html').ok).toBe(false)
+  })
+})

--- a/src/main/plugin/plugin-asset-protocol.ts
+++ b/src/main/plugin/plugin-asset-protocol.ts
@@ -1,0 +1,101 @@
+// Serves a plugin's single-file UI over a registered `orca-plugin://<id>/<path>`
+// scheme, scoped to the plugin's install directory. The URL parsing and the
+// path-scoped resolution — the security-critical parts — are pure and unit-
+// tested here; the Electron `protocol.handle` / scheme registration are thin
+// wrappers marked NEEDS-RUNTIME-VERIFY (they require the running app).
+
+import { resolve, sep } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { isSafePluginId } from '../../shared/plugin/manifest'
+
+export type AssetResolution = { ok: true; filePath: string } | { ok: false; reason: string }
+
+// Parse `orca-plugin://<id>/<assetPath>` preserving id case (URL host-casing
+// would lowercase ids, which are case-sensitive). Defaults to index.html.
+export function parsePluginAssetUrl(url: string): { pluginId: string; assetPath: string } | null {
+  const prefix = 'orca-plugin://'
+  if (!url.startsWith(prefix)) {
+    return null
+  }
+  const rest = url.slice(prefix.length)
+  const slash = rest.indexOf('/')
+  if (slash === -1) {
+    return rest.length > 0 ? { pluginId: rest, assetPath: 'index.html' } : null
+  }
+  const pluginId = rest.slice(0, slash)
+  const assetPath = rest.slice(slash + 1)
+  return { pluginId, assetPath: assetPath.length > 0 ? assetPath : 'index.html' }
+}
+
+// Resolve a request to an absolute file inside `pluginsDir/<id>`, rejecting
+// unsafe ids, inactive plugins, and any path that escapes the plugin directory.
+export function resolvePluginAsset(
+  pluginsDir: string,
+  isActive: (id: string) => boolean,
+  pluginId: string,
+  assetPath: string
+): AssetResolution {
+  if (!isSafePluginId(pluginId)) {
+    return { ok: false, reason: 'unsafe plugin id' }
+  }
+  if (!isActive(pluginId)) {
+    return { ok: false, reason: 'plugin not active' }
+  }
+  const root = resolve(pluginsDir, pluginId)
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(assetPath)
+  } catch {
+    return { ok: false, reason: 'malformed asset path' }
+  }
+  const target = resolve(root, decoded.replace(/^[/\\]+/, ''))
+  if (target !== root && !target.startsWith(root + sep)) {
+    return { ok: false, reason: 'path traversal' }
+  }
+  return { ok: true, filePath: target }
+}
+
+// Minimal shape of the electron bits used here — avoids importing electron
+// (main-only) into a module that must stay unit-testable, and keeps lint happy.
+type ElectronProtocolModule = {
+  protocol: {
+    registerSchemesAsPrivileged(schemes: unknown): void
+    handle(scheme: string, handler: (request: Request) => Response | Promise<Response>): void
+  }
+  net: { fetch(url: string): Promise<Response> }
+}
+
+function loadElectron(): ElectronProtocolModule {
+  return require('electron') as ElectronProtocolModule
+}
+
+// NEEDS-RUNTIME-VERIFY: declare the scheme as privileged (standard + secure +
+// fetch-enabled) so a tight CSP can anchor at orca-plugin://. MUST be called
+// before app.whenReady() — wire into app bootstrap, not a manager constructor.
+export function registerPluginScheme(): void {
+  loadElectron().protocol.registerSchemesAsPrivileged([
+    {
+      scheme: 'orca-plugin',
+      privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: false }
+    }
+  ])
+}
+
+// NEEDS-RUNTIME-VERIFY: register the request handler that serves resolved files.
+export function registerPluginAssetProtocol(
+  pluginsDir: string,
+  isActive: (id: string) => boolean
+): void {
+  const { protocol, net } = loadElectron()
+  protocol.handle('orca-plugin', (request: Request) => {
+    const parsed = parsePluginAssetUrl(request.url)
+    if (!parsed) {
+      return new Response('bad request', { status: 400 })
+    }
+    const resolved = resolvePluginAsset(pluginsDir, isActive, parsed.pluginId, parsed.assetPath)
+    if (!resolved.ok) {
+      return new Response(resolved.reason, { status: 403 })
+    }
+    return net.fetch(pathToFileURL(resolved.filePath).toString())
+  })
+}

--- a/src/main/plugin/plugin-bundle.test.ts
+++ b/src/main/plugin/plugin-bundle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   PLUGIN_BUNDLE_MAX_BYTES,
+  PLUGIN_BUNDLE_MAX_FILES,
   isSafeBundlePath,
   serializePluginBundle,
   verifyPluginBundle,
@@ -25,6 +26,13 @@ describe('isSafeBundlePath', () => {
   it('rejects absolute, traversal, drive, and backslash paths', () => {
     for (const p of ['/etc/passwd', '../x', 'a/../../b', 'C:/x', 'a\\b', '', './x', 'a/./b']) {
       expect(isSafeBundlePath(p)).toBe(false)
+    }
+  })
+
+  it('rejects paths containing control characters (NUL/tab/LF/CR/unit-sep/DEL)', () => {
+    // Build inputs via fromCharCode so no control-char literals live in source.
+    for (const code of [0x00, 0x09, 0x0a, 0x0d, 0x1f, 0x7f]) {
+      expect(isSafeBundlePath(`a${String.fromCharCode(code)}b`)).toBe(false)
     }
   })
 })
@@ -76,5 +84,16 @@ describe('verifyPluginBundle guards', () => {
       { path: 'big.bin', dataBase64: Buffer.from(big, 'utf8').toString('base64') }
     ])
     expect(verifyPluginBundle(bundle)).toEqual({ ok: false, error: 'too_large' })
+  })
+
+  it('rejects a bundle over the file-count cap', () => {
+    const files: PluginBundleFile[] = Array.from(
+      { length: PLUGIN_BUNDLE_MAX_FILES + 1 },
+      (_, i) => ({ path: `f${i}.txt`, dataBase64: b64('x') })
+    )
+    expect(verifyPluginBundle(serializePluginBundle('acme.foo', files))).toEqual({
+      ok: false,
+      error: 'too_many_files'
+    })
   })
 })

--- a/src/main/plugin/plugin-bundle.test.ts
+++ b/src/main/plugin/plugin-bundle.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PLUGIN_BUNDLE_MAX_BYTES,
+  isSafeBundlePath,
+  serializePluginBundle,
+  verifyPluginBundle,
+  type PluginBundleFile
+} from './plugin-bundle'
+
+const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64')
+
+function sampleFiles(): PluginBundleFile[] {
+  return [
+    { path: 'plugin.json', dataBase64: b64('{"id":"acme.foo"}') },
+    { path: 'ui/index.html', dataBase64: b64('<!doctype html>') }
+  ]
+}
+
+describe('isSafeBundlePath', () => {
+  it('accepts relative posix paths', () => {
+    expect(isSafeBundlePath('plugin.json')).toBe(true)
+    expect(isSafeBundlePath('ui/index.html')).toBe(true)
+  })
+
+  it('rejects absolute, traversal, drive, and backslash paths', () => {
+    for (const p of ['/etc/passwd', '../x', 'a/../../b', 'C:/x', 'a\\b', '', './x', 'a/./b']) {
+      expect(isSafeBundlePath(p)).toBe(false)
+    }
+  })
+})
+
+describe('plugin bundle round-trip', () => {
+  it('serialize then verify returns the same files', () => {
+    const bundle = serializePluginBundle('acme.foo', sampleFiles())
+    const result = verifyPluginBundle(bundle)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.files).toEqual(sampleFiles())
+    }
+  })
+
+  it('detects tampered file bytes via the integrity digest', () => {
+    const bundle = serializePluginBundle('acme.foo', sampleFiles())
+    bundle.files[0].dataBase64 = b64('{"id":"evil"}')
+    expect(verifyPluginBundle(bundle)).toEqual({ ok: false, error: 'integrity_mismatch' })
+  })
+
+  it('integrity is order-independent (files reordered still verify)', () => {
+    const bundle = serializePluginBundle('acme.foo', sampleFiles())
+    bundle.files.reverse()
+    expect(verifyPluginBundle(bundle).ok).toBe(true)
+  })
+})
+
+describe('verifyPluginBundle guards', () => {
+  it('rejects a non-object or shape-invalid bundle', () => {
+    expect(verifyPluginBundle(null).ok).toBe(false)
+    expect(verifyPluginBundle({ pluginId: 'x' }).ok).toBe(false)
+    expect(verifyPluginBundle({ pluginId: 'x', files: 'no', integrity: 'h' }).ok).toBe(false)
+  })
+
+  it('rejects a malformed file entry', () => {
+    const bundle = serializePluginBundle('acme.foo', sampleFiles())
+    ;(bundle.files as unknown[])[0] = { path: 'x' }
+    expect(verifyPluginBundle(bundle)).toEqual({ ok: false, error: 'invalid_file_entry' })
+  })
+
+  it('rejects an unsafe path before checking integrity', () => {
+    const bundle = serializePluginBundle('acme.foo', [{ path: '../escape', dataBase64: b64('x') }])
+    expect(verifyPluginBundle(bundle)).toEqual({ ok: false, error: 'unsafe_path' })
+  })
+
+  it('rejects a bundle over the byte cap', () => {
+    const big = 'a'.repeat(PLUGIN_BUNDLE_MAX_BYTES + 1)
+    const bundle = serializePluginBundle('acme.foo', [
+      { path: 'big.bin', dataBase64: Buffer.from(big, 'utf8').toString('base64') }
+    ])
+    expect(verifyPluginBundle(bundle)).toEqual({ ok: false, error: 'too_large' })
+  })
+})

--- a/src/main/plugin/plugin-bundle.ts
+++ b/src/main/plugin/plugin-bundle.ts
@@ -1,0 +1,88 @@
+// Serializable plugin bundle for provisioning a plugin to the relay host. A
+// bundle is a flat file list (each file's bytes base64-encoded) plus a sha256
+// integrity digest over a canonical serialization. Electron-free and dependency
+// -free (reuses the installer's sha256); the desktop packages it, the relay
+// verifies + unpacks it. Lives beside install-integrity (node:crypto), not in
+// src/shared, so node-only code stays out of the web typecheck graph.
+
+import { sha256 } from './install/install-integrity'
+
+// Generous ceiling for a self-contained v1 plugin (manifest + main.js + one
+// inlined HTML UI). Bounds an abusive transfer over the wire; asserted on both
+// the package and receive ends.
+export const PLUGIN_BUNDLE_MAX_BYTES = 4 * 1024 * 1024
+
+export type PluginBundleFile = { path: string; dataBase64: string }
+export type PluginBundle = { pluginId: string; files: PluginBundleFile[]; integrity: string }
+
+export type VerifyBundleResult =
+  | { ok: true; files: PluginBundleFile[] }
+  | { ok: false; error: string }
+
+// A bundle file path must be relative, posix-separated, and stay inside the
+// plugin dir: no absolute paths, no drive letters, no backslashes, no empty / `.`
+// / `..` segments. The relay re-checks this before writing — never trust the
+// sender's paths.
+export function isSafeBundlePath(path: string): boolean {
+  if (typeof path !== 'string' || path.length === 0) {
+    return false
+  }
+  if (path.startsWith('/') || /^[A-Za-z]:/.test(path) || path.includes('\\')) {
+    return false
+  }
+  return !path.split('/').some((seg) => seg === '' || seg === '.' || seg === '..')
+}
+
+// Canonical serialization for the integrity digest: files sorted by path, each
+// rendered as `path\n<base64>`, joined by newlines. Order-independent so the
+// digest is stable regardless of how the file list was assembled.
+function canonicalize(files: PluginBundleFile[]): string {
+  return [...files]
+    .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+    .map((f) => `${f.path}\n${f.dataBase64}`)
+    .join('\n')
+}
+
+export function serializePluginBundle(pluginId: string, files: PluginBundleFile[]): PluginBundle {
+  return { pluginId, files, integrity: sha256(canonicalize(files)) }
+}
+
+// Validate a received bundle: shape, per-file path safety, total decoded byte
+// cap, and integrity. Returns the files on success so the caller writes only a
+// verified set.
+export function verifyPluginBundle(bundle: unknown): VerifyBundleResult {
+  if (!bundle || typeof bundle !== 'object') {
+    return { ok: false, error: 'invalid_bundle' }
+  }
+  const candidate = bundle as Partial<PluginBundle>
+  if (
+    typeof candidate.pluginId !== 'string' ||
+    !Array.isArray(candidate.files) ||
+    typeof candidate.integrity !== 'string'
+  ) {
+    return { ok: false, error: 'invalid_bundle' }
+  }
+  let totalBytes = 0
+  for (const file of candidate.files) {
+    if (
+      !file ||
+      typeof file !== 'object' ||
+      typeof (file as PluginBundleFile).path !== 'string' ||
+      typeof (file as PluginBundleFile).dataBase64 !== 'string'
+    ) {
+      return { ok: false, error: 'invalid_file_entry' }
+    }
+    if (!isSafeBundlePath((file as PluginBundleFile).path)) {
+      return { ok: false, error: 'unsafe_path' }
+    }
+    totalBytes += Buffer.from((file as PluginBundleFile).dataBase64, 'base64').length
+  }
+  if (totalBytes > PLUGIN_BUNDLE_MAX_BYTES) {
+    return { ok: false, error: 'too_large' }
+  }
+  const files = candidate.files as PluginBundleFile[]
+  if (sha256(canonicalize(files)) !== candidate.integrity) {
+    return { ok: false, error: 'integrity_mismatch' }
+  }
+  return { ok: true, files }
+}

--- a/src/main/plugin/plugin-bundle.ts
+++ b/src/main/plugin/plugin-bundle.ts
@@ -11,6 +11,9 @@ import { sha256 } from './install/install-integrity'
 // inlined HTML UI). Bounds an abusive transfer over the wire; asserted on both
 // the package and receive ends.
 export const PLUGIN_BUNDLE_MAX_BYTES = 4 * 1024 * 1024
+// Bound the file count too — the byte cap alone lets a flood of tiny files
+// exhaust inodes/syscalls on the relay host.
+export const PLUGIN_BUNDLE_MAX_FILES = 1000
 
 export type PluginBundleFile = { path: string; dataBase64: string }
 export type PluginBundle = { pluginId: string; files: PluginBundleFile[]; integrity: string }
@@ -21,8 +24,8 @@ export type VerifyBundleResult =
 
 // A bundle file path must be relative, posix-separated, and stay inside the
 // plugin dir: no absolute paths, no drive letters, no backslashes, no empty / `.`
-// / `..` segments. The relay re-checks this before writing — never trust the
-// sender's paths.
+// / `..` segments, and no control characters. The relay re-checks this before
+// writing — never trust the sender's paths.
 export function isSafeBundlePath(path: string): boolean {
   if (typeof path !== 'string' || path.length === 0) {
     return false
@@ -30,12 +33,22 @@ export function isSafeBundlePath(path: string): boolean {
   if (path.startsWith('/') || /^[A-Za-z]:/.test(path) || path.includes('\\')) {
     return false
   }
+  // Reject control chars (newline/CR/tab/NUL/DEL). A newline in a path could
+  // straddle the integrity canonicalization's `\n` separators (digest collision),
+  // and embedded control chars are invalid filenames.
+  for (let i = 0; i < path.length; i++) {
+    const code = path.charCodeAt(i)
+    if (code <= 0x1f || code === 0x7f) {
+      return false
+    }
+  }
   return !path.split('/').some((seg) => seg === '' || seg === '.' || seg === '..')
 }
 
 // Canonical serialization for the integrity digest: files sorted by path, each
 // rendered as `path\n<base64>`, joined by newlines. Order-independent so the
-// digest is stable regardless of how the file list was assembled.
+// digest is stable regardless of how the file list was assembled. Path control
+// chars (which could straddle the separators) are rejected by isSafeBundlePath.
 function canonicalize(files: PluginBundleFile[]): string {
   return [...files]
     .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
@@ -47,9 +60,9 @@ export function serializePluginBundle(pluginId: string, files: PluginBundleFile[
   return { pluginId, files, integrity: sha256(canonicalize(files)) }
 }
 
-// Validate a received bundle: shape, per-file path safety, total decoded byte
-// cap, and integrity. Returns the files on success so the caller writes only a
-// verified set.
+// Validate a received bundle: shape, file count, per-file path safety, total
+// decoded byte cap, and integrity. Returns the files on success so the caller
+// writes only a verified set.
 export function verifyPluginBundle(bundle: unknown): VerifyBundleResult {
   if (!bundle || typeof bundle !== 'object') {
     return { ok: false, error: 'invalid_bundle' }
@@ -61,6 +74,9 @@ export function verifyPluginBundle(bundle: unknown): VerifyBundleResult {
     typeof candidate.integrity !== 'string'
   ) {
     return { ok: false, error: 'invalid_bundle' }
+  }
+  if (candidate.files.length > PLUGIN_BUNDLE_MAX_FILES) {
+    return { ok: false, error: 'too_many_files' }
   }
   let totalBytes = 0
   for (const file of candidate.files) {

--- a/src/main/plugin/plugin-discovery.test.ts
+++ b/src/main/plugin/plugin-discovery.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { discoverPlugins, readManifestRaw } from './plugin-discovery'
+
+function validManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'acme.foo',
+    name: 'Foo',
+    version: '1.0.0',
+    hostApiVersion: '0.1.0',
+    main: 'main.js',
+    contributes: { sidebar: { title: 'Foo', icon: 'Activity', ui: 'index.html' } },
+    capabilities: ['workspace:read'],
+    ...overrides
+  }
+}
+
+let tmp: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'plugin-discovery-'))
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+function writePluginDir(
+  name: string,
+  manifest: Record<string, unknown> | null,
+  usePackageJson = false
+): string {
+  const dir = join(tmp, name)
+  mkdirSync(dir, { recursive: true })
+  if (manifest !== null) {
+    if (usePackageJson) {
+      writeFileSync(
+        join(dir, 'package.json'),
+        JSON.stringify({ name, version: '1.0.0', orca: manifest })
+      )
+    } else {
+      writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest))
+    }
+  }
+  return dir
+}
+
+describe('readManifestRaw', () => {
+  it('reads plugin.json when present', () => {
+    const dir = writePluginDir('p1', validManifest())
+    expect(readManifestRaw(dir)).toMatchObject({ id: 'acme.foo' })
+  })
+
+  it('falls back to package.json#orca', () => {
+    const dir = writePluginDir('p2', validManifest({ id: 'acme.bar' }), true)
+    expect(readManifestRaw(dir)).toMatchObject({ id: 'acme.bar' })
+  })
+
+  it('returns null when no manifest exists', () => {
+    const dir = writePluginDir('p3', null)
+    expect(readManifestRaw(dir)).toBeNull()
+  })
+})
+
+describe('discoverPlugins', () => {
+  it('returns empty when the plugins dir does not exist', () => {
+    expect(discoverPlugins(join(tmp, 'nope'))).toEqual({ valid: [], invalid: [] })
+  })
+
+  it('separates valid and invalid plugins', () => {
+    writePluginDir('good', validManifest({ id: 'acme.good' }))
+    writePluginDir('viapkg', validManifest({ id: 'acme.viapkg' }), true)
+    writePluginDir('bad', validManifest({ capabilities: ['process:exec'] }))
+    writePluginDir('nomanifest', null)
+
+    const result = discoverPlugins(tmp)
+    const validIds = result.valid.map((p) => p.manifest.id).sort()
+    expect(validIds).toEqual(['acme.good', 'acme.viapkg'])
+    expect(result.invalid).toHaveLength(2)
+    expect(result.invalid.some((i) => i.errors.join().includes('process:exec'))).toBe(true)
+    expect(result.invalid.some((i) => i.errors.join().includes('no plugin.json'))).toBe(true)
+  })
+})

--- a/src/main/plugin/plugin-discovery.test.ts
+++ b/src/main/plugin/plugin-discovery.test.ts
@@ -82,4 +82,20 @@ describe('discoverPlugins', () => {
     expect(result.invalid.some((i) => i.errors.join().includes('process:exec'))).toBe(true)
     expect(result.invalid.some((i) => i.errors.join().includes('no plugin.json'))).toBe(true)
   })
+
+  it('treats a malformed plugin.json as an invalid plugin, not a crash', () => {
+    const dir = join(tmp, 'broken')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'plugin.json'), '{ not valid json')
+    const result = discoverPlugins(tmp)
+    expect(result.valid).toEqual([])
+    expect(result.invalid).toHaveLength(1)
+  })
+
+  it('rejects an unsafe id (path traversal) during discovery', () => {
+    writePluginDir('traverse', validManifest({ id: '../../escape' }))
+    const result = discoverPlugins(tmp)
+    expect(result.valid).toEqual([])
+    expect(result.invalid.some((i) => i.errors.join().includes('id:'))).toBe(true)
+  })
 })

--- a/src/main/plugin/plugin-discovery.ts
+++ b/src/main/plugin/plugin-discovery.ts
@@ -1,0 +1,60 @@
+// Discover installed plugins under a plugins directory: read each plugin's
+// manifest (`plugin.json`, or the `orca` field of `package.json`) and validate
+// it against the shared contract. Pure fs + the shared validator — no Electron.
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { validatePluginManifest } from '../../shared/plugin/manifest-validate'
+import type { PluginManifest } from '../../shared/plugin/manifest'
+
+// Read the raw manifest object from a plugin directory, or null when neither a
+// `plugin.json` nor a `package.json#orca` field is present / parseable.
+export function readManifestRaw(pluginDir: string): unknown | null {
+  const pluginJson = join(pluginDir, 'plugin.json')
+  if (existsSync(pluginJson)) {
+    try {
+      return JSON.parse(readFileSync(pluginJson, 'utf8'))
+    } catch {
+      return null
+    }
+  }
+  const packageJson = join(pluginDir, 'package.json')
+  if (existsSync(packageJson)) {
+    try {
+      const parsed = JSON.parse(readFileSync(packageJson, 'utf8')) as { orca?: unknown }
+      return parsed.orca ?? null
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+export type DiscoveredPlugin = { dir: string; manifest: PluginManifest }
+export type InvalidPlugin = { dir: string; errors: string[] }
+export type DiscoveryResult = { valid: DiscoveredPlugin[]; invalid: InvalidPlugin[] }
+
+export function discoverPlugins(pluginsDir: string): DiscoveryResult {
+  const result: DiscoveryResult = { valid: [], invalid: [] }
+  if (!existsSync(pluginsDir)) {
+    return result
+  }
+  for (const name of readdirSync(pluginsDir)) {
+    const dir = join(pluginsDir, name)
+    if (!statSync(dir).isDirectory()) {
+      continue
+    }
+    const raw = readManifestRaw(dir)
+    if (raw === null) {
+      result.invalid.push({ dir, errors: ['no plugin.json or package.json#orca manifest found'] })
+      continue
+    }
+    const validated = validatePluginManifest(raw)
+    if (validated.ok) {
+      result.valid.push({ dir, manifest: validated.manifest })
+    } else {
+      result.invalid.push({ dir, errors: validated.errors })
+    }
+  }
+  return result
+}

--- a/src/main/plugin/plugin-discovery.ts
+++ b/src/main/plugin/plugin-discovery.ts
@@ -41,7 +41,15 @@ export function discoverPlugins(pluginsDir: string): DiscoveryResult {
   }
   for (const name of readdirSync(pluginsDir)) {
     const dir = join(pluginsDir, name)
-    if (!statSync(dir).isDirectory()) {
+    let isDirectory = false
+    try {
+      isDirectory = statSync(dir).isDirectory()
+    } catch {
+      // A dangling symlink (ENOENT) or unreadable entry (EACCES) must not abort
+      // the whole scan — skip it.
+      continue
+    }
+    if (!isDirectory) {
       continue
     }
     const raw = readManifestRaw(dir)

--- a/src/main/plugin/plugin-host-entry.ts
+++ b/src/main/plugin/plugin-host-entry.ts
@@ -1,0 +1,160 @@
+// NEEDS-RUNTIME-VERIFY: runs inside the forked plugin-host child process.
+// Exercised in production only (requires the built `out/` entry + the parent
+// fork wiring); its host side, PluginHost, is integration-tested with a fixture
+// that speaks this same protocol. Loads the plugin's backend `main`, builds an
+// async `context` whose host-backed calls round-trip to the parent over IPC,
+// and drives the activate/deactivate lifecycle.
+
+import type {
+  BridgeResponse,
+  Disposable,
+  HostCommand,
+  LifecycleEvent,
+  PluginContext,
+  WorkspaceSnapshot
+} from '../../shared/plugin/api-contract'
+import { LIFECYCLE_EVENTS } from '../../shared/plugin/api-contract'
+import type { HostToPlugin, PluginToHost } from './plugin-host-protocol'
+
+type PluginModule = {
+  activate?: (context: PluginContext) => void | Promise<void>
+  deactivate?: () => void | Promise<void>
+}
+
+function send(message: PluginToHost): void {
+  process.send?.(message)
+}
+
+// argv: [node, entry, pluginId, mainPath]
+const mainPath = process.argv[3]
+
+const pendingHostCalls = new Map<string, (response: BridgeResponse) => void>()
+let requestSeq = 0
+const uiHandlers = new Set<(message: unknown) => void>()
+const eventHandlers = new Map<LifecycleEvent, Set<(payload?: unknown) => void>>()
+const disposables: Disposable[] = []
+let pluginModule: PluginModule | null = null
+
+function callHost(method: string, params?: unknown): Promise<unknown> {
+  const reqId = `req-${requestSeq++}`
+  return new Promise((resolve, reject) => {
+    pendingHostCalls.set(reqId, (response) => {
+      if (response.ok) {
+        resolve(response.result)
+      } else {
+        reject(new Error(response.error))
+      }
+    })
+    send({ type: 'host-request', request: { reqId, method: method as never, params } })
+  })
+}
+
+function subscribe<T>(set: Set<T>, handler: T): Disposable {
+  set.add(handler)
+  return {
+    dispose() {
+      set.delete(handler)
+    }
+  }
+}
+
+function eventSet(event: LifecycleEvent): Set<(payload?: unknown) => void> {
+  let set = eventHandlers.get(event)
+  if (!set) {
+    set = new Set()
+    eventHandlers.set(event, set)
+  }
+  return set
+}
+
+function buildContext(): PluginContext {
+  const events = Object.fromEntries(
+    LIFECYCLE_EVENTS.map((event) => [
+      event,
+      (cb: (payload?: unknown) => void) => subscribe(eventSet(event), cb)
+    ])
+  ) as PluginContext['events']
+
+  return {
+    workspace: {
+      getSnapshot: () => callHost('workspace.getSnapshot') as Promise<WorkspaceSnapshot>,
+      onDidChange: (cb) => subscribe(eventSet('onWorkspaceChanged'), cb)
+    },
+    commands: {
+      register: () => ({ dispose() {} }),
+      invokeHost: (name: HostCommand, params?: unknown) =>
+        callHost('commands.invokeHost', { name, params })
+    },
+    settings: {
+      get: <T = unknown>(key: string) =>
+        callHost('settings.get', { key }) as Promise<T | undefined>,
+      set: (key: string, value: unknown) =>
+        callHost('settings.set', { key, value }) as Promise<void>,
+      onDidChange: (cb) => subscribe(eventSet('onSettingsChanged'), cb)
+    },
+    ui: {
+      postMessage: (message: unknown) => send({ type: 'ui', message }),
+      onMessage: (cb) => subscribe(uiHandlers, cb)
+    },
+    events,
+    log: (...args: unknown[]) => {
+      process.stdout.write(`${args.map((a) => String(a)).join(' ')}\n`)
+    },
+    subscriptions: disposables
+  }
+}
+
+async function runActivate(): Promise<void> {
+  try {
+    // The plugin backend is trusted CJS; require it directly.
+    pluginModule = require(mainPath) as PluginModule
+    await pluginModule.activate?.(buildContext())
+    send({ type: 'ready' })
+  } catch (error) {
+    send({
+      type: 'activate-error',
+      message: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+async function runDeactivate(): Promise<void> {
+  try {
+    await pluginModule?.deactivate?.()
+  } finally {
+    for (const disposable of disposables.splice(0)) {
+      disposable.dispose()
+    }
+    process.exit(0)
+  }
+}
+
+process.on('message', (raw: unknown) => {
+  const message = raw as HostToPlugin
+  switch (message.type) {
+    case 'activate':
+      void runActivate()
+      break
+    case 'deactivate':
+      void runDeactivate()
+      break
+    case 'host-response': {
+      const resolver = pendingHostCalls.get(message.response.reqId)
+      if (resolver) {
+        pendingHostCalls.delete(message.response.reqId)
+        resolver(message.response)
+      }
+      break
+    }
+    case 'ui':
+      for (const handler of uiHandlers) {
+        handler(message.message)
+      }
+      break
+    case 'event':
+      for (const handler of eventSet(message.event)) {
+        handler(message.payload)
+      }
+      break
+  }
+})

--- a/src/main/plugin/plugin-host-handler.test.ts
+++ b/src/main/plugin/plugin-host-handler.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createHostRequestHandler, type HostServices } from './plugin-host-handler'
+import { PluginSettingsStore } from './plugin-settings-store'
+import type { BridgeRequest } from '../../shared/plugin/api-contract'
+import type { PluginCapability } from '../../shared/plugin/manifest'
+
+let tmp: string
+
+function makeServices(): HostServices {
+  return {
+    getWorkspaceSnapshot: vi.fn(async () => ({
+      workspaceName: 'orca',
+      currentBranch: 'main',
+      isDirty: false,
+      openFileCount: 2,
+      // a service that leaks extra fields — the gate must project them away:
+      absolutePath: '/Users/me/secret'
+    })) as unknown as HostServices['getWorkspaceSnapshot'],
+    invokeCommand: vi.fn(async () => 'invoked'),
+    settings: new PluginSettingsStore(tmp, 'acme.foo')
+  }
+}
+
+function req(method: string, params?: unknown): BridgeRequest {
+  return { reqId: 'r1', method: method as BridgeRequest['method'], params }
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'host-handler-'))
+})
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('createHostRequestHandler', () => {
+  const all: PluginCapability[] = ['workspace:read', 'commands', 'settings']
+
+  it('denies a method whose capability was not declared', async () => {
+    const handle = createHostRequestHandler([], makeServices())
+    expect(await handle(req('workspace.getSnapshot'))).toEqual({
+      reqId: 'r1',
+      ok: false,
+      error: 'capability_denied'
+    })
+  })
+
+  it('returns a projected workspace snapshot (no leaked fields)', async () => {
+    const handle = createHostRequestHandler(all, makeServices())
+    const res = await handle(req('workspace.getSnapshot'))
+    expect(res.ok).toBe(true)
+    if (res.ok) {
+      expect(res.result).toEqual({
+        workspaceName: 'orca',
+        currentBranch: 'main',
+        isDirty: false,
+        openFileCount: 2
+      })
+      expect(res.result).not.toHaveProperty('absolutePath')
+    }
+  })
+
+  it('validates host commands before invoking', async () => {
+    const services = makeServices()
+    const handle = createHostRequestHandler(all, services)
+    // bad scheme is rejected without invoking
+    const bad = await handle(
+      req('commands.invokeHost', { name: 'open-external-url', params: { url: 'file:///x' } })
+    )
+    expect(bad).toEqual({ reqId: 'r1', ok: false, error: 'invalid_params' })
+    expect(services.invokeCommand).not.toHaveBeenCalled()
+    // good command invokes
+    const good = await handle(
+      req('commands.invokeHost', { name: 'copy-to-clipboard', params: { text: 'hi' } })
+    )
+    expect(good.ok).toBe(true)
+    expect(services.invokeCommand).toHaveBeenCalledOnce()
+  })
+
+  it('round-trips settings get/set through the per-plugin store', async () => {
+    const services = makeServices()
+    const handle = createHostRequestHandler(all, services)
+    expect((await handle(req('settings.set', { key: 'theme', value: 'dark' }))).ok).toBe(true)
+    const got = await handle(req('settings.get', { key: 'theme' }))
+    expect(got.ok && got.result).toBe('dark')
+  })
+
+  it('rejects an unknown method and maps thrown errors to internal', async () => {
+    const services = makeServices()
+    services.getWorkspaceSnapshot = vi.fn(async () => {
+      throw new Error('boom')
+    }) as unknown as HostServices['getWorkspaceSnapshot']
+    const handle = createHostRequestHandler(all, services)
+    expect(await handle(req('does.not.exist'))).toEqual({
+      reqId: 'r1',
+      ok: false,
+      error: 'unknown_method'
+    })
+    expect(await handle(req('workspace.getSnapshot'))).toEqual({
+      reqId: 'r1',
+      ok: false,
+      error: 'internal'
+    })
+  })
+})

--- a/src/main/plugin/plugin-host-handler.ts
+++ b/src/main/plugin/plugin-host-handler.ts
@@ -1,0 +1,86 @@
+// Builds the capability-gated `onHostRequest` callback that PluginHost hands
+// backend->host bridge requests to. This is where the shared gate, the
+// WorkspaceSnapshot projection, host-command validation, and the per-plugin
+// settings store come together — one place, reused by the desktop main path
+// (and mirrored by the relay for mobile). Pure wiring over injected services,
+// so it unit-tests with fakes + a real settings store.
+
+import {
+  gateBridgeMethod,
+  projectWorkspaceSnapshot,
+  validateHostCommand
+} from '../../shared/plugin/capability-gate'
+import type {
+  BridgeErrorCode,
+  BridgeRequest,
+  BridgeResponse,
+  HostCommand,
+  WorkspaceSnapshot
+} from '../../shared/plugin/api-contract'
+import type { PluginCapability } from '../../shared/plugin/manifest'
+import type { PluginSettingsStore } from './plugin-settings-store'
+
+// The host-side capabilities a plugin's bridge calls resolve against. The
+// workspace snapshot + command invocation are injected so the same handler
+// works in Electron main and (via a parallel impl) the relay.
+export type HostServices = {
+  getWorkspaceSnapshot(): WorkspaceSnapshot | Promise<WorkspaceSnapshot>
+  invokeCommand(name: HostCommand, params: unknown): Promise<unknown>
+  settings: PluginSettingsStore
+}
+
+function ok(reqId: string, result: unknown): BridgeResponse {
+  return { reqId, ok: true, result }
+}
+
+function fail(reqId: string, error: BridgeErrorCode): BridgeResponse {
+  return { reqId, ok: false, error }
+}
+
+export function createHostRequestHandler(
+  declaredCapabilities: readonly PluginCapability[],
+  services: HostServices
+): (request: BridgeRequest) => Promise<BridgeResponse> {
+  return async (request) => {
+    const decision = gateBridgeMethod(declaredCapabilities, request.method)
+    if (!decision.granted) {
+      return fail(request.reqId, decision.error)
+    }
+    try {
+      switch (request.method) {
+        case 'workspace.getSnapshot':
+          return ok(request.reqId, projectWorkspaceSnapshot(await services.getWorkspaceSnapshot()))
+        case 'commands.invokeHost': {
+          const params = (request.params ?? {}) as { name?: unknown; params?: unknown }
+          const check = validateHostCommand(params.name, params.params)
+          if (!check.ok) {
+            return fail(request.reqId, check.error)
+          }
+          return ok(
+            request.reqId,
+            await services.invokeCommand(params.name as HostCommand, params.params)
+          )
+        }
+        case 'settings.get': {
+          const params = (request.params ?? {}) as { key?: unknown }
+          if (typeof params.key !== 'string') {
+            return fail(request.reqId, 'invalid_params')
+          }
+          return ok(request.reqId, services.settings.get(params.key))
+        }
+        case 'settings.set': {
+          const params = (request.params ?? {}) as { key?: unknown; value?: unknown }
+          if (typeof params.key !== 'string') {
+            return fail(request.reqId, 'invalid_params')
+          }
+          const result = services.settings.set(params.key, params.value)
+          return result.ok ? ok(request.reqId, undefined) : fail(request.reqId, 'invalid_params')
+        }
+        default:
+          return fail(request.reqId, 'unknown_method')
+      }
+    } catch {
+      return fail(request.reqId, 'internal')
+    }
+  }
+}

--- a/src/main/plugin/plugin-host-process.test.ts
+++ b/src/main/plugin/plugin-host-process.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PluginHost } from './plugin-host-process'
+import { PluginOutputBuffer } from './plugin-output-buffer'
+import type { BridgeRequest, BridgeResponse } from '../../shared/plugin/api-contract'
+
+// A CJS fixture that speaks the child side of the host protocol, so we fork a
+// real Node child and exercise PluginHost end-to-end without Electron. (The
+// production plugin-host-entry.ts mirrors this protocol.)
+const FIXTURE_ENTRY = `
+process.on('message', (msg) => {
+  if (msg.type === 'activate') {
+    if (process.env.FIXTURE_CRASH === '1') { process.exit(1); return }
+    process.stdout.write('hello from plugin\\n')
+    const reqId = 'x1'
+    const onResp = (m) => {
+      if (m && m.type === 'host-response' && m.response.reqId === reqId) {
+        process.off('message', onResp)
+        process.send({ type: 'ready' })
+      }
+    }
+    process.on('message', onResp)
+    process.send({ type: 'host-request', request: { reqId, method: 'workspace.getSnapshot', params: {} } })
+  } else if (msg.type === 'deactivate') {
+    process.exit(0)
+  }
+})
+`
+
+let tmp: string
+let entryPath: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'plugin-host-'))
+  entryPath = join(tmp, 'fixture-entry.cjs')
+  writeFileSync(entryPath, FIXTURE_ENTRY)
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+function snapshotResponse(request: BridgeRequest): BridgeResponse {
+  return {
+    reqId: request.reqId,
+    ok: true,
+    result: { workspaceName: 't', currentBranch: 'main', isDirty: false, openFileCount: 0 }
+  }
+}
+
+describe('PluginHost (real forked child)', () => {
+  it('starts, handles a backend->host bridge request, captures output, and stops', async () => {
+    const output = new PluginOutputBuffer()
+    const onHostRequest = vi.fn(async (request: BridgeRequest) => snapshotResponse(request))
+    const host = new PluginHost({
+      pluginId: 'acme.a',
+      pluginDir: tmp,
+      mainPath: 'unused',
+      entryPath,
+      output,
+      onHostRequest
+    })
+
+    await host.start()
+    expect(host.isRunning()).toBe(true)
+    expect(onHostRequest).toHaveBeenCalledTimes(1)
+    expect(onHostRequest.mock.calls[0][0].method).toBe('workspace.getSnapshot')
+    expect(output.snapshot().map((l) => l.text)).toContain('hello from plugin')
+
+    await host.stop(1000)
+    expect(host.isRunning()).toBe(false)
+  })
+
+  it('isolates a crashing backend: a crash does not affect another running host', async () => {
+    const output = new PluginOutputBuffer()
+    const onHostRequest = vi.fn(async (request: BridgeRequest) => snapshotResponse(request))
+
+    const healthy = new PluginHost({
+      pluginId: 'acme.healthy',
+      pluginDir: tmp,
+      mainPath: 'unused',
+      entryPath,
+      output: new PluginOutputBuffer(),
+      onHostRequest
+    })
+    await healthy.start()
+
+    const exits: { expected: boolean }[] = []
+    const crasher = new PluginHost({
+      pluginId: 'acme.crasher',
+      pluginDir: tmp,
+      mainPath: 'unused',
+      entryPath,
+      env: { FIXTURE_CRASH: '1' },
+      output,
+      onHostRequest,
+      onExit: (info) => exits.push({ expected: info.expected })
+    })
+
+    await expect(crasher.start()).rejects.toThrow()
+    expect(crasher.isRunning()).toBe(false)
+    expect(exits[0]?.expected).toBe(false) // crash, not a host-initiated stop
+    // The healthy plugin's process is untouched by the crash.
+    expect(healthy.isRunning()).toBe(true)
+
+    await healthy.stop(1000)
+  })
+})

--- a/src/main/plugin/plugin-host-process.ts
+++ b/src/main/plugin/plugin-host-process.ts
@@ -1,0 +1,153 @@
+// Manages one plugin backend running as a forked Node child process (the
+// trusted runtime). Mirrors the repo's existing child-process pattern
+// (`src/main/computer/sidecar-client.ts`): in production the child is forked
+// from Electron's own binary with ELECTRON_RUN_AS_NODE=1 and an entry resolved
+// from app.asar.unpacked — both supplied via `entryPath` + `env` so this class
+// stays Electron-free and unit/integration-testable by forking a plain-node
+// fixture.
+//
+// Responsibilities: spawn, capture stdout/stderr into the output buffer, relay
+// backend->host bridge requests to `onHostRequest` and send responses back,
+// deliver host->backend messages, and stop gracefully (deactivate then kill).
+// Crash/restart policy is owned by PluginSupervisor; this class reports exits.
+
+import { fork, type ChildProcess } from 'node:child_process'
+import type { BridgeRequest, BridgeResponse } from '../../shared/plugin/api-contract'
+import type { HostToPlugin, PluginToHost } from './plugin-host-protocol'
+import type { PluginOutputBuffer } from './plugin-output-buffer'
+
+export type PluginExitInfo = {
+  code: number | null
+  signal: NodeJS.Signals | null
+  // True when the exit followed a host-initiated stop() (not a crash).
+  expected: boolean
+}
+
+export type PluginHostConfig = {
+  pluginId: string
+  pluginDir: string
+  // Resolved path to the plugin's backend `main` module.
+  mainPath: string
+  // Path to the built plugin-host-entry script the child runs.
+  entryPath: string
+  // Extra env for the fork (e.g. { ELECTRON_RUN_AS_NODE: '1' } in production).
+  env?: NodeJS.ProcessEnv
+  output: PluginOutputBuffer
+  // Backend -> host bridge calls (capability-gated by the caller).
+  onHostRequest: (request: BridgeRequest) => Promise<BridgeResponse>
+  // Backend -> UI messages (routed to the plugin's webview by the caller).
+  onUiMessage?: (message: unknown) => void
+  onExit?: (info: PluginExitInfo) => void
+}
+
+export class PluginHost {
+  private child: ChildProcess | null = null
+  private stopping = false
+  private readyPromise: Promise<void> | null = null
+
+  constructor(private readonly config: PluginHostConfig) {}
+
+  // Fork the child and resolve once the backend's activate() completes (ready)
+  // or reject if activation throws. Idempotent while running.
+  start(): Promise<void> {
+    if (this.child) {
+      return this.readyPromise ?? Promise.resolve()
+    }
+    const child = fork(this.config.entryPath, [this.config.pluginId, this.config.mainPath], {
+      cwd: this.config.pluginDir,
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      env: { ...process.env, ...this.config.env }
+    })
+    this.child = child
+    this.stopping = false
+
+    child.stdout?.on('data', (chunk: Buffer) =>
+      this.config.output.append('stdout', chunk.toString())
+    )
+    child.stderr?.on('data', (chunk: Buffer) =>
+      this.config.output.append('stderr', chunk.toString())
+    )
+
+    let resolveReady!: () => void
+    let rejectReady!: (error: Error) => void
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve
+      rejectReady = reject
+    })
+
+    child.on('message', (raw: unknown) => {
+      const message = raw as PluginToHost
+      switch (message.type) {
+        case 'ready':
+          resolveReady()
+          break
+        case 'activate-error':
+          rejectReady(new Error(message.message))
+          break
+        case 'host-request':
+          void this.handleHostRequest(message.request)
+          break
+        case 'ui':
+          this.config.onUiMessage?.(message.message)
+          break
+      }
+    })
+
+    child.on('error', (error: Error) => {
+      this.config.output.append('stderr', `plugin host error: ${error.message}\n`)
+    })
+
+    child.on('exit', (code, signal) => {
+      const expected = this.stopping
+      this.child = null
+      this.config.output.flush()
+      // A crash before ready should reject the start() promise.
+      rejectReady(
+        new Error(`plugin backend exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})`)
+      )
+      this.config.onExit?.({ code, signal, expected })
+    })
+
+    this.send({ type: 'activate' })
+    return this.readyPromise
+  }
+
+  private async handleHostRequest(request: BridgeRequest): Promise<void> {
+    const response = await this.config.onHostRequest(request)
+    this.send({ type: 'host-response', response })
+  }
+
+  send(message: HostToPlugin): void {
+    this.child?.send(message)
+  }
+
+  postUi(message: unknown): void {
+    this.send({ type: 'ui', message })
+  }
+
+  isRunning(): boolean {
+    return this.child !== null
+  }
+
+  // Ask the backend to deactivate, then force-kill if it does not exit within
+  // the grace period.
+  async stop(graceMs = 2000): Promise<void> {
+    const child = this.child
+    if (!child) {
+      return
+    }
+    this.stopping = true
+    this.send({ type: 'deactivate' })
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL')
+        resolve()
+      }, graceMs)
+      child.once('exit', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+    this.child = null
+  }
+}

--- a/src/main/plugin/plugin-host-process.ts
+++ b/src/main/plugin/plugin-host-process.ts
@@ -129,6 +129,19 @@ export class PluginHost {
     return this.child !== null
   }
 
+  // Synchronously signal the child to terminate. Unlike stop(), this returns
+  // immediately without awaiting exit — for process-exit cleanup where there is
+  // no event loop left to await on, so the kill signal must be delivered inline.
+  terminate(): void {
+    const child = this.child
+    if (!child) {
+      return
+    }
+    this.stopping = true
+    child.kill('SIGTERM')
+    this.child = null
+  }
+
   // Ask the backend to deactivate, then force-kill if it does not exit within
   // the grace period.
   async stop(graceMs = 2000): Promise<void> {

--- a/src/main/plugin/plugin-host-protocol.ts
+++ b/src/main/plugin/plugin-host-protocol.ts
@@ -1,0 +1,25 @@
+// IPC message protocol between the plugin-host manager (parent, Electron main)
+// and the forked plugin-host child that runs a plugin's trusted backend. Shared
+// by `plugin-host-process.ts` (parent) and `plugin-host-entry.ts` (child) so the
+// two sides cannot drift.
+
+import type {
+  BridgeRequest,
+  BridgeResponse,
+  LifecycleEvent
+} from '../../shared/plugin/api-contract'
+
+// Parent (host) -> child (plugin backend).
+export type HostToPlugin =
+  | { type: 'activate' }
+  | { type: 'deactivate' }
+  | { type: 'host-response'; response: BridgeResponse }
+  | { type: 'ui'; message: unknown }
+  | { type: 'event'; event: LifecycleEvent; payload?: unknown }
+
+// Child (plugin backend) -> parent (host).
+export type PluginToHost =
+  | { type: 'ready' }
+  | { type: 'activate-error'; message: string }
+  | { type: 'host-request'; request: BridgeRequest }
+  | { type: 'ui'; message: unknown }

--- a/src/main/plugin/plugin-install.test.ts
+++ b/src/main/plugin/plugin-install.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { installFromLocalFolder } from './plugin-install'
+
+function validManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'acme.foo',
+    name: 'Foo',
+    version: '1.0.0',
+    hostApiVersion: '0.1.0',
+    main: 'main.js',
+    contributes: { sidebar: { title: 'Foo', icon: 'Activity', ui: 'index.html' } },
+    capabilities: ['workspace:read'],
+    ...overrides
+  }
+}
+
+let tmp: string
+let pluginsDir: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'plugin-install-'))
+  pluginsDir = join(tmp, 'installed')
+  mkdirSync(pluginsDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+function makeSource(manifest: Record<string, unknown>): string {
+  const src = join(tmp, 'source')
+  mkdirSync(src, { recursive: true })
+  writeFileSync(join(src, 'plugin.json'), JSON.stringify(manifest))
+  writeFileSync(join(src, 'index.html'), '<!doctype html><body>hi</body>')
+  return src
+}
+
+describe('installFromLocalFolder', () => {
+  it('copies a valid plugin into pluginsDir/<id> and reports id+version', () => {
+    const src = makeSource(validManifest())
+    const result = installFromLocalFolder(src, pluginsDir)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.id).toBe('acme.foo')
+      expect(existsSync(join(pluginsDir, 'acme.foo', 'plugin.json'))).toBe(true)
+      expect(existsSync(join(pluginsDir, 'acme.foo', 'index.html'))).toBe(true)
+    }
+  })
+
+  it('writes nothing when the source manifest is invalid', () => {
+    const src = makeSource(validManifest({ capabilities: ['process:exec'] }))
+    const result = installFromLocalFolder(src, pluginsDir)
+    expect(result.ok).toBe(false)
+    expect(readdirSync(pluginsDir)).toEqual([])
+  })
+
+  it('replaces an existing install on reinstall', () => {
+    const src1 = makeSource(validManifest({ version: '1.0.0' }))
+    installFromLocalFolder(src1, pluginsDir)
+    const src2 = makeSource(validManifest({ version: '2.0.0' }))
+    const result = installFromLocalFolder(src2, pluginsDir)
+    expect(result.ok && result.version).toBe('2.0.0')
+  })
+
+  it('fails cleanly for a non-existent source', () => {
+    const result = installFromLocalFolder(join(tmp, 'ghost'), pluginsDir)
+    expect(result.ok).toBe(false)
+  })
+})

--- a/src/main/plugin/plugin-install.ts
+++ b/src/main/plugin/plugin-install.ts
@@ -1,0 +1,34 @@
+// Install a plugin from a user-selected local folder (the v1a dev-loop source).
+// Validates the source manifest BEFORE copying so nothing lands on disk for an
+// invalid bundle. Copying a folder runs no lifecycle scripts — the
+// dependency-install path (with scripts disabled) arrives with the vendored
+// installer in a later unit.
+
+import { cpSync, existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { readManifestRaw } from './plugin-discovery'
+import { validatePluginManifest } from '../../shared/plugin/manifest-validate'
+
+export type InstallResult =
+  | { ok: true; id: string; version: string; dir: string }
+  | { ok: false; errors: string[] }
+
+// Validate the source manifest, then copy the folder into `pluginsDir/<id>/`.
+// A reinstall of the same id replaces the destination atomically-enough
+// (remove then copy). Invalid manifests write nothing.
+export function installFromLocalFolder(sourceDir: string, pluginsDir: string): InstallResult {
+  if (!existsSync(sourceDir)) {
+    return { ok: false, errors: [`source folder does not exist: ${sourceDir}`] }
+  }
+  const validated = validatePluginManifest(readManifestRaw(sourceDir))
+  if (!validated.ok) {
+    return { ok: false, errors: validated.errors }
+  }
+  const { id, version } = validated.manifest
+  const dest = join(pluginsDir, id)
+  if (existsSync(dest)) {
+    rmSync(dest, { recursive: true, force: true })
+  }
+  cpSync(sourceDir, dest, { recursive: true })
+  return { ok: true, id, version, dir: dest }
+}

--- a/src/main/plugin/plugin-install.ts
+++ b/src/main/plugin/plugin-install.ts
@@ -29,6 +29,14 @@ export function installFromLocalFolder(sourceDir: string, pluginsDir: string): I
   if (existsSync(dest)) {
     rmSync(dest, { recursive: true, force: true })
   }
-  cpSync(sourceDir, dest, { recursive: true })
+  try {
+    cpSync(sourceDir, dest, { recursive: true })
+  } catch (error) {
+    // A mid-copy failure (disk full, permissions) already removed the prior
+    // install above — clean up the partial copy so discovery never sees a
+    // half-installed directory, and report the failure instead of throwing.
+    rmSync(dest, { recursive: true, force: true })
+    return { ok: false, errors: [error instanceof Error ? error.message : String(error)] }
+  }
   return { ok: true, id, version, dir: dest }
 }

--- a/src/main/plugin/plugin-manager.test.ts
+++ b/src/main/plugin/plugin-manager.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PluginManager, type PluginManagerConfig } from './plugin-manager'
+
+function validManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'acme.foo',
+    name: 'Foo',
+    version: '1.0.0',
+    hostApiVersion: '0.1.0',
+    main: 'main.js',
+    contributes: { sidebar: { title: 'Foo', icon: 'Activity', ui: 'index.html' } },
+    capabilities: ['workspace:read'],
+    ...overrides
+  }
+}
+
+let tmp: string
+let config: PluginManagerConfig
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'plugin-manager-'))
+  config = { pluginsDir: join(tmp, 'installed'), stateFilePath: join(tmp, 'state.json') }
+  mkdirSync(config.pluginsDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+function makeSource(manifest: Record<string, unknown> = validManifest()): string {
+  const src = join(tmp, `source-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(src, { recursive: true })
+  writeFileSync(join(src, 'plugin.json'), JSON.stringify(manifest))
+  writeFileSync(join(src, 'index.html'), '<!doctype html>')
+  return src
+}
+
+describe('PluginManager', () => {
+  it('installs (inactive), activates, and persists across a new instance', () => {
+    const manager = new PluginManager(config)
+    const install = manager.installLocal(makeSource())
+    expect(install.ok).toBe(true)
+    expect(manager.get('acme.foo')?.active).toBe(false)
+
+    expect(manager.activate('acme.foo')).toBe(true)
+    expect(manager.get('acme.foo')?.active).toBe(true)
+
+    // A fresh manager (simulated restart) reads persisted state.
+    const reopened = new PluginManager(config)
+    expect(reopened.get('acme.foo')?.active).toBe(true)
+    expect(reopened.list()).toHaveLength(1)
+  })
+
+  it('double-activate is a no-op', () => {
+    const manager = new PluginManager(config)
+    manager.installLocal(makeSource())
+    expect(manager.activate('acme.foo')).toBe(true)
+    expect(manager.activate('acme.foo')).toBe(false)
+  })
+
+  it('activate returns false for an unknown plugin', () => {
+    expect(new PluginManager(config).activate('nope')).toBe(false)
+  })
+
+  it('remove deactivates first, then deletes the directory and state entry', () => {
+    const manager = new PluginManager(config)
+    manager.installLocal(makeSource())
+    manager.activate('acme.foo')
+    expect(existsSync(join(config.pluginsDir, 'acme.foo'))).toBe(true)
+
+    expect(manager.remove('acme.foo')).toBe(true)
+    expect(manager.get('acme.foo')).toBeUndefined()
+    expect(existsSync(join(config.pluginsDir, 'acme.foo'))).toBe(false)
+    expect(manager.remove('acme.foo')).toBe(false)
+  })
+
+  it('does not record or write anything for an invalid install', () => {
+    const manager = new PluginManager(config)
+    const result = manager.installLocal(
+      makeSource(validManifest({ capabilities: ['process:exec'] }))
+    )
+    expect(result.ok).toBe(false)
+    expect(manager.list()).toEqual([])
+    expect(readdirSync(config.pluginsDir)).toEqual([])
+  })
+
+  it('discover scans the plugins directory for installed bundles', () => {
+    const manager = new PluginManager(config)
+    manager.installLocal(makeSource())
+    const discovered = manager.discover()
+    expect(discovered.valid.map((p) => p.manifest.id)).toEqual(['acme.foo'])
+  })
+})

--- a/src/main/plugin/plugin-manager.test.ts
+++ b/src/main/plugin/plugin-manager.test.ts
@@ -93,4 +93,16 @@ describe('PluginManager', () => {
     const discovered = manager.discover()
     expect(discovered.valid.map((p) => p.manifest.id)).toEqual(['acme.foo'])
   })
+
+  it('deactivate flips an active plugin inactive, is idempotent, and false for unknown', () => {
+    const manager = new PluginManager(config)
+    manager.installLocal(makeSource())
+    manager.activate('acme.foo')
+    expect(manager.deactivate('acme.foo')).toBe(true)
+    expect(manager.get('acme.foo')?.active).toBe(false)
+    expect(manager.deactivate('acme.foo')).toBe(false) // already inactive
+    expect(manager.deactivate('nope')).toBe(false)
+    // persisted across a simulated restart
+    expect(new PluginManager(config).get('acme.foo')?.active).toBe(false)
+  })
 })

--- a/src/main/plugin/plugin-manager.ts
+++ b/src/main/plugin/plugin-manager.ts
@@ -42,12 +42,20 @@ export class PluginManager {
   // Install from a local folder and record it (inactive) in the store.
   installLocal(sourceDir: string): InstallResult {
     const result = installFromLocalFolder(sourceDir, this.config.pluginsDir)
-    if (result.ok) {
+    if (!result.ok) {
+      return result
+    }
+    try {
       this.store.recordInstalled({
         id: result.id,
         version: result.version,
         source: { kind: 'local', path: sourceDir }
       })
+    } catch (error) {
+      // State write failed — remove the copied dir so we never leave an
+      // installed-but-unrecorded plugin behind.
+      rmSync(join(this.config.pluginsDir, result.id), { recursive: true, force: true })
+      return { ok: false, errors: [error instanceof Error ? error.message : String(error)] }
     }
     return result
   }

--- a/src/main/plugin/plugin-manager.ts
+++ b/src/main/plugin/plugin-manager.ts
@@ -1,0 +1,83 @@
+// The Plugin Manager: host authority for discovery, local install, and
+// persisted install/activation state. Composes the store, discovery, and
+// install modules. Electron-free and fully injectable (pluginsDir +
+// stateFilePath) so it unit-tests against temp dirs.
+//
+// Deferred to later units (kept out so nothing here is half-wired): the
+// `orca-plugin://` asset protocol + webview-partition lifecycle (Electron-
+// coupled), the trusted child-process runtime, and the IPC/relay bridges. Those
+// subscribe to the activation state this manager owns.
+
+import { existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { PluginStore, type PluginStateEntry } from './plugin-store'
+import { discoverPlugins, type DiscoveryResult } from './plugin-discovery'
+import { installFromLocalFolder, type InstallResult } from './plugin-install'
+
+export type PluginManagerConfig = {
+  pluginsDir: string
+  stateFilePath: string
+}
+
+export class PluginManager {
+  private readonly store: PluginStore
+
+  constructor(private readonly config: PluginManagerConfig) {
+    this.store = new PluginStore(config.stateFilePath)
+  }
+
+  list(): PluginStateEntry[] {
+    return this.store.list()
+  }
+
+  get(id: string): PluginStateEntry | undefined {
+    return this.store.get(id)
+  }
+
+  // Scan the plugins directory for installed bundles and their manifest state.
+  discover(): DiscoveryResult {
+    return discoverPlugins(this.config.pluginsDir)
+  }
+
+  // Install from a local folder and record it (inactive) in the store.
+  installLocal(sourceDir: string): InstallResult {
+    const result = installFromLocalFolder(sourceDir, this.config.pluginsDir)
+    if (result.ok) {
+      this.store.recordInstalled({
+        id: result.id,
+        version: result.version,
+        source: { kind: 'local', path: sourceDir }
+      })
+    }
+    return result
+  }
+
+  // Idempotent: returns true only when the plugin existed and flipped to active.
+  activate(id: string): boolean {
+    if (!this.store.get(id)) {
+      return false
+    }
+    return this.store.setActive(id, true)
+  }
+
+  // Idempotent: returns true only when the plugin existed and flipped to inactive.
+  deactivate(id: string): boolean {
+    if (!this.store.get(id)) {
+      return false
+    }
+    return this.store.setActive(id, false)
+  }
+
+  // Deactivate (idempotent) then delete the plugin directory and state entry.
+  remove(id: string): boolean {
+    if (!this.store.get(id)) {
+      return false
+    }
+    this.store.setActive(id, false)
+    const dir = join(this.config.pluginsDir, id)
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+    return this.store.remove(id)
+  }
+}

--- a/src/main/plugin/plugin-manager.ts
+++ b/src/main/plugin/plugin-manager.ts
@@ -10,7 +10,7 @@
 
 import { existsSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
-import { PluginStore, type PluginStateEntry } from './plugin-store'
+import { PluginStore, type PluginInstallSource, type PluginStateEntry } from './plugin-store'
 import { discoverPlugins, type DiscoveryResult } from './plugin-discovery'
 import { installFromLocalFolder, type InstallResult } from './plugin-install'
 
@@ -37,6 +37,12 @@ export class PluginManager {
   // Scan the plugins directory for installed bundles and their manifest state.
   discover(): DiscoveryResult {
     return discoverPlugins(this.config.pluginsDir)
+  }
+
+  // Record a plugin whose files were already placed in pluginsDir by an external
+  // installer (e.g. resolveAndInstall for registry/git/tarball sources).
+  recordInstalled(entry: { id: string; version: string; source: PluginInstallSource }): void {
+    this.store.recordInstalled(entry)
   }
 
   // Install from a local folder and record it (inactive) in the store.

--- a/src/main/plugin/plugin-output-buffer.test.ts
+++ b/src/main/plugin/plugin-output-buffer.test.ts
@@ -2,41 +2,66 @@ import { describe, expect, it } from 'vitest'
 import { PluginOutputBuffer } from './plugin-output-buffer'
 
 describe('PluginOutputBuffer', () => {
-  it('appends lines split on newlines with monotonic seq', () => {
+  it('records complete lines with monotonic seq', () => {
     const buf = new PluginOutputBuffer()
     buf.append('stdout', 'a\nb\n')
-    buf.append('stderr', 'c')
+    buf.append('stderr', 'c\n')
     const snap = buf.snapshot()
     expect(snap.map((l) => l.text)).toEqual(['a', 'b', 'c'])
     expect(snap.map((l) => l.channel)).toEqual(['stdout', 'stdout', 'stderr'])
     expect(snap.map((l) => l.seq)).toEqual([0, 1, 2])
   })
 
-  it('keeps a trailing partial line (no newline) but drops the empty trailer after a newline', () => {
+  it('reassembles a line split across chunk boundaries', () => {
     const buf = new PluginOutputBuffer()
-    buf.append('stdout', 'x\n') // -> ['x'], no '' entry
-    buf.append('stdout', 'y') // -> ['y'] partial
-    expect(buf.snapshot().map((l) => l.text)).toEqual(['x', 'y'])
+    buf.append('stdout', 'hel')
+    buf.append('stdout', 'lo\nworld')
+    // 'hello' is complete; 'world' is still pending (no newline yet)
+    expect(buf.snapshot().map((l) => l.text)).toEqual(['hello'])
+    buf.flush()
+    expect(buf.snapshot().map((l) => l.text)).toEqual(['hello', 'world'])
+  })
+
+  it('strips a trailing CR from CRLF output', () => {
+    const buf = new PluginOutputBuffer()
+    buf.append('stdout', 'line1\r\nline2\r\n')
+    expect(buf.snapshot().map((l) => l.text)).toEqual(['line1', 'line2'])
+  })
+
+  it('caps a newline-less flood to maxLineLength instead of growing unbounded', () => {
+    const buf = new PluginOutputBuffer(1000, 8)
+    buf.append('stdout', 'x'.repeat(50)) // no newline, exceeds maxLineLength=8
+    const snap = buf.snapshot()
+    expect(snap).toHaveLength(1)
+    expect(snap[0].text).toBe('xxxxxxxx') // truncated to 8
+  })
+
+  it('truncates an over-long completed line', () => {
+    const buf = new PluginOutputBuffer(1000, 5)
+    buf.append('stdout', 'abcdefghij\n')
+    expect(buf.snapshot()[0].text).toBe('abcde')
   })
 
   it('drops oldest lines past capacity (ring behavior)', () => {
     const buf = new PluginOutputBuffer(3)
     buf.append('stdout', '1\n2\n3\n4\n5\n')
-    const texts = buf.snapshot().map((l) => l.text)
-    expect(texts).toEqual(['3', '4', '5'])
+    expect(buf.snapshot().map((l) => l.text)).toEqual(['3', '4', '5'])
     expect(buf.size).toBe(3)
   })
 
-  it('ignores empty chunks and supports clear', () => {
+  it('ignores empty chunks; clear resets lines and pending but keeps seq monotonic', () => {
     const buf = new PluginOutputBuffer()
     buf.append('stdout', '')
     expect(buf.size).toBe(0)
     buf.append('stdout', 'a\n')
     buf.clear()
     expect(buf.snapshot()).toEqual([])
+    buf.append('stdout', 'b\n')
+    expect(buf.snapshot()[0].seq).toBe(1) // continues from before clear, not reset to 0
   })
 
-  it('rejects a non-positive capacity', () => {
+  it('rejects non-positive capacity / maxLineLength', () => {
     expect(() => new PluginOutputBuffer(0)).toThrow()
+    expect(() => new PluginOutputBuffer(10, 0)).toThrow()
   })
 })

--- a/src/main/plugin/plugin-output-buffer.test.ts
+++ b/src/main/plugin/plugin-output-buffer.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { PluginOutputBuffer } from './plugin-output-buffer'
+
+describe('PluginOutputBuffer', () => {
+  it('appends lines split on newlines with monotonic seq', () => {
+    const buf = new PluginOutputBuffer()
+    buf.append('stdout', 'a\nb\n')
+    buf.append('stderr', 'c')
+    const snap = buf.snapshot()
+    expect(snap.map((l) => l.text)).toEqual(['a', 'b', 'c'])
+    expect(snap.map((l) => l.channel)).toEqual(['stdout', 'stdout', 'stderr'])
+    expect(snap.map((l) => l.seq)).toEqual([0, 1, 2])
+  })
+
+  it('keeps a trailing partial line (no newline) but drops the empty trailer after a newline', () => {
+    const buf = new PluginOutputBuffer()
+    buf.append('stdout', 'x\n') // -> ['x'], no '' entry
+    buf.append('stdout', 'y') // -> ['y'] partial
+    expect(buf.snapshot().map((l) => l.text)).toEqual(['x', 'y'])
+  })
+
+  it('drops oldest lines past capacity (ring behavior)', () => {
+    const buf = new PluginOutputBuffer(3)
+    buf.append('stdout', '1\n2\n3\n4\n5\n')
+    const texts = buf.snapshot().map((l) => l.text)
+    expect(texts).toEqual(['3', '4', '5'])
+    expect(buf.size).toBe(3)
+  })
+
+  it('ignores empty chunks and supports clear', () => {
+    const buf = new PluginOutputBuffer()
+    buf.append('stdout', '')
+    expect(buf.size).toBe(0)
+    buf.append('stdout', 'a\n')
+    buf.clear()
+    expect(buf.snapshot()).toEqual([])
+  })
+
+  it('rejects a non-positive capacity', () => {
+    expect(() => new PluginOutputBuffer(0)).toThrow()
+  })
+})

--- a/src/main/plugin/plugin-output-buffer.ts
+++ b/src/main/plugin/plugin-output-buffer.ts
@@ -2,6 +2,11 @@
 // captures child-process output here so the management UI's "View Output" can
 // show recent logs without unbounded memory growth (authority in main, the
 // renderer reads a snapshot). Pure + framework-free, so it unit-tests directly.
+//
+// Two bounds keep memory safe regardless of plugin behavior: `capacity` caps
+// the number of retained lines, and `maxLineLength` caps any single line —
+// without the latter, a plugin emitting a multi-MB line with no newline would
+// grow the pending buffer without limit.
 
 export type OutputChannel = 'stdout' | 'stderr'
 
@@ -12,32 +17,67 @@ export type OutputLine = {
 }
 
 const DEFAULT_CAPACITY = 1000
+const DEFAULT_MAX_LINE_LENGTH = 64 * 1024
 
 export class PluginOutputBuffer {
   private lines: OutputLine[] = []
   private nextSeq = 0
+  // Unterminated tail per channel; completed when a newline arrives (or on
+  // flush). Reassembles lines split across chunk boundaries.
+  private pending: Record<OutputChannel, string> = { stdout: '', stderr: '' }
 
-  constructor(private readonly capacity: number = DEFAULT_CAPACITY) {
+  constructor(
+    private readonly capacity: number = DEFAULT_CAPACITY,
+    private readonly maxLineLength: number = DEFAULT_MAX_LINE_LENGTH
+  ) {
     if (capacity <= 0) {
       throw new Error('PluginOutputBuffer capacity must be > 0')
     }
+    if (maxLineLength <= 0) {
+      throw new Error('PluginOutputBuffer maxLineLength must be > 0')
+    }
   }
 
-  // Append a chunk; splits on newlines so each line is an entry. A trailing
-  // partial line (no newline) is kept as its own entry. Oldest lines are
-  // dropped once capacity is exceeded.
+  // Append a chunk. Complete lines (terminated by '\n', possibly preceded by a
+  // chunk-boundary split) are recorded; the trailing partial is held until the
+  // next newline or flush. An over-long pending tail is truncated to bound memory.
   append(channel: OutputChannel, chunk: string): void {
     if (chunk.length === 0) {
       return
     }
-    const parts = chunk.split('\n')
-    // A trailing '' from a chunk ending in '\n' is not a real line.
-    if (parts.length > 1 && parts.at(-1) === '') {
-      parts.pop()
+    let buffer = this.pending[channel] + chunk
+    let newlineIndex = buffer.indexOf('\n')
+    while (newlineIndex !== -1) {
+      this.pushLine(channel, buffer.slice(0, newlineIndex))
+      buffer = buffer.slice(newlineIndex + 1)
+      newlineIndex = buffer.indexOf('\n')
     }
-    for (const text of parts) {
-      this.lines.push({ channel, text, seq: this.nextSeq++ })
+    // Cap the unterminated tail so a newline-less flood can't grow without limit.
+    if (buffer.length > this.maxLineLength) {
+      this.pushLine(channel, buffer.slice(0, this.maxLineLength))
+      buffer = ''
     }
+    this.pending[channel] = buffer
+  }
+
+  // Emit any buffered partial line as a final line. Call when the backend exits
+  // so a last unterminated line is not lost.
+  flush(): void {
+    for (const channel of ['stdout', 'stderr'] as OutputChannel[]) {
+      if (this.pending[channel].length > 0) {
+        this.pushLine(channel, this.pending[channel])
+        this.pending[channel] = ''
+      }
+    }
+  }
+
+  private pushLine(channel: OutputChannel, raw: string): void {
+    // Strip a single trailing CR so CRLF (Windows) output doesn't leave '\r'.
+    let text = raw.endsWith('\r') ? raw.slice(0, -1) : raw
+    if (text.length > this.maxLineLength) {
+      text = text.slice(0, this.maxLineLength)
+    }
+    this.lines.push({ channel, text, seq: this.nextSeq++ })
     if (this.lines.length > this.capacity) {
       this.lines.splice(0, this.lines.length - this.capacity)
     }
@@ -47,8 +87,11 @@ export class PluginOutputBuffer {
     return [...this.lines]
   }
 
+  // Clears retained + pending output. `seq` stays monotonic across clears so a
+  // consumer polling by seq never sees a number it already processed reused.
   clear(): void {
     this.lines = []
+    this.pending = { stdout: '', stderr: '' }
   }
 
   get size(): number {

--- a/src/main/plugin/plugin-output-buffer.ts
+++ b/src/main/plugin/plugin-output-buffer.ts
@@ -1,0 +1,57 @@
+// Bounded ring buffer for a plugin backend's stdout/stderr. The plugin host
+// captures child-process output here so the management UI's "View Output" can
+// show recent logs without unbounded memory growth (authority in main, the
+// renderer reads a snapshot). Pure + framework-free, so it unit-tests directly.
+
+export type OutputChannel = 'stdout' | 'stderr'
+
+export type OutputLine = {
+  channel: OutputChannel
+  text: string
+  seq: number
+}
+
+const DEFAULT_CAPACITY = 1000
+
+export class PluginOutputBuffer {
+  private lines: OutputLine[] = []
+  private nextSeq = 0
+
+  constructor(private readonly capacity: number = DEFAULT_CAPACITY) {
+    if (capacity <= 0) {
+      throw new Error('PluginOutputBuffer capacity must be > 0')
+    }
+  }
+
+  // Append a chunk; splits on newlines so each line is an entry. A trailing
+  // partial line (no newline) is kept as its own entry. Oldest lines are
+  // dropped once capacity is exceeded.
+  append(channel: OutputChannel, chunk: string): void {
+    if (chunk.length === 0) {
+      return
+    }
+    const parts = chunk.split('\n')
+    // A trailing '' from a chunk ending in '\n' is not a real line.
+    if (parts.length > 1 && parts.at(-1) === '') {
+      parts.pop()
+    }
+    for (const text of parts) {
+      this.lines.push({ channel, text, seq: this.nextSeq++ })
+    }
+    if (this.lines.length > this.capacity) {
+      this.lines.splice(0, this.lines.length - this.capacity)
+    }
+  }
+
+  snapshot(): OutputLine[] {
+    return [...this.lines]
+  }
+
+  clear(): void {
+    this.lines = []
+  }
+
+  get size(): number {
+    return this.lines.length
+  }
+}

--- a/src/main/plugin/plugin-remote-provision.test.ts
+++ b/src/main/plugin/plugin-remote-provision.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  provisionToRelay,
+  readPluginBundleFromDisk,
+  shouldProvisionToRelay
+} from './plugin-remote-provision'
+import { verifyPluginBundle } from './plugin-bundle'
+import { provisionPlugin } from '../../relay/plugin-provision'
+import { discoverPlugins } from './plugin-discovery'
+
+const manifest = JSON.stringify({
+  id: 'acme.foo',
+  name: 'Foo',
+  version: '1.0.0',
+  hostApiVersion: '0.1.0',
+  main: 'main.js',
+  contributes: { sidebar: { title: 'Foo', icon: 'Activity', ui: 'index.html' } },
+  capabilities: ['workspace:read']
+})
+
+let tmp: string
+let pluginsDir: string
+
+function installPlugin(): void {
+  const dir = join(pluginsDir, 'acme.foo')
+  mkdirSync(join(dir, 'ui'), { recursive: true })
+  writeFileSync(join(dir, 'plugin.json'), manifest)
+  writeFileSync(join(dir, 'main.js'), 'exports.activate=()=>{}')
+  writeFileSync(join(dir, 'ui', 'index.html'), '<!doctype html><body>hi</body>')
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'remote-provision-'))
+  pluginsDir = join(tmp, 'plugins')
+})
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('readPluginBundleFromDisk', () => {
+  it('packages a plugin dir into a bundle that verifies', () => {
+    installPlugin()
+    const bundle = readPluginBundleFromDisk(pluginsDir, 'acme.foo')
+    expect(bundle.pluginId).toBe('acme.foo')
+    const verified = verifyPluginBundle(bundle)
+    expect(verified.ok).toBe(true)
+    if (verified.ok) {
+      expect(verified.files.map((f) => f.path).sort()).toEqual([
+        'main.js',
+        'plugin.json',
+        'ui/index.html'
+      ])
+    }
+  })
+
+  it('skips symlinks (never packages bytes from outside the dir)', () => {
+    installPlugin()
+    const secret = join(tmp, 'secret.txt')
+    writeFileSync(secret, 'TOP SECRET')
+    symlinkSync(secret, join(pluginsDir, 'acme.foo', 'link.txt'))
+    const bundle = readPluginBundleFromDisk(pluginsDir, 'acme.foo')
+    expect(bundle.files.some((f) => f.path === 'link.txt')).toBe(false)
+  })
+})
+
+describe('desktop-package <-> relay-unpack round-trip', () => {
+  it('a packaged plugin provisions cleanly into a fresh relay plugins dir', () => {
+    installPlugin()
+    const bundle = readPluginBundleFromDisk(pluginsDir, 'acme.foo')
+    const relayDir = join(tmp, 'relay-plugins')
+    const result = provisionPlugin(bundle, {
+      pluginsDir: relayDir,
+      stagingDir: `${relayDir}-staging`
+    })
+    expect(result).toEqual({ ok: true })
+    expect(discoverPlugins(relayDir).valid.map((p) => p.manifest.id)).toEqual(['acme.foo'])
+    expect(readFileSync(join(relayDir, 'acme.foo', 'ui', 'index.html'), 'utf8')).toContain('hi')
+  })
+})
+
+describe('provisionToRelay', () => {
+  it('returns the relay handler result', async () => {
+    const request = (): Promise<unknown> => Promise.resolve({ ok: true })
+    expect(await provisionToRelay(request, { pluginId: 'x', files: [], integrity: 'h' })).toEqual({
+      ok: true,
+      error: undefined
+    })
+  })
+
+  it('synthesizes a failure when the relay returns nothing', async () => {
+    const request = (): Promise<unknown> => Promise.resolve(null)
+    const result = await provisionToRelay(request, { pluginId: 'x', files: [], integrity: 'h' })
+    expect(result).toEqual({ ok: false, error: 'no_response' })
+  })
+})
+
+describe('shouldProvisionToRelay', () => {
+  it('is true for a remote workspace, false otherwise', () => {
+    expect(shouldProvisionToRelay({ isRemote: true })).toBe(true)
+    expect(shouldProvisionToRelay({ isRemote: false })).toBe(false)
+    expect(shouldProvisionToRelay(null)).toBe(false)
+    expect(shouldProvisionToRelay(undefined)).toBe(false)
+  })
+})

--- a/src/main/plugin/plugin-remote-provision.test.ts
+++ b/src/main/plugin/plugin-remote-provision.test.ts
@@ -82,18 +82,29 @@ describe('desktop-package <-> relay-unpack round-trip', () => {
 })
 
 describe('provisionToRelay', () => {
-  it('returns the relay handler result', async () => {
-    const request = (): Promise<unknown> => Promise.resolve({ ok: true })
-    expect(await provisionToRelay(request, { pluginId: 'x', files: [], integrity: 'h' })).toEqual({
-      ok: true,
-      error: undefined
-    })
+  const bundle = { pluginId: 'x', files: [], integrity: 'h' }
+
+  it('forwards the bundle under params.bundle to plugin.provision and returns the result', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const request = (method: string, params?: Record<string, unknown>): Promise<unknown> => {
+      calls.push({ method, params })
+      return Promise.resolve({ ok: true })
+    }
+    expect(await provisionToRelay(request, bundle)).toEqual({ ok: true, error: undefined })
+    expect(calls).toEqual([{ method: 'plugin.provision', params: { bundle } }])
   })
 
   it('synthesizes a failure when the relay returns nothing', async () => {
     const request = (): Promise<unknown> => Promise.resolve(null)
-    const result = await provisionToRelay(request, { pluginId: 'x', files: [], integrity: 'h' })
-    expect(result).toEqual({ ok: false, error: 'no_response' })
+    expect(await provisionToRelay(request, bundle)).toEqual({ ok: false, error: 'no_response' })
+  })
+
+  it('maps a rejected relay request to a typed failure (not a throw)', async () => {
+    const request = (): Promise<unknown> => Promise.reject(new Error('connection closed'))
+    expect(await provisionToRelay(request, bundle)).toEqual({
+      ok: false,
+      error: 'connection closed'
+    })
   })
 })
 

--- a/src/main/plugin/plugin-remote-provision.ts
+++ b/src/main/plugin/plugin-remote-provision.ts
@@ -11,6 +11,8 @@ import { isSafeBundlePath, serializePluginBundle, type PluginBundle } from './pl
 // Recursively read pluginsDir/<pluginId> into a bundle. Symlinks are skipped
 // entirely (never followed, never packaged) so a link can't smuggle bytes from
 // outside the plugin dir; any path that isn't bundle-safe is also dropped.
+// Throws on filesystem errors (missing/unreadable plugin dir) — it reads a
+// known-installed plugin, so the caller treats a throw as "can't provision".
 export function readPluginBundleFromDisk(pluginsDir: string, pluginId: string): PluginBundle {
   const root = join(pluginsDir, pluginId)
   const files: { path: string; dataBase64: string }[] = []
@@ -47,10 +49,17 @@ export async function provisionToRelay(
   request: RelayRequest,
   bundle: PluginBundle
 ): Promise<{ ok: boolean; error?: string }> {
-  const result = (await request('plugin.provision', { bundle })) as
-    | { ok?: boolean; error?: string }
-    | null
-    | undefined
+  let result: { ok?: boolean; error?: string } | null | undefined
+  try {
+    result = (await request('plugin.provision', { bundle })) as
+      | { ok?: boolean; error?: string }
+      | null
+      | undefined
+  } catch (error) {
+    // A dropped/absent relay connection rejects the request; surface it as a
+    // typed failure so callers handle it like any other provision error.
+    return { ok: false, error: error instanceof Error ? error.message : 'request_failed' }
+  }
   if (!result || typeof result.ok !== 'boolean') {
     return { ok: false, error: 'no_response' }
   }

--- a/src/main/plugin/plugin-remote-provision.ts
+++ b/src/main/plugin/plugin-remote-provision.ts
@@ -1,0 +1,66 @@
+// Desktop side of plugin provisioning: read an installed plugin directory off
+// disk into a transferable bundle (U1 codec) and send it to the relay's
+// plugin.provision before activating, when the workspace runs on a remote relay.
+// The disk read + predicate are pure/testable; the live dispatcher wiring is the
+// NEEDS-RUNTIME-VERIFY seam (no remote relay in this environment).
+
+import { lstatSync, readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { isSafeBundlePath, serializePluginBundle, type PluginBundle } from './plugin-bundle'
+
+// Recursively read pluginsDir/<pluginId> into a bundle. Symlinks are skipped
+// entirely (never followed, never packaged) so a link can't smuggle bytes from
+// outside the plugin dir; any path that isn't bundle-safe is also dropped.
+export function readPluginBundleFromDisk(pluginsDir: string, pluginId: string): PluginBundle {
+  const root = join(pluginsDir, pluginId)
+  const files: { path: string; dataBase64: string }[] = []
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      const abs = join(dir, name)
+      const stat = lstatSync(abs)
+      if (stat.isSymbolicLink()) {
+        continue
+      }
+      if (stat.isDirectory()) {
+        walk(abs)
+        continue
+      }
+      if (!stat.isFile()) {
+        continue
+      }
+      const rel = relative(root, abs).split(sep).join('/')
+      if (!isSafeBundlePath(rel)) {
+        continue
+      }
+      files.push({ path: rel, dataBase64: readFileSync(abs).toString('base64') })
+    }
+  }
+  walk(root)
+  return serializePluginBundle(pluginId, files)
+}
+
+export type RelayRequest = (method: string, params?: Record<string, unknown>) => Promise<unknown>
+
+// Send a packaged bundle to the relay. Returns the handler's result (or a
+// synthetic failure if the relay returned nothing).
+export async function provisionToRelay(
+  request: RelayRequest,
+  bundle: PluginBundle
+): Promise<{ ok: boolean; error?: string }> {
+  const result = (await request('plugin.provision', { bundle })) as
+    | { ok?: boolean; error?: string }
+    | null
+    | undefined
+  if (!result || typeof result.ok !== 'boolean') {
+    return { ok: false, error: 'no_response' }
+  }
+  return { ok: result.ok, error: result.error }
+}
+
+// A plugin only needs provisioning when its backend will run on a remote relay;
+// a local (in-process) plugin already has its files in the desktop userData.
+export function shouldProvisionToRelay(
+  workspace: { isRemote?: boolean } | null | undefined
+): boolean {
+  return Boolean(workspace?.isRemote)
+}

--- a/src/main/plugin/plugin-runtime.test.ts
+++ b/src/main/plugin/plugin-runtime.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PluginManager } from './plugin-manager'
+import { PluginRuntime, type PluginHostLike } from './plugin-runtime'
+import type { PluginHostConfig } from './plugin-host-process'
+
+function validManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'acme.foo',
+    name: 'Foo',
+    version: '1.0.0',
+    hostApiVersion: '0.1.0',
+    main: 'main.js',
+    contributes: { sidebar: { title: 'Foo', icon: 'Activity', ui: 'index.html' } },
+    capabilities: ['workspace:read'],
+    ...overrides
+  }
+}
+
+class FakeHost implements PluginHostLike {
+  private up = false
+  readonly config: PluginHostConfig
+  constructor(config: PluginHostConfig) {
+    this.config = config
+  }
+  start(): Promise<void> {
+    this.up = true
+    return Promise.resolve()
+  }
+  stop(): Promise<void> {
+    this.up = false
+    return Promise.resolve()
+  }
+  isRunning(): boolean {
+    return this.up
+  }
+  postUi(): void {}
+  // test helper: simulate a crash
+  crash(): void {
+    this.up = false
+    this.config.onExit?.({ code: 1, signal: null, expected: false })
+  }
+}
+
+let tmp: string
+let pluginsDir: string
+let manager: PluginManager
+let hosts: FakeHost[]
+let scheduled: (() => void)[]
+let runtime: PluginRuntime
+
+function makeSource(): string {
+  const src = join(tmp, `source-${hosts.length}-${scheduled.length}`)
+  mkdirSync(src, { recursive: true })
+  writeFileSync(join(src, 'plugin.json'), JSON.stringify(validManifest()))
+  writeFileSync(join(src, 'main.js'), 'module.exports={activate(){},deactivate(){}}')
+  writeFileSync(join(src, 'index.html'), '<!doctype html>')
+  return src
+}
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'plugin-runtime-'))
+  pluginsDir = join(tmp, 'installed')
+  mkdirSync(pluginsDir, { recursive: true })
+  manager = new PluginManager({ pluginsDir, stateFilePath: join(tmp, 'state.json') })
+  hosts = []
+  scheduled = []
+  runtime = new PluginRuntime({
+    manager,
+    pluginsDir,
+    entryPath: 'unused',
+    getWorkspaceSnapshot: () => ({
+      workspaceName: 'w',
+      currentBranch: 'main',
+      isDirty: false,
+      openFileCount: 0
+    }),
+    invokeCommand: async () => 'ok',
+    hostFactory: (config) => {
+      const host = new FakeHost(config)
+      hosts.push(host)
+      return host
+    },
+    scheduleRestart: (_ms, run) => {
+      scheduled.push(run)
+    }
+  })
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('PluginRuntime', () => {
+  it('activates an installed plugin: spawns a host and marks it active', async () => {
+    manager.installLocal(makeSource())
+    const result = await runtime.activate('acme.foo')
+    expect(result.ok).toBe(true)
+    expect(runtime.isRunning('acme.foo')).toBe(true)
+    expect(manager.get('acme.foo')?.active).toBe(true)
+    expect(hosts).toHaveLength(1)
+  })
+
+  it('fails to activate a plugin with no valid manifest on disk', async () => {
+    const result = await runtime.activate('ghost')
+    expect(result.ok).toBe(false)
+    expect(runtime.isRunning('ghost')).toBe(false)
+  })
+
+  it('restarts a crashed plugin via the scheduled backoff', async () => {
+    manager.installLocal(makeSource())
+    await runtime.activate('acme.foo')
+    expect(hosts).toHaveLength(1)
+
+    hosts[0].crash()
+    expect(runtime.isRunning('acme.foo')).toBe(false)
+    expect(scheduled).toHaveLength(1)
+
+    scheduled[0]() // fire the backoff restart
+    await flush()
+    expect(hosts).toHaveLength(2) // a fresh host was spawned
+    expect(runtime.isRunning('acme.foo')).toBe(true)
+  })
+
+  it('deactivate stops the host and clears active state (no restart)', async () => {
+    manager.installLocal(makeSource())
+    await runtime.activate('acme.foo')
+    await runtime.deactivate('acme.foo')
+    expect(runtime.isRunning('acme.foo')).toBe(false)
+    expect(manager.get('acme.foo')?.active).toBe(false)
+    expect(scheduled).toHaveLength(0)
+  })
+
+  it('does not restart after a crash if the plugin was deactivated', async () => {
+    manager.installLocal(makeSource())
+    await runtime.activate('acme.foo')
+    hosts[0].crash()
+    manager.deactivate('acme.foo') // user deactivates before backoff fires
+    scheduled[0]()
+    await flush()
+    expect(hosts).toHaveLength(1) // no respawn
+  })
+})

--- a/src/main/plugin/plugin-runtime.test.ts
+++ b/src/main/plugin/plugin-runtime.test.ts
@@ -19,13 +19,21 @@ function validManifest(overrides: Record<string, unknown> = {}): Record<string, 
   }
 }
 
+// When true, the next FakeHost.start() rejects — models an activate-error /
+// crash-before-ready so the runtime's failed-start cleanup can be asserted.
+let failStart = false
+
 class FakeHost implements PluginHostLike {
   private up = false
+  terminated = false
   readonly config: PluginHostConfig
   constructor(config: PluginHostConfig) {
     this.config = config
   }
   start(): Promise<void> {
+    if (failStart) {
+      return Promise.reject(new Error('start failed'))
+    }
     this.up = true
     return Promise.resolve()
   }
@@ -39,6 +47,7 @@ class FakeHost implements PluginHostLike {
   postUi(): void {}
   terminate(): void {
     this.up = false
+    this.terminated = true
   }
   // test helper: simulate a crash
   crash(): void {
@@ -72,6 +81,7 @@ beforeEach(() => {
   manager = new PluginManager({ pluginsDir, stateFilePath: join(tmp, 'state.json') })
   hosts = []
   scheduled = []
+  failStart = false
   runtime = new PluginRuntime({
     manager,
     pluginsDir,
@@ -146,5 +156,33 @@ describe('PluginRuntime', () => {
     scheduled[0]()
     await flush()
     expect(hosts).toHaveLength(1) // no respawn
+  })
+
+  it('stops restarting after maxRestarts crashes and marks the plugin errored', async () => {
+    manager.installLocal(makeSource())
+    await runtime.activate('acme.foo')
+    // Default maxRestarts is 3: crash + restart three times; the fourth crash
+    // must error out rather than restart (supervisor-driven restarts keep the
+    // crash count instead of resetting it on every activate()).
+    for (let i = 0; i < 3; i++) {
+      hosts.at(-1)!.crash()
+      expect(scheduled).toHaveLength(i + 1)
+      scheduled[i]()
+      await flush()
+    }
+    expect(hosts).toHaveLength(4) // initial + 3 restarts
+    hosts.at(-1)!.crash() // fourth crash
+    expect(runtime.state('acme.foo')).toBe('errored')
+    expect(scheduled).toHaveLength(3) // no fourth restart was scheduled
+  })
+
+  it('terminates the host and reports failure when start() rejects (no orphan)', async () => {
+    manager.installLocal(makeSource())
+    failStart = true
+    const result = await runtime.activate('acme.foo')
+    expect(result.ok).toBe(false)
+    expect(runtime.isRunning('acme.foo')).toBe(false)
+    expect(hosts).toHaveLength(1)
+    expect(hosts[0].terminated).toBe(true) // failed-start child was killed, not orphaned
   })
 })

--- a/src/main/plugin/plugin-runtime.test.ts
+++ b/src/main/plugin/plugin-runtime.test.ts
@@ -37,6 +37,9 @@ class FakeHost implements PluginHostLike {
     return this.up
   }
   postUi(): void {}
+  terminate(): void {
+    this.up = false
+  }
   // test helper: simulate a crash
   crash(): void {
     this.up = false

--- a/src/main/plugin/plugin-runtime.ts
+++ b/src/main/plugin/plugin-runtime.ts
@@ -1,0 +1,151 @@
+// Host-side orchestrator that actually runs plugins: ties the manager, the
+// per-plugin child process (PluginHost), the capability-gated host handler, the
+// per-plugin settings store, output capture, and the crash/restart supervisor
+// together. The PluginHost factory and the restart timer are injectable so the
+// orchestration is unit-testable without forking real processes.
+
+import { join } from 'node:path'
+import type { PluginManager } from './plugin-manager'
+import { PluginHost, type PluginHostConfig } from './plugin-host-process'
+import { PluginSupervisor } from './plugin-supervision'
+import { PluginOutputBuffer, type OutputLine } from './plugin-output-buffer'
+import { PluginSettingsStore } from './plugin-settings-store'
+import { createHostRequestHandler } from './plugin-host-handler'
+import { readManifestRaw } from './plugin-discovery'
+import { validatePluginManifest } from '../../shared/plugin/manifest-validate'
+import type { HostCommand, WorkspaceSnapshot } from '../../shared/plugin/api-contract'
+
+// The subset of PluginHost the runtime depends on (injectable for tests).
+export type PluginHostLike = {
+  start(): Promise<void>
+  stop(graceMs?: number): Promise<void>
+  isRunning(): boolean
+  postUi(message: unknown): void
+}
+
+export type PluginHostFactory = (config: PluginHostConfig) => PluginHostLike
+
+export type PluginRuntimeConfig = {
+  manager: PluginManager
+  pluginsDir: string
+  // Path to the built plugin-host-entry script the child runs.
+  entryPath: string
+  // Extra fork env (e.g. { ELECTRON_RUN_AS_NODE: '1' }) in production.
+  forkEnv?: NodeJS.ProcessEnv
+  getWorkspaceSnapshot: () => WorkspaceSnapshot | Promise<WorkspaceSnapshot>
+  invokeCommand: (name: HostCommand, params: unknown) => Promise<unknown>
+  onUiMessage?: (pluginId: string, message: unknown) => void
+  // Injectable for tests.
+  hostFactory?: PluginHostFactory
+  scheduleRestart?: (ms: number, run: () => void) => void
+}
+
+export type ActivateResult = { ok: true } | { ok: false; error: string }
+
+type Running = { host: PluginHostLike; output: PluginOutputBuffer }
+
+export class PluginRuntime {
+  private readonly running = new Map<string, Running>()
+  private readonly supervisor = new PluginSupervisor()
+  private readonly factory: PluginHostFactory
+  private readonly schedule: (ms: number, run: () => void) => void
+
+  constructor(private readonly config: PluginRuntimeConfig) {
+    this.factory = config.hostFactory ?? ((c) => new PluginHost(c))
+    this.schedule =
+      config.scheduleRestart ??
+      ((ms, run) => {
+        setTimeout(run, ms).unref?.()
+      })
+  }
+
+  isRunning(pluginId: string): boolean {
+    return this.running.get(pluginId)?.host.isRunning() ?? false
+  }
+
+  state(pluginId: string): 'inactive' | 'running' | 'errored' {
+    return this.supervisor.getState(pluginId)
+  }
+
+  getOutput(pluginId: string): OutputLine[] {
+    return this.running.get(pluginId)?.output.snapshot() ?? []
+  }
+
+  // Load the plugin's manifest, spawn its backend wired to the gated handler,
+  // and mark it active. Idempotent while running.
+  async activate(pluginId: string): Promise<ActivateResult> {
+    if (this.running.has(pluginId)) {
+      return { ok: true }
+    }
+    const dir = join(this.config.pluginsDir, pluginId)
+    const validated = validatePluginManifest(readManifestRaw(dir))
+    if (!validated.ok) {
+      return { ok: false, error: `invalid manifest: ${validated.errors.join('; ')}` }
+    }
+    const manifest = validated.manifest
+    const output = new PluginOutputBuffer()
+    const handler = createHostRequestHandler(manifest.capabilities, {
+      getWorkspaceSnapshot: this.config.getWorkspaceSnapshot,
+      invokeCommand: this.config.invokeCommand,
+      settings: new PluginSettingsStore(this.config.pluginsDir, pluginId, manifest.settingsSchema)
+    })
+    const host = this.factory({
+      pluginId,
+      pluginDir: dir,
+      mainPath: join(dir, manifest.main),
+      entryPath: this.config.entryPath,
+      env: this.config.forkEnv,
+      output,
+      onHostRequest: handler,
+      onUiMessage: (message) => this.config.onUiMessage?.(pluginId, message),
+      onExit: (info) => this.handleExit(pluginId, info.expected)
+    })
+    this.running.set(pluginId, { host, output })
+    this.supervisor.markRunning(pluginId, { resetRestarts: true })
+    try {
+      await host.start()
+    } catch (error) {
+      this.running.delete(pluginId)
+      this.handleExit(pluginId, false)
+      return { ok: false, error: error instanceof Error ? error.message : String(error) }
+    }
+    this.config.manager.activate(pluginId)
+    return { ok: true }
+  }
+
+  async deactivate(pluginId: string): Promise<void> {
+    const entry = this.running.get(pluginId)
+    this.running.delete(pluginId)
+    this.supervisor.reset(pluginId)
+    if (entry) {
+      await entry.host.stop()
+    }
+    this.config.manager.deactivate(pluginId)
+  }
+
+  postUi(pluginId: string, message: unknown): void {
+    this.running.get(pluginId)?.host.postUi(message)
+  }
+
+  async stopAll(): Promise<void> {
+    await Promise.all([...this.running.keys()].map((id) => this.deactivate(id)))
+  }
+
+  // A backend exited. A host-initiated stop is expected (no restart); a crash
+  // consults the supervisor for a bounded backoff restart, else marks Errored.
+  private handleExit(pluginId: string, expected: boolean): void {
+    if (expected) {
+      return
+    }
+    this.running.delete(pluginId)
+    const decision = this.supervisor.markExited(pluginId, { crashed: true })
+    if (decision.restart) {
+      this.schedule(decision.delayMs, () => {
+        // Only restart if it was not deactivated in the meantime.
+        if (this.config.manager.get(pluginId)?.active && !this.running.has(pluginId)) {
+          void this.activate(pluginId)
+        }
+      })
+    }
+  }
+}

--- a/src/main/plugin/plugin-runtime.ts
+++ b/src/main/plugin/plugin-runtime.ts
@@ -21,6 +21,8 @@ export type PluginHostLike = {
   stop(graceMs?: number): Promise<void>
   isRunning(): boolean
   postUi(message: unknown): void
+  // Synchronous best-effort kill for process-exit cleanup (no await available).
+  terminate(): void
 }
 
 export type PluginHostFactory = (config: PluginHostConfig) => PluginHostLike
@@ -129,6 +131,16 @@ export class PluginRuntime {
 
   async stopAll(): Promise<void> {
     await Promise.all([...this.running.keys()].map((id) => this.deactivate(id)))
+  }
+
+  // Synchronously terminate every running backend. For process-exit cleanup
+  // where there is no event loop left to await stopAll() — the SIGTERM must be
+  // delivered inline or the children are orphaned.
+  stopAllSync(): void {
+    for (const [, entry] of this.running) {
+      entry.host.terminate()
+    }
+    this.running.clear()
   }
 
   // A backend exited. A host-initiated stop is expected (no restart); a crash

--- a/src/main/plugin/plugin-runtime.ts
+++ b/src/main/plugin/plugin-runtime.ts
@@ -74,8 +74,10 @@ export class PluginRuntime {
   }
 
   // Load the plugin's manifest, spawn its backend wired to the gated handler,
-  // and mark it active. Idempotent while running.
-  async activate(pluginId: string): Promise<ActivateResult> {
+  // and mark it active. Idempotent while running. A fresh (user) activation
+  // resets the crash budget; a supervisor-driven restart (isRestart) keeps the
+  // accumulating count so the maxRestarts cap is actually reached.
+  async activate(pluginId: string, options: { isRestart?: boolean } = {}): Promise<ActivateResult> {
     if (this.running.has(pluginId)) {
       return { ok: true }
     }
@@ -103,10 +105,15 @@ export class PluginRuntime {
       onExit: (info) => this.handleExit(pluginId, info.expected)
     })
     this.running.set(pluginId, { host, output })
-    this.supervisor.markRunning(pluginId, { resetRestarts: true })
+    this.supervisor.markRunning(pluginId, { resetRestarts: !options.isRestart })
     try {
       await host.start()
     } catch (error) {
+      // A failed start() can leave the forked child alive (it reported
+      // activate-error without exiting); terminate it so it isn't orphaned.
+      // terminate() marks the stop expected, so the child's exit event won't
+      // double-drive the supervisor — the handleExit below records the failure.
+      host.terminate()
       this.running.delete(pluginId)
       this.handleExit(pluginId, false)
       return { ok: false, error: error instanceof Error ? error.message : String(error) }
@@ -155,7 +162,7 @@ export class PluginRuntime {
       this.schedule(decision.delayMs, () => {
         // Only restart if it was not deactivated in the meantime.
         if (this.config.manager.get(pluginId)?.active && !this.running.has(pluginId)) {
-          void this.activate(pluginId)
+          void this.activate(pluginId, { isRestart: true })
         }
       })
     }

--- a/src/main/plugin/plugin-settings-store.test.ts
+++ b/src/main/plugin/plugin-settings-store.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { isSafePluginId, PluginSettingsStore, pluginSettingsPath } from './plugin-settings-store'
 
 const SCHEMA = {
@@ -75,5 +75,13 @@ describe('PluginSettingsStore', () => {
     store.delete('a')
     expect(store.get('a')).toBeUndefined()
     expect(existsSync(pluginSettingsPath(pluginsDir, 'acme.foo'))).toBe(true)
+  })
+
+  it('recovers to empty when the settings file is corrupt', () => {
+    const path = pluginSettingsPath(pluginsDir, 'acme.foo')
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, 'not json{{{')
+    const store = new PluginSettingsStore(pluginsDir, 'acme.foo')
+    expect(store.getAll()).toEqual({})
   })
 })

--- a/src/main/plugin/plugin-settings-store.test.ts
+++ b/src/main/plugin/plugin-settings-store.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { isSafePluginId, PluginSettingsStore, pluginSettingsPath } from './plugin-settings-store'
+
+const SCHEMA = {
+  type: 'object',
+  properties: { count: { type: 'integer' } },
+  additionalProperties: false
+} as Record<string, unknown>
+
+let pluginsDir: string
+
+beforeEach(() => {
+  pluginsDir = mkdtempSync(join(tmpdir(), 'plugin-settings-'))
+})
+
+afterEach(() => {
+  rmSync(pluginsDir, { recursive: true, force: true })
+})
+
+describe('isSafePluginId / pluginSettingsPath', () => {
+  it('accepts dotted ids and rejects traversal/separators', () => {
+    expect(isSafePluginId('acme.foo')).toBe(true)
+    expect(isSafePluginId('../evil')).toBe(false)
+    expect(isSafePluginId('a/b')).toBe(false)
+    expect(isSafePluginId('..')).toBe(false)
+  })
+
+  it('throws for an unsafe id rather than escaping the directory', () => {
+    expect(() => pluginSettingsPath(pluginsDir, '../other')).toThrow()
+  })
+
+  it('isolates each plugin in its own file', () => {
+    const a = pluginSettingsPath(pluginsDir, 'acme.a')
+    const b = pluginSettingsPath(pluginsDir, 'acme.b')
+    expect(a).not.toBe(b)
+    expect(a).toContain(join('acme.a', 'settings.json'))
+  })
+})
+
+describe('PluginSettingsStore', () => {
+  it('round-trips and persists settings per plugin', () => {
+    const store = new PluginSettingsStore(pluginsDir, 'acme.foo')
+    expect(store.set('theme', 'dark')).toEqual({ ok: true })
+    expect(store.get('theme')).toBe('dark')
+
+    const reopened = new PluginSettingsStore(pluginsDir, 'acme.foo')
+    expect(reopened.get('theme')).toBe('dark')
+    expect(reopened.getAll()).toEqual({ theme: 'dark' })
+  })
+
+  it('does not leak settings between plugins', () => {
+    new PluginSettingsStore(pluginsDir, 'acme.a').set('secret', 'A')
+    const b = new PluginSettingsStore(pluginsDir, 'acme.b')
+    expect(b.get('secret')).toBeUndefined()
+  })
+
+  it('rejects a schema-invalid write and leaves the file untouched', () => {
+    const store = new PluginSettingsStore(pluginsDir, 'acme.foo', SCHEMA)
+    expect(store.set('count', 1)).toEqual({ ok: true })
+
+    const bad = store.set('count', 'lots')
+    expect(bad.ok).toBe(false)
+    expect(store.get('count')).toBe(1) // unchanged
+
+    const extra = store.set('nope', true)
+    expect(extra.ok).toBe(false)
+  })
+
+  it('deletes a key', () => {
+    const store = new PluginSettingsStore(pluginsDir, 'acme.foo')
+    store.set('a', 1)
+    store.delete('a')
+    expect(store.get('a')).toBeUndefined()
+    expect(existsSync(pluginSettingsPath(pluginsDir, 'acme.foo'))).toBe(true)
+  })
+})

--- a/src/main/plugin/plugin-settings-store.ts
+++ b/src/main/plugin/plugin-settings-store.ts
@@ -1,0 +1,102 @@
+// Per-plugin settings persistence (U13). Each plugin's settings live in their
+// OWN file — `<pluginsDir>/<id>/settings.json` — not a shared namespaced blob,
+// so one plugin's settings path can never resolve into another's. Writes are
+// validated against the manifest's `settingsSchema` when present.
+//
+// Cross-plugin READ of another plugin's file is possible by design (plugins are
+// trusted, with full Node access) — documented in the security notes; users
+// should not store cross-sensitive secrets in plugin settings.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { validateAgainstSchema, type SchemaValidation } from '../../shared/plugin/settings-schema'
+
+// A plugin id must be a single safe path segment (no separators / traversal) so
+// it cannot escape its own directory. Plugin ids look like `acme.foo`.
+export function isSafePluginId(id: string): boolean {
+  return (
+    id.length > 0 &&
+    !id.includes('/') &&
+    !id.includes('\\') &&
+    id !== '.' &&
+    id !== '..' &&
+    !id.includes('..')
+  )
+}
+
+export function pluginSettingsPath(pluginsDir: string, id: string): string {
+  if (!isSafePluginId(id)) {
+    throw new Error(`unsafe plugin id: ${id}`)
+  }
+  return join(pluginsDir, id, 'settings.json')
+}
+
+export type SettingsWriteResult = { ok: true } | { ok: false; errors: string[] }
+
+export class PluginSettingsStore {
+  private readonly filePath: string
+
+  constructor(
+    pluginsDir: string,
+    pluginId: string,
+    private readonly settingsSchema?: Record<string, unknown>
+  ) {
+    this.filePath = pluginSettingsPath(pluginsDir, pluginId)
+  }
+
+  private read(): Record<string, unknown> {
+    try {
+      if (!existsSync(this.filePath)) {
+        return {}
+      }
+      const parsed: unknown = JSON.parse(readFileSync(this.filePath, 'utf8'))
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>
+      }
+    } catch {
+      // Corrupt settings reset to empty rather than crashing the plugin host.
+    }
+    return {}
+  }
+
+  private write(settings: Record<string, unknown>): void {
+    mkdirSync(dirname(this.filePath), { recursive: true })
+    writeFileSync(this.filePath, JSON.stringify(settings, null, 2), 'utf8')
+  }
+
+  getAll(): Record<string, unknown> {
+    return this.read()
+  }
+
+  get<T = unknown>(key: string): T | undefined {
+    return this.read()[key] as T | undefined
+  }
+
+  // Apply the change, validate the RESULTING object against the schema (when
+  // present), and persist only if valid. Invalid writes leave the file untouched.
+  set(key: string, value: unknown): SettingsWriteResult {
+    const next = { ...this.read(), [key]: value }
+    const validation = this.validate(next)
+    if (!validation.ok) {
+      return validation
+    }
+    this.write(next)
+    return { ok: true }
+  }
+
+  delete(key: string): void {
+    const current = this.read()
+    if (!(key in current)) {
+      return
+    }
+    delete current[key]
+    this.write(current)
+  }
+
+  private validate(settings: Record<string, unknown>): SchemaValidation {
+    if (!this.settingsSchema) {
+      return { ok: true }
+    }
+    return validateAgainstSchema(settings, this.settingsSchema)
+  }
+}

--- a/src/main/plugin/plugin-settings-store.ts
+++ b/src/main/plugin/plugin-settings-store.ts
@@ -7,22 +7,14 @@
 // trusted, with full Node access) — documented in the security notes; users
 // should not store cross-sensitive secrets in plugin settings.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { validateAgainstSchema, type SchemaValidation } from '../../shared/plugin/settings-schema'
+import { isSafePluginId } from '../../shared/plugin/manifest'
 
-// A plugin id must be a single safe path segment (no separators / traversal) so
-// it cannot escape its own directory. Plugin ids look like `acme.foo`.
-export function isSafePluginId(id: string): boolean {
-  return (
-    id.length > 0 &&
-    !id.includes('/') &&
-    !id.includes('\\') &&
-    id !== '.' &&
-    id !== '..' &&
-    !id.includes('..')
-  )
-}
+// Re-exported for callers that path-build by id; the canonical safe-id check
+// lives at the manifest trust boundary in src/shared/plugin/manifest.ts.
+export { isSafePluginId }
 
 export function pluginSettingsPath(pluginsDir: string, id: string): string {
   if (!isSafePluginId(id)) {
@@ -59,9 +51,13 @@ export class PluginSettingsStore {
     return {}
   }
 
+  // Atomic write: stage to a temp file then rename, so a crash mid-write never
+  // truncates the live settings file (which read() would then silently reset).
   private write(settings: Record<string, unknown>): void {
     mkdirSync(dirname(this.filePath), { recursive: true })
-    writeFileSync(this.filePath, JSON.stringify(settings, null, 2), 'utf8')
+    const tmp = `${this.filePath}.tmp`
+    writeFileSync(tmp, JSON.stringify(settings, null, 2), 'utf8')
+    renameSync(tmp, this.filePath)
   }
 
   getAll(): Record<string, unknown> {
@@ -80,7 +76,13 @@ export class PluginSettingsStore {
     if (!validation.ok) {
       return validation
     }
-    this.write(next)
+    try {
+      this.write(next)
+    } catch (error) {
+      // Surface the disk error to the caller instead of throwing through the
+      // host IPC handler; the live file is intact (atomic write).
+      return { ok: false, errors: [error instanceof Error ? error.message : String(error)] }
+    }
     return { ok: true }
   }
 

--- a/src/main/plugin/plugin-store.test.ts
+++ b/src/main/plugin/plugin-store.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PluginStore, type PluginInstallSource } from './plugin-store'
+
+const SOURCE: PluginInstallSource = { kind: 'local', path: '/tmp/src' }
+
+let tmp: string
+let stateFile: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'plugin-store-'))
+  stateFile = join(tmp, 'nested', 'plugins-state.json')
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('PluginStore', () => {
+  it('records an installed plugin as inactive and persists it', () => {
+    const store = new PluginStore(stateFile)
+    store.recordInstalled({ id: 'acme.foo', version: '1.0.0', source: SOURCE })
+
+    expect(existsSync(stateFile)).toBe(true)
+    const reloaded = new PluginStore(stateFile)
+    const entry = reloaded.get('acme.foo')
+    expect(entry?.active).toBe(false)
+    expect(entry?.version).toBe('1.0.0')
+  })
+
+  it('setActive is idempotent and reports only real changes', () => {
+    const store = new PluginStore(stateFile)
+    store.recordInstalled({ id: 'acme.foo', version: '1.0.0', source: SOURCE })
+
+    expect(store.setActive('acme.foo', true)).toBe(true)
+    expect(store.setActive('acme.foo', true)).toBe(false) // no-op
+    expect(store.get('acme.foo')?.active).toBe(true)
+    expect(store.setActive('missing', true)).toBe(false)
+  })
+
+  it('preserves the active flag across a reinstall', () => {
+    const store = new PluginStore(stateFile)
+    store.recordInstalled({ id: 'acme.foo', version: '1.0.0', source: SOURCE })
+    store.setActive('acme.foo', true)
+    store.recordInstalled({ id: 'acme.foo', version: '1.1.0', source: SOURCE })
+
+    const entry = store.get('acme.foo')
+    expect(entry?.active).toBe(true)
+    expect(entry?.version).toBe('1.1.0')
+  })
+
+  it('removes an entry', () => {
+    const store = new PluginStore(stateFile)
+    store.recordInstalled({ id: 'acme.foo', version: '1.0.0', source: SOURCE })
+    expect(store.remove('acme.foo')).toBe(true)
+    expect(store.remove('acme.foo')).toBe(false)
+    expect(new PluginStore(stateFile).list()).toEqual([])
+  })
+
+  it('resets to empty state when the state file is corrupt', () => {
+    mkdirSync(join(tmp, 'nested'), { recursive: true })
+    writeFileSync(stateFile, 'not json{{{')
+    const store = new PluginStore(stateFile)
+    expect(store.list()).toEqual([])
+  })
+
+  it('writes valid JSON to disk', () => {
+    const store = new PluginStore(stateFile)
+    store.recordInstalled({ id: 'acme.foo', version: '1.0.0', source: SOURCE })
+    expect(() => JSON.parse(readFileSync(stateFile, 'utf8'))).not.toThrow()
+  })
+})

--- a/src/main/plugin/plugin-store.ts
+++ b/src/main/plugin/plugin-store.ts
@@ -6,7 +6,7 @@
 // bearing stores (plugin settings that may hold tokens) use the secure-file /
 // Windows-ACL path in a later unit.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 
 // Where a plugin came from. v1a ships local-folder install; registry/git/
@@ -23,7 +23,26 @@ export type PluginStateEntry = {
 
 type PersistedState = { version: 1; plugins: Record<string, PluginStateEntry> }
 
-const EMPTY_STATE: PersistedState = { version: 1, plugins: {} }
+// Fresh empty state with a null-prototype plugins map so a plugin id used as a
+// key can never reach Object.prototype (prototype-pollution defense-in-depth;
+// ids are also validated safe at the manifest boundary).
+function emptyState(): PersistedState {
+  return { version: 1, plugins: Object.create(null) as Record<string, PluginStateEntry> }
+}
+
+// A persisted entry must carry the fields list()/get() consumers rely on; a
+// hand-edited or partial state file is filtered rather than trusted wholesale.
+function isValidEntry(value: unknown): value is PluginStateEntry {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const entry = value as Record<string, unknown>
+  return (
+    typeof entry.id === 'string' &&
+    typeof entry.version === 'string' &&
+    typeof entry.active === 'boolean'
+  )
+}
 
 export class PluginStore {
   private state: PersistedState
@@ -35,25 +54,34 @@ export class PluginStore {
   private load(): PersistedState {
     try {
       if (!existsSync(this.stateFilePath)) {
-        return { version: 1, plugins: {} }
+        return emptyState()
       }
       const parsed: unknown = JSON.parse(readFileSync(this.stateFilePath, 'utf8'))
-      if (
-        parsed &&
-        typeof parsed === 'object' &&
-        typeof (parsed as PersistedState).plugins === 'object'
-      ) {
-        return { version: 1, plugins: { ...(parsed as PersistedState).plugins } }
+      const parsedPlugins =
+        parsed && typeof parsed === 'object' ? (parsed as PersistedState).plugins : undefined
+      if (parsedPlugins && typeof parsedPlugins === 'object') {
+        const state = emptyState()
+        // Copy only well-formed entries into the null-prototype map.
+        for (const [id, entry] of Object.entries(parsedPlugins)) {
+          if (isValidEntry(entry)) {
+            state.plugins[id] = entry
+          }
+        }
+        return state
       }
     } catch {
       // Corrupt/unreadable state resets to empty rather than crashing the host.
     }
-    return { version: 1, plugins: {} }
+    return emptyState()
   }
 
+  // Atomic write: stage to a temp file then rename, so a crash mid-write never
+  // truncates the live state file (which load() would then silently reset).
   private persist(): void {
     mkdirSync(dirname(this.stateFilePath), { recursive: true })
-    writeFileSync(this.stateFilePath, JSON.stringify(this.state, null, 2), 'utf8')
+    const tmp = `${this.stateFilePath}.tmp`
+    writeFileSync(tmp, JSON.stringify(this.state, null, 2), 'utf8')
+    renameSync(tmp, this.stateFilePath)
   }
 
   list(): PluginStateEntry[] {
@@ -78,7 +106,17 @@ export class PluginStore {
       installedAt: prior?.installedAt ?? entry.installedAt ?? new Date().toISOString()
     }
     this.state.plugins[entry.id] = stored
-    this.persist()
+    try {
+      this.persist()
+    } catch (error) {
+      // Roll back the in-memory mutation so memory and disk never diverge.
+      if (prior) {
+        this.state.plugins[entry.id] = prior
+      } else {
+        delete this.state.plugins[entry.id]
+      }
+      throw error
+    }
     return stored
   }
 
@@ -88,19 +126,29 @@ export class PluginStore {
     if (!entry || entry.active === active) {
       return false
     }
+    const previous = entry.active
     entry.active = active
-    this.persist()
+    try {
+      this.persist()
+    } catch {
+      entry.active = previous
+      return false
+    }
     return true
   }
 
   remove(id: string): boolean {
-    if (!this.state.plugins[id]) {
+    const removed = this.state.plugins[id]
+    if (!removed) {
       return false
     }
     delete this.state.plugins[id]
-    this.persist()
+    try {
+      this.persist()
+    } catch {
+      this.state.plugins[id] = removed
+      return false
+    }
     return true
   }
 }
-
-export { EMPTY_STATE }

--- a/src/main/plugin/plugin-store.ts
+++ b/src/main/plugin/plugin-store.ts
@@ -9,9 +9,13 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 
-// Where a plugin came from. v1a ships local-folder install; registry/git/
-// tarball sources extend this union in a later increment.
-export type PluginInstallSource = { kind: 'local'; path: string }
+// Where a plugin came from. Mirrors the install module's PluginSource shape
+// (kept local to avoid coupling the store to the installer).
+export type PluginInstallSource =
+  | { kind: 'local'; path: string }
+  | { kind: 'registry'; name: string; version: string | null }
+  | { kind: 'git'; url: string }
+  | { kind: 'tarball'; url: string }
 
 export type PluginStateEntry = {
   id: string

--- a/src/main/plugin/plugin-store.ts
+++ b/src/main/plugin/plugin-store.ts
@@ -1,0 +1,106 @@
+// Persisted install/activation state for plugins — the host's source of truth
+// (authority lives in main; renderer/mobile rebuild from this). Injectable
+// state-file path so it unit-tests against a temp dir with no Electron.
+//
+// Activation state is not a secret, so it is written as plain JSON; secret-
+// bearing stores (plugin settings that may hold tokens) use the secure-file /
+// Windows-ACL path in a later unit.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+// Where a plugin came from. v1a ships local-folder install; registry/git/
+// tarball sources extend this union in a later increment.
+export type PluginInstallSource = { kind: 'local'; path: string }
+
+export type PluginStateEntry = {
+  id: string
+  version: string
+  source: PluginInstallSource
+  active: boolean
+  installedAt: string
+}
+
+type PersistedState = { version: 1; plugins: Record<string, PluginStateEntry> }
+
+const EMPTY_STATE: PersistedState = { version: 1, plugins: {} }
+
+export class PluginStore {
+  private state: PersistedState
+
+  constructor(private readonly stateFilePath: string) {
+    this.state = this.load()
+  }
+
+  private load(): PersistedState {
+    try {
+      if (!existsSync(this.stateFilePath)) {
+        return { version: 1, plugins: {} }
+      }
+      const parsed: unknown = JSON.parse(readFileSync(this.stateFilePath, 'utf8'))
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        typeof (parsed as PersistedState).plugins === 'object'
+      ) {
+        return { version: 1, plugins: { ...(parsed as PersistedState).plugins } }
+      }
+    } catch {
+      // Corrupt/unreadable state resets to empty rather than crashing the host.
+    }
+    return { version: 1, plugins: {} }
+  }
+
+  private persist(): void {
+    mkdirSync(dirname(this.stateFilePath), { recursive: true })
+    writeFileSync(this.stateFilePath, JSON.stringify(this.state, null, 2), 'utf8')
+  }
+
+  list(): PluginStateEntry[] {
+    return Object.values(this.state.plugins)
+  }
+
+  get(id: string): PluginStateEntry | undefined {
+    return this.state.plugins[id]
+  }
+
+  // Record (or refresh) an installed plugin. A reinstall preserves the prior
+  // active flag; a first install lands inactive.
+  recordInstalled(
+    entry: Omit<PluginStateEntry, 'active' | 'installedAt'> & { installedAt?: string }
+  ): PluginStateEntry {
+    const prior = this.state.plugins[entry.id]
+    const stored: PluginStateEntry = {
+      id: entry.id,
+      version: entry.version,
+      source: entry.source,
+      active: prior?.active ?? false,
+      installedAt: prior?.installedAt ?? entry.installedAt ?? new Date().toISOString()
+    }
+    this.state.plugins[entry.id] = stored
+    this.persist()
+    return stored
+  }
+
+  // Idempotent: returns true when the active flag actually changed.
+  setActive(id: string, active: boolean): boolean {
+    const entry = this.state.plugins[id]
+    if (!entry || entry.active === active) {
+      return false
+    }
+    entry.active = active
+    this.persist()
+    return true
+  }
+
+  remove(id: string): boolean {
+    if (!this.state.plugins[id]) {
+      return false
+    }
+    delete this.state.plugins[id]
+    this.persist()
+    return true
+  }
+}
+
+export { EMPTY_STATE }

--- a/src/main/plugin/plugin-supervision.test.ts
+++ b/src/main/plugin/plugin-supervision.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { PluginSupervisor } from './plugin-supervision'
+
+describe('PluginSupervisor', () => {
+  it('starts inactive and becomes running', () => {
+    const sup = new PluginSupervisor()
+    expect(sup.getState('p')).toBe('inactive')
+    sup.markRunning('p', { resetRestarts: true })
+    expect(sup.getState('p')).toBe('running')
+  })
+
+  it('treats a clean exit as inactive with no restart', () => {
+    const sup = new PluginSupervisor()
+    sup.markRunning('p', { resetRestarts: true })
+    expect(sup.markExited('p', { crashed: false })).toEqual({ restart: false, state: 'inactive' })
+    expect(sup.getState('p')).toBe('inactive')
+  })
+
+  it('restarts a crash with backoff until maxRestarts, then errors', () => {
+    const sup = new PluginSupervisor({ maxRestarts: 3, backoffMs: [500, 2000, 5000] })
+    sup.markRunning('p', { resetRestarts: true })
+
+    expect(sup.markExited('p', { crashed: true })).toEqual({
+      restart: true,
+      delayMs: 500,
+      attempt: 1
+    })
+    expect(sup.markExited('p', { crashed: true })).toEqual({
+      restart: true,
+      delayMs: 2000,
+      attempt: 2
+    })
+    expect(sup.markExited('p', { crashed: true })).toEqual({
+      restart: true,
+      delayMs: 5000,
+      attempt: 3
+    })
+    // 4th crash exceeds maxRestarts -> errored, no restart
+    expect(sup.markExited('p', { crashed: true })).toEqual({ restart: false, state: 'errored' })
+    expect(sup.getState('p')).toBe('errored')
+  })
+
+  it('reuses the last backoff entry past the schedule length', () => {
+    const sup = new PluginSupervisor({ maxRestarts: 5, backoffMs: [100, 200] })
+    sup.markRunning('p', { resetRestarts: true })
+    sup.markExited('p', { crashed: true }) // attempt 1 -> 100
+    sup.markExited('p', { crashed: true }) // attempt 2 -> 200
+    expect(sup.markExited('p', { crashed: true })).toEqual({
+      restart: true,
+      delayMs: 200,
+      attempt: 3
+    })
+  })
+
+  it('a fresh activation resets the crash counter', () => {
+    const sup = new PluginSupervisor({ maxRestarts: 1, backoffMs: [10] })
+    sup.markRunning('p', { resetRestarts: true })
+    sup.markExited('p', { crashed: true }) // attempt 1
+    expect(sup.restartCount('p')).toBe(1)
+    sup.markRunning('p', { resetRestarts: true }) // user re-activated
+    expect(sup.restartCount('p')).toBe(0)
+  })
+
+  it('does not cross-contaminate plugins', () => {
+    const sup = new PluginSupervisor({ maxRestarts: 0, backoffMs: [10] })
+    sup.markRunning('a', { resetRestarts: true })
+    sup.markRunning('b', { resetRestarts: true })
+    expect(sup.markExited('a', { crashed: true })).toEqual({ restart: false, state: 'errored' })
+    expect(sup.getState('b')).toBe('running')
+  })
+
+  it('reset clears state', () => {
+    const sup = new PluginSupervisor()
+    sup.markRunning('p', { resetRestarts: true })
+    sup.reset('p')
+    expect(sup.getState('p')).toBe('inactive')
+  })
+})

--- a/src/main/plugin/plugin-supervision.test.ts
+++ b/src/main/plugin/plugin-supervision.test.ts
@@ -75,4 +75,20 @@ describe('PluginSupervisor', () => {
     sup.reset('p')
     expect(sup.getState('p')).toBe('inactive')
   })
+
+  it('rejects an empty backoff schedule (would index [-1] -> undefined delay)', () => {
+    expect(() => new PluginSupervisor({ backoffMs: [] })).toThrow()
+  })
+
+  it('rejects a negative maxRestarts', () => {
+    expect(() => new PluginSupervisor({ maxRestarts: -1 })).toThrow()
+  })
+
+  it('treats an exit for an untracked plugin as inactive (no phantom restart)', () => {
+    const sup = new PluginSupervisor()
+    expect(sup.markExited('never-ran', { crashed: true })).toEqual({
+      restart: false,
+      state: 'inactive'
+    })
+  })
 })

--- a/src/main/plugin/plugin-supervision.ts
+++ b/src/main/plugin/plugin-supervision.ts
@@ -1,0 +1,83 @@
+// Crash/restart supervision policy for plugin backend processes — the pure
+// decision half of the runtime (the real `child_process` fork is wired and
+// integration-tested separately). Decides whether a plugin that exited should
+// be restarted (with backoff) or marked Errored after too many crashes.
+//
+// Pure + deterministic: callers own the actual timers and spawning; this just
+// tracks per-plugin state and returns decisions.
+
+export type RunState = 'inactive' | 'running' | 'errored'
+
+export type ExitInfo = {
+  // Clean exit from a host-initiated deactivate vs. an unexpected crash.
+  crashed: boolean
+}
+
+export type RestartDecision =
+  | { restart: true; delayMs: number; attempt: number }
+  | { restart: false; state: RunState }
+
+export type SupervisionConfig = {
+  maxRestarts: number
+  // Backoff schedule indexed by attempt; the last entry is reused past its end.
+  backoffMs: number[]
+}
+
+const DEFAULT_CONFIG: SupervisionConfig = {
+  maxRestarts: 3,
+  backoffMs: [500, 2000, 5000]
+}
+
+type Entry = { state: RunState; restarts: number }
+
+export class PluginSupervisor {
+  private readonly entries = new Map<string, Entry>()
+  private readonly config: SupervisionConfig
+
+  constructor(config: Partial<SupervisionConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config }
+  }
+
+  getState(id: string): RunState {
+    return this.entries.get(id)?.state ?? 'inactive'
+  }
+
+  restartCount(id: string): number {
+    return this.entries.get(id)?.restarts ?? 0
+  }
+
+  // Mark a plugin as running. A fresh activation (not a restart) resets the
+  // crash counter so a previously-flaky plugin gets a clean slate.
+  markRunning(id: string, options: { resetRestarts?: boolean } = {}): void {
+    const prior = this.entries.get(id)
+    this.entries.set(id, {
+      state: 'running',
+      restarts: options.resetRestarts ? 0 : (prior?.restarts ?? 0)
+    })
+  }
+
+  // Record that the process exited and decide what to do next.
+  markExited(id: string, info: ExitInfo): RestartDecision {
+    if (!info.crashed) {
+      // Host-initiated stop: go inactive, clear restart history.
+      this.entries.set(id, { state: 'inactive', restarts: 0 })
+      return { restart: false, state: 'inactive' }
+    }
+    const entry = this.entries.get(id) ?? { state: 'running', restarts: 0 }
+    if (entry.restarts >= this.config.maxRestarts) {
+      this.entries.set(id, { state: 'errored', restarts: entry.restarts })
+      return { restart: false, state: 'errored' }
+    }
+    const attempt = entry.restarts + 1
+    const idx = Math.min(entry.restarts, this.config.backoffMs.length - 1)
+    this.entries.set(id, { state: 'running', restarts: attempt })
+    return { restart: true, delayMs: this.config.backoffMs[idx], attempt }
+  }
+
+  // Clear all state for a plugin (e.g. on deactivate/remove or manual re-enable).
+  reset(id: string): void {
+    this.entries.delete(id)
+  }
+}
+
+export { DEFAULT_CONFIG }

--- a/src/main/plugin/plugin-supervision.ts
+++ b/src/main/plugin/plugin-supervision.ts
@@ -18,8 +18,11 @@ export type RestartDecision =
   | { restart: false; state: RunState }
 
 export type SupervisionConfig = {
+  // Max crash-restarts before a plugin is marked Errored. `0` means no restart
+  // attempts — the first crash goes straight to Errored.
   maxRestarts: number
   // Backoff schedule indexed by attempt; the last entry is reused past its end.
+  // Must be non-empty (enforced in the constructor).
   backoffMs: number[]
 }
 
@@ -36,6 +39,14 @@ export class PluginSupervisor {
 
   constructor(config: Partial<SupervisionConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config }
+    // Guard misconfiguration: an empty backoff schedule would index [-1] →
+    // undefined delay (immediate restart loop); a negative cap is meaningless.
+    if (this.config.maxRestarts < 0) {
+      throw new Error('SupervisionConfig.maxRestarts must be >= 0')
+    }
+    if (this.config.backoffMs.length === 0) {
+      throw new Error('SupervisionConfig.backoffMs must be non-empty')
+    }
   }
 
   getState(id: string): RunState {
@@ -63,13 +74,17 @@ export class PluginSupervisor {
       this.entries.set(id, { state: 'inactive', restarts: 0 })
       return { restart: false, state: 'inactive' }
     }
-    const entry = this.entries.get(id) ?? { state: 'running', restarts: 0 }
+    const entry = this.entries.get(id)
+    // An exit for an untracked plugin is not a running crash to restart.
+    if (!entry) {
+      return { restart: false, state: 'inactive' }
+    }
     if (entry.restarts >= this.config.maxRestarts) {
       this.entries.set(id, { state: 'errored', restarts: entry.restarts })
       return { restart: false, state: 'errored' }
     }
     const attempt = entry.restarts + 1
-    const idx = Math.min(entry.restarts, this.config.backoffMs.length - 1)
+    const idx = Math.max(0, Math.min(entry.restarts, this.config.backoffMs.length - 1))
     this.entries.set(id, { state: 'running', restarts: attempt })
     return { restart: true, delayMs: this.config.backoffMs[idx], attempt }
   }
@@ -79,5 +94,3 @@ export class PluginSupervisor {
     this.entries.delete(id)
   }
 }
-
-export { DEFAULT_CONFIG }

--- a/src/main/plugin/plugin-system.ts
+++ b/src/main/plugin/plugin-system.ts
@@ -11,6 +11,7 @@
 //   - add the plugin-host-entry build target to electron.vite.config
 //   - expose window.api.plugins in the preload
 
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { app, clipboard, shell } from 'electron'
 import { PluginManager } from './plugin-manager'
@@ -18,6 +19,10 @@ import { PluginRuntime } from './plugin-runtime'
 import { registerPluginAssetProtocol } from './plugin-asset-protocol'
 import { readManifestRaw } from './plugin-discovery'
 import { validatePluginManifest } from '../../shared/plugin/manifest-validate'
+import { parseInstallSource } from './install/install-source'
+import { resolveAndInstall } from './install/install-resolver'
+import { createInstallAdapters } from './install/install-adapters'
+import { emptyLockfile, type PluginLockfile } from './install/install-integrity'
 import type { HostCommand, WorkspaceSnapshot } from '../../shared/plugin/api-contract'
 import type { OutputLine } from './plugin-output-buffer'
 
@@ -60,9 +65,13 @@ export class PluginSystem {
   readonly manager: PluginManager
   readonly runtime: PluginRuntime
   private readonly pluginsDir: string
+  private readonly lockfilePath: string
+  private readonly stagingDir: string
 
   constructor(deps: PluginSystemDeps = {}) {
     this.pluginsDir = join(app.getPath('userData'), 'plugins')
+    this.lockfilePath = join(app.getPath('userData'), 'plugins-lock.json')
+    this.stagingDir = join(app.getPath('userData'), 'plugins-staging')
     this.manager = new PluginManager({
       pluginsDir: this.pluginsDir,
       stateFilePath: join(app.getPath('userData'), 'plugins-state.json')
@@ -82,6 +91,45 @@ export class PluginSystem {
   // registered as privileged before ready — see registerPluginScheme()).
   registerAssetProtocol(): void {
     registerPluginAssetProtocol(this.pluginsDir, (id) => this.runtime.isRunning(id))
+  }
+
+  private loadLockfile(): PluginLockfile {
+    try {
+      if (existsSync(this.lockfilePath)) {
+        const parsed = JSON.parse(readFileSync(this.lockfilePath, 'utf8')) as PluginLockfile
+        if (parsed?.plugins && typeof parsed.plugins === 'object') {
+          return { version: 1, plugins: parsed.plugins }
+        }
+      }
+    } catch {
+      // Corrupt lockfile resets; reinstall re-pins integrity.
+    }
+    return emptyLockfile()
+  }
+
+  private saveLockfile(lockfile: PluginLockfile): void {
+    writeFileSync(this.lockfilePath, JSON.stringify(lockfile, null, 2), 'utf8')
+  }
+
+  // Install from any source string (local path / registry name / git / tarball),
+  // pin it in the lockfile, and record it in the manager (inactive).
+  async installFromSource(input: string): Promise<{ ok: boolean; id?: string; errors?: string[] }> {
+    const source = parseInstallSource(input)
+    if (!source) {
+      return { ok: false, errors: ['empty install source'] }
+    }
+    const result = await resolveAndInstall(source, {
+      pluginsDir: this.pluginsDir,
+      stagingDir: this.stagingDir,
+      adapters: createInstallAdapters(),
+      lockfile: this.loadLockfile()
+    })
+    if (!result.ok) {
+      return { ok: false, errors: result.errors }
+    }
+    this.saveLockfile(result.lockfile)
+    this.manager.recordInstalled({ id: result.id, version: result.version, source })
+    return { ok: true, id: result.id }
   }
 
   // Enrich each installed plugin's state with its manifest title/icon so the

--- a/src/main/plugin/plugin-system.ts
+++ b/src/main/plugin/plugin-system.ts
@@ -17,6 +17,12 @@ import { join } from 'node:path'
 import { app, clipboard, shell } from 'electron'
 import { PluginManager } from './plugin-manager'
 import { PluginRuntime } from './plugin-runtime'
+import {
+  activatePluginForWorkspace,
+  type ActivationResult,
+  type RemoteDescriptor
+} from './plugin-activation-coordinator'
+import type { RelayRequest } from './plugin-remote-provision'
 import { registerPluginAssetProtocol } from './plugin-asset-protocol'
 import { readManifestRaw } from './plugin-discovery'
 import { validatePluginManifest } from '../../shared/plugin/manifest-validate'
@@ -45,6 +51,11 @@ export type PluginSystemDeps = {
   getWorkspaceSnapshot?: WorkspaceSnapshotProvider
   // Routes a backend's UI message to the plugin's webview in the renderer.
   onUiMessage?: (pluginId: string, message: unknown) => void
+  // Resolves a relay request fn for a remote workspace (for activateForWorkspace's
+  // remote path). NEEDS-RUNTIME-VERIFY: the production resolver comes from the
+  // workspace's SshRelaySession. Defaults to a fn that rejects when called, so the
+  // remote path is an explicit, never-silent seam until that wiring lands.
+  resolveRelayRequest?: (remote: RemoteDescriptor) => RelayRequest
 }
 
 const EMPTY_SNAPSHOT: WorkspaceSnapshot = {
@@ -68,6 +79,7 @@ export class PluginSystem {
   private readonly pluginsDir: string
   private readonly lockfilePath: string
   private readonly stagingDir: string
+  private readonly resolveRelayRequest: (remote: RemoteDescriptor) => RelayRequest
 
   constructor(deps: PluginSystemDeps = {}) {
     this.pluginsDir = join(app.getPath('userData'), 'plugins')
@@ -86,6 +98,26 @@ export class PluginSystem {
       invokeCommand: (name, params) => this.invokeCommand(name, params),
       onUiMessage: deps.onUiMessage
     })
+    // Default rejects-on-call so the remote activate path is explicit, never a
+    // silent no-op, until the workspace→relay request wiring lands.
+    this.resolveRelayRequest =
+      deps.resolveRelayRequest ??
+      (() => () => Promise.reject(new Error('relay request not configured')))
+  }
+
+  // Activate a plugin for a workspace. Local workspaces (the default) run the
+  // backend in-process exactly as before; a remote descriptor routes through the
+  // coordinator to provision + activate on the relay. NEEDS-RUNTIME-VERIFY: the
+  // caller must supply the remote descriptor + a configured resolveRelayRequest.
+  activateForWorkspace(pluginId: string, remote?: RemoteDescriptor): Promise<ActivationResult> {
+    return activatePluginForWorkspace(
+      { pluginId, remote: remote ?? null },
+      {
+        pluginsDir: this.pluginsDir,
+        localActivate: (id) => this.runtime.activate(id),
+        relayRequest: this.resolveRelayRequest(remote ?? null)
+      }
+    )
   }
 
   // Serve plugin assets; call after app.whenReady() (the scheme itself must be

--- a/src/main/plugin/plugin-system.ts
+++ b/src/main/plugin/plugin-system.ts
@@ -16,9 +16,20 @@ import { app, clipboard, shell } from 'electron'
 import { PluginManager } from './plugin-manager'
 import { PluginRuntime } from './plugin-runtime'
 import { registerPluginAssetProtocol } from './plugin-asset-protocol'
+import { readManifestRaw } from './plugin-discovery'
+import { validatePluginManifest } from '../../shared/plugin/manifest-validate'
 import type { HostCommand, WorkspaceSnapshot } from '../../shared/plugin/api-contract'
-import type { PluginStateEntry } from './plugin-store'
 import type { OutputLine } from './plugin-output-buffer'
+
+// What the renderer needs to render a plugin's activity-bar tab + list row.
+export type RendererPluginEntry = {
+  id: string
+  version: string
+  active: boolean
+  title: string
+  // Lucide icon name from the manifest (falls back to a default in the UI).
+  icon: string
+}
 
 export type WorkspaceSnapshotProvider = () => WorkspaceSnapshot | Promise<WorkspaceSnapshot>
 
@@ -73,8 +84,20 @@ export class PluginSystem {
     registerPluginAssetProtocol(this.pluginsDir, (id) => this.runtime.isRunning(id))
   }
 
-  list(): PluginStateEntry[] {
-    return this.manager.list()
+  // Enrich each installed plugin's state with its manifest title/icon so the
+  // renderer can build activity-bar tabs without a second round-trip.
+  list(): RendererPluginEntry[] {
+    return this.manager.list().map((entry) => {
+      const validated = validatePluginManifest(readManifestRaw(join(this.pluginsDir, entry.id)))
+      const sidebar = validated.ok ? validated.manifest.contributes.sidebar : undefined
+      return {
+        id: entry.id,
+        version: entry.version,
+        active: entry.active,
+        title: sidebar?.title ?? entry.id,
+        icon: sidebar?.icon ?? 'Plug'
+      }
+    })
   }
 
   getOutput(pluginId: string): OutputLine[] {

--- a/src/main/plugin/plugin-system.ts
+++ b/src/main/plugin/plugin-system.ts
@@ -1,16 +1,6 @@
 // NEEDS-RUNTIME-VERIFY: the main-process composition root for the plugin
-// system. Builds the manager + runtime against Electron paths, wires the host
-// command implementations (open-external-url / copy-to-clipboard), the asset
-// protocol, and multi-source install (installFromSource + lockfile). Unit-tested
-// pieces (manager, runtime, gate, handler, installer) are composed here; this
-// glue runs only in the app.
-//
-// The boot wiring this enables is now in place: index.ts calls
-// registerPluginScheme() before app.whenReady(), then createPluginSystem() +
-// registerAssetProtocol() + registerPluginHandlers() on ready; the
-// plugin-host-entry build target is in electron.vite.config; and the preload
-// exposes window.api.plugins. What remains is mobile/relay (v1c) and launching
-// the app to verify runtime behavior.
+// system — Electron-coupled glue (paths, host commands, asset protocol) that
+// composes the unit-tested pieces and runs only in the app.
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -105,17 +95,19 @@ export class PluginSystem {
       (() => () => Promise.reject(new Error('relay request not configured')))
   }
 
-  // Activate a plugin for a workspace. Local workspaces (the default) run the
-  // backend in-process exactly as before; a remote descriptor routes through the
-  // coordinator to provision + activate on the relay. NEEDS-RUNTIME-VERIFY: the
-  // caller must supply the remote descriptor + a configured resolveRelayRequest.
+  // NEEDS-RUNTIME-VERIFY: the SSH path needs the caller to supply a remote
+  // descriptor + a configured resolveRelayRequest; default is local, unchanged.
   activateForWorkspace(pluginId: string, remote?: RemoteDescriptor): Promise<ActivationResult> {
+    const descriptor = remote ?? null
     return activatePluginForWorkspace(
-      { pluginId, remote: remote ?? null },
+      { pluginId, remote: descriptor },
       {
         pluginsDir: this.pluginsDir,
         localActivate: (id) => this.runtime.activate(id),
-        relayRequest: this.resolveRelayRequest(remote ?? null)
+        // Resolve the relay request fn lazily — only when the coordinator takes
+        // the remote path and actually issues a call — so a future resolver that
+        // opens an SSH/relay session never runs on a local activation.
+        relayRequest: (method, params) => this.resolveRelayRequest(descriptor)(method, params)
       }
     )
   }

--- a/src/main/plugin/plugin-system.ts
+++ b/src/main/plugin/plugin-system.ts
@@ -1,15 +1,16 @@
 // NEEDS-RUNTIME-VERIFY: the main-process composition root for the plugin
-// system. Builds the manager + runtime against Electron paths and wires the
-// host command implementations (open-external-url / copy-to-clipboard) and the
-// asset protocol. Unit-tested pieces (manager, runtime, gate, handler) are
-// composed here; this glue runs only in the app.
+// system. Builds the manager + runtime against Electron paths, wires the host
+// command implementations (open-external-url / copy-to-clipboard), the asset
+// protocol, and multi-source install (installFromSource + lockfile). Unit-tested
+// pieces (manager, runtime, gate, handler, installer) are composed here; this
+// glue runs only in the app.
 //
-// Remaining wiring this enables (each a small, explicit step):
-//   - call registerPluginScheme() from app bootstrap BEFORE app.whenReady()
-//   - on ready: createPluginSystem(), then registerPluginAssetProtocol()
-//   - register the IPC handlers (src/main/ipc/plugins.ts) in register-core-handlers
-//   - add the plugin-host-entry build target to electron.vite.config
-//   - expose window.api.plugins in the preload
+// The boot wiring this enables is now in place: index.ts calls
+// registerPluginScheme() before app.whenReady(), then createPluginSystem() +
+// registerAssetProtocol() + registerPluginHandlers() on ready; the
+// plugin-host-entry build target is in electron.vite.config; and the preload
+// exposes window.api.plugins. What remains is mobile/relay (v1c) and launching
+// the app to verify runtime behavior.
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'

--- a/src/main/plugin/plugin-system.ts
+++ b/src/main/plugin/plugin-system.ts
@@ -104,7 +104,10 @@ export class PluginSystem {
   // descriptor + a configured resolveRelayRequest; default is local, unchanged.
   activateForWorkspace(pluginId: string, remote?: RemoteDescriptor): Promise<ActivationResult> {
     const descriptor = remote ?? null
-    return coalesceByKey(this.activationsInFlight, pluginId, () =>
+    // Key by tier+id so a local and a remote activation of the same plugin don't
+    // coalesce into each other's result (they run different code paths).
+    const key = `${descriptor?.isRemote ? 'remote' : 'local'}:${pluginId}`
+    return coalesceByKey(this.activationsInFlight, key, () =>
       activatePluginForWorkspace(
         { pluginId, remote: descriptor },
         {

--- a/src/main/plugin/plugin-system.ts
+++ b/src/main/plugin/plugin-system.ts
@@ -1,0 +1,113 @@
+// NEEDS-RUNTIME-VERIFY: the main-process composition root for the plugin
+// system. Builds the manager + runtime against Electron paths and wires the
+// host command implementations (open-external-url / copy-to-clipboard) and the
+// asset protocol. Unit-tested pieces (manager, runtime, gate, handler) are
+// composed here; this glue runs only in the app.
+//
+// Remaining wiring this enables (each a small, explicit step):
+//   - call registerPluginScheme() from app bootstrap BEFORE app.whenReady()
+//   - on ready: createPluginSystem(), then registerPluginAssetProtocol()
+//   - register the IPC handlers (src/main/ipc/plugins.ts) in register-core-handlers
+//   - add the plugin-host-entry build target to electron.vite.config
+//   - expose window.api.plugins in the preload
+
+import { join } from 'node:path'
+import { app, clipboard, shell } from 'electron'
+import { PluginManager } from './plugin-manager'
+import { PluginRuntime } from './plugin-runtime'
+import { registerPluginAssetProtocol } from './plugin-asset-protocol'
+import type { HostCommand, WorkspaceSnapshot } from '../../shared/plugin/api-contract'
+import type { PluginStateEntry } from './plugin-store'
+import type { OutputLine } from './plugin-output-buffer'
+
+export type WorkspaceSnapshotProvider = () => WorkspaceSnapshot | Promise<WorkspaceSnapshot>
+
+export type PluginSystemDeps = {
+  // Supplies the bounded workspace snapshot for read:workspace. Injected so the
+  // system stays decoupled from the rest of main; defaults to an empty snapshot.
+  getWorkspaceSnapshot?: WorkspaceSnapshotProvider
+  // Routes a backend's UI message to the plugin's webview in the renderer.
+  onUiMessage?: (pluginId: string, message: unknown) => void
+}
+
+const EMPTY_SNAPSHOT: WorkspaceSnapshot = {
+  workspaceName: '',
+  currentBranch: null,
+  isDirty: false,
+  openFileCount: 0
+}
+
+// Resolve the built plugin-host-entry, mirroring sidecar-client's asar.unpacked
+// handling (ELECTRON_RUN_AS_NODE bypasses asar require integration).
+function resolveEntryPath(): string {
+  const appPath = app.getAppPath()
+  const base = app.isPackaged ? appPath.replace('app.asar', 'app.asar.unpacked') : appPath
+  return join(base, 'out', 'main', 'plugin-host-entry.js')
+}
+
+export class PluginSystem {
+  readonly manager: PluginManager
+  readonly runtime: PluginRuntime
+  private readonly pluginsDir: string
+
+  constructor(deps: PluginSystemDeps = {}) {
+    this.pluginsDir = join(app.getPath('userData'), 'plugins')
+    this.manager = new PluginManager({
+      pluginsDir: this.pluginsDir,
+      stateFilePath: join(app.getPath('userData'), 'plugins-state.json')
+    })
+    this.runtime = new PluginRuntime({
+      manager: this.manager,
+      pluginsDir: this.pluginsDir,
+      entryPath: resolveEntryPath(),
+      forkEnv: { ELECTRON_RUN_AS_NODE: '1' },
+      getWorkspaceSnapshot: deps.getWorkspaceSnapshot ?? (() => EMPTY_SNAPSHOT),
+      invokeCommand: (name, params) => this.invokeCommand(name, params),
+      onUiMessage: deps.onUiMessage
+    })
+  }
+
+  // Serve plugin assets; call after app.whenReady() (the scheme itself must be
+  // registered as privileged before ready — see registerPluginScheme()).
+  registerAssetProtocol(): void {
+    registerPluginAssetProtocol(this.pluginsDir, (id) => this.runtime.isRunning(id))
+  }
+
+  list(): PluginStateEntry[] {
+    return this.manager.list()
+  }
+
+  getOutput(pluginId: string): OutputLine[] {
+    return this.runtime.getOutput(pluginId)
+  }
+
+  // The allowlisted host commands (the gate already validated name + params).
+  private async invokeCommand(name: HostCommand, params: unknown): Promise<unknown> {
+    const args = (params ?? {}) as { url?: string; text?: string }
+    switch (name) {
+      case 'open-external-url':
+        await shell.openExternal(String(args.url))
+        return undefined
+      case 'copy-to-clipboard':
+        clipboard.writeText(String(args.text))
+        return undefined
+      default:
+        return undefined
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    await this.runtime.stopAll()
+  }
+}
+
+let singleton: PluginSystem | null = null
+
+export function createPluginSystem(deps: PluginSystemDeps = {}): PluginSystem {
+  singleton ??= new PluginSystem(deps)
+  return singleton
+}
+
+export function getPluginSystem(): PluginSystem | null {
+  return singleton
+}

--- a/src/main/plugin/plugin-system.ts
+++ b/src/main/plugin/plugin-system.ts
@@ -13,6 +13,7 @@ import {
   type RemoteDescriptor
 } from './plugin-activation-coordinator'
 import type { RelayRequest } from './plugin-remote-provision'
+import { coalesceByKey } from './in-flight-coalesce'
 import { registerPluginAssetProtocol } from './plugin-asset-protocol'
 import { readManifestRaw } from './plugin-discovery'
 import { validatePluginManifest } from '../../shared/plugin/manifest-validate'
@@ -70,6 +71,10 @@ export class PluginSystem {
   private readonly lockfilePath: string
   private readonly stagingDir: string
   private readonly resolveRelayRequest: (remote: RemoteDescriptor) => RelayRequest
+  // Per-pluginId in-flight activations: concurrent calls for the same id share
+  // one activation (a plugin's relay bundle dir is keyed by id, not workspace),
+  // so they can't race the relay's non-atomic bundle swap.
+  private readonly activationsInFlight = new Map<string, Promise<ActivationResult>>()
 
   constructor(deps: PluginSystemDeps = {}) {
     this.pluginsDir = join(app.getPath('userData'), 'plugins')
@@ -99,16 +104,18 @@ export class PluginSystem {
   // descriptor + a configured resolveRelayRequest; default is local, unchanged.
   activateForWorkspace(pluginId: string, remote?: RemoteDescriptor): Promise<ActivationResult> {
     const descriptor = remote ?? null
-    return activatePluginForWorkspace(
-      { pluginId, remote: descriptor },
-      {
-        pluginsDir: this.pluginsDir,
-        localActivate: (id) => this.runtime.activate(id),
-        // Resolve the relay request fn lazily — only when the coordinator takes
-        // the remote path and actually issues a call — so a future resolver that
-        // opens an SSH/relay session never runs on a local activation.
-        relayRequest: (method, params) => this.resolveRelayRequest(descriptor)(method, params)
-      }
+    return coalesceByKey(this.activationsInFlight, pluginId, () =>
+      activatePluginForWorkspace(
+        { pluginId, remote: descriptor },
+        {
+          pluginsDir: this.pluginsDir,
+          localActivate: (id) => this.runtime.activate(id),
+          // Resolve the relay request fn lazily — only when the coordinator takes
+          // the remote path and actually issues a call — so a future resolver that
+          // opens an SSH/relay session never runs on a local activation.
+          relayRequest: (method, params) => this.resolveRelayRequest(descriptor)(method, params)
+        }
+      )
     )
   }
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -464,6 +464,32 @@ export function createMainWindow(
     // persist:orca-browser-session-<uuid>). The registry is the sole authority
     // for which partitions are valid — renderer-provided strings that are not
     // in the allowlist are rejected.
+    // Plugin UIs attach with a per-plugin partition (persist:orca-plugin-<id>)
+    // serving orca-plugin://<id>/ — a sandboxed plugin surface, not a browser
+    // session. Allow these with the SAME fail-closed hardening, requiring the
+    // plugin partition and the orca-plugin:// scheme to agree (NEEDS-RUNTIME-
+    // VERIFY: confirm the guest cannot navigate off orca-plugin://<id>/).
+    const pluginPartition = partition.startsWith('persist:orca-plugin-')
+    const pluginSrc = src.startsWith('orca-plugin://')
+    if (pluginPartition || pluginSrc) {
+      if (!pluginPartition || !pluginSrc) {
+        event.preventDefault()
+        return
+      }
+      delete webPreferences.preload
+      delete (webPreferences as Record<string, unknown>).preloadURL
+      webPreferences.nodeIntegration = false
+      webPreferences.nodeIntegrationInSubFrames = false
+      webPreferences.enableBlinkFeatures = ''
+      webPreferences.disableBlinkFeatures = ''
+      webPreferences.webSecurity = true
+      webPreferences.allowRunningInsecureContent = false
+      webPreferences.contextIsolation = true
+      webPreferences.sandbox = true
+      webPreferences.partition = partition
+      return
+    }
+
     if (!normalizedSrc || !browserSessionRegistry.isAllowedPartition(partition)) {
       event.preventDefault()
       return

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -755,7 +755,9 @@ export type AppApi = {
 export type PreloadApi = {
   // Plugin system surface (structural types keep preload decoupled from main).
   plugins: {
-    list: () => Promise<{ id: string; version: string; active: boolean }[]>
+    list: () => Promise<
+      { id: string; version: string; active: boolean; title: string; icon: string }[]
+    >
     installLocal: (sourceDir: string) => Promise<{ ok: boolean; id?: string; errors?: string[] }>
     activate: (pluginId: string) => Promise<{ ok: boolean; error?: string }>
     deactivate: (pluginId: string) => Promise<{ ok: boolean }>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -759,6 +759,7 @@ export type PreloadApi = {
       { id: string; version: string; active: boolean; title: string; icon: string }[]
     >
     installLocal: (sourceDir: string) => Promise<{ ok: boolean; id?: string; errors?: string[] }>
+    installFromSource: (input: string) => Promise<{ ok: boolean; id?: string; errors?: string[] }>
     activate: (pluginId: string) => Promise<{ ok: boolean; error?: string }>
     deactivate: (pluginId: string) => Promise<{ ok: boolean }>
     remove: (pluginId: string) => Promise<{ ok: boolean }>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -753,6 +753,18 @@ export type AppApi = {
 }
 
 export type PreloadApi = {
+  // Plugin system surface (structural types keep preload decoupled from main).
+  plugins: {
+    list: () => Promise<{ id: string; version: string; active: boolean }[]>
+    installLocal: (sourceDir: string) => Promise<{ ok: boolean; id?: string; errors?: string[] }>
+    activate: (pluginId: string) => Promise<{ ok: boolean; error?: string }>
+    deactivate: (pluginId: string) => Promise<{ ok: boolean }>
+    remove: (pluginId: string) => Promise<{ ok: boolean }>
+    getOutput: (
+      pluginId: string
+    ) => Promise<{ channel: 'stdout' | 'stderr'; text: string; seq: number }[]>
+    sendUiMessage: (pluginId: string, message: unknown) => Promise<void>
+  }
   app: AppApi
   platform: {
     get: () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -406,6 +406,7 @@ const api = {
   plugins: {
     list: () => ipcRenderer.invoke('plugins:list'),
     installLocal: (sourceDir: string) => ipcRenderer.invoke('plugins:install-local', sourceDir),
+    installFromSource: (input: string) => ipcRenderer.invoke('plugins:install', input),
     activate: (pluginId: string) => ipcRenderer.invoke('plugins:activate', pluginId),
     deactivate: (pluginId: string) => ipcRenderer.invoke('plugins:deactivate', pluginId),
     remove: (pluginId: string) => ipcRenderer.invoke('plugins:remove', pluginId),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -402,6 +402,17 @@ document.addEventListener(
 
 // Custom APIs for renderer
 const api = {
+  // Plugin system surface — see registerPluginHandlers (src/main/ipc/plugins.ts).
+  plugins: {
+    list: () => ipcRenderer.invoke('plugins:list'),
+    installLocal: (sourceDir: string) => ipcRenderer.invoke('plugins:install-local', sourceDir),
+    activate: (pluginId: string) => ipcRenderer.invoke('plugins:activate', pluginId),
+    deactivate: (pluginId: string) => ipcRenderer.invoke('plugins:deactivate', pluginId),
+    remove: (pluginId: string) => ipcRenderer.invoke('plugins:remove', pluginId),
+    getOutput: (pluginId: string) => ipcRenderer.invoke('plugins:get-output', pluginId),
+    sendUiMessage: (pluginId: string, message: unknown) =>
+      ipcRenderer.invoke('plugins:ui-message', pluginId, message)
+  },
   app: {
     getIdentity: (): Promise<AppIdentity> => ipcRenderer.invoke('app:getIdentity'),
     getFeatureWallAssetBaseUrl: (): Promise<string> =>

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -165,6 +165,24 @@ export class RelayDispatcher {
     }
   }
 
+  // Send a notification to a single client (by id), not all clients. Used when a
+  // pushed message carries one client's data and must not leak to others.
+  notifyClient(clientId: number, method: string, params?: Record<string, unknown>): void {
+    if (this.disposed) {
+      return
+    }
+    const client = this.clients.get(clientId)
+    if (!client || client.closed) {
+      return
+    }
+    const msg: JsonRpcNotification = {
+      jsonrpc: '2.0',
+      method,
+      ...(params !== undefined ? { params } : {})
+    }
+    this.sendFrame(client, msg)
+  }
+
   requestPrimary(
     method: string,
     params?: Record<string, unknown>,

--- a/src/relay/plugin-handler.test.ts
+++ b/src/relay/plugin-handler.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path'
 import { registerRelayPluginHandlers, type RelayDispatcherLike } from './plugin-handler'
 import type { PluginHostConfig } from '../main/plugin/plugin-host-process'
 import type { PluginHostLike } from '../main/plugin/plugin-runtime'
+import { serializePluginBundle } from '../main/plugin/plugin-bundle'
+import { discoverPlugins } from '../main/plugin/plugin-discovery'
 
 function manifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -287,4 +289,24 @@ describe('relay plugin handlers', () => {
     await Promise.resolve()
     expect(hosts.every((h) => h.stopped)).toBe(true)
   })
+
+  it('plugin.provision writes a valid bundle, then discoverPlugins finds it', async () => {
+    const bundle = serializePluginBundle('acme.bar', [
+      { path: 'plugin.json', dataBase64: b64(JSON.stringify(manifest({ id: 'acme.bar' }))) },
+      { path: 'index.html', dataBase64: b64('<!doctype html>') }
+    ])
+    const result = (await handlers.get('plugin.provision')!({ bundle }, {})) as { ok: boolean }
+    expect(result.ok).toBe(true)
+    expect(discoverPlugins(tmp).valid.map((p) => p.manifest.id)).toContain('acme.bar')
+  })
+
+  it('plugin.provision rejects an invalid bundle param through the dispatch layer', async () => {
+    const result = (await handlers.get('plugin.provision')!({ bundle: null }, {})) as {
+      ok: boolean
+      error?: string
+    }
+    expect(result).toEqual({ ok: false, error: 'invalid_bundle' })
+  })
 })
+
+const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64')

--- a/src/relay/plugin-handler.test.ts
+++ b/src/relay/plugin-handler.test.ts
@@ -19,20 +19,28 @@ function manifest(overrides: Record<string, unknown> = {}): Record<string, unkno
   }
 }
 
-type Handler = (params: Record<string, unknown>, ctx: unknown) => Promise<unknown>
-type FakeHost = PluginHostLike & { config: PluginHostConfig; posted: unknown[] }
+type Handler = (params: Record<string, unknown>, ctx: { clientId?: number }) => Promise<unknown>
+type FakeHost = PluginHostLike & { config: PluginHostConfig; posted: unknown[]; stopped: boolean }
+type Notification = { clientId: number; method: string; params?: Record<string, unknown> }
 
 let tmp: string
 let handlers: Map<string, Handler>
-let notifications: { method: string; params?: Record<string, unknown> }[]
+let notifications: Notification[]
+let detachListeners: ((clientId: number) => void)[]
 let hosts: FakeHost[]
+let failStart: boolean
 
 function fakeDispatcher(): RelayDispatcherLike {
   handlers = new Map()
   notifications = []
+  detachListeners = []
   return {
     onRequest: (method, handler) => handlers.set(method, handler),
-    notify: (method, params) => notifications.push({ method, params })
+    notifyClient: (clientId, method, params) => notifications.push({ clientId, method, params }),
+    onClientDetached: (listener) => {
+      detachListeners.push(listener)
+      return () => {}
+    }
   }
 }
 
@@ -40,10 +48,17 @@ function fakeHostFactory(config: PluginHostConfig): FakeHost {
   const host: FakeHost = {
     config,
     posted: [],
-    start: () => Promise.resolve(),
-    stop: () => Promise.resolve(),
-    isRunning: () => true,
-    postUi: (message) => host.posted.push(message)
+    stopped: false,
+    start: () => (failStart ? Promise.reject(new Error('boom')) : Promise.resolve()),
+    stop: () => {
+      host.stopped = true
+      return Promise.resolve()
+    },
+    isRunning: () => !host.stopped && !failStart,
+    postUi: (message) => host.posted.push(message),
+    terminate: () => {
+      host.stopped = true
+    }
   }
   hosts.push(host)
   return host
@@ -56,9 +71,12 @@ function installFixture(id = 'acme.foo'): void {
   writeFileSync(join(dir, 'index.html'), '<!doctype html><body>hi</body>')
 }
 
+const ctx = (clientId: number): { clientId: number } => ({ clientId })
+
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), 'relay-plugin-'))
   hosts = []
+  failStart = false
   registerRelayPluginHandlers(fakeDispatcher(), {
     pluginsDir: tmp,
     stateFilePath: join(tmp, 'state.json'),
@@ -78,13 +96,13 @@ afterEach(() => {
 describe('relay plugin handlers', () => {
   it('plugin.list returns discovered plugins', async () => {
     installFixture()
-    const result = (await handlers.get('plugin.list')!({}, null)) as { plugins: { id: string }[] }
+    const result = (await handlers.get('plugin.list')!({}, {})) as { plugins: { id: string }[] }
     expect(result.plugins.map((p) => p.id)).toEqual(['acme.foo'])
   })
 
   it('plugin.getEntry returns the single UI html', async () => {
     installFixture()
-    const result = (await handlers.get('plugin.getEntry')!({ pluginId: 'acme.foo' }, null)) as {
+    const result = (await handlers.get('plugin.getEntry')!({ pluginId: 'acme.foo' }, {})) as {
       ok: boolean
       html?: string
     }
@@ -93,7 +111,7 @@ describe('relay plugin handlers', () => {
   })
 
   it('plugin.getEntry rejects an unknown plugin', async () => {
-    const result = (await handlers.get('plugin.getEntry')!({ pluginId: 'nope' }, null)) as {
+    const result = (await handlers.get('plugin.getEntry')!({ pluginId: 'nope' }, {})) as {
       ok: boolean
     }
     expect(result.ok).toBe(false)
@@ -103,7 +121,7 @@ describe('relay plugin handlers', () => {
     const dir = join(tmp, 'acme.foo')
     mkdirSync(dir, { recursive: true })
     writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest()))
-    const result = (await handlers.get('plugin.getEntry')!({ pluginId: 'acme.foo' }, null)) as {
+    const result = (await handlers.get('plugin.getEntry')!({ pluginId: 'acme.foo' }, {})) as {
       ok: boolean
       error?: string
     }
@@ -112,7 +130,7 @@ describe('relay plugin handlers', () => {
 
   it('plugin.activate starts the backend for an installed plugin', async () => {
     installFixture()
-    const result = (await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, null)) as {
+    const result = (await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))) as {
       ok: boolean
     }
     expect(result.ok).toBe(true)
@@ -121,7 +139,7 @@ describe('relay plugin handlers', () => {
   })
 
   it('plugin.activate rejects an unknown id before forking', async () => {
-    const result = (await handlers.get('plugin.activate')!({ pluginId: 'nope' }, null)) as {
+    const result = (await handlers.get('plugin.activate')!({ pluginId: 'nope' }, ctx(1))) as {
       ok: boolean
       error?: string
     }
@@ -130,49 +148,84 @@ describe('relay plugin handlers', () => {
   })
 
   it('plugin.activate rejects a traversal-shaped id before forking', async () => {
-    const result = (await handlers.get('plugin.activate')!({ pluginId: '../evil' }, null)) as {
+    const result = (await handlers.get('plugin.activate')!({ pluginId: '../evil' }, ctx(1))) as {
       ok: boolean
     }
     expect(result.ok).toBe(false)
     expect(hosts).toHaveLength(0)
   })
 
+  it('plugin.deactivate rejects a traversal-shaped id', async () => {
+    const result = (await handlers.get('plugin.deactivate')!({ pluginId: '../evil' }, ctx(1))) as {
+      ok: boolean
+      error?: string
+    }
+    expect(result).toEqual({ ok: false, error: 'invalid_params' })
+  })
+
   it('plugin.postUi lazily activates and forwards the message to the child', async () => {
     installFixture()
     const result = (await handlers.get('plugin.postUi')!(
       { pluginId: 'acme.foo', message: { reqId: 'r1', method: 'settings.get' } },
-      null
+      ctx(1)
     )) as { ok: boolean }
     expect(result.ok).toBe(true)
     expect(hosts).toHaveLength(1)
     expect(hosts[0].posted).toEqual([{ reqId: 'r1', method: 'settings.get' }])
   })
 
+  it('plugin.postUi returns activation_failed when the backend cannot start', async () => {
+    installFixture()
+    failStart = true
+    const result = (await handlers.get('plugin.postUi')!(
+      { pluginId: 'acme.foo', message: {} },
+      ctx(1)
+    )) as { ok: boolean; error?: string }
+    expect(result).toEqual({ ok: false, error: 'activation_failed' })
+  })
+
   it('plugin.postUi rejects an unknown id', async () => {
     const result = (await handlers.get('plugin.postUi')!(
       { pluginId: 'nope', message: {} },
-      null
-    )) as { ok: boolean; error?: string }
+      ctx(1)
+    )) as {
+      ok: boolean
+      error?: string
+    }
     expect(result).toEqual({ ok: false, error: 'unknown_plugin' })
   })
 
-  it('pushes child outbound messages to the client as plugin.uiMessage notifications', async () => {
+  it('routes child uiMessages only to the client that opened the plugin', async () => {
     installFixture()
-    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, null)
-    // Simulate the child posting a bridge response back out.
+    // Client 1 opens the plugin; client 2 never does.
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
     hosts[0].config.onUiMessage!({ reqId: 'r1', ok: true, result: null })
-    expect(notifications).toContainEqual({
-      method: 'plugin.uiMessage',
-      params: { pluginId: 'acme.foo', message: { reqId: 'r1', ok: true, result: null } }
-    })
+    expect(notifications).toEqual([
+      {
+        clientId: 1,
+        method: 'plugin.uiMessage',
+        params: { pluginId: 'acme.foo', message: { reqId: 'r1', ok: true, result: null } }
+      }
+    ])
+    // Nothing was sent to any other client — no cross-client leak.
+    expect(notifications.every((n) => n.clientId === 1)).toBe(true)
+  })
+
+  it('stops delivering to a client after it detaches', async () => {
+    installFixture()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    detachListeners.forEach((fn) => fn(1))
+    hosts[0].config.onUiMessage!({ reqId: 'r1', ok: true })
+    expect(notifications).toHaveLength(0)
   })
 
   it('plugin.deactivate stops the backend', async () => {
     installFixture()
-    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, null)
-    const result = (await handlers.get('plugin.deactivate')!({ pluginId: 'acme.foo' }, null)) as {
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    const result = (await handlers.get('plugin.deactivate')!({ pluginId: 'acme.foo' }, ctx(1))) as {
       ok: boolean
     }
     expect(result.ok).toBe(true)
+    expect(hosts[0].stopped).toBe(true)
   })
 })

--- a/src/relay/plugin-handler.test.ts
+++ b/src/relay/plugin-handler.test.ts
@@ -219,7 +219,7 @@ describe('relay plugin handlers', () => {
     expect(notifications).toHaveLength(0)
   })
 
-  it('plugin.deactivate stops the backend', async () => {
+  it('plugin.deactivate stops the backend for the only subscriber', async () => {
     installFixture()
     await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
     const result = (await handlers.get('plugin.deactivate')!({ pluginId: 'acme.foo' }, ctx(1))) as {
@@ -227,5 +227,45 @@ describe('relay plugin handlers', () => {
     }
     expect(result.ok).toBe(true)
     expect(hosts[0].stopped).toBe(true)
+  })
+
+  it('keeps the shared backend running until the last subscriber deactivates', async () => {
+    installFixture()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(2))
+    // One shared child for both clients.
+    expect(hosts).toHaveLength(1)
+    await handlers.get('plugin.deactivate')!({ pluginId: 'acme.foo' }, ctx(1))
+    expect(hosts[0].stopped).toBe(false)
+    await handlers.get('plugin.deactivate')!({ pluginId: 'acme.foo' }, ctx(2))
+    expect(hosts[0].stopped).toBe(true)
+  })
+
+  it('stops the child only when the last subscriber detaches', async () => {
+    installFixture()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(2))
+    detachListeners.forEach((fn) => fn(1))
+    await Promise.resolve()
+    expect(hosts[0].stopped).toBe(false)
+    detachListeners.forEach((fn) => fn(2))
+    await Promise.resolve()
+    expect(hosts[0].stopped).toBe(true)
+  })
+
+  it('plugin.deactivate with no clientId fully stops the backend', async () => {
+    installFixture()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    await handlers.get('plugin.deactivate')!({ pluginId: 'acme.foo' }, {})
+    expect(hosts[0].stopped).toBe(true)
+  })
+
+  it('plugin.deactivate on a never-activated plugin is a no-op success', async () => {
+    installFixture()
+    const result = (await handlers.get('plugin.deactivate')!({ pluginId: 'acme.foo' }, ctx(1))) as {
+      ok: boolean
+    }
+    expect(result.ok).toBe(true)
+    expect(hosts).toHaveLength(0)
   })
 })

--- a/src/relay/plugin-handler.test.ts
+++ b/src/relay/plugin-handler.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { registerRelayPluginHandlers, type RelayDispatcherLike } from './plugin-handler'
+
+function manifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'acme.foo',
+    name: 'Foo',
+    version: '1.0.0',
+    hostApiVersion: '0.1.0',
+    main: 'main.js',
+    contributes: { sidebar: { title: 'Foo', icon: 'Activity', ui: 'index.html' } },
+    capabilities: ['workspace:read'],
+    ...overrides
+  }
+}
+
+let tmp: string
+let handlers: Map<string, (params: Record<string, unknown>, ctx: unknown) => Promise<unknown>>
+
+function fakeDispatcher(): RelayDispatcherLike {
+  handlers = new Map()
+  return { onRequest: (method, handler) => handlers.set(method, handler) }
+}
+
+function installFixture(): void {
+  const dir = join(tmp, 'acme.foo')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest()))
+  writeFileSync(join(dir, 'index.html'), '<!doctype html><body>hi</body>')
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'relay-plugin-'))
+  registerRelayPluginHandlers(fakeDispatcher(), {
+    pluginsDir: tmp,
+    getWorkspaceSnapshot: () => ({
+      workspaceName: 'w',
+      currentBranch: 'main',
+      isDirty: false,
+      openFileCount: 1
+    })
+  })
+})
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('relay plugin handlers', () => {
+  it('plugin.list returns discovered plugins', async () => {
+    installFixture()
+    const result = (await handlers.get('plugin.list')!({}, null)) as { plugins: { id: string }[] }
+    expect(result.plugins.map((p) => p.id)).toEqual(['acme.foo'])
+  })
+
+  it('plugin.getEntry returns the single UI html', async () => {
+    installFixture()
+    const result = (await handlers.get('plugin.getEntry')!({ pluginId: 'acme.foo' }, null)) as {
+      ok: boolean
+      html?: string
+    }
+    expect(result.ok).toBe(true)
+    expect(result.html).toContain('<body>hi</body>')
+  })
+
+  it('plugin.getEntry rejects an unknown plugin', async () => {
+    const result = (await handlers.get('plugin.getEntry')!({ pluginId: 'nope' }, null)) as {
+      ok: boolean
+    }
+    expect(result.ok).toBe(false)
+  })
+
+  it('plugin.bridge gates workspace.getSnapshot and returns a projected snapshot', async () => {
+    installFixture()
+    const ok = (await handlers.get('plugin.bridge')!(
+      { pluginId: 'acme.foo', request: { reqId: 'r1', method: 'workspace.getSnapshot' } },
+      null
+    )) as { ok: boolean; result?: Record<string, unknown> }
+    expect(ok.ok).toBe(true)
+    expect(Object.keys(ok.result ?? {}).sort()).toEqual([
+      'currentBranch',
+      'isDirty',
+      'openFileCount',
+      'workspaceName'
+    ])
+  })
+
+  it('plugin.bridge denies an undeclared capability', async () => {
+    installFixture()
+    const denied = (await handlers.get('plugin.bridge')!(
+      { pluginId: 'acme.foo', request: { reqId: 'r1', method: 'settings.get' } },
+      null
+    )) as { ok: boolean; error?: string }
+    expect(denied.ok).toBe(false)
+    expect(denied.error).toBe('capability_denied')
+  })
+})

--- a/src/relay/plugin-handler.test.ts
+++ b/src/relay/plugin-handler.test.ts
@@ -268,4 +268,23 @@ describe('relay plugin handlers', () => {
     expect(result.ok).toBe(true)
     expect(hosts).toHaveLength(0)
   })
+
+  it('deactivate by a non-subscriber leaves another client’s child running', async () => {
+    installFixture()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    // Client 2 never activated this plugin; its deactivate must not stop client 1's child.
+    await handlers.get('plugin.deactivate')!({ pluginId: 'acme.foo' }, ctx(2))
+    expect(hosts[0].stopped).toBe(false)
+  })
+
+  it('detaching a client releases every plugin it had open', async () => {
+    installFixture('acme.foo')
+    installFixture('acme.bar')
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.bar' }, ctx(1))
+    expect(hosts).toHaveLength(2)
+    detachListeners.forEach((fn) => fn(1))
+    await Promise.resolve()
+    expect(hosts.every((h) => h.stopped)).toBe(true)
+  })
 })

--- a/src/relay/plugin-handler.test.ts
+++ b/src/relay/plugin-handler.test.ts
@@ -310,3 +310,87 @@ describe('relay plugin handlers', () => {
 })
 
 const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64')
+
+describe('relay plugin discovery cache', () => {
+  // Register a fresh handler set whose discovery scans are counted, so cache
+  // hits/invalidations are assertable without real-filesystem churn.
+  function registerCounting(): { scans: () => number } {
+    let scans = 0
+    registerRelayPluginHandlers(fakeDispatcher(), {
+      pluginsDir: tmp,
+      stateFilePath: join(tmp, 'state.json'),
+      getWorkspaceSnapshot: () => ({
+        workspaceName: 'w',
+        currentBranch: 'main',
+        isDirty: false,
+        openFileCount: 1
+      }),
+      hostFactory: fakeHostFactory,
+      discover: (dir) => {
+        scans++
+        return discoverPlugins(dir)
+      }
+    })
+    return { scans: () => scans }
+  }
+
+  it('scans once for back-to-back list/activate/getEntry (cache hit)', async () => {
+    installFixture()
+    const counter = registerCounting()
+    await handlers.get('plugin.list')!({}, {})
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    await handlers.get('plugin.getEntry')!({ pluginId: 'acme.foo' }, {})
+    expect(counter.scans()).toBe(1)
+  })
+
+  it('invalidates on a successful provision so the new plugin activates', async () => {
+    installFixture('acme.foo')
+    const counter = registerCounting()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1)) // scan 1, cached
+    const bundle = serializePluginBundle('acme.bar', [
+      { path: 'plugin.json', dataBase64: b64(JSON.stringify(manifest({ id: 'acme.bar' }))) },
+      { path: 'index.html', dataBase64: b64('<!doctype html>') }
+    ])
+    const provisioned = (await handlers.get('plugin.provision')!({ bundle }, {})) as { ok: boolean }
+    expect(provisioned.ok).toBe(true)
+    const activated = (await handlers.get('plugin.activate')!(
+      { pluginId: 'acme.bar' },
+      ctx(1)
+    )) as { ok: boolean }
+    expect(activated.ok).toBe(true) // not a stale unknown_plugin
+    expect(counter.scans()).toBe(2) // cache was cleared by the provision
+  })
+
+  it('does not invalidate on a failed provision', async () => {
+    installFixture()
+    const counter = registerCounting()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1)) // scan 1, cached
+    const failed = (await handlers.get('plugin.provision')!({ bundle: null }, {})) as {
+      ok: boolean
+    }
+    expect(failed.ok).toBe(false)
+    await handlers.get('plugin.list')!({}, {}) // cache read, no re-scan
+    expect(counter.scans()).toBe(1)
+  })
+
+  it('rejects an unsafe pluginId before touching discovery (id-safety gate first)', async () => {
+    const counter = registerCounting()
+    const result = (await handlers.get('plugin.activate')!({ pluginId: '../evil' }, ctx(1))) as {
+      ok: boolean
+      error?: string
+    }
+    expect(result).toEqual({ ok: false, error: 'unknown_plugin' })
+    expect(counter.scans()).toBe(0) // discovery never ran
+  })
+
+  it('keeps a fresh cache per handler instance (no cross-instance leakage)', async () => {
+    installFixture()
+    const first = registerCounting()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    expect(first.scans()).toBe(1)
+    // A second registration starts cold and must scan on its own first read.
+    const second = registerCounting()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, ctx(1))
+    expect(second.scans()).toBe(1)
+  })
+})

--- a/src/relay/plugin-handler.test.ts
+++ b/src/relay/plugin-handler.test.ts
@@ -383,6 +383,38 @@ describe('relay plugin discovery cache', () => {
     expect(counter.scans()).toBe(0) // discovery never ran
   })
 
+  it('plugin.getEntry also gates an unsafe pluginId before touching discovery', async () => {
+    const counter = registerCounting()
+    const result = (await handlers.get('plugin.getEntry')!({ pluginId: '../evil' }, {})) as {
+      ok: boolean
+      error?: string
+    }
+    expect(result).toEqual({ ok: false, error: 'unknown_plugin' })
+    expect(counter.scans()).toBe(0)
+  })
+
+  it('plugin.postUi reads the cache instead of re-scanning', async () => {
+    installFixture()
+    const counter = registerCounting()
+    await handlers.get('plugin.list')!({}, {}) // warm the cache (scan 1)
+    await handlers.get('plugin.postUi')!({ pluginId: 'acme.foo', message: {} }, ctx(1))
+    expect(counter.scans()).toBe(1)
+  })
+
+  it('a newly-provisioned plugin appears in plugin.list (cache invalidated)', async () => {
+    const counter = registerCounting()
+    await handlers.get('plugin.list')!({}, {}) // scan 1, cached (empty)
+    const bundle = serializePluginBundle('acme.bar', [
+      { path: 'plugin.json', dataBase64: b64(JSON.stringify(manifest({ id: 'acme.bar' }))) },
+      { path: 'index.html', dataBase64: b64('<!doctype html>') }
+    ])
+    const provisioned = (await handlers.get('plugin.provision')!({ bundle }, {})) as { ok: boolean }
+    expect(provisioned.ok).toBe(true)
+    const listed = (await handlers.get('plugin.list')!({}, {})) as { plugins: { id: string }[] }
+    expect(listed.plugins.map((p) => p.id)).toContain('acme.bar')
+    expect(counter.scans()).toBe(2) // re-scanned after invalidation
+  })
+
   it('keeps a fresh cache per handler instance (no cross-instance leakage)', async () => {
     installFixture()
     const first = registerCounting()

--- a/src/relay/plugin-handler.test.ts
+++ b/src/relay/plugin-handler.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { registerRelayPluginHandlers, type RelayDispatcherLike } from './plugin-handler'
+import type { PluginHostConfig } from '../main/plugin/plugin-host-process'
+import type { PluginHostLike } from '../main/plugin/plugin-runtime'
 
 function manifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -17,31 +19,56 @@ function manifest(overrides: Record<string, unknown> = {}): Record<string, unkno
   }
 }
 
+type Handler = (params: Record<string, unknown>, ctx: unknown) => Promise<unknown>
+type FakeHost = PluginHostLike & { config: PluginHostConfig; posted: unknown[] }
+
 let tmp: string
-let handlers: Map<string, (params: Record<string, unknown>, ctx: unknown) => Promise<unknown>>
+let handlers: Map<string, Handler>
+let notifications: { method: string; params?: Record<string, unknown> }[]
+let hosts: FakeHost[]
 
 function fakeDispatcher(): RelayDispatcherLike {
   handlers = new Map()
-  return { onRequest: (method, handler) => handlers.set(method, handler) }
+  notifications = []
+  return {
+    onRequest: (method, handler) => handlers.set(method, handler),
+    notify: (method, params) => notifications.push({ method, params })
+  }
 }
 
-function installFixture(): void {
-  const dir = join(tmp, 'acme.foo')
+function fakeHostFactory(config: PluginHostConfig): FakeHost {
+  const host: FakeHost = {
+    config,
+    posted: [],
+    start: () => Promise.resolve(),
+    stop: () => Promise.resolve(),
+    isRunning: () => true,
+    postUi: (message) => host.posted.push(message)
+  }
+  hosts.push(host)
+  return host
+}
+
+function installFixture(id = 'acme.foo'): void {
+  const dir = join(tmp, id)
   mkdirSync(dir, { recursive: true })
-  writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest()))
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest({ id })))
   writeFileSync(join(dir, 'index.html'), '<!doctype html><body>hi</body>')
 }
 
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), 'relay-plugin-'))
+  hosts = []
   registerRelayPluginHandlers(fakeDispatcher(), {
     pluginsDir: tmp,
+    stateFilePath: join(tmp, 'state.json'),
     getWorkspaceSnapshot: () => ({
       workspaceName: 'w',
       currentBranch: 'main',
       isDirty: false,
       openFileCount: 1
-    })
+    }),
+    hostFactory: fakeHostFactory
   })
 })
 afterEach(() => {
@@ -72,33 +99,7 @@ describe('relay plugin handlers', () => {
     expect(result.ok).toBe(false)
   })
 
-  it('plugin.bridge gates workspace.getSnapshot and returns a projected snapshot', async () => {
-    installFixture()
-    const ok = (await handlers.get('plugin.bridge')!(
-      { pluginId: 'acme.foo', request: { reqId: 'r1', method: 'workspace.getSnapshot' } },
-      null
-    )) as { ok: boolean; result?: Record<string, unknown> }
-    expect(ok.ok).toBe(true)
-    expect(Object.keys(ok.result ?? {}).sort()).toEqual([
-      'currentBranch',
-      'isDirty',
-      'openFileCount',
-      'workspaceName'
-    ])
-  })
-
-  it('plugin.bridge denies an undeclared capability', async () => {
-    installFixture()
-    const denied = (await handlers.get('plugin.bridge')!(
-      { pluginId: 'acme.foo', request: { reqId: 'r1', method: 'settings.get' } },
-      null
-    )) as { ok: boolean; error?: string }
-    expect(denied.ok).toBe(false)
-    expect(denied.error).toBe('capability_denied')
-  })
-
   it('plugin.getEntry reports entry_missing when the UI file is absent', async () => {
-    // Manifest present, but no index.html written alongside it.
     const dir = join(tmp, 'acme.foo')
     mkdirSync(dir, { recursive: true })
     writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest()))
@@ -106,46 +107,72 @@ describe('relay plugin handlers', () => {
       ok: boolean
       error?: string
     }
-    expect(result.ok).toBe(false)
-    expect(result.error).toBe('entry_missing')
+    expect(result).toEqual({ ok: false, error: 'entry_missing' })
   })
 
-  it('plugin.bridge rejects a malformed request with invalid_params', async () => {
+  it('plugin.activate starts the backend for an installed plugin', async () => {
     installFixture()
-    const noRequest = (await handlers.get('plugin.bridge')!({ pluginId: 'acme.foo' }, null)) as {
+    const result = (await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, null)) as {
+      ok: boolean
+    }
+    expect(result.ok).toBe(true)
+    expect(hosts).toHaveLength(1)
+    expect(hosts[0].config.pluginId).toBe('acme.foo')
+  })
+
+  it('plugin.activate rejects an unknown id before forking', async () => {
+    const result = (await handlers.get('plugin.activate')!({ pluginId: 'nope' }, null)) as {
       ok: boolean
       error?: string
     }
-    expect(noRequest).toEqual({ ok: false, error: 'invalid_params' })
-    const badReqId = (await handlers.get('plugin.bridge')!(
-      { pluginId: 'acme.foo', request: { reqId: 42, method: 'workspace.getSnapshot' } },
+    expect(result).toEqual({ ok: false, error: 'unknown_plugin' })
+    expect(hosts).toHaveLength(0)
+  })
+
+  it('plugin.activate rejects a traversal-shaped id before forking', async () => {
+    const result = (await handlers.get('plugin.activate')!({ pluginId: '../evil' }, null)) as {
+      ok: boolean
+    }
+    expect(result.ok).toBe(false)
+    expect(hosts).toHaveLength(0)
+  })
+
+  it('plugin.postUi lazily activates and forwards the message to the child', async () => {
+    installFixture()
+    const result = (await handlers.get('plugin.postUi')!(
+      { pluginId: 'acme.foo', message: { reqId: 'r1', method: 'settings.get' } },
+      null
+    )) as { ok: boolean }
+    expect(result.ok).toBe(true)
+    expect(hosts).toHaveLength(1)
+    expect(hosts[0].posted).toEqual([{ reqId: 'r1', method: 'settings.get' }])
+  })
+
+  it('plugin.postUi rejects an unknown id', async () => {
+    const result = (await handlers.get('plugin.postUi')!(
+      { pluginId: 'nope', message: {} },
       null
     )) as { ok: boolean; error?: string }
-    expect(badReqId).toEqual({ ok: false, error: 'invalid_params' })
+    expect(result).toEqual({ ok: false, error: 'unknown_plugin' })
   })
 
-  it('plugin.bridge returns an unknown_plugin BridgeResponse for an unregistered id', async () => {
-    const result = (await handlers.get('plugin.bridge')!(
-      { pluginId: 'does.not.exist', request: { reqId: 'r1', method: 'workspace.getSnapshot' } },
-      null
-    )) as { reqId: string; ok: boolean; error?: string }
-    expect(result).toEqual({ reqId: 'r1', ok: false, error: 'unknown_plugin' })
+  it('pushes child outbound messages to the client as plugin.uiMessage notifications', async () => {
+    installFixture()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, null)
+    // Simulate the child posting a bridge response back out.
+    hosts[0].config.onUiMessage!({ reqId: 'r1', ok: true, result: null })
+    expect(notifications).toContainEqual({
+      method: 'plugin.uiMessage',
+      params: { pluginId: 'acme.foo', message: { reqId: 'r1', ok: true, result: null } }
+    })
   })
 
-  it('plugin.bridge returns internal for a gate-granted method the relay cannot fulfil', async () => {
-    // commands.invokeHost is granted by the 'commands' capability, but the relay
-    // has no trusted backend yet, so the deferred path returns 'internal'.
-    const dir = join(tmp, 'acme.cmd')
-    mkdirSync(dir, { recursive: true })
-    writeFileSync(
-      join(dir, 'plugin.json'),
-      JSON.stringify(manifest({ id: 'acme.cmd', capabilities: ['commands'] }))
-    )
-    writeFileSync(join(dir, 'index.html'), '<!doctype html>')
-    const result = (await handlers.get('plugin.bridge')!(
-      { pluginId: 'acme.cmd', request: { reqId: 'r1', method: 'commands.invokeHost' } },
-      null
-    )) as { reqId: string; ok: boolean; error?: string }
-    expect(result).toEqual({ reqId: 'r1', ok: false, error: 'internal' })
+  it('plugin.deactivate stops the backend', async () => {
+    installFixture()
+    await handlers.get('plugin.activate')!({ pluginId: 'acme.foo' }, null)
+    const result = (await handlers.get('plugin.deactivate')!({ pluginId: 'acme.foo' }, null)) as {
+      ok: boolean
+    }
+    expect(result.ok).toBe(true)
   })
 })

--- a/src/relay/plugin-handler.test.ts
+++ b/src/relay/plugin-handler.test.ts
@@ -96,4 +96,56 @@ describe('relay plugin handlers', () => {
     expect(denied.ok).toBe(false)
     expect(denied.error).toBe('capability_denied')
   })
+
+  it('plugin.getEntry reports entry_missing when the UI file is absent', async () => {
+    // Manifest present, but no index.html written alongside it.
+    const dir = join(tmp, 'acme.foo')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest()))
+    const result = (await handlers.get('plugin.getEntry')!({ pluginId: 'acme.foo' }, null)) as {
+      ok: boolean
+      error?: string
+    }
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('entry_missing')
+  })
+
+  it('plugin.bridge rejects a malformed request with invalid_params', async () => {
+    installFixture()
+    const noRequest = (await handlers.get('plugin.bridge')!({ pluginId: 'acme.foo' }, null)) as {
+      ok: boolean
+      error?: string
+    }
+    expect(noRequest).toEqual({ ok: false, error: 'invalid_params' })
+    const badReqId = (await handlers.get('plugin.bridge')!(
+      { pluginId: 'acme.foo', request: { reqId: 42, method: 'workspace.getSnapshot' } },
+      null
+    )) as { ok: boolean; error?: string }
+    expect(badReqId).toEqual({ ok: false, error: 'invalid_params' })
+  })
+
+  it('plugin.bridge returns an unknown_plugin BridgeResponse for an unregistered id', async () => {
+    const result = (await handlers.get('plugin.bridge')!(
+      { pluginId: 'does.not.exist', request: { reqId: 'r1', method: 'workspace.getSnapshot' } },
+      null
+    )) as { reqId: string; ok: boolean; error?: string }
+    expect(result).toEqual({ reqId: 'r1', ok: false, error: 'unknown_plugin' })
+  })
+
+  it('plugin.bridge returns internal for a gate-granted method the relay cannot fulfil', async () => {
+    // commands.invokeHost is granted by the 'commands' capability, but the relay
+    // has no trusted backend yet, so the deferred path returns 'internal'.
+    const dir = join(tmp, 'acme.cmd')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, 'plugin.json'),
+      JSON.stringify(manifest({ id: 'acme.cmd', capabilities: ['commands'] }))
+    )
+    writeFileSync(join(dir, 'index.html'), '<!doctype html>')
+    const result = (await handlers.get('plugin.bridge')!(
+      { pluginId: 'acme.cmd', request: { reqId: 'r1', method: 'commands.invokeHost' } },
+      null
+    )) as { reqId: string; ok: boolean; error?: string }
+    expect(result).toEqual({ reqId: 'r1', ok: false, error: 'internal' })
+  })
 })

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -96,6 +96,8 @@ export function registerRelayPluginHandlers(
   // Drop one client's subscription; stop the shared backend child only when the
   // last subscriber for that plugin leaves (refcount). A missing clientId means
   // a full stop (clears the set and deactivates regardless).
+  // Note: a crash-restart that fires between the last subscriber dropping and the
+  // deactivate is a narrow message-loss window, not an orphan (bounded restarts).
   const releasePlugin = async (pluginId: string, clientId: number | undefined): Promise<void> => {
     const set = subscribers.get(pluginId)
     if (clientId !== undefined && set) {
@@ -113,7 +115,11 @@ export function registerRelayPluginHandlers(
   dispatcher.onClientDetached((clientId) => {
     for (const [pluginId, set] of subscribers) {
       if (set.has(clientId)) {
-        void releasePlugin(pluginId, clientId)
+        // Fire-and-forget: surface a failed deactivate rather than dropping it
+        // as an unhandled rejection (the relay only logs those).
+        releasePlugin(pluginId, clientId).catch((error: unknown) => {
+          process.stderr.write(`[relay] plugin '${pluginId}' release failed: ${String(error)}\n`)
+        })
       }
     }
   })

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { discoverPlugins } from '../main/plugin/plugin-discovery'
+import { discoverPlugins, type DiscoveryResult } from '../main/plugin/plugin-discovery'
 import { isSafePluginId } from '../shared/plugin/manifest'
 import type { WorkspaceSnapshot } from '../shared/plugin/api-contract'
 import type { PluginHostFactory } from '../main/plugin/plugin-runtime'
@@ -45,25 +45,37 @@ export type RelayPluginConfig = {
   stateFilePath?: string
   stagingDir?: string
   hostFactory?: PluginHostFactory
+  // Injectable for tests so a counting fake makes the discovery-cache scan count
+  // observable; defaults to the real disk scanner.
+  discover?: (pluginsDir: string) => DiscoveryResult
 }
 
 type PluginMeta = { id: string; title: string; icon: string; version: string; ui: string }
-
-// Boundary validation: the id must be structurally safe AND match an installed,
-// validated manifest. Both gates run before any activation/messaging so a client
-// can't name an arbitrary id (closes the confused-deputy concern for the backend
-// path), and so traversal-shaped ids never reach the runtime.
-function isInstalledPlugin(pluginsDir: string, pluginId: string): boolean {
-  if (!isSafePluginId(pluginId)) {
-    return false
-  }
-  return discoverPlugins(pluginsDir).valid.some((p) => p.manifest.id === pluginId)
-}
 
 export function registerRelayPluginHandlers(
   dispatcher: RelayDispatcherLike,
   config: RelayPluginConfig
 ): { stopAll: () => Promise<void>; stopAllSync: () => void } {
+  // Discovery is a full plugins-dir scan + per-manifest validate; memoize it so
+  // back-to-back requests don't re-scan. The installed set only changes via
+  // plugin.provision, which invalidates the cache on success (see below).
+  const discover = config.discover ?? discoverPlugins
+  let cachedDiscovery: DiscoveryResult | null = null
+  const getDiscovered = (): DiscoveryResult => (cachedDiscovery ??= discover(config.pluginsDir))
+  const invalidateDiscovery = (): void => {
+    cachedDiscovery = null
+  }
+
+  // Boundary validation: the id must be structurally safe AND match an installed,
+  // validated manifest. The isSafePluginId gate runs first so a client can't name
+  // an arbitrary id (confused-deputy) and traversal-shaped ids never reach the
+  // runtime or the cache lookup.
+  const isInstalledPlugin = (pluginId: string): boolean => {
+    if (!isSafePluginId(pluginId)) {
+      return false
+    }
+    return getDiscovered().valid.some((p) => p.manifest.id === pluginId)
+  }
   // Which clients have opened each plugin. A backend response carries one
   // client's data (settings, workspace snapshot), so it must be routed only to
   // the clients that opened that plugin — never broadcast to every client.
@@ -128,7 +140,7 @@ export function registerRelayPluginHandlers(
   })
 
   dispatcher.onRequest('plugin.list', async () => {
-    const result = discoverPlugins(config.pluginsDir)
+    const result = getDiscovered()
     const plugins: PluginMeta[] = result.valid.map((p) => ({
       id: p.manifest.id,
       title: p.manifest.contributes.sidebar.title,
@@ -144,7 +156,7 @@ export function registerRelayPluginHandlers(
   // single self-contained file).
   dispatcher.onRequest('plugin.getEntry', async (params) => {
     const pluginId = String(params.pluginId ?? '')
-    const found = discoverPlugins(config.pluginsDir).valid.find((p) => p.manifest.id === pluginId)
+    const found = getDiscovered().valid.find((p) => p.manifest.id === pluginId)
     if (!found) {
       return { ok: false, error: 'unknown_plugin' }
     }
@@ -165,16 +177,23 @@ export function registerRelayPluginHandlers(
     // interleave (the event loop is blocked through each call) — no per-id lock
     // needed. Staging defaults to a same-volume sibling of the plugins dir so the
     // final rename is atomic.
-    return provisionPlugin(params.bundle, {
+    const result = provisionPlugin(params.bundle, {
       pluginsDir: config.pluginsDir,
       stagingDir: config.stagingDir ?? `${config.pluginsDir}-staging`
     })
+    // A successful provision changed the installed set on disk — drop the cache
+    // so a following plugin.activate discovers the new plugin (not stale
+    // unknown_plugin). A failed provision left the dir untouched: keep the cache.
+    if (result.ok) {
+      invalidateDiscovery()
+    }
+    return result
   })
 
   // Start the trusted backend child on the relay host.
   dispatcher.onRequest('plugin.activate', async (params, context) => {
     const pluginId = String(params.pluginId ?? '')
-    if (!isInstalledPlugin(config.pluginsDir, pluginId)) {
+    if (!isInstalledPlugin(pluginId)) {
       return { ok: false, error: 'unknown_plugin' }
     }
     subscribe(pluginId, context.clientId)
@@ -196,7 +215,7 @@ export function registerRelayPluginHandlers(
   // ahead of an explicit activate still reaches a running child.
   dispatcher.onRequest('plugin.postUi', async (params, context) => {
     const pluginId = String(params.pluginId ?? '')
-    if (!isInstalledPlugin(config.pluginsDir, pluginId)) {
+    if (!isInstalledPlugin(pluginId)) {
       return { ok: false, error: 'unknown_plugin' }
     }
     subscribe(pluginId, context.clientId)

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -1,0 +1,100 @@
+// NEEDS-RUNTIME-VERIFY: relay-side plugin host (mobile path). Registers plugin.*
+// JSON-RPC methods so the mobile app can list plugins, fetch a plugin's single
+// UI HTML, and route UI->backend bridge calls — all running where the workspace
+// lives (the relay host, possibly remote over SSH). Reuses the SHARED, electron-
+// free capability gate so the relay and the desktop main path enforce identical
+// decisions (KTD3); it does NOT import electron or src/main glue.
+//
+// v1c scope: list + getEntry + gated workspace snapshot. Running the trusted
+// backend child on the relay host and the host commands (open-url/clipboard,
+// which must round-trip to the device) are the follow-on remote-provisioning
+// work the plan flags as the hardest tier.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { discoverPlugins } from '../main/plugin/plugin-discovery'
+import { gateBridgeMethod, projectWorkspaceSnapshot } from '../shared/plugin/capability-gate'
+import type {
+  BridgeRequest,
+  BridgeResponse,
+  WorkspaceSnapshot
+} from '../shared/plugin/api-contract'
+import type { PluginCapability } from '../shared/plugin/manifest'
+
+export type RelayDispatcherLike = {
+  onRequest(
+    method: string,
+    handler: (params: Record<string, unknown>, context: unknown) => Promise<unknown>
+  ): void
+}
+
+export type RelayPluginConfig = {
+  pluginsDir: string
+  getWorkspaceSnapshot: () => WorkspaceSnapshot | Promise<WorkspaceSnapshot>
+}
+
+type PluginMeta = { id: string; title: string; icon: string; version: string; ui: string }
+
+function capabilitiesFor(pluginsDir: string, pluginId: string): PluginCapability[] | null {
+  const found = discoverPlugins(pluginsDir).valid.find((p) => p.manifest.id === pluginId)
+  return found ? found.manifest.capabilities : null
+}
+
+export function registerRelayPluginHandlers(
+  dispatcher: RelayDispatcherLike,
+  config: RelayPluginConfig
+): void {
+  dispatcher.onRequest('plugin.list', async () => {
+    const result = discoverPlugins(config.pluginsDir)
+    const plugins: PluginMeta[] = result.valid.map((p) => ({
+      id: p.manifest.id,
+      title: p.manifest.contributes.sidebar.title,
+      icon: p.manifest.contributes.sidebar.icon,
+      version: p.manifest.version,
+      ui: p.manifest.contributes.sidebar.ui
+    }))
+    return { plugins }
+  })
+
+  // Serve a plugin's single UI HTML inline (mobile feeds it to react-native-
+  // webview as { html } — no on-device server, which is why v1 mandates a
+  // single self-contained file).
+  dispatcher.onRequest('plugin.getEntry', async (params) => {
+    const pluginId = String(params.pluginId ?? '')
+    const found = discoverPlugins(config.pluginsDir).valid.find((p) => p.manifest.id === pluginId)
+    if (!found) {
+      return { ok: false, error: 'unknown_plugin' }
+    }
+    const htmlPath = join(config.pluginsDir, pluginId, found.manifest.contributes.sidebar.ui)
+    if (!existsSync(htmlPath)) {
+      return { ok: false, error: 'entry_missing' }
+    }
+    return { ok: true, html: readFileSync(htmlPath, 'utf8') }
+  })
+
+  // UI -> backend bridge, capability-gated by the SHARED gate.
+  dispatcher.onRequest('plugin.bridge', async (params) => {
+    const pluginId = String(params.pluginId ?? '')
+    const request = params.request as BridgeRequest | undefined
+    if (!request || typeof request.reqId !== 'string') {
+      return { ok: false, error: 'invalid_params' } satisfies
+        | BridgeResponse
+        | { ok: false; error: string }
+    }
+    const declared = capabilitiesFor(config.pluginsDir, pluginId)
+    if (!declared) {
+      return { reqId: request.reqId, ok: false, error: 'unknown_plugin' } satisfies BridgeResponse
+    }
+    const decision = gateBridgeMethod(declared, request.method)
+    if (!decision.granted) {
+      return { reqId: request.reqId, ok: false, error: decision.error } satisfies BridgeResponse
+    }
+    if (request.method === 'workspace.getSnapshot') {
+      const snapshot = projectWorkspaceSnapshot(await config.getWorkspaceSnapshot())
+      return { reqId: request.reqId, ok: true, result: snapshot } satisfies BridgeResponse
+    }
+    // commands/settings on the relay require the trusted backend + device
+    // round-trip (deferred); deny cleanly for now rather than half-acting.
+    return { reqId: request.reqId, ok: false, error: 'internal' } satisfies BridgeResponse
+  })
+}

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -65,7 +65,9 @@ export function registerRelayPluginHandlers(
     if (!found) {
       return { ok: false, error: 'unknown_plugin' }
     }
-    const htmlPath = join(config.pluginsDir, pluginId, found.manifest.contributes.sidebar.ui)
+    // Use the discovered dir, not a re-join of the client-supplied pluginId, so
+    // the served path is anchored to a validated manifest's own directory.
+    const htmlPath = join(found.dir, found.manifest.contributes.sidebar.ui)
     if (!existsSync(htmlPath)) {
       return { ok: false, error: 'entry_missing' }
     }
@@ -73,6 +75,12 @@ export function registerRelayPluginHandlers(
   })
 
   // UI -> backend bridge, capability-gated by the SHARED gate.
+  // SECURITY: pluginId comes from the client and only selects which validated
+  // manifest's declared capabilities gate the call. That is safe today because
+  // the only fulfilled method is workspace.getSnapshot (bounded empty snapshot);
+  // commands/settings return 'internal'. Before the deferred remote tier wires
+  // commands/settings here, bind pluginId to the authenticated relay session
+  // (per api-contract.ts) so a client can't name another plugin's capabilities.
   dispatcher.onRequest('plugin.bridge', async (params) => {
     const pluginId = String(params.pluginId ?? '')
     const request = params.request as BridgeRequest | undefined

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -39,9 +39,11 @@ export type RelayPluginConfig = {
   pluginsDir: string
   getWorkspaceSnapshot: () => WorkspaceSnapshot | Promise<WorkspaceSnapshot>
   // Optional overrides (tests / provisioning): the built host-entry path, the
-  // state file, and an injectable host factory to avoid forking real processes.
+  // state + staging dirs, and an injectable host factory to avoid forking real
+  // processes.
   entryPath?: string
   stateFilePath?: string
+  stagingDir?: string
   hostFactory?: PluginHostFactory
 }
 
@@ -159,9 +161,13 @@ export function registerRelayPluginHandlers(
   // plugins dir (verified + atomic). Must precede plugin.activate for a plugin
   // whose files aren't already on the relay host.
   dispatcher.onRequest('plugin.provision', async (params) => {
+    // provisionPlugin is fully synchronous, so concurrent provisions can't
+    // interleave (the event loop is blocked through each call) — no per-id lock
+    // needed. Staging defaults to a same-volume sibling of the plugins dir so the
+    // final rename is atomic.
     return provisionPlugin(params.bundle, {
       pluginsDir: config.pluginsDir,
-      stagingDir: `${config.pluginsDir}-staging`
+      stagingDir: config.stagingDir ?? `${config.pluginsDir}-staging`
     })
   })
 

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -1,49 +1,73 @@
 // NEEDS-RUNTIME-VERIFY: relay-side plugin host (mobile path). Registers plugin.*
 // JSON-RPC methods so the mobile app can list plugins, fetch a plugin's single
-// UI HTML, and route UI->backend bridge calls — all running where the workspace
-// lives (the relay host, possibly remote over SSH). Reuses the SHARED, electron-
-// free capability gate so the relay and the desktop main path enforce identical
-// decisions (KTD3); it does NOT import electron or src/main glue.
+// UI HTML, run the trusted backend child on the relay host, and round-trip
+// UI<->backend messages — all where the workspace lives (the relay host,
+// possibly remote over SSH).
 //
-// v1c scope: list + getEntry + gated workspace snapshot. Running the trusted
-// backend child on the relay host and the host commands (open-url/clipboard,
-// which must round-trip to the device) are the follow-on remote-provisioning
-// work the plan flags as the hardest tier.
+// The backend bridge is asynchronous message-passing (mirroring the desktop):
+// inbound webview messages are posted into the child via plugin.postUi; the
+// child answers with its own capability-gated handler and posts responses back,
+// which we push to the mobile client as plugin.uiMessage notifications. The
+// in-webview ui-bridge-client correlates reqIds, so settings/workspace round
+// trips work without the relay parsing the payload. Host commands
+// (open-url/clipboard) act on the device and are denied by the runtime (device
+// round-trip deferred).
 
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { discoverPlugins } from '../main/plugin/plugin-discovery'
-import { gateBridgeMethod, projectWorkspaceSnapshot } from '../shared/plugin/capability-gate'
-import type {
-  BridgeRequest,
-  BridgeResponse,
-  WorkspaceSnapshot
-} from '../shared/plugin/api-contract'
-import type { PluginCapability } from '../shared/plugin/manifest'
+import { isSafePluginId } from '../shared/plugin/manifest'
+import type { WorkspaceSnapshot } from '../shared/plugin/api-contract'
+import type { PluginHostFactory } from '../main/plugin/plugin-runtime'
+import { createRelayPluginRuntime } from './relay-plugin-runtime'
 
 export type RelayDispatcherLike = {
   onRequest(
     method: string,
     handler: (params: Record<string, unknown>, context: unknown) => Promise<unknown>
   ): void
+  notify(method: string, params?: Record<string, unknown>): void
 }
 
 export type RelayPluginConfig = {
   pluginsDir: string
   getWorkspaceSnapshot: () => WorkspaceSnapshot | Promise<WorkspaceSnapshot>
+  // Optional overrides (tests / provisioning): the built host-entry path, the
+  // state file, and an injectable host factory to avoid forking real processes.
+  entryPath?: string
+  stateFilePath?: string
+  hostFactory?: PluginHostFactory
 }
 
 type PluginMeta = { id: string; title: string; icon: string; version: string; ui: string }
 
-function capabilitiesFor(pluginsDir: string, pluginId: string): PluginCapability[] | null {
-  const found = discoverPlugins(pluginsDir).valid.find((p) => p.manifest.id === pluginId)
-  return found ? found.manifest.capabilities : null
+// Boundary validation: the id must be structurally safe AND match an installed,
+// validated manifest. Both gates run before any activation/messaging so a client
+// can't name an arbitrary id (closes the confused-deputy concern for the backend
+// path), and so traversal-shaped ids never reach the runtime.
+function isInstalledPlugin(pluginsDir: string, pluginId: string): boolean {
+  if (!isSafePluginId(pluginId)) {
+    return false
+  }
+  return discoverPlugins(pluginsDir).valid.some((p) => p.manifest.id === pluginId)
 }
 
 export function registerRelayPluginHandlers(
   dispatcher: RelayDispatcherLike,
   config: RelayPluginConfig
-): void {
+): { stopAll: () => Promise<void> } {
+  const { runtime } = createRelayPluginRuntime({
+    pluginsDir: config.pluginsDir,
+    entryPath: config.entryPath,
+    stateFilePath: config.stateFilePath,
+    getWorkspaceSnapshot: config.getWorkspaceSnapshot,
+    // Child outbound messages (bridge responses + lifecycle events) are pushed
+    // to the mobile client; the webview's ui-bridge-client matches reqIds.
+    onUiMessage: (pluginId, message) =>
+      dispatcher.notify('plugin.uiMessage', { pluginId, message }),
+    hostFactory: config.hostFactory
+  })
+
   dispatcher.onRequest('plugin.list', async () => {
     const result = discoverPlugins(config.pluginsDir)
     const plugins: PluginMeta[] = result.valid.map((p) => ({
@@ -74,35 +98,41 @@ export function registerRelayPluginHandlers(
     return { ok: true, html: readFileSync(htmlPath, 'utf8') }
   })
 
-  // UI -> backend bridge, capability-gated by the SHARED gate.
-  // SECURITY: pluginId comes from the client and only selects which validated
-  // manifest's declared capabilities gate the call. That is safe today because
-  // the only fulfilled method is workspace.getSnapshot (bounded empty snapshot);
-  // commands/settings return 'internal'. Before the deferred remote tier wires
-  // commands/settings here, bind pluginId to the authenticated relay session
-  // (per api-contract.ts) so a client can't name another plugin's capabilities.
-  dispatcher.onRequest('plugin.bridge', async (params) => {
+  // Start the trusted backend child on the relay host.
+  dispatcher.onRequest('plugin.activate', async (params) => {
     const pluginId = String(params.pluginId ?? '')
-    const request = params.request as BridgeRequest | undefined
-    if (!request || typeof request.reqId !== 'string') {
-      return { ok: false, error: 'invalid_params' } satisfies
-        | BridgeResponse
-        | { ok: false; error: string }
+    if (!isInstalledPlugin(config.pluginsDir, pluginId)) {
+      return { ok: false, error: 'unknown_plugin' }
     }
-    const declared = capabilitiesFor(config.pluginsDir, pluginId)
-    if (!declared) {
-      return { reqId: request.reqId, ok: false, error: 'unknown_plugin' } satisfies BridgeResponse
-    }
-    const decision = gateBridgeMethod(declared, request.method)
-    if (!decision.granted) {
-      return { reqId: request.reqId, ok: false, error: decision.error } satisfies BridgeResponse
-    }
-    if (request.method === 'workspace.getSnapshot') {
-      const snapshot = projectWorkspaceSnapshot(await config.getWorkspaceSnapshot())
-      return { reqId: request.reqId, ok: true, result: snapshot } satisfies BridgeResponse
-    }
-    // commands/settings on the relay require the trusted backend + device
-    // round-trip (deferred); deny cleanly for now rather than half-acting.
-    return { reqId: request.reqId, ok: false, error: 'internal' } satisfies BridgeResponse
+    return runtime.activate(pluginId)
   })
+
+  // Stop the backend child.
+  dispatcher.onRequest('plugin.deactivate', async (params) => {
+    const pluginId = String(params.pluginId ?? '')
+    if (!isSafePluginId(pluginId)) {
+      return { ok: false, error: 'invalid_params' }
+    }
+    await runtime.deactivate(pluginId)
+    return { ok: true }
+  })
+
+  // Inbound webview -> backend message. Lazily activates so a message that races
+  // ahead of an explicit activate still reaches a running child.
+  dispatcher.onRequest('plugin.postUi', async (params) => {
+    const pluginId = String(params.pluginId ?? '')
+    if (!isInstalledPlugin(config.pluginsDir, pluginId)) {
+      return { ok: false, error: 'unknown_plugin' }
+    }
+    if (!runtime.isRunning(pluginId)) {
+      const activated = await runtime.activate(pluginId)
+      if (!activated.ok) {
+        return { ok: false, error: 'activation_failed' }
+      }
+    }
+    runtime.postUi(pluginId, params.message)
+    return { ok: true }
+  })
+
+  return { stopAll: () => runtime.stopAll() }
 }

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -76,11 +76,6 @@ export function registerRelayPluginHandlers(
     }
     set.add(clientId)
   }
-  dispatcher.onClientDetached((clientId) => {
-    for (const set of subscribers.values()) {
-      set.delete(clientId)
-    }
-  })
 
   const { runtime } = createRelayPluginRuntime({
     pluginsDir: config.pluginsDir,
@@ -96,6 +91,31 @@ export function registerRelayPluginHandlers(
       }
     },
     hostFactory: config.hostFactory
+  })
+
+  // Drop one client's subscription; stop the shared backend child only when the
+  // last subscriber for that plugin leaves (refcount). A missing clientId means
+  // a full stop (clears the set and deactivates regardless).
+  const releasePlugin = async (pluginId: string, clientId: number | undefined): Promise<void> => {
+    const set = subscribers.get(pluginId)
+    if (clientId !== undefined && set) {
+      set.delete(clientId)
+      if (set.size > 0) {
+        return
+      }
+    }
+    subscribers.delete(pluginId)
+    await runtime.deactivate(pluginId)
+  }
+
+  // A dropped client releases every plugin it had open. releasePlugin only ever
+  // deletes the current pluginId key, which Map for-of tolerates.
+  dispatcher.onClientDetached((clientId) => {
+    for (const [pluginId, set] of subscribers) {
+      if (set.has(clientId)) {
+        void releasePlugin(pluginId, clientId)
+      }
+    }
   })
 
   dispatcher.onRequest('plugin.list', async () => {
@@ -139,13 +159,13 @@ export function registerRelayPluginHandlers(
   })
 
   // Stop the backend child.
-  dispatcher.onRequest('plugin.deactivate', async (params) => {
+  dispatcher.onRequest('plugin.deactivate', async (params, context) => {
     const pluginId = String(params.pluginId ?? '')
     if (!isSafePluginId(pluginId)) {
       return { ok: false, error: 'invalid_params' }
     }
-    await runtime.deactivate(pluginId)
-    subscribers.delete(pluginId)
+    // Refcounted: stops the child only when this was the last subscriber.
+    await releasePlugin(pluginId, context.clientId)
     return { ok: true }
   })
 

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -156,6 +156,11 @@ export function registerRelayPluginHandlers(
   // single self-contained file).
   dispatcher.onRequest('plugin.getEntry', async (params) => {
     const pluginId = String(params.pluginId ?? '')
+    // Same id-safety gate as activate/postUi, first: short-circuits unsafe ids
+    // before the cache lookup and keeps one boundary-contract shape everywhere.
+    if (!isSafePluginId(pluginId)) {
+      return { ok: false, error: 'unknown_plugin' }
+    }
     const found = getDiscovered().valid.find((p) => p.manifest.id === pluginId)
     if (!found) {
       return { ok: false, error: 'unknown_plugin' }
@@ -166,7 +171,13 @@ export function registerRelayPluginHandlers(
     if (!existsSync(htmlPath)) {
       return { ok: false, error: 'entry_missing' }
     }
-    return { ok: true, html: readFileSync(htmlPath, 'utf8') }
+    // Return the structured contract on an I/O race (file removed after the
+    // existsSync check) rather than leaking a raw fs error to the client.
+    try {
+      return { ok: true, html: readFileSync(htmlPath, 'utf8') }
+    } catch {
+      return { ok: false, error: 'entry_read_failed' }
+    }
   })
 
   // Receive a plugin bundle from the desktop and write it under the relay

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -21,12 +21,17 @@ import type { WorkspaceSnapshot } from '../shared/plugin/api-contract'
 import type { PluginHostFactory } from '../main/plugin/plugin-runtime'
 import { createRelayPluginRuntime } from './relay-plugin-runtime'
 
+export type RelayRequestContext = { clientId?: number }
+
 export type RelayDispatcherLike = {
   onRequest(
     method: string,
-    handler: (params: Record<string, unknown>, context: unknown) => Promise<unknown>
+    handler: (params: Record<string, unknown>, context: RelayRequestContext) => Promise<unknown>
   ): void
-  notify(method: string, params?: Record<string, unknown>): void
+  // Send a notification to a single client (by id). Used so a plugin's backend
+  // responses reach only the client that opened it, never every attached client.
+  notifyClient(clientId: number, method: string, params?: Record<string, unknown>): void
+  onClientDetached(listener: (clientId: number) => void): () => void
 }
 
 export type RelayPluginConfig = {
@@ -55,16 +60,41 @@ function isInstalledPlugin(pluginsDir: string, pluginId: string): boolean {
 export function registerRelayPluginHandlers(
   dispatcher: RelayDispatcherLike,
   config: RelayPluginConfig
-): { stopAll: () => Promise<void> } {
+): { stopAll: () => Promise<void>; stopAllSync: () => void } {
+  // Which clients have opened each plugin. A backend response carries one
+  // client's data (settings, workspace snapshot), so it must be routed only to
+  // the clients that opened that plugin — never broadcast to every client.
+  const subscribers = new Map<string, Set<number>>()
+  const subscribe = (pluginId: string, clientId: number | undefined): void => {
+    if (clientId === undefined) {
+      return
+    }
+    let set = subscribers.get(pluginId)
+    if (!set) {
+      set = new Set()
+      subscribers.set(pluginId, set)
+    }
+    set.add(clientId)
+  }
+  dispatcher.onClientDetached((clientId) => {
+    for (const set of subscribers.values()) {
+      set.delete(clientId)
+    }
+  })
+
   const { runtime } = createRelayPluginRuntime({
     pluginsDir: config.pluginsDir,
     entryPath: config.entryPath,
     stateFilePath: config.stateFilePath,
     getWorkspaceSnapshot: config.getWorkspaceSnapshot,
-    // Child outbound messages (bridge responses + lifecycle events) are pushed
-    // to the mobile client; the webview's ui-bridge-client matches reqIds.
-    onUiMessage: (pluginId, message) =>
-      dispatcher.notify('plugin.uiMessage', { pluginId, message }),
+    // Child outbound messages (bridge responses + lifecycle events) go only to
+    // the clients that opened this plugin; the webview's ui-bridge-client then
+    // matches reqIds. Broadcasting would leak one client's data to others.
+    onUiMessage: (pluginId, message) => {
+      for (const clientId of subscribers.get(pluginId) ?? []) {
+        dispatcher.notifyClient(clientId, 'plugin.uiMessage', { pluginId, message })
+      }
+    },
     hostFactory: config.hostFactory
   })
 
@@ -99,11 +129,12 @@ export function registerRelayPluginHandlers(
   })
 
   // Start the trusted backend child on the relay host.
-  dispatcher.onRequest('plugin.activate', async (params) => {
+  dispatcher.onRequest('plugin.activate', async (params, context) => {
     const pluginId = String(params.pluginId ?? '')
     if (!isInstalledPlugin(config.pluginsDir, pluginId)) {
       return { ok: false, error: 'unknown_plugin' }
     }
+    subscribe(pluginId, context.clientId)
     return runtime.activate(pluginId)
   })
 
@@ -114,16 +145,18 @@ export function registerRelayPluginHandlers(
       return { ok: false, error: 'invalid_params' }
     }
     await runtime.deactivate(pluginId)
+    subscribers.delete(pluginId)
     return { ok: true }
   })
 
   // Inbound webview -> backend message. Lazily activates so a message that races
   // ahead of an explicit activate still reaches a running child.
-  dispatcher.onRequest('plugin.postUi', async (params) => {
+  dispatcher.onRequest('plugin.postUi', async (params, context) => {
     const pluginId = String(params.pluginId ?? '')
     if (!isInstalledPlugin(config.pluginsDir, pluginId)) {
       return { ok: false, error: 'unknown_plugin' }
     }
+    subscribe(pluginId, context.clientId)
     if (!runtime.isRunning(pluginId)) {
       const activated = await runtime.activate(pluginId)
       if (!activated.ok) {
@@ -134,5 +167,5 @@ export function registerRelayPluginHandlers(
     return { ok: true }
   })
 
-  return { stopAll: () => runtime.stopAll() }
+  return { stopAll: () => runtime.stopAll(), stopAllSync: () => runtime.stopAllSync() }
 }

--- a/src/relay/plugin-handler.ts
+++ b/src/relay/plugin-handler.ts
@@ -20,6 +20,7 @@ import { isSafePluginId } from '../shared/plugin/manifest'
 import type { WorkspaceSnapshot } from '../shared/plugin/api-contract'
 import type { PluginHostFactory } from '../main/plugin/plugin-runtime'
 import { createRelayPluginRuntime } from './relay-plugin-runtime'
+import { provisionPlugin } from './plugin-provision'
 
 export type RelayRequestContext = { clientId?: number }
 
@@ -152,6 +153,16 @@ export function registerRelayPluginHandlers(
       return { ok: false, error: 'entry_missing' }
     }
     return { ok: true, html: readFileSync(htmlPath, 'utf8') }
+  })
+
+  // Receive a plugin bundle from the desktop and write it under the relay
+  // plugins dir (verified + atomic). Must precede plugin.activate for a plugin
+  // whose files aren't already on the relay host.
+  dispatcher.onRequest('plugin.provision', async (params) => {
+    return provisionPlugin(params.bundle, {
+      pluginsDir: config.pluginsDir,
+      stagingDir: `${config.pluginsDir}-staging`
+    })
   })
 
   // Start the trusted backend child on the relay host.

--- a/src/relay/plugin-provision.test.ts
+++ b/src/relay/plugin-provision.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { provisionPlugin } from './plugin-provision'
+import { serializePluginBundle, type PluginBundleFile } from '../main/plugin/plugin-bundle'
+import { discoverPlugins } from '../main/plugin/plugin-discovery'
+
+const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64')
+
+function manifest(id = 'acme.foo'): string {
+  return JSON.stringify({
+    id,
+    name: 'Foo',
+    version: '1.0.0',
+    hostApiVersion: '0.1.0',
+    main: 'main.js',
+    contributes: { sidebar: { title: 'Foo', icon: 'Activity', ui: 'index.html' } },
+    capabilities: ['workspace:read']
+  })
+}
+
+function bundleFiles(manifestId = 'acme.foo', html = '<!doctype html>'): PluginBundleFile[] {
+  return [
+    { path: 'plugin.json', dataBase64: b64(manifest(manifestId)) },
+    { path: 'main.js', dataBase64: b64('exports.activate=()=>{}') },
+    { path: 'index.html', dataBase64: b64(html) }
+  ]
+}
+
+let tmp: string
+let pluginsDir: string
+let config: { pluginsDir: string; stagingDir: string }
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'relay-provision-'))
+  pluginsDir = join(tmp, 'plugins')
+  config = { pluginsDir, stagingDir: `${pluginsDir}-staging` }
+})
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('provisionPlugin', () => {
+  it('writes a valid bundle so discoverPlugins finds it', () => {
+    const bundle = serializePluginBundle('acme.foo', bundleFiles())
+    expect(provisionPlugin(bundle, config)).toEqual({ ok: true })
+    const found = discoverPlugins(pluginsDir).valid.map((p) => p.manifest.id)
+    expect(found).toEqual(['acme.foo'])
+    expect(readFileSync(join(pluginsDir, 'acme.foo', 'index.html'), 'utf8')).toBe('<!doctype html>')
+  })
+
+  it('writes nothing on an integrity mismatch', () => {
+    const bundle = serializePluginBundle('acme.foo', bundleFiles())
+    bundle.files[2].dataBase64 = b64('<tampered>')
+    expect(provisionPlugin(bundle, config)).toEqual({ ok: false, error: 'integrity_mismatch' })
+    expect(existsSync(join(pluginsDir, 'acme.foo'))).toBe(false)
+  })
+
+  it('rejects a manifest whose id does not match the bundle id', () => {
+    // bundle pluginId is acme.foo but the embedded manifest says acme.bar
+    const bundle = serializePluginBundle('acme.foo', bundleFiles('acme.bar'))
+    expect(provisionPlugin(bundle, config)).toEqual({ ok: false, error: 'manifest_id_mismatch' })
+    expect(existsSync(join(pluginsDir, 'acme.foo'))).toBe(false)
+  })
+
+  it('rejects an unsafe plugin id before touching the filesystem', () => {
+    const bundle = serializePluginBundle('../evil', bundleFiles('../evil'))
+    expect(provisionPlugin(bundle, config)).toEqual({ ok: false, error: 'unsafe_plugin_id' })
+    expect(existsSync(config.stagingDir)).toBe(false)
+  })
+
+  it('reports a missing manifest and writes nothing', () => {
+    const bundle = serializePluginBundle('acme.foo', [
+      { path: 'index.html', dataBase64: b64('<!doctype html>') }
+    ])
+    expect(provisionPlugin(bundle, config)).toEqual({ ok: false, error: 'missing_manifest' })
+    expect(existsSync(join(pluginsDir, 'acme.foo'))).toBe(false)
+  })
+
+  it('rejects an invalid manifest', () => {
+    const bundle = serializePluginBundle('acme.foo', [
+      { path: 'plugin.json', dataBase64: b64('{"id":"acme.foo"}') }
+    ])
+    expect(provisionPlugin(bundle, config)).toEqual({ ok: false, error: 'invalid_manifest' })
+  })
+
+  it('atomically replaces an existing plugin on re-provision', () => {
+    provisionPlugin(serializePluginBundle('acme.foo', bundleFiles('acme.foo', 'v1')), config)
+    provisionPlugin(serializePluginBundle('acme.foo', bundleFiles('acme.foo', 'v2')), config)
+    expect(readFileSync(join(pluginsDir, 'acme.foo', 'index.html'), 'utf8')).toBe('v2')
+  })
+})

--- a/src/relay/plugin-provision.test.ts
+++ b/src/relay/plugin-provision.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { provisionPlugin } from './plugin-provision'
@@ -48,6 +48,8 @@ describe('provisionPlugin', () => {
     const found = discoverPlugins(pluginsDir).valid.map((p) => p.manifest.id)
     expect(found).toEqual(['acme.foo'])
     expect(readFileSync(join(pluginsDir, 'acme.foo', 'index.html'), 'utf8')).toBe('<!doctype html>')
+    // The staged temp dir is renamed into place, leaving no leftover under staging.
+    expect(readdirSync(config.stagingDir)).toEqual([])
   })
 
   it('writes nothing on an integrity mismatch', () => {

--- a/src/relay/plugin-provision.ts
+++ b/src/relay/plugin-provision.ts
@@ -1,0 +1,63 @@
+// Relay-side receipt of a provisioned plugin bundle: verify integrity + paths
+// (shared codec), stage the files to a temp dir, validate the embedded manifest
+// and id, then atomically rename into relayPluginsDir()/<id>. Electron-free.
+// Nothing is written unless every check passes; a partial stage is cleaned up.
+
+import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { isSafePluginId } from '../shared/plugin/manifest'
+import { validatePluginManifest } from '../shared/plugin/manifest-validate'
+import { readManifestRaw } from '../main/plugin/plugin-discovery'
+import { verifyPluginBundle, type PluginBundle } from '../main/plugin/plugin-bundle'
+
+export type ProvisionResult = { ok: true } | { ok: false; error: string }
+export type ProvisionConfig = { pluginsDir: string; stagingDir: string }
+
+export function provisionPlugin(bundle: unknown, config: ProvisionConfig): ProvisionResult {
+  const verified = verifyPluginBundle(bundle)
+  if (!verified.ok) {
+    return { ok: false, error: verified.error }
+  }
+  const pluginId = (bundle as PluginBundle).pluginId
+  // Reject an unsafe id before touching the filesystem.
+  if (!isSafePluginId(pluginId)) {
+    return { ok: false, error: 'unsafe_plugin_id' }
+  }
+
+  mkdirSync(config.stagingDir, { recursive: true })
+  const staged = mkdtempSync(join(config.stagingDir, `${pluginId}-`))
+  try {
+    for (const file of verified.files) {
+      const target = join(staged, file.path)
+      mkdirSync(dirname(target), { recursive: true })
+      writeFileSync(target, Buffer.from(file.dataBase64, 'base64'))
+    }
+    // Reuse the canonical manifest read (plugin.json or package.json#orca) +
+    // validation rather than re-parsing, so the relay and installer agree.
+    const raw = readManifestRaw(staged)
+    if (raw === null) {
+      return fail(staged, 'missing_manifest')
+    }
+    const validated = validatePluginManifest(raw)
+    if (!validated.ok) {
+      return fail(staged, 'invalid_manifest')
+    }
+    if (validated.manifest.id !== pluginId) {
+      return fail(staged, 'manifest_id_mismatch')
+    }
+    const dest = join(config.pluginsDir, pluginId)
+    mkdirSync(config.pluginsDir, { recursive: true })
+    // Replace any prior copy atomically: clear the target, then rename the
+    // fully-staged dir into place (same volume — sibling staging dir).
+    rmSync(dest, { recursive: true, force: true })
+    renameSync(staged, dest)
+    return { ok: true }
+  } catch (error) {
+    return fail(staged, error instanceof Error ? error.message : 'write_failed')
+  }
+}
+
+function fail(staged: string, error: string): ProvisionResult {
+  rmSync(staged, { recursive: true, force: true })
+  return { ok: false, error }
+}

--- a/src/relay/plugin-provision.ts
+++ b/src/relay/plugin-provision.ts
@@ -1,10 +1,11 @@
 // Relay-side receipt of a provisioned plugin bundle: verify integrity + paths
 // (shared codec), stage the files to a temp dir, validate the embedded manifest
-// and id, then atomically rename into relayPluginsDir()/<id>. Electron-free.
-// Nothing is written unless every check passes; a partial stage is cleaned up.
+// and id, then atomically swap into relayPluginsDir()/<id>. Electron-free.
+// Nothing is written unless every check passes; a partial stage is cleaned up,
+// and a failed swap restores any prior install rather than losing it.
 
-import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
+import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { isSafePluginId } from '../shared/plugin/manifest'
 import { validatePluginManifest } from '../shared/plugin/manifest-validate'
 import { readManifestRaw } from '../main/plugin/plugin-discovery'
@@ -24,11 +25,21 @@ export function provisionPlugin(bundle: unknown, config: ProvisionConfig): Provi
     return { ok: false, error: 'unsafe_plugin_id' }
   }
 
-  mkdirSync(config.stagingDir, { recursive: true })
-  const staged = mkdtempSync(join(config.stagingDir, `${pluginId}-`))
+  // Staging-dir creation can itself fail (EACCES/ENOSPC/EROFS); keep it inside
+  // the result contract rather than throwing out of the handler.
+  let staged: string
+  try {
+    mkdirSync(config.stagingDir, { recursive: true })
+    staged = mkdtempSync(join(config.stagingDir, `${pluginId}-`))
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'staging_failed' }
+  }
+
   try {
     for (const file of verified.files) {
-      const target = join(staged, file.path)
+      // Reconstruct from posix segments via native join so a Windows relay host
+      // writes platform-correct paths (the wire format is always posix `/`).
+      const target = join(staged, ...file.path.split('/'))
       mkdirSync(dirname(target), { recursive: true })
       writeFileSync(target, Buffer.from(file.dataBase64, 'base64'))
     }
@@ -45,16 +56,35 @@ export function provisionPlugin(bundle: unknown, config: ProvisionConfig): Provi
     if (validated.manifest.id !== pluginId) {
       return fail(staged, 'manifest_id_mismatch')
     }
-    const dest = join(config.pluginsDir, pluginId)
     mkdirSync(config.pluginsDir, { recursive: true })
-    // Replace any prior copy atomically: clear the target, then rename the
-    // fully-staged dir into place (same volume — sibling staging dir).
-    rmSync(dest, { recursive: true, force: true })
-    renameSync(staged, dest)
-    return { ok: true }
+    return commitStaged(staged, join(config.pluginsDir, pluginId))
   } catch (error) {
     return fail(staged, error instanceof Error ? error.message : 'write_failed')
   }
+}
+
+// Swap the fully-staged dir into place without a destructive window: move any
+// prior install aside first, so a failed rename (cross-volume EXDEV, a racing
+// re-provision) restores the prior plugin instead of leaving it missing.
+function commitStaged(staged: string, dest: string): ProvisionResult {
+  const backup = `${dest}.bak-${basename(staged)}`
+  const hadPrior = existsSync(dest)
+  if (hadPrior) {
+    renameSync(dest, backup)
+  }
+  try {
+    renameSync(staged, dest)
+  } catch (error) {
+    if (hadPrior) {
+      renameSync(backup, dest)
+    }
+    rmSync(staged, { recursive: true, force: true })
+    return { ok: false, error: error instanceof Error ? error.message : 'commit_failed' }
+  }
+  if (hadPrior) {
+    rmSync(backup, { recursive: true, force: true })
+  }
+  return { ok: true }
 }
 
 function fail(staged: string, error: string): ProvisionResult {

--- a/src/relay/relay-plugin-config.test.ts
+++ b/src/relay/relay-plugin-config.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { defaultRelayWorkspaceSnapshot, relayPluginsDir } from './relay-plugin-config'
+
+describe('relay plugin config', () => {
+  it('resolves the plugins dir under the $HOME/.orca-relay userData equivalent', () => {
+    expect(relayPluginsDir()).toBe(join(homedir(), '.orca-relay', 'plugins'))
+  })
+
+  it('returns a bounded empty default workspace snapshot', () => {
+    // No live workspace root on the relay (registerRoot is a no-op), so the
+    // only workspace:read surface defaults to an empty, safe snapshot.
+    expect(defaultRelayWorkspaceSnapshot()).toEqual({
+      workspaceName: '',
+      currentBranch: null,
+      isDirty: false,
+      openFileCount: 0
+    })
+  })
+})

--- a/src/relay/relay-plugin-config.test.ts
+++ b/src/relay/relay-plugin-config.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
-import { defaultRelayWorkspaceSnapshot, relayPluginsDir } from './relay-plugin-config'
+import { basename, join } from 'node:path'
+import {
+  defaultRelayWorkspaceSnapshot,
+  relayPluginHostEntryPath,
+  relayPluginsDir
+} from './relay-plugin-config'
 
 describe('relay plugin config', () => {
   it('resolves the plugins dir under the $HOME/.orca-relay userData equivalent', () => {
@@ -16,6 +20,24 @@ describe('relay plugin config', () => {
       currentBranch: null,
       isDirty: false,
       openFileCount: 0
+    })
+  })
+
+  describe('relayPluginHostEntryPath', () => {
+    afterEach(() => {
+      delete process.env.ORCA_RELAY_PLUGIN_HOST_ENTRY
+    })
+
+    it('honors the env override verbatim (highest precedence)', () => {
+      process.env.ORCA_RELAY_PLUGIN_HOST_ENTRY = '/custom/path/host-entry.js'
+      expect(relayPluginHostEntryPath()).toBe('/custom/path/host-entry.js')
+    })
+
+    it('defaults to a bundle-relative plugin-host-entry.js (not the $HOME plugins dir)', () => {
+      delete process.env.ORCA_RELAY_PLUGIN_HOST_ENTRY
+      const resolved = relayPluginHostEntryPath()
+      expect(basename(resolved)).toBe('plugin-host-entry.js')
+      expect(resolved).not.toContain(join('.orca-relay', 'plugins'))
     })
   })
 })

--- a/src/relay/relay-plugin-config.ts
+++ b/src/relay/relay-plugin-config.ts
@@ -20,6 +20,12 @@ export function relayPluginStateFilePath(): string {
   return join(homedir(), RELAY_USERDATA_DIR_NAME, 'plugins-state.json')
 }
 
+// Staging area for provisioning writes — a sibling of the plugins dir (same
+// volume) so the final rename into place is atomic.
+export function relayPluginStagingDir(): string {
+  return join(homedir(), RELAY_USERDATA_DIR_NAME, 'plugins-staging')
+}
+
 // The built plugin-host-entry the trusted child runs. It ships alongside the
 // relay bundle (build-relay emits plugin-host-entry.js next to relay.js), so the
 // default resolves relative to this module's runtime directory — which, in the

--- a/src/relay/relay-plugin-config.ts
+++ b/src/relay/relay-plugin-config.ts
@@ -15,6 +15,20 @@ export function relayPluginsDir(): string {
   return join(homedir(), RELAY_USERDATA_DIR_NAME, 'plugins')
 }
 
+// Per-plugin active/installed state, alongside the plugins dir.
+export function relayPluginStateFilePath(): string {
+  return join(homedir(), RELAY_USERDATA_DIR_NAME, 'plugins-state.json')
+}
+
+// The built plugin-host-entry the trusted child runs. Provisioning this file to
+// the relay host is deferred (NEEDS-RUNTIME-VERIFY); the path is overridable so
+// provisioning can place it wherever it lands. Default sits alongside the relay
+// userData so plugins + entry are provisioned together.
+export function relayPluginHostEntryPath(): string {
+  const override = process.env.ORCA_RELAY_PLUGIN_HOST_ENTRY?.trim()
+  return override || join(homedir(), RELAY_USERDATA_DIR_NAME, 'plugin-host-entry.js')
+}
+
 // The relay no longer tracks a live workspace root (RelayContext.registerRoot is
 // a no-op), so the only workspace:read surface returns a bounded empty snapshot.
 // NEEDS-RUNTIME-VERIFY: the remote-provisioning tier replaces this with a real

--- a/src/relay/relay-plugin-config.ts
+++ b/src/relay/relay-plugin-config.ts
@@ -10,10 +10,9 @@ import type { WorkspaceSnapshot } from '../shared/plugin/api-contract'
 // Why: mirror the $HOME/.orca-relay convention (see agent-hook-server.ts) so all
 // relay-side state lives in one predictable per-user place.
 const RELAY_USERDATA_DIR_NAME = '.orca-relay'
-const PLUGINS_SUBDIR = 'plugins'
 
 export function relayPluginsDir(): string {
-  return join(homedir(), RELAY_USERDATA_DIR_NAME, PLUGINS_SUBDIR)
+  return join(homedir(), RELAY_USERDATA_DIR_NAME, 'plugins')
 }
 
 // The relay no longer tracks a live workspace root (RelayContext.registerRoot is

--- a/src/relay/relay-plugin-config.ts
+++ b/src/relay/relay-plugin-config.ts
@@ -20,13 +20,14 @@ export function relayPluginStateFilePath(): string {
   return join(homedir(), RELAY_USERDATA_DIR_NAME, 'plugins-state.json')
 }
 
-// The built plugin-host-entry the trusted child runs. Provisioning this file to
-// the relay host is deferred (NEEDS-RUNTIME-VERIFY); the path is overridable so
-// provisioning can place it wherever it lands. Default sits alongside the relay
-// userData so plugins + entry are provisioned together.
+// The built plugin-host-entry the trusted child runs. It ships alongside the
+// relay bundle (build-relay emits plugin-host-entry.js next to relay.js), so the
+// default resolves relative to this module's runtime directory — which, in the
+// esbuild CJS relay bundle, is the relay.js output dir. The env var overrides for
+// custom provisioning layouts.
 export function relayPluginHostEntryPath(): string {
   const override = process.env.ORCA_RELAY_PLUGIN_HOST_ENTRY?.trim()
-  return override || join(homedir(), RELAY_USERDATA_DIR_NAME, 'plugin-host-entry.js')
+  return override || join(__dirname, 'plugin-host-entry.js')
 }
 
 // The relay no longer tracks a live workspace root (RelayContext.registerRoot is

--- a/src/relay/relay-plugin-config.ts
+++ b/src/relay/relay-plugin-config.ts
@@ -1,0 +1,30 @@
+// Relay-side config for the right-sidebar plugin system (mobile path). The relay
+// has no Electron userData dir, so plugin state lives under $HOME/.orca-relay —
+// the same userData equivalent agent-hook-server.ts uses. Electron-free: this is
+// part of the relay esbuild bundle and imports only node built-ins.
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { WorkspaceSnapshot } from '../shared/plugin/api-contract'
+
+// Why: mirror the $HOME/.orca-relay convention (see agent-hook-server.ts) so all
+// relay-side state lives in one predictable per-user place.
+const RELAY_USERDATA_DIR_NAME = '.orca-relay'
+const PLUGINS_SUBDIR = 'plugins'
+
+export function relayPluginsDir(): string {
+  return join(homedir(), RELAY_USERDATA_DIR_NAME, PLUGINS_SUBDIR)
+}
+
+// The relay no longer tracks a live workspace root (RelayContext.registerRoot is
+// a no-op), so the only workspace:read surface returns a bounded empty snapshot.
+// NEEDS-RUNTIME-VERIFY: the remote-provisioning tier replaces this with a real
+// per-session snapshot once the relay tracks an active workspace again.
+export function defaultRelayWorkspaceSnapshot(): WorkspaceSnapshot {
+  return {
+    workspaceName: '',
+    currentBranch: null,
+    isDirty: false,
+    openFileCount: 0
+  }
+}

--- a/src/relay/relay-plugin-runtime.test.ts
+++ b/src/relay/relay-plugin-runtime.test.ts
@@ -20,7 +20,8 @@ function fakeHostFactory(config: PluginHostConfig): FakeHost {
     start: () => Promise.resolve(),
     stop: () => Promise.resolve(),
     isRunning: () => true,
-    postUi: () => {}
+    postUi: () => {},
+    terminate: () => {}
   }
 }
 

--- a/src/relay/relay-plugin-runtime.test.ts
+++ b/src/relay/relay-plugin-runtime.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createRelayPluginRuntime, denyRelayHostCommand } from './relay-plugin-runtime'
+import type { PluginHostConfig } from '../main/plugin/plugin-host-process'
+import type { PluginHostLike } from '../main/plugin/plugin-runtime'
+
+// Fake host: captures its config and never forks a real process, so the relay
+// composition can be exercised in node without the built entry script.
+type FakeHost = PluginHostLike & { config: PluginHostConfig }
+
+let tmp: string
+let captured: PluginHostConfig[]
+
+function fakeHostFactory(config: PluginHostConfig): FakeHost {
+  captured.push(config)
+  return {
+    config,
+    start: () => Promise.resolve(),
+    stop: () => Promise.resolve(),
+    isRunning: () => true,
+    postUi: () => {}
+  }
+}
+
+function manifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'acme.foo',
+    name: 'Foo',
+    version: '1.0.0',
+    hostApiVersion: '0.1.0',
+    main: 'main.js',
+    contributes: { sidebar: { title: 'Foo', icon: 'Activity', ui: 'index.html' } },
+    capabilities: ['workspace:read'],
+    ...overrides
+  }
+}
+
+function installFixture(id = 'acme.foo', overrides: Record<string, unknown> = {}): void {
+  const dir = join(tmp, id)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest({ id, ...overrides })))
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'relay-plugin-runtime-'))
+  captured = []
+})
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+function build(onUiMessage: (pluginId: string, message: unknown) => void = () => {}) {
+  return createRelayPluginRuntime({
+    pluginsDir: tmp,
+    stateFilePath: join(tmp, 'state.json'),
+    getWorkspaceSnapshot: () => ({
+      workspaceName: '',
+      currentBranch: null,
+      isDirty: false,
+      openFileCount: 0
+    }),
+    onUiMessage,
+    hostFactory: fakeHostFactory
+  })
+}
+
+describe('relay plugin runtime', () => {
+  it('denies host commands (device round-trip not available on the relay host)', async () => {
+    await expect(denyRelayHostCommand('open-external-url')).rejects.toThrow(/device round-trip/)
+  })
+
+  it('forks the backend with no ELECTRON_RUN_AS_NODE (plain node on the relay)', async () => {
+    installFixture()
+    const { runtime } = build()
+    const result = await runtime.activate('acme.foo')
+    expect(result.ok).toBe(true)
+    expect(captured).toHaveLength(1)
+    // No forkEnv: the relay process is already node.
+    expect(captured[0].env).toBeUndefined()
+    expect(captured[0].pluginId).toBe('acme.foo')
+  })
+
+  it('forwards child UI messages to the injected onUiMessage with the pluginId', async () => {
+    installFixture()
+    const received: { pluginId: string; message: unknown }[] = []
+    const { runtime } = build((pluginId, message) => received.push({ pluginId, message }))
+    await runtime.activate('acme.foo')
+    // Simulate the child posting an outbound message.
+    captured[0].onUiMessage!({ reqId: 'r1', ok: true })
+    expect(received).toEqual([{ pluginId: 'acme.foo', message: { reqId: 'r1', ok: true } }])
+  })
+
+  it('wires the gated host handler so the child can answer bridge requests', async () => {
+    installFixture()
+    const { runtime } = build()
+    await runtime.activate('acme.foo')
+    // workspace:read is declared, so the snapshot method is granted.
+    const response = await captured[0].onHostRequest({
+      reqId: 'r1',
+      method: 'workspace.getSnapshot'
+    })
+    expect(response).toMatchObject({ reqId: 'r1', ok: true })
+  })
+})

--- a/src/relay/relay-plugin-runtime.ts
+++ b/src/relay/relay-plugin-runtime.ts
@@ -38,7 +38,6 @@ export async function denyRelayHostCommand(name: HostCommand): Promise<never> {
 }
 
 export function createRelayPluginRuntime(config: RelayPluginRuntimeConfig): {
-  manager: PluginManager
   runtime: PluginRuntime
 } {
   const pluginsDir = config.pluginsDir ?? relayPluginsDir()
@@ -57,5 +56,5 @@ export function createRelayPluginRuntime(config: RelayPluginRuntimeConfig): {
     onUiMessage: config.onUiMessage,
     hostFactory: config.hostFactory
   })
-  return { manager, runtime }
+  return { runtime }
 }

--- a/src/relay/relay-plugin-runtime.ts
+++ b/src/relay/relay-plugin-runtime.ts
@@ -1,0 +1,61 @@
+// Relay-side composition of the trusted plugin backend. Reuses the exact
+// electron-free runtime stack the desktop main process uses (PluginManager +
+// PluginRuntime + PluginHost), with relay-appropriate deps:
+//   - the child forks with plain node (process.execPath is node on the relay),
+//     so no ELECTRON_RUN_AS_NODE — forkEnv is omitted;
+//   - host commands (open-url/clipboard) act on the device, not the relay host,
+//     so invokeCommand is denied (device round-trip deferred);
+//   - onUiMessage forwards the child's outbound messages to the caller, which
+//     pushes them to the mobile client as plugin.uiMessage notifications.
+// Electron-free: imports only node:*, the shared contract, and the (already
+// electron-free) src/main/plugin runtime modules.
+
+import { PluginManager } from '../main/plugin/plugin-manager'
+import { PluginRuntime, type PluginHostFactory } from '../main/plugin/plugin-runtime'
+import type { HostCommand, WorkspaceSnapshot } from '../shared/plugin/api-contract'
+import {
+  relayPluginHostEntryPath,
+  relayPluginStateFilePath,
+  relayPluginsDir
+} from './relay-plugin-config'
+
+export type RelayPluginRuntimeConfig = {
+  pluginsDir?: string
+  stateFilePath?: string
+  entryPath?: string
+  getWorkspaceSnapshot: () => WorkspaceSnapshot | Promise<WorkspaceSnapshot>
+  onUiMessage: (pluginId: string, message: unknown) => void
+  // Injectable for tests so the runtime can be exercised without forking node.
+  hostFactory?: PluginHostFactory
+}
+
+// Host commands run on the device (open URL / clipboard), not the relay host, so
+// the relay denies them; the child surfaces the rejection to the plugin UI.
+export async function denyRelayHostCommand(name: HostCommand): Promise<never> {
+  throw new Error(
+    `host command '${name}' requires a device round-trip; not available on the relay host`
+  )
+}
+
+export function createRelayPluginRuntime(config: RelayPluginRuntimeConfig): {
+  manager: PluginManager
+  runtime: PluginRuntime
+} {
+  const pluginsDir = config.pluginsDir ?? relayPluginsDir()
+  const manager = new PluginManager({
+    pluginsDir,
+    stateFilePath: config.stateFilePath ?? relayPluginStateFilePath()
+  })
+  const runtime = new PluginRuntime({
+    manager,
+    pluginsDir,
+    entryPath: config.entryPath ?? relayPluginHostEntryPath(),
+    // No forkEnv: the relay process is already node, so the child needs no
+    // ELECTRON_RUN_AS_NODE shim (unlike the desktop main path).
+    getWorkspaceSnapshot: config.getWorkspaceSnapshot,
+    invokeCommand: denyRelayHostCommand,
+    onUiMessage: config.onUiMessage,
+    hostFactory: config.hostFactory
+  })
+  return { manager, runtime }
+}

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -55,7 +55,11 @@ import {
   SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD
 } from '../shared/ssh-types'
 import { registerRelayPluginHandlers } from './plugin-handler'
-import { defaultRelayWorkspaceSnapshot, relayPluginsDir } from './relay-plugin-config'
+import {
+  defaultRelayWorkspaceSnapshot,
+  relayPluginStagingDir,
+  relayPluginsDir
+} from './relay-plugin-config'
 import { assertPluginSourceUnderByteCap } from './plugin-source-limit'
 import { resolveOpenCodeSourceConfigDir, resolvePiSourceAgentDir } from './plugin-overlay-env'
 import { detectPiAgentKindFromCommand } from '../shared/pi-agent-kind'
@@ -467,6 +471,7 @@ async function main(): Promise<void> {
   // $HOME/.orca-relay. Stopped on socket cleanup so children aren't orphaned.
   const pluginHandlers = registerRelayPluginHandlers(dispatcher, {
     pluginsDir: relayPluginsDir(),
+    stagingDir: relayPluginStagingDir(),
     getWorkspaceSnapshot: defaultRelayWorkspaceSnapshot
   })
   stopPluginBackends = pluginHandlers.stopAllSync

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -368,6 +368,9 @@ async function main(): Promise<void> {
     cleanupOwnedSocket()
     process.exit(code)
   }
+  // Expose cleanup to the module-level main().catch safety net (REL-02), so a
+  // late-startup rejection that escapes the in-main guards still stops children.
+  relayCleanupOnFatal = cleanupOwnedSocket
 
   // Why: After an uncaught exception Node's internal state may be corrupted
   // (e.g. half-written buffers, broken invariants). Logging and continuing
@@ -375,8 +378,7 @@ async function main(): Promise<void> {
   // and then exit so the client can detect the disconnect and reconnect cleanly.
   process.on('uncaughtException', (err) => {
     process.stderr.write(`[relay] Uncaught exception: ${err.message}\n${err.stack}\n`)
-    cleanupOwnedSocket()
-    process.exit(1)
+    exitWithCleanup(1)
   })
 
   process.on('unhandledRejection', (reason) => {
@@ -989,8 +991,7 @@ async function main(): Promise<void> {
     if (socketServer && ownsCurrentSocketPath()) {
       socketServer.close()
     }
-    cleanupOwnedSocket()
-    process.exit(0)
+    exitWithCleanup(0)
   }
 
   process.on('SIGTERM', shutdown)
@@ -1026,9 +1027,14 @@ function cleanupSocket(sockPath: string): void {
   }
 }
 
+// Assigned by main() once cleanup is wired, so a late-startup rejection that
+// escapes main()'s own guards still stops plugin backend children before exit.
+let relayCleanupOnFatal: (() => void) | null = null
+
 void main().catch((err) => {
   process.stderr.write(
     `[relay] Fatal startup error: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`
   )
+  relayCleanupOnFatal?.()
   process.exit(1)
 })

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -54,6 +54,8 @@ import {
   DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS,
   SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD
 } from '../shared/ssh-types'
+import { registerRelayPluginHandlers } from './plugin-handler'
+import { defaultRelayWorkspaceSnapshot, relayPluginsDir } from './relay-plugin-config'
 import { assertPluginSourceUnderByteCap } from './plugin-source-limit'
 import { resolveOpenCodeSourceConfigDir, resolvePiSourceAgentDir } from './plugin-overlay-env'
 import { detectPiAgentKindFromCommand } from '../shared/pi-agent-kind'
@@ -441,6 +443,14 @@ async function main(): Promise<void> {
 
   const _workspaceSessionHandler = new WorkspaceSessionHandler(dispatcher)
   void _workspaceSessionHandler
+
+  // Right-sidebar plugin system (mobile path): list installed plugins, serve a
+  // plugin's single UI HTML, and route capability-gated bridge calls — all where
+  // the workspace lives. Plugin state lives under $HOME/.orca-relay/plugins.
+  registerRelayPluginHandlers(dispatcher, {
+    pluginsDir: relayPluginsDir(),
+    getWorkspaceSnapshot: defaultRelayWorkspaceSnapshot
+  })
 
   dispatcher.onRequest('orca.cli', async (params, context) => {
     return await dispatcher.requestAnyClient('orca.cli', params, {

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -361,6 +361,14 @@ async function main(): Promise<void> {
     ownedSocketIdentity = null
   }
 
+  // Fatal exit that first runs socket + plugin-backend cleanup. Use on exit paths
+  // that run after the plugin handlers register, so a backend child started in
+  // that window isn't orphaned (a bare process.exit would skip cleanup).
+  const exitWithCleanup = (code: number): never => {
+    cleanupOwnedSocket()
+    process.exit(code)
+  }
+
   // Why: After an uncaught exception Node's internal state may be corrupted
   // (e.g. half-written buffers, broken invariants). Logging and continuing
   // would risk silent data corruption or zombie PTYs. We log for diagnostics
@@ -894,7 +902,8 @@ async function main(): Promise<void> {
     // cannot poison the active relay's hook coordinates.
     hookServer.publishEndpointFile()
   } catch {
-    process.exit(1)
+    // Runs after registerRelayPluginHandlers — clean up plugin children too.
+    exitWithCleanup(1)
   }
 
   // ── stdin/stdout transport (initial connection) ─────────────────────

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -348,11 +348,12 @@ async function main(): Promise<void> {
   }
   // Assigned once the plugin handlers register (below); null-guarded so an early
   // exception during setup can't hit it in the temporal dead zone.
-  let stopPluginBackends: (() => Promise<void>) | null = null
+  let stopPluginBackends: (() => void) | null = null
   const cleanupOwnedSocket = (): void => {
-    // Best-effort: stop any running plugin backend children so they aren't
-    // orphaned when the relay exits.
-    void stopPluginBackends?.()
+    // Synchronously SIGTERM any running plugin backend children. cleanupOwnedSocket
+    // runs on the synchronous path right before process.exit, so an awaited stop
+    // would never complete — the kill must be delivered inline or children orphan.
+    stopPluginBackends?.()
     if (ownsCurrentSocketPath()) {
       cleanupSocket(sockPath)
     }
@@ -458,7 +459,7 @@ async function main(): Promise<void> {
     pluginsDir: relayPluginsDir(),
     getWorkspaceSnapshot: defaultRelayWorkspaceSnapshot
   })
-  stopPluginBackends = pluginHandlers.stopAll
+  stopPluginBackends = pluginHandlers.stopAllSync
 
   dispatcher.onRequest('orca.cli', async (params, context) => {
     return await dispatcher.requestAnyClient('orca.cli', params, {

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -346,7 +346,13 @@ async function main(): Promise<void> {
       sameSocketIdentity(currentIdentity, ownedSocketIdentity)
     )
   }
+  // Assigned once the plugin handlers register (below); null-guarded so an early
+  // exception during setup can't hit it in the temporal dead zone.
+  let stopPluginBackends: (() => Promise<void>) | null = null
   const cleanupOwnedSocket = (): void => {
+    // Best-effort: stop any running plugin backend children so they aren't
+    // orphaned when the relay exits.
+    void stopPluginBackends?.()
     if (ownsCurrentSocketPath()) {
       cleanupSocket(sockPath)
     }
@@ -445,12 +451,14 @@ async function main(): Promise<void> {
   void _workspaceSessionHandler
 
   // Right-sidebar plugin system (mobile path): list installed plugins, serve a
-  // plugin's single UI HTML, and route capability-gated bridge calls — all where
-  // the workspace lives. Plugin state lives under $HOME/.orca-relay/plugins.
-  registerRelayPluginHandlers(dispatcher, {
+  // plugin's single UI HTML, run the trusted backend child on the relay host,
+  // and round-trip UI<->backend messages. Plugin state + host-entry live under
+  // $HOME/.orca-relay. Stopped on socket cleanup so children aren't orphaned.
+  const pluginHandlers = registerRelayPluginHandlers(dispatcher, {
     pluginsDir: relayPluginsDir(),
     getWorkspaceSnapshot: defaultRelayWorkspaceSnapshot
   })
+  stopPluginBackends = pluginHandlers.stopAll
 
   dispatcher.onRequest('orca.cli', async (params, context) => {
     return await dispatcher.requestAnyClient('orca.cli', params, {

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -25,6 +25,7 @@ import {
   type ActivityBarItem
 } from './activity-bar-buttons'
 import { getActiveChecksStatus } from './active-checks-status'
+import { usePluginActivityItems } from './use-plugin-activity-items'
 import { getVisibleRightSidebarActivityItems } from './right-sidebar-activity-visibility'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import {
@@ -84,6 +85,7 @@ function RightSidebarInner(): React.JSX.Element {
   const isFolderWorkspace = activeWorkspaceScope?.type === 'folder'
   const isFolder = isFolderWorkspace || (activeRepo ? isFolderRepo(activeRepo) : false)
   const isSshRepo = Boolean(activeRepo?.connectionId)
+  const pluginActivityItems = usePluginActivityItems()
 
   const activityItems = useMemo<ActivityBarItem[]>(
     () => [
@@ -136,9 +138,11 @@ function RightSidebarInner(): React.JSX.Element {
         title: translate('auto.components.right.sidebar.index.441733b630', 'Ports'),
         shortcut: portsShortcut === 'Unassigned' ? '' : portsShortcut,
         sshOnly: true
-      }
+      },
+      // Active plugin-contributed tabs (appended after the built-in tabs).
+      ...pluginActivityItems
     ],
-    [checksShortcut, explorerShortcut, portsShortcut, sourceControlShortcut]
+    [checksShortcut, explorerShortcut, portsShortcut, sourceControlShortcut, pluginActivityItems]
   )
 
   const visibleItems = useMemo(

--- a/src/renderer/src/components/right-sidebar/plugin-panel.tsx
+++ b/src/renderer/src/components/right-sidebar/plugin-panel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { translate } from '@/i18n/i18n'
 
 // NEEDS-RUNTIME-VERIFY: renders a plugin's sandboxed UI in an imperatively
 // created <webview> (the repo manages webviews imperatively, not via JSX). The
@@ -61,10 +62,14 @@ export function PluginPanel({ pluginId }: PluginPanelProps): React.JSX.Element {
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
       {status === 'loading' && (
-        <div className="text-muted-foreground p-3 text-xs">Loading plugin…</div>
+        <div className="text-muted-foreground p-3 text-xs">
+          {translate('plugins.panel.loading', 'Loading plugin…')}
+        </div>
       )}
       {status === 'error' && (
-        <div className="text-destructive p-3 text-xs">This plugin failed to load.</div>
+        <div className="text-destructive p-3 text-xs">
+          {translate('plugins.panel.loadError', 'This plugin failed to load.')}
+        </div>
       )}
       <div ref={containerRef} className="min-h-0 flex-1" />
     </div>

--- a/src/renderer/src/components/right-sidebar/plugin-panel.tsx
+++ b/src/renderer/src/components/right-sidebar/plugin-panel.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react'
+
+// NEEDS-RUNTIME-VERIFY: renders a plugin's sandboxed UI in an imperatively
+// created <webview> (the repo manages webviews imperatively, not via JSX). The
+// guest loads orca-plugin://<id>/ in its own partition with Node disabled —
+// fault isolation, not a privilege boundary (the backend is trusted).
+//
+// The guest<->host message channel for a no-preload guest is the murky desktop
+// bit the plan flags: a sandboxed guest cannot reach window.api, so messages
+// must cross via the webview element. We listen for `ipc-message` and forward to
+// the backend; whether the guest can emit without a minimal plugin preload is
+// exactly what the runtime pass must confirm.
+
+type PluginPanelProps = { pluginId: string }
+
+type PanelStatus = 'loading' | 'ready' | 'error'
+
+export function PluginPanel({ pluginId }: PluginPanelProps): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [status, setStatus] = useState<PanelStatus>('loading')
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+    setStatus('loading')
+    const webview = document.createElement('webview') as Electron.WebviewTag
+    webview.setAttribute('src', `orca-plugin://${pluginId}/index.html`)
+    webview.setAttribute('partition', `persist:orca-plugin-${pluginId}`)
+    webview.setAttribute('nodeintegration', 'off')
+    webview.setAttribute('webpreferences', 'contextIsolation=yes, sandbox=yes, nodeIntegration=no')
+    webview.style.width = '100%'
+    webview.style.height = '100%'
+    webview.style.border = '0'
+
+    const onReady = (): void => setStatus('ready')
+    const onFail = (): void => setStatus('error')
+    const onCrash = (): void => setStatus('error')
+    const onIpc = (event: Electron.IpcMessageEvent): void => {
+      if (event.channel === 'plugin-ui') {
+        void window.api.plugins.sendUiMessage(pluginId, event.args?.[0])
+      }
+    }
+
+    webview.addEventListener('dom-ready', onReady)
+    webview.addEventListener('did-fail-load', onFail)
+    webview.addEventListener('render-process-gone', onCrash)
+    webview.addEventListener('ipc-message', onIpc)
+    container.appendChild(webview)
+
+    return () => {
+      webview.removeEventListener('dom-ready', onReady)
+      webview.removeEventListener('did-fail-load', onFail)
+      webview.removeEventListener('render-process-gone', onCrash)
+      webview.removeEventListener('ipc-message', onIpc)
+      webview.remove()
+    }
+  }, [pluginId])
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      {status === 'loading' && (
+        <div className="text-muted-foreground p-3 text-xs">Loading plugin…</div>
+      )}
+      {status === 'error' && (
+        <div className="text-destructive p-3 text-xs">This plugin failed to load.</div>
+      )}
+      <div ref={containerRef} className="min-h-0 flex-1" />
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -8,6 +8,9 @@ const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
 const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
+const PluginPanel = lazy(() => import('./plugin-panel').then((m) => ({ default: m.PluginPanel })))
+
+const PLUGIN_TAB_PREFIX = 'plugin:'
 
 type RightSidebarPanelContentProps = {
   effectiveTab: ActiveRightSidebarTab
@@ -36,6 +39,9 @@ export function RightSidebarPanelContent({
           <FolderWorkspacePrChecksPanel
             isVisible={rightSidebarOpen && effectiveTab === 'pr-checks'}
           />
+        )}
+        {effectiveTab.startsWith(PLUGIN_TAB_PREFIX) && (
+          <PluginPanel pluginId={effectiveTab.slice(PLUGIN_TAB_PREFIX.length)} />
         )}
       </Suspense>
     </div>

--- a/src/renderer/src/components/right-sidebar/use-plugin-activity-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/use-plugin-activity-items.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { Plug } from 'lucide-react'
+import { resolveIcon } from './use-plugin-activity-items'
+
+describe('resolveIcon', () => {
+  it('resolves a real Lucide icon name to its component', () => {
+    // Activity is a forwardRef icon component, not the Plug fallback.
+    expect(resolveIcon('Activity')).not.toBe(Plug)
+    expect(typeof resolveIcon('Activity')).toBe('object')
+  })
+
+  it('falls back to Plug for an unknown name', () => {
+    expect(resolveIcon('NotARealIconName')).toBe(Plug)
+  })
+
+  it('falls back to Plug for a non-component namespace export (function helper)', () => {
+    // createLucideIcon is a plain function on the namespace; rendering it would
+    // crash, so it must not be returned as an icon.
+    expect(resolveIcon('createLucideIcon')).toBe(Plug)
+  })
+
+  it('falls back to Plug for the icons namespace object', () => {
+    expect(resolveIcon('icons')).toBe(Plug)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/use-plugin-activity-items.ts
+++ b/src/renderer/src/components/right-sidebar/use-plugin-activity-items.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import * as LucideIcons from 'lucide-react'
+import { Plug } from 'lucide-react'
+import type { ActivityBarItem } from './activity-bar-buttons'
+
+type IconComponent = ActivityBarItem['icon']
+
+// Resolve a manifest's Lucide icon NAME to a component, falling back to Plug for
+// an unknown name (manifest validation only checks the name's format, not
+// membership — that resolution happens here, where lucide-react is available).
+function resolveIcon(name: string): IconComponent {
+  const icon = (LucideIcons as unknown as Record<string, IconComponent | undefined>)[name]
+  return icon ?? Plug
+}
+
+// NEEDS-RUNTIME-VERIFY: builds activity-bar items for ACTIVE plugins from the
+// plugin registry (window.api.plugins.list()). Inactive/installed plugins are
+// managed in Settings, not shown in the bar. Refetches on mount; a future
+// onChanged subscription would keep it live.
+export function usePluginActivityItems(): ActivityBarItem[] {
+  const [items, setItems] = useState<ActivityBarItem[]>([])
+  useEffect(() => {
+    let cancelled = false
+    window.api.plugins
+      .list()
+      .then((plugins) => {
+        if (cancelled) {
+          return
+        }
+        setItems(
+          plugins
+            .filter((plugin) => plugin.active)
+            .map((plugin) => ({
+              id: `plugin:${plugin.id}`,
+              icon: resolveIcon(plugin.icon),
+              title: plugin.title,
+              shortcut: ''
+            }))
+        )
+      })
+      .catch(() => {
+        // Registry unavailable (e.g. plugin system failed to init) — no tabs.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+  return items
+}

--- a/src/renderer/src/components/right-sidebar/use-plugin-activity-items.ts
+++ b/src/renderer/src/components/right-sidebar/use-plugin-activity-items.ts
@@ -8,9 +8,17 @@ type IconComponent = ActivityBarItem['icon']
 // Resolve a manifest's Lucide icon NAME to a component, falling back to Plug for
 // an unknown name (manifest validation only checks the name's format, not
 // membership — that resolution happens here, where lucide-react is available).
-function resolveIcon(name: string): IconComponent {
-  const icon = (LucideIcons as unknown as Record<string, IconComponent | undefined>)[name]
-  return icon ?? Plug
+// The namespace also exports non-icon helpers (createLucideIcon, toKebabCase…)
+// whose names an untrusted manifest could request; only Lucide's forwardRef icon
+// components (objects carrying `$$typeof`) are renderable, so anything else —
+// including those plain-function helpers — falls back to Plug rather than
+// crashing the sidebar.
+export function resolveIcon(name: string): IconComponent {
+  const candidate = (LucideIcons as Record<string, unknown>)[name]
+  if (typeof candidate === 'object' && candidate !== null && '$$typeof' in candidate) {
+    return candidate as IconComponent
+  }
+  return Plug
 }
 
 // NEEDS-RUNTIME-VERIFY: builds activity-bar items for ACTIVE plugins from the

--- a/src/renderer/src/components/settings/PluginsPane.tsx
+++ b/src/renderer/src/components/settings/PluginsPane.tsx
@@ -36,7 +36,7 @@ export function PluginsPane(): React.JSX.Element {
     setBusy(true)
     setError(null)
     try {
-      const result = await window.api.plugins.installLocal(sourceDir.trim())
+      const result = await window.api.plugins.installFromSource(sourceDir.trim())
       if (!result.ok) {
         setError(
           result.errors?.join('; ') ?? translate('plugins.pane.installFailed', 'Install failed')
@@ -80,12 +80,18 @@ export function PluginsPane(): React.JSX.Element {
       <div className="flex items-end gap-2">
         <div className="flex flex-1 flex-col gap-1">
           <label className="text-muted-foreground text-xs" htmlFor="plugin-source">
-            {translate('plugins.pane.installFromFolder', 'Install from a local folder')}
+            {translate(
+              'plugins.pane.installFromSource',
+              'Install a plugin (npm name, git URL, .tgz, or local path)'
+            )}
           </label>
           <Input
             id="plugin-source"
             value={sourceDir}
-            placeholder={translate('plugins.pane.sourcePlaceholder', '/path/to/plugin')}
+            placeholder={translate(
+              'plugins.pane.sourcePlaceholder',
+              '@acme/orca-foo or /path/to/plugin'
+            )}
             onChange={(event) => setSourceDir(event.target.value)}
           />
         </div>

--- a/src/renderer/src/components/settings/PluginsPane.tsx
+++ b/src/renderer/src/components/settings/PluginsPane.tsx
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from 'react'
+import { translate } from '@/i18n/i18n'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+// NEEDS-RUNTIME-VERIFY: Settings → Plugins management UI. Lists installed
+// plugins, toggles activation, removes, and installs from a local folder via
+// window.api.plugins. The trusted-runtime model means every plugin runs with
+// full machine access — the pane states this prominently. (Preview-gating and
+// the multi-source install dialog are follow-ups; v1a is local-folder install.)
+
+type PluginRow = { id: string; version: string; active: boolean; title: string; icon: string }
+
+export function PluginsPane(): React.JSX.Element {
+  const [plugins, setPlugins] = useState<PluginRow[]>([])
+  const [sourceDir, setSourceDir] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      setPlugins(await window.api.plugins.list())
+    } catch {
+      setPlugins([])
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const install = useCallback(async () => {
+    if (!sourceDir.trim()) {
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await window.api.plugins.installLocal(sourceDir.trim())
+      if (!result.ok) {
+        setError(
+          result.errors?.join('; ') ?? translate('plugins.pane.installFailed', 'Install failed')
+        )
+      } else {
+        setSourceDir('')
+      }
+      await refresh()
+    } finally {
+      setBusy(false)
+    }
+  }, [sourceDir, refresh])
+
+  const toggle = useCallback(
+    async (plugin: PluginRow) => {
+      await (plugin.active
+        ? window.api.plugins.deactivate(plugin.id)
+        : window.api.plugins.activate(plugin.id))
+      await refresh()
+    },
+    [refresh]
+  )
+
+  const remove = useCallback(
+    async (plugin: PluginRow) => {
+      await window.api.plugins.remove(plugin.id)
+      await refresh()
+    },
+    [refresh]
+  )
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-muted-foreground text-xs">
+        {translate(
+          'plugins.pane.trustWarning',
+          'Plugins run with full access to your computer (files, network, processes). Only install plugins you trust.'
+        )}
+      </p>
+
+      <div className="flex items-end gap-2">
+        <div className="flex flex-1 flex-col gap-1">
+          <label className="text-muted-foreground text-xs" htmlFor="plugin-source">
+            {translate('plugins.pane.installFromFolder', 'Install from a local folder')}
+          </label>
+          <Input
+            id="plugin-source"
+            value={sourceDir}
+            placeholder={translate('plugins.pane.sourcePlaceholder', '/path/to/plugin')}
+            onChange={(event) => setSourceDir(event.target.value)}
+          />
+        </div>
+        <Button disabled={busy || !sourceDir.trim()} onClick={() => void install()}>
+          {translate('plugins.pane.install', 'Install')}
+        </Button>
+      </div>
+      {error && <p className="text-destructive text-xs">{error}</p>}
+
+      {plugins.length === 0 ? (
+        <p className="text-muted-foreground text-xs">
+          {translate('plugins.pane.empty', 'No plugins installed yet.')}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {plugins.map((plugin) => (
+            <li
+              key={plugin.id}
+              className="flex items-center justify-between rounded-md border border-border p-3"
+            >
+              <div className="flex flex-col">
+                <span className="text-sm">{plugin.title}</span>
+                <span className="text-muted-foreground text-xs">
+                  {translate('plugins.pane.idVersion', '{{id}} · v{{version}}', {
+                    id: plugin.id,
+                    version: plugin.version
+                  })}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" onClick={() => void toggle(plugin)}>
+                  {plugin.active
+                    ? translate('plugins.pane.deactivate', 'Deactivate')
+                    : translate('plugins.pane.activate', 'Activate')}
+                </Button>
+                <Button variant="destructive" onClick={() => void remove(plugin)}>
+                  {translate('plugins.pane.remove', 'Remove')}
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -48,6 +48,7 @@ import { MobileEmulatorSettingsPane } from './MobileEmulatorSettingsPane'
 import { RuntimeEnvironmentsPane } from './RuntimeEnvironmentsPane'
 import { PrivacyPane } from './PrivacyPane'
 import { AdvancedPane } from './AdvancedPane'
+import { PluginsPane } from './PluginsPane'
 import { SettingsSidebar } from './SettingsSidebar'
 import { SettingsSetupGuidePane } from './SettingsSetupGuidePane'
 import { ActiveSettingsSectionProvider, SettingsSection } from './SettingsSection'
@@ -1418,6 +1419,18 @@ function Settings(): React.JSX.Element {
                   searchEntries={getSectionSearchEntries('stats')}
                 >
                   {isSectionMounted('stats') ? <StatsPane /> : null}
+                </SettingsSection>
+
+                <SettingsSection
+                  id="plugins"
+                  title={translate('plugins.nav.title', 'Plugins')}
+                  description={translate(
+                    'plugins.nav.description',
+                    'Install and manage Orca plugins.'
+                  )}
+                  searchEntries={getSectionSearchEntries('plugins')}
+                >
+                  {isSectionMounted('plugins') ? <PluginsPane /> : null}
                 </SettingsSection>
 
                 <SettingsSection

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -27,6 +27,7 @@ import {
   SlidersHorizontal,
   Smartphone,
   TabletSmartphone,
+  Plug,
   SquareTerminal,
   TextCursorInput,
   UserCog,
@@ -384,6 +385,14 @@ export function buildSettingsNavigationMetadata({
       ),
       icon: BarChart3,
       searchEntries: getStatsPaneSearchEntries(),
+      group: 'interface'
+    },
+    {
+      id: 'plugins',
+      title: translate('plugins.nav.title', 'Plugins'),
+      description: translate('plugins.nav.description', 'Install and manage Orca plugins.'),
+      icon: Plug,
+      searchEntries: [],
       group: 'interface'
     },
     {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4393,10 +4393,10 @@
           "5f5142a62a": "Previous icon"
         },
         "AppearancePane": {
+          "3057983501": "Unassigned",
           "872af9556e": "System Tray",
           "2edf606c46": "Minimize to Tray on Close",
           "b707773a0d": "When enabled, closing the window keeps Orca running in the system tray instead of quitting.",
-          "3057983501": "Unassigned",
           "0cd9b8228f": "Choose the app icon shown in the Dock and window switcher.",
           "ca1590d42f": "App Icon",
           "61d842eca0": "Show the Orca Mobile shortcut in the sidebar. It remains available from Toolbox.",
@@ -11552,6 +11552,24 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    }
+  },
+  "plugins": {
+    "pane": {
+      "installFailed": "Install failed",
+      "trustWarning": "Plugins run with full access to your computer (files, network, processes). Only install plugins you trust.",
+      "installFromFolder": "Install from a local folder",
+      "install": "Install",
+      "empty": "No plugins installed yet.",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "remove": "Remove",
+      "sourcePlaceholder": "/path/to/plugin",
+      "idVersion": "{{id}} · v{{version}}"
+    },
+    "panel": {
+      "loading": "Loading plugin…",
+      "loadError": "This plugin failed to load."
     }
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11565,7 +11565,8 @@
       "activate": "Activate",
       "remove": "Remove",
       "sourcePlaceholder": "/path/to/plugin",
-      "idVersion": "{{id}} · v{{version}}"
+      "idVersion": "{{id}} · v{{version}}",
+      "installFromSource": "Install a plugin (npm name, git URL, .tgz, or local path)"
     },
     "panel": {
       "loading": "Loading plugin…",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11570,6 +11570,10 @@
     "panel": {
       "loading": "Loading plugin…",
       "loadError": "This plugin failed to load."
+    },
+    "nav": {
+      "title": "Plugins",
+      "description": "Install and manage Orca plugins."
     }
   }
 }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11553,5 +11553,23 @@
         }
       }
     }
+  },
+  "plugins": {
+    "pane": {
+      "installFailed": "Install failed",
+      "trustWarning": "Plugins run with full access to your computer (files, network, processes). Only install plugins you trust.",
+      "installFromFolder": "Install from a local folder",
+      "install": "Install",
+      "empty": "No plugins installed yet.",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "remove": "Remove",
+      "sourcePlaceholder": "/path/to/plugin",
+      "idVersion": "{{id}} · v{{version}}"
+    },
+    "panel": {
+      "loading": "Loading plugin…",
+      "loadError": "This plugin failed to load."
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11565,7 +11565,8 @@
       "activate": "Activate",
       "remove": "Remove",
       "sourcePlaceholder": "/path/to/plugin",
-      "idVersion": "{{id}} · v{{version}}"
+      "idVersion": "{{id}} · v{{version}}",
+      "installFromSource": "Install a plugin (npm name, git URL, .tgz, or local path)"
     },
     "panel": {
       "loading": "Loading plugin…",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11570,6 +11570,10 @@
     "panel": {
       "loading": "Loading plugin…",
       "loadError": "This plugin failed to load."
+    },
+    "nav": {
+      "title": "Plugins",
+      "description": "Install and manage Orca plugins."
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11553,5 +11553,23 @@
         }
       }
     }
+  },
+  "plugins": {
+    "pane": {
+      "installFailed": "Install failed",
+      "trustWarning": "Plugins run with full access to your computer (files, network, processes). Only install plugins you trust.",
+      "installFromFolder": "Install from a local folder",
+      "install": "Install",
+      "empty": "No plugins installed yet.",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "remove": "Remove",
+      "sourcePlaceholder": "/path/to/plugin",
+      "idVersion": "{{id}} · v{{version}}"
+    },
+    "panel": {
+      "loading": "Loading plugin…",
+      "loadError": "This plugin failed to load."
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11565,7 +11565,8 @@
       "activate": "Activate",
       "remove": "Remove",
       "sourcePlaceholder": "/path/to/plugin",
-      "idVersion": "{{id}} · v{{version}}"
+      "idVersion": "{{id}} · v{{version}}",
+      "installFromSource": "Install a plugin (npm name, git URL, .tgz, or local path)"
     },
     "panel": {
       "loading": "Loading plugin…",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11570,6 +11570,10 @@
     "panel": {
       "loading": "Loading plugin…",
       "loadError": "This plugin failed to load."
+    },
+    "nav": {
+      "title": "Plugins",
+      "description": "Install and manage Orca plugins."
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11553,5 +11553,23 @@
         }
       }
     }
+  },
+  "plugins": {
+    "pane": {
+      "installFailed": "Install failed",
+      "trustWarning": "Plugins run with full access to your computer (files, network, processes). Only install plugins you trust.",
+      "installFromFolder": "Install from a local folder",
+      "install": "Install",
+      "empty": "No plugins installed yet.",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "remove": "Remove",
+      "sourcePlaceholder": "/path/to/plugin",
+      "idVersion": "{{id}} · v{{version}}"
+    },
+    "panel": {
+      "loading": "Loading plugin…",
+      "loadError": "This plugin failed to load."
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11565,7 +11565,8 @@
       "activate": "Activate",
       "remove": "Remove",
       "sourcePlaceholder": "/path/to/plugin",
-      "idVersion": "{{id}} · v{{version}}"
+      "idVersion": "{{id}} · v{{version}}",
+      "installFromSource": "Install a plugin (npm name, git URL, .tgz, or local path)"
     },
     "panel": {
       "loading": "Loading plugin…",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11570,6 +11570,10 @@
     "panel": {
       "loading": "Loading plugin…",
       "loadError": "This plugin failed to load."
+    },
+    "nav": {
+      "title": "Plugins",
+      "description": "Install and manage Orca plugins."
     }
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11553,5 +11553,23 @@
         }
       }
     }
+  },
+  "plugins": {
+    "pane": {
+      "installFailed": "Install failed",
+      "trustWarning": "Plugins run with full access to your computer (files, network, processes). Only install plugins you trust.",
+      "installFromFolder": "Install from a local folder",
+      "install": "Install",
+      "empty": "No plugins installed yet.",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "remove": "Remove",
+      "sourcePlaceholder": "/path/to/plugin",
+      "idVersion": "{{id}} · v{{version}}"
+    },
+    "panel": {
+      "loading": "Loading plugin…",
+      "loadError": "This plugin failed to load."
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11565,7 +11565,8 @@
       "activate": "Activate",
       "remove": "Remove",
       "sourcePlaceholder": "/path/to/plugin",
-      "idVersion": "{{id}} · v{{version}}"
+      "idVersion": "{{id}} · v{{version}}",
+      "installFromSource": "Install a plugin (npm name, git URL, .tgz, or local path)"
     },
     "panel": {
       "loading": "Loading plugin…",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11570,6 +11570,10 @@
     "panel": {
       "loading": "Loading plugin…",
       "loadError": "This plugin failed to load."
+    },
+    "nav": {
+      "title": "Plugins",
+      "description": "Install and manage Orca plugins."
     }
   }
 }

--- a/src/renderer/src/store/right-sidebar-route.test.ts
+++ b/src/renderer/src/store/right-sidebar-route.test.ts
@@ -15,4 +15,11 @@ describe('normalizeRightSidebarRoute', () => {
       rightSidebarExplorerView: 'files'
     })
   })
+
+  it('preserves a plugin-contributed tab route', () => {
+    expect(normalizeRightSidebarRoute('plugin:orca.hello-sidebar')).toEqual({
+      rightSidebarTab: 'plugin:orca.hello-sidebar',
+      rightSidebarExplorerView: 'files'
+    })
+  })
 })

--- a/src/renderer/src/store/right-sidebar-route.ts
+++ b/src/renderer/src/store/right-sidebar-route.ts
@@ -17,6 +17,11 @@ export function normalizeRightSidebarRoute(
   if (tab === 'search') {
     return { rightSidebarTab: 'explorer', rightSidebarExplorerView: 'search' }
   }
+  // A plugin-contributed tab (`plugin:<id>`). The sidebar registry decides
+  // whether it is still active and falls back to a default tab if not.
+  if (typeof tab === 'string' && tab.startsWith('plugin:')) {
+    return { rightSidebarTab: tab as ActiveRightSidebarTab, rightSidebarExplorerView: 'files' }
+  }
   if (
     tab === 'explorer' ||
     tab === 'vault' ||

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1078,7 +1078,10 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
         tab === 'workspaces' ||
         tab === 'source-control' ||
         tab === 'checks' ||
-        tab === 'ports'
+        tab === 'ports' ||
+        // Keep plugin-contributed tabs (`plugin:<id>`); the registry resolves
+        // whether the plugin is still active at render time.
+        (typeof tab === 'string' && tab.startsWith('plugin:'))
       ) {
         out[id] = tab
       } else {

--- a/src/shared/plugin/api-contract.test.ts
+++ b/src/shared/plugin/api-contract.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, expectTypeOf } from 'vitest'
+import {
+  BRIDGE_METHOD_CAPABILITY,
+  BRIDGE_METHODS,
+  isBridgeMethod,
+  isHostCommand,
+  isLifecycleEvent,
+  type PluginContext,
+  type WorkspaceSnapshot
+} from './api-contract'
+import { isPluginCapability } from './manifest'
+
+describe('bridge method contract', () => {
+  it('recognizes declared methods and rejects unknown ones', () => {
+    expect(isBridgeMethod('workspace.getSnapshot')).toBe(true)
+    expect(isBridgeMethod('workspace.nope')).toBe(false)
+    expect(isBridgeMethod(123)).toBe(false)
+  })
+
+  it('maps every bridge method to a valid capability', () => {
+    for (const method of BRIDGE_METHODS) {
+      const cap = BRIDGE_METHOD_CAPABILITY[method]
+      expect(isPluginCapability(cap)).toBe(true)
+    }
+  })
+})
+
+describe('host command + lifecycle guards', () => {
+  it('recognizes allowlisted host commands', () => {
+    expect(isHostCommand('open-external-url')).toBe(true)
+    expect(isHostCommand('copy-to-clipboard')).toBe(true)
+    expect(isHostCommand('rm-rf')).toBe(false)
+  })
+
+  it('recognizes lifecycle events', () => {
+    expect(isLifecycleEvent('onWorkspaceChanged')).toBe(true)
+    expect(isLifecycleEvent('onWhatever')).toBe(false)
+  })
+})
+
+describe('context API is async for every host-backed accessor', () => {
+  it('types host reads as Promise-returning (compile-time contract)', () => {
+    expectTypeOf<PluginContext['workspace']['getSnapshot']>().returns.toEqualTypeOf<
+      Promise<WorkspaceSnapshot>
+    >()
+    expectTypeOf<PluginContext['commands']['invokeHost']>().returns.toExtend<Promise<unknown>>()
+    expectTypeOf<PluginContext['settings']['set']>().returns.toEqualTypeOf<Promise<void>>()
+    expectTypeOf<PluginContext['settings']['get']>().returns.toExtend<Promise<unknown>>()
+  })
+})

--- a/src/shared/plugin/api-contract.ts
+++ b/src/shared/plugin/api-contract.ts
@@ -84,6 +84,7 @@ export type BridgeErrorCode =
   | 'unknown_method'
   | 'unknown_plugin'
   | 'invalid_params'
+  | 'internal'
 
 export type BridgeResponse =
   | { reqId: string; ok: true; result: unknown }

--- a/src/shared/plugin/api-contract.ts
+++ b/src/shared/plugin/api-contract.ts
@@ -1,0 +1,120 @@
+// The plugin <-> host API contract: the message protocol, the typed `context`
+// surface authors program against, the bounded workspace snapshot, the host
+// command allowlist, and the lifecycle/event names. Shared by main, the relay,
+// and the SDK so client and host cannot drift.
+//
+// Every host-backed accessor is async (Promise-returning): each call crosses a
+// process boundary (child IPC) and, on mobile, an SSH relay hop. A synchronous
+// signature could not be backed by the remote transport.
+
+import type { PluginCapability } from './manifest'
+
+// Bounded workspace data a plugin may read via `workspace:read`. Deliberately
+// excludes filesystem paths, remotes, and credentials — a plugin that needs
+// more uses raw Node (which the trusted-runtime consent already covers).
+export type WorkspaceSnapshot = {
+  workspaceName: string
+  currentBranch: string | null
+  isDirty: boolean
+  openFileCount: number
+}
+
+// The keys a projected snapshot is allowed to contain. Used by the gate's
+// projection to strip anything else a host service might hand it.
+export const WORKSPACE_SNAPSHOT_KEYS = [
+  'workspaceName',
+  'currentBranch',
+  'isDirty',
+  'openFileCount'
+] as const satisfies readonly (keyof WorkspaceSnapshot)[]
+
+// Allowlisted host commands a plugin may invoke via `context.commands.invokeHost`.
+export const HOST_COMMANDS = ['open-external-url', 'copy-to-clipboard'] as const
+export type HostCommand = (typeof HOST_COMMANDS)[number]
+
+export function isHostCommand(value: unknown): value is HostCommand {
+  return typeof value === 'string' && (HOST_COMMANDS as readonly string[]).includes(value)
+}
+
+// Host -> plugin lifecycle/event names the backend can subscribe to.
+export const LIFECYCLE_EVENTS = [
+  'onWorkspaceChanged',
+  'onBranchChanged',
+  'onSettingsChanged',
+  'onPanelVisible',
+  'onDeactivate'
+] as const
+export type LifecycleEvent = (typeof LIFECYCLE_EVENTS)[number]
+
+export function isLifecycleEvent(value: unknown): value is LifecycleEvent {
+  return typeof value === 'string' && (LIFECYCLE_EVENTS as readonly string[]).includes(value)
+}
+
+// Bridge methods the plugin backend may call on the host, each gated by a
+// declared capability. `satisfies` keeps the capability map exhaustive.
+export const BRIDGE_METHODS = [
+  'workspace.getSnapshot',
+  'commands.invokeHost',
+  'settings.get',
+  'settings.set'
+] as const
+export type BridgeMethod = (typeof BRIDGE_METHODS)[number]
+
+export function isBridgeMethod(value: unknown): value is BridgeMethod {
+  return typeof value === 'string' && (BRIDGE_METHODS as readonly string[]).includes(value)
+}
+
+export const BRIDGE_METHOD_CAPABILITY = {
+  'workspace.getSnapshot': 'workspace:read',
+  'commands.invokeHost': 'commands',
+  'settings.get': 'settings',
+  'settings.set': 'settings'
+} satisfies Record<BridgeMethod, PluginCapability>
+
+// Wire envelope. `pluginId` is never carried here — the host derives it from
+// the authenticated sender (webContents / child process / paired relay client).
+export type BridgeRequest = {
+  reqId: string
+  method: BridgeMethod
+  params?: unknown
+}
+
+export type BridgeErrorCode =
+  | 'capability_denied'
+  | 'unknown_method'
+  | 'unknown_plugin'
+  | 'invalid_params'
+
+export type BridgeResponse =
+  | { reqId: string; ok: true; result: unknown }
+  | { reqId: string; ok: false; error: BridgeErrorCode }
+
+// A subscription handle returned by `onDidChange`/event subscriptions.
+export type Disposable = {
+  dispose(): void
+}
+
+// The typed surface a plugin backend programs against. All host-backed reads
+// are async; `register`/`on*`/`postMessage` are local and synchronous.
+export type PluginContext = {
+  workspace: {
+    getSnapshot(): Promise<WorkspaceSnapshot>
+    onDidChange(cb: () => void): Disposable
+  }
+  commands: {
+    register(id: string, handler: (...args: unknown[]) => unknown): Disposable
+    invokeHost(name: HostCommand, params?: unknown): Promise<unknown>
+  }
+  settings: {
+    get<T = unknown>(key: string): Promise<T | undefined>
+    set(key: string, value: unknown): Promise<void>
+    onDidChange(cb: () => void): Disposable
+  }
+  ui: {
+    postMessage(message: unknown): void
+    onMessage(cb: (message: unknown) => void): Disposable
+  }
+  events: Record<LifecycleEvent, (cb: (payload?: unknown) => void) => Disposable>
+  log: (...args: unknown[]) => void
+  subscriptions: Disposable[]
+}

--- a/src/shared/plugin/capability-consent.test.ts
+++ b/src/shared/plugin/capability-consent.test.ts
@@ -9,7 +9,7 @@ import { PLUGIN_CAPABILITIES } from './manifest'
 describe('capability consent copy', () => {
   it('has copy for every capability', () => {
     for (const cap of PLUGIN_CAPABILITIES) {
-      expect(CAPABILITY_CONSENT_COPY[cap]).toBeTruthy()
+      expect(CAPABILITY_CONSENT_COPY[cap].trim().length).toBeGreaterThan(10)
     }
   })
 

--- a/src/shared/plugin/capability-consent.test.ts
+++ b/src/shared/plugin/capability-consent.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CAPABILITY_CONSENT_COPY,
+  CAPABILITY_NOT_A_LIMIT_DISCLAIMER,
+  capabilityConsentLines
+} from './capability-consent'
+import { PLUGIN_CAPABILITIES } from './manifest'
+
+describe('capability consent copy', () => {
+  it('has copy for every capability', () => {
+    for (const cap of PLUGIN_CAPABILITIES) {
+      expect(CAPABILITY_CONSENT_COPY[cap]).toBeTruthy()
+    }
+  })
+
+  it('renders lines in canonical order regardless of declared order', () => {
+    const lines = capabilityConsentLines(['settings', 'workspace:read'])
+    expect(lines).toEqual([
+      CAPABILITY_CONSENT_COPY['workspace:read'],
+      CAPABILITY_CONSENT_COPY['settings']
+    ])
+  })
+
+  it('returns no lines for an empty capability list', () => {
+    expect(capabilityConsentLines([])).toEqual([])
+  })
+
+  it('disclaimer makes clear capabilities are not enforced limits', () => {
+    expect(CAPABILITY_NOT_A_LIMIT_DISCLAIMER.toLowerCase()).toContain('not enforced limits')
+    expect(CAPABILITY_NOT_A_LIMIT_DISCLAIMER.toLowerCase()).toContain('full access')
+  })
+})

--- a/src/shared/plugin/capability-consent.ts
+++ b/src/shared/plugin/capability-consent.ts
@@ -1,0 +1,33 @@
+// Consent copy for the install-time trust gate. Because plugins run trusted
+// (full Node/shell), capabilities are NOT a runtime boundary — the consent UI
+// must say so. The disclaimer constant below is required wherever capabilities
+// are listed, so a UI implementer cannot quietly present them as limits.
+
+import { PLUGIN_CAPABILITIES, type PluginCapability } from './manifest'
+
+// Required, rendered at the same weight as the capability list, so users do not
+// infer that unlisted capabilities are blocked. See the plan's Trust Model.
+export const CAPABILITY_NOT_A_LIMIT_DISCLAIMER =
+  'These are the author’s declared intentions, not enforced limits. Because plugins run with full ' +
+  'access to your computer, they are not technically restricted to the capabilities listed here.'
+
+// Plain-language description per capability. `satisfies` keeps it exhaustive so
+// adding a capability forces adding its consent copy.
+export const CAPABILITY_CONSENT_COPY = {
+  'workspace:read':
+    'Read basic workspace info (name, current branch, dirty state, open file count)',
+  commands: 'Run allowlisted host commands (open external links, copy to clipboard)',
+  settings: 'Store and read its own plugin settings',
+  'process:spawn': 'Run programs and shell commands on your computer',
+  network: 'Make network connections',
+  fs: 'Read and write files on your computer'
+} satisfies Record<PluginCapability, string>
+
+// Build the consent lines for a manifest's declared capabilities, in the
+// canonical capability order (stable display regardless of manifest order).
+export function capabilityConsentLines(declared: readonly PluginCapability[]): string[] {
+  const set = new Set(declared)
+  return PLUGIN_CAPABILITIES.filter((cap) => set.has(cap)).map(
+    (cap) => CAPABILITY_CONSENT_COPY[cap]
+  )
+}

--- a/src/shared/plugin/capability-gate.test.ts
+++ b/src/shared/plugin/capability-gate.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { gateBridgeMethod, projectWorkspaceSnapshot, validateHostCommand } from './capability-gate'
+import { BRIDGE_METHODS, WORKSPACE_SNAPSHOT_KEYS } from './api-contract'
+
+describe('gateBridgeMethod', () => {
+  it('grants a declared capability', () => {
+    expect(gateBridgeMethod(['workspace:read'], 'workspace.getSnapshot')).toEqual({ granted: true })
+    expect(gateBridgeMethod(['settings'], 'settings.set')).toEqual({ granted: true })
+  })
+
+  it('denies an undeclared capability (deny-by-default)', () => {
+    expect(gateBridgeMethod([], 'workspace.getSnapshot')).toEqual({
+      granted: false,
+      error: 'capability_denied'
+    })
+    expect(gateBridgeMethod(['workspace:read'], 'settings.get')).toEqual({
+      granted: false,
+      error: 'capability_denied'
+    })
+  })
+
+  it('rejects an unknown method', () => {
+    expect(gateBridgeMethod(['workspace:read'], 'workspace.deleteEverything')).toEqual({
+      granted: false,
+      error: 'unknown_method'
+    })
+  })
+
+  it('has a capability mapping for every bridge method', () => {
+    for (const method of BRIDGE_METHODS) {
+      expect(gateBridgeMethod([], method).granted).toBe(false) // mapped, just undeclared
+      expect(gateBridgeMethod([], method)).not.toEqual({ granted: false, error: 'unknown_method' })
+    }
+  })
+})
+
+describe('validateHostCommand', () => {
+  it('accepts an https open-external-url', () => {
+    expect(validateHostCommand('open-external-url', { url: 'https://example.com' })).toEqual({
+      ok: true
+    })
+  })
+
+  it('rejects a non-http(s) scheme', () => {
+    expect(validateHostCommand('open-external-url', { url: 'file:///etc/passwd' }).ok).toBe(false)
+    expect(validateHostCommand('open-external-url', { url: 'javascript:alert(1)' }).ok).toBe(false)
+    expect(validateHostCommand('open-external-url', { url: 'not a url' }).ok).toBe(false)
+  })
+
+  it('accepts copy-to-clipboard with string text and rejects non-string', () => {
+    expect(validateHostCommand('copy-to-clipboard', { text: 'hi' })).toEqual({ ok: true })
+    expect(validateHostCommand('copy-to-clipboard', { text: 42 }).ok).toBe(false)
+  })
+
+  it('rejects an unlisted host command', () => {
+    expect(validateHostCommand('spawn-shell', {})).toEqual({ ok: false, error: 'unknown_method' })
+  })
+})
+
+describe('projectWorkspaceSnapshot', () => {
+  it('keeps exactly the bounded keys and drops everything else', () => {
+    const projected = projectWorkspaceSnapshot({
+      workspaceName: 'orca',
+      currentBranch: 'main',
+      isDirty: true,
+      openFileCount: 3,
+      // sensitive fields a host service must never leak:
+      absolutePath: '/Users/me/secret',
+      remoteUrl: 'git@github.com:me/secret.git',
+      token: 'ghp_xxx'
+    })
+    expect(Object.keys(projected).sort()).toEqual([...WORKSPACE_SNAPSHOT_KEYS].sort())
+    expect(projected).not.toHaveProperty('absolutePath')
+    expect(projected).not.toHaveProperty('token')
+    expect(projected).toEqual({
+      workspaceName: 'orca',
+      currentBranch: 'main',
+      isDirty: true,
+      openFileCount: 3
+    })
+  })
+
+  it('coerces missing / wrong-typed fields to safe defaults', () => {
+    expect(projectWorkspaceSnapshot({})).toEqual({
+      workspaceName: '',
+      currentBranch: null,
+      isDirty: false,
+      openFileCount: 0
+    })
+    expect(projectWorkspaceSnapshot(null)).toEqual({
+      workspaceName: '',
+      currentBranch: null,
+      isDirty: false,
+      openFileCount: 0
+    })
+  })
+})

--- a/src/shared/plugin/capability-gate.ts
+++ b/src/shared/plugin/capability-gate.ts
@@ -6,11 +6,10 @@
 
 import {
   BRIDGE_METHOD_CAPABILITY,
-  HOST_COMMANDS,
   isBridgeMethod,
   isHostCommand,
-  WORKSPACE_SNAPSHOT_KEYS,
   type BridgeErrorCode,
+  type HostCommand,
   type WorkspaceSnapshot
 } from './api-contract'
 import type { PluginCapability } from './manifest'
@@ -42,21 +41,29 @@ export function validateHostCommand(name: unknown, params: unknown): HostCommand
   if (!isHostCommand(name)) {
     return { ok: false, error: 'unknown_method' }
   }
-  if (name === 'open-external-url') {
-    const url =
-      typeof params === 'object' && params !== null ? (params as { url?: unknown }).url : params
-    if (typeof url !== 'string' || !isHttpUrl(url)) {
-      return { ok: false, error: 'invalid_params' }
+  const command: HostCommand = name
+  switch (command) {
+    case 'open-external-url': {
+      const url =
+        typeof params === 'object' && params !== null ? (params as { url?: unknown }).url : params
+      return typeof url === 'string' && isHttpUrl(url)
+        ? { ok: true }
+        : { ok: false, error: 'invalid_params' }
+    }
+    case 'copy-to-clipboard': {
+      const text =
+        typeof params === 'object' && params !== null ? (params as { text?: unknown }).text : params
+      return typeof text === 'string' ? { ok: true } : { ok: false, error: 'invalid_params' }
+    }
+    default: {
+      // Exhaustiveness guard: adding a HostCommand without a case here is a
+      // compile error, preventing a new command from being silently allowed
+      // with no param validation.
+      const exhaustive: never = command
+      void exhaustive
+      return { ok: false, error: 'unknown_method' }
     }
   }
-  if (name === 'copy-to-clipboard') {
-    const text =
-      typeof params === 'object' && params !== null ? (params as { text?: unknown }).text : params
-    if (typeof text !== 'string') {
-      return { ok: false, error: 'invalid_params' }
-    }
-  }
-  return { ok: true }
 }
 
 function isHttpUrl(value: string): boolean {
@@ -84,7 +91,3 @@ export function projectWorkspaceSnapshot(raw: unknown): WorkspaceSnapshot {
         : 0
   }
 }
-
-// Re-exported so callers can assert/iterate the allowlist + projected keys
-// without reaching back into the contract module.
-export { HOST_COMMANDS, WORKSPACE_SNAPSHOT_KEYS }

--- a/src/shared/plugin/capability-gate.ts
+++ b/src/shared/plugin/capability-gate.ts
@@ -1,0 +1,90 @@
+// The capability gate — pure, electron-free, and shared by BOTH the Electron
+// main host services and the relay host services so a security decision cannot
+// land on desktop while drifting on the remote/mobile path. Holds no I/O: only
+// the allow/deny decisions, host-command validation, and snapshot projection.
+// A conformance test runs the same cases against both service impls.
+
+import {
+  BRIDGE_METHOD_CAPABILITY,
+  HOST_COMMANDS,
+  isBridgeMethod,
+  isHostCommand,
+  WORKSPACE_SNAPSHOT_KEYS,
+  type BridgeErrorCode,
+  type WorkspaceSnapshot
+} from './api-contract'
+import type { PluginCapability } from './manifest'
+
+export type GateDecision = { granted: true } | { granted: false; error: BridgeErrorCode }
+
+// Decide whether a plugin that declared `declared` may call `method`. Unknown
+// methods are denied as `unknown_method`; undeclared capabilities as
+// `capability_denied`. Deny-by-default: an empty declared list grants nothing.
+export function gateBridgeMethod(
+  declared: readonly PluginCapability[],
+  method: string
+): GateDecision {
+  if (!isBridgeMethod(method)) {
+    return { granted: false, error: 'unknown_method' }
+  }
+  const required = BRIDGE_METHOD_CAPABILITY[method]
+  return declared.includes(required)
+    ? { granted: true }
+    : { granted: false, error: 'capability_denied' }
+}
+
+export type HostCommandCheck = { ok: true } | { ok: false; error: BridgeErrorCode }
+
+// Validate an allowlisted host command and its params. `open-external-url` is
+// restricted to http(s) so a plugin cannot drive the host into opening
+// arbitrary schemes (file:, etc.).
+export function validateHostCommand(name: unknown, params: unknown): HostCommandCheck {
+  if (!isHostCommand(name)) {
+    return { ok: false, error: 'unknown_method' }
+  }
+  if (name === 'open-external-url') {
+    const url =
+      typeof params === 'object' && params !== null ? (params as { url?: unknown }).url : params
+    if (typeof url !== 'string' || !isHttpUrl(url)) {
+      return { ok: false, error: 'invalid_params' }
+    }
+  }
+  if (name === 'copy-to-clipboard') {
+    const text =
+      typeof params === 'object' && params !== null ? (params as { text?: unknown }).text : params
+    if (typeof text !== 'string') {
+      return { ok: false, error: 'invalid_params' }
+    }
+  }
+  return { ok: true }
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+// Project an arbitrary host-produced object down to exactly the bounded
+// `WorkspaceSnapshot` keys, dropping anything a service impl might leak (paths,
+// remotes, credentials). The output never carries extra keys.
+export function projectWorkspaceSnapshot(raw: unknown): WorkspaceSnapshot {
+  const source = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>
+  const branch = source.currentBranch
+  return {
+    workspaceName: typeof source.workspaceName === 'string' ? source.workspaceName : '',
+    currentBranch: typeof branch === 'string' ? branch : null,
+    isDirty: source.isDirty === true,
+    openFileCount:
+      typeof source.openFileCount === 'number' && Number.isFinite(source.openFileCount)
+        ? source.openFileCount
+        : 0
+  }
+}
+
+// Re-exported so callers can assert/iterate the allowlist + projected keys
+// without reaching back into the contract module.
+export { HOST_COMMANDS, WORKSPACE_SNAPSHOT_KEYS }

--- a/src/shared/plugin/example-plugin.test.ts
+++ b/src/shared/plugin/example-plugin.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { validatePluginManifest } from './manifest-validate'
+
+// Keeps the shipped example plugin honest against the live contract: if the
+// manifest schema tightens, this test fails until the example is updated.
+const EXAMPLE_DIR = join(__dirname, '..', '..', '..', 'examples', 'hello-sidebar-plugin')
+
+describe('example plugin (hello-sidebar)', () => {
+  it('has a manifest that validates against the contract', () => {
+    const raw = JSON.parse(readFileSync(join(EXAMPLE_DIR, 'plugin.json'), 'utf8'))
+    const result = validatePluginManifest(raw)
+    expect(result.ok).toBe(true)
+  })
+
+  it('declares single-file .html UI entries', () => {
+    const raw = JSON.parse(readFileSync(join(EXAMPLE_DIR, 'plugin.json'), 'utf8')) as {
+      contributes: { sidebar: { ui: string }; settings?: { ui: string } }
+    }
+    expect(raw.contributes.sidebar.ui.endsWith('.html')).toBe(true)
+    expect(raw.contributes.settings?.ui.endsWith('.html')).toBe(true)
+  })
+})

--- a/src/shared/plugin/manifest-validate.test.ts
+++ b/src/shared/plugin/manifest-validate.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { validatePluginManifest } from './manifest-validate'
+import type { PluginManifest } from './manifest'
+
+function validRaw(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'acme.workspace-status',
+    name: 'Workspace Status',
+    version: '1.0.0',
+    hostApiVersion: '0.1.0',
+    main: 'dist/main.js',
+    contributes: {
+      sidebar: { title: 'Status', icon: 'Activity', ui: 'ui/index.html' }
+    },
+    capabilities: ['workspace:read', 'commands'],
+    ...overrides
+  }
+}
+
+describe('validatePluginManifest', () => {
+  it('accepts a valid manifest (no settings)', () => {
+    const result = validatePluginManifest(validRaw())
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const manifest: PluginManifest = result.manifest
+      expect(manifest.id).toBe('acme.workspace-status')
+      expect(manifest.capabilities).toEqual(['workspace:read', 'commands'])
+    }
+  })
+
+  it('accepts a valid manifest with a settings contribution', () => {
+    const result = validatePluginManifest(
+      validRaw({
+        contributes: {
+          sidebar: { title: 'Status', icon: 'Activity', ui: 'ui/index.html' },
+          settings: { ui: 'ui/settings.html' }
+        }
+      })
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('reports each missing required field by name', () => {
+    const result = validatePluginManifest({ contributes: {}, capabilities: [] })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      const joined = result.errors.join('\n')
+      expect(joined).toContain('id:')
+      expect(joined).toContain('name:')
+      expect(joined).toContain('version:')
+      expect(joined).toContain('main:')
+      expect(joined).toContain('hostApiVersion:')
+    }
+  })
+
+  it('rejects a multi-file / non-.html ui entry', () => {
+    const result = validatePluginManifest(
+      validRaw({ contributes: { sidebar: { title: 'S', icon: 'Activity', ui: 'ui/' } } })
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join('\n')).toContain('single .html file')
+    }
+  })
+
+  it('rejects a traversing or absolute ui path', () => {
+    const traverse = validatePluginManifest(
+      validRaw({ contributes: { sidebar: { title: 'S', icon: 'Activity', ui: '../evil.html' } } })
+    )
+    const absolute = validatePluginManifest(
+      validRaw({ contributes: { sidebar: { title: 'S', icon: 'Activity', ui: '/etc/x.html' } } })
+    )
+    expect(traverse.ok).toBe(false)
+    expect(absolute.ok).toBe(false)
+    if (!traverse.ok) {
+      expect(traverse.errors.join('\n')).toContain('..')
+    }
+    if (!absolute.ok) {
+      expect(absolute.errors.join('\n')).toContain('absolute')
+    }
+  })
+
+  it('rejects an unknown capability and names the offending value', () => {
+    const result = validatePluginManifest(
+      validRaw({ capabilities: ['workspace:read', 'process:exec'] })
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join('\n')).toContain('process:exec')
+    }
+  })
+
+  it('rejects an icon that is not a valid Lucide name (format check)', () => {
+    const result = validatePluginManifest(
+      validRaw({ contributes: { sidebar: { title: 'S', icon: 'my-icon', ui: 'ui/index.html' } } })
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join('\n')).toContain('icon')
+    }
+  })
+
+  it('rejects a newer-major hostApiVersion with an actionable message', () => {
+    const result = validatePluginManifest(validRaw({ hostApiVersion: '1.0.0' }))
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join('\n')).toContain('newer version of Orca')
+    }
+  })
+
+  it('accepts any 0.x hostApiVersion (pre-stable)', () => {
+    expect(validatePluginManifest(validRaw({ hostApiVersion: '0.4.2' })).ok).toBe(true)
+  })
+
+  it('rejects a non-object manifest', () => {
+    expect(validatePluginManifest(null).ok).toBe(false)
+    expect(validatePluginManifest('nope').ok).toBe(false)
+  })
+})

--- a/src/shared/plugin/manifest-validate.test.ts
+++ b/src/shared/plugin/manifest-validate.test.ts
@@ -116,4 +116,29 @@ describe('validatePluginManifest', () => {
     expect(validatePluginManifest(null).ok).toBe(false)
     expect(validatePluginManifest('nope').ok).toBe(false)
   })
+
+  it('rejects an unsafe id (path traversal) at the trust boundary', () => {
+    for (const id of ['../../../tmp/evil', '/etc/x', 'a/b']) {
+      const result = validatePluginManifest(validRaw({ id }))
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.errors.join('\n')).toContain('id:')
+      }
+    }
+  })
+
+  it('rejects prototype-pollution ids (__proto__, constructor, prototype)', () => {
+    for (const id of ['__proto__', 'constructor', 'prototype']) {
+      expect(validatePluginManifest(validRaw({ id })).ok).toBe(false)
+    }
+  })
+
+  it('rejects a non-object contributes.settings', () => {
+    const result = validatePluginManifest(
+      validRaw({
+        contributes: { sidebar: { title: 'S', icon: 'Activity', ui: 'i.html' }, settings: true }
+      })
+    )
+    expect(result.ok).toBe(false)
+  })
 })

--- a/src/shared/plugin/manifest-validate.ts
+++ b/src/shared/plugin/manifest-validate.ts
@@ -1,0 +1,147 @@
+// Parse + validate a raw plugin manifest into a typed `PluginManifest`.
+// Returns a discriminated result (never throws) so callers — install, the
+// management UI, and tests — can surface every problem at once.
+
+import {
+  isPluginCapability,
+  SUPPORTED_HOST_API_MAJOR,
+  type PluginManifest,
+  type PluginContributes
+} from './manifest'
+
+export type ManifestValidationResult =
+  | { ok: true; manifest: PluginManifest }
+  | { ok: false; errors: string[] }
+
+// A single self-contained HTML entry, relative to the plugin directory. We
+// reject traversal/absolute paths and anything that isn't a lone `.html` file
+// (multi-file UIs / directory entries are deferred to a later phase).
+function validateUiEntry(value: unknown, field: string, errors: string[]): void {
+  if (typeof value !== 'string' || value.length === 0) {
+    errors.push(`${field}: must be a non-empty string path to a single .html file`)
+    return
+  }
+  if (value.includes('..')) {
+    errors.push(`${field}: must not contain '..' (path traversal)`)
+  }
+  if (value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)) {
+    errors.push(`${field}: must be a relative path, not absolute`)
+  }
+  if (!value.toLowerCase().endsWith('.html')) {
+    errors.push(
+      `${field}: must point to a single .html file (multi-file UIs are not supported yet)`
+    )
+  }
+}
+
+// Lucide icon name. The shared validator (used by the electron-free relay and
+// mobile, which do not bundle lucide-react) checks only the FORMAT — a
+// PascalCase identifier. Exact membership in the Lucide set is a render-time
+// check in the renderer, where the icon map is available.
+function validateIcon(value: unknown, errors: string[]): void {
+  if (typeof value !== 'string' || value.length === 0) {
+    errors.push('contributes.sidebar.icon: must be a non-empty Lucide icon name')
+    return
+  }
+  if (!/^[A-Z][A-Za-z0-9]*$/.test(value)) {
+    errors.push(
+      `contributes.sidebar.icon: '${value}' is not a valid Lucide icon name (PascalCase letters/digits)`
+    )
+  }
+}
+
+// Parse the major from a semver-ish string. Returns null when unparseable.
+function parseMajor(version: string): number | null {
+  const match = /^(\d+)\./.exec(version) ?? /^(\d+)$/.exec(version)
+  if (!match) {
+    return null
+  }
+  return Number.parseInt(match[1], 10)
+}
+
+function validateHostApiVersion(value: unknown, errors: string[]): void {
+  if (typeof value !== 'string' || value.length === 0) {
+    errors.push('hostApiVersion: required semver string (e.g. "0.1.0")')
+    return
+  }
+  const major = parseMajor(value)
+  if (major === null) {
+    errors.push(`hostApiVersion: '${value}' is not a valid semver version`)
+    return
+  }
+  if (major > SUPPORTED_HOST_API_MAJOR) {
+    errors.push('hostApiVersion: this plugin requires a newer version of Orca')
+  }
+}
+
+function validateCapabilities(value: unknown, errors: string[]): void {
+  if (!Array.isArray(value)) {
+    errors.push('capabilities: must be an array')
+    return
+  }
+  for (const cap of value) {
+    if (!isPluginCapability(cap)) {
+      errors.push(`capabilities: unknown capability '${String(cap)}'`)
+    }
+  }
+}
+
+function validateContributes(value: unknown, errors: string[]): void {
+  if (typeof value !== 'object' || value === null) {
+    errors.push('contributes: required object with a "sidebar" contribution')
+    return
+  }
+  const contributes = value as Partial<PluginContributes>
+  const sidebar = contributes.sidebar
+  if (typeof sidebar !== 'object' || sidebar === null) {
+    errors.push('contributes.sidebar: required object')
+  } else {
+    if (typeof sidebar.title !== 'string' || sidebar.title.length === 0) {
+      errors.push('contributes.sidebar.title: required non-empty string')
+    }
+    validateIcon(sidebar.icon, errors)
+    validateUiEntry(sidebar.ui, 'contributes.sidebar.ui', errors)
+  }
+  if (contributes.settings !== undefined) {
+    if (typeof contributes.settings !== 'object' || contributes.settings === null) {
+      errors.push('contributes.settings: must be an object when present')
+    } else {
+      validateUiEntry(contributes.settings.ui, 'contributes.settings.ui', errors)
+    }
+  }
+}
+
+function requireString(record: Record<string, unknown>, field: string, errors: string[]): void {
+  const value = record[field]
+  if (typeof value !== 'string' || value.length === 0) {
+    errors.push(`${field}: required non-empty string`)
+  }
+}
+
+export function validatePluginManifest(raw: unknown): ManifestValidationResult {
+  const errors: string[] = []
+
+  if (typeof raw !== 'object' || raw === null) {
+    return { ok: false, errors: ['manifest: expected an object'] }
+  }
+  const record = raw as Record<string, unknown>
+
+  requireString(record, 'id', errors)
+  requireString(record, 'name', errors)
+  requireString(record, 'version', errors)
+  requireString(record, 'main', errors)
+  validateHostApiVersion(record.hostApiVersion, errors)
+  validateContributes(record.contributes, errors)
+  validateCapabilities(record.capabilities, errors)
+  if (
+    record.settingsSchema !== undefined &&
+    (typeof record.settingsSchema !== 'object' || record.settingsSchema === null)
+  ) {
+    errors.push('settingsSchema: must be an object (JSON Schema) when present')
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors }
+  }
+  return { ok: true, manifest: record as unknown as PluginManifest }
+}

--- a/src/shared/plugin/manifest-validate.ts
+++ b/src/shared/plugin/manifest-validate.ts
@@ -4,6 +4,7 @@
 
 import {
   isPluginCapability,
+  isSafePluginId,
   SUPPORTED_HOST_API_MAJOR,
   type PluginManifest,
   type PluginContributes
@@ -127,6 +128,15 @@ export function validatePluginManifest(raw: unknown): ManifestValidationResult {
   const record = raw as Record<string, unknown>
 
   requireString(record, 'id', errors)
+  // The id is used both as a directory name and as an object-map key, so it
+  // must be a safe path segment AND a safe key (no traversal / prototype keys).
+  // This is the single trust boundary — install, manager, store, and settings
+  // store all rely on it rather than re-checking.
+  if (typeof record.id === 'string' && record.id.length > 0 && !isSafePluginId(record.id)) {
+    errors.push(
+      "id: must start alphanumeric and contain only letters, digits, '.', '-', '_' (no '..', no reserved keys like __proto__/constructor)"
+    )
+  }
   requireString(record, 'name', errors)
   requireString(record, 'version', errors)
   requireString(record, 'main', errors)
@@ -143,5 +153,33 @@ export function validatePluginManifest(raw: unknown): ManifestValidationResult {
   if (errors.length > 0) {
     return { ok: false, errors }
   }
-  return { ok: true, manifest: record as unknown as PluginManifest }
+
+  // Construct the typed manifest field-by-field from validated values rather
+  // than a blanket `as unknown as` cast. Adding a required field to
+  // PluginManifest now forces a compile error here if the validator omits it.
+  const contributes = record.contributes as Record<string, unknown>
+  const sidebar = contributes.sidebar as Record<string, unknown>
+  const built: PluginContributes = {
+    sidebar: {
+      title: sidebar.title as string,
+      icon: sidebar.icon as string,
+      ui: sidebar.ui as string
+    }
+  }
+  if (contributes.settings) {
+    built.settings = { ui: (contributes.settings as Record<string, unknown>).ui as string }
+  }
+  const manifest: PluginManifest = {
+    id: record.id as string,
+    name: record.name as string,
+    version: record.version as string,
+    hostApiVersion: record.hostApiVersion as string,
+    main: record.main as string,
+    contributes: built,
+    capabilities: record.capabilities as PluginManifest['capabilities']
+  }
+  if (record.settingsSchema !== undefined) {
+    manifest.settingsSchema = record.settingsSchema as Record<string, unknown>
+  }
+  return { ok: true, manifest }
 }

--- a/src/shared/plugin/manifest.test.ts
+++ b/src/shared/plugin/manifest.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { isPluginCapability, PLUGIN_CAPABILITIES, SUPPORTED_HOST_API_MAJOR } from './manifest'
+import {
+  isPluginCapability,
+  isSafePluginId,
+  PLUGIN_CAPABILITIES,
+  SUPPORTED_HOST_API_MAJOR
+} from './manifest'
 
 describe('plugin capability union', () => {
   it('recognizes every declared capability', () => {
@@ -17,5 +22,36 @@ describe('plugin capability union', () => {
 
   it('is pre-stable (host API major 0)', () => {
     expect(SUPPORTED_HOST_API_MAJOR).toBe(0)
+  })
+})
+
+describe('isSafePluginId', () => {
+  it('accepts normal dotted/dashed ids', () => {
+    for (const id of ['acme.foo', 'a', 'org.team.plugin-name', 'x_y', 'A1.b2']) {
+      expect(isSafePluginId(id)).toBe(true)
+    }
+  })
+
+  it('rejects path traversal and separators', () => {
+    for (const id of ['../evil', '../../tmp/x', 'a/b', 'a\\b', 'a..b', '..', '.']) {
+      expect(isSafePluginId(id)).toBe(false)
+    }
+  })
+
+  it('rejects absolute-path-like ids', () => {
+    expect(isSafePluginId('/etc/passwd')).toBe(false)
+    expect(isSafePluginId('C:\\x')).toBe(false)
+  })
+
+  it('rejects prototype-pollution keys', () => {
+    for (const id of ['__proto__', 'prototype', 'constructor']) {
+      expect(isSafePluginId(id)).toBe(false)
+    }
+  })
+
+  it('rejects empty and leading-symbol ids', () => {
+    expect(isSafePluginId('')).toBe(false)
+    expect(isSafePluginId('-leading')).toBe(false)
+    expect(isSafePluginId('.leading')).toBe(false)
   })
 })

--- a/src/shared/plugin/manifest.test.ts
+++ b/src/shared/plugin/manifest.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { isPluginCapability, PLUGIN_CAPABILITIES, SUPPORTED_HOST_API_MAJOR } from './manifest'
+
+describe('plugin capability union', () => {
+  it('recognizes every declared capability', () => {
+    for (const cap of PLUGIN_CAPABILITIES) {
+      expect(isPluginCapability(cap)).toBe(true)
+    }
+  })
+
+  it('rejects unknown / non-string values', () => {
+    expect(isPluginCapability('process:exec')).toBe(false)
+    expect(isPluginCapability('')).toBe(false)
+    expect(isPluginCapability(undefined)).toBe(false)
+    expect(isPluginCapability(42)).toBe(false)
+  })
+
+  it('is pre-stable (host API major 0)', () => {
+    expect(SUPPORTED_HOST_API_MAJOR).toBe(0)
+  })
+})

--- a/src/shared/plugin/manifest.ts
+++ b/src/shared/plugin/manifest.ts
@@ -30,6 +30,32 @@ export function isPluginCapability(value: unknown): value is PluginCapability {
   return typeof value === 'string' && (PLUGIN_CAPABILITIES as readonly string[]).includes(value)
 }
 
+// Object keys that would corrupt a plain-object map (prototype pollution) if a
+// plugin id were used as a property key.
+const DANGEROUS_PLUGIN_IDS = new Set(['__proto__', 'prototype', 'constructor'])
+
+// A plugin id must be a single safe path segment AND a safe object key, because
+// it is used both as a directory name (`join(pluginsDir, id)`) and as a map key
+// (`state.plugins[id]`). Enforced at the manifest trust boundary so install,
+// the manager, the store, and the settings store all receive safe ids. Plugin
+// ids look like `acme.foo`. Lives in `src/shared/` so the electron-free
+// validator and the main-process settings store share one definition.
+export function isSafePluginId(id: string): boolean {
+  if (typeof id !== 'string') {
+    return false
+  }
+  // Must start alphanumeric, then alphanumerics / dot / dash / underscore.
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id)) {
+    return false
+  }
+  // `..` is a path-traversal segment even though its characters are allowed.
+  if (id.includes('..')) {
+    return false
+  }
+  // `constructor` is alphanumeric and would pass the charset check.
+  return !DANGEROUS_PLUGIN_IDS.has(id)
+}
+
 // A plugin's right-sidebar contribution. `icon` is a Lucide icon name (string)
 // rather than an arbitrary image, so the activity bar stays visually
 // consistent; `ui` is a single self-contained HTML file relative to the plugin

--- a/src/shared/plugin/manifest.ts
+++ b/src/shared/plugin/manifest.ts
@@ -1,0 +1,66 @@
+// The plugin manifest contract — the npm-package shape Orca loads. Lives in
+// `src/shared/` (not the renderer or main) because every host environment that
+// touches a plugin — Electron main, the preload bridge, the renderer registry,
+// and the electron-free relay — validates against this one definition. Mirrors
+// the single-shared-source pattern of `agent-kind.ts`.
+//
+// v1 is pre-stable: `hostApiVersion` is 0.x and the contract may take breaking
+// changes until a real plugin exercises it (see the plan's Versioning section).
+
+// The host API major the shipped app implements. A plugin declaring a newer
+// major than this is rejected at validation time ("requires a newer Orca").
+export const SUPPORTED_HOST_API_MAJOR = 0
+
+// Closed capability union. Capabilities are declared-intent surfaced at install
+// for informed consent — NOT a runtime jail (plugins run trusted with full
+// Node access). Keep this list closed + `satisfies`-checked so a new capability
+// is one edit, not a sweep across consent copy and the gate.
+export const PLUGIN_CAPABILITIES = [
+  'workspace:read',
+  'commands',
+  'settings',
+  'process:spawn',
+  'network',
+  'fs'
+] as const
+
+export type PluginCapability = (typeof PLUGIN_CAPABILITIES)[number]
+
+export function isPluginCapability(value: unknown): value is PluginCapability {
+  return typeof value === 'string' && (PLUGIN_CAPABILITIES as readonly string[]).includes(value)
+}
+
+// A plugin's right-sidebar contribution. `icon` is a Lucide icon name (string)
+// rather than an arbitrary image, so the activity bar stays visually
+// consistent; `ui` is a single self-contained HTML file relative to the plugin
+// directory (multi-file UIs are deferred — see the plan).
+export type PluginSidebarContribution = {
+  title: string
+  icon: string
+  ui: string
+}
+
+// Optional settings page the plugin presents (its own single-file webview).
+export type PluginSettingsContribution = {
+  ui: string
+}
+
+export type PluginContributes = {
+  sidebar: PluginSidebarContribution
+  settings?: PluginSettingsContribution
+}
+
+export type PluginManifest = {
+  id: string
+  name: string
+  version: string
+  // Semver of the host API the plugin targets. Pre-stable: 0.x.
+  hostApiVersion: string
+  // Backend entry module (Node), relative to the plugin directory.
+  main: string
+  contributes: PluginContributes
+  capabilities: PluginCapability[]
+  // Optional JSON Schema used only to validate settings writes (it does not
+  // auto-generate a UI — the plugin presents its own settings page).
+  settingsSchema?: Record<string, unknown>
+}

--- a/src/shared/plugin/settings-schema.test.ts
+++ b/src/shared/plugin/settings-schema.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { validateAgainstSchema } from './settings-schema'
+
+const SCHEMA = {
+  type: 'object',
+  properties: {
+    apiBase: { type: 'string' },
+    refreshSeconds: { type: 'integer' },
+    mode: { type: 'string', enum: ['compact', 'full'] },
+    tags: { type: 'array', items: { type: 'string' } }
+  },
+  required: ['apiBase'],
+  additionalProperties: false
+} as Record<string, unknown>
+
+describe('validateAgainstSchema', () => {
+  it('accepts a conforming object', () => {
+    expect(
+      validateAgainstSchema(
+        { apiBase: 'https://x', refreshSeconds: 30, mode: 'compact', tags: ['a'] },
+        SCHEMA
+      )
+    ).toEqual({ ok: true })
+  })
+
+  it('rejects a missing required property', () => {
+    const result = validateAgainstSchema({ refreshSeconds: 10 }, SCHEMA)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join()).toContain('apiBase')
+    }
+  })
+
+  it('rejects a wrong-typed property', () => {
+    const result = validateAgainstSchema({ apiBase: 'x', refreshSeconds: 'soon' }, SCHEMA)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join()).toContain('refreshSeconds')
+    }
+  })
+
+  it('rejects an out-of-enum value', () => {
+    const result = validateAgainstSchema({ apiBase: 'x', mode: 'weird' }, SCHEMA)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join()).toContain('mode')
+    }
+  })
+
+  it('rejects additional properties when additionalProperties is false', () => {
+    const result = validateAgainstSchema({ apiBase: 'x', extra: 1 }, SCHEMA)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join()).toContain('extra')
+    }
+  })
+
+  it('validates array item types', () => {
+    const result = validateAgainstSchema({ apiBase: 'x', tags: ['ok', 5] }, SCHEMA)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join()).toContain('tags[1]')
+    }
+  })
+
+  it('treats integers as valid numbers', () => {
+    expect(validateAgainstSchema(3, { type: 'number' }).ok).toBe(true)
+  })
+})

--- a/src/shared/plugin/settings-schema.test.ts
+++ b/src/shared/plugin/settings-schema.test.ts
@@ -66,4 +66,15 @@ describe('validateAgainstSchema', () => {
   it('treats integers as valid numbers', () => {
     expect(validateAgainstSchema(3, { type: 'number' }).ok).toBe(true)
   })
+
+  it('rejects all extra keys when additionalProperties is false and no properties are declared', () => {
+    const result = validateAgainstSchema(
+      { anything: 1 },
+      { type: 'object', additionalProperties: false }
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.join()).toContain('anything')
+    }
+  })
 })

--- a/src/shared/plugin/settings-schema.ts
+++ b/src/shared/plugin/settings-schema.ts
@@ -1,0 +1,99 @@
+// A minimal JSON-Schema-subset validator for plugin settings. Plugin authors
+// declare `settingsSchema` (JSON Schema) in their manifest; the settings store
+// validates writes against it. Lives in `src/shared/` so both the Electron main
+// store and the electron-free relay store validate identically.
+//
+// Intentionally a SUBSET — enough to validate plain settings objects without a
+// heavy dependency: type, properties, required, items, enum, additionalProperties.
+// Full JSON Schema (refs, allOf/anyOf, formats, etc.) is deferred.
+
+export type JsonSchemaType =
+  | 'object'
+  | 'array'
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'null'
+
+export type JsonSchema = {
+  type?: JsonSchemaType
+  properties?: Record<string, JsonSchema>
+  required?: string[]
+  items?: JsonSchema
+  enum?: unknown[]
+  additionalProperties?: boolean
+}
+
+export type SchemaValidation = { ok: true } | { ok: false; errors: string[] }
+
+function typeOf(value: unknown): JsonSchemaType {
+  if (value === null) {
+    return 'null'
+  }
+  if (Array.isArray(value)) {
+    return 'array'
+  }
+  if (Number.isInteger(value)) {
+    return 'integer'
+  }
+  return typeof value as JsonSchemaType
+}
+
+function matchesType(value: unknown, expected: JsonSchemaType): boolean {
+  const actual = typeOf(value)
+  if (expected === 'number') {
+    return actual === 'number' || actual === 'integer'
+  }
+  return actual === expected
+}
+
+function validate(value: unknown, schema: JsonSchema, path: string, errors: string[]): void {
+  if (schema.enum && !schema.enum.some((option) => option === value)) {
+    errors.push(`${path}: value is not one of the allowed options`)
+  }
+
+  if (schema.type && !matchesType(value, schema.type)) {
+    errors.push(`${path}: expected ${schema.type}, got ${typeOf(value)}`)
+    return
+  }
+
+  if (schema.type === 'object' && typeOf(value) === 'object') {
+    const obj = value as Record<string, unknown>
+    for (const key of schema.required ?? []) {
+      if (!(key in obj)) {
+        errors.push(`${path}.${key}: required`)
+      }
+    }
+    if (schema.properties) {
+      for (const [key, child] of Object.entries(schema.properties)) {
+        if (key in obj) {
+          validate(obj[key], child, `${path}.${key}`, errors)
+        }
+      }
+    }
+    if (schema.additionalProperties === false && schema.properties) {
+      const allowed = new Set(Object.keys(schema.properties))
+      for (const key of Object.keys(obj)) {
+        if (!allowed.has(key)) {
+          errors.push(`${path}.${key}: additional property not allowed`)
+        }
+      }
+    }
+  }
+
+  if (schema.type === 'array' && Array.isArray(value) && schema.items) {
+    value.forEach((item, index) =>
+      validate(item, schema.items as JsonSchema, `${path}[${index}]`, errors)
+    )
+  }
+}
+
+export function validateAgainstSchema(
+  value: unknown,
+  schema: Record<string, unknown>
+): SchemaValidation {
+  const errors: string[] = []
+  validate(value, schema as JsonSchema, '$', errors)
+  return errors.length === 0 ? { ok: true } : { ok: false, errors }
+}

--- a/src/shared/plugin/settings-schema.ts
+++ b/src/shared/plugin/settings-schema.ts
@@ -72,8 +72,9 @@ function validate(value: unknown, schema: JsonSchema, path: string, errors: stri
         }
       }
     }
-    if (schema.additionalProperties === false && schema.properties) {
-      const allowed = new Set(Object.keys(schema.properties))
+    if (schema.additionalProperties === false) {
+      // With no `properties` declared, every key is "additional" and rejected.
+      const allowed = new Set(Object.keys(schema.properties ?? {}))
       for (const key of Object.keys(obj)) {
         if (!allowed.has(key)) {
           errors.push(`${path}.${key}: additional property not allowed`)

--- a/src/shared/plugin/ui-bridge-client.test.ts
+++ b/src/shared/plugin/ui-bridge-client.test.ts
@@ -60,3 +60,78 @@ describe('ui-bridge-client substrate detection', () => {
     expect(received).toEqual([])
   })
 })
+
+describe('ui-bridge-client request()', () => {
+  // Pull the reqId the bridge stamped onto the outbound message.
+  function postedReqId(post: ReturnType<typeof vi.fn>): string {
+    return (post.mock.calls[0][0] as { reqId: string }).reqId
+  }
+
+  it('resolves with the response carrying the matching reqId', async () => {
+    const post = vi.fn()
+    const win = fakeWindow({ parent: { postMessage: post } })
+    const bridge = createUiBridge(win)
+    const promise = bridge.request({ method: 'settings.get' })
+    const reqId = postedReqId(post)
+    ;(win.__emit as (d: unknown) => void)({ reqId, ok: true, result: 42 })
+    await expect(promise).resolves.toEqual({ reqId, ok: true, result: 42 })
+  })
+
+  it('ignores responses with a non-matching reqId', async () => {
+    vi.useFakeTimers()
+    try {
+      const post = vi.fn()
+      const win = fakeWindow({ parent: { postMessage: post } })
+      const bridge = createUiBridge(win)
+      const promise = bridge.request({ method: 'settings.get' }, { timeoutMs: 1000 })
+      const rejected = promise.catch((e: Error) => e.message)
+      ;(win.__emit as (d: unknown) => void)({ reqId: 'someone-else', ok: true })
+      vi.advanceTimersByTime(1000)
+      expect(await rejected).toMatch(/timed out/i)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects after the timeout and removes its listener (no leak)', async () => {
+    vi.useFakeTimers()
+    try {
+      const removeSpy = vi.fn()
+      const post = vi.fn()
+      const win = fakeWindow({ parent: { postMessage: post }, removeEventListener: removeSpy })
+      const bridge = createUiBridge(win)
+      const rejected = bridge.request({ method: 'x' }, { timeoutMs: 500 }).catch((e: Error) => e)
+      vi.advanceTimersByTime(500)
+      expect(await rejected).toBeInstanceOf(Error)
+      expect(removeSpy).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears the timeout on resolve so no late rejection fires', async () => {
+    vi.useFakeTimers()
+    try {
+      const post = vi.fn()
+      const win = fakeWindow({ parent: { postMessage: post } })
+      const bridge = createUiBridge(win)
+      const promise = bridge.request({ method: 'x' }, { timeoutMs: 1000 })
+      ;(win.__emit as (d: unknown) => void)({ reqId: postedReqId(post), ok: true })
+      await expect(promise).resolves.toMatchObject({ ok: true })
+      // Advancing past the timeout must not throw an unhandled late rejection.
+      vi.advanceTimersByTime(2000)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('works on the RN substrate (JSON string transport)', async () => {
+    const rnPost = vi.fn()
+    const win = fakeWindow({ ReactNativeWebView: { postMessage: rnPost } })
+    const bridge = createUiBridge(win)
+    const promise = bridge.request({ method: 'settings.get' })
+    const reqId = (JSON.parse(rnPost.mock.calls[0][0] as string) as { reqId: string }).reqId
+    ;(win.__emit as (d: unknown) => void)(JSON.stringify({ reqId, ok: true }))
+    await expect(promise).resolves.toMatchObject({ reqId, ok: true })
+  })
+})

--- a/src/shared/plugin/ui-bridge-client.test.ts
+++ b/src/shared/plugin/ui-bridge-client.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createUiBridge, isReactNativeSubstrate } from './ui-bridge-client'
+
+function fakeWindow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const listeners: Record<string, ((e: { data: unknown }) => void)[]> = {}
+  return {
+    addEventListener: (type: string, cb: (e: { data: unknown }) => void) => {
+      ;(listeners[type] ??= []).push(cb)
+    },
+    removeEventListener: (type: string, cb: (e: { data: unknown }) => void) => {
+      listeners[type] = (listeners[type] ?? []).filter((l) => l !== cb)
+    },
+    // test helper to emit a message
+    __emit: (data: unknown) => (listeners.message ?? []).forEach((l) => l({ data })),
+    ...overrides
+  }
+}
+
+describe('ui-bridge-client substrate detection', () => {
+  it('detects the react-native-webview substrate', () => {
+    expect(isReactNativeSubstrate({ ReactNativeWebView: { postMessage: () => {} } })).toBe(true)
+    expect(isReactNativeSubstrate({})).toBe(false)
+  })
+
+  it('mobile: posts JSON via ReactNativeWebView and parses JSON on receive', () => {
+    const rnPost = vi.fn()
+    const win = fakeWindow({ ReactNativeWebView: { postMessage: rnPost } })
+    const bridge = createUiBridge(win)
+
+    bridge.postMessage({ hello: 'world' })
+    expect(rnPost).toHaveBeenCalledWith(JSON.stringify({ hello: 'world' }))
+
+    const received: unknown[] = []
+    bridge.onMessage((m) => received.push(m))
+    ;(win.__emit as (d: unknown) => void)(JSON.stringify({ from: 'host' }))
+    expect(received).toEqual([{ from: 'host' }])
+  })
+
+  it('desktop: posts structured data to the embedder and receives structured data', () => {
+    const parentPost = vi.fn()
+    const win = fakeWindow({ parent: { postMessage: parentPost } })
+    const bridge = createUiBridge(win)
+
+    bridge.postMessage({ hello: 'world' })
+    expect(parentPost).toHaveBeenCalledWith({ hello: 'world' }, '*')
+
+    const received: unknown[] = []
+    bridge.onMessage((m) => received.push(m))
+    ;(win.__emit as (d: unknown) => void)({ from: 'host' })
+    expect(received).toEqual([{ from: 'host' }])
+  })
+
+  it('onMessage returns an unsubscribe that stops delivery', () => {
+    const win = fakeWindow({ parent: { postMessage: vi.fn() } })
+    const bridge = createUiBridge(win)
+    const received: unknown[] = []
+    const off = bridge.onMessage((m) => received.push(m))
+    off()
+    ;(win.__emit as (d: unknown) => void)({ x: 1 })
+    expect(received).toEqual([])
+  })
+})

--- a/src/shared/plugin/ui-bridge-client.test.ts
+++ b/src/shared/plugin/ui-bridge-client.test.ts
@@ -12,6 +12,8 @@ function fakeWindow(overrides: Record<string, unknown> = {}): Record<string, unk
     },
     // test helper to emit a message
     __emit: (data: unknown) => (listeners.message ?? []).forEach((l) => l({ data })),
+    // test helper: how many 'message' listeners are currently registered
+    __listenerCount: () => (listeners.message ?? []).length,
     ...overrides
   }
 }
@@ -93,24 +95,26 @@ describe('ui-bridge-client request()', () => {
     }
   })
 
-  it('rejects after the timeout and removes its listener (no leak)', async () => {
+  it('rejects after the timeout and actually removes its message listener (no leak)', async () => {
     vi.useFakeTimers()
     try {
-      const removeSpy = vi.fn()
       const post = vi.fn()
-      const win = fakeWindow({ parent: { postMessage: post }, removeEventListener: removeSpy })
+      const win = fakeWindow({ parent: { postMessage: post } })
       const bridge = createUiBridge(win)
       const rejected = bridge.request({ method: 'x' }, { timeoutMs: 500 }).catch((e: Error) => e)
+      expect((win.__listenerCount as () => number)()).toBe(1)
       vi.advanceTimersByTime(500)
       expect(await rejected).toBeInstanceOf(Error)
-      expect(removeSpy).toHaveBeenCalled()
+      // The listener is genuinely unregistered, not merely neutralized by a flag.
+      expect((win.__listenerCount as () => number)()).toBe(0)
     } finally {
       vi.useRealTimers()
     }
   })
 
-  it('clears the timeout on resolve so no late rejection fires', async () => {
+  it('clears the timeout on resolve so the timer callback never fires reject', async () => {
     vi.useFakeTimers()
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
     try {
       const post = vi.fn()
       const win = fakeWindow({ parent: { postMessage: post } })
@@ -118,9 +122,13 @@ describe('ui-bridge-client request()', () => {
       const promise = bridge.request({ method: 'x' }, { timeoutMs: 1000 })
       ;(win.__emit as (d: unknown) => void)({ reqId: postedReqId(post), ok: true })
       await expect(promise).resolves.toMatchObject({ ok: true })
-      // Advancing past the timeout must not throw an unhandled late rejection.
+      // The resolve path cleared the timer (not just relied on the settled guard),
+      // and the listener was removed.
+      expect(clearSpy).toHaveBeenCalled()
+      expect((win.__listenerCount as () => number)()).toBe(0)
       vi.advanceTimersByTime(2000)
     } finally {
+      clearSpy.mockRestore()
       vi.useRealTimers()
     }
   })

--- a/src/shared/plugin/ui-bridge-client.ts
+++ b/src/shared/plugin/ui-bridge-client.ts
@@ -72,19 +72,10 @@ export function createUiBridge(win: ReactNativeWebViewWindow): UiBridge {
     const reqId = `ui-${++reqCounter}`
     const timeoutMs = options?.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     return new Promise<unknown>((resolve, reject) => {
+      // Declare finish before off/timer so neither callback can reference it in a
+      // temporal dead zone even if a substrate ever delivers a message synchronously.
       let settled = false
-      const off = onMessage((incoming) => {
-        if (
-          typeof incoming === 'object' &&
-          incoming !== null &&
-          (incoming as { reqId?: unknown }).reqId === reqId
-        ) {
-          finish(() => resolve(incoming))
-        }
-      })
-      const timer = setTimeout(() => {
-        finish(() => reject(new Error(`plugin bridge request '${reqId}' timed out`)))
-      }, timeoutMs)
+      let timer: ReturnType<typeof setTimeout>
       const finish = (settle: () => void): void => {
         if (settled) {
           return
@@ -94,6 +85,18 @@ export function createUiBridge(win: ReactNativeWebViewWindow): UiBridge {
         off()
         settle()
       }
+      const off = onMessage((incoming) => {
+        if (
+          typeof incoming === 'object' &&
+          incoming !== null &&
+          (incoming as { reqId?: unknown }).reqId === reqId
+        ) {
+          finish(() => resolve(incoming))
+        }
+      })
+      timer = setTimeout(() => {
+        finish(() => reject(new Error(`plugin bridge request '${reqId}' timed out`)))
+      }, timeoutMs)
       postMessage({ ...message, reqId })
     })
   }

--- a/src/shared/plugin/ui-bridge-client.ts
+++ b/src/shared/plugin/ui-bridge-client.ts
@@ -15,7 +15,15 @@
 export type UiBridge = {
   postMessage(message: unknown): void
   onMessage(handler: (message: unknown) => void): () => void
+  // Correlated request/response: stamps a reqId, resolves on the matching
+  // response, and rejects after timeoutMs so a dropped connection can't leave a
+  // pending call hanging forever. Built on postMessage/onMessage.
+  request(message: object, options?: { timeoutMs?: number }): Promise<unknown>
 }
+
+// Default ceiling for a bridge round-trip; mirrors the mobile rpc-client request
+// timeout so a stalled relay surfaces as a rejection in a comparable window.
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 
 type ReactNativeWebViewWindow = {
   ReactNativeWebView?: { postMessage(data: string): void }
@@ -59,5 +67,36 @@ export function createUiBridge(win: ReactNativeWebViewWindow): UiBridge {
     return () => win.removeEventListener?.('message', listener)
   }
 
-  return { postMessage, onMessage }
+  let reqCounter = 0
+  const request = (message: object, options?: { timeoutMs?: number }): Promise<unknown> => {
+    const reqId = `ui-${++reqCounter}`
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+    return new Promise<unknown>((resolve, reject) => {
+      let settled = false
+      const off = onMessage((incoming) => {
+        if (
+          typeof incoming === 'object' &&
+          incoming !== null &&
+          (incoming as { reqId?: unknown }).reqId === reqId
+        ) {
+          finish(() => resolve(incoming))
+        }
+      })
+      const timer = setTimeout(() => {
+        finish(() => reject(new Error(`plugin bridge request '${reqId}' timed out`)))
+      }, timeoutMs)
+      const finish = (settle: () => void): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        clearTimeout(timer)
+        off()
+        settle()
+      }
+      postMessage({ ...message, reqId })
+    })
+  }
+
+  return { postMessage, onMessage, request }
 }

--- a/src/shared/plugin/ui-bridge-client.ts
+++ b/src/shared/plugin/ui-bridge-client.ts
@@ -1,0 +1,63 @@
+// The client a plugin's UI bundle uses to talk to its backend. Detects the host
+// substrate so one UI bundle works on both desktop and mobile:
+//   - mobile (react-native-webview): window.ReactNativeWebView.postMessage +
+//     'message' events carrying JSON strings.
+//   - desktop (Electron <webview>/iframe): window.parent.postMessage + 'message'
+//     events carrying structured data.
+// Authors vendor this file (or import the published SDK). It is messaging-only
+// (matching context.ui's generic post/subscribe); request/response is the
+// author's convention on top.
+//
+// NEEDS-RUNTIME-VERIFY: the exact desktop post target (guest <webview> ->
+// renderer) is confirmed when the renderer panel wiring lands and the app runs.
+// Substrate detection and the mobile path are unit-tested here.
+
+export type UiBridge = {
+  postMessage(message: unknown): void
+  onMessage(handler: (message: unknown) => void): () => void
+}
+
+type ReactNativeWebViewWindow = {
+  ReactNativeWebView?: { postMessage(data: string): void }
+  parent?: { postMessage(data: unknown, targetOrigin: string): void }
+  postMessage?(data: unknown, targetOrigin: string): void
+  addEventListener?(type: string, listener: (event: { data: unknown }) => void): void
+  removeEventListener?(type: string, listener: (event: { data: unknown }) => void): void
+}
+
+export function isReactNativeSubstrate(win: ReactNativeWebViewWindow): boolean {
+  return typeof win.ReactNativeWebView?.postMessage === 'function'
+}
+
+export function createUiBridge(win: ReactNativeWebViewWindow): UiBridge {
+  const reactNative = isReactNativeSubstrate(win)
+
+  const postMessage = (message: unknown): void => {
+    if (reactNative) {
+      win.ReactNativeWebView!.postMessage(JSON.stringify(message))
+      return
+    }
+    // Desktop: post up to the embedder. NEEDS-RUNTIME-VERIFY target.
+    const target = win.parent ?? win
+    target.postMessage?.(message, '*')
+  }
+
+  const onMessage = (handler: (message: unknown) => void): (() => void) => {
+    const listener = (event: { data: unknown }): void => {
+      // RN delivers JSON strings; desktop delivers structured data.
+      if (reactNative && typeof event.data === 'string') {
+        try {
+          handler(JSON.parse(event.data))
+        } catch {
+          handler(event.data)
+        }
+      } else {
+        handler(event.data)
+      }
+    }
+    win.addEventListener?.('message', listener)
+    return () => win.removeEventListener?.('message', listener)
+  }
+
+  return { postMessage, onMessage }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2995,6 +2995,11 @@ export type RightSidebarTab =
   | 'source-control'
   | 'checks'
   | 'ports'
+  // A plugin-contributed sidebar tab, keyed `plugin:<pluginId>`. Adding a plugin
+  // never edits this union — but the two runtime validators
+  // (right-sidebar-route.ts and worktrees.ts pruneRightSidebarTabByWorktree)
+  // must each accept the `plugin:` prefix or plugin routing is silently dropped.
+  | `plugin:${string}`
 export type ActiveRightSidebarTab = Exclude<RightSidebarTab, 'search'>
 export type RightSidebarExplorerView = 'files' | 'search'
 


### PR DESCRIPTION
> **Draft.** Plugin system for Orca (VS Code-style): trusted Node backend per plugin + sandboxed webview UI, right-sidebar panel + Settings management, npm/git/tarball/local install. Plan: stablyai/orca#5738.

## Status

**Desktop: complete end-to-end and build-green** (lint incl. localization, node + web typecheck, ~141 tests). **Mobile/relay (v1c) + runtime verification remain.**

Flow: **Settings → Plugins** → install (npm name / git / tarball / local path) → activate → the plugin **spawns a trusted Node child-process backend**, gets a **right-sidebar tab**, and the tab **renders its sandboxed `orca-plugin://` webview**.

### Landed (build-green)
- **Host engine** — manifest+validation+id-safety, capability gate + consent, settings store + JSON-schema validator, supervision (crash/backoff), output ring buffer, **trusted child-process runtime** (real forked-child crash-isolation integration test), capability-gated host handler, `orca-plugin://` asset protocol, runtime orchestrator. *Unit/integration-tested.*
- **Main wiring** — composition root, IPC, `window.api.plugins` preload, boot (scheme pre-ready + system + protocol + handlers + build entry + asar-unpack).
- **Renderer** — `plugin:` routing seam (+ both validators), activity-bar tab for active plugins, `PluginPanel` webview, webview attach-gate hardening, **Settings → Plugins pane** (registered in nav).
- **Installer** — source parsing + integrity/lockfile + orchestration + real adapters (node:https + system git/tar, **no new deps**), wired to the Settings UI.
- **SDK + example plugin (`examples/hello-sidebar-plugin`) + authoring/security docs.**
- 8-persona code review run; all findings fixed (incl. a localization regression caught mid-build).

### `NEEDS-RUNTIME-VERIFY`
All renderer/Electron runtime behavior (webview attach, scheme serving, fork, the no-preload guest bridge) compiles + lints + typechecks but is **proven only by launching the app**. To verify: launch `orca-dev` (full quit+reopen), Settings → Plugins, install `examples/hello-sidebar-plugin`, activate, confirm the tab + panel.

### v1c relay + mobile integration (landed, build-green)
- **Relay** — `registerRelayPluginHandlers` now wired into the live `RelayDispatcher` (`src/relay/relay.ts`); plugins resolve under `$HOME/.orca-relay/plugins`; workspace snapshot defaults to a bounded-empty value (no live root on the relay). Electron-free; relay bundle builds for all 6 targets. `plugin.*` error branches covered by tests.
- **Mobile** — installed plugins surface as a session **Plugins** pane (activity-bar button + dock + narrow-layout route); list → open → `MobilePluginPanel`. Pure list-parsing + panel-routing logic unit-tested. JSX/navigation wiring is `NEEDS-RUNTIME-VERIFY` (Expo build can't run in CI env — `expo` deps absent).

### Remaining
- **Relay-host trusted backend child** + device round-trip for `commands`/`settings` bridge methods (relay denies them cleanly today) — the remote-provisioning tier.
- **Transitive npm dep resolution** for plugins (v1 targets self-contained bundles).
- **Runtime verification** of the desktop flow + on-device mobile pass (Expo).

> The plan doc lives under `docs/` (gitignored) — see PR #5738.

---

## Relay-host backend runtime (landed, build-green)

The trusted per-plugin backend child now runs **on the relay host**, reusing the electron-free `PluginManager` + `PluginRuntime` + `PluginHost` stack (plain-node fork, no `ELECTRON_RUN_AS_NODE`). `plugin.bridge` was replaced by the real async message-passing model: `plugin.activate`/`deactivate`/`postUi` drive the child, and child responses are pushed back to **only the originating client** as `plugin.uiMessage` notifications (reqId-correlated by the in-webview `ui-bridge-client`). `settings.*` and `workspace.getSnapshot` are now served by the real backend; `commands.invokeHost` stays denied (device round-trip deferred). `pluginId` is validated (`isSafePluginId` + installed-manifest match) at every entry. Relay bundle builds electron-free for all targets.

## Residual Review Findings

The backend-tier review **fixed** the P1 cross-client broadcast leak (per-client routing), the orphaned-children-on-exit bug (synchronous `terminate()`), and the mobile activate-error/deactivate-on-unmount gaps.

A follow-up **residual-hardening pass** (`fix(plugin): harden deferred relay-plugin review residuals` + `fix(review): apply autofix feedback (residual hardening)`) then **resolved** three of the previously-deferred items:
- ✅ **startSocketServer cleanup** — `exitWithCleanup` now runs on the socket-server failure path, `uncaughtException`, `shutdown`, and the module-level `main().catch`, so plugin children aren't orphaned on any post-registration exit.
- ✅ **bridge reqId hang** — the in-webview `ui-bridge-client` gained a correlated `request()` with a bounded (30s default) timeout that rejects + cleans up instead of hanging.
- ✅ **multi-client deactivate** — subscribers are refcounted; the shared backend child stops only when its last subscriber leaves (via `plugin.deactivate` or client detach).

The reviewers found **no production bugs** in the hardening pass (correctness traced clean; the rest were test-strength + clarity, applied as autofixes). Remaining intentionally-deferred items:

- **P2 · maintainability · `mobile/src/transport/rpc-client.ts`** — pre-existing >1k-line monolith; a larger decomposition (terminal-stream / browser-screencast blocks) is the real fix.
- **P3 · perf · `src/relay/plugin-handler.ts`** — `discoverPlugins` re-scans the plugins dir per request; cache with explicit invalidation (deferred to avoid a staleness regression).
- **P3 · correctness · `src/relay/plugin-handler.ts`** — a `postUi` racing a concurrent `activate` on a cold child can drop the first message before the child registers its UI handler (narrow; the awaited path is safe).
- **P3 · clarity · `src/relay/plugin-handler.ts`** — `releasePlugin`'s undefined-`clientId` full-stop branch has no production caller (kept as a type-required defensive default for `context.clientId`); could tighten the signature if a force-stop entry point is never needed.
- **Info · `ui-bridge-client`** — a timed-out `request()` doesn't tell the relay to abort the in-flight `postUi` round-trip; the late response is harmlessly ignored. No relay-side resource accumulates.

### Remote provisioning (landed, build-green)

A **provisioning tier** (`feat(plugin): relay-host plugin provisioning` + `fix(review): apply autofix feedback (provisioning)`) closes the gating prerequisite — an installed plugin's files now reach the relay host:
- ✅ **bundle codec** — desktop packages a plugin dir into a file-list payload with sha256 integrity, a byte cap + file-count cap, and per-file path-safety (control chars rejected).
- ✅ **`plugin.provision`** — the relay verifies integrity + `isSafePluginId` + manifest-id match, stages to a temp dir, and swaps into `relayPluginsDir()/<id>` via a **backup-restore** that never destroys the prior install on a failed rename.
- ✅ **host-entry shipping** — the relay build emits `plugin-host-entry.js` next to `relay.js`; `relayPluginHostEntryPath()` resolves bundle-relative, so only plugin files transfer.
- ✅ **desktop package + send** — `readPluginBundleFromDisk` (symlink/traversal-guarded) + `provisionToRelay`; a package↔unpack round-trip test proves the contract without a live relay.

A 6-reviewer security pass (correctness/security/adversarial/reliability/testing/maintainability) found **no surviving exploitable write-outside-dir or integrity bypass**; the two HIGH findings it surfaced (destructive replace, staging-throw) were fixed in the autofix commit. Remaining provisioning residuals:

- **P3 · reliability · `src/relay/plugin-provision.ts`** — a brand-new install across a cross-volume `pluginsDir`/staging boundary (EXDEV) fails safely (prior preserved) but without a copy-fallback; only relevant under non-default mount config.
- **P3 · perf · `src/relay/plugin-provision.ts`** — provisioning is synchronous fs (bounded by the 4 MB cap); a worker/stream is deferred.
- **P3 · validation · `src/shared/plugin/manifest.ts`** — `isSafePluginId` accepts trailing-dot / mixed-case ids that could collide on case-insensitive filesystems; pre-existing id-rule hardening, tracked separately.

### Desktop→relay activate path (landed, build-green)

An **activate-path tier** (`feat(plugin): desktop→relay activate path` + `fix(review): apply autofix feedback (activate path)`) adds the pure, unit-tested coordinator that sequences provision-then-remote-activate vs local activate:
- ✅ **coordinator** — `activatePluginForWorkspace({pluginId, remote}, deps)`: `shouldProvisionToRelay(remote)` false → local `runtime.activate` (behavior unchanged); true → `readPluginBundleFromDisk` → `provisionToRelay` → on success `plugin.activate` over the injected relay request fn. Every throw/reject becomes a typed `{ok:false,error}`; a provision failure aborts before activate.
- ✅ **system seam** — `PluginSystem.activateForWorkspace(pluginId, remote?)`; the `plugins:activate` IPC routes through it (local default). `resolveRelayRequest` defaults to a rejects-on-call fn so the remote path is explicit, never a silent no-op.
- ✅ **autofix review** — a 6-reviewer pass (correctness/adversarial/testing/reliability/maintainability/project-standards) found no production bug on the local path. Fixed in the autofix commit: a **pluginId traversal guard** (`isSafePluginId` runs before any disk read or relay call, so the remote bundle-packaging sink can't harvest bytes outside the plugin dir), result-type consolidation onto `ActivateResult` (no drift), lazy relay-request resolution (a future SSH-opening resolver never runs on a local activation), and the no-cleanup-on-partial-commit contract is now documented in-code.

Remaining activate-path residuals (intentionally deferred):
- **P1 · reliability · `RelayRequest` contract** — no per-request timeout; a stuck relay makes provision/activate await indefinitely. Needs a deadline at the transport-contract level (or a `Promise.race` wrapper yielding `provision_timeout`/`activate_timeout`). Deferred with the live-transport wiring.
- **P2 · reliability/adversarial · `plugin-activation-coordinator.ts`** — provision-succeeds-but-activate-fails leaves the relay provisioned-but-inactive with no compensating `plugin.deactivate`; safe for v1a (re-provision is idempotent) and documented in-code. A `deprovision` path + a distinct `activate_failed_provisioned` code is the real fix.
- **P3 · adversarial · `plugin-activation-coordinator.ts`** — concurrent `activateForWorkspace` for the same id can race the relay's non-atomic bundle swap; needs a per-id in-flight coalescing map and/or relay-side serialization (requires runtime verification).
- **P3 · reliability · transfer** — a ~5.3 MB base64 bundle ships in one synchronous frame; chunked transfer is v1c.
- **P2 · maintainability** — `RemoteDescriptor` is a single optional boolean today; it will need richer relay-addressing fields when the production resolver lands, and `normalizeRelayResponse` could be extracted to dedupe the relay-result guard.

### Activation failure-mode hardening (landed, build-green)

A **hardening tier** (`fix(plugin): harden activation coordinator remote-path failure modes` + `fix(review): apply autofix feedback (coordinator hardening)`) closes the deferred residuals from the activate-path review:
- ✅ **per-request timeout** — each remote relay call (provision + activate) races an injected delay (default 20s, unref'd); expiry yields a typed `provision_timeout` / `activate_timeout` instead of an indefinite hang.
- ✅ **compensating deactivate** — when provision succeeds but activate fails by any means (reject / `ok:false` / `no_response` / timeout), a best-effort, **deadline-bounded** `plugin.deactivate` reclaims a forked-but-unacknowledged backend; its outcome is swallowed so it never masks or outlasts the original error.
- ✅ **concurrent-activation coalescing** — a pure `coalesceByKey` + a per-`tier:pluginId` in-flight `Map` on `PluginSystem` so concurrent same-id activations share one activation (and a local vs remote activation of the same plugin don't coalesce into each other).

A 6-reviewer pass (correctness/adversarial/testing/reliability/maintainability/project-standards) found **no shipped bug**; the autofix commit then fixed the one real issue all reviewers converged on — the compensating deactivate was originally un-timed and could re-introduce the very hang the timeout removed — by bounding it with the same `raceWithTimeout`, plus a type-guarded activate response and a tier-keyed coalesce map. Remaining hardening residuals (intentionally deferred):

- **P2 · reliability/adversarial · local path** — `runtime.activate` (in-process) is not deadline-bounded, so a hung plugin-host fork can wedge the local coalesce entry. The remote path is now bounded by the timeout; a local-path timeout is a behavior change deferred until the fork-hang risk is verified.
- **P2 · adversarial · `plugin-activation-coordinator.ts`** — a `provisionToRelay` that resolves *after* its timeout may have committed a bundle on the relay that is never activated or reclaimed (orphan window); best addressed by relay-side GC of unacknowledged provisions.
- **P3 · reliability — accepted** — the losing `raceWithTimeout` timer is unref'd (no process-lifetime leak) but not cancelled, leaving a ≤20s handle tail per call; a cancel-token on the injected delay would remove it.
- **Note (won't-fix) ·** the lazy per-call `resolveRelayRequest` wrapper is **intentional** — it defers session resolution to the remote path so a future SSH-opening resolver never runs on a local activation; "resolve once" was declined for that reason.

### Relay discovery cache (landed, build-green)

A **perf tier** (`perf(relay): cache plugin discovery with provision-scoped invalidation` + `fix(review): apply autofix feedback (discovery cache)`) resolves the deferred `discoverPlugins`-per-request residual:
- ✅ **closure-held memoization** — `registerRelayPluginHandlers` caches the discovery scan; back-to-back `plugin.list`/`getEntry`/`activate`/`postUi` requests scan once instead of re-reading + re-validating every manifest per call.
- ✅ **provision-scoped invalidation** — the cache is dropped only on a **successful** `plugin.provision` (the sole relay-side mutation of the installed set), so a freshly-provisioned plugin is immediately discoverable (never a stale `unknown_plugin`); a failed provision keeps the cache. `provisionPlugin` is synchronous, so invalidation runs the same turn as the disk swap — no interleave.
- ✅ **getEntry boundary hardening** (review autofix) — `plugin.getEntry` now runs the `isSafePluginId` gate first (matching `activate`/`postUi`) and returns `entry_read_failed` on an `existsSync`→`readFileSync` I/O race instead of leaking a raw fs error.

A 6-reviewer pass (correctness/adversarial/testing/reliability/maintainability/project-standards) confirmed the cache-coherency core is sound (synchronous provision + same-turn invalidate; no interleave; `isSafePluginId` not bypassable via the cache; provision is the only pluginsDir mutation path). Remaining hardening residuals (intentionally deferred — independent of the cache):

- **P2 · adversarial · `src/relay/plugin-handler.ts`** — re-provisioning an already-running plugin invalidates the cache but leaves the old backend child forked from the old dir (new UI ↔ old backend until a crash-restart). Fix: have `plugin.provision` also `await runtime.deactivate(pluginId)` so the next activate rebuilds — a behavior change needing runtime verification.
- **P2 · adversarial · `src/relay/plugin-provision.ts`** — the `commitStaged` `.bak-*` backup dir is written **inside** `pluginsDir`; an interrupted cleanup leaves a backup that discovery re-scans as a second valid plugin with the same `manifest.id`. Fix: put the backup outside `pluginsDir`, or de-dup discovery by `manifest.id`. (Pre-existing provisioning code.)
- **P3 · adversarial · provisioning** — a custom `stagingDir` resolving inside `pluginsDir` would surface partial bundles as discovered plugins; the default sibling path is safe but the invariant is unenforced.
- **P3 · project-standards · `src/relay/plugin-handler.ts`** — the pre-existing 14-line file header + a couple of handler comments narrate mechanism beyond the AGENTS.md "why, briefly" limit; a trim is deferred to avoid unrelated churn in a perf PR.

**Still deferred (the hardest tier):** the live SSH transfer + real remote fork, the production host-context threading + relay-request resolver from `SshRelaySession` into `plugins:activate` (the coordinator + seam now exist; the live wiring does not), `commands.invokeHost` device round-trip, and full runtime verification (desktop launch + on-device mobile/Expo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

Foundation for a VS Code-style plugin system: install plugins, run a trusted backend, sandbox UI, and manage them in Settings. Desktop end-to-end base; mobile pieces later.
