### PR TITLE
Show git submodules in Source Control

### DIFF
--- a/src/main/git/status-submodules.integration.test.ts
+++ b/src/main/git/status-submodules.integration.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getStatus } from './status'
+
+const execFileAsync = promisify(execFile)
+
+async function git(cwd: string, args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd })
+}
+
+describe('getStatus submodules integration', () => {
+  let root: string | null = null
+
+  afterEach(async () => {
+    if (root) {
+      await rm(root, { recursive: true, force: true })
+      root = null
+    }
+  })
+
+  it('reports submodule metadata from .gitmodules when porcelain status omits clean submodules', async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'orca-status-submodules-'))
+    const libraryPath = path.join(root, 'library')
+    const appPath = path.join(root, 'app')
+
+    await git(root, ['init', '-q', libraryPath])
+    await git(libraryPath, ['config', 'user.email', 'test@example.com'])
+    await git(libraryPath, ['config', 'user.name', 'Test User'])
+    await writeFile(path.join(libraryPath, 'README.md'), 'library\n')
+    await git(libraryPath, ['add', 'README.md'])
+    await git(libraryPath, ['commit', '-qm', 'init library'])
+
+    await git(root, ['init', '-q', appPath])
+    await git(appPath, ['config', 'user.email', 'test@example.com'])
+    await git(appPath, ['config', 'user.name', 'Test User'])
+    await writeFile(path.join(appPath, 'README.md'), 'app\n')
+    await git(appPath, ['add', 'README.md'])
+    await git(appPath, ['commit', '-qm', 'init app'])
+    await git(appPath, [
+      '-c',
+      'protocol.file.allow=always',
+      'submodule',
+      'add',
+      '-q',
+      libraryPath,
+      'vendor/lib'
+    ])
+    await git(appPath, ['commit', '-qm', 'add submodule'])
+
+    const status = await getStatus(appPath)
+
+    expect(status.entries).toEqual([])
+    expect(status.submodules).toEqual([
+      expect.objectContaining({
+        name: 'vendor/lib',
+        path: 'vendor/lib',
+        url: libraryPath
+      })
+    ])
+  })
+})

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -571,6 +571,41 @@ describe('getStatus', () => {
     ])
   })
 
