### PR TITLE
Reduce idle remote runtime workspace work

### DIFF
--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRuntimeProjectRefreshScheduler } from './runtime-project-refresh-scheduler'
+
+describe('createRuntimeProjectRefreshScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('coalesces a burst of remote repo events into one refresh', async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000
+    })
+
+    scheduler.request('env-1')
+    scheduler.request('env-1')
+    scheduler.request('env-1')
+
+    await vi.advanceTimersByTimeAsync(99)
+    expect(refresh).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(refresh).toHaveBeenCalledWith('env-1')
+
+    scheduler.stop()
+  })
+
+  it('throttles repeated bursts after the first refresh', async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000
+    })
+
+    scheduler.request('env-1')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    scheduler.request('env-1')
+    scheduler.request('env-1')
+    await vi.advanceTimersByTimeAsync(999)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(refresh).toHaveBeenCalledTimes(2)
+
+    scheduler.stop()
+  })
+
+  it('waits for an in-flight refresh before running a pending follow-up', async () => {
+    let finishRefresh = (): void => {
+      throw new Error('Expected refresh promise resolver to be set')
+    }
+    const refresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRefresh = resolve
+        })
+    )
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000
+    })
+
+    scheduler.request('env-1')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    scheduler.request('env-1')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    finishRefresh()
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(refresh).toHaveBeenCalledTimes(2)
+
+    scheduler.stop()
+  })
+
+  it('clears pending timers on stop', async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined)
+    const scheduler = createRuntimeProjectRefreshScheduler({
+      refresh,
+      debounceMs: 100,
+      minIntervalMs: 1_000
+    })
+
+    scheduler.request('env-1')
+    scheduler.stop()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
@@ -1,0 +1,102 @@
+export type RuntimeProjectRefreshSchedulerDeps = {
+  refresh: (environmentId: string) => Promise<void>
+  debounceMs?: number
+  minIntervalMs?: number
+  now?: () => number
+  onError?: (error: unknown) => void
+}
+
+export type RuntimeProjectRefreshScheduler = {
+  request: (environmentId: string) => void
+  stop: () => void
+}
+
+type RefreshEntry = {
+  inFlight: boolean
+  lastStartedAt: number
+  pending: boolean
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+const DEFAULT_DEBOUNCE_MS = 250
+const DEFAULT_MIN_INTERVAL_MS = 5_000
+
+export function createRuntimeProjectRefreshScheduler(
+  deps: RuntimeProjectRefreshSchedulerDeps
+): RuntimeProjectRefreshScheduler {
+  const debounceMs = deps.debounceMs ?? DEFAULT_DEBOUNCE_MS
+  const minIntervalMs = deps.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS
+  const now = deps.now ?? Date.now
+  const entries = new Map<string, RefreshEntry>()
+  let stopped = false
+
+  const getEntry = (environmentId: string): RefreshEntry => {
+    let entry = entries.get(environmentId)
+    if (!entry) {
+      entry = {
+        inFlight: false,
+        lastStartedAt: 0,
+        pending: false,
+        timer: null
+      }
+      entries.set(environmentId, entry)
+    }
+    return entry
+  }
+
+  const schedule = (environmentId: string, entry: RefreshEntry): void => {
+    if (stopped || entry.inFlight || entry.timer) {
+      return
+    }
+    const elapsed = entry.lastStartedAt > 0 ? now() - entry.lastStartedAt : minIntervalMs
+    const throttleDelay = Math.max(0, minIntervalMs - elapsed)
+    const delay = Math.max(debounceMs, throttleDelay)
+    entry.timer = setTimeout(() => {
+      entry.timer = null
+      void run(environmentId, entry)
+    }, delay)
+  }
+
+  const run = async (environmentId: string, entry: RefreshEntry): Promise<void> => {
+    if (stopped || !entry.pending) {
+      return
+    }
+    entry.pending = false
+    entry.inFlight = true
+    entry.lastStartedAt = now()
+    try {
+      await deps.refresh(environmentId)
+    } catch (error) {
+      deps.onError?.(error)
+    } finally {
+      entry.inFlight = false
+      if (entry.pending) {
+        // Why: runtime repo events can be noisy while a remote server is merely
+        // connected; keep discovery live without letting it drive the renderer.
+        schedule(environmentId, entry)
+      }
+    }
+  }
+
+  const request = (environmentId: string): void => {
+    const trimmedEnvironmentId = environmentId.trim()
+    if (!trimmedEnvironmentId || stopped) {
+      return
+    }
+    const entry = getEntry(trimmedEnvironmentId)
+    entry.pending = true
+    schedule(trimmedEnvironmentId, entry)
+  }
+
+  const stop = (): void => {
+    stopped = true
+    for (const entry of entries.values()) {
+      if (entry.timer) {
+        clearTimeout(entry.timer)
+      }
+    }
+    entries.clear()
+  }
+
+  return { request, stop }
+}

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildRuntimeClientEventEnvironmentKey,
   buildNewWorkspaceShortcutModalData,
+  getNewlyConnectedRuntimeEnvironmentIds,
   openNewWorkspaceFromShortcut,
   resolveBrowserSessionTabTarget,
   resolveZoomTarget
@@ -32,6 +33,23 @@ describe('buildRuntimeClientEventEnvironmentKey', () => {
     expect(buildRuntimeClientEventEnvironmentKey(['env-b', 'env-a', 'env-b'])).toBe(
       buildRuntimeClientEventEnvironmentKey(['env-a', 'env-b'])
     )
+  })
+})
+
+describe('getNewlyConnectedRuntimeEnvironmentIds', () => {
+  it('returns only environments that became connected', () => {
+    expect(getNewlyConnectedRuntimeEnvironmentIds(['env-a'], ['env-a', 'env-b'])).toEqual(['env-b'])
+  })
+
+  it('ignores environments that disconnected or stayed connected', () => {
+    expect(getNewlyConnectedRuntimeEnvironmentIds(['env-a', 'env-b'], ['env-a'])).toEqual([])
+  })
+
+  it('treats every environment as new when none were connected before', () => {
+    expect(getNewlyConnectedRuntimeEnvironmentIds([], ['env-a', 'env-a', 'env-b'])).toEqual([
+      'env-a',
+      'env-b'
+    ])
   })
 })
 

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -5,6 +5,7 @@ import {
   buildRuntimeClientEventEnvironmentKey,
   buildNewWorkspaceShortcutModalData,
   getNewlyConnectedRuntimeEnvironmentIds,
+  getRuntimeProjectRefreshEnvironmentIds,
   openNewWorkspaceFromShortcut,
   resolveBrowserSessionTabTarget,
   resolveZoomTarget
@@ -50,6 +51,30 @@ describe('getNewlyConnectedRuntimeEnvironmentIds', () => {
       'env-a',
       'env-b'
     ])
+  })
+})
+
+describe('getRuntimeProjectRefreshEnvironmentIds', () => {
+  it('refreshes when an already-desired runtime becomes reachable', () => {
+    expect(
+      getRuntimeProjectRefreshEnvironmentIds({
+        previousDesired: ['env-a'],
+        nextDesired: ['env-a'],
+        previousReachable: [],
+        nextReachable: ['env-a']
+      })
+    ).toEqual(['env-a'])
+  })
+
+  it('deduplicates runtimes that are both newly desired and newly reachable', () => {
+    expect(
+      getRuntimeProjectRefreshEnvironmentIds({
+        previousDesired: [],
+        nextDesired: ['env-a'],
+        previousReachable: [],
+        nextReachable: ['env-a']
+      })
+    ).toEqual(['env-a'])
   })
 })
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -717,8 +717,14 @@ export function buildRuntimeClientEventEnvironmentKey(environmentIds: string[]):
   return [...new Set(environmentIds)].sort().join('\u0000')
 }
 
