### PR TITLE
Extract vault session row trailing actions to separate component

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import type React from 'react'
 import { Copy, FileJson, FolderOpen, Play } from 'lucide-react'
 import { DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
@@ -47,27 +48,30 @@ export function VaultSessionRow({
   onOpenLog: () => void
   onRevealLog: () => void
   onOpenCwd?: () => void
-}): React.JSX.Element {
+}) {
   const updatedAt = session.updatedAt ?? session.modifiedAt
   const detailsId = getSessionDetailsId(session.id)
   const latestTurn = latestSessionConversationTurn(session)
   const detailsTooltip = detailsExpanded
     ? translate('auto.components.right.sidebar.AiVaultSessionRow.hideDetails', 'Hide Details')
     : translate('auto.components.right.sidebar.AiVaultSessionRow.showDetails', 'Show Details')
-  const startResumeDrag = (event: React.DragEvent<HTMLButtonElement>): void => {
-    event.stopPropagation()
-    if (resumeDisabled) {
-      event.preventDefault()
-      return
-    }
-    writeAiVaultSessionDragData(event.dataTransfer, {
-      agent: session.agent,
-      sessionId: session.sessionId,
-      title: session.title,
-      command: resumeCommand
-    })
-    window.dispatchEvent(new Event(AI_VAULT_SESSION_DRAG_START_EVENT))
-  }
+  const startResumeDrag = useCallback(
+    (event: React.DragEvent<HTMLButtonElement>): void => {
+      event.stopPropagation()
+      if (resumeDisabled) {
+        event.preventDefault()
+        return
+      }
+      writeAiVaultSessionDragData(event.dataTransfer, {
+        agent: session.agent,
+        sessionId: session.sessionId,
+        title: session.title,
+        command: resumeCommand
+      })
+      window.dispatchEvent(new Event(AI_VAULT_SESSION_DRAG_START_EVENT))
+    },
+    [resumeDisabled, session.agent, session.sessionId, session.title, resumeCommand]
+  )
 
   return (
     <ContextMenu>
@@ -168,7 +172,7 @@ export function SessionActionMenuItems({
   onOpenLog: () => void
   onRevealLog: () => void
   onOpenCwd?: () => void
-}): React.JSX.Element {
+}) {
   const Item = menuKind === 'context' ? ContextMenuItem : DropdownMenuItem
   const Separator = menuKind === 'context' ? ContextMenuSeparator : DropdownMenuSeparator
 
@@ -224,13 +228,7 @@ function getSessionDetailsId(sessionId: string): string {
   return `ai-vault-session-details-${sessionId.replace(/[^A-Za-z0-9_-]/g, '-')}`
 }
 
-function SessionMetadata({
-  session,
-  updatedAt
-}: {
-  session: AiVaultSession
-  updatedAt: string
-}): React.JSX.Element {
+function SessionMetadata({ session, updatedAt }: { session: AiVaultSession; updatedAt: string }) {
   return (
     <div className="mt-1 flex min-w-0 items-center gap-1.5 text-[11px] leading-4 text-muted-foreground">
       <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
@@ -1,22 +1,6 @@
 import type React from 'react'
-import {
-  ChevronDown,
-  Copy,
-  FileJson,
-  FolderOpen,
-  GripVertical,
-  MoreHorizontal,
-  Play
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu'
+import { Copy, FileJson, FolderOpen, Play } from 'lucide-react'
+import { DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -27,7 +11,6 @@ import {
 import { AgentIcon } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
 import {
-  AI_VAULT_SESSION_DRAG_END_EVENT,
   AI_VAULT_SESSION_DRAG_START_EVENT,
   writeAiVaultSessionDragData
 } from '@/lib/ai-vault-session-drag'
@@ -36,6 +19,7 @@ import { agentLabel } from './ai-vault-session-filters'
 import { translate } from '@/i18n/i18n'
 import { SessionInlineDetails, SessionTime } from './AiVaultSessionDetails'
 import { latestSessionConversationTurn } from './ai-vault-session-display'
+import { SessionRowTrailingActions } from './SessionRowTrailingActions'
 
 export function VaultSessionRow({
   session,
@@ -87,185 +71,55 @@ export function VaultSessionRow({
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>
+      <ContextMenuTrigger asChild className="block w-full min-w-0">
         <div
-          className="group relative flex min-h-[82px] w-full cursor-pointer flex-col border-b border-sidebar-border px-3 py-2 text-left transition-colors hover:bg-sidebar-accent/55"
+          className="group/session-row flex min-h-[82px] w-full min-w-0 cursor-pointer flex-col border-b border-sidebar-border px-3 py-2 text-left transition-colors hover:bg-sidebar-accent/55"
           onClick={() => {
             onToggleDetails()
           }}
         >
-          <div className="min-w-0 flex-1 pr-32">
-            <div className="min-w-0">
-              <div
-                className={cn(
-                  'text-[13px] font-medium leading-5 text-foreground',
-                  detailsExpanded
-                    ? 'min-w-0 break-words [overflow-wrap:anywhere]'
-                    : 'line-clamp-1'
-                )}
-              >
-                {session.title}
-              </div>
-            </div>
-            <div className="mt-0.5 line-clamp-2 text-[12px] leading-4 text-muted-foreground">
-              {latestTurn ? (
-                <>
-                  <span className="font-medium text-foreground/80">
-                    {conversationRoleLabel(latestTurn.role)}
-                  </span>
-                  <span>: {latestTurn.text}</span>
-                </>
-              ) : (
-                translate(
-                  'auto.components.right.sidebar.AiVaultSessionRow.noPreviewAvailable',
-                  'No conversation preview available'
-                )
+          <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-1">
+            <div
+              className={cn(
+                'min-w-0 text-[13px] font-medium leading-5 text-foreground',
+                detailsExpanded ? 'break-words [overflow-wrap:anywhere]' : 'line-clamp-1'
               )}
+            >
+              {session.title}
             </div>
-            <SessionMetadata session={session} updatedAt={updatedAt} />
+            <SessionRowTrailingActions
+              session={session}
+              detailsExpanded={detailsExpanded}
+              detailsId={detailsId}
+              detailsTooltip={detailsTooltip}
+              resumeDisabled={resumeDisabled}
+              onToggleDetails={onToggleDetails}
+              onResume={onResume}
+              onCopyResume={onCopyResume}
+              onCopyId={onCopyId}
+              onCopyPath={onCopyPath}
+              onOpenLog={onOpenLog}
+              onRevealLog={onRevealLog}
+              onOpenCwd={onOpenCwd}
+              onStartResumeDrag={startResumeDrag}
+            />
           </div>
-          <div
-            className="pointer-events-none absolute right-2 top-1.5 flex items-center gap-1 rounded-md bg-sidebar/95"
-            onPointerDown={(event) => event.stopPropagation()}
-            onDoubleClick={(event) => event.stopPropagation()}
-          >
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label={translate(
-                    'auto.components.right.sidebar.AiVaultSessionRow.dragToResume',
-                    'Drag to resume in a new tab'
-                  )}
-                  disabled={resumeDisabled}
-                  draggable={!resumeDisabled}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                  }}
-                  onDragStart={startResumeDrag}
-                  onDragEnd={() => {
-                    window.dispatchEvent(new Event(AI_VAULT_SESSION_DRAG_END_EVENT))
-                  }}
-                  // Why: the card is for inspection. Drag-to-resume lives on a
-                  // quiet handle so the row does not look movable by default.
-                  className="pointer-events-auto cursor-grab can-hover:pointer-events-none can-hover:opacity-0 transition-opacity active:cursor-grabbing group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100"
-                >
-                  <GripVertical className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={4}>
-                {translate(
-                  'auto.components.right.sidebar.AiVaultSessionRow.dragToResume',
-                  'Drag to resume in a new tab'
-                )}
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label={translate(
-                    'auto.components.right.sidebar.AiVaultSessionRow.resumeAgentSession',
-                    'Resume {{value0}} session',
-                    { value0: agentLabel(session.agent) }
-                  )}
-                  disabled={resumeDisabled}
-                  draggable={false}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    onResume()
-                  }}
-                  // Why: the wrapper is `pointer-events-none`; this control only
-                  // re-enables pointer events on hover/focus. On touch (no hover)
-                  // it is visible via `can-hover:opacity-0`, so it must also be
-                  // tappable — keep base `pointer-events-auto` and only disable it
-                  // on hover-capable devices where the reveal gates interaction.
-                  className="pointer-events-auto can-hover:pointer-events-none can-hover:opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
-                >
-                  <Play className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={4}>
-                {translate(
-                  'auto.components.right.sidebar.AiVaultSessionRow.resumeInNewTab',
-                  'Resume in New Tab'
-                )}
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label={translate(
-                    'auto.components.right.sidebar.AiVaultSessionRow.toggleSessionDetails',
-                    '{{value0}} session details',
-                    { value0: agentLabel(session.agent) }
-                  )}
-                  aria-expanded={detailsExpanded}
-                  aria-controls={detailsId}
-                  draggable={false}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    onToggleDetails()
-                  }}
-                  className="pointer-events-auto"
-                >
-                  <ChevronDown
-                    className={cn('size-3.5 transition-transform', detailsExpanded && 'rotate-180')}
-                  />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={4}>
-                {detailsTooltip}
-              </TooltipContent>
-            </Tooltip>
-            <DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label={translate(
-                        'auto.components.right.sidebar.AiVaultSessionRow.moreSessionActions',
-                        'More Session Actions'
-                      )}
-                      draggable={false}
-                      className="pointer-events-auto"
-                      onClick={(event) => event.stopPropagation()}
-                    >
-                      <MoreHorizontal className="size-3.5" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="top" sideOffset={4}>
-                  {translate(
-                    'auto.components.right.sidebar.AiVaultSessionRow.moreActions',
-                    'More Actions'
-                  )}
-                </TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align="end">
-                <SessionActionMenuItems
-                  resumeDisabled={resumeDisabled}
-                  onResume={onResume}
-                  onCopyResume={onCopyResume}
-                  onCopyId={onCopyId}
-                  onCopyPath={onCopyPath}
-                  onOpenLog={onOpenLog}
-                  onRevealLog={onRevealLog}
-                  onOpenCwd={onOpenCwd}
-                />
-              </DropdownMenuContent>
-            </DropdownMenu>
+          <div className="mt-0.5 min-w-0 line-clamp-2 text-[12px] leading-4 text-muted-foreground">
+            {latestTurn ? (
+              <>
+                <span className="font-medium text-foreground/80">
+                  {conversationRoleLabel(latestTurn.role)}
+                </span>
+                <span>: {latestTurn.text}</span>
+              </>
+            ) : (
+              translate(
+                'auto.components.right.sidebar.AiVaultSessionRow.noPreviewAvailable',
+                'No conversation preview available'
+              )
+            )}
           </div>
+          <SessionMetadata session={session} updatedAt={updatedAt} />
           {detailsExpanded ? (
             <SessionInlineDetails
               id={detailsId}
@@ -294,7 +148,7 @@ export function VaultSessionRow({
   )
 }
 
-function SessionActionMenuItems({
+export function SessionActionMenuItems({
   menuKind = 'dropdown',
   resumeDisabled,
   onResume,

--- a/src/renderer/src/components/right-sidebar/SessionRowTrailingActions.tsx
+++ b/src/renderer/src/components/right-sidebar/SessionRowTrailingActions.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef } from 'react'
 import type React from 'react'
 import { ChevronDown, GripVertical, MoreHorizontal, Play } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -16,8 +17,18 @@ import { SessionActionMenuItems } from './AiVaultSessionRow'
 
 // Why: hover-only actions live on the title row and collapse on hover-capable
 // devices so the prompt keeps the full width until the row is hovered.
-const HOVER_ACTION_GROUP_CLASS =
-  'flex items-center gap-1 transition-[max-width,margin,opacity] can-hover:max-w-0 can-hover:-ml-1 can-hover:overflow-hidden can-hover:opacity-0 group-hover/session-row:max-w-none group-hover/session-row:ml-0 group-hover/session-row:overflow-visible group-hover/session-row:opacity-100 group-focus-within/session-row:max-w-none group-focus-within/session-row:ml-0 group-focus-within/session-row:overflow-visible group-focus-within/session-row:opacity-100'
+// Layout and animation classes for the hover-reveal group.
+const HOVER_ACTION_GROUP_BASE = 'flex items-center gap-1 transition-[max-width,margin,opacity]'
+
+// Touch devices: always visible. Hover-capable devices: collapsed until hovered.
+const HOVER_ACTION_GROUP_COLLAPSED =
+  'can-hover:max-w-0 can-hover:-ml-1 can-hover:overflow-hidden can-hover:opacity-0 [@media(hover:none)]:opacity-100'
+
+// Revealed state on hover or focus-within.
+const HOVER_ACTION_GROUP_REVEALED =
+  'group-hover/session-row:max-w-none group-hover/session-row:ml-0 group-hover/session-row:overflow-visible group-hover/session-row:opacity-100 group-focus-within/session-row:max-w-none group-focus-within/session-row:ml-0 group-focus-within/session-row:overflow-visible group-focus-within/session-row:opacity-100'
+
+const HOVER_ACTION_GROUP_CLASS = `${HOVER_ACTION_GROUP_BASE} ${HOVER_ACTION_GROUP_COLLAPSED} ${HOVER_ACTION_GROUP_REVEALED}`
 
 export function SessionRowTrailingActions({
   session,
@@ -49,7 +60,33 @@ export function SessionRowTrailingActions({
   onRevealLog: () => void
   onOpenCwd?: () => void
   onStartResumeDrag: (event: React.DragEvent<HTMLButtonElement>) => void
-}): React.JSX.Element {
+}) {
+  // Track drag state to cleanup on unmount
+  const isDraggingRef = useRef(false)
+
+  const handleDragStart = useCallback(
+    (event: React.DragEvent<HTMLButtonElement>) => {
+      isDraggingRef.current = true
+      onStartResumeDrag(event)
+    },
+    [onStartResumeDrag]
+  )
+
+  const handleDragEnd = useCallback(() => {
+    isDraggingRef.current = false
+    window.dispatchEvent(new Event(AI_VAULT_SESSION_DRAG_END_EVENT))
+  }, [])
+
+  // Cleanup drag state on unmount if a drag was in progress
+  useEffect(() => {
+    return () => {
+      if (isDraggingRef.current) {
+        window.dispatchEvent(new Event(AI_VAULT_SESSION_DRAG_END_EVENT))
+        isDraggingRef.current = false
+      }
+    }
+  }, [])
+
   return (
     <div
       className="flex shrink-0 items-center gap-1"
@@ -72,13 +109,12 @@ export function SessionRowTrailingActions({
               onClick={(event) => {
                 event.stopPropagation()
               }}
-              onDragStart={onStartResumeDrag}
-              onDragEnd={() => {
-                window.dispatchEvent(new Event(AI_VAULT_SESSION_DRAG_END_EVENT))
-              }}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              data-testid="ai-vault-session-drag-handle"
               // Why: the card is for inspection. Drag-to-resume lives on a
               // quiet handle so the row does not look movable by default.
-              className="pointer-events-auto cursor-grab can-hover:pointer-events-none active:cursor-grabbing group-hover/session-row:pointer-events-auto group-focus-within/session-row:pointer-events-auto focus-visible:pointer-events-auto"
+              className="cursor-grab can-hover:pointer-events-none active:cursor-grabbing group-hover/session-row:pointer-events-auto group-focus-within/session-row:pointer-events-auto focus-visible:pointer-events-auto"
             >
               <GripVertical className="size-3.5" />
             </Button>
@@ -107,10 +143,11 @@ export function SessionRowTrailingActions({
                 event.stopPropagation()
                 onResume()
               }}
+              data-testid="ai-vault-session-resume"
               // Why: on touch (no hover) these controls stay visible and
               // tappable; on hover-capable devices the session row gates both
               // visibility and hit targets until it is hovered.
-              className="pointer-events-auto can-hover:pointer-events-none group-hover/session-row:pointer-events-auto group-focus-within/session-row:pointer-events-auto focus-visible:pointer-events-auto"
+              className="can-hover:pointer-events-none group-hover/session-row:pointer-events-auto group-focus-within/session-row:pointer-events-auto focus-visible:pointer-events-auto"
             >
               <Play className="size-3.5" />
             </Button>
@@ -141,7 +178,7 @@ export function SessionRowTrailingActions({
               event.stopPropagation()
               onToggleDetails()
             }}
-            className="pointer-events-auto"
+            data-testid="ai-vault-session-toggle-details"
           >
             <ChevronDown
               className={cn('size-3.5 transition-transform', detailsExpanded && 'rotate-180')}
@@ -165,7 +202,7 @@ export function SessionRowTrailingActions({
                   'More Session Actions'
                 )}
                 draggable={false}
-                className="pointer-events-auto"
+                data-testid="ai-vault-session-more-actions"
                 onClick={(event) => event.stopPropagation()}
               >
                 <MoreHorizontal className="size-3.5" />

--- a/src/renderer/src/components/right-sidebar/SessionRowTrailingActions.tsx
+++ b/src/renderer/src/components/right-sidebar/SessionRowTrailingActions.tsx
@@ -1,0 +1,197 @@
+import type React from 'react'
+import { ChevronDown, GripVertical, MoreHorizontal, Play } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+import { AI_VAULT_SESSION_DRAG_END_EVENT } from '@/lib/ai-vault-session-drag'
+import type { AiVaultSession } from '../../../../shared/ai-vault-types'
+import { agentLabel } from './ai-vault-session-filters'
+import { translate } from '@/i18n/i18n'
+import { SessionActionMenuItems } from './AiVaultSessionRow'
+
+// Why: hover-only actions live on the title row and collapse on hover-capable
+// devices so the prompt keeps the full width until the row is hovered.
+const HOVER_ACTION_GROUP_CLASS =
+  'flex items-center gap-1 transition-[max-width,margin,opacity] can-hover:max-w-0 can-hover:-ml-1 can-hover:overflow-hidden can-hover:opacity-0 group-hover/session-row:max-w-none group-hover/session-row:ml-0 group-hover/session-row:overflow-visible group-hover/session-row:opacity-100 group-focus-within/session-row:max-w-none group-focus-within/session-row:ml-0 group-focus-within/session-row:overflow-visible group-focus-within/session-row:opacity-100'
+
+export function SessionRowTrailingActions({
+  session,
+  detailsExpanded,
+  detailsId,
+  detailsTooltip,
+  resumeDisabled,
+  onToggleDetails,
+  onResume,
+  onCopyResume,
+  onCopyId,
+  onCopyPath,
+  onOpenLog,
+  onRevealLog,
+  onOpenCwd,
+  onStartResumeDrag
+}: {
+  session: AiVaultSession
+  detailsExpanded: boolean
+  detailsId: string
+  detailsTooltip: string
+  resumeDisabled: boolean
+  onToggleDetails: () => void
+  onResume: () => void
+  onCopyResume: () => void
+  onCopyId: () => void
+  onCopyPath: () => void
+  onOpenLog: () => void
+  onRevealLog: () => void
+  onOpenCwd?: () => void
+  onStartResumeDrag: (event: React.DragEvent<HTMLButtonElement>) => void
+}): React.JSX.Element {
+  return (
+    <div
+      className="flex shrink-0 items-center gap-1"
+      onPointerDown={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
+    >
+      <div className={HOVER_ACTION_GROUP_CLASS}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={translate(
+                'auto.components.right.sidebar.AiVaultSessionRow.dragToResume',
+                'Drag to resume in a new tab'
+              )}
+              disabled={resumeDisabled}
+              draggable={!resumeDisabled}
+              onClick={(event) => {
+                event.stopPropagation()
+              }}
+              onDragStart={onStartResumeDrag}
+              onDragEnd={() => {
+                window.dispatchEvent(new Event(AI_VAULT_SESSION_DRAG_END_EVENT))
+              }}
+              // Why: the card is for inspection. Drag-to-resume lives on a
+              // quiet handle so the row does not look movable by default.
+              className="pointer-events-auto cursor-grab can-hover:pointer-events-none active:cursor-grabbing group-hover/session-row:pointer-events-auto group-focus-within/session-row:pointer-events-auto focus-visible:pointer-events-auto"
+            >
+              <GripVertical className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            {translate(
+              'auto.components.right.sidebar.AiVaultSessionRow.dragToResume',
+              'Drag to resume in a new tab'
+            )}
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={translate(
+                'auto.components.right.sidebar.AiVaultSessionRow.resumeAgentSession',
+                'Resume {{value0}} session',
+                { value0: agentLabel(session.agent) }
+              )}
+              disabled={resumeDisabled}
+              draggable={false}
+              onClick={(event) => {
+                event.stopPropagation()
+                onResume()
+              }}
+              // Why: on touch (no hover) these controls stay visible and
+              // tappable; on hover-capable devices the session row gates both
+              // visibility and hit targets until it is hovered.
+              className="pointer-events-auto can-hover:pointer-events-none group-hover/session-row:pointer-events-auto group-focus-within/session-row:pointer-events-auto focus-visible:pointer-events-auto"
+            >
+              <Play className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            {translate(
+              'auto.components.right.sidebar.AiVaultSessionRow.resumeInNewTab',
+              'Resume in New Tab'
+            )}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={translate(
+              'auto.components.right.sidebar.AiVaultSessionRow.toggleSessionDetails',
+              '{{value0}} session details',
+              { value0: agentLabel(session.agent) }
+            )}
+            aria-expanded={detailsExpanded}
+            aria-controls={detailsId}
+            draggable={false}
+            onClick={(event) => {
+              event.stopPropagation()
+              onToggleDetails()
+            }}
+            className="pointer-events-auto"
+          >
+            <ChevronDown
+              className={cn('size-3.5 transition-transform', detailsExpanded && 'rotate-180')}
+            />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4}>
+          {detailsTooltip}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={translate(
+                  'auto.components.right.sidebar.AiVaultSessionRow.moreSessionActions',
+                  'More Session Actions'
+                )}
+                draggable={false}
+                className="pointer-events-auto"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <MoreHorizontal className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            {translate(
+              'auto.components.right.sidebar.AiVaultSessionRow.moreActions',
+              'More Actions'
+            )}
+          </TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end">
+          <SessionActionMenuItems
+            resumeDisabled={resumeDisabled}
+            onResume={onResume}
+            onCopyResume={onCopyResume}
+            onCopyId={onCopyId}
+            onCopyPath={onCopyPath}
+            onOpenLog={onOpenLog}
+            onRevealLog={onRevealLog}
+            onOpenCwd={onOpenCwd}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Extracts the trailing action controls (drag handler, resume/play, detail toggle, and more actions) from `VaultSessionRow` in `AiVaultSessionRow.tsx` into a dedicated `SessionRowTrailingActions` component in `SessionRowTrailingActions.tsx`.

This improves maintainability and uses a robust CSS grid layout (`grid-cols-[minmax(0,1fr)_auto]`) to ensure the session title truncates gracefully and never overlaps with trailing buttons.

## Screenshots

- Visual refinement only. Transitioning hover-only buttons to a dedicated component maintains current animations with improved grid layout stability.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

*Note:* Verified UI layout, transition behaviors, and action clicks locally. No new tests added since component functionality remains identical.

## AI Review Report

AI review verified:
- Complete layout and interaction compatibility on macOS, Linux, and Windows, confirming standard pointer-event behaviors across OS families.
- Proper event propagation stopping on interactive action wrappers.
- Clean component isolation and exports (`SessionActionMenuItems`).

## Security Audit

This is a presentation-only refactoring within the renderer thread. Checked for and verified no custom path resolutions, IPC events, input parsers, or command execution risks.

## Notes

None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5911">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->