### PR TITLE
Fix mobile pending terminal tabs and prepare 0.0.15

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 1
+      "versionCode": 2
     },
     "plugins": [
       "expo-router",

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1024,6 +1024,7 @@ export default function SessionScreen() {
   // switching back to the terminal work). A ref breaks the callback dep cycle.
   const pendingBrowserFocusPageIdRef = useRef<string | null>(null)
   const switchSessionTabRef = useRef<((tab: MobileSessionTab) => void) | null>(null)
+  const pendingTerminalActivationAttemptRef = useRef<string | null>(null)
   // Why: handleTerminalOpenUrl is memoized on terminalLinkOpenMode, but
   // handleCreateBrowser is a per-render closure that captures the live `client`.
   // A terminal URL tap must run the CURRENT closure (the memoized one can hold a
@@ -2494,6 +2495,7 @@ export default function SessionScreen() {
     pendingActiveSessionTabIdRef.current = null
     pendingActiveTerminalHandleRef.current = null
     pendingBrowserFocusPageIdRef.current = null
+    pendingTerminalActivationAttemptRef.current = null
     initialEmptySessionAutoCreateRef.current = null
     for (const queued of terminalGestureInputQueuesRef.current.values()) {
       if (queued.timer) {
@@ -4025,6 +4027,53 @@ export default function SessionScreen() {
     activeSessionTab?.type === 'terminal' && typeof activeSessionTab.terminal !== 'string'
       ? activeSessionTab
       : null
+
+  useEffect(() => {
+    if (!client || connState !== 'connected' || !activePendingTerminalTab) {
+      if (connState !== 'connected' || !activePendingTerminalTab) {
+        pendingTerminalActivationAttemptRef.current = null
+      }
+      return
+    }
+    const activationKey = `${worktreeId}:${activePendingTerminalTab.id}:${activePendingTerminalTab.leafId ?? ''}`
+    if (pendingTerminalActivationAttemptRef.current === activationKey) {
+      return
+    }
+    // Why: a hydrated headless/server-owned tab can already be active but still
+    // pending; activation is the RPC that materializes or focuses its PTY handle.
+    pendingTerminalActivationAttemptRef.current = activationKey
+    void client
+      .sendRequest('session.tabs.activate', {
+        worktree: `id:${worktreeId}`,
+        tabId: activePendingTerminalTab.id,
+        leafId: activePendingTerminalTab.leafId
+      })
+      .then((response) => {
+        if (!response.ok) {
+          if (pendingTerminalActivationAttemptRef.current === activationKey) {
+            pendingTerminalActivationAttemptRef.current = null
+          }
+          return
+        }
+        applySessionTabs((response as RpcSuccess).result as SessionTabsResult)
+        scheduleDelayedAction(() => void fetchSessionTabs(), 300)
+        scheduleDelayedAction(() => void fetchSessionTabs(), 1200)
+      })
+      .catch(() => {
+        if (pendingTerminalActivationAttemptRef.current === activationKey) {
+          pendingTerminalActivationAttemptRef.current = null
+        }
+      })
+  }, [
+    activePendingTerminalTab,
+    applySessionTabs,
+    client,
+    connState,
+    fetchSessionTabs,
+    scheduleDelayedAction,
+    worktreeId
+  ])
+
   const showLoadingState = connState === 'connected' && !terminalsLoaded && visibleTabs.length === 0
   const showEmptyState =
     connState === 'connected' && terminalsLoaded && visibleTabs.length === 0 && !activeHandle

--- a/mobile/src/session/mobile-session-startup-source.test.ts
+++ b/mobile/src/session/mobile-session-startup-source.test.ts
@@ -42,6 +42,28 @@ describe('mobile session startup', () => {
     )
   })
 
+  it('activates an already-selected pending terminal tab after hydration', () => {
+    expect(source).toContain(
+      'const pendingTerminalActivationAttemptRef = useRef<string | null>(null)'
+    )
+    expect(source).toContain('pendingTerminalActivationAttemptRef.current = null')
+
+    const pendingActivationEffect = sliceBetween(
+      "if (!client || connState !== 'connected' || !activePendingTerminalTab) {",
+      'const showLoadingState ='
+    )
+    expect(pendingActivationEffect).toContain(
+      'pendingTerminalActivationAttemptRef.current === activationKey'
+    )
+    expect(pendingActivationEffect).toContain("sendRequest('session.tabs.activate'")
+    expect(pendingActivationEffect).toContain('tabId: activePendingTerminalTab.id')
+    expect(pendingActivationEffect).toContain('leafId: activePendingTerminalTab.leafId')
+    expect(pendingActivationEffect).toContain(
+      'applySessionTabs((response as RpcSuccess).result as SessionTabsResult)'
+    )
+    expect(pendingActivationEffect).toContain('scheduleDelayedAction(() => void fetchSessionTabs()')
+  })
+
   it('keeps dynamic agent rows above fixed New Tab actions', () => {
     const newTabActions = sliceBetween('title="New Tab"', 'onClose={() => setShowCreateTabDrawer')
 


### PR DESCRIPTION
## Summary
- Fix mobile session hydrate when the active terminal tab is still pending a runtime handle
- Trigger a one-shot session tab activation so headless/server-owned pending terminal tabs materialize instead of spinning forever
- Bump Orca Mobile to 0.0.15 and Android versionCode to 2

Fixes #5780.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "keeps mobile terminal surfaces pending while a live leaf has no PTY|refreshes daemon PTY liveness before publishing mobile session tabs|reattaches mobile terminal surfaces from saved PTY bindings when the PTY is connected|does not publish exited saved PTY bindings as ready terminal streams"
- pnpm exec oxlint 'mobile/app/h/[hostId]/session/[worktreeId].tsx' mobile/src/session/mobile-session-startup-source.test.ts
- pnpm exec oxfmt --check mobile/app.json 'mobile/app/h/[hostId]/session/[worktreeId].tsx' mobile/src/session/mobile-session-startup-source.test.ts
- git diff --check

## Notes
- mobile package Vitest could not run directly in this worktree because mobile/node_modules is missing and Vite cannot resolve expo/tsconfig.base; the source-level regression guard was checked via lint/format and the focused runtime tests above.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5839">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->