### PR TITLE
Revert "Show worktree delete icon on sidebar row hover"

### DIFF
--- a/src/main/runtime/headless-tab-group-split-layout.ts
+++ b/src/main/runtime/headless-tab-group-split-layout.ts
@@ -193,7 +193,8 @@ export function buildHeadlessTabGroupSplit(args: {
       return {
         ...group,
         tabOrder: sourceOrder,
-        activeTabId: group.activeTabId === args.tabId ? (sourceOrder[0] ?? null) : group.activeTabId
+        activeTabId:
+          group.activeTabId === args.tabId ? (sourceOrder[0] ?? null) : group.activeTabId
       }
     }
     return group

--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -9,6 +9,7 @@ import type {
   WorktreeCardProperty
 } from '../../../../shared/types'
 import type WorktreeCardComponent from './WorktreeCard'
+import type * as WorkspaceDeleteQuickAction from './workspace-delete-quick-action'
 
 const fetchHostedReviewForBranch = vi.fn()
 const fetchIssue = vi.fn()
@@ -20,6 +21,7 @@ let tabsByWorktree: Record<string, { id: string }[]> = {}
 let ptyIdsByTabId: Record<string, string[]> = {}
 let browserTabsByWorktree: Record<string, { id: string }[]> = {}
 let settings: Partial<GlobalSettings> | null = null
+let workspaceDeleteModifierPressed = false
 let gitConflictOperationByWorktree: Record<string, GitConflictOperation> = {}
 let WorktreeCard: typeof WorktreeCardComponent
 
@@ -79,6 +81,14 @@ vi.mock('./WorktreeContextMenu', () => ({
   WORKTREE_NATIVE_CONTEXT_MENU_ATTR: 'data-worktree-native-context-menu'
 }))
 
+vi.mock('./workspace-delete-quick-action', async (importOriginal) => {
+  const actual = await importOriginal<typeof WorkspaceDeleteQuickAction>()
+  return {
+    ...actual,
+    useWorkspaceDeleteModifierPressed: () => workspaceDeleteModifierPressed
+  }
+})
+
 function makeRepo(): Repo {
   return {
     id: 'repo-1',
@@ -124,6 +134,7 @@ describe('WorktreeCard quick actions', () => {
     ptyIdsByTabId = {}
     browserTabsByWorktree = {}
     settings = null
+    workspaceDeleteModifierPressed = false
     gitConflictOperationByWorktree = {}
   })
 
@@ -359,18 +370,27 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
   })
 
-  it('renders a hover-revealed delete action for deletable workspaces', () => {
+  it('hides delete by default for an inactive workspace', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).not.toContain('aria-label="Delete workspace"')
+  })
+
+  it('shows delete as the top-right quick action while Option/Alt is held', () => {
+    workspaceDeleteModifierPressed = true
+
     const markup = renderToStaticMarkup(
       <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
     )
 
     expect(markup).toContain('aria-label="Delete workspace"')
-    expect(markup).toContain('can-hover:pointer-events-none')
-    expect(markup).toContain('group-hover/worktree-card:opacity-100')
-    expect(markup).toContain('group-hover/worktree-card:pointer-events-auto')
   })
 
-  it('shows delete for folder workspace instances', () => {
+  it('shows delete as the quick action for folder workspace instances while Option/Alt is held', () => {
+    workspaceDeleteModifierPressed = true
+
     const markup = renderToStaticMarkup(
       <WorktreeCard
         worktree={makeWorktree({
@@ -386,7 +406,8 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).toContain('aria-label="Delete workspace"')
   })
 
-  it('shows delete for a current workspace', () => {
+  it('shows delete for a current workspace while Option/Alt is held', () => {
+    workspaceDeleteModifierPressed = true
     const worktree = makeWorktree()
 
     const markup = renderToStaticMarkup(
@@ -396,7 +417,9 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).toContain('aria-label="Delete workspace"')
   })
 
-  it('does not show delete for the main worktree', () => {
+  it('does not show delete for the main worktree while Option/Alt is held', () => {
+    workspaceDeleteModifierPressed = true
+
     const markup = renderToStaticMarkup(
       <WorktreeCard
         worktree={makeWorktree({ isMainWorktree: true })}
@@ -408,7 +431,7 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).not.toContain('aria-label="Delete workspace"')
   })
 
-  it('does not show sleep for a workspace with live activity', () => {
+  it('does not replace sleep with delete for a workspace with live activity', () => {
     const worktree = makeWorktree()
     tabsByWorktree = { [worktree.id]: [{ id: 'tab-1' }] }
     ptyIdsByTabId = { 'tab-1': ['pty-1'] }
@@ -418,7 +441,7 @@ describe('WorktreeCard quick actions', () => {
     )
 
     expect(markup).not.toContain('aria-label="Sleep workspace"')
-    expect(markup).toContain('aria-label="Delete workspace"')
+    expect(markup).not.toContain('aria-label="Delete workspace"')
   })
 
   it('does not show sleep as the top-right quick action for an active workspace', () => {
@@ -431,7 +454,17 @@ describe('WorktreeCard quick actions', () => {
     )
 
     expect(markup).not.toContain('aria-label="Sleep workspace"')
-    expect(markup).toContain('aria-label="Delete workspace"')
+    expect(markup).not.toContain('aria-label="Delete workspace"')
+  })
+
+  it('does not show delete when the workspace is current but not selected in the sidebar', () => {
+    const worktree = makeWorktree()
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={worktree} repo={makeRepo()} isActive={false} isCurrentWorktree />
+    )
+
+    expect(markup).not.toContain('aria-label="Delete workspace"')
   })
 
   it('does not show the rebase operation chip on the card', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -56,7 +56,10 @@ import { installWindowVisibilityInterval, isWindowVisible } from '@/lib/window-v
 import { isMacAppDataPath } from '@/lib/passive-macos-app-data-access'
 import { runWorktreeDelete } from './delete-worktree-flow'
 import { WorktreeTitleInlineRename } from './WorktreeTitleInlineRename'
-import { canShowWorkspaceDeleteQuickAction } from './workspace-delete-quick-action'
+import {
+  canShowWorkspaceDeleteQuickAction,
+  useWorkspaceDeleteModifierPressed
+} from './workspace-delete-quick-action'
 import { DetachedHeadBadge } from '@/components/DetachedHeadBadge'
 import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { getFlushWorktreeCardPaddingLeft } from './worktree-list-indentation'
@@ -496,6 +499,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   })
   const visibleCardTitle = newCardStyle ? cardTitleDisplay : worktree.displayName
   const isDeleting = deleteState?.isDeleting ?? false
+  const deleteModifierPressed = useWorkspaceDeleteModifierPressed()
 
   const showStatus = cardProps.includes('status')
   const showIssue = cardProps.includes('issue')
@@ -801,11 +805,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
     },
     [worktree.id, worktree.isUnread, updateWorktreeMeta]
   )
-  // Why: delete is destructive, so the trash icon stays hidden until row hover
-  // (or keyboard focus within the row) instead of sitting in the default chrome.
+  // Why: delete is destructive, so it only appears while the user is holding
+  // Option/Alt instead of being part of the ordinary hover chrome.
   const showDeleteQuickAction =
     !affiliateListMode &&
     canShowWorkspaceDeleteQuickAction({
+      deleteModifierPressed,
       isDeleting,
       isMainWorktree: worktree.isMainWorktree
     })
@@ -1454,19 +1459,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
               {showDeleteQuickAction && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button
+                    <button
                       type="button"
-                      variant="ghost"
-                      size="icon-xs"
                       data-workspace-board-preserve-open=""
                       onPointerDown={stopQuickActionPointerPropagation}
                       onClick={handleWorkspaceQuickAction}
                       className={cn(
-                        'size-4 rounded bg-transparent p-0 text-muted-foreground transition-[background-color,color,opacity]',
-                        'can-hover:pointer-events-none can-hover:opacity-0',
-                        'group-hover/worktree-card:pointer-events-auto group-hover/worktree-card:opacity-100',
-                        'group-focus-within/worktree-card:pointer-events-auto group-focus-within/worktree-card:opacity-100',
-                        'focus-visible:pointer-events-auto focus-visible:opacity-100',
+                        'inline-flex size-4 items-center justify-center rounded bg-transparent opacity-0 transition-colors transition-opacity',
+                        'group-hover/worktree-card:opacity-100 group-focus-within/worktree-card:opacity-100 focus-visible:opacity-100',
                         'text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive'
                       )}
                       aria-label={translate(
@@ -1475,7 +1475,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
                       )}
                     >
                       <Trash2 className="size-3.5" />
-                    </Button>
+                    </button>
                   </TooltipTrigger>
                   <TooltipContent side="right" sideOffset={8}>
                     {translate(

--- a/src/renderer/src/components/sidebar/workspace-delete-quick-action.ts
+++ b/src/renderer/src/components/sidebar/workspace-delete-quick-action.ts
@@ -1,6 +1,99 @@
+import { useSyncExternalStore } from 'react'
+
+let deleteModifierPressed = false
+let listenersInstalled = false
+const listeners = new Set<() => void>()
+
+function notifyListeners(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+function setDeleteModifierPressed(next: boolean): void {
+  if (deleteModifierPressed === next) {
+    return
+  }
+  deleteModifierPressed = next
+  notifyListeners()
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (event.altKey || event.key === 'Alt') {
+    setDeleteModifierPressed(true)
+  }
+}
+
+function onKeyUp(event: KeyboardEvent): void {
+  if (event.key === 'Alt' || !event.altKey) {
+    setDeleteModifierPressed(false)
+  }
+}
+
+function clearDeleteModifierPressed(): void {
+  setDeleteModifierPressed(false)
+}
+
+function installListeners(): void {
+  if (listenersInstalled || typeof window === 'undefined') {
+    return
+  }
+  listenersInstalled = true
+  // Why: Option/Alt is a transient reveal modifier, so stale key state after
+  // focus loss would leave destructive affordances visible.
+  window.addEventListener('keydown', onKeyDown, { capture: true })
+  window.addEventListener('keyup', onKeyUp, { capture: true })
+  window.addEventListener('blur', clearDeleteModifierPressed)
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', clearDeleteModifierPressed)
+  }
+}
+
+function uninstallListeners(): void {
+  if (!listenersInstalled || typeof window === 'undefined') {
+    return
+  }
+  listenersInstalled = false
+  window.removeEventListener('keydown', onKeyDown, { capture: true })
+  window.removeEventListener('keyup', onKeyUp, { capture: true })
+  window.removeEventListener('blur', clearDeleteModifierPressed)
+  if (typeof document !== 'undefined') {
+    document.removeEventListener('visibilitychange', clearDeleteModifierPressed)
+  }
+  clearDeleteModifierPressed()
+}
+
+function subscribeDeleteModifier(listener: () => void): () => void {
+  listeners.add(listener)
+  installListeners()
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0) {
+      uninstallListeners()
+    }
+  }
+}
+
+function getDeleteModifierSnapshot(): boolean {
+  return deleteModifierPressed
+}
+
+function getServerDeleteModifierSnapshot(): boolean {
+  return false
+}
+
+export function useWorkspaceDeleteModifierPressed(): boolean {
+  return useSyncExternalStore(
+    subscribeDeleteModifier,
+    getDeleteModifierSnapshot,
+    getServerDeleteModifierSnapshot
+  )
+}
+
 export function canShowWorkspaceDeleteQuickAction(args: {
+  deleteModifierPressed: boolean
   isDeleting: boolean
   isMainWorktree: boolean
 }): boolean {
-  return !args.isDeleting && !args.isMainWorktree
+  return args.deleteModifierPressed && !args.isDeleting && !args.isMainWorktree
 }


### PR DESCRIPTION
## Summary
- Reverts #5571 / ce253354fe83c778bdd8f755e658a3b89330a969
- Restores the prior worktree delete quick action behavior so delete is not always exposed on row hover

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
- pnpm typecheck

Note: `pnpm test -- src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx` unexpectedly ran the broader suite and surfaced an unrelated existing failure in `src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts`; the exact touched test file passes with direct Vitest syntax.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5874">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->