### PR TITLE
Select last visited worktree repo by default on mobile

### DIFF
--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -41,6 +41,12 @@ import {
   type NewWorktreeAgentOption as AgentOption
 } from './new-worktree-agent-selection'
 import { getCachedRepos, setCachedRepos } from '../cache/repo-cache'
+import { useLastVisitedWorktreeRepoId } from '../worktree/use-last-visited-worktree-repo'
+import {
+  getMobileNewWorkspaceDialogEligibleRepos,
+  refreshMobileNewWorkspaceDialogSelectedRepo,
+  resolveMobileNewWorkspaceDialogRepoId
+} from '../worktree/new-workspace-dialog-repo-selection'
 
 type Repo = {
   id: string
@@ -165,9 +171,7 @@ function NewWorktreeModalContent({
 }: Props) {
   const [initialRepos] = useState(() => (hostId ? (getCachedRepos(hostId) as Repo[] | null) : null))
   const [repos, setRepos] = useState<Repo[]>(initialRepos ?? [])
-  const [selectedRepo, setSelectedRepo] = useState<Repo | null>(
-    initialRepos?.length === 1 ? initialRepos[0]! : null
-  )
+  const [selectedRepo, setSelectedRepo] = useState<Repo | null>(null)
   const [showRepoPicker, setShowRepoPicker] = useState(false)
   const [selectedAgentState, setSelectedAgent] = useState<AgentOption>(AGENT_OPTIONS[0]!)
   const [runtimeSettings, setRuntimeSettings] = useState<RuntimeSettings | null>(null)
@@ -192,6 +196,7 @@ function NewWorktreeModalContent({
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(initialRepos == null)
+  const lastVisitedRepo = useLastVisitedWorktreeRepoId(hostId, visible)
 
   // Why: matches the desktop UI — the input shows a generic "Workspace name"
   // placeholder, not the suggested creature. The creature name is only used
@@ -235,6 +240,21 @@ function NewWorktreeModalContent({
   const selectedAgent = selectedAgentResolution.selectedAgent
 
   useEffect(() => {
+    if (!visible || !lastVisitedRepo.loaded || selectedRepo || repos.length === 0) {
+      return
+    }
+    const eligibleRepos = getMobileNewWorkspaceDialogEligibleRepos(repos)
+    const preferredRepoId = resolveMobileNewWorkspaceDialogRepoId({
+      eligibleRepos,
+      activeRepoId: lastVisitedRepo.repoId
+    })
+    const preferredRepo = repos.find((repo) => repo.id === preferredRepoId) ?? null
+    if (preferredRepo) {
+      setSelectedRepo(preferredRepo)
+    }
+  }, [lastVisitedRepo.loaded, lastVisitedRepo.repoId, repos, selectedRepo, visible])
+
+  useEffect(() => {
     if (!visible || !client) {
       return
     }
@@ -257,10 +277,9 @@ function NewWorktreeModalContent({
             setCachedRepos(hostId, result.repos)
           }
           setSelectedRepo((current) => {
-            if (current) {
-              return result.repos.find((repo) => repo.id === current.id) ?? current
-            }
-            return result.repos.length === 1 ? result.repos[0]! : null
+            // Why: the optimistic cache can include repos removed before the
+            // fresh repo.list returns; never create against a stale repo id.
+            return refreshMobileNewWorkspaceDialogSelectedRepo(result.repos, current)
           })
         }
       })

--- a/mobile/src/worktree/last-visited-worktree-repo.test.ts
+++ b/mobile/src/worktree/last-visited-worktree-repo.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { readLastVisitedWorktreeRepoId } from './last-visited-worktree-repo'
+
+describe('last visited worktree repo', () => {
+  it('extracts the repo id for the current host', () => {
+    const raw = JSON.stringify({ hostId: 'host-1', worktreeId: 'repo-2::/tmp/worktree' })
+
+    expect(readLastVisitedWorktreeRepoId(raw, 'host-1')).toBe('repo-2')
+  })
+
+  it('ignores records for another host', () => {
+    const raw = JSON.stringify({ hostId: 'host-2', worktreeId: 'repo-2::/tmp/worktree' })
+
+    expect(readLastVisitedWorktreeRepoId(raw, 'host-1')).toBeNull()
+  })
+
+  it('ignores malformed stored values', () => {
+    expect(readLastVisitedWorktreeRepoId('{', 'host-1')).toBeNull()
+    expect(readLastVisitedWorktreeRepoId(JSON.stringify({ hostId: 'host-1' }), 'host-1')).toBeNull()
+  })
+})

--- a/mobile/src/worktree/last-visited-worktree-repo.ts
+++ b/mobile/src/worktree/last-visited-worktree-repo.ts
@@ -1,0 +1,40 @@
+import { getRepoIdFromMobileWorktreeId } from '../session/mobile-session-route-helpers'
+
+export const LAST_VISITED_WORKTREE_STORAGE_KEY = 'orca:last-visited-worktree'
+
+type LastVisitedWorktreeRecord = {
+  hostId: string
+  worktreeId: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function readLastVisitedWorktreeRecord(raw: string | null): LastVisitedWorktreeRecord | null {
+  if (!raw) {
+    return null
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      !isRecord(parsed) ||
+      typeof parsed.hostId !== 'string' ||
+      typeof parsed.worktreeId !== 'string'
+    ) {
+      return null
+    }
+    return { hostId: parsed.hostId, worktreeId: parsed.worktreeId }
+  } catch {
+    return null
+  }
+}
+
+export function readLastVisitedWorktreeRepoId(raw: string | null, hostId: string): string | null {
+  const record = readLastVisitedWorktreeRecord(raw)
+  if (!record || record.hostId !== hostId) {
+    return null
+  }
+  const repoId = getRepoIdFromMobileWorktreeId(record.worktreeId).trim()
+  return repoId || null
+}

--- a/mobile/src/worktree/new-workspace-dialog-repo-selection.test.ts
+++ b/mobile/src/worktree/new-workspace-dialog-repo-selection.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getMobileNewWorkspaceDialogEligibleRepos,
+  refreshMobileNewWorkspaceDialogSelectedRepo,
+  resolveMobileNewWorkspaceDialogRepoId
+} from './new-workspace-dialog-repo-selection'
+
+type Repo = {
+  id: string
+  path: string
+  connectionId?: string | null
+  executionHostId?: 'local' | `ssh:${string}` | `runtime:${string}` | null
+}
+
+function makeRepo(id: string, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path: `/repos/${id}`,
+    ...overrides
+  }
+}
+
+describe('mobile new workspace dialog repo selection', () => {
+  it('matches the dialog repo priority order', () => {
+    const eligibleRepos = [
+      makeRepo('first'),
+      makeRepo('active'),
+      makeRepo('initial'),
+      makeRepo('draft')
+    ]
+
+    expect(
+      resolveMobileNewWorkspaceDialogRepoId({
+        eligibleRepos,
+        draftRepoId: 'draft',
+        initialRepoId: 'initial',
+        activeRepoId: 'active'
+      })
+    ).toBe('draft')
+  })
+
+  it('uses the last visited repo as the active repo before falling back', () => {
+    const eligibleRepos = [makeRepo('first'), makeRepo('active')]
+
+    expect(resolveMobileNewWorkspaceDialogRepoId({ eligibleRepos, activeRepoId: 'active' })).toBe(
+      'active'
+    )
+    expect(resolveMobileNewWorkspaceDialogRepoId({ eligibleRepos, activeRepoId: 'missing' })).toBe(
+      'first'
+    )
+  })
+
+  it('defaults to a repo on the focused host when no explicit repo is chosen', () => {
+    const eligibleRepos = [
+      makeRepo('local-repo'),
+      makeRepo('ssh-repo', { connectionId: 'win-vm' }),
+      makeRepo('runtime-repo', { executionHostId: 'runtime:env-1' })
+    ]
+
+    expect(
+      resolveMobileNewWorkspaceDialogRepoId({ eligibleRepos, focusedHostScope: 'ssh:win-vm' })
+    ).toBe('ssh-repo')
+    expect(
+      resolveMobileNewWorkspaceDialogRepoId({
+        eligibleRepos,
+        focusedHostScope: 'runtime:env-1'
+      })
+    ).toBe('runtime-repo')
+    expect(
+      resolveMobileNewWorkspaceDialogRepoId({ eligibleRepos, focusedHostScope: 'local' })
+    ).toBe('local-repo')
+  })
+
+  it('excludes repos without paths from dialog defaults', () => {
+    expect(
+      getMobileNewWorkspaceDialogEligibleRepos([
+        makeRepo('missing-path', { path: '' }),
+        makeRepo('repo')
+      ])
+    ).toEqual([expect.objectContaining({ id: 'repo' })])
+  })
+
+  it('refreshes the selected repo from the fresh repo list', () => {
+    const staleSelectedRepo = makeRepo('repo', { path: '/cached/repo' })
+    const freshRepo = makeRepo('repo', { path: '/fresh/repo' })
+
+    expect(refreshMobileNewWorkspaceDialogSelectedRepo([freshRepo], staleSelectedRepo)).toBe(
+      freshRepo
+    )
+  })
+
+  it('clears a cached selected repo that is missing from the fresh repo list', () => {
+    expect(
+      refreshMobileNewWorkspaceDialogSelectedRepo([makeRepo('fresh')], makeRepo('stale'))
+    ).toBe(null)
+  })
+})

--- a/mobile/src/worktree/new-workspace-dialog-repo-selection.ts
+++ b/mobile/src/worktree/new-workspace-dialog-repo-selection.ts
@@ -1,0 +1,63 @@
+type ExecutionHostScope = 'all' | 'local' | `ssh:${string}` | `runtime:${string}`
+
+type MobileNewWorkspaceDialogRepo = {
+  id: string
+  path: string
+  connectionId?: string | null
+  executionHostId?: 'local' | `ssh:${string}` | `runtime:${string}` | null
+}
+
+export function getMobileNewWorkspaceDialogEligibleRepos<T extends { path: string }>(
+  repos: readonly T[]
+): T[] {
+  return repos.filter((repo) => Boolean(repo.path))
+}
+
+function getMobileRepoExecutionHostId(
+  repo: MobileNewWorkspaceDialogRepo
+): Exclude<ExecutionHostScope, 'all'> {
+  if (repo.executionHostId) {
+    return repo.executionHostId
+  }
+  return repo.connectionId ? `ssh:${encodeURIComponent(repo.connectionId)}` : 'local'
+}
+
+export function resolveMobileNewWorkspaceDialogRepoId({
+  eligibleRepos,
+  draftRepoId,
+  initialRepoId,
+  activeRepoId,
+  focusedHostScope
+}: {
+  eligibleRepos: readonly MobileNewWorkspaceDialogRepo[]
+  draftRepoId?: string | null
+  initialRepoId?: string | null
+  activeRepoId?: string | null
+  focusedHostScope?: ExecutionHostScope | null
+}): string {
+  // Why: Metro cannot bundle runtime imports from the root shared tree today.
+  // Keep this mirror in sync with src/shared/new-workspace-dialog-repo.ts.
+  const focusedHostRepo =
+    focusedHostScope && focusedHostScope !== 'all'
+      ? eligibleRepos.find((repo) => getMobileRepoExecutionHostId(repo) === focusedHostScope)
+      : undefined
+
+  const resolvedRepo =
+    (draftRepoId && eligibleRepos.find((repo) => repo.id === draftRepoId)) ||
+    (initialRepoId && eligibleRepos.find((repo) => repo.id === initialRepoId)) ||
+    (activeRepoId && eligibleRepos.find((repo) => repo.id === activeRepoId)) ||
+    focusedHostRepo ||
+    eligibleRepos[0]
+
+  return resolvedRepo?.id ?? ''
+}
+
+export function refreshMobileNewWorkspaceDialogSelectedRepo<T extends { id: string }>(
+  repos: readonly T[],
+  current: T | null
+): T | null {
+  if (!current) {
+    return null
+  }
+  return repos.find((repo) => repo.id === current.id) ?? null
+}

--- a/mobile/src/worktree/use-last-visited-worktree-repo.ts
+++ b/mobile/src/worktree/use-last-visited-worktree-repo.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  LAST_VISITED_WORKTREE_STORAGE_KEY,
+  readLastVisitedWorktreeRepoId
+} from './last-visited-worktree-repo'
+
+export function useLastVisitedWorktreeRepoId(
+  hostId: string | undefined,
+  enabled: boolean
+): { loaded: boolean; repoId: string | null } {
+  const [lastVisitedRepoId, setLastVisitedRepoId] = useState<string | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!enabled || !hostId) {
+      setLastVisitedRepoId(null)
+      setLoaded(enabled)
+      return
+    }
+    let stale = false
+    setLoaded(false)
+    void AsyncStorage.getItem(LAST_VISITED_WORKTREE_STORAGE_KEY)
+      .then((raw) => {
+        if (stale) {
+          return
+        }
+        setLastVisitedRepoId(readLastVisitedWorktreeRepoId(raw, hostId))
+        setLoaded(true)
+      })
+      .catch(() => {
+        if (!stale) {
+          setLastVisitedRepoId(null)
+          setLoaded(true)
+        }
+      })
+
+    return () => {
+      stale = true
+    }
+  }, [enabled, hostId])
+
+  return { loaded, repoId: lastVisitedRepoId }
+}

