### PR TITLE
Refactor project header drag-and-drop to support project groups

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -130,6 +130,7 @@ import {
   type ScrollToCurrentWorkspaceRevealRequestDetail
 } from '@/lib/scroll-to-current-workspace-status'
 import { isRepoHeaderActionTarget, useRepoHeaderDrag } from './project-header-drag'
+import { getSidebarOrderedRepoHeaderIdsByBucket } from './project-header-drop'
 import {
   buildManualOrderUpdatesForGroupDrop,
   buildManualOrderUpdatesForVisibleGroups,
@@ -1189,8 +1190,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   )
   const suppressWorktreeClickUntilRef = useRef(0)
   const hasProjectGroups = projectGroups.length > 0
-  const canReorderRepoHeaders =
-    groupBy === 'repo' && projectOrderBy === 'manual' && !hasProjectGroups
+  const canReorderRepoHeaders = groupBy === 'repo' && projectOrderBy === 'manual'
+  const moveProjectToGroup = useAppStore((s) => s.moveProjectToGroup)
   const lastVisibleRefreshKeyRef = useRef('')
   const reportVisibleGitHubPRRefreshCandidates = useAppStore(
     (s) => s.reportVisibleGitHubPRRefreshCandidates
@@ -1234,13 +1235,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     },
     [reorderRepos]
   )
-  // Drag is only meaningful when repo headers are using manual order. The
-  // controller is still constructed for hook order stability when inert.
-  const repoDrag = useRepoHeaderDrag({
-    orderedRepoIds: allRepoIds,
-    onCommit: commitRepoReorder,
-    getScrollContainer: () => scrollRef.current
-  })
   const orderedHostIds = useMemo(
     () =>
       rows
@@ -1367,6 +1361,48 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     [computeWorktreeDropForGroup]
   )
   const renderRows = useMemo(() => buildRenderableRows(rows), [rows])
+  const sidebarRepoHeaderIdsByBucket = useMemo(
+    () =>
+      getSidebarOrderedRepoHeaderIdsByBucket(
+        rows.filter((row): row is Row => row.type !== 'host-header')
+      ),
+    [rows]
+  )
+  const repoHeaderIndexByRepoId = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const repoIds of sidebarRepoHeaderIdsByBucket.values()) {
+      repoIds.forEach((repoId, index) => {
+        map.set(repoId, index)
+      })
+    }
+    return map
+  }, [sidebarRepoHeaderIdsByBucket])
+  const repoHeaderBucketByRepoId = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const [bucketKey, repoIds] of sidebarRepoHeaderIdsByBucket) {
+      for (const repoId of repoIds) {
+        map.set(repoId, bucketKey)
+      }
+    }
+    return map
+  }, [sidebarRepoHeaderIdsByBucket])
+  const commitProjectGroupOrder = useCallback(
+    (repoId: string, projectGroupId: string | null, order: number) => {
+      void moveProjectToGroup(repoId, projectGroupId, order)
+    },
+    [moveProjectToGroup]
+  )
+  // Drag is only meaningful when repo headers are using manual order. The
+  // controller is still constructed for hook order stability when inert.
+  const repoDrag = useRepoHeaderDrag({
+    orderedRepoIds: allRepoIds,
+    sidebarRepoHeaderIdsByBucket,
+    repoById: repoMap,
+    usesProjectGroupOrdering: hasProjectGroups,
+    onCommitRepoOrder: commitRepoReorder,
+    onCommitProjectGroupOrder: commitProjectGroupOrder,
+    getScrollContainer: () => scrollRef.current
+  })
   const [primaryActiveWorktreeRow, setPrimaryActiveWorktreeRow] = useState<{
     worktreeId: string
     rowKey: string
@@ -3577,6 +3613,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               const isRepoHeader = groupBy === 'repo' && row.repo !== undefined
               const isProjectGroupHeader = groupBy === 'repo' && row.projectGroup !== undefined
               const projectIdForHeader = isRepoHeader ? row.repo!.id : undefined
+              const repoHeaderIndex =
+                projectIdForHeader !== undefined
+                  ? repoHeaderIndexByRepoId.get(projectIdForHeader)
+                  : undefined
+              const repoHeaderBucketKey =
+                projectIdForHeader !== undefined
+                  ? repoHeaderBucketByRepoId.get(projectIdForHeader)
+                  : undefined
+              const isDraggableRepoHeader = Boolean(
+                canReorderRepoHeaders &&
+                isRepoHeader &&
+                projectIdForHeader &&
+                repoHeaderBucketKey &&
+                (sidebarRepoHeaderIdsByBucket.get(repoHeaderBucketKey)?.length ?? 0) > 1
+              )
               const isDraggingThis =
                 canReorderRepoHeaders &&
                 repoDrag.state.draggingRepoId !== null &&
@@ -3627,6 +3678,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   role="presentation"
                   data-worktree-virtual-row
                   data-worktree-virtual-row-key={String(vItem.key)}
+                  data-worktree-virtual-row-start={vItem.start}
                   data-worktree-sticky-header=""
                   data-worktree-sticky-header-active={isActiveStickyHeader ? '' : undefined}
                   data-index={vItem.index}
@@ -3653,6 +3705,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     role="button"
                     tabIndex={0}
                     data-repo-header-id={projectIdForHeader}
+                    data-repo-header-index={repoHeaderIndex}
+                    data-repo-header-bucket={repoHeaderBucketKey}
                     data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
                     data-workspace-status={headerWorkspaceStatus ?? undefined}
                     data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
@@ -3670,16 +3724,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       row.repo && 'overflow-hidden'
                     )}
                     style={{ paddingLeft: headerPaddingLeft }}
