### PR TITLE
fix: fall back to default Source Control AI agent when default TUI agent has no spec

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -17,6 +17,7 @@ import {
   parsePiModels,
   resolveCommitMessageAgentChoice
 } from './commit-message-agent-spec'
+import { TUI_AGENT_AUTO_PICK_ORDER } from './tui-agent-selection'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -81,6 +82,31 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
     expect(resolveCommitMessageAgentChoice(null, 'codex', ['codex'])).toBe('claude')
     expect(resolveCommitMessageAgentChoice(null, null, ['claude'])).toBeNull()
     expect(resolveCommitMessageAgentChoice('codex', null, ['codex'])).toBe('codex')
+  })
+
+  it('falls back to the system Source Control AI default when an enabled default TUI agent has no spec', () => {
+    // An enabled default TUI agent with no spec must fall through to the system
+    // default, not resolve to null (which surfaces as a config error). Derived
+    // at runtime so it stays correct if such an agent later gains a spec.
+    const specless = TUI_AGENT_AUTO_PICK_ORDER.find(
+      (agent) => !isCustomAgentId(agent) && !getCommitMessageAgentSpec(agent)
+    )
+    expect(
+      specless,
+      'expected at least one TUI agent without a Source Control AI spec'
+    ).toBeDefined()
+    expect(resolveCommitMessageAgentChoice(null, specless!, [])).toBe(
+      DEFAULT_COMMIT_MESSAGE_AGENT_ID
+    )
+
+    // Inverse: an enabled default that DOES have a spec is used as-is. Pick a
+    // non-default spec-bearing agent so the result proves the guard returned it
+    // rather than the fallback.
+    const withSpec = TUI_AGENT_AUTO_PICK_ORDER.find(
+      (agent) => getCommitMessageAgentSpec(agent) && agent !== DEFAULT_COMMIT_MESSAGE_AGENT_ID
+    )
+    expect(withSpec, 'expected a non-default spec-bearing agent').toBeDefined()
+    expect(resolveCommitMessageAgentChoice(null, withSpec!, [])).toBe(withSpec)
   })
 
   it('gives every model with thinking levels a valid default', () => {

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -695,12 +695,15 @@ export function resolveCommitMessageAgentChoice(
   if (configuredAgentId) {
     return configuredAgentId
   }
+  // A spec-less but enabled default agent must fall through to the system default
+  // (like a disabled one), not resolve to null and surface a config error.
   if (
     defaultTuiAgent &&
     defaultTuiAgent !== 'blank' &&
-    isTuiAgentEnabled(defaultTuiAgent, disabledTuiAgents)
+    isTuiAgentEnabled(defaultTuiAgent, disabledTuiAgents) &&
+    getCommitMessageAgentSpec(defaultTuiAgent)
   ) {
-    return getCommitMessageAgentSpec(defaultTuiAgent) ? defaultTuiAgent : null
+    return defaultTuiAgent
   }
   return isTuiAgentEnabled(DEFAULT_COMMIT_MESSAGE_AGENT_ID, disabledTuiAgents)
     ? DEFAULT_COMMIT_MESSAGE_AGENT_ID

--- a/src/shared/source-control-ai.test.ts
+++ b/src/shared/source-control-ai.test.ts
@@ -66,6 +66,29 @@ describe('source-control AI resolution', () => {
     expect(resolve('branchName').params.model).toBe('gpt-5.5')
   })
 
+  it('resolves branchName to the system default agent when the default TUI agent has no spec', () => {
+    // Reproduces the "rename failed" badge: Source Control AI on, no explicit
+    // agent, and the default TUI agent (omp) has no spec. Pre-fix this errored
+    // ("Choose a supported agent"); it must now fall back to the system default.
+    const base = getDefaultSettings('/tmp')
+    const result = resolveSourceControlAiForOperation({
+      settings: {
+        ...base,
+        defaultTuiAgent: 'omp',
+        disabledTuiAgents: [],
+        sourceControlAi: { ...base.sourceControlAi!, enabled: true, agentId: null }
+      },
+      repo: null,
+      operation: 'branchName',
+      discoveryHostKey: 'local'
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      throw new Error(result.error)
+    }
+    expect(result.value.params.agentId).toBe('claude')
+  })
+
   it('resolves generation config and PR defaults when Source Control AI actions are hidden', () => {
     const base = settings()
     base.sourceControlAi = {


### PR DESCRIPTION
## Summary

A spec-less but enabled default TUI agent (e.g. omp) resolved to null, which surfaced as a "rename failed" / "choose a supported agent" config error. Route it to the system default like a disabled agent instead.

## Screenshots

No more failed renames
<img width="192" height="48" alt="image" src="https://github.com/user-attachments/assets/a53d3768-4c87-4101-a9e1-f0dc83bbba20" />

## Testing

- [ ] `pnpm lint` — plain `oxlint` is clean across the repo; the `lint:switch-exhaustiveness` (tsgolint) step could not run locally (requires Node 24, dev box is on Node 22). CI covers it.
- [x] `pnpm typecheck` — clean across all three projects (node, cli, web).
- [x] `pnpm test` — the two new tests pass; full suite is green except one pre-existing, unrelated failure in `TabBar.context-menu.test.ts` (tab-strip flex class), which this PR does not touch.
- [ ] `pnpm build` — not run locally (Node 24 requirement); relying on CI.
- [x] Added high-quality tests that would catch regressions — a resolver-level test in `commit-message-agent-spec.test.ts` and an end-to-end test in `source-control-ai.test.ts` reproducing the exact persisted-settings shape behind the bug.

## AI Review Report

Ran an extra-high-effort multi-angle code review (correctness, removed-behavior, cross-file tracing, language pitfalls, reuse/simplification/efficiency, altitude, conventions).

Main risks checked and outcome:
- **Resolver correctness** — verified that routing a spec-less enabled default to the system default does not regress the disabled-default or explicitly-configured-agent paths, and that the second resolution pass in `resolveSourceControlAiForOperation` (action-recipe agent) still behaves. No correctness bug found.
- **Cross-file impact** — traced all callers. Noted that the `unsupportedDefaultAgent` warning path in `useAiCommitPrSettings.ts` becomes unreachable for the common case (it only fired when the resolver returned null); this is the intended consequence of the fix (silent fallback replaces the error badge), so it was left as-is.
- **Conventions** — flagged and trimmed an over-long comment block (repo rule: keep comments to one or two lines) on the resolver and in the new tests.

Cross-platform compatibility: this change is pure shared logic — a string-returning resolver function. It introduces no keyboard shortcuts, shortcut labels, file paths, shell invocations, or Electron-specific code, so there is no macOS/Linux/Windows divergence to verify.

## Security Audit

No security-relevant surface is touched. The change is a pure decision function selecting an agent id from existing settings — no input parsing, command execution, path handling, authentication, secrets, dependency changes, or IPC. No follow-up needed.

## Notes

- **No visual change** beyond eliminating the error state (the "rename failed" badge no longer appears for spec-less default agents).
- **Provider-neutral and SSH/remote-safe**: the resolver does not assume a git provider or local-only execution.
- **Unrelated pre-existing test failure**: `TabBar.context-menu.test.ts` fails on the base branch (flex class mismatch from the tab-strip scrollbar change); out of scope here.
- Dev environment is on Node 22; the repo requires Node 24, which is why the type-aware lint and build steps were deferred to CI.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5878">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

A default TUI agent without a Source Control AI spec made renames fail with a confusing agent error. Orca falls back to the system default agent for that flow instead.