+  it('lists .gitmodules entries even when git status has no changed entries', async () => {
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath.endsWith('.gitmodules')) {
+        return [
+          '[submodule "vendor/lib"]',
+          '  path = vendor/lib',
+          '  url = https://example.com/lib.git',
+          '[submodule "vendor/missing"]',
+          '  path = vendor/missing'
+        ].join('\n')
+      }
+      return 'gitdir: /repo/.git/worktrees/feature\n'
+    })
+    existsSyncMock.mockReturnValue(false)
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout:
+        '# branch.oid abc123\n# branch.head feature\n# branch.upstream origin/feature\n# branch.ab +0 -0\n'
+    })
+
+    const result = await getStatus('/repo')
+
+    expect(result.entries).toEqual([])
+    expect(result.submodules).toEqual([
+      {
+        name: 'vendor/lib',
+        path: 'vendor/lib',
+        url: 'https://example.com/lib.git'
+      },
+      {
+        name: 'vendor/missing',
+        path: 'vendor/missing'
+      }
+    ])
+  })
+
   it('omits ignored files by default and parses them when requested', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
     existsSyncMock.mockReturnValue(false)
@@ -859,6 +894,7 @@ describe('getStatus', () => {
     await getStatus('/repo')
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock.mock.calls.some(([args]) => args.includes('diff'))).toBe(false)
   })
 
   it('truncates and flags didHitLimit when entries exceed the limit', async () => {
@@ -875,9 +911,9 @@ describe('getStatus', () => {
     expect(result.statusLength).toBeGreaterThan(10)
     // First `limit` entries are kept; the rest are dropped.
     expect(result.entries.length).toBe(10)
-    // attachLineStats (numstat) must be skipped when the limit was hit — only
-    // the single streamed status read should have happened.
+    // attachLineStats (numstat) must be skipped when the limit was hit.
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock.mock.calls.some(([args]) => args.includes('diff'))).toBe(false)
   })
 
   it('does not flag didHitLimit for a normal repo under the limit', async () => {

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -48,6 +48,7 @@ import { getLargeDiffRenderLimit } from '../../shared/large-diff-render-limit'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
 import { parseGitRevListFirstParentOid } from '../../shared/git-rev-list-output'
+import { parseGitmodules } from '../../shared/gitmodules-parser'
 
 const MAX_GIT_SHOW_BYTES = 10 * 1024 * 1024
 const MAX_STAGED_COMMIT_CONTEXT_BYTES = MAX_GIT_SHOW_BYTES
@@ -189,6 +190,7 @@ export async function getStatus(
 
   return {
     entries,
+    submodules: await getSubmodules(worktreePath),
     conflictOperation,
     head,
     branch,
@@ -208,6 +210,16 @@ export async function getStatus(
               : { hasUpstream: false, ahead: 0, behind: 0 })
         }
       : {})
+  }
+}
+
+async function getSubmodules(worktreePath: string): Promise<GitStatusResult['submodules']> {
+  try {
+    // Why: submodule folders are repository metadata from .gitmodules; parent
+    // worktree dirtiness still comes from ordinary porcelain status rows.
+    return parseGitmodules(await readFile(path.join(worktreePath, '.gitmodules'), 'utf8'))
+  } catch {
+    return []
   }
 }
 

--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -1,5 +1,5 @@
 import type * as NodePath from 'node:path'
-import { mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -172,6 +172,47 @@ describe('filesystem-auth path containment', () => {
       )
       await expect(resolveAuthorizedPath(join(folderPath, 'notes.md'), store)).resolves.toBe(
         join(await realpath(folderPath), 'notes.md')
+      )
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('authorizes registered .gitmodules submodule roots for git operations', async () => {
+    invalidateAuthorizedRootsCache()
+    const tempRoot = await mkdtemp(join(tmpdir(), 'orca-auth-submodule-'))
+    try {
+      const repoPath = join(tempRoot, 'repo')
+      const submodulePath = join(repoPath, 'vendor', 'lib')
+      await mkdir(submodulePath, { recursive: true })
+      await writeFile(
+        join(repoPath, '.gitmodules'),
+        '[submodule "vendor/lib"]\n\tpath = vendor/lib\n\turl = https://example.com/lib.git\n'
+      )
+      await writeFile(join(submodulePath, '.git'), 'gitdir: ../../.git/modules/vendor/lib\n')
+      const store = makeStore([{ ...repo, id: 'repo-temp', path: repoPath }])
+
+      await expect(resolveRegisteredWorktreePath(submodulePath, store)).resolves.toBe(
+        await realpath(submodulePath)
+      )
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not authorize arbitrary nested git roots that are not in .gitmodules', async () => {
+    invalidateAuthorizedRootsCache()
+    const tempRoot = await mkdtemp(join(tmpdir(), 'orca-auth-nested-git-'))
+    try {
+      const repoPath = join(tempRoot, 'repo')
+      const nestedPath = join(repoPath, 'vendor', 'other')
+      await mkdir(nestedPath, { recursive: true })
+      await writeFile(join(repoPath, '.gitmodules'), '')
+      await writeFile(join(nestedPath, '.git'), 'gitdir: ../../.git/modules/vendor/other\n')
+      const store = makeStore([{ ...repo, id: 'repo-temp', path: repoPath }])
+
+      await expect(resolveRegisteredWorktreePath(nestedPath, store)).rejects.toThrow(
+        'Access denied'
       )
     } finally {
       await rm(tempRoot, { recursive: true, force: true })

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -3,11 +3,12 @@ discovery, canonicalization, and registered-worktree cache checks together so
 the security boundary is auditable end to end. */
 import { resolve, relative, dirname, basename, isAbsolute, sep } from 'path'
 import { realpathSync } from 'fs'
-import { realpath } from 'fs/promises'
+import { readFile, realpath, stat } from 'fs/promises'
 import type { Store } from '../persistence'
 import { isRepoRoot, listRepoWorktrees } from '../repo-worktrees'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './worktree-logic'
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
+import { parseGitmodules } from '../../shared/gitmodules-parser'
 import { getProjectGroupSubtreeIds } from '../../shared/project-groups'
 import type { FolderWorkspace, ProjectGroup, Repo } from '../../shared/types'
 
@@ -447,7 +448,60 @@ export async function resolveRegisteredWorktreePath(
     return normalizedTarget
   }
 
+  if (await isRegisteredSubmoduleGitRoot(normalizedTarget, store)) {
+    return normalizedTarget
+  }
+
   throw new Error('Access denied: unknown repository or worktree path')
+}
+
+async function isRegisteredSubmoduleGitRoot(targetPath: string, store: Store): Promise<boolean> {
+  const parentRoot = await findRegisteredWorktreeRootIncludingCanonical(targetPath, store)
+  if (!parentRoot || parentRoot === targetPath) {
+    return false
+  }
+  if (!(await hasGitMetadata(targetPath))) {
+    return false
+  }
+  const relativeSubmodulePath = relative(parentRoot, targetPath).split(sep).join('/')
+  try {
+    const gitmodules = parseGitmodules(await readFile(resolve(parentRoot, '.gitmodules'), 'utf8'))
+    return gitmodules.some((entry) => entry.path === relativeSubmodulePath)
+  } catch {
+    return false
+  }
+}
+
+async function findRegisteredWorktreeRootIncludingCanonical(
+  targetPath: string,
+  store: Store
+): Promise<string | null> {
+  const textualRoot = findRegisteredWorktreeRoot(targetPath)
+  if (textualRoot) {
+    return textualRoot
+  }
+  await ensureAuthorizedRootsCache(store)
+  const refreshedRoot = findRegisteredWorktreeRoot(targetPath)
+  if (refreshedRoot) {
+    return refreshedRoot
+  }
+  for (const root of registeredWorktreeRoots) {
+    const canonicalRoot = await normalizeExistingPath(root)
+    if (isDescendantOrEqual(targetPath, canonicalRoot)) {
+      registeredWorktreeRoots.add(canonicalRoot)
+      return canonicalRoot
+    }
+  }
+  return null
+}
+
+async function hasGitMetadata(targetPath: string): Promise<boolean> {
+  try {
+    const gitMetadata = await stat(resolve(targetPath, '.git'))
+    return gitMetadata.isFile() || gitMetadata.isDirectory()
+  } catch {
+    return false
+  }
 }
 
 function refreshRegisteredWorktreeRoots(): void {

--- a/src/relay/git-handler-status-ops.test.ts
+++ b/src/relay/git-handler-status-ops.test.ts
@@ -70,4 +70,36 @@ describe('getStatusOp', () => {
     expect(result.didHitLimit).toBeUndefined()
     expect(result.entries).toHaveLength(5)
   })
+
+  it('returns .gitmodules submodules for SSH status results', async () => {
+    await fs.writeFile(
+      path.join(tmpDir, '.gitmodules'),
+      [
+        '[submodule "vendor/lib"]',
+        '  path = vendor/lib',
+        '  url = https://example.com/lib.git'
+      ].join('\n')
+    )
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args.includes('status')) {
+        return {
+          stdout:
+            '# branch.oid abc123\n# branch.head main\n# branch.upstream origin/main\n# branch.ab +0 -0\n',
+          stderr: ''
+        }
+      }
+      throw new Error(`Unexpected git command: ${args.join(' ')}`)
+    })
+
+    const result = await getStatusOp(git, { worktreePath: tmpDir })
+
+    expect(result.entries).toEqual([])
+    expect(result.submodules).toEqual([
+      {
+        name: 'vendor/lib',
+        path: 'vendor/lib',
+        url: 'https://example.com/lib.git'
+      }
+    ])
+  })
 })

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -22,6 +22,7 @@ import {
   type GitLineStats
 } from '../shared/git-uncommitted-line-stats'
 import { DEFAULT_GIT_STATUS_LIMIT } from '../shared/git-status-limit'
+import { parseGitmodules } from '../shared/gitmodules-parser'
 
 export async function resolveGitDir(worktreePath: string): Promise<string> {
   const dotGitPath = path.join(worktreePath, '.git')
@@ -68,6 +69,7 @@ export async function getStatusOp(
   branch?: string
   upstreamStatus?: GitUpstreamStatus
   ignoredPaths?: string[]
+  submodules?: Record<string, unknown>[]
   didHitLimit?: boolean
   statusLength?: number
 }> {
@@ -163,12 +165,23 @@ export async function getStatusOp(
 
   return {
     entries,
+    submodules: await getSubmodulesOp(worktreePath),
     conflictOperation,
     head,
     branch,
     upstreamStatus,
     ...(includeIgnored ? { ignoredPaths } : {}),
     ...(didHitLimit ? { didHitLimit: true, statusLength } : {})
+  }
+}
+
+async function getSubmodulesOp(worktreePath: string): Promise<Record<string, unknown>[]> {
+  try {
+    // Why: the relay runs beside the repository, including over SSH, so reading
+    // .gitmodules here preserves remote worktrees without a local path probe.
+    return parseGitmodules(await readFile(path.join(worktreePath, '.gitmodules'), 'utf8'))
+  } catch {
+    return []
   }
 }
 

--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -617,6 +617,7 @@ describe('FileExplorerRow collapse folder action', () => {
       dismissInlineInput: vi.fn(),
       folderStatusByRelativePath: new Map(),
       statusByRelativePath: new Map(),
+      submodulePaths: new Set(),
       ignoredByRelativePath: new Set(),
       expanded: new Set([directoryNode.path]),
       dirCache: {},
@@ -668,6 +669,7 @@ describe('FileExplorerRow collapse folder action', () => {
       dismissInlineInput: vi.fn(),
       folderStatusByRelativePath: new Map(),
       statusByRelativePath: new Map(),
+      submodulePaths: new Set(),
       ignoredByRelativePath: new Set(),
       expanded: new Set([directoryNode.path]),
       dirCache: {},
@@ -718,6 +720,7 @@ describe('FileExplorerRow collapse folder action', () => {
       dismissInlineInput: vi.fn(),
       folderStatusByRelativePath: new Map(),
       statusByRelativePath: new Map(),
+      submodulePaths: new Set(),
       ignoredByRelativePath: new Set(),
       expanded: new Set(),
       dirCache: {},
@@ -752,5 +755,56 @@ describe('FileExplorerRow collapse folder action', () => {
     const row = findFileExplorerRow(element)
 
     expect(row.props.connectionId).toBe('ssh-1')
+  })
+
+  it('marks matching directories as submodules in virtualized rows', () => {
+    const element = FileExplorerVirtualRows({
+      virtualizer: {
+        getTotalSize: () => 26,
+        getVirtualItems: () => [{ index: 0, key: 'src', start: 0 }],
+        measureElement: vi.fn()
+      } as never,
+      inlineInputIndex: -1,
+      rowProjection: createFileExplorerRowProjection([directoryNode]),
+      inlineInput: null,
+      handleInlineSubmit: vi.fn(),
+      dismissInlineInput: vi.fn(),
+      folderStatusByRelativePath: new Map([['src', 'modified']]),
+      statusByRelativePath: new Map(),
+      submodulePaths: new Set(['src']),
+      ignoredByRelativePath: new Set(),
+      expanded: new Set([directoryNode.path]),
+      dirCache: {},
+      selectedPaths: new Set(),
+      activeFileId: null,
+      flashingPath: null,
+      deleteShortcutLabel: 'Del',
+      onClick: vi.fn(),
+      onDoubleClick: vi.fn(),
+      onContextMenuSelect: vi.fn(),
+      onCopyPaths: vi.fn(),
+      onStartNew: vi.fn(),
+      onStartRename: vi.fn(),
+      onDuplicate: vi.fn(),
+      onAddFolderAsProject: vi.fn(),
+      canAddFolderAsProject: () => false,
+      onRequestDelete: vi.fn(),
+      onCollapseFolderSubtree: vi.fn(),
+      onFindInFolder: vi.fn(),
+      onMoveDrop: vi.fn(),
+      onDragTargetChange: vi.fn(),
+      onDragSourceChange: vi.fn(),
+      onDragExpandDir: vi.fn(),
+      onNativeDragTargetChange: vi.fn(),
+      onNativeDragExpandDir: vi.fn(),
+      dropTargetDir: null,
+      dragSourcePath: null,
+      nativeDropTargetDir: null
+    })
+
+    const row = findFileExplorerRow(element)
+
+    expect(row.props.isSubmodule).toBe(true)
+    expect(row.props.nodeStatus).toBe('modified')
   })
 })

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useAppStore } from '@/store'
 import { useActiveWorktree, useRepoById } from '@/store/selectors'
-import { basename, dirname } from '@/lib/path'
+import { basename, dirname, normalizeRelativePath } from '@/lib/path'
 import { useRuntimeFileListForWorktree } from '@/components/quick-open-file-list'
 import { folderRelativePathToIncludeGlob } from './file-search-include-pattern'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -82,6 +82,7 @@ function FileExplorerFiles(): React.JSX.Element {
   const makePreviewFilePermanent = useAppStore((s) => s.makePreviewFilePermanent)
   const activeFileId = useAppStore((s) => s.activeFileId)
   const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
+  const gitSubmodulesByWorktree = useAppStore((s) => s.gitSubmodulesByWorktree)
   const openFiles = useAppStore((s) => s.openFiles)
   const closeFile = useAppStore((s) => s.closeFile)
   const openModal = useAppStore((s) => s.openModal)
@@ -226,6 +227,17 @@ function FileExplorerFiles(): React.JSX.Element {
   const entries = useMemo(
     () => (activeWorktreeId ? (gitStatusByWorktree[activeWorktreeId] ?? []) : []),
     [activeWorktreeId, gitStatusByWorktree]
+  )
+  const submodulePaths = useMemo(
+    () =>
+      new Set(
+        activeWorktreeId
+          ? (gitSubmodulesByWorktree[activeWorktreeId] ?? []).map((entry) =>
+              normalizeRelativePath(entry.path)
+            )
+          : []
+      ),
+    [activeWorktreeId, gitSubmodulesByWorktree]
   )
   const statusByRelativePath = useMemo(() => buildStatusMap(entries), [entries])
   const folderStatusByRelativePath = useMemo(() => buildFolderStatusMap(entries), [entries])
@@ -680,6 +692,7 @@ function FileExplorerFiles(): React.JSX.Element {
                 dismissInlineInput={dismissInlineInput}
                 folderStatusByRelativePath={folderStatusByRelativePath}
                 statusByRelativePath={statusByRelativePath}
+                submodulePaths={submodulePaths}
                 ignoredByRelativePath={ignoredByRelativePath}
                 expanded={rowExpandedPaths}
                 canCollapseFolderSubtree={!hasNameFilter}

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -267,6 +267,7 @@ type FileExplorerRowProps = {
   selectedPaths: Set<string>
   nodeStatus: GitFileStatus | null
   statusColor: string | null
+  isSubmodule: boolean
   isIgnored: boolean
   deleteShortcutLabel: string
   connectionId?: string | null
@@ -359,6 +360,7 @@ export function FileExplorerRow({
   selectedPaths,
   nodeStatus,
   statusColor,
+  isSubmodule,
   isIgnored,
   deleteShortcutLabel,
   connectionId,
@@ -391,6 +393,10 @@ export function FileExplorerRow({
   const copyRelativePathShortcutLabel = useShortcutLabel('fileExplorer.copyRelativePath')
   const findInFolderShortcutLabel = useShortcutLabel('sidebar.search.toggle')
   const FileIcon = getFileTypeIcon(node.relativePath || node.name)
+  const submoduleLabel = translate(
+    'auto.components.right.sidebar.FileExplorerRow.submodule',
+    'Submodule'
+  )
   const rowDropDir = node.isDirectory ? node.path : targetDir
   const showRemoteDownloadAction = shouldShowRemoteDownloadAction(node, connectionId)
   const { setRowDragNode, handleDragOver, handleDragEnter, handleDragLeave, handleDrop } =
@@ -559,7 +565,15 @@ export function FileExplorerRow({
           >
             {node.name}
           </span>
-          {nodeStatus ? (
+          {isSubmodule ? (
+            <span
+              aria-label={submoduleLabel}
+              title={submoduleLabel}
+              className="ml-auto shrink-0 text-[10px] font-semibold tracking-wide text-muted-foreground mr-2"
+            >
+              S
+            </span>
+          ) : nodeStatus ? (
             <span
               className="ml-auto shrink-0 text-[10px] font-semibold tracking-wide mr-2"
               style={{ color: statusColor ?? undefined }}

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
@@ -17,6 +17,7 @@ type FileExplorerVirtualRowsProps = {
   dismissInlineInput: () => void
   folderStatusByRelativePath: Map<string, GitFileStatus | null>
   statusByRelativePath: Map<string, GitFileStatus>
+  submodulePaths: ReadonlySet<string>
   ignoredByRelativePath: Set<string>
   expanded: Set<string>
   canCollapseFolderSubtree?: boolean
@@ -59,6 +60,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
     dismissInlineInput,
     folderStatusByRelativePath,
     statusByRelativePath,
+    submodulePaths,
     ignoredByRelativePath,
     expanded,
     canCollapseFolderSubtree = true,
@@ -135,6 +137,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
         const nodeStatus = n.isDirectory
           ? (folderStatusByRelativePath.get(normalizedRelativePath) ?? null)
           : (statusByRelativePath.get(normalizedRelativePath) ?? null)
+        const isSubmodule = n.isDirectory && submodulePaths.has(normalizedRelativePath)
         const isIgnored = shouldShowIgnoredDecoration(
           nodeStatus,
           ignoredByRelativePath,
@@ -165,6 +168,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
               isFlashing={flashingPath === n.path}
               nodeStatus={nodeStatus}
               statusColor={nodeStatus ? STATUS_COLORS[nodeStatus] : null}
+              isSubmodule={isSubmodule}
               isIgnored={isIgnored}
               deleteShortcutLabel={deleteShortcutLabel}
               connectionId={connectionId}

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRowsAddProject.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRowsAddProject.test.tsx
@@ -61,6 +61,7 @@ describe('FileExplorerVirtualRows add-as-project action', () => {
       dismissInlineInput: vi.fn(),
       folderStatusByRelativePath: new Map(),
       statusByRelativePath: new Map(),
+      submodulePaths: new Set(),
       ignoredByRelativePath: new Set(),
       expanded: new Set([directoryNode.path]),
       dirCache: {},

--- a/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
@@ -48,6 +48,8 @@ const mocks = vi.hoisted(() => {
     createEmptySplitGroup: vi.fn(),
     getRuntimeGitStatus: vi.fn(),
     stageRuntimeGitPath: vi.fn(),
+    bulkStageRuntimeGitPaths: vi.fn(),
+    commitRuntimeGit: vi.fn(),
     discardRuntimeGitPath: vi.fn(),
     refreshGitStatusForWorktree: vi.fn(),
     requestEditorSaveQuiesce: vi.fn(),
@@ -89,6 +91,8 @@ vi.mock('@/runtime/runtime-git-client', async (importOriginal) => {
     ...actual,
     getRuntimeGitStatus: mocks.calls.getRuntimeGitStatus,
     stageRuntimeGitPath: mocks.calls.stageRuntimeGitPath,
+    bulkStageRuntimeGitPaths: mocks.calls.bulkStageRuntimeGitPaths,
+    commitRuntimeGit: mocks.calls.commitRuntimeGit,
     discardRuntimeGitPath: mocks.calls.discardRuntimeGitPath
   }
 })
@@ -148,6 +152,8 @@ function resetState(overrides: Partial<Record<string, unknown>> = {}): void {
     conflictOperation: 'unknown'
   })
   mocks.calls.stageRuntimeGitPath.mockResolvedValue(undefined)
+  mocks.calls.bulkStageRuntimeGitPaths.mockResolvedValue(undefined)
+  mocks.calls.commitRuntimeGit.mockResolvedValue({ success: true })
   mocks.calls.discardRuntimeGitPath.mockResolvedValue(undefined)
   mocks.calls.refreshGitStatusForWorktree.mockResolvedValue(undefined)
   mocks.calls.requestEditorSaveQuiesce.mockResolvedValue(undefined)
@@ -537,6 +543,144 @@ describe('SourceControl preview row opens', () => {
         worktreePath: '/repo/wt/packages/nested'
       }),
       'README.md'
+    )
+  })
+
+  it('renders a separate submodule repository action surface that stages in the nested repo', async () => {
+    resetState({
+      gitSubmodulesByWorktree: {
+        [mocks.activeWorktree.id]: [
+          {
+            name: 'packages/nested',
+            path: 'packages/nested',
+            url: 'https://example.com/nested.git'
+          }
+        ]
+      },
+      gitStatusByWorktree: {
+        [mocks.activeWorktree.id]: [
+          gitEntry({
+            path: 'packages/nested',
+            submodule: { commitChanged: false, trackedChanges: true, untrackedChanges: false }
+          })
+        ]
+      }
+    })
+    mocks.calls.getRuntimeGitStatus.mockResolvedValue({
+      entries: [
+        gitEntry({
+          path: 'README.md',
+          area: 'unstaged',
+          status: 'modified',
+          added: 3,
+          removed: 1
+        })
+      ],
+      conflictOperation: 'unknown'
+    })
+    renderSourceControl()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const actions = container.querySelector<HTMLDivElement>(
+      '[data-source-control-submodule-actions="packages/nested"]'
+    )
+    expect(actions).not.toBeNull()
+    const stageAllButton = [...(actions?.querySelectorAll<HTMLButtonElement>('button') ?? [])].find(
+      (button) => button.textContent?.includes('Stage All')
+    )
+    expect(stageAllButton).not.toBeNull()
+
+    await act(async () => {
+      stageAllButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(mocks.calls.bulkStageRuntimeGitPaths).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: null,
+        worktreePath: '/repo/wt/packages/nested'
+      }),
+      ['README.md']
+    )
+  })
+
+  it('commits staged submodule files from the separate submodule repository action surface', async () => {
+    resetState({
+      gitSubmodulesByWorktree: {
+        [mocks.activeWorktree.id]: [
+          {
+            name: 'packages/nested',
+            path: 'packages/nested',
+            url: 'https://example.com/nested.git'
+          }
+        ]
+      },
+      gitStatusByWorktree: {
+        [mocks.activeWorktree.id]: [
+          gitEntry({
+            path: 'packages/nested',
+            submodule: { commitChanged: false, trackedChanges: true, untrackedChanges: false }
+          })
+        ]
+      }
+    })
+    mocks.calls.getRuntimeGitStatus.mockResolvedValue({
+      entries: [
+        gitEntry({
+          path: 'README.md',
+          area: 'staged',
+          status: 'modified',
+          added: 3,
+          removed: 1
+        })
+      ],
+      conflictOperation: 'unknown'
+    })
+    renderSourceControl()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const actions = container.querySelector<HTMLDivElement>(
+      '[data-source-control-submodule-actions="packages/nested"]'
+    )
+    const message = actions?.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Submodule commit message"]'
+    )
+    expect(message).not.toBeNull()
+
+    await act(async () => {
+      if (message) {
+        const valueSetter = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          'value'
+        )?.set
+        valueSetter?.call(message, 'fix nested readme')
+        message.dispatchEvent(new Event('input', { bubbles: true }))
+      }
+      await Promise.resolve()
+    })
+
+    const commitButton = [...(actions?.querySelectorAll<HTMLButtonElement>('button') ?? [])].find(
+      (button) => button.textContent?.includes('Commit')
+    )
+    expect(commitButton).not.toBeNull()
+
+    await act(async () => {
+      commitButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(mocks.calls.commitRuntimeGit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: null,
+        worktreePath: '/repo/wt/packages/nested'
+      }),
+      'fix nested readme'
     )
   })
 

--- a/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
@@ -46,6 +46,8 @@ const mocks = vi.hoisted(() => {
     openConflictFile: vi.fn(),
     openBranchDiff: vi.fn(),
     createEmptySplitGroup: vi.fn(),
+    getRuntimeGitStatus: vi.fn(),
+    stageRuntimeGitPath: vi.fn(),
     discardRuntimeGitPath: vi.fn(),
     refreshGitStatusForWorktree: vi.fn(),
     requestEditorSaveQuiesce: vi.fn(),
@@ -85,6 +87,8 @@ vi.mock('@/runtime/runtime-git-client', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
+    getRuntimeGitStatus: mocks.calls.getRuntimeGitStatus,
+    stageRuntimeGitPath: mocks.calls.stageRuntimeGitPath,
     discardRuntimeGitPath: mocks.calls.discardRuntimeGitPath
   }
 })
@@ -139,6 +143,11 @@ function noopAsync(value: unknown = undefined): () => Promise<unknown> {
 function resetState(overrides: Partial<Record<string, unknown>> = {}): void {
   vi.clearAllMocks()
   mocks.calls.createEmptySplitGroup.mockReturnValue('group-2')
+  mocks.calls.getRuntimeGitStatus.mockResolvedValue({
+    entries: [],
+    conflictOperation: 'unknown'
+  })
+  mocks.calls.stageRuntimeGitPath.mockResolvedValue(undefined)
   mocks.calls.discardRuntimeGitPath.mockResolvedValue(undefined)
   mocks.calls.refreshGitStatusForWorktree.mockResolvedValue(undefined)
   mocks.calls.requestEditorSaveQuiesce.mockResolvedValue(undefined)
@@ -155,6 +164,7 @@ function resetState(overrides: Partial<Record<string, unknown>> = {}): void {
     gitBranchCompareSummaryByWorktree: { [mocks.activeWorktree.id]: null },
     gitConflictOperationByWorktree: {},
     remoteStatusesByWorktree: {},
+    gitSubmodulesByWorktree: {},
     isRemoteOperationActive: false,
     inFlightRemoteOpKind: null,
     settings: null,
@@ -443,6 +453,91 @@ describe('SourceControl preview row opens', () => {
     )
     expect(stageButton).not.toBeNull()
     expect(stageButton?.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('does not render clean submodules as source-control changes', () => {
+    resetState({
+      gitSubmodulesByWorktree: {
+        [mocks.activeWorktree.id]: [
+          {
+            name: 'vendor/lib',
+            path: 'vendor/lib',
+            url: 'https://example.com/lib.git'
+          }
+        ]
+      },
+      gitBranchCompareSummaryByWorktree: {
+        [mocks.activeWorktree.id]: branchSummary()
+      }
+    })
+    renderSourceControl()
+
+    const row = container.querySelector<HTMLDivElement>(
+      '[data-source-control-submodule-path="vendor/lib"]'
+    )
+    expect(container.textContent).not.toContain('Submodules')
+    expect(row).toBeNull()
+    expect(container.textContent).toContain('No changes on this branch')
+  })
+
+  it('renders dirty initialized submodules as stageable nested source-control sections', async () => {
+    resetState({
+      gitSubmodulesByWorktree: {
+        [mocks.activeWorktree.id]: [
+          {
+            name: 'packages/nested',
+            path: 'packages/nested',
+            url: 'https://example.com/nested.git'
+          }
+        ]
+      },
+      gitStatusByWorktree: {
+        [mocks.activeWorktree.id]: [
+          gitEntry({
+            path: 'packages/nested',
+            submodule: { commitChanged: false, trackedChanges: true, untrackedChanges: false }
+          })
+        ]
+      }
+    })
+    mocks.calls.getRuntimeGitStatus.mockResolvedValue({
+      entries: [
+        gitEntry({
+          path: 'README.md',
+          area: 'unstaged',
+          status: 'modified',
+          added: 3,
+          removed: 1
+        })
+      ],
+      conflictOperation: 'unknown'
+    })
+    renderSourceControl()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toContain('nested Git')
+    const nestedRow = container.querySelector<HTMLDivElement>(
+      '[data-source-control-path="README.md"]'
+    )
+    expect(nestedRow).not.toBeNull()
+    const stageButton = nestedRow?.querySelector<HTMLButtonElement>('button[aria-label="Stage"]')
+    expect(stageButton).not.toBeNull()
+
+    await act(async () => {
+      stageButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(mocks.calls.stageRuntimeGitPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: null,
+        worktreePath: '/repo/wt/packages/nested'
+      }),
+      'README.md'
+    )
   })
 
   it('passes preview=true when a plain branch row click opens a branch diff tab', () => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -849,6 +849,13 @@ function SourceControlInner(): React.JSX.Element {
   const [submoduleStatusByPath, setSubmoduleStatusByPath] = useState<
     Record<string, SubmoduleSourceControlStatus>
   >({})
+  const [submoduleCommitDrafts, setSubmoduleCommitDrafts] = useState<Record<string, string>>({})
+  const [submoduleCommitErrors, setSubmoduleCommitErrors] = useState<Record<string, string | null>>(
+    {}
+  )
+  const [submoduleCommitInFlight, setSubmoduleCommitInFlight] = useState<Record<string, boolean>>(
+    {}
+  )
   const submoduleStatusRequestSeqRef = useRef(0)
   const [pendingDiffCommentsClear, setPendingDiffCommentsClear] =
     useState<PendingDiffCommentsClear | null>(null)
@@ -5064,6 +5071,64 @@ function SourceControlInner(): React.JSX.Element {
     ]
   )
 
+  const handleCommitSubmodule = useCallback(
+    async (
+      submodulePath: string,
+      submoduleWorktreePath: string,
+      stagedEntries: readonly GitStatusEntry[]
+    ): Promise<void> => {
+      const message = (submoduleCommitDrafts[submodulePath] ?? '').trim()
+      if (!message || stagedEntries.length === 0 || submoduleCommitInFlight[submodulePath]) {
+        return
+      }
+      setSubmoduleCommitInFlight((prev) => ({ ...prev, [submodulePath]: true }))
+      setSubmoduleCommitErrors((prev) => ({ ...prev, [submodulePath]: null }))
+      try {
+        const result = await commitRuntimeGit(
+          {
+            // Why: VS Code models initialized submodules as their own SCM repos;
+            // commits must run in the nested repo, not the parent gitlink owner.
+            settings: activeRepoSettings,
+            worktreeId: null,
+            worktreePath: submoduleWorktreePath,
+            connectionId: activeConnectionId ?? undefined
+          },
+          message
+        )
+        if (!result.success) {
+          setSubmoduleCommitErrors((prev) => ({
+            ...prev,
+            [submodulePath]: result.error ?? 'Commit failed'
+          }))
+          return
+        }
+        setSubmoduleCommitDrafts((prev) => {
+          if ((prev[submodulePath] ?? '').trim() !== message) {
+            return prev
+          }
+          return { ...prev, [submodulePath]: '' }
+        })
+        await refreshSubmoduleSourceControlStatuses()
+        await refreshActiveGitStatusAfterMutation()
+      } catch (error) {
+        setSubmoduleCommitErrors((prev) => ({
+          ...prev,
+          [submodulePath]: error instanceof Error ? error.message : 'Commit failed'
+        }))
+      } finally {
+        setSubmoduleCommitInFlight((prev) => ({ ...prev, [submodulePath]: false }))
+      }
+    },
+    [
+      activeConnectionId,
+      activeRepoSettings,
+      refreshActiveGitStatusAfterMutation,
+      refreshSubmoduleSourceControlStatuses,
+      submoduleCommitDrafts,
+      submoduleCommitInFlight
+    ]
+  )
+
   const requestDiscardSubmoduleEntry = useCallback(
     (submoduleWorktreePath: string, entry: GitStatusEntry): void => {
       setPendingDiscard({
@@ -5989,6 +6054,21 @@ function SourceControlInner(): React.JSX.Element {
               const stageAllPaths = section.visibleEntries
                 .filter(isStageableStatusEntry)
                 .map((entry) => entry.path)
+              const stagedEntries = section.groups.staged
+              const submoduleHasStageableChanges =
+                section.groups.unstaged.some(isStageableStatusEntry) ||
+                section.groups.untracked.some(isStageableStatusEntry)
+              const submoduleHasUnresolvedConflicts = section.visibleEntries.some(
+                (entry) => entry.conflictStatus === 'unresolved'
+              )
+              const submoduleCommitMessage = submoduleCommitDrafts[section.submodule.path] ?? ''
+              const submodulePrimaryAction = resolveSubmoduleRepositoryPrimaryAction({
+                stagedCount: stagedEntries.length,
+                hasStageableChanges: submoduleHasStageableChanges,
+                hasMessage: submoduleCommitMessage.trim().length > 0,
+                hasUnresolvedConflicts: submoduleHasUnresolvedConflicts,
+                isCommitting: submoduleCommitInFlight[section.submodule.path] ?? false
+              })
               const unstageAllPaths = getUnstageAllPaths(section.visibleEntries)
               const label = translate(
                 'auto.components.right.sidebar.SourceControl.submoduleRepoLabel',
@@ -6041,6 +6121,35 @@ function SourceControlInner(): React.JSX.Element {
                       </div>
                     }
                   />
+                  {!isCollapsed && (
+                    <SubmoduleRepositoryActions
+                      submodulePath={section.submodule.path}
+                      commitMessage={submoduleCommitMessage}
+                      commitError={submoduleCommitErrors[section.submodule.path] ?? null}
+                      isCommitting={submoduleCommitInFlight[section.submodule.path] ?? false}
+                      primaryAction={submodulePrimaryAction}
+                      onCommitMessageChange={(value) => {
+                        setSubmoduleCommitDrafts((prev) => ({
+                          ...prev,
+                          [section.submodule.path]: value
+                        }))
+                      }}
+                      onPrimaryAction={() => {
+                        if (submodulePrimaryAction.disabled) {
+                          return
+                        }
+                        if (submodulePrimaryAction.kind === 'stage') {
+                          void handleStageAllSubmodulePaths(section.worktreePath, stageAllPaths)
+                          return
+                        }
+                        void handleCommitSubmodule(
+                          section.submodule.path,
+                          section.worktreePath,
+                          stagedEntries
+                        )
+                      }}
+                    />
+                  )}
                   {!isCollapsed &&
                     section.visibleEntries.map((entry) => {
                       const key = `${collapseKey}:${entry.area}::${entry.path}`
@@ -6532,6 +6641,164 @@ function getCommitFailureKindLabel(summary: string): string | null {
   }
 
   return null
+}
+
+function resolveSubmoduleRepositoryPrimaryAction({
+  stagedCount,
+  hasStageableChanges,
+  hasMessage,
+  hasUnresolvedConflicts,
+  isCommitting
+}: {
+  stagedCount: number
+  hasStageableChanges: boolean
+  hasMessage: boolean
+  hasUnresolvedConflicts: boolean
+  isCommitting: boolean
+}): PrimaryAction {
+  const commitLabel = translate(
+    'auto.components.right.sidebar.SourceControl.submoduleCommit',
+    'Commit'
+  )
+  if (isCommitting) {
+    return {
+      kind: 'commit',
+      label: commitLabel,
+      title: translate(
+        'auto.components.right.sidebar.SourceControl.submoduleCommitInProgress',
+        'Commit in progress...'
+      ),
+      disabled: true
+    }
+  }
+  if (hasUnresolvedConflicts) {
+    return {
+      kind: 'commit',
+      label: commitLabel,
+      title: translate(
+        'auto.components.right.sidebar.SourceControl.submoduleResolveConflicts',
+        'Resolve conflicts before committing'
+      ),
+      disabled: true
+    }
+  }
+  if (stagedCount > 0 && hasMessage) {
+    return {
+      kind: 'commit',
+      label: commitLabel,
+      title: translate(
+        'auto.components.right.sidebar.SourceControl.submoduleCommitStaged',
+        'Commit staged submodule changes'
+      ),
+      disabled: false
+    }
+  }
+  if (stagedCount > 0) {
+    return {
+      kind: 'commit',
+      label: commitLabel,
+      title: translate(
+        'auto.components.right.sidebar.SourceControl.submoduleEnterMessage',
+        'Enter a commit message to commit'
+      ),
+      disabled: true
+    }
+  }
+  if (hasStageableChanges) {
+    return {
+      kind: 'stage',
+      label: translate(
+        'auto.components.right.sidebar.SourceControl.submoduleStageAll',
+        'Stage All'
+      ),
+      title: translate(
+        'auto.components.right.sidebar.SourceControl.submoduleStageAllTitle',
+        'Stage all submodule changes'
+      ),
+      disabled: false
+    }
+  }
+  return {
+    kind: 'commit',
+    label: commitLabel,
+    title: translate(
+      'auto.components.right.sidebar.SourceControl.submoduleNothingToCommit',
+      'Stage at least one submodule file to commit'
+    ),
+    disabled: true
+  }
+}
+
+function SubmoduleRepositoryActions({
+  submodulePath,
+  commitMessage,
+  commitError,
+  isCommitting,
+  primaryAction,
+  onCommitMessageChange,
+  onPrimaryAction
+}: {
+  submodulePath: string
+  commitMessage: string
+  commitError: string | null
+  isCommitting: boolean
+  primaryAction: PrimaryAction
+  onCommitMessageChange: (message: string) => void
+  onPrimaryAction: () => void
+}): React.JSX.Element {
+  const PrimaryIcon = primaryAction.kind === 'stage' ? Plus : Check
+  return (
+    <div className="px-3 pb-2" data-source-control-submodule-actions={submodulePath}>
+      <textarea
+        rows={1}
+        value={commitMessage}
+        disabled={isCommitting}
+        onChange={(event) => onCommitMessageChange(event.target.value)}
+        placeholder={translate(
+          'auto.components.right.sidebar.SourceControl.submoduleCommitMessage',
+          'Message'
+        )}
+        aria-label={translate(
+          'auto.components.right.sidebar.SourceControl.submoduleCommitMessageLabel',
+          'Submodule commit message'
+        )}
+        className="mt-0.5 min-h-9 w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+      />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="mt-1 flex">
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              disabled={primaryAction.disabled}
+              onClick={onPrimaryAction}
+              className="w-full px-3 text-[11px]"
+              title={primaryAction.title}
+            >
+              {isCommitting ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <PrimaryIcon className="size-3.5" aria-hidden="true" />
+              )}
+              {primaryAction.label}
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6} className="max-w-72">
+          {primaryAction.title}
+        </TooltipContent>
+      </Tooltip>
+      {commitError ? (
+        <div
+          role="alert"
+          className="mt-1 rounded-md border border-destructive/20 bg-card px-2 py-1.5 font-mono text-[11px] leading-4 text-destructive [overflow-wrap:anywhere]"
+        >
+          {commitError}
+        </div>
+      ) : null}
+    </div>
+  )
 }
 
 type CommitAreaProps = {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -159,6 +159,7 @@ import {
   generateRuntimePullRequestFields,
   getRuntimeGitBranchCompare,
   getRuntimeGitHistory,
+  getRuntimeGitStatus,
   stageRuntimeGitPath,
   unstageRuntimeGitPath,
   type RuntimeGitContext,
@@ -178,7 +179,9 @@ import type {
   GitBranchCompareSummary,
   GitConflictOperation,
   GitPushTarget,
+  GitStatusResult,
   GitStatusEntry,
+  GitSubmoduleEntry,
   GitUpstreamStatus,
   SourceControlViewMode,
   TuiAgent
@@ -296,6 +299,11 @@ type SourceControlOperationTarget = RuntimeGitContext & {
   worktreeId: string
   pushTarget?: GitPushTarget
 }
+type SubmoduleSourceControlStatus = {
+  submodule: GitSubmoduleEntry
+  worktreePath: string
+  status: GitStatusResult
+}
 type HostedReviewCreatedContext = {
   repoPath: string
   repoId: string
@@ -410,6 +418,7 @@ function rewriteCompareBaseBranchFromCandidate(
 
 const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntry[] = []
 const EMPTY_BRANCH_CHANGE_ENTRIES: GitBranchChangeEntry[] = []
+const EMPTY_GIT_SUBMODULES: GitSubmoduleEntry[] = []
 
 // Why: the "too many changes — add folder to .gitignore?" warning shows at most
 // once per worktree per session (the analog of a "Don't show again" gate), so a
@@ -733,6 +742,11 @@ function SourceControlInner(): React.JSX.Element {
       ? (s.gitStatusByWorktree[activeWorktreeId] ?? EMPTY_GIT_STATUS_ENTRIES)
       : EMPTY_GIT_STATUS_ENTRIES
   )
+  const gitSubmodules = useAppStore((s) =>
+    activeWorktreeId
+      ? (s.gitSubmodulesByWorktree?.[activeWorktreeId] ?? EMPTY_GIT_SUBMODULES)
+      : EMPTY_GIT_SUBMODULES
+  )
   const repositoryHuge = useAppStore((s) =>
     activeWorktreeId ? s.gitStatusHugeByWorktree?.[activeWorktreeId] : undefined
   )
@@ -832,6 +846,10 @@ function SourceControlInner(): React.JSX.Element {
   )
   const [diffCommentsExpanded, setDiffCommentsExpanded] = useState(false)
   const [diffCommentsCopied, showDiffCommentsCopied] = useCopyFeedbackState(false)
+  const [submoduleStatusByPath, setSubmoduleStatusByPath] = useState<
+    Record<string, SubmoduleSourceControlStatus>
+  >({})
+  const submoduleStatusRequestSeqRef = useRef(0)
   const [pendingDiffCommentsClear, setPendingDiffCommentsClear] =
     useState<PendingDiffCommentsClear | null>(null)
   const [isClearingDiffComments, setIsClearingDiffComments] = useState(false)
@@ -1081,6 +1099,77 @@ function SourceControlInner(): React.JSX.Element {
   const activeConnectionId = activeWorktreeId
     ? (getConnectionId(activeWorktreeId) ?? activeRepo?.connectionId ?? null)
     : null
+  const sourceControlGitSubmodules = useMemo((): GitSubmoduleEntry[] => {
+    if (gitSubmodules.length > 0) {
+      return gitSubmodules
+    }
+    return entries
+      .filter((entry) => entry.submodule)
+      .map((entry) => ({ name: entry.path, path: entry.path }))
+  }, [entries, gitSubmodules])
+  const gitSubmoduleSignature = useMemo(
+    () =>
+      sourceControlGitSubmodules
+        .map((submodule) => `${submodule.path}\0${submodule.name}`)
+        .join('\u0001'),
+    [sourceControlGitSubmodules]
+  )
+  const refreshSubmoduleSourceControlStatuses = useCallback(async (): Promise<void> => {
+    const requestSeq = submoduleStatusRequestSeqRef.current + 1
+    submoduleStatusRequestSeqRef.current = requestSeq
+
+    if (!activeWorktreeId || !worktreePath || sourceControlGitSubmodules.length === 0 || isFolder) {
+      setSubmoduleStatusByPath({})
+      return
+    }
+
+    const connectionId = activeConnectionId ?? undefined
+    const statuses = await Promise.all(
+      sourceControlGitSubmodules.map(
+        async (submodule): Promise<SubmoduleSourceControlStatus | null> => {
+          const submoduleWorktreePath = joinPath(worktreePath, submodule.path)
+          try {
+            const status = await getRuntimeGitStatus({
+              // Why: nested submodules are addressed by their own repo path while
+              // staying on the parent repo's owner host/SSH connection.
+              settings: activeRepoSettings,
+              worktreeId: null,
+              worktreePath: submoduleWorktreePath,
+              connectionId
+            })
+            return status.entries.length > 0
+              ? { submodule, worktreePath: submoduleWorktreePath, status }
+              : null
+          } catch (error) {
+            console.warn('[SourceControl] submodule git status failed', {
+              path: submodule.path,
+              error
+            })
+            return null
+          }
+        }
+      )
+    )
+
+    if (submoduleStatusRequestSeqRef.current !== requestSeq) {
+      return
+    }
+
+    const next: Record<string, SubmoduleSourceControlStatus> = {}
+    for (const item of statuses) {
+      if (item) {
+        next[item.submodule.path] = item
+      }
+    }
+    setSubmoduleStatusByPath(next)
+  }, [
+    activeConnectionId,
+    activeRepoSettings,
+    activeWorktreeId,
+    isFolder,
+    sourceControlGitSubmodules,
+    worktreePath
+  ])
   const activeSourceControlLaunchPlatform = resolveSourceControlLaunchPlatform({
     connectionId: activeConnectionId,
     worktreePath,
@@ -1151,6 +1240,13 @@ function SourceControlInner(): React.JSX.Element {
       console.warn('[SourceControl] post-mutation git status refresh failed', error)
     }
   }, [refreshActiveGitStatus])
+
+  useEffect(() => {
+    if (rightSidebarTab !== 'source-control') {
+      return
+    }
+    void refreshSubmoduleSourceControlStatuses()
+  }, [entries, gitSubmoduleSignature, refreshSubmoduleSourceControlStatuses, rightSidebarTab])
 
   // Why: when status is truncated at the entry limit, offer (once per worktree)
   // to .gitignore the folder most likely flooding it — the usual cause is a
@@ -1503,12 +1599,45 @@ function SourceControlInner(): React.JSX.Element {
     () => new Map(unfilteredDisplaySections.map((section) => [section.id, section])),
     [unfilteredDisplaySections]
   )
+  const submoduleSourceControlSections = useMemo(() => {
+    return Object.values(submoduleStatusByPath)
+      .sort((a, b) =>
+        a.submodule.path.localeCompare(b.submodule.path, undefined, { numeric: true })
+      )
+      .map((item) => {
+        const submoduleGroups: SourceControlEntryGroups = {
+          staged: [],
+          unstaged: [],
+          untracked: []
+        }
+        for (const entry of item.status.entries) {
+          submoduleGroups[entry.area].push(entry)
+        }
+        for (const area of SOURCE_CONTROL_AREAS) {
+          submoduleGroups[area].sort(compareGitStatusEntries)
+        }
+        const filteredSubmoduleGroups = filterSourceControlGroupedPathEntries(
+          submoduleGroups,
+          fileFilterState
+        )
+        const visibleSections = buildSourceControlDisplaySections(
+          filteredSubmoduleGroups,
+          sourceControlGroupOrder
+        )
+        const visibleEntries = visibleSections.flatMap((section) => section.items)
+        return {
+          ...item,
+          groups: submoduleGroups,
+          visibleEntries
+        }
+      })
+      .filter((section) => section.visibleEntries.length > 0)
+  }, [fileFilterState, sourceControlGroupOrder, submoduleStatusByPath])
 
   const filteredBranchEntries = useMemo(
     () => filterSourceControlPathEntries(branchEntries, fileFilterState),
     [branchEntries, fileFilterState]
   )
-
   const flatEntries = useMemo(() => {
     const arr: FlatEntry[] = []
     for (const section of displaySections) {
@@ -4782,6 +4911,170 @@ function SourceControlInner(): React.JSX.Element {
     [activeRepoSettings, worktreePath, activeWorktreeId, refreshActiveGitStatusAfterMutation]
   )
 
+  const handleOpenSubmoduleDiff = useCallback(
+    (
+      submoduleWorktreePath: string,
+      entry: GitStatusEntry,
+      event?: SourceControlRowOpenEvent
+    ): void => {
+      if (!activeWorktreeId) {
+        return
+      }
+      const targetGroupId = resolveSplitTargetGroupId(event)
+      const openAsPreview = shouldOpenSourceControlRowAsPreview(event, targetGroupId)
+      const language = detectLanguage(entry.path)
+      const filePath = joinPath(submoduleWorktreePath, entry.path)
+      if (language === 'markdown' && entry.area === 'unstaged') {
+        openFile(
+          {
+            filePath,
+            relativePath: entry.path,
+            worktreeId: activeWorktreeId,
+            language,
+            mode: 'edit'
+          },
+          { targetGroupId, preview: openAsPreview }
+        )
+        setEditorViewMode(filePath, 'changes')
+        return
+      }
+      openDiff(activeWorktreeId, filePath, entry.path, language, entry.area === 'staged', {
+        targetGroupId,
+        preview: openAsPreview
+      })
+    },
+    [activeWorktreeId, openDiff, openFile, resolveSplitTargetGroupId, setEditorViewMode]
+  )
+
+  const handleStageSubmodulePath = useCallback(
+    async (submoduleWorktreePath: string, filePath: string): Promise<void> => {
+      try {
+        await stageRuntimeGitPath(
+          {
+            // Why: submodule rows are normal git rows in the nested repo, not
+            // gitlink rows in the parent worktree.
+            settings: activeRepoSettings,
+            worktreeId: null,
+            worktreePath: submoduleWorktreePath,
+            connectionId: activeConnectionId ?? undefined
+          },
+          filePath
+        )
+        await refreshSubmoduleSourceControlStatuses()
+        await refreshActiveGitStatusAfterMutation()
+      } catch {
+        // git operation failed silently
+      }
+    },
+    [
+      activeConnectionId,
+      activeRepoSettings,
+      refreshActiveGitStatusAfterMutation,
+      refreshSubmoduleSourceControlStatuses
+    ]
+  )
+
+  const handleUnstageSubmodulePath = useCallback(
+    async (submoduleWorktreePath: string, filePath: string): Promise<void> => {
+      try {
+        await unstageRuntimeGitPath(
+          {
+            // Why: submodule rows are normal git rows in the nested repo, not
+            // gitlink rows in the parent worktree.
+            settings: activeRepoSettings,
+            worktreeId: null,
+            worktreePath: submoduleWorktreePath,
+            connectionId: activeConnectionId ?? undefined
+          },
+          filePath
+        )
+        await refreshSubmoduleSourceControlStatuses()
+        await refreshActiveGitStatusAfterMutation()
+      } catch {
+        // git operation failed silently
+      }
+    },
+    [
+      activeConnectionId,
+      activeRepoSettings,
+      refreshActiveGitStatusAfterMutation,
+      refreshSubmoduleSourceControlStatuses
+    ]
+  )
+
+  const handleStageAllSubmodulePaths = useCallback(
+    async (submoduleWorktreePath: string, filePaths: readonly string[]): Promise<void> => {
+      if (filePaths.length === 0) {
+        return
+      }
+      try {
+        await bulkStageRuntimeGitPaths(
+          {
+            // Why: submodule bulk actions must mutate the nested repo, not the
+            // parent repo that owns the gitlink row.
+            settings: activeRepoSettings,
+            worktreeId: null,
+            worktreePath: submoduleWorktreePath,
+            connectionId: activeConnectionId ?? undefined
+          },
+          [...filePaths]
+        )
+        await refreshSubmoduleSourceControlStatuses()
+        await refreshActiveGitStatusAfterMutation()
+      } catch {
+        // git operation failed silently
+      }
+    },
+    [
+      activeConnectionId,
+      activeRepoSettings,
+      refreshActiveGitStatusAfterMutation,
+      refreshSubmoduleSourceControlStatuses
+    ]
+  )
+
+  const handleUnstageAllSubmodulePaths = useCallback(
+    async (submoduleWorktreePath: string, filePaths: readonly string[]): Promise<void> => {
+      if (filePaths.length === 0) {
+        return
+      }
+      try {
+        await bulkUnstageRuntimeGitPaths(
+          {
+            // Why: submodule bulk actions must mutate the nested repo, not the
+            // parent repo that owns the gitlink row.
+            settings: activeRepoSettings,
+            worktreeId: null,
+            worktreePath: submoduleWorktreePath,
+            connectionId: activeConnectionId ?? undefined
+          },
+          [...filePaths]
+        )
+        await refreshSubmoduleSourceControlStatuses()
+        await refreshActiveGitStatusAfterMutation()
+      } catch {
+        // git operation failed silently
+      }
+    },
+    [
+      activeConnectionId,
+      activeRepoSettings,
+      refreshActiveGitStatusAfterMutation,
+      refreshSubmoduleSourceControlStatuses
+    ]
+  )
+
+  const requestDiscardSubmoduleEntry = useCallback(
+    (submoduleWorktreePath: string, entry: GitStatusEntry): void => {
+      setPendingDiscard({
+        kind: 'submodule-entry',
+        submoduleWorktreePath,
+        entry
+      })
+    },
+    []
+  )
+
   // Why: split into two variants — `discardSingle` throws so bulk callers can
   // aggregate failures into a single toast via `runDiscardAllForArea`'s
   // onError, while `handleDiscard` swallows for the per-row fire-and-forget UI
@@ -4878,6 +5171,57 @@ function SourceControlInner(): React.JSX.Element {
       }
     },
     [discardSingle, refreshActiveGitStatusAfterMutation]
+  )
+
+  const discardSubmoduleSingle = useCallback(
+    async (submoduleWorktreePath: string, filePath: string): Promise<void> => {
+      if (!activeWorktreeId) {
+        return
+      }
+      const runtimeEnvironmentId =
+        useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() || null
+      await requestEditorSaveQuiesce({
+        worktreeId: activeWorktreeId,
+        worktreePath: submoduleWorktreePath,
+        relativePath: filePath,
+        runtimeEnvironmentId
+      })
+      await discardRuntimeGitPath(
+        {
+          // Why: submodule rows discard from the nested repo's working tree,
+          // not from the parent repo gitlink row.
+          settings: activeRepoSettings,
+          worktreeId: null,
+          worktreePath: submoduleWorktreePath,
+          connectionId: activeConnectionId ?? undefined
+        },
+        filePath
+      )
+      notifyEditorExternalFileChange({
+        worktreeId: activeWorktreeId,
+        worktreePath: submoduleWorktreePath,
+        relativePath: filePath,
+        runtimeEnvironmentId
+      })
+    },
+    [activeConnectionId, activeRepoSettings, activeWorktreeId]
+  )
+
+  const handleDiscardSubmoduleEntry = useCallback(
+    async (submoduleWorktreePath: string, filePath: string): Promise<void> => {
+      try {
+        await discardSubmoduleSingle(submoduleWorktreePath, filePath)
+        await refreshSubmoduleSourceControlStatuses()
+        await refreshActiveGitStatusAfterMutation()
+      } catch {
+        // Why: per-row discard is fire-and-forget for the UI, matching parent rows.
+      }
+    },
+    [
+      discardSubmoduleSingle,
+      refreshActiveGitStatusAfterMutation,
+      refreshSubmoduleSourceControlStatuses
+    ]
   )
 
   // Why: "Discard all" mirrors the per-row discard rules — it skips unresolved
@@ -5013,8 +5357,12 @@ function SourceControlInner(): React.JSX.Element {
       void handleDiscard(pending.entry.path)
       return
     }
+    if (pending.kind === 'submodule-entry') {
+      void handleDiscardSubmoduleEntry(pending.submoduleWorktreePath, pending.entry.path)
+      return
+    }
     void handleRevertAllInArea(pending.area, pending.paths)
-  }, [handleDiscard, handleRevertAllInArea, pendingDiscard])
+  }, [handleDiscard, handleDiscardSubmoduleEntry, handleRevertAllInArea, pendingDiscard])
 
   if (!activeWorktree || !activeRepo || !worktreePath) {
     return (
@@ -5041,9 +5389,14 @@ function SourceControlInner(): React.JSX.Element {
     filteredGrouped.staged.length > 0 ||
     filteredGrouped.unstaged.length > 0 ||
     filteredGrouped.untracked.length > 0
+  const hasFilteredSubmoduleEntries = submoduleSourceControlSections.length > 0
   const hasFilteredBranchEntries = filteredBranchEntries.length > 0
   const showGenericEmptyState =
-    !hasUncommittedEntries && branchSummary?.status === 'ready' && branchEntries.length === 0
+    !hasUncommittedEntries &&
+    !hasFilteredSubmoduleEntries &&
+    branchSummary?.status === 'ready' &&
+    branchEntries.length === 0
+  const showCleanBranchEmptyState = showGenericEmptyState
   const currentWorktreeId = activeWorktree.id
 
   return (
@@ -5272,7 +5625,7 @@ function SourceControlInner(): React.JSX.Element {
             </div>
           )}
 
-          {showGenericEmptyState && !normalizedFilter ? (
+          {showCleanBranchEmptyState && !normalizedFilter ? (
             <EmptyState
               heading="No changes on this branch"
               supportingText={`This workspace is clean and this branch has no changes ahead of ${branchSummary?.baseRef ?? 'base'}`}
@@ -5628,6 +5981,99 @@ function SourceControlInner(): React.JSX.Element {
               })}
             </>
           )}
+
+          {hasFilteredSubmoduleEntries &&
+            submoduleSourceControlSections.map((section) => {
+              const collapseKey = `submodule:${section.submodule.path}`
+              const isCollapsed = collapsedSections.has(collapseKey)
+              const stageAllPaths = section.visibleEntries
+                .filter(isStageableStatusEntry)
+                .map((entry) => entry.path)
+              const unstageAllPaths = getUnstageAllPaths(section.visibleEntries)
+              const label = translate(
+                'auto.components.right.sidebar.SourceControl.submoduleRepoLabel',
+                '{{value0}} Git',
+                { value0: basename(section.submodule.path) || section.submodule.name }
+              )
+              return (
+                <div key={collapseKey}>
+                  <SectionHeader
+                    label={label}
+                    count={section.visibleEntries.length}
+                    conflictCount={
+                      section.visibleEntries.filter(
+                        (entry) => entry.conflictStatus === 'unresolved'
+                      ).length
+                    }
+                    isCollapsed={isCollapsed}
+                    onToggle={() => toggleSection(collapseKey)}
+                    actions={
+                      <div className="flex items-center can-hover:opacity-0 transition-opacity group-hover/section:opacity-100 focus-within:opacity-100">
+                        {stageAllPaths.length > 0 && !normalizedFilter ? (
+                          <ActionButton
+                            icon={Plus}
+                            title={translate(
+                              'auto.components.right.sidebar.SourceControl.24d2598eff',
+                              'Stage all'
+                            )}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              void handleStageAllSubmodulePaths(section.worktreePath, stageAllPaths)
+                            }}
+                          />
+                        ) : null}
+                        {unstageAllPaths.length > 0 && !normalizedFilter ? (
+                          <ActionButton
+                            icon={Minus}
+                            title={translate(
+                              'auto.components.right.sidebar.SourceControl.9339382454',
+                              'Unstage all'
+                            )}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              void handleUnstageAllSubmodulePaths(
+                                section.worktreePath,
+                                unstageAllPaths
+                              )
+                            }}
+                          />
+                        ) : null}
+                      </div>
+                    }
+                  />
+                  {!isCollapsed &&
+                    section.visibleEntries.map((entry) => {
+                      const key = `${collapseKey}:${entry.area}::${entry.path}`
+                      return (
+                        <UncommittedEntryRow
+                          key={key}
+                          entryKey={key}
+                          entry={entry}
+                          currentWorktreeId={currentWorktreeId}
+                          worktreePath={section.worktreePath}
+                          selected={false}
+                          isOpenFile={false}
+                          onRevealInExplorer={revealInExplorer}
+                          connectionId={activeConnectionId}
+                          onOpen={(rowEntry, event) =>
+                            handleOpenSubmoduleDiff(section.worktreePath, rowEntry, event)
+                          }
+                          onStage={(filePath) =>
+                            handleStageSubmodulePath(section.worktreePath, filePath)
+                          }
+                          onUnstage={(filePath) =>
+                            handleUnstageSubmodulePath(section.worktreePath, filePath)
+                          }
+                          onDiscard={(rowEntry) =>
+                            requestDiscardSubmoduleEntry(section.worktreePath, rowEntry)
+                          }
+                          commentCount={0}
+                        />
+                      )
+                    })}
+                </div>
+              )
+            })}
 
           {shouldShowSourceControlCompareUnavailableCard(
             branchSummary,

--- a/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
@@ -62,6 +62,7 @@ function virtualRowsElement(nodes: TreeNode[]): React.JSX.Element {
     dismissInlineInput: vi.fn(),
     folderStatusByRelativePath: new Map(),
     statusByRelativePath: new Map(),
+    submodulePaths: new Set(),
     ignoredByRelativePath: new Set(),
     expanded: new Set(),
     dirCache: {},

--- a/src/renderer/src/components/right-sidebar/source-control-discard-dialog.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-discard-dialog.tsx
@@ -20,6 +20,7 @@ import { translate } from '@/i18n/i18n'
 
 export type PendingDiscardConfirmation =
   | { kind: 'entry'; entry: GitStatusEntry }
+  | { kind: 'submodule-entry'; submoduleWorktreePath: string; entry: GitStatusEntry }
   | { kind: 'area'; area: DiscardAllArea; paths: readonly string[] }
 
 export function focusDiscardDialogConfirmButton(
@@ -48,7 +49,7 @@ export function SourceControlDiscardDialog({
     if (!pendingDiscard) {
       return null
     }
-    if (pendingDiscard.kind === 'entry') {
+    if (pendingDiscard.kind === 'entry' || pendingDiscard.kind === 'submodule-entry') {
       return getDiscardEntryConfirmationCopy(pendingDiscard.entry)
     }
     return getDiscardAreaConfirmationCopy(pendingDiscard.area, pendingDiscard.paths.length)
@@ -99,7 +100,7 @@ export function SourceControlDiscardDialog({
                   'files'
                 )}
           </div>
-        ) : pendingDiscard?.kind === 'entry' ? (
+        ) : pendingDiscard?.kind === 'entry' || pendingDiscard?.kind === 'submodule-entry' ? (
           <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
             <div className="break-all font-medium text-foreground">{pendingDiscard.entry.path}</div>
           </div>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8669,7 +8669,17 @@
             "b715ef615b": "{{value0}} commits ahead of {{value1}}",
             "c1a8f3e204": "1 commit behind {{value0}}",
             "d2b9g4f315": "{{value0}} commits behind {{value1}}",
-            "e9c2a5d416": "Even with {{value0}}"
+            "e9c2a5d416": "Even with {{value0}}",
+            "submoduleCommit": "Commit",
+            "submoduleCommitInProgress": "Commit in progress...",
+            "submoduleResolveConflicts": "Resolve conflicts before committing",
+            "submoduleCommitStaged": "Commit staged submodule changes",
+            "submoduleEnterMessage": "Enter a commit message to commit",
+            "submoduleStageAll": "Stage All",
+            "submoduleStageAllTitle": "Stage all submodule changes",
+            "submoduleNothingToCommit": "Stage at least one submodule file to commit",
+            "submoduleCommitMessage": "Message",
+            "submoduleCommitMessageLabel": "Submodule commit message"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "Could not start the selected agent.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "Copy",
             "c2f0b72b8d": "Insert",
             "925f49f210": "Expand Pane",
-            "df766809e0": "Collapse Pane",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "Collapse Pane"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Restart daemon",
@@ -8321,7 +8320,8 @@
             "42e10cbf57": "Copy Relative Paths",
             "b5d436aa30": "Copy Path",
             "f9d7ca753d": "Copy Paths",
-            "3161c4e425": "folder"
+            "3161c4e425": "folder",
+            "submodule": "Submodule"
           },
           "FileExplorerToolbar": {
             "d238264654": "Show Git Ignored Files",
@@ -8469,8 +8469,8 @@
             "a1f2c8d901": "View"
           },
           "SourceControl": {
-            "conflictsSection": "Conflicts",
             "1406954883": "Clear all notes...",
+            "conflictsSection": "Conflicts",
             "cc05b2d088": "Open in File Explorer",
             "03194cfff4": "Local session state derived from a conflict you opened here.",
             "413a3ba113": "conflict",
@@ -8600,6 +8600,7 @@
             "a0cc0e6b4e": "loading",
             "9339382454": "Unstage all",
             "24d2598eff": "Stage all",
+            "submoduleRepoLabel": "{{value0}} Git",
             "ce41708855": "Discard all",
             "2f609a2e7c": "Delete all untracked",
             "9bb062a886": "uncommitted",
@@ -9183,9 +9184,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "View"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8669,7 +8669,17 @@
             "b715ef615b": "{{value0}} commits adelante de {{value1}}",
             "c1a8f3e204": "1 commit detrás de {{value0}}",
             "d2b9g4f315": "{{value0}} commits detrás de {{value1}}",
-            "e9c2a5d416": "A la par con {{value0}}"
+            "e9c2a5d416": "A la par con {{value0}}",
+            "submoduleCommit": "Commit",
+            "submoduleCommitInProgress": "Commit in progress...",
+            "submoduleResolveConflicts": "Resolve conflicts before committing",
+            "submoduleCommitStaged": "Commit staged submodule changes",
+            "submoduleEnterMessage": "Enter a commit message to commit",
+            "submoduleStageAll": "Stage All",
+            "submoduleStageAllTitle": "Stage all submodule changes",
+            "submoduleNothingToCommit": "Stage at least one submodule file to commit",
+            "submoduleCommitMessage": "Message",
+            "submoduleCommitMessageLabel": "Submodule commit message"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "No se pudo iniciar el agente seleccionado.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "Borrar pantalla",
             "8c17d6786d": "Cerrar panel",
-            "copyTerminalId": "Copiar ID de terminal",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "Copiar ID del panel",
             "39809d152f": "Establecer título…",
             "06c2b0f043": "Igualar tamaños de paneles",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "Copiar",
             "c2f0b72b8d": "Insertar",
             "925f49f210": "Expandir panel",
-            "df766809e0": "Contraer panel",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "Contraer panel"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Reiniciar demonio",
@@ -8321,7 +8320,8 @@
             "42e10cbf57": "Copiar rutas relativas",
             "b5d436aa30": "Copiar ruta",
             "f9d7ca753d": "Copiar rutas",
-            "3161c4e425": "carpeta"
+            "3161c4e425": "carpeta",
+            "submodule": "Submodule"
           },
           "FileExplorerToolbar": {
             "d238264654": "Mostrar archivos ignorados de Git",
@@ -8469,8 +8469,8 @@
             "a1f2c8d901": "Ver"
           },
           "SourceControl": {
-            "conflictsSection": "Conflictos",
             "1406954883": "Borrar todas las notas...",
+            "conflictsSection": "Conflictos",
             "cc05b2d088": "Abrir en el Explorador de archivos",
             "03194cfff4": "Estado de la sesión local derivado de un conflicto que abrió aquí.",
             "413a3ba113": "conflicto",
@@ -8600,6 +8600,7 @@
             "a0cc0e6b4e": "cargando",
             "9339382454": "Dejar de escena todo",
             "24d2598eff": "poner en escena todo",
+            "submoduleRepoLabel": "{{value0}} Git",
             "ce41708855": "Descartar todo",
             "2f609a2e7c": "Eliminar todo sin seguimiento",
             "9bb062a886": "no comprometido",
@@ -9106,7 +9107,16 @@
             "daysAgo": "{{value0}}d ago",
             "monthsAgo": "{{value0}}mo ago",
             "yearsAgo": "{{value0}}y ago",
-            "sessionId": "ID de sesión"
+            "sessionId": "ID de sesión",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "Resume {{value0}} session",
@@ -9123,7 +9133,14 @@
             "hideDetails": "Ocultar detalles",
             "showDetails": "Mostrar detalles",
             "moreSessionActions": "Más acciones de sesión",
-            "moreActions": "Más acciones"
+            "moreActions": "Más acciones",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "Buscar archivos",
@@ -9167,9 +9184,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "Ver"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8669,7 +8669,17 @@
             "b715ef615b": "{{value1}}より{{value0}}commits 進んでいます",
             "c1a8f3e204": "{{value0}}より1commit 遅れています",
             "d2b9g4f315": "{{value1}}より{{value0}}commits 遅れています",
-            "e9c2a5d416": "{{value0}}と同じ状態"
+            "e9c2a5d416": "{{value0}}と同じ状態",
+            "submoduleCommit": "Commit",
+            "submoduleCommitInProgress": "Commit in progress...",
+            "submoduleResolveConflicts": "Resolve conflicts before committing",
+            "submoduleCommitStaged": "Commit staged submodule changes",
+            "submoduleEnterMessage": "Enter a commit message to commit",
+            "submoduleStageAll": "Stage All",
+            "submoduleStageAllTitle": "Stage all submodule changes",
+            "submoduleNothingToCommit": "Stage at least one submodule file to commit",
+            "submoduleCommitMessage": "Message",
+            "submoduleCommitMessageLabel": "Submodule commit message"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "選択した agent を開始できませんでした。",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "クリアスクリーン",
             "8c17d6786d": "ペインを閉じる",
-            "copyTerminalId": "Terminal ID をコピー",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "ペインIDのコピー",
             "39809d152f": "タイトルを設定…",
             "06c2b0f043": "ペインのサイズを均等化する",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "コピー",
             "c2f0b72b8d": "入れる",
             "925f49f210": "ペインを展開する",
-            "df766809e0": "ペインを折りたたむ",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "ペインを折りたたむ"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "デーモンを再起動します",
@@ -8321,7 +8320,8 @@
             "42e10cbf57": "相対パスのコピー",
             "b5d436aa30": "パスのコピー",
             "f9d7ca753d": "パスのコピー",
-            "3161c4e425": "フォルダ"
+            "3161c4e425": "フォルダ",
+            "submodule": "Submodule"
           },
           "FileExplorerToolbar": {
             "d238264654": "Git で無視されたファイルを表示",
@@ -8469,8 +8469,8 @@
             "a1f2c8d901": "表示"
           },
           "SourceControl": {
-            "conflictsSection": "競合",
             "1406954883": "すべてのメモをクリアします...",
+            "conflictsSection": "競合",
             "cc05b2d088": "ファイルエクスプローラーで開く",
             "03194cfff4": "ここで開いた競合から派生したローカル セッション状態。",
             "413a3ba113": "競合",
@@ -8600,6 +8600,7 @@
             "a0cc0e6b4e": "読み込み中",
             "9339382454": "すべてのステージを解除する",
             "24d2598eff": "すべてのステージ",
+            "submoduleRepoLabel": "{{value0}} Git",
             "ce41708855": "すべて破棄",
             "2f609a2e7c": "追跡されていないものをすべて削除",
             "9bb062a886": "commit されていない",
@@ -9106,7 +9107,16 @@
             "daysAgo": "{{value0}}d ago",
             "monthsAgo": "{{value0}}mo ago",
             "yearsAgo": "{{value0}}y ago",
-            "sessionId": "セッション ID"
+            "sessionId": "セッション ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "Resume {{value0}} session",
@@ -9123,7 +9133,14 @@
             "hideDetails": "詳細を非表示",
             "showDetails": "詳細を表示",
             "moreSessionActions": "セッションのその他の操作",
-            "moreActions": "その他の操作"
+            "moreActions": "その他の操作",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "ファイルを検索",
@@ -9167,9 +9184,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "表示"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8669,7 +8669,17 @@
             "b715ef615b": "{{value1}}보다 {{value0}} commits 앞서 있음",
             "c1a8f3e204": "{{value0}}보다 1 commit 뒤처짐",
             "d2b9g4f315": "{{value1}}보다 {{value0}} commits 뒤처짐",
-            "e9c2a5d416": "{{value0}}와 동일한 상태"
+            "e9c2a5d416": "{{value0}}와 동일한 상태",
+            "submoduleCommit": "Commit",
+            "submoduleCommitInProgress": "Commit in progress...",
+            "submoduleResolveConflicts": "Resolve conflicts before committing",
+            "submoduleCommitStaged": "Commit staged submodule changes",
+            "submoduleEnterMessage": "Enter a commit message to commit",
+            "submoduleStageAll": "Stage All",
+            "submoduleStageAllTitle": "Stage all submodule changes",
+            "submoduleNothingToCommit": "Stage at least one submodule file to commit",
+            "submoduleCommitMessage": "Message",
+            "submoduleCommitMessageLabel": "Submodule commit message"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "선택한 agent를 시작할 수 없습니다.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "화면 지우기",
             "8c17d6786d": "창 닫기",
-            "copyTerminalId": "터미널 ID 복사",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "창 ID 복사",
             "39809d152f": "제목 설정…",
             "06c2b0f043": "창 크기 균등화",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "복사",
             "c2f0b72b8d": "삽입",
             "925f49f210": "창 확장",
-            "df766809e0": "창 축소",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "창 축소"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "데몬 재시작",
@@ -8321,7 +8320,8 @@
             "42e10cbf57": "상대 경로 복사",
             "b5d436aa30": "경로 복사",
             "f9d7ca753d": "경로 복사",
-            "3161c4e425": "폴더"
+            "3161c4e425": "폴더",
+            "submodule": "Submodule"
           },
           "FileExplorerToolbar": {
             "d238264654": "Git이 무시한 파일 표시",
@@ -8469,8 +8469,8 @@
             "a1f2c8d901": "보기"
           },
           "SourceControl": {
-            "conflictsSection": "충돌",
             "1406954883": "모든 메모 지우기...",
+            "conflictsSection": "충돌",
             "cc05b2d088": "파일 탐색기에서 열기",
             "03194cfff4": "여기에서 연 충돌에서 파생된 로컬 세션 상태입니다.",
             "413a3ba113": "충돌",
@@ -8600,6 +8600,7 @@
             "a0cc0e6b4e": "로드 중",
             "9339382454": "모두 언스테이징",
             "24d2598eff": "모두 스테이지",
+            "submoduleRepoLabel": "{{value0}} Git",
             "ce41708855": "모두 폐기",
             "2f609a2e7c": "추적되지 않은 모든 항목 삭제",
             "9bb062a886": "commit 되지 않음",
@@ -9106,7 +9107,16 @@
             "daysAgo": "{{value0}}일 전",
             "monthsAgo": "{{value0}}개월 전",
             "yearsAgo": "{{value0}}년 전",
-            "sessionId": "세션 ID"
+            "sessionId": "세션 ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "{{value0}} 세션 재개",
@@ -9123,7 +9133,14 @@
             "hideDetails": "세부정보 숨기기",
             "showDetails": "세부정보 표시",
             "moreSessionActions": "세션 추가 작업",
-            "moreActions": "추가 작업"
+            "moreActions": "추가 작업",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "파일 찾기",
@@ -9167,9 +9184,6 @@
                 "copyCommand": "명령 복사"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "보기"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8669,7 +8669,17 @@
             "b715ef615b": "领先 {{value1}} {{value0}} 个提交",
             "c1a8f3e204": "落后 {{value0}} 1 个提交",
             "d2b9g4f315": "落后 {{value1}} {{value0}} 个提交",
-            "e9c2a5d416": "与 {{value0}} 同步"
+            "e9c2a5d416": "与 {{value0}} 同步",
+            "submoduleCommit": "Commit",
+            "submoduleCommitInProgress": "Commit in progress...",
+            "submoduleResolveConflicts": "Resolve conflicts before committing",
+            "submoduleCommitStaged": "Commit staged submodule changes",
+            "submoduleEnterMessage": "Enter a commit message to commit",
+            "submoduleStageAll": "Stage All",
+            "submoduleStageAllTitle": "Stage all submodule changes",
+            "submoduleNothingToCommit": "Stage at least one submodule file to commit",
+            "submoduleCommitMessage": "Message",
+            "submoduleCommitMessageLabel": "Submodule commit message"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "无法启动选定的 Agent。",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "清晰的屏幕",
             "8c17d6786d": "关闭窗格",
-            "copyTerminalId": "复制终端 ID",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "复制窗格 ID",
             "39809d152f": "设置标题...",
             "06c2b0f043": "均衡窗格大小",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "复制",
             "c2f0b72b8d": "插入",
             "925f49f210": "展开窗格",
-            "df766809e0": "折叠窗格",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "折叠窗格"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "重新启动守护进程",
@@ -8321,7 +8320,8 @@
             "42e10cbf57": "复制相对路径",
             "b5d436aa30": "复制路径",
             "f9d7ca753d": "复制路径",
-            "3161c4e425": "文件夹"
+            "3161c4e425": "文件夹",
+            "submodule": "Submodule"
           },
           "FileExplorerToolbar": {
             "d238264654": "显示 Git 忽略的文件",
@@ -8469,8 +8469,8 @@
             "a1f2c8d901": "查看"
           },
           "SourceControl": {
-            "conflictsSection": "冲突",
             "1406954883": "清除所有笔记...",
+            "conflictsSection": "冲突",
             "cc05b2d088": "在文件资源管理器中打开",
             "03194cfff4": "本地会话状态源自您在此处打开的冲突。",
             "413a3ba113": "冲突",
@@ -8600,6 +8600,7 @@
             "a0cc0e6b4e": "加载中",
             "9339382454": "全部取消暂存",
             "24d2598eff": "暂存全部",
+            "submoduleRepoLabel": "{{value0}} Git",
             "ce41708855": "全部丢弃",
             "2f609a2e7c": "删除所有未跟踪的",
             "9bb062a886": "未提交",
@@ -9106,7 +9107,16 @@
             "daysAgo": "{{value0}} 天前",
             "monthsAgo": "{{value0}} 个月前",
             "yearsAgo": "{{value0}} 年前",
-            "sessionId": "会话 ID"
+            "sessionId": "会话 ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "恢复 {{value0}} 会话",
@@ -9123,7 +9133,14 @@
             "hideDetails": "隐藏详情",
             "showDetails": "显示详情",
             "moreSessionActions": "更多会话操作",
-            "moreActions": "更多操作"
+            "moreActions": "更多操作",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "查找文件",
@@ -9167,9 +9184,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "查看"
           }
         }
       },

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -25,6 +25,7 @@ import type {
   GitPushTarget,
   GitStatusEntry,
   GitStatusResult,
+  GitSubmoduleEntry,
   PersistedOpenFile,
   Tab,
   TabGroup,
@@ -557,6 +558,7 @@ export type EditorSlice = {
 
   // Git status cache
   gitStatusByWorktree: Record<string, GitStatusEntry[]>
+  gitSubmodulesByWorktree: Record<string, GitSubmoduleEntry[]>
   gitStatusHeadByWorktree: Record<string, string>
   // Why: when status was truncated at the entry limit (a repo with an enormous
   // un-ignored folder), the SCM view shows a "too many changes" state and
@@ -3253,6 +3255,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
   // Git status
   gitStatusByWorktree: {},
+  gitSubmodulesByWorktree: {},
   gitStatusHeadByWorktree: {},
   gitStatusHugeByWorktree: {},
   gitIgnoredPathsByWorktree: {},
@@ -3355,6 +3358,20 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const prevHuge = s.gitStatusHugeByWorktree[worktreeId]
       const nextHuge = status.didHitLimit ? { limit: nextEntries.length } : undefined
       const hugeUnchanged = (prevHuge?.limit ?? null) === (nextHuge?.limit ?? null)
+      const prevSubmodules = s.gitSubmodulesByWorktree[worktreeId]
+      const nextSubmodules = status.submodules ?? []
+      const submodulesUnchanged =
+        prevSubmodules !== undefined &&
+        prevSubmodules.length === nextSubmodules.length &&
+        prevSubmodules.every((entry, index) => {
+          const next = nextSubmodules[index]
+          return (
+            next !== undefined &&
+            entry.path === next.path &&
+            entry.name === next.name &&
+            entry.url === next.url
+          )
+        })
       const prevStatusHead = s.gitStatusHeadByWorktree[worktreeId]
       const nextStatusHead = getKnownGitHead(status.head)
       const statusHeadUnchanged = prevStatusHead === nextStatusHead
@@ -3375,6 +3392,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         operationUnchanged &&
         ignoredUnchanged &&
         hugeUnchanged &&
+        submodulesUnchanged &&
         statusHeadUnchanged &&
         !shouldInvalidateBranchCompare
       ) {
@@ -3417,6 +3435,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         gitStatusByWorktree: statusUnchanged
           ? s.gitStatusByWorktree
           : { ...s.gitStatusByWorktree, [worktreeId]: nextEntries },
+        gitSubmodulesByWorktree: submodulesUnchanged
+          ? s.gitSubmodulesByWorktree
+          : { ...s.gitSubmodulesByWorktree, [worktreeId]: nextSubmodules },
         gitIgnoredPathsByWorktree: ignoredUnchanged
           ? s.gitIgnoredPathsByWorktree
           : { ...s.gitIgnoredPathsByWorktree, [worktreeId]: nextIgnored },

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -980,6 +980,7 @@ const WORKTREE_ID_KEYED_MAP_KEYS = [
   'layoutByWorktree',
   'activeGroupIdByWorktree',
   'gitStatusByWorktree',
+  'gitSubmodulesByWorktree',
   'gitStatusHeadByWorktree',
   'gitIgnoredPathsByWorktree',
   'gitConflictOperationByWorktree',
@@ -1327,6 +1328,7 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     activeGroupIdByWorktree: omitByWorktree(s.activeGroupIdByWorktree),
     // Git status caches
     gitStatusByWorktree: omitByWorktree(s.gitStatusByWorktree),
+    gitSubmodulesByWorktree: omitByWorktree(s.gitSubmodulesByWorktree),
     // Why: keyed by worktreeId; re-keyed on rename but missed by both removal
     // paths, leaking an upstream-status entry per removed worktree.
     remoteStatusesByWorktree: omitByWorktree(s.remoteStatusesByWorktree),
@@ -2103,6 +2105,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         // request keys indefinitely in a long-lived renderer session.
         const nextGitStatusByWorktree = { ...s.gitStatusByWorktree }
         delete nextGitStatusByWorktree[worktreeId]
+        const nextGitSubmodulesByWorktree = { ...s.gitSubmodulesByWorktree }
+        delete nextGitSubmodulesByWorktree[worktreeId]
         const nextGitStatusHeadByWorktree = { ...s.gitStatusHeadByWorktree }
         delete nextGitStatusHeadByWorktree[worktreeId]
         const nextGitIgnoredPathsByWorktree = { ...s.gitIgnoredPathsByWorktree }
@@ -2254,6 +2258,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           expandedDirs: nextExpandedDirs,
           gitStatusHugeByWorktree: nextGitStatusHugeByWorktree,
           gitStatusByWorktree: nextGitStatusByWorktree,
+          gitSubmodulesByWorktree: nextGitSubmodulesByWorktree,
           gitStatusHeadByWorktree: nextGitStatusHeadByWorktree,
           gitIgnoredPathsByWorktree: nextGitIgnoredPathsByWorktree,
           gitConflictOperationByWorktree: nextGitConflictOperationByWorktree,

--- a/src/shared/git-status-types.ts
+++ b/src/shared/git-status-types.ts
@@ -18,6 +18,12 @@ export type GitSubmoduleStatus = {
   untrackedChanges: boolean
 }
 
+export type GitSubmoduleEntry = {
+  name: string
+  path: string
+  url?: string
+}
+
 // Compatibility note for non-upgraded consumers:
 // Any consumer that has not been upgraded to read `conflictStatus` may still
 // render `modified` styling via the `status` field (which is a compatibility
@@ -49,6 +55,7 @@ export type GitStatusEntry = GitUncommittedEntry
 
 export type GitStatusResult = {
   entries: GitStatusEntry[]
+  submodules?: GitSubmoduleEntry[]
   conflictOperation: GitConflictOperation
   head?: string
   branch?: string

--- a/src/shared/gitmodules-parser.test.ts
+++ b/src/shared/gitmodules-parser.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { parseGitmodules } from './gitmodules-parser'
+
+describe('parseGitmodules', () => {
+  it('parses submodule names, paths, and urls', () => {
+    expect(
+      parseGitmodules(
+        [
+          '[submodule "vendor/clean"]',
+          '  path = vendor/clean',
+          '  url = https://example.com/clean.git',
+          '',
+          ' [submodule "libs/missing"]',
+          ' path=libs/missing',
+          '; unrelated comment',
+          ' branch = main'
+        ].join('\n')
+      )
+    ).toEqual([
+      {
+        name: 'vendor/clean',
+        path: 'vendor/clean',
+        url: 'https://example.com/clean.git'
+      },
+      {
+        name: 'libs/missing',
+        path: 'libs/missing'
+      }
+    ])
+  })
+
+  it('skips submodule sections without paths', () => {
+    expect(
+      parseGitmodules(
+        ['[submodule "vendor/no-path"]', 'url = https://example.com/no-path.git'].join('\n')
+      )
+    ).toEqual([])
+  })
+})

--- a/src/shared/gitmodules-parser.ts
+++ b/src/shared/gitmodules-parser.ts
@@ -1,0 +1,45 @@
+import type { GitSubmoduleEntry } from './git-status-types'
+
+export function parseGitmodules(raw: string): GitSubmoduleEntry[] {
+  const entriesByName = new Map<string, Partial<GitSubmoduleEntry> & { name: string }>()
+  let currentName: string | null = null
+
+  for (const line of raw.split(/\r?\n/)) {
+    const sectionMatch = line.match(/^\s*\[submodule\s+"(.+)"\]\s*(?:[#;].*)?$/)
+    if (sectionMatch) {
+      currentName = sectionMatch[1]
+      if (!entriesByName.has(currentName)) {
+        entriesByName.set(currentName, { name: currentName })
+      }
+      continue
+    }
+
+    if (!currentName) {
+      continue
+    }
+
+    const propertyMatch = line.match(/^\s*([A-Za-z][A-Za-z0-9.-]*)\s*=\s*(.*?)\s*$/)
+    if (!propertyMatch) {
+      continue
+    }
+
+    const entry = entriesByName.get(currentName)
+    if (!entry) {
+      continue
+    }
+
+    const key = propertyMatch[1]
+    const value = propertyMatch[2]
+    if (key === 'path') {
+      entry.path = value
+    } else if (key === 'url') {
+      entry.url = value
+    }
+  }
+
+  return Array.from(entriesByName.values()).flatMap((entry) =>
+    entry.path
+      ? [{ name: entry.name, path: entry.path, ...(entry.url ? { url: entry.url } : {}) }]
+      : []
+  )
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -54,6 +54,7 @@ export type {
   GitStagingArea,
   GitStatusEntry,
   GitStatusResult,
+  GitSubmoduleEntry,
   GitSubmoduleStatus,
   GitUncommittedEntry,
   GitUpstreamStatus

--- a/tests/e2e/source-control-submodules.spec.ts
+++ b/tests/e2e/source-control-submodules.spec.ts
@@ -114,6 +114,9 @@ test.describe('Source Control submodules', () => {
     const clean = await createCommittedSubmodule(worktreePath, `000-e2e-clean-submodule-${stamp}`)
     const dirty = await createCommittedSubmodule(worktreePath, `000-e2e-dirty-submodule-${stamp}`)
     libraryPaths.push(clean.libraryPath, dirty.libraryPath)
+    const dirtySubmoduleWorktreePath = path.join(worktreePath, dirty.submodulePath)
+    await git(dirtySubmoduleWorktreePath, ['config', 'user.email', 'e2e@test.local'])
+    await git(dirtySubmoduleWorktreePath, ['config', 'user.name', 'E2E Test'])
     await writeFile(path.join(worktreePath, dirty.submodulePath, 'README.md'), 'dirty library\n')
     await writeFile(path.join(worktreePath, dirty.submodulePath, 'NOTES.md'), 'nested notes\n')
 
@@ -157,18 +160,46 @@ test.describe('Source Control submodules', () => {
     const nestedNotesRow = orcaPage.locator('[data-source-control-path="NOTES.md"]')
     await expect(nestedReadmeRow).toBeVisible()
     await expect(nestedNotesRow).toBeVisible()
-    await nestedReadmeRow.hover()
-    await nestedReadmeRow.getByLabel('Stage').click()
+    const submoduleActions = orcaPage.locator(
+      `[data-source-control-submodule-actions="${dirty.submodulePath}"]`
+    )
+    await expect(submoduleActions).toBeVisible()
+    await expect(submoduleActions.getByRole('button', { name: 'Stage All' })).toBeVisible()
+    await submoduleActions.getByRole('button', { name: 'Stage All' }).click()
 
-    const dirtySubmoduleWorktreePath = path.join(worktreePath, dirty.submodulePath)
     await expect
       .poll(async () => {
         return orcaPage.evaluate(async (submodulePath) => {
           const status = await window.api.git.status({ worktreePath: submodulePath })
-          return status.entries.find((entry) => entry.path === 'README.md')?.area ?? null
+          return status.entries
+            .map((entry) => [entry.path, entry.area])
+            .sort(([a], [b]) => a.localeCompare(b))
         }, dirtySubmoduleWorktreePath)
       })
-      .toBe('staged')
+      .toEqual([
+        ['NOTES.md', 'staged'],
+        ['README.md', 'staged']
+      ])
+
+    await expect(submoduleActions.getByRole('button', { name: 'Commit' })).toBeDisabled()
+    await submoduleActions.getByLabel('Submodule commit message').fill('commit nested changes')
+    await expect(submoduleActions.getByRole('button', { name: 'Commit' })).toBeEnabled()
+    await submoduleActions.getByRole('button', { name: 'Commit' }).click()
+
+    await expect
+      .poll(async () => {
+        return orcaPage.evaluate(async (submodulePath) => {
+          const status = await window.api.git.status({ worktreePath: submodulePath })
+          return status.entries.length
+        }, dirtySubmoduleWorktreePath)
+      })
+      .toBe(0)
+    const { stdout: latestSubmoduleCommit } = await execFileAsync(
+      'git',
+      ['log', '-1', '--pretty=%s'],
+      { cwd: dirtySubmoduleWorktreePath }
+    )
+    expect(latestSubmoduleCommit.trim()).toBe('commit nested changes')
 
     await openFileExplorer(orcaPage)
     const cleanExplorerRow = orcaPage.getByRole('button', {

--- a/tests/e2e/source-control-submodules.spec.ts
+++ b/tests/e2e/source-control-submodules.spec.ts
@@ -1,0 +1,183 @@
+import { execFile } from 'child_process'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { promisify } from 'util'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import type { Page } from '@playwright/test'
+
+const execFileAsync = promisify(execFile)
+
+async function git(cwd: string, args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd })
+}
+
+async function openSourceControl(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const state = window.__store?.getState()
+    state?.setRightSidebarOpen(true)
+    state?.setRightSidebarTab('source-control')
+  })
+  await expect(page.getByRole('button', { name: /Source Control/ })).toBeVisible()
+}
+
+async function openFileExplorer(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const state = window.__store?.getState()
+    state?.setRightSidebarOpen(true)
+    state?.setRightSidebarTab('explorer')
+    state?.showRightSidebarFiles()
+  })
+  await expect(page.getByRole('button', { name: /^Explorer/ }).first()).toBeVisible()
+}
+
+async function getActiveWorktreePath(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    if (!state?.activeWorktreeId) {
+      throw new Error('active worktree is not set')
+    }
+    const worktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((entry) => entry.id === state.activeWorktreeId)
+    if (!worktree) {
+      throw new Error('active worktree not found')
+    }
+    return worktree.path
+  })
+}
+
+async function refreshSourceControlStatus(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const state = store.getState()
+    const worktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((entry) => entry.id === state.activeWorktreeId)
+    if (!worktree) {
+      throw new Error('active worktree not found')
+    }
+    const status = await window.api.git.status({ worktreePath: worktree.path })
+    state.setGitStatus(worktree.id, status)
+  })
+}
+
+async function createCommittedSubmodule(
+  worktreePath: string,
+  submodulePath: string
+): Promise<{ libraryPath: string; submodulePath: string }> {
+  const libraryPath = await mkdtemp(path.join(tmpdir(), 'orca-e2e-submodule-lib-'))
+  await git(libraryPath, ['init', '-q'])
+  await git(libraryPath, ['config', 'user.email', 'e2e@test.local'])
+  await git(libraryPath, ['config', 'user.name', 'E2E Test'])
+  await writeFile(path.join(libraryPath, 'README.md'), 'submodule library\n')
+  await git(libraryPath, ['add', 'README.md'])
+  await git(libraryPath, ['commit', '-qm', 'init submodule library'])
+
+  await git(worktreePath, [
+    '-c',
+    'protocol.file.allow=always',
+    'submodule',
+    'add',
+    '-q',
+    libraryPath,
+    submodulePath
+  ])
+  await git(worktreePath, ['commit', '-qm', 'add e2e submodule'])
+  return { libraryPath, submodulePath }
+}
+
+test.describe('Source Control submodules', () => {
+  let libraryPaths: string[] = []
+
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test.afterEach(async () => {
+    for (const libraryPath of libraryPaths) {
+      await rm(libraryPath, { recursive: true, force: true })
+    }
+    libraryPaths = []
+  })
+
+  test('models submodules from .gitmodules while source control shows dirty parent rows plus nested SCM sections in Electron', async ({
+    orcaPage
+  }) => {
+    const worktreePath = await getActiveWorktreePath(orcaPage)
+    const stamp = Date.now()
+    const clean = await createCommittedSubmodule(worktreePath, `000-e2e-clean-submodule-${stamp}`)
+    const dirty = await createCommittedSubmodule(worktreePath, `000-e2e-dirty-submodule-${stamp}`)
+    libraryPaths.push(clean.libraryPath, dirty.libraryPath)
+    await writeFile(path.join(worktreePath, dirty.submodulePath, 'README.md'), 'dirty library\n')
+    await writeFile(path.join(worktreePath, dirty.submodulePath, 'NOTES.md'), 'nested notes\n')
+
+    const statusSnapshot = await orcaPage.evaluate(async (worktreePath) => {
+      const status = await window.api.git.status({ worktreePath })
+      return {
+        entries: status.entries,
+        submodules: status.submodules ?? []
+      }
+    }, worktreePath)
+    expect(statusSnapshot.submodules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: clean.submodulePath, path: clean.submodulePath }),
+        expect.objectContaining({ name: dirty.submodulePath, path: dirty.submodulePath })
+      ])
+    )
+    expect(statusSnapshot.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: dirty.submodulePath,
+          submodule: expect.objectContaining({ trackedChanges: true })
+        })
+      ])
+    )
+    expect(statusSnapshot.entries).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: clean.submodulePath })])
+    )
+
+    await refreshSourceControlStatus(orcaPage)
+    await openSourceControl(orcaPage)
+
+    await expect(orcaPage.getByText('Submodules')).toHaveCount(0)
+    await expect(
+      orcaPage.locator(`[data-source-control-path="${dirty.submodulePath}"]`)
+    ).toBeVisible()
+    await expect(
+      orcaPage.locator(`[data-source-control-path="${clean.submodulePath}"]`)
+    ).toHaveCount(0)
+    await expect(orcaPage.getByText(`${path.basename(dirty.submodulePath)} Git`)).toBeVisible()
+    const nestedReadmeRow = orcaPage.locator('[data-source-control-path="README.md"]')
+    const nestedNotesRow = orcaPage.locator('[data-source-control-path="NOTES.md"]')
+    await expect(nestedReadmeRow).toBeVisible()
+    await expect(nestedNotesRow).toBeVisible()
+    await nestedReadmeRow.hover()
+    await nestedReadmeRow.getByLabel('Stage').click()
+
+    const dirtySubmoduleWorktreePath = path.join(worktreePath, dirty.submodulePath)
+    await expect
+      .poll(async () => {
+        return orcaPage.evaluate(async (submodulePath) => {
+          const status = await window.api.git.status({ worktreePath: submodulePath })
+          return status.entries.find((entry) => entry.path === 'README.md')?.area ?? null
+        }, dirtySubmoduleWorktreePath)
+      })
+      .toBe('staged')
+
+    await openFileExplorer(orcaPage)
+    const cleanExplorerRow = orcaPage.getByRole('button', {
+      name: new RegExp(path.basename(clean.submodulePath))
+    })
+    const dirtyExplorerRow = orcaPage.getByRole('button', {
+      name: new RegExp(path.basename(dirty.submodulePath))
+    })
+    await expect(cleanExplorerRow.getByLabel('Submodule')).toBeVisible()
+    await expect(dirtyExplorerRow.getByLabel('Submodule')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- Parse submodule metadata from `.gitmodules` as `{ name, path, url }` and include it in git status results for local and relay/SSH worktrees.
- Match the VS Code-style Source Control model more closely: parent repos show dirty submodule gitlink/worktree rows, clean submodules stay out of Source Control, and dirty initialized submodules render their own nested `Git` section.
- Add a separate submodule SCM action surface with its own message box and Stage All/Commit primary action; nested stage/unstage/discard/commit operations run against the submodule repo path, not the parent worktree.
- Keep parent dirty-submodule rows non-stageable and label them as submodule changes, while file explorer folders get an `S` submodule badge for clean and dirty submodules.
- Tighten main-process git IPC auth so nested git operations are allowed only for initialized submodule paths listed in the parent `.gitmodules`.
- Add focused unit/integration coverage and an Electron E2E harness with real clean and dirty submodules, including nested Stage All and committing from the submodule SCM section.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-auth.test.ts src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/gitmodules-parser.test.ts src/main/git/status-submodules.integration.test.ts src/main/git/status.test.ts src/relay/git-handler-status-ops.test.ts src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx src/renderer/src/components/right-sidebar/FileExplorerVirtualRowsAddProject.test.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test:e2e -- tests/e2e/source-control-submodules.spec.ts --workers=1`

## Manual Electron Check
- Opened the dummy parent repo in Orca dev, confirmed `000-DIRTY-SUBMODULE GIT` has its own action surface.
- Clicked the nested `Stage All`, confirmed only the submodule README staged inside the submodule.
- Entered a nested commit message and clicked the submodule `Commit`, confirmed the submodule commit landed and the nested section disappeared once clean.