--- a/src/renderer/src/lib/new-workspace-composer-repo.ts
+++ b/src/renderer/src/lib/new-workspace-composer-repo.ts
@@ -1,13 +1,13 @@
+import type { ExecutionHostScope } from '../../../shared/execution-host'
 import {
-  ALL_EXECUTION_HOSTS_SCOPE,
-  getRepoExecutionHostId,
-  type ExecutionHostScope
-} from '../../../shared/execution-host'
-import { isGitRepoKind } from '../../../shared/repo-kind'
+  getNewWorkspaceDialogEligibleRepos,
+  resolveNewWorkspaceDialogGitRepoId,
+  resolveNewWorkspaceDialogRepoId
+} from '../../../shared/new-workspace-dialog-repo'
 import type { Repo } from '../../../shared/types'
 
 export function getComposerEligibleRepos(repos: readonly Repo[]): Repo[] {
-  return repos.filter((repo) => Boolean(repo.path))
+  return getNewWorkspaceDialogEligibleRepos(repos)
 }
 
 export function resolveComposerRepoId({
@@ -23,22 +23,13 @@ export function resolveComposerRepoId({
   activeRepoId?: string | null
   focusedHostScope?: ExecutionHostScope | null
 }): string {
-  // Why: explicit choices (draft/initial/active) win, but the generic fallback
-  // must honor the focused host scope so "new workspace defaults to the
-  // focused host" holds for Landing/Cmd+J entry points (multi-host plan).
-  const focusedHostRepo =
-    focusedHostScope && focusedHostScope !== ALL_EXECUTION_HOSTS_SCOPE
-      ? eligibleRepos.find((repo) => getRepoExecutionHostId(repo) === focusedHostScope)
-      : undefined
-
-  const resolvedRepo =
-    (draftRepoId && eligibleRepos.find((repo) => repo.id === draftRepoId)) ||
-    (initialRepoId && eligibleRepos.find((repo) => repo.id === initialRepoId)) ||
-    (activeRepoId && eligibleRepos.find((repo) => repo.id === activeRepoId)) ||
-    focusedHostRepo ||
-    eligibleRepos[0]
-
-  return resolvedRepo?.id ?? ''
+  return resolveNewWorkspaceDialogRepoId({
+    eligibleRepos,
+    draftRepoId,
+    initialRepoId,
+    activeRepoId,
+    focusedHostScope
+  })
 }
 
 export function resolveComposerGitRepoId(args: {
@@ -48,7 +39,5 @@ export function resolveComposerGitRepoId(args: {
   activeRepoId?: string | null
   focusedHostScope?: ExecutionHostScope | null
 }): string | null {
-  const repoId = resolveComposerRepoId(args)
-  const repo = repoId ? args.eligibleRepos.find((entry) => entry.id === repoId) : null
-  return repo && isGitRepoKind(repo) ? repo.id : null
+  return resolveNewWorkspaceDialogGitRepoId(args)
 }

--- a/src/shared/new-workspace-dialog-repo.test.ts
+++ b/src/shared/new-workspace-dialog-repo.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from './types'
+import {
+  getNewWorkspaceDialogEligibleRepos,
+  resolveNewWorkspaceDialogGitRepoId,
+  resolveNewWorkspaceDialogRepoId
+} from './new-workspace-dialog-repo'
+
+function makeRepo(id: string, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path: `/repos/${id}`,
+    displayName: id,
+    badgeColor: '#000000',
+    addedAt: 0,
+    ...overrides
+  }
+}
+
+describe('new workspace dialog repo selection', () => {
+  it('matches the dialog repo priority order', () => {
+    const eligibleRepos = [
+      makeRepo('first'),
+      makeRepo('active'),
+      makeRepo('initial'),
+      makeRepo('draft')
+    ]
+
+    expect(
+      resolveNewWorkspaceDialogRepoId({
+        eligibleRepos,
+        draftRepoId: 'draft',
+        initialRepoId: 'initial',
+        activeRepoId: 'active'
+      })
+    ).toBe('draft')
+  })
+
+  it('falls back through initial, active, then first eligible repo', () => {
+    const eligibleRepos = [makeRepo('first'), makeRepo('active')]
+
+    expect(resolveNewWorkspaceDialogRepoId({ eligibleRepos, initialRepoId: 'missing' })).toBe(
+      'first'
+    )
+    expect(resolveNewWorkspaceDialogRepoId({ eligibleRepos, activeRepoId: 'active' })).toBe(
+      'active'
+    )
+  })
+
+  it('returns null for create-base prefetch when the dialog default is a folder repo', () => {
+    const eligibleRepos = [makeRepo('folder', { kind: 'folder' }), makeRepo('git')]
+
+    expect(resolveNewWorkspaceDialogGitRepoId({ eligibleRepos })).toBeNull()
+  })
+
+  it('excludes repos without paths from dialog defaults', () => {
+    expect(
+      getNewWorkspaceDialogEligibleRepos([makeRepo('missing-path', { path: '' }), makeRepo('repo')])
+    ).toEqual([expect.objectContaining({ id: 'repo' })])
+  })
+
+  it('defaults to a repo on the focused host when no explicit repo is chosen', () => {
+    const eligibleRepos = [
+      makeRepo('local-repo'),
+      makeRepo('ssh-repo', { connectionId: 'win-vm' }),
+      makeRepo('runtime-repo', { executionHostId: 'runtime:env-1' })
+    ]
+
+    expect(resolveNewWorkspaceDialogRepoId({ eligibleRepos, focusedHostScope: 'ssh:win-vm' })).toBe(
+      'ssh-repo'
+    )
+    expect(
+      resolveNewWorkspaceDialogRepoId({ eligibleRepos, focusedHostScope: 'runtime:env-1' })
+    ).toBe('runtime-repo')
+    expect(resolveNewWorkspaceDialogRepoId({ eligibleRepos, focusedHostScope: 'local' })).toBe(
+      'local-repo'
+    )
+  })
+
+  it('lets explicit draft/initial/active choices win over the focused host', () => {
+    const eligibleRepos = [makeRepo('local-repo'), makeRepo('ssh-repo', { connectionId: 'win-vm' })]
+
+    expect(
+      resolveNewWorkspaceDialogRepoId({
+        eligibleRepos,
+        activeRepoId: 'local-repo',
+        focusedHostScope: 'ssh:win-vm'
+      })
+    ).toBe('local-repo')
+  })
+
+  it('ignores host scope "all" and falls back to the first eligible repo', () => {
+    const eligibleRepos = [makeRepo('local-repo'), makeRepo('ssh-repo', { connectionId: 'win-vm' })]
+
+    expect(resolveNewWorkspaceDialogRepoId({ eligibleRepos, focusedHostScope: 'all' })).toBe(
+      'local-repo'
+    )
+  })
+})

--- a/src/shared/new-workspace-dialog-repo.ts
+++ b/src/shared/new-workspace-dialog-repo.ts
@@ -1,0 +1,60 @@
+import {
+  ALL_EXECUTION_HOSTS_SCOPE,
+  getRepoExecutionHostId,
+  type ExecutionHostScope
+} from './execution-host'
+import { isGitRepoKind } from './repo-kind'
+import type { Repo } from './types'
+
+type NewWorkspaceDialogRepo = Pick<
+  Repo,
+  'id' | 'path' | 'kind' | 'connectionId' | 'executionHostId'
+>
+
+export function getNewWorkspaceDialogEligibleRepos<T extends Pick<Repo, 'path'>>(
+  repos: readonly T[]
+): T[] {
+  return repos.filter((repo) => Boolean(repo.path))
+}
+
+export function resolveNewWorkspaceDialogRepoId({
+  eligibleRepos,
+  draftRepoId,
+  initialRepoId,
+  activeRepoId,
+  focusedHostScope
+}: {
+  eligibleRepos: readonly NewWorkspaceDialogRepo[]
+  draftRepoId?: string | null
+  initialRepoId?: string | null
+  activeRepoId?: string | null
+  focusedHostScope?: ExecutionHostScope | null
+}): string {
+  // Why: every new-workspace dialog should seed the repo the same way. Mobile
+  // mirrors this locally because Metro cannot bundle root shared runtime modules.
+  const focusedHostRepo =
+    focusedHostScope && focusedHostScope !== ALL_EXECUTION_HOSTS_SCOPE
+      ? eligibleRepos.find((repo) => getRepoExecutionHostId(repo) === focusedHostScope)
+      : undefined
+
+  const resolvedRepo =
+    (draftRepoId && eligibleRepos.find((repo) => repo.id === draftRepoId)) ||
+    (initialRepoId && eligibleRepos.find((repo) => repo.id === initialRepoId)) ||
+    (activeRepoId && eligibleRepos.find((repo) => repo.id === activeRepoId)) ||
+    focusedHostRepo ||
+    eligibleRepos[0]
+
+  return resolvedRepo?.id ?? ''
+}
+
+export function resolveNewWorkspaceDialogGitRepoId(args: {
+  eligibleRepos: readonly NewWorkspaceDialogRepo[]
+  draftRepoId?: string | null
+  initialRepoId?: string | null
+  activeRepoId?: string | null
+  focusedHostScope?: ExecutionHostScope | null
+}): string | null {
+  const repoId = resolveNewWorkspaceDialogRepoId(args)
+  const repo = repoId ? args.eligibleRepos.find((entry) => entry.id === repoId) : null
+  return repo && isGitRepoKind(repo) ? repo.id : null
+}


### PR DESCRIPTION
## Summary

On mobile, the new worktree creation dialog now defaults to selecting the user's last visited worktree repository for the current host, instead of defaulting to null or the first cached repo. This mirrors the desktop behavior and ensures a smoother user experience when creating new worktrees across multiple hosts.

To support this, the repository resolution logic has been extracted into a shared helper (`src/shared/new-workspace-dialog-repo.ts`) and mirrored on mobile (`mobile/src/worktree/new-workspace-dialog-repo-selection.ts`) since Metro cannot bundle runtime imports from the shared root tree.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added unit tests covering storage parsing, priority-based repo selection, and active/draft repo fallback logic on both mobile and shared modules:
- `mobile/src/worktree/last-visited-worktree-repo.test.ts`
- `mobile/src/worktree/new-workspace-dialog-repo-selection.test.ts`
- `src/shared/new-workspace-dialog-repo.test.ts`

## AI Review Report

The review checked:
- Proper state synchronization when the worktree modal visibility changes or when repositories are refreshed.
- Handling of malformed JSON gracefully when parsing the last visited worktree record from AsyncStorage.
- Synchronicity of the mirrored selection logic between shared and mobile implementations.
- Cross-platform compatibility: The changes are platform-agnostic. Host scope parsing (`local`, `ssh:*`, `runtime:*`) works identically across mobile, macOS, Linux, and Windows. No Electron-specific platform differences are affected.

## Security Audit

- **Input Handling**: Storage reads in `readLastVisitedWorktreeRecord` safely wrap `JSON.parse` in a `try-catch` to handle malformed, corrupted, or older schema data gracefully.
- **Secrets / PII**: No secrets or PII are stored; only host and worktree IDs are tracked locally in AsyncStorage.
- No other IPC, command execution, or path-traversal risks were introduced.

## Notes

- Metro bundler constraint: `mobile/src/worktree/new-workspace-dialog-repo-selection.ts` mirrors `src/shared/new-workspace-dialog-repo.ts` because Metro cannot bundle runtime imports from the root shared tree. Both files are fully unit-tested to ensure parity.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5912">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->