### PR TITLE
Fix tall workspace drag previews

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts
+++ b/src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts
@@ -1,0 +1,109 @@
+import { moveWorktreeIdsWithinGroup } from './worktree-manual-order'
+
+export type WorktreeDragPreviewRect = {
+  worktreeId: string
+  groupIndex: number
+  top: number
+  bottom: number
+}
+
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index])
+}
+
+function getFallbackStride(rects: readonly WorktreeDragPreviewRect[]): number {
+  const sortedRects = [...rects].sort((a, b) => a.groupIndex - b.groupIndex)
+  const strides: number[] = []
+  for (let index = 1; index < sortedRects.length; index++) {
+    strides.push(sortedRects[index]!.top - sortedRects[index - 1]!.top)
+  }
+  if (strides.length > 0) {
+    strides.sort((a, b) => a - b)
+    return strides[Math.floor(strides.length / 2)]!
+  }
+  const firstRect = sortedRects[0]
+  return firstRect ? firstRect.bottom - firstRect.top : 0
+}
+
+function getFallbackGap(rects: readonly WorktreeDragPreviewRect[]): number {
+  const sortedRects = [...rects].sort((a, b) => a.groupIndex - b.groupIndex)
+  const gaps: number[] = []
+  for (let index = 1; index < sortedRects.length; index++) {
+    gaps.push(Math.max(0, sortedRects[index]!.top - sortedRects[index - 1]!.bottom))
+  }
+  if (gaps.length === 0) {
+    return 0
+  }
+  gaps.sort((a, b) => a - b)
+  return gaps[Math.floor(gaps.length / 2)]!
+}
+
+export function buildWorktreeDragPreviewOffsets(args: {
+  groupIds: readonly string[]
+  draggedIds: readonly string[]
+  dropIndex: number
+  rects: readonly WorktreeDragPreviewRect[]
+}): Map<string, number> {
+  const nextIds = moveWorktreeIdsWithinGroup(args.groupIds, args.draggedIds, args.dropIndex)
+  if (arraysEqual(nextIds, args.groupIds)) {
+    return new Map()
+  }
+
+  const draggedSet = new Set(args.draggedIds)
+  const newIndexById = new Map<string, number>()
+  nextIds.forEach((id, index) => newIndexById.set(id, index))
+
+  const groupIdSet = new Set(args.groupIds)
+  const rectById = new Map<string, WorktreeDragPreviewRect>()
+  for (const rect of args.rects) {
+    if (groupIdSet.has(rect.worktreeId)) {
+      rectById.set(rect.worktreeId, rect)
+    }
+  }
+
+  const fallbackStride = getFallbackStride(args.rects)
+  const fallbackGap = getFallbackGap(args.rects)
+  const groupRects = args.groupIds.flatMap((id) => {
+    const rect = rectById.get(id)
+    return rect ? [rect] : []
+  })
+  const baseTop = groupRects[0]?.top ?? 0
+  const fallbackHeight = Math.max(0, fallbackStride - fallbackGap)
+  const gapAfterById = new Map<string, number>()
+  for (let index = 0; index < groupRects.length; index++) {
+    const rect = groupRects[index]!
+    const nextRect = groupRects[index + 1]
+    gapAfterById.set(
+      rect.worktreeId,
+      nextRect ? Math.max(0, nextRect.top - rect.bottom) : fallbackGap
+    )
+  }
+
+  const targetTopById = new Map<string, number>()
+  let nextTop = baseTop
+  // Why: lineage drag units can be much taller than ordinary cards, so replay
+  // layout with measured heights instead of mapping indexes to old slot tops.
+  for (const id of nextIds) {
+    targetTopById.set(id, nextTop)
+    const rect = rectById.get(id)
+    const height = rect ? rect.bottom - rect.top : fallbackHeight
+    nextTop += height + (gapAfterById.get(id) ?? fallbackGap)
+  }
+
+  const offsets = new Map<string, number>()
+  for (const rect of args.rects) {
+    if (draggedSet.has(rect.worktreeId)) {
+      continue
+    }
+    const newIndex = newIndexById.get(rect.worktreeId)
+    if (newIndex === undefined) {
+      continue
+    }
+    const fallbackTop = rect.top + (newIndex - rect.groupIndex) * fallbackStride
+    const offset = (targetTopById.get(rect.worktreeId) ?? fallbackTop) - rect.top
+    if (Math.abs(offset) >= 0.5) {
+      offsets.set(rect.worktreeId, offset)
+    }
+  }
+  return offsets
+}

