### PR TITLE
Improve Settings integrations readability

### DIFF
--- a/src/renderer/src/components/settings/ProviderHostScopeControl.tsx
+++ b/src/renderer/src/components/settings/ProviderHostScopeControl.tsx
@@ -25,8 +25,10 @@ export function ProviderHostScopeControl({
 
   return (
     <div className={className}>
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        {/* Why: integration cards can become narrow while Settings navigation
+        remains visible, so the action must wrap before scope copy collapses. */}
+        <div className="min-w-[min(14rem,100%)] flex-1">
           <span className="font-medium text-foreground">
             {translate(
               'auto.components.settings.ProviderHostScopeControl.scope_label',
@@ -36,7 +38,13 @@ export function ProviderHostScopeControl({
           </span>
           <div className="mt-0.5 text-muted-foreground">{scope.description}</div>
         </div>
-        <Button type="button" variant="ghost" size="sm" onClick={openHostsSettings}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="shrink-0"
+          onClick={openHostsSettings}
+        >
           <ServerCog className="size-3.5" />
           {translate(
             'auto.components.settings.ProviderHostScopeControl.change_host',

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -1170,6 +1170,7 @@ function Settings(): React.JSX.Element {
                     'Connect GitHub, GitLab, Linear, and source-hosting services.'
                   )}
                   searchEntries={getSectionSearchEntries('integrations')}
+                  bodyClassName="rounded-none border-0 bg-transparent p-0 shadow-none"
                 >
                   {isSectionMounted('integrations') ? <IntegrationsPane /> : null}
                 </SettingsSection>

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
@@ -7,6 +7,10 @@ import { ProviderHostScopeControl } from './ProviderHostScopeControl'
 import { usePreflightCardStatuses } from './source-control-preflight-card-status'
 import { translate } from '@/i18n/i18n'
 
+const INTEGRATION_COMMAND_ROW_CLASS =
+  'flex items-center gap-2 rounded-md border border-border/50 bg-muted/50 px-3 py-2 font-mono text-xs'
+const INTEGRATION_SUBORDINATE_ROW_CLASS = 'rounded-md border border-border/50 bg-muted/50 px-3 py-2'
+
 function ProviderAccountScopeDetails({
   children
 }: {
@@ -23,7 +27,7 @@ function ProviderAccountScopeDetails({
           'Account scope'
         )}
         scope={accountScope}
-        className="text-xs"
+        className={`text-xs ${INTEGRATION_SUBORDINATE_ROW_CLASS}`}
       />
       {children}
     </IntegrationCardDetails>
@@ -122,7 +126,7 @@ export function GitHubIntegrationCard(): React.JSX.Element {
                   'The GitHub CLI is installed but not authenticated. Run this command in a terminal:'
                 )}
               </p>
-              <div className="flex items-center gap-2 rounded-md bg-muted/50 px-2.5 py-1.5 font-mono text-xs">
+              <div className={INTEGRATION_COMMAND_ROW_CLASS}>
                 <Terminal className="size-3.5 shrink-0 text-muted-foreground" />
                 {translate(
                   'auto.components.settings.cli.source.control.integration.cards.8d90249d22',
@@ -252,7 +256,7 @@ export function GitLabIntegrationCard(): React.JSX.Element {
                   'The GitLab CLI is installed but not authenticated. Run this command in a terminal:'
                 )}
               </p>
-              <div className="flex items-center gap-2 rounded-md bg-muted/50 px-2.5 py-1.5 font-mono text-xs">
+              <div className={INTEGRATION_COMMAND_ROW_CLASS}>
                 <Terminal className="size-3.5 shrink-0 text-muted-foreground" />
                 {translate(
                   'auto.components.settings.cli.source.control.integration.cards.707180d09c',

--- a/src/renderer/src/components/settings/integration-card-shell.tsx
+++ b/src/renderer/src/components/settings/integration-card-shell.tsx
@@ -20,34 +20,38 @@ export function IntegrationCardShell(props: {
   actions?: React.ReactNode
   children?: React.ReactNode
 }): React.JSX.Element {
+  const status = props.checking ? (
+    <LoaderCircle className="size-4 shrink-0 animate-spin text-muted-foreground" />
+  ) : (
+    <span
+      className={cn(
+        'shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium',
+        STATUS_TONE_CLASSES[props.statusTone]
+      )}
+    >
+      {props.statusLabel}
+    </span>
+  )
+
   return (
     <div
       className={cn(
-        'rounded-xl border border-border/60 bg-card/40 px-4 py-3.5 shadow-xs',
+        'rounded-xl border border-border bg-card px-4 py-3.5 shadow-xs',
         props.className
       )}
     >
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-start gap-3">
         <span className="shrink-0 text-muted-foreground">{props.icon}</span>
-        <div className="min-w-0 flex-1 space-y-0.5">
+        <div className="min-w-0 flex-1 basis-[16rem] space-y-0.5">
           <p className="text-sm font-medium">{props.name}</p>
           <p className="text-xs text-muted-foreground">{props.description}</p>
         </div>
-        {props.actions ? (
-          <div className="flex shrink-0 items-center gap-1.5">{props.actions}</div>
-        ) : null}
-        {props.checking ? (
-          <LoaderCircle className="size-4 shrink-0 animate-spin text-muted-foreground" />
-        ) : (
-          <span
-            className={cn(
-              'shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium',
-              STATUS_TONE_CLASSES[props.statusTone]
-            )}
-          >
-            {props.statusLabel}
-          </span>
-        )}
+        {/* Why: settings can be narrow with the sidebar open; controls need their
+        own row before they squeeze provider copy into unreadable columns. */}
+        <div className="flex basis-full shrink-0 flex-wrap items-center justify-start gap-1.5 min-[1100px]:ml-auto min-[1100px]:basis-auto min-[1100px]:justify-end">
+          {props.actions}
+          {status}
+        </div>
       </div>
       {props.children}
     </div>
@@ -59,7 +63,7 @@ export function IntegrationCardDetails(props: {
   children: React.ReactNode
 }): React.JSX.Element {
   return (
-    <div className={cn('mt-3 space-y-2 border-t border-border/40 pt-3', props.className)}>
+    <div className={cn('mt-4 space-y-2 border-t border-border/60 pt-4', props.className)}>
       {props.children}
     </div>
   )

--- a/src/renderer/src/components/settings/jira-integration-card.tsx
+++ b/src/renderer/src/components/settings/jira-integration-card.tsx
@@ -15,6 +15,7 @@ import { ProviderHostScopeControl } from './ProviderHostScopeControl'
 import { translate } from '@/i18n/i18n'
 
 type VerificationResult = { state: 'ok' | 'error'; error?: string }
+const INTEGRATION_SUBORDINATE_ROW_CLASS = 'rounded-md border border-border/50 bg-muted/50 px-3 py-2'
 
 export function JiraIntegrationCard(): React.JSX.Element {
   const jiraStatus = useAppStore((s) => s.jiraStatus)
@@ -109,122 +110,126 @@ export function JiraIntegrationCard(): React.JSX.Element {
         ) : null
       }
     >
-      <ProviderHostScopeControl
-        labelPrefix={translate(
-          'auto.components.settings.task.tracker.integration.cards.account_scope_prefix',
-          'Account scope'
-        )}
-        scope={accountScope}
-        className="mt-3 rounded-md border border-border/40 bg-background/50 px-3 py-2 text-xs"
-      />
-      {connected && sites.length > 0 ? (
-        <div className="mt-3 space-y-2">
-          {sites.map((site) => {
-            const testResult = testResultBySite[site.id]
-            const testing = testingSiteId === site.id
-            return (
-              <div
-                key={site.id}
-                className="flex items-center gap-3 rounded-md border border-border/50 bg-background/60 px-3 py-2"
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-foreground">{site.displayName}</p>
-                  <p className="truncate text-xs text-muted-foreground">
-                    {site.siteUrl}
-                    {site.email ? ` · ${site.email}` : ''}
-                  </p>
-                </div>
-                {testResult?.state === 'ok' ? (
-                  <span className="flex shrink-0 items-center gap-1 text-xs text-status-success">
-                    <CheckCircle2 className="size-3.5" />
-                    {translate(
-                      'auto.components.settings.task.tracker.integration.cards.a2c0015fb8',
-                      'Verified'
-                    )}
-                  </span>
-                ) : null}
-                {testResult?.state === 'error' ? (
-                  <span className="flex min-w-0 max-w-[220px] shrink items-center gap-1 truncate text-xs text-destructive">
-                    <AlertCircle className="size-3.5 shrink-0" />
-                    <span className="truncate">{testResult.error}</span>
-                  </span>
-                ) : null}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void handleTest(site.id)}
-                  disabled={testing}
+      <IntegrationCardDetails>
+        <ProviderHostScopeControl
+          labelPrefix={translate(
+            'auto.components.settings.task.tracker.integration.cards.account_scope_prefix',
+            'Account scope'
+          )}
+          scope={accountScope}
+          className={`text-xs ${INTEGRATION_SUBORDINATE_ROW_CLASS}`}
+        />
+        {connected && sites.length > 0 ? (
+          <div className="space-y-2">
+            {sites.map((site) => {
+              const testResult = testResultBySite[site.id]
+              const testing = testingSiteId === site.id
+              return (
+                <div
+                  key={site.id}
+                  className={`flex items-center gap-3 ${INTEGRATION_SUBORDINATE_ROW_CLASS}`}
                 >
-                  {testing ? (
-                    <>
-                      <LoaderCircle className="size-3.5 mr-1.5 animate-spin" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-foreground">
+                      {site.displayName}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {site.siteUrl}
+                      {site.email ? ` · ${site.email}` : ''}
+                    </p>
+                  </div>
+                  {testResult?.state === 'ok' ? (
+                    <span className="flex shrink-0 items-center gap-1 text-xs text-status-success">
+                      <CheckCircle2 className="size-3.5" />
                       {translate(
-                        'auto.components.settings.task.tracker.integration.cards.3e7c10d286',
-                        'Testing...'
+                        'auto.components.settings.task.tracker.integration.cards.a2c0015fb8',
+                        'Verified'
                       )}
-                    </>
-                  ) : (
-                    translate(
-                      'auto.components.settings.task.tracker.integration.cards.c24e56c532',
-                      'Test'
-                    )
-                  )}
-                </Button>
-                <button
-                  onClick={() => void handleDisconnect(site.id)}
-                  aria-label={translate(
-                    'auto.components.settings.task.tracker.integration.cards.dd3529015d',
-                    'Disconnect {{value0}}',
-                    { value0: site.displayName }
-                  )}
-                  className="rounded-md p-1 text-muted-foreground/50 transition-colors hover:text-destructive"
-                >
-                  <Unlink className="size-3.5" />
-                </button>
-              </div>
-            )
-          })}
-          <p className="text-[11px] text-muted-foreground/70">
-            {translate(
-              'auto.components.settings.task.tracker.integration.cards.8c20e76308',
-              'Each connected Jira site has one token stored by the active runtime.'
-            )}
-          </p>
-        </div>
-      ) : connected ? (
-        <IntegrationCardDetails>
-          <p className="text-xs text-muted-foreground">
-            {translate(
-              'auto.components.settings.task.tracker.integration.cards.8b2408a8e5',
-              'Jira is connected for this runtime. Re-check if the connected site list looks stale.'
-            )}
-          </p>
-          <div className="flex items-center gap-2">
+                    </span>
+                  ) : null}
+                  {testResult?.state === 'error' ? (
+                    <span className="flex min-w-0 max-w-[220px] shrink items-center gap-1 truncate text-xs text-destructive">
+                      <AlertCircle className="size-3.5 shrink-0" />
+                      <span className="truncate">{testResult.error}</span>
+                    </span>
+                  ) : null}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void handleTest(site.id)}
+                    disabled={testing}
+                  >
+                    {testing ? (
+                      <>
+                        <LoaderCircle className="size-3.5 mr-1.5 animate-spin" />
+                        {translate(
+                          'auto.components.settings.task.tracker.integration.cards.3e7c10d286',
+                          'Testing...'
+                        )}
+                      </>
+                    ) : (
+                      translate(
+                        'auto.components.settings.task.tracker.integration.cards.c24e56c532',
+                        'Test'
+                      )
+                    )}
+                  </Button>
+                  <button
+                    onClick={() => void handleDisconnect(site.id)}
+                    aria-label={translate(
+                      'auto.components.settings.task.tracker.integration.cards.dd3529015d',
+                      'Disconnect {{value0}}',
+                      { value0: site.displayName }
+                    )}
+                    className="rounded-md p-1 text-muted-foreground/50 transition-colors hover:text-destructive"
+                  >
+                    <Unlink className="size-3.5" />
+                  </button>
+                </div>
+              )
+            })}
+            <p className="text-[11px] text-muted-foreground/70">
+              {translate(
+                'auto.components.settings.task.tracker.integration.cards.8c20e76308',
+                'Each connected Jira site has one token stored by the active runtime.'
+              )}
+            </p>
+          </div>
+        ) : connected ? (
+          <>
+            <p className="text-xs text-muted-foreground">
+              {translate(
+                'auto.components.settings.task.tracker.integration.cards.8b2408a8e5',
+                'Jira is connected for this runtime. Re-check if the connected site list looks stale.'
+              )}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={() => void checkJiraConnection()}>
+                {translate(
+                  'auto.components.settings.task.tracker.integration.cards.c90f2ef419',
+                  'Re-check'
+                )}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => void handleDisconnect()}>
+                {translate(
+                  'auto.components.settings.task.tracker.integration.cards.disconnect_all',
+                  'Disconnect'
+                )}
+              </Button>
+            </div>
+          </>
+        ) : !checking ? (
+          <>
+            <p className="text-xs text-muted-foreground">{credentialCopy}</p>
             <Button variant="ghost" size="sm" onClick={() => void checkJiraConnection()}>
               {translate(
                 'auto.components.settings.task.tracker.integration.cards.c90f2ef419',
                 'Re-check'
               )}
             </Button>
-            <Button variant="ghost" size="sm" onClick={() => void handleDisconnect()}>
-              {translate(
-                'auto.components.settings.task.tracker.integration.cards.disconnect_all',
-                'Disconnect'
-              )}
-            </Button>
-          </div>
-        </IntegrationCardDetails>
-      ) : !checking ? (
-        <IntegrationCardDetails>
-          <p className="text-xs text-muted-foreground">{credentialCopy}</p>
-          <Button variant="ghost" size="sm" onClick={() => void checkJiraConnection()}>
-            {translate(
-              'auto.components.settings.task.tracker.integration.cards.c90f2ef419',
-              'Re-check'
-            )}
-          </Button>
-        </IntegrationCardDetails>
-      ) : null}
+          </>
+        ) : null}
+      </IntegrationCardDetails>
 
       <JiraConnectDialog
         open={dialogOpen}

--- a/src/renderer/src/components/settings/task-tracker-integration-cards.tsx
+++ b/src/renderer/src/components/settings/task-tracker-integration-cards.tsx
@@ -12,6 +12,7 @@ import { ProviderHostScopeControl } from './ProviderHostScopeControl'
 import { translate } from '@/i18n/i18n'
 
 type VerificationResult = { state: 'ok' | 'error'; error?: string }
+const INTEGRATION_SUBORDINATE_ROW_CLASS = 'rounded-md border border-border/50 bg-muted/50 px-3 py-2'
 
 export function LinearIntegrationCard(): React.JSX.Element {
   const linearStatus = useAppStore((s) => s.linearStatus)
@@ -107,99 +108,101 @@ export function LinearIntegrationCard(): React.JSX.Element {
         ) : null
       }
     >
-      <ProviderAccountScopeRow scope={accountScope} />
-      {connected ? (
-        <div className="mt-3 space-y-2">
-          {workspaces.map((workspace) => {
-            const testResult = testResultByWorkspace[workspace.id]
-            const testing = testingWorkspaceId === workspace.id
-            return (
-              <div
-                key={workspace.id}
-                className="flex items-center gap-3 rounded-md border border-border/50 bg-background/60 px-3 py-2"
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium text-foreground">
-                    {workspace.organizationName}
-                  </p>
-                  <p className="truncate text-xs text-muted-foreground">
-                    {workspace.displayName}
-                    {workspace.email ? ` · ${workspace.email}` : ''}
-                  </p>
-                </div>
-                {testResult?.state === 'ok' ? (
-                  <span className="flex shrink-0 items-center gap-1 text-xs text-status-success">
-                    <CheckCircle2 className="size-3.5" />
-                    {translate(
-                      'auto.components.settings.task.tracker.integration.cards.a2c0015fb8',
-                      'Verified'
-                    )}
-                  </span>
-                ) : null}
-                {testResult?.state === 'error' ? (
-                  <span className="flex min-w-0 max-w-[220px] shrink items-center gap-1 truncate text-xs text-destructive">
-                    <AlertCircle className="size-3.5 shrink-0" />
-                    <span className="truncate">{testResult.error}</span>
-                  </span>
-                ) : null}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => void handleTest(workspace.id)}
-                  disabled={testing}
+      <IntegrationCardDetails>
+        <ProviderAccountScopeRow scope={accountScope} />
+        {connected ? (
+          <div className="space-y-2">
+            {workspaces.map((workspace) => {
+              const testResult = testResultByWorkspace[workspace.id]
+              const testing = testingWorkspaceId === workspace.id
+              return (
+                <div
+                  key={workspace.id}
+                  className={`flex items-center gap-3 ${INTEGRATION_SUBORDINATE_ROW_CLASS}`}
                 >
-                  {testing ? (
-                    <>
-                      <LoaderCircle className="size-3.5 mr-1.5 animate-spin" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-foreground">
+                      {workspace.organizationName}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {workspace.displayName}
+                      {workspace.email ? ` · ${workspace.email}` : ''}
+                    </p>
+                  </div>
+                  {testResult?.state === 'ok' ? (
+                    <span className="flex shrink-0 items-center gap-1 text-xs text-status-success">
+                      <CheckCircle2 className="size-3.5" />
                       {translate(
-                        'auto.components.settings.task.tracker.integration.cards.3e7c10d286',
-                        'Testing...'
+                        'auto.components.settings.task.tracker.integration.cards.a2c0015fb8',
+                        'Verified'
                       )}
-                    </>
-                  ) : (
-                    translate(
-                      'auto.components.settings.task.tracker.integration.cards.c24e56c532',
-                      'Test'
-                    )
-                  )}
-                </Button>
-                <button
-                  onClick={() => void handleDisconnect(workspace.id)}
-                  aria-label={translate(
-                    'auto.components.settings.task.tracker.integration.cards.dd3529015d',
-                    'Disconnect {{value0}}',
-                    { value0: workspace.organizationName }
-                  )}
-                  className="rounded-md p-1 text-muted-foreground/50 transition-colors hover:text-destructive"
-                >
-                  <Unlink className="size-3.5" />
-                </button>
-              </div>
-            )
-          })}
-          <p className="text-[11px] text-muted-foreground/70">
-            {translate(
-              'auto.components.settings.task.tracker.integration.cards.6224fe9d34',
-              'Each connected Linear workspace has one key stored by the active runtime. Full-access keys can cover all teams the key owner can access; restricted keys can be replaced any time.'
-            )}
-          </p>
-        </div>
-      ) : !checking ? (
-        <IntegrationCardDetails>
-          <p className="text-xs text-muted-foreground">
-            {translate(
-              'auto.components.settings.task.tracker.integration.cards.cef18762a2',
-              'Add access with a Personal API key from your Linear settings. Full-access keys can see every team the key owner can reach.'
-            )}
-          </p>
-          <Button variant="ghost" size="sm" onClick={() => void checkLinearConnection(true)}>
-            {translate(
-              'auto.components.settings.task.tracker.integration.cards.c90f2ef419',
-              'Re-check'
-            )}
-          </Button>
-        </IntegrationCardDetails>
-      ) : null}
+                    </span>
+                  ) : null}
+                  {testResult?.state === 'error' ? (
+                    <span className="flex min-w-0 max-w-[220px] shrink items-center gap-1 truncate text-xs text-destructive">
+                      <AlertCircle className="size-3.5 shrink-0" />
+                      <span className="truncate">{testResult.error}</span>
+                    </span>
+                  ) : null}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void handleTest(workspace.id)}
+                    disabled={testing}
+                  >
+                    {testing ? (
+                      <>
+                        <LoaderCircle className="size-3.5 mr-1.5 animate-spin" />
+                        {translate(
+                          'auto.components.settings.task.tracker.integration.cards.3e7c10d286',
+                          'Testing...'
+                        )}
+                      </>
+                    ) : (
+                      translate(
+                        'auto.components.settings.task.tracker.integration.cards.c24e56c532',
+                        'Test'
+                      )
+                    )}
+                  </Button>
+                  <button
+                    onClick={() => void handleDisconnect(workspace.id)}
+                    aria-label={translate(
+                      'auto.components.settings.task.tracker.integration.cards.dd3529015d',
+                      'Disconnect {{value0}}',
+                      { value0: workspace.organizationName }
+                    )}
+                    className="rounded-md p-1 text-muted-foreground/50 transition-colors hover:text-destructive"
+                  >
+                    <Unlink className="size-3.5" />
+                  </button>
+                </div>
+              )
+            })}
+            <p className="text-[11px] text-muted-foreground/70">
+              {translate(
+                'auto.components.settings.task.tracker.integration.cards.6224fe9d34',
+                'Each connected Linear workspace has one key stored by the active runtime. Full-access keys can cover all teams the key owner can access; restricted keys can be replaced any time.'
+              )}
+            </p>
+          </div>
+        ) : !checking ? (
+          <>
+            <p className="text-xs text-muted-foreground">
+              {translate(
+                'auto.components.settings.task.tracker.integration.cards.cef18762a2',
+                'Add access with a Personal API key from your Linear settings. Full-access keys can see every team the key owner can reach.'
+              )}
+            </p>
+            <Button variant="ghost" size="sm" onClick={() => void checkLinearConnection(true)}>
+              {translate(
+                'auto.components.settings.task.tracker.integration.cards.c90f2ef419',
+                'Re-check'
+              )}
+            </Button>
+          </>
+        ) : null}
+      </IntegrationCardDetails>
 
       <LinearApiKeyDialog
         open={dialogOpen}
@@ -221,7 +224,7 @@ function ProviderAccountScopeRow({ scope }: { scope: ReturnType<typeof getProvid
         'Account scope'
       )}
       scope={scope}
-      className="mt-3 rounded-md border border-border/40 bg-background/50 px-3 py-2 text-xs"
+      className={`text-xs ${INTEGRATION_SUBORDINATE_ROW_CLASS}`}
     />
   )
 }


### PR DESCRIPTION
## Summary
- Removes the generic outer card treatment from Settings > Integrations so provider cards become the primary surfaces.
- Raises integration card contrast with existing design tokens and clearer detail dividers.
- Improves narrow-width wrapping for provider controls and account-scope rows.

## Design Review
- Scratch design doc: `design-docs/sta-611-settings-contrast.md` (ignored, not part of PR).
- `auto-design-review-fix` completed READY after Phase 0.5 and 2 review iterations.
- Direction adjusted to provider cards as the primary surfaces for the Integrations pane.

## Implementation
- Updated `SettingsSection` usage for Integrations only.
- Updated `IntegrationCardShell` card surface, header wrapping, and detail divider.
- Updated CLI, Linear, and Jira account/detail rows to use the neutral subordinate row treatment.
- No provider behavior, credential flow, runtime ownership logic, global tokens, or agent-visible workflow text changed.

## Completeness Verification
- Initial completeness pass found two gaps: connected Linear/Jira details bypassed the shared divider, and CLI account-scope rows missed the subordinate row recipe.
- Both gaps were fixed.
- Recheck confirmed complete against the design doc.

## Code Review Loop
- Round 1: two independent reviewers returned clean after initial implementation fixes.
- Validation found and fixed two narrow-layout blockers.
- Round 2: two fresh independent reviewers returned clean on the final diff.

## Brennan Test Changes
- Verdict: land.
- Electron identity verified: branch `brennanb2025/611`, root `/Users/thebr/orca/workspaces/orca/611`.
- Settings > Integrations validated in dark mode at desktop and narrow widths.
- Visual review passed with no blockers.

## Screenshot Evidence
- `/tmp/orca-sta-611-validation/integrations-review-providers-desktop-dark-final.png`
- `/tmp/orca-sta-611-validation/integrations-task-providers-desktop-dark-final.png`
- `/tmp/orca-sta-611-validation/integrations-task-providers-narrow-720-dark-final.png`
- `/tmp/orca-sta-611-validation/integrations-jira-narrow-640-dark-final.png`

## Checks
- `pnpm run typecheck` passed.
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx src/renderer/src/components/settings/task-tracker-integration-cards.test.tsx src/renderer/src/components/settings/jira-integration-card.test.tsx src/renderer/src/components/settings/provider-account-scope.test.ts` passed.
- Focused `pnpm exec oxlint` on changed Settings files passed.
- `git diff --check` passed.
- Pre-commit lint/React doctor/format hooks passed on staged files.
- Full `pnpm run lint` was attempted during validation and failed on unrelated missing localization keys in terminal context-menu files outside this diff.

## Post-PR Stabilization
- Waited 8 minutes after opening the PR.
- GitHub checks passed: `verify` and `track-community-pr`.
- CodeRabbit reported no actionable comments.
- CodeRabbit's docstring coverage warning was treated as non-actionable for this UI component diff because the repo does not use docstrings on these React components and no inline review comment requested a fix.

## Accepted Gaps / Risks
- Provider auth/test/disconnect actions were not exercised because this is a visual/layout-only diff and live provider actions would touch real credentials.
- No project context was needed; `demo-project` was not mutated.
- Screenshot evidence is intentionally stored outside the repo and not committed.
