### PR TITLE
Show Codex reset credit expiry

### DIFF
--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -240,7 +240,27 @@ describe('fetchCodexRateLimits', () => {
     )
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
-      json: async () => ({ rate_limit_reset_credits: { available_count: 2 } })
+      json: async () => ({
+        available_count: 2,
+        total_earned_count: 3,
+        credits: [
+          {
+            status: 'available',
+            expires_at: '2026-06-25T12:00:00Z',
+            granted_at: '2026-06-18T12:00:00Z'
+          },
+          {
+            status: 'available',
+            expires_at: '2026-06-24T12:00:00Z',
+            granted_at: '2026-06-17T12:00:00Z'
+          },
+          {
+            status: 'redeemed',
+            expires_at: '2026-06-23T12:00:00Z',
+            granted_at: '2026-06-16T12:00:00Z'
+          }
+        ]
+      })
     } as Response)
     rpcChild.stdin.write.mockImplementation((line: string) => {
       const msg = JSON.parse(line) as { id?: number; method?: string }
@@ -278,14 +298,37 @@ describe('fetchCodexRateLimits', () => {
     await vi.advanceTimersByTimeAsync(1)
     const result = await resultPromise
 
-    expect(result.rateLimitResetCredits).toEqual({ availableCount: 2 })
+    expect(result.rateLimitResetCredits).toEqual({
+      availableCount: 2,
+      totalEarnedCount: 3,
+      nextExpiresAt: Date.parse('2026-06-24T12:00:00Z'),
+      credits: [
+        {
+          status: 'available',
+          expiresAt: Date.parse('2026-06-25T12:00:00Z'),
+          grantedAt: Date.parse('2026-06-18T12:00:00Z')
+        },
+        {
+          status: 'available',
+          expiresAt: Date.parse('2026-06-24T12:00:00Z'),
+          grantedAt: Date.parse('2026-06-17T12:00:00Z')
+        },
+        {
+          status: 'redeemed',
+          expiresAt: Date.parse('2026-06-23T12:00:00Z'),
+          grantedAt: Date.parse('2026-06-16T12:00:00Z')
+        }
+      ]
+    })
     expect(readFileMock).toHaveBeenCalledWith(join('/managed/codex-home', 'auth.json'), 'utf8')
     expect(fetch).toHaveBeenCalledWith(
-      'https://chatgpt.com/backend-api/wham/usage',
+      'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: 'Bearer access-token',
-          'ChatGPT-Account-Id': 'account-id'
+          'ChatGPT-Account-Id': 'account-id',
+          'OpenAI-Beta': 'codex-1',
+          originator: 'Codex Desktop'
         })
       })
     )
