### PR TITLE
Fix hide completed agents after tab close

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
@@ -150,6 +150,27 @@ describe('selectLiveAgentStatusEntriesForWorktree', () => {
 
     expect(selectLiveAgentStatusEntriesForWorktree(state, 'wt-1')).toEqual([childEntry])
   })
+
+  it('does not use worktree attribution for a completed row whose tab is gone', () => {
+    const closedEntry = makeEntry(PANE_KEY_1, 1000, {
+      state: 'done',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      agentType: 'pi'
+    })
+    const state = {
+      tabsByWorktree: {
+        'wt-1': [makeTab('tab-live')]
+      },
+      agentStatusByPaneKey: {
+        [PANE_KEY_1]: closedEntry
+      },
+      migrationUnsupportedByPtyId: {},
+      retainedAgentsByPaneKey: {}
+    }
+
+    expect(selectLiveAgentStatusEntriesForWorktree(state, 'wt-1')).toEqual([])
+  })
 })
 
 describe('selectRuntimeAgentOrchestrationForWorktree', () => {

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
@@ -92,7 +92,9 @@ function getLiveEntriesByWorktree(state: WorktreeAgentRowsState): Map<string, Ag
     if (!parsed) {
       continue
     }
-    const worktreeId = tabIdToWorktreeId.get(parsed.tabId) ?? entry.worktreeId
+    const tabWorktreeId = tabIdToWorktreeId.get(parsed.tabId)
+    // Why: keep early attributed child rows, but hide completed rows once their tab is gone.
+    const worktreeId = tabWorktreeId ?? (entry.state === 'done' ? undefined : entry.worktreeId)
     if (!worktreeId) {
       continue
     }


### PR DESCRIPTION
## Summary

Fixes a stale compact agent row after closing a Pi terminal tab. Completed agent rows that are only worktree-attributed are no longer rendered as live sidebar rows once their owning terminal tab is gone.

The existing worktree-attribution fallback is preserved for active rows, so early child-agent statuses can still appear before their tab reaches the renderer.

Fixes #5913 

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted checks run:

- `pnpm test src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts` - passed
- `pnpm typecheck` - passed

## AI Review Report

The fix was narrowed after live debugging the dev renderer state. The stale Pi row was present in `agentStatusByPaneKey`, not `retainedAgentsByPaneKey`; its `tabId` no longer existed in `tabsByWorktree` / `unifiedTabsByWorktree`, but the sidebar selector still fell back to `entry.worktreeId` and rendered the completed row as live.

Main risks checked:

- Avoided removing the worktree-attribution fallback entirely, because existing tests cover active child-agent rows that may arrive before their tab is visible in the renderer.
- Scoped the behavior change to completed `done` rows whose parsed tab is not in the current terminal tab index.
- Added a regression test for a completed Pi-style row whose tab is gone.
- Kept the patch limited to the sidebar row selector and its test after trimming broader speculative cleanup.

Cross-platform compatibility:

- This PR touches renderer selector logic only.
- No platform-specific shortcuts, labels, shell behavior, filesystem paths, process launching, IPC contracts, or Electron main/preload behavior are changed.
- The behavior is data-shape based and applies consistently on macOS, Linux, and Windows.

## Security Audit

This PR changes only local renderer selection of already-present agent status records.

Reviewed risk areas:

- Input handling: no new user input parsing.
- Command execution: no command execution changes.
- Path handling: no path handling changes.
- Auth/secrets: no auth, token, credential, or secret handling changes.
- Dependencies: no dependency changes.
- IPC/network: no IPC, preload, main-process, network, or persistence changes.

No security follow-up identified.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5914">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->