### PR TITLE
Fix stale review display follow-ups

### DIFF
--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-row-types.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-row-types.ts
@@ -7,6 +7,7 @@ export type ParentPrChecksCacheEntry<T> = {
   data: T | null
   fetchedAt: number
   headSha?: string
+  linkedReviewHintKey?: string
 }
 
 export type ParentPrChecksRefreshOutcome =

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.test.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.test.ts
@@ -72,7 +72,10 @@ function makeProjection({
 }: {
   worktree?: Worktree
   repo?: Repo
-  hostedReviewCache?: Record<string, { data: HostedReviewInfo | null; fetchedAt: number }>
+  hostedReviewCache?: Record<
+    string,
+    { data: HostedReviewInfo | null; fetchedAt: number; linkedReviewHintKey?: string }
+  >
   prCache?: Record<string, { data: PRInfo | null; fetchedAt: number }>
   checksCache?: Record<
     string,
@@ -102,7 +105,11 @@ describe('buildParentPrChecksProjection', () => {
         worktree,
         repo,
         hostedReviewCache: {
-          [cacheKey]: { data: makeReview({ status: 'failure' }), fetchedAt: 1 }
+          [cacheKey]: {
+            data: makeReview({ status: 'failure' }),
+            fetchedAt: 1,
+            linkedReviewHintKey: ''
+          }
         }
       }).rows[0]
     ).toMatchObject({
@@ -116,7 +123,11 @@ describe('buildParentPrChecksProjection', () => {
         worktree,
         repo,
         hostedReviewCache: {
-          [cacheKey]: { data: makeReview({ status: 'pending' }), fetchedAt: 1 }
+          [cacheKey]: {
+            data: makeReview({ status: 'pending' }),
+            fetchedAt: 1,
+            linkedReviewHintKey: ''
+          }
         }
       }).rows[0]
     ).toMatchObject({ status: 'pending', group: 'pending' })
@@ -126,7 +137,11 @@ describe('buildParentPrChecksProjection', () => {
         worktree,
         repo,
         hostedReviewCache: {
-          [cacheKey]: { data: makeReview({ state: 'merged' }), fetchedAt: 1 }
+          [cacheKey]: {
+            data: makeReview({ state: 'merged' }),
+            fetchedAt: 1,
+            linkedReviewHintKey: ''
+          }
         }
       }).rows[0]
     ).toMatchObject({ status: 'merged', group: 'merged' })
@@ -138,11 +153,114 @@ describe('buildParentPrChecksProjection', () => {
         hostedReviewCache: {
           [cacheKey]: {
             data: makeReview({ mergeable: 'CONFLICTING', status: 'success' }),
-            fetchedAt: 1
+            fetchedAt: 1,
+            linkedReviewHintKey: ''
           }
         }
       }).rows[0]
     ).toMatchObject({ status: 'conflict', group: 'needsAttention', checkTone: 'failure' })