@@ -314,7 +357,16 @@ describe('fetchCodexRateLimits', () => {
                 id: msg.id,
                 result: {
                   rateLimits: { primary: { usedPercent: 5 } },
-                  rateLimitResetCredits: { availableCount: 1 }
+                  rateLimitResetCredits: {
+                    availableCount: 1,
+                    credits: [
+                      {
+                        status: 'available',
+                        expiresAt: '1719326400',
+                        grantedAt: '1718721600000'
+                      }
+                    ]
+                  }
                 }
               })}\n`
             )
@@ -328,7 +380,17 @@ describe('fetchCodexRateLimits', () => {
     await vi.advanceTimersByTimeAsync(1)
     const result = await resultPromise
 
-    expect(result.rateLimitResetCredits).toEqual({ availableCount: 1 })
+    expect(result.rateLimitResetCredits).toEqual({
+      availableCount: 1,
+      nextExpiresAt: 1719326400 * 1000,
+      credits: [
+        {
+          status: 'available',
+          expiresAt: 1719326400 * 1000,
+          grantedAt: 1718721600000
+        }
+      ]
+    })
     expect(readFileMock).not.toHaveBeenCalled()
     expect(fetch).not.toHaveBeenCalled()
   })

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -46,6 +46,13 @@ type RpcRateWindow = {
 
 type RateLimitResetCredits = {
   availableCount: number
+  totalEarnedCount?: number
+  nextExpiresAt?: number | null
+  credits?: {
+    status: string
+    expiresAt: number | null
+    grantedAt: number | null
+  }[]
 }
 
 type RpcRateLimitsResult = {
@@ -59,6 +66,13 @@ type RpcRateLimitsResponse = {
   rateLimits?: RpcRateLimitsResult
   rateLimitResetCredits?: {
     availableCount?: number
+    totalEarnedCount?: number
+    nextExpiresAt?: number | null
+    credits?: {
+      status?: string
+      expiresAt?: number | string | null
+      grantedAt?: number | string | null
+    }[]
   } | null
 }
 
@@ -69,10 +83,14 @@ type CodexAuthFile = {
   }
 }
 
-type BackendUsageResponse = {
-  rate_limit_reset_credits?: {
-    available_count?: number
-  } | null
+type BackendRateLimitResetCreditsResponse = {
+  available_count?: number
+  total_earned_count?: number
+  credits?: {
+    status?: string
+    expires_at?: string | null
+    granted_at?: string | null
+  }[]
 }
 
 type BackendConsumeRateLimitResetCreditResponse = {
@@ -122,6 +140,39 @@ function getCodexHomePath(codexHomePath?: string | null): string {
   return codexHomePath ?? process.env.CODEX_HOME ?? join(homedir(), '.codex')
 }
 
+function parseCreditTimestamp(value: number | string | null | undefined): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    // Why: reset-credit payloads may use Unix seconds or Unix milliseconds.
+    return value < 10_000_000_000 ? value * 1000 : value
+  }
+  if (typeof value !== 'string' || !value.trim()) {
+    return null
+  }
+  const trimmed = value.trim()
+  const numeric = Number(trimmed)
+  if (Number.isFinite(numeric)) {
+    return numeric < 10_000_000_000 ? numeric * 1000 : numeric
+  }
+  const timestamp = Date.parse(trimmed)
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+function normalizeCreditStatus(status: string | undefined): string {
+  return status?.toLowerCase() ?? 'unknown'
+}
+
+function getNextAvailableCreditExpiry(
+  credits: RateLimitResetCredits['credits'] | undefined
+): number | null {
+  const expiries =
+    credits
+      ?.filter((credit) => credit.status === 'available')
+      .map((credit) => credit.expiresAt)
+      .filter((expiresAt): expiresAt is number => typeof expiresAt === 'number')
+      .sort((a, b) => a - b) ?? []
+  return expiries[0] ?? null
+}
+
 function mapRpcRateLimitResetCredits(
   raw: RpcRateLimitsResponse['rateLimitResetCredits']
 ): RateLimitResetCredits | null | undefined {
@@ -131,19 +182,47 @@ function mapRpcRateLimitResetCredits(
   if (typeof raw.availableCount !== 'number' || !Number.isFinite(raw.availableCount)) {
     return null
   }
-  return { availableCount: Math.max(0, Math.floor(raw.availableCount)) }
+  const credits = raw.credits?.map((credit) => ({
+    status: normalizeCreditStatus(credit.status),
+    expiresAt: parseCreditTimestamp(credit.expiresAt),
+    grantedAt: parseCreditTimestamp(credit.grantedAt)
+  }))
+  return {
+    availableCount: Math.max(0, Math.floor(raw.availableCount)),
+    ...(typeof raw.totalEarnedCount === 'number' && Number.isFinite(raw.totalEarnedCount)
+      ? { totalEarnedCount: Math.max(0, Math.floor(raw.totalEarnedCount)) }
+      : {}),
+    nextExpiresAt: parseCreditTimestamp(raw.nextExpiresAt) ?? getNextAvailableCreditExpiry(credits),
+    ...(credits ? { credits } : {})
+  }
 }
 
 function mapBackendRateLimitResetCredits(
-  raw: BackendUsageResponse['rate_limit_reset_credits']
+  raw: BackendRateLimitResetCreditsResponse | null | undefined
 ): RateLimitResetCredits | null | undefined {
   if (!raw) {
     return raw
   }
-  if (typeof raw.available_count !== 'number' || !Number.isFinite(raw.available_count)) {
+  const credits = raw.credits?.map((credit) => ({
+    status: normalizeCreditStatus(credit.status),
+    expiresAt: parseCreditTimestamp(credit.expires_at),
+    grantedAt: parseCreditTimestamp(credit.granted_at)
+  }))
+  const availableCount =
+    typeof raw.available_count === 'number' && Number.isFinite(raw.available_count)
+      ? raw.available_count
+      : (credits?.filter((credit) => credit.status === 'available').length ?? null)
+  if (availableCount === null) {
     return null
   }
-  return { availableCount: Math.max(0, Math.floor(raw.available_count)) }
+  return {
+    availableCount: Math.max(0, Math.floor(availableCount)),
+    ...(typeof raw.total_earned_count === 'number' && Number.isFinite(raw.total_earned_count)
+      ? { totalEarnedCount: Math.max(0, Math.floor(raw.total_earned_count)) }
+      : {}),
+    nextExpiresAt: getNextAvailableCreditExpiry(credits),
+    ...(credits ? { credits } : {})
+  }
 }
 
 async function getCodexBackendAuthHeaders(
@@ -158,7 +237,9 @@ async function getCodexBackendAuthHeaders(
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${accessToken}`,
-    'User-Agent': 'codex-cli'
+    'User-Agent': 'codex-cli',
+    'OpenAI-Beta': 'codex-1',
+    originator: 'Codex Desktop'
   }
   if (auth.tokens?.account_id) {
     headers['ChatGPT-Account-Id'] = auth.tokens.account_id
@@ -175,19 +256,26 @@ async function fetchBackendRateLimitResetCredits(
   }
   // Why: published Codex 0.140 can read windows through app-server but strips
   // reset-credit metadata that the backend already returns.
-  const response = await fetch('https://chatgpt.com/backend-api/wham/usage', auth)
+  const response = await fetch(
+    'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
+    auth
+  )
   if (!response.ok) {
     return null
   }
-  const payload = (await response.json()) as BackendUsageResponse
-  return mapBackendRateLimitResetCredits(payload.rate_limit_reset_credits) ?? null
+  const payload = (await response.json()) as BackendRateLimitResetCreditsResponse
+  return mapBackendRateLimitResetCredits(payload) ?? null
 }
 
 async function withBackendRateLimitResetCredits(
   limits: ProviderRateLimits,
   options?: FetchCodexRateLimitsOptions
 ): Promise<ProviderRateLimits> {
-  if (limits.provider !== 'codex' || limits.rateLimitResetCredits !== undefined) {
+  if (
+    limits.provider !== 'codex' ||
+    (limits.rateLimitResetCredits?.nextExpiresAt !== undefined &&
+      limits.rateLimitResetCredits.nextExpiresAt !== null)
+  ) {
     return limits
   }
   try {

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -46,7 +46,13 @@ import type {
   RateLimitRuntimeTarget,
   RateLimitWindow
 } from '../../../../shared/rate-limit-types'
-import { ProviderIcon, ProviderPanel, barColor, getProviderUsageStatusLabel } from './tooltip'
+import {
+  ProviderIcon,
+  ProviderPanel,
+  barColor,
+  formatResetCreditExpiry,
+  getProviderUsageStatusLabel
+} from './tooltip'
 import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { formatWindowLabel } from '@/lib/window-label-formatter'
@@ -1365,6 +1371,10 @@ function CodexSwitcherMenu({
     switchGroups.find((group) => group.key === selectedRuntimeKey) ?? switchGroups[0]
   const activeTarget = selectedGroup?.targets.find((target) => target.active)
   const resetCreditCount = codex.rateLimitResetCredits?.availableCount ?? null
+  const resetCreditExpiry =
+    resetCreditCount !== null
+      ? formatResetCreditExpiry(codex.rateLimitResetCredits?.nextExpiresAt, resetCreditCount)
+      : null
   const canRedeemReset = resetCreditCount !== null && resetCreditCount > 0
 
   return (
@@ -1372,6 +1382,9 @@ function CodexSwitcherMenu({
       provider={codex}
       compact={compact}
       iconOnly={iconOnly}
+      // Why: Codex reset credits render beside the reset action below; showing
+      // them in the generic provider summary duplicates the same metadata.
+      hidePanelResetCredits
       ariaLabel={translate(
         'auto.components.status.bar.StatusBar.ba55303942',
         'Open Codex details and account switcher'
@@ -1431,17 +1444,24 @@ function CodexSwitcherMenu({
       </Dialog>
       {resetCreditCount !== null ? (
         <>
-          <DropdownMenuLabel>
-            {resetCreditCount === 1
-              ? translate(
-                  'auto.components.status.bar.StatusBar.5e5f9f5160',
-                  '1 rate-limit reset available'
-                )
-              : translate(
-                  'auto.components.status.bar.StatusBar.5ecae9197c',
-                  '{{value0}} rate-limit resets available',
-                  { value0: resetCreditCount }
-                )}
+          <DropdownMenuLabel className="space-y-0.5">
+            <div>
+              {resetCreditCount === 1
+                ? translate(
+                    'auto.components.status.bar.StatusBar.5e5f9f5160',
+                    '1 rate-limit reset available'
+                  )
+                : translate(
+                    'auto.components.status.bar.StatusBar.5ecae9197c',
+                    '{{value0}} rate-limit resets available',
+                    { value0: resetCreditCount }
+                  )}
+            </div>
+            {resetCreditExpiry ? (
+              <div className="text-[11px] font-normal text-muted-foreground">
+                {resetCreditExpiry}
+              </div>
+            ) : null}
           </DropdownMenuLabel>
           {canRedeemReset ? (
             <DropdownMenuItem
@@ -1586,6 +1606,7 @@ export function ProviderDetailsMenu({
   iconOnly,
   ariaLabel,
   topContent,
+  hidePanelResetCredits = false,
   open,
   onOpenChange,
   children
@@ -1595,6 +1616,7 @@ export function ProviderDetailsMenu({
   iconOnly: boolean
   ariaLabel: string
   topContent?: React.ReactNode
+  hidePanelResetCredits?: boolean
   open?: boolean
   onOpenChange?: (open: boolean) => void
   children?: React.ReactNode
@@ -1660,7 +1682,8 @@ export function ProviderDetailsMenu({
       >
         {topContent}
         <div className="p-2">
-          <ProviderPanel p={provider} />
+          {/* Why: provider-specific action sections may render richer reset-credit UI. */}
+          <ProviderPanel p={provider} showResetCredits={!hidePanelResetCredits} />
         </div>
         {children ? (
           <>

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 import {
+  formatResetCreditExpiry,
   formatResetCountdown,
   getProviderUsageErrorMessage,
   getProviderUsageStatusLabel,
@@ -19,6 +20,10 @@ function provider(overrides: Partial<ProviderRateLimits> = {}): ProviderRateLimi
   }
 }
 
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 describe('formatResetCountdown', () => {
   it('uses natural copy when the reset time has arrived', () => {
     expect(formatResetCountdown(0)).toBe('Resets now')
@@ -27,6 +32,22 @@ describe('formatResetCountdown', () => {
 
   it('keeps the "in" preposition for future reset times', () => {
     expect(formatResetCountdown(12 * 60 * 60_000 + 41 * 60_000)).toBe('Resets in 12h 41m')
+  })
+})
+
+describe('formatResetCreditExpiry', () => {
+  it('shows singular and plural expiry countdowns', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-20T12:00:00Z'))
+
+    expect(formatResetCreditExpiry(Date.parse('2026-06-20T14:30:00Z'), 1)).toBe('Expires in 2h 30m')
+    expect(formatResetCreditExpiry(Date.parse('2026-06-25T12:00:00Z'), 2)).toBe(
+      'Next expires in 5d'
+    )
+  })
+
+  it('omits expiry copy when the backend has not reported an expiry', () => {
+    expect(formatResetCreditExpiry(null, 1)).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -43,6 +43,28 @@ export function formatResetCountdown(ms: number): string {
   return duration === 'now' ? 'Resets now' : `Resets in ${duration}`
 }
 
+export function formatResetCreditExpiry(
+  expiresAt: number | null | undefined,
+  count: number
+): string | null {
+  if (!expiresAt) {
+    return null
+  }
+  const duration = formatDuration(expiresAt - Date.now())
+  if (duration === 'now') {
+    return count > 1
+      ? translate('auto.components.status.bar.tooltip.7ec6e030a0', 'Next expires now')
+      : translate('auto.components.status.bar.tooltip.d1e442a9e5', 'Expires now')
+  }
+  return count > 1
+    ? translate('auto.components.status.bar.tooltip.6cf9eaed10', 'Next expires in {{value0}}', {
+        value0: duration
+      })
+    : translate('auto.components.status.bar.tooltip.20ad66aed1', 'Expires in {{value0}}', {
+        value0: duration
+      })
+}
+
 // ---------------------------------------------------------------------------
 // Shared icon component
 // ---------------------------------------------------------------------------
@@ -229,11 +251,13 @@ export function barColor(leftPct: number): string {
 export function ProviderPanel({
   p,
   inverted = false,
-  className
+  className,
+  showResetCredits = true
 }: {
   p: ProviderRateLimits | null
   inverted?: boolean
   className?: string
+  showResetCredits?: boolean
 }): React.JSX.Element {
   const textClass = inverted ? 'text-background' : 'text-foreground'
   const mutedClass = inverted ? 'text-background/60' : 'text-muted-foreground'
@@ -284,7 +308,14 @@ export function ProviderPanel({
   }
 
   const updatedAgo = p.updatedAt ? `Updated ${formatTimeAgo(p.updatedAt)}` : 'Not yet updated'
-  const resetCreditCount = p.provider === 'codex' ? p.rateLimitResetCredits?.availableCount : null
+  const resetCreditCount =
+    showResetCredits && p.provider === 'codex'
+      ? (p.rateLimitResetCredits?.availableCount ?? null)
+      : null
+  const resetCreditExpiry =
+    resetCreditCount != null
+      ? formatResetCreditExpiry(p.rateLimitResetCredits?.nextExpiresAt, resetCreditCount)
+      : null
 
   const PanelWindowSection = ({
     w,
@@ -341,6 +372,7 @@ export function ProviderPanel({
                 )}
           </div>
         ) : null}
+        {resetCreditExpiry ? <div className={faintClass}>{resetCreditExpiry}</div> : null}
       </div>
 
       <div className={`border-t ${dividerClass}`} />

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -28,6 +28,15 @@ export type ProviderRateLimits = {
   /** Available earned Codex rate-limit reset credits, if reported. */
   rateLimitResetCredits?: {
     availableCount: number
+    /** Total earned reset credits, including spent or expired credits, if reported. */
+    totalEarnedCount?: number
+    /** Unix ms timestamp for the next available reset credit expiry, if reported. */
+    nextExpiresAt?: number | null
+    credits?: {
+      status: string
+      expiresAt: number | null
+      grantedAt: number | null
+    }[]
   } | null
   /** Unix ms timestamp of the last successful data update. */
   updatedAt: number


### PR DESCRIPTION
## Summary
- fetch detailed Codex reset-credit metadata, including expiry timestamps
- display the next available reset-credit expiry next to the reset action
- avoid duplicating reset-credit copy in the Codex provider summary

## Test Plan
- pnpm vitest run --config config/vitest.config.ts src/main/rate-limits/codex-fetcher.test.ts
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/tooltip.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5865">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->