### PR TITLE
Improve built-in browser downloads

### DIFF
--- a/docs/browser-normal-download-behavior.md
+++ b/docs/browser-normal-download-behavior.md
@@ -81,7 +81,7 @@ Make built-in browser downloads feel like a normal browser:
 
 6. **Use existing shell bridges for actions**
 
-   Use `window.api.shell.openFilePath(savePath)` for `Open` and `window.api.shell.openInFileManager(savePath)` for `Show`. `openPath` is a legacy reveal wrapper with a void renderer contract, so it cannot report action failure honestly. If either action fails or the file has been moved/deleted, show an inline or toast failure that does not claim the file opened.
+   Use `window.api.shell.openFilePath(savePath)` for `Open` and `window.api.shell.openInFileManager(savePath)` for `Show`. `openPath` is a legacy reveal wrapper whose `void` return type prevents the preload bridge from reporting success or failure back to the renderer. If either action fails or the file has been moved/deleted, show an inline or toast failure that does not claim the file opened.
 
 ## Data Flow
 
@@ -149,8 +149,8 @@ Stage 5 must capture:
 1. Add the destination builder and focused tests.
 2. Move BrowserManager download handling to immediate save-path assignment and progress tracking.
 3. Update browser IPC/preload/API types to remove approval semantics and carry save-path/status data.
-4. Update BrowserPane state and UI for active/recent downloads.
-5. Update renderer notices/tests and localization catalog as required.
+4. Refresh BrowserPane state and UI for active/recent downloads.
+5. Add renderer notices, tests, and localization catalog entries as required.
 6. Run targeted unit tests, typecheck, lint, then Electron validation with screenshots.
 
 ## Lightweight Eng Review

--- a/docs/browser-normal-download-behavior.md
+++ b/docs/browser-normal-download-behavior.md
@@ -1,0 +1,183 @@
+# Browser Normal Download Behavior
+
+## Problem
+
+The built-in browser does not behave like a normal desktop browser when a page downloads a file.
+
+- `src/main/browser/browser-session-registry.ts:553` installs a `will-download` handler for browser sessions.
+- `src/main/browser/browser-manager.ts:952` pauses every download before Orca has a save path.
+- `src/renderer/src/components/browser-pane/BrowserPane.tsx:4915` shows a `Save` / `Cancel` prompt instead of starting the download.
+- `src/main/ipc/browser.ts:342` opens a native save dialog after the renderer clicks `Save`.
+- `src/main/browser/browser-manager.ts:1026` calls `DownloadItem.setSavePath()` only after that renderer + dialog round trip.
+- Electron's installed type contract says `setSavePath()` is only available during the session `will-download` callback (`node_modules/electron/electron.d.ts:8271`).
+
+That late path assignment explains the "clicked Save, still did not save" failure mode and makes the flow higher-friction than Chrome/Safari/Edge defaults.
+
+## Root Cause
+
+Orca treats downloads as renderer-approved actions. Electron treats the destination as a main-process `will-download` decision. The current flow crosses that boundary too late: it pauses the download, asks the renderer to approve it, asks the OS where to save it, and only then sets the save path.
+
+## Goal
+
+Make built-in browser downloads feel like a normal browser:
+
+- Download starts automatically.
+- File saves to the OS Downloads directory by default.
+- Name collisions are resolved without overwriting.
+- Browser chrome shows progress and completion.
+- Completed downloads offer familiar actions such as opening or revealing the file.
+- Cancel remains available while downloading.
+
+## Non-goals
+
+- A full persistent download manager/history.
+- A settings UI for "ask where to save every file."
+- Cross-device transfer of downloads from a remote browser host to a local client.
+- Changing generic filesystem downloads outside the browser.
+
+## Design
+
+1. **Resolve the save path synchronously in main**
+
+   Add a small browser-specific destination module, e.g. `src/main/browser/browser-download-destination.ts`, that:
+
+   - uses `app.getPath('downloads')`;
+   - normalizes the filename to a safe basename;
+   - uses `path.join` for cross-platform paths;
+   - avoids overwrites with browser-style suffixes (`report.csv`, `report (1).csv`);
+   - checks existing files synchronously because Electron requires `setSavePath()` during `will-download`;
+   - also checks a main-process reservation set for active browser downloads, so two same-name downloads that start before either file exists still get distinct paths;
+   - keys reservations by a normalized absolute path, with platform-aware case folding where the target filesystem is conventionally case-insensitive, so `Report.csv` and `report.csv` cannot collide on Windows;
+   - caps suffix attempts and fails the download with a clear error instead of spinning forever in a crowded Downloads directory.
+
+   Do not create a placeholder file just to reserve the path: Electron may treat an existing target as an overwrite. The in-memory reservation prevents Orca-internal concurrent collisions; an external process can still create the same path after the check, so this remains best-effort at the filesystem boundary.
+
+2. **Set the destination during `will-download`**
+
+   In `BrowserManager.handleGuestWillDownload`, compute and reserve the path, then call `DownloadItem.setSavePath()` immediately while still in the `will-download` call stack. Do not pause for renderer approval, do not open `dialog.showSaveDialog`, and do not use `setSaveDialogOptions()` for this flow because that still preserves dialog behavior. If destination resolution or `setSavePath()` fails, release the reservation, cancel the item, and send or queue a failed terminal event with a specific, non-secret error.
+
+3. **Track downloads from start to finish in main**
+
+   Replace the approval-centric state with browser download state:
+
+   - `downloading`: save path is already assigned; item is progressing, waiting on network, or temporarily interrupted.
+   - `completed` / `failed` / `canceled`: terminal states sent to the renderer.
+
+   Register `updated` and `done` listeners immediately in `will-download`, store latest received-byte count plus any terminal result, and keep the existing guest-to-tab queue so downloads that start before registration still surface when the tab binds. Queue state snapshots, not every progress event: if a download finishes before the tab registers, flush a started row followed by its terminal state so the renderer does not drop an orphan progress/finish event. If an unregistered guest is destroyed or retired before the tab binds, cancel its queued active downloads and release their reservations instead of only dropping the pending queue entry. Send exactly one terminal event per download, detach only this feature's listener references during cleanup, and release the reserved path on every terminal path and on explicit cancel.
+
+4. **Update IPC shape for browser-like status**
+
+   Keep the existing renderer event channels if that keeps the diff smaller, but change the payload contract from "approval requested" to "download started" semantics. Include `browserPageId` on start/progress/finish when the tab is known, include `savePath` on start and terminal data, and keep progress payloads to `downloadId`, byte counts, and transient state. Remove the renderer `acceptDownload` path for normal browser downloads and delete the save-dialog IPC test; `cancelDownload` remains useful while an item is active.
+
+5. **Render browser chrome, not an approval prompt**
+
+   In `BrowserPane`, replace the `Save` / `Cancel` prompt with a compact download row/list under the toolbar:
+
+   - active row: filename, origin, progress label, `Cancel`;
+   - completed row: filename, "Downloaded" status, `Open`, `Show`, dismiss;
+   - failed/canceled row: filename, concise failure/cancel reason, dismiss.
+
+   Track more than one download per pane so a second download does not hide the first. Cap visible recent completed rows to a small number, such as three, to avoid growing the browser surface. This is a per-pane transient list, not persisted history.
+
+6. **Use existing shell bridges for actions**
+
+   Use `window.api.shell.openFilePath(savePath)` for `Open` and `window.api.shell.openInFileManager(savePath)` for `Show`. `openPath` is a legacy reveal wrapper with a void renderer contract, so it cannot report action failure honestly. If either action fails or the file has been moved/deleted, show an inline or toast failure that does not claim the file opened.
+
+## Data Flow
+
+```text
+Browser session will-download
+  -> BrowserManager computes and reserves ~/Downloads/name.ext
+  -> DownloadItem.setSavePath(path) during will-download
+  -> BrowserManager tracks item and sends/queues browser download-started
+  -> BrowserPane renders progress row
+  -> DownloadItem updated/done
+  -> BrowserManager sends progress/finished
+  -> BrowserPane shows completed row with Open / Show
+```
+
+## Edge Cases
+
+- Duplicate filenames must not overwrite existing files.
+- Simultaneous same-name downloads in the same Orca process must not choose the same path before either file exists.
+- Same-name reservation checks must respect platform path identity, including case-insensitive collisions on Windows.
+- External filesystem races between path selection and Chromium's file creation are unavoidable with `setSavePath()`; treat them as residual risk, not a guarantee.
+- Path traversal or separator-like filenames must collapse to a safe basename.
+- Empty filenames fall back to `download`.
+- Unknown total bytes should show received bytes or a generic "Downloading" state without broken math.
+- Multiple simultaneous downloads from the same tab must render independently.
+- A download that starts, progresses, or finishes before the webview registers must still appear once the tab binds.
+- A queued download whose guest is destroyed or retired before registration must be canceled and release its reserved path.
+- Since this design intentionally avoids a global persistent download manager, closing the owning browser tab must cancel active downloads rather than leaving hidden file writes with no chrome.
+- `setSavePath()` failure should not leave a hidden, still-running download.
+- `updated` events with `interrupted` state should keep the row honest without treating them as terminal; `done` is the terminal source of truth.
+- Explicit cancel and Electron's eventual `done` callback must not produce duplicate terminal UI events.
+- Completed file actions may fail if the file was moved/deleted after download; UI must report that honestly.
+- On Windows, Linux, and macOS, all paths are built with Node/Electron path APIs.
+- In SSH/remote workflows, the file is saved on the machine running the browser runtime; UI copy must not imply cross-machine transfer.
+- Web clients keep their existing "handled by server browser" behavior unless the server-side browser implements equivalent events.
+
+## Test Plan
+
+- Unit: destination builder sanitizes names, preserves extensions, picks collision-free paths, respects active path reservations including platform path identity, releases reservations, and stops at a bounded suffix limit.
+- Unit: `BrowserManager.handleGuestWillDownload` calls `setSavePath()` during handling, does not pause/resume for approval, registers listeners immediately, sends started/progress/finished events exactly once, and cancels cleanly on destination failure.
+- Unit: queued download-started/progress/finished state flushes after guest registration with the latest state.
+- Unit: multiple download events for one browser page are tracked independently.
+- Unit: guest cleanup cancels queued-but-unbound active downloads and releases reserved paths.
+- Unit: tab unregister cancels every active download for that tab and releases reserved paths.
+- IPC: remove `browser:acceptDownload` and its native save-dialog test for normal downloads; keep `browser:cancelDownload` authorization coverage.
+- Renderer: download list state covers active, completed, failed, canceled, unknown-size, multiple same-tab downloads, bounded recent rows, and missing-file action failures.
+- Shell IPC/preload: `Open` uses `openFilePath`; `Show` uses `openInFileManager` and surfaces structured failure.
+- Electron validation: from a local test page, click a download link and verify a file appears in the OS Downloads folder without a save dialog.
+
+## UI Quality Bar
+
+The changed browser chrome should be quiet and dense, matching the toolbar area around it. Use existing tokens (`background`, `foreground`, `muted-foreground`, `border`, `accent`) and shadcn `Button` variants/sizes. Do not use amber warning color for ordinary downloads. The active state should be readable without looking like an error. Buttons must not wrap, overlap, or resize the toolbar/pane unexpectedly. Copy must describe real state only: "Downloading", "Downloaded", "Canceled", or the specific failure.
+
+## Review Screenshots
+
+Stage 5 must capture:
+
+1. Active download in progress, with no save prompt visible.
+2. Completed download row with file actions visible.
+3. A repeat download of the same filename showing successful completion without overwrite.
+4. Multiple browser downloads visible at once or in the recent-download cap.
+5. Adjacent browser toolbar smoke state after the download row is dismissed.
+
+## Rollout
+
+1. Add the destination builder and focused tests.
+2. Move BrowserManager download handling to immediate save-path assignment and progress tracking.
+3. Update browser IPC/preload/API types to remove approval semantics and carry save-path/status data.
+4. Update BrowserPane state and UI for active/recent downloads.
+5. Update renderer notices/tests and localization catalog as required.
+6. Run targeted unit tests, typecheck, lint, then Electron validation with screenshots.
+
+## Lightweight Eng Review
+
+- Scope: Kept to local built-in browser download behavior. Reduced by excluding a preferences UI, persistent download history, and remote-to-local transfer. The smallest useful normal-browser behavior is automatic save to Downloads plus transient progress/completion chrome.
+- Architecture/data flow: Main owns destination choice and file writes because Electron requires `setSavePath()` during `will-download`. Renderer owns only display and user actions (`Cancel`, `Open`, `Show`, dismiss). Existing session policy installation remains the entry point; existing shell bridges handle file actions. Browser web clients remain unchanged.
+- Failure modes covered:
+  - Late `setSavePath()` is removed by assigning the path synchronously in `will-download`.
+  - Duplicate filenames use existing-file checks plus active path reservations instead of overwriting each other inside Orca.
+  - Unsafe or empty filenames are normalized before `path.join`.
+  - Downloads starting or finishing before tab registration are snapshotted and flushed in order.
+  - Queued downloads are canceled if their guest is destroyed or retired before registration.
+  - Multiple downloads no longer overwrite a single pane state.
+  - Tab close/app shutdown cancels active items rather than leaving hidden downloads without chrome.
+  - File action failures after external deletion are surfaced without overclaiming.
+- Test coverage required:
+  - Unit: `src/main/browser/browser-download-destination.test.ts` for basename/suffix/collision/reservation behavior and bounded failure.
+  - Unit: `src/main/browser/browser-manager.test.ts` for immediate `setSavePath`, listener registration, queued snapshots, progress/finish, cancellation, path-reservation release, and failure.
+  - Unit/IPC: `src/main/ipc/browser.test.ts` removes the native save-dialog accept path and keeps cancel authorization.
+  - Renderer: focused tests around download notice/list state if an existing seam is available; otherwise cover formatting helpers and rely on Electron validation for BrowserPane DOM behavior.
+  - Electron: local server download verifies file creation in Downloads without save dialog.
+- Performance/blast radius: No startup cost. Per-download synchronous filesystem checks are bounded by the collision limit and happen only during `will-download`; this is acceptable for one user action but must not walk unbounded directories. Renderer IPC volume stays proportional to Electron download progress events already emitted. No migration.
+- UI quality bar: Validation should judge a neutral browser-toolbar-adjacent download row/list against `docs/STYLEGUIDE.md`: no amber error styling for ordinary progress, compact button sizes, no overlap/wrapping, honest copy, clear active/completed/failed hierarchy, and stable layout while progress changes.
+- Required review screenshots:
+  1. Active download in progress with no save prompt.
+  2. Completed download row with `Open` / `Show` actions.
+  3. Repeat same-name download completed with distinct filename.
+  4. Multiple downloads visible or capped as designed.
+  5. Browser toolbar after dismissing download chrome.
+- Residual risks: Headless Electron may not reliably prove absence of a native save dialog; validation should instead verify no Orca `Save` prompt appears and the file lands in Downloads. If the OS Downloads path is redirected or unavailable, behavior depends on Electron's `app.getPath('downloads')` result.

