### PR TITLE
Fix packaged Windows CLI entry launches

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,6 +62,7 @@ import {
   suppressDevEducationForStore
 } from './startup/dev-education-suppression'
 import { maybeRedirectAppImageCliLaunch } from './startup/appimage-cli-redirect'
+import { maybeRedirectPackagedCliEntryLaunch } from './startup/packaged-cli-entry-redirect'
 import { startFirstWindowStartupServices } from './startup/first-window-startup-services'
 import { getDevInstanceIdentity } from './startup/dev-instance-identity'
 import { hydrateShellPath, mergePathSegments } from './startup/hydrate-shell-path'
@@ -183,6 +184,16 @@ let firstWindowStartupServicesReady: Promise<void> = Promise.resolve()
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
 const isServeMode = process.argv.includes('--serve')
+// Why: Windows can otherwise bounce a CLI-shaped launch on the single-instance
+// lock before the command writes stdout.
+const packagedCliEntryRedirect = maybeRedirectPackagedCliEntryLaunch({
+  isPackaged: app.isPackaged,
+  resourcesPath: process.resourcesPath,
+  execPath: process.execPath
+})
+if (packagedCliEntryRedirect.redirected) {
+  app.exit(packagedCliEntryRedirect.status)
+}
 const appImageCliRedirect = maybeRedirectAppImageCliLaunch({
   isPackaged: app.isPackaged,
   resourcesPath: process.resourcesPath,

--- a/src/main/startup/packaged-cli-entry-redirect.test.ts
+++ b/src/main/startup/packaged-cli-entry-redirect.test.ts
@@ -1,0 +1,127 @@
+import { win32 } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  getPackagedCliEntryArgs,
+  maybeRedirectPackagedCliEntryLaunch
+} from './packaged-cli-entry-redirect'
+
+const resourcesPath = 'C:\\Users\\me\\AppData\\Local\\Programs\\Orca\\resources'
+const cliEntryPath = win32.join(resourcesPath, 'app.asar.unpacked', 'out', 'cli', 'index.js')
+
+describe('packaged CLI entry redirect', () => {
+  it('detects Windows GUI launches that received the unpacked CLI entrypoint', () => {
+    expect(
+      getPackagedCliEntryArgs(
+        [
+          'C:\\Users\\me\\AppData\\Local\\Programs\\Orca\\Orca.exe',
+          cliEntryPath.toUpperCase(),
+          'status',
+          '--json'
+        ],
+        cliEntryPath,
+        'win32'
+      )
+    ).toEqual(['status', '--json'])
+  })
+
+  it('ignores normal desktop launches', () => {
+    expect(
+      getPackagedCliEntryArgs(
+        ['C:\\Users\\me\\AppData\\Local\\Programs\\Orca\\Orca.exe', '--updated'],
+        cliEntryPath,
+        'win32'
+      )
+    ).toBeNull()
+  })
+
+  it('spawns the CLI in Electron node mode before the single-instance lock can win', () => {
+    const spawn = vi.fn((..._args: unknown[]) => ({ status: 0 }))
+
+    const result = maybeRedirectPackagedCliEntryLaunch({
+      argv: [
+        'C:\\Users\\me\\AppData\\Local\\Programs\\Orca\\Orca.exe',
+        cliEntryPath,
+        'status',
+        '--json'
+      ],
+      env: {
+        NODE_OPTIONS: '--inspect',
+        NODE_REPL_EXTERNAL_MODULE: 'external-loader'
+      },
+      platform: 'win32',
+      isPackaged: true,
+      resourcesPath,
+      execPath: 'C:\\Users\\me\\AppData\\Local\\Programs\\Orca\\Orca.exe',
+      exists: () => true,
+      spawn: spawn as never
+    })
+
+    expect(result).toEqual({ redirected: true, status: 0 })
+    expect(spawn).toHaveBeenCalledWith(
+      'C:\\Users\\me\\AppData\\Local\\Programs\\Orca\\Orca.exe',
+      [cliEntryPath, 'status', '--json'],
+      {
+        env: expect.objectContaining({
+          ELECTRON_RUN_AS_NODE: '1',
+          ORCA_PACKAGED_CLI_ENTRY_REDIRECTED: '1',
+          ORCA_NODE_OPTIONS: '--inspect',
+          ORCA_NODE_REPL_EXTERNAL_MODULE: 'external-loader'
+        }),
+        stdio: 'inherit'
+      }
+    )
+    const spawnOptions = spawn.mock.calls[0]?.[2] as { env: NodeJS.ProcessEnv } | undefined
+    expect(spawnOptions?.env).not.toHaveProperty('NODE_OPTIONS')
+    expect(spawnOptions?.env).not.toHaveProperty('NODE_REPL_EXTERNAL_MODULE')
+  })
+
+  it('does not redirect development launches', () => {
+    const spawn = vi.fn()
+
+    const result = maybeRedirectPackagedCliEntryLaunch({
+      argv: ['C:\\dev\\Orca.exe', cliEntryPath, 'status'],
+      platform: 'win32',
+      isPackaged: false,
+      resourcesPath,
+      execPath: 'C:\\dev\\Orca.exe',
+      exists: () => true,
+      spawn: spawn as never
+    })
+
+    expect(result).toEqual({ redirected: false })
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('fails clearly instead of recursively redirecting when node mode already failed once', () => {
+    const spawn = vi.fn()
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    try {
+      const result = maybeRedirectPackagedCliEntryLaunch({
+        argv: [
+          'C:\\Users\\me\\AppData\\Local\\Programs\\Orca\\Orca.exe',
+          cliEntryPath,
+          'status',
+          '--json'
+        ],
+        env: {
+          ORCA_PACKAGED_CLI_ENTRY_REDIRECTED: '1'
+        },
+        platform: 'win32',
+        isPackaged: true,
+        resourcesPath,
+        execPath: 'C:\\Users\\me\\AppData\\Local\\Programs\\Orca\\Orca.exe',
+        exists: () => true,
+        spawn: spawn as never
+      })
+
+      expect(result).toEqual({ redirected: true, status: 1 })
+      expect(stderrWrite).toHaveBeenCalledWith(
+        'Unable to start the Orca CLI through Electron node mode.\n'
+      )
+      expect(spawn).not.toHaveBeenCalled()
+    } finally {
+      stderrWrite.mockRestore()
+    }
+  })
+})

--- a/src/main/startup/packaged-cli-entry-redirect.ts
+++ b/src/main/startup/packaged-cli-entry-redirect.ts
@@ -1,0 +1,99 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { posix, win32 } from 'node:path'
+
+type RedirectResult =
+  | {
+      redirected: false
+    }
+  | {
+      redirected: true
+      status: number
+    }
+
+type RedirectOptions = {
+  argv?: string[]
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform
+  isPackaged?: boolean
+  resourcesPath?: string
+  execPath?: string
+  exists?: typeof existsSync
+  spawn?: typeof spawnSync
+}
+
+const REDIRECT_ATTEMPT_ENV = 'ORCA_PACKAGED_CLI_ENTRY_REDIRECTED'
+
+export function maybeRedirectPackagedCliEntryLaunch(options: RedirectOptions = {}): RedirectResult {
+  const argv = options.argv ?? process.argv
+  const env = options.env ?? process.env
+  const platform = options.platform ?? process.platform
+  const isPackaged = options.isPackaged ?? false
+  const resourcesPath = options.resourcesPath ?? process.resourcesPath
+  const execPath = options.execPath ?? process.execPath
+  const exists = options.exists ?? existsSync
+  const spawn = options.spawn ?? spawnSync
+  const cliEntryPath = buildPackagedCliEntryPath(platform, resourcesPath)
+  const cliArgs = getPackagedCliEntryArgs(argv, cliEntryPath, platform)
+
+  if (!isPackaged || !cliArgs) {
+    return { redirected: false }
+  }
+  if (env[REDIRECT_ATTEMPT_ENV] === '1') {
+    process.stderr.write('Unable to start the Orca CLI through Electron node mode.\n')
+    return { redirected: true, status: 1 }
+  }
+  if (!exists(cliEntryPath)) {
+    process.stderr.write(`Unable to locate the Orca CLI entrypoint at ${cliEntryPath}\n`)
+    return { redirected: true, status: 1 }
+  }
+
+  const result = spawn(execPath, [cliEntryPath, ...cliArgs], {
+    env: buildElectronRunAsNodeEnv(env),
+    stdio: 'inherit'
+  }) as SpawnSyncReturns<Buffer>
+
+  if (result.error) {
+    process.stderr.write(`${result.error.message}\n`)
+    return { redirected: true, status: 1 }
+  }
+
+  return { redirected: true, status: result.status ?? 1 }
+}
+
+export function getPackagedCliEntryArgs(
+  argv: string[],
+  cliEntryPath: string,
+  platform: NodeJS.Platform
+): string[] | null {
+  const expectedCliPath = normalizePathForPlatform(cliEntryPath, platform)
+  const cliEntryIndex = argv.findIndex(
+    (arg, index) => index > 0 && normalizePathForPlatform(arg, platform) === expectedCliPath
+  )
+  return cliEntryIndex === -1 ? null : argv.slice(cliEntryIndex + 1)
+}
+
+function buildPackagedCliEntryPath(platform: NodeJS.Platform, resourcesPath: string): string {
+  return getPathApi(platform).join(resourcesPath, 'app.asar.unpacked', 'out', 'cli', 'index.js')
+}
+
+function normalizePathForPlatform(value: string, platform: NodeJS.Platform): string {
+  const pathApi = getPathApi(platform)
+  const normalized = pathApi.normalize(pathApi.isAbsolute(value) ? value : pathApi.resolve(value))
+  return platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+function getPathApi(platform: NodeJS.Platform): typeof win32 | typeof posix {
+  return platform === 'win32' ? win32 : posix
+}
+
+function buildElectronRunAsNodeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const childEnv = { ...env }
+  childEnv.ORCA_NODE_OPTIONS = env.NODE_OPTIONS ?? ''
+  childEnv.ORCA_NODE_REPL_EXTERNAL_MODULE = env.NODE_REPL_EXTERNAL_MODULE ?? ''
+  childEnv.ELECTRON_RUN_AS_NODE = '1'
+  childEnv[REDIRECT_ATTEMPT_ENV] = '1'
+  delete childEnv.NODE_OPTIONS
+  delete childEnv.NODE_REPL_EXTERNAL_MODULE
+  return childEnv
+}


### PR DESCRIPTION
## Summary

Fixes #5774.

On Windows, a packaged CLI-shaped launch can reach Electron main as:

```text
Orca.exe <resources>/app.asar.unpacked/out/cli/index.js status --json
```

If that happens without `ELECTRON_RUN_AS_NODE=1`, Electron treats it as a desktop app launch. When another Orca GUI instance is already running, the single-instance lock wins before the CLI writes stdout, so the user sees no JSON and only the single-instance stderr line.

This PR detects that exact packaged CLI-entry argv shape before the single-instance lock, respawns the same executable with `ELECTRON_RUN_AS_NODE=1`, and exits with the CLI child status. It also carries over `NODE_OPTIONS` / `NODE_REPL_EXTERNAL_MODULE` into the Orca-preserved env vars and strips the originals, matching the existing launcher/AppImage behavior.

## Regression Risk

Low and tightly scoped:

- Only runs in packaged builds (`app.isPackaged`).
- Only redirects when argv contains the exact unpacked CLI entrypoint under `process.resourcesPath`.
- Normal desktop launches, dev launches, and AppImage CLI redirect behavior are covered separately and unchanged.
- A loop guard prevents recursive respawn if Electron node mode somehow fails to take over.

## Validation

- Reproduced the underlying failure against the installed packaged app by launching `Orca.exe <cli-entry> status --json` without `ELECTRON_RUN_AS_NODE`: exit 0, no JSON stdout, single-instance stderr.
- Verified the fixed unpacked build with the same no-env launch shape: returned `status --json` for the already-running Orca instance with empty stderr.
- Verified the fixed unpacked `resources/bin/orca.cmd status --json` path still returns JSON.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/packaged-cli-entry-redirect.test.ts src/main/startup/appimage-cli-redirect.test.ts src/main/startup/single-instance-lock.test.ts src/main/cli/windows-launcher-asset.test.ts src/main/cli/packaged-cli-assets.test.ts src/main/cli/cli-installer.test.ts`
  - 6 files passed, 21 passed, 21 skipped.
- `pnpm run typecheck:node`
- `pnpm lint`
- `pnpm run build:desktop`

Note: `electron-builder --win --dir` produced a runnable `dist/win-unpacked` used for validation, then exited nonzero while extracting electron-builder's signing helper because this Windows shell lacks symlink privilege for the helper archive. The source-level build and runtime CLI validation completed successfully.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5811">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->