### PR TITLE
Prioritize Create PR intent over blocked notices

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
@@ -86,9 +86,9 @@ describe('resolvePrimaryAction Create PR intent', () => {
     expect(result.kind).toBe('create_pr_intent')
     expect(result.disabled).toBe(false)
     expect(resolveCreatePrHeaderAction(input)).toEqual({
-      kind: 'create_pr',
+      kind: 'create_pr_intent',
       label: 'Create PR',
-      title: 'Push commits before creating a pull request.',
+      title: 'Prepare this branch and create a pull request',
       disabled: false
     })
     expect(resolveCommitAreaPrimaryAction(input)).toEqual({
@@ -120,25 +120,75 @@ describe('resolvePrimaryAction Create PR intent', () => {
       title: 'Prepare this branch and create a pull request',
       disabled: false
     })
+    expect(
+      resolveCreatePrHeaderAction(
+        inputs({
+          stagedCount: 0,
+          hasUnstagedChanges: true,
+          hasStageableChanges: true,
+          upstreamStatus: upstreamInSync,
+          hostedReviewCreation: {
+            provider: 'github',
+            review: null,
+            canCreate: false,
+            blockedReason: 'dirty',
+            nextAction: 'commit'
+          }
+        })
+      )
+    ).toEqual({
+      kind: 'create_pr_intent',
+      label: 'Create PR',
+      title: 'Prepare this branch and create a pull request',
+      disabled: false
+    })
   })
 
   it('returns Create PR intent for staged changes without a message so the flow can request one', () => {
-    const result = resolvePrimaryAction(
-      inputs({
-        stagedCount: 1,
-        hasMessage: false,
-        upstreamStatus: upstreamInSync,
-        hostedReviewCreation: {
-          provider: 'github',
-          review: null,
-          canCreate: false,
-          blockedReason: 'dirty',
-          nextAction: 'commit'
-        }
-      })
-    )
+    const input = inputs({
+      stagedCount: 1,
+      hasMessage: false,
+      upstreamStatus: upstreamInSync,
+      hostedReviewCreation: {
+        provider: 'github',
+        review: null,
+        canCreate: false,
+        blockedReason: 'dirty',
+        nextAction: 'commit'
+      }
+    })
+    const result = resolvePrimaryAction(input)
     expect(result.kind).toBe('create_pr_intent')
     expect(result.disabled).toBe(false)
+    expect(resolveCreatePrHeaderAction(input)).toEqual({
+      kind: 'create_pr_intent',
+      label: 'Create PR',
+      title: 'Prepare this branch and create a pull request',
+      disabled: false
+    })
+  })
+
+  it('keeps default branch blockers on the direct notice path', () => {
+    expect(
+      resolveCreatePrHeaderAction(
+        inputs({
+          stagedCount: 1,
+          upstreamStatus: upstreamInSync,
+          hostedReviewCreation: {
+            provider: 'github',
+            review: null,
+            canCreate: false,
+            blockedReason: 'default_branch',
+            nextAction: null
+          }
+        })
+      )
+    ).toEqual({
+      kind: 'create_pr',
+      label: 'Create PR',
+      title: 'Cannot create a pull request from the default branch.',
+      disabled: false
+    })
   })
 
   it('returns Create MR intent with provider copy for a GitLab dirty branch', () => {
@@ -161,7 +211,7 @@ describe('resolvePrimaryAction Create PR intent', () => {
     expect(result.title).toBe('Prepare this branch and create a merge request')
   })
 
-  it('returns a direct Create MR header notice path for a GitLab dirty branch', () => {
+  it('routes a GitLab dirty branch header through Create MR intent', () => {
     expect(
       resolveCreatePrHeaderAction(
         inputs({
@@ -178,9 +228,9 @@ describe('resolvePrimaryAction Create PR intent', () => {
         })
       )
     ).toEqual({
-      kind: 'create_pr',
+      kind: 'create_pr_intent',
       label: 'Create MR',
-      title: 'Commit changes before creating a merge request.',
+      title: 'Prepare this branch and create a merge request',
       disabled: false
     })
   })
@@ -235,7 +285,7 @@ describe('resolvePrimaryAction Create PR intent', () => {
     }
   )
 
-  it('separates Publish Branch from the Create PR header action for unpublished commits', () => {
+  it('routes unpublished commits through Create PR intent while keeping Publish Branch in the commit area', () => {
     const input = inputs({
       upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0 },
       branchCommitsAhead: 2,
@@ -249,9 +299,9 @@ describe('resolvePrimaryAction Create PR intent', () => {
     })
 
     expect(resolveCreatePrHeaderAction(input)).toEqual({
-      kind: 'create_pr',
+      kind: 'create_pr_intent',
       label: 'Create PR',
-      title: 'Publish commits before creating a pull request.',
+      title: 'Prepare this branch and create a pull request',
       disabled: false
     })
     expect(resolveCommitAreaPrimaryAction(input)).toEqual({
@@ -262,7 +312,7 @@ describe('resolvePrimaryAction Create PR intent', () => {
     })
   })
 
-  it('separates Force Push from the Create PR header action for patch-equivalent divergence', () => {
+  it('routes patch-equivalent divergence through Create PR intent while keeping Force Push in the commit area', () => {
     const input = inputs({
       branchCommitsAhead: 4,
       upstreamStatus: {
@@ -282,9 +332,9 @@ describe('resolvePrimaryAction Create PR intent', () => {
     })
 
     expect(resolveCreatePrHeaderAction(input)).toEqual({
-      kind: 'create_pr',
+      kind: 'create_pr_intent',
       label: 'Create PR',
-      title: 'Sync this branch before creating a pull request.',
+      title: 'Prepare this branch and create a pull request',
       disabled: false
     })
     expect(resolveCommitAreaPrimaryAction(input)).toEqual({
@@ -292,6 +342,32 @@ describe('resolvePrimaryAction Create PR intent', () => {
       label: 'Force Push',
       title:
         'Remote only has older copies of local commits. Force push 4 branch commits with lease to update origin/feature.',
+      disabled: false
+    })
+  })
+
+  it('keeps unsafe sync blockers on the direct notice path', () => {
+    const input = inputs({
+      branchCommitsAhead: 4,
+      upstreamStatus: {
+        hasUpstream: true,
+        upstreamName: 'origin/feature',
+        ahead: 2,
+        behind: 3
+      },
+      hostedReviewCreation: {
+        provider: 'github',
+        review: null,
+        canCreate: false,
+        blockedReason: 'needs_sync',
+        nextAction: 'sync'
+      }
+    })
+
+    expect(resolveCreatePrHeaderAction(input)).toEqual({
+      kind: 'create_pr',
+      label: 'Create PR',
+      title: 'Sync this branch before creating a pull request.',
       disabled: false
     })
   })

--- a/src/renderer/src/components/right-sidebar/source-control-primary-create-pr-intent-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-create-pr-intent-action.ts
@@ -306,11 +306,16 @@ export function resolveCreatePrHeaderAction(inputs: PrimaryActionInputs): Primar
     }
   }
 
-  // Why: direct header clicks for known blocked states should show the local
-  // notice instead of starting the push-before-review preparation flow.
+  const createPrIntent = resolveCreatePrIntentPrimaryAction(inputs)
+  if (createPrIntent) {
+    return createPrIntent
+  }
+
+  // Why: blocked notices are only for states the preparation intent cannot
+  // safely resolve, such as auth/default-branch/unsafe sync blockers.
   if (canClickBlockedCreateReviewReason(inputs.hostedReviewCreation?.blockedReason)) {
     return resolveDisabledCreatePrHeaderAction(inputs)
   }
 
-  return resolveCreatePrIntentPrimaryAction(inputs) ?? resolveDisabledCreatePrHeaderAction(inputs)
+  return resolveDisabledCreatePrHeaderAction(inputs)
 }


### PR DESCRIPTION
## Summary
- route recoverable Create PR/MR preparation states through the intent action before blocked notices
- keep direct blockers for default branch, auth, conflicts, and unsafe sync conditions
- cover dirty, staged, unpublished, provider-specific, and in-flight states with tests

## Tests
- Not run locally before PR creation

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5884">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->