### PR TITLE
Harden Windows worktree removal cleanup

### DIFF
--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -146,6 +146,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     getProjectHostSetups: vi.fn(),
     getSettings: vi.fn(),
     getWorktreeMeta: vi.fn(),
+    getAllWorktreeMeta: vi.fn(),
     setWorktreeMeta: vi.fn(),
     removeWorktreeMeta: vi.fn()
   }
@@ -185,6 +186,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     store.getProjectHostSetups.mockReset()
     store.getSettings.mockReset()
     store.getWorktreeMeta.mockReset()
+    store.getAllWorktreeMeta.mockReset()
     store.setWorktreeMeta.mockReset()
     store.removeWorktreeMeta.mockReset()
 
@@ -222,6 +224,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
       workspaceDir: 'C:\\workspaces'
     })
     store.getWorktreeMeta.mockReturnValue(undefined)
+    store.getAllWorktreeMeta.mockReturnValue({})
     store.setWorktreeMeta.mockReturnValue({})
     getGitUsernameMock.mockReturnValue('')
     getDefaultBaseRefMock.mockReturnValue('origin/main')
@@ -383,5 +386,52 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
       repoId: 'repo-1'
     })
+  })
+
+  it('uses canonical Windows worktree metadata when the requested path spelling differs', async () => {
+    const requestedWorktreeId = 'repo-1::C:/workspaces/improve-dashboard'
+    const canonicalWorktreeId = 'repo-1::c:\\workspaces\\Improve-Dashboard'
+    const registeredWorktree = {
+      path: 'c:\\workspaces\\Improve-Dashboard',
+      head: 'feature-head',
+      branch: 'refs/heads/improve-dashboard',
+      isBare: false,
+      isMainWorktree: false
+    }
+    const metaById = {
+      [canonicalWorktreeId]: {
+        preserveBranchOnDelete: true
+      }
+    }
+    store.getAllWorktreeMeta.mockReturnValue(metaById)
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) => metaById[worktreeId])
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: 'C:\\repo',
+        head: 'main-head',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      },
+      registeredWorktree
+    ])
+    removeWorktreeMock.mockResolvedValue({})
+
+    await handlers['worktrees:remove'](null, {
+      worktreeId: requestedWorktreeId
+    })
+
+    expect(removeWorktreeMock).toHaveBeenCalledWith(
+      'C:\\repo',
+      registeredWorktree.path,
+      false,
+      expect.objectContaining({
+        deleteBranch: false,
+        knownRemovedWorktree: registeredWorktree
+      })
+    )
+    expect(store.removeWorktreeMeta).toHaveBeenCalledWith(requestedWorktreeId)
+    expect(store.removeWorktreeMeta).toHaveBeenCalledWith(canonicalWorktreeId)
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(canonicalWorktreeId)
   })
 })

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -124,6 +124,11 @@ import {
   removeLocalWorktreePath,
   toLocalWorktreeRuntimePath
 } from '../local-worktree-filesystem'
+import {
+  getEquivalentWorktreeIdsForRemoval,
+  getWorktreeRemovalMetadata,
+  omitWorktreeMetaIds
+} from '../worktree-removal-metadata'
 
 const WORKTREE_ARCHIVE_HOOK_TIMEOUT_MS = 120_000
 const WORKTREE_LIST_ALL_CONCURRENCY = 8
@@ -148,12 +153,18 @@ async function mapWithConcurrency<T, R>(
   return results
 }
 
