### PR TITLE
feat(mobile): add explicit keyboard dismiss control to terminal command dock

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -4808,13 +4808,15 @@ export default function SessionScreen() {
                       accessibilityLabel="Dismiss keyboard"
                       accessibilityHint="Hides the software keyboard and keeps the current terminal session open."
                     >
-                      <KeyboardIcon size={15} color={colors.textSecondary} strokeWidth={2} />
-                      <ChevronDown
-                        size={11}
-                        color={colors.textSecondary}
-                        strokeWidth={2.5}
-                        style={styles.keyboardDismissChevron}
-                      />
+                      <View style={styles.keyboardDismissGlyph}>
+                        <KeyboardIcon size={15} color={colors.textSecondary} strokeWidth={2} />
+                        <ChevronDown
+                          size={10}
+                          color={colors.textSecondary}
+                          strokeWidth={2.5}
+                          style={styles.keyboardDismissChevron}
+                        />
+                      </View>
                     </Pressable>
                   )}
                   {/* Why: with default tap handling the first tap on any accessory

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -24,6 +24,7 @@ import {
   AlertTriangle,
   ArrowUp,
   Bot,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   ChevronsRight,
@@ -4807,8 +4808,13 @@ export default function SessionScreen() {
                       accessibilityLabel="Dismiss keyboard"
                       accessibilityHint="Hides the software keyboard and keeps the current terminal session open."
                     >
-                      <KeyboardIcon size={14} color={colors.textSecondary} strokeWidth={2} />
-                      <Text style={styles.keyboardDismissKeyText}>Hide</Text>
+                      <KeyboardIcon size={15} color={colors.textSecondary} strokeWidth={2} />
+                      <ChevronDown
+                        size={11}
+                        color={colors.textSecondary}
+                        strokeWidth={2.5}
+                        style={styles.keyboardDismissChevron}
+                      />
                     </Pressable>
                   )}
                   {/* Why: with default tap handling the first tap on any accessory

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -100,6 +100,7 @@ import {
   isTerminalLiveInputWithinByteLimit,
   scheduleTerminalLiveInputFocus
 } from '../../../../src/terminal/terminal-live-input'
+import { dismissTerminalKeyboard } from '../../../../src/terminal/terminal-keyboard-dismiss'
 import type { TerminalLiveInputSender } from '../../../../src/terminal/terminal-live-input-sender'
 import { isTerminalSendRpcAccepted } from '../../../../src/terminal/terminal-send-rpc-response'
 import { useTerminalLiveInputCommit } from '../../../../src/terminal/use-terminal-live-input-commit'
@@ -1006,6 +1007,7 @@ export default function SessionScreen() {
   const viewportMeasuredRef = useRef(false)
   const terminalRefs = useRef<Map<string, TerminalWebViewHandle>>(new Map())
   const liveInputRef = useRef<TextInput>(null)
+  const commandInputRef = useRef<TextInput>(null)
   const liveInputFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const sendLiveTerminalInputRef = useRef<TerminalLiveInputSender>(async () => false)
   const sessionTabActionSheetKeyboardHideSubRef = useRef<ReturnType<
@@ -3208,6 +3210,15 @@ export default function SessionScreen() {
     ]
   )
 
+  const dismissSoftwareKeyboard = useCallback(() => {
+    dismissTerminalKeyboard({
+      clearPendingLiveInputFocus: () => clearTerminalLiveInputFocusTimer(liveInputFocusTimerRef),
+      commandInput: commandInputRef.current,
+      dismissKeyboard: () => Keyboard.dismiss(),
+      liveInput: liveInputRef.current
+    })
+  }, [])
+
   const handleTerminalTap = useCallback(
     (handle: string) => {
       if (handle !== activeHandleRef.current) {
@@ -4783,7 +4794,22 @@ export default function SessionScreen() {
                   {/* Why: with default tap handling the first tap on any accessory
                   key dismisses the open keyboard and is swallowed, so live
                   input lost its keyboard on every Esc/Tab press (#5106). */}
+                  {keyboardHeight > 0 && (
+                    <Pressable
+                      style={({ pressed }) => [
+                        styles.keyboardDismissKey,
+                        pressed && styles.accessoryKeyPressed
+                      ]}
+                      onPress={dismissSoftwareKeyboard}
+                      accessibilityLabel="Dismiss keyboard"
+                      accessibilityHint="Hides the software keyboard and keeps the current terminal session open."
+                    >
+                      <KeyboardIcon size={14} color={colors.textSecondary} strokeWidth={2} />
+                      <Text style={styles.keyboardDismissKeyText}>Hide</Text>
+                    </Pressable>
+                  )}
                   <ScrollView
