### PR TITLE
Make worktree hovercards easier to read

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
@@ -372,6 +372,66 @@ describe('WorktreeCard compact hover details', () => {
     expect(markup).toContain('Reviewer handoff note')
   })
 
+  it('repeats a long workspace title inside the whole-card hover when branch is already visible', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
+    worktreeCardProperties = ['status', 'branch', 'comment']
+    const longTitle =
+      'Investigate why the worktree hover card title disappears behind single-line truncation'
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ displayName: longTitle, comment: 'Reviewer handoff note' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expectParentBodyIsHoverTrigger(markup)
+    expect(markup.match(new RegExp(longTitle, 'g'))).toHaveLength(2)
+    expect(markup).toContain('feature/local-branch')
+    expect(markup).toContain('Reviewer handoff note')
+  })
+
+  it('uses whole-card hover for identity-only new card worktrees with branch row visible', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
+    worktreeCardProperties = ['status', 'branch']
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ displayName: 'Readable identity only' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('data-worktree-card-meta-row=""')
+    expectParentBodyIsHoverTrigger(markup)
+    expect(markup.match(/data-hover-open-delay="100"/g)).toHaveLength(1)
+    expect(markup.match(/Readable identity only/g)).toHaveLength(2)
+    expect(markup).toContain('feature/local-branch')
+    expect(markup).not.toContain('Workspace metadata')
+    expect(markup).not.toContain('Live Ports')
+  })
+
+  it('does not duplicate workspace identity when trimmed title equals branch', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: true }
+    worktreeCardProperties = ['status', 'branch']
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ displayName: '  feature/local-branch  ' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expectParentBodyIsHoverTrigger(markup)
+    expect(markup.match(/feature\/local-branch/g)).toHaveLength(3)
+  })
+
   it('keeps detailed metadata hover scoped to metadata icons by default', async () => {
     settings = { compactWorktreeCards: false }
     worktreeCardProperties = ['status', 'issue', 'linear-issue', 'comment', 'ports']

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1070,6 +1070,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
     ? hasMetadataBadge || (newCardStyle && showBranch) || cacheStartedAt != null
     : hasDetailedMetaRowContent
   const showHeaderActions = showTitleRowPrimary || showDeleteQuickAction
+  // Why: the hover owns full identity when the row truncates; normalize once
+  // so title/branch de-dupe and identity-only hover eligibility stay in sync.
   const trimmedVisibleCardTitle = visibleCardTitle.trim()
   const showBranchIdentityHover = newCardStyle
     ? !isFolder &&

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1070,9 +1070,25 @@ const WorktreeCard = React.memo(function WorktreeCard({
     ? hasMetadataBadge || (newCardStyle && showBranch) || cacheStartedAt != null
     : hasDetailedMetaRowContent
   const showHeaderActions = showTitleRowPrimary || showDeleteQuickAction
+  const trimmedVisibleCardTitle = visibleCardTitle.trim()
   const showBranchIdentityHover = newCardStyle
-    ? !isFolder && branch.length > 0 && !cardProps.includes('branch') && branch !== visibleCardTitle
+    ? !isFolder &&
+      branch.length > 0 &&
+      !cardProps.includes('branch') &&
+      branch !== trimmedVisibleCardTitle
     : compactCards && showBranch
+  const hoverBranchName = newCardStyle
+    ? !isFolder && branch.length > 0
+      ? branch
+      : undefined
+    : showBranchIdentityHover
+      ? branch
+      : undefined
+  const hoverWorkspaceTitle =
+    trimmedVisibleCardTitle.length > 0 && trimmedVisibleCardTitle !== hoverBranchName
+      ? trimmedVisibleCardTitle
+      : undefined
+  const hasHoverIdentity = Boolean(hoverWorkspaceTitle || hoverBranchName)
   const showInlineAgentList = cardProps.includes('inline-agents') && (newCardStyle || !compactCards)
   const hasHoverDetails =
     newCardStyle &&
@@ -1084,7 +1100,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       automationProvenance: metaAutomationProvenance
     }) ||
       workspacePorts.length > 0 ||
-      showBranchIdentityHover)
+      hasHoverIdentity)
   // Why: the parent row owns metadata hover; avoid stacking the title's
   // truncation tooltip on top of the richer details popover.
   const titleWrapper = newCardStyle
@@ -1667,8 +1683,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
         comment={hoverComment}
         automationProvenance={metaAutomationProvenance}
         automationHostId={worktree.hostId}
-        branchName={showBranchIdentityHover ? branch : undefined}
-        workspaceTitle={showBranchIdentityHover ? visibleCardTitle : undefined}
+        branchName={hoverBranchName}
+        workspaceTitle={hoverWorkspaceTitle}
         detailsAfter={
           workspacePorts.length > 0 ? <WorktreeCardPortsDetails ports={workspacePorts} /> : null
         }

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -182,7 +182,7 @@ export function WorktreeCardDetailsHover({
   const branchIdentity = branchName ? (
     <div
       className={cn(
-        'truncate font-mono text-[11px] leading-none text-muted-foreground',
+        'break-all font-mono text-[11px] leading-snug text-muted-foreground',
         identityOrder === 'workspace-first' && 'mt-1'
       )}
     >
@@ -193,7 +193,7 @@ export function WorktreeCardDetailsHover({
     workspaceTitle && workspaceTitle !== branchName ? (
       <div
         className={cn(
-          'truncate text-[13px] font-semibold leading-snug text-foreground',
+          'break-words text-[13px] font-semibold leading-snug text-foreground',
           identityOrder === 'branch-first' && 'mt-1'
         )}
       >


### PR DESCRIPTION
## Summary

Improves worktree hovercards so the hover is a readable identity surface for compact sidebar rows:

- keeps the worktree card row dense and preserves the current metadata/actions
- repeats the visible workspace title and branch in the whole-card hover when useful
- wraps long workspace titles and branch names inside the hover instead of truncating them
- keeps identity-only worktrees hoverable so a long title/branch can still be read even without notes, ports, issues, or reviews

## Design Approach

The design keeps all existing row and hover data surfaces, then normalizes hover identity in `WorktreeCard` before deciding whether the row needs a whole-card hover. `WorktreeCardDetailsHover` remains the shared rich-hover surface for identity, issue, Linear, review, automation, notes, and ports.

The scratch design doc is local-only at `design-docs/worktree-hovercard-layout.md` and is not included in this PR.

## Design Review

Delegated design review completed cleanly after tightening the contract:

- identity-only hover eligibility is a first-class requirement
- hover title/branch values are normalized before duplicate suppression
- title-equals-branch after trimming should not render duplicate identity

No design blockers remained before implementation.

## Implementation

- Added normalized `trimmedVisibleCardTitle`, `hoverWorkspaceTitle`, `hoverBranchName`, and `hasHoverIdentity` in `WorktreeCard`.
- Updated whole-card hover eligibility to include identity-only cases.
- Passed normalized identity into `WorktreeCardDetailsHover`.
- Changed hover identity text from single-line truncation to wrapping:
  - workspace title: `break-words`
  - branch: monospace `break-all`
- Added render regressions for long-title hover, identity-only hover, and trimmed title/branch dedupe.

No product deviations from the reviewed design.

## Completeness Verification

Delegated completeness verification reported complete:

- existing data surfaces are preserved: issue, Linear, review, automation provenance, notes, ports, branch identity, and actions
- inline rename, context menu, metadata actions, SSH/runtime indicators, and provider behavior are unchanged
- no agent-facing text or instructions were created or edited

## Code Review

Two independent delegated reviewers ran in parallel on the current branch diff.

- Reviewer A: clean, no actionable findings
- Reviewer B: clean, no actionable findings

Both noted the expected non-blocking gap that visual wrapping requires product-surface validation, which was covered in the Brennan test pass.

## Brennan Test

Verdict: land.

Validated in Electron against `demo-project`, not Orca:

- created a disposable demo-project worktree with a long workspace title, long branch, visible branch row, and notes metadata
- hovered the actual rendered sidebar card
- confirmed the hover displayed readable wrapped title and branch
- confirmed the Notes section/comment remained present
- measured rendered hover text: title and branch wrapped without horizontal overflow
- inspected console/logs; no relevant hovercard/runtime failures found
- cleaned up the disposable worktree and Electron/Playwright session

Screenshot evidence:

- `.playwright-cli/stage7-hovercard-demo-project-hover.png`
- `.playwright-cli/stage7-hovercard-demo-project-hover-content.png`

## Screenshot Evidence

Manual validation screenshots were captured locally and intentionally not committed:

- `.playwright-cli/stage7-hovercard-demo-project-hover.png`
- `.playwright-cli/stage7-hovercard-demo-project-hover-content.png`

The content screenshot shows the long workspace title and long branch wrapping in the hovercard with the Notes section preserved.

## Cross-Platform / Security

- Cross-platform: no path handling, keyboard shortcut handling, IPC schema, provider routing, SSH, runtime host, or filesystem behavior changed.
- Security/privacy: no new data collection, network calls, provider mutations, agent prompts, or external side effects were added.

## Tests

- [x] `git diff --check`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx`
- [x] `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/components/sidebar/WorktreeCardMeta.tsx src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx`
- [x] `pnpm run typecheck:web`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] Electron validation against `demo-project`: long workspace title + long branch row hover wraps readably and preserves notes metadata

## Post-PR Stabilization

- Waited 8 minutes after opening the PR.
- CodeRabbit posted one actionable comment requesting a short rationale comment for the trim-aware hover identity derivation.
- Fixed the comment in `a6962f1b42c265f0b54df12c82cf1425810a0fdc`, validated locally, and pushed.
- Waited 8 minutes again after the push.
- Refreshed CodeRabbit review reported no actionable comments; the original review comment is marked addressed.
- PR check `verify` passed.

Non-actionable note: CodeRabbit's pre-merge checklist includes a generic docstring coverage warning for this TSX-only diff. No docstrings are appropriate for the changed React component/test code, and repository CI is passing.

## Assumptions / Risks

- SSH/remoting, provider-specific review flows, external auth, and PR mutation are not in scope for this UI-only hovercard formatting change.
- Screenshot evidence is intentionally not committed.
