### PR TITLE
fix(mobile): keep iOS terminal inputs on the default keyboard

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -4859,8 +4859,6 @@ export default function SessionScreen() {
                       autoCorrect={autocompleteEnabled}
                       spellCheck={autocompleteEnabled}
                       smartInsertDelete={false}
-                      // Why: Android's default keyboard is required for CJK IME
-                      // composition; iOS can still use ASCII when autocomplete is off.
                       keyboardType={getTerminalCommandKeyboardType(
                         Platform.OS,
                         autocompleteEnabled

--- a/mobile/src/terminal/terminal-ios-ime-keyboard.test.ts
+++ b/mobile/src/terminal/terminal-ios-ime-keyboard.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const sessionRouteSource = readFileSync(
+  new URL('../../app/h/[hostId]/session/[worktreeId].tsx', import.meta.url),
+  'utf8'
+)
+
+describe('terminal iOS IME keyboard', () => {
+  it('does not force terminal inputs onto the ASCII-only iOS keyboard', () => {
+    expect(sessionRouteSource).not.toContain("'ascii-capable'")
+    expect(sessionRouteSource).not.toContain('"ascii-capable"')
+  })
+})

--- a/mobile/src/terminal/terminal-keyboard-type.test.ts
+++ b/mobile/src/terminal/terminal-keyboard-type.test.ts
@@ -14,9 +14,9 @@ describe('terminal keyboard type', () => {
     expect(getTerminalCommandKeyboardType('android', true)).toBe('default')
   })
 
-  it('keeps the iOS ASCII keyboard when terminal autocomplete is disabled', () => {
-    expect(getTerminalLiveInputKeyboardType('ios')).toBe('ascii-capable')
-    expect(getTerminalCommandKeyboardType('ios', false)).toBe('ascii-capable')
+  it('keeps iOS IME keyboards available for terminal input', () => {
+    expect(getTerminalLiveInputKeyboardType('ios')).toBe('default')
+    expect(getTerminalCommandKeyboardType('ios', false)).toBe('default')
     expect(getTerminalCommandKeyboardType('ios', true)).toBe('default')
   })
 })

--- a/mobile/src/terminal/terminal-keyboard-type.ts
+++ b/mobile/src/terminal/terminal-keyboard-type.ts
@@ -1,20 +1,17 @@
 export type TerminalKeyboardPlatform = 'android' | 'ios' | 'web' | 'windows' | 'macos'
-export type TerminalKeyboardType = 'ascii-capable' | 'default'
+export type TerminalKeyboardType = 'default'
 
+// Why: terminal inputs use the system default keyboard so non-Latin IMEs (iOS
+// Zhuyin/Japanese/Korean, Android CJK) stay selectable — ASCII-only keyboards hide them.
 export function getTerminalLiveInputKeyboardType(
-  platform: TerminalKeyboardPlatform
+  _platform: TerminalKeyboardPlatform
 ): TerminalKeyboardType {
-  // Why: Android CJK IMEs need the normal system keyboard; password-style
-  // input types suppress composition and break Chinese terminal input.
-  return platform === 'ios' ? 'ascii-capable' : 'default'
+  return 'default'
 }
 
 export function getTerminalCommandKeyboardType(
-  platform: TerminalKeyboardPlatform,
-  autocompleteEnabled: boolean
+  _platform: TerminalKeyboardPlatform,
+  _autocompleteEnabled: boolean
 ): TerminalKeyboardType {
-  if (autocompleteEnabled) {
-    return 'default'
-  }
-  return platform === 'ios' ? 'ascii-capable' : 'default'
+  return 'default'
 }

--- a/mobile/src/terminal/terminal-keyboard-type.ts
+++ b/mobile/src/terminal/terminal-keyboard-type.ts
@@ -1,8 +1,8 @@
 export type TerminalKeyboardPlatform = 'android' | 'ios' | 'web' | 'windows' | 'macos'
 export type TerminalKeyboardType = 'default'
 
-// Why: terminal inputs use the system default keyboard so non-Latin IMEs (iOS
-// Zhuyin/Japanese/Korean, Android CJK) stay selectable — ASCII-only keyboards hide them.
+// Why: default keyboards keep non-Latin IMEs selectable; ASCII-only keyboards hide them.
+// Parameters stay for call-site stability while autocomplete no longer changes the keyboard.
 export function getTerminalLiveInputKeyboardType(
   _platform: TerminalKeyboardPlatform
 ): TerminalKeyboardType {


### PR DESCRIPTION
Fixes #5525.

## Summary

- keep iOS terminal text inputs on the default keyboard so system IMEs such as Zhuyin, Japanese, Korean, and other non-English keyboards remain selectable
- preserve the already-merged Android system-keyboard behavior for terminal IME composition
- update focused regression coverage for the terminal keyboard-type helper and the session screen source invariant

## Problem

The mobile terminal used iOS `keyboardType="ascii-capable"` when terminal autocomplete was disabled. iOS treats that as an ASCII-only input surface, which hides non-Latin keyboards from the keyboard switcher. Users with Traditional Chinese Zhuyin or other IMEs could not switch away from English in the terminal.

## Fix

Changed `terminal-keyboard-type.ts` so iOS terminal inputs use the `default` keyboard. This preserves IME availability while keeping `autoCorrect={false}` / `spellCheck={false}` on terminal inputs so commands, flags, and paths are not rewritten by the OS keyboard.

## Testing

- `./node_modules/.bin/vitest run src/terminal/terminal-ios-ime-keyboard.test.ts src/terminal/terminal-keyboard-type.test.ts src/terminal/terminal-live-input.test.ts src/terminal/terminal-text-input-normalization.test.ts`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `./node_modules/.bin/oxlint app/h/[hostId]/session/[worktreeId].tsx src/terminal/terminal-keyboard-type.ts src/terminal/terminal-keyboard-type.test.ts src/terminal/terminal-ios-ime-keyboard.test.ts`
- `./node_modules/.bin/oxfmt --check app/h/[hostId]/session/[worktreeId].tsx src/terminal/terminal-keyboard-type.ts src/terminal/terminal-keyboard-type.test.ts src/terminal/terminal-ios-ime-keyboard.test.ts`

## Screenshots

No visual change. This is a native keyboard/IME behavior fix.

## AI Review Summary

- Cross-platform: iOS now uses the default keyboard for IME compatibility; Android keeps the existing default-keyboard path from the recent Android IME fix. Desktop macOS/Linux/Windows code is not touched.
- SSH/remote/local: terminal input is still sent through the existing `terminal.send` flow; no runtime, path, process, or SSH assumptions changed.
- Agent/integration/git-provider compatibility: provider-neutral terminal input behavior only; no agent, review, or git-provider code changed.
- Performance: no hot-path work added beyond the existing tiny pure keyboard-type helper.
- Security: no new IPC, network, shell, credential, or file-system surface. User text continues through the existing terminal input pipeline.

## X Handle

Not provided.
