### PR TITLE
Allow dragging workspaces out of lineage

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -154,6 +154,7 @@ import {
   getFullDropIndexForWorktreeDragUnit,
   getWorktreeDragUnitGroups
 } from './worktree-drag-units'
+import { getLineageDragOutWorktreeIds } from './worktree-lineage-drag-out'
 import {
   createSidebarDragPreview,
   isSidebarPointerDragBlocked,
@@ -1133,6 +1134,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   )
   const setRenamingWorktreeId = useAppStore((s) => s.setRenamingWorktreeId)
   const assignWorktreeParent = useAppStore((s) => s.assignWorktreeParent)
+  const updateWorktreeLineage = useAppStore((s) => s.updateWorktreeLineage)
   const worktreeDragSessionRef = useRef<WorktreeSidebarDragSession | null>(null)
   const worktreePointerDragRef = useRef<WorktreePointerDrag | null>(null)
   const worktreePointerAutoscrollFrameIdRef = useRef<number | null>(null)
@@ -2221,6 +2223,74 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     [assignWorktreeParent, getEligibleLineageDropTarget]
   )
 
+  const getLineageDragOutIdsForPointer = useCallback(
+    (args: {
+      draggedIds: readonly string[]
+      rects: readonly WorktreeSidebarDragRect[]
+      pointerY: number
+    }): string[] => {
+      const container = scrollRef.current
+      if (!container) {
+        return []
+      }
+      const containerRect = container.getBoundingClientRect()
+      return getLineageDragOutWorktreeIds({
+        draggedIds: args.draggedIds,
+        lineageById: worktreeLineageById,
+        rects: args.rects,
+        localY: args.pointerY - containerRect.top + container.scrollTop
+      })
+    },
+    [worktreeLineageById]
+  )
+
+  const commitLineageDragOut = useCallback(
+    (dragOutIds: readonly string[]): void => {
+      if (dragOutIds.length === 0) {
+        return
+      }
+      void Promise.all(dragOutIds.map((id) => updateWorktreeLineage(id, { noParent: true }))).catch(
+        (err) => {
+          console.error('Failed to remove workspace parent:', err)
+          toast.error(
+            translate(
+              'auto.components.sidebar.WorktreeList.failedRemoveWorkspaceParent',
+              'Failed to remove workspace parent'
+            )
+          )
+        }
+      )
+    },
+    [updateWorktreeLineage]
+  )
+
+  const commitWorktreeRootDrop = useCallback(
+    (args: {
+      groups: readonly WorktreeDragGroup[]
+      sourceGroupKey: string
+      draggedIds: readonly string[]
+      reorderDraggedIds: readonly string[]
+      rects: readonly WorktreeSidebarDragRect[]
+      pointerY: number
+      dropIndex: number
+    }): void => {
+      onReorderWorktrees({
+        groups: args.groups,
+        sourceGroupKey: args.sourceGroupKey,
+        draggedIds: args.reorderDraggedIds,
+        dropIndex: args.dropIndex
+      })
+      commitLineageDragOut(
+        getLineageDragOutIdsForPointer({
+          draggedIds: args.draggedIds,
+          rects: args.rects,
+          pointerY: args.pointerY
+        })
+      )
+    },
+    [commitLineageDragOut, getLineageDragOutIdsForPointer, onReorderWorktrees]
+  )
+
   const flushWorktreePointerDrag = useCallback(() => {
     const drag = worktreePointerDragRef.current
     if (!drag) {
@@ -2725,10 +2795,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         }
         const drop = computeWorktreeDrop(event.clientY)
         if (drop) {
-          onReorderWorktrees({
+          const refreshedSession = worktreeDragSessionRef.current
+          commitWorktreeRootDrop({
             groups: worktreeDragGroups,
             sourceGroupKey: drag.sourceGroupKey,
-            draggedIds: drag.reorderDraggedIds,
+            draggedIds: drag.draggedIds,
+            reorderDraggedIds: drag.reorderDraggedIds,
+            rects: refreshedSession?.rects ?? drag.rects,
+            pointerY: event.clientY,
             dropIndex: getFullDropIndexForWorktreeDragUnit({
               groups: worktreeDragUnitGroups,
               sourceGroupKey: drag.sourceGroupKey,
@@ -2792,6 +2866,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     beginWorktreePointerDrag,
     clearWorktreeDrag,
     commitWorktreeLineageParentDrop,
+    commitWorktreeRootDrop,
     computeWorktreeDrop,
     computeWorktreeStatusDrop,
     getEligibleLineageDropTarget,
@@ -2799,7 +2874,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     onMoveWorktreesToStatusAtIndex,
     onDropWorktreesOnWorkspaceBoard,
     onPinWorktrees,
-    onReorderWorktrees,
     onWorkspaceBoardDragPreviewCommit,
     refreshWorktreeDragSession,
     scheduleWorktreePointerDragFrame,
@@ -3077,6 +3151,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         clearWorktreeDrag()
         return
       }
+      const refreshedSession = worktreeDragSessionRef.current ?? session
       const boardDropTarget = getWorkspaceKanbanSidebarDropTarget(event.clientX, event.clientY)
       if (boardDropTarget.status || boardDropTarget.isPinDrop) {
         clearWorktreeDrag()
@@ -3128,13 +3203,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         return
       }
       event.preventDefault()
-      onReorderWorktrees({
+      commitWorktreeRootDrop({
         groups: worktreeDragGroups,
-        sourceGroupKey: session.sourceGroupKey,
-        draggedIds: session.reorderDraggedIds,
+        sourceGroupKey: refreshedSession.sourceGroupKey,
+        draggedIds: refreshedSession.draggedIds,
+        reorderDraggedIds: refreshedSession.reorderDraggedIds,
+        rects: refreshedSession.rects,
+        pointerY: event.clientY,
         dropIndex: getFullDropIndexForWorktreeDragUnit({
           groups: worktreeDragUnitGroups,
-          sourceGroupKey: session.sourceGroupKey,
+          sourceGroupKey: refreshedSession.sourceGroupKey,
           dropIndex: drop.dropIndex
         })
       })
@@ -3143,11 +3221,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     [
       clearWorktreeDrag,
       commitWorktreeLineageParentDrop,
+      commitWorktreeRootDrop,
       computeWorktreeDrop,
       computeWorktreeStatusDrop,
       getEligibleLineageDropTarget,
       onMoveWorktreesToStatusAtIndex,
-      onReorderWorktrees,
       refreshWorktreeDragSession,
       worktreeDragGroups,
       worktreeDragUnitGroups
@@ -3334,6 +3412,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         clearWorktreeDrag()
         return
       }
+      const refreshedSession = worktreeDragSessionRef.current ?? session
       const drop = computeWorktreeDrop(event.clientY)
       if (!drop) {
         const container = scrollRef.current
@@ -3381,13 +3460,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       // a status move, so commit here and stop the status-drop capture handler.
       event.preventDefault()
       event.stopPropagation()
-      onReorderWorktrees({
+      commitWorktreeRootDrop({
         groups: worktreeDragGroups,
-        sourceGroupKey: session.sourceGroupKey,
-        draggedIds: session.reorderDraggedIds,
+        sourceGroupKey: refreshedSession.sourceGroupKey,
+        draggedIds: refreshedSession.draggedIds,
+        reorderDraggedIds: refreshedSession.reorderDraggedIds,
+        rects: refreshedSession.rects,
+        pointerY: event.clientY,
         dropIndex: getFullDropIndexForWorktreeDragUnit({
           groups: worktreeDragUnitGroups,
-          sourceGroupKey: session.sourceGroupKey,
+          sourceGroupKey: refreshedSession.sourceGroupKey,
           dropIndex: drop.dropIndex
         })
       })
@@ -3399,11 +3481,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   }, [
     clearWorktreeDrag,
     commitWorktreeLineageParentDrop,
+    commitWorktreeRootDrop,
     computeWorktreeDrop,
     computeWorktreeStatusDrop,
     getEligibleLineageDropTarget,
     onMoveWorktreesToStatusAtIndex,
-    onReorderWorktrees,
     refreshWorktreeDragSession,
     worktreeDragGroups,
     worktreeDragUnitGroups
@@ -4184,11 +4266,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   onClickCapture={handleWorktreeRowClickCapture}
                   onDoubleClick={nested ? stopNestedWorktreeCardBubble : undefined}
                   onDragStart={nested ? stopNestedWorktreeCardBubble : undefined}
-                  onPointerDown={(event) =>
-                    nested
-                      ? undefined
-                      : handleWorktreeRowPointerDown(event, itemRow.worktree.id, itemRow.rowKey)
-                  }
+                  onPointerDown={(event) => {
+                    if (nested) {
+                      // Why: nested rows sit inside the parent card; their
+                      // drag must not bubble into a parent-workspace drag.
+                      event.stopPropagation()
+                    }
+                    handleWorktreeRowPointerDown(event, itemRow.worktree.id, itemRow.rowKey)
+                  }}
                   style={{
                     paddingLeft: surfaceInset > 0 ? `${surfaceInset}px` : undefined
                   }}

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-out.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-out.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import type { WorktreeLineage } from '../../../../shared/types'
+import { getLineageDragOutWorktreeIds } from './worktree-lineage-drag-out'
+import type { WorktreeSidebarDragRect } from './worktree-sidebar-drag-autoscroll'
+
+function lineage(parentWorktreeId: string): WorktreeLineage {
+  return {
+    worktreeId: 'child',
+    worktreeInstanceId: 'child-instance',
+    parentWorktreeId,
+    parentWorktreeInstanceId: `${parentWorktreeId}-instance`,
+    origin: 'manual',
+    capture: {
+      source: 'manual-action',
+      confidence: 'explicit'
+    },
+    createdAt: Date.now()
+  }
+}
+
+function rect(worktreeId: string, top: number, bottom: number): WorktreeSidebarDragRect {
+  return { worktreeId, groupIndex: 0, top, bottom }
+}
+
+describe('getLineageDragOutWorktreeIds', () => {
+  it('detaches a child when dropped outside its current parent bounds', () => {
+    expect(
+      getLineageDragOutWorktreeIds({
+        draggedIds: ['child'],
+        lineageById: { child: lineage('parent') },
+        rects: [rect('parent', 100, 260), rect('child', 160, 220)],
+        localY: 280
+      })
+    ).toEqual(['child'])
+  })
+
+  it('keeps a child parented while the drop remains inside the parent bounds', () => {
+    expect(
+      getLineageDragOutWorktreeIds({
+        draggedIds: ['child'],
+        lineageById: { child: lineage('parent') },
+        rects: [rect('parent', 100, 260), rect('child', 160, 220)],
+        localY: 200
+      })
+    ).toEqual([])
+  })
+
+  it('ignores root worktrees and missing parent rects', () => {
+    expect(
+      getLineageDragOutWorktreeIds({
+        draggedIds: ['root', 'hidden-child'],
+        lineageById: { 'hidden-child': lineage('missing-parent') },
+        rects: [rect('root', 0, 80)],
+        localY: 120
+      })
+    ).toEqual([])
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-out.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-out.ts
@@ -1,0 +1,34 @@
+import type { WorktreeLineage } from '../../../../shared/types'
+import type { WorktreeSidebarDragRect } from './worktree-sidebar-drag-autoscroll'
+
+export function getLineageDragOutWorktreeIds(args: {
+  draggedIds: readonly string[]
+  lineageById: Readonly<Record<string, WorktreeLineage>>
+  rects: readonly WorktreeSidebarDragRect[]
+  localY: number
+}): string[] {
+  const rectByWorktreeId = new Map(args.rects.map((rect) => [rect.worktreeId, rect]))
+  const draggedSet = new Set<string>()
+  const dragOutIds: string[] = []
+
+  for (const worktreeId of args.draggedIds) {
+    if (draggedSet.has(worktreeId)) {
+      continue
+    }
+    draggedSet.add(worktreeId)
+
+    const parentId = args.lineageById[worktreeId]?.parentWorktreeId
+    if (!parentId) {
+      continue
+    }
+    const parentRect = rectByWorktreeId.get(parentId)
+    if (!parentRect) {
+      continue
+    }
+    if (args.localY < parentRect.top || args.localY > parentRect.bottom) {
+      dragOutIds.push(worktreeId)
+    }
+  }
+
+  return dragOutIds
+}

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts
@@ -161,6 +161,34 @@ describe('refreshWorktreeSidebarDragSession', () => {
     ).toEqual({ ...SESSION, rects })
   })
 
+  it('keeps a child drag source when it belongs to a refreshed lineage unit', () => {
+    const childSession: WorktreeSidebarDragSession = {
+      ...SESSION,
+      draggingWorktreeId: 'child',
+      draggedIds: ['child'],
+      reorderDraggedIds: ['child'],
+      reorderUnitDraggedIds: ['child']
+    }
+
+    expect(
+      refreshWorktreeSidebarDragSession({
+        session: childSession,
+        groups: [{ key: 'repo:one', worktreeIds: ['parent', 'child', 'sibling'] }],
+        unitGroups: [
+          {
+            key: 'repo:one',
+            worktreeIds: ['parent', 'sibling'],
+            units: [
+              { worktreeId: 'parent', worktreeIds: ['parent', 'child'] },
+              { worktreeId: 'sibling', worktreeIds: ['sibling'] }
+            ]
+          }
+        ],
+        rects: []
+      })
+    ).toEqual({ ...childSession, rects: [] })
+  })
+
   it('clears when the source group is missing', () => {
     expect(
       refreshWorktreeSidebarDragSession({

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.ts
@@ -180,7 +180,11 @@ export function refreshWorktreeSidebarDragSession(args: {
     return null
   }
 
-  const sourceUnitIds = new Set(sourceUnitGroup.worktreeIds)
+  const sourceUnitIds = new Set(
+    sourceUnitGroup.units.length > 0
+      ? sourceUnitGroup.units.flatMap((unit) => unit.worktreeIds)
+      : sourceUnitGroup.worktreeIds
+  )
   if (args.session.reorderUnitDraggedIds.some((worktreeId) => !sourceUnitIds.has(worktreeId))) {
     return null
   }


### PR DESCRIPTION
## Summary
- allow nested lineage child workspace rows to start their own sidebar drag
- detach dragged child workspaces with `noParent` when they are dropped outside their current parent bounds
- keep lineage unit drag-session validation compatible with child drag sources

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-lineage-drag-out.test.ts src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts src/renderer/src/components/sidebar/worktree-drag-units.test.ts src/renderer/src/components/sidebar/worktree-manual-order.test.ts --reporter=verbose --maxWorkers=1`
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.ts src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts src/renderer/src/components/sidebar/worktree-lineage-drag-out.ts src/renderer/src/components/sidebar/worktree-lineage-drag-out.test.ts`
- `pnpm run typecheck:web`

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5854">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->