### PR TITLE
Test restored terminal pane titles

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  mapRestoredPaneTitlesByPaneId,
   shouldDetachPaneTransportOnUnmount,
   splitPaneWithOneShotStartup,
   suppressIntentionalPaneCloseExit
@@ -122,6 +123,41 @@ describe('shouldDetachPaneTransportOnUnmount', () => {
         worktreeTabs: []
       })
     ).toBe(false)
+  })
+})
+
+describe('mapRestoredPaneTitlesByPaneId', () => {
+  it('restores persisted pane titles onto newly-created pane ids', () => {
+    const restoredPaneByLeafId = new Map([
+      ['11111111-1111-4111-8111-111111111111', 7],
+      ['22222222-2222-4222-8222-222222222222', 3]
+    ])
+
+    expect(
+      mapRestoredPaneTitlesByPaneId(
+        {
+          '11111111-1111-4111-8111-111111111111': 'build logs',
+          '22222222-2222-4222-8222-222222222222': 'test runner'
+        },
+        restoredPaneByLeafId
+      )
+    ).toEqual({
+      7: 'build logs',
+      3: 'test runner'
+    })
+  })
+
+  it('ignores stale leaf ids and empty persisted titles', () => {
+    expect(
+      mapRestoredPaneTitlesByPaneId(
+        {
+          '11111111-1111-4111-8111-111111111111': 'build logs',
+          '22222222-2222-4222-8222-222222222222': '',
+          '33333333-3333-4333-8333-333333333333': 'closed pane'
+        },
+        new Map([['11111111-1111-4111-8111-111111111111', 2]])
+      )
+    ).toEqual({ 2: 'build logs' })
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -222,6 +222,24 @@ export function suppressIntentionalPaneCloseExit(
   return ptyId
 }
 
+export function mapRestoredPaneTitlesByPaneId(
+  savedTitles: Record<string, string> | undefined,
+  restoredPaneByLeafId: ReadonlyMap<string, number>
+): Record<number, string> {
+  if (!savedTitles) {
+    return {}
+  }
+
+  const restored: Record<number, string> = {}
+  for (const [oldLeafId, title] of Object.entries(savedTitles)) {
+    const newPaneId = restoredPaneByLeafId.get(oldLeafId)
+    if (newPaneId != null && title) {
+      restored[newPaneId] = title
+    }
+  }
+  return restored
+}
+
 function terminalSelectionExceedsPrimaryLimit(terminal: Terminal): boolean {
   const range = terminal.getSelectionPosition()
   if (!range) {
@@ -1111,24 +1129,18 @@ export function useTerminalPaneLifecycle({
 
     // Seed pane titles from the persisted snapshot using the same
     // old-leafId → new-paneId mapping used for buffer restore.
-    const savedTitles = initialLayoutRef.current.titlesByLeafId
-    if (savedTitles) {
-      const restored: Record<number, string> = {}
-      for (const [oldLeafId, title] of Object.entries(savedTitles)) {
-        const newPaneId = restoredPaneByLeafId.get(oldLeafId)
-        if (newPaneId != null && title) {
-          restored[newPaneId] = title
-        }
-      }
-      if (Object.keys(restored).length > 0) {
-        // Merge (not replace) so we don't discard any concurrent state
-        // updates from onPaneClosed that React may have batched.
-        setPaneTitles((prev) => ({ ...prev, ...restored }))
-        // Why: the lifecycle immediately persists a fresh layout after restore,
-        // before React state has flushed. Keep the ref in sync now so that
-        // persist preserves restored titles instead of rewriting them away.
-        paneTitlesRef.current = { ...paneTitlesRef.current, ...restored }
-      }
+    const restoredTitles = mapRestoredPaneTitlesByPaneId(
+      initialLayoutRef.current.titlesByLeafId,
+      restoredPaneByLeafId
+    )
+    if (Object.keys(restoredTitles).length > 0) {
+      // Merge (not replace) so we don't discard any concurrent state
+      // updates from onPaneClosed that React may have batched.
+      setPaneTitles((prev) => ({ ...prev, ...restoredTitles }))
+      // Why: the lifecycle immediately persists a fresh layout after restore,
+      // before React state has flushed. Keep the ref in sync now so that
+      // persist preserves restored titles instead of rewriting them away.
+      paneTitlesRef.current = { ...paneTitlesRef.current, ...restoredTitles }
     }
 
     const restoredActivePaneId =


### PR DESCRIPTION
## Summary
- extract the persisted-pane-title restore mapping into a small pure helper
- add regression coverage for saved leaf-id titles mapping onto fresh pane ids after restore
- verify stale leaf ids and empty saved titles are ignored

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts src/renderer/src/lib/terminal-pane-title-sanitization.test.ts src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts
- pnpm run typecheck
- pnpm run lint

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5861">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->