### PR TITLE
fix(store): purge all per-worktree maps on project removal via purgeWorktreeTerminalState

### DIFF
--- a/src/renderer/src/store/slices/repos-remove-project-purge-leak.test.ts
+++ b/src/renderer/src/store/slices/repos-remove-project-purge-leak.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Memory-leak regression: removing a project must purge its worktrees' per-worktree
+ * state.
+ *
+ * `removeProject` hand-deleted only a small subset of per-worktree maps
+ * (tabsByWorktree, terminalLayoutsByTabId, ptyIdsByTabId, …) and never called the
+ * canonical `purgeWorktreeTerminalState` / `buildWorktreePurgeState`. So ~30+
+ * worktree-scoped maps (unifiedTabsByWorktree, groupsByWorktree, layoutByWorktree,
+ * gitStatusByWorktree, gitStatusHugeByWorktree, browserTabsByWorktree,
+ * everActivatedWorktreeIds, …) kept an entry for every worktree of every removed
+ * project. No background reaper recovers them (fetchWorktrees never runs again for a
+ * removed repo). Repos churn forever and each can own many worktrees, so the state
+ * grew monotonically. The single `removeWorktree` path already routes through
+ * `purgeWorktreeTerminalState`; project removal did not.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createTestStore, makeWorktree } from './store-test-helpers'
+import type { Repo } from '../../../../shared/types'
+
+const repo1: Repo = { id: 'repo-1', path: '/r1', displayName: 'R1', badgeColor: '#000', addedAt: 1 }
+const repo2: Repo = { id: 'repo-2', path: '/r2', displayName: 'R2', badgeColor: '#111', addedAt: 2 }
+
+const reposRemove = vi.fn().mockResolvedValue(undefined)
+const ptyKill = vi.fn()
+
+beforeEach(() => {
+  reposRemove.mockReset().mockResolvedValue(undefined)
+  ptyKill.mockReset()
+  vi.stubGlobal('window', {
+    api: {
+      repos: { remove: reposRemove },
+      pty: { kill: ptyKill },
+      runtimeEnvironments: { call: vi.fn() }
+    }
+  })
+})
+
+const W1 = 'repo-1::/r1/wt1'
+const W2 = 'repo-2::/r2/wt1'
+
+function seedTwoProjects(store: ReturnType<typeof createTestStore>): void {
+  store.setState({
+    repos: [repo1, repo2],
+    worktreesByRepo: {
+      [repo1.id]: [makeWorktree({ id: W1, repoId: repo1.id, path: '/r1/wt1' })],
+      [repo2.id]: [makeWorktree({ id: W2, repoId: repo2.id, path: '/r2/wt1' })]
+    },
+    // Per-worktree maps that removeProject previously left behind.
+    unifiedTabsByWorktree: { [W1]: [], [W2]: [] },
+    groupsByWorktree: { [W1]: [], [W2]: [] },
+    browserTabsByWorktree: { [W1]: [], [W2]: [] },
+    gitStatusHugeByWorktree: { [W1]: { limit: 1000 }, [W2]: { limit: 2000 } },
+    everActivatedWorktreeIds: new Set([W1, W2])
+  })
+}
+
+describe('removeProject purges per-worktree state (leak regression)', () => {
+  it('drops every per-worktree map entry for the removed project', async () => {
+    const store = createTestStore()
+    seedTwoProjects(store)
+
+    await store.getState().removeProject(repo1.id)
+
+    const s = store.getState()
+    // Removed project's worktree is purged from every map.
+    expect(s.unifiedTabsByWorktree[W1]).toBeUndefined()
+    expect(s.groupsByWorktree[W1]).toBeUndefined()
+    expect(s.browserTabsByWorktree[W1]).toBeUndefined()
+    expect(s.gitStatusHugeByWorktree[W1]).toBeUndefined()
+    expect(s.everActivatedWorktreeIds.has(W1)).toBe(false)
+  })
+
+  it('keeps per-worktree state for projects that are NOT removed', async () => {
+    const store = createTestStore()
+    seedTwoProjects(store)
+
+    await store.getState().removeProject(repo1.id)
+
+    const s = store.getState()
+    // Surviving project's worktree state is untouched (guard over-eviction).
+    expect(s.unifiedTabsByWorktree[W2]).toBeDefined()
+    expect(s.groupsByWorktree[W2]).toBeDefined()
+    expect(s.browserTabsByWorktree[W2]).toBeDefined()
+    expect(s.gitStatusHugeByWorktree[W2]).toEqual({ limit: 2000 })
+    expect(s.everActivatedWorktreeIds.has(W2)).toBe(true)
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1677,6 +1677,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         }
       }
 
+      // Why: route project removal through the canonical per-worktree purge so all
+      // ~30 worktree-scoped maps are evicted. removeProject previously hand-deleted
+      // only a handful (tabs/layouts/ptys), leaking the rest (unified tabs, groups,
+      // git status, browser, everActivated, …) per worktree of every removed repo.
+      // Runs before the repo-scoped set() below so the purge still sees tabsByWorktree.
+      get().purgeWorktreeTerminalState(worktreeIds)
+
       set((s) => {
         const nextWorktrees = { ...s.worktreesByRepo }
         delete nextWorktrees[projectId]


### PR DESCRIPTION
## Leak

`removeProject` hand-deleted only a small subset of per-worktree maps (`tabsByWorktree`, `terminalLayoutsByTabId`, `ptyIdsByTabId`, `runtimePaneTitlesByTabId`, `activeFileIdByWorktree`, `activeTabTypeByWorktree`, `lastVisitedAtByWorktreeId`, `openFiles`) and **never called the canonical `purgeWorktreeTerminalState` / `buildWorktreePurgeState`**. So ~30+ worktree-scoped maps — `unifiedTabsByWorktree`, `groupsByWorktree`, `layoutByWorktree`, all `git*ByWorktree`, `gitStatusHugeByWorktree`, `fileSearchStateByWorktree`, `browserTabsByWorktree`, `worktreeLineageById`, `everActivatedWorktreeIds`, and more — retained an entry for **every worktree of every removed project**.

No background reaper recovers them: `fetchWorktrees(repoId)` never runs again for a removed repo, and the one-shot hydration purge only scans `tabsByWorktree` keys (already deleted). Repos churn over a session and each can own many worktrees, so the state grew monotonically. The single-worktree `removeWorktree` path already routes through `purgeWorktreeTerminalState`; project removal did not.

## Fix

In `removeProject`, after the PTY-kill loop computes `worktreeIds`, call `get().purgeWorktreeTerminalState(worktreeIds)` **before** the repo-scoped `set()` (so the purge still sees `tabsByWorktree`/`browserTabsByWorktree` to derive doomed tab/page ids). `purgeWorktreeTerminalState` is a pure `set(buildWorktreePurgeState(...))` with no PTY side effects, so it composes cleanly with the existing repo-scoped cleanup — which still deletes the repo-level entries (`worktreesByRepo`, `repos`, `activeRepoId`, …) that the per-worktree purge does not touch.

## Evidence of the leak (regression test FAILS before the fix)

`repos-remove-project-purge-leak.test.ts` against the **unfixed** code:

```
× drops every per-worktree map entry for the removed project
   AssertionError: expected [] to be undefined
       66|     expect(s.unifiedTabsByWorktree[W1]).toBeUndefined()
 Tests  1 failed | 1 passed (2)
```

The removed project's worktree survives in `unifiedTabsByWorktree`, `groupsByWorktree`, `browserTabsByWorktree`, `gitStatusHugeByWorktree`, and `everActivatedWorktreeIds`.

## Evidence the leak is resolved (test PASSES after the fix)

```
 Tests  2 passed (2)
```

The removed project's worktree is gone from every map; the second (surviving) project's worktree state is retained (guards over-eviction).

## No functional regression

```
repos.test.ts + worktrees.test.ts
 Tests  151 passed (151)
```

`purgeWorktreeTerminalState` is the same tested function the single-worktree removal path already uses; eviction is keyed strictly to the removed project's worktrees; the surviving-project assertions guard over-eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5815">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->