### PR TITLE
fix(tab-bar): search agents by prefix and make the open-entry list keyboard-navigable

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TabEntryOption } from './tab-create-entry-action'
+import type { TabAgentLaunchOption } from './tab-agent-launch-options'
+
+// Why: the real entry-action module pulls in runtime IPC + the app store; the
+// keyboard behavior under test only needs a controllable option list.
+const entryOptionsMock = vi.hoisted(() => ({ options: [] as TabEntryOption[] }))
+vi.mock('./tab-create-entry-action', () => ({
+  getTabEntryOptions: () => entryOptionsMock.options
+}))
+vi.mock('../quick-open-file-list', () => ({
+  useRuntimeFileListForWorktree: () => ({ files: [], loading: false, loadError: null })
+}))
+vi.mock('@/lib/agent-catalog', () => ({
+  getAgentCatalog: () => [],
+  AgentIcon: () => null
+}))
+
+import TabBarCreateEntry from './TabBarCreateEntry'
+
+// Why: opt into React's act environment so state updates flush synchronously.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const fileOption = (relativePath: string): TabEntryOption => ({
+  id: `existing-file:${relativePath}`,
+  classification: { kind: 'existing-file', matchKind: 'fuzzy', relativePath }
+})
+
+let container: HTMLDivElement
+let root: Root
+
+function mount(node: React.JSX.Element): void {
+  act(() => {
+    root.render(node)
+  })
+}
+
+function pressKey(target: Element, key: string): KeyboardEvent {
+  const event = new window.KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+  act(() => {
+    target.dispatchEvent(event)
+  })
+  return event
+}
+
+function setQuery(value: string): void {
+  const input = container.querySelector('input')
+  if (!input) {
+    throw new Error('input not found')
+  }
+  // Why: React patches the input value setter to track changes; bypass it with
+  // the native setter so the synthetic onChange actually fires.
+  const nativeSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value'
+  )?.set
+  act(() => {
+    nativeSetter?.call(input, value)
+    input.dispatchEvent(new window.Event('input', { bubbles: true }))
+  })
+}
+
+function submitForm(): void {
+  const form = container.querySelector('form')
+  if (!form) {
+    throw new Error('form not found')
+  }
+  act(() => {
+    form.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }))
+  })
+}
+
+beforeEach(() => {
+  entryOptionsMock.options = []
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.clearAllMocks()
+})
+
+describe('TabBarCreateEntry keyboard navigation', () => {
+  it('intercepts ArrowDown on a single-option list so it does not leak (guards >0 vs >1)', () => {
+    entryOptionsMock.options = [fileOption('src/only-match.ts')]
+    const onOpenEntry = vi.fn().mockResolvedValue(undefined)
+    mount(<TabBarCreateEntry worktreeId="wt" groupId="g" menuOpen onOpenEntry={onOpenEntry} />)
+
+    // The pre-fix `> 1` guard left a single result unhandled: the arrow leaked to
+    // the input cursor / Radix. Now it must be consumed (preventDefault) and Enter
+    // still opens the row.
+    const event = pressKey(container.querySelector('input')!, 'ArrowDown')
+    expect(event.defaultPrevented).toBe(true)
+
+    submitForm()
+    expect(onOpenEntry).toHaveBeenCalledTimes(1)
+    expect(onOpenEntry.mock.calls[0][0].classification).toMatchObject({
+      kind: 'existing-file',
+      relativePath: 'src/only-match.ts'
+    })
+  })
+
+  it('iterates a multi-option result list with ArrowDown and selects the highlighted row', () => {
+    entryOptionsMock.options = [fileOption('a.ts'), fileOption('b.ts'), fileOption('c.ts')]
+    const onOpenEntry = vi.fn().mockResolvedValue(undefined)
+    mount(<TabBarCreateEntry worktreeId="wt" groupId="g" menuOpen onOpenEntry={onOpenEntry} />)
+
+    const input = container.querySelector('input')!
+    pressKey(input, 'ArrowDown')
+    pressKey(input, 'ArrowDown')
+    submitForm()
+
+    expect(onOpenEntry.mock.calls[0][0].classification).toMatchObject({ relativePath: 'c.ts' })
+  })
+
+  it('wraps from the first row to the last with ArrowUp', () => {
+    entryOptionsMock.options = [fileOption('a.ts'), fileOption('b.ts')]
+    const onOpenEntry = vi.fn().mockResolvedValue(undefined)
+    mount(<TabBarCreateEntry worktreeId="wt" groupId="g" menuOpen onOpenEntry={onOpenEntry} />)
+
+    pressKey(container.querySelector('input')!, 'ArrowUp')
+    submitForm()
+
+    expect(onOpenEntry.mock.calls[0][0].classification).toMatchObject({ relativePath: 'b.ts' })
+  })
+
+  it('launches a matched agent when its highlighted row is selected', () => {
+    const agentOptions: TabAgentLaunchOption[] = [
+      { agent: 'gemini', aliases: ['gemini'], label: 'Gemini' }
+    ]
+    const onLaunchAgent = vi.fn()
+    mount(
+      <TabBarCreateEntry
+        worktreeId="wt"
+        groupId="g"
+        menuOpen
+        agentOptions={agentOptions}
+        onOpenEntry={vi.fn().mockResolvedValue(undefined)}
+        onLaunchAgent={onLaunchAgent}
+      />
+    )
+
+    // A partial query surfaces the agent (issue #1); it is the top row, so Enter
+    // launches it.
+    setQuery('gem')
+    submitForm()
+
+    expect(onLaunchAgent).toHaveBeenCalledWith('gemini')
+  })
+
+  it('exposes the highlighted row to assistive tech via aria-activedescendant', () => {
+    entryOptionsMock.options = [fileOption('a.ts'), fileOption('b.ts'), fileOption('c.ts')]
+    mount(
+      <TabBarCreateEntry
+        worktreeId="wt"
+        groupId="g"
+        menuOpen
+        onOpenEntry={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    const input = container.querySelector('input')!
+    expect(input.getAttribute('role')).toBe('combobox')
+    expect(input.getAttribute('aria-activedescendant')).toBe('tab-create-entry-result-0')
+
+    pressKey(input, 'ArrowDown')
+    expect(input.getAttribute('aria-activedescendant')).toBe('tab-create-entry-result-1')
+    const active = document.getElementById('tab-create-entry-result-1')
+    expect(active?.getAttribute('role')).toBe('option')
+    expect(active?.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('routes ArrowDown into the enclosing menu when there are no result rows', () => {
+    mount(
+      <div role="menu">
+        <TabBarCreateEntry worktreeId="wt" groupId="g" menuOpen onOpenEntry={vi.fn()} />
+        <button type="button" role="menuitem">
+          New Terminal
+        </button>
+        <button type="button" role="menuitem">
+          Launch Claude
+        </button>
+      </div>
+    )
+
+    const firstItem = container.querySelector('[role="menuitem"]') as HTMLButtonElement
+    pressKey(container.querySelector('input')!, 'ArrowDown')
+
+    expect(document.activeElement).toBe(firstItem)
+  })
+
+  it('returns focus to the input on ArrowUp from the first menu item (no dead-end)', () => {
+    mount(
+      <div role="menu">
+        <TabBarCreateEntry worktreeId="wt" groupId="g" menuOpen onOpenEntry={vi.fn()} />
+        <button type="button" role="menuitem">
+          New Terminal
+        </button>
+        <button type="button" role="menuitem">
+          Launch Claude
+        </button>
+      </div>
+    )
+
+    const input = container.querySelector('input')!
+    const firstItem = container.querySelector('[role="menuitem"]') as HTMLButtonElement
+    act(() => firstItem.focus())
+    expect(document.activeElement).toBe(firstItem)
+
+    pressKey(firstItem, 'ArrowUp')
+    expect(document.activeElement).toBe(input)
+  })
+})

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
@@ -1,15 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { FilePlus, FileText, Globe, Loader2, Smartphone, TerminalSquare } from 'lucide-react'
 import { Input } from '@/components/ui/input'
-import { AgentIcon } from '@/lib/agent-catalog'
-import { cn } from '@/lib/utils'
 import { useRuntimeFileListForWorktree } from '../quick-open-file-list'
-import {
-  getTabEntryOptions,
-  type TabCreateEntryArgs,
-  type TabEntryActionClassification,
-  type TabEntryOption
-} from './tab-create-entry-action'
+import { getTabEntryOptions, type TabCreateEntryArgs } from './tab-create-entry-action'
 import {
   findMatchingTabAgentLaunchOptions,
   type TabAgentLaunchOption
@@ -18,6 +10,17 @@ import {
   findMatchingTabCreateMenuOptions,
   type TabCreateMenuOption
 } from './tab-create-menu-options'
+import {
+  getActiveOptionId,
+  isActiveEntryOption,
+  type ActiveOption
+} from './tab-create-entry-active-option'
+import {
+  EntryActionRow,
+  EntryStatusRow,
+  RESULT_LISTBOX_ID,
+  resultOptionDomId
+} from './TabBarCreateEntryRow'
 import type { TuiAgent } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 
@@ -59,6 +62,35 @@ export default function TabBarCreateEntry({
   const [lastMenuOpen, setLastMenuOpen] = useState(menuOpen)
   const inputRef = useRef<HTMLInputElement>(null)
   const fileList = useRuntimeFileListForWorktree({ enabled: menuOpen, worktreeId })
+
+  // Why: once ArrowDown moves focus into the static menu list, ArrowUp on the
+  // first item should return to the search box so the keyboard trip isn't
+  // one-way. Capture phase beats Radix's roving-focus handler.
+  useEffect(() => {
+    if (!menuOpen) {
+      return
+    }
+    const input = inputRef.current
+    const menu = input?.closest<HTMLElement>('[role="menu"]')
+    if (!input || !menu) {
+      return
+    }
+    const handleMenuKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'ArrowUp') {
+        return
+      }
+      const firstItem = menu.querySelector(
+        '[role="menuitem"]:not([data-disabled]):not([aria-disabled="true"])'
+      )
+      if (firstItem && document.activeElement === firstItem) {
+        event.preventDefault()
+        event.stopPropagation()
+        input.focus()
+      }
+    }
+    menu.addEventListener('keydown', handleMenuKeyDown, true)
+    return () => menu.removeEventListener('keydown', handleMenuKeyDown, true)
+  }, [menuOpen])
 
   useEffect(() => {
     if (!menuOpen) {
@@ -185,14 +217,26 @@ export default function TabBarCreateEntry({
         submitOption()
       }}
       onKeyDown={(event) => {
-        if (activeOptions.length > 1 && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
-          event.preventDefault()
-          event.stopPropagation()
-          setSelectedIndex((current) => {
-            const delta = event.key === 'ArrowDown' ? 1 : -1
-            return (current + delta + activeOptions.length) % activeOptions.length
-          })
-          return
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+          if (activeOptions.length > 0) {
+            event.preventDefault()
+            event.stopPropagation()
+            setSelectedIndex((current) => {
+              const delta = event.key === 'ArrowDown' ? 1 : -1
+              return (current + delta + activeOptions.length) % activeOptions.length
+            })
+            return
+          }
+          // Why: with no result rows the static create/agent items render below;
+          // move focus into that Radix menu list so it stays keyboard-navigable
+          // from the search box instead of trapping focus in the input.
+          if (
+            focusMenuItemAtEdge(event.currentTarget, event.key === 'ArrowDown' ? 'first' : 'last')
+          ) {
+            event.preventDefault()
+            event.stopPropagation()
+            return
+          }
         }
         if (event.key !== 'Escape') {
           event.stopPropagation()
@@ -209,6 +253,13 @@ export default function TabBarCreateEntry({
             setError(null)
           }}
           disabled={disabled}
+          role="combobox"
+          aria-expanded={activeOptions.length > 0}
+          aria-controls={RESULT_LISTBOX_ID}
+          aria-autocomplete="list"
+          aria-activedescendant={
+            activeOptions.length > 0 && !error ? resultOptionDomId(activeSelectedIndex) : undefined
+          }
           aria-label={translate(
             'auto.components.tab.bar.TabBarCreateEntry.39676a184c',
             'Open any file, URL, agent, ...'
@@ -222,13 +273,18 @@ export default function TabBarCreateEntry({
         />
       </div>
       {error || activeOptions.length > 0 || hasQuery ? (
-        <div className="mt-1 space-y-0.5 px-1">
+        <div
+          className="mt-1 space-y-0.5 px-1"
+          id={RESULT_LISTBOX_ID}
+          role={activeOptions.length > 0 && !error ? 'listbox' : undefined}
+        >
           {error ? (
             <EntryStatusRow message={error} />
           ) : activeOptions.length > 0 ? (
             activeOptions.map((option, index) => (
               <EntryActionRow
                 key={getActiveOptionId(option)}
+                id={resultOptionDomId(index)}
                 option={option}
                 selected={index === activeSelectedIndex}
                 onClick={() => submitOption(option)}
@@ -243,146 +299,20 @@ export default function TabBarCreateEntry({
   )
 }
 
-type ActiveEntryOption = TabEntryOption & {
-  classification: TabEntryActionClassification
-}
-
-type ActiveOption =
-  | {
-      kind: 'agent'
-      option: TabAgentLaunchOption
-    }
-  | {
-      kind: 'entry'
-      option: ActiveEntryOption
-    }
-  | {
-      kind: 'menu'
-      option: TabCreateMenuOption
-    }
-
-function isActiveEntryOption(option: TabEntryOption): option is ActiveEntryOption {
-  return option.classification.kind !== 'empty' && option.classification.kind !== 'blocked'
-}
-
-function getActiveOptionId(option: ActiveOption): string {
-  if (option.kind === 'agent') {
-    return `agent:${option.option.agent}`
+// Moves keyboard focus to the first/last enabled item of the enclosing Radix
+// menu so the static create/agent list stays navigable from the search input.
+function focusMenuItemAtEdge(fromElement: HTMLElement, edge: 'first' | 'last'): boolean {
+  const menu = fromElement.closest('[role="menu"]')
+  if (!menu) {
+    return false
   }
-  if (option.kind === 'menu') {
-    return `menu:${option.option.id}`
-  }
-  return option.option.id
-}
-
-function EntryStatusRow({
-  loading = false,
-  message
-}: {
-  loading?: boolean
-  message: string
-}): React.JSX.Element {
-  return (
-    <div className="flex min-h-6 items-center gap-1.5 rounded-[7px] px-1 text-[11px] leading-5 text-muted-foreground">
-      {loading ? <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden="true" /> : null}
-      <span className="truncate">{message}</span>
-    </div>
+  const items = menu.querySelectorAll<HTMLElement>(
+    '[role="menuitem"]:not([data-disabled]):not([aria-disabled="true"])'
   )
-}
-
-function EntryActionRow({
-  onClick,
-  option,
-  selected
-}: {
-  onClick: () => void
-  option: ActiveOption
-  selected: boolean
-}): React.JSX.Element {
-  const presentation = getActionPresentation(option)
-
-  return (
-    <button
-      type="button"
-      className={cn(
-        'flex h-6 w-full items-center gap-1.5 rounded-[7px] px-1 text-left text-[11px] leading-5 outline-none',
-        selected
-          ? 'bg-black/8 text-accent-foreground dark:bg-white/14'
-          : 'text-muted-foreground hover:bg-black/8 hover:text-accent-foreground dark:hover:bg-white/14'
-      )}
-      onClick={onClick}
-    >
-      {presentation.icon}
-      <span className={cn('min-w-0 truncate font-medium', presentation.showDetail && 'shrink-0')}>
-        {presentation.label}
-      </span>
-      {presentation.showDetail ? (
-        <>
-          <span className="text-muted-foreground/70" aria-hidden="true">
-            ·
-          </span>
-          <span className="min-w-0 truncate">{presentation.detail}</span>
-        </>
-      ) : null}
-    </button>
-  )
-}
-
-function getActionPresentation(option: ActiveOption): {
-  detail: string
-  icon: React.ReactNode
-  label: string
-  showDetail: boolean
-} {
-  if (option.kind === 'menu') {
-    const icon =
-      option.option.kind === 'new-browser' ? (
-        <Globe className="size-3.5 shrink-0" aria-hidden="true" />
-      ) : option.option.kind === 'new-markdown' ? (
-        <FilePlus className="size-3.5 shrink-0" aria-hidden="true" />
-      ) : option.option.kind === 'open-markdown' ? (
-        <FileText className="size-3.5 shrink-0" aria-hidden="true" />
-      ) : option.option.kind === 'new-simulator' || option.option.kind === 'go-to-simulator' ? (
-        <Smartphone className="size-3.5 shrink-0" aria-hidden="true" />
-      ) : (
-        <TerminalSquare className="size-3.5 shrink-0" aria-hidden="true" />
-      )
-    return {
-      detail: '',
-      icon,
-      label: option.option.label,
-      showDetail: false
-    }
+  const target = edge === 'first' ? items[0] : items.item(items.length - 1)
+  if (!target) {
+    return false
   }
-  if (option.kind === 'agent') {
-    return {
-      detail: option.option.label,
-      icon: <AgentIcon agent={option.option.agent} size={14} />,
-      label: translate('auto.components.tab.bar.TabBarCreateEntry.b27864279e', 'Launch agent'),
-      showDetail: true
-    }
-  }
-  const { classification } = option.option
-  if (classification.kind === 'explicit-url' || classification.kind === 'host-url') {
-    return {
-      detail: classification.url,
-      icon: <Globe className="size-3.5 shrink-0" aria-hidden="true" />,
-      label: translate('auto.components.tab.bar.TabBarCreateEntry.7cdf8ee0c8', 'Open URL'),
-      showDetail: true
-    }
-  }
-  if (classification.kind === 'existing-file') {
-    return {
-      detail: classification.relativePath,
-      icon: <FileText className="size-3.5 shrink-0" aria-hidden="true" />,
-      label: translate('auto.components.tab.bar.TabBarCreateEntry.25dc1cd653', 'Open file'),
-      showDetail: true
-    }
-  }
-  return {
-    detail: classification.relativePath,
-    icon: <FilePlus className="size-3.5 shrink-0" aria-hidden="true" />,
-    label: translate('auto.components.tab.bar.TabBarCreateEntry.d62d63b807', 'Create file'),
-    showDetail: true
-  }
+  target.focus()
+  return true
 }

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -1,0 +1,131 @@
+import React from 'react'
+import { FilePlus, FileText, Globe, Loader2, Smartphone, TerminalSquare } from 'lucide-react'
+import { AgentIcon } from '@/lib/agent-catalog'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { ActiveOption } from './tab-create-entry-active-option'
+
+export const RESULT_LISTBOX_ID = 'tab-create-entry-results'
+
+// Index-based (not the option id, which may contain spaces/slashes from file
+// paths) so it is always a valid aria-activedescendant IDREF.
+export function resultOptionDomId(index: number): string {
+  return `tab-create-entry-result-${index}`
+}
+
+export function EntryStatusRow({
+  loading = false,
+  message
+}: {
+  loading?: boolean
+  message: string
+}): React.JSX.Element {
+  return (
+    <div className="flex min-h-6 items-center gap-1.5 rounded-[7px] px-1 text-[11px] leading-5 text-muted-foreground">
+      {loading ? <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden="true" /> : null}
+      <span className="truncate">{message}</span>
+    </div>
+  )
+}
+
+export function EntryActionRow({
+  id,
+  onClick,
+  option,
+  selected
+}: {
+  id: string
+  onClick: () => void
+  option: ActiveOption
+  selected: boolean
+}): React.JSX.Element {
+  const presentation = getActionPresentation(option)
+
+  return (
+    <button
+      type="button"
+      id={id}
+      role="option"
+      aria-selected={selected}
+      className={cn(
+        'flex h-6 w-full items-center gap-1.5 rounded-[7px] px-1 text-left text-[11px] leading-5 outline-none',
+        selected
+          ? 'bg-black/8 text-accent-foreground dark:bg-white/14'
+          : 'text-muted-foreground hover:bg-black/8 hover:text-accent-foreground dark:hover:bg-white/14'
+      )}
+      onClick={onClick}
+    >
+      {presentation.icon}
+      <span className={cn('min-w-0 truncate font-medium', presentation.showDetail && 'shrink-0')}>
+        {presentation.label}
+      </span>
+      {presentation.showDetail ? (
+        <>
+          <span className="text-muted-foreground/70" aria-hidden="true">
+            ·
+          </span>
+          <span className="min-w-0 truncate">{presentation.detail}</span>
+        </>
+      ) : null}
+    </button>
+  )
+}
+
+function getActionPresentation(option: ActiveOption): {
+  detail: string
+  icon: React.ReactNode
+  label: string
+  showDetail: boolean
+} {
+  if (option.kind === 'menu') {
+    const icon =
+      option.option.kind === 'new-browser' ? (
+        <Globe className="size-3.5 shrink-0" aria-hidden="true" />
+      ) : option.option.kind === 'new-markdown' ? (
+        <FilePlus className="size-3.5 shrink-0" aria-hidden="true" />
+      ) : option.option.kind === 'open-markdown' ? (
+        <FileText className="size-3.5 shrink-0" aria-hidden="true" />
+      ) : option.option.kind === 'new-simulator' || option.option.kind === 'go-to-simulator' ? (
+        <Smartphone className="size-3.5 shrink-0" aria-hidden="true" />
+      ) : (
+        <TerminalSquare className="size-3.5 shrink-0" aria-hidden="true" />
+      )
+    return {
+      detail: '',
+      icon,
+      label: option.option.label,
+      showDetail: false
+    }
+  }
+  if (option.kind === 'agent') {
+    return {
+      detail: option.option.label,
+      icon: <AgentIcon agent={option.option.agent} size={14} />,
+      label: translate('auto.components.tab.bar.TabBarCreateEntry.b27864279e', 'Launch agent'),
+      showDetail: true
+    }
+  }
+  const { classification } = option.option
+  if (classification.kind === 'explicit-url' || classification.kind === 'host-url') {
+    return {
+      detail: classification.url,
+      icon: <Globe className="size-3.5 shrink-0" aria-hidden="true" />,
+      label: translate('auto.components.tab.bar.TabBarCreateEntry.7cdf8ee0c8', 'Open URL'),
+      showDetail: true
+    }
+  }
+  if (classification.kind === 'existing-file') {
+    return {
+      detail: classification.relativePath,
+      icon: <FileText className="size-3.5 shrink-0" aria-hidden="true" />,
+      label: translate('auto.components.tab.bar.TabBarCreateEntry.25dc1cd653', 'Open file'),
+      showDetail: true
+    }
+  }
+  return {
+    detail: classification.relativePath,
+    icon: <FilePlus className="size-3.5 shrink-0" aria-hidden="true" />,
+    label: translate('auto.components.tab.bar.TabBarCreateEntry.d62d63b807', 'Create file'),
+    showDetail: true
+  }
+}

--- a/src/renderer/src/components/tab-bar/query-token-match.test.ts
+++ b/src/renderer/src/components/tab-bar/query-token-match.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeMatchQuery, scoreQueryTokens, tokenizeMatchValue } from './query-token-match'
+
+describe('query token match', () => {
+  it('normalizes case and collapses whitespace', () => {
+    expect(normalizeMatchQuery('  New   Terminal ')).toBe('new terminal')
+  })
+
+  it('tokenizes on non-alphanumeric boundaries', () => {
+    expect(tokenizeMatchValue('GitHub Copilot-cli')).toEqual(['github', 'copilot', 'cli'])
+  })
+
+  it('ranks exact tokens above prefixes above substrings', () => {
+    const exact = scoreQueryTokens('terminal', ['terminal'])
+    const prefix = scoreQueryTokens('term', ['terminal'])
+    const substring = scoreQueryTokens('rmin', ['terminal'])
+    expect(exact.score).toBeGreaterThan(prefix.score)
+    expect(prefix.score).toBeGreaterThan(substring.score)
+    expect(substring.allTokensMatched).toBe(true)
+  })
+
+  it('reports unmatched query tokens', () => {
+    const result = scoreQueryTokens('new browser', ['new terminal'])
+    expect(result.allTokensMatched).toBe(false)
+  })
+
+  it('returns no score for empty inputs', () => {
+    expect(scoreQueryTokens('', ['terminal'])).toEqual({ allTokensMatched: false, score: 0 })
+    expect(scoreQueryTokens('terminal', [])).toEqual({ allTokensMatched: false, score: 0 })
+  })
+})

--- a/src/renderer/src/components/tab-bar/query-token-match.ts
+++ b/src/renderer/src/components/tab-bar/query-token-match.ts
@@ -1,0 +1,51 @@
+// Shared token matching for the new-tab open entry: the create-menu actions and
+// the agent launch options both rank a query against a set of candidate strings.
+
+export type QueryTokenMatch = {
+  allTokensMatched: boolean
+  score: number
+}
+
+export function normalizeMatchQuery(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+export function tokenizeMatchValue(value: string): string[] {
+  return normalizeMatchQuery(value)
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+}
+
+// Scores each query token against the best-matching candidate token: an exact
+// token wins over a prefix, which wins over a mid-string substring.
+export function scoreQueryTokens(query: string, values: readonly string[]): QueryTokenMatch {
+  const candidateTokens = values.flatMap(tokenizeMatchValue)
+  if (candidateTokens.length === 0) {
+    return { allTokensMatched: false, score: 0 }
+  }
+
+  const queryTokens = tokenizeMatchValue(query)
+  if (queryTokens.length === 0) {
+    return { allTokensMatched: false, score: 0 }
+  }
+
+  let score = 0
+  let allTokensMatched = true
+  for (const queryToken of queryTokens) {
+    let best = 0
+    for (const candidateToken of candidateTokens) {
+      if (candidateToken === queryToken) {
+        best = Math.max(best, 3)
+      } else if (candidateToken.startsWith(queryToken)) {
+        best = Math.max(best, 2)
+      } else if (candidateToken.includes(queryToken)) {
+        best = Math.max(best, 1)
+      }
+    }
+    if (best === 0) {
+      allTokensMatched = false
+    }
+    score += best
+  }
+  return { allTokensMatched, score }
+}

--- a/src/renderer/src/components/tab-bar/tab-agent-launch-options.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-launch-options.test.ts
@@ -30,4 +30,48 @@ describe('tab agent launch options', () => {
       ['antigravity']
     )
   })
+
+  it('matches agents on a partial prefix so the launcher actually searches', () => {
+    const options = buildTabAgentLaunchOptions(['claude', 'codex', 'gemini', 'antigravity'])
+
+    // Each is one character short of the full agent name.
+    expect(findMatchingTabAgentLaunchOptions('gemin', options).map((o) => o.agent)).toEqual([
+      'gemini'
+    ])
+    expect(findMatchingTabAgentLaunchOptions('clau', options).map((o) => o.agent)).toEqual([
+      'claude'
+    ])
+    expect(findMatchingTabAgentLaunchOptions('anti', options).map((o) => o.agent)).toEqual([
+      'antigravity'
+    ])
+  })
+
+  it('ranks an exact alias above weaker prefix matches', () => {
+    const options = buildTabAgentLaunchOptions(['codex', 'copilot', 'codebuff'])
+
+    // "co" prefixes all three; "codex" exactly matches one and must lead.
+    expect(findMatchingTabAgentLaunchOptions('codex', options)[0]?.agent).toBe('codex')
+    expect(findMatchingTabAgentLaunchOptions('co', options).map((o) => o.agent)).toEqual(
+      expect.arrayContaining(['codex', 'copilot', 'codebuff'])
+    )
+  })
+
+  it('does not match on a mid-string substring that would hijack file results', () => {
+    const options = buildTabAgentLaunchOptions(['opencode', 'claude'])
+
+    // "ode" is inside "opencode" but not a prefix — agents rank above files, so
+    // a noisy mid-string hit must not surface.
+    expect(findMatchingTabAgentLaunchOptions('ode', options)).toEqual([])
+  })
+
+  it('requires at least two characters before a prefix matches (no single-key flood)', () => {
+    const options = buildTabAgentLaunchOptions(['claude', 'codex', 'copilot', 'cursor'])
+
+    // A lone "c" must not surface (and auto-launch) an agent.
+    expect(findMatchingTabAgentLaunchOptions('c', options)).toEqual([])
+    // Two characters is enough to start searching.
+    expect(findMatchingTabAgentLaunchOptions('co', options).map((o) => o.agent)).toEqual(
+      expect.arrayContaining(['codex', 'copilot'])
+    )
+  })
 })

--- a/src/renderer/src/components/tab-bar/tab-agent-launch-options.ts
+++ b/src/renderer/src/components/tab-bar/tab-agent-launch-options.ts
@@ -1,4 +1,5 @@
 import { getAgentCatalog } from '@/lib/agent-catalog'
+import { normalizeMatchQuery, tokenizeMatchValue } from './query-token-match'
 import type { TuiAgent } from '../../../../shared/types'
 
 export type TabAgentLaunchOption = {
@@ -58,16 +59,62 @@ export function buildTabAgentLaunchOptions(
   })
 }
 
+// Scores how well a query matches an agent. Exact alias equality is the
+// strongest signal; otherwise every query token must prefix some alias token.
+// Why prefix-only (not substring): agent rows rank above file matches, so a
+// mid-string match like "ode" → "opencode" would noisily hijack the list.
+function scoreAgentLaunchOption(
+  normalizedQuery: string,
+  compactQuery: string,
+  option: TabAgentLaunchOption
+): number {
+  if (option.aliases.includes(normalizedQuery) || option.aliases.includes(compactQuery)) {
+    return 1000
+  }
+  const candidateTokens = option.aliases.flatMap(tokenizeMatchValue)
+  const queryTokens = tokenizeMatchValue(normalizedQuery)
+  if (queryTokens.length === 0 || candidateTokens.length === 0) {
+    return 0
+  }
+  let score = 0
+  for (const queryToken of queryTokens) {
+    let best = 0
+    for (const candidateToken of candidateTokens) {
+      if (candidateToken === queryToken) {
+        best = Math.max(best, 3)
+      } else if (queryToken.length >= 2 && candidateToken.startsWith(queryToken)) {
+        // Why: a single-character prefix matches almost every agent, flooding the
+        // list and letting one keystroke auto-launch the wrong agent; require an
+        // exact token match below 2 chars.
+        best = Math.max(best, 2)
+      }
+    }
+    if (best === 0) {
+      return 0
+    }
+    score += best
+  }
+  return score
+}
+
 export function findMatchingTabAgentLaunchOptions(
   query: string,
   agents: readonly TabAgentLaunchOption[]
 ): TabAgentLaunchOption[] {
-  const normalizedQuery = normalizeAgentAlias(query)
+  const normalizedQuery = normalizeMatchQuery(query)
   if (!normalizedQuery) {
     return []
   }
   const compactQuery = compactAgentAlias(query)
-  return agents.filter(
-    (option) => option.aliases.includes(normalizedQuery) || option.aliases.includes(compactQuery)
-  )
+  return agents
+    .map((option, index) => ({
+      index,
+      option,
+      score: scoreAgentLaunchOption(normalizedQuery, compactQuery, option)
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) =>
+      left.score !== right.score ? right.score - left.score : left.index - right.index
+    )
+    .map((entry) => entry.option)
 }

--- a/src/renderer/src/components/tab-bar/tab-create-entry-active-option.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-active-option.ts
@@ -1,0 +1,37 @@
+import type { TabEntryActionClassification, TabEntryOption } from './tab-create-entry-action'
+import type { TabAgentLaunchOption } from './tab-agent-launch-options'
+import type { TabCreateMenuOption } from './tab-create-menu-options'
+
+export type ActiveEntryOption = TabEntryOption & {
+  classification: TabEntryActionClassification
+}
+
+// A row the user can act on in the new-tab open entry: a create-menu action, a
+// matched agent to launch, or a file/URL entry.
+export type ActiveOption =
+  | {
+      kind: 'agent'
+      option: TabAgentLaunchOption
+    }
+  | {
+      kind: 'entry'
+      option: ActiveEntryOption
+    }
+  | {
+      kind: 'menu'
+      option: TabCreateMenuOption
+    }
+
+export function isActiveEntryOption(option: TabEntryOption): option is ActiveEntryOption {
+  return option.classification.kind !== 'empty' && option.classification.kind !== 'blocked'
+}
+
+export function getActiveOptionId(option: ActiveOption): string {
+  if (option.kind === 'agent') {
+    return `agent:${option.option.agent}`
+  }
+  if (option.kind === 'menu') {
+    return `menu:${option.option.id}`
+  }
+  return option.option.id
+}

--- a/src/renderer/src/components/tab-bar/tab-create-menu-options.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-menu-options.ts
@@ -1,4 +1,5 @@
 import { translate } from '@/i18n/i18n'
+import { normalizeMatchQuery, scoreQueryTokens } from './query-token-match'
 import type { BuiltInWindowsTerminalShell } from '../../../../shared/windows-terminal-shell'
 
 export type TabCreateMenuOptionKind =
@@ -28,58 +29,13 @@ export type TabCreateMenuOptionsContext = {
   windowsShellEntries?: readonly { label: string; shell: BuiltInWindowsTerminalShell }[]
 }
 
-function normalizeQuery(value: string): string {
-  return value.trim().toLowerCase().replace(/\s+/g, ' ')
-}
-
-function tokenize(value: string): string[] {
-  return normalizeQuery(value)
-    .split(/[^a-z0-9]+/)
-    .filter(Boolean)
-}
-
-function scoreQueryTokens(
-  query: string,
-  values: readonly string[]
-): { allTokensMatched: boolean; score: number } {
-  const candidateTokens = values.flatMap(tokenize)
-  if (candidateTokens.length === 0) {
-    return { allTokensMatched: false, score: 0 }
-  }
-
-  const queryTokens = tokenize(query)
-  if (queryTokens.length === 0) {
-    return { allTokensMatched: false, score: 0 }
-  }
-
-  let score = 0
-  let allTokensMatched = true
-  for (const queryToken of queryTokens) {
-    let best = 0
-    for (const candidateToken of candidateTokens) {
-      if (candidateToken === queryToken) {
-        best = Math.max(best, 3)
-      } else if (candidateToken.startsWith(queryToken)) {
-        best = Math.max(best, 2)
-      } else if (candidateToken.includes(queryToken)) {
-        best = Math.max(best, 1)
-      }
-    }
-    if (best === 0) {
-      allTokensMatched = false
-    }
-    score += best
-  }
-  return { allTokensMatched, score }
-}
-
 function scoreMenuOption(query: string, option: TabCreateMenuOption): number {
-  const normalizedQuery = normalizeQuery(query)
+  const normalizedQuery = normalizeMatchQuery(query)
   if (!normalizedQuery) {
     return 0
   }
   const values = [option.label, ...option.keywords]
-  const normalizedLabel = normalizeQuery(option.label)
+  const normalizedLabel = normalizeMatchQuery(option.label)
   if (normalizedQuery === normalizedLabel) {
     return 100
   }
@@ -207,7 +163,7 @@ export function findMatchingTabCreateMenuOptions(
   query: string,
   options: readonly TabCreateMenuOption[]
 ): TabCreateMenuOption[] {
-  const normalizedQuery = normalizeQuery(query)
+  const normalizedQuery = normalizeMatchQuery(query)
   if (!normalizedQuery) {
     return []
   }


### PR DESCRIPTION
## What & why

The **"Open any file, URL, agent, …"** new-tab entry (the `+` dropdown) had two bugs:

1. **It didn't actually search agents.** `findMatchingTabAgentLaunchOptions` only matched on **exact alias equality**, so a partial agent name surfaced nothing — you had to type the *entire* agent name. Typing `gemin` (one char short of `gemini`) dropped Gemini completely.
2. **The down arrow didn't move into the list.** Arrow navigation only ran when there were **more than one** result rows, and on the just-opened (empty-query) state focus was trapped in the input — so the agent/terminal list below was unreachable by keyboard, and nothing got highlighted.

## Changes

**Agent search (`tab-agent-launch-options.ts`)** — replaced exact-equality matching with prefix/token scoring:
- Exact alias (e.g. `gemini`, `agy`) ranks highest.
- Otherwise every query token must **prefix** an alias token. Mid-string substrings (e.g. `ode` → `opencode`) are rejected, and single-character prefixes are ignored, so agents — which rank above file matches — don't noisily hijack the list.
- The tokenizer is shared with the create-menu matcher via a new `query-token-match.ts`.

**Keyboard navigation (`TabBarCreateEntry.tsx`)**
- Arrows move the highlight for **any** result count (was `> 1`).
- With **no** result rows, ArrowDown/ArrowUp routes focus into the enclosing Radix menu's first/last item so the static create/agent list is keyboard-navigable from the search box.
- ArrowUp on the first menu item **returns focus to the search input**, so the trip isn't one-way.

**Accessibility** — the input is now a `combobox` with `aria-expanded` / `aria-controls` / `aria-autocomplete`, the result list is a `listbox`, and each row is an `option` with `aria-selected`. `aria-activedescendant` tracks the highlighted row so the arrow-key highlight is exposed to assistive tech.

**Refactor** — split the row presentation (`TabBarCreateEntryRow.tsx`) and the option types (`tab-create-entry-active-option.ts`) into focused modules to keep the component under the line cap (no lint disables).

### Design note
Prefix-matched agents are kept **ranked above file results** (and the top row stays auto-highlighted) because the request was to make agents *searchable and prominent*. The single-character guard + the new ARIA announcement keep a short prefix from *silently* changing what Enter does.

## Evidence (verified in a running dev build via CDP)

**Issue 1 — agent search**
| | Before | After |
|---|---|---|
| type `gemin` (partial) | only file matches; **no Gemini** | **`Launch agent · Gemini`** is the top row |
| type `clau` | nothing | **Claude** + **Claude Agent Teams** both surface |
| type `gemini` (exact) | Gemini shown | Gemini shown (unchanged) |

DOM check for `gemin`: `aria-expanded="true"`, `aria-activedescendant="tab-create-entry-result-0"`, first option text `Launch agent·Gemini`, `aria-selected="true"`.

**Issue 2 — arrow navigation (empty query)**
| | Before | After |
|---|---|---|
| ArrowDown | nothing highlighted | focus → `menuitem "New Terminal"` |
| ArrowDown ×5 | nothing | iterates to `menuitem "Codex"` |
| ArrowUp on first item | n/a | focus returns to the search input (`role=combobox`) |

_Screenshots of each before/after state were captured during verification; per repo policy evidence images aren't committed — happy to attach them to this PR conversation._

## Test plan
- `query-token-match.test.ts` — shared tokenizer (exact > prefix > substring, unmatched tokens, empty inputs).
- `tab-agent-launch-options.test.ts` — partial-prefix matching, exact-over-prefix ranking, mid-string rejection, single-char guard (existing exact-match cases still pass).
- `TabBarCreateEntry.keyboard.test.tsx` — single-option interception (asserts `defaultPrevented`, which fails under the old `> 1` guard), multi-option iteration + wrap, agent launch from a partial query, `aria-activedescendant` updates, routing into the menu, and ArrowUp return-to-input.
- All **117** tab-bar tests pass; `typecheck:web` and the full `lint` suite (oxlint + react-doctor + localization) are green.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5817">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->