--- a/src/main/browser/browser-download-destination.test.ts
+++ b/src/main/browser/browser-download-destination.test.ts
@@ -1,0 +1,100 @@
+import path from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { BrowserDownloadDestinationReservations } from './browser-download-destination'
+
+describe('BrowserDownloadDestinationReservations', () => {
+  const downloadsPath = path.join(path.sep, 'Users', 'orca', 'Downloads')
+
+  it('uses the downloads folder and preserves a safe basename', () => {
+    const reservations = new BrowserDownloadDestinationReservations({
+      downloadsPath,
+      pathExists: vi.fn(() => false),
+      platform: 'linux'
+    })
+
+    expect(reservations.reserve('../nested/report.csv')).toEqual({
+      filename: 'report.csv',
+      savePath: path.join(downloadsPath, 'report.csv'),
+      reservationKey: path.resolve(downloadsPath, 'report.csv')
+    })
+    expect(reservations.reserve('C:\\Users\\orca\\Downloads\\budget.xlsx').filename).toBe(
+      'budget.xlsx'
+    )
+  })
+
+  it('falls back to download for empty or unsafe filenames', () => {
+    const reservations = new BrowserDownloadDestinationReservations({
+      downloadsPath,
+      pathExists: vi.fn(() => false),
+      platform: 'linux'
+    })
+
+    expect(reservations.reserve('   ').filename).toBe('download')
+    expect(reservations.reserve('...').filename).toBe('download (1)')
+    expect(reservations.reserve('bad<name>.txt').filename).toBe('bad_name_.txt')
+  })
+
+  it('adds browser-style suffixes without overwriting existing files', () => {
+    const existingPaths = new Set([
+      path.join(downloadsPath, 'report.csv'),
+      path.join(downloadsPath, 'report (1).csv')
+    ])
+    const reservations = new BrowserDownloadDestinationReservations({
+      downloadsPath,
+      pathExists: vi.fn((filePath: string) => existingPaths.has(filePath)),
+      platform: 'linux'
+    })
+
+    expect(reservations.reserve('report.csv').filename).toBe('report (2).csv')
+  })
+
+  it('reserves simultaneous same-name downloads before files exist', () => {
+    const reservations = new BrowserDownloadDestinationReservations({
+      downloadsPath,
+      pathExists: vi.fn(() => false),
+      platform: 'linux'
+    })
+
+    const first = reservations.reserve('report.csv')
+    const second = reservations.reserve('report.csv')
+
+    expect(first.filename).toBe('report.csv')
+    expect(second.filename).toBe('report (1).csv')
+
+    reservations.release(first.reservationKey)
+
+    expect(reservations.reserve('report.csv').filename).toBe('report.csv')
+  })
+
+  it('uses case-insensitive path identity on Windows and macOS', () => {
+    const windowsReservations = new BrowserDownloadDestinationReservations({
+      downloadsPath: 'C:\\Users\\orca\\Downloads',
+      pathExists: vi.fn(() => false),
+      platform: 'win32'
+    })
+    const macReservations = new BrowserDownloadDestinationReservations({
+      downloadsPath,
+      pathExists: vi.fn(() => false),
+      platform: 'darwin'
+    })
+
+    expect(windowsReservations.reserve('Report.csv').filename).toBe('Report.csv')
+    expect(windowsReservations.reserve('report.csv').filename).toBe('report (1).csv')
+    expect(macReservations.reserve('Report.csv').filename).toBe('Report.csv')
+    expect(macReservations.reserve('report.csv').filename).toBe('report (1).csv')
+  })
+
+  it('fails after bounded collision attempts', () => {
+    const reservations = new BrowserDownloadDestinationReservations({
+      downloadsPath,
+      pathExists: vi.fn(() => true),
+      platform: 'linux'
+    })
+
+    expect(() => reservations.reserve('report.csv')).toThrow(
+      'Could not choose a unique file name in Downloads.'
+    )
+  })
+})

--- a/src/main/browser/browser-download-destination.ts
+++ b/src/main/browser/browser-download-destination.ts
@@ -1,0 +1,99 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+import { app } from 'electron'
+
+const MAX_BROWSER_DOWNLOAD_COLLISION_ATTEMPTS = 1_000
+const WINDOWS_RESERVED_FILENAME_CHARS = new Set(['<', '>', ':', '"', '|', '?', '*'])
+
+export type BrowserDownloadDestination = {
+  filename: string
+  savePath: string
+  reservationKey: string
+}
+
+type BrowserDownloadDestinationOptions = {
+  downloadsPath?: string
+  pathExists?: (filePath: string) => boolean
+  platform?: NodeJS.Platform
+}
+
+function normalizeFilename(filename: string): string {
+  const normalizedSeparators = filename.replace(/\\/g, '/')
+  const rawBasename = path.posix.basename(normalizedSeparators).trim()
+  const safeName = [...rawBasename]
+    .map((char) => {
+      if (char.charCodeAt(0) < 32 || WINDOWS_RESERVED_FILENAME_CHARS.has(char)) {
+        return '_'
+      }
+      return char
+    })
+    .join('')
+    .replace(/[. ]+$/g, '')
+    .trim()
+  return safeName || 'download'
+}
+
+function buildCollisionCandidate(filename: string, suffix: number): string {
+  if (suffix === 0) {
+    return filename
+  }
+  const extension = path.extname(filename)
+  const stem = extension ? filename.slice(0, -extension.length) : filename
+  return `${stem} (${suffix})${extension}`
+}
+
+function normalizeReservationKey(filePath: string, platform: NodeJS.Platform): string {
+  const normalizedPath = path.resolve(filePath)
+  return platform === 'win32' || platform === 'darwin'
+    ? normalizedPath.toLocaleLowerCase('en-US')
+    : normalizedPath
+}
+
+export class BrowserDownloadDestinationReservations {
+  private readonly reservedPathKeys = new Set<string>()
+  private readonly pathExists: (filePath: string) => boolean
+  private readonly downloadsPath: () => string
+  private readonly platform: NodeJS.Platform
+
+  constructor(options: BrowserDownloadDestinationOptions = {}) {
+    this.pathExists = options.pathExists ?? existsSync
+    this.downloadsPath = () => options.downloadsPath ?? app.getPath('downloads')
+    this.platform = options.platform ?? process.platform
+  }
+
+  reserve(filename: string): BrowserDownloadDestination {
+    const safeFilename = normalizeFilename(filename)
+    const downloadsPath = this.downloadsPath()
+
+    for (let attempt = 0; attempt < MAX_BROWSER_DOWNLOAD_COLLISION_ATTEMPTS; attempt += 1) {
+      const candidateFilename = buildCollisionCandidate(safeFilename, attempt)
+      const savePath = path.join(downloadsPath, candidateFilename)
+      const reservationKey = normalizeReservationKey(savePath, this.platform)
+      if (this.reservedPathKeys.has(reservationKey) || this.pathExists(savePath)) {
+        continue
+      }
+      this.reservedPathKeys.add(reservationKey)
+      return {
+        filename: candidateFilename,
+        savePath,
+        reservationKey
+      }
+    }
+
+    throw new Error('Could not choose a unique file name in Downloads.')
+  }
+
+  release(reservationKey: string | null): void {
+    if (!reservationKey) {
+      return
+    }
+    this.reservedPathKeys.delete(reservationKey)
+  }
+
+  clear(): void {
+    this.reservedPathKeys.clear()
+  }
+}
+
+export const browserDownloadDestinationReservations = new BrowserDownloadDestinationReservations()

