### PR TITLE
Improve dispatch message displays with explicit task title and display name

### DIFF
--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -298,6 +298,8 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       'orchestration.taskCreate',
       {
         spec: getRequiredStringFlag(flags, 'spec'),
+        taskTitle: getOptionalStringFlag(flags, 'task-title'),
+        displayName: getOptionalStringFlag(flags, 'display-name'),
         deps: getOptionalStringFlag(flags, 'deps'),
         parent: getOptionalStringFlag(flags, 'parent'),
         callerTerminalHandle
@@ -311,6 +313,8 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       tasks: {
         id: string
         spec: string
+        task_title?: string | null
+        display_name?: string | null
         status: string
         assignee_handle?: string | null
         dispatch_id?: string | null
@@ -326,7 +330,8 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       }
       return r.tasks
         .map((t) => {
-          const head = `${t.id} [${t.status}] ${t.spec.slice(0, 60)}`
+          const label = t.display_name ?? t.task_title ?? t.spec
+          const head = `${t.id} [${t.status}] ${label.slice(0, 60)}`
           if (t.status === 'dispatched' && t.assignee_handle) {
             return `${head} -> ${t.assignee_handle} (${t.dispatch_id ?? '?'})`
           }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -435,6 +435,12 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
   if (command === 'worktree create' && flag === 'parent-worktree') {
     return '--parent-worktree <selector> Parent selector such as active/current, id:<id>, branch:<branch>, issue:<number>, path:<path>, folder:<id>, or worktree:<id>'
   }
+  if (command === 'orchestration task-create' && flag === 'task-title') {
+    return '--task-title <text>  Concise title for the orchestration task'
+  }
+  if (command === 'orchestration task-create' && flag === 'display-name') {
+    return '--display-name <text> UI label shown for dispatched worker rows'
+  }
   if (flag === 'key' && command === 'computer hotkey') {
     return '--key <key-combo>      Modifier chord with one key, e.g. CmdOrCtrl+A'
   }
@@ -496,6 +502,7 @@ export function formatFlagHelp(flag: string): string {
     text: '--text <text>          Text payload to send or type',
     'text-stdin': '--text-stdin          Read text payload from stdin',
     'task-id': '--task-id <id>        Task id to include in orchestration payload JSON',
+    'task-title': '--task-title <text>    Concise title for an orchestration task',
     'dispatch-id': '--dispatch-id <id>    Dispatch id to include in orchestration payload JSON',
     'files-modified': '--files-modified <csv> Comma-separated files for orchestration payload JSON',
     'report-path': '--report-path <path>  Report path to include in orchestration payload JSON',

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -222,6 +222,19 @@ describe('orca root help', () => {
     expect(callMock).not.toHaveBeenCalled()
   })
 
+  it('advertises explicit orchestration task display labels', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    logSpy.mockClear()
+
+    await main(['orchestration', 'task-create', '--help'], '/tmp/repo')
+
+    const help = String(logSpy.mock.calls[0][0])
+    expect(help).toContain('[--task-title <text>] [--display-name <text>]')
+    expect(help).toContain('--task-title <text>  Concise title for the orchestration task')
+    expect(help).toContain('--display-name <text> UI label shown for dispatched worker rows')
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
   it('hides removed parent-workspace help and scopes create parent selectors', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     logSpy.mockClear()
@@ -2929,10 +2942,24 @@ describe('orca cli worktree awareness', () => {
     })
     vi.spyOn(console, 'log').mockImplementation(() => {})
 
-    await main(['orchestration', 'task-create', '--spec', 'spawn child workspace'], '/tmp/repo')
+    await main(
+      [
+        'orchestration',
+        'task-create',
+        '--spec',
+        'spawn child workspace',
+        '--task-title',
+        'Child workspace',
+        '--display-name',
+        'Spawn child workspace'
+      ],
+      '/tmp/repo'
+    )
 
     expect(callMock).toHaveBeenCalledWith('orchestration.taskCreate', {
       spec: 'spawn child workspace',
+      taskTitle: 'Child workspace',
+      displayName: 'Spawn child workspace',
       deps: undefined,
       parent: undefined,
       callerTerminalHandle: 'term_creator'

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -70,8 +70,8 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     path: ['orchestration', 'task-create'],
     summary: 'Create an orchestration task',
     usage:
-      'orca orchestration task-create --spec <text> [--deps <json_array>] [--parent <task_id>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'spec', 'deps', 'parent']
+      'orca orchestration task-create --spec <text> [--task-title <text>] [--display-name <text>] [--deps <json_array>] [--parent <task_id>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'spec', 'task-title', 'display-name', 'deps', 'parent']
   },
   {
     path: ['orchestration', 'task-list'],

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -14267,6 +14267,27 @@ describe('OrcaRuntimeService', () => {
         }
       ]
     })
+    const workerHandle = runtime.preAllocateHandleForPty('pty-1')
+    runtime.setOrchestrationDb({
+      getActiveDispatchForTerminal: vi.fn((handle: string) =>
+        handle === workerHandle
+          ? {
+              id: 'ctx-1',
+              task_id: 'task-1',
+              assignee_handle: workerHandle,
+              status: 'dispatched'
+            }
+          : undefined
+      ),
+      getLatestDispatchForTerminal: vi.fn(() => undefined),
+      getTask: vi.fn(() => ({
+        id: 'task-1',
+        task_title: 'Dispatch prompt work',
+        display_name: 'Review dispatch prompts and make worker labels distinct',
+        spec: 'Review dispatch prompts\n\nand make worker labels distinct'
+      })),
+      getActiveCoordinatorRun: vi.fn(() => undefined)
+    } as never)
     runtime.attachWindow(1)
     runtime.syncWindowGraph(1, {
       tabs: [
@@ -14297,6 +14318,8 @@ describe('OrcaRuntimeService', () => {
         state: 'working',
         agentType: 'claude',
         prompt: 'ship it',
+        taskTitle: 'Dispatch prompt work',
+        displayName: 'Review dispatch prompts and make worker labels distinct',
         lastAssistantMessage: 'on it',
         stateStartedAt: 900,
         updatedAt: 1000
@@ -16200,6 +16223,9 @@ describe('OrcaRuntimeService', () => {
       ),
       getTask: vi.fn(() => ({
         id: 'task-1',
+        task_title: 'Dispatch prompt work',
+        display_name: 'Review dispatch prompts and make worker labels distinct',
+        spec: 'Review dispatch prompts\n\nand make worker labels distinct',
         created_by_terminal_handle: coordinatorHandle
       })),
       getActiveCoordinatorRun: vi.fn(() => ({
@@ -16249,6 +16275,8 @@ describe('OrcaRuntimeService', () => {
     expect(result.agentOrchestrationByPaneKey?.[workerPaneKey]).toMatchObject({
       taskId: 'task-1',
       dispatchId: 'ctx-1',
+      taskTitle: 'Dispatch prompt work',
+      displayName: 'Review dispatch prompts and make worker labels distinct',
       parentPaneKey: coordinatorPaneKey,
       parentTerminalHandle: coordinatorHandle,
       coordinatorHandle,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -21,6 +21,7 @@ import {
   createAgentStatusOscProcessor,
   type ProcessedAgentStatusChunk
 } from '../../shared/agent-status-osc'
+import { buildOrchestrationTaskDisplayMetadata } from '../../shared/orchestration-task-display'
 import {
   isTerminalInputTooLargeWithYield,
   TERMINAL_INPUT_TOO_LARGE_ERROR,
@@ -8683,12 +8684,16 @@ export class OrcaRuntimeService {
       if (!worktreeId || !summaries.has(worktreeId)) {
         continue
       }
+      const taskTitle = orchestrationByPaneKey?.[src.paneKey]?.taskTitle ?? null
+      const displayName = orchestrationByPaneKey?.[src.paneKey]?.displayName ?? null
       const row: RuntimeWorktreeAgentRow = {
         paneKey: src.paneKey,
         parentPaneKey: orchestrationByPaneKey?.[src.paneKey]?.parentPaneKey ?? null,
         state: src.state,
         agentType: src.agentType,
         prompt: src.prompt,
+        taskTitle,
+        displayName,
         lastAssistantMessage: src.lastAssistantMessage,
         toolName: src.toolName,
         toolInput: src.toolInput,
@@ -17216,6 +17221,14 @@ export class OrcaRuntimeService {
       return undefined
     }
     const task = db?.getTask?.(dispatch.task_id)
+    const display =
+      typeof task?.spec === 'string'
+        ? buildOrchestrationTaskDisplayMetadata({
+            spec: task.spec,
+            taskTitle: task.task_title,
+            displayName: task.display_name
+          })
+        : { taskTitle: '', displayName: '' }
     const activeRun = dispatch.status === 'completed' ? undefined : db?.getActiveCoordinatorRun?.()
     const parentTerminalHandle =
       task?.created_by_terminal_handle ??
@@ -17229,6 +17242,8 @@ export class OrcaRuntimeService {
     return {
       taskId: dispatch.task_id,
       dispatchId: dispatch.id,
+      ...(display.taskTitle ? { taskTitle: display.taskTitle } : {}),
+      ...(display.displayName ? { displayName: display.displayName } : {}),
       ...(parentTerminalHandle ? { parentTerminalHandle } : {}),
       ...(parentPaneKey ? { parentPaneKey } : {}),
       ...(activeRun?.coordinator_handle ? { coordinatorHandle: activeRun.coordinator_handle } : {}),

--- a/src/main/runtime/orchestration/db.test.ts
+++ b/src/main/runtime/orchestration/db.test.ts
@@ -170,6 +170,21 @@ describe('OrchestrationDb', () => {
       expect(task.id).toMatch(/^task_/)
       expect(task.status).toBe('ready')
       expect(task.deps).toBe('[]')
+      expect(task.task_title).toBe('do something')
+      expect(task.display_name).toBe('do something')
+    })
+
+    it('persists explicit task display metadata', () => {
+      const d = createDb()
+      const task = d.createTask({
+        spec: 'full details',
+        taskTitle: 'Checkout race',
+        displayName: 'Fix checkout race'
+      })
+
+      expect(task.task_title).toBe('Checkout race')
+      expect(task.display_name).toBe('Fix checkout race')
+      expect(d.getTask(task.id)?.display_name).toBe('Fix checkout race')
     })
 
     it('persists the creating terminal handle for task-created worktrees', () => {
@@ -788,6 +803,8 @@ describe('OrchestrationDb', () => {
       const ctx = d.createDispatchContext(task.id, 'term_a')
       d.recordHeartbeat(ctx.id, '2026-05-04T00:00:00.000Z')
       expect(d.getDispatchContext(task.id)?.last_heartbeat_at).toBe('2026-05-04T00:00:00.000Z')
+      expect(d.getTask(task.id)?.task_title).toBe('work')
+      expect(d.getTask(task.id)?.display_name).toBe('work')
 
       // (c) Indexes still attached to messages post-rebuild.
       const sqlite = (d as unknown as { db: Database.Database }).db

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -14,6 +14,7 @@ import type {
   DecisionGateRow,
   CoordinatorRun
 } from './types'
+import { buildOrchestrationTaskDisplayMetadata } from '../../../shared/orchestration-task-display'
 
 export type {
   MessageType,
@@ -38,8 +39,9 @@ function generateId(prefix: string): string {
 // push-on-idle can distinguish queued-but-undelivered from user-acknowledged
 // messages without touching the `read` bit (check-wait PR). v3 → v4 records
 // the terminal that created a task so task-record worktree creation can infer
-// the parent workspace even when no dispatch context exists.
-const SCHEMA_VERSION = 4
+// the parent workspace even when no dispatch context exists. v4 → v5 adds
+// explicit task_title/display_name fields for orchestration worker UI labels.
+const SCHEMA_VERSION = 5
 
 export class OrchestrationDb {
   private db: Database.Database
@@ -84,6 +86,8 @@ export class OrchestrationDb {
         id            TEXT PRIMARY KEY,
         parent_id     TEXT,
         created_by_terminal_handle TEXT,
+        task_title    TEXT,
+        display_name  TEXT,
         spec          TEXT NOT NULL,
         status        TEXT NOT NULL DEFAULT 'pending'
           CHECK(status IN (
@@ -232,6 +236,14 @@ export class OrchestrationDb {
       if (current < 4) {
         if (!this.hasColumn('tasks', 'created_by_terminal_handle')) {
           this.db.exec(`ALTER TABLE tasks ADD COLUMN created_by_terminal_handle TEXT`)
+        }
+      }
+      if (current < 5) {
+        if (!this.hasColumn('tasks', 'task_title')) {
+          this.db.exec(`ALTER TABLE tasks ADD COLUMN task_title TEXT`)
+        }
+        if (!this.hasColumn('tasks', 'display_name')) {
+          this.db.exec(`ALTER TABLE tasks ADD COLUMN display_name TEXT`)
         }
       }
       this.createUndeliveredInboxIndexIfPossible()
@@ -417,6 +429,8 @@ export class OrchestrationDb {
 
   createTask(task: {
     spec: string
+    taskTitle?: string
+    displayName?: string
     deps?: string[]
     parentId?: string
     createdByTerminalHandle?: string
@@ -425,14 +439,21 @@ export class OrchestrationDb {
     const depsJson = JSON.stringify(task.deps ?? [])
     const hasDeps = (task.deps ?? []).length > 0
     const status: TaskStatus = hasDeps ? 'pending' : 'ready'
+    const display = buildOrchestrationTaskDisplayMetadata({
+      spec: task.spec,
+      taskTitle: task.taskTitle,
+      displayName: task.displayName
+    })
     this.db
       .prepare(
-        'INSERT INTO tasks (id, parent_id, created_by_terminal_handle, spec, status, deps) VALUES (?, ?, ?, ?, ?, ?)'
+        'INSERT INTO tasks (id, parent_id, created_by_terminal_handle, task_title, display_name, spec, status, deps) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
       )
       .run(
         id,
         task.parentId ?? null,
         task.createdByTerminalHandle ?? null,
+        display.taskTitle || null,
+        display.displayName || null,
         task.spec,
         status,
         depsJson

--- a/src/main/runtime/orchestration/types.ts
+++ b/src/main/runtime/orchestration/types.ts
@@ -38,6 +38,8 @@ export type TaskRow = {
   id: string
   parent_id: string | null
   created_by_terminal_handle: string | null
+  task_title: string | null
+  display_name: string | null
   spec: string
   status: TaskStatus
   deps: string

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -660,11 +660,15 @@ describe('orchestration RPC methods', () => {
     it('creates a task', async () => {
       setup()
       const result = (await call('orchestration.taskCreate', {
-        spec: 'implement feature X'
+        spec: 'implement feature X',
+        taskTitle: 'Feature X',
+        displayName: 'Implement feature X'
       })) as { task: { id: string; status: string } }
 
       expect(result.task.id).toMatch(/^task_/)
       expect(result.task.status).toBe('ready')
+      expect(db.getTask(result.task.id)?.task_title).toBe('Feature X')
+      expect(db.getTask(result.task.id)?.display_name).toBe('Implement feature X')
     })
 
     it('creates a task with deps', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -100,6 +100,8 @@ const InboxParams = z.object({
 
 const TaskCreateParams = z.object({
   spec: requiredString('Missing --spec'),
+  taskTitle: OptionalString,
+  displayName: OptionalString,
   deps: OptionalString,
   parent: OptionalString,
   callerTerminalHandle: OptionalString
@@ -360,6 +362,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       }
       const task = db.createTask({
         spec: params.spec,
+        taskTitle: params.taskTitle,
+        displayName: params.displayName,
         deps,
         parentId: params.parent,
         createdByTerminalHandle: params.callerTerminalHandle

--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -291,6 +291,39 @@ describe('buildActivityEvents', () => {
     })
   })
 
+  it('uses orchestration display metadata for live thread titles', () => {
+    const result = makeActivityResult({
+      entries: {
+        [PANE_KEY]: {
+          ...makeWorkingEntryWithoutHistory(),
+          prompt: 'You are working inside Orca, a multi-agent IDE.',
+          orchestration: {
+            taskId: 'task-1',
+            dispatchId: 'ctx-1',
+            taskTitle: 'Checkout race',
+            displayName: 'Fix checkout race'
+          }
+        }
+      }
+    })
+
+    const threads = makeThreads(result)
+
+    expect(threads[0].paneTitle).toBe('Fix checkout race')
+    expect(
+      activityThreadMatchesSearchQuery({
+        thread: threads[0],
+        searchQuery: 'fix checkout race'
+      })
+    ).toBe(true)
+    expect(
+      activityThreadMatchesSearchQuery({
+        thread: threads[0],
+        searchQuery: 'multi-agent ide'
+      })
+    ).toBe(true)
+  })
+
   it('creates a thread for a repo-less floating terminal agent', () => {
     const tab = makeTabWithIds('tab-1', FLOATING_TERMINAL_WORKTREE_ID, 'Claude')
     const result = buildActivityEvents({

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -67,6 +67,7 @@ import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { translate } from '@/i18n/i18n'
+import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 
 type ThreadReadFilter = 'all' | 'unread'
 type ActivityGroupBy = 'status' | 'project' | 'worktree' | 'agent'
@@ -421,7 +422,7 @@ function agentTitle(event: ActivityEvent): string {
 }
 
 function agentSummary(event: ActivityEvent): string {
-  const prompt = event.entry.prompt.trim()
+  const prompt = getAgentRowPrimaryText(event.entry)
   if (event.state === 'done') {
     const message = event.entry.lastAssistantMessage?.trim()
     return message || prompt || 'Completed the current turn.'
@@ -449,7 +450,7 @@ function paneTitleForEntry(entry: AgentStatusEntry, tab: TerminalTab): string {
   if (customTitle) {
     return customTitle
   }
-  const prompt = entry.prompt.trim()
+  const prompt = getAgentRowPrimaryText(entry)
   if (prompt) {
     return prompt
   }
@@ -990,12 +991,15 @@ export function groupActivityThreadsByStatus(threads: AgentPaneThread[]): Activi
 function threadSearchText(thread: AgentPaneThread): string {
   const latest = thread.latestEvent
   const stateLabel = threadAgentStateLabel(thread)
-  const currentPrompt = thread.currentAgentEntry?.prompt.trim() ?? ''
+  const currentPrompt = thread.currentAgentEntry
+    ? getAgentRowPrimaryText(thread.currentAgentEntry)
+    : ''
+  const rawCurrentPrompt = thread.currentAgentEntry?.prompt.trim() ?? ''
   const currentSummary = thread.currentAgentEntry?.lastAssistantMessage?.trim() ?? ''
   const latestEventText = latest
     ? `${agentTitle(latest)} ${agentSummary(latest)} ${agentMeta(latest)}`
     : ''
-  return `${thread.paneTitle} ${thread.worktree.displayName} ${thread.repo?.displayName ?? ''} ${formatAgentTypeLabel(thread.agentType)} ${stateLabel} ${currentPrompt} ${currentSummary} ${thread.responsePreview} ${latestEventText}`.toLowerCase()
+  return `${thread.paneTitle} ${thread.worktree.displayName} ${thread.repo?.displayName ?? ''} ${formatAgentTypeLabel(thread.agentType)} ${stateLabel} ${currentPrompt} ${rawCurrentPrompt} ${currentSummary} ${thread.responsePreview} ${latestEventText}`.toLowerCase()
 }
 
 export const ACTIVITY_SEARCH_QUERY_MAX_BYTES = 2 * 1024

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -126,6 +126,26 @@ function classTokensForTaggedElement(markup: string, dataAttribute: string): str
 }
 
 describe('DashboardAgentRow', () => {
+  it('renders orchestration task preview instead of the raw dispatch preamble prompt', () => {
+    const markup = renderRow(
+      makeAgent(
+        {},
+        {
+          prompt: 'You are working inside Orca, a multi-agent IDE.',
+          orchestration: {
+            taskId: 'task-1',
+            dispatchId: 'ctx-1',
+            taskTitle: 'Checkout race',
+            displayName: 'Fix checkout race'
+          }
+        }
+      )
+    )
+
+    expect(markup).toContain('Fix checkout race')
+    expect(markup).not.toContain('You are working inside Orca')
+  })
+
   it('uses the hover background as the focused-pane row highlight', () => {
     const markup = renderToStaticMarkup(
       <TooltipProvider>

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -10,6 +10,7 @@ import { DashboardAgentRowTrailingControls } from './DashboardAgentRowTrailingCo
 import { DashboardAgentRowToolStep } from './DashboardAgentRowToolStep'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import type { DashboardAgentRow as DashboardAgentRowData } from './useDashboardData'
+import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 
 // Why: the dashboard tracks its own rollup states (incl. 'idle'); narrow to the
 // shared dot states for rendering, falling back to 'idle' for any unknown
@@ -188,7 +189,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   )
   const startedAt = agent.startedAt > 0 ? agent.startedAt : null
   const doneAt = lastEnteredDoneAt(agent)
-  const prompt = agent.entry.prompt.trim()
+  const prompt = getAgentRowPrimaryText(agent.entry)
   // Why: `agent.entry.prompt` is normalized to '' when the prompt is unknown
   // (fresh agent, missing telemetry). Rendering the row with an empty primary
   // slot would collapse the text column and leave the row with no human-

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -59,6 +59,8 @@ function orchestrationContextsEqual(
   return (
     a.taskId === b.taskId &&
     a.dispatchId === b.dispatchId &&
+    a.taskTitle === b.taskTitle &&
+    a.displayName === b.displayName &&
     a.parentTerminalHandle === b.parentTerminalHandle &&
     a.parentPaneKey === b.parentPaneKey &&
     a.coordinatorHandle === b.coordinatorHandle &&

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils'
 import CommentMarkdown from './CommentMarkdown'
 import { getAgentDotState } from './worktree-card-agent-summary'
 import { translate } from '@/i18n/i18n'
+import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 
 const MARKDOWN_IMAGE_PATTERN = /!\[[^\]\n]*\]\([^)]+\)/
 
@@ -41,7 +42,7 @@ function lastEnteredDoneAt(agent: DashboardAgentRowData): number | null {
 }
 
 function getCompactAgentPrimary(agent: DashboardAgentRowData): string {
-  const prompt = agent.entry.prompt?.trim() ?? ''
+  const prompt = getAgentRowPrimaryText(agent.entry)
   return prompt || agentStateLabel(getAgentDotState(agent))
 }
 

--- a/src/renderer/src/lib/agent-row-primary-text.test.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { getAgentRowPrimaryText } from './agent-row-primary-text'
+
+describe('getAgentRowPrimaryText', () => {
+  it('prefers orchestration display name over the raw hook prompt', () => {
+    expect(
+      getAgentRowPrimaryText({
+        prompt: 'You are working inside Orca, a multi-agent IDE.',
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          taskTitle: 'Checkout race',
+          displayName: 'Fix checkout race'
+        }
+      })
+    ).toBe('Fix checkout race')
+  })
+
+  it('falls back to task title when display name is absent', () => {
+    expect(
+      getAgentRowPrimaryText({
+        prompt: 'You are working inside Orca, a multi-agent IDE.',
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          taskTitle: 'Checkout race'
+        }
+      })
+    ).toBe('Checkout race')
+  })
+
+  it('falls back to the raw prompt outside orchestration workers', () => {
+    expect(getAgentRowPrimaryText({ prompt: 'Fix checkout race' })).toBe('Fix checkout race')
+  })
+})

--- a/src/renderer/src/lib/agent-row-primary-text.ts
+++ b/src/renderer/src/lib/agent-row-primary-text.ts
@@ -1,0 +1,11 @@
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+
+export function getAgentRowPrimaryText(
+  entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
+): string {
+  return (
+    entry.orchestration?.displayName?.trim() ||
+    entry.orchestration?.taskTitle?.trim() ||
+    entry.prompt.trim()
+  )
+}

--- a/src/renderer/src/lib/workspace-tab-agent-metadata.test.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-metadata.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import { collectAgentMetadataForTerminal } from './workspace-tab-agent-metadata'
+
+function makeEntry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  return {
+    state: 'working',
+    prompt: 'You are working inside Orca, a multi-agent IDE.',
+    updatedAt: 1000,
+    stateStartedAt: 900,
+    paneKey: 'tab-1:leaf-1',
+    worktreeId: 'wt-1',
+    stateHistory: [],
+    ...overrides
+  }
+}
+
+describe('collectAgentMetadataForTerminal', () => {
+  it('indexes orchestration task display metadata for tab search snippets', () => {
+    const [metadata] = collectAgentMetadataForTerminal({
+      terminalTabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agentStatusByPaneKey: {
+        'tab-1:leaf-1': makeEntry({
+          orchestration: {
+            taskId: 'task-1',
+            dispatchId: 'ctx-1',
+            taskTitle: 'Checkout race',
+            displayName: 'Fix checkout race'
+          }
+        })
+      },
+      retainedAgentsByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {}
+    })
+
+    expect(metadata?.textParts).toContain('Fix checkout race')
+    expect(metadata?.textParts).toContain('Checkout race')
+    expect(metadata?.snippetCandidates).toContain('Fix checkout race')
+    expect(metadata?.snippetCandidates).toContain('Checkout race')
+  })
+})

--- a/src/renderer/src/lib/workspace-tab-agent-metadata.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-metadata.ts
@@ -71,6 +71,10 @@ function collectLiveMetadata(
 ): Pick<AgentMetadata, 'snippetCandidates' | 'textParts'> {
   const textParts: string[] = []
   const snippetCandidates: string[] = []
+  addText(textParts, entry.orchestration?.displayName)
+  addText(snippetCandidates, entry.orchestration?.displayName)
+  addText(textParts, entry.orchestration?.taskTitle)
+  addText(snippetCandidates, entry.orchestration?.taskTitle)
   addText(textParts, entry.prompt)
   addText(snippetCandidates, entry.prompt)
   addText(textParts, entry.agentType)

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -156,6 +156,8 @@ describe('agent status runtime orchestration metadata', () => {
       [childPaneKey]: {
         taskId: 'task-1',
         dispatchId: 'ctx-1',
+        taskTitle: 'Checkout race',
+        displayName: 'Fix checkout race',
         parentPaneKey
       }
     })
@@ -163,6 +165,8 @@ describe('agent status runtime orchestration metadata', () => {
     expect(store.getState().agentStatusByPaneKey[childPaneKey].orchestration).toMatchObject({
       taskId: 'task-1',
       dispatchId: 'ctx-1',
+      taskTitle: 'Checkout race',
+      displayName: 'Fix checkout race',
       parentPaneKey
     })
     expect(store.getState().agentStatusEpoch).toBe(epochBeforeRuntime + 1)

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -426,6 +426,8 @@ function orchestrationContextsEqual(
   return (
     a.taskId === b.taskId &&
     a.dispatchId === b.dispatchId &&
+    a.taskTitle === b.taskTitle &&
+    a.displayName === b.displayName &&
     a.parentTerminalHandle === b.parentTerminalHandle &&
     a.parentPaneKey === b.parentPaneKey &&
     a.coordinatorHandle === b.coordinatorHandle &&

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -63,6 +63,8 @@ export const AGENT_STATE_HISTORY_MAX = 20
 export type AgentStatusOrchestrationContext = {
   taskId: string
   dispatchId: string
+  taskTitle?: string
+  displayName?: string
   parentTerminalHandle?: string
   parentPaneKey?: string
   coordinatorHandle?: string

--- a/src/shared/orchestration-task-display.test.ts
+++ b/src/shared/orchestration-task-display.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildOrchestrationTaskDisplayMetadata,
+  ORCHESTRATION_DISPLAY_NAME_MAX_LENGTH,
+  ORCHESTRATION_TASK_TITLE_MAX_LENGTH
+} from './orchestration-task-display'
+
+describe('buildOrchestrationTaskDisplayMetadata', () => {
+  it('uses explicit task title and display name when provided', () => {
+    expect(
+      buildOrchestrationTaskDisplayMetadata({
+        spec: 'Long implementation details',
+        taskTitle: 'Checkout race',
+        displayName: 'Fix checkout race'
+      })
+    ).toEqual({
+      taskTitle: 'Checkout race',
+      displayName: 'Fix checkout race'
+    })
+  })
+
+  it('derives a task title from the first non-empty spec line', () => {
+    expect(
+      buildOrchestrationTaskDisplayMetadata({
+        spec: '\n\nFix login form\n\nAdd focused tests'
+      })
+    ).toEqual({
+      taskTitle: 'Fix login form',
+      displayName: 'Fix login form'
+    })
+  })
+
+  it('normalizes and caps explicit task display fields', () => {
+    const metadata = buildOrchestrationTaskDisplayMetadata({
+      spec: 'fallback',
+      taskTitle: `  ${'x'.repeat(120)}\n`,
+      displayName: `  ${'y'.repeat(220)}\n`
+    })
+
+    expect(metadata.taskTitle).toHaveLength(ORCHESTRATION_TASK_TITLE_MAX_LENGTH)
+    expect(metadata.taskTitle.endsWith('...')).toBe(true)
+    expect(metadata.displayName).toHaveLength(ORCHESTRATION_DISPLAY_NAME_MAX_LENGTH)
+    expect(metadata.displayName.endsWith('...')).toBe(true)
+  })
+
+  it('does not leave a dangling high surrogate when truncating', () => {
+    const metadata = buildOrchestrationTaskDisplayMetadata({
+      spec: `x${'😀'.repeat(ORCHESTRATION_TASK_TITLE_MAX_LENGTH)}`
+    })
+    const last = metadata.taskTitle.charCodeAt(metadata.taskTitle.length - 1)
+
+    expect(metadata.taskTitle.length).toBeLessThanOrEqual(ORCHESTRATION_TASK_TITLE_MAX_LENGTH)
+    expect(last < 0xd800 || last > 0xdbff).toBe(true)
+  })
+})

--- a/src/shared/orchestration-task-display.ts
+++ b/src/shared/orchestration-task-display.ts
@@ -1,0 +1,53 @@
+export const ORCHESTRATION_TASK_TITLE_MAX_LENGTH = 80
+export const ORCHESTRATION_DISPLAY_NAME_MAX_LENGTH = 160
+
+export type OrchestrationTaskDisplayMetadata = {
+  taskTitle: string
+  displayName: string
+}
+
+export function buildOrchestrationTaskDisplayMetadata(input: {
+  spec: string
+  taskTitle?: string | null
+  displayName?: string | null
+}): OrchestrationTaskDisplayMetadata {
+  const taskTitle =
+    normalizeSingleLine(input.taskTitle, ORCHESTRATION_TASK_TITLE_MAX_LENGTH) ||
+    deriveTaskTitleFromSpec(input.spec)
+  const displayName =
+    normalizeSingleLine(input.displayName, ORCHESTRATION_DISPLAY_NAME_MAX_LENGTH) || taskTitle
+  return { taskTitle, displayName }
+}
+
+function deriveTaskTitleFromSpec(spec: string): string {
+  for (const line of spec.split(/\r?\n/)) {
+    const title = normalizeSingleLine(line, ORCHESTRATION_TASK_TITLE_MAX_LENGTH)
+    if (title) {
+      return title
+    }
+  }
+  return normalizeSingleLine(spec, ORCHESTRATION_TASK_TITLE_MAX_LENGTH)
+}
+
+function normalizeSingleLine(value: string | null | undefined, maxLength: number): string {
+  if (!value) {
+    return ''
+  }
+  const normalized = value.trim().replace(/\s+/g, ' ')
+  if (!normalized) {
+    return ''
+  }
+  if (normalized.length <= maxLength) {
+    return normalized
+  }
+  const body = trimDanglingHighSurrogate(normalized.slice(0, maxLength - 3)).trimEnd()
+  return `${body}...`
+}
+
+function trimDanglingHighSurrogate(value: string): string {
+  if (value.length === 0) {
+    return value
+  }
+  const lastCode = value.charCodeAt(value.length - 1)
+  return lastCode >= 0xd800 && lastCode <= 0xdbff ? value.slice(0, -1) : value
+}

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -498,7 +498,12 @@ export type RuntimeWorktreeAgentRow = {
   parentPaneKey: string | null
   state: AgentStatusState
   agentType: AgentType | null
+  /** Raw hook-reported prompt. Display surfaces can prefer displayName. */
   prompt: string
+  /** Explicit orchestration task title, or null outside dispatch. */
+  taskTitle: string | null
+  /** Explicit UI label for orchestration task rows, or null outside dispatch. */
+  displayName: string | null
   lastAssistantMessage: string | null
   toolName: string | null
   toolInput: string | null


### PR DESCRIPTION
## Summary

This PR adds explicit task titles and display names to orchestration tasks, addressing the issue where raw, verbose dispatcher preamble prompts (e.g., "You are working inside Orca, a multi-agent IDE.") clutter the UI dashboard, activity tabs, and sidebar rows. 

Key changes include:
1. **CLI / API Updates:** Added optional `--task-title` and `--display-name` parameters to the orchestration task creation commands and RPC handlers.
2. **Database Schema:** Incremented orchestration SQLite DB to version 5, adding nullable `task_title` and `display_name` columns to the `tasks` table.
3. **UI / Display Logic:** Added helper `getAgentRowPrimaryText` to resolve the row text prioritising the display name, then task title, and falling back to the raw prompt if neither are available.
4. **Search and Indexing:** Enhanced tab/activity search metadata indexing so that these explicit fields are searchable in the UI.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test` (New unit tests added for database schemas, display parsing/truncation, and UI component renderers)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

The change has been reviewed with an AI coding agent. The main risk check was database migration safety: schema version bumped from 4 to 5, correctly utilizing non-blocking `ALTER TABLE` operations to append nullable columns. Checked and confirmed cross-platform compatibility for macOS, Linux, and Windows; the changes do not touch shortcuts, platform-specific path helpers, or shell scripts.

## Security Audit

Verified input handling for CLI inputs and RPC requests, which are fully validated and safely passed into SQLite using parameterized queries. No command execution or path traversal risks are introduced.

## Notes

None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->