-function getRuntimeClientEventEnvironmentKey(): string {
-  return buildRuntimeClientEventEnvironmentKey(getRuntimeClientEventEnvironmentIds())
+/** Ids in `next` not in `previous` — runtime environments that just became
+ *  connected. Exported to unit-test the on-connect discovery trigger. */
+export function getNewlyConnectedRuntimeEnvironmentIds(
+  previous: readonly string[],
+  next: readonly string[]
+): string[] {
+  const known = new Set(previous)
+  return [...new Set(next)].filter((environmentId) => !known.has(environmentId))
 }
 
 function getWorktreeRuntimeEnvironmentId(worktreeId: string | null | undefined): string | null {
@@ -902,13 +908,32 @@ export function useIpcEvents(): void {
     })
 
     runtimeClientEventsSync.sync()
-    let runtimeClientEventEnvironmentKey = getRuntimeClientEventEnvironmentKey()
+    // Why: PR #2 removed desktop's eager session-sync discovery and there is no
+    // on-connect repo fetch, so remote projects only appeared after the user
+    // opened the Add-Project dropdown. Seed discovery for runtimes already
+    // connected at mount, and for each newly-connected one below. The scheduler
+    // debounces/throttles, so this stays cheap even with chatty status updates.
+    let runtimeClientEventEnvironmentIds = getRuntimeClientEventEnvironmentIds()
+    for (const environmentId of runtimeClientEventEnvironmentIds) {
+      runtimeProjectRefreshScheduler.request(environmentId)
+    }
+    let runtimeClientEventEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
+      runtimeClientEventEnvironmentIds
+    )
     unsubs.push(
       useAppStore.subscribe(() => {
-        const nextKey = getRuntimeClientEventEnvironmentKey()
+        const nextEnvironmentIds = getRuntimeClientEventEnvironmentIds()
+        const nextKey = buildRuntimeClientEventEnvironmentKey(nextEnvironmentIds)
         if (nextKey === runtimeClientEventEnvironmentKey) {
           return
         }
+        for (const environmentId of getNewlyConnectedRuntimeEnvironmentIds(
+          runtimeClientEventEnvironmentIds,
+          nextEnvironmentIds
+        )) {
+          runtimeProjectRefreshScheduler.request(environmentId)
+        }
+        runtimeClientEventEnvironmentIds = nextEnvironmentIds
         runtimeClientEventEnvironmentKey = nextKey
         runtimeClientEventsSync.sync()
       })

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -79,6 +79,7 @@ import {
 } from '@/components/browser-pane/browser-automation-visibility'
 import { attachMobileMarkdownBridge } from '@/runtime/mobile-markdown-bridge'
 import { subscribeRuntimeClientEvents } from '@/runtime/runtime-client-events'
+import { createRuntimeProjectRefreshScheduler } from './runtime-project-refresh-scheduler'
 import { createRuntimeClientEventsSync } from './runtime-client-events-sync'
 import { detectLanguage } from '@/lib/language-detect'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
@@ -856,13 +857,20 @@ export function useIpcEvents(): void {
       await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
     }
 
+    const runtimeProjectRefreshScheduler = createRuntimeProjectRefreshScheduler({
+      refresh: async (environmentId) => {
+        const repos = await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
+        await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
+        await useAppStore.getState().fetchWorktreeLineage()
+      },
+      onError: (error) => {
+        console.error('Failed to refresh runtime projects:', error)
+      }
+    })
+
     const handleRuntimeClientEvent = (environmentId: string, event: RuntimeClientEvent): void => {
       if (event.type === 'reposChanged') {
-        const state = useAppStore.getState()
-        void state.fetchRuntimeEnvironmentRepos(environmentId).then(async (repos) => {
-          await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
-          await useAppStore.getState().fetchWorktreeLineage()
-        })
+        runtimeProjectRefreshScheduler.request(environmentId)
         return
       }
       if (event.type === 'worktreesChanged') {
@@ -906,6 +914,7 @@ export function useIpcEvents(): void {
       })
     )
     unsubs.push(runtimeClientEventsSync.stop)
+    unsubs.push(runtimeProjectRefreshScheduler.stop)
 
     unsubs.push(
       window.api.repos.onChanged(() => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -128,6 +128,7 @@ function getShortcutPlatform(): NodeJS.Platform {
 }
 
 const BROWSER_AUTOMATION_BOOTSTRAP_LEASE_MS = 10_000
+const RUNTIME_PROJECT_REFRESH_CONCURRENCY = 5
 const browserAutomationBootstrapLeaseByPageId = new Map<string, { token: string; timer: number }>()
 
 function isPinnedSessionTab(store: AppState, worktreeId: string, visibleId: string): boolean {
@@ -713,6 +714,17 @@ function getRuntimeClientEventEnvironmentIds(): string[] {
   return [...ids]
 }
 
+function getReachableRuntimeEnvironmentIds(): string[] {
+  const state = useAppStore.getState()
+  const ids: string[] = []
+  for (const [environmentId, status] of state.runtimeStatusByEnvironmentId ?? []) {
+    if (status?.status) {
+      ids.push(environmentId)
+    }
+  }
+  return ids
+}
+
 export function buildRuntimeClientEventEnvironmentKey(environmentIds: string[]): string {
   return [...new Set(environmentIds)].sort().join('\u0000')
 }
@@ -725,6 +737,51 @@ export function getNewlyConnectedRuntimeEnvironmentIds(
 ): string[] {
   const known = new Set(previous)
   return [...new Set(next)].filter((environmentId) => !known.has(environmentId))
+}
+
+export function getRuntimeProjectRefreshEnvironmentIds(args: {
+  previousDesired: readonly string[]
+  nextDesired: readonly string[]
+  previousReachable: readonly string[]
+  nextReachable: readonly string[]
+}): string[] {
+  return [
+    ...new Set([
+      ...getNewlyConnectedRuntimeEnvironmentIds(args.previousDesired, args.nextDesired),
+      ...getNewlyConnectedRuntimeEnvironmentIds(args.previousReachable, args.nextReachable)
+    ])
+  ]
+}
+
+async function refreshRuntimeProjectWorktrees(repos: readonly { id: string }[]): Promise<void> {
+  let nextIndex = 0
+  const failures: { repoId: string; error: unknown }[] = []
+  const workerCount = Math.min(RUNTIME_PROJECT_REFRESH_CONCURRENCY, repos.length)
+
+  // Why: one coalesced remote repo event can still represent many repos; keep the
+  // expensive worktree probes bounded so idle refresh never floods the renderer.
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < repos.length) {
+        const index = nextIndex
+        nextIndex += 1
+        const repoId = repos[index].id
+        try {
+          await useAppStore.getState().fetchWorktrees(repoId)
+        } catch (error) {
+          failures.push({ repoId, error })
+        }
+      }
+    })
+  )
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((failure) => failure.error),
+      `Failed to refresh ${failures.length} runtime project worktree(s): ${failures
+        .map((failure) => failure.repoId)
+        .join(', ')}`
+    )
+  }
 }
 
 function getWorktreeRuntimeEnvironmentId(worktreeId: string | null | undefined): string | null {
@@ -866,7 +923,7 @@ export function useIpcEvents(): void {
     const runtimeProjectRefreshScheduler = createRuntimeProjectRefreshScheduler({
       refresh: async (environmentId) => {
         const repos = await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
-        await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
+        await refreshRuntimeProjectWorktrees(repos)
         await useAppStore.getState().fetchWorktreeLineage()
       },
       onError: (error) => {
@@ -920,21 +977,34 @@ export function useIpcEvents(): void {
     let runtimeClientEventEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
       runtimeClientEventEnvironmentIds
     )
+    let reachableRuntimeEnvironmentIds = getReachableRuntimeEnvironmentIds()
+    let reachableRuntimeEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
+      reachableRuntimeEnvironmentIds
+    )
     unsubs.push(
       useAppStore.subscribe(() => {
         const nextEnvironmentIds = getRuntimeClientEventEnvironmentIds()
         const nextKey = buildRuntimeClientEventEnvironmentKey(nextEnvironmentIds)
-        if (nextKey === runtimeClientEventEnvironmentKey) {
+        const nextReachableEnvironmentIds = getReachableRuntimeEnvironmentIds()
+        const nextReachableKey = buildRuntimeClientEventEnvironmentKey(nextReachableEnvironmentIds)
+        if (
+          nextKey === runtimeClientEventEnvironmentKey &&
+          nextReachableKey === reachableRuntimeEnvironmentKey
+        ) {
           return
         }
-        for (const environmentId of getNewlyConnectedRuntimeEnvironmentIds(
-          runtimeClientEventEnvironmentIds,
-          nextEnvironmentIds
-        )) {
+        for (const environmentId of getRuntimeProjectRefreshEnvironmentIds({
+          previousDesired: runtimeClientEventEnvironmentIds,
+          nextDesired: nextEnvironmentIds,
+          previousReachable: reachableRuntimeEnvironmentIds,
+          nextReachable: nextReachableEnvironmentIds
+        })) {
           runtimeProjectRefreshScheduler.request(environmentId)
         }
         runtimeClientEventEnvironmentIds = nextEnvironmentIds
         runtimeClientEventEnvironmentKey = nextKey
+        reachableRuntimeEnvironmentIds = nextReachableEnvironmentIds
+        reachableRuntimeEnvironmentKey = nextReachableKey
         runtimeClientEventsSync.sync()
       })
     )

--- a/src/renderer/src/lib/worktree-runtime-owner.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getExplicitRuntimeEnvironmentIdForWorktree,
   getExecutionHostIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree,
   getSettingsForWorktreeRuntimeOwner,
   type WorktreeRuntimeOwnerState
 } from './worktree-runtime-owner'
@@ -9,10 +11,12 @@ const state: WorktreeRuntimeOwnerState = {
   settings: { activeRuntimeEnvironmentId: 'focused-env' },
   repos: [
     { id: 'local-repo', connectionId: null, executionHostId: 'local' },
+    { id: 'legacy-repo', connectionId: null, executionHostId: null },
     { id: 'runtime-repo', connectionId: null, executionHostId: 'runtime:owner-env' }
   ],
   worktreesByRepo: {
     'local-repo': [{ id: 'local-repo::wt-a', repoId: 'local-repo' }],
+    'legacy-repo': [{ id: 'legacy-repo::wt-legacy', repoId: 'legacy-repo' }],
     'runtime-repo': [{ id: 'runtime-repo::wt-b', repoId: 'runtime-repo' }]
   },
   projectGroups: [
@@ -54,5 +58,62 @@ describe('getSettingsForWorktreeRuntimeOwner', () => {
       activeRuntimeEnvironmentId: null
     })
     expect(getExecutionHostIdForWorktree(state, 'folder:local-folder')).toBe('local')
+  })
+})
+
+describe('getExplicitRuntimeEnvironmentIdForWorktree', () => {
+  it('does not treat the focused runtime as ownership for legacy-local worktrees', () => {
+    expect(getRuntimeEnvironmentIdForWorktree(state, 'legacy-repo::wt-legacy')).toBe('focused-env')
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(state, 'legacy-repo::wt-legacy')).toBeNull()
+  })
+
+  it('returns the runtime owner when the repo or folder explicitly names one', () => {
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(state, 'runtime-repo::wt-b')).toBe(
+      'owner-env'
+    )
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(state, 'folder:runtime-folder')).toBe(
+      'folder-env'
+    )
+  })
+
+  it('uses a worktree host id before the repo owner', () => {
+    const hostOverrideState: WorktreeRuntimeOwnerState = {
+      ...state,
+      worktreesByRepo: {
+        ...state.worktreesByRepo,
+        'runtime-repo': [
+          { id: 'runtime-repo::wt-local-override', repoId: 'runtime-repo', hostId: 'local' },
+          {
+            id: 'runtime-repo::wt-runtime-override',
+            repoId: 'runtime-repo',
+            hostId: 'runtime:worktree-env'
+          }
+        ]
+      }
+    }
+
+    expect(
+      getExplicitRuntimeEnvironmentIdForWorktree(
+        hostOverrideState,
+        'runtime-repo::wt-local-override'
+      )
+    ).toBeNull()
+    expect(getRuntimeEnvironmentIdForWorktree(hostOverrideState, 'runtime-repo::wt-local-override'))
+      .toBeNull()
+    expect(getExecutionHostIdForWorktree(hostOverrideState, 'runtime-repo::wt-local-override')).toBe(
+      'local'
+    )
+    expect(
+      getExplicitRuntimeEnvironmentIdForWorktree(
+        hostOverrideState,
+        'runtime-repo::wt-runtime-override'
+      )
+    ).toBe('worktree-env')
+    expect(
+      getRuntimeEnvironmentIdForWorktree(hostOverrideState, 'runtime-repo::wt-runtime-override')
+    ).toBe('worktree-env')
+    expect(
+      getExecutionHostIdForWorktree(hostOverrideState, 'runtime-repo::wt-runtime-override')
+    ).toBe('runtime:worktree-env')
   })
 })

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -13,19 +13,19 @@ import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
 export type WorktreeRuntimeOwnerState = {
   repos?: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[]
   settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
-  worktreesByRepo?: Record<string, readonly Pick<Worktree, 'id' | 'repoId'>[]>
+  worktreesByRepo?: Record<string, readonly Pick<Worktree, 'id' | 'repoId' | 'hostId'>[]>
   folderWorkspaces?: readonly Pick<FolderWorkspace, 'id' | 'projectGroupId'>[]
   projectGroups?: readonly Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>[]
 }
 
