### PR TITLE
Keep Source Control AI generation available when actions are hidden

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -119,6 +119,7 @@ import { readSourceControlLaunchRecipeAgentId } from '@/lib/source-control-launc
 import {
   DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS,
   resolveSourceControlActionRecipe,
+  resolveSourceControlAiEnabled,
   resolveSourceControlAiForOperation,
   resolveSourceControlAiPrCreationDefaults
 } from '../../../../shared/source-control-ai'
@@ -754,6 +755,10 @@ export default function ChecksPanel(): React.JSX.Element {
           prCreationProductDefaults: DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS
         })
   }, [repo, settings])
+  const sourceControlAiActionsVisible = useMemo(
+    () => (settings ? resolveSourceControlAiEnabled({ settings, repo }) : false),
+    [repo, settings]
+  )
   const createComposerOpen =
     !activeReview &&
     !isFolder &&
@@ -792,6 +797,7 @@ export default function ChecksPanel(): React.JSX.Element {
     settings: ownerSettings,
     submitting: isCreatingPr,
     prCreationDefaults,
+    sourceControlAiActionsVisible,
     onBranchChangedByGeneration: handleBranchChangedByPullRequestGeneration
   })
   const handlePrBaseChange = useCallback(
@@ -2014,6 +2020,11 @@ export default function ChecksPanel(): React.JSX.Element {
     : noEnabledAgentKnown
       ? 'No enabled AI agents. Configure agents in Settings.'
       : undefined
+  useEffect(() => {
+    if (!sourceControlAiActionsVisible) {
+      setAgentComposerState(null)
+    }
+  }, [sourceControlAiActionsVisible])
   const resolveCommentsWithAIDisabledReason = commentsLoading
     ? 'Comments are still loading.'
     : aiActionDisabledReason
@@ -2173,7 +2184,7 @@ export default function ChecksPanel(): React.JSX.Element {
   // not a local MERGE_HEAD, so the prompt must tell the agent how to reproduce
   // the merge locally instead of reusing the live Source Control conflict prompt.
   const handleResolveConflictsWithAI = useCallback(async (): Promise<void> => {
-    if (!activeWorktreeId || !activeConflictReview) {
+    if (!sourceControlAiActionsVisible || !activeWorktreeId || !activeConflictReview) {
       return
     }
     const conflictFiles = activeConflictReview.conflictSummary?.files ?? []
@@ -2195,11 +2206,17 @@ export default function ChecksPanel(): React.JSX.Element {
       }),
       launchSource: 'conflict_resolution'
     })
-  }, [activeConflictReview, activeWorktreeId, activeWorktreePath])
+  }, [activeConflictReview, activeWorktreeId, activeWorktreePath, sourceControlAiActionsVisible])
 
   const handleResolveCommentsWithAI = useCallback(
     (selectedGroups: PRCommentGroup[]): void => {
-      if (!activeWorktreeId || !activeReview || !repo || resolveCommentsWithAIDisabledReason) {
+      if (
+        !sourceControlAiActionsVisible ||
+        !activeWorktreeId ||
+        !activeReview ||
+        !repo ||
+        resolveCommentsWithAIDisabledReason
+      ) {
         return
       }
       const selectedThreadIds = selectedGroups.flatMap((group) =>
@@ -2248,6 +2265,7 @@ export default function ChecksPanel(): React.JSX.Element {
       activeWorktreePath,
       repo,
       resolveCommentsWithAIDisabledReason,
+      sourceControlAiActionsVisible,
       stateRequestKey
     ]
   )
@@ -2323,7 +2341,13 @@ export default function ChecksPanel(): React.JSX.Element {
   )
 
   const handleFixChecksWithAI = useCallback(async (): Promise<void> => {
-    if (isFixingChecksWithAI || !activeWorktreeId || !activeReview || !repo) {
+    if (
+      !sourceControlAiActionsVisible ||
+      isFixingChecksWithAI ||
+      !activeWorktreeId ||
+      !activeReview ||
+      !repo
+    ) {
       return
     }
     const broken = getBrokenChecks(checks)
@@ -2405,6 +2429,7 @@ export default function ChecksPanel(): React.JSX.Element {
     isFixingChecksWithAI,
     pr?.prRepo,
     repo,
+    sourceControlAiActionsVisible,
     stateRequestKey
   ])
 
@@ -3018,7 +3043,7 @@ export default function ChecksPanel(): React.JSX.Element {
               baseResults={prBaseResults}
               setBaseResults={setPrBaseResults}
               baseSearchError={prBaseSearchError}
-              aiGenerationEnabled={prAiGenerationEnabled}
+              aiGenerationEnabled={sourceControlAiActionsVisible && prAiGenerationEnabled}
               generating={prGenerating}
               generateDisabled={prGenerateDisabled}
               generateDisabledReason={prGenerateDisabledReason}
@@ -3179,7 +3204,7 @@ export default function ChecksPanel(): React.JSX.Element {
         )}
       </div>
 
-      {shouldShowReviewTriageStrip && (
+      {shouldShowReviewTriageStrip && sourceControlAiActionsVisible && (
         <PRTriageStrip
           review={activeConflictReview ?? activeReview}
           reviewKind={reviewShortLabel}
@@ -3226,14 +3251,16 @@ export default function ChecksPanel(): React.JSX.Element {
         resolveCommentsWithAIDisabled={Boolean(resolveCommentsWithAIDisabledReason)}
         resolveCommentsWithAIDisabledReason={resolveCommentsWithAIDisabledReason}
         onAddComment={pr ? handleAddPRComment : undefined}
-        onResolveSelectedCommentsWithAI={handleResolveCommentsWithAI}
+        onResolveSelectedCommentsWithAI={
+          sourceControlAiActionsVisible ? handleResolveCommentsWithAI : undefined
+        }
         onReply={pr ? handleReplyToComment : undefined}
         onResolve={pr || activeGitLabReview ? handleResolve : undefined}
         onEditComment={pr ? handleEditComment : undefined}
         onDeleteComment={pr ? handleDeleteComment : undefined}
       />
       <SourceControlAgentActionDialog
-        open={agentComposerState !== null}
+        open={sourceControlAiActionsVisible && agentComposerState !== null}
         onOpenChange={(open) => {
           if (!open) {
             setAgentComposerState(null)

--- a/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
@@ -36,6 +36,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     remoteActionError: null as string | null,
     isCommitting: inputs.isCommitting,
     isFixingCommitFailureWithAI: false,
+    sourceControlAiActionsVisible: true,
     aiEnabled: false,
     aiAgentConfigured: false,
     isGenerating: false,

--- a/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
@@ -37,6 +37,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     isCommitting: inputs.isCommitting,
     isFixingCommitFailureWithAI: false,
     showComposer: true,
+    sourceControlAiActionsVisible: true,
     aiEnabled: false,
     aiAgentConfigured: false,
     isGenerating: false,

--- a/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
@@ -36,6 +36,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     remoteActionError: null as string | null,
     isCommitting: inputs.isCommitting,
     isFixingCommitFailureWithAI: false,
+    sourceControlAiActionsVisible: true,
     aiEnabled: false,
     aiAgentConfigured: false,
     isGenerating: false,

--- a/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
@@ -34,6 +34,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     remoteActionError: null as string | null,
     isCommitting: inputs.isCommitting,
     isFixingCommitFailureWithAI: false,
+    sourceControlAiActionsVisible: true,
     aiEnabled: false,
     aiAgentConfigured: false,
     isGenerating: false,
@@ -195,6 +196,19 @@ describe('CommitArea', () => {
     expect(button).toBeDefined()
     expect(button).toContain('disabled=""')
     expect(button).toContain('animate-spin')
+  })
+
+  it('hides commit failure AI actions when Source Control AI actions are hidden', () => {
+    const markup = renderCommitArea({
+      ...baseProps(),
+      commitError: 'husky - pre-commit hook failed',
+      commitFailureRecoveryPrompt: 'Fix this commit failure.',
+      sourceControlAiActionsVisible: false
+    })
+
+    expect(markup).not.toContain('AI Fix')
+    expect(markup).not.toContain('Fix commit failure with AI')
+    expect(markup).toContain('Commit blocked')
   })
 
   it('enables the agent picker when commit failure context is available', () => {
@@ -466,6 +480,7 @@ describe('ConflictSummaryCard', () => {
       <ConflictSummaryCard
         conflictOperation="rebase"
         unresolvedCount={1}
+        sourceControlAiActionsVisible={true}
         isResolvingWithAI={false}
         onResolveWithAI={vi.fn()}
         onReview={vi.fn()}
@@ -480,6 +495,7 @@ describe('ConflictSummaryCard', () => {
       <ConflictSummaryCard
         conflictOperation="merge"
         unresolvedCount={1}
+        sourceControlAiActionsVisible={true}
         isResolvingWithAI={false}
         onAbortOperation={vi.fn()}
         onResolveWithAI={vi.fn()}
@@ -490,6 +506,7 @@ describe('ConflictSummaryCard', () => {
       <ConflictSummaryCard
         conflictOperation="rebase"
         unresolvedCount={1}
+        sourceControlAiActionsVisible={true}
         isResolvingWithAI={false}
         onAbortOperation={vi.fn()}
         onResolveWithAI={vi.fn()}
@@ -500,6 +517,7 @@ describe('ConflictSummaryCard', () => {
       <ConflictSummaryCard
         conflictOperation="cherry-pick"
         unresolvedCount={1}
+        sourceControlAiActionsVisible={true}
         isResolvingWithAI={false}
         onAbortOperation={vi.fn()}
         onResolveWithAI={vi.fn()}
@@ -520,6 +538,7 @@ describe('ConflictSummaryCard', () => {
       <ConflictSummaryCard
         conflictOperation="merge"
         unresolvedCount={1}
+        sourceControlAiActionsVisible={true}
         isResolvingWithAI={false}
         onAbortOperation={vi.fn()}
         onResolveWithAI={vi.fn()}
@@ -530,6 +549,7 @@ describe('ConflictSummaryCard', () => {
       <ConflictSummaryCard
         conflictOperation="rebase"
         unresolvedCount={1}
+        sourceControlAiActionsVisible={true}
         isResolvingWithAI={false}
         onAbortOperation={vi.fn()}
         onResolveWithAI={vi.fn()}
@@ -548,6 +568,7 @@ describe('ConflictSummaryCard', () => {
       <ConflictSummaryCard
         conflictOperation="merge"
         unresolvedCount={2}
+        sourceControlAiActionsVisible={true}
         isResolvingWithAI={false}
         onResolveWithAI={vi.fn()}
         onReview={vi.fn()}
@@ -557,6 +578,22 @@ describe('ConflictSummaryCard', () => {
     expect(markup).toContain('Resolve with AI')
     expect(markup).toContain('lucide-sparkles')
     expect(markup).not.toMatch(/\blucide-sparkle(?!s)\b/)
+  })
+
+  it('hides Resolve with AI when Source Control AI actions are hidden', () => {
+    const markup = renderToStaticMarkup(
+      <ConflictSummaryCard
+        conflictOperation="merge"
+        unresolvedCount={2}
+        sourceControlAiActionsVisible={false}
+        isResolvingWithAI={false}
+        onResolveWithAI={vi.fn()}
+        onReview={vi.fn()}
+      />
+    )
+
+    expect(markup).not.toContain('Resolve with AI')
+    expect(markup).toContain('Review conflicts')
   })
 })
 

--- a/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
+++ b/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
@@ -20,6 +20,7 @@ import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-r
 import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullRequestDialogFields'
 import {
   DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS,
+  resolveSourceControlAiEnabled,
   resolveSourceControlAiForOperation,
   resolveSourceControlAiPrCreationDefaults
 } from '../../../../shared/source-control-ai'
@@ -71,6 +72,10 @@ export function CreatePullRequestDialog({
   const [error, setError] = useState<string | null>(null)
   const provider = resolveHostedReviewCreationProvider(eligibility?.provider)
   const copy = reviewCopy(provider)
+  const sourceControlAiActionsVisible = React.useMemo(
+    () => (settings ? resolveSourceControlAiEnabled({ settings, repo }) : false),
+    [repo, settings]
+  )
   const prCreationDefaults = React.useMemo(() => {
     if (!settings) {
       return DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS
@@ -125,6 +130,7 @@ export function CreatePullRequestDialog({
     settings,
     submitting,
     prCreationDefaults,
+    sourceControlAiActionsVisible,
     onBranchChangedByGeneration
   })
 

--- a/src/renderer/src/components/right-sidebar/PullRequestComposer.generate-tooltip.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PullRequestComposer.generate-tooltip.test.tsx
@@ -6,12 +6,14 @@ import { resolveDropdownItems } from './source-control-dropdown-items'
 import { resolvePrimaryAction } from './source-control-primary-action'
 
 type RenderPullRequestComposerOptions = {
+  aiGenerationEnabled?: boolean
   generating?: boolean
   generateDisabled?: boolean
   generateDisabledReason?: string
 }
 
 function renderPullRequestComposer({
+  aiGenerationEnabled = true,
   generating = false,
   generateDisabled = false,
   generateDisabledReason
@@ -47,7 +49,7 @@ function renderPullRequestComposer({
         baseResults={[]}
         setBaseResults={vi.fn()}
         baseSearchError={null}
-        aiGenerationEnabled={true}
+        aiGenerationEnabled={aiGenerationEnabled}
         generating={generating}
         generateDisabled={generateDisabled}
         generateDisabledReason={generateDisabledReason}
@@ -84,6 +86,13 @@ describe('CreateHostedReviewComposer generate tooltip', () => {
     expect(markup).toContain('aria-label="Generate pull request details with AI"')
     expect(markup).not.toContain('{{value0}}')
     expect(markup).not.toContain('title="Generate {{value0}} details with AI"')
+  })
+
+  it('hides hosted review generation controls when Source Control AI actions are hidden', () => {
+    const markup = renderPullRequestComposer({ aiGenerationEnabled: false })
+
+    expect(markup).not.toContain('Generate pull request details with AI')
+    expect(markup).toContain('Create')
   })
 
   it('keeps enabled generation controls as direct tooltip triggers', () => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1566,6 +1566,7 @@ function SourceControlInner(): React.JSX.Element {
   )
   const {
     sourceControlAiDiscoveryHostKey,
+    sourceControlAiActionsVisible,
     resolvedCommitMessageAi,
     resolvedPrCreationDefaults,
     resolveConflictsComposerOpen,
@@ -1604,6 +1605,20 @@ function SourceControlInner(): React.JSX.Element {
     openSettingsTarget,
     openSettingsPage
   })
+
+  useEffect(() => {
+    if (sourceControlAiActionsVisible) {
+      return
+    }
+    setResolveConflictsComposerOpen(false)
+    setCommitGenerationDialogOpen(false)
+    setPullRequestGenerationDialogOpen(false)
+  }, [
+    setCommitGenerationDialogOpen,
+    setPullRequestGenerationDialogOpen,
+    setResolveConflictsComposerOpen,
+    sourceControlAiActionsVisible
+  ])
 
   // Why: orphaned draft/error/in-flight entries accumulate when worktrees are
   // removed from the store (long sessions with many create/destroy cycles).
@@ -1966,6 +1981,9 @@ function SourceControlInner(): React.JSX.Element {
   )
 
   const handleGenerateCommitMessageClick = useCallback((): void => {
+    if (!sourceControlAiActionsVisible) {
+      return
+    }
     if (
       hasConfiguredCommitMessageGenerationDefaults({ settings, repo: activeRepo ?? null }) &&
       resolvedCommitMessageAi?.ok
@@ -1974,7 +1992,14 @@ function SourceControlInner(): React.JSX.Element {
       return
     }
     openCommitGenerationDialog()
-  }, [activeRepo, handleGenerate, openCommitGenerationDialog, resolvedCommitMessageAi, settings])
+  }, [
+    activeRepo,
+    handleGenerate,
+    openCommitGenerationDialog,
+    resolvedCommitMessageAi,
+    settings,
+    sourceControlAiActionsVisible
+  ])
 
   const generateCommitMessageForCreatePrIntent = useCallback(
     async (
@@ -2645,6 +2670,7 @@ function SourceControlInner(): React.JSX.Element {
     settings: activeRepoSettings,
     submitting: isCreatingPr,
     prCreationDefaults: resolvedPrCreationDefaults,
+    sourceControlAiActionsVisible,
     onBranchChangedByGeneration: handleBranchChangedByPullRequestGeneration,
     generation: {
       generating: activePullRequestGenerationRecord?.status === 'running',
@@ -2657,6 +2683,9 @@ function SourceControlInner(): React.JSX.Element {
   })
 
   const handleGeneratePullRequestFieldsClick = useCallback((): void => {
+    if (!sourceControlAiActionsVisible) {
+      return
+    }
     if (
       hasConfiguredSourceControlTextGenerationDefaults({
         actionId: 'pullRequest',
@@ -2668,7 +2697,13 @@ function SourceControlInner(): React.JSX.Element {
       return
     }
     openPullRequestGenerationDialog()
-  }, [activeRepo, handleGeneratePullRequestFields, openPullRequestGenerationDialog, settings])
+  }, [
+    activeRepo,
+    handleGeneratePullRequestFields,
+    openPullRequestGenerationDialog,
+    settings,
+    sourceControlAiActionsVisible
+  ])
 
   useEffect(() => {
     // Why: on Source Control remount, the PR fields hook seeds eligibility
@@ -5215,6 +5250,7 @@ function SourceControlInner(): React.JSX.Element {
               <ConflictSummaryCard
                 conflictOperation={conflictOperation}
                 unresolvedCount={unresolvedConflictReviewEntries.length}
+                sourceControlAiActionsVisible={sourceControlAiActionsVisible}
                 isResolvingWithAI={false}
                 isAbortingOperation={isAbortingOperation}
                 onAbortOperation={handleAbortOperationForConflict}
@@ -5317,7 +5353,7 @@ function SourceControlInner(): React.JSX.Element {
                 baseResults={prBaseResults}
                 setBaseResults={setPrBaseResults}
                 baseSearchError={prBaseSearchError}
-                aiGenerationEnabled={prAiGenerationEnabled}
+                aiGenerationEnabled={sourceControlAiActionsVisible && prAiGenerationEnabled}
                 generating={prGenerating}
                 generateDisabled={prGenerateDisabled}
                 generateDisabledReason={prGenerateDisabledReason}
@@ -5352,7 +5388,8 @@ function SourceControlInner(): React.JSX.Element {
                 isCreatePrIntentInFlight={isCreatePrIntentInFlight}
                 groupId={activeGroupId ?? activeWorktreeId}
                 showComposer={!showGenericEmptyState}
-                aiEnabled={resolvedCommitMessageAi?.ok === true}
+                sourceControlAiActionsVisible={sourceControlAiActionsVisible}
+                aiEnabled={sourceControlAiActionsVisible && resolvedCommitMessageAi?.ok === true}
                 aiAgentConfigured={resolvedCommitMessageAi?.ok === true}
                 isGenerating={isGenerating}
                 generateError={generateError}
@@ -5813,7 +5850,7 @@ function SourceControlInner(): React.JSX.Element {
         </DialogContent>
       </Dialog>
       <SourceControlAgentActionDialog
-        open={resolveConflictsComposerOpen}
+        open={sourceControlAiActionsVisible && resolveConflictsComposerOpen}
         onOpenChange={setResolveConflictsComposerOpen}
         actionId="resolveConflicts"
         title={translate(
@@ -5851,7 +5888,7 @@ function SourceControlInner(): React.JSX.Element {
         }
       />
       <SourceControlTextGenerationDialog
-        open={commitGenerationDialogOpen}
+        open={sourceControlAiActionsVisible && commitGenerationDialogOpen}
         onOpenChange={setCommitGenerationDialogOpen}
         actionId="commitMessage"
         title={translate(
@@ -5872,7 +5909,7 @@ function SourceControlInner(): React.JSX.Element {
         onSaveDefaults={handleSaveCommitMessageGenerationDefaults}
       />
       <SourceControlTextGenerationDialog
-        open={pullRequestGenerationDialogOpen}
+        open={sourceControlAiActionsVisible && pullRequestGenerationDialogOpen}
         onOpenChange={setPullRequestGenerationDialogOpen}
         actionId="pullRequest"
         title={translate(
@@ -6082,6 +6119,7 @@ type CommitAreaProps = {
   isCreatingPr?: boolean
   isCreatePrIntentInFlight?: boolean
   showComposer?: boolean
+  sourceControlAiActionsVisible: boolean
   aiEnabled: boolean
   aiAgentConfigured: boolean
   isGenerating: boolean
@@ -6124,6 +6162,7 @@ export function CommitArea({
   isCreatingPr = false,
   isCreatePrIntentInFlight = false,
   showComposer = true,
+  sourceControlAiActionsVisible,
   aiEnabled,
   aiAgentConfigured,
   isGenerating,
@@ -6541,31 +6580,33 @@ export function CommitArea({
               </p>
             </div>
             <div className="ml-[1.375rem] flex min-w-0 items-center gap-1.5">
-              <CommitFailureFixSplitButton
-                label={translate(
-                  'auto.components.right.sidebar.SourceControl.60bd988f0b',
-                  'AI Fix'
-                )}
-                worktreeId={worktreeId}
-                groupId={groupId}
-                connectionId={connectionId}
-                repoId={repoId}
-                launchPlatform={launchPlatform}
-                prompt={commitFailureRecoveryPrompt}
-                isLaunching={isFixingCommitFailureWithAI}
-                variant="secondary"
-                size="xs"
-                iconClassName="size-3"
-                primaryClassName="h-6 px-2 text-[11px]"
-                chevronClassName="h-6 px-1.5"
-                savedAgentId={readSourceControlLaunchRecipeAgentId(fixCommitFailureRecipe)}
-                savedCommandInputTemplate={fixCommitFailureRecipe?.commandInputTemplate ?? null}
-                savedAgentArgs={fixCommitFailureRecipe?.agentArgs ?? null}
-                onSaveAgentDefault={onSaveLaunchActionDefault}
-                onOpenSettings={onOpenSourceControlAiSettings}
-                onFixWithDefaultAgent={handleFixCommitFailureWithAI}
-                onPromptDelivered={handleCommitFailureAgentPromptDelivered}
-              />
+              {sourceControlAiActionsVisible ? (
+                <CommitFailureFixSplitButton
+                  label={translate(
+                    'auto.components.right.sidebar.SourceControl.60bd988f0b',
+                    'AI Fix'
+                  )}
+                  worktreeId={worktreeId}
+                  groupId={groupId}
+                  connectionId={connectionId}
+                  repoId={repoId}
+                  launchPlatform={launchPlatform}
+                  prompt={commitFailureRecoveryPrompt}
+                  isLaunching={isFixingCommitFailureWithAI}
+                  variant="secondary"
+                  size="xs"
+                  iconClassName="size-3"
+                  primaryClassName="h-6 px-2 text-[11px]"
+                  chevronClassName="h-6 px-1.5"
+                  savedAgentId={readSourceControlLaunchRecipeAgentId(fixCommitFailureRecipe)}
+                  savedCommandInputTemplate={fixCommitFailureRecipe?.commandInputTemplate ?? null}
+                  savedAgentArgs={fixCommitFailureRecipe?.agentArgs ?? null}
+                  onSaveAgentDefault={onSaveLaunchActionDefault}
+                  onOpenSettings={onOpenSourceControlAiSettings}
+                  onFixWithDefaultAgent={handleFixCommitFailureWithAI}
+                  onPromptDelivered={handleCommitFailureAgentPromptDelivered}
+                />
+              ) : null}
               {hasCommitFailureDetails && (
                 <Button
                   type="button"
@@ -6601,31 +6642,33 @@ export function CommitArea({
               {commitError}
             </pre>
             <DialogFooter>
-              <CommitFailureFixSplitButton
-                label={translate(
-                  'auto.components.right.sidebar.SourceControl.834cb3f23d',
-                  'Fix with AI'
-                )}
-                worktreeId={worktreeId}
-                groupId={groupId}
-                connectionId={connectionId}
-                repoId={repoId}
-                launchPlatform={launchPlatform}
-                prompt={commitFailureRecoveryPrompt}
-                isLaunching={isFixingCommitFailureWithAI}
-                variant="default"
-                size="sm"
-                iconClassName="size-4"
-                primaryClassName="rounded-r-none"
-                chevronClassName="rounded-l-none border-l border-primary-foreground/20 px-2"
-                savedAgentId={readSourceControlLaunchRecipeAgentId(fixCommitFailureRecipe)}
-                savedCommandInputTemplate={fixCommitFailureRecipe?.commandInputTemplate ?? null}
-                savedAgentArgs={fixCommitFailureRecipe?.agentArgs ?? null}
-                onSaveAgentDefault={onSaveLaunchActionDefault}
-                onOpenSettings={onOpenSourceControlAiSettings}
-                onFixWithDefaultAgent={handleFixCommitFailureWithAI}
-                onPromptDelivered={handleCommitFailureAgentPromptDelivered}
-              />
+              {sourceControlAiActionsVisible ? (
+                <CommitFailureFixSplitButton
+                  label={translate(
+                    'auto.components.right.sidebar.SourceControl.834cb3f23d',
+                    'Fix with AI'
+                  )}
+                  worktreeId={worktreeId}
+                  groupId={groupId}
+                  connectionId={connectionId}
+                  repoId={repoId}
+                  launchPlatform={launchPlatform}
+                  prompt={commitFailureRecoveryPrompt}
+                  isLaunching={isFixingCommitFailureWithAI}
+                  variant="default"
+                  size="sm"
+                  iconClassName="size-4"
+                  primaryClassName="rounded-r-none"
+                  chevronClassName="rounded-l-none border-l border-primary-foreground/20 px-2"
+                  savedAgentId={readSourceControlLaunchRecipeAgentId(fixCommitFailureRecipe)}
+                  savedCommandInputTemplate={fixCommitFailureRecipe?.commandInputTemplate ?? null}
+                  savedAgentArgs={fixCommitFailureRecipe?.agentArgs ?? null}
+                  onSaveAgentDefault={onSaveLaunchActionDefault}
+                  onOpenSettings={onOpenSourceControlAiSettings}
+                  onFixWithDefaultAgent={handleFixCommitFailureWithAI}
+                  onPromptDelivered={handleCommitFailureAgentPromptDelivered}
+                />
+              ) : null}
               <DialogClose asChild>
                 <Button type="button" variant="outline" size="sm">
                   {translate('auto.components.right.sidebar.SourceControl.783a808870', 'Close')}
@@ -7140,6 +7183,7 @@ function DiffCommentsInlineList({
 export function ConflictSummaryCard({
   conflictOperation,
   unresolvedCount,
+  sourceControlAiActionsVisible,
   isResolvingWithAI,
   isAbortingOperation = false,
   onAbortOperation,
@@ -7148,6 +7192,7 @@ export function ConflictSummaryCard({
 }: {
   conflictOperation: GitConflictOperation
   unresolvedCount: number
+  sourceControlAiActionsVisible: boolean
   isResolvingWithAI: boolean
   isAbortingOperation?: boolean
   onAbortOperation?: (operation: GitConflictOperation) => void
@@ -7184,26 +7229,28 @@ export function ConflictSummaryCard({
         </div>
       </div>
       <div className="mt-2">
-        <Button
-          type="button"
-          variant="default"
-          size="sm"
-          className="h-7 w-full text-xs"
-          disabled={isResolvingWithAI}
-          onClick={onResolveWithAI}
-        >
-          {isResolvingWithAI ? (
-            <RefreshCw className="size-3.5 animate-spin" />
-          ) : (
-            <Sparkles className="size-3.5" />
-          )}
-          {translate('auto.components.right.sidebar.SourceControl.f6cb48b6fe', 'Resolve with AI')}
-        </Button>
+        {sourceControlAiActionsVisible ? (
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            className="h-7 w-full text-xs"
+            disabled={isResolvingWithAI}
+            onClick={onResolveWithAI}
+          >
+            {isResolvingWithAI ? (
+              <RefreshCw className="size-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="size-3.5" />
+            )}
+            {translate('auto.components.right.sidebar.SourceControl.f6cb48b6fe', 'Resolve with AI')}
+          </Button>
+        ) : null}
         <Button
           type="button"
           variant="outline"
           size="sm"
-          className="mt-1.5 h-7 w-full text-xs"
+          className={cn(sourceControlAiActionsVisible && 'mt-1.5', 'h-7 w-full text-xs')}
           onClick={onReview}
         >
           <GitMerge className="size-3.5" />

--- a/src/renderer/src/components/right-sidebar/use-source-control-ai.ts
+++ b/src/renderer/src/components/right-sidebar/use-source-control-ai.ts
@@ -6,6 +6,7 @@ import { getCommitMessageModelDiscoveryHostKeyForScope } from '../../../../share
 import {
   DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS,
   resolveSourceControlActionRecipe,
+  resolveSourceControlAiEnabled,
   resolveSourceControlAiForOperation,
   resolveSourceControlAiPrCreationDefaults,
   type ResolvedSourceControlAiGenerationParams
@@ -66,6 +67,10 @@ export function useSourceControlAi({
   const sourceControlAiDiscoveryHostKey = useMemo(
     () => getSourceControlAiControllerDiscoveryHostKey(settings, activeConnectionId),
     [activeConnectionId, settings]
+  )
+  const sourceControlAiActionsVisible = useMemo(
+    () => (settings ? resolveSourceControlAiEnabled({ settings, repo: activeRepo }) : false),
+    [activeRepo, settings]
   )
   const resolvedCommitMessageAi = useMemo(
     () =>
@@ -259,6 +264,7 @@ export function useSourceControlAi({
 
   return {
     sourceControlAiDiscoveryHostKey,
+    sourceControlAiActionsVisible,
     resolvedCommitMessageAi,
     resolvedPrCreationDefaults,
     resolveConflictsComposerOpen,

--- a/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
+++ b/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
@@ -45,6 +45,7 @@ type UseCreatePullRequestDialogFieldsOptions = {
   settings: AppState['settings']
   submitting: boolean
   prCreationDefaults?: SourceControlAiPrCreationDefaults
+  sourceControlAiActionsVisible?: boolean
   onBranchChangedByGeneration?: () => Promise<void>
   generation?: {
     generating: boolean
@@ -106,6 +107,7 @@ export function useCreatePullRequestDialogFields({
   settings,
   submitting,
   prCreationDefaults,
+  sourceControlAiActionsVisible = true,
   onBranchChangedByGeneration,
   generation
 }: UseCreatePullRequestDialogFieldsOptions) {
@@ -484,7 +486,7 @@ export function useCreatePullRequestDialogFields({
   ])
 
   return {
-    aiGenerationEnabled: resolvedPullRequestAi?.ok === true,
+    aiGenerationEnabled: sourceControlAiActionsVisible && resolvedPullRequestAi?.ok === true,
     initializedFromEligibility:
       currentEligibilityKey !== null && initializedEligibilityKey === currentEligibilityKey,
     base,

--- a/src/renderer/src/components/settings/RepositorySourceControlAiEnablement.tsx
+++ b/src/renderer/src/components/settings/RepositorySourceControlAiEnablement.tsx
@@ -20,6 +20,12 @@ function enablementValue(value: boolean | undefined): 'inherit' | 'on' | 'off' {
   return 'inherit'
 }
 
+function visibilityLabel(value: boolean): string {
+  return value
+    ? translate('auto.components.settings.RepositorySourceControlAiEnablement.show', 'Show')
+    : translate('auto.components.settings.RepositorySourceControlAiEnablement.hide', 'Hide')
+}
+
 export function RepositorySourceControlAiEnablement({
   value,
   source,
@@ -30,25 +36,16 @@ export function RepositorySourceControlAiEnablement({
       <div className="min-w-0 space-y-0.5">
         <Label className="text-xs font-medium">
           {translate(
-            'auto.components.settings.RepositorySourceControlAiEnablement.cf5959c834',
-            'Source Control AI enabled'
+            'auto.components.settings.RepositorySourceControlAiEnablement.showActionsLabel',
+            'Show Source Control AI actions'
           )}
         </Label>
         <p className="text-[11px] text-muted-foreground">
           {translate(
-            'auto.components.settings.RepositorySourceControlAiEnablement.30ae6dcce8',
-            'Global default is'
+            'auto.components.settings.RepositorySourceControlAiEnablement.visibilityHelper',
+            "Controls whether Source Control AI buttons are shown for this repository. Generation used by separate features follows those features' settings. Global default is {{value0}}.",
+            { value0: visibilityLabel(source.enabled) }
           )}
-          {source.enabled
-            ? translate(
-                'auto.components.settings.RepositorySourceControlAiEnablement.bea897eec2',
-                'On'
-              )
-            : translate(
-                'auto.components.settings.RepositorySourceControlAiEnablement.84233d1bb3',
-                'Off'
-              )}
-          .
         </p>
       </div>
       <Select
@@ -68,16 +65,10 @@ export function RepositorySourceControlAiEnablement({
             )}
           </SelectItem>
           <SelectItem value="on">
-            {translate(
-              'auto.components.settings.RepositorySourceControlAiEnablement.bea897eec2',
-              'On'
-            )}
+            {translate('auto.components.settings.RepositorySourceControlAiEnablement.show', 'Show')}
           </SelectItem>
           <SelectItem value="off">
-            {translate(
-              'auto.components.settings.RepositorySourceControlAiEnablement.84233d1bb3',
-              'Off'
-            )}
+            {translate('auto.components.settings.RepositorySourceControlAiEnablement.hide', 'Hide')}
           </SelectItem>
         </SelectContent>
       </Select>

--- a/src/renderer/src/components/settings/RepositorySourceControlAiSection.test.ts
+++ b/src/renderer/src/components/settings/RepositorySourceControlAiSection.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { normalizeRepoSourceControlAiOverrides } from '../../../../shared/source-control-ai'
-import type { RepoSourceControlAiOverrides } from '../../../../shared/source-control-ai-types'
+import type {
+  RepoSourceControlAiOverrides,
+  SourceControlAiSettings
+} from '../../../../shared/source-control-ai-types'
 import {
   createRepoAiDraftState,
   dropRepoLegacyInstructionForAction,
   resolveRepoAiDraftState
 } from './RepositorySourceControlAiSection'
+import { RepositorySourceControlAiEnablement } from './RepositorySourceControlAiEnablement'
 
 describe('RepositorySourceControlAiSection draft state', () => {
   it('refreshes clean drafts when persisted repo overrides change', () => {
@@ -71,6 +77,24 @@ describe('RepositorySourceControlAiSection draft state', () => {
       value: persisted,
       baseSerialized: JSON.stringify(normalizeRepoSourceControlAiOverrides(persisted))
     })
+  })
+})
+
+describe('RepositorySourceControlAiEnablement', () => {
+  it('describes repo enablement as Source Control AI action visibility', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(RepositorySourceControlAiEnablement, {
+        value: false,
+        source: { enabled: true } as SourceControlAiSettings,
+        onChange: () => {}
+      })
+    )
+
+    expect(markup).toContain('Show Source Control AI actions')
+    expect(markup).toContain('Controls whether Source Control AI buttons are shown')
+    expect(markup).toContain('separate features follows those features&#x27; settings')
+    expect(markup).toContain('Show')
+    expect(markup).not.toContain('Source Control AI enabled')
   })
 })
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5607,7 +5607,11 @@
           "bea897eec2": "On",
           "62511a575d": "Use global",
           "30ae6dcce8": "Global default is",
-          "cf5959c834": "Source Control AI enabled"
+          "cf5959c834": "Source Control AI enabled",
+          "show": "Show",
+          "hide": "Hide",
+          "showActionsLabel": "Show Source Control AI actions",
+          "visibilityHelper": "Controls whether Source Control AI buttons are shown for this repository. Generation used by separate features follows those features' settings. Global default is {{value0}}."
         },
         "RepositorySourceControlAiHostedReviewDefaults": {
           "053ccfbf52": "Off",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5570,7 +5570,11 @@
           "bea897eec2": "En",
           "62511a575d": "Usar global",
           "30ae6dcce8": "El valor predeterminado global es",
-          "cf5959c834": "Control de fuente AI habilitado"
+          "cf5959c834": "Control de fuente AI habilitado",
+          "show": "Mostrar",
+          "hide": "Ocultar",
+          "showActionsLabel": "Mostrar acciones de IA de control de código fuente",
+          "visibilityHelper": "Controla si los botones de IA de control de código fuente se muestran para este repositorio. La generación usada por funciones separadas sigue la configuración de esas funciones. El valor predeterminado global es {{value0}}."
         },
         "RepositorySourceControlAiHostedReviewDefaults": {
           "053ccfbf52": "Apagado",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5592,7 +5592,11 @@
           "bea897eec2": "オン",
           "62511a575d": "グローバルを使用する",
           "30ae6dcce8": "グローバルデフォルトは",
-          "cf5959c834": "ソース管理 AI が有効になっている"
+          "cf5959c834": "ソース管理 AI が有効になっている",
+          "show": "表示",
+          "hide": "非表示",
+          "showActionsLabel": "ソース管理 AI 操作を表示する",
+          "visibilityHelper": "このリポジトリでソース管理 AI ボタンを表示するかどうかを制御します。別機能で使用される生成は、それぞれの機能の設定に従います。グローバルデフォルトは {{value0}} です。"
         },
         "RepositorySourceControlAiHostedReviewDefaults": {
           "053ccfbf52": "オフ",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5555,7 +5555,11 @@
           "bea897eec2": "켜기",
           "62511a575d": "글로벌 사용",
           "30ae6dcce8": "전역 기본값은",
-          "cf5959c834": "소스 제어 AI 활성화"
+          "cf5959c834": "소스 제어 AI 활성화",
+          "show": "표시",
+          "hide": "숨기기",
+          "showActionsLabel": "Source Control AI 작업 표시",
+          "visibilityHelper": "이 저장소에 Source Control AI 버튼을 표시할지 제어합니다. 별도 기능에서 사용하는 생성은 해당 기능의 설정을 따릅니다. 전역 기본값은 {{value0}}입니다."
         },
         "RepositorySourceControlAiHostedReviewDefaults": {
           "053ccfbf52": "끄기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5555,7 +5555,11 @@
           "bea897eec2": "在",
           "62511a575d": "使用全局",
           "30ae6dcce8": "全局默认是",
-          "cf5959c834": "启用源代码控制 AI"
+          "cf5959c834": "启用源代码控制 AI",
+          "show": "显示",
+          "hide": "隐藏",
+          "showActionsLabel": "显示源代码控制 AI 操作",
+          "visibilityHelper": "控制是否为此仓库显示源代码控制 AI 按钮。单独功能使用的生成会遵循这些功能各自的设置。全局默认值为 {{value0}}。"
         },
         "RepositorySourceControlAiHostedReviewDefaults": {
           "053ccfbf52": "离开",

--- a/src/shared/source-control-ai.test.ts
+++ b/src/shared/source-control-ai.test.ts
@@ -66,7 +66,7 @@ describe('source-control AI resolution', () => {
     expect(resolve('branchName').params.model).toBe('gpt-5.5')
   })
 
-  it('resolves PR defaults even when Source Control AI generation is disabled', () => {
+  it('resolves generation config and PR defaults when Source Control AI actions are hidden', () => {
     const base = settings()
     base.sourceControlAi = {
       ...base.sourceControlAi!,
@@ -84,7 +84,8 @@ describe('source-control AI resolution', () => {
       repo: null,
       operation: 'pullRequest'
     })
-    expect(generation.ok).toBe(false)
+    expect(generation.ok).toBe(true)
+    expect(generation.ok && generation.value.params.model).toBe('gpt-5.5')
     expect(
       resolveSourceControlAiPrCreationDefaults({
         settings: base,
@@ -112,7 +113,19 @@ describe('source-control AI resolution', () => {
     })
   })
 
-  it('lets repo enablement override the global default', () => {
+  it('lets repo-hidden Source Control AI actions keep operation generation valid', () => {
+    const result = resolveSourceControlAiForOperation({
+      settings: settings(),
+      repo: { sourceControlAi: { enabled: false } },
+      operation: 'branchName',
+      discoveryHostKey: 'local'
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.value.params.model).toBe('gpt-5.5')
+  })
+
+  it('lets repo action visibility override the global default', () => {
     const base = settings()
     base.sourceControlAi = {
       ...base.sourceControlAi!,

--- a/src/shared/source-control-ai.ts
+++ b/src/shared/source-control-ai.ts
@@ -1148,12 +1148,6 @@ export function resolveSourceControlAiForOperation(
   const legacy = input.settings.commitMessageAi
   const source = normalizeSourceControlAiSettings(input.settings.sourceControlAi, legacy)
   const repoOverrides = normalizeRepoSourceControlAiOverrides(input.repo?.sourceControlAi)
-  if (!(repoOverrides?.enabled ?? source.enabled)) {
-    return {
-      ok: false,
-      error: 'Enable Source Control AI in Settings -> Git.'
-    }
-  }
 
   const prCreationDefaults = resolvePrCreationDefaults(
     source,


### PR DESCRIPTION
## Summary
- Treat the repository Source Control AI setting as UI visibility only: hiding actions removes manual AI buttons, but no longer blocks independent generation features.
- Rename the repository setting copy to "Show Source Control AI actions" with Show/Hide choices and updated localized strings.
- Keep manual Source Control AI affordances hidden consistently across commit, PR, check/review, conflict, and commit-failure flows.

## Design and review
- Design doc: `design-docs/source-control-ai-actions-visibility.md` (scratch/ignored, not committed).
- Design review completed via `auto-design-review-fix`; no P0/P1 issues remained. One accepted P2: hiding actions can make advanced action settings less discoverable.
- Implementation followed the reviewed design with no reported deviations.
- Completeness verification found the implementation matched the design requirements.

## Code review
- Round 1 found untranslated English strings in non-English locale catalogs.
- Fixed locale strings for `es`, `ja`, `ko`, and `zh`, then reran checks.
- Fresh round 2 returned clean from both reviewers; only residual gaps were full Electron validation, which was covered by `brennan-test-changes`.

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run verify:localization-catalog`
- [x] `pnpm run verify:localization-coverage`
- [x] `git diff --check`
- [x] Focused Vitest suite: `pnpm vitest run --config config/vitest.config.ts src/shared/source-control-ai.test.ts src/shared/source-control-ai-action-recipes.test.ts src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx src/renderer/src/components/right-sidebar/CommitArea.test.tsx src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx src/renderer/src/components/right-sidebar/PullRequestComposer.generate-tooltip.test.tsx src/renderer/src/components/settings/RepositorySourceControlAiSection.test.ts` (8 files, 111 tests)
- [x] Electron validation from exact worktree `salp @ brennanb2025/investigate-ai-enablement`, identity verified with `window.api.app.getIdentity()`.
- [x] `demo-project` validation: default Source Control shows manual AI UI; setting repo visibility to Hide persists `repo.sourceControlAi.enabled === false`; normal git controls remain; `Generate commit message with AI` is absent.
- [x] In-Electron resolver check: hidden repo visibility returns `resolveSourceControlAiEnabled(...) === false` while `resolveSourceControlAiForOperation(...)` still returns `ok: true`.

## Evidence
- `.context/brennan-test-evidence/source-control-ai-visibility/repo-setting-show-actions-copy.png`
- `.context/brennan-test-evidence/source-control-ai-visibility/source-control-actions-shown.png`
- `.context/brennan-test-evidence/source-control-ai-visibility/source-control-actions-hidden.png`

## Assumptions and gaps
- SSH validation was not run because no SSH/remoting-specific code path changed; shared resolver behavior applies in both local and remote contexts.
- A real external AI provider and hosted PR mutation were not invoked; generation behavior was covered by focused tests plus the in-Electron resolver check to avoid mutating real provider/PR state.

## Post-PR stabilization
- [x] Waited 8 minutes after PR creation, checked PR checks and CodeRabbit surfaces.
- [x] PR checks passed: `verify` and `track-community-pr`.
- [x] Requested a CodeRabbit review after the initial rate-limit warning; CodeRabbit replied that review finished, and no actionable review comments were posted.