### PR TITLE
fix(runtime): evict ClaudeAgentTeams team on natural leader PTY exit

### DIFF
--- a/src/main/runtime/claude-agent-teams-pty-exit-leak.test.ts
+++ b/src/main/runtime/claude-agent-teams-pty-exit-leak.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Memory-leak regression: a Claude agent-team must be evicted when its leader PTY
+ * goes away naturally, not only on explicit user-close.
+ *
+ * `ClaudeAgentTeamsService.createLaunchEnv` adds a team (with a nested panes Map)
+ * per agent-team leader launch. The only eviction was `removeTeamForLeaderHandle`,
+ * called solely from `OrcaRuntimeService.closeTerminal` (the explicit user-close IPC).
+ * The natural-exit teardown paths — `onPtyExit` and `dropDisconnectedPtyRecord` —
+ * tore down every other per-pty map but never evicted the team. teamId is a fresh
+ * `team-${randomUUID()}`, so when a leader shell exits on its own (agent finishes,
+ * process dies, renderer reload) the team + nested panes Map leaked permanently.
+ */
+import { describe, it, expect } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import type { ClaudeAgentTeamsService } from './claude-agent-teams-service'
+
+type RuntimeInternals = {
+  claudeAgentTeams: ClaudeAgentTeamsService
+  handleByPtyId: Map<string, string>
+  dropDisconnectedPtyRecord: (ptyId: string) => void
+}
+
+function internals(runtime: OrcaRuntimeService): RuntimeInternals {
+  return runtime as unknown as RuntimeInternals
+}
+
+function registerTeam(runtime: OrcaRuntimeService, ptyId: string, leaderHandle: string): void {
+  const { claudeAgentTeams, handleByPtyId } = internals(runtime)
+  claudeAgentTeams.createLaunchEnv({
+    leaderHandle,
+    baseEnv: {},
+    shimDir: '/tmp/orca-shim',
+    shimBin: 'orca'
+  })
+  // onPtyExit / dropDisconnectedPtyRecord resolve the leader handle via this map.
+  handleByPtyId.set(ptyId, leaderHandle)
+}
+
+describe('ClaudeAgentTeams eviction on natural PTY exit (leak regression)', () => {
+  it('evicts the team when its leader PTY exits naturally (onPtyExit)', () => {
+    const runtime = new OrcaRuntimeService()
+    registerTeam(runtime, 'pty-leader', 'handle-leader')
+    expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(1)
+
+    runtime.onPtyExit('pty-leader', 0)
+
+    expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(0)
+  })
+
+  it('evicts the team when the disconnected PTY record is pruned', () => {
+    const runtime = new OrcaRuntimeService()
+    registerTeam(runtime, 'pty-leader', 'handle-leader')
+    expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(1)
+
+    internals(runtime).dropDisconnectedPtyRecord('pty-leader')
+
+    expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(0)
+  })
+
+  it('does not accumulate teams across many natural leader exits', () => {
+    const runtime = new OrcaRuntimeService()
+    for (let i = 0; i < 100; i++) {
+      registerTeam(runtime, `pty-${i}`, `handle-${i}`)
+      runtime.onPtyExit(`pty-${i}`, 0)
+    }
+    expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(0)
+  })
+
+  it('leaves a concurrently-launched team intact when only one leader exits', () => {
+    const runtime = new OrcaRuntimeService()
+    registerTeam(runtime, 'pty-a', 'handle-a')
+    registerTeam(runtime, 'pty-b', 'handle-b')
+    expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(2)
+
+    runtime.onPtyExit('pty-a', 0)
+
+    // Only team A is evicted; team B (still live) remains.
+    expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(1)
+  })
+
+  it('is a no-op for a PTY that never launched a team', () => {
+    const runtime = new OrcaRuntimeService()
+    const { handleByPtyId } = internals(runtime)
+    handleByPtyId.set('pty-plain', 'handle-plain') // a normal terminal, no team
+    expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(0)
+
+    runtime.onPtyExit('pty-plain', 0)
+
+    expect(internals(runtime).claudeAgentTeams.getActiveTeamCount()).toBe(0)
+  })
+})

