### PR TITLE
chore: narrow rate-limit settings resolver

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1328,7 +1328,13 @@ app.whenReady().then(async () => {
   rateLimits.setClaudeAuthPreparationResolver((target) =>
     claudeRuntimeAuth!.prepareForRateLimitFetch(target)
   )
-  rateLimits.setSettingsResolver(() => store!.getSettings())
+  rateLimits.setSettingsResolver(() => {
+    const settings = store!.getSettings()
+    return {
+      opencodeSessionCookie: settings.opencodeSessionCookie,
+      opencodeWorkspaceId: settings.opencodeWorkspaceId
+    }
+  })
   keybindings = new KeybindingService({
     homePath: app.getPath('home'),
     getLegacyOverrides: () => store!.getSettings().keybindings

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1328,13 +1328,14 @@ app.whenReady().then(async () => {
   rateLimits.setClaudeAuthPreparationResolver((target) =>
     claudeRuntimeAuth!.prepareForRateLimitFetch(target)
   )
-  rateLimits.setSettingsResolver(() => {
+  rateLimits.setOpenCodeGoConfigResolver(() => {
     const settings = store!.getSettings()
     return {
-      opencodeSessionCookie: settings.opencodeSessionCookie,
-      opencodeWorkspaceId: settings.opencodeWorkspaceId
+      sessionCookie: settings.opencodeSessionCookie,
+      workspaceIdOverride: settings.opencodeWorkspaceId
     }
   })
+  rateLimits.setGeminiCliOAuthEnabledResolver(() => store!.getSettings().geminiCliOAuthEnabled)
   keybindings = new KeybindingService({
     homePath: app.getPath('home'),
     getLegacyOverrides: () => store!.getSettings().keybindings

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -335,10 +335,11 @@ describe('RateLimitService', () => {
 
   it('fetches Gemini and OpenCode Go alongside Claude and Codex', async () => {
     const service = new RateLimitService()
-    service.setSettingsResolver(() => ({
-      opencodeSessionCookie: 'session=abc123',
-      opencodeWorkspaceId: ''
+    service.setOpenCodeGoConfigResolver(() => ({
+      sessionCookie: 'session=abc123',
+      workspaceIdOverride: ''
     }))
+    service.setGeminiCliOAuthEnabledResolver(() => true)
 
     vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
     vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
@@ -356,6 +357,7 @@ describe('RateLimitService', () => {
     })
     expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchGeminiRateLimits).toHaveBeenCalledTimes(1)
+    expect(fetchGeminiRateLimits).toHaveBeenCalledWith(true)
     expect(fetchOpenCodeGoRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchOpenCodeGoRateLimits).toHaveBeenCalledWith('session=abc123', undefined)
 
@@ -678,7 +680,10 @@ describe('RateLimitService', () => {
 
   it('isolates provider failures so one error does not block others', async () => {
     const service = new RateLimitService()
-    service.setSettingsResolver(() => ({ opencodeSessionCookie: '', opencodeWorkspaceId: '' }))
+    service.setOpenCodeGoConfigResolver(() => ({
+      sessionCookie: '',
+      workspaceIdOverride: ''
+    }))
 
     vi.mocked(fetchClaudeRateLimits).mockRejectedValueOnce(new Error('claude down'))
     vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
@@ -701,7 +706,10 @@ describe('RateLimitService', () => {
   it('discards stale data when a provider becomes unavailable', async () => {
     const service = new RateLimitService()
     let cookie = 'session=valid'
-    service.setSettingsResolver(() => ({ opencodeSessionCookie: cookie, opencodeWorkspaceId: '' }))
+    service.setOpenCodeGoConfigResolver(() => ({
+      sessionCookie: cookie,
+      workspaceIdOverride: ''
+    }))
 
     // 1. Success fetch
     vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 10, Date.now()))
@@ -736,9 +744,9 @@ describe('RateLimitService', () => {
   it('discards stale data when Workspace ID override is changed', async () => {
     const service = new RateLimitService()
     let workspaceId = 'wrk_A'
-    service.setSettingsResolver(() => ({
-      opencodeSessionCookie: 'session=valid',
-      opencodeWorkspaceId: workspaceId
+    service.setOpenCodeGoConfigResolver(() => ({
+      sessionCookie: 'session=valid',
+      workspaceIdOverride: workspaceId
     }))
 
     // 1. Success fetch for Workspace A

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -37,6 +37,11 @@ type ClaudeAuthPreparationResolver = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
 
+type OpencodeSettingsSnapshot = {
+  opencodeSessionCookie: string
+  opencodeWorkspaceId: string
+}
+
 // Why: Claude's subscription usage endpoint has a tight request budget. Quota
 // state is informational, so prefer keeping a recent snapshot over polling it
 // into 429s during long focused Orca sessions.
@@ -98,13 +103,7 @@ export class RateLimitService {
     runtime: 'host',
     wslDistro: null
   }
-  private settingsResolver:
-    | (() => {
-        opencodeSessionCookie: string
-        opencodeWorkspaceId: string
-        geminiCliOAuthEnabled?: boolean
-      })
-    | null = null
+  private settingsResolver: (() => OpencodeSettingsSnapshot) | null = null
   private inactiveClaudeAccountsResolver: (() => InactiveClaudeAccountInfo[]) | null = null
   private inactiveCodexAccountsResolver: (() => InactiveCodexAccountInfo[]) | null = null
   private inactiveClaudeCache = new Map<string, ProviderRateLimits>()
@@ -142,13 +141,7 @@ export class RateLimitService {
     this.claudeFetchTarget = normalizeClaudeAccountSelectionTarget(target)
   }
 
-  setSettingsResolver(
-    resolver: () => {
-      opencodeSessionCookie: string
-      opencodeWorkspaceId: string
-      geminiCliOAuthEnabled?: boolean
-    }
-  ): void {
+  setSettingsResolver(resolver: () => OpencodeSettingsSnapshot): void {
     this.settingsResolver = resolver
   }
 

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -37,10 +37,12 @@ type ClaudeAuthPreparationResolver = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
 
-type OpencodeSettingsSnapshot = {
-  opencodeSessionCookie: string
-  opencodeWorkspaceId: string
+type OpenCodeGoRateLimitConfig = {
+  sessionCookie: string
+  workspaceIdOverride: string
 }
+
+type GeminiCliOAuthEnabledResolver = () => boolean
 
 // Why: Claude's subscription usage endpoint has a tight request budget. Quota
 // state is informational, so prefer keeping a recent snapshot over polling it
@@ -103,7 +105,8 @@ export class RateLimitService {
     runtime: 'host',
     wslDistro: null
   }
-  private settingsResolver: (() => OpencodeSettingsSnapshot) | null = null
+  private openCodeGoConfigResolver: (() => OpenCodeGoRateLimitConfig) | null = null
+  private geminiCliOAuthEnabledResolver: GeminiCliOAuthEnabledResolver | null = null
   private inactiveClaudeAccountsResolver: (() => InactiveClaudeAccountInfo[]) | null = null
   private inactiveCodexAccountsResolver: (() => InactiveCodexAccountInfo[]) | null = null
   private inactiveClaudeCache = new Map<string, ProviderRateLimits>()
@@ -141,8 +144,12 @@ export class RateLimitService {
     this.claudeFetchTarget = normalizeClaudeAccountSelectionTarget(target)
   }
 
-  setSettingsResolver(resolver: () => OpencodeSettingsSnapshot): void {
-    this.settingsResolver = resolver
+  setOpenCodeGoConfigResolver(resolver: () => OpenCodeGoRateLimitConfig): void {
+    this.openCodeGoConfigResolver = resolver
+  }
+
+  setGeminiCliOAuthEnabledResolver(resolver: GeminiCliOAuthEnabledResolver): void {
+    this.geminiCliOAuthEnabledResolver = resolver
   }
 
   setInactiveClaudeAccountsResolver(resolver: () => InactiveClaudeAccountInfo[]): void {
@@ -812,10 +819,10 @@ export class RateLimitService {
     const codexProvenance = this.getCodexProvenance(codexTarget, codexHomePath)
     const codexGeneration = this.codexFetchGeneration
     const previousState = this.state
-    const settings = this.settingsResolver?.()
-    const cookie = settings?.opencodeSessionCookie ?? ''
-    const workspaceIdOverride = settings?.opencodeWorkspaceId ?? ''
-    const geminiCliOAuthEnabled = settings?.geminiCliOAuthEnabled ?? false
+    const openCodeGoConfig = this.openCodeGoConfigResolver?.()
+    const cookie = openCodeGoConfig?.sessionCookie ?? ''
+    const workspaceIdOverride = openCodeGoConfig?.workspaceIdOverride ?? ''
+    const geminiCliOAuthEnabled = this.geminiCliOAuthEnabledResolver?.() ?? false
 
     // Detect if configuration changed — if it did, we must discard any stale
     // data because it belongs to a different session/workspace.


### PR DESCRIPTION
## Summary

Narrowed the rate-limit settings resolver so `RateLimitService` only receives the OpenCode fields it actually uses.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the contract change for runtime risk, type safety, and cross-platform compatibility. Confirmed it only narrows an internal settings dependency, does not change UI or shell behavior, and does not introduce new platform-specific issues.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependency, and IPC risks. No security-impacting changes were introduced.

## Notes

No user-visible behavior change. This is a cleanup/refactor to reduce coupling.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5932">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->