### PR TITLE
Clarify worktree lineage and handoff rules in skills and CLI help

### DIFF
--- a/config/scripts/orca-cli-skill-guidance.test.mjs
+++ b/config/scripts/orca-cli-skill-guidance.test.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const skillPath = join(projectDir, 'skills', 'orca-cli', 'SKILL.md')
+
+describe('orca CLI skill guidance', () => {
+  it('keeps independent worktree lineage separate from Git base selection', () => {
+    const skill = readFileSync(skillPath, 'utf8')
+
+    expect(skill).toContain('`--no-parent` only controls Orca lineage')
+    expect(skill).toContain('omit `--base-branch` so Orca uses the repo default base')
+    expect(skill).toContain('Never base it on the current feature branch')
+  })
+})

--- a/config/scripts/orchestration-skill-guidance.test.mjs
+++ b/config/scripts/orchestration-skill-guidance.test.mjs
@@ -17,4 +17,20 @@ describe('orchestration skill guidance', () => {
       'If `check --wait` times out with no `worker_done` or `escalation`, fall back to `terminal wait --for tui-idle`, then `terminal read`.'
     )
   })
+
+  it('keeps full handoffs out of dispatch lifecycle and off the active branch base', () => {
+    const skill = readFileSync(skillPath, 'utf8')
+
+    expect(skill).toContain('Full handoff means ownership transfer, not supervised dispatch.')
+    expect(skill).toContain('Do not use `orca orchestration dispatch --inject` for full handoffs')
+    expect(skill).toContain(
+      '`--no-parent` only controls Orca lineage; it does not choose the Git base.'
+    )
+    expect(skill).toContain(
+      'never base it on the current feature branch unless the user explicitly asks'
+    )
+    expect(skill).toContain(
+      'orca worktree create --name <task-name> --no-parent --agent codex --prompt'
+    )
+  })
 })

--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -76,6 +76,7 @@ Lineage rules:
 - Use `--parent-worktree active` when the child worktree relationship should be explicit.
 - Use `--parent-worktree folder:<folderId>` or `--parent-worktree worktree:<worktreeId>` when a folder or worktree parent context should be explicit.
 - Use `--no-parent` only when the new work is independent.
+- `--no-parent` only controls Orca lineage; it does not choose the Git base. For independent top-level work, omit `--base-branch` so Orca uses the repo default base, or explicitly pass the repo default base. Never base it on the current feature branch unless the user asks for stacked work or "branch from current".
 - If `--repo` is omitted, Orca infers the repo from the current Orca worktree when possible.
 
 Agent/setup flags:

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -4,11 +4,11 @@ description: >-
   Use Orca orchestration for structured multi-agent coordination: threaded
   messages, blocking ask/reply flows, task dispatch, worker_done/escalation
   waits, task DAGs, decision gates, coordinator loops, or decomposing work
-  across agents. Use `orca-cli` instead for ordinary terminal control,
-  lightweight terminal prompts, shell commands, Orca worktree management,
-  reading or waiting on terminals, and automation of the browser embedded inside
-  Orca. Use Computer Use for browser windows, webviews, Orca app UI, or desktop
-  UI outside Orca's embedded browser.
+  across agents. Use `orca-cli` instead for full ownership handoffs, ordinary
+  terminal control, lightweight terminal prompts, shell commands, Orca worktree
+  management, reading or waiting on terminals, and automation of the browser
+  embedded inside Orca. Use Computer Use for browser windows, webviews, Orca app
+  UI, or desktop UI outside Orca's embedded browser.
 ---
 
 # Orca Inter-Agent Orchestration
@@ -38,7 +38,8 @@ Orchestration messages and tasks are runtime-global. Completion authority comes 
 Classify inherited context before sending lifecycle messages:
 
 - Coordinated subtask: a live coordinator owns the DAG and waits on this dispatch. Follow the preamble exactly, including `worker_done`, heartbeat/status, `ask`, and `escalation`.
-- Full handoff: the original actor delegated ownership and is not monitoring. Finish in the current session. Create a new coordinator only when the user asks or you deliberately decompose fresh subtasks; if spawning workers, use your current-worktree coordinator handle and a selector such as `--worktree active`.
+- Full handoff means ownership transfer, not supervised dispatch. The original actor is not monitoring a DAG, so do not create lifecycle obligations unless the user explicitly asks you to supervise.
+- Do not use `orca orchestration dispatch --inject` for full handoffs. It injects a coordinator preamble that tells the worker to send `worker_done`, heartbeat, `ask`, and post-completion polling messages back to the original terminal.
 
 If unclear, inspect orchestration state before sending lifecycle messages:
 
@@ -107,6 +108,24 @@ orca orchestration run-stop [--json]
 
 Recovery only: `orca orchestration reset --tasks|--messages|--all --json` clears runtime-global orchestration state. Do not run it during active coordination unless explicitly abandoning that state.
 
