### PR TITLE
Don't show local Windows shells for serve-runtime worktrees

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -76,6 +76,7 @@ import { TabStripScrollIndicator } from './TabStripScrollIndicator'
 import { getTabStripScrollMaskClassName } from './tab-strip-scroll-metrics'
 import { useTabStripOverflowNavigation } from './tab-strip-overflow-navigation'
 import { useTabStripDragScrollHandlers } from './tab-strip-drag-scroll'
+import { shouldShowWindowsShellMenu } from './windows-shell-menu-visibility'
 
 const isWindows = navigator.userAgent.includes('Windows')
 const isMacOs = navigator.userAgent.includes('Mac')
@@ -374,23 +375,14 @@ function TabBarInner({
     windowsTerminalCapabilityOwnerKey,
     runtimeTarget
   )
-  // Why: SSH-backed PTYs ignore local Windows shell overrides; showing these
-  // entries there promises PowerShell/CMD/Git Bash but opens the remote shell.
-  // A serve/remote runtime whose host is not Windows (e.g. a Linux `orca serve`) is
-  // the same situation: the local Windows shell choices are meaningless on that host,
-  // and the plain "New Terminal" already opens the runtime's default shell. Keyed on
-  // the probed runtime host platform so a LOCAL Windows-WSL project runtime
-  // (hostPlatform === 'win32') keeps its shell menu.
-  const runtimeHostIsNonWindows =
-    Boolean(activeRuntimeEnvironmentId?.trim()) &&
-    !windowsTerminalCapabilities.isLoading &&
-    windowsTerminalCapabilities.hostPlatform !== 'win32'
-  const shouldShowWindowsShellMenu =
-    (isWindows || windowsTerminalCapabilities.hostPlatform === 'win32') &&
-    !worktreeHasRemoteConnection &&
-    !runtimeHostIsNonWindows
+  const showWindowsShellMenu = shouldShowWindowsShellMenu({
+    activeRuntimeEnvironmentId,
+    hostPlatform: windowsTerminalCapabilities.hostPlatform,
+    isWindowsClient: isWindows,
+    worktreeHasRemoteConnection
+  })
   const localProjectRuntime = useMemo(() => {
-    if (!shouldShowWindowsShellMenu || activeRuntimeEnvironmentId?.trim()) {
+    if (!showWindowsShellMenu || activeRuntimeEnvironmentId?.trim()) {
       return undefined
     }
     return getLocalProjectExecutionRuntimeContext(
@@ -420,7 +412,7 @@ function TabBarInner({
     projects,
     repos,
     settings,
-    shouldShowWindowsShellMenu,
+    showWindowsShellMenu,
     windowsTerminalCapabilities.isLoading,
     windowsTerminalCapabilities.wslAvailable,
     windowsTerminalCapabilities.wslDistros,
@@ -501,7 +493,7 @@ function TabBarInner({
     pendingNewTabMenuFocusRef.current = () => focusTerminalTabSurface(tabId)
   }
   const windowsShellEntries = useMemo(() => {
-    if (!shouldShowWindowsShellMenu || !onNewTerminalWithShell) {
+    if (!showWindowsShellMenu || !onNewTerminalWithShell) {
       return undefined
     }
     const includeHostShells = projectRuntimeShellMenuMode !== 'wsl'
@@ -548,7 +540,7 @@ function TabBarInner({
     defaultWindowsShell,
     onNewTerminalWithShell,
     projectRuntimeShellMenuMode,
-    shouldShowWindowsShellMenu,
+    showWindowsShellMenu,
     windowsTerminalCapabilities.gitBashAvailable,
     windowsTerminalCapabilities.wslAvailable
   ])

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -376,9 +376,19 @@ function TabBarInner({
   )
   // Why: SSH-backed PTYs ignore local Windows shell overrides; showing these
   // entries there promises PowerShell/CMD/Git Bash but opens the remote shell.
+  // A serve/remote runtime whose host is not Windows (e.g. a Linux `orca serve`) is
+  // the same situation: the local Windows shell choices are meaningless on that host,
+  // and the plain "New Terminal" already opens the runtime's default shell. Keyed on
+  // the probed runtime host platform so a LOCAL Windows-WSL project runtime
+  // (hostPlatform === 'win32') keeps its shell menu.
+  const runtimeHostIsNonWindows =
+    Boolean(activeRuntimeEnvironmentId?.trim()) &&
+    !windowsTerminalCapabilities.isLoading &&
+    windowsTerminalCapabilities.hostPlatform !== 'win32'
   const shouldShowWindowsShellMenu =
     (isWindows || windowsTerminalCapabilities.hostPlatform === 'win32') &&
-    !worktreeHasRemoteConnection
+    !worktreeHasRemoteConnection &&
+    !runtimeHostIsNonWindows
   const localProjectRuntime = useMemo(() => {
     if (!shouldShowWindowsShellMenu || activeRuntimeEnvironmentId?.trim()) {
       return undefined

--- a/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
@@ -751,4 +751,68 @@ describe('TabBar PowerShell launch wiring', () => {
     expect(findDropdownMenuItemByText(expandNode(element), 'New Terminal: PowerShell')).toBeNull()
     expect(findDropdownMenuItemByText(expandNode(element), 'New Terminal')).not.toBeNull()
   })
+
+  it('hides local Windows shell rows for a non-Windows serve runtime', async () => {
+    // Why: a Windows desktop client paired to a Linux `orca serve` runs its PTY on
+    // the serve host. The local Windows shell choices (PowerShell/CMD/WSL) are
+    // meaningless there; the plain "New Terminal" already opens the serve's default
+    // shell. Sibling tests above assert that a win32 remote host still shows the
+    // rows, so the LOCAL Windows-WSL project-runtime menu (hostPlatform 'win32')
+    // is unaffected by this suppression.
+    vi.stubGlobal('navigator', { userAgent: 'Windows' })
+    vi.stubGlobal('__ORCA_WEB_CLIENT__', false)
+    vi.stubGlobal('window', {
+      api: {
+        wsl: {
+          isAvailable: vi.fn().mockResolvedValue(false),
+          listDistros: vi.fn().mockResolvedValue([])
+        },
+        pwsh: { isAvailable: vi.fn().mockResolvedValue(false) },
+        gitBash: { isAvailable: vi.fn().mockResolvedValue(false) },
+        runtime: { getStatus: vi.fn().mockResolvedValue({ hostPlatform: 'linux' }) }
+      }
+    })
+    appStoreSnapshot.activeRuntimeEnvironmentId = 'serve-env-1'
+    const capabilities = await import('@/lib/windows-terminal-capabilities')
+    await capabilities.loadWindowsTerminalCapabilities({
+      force: true,
+      ownerKey: 'runtime:serve-env-1'
+    })
+
+    const tabBarModule = await import('./TabBar')
+    const candidate = tabBarModule.default ?? tabBarModule
+    const TabBar =
+      typeof candidate === 'function'
+        ? candidate
+        : typeof (candidate as { type?: unknown }).type === 'function'
+          ? (candidate as { type: (props: Record<string, unknown>) => unknown }).type
+          : null
+    expect(TabBar).not.toBeNull()
+
+    const element = TabBar!({
+      tabs: [],
+      activeTabId: null,
+      worktreeId: 'wt-1',
+      expandedPaneByTabId: {},
+      onActivate: () => {},
+      onClose: () => {},
+      onCloseOthers: () => {},
+      onCloseToRight: () => {},
+      onNewTerminalTab: () => {},
+      onNewTerminalWithShell: vi.fn(),
+      onNewBrowserTab: () => {},
+      onSetCustomTitle: () => {},
+      onSetTabColor: () => {},
+      onTogglePaneExpand: () => {}
+    })
+
+    expect(
+      findDropdownMenuItemByText(expandNode(element), 'New Terminal: PowerShell')
+    ).toBeNull()
+    expect(
+      findDropdownMenuItemByText(expandNode(element), 'New Terminal: CMD Prompt')
+    ).toBeNull()
+    expect(findDropdownMenuItemByText(expandNode(element), 'New Terminal: WSL')).toBeNull()
+    expect(findDropdownMenuItemByText(expandNode(element), 'New Terminal')).not.toBeNull()
+  })
 })

--- a/src/renderer/src/components/tab-bar/windows-shell-menu-visibility.test.ts
+++ b/src/renderer/src/components/tab-bar/windows-shell-menu-visibility.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowWindowsShellMenu } from './windows-shell-menu-visibility'
+
+describe('shouldShowWindowsShellMenu', () => {
+  it('shows local Windows shells for a local Windows client without a runtime owner', () => {
+    expect(
+      shouldShowWindowsShellMenu({
+        activeRuntimeEnvironmentId: null,
+        hostPlatform: null,
+        isWindowsClient: true,
+        worktreeHasRemoteConnection: false
+      })
+    ).toBe(true)
+  })
+
+  it('keeps the menu hidden while a runtime host platform is unknown', () => {
+    expect(
+      shouldShowWindowsShellMenu({
+        activeRuntimeEnvironmentId: 'serve-env-1',
+        hostPlatform: null,
+        isWindowsClient: true,
+        worktreeHasRemoteConnection: false
+      })
+    ).toBe(false)
+  })
+
+  it('shows runtime Windows shells only after the runtime host is known to be Windows', () => {
+    expect(
+      shouldShowWindowsShellMenu({
+        activeRuntimeEnvironmentId: 'serve-env-1',
+        hostPlatform: 'win32',
+        isWindowsClient: false,
+        worktreeHasRemoteConnection: false
+      })
+    ).toBe(true)
+  })
+
+  it('hides local Windows shells for a non-Windows runtime host', () => {
+    expect(
+      shouldShowWindowsShellMenu({
+        activeRuntimeEnvironmentId: 'serve-env-1',
+        hostPlatform: 'linux',
+        isWindowsClient: true,
+        worktreeHasRemoteConnection: false
+      })
+    ).toBe(false)
+  })
+
+  it('hides local Windows shells for SSH worktrees', () => {
+    expect(
+      shouldShowWindowsShellMenu({
+        activeRuntimeEnvironmentId: null,
+        hostPlatform: 'win32',
+        isWindowsClient: true,
+        worktreeHasRemoteConnection: true
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/tab-bar/windows-shell-menu-visibility.ts
+++ b/src/renderer/src/components/tab-bar/windows-shell-menu-visibility.ts
@@ -1,0 +1,16 @@
+export function shouldShowWindowsShellMenu(args: {
+  activeRuntimeEnvironmentId: string | null | undefined
+  hostPlatform: NodeJS.Platform | null
+  isWindowsClient: boolean
+  worktreeHasRemoteConnection: boolean
+}): boolean {
+  // Why: runtime terminals execute on the runtime host. Until that host is known
+  // to be Windows, local Windows shell choices would advertise the wrong target.
+  const runtimeHostIsNotKnownWindows =
+    Boolean(args.activeRuntimeEnvironmentId?.trim()) && args.hostPlatform !== 'win32'
+  return (
+    (args.isWindowsClient || args.hostPlatform === 'win32') &&
+    !args.worktreeHasRemoteConnection &&
+    !runtimeHostIsNotKnownWindows
+  )
+}


### PR DESCRIPTION
## Summary

Suppresses the local Windows shell submenu when the active terminal runtime host is **not** Windows (e.g. a Linux `orca serve`). On such a host PowerShell/CMD/Git Bash are meaningless, and the plain **"New Terminal"** already opens the runtime's default shell (bash). Mirrors the existing SSH-PTY suppression and applies #5327's principle: shell choices follow the execution host, not the client OS.

**Suppression-only — no new transport, no PowerShell/bash bridge.**

Fixes #5945

## Screenshots

Visual change: on a non-Windows serve runtime, the "+" / `Ctrl+T` menu no longer renders the PowerShell/CMD/Git Bash submenu; it shows the plain "New Terminal" (which opens the serve's default shell). Before/after screenshots of the menu can be attached to the PR conversation.

## Testing

- [x] `pnpm typecheck` — passes
- [x] Added high-quality tests: `TabBar.windows-shell-launch.test.ts` asserts a serve runtime (`hostPlatform: 'linux'`) hides PowerShell/CMD/WSL rows and keeps the plain "New Terminal"; existing `win32`-remote regression cases retained.
- [ ] `pnpm lint` / `pnpm test` / `pnpm build` — see note below

> **Note on lint/test/build:** in my local WSL dev environment `oxlint src/renderer/src/components/tab-bar/TabBar.tsx` is clean in isolation and `typecheck` passes, but the full `lint`/`test`/`build` suites hit pre-existing baseline issues unrelated to this change — `es.json` localization-catalog parity, and a `node-pty`/Electron native-module load error that prevents most renderer test files (including this PR's new test) from executing locally. CI on a clean environment is authoritative for these.

Also verified on a live Windows-client ↔ WSL-serve repro: the Windows shells are suppressed and "New Terminal" opens the serve shell.

## AI Review Report

Reviewed for cross-platform, remote/SSH/local, agent/integration, performance, and security risk:
- **Cross-platform:** behavior unchanged on a native Windows client (`isWindows` / `hostPlatform === 'win32'` still shows the full menu); only a non-Windows **runtime host** suppresses. Keyed on the probed `windowsTerminalCapabilities.hostPlatform !== 'win32'` specifically so #5519's **local Windows-WSL project runtime** (a `win32` host) keeps its 4-shell menu.
- **SSH / remote / local:** reuses the existing `worktreeHasRemoteConnection` SSH suppression and adds the parallel serve-runtime case. Local project runtimes on Windows are explicitly preserved.
- **Agents/integrations:** launching an agent already routes serve-side and is unaffected — only the shell submenu *render* changes.
- **Performance:** one boolean derived from already-computed state; no new probes or renders.

## Security Audit

- **Command execution / shell launch:** no new shell-launch path is added; the change only *removes* nonsensical local-Windows shell entries on non-Windows hosts. No `bash` entry is bolted into the Windows-shell builder (which would route through `resolveWindowsShellLaunchTarget`).
- **Input/IPC/secrets:** no new input handling, IPC surface, auth, or secret handling. No dependency changes.

## Notes

- Renderer (client-side) change only; UI behavior on a non-Windows runtime host.
- No change for native Windows clients or local Windows-WSL project runtimes.

Contributor: GitHub @LesleyMurfin


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5947">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->