### PR TITLE
Put the orca CLI on PATH at install time for headless hosts

### DIFF
--- a/Casks/orca.rb
+++ b/Casks/orca.rb
@@ -27,6 +27,13 @@ cask "orca" do
 
   app "Orca.app"
 
+  # Why: expose the bundled `orca` CLI on PATH at install time (Homebrew symlinks
+  # this into its already-on-PATH bin dir). Without it, the CLI is only registered
+  # by the in-app "Install CLI" action, which a headless host can never trigger —
+  # so `orca serve` on a server would be unreachable from the shell. The shim
+  # resolves the real app by walking symlinks, so the Homebrew symlink works.
+  binary "#{appdir}/Orca.app/Contents/Resources/bin/orca"
+
   # Why: Orca writes user data under ~/.orca (worktrees, agent state) and
   # Electron's standard userData directories. Zap removes everything the app
   # creates during normal use so `brew uninstall --zap` is a clean slate.

--- a/Casks/orca@rc.rb
+++ b/Casks/orca@rc.rb
@@ -35,6 +35,13 @@ cask "orca@rc" do
 
   app "Orca.app"
 
+  # Why: expose the bundled `orca` CLI on PATH at install time (Homebrew symlinks
+  # this into its already-on-PATH bin dir). Without it, the CLI is only registered
+  # by the in-app "Install CLI" action, which a headless host can never trigger —
+  # so `orca serve` on a server would be unreachable from the shell. The shim
+  # resolves the real app by walking symlinks, so the Homebrew symlink works.
+  binary "#{appdir}/Orca.app/Contents/Resources/bin/orca"
+
   # Why: Orca writes user data under ~/.orca (worktrees, agent state) and
   # Electron's standard userData directories. Zap removes everything the app
   # creates during normal use so `brew uninstall --zap` is a clean slate.

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -281,7 +281,13 @@ module.exports = {
     // Why: xvfb lets the bundled `orca serve` CLI run browser panes on a headless
     // Linux host — Chromium needs a display server even for offscreen rendering,
     // and serve starts Xvfb itself when present (see ensure-virtual-display.ts).
-    depends: ['python3', 'python3-gi', 'gir1.2-atspi-2.0', 'at-spi2-core', 'xdotool', 'xclip', 'xvfb']
+    depends: ['python3', 'python3-gi', 'gir1.2-atspi-2.0', 'at-spi2-core', 'xdotool', 'xclip', 'xvfb'],
+    // Why: symlink the bundled CLI onto PATH at install time so `orca-ide serve`
+    // works on a headless host. The in-app CLI registration (CliInstaller) is
+    // GUI-triggered and can never run on a server, so without this the CLI is
+    // unreachable from the shell on exactly the hosts that need it.
+    afterInstall: 'resources/linux/packaging/after-install.sh',
+    afterRemove: 'resources/linux/packaging/after-remove.sh'
   },
   rpm: {
     packageName: 'orca-ide',
@@ -295,7 +301,10 @@ module.exports = {
       'xdotool',
       'xclip',
       'xorg-x11-server-Xvfb'
-    ]
+    ],
+    // Why: same headless CLI-on-PATH registration as deb; rpm runs these via fpm.
+    afterInstall: 'resources/linux/packaging/after-install.sh',
+    afterRemove: 'resources/linux/packaging/after-remove.sh'
   },
   beforeBuild: electronBuilderNativeRebuild,
   // Why: must be true so that electron-builder rebuilds native modules

--- a/resources/linux/packaging/after-install.sh
+++ b/resources/linux/packaging/after-install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Why: register the bundled `orca-ide` CLI on PATH at package-install time.
+# The in-app "Install CLI" action (CliInstaller) can never run on a headless
+# server, so without this symlink `orca serve` is unreachable from the shell on
+# the exact hosts that need it most. deb/rpm both run this after unpacking.
+#
+# The shim resolves the real app by walking up from its own location, so a
+# symlink works. We discover the install dir instead of hardcoding /opt/Orca
+# because electron-builder's directory name can vary by productName sanitization.
+set -e
+
+link="/usr/bin/orca-ide"
+
+for dir in /opt/Orca /opt/orca-ide /opt/orca; do
+  shim="$dir/resources/bin/orca-ide"
+  if [ -x "$shim" ]; then
+    # Only manage our own symlink; never clobber an unrelated /usr/bin/orca-ide.
+    if [ ! -e "$link" ] || [ -L "$link" ]; then
+      ln -sf "$shim" "$link"
+    fi
+    break
+  fi
+done
+
+exit 0

