### PR TITLE
test: prove mobile session tab pruning after pending-tab fix

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11587,6 +11587,96 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('prunes renderer-origin mobile-created pending tabs when desktop republishes fewer tabs', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const rendererTab = (tabId: string, leafId: string, title: string, isActive = false) => ({
+      type: 'terminal' as const,
+      id: `${tabId}::${leafId}`,
+      parentTabId: tabId,
+      leafId,
+      title,
+      isActive
+    })
+    const desktopTabs = [
+      rendererTab('desktop-tab-1', '11111111-1111-4111-8111-111111111111', 'Agent'),
+      rendererTab('desktop-tab-2', '22222222-2222-4222-8222-222222222222', 'Shell'),
+      rendererTab('desktop-tab-3', '33333333-3333-4333-8333-333333333333', 'Logs', true)
+    ]
+
+    runtime.syncWindowGraph(0, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer:issue-5910',
+          snapshotVersion: 1,
+          activeGroupId: 'group-1',
+          activeTabId: desktopTabs[2]!.id,
+          activeTabType: 'terminal',
+          tabGroups: [
+            {
+              id: 'group-1',
+              activeTabId: 'desktop-tab-3',
+              tabOrder: [
+                'desktop-tab-1',
+                'desktop-tab-2',
+                'desktop-tab-3',
+                'mobile-created-ghost-1',
+                'mobile-created-ghost-2'
+              ]
+            }
+          ],
+          tabs: [
+            ...desktopTabs,
+            rendererTab(
+              'mobile-created-ghost-1',
+              '44444444-4444-4444-8444-444444444444',
+              'Starting agent'
+            ),
+            rendererTab(
+              'mobile-created-ghost-2',
+              '55555555-5555-4555-8555-555555555555',
+              'Starting agent'
+            )
+          ]
+        }
+      ]
+    })
+
+    runtime.syncWindowGraph(0, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer:issue-5910',
+          snapshotVersion: 2,
+          activeGroupId: 'group-1',
+          activeTabId: desktopTabs[2]!.id,
+          activeTabType: 'terminal',
+          tabGroups: [
+            {
+              id: 'group-1',
+              activeTabId: 'desktop-tab-3',
+              tabOrder: ['desktop-tab-1', 'desktop-tab-2', 'desktop-tab-3']
+            }
+          ],
+          tabs: desktopTabs
+        }
+      ]
+    })
+
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    expect(listed.tabs.map((tab) => tab.id)).toEqual(desktopTabs.map((tab) => tab.id))
+    expect(listed.tabGroups?.[0]?.tabOrder).toEqual([
+      'desktop-tab-1',
+      'desktop-tab-2',
+      'desktop-tab-3'
+    ])
+  })
+
   it('publishes laptop-created remote runtime split terminals to phone session tabs', async () => {
     const spawn = vi
       .fn()


### PR DESCRIPTION
## Summary
- adds a regression harness for issue #5910's reported 5-tabs-on-mobile vs 3-tabs-on-desktop state
- simulates renderer-origin pending mobile-created terminal tabs followed by a newer authoritative desktop snapshot with only the 3 real tabs
- proves current runtime/session-sync code prunes the stale renderer-origin tabs instead of preserving them

## Why this proves it
- Recent PR #5839 (Fix mobile pending terminal tabs and prepare 0.0.15) fixed pending terminal hydration on mobile.
- Existing runtime merge behavior from PR #4843 keeps renderer snapshots authoritative while preserving only real headless/server-owned tabs.
- The new test encodes the issue shape directly: first snapshot has 5 tabs, second desktop snapshot has 3, final `session.tabs.list` returns exactly those 3.

## Test Plan
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts --testNamePattern "prunes renderer-origin mobile-created pending tabs|replaces pending phone session tabs|keeps live headless mobile session terminals"`
- `pnpm exec oxfmt --check src/main/runtime/orca-runtime.test.ts`

Fixes #5910

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->