### PR TITLE
Handle literal Codex hook trust keys

### DIFF
--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -386,6 +386,34 @@ describe('upsertHookTrustEntries', () => {
     expect(written).toContain(`trusted_hash = "${computeTrustedHash(entry)}"`)
   })
 
+  it('collapses a literal-string hook table before writing the canonical basic-string table', () => {
+    const sourcePath = 'C:\\Users\\me\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json'
+    const key = `${sourcePath}:session_start:0:0`
+    const original = [
+      `[hooks.state.'${key}']`,
+      'enabled = false',
+      'trusted_hash = "sha256:LITERAL"',
+      ''
+    ].join('\r\n')
+    writeFileSync(configPath, original, 'utf-8')
+
+    const entry: CodexTrustEntry = {
+      sourcePath,
+      eventLabel: 'session_start',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'echo session'
+    }
+    upsertHookTrustEntries(configPath, [entry])
+
+    const written = readFileSync(configPath, 'utf-8')
+    expect(written).not.toContain(`[hooks.state.'${key}']`)
+    expect(written.match(/\[hooks\.state\./g)).toHaveLength(1)
+    expect(written).toContain(`[hooks.state."${escapeTomlString(key)}"]`)
+    expect(written).toContain('enabled = false')
+    expect(written).toContain(`trusted_hash = "${computeTrustedHash(entry)}"`)
+  })
+
   it('writes a .bak file before overwriting an existing config', () => {
     writeFileSync(configPath, 'model = "old"\n', 'utf-8')
     upsertHookTrustEntries(configPath, [
@@ -947,6 +975,44 @@ describe('removeHookTrustEntries', () => {
     expect(written).toContain('sha256:OTHER')
   })
 
+  it('removes a literal-string hook table for the requested key', () => {
+    const key = 'C:\\x\\hooks.json:session_start:0:0'
+    const original = [
+      `[hooks.state.'${key}']`,
+      'enabled = true',
+      'trusted_hash = "sha256:LITERAL"',
+      ''
+    ].join('\n')
+    writeFileSync(configPath, original, 'utf-8')
+
+    removeHookTrustEntries(configPath, [key])
+
+    const written = readFileSync(configPath, 'utf-8')
+    expect(written).not.toContain(`[hooks.state.'${key}']`)
+    expect(written).not.toContain('sha256:LITERAL')
+  })
+
+  it('removes mixed quoting duplicates for the requested key', () => {
+    const key = 'C:\\x\\hooks.json:session_start:0:0'
+    const original = [
+      `[hooks.state.'${key}']`,
+      'enabled = true',
+      'trusted_hash = "sha256:LITERAL"',
+      '',
+      `[hooks.state."${escapeTomlString(key)}"]`,
+      'enabled = true',
+      'trusted_hash = "sha256:BASIC"',
+      ''
+    ].join('\n')
+    writeFileSync(configPath, original, 'utf-8')
+
+    removeHookTrustEntries(configPath, [key])
+
+    const written = readFileSync(configPath, 'utf-8')
+    expect(written).not.toContain(`[hooks.state.'${key}']`)
+    expect(written).not.toContain(`[hooks.state."${escapeTomlString(key)}"]`)
+  })
+
   it('does not remove the target hook header text inside a multi-line string', () => {
     const key = '/x/hooks.json:pre_tool_use:0:0'
     const original = [
@@ -1129,6 +1195,20 @@ describe('readHookTrustEntries', () => {
 
     const result = readHookTrustEntries(configPath)
     expect(result.get('C:\\foo\\hooks.json:pre_tool_use:0:0')?.trustedHash).toBe('sha256:WIN')
+  })
+
+  it('reads a literal-string hook table key', () => {
+    const key = 'C:\\foo\\hooks.json:session_start:0:0'
+    const original = [
+      `[hooks.state.'${key}']`,
+      'enabled = false',
+      'trusted_hash = "sha256:LITERAL"',
+      ''
+    ].join('\n')
+    writeFileSync(configPath, original, 'utf-8')
+
+    const result = readHookTrustEntries(configPath)
+    expect(result.get(key)).toEqual({ trustedHash: 'sha256:LITERAL', enabled: false })
   })
 
   it('reads entries from a CRLF-terminated config', () => {

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -336,15 +336,6 @@ function upsertTrustBlock(content: string, key: string, hash: string): string {
   return deduped + content.slice(cursor)
 }
 
-// Why: Codex emits the canonical form with the key double-quoted; we never
-// share this slot with another tool, so we don't bother accepting bare
-// dotted-key variants. The caller applies this only to complete physical lines
-// outside TOML multi-line strings.
-function buildHeaderLinePattern(key: string): RegExp {
-  const escapedKey = escapeRegex(escapeTomlString(key))
-  return new RegExp(`^[ \\t]*\\[hooks\\.state\\."${escapedKey}"\\][ \\t]*(?:#[^\\r\\n]*)?$`)
-}
-
 type TrustBlockRange = {
   start: number
   headerLineEnd: number
@@ -352,7 +343,6 @@ type TrustBlockRange = {
 }
 
 function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
-  const headerPattern = buildHeaderLinePattern(key)
   const ranges: TrustBlockRange[] = []
   let cursor = 0
   let multilineState: TomlMultilineState = { basic: false, literal: false }
@@ -362,7 +352,10 @@ function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
     const rawLine = content.slice(cursor, lineEnd)
     const line = rawLine.replace(/\r$/, '')
     const nextCursor = newlineIdx === -1 ? content.length : newlineIdx + 1
-    if (!isInsideTomlMultilineString(multilineState) && headerPattern.test(line)) {
+    const headerKey = isInsideTomlMultilineString(multilineState)
+      ? null
+      : parseHookStateHeaderKey(line)
+    if (headerKey === key) {
       const headerLineEnd = rawLine.endsWith('\r') ? lineEnd - 1 : lineEnd
       const after = content.slice(headerLineEnd)
       const nextHeaderRel = findNextTableHeader(after)
@@ -382,6 +375,80 @@ function buildProjectHeaderPattern(projectPath: string): RegExp {
   return new RegExp(
     `(^|\\r?\\n)[ \\t]*\\[projects\\."${escapedPath}"\\][ \\t]*(?:#[^\\r\\n]*)?(?=\\r?\\n|$)`
   )
+}
+
+type ParsedTomlString = {
+  value: string
+  endIndex: number
+}
+
+// Why: Codex can write hook-state dotted keys as TOML basic strings while
+// users/Codex TUI may leave equivalent literal-string keys behind.
+function parseHookStateHeaderKey(line: string): string | null {
+  const trimmed = line.trimStart()
+  const prefixMatch = /^\[[ \t]*hooks[ \t]*\.[ \t]*state[ \t]*\.[ \t]*/.exec(trimmed)
+  if (!prefixMatch) {
+    return null
+  }
+  const parsedKey = parseTomlSingleLineString(trimmed, prefixMatch[0].length)
+  if (!parsedKey) {
+    return null
+  }
+  let index = skipTomlInlineWhitespace(trimmed, parsedKey.endIndex)
+  if (trimmed[index] !== ']') {
+    return null
+  }
+  index = skipTomlInlineWhitespace(trimmed, index + 1)
+  return index === trimmed.length || trimmed[index] === '#' ? parsedKey.value : null
+}
+
+function parseTomlSingleLineString(line: string, startIndex: number): ParsedTomlString | null {
+  if (line[startIndex] === '"') {
+    return parseTomlBasicSingleLineString(line, startIndex + 1)
+  }
+  if (line[startIndex] === "'") {
+    return parseTomlLiteralSingleLineString(line, startIndex + 1)
+  }
+  return null
+}
+
+function parseTomlBasicSingleLineString(line: string, startIndex: number): ParsedTomlString | null {
+  let value = ''
+  let index = startIndex
+  while (index < line.length) {
+    const char = line[index]
+    if (char === '"') {
+      return { value, endIndex: index + 1 }
+    }
+    if (char === '\\' && index + 1 < line.length) {
+      const next = line[index + 1]
+      value += unescapeTomlBasicStringEscape(next)
+      index += 2
+      continue
+    }
+    value += char
+    index++
+  }
+  return null
+}
+
+function parseTomlLiteralSingleLineString(
+  line: string,
+  startIndex: number
+): ParsedTomlString | null {
+  const endIndex = line.indexOf("'", startIndex)
+  if (endIndex === -1) {
+    return null
+  }
+  return { value: line.slice(startIndex, endIndex), endIndex: endIndex + 1 }
+}
+
+function skipTomlInlineWhitespace(line: string, startIndex: number): number {
+  let index = startIndex
+  while (line[index] === ' ' || line[index] === '\t') {
+    index++
+  }
+  return index
 }
 // Why: quoted keys can contain `]` (e.g. `[hooks.state."a]b"]`) and `[` lines
 // inside multi-line strings aren't headers, so we need a stateful scanner —
@@ -621,9 +688,6 @@ export function readHookTrustEntries(configPath: string): Map<string, CodexHookT
   const content = readTomlFile(configPath)
   // Why: walk line-by-line so `[hooks.state."..."]` inside a `"""..."""` or
   // `'''...'''` multi-line string isn't mistaken for a real header.
-  // Why: accept an optional `# inline comment` after `]` — TOML permits it,
-  // and rejecting hides a real entry, making getStatus misreport trustMissing.
-  const headerLineRegex = /^[ \t]*\[hooks\.state\."((?:[^"\\]|\\.)*)"\][ \t]*(?:#[^\r\n]*)?$/
   let cursor = 0
   let multilineState: TomlMultilineState = { basic: false, literal: false }
   while (cursor < content.length) {
@@ -632,12 +696,8 @@ export function readHookTrustEntries(configPath: string): Map<string, CodexHookT
     const rawLine = content.slice(cursor, lineEnd)
     const line = rawLine.replace(/\r$/, '')
     const nextCursor = newlineIdx === -1 ? content.length : newlineIdx + 1
-    const headerMatch = isInsideTomlMultilineString(multilineState)
-      ? null
-      : headerLineRegex.exec(line)
-    if (headerMatch) {
-      const escapedKey = headerMatch[1]
-      const key = unescapeTomlString(escapedKey)
+    const key = isInsideTomlMultilineString(multilineState) ? null : parseHookStateHeaderKey(line)
+    if (key !== null) {
       // Why: block ends at the next *real* header (multi-line aware).
       const after = content.slice(nextCursor)
       const nextHeaderRel = findNextTableHeader(after)
@@ -660,33 +720,40 @@ export function readHookTrustEntries(configPath: string): Map<string, CodexHookT
   return result
 }
 
+function unescapeTomlBasicStringEscape(next: string): string {
+  if (next === 'n') {
+    return '\n'
+  }
+  if (next === 'r') {
+    return '\r'
+  }
+  if (next === 't') {
+    return '\t'
+  }
+  if (next === 'b') {
+    return '\b'
+  }
+  if (next === 'f') {
+    return '\f'
+  }
+  if (next === '"') {
+    return '"'
+  }
+  if (next === '\\') {
+    return '\\'
+  }
+  // Why: unknown escapes round-trip — preserve the backslash so we don't
+  // silently drop information.
+  return `\\${next}`
+}
+
 function unescapeTomlString(escaped: string): string {
   let result = ''
   let i = 0
   while (i < escaped.length) {
     const ch = escaped[i]
     if (ch === '\\' && i + 1 < escaped.length) {
-      const next = escaped[i + 1]
-      if (next === 'n') {
-        result += '\n'
-      } else if (next === 'r') {
-        result += '\r'
-      } else if (next === 't') {
-        result += '\t'
-      } else if (next === 'b') {
-        result += '\b'
-      } else if (next === 'f') {
-        result += '\f'
-      } else if (next === '"') {
-        result += '"'
-      } else if (next === '\\') {
-        result += '\\'
-      }
-      // Why: unknown escapes round-trip — preserve the backslash so we don't
-      // silently drop information.
-      else {
-        result += `\\${next}`
-      }
+      result += unescapeTomlBasicStringEscape(escaped[i + 1])
       i += 2
     } else {
       result += ch


### PR DESCRIPTION
## Summary
- Parse `[hooks.state.*]` headers as TOML quoted keys instead of matching only Orca's canonical double-quoted spelling.
- Collapse, remove, and read equivalent hook trust tables written with literal-string keys like `[hooks.state.'C:\...']`.
- Add regressions for mixed TOML quoting so Windows Codex configs do not accumulate semantic duplicate hook-state tables.

## Investigation
- Followed up on #3190's latest report from V1.4.81-rc2.
- Reproduced the core failure locally with an existing literal-string hook table: Orca missed `[hooks.state.'C:\...\hooks.json:session_start:0:0']` and appended `[hooks.state.C:\\...\\hooks.json:session_start:0:0]`, leaving duplicate TOML keys.
- The new parser is shared by upsert/read/remove paths, so install repair, stale cleanup, and status checks agree on both basic-string and literal-string hook keys.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex/config-toml-trust.test.ts src/main/codex/hook-service.test.ts src/main/agent-hooks/installer-utils-remote.test.ts src/main/codex-accounts/fs-utils.test.ts` (111 tests passed)
- `pnpm run typecheck`
- `pnpm exec tsc --project config/tsconfig.cli.json --pretty false`
- `pnpm exec oxlint src/main/codex/config-toml-trust.ts src/main/codex/config-toml-trust.test.ts src/main/codex/hook-service.ts src/main/codex/hook-service.test.ts src/main/agent-hooks/installer-utils-remote.test.ts src/main/codex-accounts/fs-utils.ts src/main/codex-accounts/fs-utils.test.ts`
- `git diff --check`

## Validation note
- `pnpm run lint` currently fails in `verify-localization-catalog` on existing missing keys in `src/renderer/src/components/status-bar/tooltip.tsx`; this PR does not touch renderer/localization files. Oxlint and switch-exhaustiveness portions completed before that catalog failure.

## Risk
- Main-process TOML scanner only; no renderer/UI, SSH transport, or provider-specific review behavior changed.
- The parser remains line-scoped and still ignores hook-shaped text inside TOML multiline strings via the existing multiline scanner.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5872">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->