-                    // Why: arm project-header drag from anywhere on the row, not
-                    // just the icon — users grab the name to reorder. The hook
-                    // ignores presses on nested buttons (+/chevron) and only
-                    // promotes to a drag past a 4px threshold, so a plain click
-                    // still toggles collapse via onClick.
-                    onPointerDown={
-                      canReorderRepoHeaders && isRepoHeader && projectIdForHeader
-                        ? (e) => repoDrag.onHandlePointerDown(e, projectIdForHeader)
-                        : undefined
-                    }
                     onDragOver={
                       isPinnedHeader
                         ? handleWorkspacePinDragOver
@@ -3717,10 +3761,17 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   >
                     {row.icon ? (
                       <div
+                        data-repo-header-drag-handle={isDraggableRepoHeader ? '' : undefined}
                         className={cn(
                           'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
-                          repoHeaderColor ? 'text-muted-foreground' : row.tone
+                          repoHeaderColor ? 'text-muted-foreground' : row.tone,
+                          isDraggableRepoHeader && 'hover:cursor-grab active:cursor-grabbing'
                         )}
+                        onPointerDown={
+                          isDraggableRepoHeader && projectIdForHeader
+                            ? (event) => repoDrag.onHandlePointerDown(event, projectIdForHeader)
+                            : undefined
+                        }
                       >
                         {row.repo ? (
                           <RepoIconGlyph

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.ts
@@ -37,7 +37,13 @@ export function commitProjectHeaderDragDrop(args: {
       sourceIndex,
       siblingCount: siblings.length
     })
-    if (siblingDropIndex === sourceIndex) {
+    // Why: sourceIndex is the position in the original array (including the
+    // dragged item), but siblingDropIndex is the position in the filtered
+    // array. The equivalent position in the filtered array is the sourceIndex
+    // capped at siblings.length (since removing an item can only shift indices
+    // down by 1 when the removed item was before the insertion point).
+    const sourceIndexInSiblings = Math.min(sourceIndex, siblings.length)
+    if (siblingDropIndex === sourceIndexInSiblings) {
       return
     }
     const repoOrderRankById = new Map(

--- a/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
@@ -46,7 +46,7 @@ describe('createProjectHeaderDragSession', () => {
     expect(handleEl.setPointerCapture).not.toHaveBeenCalled()
   })
 
-  it('does not arm drag when the pointer starts outside the project name handle', () => {
+  it('does not arm drag when the pointer starts outside the project icon handle', () => {
     const header = document.createElement('div')
     const handleEl = document.createElement('div')
     handleEl.setAttribute('data-repo-header-drag-handle', '')

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -1,105 +1,69 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import {
+  computeProjectHeaderDropPreview,
+  measureProjectHeaderDragRects
+} from './project-header-drop'
+import { commitProjectHeaderDragDrop } from './project-header-drag-commit'
+import {
+  INITIAL_REPO_DRAG_STATE,
+  PROJECT_HEADER_DRAG_THRESHOLD_PX,
+  type ProjectHeaderDragSession,
+  type RepoDragState,
+  type RepoHeaderDragController,
+  type UseRepoHeaderDragArgs
+} from './project-header-drag-contract'
+import { createProjectHeaderDragSession } from './project-header-drag-start'
+import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+
 // Why pointer events instead of HTML5 DnD: rows are absolutely-positioned by
 // react-virtual and unmount/remount as scroll changes, so DnD enter/leave fire
 // against stale targets. With pointer events we cache the active set of repo
 // header positions and compute the drop index from the live pointer Y.
 
-export type RepoDragState = {
-  draggingRepoId: string | null
-  // Insertion index in the orderedRepoIds array where the dragged repo would
-  // land if released now. null while not dragging.
-  dropIndex: number | null
-  // Y coordinate (in scrollContainer's local space, i.e. relative to its
-  // top-left content origin including current scrollTop offset) where the
-  // insertion bar should be drawn. null while not dragging.
-  dropIndicatorY: number | null
-}
-
-const INITIAL_STATE: RepoDragState = {
-  draggingRepoId: null,
-  dropIndex: null,
-  dropIndicatorY: null
-}
-
-export type UseRepoHeaderDragArgs = {
-  orderedRepoIds: string[]
-  onCommit: (orderedIds: string[]) => void
-  // Returns the scroll container that hosts the virtualized rows. Bounding
-  // rects are read from this element so insertion-bar Y values stay correct
-  // when the sidebar is resized.
-  getScrollContainer: () => HTMLElement | null
-}
-
-type HeaderRect = {
-  repoId: string
-  // top/bottom in scrollContainer-local space (page-coord top minus container
-  // page-coord top, plus current scrollTop).
-  top: number
-  bottom: number
-}
-
-export type RepoHeaderDragController = {
-  state: RepoDragState
-  // Call from the repo header's onPointerDown. The drag does NOT start
-  // immediately — it arms a pending session that promotes to an active drag
-  // only once the pointer moves past DRAG_THRESHOLD_PX. A pointerup before
-  // promotion releases without committing, so the surrounding click handler
-  // still fires and toggles the group's collapsed state.
-  onHandlePointerDown: (event: React.PointerEvent<HTMLElement>, repoId: string) => void
-}
-
-// Pixels the pointer must travel before we promote a pending press into a
-// real drag. Below this we treat the press as a normal click (toggle group).
-const DRAG_THRESHOLD_PX = 4
-const REPO_HEADER_ACTION_SELECTOR =
-  '[data-repo-header-action], button, a, input, textarea, select, [contenteditable=""], [contenteditable="true"]'
-
-export function isRepoHeaderActionTarget(
-  target: EventTarget | null,
-  currentTarget: HTMLElement
-): boolean {
-  if (!(target instanceof HTMLElement) || target === currentTarget) {
-    return false
-  }
-  return currentTarget.contains(target) && target.closest(REPO_HEADER_ACTION_SELECTOR) !== null
-}
-
 export function useRepoHeaderDrag({
   orderedRepoIds,
-  onCommit,
+  sidebarRepoHeaderIdsByBucket,
+  repoById,
+  usesProjectGroupOrdering,
+  onCommitRepoOrder,
+  onCommitProjectGroupOrder,
   getScrollContainer
 }: UseRepoHeaderDragArgs): RepoHeaderDragController {
-  const [state, setState] = useState<RepoDragState>(INITIAL_STATE)
-  // Tracks whether a press has begun (armed) regardless of promotion. Used
-  // only to gate window listeners; visible drag state lives in `state`.
+  const [state, setState] = useState<RepoDragState>(INITIAL_REPO_DRAG_STATE)
   const [sessionArmed, setSessionArmed] = useState(false)
-  // Why: endDrag reads dropIndex on pointerup, but binding the listener with
-  // dropIndex in deps would re-add window listeners on every pointermove.
-  // The ref tracks the latest computed value without invalidating the effect.
   const latestDropIndexRef = useRef<number | null>(null)
   latestDropIndexRef.current = state.dropIndex
-  // Keep callbacks stable: they read from refs so we don't re-bind window
-  // listeners every render.
   const orderedIdsRef = useRef(orderedRepoIds)
   orderedIdsRef.current = orderedRepoIds
-  const onCommitRef = useRef(onCommit)
-  onCommitRef.current = onCommit
+  const sidebarRepoHeaderIdsByBucketRef = useRef(sidebarRepoHeaderIdsByBucket)
+  sidebarRepoHeaderIdsByBucketRef.current = sidebarRepoHeaderIdsByBucket
+  const repoByIdRef = useRef(repoById)
+  repoByIdRef.current = repoById
+  const usesProjectGroupOrderingRef = useRef(usesProjectGroupOrdering)
+  usesProjectGroupOrderingRef.current = usesProjectGroupOrdering
+  const onCommitRepoOrderRef = useRef(onCommitRepoOrder)
+  onCommitRepoOrderRef.current = onCommitRepoOrder
+  const onCommitProjectGroupOrderRef = useRef(onCommitProjectGroupOrder)
+  onCommitProjectGroupOrderRef.current = onCommitProjectGroupOrder
   const getContainerRef = useRef(getScrollContainer)
   getContainerRef.current = getScrollContainer
+  const autoscrollLastFrameTimeRef = useRef<number | null>(null)
+  const autoscrollFrameIdRef = useRef<number | null>(null)
 
-  const dragSessionRef = useRef<{
-    repoId: string
-    pointerId: number
-    headerRects: HeaderRect[]
-    handleEl: HTMLElement
-    startX: number
-    startY: number
-    // false until the pointer moves past DRAG_THRESHOLD_PX. While false the
-    // session exists but no drop indicator is shown and pointerup is treated
-    // as a click rather than a drop.
-    promoted: boolean
-  } | null>(null)
+  const dragSessionRef = useRef<ProjectHeaderDragSession | null>(null)
+  const clickSwallowTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const refreshHeaderRects = useCallback(() => {
+    const container = getContainerRef.current()
+    const session = dragSessionRef.current
+    if (!container || !session) {
+      return []
+    }
+    const rects = measureProjectHeaderDragRects(container, session.bucketKey)
+    session.headerRects = rects
+    return rects
+  }, [])
 
   const computeDrop = useCallback(
     (pointerY: number): { dropIndex: number; dropIndicatorY: number } | null => {
@@ -109,107 +73,126 @@ export function useRepoHeaderDrag({
         return null
       }
       const containerRect = container.getBoundingClientRect()
-      // Translate pointer to container-local coords + scroll.
-      const localY = pointerY - containerRect.top + container.scrollTop
-      const rects = session.headerRects
-      if (rects.length === 0) {
-        return null
-      }
-      // Find the first header whose midpoint is below the pointer.
-      let insertBefore = rects.length
-      for (let i = 0; i < rects.length; i++) {
-        const mid = (rects[i].top + rects[i].bottom) / 2
-        if (localY < mid) {
-          insertBefore = i
-          break
-        }
-      }
-      // Why anchor to the target header (not midpoint between headers): the
-      // space between two project group headers is filled with worktree cards,
-      // so the midpoint falls *inside another repo's content*. Sitting the
-      // indicator just above the target header keeps it at the visual top of
-      // where the dragged group would land.
-      const INDICATOR_GAP_PX = 4
-      const rawIndicatorY =
-        insertBefore >= rects.length
-          ? rects.at(-1)!.bottom + INDICATOR_GAP_PX
-          : Math.max(0, rects[insertBefore].top - INDICATOR_GAP_PX)
-      // Why: while scrolled, the topmost mounted header is pinned flush at the
-      // container top, so `top - GAP` lands above the overflow clip region and
-      // the line is painted invisibly. Floor the indicator at the current
-      // scroll offset so a top-of-list drop stays visible just below the edge.
-      const indicatorY = Math.max(container.scrollTop, rawIndicatorY)
-      return { dropIndex: insertBefore, dropIndicatorY: indicatorY }
+      return computeProjectHeaderDropPreview({
+        pointerY,
+        containerTop: containerRect.top,
+        scrollTop: container.scrollTop,
+        rects: session.headerRects,
+        sidebarRepoHeaderIds: session.sidebarRepoHeaderIds
+      })
     },
     []
   )
 
-  const endDrag = useCallback((commit: boolean) => {
-    const session = dragSessionRef.current
-    if (!session) {
-      setState(INITIAL_STATE)
-      setSessionArmed(false)
-      return
+  const cancelAutoscroll = useCallback(() => {
+    if (autoscrollFrameIdRef.current !== null) {
+      window.cancelAnimationFrame(autoscrollFrameIdRef.current)
+      autoscrollFrameIdRef.current = null
     }
-    try {
-      session.handleEl.releasePointerCapture(session.pointerId)
-    } catch {
-      // capture may already be released (pointercancel, element unmounted)
-    }
-    if (session.promoted) {
-      // After a real drag, the browser still fires a click on the header.
-      // Swallow exactly one click in capture phase so it doesn't toggle the
-      // group's collapsed state. Scope to the dragged handle (and ancestors)
-      // so an unrelated click that races between pointerup and the failsafe
-      // teardown isn't silently eaten.
-      const handleEl = session.handleEl
-      const swallow = (e: MouseEvent): void => {
-        const target = e.target as Node | null
-        if (target && handleEl.contains(target)) {
-          e.stopPropagation()
-          e.preventDefault()
-        }
-        window.removeEventListener('click', swallow, true)
-      }
-      window.addEventListener('click', swallow, true)
-      // Failsafe: if no click ever arrives (e.g. pointercancel), drop the
-      // listener after a tick so future clicks aren't silenced.
-      setTimeout(() => window.removeEventListener('click', swallow, true), 0)
-    }
-    // Only commit a reorder if the press was promoted into a real drag —
-    // otherwise the press was effectively a click, and the surrounding
-    // header onClick handler will toggle collapse.
-    const finalIndex =
-      commit && session.promoted && latestDropIndexRef.current !== null
-        ? latestDropIndexRef.current
-        : null
-    dragSessionRef.current = null
-    setState(INITIAL_STATE)
-    setSessionArmed(false)
-    if (finalIndex === null) {
-      return
-    }
-    const ids = orderedIdsRef.current
-    const fromIndex = ids.indexOf(session.repoId)
-    if (fromIndex === -1) {
-      return
-    }
-    // Splice fromIndex out, then insert at finalIndex (adjusting if the
-    // removal shifted indices).
-    const next = ids.slice()
-    next.splice(fromIndex, 1)
-    const insertAt = finalIndex > fromIndex ? finalIndex - 1 : finalIndex
-    if (insertAt === fromIndex) {
-      return
-    }
-    next.splice(insertAt, 0, session.repoId)
-    onCommitRef.current(next)
+    autoscrollLastFrameTimeRef.current = null
   }, [])
 
-  // Window-level listeners while a session is armed — pointer capture on the
-  // header element ensures the events still fire even if the pointer leaves
-  // it. The session may be unpromoted (waiting for a movement past the
-  // threshold to become a real drag) or promoted (drop indicator visible).
+  const endDrag = useCallback(
+    (commit: boolean) => {
+      cancelAutoscroll()
+      const session = dragSessionRef.current
+      if (!session) {
+        setState(INITIAL_REPO_DRAG_STATE)
+        setSessionArmed(false)
+        return
+      }
+      try {
+        session.handleEl.releasePointerCapture(session.pointerId)
+      } catch {
+        // capture may already be released (pointercancel, element unmounted)
+      }
+      if (session.promoted) {
+        const handleEl = session.handleEl
+        const swallow = (e: MouseEvent): void => {
+          const target = e.target as Node | null
+          if (target && handleEl.contains(target)) {
+            e.stopPropagation()
+            e.preventDefault()
+          }
+          window.removeEventListener('click', swallow, true)
+        }
+        window.addEventListener('click', swallow, true)
+        clickSwallowTimeoutRef.current = setTimeout(() => {
+          window.removeEventListener('click', swallow, true)
+          clickSwallowTimeoutRef.current = null
+        }, 0)
+      }
+      const sidebarDropIndex =
+        commit && session.promoted && latestDropIndexRef.current !== null
+          ? latestDropIndexRef.current
+          : null
+      dragSessionRef.current = null
+      setState(INITIAL_REPO_DRAG_STATE)
+      setSessionArmed(false)
+      if (sidebarDropIndex === null) {
+        return
+      }
+
+      commitProjectHeaderDragDrop({
+        session,
+        sidebarDropIndex,
+        orderedRepoIds: orderedIdsRef.current,
+        repoById: repoByIdRef.current,
+        usesProjectGroupOrdering: usesProjectGroupOrderingRef.current,
+        onCommitRepoOrder: onCommitRepoOrderRef.current,
+        onCommitProjectGroupOrder: onCommitProjectGroupOrderRef.current
+      })
+    },
+    [cancelAutoscroll]
+  )
+
+  const runAutoscrollFrame = useCallback(
+    (frameTime: number) => {
+      autoscrollFrameIdRef.current = null
+      const session = dragSessionRef.current
+      const container = getContainerRef.current()
+      if (!session?.promoted || !container) {
+        cancelAutoscroll()
+        return
+      }
+
+      const previousFrameTime = autoscrollLastFrameTimeRef.current ?? frameTime
+      autoscrollLastFrameTimeRef.current = frameTime
+      const autoscroll = getWorktreeSidebarDragAutoscroll({
+        point: { clientX: 0, clientY: session.latestPointerY },
+        containerRect: container.getBoundingClientRect(),
+        scrollTop: container.scrollTop,
+        scrollHeight: container.scrollHeight,
+        clientHeight: container.clientHeight,
+        elapsedMs: frameTime - previousFrameTime
+      })
+      if (autoscroll) {
+        container.scrollTop = autoscroll.scrollTop
+        refreshHeaderRects()
+      }
+
+      const drop = computeDrop(session.latestPointerY)
+      if (drop) {
+        setState((prev) =>
+          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
+            ? prev
+            : { draggingRepoId: session.repoId, ...drop }
+        )
+      }
+
+      autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
+    },
+    [cancelAutoscroll, computeDrop, refreshHeaderRects]
+  )
+
+  const ensureAutoscroll = useCallback(() => {
+    if (autoscrollFrameIdRef.current !== null) {
+      return
+    }
+    autoscrollLastFrameTimeRef.current = null
+    autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
+  }, [runAutoscrollFrame])
+
   useEffect(() => {
     if (!sessionArmed) {
       return
@@ -219,24 +202,40 @@ export function useRepoHeaderDrag({
       if (!session || e.pointerId !== session.pointerId) {
         return
       }
+      session.latestPointerY = e.clientY
       if (!session.promoted) {
         const dx = e.clientX - session.startX
         const dy = e.clientY - session.startY
-        if (dx * dx + dy * dy < DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) {
+        if (
+          dx * dx + dy * dy <
+          PROJECT_HEADER_DRAG_THRESHOLD_PX * PROJECT_HEADER_DRAG_THRESHOLD_PX
+        ) {
           return
         }
         session.promoted = true
+        // Why: setPointerCapture can throw if the element is detached. Check
+        // isConnected first to avoid the throw; the global pointer listeners
+        // still fire, so dragging keeps working even if capture fails.
+        if (session.handleEl.isConnected) {
+          try {
+            session.handleEl.setPointerCapture(session.pointerId)
+          } catch {
+            // Ignore capture failure; global listeners will handle the drag.
+          }
+        }
+        refreshHeaderRects()
         setState({ draggingRepoId: session.repoId, dropIndex: null, dropIndicatorY: null })
       }
+      refreshHeaderRects()
       const drop = computeDrop(e.clientY)
-      if (!drop) {
-        return
+      if (drop) {
+        setState((prev) =>
+          prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
+            ? prev
+            : { draggingRepoId: session.repoId, ...drop }
+        )
       }
-      setState((prev) =>
-        prev.dropIndex === drop.dropIndex && prev.dropIndicatorY === drop.dropIndicatorY
-          ? prev
-          : { draggingRepoId: session.repoId, ...drop }
-      )
+      ensureAutoscroll()
     }
     const onPointerUp = (e: PointerEvent): void => {
       const session = dragSessionRef.current
@@ -270,15 +269,16 @@ export function useRepoHeaderDrag({
       window.removeEventListener('pointercancel', onPointerCancel)
       window.removeEventListener('keydown', onKeyDown)
       window.removeEventListener('blur', onBlur)
+      cancelAutoscroll()
+      if (clickSwallowTimeoutRef.current !== null) {
+        clearTimeout(clickSwallowTimeoutRef.current)
+        clickSwallowTimeoutRef.current = null
+      }
     }
-  }, [sessionArmed, computeDrop, endDrag])
+  }, [cancelAutoscroll, computeDrop, endDrag, ensureAutoscroll, refreshHeaderRects, sessionArmed])
 
-  // From pointerdown onward (armed session, before/after promotion) force a
-  // grabbing cursor and disable text selection across the whole window so
-  // the user gets immediate feedback that the press registered, even before
-  // they've moved past DRAG_THRESHOLD_PX.
   useEffect(() => {
-    if (!sessionArmed) {
+    if (state.draggingRepoId === null) {
       return
     }
     const body = document.body
@@ -290,63 +290,21 @@ export function useRepoHeaderDrag({
       body.style.cursor = prevCursor
       body.style.userSelect = prevUserSelect
     }
-  }, [sessionArmed])
+  }, [state.draggingRepoId])
 
   const onHandlePointerDown = useCallback(
     (event: React.PointerEvent<HTMLElement>, repoId: string) => {
-      // Only react to primary button. Ignore right/middle clicks.
-      if (event.button !== 0) {
-        return
-      }
-      // Don't intercept presses from nested action surfaces; Radix triggers
-      // and disabled wrappers are not always plain button descendants.
-      if (isRepoHeaderActionTarget(event.target, event.currentTarget)) {
-        return
-      }
-      const container = getContainerRef.current()
-      if (!container) {
-        return
-      }
-      // Snapshot every repo header's position in scrollContainer-local space.
-      // Using a snapshot (vs reading the DOM each pointermove) means the drop
-      // computation does not depend on those rows still being mounted —
-      // critical because react-virtual will unmount them as the user scrolls.
-      const containerRect = container.getBoundingClientRect()
-      const headerEls = container.querySelectorAll<HTMLElement>('[data-repo-header-id]')
-      const headerRects: HeaderRect[] = []
-      headerEls.forEach((el) => {
-        const id = el.getAttribute('data-repo-header-id')
-        if (!id) {
-          return
-        }
-        const rect = el.getBoundingClientRect()
-        headerRects.push({
-          repoId: id,
-          top: rect.top - containerRect.top + container.scrollTop,
-          bottom: rect.bottom - containerRect.top + container.scrollTop
-        })
-      })
-      headerRects.sort((a, b) => a.top - b.top)
-
-      const handleEl = event.currentTarget
-      try {
-        handleEl.setPointerCapture(event.pointerId)
-      } catch {
-        // setPointerCapture can throw if the element is detached; the global
-        // pointer listeners still fire, so dragging keeps working.
-      }
-      dragSessionRef.current = {
+      const session = createProjectHeaderDragSession({
+        event,
         repoId,
-        pointerId: event.pointerId,
-        headerRects,
-        handleEl,
-        startX: event.clientX,
-        startY: event.clientY,
-        promoted: false
+        repoById: repoByIdRef.current,
+        sidebarRepoHeaderIdsByBucket: sidebarRepoHeaderIdsByBucketRef.current,
+        getScrollContainer: getContainerRef.current
+      })
+      if (!session) {
+        return
       }
-      // Don't show drag UI yet. Wait for movement past DRAG_THRESHOLD_PX so a
-      // simple click on the header still toggles collapse via the surrounding
-      // onClick handler.
+      dragSessionRef.current = session
       setSessionArmed(true)
     },
     []
@@ -354,3 +312,8 @@ export function useRepoHeaderDrag({
 
   return { state, onHandlePointerDown }
 }
+
+export {
+  isRepoHeaderActionTarget,
+  isProjectHeaderDragHandleTarget
+} from './project-header-drag-contract'


### PR DESCRIPTION
## Summary

Refactors project header drag-and-drop to support project groups and bucket-based reordering in the worktree sidebar list.

Key updates:
- Enables repo header reordering when project groups exist.
- Restricts the drag trigger area to the repo icon instead of the entire row, avoiding interference with click handlers.
- Adds autoscroll support during dragging using requestAnimationFrame.
- Refactors state management and drag session handling.

## Screenshots

- No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed (Updated unit tests in `project-header-drag-start.test.ts` to align with icon handle target behavior).

## AI Review Report

Main risks checked:
- Tracked pointer capture behavior and potential failure modes.
- Checked index offsets when committing a drop in a bucketed list.
- Verified cross-platform compatibility across macOS, Linux, and Windows, confirming that pointer event helpers and keyboard event handling (e.g., Escape key) behave consistently across all target operating systems.

## Security Audit

No security risks. Drag-and-drop mechanics are fully contained in the UI/Renderer layer using local React state and standard DOM events. No IPC, script injection, or filesystem access is introduced.

## Notes

- Swallowing of click events on drag-end is handled via global listeners with a failsafe timeout to prevent accidental toggles.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5867">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->