### PR TITLE
Make Codex account switch restart prompt prominent

### DIFF
--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -1,7 +1,15 @@
+import { useEffect, useId, useRef, useState } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
+import { Button } from '@/components/ui/button'
 import { useAppStore } from '../store'
 import { translate } from '@/i18n/i18n'
+import { shouldFocusMobileDriverAction } from './terminal-pane/mobile-driver-overlay-focus'
+import {
+  buildCodexRestartNoticeKey,
+  createCodexRestartOverlayCollapseState,
+  getCodexRestartOverlayCollapseState
+} from './codex-restart-overlay-collapse'
 
 const EMPTY_TABS: { id: string }[] = []
 
@@ -49,54 +57,205 @@ export function dismissStaleWorktreePtyIds(
   }
 }
 
+function isInsideHiddenTree(element: HTMLElement): boolean {
+  return element.closest('[aria-hidden="true"], [hidden], [inert]') !== null
+}
+
+type RestartNotice = {
+  previousAccountLabel: string
+  nextAccountLabel: string
+}
+
 export default function CodexRestartChip({
+  isVisible = true,
   worktreeId
 }: {
+  isVisible?: boolean
   worktreeId: string
 }): React.JSX.Element | null {
-  const staleWorktreePtyIds = useAppStore(
-    useShallow((s) =>
-      collectStalePtyIdsForTabs({
+  const { staleWorktreePtyIds, restartNotice } = useAppStore(
+    useShallow((s) => {
+      const stalePtyIds = collectStalePtyIdsForTabs({
         tabs: s.tabsByWorktree[worktreeId] ?? EMPTY_TABS,
         ptyIdsByTabId: s.ptyIdsByTabId,
         codexRestartNoticeByPtyId: s.codexRestartNoticeByPtyId
       })
-    )
+      const firstStalePtyId = stalePtyIds[0]
+      return {
+        staleWorktreePtyIds: stalePtyIds,
+        restartNotice: firstStalePtyId ? s.codexRestartNoticeByPtyId[firstStalePtyId] : undefined
+      }
+    })
   )
   const queueCodexPaneRestarts = useAppStore((s) => s.queueCodexPaneRestarts)
   const clearCodexRestartNotice = useAppStore((s) => s.clearCodexRestartNotice)
 
-  if (staleWorktreePtyIds.length === 0) {
+  const noticeKey = restartNotice ? buildCodexRestartNoticeKey(restartNotice) : null
+  const [collapseState, setCollapseState] = useState(() =>
+    createCodexRestartOverlayCollapseState(noticeKey)
+  )
+
+  const currentCollapseState = getCodexRestartOverlayCollapseState(collapseState, noticeKey)
+  // Why: a new account switch must reopen loud mode even if the prior notice was collapsed.
+  if (currentCollapseState !== collapseState) {
+    setCollapseState(currentCollapseState)
+  }
+
+  if (staleWorktreePtyIds.length === 0 || !restartNotice) {
     return null
   }
 
+  const handleRestart = (): void => {
+    queueCodexPaneRestarts(staleWorktreePtyIds)
+  }
+
+  const handleDismiss = (): void => {
+    dismissStaleWorktreePtyIds(staleWorktreePtyIds, clearCodexRestartNotice)
+  }
+
+  if (currentCollapseState.collapsed) {
+    return (
+      <CollapsedRestartChip
+        restartNotice={restartNotice}
+        onExpand={() => setCollapseState(createCodexRestartOverlayCollapseState(noticeKey))}
+        onRestart={handleRestart}
+      />
+    )
+  }
+
   return (
-    <div className="pointer-events-none absolute right-3 top-3 z-20">
-      <div className="pointer-events-auto flex items-center gap-2 rounded-lg border border-border/80 bg-popover/95 px-2 py-1.5 shadow-lg backdrop-blur-sm">
-        <span className="text-[11px] text-muted-foreground">
+    <LoudRestartOverlay
+      isVisible={isVisible}
+      noticeKey={noticeKey}
+      restartNotice={restartNotice}
+      onCollapse={() => setCollapseState({ noticeKey, collapsed: true })}
+      onDismiss={handleDismiss}
+      onRestart={handleRestart}
+    />
+  )
+}
+
+function LoudRestartOverlay({
+  isVisible,
+  noticeKey,
+  restartNotice,
+  onCollapse,
+  onDismiss,
+  onRestart
+}: {
+  isVisible: boolean
+  noticeKey: string | null
+  restartNotice: RestartNotice
+  onCollapse: () => void
+  onDismiss: () => void
+  onRestart: () => void
+}): React.JSX.Element {
+  const titleId = useId()
+  const bodyId = useId()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const restartRef = useRef<HTMLButtonElement>(null)
+
+  // Why: focus Restart only when the user isn't typing elsewhere; unconditional
+  // autoFocus would steal keys from an active composer or terminal input.
+  useEffect(() => {
+    if (!isVisible) {
+      return
+    }
+    const root = rootRef.current
+    if (!root || isInsideHiddenTree(root)) {
+      return
+    }
+    const paneScope = root.parentElement
+    if (shouldFocusMobileDriverAction(document.activeElement, document.body, paneScope)) {
+      restartRef.current?.focus()
+    }
+  }, [isVisible, noticeKey])
+
+  return (
+    <div
+      ref={rootRef}
+      role="dialog"
+      aria-live="assertive"
+      aria-labelledby={titleId}
+      aria-describedby={bodyId}
+      className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center p-6"
+    >
+      <div className="pointer-events-auto flex w-full max-w-[30rem] flex-col gap-3 rounded-lg border border-border bg-card p-6 pb-5 text-card-foreground shadow-xs">
+        <div className="flex items-start gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-full border border-border bg-muted">
+            <RefreshCw className="size-5 text-foreground" aria-hidden="true" />
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="text-xs font-medium uppercase tracking-wide text-foreground">
+              {translate('auto.components.CodexRestartChip.d3e8a1f4b2', 'Account switched')}
+            </div>
+            <div id={titleId} className="text-base font-semibold leading-tight">
+              {translate(
+                'auto.components.CodexRestartChip.a4c8e1b2f7',
+                'Codex is still signed in as {{value0}}',
+                { value0: restartNotice.previousAccountLabel }
+              )}
+            </div>
+          </div>
+        </div>
+        <div id={bodyId} className="text-sm leading-relaxed text-muted-foreground">
           {translate(
-            'auto.components.CodexRestartChip.9263e75f49',
-            'Codex is using the previous account'
+            'auto.components.CodexRestartChip.e9b2c7d1a5',
+            'Restart this session to use {{value0}}. Collapse to keep working with the current account.',
+            { value0: restartNotice.nextAccountLabel }
           )}
-        </span>
-        <div className="flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={() => queueCodexPaneRestarts(staleWorktreePtyIds)}
-            className="inline-flex items-center gap-1.5 rounded-md bg-foreground px-2 py-1 text-[11px] font-medium text-background transition-colors hover:opacity-90"
-          >
-            <RefreshCw className="size-3" />
-            {translate('auto.components.CodexRestartChip.c72a5fb234', 'Restart')}
-          </button>
-          <button
-            type="button"
-            onClick={() => dismissStaleWorktreePtyIds(staleWorktreePtyIds, clearCodexRestartNotice)}
-            className="rounded-md px-1.5 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
-          >
+        </div>
+        <div className="mt-1 flex flex-wrap justify-end gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onDismiss}>
             {translate('auto.components.CodexRestartChip.9132779820', 'Dismiss')}
-          </button>
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={onCollapse}>
+            {translate('auto.components.CodexRestartChip.f1a6c8e3b4', 'Collapse')}
+          </Button>
+          <Button ref={restartRef} type="button" variant="default" size="sm" onClick={onRestart}>
+            <RefreshCw />
+            {translate('auto.components.CodexRestartChip.c72a5fb234', 'Restart')}
+          </Button>
         </div>
       </div>
+    </div>
+  )
+}
+
+function CollapsedRestartChip({
+  restartNotice,
+  onExpand,
+  onRestart
+}: {
+  restartNotice: RestartNotice
+  onExpand: () => void
+  onRestart: () => void
+}): React.JSX.Element {
+  return (
+    <div
+      className="absolute right-2 top-2 z-50 flex max-w-[min(100%-1rem,24rem)] items-center gap-1.5 rounded-full border border-border bg-card px-2 py-1 text-xs font-medium text-card-foreground shadow-xs"
+      role="status"
+      aria-live="polite"
+    >
+      <RefreshCw className="size-3 shrink-0 text-foreground" aria-hidden="true" />
+      <Button
+        type="button"
+        variant="ghost"
+        size="xs"
+        className="min-w-0 max-w-[10rem] px-1 font-medium"
+        onClick={onExpand}
+      >
+        <span className="truncate">
+          {translate(
+            'auto.components.CodexRestartChip.a4c8e1b2f7',
+            'Codex is still signed in as {{value0}}',
+            { value0: restartNotice.previousAccountLabel }
+          )}
+        </span>
+      </Button>
+      <Button type="button" variant="default" size="xs" onClick={onRestart}>
+        {translate('auto.components.CodexRestartChip.c72a5fb234', 'Restart')}
+      </Button>
     </div>
   )
 }

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1866,7 +1866,7 @@ function Terminal(): React.JSX.Element | null {
                     }
                     aria-hidden={!isVisible}
                   >
-                    <CodexRestartChip worktreeId={workspace.id} />
+                    <CodexRestartChip isVisible={isVisible} worktreeId={workspace.id} />
                     {(tabsByWorktree[workspace.id] ?? []).map((tab) => {
                       const activityTerminalPortal = findActivityTerminalPortal(
                         activityTerminalPortals,
@@ -2111,7 +2111,7 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
       inert={!isVisible}
       aria-hidden={!isVisible}
     >
-      <CodexRestartChip worktreeId={worktreeId} />
+      <CodexRestartChip isVisible={isVisible} worktreeId={worktreeId} />
       <TabGroupSplitLayout
         layout={layout}
         worktreeId={worktreeId}

--- a/src/renderer/src/components/codex-restart-overlay-collapse.test.ts
+++ b/src/renderer/src/components/codex-restart-overlay-collapse.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCodexRestartNoticeKey,
+  createCodexRestartOverlayCollapseState,
+  getCodexRestartOverlayCollapseState
+} from './codex-restart-overlay-collapse'
+
+describe('codex restart overlay collapse', () => {
+  it('builds a stable notice key from account labels', () => {
+    expect(
+      buildCodexRestartNoticeKey({
+        previousAccountLabel: 'Account A',
+        nextAccountLabel: 'Account B'
+      })
+    ).toBe('Account A\u0000Account B')
+  })
+
+  it('reopens loud mode when the notice key changes', () => {
+    const collapsed = {
+      noticeKey: buildCodexRestartNoticeKey({
+        previousAccountLabel: 'Account A',
+        nextAccountLabel: 'Account B'
+      }),
+      collapsed: true
+    }
+
+    expect(
+      getCodexRestartOverlayCollapseState(
+        collapsed,
+        buildCodexRestartNoticeKey({
+          previousAccountLabel: 'Account A',
+          nextAccountLabel: 'Account C'
+        })
+      )
+    ).toEqual({
+      noticeKey: 'Account A\u0000Account C',
+      collapsed: false
+    })
+  })
+
+  it('preserves collapse state for the same notice key', () => {
+    const noticeKey = buildCodexRestartNoticeKey({
+      previousAccountLabel: 'Account A',
+      nextAccountLabel: 'Account B'
+    })
+    const collapsed = { noticeKey, collapsed: true }
+
+    expect(getCodexRestartOverlayCollapseState(collapsed, noticeKey)).toBe(collapsed)
+  })
+
+  it('creates loud mode for a new notice key', () => {
+    const noticeKey = buildCodexRestartNoticeKey({
+      previousAccountLabel: 'Account A',
+      nextAccountLabel: 'Account B'
+    })
+
+    expect(createCodexRestartOverlayCollapseState(noticeKey)).toEqual({
+      noticeKey,
+      collapsed: false
+    })
+  })
+})

--- a/src/renderer/src/components/codex-restart-overlay-collapse.ts
+++ b/src/renderer/src/components/codex-restart-overlay-collapse.ts
@@ -1,0 +1,32 @@
+export type CodexRestartOverlayCollapseState = {
+  noticeKey: string | null
+  collapsed: boolean
+}
+
+export function buildCodexRestartNoticeKey(args: {
+  previousAccountLabel: string
+  nextAccountLabel: string
+}): string {
+  return `${args.previousAccountLabel}\u0000${args.nextAccountLabel}`
+}
+
+export function getCodexRestartOverlayCollapseState(
+  state: CodexRestartOverlayCollapseState,
+  noticeKey: string | null
+): CodexRestartOverlayCollapseState {
+  return state.noticeKey === noticeKey
+    ? state
+    : {
+        noticeKey,
+        collapsed: false
+      }
+}
+
+export function createCodexRestartOverlayCollapseState(
+  noticeKey: string | null
+): CodexRestartOverlayCollapseState {
+  return {
+    noticeKey,
+    collapsed: false
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -624,8 +624,12 @@
     "components": {
       "CodexRestartChip": {
         "9132779820": "Dismiss",
+        "a4c8e1b2f7": "Codex is still signed in as {{value0}}",
         "c72a5fb234": "Restart",
-        "9263e75f49": "Codex is using the previous account"
+        "9263e75f49": "Codex is using the previous account",
+        "d3e8a1f4b2": "Account switched",
+        "e9b2c7d1a5": "Restart this session to use {{value0}}. Collapse to keep working with the current account.",
+        "f1a6c8e3b4": "Collapse"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "Dismiss notice",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -625,7 +625,11 @@
       "CodexRestartChip": {
         "9132779820": "Despedir",
         "c72a5fb234": "Reanudar",
-        "9263e75f49": "Codex está usando la cuenta anterior."
+        "9263e75f49": "Codex está usando la cuenta anterior.",
+        "a4c8e1b2f7": "Codex is still signed in as {{value0}}",
+        "d3e8a1f4b2": "Account switched",
+        "e9b2c7d1a5": "Restart this session to use {{value0}}. Collapse to keep working with the current account.",
+        "f1a6c8e3b4": "Collapse"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "Descartar aviso",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -625,7 +625,11 @@
       "CodexRestartChip": {
         "9132779820": "閉じる",
         "c72a5fb234": "再起動",
-        "9263e75f49": "Codex は前のアカウントを使用しています"
+        "9263e75f49": "Codex は前のアカウントを使用しています",
+        "a4c8e1b2f7": "Codex is still signed in as {{value0}}",
+        "d3e8a1f4b2": "Account switched",
+        "e9b2c7d1a5": "Restart this session to use {{value0}}. Collapse to keep working with the current account.",
+        "f1a6c8e3b4": "Collapse"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "通知を閉じる",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -625,7 +625,11 @@
       "CodexRestartChip": {
         "9132779820": "닫기",
         "c72a5fb234": "다시 시작",
-        "9263e75f49": "Codex는 이전 계정을 사용하고 있습니다"
+        "9263e75f49": "Codex는 이전 계정을 사용하고 있습니다",
+        "a4c8e1b2f7": "Codex is still signed in as {{value0}}",
+        "d3e8a1f4b2": "Account switched",
+        "e9b2c7d1a5": "Restart this session to use {{value0}}. Collapse to keep working with the current account.",
+        "f1a6c8e3b4": "Collapse"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "알림 닫기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -625,7 +625,11 @@
       "CodexRestartChip": {
         "9132779820": "关闭",
         "c72a5fb234": "重新启动",
-        "9263e75f49": "Codex 正在使用以前的账户"
+        "9263e75f49": "Codex 正在使用以前的账户",
+        "a4c8e1b2f7": "Codex is still signed in as {{value0}}",
+        "d3e8a1f4b2": "Account switched",
+        "e9b2c7d1a5": "Restart this session to use {{value0}}. Collapse to keep working with the current account.",
+        "f1a6c8e3b4": "Collapse"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "关闭通知",


### PR DESCRIPTION
## Summary
- Replace the small Codex restart chip with a prominent restart overlay and collapsible chip state
- Reopen loud mode when the account-switch notice changes and preserve collapse state otherwise
- Keep focus behavior safe for hidden worktree surfaces and sync locale catalog keys

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/codex-restart-chip.test.ts src/renderer/src/components/codex-restart-overlay-collapse.test.ts src/renderer/src/components/terminal-pane/mobile-driver-overlay-focus.test.ts
- pnpm run verify:localization-catalog
- pnpm typecheck
- git diff --check

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5857">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->