### PR TITLE
fix(window): keep renderer unthrottled on all platforms so backgrounded floating-workspace agents don't freeze

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -286,6 +286,51 @@ describe('createMainWindow', () => {
     }
   })
 
+  it('disables renderer background throttling on every platform so backgrounded agents do not freeze', () => {
+    // Why: a backgrounded renderer otherwise throttles rAF/timers, freezing
+    // terminal rendering and agent status — Claude Code sessions in a minimized
+    // floating workspace looked stuck mid-turn on Windows/Linux. The macOS-only
+    // compositor repaint stays gated to darwin.
+    for (const platform of ['darwin', 'win32', 'linux'] satisfies NodeJS.Platform[]) {
+      browserWindowMock.mockReset()
+      const windowHandlers: Record<string, (...args: any[]) => void> = {}
+      const webContents = {
+        on: vi.fn(),
+        setZoomLevel: vi.fn(),
+        setBackgroundThrottling: vi.fn(),
+        invalidate: vi.fn(),
+        setWindowOpenHandler: vi.fn(),
+        send: vi.fn()
+      }
+      const browserWindowInstance = {
+        webContents,
+        on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          windowHandlers[event] = handler
+        }),
+        isDestroyed: vi.fn(() => false),
+        isMaximized: vi.fn(() => true),
+        isFullScreen: vi.fn(() => false),
+        getSize: vi.fn(() => [1200, 800]),
+        setSize: vi.fn(),
+        setWindowButtonPosition: vi.fn(),
+        maximize: vi.fn(),
+        show: vi.fn(),
+        loadFile: vi.fn(),
+        loadURL: vi.fn()
+      }
+      browserWindowMock.mockImplementation(function () {
+        return browserWindowInstance
+      })
+
+      withPlatform(platform, () => createMainWindow(null))
+
+      expect(webContents.setBackgroundThrottling).toHaveBeenCalledWith(false)
+      const hasRepaintHandlers =
+        typeof windowHandlers.restore === 'function' && typeof windowHandlers.show === 'function'
+      expect(hasRepaintHandlers).toBe(platform === 'darwin')
+    }
+  })
+
   it('supports all minus key variants for terminal zoom out', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -294,13 +294,21 @@ export function createMainWindow(
   })
   const rendererWebContentsId = mainWindow.webContents.id
 
