### PR TITLE
Improve unread workspace contrast in the sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -205,6 +205,47 @@ describe('WorktreeCardAgents', () => {
     expect(markup).not.toContain('data-testid="agent-row"')
   })
 
+  it('dims non-focused compact agent row text', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    mockAgents = [
+      mockAgent({
+        agentType: 'codex',
+        startedAt: 1000,
+        prompt: 'Run tests',
+        lastAssistantMessage: 'Inspecting changes'
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('<span class="text-muted-foreground/90">Run tests</span>')
+    expect(markup).toContain('<span class="text-muted-foreground/65"> - Inspecting changes</span>')
+    expect(markup).not.toContain('data-focused-agent-pane="true"')
+    expect(markup).not.toContain('<span class="text-foreground">Run tests</span>')
+  })
+
+  it('keeps focused compact agent row text legible', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    mockFocusedAgentPaneKey = 'tab-1:1'
+    mockAgents = [
+      mockAgent({
+        agentType: 'codex',
+        startedAt: 1000,
+        prompt: 'Focused prompt',
+        lastAssistantMessage: 'Reading output'
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('data-focused-agent-pane="true"')
+    expect(markup).toContain('<span class="text-foreground">Focused prompt</span>')
+    expect(markup).toContain('<span class="text-foreground/70"> - Reading output</span>')
+    expect(markup).not.toContain('<span class="text-muted-foreground/90">Focused prompt</span>')
+  })
+
   it('marks only the focused agent row', async () => {
     mockAgentActivityDisplayMode = 'full'
     mockFocusedAgentPaneKey = 'tab-1:2'

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -199,9 +199,11 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
       <span className="min-w-0 flex-1 truncate">
         {/* Why: the selected-row fill is strong enough to wash out the dimmed
             prompt/secondary text, so lift both toward full foreground when focused. */}
-        <span className={isFocusedPane ? 'text-foreground' : 'text-foreground/85'}>{primary}</span>
+        <span className={isFocusedPane ? 'text-foreground' : 'text-muted-foreground/90'}>
+          {primary}
+        </span>
         {secondary && (
-          <span className={isFocusedPane ? 'text-foreground/70' : 'text-muted-foreground/75'}>
+          <span className={isFocusedPane ? 'text-foreground/70' : 'text-muted-foreground/65'}>
             {' '}
             - {secondary}
           </span>


### PR DESCRIPTION
## Summary

This makes compact inline agent rows visually quieter in the left sidebar so unread worktree titles remain the strongest scan target now that the bell indicator is gone.

- Non-focused compact agent prompts now use muted foreground instead of near-foreground text.
- Non-focused compact secondary/status text is dimmed slightly further.
- Focused agent rows keep their higher-contrast selected-row text treatment.
- Summary rows, full agent rows, title/unread semantics, dots/icons, dimensions, hover/focus backgrounds, activation, and send-target behavior are unchanged.

## Design Review

Scratch design doc: `design-docs/worktree-card-agent-status-contrast.md` (ignored planning artifact, not included in the PR diff).

`auto-design-review-fix` ran on the doc. The final verification reviewers returned clean. The doc was tightened to call out the `dimReadTitle={newCardStyle}` path, focus/send-target edge cases, and light/dark screenshot validation.

## Implementation

Implemented as designed with no deviations:

- `src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx`
- `src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx`

Added render coverage for both the non-focused dimmed classes and the focused-row contrast exception.

## Completeness Verification

Read-only completeness pass returned clean. It confirmed:

- Only non-focused compact inline agent text was dimmed.
- Focused compact rows preserve contrast.
- Summary/full rows, title styling, unread/status semantics, dots/icons, dimensions, hover/focus backgrounds, activation, and send-target wiring were not changed.
- Tests cover both non-focused and focused compact row classes.

## Code Review Loop

Two review rounds were run with independent reviewers:

- Round 1: both reviewers returned `No issues found`.
- Round 2: both reviewers returned `No issues found`.

No agent-facing prompt text was created or edited.

## Validation

`brennan-test-changes` verdict: land.

Electron identity verified:

- `devRepoRoot: /Users/thebr/orca/workspaces/orca/osprey`
- `devBranch: brennanb2025/worktree-card-visuals`

Visual validation used `demo-project` with an isolated Electron profile and renderer state setup because the existing demo project had unrelated local dirt.

Screenshot evidence:

- Light mode compact inline row: `/tmp/orca-osprey-sidebar-evidence/sidebar-compact-agent-light-newcard.png`
- Dark mode compact inline row: `/tmp/orca-osprey-sidebar-evidence/sidebar-compact-agent-dark-newcard.png`
- Send-target open/disabled state: `/tmp/orca-osprey-sidebar-evidence/sidebar-send-target-open-dark.png`
- Send-target sending state: `/tmp/orca-osprey-sidebar-evidence/sidebar-send-target-sending-dark.png`

Rendered DOM confirmed:

- Unread title `main`: `text-foreground`, font weight `600`
- Compact prompt `Run tests`: `text-muted-foreground/90`
- Compact status `Inspecting changes`: `text-muted-foreground/65`
- Disabled send target: `opacity: 0.6`, `cursor: default`, title `Agent is working`
- Sending target: `opacity: 0.75`, `cursor: progress`, title `Sending...`

No relevant console errors were observed.

## Checks

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.send-target.test.tsx` - 24 tests passed

Pre-commit also ran staged `oxlint`, React doctor lint, and `oxfmt` successfully.

## Post-PR Stabilization

After the required 8-minute wait:

- [x] CodeRabbit reported no actionable comments.
- [x] `verify` passed.
- [x] `track-community-pr` passed.
- [x] PR merge state is clean.

## Notes

Legacy compact worktree cards suppress inline agent rows by design, so the visible compact-card + inline-agent evidence used `experimentalNewWorktreeCardStyle: true`, where that combination is supported.