### PR TITLE
fix(terminal): evict lastCompletionIdentityByPaneKey on genuine pane teardown

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-dispose-leak.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-dispose-leak.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Memory-leak regression: lastCompletionIdentityByPaneKey must not retain an entry
+ * per genuinely-torn-down coordinator.
+ *
+ * `dispatchCompletion` does `lastCompletionIdentityByPaneKey.set(options.paneKey, …)`
+ * on every agent completion. `paneKey` is `${tabId}:${leafUUID}` — a never-reused
+ * per-pane UUID, so the key space is unbounded. The map is module-scoped on purpose
+ * so it survives a live-stream remount (dispose-then-recreate with the same paneKey
+ * while the PTY/hook stream stays live). But `dispose()` cleared only local timers
+ * and never the map, so on genuine teardown (PTY gone) the identity leaked — one
+ * entry per closed pane for the renderer session. The fix evicts on dispose only
+ * when the pane is no longer live, preserving the cross-remount dedup.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createAgentCompletionCoordinator,
+  resetAgentCompletionCoordinatorIdentitiesForTest,
+  getAgentCompletionCoordinatorIdentityCountForTest
+} from './agent-completion-coordinator'
+import type {
+  AgentCompletionCoordinatorOptions,
+  AgentCompletionStatusSnapshot
+} from './agent-completion-coordinator-types'
+
+const HOOK_DONE_QUIET_MS = 1_500
+
+function makeOptions(paneKey: string, live: { value: boolean }): AgentCompletionCoordinatorOptions {
+  return {
+    paneKey,
+    getPtyId: () => 'pty-1',
+    getSettings: () => null,
+    inspectProcess: vi.fn(),
+    dispatchCompletion: vi.fn(),
+    isLive: () => live.value
+  }
+}
+
+// A working->done hook sequence with finite stateStartedAt makes the coordinator
+// write a completion identity into the module map (the leaking write).
+function driveCompletion(
+  paneKey: string,
+  live: { value: boolean }
+): ReturnType<typeof createAgentCompletionCoordinator> {
+  const coordinator = createAgentCompletionCoordinator(makeOptions(paneKey, live))
+  coordinator.observeHookStatus({
+    state: 'working',
+    prompt: '',
+    agentType: 'codex',
+    stateStartedAt: 1000
+  } as AgentCompletionStatusSnapshot)
+  coordinator.observeHookStatus({
+    state: 'done',
+    prompt: '',
+    agentType: 'codex',
+    stateStartedAt: 2000
+  } as AgentCompletionStatusSnapshot)
+  vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+  return coordinator
+}
+
+describe('agent completion coordinator identity map stays bounded (leak regression)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetAgentCompletionCoordinatorIdentitiesForTest()
+  })
+
+  afterEach(() => {
+    resetAgentCompletionCoordinatorIdentitiesForTest()
+    vi.useRealTimers()
+  })
+
+  it('writes an identity on completion and clears it on genuine teardown', () => {
+    const live = { value: true }
+    const coordinator = driveCompletion('tab-1:leaf-x', live)
+    // The map is genuinely exercised by the completion.
+    expect(getAgentCompletionCoordinatorIdentityCountForTest()).toBe(1)
+
+    // Genuine teardown: the PTY is gone.
+    live.value = false
+    coordinator.dispose()
+    expect(getAgentCompletionCoordinatorIdentityCountForTest()).toBe(0)
+  })
+
+  it('does not retain an identity per torn-down pane across many panes', () => {
+    for (let i = 0; i < 200; i++) {
+      const live = { value: true }
+      const coordinator = driveCompletion(`tab-1:leaf-${i}`, live)
+      live.value = false
+      coordinator.dispose()
+    }
+    expect(getAgentCompletionCoordinatorIdentityCountForTest()).toBe(0)
+  })
+
+  it('retains the identity across a live remount (dispose while still live)', () => {
+    // Cross-remount dedup: the pane remounts (dispose-then-recreate) while the
+    // stream stays live, so the identity must survive the dispose.
+    const live = { value: true }
+    const coordinator = driveCompletion('tab-1:leaf-remount', live)
+    expect(getAgentCompletionCoordinatorIdentityCountForTest()).toBe(1)
+
+    coordinator.dispose() // isLive() still true -> remount, not teardown
+    expect(getAgentCompletionCoordinatorIdentityCountForTest()).toBe(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -717,6 +717,13 @@ export function createAgentCompletionCoordinator(
     clearPollTimer()
     clearPendingHookDone()
     dropPendingTitle()
+    // Why: the dedup identity is module-scoped so it survives a live-stream remount
+    // (dispose-then-recreate with the same paneKey while isLive() stays true). Only
+    // evict it on genuine teardown — when the PTY is gone (isLive() false) — so the
+    // never-reused ${tabId}:${leafUUID} key can't leak one identity per closed pane.
+    if (!options.isLive()) {
+      lastCompletionIdentityByPaneKey.delete(options.paneKey)
+    }
   }
 
   return {
@@ -733,4 +740,8 @@ export function createAgentCompletionCoordinator(
 
 export function resetAgentCompletionCoordinatorIdentitiesForTest(): void {
   lastCompletionIdentityByPaneKey.clear()
+}
+
+export function getAgentCompletionCoordinatorIdentityCountForTest(): number {
+  return lastCompletionIdentityByPaneKey.size
 }


### PR DESCRIPTION
## Leak

`dispatchCompletion` does `lastCompletionIdentityByPaneKey.set(options.paneKey, …)` on every agent completion. `paneKey` is `${tabId}:${leafUUID}` — a never-reused per-pane UUID, so the key space is unbounded. The map is **module-scoped on purpose** so it outlives one coordinator across a *live-stream remount* (a worktree switch can dispose-then-recreate the coordinator with the same `paneKey` while the PTY/hook stream stays live, and the stale completion replay must stay suppressed).

But `dispose()` cleared only local timers and never touched the map. `dispose()` also runs on **genuine** teardown — PTY exit (`pty-connection.ts:1178`) and teardown (`pty-connection.ts:3798`) — exactly when the `paneKey` goes permanently stale. The only per-key delete (`recordTitleWorking`) fires only on a *live* pane returning to `working`, so the common completion-then-close path leaked one identity entry per pane for the renderer session.

## Fix

Evict the identity in `dispose()` **only when the pane is no longer live** (`!options.isLive()`). This is the exact discriminator the existing cross-remount dedup tests encode: a remount disposes with `isLive() === true` (retain), genuine teardown disposes with `isLive() === false` (evict). A `getAgentCompletionCoordinatorIdentityCountForTest` accessor exposes the bound.

## Evidence of the leak (regression test FAILS before the fix)

`agent-completion-coordinator-dispose-leak.test.ts` against the **unfixed** `dispose()`:

```
× writes an identity on completion and clears it on genuine teardown
   AssertionError: expected 1 to be +0
× does not retain an identity per torn-down pane across many panes
   AssertionError: expected 200 to be +0
 Tests  2 failed | 1 passed (3)
```

The completion writes the identity (count 1), but it survives teardown; 200 torn-down panes leave 200 entries. (The "retains across a live remount" guard passes both before and after — it must not be evicted on remount.)

## Evidence the leak is resolved (test PASSES after the fix)

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

On genuine teardown the identity is evicted (count → 0 across 200 panes); on a live remount it is retained.

## No functional regression

```
src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
 Tests  44 passed (44)
```

Includes the two cross-remount dedup tests ("suppresses stale title completion replay after a pane remount / hook completion remount"), which dispose with `isLive() === true` and require the identity to persist — confirming the fix preserves dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5822">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->