### PR TITLE
fix(store): cap prRefreshStates the same way prRefreshSequences is capped

### DIFF
--- a/src/renderer/src/store/slices/github-pr-refresh-states-leak.test.ts
+++ b/src/renderer/src/store/slices/github-pr-refresh-states-leak.test.ts
@@ -1,14 +1,17 @@
 /**
  * Memory-leak regression: prRefreshStates must stay bounded.
  *
- * `prRefreshStates` is a Record keyed by PR cache key (repo/branch/execution
- * host) — the SAME unbounded, ephemeral key space the sibling `prRefreshSequences`
- * is already capped against. `applyGitHubPRRefreshEvent` writes a status entry on
- * every status-only refresh event (paused/skipped/in-flight) and re-adds an entry
- * for upstream-error outcomes, but no prune path ever removes them, so the map grew
+ * `prRefreshStates` is a Record keyed by PR cache key (repo/branch/execution host)
+ * — the SAME unbounded, ephemeral key space the sibling `prRefreshSequences` is
+ * already capped against. `applyGitHubPRRefreshEvent` writes a status entry on every
+ * status-only refresh event (paused/skipped/in-flight) and re-adds one for
+ * upstream-error outcomes, but no prune path ever removed them, so the map grew
  * monotonically with the number of distinct (host, repo, branch) tuples observed.
- * The fix caps it to MAX_CACHE_ENTRIES by insertion order (the writer moves each
- * touched key to the most-recent position), exactly like prRefreshSequences.
+ *
+ * The fix bounds it to MAX_PR_REFRESH_STATE_ENTRIES, but because this map backs
+ * visible status pills it uses status-aware eviction: settled statuses (error/
+ * skipped) are evicted first so an in-progress (in-flight/queued/paused) indicator
+ * is never dropped except as a last-resort hard bound.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { create } from 'zustand'
@@ -17,11 +20,24 @@ import { createHostedReviewSlice } from './hosted-review'
 import type { AppState } from '../types'
 import type { GitHubPRRefreshEvent, GitHubPRRefreshReason } from '../../../../shared/types'
 
-// MAX_CACHE_ENTRIES is module-private; mirror its value here.
-const MAX_CACHE_ENTRIES = 500
+// MAX_PR_REFRESH_STATE_ENTRIES is module-private; mirror its value here.
+const MAX_ENTRIES = 2000
 
-// A prRefreshStates entry shape (the module's PRRefreshState type is not exported).
-type SeededRefreshState = { status: 'in-flight'; reason: GitHubPRRefreshReason; updatedAt: number }
+// prRefreshStates entry shapes (the module's PRRefreshState type is not exported).
+type SeedState = {
+  status: 'in-flight' | 'error'
+  reason: GitHubPRRefreshReason
+  updatedAt: number
+  message?: string
+}
+
+function inFlightState(): SeedState {
+  return { status: 'in-flight', reason: 'visible', updatedAt: 0 }
+}
+
+function errorState(): SeedState {
+  return { status: 'error', reason: 'visible', updatedAt: 0, message: 'boom' }
+}
 
 const mockApi = {
   gh: {
@@ -71,39 +87,40 @@ describe('prRefreshStates stays bounded (leak regression)', () => {
     const store = createTestStore()
 
     // Each distinct branch produces a distinct cache key — an unbounded key space.
-    const total = MAX_CACHE_ENTRIES + 150
+    const total = MAX_ENTRIES + 150
     for (let i = 0; i < total; i++) {
       store.getState().applyGitHubPRRefreshEvent(statusEvent(`branch-${i}`, 1))
     }
 
     const states = store.getState().prRefreshStates
     // Bounded — not `total`.
-    expect(Object.keys(states)).toHaveLength(MAX_CACHE_ENTRIES)
-    // The most-recently-written key survives.
+    expect(Object.keys(states)).toHaveLength(MAX_ENTRIES)
+    // The most-recently-written key survives; the oldest is evicted.
     expect(states[`branch-${total - 1}`]).toBeDefined()
-    // The oldest key has been evicted.
     expect(states['branch-0']).toBeUndefined()
   })
 
-  it('caps prRefreshStates and keeps the most recently touched key', () => {
+  it('evicts settled (error/skipped) statuses before active ones', () => {
     const store = createTestStore()
 
-    // Seed more state entries than the cap allows.
-    const seeded: Record<string, SeededRefreshState> = {}
-    const seedCount = MAX_CACHE_ENTRIES + 100
-    for (let i = 0; i < seedCount; i++) {
-      seeded[`seed-${i}`] = { status: 'in-flight', reason: 'visible', updatedAt: 0 }
+    // Oldest entry is a settled error; the rest are active in-flight refreshes,
+    // filling the map exactly to the cap.
+    const seeded: Record<string, SeedState> = { 'stale-error': errorState() }
+    for (let i = 0; i < MAX_ENTRIES - 1; i++) {
+      seeded[`active-${i}`] = inFlightState()
     }
     store.setState({ prRefreshStates: seeded })
 
-    // One more status event for a brand-new PR cache key pushes over the cap.
-    store.getState().applyGitHubPRRefreshEvent(statusEvent('key-new', 1))
+    // One more active refresh pushes over the cap by one.
+    store.getState().applyGitHubPRRefreshEvent(statusEvent('fresh', 1))
 
     const states = store.getState().prRefreshStates
-    expect(Object.keys(states)).toHaveLength(MAX_CACHE_ENTRIES)
-    // The just-touched key survives; the oldest seeded key is evicted.
-    expect(states['key-new']).toBeDefined()
-    expect(states['seed-0']).toBeUndefined()
+    expect(Object.keys(states)).toHaveLength(MAX_ENTRIES)
+    // The settled error is evicted first; every active entry survives.
+    expect(states['stale-error']).toBeUndefined()
+    expect(states['fresh']).toBeDefined()
+    expect(states['active-0']).toBeDefined()
+    expect(states['active-500']).toBeDefined()
   })
 
   it('does not evict anything while under the cap', () => {
@@ -115,22 +132,22 @@ describe('prRefreshStates stays bounded (leak regression)', () => {
 
   it('keeps a refreshed older key by moving it to most-recent before capping', () => {
     const store = createTestStore()
-    const seeded: Record<string, SeededRefreshState> = {}
-    const seedCount = MAX_CACHE_ENTRIES + 100
-    for (let i = 0; i < seedCount; i++) {
-      seeded[`seed-${i}`] = { status: 'in-flight', reason: 'visible', updatedAt: 0 }
+    // Fill exactly to the cap with active entries (no settled ones to evict first).
+    const seeded: Record<string, SeedState> = {}
+    for (let i = 0; i < MAX_ENTRIES; i++) {
+      seeded[`seed-${i}`] = inFlightState()
     }
     store.setState({ prRefreshStates: seeded })
 
-    // Refresh the OLDEST key. The writer moves it to most-recent (delete+set),
-    // so capping must evict the next-oldest keys, not this freshly-touched one.
+    // Refresh the OLDEST key (move-to-end), then add a brand-new key to force a
+    // last-resort eviction: the just-refreshed key must survive, the next-oldest not.
     store.getState().applyGitHubPRRefreshEvent(statusEvent('seed-0', 9))
+    store.getState().applyGitHubPRRefreshEvent(statusEvent('newcomer', 1))
 
     const states = store.getState().prRefreshStates
-    expect(Object.keys(states)).toHaveLength(MAX_CACHE_ENTRIES)
-    // Survives — without move-to-end it would be evicted.
+    expect(Object.keys(states)).toHaveLength(MAX_ENTRIES)
     expect(states['seed-0']).toBeDefined()
-    // The next-oldest key is the one evicted instead.
     expect(states['seed-1']).toBeUndefined()
+    expect(states['newcomer']).toBeDefined()
   })
 })

--- a/src/renderer/src/store/slices/github-pr-refresh-states-leak.test.ts
+++ b/src/renderer/src/store/slices/github-pr-refresh-states-leak.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Memory-leak regression: prRefreshStates must stay bounded.
+ *
+ * `prRefreshStates` is a Record keyed by PR cache key (repo/branch/execution
+ * host) — the SAME unbounded, ephemeral key space the sibling `prRefreshSequences`
+ * is already capped against. `applyGitHubPRRefreshEvent` writes a status entry on
+ * every status-only refresh event (paused/skipped/in-flight) and re-adds an entry
+ * for upstream-error outcomes, but no prune path ever removes them, so the map grew
+ * monotonically with the number of distinct (host, repo, branch) tuples observed.
+ * The fix caps it to MAX_CACHE_ENTRIES by insertion order (the writer moves each
+ * touched key to the most-recent position), exactly like prRefreshSequences.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { create } from 'zustand'
+import { createGitHubSlice } from './github'
+import { createHostedReviewSlice } from './hosted-review'
+import type { AppState } from '../types'
+
+// MAX_CACHE_ENTRIES is module-private; mirror its value here.
+const MAX_CACHE_ENTRIES = 500
+
+const mockApi = {
+  gh: {
+    prForBranch: vi.fn().mockResolvedValue(null),
+    refreshPRNow: vi.fn(),
+    enqueuePRRefresh: vi.fn().mockResolvedValue(undefined),
+    issue: vi.fn().mockResolvedValue(null),
+    prChecks: vi.fn().mockResolvedValue([])
+  },
+  hostedReview: { forBranch: vi.fn().mockResolvedValue(null) },
+  runtimeEnvironments: { call: vi.fn() },
+  cache: {
+    getGitHub: vi.fn().mockResolvedValue(null),
+    setGitHub: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+// @ts-expect-error -- minimal window.api stub for the slice under test
+globalThis.window = { api: mockApi }
+
+function createTestStore() {
+  return create<AppState>()(
+    (...a) =>
+      ({
+        ...createGitHubSlice(...a),
+        ...createHostedReviewSlice(...a)
+      }) as AppState
+  )
+}
+
+// A status-only refresh event (no outcome) lands in the prRefreshStates writer.
+function statusEvent(cacheKey: string, sequence: number) {
+  return {
+    sequence,
+    reason: 'visible' as const,
+    status: 'paused' as const,
+    aliases: [{ cacheKey, repoPath: `/repo/${cacheKey}`, branch: cacheKey }]
+  }
+}
+
+describe('prRefreshStates stays bounded (leak regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('caps prRefreshStates when driven past the cap by the real writer', () => {
+    const store = createTestStore()
+
+    // Each distinct branch produces a distinct cache key — an unbounded key space.
+    const total = MAX_CACHE_ENTRIES + 150
+    for (let i = 0; i < total; i++) {
+      store.getState().applyGitHubPRRefreshEvent(statusEvent(`branch-${i}`, 1))
+    }
+
+    const states = store.getState().prRefreshStates
+    // Bounded — not `total`.
+    expect(Object.keys(states)).toHaveLength(MAX_CACHE_ENTRIES)
+    // The most-recently-written key survives.
+    expect(states[`branch-${total - 1}`]).toBeDefined()
+    // The oldest key has been evicted.
+    expect(states['branch-0']).toBeUndefined()
+  })
+
+  it('caps prRefreshStates and keeps the most recently touched key', () => {
+    const store = createTestStore()
+
+    // Seed more state entries than the cap allows.
+    const seeded: Record<string, { status: 'paused'; reason: string; updatedAt: number }> = {}
+    const seedCount = MAX_CACHE_ENTRIES + 100
+    for (let i = 0; i < seedCount; i++) {
+      seeded[`seed-${i}`] = { status: 'paused', reason: 'visible', updatedAt: 0 }
+    }
+    store.setState({ prRefreshStates: seeded })
+
+    // One more status event for a brand-new PR cache key pushes over the cap.
+    store.getState().applyGitHubPRRefreshEvent(statusEvent('key-new', 1))
+
+    const states = store.getState().prRefreshStates
+    expect(Object.keys(states)).toHaveLength(MAX_CACHE_ENTRIES)
+    // The just-touched key survives; the oldest seeded key is evicted.
+    expect(states['key-new']).toBeDefined()
+    expect(states['seed-0']).toBeUndefined()
+  })
+
+  it('does not evict anything while under the cap', () => {
+    const store = createTestStore()
+    store.getState().applyGitHubPRRefreshEvent(statusEvent('only-key', 3))
+    expect(store.getState().prRefreshStates['only-key']).toBeDefined()
+    expect(store.getState().prRefreshStates['only-key']?.status).toBe('paused')
+  })
+
+  it('keeps a refreshed older key by moving it to most-recent before capping', () => {
+    const store = createTestStore()
+    const seeded: Record<string, { status: 'paused'; reason: string; updatedAt: number }> = {}
+    const seedCount = MAX_CACHE_ENTRIES + 100
+    for (let i = 0; i < seedCount; i++) {
+      seeded[`seed-${i}`] = { status: 'paused', reason: 'visible', updatedAt: 0 }
+    }
+    store.setState({ prRefreshStates: seeded })
+
+    // Refresh the OLDEST key. The writer moves it to most-recent (delete+set),
+    // so capping must evict the next-oldest keys, not this freshly-touched one.
+    store.getState().applyGitHubPRRefreshEvent(statusEvent('seed-0', 9))
+
+    const states = store.getState().prRefreshStates
+    expect(Object.keys(states)).toHaveLength(MAX_CACHE_ENTRIES)
+    // Survives — without move-to-end it would be evicted.
+    expect(states['seed-0']).toBeDefined()
+    // The next-oldest key is the one evicted instead.
+    expect(states['seed-1']).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/github-pr-refresh-states-leak.test.ts
+++ b/src/renderer/src/store/slices/github-pr-refresh-states-leak.test.ts
@@ -15,9 +15,13 @@ import { create } from 'zustand'
 import { createGitHubSlice } from './github'
 import { createHostedReviewSlice } from './hosted-review'
 import type { AppState } from '../types'
+import type { GitHubPRRefreshEvent, GitHubPRRefreshReason } from '../../../../shared/types'
 
 // MAX_CACHE_ENTRIES is module-private; mirror its value here.
 const MAX_CACHE_ENTRIES = 500
+
+// A prRefreshStates entry shape (the module's PRRefreshState type is not exported).
+type SeededRefreshState = { status: 'in-flight'; reason: GitHubPRRefreshReason; updatedAt: number }
 
 const mockApi = {
   gh: {
@@ -49,11 +53,11 @@ function createTestStore() {
 }
 
 // A status-only refresh event (no outcome) lands in the prRefreshStates writer.
-function statusEvent(cacheKey: string, sequence: number) {
+function statusEvent(cacheKey: string, sequence: number): GitHubPRRefreshEvent {
   return {
     sequence,
-    reason: 'visible' as const,
-    status: 'paused' as const,
+    reason: 'visible',
+    status: 'in-flight',
     aliases: [{ cacheKey, repoPath: `/repo/${cacheKey}`, branch: cacheKey }]
   }
 }
@@ -85,10 +89,10 @@ describe('prRefreshStates stays bounded (leak regression)', () => {
     const store = createTestStore()
 
     // Seed more state entries than the cap allows.
-    const seeded: Record<string, { status: 'paused'; reason: string; updatedAt: number }> = {}
+    const seeded: Record<string, SeededRefreshState> = {}
     const seedCount = MAX_CACHE_ENTRIES + 100
     for (let i = 0; i < seedCount; i++) {
-      seeded[`seed-${i}`] = { status: 'paused', reason: 'visible', updatedAt: 0 }
+      seeded[`seed-${i}`] = { status: 'in-flight', reason: 'visible', updatedAt: 0 }
     }
     store.setState({ prRefreshStates: seeded })
 
@@ -106,15 +110,15 @@ describe('prRefreshStates stays bounded (leak regression)', () => {
     const store = createTestStore()
     store.getState().applyGitHubPRRefreshEvent(statusEvent('only-key', 3))
     expect(store.getState().prRefreshStates['only-key']).toBeDefined()
-    expect(store.getState().prRefreshStates['only-key']?.status).toBe('paused')
+    expect(store.getState().prRefreshStates['only-key']?.status).toBe('in-flight')
   })
 
   it('keeps a refreshed older key by moving it to most-recent before capping', () => {
     const store = createTestStore()
-    const seeded: Record<string, { status: 'paused'; reason: string; updatedAt: number }> = {}
+    const seeded: Record<string, SeededRefreshState> = {}
     const seedCount = MAX_CACHE_ENTRIES + 100
     for (let i = 0; i < seedCount; i++) {
-      seeded[`seed-${i}`] = { status: 'paused', reason: 'visible', updatedAt: 0 }
+      seeded[`seed-${i}`] = { status: 'in-flight', reason: 'visible', updatedAt: 0 }
     }
     store.setState({ prRefreshStates: seeded })
 

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1365,25 +1365,31 @@ function withBoundedCacheEntry<T extends { fetchedAt: number }>(
   return evictStaleEntries({ ...cache, [key]: entry })
 }
 
-// Why: prRefreshSequences only ever grows — one entry per PR cache key
-// (repo/branch/execution-host) ever observed, and branches are ephemeral and
-// unbounded over a long session. It has no `fetchedAt` to sort by, so bound it
-// by insertion order (oldest-touched keys evicted first; the writer moves each
-// touched key to the end). An evicted long-idle branch simply restarts sequence
-// comparison from 0, which is acceptable.
+// Why: the prRefresh* maps are keyed by PR cache key (repo/branch/execution-host)
+// — an ephemeral, unbounded key space over a long session. They have no
+// `fetchedAt` to sort by, so bound them by insertion order (oldest-touched keys
+// evicted first; the writers move each touched key to the end). An evicted
+// long-idle branch simply restarts from a clean state, which is acceptable.
+function capRecordByInsertionOrder<T>(
+  record: Record<string, T>,
+  maxEntries = MAX_CACHE_ENTRIES
+): Record<string, T> {
+  const keys = Object.keys(record)
+  if (keys.length <= maxEntries) {
+    return record
+  }
+  const capped: Record<string, T> = {}
+  for (const key of keys.slice(keys.length - maxEntries)) {
+    capped[key] = record[key]
+  }
+  return capped
+}
+
 function capPrRefreshSequences(
   sequences: Record<string, number>,
   maxEntries = MAX_CACHE_ENTRIES
 ): Record<string, number> {
-  const keys = Object.keys(sequences)
-  if (keys.length <= maxEntries) {
-    return sequences
-  }
-  const capped: Record<string, number> = {}
-  for (const key of keys.slice(keys.length - maxEntries)) {
-    capped[key] = sequences[key]
-  }
-  return capped
+  return capRecordByInsertionOrder(sequences, maxEntries)
 }
 
 function shouldRefreshIssueDecorations(state: AppState): boolean {
@@ -3523,6 +3529,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             // longer live and would otherwise accumulate per refresh sequence.
             deletePRRefreshStartedEntry(event.sequence, alias.cacheKey)
           }
+          // Why: delete-then-set moves this key to the end of insertion order so
+          // capRecordByInsertionOrder evicts genuinely idle keys, not active ones.
+          delete nextStates[alias.cacheKey]
           nextStates[alias.cacheKey] = {
             status: event.status,
             reason: event.reason,
@@ -3535,7 +3544,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       return changed
         ? {
             prRefreshSequences: capPrRefreshSequences(nextSequences),
-            prRefreshStates: nextStates,
+            // Why: bound prRefreshStates by the same insertion-order cap as its
+            // sibling sequences map — both share the unbounded PR-cache-key space.
+            prRefreshStates: capRecordByInsertionOrder(nextStates),
             prCache: nextPRCache,
             hostedReviewCache: nextHostedReviewCache
           }

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1392,6 +1392,54 @@ function capPrRefreshSequences(
   return capRecordByInsertionOrder(sequences, maxEntries)
 }
 
+// Why: prRefreshStates backs visible status pills (refreshing/queued/paused/error)
+// so — unlike the invisible sequence guard — eviction must never drop an in-progress
+// indicator. Bound it well above any realistic tracked-branch count, and when over
+// cap evict *settled* statuses (error/skipped) first; only fall back to evicting an
+// active (in-flight/queued/paused) entry as a last-resort hard memory bound that
+// realistic usage never reaches. Evicted entries self-heal on the next refresh event.
+const MAX_PR_REFRESH_STATE_ENTRIES = 2000
+const SETTLED_PR_REFRESH_STATUSES = new Set<PRRefreshState['status']>(['error', 'skipped'])
+
+function capPrRefreshStates(
+  states: Record<string, PRRefreshState>,
+  maxEntries = MAX_PR_REFRESH_STATE_ENTRIES
+): Record<string, PRRefreshState> {
+  const keys = Object.keys(states)
+  let toEvict = keys.length - maxEntries
+  if (toEvict <= 0) {
+    return states
+  }
+  const evicted = new Set<string>()
+  // First pass: evict oldest settled (error/skipped) entries.
+  for (const key of keys) {
+    if (toEvict === 0) {
+      break
+    }
+    if (SETTLED_PR_REFRESH_STATUSES.has(states[key].status)) {
+      evicted.add(key)
+      toEvict--
+    }
+  }
+  // Last resort: evict oldest remaining keys to enforce the hard bound.
+  for (const key of keys) {
+    if (toEvict === 0) {
+      break
+    }
+    if (!evicted.has(key)) {
+      evicted.add(key)
+      toEvict--
+    }
+  }
+  const capped: Record<string, PRRefreshState> = {}
+  for (const key of keys) {
+    if (!evicted.has(key)) {
+      capped[key] = states[key]
+    }
+  }
+  return capped
+}
+
 function shouldRefreshIssueDecorations(state: AppState): boolean {
   return (state.worktreeCardProperties ?? []).includes('issue')
 }
@@ -3544,9 +3592,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       return changed
         ? {
             prRefreshSequences: capPrRefreshSequences(nextSequences),
-            // Why: bound prRefreshStates by the same insertion-order cap as its
-            // sibling sequences map — both share the unbounded PR-cache-key space.
-            prRefreshStates: capRecordByInsertionOrder(nextStates),
+            // Why: bound prRefreshStates too (same unbounded PR-cache-key space),
+            // but with status-aware eviction so visible in-progress pills survive.
+            prRefreshStates: capPrRefreshStates(nextStates),
             prCache: nextPRCache,
             hostedReviewCache: nextHostedReviewCache
           }


### PR DESCRIPTION
## Leak

`prRefreshStates` (`store/slices/github.ts`) is a `Record` keyed by PR cache key (`executionHostScope::repoId|repoPath::branch`) — the **same unbounded, ephemeral key space** the sibling `prRefreshSequences` is already capped against (`capPrRefreshSequences`, #5792). `applyGitHubPRRefreshEvent` writes a status entry on every status-only refresh event (`paused`/`skipped`/`in-flight`) and re-adds an entry for `upstream-error` outcomes, but **no prune path ever removes them** (`evictGitHubRepoCaches`, `refreshAllGitHub`, and the worktree-removal reconcile all skip it). Branches are ephemeral and unbounded, so the map grows monotonically for the life of the session — while its sibling `prRefreshSequences` was capped at `github.ts:3537`, `prRefreshStates` was committed uncapped one line below.

## Fix

- Extract the existing insertion-order cap into a generic `capRecordByInsertionOrder<T>` (and make `capPrRefreshSequences` delegate to it — no behavior change, just dedup).
- Cap `prRefreshStates` with it at the commit site (`prRefreshStates: capRecordByInsertionOrder(nextStates)`).
- `delete`-then-set the touched key in the status writer so insertion order tracks recency — only genuinely **idle** keys are evicted, never the active ones (mirrors the sequences writer).

## Evidence of the leak (regression test FAILS before the fix)

`github-pr-refresh-states-leak.test.ts` run against the **unfixed** code:

```
FAIL  caps prRefreshStates and keeps the most recently touched key
  AssertionError: expected [ Array(601) ] to have a length of 500 but got 601
FAIL  keeps a refreshed older key by moving it to most-recent before capping
  AssertionError: expected [ Array(600) ] to have a length of 500 but got 600
FAIL  caps prRefreshStates when driven past the cap by the real writer
  (650 distinct branches → 650 entries, unbounded)
 Tests  3 failed | 1 passed (4)
```

The map grows 1:1 with distinct branches observed — exactly the leak.

## Evidence the leak is resolved (test PASSES after the fix)

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The map is bounded at `MAX_CACHE_ENTRIES` (500); the most-recently-touched key always survives; a refreshed older key is moved to most-recent and survives capping (guards the delete-then-set).

## No functional regression

Full existing GitHub-slice suite passes unchanged:

```
src/renderer/src/store/slices/github.test.ts
 Tests  109 passed (109)
```

Capping can at worst evict a transient refresh status for a **long-idle** branch (cap 500 ≫ plausible simultaneously-active branches); `ChecksPanel` already treats a missing status as `undefined`. The "does not evict anything while under the cap" and "keeps the most recently touched key" tests guard against over-eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5802">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->