### PR TITLE
Share iOS releases with TestFlight peeps

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -21,9 +21,10 @@ default_platform(:ios)
 WORKSPACE = "ios/Orca.xcworkspace"
 SCHEME = "Orca"
 BUNDLE_ID = "com.stably.orca.mobile"
+TESTFLIGHT_GROUPS = ["peeps"].freeze
 
 platform :ios do
-  desc "Build, sign, and upload Orca Mobile to TestFlight"
+  desc "Build, sign, upload, and share Orca Mobile on TestFlight"
   lane :release do
     api_key = app_store_connect_api_key(
       key_id: ENV.fetch("ASC_KEY_ID"),
@@ -72,10 +73,12 @@ platform :ios do
 
     upload_to_testflight(
       api_key: api_key,
-      skip_waiting_for_build_processing: true,
-      # Why: the human still drafts "What's New" + review notes in the ASC web
-      # UI (see the mobile-app-store-release skill). CI only delivers the build.
-      distribute_external: false,
+      # Why: fastlane can only assign external TestFlight groups after Apple
+      # finishes processing the uploaded build.
+      skip_waiting_for_build_processing: false,
+      distribute_external: true,
+      groups: TESTFLIGHT_GROUPS,
+      notify_external_testers: true,
     )
   end
 end


### PR DESCRIPTION
## Summary
- Configure the iOS fastlane release lane to wait for App Store Connect build processing
- Automatically distribute uploaded builds to the external TestFlight group `peeps`
- Notify external testers when the build is shared

## Verification
- `ruby -c mobile/fastlane/Fastfile`
- `git diff --check`

## Notes
- `bundle exec fastlane lanes` could not run locally because the fastlane gem executable is not installed in this workspace (`bundle install` needed).
- The current 0.0.15 iOS release workflow failed before archive/upload because Apple requires the Account Holder to accept the latest Program License Agreement.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5841">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->