### PR TITLE
fix: narrow rate-limit settings resolver

### DIFF
--- a/config/scripts/rate-limit-settings-contract.test.mjs
+++ b/config/scripts/rate-limit-settings-contract.test.mjs
@@ -1,0 +1,92 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const projectDir = join(import.meta.dirname, '..', '..')
+const indexPath = join(projectDir, 'src', 'main', 'index.ts')
+const requiredSnapshotFields = [
+  'opencodeSessionCookie',
+  'opencodeWorkspaceId',
+  'geminiCliOAuthEnabled'
+]
+
+function parseSource(filePath) {
+  return ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  )
+}
+
+function findSetSettingsResolverCall(sourceFile) {
+  let match = null
+
+  function visit(node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'setSettingsResolver' &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === 'rateLimits'
+    ) {
+      match = node
+      return
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return match
+}
+
+function getReturnedObjectLiteral(callback) {
+  if (!ts.isArrowFunction(callback)) {
+    return null
+  }
+
+  if (ts.isObjectLiteralExpression(callback.body)) {
+    return callback.body
+  }
+
+  if (!ts.isBlock(callback.body)) {
+    return null
+  }
+
+  const returnStatement = callback.body.statements.find(ts.isReturnStatement)
+  return returnStatement?.expression && ts.isObjectLiteralExpression(returnStatement.expression)
+    ? returnStatement.expression
+    : null
+}
+
+function getPropertyName(property) {
+  if (!ts.isPropertyAssignment(property) || !ts.isIdentifier(property.name)) {
+    return null
+  }
+
+  return property.name.text
+}
+
+describe('rate-limit settings resolver contract', () => {
+  it('passes a narrow settings snapshot instead of the full persisted settings', () => {
+    const sourceFile = parseSource(indexPath)
+    const call = findSetSettingsResolverCall(sourceFile)
+    expect(call).toBeTruthy()
+
+    const snapshot = getReturnedObjectLiteral(call.arguments[0])
+    expect(snapshot).toBeTruthy()
+
+    const propertyNames = snapshot.properties.map(getPropertyName)
+    expect(propertyNames).toEqual(requiredSnapshotFields)
+
+    for (const [index, field] of requiredSnapshotFields.entries()) {
+      const property = snapshot.properties[index]
+      expect(ts.isPropertyAssignment(property)).toBe(true)
+      expect(ts.isPropertyAccessExpression(property.initializer)).toBe(true)
+      expect(property.initializer.name.text).toBe(field)
+    }
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1328,7 +1328,15 @@ app.whenReady().then(async () => {
   rateLimits.setClaudeAuthPreparationResolver((target) =>
     claudeRuntimeAuth!.prepareForRateLimitFetch(target)
   )
-  rateLimits.setSettingsResolver(() => store!.getSettings())
+  rateLimits.setSettingsResolver(() => {
+    const settings = store!.getSettings()
+    // Why: RateLimitService should only depend on the settings fields it reads.
+    return {
+      opencodeSessionCookie: settings.opencodeSessionCookie,
+      opencodeWorkspaceId: settings.opencodeWorkspaceId,
+      geminiCliOAuthEnabled: settings.geminiCliOAuthEnabled
+    }
+  })
   keybindings = new KeybindingService({
     homePath: app.getPath('home'),
     getLegacyOverrides: () => store!.getSettings().keybindings

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -37,6 +37,12 @@ type ClaudeAuthPreparationResolver = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
 
+export type RateLimitSettingsSnapshot = {
+  opencodeSessionCookie: string
+  opencodeWorkspaceId: string
+  geminiCliOAuthEnabled?: boolean
+}
+
 // Why: Claude's subscription usage endpoint has a tight request budget. Quota
 // state is informational, so prefer keeping a recent snapshot over polling it
 // into 429s during long focused Orca sessions.
@@ -98,13 +104,7 @@ export class RateLimitService {
     runtime: 'host',
     wslDistro: null
   }
-  private settingsResolver:
-    | (() => {
-        opencodeSessionCookie: string
-        opencodeWorkspaceId: string
-        geminiCliOAuthEnabled?: boolean
-      })
-    | null = null
+  private settingsResolver: (() => RateLimitSettingsSnapshot) | null = null
   private inactiveClaudeAccountsResolver: (() => InactiveClaudeAccountInfo[]) | null = null
   private inactiveCodexAccountsResolver: (() => InactiveCodexAccountInfo[]) | null = null
   private inactiveClaudeCache = new Map<string, ProviderRateLimits>()
@@ -142,13 +142,7 @@ export class RateLimitService {
     this.claudeFetchTarget = normalizeClaudeAccountSelectionTarget(target)
   }
 
-  setSettingsResolver(
-    resolver: () => {
-      opencodeSessionCookie: string
-      opencodeWorkspaceId: string
-      geminiCliOAuthEnabled?: boolean
-    }
-  ): void {
+  setSettingsResolver(resolver: () => RateLimitSettingsSnapshot): void {
     this.settingsResolver = resolver
   }
 


### PR DESCRIPTION
## Summary

- Narrow `RateLimitService` settings resolver to a named snapshot type containing only the fields it reads.
- Pass an explicit settings snapshot from the main-process composition root instead of the full persisted settings object.
- Add a regression harness that catches reintroducing direct `store.getSettings()` wiring.

Fixes #5929

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts config/scripts/rate-limit-settings-contract.test.mjs src/main/rate-limits/service.test.ts`
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec oxlint config/scripts/rate-limit-settings-contract.test.mjs src/main/rate-limits/service.ts src/main/index.ts`
- [x] `pnpm exec oxfmt --check config/scripts/rate-limit-settings-contract.test.mjs src/main/rate-limits/service.ts src/main/index.ts`

Note: `typecheck:node` passed with the existing local Node engine warning because this shell is on Node 26 while the repo asks for Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5938">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->