### PR TITLE
fix(daemon): clear disabledSessions on normal terminal exit in closeSession

### DIFF
--- a/src/main/daemon/history-manager-disabled-sessions-leak.test.ts
+++ b/src/main/daemon/history-manager-disabled-sessions-leak.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Memory-leak regression: disabledSessions must not retain ids of sessions that
+ * exited normally.
+ *
+ * `handleWriteError` adds a sessionId to the `disabledSessions` Set on any
+ * best-effort history write failure (EIO/ENOSPC/EACCES). `closeSession` — the
+ * NORMAL terminal-exit teardown — deleted the writer but never the disabled flag.
+ * The only other delete sites are `openSession` (fires only on id reuse, which
+ * never happens — sessionIds are fresh per PTY) and `removeSession` (explicit
+ * user-kill). So a session that hit a transient write error mid-life then exited
+ * normally left its sessionId in `disabledSessions` forever — one leaked id per
+ * such session for the daemon's lifetime.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdtempSync, rmSync, chmodSync } from 'fs'
+import { HistoryManager } from './history-manager'
+import type { TerminalSnapshot, TerminalModes } from './types'
+import { getHistorySessionDirName } from './history-paths'
+
+function createTestDir(): string {
+  return mkdtempSync(join(tmpdir(), 'history-mgr-leak-test-'))
+}
+
+const defaultModes: TerminalModes = {
+  bracketedPaste: false,
+  mouseTracking: false,
+  applicationCursor: false,
+  alternateScreen: false
+}
+
+function makeSnapshot(): TerminalSnapshot {
+  return {
+    snapshotAnsi: 'hello\r\n',
+    scrollbackAnsi: '',
+    rehydrateSequences: '',
+    cwd: '/tmp',
+    modes: defaultModes,
+    cols: 80,
+    rows: 24,
+    scrollbackLines: 0
+  }
+}
+
+describe('HistoryManager disabledSessions stays bounded (leak regression)', () => {
+  let dir: string
+  let mgr: HistoryManager
+
+  beforeEach(() => {
+    dir = createTestDir()
+    mgr = new HistoryManager(dir)
+  })
+
+  afterEach(async () => {
+    await mgr.dispose()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // Drive a session into the disabled set via a write error, then close it
+  // normally — mirrors the chmod-based error injection in history-manager.test.ts.
+  async function poisonThenCloseNormally(sessionId: string): Promise<void> {
+    await mgr.openSession(sessionId, { cwd: '/tmp', cols: 80, rows: 24 })
+    const sessionDir = join(dir, getHistorySessionDirName(sessionId))
+    chmodSync(sessionDir, 0o555) // read-only -> checkpoint write fails -> disabled
+    await mgr.checkpoint(sessionId, makeSnapshot())
+    chmodSync(sessionDir, 0o755) // restore so endedAt write at close succeeds
+    await mgr.closeSession(sessionId, 0)
+  }
+
+  it.skipIf(process.platform === 'win32')(
+    'clears the disabled flag when a poisoned session exits normally',
+    async () => {
+      await poisonThenCloseNormally('sess-1')
+      expect(mgr.isSessionDisabled('sess-1')).toBe(false)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'does not accumulate disabled ids across many poisoned-then-closed sessions',
+    async () => {
+      for (let i = 0; i < 50; i++) {
+        await poisonThenCloseNormally(`sess-${i}`)
+      }
+      expect(mgr.disabledSessionCount()).toBe(0)
+    }
+  )
+})

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -285,6 +285,10 @@ export class HistoryManager {
     }
 
     this.writers.delete(sessionId)
+    // Why: the session is dead, so its disabled flag is dead state. Without this
+    // a session poisoned by a transient mid-life write error leaks its id in
+    // disabledSessions forever (sessionIds are fresh per PTY, never reused).
+    this.disabledSessions.delete(sessionId)
     try {
       this.updateMeta(writer.dir, { endedAt: new Date().toISOString(), exitCode })
     } catch (err) {
@@ -302,6 +306,14 @@ export class HistoryManager {
       recursive: true,
       force: true
     })
+  }
+
+  isSessionDisabled(sessionId: string): boolean {
+    return this.disabledSessions.has(sessionId)
+  }
+
+  disabledSessionCount(): number {
+    return this.disabledSessions.size
   }
 
   hasHistory(sessionId: string): boolean {


### PR DESCRIPTION
## Leak

`HistoryManager.handleWriteError` adds a `sessionId` to the `disabledSessions` `Set` on any best-effort history write failure (EIO/ENOSPC/EACCES). `closeSession` — the **normal** terminal-exit teardown, invoked on PTY `exit` — deletes the writer (`writers.delete`) but never `disabledSessions.delete`. The only other delete sites are `openSession` (fires only on id reuse, which never happens — sessionIds are fresh per PTY) and `removeSession` (explicit user-kill).

So a session that hits a transient write error mid-life and then exits normally leaves its `sessionId` in `disabledSessions` **forever** — one leaked id per such session for the daemon's lifetime. The sibling exit cleanup (`activeSessionIds`, `dirtySessionVersions`, `coldRestoreCache`, …) has no hook for this Set.

## Fix

In `closeSession()`, after `this.writers.delete(sessionId)`, add `this.disabledSessions.delete(sessionId)` — the session is dead, so its disabled flag is dead state. Two test accessors (`isSessionDisabled`, `disabledSessionCount`) expose the bound.

## Evidence of the leak (regression test FAILS before the fix)

`history-manager-disabled-sessions-leak.test.ts` against the **unfixed** code (each session is poisoned with a real `chmod 0o555` write error, then closed normally after restoring perms — mirroring the existing chmod tests):

```
× clears the disabled flag when a poisoned session exits normally
   AssertionError: expected true to be false
× does not accumulate disabled ids across many poisoned-then-closed sessions
   AssertionError: expected 50 to be +0
 Tests  2 failed (2)
```

50 poisoned-then-closed sessions leave 50 ids in `disabledSessions`.

## Evidence the leak is resolved (test PASSES after the fix)

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

`disabledSessionCount()` returns to 0 after the sessions close.

## No functional regression

```
src/main/daemon/history-manager.test.ts
 Tests  23 passed (23)
```

Clearing the flag in `closeSession` is safe: `writers.delete` already makes subsequent `appendIncrements`/`checkpoint` return early on the missing writer regardless of the flag, so no write to a dead session can be re-enabled. The mid-life short-circuit (error → exit window) is preserved — covered by the existing "ignores checkpoint for disabled sessions" test. Tests are `skipIf(win32)` like the existing chmod-based tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5816">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->