+  // Why: when the renderer is backgrounded (window minimized/occluded), Chromium
+  // stops requestAnimationFrame and throttles timers to ~1Hz, freezing xterm
+  // rendering and the agent status/elapsed timers. A long-running agent (e.g. a
+  // Claude Code session in the often-minimized floating workspace) then looks
+  // stuck mid-turn even though its subprocess keeps running. Keep the renderer
+  // unthrottled on every platform so background agents keep flowing and the UI
+  // resumes cleanly; this previously shipped macOS-only and left Windows/Linux
+  // exposed to the freeze.
+  mainWindow.webContents.setBackgroundThrottling(false)
+
   if (process.platform === 'darwin') {
     // Why: persistent browser webviews use separate compositor layers, and on
     // recent macOS releases those layers can fail to repaint after occlusion or
-    // restore. Disabling main-window throttling and forcing a repaint on
-    // visibility transitions hardens Orca against black-surface failures during
-    // browser-tab restore and tab switching.
-    mainWindow.webContents.setBackgroundThrottling(false)
+    // restore. Force a repaint on visibility transitions to harden against
+    // black-surface failures during browser-tab restore and tab switching.
     mainWindow.on('restore', () => {
       forceRepaint(mainWindow)
     })


### PR DESCRIPTION
## Status: ⚠️ Tentative — fix is correct for a real gap, but not yet confirmed against the exact report

This closes a genuine cross-platform gap that produces the reported symptom, **but I could not reproduce the permanent freeze on macOS** (see *Reproduction* below), and the reporter's OS is currently unknown. If they're on Windows/Linux this is almost certainly their bug; if they're on macOS and only used the in-app minimize, more digging is needed. Opening as a draft so we can confirm the reporter's OS before merge.

---

## TL;DR

`createMainWindow.ts` disabled Chromium background throttling (`setBackgroundThrottling(false)`) **only on macOS**. On Windows and Linux the main-window renderer therefore throttles whenever the window is backgrounded (minimized/occluded): `requestAnimationFrame` stops and `setTimeout`/`setInterval` collapse to ~1 Hz. That freezes the terminal's xterm rendering and the agent status/elapsed timers, so a long-running **Claude Code session in the (often-minimized) floating workspace looks stuck mid-turn** — even though the agent's subprocess is still running fine underneath.

The fix moves the one line that disables throttling out of the `darwin`-only block so it applies on every platform. The macOS-specific compositor `forceRepaint` on restore/show stays gated to `darwin`.

```diff
   const rendererWebContentsId = mainWindow.webContents.id

+  mainWindow.webContents.setBackgroundThrottling(false)   // now all platforms
+
   if (process.platform === 'darwin') {
-    mainWindow.webContents.setBackgroundThrottling(false)  // was macOS-only
     mainWindow.on('restore', () => forceRepaint(mainWindow))
     mainWindow.on('show', () => forceRepaint(mainWindow))
   }
```

## The report

Discord (#bugs, 2026-06-19, from `_fraktall_`): *"I love the floating workspace! But I noticed Claude Code sessions there can get stuck if the floating workspace is minimized mid-assistant turn. Can you replicate?"*

The attached screenshot is Claude Code's own footer **frozen** at `(9m 41s · ↓ 2.6k tokens)` — the spinner/elapsed timer stopped advancing. (`9m 41s` with only `2.6k` output tokens is the signature of a long turn that's mostly *waiting*, e.g. on a tool call, with the timer as the only thing that should be moving.)

Thread: https://discord.com/channels/1492228674081263786/1492228675272315163/1517431114682077306

## Root cause

The "stuck" appearance is a **renderer freeze, not a hang of the agent**. The chain:

1. The Orca renderer is backgrounded (window minimized, occluded, or app hidden).
2. With default Electron `backgroundThrottling` (which is `true`), Chromium throttles the backgrounded page: `requestAnimationFrame` callbacks stop entirely, and `setTimeout`/`setInterval` are clamped to roughly once per second.
3. That stalls three things at once:
   - **xterm rendering** is rAF-driven → Claude Code's in-terminal status line stops repainting and is frozen on its last frame (the `9m 41s` screenshot).
   - The **PTY→xterm background-output drain** is a `setTimeout` pump (`pane-terminal-output-scheduler.ts`) → terminal output barely advances while backgrounded.
   - The **agent status / elapsed-time** `setInterval`s (e.g. `WorktreeCardAgents`) freeze.
4. The agent's subprocess keeps running the whole time (verified — see below). When the window comes back, everything resumes — but until then it reads as a stuck session.

**Why macOS was already immune and Windows/Linux weren't:** the existing `if (process.platform === 'darwin')` block calls `setBackgroundThrottling(false)` (originally added to fix macOS browser-webview "black surface" repaint issues after occlusion/restore). A side effect of that call is that it *also* keeps the terminal/agent renderer alive when the window is backgrounded — but only on macOS. Windows and Linux never got that call, so they remained exposed to the freeze. This PR makes the freeze-immunity uniform.

## The change

- `src/main/window/createMainWindow.ts`
  - Hoist `mainWindow.webContents.setBackgroundThrottling(false)` above the `darwin` check so it runs on **macOS, Windows, and Linux**.
  - Keep the `restore`/`show` → `forceRepaint(mainWindow)` handlers **macOS-only**: they target a macOS-specific compositor black-surface bug, and `forceRepaint` does a 1px window resize nudge that would add a visible flicker on other platforms without benefit (with throttling now off, Win/Linux repaint naturally on restore).
  - Updated the comments so the rationale (terminal/agent freeze) is captured next to the call.
- `src/main/window/createMainWindow.test.ts`
  - New test: asserts `setBackgroundThrottling(false)` is called for `darwin`, `win32`, and `linux`, while the repaint handlers register only on `darwin`.

## Reproduction & investigation (full transparency)

I drove a real dev build via CDP and tested the exact scenario plus several harder variants:

- ✅ **Confirmed: not a deadlock.** Flooded a minimized floating terminal at ~13 MB/s with a side-channel logfile — the subprocess kept running at full rate while hidden. The renderer ACKs PTY data unconditionally (`pty-dispatcher.ts` ACKs in a `finally`), so there is no flow-control backpressure stall.
- ✅ **Confirmed: in-app minimize recovers on macOS.** A real Claude turn (long essay prompt) minimized mid-stream → restored → the essay **completed normally**. The floating-workspace "minimize" is a CSS toggle (`onOpenChange(false)` → `visibility:hidden`, pane `display:none`); the document stays visible, so output keeps draining and it recovers.
- ✅ **Confirmed the mechanism + the guard.** Measured that, while OS-minimized on macOS, `requestAnimationFrame` and `setInterval` keep running at full rate and `document.visibilityState` stays `visible` — i.e. the macOS `setBackgroundThrottling(false)` guard is doing real work. Without that guard (the Windows/Linux situation), the backgrounded page throttles and the symptoms above follow.

**Why I couldn't capture a frozen screenshot on this machine (important caveat):** the freeze needs Chromium throttling to actually engage, which requires **(a)** a platform/condition without the guard (Windows/Linux, or macOS occlusion pre-this-PR) **and (b)** no debugger attached — an attached CDP/DevTools client itself suppresses background throttling. On an instrumented macOS build neither holds, so it always recovers. I reproduced the *action*, the *no-deadlock* fact, and the *protection mechanism*, but not the literal frozen frame.

## Verification

- `vitest run src/main/window/createMainWindow.test.ts` → **54 passed** (incl. the new cross-platform test)
- `tsgo --noEmit -p config/tsconfig.node.json` → clean
- `oxlint` on the changed files → clean
- Confirmed the rebuilt main bundle contains the now-ungated call
- **No macOS regression by construction:** on macOS this is a no-op (the call was already made on `darwin`); only `win32`/`linux` gain it. The macOS path is unchanged, and my earlier macOS minimize/restore Claude test already validates it.

## Risk & tradeoffs

- `setBackgroundThrottling(false)` keeps the renderer running (incl. rAF) while the window is backgrounded → slightly higher CPU/GPU when minimized. For an agentic terminal app this is the desired behavior (you minimize *so agents keep working*), and it's exactly what macOS has shipped with already. The output scheduler still suspends rendering for individually hidden panes, so the cost is bounded.
- Cross-platform safe: `setBackgroundThrottling` is a stable Electron API on all platforms; no platform-specific code paths added.
- SSH/remote unaffected (this is purely main-window renderer scheduling).

## How to confirm on Windows/Linux (test plan)

1. Open the floating workspace, start a Claude Code session, give it a multi-minute task.
2. Mid-turn, minimize the floating workspace **and** background the Orca window (switch to another app).
3. **Before this PR:** the status line freezes and stays frozen on return. **After:** the timer/output keep advancing and the turn completes normally.

## Open question for the reporter

What OS, and did the freeze come from the in-app floating-workspace minimize alone (Orca still in foreground) or from also backgrounding the whole Orca window? Their answer confirms whether this is the complete fix or whether a macOS-specific path also needs attention.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5829">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->