+                    style={styles.accessoryScroll}
                     horizontal
                     showsHorizontalScrollIndicator={false}
                     contentContainerStyle={styles.accessoryContent}
@@ -5009,6 +5035,7 @@ export default function SessionScreen() {
                 ) : (
                   <View style={styles.inputBar}>
                     <TextInput
+                      ref={commandInputRef}
                       // Why: Android caches the IME inputType at mount, so toggling
                       // autocomplete must remount there; iOS can update without a focus-costly remount.
                       key={

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -4795,7 +4795,7 @@ export default function SessionScreen() {
                   keyboard. Kept outside the horizontal ScrollView so it does
                   not scroll away, and out of the terminal-byte shortcut path so
                   it cannot be hidden by user shortcut customization (#5106). */}
-                  {keyboardHeight > 0 && (
+                  {keyboardLift > 0 && (
                     <Pressable
                       style={({ pressed }) => [
                         styles.keyboardDismissKey,

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -4791,9 +4791,10 @@ export default function SessionScreen() {
               >
                 {/* Accessory keys */}
                 <View style={styles.accessoryBar}>
-                  {/* Why: with default tap handling the first tap on any accessory
-                  key dismisses the open keyboard and is swallowed, so live
-                  input lost its keyboard on every Esc/Tab press (#5106). */}
+                  {/* Why: a fixed, always-visible escape hatch from the open
+                  keyboard. Kept outside the horizontal ScrollView so it does
+                  not scroll away, and out of the terminal-byte shortcut path so
+                  it cannot be hidden by user shortcut customization (#5106). */}
                   {keyboardHeight > 0 && (
                     <Pressable
                       style={({ pressed }) => [
@@ -4801,6 +4802,8 @@ export default function SessionScreen() {
                         pressed && styles.accessoryKeyPressed
                       ]}
                       onPress={dismissSoftwareKeyboard}
+                      hitSlop={8}
+                      accessibilityRole="button"
                       accessibilityLabel="Dismiss keyboard"
                       accessibilityHint="Hides the software keyboard and keeps the current terminal session open."
                     >
@@ -4808,6 +4811,9 @@ export default function SessionScreen() {
                       <Text style={styles.keyboardDismissKeyText}>Hide</Text>
                     </Pressable>
                   )}
+                  {/* Why: with default tap handling the first tap on any accessory
+                  key dismisses the open keyboard and is swallowed, so live
+                  input lost its keyboard on every Esc/Tab press (#5106). */}
                   <ScrollView
                     style={styles.accessoryScroll}
                     horizontal

--- a/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
+++ b/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
@@ -117,19 +117,27 @@ export const mobileSessionCommandInputStyles = StyleSheet.create({
     color: colors.textMuted
   },
   keyboardDismissKey: {
-    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
     marginLeft: spacing.sm,
     marginVertical: spacing.xs,
     backgroundColor: colors.bgRaised,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm + 2,
+    paddingVertical: 0,
     borderRadius: radii.button,
-    minHeight: 28
+    minWidth: 36,
+    height: 28
+  },
+  keyboardDismissGlyph: {
+    alignItems: 'center',
+    height: 18,
+    justifyContent: 'flex-start',
+    position: 'relative',
+    width: 18
   },
   keyboardDismissChevron: {
-    marginTop: -3
+    bottom: -2,
+    position: 'absolute'
   },
   inputBar: {
     flexDirection: 'row',

--- a/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
+++ b/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
@@ -117,21 +117,19 @@ export const mobileSessionCommandInputStyles = StyleSheet.create({
     color: colors.textMuted
   },
   keyboardDismissKey: {
-    flexDirection: 'row',
+    flexDirection: 'column',
     alignItems: 'center',
-    gap: spacing.xs,
+    justifyContent: 'center',
     marginLeft: spacing.sm,
     marginVertical: spacing.xs,
     backgroundColor: colors.bgRaised,
-    paddingHorizontal: spacing.sm + 2,
+    paddingHorizontal: spacing.sm,
     paddingVertical: spacing.xs,
     borderRadius: radii.button,
     minHeight: 28
   },
-  keyboardDismissKeyText: {
-    color: colors.textSecondary,
-    fontSize: 12,
-    fontFamily: typography.monoFamily
+  keyboardDismissChevron: {
+    marginTop: -3
   },
   inputBar: {
     flexDirection: 'row',

--- a/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
+++ b/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
@@ -68,9 +68,14 @@ export const mobileSessionCommandInputStyles = StyleSheet.create({
     zIndex: 20
   },
   accessoryBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
     borderTopWidth: 1,
     borderTopColor: colors.borderSubtle,
     backgroundColor: colors.bgPanel
+  },
+  accessoryScroll: {
+    flex: 1
   },
   accessoryContent: {
     paddingHorizontal: spacing.sm,
@@ -109,6 +114,23 @@ export const mobileSessionCommandInputStyles = StyleSheet.create({
   },
   accessoryKeyTextDisabled: {
     color: colors.textMuted
+  },
+  keyboardDismissKey: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginLeft: spacing.sm,
+    marginVertical: spacing.xs,
+    backgroundColor: colors.bgRaised,
+    paddingHorizontal: spacing.sm + 2,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.button,
+    minHeight: 28
+  },
+  keyboardDismissKeyText: {
+    color: colors.textSecondary,
+    fontSize: 12,
+    fontFamily: typography.monoFamily
   },
   inputBar: {
     flexDirection: 'row',

--- a/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
+++ b/mobile/app/h/[hostId]/session/mobile-session-command-input-styles.ts
@@ -75,7 +75,8 @@ export const mobileSessionCommandInputStyles = StyleSheet.create({
     backgroundColor: colors.bgPanel
   },
   accessoryScroll: {
-    flex: 1
+    flex: 1,
+    minWidth: 0
   },
   accessoryContent: {
     paddingHorizontal: spacing.sm,

--- a/mobile/src/terminal/terminal-keyboard-dismiss.test.ts
+++ b/mobile/src/terminal/terminal-keyboard-dismiss.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { dismissTerminalKeyboard } from './terminal-keyboard-dismiss'
+
+describe('dismissTerminalKeyboard', () => {
+  it('clears pending live input focus before blur and dismiss', () => {
+    const calls: string[] = []
+    const clearPendingLiveInputFocus = vi.fn(() => calls.push('clear'))
+    const liveInput = { blur: vi.fn(() => calls.push('live-blur')) }
+    const commandInput = { blur: vi.fn(() => calls.push('command-blur')) }
+    const dismissKeyboard = vi.fn(() => calls.push('dismiss'))
+
+    dismissTerminalKeyboard({
+      clearPendingLiveInputFocus,
+      commandInput,
+      dismissKeyboard,
+      liveInput
+    })
+
+    expect(calls).toEqual(['clear', 'live-blur', 'command-blur', 'dismiss'])
+  })
+
+  it('blurs both live and buffered command inputs', () => {
+    const liveInput = { blur: vi.fn() }
+    const commandInput = { blur: vi.fn() }
+
+    dismissTerminalKeyboard({
+      clearPendingLiveInputFocus: vi.fn(),
+      commandInput,
+      dismissKeyboard: vi.fn(),
+      liveInput
+    })
+
+    expect(liveInput.blur).toHaveBeenCalledTimes(1)
+    expect(commandInput.blur).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses the keyboard without a live input handle', () => {
+    const commandInput = { blur: vi.fn() }
+    const dismissKeyboard = vi.fn()
+
+    dismissTerminalKeyboard({
+      clearPendingLiveInputFocus: vi.fn(),
+      commandInput,
+      dismissKeyboard,
+      liveInput: null
+    })
+
+    expect(commandInput.blur).toHaveBeenCalledTimes(1)
+    expect(dismissKeyboard).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses the keyboard without a buffered command input handle', () => {
+    const liveInput = { blur: vi.fn() }
+    const dismissKeyboard = vi.fn()
+
+    dismissTerminalKeyboard({
+      clearPendingLiveInputFocus: vi.fn(),
+      commandInput: undefined,
+      dismissKeyboard,
+      liveInput
+    })
+
+    expect(liveInput.blur).toHaveBeenCalledTimes(1)
+    expect(dismissKeyboard).toHaveBeenCalledTimes(1)
+  })
+})

--- a/mobile/src/terminal/terminal-keyboard-dismiss.test.ts
+++ b/mobile/src/terminal/terminal-keyboard-dismiss.test.ts
@@ -64,4 +64,19 @@ describe('dismissTerminalKeyboard', () => {
     expect(liveInput.blur).toHaveBeenCalledTimes(1)
     expect(dismissKeyboard).toHaveBeenCalledTimes(1)
   })
+
+  it('still clears focus and dismisses when both input handles are missing', () => {
+    const calls: string[] = []
+    const clearPendingLiveInputFocus = vi.fn(() => calls.push('clear'))
+    const dismissKeyboard = vi.fn(() => calls.push('dismiss'))
+
+    dismissTerminalKeyboard({
+      clearPendingLiveInputFocus,
+      commandInput: undefined,
+      dismissKeyboard,
+      liveInput: null
+    })
+
+    expect(calls).toEqual(['clear', 'dismiss'])
+  })
 })

--- a/mobile/src/terminal/terminal-keyboard-dismiss.ts
+++ b/mobile/src/terminal/terminal-keyboard-dismiss.ts
@@ -8,6 +8,8 @@ export type DismissTerminalKeyboardOptions = {
 }
 
 export function dismissTerminalKeyboard(options: DismissTerminalKeyboardOptions): void {
+  // Why: clear the queued live-input focus before blurring/dismissing so a
+  // pending deferred focus cannot re-open the iOS keyboard right after Hide.
   options.clearPendingLiveInputFocus()
   options.liveInput?.blur()
   options.commandInput?.blur()

--- a/mobile/src/terminal/terminal-keyboard-dismiss.ts
+++ b/mobile/src/terminal/terminal-keyboard-dismiss.ts
@@ -1,0 +1,15 @@
+export type TerminalKeyboardDismissHandle = { blur: () => void } | null | undefined
+
+export type DismissTerminalKeyboardOptions = {
+  clearPendingLiveInputFocus: () => void
+  commandInput: TerminalKeyboardDismissHandle
+  dismissKeyboard: () => void
+  liveInput: TerminalKeyboardDismissHandle
+}
+
+export function dismissTerminalKeyboard(options: DismissTerminalKeyboardOptions): void {
+  options.clearPendingLiveInputFocus()
+  options.liveInput?.blur()
+  options.commandInput?.blur()
+  options.dismissKeyboard()
+}

--- a/mobile/vitest.config.ts
+++ b/mobile/vitest.config.ts
@@ -1,25 +1,12 @@
 import { defineConfig } from 'vitest/config'
 
-const tsconfigRaw = JSON.stringify({
-  compilerOptions: {
-    jsx: 'react-jsx',
-    module: 'esnext',
-    moduleResolution: 'bundler',
-    strict: true,
-    target: 'es2022'
-  }
-})
+const vitestOxcConfig = { tsconfig: false } as never
 
 export default defineConfig({
   root: import.meta.dirname,
-  esbuild: {
-    tsconfigRaw
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      tsconfigRaw
-    }
-  },
+  // Why: the app tsconfig intentionally excludes tests; Vite 8's OXC transform
+  // otherwise fails before Vitest can run the test modules.
+  oxc: vitestOxcConfig,
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts']


### PR DESCRIPTION
## Summary

Mobile terminal sessions track the software-keyboard height and translate the command dock above the IME instead of resizing the PTY. But the only ways to dismiss the keyboard were indirect (blur an input, switch tabs, or start terminal selection), so the keyboard often stayed up and ate vertical space the user wanted back for terminal output.

This adds an explicit, always-available keyboard-dismiss control to the left of the terminal command dock accessory bar — a compact keyboard-with-chevron-down glyph (the iOS-native dismiss symbol). It appears whenever the command dock is lifted above the keyboard (`keyboardLift > 0`) and rides the existing `translateY` lift so it sits directly above the IME.

Tapping it:
- clears any pending live-input focus timer (so a queued focus can't immediately reopen the iOS keyboard),
- blurs both the live and buffered command inputs,
- calls `Keyboard.dismiss()`.

It deliberately does **not** send terminal bytes, switch live/buffered input mode, clear typed text, or change the phone/desktop terminal fit. (It is distinct from the `»` accessory button, which toggles buffered ↔ live input mode and only incidentally affects the keyboard.)

The behavior lives in a dedicated, unit-tested `terminal-keyboard-dismiss` module rather than the user-customizable accessory-key path, so this escape hatch can't be hidden by shortcut customization. Both iOS and Android feed the same keyboard-height state (iOS via `keyboardWillShow`/`keyboardWillHide`, Android via `keyboardDidShow`/`keyboardDidHide`), so the control is platform-neutral and shows wherever the IME covers the app.

## Screenshots

Before/after captured in the iOS Simulator (iPhone 16 Pro) against a live paired Orca host, cropped to the command dock.

**Before — keyboard open:** software keyboard covers the terminal; the accessory bar starts with `🖥 / » / Paste / Esc / Tab…` — no dismiss affordance.

<img width="372" alt="before — no dismiss control" src="https://github.com/user-attachments/assets/e839094d-f32c-4dd1-a175-5d44f789d606" />

**After — keyboard open:** a compact keyboard-with-chevron-down dismiss glyph pinned at the far left of the accessory bar, above the keyboard; the `»` mode toggle and remaining keys still scroll to its right; typed text (`git status`) preserved.

<img width="372" alt="after — keyboard-dismiss glyph above keyboard" src="https://github.com/user-attachments/assets/f4638062-aefe-4cef-af0b-6250837f06bc" />

## Testing

- [x] `pnpm lint` (mobile `oxlint`) — clean
- [x] `pnpm typecheck` (mobile `tsc --noEmit`) — clean
- [x] `pnpm test` (mobile `vitest`) — new `terminal-keyboard-dismiss.test.ts` passes (5/5). Full suite is green except one pre-existing, unrelated failure in `terminal-webview-url-tap.test.ts` (a desktop regex file this PR never touches drifted from its mobile mirror; confirmed failing on `main` with my changes stashed).
- [x] High-quality regression tests: dismiss order (clear-focus → blur live → blur buffered → dismiss), both inputs blurred, and graceful behavior when either or both input handles are `null`/`undefined`.
- [x] iOS Simulator manual check: verified buffered and live-input modes, keyboard close, text preservation, and no command send. Confirmed the control is correctly absent when the dock is not lifted.

`pnpm build` not run locally; this is a self-contained Expo/React Native mobile change with no desktop/main/preload/native surface touched.

## AI Review Report

Code review checked cross-platform compatibility, regression isolation, design-system compliance, and performance, with no code-level blockers found.

- **Cross-platform (macOS/Linux/Windows + iOS/Android):** mobile-only React Native UI; no Electron accelerators, OS shell, or filesystem paths touched. The control has no iOS-only branch and renders off the existing platform-neutral keyboard-lift state. On `react-native-web`/Electron, if the keyboard height is never set the control simply does not render.
- **Regression isolation:** the dismiss handler does not reach `handleAccessoryKey`/`sendLiveTerminalInput`, does not mutate `liveInputTerminalHandles`, does not touch `input` state, and does not feed `keyboardLift`/`useTerminalViewportRefit`, so the desktop PTY size and typed text are preserved.
- **Design tokens:** new styles use only `colors`/`spacing`/`radii`/`typography` from `mobile-theme.ts` and reuse the existing `accessoryKeyPressed` state.
- **Performance:** no new work in hot render paths; the control is a single conditionally-rendered `Pressable` and the callback closes over stable refs only.

Hardening applied as a result: documented the load-bearing clear-before-blur order, added a both-handles-missing test case, added `accessibilityRole="button"` + `hitSlop`, added `minWidth: 0` to the accessory scroll row, and gated visibility on `keyboardLift > 0` so the control never appears when the dock is not actually raised. A UX-clarity follow-up replaced the original icon-plus-`Hide`-text button with the compact stacked keyboard/chevron-down glyph so it reads as a dismiss affordance and is visually distinct from the neighboring `»` input-mode toggle.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change only calls React Native's `Keyboard.dismiss()` and `TextInput.blur()` on refs the route already owns. No user-controlled strings flow into any sink. No new dependencies.

## Notes

- Platform-specific: mobile-only; no desktop/SSH/remote/agent/git-provider behavior touched.
- The dismiss control is intentionally fixed chrome, not a customizable shortcut key — hiding the only dismiss affordance would recreate the reported problem. Customization, if ever wanted, should be a separate change.
- It is intentionally separate from the `»` input-mode toggle: `»` switches buffered ↔ live input (and only incidentally shows/hides the keyboard, one direction), whereas this control always dismisses without changing mode or clearing text.
- Pre-existing unrelated test failure (`terminal-webview-url-tap.test.ts`) is not introduced by this PR.
- X handle: @wolfie_