--- a/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { buildWorktreeDragPreviewOffsets } from './worktree-drag-preview-offsets'
 import {
   buildManualOrderUpdatesForGroupDrop,
-  buildWorktreeDragPreviewOffsets,
   buildManualOrderUpdatesForVisibleGroups,
   expandDraggedWorktreeIdsForVisibleLineage,
   moveWorktreeIdsWithinGroup,
@@ -117,6 +117,34 @@ describe('buildWorktreeDragPreviewOffsets', () => {
     })
 
     expect(offsets.size).toBe(0)
+  })
+
+  it('uses the dragged unit height when previewing variable-height rows', () => {
+    const offsets = buildWorktreeDragPreviewOffsets({
+      groupIds: ['parent', 'sibling'],
+      draggedIds: ['parent'],
+      dropIndex: 2,
+      rects: [
+        { worktreeId: 'parent', groupIndex: 0, top: 0, bottom: 300 },
+        { worktreeId: 'sibling', groupIndex: 1, top: 308, bottom: 408 }
+      ]
+    })
+
+    expect(Array.from(offsets)).toEqual([['sibling', -308]])
+  })
+
+  it('uses the dragged unit height when previewing a short row above a tall row', () => {
+    const offsets = buildWorktreeDragPreviewOffsets({
+      groupIds: ['parent', 'sibling'],
+      draggedIds: ['sibling'],
+      dropIndex: 0,
+      rects: [
+        { worktreeId: 'parent', groupIndex: 0, top: 0, bottom: 300 },
+        { worktreeId: 'sibling', groupIndex: 1, top: 308, bottom: 408 }
+      ]
+    })
+
+    expect(Array.from(offsets)).toEqual([['parent', 108]])
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-manual-order.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.ts
@@ -15,13 +15,6 @@ export type WorktreeDragLineageRow = {
   depth: number
 }
 
-export type WorktreeDragPreviewRect = {
-  worktreeId: string
-  groupIndex: number
-  top: number
-  bottom: number
-}
-
 function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((value, index) => value === b[index])
 }
@@ -250,58 +243,4 @@ export function shouldWriteManualOrderForGroupDrop(args: {
     args.sourceGroupKeys.length > 0 &&
     args.sourceGroupKeys.every((sourceGroupKey) => sourceGroupKey === args.targetGroupKey)
   )
-}
-
-function getFallbackStride(rects: readonly WorktreeDragPreviewRect[]): number {
-  const sortedRects = [...rects].sort((a, b) => a.groupIndex - b.groupIndex)
-  const strides: number[] = []
-  for (let index = 1; index < sortedRects.length; index++) {
-    strides.push(sortedRects[index]!.top - sortedRects[index - 1]!.top)
-  }
-  if (strides.length > 0) {
-    strides.sort((a, b) => a - b)
-    return strides[Math.floor(strides.length / 2)]!
-  }
-  const firstRect = sortedRects[0]
-  return firstRect ? firstRect.bottom - firstRect.top : 0
-}
-
-export function buildWorktreeDragPreviewOffsets(args: {
-  groupIds: readonly string[]
-  draggedIds: readonly string[]
-  dropIndex: number
-  rects: readonly WorktreeDragPreviewRect[]
-}): Map<string, number> {
-  const nextIds = moveWorktreeIdsWithinGroup(args.groupIds, args.draggedIds, args.dropIndex)
-  if (arraysEqual(nextIds, args.groupIds)) {
-    return new Map()
-  }
-
-  const draggedSet = new Set(args.draggedIds)
-  const newIndexById = new Map<string, number>()
-  nextIds.forEach((id, index) => newIndexById.set(id, index))
-
-  const topByGroupIndex = new Map<number, number>()
-  for (const rect of args.rects) {
-    topByGroupIndex.set(rect.groupIndex, rect.top)
-  }
-
-  const fallbackStride = getFallbackStride(args.rects)
-  const offsets = new Map<string, number>()
-  for (const rect of args.rects) {
-    if (draggedSet.has(rect.worktreeId)) {
-      continue
-    }
-    const newIndex = newIndexById.get(rect.worktreeId)
-    if (newIndex === undefined) {
-      continue
-    }
-    const targetTop =
-      topByGroupIndex.get(newIndex) ?? rect.top + (newIndex - rect.groupIndex) * fallbackStride
-    const offset = targetTop - rect.top
-    if (Math.abs(offset) >= 0.5) {
-      offsets.set(rect.worktreeId, offset)
-    }
-  }
-  return offsets
 }

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
@@ -38,6 +38,28 @@ describe('computeWorktreeSidebarDropPreview', () => {
       })
     ).toBeNull()
   })
