### PR TITLE
Keep compact agent rows steady for screenshot links

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -390,7 +390,7 @@ describe('WorktreeCardAgents', () => {
     expect(markup).not.toContain('data-testid="agent-row"')
   })
 
-  it('renders compact agent messages with images as inline thumbnails', async () => {
+  it('keeps compact agent messages with trusted data image markdown to the single-line preview', async () => {
     mockAgentActivityDisplayMode = 'compact'
     mockAgents = [
       mockAgent({
@@ -398,7 +398,7 @@ describe('WorktreeCardAgents', () => {
         state: 'done',
         startedAt: 1000,
         prompt: 'Check screenshot',
-        lastAssistantMessage: 'Result:\n\n![Image #1](data:image/png;base64,abc123)'
+        lastAssistantMessage: `${'Detailed result. '.repeat(400)}\n\n![Image #1](data:image/png;base64,abc123)`
       })
     ]
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
@@ -407,13 +407,59 @@ describe('WorktreeCardAgents', () => {
 
     expect(markup).toContain('compact-agent-row')
     expect(markup).toContain('group/compact-agent-row')
-    expect(markup).toContain('<img')
-    expect(markup).toContain('alt="Image #1"')
-    expect(markup).toContain('max-h-36')
+    expect(markup).toContain('flex h-6 items-center gap-1')
+    expect(markup).not.toContain('<img')
+    expect(markup).not.toContain('max-h-36')
     expect(markup).not.toContain('data-testid="agent-row"')
   })
 
-  it('bounds long compact agent messages that include image markdown', async () => {
+  it('keeps compact agent messages with trusted blob image markdown to the single-line preview', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    mockAgents = [
+      mockAgent({
+        agentType: 'codex',
+        state: 'done',
+        startedAt: 1000,
+        prompt: 'Check screenshot',
+        lastAssistantMessage: 'Result:\n\n![Image #1](blob:orca-preview-1)'
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('flex h-6 items-center gap-1')
+    expect(markup).not.toContain('<img')
+    expect(markup).not.toContain('max-h-36')
+  })
+
+  it('keeps reference-style compact agent image markdown to the single-line preview', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    mockAgents = [
+      mockAgent({
+        agentType: 'codex',
+        state: 'done',
+        startedAt: 1000,
+        prompt: 'Check screenshot',
+        lastAssistantMessage: [
+          'Result:',
+          '',
+          '![Image #1][trusted-screenshot]',
+          '',
+          '[trusted-screenshot]: data:image/png;base64,abc123 "preview"'
+        ].join('\n')
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('flex h-6 items-center gap-1')
+    expect(markup).not.toContain('<img')
+    expect(markup).not.toContain('max-h-36')
+  })
+
+  it('keeps untrusted compact agent image markdown to the single-line preview', async () => {
     mockAgentActivityDisplayMode = 'compact'
     mockAgents = [
       mockAgent({
@@ -428,10 +474,10 @@ describe('WorktreeCardAgents', () => {
 
     const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
 
-    expect(markup).toContain('max-h-36')
-    expect(markup).toContain('overflow-hidden')
+    expect(markup).toContain('flex h-6 items-center gap-1')
     expect(markup).not.toContain('<img')
-    expect(markup).toContain('href="https://example.com/screenshot.png"')
+    expect(markup).not.toContain('max-h-36')
+    expect(markup).not.toContain('href="https://example.com/screenshot.png"')
   })
 
   it('renders a compact summary affordance for multiple flat agents', async () => {

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -5,11 +5,8 @@ import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/da
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { cn } from '@/lib/utils'
-import CommentMarkdown from './CommentMarkdown'
 import { getAgentDotState } from './worktree-card-agent-summary'
 import { translate } from '@/i18n/i18n'
-
-const MARKDOWN_IMAGE_PATTERN = /!\[[^\]\n]*\]\([^)]+\)/
 
 function formatShortTimeAgo(ts: number, now: number): string {
   const delta = now - ts
@@ -116,12 +113,8 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
     typeof onToggleChildAgents === 'function'
   const dotState = getAgentDotState(agent)
   const primary = getCompactAgentPrimary(agent)
-  const assistantMessage = agent.entry.lastAssistantMessage?.trim() ?? ''
-  const hasAssistantImage = MARKDOWN_IMAGE_PATTERN.test(assistantMessage)
   const isLineageChild = agent.lineage?.depth === 1
-  const secondary = hasAssistantImage
-    ? formatAgentTypeLabel(agent.agentType)
-    : getCompactAgentSecondary(agent)
+  const secondary = getCompactAgentSecondary(agent)
   const shortTime = getCompactAgentTime(agent, now)
 
   const handleActivate = useCallback(
@@ -239,7 +232,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
         'text-muted-foreground worktree-agent-row-hover',
         hasChildDisclosure && 'worktree-agent-lineage-parent-row',
         isLineageChild && 'worktree-agent-lineage-child-row',
-        hasAssistantImage ? 'flex flex-col py-0.5' : 'flex h-6 items-center gap-1',
+        'flex h-6 items-center gap-1',
         isFocusedPane && 'bg-worktree-sidebar-accent',
         sendTargetStatus === 'sending' && 'cursor-progress opacity-75',
         sendTargetStatus === 'disabled' && 'cursor-default opacity-60'
@@ -256,17 +249,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
       aria-expanded={hasChildDisclosure ? childAgentsExpanded : undefined}
       title={sendTargetDisabledReason ?? `${primary}${secondary ? ` - ${secondary}` : ''}`}
     >
-      {hasAssistantImage ? (
-        <>
-          <div className="flex h-6 min-w-0 items-center gap-1">{rowBody}</div>
-          <CommentMarkdown
-            content={assistantMessage}
-            className="ml-5 max-h-36 max-w-full overflow-hidden text-[10px] leading-snug text-muted-foreground/80 [&_.comment-md-p]:block [&_.comment-md-p+.comment-md-p]:mt-1"
-          />
-        </>
-      ) : (
-        rowBody
-      )}
+      {rowBody}
     </div>
   )
 })


### PR DESCRIPTION
## Summary

Compact inline agent rows now always stay in the one-line `h-6` preview layout, even when the assistant message contains screenshot/image markdown. The richer `CommentMarkdown` image rendering remains available in full agent/message surfaces; this PR keeps the tiny status line under a workspace name from becoming a tall markdown preview.

## Design approach

- Reproduced the bug first with a failing `WorktreeCardAgents.test.tsx` regression: untrusted `https://...` image markdown rendered the tall compact preview path.
- Reviewed design doc: `design-docs/compact-agent-screenshot-preview.md` (scratch/ignored, not part of the PR diff).
- After clarifying the intended UX, removed the compact-row thumbnail exception entirely.
- Kept image rendering localized to `CommentMarkdown` consumers that are meant to show rich markdown, rather than the compact inline status row.

## Design review

`auto-design-review-fix` completed clean by threshold. It tightened the design around trusted thumbnail eligibility, parser edge cases, and the tradeoff of exporting the existing trust predicate instead of creating a new media-policy module.

## Implementation

- Removed markdown parsing and `CommentMarkdown` rendering from `CompactAgentRow`.
- Restored `isTrustedCompactImageSrc` to a private helper inside `CommentMarkdown`.
- Kept the compact row on the fixed `flex h-6 items-center gap-1` path and let the existing `.truncate` span contain long assistant text.
- Updated tests so trusted `data:`, trusted `blob:`, reference-style, and untrusted remote image markdown all stay in the single-line preview with no `<img>` or `max-h-36` markdown preview branch.

## Completeness verification

Read-only verification agent returned `complete`: implementation matched every design requirement and validation item, with no omissions/blockers.

## Code review loop

- Round 1: one clean review, one low parser-title finding. Fixed and added coverage.
- Round 2: one clean review, one low nested-alt-bracket finding. Fixed and added coverage.
- Round 3: two parser-parity findings around code spans/reference images/malformed syntax/invalid titles. Replaced scanner with markdown AST and added coverage.
- Round 4: both reviewers found duplicate reference definition mismatch. Fixed by preserving first definitions and added coverage.
- Round 5: both independent reviewers returned `No issues found.`

## Brennan test changes

Verdict: `land`, then amended after UX clarification.

- `demo-project` used in an isolated temp Orca profile.
- Electron launched from this exact worktree and identity verified:
  - `devRepoRoot`: `/Users/thebr/orca/workspaces/orca/marron`
  - branch: `brennanb2025/worktree-codex-truncation`
- Real sidebar compact summary expand control was clicked.
- Original UI/DOM verification showed the old narrow fix worked for untrusted remote screenshot markdown.
- Post-clarification UI/DOM verification used a synthetic explicit agent status with a long assistant message plus trusted `data:image/png` markdown:
  - rendered compact rows stayed 24px high
  - class stayed `flex h-6 items-center gap-1`
  - truncation span reported `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`
  - no `<img>` was mounted
  - no `max-h-36` markdown preview branch was present
- Gemini visual review confirmed the screenshot had no visible overlap/clipping.
- Screenshot evidence: `/tmp/orca-validation-marron/compact-agent-thumbnail-expanded-final.png`
- Accepted gap: no real external provider was run to emit the markdown; provider behavior was not touched, and seeded agent rows were enough to validate the changed renderer behavior.

## Checks

- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/components/sidebar/CommentMarkdown.test.tsx`
- Focused post-amend checks passed with 36 tests.

## Post-PR stabilization

- Ran required `sleep 480` after PR creation.
- Initial sweep: GitHub checks passed; CodeRabbit was rate-limited and requested a retry after refill.
- Requested `@coderabbitai review`, then ran a second required `sleep 480`.
- Final sweep:
  - `track-community-pr`: passed
  - `verify`: passed
  - CodeRabbit: “No actionable comments were generated in the recent review.”
- Non-actionable residual: CodeRabbit’s generic pre-merge checklist showed a docstring coverage warning, but it produced no actionable code comments and this TypeScript UI change follows the repo’s existing comment/doc style.
- Latest amend stabilization:
  - `verify`: passed on `3fc011fcdad2550f4bc40df08dec1963d905e764`
  - merge state: clean
  - CodeRabbit: “No actionable comments were generated in the recent review.”
