### PR TITLE
Disable Windows rendering release evidence

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -630,8 +630,10 @@ jobs:
             platform: linux
           - os: macos-15
             platform: mac
-          - os: windows-latest
-            platform: windows
+          # Why: Windows release evidence currently fails on CI runner PTY
+          # readiness before reaching the rendering assertions.
+          # - os: windows-latest
+          #   platform: windows
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- temporarily remove the Windows matrix entry from terminal rendering release evidence
- keep Linux and macOS release evidence running

## Context
- linked release run: https://github.com/stablyai/orca/actions/runs/27857966648/job/82448841952
- the failing Windows job timed out waiting for the PTY readiness marker before reaching rendering assertions
- publish-release succeeded, but the diagnostic Windows evidence failure left the release workflow red

## Validation
- parsed .github/workflows/release-cut.yml with the repo yaml dependency

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5898">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->