### PR TITLE
Fix tab strip layout test assertion

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -322,13 +322,20 @@ describe('TabBar context menu wiring', () => {
       browserTabs: [],
       tabBarOrder: ['term-1', 'unified-editor-1']
     })
-    const strip = findChildrenByType(element, 'div').find((candidate) =>
+    const divs = findChildrenByType(element, 'div')
+    const stripWrapper = divs.find((candidate) =>
+      String(candidate.props.className ?? '').includes('flex-[0_1_auto]')
+    )
+    const strip = divs.find((candidate) =>
       String(candidate.props.className ?? '').includes('terminal-tab-strip')
     )
 
+    expect(stripWrapper).toBeTruthy()
+    expect(stripWrapper?.props.className).toContain('min-w-0')
+    expect(stripWrapper?.props.className).toContain('max-w-full')
     expect(strip).toBeTruthy()
     expect(strip?.props.className).toContain('min-w-0')
-    expect(strip?.props.className).toContain('flex-[0_1_auto]')
+    expect(strip?.props.className).toContain('flex-1')
     expect(strip?.props.className).toContain('overflow-x-auto')
     expect(strip?.props.className).not.toContain('scrollbar-sleek')
   })


### PR DESCRIPTION
## Summary
- Updates the tab strip layout test to assert the content-sized flex class on the wrapper
- Keeps the scroll strip assertion focused on its own flex/overflow classes

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
- pnpm typecheck

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5875">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->