### PR TITLE
Keep mobile-controlled browser panes paintable and park idle hidden panes

### DIFF
--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -223,9 +223,21 @@ describe('Electron runtime package contract', () => {
       readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
     )
     const steps = goldenWorkflow.jobs['golden-e2e'].steps
-    const linuxRunStep = steps.find((step) => step.name === 'Run golden E2E tests on Linux')
-    const macRunStep = steps.find((step) => step.name === 'Run golden E2E tests on macOS')
-    const windowsRunStep = steps.find((step) => step.name === 'Run golden E2E tests on Windows')
+    const goldenPlatformLabels = new Map([
+      ['linux', 'Linux'],
+      ['mac', 'macOS'],
+      ['windows', 'Windows']
+    ])
+    const goldenPlatforms = goldenWorkflow.jobs['golden-e2e'].strategy.matrix.include
+      .map(({ platform }) => platform)
+      .sort()
+    const goldenRunSteps = goldenPlatforms.map((platform) => {
+      const label = goldenPlatformLabels.get(platform)
+
+      expect(label, platform).toBeDefined()
+
+      return steps.find((step) => step.name === `Run golden E2E tests on ${label}`)
+    })
     const pullRequestPaths = goldenWorkflow.on.pull_request.paths
     const releaseGoldenJob = releaseWorkflow.jobs['terminal-rendering-golden']
     const releaseEvidenceJob = releaseWorkflow.jobs['terminal-rendering-release-evidence']
@@ -247,8 +259,8 @@ describe('Electron runtime package contract', () => {
     expect(packageScripts['test:e2e:terminal-rendering-release-evidence']).toContain(
       'terminal-long-table-scroll-restore.spec.ts'
     )
-    for (const runStep of [linuxRunStep, macRunStep, windowsRunStep]) {
-      expect(runStep.run).toContain('pnpm run test:e2e:terminal-rendering-golden')
+    for (const runStep of goldenRunSteps) {
+      expect(runStep?.run).toContain('pnpm run test:e2e:terminal-rendering-golden')
     }
     expect(pullRequestPaths).toContain('tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts')
     expect(pullRequestPaths).toContain('tests/e2e/fixtures/terminal-emoji-table.md')
@@ -260,7 +272,7 @@ describe('Electron runtime package contract', () => {
     expect(publishReleaseNeeds).not.toContain('terminal-rendering-release-evidence')
     expect(releaseGoldenJob['continue-on-error']).toBeUndefined()
     expect(releaseGoldenJob.strategy.matrix.include.map(({ platform }) => platform).sort()).toEqual(
-      ['linux', 'mac', 'windows']
+      goldenPlatforms
     )
     expect(releaseGoldenJob.steps.map((step) => step.run ?? '')).toContain(
       'xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:terminal-rendering-golden'

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -41,6 +41,7 @@ import BrowserPane from './browser-pane/BrowserPane'
 import BrowserPaneOverlayLayer from './browser-pane/BrowserPaneOverlayLayer'
 import EmulatorPaneOverlayLayer from './emulator-pane/EmulatorPaneOverlayLayer'
 import { useBrowserAutomationVisibilityForAny } from './browser-pane/browser-automation-visibility'
+import { useBrowserMobileDriverForAny } from '@/lib/pane-manager/browser-mobile-driver-state'
 import TerminalPaneOverlayLayer from './terminal-pane/TerminalPaneOverlayLayer'
 import {
   collectBrowserWebviewIds,
@@ -2095,7 +2096,9 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
     )
   )
   const hasAutomationVisibleBrowser = useBrowserAutomationVisibilityForAny(browserPageIds)
-  const shouldKeepPaintable = shouldMeasureHiddenWorktree || hasAutomationVisibleBrowser
+  const hasMobileDrivenBrowser = useBrowserMobileDriverForAny(browserPageIds)
+  const shouldKeepPaintable =
+    shouldMeasureHiddenWorktree || hasAutomationVisibleBrowser || hasMobileDrivenBrowser
 
   return (
     <div
@@ -2106,8 +2109,8 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
             ? 'absolute inset-0 flex opacity-0 pointer-events-none'
             : 'absolute inset-0 hidden'
       }
-      // Why: automation-visible panes must stay paintable for webviews, but
-      // invisible controls cannot remain reachable by Tab or assistive tech.
+      // Why: automation and mobile control need paintable webviews, but hidden
+      // worktree controls cannot remain reachable by Tab or assistive tech.
       inert={!isVisible}
       aria-hidden={!isVisible}
     >

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -164,11 +164,13 @@ import {
 import {
   getDriverForBrowserPage,
   onBrowserDriverChange,
+  useBrowserMobileDrivenPageIds,
   type BrowserDriverState
 } from '@/lib/pane-manager/browser-mobile-driver-state'
 import { shouldPollChromiumErrorPage } from './chromium-error-page-polling'
 import { useContextualTour } from '@/components/contextual-tours/use-contextual-tour'
 import { translate } from '@/i18n/i18n'
+import { isBrowserPagePanePaintable } from './browser-page-paintability'
 
 type BrowserTabPageState = Partial<
   Pick<
@@ -767,6 +769,7 @@ export default function BrowserPane({
   const activeBrowserPageId = activeBrowserPage?.id ?? null
   const browserPageIds = useMemo(() => browserPages.map((page) => page.id), [browserPages])
   const automationVisiblePageIds = useBrowserAutomationVisiblePageIds(browserPageIds)
+  const mobileDrivenPageIds = useBrowserMobileDrivenPageIds(browserPageIds)
   // Why: inactive Electron webviews must stay mounted in their original DOM
   // parent. Parking them by unmounting/reparenting loses form text and SPA
   // state on normal tab switches.
@@ -843,6 +846,7 @@ export default function BrowserPane({
               sessionProfileId={browserTab.sessionProfileId ?? null}
               isActive={isActive && page.id === activeBrowserPage?.id}
               isAutomationVisible={automationVisiblePageIds.has(page.id)}
+              isMobileDriven={mobileDrivenPageIds.has(page.id)}
               inputLocked={activeBrowserDriver.kind === 'mobile'}
               onUpdatePageState={updateBrowserPageState}
               onSetUrl={setBrowserPageUrl}
@@ -2621,6 +2625,7 @@ function BrowserPagePane({
   sessionProfileId,
   isActive,
   isAutomationVisible,
+  isMobileDriven,
   inputLocked,
   onUpdatePageState,
   onSetUrl
@@ -2631,11 +2636,16 @@ function BrowserPagePane({
   sessionProfileId: string | null
   isActive: boolean
   isAutomationVisible: boolean
+  isMobileDriven: boolean
   inputLocked: boolean
   onUpdatePageState: (tabId: string, updates: BrowserTabPageState) => void
   onSetUrl: (tabId: string, url: string) => void
 }): React.JSX.Element {
-  const isPaintable = isActive || isAutomationVisible
+  const isPaintable = isBrowserPagePanePaintable({
+    isActive,
+    isAutomationVisible,
+    isMobileDriven
+  })
   const containerRef = useRef<HTMLDivElement | null>(null)
   const grabToastTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const annotationCopyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
@@ -4561,8 +4571,8 @@ function BrowserPagePane({
             ? 'pointer-events-none z-0 opacity-0'
             : 'pointer-events-none hidden'
       )}
-      // Why: automation-visible webviews must remain mounted and paintable, but
-      // their hidden toolbar and guest content cannot stay keyboard-focusable.
+      // Why: automation-visible and mobile-driven webviews must stay paintable,
+      // but hidden toolbar and guest content cannot stay keyboard-focusable.
       inert={!isActive}
       aria-hidden={!isActive}
     >

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
@@ -12,6 +12,7 @@ type MockAppState = {
 const mocks = vi.hoisted(() => ({
   state: null as MockAppState | null,
   automationVisiblePageIds: new Set<string>(),
+  mobileDrivenPageIds: new Set<string>(),
   focusGroup: vi.fn()
 }))
 
@@ -29,6 +30,11 @@ vi.mock('./browser-automation-visibility', () => ({
     pageIds.some((pageId) => mocks.automationVisiblePageIds.has(pageId))
 }))
 
+vi.mock('@/lib/pane-manager/browser-mobile-driver-state', () => ({
+  useBrowserMobileDriverForAny: (pageIds: readonly string[]) =>
+    pageIds.some((pageId) => mocks.mobileDrivenPageIds.has(pageId))
+}))
+
 vi.mock('./BrowserPane', () => ({
   default: ({ browserTab, isActive }: { browserTab: BrowserTabState; isActive: boolean }) => (
     <span
@@ -43,6 +49,7 @@ import BrowserPaneOverlayLayer from './BrowserPaneOverlayLayer'
 describe('BrowserPaneOverlayLayer', () => {
   beforeEach(() => {
     mocks.automationVisiblePageIds.clear()
+    mocks.mobileDrivenPageIds.clear()
     mocks.focusGroup.mockClear()
     mocks.state = createState()
   })
@@ -66,12 +73,31 @@ describe('BrowserPaneOverlayLayer', () => {
     expect(markup).toContain('data-browser-pane-active="false"')
   })
 
-  it('keeps the selected browser pane mounted but inactive when its worktree is not visible', () => {
+  it('parks browser panes when their worktree is hidden', () => {
     const markup = renderOverlay({ isWorktreeActive: false })
 
-    expect(markup).toContain('data-browser-pane-id="browser-a"')
-    expect(markup).toContain('data-browser-pane-active="false"')
+    expect(markup).not.toContain('data-browser-pane-id="browser-a"')
+    expect(markup).not.toContain('data-browser-pane-id="browser-b"')
+  })
+
+  it('keeps an automation-visible hidden browser pane mounted', () => {
+    mocks.automationVisiblePageIds.add('page-b')
+
+    const markup = renderOverlay({ isWorktreeActive: false })
+
+    expect(markup).not.toContain('data-browser-pane-id="browser-a"')
     expect(markup).toContain('data-browser-pane-id="browser-b"')
+    expect(markup).toContain('data-browser-pane-active="false"')
+  })
+
+  it('keeps a mobile-controlled hidden browser pane mounted', () => {
+    mocks.mobileDrivenPageIds.add('page-b')
+
+    const markup = renderOverlay({ isWorktreeActive: false })
+
+    expect(markup).not.toContain('data-browser-pane-id="browser-a"')
+    expect(markup).toContain('data-browser-pane-id="browser-b"')
+    expect(markup).toContain('data-browser-pane-active="false"')
   })
 })
 

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -5,6 +5,7 @@ import type { BrowserTab as BrowserTabState, Tab, TabGroup } from '../../../../s
 import BrowserPane from './BrowserPane'
 import { tabGroupBodyAnchorName } from '../tab-group/tab-group-body-anchor'
 import { useBrowserAutomationVisibilityForAny } from './browser-automation-visibility'
+import { useBrowserMobileDriverForAny } from '@/lib/pane-manager/browser-mobile-driver-state'
 
 // Why: Electron `<webview>` destroys its guest contents whenever its DOM
 // parent changes. Rendering paintable BrowserPanes at the worktree level
@@ -38,27 +39,31 @@ type BrowserOverlaySlotProps = {
   // `activeGroupIdByWorktree` stale. The overlay slot re-implements that
   // focus sync directly, targeting the owning group.
   onFocusOwningGroup: ((groupId: string) => void) | undefined
+  isWorktreeActive: boolean
 }
 
 // Why: each overlay slot is memoized so its BrowserPane subtree only re-renders
-// when its own `browserTab`, `groupId`, or `isActive` changes. Without this,
-// any unrelated worktree mutation (terminal keystrokes, editor updates, etc.)
-// that re-renders the parent overlay layer would cascade into every
-// BrowserPane — defeating the "never reparent/reload the webview" goal of
-// this layer by constantly re-running props diffing on heavy subtrees.
+// when its own assignment, active state, or worktree visibility changes.
+// Without this, unrelated worktree mutations (terminal keystrokes, editor
+// updates, etc.) would cascade into every BrowserPane.
 const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   browserTab,
   groupId,
   isActive,
-  onFocusOwningGroup
+  onFocusOwningGroup,
+  isWorktreeActive
 }: BrowserOverlaySlotProps): React.JSX.Element {
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
-  const automationVisible = useBrowserAutomationVisibilityForAny(
+  const browserPageIds =
     browserTab.pageIds && browserTab.pageIds.length > 0
       ? browserTab.pageIds
       : [browserTab.activePageId ?? browserTab.id]
-  )
-  const isPaintable = isActive || automationVisible
+  const automationVisible = useBrowserAutomationVisibilityForAny(browserPageIds)
+  const mobileDriven = useBrowserMobileDriverForAny(browserPageIds)
+  const isPaintable = isActive || automationVisible || mobileDriven
+  // Why: hidden worktrees keep lightweight overlay slots mounted, but their
+  // Electron webviews must park unless a remote controller needs the guest.
+  const shouldMountPane = isWorktreeActive || automationVisible || mobileDriven
   // Why: each overlay pins itself to the owning TabGroupPanel's body via CSS
   // anchor positioning. `anchor()` resolves top/left relative to the viewport,
   // and the overlay's own `position: absolute` inside a positioned ancestor
@@ -108,9 +113,9 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
       onFocusCapture={handleFocus}
     >
       {/* Why: moving an Electron webview between DOM parents destroys the guest
-          document in some Electron builds. Keep every open browser mounted in
-          its stable overlay slot; CSS decides whether it is paintable. */}
-      <BrowserPane browserTab={browserTab} isActive={isActive} />
+          document in some Electron builds. Visible worktree browsers stay in
+          stable overlay slots; hidden worktrees park the heavy pane subtree. */}
+      {shouldMountPane ? <BrowserPane browserTab={browserTab} isActive={isActive} /> : null}
     </div>
   )
 })
@@ -192,6 +197,7 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
             groupId={assignment?.groupId}
             isActive={isActive}
             onFocusOwningGroup={focusOwningGroup}
+            isWorktreeActive={isWorktreeActive}
           />
         )
       })}

--- a/src/renderer/src/components/browser-pane/browser-page-paintability.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-paintability.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isBrowserPagePanePaintable } from './browser-page-paintability'
+
+describe('isBrowserPagePanePaintable', () => {
+  it.each([
+    { isActive: true, isAutomationVisible: false, isMobileDriven: false },
+    { isActive: false, isAutomationVisible: true, isMobileDriven: false },
+    { isActive: false, isAutomationVisible: false, isMobileDriven: true }
+  ])('keeps the pane paintable for active, automation, and mobile control', (state) => {
+    expect(isBrowserPagePanePaintable(state)).toBe(true)
+  })
+
+  it('parks an inactive pane with no remote controller', () => {
+    expect(
+      isBrowserPagePanePaintable({
+        isActive: false,
+        isAutomationVisible: false,
+        isMobileDriven: false
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-page-paintability.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-paintability.ts
@@ -1,0 +1,13 @@
+export type BrowserPagePaintabilityState = {
+  isActive: boolean
+  isAutomationVisible: boolean
+  isMobileDriven: boolean
+}
+
+export function isBrowserPagePanePaintable({
+  isActive,
+  isAutomationVisible,
+  isMobileDriven
+}: BrowserPagePaintabilityState): boolean {
+  return isActive || isAutomationVisible || isMobileDriven
+}

--- a/src/renderer/src/lib/pane-manager/browser-mobile-driver-state.test.ts
+++ b/src/renderer/src/lib/pane-manager/browser-mobile-driver-state.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getBrowserMobileDrivenPageIds,
+  getDriverForBrowserPage,
+  hasMobileDriverForAnyBrowserPage,
+  hydrateBrowserDrivers,
+  isBrowserPageMobileDriven,
+  onBrowserDriverChange,
+  setDriverForBrowserPage
+} from './browser-mobile-driver-state'
+
+afterEach(() => {
+  hydrateBrowserDrivers([])
+})
+
+describe('browser-mobile-driver-state', () => {
+  it('stores and clears driver state keyed by browser page id', () => {
+    setDriverForBrowserPage('page-1', { kind: 'mobile', clientId: 'phone-1' })
+    setDriverForBrowserPage('page-2', { kind: 'desktop' })
+
+    expect(getDriverForBrowserPage('page-1')).toEqual({ kind: 'mobile', clientId: 'phone-1' })
+    expect(isBrowserPageMobileDriven('page-1')).toBe(true)
+    expect(hasMobileDriverForAnyBrowserPage(['missing', 'page-1'])).toBe(true)
+    expect([...getBrowserMobileDrivenPageIds(['missing', 'page-1', 'page-2'])]).toEqual(['page-1'])
+
+    setDriverForBrowserPage('page-1', { kind: 'desktop' })
+
+    expect(getDriverForBrowserPage('page-1')).toEqual({ kind: 'desktop' })
+    expect(isBrowserPageMobileDriven('page-1')).toBe(false)
+    expect(hasMobileDriverForAnyBrowserPage(['page-1'])).toBe(false)
+
+    setDriverForBrowserPage('page-1', { kind: 'idle' })
+
+    expect(getDriverForBrowserPage('page-1')).toEqual({ kind: 'idle' })
+  })
+
+  it('hydrates driver snapshots and notifies affected listeners', () => {
+    setDriverForBrowserPage('page-old', { kind: 'mobile', clientId: 'phone-old' })
+    const listener = vi.fn()
+    const unsub = onBrowserDriverChange(listener)
+
+    hydrateBrowserDrivers([
+      { browserPageId: 'page-new', driver: { kind: 'mobile', clientId: 'phone-new' } }
+    ])
+
+    expect(getDriverForBrowserPage('page-old')).toEqual({ kind: 'idle' })
+    expect(getDriverForBrowserPage('page-new')).toEqual({
+      kind: 'mobile',
+      clientId: 'phone-new'
+    })
+    expect(listener).toHaveBeenCalledWith({
+      browserPageId: 'page-old',
+      driver: { kind: 'idle' }
+    })
+    expect(listener).toHaveBeenCalledWith({
+      browserPageId: 'page-new',
+      driver: { kind: 'mobile', clientId: 'phone-new' }
+    })
+
+    unsub()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/browser-mobile-driver-state.ts
+++ b/src/renderer/src/lib/pane-manager/browser-mobile-driver-state.ts
@@ -1,3 +1,4 @@
+import { useSyncExternalStore } from 'react'
 import type { RuntimeBrowserDriverState } from '../../../../shared/runtime-types'
 
 export type BrowserDriverState = RuntimeBrowserDriverState
@@ -11,15 +12,36 @@ type BrowserDriverChangeEvent = {
 
 type BrowserDriverChangeListener = (event: BrowserDriverChangeEvent) => void
 const changeListeners = new Set<BrowserDriverChangeListener>()
+const snapshotListeners = new Set<() => void>()
+let version = 0
 
 export function onBrowserDriverChange(listener: BrowserDriverChangeListener): () => void {
   changeListeners.add(listener)
   return () => changeListeners.delete(listener)
 }
 
+function subscribe(listener: () => void): () => void {
+  snapshotListeners.add(listener)
+  return () => {
+    snapshotListeners.delete(listener)
+  }
+}
+
+function getSnapshot(): number {
+  return version
+}
+
+function getServerSnapshot(): number {
+  return 0
+}
+
 function notifyChange(event: BrowserDriverChangeEvent): void {
+  version += 1
   for (const listener of changeListeners) {
     listener(event)
+  }
+  for (const listener of snapshotListeners) {
+    listener()
   }
 }
 
@@ -34,6 +56,42 @@ export function setDriverForBrowserPage(browserPageId: string, driver: BrowserDr
 
 export function getDriverForBrowserPage(browserPageId: string): BrowserDriverState {
   return driverByBrowserPageId.get(browserPageId) ?? { kind: 'idle' }
+}
+
+export function isBrowserPageMobileDriven(browserPageId: string): boolean {
+  return driverByBrowserPageId.get(browserPageId)?.kind === 'mobile'
+}
+
+export function hasMobileDriverForAnyBrowserPage(
+  browserPageIds: readonly (string | null | undefined)[]
+): boolean {
+  return browserPageIds.some((pageId) => Boolean(pageId && isBrowserPageMobileDriven(pageId)))
+}
+
+export function getBrowserMobileDrivenPageIds(
+  browserPageIds: readonly (string | null | undefined)[]
+): Set<string> {
+  const mobileDrivenPageIds = new Set<string>()
+  for (const pageId of browserPageIds) {
+    if (pageId && isBrowserPageMobileDriven(pageId)) {
+      mobileDrivenPageIds.add(pageId)
+    }
+  }
+  return mobileDrivenPageIds
+}
+
+export function useBrowserMobileDriverForAny(
+  browserPageIds: readonly (string | null | undefined)[]
+): boolean {
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+  return hasMobileDriverForAnyBrowserPage(browserPageIds)
+}
+
+export function useBrowserMobileDrivenPageIds(
+  browserPageIds: readonly (string | null | undefined)[]
+): Set<string> {
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+  return getBrowserMobileDrivenPageIds(browserPageIds)
 }
 
 export function hydrateBrowserDrivers(


### PR DESCRIPTION
## Summary

Ensures browser panes driven by a mobile client remain paintable and mounted in the DOM to avoid breaking remote interactions. Conversely, idle hidden browser panes in inactive worktrees are now parked (unmounted) to significantly improve tab performance and reduce background resource consumption.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

*Added unit tests for paintability rules (`browser-page-paintability.test.ts`) and external driver state storage/hooks (`browser-mobile-driver-state.test.ts`), and updated `BrowserPaneOverlayLayer.test.tsx` to verify unmounting behavior.*

## AI Review Report

We verified that the paintability rules successfully keep active, automated, or mobile-driven pages paintable while reclaiming resource overhead from idle tabs in hidden worktrees. This review explicitly checked cross-platform compatibility across macOS, Linux, and Windows, ensuring Webview mounting/unmounting behavior and reactivity behave uniformly across all desktop environments.

## Security Audit

Reviewed state management and paintability updates. Since these changes strictly manage internal UI layout and React rendering states, they do not expose any custom command executions, path manipulations, auth handling, or IPC channel alterations.

## Notes

None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5900">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->