-function findWorktreeRepoId(
+function findWorktreeRecord(
   worktreesByRepo: WorktreeRuntimeOwnerState['worktreesByRepo'],
   worktreeId: string
-): string | null {
+): Pick<Worktree, 'id' | 'repoId' | 'hostId'> | null {
   for (const worktrees of Object.values(worktreesByRepo ?? {})) {
     const match = worktrees.find((worktree) => worktree.id === worktreeId)
     if (match) {
-      return match.repoId
+      return match
     }
   }
   return null
@@ -59,6 +59,37 @@ function getRuntimeEnvironmentIdForFolderWorkspace(
   return state.settings?.activeRuntimeEnvironmentId?.trim() || null
 }
 
+function getExplicitRuntimeEnvironmentIdFromHost(
+  executionHostId: string | null | undefined
+): string | null {
+  const parsed = parseExecutionHostId(executionHostId)
+  return parsed?.kind === 'runtime' ? parsed.environmentId : null
+}
+
+function getRuntimeEnvironmentIdFromWorktreeHost(
+  hostId: string | null | undefined
+): string | null | undefined {
+  if (!hostId?.trim()) {
+    return undefined
+  }
+  return getExplicitRuntimeEnvironmentIdFromHost(hostId)
+}
+
+function getExecutionHostIdFromWorktreeHost(
+  hostId: string | null | undefined
+): ExecutionHostId | null {
+  return parseExecutionHostId(hostId)?.id ?? null
+}
+
+function getExplicitRuntimeEnvironmentIdForFolderWorkspace(
+  state: WorktreeRuntimeOwnerState,
+  folderWorkspaceId: string
+): string | null {
+  return getExplicitRuntimeEnvironmentIdFromHost(
+    findFolderProjectGroup(state, folderWorkspaceId)?.executionHostId
+  )
+}
+
 function getExecutionHostIdForFolderWorkspace(
   state: WorktreeRuntimeOwnerState,
   folderWorkspaceId: string
@@ -86,8 +117,14 @@ export function getRuntimeEnvironmentIdForWorktree(
   if (workspaceScope?.type === 'folder') {
     return getRuntimeEnvironmentIdForFolderWorkspace(state, workspaceScope.folderWorkspaceId)
   }
-  const repoId =
-    findWorktreeRepoId(state.worktreesByRepo, worktreeId) ?? getRepoIdFromWorktreeId(worktreeId)
+  const worktree = findWorktreeRecord(state.worktreesByRepo, worktreeId)
+  const worktreeRuntimeEnvironmentId = getRuntimeEnvironmentIdFromWorktreeHost(worktree?.hostId)
+  if (worktreeRuntimeEnvironmentId !== undefined) {
+    // Why: the same repo can exist on local and remote hosts; a concrete
+    // worktree host must override the repo-level default owner.
+    return worktreeRuntimeEnvironmentId
+  }
+  const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
   const repo = state.repos?.find((entry) => entry.id === repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
@@ -95,6 +132,34 @@ export function getRuntimeEnvironmentIdForWorktree(
     return parsed?.kind === 'runtime' ? parsed.environmentId : null
   }
   return state.settings?.activeRuntimeEnvironmentId?.trim() || null
+}
+
+export function getExplicitRuntimeEnvironmentIdForWorktree(
+  state: WorktreeRuntimeOwnerState,
+  worktreeId: string | null | undefined
+): string | null {
+  if (!worktreeId) {
+    return null
+  }
+  const workspaceScope = parseWorkspaceKey(worktreeId)
+  if (workspaceScope?.type === 'folder') {
+    return getExplicitRuntimeEnvironmentIdForFolderWorkspace(
+      state,
+      workspaceScope.folderWorkspaceId
+    )
+  }
+  const worktree = findWorktreeRecord(state.worktreesByRepo, worktreeId)
+  if (worktree?.hostId) {
+    return getExplicitRuntimeEnvironmentIdFromHost(worktree.hostId)
+  }
+  const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
+  const repo = state.repos?.find((entry) => entry.id === repoId)
+  if (!repo) {
+    return null
+  }
+  // Why: session mirroring is expensive; a merely focused runtime must not make
+  // legacy/local worktrees look remote-owned.
+  return getExplicitRuntimeEnvironmentIdFromHost(getRepoExecutionHostId(repo))
 }
 
 export function getExecutionHostIdForWorktree(
@@ -108,8 +173,14 @@ export function getExecutionHostIdForWorktree(
   if (workspaceScope?.type === 'folder') {
     return getExecutionHostIdForFolderWorkspace(state, workspaceScope.folderWorkspaceId)
   }
-  const repoId =
-    findWorktreeRepoId(state.worktreesByRepo, worktreeId) ?? getRepoIdFromWorktreeId(worktreeId)
+  const worktree = findWorktreeRecord(state.worktreesByRepo, worktreeId)
+  const worktreeHostId = getExecutionHostIdFromWorktreeHost(worktree?.hostId)
+  if (worktreeHostId) {
+    // Why: per-worktree host ownership is more specific than the repo host
+    // default, especially when local and runtime checkouts share a project.
+    return worktreeHostId
+  }
+  const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
   const repo = state.repos?.find((entry) => entry.id === repoId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -23,6 +23,7 @@ import {
   clearWebSessionTabsTrackingForEnvironment,
   resolveHostSessionTabIdForWebSessionTab,
   resetWebSessionTabsSnapshotFreshnessForTests,
+  shouldSyncAllRuntimeSessionTabs,
   shouldApplyWebSessionTabsSnapshot,
   shouldBootstrapInitialWebRuntimeTerminal,
   shouldRespawnWebRuntimeTerminalAfterWake,
@@ -268,12 +269,12 @@ describe('applyWebSessionTabsSnapshot', () => {
     ).toBe(true)
   })
 
-  it('syncs session tabs for desktop remote runtime clients, not only web clients', () => {
-    vi.stubGlobal('__ORCA_WEB_CLIENT__', false)
-
+  it('syncs active session tabs for desktop remote runtime clients only when the worktree is remote-owned', () => {
     expect(
       shouldSyncRuntimeSessionTabs({
         activeRuntimeEnvironmentId: ENV,
+        activeWorktreeId: WT,
+        activeWorktreeRuntimeEnvironmentId: ENV,
         workspaceSessionReady: true
       })
     ).toBe(true)
@@ -281,14 +282,48 @@ describe('applyWebSessionTabsSnapshot', () => {
       shouldSyncRuntimeSessionTabs({
         activeRuntimeEnvironmentId: ENV,
         activeWorktreeId: WT,
-        workspaceSessionReady: true,
-        requireActiveWorktree: true
+        activeWorktreeRuntimeEnvironmentId: null,
+        workspaceSessionReady: true
       })
-    ).toBe(true)
+    ).toBe(false)
+    expect(
+      shouldSyncRuntimeSessionTabs({
+        activeRuntimeEnvironmentId: ENV,
+        activeWorktreeId: WT,
+        activeWorktreeRuntimeEnvironmentId: 'other-env',
+        workspaceSessionReady: true
+      })
+    ).toBe(false)
+    expect(
+      shouldSyncRuntimeSessionTabs({
+        activeRuntimeEnvironmentId: ENV,
+        activeWorktreeRuntimeEnvironmentId: ENV,
+        workspaceSessionReady: true
+      })
+    ).toBe(false)
     expect(
       shouldSyncRuntimeSessionTabs({
         activeRuntimeEnvironmentId: null,
+        activeWorktreeId: WT,
+        activeWorktreeRuntimeEnvironmentId: ENV,
         workspaceSessionReady: true
+      })
+    ).toBe(false)
+  })
+
+  it('only starts the all-session mirror for paired web clients', () => {
+    expect(
+      shouldSyncAllRuntimeSessionTabs({
+        activeRuntimeEnvironmentId: ENV,
+        workspaceSessionReady: true,
+        isWebClient: true
+      })
+    ).toBe(true)
+    expect(
+      shouldSyncAllRuntimeSessionTabs({
+        activeRuntimeEnvironmentId: ENV,
+        workspaceSessionReady: true,
+        isWebClient: false
       })
     ).toBe(false)
   })

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -269,10 +269,9 @@ describe('applyWebSessionTabsSnapshot', () => {
     ).toBe(true)
   })
 
-  it('syncs active session tabs for desktop remote runtime clients only when the worktree is remote-owned', () => {
+  it('syncs active session tabs for desktop remote runtime clients using the worktree owner', () => {
     expect(
       shouldSyncRuntimeSessionTabs({
-        activeRuntimeEnvironmentId: ENV,
         activeWorktreeId: WT,
         activeWorktreeRuntimeEnvironmentId: ENV,
         workspaceSessionReady: true
@@ -280,7 +279,6 @@ describe('applyWebSessionTabsSnapshot', () => {
     ).toBe(true)
     expect(
       shouldSyncRuntimeSessionTabs({
-        activeRuntimeEnvironmentId: ENV,
         activeWorktreeId: WT,
         activeWorktreeRuntimeEnvironmentId: null,
         workspaceSessionReady: true
@@ -288,25 +286,22 @@ describe('applyWebSessionTabsSnapshot', () => {
     ).toBe(false)
     expect(
       shouldSyncRuntimeSessionTabs({
-        activeRuntimeEnvironmentId: ENV,
         activeWorktreeId: WT,
         activeWorktreeRuntimeEnvironmentId: 'other-env',
         workspaceSessionReady: true
       })
-    ).toBe(false)
+    ).toBe(true)
     expect(
       shouldSyncRuntimeSessionTabs({
-        activeRuntimeEnvironmentId: ENV,
         activeWorktreeRuntimeEnvironmentId: ENV,
         workspaceSessionReady: true
       })
     ).toBe(false)
     expect(
       shouldSyncRuntimeSessionTabs({
-        activeRuntimeEnvironmentId: null,
         activeWorktreeId: WT,
         activeWorktreeRuntimeEnvironmentId: ENV,
-        workspaceSessionReady: true
+        workspaceSessionReady: false
       })
     ).toBe(false)
   })

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -32,6 +32,7 @@ import type { OpenFile } from '../store/slices/editor'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { getRemoteRuntimePtyEnvironmentId, toRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { sanitizeTerminalLayoutPaneTitlesForLabels } from '@/lib/terminal-pane-title-sanitization'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import {
   createWebRuntimeSessionTerminal,
   HOST_TERMINAL_SURFACE_SEPARATOR,
@@ -242,14 +243,24 @@ export function shouldRespawnWebRuntimeTerminalAfterWake(args: {
 export function shouldSyncRuntimeSessionTabs(args: {
   activeRuntimeEnvironmentId: string | null | undefined
   activeWorktreeId?: string | null
+  activeWorktreeRuntimeEnvironmentId?: string | null
   workspaceSessionReady: boolean
-  requireActiveWorktree?: boolean
 }): boolean {
   const environmentId = args.activeRuntimeEnvironmentId?.trim()
   if (!environmentId || !args.workspaceSessionReady) {
     return false
   }
-  return args.requireActiveWorktree === true ? Boolean(args.activeWorktreeId) : true
+  const worktreeEnvironmentId = args.activeWorktreeRuntimeEnvironmentId?.trim()
+  return Boolean(args.activeWorktreeId?.trim() && worktreeEnvironmentId === environmentId)
+}
+
+export function shouldSyncAllRuntimeSessionTabs(args: {
+  activeRuntimeEnvironmentId: string | null | undefined
+  workspaceSessionReady: boolean
+  isWebClient: boolean
+}): boolean {
+  const environmentId = args.activeRuntimeEnvironmentId?.trim()
+  return Boolean(environmentId && args.workspaceSessionReady && args.isWebClient)
 }
 
 export function resetWebSessionTabsSnapshotFreshnessForTests(): void {
@@ -2322,16 +2333,23 @@ export function useWebSessionTabsSync(): void {
   const activeRuntimeEnvironmentId = useAppStore(
     (state) => state.settings?.activeRuntimeEnvironmentId ?? null
   )
+  const activeWorktreeRuntimeEnvironmentId = useAppStore((state) =>
+    getExplicitRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId)
+  )
   const workspaceSessionReady = useAppStore((state) => state.workspaceSessionReady)
+  const isWebClient = (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ === true
 
   useEffect(() => {
     const environmentId = activeRuntimeEnvironmentId?.trim()
     // Why: startup hydration writes browser-local session state; applying the
     // host snapshot before that point gets clobbered and leaves the sidebar stale.
+    // Desktop clients should not mirror every remote session just because a
+    // remote is connected; project discovery runs through separate repo APIs.
     if (
-      !shouldSyncRuntimeSessionTabs({
+      !shouldSyncAllRuntimeSessionTabs({
         activeRuntimeEnvironmentId,
-        workspaceSessionReady
+        workspaceSessionReady,
+        isWebClient
       }) ||
       !environmentId
     ) {
@@ -2439,7 +2457,7 @@ export function useWebSessionTabsSync(): void {
       // stale freshness/mapping entries should not live for the renderer lifetime.
       clearWebSessionTabsTrackingForEnvironment(environmentId)
     }
-  }, [activeRuntimeEnvironmentId, workspaceSessionReady])
+  }, [activeRuntimeEnvironmentId, isWebClient, workspaceSessionReady])
 
   useEffect(() => {
     const environmentId = activeRuntimeEnvironmentId?.trim()
@@ -2447,8 +2465,8 @@ export function useWebSessionTabsSync(): void {
       !shouldSyncRuntimeSessionTabs({
         activeRuntimeEnvironmentId,
         activeWorktreeId,
-        workspaceSessionReady,
-        requireActiveWorktree: true
+        activeWorktreeRuntimeEnvironmentId,
+        workspaceSessionReady
       }) ||
       !environmentId ||
       !activeWorktreeId
@@ -2559,5 +2577,10 @@ export function useWebSessionTabsSync(): void {
       disposed = true
       unsubscribe?.()
     }
-  }, [activeRuntimeEnvironmentId, activeWorktreeId, workspaceSessionReady])
+  }, [
+    activeRuntimeEnvironmentId,
+    activeWorktreeId,
+    activeWorktreeRuntimeEnvironmentId,
+    workspaceSessionReady
+  ])
 }

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -241,17 +241,15 @@ export function shouldRespawnWebRuntimeTerminalAfterWake(args: {
 }
 
 export function shouldSyncRuntimeSessionTabs(args: {
-  activeRuntimeEnvironmentId: string | null | undefined
   activeWorktreeId?: string | null
   activeWorktreeRuntimeEnvironmentId?: string | null
   workspaceSessionReady: boolean
 }): boolean {
-  const environmentId = args.activeRuntimeEnvironmentId?.trim()
+  const environmentId = args.activeWorktreeRuntimeEnvironmentId?.trim()
   if (!environmentId || !args.workspaceSessionReady) {
     return false
   }
-  const worktreeEnvironmentId = args.activeWorktreeRuntimeEnvironmentId?.trim()
-  return Boolean(args.activeWorktreeId?.trim() && worktreeEnvironmentId === environmentId)
+  return Boolean(args.activeWorktreeId?.trim())
 }
 
 export function shouldSyncAllRuntimeSessionTabs(args: {
@@ -2460,10 +2458,9 @@ export function useWebSessionTabsSync(): void {
   }, [activeRuntimeEnvironmentId, isWebClient, workspaceSessionReady])
 
   useEffect(() => {
-    const environmentId = activeRuntimeEnvironmentId?.trim()
+    const environmentId = activeWorktreeRuntimeEnvironmentId?.trim()
     if (
       !shouldSyncRuntimeSessionTabs({
-        activeRuntimeEnvironmentId,
         activeWorktreeId,
         activeWorktreeRuntimeEnvironmentId,
         workspaceSessionReady
@@ -2577,10 +2574,5 @@ export function useWebSessionTabsSync(): void {
       disposed = true
       unsubscribe?.()
     }
-  }, [
-    activeRuntimeEnvironmentId,
-    activeWorktreeId,
-    activeWorktreeRuntimeEnvironmentId,
-    workspaceSessionReady
-  ])
+  }, [activeWorktreeId, activeWorktreeRuntimeEnvironmentId, workspaceSessionReady])
 }

--- a/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
+++ b/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
@@ -133,4 +133,23 @@ describe('Cmd+J lifted creation actions', () => {
     })
     expect(store.getState().tabsByWorktree['wt-1'] ?? []).toEqual([])
   })
+
+  it('keeps desktop terminal creation local when a local worktree overrides a runtime repo owner', async () => {
+    delete pairedWebFlag.__ORCA_WEB_CLIENT__
+    createWebRuntimeSessionTerminalMock.mockResolvedValue(false)
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+    store.setState({
+      repos: [{ ...TEST_REPO, executionHostId: 'runtime:owner-runtime' }],
+      worktreesByRepo: {
+        [TEST_REPO.id]: [makeWorktree({ id: 'wt-1', repoId: TEST_REPO.id, hostId: 'local' })]
+      },
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
+    })
+
+    await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(createWebRuntimeSessionTerminalMock).not.toHaveBeenCalled()
+    expect(store.getState().tabsByWorktree['wt-1'] ?? []).toHaveLength(1)
+  })
 })

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -1507,6 +1507,10 @@ describe('reconnectPersistedTerminals', () => {
     // can pass them as sessionId to the daemon's createOrAttach.
     expect(s.tabsByWorktree[wt1][0].ptyId).toBe('old-pty-1')
     expect(s.tabsByWorktree[wt2][0].ptyId).toBe('old-pty-2')
+    expect(s.ptyIdsByTabId.tab1).toEqual(['old-pty-1'])
+    // Why: inactive worktrees keep a wake hint but must not advertise live PTYs
+    // until the user opens them and connectPanePty performs the actual reattach.
+    expect(s.ptyIdsByTabId.tab2).toEqual([])
     expect(s.pendingReconnectWorktreeIds).toEqual([])
     // No eager spawn — PTY creation deferred to pane mount
     expect((mockApi.pty as Record<string, unknown>).spawn).not.toHaveBeenCalled()

--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -255,6 +255,35 @@ describe('hydrateWorkspaceSession', () => {
     expect(store.getState().worktreeNavHistoryIndex).toBe(0)
   })
 
+  it('restores the active repo main worktree when the session has no active terminal tabs', () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/wt-main'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo1',
+            path: '/wt-main',
+            isMainWorktree: true
+          })
+        ]
+      }
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    })
+
+    expect(store.getState().activeWorktreeId).toBe(worktreeId)
+    expect(store.getState().activeWorkspaceKey).toBe(`worktree:${worktreeId}`)
+    expect(store.getState().worktreeNavHistory).toEqual([worktreeId])
+  })
+
   it('leaves nav history empty when no active worktree is restored', () => {
     const store = createTestStore()
     seedStore(store, { worktreesByRepo: {} })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -40,7 +40,6 @@ import {
   updateGroup
 } from './tab-group-state'
 import {
-  ensurePtyDispatcher,
   restorePtyDataHandlersAfterFailedShutdown,
   unregisterPtyDataHandlers
 } from '@/components/terminal-pane/pty-transport'
@@ -2523,10 +2522,22 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           validWorktreeIds.has(record.worktreeId)
         )
       )
-      const activeWorktreeId =
-        session.activeWorktreeId && validWorktreeIds.has(session.activeWorktreeId)
-          ? session.activeWorktreeId
+      const fallbackActiveWorktreeId =
+        !session.activeWorktreeId && session.activeRepoId && knownRepoIds.has(session.activeRepoId)
+          ? (s.worktreesByRepo[session.activeRepoId]?.find((worktree) => worktree.isMainWorktree)
+              ?.id ??
+            s.worktreesByRepo[session.activeRepoId]?.[0]?.id ??
+            null)
           : null
+      const activeWorktreeId = (() => {
+        if (session.activeWorktreeId && validWorktreeIds.has(session.activeWorktreeId)) {
+          return session.activeWorktreeId
+        }
+        // Why: a workspace with no terminal tabs is still a valid workspace.
+        // Falling back from the active repo prevents the blank landing screen
+        // when session tabs were pruned or never created.
+        return fallbackActiveWorktreeId
+      })()
       const activeWorkspaceKey: WorkspaceKey | null =
         session.activeWorkspaceKey && validWorktreeIds.has(session.activeWorkspaceKey)
           ? session.activeWorkspaceKey
@@ -2745,7 +2756,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       pendingReconnectTabByWorktree,
       pendingReconnectPtyIdByTabId,
       terminalLayoutsByTabId,
-      tabsByWorktree
+      tabsByWorktree,
+      activeWorktreeId
     } = get()
     const ids = pendingReconnectWorktreeIds ?? []
 
@@ -2769,8 +2781,6 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     // The layout's ptyIdsByLeafId (preserved from shutdown) already has per-leaf
     // mappings. For single-pane tabs without leaf mappings, store the tab-level
     // ptyId as a sentinel so connectPanePty knows to reattach.
-    ensurePtyDispatcher()
-
     for (const worktreeId of ids) {
       const tabs = tabsByWorktree[worktreeId] ?? []
       const worktree = Object.values(get().worktreesByRepo)
@@ -2821,6 +2831,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           `[reconnect-terminals] tab=${tabId} tabLevelPtyId=${tabLevelPtyId} supportsDeferredReattach=${supportsDeferredReattach} hasLeafMappings=${hasLeafMappings}`
         )
         if (tabLevelPtyId) {
+          const shouldAdvertiseLivePtys = worktreeId === activeWorktreeId
           set((s) => {
             const next = { ...s.tabsByWorktree }
             if (!next[worktreeId]) {
@@ -2839,10 +2850,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
               : [tabLevelPtyId]
             return {
               tabsByWorktree: next,
-              ptyIdsByTabId: {
-                ...s.ptyIdsByTabId,
-                [tabId]: allPtyIds
-              }
+              ...(shouldAdvertiseLivePtys
+                ? {
+                    // Why: inactive worktrees only need wake hints. Publishing
+                    // their PTYs as live at startup starts global session/status
+                    // machinery before the user opens that workspace.
+                    ptyIdsByTabId: {
+                      ...s.ptyIdsByTabId,
+                      [tabId]: allPtyIds
+                    }
+                  }
+                : {})
             }
           })
         }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -730,7 +730,48 @@ describe('fetchWorktrees', () => {
 
     expect(mockApi.worktrees.listDetected).toHaveBeenCalledWith({ repoId: 'repo-ssh' })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
-    expect(store.getState().worktreesByRepo['repo-ssh']).toEqual([sshWorktree])
+    // Why: SSH worktrees are fetched via local IPC but belong to the SSH host;
+    // they must carry the repo's ssh host id, not the local default.
+    expect(store.getState().worktreesByRepo['repo-ssh']).toEqual([
+      { ...sshWorktree, hostId: 'ssh:ssh-1' }
+    ])
+  })
+
+  it('stamps remote runtime worktrees with the owning repo runtime host', async () => {
+    const store = createTestStore()
+    // Why: a remote runtime returns its worktrees from its own perspective, so
+    // their hostId arrives as the default "local" even though they live remotely.
+    const remote = makeWorktree({
+      id: 'repo-remote::/remote/wt1',
+      repoId: 'repo-remote',
+      path: '/remote/wt1',
+      branch: 'refs/heads/remote',
+      hostId: 'local'
+    })
+    store.setState({
+      repos: [
+        {
+          id: 'repo-remote',
+          path: '/home/dvic/src/omarchy-dotfiles',
+          displayName: 'omarchy-dotfiles',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'runtime:env-1'
+        }
+      ]
+    } as Partial<AppState>)
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: makeDetectedResult('repo-remote', [remote]),
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+
+    await store.getState().fetchWorktrees('repo-remote')
+
+    expect(store.getState().worktreesByRepo['repo-remote']).toEqual([
+      { ...remote, hostId: 'runtime:env-1' }
+    ])
   })
 
   it('falls back to legacy remote worktree.list when detectedList is unavailable', async () => {
@@ -1140,6 +1181,50 @@ describe('worktree lineage state', () => {
     expect(store.getState().worktreeLineageById).toEqual({ [lineage.worktreeId]: lineage })
     expect(store.getState().worktreesByRepo.repo1?.[0]).toEqual(updatedChild)
     expect(store.getState().sortEpoch).toBe(4)
+  })
+
+  it('stamps the owning runtime host onto worktrees returned by a remote lineage update', async () => {
+    const store = createTestStore()
+    const lineage = makeLineage({
+      worktreeId: 'repo-remote::/remote/child',
+      parentWorktreeId: 'repo-remote::/remote/parent'
+    })
+    const child = makeWorktree({
+      id: lineage.worktreeId,
+      repoId: 'repo-remote',
+      path: '/remote/child'
+    })
+    // Why: the remote returns the updated worktree from its own perspective, so
+    // it arrives with the default local host even though the repo is remote.
+    const updatedChild = { ...child, hostId: 'local' as const, lineage }
+    store.setState({
+      repos: [
+        {
+          id: 'repo-remote',
+          path: '/home/dvic/src/omarchy-dotfiles',
+          displayName: 'omarchy-dotfiles',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'runtime:env-1'
+        }
+      ],
+      worktreesByRepo: { 'repo-remote': [child] }
+    } as Partial<AppState>)
+    runtimeEnvironmentCall.mockResolvedValueOnce({
+      id: 'rpc-remote-lineage',
+      ok: true,
+      result: { worktree: updatedChild },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+
+    await store.getState().updateWorktreeLineage(lineage.worktreeId, {
+      parentWorktreeId: lineage.parentWorktreeId
+    })
+
+    expect(store.getState().worktreesByRepo['repo-remote']?.[0]).toEqual({
+      ...updatedChild,
+      hostId: 'runtime:env-1'
+    })
   })
 
   it('assigns a parent through the active remote runtime environment and rethrows failures', async () => {
@@ -1612,6 +1697,46 @@ describe('createWorktree base status merge', () => {
       linkedLinearIssue: 'ENG-123',
       workspaceStatus: 'in-review',
       pendingFirstAgentMessageRename: true
+    })
+  })
+
+  it('stamps the owning runtime host onto worktrees created on a remote runtime', async () => {
+    const store = createTestStore()
+    const created = makeWorktree({
+      id: 'repo-remote::/remote/feature',
+      repoId: 'repo-remote',
+      path: '/remote/feature',
+      // Why: the remote creates the worktree and reports it from its own
+      // perspective, so it comes back with the default local host.
+      hostId: 'local'
+    })
+    store.setState({
+      repos: [
+        {
+          id: 'repo-remote',
+          path: '/home/dvic/src/omarchy-dotfiles',
+          displayName: 'omarchy-dotfiles',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'runtime:env-1'
+        }
+      ]
+    } as Partial<AppState>)
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) =>
+      Promise.resolve({
+        id: 'rpc-remote-create',
+        ok: true,
+        result: method === 'worktree.create' ? { worktree: created } : null,
+        _meta: { runtimeId: 'runtime-remote' }
+      })
+    )
+
+    await store.getState().createWorktree('repo-remote', 'feature', 'origin/main')
+
+    expect(mockApi.worktrees.create).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo['repo-remote']?.[0]).toEqual({
+      ...created,
+      hostId: 'runtime:env-1'
     })
   })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -44,6 +44,7 @@ import { translate } from '@/i18n/i18n'
 import {
   getRepoExecutionHostId,
   getSettingsFocusedExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
@@ -345,8 +346,31 @@ function toVisibleWorktree(worktree: DetectedWorktreeListResult['worktrees'][num
   return base
 }
 
-function toVisibleWorktrees(result: DetectedWorktreeListResult): Worktree[] {
-  return result.worktrees.filter((worktree) => worktree.visible).map(toVisibleWorktree)
+// Why: runtime worktree payloads arrive from the owning host's own perspective,
+// so their hostId defaults to "local" even for remote checkouts. Re-stamp them
+// with the repo's execution host so per-worktree host resolution doesn't route
+// remote terminals to the local machine. Local-owned repos are left untouched,
+// so an explicit local worktree still overrides a runtime repo owner.
+function withRepoHostId<T extends { hostId?: ExecutionHostId }>(
+  worktree: T,
+  hostId: ExecutionHostId
+): T {
+  return hostId === LOCAL_EXECUTION_HOST_ID ? worktree : { ...worktree, hostId }
+}
+
+function repoHostId(state: Pick<AppState, 'repos'>, repoId: string): ExecutionHostId {
+  const repo = state.repos.find((entry) => entry.id === repoId)
+  return repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+}
+
+function toVisibleWorktrees(
+  result: DetectedWorktreeListResult,
+  hostId: ExecutionHostId
+): Worktree[] {
+  return result.worktrees
+    .filter((worktree) => worktree.visible)
+    .map(toVisibleWorktree)
+    .map((worktree) => withRepoHostId(worktree, hostId))
 }
 
 function getHydratedSessionWorktreeIdsForRepo(state: AppState, repoId: string): string[] {
@@ -814,7 +838,13 @@ function applyWorktreeLineageUpdate(
       worktreesByRepo:
         result.target.kind === 'local' || !result.updatedRemoteWorktree
           ? s.worktreesByRepo
-          : replaceWorktreeInRepoLists(s.worktreesByRepo, result.updatedRemoteWorktree),
+          : replaceWorktreeInRepoLists(
+              s.worktreesByRepo,
+              withRepoHostId(
+                result.updatedRemoteWorktree,
+                repoHostId(s, getRepoIdFromWorktreeId(result.updatedRemoteWorktree.id))
+              )
+            ),
       sortEpoch: s.sortEpoch + 1
     }
   })
@@ -1422,7 +1452,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       if (options?.requireAuthoritative && !detected.authoritative) {
         return false
       }
-      const worktrees = toVisibleWorktrees(detected)
+      const worktrees = toVisibleWorktrees(detected, repoHostId(get(), repoId))
       const current = get().worktreesByRepo[repoId]
       if (areWorktreesEqual(current, worktrees)) {
         set((s) => {
@@ -1515,7 +1545,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             settingsForRepoOwner(get(), r.id),
             r.id
           )
-          const list = toVisibleWorktrees(detected)
+          const list = toVisibleWorktrees(detected, repoHostId(get(), r.id))
           const current = get().worktreesByRepo[r.id]
           if (
             !areWorktreesEqual(current, list) &&
@@ -1850,15 +1880,16 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           // then produces a duplicate entry in worktreesByRepo, which gives
           // React duplicate keys and can corrupt terminal DOM containers.
           set((s) => {
+            const createdWorktree = withRepoHostId(result.worktree, repoHostId(s, repoId))
             const current = s.worktreesByRepo[repoId] ?? []
-            const alreadyPresent = current.some((w) => w.id === result.worktree.id)
+            const alreadyPresent = current.some((w) => w.id === createdWorktree.id)
             const nextWorktrees = alreadyPresent
               ? current.map((worktree) =>
-                  worktree.id === result.worktree.id
-                    ? { ...worktree, ...result.worktree }
+                  worktree.id === createdWorktree.id
+                    ? { ...worktree, ...createdWorktree }
                     : worktree
                 )
-              : [...current, result.worktree]
+              : [...current, createdWorktree]
             return {
               worktreesByRepo: {
                 ...s.worktreesByRepo,


### PR DESCRIPTION
## Summary

Found this while digging into #4527 (slow scroll/typing). It's not a direct fix for that, but a connected-but-idle remote/SSH runtime turned out to be doing a surprising amount of background work, which was a big part of why things felt bad on my setup. This trims it down.

What was going on:

- `reposChanged` events from a connected runtime kept re-triggering repo/worktree/lineage fetches.
- Desktop mirrored *all* remote session tabs just for being connected, keeping PTY machinery warm for sessions nobody had open.
- A repo-level runtime owner could make local worktrees look remote-owned once you focused a runtime.

What I changed:

- Coalesce the noisy runtime repo events before refreshing project state (connected remotes still show up immediately).
- Desktop only syncs session tabs for the active worktree of that runtime; full all-session mirroring stays web-only.
- Worktree host ownership wins over the repo-level runtime default when routing terminals/sessions.
- Restore a repo's main worktree when no active tab was stored, and treat inactive PTY ids as wake hints instead of advertising them as live.

For reference, on my setup an idle 5s window went from ~150 store writes (plus a pile of repo/worktree/lineage fetches) down to 0, and renderer CPU dropped from a ~116% spike to low single digits.

## Follow-up fixes

While test-driving I hit two regressions caused by the changes above and fixed them in follow-up commits — both renderer-only, both with tests:

1. **Remote/SSH worktrees were routing to the local machine.** Once worktree host ownership started winning, remote worktrees broke: they come back from the owning host with `hostId: "local"`, so that bogus `"local"` overrode the repo's real runtime owner and a remote worktree opened a shell on the *local* box. Fix: re-stamp every runtime worktree with its repo's execution host (`withRepoHostId`) at all the ingress points (fetch/create/reparent). Local-owned repos are left alone, so an explicit local worktree still wins.

2. **Remote projects stopped auto-appearing.** Making all-session mirroring web-only removed the desktop path that eagerly populated remote projects, and nothing fetched them on connect — so they only showed up after opening the Add-Project dropdown. Fix: kick off a repo/worktree/lineage refresh for each runtime that's already connected when `useIpcEvents` mounts, and for each one that connects later.

## Screenshots

No visual change.

## Testing

- `typecheck` ✅
- Focused renderer suites green (worktree host stamping, session-tab sync, idle refresh coalescing, terminal hydration, auto-discover-on-connect).
- `lint` trips on pre-existing localization-catalog drift in `status-bar/tooltip.tsx`, which I didn't touch.

Still being test-driven on a real remote/SSH setup before it comes out of draft.

## Security

No new IPC channels, deps, auth, or filesystem surface — this only narrows *when* renderer events trigger refresh work. Host/runtime selection still uses existing store data.

## Notes

Came out of #4527. Again, not a direct scroll fix — just removing idle runtime/session work that made typing and scrolling feel bad for me.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5895">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
