### PR TITLE
fix: allow selecting a project on a non-active host when creating a workspace

### DIFF
--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -240,6 +240,19 @@ describe('useComposerState host-context boundaries', () => {
     )
   })
 
+  it('selects a project by its own host instead of pinning the current host', () => {
+    // Regression: passing the current host as a hard `hostId` made picking a
+    // project set up only on a different host a silent no-op. The current host
+    // must be a preference (focusedHostScope), with a fallback to any ready host.
+    const handleProjectChange = sourceBetween(
+      HOOK_SOURCE,
+      'const handleProjectChange = useCallback',
+      'const handleSmartGitHubItemSelect'
+    )
+    expect(handleProjectChange).toContain('focusedHostScope: preferredHostId ?? workspaceHostScope')
+    expect(handleProjectChange).not.toContain('hostId: preferredHostId')
+  })
+
   it('clears GitLab-specific linked state when clearing smart-name selection', () => {
     const section = sourceBetween(
       HOOK_SOURCE,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -2261,13 +2261,18 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setSelectedProjectGroupId(null)
       const preferredHostId =
         selectedWorkspaceTarget.status === 'ready' ? selectedWorkspaceTarget.target.hostId : null
+      // Why: prefer the host the user is currently on, but treat it as a
+      // preference (focusedHostScope) rather than a hard hostId match. Pinning
+      // hostId made selecting a project that is only set up on a different host
+      // a silent no-op — the resolver returned '' (project-not-set-up-on-host)
+      // and the early return below swallowed the click. Falling back to any
+      // host the project is ready on lets cross-host selection work.
       const nextRepoId = resolveWorkspaceCreationRepoId({
         eligibleRepos,
         projects,
         projectHostSetups,
         projectId,
-        hostId: preferredHostId,
-        focusedHostScope: workspaceHostScope
+        focusedHostScope: preferredHostId ?? workspaceHostScope
       })
       if (!nextRepoId) {
         return

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -200,4 +200,87 @@ describe('project-host workspace target resolution', () => {
       reason: 'setup-not-ready'
     })
   })
+
+  // Regression: selecting a project in the new-workspace dropdown must not be
+  // pinned to the host of the currently-active workspace. Each project below is
+  // set up on exactly one (different) host; picking the other project while the
+  // current host is given only as a preference must resolve to that project's
+  // own host instead of returning '' (the silent no-op the dropdown showed).
+  describe('cross-host project selection', () => {
+    const repos = [
+      makeRepo('local-repo'),
+      makeRepo('remote-repo', { connectionId: 'remote-1' })
+    ]
+    const projects = [
+      makeProject('repo:local-repo', ['local-repo']),
+      makeProject('repo:remote-repo', ['remote-repo'])
+    ]
+    const projectHostSetups = [
+      makeSetup('local-repo', 'repo:local-repo', 'local', 'local-repo'),
+      makeSetup('remote-repo', 'repo:remote-repo', 'ssh:remote-1', 'remote-repo')
+    ]
+
+    it('resolves a remote-only project while the current host is local', () => {
+      expect(
+        resolveWorkspaceCreationRepoId({
+          eligibleRepos: repos,
+          projects,
+          projectHostSetups,
+          projectId: 'repo:remote-repo',
+          focusedHostScope: 'local'
+        })
+      ).toBe('remote-repo')
+    })
+
+    it('resolves a local-only project while the current host is remote', () => {
+      expect(
+        resolveWorkspaceCreationRepoId({
+          eligibleRepos: repos,
+          projects,
+          projectHostSetups,
+          projectId: 'repo:local-repo',
+          focusedHostScope: 'ssh:remote-1'
+        })
+      ).toBe('local-repo')
+    })
+
+    it('still prefers the current host when the project is set up on it', () => {
+      const multiHostProjects = [makeProject('repo:multi', ['multi-local', 'multi-remote'])]
+      const multiHostSetups = [
+        makeSetup('multi-local', 'repo:multi', 'local', 'multi-local'),
+        makeSetup('multi-remote', 'repo:multi', 'ssh:remote-1', 'multi-remote')
+      ]
+
+      expect(
+        resolveWorkspaceCreationRepoId({
+          eligibleRepos: [
+            makeRepo('multi-local'),
+            makeRepo('multi-remote', { connectionId: 'remote-1' })
+          ],
+          projects: multiHostProjects,
+          projectHostSetups: multiHostSetups,
+          projectId: 'repo:multi',
+          focusedHostScope: 'local'
+        })
+      ).toBe('multi-local')
+    })
+
+    it('still reports unavailable for an explicit project+host with no ready setup', () => {
+      // The strict projectId+hostId path (used by the explicit "Run on" host
+      // picker) keeps its hard match — only the project-dropdown call site
+      // changed to pass the host as a preference.
+      expect(
+        resolveWorkspaceCreationTarget({
+          eligibleRepos: repos,
+          projects,
+          projectHostSetups,
+          projectId: 'repo:remote-repo',
+          hostId: 'local'
+        })
+      ).toEqual({
+        status: 'unavailable',
+        reason: 'project-not-set-up-on-host'
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Selecting a project in the new-workspace ("Create worktree") dialog was a silent no-op whenever that project was set up on a host other than the one your active workspace is on — so the Project dropdown effectively only let you pick projects on your current host.

**Root cause:** `handleProjectChange` (`src/renderer/src/hooks/useComposerState.ts`) resolved the clicked project to a repo by passing the *active* workspace's host to `resolveWorkspaceCreationRepoId` as a hard `hostId` constraint. The `projectId + hostId` branch of `resolveWorkspaceCreationTarget` only matches a setup on that exact host, so a project set up on a different host resolved to `project-not-set-up-on-host` → empty `repoId` → the `if (!nextRepoId) return` guard swallowed the click.

**Fix:** pass the current host as a *preference* (`focusedHostScope`) instead of a hard `hostId`. The resolver still prefers the current host when the project is set up there, and otherwise falls back to any host the project is ready on. The strict `projectId + hostId` path used by the explicit "Run on" host picker is unchanged.

```diff
-        hostId: preferredHostId,
-        focusedHostScope: workspaceHostScope
+        focusedHostScope: preferredHostId ?? workspaceHostScope
```

## Screenshots

Screen recording attached to this PR conversation. In a local workspace, opening **Create worktree** (⌘N) and selecting an SSH-host project (`Checkmate`, on a remote host) from the Project dropdown — previously a no-op, now correctly switches the selection and the target host. Before: dropdown stuck on the local project; after: switches to the remote-host project.

## Testing

- [x] `pnpm lint` — passes for the changed code (oxlint, switch-exhaustiveness, scrollbar checks). `verify:localization-catalog` reports a **pre-existing** `es.json` parity drift for `AiVaultSession*` keys (from #5911), unrelated to this change.
- [x] `pnpm typecheck`
- [x] `pnpm test` — 19,588 passed, 0 failed
- [x] `pnpm build`
- [x] Added regression tests: `project-host-workspace-target.test.ts` (cross-host selection — remote-only project resolves while current host is local and vice versa; multi-host project still prefers the current host; explicit `project+host` with no setup still reports `project-not-set-up-on-host`) and a source guard in `useComposerState-host-context-boundaries.test.ts` that the call site no longer pins `hostId`.

## AI Review Report

Reviewed with Claude Code across the dimensions CONTRIBUTING requires:
- **Cross-platform (macOS/Linux/Windows):** pure TS in a React hook — no `metaKey`/accelerators, no path/shell/filesystem APIs, no platform branches. No cross-platform risk.
- **SSH / remote / local:** this is the path the fix improves — selecting a project on an SSH or runtime host now works from a local-host context. The explicit "Run on" host picker's strict `projectId+hostId` resolution is deliberately untouched. Verified live against a connected SSH host.
- **Agent / integration / git-provider:** none touched; resolution is provider-neutral.
- **Performance:** no new work in hot paths; the change *removes* a constraint argument and keeps a single resolver call. Negligible.
- **UI quality:** no visual/component change — behavior only; the dropdown now commits the selection. Verified in light theme (recording).

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change only alters which already-known in-memory `repoId` is selected from already-trusted store state (repos/projects/host-setups). No new attack surface; nothing to follow up.

## Notes

Remote/SSH-specific behavior is the point of the fix; reproduced against a live SSH host. No migrations, no config changes. X: @ScienceSaad


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5937">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->