### PR TITLE
Validate shell openPath targets

### DIFF
--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -156,6 +156,17 @@ describe('registerShellHandlers', () => {
       await expect(handler({}, workspacePath)).resolves.toBeUndefined()
       expect(showItemInFolderMock).toHaveBeenCalledWith(normalize(workspacePath))
     })
+
+    it('swallows launcher failures', async () => {
+      showItemInFolderMock.mockImplementationOnce(() => {
+        throw new Error('launcher unavailable')
+      })
+      const workspacePath = resolve('workspace')
+      const handler = getHandler('shell:openPath')
+
+      await expect(handler({}, workspacePath)).resolves.toBeUndefined()
+      expect(showItemInFolderMock).toHaveBeenCalledWith(normalize(workspacePath))
+    })
   })
 
   describe('shell:openInFileManager', () => {

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -130,6 +130,34 @@ describe('registerShellHandlers', () => {
     await expect(handler({})).resolves.toBeNull()
   })
 
+  describe('shell:openPath', () => {
+    it('ignores relative paths', async () => {
+      const handler = getHandler('shell:openPath')
+
+      await expect(handler({}, 'relative/workspace')).resolves.toBeUndefined()
+      expect(statMock).not.toHaveBeenCalled()
+      expect(showItemInFolderMock).not.toHaveBeenCalled()
+    })
+
+    it('ignores missing paths', async () => {
+      statMock.mockRejectedValueOnce(new Error('missing'))
+      const workspacePath = resolve('missing-workspace')
+      const handler = getHandler('shell:openPath')
+
+      await expect(handler({}, workspacePath)).resolves.toBeUndefined()
+      expect(statMock).toHaveBeenCalledWith(normalize(workspacePath))
+      expect(showItemInFolderMock).not.toHaveBeenCalled()
+    })
+
+    it('reveals existing absolute paths', async () => {
+      const workspacePath = resolve('workspace')
+      const handler = getHandler('shell:openPath')
+
+      await expect(handler({}, workspacePath)).resolves.toBeUndefined()
+      expect(showItemInFolderMock).toHaveBeenCalledWith(normalize(workspacePath))
+    })
+  })
+
   describe('shell:openInFileManager', () => {
     it('rejects relative paths', async () => {
       const handler = getHandler('shell:openInFileManager')

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -142,8 +142,10 @@ async function openWithSystemDefault(pathValue: string): Promise<boolean> {
 }
 
 export function registerShellHandlers(): void {
-  ipcMain.handle('shell:openPath', (_event, path: string) => {
-    shell.showItemInFolder(path)
+  ipcMain.handle('shell:openPath', async (_event, path: string): Promise<void> => {
+    // Why: keep the legacy fire-and-forget renderer contract while reusing the
+    // same absolute/existing path validation as the explicit file-manager API.
+    void (await openInFileManager(path))
   })
 
   ipcMain.handle(


### PR DESCRIPTION
## Problem

shell:openPath directly passed the renderer-provided path to the OS reveal call. Other shell file-open paths already validate that a target is absolute and exists, so this older channel behaved inconsistently for malformed, relative, or missing paths.

## Why this is worth fixing

This is a small reliability and safety enhancement for a frequently used desktop path. The app still exposes the same renderer API, but the main process no longer forwards invalid targets to the OS file manager.

The practical improvement is cleaner behavior at the boundary: valid paths still reveal normally, while relative or missing paths are ignored through the same validation path used by the explicit file-manager API.

## What changed

- shell:openPath now delegates through the existing openInFileManager validation path.
- The handler still resolves void for callers, so renderer call sites do not need to change.
- Added tests for relative paths, missing paths, and valid absolute path reveal behavior.

## Verification

- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/shell.test.ts
- pnpm run typecheck:node