### PR TITLE
Move workspace options to the top of worktree context menu

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
@@ -653,6 +654,47 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
           onClickCapture={suppressOpeningPointerEvent}
           onCloseAutoFocus={handleCloseAutoFocus}
         >
+          <DropdownMenuLabel className="px-2 py-1 text-[11px] font-medium text-muted-foreground">
+            {translate('auto.components.sidebar.WorktreeContextMenu.workspaceSection', 'Workspace')}
+          </DropdownMenuLabel>
+          {!isMultiContext && (
+            <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
+              <Pencil className="size-3.5" />
+              {translate('auto.components.sidebar.WorktreeContextMenu.439fa94d53', 'Update')}
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger disabled={deletingContext}>
+              <Kanban className="size-3.5" />
+              {isMultiContext
+                ? translate(
+                    'auto.components.sidebar.WorktreeContextMenu.56cde9e8e6',
+                    'Move Statuses To'
+                  )
+                : translate(
+                    'auto.components.sidebar.WorktreeContextMenu.84cdbb7e30',
+                    'Move to Status'
+                  )}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-44">
+              <DropdownMenuRadioGroup value={contextWorkspaceStatus}>
+                {workspaceStatuses.map((status) => {
+                  const meta = getWorkspaceStatusVisualMeta(status)
+                  return (
+                    <DropdownMenuRadioItem
+                      key={status.id}
+                      value={status.id}
+                      onSelect={() => handleAssignWorkspaceStatus(status.id)}
+                    >
+                      <meta.icon className={cn('size-3.5', meta.tone)} />
+                      {status.label}
+                    </DropdownMenuRadioItem>
+                  )
+                })}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuSeparator />
           {!isMultiContext && (
             <>
               <WorktreeOpenInSubMenu
@@ -765,58 +807,19 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
               )}
             </>
           )}
-          {isMultiContext && (
+          {isMultiContext && hasAnyContextLineage ? (
             <>
-              {hasAnyContextLineage && (
-                <DropdownMenuItem onSelect={handleRemoveParentLink} disabled={deletingContext}>
-                  <Unlink className="size-3.5" />
-                  {translate(
-                    'auto.components.sidebar.WorktreeContextMenu.579b1a8e61',
-                    'Remove from Parent'
-                  )}
-                </DropdownMenuItem>
-              )}
+              <DropdownMenuItem onSelect={handleRemoveParentLink} disabled={deletingContext}>
+                <Unlink className="size-3.5" />
+                {translate(
+                  'auto.components.sidebar.WorktreeContextMenu.579b1a8e61',
+                  'Remove from Parent'
+                )}
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
             </>
-          )}
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger disabled={deletingContext}>
-              <Kanban className="size-3.5" />
-              {isMultiContext
-                ? translate(
-                    'auto.components.sidebar.WorktreeContextMenu.56cde9e8e6',
-                    'Move Statuses To'
-                  )
-                : translate(
-                    'auto.components.sidebar.WorktreeContextMenu.84cdbb7e30',
-                    'Move to Status'
-                  )}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="w-44">
-              <DropdownMenuRadioGroup value={contextWorkspaceStatus}>
-                {workspaceStatuses.map((status) => {
-                  const meta = getWorkspaceStatusVisualMeta(status)
-                  return (
-                    <DropdownMenuRadioItem
-                      key={status.id}
-                      value={status.id}
-                      onSelect={() => handleAssignWorkspaceStatus(status.id)}
-                    >
-                      <meta.icon className={cn('size-3.5', meta.tone)} />
-                      {status.label}
-                    </DropdownMenuRadioItem>
-                  )
-                })}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          {!isMultiContext && (
-            <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
-              <Pencil className="size-3.5" />
-              {translate('auto.components.sidebar.WorktreeContextMenu.439fa94d53', 'Update')}
-            </DropdownMenuItem>
-          )}
-          <DropdownMenuSeparator />
+          ) : null}
+
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuItem

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3877,7 +3877,8 @@
           "697d0f6e1b": "Unpin",
           "250de158fd": "Remove Workspace",
           "changeParentWorkspace": "Change Parent Worktree...",
-          "setParentWorkspace": "Set Parent Worktree..."
+          "setParentWorkspace": "Set Parent Worktree...",
+          "workspaceSection": "Workspace"
         },
         "WorktreeList": {
           "7a8b9c0d1e": "Update required",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3863,7 +3863,8 @@
           "697d0f6e1b": "Desprender",
           "250de158fd": "Remove Workspace",
           "changeParentWorkspace": "Cambiar árbol de trabajo padre...",
-          "setParentWorkspace": "Establecer árbol de trabajo padre..."
+          "setParentWorkspace": "Establecer árbol de trabajo padre...",
+          "workspaceSection": "Espacio de trabajo"
         },
         "WorktreeList": {
           "d880ea0744": "Crea un grupo y mueve este proyecto a él.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3844,7 +3844,8 @@
           "697d0f6e1b": "固定を解除する",
           "250de158fd": "Remove Workspace",
           "changeParentWorkspace": "親ワークツリーを変更...",
-          "setParentWorkspace": "親ワークツリーを設定..."
+          "setParentWorkspace": "親ワークツリーを設定...",
+          "workspaceSection": "ワークスペース"
         },
         "WorktreeList": {
           "d880ea0744": "グループを作成し、このプロジェクトをそのグループに移動します。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3844,7 +3844,8 @@
           "697d0f6e1b": "고정 해제",
           "250de158fd": "워크스페이스 제거",
           "changeParentWorkspace": "상위 워크트리 변경...",
-          "setParentWorkspace": "상위 워크트리 설정..."
+          "setParentWorkspace": "상위 워크트리 설정...",
+          "workspaceSection": "워크스페이스"
         },
         "WorktreeList": {
           "d880ea0744": "그룹을 만들고 이 프로젝트를 그룹으로 이동하세요.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3844,7 +3844,8 @@
           "697d0f6e1b": "取消固定",
           "250de158fd": "移除工作区",
           "changeParentWorkspace": "更改父工作树...",
-          "setParentWorkspace": "设置父工作树..."
+          "setParentWorkspace": "设置父工作树...",
+          "workspaceSection": "工作区"
         },
         "WorktreeList": {
           "d880ea0744": "创建一个组并将该项目移入其中。",


### PR DESCRIPTION
## Summary

Moves workspace options (including the "Update" action and "Move to Status" sub-menu) to the top of the worktree context menu under a new "Workspace" section label. This improves menu usability and hierarchy by highlighting primary workspace actions.

## Screenshots

- UI changes: The worktree context menu now starts with a localized "Workspace" label containing "Update" and "Move to Status" options.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

- Verified the repositioned elements maintain their original React props and event handlers.
- Confirmed cross-platform compatibility across macOS, Linux, and Windows. Layout reordering is purely CSS/Renderer-based and contains no OS-specific system menus, custom shortcuts, or local path dependencies.
- Confirmed the translation key `workspaceSection` was successfully added and localized across all supported languages.

## Security Audit

- Restructured menu layout contains no IPC channel alterations, dynamic string interpolation, shell execution, or sensitive data access.

## Notes

No platform-specific risks or follow-up required.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5948">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->