--- a/src/main/runtime/claude-agent-teams-service.ts
+++ b/src/main/runtime/claude-agent-teams-service.ts
@@ -81,6 +81,10 @@ export class ClaudeAgentTeamsService {
     }
   }
 
+  getActiveTeamCount(): number {
+    return this.teams.size
+  }
+
   async handleTmuxCompat(
     request: AgentTeamsTmuxCompatRequest,
     api: AgentTeamsTerminalApi

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2980,7 +2980,9 @@ export class OrcaRuntimeService {
       .map((group) => {
         const tabOrder = retainedOrder.get(group.id) ?? []
         const keptActive =
-          group.activeTabId && tabOrder.includes(group.activeTabId) && liveTabIds.has(group.activeTabId)
+          group.activeTabId &&
+          tabOrder.includes(group.activeTabId) &&
+          liveTabIds.has(group.activeTabId)
             ? group.activeTabId
             : null
         return {
@@ -3370,8 +3372,7 @@ export class OrcaRuntimeService {
       groupIdByTabId.set(newTabAssignment!.tabId, newTabAssignment!.groupId)
     }
     const activeGroupId =
-      (activeTopLevelId ? groupIdByTabId.get(activeTopLevelId) : undefined) ??
-      existingGroups[0]!.id
+      (activeTopLevelId ? groupIdByTabId.get(activeTopLevelId) : undefined) ?? existingGroups[0]!.id
     const orderByGroup = new Map<string, string[]>(existingGroups.map((group) => [group.id, []]))
     for (const tabId of tabOrder) {
       const groupId = groupIdByTabId.get(tabId) ?? activeGroupId
@@ -4061,14 +4062,12 @@ export class OrcaRuntimeService {
   // Merge the client's pane structure into the persisted tab layout. PTY
   // bindings and active leaf stay host-owned; only ratios/expand/titles change.
   // terminalLayoutsByTabId is keyed by tab id (worktree-independent).
-  private persistHeadlessTerminalPaneLayout(
-    args: {
-      tabId: string
-      root: TerminalPaneLayoutNode | null
-      expandedLeafId: string | null
-      titlesByLeafId?: Record<string, string>
-    }
-  ): void {
+  private persistHeadlessTerminalPaneLayout(args: {
+    tabId: string
+    root: TerminalPaneLayoutNode | null
+    expandedLeafId: string | null
+    titlesByLeafId?: Record<string, string>
+  }): void {
     const session = this.store?.getWorkspaceSession?.()
     if (!session || !this.store?.setWorkspaceSession) {
       return
@@ -4167,11 +4166,7 @@ export class OrcaRuntimeService {
     })
     const active = nextTabs.find((candidate) => candidate.isActive) ?? nextTabs[0] ?? null
     const reorderedTargetActiveTabId =
-      active?.type === 'terminal'
-        ? active.parentTabId
-        : active
-          ? active.id
-          : (tabOrder[0] ?? null)
+      active?.type === 'terminal' ? active.parentTabId : active ? active.id : (tabOrder[0] ?? null)
     // Why: reorder only changes ONE group's order. Preserve every other group so
     // a multi-group split isn't deleted by re-sorting tabs in one of its groups.
     const existingGroups = snapshot.tabGroups ?? []
@@ -4323,9 +4318,7 @@ export class OrcaRuntimeService {
       ...session,
       tabsByWorktree: {
         ...session.tabsByWorktree,
-        [worktreeId]: tabs.map((tab) =>
-          tab.id === tabId ? { ...tab, customTitle: title } : tab
-        )
+        [worktreeId]: tabs.map((tab) => (tab.id === tabId ? { ...tab, customTitle: title } : tab))
       }
     })
   }
@@ -6162,6 +6155,14 @@ export class OrcaRuntimeService {
     this.agentStatusOscProcessorsByPtyId.delete(ptyId)
     this.oscTitleScanTailByPtyId.delete(ptyId)
     this.clearAgentRowSnapshotsForPty(ptyId)
+    // Why: a Claude agent-team leader whose PTY exits naturally (agent finished,
+    // process died, renderer reload) must release its team + nested panes map.
+    // Previously only explicit closeTerminal evicted it, so natural exits leaked
+    // one team per never-reused teamId for the runtime's lifetime.
+    const exitedTeamLeaderHandle = this.handleByPtyId.get(ptyId)
+    if (exitedTeamLeaderHandle) {
+      this.claudeAgentTeams.removeTeamForLeaderHandle(exitedTeamLeaderHandle)
+    }
     // Layout state machine: clear `layouts` and `layoutQueues`. Any
     // already-queued applyLayout work for this ptyId will run, but every
     // applyLayout re-checks `layouts.has(ptyId)` (or fresh-subscribe) and
@@ -15118,8 +15119,7 @@ export class OrcaRuntimeService {
       } catch {
         warnings.push({
           code: 'LINEAGE_PARENT_CONTEXT_MISSING',
-          message:
-            'Worktree created, but Orca could not validate the environment parent context.',
+          message: 'Worktree created, but Orca could not validate the environment parent context.',
           details: { envParentWorkspace: input.envParentWorkspace }
         })
       }
@@ -15907,6 +15907,9 @@ export class OrcaRuntimeService {
     this.clearAgentRowSnapshotsForPty(ptyId)
     const handle = this.handleByPtyId.get(ptyId)
     if (handle) {
+      // Why: pruning can remove a PTY without onPtyExit firing; release any agent
+      // team owned by this leader handle so it does not leak.
+      this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
       this.handleByPtyId.delete(ptyId)
       const record = this.handles.get(handle)
       if (record?.tabId.startsWith('pty:')) {


### PR DESCRIPTION
## Leak

`ClaudeAgentTeamsService.createLaunchEnv` adds a team (with a nested `panes` Map) per agent-team leader launch, keyed by a fresh `team-${randomUUID()}`. The only eviction is `removeTeamForLeaderHandle`, called **solely from `OrcaRuntimeService.closeTerminal`** — the explicit user-close IPC.

The natural-exit teardown paths — `onPtyExit` (PTY died on its own: agent finished, process exited, renderer reload) and `dropDisconnectedPtyRecord` (a PTY pruned without the normal exit callback) — tear down every other per-pty map but **never** evicted the team. So a leader shell that exits on its own leaks its team + nested panes Map permanently. The stored `leaderHandle` equals `handleByPtyId.get(ptyId)` at exit, so the right handle is recoverable.

## Fix

- `onPtyExit`: resolve `this.handleByPtyId.get(ptyId)` and call `this.claudeAgentTeams.removeTeamForLeaderHandle(handle)` when present (mirrors the existing `closeTerminal` eviction).
- `dropDisconnectedPtyRecord`: add the same call where the handle is already fetched.
- Add `ClaudeAgentTeamsService.getActiveTeamCount()` for assertability.

`removeTeamForLeaderHandle` is idempotent and matches only teams whose `leaderHandle` equals the exiting handle, so non-agent-team PTYs are unaffected.

## Evidence of the leak (regression test FAILS before the fix)

`claude-agent-teams-pty-exit-leak.test.ts` drives the **real** `OrcaRuntimeService.onPtyExit` / `dropDisconnectedPtyRecord` against the **unfixed** code:

```
× evicts the team when its leader PTY exits naturally (onPtyExit)
   AssertionError: expected 1 to be +0
× evicts the team when the disconnected PTY record is pruned
   AssertionError: expected 1 to be +0
× does not accumulate teams across many natural leader exits
   AssertionError: expected 100 to be +0
× leaves a concurrently-launched team intact when only one leader exits
   AssertionError: expected 2 to be 1
 Tests  4 failed | 1 passed (5)
```

100 natural leader exits leak 100 teams.

## Evidence the leak is resolved (test PASSES after the fix)

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Each teardown path evicts exactly the exiting leader's team; a concurrently-launched team stays intact; a plain (non-team) PTY exit is a no-op.

## No functional regression

```
claude-agent-teams-service.test.ts + claude-agent-teams-shim-env.test.ts
 Tests  7 passed (7)
```

Eviction is idempotent and scoped to the exiting leader handle; the "leaves a concurrently-launched team intact" and "no-op for a plain PTY" cases guard against over-eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5823">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->