+## Full Handoffs
+
+For full ownership transfer, use non-lifecycle terminal/worktree commands and then stop monitoring unless the user asks for supervision.
+
+New top-level worktree handoff:
+
+```bash
+orca worktree create --name <task-name> --no-parent --agent codex --prompt "<task brief>" --json
+```
+
+Existing terminal handoff:
+
+```bash
+orca terminal send --terminal <handle> --text "<task brief>" --enter --json
+```
+
+`--no-parent` only controls Orca lineage; it does not choose the Git base. For an independent top-level worktree, omit `--base-branch` so Orca uses the repo default base, or explicitly pass the repo default base (`origin/main`, `origin/master`, or the `orca repo show --repo <selector> --json` value); never base it on the current feature branch unless the user explicitly asks for stacked work or "branch from current". Put current-branch context in the prompt instead.
+
 ## Worker Terminals
 
 Choose the worker location before creating a terminal. `Fresh worker` means a fresh agent session, not a new git worktree. If the task says current worktree only, depends on uncommitted files/artifacts, or must validate/PR the current branch, create the worker in the active worktree:
@@ -117,7 +136,7 @@ orca terminal wait --terminal <handle> --for tui-idle --timeout-ms 60000 --json
 orca orchestration dispatch --task <task_id> --to <handle> --inject --json
 ```
 
-Reuse an idle agent in the required worktree only if the prompt allows reuse; otherwise create a fresh terminal there. Use a new worktree only when explicitly requested or when independent isolated checkout state is intended:
+Reuse an idle agent in the required worktree only if the prompt allows reuse; otherwise create a fresh terminal there. Use a new worktree only when explicitly requested or when independent isolated checkout state is intended. For supervised new-worktree workers, decide the Git base separately from lineage: `--no-parent` makes the worktree top-level in Orca, while omitted `--base-branch` uses the repo default base.
 
 ```bash
 orca worktree create --name <task-name> --agent codex --json
@@ -128,7 +147,7 @@ orca orchestration dispatch --task <task_id> --to <handle> --inject --json
 
 For new-worktree workers, read the id from `worktree create`, then use `terminal list` to get the agent handle. Omit `--repo` only inside an Orca-managed worktree; otherwise pass `--repo <selector>`. `--agent` reveals the new worktree and launches the selected agent in its first terminal, so do not create a separate startup terminal. Do not run `worktree create` when the task must stay in the current worktree.
 
-Use `orca worktree create --prompt ...` or `orca terminal send ...` only for untracked/lightweight prompts. Those paths do not attach `taskId`/`dispatchId`; the worker should not send lifecycle messages unless the prompt supplies a live orchestration preamble.
+Use `orca worktree create --prompt ...` or `orca terminal send ...` for full handoffs or untracked/lightweight prompts. Those paths do not attach `taskId`/`dispatchId`; the worker should not send lifecycle messages unless the prompt supplies a live orchestration preamble.
 
 Other terminal commands coordinators often need:
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -245,6 +245,9 @@ describe('orca root help', () => {
     expect(createHelp).toContain('folder:<id>')
     expect(createHelp).toContain('folder:<folderId>')
     expect(createHelp).toContain('worktree:<id>')
+    expect(createHelp).toContain(
+      '--no-parent only affects Orca lineage; omit --base-branch to use the repo default base'
+    )
 
     logSpy.mockClear()
     await main(['worktree', 'set', '--help'], '/tmp/repo')

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -129,6 +129,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'Use --project with --host to create on a ready project host setup without spelling the backing repo id.',
       'For related work, use the inferred parent or pass --parent-worktree active, folder:<id>, or worktree:<id> to make the relationship explicit.',
       'Use --no-parent when the new worktree should be independent of the current context.',
+      '--no-parent only affects Orca lineage; omit --base-branch to use the repo default base, or pass the default base ref explicitly for independent top-level work.',
       'By default this creates the worktree and its first terminal without switching the active Orca view.',
       'Pass --agent to launch an agent in the first terminal; --prompt sends initial work to that agent.',
       'Repo-defined setup hooks follow the repository setup policy; pass --setup run to force them.',


### PR DESCRIPTION
## Summary

Clarifies Orca worktree lineage rules and full handoff protocols across skill guides and CLI help text. Specifically:
- Explains that `--no-parent` only controls Orca lineage and does not choose the Git base branch (to target the default base, omit `--base-branch` rather than basing on the current feature branch).
- Defines "full handoff" as ownership transfer rather than supervised dispatch, advising against using `orca orchestration dispatch --inject` for handoffs.
- Documents and illustrates CLI patterns for full handoffs (e.g., `orca worktree create` and `orca terminal send`).
- Updates `worktree create` CLI command specification and corresponding unit tests to align CLI help with these rules.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

*Testing evidence:*
- Added `config/scripts/orca-cli-skill-guidance.test.mjs` verifying lineage separation assertions.
- Updated `config/scripts/orchestration-skill-guidance.test.mjs` to verify full handoff rules.
- Updated CLI tests in `src/cli/index.test.ts` to assert the updated help text.

## AI Review Report

The AI review checked:
1. **Orchestration / Skill guidelines:** Verified the correctness of the handoff and lineage descriptions to ensure clear boundaries between coordinated tasks and full handoffs.
2. **Cross-platform compatibility:** Explicitly verified compatibility for macOS, Linux, and Windows. Path handling in tests uses standard `node:path` modules (`join`, `resolve`). No keyboard shortcuts, platform-specific labels, or execution differences were introduced.

## Security Audit

No security risks were introduced. The modifications are documentation and help-text only:
- Command execution is merely documented/illustrated, not run in production paths.
- Input and path handling in test files use safe, standard library functions.
- No IPC, auth, secrets, or dependency changes.

## Notes

None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5892">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->