### PR TITLE
Preserve scrollback during hidden terminal recovery

### DIFF
--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -130,7 +130,8 @@ export class HeadlessEmulator {
     const modes = this.getModes()
     const snapshotAnsi = this.normalizeSnapshotAnsiForModes(
       this.serializer.serialize({ scrollback: opts.scrollbackRows }),
-      modes
+      modes,
+      (opts.scrollbackRows ?? 0) > 0
     )
     return {
       snapshotAnsi,
@@ -271,9 +272,19 @@ export class HeadlessEmulator {
     return /^[0-9;]*$/.test(params)
   }
 
-  private normalizeSnapshotAnsiForModes(snapshotAnsi: string, modes: TerminalModes): string {
+  private normalizeSnapshotAnsiForModes(
+    snapshotAnsi: string,
+    modes: TerminalModes,
+    preserveNormalBufferBeforeAltScreen: boolean
+  ): string {
     if (!modes.alternateScreen) {
       return snapshotAnsi
+    }
+    if (preserveNormalBufferBeforeAltScreen) {
+      // Why: desktop hidden-output recovery clears xterm entirely. Restore the
+      // normal buffer first, then let the serialized payload re-enter alt-screen.
+      const rehydrateModes = this.buildRehydrateSequences(modes, false)
+      return `\x1b[?1049l${snapshotAnsi}${rehydrateModes}`
     }
     const alternateScreenMarker = '\x1b[?1049h'
     const start = snapshotAnsi.lastIndexOf(alternateScreenMarker)
@@ -308,9 +319,9 @@ export class HeadlessEmulator {
     }
   }
 
-  private buildRehydrateSequences(modes: TerminalModes): string {
+  private buildRehydrateSequences(modes: TerminalModes, includeAlternateScreen = true): string {
     const seqs: string[] = []
-    if (modes.alternateScreen) {
+    if (modes.alternateScreen && includeAlternateScreen) {
       seqs.push('\x1b[?1049h')
     }
     if (modes.bracketedPaste) {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -6468,11 +6468,12 @@ describe('registerPtyHandlers', () => {
 
       const result = await handlers.get('pty:getMainBufferSnapshot')!(null, {
         id: 'pty-1',
-        opts: { scrollbackRows: 999_999 }
+        opts: { scrollbackRows: 999_999, altScreenForcesZeroRows: false }
       })
 
       expect(runtime.serializeMainTerminalBuffer).toHaveBeenCalledWith('pty-1', {
-        scrollbackRows: 50_000
+        scrollbackRows: 50_000,
+        altScreenForcesZeroRows: false
       })
       expect(result).toEqual({
         data: 'snapshot\r\n',

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2073,7 +2073,10 @@ export function registerPtyHandlers(
     'pty:getMainBufferSnapshot',
     async (
       _event,
-      args: { id?: unknown; opts?: { scrollbackRows?: unknown } }
+      args: {
+        id?: unknown
+        opts?: { scrollbackRows?: unknown; altScreenForcesZeroRows?: unknown }
+      }
     ): Promise<{
       data: string
       cols: number
@@ -2087,8 +2090,15 @@ export function registerPtyHandlers(
         return null
       }
       const scrollbackRows = normalizeSnapshotScrollbackRows(args.opts?.scrollbackRows)
+      const altScreenForcesZeroRows =
+        typeof args.opts?.altScreenForcesZeroRows === 'boolean'
+          ? args.opts.altScreenForcesZeroRows
+          : undefined
       try {
-        return await runtime.serializeMainTerminalBuffer(args.id, { scrollbackRows })
+        return await runtime.serializeMainTerminalBuffer(args.id, {
+          scrollbackRows,
+          altScreenForcesZeroRows
+        })
       } catch {
         return null
       }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5060,6 +5060,23 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('preserves requested desktop-recovery scrollback while an alternate-screen TUI is active', async () => {
+    const runtime = createRuntime()
+    syncSinglePty(runtime, 'pty-1')
+    const history = Array.from({ length: 60 }, (_, index) => `history-${index}\r\n`).join('')
+
+    runtime.onPtyData('pty-1', history, 100)
+    runtime.onPtyData('pty-1', '\x1b[?1049hClaude Code\r\nWorking\r\n', 100)
+
+    const snapshot = await runtime.serializeMainTerminalBuffer('pty-1', {
+      scrollbackRows: 1000,
+      altScreenForcesZeroRows: false
+    })
+
+    expect(snapshot?.data).toContain('history-0')
+    expect(snapshot?.data).toContain('Claude Code')
+  })
+
   it('emits explicit OSC 9999 agent status from runtime PTY data', () => {
     const statuses: RuntimeTerminalAgentStatusEvent[] = []
     const runtime = new OrcaRuntimeService(store, undefined, {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5052,7 +5052,7 @@ export class OrcaRuntimeService {
 
   serializeMainTerminalBuffer(
     ptyId: string,
-    opts: { scrollbackRows?: number } = {}
+    opts: { scrollbackRows?: number; altScreenForcesZeroRows?: boolean } = {}
   ): Promise<{
     data: string
     cols: number
@@ -5384,7 +5384,11 @@ export class OrcaRuntimeService {
 
   private async serializeHeadlessTerminalBuffer(
     ptyId: string,
-    opts: { scrollbackRows?: number; includeEmpty?: boolean } = {}
+    opts: {
+      scrollbackRows?: number
+      includeEmpty?: boolean
+      altScreenForcesZeroRows?: boolean
+    } = {}
   ): Promise<{
     data: string
     cols: number
@@ -5400,15 +5404,13 @@ export class OrcaRuntimeService {
       return null
     }
     await state.writeChain
-    // Why: when an alternate-screen TUI (Claude Code, vim, etc.) is currently
-    // active, the visible content is the alt-screen snapshot — replaying any
-    // normal-buffer scrollback before it can duplicate shell prompts and
-    // flatten SGR attributes when the mobile xterm replays the data. Force
-    // scrollbackRows=0 in that case. When the buffer is in normal mode the
-    // caller can request scrollback so the user can scroll up to see prior
-    // agent output.
+    // Why: mobile/hydration snapshots suppress normal-buffer scrollback while
+    // alt-screen TUIs are active. Desktop hidden-output recovery opts out
+    // because it clears xterm and needs the user's scrollback restored too.
     const requested = opts.scrollbackRows ?? 0
-    const scrollbackRows = state.emulator.isAlternateScreen ? 0 : requested
+    const altScreenForcesZeroRows = opts.altScreenForcesZeroRows !== false
+    const scrollbackRows =
+      state.emulator.isAlternateScreen && altScreenForcesZeroRows ? 0 : requested
     const snapshot = state.emulator.getSnapshot({ scrollbackRows })
     const data = snapshot.rehydrateSequences + snapshot.snapshotAnsi
     return data.length > 0 || opts.includeEmpty === true

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1061,7 +1061,7 @@ export type PreloadApi = {
     listSessions: () => Promise<{ id: string; cwd: string; title: string }[]>
     getMainBufferSnapshot: (
       id: string,
-      opts?: { scrollbackRows?: number }
+      opts?: { scrollbackRows?: number; altScreenForcesZeroRows?: boolean }
     ) => Promise<{
       data: string
       cols: number

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -771,7 +771,7 @@ const api = {
 
     getMainBufferSnapshot: (
       id: string,
-      opts?: { scrollbackRows?: number }
+      opts?: { scrollbackRows?: number; altScreenForcesZeroRows?: boolean }
     ): Promise<{
       data: string
       cols: number

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -5189,7 +5189,10 @@ describe('connectPanePty', () => {
     })
     await flushAsyncTicks(20)
 
-    expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+    expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', {
+      scrollbackRows: 5000,
+      altScreenForcesZeroRows: false
+    })
     expect(pane.terminal.resize).toHaveBeenCalledWith(100, 30)
     expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[2J\x1b[3J\x1b[H', expect.any(Function))
     expect(pane.terminal.write).toHaveBeenCalledWith('snapshot-state\r\n', expect.any(Function))
@@ -5240,7 +5243,10 @@ describe('connectPanePty', () => {
     })
     await flushAsyncTicks(20)
 
-    expect(getMainBufferSnapshot).toHaveBeenCalledWith('old-pty-id', { scrollbackRows: 5000 })
+    expect(getMainBufferSnapshot).toHaveBeenCalledWith('old-pty-id', {
+      scrollbackRows: 5000,
+      altScreenForcesZeroRows: false
+    })
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
       'old-snapshot-state\r\n',
       expect.any(Function)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2303,7 +2303,7 @@ export function connectPanePty(
 
     async function serializeHiddenOutputSnapshot(
       ptyId: string,
-      opts: { scrollbackRows?: number }
+      opts: { scrollbackRows?: number; altScreenForcesZeroRows?: boolean }
     ): Promise<PtyBufferSnapshot | null> {
       const e2eSnapshot = readE2eHiddenSnapshotOverride(ptyId)
       if (e2eSnapshot) {
@@ -2949,7 +2949,10 @@ export function connectPanePty(
           let snapshot: PtyBufferSnapshot | null = null
           try {
             snapshot = await serializeHiddenOutputSnapshot(currentPtyId, {
-              scrollbackRows: HIDDEN_OUTPUT_RESTORE_SCROLLBACK_ROWS
+              scrollbackRows: HIDDEN_OUTPUT_RESTORE_SCROLLBACK_ROWS,
+              // Why: desktop hidden-output recovery clears this xterm; preserve
+              // normal-buffer history even if the agent TUI is in alt-screen.
+              altScreenForcesZeroRows: false
             })
           } catch {
             snapshot = null

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -358,7 +358,10 @@ export type PtyTransport = {
   getPtyId: () => string | null
   getConnectionId?: () => string | null | undefined
   getLocalSessionMetadata?: () => LocalPtySessionMetadata | null
-  serializeBuffer?: (opts?: { scrollbackRows?: number }) => Promise<PtyBufferSnapshot | null>
+  serializeBuffer?: (opts?: {
+    scrollbackRows?: number
+    altScreenForcesZeroRows?: boolean
+  }) => Promise<PtyBufferSnapshot | null>
   preserve?: () => void
   /** Unregister PTY handlers without killing the process for pane remounts. */
   detach?: () => void


### PR DESCRIPTION
﻿## Summary
- preserve normal-buffer scrollback when desktop hidden-terminal recovery restores an alternate-screen TUI snapshot
- thread altScreenForcesZeroRows through renderer, preload, IPC, and runtime snapshot APIs
- add a regression harness for alternate-screen desktop recovery plus IPC/renderer expectations

## Testing
- pnpm test -- src/renderer/src/components/terminal-pane/pty-connection.test.ts
- pnpm test -- src/main/daemon/headless-emulator.test.ts
- pnpm test -- src/main/ipc/pty.test.ts -t "main buffer snapshot dispatch"
- pnpm test -- src/main/runtime/orca-runtime.test.ts -t "main terminal snapshots|visible screen|desktop-recovery|renderer-seeded titles"
- pnpm run typecheck

Fixes #5723
Investigates #5787


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5873">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->