### PR TITLE
Use quiet agent rows in new sidebar cards

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -65,7 +65,12 @@ vi.mock('./CacheTimer', () => ({
 }))
 
 vi.mock('./WorktreeCardAgents', () => ({
-  default: () => null
+  default: ({ useQuietAgentRows }: { useQuietAgentRows?: boolean }) => (
+    <div
+      data-worktree-card-agents=""
+      data-use-quiet-agent-rows={useQuietAgentRows ? 'true' : 'false'}
+    />
+  )
 }))
 
 vi.mock('./SshDisconnectedDialog', () => ({
@@ -357,6 +362,18 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).toContain('aria-label="Primary worktree"')
     expect(markup).not.toContain('>primary<')
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
+  })
+
+  it('uses quiet inline agent rows for the new card style', () => {
+    worktreeCardProperties = ['inline-agents']
+    settings = { experimentalNewWorktreeCardStyle: true }
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).toContain('data-worktree-card-agents=""')
+    expect(markup).toContain('data-use-quiet-agent-rows="true"')
   })
 
   it('renders a hover-revealed delete action for deletable workspaces', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1596,6 +1596,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
         {showInlineAgentList && (
           <WorktreeCardAgents
             worktreeId={worktree.id}
+            useQuietAgentRows={newCardStyle}
             className={hasMetaRow || remoteBranchConflict ? 'mt-0' : '-mt-1'}
           />
         )}

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -193,6 +193,26 @@ describe('WorktreeCardAgents', () => {
     expect(markup).not.toContain('aria-expanded')
   }, 30_000)
 
+  it('uses quiet row UX when requested by the new card style', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    mockAgents = [
+      mockAgent({
+        agentType: 'codex',
+        startedAt: 1000,
+        prompt: 'Run tests',
+        lastAssistantMessage: 'Inspecting changes'
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" useQuietAgentRows />)
+
+    expect(markup).toContain('compact-agent-row')
+    expect(markup).toContain('<span class="text-muted-foreground/90">Run tests</span>')
+    expect(markup).toContain('<span class="text-muted-foreground/65"> - Inspecting changes</span>')
+    expect(markup).not.toContain('data-testid="agent-row"')
+  })
+
   it('uses compact mode when the display preference is absent', async () => {
     mockAgents = [mockAgent({ agentType: 'codex', startedAt: 1000, prompt: 'Run tests' })]
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -42,6 +42,7 @@ function revealCompactAgentCard(agentListRoot: HTMLElement | null): void {
 
 type Props = {
   worktreeId: string
+  useQuietAgentRows?: boolean
   /** Controls spacing from the card body above. Passed in so the parent can
    *  decide whether a divider is appropriate — e.g. suppressed when the card
    *  chrome already provides visual separation. */
@@ -58,6 +59,7 @@ type Props = {
  */
 const WorktreeCardAgents = React.memo(function WorktreeCardAgents({
   worktreeId,
+  useQuietAgentRows = false,
   className
 }: Props) {
   const agents = useWorktreeAgentRows(worktreeId)
@@ -67,22 +69,35 @@ const WorktreeCardAgents = React.memo(function WorktreeCardAgents({
   // Why: gate the 30s tick behind non-empty rows by mounting the inner body
   // only when there's something to show. The setInterval lives in the inner
   // component's useNow, so idle worktrees don't pay per-card timer cost.
-  return <WorktreeCardAgentsBody worktreeId={worktreeId} agents={agents} className={className} />
+  return (
+    <WorktreeCardAgentsBody
+      worktreeId={worktreeId}
+      agents={agents}
+      useQuietAgentRows={useQuietAgentRows}
+      className={className}
+    />
+  )
 })
 
 type BodyProps = {
   worktreeId: string
   agents: DashboardAgentRowData[]
+  useQuietAgentRows: boolean
   className?: string
 }
 
 const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   worktreeId,
   agents,
+  useQuietAgentRows,
   className
 }: BodyProps) {
-  const agentActivityDisplayMode =
+  const configuredAgentActivityDisplayMode =
     useAppStore((s) => s.agentActivityDisplayMode) ?? DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE
+  // Why: the new sidebar card is the future path and no longer exposes the
+  // legacy compact/full inline-agent choice; it always uses the quiet row UX.
+  const isCompactAgentDisplay =
+    useQuietAgentRows || configuredAgentActivityDisplayMode === 'compact'
   const dropAgentStatus = useAppStore((s) => s.dropAgentStatus)
   const dismissRetainedAgent = useAppStore((s) => s.dismissRetainedAgent)
   const agentSendPopoverTargetMode = useAppStore((s) => s.agentSendPopoverTargetMode)
@@ -230,7 +245,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   const [compactRootListExpanded, setCompactRootListExpanded] = useState(false)
 
   useLayoutEffect(() => {
-    if (compactRootListExpanded && agentActivityDisplayMode === 'compact') {
+    if (compactRootListExpanded && isCompactAgentDisplay) {
       dispatchSuppressScrollAdjustment()
       // Why: defer the reveal scroll out of the expand commit. Running it inline
       // forces a synchronous sidebar layout that blocks the animation's opening
@@ -242,7 +257,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
       return () => cancelAnimationFrame(handle)
     }
     return undefined
-  }, [agentActivityDisplayMode, compactRootListExpanded])
+  }, [compactRootListExpanded, isCompactAgentDisplay])
   const toggleLineageParent = useCallback((paneKey: string) => {
     dispatchSuppressScrollAdjustment()
     setCollapsedLineageParents((current) => {
@@ -397,7 +412,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     )
   }
 
-  if (agentActivityDisplayMode === 'compact') {
+  if (isCompactAgentDisplay) {
     const summaryAgents = hasLineage ? rootAgents : agents
     // Why: compact worktree cards keep multiple active agents to a single
     // predictable status line, even when there are only two agents. In


### PR DESCRIPTION
## Summary

Follow-up to #5866. The experimental/new sidebar card style now always uses the quieter inline agent row UX instead of honoring the legacy compact/full agent display preference.

- `WorktreeCard` passes `useQuietAgentRows={newCardStyle}` into inline agent rendering.
- `WorktreeCardAgents` uses quiet compact-row rendering when requested by the new card style, even if the legacy agent activity display mode is `full`.
- Legacy card behavior remains driven by the existing agent activity display setting.

## Why

The new experimental card style is the future card path and will not expose compact/non-compact variants. Its inline agent rows should always keep the calmer hierarchy from #5866 so worktree titles remain the primary scan target.

## Tests

- [x] `pnpm exec oxfmt --write src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx` - 44 tests passed
- [x] `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx`
- [x] `git diff --check`
- [x] `pnpm run typecheck:web`

Pre-commit also ran staged `oxlint`, React doctor lint, and `oxfmt` successfully.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5870">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->