+
+  it('collapses lineage child rects into the parent drag unit for preview offsets', () => {
+    const preview = computeWorktreeSidebarDropPreview({
+      pointerY: 430,
+      containerTop: 0,
+      scrollTop: 0,
+      rects: [
+        { worktreeId: 'parent', groupIndex: 0, top: 0, bottom: 90 },
+        { worktreeId: 'child-a', groupIndex: 1, top: 96, bottom: 186 },
+        { worktreeId: 'child-b', groupIndex: 2, top: 192, bottom: 282 },
+        { worktreeId: 'sibling', groupIndex: 3, top: 288, bottom: 388 }
+      ],
+      groupIds: ['parent', 'sibling'],
+      draggedIds: ['parent']
+    })
+
+    expect(preview).toMatchObject({
+      dropIndex: 2,
+      dropIndicatorY: 391
+    })
+    expect(Array.from(preview?.previewOffsetsByWorktreeId ?? [])).toEqual([['sibling', -288]])
+  })
 })
 
 describe('resolveWorktreeSidebarStatusDropCommitTarget', () => {

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts
@@ -1,4 +1,4 @@
-import { buildWorktreeDragPreviewOffsets } from './worktree-manual-order'
+import { buildWorktreeDragPreviewOffsets } from './worktree-drag-preview-offsets'
 import {
   getWorktreeSidebarBoundaryDrop,
   type WorktreeSidebarDragRect
@@ -24,6 +24,44 @@ export type WorktreeSidebarTrackedStatusDropTarget = {
 }
 
 const STATUS_DROP_TARGET_FALLBACK_TOLERANCE_PX = 6
+
+function getWorktreeSidebarDragUnitRects(args: {
+  rects: readonly WorktreeSidebarDragRect[]
+  groupIds: readonly string[]
+}): WorktreeSidebarDragRect[] {
+  // Why: expanded lineage renders child cards in the DOM, but reorder preview
+  // moves the whole parent lineage as one drag unit.
+  const sortedRects = [...args.rects].sort((a, b) => a.top - b.top)
+  const rectByWorktreeId = new Map(sortedRects.map((rect) => [rect.worktreeId, rect]))
+
+  return args.groupIds.flatMap((worktreeId, unitIndex) => {
+    const rootRect = rectByWorktreeId.get(worktreeId)
+    if (!rootRect) {
+      return []
+    }
+    const nextRootTop =
+      args.groupIds
+        .slice(unitIndex + 1)
+        .flatMap((nextId) => {
+          const nextRect = rectByWorktreeId.get(nextId)
+          return nextRect ? [nextRect.top] : []
+        })
+        .at(0) ?? Number.POSITIVE_INFINITY
+    const unitBottom = sortedRects.reduce(
+      (bottom, rect) =>
+        rect.top >= rootRect.top && rect.top < nextRootTop ? Math.max(bottom, rect.bottom) : bottom,
+      rootRect.bottom
+    )
+    return [
+      {
+        worktreeId,
+        groupIndex: unitIndex,
+        top: rootRect.top,
+        bottom: unitBottom
+      }
+    ]
+  })
+}
 
 function hasWorktreeSidebarStatusDropTarget(
   target: WorktreeSidebarStatusDropTarget & { lineageParentId?: string | null }
@@ -62,7 +100,10 @@ export function computeWorktreeSidebarDropPreview(args: {
   groupIds: readonly string[]
   draggedIds: readonly string[]
 }): WorktreeSidebarDropPreview | null {
-  const { rects } = args
+  const rects = getWorktreeSidebarDragUnitRects({
+    rects: args.rects,
+    groupIds: args.groupIds
+  })
   if (rects.length === 0 || args.groupIds.length === 0) {
     return null
   }


### PR DESCRIPTION
## Summary
- collapse expanded lineage child rects into a single sidebar drag unit before computing drop previews
- replay drag preview offsets using measured unit heights/gaps so tall parent workspaces do not overlap siblings
- add regression coverage for tall lineage drag previews

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-drag-units.test.ts src/renderer/src/components/sidebar/worktree-manual-order.test.ts src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts --reporter=verbose --maxWorkers=1
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts src/renderer/src/components/sidebar/worktree-manual-order.ts src/renderer/src/components/sidebar/worktree-manual-order.test.ts src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5849">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->