### PR TITLE
Harden runtime IPC sender boundaries

### DIFF
--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -38,6 +38,7 @@ const {
   registerBrowserHandlersMock,
   setAgentBrowserBridgeRefMock,
   setTrustedBrowserRendererWebContentsIdMock,
+  setTrustedRendererWebContentsIdMock,
   registerFilesystemWatcherHandlersMock,
   registerAppHandlersMock,
   registerLinearHandlersMock,
@@ -87,6 +88,7 @@ const {
   registerBrowserHandlersMock: vi.fn(),
   setAgentBrowserBridgeRefMock: vi.fn(),
   setTrustedBrowserRendererWebContentsIdMock: vi.fn(),
+  setTrustedRendererWebContentsIdMock: vi.fn(),
   registerFilesystemWatcherHandlersMock: vi.fn(),
   registerAppHandlersMock: vi.fn(),
   registerLinearHandlersMock: vi.fn(),
@@ -268,6 +270,10 @@ vi.mock('./browser', () => ({
   setAgentBrowserBridgeRef: setAgentBrowserBridgeRefMock
 }))
 
+vi.mock('./trusted-renderer-ipc', () => ({
+  setTrustedRendererWebContentsId: setTrustedRendererWebContentsIdMock
+}))
+
 vi.mock('./app', () => ({
   registerAppHandlers: registerAppHandlersMock
 }))
@@ -327,6 +333,7 @@ describe('registerCoreHandlers', () => {
     registerBrowserHandlersMock.mockReset()
     setAgentBrowserBridgeRefMock.mockReset()
     setTrustedBrowserRendererWebContentsIdMock.mockReset()
+    setTrustedRendererWebContentsIdMock.mockReset()
     registerFilesystemWatcherHandlersMock.mockReset()
     registerAppHandlersMock.mockReset()
     registerLinearHandlersMock.mockReset()
@@ -414,6 +421,7 @@ describe('registerCoreHandlers', () => {
     expect(registerShellHandlersMock).toHaveBeenCalled()
     expect(registerClipboardHandlersMock).toHaveBeenCalled()
     expect(registerUpdaterHandlersMock).toHaveBeenCalled()
+    expect(setTrustedRendererWebContentsIdMock).toHaveBeenCalledWith(null)
     expect(setTrustedBrowserRendererWebContentsIdMock).toHaveBeenCalledWith(null)
     expect(registerBrowserHandlersMock).toHaveBeenCalled()
     expect(registerFilesystemWatcherHandlersMock).toHaveBeenCalled()
@@ -447,6 +455,7 @@ describe('registerCoreHandlers', () => {
     )
 
     // Web contents ID should always be updated
+    expect(setTrustedRendererWebContentsIdMock).toHaveBeenCalledWith(42)
     expect(setTrustedBrowserRendererWebContentsIdMock).toHaveBeenCalledWith(42)
     // IPC handlers should NOT be registered again
     expect(registerCliHandlersMock).not.toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -41,6 +41,7 @@ import { registerKeybindingHandlers } from './keybindings'
 import { registerTelemetryHandlers } from './telemetry'
 import { registerBrowserHandlers } from './browser'
 import { registerShellHandlers } from './shell'
+import { setTrustedRendererWebContentsId } from './trusted-renderer-ipc'
 import { registerPetHandlers } from './pet'
 import { registerUIHandlers } from './ui'
 import { registerEmulatorFrameStreamHandlers } from './emulator-frame-stream'
@@ -91,6 +92,7 @@ export function registerCoreHandlers(
   // openMainWindow() is called again on 'activate'. ipcMain.handle() throws
   // if a channel is registered twice, so we guard to register only once and
   // just update the per-window web-contents ID on subsequent calls.
+  setTrustedRendererWebContentsId(mainWindowWebContentsId)
   setTrustedBrowserRendererWebContentsId(mainWindowWebContentsId)
   setAgentBrowserBridgeRef(runtime.getAgentBrowserBridge())
   if (registered) {

--- a/src/main/ipc/runtime-environments.test.ts
+++ b/src/main/ipc/runtime-environments.test.ts
@@ -60,6 +60,29 @@ vi.mock('./runtime-environment-request-connections', () => ({
 }))
 
 import { registerRuntimeEnvironmentHandlers } from './runtime-environments'
+import { setTrustedRendererWebContentsId } from './trusted-renderer-ipc'
+
+const TRUSTED_WEB_CONTENTS_ID = 1
+
+function trustedEvent(): {
+  sender: {
+    id: number
+    isDestroyed: () => boolean
+    send: ReturnType<typeof vi.fn>
+    once: ReturnType<typeof vi.fn>
+    removeListener: ReturnType<typeof vi.fn>
+  }
+} {
+  return {
+    sender: {
+      id: TRUSTED_WEB_CONTENTS_ID,
+      isDestroyed: () => false,
+      send: vi.fn(),
+      once: vi.fn(),
+      removeListener: vi.fn()
+    }
+  }
+}
 
 function pairingCode(endpoint = 'ws://127.0.0.1:6768'): string {
   return encodePairingOffer({
@@ -75,7 +98,9 @@ function handler<TArgs, TResult>(
 ): (_event: unknown, args: TArgs) => TResult | Promise<TResult> {
   const match = handleMock.mock.calls.find((call) => call[0] === channel)
   expect(match).toBeTruthy()
-  return match![1] as (_event: unknown, args: TArgs) => TResult | Promise<TResult>
+  const registered = match![1] as (_event: unknown, args: TArgs) => TResult | Promise<TResult>
+  return (event: unknown, args: TArgs): TResult | Promise<TResult> =>
+    registered(event ?? trustedEvent(), args)
 }
 
 describe('registerRuntimeEnvironmentHandlers', () => {
@@ -97,6 +122,7 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     getRemoteRuntimeSharedControlDiagnosticsMock.mockReset()
     getRemoteRuntimeSharedControlDiagnosticsMock.mockReturnValue(null)
     closeRemoteRuntimeRequestConnectionMock.mockReset()
+    setTrustedRendererWebContentsId(TRUSTED_WEB_CONTENTS_ID)
   })
 
   afterEach(() => {
@@ -120,6 +146,16 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     expect(onMock.mock.calls.map((call) => call[0])).toEqual([
       'runtimeEnvironments:subscriptionBinary'
     ])
+  })
+
+  it('rejects runtime environment calls from untrusted senders', async () => {
+    registerRuntimeEnvironmentHandlers()
+
+    const list = handler<undefined, { id: string; name: string }[]>('runtimeEnvironments:list')
+
+    expect(() => list({ sender: { id: 999, isDestroyed: () => false } }, undefined)).toThrow(
+      'runtimeEnvironments:list must originate from the trusted Orca renderer'
+    )
   })
 
   it('clears stale IPC registrations before registering runtime environment handlers', () => {
@@ -1404,11 +1440,9 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     const unsubscribe = handler<{ subscriptionId: string }, { unsubscribed: boolean }>(
       'runtimeEnvironments:unsubscribe'
     )
-    expect(
-      await unsubscribe({ sender: { id: 2 } }, { subscriptionId: result.subscriptionId })
-    ).toEqual({
-      unsubscribed: false
-    })
+    expect(() =>
+      unsubscribe({ sender: { id: 2 } }, { subscriptionId: result.subscriptionId })
+    ).toThrow('runtimeEnvironments:unsubscribe must originate from the trusted Orca renderer')
     expect(close).not.toHaveBeenCalled()
 
     expect(

--- a/src/main/ipc/runtime-environments.ts
+++ b/src/main/ipc/runtime-environments.ts
@@ -21,6 +21,7 @@ import {
   resetSharedControlSupport,
   subscribeRuntimeEnvironment
 } from './runtime-environment-transport-routing'
+import { handleTrustedRenderer, isTrustedRendererSender } from './trusted-renderer-ipc'
 
 const RUNTIME_ENVIRONMENT_HANDLER_CHANNELS = [
   'runtimeEnvironments:list',
@@ -66,10 +67,10 @@ export function registerRuntimeEnvironmentHandlers(): void {
   }
   ipcMain.removeAllListeners('runtimeEnvironments:subscriptionBinary')
 
-  ipcMain.handle('runtimeEnvironments:list', (): PublicKnownRuntimeEnvironment[] =>
+  handleTrustedRenderer('runtimeEnvironments:list', (): PublicKnownRuntimeEnvironment[] =>
     listEnvironments(getUserDataPath()).map(redactRuntimeEnvironment)
   )
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtimeEnvironments:addFromPairingCode',
     (
       _event,
@@ -78,12 +79,12 @@ export function registerRuntimeEnvironmentHandlers(): void {
       environment: redactRuntimeEnvironment(addEnvironmentFromPairingCode(getUserDataPath(), args))
     })
   )
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtimeEnvironments:resolve',
     (_event, args: { selector: string }): PublicKnownRuntimeEnvironment =>
       redactRuntimeEnvironment(resolveEnvironment(getUserDataPath(), args.selector))
   )
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtimeEnvironments:remove',
     (_event, args: { selector: string }): { removed: PublicKnownRuntimeEnvironment } => {
       const removed = removeEnvironment(getUserDataPath(), args.selector)
@@ -97,7 +98,7 @@ export function registerRuntimeEnvironmentHandlers(): void {
       return { removed: redactRuntimeEnvironment(removed) }
     }
   )
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtimeEnvironments:disconnect',
     (_event, args: { selector: string }): { disconnected: PublicKnownRuntimeEnvironment } => {
       const environment = resolveEnvironment(getUserDataPath(), args.selector)
@@ -113,7 +114,7 @@ export function registerRuntimeEnvironmentHandlers(): void {
       return { disconnected: redactRuntimeEnvironment(environment) }
     }
   )
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtimeEnvironments:getStatus',
     async (
       _event,
@@ -122,7 +123,7 @@ export function registerRuntimeEnvironmentHandlers(): void {
       return getRuntimeEnvironmentStatus(getUserDataPath(), args.selector, args.timeoutMs)
     }
   )
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtimeEnvironments:call',
     async (
       _event,
@@ -137,7 +138,7 @@ export function registerRuntimeEnvironmentHandlers(): void {
       )
     }
   )
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtimeEnvironments:subscribe',
     async (
       event,
@@ -228,7 +229,7 @@ export function registerRuntimeEnvironmentHandlers(): void {
       return { subscriptionId, requestId: subscription.requestId }
     }
   )
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtimeEnvironments:unsubscribe',
     (event, args: { subscriptionId: string }): { unsubscribed: boolean } => {
       const subscription = remoteRuntimeSubscriptions.get(args.subscriptionId)
@@ -243,6 +244,9 @@ export function registerRuntimeEnvironmentHandlers(): void {
   ipcMain.on(
     'runtimeEnvironments:subscriptionBinary',
     (event, args: { subscriptionId?: unknown; bytes?: unknown }) => {
+      if (!isTrustedRendererSender(event.sender)) {
+        return
+      }
       if (typeof args.subscriptionId !== 'string') {
         return
       }

--- a/src/main/ipc/runtime.test.ts
+++ b/src/main/ipc/runtime.test.ts
@@ -17,12 +17,25 @@ vi.mock('electron', () => ({
 }))
 
 import { registerRuntimeHandlers } from './runtime'
+import { setTrustedRendererWebContentsId } from './trusted-renderer-ipc'
+
+const TRUSTED_WEB_CONTENTS_ID = 42
+
+function trustedEvent(): { sender: { id: number; isDestroyed: () => boolean } } {
+  return {
+    sender: {
+      id: TRUSTED_WEB_CONTENTS_ID,
+      isDestroyed: () => false
+    }
+  }
+}
 
 describe('registerRuntimeHandlers', () => {
   beforeEach(() => {
     handleMock.mockReset()
     removeHandlerMock.mockReset()
     fromWebContentsMock.mockReset()
+    setTrustedRendererWebContentsId(TRUSTED_WEB_CONTENTS_ID)
   })
 
   it('routes sync requests through the authoritative browser window id', () => {
@@ -42,7 +55,7 @@ describe('registerRuntimeHandlers', () => {
     fromWebContentsMock.mockReturnValue({ id: 17 })
 
     const handler = syncRegistration![1]
-    const result = handler({ sender: {} }, { tabs: [], leaves: [] })
+    const result = handler(trustedEvent(), { tabs: [], leaves: [] })
 
     expect(runtime.syncWindowGraph).toHaveBeenCalledWith(17, { tabs: [], leaves: [] })
     expect(result).toEqual({ graphStatus: 'ready' })
@@ -68,7 +81,7 @@ describe('registerRuntimeHandlers', () => {
     expect(callRegistration).toBeTruthy()
 
     const handler = callRegistration![1]
-    const result = await handler({ sender: {} }, { method: 'status.get' })
+    const result = await handler(trustedEvent(), { method: 'status.get' })
 
     expect(result).toMatchObject({
       ok: true,
@@ -91,12 +104,31 @@ describe('registerRuntimeHandlers', () => {
     expect(callRegistration).toBeTruthy()
 
     const handler = callRegistration![1]
-    const result = await handler({ sender: {} }, { method: 'projectGroup.list' })
+    const result = await handler(trustedEvent(), { method: 'projectGroup.list' })
 
     expect(result).toMatchObject({
       ok: true,
       result: { groups: [{ id: 'group-1', name: 'Platform' }] },
       _meta: { runtimeId: 'runtime-1' }
     })
+  })
+
+  it('rejects generic runtime RPC calls from untrusted senders', async () => {
+    const runtime = {
+      syncWindowGraph: vi.fn(),
+      getStatus: vi.fn(),
+      getRuntimeId: vi.fn().mockReturnValue('runtime-1')
+    }
+
+    registerRuntimeHandlers(runtime as never)
+
+    const callRegistration = handleMock.mock.calls.find(([channel]) => channel === 'runtime:call')
+    expect(callRegistration).toBeTruthy()
+
+    const handler = callRegistration![1]
+
+    expect(() =>
+      handler({ sender: { id: 999, isDestroyed: () => false } }, { method: 'status.get' })
+    ).toThrow('runtime:call must originate from the trusted Orca renderer')
   })
 })

--- a/src/main/ipc/runtime.ts
+++ b/src/main/ipc/runtime.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../shared/runtime-types'
 import type { RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
 import { RpcDispatcher } from '../runtime/rpc/dispatcher'
+import { assertTrustedRendererSender, handleTrustedRenderer } from './trusted-renderer-ipc'
 
 export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   ipcMain.removeHandler('runtime:syncWindowGraph')
@@ -18,6 +19,7 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   ipcMain.handle(
     'runtime:syncWindowGraph',
     (event, graph: RuntimeSyncWindowGraph): RuntimeSyncWindowGraphResult => {
+      assertTrustedRendererSender(event, 'runtime:syncWindowGraph')
       const window = BrowserWindow.fromWebContents(event.sender)
       if (!window) {
         throw new Error('Runtime graph sync must originate from a BrowserWindow')
@@ -26,11 +28,11 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
     }
   )
 
-  ipcMain.handle('runtime:getStatus', (): RuntimeStatus => {
+  handleTrustedRenderer('runtime:getStatus', (): RuntimeStatus => {
     return runtime.getStatus()
   })
 
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtime:call',
     async (
       _event,
@@ -46,7 +48,7 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   )
 
   ipcMain.removeHandler('runtime:getTerminalFitOverrides')
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtime:getTerminalFitOverrides',
     (): { ptyId: string; mode: 'mobile-fit'; cols: number; rows: number }[] => {
       const overrides = runtime.getAllTerminalFitOverrides()
@@ -58,7 +60,7 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   )
 
   ipcMain.removeHandler('runtime:getTerminalDrivers')
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtime:getTerminalDrivers',
     (): { ptyId: string; driver: RuntimeTerminalDriverState }[] => {
       const drivers = runtime.getAllTerminalDrivers()
@@ -67,7 +69,7 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   )
 
   ipcMain.removeHandler('runtime:getBrowserDrivers')
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtime:getBrowserDrivers',
     (): { browserPageId: string; driver: RuntimeBrowserDriverState }[] => {
       const drivers = runtime.getAllBrowserDrivers()
@@ -83,7 +85,7 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   // a 'resized' event to any active mobile subscriber. This uses the same
   // code path as the mobile toggle button (terminal.setDisplayMode RPC).
   ipcMain.removeHandler('runtime:restoreTerminalFit')
-  ipcMain.handle('runtime:restoreTerminalFit', async (_event, args: { ptyId: string }) => {
+  handleTrustedRenderer('runtime:restoreTerminalFit', async (_event, args: { ptyId: string }) => {
     // Why: this IPC powers the desktop "Take back" button. Beyond restoring
     // PTY dims (the original semantic), it now also reclaims the input
     // floor for the desktop via the driver state machine. The lock banner
@@ -105,7 +107,7 @@ export function registerRuntimeHandlers(runtime: OrcaRuntimeService): void {
   })
 
   ipcMain.removeHandler('runtime:reclaimBrowserForDesktop')
-  ipcMain.handle(
+  handleTrustedRenderer(
     'runtime:reclaimBrowserForDesktop',
     (_event, args: { browserPageId: string }): { reclaimed: boolean } => {
       try {

--- a/src/main/ipc/trusted-renderer-ipc.ts
+++ b/src/main/ipc/trusted-renderer-ipc.ts
@@ -1,0 +1,49 @@
+import { ipcMain, type IpcMainEvent, type IpcMainInvokeEvent, type WebContents } from 'electron'
+
+let trustedRendererWebContentsId: number | null = null
+
+export function setTrustedRendererWebContentsId(webContentsId: number | null): void {
+  trustedRendererWebContentsId = webContentsId
+}
+
+export function isTrustedRendererSender(sender: WebContents | undefined): boolean {
+  if (!sender || sender.isDestroyed?.()) {
+    return false
+  }
+  if (trustedRendererWebContentsId !== null) {
+    return sender.id === trustedRendererWebContentsId
+  }
+  if (sender.getType?.() !== 'window') {
+    return false
+  }
+  const senderUrl = sender.getURL?.() ?? ''
+  if (process.env.ELECTRON_RENDERER_URL) {
+    try {
+      return new URL(senderUrl).origin === new URL(process.env.ELECTRON_RENDERER_URL).origin
+    } catch {
+      return false
+    }
+  }
+  return senderUrl.startsWith('file://')
+}
+
+export function assertTrustedRendererSender(
+  event: IpcMainEvent | IpcMainInvokeEvent,
+  channel: string
+): void {
+  // Why: high-power desktop IPC channels must not be callable by webview or
+  // offscreen browser content if raw IPC is ever accidentally exposed.
+  if (!isTrustedRendererSender(event.sender)) {
+    throw new Error(`${channel} must originate from the trusted Orca renderer`)
+  }
+}
+
+export function handleTrustedRenderer<TArgs extends unknown[], TResult>(
+  channel: string,
+  handler: (event: IpcMainInvokeEvent, ...args: TArgs) => TResult
+): void {
+  ipcMain.handle(channel, (event, ...args: TArgs): TResult => {
+    assertTrustedRendererSender(event, channel)
+    return handler(event, ...args)
+  })
+}


### PR DESCRIPTION
## Problem

Runtime and runtime-environment IPC handlers are broad entry points into local and remote runtime control. Before this change, those handlers accepted calls without a shared main-process check that the sender was the trusted Orca renderer WebContents.

## Why this is worth fixing

This is a hardening and maintainability improvement for Orca's desktop runtime boundary. It reduces the blast radius if a renderer dependency, guest surface, or future preload change exposes more IPC than intended, and it gives runtime IPC a single reusable trust check instead of per-handler convention.

The goal is not guideline compliance for its own sake. The practical enhancement is that privileged runtime control now fails closed for untrusted senders while valid app-renderer behavior remains unchanged.

## What changed

- Added trusted-renderer-ipc to track the trusted renderer WebContents ID and wrap trusted-only ipcMain.handle registrations.
- Wired the trusted renderer ID from registerCoreHandlers, alongside the existing browser IPC trust ID.
- Applied the guard to runtime and runtime-environment IPC handlers.
- Added tests for accepted trusted senders and rejected untrusted senders.

## Verification

- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/runtime.test.ts src/main/ipc/runtime-environments.test.ts src/main/ipc/register-core-handlers.test.ts
- pnpm run typecheck:node

## ELI5

Runtime IPC handlers now verify the caller is the trusted Orca renderer. Hardens the desktop boundary so untrusted senders cannot drive local/remote runtime control.
