### PR TITLE
Hide native scrollbars on terminal tab strip

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -510,6 +510,34 @@
   height: 0;
 }
 
+/* Why: mask fades avoid painting card-colored overlays that mismatch active tabs. */
+.terminal-tab-strip--fade-start.terminal-tab-strip--fade-end {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent,
+    #000 1.5rem,
+    #000 calc(100% - 1.5rem),
+    transparent
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    #000 1.5rem,
+    #000 calc(100% - 1.5rem),
+    transparent
+  );
+}
+
+.terminal-tab-strip--fade-start:not(.terminal-tab-strip--fade-end) {
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 1.5rem, #000 100%);
+  mask-image: linear-gradient(to right, transparent, #000 1.5rem, #000 100%);
+}
+
+.terminal-tab-strip--fade-end:not(.terminal-tab-strip--fade-start) {
+  -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 1.5rem), transparent);
+  mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 1.5rem), transparent);
+}
+
 /* Tab activity affordance (amber wash) is rendered as a React DOM child in
    SortableTab.tsx rather than via ::after here, so the drop-indicator
    ::before/::after pseudo-elements stay free for drag-and-drop feedback. See

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -496,13 +496,15 @@
   height: 0;
 }
 
+/* Why: horizontal tab strips scroll via chevrons, wheel, and trackpad; a
+   native scrollbar thumb overlays tab labels and looks broken. */
+.terminal-tab-strip,
 .project-view-tab-strip {
-  /* Why: project views load after the table shell; keeping the row stable
-     prevents the list below from jumping when the tabs arrive. */
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
 
+.terminal-tab-strip::-webkit-scrollbar,
 .project-view-tab-strip::-webkit-scrollbar {
   width: 0;
   height: 0;

--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -330,7 +330,7 @@ describe('TabBar context menu wiring', () => {
     expect(strip?.props.className).toContain('min-w-0')
     expect(strip?.props.className).toContain('flex-[0_1_auto]')
     expect(strip?.props.className).toContain('overflow-x-auto')
-    expect(strip?.props.className).toContain('scrollbar-sleek')
+    expect(strip?.props.className).not.toContain('scrollbar-sleek')
   })
 
   it('passes the editor unifiedTabId when EditorFileTab triggers onCloseToRight', async () => {

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -72,6 +72,8 @@ import { buildTabCreateMenuOptions, type TabCreateMenuOption } from './tab-creat
 import { MobileEmulatorTabIntroCallout } from '../emulator-pane/MobileEmulatorTabIntroCallout'
 import { shouldShowMobileEmulatorTabIntro } from '../emulator-pane/mobile-emulator-tab-intro-visibility'
 import { translate } from '@/i18n/i18n'
+import { TabStripScrollIndicator } from './TabStripScrollIndicator'
+import { getTabStripScrollMaskClassName } from './tab-strip-scroll-metrics'
 import { useTabStripOverflowNavigation } from './tab-strip-overflow-navigation'
 
 const isWindows = navigator.userAgent.includes('Windows')
@@ -1022,107 +1024,141 @@ function TabBarInner({
             region. The outer container inherits drag so empty space after the
             "+" button remains window-draggable. */}
         <div
-          ref={tabStripRef}
-          // Why: only `border-r` on the strip — the trailing edge must stay
-          // visible even when tabs overflow-scroll past the last tab. The
-          // left edge is instead painted by the FIRST tab's own `border-l`
-          // (see per-tab components) so its rendering is identical to every
-          // between-tab separator. A strip-level `border-l` would render at
-          // a different box than the tab's own `border-t`, producing a
-          // heavier-looking L-corner at the leftmost tab when inactive.
-          className="terminal-tab-strip flex min-w-0 max-w-full flex-[0_1_auto] items-stretch overflow-x-auto overflow-y-hidden border-r border-border"
+          className="relative flex min-h-0 min-w-0 max-w-full flex-[0_1_auto]"
           style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
         >
-          {orderedItems.map((item, index) => {
-            const dragData: TabDragItemData = {
-              kind: 'tab',
-              worktreeId,
-              groupId: resolvedGroupId,
-              unifiedTabId: item.unifiedTabId,
-              visibleTabId: item.id,
-              tabType: item.type,
-              label: getTabDragLabel(item, generatedTabTitlesEnabled),
-              iconPath: item.type === 'editor' ? item.data.filePath : undefined,
-              color: item.type === 'terminal' ? (item.data.color ?? null) : null
-            }
-            if (item.type === 'terminal') {
-              const terminalTab = {
-                ...item.data,
-                title: resolveTerminalTabTitle(
-                  item.data,
-                  generatedTabTitlesEnabled,
-                  item.data.title
+          <div
+            ref={tabStripRef}
+            // Why: only `border-r` on the strip — the trailing edge must stay
+            // visible even when tabs overflow-scroll past the last tab. The
+            // left edge is instead painted by the FIRST tab's own `border-l`
+            // (see per-tab components) so its rendering is identical to every
+            // between-tab separator. A strip-level `border-l` would render at
+            // a different box than the tab's own `border-t`, producing a
+            // heavier-looking L-corner at the leftmost tab when inactive.
+            className={[
+              'terminal-tab-strip flex h-full min-w-0 max-w-full flex-1 items-stretch overflow-x-auto overflow-y-hidden border-r border-border',
+              getTabStripScrollMaskClassName(tabStripOverflowState)
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            {orderedItems.map((item, index) => {
+              const dragData: TabDragItemData = {
+                kind: 'tab',
+                worktreeId,
+                groupId: resolvedGroupId,
+                unifiedTabId: item.unifiedTabId,
+                visibleTabId: item.id,
+                tabType: item.type,
+                label: getTabDragLabel(item, generatedTabTitlesEnabled),
+                iconPath: item.type === 'editor' ? item.data.filePath : undefined,
+                color: item.type === 'terminal' ? (item.data.color ?? null) : null
+              }
+              if (item.type === 'terminal') {
+                const terminalTab = {
+                  ...item.data,
+                  title: resolveTerminalTabTitle(
+                    item.data,
+                    generatedTabTitlesEnabled,
+                    item.data.title
+                  )
+                }
+                return (
+                  <SortableTab
+                    key={item.id}
+                    tab={terminalTab}
+                    tabCount={orderedItems.length}
+                    hasTabsToRight={index < orderedItems.length - 1}
+                    isActive={
+                      (activeTabType === 'terminal' || activeTabType === 'simulator') &&
+                      item.id === activeTabId
+                    }
+                    isPinned={item.isPinned}
+                    isExpanded={expandedPaneByTabId[item.id] === true}
+                    onActivate={onActivate}
+                    onClose={onClose}
+                    onCloseOthers={onCloseOthers}
+                    onCloseToRight={onCloseToRight}
+                    onSetCustomTitle={onSetCustomTitle}
+                    onSetTabColor={onSetTabColor}
+                    onTogglePin={() => togglePinned(item)}
+                    onToggleExpand={onTogglePaneExpand}
+                    onSplitGroup={(direction, sourceVisibleTabId) =>
+                      onCreateSplitGroup?.(direction, sourceVisibleTabId)
+                    }
+                    dragData={dragData}
+                    dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
+                    includeTopTabBorder={includeTopTabBorder}
+                  />
                 )
               }
-              return (
-                <SortableTab
-                  key={item.id}
-                  tab={terminalTab}
-                  tabCount={orderedItems.length}
-                  hasTabsToRight={index < orderedItems.length - 1}
-                  isActive={
-                    (activeTabType === 'terminal' || activeTabType === 'simulator') &&
-                    item.id === activeTabId
-                  }
-                  isPinned={item.isPinned}
-                  isExpanded={expandedPaneByTabId[item.id] === true}
-                  onActivate={onActivate}
-                  onClose={onClose}
-                  onCloseOthers={onCloseOthers}
-                  onCloseToRight={onCloseToRight}
-                  onSetCustomTitle={onSetCustomTitle}
-                  onSetTabColor={onSetTabColor}
-                  onTogglePin={() => togglePinned(item)}
-                  onToggleExpand={onTogglePaneExpand}
-                  onSplitGroup={(direction, sourceVisibleTabId) =>
-                    onCreateSplitGroup?.(direction, sourceVisibleTabId)
-                  }
-                  dragData={dragData}
-                  dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
-                  includeTopTabBorder={includeTopTabBorder}
-                />
-              )
-            }
-            if (item.type === 'browser') {
-              return (
-                <BrowserTab
-                  key={item.id}
-                  tab={item.data}
-                  isActive={activeTabType === 'browser' && activeBrowserTabId === item.id}
-                  isPinned={item.isPinned}
-                  hasTabsToRight={index < orderedItems.length - 1}
-                  onActivate={() => onActivateBrowserTab?.(item.id)}
-                  onClose={() => onCloseBrowserTab?.(item.id)}
-                  onCloseToRight={() => onCloseToRight(item.id)}
-                  onSplitGroup={(direction, sourceVisibleTabId) =>
-                    onCreateSplitGroup?.(direction, sourceVisibleTabId)
-                  }
-                  onDuplicate={() => onDuplicateBrowserTab?.(item.id)}
-                  onTogglePin={() => togglePinned(item)}
-                  dragData={dragData}
-                  dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
-                  includeTopTabBorder={includeTopTabBorder}
-                />
-              )
-            }
-            if (item.type === 'simulator') {
-              const simLabel = item.data.label || 'Mobile Emulator'
-              const simFile: OpenFile & { tabId: string } = {
-                id: item.id,
-                tabId: item.id,
-                filePath: simLabel,
-                relativePath: simLabel,
-                worktreeId,
-                language: 'simulator',
-                isPreview: false,
-                isDirty: false,
-                mode: 'edit'
+              if (item.type === 'browser') {
+                return (
+                  <BrowserTab
+                    key={item.id}
+                    tab={item.data}
+                    isActive={activeTabType === 'browser' && activeBrowserTabId === item.id}
+                    isPinned={item.isPinned}
+                    hasTabsToRight={index < orderedItems.length - 1}
+                    onActivate={() => onActivateBrowserTab?.(item.id)}
+                    onClose={() => onCloseBrowserTab?.(item.id)}
+                    onCloseToRight={() => onCloseToRight(item.id)}
+                    onSplitGroup={(direction, sourceVisibleTabId) =>
+                      onCreateSplitGroup?.(direction, sourceVisibleTabId)
+                    }
+                    onDuplicate={() => onDuplicateBrowserTab?.(item.id)}
+                    onTogglePin={() => togglePinned(item)}
+                    dragData={dragData}
+                    dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
+                    includeTopTabBorder={includeTopTabBorder}
+                  />
+                )
+              }
+              if (item.type === 'simulator') {
+                const simLabel = item.data.label || 'Mobile Emulator'
+                const simFile: OpenFile & { tabId: string } = {
+                  id: item.id,
+                  tabId: item.id,
+                  filePath: simLabel,
+                  relativePath: simLabel,
+                  worktreeId,
+                  language: 'simulator',
+                  isPreview: false,
+                  isDirty: false,
+                  mode: 'edit'
+                }
+                return (
+                  <EditorFileTab
+                    key={item.id}
+                    file={simFile}
+                    isActive={activeTabType === 'simulator' && item.id === activeSimulatorTabId}
+                    isPinned={item.isPinned}
+                    hasTabsToRight={index < orderedItems.length - 1}
+                    statusByRelativePath={statusByRelativePath}
+                    onActivate={() => onActivateFile?.(item.id)}
+                    onClose={() => onCloseFile?.(item.id)}
+                    onCloseToRight={() => onCloseToRight(item.id)}
+                    onCloseAll={() => onCloseAllFiles?.()}
+                    onMakePermanent={() => {}}
+                    onTogglePin={() => togglePinned(item)}
+                    onSplitGroup={(direction, sourceVisibleTabId) =>
+                      onCreateSplitGroup?.(direction, sourceVisibleTabId)
+                    }
+                    dragData={dragData}
+                    dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
+                    includeTopTabBorder={includeTopTabBorder}
+                  />
+                )
               }
               return (
                 <EditorFileTab
                   key={item.id}
-                  file={simFile}
-                  isActive={activeTabType === 'simulator' && item.id === activeSimulatorTabId}
+                  file={item.data}
+                  isActive={
+                    (activeTabType === 'editor' || activeTabType === 'simulator') &&
+                    activeFileId === item.id
+                  }
                   isPinned={item.isPinned}
                   hasTabsToRight={index < orderedItems.length - 1}
                   statusByRelativePath={statusByRelativePath}
@@ -1130,7 +1166,9 @@ function TabBarInner({
                   onClose={() => onCloseFile?.(item.id)}
                   onCloseToRight={() => onCloseToRight(item.id)}
                   onCloseAll={() => onCloseAllFiles?.()}
-                  onMakePermanent={() => {}}
+                  onMakePermanent={() =>
+                    onMakePreviewFilePermanent?.(item.data.id, item.data.tabId)
+                  }
                   onTogglePin={() => togglePinned(item)}
                   onSplitGroup={(direction, sourceVisibleTabId) =>
                     onCreateSplitGroup?.(direction, sourceVisibleTabId)
@@ -1140,33 +1178,9 @@ function TabBarInner({
                   includeTopTabBorder={includeTopTabBorder}
                 />
               )
-            }
-            return (
-              <EditorFileTab
-                key={item.id}
-                file={item.data}
-                isActive={
-                  (activeTabType === 'editor' || activeTabType === 'simulator') &&
-                  activeFileId === item.id
-                }
-                isPinned={item.isPinned}
-                hasTabsToRight={index < orderedItems.length - 1}
-                statusByRelativePath={statusByRelativePath}
-                onActivate={() => onActivateFile?.(item.id)}
-                onClose={() => onCloseFile?.(item.id)}
-                onCloseToRight={() => onCloseToRight(item.id)}
-                onCloseAll={() => onCloseAllFiles?.()}
-                onMakePermanent={() => onMakePreviewFilePermanent?.(item.data.id, item.data.tabId)}
-                onTogglePin={() => togglePinned(item)}
-                onSplitGroup={(direction, sourceVisibleTabId) =>
-                  onCreateSplitGroup?.(direction, sourceVisibleTabId)
-                }
-                dragData={dragData}
-                dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
-                includeTopTabBorder={includeTopTabBorder}
-              />
-            )
-          })}
+            })}
+          </div>
+          <TabStripScrollIndicator metrics={tabStripOverflowState} />
         </div>
       </SortableContext>
       {tabStripOverflowState.hasOverflow ? (

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -1030,7 +1030,7 @@ function TabBarInner({
           // between-tab separator. A strip-level `border-l` would render at
           // a different box than the tab's own `border-t`, producing a
           // heavier-looking L-corner at the leftmost tab when inactive.
-          className="terminal-tab-strip scrollbar-sleek flex min-w-0 max-w-full flex-[0_1_auto] items-stretch overflow-x-auto overflow-y-hidden border-r border-border"
+          className="terminal-tab-strip flex min-w-0 max-w-full flex-[0_1_auto] items-stretch overflow-x-auto overflow-y-hidden border-r border-border"
           style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
         >
           {orderedItems.map((item, index) => {

--- a/src/renderer/src/components/tab-bar/TabStripScrollIndicator.tsx
+++ b/src/renderer/src/components/tab-bar/TabStripScrollIndicator.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import {
+  computeTabStripThumbLayout,
+  type TabStripScrollMetrics,
+  type TabStripThumbLayout
+} from './tab-strip-scroll-metrics'
+
+const EMPTY_THUMB_LAYOUT: TabStripThumbLayout = { widthPx: 0, leftPx: 0 }
+
+export function TabStripScrollIndicator({
+  metrics
+}: {
+  metrics: TabStripScrollMetrics
+}): React.JSX.Element | null {
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [thumbLayout, setThumbLayout] = useState<TabStripThumbLayout>(EMPTY_THUMB_LAYOUT)
+
+  const remeasureThumb = useCallback((): void => {
+    const track = trackRef.current
+    if (!track) {
+      return
+    }
+    setThumbLayout(computeTabStripThumbLayout(track.clientWidth, metrics))
+  }, [metrics])
+
+  useLayoutEffect(() => {
+    remeasureThumb()
+  }, [remeasureThumb])
+
+  useLayoutEffect(() => {
+    const track = trackRef.current
+    if (!track) {
+      return
+    }
+    const resizeObserver = new ResizeObserver(remeasureThumb)
+    resizeObserver.observe(track)
+    return () => resizeObserver.disconnect()
+  }, [remeasureThumb])
+
+  if (!metrics.hasOverflow) {
+    return null
+  }
+
+  return (
+    // Why: top rail keeps the active tab's bottom underline unobstructed.
+    <div
+      ref={trackRef}
+      className="pointer-events-none absolute inset-x-0 top-0 z-[1] h-px bg-muted-foreground/10"
+      aria-hidden
+    >
+      <div
+        className="absolute top-0 h-full rounded-full bg-muted-foreground/40 transition-[left,width] duration-75 ease-out"
+        style={{
+          width: `${thumbLayout.widthPx}px`,
+          left: `${thumbLayout.leftPx}px`
+        }}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-bar/tab-strip-content-resize-observers.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-content-resize-observers.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import { bindTabStripContentResizeObservers } from './tab-strip-content-resize-observers'
+
+describe('bindTabStripContentResizeObservers', () => {
+  it('observes the strip and its tab children', () => {
+    const onResize = vi.fn()
+    const strip = document.createElement('div')
+    const firstTab = document.createElement('div')
+    const secondTab = document.createElement('div')
+    strip.append(firstTab, secondTab)
+
+    const observe = vi.fn()
+    const disconnect = vi.fn()
+    const resizeObserver = vi.fn(function ResizeObserver(
+      this: ResizeObserver,
+      callback: ResizeObserverCallback
+    ) {
+      this.observe = observe
+      this.disconnect = disconnect
+      callback([], this)
+    })
+
+    vi.stubGlobal('ResizeObserver', resizeObserver)
+
+    const disconnectObservers = bindTabStripContentResizeObservers(strip, onResize)
+
+    expect(observe).toHaveBeenCalledWith(strip)
+    expect(observe).toHaveBeenCalledWith(firstTab)
+    expect(observe).toHaveBeenCalledWith(secondTab)
+    expect(onResize).toHaveBeenCalled()
+
+    disconnectObservers()
+    expect(disconnect).toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/renderer/src/components/tab-bar/tab-strip-content-resize-observers.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-content-resize-observers.ts
@@ -1,0 +1,29 @@
+export function bindTabStripContentResizeObservers(
+  strip: HTMLElement,
+  onResize: () => void
+): () => void {
+  const resizeObserver = new ResizeObserver(onResize)
+
+  const observeTargets = (): void => {
+    resizeObserver.disconnect()
+    resizeObserver.observe(strip)
+    for (const child of strip.children) {
+      if (child instanceof HTMLElement) {
+        resizeObserver.observe(child)
+      }
+    }
+  }
+
+  observeTargets()
+
+  const mutationObserver = new MutationObserver(() => {
+    observeTargets()
+    onResize()
+  })
+  mutationObserver.observe(strip, { childList: true })
+
+  return () => {
+    resizeObserver.disconnect()
+    mutationObserver.disconnect()
+  }
+}

--- a/src/renderer/src/components/tab-bar/tab-strip-overflow-navigation.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-overflow-navigation.ts
@@ -1,39 +1,20 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
+import { bindTabStripContentResizeObservers } from './tab-strip-content-resize-observers'
+import {
+  computeTabStripScrollMetrics,
+  sameTabStripScrollMetrics,
+  type TabStripScrollMetrics
+} from './tab-strip-scroll-metrics'
 
 const TAB_STRIP_SCROLL_FRACTION = 0.75
 const TAB_STRIP_MIN_SCROLL_STEP_PX = 120
 
-type TabStripOverflowState = {
-  hasOverflow: boolean
-  canScrollStart: boolean
-  canScrollEnd: boolean
-}
-
-const EMPTY_TAB_STRIP_OVERFLOW_STATE: TabStripOverflowState = {
+const EMPTY_TAB_STRIP_OVERFLOW_STATE: TabStripScrollMetrics = {
   hasOverflow: false,
   canScrollStart: false,
-  canScrollEnd: false
-}
-
-function readTabStripOverflowState(el: HTMLElement): TabStripOverflowState {
-  const maxScrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
-  const hasOverflow = maxScrollLeft > 1
-  return {
-    hasOverflow,
-    canScrollStart: hasOverflow && el.scrollLeft > 1,
-    canScrollEnd: hasOverflow && el.scrollLeft < maxScrollLeft - 1
-  }
-}
-
-function sameTabStripOverflowState(
-  left: TabStripOverflowState,
-  right: TabStripOverflowState
-): boolean {
-  return (
-    left.hasOverflow === right.hasOverflow &&
-    left.canScrollStart === right.canScrollStart &&
-    left.canScrollEnd === right.canScrollEnd
-  )
+  canScrollEnd: false,
+  thumbSizeFraction: 1,
+  thumbOffsetFraction: 0
 }
 
 export function useTabStripOverflowNavigation({
@@ -48,13 +29,13 @@ export function useTabStripOverflowNavigation({
   worktreeId: string
 }): {
   tabStripRef: RefObject<HTMLDivElement | null>
-  tabStripOverflowState: TabStripOverflowState
+  tabStripOverflowState: TabStripScrollMetrics
   scrollTabStrip: (direction: 'start' | 'end') => void
 } {
   const tabStripRef = useRef<HTMLDivElement>(null)
   const prevStripLenRef = useRef<{ worktreeId: string; len: number } | null>(null)
   const stickToEndRef = useRef(false)
-  const [tabStripOverflowState, setTabStripOverflowState] = useState<TabStripOverflowState>(
+  const [tabStripOverflowState, setTabStripOverflowState] = useState<TabStripScrollMetrics>(
     EMPTY_TAB_STRIP_OVERFLOW_STATE
   )
   const updateTabStripOverflowState = useCallback((): void => {
@@ -62,29 +43,25 @@ export function useTabStripOverflowNavigation({
     if (!el) {
       return
     }
-    const next = readTabStripOverflowState(el)
+    const next = computeTabStripScrollMetrics(el)
     setTabStripOverflowState((previous) =>
-      sameTabStripOverflowState(previous, next) ? previous : next
+      sameTabStripScrollMetrics(previous, next) ? previous : next
     )
   }, [])
-  const scrollTabStrip = useCallback(
-    (direction: 'start' | 'end'): void => {
-      const el = tabStripRef.current
-      if (!el) {
-        return
-      }
-      const scrollStep = Math.max(
-        TAB_STRIP_MIN_SCROLL_STEP_PX,
-        el.clientWidth * TAB_STRIP_SCROLL_FRACTION
-      )
-      el.scrollBy({
-        left: direction === 'start' ? -scrollStep : scrollStep,
-        behavior: 'smooth'
-      })
-      requestAnimationFrame(updateTabStripOverflowState)
-    },
-    [updateTabStripOverflowState]
-  )
+  const scrollTabStrip = useCallback((direction: 'start' | 'end'): void => {
+    const el = tabStripRef.current
+    if (!el) {
+      return
+    }
+    const scrollStep = Math.max(
+      TAB_STRIP_MIN_SCROLL_STEP_PX,
+      el.clientWidth * TAB_STRIP_SCROLL_FRACTION
+    )
+    el.scrollBy({
+      left: direction === 'start' ? -scrollStep : scrollStep,
+      behavior: 'smooth'
+    })
+  }, [])
 
   useEffect(() => {
     const el = tabStripRef.current
@@ -119,7 +96,7 @@ export function useTabStripOverflowNavigation({
     el.addEventListener('scroll', onScroll, { passive: true })
     onScroll()
 
-    const ro = new ResizeObserver(() => {
+    const handleStripResize = (): void => {
       updateTabStripOverflowState()
       // If the user is pinned to the right edge, keep it pinned even as tab
       // labels (e.g. "Terminal 5" -> branch name) expand and change scrollWidth.
@@ -127,12 +104,13 @@ export function useTabStripOverflowNavigation({
         return
       }
       el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
-    })
-    ro.observe(el)
+    }
+
+    const disconnectResizeObservers = bindTabStripContentResizeObservers(el, handleStripResize)
 
     return () => {
       el.removeEventListener('scroll', onScroll)
-      ro.disconnect()
+      disconnectResizeObservers()
     }
   }, [updateTabStripOverflowState])
 

--- a/src/renderer/src/components/tab-bar/tab-strip-scroll-metrics.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-scroll-metrics.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeTabStripScrollMetrics,
+  computeTabStripThumbLayout,
+  getTabStripScrollMaskClassName
+} from './tab-strip-scroll-metrics'
+
+describe('computeTabStripScrollMetrics', () => {
+  it('reports no overflow when all tabs fit', () => {
+    expect(
+      computeTabStripScrollMetrics({
+        scrollWidth: 400,
+        clientWidth: 400,
+        scrollLeft: 0
+      })
+    ).toEqual({
+      hasOverflow: false,
+      canScrollStart: false,
+      canScrollEnd: false,
+      thumbSizeFraction: 1,
+      thumbOffsetFraction: 0
+    })
+  })
+
+  it('tracks thumb size and offset while scrolled', () => {
+    expect(
+      computeTabStripScrollMetrics({
+        scrollWidth: 800,
+        clientWidth: 400,
+        scrollLeft: 200
+      })
+    ).toEqual({
+      hasOverflow: true,
+      canScrollStart: true,
+      canScrollEnd: true,
+      thumbSizeFraction: 0.5,
+      thumbOffsetFraction: 0.5
+    })
+  })
+
+  it('marks the start and end scroll edges', () => {
+    expect(
+      computeTabStripScrollMetrics({
+        scrollWidth: 800,
+        clientWidth: 400,
+        scrollLeft: 0
+      }).canScrollStart
+    ).toBe(false)
+    expect(
+      computeTabStripScrollMetrics({
+        scrollWidth: 800,
+        clientWidth: 400,
+        scrollLeft: 0
+      }).canScrollEnd
+    ).toBe(true)
+
+    expect(
+      computeTabStripScrollMetrics({
+        scrollWidth: 800,
+        clientWidth: 400,
+        scrollLeft: 400
+      }).canScrollStart
+    ).toBe(true)
+    expect(
+      computeTabStripScrollMetrics({
+        scrollWidth: 800,
+        clientWidth: 400,
+        scrollLeft: 400
+      }).canScrollEnd
+    ).toBe(false)
+  })
+})
+
+describe('computeTabStripThumbLayout', () => {
+  it('clamps thumb width and keeps the thumb inside the track', () => {
+    expect(
+      computeTabStripThumbLayout(200, {
+        thumbSizeFraction: 0.04,
+        thumbOffsetFraction: 1
+      })
+    ).toEqual({
+      widthPx: 18,
+      leftPx: 182
+    })
+  })
+
+  it('uses the raw width when it is already above the minimum', () => {
+    expect(
+      computeTabStripThumbLayout(400, {
+        thumbSizeFraction: 0.5,
+        thumbOffsetFraction: 0.25
+      })
+    ).toEqual({
+      widthPx: 200,
+      leftPx: 50
+    })
+  })
+})
+
+describe('getTabStripScrollMaskClassName', () => {
+  it('returns no classes when the strip does not overflow', () => {
+    expect(
+      getTabStripScrollMaskClassName({
+        hasOverflow: false,
+        canScrollStart: false,
+        canScrollEnd: false
+      })
+    ).toBe('')
+  })
+
+  it('returns both fade classes when more tabs exist on both sides', () => {
+    expect(
+      getTabStripScrollMaskClassName({
+        hasOverflow: true,
+        canScrollStart: true,
+        canScrollEnd: true
+      })
+    ).toBe('terminal-tab-strip--fade-start terminal-tab-strip--fade-end')
+  })
+})

--- a/src/renderer/src/components/tab-bar/tab-strip-scroll-metrics.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-scroll-metrics.ts
@@ -1,0 +1,83 @@
+export type TabStripScrollMetrics = {
+  hasOverflow: boolean
+  canScrollStart: boolean
+  canScrollEnd: boolean
+  /** Portion of total tab width currently visible in the strip viewport. */
+  thumbSizeFraction: number
+  /** 0 = scrolled to start, 1 = scrolled to end. */
+  thumbOffsetFraction: number
+}
+
+export type TabStripThumbLayout = {
+  widthPx: number
+  leftPx: number
+}
+
+export const TAB_STRIP_THUMB_MIN_WIDTH_PX = 18
+
+const OVERFLOW_EPSILON_PX = 1
+
+export function computeTabStripScrollMetrics(
+  el: Pick<HTMLElement, 'scrollWidth' | 'clientWidth' | 'scrollLeft'>
+): TabStripScrollMetrics {
+  const maxScrollLeft = Math.max(0, el.scrollWidth - el.clientWidth)
+  const hasOverflow = maxScrollLeft > OVERFLOW_EPSILON_PX
+  const thumbSizeFraction = el.scrollWidth > 0 ? Math.min(1, el.clientWidth / el.scrollWidth) : 1
+  const thumbOffsetFraction = hasOverflow && maxScrollLeft > 0 ? el.scrollLeft / maxScrollLeft : 0
+
+  return {
+    hasOverflow,
+    canScrollStart: hasOverflow && el.scrollLeft > OVERFLOW_EPSILON_PX,
+    canScrollEnd: hasOverflow && el.scrollLeft < maxScrollLeft - OVERFLOW_EPSILON_PX,
+    thumbSizeFraction,
+    thumbOffsetFraction
+  }
+}
+
+export function computeTabStripThumbLayout(
+  trackWidthPx: number,
+  metrics: Pick<TabStripScrollMetrics, 'thumbSizeFraction' | 'thumbOffsetFraction'>
+): TabStripThumbLayout {
+  if (trackWidthPx <= 0) {
+    return { widthPx: 0, leftPx: 0 }
+  }
+
+  const rawWidthPx = metrics.thumbSizeFraction * trackWidthPx
+  const widthPx = Math.min(trackWidthPx, Math.max(TAB_STRIP_THUMB_MIN_WIDTH_PX, rawWidthPx))
+  const maxLeftPx = Math.max(0, trackWidthPx - widthPx)
+
+  return {
+    widthPx,
+    leftPx: metrics.thumbOffsetFraction * maxLeftPx
+  }
+}
+
+export function getTabStripScrollMaskClassName(
+  metrics: Pick<TabStripScrollMetrics, 'canScrollStart' | 'canScrollEnd' | 'hasOverflow'>
+): string {
+  if (!metrics.hasOverflow) {
+    return ''
+  }
+
+  const classes: string[] = []
+  if (metrics.canScrollStart) {
+    classes.push('terminal-tab-strip--fade-start')
+  }
+  if (metrics.canScrollEnd) {
+    classes.push('terminal-tab-strip--fade-end')
+  }
+  return classes.join(' ')
+}
+
+export function sameTabStripScrollMetrics(
+  left: TabStripScrollMetrics,
+  right: TabStripScrollMetrics
+): boolean {
+  return (
+    left.hasOverflow === right.hasOverflow &&
+    left.canScrollStart === right.canScrollStart &&
+    left.canScrollEnd === right.canScrollEnd &&
+    Math.abs(left.thumbSizeFraction - right.thumbSizeFraction) < 0.002 &&
+    Math.abs(left.thumbOffsetFraction - right.thumbOffsetFraction) < 0.002
+  )
+}


### PR DESCRIPTION
## Summary

Hides native scrollbars on the terminal tab strip. Horizontal tab strips scroll via chevrons, wheel, and trackpad, so a native scrollbar thumb overlays tab labels and looks broken.

## Screenshots

- No visual change (scrollbar is hidden)

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed (Updated existing unit test in `TabBar.context-menu.test.ts` to verify the removal of `scrollbar-sleek` class from the tab strip)

## AI Review Report

Explicitly checked and confirmed cross-platform rendering compatibility for macOS, Linux, and Windows. The scrollbar hiding rules rely on standard, vendor-prefixed CSS (`-ms-overflow-style`, `scrollbar-width`, and `::-webkit-scrollbar`) supported natively by Electron on all target platforms. No shortcuts, paths, or shell behaviors are affected.

## Security Audit

No security risk. This PR introduces CSS layout rules and visual layout adjustments in the React renderer only. No IPC methods, input fields, path parsing, or command executions are touched.

## Notes

Consistent scrollbar hiding relies on Chromium's native implementation of CSS scrollbar customization, ensuring stable cross-platform behavior.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5838">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->