### PR TITLE
Rename experimental agent sleep setting

### DIFF
--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -48,7 +48,7 @@ describe('ExperimentalPane', () => {
     )
   })
 
-  it('renders agent hibernation as an off-by-default searchable experimental switch', () => {
+  it('renders agent sleep as an off-by-default searchable experimental switch', () => {
     const settings = getDefaultSettings('/tmp')
     const markup = renderToStaticMarkup(
       <ExperimentalPane settings={settings} updateSettings={vi.fn()} />
@@ -56,12 +56,10 @@ describe('ExperimentalPane', () => {
 
     expect(settings.experimentalAgentHibernation).toBe(false)
     expect(settings.agentHibernationIdleMs).toBe(30 * 60 * 1000)
-    expect(markup).toContain('Agent hibernation')
-    expect(markup).not.toContain('Hibernate after')
+    expect(markup).toContain('Agent sleep')
+    expect(markup).not.toContain('Sleep after')
     expect(markup).toContain('aria-checked="false"')
-    expect(getExperimentalPaneSearchEntries().map((entry) => entry.title)).toContain(
-      'Agent hibernation'
-    )
+    expect(getExperimentalPaneSearchEntries().map((entry) => entry.title)).toContain('Agent sleep')
   })
 
   it('renders new card style as an off-by-default searchable experimental switch', () => {
@@ -78,7 +76,7 @@ describe('ExperimentalPane', () => {
     )
   })
 
-  it('renders the agent hibernation idle duration as configurable minutes', async () => {
+  it('renders the agent sleep idle duration as configurable minutes', async () => {
     const updateSettings = vi.fn()
     const settings = {
       ...getDefaultSettings('/tmp'),
@@ -90,7 +88,7 @@ describe('ExperimentalPane', () => {
       '#experimental-agent-hibernation input[type="number"]'
     )
     if (!idleInput) {
-      throw new Error('Agent hibernation duration input was not rendered')
+      throw new Error('Agent sleep duration input was not rendered')
     }
 
     expect(idleInput.value).toBe('30')
@@ -102,7 +100,7 @@ describe('ExperimentalPane', () => {
     root.unmount()
   })
 
-  it('enables agent hibernation through the experimental switch', async () => {
+  it('enables agent sleep through the experimental switch', async () => {
     const updateSettings = vi.fn()
     const { root, container } = await renderExperimentalPane({ updateSettings })
 
@@ -110,7 +108,7 @@ describe('ExperimentalPane', () => {
       '#experimental-agent-hibernation button[role="switch"]'
     )
     if (!switchButton) {
-      throw new Error('Agent hibernation switch was not rendered')
+      throw new Error('Agent sleep switch was not rendered')
     }
 
     await act(async () => {

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -201,7 +201,7 @@ export function ExperimentalPane({
         <SearchableSetting
           title={translate(
             'auto.components.settings.ExperimentalPane.agentHibernation.title',
-            'Agent hibernation'
+            'Agent sleep'
           )}
           description={translate(
             'auto.components.settings.ExperimentalPane.agentHibernation.description',
@@ -216,7 +216,7 @@ export function ExperimentalPane({
               <Label>
                 {translate(
                   'auto.components.settings.ExperimentalPane.agentHibernation.title',
-                  'Agent hibernation'
+                  'Agent sleep'
                 )}
               </Label>
               <p className="text-xs text-muted-foreground">
@@ -230,7 +230,7 @@ export function ExperimentalPane({
               checked={agentHibernationEnabled}
               ariaLabel={translate(
                 'auto.components.settings.ExperimentalPane.agentHibernation.toggleLabel',
-                'Toggle agent hibernation'
+                'Toggle agent sleep'
               )}
               onChange={() =>
                 updateSettings({
@@ -243,11 +243,11 @@ export function ExperimentalPane({
             <NumberField
               label={translate(
                 'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesLabel',
-                'Hibernate after'
+                'Sleep after'
               )}
               description={translate(
                 'auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesDescription',
-                'How many idle minutes a completed background agent must wait before Orca can hibernate it.'
+                'How many idle minutes a completed background agent must wait before Orca can sleep it.'
               )}
               value={agentHibernationIdleMinutes}
               min={MIN_AGENT_HIBERNATION_IDLE_MS / MS_PER_MINUTE}

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -148,7 +148,7 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
     {
       title: translate(
         'auto.components.settings.experimental.search.agentHibernation.title',
-        'Agent hibernation'
+        'Agent sleep'
       ),
       description: translate(
         'auto.components.settings.experimental.search.agentHibernation.description',
@@ -166,10 +166,6 @@ export const getExperimentalPaneSearchEntries = createLocalizedCatalog(
         ...translateSearchKeyword(
           'auto.components.settings.experimental.search.agentHibernation.agents',
           'agents'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.experimental.search.agentHibernation.hibernate',
-          'hibernate'
         ),
         ...translateSearchKeyword(
           'auto.components.settings.experimental.search.agentHibernation.sleep',
@@ -261,7 +257,7 @@ export function getExperimentalSearchEntry() {
     agentHibernation: findEntry(
       translate(
         'auto.components.settings.experimental.search.agentHibernation.title',
-        'Agent hibernation'
+        'Agent sleep'
       )
     ),
     newWorktreeCardStyle: findEntry(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4750,11 +4750,11 @@
           "agentHibernation": {
             "copy": "Stops idle background agent terminals after the configured idle window and resumes supported sessions when you open them again. Experimental while we tune the safety model.",
             "description": "Stops idle background agent terminals after the configured idle window and resumes supported sessions when you open them again.",
-            "idleMinutesDescription": "How many idle minutes a completed background agent must wait before Orca can hibernate it.",
-            "idleMinutesLabel": "Hibernate after",
+            "idleMinutesDescription": "How many idle minutes a completed background agent must wait before Orca can sleep it.",
+            "idleMinutesLabel": "Sleep after",
             "idleMinutesSuffix": "minutes",
-            "title": "Agent hibernation",
-            "toggleLabel": "Toggle agent hibernation"
+            "title": "Agent sleep",
+            "toggleLabel": "Toggle agent sleep"
           },
           "newWorktreeCardStyle": {
             "copy": "Preview updated worktree-card layout, metadata placement, card-display menu options, and status presentation.",
@@ -6850,11 +6850,10 @@
               "agent": "agent",
               "agents": "agents",
               "description": "Stops idle background agent terminals after the configured idle window and resumes supported sessions when opened again.",
-              "hibernate": "hibernate",
               "minutes": "minutes",
               "sleep": "sleep",
               "terminal": "terminal",
-              "title": "Agent hibernation"
+              "title": "Agent sleep"
             },
             "newWorktreeCardStyle": {
               "card": "card",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4753,11 +4753,11 @@
           "agentHibernation": {
             "copy": "Detiene los terminales de agentes en segundo plano que estén inactivos después del intervalo configurado y reanuda las sesiones compatibles cuando las vuelves a abrir. Experimental mientras ajustamos el modelo de seguridad.",
             "description": "Detiene los terminales de agentes en segundo plano que estén inactivos después del intervalo configurado y reanuda las sesiones compatibles cuando las vuelves a abrir.",
-            "idleMinutesDescription": "Cuántos minutos inactivo debe esperar un agente en segundo plano completado antes de que Orca pueda hibernarlo.",
-            "idleMinutesLabel": "Hibernar después de",
+            "idleMinutesDescription": "Cuántos minutos inactivo debe esperar un agente en segundo plano completado antes de que Orca pueda suspenderlo.",
+            "idleMinutesLabel": "Suspender después de",
             "idleMinutesSuffix": "minutos",
-            "title": "Hibernación de agentes",
-            "toggleLabel": "Alternar hibernación de agentes"
+            "title": "Suspensión de agentes",
+            "toggleLabel": "Alternar suspensión de agentes"
           },
           "newWorktreeCardStyle": {
             "copy": "Previsualiza el diseño actualizado de tarjetas de worktree, la ubicación de metadatos, las opciones del menú de visualización de tarjeta y la presentación de estado.",
@@ -6830,11 +6830,10 @@
               "agent": "agente",
               "agents": "agentes",
               "description": "Detiene los terminales de agentes en segundo plano que estén inactivos después del intervalo configurado y reanuda las sesiones compatibles cuando se vuelven a abrir.",
-              "hibernate": "hibernar",
               "minutes": "minutos",
               "sleep": "suspender",
               "terminal": "terminal",
-              "title": "Hibernación de agentes"
+              "title": "Suspensión de agentes"
             },
             "newWorktreeCardStyle": {
               "card": "tarjeta",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4738,11 +4738,11 @@
           "agentHibernation": {
             "copy": "設定したアイドル時間が経過したバックグラウンド agent terminals を停止し、対応しているセッションは再度開いたときに再開します。安全モデルを調整中の実験的機能です。",
             "description": "設定したアイドル時間が経過したバックグラウンド agent terminals を停止し、対応しているセッションは再度開いたときに再開します。",
-            "idleMinutesDescription": "完了したバックグラウンド agent を Orca が休止状態にできるまで待つアイドル時間（分）。",
-            "idleMinutesLabel": "休止まで",
+            "idleMinutesDescription": "完了したバックグラウンド agent を Orca がスリープ状態にできるまで待つアイドル時間（分）。",
+            "idleMinutesLabel": "スリープまで",
             "idleMinutesSuffix": "分",
-            "title": "Agent の休止",
-            "toggleLabel": "Agent の休止を切り替え"
+            "title": "Agent のスリープ",
+            "toggleLabel": "Agent のスリープを切り替え"
           },
           "newWorktreeCardStyle": {
             "copy": "更新された worktree カードのレイアウト、メタデータ配置、カード表示メニュー項目、ステータス表示をプレビューします。",
@@ -6852,11 +6852,10 @@
               "agent": "agent",
               "agents": "agents",
               "description": "設定したアイドル時間が経過したバックグラウンド agent terminals を停止し、再度開いたときに対応セッションを再開します。",
-              "hibernate": "休止",
               "minutes": "分",
               "sleep": "スリープ",
               "terminal": "terminal",
-              "title": "Agent の休止"
+              "title": "Agent のスリープ"
             },
             "newWorktreeCardStyle": {
               "card": "カード",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4738,11 +4738,11 @@
           "agentHibernation": {
             "copy": "설정된 유휴 시간이 지난 백그라운드 agent terminals을 중지하고, 다시 열 때 지원되는 세션을 재개합니다. 안전 모델을 조정하는 동안 제공되는 실험적 기능입니다.",
             "description": "설정된 유휴 시간이 지난 백그라운드 agent terminals을 중지하고, 다시 열 때 지원되는 세션을 재개합니다.",
-            "idleMinutesDescription": "완료된 백그라운드 agent를 Orca가 최대 절전 모드로 전환하기 전에 기다릴 유휴 시간(분)입니다.",
-            "idleMinutesLabel": "최대 절전까지",
+            "idleMinutesDescription": "완료된 백그라운드 agent를 Orca가 절전 모드로 전환하기 전에 기다릴 유휴 시간(분)입니다.",
+            "idleMinutesLabel": "절전까지",
             "idleMinutesSuffix": "분",
-            "title": "Agent 최대 절전",
-            "toggleLabel": "Agent 최대 절전 전환"
+            "title": "Agent 절전",
+            "toggleLabel": "Agent 절전 전환"
           },
           "newWorktreeCardStyle": {
             "copy": "업데이트된 worktree 카드 레이아웃, 메타데이터 배치, 카드 표시 메뉴 옵션 및 상태 표시를 미리 봅니다.",
@@ -6815,11 +6815,10 @@
               "agent": "agent",
               "agents": "agents",
               "description": "설정된 유휴 시간이 지난 백그라운드 agent terminals을 중지하고, 다시 열 때 지원되는 세션을 재개합니다.",
-              "hibernate": "최대 절전",
               "minutes": "분",
               "sleep": "절전",
               "terminal": "terminal",
-              "title": "Agent 최대 절전"
+              "title": "Agent 절전"
             },
             "newWorktreeCardStyle": {
               "card": "카드",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4738,11 +4738,11 @@
           "agentHibernation": {
             "copy": "在配置的空闲时间后停止后台 agent 终端，并在你再次打开时恢复受支持的会话。我们仍在调校安全模型，此功能为实验性功能。",
             "description": "在配置的空闲时间后停止后台 agent 终端，并在你再次打开时恢复受支持的会话。",
-            "idleMinutesDescription": "已完成的后台 agent 在 Orca 可以将其休眠前需要等待的空闲分钟数。",
-            "idleMinutesLabel": "休眠等待时间",
+            "idleMinutesDescription": "已完成的后台 agent 在 Orca 可以将其睡眠前需要等待的空闲分钟数。",
+            "idleMinutesLabel": "睡眠等待时间",
             "idleMinutesSuffix": "分钟",
-            "title": "Agent 休眠",
-            "toggleLabel": "切换 agent 休眠"
+            "title": "Agent 睡眠",
+            "toggleLabel": "切换 agent 睡眠"
           },
           "newWorktreeCardStyle": {
             "copy": "预览更新后的 worktree 卡片布局、元数据位置、卡片显示菜单选项和状态呈现。",
@@ -6815,11 +6815,10 @@
               "agent": "agent",
               "agents": "agents",
               "description": "在配置的空闲时间后停止后台 agent 终端，并在再次打开时恢复受支持的会话。",
-              "hibernate": "休眠",
               "minutes": "分钟",
               "sleep": "睡眠",
               "terminal": "终端",
-              "title": "Agent 休眠"
+              "title": "Agent 睡眠"
             },
             "newWorktreeCardStyle": {
               "card": "卡片",

--- a/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
@@ -169,7 +169,7 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-describe('agent hibernation coordinator', () => {
+describe('agent sleep coordinator', () => {
   it('hibernates an eligible background worktree after two stable ticks', async () => {
     vi.useFakeTimers()
     const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -86,7 +86,7 @@ function plannedPaneKeys(input: AgentHibernationPlannerSnapshot): string[] {
   return planAgentHibernationCandidates(input).map((candidate) => candidate.paneKey)
 }
 
-describe('agent hibernation planner', () => {
+describe('agent sleep planner', () => {
   it('selects nothing when disabled, active, or foreground', () => {
     expect(
       plannedWorktrees(

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -3104,7 +3104,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
   })
 
-  it('records terminal input even before agent hibernation is enabled', () => {
+  it('records terminal input even before agent sleep is enabled', () => {
     const store = createTestStore()
 
     store.getState().recordTerminalInput('tab-1:leaf-1', 1000)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2195,7 +2195,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       get().clearSleepingAgentSessionsByWorktree(worktreeId)
     }
 
-    // Why: only automatic completed-agent hibernation keeps passive completion
+    // Why: only automatic completed-agent sleep keeps passive completion
     // evidence; manual sleep/remove still fold the entire worktree surface.
     get().dropAgentStatusByWorktree(worktreeId, {
       shutdownReason,


### PR DESCRIPTION
## Summary
- Renames the experimental settings copy from "Agent hibernation" to "Agent sleep" in the Settings > Experimental UI.
- Updates the settings search catalog, English defaults, all checked-in locale files (`en`, `es`, `ja`, `ko`, `zh`), and related test/comment prose.
- Keeps internal setting IDs/types unchanged to avoid persistence or migration risk.
- Adds the pre-existing missing `SourceControlEntryContextMenu` `View` locale key across locales so localization catalog verification passes.

## Screenshots
- Manual validation screenshot captured locally, not committed: `.playwright-cli/agent-sleep-enabled-experimental-settings.png`.
- The screenshot shows Settings > Experimental with `Agent sleep` enabled and the `Sleep after` idle-minutes control visible.

## Testing Checklist
- [x] `git diff --check`
- [x] Locale JSON parse for `en`, `es`, `ja`, `ko`, `zh`
- [x] `node config/scripts/verify-localization-catalog.mjs`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ExperimentalPane.test.tsx`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] Pre-commit hook: `oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt --write`
- [x] Electron manual validation of Settings > Experimental on this exact worktree
- [x] GitHub checks after PR open: `verify`, `track-community-pr`

## AI Review Report
- Design and implementation stages: skipped at Brennan's explicit request because the rename was already implemented before PR prep.
- Design-review outcome: skipped with the same explicit direction.
- Completeness verification: stale visible-copy searches found no `Agent hibernation`, `agent hibernation`, `Toggle agent hibernation`, or `Hibernate after` in the touched settings/locales/test surfaces. Locale sanity check confirmed all five locale files have the new title/search title and no legacy `hibernate` keyword.
- Code review: two delegated review passes completed clean on the final diff. One earlier reviewer noted the removed hidden `hibernate` search alias as a low-risk intentional rename tradeoff; final reviewers found no actionable issues.
- Brennan test result: `land` for this copy/localization-only change.
- Cross-platform/SSH: no OS-specific logic, path behavior, shortcuts, runtime transport, SSH, or remoting code changed. Internal persisted keys remain unchanged.

## Security Audit
- No new IPC, filesystem, network, authentication, provider, telemetry, or external side-effect behavior.
- No agent prompt/instruction text changed.
- The diff is limited to settings UI copy, search metadata, locale JSON, tests, and one explanatory comment.

## Manual Validation
- Launched this exact worktree in Electron with CDP and verified `window.api.app.getIdentity()` reported branch `brennanb2025/rename-agent-sleep` and root `/Users/thebr/orca/workspaces/orca/oarfish`.
- Navigated through the real Settings UI to Experimental, verified `Agent sleep` is visible and old visible labels are absent.
- Enabled the switch in an isolated dev profile and verified `Sleep after` appears with the updated description.
- Console notes: clean second-pass UI run had 0 errors and 3 warnings; warnings were existing dev/runtime noise, not rename-specific.

## Post-PR Stabilization
- Waited the required 8 minutes after opening the PR.
- CodeRabbit reported no actionable comments.
- GitHub checks passed: `verify`, `track-community-pr`.
- CodeRabbit's docstring-coverage pre-merge warning is treated as non-actionable for this copy-only diff because no public API/function behavior was added.

## Accepted Gaps
- No SSH/remoting live pass: this diff only changes settings copy, locale JSON, and test/comment prose.
- The old hidden search alias `hibernate` was intentionally removed so the setting is renamed consistently everywhere user-facing/searchable.
