### PR TITLE
Show branch-discovered PRs on worktrees with no linked PRs

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -247,6 +247,30 @@ describe('WorktreeCard linked PR display', () => {
     expect(markup).not.toContain('Stale branch PR')
   })
 
+  it('shows branch-discovered GH PR status when the worktree has no linked PR', async () => {
+    settings = { experimentalNewWorktreeCardStyle: true }
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: makeHostedReview({ number: 456, title: 'Branch PR', state: 'open' }),
+        fetchedAt: Date.now(),
+        linkedReviewHintKey: ''
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedPR: null })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('PR checks: Passing')
+    expect(markup).toContain('text-emerald-500/80')
+    expect(markup).not.toContain('Branch')
+  })
+
   it('shows branch-discovered hosted review providers without linked worktree metadata', async () => {
     settings = { experimentalNewWorktreeCardStyle: true }
     hostedReviewCache = {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -409,7 +409,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
     linkedGitLabMR,
     linkedBitbucketPR,
     linkedAzureDevOpsPR,
-    linkedGiteaPR
+    linkedGiteaPR,
+    {
+      reviewHintKey: hostedReviewEntry?.linkedReviewHintKey
+    }
   )
   const issue: IssueInfo | null | undefined = worktree.linkedIssue
     ? issueEntry !== undefined

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
@@ -60,7 +60,23 @@ describe('getWorktreeCardPrDisplay', () => {
     expect(getWorktreeCardPrDisplay(undefined, null)).toBeNull()
   })
 
-  it('ignores cached branch PR details when the worktree is unlinked', () => {
+  it('ignores linked-lookup PR details when the worktree is unlinked', () => {
+    expect(
+      getWorktreeCardPrDisplay(pr, null, null, null, null, null, {
+        reviewHintKey: 'github:123'
+      })
+    ).toBeNull()
+  })
+
+  it('shows branch-discovered GitHub PR details when the worktree is unlinked', () => {
+    expect(
+      getWorktreeCardPrDisplay(pr, null, null, null, null, null, {
+        reviewHintKey: ''
+      })
+    ).toBe(pr)
+  })
+
+  it('treats missing cache hints as unsafe for unlinked GitHub PR details', () => {
     expect(getWorktreeCardPrDisplay(pr, null)).toBeNull()
   })
 

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -21,6 +21,10 @@ export type WorktreeCardPrDisplay =
       status?: HostedReviewInfo['status']
     }
 
+type WorktreeCardPrDisplayOptions = {
+  reviewHintKey?: string
+}
+
 function getLinkedReviewNumber(
   provider: LinkedReviewMetadataProvider,
   links: LinkedReviewNumbers
@@ -60,7 +64,8 @@ export function getWorktreeCardPrDisplay(
   linkedGitLabMR: number | null = null,
   linkedBitbucketPR: number | null = null,
   linkedAzureDevOpsPR: number | null = null,
-  linkedGiteaPR: number | null = null
+  linkedGiteaPR: number | null = null,
+  options: WorktreeCardPrDisplayOptions = {}
 ): WorktreeCardPrDisplay | null {
   const links = {
     linkedPR,
@@ -75,7 +80,12 @@ export function getWorktreeCardPrDisplay(
     }
     const linkedReviewNumber = getLinkedReviewNumber(review.provider, links)
     if (linkedReviewNumber === null) {
-      return review.provider === 'github' || review.provider === 'gitlab' ? null : review
+      if (review.provider !== 'github' && review.provider !== 'gitlab') {
+        return review
+      }
+      // Why: GitHub/GitLab linked lookups can outlive the worktree metadata
+      // that requested them. A neutral branch lookup is safe to show unlinked.
+      return options.reviewHintKey === '' ? review : null
     }
     if (review.number === linkedReviewNumber) {
       return review


### PR DESCRIPTION
## Summary

Show branch-discovered GitHub/GitLab PRs on worktrees that have no linked PR metadata.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the renderer changes for worktree PR display logic. The review confirmed that:
- The logic correctly differentiates between neutral branch lookups (safe to show unlinked) and linked lookups.
- Checked cross-platform compatibility for macOS, Linux, and Windows; because these are platform-agnostic React elements and helper functions, there are no platform-specific shortcuts, labels, paths, or shell behaviors affected.

## Security Audit

The changes are limited to frontend sidebar UI components and cache-checking logic. No input handling, IPC, command execution, or authentication risks were introduced.

## Notes

None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5894">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->