### PR TITLE
fix(crash-reporting): bound coalescedBreadcrumbs with TTL prune + LRU cap

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-store-leak.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store-leak.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Memory-leak regression: the coalesced-breadcrumb map must stay bounded.
+ *
+ * `recordCoalescedCrashBreadcrumb` does `coalescedBreadcrumbs.set(coalesceKey, …)`
+ * with no TTL prune and no size cap. Production keys are `agent:${agentType}:${state}`,
+ * and agentType reaches this store (via relay/SSH ingestRemote + OSC observed-status)
+ * as an OPEN string — only length-trimmed to 40 chars, never enum-checked — so the key
+ * space is unbounded over a long multi-agent/SSH session. The only shrink path was the
+ * test-only clear. (The sibling `breadcrumbs` array is already bounded to 30.)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  recordCoalescedCrashBreadcrumb,
+  clearCrashBreadcrumbsForTest,
+  getCoalescedKeyCountForTest
+} from './crash-breadcrumb-store'
+
+// MAX_COALESCE_KEYS is module-private; mirror its value here.
+const MAX_COALESCE_KEYS = 128
+
+describe('coalescedBreadcrumbs stays bounded (leak regression)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    clearCrashBreadcrumbsForTest()
+  })
+
+  afterEach(() => {
+    clearCrashBreadcrumbsForTest()
+    vi.useRealTimers()
+  })
+
+  it('caps the map even with an unbounded stream of distinct agentType keys', () => {
+    // No time advance, so nothing coalesces or TTL-prunes — pure cap pressure.
+    for (let i = 0; i < 1000; i++) {
+      recordCoalescedCrashBreadcrumb({
+        name: 'agent_state',
+        coalesceKey: `agent:type-${i}:working`,
+        minIntervalMs: 30_000
+      })
+    }
+    expect(getCoalescedKeyCountForTest()).toBeLessThanOrEqual(MAX_COALESCE_KEYS)
+  })
+
+  it('still coalesces repeated breadcrumbs for the same key within the interval', () => {
+    recordCoalescedCrashBreadcrumb({ name: 'x', coalesceKey: 'k', minIntervalMs: 30_000 })
+    recordCoalescedCrashBreadcrumb({ name: 'x', coalesceKey: 'k', minIntervalMs: 30_000 })
+    // Second call is suppressed within the interval — one key, no growth.
+    expect(getCoalescedKeyCountForTest()).toBe(1)
+  })
+
+  it('keeps the most-recently-recorded key after capping', () => {
+    for (let i = 0; i < MAX_COALESCE_KEYS + 50; i++) {
+      recordCoalescedCrashBreadcrumb({
+        name: 'agent_state',
+        coalesceKey: `agent:type-${i}:working`,
+        minIntervalMs: 30_000
+      })
+    }
+    // The newest key survives; record it again — still suppressed (still present).
+    recordCoalescedCrashBreadcrumb({
+      name: 'agent_state',
+      coalesceKey: `agent:type-${MAX_COALESCE_KEYS + 49}:working`,
+      minIntervalMs: 30_000
+    })
+    expect(getCoalescedKeyCountForTest()).toBeLessThanOrEqual(MAX_COALESCE_KEYS)
+  })
+})

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -5,6 +5,10 @@ import {
 } from '../../shared/crash-reporting'
 
 const MAX_BREADCRUMBS = 30
+// Why: coalesceKey embeds an open-string agentType (length-trimmed only, never
+// enum-checked), so the key space is unbounded over a long multi-agent/SSH session.
+// Bound the coalesce map the same way ProcessGoneDedupe bounds its key map.
+const MAX_COALESCE_KEYS = 128
 
 let breadcrumbs: CrashReportBreadcrumb[] = []
 let coalescedBreadcrumbs = new Map<string, { recordedAt: number; suppressed: number }>()
@@ -45,7 +49,23 @@ export function recordCoalescedCrashBreadcrumb({
     return
   }
 
+  // Drop entries past their suppression window (they can no longer coalesce
+  // anything) and LRU-cap the rest. delete-then-set keeps insertion order =
+  // recency so only genuinely idle keys are evicted.
+  for (const [key, entry] of coalescedBreadcrumbs) {
+    if (now - entry.recordedAt >= minIntervalMs) {
+      coalescedBreadcrumbs.delete(key)
+    }
+  }
+  coalescedBreadcrumbs.delete(coalesceKey)
   coalescedBreadcrumbs.set(coalesceKey, { recordedAt: now, suppressed: 0 })
+  while (coalescedBreadcrumbs.size > MAX_COALESCE_KEYS) {
+    const oldest = coalescedBreadcrumbs.keys().next()
+    if (oldest.done) {
+      break
+    }
+    coalescedBreadcrumbs.delete(oldest.value)
+  }
   recordCrashBreadcrumb(
     name,
     previous?.suppressed ? { ...data, suppressedSinceLast: previous.suppressed } : data
@@ -62,4 +82,8 @@ export function getCrashBreadcrumbSnapshot(): CrashReportBreadcrumb[] {
 export function clearCrashBreadcrumbsForTest(): void {
   breadcrumbs = []
   coalescedBreadcrumbs = new Map()
+}
+
+export function getCoalescedKeyCountForTest(): number {
+  return coalescedBreadcrumbs.size
 }


### PR DESCRIPTION
## Leak

`recordCoalescedCrashBreadcrumb` does `coalescedBreadcrumbs.set(coalesceKey, …)` with **no TTL prune and no size cap**. Production keys are `agent:${agentType}:${state}`, and `agentType` reaches this store (via the relay/SSH `ingestRemote` and OSC observed-status paths through `normalizeAgentStatusPayload`) as an **open string** — only length-trimmed to 40 chars, never enum-checked — so the key space is unbounded over a long multi-agent/SSH session. The only shrink path was the test-only `clearCrashBreadcrumbsForTest`. (The sibling `breadcrumbs` array is already bounded to `MAX_BREADCRUMBS = 30` — the unbounded map was the oversight.)

## Fix

In `recordCoalescedCrashBreadcrumb`, after the suppression check: prune entries past their suppression window (`now - recordedAt >= minIntervalMs` — provably inert, can no longer coalesce anything), then enforce an LRU cap of `MAX_COALESCE_KEYS = 128` (`delete`-then-`set` the live key so insertion order tracks recency; evict the oldest while over the cap). This mirrors the `prune()` / `maxKeys` idiom already used by `ProcessGoneDedupe` in the same directory.

## Evidence of the leak (regression test FAILS before the fix)

`crash-breadcrumb-store-leak.test.ts` against the **unfixed** code (fake timers, no advance, so nothing coalesces — pure cap pressure):

```
× caps the map even with an unbounded stream of distinct agentType keys
   AssertionError: expected 1000 to be less than or equal to 128
× keeps the most-recently-recorded key after capping
   AssertionError: expected 178 to be less than or equal to 128
 Tests  2 failed | 1 passed (3)
```

1000 distinct agentType keys → 1000 map entries.

## Evidence the leak is resolved (test PASSES after the fix)

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

The map stays ≤ 128 under unbounded distinct keys, and still coalesces repeated breadcrumbs for the same key within the interval.

## No functional regression

```
src/main/crash-reporting/crash-breadcrumb-store.test.ts
 Tests  4 passed (4)
```

The TTL prune only deletes entries past `minIntervalMs` (provably inert), so a still-live entry is never wrongly evicted — the existing "coalesces repeated breadcrumbs inside the interval" test guards within-window suppression. The cap only triggers above 128 live keys, far above any single agent's working set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5818">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->