### PR TITLE
Refresh live worktree display name in mobile session

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -162,6 +162,7 @@ import {
 } from '../../../../src/session/mobile-clipboard-image'
 import { useMobileImageAttachment } from '../../../../src/session/use-mobile-image-attachment'
 import { classifyMobileArtifact } from '../../../../src/session/mobile-artifact-kind'
+import { useLiveWorktreeName } from '../../../../src/session/use-live-worktree-name'
 import {
   buildMarkdownDiskFallbackDoc,
   shouldReadMarkdownFromDiskAfterReadTabFailure
@@ -841,7 +842,7 @@ export default function SessionScreen() {
   const {
     hostId,
     worktreeId,
-    name: worktreeName,
+    name: routeWorktreeName,
     created,
     warning: createdWarning
   } = useLocalSearchParams<{
@@ -860,6 +861,12 @@ export default function SessionScreen() {
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
   const forceReconnectHost = useForceReconnect()
+  const worktreeName = useLiveWorktreeName({
+    client,
+    connState,
+    routeName: routeWorktreeName,
+    worktreeId
+  })
   // Master-detail host state (U5/KTD2): on wide layouts a tapped panel docks beside the
   // session content; on narrow it stays null and the icons push full-screen routes.
   const { isWideLayout } = useResponsiveLayout()

--- a/mobile/src/session/use-live-worktree-name.ts
+++ b/mobile/src/session/use-live-worktree-name.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useFocusEffect } from 'expo-router'
+import type { RpcClient } from '../transport/rpc-client'
+import type { ConnectionState, RpcSuccess } from '../transport/types'
+import { getLiveWorktreeDisplayName, type WorktreeDisplayNameSource } from './worktree-display-name'
+
+type Params = {
+  client: RpcClient | null
+  connState: ConnectionState
+  routeName?: string
+  worktreeId: string
+}
+
+export function useLiveWorktreeName({ client, connState, routeName, worktreeId }: Params): string {
+  const [worktreeName, setWorktreeName] = useState(() => routeName?.trim() ?? '')
+
+  useEffect(() => {
+    setWorktreeName(routeName?.trim() ?? '')
+  }, [routeName, worktreeId])
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!client || connState !== 'connected') {
+        return
+      }
+      let stale = false
+      const refreshWorktreeName = async () => {
+        try {
+          const response = await client.sendRequest('worktree.show', {
+            worktree: `id:${worktreeId}`
+          })
+          if (stale || !response.ok) {
+            return
+          }
+          const result = (response as RpcSuccess).result as {
+            worktree?: WorktreeDisplayNameSource
+          }
+          const liveName = result.worktree
+            ? getLiveWorktreeDisplayName([result.worktree], worktreeId)
+            : null
+          if (liveName) {
+            setWorktreeName((current) => (current === liveName ? current : liveName))
+          }
+        } catch {
+          // Non-fatal: the route param remains a usable label until the next refresh.
+        }
+      }
+      // Why: route params are only an entry hint. The desktop/runtime owns
+      // displayName, including task-generated names that may settle after open.
+      void refreshWorktreeName()
+      const interval = setInterval(() => void refreshWorktreeName(), 3000)
+      return () => {
+        stale = true
+        clearInterval(interval)
+      }
+    }, [client, connState, worktreeId])
+  )
+
+  return worktreeName
+}

--- a/mobile/src/session/worktree-display-name.test.ts
+++ b/mobile/src/session/worktree-display-name.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { getLiveWorktreeDisplayName } from './worktree-display-name'
+
+describe('getLiveWorktreeDisplayName', () => {
+  it('uses the host-list display name for the current worktree', () => {
+    expect(
+      getLiveWorktreeDisplayName(
+        [
+          { worktreeId: 'wt-1', displayName: 'Old' },
+          { worktreeId: 'wt-2', displayName: 'Auto Generated Name' }
+        ],
+        'wt-2'
+      )
+    ).toBe('Auto Generated Name')
+  })
+
+  it('matches worktree.show payloads keyed by id', () => {
+    expect(getLiveWorktreeDisplayName([{ id: 'wt-1', displayName: 'Settled Name' }], 'wt-1')).toBe(
+      'Settled Name'
+    )
+  })
+
+  it('falls back to repo only when the display name is blank', () => {
+    expect(
+      getLiveWorktreeDisplayName([{ worktreeId: 'wt-1', displayName: '  ', repo: 'orca' }], 'wt-1')
+    ).toBe('orca')
+  })
+
+  it('ignores snapshots that do not contain the current worktree', () => {
+    expect(getLiveWorktreeDisplayName([{ worktreeId: 'wt-1', displayName: 'Other' }], 'wt-2')).toBe(
+      null
+    )
+  })
+})

--- a/mobile/src/session/worktree-display-name.ts
+++ b/mobile/src/session/worktree-display-name.ts
@@ -1,0 +1,21 @@
+export type WorktreeDisplayNameSource = {
+  worktreeId?: string
+  id?: string
+  displayName?: string | null
+  repo?: string | null
+}
+
+export function getLiveWorktreeDisplayName(
+  worktrees: readonly WorktreeDisplayNameSource[],
+  worktreeId: string
+): string | null {
+  const worktree = worktrees.find((item) => (item.worktreeId ?? item.id) === worktreeId)
+  if (!worktree) {
+    return null
+  }
+  const displayName = worktree.displayName?.trim()
+  if (displayName) {
+    return displayName
+  }
+  return worktree.repo?.trim() || null
+}


### PR DESCRIPTION
## Summary

Refreshes the live worktree display name in the mobile session screen. Introduces `useLiveWorktreeName` to fetch and periodically poll (every 3s) the active display name of the worktree from the host via the `worktree.show` RPC, ensuring the header stays in sync when background tasks or the desktop rename it.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed (added unit tests in `mobile/src/session/worktree-display-name.test.ts`)

## AI Review Report

The code review was run to verify the correctness of the dynamic worktree display name polling hook:
- Verified that `useFocusEffect` with `useCallback` and `stale` flags are properly utilized to clean up intervals and avoid memory leaks or state updates after unmount.
- Verified that network/RPC errors are caught gracefully, falling back to the route parameter.
- Cross-platform compatibility check: Explicitly verified that the React Native/Expo changes do not depend on platform-specific paths, shell behavior, or shortcuts, remaining fully portable.

## Security Audit

The RPC parameter `worktreeId` is sourced directly from route parameters and sent via the established authenticated `RpcClient` channel. No raw input shell execution, path injection risks, or secrets handling are present.

## Notes

- Uses a 3-second interval polling mechanism restricted strictly to when the session route is focused to prevent background battery/resource drain.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5934">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->