+  })
+
+  it('keeps linked-lookup GitHub reviews hidden after the worktree is unlinked', () => {
+    const repo = makeRepo()
+    const worktree = makeWorktree({ id: 'repo-1::/feature' })
+    const review = makeReview({ status: 'success' })
+    const cacheKey = getHostedReviewCacheKey(repo.path, 'feature', settings, repo.id)
+    const checksKey = getGitHubRepoCacheKey(
+      repo.path,
+      repo.id,
+      prChecksCacheSuffix(review.number, null),
+      settings
+    )
+
+    const projection = makeProjection({
+      worktree,
+      repo,
+      hostedReviewCache: {
+        [cacheKey]: {
+          data: review,
+          fetchedAt: 1,
+          linkedReviewHintKey: 'github:12'
+        }
+      },
+      checksCache: {
+        [checksKey]: {
+          data: [
+            {
+              name: 'stale-build',
+              status: 'completed',
+              conclusion: 'failure',
+              url: null
+            }
+          ],
+          fetchedAt: 1
+        }
+      }
+    })
+
+    expect(projection.rows[0]).toMatchObject({
+      status: 'notFetched',
+      group: 'unavailable',
+      title: 'feature',
+      reviewLabel: null,
+      provider: null,
+      detailNames: []
+    })
+    expect(projection.summary.knownReview).toBe(0)
+  })
+
+  it('shows neutral branch-discovered GitHub reviews for unlinked rows', () => {
+    const repo = makeRepo()
+    const worktree = makeWorktree({ id: 'repo-1::/feature' })
+    const cacheKey = getHostedReviewCacheKey(repo.path, 'feature', settings, repo.id)
+
+    const projection = makeProjection({
+      worktree,
+      repo,
+      hostedReviewCache: {
+        [cacheKey]: {
+          data: makeReview({ status: 'success' }),
+          fetchedAt: 1,
+          linkedReviewHintKey: ''
+        }
+      }
+    })
+
+    expect(projection.rows[0]).toMatchObject({
+      status: 'success',
+      group: 'passing',
+      title: 'Review title',
+      reviewLabel: '#12',
+      provider: 'github',
+      summary: 'Checks passing'
+    })
+    expect(projection.summary.knownReview).toBe(1)
+  })
+
+  it('shows newly refreshed branch-discovered GitHub reviews for unlinked rows', () => {
+    const repo = makeRepo()
+    const worktree = makeWorktree({ id: 'repo-1::/feature' })
+    const identity = getParentPrChecksRefreshIdentity(worktree, repo, 'feature')
+
+    const projection = makeProjection({
+      worktree,
+      repo,
+      refreshOutcomes: new Map([
+        [
+          identity,
+          {
+            kind: 'found',
+            review: makeReview({ status: 'success' })
+          }
+        ]
+      ])
+    })
+
+    expect(projection.rows[0]).toMatchObject({
+      status: 'success',
+      group: 'passing',
+      reviewLabel: '#12'
+    })
   })
 
   it('only counts a visible successful unlinked no-review outcome as No PR', () => {
@@ -218,7 +336,11 @@ describe('buildParentPrChecksProjection', () => {
       worktree,
       repo,
       hostedReviewCache: {
-        [cacheKey]: { data: makeReview({ status: 'success' }), fetchedAt: 1 }
+        [cacheKey]: {
+          data: makeReview({ status: 'success' }),
+          fetchedAt: 1,
+          linkedReviewHintKey: ''
+        }
       },
       refreshOutcomes: new Map([[identity, { kind: 'error' }]])
     })
@@ -253,7 +375,7 @@ describe('buildParentPrChecksProjection', () => {
     const projection = makeProjection({
       worktree,
       repo,
-      hostedReviewCache: { [hostedKey]: { data: review, fetchedAt: 1 } },
+      hostedReviewCache: { [hostedKey]: { data: review, fetchedAt: 1, linkedReviewHintKey: '' } },
       checksCache: {
         [checksKey]: {
           data: [

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.ts
@@ -102,9 +102,14 @@ function buildParentPrChecksRow(
     args.worktree.linkedGitLabMR ?? null,
     args.worktree.linkedBitbucketPR ?? null,
     args.worktree.linkedAzureDevOpsPR ?? null,
-    args.worktree.linkedGiteaPR ?? null
+    args.worktree.linkedGiteaPR ?? null,
+    {
+      reviewHintKey: reviewSnapshot.reviewHintKey
+    }
   )
-  const review = reviewSnapshot.review
+  // Why: the display helper filters stale linked lookup cache entries; parent
+  // rows must not classify or link a review the worktree card would hide.
+  const review = fallbackDisplay === reviewSnapshot.review ? reviewSnapshot.review : null
   const status = classifyParentPrChecksRowStatus({
     isUnavailable: !args.repo || isFolderRepo(args.repo) || args.worktree.isBare || !branch,
     review,
@@ -141,9 +146,17 @@ function getReviewSnapshot(
   args: BuildParentPrChecksRowsArgs & { worktree: Worktree; repo: Repo | null },
   branch: string | null,
   outcome: ParentPrChecksRefreshOutcome | undefined
-): { review: HostedReviewInfo | null | undefined; hasCacheEntry: boolean } {
+): {
+  review: HostedReviewInfo | null | undefined
+  hasCacheEntry: boolean
+  reviewHintKey?: string
+} {
   if (outcome?.kind === 'found') {
-    return { review: outcome.review, hasCacheEntry: true }
+    return {
+      review: outcome.review,
+      hasCacheEntry: true,
+      reviewHintKey: linkedReviewHintKey(getLinkedReviewHints(args.worktree))
+    }
   }
   if (!args.repo || !branch) {
     return { review: undefined, hasCacheEntry: false }
@@ -151,7 +164,11 @@ function getReviewSnapshot(
   const scopedArgs = { ...args, repo: args.repo }
   const hostedReviewEntry = args.hostedReviewCache[getHostedReviewKey(scopedArgs, branch)]
   if (hostedReviewEntry?.data) {
-    return { review: hostedReviewEntry.data, hasCacheEntry: true }
+    return {
+      review: hostedReviewEntry.data,
+      hasCacheEntry: true,
+      reviewHintKey: hostedReviewEntry.linkedReviewHintKey
+    }
   }
   const prEntry = args.prCache[getPRKey(scopedArgs, branch)]
   if (prEntry?.data) {

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
@@ -92,6 +92,22 @@ describe('getWorktreeCardPrDisplay', () => {
     expect(getWorktreeCardPrDisplay(gitLabReview, null, 321)).toBe(gitLabReview)
   })
 
+  it('ignores linked-lookup GitLab MR details when the worktree is unlinked', () => {
+    expect(
+      getWorktreeCardPrDisplay(gitLabReview, null, null, null, null, null, {
+        reviewHintKey: 'gitlab:321'
+      })
+    ).toBeNull()
+  })
+
+  it('shows branch-discovered GitLab MR details when the worktree is unlinked', () => {
+    expect(
+      getWorktreeCardPrDisplay(gitLabReview, null, null, null, null, null, {
+        reviewHintKey: ''
+      })
+    ).toBe(gitLabReview)
+  })
+
   it('keeps the linked GitLab MR number visible when cached details belong to a different MR', () => {
     expect(getWorktreeCardPrDisplay(gitLabReview, null, 654)).toEqual({
       provider: 'gitlab',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "Copy",
             "c2f0b72b8d": "Insert",
             "925f49f210": "Expand Pane",
-            "df766809e0": "Collapse Pane",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "Collapse Pane"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Restart daemon",
@@ -2912,7 +2911,11 @@
             "e740f92596": "Refresh failed",
             "8418ec448d": "{{value0}} usage could not be refreshed. Agent sessions may still be signed in.",
             "45198c7d95": "1 rate-limit reset available",
-            "bce421cba3": "{{value0}} rate-limit resets available"
+            "bce421cba3": "{{value0}} rate-limit resets available",
+            "7ec6e030a0": "Next expires now",
+            "d1e442a9e5": "Expires now",
+            "6cf9eaed10": "Next expires in {{value0}}",
+            "20ad66aed1": "Expires in {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"
@@ -8465,8 +8468,8 @@
             "a1f2c8d901": "View"
           },
           "SourceControl": {
-            "conflictsSection": "Conflicts",
             "1406954883": "Clear all notes...",
+            "conflictsSection": "Conflicts",
             "cc05b2d088": "Open in File Explorer",
             "03194cfff4": "Local session state derived from a conflict you opened here.",
             "413a3ba113": "conflict",
@@ -9179,9 +9182,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "View"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "Borrar pantalla",
             "8c17d6786d": "Cerrar panel",
-            "copyTerminalId": "Copiar ID de terminal",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "Copiar ID del panel",
             "39809d152f": "Establecer título…",
             "06c2b0f043": "Igualar tamaños de paneles",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "Copiar",
             "c2f0b72b8d": "Insertar",
             "925f49f210": "Expandir panel",
-            "df766809e0": "Contraer panel",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "Contraer panel"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Reiniciar demonio",
@@ -2912,7 +2911,11 @@
             "e740f92596": "Error al actualizar",
             "8418ec448d": "No se pudo actualizar el uso de {{value0}}. Es posible que las sesiones de agente sigan iniciadas.",
             "45198c7d95": "1 rate-limit reset available",
-            "bce421cba3": "{{value0}} rate-limit resets available"
+            "bce421cba3": "{{value0}} rate-limit resets available",
+            "7ec6e030a0": "Next expires now",
+            "d1e442a9e5": "Expires now",
+            "6cf9eaed10": "Next expires in {{value0}}",
+            "20ad66aed1": "Expires in {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"
@@ -8465,8 +8468,8 @@
             "a1f2c8d901": "Ver"
           },
           "SourceControl": {
-            "conflictsSection": "Conflictos",
             "1406954883": "Borrar todas las notas...",
+            "conflictsSection": "Conflictos",
             "cc05b2d088": "Abrir en el Explorador de archivos",
             "03194cfff4": "Estado de la sesión local derivado de un conflicto que abrió aquí.",
             "413a3ba113": "conflicto",
@@ -9102,7 +9105,16 @@
             "daysAgo": "{{value0}}d ago",
             "monthsAgo": "{{value0}}mo ago",
             "yearsAgo": "{{value0}}y ago",
-            "sessionId": "ID de sesión"
+            "sessionId": "ID de sesión",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "Resume {{value0}} session",
@@ -9119,7 +9131,14 @@
             "hideDetails": "Ocultar detalles",
             "showDetails": "Mostrar detalles",
             "moreSessionActions": "Más acciones de sesión",
-            "moreActions": "Más acciones"
+            "moreActions": "Más acciones",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "Buscar archivos",
@@ -9163,9 +9182,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "Ver"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "クリアスクリーン",
             "8c17d6786d": "ペインを閉じる",
-            "copyTerminalId": "Terminal ID をコピー",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "ペインIDのコピー",
             "39809d152f": "タイトルを設定…",
             "06c2b0f043": "ペインのサイズを均等化する",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "コピー",
             "c2f0b72b8d": "入れる",
             "925f49f210": "ペインを展開する",
-            "df766809e0": "ペインを折りたたむ",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "ペインを折りたたむ"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "デーモンを再起動します",
@@ -2912,7 +2911,11 @@
             "e740f92596": "更新に失敗しました",
             "8418ec448d": "{{value0}} の使用状況を更新できませんでした。Agent セッションは引き続きサインイン済みの場合があります。",
             "45198c7d95": "1 rate-limit reset available",
-            "bce421cba3": "{{value0}} rate-limit resets available"
+            "bce421cba3": "{{value0}} rate-limit resets available",
+            "7ec6e030a0": "Next expires now",
+            "d1e442a9e5": "Expires now",
+            "6cf9eaed10": "Next expires in {{value0}}",
+            "20ad66aed1": "Expires in {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"
@@ -8465,8 +8468,8 @@
             "a1f2c8d901": "表示"
           },
           "SourceControl": {
-            "conflictsSection": "競合",
             "1406954883": "すべてのメモをクリアします...",
+            "conflictsSection": "競合",
             "cc05b2d088": "ファイルエクスプローラーで開く",
             "03194cfff4": "ここで開いた競合から派生したローカル セッション状態。",
             "413a3ba113": "競合",
@@ -9102,7 +9105,16 @@
             "daysAgo": "{{value0}}d ago",
             "monthsAgo": "{{value0}}mo ago",
             "yearsAgo": "{{value0}}y ago",
-            "sessionId": "セッション ID"
+            "sessionId": "セッション ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "Resume {{value0}} session",
@@ -9119,7 +9131,14 @@
             "hideDetails": "詳細を非表示",
             "showDetails": "詳細を表示",
             "moreSessionActions": "セッションのその他の操作",
-            "moreActions": "その他の操作"
+            "moreActions": "その他の操作",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "ファイルを検索",
@@ -9163,9 +9182,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "表示"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "화면 지우기",
             "8c17d6786d": "창 닫기",
-            "copyTerminalId": "터미널 ID 복사",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "창 ID 복사",
             "39809d152f": "제목 설정…",
             "06c2b0f043": "창 크기 균등화",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "복사",
             "c2f0b72b8d": "삽입",
             "925f49f210": "창 확장",
-            "df766809e0": "창 축소",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "창 축소"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "데몬 재시작",
@@ -2912,7 +2911,11 @@
             "e740f92596": "새로 고침 실패",
             "8418ec448d": "{{value0}} 사용량을 새로 고칠 수 없습니다. Agent 세션은 여전히 로그인되어 있을 수 있습니다.",
             "45198c7d95": "rate-limit 재설정 1회 사용 가능",
-            "bce421cba3": "rate-limit 재설정 {{value0}}회 사용 가능"
+            "bce421cba3": "rate-limit 재설정 {{value0}}회 사용 가능",
+            "7ec6e030a0": "Next expires now",
+            "d1e442a9e5": "Expires now",
+            "6cf9eaed10": "Next expires in {{value0}}",
+            "20ad66aed1": "Expires in {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 호스트"
@@ -8465,8 +8468,8 @@
             "a1f2c8d901": "보기"
           },
           "SourceControl": {
-            "conflictsSection": "충돌",
             "1406954883": "모든 메모 지우기...",
+            "conflictsSection": "충돌",
             "cc05b2d088": "파일 탐색기에서 열기",
             "03194cfff4": "여기에서 연 충돌에서 파생된 로컬 세션 상태입니다.",
             "413a3ba113": "충돌",
@@ -9102,7 +9105,16 @@
             "daysAgo": "{{value0}}일 전",
             "monthsAgo": "{{value0}}개월 전",
             "yearsAgo": "{{value0}}년 전",
-            "sessionId": "세션 ID"
+            "sessionId": "세션 ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "{{value0}} 세션 재개",
@@ -9119,7 +9131,14 @@
             "hideDetails": "세부정보 숨기기",
             "showDetails": "세부정보 표시",
             "moreSessionActions": "세션 추가 작업",
-            "moreActions": "추가 작업"
+            "moreActions": "추가 작업",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "파일 찾기",
@@ -9163,9 +9182,6 @@
                 "copyCommand": "명령 복사"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "보기"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "清晰的屏幕",
             "8c17d6786d": "关闭窗格",
-            "copyTerminalId": "复制终端 ID",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "复制窗格 ID",
             "39809d152f": "设置标题...",
             "06c2b0f043": "均衡窗格大小",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "复制",
             "c2f0b72b8d": "插入",
             "925f49f210": "展开窗格",
-            "df766809e0": "折叠窗格",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "折叠窗格"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "重新启动守护进程",
@@ -2912,7 +2911,11 @@
             "e740f92596": "刷新失败",
             "8418ec448d": "{{value0}} 用量无法刷新。智能体会话可能仍处于登录状态。",
             "45198c7d95": "1 rate-limit reset available",
-            "bce421cba3": "{{value0}} rate-limit resets available"
+            "bce421cba3": "{{value0}} rate-limit resets available",
+            "7ec6e030a0": "Next expires now",
+            "d1e442a9e5": "Expires now",
+            "6cf9eaed10": "Next expires in {{value0}}",
+            "20ad66aed1": "Expires in {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 主机"
@@ -8465,8 +8468,8 @@
             "a1f2c8d901": "查看"
           },
           "SourceControl": {
-            "conflictsSection": "冲突",
             "1406954883": "清除所有笔记...",
+            "conflictsSection": "冲突",
             "cc05b2d088": "在文件资源管理器中打开",
             "03194cfff4": "本地会话状态源自您在此处打开的冲突。",
             "413a3ba113": "冲突",
@@ -9102,7 +9105,16 @@
             "daysAgo": "{{value0}} 天前",
             "monthsAgo": "{{value0}} 个月前",
             "yearsAgo": "{{value0}} 年前",
-            "sessionId": "会话 ID"
+            "sessionId": "会话 ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "恢复 {{value0}} 会话",
@@ -9119,7 +9131,14 @@
             "hideDetails": "隐藏详情",
             "showDetails": "显示详情",
             "moreSessionActions": "更多会话操作",
-            "moreActions": "更多操作"
+            "moreActions": "更多操作",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "查找文件",
@@ -9163,9 +9182,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "查看"
           }
         }
       },


### PR DESCRIPTION
## Summary
- keep parent PR checks rows aligned with WorktreeCard stale linked-review filtering
- add regression coverage for branch-discovered vs linked-lookup GitHub/GitLab review display
- repair locale catalog parity after the new tooltip/AiVault keys on main

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts src/renderer/src/components/right-sidebar/parent-pr-checks-rows.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->