### PR TITLE
Fix desktop resize and long-thread jitter

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -239,6 +239,49 @@ describe('createMainWindow', () => {
     expect(attachGuestPoliciesMock).toHaveBeenCalledWith(guest)
   })
 
+  it('notifies the renderer when the window minimizes and restores', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => false),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      unmaximize: vi.fn(),
+      minimize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null, { deferLoad: true })
+
+    windowHandlers.minimize?.()
+    windowHandlers.restore?.()
+
+    expect(webContents.send).toHaveBeenCalledWith('window:minimized-changed', true)
+    expect(webContents.send).toHaveBeenCalledWith('window:minimized-changed', false)
+  })
+
   it('sets platform-specific titlebar and frame options for every desktop platform', () => {
     for (const [platform, expected] of [
       ['darwin', { titleBarStyle: 'hiddenInset', frame: undefined }],

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -301,9 +301,6 @@ export function createMainWindow(
     // visibility transitions hardens Orca against black-surface failures during
     // browser-tab restore and tab switching.
     mainWindow.webContents.setBackgroundThrottling(false)
-    mainWindow.on('restore', () => {
-      forceRepaint(mainWindow)
-    })
     mainWindow.on('show', () => {
       forceRepaint(mainWindow)
     })
@@ -440,6 +437,16 @@ export function createMainWindow(
 
   mainWindow.on('leave-full-screen', () => {
     mainWindow.webContents.send('window:fullscreen-changed', false)
+  })
+
+  mainWindow.on('minimize', () => {
+    mainWindow.webContents.send('window:minimized-changed', true)
+  })
+  mainWindow.on('restore', () => {
+    mainWindow.webContents.send('window:minimized-changed', false)
+    if (process.platform === 'darwin') {
+      forceRepaint(mainWindow)
+    }
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2475,6 +2475,7 @@ export type PreloadApi = {
       callback: (payload: RichMarkdownContextMenuCommandPayload) => void
     ) => () => void
     onFullscreenChanged: (callback: (isFullScreen: boolean) => void) => () => void
+    onMinimizedChanged: (callback: (isMinimized: boolean) => void) => () => void
     minimize: () => void
     maximize: () => void
     isMaximized: () => Promise<boolean>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3244,6 +3244,12 @@ const api = {
       ipcRenderer.on('window:fullscreen-changed', listener)
       return () => ipcRenderer.removeListener('window:fullscreen-changed', listener)
     },
+    onMinimizedChanged: (callback: (isMinimized: boolean) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, isMinimized: boolean) =>
+        callback(isMinimized)
+      ipcRenderer.on('window:minimized-changed', listener)
+      return () => ipcRenderer.removeListener('window:minimized-changed', listener)
+    },
     /** Desktop custom titlebar only: minimize via renderer-drawn window controls. */
     minimize: (): void => {
       ipcRenderer.send('window:minimize')

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1467,6 +1467,8 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     overscan: ACTIVITY_THREAD_VIRTUALIZER_OVERSCAN,
     rangeExtractor: useCallback(
       (range: Range) => {
+        // Why: keep the nearest previous group header mounted so the active
+        // sticky header remains stable while virtual rows scroll underneath.
         const activeStickyIndex = getActiveActivityThreadStickyIndex(
           stickyThreadGroupIndexes,
           range.startIndex

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -60,6 +60,7 @@ import {
   type ActivityTerminalPortalTarget
 } from './activity-terminal-portal'
 import {
+  ACTIVITY_THREAD_VIRTUALIZER_OVERSCAN,
   buildActivityThreadVirtualRows,
   estimateActivityThreadVirtualRowSize,
   getActiveActivityThreadStickyIndex,
@@ -1463,7 +1464,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     getItemKey: (index) => virtualThreadRows[index]?.key ?? index,
     estimateSize: (index) =>
       estimateActivityThreadVirtualRowSize(virtualThreadRows[index], compactMode),
-    overscan: 8,
+    overscan: ACTIVITY_THREAD_VIRTUALIZER_OVERSCAN,
     rangeExtractor: useCallback(
       (range: Range) => {
         const activeStickyIndex = getActiveActivityThreadStickyIndex(

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable max-lines -- Why: this prototype keeps the real-data adapter
 and current visual skeleton together until the next refinement pass decides
 which pieces become production modules. */
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  defaultRangeExtractor,
+  useVirtualizer,
+  type Range,
+  type VirtualItem
+} from '@tanstack/react-virtual'
 import { useShallow } from 'zustand/react/shallow'
 import {
   Bell,
@@ -53,6 +59,12 @@ import {
   setActivityTerminalPortals,
   type ActivityTerminalPortalTarget
 } from './activity-terminal-portal'
+import {
+  buildActivityThreadVirtualRows,
+  estimateActivityThreadVirtualRowSize,
+  getActiveActivityThreadStickyIndex,
+  getActivityThreadStickyIndexes
+} from './activity-thread-virtual-rows'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import {
@@ -124,6 +136,10 @@ type ActivityThreadGroup = {
   state?: AgentStatusState
   threads: AgentPaneThread[]
 }
+
+type ActivityThreadVirtualRowModel = ReturnType<
+  typeof buildActivityThreadVirtualRows<AgentPaneThread, ActivityThreadGroup>
+>[number]
 
 type ActivityTerminalPortalReadiness = {
   target: HTMLElement | null
@@ -1027,7 +1043,7 @@ function ThreadAgentStateIndicator({ thread }: { thread: AgentPaneThread }): Rea
 
 function ActivityStatusGroupHeader({ group }: { group: ActivityThreadGroup }): React.JSX.Element {
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-3 py-1.5 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+    <div className="flex items-center gap-2 border-b border-border bg-background/95 px-3 py-1.5 backdrop-blur supports-[backdrop-filter]:bg-background/80">
       {group.state ? (
         <span className="inline-flex size-4 shrink-0 items-center justify-center">
           <AgentStateDot state={group.state} size="sm" />
@@ -1259,6 +1275,69 @@ function ThreadRow({
   )
 }
 
+function ActivityThreadVirtualRow({
+  row,
+  virtualItem,
+  activeStickyIndex,
+  selectedPaneKey,
+  compactMode,
+  canJumpToWorktree,
+  measureElement,
+  onSelectThread,
+  onJumpToWorkspace,
+  onMarkThreadUnread
+}: {
+  row: ActivityThreadVirtualRowModel
+  virtualItem: VirtualItem
+  activeStickyIndex: number | null
+  selectedPaneKey: string | null
+  compactMode: boolean
+  canJumpToWorktree: (worktreeId: string) => boolean
+  measureElement: (node: HTMLDivElement | null) => void
+  onSelectThread: (thread: AgentPaneThread) => void
+  onJumpToWorkspace: (thread: AgentPaneThread) => void
+  onMarkThreadUnread: (thread: AgentPaneThread) => void
+}): React.JSX.Element {
+  const isActiveSticky = row.kind === 'group' && activeStickyIndex === virtualItem.index
+  return (
+    <div
+      ref={measureElement}
+      data-index={virtualItem.index}
+      className={cn('left-0 w-full', isActiveSticky ? 'sticky z-20' : 'absolute')}
+      style={
+        isActiveSticky
+          ? { top: 0 }
+          : {
+              top: 0,
+              transform: `translateY(${virtualItem.start}px)`
+            }
+      }
+    >
+      {row.kind === 'group' ? (
+        <section
+          aria-label={translate(
+            'auto.components.activity.ActivityPrototypePage.a2b4437bfb',
+            '{{value0}} activity',
+            { value0: row.group.label }
+          )}
+        >
+          <ActivityStatusGroupHeader group={row.group} />
+        </section>
+      ) : (
+        <ThreadRow
+          thread={row.thread}
+          selected={row.thread.paneKey === selectedPaneKey}
+          onSelect={() => onSelectThread(row.thread)}
+          onJump={() => onJumpToWorkspace(row.thread)}
+          onMarkUnread={() => onMarkThreadUnread(row.thread)}
+          canJump={canJumpToWorktree(row.thread.worktree.id)}
+          compactMode={compactMode}
+        />
+      )}
+    </div>
+  )
+}
+
 export default function ActivityPrototypePage(): React.JSX.Element {
   const [readFilter, setReadFilter] = useState<ThreadReadFilter>('all')
   const [groupBy, setGroupBy] = useState<ActivityGroupBy>('status')
@@ -1270,6 +1349,8 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     useState<ActivityTerminalPortalSlotId>('primary')
   const [primaryPortalTargetEl, setPrimaryPortalTargetEl] = useState<HTMLElement | null>(null)
   const [secondaryPortalTargetEl, setSecondaryPortalTargetEl] = useState<HTMLElement | null>(null)
+  const threadScrollParentRef = useRef<HTMLDivElement | null>(null)
+  const activeStickyThreadGroupIndexRef = useRef<number | null>(null)
   // Why (default width): the thread cards are the primary surface in the
   // Activity view; the terminal is supplementary. A narrow list squeezed the
   // prompts to truncated single-liners and made the per-card actions feel
@@ -1326,6 +1407,10 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [storeData, agentStatusEpoch]
   )
+  const canJumpToWorktree = useCallback(
+    (worktreeId: string) => storeData.worktreeMap.has(worktreeId),
+    [storeData.worktreeMap]
+  )
 
   const allThreads = useMemo(
     () => buildAgentPaneThreads({ events: allEvents, liveAgentByPaneKey }),
@@ -1360,6 +1445,48 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     () => buildActivityThreadGroups(visibleThreads, groupBy),
     [visibleThreads, groupBy]
   )
+  const virtualThreadRows = useMemo(
+    () =>
+      buildActivityThreadVirtualRows<AgentPaneThread, ActivityThreadGroup>(
+        visibleThreadGroups,
+        (thread) => thread.paneKey
+      ),
+    [visibleThreadGroups]
+  )
+  const stickyThreadGroupIndexes = useMemo(
+    () => getActivityThreadStickyIndexes(virtualThreadRows),
+    [virtualThreadRows]
+  )
+  const threadRowVirtualizer = useVirtualizer({
+    count: virtualThreadRows.length,
+    getScrollElement: () => threadScrollParentRef.current,
+    getItemKey: (index) => virtualThreadRows[index]?.key ?? index,
+    estimateSize: (index) =>
+      estimateActivityThreadVirtualRowSize(virtualThreadRows[index], compactMode),
+    overscan: 8,
+    rangeExtractor: useCallback(
+      (range: Range) => {
+        const activeStickyIndex = getActiveActivityThreadStickyIndex(
+          stickyThreadGroupIndexes,
+          range.startIndex
+        )
+        activeStickyThreadGroupIndexRef.current = activeStickyIndex
+        if (activeStickyIndex === null) {
+          return defaultRangeExtractor(range)
+        }
+        const next = new Set([activeStickyIndex, ...defaultRangeExtractor(range)])
+        return [...next].sort((a, b) => a - b)
+      },
+      [stickyThreadGroupIndexes]
+    )
+  })
+  const virtualThreadItems = threadRowVirtualizer.getVirtualItems()
+
+  useLayoutEffect(() => {
+    // Why: compact mode changes row height without changing row identity, so
+    // TanStack's measured cache must be refreshed when the density flips.
+    threadRowVirtualizer.measure()
+  }, [compactMode, threadRowVirtualizer])
 
   const selectedThread = effectiveSelectedPaneKey
     ? (allThreads.find((thread) => thread.paneKey === effectiveSelectedPaneKey) ?? null)
@@ -1770,31 +1897,33 @@ export default function ActivityPrototypePage(): React.JSX.Element {
               </DropdownMenu>
             </div>
           </div>
-          <div className="min-h-0 flex-1 overflow-auto scrollbar-sleek">
-            {visibleThreadGroups.map((group) => (
-              <section
-                key={group.key}
-                aria-label={translate(
-                  'auto.components.activity.ActivityPrototypePage.a2b4437bfb',
-                  '{{value0}} activity',
-                  { value0: group.label }
-                )}
-              >
-                <ActivityStatusGroupHeader group={group} />
-                {group.threads.map((thread) => (
-                  <ThreadRow
-                    key={thread.paneKey}
-                    thread={thread}
-                    selected={thread.paneKey === selectedThread?.paneKey}
-                    onSelect={() => selectThread(thread)}
-                    onJump={() => jumpToWorkspace(thread)}
-                    onMarkUnread={() => markThreadUnread(thread)}
-                    canJump={storeData.worktreeMap.has(thread.worktree.id)}
+          <div ref={threadScrollParentRef} className="min-h-0 flex-1 overflow-auto scrollbar-sleek">
+            <div
+              className="relative w-full"
+              style={{ height: `${threadRowVirtualizer.getTotalSize()}px` }}
+            >
+              {virtualThreadItems.map((virtualItem) => {
+                const row = virtualThreadRows[virtualItem.index]
+                if (!row) {
+                  return null
+                }
+                return (
+                  <ActivityThreadVirtualRow
+                    key={virtualItem.key}
+                    row={row}
+                    virtualItem={virtualItem}
+                    activeStickyIndex={activeStickyThreadGroupIndexRef.current}
+                    selectedPaneKey={selectedThread?.paneKey ?? null}
                     compactMode={compactMode}
+                    canJumpToWorktree={canJumpToWorktree}
+                    measureElement={threadRowVirtualizer.measureElement}
+                    onSelectThread={selectThread}
+                    onJumpToWorkspace={jumpToWorkspace}
+                    onMarkThreadUnread={markThreadUnread}
                   />
-                ))}
-              </section>
-            ))}
+                )
+              })}
+            </div>
             {visibleThreads.length === 0 ? (
               <div className="px-3 py-8 text-sm text-muted-foreground">
                 {translate(

--- a/src/renderer/src/components/activity/activity-thread-virtual-rows.test.ts
+++ b/src/renderer/src/components/activity/activity-thread-virtual-rows.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildActivityThreadVirtualRows,
+  estimateActivityThreadVirtualRowSize,
+  getActiveActivityThreadStickyIndex,
+  getActivityThreadStickyIndexes
+} from './activity-thread-virtual-rows'
+
+type TestThread = {
+  paneKey: string
+}
+
+describe('activity thread virtual rows', () => {
+  it('flattens grouped threads into stable header and row keys', () => {
+    const rows = buildActivityThreadVirtualRows<TestThread>(
+      [
+        {
+          key: 'working',
+          label: 'Working',
+          threads: [{ paneKey: 'pane-a' }, { paneKey: 'pane-b' }]
+        },
+        {
+          key: 'done',
+          label: 'Done',
+          threads: [{ paneKey: 'pane-c' }]
+        }
+      ],
+      (thread) => thread.paneKey
+    )
+
+    expect(rows.map((row) => row.key)).toEqual([
+      'group:working',
+      'thread:pane-a',
+      'thread:pane-b',
+      'group:done',
+      'thread:pane-c'
+    ])
+    expect(getActivityThreadStickyIndexes(rows)).toEqual([0, 3])
+  })
+
+  it('selects the nearest previous group header as the active sticky row', () => {
+    expect(getActiveActivityThreadStickyIndex([0, 3, 8], 0)).toBe(0)
+    expect(getActiveActivityThreadStickyIndex([0, 3, 8], 6)).toBe(3)
+    expect(getActiveActivityThreadStickyIndex([0, 3, 8], 12)).toBe(8)
+    expect(getActiveActivityThreadStickyIndex([], 12)).toBeNull()
+  })
+
+  it('estimates compact rows smaller than regular rows', () => {
+    const rows = buildActivityThreadVirtualRows<TestThread>(
+      [{ key: 'working', label: 'Working', threads: [{ paneKey: 'pane-a' }] }],
+      (thread) => thread.paneKey
+    )
+
+    expect(estimateActivityThreadVirtualRowSize(rows[0], false)).toBeLessThan(
+      estimateActivityThreadVirtualRowSize(rows[1], false)
+    )
+    expect(estimateActivityThreadVirtualRowSize(rows[1], true)).toBeLessThan(
+      estimateActivityThreadVirtualRowSize(rows[1], false)
+    )
+  })
+})

--- a/src/renderer/src/components/activity/activity-thread-virtual-rows.test.ts
+++ b/src/renderer/src/components/activity/activity-thread-virtual-rows.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
+  ACTIVITY_THREAD_COMPACT_ROW_ESTIMATE_PX,
+  ACTIVITY_THREAD_GROUP_ROW_ESTIMATE_PX,
+  ACTIVITY_THREAD_REGULAR_ROW_ESTIMATE_PX,
+  ACTIVITY_THREAD_VIRTUALIZER_OVERSCAN,
   buildActivityThreadVirtualRows,
   estimateActivityThreadVirtualRowSize,
   getActiveActivityThreadStickyIndex,
@@ -57,5 +61,18 @@ describe('activity thread virtual rows', () => {
     expect(estimateActivityThreadVirtualRowSize(rows[1], true)).toBeLessThan(
       estimateActivityThreadVirtualRowSize(rows[1], false)
     )
+    expect(estimateActivityThreadVirtualRowSize(rows[0], false)).toBe(
+      ACTIVITY_THREAD_GROUP_ROW_ESTIMATE_PX
+    )
+    expect(estimateActivityThreadVirtualRowSize(rows[1], true)).toBe(
+      ACTIVITY_THREAD_COMPACT_ROW_ESTIMATE_PX
+    )
+    expect(estimateActivityThreadVirtualRowSize(rows[1], false)).toBe(
+      ACTIVITY_THREAD_REGULAR_ROW_ESTIMATE_PX
+    )
+  })
+
+  it('keeps enough overscan for fast scrolling before low-end devices measure rows', () => {
+    expect(ACTIVITY_THREAD_VIRTUALIZER_OVERSCAN).toBeGreaterThanOrEqual(12)
   })
 })

--- a/src/renderer/src/components/activity/activity-thread-virtual-rows.ts
+++ b/src/renderer/src/components/activity/activity-thread-virtual-rows.ts
@@ -18,9 +18,13 @@ export type ActivityThreadVirtualRow<TGroup, TThread> =
       thread: TThread
     }
 
-const ACTIVITY_THREAD_GROUP_ROW_ESTIMATE_PX = 30
-const ACTIVITY_THREAD_COMPACT_ROW_ESTIMATE_PX = 58
-const ACTIVITY_THREAD_REGULAR_ROW_ESTIMATE_PX = 84
+// Why: these estimates intentionally mirror the Activity row CSS and skew
+// slightly high; TanStack corrects with measured elements, while underestimates
+// are more likely to expose blank space during fast first-pass scrolling.
+export const ACTIVITY_THREAD_GROUP_ROW_ESTIMATE_PX = 30
+export const ACTIVITY_THREAD_COMPACT_ROW_ESTIMATE_PX = 66
+export const ACTIVITY_THREAD_REGULAR_ROW_ESTIMATE_PX = 112
+export const ACTIVITY_THREAD_VIRTUALIZER_OVERSCAN = 12
 
 export function buildActivityThreadVirtualRows<
   TThread,

--- a/src/renderer/src/components/activity/activity-thread-virtual-rows.ts
+++ b/src/renderer/src/components/activity/activity-thread-virtual-rows.ts
@@ -1,0 +1,87 @@
+export type ActivityThreadVirtualGroup<TThread> = {
+  key: string
+  label: string
+  threads: TThread[]
+}
+
+export type ActivityThreadVirtualRow<TGroup, TThread> =
+  | {
+      kind: 'group'
+      key: string
+      groupKey: string
+      group: TGroup
+    }
+  | {
+      kind: 'thread'
+      key: string
+      groupKey: string
+      thread: TThread
+    }
+
+const ACTIVITY_THREAD_GROUP_ROW_ESTIMATE_PX = 30
+const ACTIVITY_THREAD_COMPACT_ROW_ESTIMATE_PX = 58
+const ACTIVITY_THREAD_REGULAR_ROW_ESTIMATE_PX = 84
+
+export function buildActivityThreadVirtualRows<
+  TThread,
+  TGroup extends ActivityThreadVirtualGroup<TThread> = ActivityThreadVirtualGroup<TThread>
+>(
+  groups: TGroup[],
+  getThreadKey: (thread: TThread) => string
+): ActivityThreadVirtualRow<TGroup, TThread>[] {
+  const rows: ActivityThreadVirtualRow<TGroup, TThread>[] = []
+  for (const group of groups) {
+    rows.push({
+      kind: 'group',
+      key: `group:${group.key}`,
+      groupKey: group.key,
+      group
+    })
+    for (const thread of group.threads) {
+      rows.push({
+        kind: 'thread',
+        key: `thread:${getThreadKey(thread)}`,
+        groupKey: group.key,
+        thread
+      })
+    }
+  }
+  return rows
+}
+
+export function getActivityThreadStickyIndexes<TGroup, TThread>(
+  rows: ActivityThreadVirtualRow<TGroup, TThread>[]
+): number[] {
+  const indexes: number[] = []
+  rows.forEach((row, index) => {
+    if (row.kind === 'group') {
+      indexes.push(index)
+    }
+  })
+  return indexes
+}
+
+export function getActiveActivityThreadStickyIndex(
+  stickyIndexes: readonly number[],
+  startIndex: number
+): number | null {
+  for (let index = stickyIndexes.length - 1; index >= 0; index -= 1) {
+    const stickyIndex = stickyIndexes[index]
+    if (stickyIndex <= startIndex) {
+      return stickyIndex
+    }
+  }
+  return stickyIndexes[0] ?? null
+}
+
+export function estimateActivityThreadVirtualRowSize<TGroup, TThread>(
+  row: ActivityThreadVirtualRow<TGroup, TThread> | undefined,
+  compactMode: boolean
+): number {
+  if (!row || row.kind === 'group') {
+    return ACTIVITY_THREAD_GROUP_ROW_ESTIMATE_PX
+  }
+  return compactMode
+    ? ACTIVITY_THREAD_COMPACT_ROW_ESTIMATE_PX
+    : ACTIVITY_THREAD_REGULAR_ROW_ESTIMATE_PX
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -128,6 +128,15 @@ type MockTransport = {
   serializeBuffer?: ReturnType<typeof vi.fn>
 }
 
+class MockCustomEvent<T> extends Event {
+  detail: T
+
+  constructor(type: string, init: { detail: T }) {
+    super(type)
+    this.detail = init.detail
+  }
+}
+
 const scheduleRuntimeGraphSync = vi.fn()
 const shouldSeedCacheTimerOnInitialTitle = vi.fn(() => false)
 
@@ -626,6 +635,56 @@ describe('connectPanePty', () => {
         cacheKey: 'repo1:windows-host'
       }
     })
+  })
+
+  it('coalesces terminal resize forwarding while a pane resize hold is active', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { holdPtyResizesForPaneSubtrees } =
+      await import('@/lib/pane-manager/pane-pty-resize-hold')
+    const originalCustomEvent = globalThis.CustomEvent
+    globalThis.CustomEvent = MockCustomEvent as unknown as typeof CustomEvent
+    const transport = createMockTransport('pty-id')
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+    const capturedOnResize: {
+      current: ((size: { cols: number; rows: number }) => void) | null
+    } = { current: null }
+    ;(pane.terminal.onResize as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (listener: (size: { cols: number; rows: number }) => void) => {
+        capturedOnResize.current = listener
+        return { dispose: vi.fn() }
+      }
+    )
+    try {
+      const disposable = connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(6)
+      transport.resize.mockClear()
+      if (!capturedOnResize.current) {
+        throw new Error('expected terminal resize listener to be registered')
+      }
+
+      const root = {
+        classList: { contains: () => false },
+        querySelectorAll: () => [pane.container]
+      } as unknown as HTMLElement
+      const releaseResizeHold = holdPtyResizesForPaneSubtrees([root])
+
+      capturedOnResize.current({ cols: 100, rows: 30 })
+      capturedOnResize.current({ cols: 120, rows: 32 })
+
+      expect(transport.resize).not.toHaveBeenCalledWith(100, 30)
+      expect(transport.resize).not.toHaveBeenCalledWith(120, 32)
+
+      releaseResizeHold.flush()
+
+      expect(transport.resize).toHaveBeenCalledTimes(1)
+      expect(transport.resize).toHaveBeenCalledWith(120, 32)
+      disposable.dispose()
+    } finally {
+      globalThis.CustomEvent = originalCustomEvent
+    }
   })
 
   it('observes live terminal GitHub PR URLs before agent completion', async () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
@@ -16,7 +16,9 @@ import {
 
 const mocks = vi.hoisted(() => ({
   cleanupCallbacks: [] as (() => void)[],
-  fitPanes: vi.fn()
+  fitPanes: vi.fn(),
+  minimizedChangedCallbacks: [] as ((isMinimized: boolean) => void)[],
+  unsubscribeMinimizedChanged: vi.fn()
 }))
 
 vi.mock('react', async (importOriginal) => {
@@ -69,8 +71,18 @@ describe('useTerminalContainerFitSync', () => {
     vi.stubGlobal('ResizeObserver', MockResizeObserver)
     ;(globalThis as { window?: unknown }).window = {
       addEventListener: vi.fn(),
-      removeEventListener: vi.fn()
+      removeEventListener: vi.fn(),
+      api: {
+        ui: {
+          onMinimizedChanged: vi.fn((callback: (isMinimized: boolean) => void) => {
+            mocks.minimizedChangedCallbacks.push(callback)
+            return mocks.unsubscribeMinimizedChanged
+          })
+        }
+      }
     }
+    mocks.minimizedChangedCallbacks = []
+    mocks.unsubscribeMinimizedChanged.mockClear()
   })
 
   afterEach(() => {
@@ -209,6 +221,40 @@ describe('useTerminalContainerFitSync', () => {
     expect(event.detail).toEqual({ cols: 110, rows: 32 })
   })
 
+  it('holds resize work while the window is minimized and flushes after restore settles', () => {
+    const paneElement = createPaneElement()
+    const container = {
+      classList: { contains: () => false },
+      querySelectorAll: () => [paneElement]
+    } as unknown as HTMLDivElement
+
+    useTerminalContainerFitSync({
+      isVisible: true,
+      isSyncFitEnabled: true,
+      managerRef: { current: { fitAllPanes: vi.fn() } as never },
+      containerRef: { current: container }
+    })
+
+    mocks.minimizedChangedCallbacks[0]?.(true)
+    expect(isTerminalContainerResizeSettling()).toBe(true)
+    expect(queuePanePtyResizeIfHeld(paneElement, 120, 35)).toBe(true)
+
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_MAX_SETTLE_MS * 2)
+
+    expect(mocks.fitPanes).not.toHaveBeenCalled()
+    expect(paneElement.dispatchEvent).not.toHaveBeenCalled()
+    expect(isTerminalContainerResizeSettling()).toBe(true)
+
+    mocks.minimizedChangedCallbacks[0]?.(false)
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS)
+
+    expect(mocks.fitPanes).toHaveBeenCalledTimes(1)
+    expect(isTerminalContainerResizeSettling()).toBe(false)
+    expect(paneElement.dispatchEvent).toHaveBeenCalledTimes(1)
+    const event = vi.mocked(paneElement.dispatchEvent).mock.calls[0]?.[0] as CustomEvent
+    expect(event.detail).toEqual({ cols: 120, rows: 35 })
+  })
+
   it('cancels a held PTY resize when the observed container unmounts before settling', () => {
     const paneElement = createPaneElement()
     const container = {
@@ -234,5 +280,6 @@ describe('useTerminalContainerFitSync', () => {
     expect(mocks.fitPanes).not.toHaveBeenCalled()
     expect(paneElement.dispatchEvent).not.toHaveBeenCalled()
     expect(isTerminalContainerResizeSettling()).toBe(false)
+    expect(mocks.unsubscribeMinimizedChanged).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
@@ -8,7 +8,11 @@ import {
   isTerminalContainerResizeSettling,
   resetTerminalContainerResizeSettleForTests
 } from '@/lib/pane-manager/terminal-container-resize-settle'
-import { useTerminalContainerFitSync } from './use-terminal-container-fit-sync'
+import {
+  TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS,
+  TERMINAL_CONTAINER_RESIZE_MAX_SETTLE_MS,
+  useTerminalContainerFitSync
+} from './use-terminal-container-fit-sync'
 
 const mocks = vi.hoisted(() => ({
   cleanupCallbacks: [] as (() => void)[],
@@ -99,7 +103,7 @@ describe('useTerminalContainerFitSync', () => {
     expect(isTerminalContainerResizeSettling()).toBe(true)
     expect(queuePanePtyResizeIfHeld(paneElement, 100, 30)).toBe(true)
 
-    vi.advanceTimersByTime(149)
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS - 1)
 
     expect(mocks.fitPanes).not.toHaveBeenCalled()
     expect(paneElement.dispatchEvent).not.toHaveBeenCalled()
@@ -112,6 +116,70 @@ describe('useTerminalContainerFitSync', () => {
     const event = vi.mocked(paneElement.dispatchEvent).mock.calls[0]?.[0] as CustomEvent
     expect(event.type).toBe(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT)
     expect(event.detail).toEqual({ cols: 100, rows: 30 })
+  })
+
+  it('resets the quiet-period debounce when resize observations continue', () => {
+    const paneElement = createPaneElement()
+    const container = {
+      classList: { contains: () => false },
+      querySelectorAll: () => [paneElement]
+    } as unknown as HTMLDivElement
+
+    useTerminalContainerFitSync({
+      isVisible: true,
+      isSyncFitEnabled: true,
+      managerRef: { current: { fitAllPanes: vi.fn() } as never },
+      containerRef: { current: container }
+    })
+
+    mockResizeObservers[0]?.trigger()
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS - 1)
+    mockResizeObservers[0]?.trigger()
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS - 1)
+
+    expect(mocks.fitPanes).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+
+    expect(mocks.fitPanes).toHaveBeenCalledTimes(1)
+  })
+
+  it('forces a final fit when resize observations never go quiet', () => {
+    const paneElement = createPaneElement()
+    const container = {
+      classList: { contains: () => false },
+      querySelectorAll: () => [paneElement]
+    } as unknown as HTMLDivElement
+
+    useTerminalContainerFitSync({
+      isVisible: true,
+      isSyncFitEnabled: true,
+      managerRef: { current: { fitAllPanes: vi.fn() } as never },
+      containerRef: { current: container }
+    })
+
+    mockResizeObservers[0]?.trigger()
+    expect(queuePanePtyResizeIfHeld(paneElement, 110, 32)).toBe(true)
+
+    let elapsedMs = 0
+    while (
+      elapsedMs + TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS <
+      TERMINAL_CONTAINER_RESIZE_MAX_SETTLE_MS
+    ) {
+      vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS - 1)
+      elapsedMs += TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS - 1
+      mockResizeObservers[0]?.trigger()
+    }
+
+    expect(mocks.fitPanes).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_MAX_SETTLE_MS - elapsedMs)
+
+    expect(mocks.fitPanes).toHaveBeenCalledTimes(1)
+    expect(isTerminalContainerResizeSettling()).toBe(false)
+    expect(paneElement.dispatchEvent).toHaveBeenCalledTimes(1)
+    const event = vi.mocked(paneElement.dispatchEvent).mock.calls[0]?.[0] as CustomEvent
+    expect(event.detail).toEqual({ cols: 110, rows: 32 })
   })
 
   it('cancels a held PTY resize when the observed container unmounts before settling', () => {
@@ -134,7 +202,7 @@ describe('useTerminalContainerFitSync', () => {
     for (const cleanup of mocks.cleanupCallbacks.splice(0)) {
       cleanup()
     }
-    vi.advanceTimersByTime(150)
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS)
 
     expect(mocks.fitPanes).not.toHaveBeenCalled()
     expect(paneElement.dispatchEvent).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
@@ -221,6 +221,44 @@ describe('useTerminalContainerFitSync', () => {
     expect(event.detail).toEqual({ cols: 110, rows: 32 })
   })
 
+  it('does not fit twice when the quiet and max-settle timers converge', () => {
+    const paneElement = createPaneElement()
+    const container = {
+      classList: { contains: () => false },
+      querySelectorAll: () => [paneElement]
+    } as unknown as HTMLDivElement
+
+    useTerminalContainerFitSync({
+      isVisible: true,
+      isSyncFitEnabled: true,
+      managerRef: { current: { fitAllPanes: vi.fn() } as never },
+      containerRef: { current: container }
+    })
+
+    mockResizeObservers[0]?.trigger()
+    expect(queuePanePtyResizeIfHeld(paneElement, 115, 33)).toBe(true)
+
+    let elapsedMs = 0
+    const finalObservationMs =
+      TERMINAL_CONTAINER_RESIZE_MAX_SETTLE_MS - TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS
+    while (elapsedMs + TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS - 1 < finalObservationMs) {
+      vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS - 1)
+      elapsedMs += TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS - 1
+      mockResizeObservers[0]?.trigger()
+    }
+    vi.advanceTimersByTime(finalObservationMs - elapsedMs)
+    mockResizeObservers[0]?.trigger()
+
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS)
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS)
+
+    expect(mocks.fitPanes).toHaveBeenCalledTimes(1)
+    expect(isTerminalContainerResizeSettling()).toBe(false)
+    expect(paneElement.dispatchEvent).toHaveBeenCalledTimes(1)
+    const event = vi.mocked(paneElement.dispatchEvent).mock.calls[0]?.[0] as CustomEvent
+    expect(event.detail).toEqual({ cols: 115, rows: 33 })
+  })
+
   it('holds resize work while the window is minimized and flushes after restore settles', () => {
     const paneElement = createPaneElement()
     const container = {

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
@@ -118,6 +118,33 @@ describe('useTerminalContainerFitSync', () => {
     expect(event.detail).toEqual({ cols: 100, rows: 30 })
   })
 
+  it('flushes the held PTY resize when the manager is unavailable at settle time', () => {
+    const paneElement = createPaneElement()
+    const container = {
+      classList: { contains: () => false },
+      querySelectorAll: () => [paneElement]
+    } as unknown as HTMLDivElement
+
+    useTerminalContainerFitSync({
+      isVisible: true,
+      isSyncFitEnabled: true,
+      managerRef: { current: null },
+      containerRef: { current: container }
+    })
+
+    mockResizeObservers[0]?.trigger()
+    expect(queuePanePtyResizeIfHeld(paneElement, 101, 31)).toBe(true)
+
+    vi.advanceTimersByTime(TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS)
+
+    expect(mocks.fitPanes).not.toHaveBeenCalled()
+    expect(isTerminalContainerResizeSettling()).toBe(false)
+    expect(paneElement.dispatchEvent).toHaveBeenCalledTimes(1)
+    const event = vi.mocked(paneElement.dispatchEvent).mock.calls[0]?.[0] as CustomEvent
+    expect(event.type).toBe(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT)
+    expect(event.detail).toEqual({ cols: 101, rows: 31 })
+  })
+
   it('resets the quiet-period debounce when resize observations continue', () => {
     const paneElement = createPaneElement()
     const container = {

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts
@@ -1,0 +1,143 @@
+import type * as ReactModule from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  PANE_PTY_RESIZE_HOLD_FLUSH_EVENT,
+  queuePanePtyResizeIfHeld
+} from '@/lib/pane-manager/pane-pty-resize-hold'
+import {
+  isTerminalContainerResizeSettling,
+  resetTerminalContainerResizeSettleForTests
+} from '@/lib/pane-manager/terminal-container-resize-settle'
+import { useTerminalContainerFitSync } from './use-terminal-container-fit-sync'
+
+const mocks = vi.hoisted(() => ({
+  cleanupCallbacks: [] as (() => void)[],
+  fitPanes: vi.fn()
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactModule>()
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => {
+      const cleanup = effect()
+      if (typeof cleanup === 'function') {
+        mocks.cleanupCallbacks.push(cleanup)
+      }
+    }
+  }
+})
+
+vi.mock('./pane-helpers', () => ({
+  fitPanes: mocks.fitPanes
+}))
+
+type ResizeObserverCallbackLike = ConstructorParameters<typeof ResizeObserver>[0]
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+
+  constructor(private readonly callback: ResizeObserverCallbackLike) {
+    mockResizeObservers.push(this)
+  }
+
+  trigger(): void {
+    this.callback([], this as never)
+  }
+}
+
+let mockResizeObservers: MockResizeObserver[] = []
+
+function createPaneElement(): HTMLElement {
+  return {
+    classList: { contains: (className: string) => className === 'pane' },
+    dispatchEvent: vi.fn()
+  } as unknown as HTMLElement
+}
+
+describe('useTerminalContainerFitSync', () => {
+  beforeEach(() => {
+    mockResizeObservers = []
+    mocks.cleanupCallbacks = []
+    mocks.fitPanes.mockClear()
+    vi.useFakeTimers()
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    ;(globalThis as { window?: unknown }).window = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    for (const cleanup of mocks.cleanupCallbacks.splice(0)) {
+      cleanup()
+    }
+    resetTerminalContainerResizeSettleForTests()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    delete (globalThis as { window?: unknown }).window
+  })
+
+  it('fits once after container resize settles and flushes the final held PTY size', () => {
+    const paneElement = createPaneElement()
+    const container = {
+      classList: { contains: () => false },
+      querySelectorAll: () => [paneElement]
+    } as unknown as HTMLDivElement
+    const manager = { fitAllPanes: vi.fn() }
+
+    useTerminalContainerFitSync({
+      isVisible: true,
+      isSyncFitEnabled: true,
+      managerRef: { current: manager as never },
+      containerRef: { current: container }
+    })
+
+    mockResizeObservers[0]?.trigger()
+
+    expect(isTerminalContainerResizeSettling()).toBe(true)
+    expect(queuePanePtyResizeIfHeld(paneElement, 100, 30)).toBe(true)
+
+    vi.advanceTimersByTime(149)
+
+    expect(mocks.fitPanes).not.toHaveBeenCalled()
+    expect(paneElement.dispatchEvent).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+
+    expect(mocks.fitPanes).toHaveBeenCalledTimes(1)
+    expect(isTerminalContainerResizeSettling()).toBe(false)
+    expect(paneElement.dispatchEvent).toHaveBeenCalledTimes(1)
+    const event = vi.mocked(paneElement.dispatchEvent).mock.calls[0]?.[0] as CustomEvent
+    expect(event.type).toBe(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT)
+    expect(event.detail).toEqual({ cols: 100, rows: 30 })
+  })
+
+  it('cancels a held PTY resize when the observed container unmounts before settling', () => {
+    const paneElement = createPaneElement()
+    const container = {
+      classList: { contains: () => false },
+      querySelectorAll: () => [paneElement]
+    } as unknown as HTMLDivElement
+
+    useTerminalContainerFitSync({
+      isVisible: true,
+      isSyncFitEnabled: true,
+      managerRef: { current: { fitAllPanes: vi.fn() } as never },
+      containerRef: { current: container }
+    })
+
+    mockResizeObservers[0]?.trigger()
+    expect(queuePanePtyResizeIfHeld(paneElement, 90, 25)).toBe(true)
+
+    for (const cleanup of mocks.cleanupCallbacks.splice(0)) {
+      cleanup()
+    }
+    vi.advanceTimersByTime(150)
+
+    expect(mocks.fitPanes).not.toHaveBeenCalled()
+    expect(paneElement.dispatchEvent).not.toHaveBeenCalled()
+    expect(isTerminalContainerResizeSettling()).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react'
 import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { holdPtyResizesForPaneSubtrees } from '@/lib/pane-manager/pane-pty-resize-hold'
+import { beginTerminalContainerResizeSettle } from '@/lib/pane-manager/terminal-container-resize-settle'
 import { fitPanes } from './pane-helpers'
 
 type UseTerminalContainerFitSyncArgs = {
@@ -55,7 +57,28 @@ export function useTerminalContainerFitSync({
     // UI while a sidebar opens or a window resizes.
     const RESIZE_DEBOUNCE_MS = 150
     let timerId: ReturnType<typeof setTimeout> | null = null
+    let releaseResizeSettle: (() => void) | null = null
+    let ptyResizeHold: ReturnType<typeof holdPtyResizesForPaneSubtrees> | null = null
+    const beginResizeSettle = (): void => {
+      releaseResizeSettle ??= beginTerminalContainerResizeSettle()
+      ptyResizeHold ??= holdPtyResizesForPaneSubtrees([container])
+    }
+    const releasePendingResizeSettle = (flush: boolean): void => {
+      releaseResizeSettle?.()
+      releaseResizeSettle = null
+      const hold = ptyResizeHold
+      ptyResizeHold = null
+      if (!hold) {
+        return
+      }
+      if (flush) {
+        hold.flush()
+      } else {
+        hold.cancel()
+      }
+    }
     const resizeObserver = new ResizeObserver(() => {
+      beginResizeSettle()
       if (timerId !== null) {
         clearTimeout(timerId)
       }
@@ -63,7 +86,17 @@ export function useTerminalContainerFitSync({
         timerId = null
         const manager = managerRef.current
         if (manager) {
-          fitPanes(manager)
+          // Why: while the outer terminal container is resizing, per-pane
+          // observers skip heavy xterm reflows and PTY resize forwarding is
+          // held. Fit once after the drag settles, then flush the final
+          // SIGWINCH-sized grid instead of every transient grid.
+          try {
+            fitPanes(manager)
+          } finally {
+            releasePendingResizeSettle(true)
+          }
+        } else {
+          releasePendingResizeSettle(false)
         }
       }, RESIZE_DEBOUNCE_MS)
     })
@@ -73,6 +106,7 @@ export function useTerminalContainerFitSync({
       if (timerId !== null) {
         clearTimeout(timerId)
       }
+      releasePendingResizeSettle(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isVisible])

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
@@ -74,19 +74,26 @@ export function useTerminalContainerFitSync({
         maxSettleTimerId = null
       }
     }
-    function beginResizeSettle(): void {
-      if (releaseResizeSettle) {
+    function armMaxSettleTimer(): void {
+      if (maxSettleTimerId !== null) {
         return
       }
-      releaseResizeSettle = beginTerminalContainerResizeSettle()
-      ptyResizeHold = holdPtyResizesForPaneSubtrees([container])
-      // Why: resize observers can keep firing during a long drag or platform
-      // window animation. A hard cap keeps suppression from starving the final
-      // xterm fit if the quiet-period debounce never gets a turn.
       maxSettleTimerId = setTimeout(() => {
         maxSettleTimerId = null
         finishResizeSettle(true)
       }, TERMINAL_CONTAINER_RESIZE_MAX_SETTLE_MS)
+    }
+    function beginResizeSettle(armMaxTimer = true): void {
+      if (!releaseResizeSettle) {
+        releaseResizeSettle = beginTerminalContainerResizeSettle()
+        ptyResizeHold = holdPtyResizesForPaneSubtrees([container])
+      }
+      // Why: resize observers can keep firing during a long drag or platform
+      // window animation. A hard cap keeps suppression from starving the final
+      // xterm fit if the quiet-period debounce never gets a turn.
+      if (armMaxTimer) {
+        armMaxSettleTimer()
+      }
     }
     function releasePendingResizeSettle(flush: boolean): void {
       releaseResizeSettle?.()
@@ -122,16 +129,32 @@ export function useTerminalContainerFitSync({
       // the held final PTY grid still needs to reach the backend.
       releasePendingResizeSettle(flush)
     }
-    const resizeObserver = new ResizeObserver(() => {
+    function scheduleFinalResizeSettle(): void {
       beginResizeSettle()
       clearTimer()
       timerId = setTimeout(() => {
         timerId = null
         finishResizeSettle(true)
       }, TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS)
+    }
+    const unsubscribeMinimizedChanged = window.api.ui.onMinimizedChanged((isMinimized) => {
+      if (isMinimized) {
+        // Why: minimized windows can report hidden/intermediate geometry for a
+        // long time. Keep fits and PTY resizes held until restore provides a
+        // measurable final layout.
+        beginResizeSettle(false)
+        clearTimer()
+        clearMaxSettleTimer()
+        return
+      }
+      scheduleFinalResizeSettle()
+    })
+    const resizeObserver = new ResizeObserver(() => {
+      scheduleFinalResizeSettle()
     })
     resizeObserver.observe(container)
     return () => {
+      unsubscribeMinimizedChanged()
       resizeObserver.disconnect()
       clearTimer()
       finishResizeSettle(false)

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
@@ -118,7 +118,9 @@ export function useTerminalContainerFitSync({
         }
         return
       }
-      releasePendingResizeSettle(false)
+      // Why: a transiently unavailable manager should only skip the local fit;
+      // the held final PTY grid still needs to reach the backend.
+      releasePendingResizeSettle(flush)
     }
     const resizeObserver = new ResizeObserver(() => {
       beginResizeSettle()

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
@@ -12,6 +12,9 @@ type UseTerminalContainerFitSyncArgs = {
   containerRef: React.RefObject<HTMLDivElement | null>
 }
 
+export const TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS = 150
+export const TERMINAL_CONTAINER_RESIZE_MAX_SETTLE_MS = 1000
+
 export function useTerminalContainerFitSync({
   isVisible,
   isSyncFitEnabled,
@@ -55,15 +58,37 @@ export function useTerminalContainerFitSync({
     // the viewport scroll position. On Windows, a single reflow of 10 000
     // scrollback lines can block the renderer for 500 ms-2 s, freezing the
     // UI while a sidebar opens or a window resizes.
-    const RESIZE_DEBOUNCE_MS = 150
     let timerId: ReturnType<typeof setTimeout> | null = null
+    let maxSettleTimerId: ReturnType<typeof setTimeout> | null = null
     let releaseResizeSettle: (() => void) | null = null
     let ptyResizeHold: ReturnType<typeof holdPtyResizesForPaneSubtrees> | null = null
-    const beginResizeSettle = (): void => {
-      releaseResizeSettle ??= beginTerminalContainerResizeSettle()
-      ptyResizeHold ??= holdPtyResizesForPaneSubtrees([container])
+    function clearTimer(): void {
+      if (timerId !== null) {
+        clearTimeout(timerId)
+        timerId = null
+      }
     }
-    const releasePendingResizeSettle = (flush: boolean): void => {
+    function clearMaxSettleTimer(): void {
+      if (maxSettleTimerId !== null) {
+        clearTimeout(maxSettleTimerId)
+        maxSettleTimerId = null
+      }
+    }
+    function beginResizeSettle(): void {
+      if (releaseResizeSettle) {
+        return
+      }
+      releaseResizeSettle = beginTerminalContainerResizeSettle()
+      ptyResizeHold = holdPtyResizesForPaneSubtrees([container])
+      // Why: resize observers can keep firing during a long drag or platform
+      // window animation. A hard cap keeps suppression from starving the final
+      // xterm fit if the quiet-period debounce never gets a turn.
+      maxSettleTimerId = setTimeout(() => {
+        maxSettleTimerId = null
+        finishResizeSettle(true)
+      }, TERMINAL_CONTAINER_RESIZE_MAX_SETTLE_MS)
+    }
+    function releasePendingResizeSettle(flush: boolean): void {
       releaseResizeSettle?.()
       releaseResizeSettle = null
       const hold = ptyResizeHold
@@ -77,36 +102,37 @@ export function useTerminalContainerFitSync({
         hold.cancel()
       }
     }
+    function finishResizeSettle(flush: boolean): void {
+      clearTimer()
+      clearMaxSettleTimer()
+      const manager = managerRef.current
+      if (flush && manager) {
+        // Why: while the outer terminal container is resizing, per-pane
+        // observers skip heavy xterm reflows and PTY resize forwarding is
+        // held. Fit once after the drag settles, then flush the final
+        // SIGWINCH-sized grid instead of every transient grid.
+        try {
+          fitPanes(manager)
+        } finally {
+          releasePendingResizeSettle(true)
+        }
+        return
+      }
+      releasePendingResizeSettle(false)
+    }
     const resizeObserver = new ResizeObserver(() => {
       beginResizeSettle()
-      if (timerId !== null) {
-        clearTimeout(timerId)
-      }
+      clearTimer()
       timerId = setTimeout(() => {
         timerId = null
-        const manager = managerRef.current
-        if (manager) {
-          // Why: while the outer terminal container is resizing, per-pane
-          // observers skip heavy xterm reflows and PTY resize forwarding is
-          // held. Fit once after the drag settles, then flush the final
-          // SIGWINCH-sized grid instead of every transient grid.
-          try {
-            fitPanes(manager)
-          } finally {
-            releasePendingResizeSettle(true)
-          }
-        } else {
-          releasePendingResizeSettle(false)
-        }
-      }, RESIZE_DEBOUNCE_MS)
+        finishResizeSettle(true)
+      }, TERMINAL_CONTAINER_RESIZE_DEBOUNCE_MS)
     })
     resizeObserver.observe(container)
     return () => {
       resizeObserver.disconnect()
-      if (timerId !== null) {
-        clearTimeout(timerId)
-      }
-      releasePendingResizeSettle(false)
+      clearTimer()
+      finishResizeSettle(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isVisible])

--- a/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.ts
@@ -112,6 +112,10 @@ export function useTerminalContainerFitSync({
     function finishResizeSettle(flush: boolean): void {
       clearTimer()
       clearMaxSettleTimer()
+      const hasActiveSettle = releaseResizeSettle !== null || ptyResizeHold !== null
+      if (!hasActiveSettle) {
+        return
+      }
       const manager = managerRef.current
       if (flush && manager) {
         // Why: while the outer terminal container is resizing, per-pane

--- a/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts
@@ -4,6 +4,10 @@ import {
   attachPaneFitResizeObserver,
   detachPaneFitResizeObserver
 } from './pane-fit-resize-observer'
+import {
+  beginTerminalContainerResizeSettle,
+  resetTerminalContainerResizeSettleForTests
+} from './terminal-container-resize-settle'
 
 type ResizeObserverCallbackLike = ConstructorParameters<typeof ResizeObserver>[0]
 
@@ -102,6 +106,7 @@ describe('attachPaneFitResizeObserver', () => {
   })
 
   afterEach(() => {
+    resetTerminalContainerResizeSettleForTests()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -152,6 +157,35 @@ describe('attachPaneFitResizeObserver', () => {
 
     expect(requestAnimationFrame).not.toHaveBeenCalled()
     expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+  })
+
+  it('skips observed fits while an outer terminal container resize is settling', () => {
+    const releaseResizeSettle = beginTerminalContainerResizeSettle()
+    const pane = createPane()
+
+    attachPaneFitResizeObserver(pane)
+    mockResizeObservers[0]?.trigger()
+
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+
+    releaseResizeSettle()
+    mockResizeObservers[0]?.trigger()
+    flushAnimationFrames()
+
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels a queued observed fit if an outer container resize starts first', () => {
+    const pane = createPane()
+
+    attachPaneFitResizeObserver(pane)
+    mockResizeObservers[0]?.trigger()
+    beginTerminalContainerResizeSettle()
+    flushAnimationFrames()
+
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+    expect(pane.pendingObservedFitRafId).toBeNull()
   })
 
   it('throttles an endlessly unstable grid instead of fitting every frame', () => {

--- a/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.ts
@@ -1,5 +1,6 @@
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { safeFit } from './pane-tree-ops'
+import { isTerminalContainerResizeSettling } from './terminal-container-resize-settle'
 
 type ProposedDimensions = {
   cols: number
@@ -40,6 +41,9 @@ export function attachPaneFitResizeObserver(pane: ManagedPaneInternal): void {
     if (pane.pendingObservedFitRafId !== null) {
       return
     }
+    if (isTerminalContainerResizeSettling()) {
+      return
+    }
     if (!hasVisibleFitGeometry(pane)) {
       return
     }
@@ -53,6 +57,10 @@ export function attachPaneFitResizeObserver(pane: ManagedPaneInternal): void {
     let frameCount = 0
     const waitForStableGrid = (): void => {
       pane.pendingObservedFitRafId = requestAnimationFrame(() => {
+        if (isTerminalContainerResizeSettling()) {
+          pane.pendingObservedFitRafId = null
+          return
+        }
         if (!hasVisibleFitGeometry(pane)) {
           pane.pendingObservedFitRafId = null
           return

--- a/src/renderer/src/lib/pane-manager/terminal-container-resize-settle.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-container-resize-settle.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  beginTerminalContainerResizeSettle,
+  isTerminalContainerResizeSettling,
+  resetTerminalContainerResizeSettleForTests
+} from './terminal-container-resize-settle'
+
+describe('terminal container resize settle state', () => {
+  afterEach(() => {
+    resetTerminalContainerResizeSettleForTests()
+  })
+
+  it('stays active until every settle token releases', () => {
+    const releaseA = beginTerminalContainerResizeSettle()
+    const releaseB = beginTerminalContainerResizeSettle()
+
+    expect(isTerminalContainerResizeSettling()).toBe(true)
+
+    releaseA()
+    expect(isTerminalContainerResizeSettling()).toBe(true)
+
+    releaseB()
+    expect(isTerminalContainerResizeSettling()).toBe(false)
+  })
+
+  it('ignores duplicate release calls', () => {
+    const release = beginTerminalContainerResizeSettle()
+
+    release()
+    release()
+
+    expect(isTerminalContainerResizeSettling()).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-container-resize-settle.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-container-resize-settle.ts
@@ -1,0 +1,22 @@
+let activeTerminalContainerResizeSettles = 0
+
+export function beginTerminalContainerResizeSettle(): () => void {
+  let released = false
+  activeTerminalContainerResizeSettles += 1
+
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    activeTerminalContainerResizeSettles = Math.max(0, activeTerminalContainerResizeSettles - 1)
+  }
+}
+
+export function isTerminalContainerResizeSettling(): boolean {
+  return activeTerminalContainerResizeSettles > 0
+}
+
+export function resetTerminalContainerResizeSettleForTests(): void {
+  activeTerminalContainerResizeSettles = 0
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2057,6 +2057,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     setShortcutRecorderFocused: () => {},
     onRichMarkdownContextCommand: () => noopUnsubscribe,
     onFullscreenChanged: () => noopUnsubscribe,
+    onMinimizedChanged: () => noopUnsubscribe,
     minimize: () => {},
     maximize: () => {},
     onMaximizeChanged: () => noopUnsubscribe,

--- a/tests/e2e/helpers/terminal.ts
+++ b/tests/e2e/helpers/terminal.ts
@@ -256,13 +256,26 @@ export async function discoverActivePtyId(page: Page): Promise<string> {
     })
     .not.toEqual([])
 
-  const candidateIds = await readCandidateIds()
+  let candidateIds = await readCandidateIds()
 
   if (candidateIds.length === 0) {
     // Why: blind-probing arbitrary PTY IDs can write into unrelated shells and
     // hides real regressions in the tab->PTY mapping the test depends on.
     throw new Error('discoverActivePtyId: active tab has no PTY candidates in store')
   }
+
+  let activePanePtyId: string | null = null
+  try {
+    activePanePtyId = await waitForActivePanePtyId(page)
+  } catch {
+    activePanePtyId = null
+  }
+  if (activePanePtyId) {
+    return activePanePtyId
+  }
+  // Why: the active PaneManager binding is the route execInTerminal uses; the
+  // slower shell probe is only needed while direct pane metadata is unavailable.
+  candidateIds = await readCandidateIds()
 
   await page.evaluate(
     ({ marker, candidateIds }) => {

--- a/tests/e2e/terminal-panes.spec.ts
+++ b/tests/e2e/terminal-panes.spec.ts
@@ -42,6 +42,17 @@ import {
 } from './helpers/store'
 import { pressShortcut } from './helpers/shortcuts'
 
+const SHELL_SAFE_NODE_ENV_TOKEN_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+function buildNodeEnvPrintCommand(marker: string, envName: string): string {
+  if (!SHELL_SAFE_NODE_ENV_TOKEN_RE.test(marker) || !SHELL_SAFE_NODE_ENV_TOKEN_RE.test(envName)) {
+    throw new Error('buildNodeEnvPrintCommand only accepts shell-safe identifier tokens')
+  }
+  // Why: the E2E terminal shell is PowerShell on Windows and POSIX elsewhere;
+  // use Node's process.env so this assertion does not depend on shell syntax.
+  return `node -e "process.stdout.write('${marker}=' + (process.env.${envName} || '') + '\\n')"`
+}
+
 async function setPaneTitleFromTerminalMenu(page: Page, title: string): Promise<void> {
   await openTerminalContextMenu(page)
   await page.getByText('Set Title…', { exact: true }).click()
@@ -231,7 +242,7 @@ test.describe('Terminal Panes', () => {
     const ptyId = await discoverActivePtyId(orcaPage)
     const marker = `ORCA_PANE_KEY_E2E_${Date.now()}`
 
-    await execInTerminal(orcaPage, ptyId, `printf '${marker}=%s\\n' "$ORCA_PANE_KEY"`)
+    await execInTerminal(orcaPage, ptyId, buildNodeEnvPrintCommand(marker, 'ORCA_PANE_KEY'))
     await waitForTerminalOutput(orcaPage, `${marker}=${expectedPaneKey}`)
 
     expect(activeLeafId).toMatch(UUID_RE)


### PR DESCRIPTION
## Summary

Fixes the desktop resize and long-thread jitter path by reducing renderer work during continuous layout changes and by avoiding full-list rendering in long activity threads.

## Root cause

- Long activity threads rendered every grouped row in the left thread list, so scrolling through very large activity histories forced React and layout work for rows that were not visible.
- Terminal container resize events triggered repeated xterm fit()/resize() work while the outer window or container was still changing size. With large scrollback, each transient grid change can force xterm to reflow the buffer and recalculate viewport state.
- PTY resize events were forwarded for every transient terminal grid during container resize, amplifying the renderer churn into backend SIGWINCH traffic.

## What changed

- Virtualized the activity thread list with sticky group headers so long histories render only the visible row window.
- Added a terminal container resize settle guard so outer-window/container resize skips per-pane observed fits and performs one settled fit after the resize burst.
- Reused the existing pane PTY resize hold path for container resizes, flushing only the final settled terminal size.
- Added regression tests for virtual row flattening/sticky header math, resize settle ref-counting, per-pane observer suppression, PTY resize coalescing, and terminal container cleanup.
- Made the ORCA_PANE_KEY E2E assertion shell-neutral so it passes on Windows PowerShell as well as POSIX shells.

## Platform impact

This is not Windows-only: the DOM rendering and xterm resize costs can occur on macOS, Linux, and Windows. Windows is hit hardest because ConPTY/PowerShell plus large xterm scrollback makes repeated resize/reflow/SIGWINCH loops much more visible, producing the resize jitter and snap-back feeling reported in the desktop app.

## Validation

- pnpm test - 18,250 passed, 188 skipped
- pnpm run typecheck
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/activity/activity-thread-virtual-rows.test.ts src/renderer/src/components/activity/ActivityPrototypePage.test.ts src/renderer/src/lib/pane-manager/terminal-container-resize-settle.test.ts src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts src/renderer/src/lib/pane-manager/pane-pty-resize-hold.test.ts src/renderer/src/components/terminal-pane/use-terminal-container-fit-sync.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- pnpm exec oxlint <changed files>
- pnpm exec oxlint --config config/oxlint-react-doctor.json <changed React/test files>
- git diff --check
- npx playwright test tests/e2e/terminal-panes.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 - 18 passed

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5819">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Resizing the window or scrolling huge activity threads caused jank. Long lists virtualize better and terminal fit/resize work is reduced during continuous layout changes.