--- a/src/main/browser/browser-download-destination.ts
+++ b/src/main/browser/browser-download-destination.ts
@@ -19,6 +19,7 @@ type BrowserDownloadDestinationOptions = {
 }
 
 function normalizeFilename(filename: string): string {
+  // Normalize separators first so basename strips paths from any platform.
   const normalizedSeparators = filename.replace(/\\/g, '/')
   const rawBasename = path.posix.basename(normalizedSeparators).trim()
   const safeName = [...rawBasename]
@@ -45,6 +46,7 @@ function buildCollisionCandidate(filename: string, suffix: number): string {
 
 function normalizeReservationKey(filePath: string, platform: NodeJS.Platform): string {
   const normalizedPath = path.resolve(filePath)
+  // Use a fixed locale for stable ASCII folding on case-insensitive filesystems.
   return platform === 'win32' || platform === 'darwin'
     ? normalizedPath.toLocaleLowerCase('en-US')
     : normalizedPath

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1188,6 +1188,35 @@ describe('browserManager', () => {
     ])
   })
 
+  it('drops pending download records when an unregistered guest is destroyed', () => {
+    const guest = {
+      id: 412,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    const item = createDownloadItem()
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.handleGuestWillDownload({ guestWebContentsId: guest.id, item })
+
+    const managerState = browserManager as unknown as { downloadsById: Map<string, unknown> }
+    expect(managerState.downloadsById.size).toBe(1)
+
+    const destroyedHandler = guestOnMock.mock.calls.find(
+      ([event]) => event === 'destroyed'
+    )?.[1] as (() => void) | undefined
+    destroyedHandler?.()
+
+    expect(item.cancel).toHaveBeenCalledTimes(1)
+    expect(managerState.downloadsById.size).toBe(0)
+  })
+
   it('cancels active downloads when the owning browser tab closes', () => {
     const rendererSendMock = vi.fn()
     const guest = {

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  appGetPathMock,
   shellOpenExternalMock,
   browserWindowFromWebContentsMock,
   menuBuildFromTemplateMock,
@@ -13,6 +14,7 @@ const {
   webContentsFromIdMock,
   screenGetCursorScreenPointMock
 } = vi.hoisted(() => ({
+  appGetPathMock: vi.fn(() => '/downloads'),
   shellOpenExternalMock: vi.fn(),
   browserWindowFromWebContentsMock: vi.fn(),
   menuBuildFromTemplateMock: vi.fn(),
@@ -26,6 +28,9 @@ const {
 }))
 
 vi.mock('electron', () => ({
+  app: {
+    getPath: appGetPathMock
+  },
   BrowserWindow: {
     fromWebContents: browserWindowFromWebContentsMock
   },
@@ -46,8 +51,41 @@ import { browserManager } from './browser-manager'
 
 describe('browserManager', () => {
   const rendererWebContentsId = 5001
+  type DownloadItemHandlerState = 'progressing' | 'interrupted' | 'completed' | 'cancelled'
+  type DownloadItemHandler = (event: Electron.Event, state: DownloadItemHandlerState) => void
+
+  function createDownloadItem(
+    overrides: Partial<Electron.DownloadItem> = {}
+  ): Electron.DownloadItem {
+    return {
+      setSavePath: vi.fn(),
+      on: vi.fn(),
+      once: vi.fn(),
+      off: vi.fn(),
+      cancel: vi.fn(),
+      getFilename: vi.fn(() => 'report.csv'),
+      getTotalBytes: vi.fn(() => 2048),
+      getMimeType: vi.fn(() => 'text/csv'),
+      getURL: vi.fn(() => 'https://example.com/report.csv'),
+      getReceivedBytes: vi.fn(() => 0),
+      ...overrides
+    } as unknown as Electron.DownloadItem
+  }
+
+  function getDownloadItemEventHandler(
+    item: Electron.DownloadItem,
+    method: 'on' | 'once',
+    eventName: string
+  ): DownloadItemHandler | undefined {
+    const eventMock = item[method] as unknown as {
+      mock: { calls: [string, DownloadItemHandler][] }
+    }
+    return eventMock.mock.calls.find(([event]) => event === eventName)?.[1]
+  }
 
   beforeEach(() => {
+    appGetPathMock.mockReset()
+    appGetPathMock.mockReturnValue('/downloads')
     shellOpenExternalMock.mockReset()
     browserWindowFromWebContentsMock.mockReset()
     menuBuildFromTemplateMock.mockReset()
@@ -980,11 +1018,16 @@ describe('browserManager', () => {
       openDevTools: guestOpenDevToolsMock
     }
     const item = {
-      pause: vi.fn(),
+      setSavePath: vi.fn(),
+      on: vi.fn(),
+      once: vi.fn(),
+      off: vi.fn(),
+      cancel: vi.fn(),
       getFilename: vi.fn(() => 'report.csv'),
       getTotalBytes: vi.fn(() => 2048),
       getMimeType: vi.fn(() => 'text/csv'),
-      getURL: vi.fn(() => 'https://example.com/report.csv')
+      getURL: vi.fn(() => 'https://example.com/report.csv'),
+      getReceivedBytes: vi.fn(() => 0)
     }
     webContentsFromIdMock.mockImplementation((id: number) => {
       if (id === guest.id) {
@@ -1024,7 +1067,216 @@ describe('browserManager', () => {
         filename: 'report.csv',
         origin: 'https://example.com',
         totalBytes: 2048,
-        mimeType: 'text/csv'
+        mimeType: 'text/csv',
+        savePath: '/downloads/report.csv',
+        status: 'downloading'
+      })
+    )
+    expect(item.setSavePath).toHaveBeenCalledWith('/downloads/report.csv')
+  })
+
+  it('sets the download save path immediately and reports progress and completion', () => {
+    const rendererSendMock = vi.fn()
+    const guest = {
+      id: 408,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    const item = createDownloadItem()
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
+    })
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+    browserManager.handleGuestWillDownload({ guestWebContentsId: guest.id, item })
+
+    expect(item.setSavePath).toHaveBeenCalledWith('/downloads/report.csv')
+    expect(item.on).toHaveBeenCalledWith('updated', expect.any(Function))
+    expect(item.once).toHaveBeenCalledWith('done', expect.any(Function))
+    expect(rendererSendMock).toHaveBeenCalledWith(
+      'browser:download-requested',
+      expect.objectContaining({
+        browserPageId: 'browser-1',
+        filename: 'report.csv',
+        savePath: '/downloads/report.csv',
+        status: 'downloading'
+      })
+    )
+
+    vi.mocked(item.getReceivedBytes).mockReturnValue(1024)
+    const updatedHandler = getDownloadItemEventHandler(item, 'on', 'updated')
+    updatedHandler?.({} as Electron.Event, 'progressing')
+
+    expect(rendererSendMock).toHaveBeenCalledWith('browser:download-progress', {
+      browserPageId: 'browser-1',
+      downloadId: expect.any(String),
+      receivedBytes: 1024,
+      totalBytes: 2048,
+      state: 'progressing'
+    })
+
+    const doneHandler = getDownloadItemEventHandler(item, 'once', 'done')
+    doneHandler?.({} as Electron.Event, 'completed')
+
+    expect(rendererSendMock).toHaveBeenCalledWith(
+      'browser:download-finished',
+      expect.objectContaining({
+        browserPageId: 'browser-1',
+        status: 'completed',
+        savePath: '/downloads/report.csv',
+        error: null
+      })
+    )
+  })
+
+  it('flushes started and terminal snapshots for downloads that finish before registration', () => {
+    const rendererSendMock = vi.fn()
+    const guest = {
+      id: 409,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    const item = createDownloadItem()
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
+    })
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.handleGuestWillDownload({ guestWebContentsId: guest.id, item })
+
+    const doneHandler = getDownloadItemEventHandler(item, 'once', 'done')
+    doneHandler?.({} as Electron.Event, 'completed')
+
+    expect(rendererSendMock).not.toHaveBeenCalled()
+
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+
+    expect(rendererSendMock.mock.calls.map(([channel]) => channel)).toEqual([
+      'browser:download-requested',
+      'browser:download-finished'
+    ])
+  })
+
+  it('cancels active downloads when the owning browser tab closes', () => {
+    const rendererSendMock = vi.fn()
+    const guest = {
+      id: 410,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    const item = createDownloadItem()
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
+    })
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+    browserManager.handleGuestWillDownload({ guestWebContentsId: guest.id, item })
+
+    browserManager.unregisterGuest('browser-1')
+
+    expect(item.cancel).toHaveBeenCalledTimes(1)
+    expect(rendererSendMock).toHaveBeenCalledWith(
+      'browser:download-finished',
+      expect.objectContaining({
+        browserPageId: 'browser-1',
+        status: 'canceled',
+        error: 'Tab closed before download completed.'
+      })
+    )
+  })
+
+  it('reports setSavePath failures without leaving a hidden download running', () => {
+    const rendererSendMock = vi.fn()
+    const guest = {
+      id: 411,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    const item = createDownloadItem({
+      setSavePath: vi.fn(() => {
+        throw new Error('cannot set path')
+      }) as never
+    })
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
+    })
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+    browserManager.handleGuestWillDownload({ guestWebContentsId: guest.id, item })
+
+    expect(item.cancel).toHaveBeenCalledTimes(1)
+    expect(rendererSendMock.mock.calls.map(([channel]) => channel)).toEqual([
+      'browser:download-requested',
+      'browser:download-finished'
+    ])
+    expect(rendererSendMock).toHaveBeenCalledWith(
+      'browser:download-finished',
+      expect.objectContaining({
+        status: 'failed',
+        error: 'Failed to set download destination.'
       })
     )
   })

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -1729,6 +1729,10 @@ export class BrowserManager {
         continue
       }
       this.cancelDownloadInternal(downloadId, 'Browser page closed before download could be shown.')
+      const afterCancel = this.downloadsById.get(downloadId)
+      if (afterCancel?.terminalEvent && !afterCancel.browserTabId) {
+        this.downloadsById.delete(downloadId)
+      }
     }
   }
 

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -28,6 +28,7 @@ import { buildGuestOverlayScript } from './grab-guest-script'
 import { clampGrabPayload } from './browser-grab-payload'
 import { captureSelectionScreenshot as captureGrabSelectionScreenshot } from './browser-grab-screenshot'
 import { BrowserGrabSessionController } from './browser-grab-session-controller'
+import { browserDownloadDestinationReservations } from './browser-download-destination'
 import {
   resolveRendererWebContents,
   setupGrabShortcutForwarding,
@@ -138,6 +139,7 @@ export type BrowserGuestRegistration = {
 
 type PendingPermissionEvent = Omit<BrowserPermissionDeniedEvent, 'browserPageId'>
 type PendingPopupEvent = Omit<BrowserPopupEvent, 'browserPageId'>
+type BrowserDownloadDoneState = 'completed' | 'cancelled' | 'interrupted'
 
 type ActiveDownload = {
   downloadId: string
@@ -149,9 +151,12 @@ type ActiveDownload = {
   totalBytes: number | null
   mimeType: string | null
   item: Electron.DownloadItem
-  state: 'requested' | 'downloading'
-  savePath: string | null
-  pendingCancelTimer: ReturnType<typeof setTimeout> | null
+  savePath: string
+  reservationKey: string | null
+  receivedBytes: number
+  transientState: BrowserDownloadProgressEvent['state']
+  terminalEvent: BrowserDownloadFinishedEvent | null
+  startedSent: boolean
   cleanup: (() => void) | null
 }
 
@@ -696,7 +701,7 @@ export class BrowserManager {
     this.pendingLoadFailuresByGuestId.delete(guestWebContentsId)
     this.pendingPermissionEventsByGuestId.delete(guestWebContentsId)
     this.pendingPopupEventsByGuestId.delete(guestWebContentsId)
-    this.pendingDownloadIdsByGuestId.delete(guestWebContentsId)
+    this.cancelPendingDownloadsForGuest(guestWebContentsId)
   }
 
   registerGuest({
@@ -804,12 +809,11 @@ export class BrowserManager {
       mouseWheelZoomCleanup()
       this.mouseWheelZoomCleanupByTabId.delete(browserTabId)
     }
-    // Why: paused downloads wait for explicit product approval. If the owning
-    // browser tab disappears first, cancel the request so the app does not
-    // retain orphaned download items or write files after context is gone.
+    // Why: browser downloads are transient per-tab chrome. Closing the owning
+    // tab must cancel active writes instead of hiding them behind no UI.
     for (const [downloadId, download] of this.downloadsById.entries()) {
-      if (download.browserTabId === browserTabId && download.state === 'requested') {
-        this.cancelDownloadInternal(downloadId, 'Tab closed before download was accepted.')
+      if (download.browserTabId === browserTabId && !download.terminalEvent) {
+        this.cancelDownloadInternal(downloadId, 'Tab closed before download completed.')
       }
     }
     const wcId = this.webContentsIdByTabId.get(browserTabId)
@@ -865,6 +869,7 @@ export class BrowserManager {
     for (const downloadId of this.downloadsById.keys()) {
       this.cancelDownloadInternal(downloadId, 'Orca is shutting down.')
     }
+    browserDownloadDestinationReservations.clear()
     for (const browserTabId of this.webContentsIdByTabId.keys()) {
       this.unregisterGuest(browserTabId)
     }
@@ -918,7 +923,7 @@ export class BrowserManager {
   handleGuestWillDownload(args: { guestWebContentsId: number; item: Electron.DownloadItem }): void {
     const { guestWebContentsId, item } = args
     const downloadId = randomUUID()
-    const filename = (() => {
+    const requestedFilename = (() => {
       try {
         return item.getFilename() || 'download'
       } catch {
@@ -949,12 +954,16 @@ export class BrowserManager {
       }
     })()
 
-    try {
-      item.pause()
-    } catch {
-      // Why: some interrupted downloads throw if paused immediately. Keep
-      // tracking the item anyway so Orca can still explain the failure path.
-    }
+    const destination = (() => {
+      try {
+        return browserDownloadDestinationReservations.reserve(requestedFilename)
+      } catch (error) {
+        console.error('[browser-download] Failed to choose download destination:', error)
+        return null
+      }
+    })()
+
+    const fallbackSavePath = destination?.savePath ?? ''
 
     const download: ActiveDownload = {
       downloadId,
@@ -962,13 +971,16 @@ export class BrowserManager {
       browserTabId: null,
       rendererWebContentsId: null,
       origin,
-      filename,
+      filename: destination?.filename ?? requestedFilename,
       totalBytes,
       mimeType,
       item,
-      state: 'requested',
-      savePath: null,
-      pendingCancelTimer: null,
+      savePath: fallbackSavePath,
+      reservationKey: destination?.reservationKey ?? null,
+      receivedBytes: 0,
+      transientState: null,
+      terminalEvent: null,
+      startedSent: false,
       cleanup: null
     }
     this.downloadsById.set(downloadId, download)
@@ -976,109 +988,76 @@ export class BrowserManager {
     const browserTabId = this.resolveBrowserTabIdForGuestWebContentsId(guestWebContentsId)
     if (browserTabId) {
       this.bindDownloadToTab(downloadId, browserTabId)
-      this.sendDownloadRequested(downloadId)
     } else {
       const pending = this.pendingDownloadIdsByGuestId.get(guestWebContentsId) ?? []
       pending.push(downloadId)
       this.pendingDownloadIdsByGuestId.set(guestWebContentsId, pending)
     }
 
-    // Why: fail closed if the user never explicitly accepts or cancels. This
-    // prevents a compromised or crashed renderer from leaving paused downloads
-    // alive until app shutdown and later resuming them without context.
-    download.pendingCancelTimer = setTimeout(() => {
-      this.cancelDownloadInternal(downloadId, 'Timed out waiting for user approval.')
-    }, 60_000)
-    // Why: approval timeout is a fail-closed safety net, not a reason to keep
-    // Electron main alive after the browser/runtime is otherwise shutting down.
-    if (typeof download.pendingCancelTimer.unref === 'function') {
-      download.pendingCancelTimer.unref()
-    }
-  }
-
-  getDownloadPrompt(downloadId: string, senderWebContentsId: number): { filename: string } | null {
-    const download = this.downloadsById.get(downloadId)
-    if (!download || download.rendererWebContentsId !== senderWebContentsId) {
-      return null
-    }
-    return { filename: download.filename }
-  }
-
-  acceptDownload(args: {
-    downloadId: string
-    senderWebContentsId: number
-    savePath: string
-  }): { ok: true } | { ok: false; reason: string } {
-    const download = this.downloadsById.get(args.downloadId)
-    if (!download || download.rendererWebContentsId !== args.senderWebContentsId) {
-      return { ok: false, reason: 'not-authorized' }
-    }
-    if (download.state !== 'requested' || !download.browserTabId) {
-      return { ok: false, reason: 'not-ready' }
-    }
-
-    if (download.pendingCancelTimer) {
-      clearTimeout(download.pendingCancelTimer)
-      download.pendingCancelTimer = null
+    if (!destination) {
+      this.finishDownloadInternal(downloadId, 'failed', 'Could not choose a Downloads file name.')
+      try {
+        item.cancel()
+      } catch {
+        // Why: without a destination, Chromium must not keep writing invisibly;
+        // cancellation remains best-effort after surfacing the failure.
+      }
+      return
     }
 
     try {
-      download.item.setSavePath(args.savePath)
-      download.savePath = args.savePath
-    } catch {
-      this.cancelDownloadInternal(args.downloadId, 'Failed to set download destination.')
-      return { ok: false, reason: 'not-ready' }
+      item.setSavePath(destination.savePath)
+    } catch (error) {
+      console.error('[browser-download] Failed to set download destination:', error)
+      this.finishDownloadInternal(downloadId, 'failed', 'Failed to set download destination.')
+      try {
+        item.cancel()
+      } catch {
+        // Why: failing setSavePath can leave Electron in a partially finalized
+        // state; cancellation is best-effort after Orca has made the UI terminal.
+      }
+      return
     }
 
-    download.state = 'downloading'
-    const cleanup = (): void => {
+    const updatedHandler = (_event: Electron.Event, state: 'progressing' | 'interrupted'): void => {
+      download.receivedBytes = this.getDownloadReceivedBytes(download.item)
+      download.transientState = state
+      this.sendDownloadProgress(download.browserTabId, {
+        browserPageId: download.browserTabId ?? undefined,
+        downloadId: download.downloadId,
+        receivedBytes: download.receivedBytes,
+        totalBytes: download.totalBytes,
+        state
+      })
+    }
+    const doneHandler = (_event: Electron.Event, state: BrowserDownloadDoneState): void => {
+      const status: BrowserDownloadFinishedEvent['status'] =
+        state === 'completed' ? 'completed' : state === 'cancelled' ? 'canceled' : 'failed'
+      this.finishDownloadInternal(
+        download.downloadId,
+        status,
+        status === 'failed'
+          ? state === 'interrupted'
+            ? 'Download was interrupted.'
+            : 'Download failed.'
+          : null
+      )
+    }
+    download.cleanup = (): void => {
       try {
-        download.item.removeAllListeners('updated')
-        download.item.removeAllListeners('done')
+        download.item.off('updated', updatedHandler)
+        download.item.off('done', doneHandler)
       } catch {
         // Why: completed DownloadItems can already be finalized when cleanup
         // runs. Cleanup must stay best-effort so UI teardown never crashes main.
       }
     }
-    download.cleanup = cleanup
+    item.on('updated', updatedHandler)
+    item.once('done', doneHandler)
 
-    download.item.on('updated', (_event, state) => {
-      if (state !== 'progressing') {
-        return
-      }
-      this.sendDownloadProgress(download.browserTabId, {
-        downloadId: download.downloadId,
-        receivedBytes: download.item.getReceivedBytes(),
-        totalBytes: download.totalBytes
-      })
-    })
-
-    download.item.once('done', (_event, state) => {
-      const status: BrowserDownloadFinishedEvent['status'] =
-        state === 'completed' ? 'completed' : state === 'cancelled' ? 'canceled' : 'failed'
-      this.sendDownloadFinished(download.browserTabId, {
-        downloadId: download.downloadId,
-        status,
-        savePath: download.savePath,
-        error:
-          status === 'failed'
-            ? state === 'interrupted'
-              ? 'Download was interrupted.'
-              : 'Download failed.'
-            : null
-      })
-      cleanup()
-      this.downloadsById.delete(download.downloadId)
-    })
-
-    try {
-      download.item.resume()
-    } catch {
-      this.cancelDownloadInternal(args.downloadId, 'Failed to start download.')
-      return { ok: false, reason: 'not-ready' }
+    if (browserTabId) {
+      this.sendDownloadStarted(downloadId)
     }
-
-    return { ok: true }
   }
 
   cancelDownload(args: { downloadId: string; senderWebContentsId: number }): boolean {
@@ -1594,13 +1573,40 @@ export class BrowserManager {
     this.pendingDownloadIdsByGuestId.delete(guestWebContentsId)
     for (const downloadId of pending) {
       this.bindDownloadToTab(downloadId, browserTabId)
-      this.sendDownloadRequested(downloadId)
+      this.flushDownloadSnapshot(downloadId)
     }
   }
 
-  private sendDownloadRequested(downloadId: string): void {
+  private flushDownloadSnapshot(downloadId: string): void {
+    const download = this.downloadsById.get(downloadId)
+    if (!download) {
+      return
+    }
+    this.sendDownloadStarted(downloadId)
+    if (download.receivedBytes > 0 || download.transientState) {
+      this.sendDownloadProgress(download.browserTabId, {
+        browserPageId: download.browserTabId ?? undefined,
+        downloadId: download.downloadId,
+        receivedBytes: download.receivedBytes,
+        totalBytes: download.totalBytes,
+        state: download.transientState
+      })
+    }
+    if (download.terminalEvent) {
+      this.sendDownloadFinished(download.browserTabId, {
+        ...download.terminalEvent,
+        browserPageId: download.browserTabId ?? undefined
+      })
+      this.downloadsById.delete(downloadId)
+    }
+  }
+
+  private sendDownloadStarted(downloadId: string): void {
     const download = this.downloadsById.get(downloadId)
     if (!download?.browserTabId) {
+      return
+    }
+    if (download.startedSent) {
       return
     }
     const renderer = this.resolveRendererForBrowserTab(download.browserTabId)
@@ -1613,8 +1619,11 @@ export class BrowserManager {
       origin: download.origin,
       filename: download.filename,
       totalBytes: download.totalBytes,
-      mimeType: download.mimeType
+      mimeType: download.mimeType,
+      savePath: download.savePath,
+      status: 'downloading'
     } satisfies BrowserDownloadRequestedEvent)
+    download.startedSent = true
   }
 
   private sendDownloadProgress(
@@ -1651,14 +1660,11 @@ export class BrowserManager {
       return
     }
 
-    if (download.pendingCancelTimer) {
-      clearTimeout(download.pendingCancelTimer)
-      download.pendingCancelTimer = null
-    }
     if (download.cleanup) {
       download.cleanup()
       download.cleanup = null
     }
+    const shouldSendCancel = !download.terminalEvent
 
     try {
       download.item.cancel()
@@ -1668,16 +1674,70 @@ export class BrowserManager {
       // source of truth for whether Orca still considers the request active.
     }
 
-    if (download.browserTabId) {
-      this.sendDownloadFinished(download.browserTabId, {
-        downloadId: download.downloadId,
-        status: 'canceled',
-        savePath: download.savePath,
-        error: reason || null
-      })
+    if (shouldSendCancel) {
+      this.finishDownloadInternal(downloadId, 'canceled', reason || null)
+      return
     }
 
     this.downloadsById.delete(downloadId)
+  }
+
+  private finishDownloadInternal(
+    downloadId: string,
+    status: BrowserDownloadFinishedEvent['status'],
+    error: string | null
+  ): void {
+    const download = this.downloadsById.get(downloadId)
+    if (!download || download.terminalEvent) {
+      return
+    }
+
+    if (download.cleanup) {
+      download.cleanup()
+      download.cleanup = null
+    }
+    browserDownloadDestinationReservations.release(download.reservationKey)
+    download.reservationKey = null
+    const event: BrowserDownloadFinishedEvent = {
+      browserPageId: download.browserTabId ?? undefined,
+      downloadId: download.downloadId,
+      status,
+      savePath: download.savePath || null,
+      error
+    }
+    download.terminalEvent = event
+    if (download.browserTabId) {
+      this.sendDownloadStarted(downloadId)
+      this.sendDownloadFinished(download.browserTabId, event)
+      this.downloadsById.delete(downloadId)
+    }
+  }
+
+  private cancelPendingDownloadsForGuest(guestWebContentsId: number): void {
+    const pending = this.pendingDownloadIdsByGuestId.get(guestWebContentsId)
+    this.pendingDownloadIdsByGuestId.delete(guestWebContentsId)
+    if (!pending?.length) {
+      return
+    }
+    for (const downloadId of pending) {
+      const download = this.downloadsById.get(downloadId)
+      if (!download) {
+        continue
+      }
+      if (download.terminalEvent) {
+        this.downloadsById.delete(downloadId)
+        continue
+      }
+      this.cancelDownloadInternal(downloadId, 'Browser page closed before download could be shown.')
+    }
+  }
+
+  private getDownloadReceivedBytes(item: Electron.DownloadItem): number {
+    try {
+      return Math.max(0, item.getReceivedBytes())
+    } catch {
+      return 0
+    }
   }
 
   private flushPendingLoadFailure(browserTabId: string, guestWebContentsId: number): void {

--- a/src/main/ipc/browser.test.ts
+++ b/src/main/ipc/browser.test.ts
@@ -11,10 +11,7 @@ const {
   getWorktreeIdForTabMock,
   openDevToolsMock,
   setAnnotationViewportBridgeMock,
-  getDownloadPromptMock,
-  acceptDownloadMock,
   cancelDownloadMock,
-  showSaveDialogMock,
   browserWindowFromWebContentsMock,
   webContentsFromIdMock
 } = vi.hoisted(() => ({
@@ -27,10 +24,7 @@ const {
   getWorktreeIdForTabMock: vi.fn(),
   openDevToolsMock: vi.fn().mockResolvedValue(true),
   setAnnotationViewportBridgeMock: vi.fn().mockResolvedValue(true),
-  getDownloadPromptMock: vi.fn(),
-  acceptDownloadMock: vi.fn(),
   cancelDownloadMock: vi.fn(),
-  showSaveDialogMock: vi.fn(),
   browserWindowFromWebContentsMock: vi.fn(),
   webContentsFromIdMock: vi.fn()
 }))
@@ -38,9 +32,6 @@ const {
 vi.mock('electron', () => ({
   BrowserWindow: {
     fromWebContents: browserWindowFromWebContentsMock
-  },
-  dialog: {
-    showSaveDialog: showSaveDialogMock
   },
   ipcMain: {
     removeHandler: removeHandlerMock,
@@ -60,8 +51,6 @@ vi.mock('../browser/browser-manager', () => ({
     getWorktreeIdForTab: getWorktreeIdForTabMock,
     openDevTools: openDevToolsMock,
     setAnnotationViewportBridge: setAnnotationViewportBridgeMock,
-    getDownloadPrompt: getDownloadPromptMock,
-    acceptDownload: acceptDownloadMock,
     cancelDownload: cancelDownloadMock
   }
 }))
@@ -87,10 +76,7 @@ describe('registerBrowserHandlers', () => {
     getWorktreeIdForTabMock.mockReset()
     openDevToolsMock.mockReset()
     setAnnotationViewportBridgeMock.mockReset()
-    getDownloadPromptMock.mockReset()
-    acceptDownloadMock.mockReset()
     cancelDownloadMock.mockReset()
-    showSaveDialogMock.mockReset()
     browserWindowFromWebContentsMock.mockReset()
     webContentsFromIdMock.mockReset()
     webContentsFromIdMock.mockReturnValue({ isDestroyed: () => false })
@@ -125,19 +111,13 @@ describe('registerBrowserHandlers', () => {
     expect(registerGuestMock).not.toHaveBeenCalled()
   })
 
-  it('accepts downloads through a main-owned save dialog', async () => {
-    getDownloadPromptMock.mockReturnValue({ filename: 'report.csv' })
-    acceptDownloadMock.mockReturnValue({ ok: true })
-    showSaveDialogMock.mockResolvedValue({ canceled: false, filePath: '/tmp/report.csv' })
-
+  it('authorizes browser download cancellation through the owning renderer', () => {
+    cancelDownloadMock.mockReturnValue(true)
     registerBrowserHandlers()
 
-    const acceptHandler = handleMock.mock.calls.find(
-      ([channel]) => channel === 'browser:acceptDownload'
-    )?.[1] as (
-      event: { sender: Electron.WebContents },
-      args: { downloadId: string }
-    ) => Promise<{ ok: true } | { ok: false; reason: string }>
+    const cancelHandler = handleMock.mock.calls.find(
+      ([channel]) => channel === 'browser:cancelDownload'
+    )?.[1] as (event: { sender: Electron.WebContents }, args: { downloadId: string }) => boolean
 
     const sender = {
       id: 91,
@@ -146,15 +126,36 @@ describe('registerBrowserHandlers', () => {
       getURL: () => 'file:///renderer/index.html'
     } as Electron.WebContents
 
-    const result = await acceptHandler({ sender }, { downloadId: 'download-1' })
+    const result = cancelHandler({ sender }, { downloadId: 'download-1' })
 
-    expect(showSaveDialogMock).toHaveBeenCalledTimes(1)
-    expect(acceptDownloadMock).toHaveBeenCalledWith({
+    expect(cancelDownloadMock).toHaveBeenCalledWith({
       downloadId: 'download-1',
-      senderWebContentsId: 91,
-      savePath: '/tmp/report.csv'
+      senderWebContentsId: 91
     })
-    expect(result).toEqual({ ok: true })
+    expect(result).toBe(true)
+  })
+
+  it('rejects browser download cancellation from untrusted callers', () => {
+    registerBrowserHandlers()
+
+    const cancelHandler = handleMock.mock.calls.find(
+      ([channel]) => channel === 'browser:cancelDownload'
+    )?.[1] as (event: { sender: Electron.WebContents }, args: { downloadId: string }) => boolean
+
+    const result = cancelHandler(
+      {
+        sender: {
+          id: 92,
+          isDestroyed: () => false,
+          getType: () => 'webview',
+          getURL: () => 'https://example.com'
+        } as Electron.WebContents
+      },
+      { downloadId: 'download-1' }
+    )
+
+    expect(result).toBe(false)
+    expect(cancelDownloadMock).not.toHaveBeenCalled()
   })
 
   it('updates the bridge active tab for the owning worktree', async () => {

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: browser IPC handlers must be registered together so the
    trust boundary (isTrustedBrowserRenderer) and handler teardown stay consistent. */
-import { BrowserWindow, dialog, ipcMain, webContents } from 'electron'
+import { BrowserWindow, ipcMain, webContents } from 'electron'
 import { browserManager } from '../browser/browser-manager'
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
 import { browserSessionRegistry } from '../browser/browser-session-registry'
@@ -329,34 +329,6 @@ export function registerBrowserHandlers(): void {
       })
     }
   )
-
-  ipcMain.handle('browser:acceptDownload', async (event, args: { downloadId: string }) => {
-    if (!isTrustedBrowserRenderer(event.sender)) {
-      return { ok: false, reason: 'not-authorized' as const }
-    }
-    const prompt = browserManager.getDownloadPrompt(args.downloadId, event.sender.id)
-    if (!prompt) {
-      return { ok: false, reason: 'not-ready' as const }
-    }
-
-    const parent = BrowserWindow.fromWebContents(event.sender)
-    const result = parent
-      ? await dialog.showSaveDialog(parent, { defaultPath: prompt.filename })
-      : await dialog.showSaveDialog({ defaultPath: prompt.filename })
-    if (result.canceled || !result.filePath) {
-      browserManager.cancelDownload({
-        downloadId: args.downloadId,
-        senderWebContentsId: event.sender.id
-      })
-      return { ok: false, reason: 'canceled' as const }
-    }
-
-    return browserManager.acceptDownload({
-      downloadId: args.downloadId,
-      senderWebContentsId: event.sender.id,
-      savePath: result.filePath
-    })
-  })
 
   ipcMain.handle('browser:cancelDownload', (event, args: { downloadId: string }) => {
     if (!isTrustedBrowserRenderer(event.sender)) {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -434,9 +434,6 @@ export type BrowserApi = {
   onOpenLinkInOrcaTab: (
     callback: (event: { browserPageId: string; url: string }) => void
   ) => () => void
-  acceptDownload: (args: {
-    downloadId: string
-  }) => Promise<{ ok: true } | { ok: false; reason: string }>
   cancelDownload: (args: { downloadId: string }) => Promise<boolean>
   setGrabMode: (args: BrowserSetGrabModeArgs) => Promise<BrowserSetGrabModeResult>
   awaitGrabSelection: (args: BrowserAwaitGrabSelectionArgs) => Promise<BrowserGrabResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1986,6 +1986,8 @@ const api = {
         filename: string
         totalBytes: number | null
         mimeType: string | null
+        savePath: string
+        status: 'downloading'
       }) => void
     ): (() => void) => {
       const listener = (
@@ -1997,6 +1999,8 @@ const api = {
           filename: string
           totalBytes: number | null
           mimeType: string | null
+          savePath: string
+          status: 'downloading'
         }
       ) => callback(data)
       ipcRenderer.on('browser:download-requested', listener)
@@ -2005,14 +2009,22 @@ const api = {
 
     onDownloadProgress: (
       callback: (event: {
+        browserPageId?: string
         downloadId: string
         receivedBytes: number
         totalBytes: number | null
+        state: 'progressing' | 'interrupted' | null
       }) => void
     ): (() => void) => {
       const listener = (
         _event: Electron.IpcRendererEvent,
-        data: { downloadId: string; receivedBytes: number; totalBytes: number | null }
+        data: {
+          browserPageId?: string
+          downloadId: string
+          receivedBytes: number
+          totalBytes: number | null
+          state: 'progressing' | 'interrupted' | null
+        }
       ) => callback(data)
       ipcRenderer.on('browser:download-progress', listener)
       return () => ipcRenderer.removeListener('browser:download-progress', listener)
@@ -2020,6 +2032,7 @@ const api = {
 
     onDownloadFinished: (
       callback: (event: {
+        browserPageId?: string
         downloadId: string
         status: 'completed' | 'canceled' | 'failed'
         savePath: string | null
@@ -2029,6 +2042,7 @@ const api = {
       const listener = (
         _event: Electron.IpcRendererEvent,
         data: {
+          browserPageId?: string
           downloadId: string
           status: 'completed' | 'canceled' | 'failed'
           savePath: string | null
@@ -2122,11 +2136,6 @@ const api = {
       ipcRenderer.on('browser:open-link-in-orca-tab', listener)
       return () => ipcRenderer.removeListener('browser:open-link-in-orca-tab', listener)
     },
-
-    acceptDownload: (args: {
-      downloadId: string
-    }): Promise<{ ok: true } | { ok: false; reason: string }> =>
-      ipcRenderer.invoke('browser:acceptDownload', args),
 
     cancelDownload: (args: { downloadId: string }): Promise<boolean> =>
       ipcRenderer.invoke('browser:cancelDownload', args),

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -27,7 +27,9 @@ import {
   Copy,
   CornerDownLeft,
   Crosshair,
+  Download,
   ExternalLink,
+  FolderOpen,
   Globe,
   Image,
   Loader2,
@@ -38,7 +40,8 @@ import {
   RefreshCw,
   Send,
   SquareCode,
-  Trash2
+  Trash2,
+  X
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
@@ -155,7 +158,6 @@ import {
 import { withBrowserPaneUiRuntimeRpcSource } from '../../../../shared/runtime-rpc-feature-interaction-source'
 import {
   formatByteCount,
-  formatDownloadFinishedNotice,
   formatLoadFailureDescription,
   formatLoadFailureRecoveryHint,
   formatPermissionNotice,
@@ -179,9 +181,22 @@ type BrowserTabPageState = Partial<
   >
 >
 
-type BrowserDownloadState = BrowserDownloadRequestedEvent & {
+type BrowserDownloadState = Omit<BrowserDownloadRequestedEvent, 'status' | 'savePath'> & {
   receivedBytes: number
-  status: 'requested' | 'downloading'
+  status: 'downloading' | 'completed' | 'failed' | 'canceled'
+  savePath: string | null
+  error: string | null
+  progressState: BrowserDownloadProgressEvent['state']
+  completedAt: number | null
+}
+
+function formatBrowserDownloadProgress(download: BrowserDownloadState): string | null {
+  const received = formatByteCount(download.receivedBytes)
+  const total = formatByteCount(download.totalBytes)
+  if (received && total) {
+    return `${received} / ${total}`
+  }
+  return received ?? total
 }
 
 type GrabIntent = 'copy' | 'annotate'
@@ -2713,8 +2728,8 @@ function BrowserPagePane({
   const [addressBarValue, setAddressBarValue] = useState(browserTab.url)
   const addressBarValueRef = useRef(browserTab.url)
   const [resourceNotice, setResourceNotice] = useState<string | null>(null)
-  const [downloadState, setDownloadState] = useState<BrowserDownloadState | null>(null)
-  const downloadStateRef = useRef<BrowserDownloadState | null>(null)
+  const [downloadStates, setDownloadStates] = useState<BrowserDownloadState[]>([])
+  const downloadStatesRef = useRef<BrowserDownloadState[]>([])
   const [browserZoomPercent, setBrowserZoomPercent] = useState(browserDefaultZoomPercent)
   const [browserZoomFeedbackVisible, setBrowserZoomFeedbackVisible] = useState(false)
   const [contextMenu, setContextMenu] = useState<{
@@ -2977,12 +2992,12 @@ function BrowserPagePane({
   }, [addressBarValue])
 
   useEffect(() => {
-    downloadStateRef.current = downloadState
-  }, [downloadState])
+    downloadStatesRef.current = downloadStates
+  }, [downloadStates])
 
   useEffect(() => {
     setResourceNotice(null)
-    setDownloadState(null)
+    setDownloadStates([])
   }, [browserTab.id])
 
   useEffect(() => {
@@ -3103,13 +3118,30 @@ function BrowserPagePane({
       if (event.browserPageId !== browserTab.id) {
         return
       }
-      // Why: downloads are approved per browser tab, not globally. Keep the
-      // request local to the owning BrowserPane so the user can see which page
-      // triggered the save prompt before Orca asks main to choose a path.
-      setDownloadState({
-        ...event,
-        receivedBytes: 0,
-        status: 'requested'
+      setDownloadStates((current) => {
+        const nextEntry: BrowserDownloadState = {
+          browserPageId: event.browserPageId,
+          downloadId: event.downloadId,
+          origin: event.origin,
+          filename: event.filename,
+          totalBytes: event.totalBytes,
+          mimeType: event.mimeType,
+          receivedBytes: 0,
+          status: 'downloading',
+          savePath: event.savePath,
+          error: null,
+          progressState: null,
+          completedAt: null
+        }
+        const existingIndex = current.findIndex(
+          (download) => download.downloadId === event.downloadId
+        )
+        if (existingIndex === -1) {
+          return [nextEntry, ...current]
+        }
+        const next = [...current]
+        next[existingIndex] = { ...next[existingIndex], ...nextEntry }
+        return next
       })
       setResourceNotice(null)
     })
@@ -3117,35 +3149,45 @@ function BrowserPagePane({
 
   useEffect(() => {
     return window.api.browser.onDownloadProgress((event: BrowserDownloadProgressEvent) => {
-      setDownloadState((current) => {
-        if (!current || current.downloadId !== event.downloadId) {
-          return current
-        }
-        return {
-          ...current,
-          receivedBytes: event.receivedBytes,
-          totalBytes: event.totalBytes,
-          status: 'downloading'
-        }
-      })
+      setDownloadStates((current) =>
+        current.map((download) =>
+          download.downloadId === event.downloadId
+            ? {
+                ...download,
+                receivedBytes: event.receivedBytes,
+                totalBytes: event.totalBytes,
+                progressState: event.state
+              }
+            : download
+        )
+      )
     })
   }, [])
 
   useEffect(() => {
     return window.api.browser.onDownloadFinished((event: BrowserDownloadFinishedEvent) => {
-      const current = downloadStateRef.current
-      if (!current || current.downloadId !== event.downloadId) {
+      if (event.browserPageId && event.browserPageId !== browserTab.id) {
         return
       }
-      setDownloadState((current) => {
-        if (!current || current.downloadId !== event.downloadId) {
-          return current
-        }
-        return null
-      })
-      setResourceNotice(formatDownloadFinishedNotice(event))
+      const current = downloadStatesRef.current
+      if (!current.some((download) => download.downloadId === event.downloadId)) {
+        return
+      }
+      setDownloadStates((current) =>
+        current.map((download) =>
+          download.downloadId === event.downloadId
+            ? {
+                ...download,
+                status: event.status,
+                savePath: event.savePath,
+                error: event.error,
+                completedAt: Date.now()
+              }
+            : download
+        )
+      )
     })
-  }, [])
+  }, [browserTab.id])
 
   const focusAddressBarNow = useCallback(() => {
     const input = addressBarInputRef.current
@@ -4467,19 +4509,13 @@ function BrowserPagePane({
   const loadErrorMeta = getLoadErrorMetadata(browserTab.loadError)
   const loadErrorHint = formatLoadFailureRecoveryHint(loadErrorMeta)
   const showFailureOverlay = Boolean(browserTab.loadError) && !isBlankTab
-  const downloadProgressLabel = (() => {
-    if (!downloadState) {
-      return null
-    }
-    const received = formatByteCount(downloadState.receivedBytes)
-    const total = formatByteCount(downloadState.totalBytes)
-    if (received && total) {
-      return `${received} / ${total}`
-    }
-    if (total) {
-      return total
-    }
-    return received
+  const visibleDownloads = (() => {
+    const active = downloadStates.filter((download) => download.status === 'downloading')
+    const recent = downloadStates
+      .filter((download) => download.status !== 'downloading')
+      .sort((a, b) => (b.completedAt ?? 0) - (a.completedAt ?? 0))
+      .slice(0, 3)
+    return [...active, ...recent]
   })()
   const browserZoomIndicatorState = getBrowserPageZoomIndicatorState({
     feedbackVisible: browserZoomFeedbackVisible,
@@ -4560,6 +4596,52 @@ function BrowserPagePane({
     },
     [navigateToUrl, worktreeId]
   )
+
+  const dismissBrowserDownload = useCallback((downloadId: string) => {
+    setDownloadStates((current) => current.filter((download) => download.downloadId !== downloadId))
+  }, [])
+
+  const handleOpenDownloadedFile = useCallback(async (download: BrowserDownloadState) => {
+    if (!download.savePath) {
+      setResourceNotice(
+        translate(
+          'auto.components.browser.pane.BrowserPane.9f6f2e8c19',
+          'The downloaded file path is unavailable.'
+        )
+      )
+      return
+    }
+    const opened = await window.api.shell.openFilePath(download.savePath)
+    if (!opened) {
+      setResourceNotice(
+        translate(
+          'auto.components.browser.pane.BrowserPane.0c79b7634d',
+          'Could not open the downloaded file. It may have been moved or deleted.'
+        )
+      )
+    }
+  }, [])
+
+  const handleShowDownloadedFile = useCallback(async (download: BrowserDownloadState) => {
+    if (!download.savePath) {
+      setResourceNotice(
+        translate(
+          'auto.components.browser.pane.BrowserPane.9f6f2e8c19',
+          'The downloaded file path is unavailable.'
+        )
+      )
+      return
+    }
+    const result = await window.api.shell.openInFileManager(download.savePath)
+    if (!result.ok) {
+      setResourceNotice(
+        translate(
+          'auto.components.browser.pane.BrowserPane.397d9dc923',
+          'Could not show the downloaded file. It may have been moved or deleted.'
+        )
+      )
+    }
+  }, [])
 
   return (
     <div
@@ -4891,60 +4973,127 @@ function BrowserPagePane({
           isActive={isActive}
         />
       </div>
-      {downloadState ? (
-        <div className="flex items-center gap-3 border-b border-border/60 bg-amber-500/10 px-3 py-2 text-xs text-foreground/90">
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-medium text-foreground">{downloadState.filename}</div>
-            <div className="truncate text-muted-foreground">
-              {downloadState.status === 'requested'
-                ? translate(
-                    'auto.components.browser.pane.BrowserPane.31375046b7',
-                    'Download from {{value0}}',
-                    { value0: downloadState.origin }
-                  )
-                : translate(
-                    'auto.components.browser.pane.BrowserPane.4300f38145',
-                    'Downloading from {{value0}}{{value1}}',
-                    {
-                      value0: downloadState.origin,
-                      value1: downloadProgressLabel ? ` • ${downloadProgressLabel}` : ''
-                    }
+      {visibleDownloads.length > 0 ? (
+        <div className="border-b border-border/60 bg-background px-3 py-1.5">
+          <div className="scrollbar-sleek flex max-h-36 flex-col gap-1 overflow-y-auto">
+            {visibleDownloads.map((download) => {
+              const progressLabel = formatBrowserDownloadProgress(download)
+              const statusLabel =
+                download.status === 'downloading'
+                  ? download.progressState === 'interrupted'
+                    ? translate(
+                        'auto.components.browser.pane.BrowserPane.39c04fed61',
+                        'Downloading paused'
+                      )
+                    : (progressLabel ??
+                      translate(
+                        'auto.components.browser.pane.BrowserPane.759f32af29',
+                        'Downloading'
+                      ))
+                  : download.status === 'completed'
+                    ? translate('auto.components.browser.pane.BrowserPane.5c3d530a68', 'Downloaded')
+                    : download.status === 'canceled'
+                      ? translate('auto.components.browser.pane.BrowserPane.4bb7424d6b', 'Canceled')
+                      : (download.error ??
+                        translate(
+                          'auto.components.browser.pane.BrowserPane.6e776f9ef9',
+                          'Download failed'
+                        ))
+              return (
+                <div
+                  key={download.downloadId}
+                  className="flex min-h-8 items-center gap-2 text-xs text-foreground"
+                >
+                  {download.status === 'completed' ? (
+                    <CircleCheck className="size-3.5 shrink-0 text-muted-foreground" />
+                  ) : download.status === 'failed' ? (
+                    <OctagonX className="size-3.5 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <Download className="size-3.5 shrink-0 text-muted-foreground" />
                   )}
-            </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-medium">{download.filename}</div>
+                    <div className="truncate text-muted-foreground">
+                      {download.status === 'downloading'
+                        ? translate(
+                            'auto.components.browser.pane.BrowserPane.4300f38145',
+                            'Downloading from {{value0}}{{value1}}',
+                            {
+                              value0: download.origin,
+                              value1: statusLabel ? ` • ${statusLabel}` : ''
+                            }
+                          )
+                        : statusLabel}
+                    </div>
+                  </div>
+                  {download.status === 'downloading' ? (
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      className="h-6 shrink-0"
+                      onClick={() => {
+                        void window.api.browser.cancelDownload({
+                          downloadId: download.downloadId
+                        })
+                      }}
+                    >
+                      {translate('auto.components.browser.pane.BrowserPane.fa6ea61de3', 'Cancel')}
+                    </Button>
+                  ) : download.status === 'completed' ? (
+                    <>
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        className="h-6 shrink-0 gap-1"
+                        onClick={() => {
+                          void handleOpenDownloadedFile(download)
+                        }}
+                      >
+                        <ExternalLink className="size-3" />
+                        {translate('auto.components.browser.pane.BrowserPane.756bfc25c9', 'Open')}
+                      </Button>
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        className="h-6 shrink-0 gap-1"
+                        onClick={() => {
+                          void handleShowDownloadedFile(download)
+                        }}
+                      >
+                        <FolderOpen className="size-3" />
+                        {translate('auto.components.browser.pane.BrowserPane.09a9489aa5', 'Show')}
+                      </Button>
+                      <Button
+                        size="icon-xs"
+                        variant="ghost"
+                        className="h-6 w-6 shrink-0"
+                        onClick={() => dismissBrowserDownload(download.downloadId)}
+                        aria-label={translate(
+                          'auto.components.browser.pane.BrowserPane.2fdca7df09',
+                          'Dismiss'
+                        )}
+                      >
+                        <X className="size-3.5" />
+                      </Button>
+                    </>
+                  ) : (
+                    <Button
+                      size="icon-xs"
+                      variant="ghost"
+                      className="h-6 w-6 shrink-0"
+                      onClick={() => dismissBrowserDownload(download.downloadId)}
+                      aria-label={translate(
+                        'auto.components.browser.pane.BrowserPane.2fdca7df09',
+                        'Dismiss'
+                      )}
+                    >
+                      <X className="size-3.5" />
+                    </Button>
+                  )}
+                </div>
+              )
+            })}
           </div>
-          {downloadState.status === 'requested' ? (
-            <>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7"
-                onClick={() => {
-                  void window.api.browser.acceptDownload({
-                    downloadId: downloadState.downloadId
-                  })
-                }}
-              >
-                {translate('auto.components.browser.pane.BrowserPane.8b6fab9ffa', 'Save')}
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-7"
-                onClick={() => {
-                  void window.api.browser.cancelDownload({
-                    downloadId: downloadState.downloadId
-                  })
-                }}
-              >
-                {translate('auto.components.browser.pane.BrowserPane.fa6ea61de3', 'Cancel')}
-              </Button>
-            </>
-          ) : (
-            <span className="shrink-0 text-muted-foreground">
-              {downloadProgressLabel ??
-                translate('auto.components.browser.pane.BrowserPane.759f32af29', 'Downloading')}
-            </span>
-          )}
         </div>
       ) : null}
       {resourceNotice ? (

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "Copy",
             "c2f0b72b8d": "Insert",
             "925f49f210": "Expand Pane",
-            "df766809e0": "Collapse Pane",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "Collapse Pane"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Restart daemon",
@@ -8469,8 +8468,8 @@
             "a1f2c8d901": "View"
           },
           "SourceControl": {
-            "conflictsSection": "Conflicts",
             "1406954883": "Clear all notes...",
+            "conflictsSection": "Conflicts",
             "cc05b2d088": "Open in File Explorer",
             "03194cfff4": "Local session state derived from a conflict you opened here.",
             "413a3ba113": "conflict",
@@ -9183,9 +9182,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "View"
           }
         }
       },
@@ -11087,7 +11083,16 @@
             "ea6af700da": "{{value0}} annotation",
             "c13693fe27": "{{value0}} annotations",
             "074f0ed10b": "{{value0}} annotation ready. Select another element or copy all feedback.",
-            "a2164a6e5a": "{{value0}} annotations ready. Select another element or copy all feedback."
+            "a2164a6e5a": "{{value0}} annotations ready. Select another element or copy all feedback.",
+            "9f6f2e8c19": "The downloaded file path is unavailable.",
+            "0c79b7634d": "Could not open the downloaded file. It may have been moved or deleted.",
+            "397d9dc923": "Could not show the downloaded file. It may have been moved or deleted.",
+            "39c04fed61": "Downloading paused",
+            "5c3d530a68": "Downloaded",
+            "4bb7424d6b": "Canceled",
+            "6e776f9ef9": "Download failed",
+            "756bfc25c9": "Open",
+            "09a9489aa5": "Show"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "Cancel",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "Borrar pantalla",
             "8c17d6786d": "Cerrar panel",
-            "copyTerminalId": "Copy Terminal ID",
+            "copyTerminalId": "Copiar ID de terminal",
             "2cf85a6a55": "Copiar ID del panel",
             "39809d152f": "Establecer título…",
             "06c2b0f043": "Igualar tamaños de paneles",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "Borrar pantalla",
             "8c17d6786d": "Cerrar panel",
-            "copyTerminalId": "Copiar ID de terminal",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "Copiar ID del panel",
             "39809d152f": "Establecer título…",
             "06c2b0f043": "Igualar tamaños de paneles",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "Copiar",
             "c2f0b72b8d": "Insertar",
             "925f49f210": "Expandir panel",
-            "df766809e0": "Contraer panel",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "Contraer panel"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Reiniciar demonio",
@@ -8469,8 +8468,8 @@
             "a1f2c8d901": "Ver"
           },
           "SourceControl": {
-            "conflictsSection": "Conflictos",
             "1406954883": "Borrar todas las notas...",
+            "conflictsSection": "Conflictos",
             "cc05b2d088": "Abrir en el Explorador de archivos",
             "03194cfff4": "Estado de la sesión local derivado de un conflicto que abrió aquí.",
             "413a3ba113": "conflicto",
@@ -9106,7 +9105,16 @@
             "daysAgo": "{{value0}}d ago",
             "monthsAgo": "{{value0}}mo ago",
             "yearsAgo": "{{value0}}y ago",
-            "sessionId": "ID de sesión"
+            "sessionId": "ID de sesión",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "Resume {{value0}} session",
@@ -9123,7 +9131,14 @@
             "hideDetails": "Ocultar detalles",
             "showDetails": "Mostrar detalles",
             "moreSessionActions": "Más acciones de sesión",
-            "moreActions": "Más acciones"
+            "moreActions": "Más acciones",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "Buscar archivos",
@@ -9167,9 +9182,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "Ver"
           }
         }
       },
@@ -11071,7 +11083,16 @@
             "ea6af700da": "{{value0}} anotación",
             "c13693fe27": "{{value0}} anotaciones",
             "074f0ed10b": "{{value0}} anotación lista. Seleccione otro elemento o copie todos los comentarios.",
-            "a2164a6e5a": "{{value0}} anotaciones listas. Seleccione otro elemento o copie todos los comentarios."
+            "a2164a6e5a": "{{value0}} anotaciones listas. Seleccione otro elemento o copie todos los comentarios.",
+            "9f6f2e8c19": "The downloaded file path is unavailable.",
+            "0c79b7634d": "Could not open the downloaded file. It may have been moved or deleted.",
+            "397d9dc923": "Could not show the downloaded file. It may have been moved or deleted.",
+            "39c04fed61": "Downloading paused",
+            "5c3d530a68": "Downloaded",
+            "4bb7424d6b": "Canceled",
+            "6e776f9ef9": "Download failed",
+            "756bfc25c9": "Open",
+            "09a9489aa5": "Show"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "Cancelar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "クリアスクリーン",
             "8c17d6786d": "ペインを閉じる",
-            "copyTerminalId": "Terminal ID をコピー",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "ペインIDのコピー",
             "39809d152f": "タイトルを設定…",
             "06c2b0f043": "ペインのサイズを均等化する",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "コピー",
             "c2f0b72b8d": "入れる",
             "925f49f210": "ペインを展開する",
-            "df766809e0": "ペインを折りたたむ",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "ペインを折りたたむ"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "デーモンを再起動します",
@@ -8469,8 +8468,8 @@
             "a1f2c8d901": "表示"
           },
           "SourceControl": {
-            "conflictsSection": "競合",
             "1406954883": "すべてのメモをクリアします...",
+            "conflictsSection": "競合",
             "cc05b2d088": "ファイルエクスプローラーで開く",
             "03194cfff4": "ここで開いた競合から派生したローカル セッション状態。",
             "413a3ba113": "競合",
@@ -9106,7 +9105,16 @@
             "daysAgo": "{{value0}}d ago",
             "monthsAgo": "{{value0}}mo ago",
             "yearsAgo": "{{value0}}y ago",
-            "sessionId": "セッション ID"
+            "sessionId": "セッション ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "Resume {{value0}} session",
@@ -9123,7 +9131,14 @@
             "hideDetails": "詳細を非表示",
             "showDetails": "詳細を表示",
             "moreSessionActions": "セッションのその他の操作",
-            "moreActions": "その他の操作"
+            "moreActions": "その他の操作",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "ファイルを検索",
@@ -9167,9 +9182,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "表示"
           }
         }
       },
@@ -11071,7 +11083,16 @@
             "ea6af700da": "{{value0}} 件の注釈",
             "c13693fe27": "{{value0}} 件の注釈",
             "074f0ed10b": "{{value0}} 件の注釈が準備できました。別の要素を選択するか、すべてのフィードバックをコピーしてください。",
-            "a2164a6e5a": "{{value0}} 件の注釈が準備できました。別の要素を選択するか、すべてのフィードバックをコピーしてください。"
+            "a2164a6e5a": "{{value0}} 件の注釈が準備できました。別の要素を選択するか、すべてのフィードバックをコピーしてください。",
+            "9f6f2e8c19": "The downloaded file path is unavailable.",
+            "0c79b7634d": "Could not open the downloaded file. It may have been moved or deleted.",
+            "397d9dc923": "Could not show the downloaded file. It may have been moved or deleted.",
+            "39c04fed61": "Downloading paused",
+            "5c3d530a68": "Downloaded",
+            "4bb7424d6b": "Canceled",
+            "6e776f9ef9": "Download failed",
+            "756bfc25c9": "Open",
+            "09a9489aa5": "Show"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "キャンセル",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "화면 지우기",
             "8c17d6786d": "창 닫기",
-            "copyTerminalId": "터미널 ID 복사",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "창 ID 복사",
             "39809d152f": "제목 설정…",
             "06c2b0f043": "창 크기 균등화",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "복사",
             "c2f0b72b8d": "삽입",
             "925f49f210": "창 확장",
-            "df766809e0": "창 축소",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "창 축소"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "데몬 재시작",
@@ -8469,8 +8468,8 @@
             "a1f2c8d901": "보기"
           },
           "SourceControl": {
-            "conflictsSection": "충돌",
             "1406954883": "모든 메모 지우기...",
+            "conflictsSection": "충돌",
             "cc05b2d088": "파일 탐색기에서 열기",
             "03194cfff4": "여기에서 연 충돌에서 파생된 로컬 세션 상태입니다.",
             "413a3ba113": "충돌",
@@ -9106,7 +9105,16 @@
             "daysAgo": "{{value0}}일 전",
             "monthsAgo": "{{value0}}개월 전",
             "yearsAgo": "{{value0}}년 전",
-            "sessionId": "세션 ID"
+            "sessionId": "세션 ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "{{value0}} 세션 재개",
@@ -9123,7 +9131,14 @@
             "hideDetails": "세부정보 숨기기",
             "showDetails": "세부정보 표시",
             "moreSessionActions": "세션 추가 작업",
-            "moreActions": "추가 작업"
+            "moreActions": "추가 작업",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "파일 찾기",
@@ -9167,9 +9182,6 @@
                 "copyCommand": "명령 복사"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "보기"
           }
         }
       },
@@ -11071,7 +11083,16 @@
             "ea6af700da": "{{value0}}개 주석",
             "c13693fe27": "{{value0}}개 주석",
             "074f0ed10b": "{{value0}}개 주석이 준비되었습니다. 다른 요소를 선택하거나 모든 피드백을 복사하세요.",
-            "a2164a6e5a": "{{value0}}개 주석이 준비되었습니다. 다른 요소를 선택하거나 모든 피드백을 복사하세요."
+            "a2164a6e5a": "{{value0}}개 주석이 준비되었습니다. 다른 요소를 선택하거나 모든 피드백을 복사하세요.",
+            "9f6f2e8c19": "The downloaded file path is unavailable.",
+            "0c79b7634d": "Could not open the downloaded file. It may have been moved or deleted.",
+            "397d9dc923": "Could not show the downloaded file. It may have been moved or deleted.",
+            "39c04fed61": "Downloading paused",
+            "5c3d530a68": "Downloaded",
+            "4bb7424d6b": "Canceled",
+            "6e776f9ef9": "Download failed",
+            "756bfc25c9": "Open",
+            "09a9489aa5": "Show"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "취소",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "清晰的屏幕",
             "8c17d6786d": "关闭窗格",
-            "copyTerminalId": "Copy Terminal ID",
+            "copyTerminalId": "复制终端 ID",
             "2cf85a6a55": "复制窗格 ID",
             "39809d152f": "设置标题...",
             "06c2b0f043": "均衡窗格大小",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "清晰的屏幕",
             "8c17d6786d": "关闭窗格",
-            "copyTerminalId": "复制终端 ID",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "复制窗格 ID",
             "39809d152f": "设置标题...",
             "06c2b0f043": "均衡窗格大小",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "复制",
             "c2f0b72b8d": "插入",
             "925f49f210": "展开窗格",
-            "df766809e0": "折叠窗格",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "折叠窗格"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "重新启动守护进程",
@@ -8469,8 +8468,8 @@
             "a1f2c8d901": "查看"
           },
           "SourceControl": {
-            "conflictsSection": "冲突",
             "1406954883": "清除所有笔记...",
+            "conflictsSection": "冲突",
             "cc05b2d088": "在文件资源管理器中打开",
             "03194cfff4": "本地会话状态源自您在此处打开的冲突。",
             "413a3ba113": "冲突",
@@ -9106,7 +9105,16 @@
             "daysAgo": "{{value0}} 天前",
             "monthsAgo": "{{value0}} 个月前",
             "yearsAgo": "{{value0}} 年前",
-            "sessionId": "会话 ID"
+            "sessionId": "会话 ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "恢复 {{value0}} 会话",
@@ -9123,7 +9131,14 @@
             "hideDetails": "隐藏详情",
             "showDetails": "显示详情",
             "moreSessionActions": "更多会话操作",
-            "moreActions": "更多操作"
+            "moreActions": "更多操作",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "查找文件",
@@ -9167,9 +9182,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "查看"
           }
         }
       },
@@ -11071,7 +11083,16 @@
             "ea6af700da": "{{value0}} 条注释",
             "c13693fe27": "{{value0}} 条注释",
             "074f0ed10b": "{{value0}} 条注释已准备好。请选择另一个元素或复制所有反馈。",
-            "a2164a6e5a": "{{value0}} 条注释已准备好。请选择另一个元素或复制所有反馈。"
+            "a2164a6e5a": "{{value0}} 条注释已准备好。请选择另一个元素或复制所有反馈。",
+            "9f6f2e8c19": "The downloaded file path is unavailable.",
+            "0c79b7634d": "Could not open the downloaded file. It may have been moved or deleted.",
+            "397d9dc923": "Could not show the downloaded file. It may have been moved or deleted.",
+            "39c04fed61": "Downloading paused",
+            "5c3d530a68": "Downloaded",
+            "4bb7424d6b": "Canceled",
+            "6e776f9ef9": "Download failed",
+            "756bfc25c9": "Open",
+            "09a9489aa5": "Show"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "取消",

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1587,8 +1587,6 @@ function createBrowserApi(): NonNullable<Partial<PreloadApi>['browser']> {
     onActivateView: () => noopUnsubscribe,
     onPaneFocus: () => noopUnsubscribe,
     onOpenLinkInOrcaTab: () => noopUnsubscribe,
-    acceptDownload: () =>
-      Promise.resolve({ ok: false, reason: 'Downloads are handled by the server browser.' }),
     cancelDownload: () => Promise.resolve(false),
     setGrabMode: () =>
       Promise.resolve({

--- a/src/shared/browser-guest-events.ts
+++ b/src/shared/browser-guest-events.ts
@@ -22,15 +22,20 @@ export type BrowserDownloadRequestedEvent = {
   filename: string
   totalBytes: number | null
   mimeType: string | null
+  savePath: string
+  status: 'downloading'
 }
 
 export type BrowserDownloadProgressEvent = {
+  browserPageId?: string
   downloadId: string
   receivedBytes: number
   totalBytes: number | null
+  state: 'progressing' | 'interrupted' | null
 }
 
 export type BrowserDownloadFinishedEvent = {
+  browserPageId?: string
   downloadId: string
   status: 'completed' | 'canceled' | 'failed'
   savePath: string | null


### PR DESCRIPTION
## Summary
- Implements the normal built-in browser download behavior described in [docs/browser-normal-download-behavior.md](https://github.com/stablyai/orca/blob/improve-browser-file-download-behavior/docs/browser-normal-download-behavior.md).
- Auto-saves browser downloads to the OS Downloads folder during Electron `will-download`, with collision-safe destinations and queued pre-registration handling.
- Updates BrowserPane download rows for active/completed downloads with Cancel, Open, Show, and dismiss controls, plus IPC, preload, localization, and tests.

## Validation
- Targeted Vitest: 5 files / 111 tests passed.
- `pnpm typecheck` passed.
- `pnpm lint` passed.
- Electron validation passed for active download, completed download, repeat same filename, multiple downloads, and dismiss/toolbar smoke scenarios.

## Review Artifacts
- Local review screenshots and manifest are intentionally uncommitted under `validation-screenshots/` for final review.