-function removeWorktreeMetadataAndTransientState(store: Store, worktreeId: string): void {
-  // Why: worktree IDs are path-derived and can be recreated, so removal must
-  // drop process-local caches before the same ID can point at a new workspace.
-  store.removeWorktreeMeta(worktreeId)
-  advertisedUrlWatcher.forgetWorktree(worktreeId)
-  deleteWorktreeHistoryDir(worktreeId)
+function removeWorktreeMetadataAndTransientState(
+  store: Store,
+  worktreeIds: string | readonly string[]
+): void {
+  const ids = typeof worktreeIds === 'string' ? [worktreeIds] : worktreeIds
+  for (const worktreeId of ids) {
+    // Why: worktree IDs are path-derived and can be recreated, so removal must
+    // drop process-local caches before the same ID can point at a new workspace.
+    store.removeWorktreeMeta(worktreeId)
+    advertisedUrlWatcher.forgetWorktree(worktreeId)
+    deleteWorktreeHistoryDir(worktreeId)
+  }
 }
 
 async function closeLocalWatcherForRemoval(worktreePath: string): Promise<void> {
@@ -1247,8 +1258,8 @@ export function registerWorktreeHandlers(
           : hasLocalWorktreeGitOptions
             ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
             : await listGitWorktreesStrict(repo.path)
-        const removedMeta = store.getWorktreeMeta(args.worktreeId)
-        const removedPushTarget = removedMeta?.pushTarget
+        const requestedMeta = store.getWorktreeMeta(args.worktreeId)
+        const requestedPushTarget = requestedMeta?.pushTarget
         const registeredWorktree = findRegisteredDeletableWorktree(
           repo.path,
           worktreePath,
@@ -1260,7 +1271,7 @@ export function registerWorktreeHandlers(
           const knownOrcaLayouts = buildKnownOrcaWorkspaceLayouts(store.getSettings(), repo)
           if (
             canCleanupUnregisteredOrcaWorktreeDirectory({
-              meta: removedMeta,
+              meta: requestedMeta,
               worktreePath,
               repo,
               knownOrcaLayouts
@@ -1303,7 +1314,7 @@ export function registerWorktreeHandlers(
                 provider!,
                 repo.path,
                 args.worktreeId,
-                removedPushTarget,
+                requestedPushTarget,
                 store
               )
             } else {
@@ -1312,7 +1323,7 @@ export function registerWorktreeHandlers(
               await cleanupUnusedWorktreePushTargetRemote(
                 repo.path,
                 args.worktreeId,
-                removedPushTarget,
+                requestedPushTarget,
                 store,
                 localWorktreeGitOptions
               )
@@ -1325,7 +1336,7 @@ export function registerWorktreeHandlers(
             return {}
           }
           if (await isAlreadyRemovedWorktreePath(repo, worktreePath, localWorktreeGitOptions)) {
-            if (!args.force && !removedMeta) {
+            if (!args.force && !requestedMeta) {
               // Why: without persisted metadata, require the renderer recovery
               // path before deleting Orca-only state for an unregistered path.
               throw new Error(UNREGISTERED_MISSING_WORKTREE_MESSAGE)
@@ -1338,14 +1349,14 @@ export function registerWorktreeHandlers(
                 provider!,
                 repo.path,
                 args.worktreeId,
-                removedPushTarget,
+                requestedPushTarget,
                 store
               )
             } else {
               await cleanupUnusedWorktreePushTargetRemote(
                 repo.path,
                 args.worktreeId,
-                removedPushTarget,
+                requestedPushTarget,
                 store,
                 localWorktreeGitOptions
               )
@@ -1360,7 +1371,16 @@ export function registerWorktreeHandlers(
           throw new Error(`Refusing to delete unregistered worktree path: ${worktreePath}`)
         }
         const canonicalWorktreePath = registeredWorktree.path
-        const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
+        const removedWorktreeIds = getEquivalentWorktreeIdsForRemoval(
+          store,
+          repo.id,
+          args.worktreeId,
+          canonicalWorktreePath
+        )
+        const removalMetadata = getWorktreeRemovalMetadata(store, removedWorktreeIds)
+        const removedPushTarget = removalMetadata.pushTarget
+        const cleanupStore = omitWorktreeMetaIds(store, removedWorktreeIds)
+        const deleteBranch = !removalMetadata.preserveBranchOnDelete
 
         let shouldTearDownPtys = true
 
@@ -1408,16 +1428,21 @@ export function registerWorktreeHandlers(
             repo.path,
             args.worktreeId,
             removedPushTarget,
-            store
+            cleanupStore
           )
+          for (const worktreeId of removedWorktreeIds) {
+            preservedBranchCleanupByWorktreeId.delete(worktreeId)
+          }
           rememberPreservedBranchCleanupTarget(
             args.worktreeId,
             removalResult,
             registeredWorktree.head,
             removedPushTarget
           )
-          runtime.clearOptimisticReconcileToken(args.worktreeId)
-          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+          for (const worktreeId of removedWorktreeIds) {
+            runtime.clearOptimisticReconcileToken(worktreeId)
+          }
+          removeWorktreeMetadataAndTransientState(store, removedWorktreeIds)
           notifyWorktreesChanged(mainWindow, repoId)
           return removalResult ?? {}
         }
@@ -1527,12 +1552,14 @@ export function registerWorktreeHandlers(
               repo.path,
               args.worktreeId,
               removedPushTarget,
-              store,
+              cleanupStore,
               localWorktreeGitOptions
             )
-            runtime.clearOptimisticReconcileToken(args.worktreeId)
-            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-            preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+            for (const worktreeId of removedWorktreeIds) {
+              runtime.clearOptimisticReconcileToken(worktreeId)
+              preservedBranchCleanupByWorktreeId.delete(worktreeId)
+            }
+            removeWorktreeMetadataAndTransientState(store, removedWorktreeIds)
             invalidateAuthorizedRootsCache()
             notifyWorktreesChanged(mainWindow, repoId)
             return {}
@@ -1545,17 +1572,22 @@ export function registerWorktreeHandlers(
           repo.path,
           args.worktreeId,
           removedPushTarget,
-          store,
+          cleanupStore,
           localWorktreeGitOptions
         )
+        for (const worktreeId of removedWorktreeIds) {
+          preservedBranchCleanupByWorktreeId.delete(worktreeId)
+        }
         rememberPreservedBranchCleanupTarget(
           args.worktreeId,
           removalResult,
           registeredWorktree.head,
           removedPushTarget
         )
-        runtime.clearOptimisticReconcileToken(args.worktreeId)
-        removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+        for (const worktreeId of removedWorktreeIds) {
+          runtime.clearOptimisticReconcileToken(worktreeId)
+        }
+        removeWorktreeMetadataAndTransientState(store, removedWorktreeIds)
         invalidateAuthorizedRootsCache()
 
         notifyWorktreesChanged(mainWindow, repoId)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19575,7 +19575,7 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
-  it('deletes a Windows runtime worktree using the canonical registered path', async () => {
+  it('deletes a Windows runtime worktree using the canonical registered path and metadata', async () => {
     setPlatform('win32')
     const repo = {
       id: TEST_REPO_ID,
@@ -19592,15 +19592,21 @@ describe('OrcaRuntimeService', () => {
       isBare: false,
       isMainWorktree: false
     }
+    const canonicalWorktreeId = `${TEST_REPO_ID}::${registeredWorktree.path}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [requestedWorktreeId]: makeWorktreeMeta(),
+      [canonicalWorktreeId]: makeWorktreeMeta({ preserveBranchOnDelete: true })
+    }
+    const removeWorktreeMeta = vi.fn((worktreeId: string) => {
+      delete metaById[worktreeId]
+    })
     const runtimeStore = {
       ...store,
       getRepos: () => [repo],
       getRepo: (id: string) => (id === TEST_REPO_ID ? repo : undefined),
-      getAllWorktreeMeta: () => ({
-        [requestedWorktreeId]: makeWorktreeMeta()
-      }),
-      getWorktreeMeta: (worktreeId: string) =>
-        worktreeId === requestedWorktreeId ? makeWorktreeMeta() : undefined,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      removeWorktreeMeta,
       getProjects: () => [
         {
           id: 'project-1',
@@ -19649,9 +19655,12 @@ describe('OrcaRuntimeService', () => {
       wslDistro: 'Ubuntu'
     })
     expect(removeWorktree).toHaveBeenCalledWith(repo.path, registeredWorktree.path, false, {
+      deleteBranch: false,
       knownRemovedWorktree: registeredWorktree,
       wslDistro: 'Ubuntu'
     })
+    expect(removeWorktreeMeta).toHaveBeenCalledWith(canonicalWorktreeId)
+    expect(removeWorktreeMeta).toHaveBeenCalledWith(requestedWorktreeId)
   })
 
   it('surfaces selected-runtime list failures during runtime worktree removal', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -614,6 +614,11 @@ import {
   stripOrcaProvenanceMetaUpdates,
   UNREGISTERED_MISSING_WORKTREE_MESSAGE
 } from '../worktree-removal-safety'
+import {
+  getEquivalentWorktreeIdsForRemoval,
+  getWorktreeRemovalMetadata,
+  omitWorktreeMetaIds
+} from '../worktree-removal-metadata'
 import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 import { invalidateAuthorizedRootsCache } from '../ipc/filesystem-auth'
 import { prepareLocalWorktreeRootForRepo } from '../worktree-root-preparation'
@@ -13744,14 +13749,20 @@ export class OrcaRuntimeService {
     }
   }
 
-  private removeWorktreeMetadataAndHistory(store: RuntimeStore, worktreeId: string): void {
-    // Why: worktree IDs are path-derived and can be recreated, so removal must
-    // purge history and process-local caches before the ID points at new state.
-    store.removeWorktreeMeta(worktreeId)
-    advertisedUrlWatcher.forgetWorktree(worktreeId)
-    serveSimStateWatcher.forgetWorktree(worktreeId)
-    deleteWorktreeHistoryDir(worktreeId)
-    this.closeHeadlessBrowserPagesForWorktree(worktreeId)
+  private removeWorktreeMetadataAndHistory(
+    store: RuntimeStore,
+    worktreeIds: string | readonly string[]
+  ): void {
+    const ids = typeof worktreeIds === 'string' ? [worktreeIds] : worktreeIds
+    for (const worktreeId of ids) {
+      // Why: worktree IDs are path-derived and can be recreated, so removal must
+      // purge history and process-local caches before the ID points at new state.
+      store.removeWorktreeMeta(worktreeId)
+      advertisedUrlWatcher.forgetWorktree(worktreeId)
+      serveSimStateWatcher.forgetWorktree(worktreeId)
+      deleteWorktreeHistoryDir(worktreeId)
+      this.closeHeadlessBrowserPagesForWorktree(worktreeId)
+    }
   }
 
   // Why: headless offscreen browser pages are main-process BrowserWindows that
@@ -13933,8 +13944,8 @@ export class OrcaRuntimeService {
         : hasLocalWorktreeGitOptions
           ? await listWorktreesStrict(repo.path, localWorktreeGitOptions)
           : await listWorktreesStrict(repo.path)
-      const removedMeta = store.getWorktreeMeta(removalTarget.id)
-      const removedPushTarget = removedMeta?.pushTarget ?? removalTarget.pushTarget
+      const requestedMeta = store.getWorktreeMeta(removalTarget.id)
+      const requestedPushTarget = requestedMeta?.pushTarget ?? removalTarget.pushTarget
       const registeredWorktree = findRegisteredDeletableWorktree(
         repo.path,
         removalTarget.path,
@@ -13945,7 +13956,7 @@ export class OrcaRuntimeService {
         const knownOrcaLayouts = buildKnownOrcaWorkspaceLayouts(store.getSettings(), repo)
         if (
           canCleanupUnregisteredOrcaWorktreeDirectory({
-            meta: removedMeta,
+            meta: requestedMeta,
             worktreePath: removalTarget.path,
             repo,
             knownOrcaLayouts
@@ -13988,7 +13999,7 @@ export class OrcaRuntimeService {
               provider!,
               repo.path,
               removalTarget.id,
-              removedPushTarget,
+              requestedPushTarget,
               store
             )
           } else {
@@ -13996,7 +14007,7 @@ export class OrcaRuntimeService {
             await cleanupUnusedWorktreePushTargetRemote(
               repo.path,
               removalTarget.id,
-              removedPushTarget,
+              requestedPushTarget,
               store,
               localWorktreeGitOptions
             )
@@ -14010,7 +14021,7 @@ export class OrcaRuntimeService {
           return {}
         }
         if (await isRuntimeWorktreePathMissing(repo, removalTarget.path, localWorktreeGitOptions)) {
-          if (!force && !removedMeta) {
+          if (!force && !requestedMeta) {
             // Why: without persisted metadata, require the renderer recovery
             // path before deleting Orca-only state for an unregistered path.
             throw new Error(UNREGISTERED_MISSING_WORKTREE_MESSAGE)
@@ -14023,13 +14034,13 @@ export class OrcaRuntimeService {
                 provider!,
                 repo.path,
                 removalTarget.id,
-                removedPushTarget,
+                requestedPushTarget,
                 store
               )
             : cleanupUnusedWorktreePushTargetRemote(
                 repo.path,
                 removalTarget.id,
-                removedPushTarget,
+                requestedPushTarget,
                 store,
                 localWorktreeGitOptions
               ))
@@ -14044,7 +14055,16 @@ export class OrcaRuntimeService {
         throw new Error(`Refusing to delete unregistered worktree path: ${removalTarget.path}`)
       }
       const canonicalWorktreePath = registeredWorktree.path
-      const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
+      const removedWorktreeIds = getEquivalentWorktreeIdsForRemoval(
+        store,
+        repo.id,
+        removalTarget.id,
+        canonicalWorktreePath
+      )
+      const removalMetadata = getWorktreeRemovalMetadata(store, removedWorktreeIds)
+      const removedPushTarget = removalMetadata.pushTarget ?? removalTarget.pushTarget
+      const cleanupStore = omitWorktreeMetaIds(store, removedWorktreeIds)
+      const deleteBranch = !removalMetadata.preserveBranchOnDelete
       if (repo.connectionId) {
         const rawRemovalResult = await (deleteBranch
           ? provider!.removeWorktree(canonicalWorktreePath, force)
@@ -14058,16 +14078,21 @@ export class OrcaRuntimeService {
           repo.path,
           removalTarget.id,
           removedPushTarget,
-          store
+          cleanupStore
         )
+        for (const worktreeId of removedWorktreeIds) {
+          this.preservedBranchCleanupByWorktreeId.delete(worktreeId)
+        }
         this.rememberPreservedBranchCleanupTarget(
           removalTarget.id,
           removalResult,
           registeredWorktree.head,
           removedPushTarget
         )
-        this.clearOptimisticReconcileToken(removalTarget.id)
-        this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
+        for (const worktreeId of removedWorktreeIds) {
+          this.clearOptimisticReconcileToken(worktreeId)
+        }
+        this.removeWorktreeMetadataAndHistory(store, removedWorktreeIds)
         this.invalidateResolvedWorktreeCache()
         invalidateAuthorizedRootsCache()
         this.notifyWorktreesChanged(repo.id)
@@ -14188,12 +14213,14 @@ export class OrcaRuntimeService {
             repo.path,
             removalTarget.id,
             removedPushTarget,
-            store,
+            cleanupStore,
             localWorktreeGitOptions
           )
-          this.clearOptimisticReconcileToken(removalTarget.id)
-          this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-          this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+          for (const worktreeId of removedWorktreeIds) {
+            this.clearOptimisticReconcileToken(worktreeId)
+            this.preservedBranchCleanupByWorktreeId.delete(worktreeId)
+          }
+          this.removeWorktreeMetadataAndHistory(store, removedWorktreeIds)
           this.invalidateResolvedWorktreeCache()
           invalidateAuthorizedRootsCache()
           this.notifyWorktreesChanged(repo.id)
@@ -14208,17 +14235,22 @@ export class OrcaRuntimeService {
         repo.path,
         removalTarget.id,
         removedPushTarget,
-        store,
+        cleanupStore,
         localWorktreeGitOptions
       )
+      for (const worktreeId of removedWorktreeIds) {
+        this.preservedBranchCleanupByWorktreeId.delete(worktreeId)
+      }
       this.rememberPreservedBranchCleanupTarget(
         removalTarget.id,
         removalResult,
         registeredWorktree.head,
         removedPushTarget
       )
-      this.clearOptimisticReconcileToken(removalTarget.id)
-      this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
+      for (const worktreeId of removedWorktreeIds) {
+        this.clearOptimisticReconcileToken(worktreeId)
+      }
+      this.removeWorktreeMetadataAndHistory(store, removedWorktreeIds)
       this.invalidateResolvedWorktreeCache()
       invalidateAuthorizedRootsCache()
       this.notifyWorktreesChanged(repo.id)

--- a/src/main/worktree-removal-metadata.ts
+++ b/src/main/worktree-removal-metadata.ts
@@ -1,0 +1,62 @@
+import type { GitPushTarget, WorktreeMeta } from '../shared/types'
+import { splitWorktreeId } from '../shared/worktree-id'
+import { areWorktreePathsEqual } from './ipc/worktree-logic'
+
+type WorktreeMetaReader = {
+  getAllWorktreeMeta(): Record<string, WorktreeMeta>
+  getWorktreeMeta(worktreeId: string): WorktreeMeta | undefined
+}
+
+export function getEquivalentWorktreeIdsForRemoval(
+  store: WorktreeMetaReader,
+  repoId: string,
+  requestedWorktreeId: string,
+  canonicalWorktreePath: string
+): string[] {
+  // Why: Windows Git can report the same registered worktree with different
+  // separators or drive casing than the renderer's path-derived worktree ID.
+  const equivalentIds = new Set([`${repoId}::${canonicalWorktreePath}`, requestedWorktreeId])
+  for (const worktreeId of Object.keys(store.getAllWorktreeMeta())) {
+    const parsed = splitWorktreeId(worktreeId)
+    if (!parsed || parsed.repoId !== repoId) {
+      continue
+    }
+    if (areWorktreePathsEqual(parsed.worktreePath, canonicalWorktreePath)) {
+      equivalentIds.add(worktreeId)
+    }
+  }
+  return [...equivalentIds]
+}
+
+export function getWorktreeRemovalMetadata(
+  store: WorktreeMetaReader,
+  worktreeIds: readonly string[]
+): { preserveBranchOnDelete: boolean; pushTarget?: GitPushTarget } {
+  let preserveBranchOnDelete = false
+  let pushTarget: GitPushTarget | undefined
+  for (const worktreeId of worktreeIds) {
+    const meta = store.getWorktreeMeta(worktreeId)
+    if (meta?.preserveBranchOnDelete === true) {
+      preserveBranchOnDelete = true
+    }
+    if (!pushTarget && meta?.pushTarget) {
+      pushTarget = meta.pushTarget
+    }
+  }
+  return { preserveBranchOnDelete, ...(pushTarget ? { pushTarget } : {}) }
+}
+
+export function omitWorktreeMetaIds(
+  store: WorktreeMetaReader,
+  omittedWorktreeIds: readonly string[]
+): Pick<WorktreeMetaReader, 'getAllWorktreeMeta'> {
+  const omitted = new Set(omittedWorktreeIds)
+  return {
+    getAllWorktreeMeta: () =>
+      Object.fromEntries(
+        Object.entries(store.getAllWorktreeMeta()).filter(
+          ([worktreeId]) => !omitted.has(worktreeId)
+        )
+      )
+  }
+}


### PR DESCRIPTION
## Summary
- resolve equivalent Windows worktree IDs during registered deletion so canonical/requested metadata and transient state are cleaned together
- use strict Git worktree listing for destructive delete paths so list failures surface instead of becoming false unregistered-path errors
- keep IPC/runtime local deletes on the selected project runtime options and reuse the validated Git row for branch cleanup

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/ipc/worktrees-windows.test.ts
- pnpm vitest run --config config/vitest.config.ts src/main/ipc/worktree-push-target-cleanup.test.ts
- pnpm vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts --testNamePattern "canonical registered path|selected-runtime list failures|worktree removal"
- pnpm run typecheck:node
- pnpm run lint
- git diff --check

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5909">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->