--- a/resources/linux/packaging/after-remove.sh
+++ b/resources/linux/packaging/after-remove.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Why: remove the PATH symlink that after-install.sh created, but only if it
+# still points into an Orca install dir — never delete an unrelated
+# /usr/bin/orca-ide a user or other package may own.
+set -e
+
+link="/usr/bin/orca-ide"
+
+if [ -L "$link" ]; then
+  target="$(readlink "$link" || true)"
+  case "$target" in
+    /opt/Orca/*|/opt/orca-ide/*|/opt/orca/*)
+      rm -f "$link"
+      ;;
+  esac
+fi
+
+exit 0


### PR DESCRIPTION
## What & why

The bundled `orca` / `orca-ide` CLI only lands on `PATH` when a user triggers the in-app **Install CLI** action (`CliInstaller`, via the `cli:install` IPC). That requires opening the desktop GUI — which **a headless server can never do**. So on the exact hosts where you'd want `orca serve` (VMs, cloud boxes), the CLI was unreachable from the shell after install.

This registers the CLI **at package-install time**, through the distribution channels we control, so `orca serve` works on a headless host with no GUI step.

## How

- **Homebrew cask** (`Casks/orca.rb` + `Casks/orca@rc.rb`): add a `binary` stanza pointing at the bundled shim (`Orca.app/Contents/Resources/bin/orca`). `brew install --cask orca` now symlinks `orca` into Homebrew's already-on-`PATH` bin dir. The cask is the source of truth synced to the tap by `homebrew-bump.yml`, so this propagates automatically on the next release.
- **deb/rpm** (`config/electron-builder.config.cjs` + `resources/linux/packaging/*.sh`): add `afterInstall` / `afterRemove` fpm scripts that symlink the bundled `…/resources/bin/orca-ide` to `/usr/bin/orca-ide` on install and remove it on uninstall. The deb already declares the `xvfb` dependency `orca serve` needs to render browser panes headlessly, so `apt install` now yields a working headless serve in one step.

The shims resolve the real app by walking up symlinks, so a `PATH` symlink works correctly. The install dir is discovered (not hardcoded `/opt/Orca`) because electron-builder's directory name can vary.

### Safety guards
- after-install **never clobbers** an unrelated `/usr/bin/orca-ide` (e.g. Ubuntu's GNOME Orca) — it only writes when the path is absent or already a symlink.
- after-remove **only deletes** a symlink that still points into an Orca install dir, so it won't remove something another package/user owns.

## Verification

Ran the postinstall/postremove logic against mock install trees in real **Debian** (`debian:stable-slim`) and **Fedora** (`fedora:latest`) containers:
- ✅ symlink created → `orca-ide` resolves on `PATH`, runs, forwards args (`orca-ide serve --foo`)
- ✅ does not clobber a pre-existing real `/usr/bin/orca-ide`
- ✅ uninstall removes our symlink
- ✅ uninstall leaves an unrelated symlink alone

Also confirmed both casks pass `ruby -c`, the builder config loads, and electron-builder 26.8.1 supports `afterInstall`/`afterRemove` (they map to fpm `--after-install`/`--after-remove`).

## Scope / not included
- **AppImage** has no install hook, so it can't auto-register the CLI — documented as a manual `ln -s` elsewhere; out of scope here.
- The **AUR** package is community-owned and GUI-only today; making it headless-capable is a separate upstream conversation.

## Follow-ups (not blocking)
- macOS cask `binary` from an `auto_updates` app: confirm the symlink survives an in-app updater swap (path inside the `.app` is stable, so it should).
- Headless secrets currently fall back to plaintext without an OS keychain — worth closing before promoting headless serve as secure-by-default.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5842">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->