### PR TITLE
Temporarily disable Windows golden E2E CI

### DIFF
--- a/.github/workflows/golden-e2e-experiment.yml
+++ b/.github/workflows/golden-e2e-experiment.yml
@@ -33,8 +33,10 @@ jobs:
             platform: linux
           - os: macos-15
             platform: mac
-          - os: windows-latest
-            platform: windows
+          # Why: Windows golden E2E is temporarily disabled on CI while its
+          # flaky runner-only failures are investigated.
+          # - os: windows-latest
+          #   platform: windows
 
     steps:
       - name: Checkout
@@ -83,15 +85,6 @@ jobs:
         run: |
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
           env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
-
-      - name: Run golden E2E tests on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $env:SKIP_BUILD = '1'
-          $env:ORCA_E2E_FORWARD_APP_LOGS = '1'
-          pnpm run test:e2e -- tests/e2e/golden-core-flows.spec.ts
-          pnpm run test:e2e:terminal-rendering-golden
 
       - name: Upload Playwright traces
         if: failure()

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -555,8 +555,10 @@ jobs:
             platform: linux
           - os: macos-15
             platform: mac
-          - os: windows-latest
-            platform: windows
+          # Why: Windows terminal rendering golden is temporarily disabled on
+          # CI while its flaky runner-only failures are investigated.
+          # - os: windows-latest
+          #   platform: windows
 
     steps:
       - name: Checkout
@@ -599,14 +601,6 @@ jobs:
       - name: Run terminal rendering golden on macOS
         if: runner.os == 'macOS'
         run: env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden
-
-      - name: Run terminal rendering golden on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $env:SKIP_BUILD = '1'
-          $env:ORCA_E2E_FORWARD_APP_LOGS = '1'
-          pnpm run test:e2e:terminal-rendering-golden
 
       - name: Upload Playwright traces
         if: failure()


### PR DESCRIPTION
## Summary
- temporarily remove Windows from the golden E2E experiment matrix
- temporarily remove Windows from the release terminal-rendering golden matrix
- leave comments marking the disable as temporary while runner-only flakes are investigated

## Validation
- ruby YAML parse for updated workflows
- git diff --check

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5897">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->