### PR TITLE
Exclude Claude subagent transcripts from Agent Session History

### DIFF
--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -305,6 +305,49 @@ describe('scanAiVaultSessions', () => {
     ])
   })
 
+  it('excludes Claude subagent transcripts so workflow agents do not clutter history', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-claude-subagents-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const sessionDir = join(roots.claudeProjectsDir, 'project', 'claude-session')
+    await mkdir(join(sessionDir, 'subagents'), { recursive: true })
+
+    await writeFile(
+      join(roots.claudeProjectsDir, 'project', 'claude-session.jsonl'),
+      jsonLines([
+        {
+          type: 'user',
+          sessionId: 'claude-session',
+          timestamp: '2026-05-01T10:00:00.000Z',
+          cwd: '/repo/app',
+          message: { role: 'user', content: 'Primary session prompt' }
+        }
+      ])
+    )
+
+    // Subagent transcript Claude writes per Task/workflow agent — must not surface.
+    await writeFile(
+      join(sessionDir, 'subagents', 'agent-ad772b7a63b38f17a.jsonl'),
+      jsonLines([
+        {
+          type: 'user',
+          sessionId: 'agent-ad772b7a63b38f17a',
+          timestamp: '2026-05-01T10:05:00.000Z',
+          cwd: '/repo/app',
+          isSidechain: true,
+          agentId: 'ad772b7a63b38f17a',
+          message: { role: 'user', content: 'Subagent task prompt' }
+        }
+      ])
+    )
+
+    const result = await scanAiVaultSessions({ ...roots, platform: 'darwin' })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]?.sessionId).toBe('claude-session')
+  })
+
   it('indexes every supported agent transcript format with native resume commands', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-all-agents-'))
     tempRoots.push(root)

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -74,7 +74,10 @@ export async function scanAiVaultSessions(
       limit: limitPerAgent,
       agent: 'claude',
       issues,
-      extensions: ['.jsonl']
+      extensions: ['.jsonl'],
+      // Why: Claude writes per-Task subagent transcripts under <session>/subagents/; workflows
+      // spawn many, so exclude them — they clutter history and crowd out real sessions.
+      filePredicate: (path) => !path.split(/[\\/]/).includes('subagents')
     }),
     ...codexSessionsDirs.map((rootDir) =>
       discoverFiles({


### PR DESCRIPTION
The AI Vault "Agent Session History" indexed every Claude .jsonl transcript as a top-level session, including the per-Task subagent transcripts Claude writes to <session>/subagents/agent-*.jsonl. Dynamic workflows spawn many of these (~90% of all transcript files on a real machine — 1782 of 1973), so they flooded the list and, because the scan is bounded by file mtime and a result limit, crowded real sessions out of the view entirely. Exclude them at the discovery layer via a filePredicate, the same way cursor, grok, hermes, rovo, kimi, and openclaw already skip their auxiliary transcripts.

## Summary

No visual change — backend filter; the existing list simply stops showing subagent rows.

## Screenshots

- Add screenshots or a screen recording for any new or changed UI behavior.
- If there is no visual change, say `No visual change`.

## Testing

- [ ] `pnpm lint` — `oxlint` and `lint:switch-exhaustiveness` are clean; the overall command fails only on `verify:localization-catalog`, a pre-existing issue for keys in `status-bar/tooltip.tsx` that this PR does not touch.
- [x] `pnpm typecheck` — clean across all three projects (node, cli, web).
- [x] `pnpm test` — the new test passes and the full `src/main/ai-vault` suite is green (8/8); the only suite failure is a pre-existing, unrelated `TabBar.context-menu.test.ts` (tab-strip flex class).
- [x] `pnpm build` — ran locally, build complete (desktop + native), exit 0.
- [x] Added a high-quality regression test: the subagent fixture carries a newer timestamp than the primary session, so it would sort first and fail the assertion if the filter were removed — not happy-path-only coverage.

## AI Review Report

Ran an extra-high-effort multi-angle code review (correctness, removed-behavior, cross-file tracing, language pitfalls, reuse/simplification/efficiency, altitude, conventions).

Main risks checked and outcome:
- **False exclusions / inclusions** — verified empirically against a real `~/.claude/projects`: every transcript under a `subagents/` directory carries `isSidechain:true`, and no sidechain files exist outside it, so the path filter is exact. Claude encodes the cwd into the project dir name by flattening `/`→`-`, so a user project path containing a `subagents` folder cannot produce a standalone `subagents` segment — only Claude's real subdirectory can.
- **Altitude** — excluding at discovery (rather than a renderer toggle) is the right depth: it also stops subagents from consuming the mtime-bounded scan budget, which a renderer-only filter would not. It matches the established per-agent `filePredicate` convention instead of adding a special case.
- **Conventions** — flagged and trimmed an over-long comment to two lines (repo rule: keep comments to one or two lines).
- **Documented edge case** — a projects-root path that itself contains a literal `subagents` segment would hide all sessions; left as-is because every sibling predicate in the file shares the identical full-path form, so hardening only this one would diverge from convention.

Cross-platform compatibility: the predicate splits on `/[\\/]/`, handling both separators; it introduces no keyboard shortcuts, shortcut labels, additional file-path construction, shell invocations, or Electron-specific code, so there is no macOS/Linux/Windows divergence to verify.

## Security Audit

No security-relevant surface is touched. The change is a read-only path predicate over paths the scanner already discovers — no input parsing, command execution, IPC, authentication, secrets, or dependency changes. The predicate is a pure string split on a fixed separator class with no injection exposure. No follow-up needed.

## Notes

- **SSH/remote-safe**: only affects scanning of the local `~/.claude/projects` history directory; introduces no new local-only assumption and leaves resume gating unchanged.
- **Provider- and agent-neutral by containment**: the filter lives solely in the Claude discovery call; all other agents are untouched.
- **Performance**: strictly improves the scan — it skips opening, streaming, and JSON-parsing ~90% of transcript files.
- **Unrelated pre-existing failures** on the base branch: `TabBar.context-menu.test.ts` (tab-strip flex class) and the `status-bar/tooltip.tsx` localization-catalog keys; both out of scope here.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5879">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Agent Session History listed Claude subagent transcripts as top-level sessions and crowded out real chats. Subagent files under session folders are excluded from the list.
