### PR TITLE
feat(diff): per-hunk stage/unstage in the combined diff viewer

### DIFF
--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -993,6 +993,106 @@ export function gitSpawn(
   })
 }
 
+/** Run git with a stdin payload (async execFile can't); via gitSpawn so WSL
+ * routing is preserved. Feeds `git apply --cached` a patch without a temp file. */
+export async function gitExecFileWithStdin(
+  args: string[],
+  options: {
+    cwd: string
+    wslDistro?: string
+    env?: NodeJS.ProcessEnv
+    maxBuffer?: number
+    signal?: AbortSignal
+  },
+  input: string
+): Promise<{ stdout: string; stderr: string }> {
+  const maxBuffer = options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER
+  return withGitSpan({ args, cwd: options.cwd }, async () => {
+    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      if (options.signal?.aborted) {
+        reject(createAbortError())
+        return
+      }
+      const child = gitSpawn(args, {
+        cwd: options.cwd,
+        env: nonInteractiveGitEnv(options.env),
+        stdio: ['pipe', 'pipe', 'pipe'],
+        wslDistro: options.wslDistro,
+        windowsHide: true
+      })
+      let settled = false
+      let stdout = ''
+      let stderr = ''
+      let stdoutBytes = 0
+      let stderrBytes = 0
+      const stdoutDecoder = new StringDecoder('utf8')
+      const stderrDecoder = new StringDecoder('utf8')
+      const cleanup = (): void => {
+        options.signal?.removeEventListener('abort', onAbort)
+        child.stdout?.off('data', onStdout)
+        child.stderr?.off('data', onStderr)
+        child.off('error', onError)
+        child.off('close', onClose)
+        stdoutDecoder.end()
+        stderrDecoder.end()
+      }
+      const finish = (error: Error | null): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanup()
+        if (error) {
+          reject(Object.assign(error, { stdout, stderr }))
+          return
+        }
+        resolve({ stdout, stderr })
+      }
+      const onAbort = (): void => {
+        killSpawnedCommandTree(child)
+        finish(createAbortError())
+      }
+      function onStdout(chunk: Buffer): void {
+        stdoutBytes += chunk.byteLength
+        if (stdoutBytes > maxBuffer) {
+          killSpawnedCommandTree(child)
+          finish(new Error('git stdout exceeded maxBuffer.'))
+          return
+        }
+        stdout += stdoutDecoder.write(chunk)
+      }
+      function onStderr(chunk: Buffer): void {
+        stderrBytes += chunk.byteLength
+        if (stderrBytes > maxBuffer) {
+          killSpawnedCommandTree(child)
+          finish(new Error('git stderr exceeded maxBuffer.'))
+          return
+        }
+        stderr += stderrDecoder.write(chunk)
+      }
+      function onError(error: Error): void {
+        finish(error)
+      }
+      function onClose(code: number | null): void {
+        if (code === 0) {
+          finish(null)
+          return
+        }
+        finish(new Error(`git exited with ${code}: ${stderr.trim()}`))
+      }
+      child.stdout?.on('data', onStdout)
+      child.stderr?.on('data', onStderr)
+      child.on('error', onError)
+      child.on('close', onClose)
+      // Why: git can exit (e.g. malformed patch) before draining stdin, raising
+      // EPIPE on the write. Swallow it — onClose already surfaces the failure.
+      child.stdin?.on('error', () => {})
+      child.stdin?.end(input)
+      options.signal?.addEventListener('abort', onAbort, { once: true })
+    })
+  })
+}
+
 // ─── gh CLI runners ─────────────────────────────────────────────────
 
 // Why: non-repo-scoped gh calls (listAccessibleProjects, rate_limit, etc.)

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -1084,11 +1084,20 @@ export async function gitExecFileWithStdin(
       child.stderr?.on('data', onStderr)
       child.on('error', onError)
       child.on('close', onClose)
+      // Why: register before writing stdin and re-check — a signal that aborts in
+      // this window would otherwise be missed (a late listener doesn't fire
+      // retroactively on an already-aborted signal).
+      if (options.signal) {
+        options.signal.addEventListener('abort', onAbort, { once: true })
+        if (options.signal.aborted) {
+          onAbort()
+          return
+        }
+      }
       // Why: git can exit (e.g. malformed patch) before draining stdin, raising
       // EPIPE on the write. Swallow it — onClose already surfaces the failure.
       child.stdin?.on('error', () => {})
       child.stdin?.end(input)
-      options.signal?.addEventListener('abort', onAbort, { once: true })
     })
   })
 }

--- a/src/main/git/status-hunk-patch.test.ts
+++ b/src/main/git/status-hunk-patch.test.ts
@@ -48,7 +48,7 @@ describe('per-hunk index patching', () => {
     const parsed = parseFileDiff(patch)
     expect(parsed.hunks).toHaveLength(2)
 
-    await applyIndexPatch(repo, buildHunkPatch(parsed, [0]), false)
+    await applyIndexPatch(repo, 'file.txt', buildHunkPatch(parsed, [0]), false)
 
     expect(cachedDiff(repo)).toContain('+2x')
     expect(cachedDiff(repo)).not.toContain('+11x')
@@ -66,7 +66,7 @@ describe('per-hunk index patching', () => {
     const parsed = parseFileDiff(staged)
     expect(parsed.hunks).toHaveLength(2)
 
-    await applyIndexPatch(repo, buildHunkPatch(parsed, [0]), true)
+    await applyIndexPatch(repo, 'file.txt', buildHunkPatch(parsed, [0]), true)
 
     expect(cachedDiff(repo)).not.toContain('+2x')
     expect(cachedDiff(repo)).toContain('+11x')
@@ -78,7 +78,21 @@ describe('per-hunk index patching', () => {
     const parsed = parseFileDiff(patch)
     // Stage everything first so the worktree-vs-index hunk no longer applies.
     execFileSync('git', ['add', 'file.txt'], { cwd: repo })
+    const cachedBefore = cachedDiff(repo)
 
-    await expect(applyIndexPatch(repo, buildHunkPatch(parsed, [0]), false)).rejects.toThrow()
+    await expect(
+      applyIndexPatch(repo, 'file.txt', buildHunkPatch(parsed, [0]), false)
+    ).rejects.toThrow()
+    expect(cachedDiff(repo)).toBe(cachedBefore)
+  })
+
+  it('rejects a patch that targets a different path', async () => {
+    const repo = await createRepo()
+    const patch = await getFileDiffPatch(repo, 'file.txt', false)
+    const parsed = parseFileDiff(patch)
+
+    await expect(
+      applyIndexPatch(repo, 'other.ts', buildHunkPatch(parsed, [0]), false)
+    ).rejects.toThrow(/expected path/)
   })
 })

--- a/src/main/git/status-hunk-patch.test.ts
+++ b/src/main/git/status-hunk-patch.test.ts
@@ -95,4 +95,28 @@ describe('per-hunk index patching', () => {
       applyIndexPatch(repo, 'other.ts', buildHunkPatch(parsed, [0]), false)
     ).rejects.toThrow(/expected path/)
   })
+
+  // Why: git octal-quotes non-ASCII and leaves spaces literal; getFileDiffPatch
+  // forces core.quotePath=false so the header path still matches the validated one.
+  it.each(['my file.ts', 'café.ts'])('stages a hunk in a file named %s', async (name) => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'orca-hunk-name-'))
+    tempRoots.push(repo)
+    execFileSync('git', ['init', '-q'], { cwd: repo })
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo })
+    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo })
+    await writeFile(path.join(repo, name), ORIGINAL)
+    execFileSync('git', ['add', '--', name], { cwd: repo })
+    execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: repo })
+    await writeFile(path.join(repo, name), MODIFIED)
+
+    const parsed = parseFileDiff(await getFileDiffPatch(repo, name, false))
+    expect(parsed.hunks.length).toBeGreaterThan(0)
+    await applyIndexPatch(repo, name, buildHunkPatch(parsed, [0]), false)
+
+    const cached = execFileSync('git', ['diff', '--cached', '--', name], {
+      cwd: repo,
+      encoding: 'utf8'
+    })
+    expect(cached).toContain('+2x')
+  })
 })

--- a/src/main/git/status-hunk-patch.test.ts
+++ b/src/main/git/status-hunk-patch.test.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from 'child_process'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import * as path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { buildHunkPatch, parseFileDiff } from '../../shared/git-hunk-patch'
+import { applyIndexPatch, getFileDiffPatch } from './status'
+
+const tempRoots: string[] = []
+
+// Why: two changes far enough apart (3+ context lines) to land in separate git
+// hunks, so a single-hunk patch can be staged while the other stays unstaged.
+const ORIGINAL = `${Array.from({ length: 12 }, (_, i) => String(i + 1)).join('\n')}\n`
+const MODIFIED = ORIGINAL.replace('2\n', '2x\n').replace('11\n', '11x\n')
+
+async function createRepo(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), 'orca-hunk-patch-'))
+  tempRoots.push(repo)
+  execFileSync('git', ['init', '-q'], { cwd: repo })
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo })
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo })
+  await writeFile(path.join(repo, 'file.txt'), ORIGINAL)
+  execFileSync('git', ['add', 'file.txt'], { cwd: repo })
+  execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: repo })
+  await writeFile(path.join(repo, 'file.txt'), MODIFIED)
+  return repo
+}
+
+function cachedDiff(repo: string): string {
+  return execFileSync('git', ['diff', '--cached', '--', 'file.txt'], {
+    cwd: repo,
+    encoding: 'utf8'
+  })
+}
+
+function worktreeDiff(repo: string): string {
+  return execFileSync('git', ['diff', '--', 'file.txt'], { cwd: repo, encoding: 'utf8' })
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('per-hunk index patching', () => {
+  it('stages only the selected hunk and leaves the rest unstaged', async () => {
+    const repo = await createRepo()
+    const patch = await getFileDiffPatch(repo, 'file.txt', false)
+    const parsed = parseFileDiff(patch)
+    expect(parsed.hunks).toHaveLength(2)
+
+    await applyIndexPatch(repo, buildHunkPatch(parsed, [0]), false)
+
+    expect(cachedDiff(repo)).toContain('+2x')
+    expect(cachedDiff(repo)).not.toContain('+11x')
+    // The unselected change is still a working-tree-only modification.
+    expect(worktreeDiff(repo)).toContain('+11x')
+  })
+
+  it('unstages only the selected hunk with reverse', async () => {
+    const repo = await createRepo()
+    execFileSync('git', ['add', 'file.txt'], { cwd: repo })
+    expect(cachedDiff(repo)).toContain('+2x')
+    expect(cachedDiff(repo)).toContain('+11x')
+
+    const staged = await getFileDiffPatch(repo, 'file.txt', true)
+    const parsed = parseFileDiff(staged)
+    expect(parsed.hunks).toHaveLength(2)
+
+    await applyIndexPatch(repo, buildHunkPatch(parsed, [0]), true)
+
+    expect(cachedDiff(repo)).not.toContain('+2x')
+    expect(cachedDiff(repo)).toContain('+11x')
+  })
+
+  it('rejects a stale patch without corrupting the index', async () => {
+    const repo = await createRepo()
+    const patch = await getFileDiffPatch(repo, 'file.txt', false)
+    const parsed = parseFileDiff(patch)
+    // Stage everything first so the worktree-vs-index hunk no longer applies.
+    execFileSync('git', ['add', 'file.txt'], { cwd: repo })
+
+    await expect(applyIndexPatch(repo, buildHunkPatch(parsed, [0]), false)).rejects.toThrow()
+  })
+})

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -29,6 +29,7 @@ import {
   type GitLineStats
 } from '../../shared/git-uncommitted-line-stats'
 import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
+import { patchTouchesOnlyPath } from '../../shared/git-hunk-patch'
 import {
   gitExecFileAsync,
   gitExecFileAsyncBuffer,
@@ -1223,10 +1224,16 @@ export async function getFileDiffPatch(
  * atomic, so a stale patch fails cleanly instead of corrupting the index. */
 export async function applyIndexPatch(
   worktreePath: string,
+  filePath: string,
   patch: string,
   reverse: boolean,
   options: GitRuntimeOptions = {}
 ): Promise<void> {
+  // Why: git apply honors every file header in the patch, so reject one that
+  // targets anything other than the validated path before it reaches the index.
+  if (!patchTouchesOnlyPath(patch, filePath)) {
+    throw new Error(`Patch does not match the expected path "${filePath}"`)
+  }
   await gitExecFileWithStdin(
     ['apply', '--cached', ...(reverse ? ['--reverse'] : [])],
     gitOptionsForWorktree(worktreePath, options),

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -1208,6 +1208,10 @@ export async function getFileDiffPatch(
 ): Promise<string> {
   const { stdout } = await gitExecFileAsync(
     [
+      // Why: emit paths literally (no octal-quoting of non-ASCII) so the patch's
+      // file headers match the validated path; git quotes unicode otherwise.
+      '-c',
+      'core.quotePath=false',
       'diff',
       ...(staged ? ['--cached'] : []),
       '--no-color',

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -32,6 +32,7 @@ import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
 import {
   gitExecFileAsync,
   gitExecFileAsyncBuffer,
+  gitExecFileWithStdin,
   gitOptionalLocksDisabledEnv,
   gitStreamStdout
 } from './runner'
@@ -1195,6 +1196,42 @@ export async function unstageFile(
   await gitExecFileAsync(['restore', '--staged', '--', literalPathspec(filePath)], {
     ...gitOptionsForWorktree(worktreePath, options)
   })
+}
+
+/** Raw unified diff for one file (staged = index-vs-HEAD, else worktree-vs-index). */
+export async function getFileDiffPatch(
+  worktreePath: string,
+  filePath: string,
+  staged: boolean,
+  options: GitRuntimeOptions = {}
+): Promise<string> {
+  const { stdout } = await gitExecFileAsync(
+    [
+      'diff',
+      ...(staged ? ['--cached'] : []),
+      '--no-color',
+      '--no-ext-diff',
+      '--',
+      literalPathspec(filePath)
+    ],
+    { ...gitOptionsForWorktree(worktreePath, options), maxBuffer: MAX_GIT_SHOW_BYTES }
+  )
+  return stdout
+}
+
+/** Apply a unified patch to the index only (reverse unstages). git apply is
+ * atomic, so a stale patch fails cleanly instead of corrupting the index. */
+export async function applyIndexPatch(
+  worktreePath: string,
+  patch: string,
+  reverse: boolean,
+  options: GitRuntimeOptions = {}
+): Promise<void> {
+  await gitExecFileWithStdin(
+    ['apply', '--cached', ...(reverse ? ['--reverse'] : [])],
+    gitOptionsForWorktree(worktreePath, options),
+    patch
+  )
 }
 
 export async function getStagedCommitContext(

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1823,23 +1823,26 @@ export function registerFilesystemHandlers(
         connectionId?: string
       }
     ): Promise<void> => {
+      // Why: coerce to a strict boolean so a malformed payload (e.g. the string
+      // 'false') can't apply the patch in the wrong direction. Matches git:push.
+      const reverse = args.reverse === true
       if (args.connectionId) {
         const provider = getSshGitProvider(args.connectionId)
         if (!provider) {
           throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
         }
-        return provider.applyIndexPatch(args.worktreePath, args.patch, args.reverse)
+        return provider.applyIndexPatch(args.worktreePath, args.filePath, args.patch, reverse)
       }
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       // Why: confine to the worktree before applying, matching stage/unstage —
       // git apply also rejects patch paths escaping the repo as defense in depth.
-      validateGitRelativeFilePath(worktreePath, args.filePath)
+      const filePath = validateGitRelativeFilePath(worktreePath, args.filePath)
       const gitOptions = getLocalGitOptionsForRegisteredWorktree(
         store,
         args.worktreePath,
         worktreePath
       )
-      await applyIndexPatch(worktreePath, args.patch, args.reverse, gitOptions)
+      await applyIndexPatch(worktreePath, filePath, args.patch, reverse, gitOptions)
     }
   )
 

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -43,6 +43,8 @@ import {
   commitChanges,
   stageFile,
   unstageFile,
+  getFileDiffPatch,
+  applyIndexPatch,
   bulkStageFiles,
   bulkUnstageFiles,
   bulkDiscardChanges,
@@ -1780,6 +1782,64 @@ export function registerFilesystemHandlers(
         worktreePath
       )
       await unstageFile(worktreePath, filePath, gitOptions)
+    }
+  )
+
+  ipcMain.handle(
+    'git:diffPatch',
+    async (
+      _event,
+      args: { worktreePath: string; filePath: string; staged: boolean; connectionId?: string }
+    ): Promise<{ patch: string }> => {
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return {
+          patch: await provider.getFileDiffPatch(args.worktreePath, args.filePath, args.staged)
+        }
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const filePath = validateGitRelativeFilePath(worktreePath, args.filePath)
+      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+        store,
+        args.worktreePath,
+        worktreePath
+      )
+      return { patch: await getFileDiffPatch(worktreePath, filePath, args.staged, gitOptions) }
+    }
+  )
+
+  ipcMain.handle(
+    'git:applyPatch',
+    async (
+      _event,
+      args: {
+        worktreePath: string
+        filePath: string
+        patch: string
+        reverse: boolean
+        connectionId?: string
+      }
+    ): Promise<void> => {
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return provider.applyIndexPatch(args.worktreePath, args.patch, args.reverse)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      // Why: confine to the worktree before applying, matching stage/unstage —
+      // git apply also rejects patch paths escaping the repo as defense in depth.
+      validateGitRelativeFilePath(worktreePath, args.filePath)
+      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+        store,
+        args.worktreePath,
+        worktreePath
+      )
+      await applyIndexPatch(worktreePath, args.patch, args.reverse, gitOptions)
     }
   )
 

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -342,8 +342,13 @@ export class SshGitProvider implements IGitProvider {
     return result.patch
   }
 
-  async applyIndexPatch(worktreePath: string, patch: string, reverse: boolean): Promise<void> {
-    await this.mux.request('git.applyPatch', { worktreePath, patch, reverse })
+  async applyIndexPatch(
+    worktreePath: string,
+    filePath: string,
+    patch: string,
+    reverse: boolean
+  ): Promise<void> {
+    await this.mux.request('git.applyPatch', { worktreePath, filePath, patch, reverse })
   }
 
   async bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void> {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -333,6 +333,19 @@ export class SshGitProvider implements IGitProvider {
     await this.mux.request('git.unstage', { worktreePath, filePath })
   }
 
+  async getFileDiffPatch(worktreePath: string, filePath: string, staged: boolean): Promise<string> {
+    const result = (await this.mux.request('git.diffPatch', {
+      worktreePath,
+      filePath,
+      staged
+    })) as { patch: string }
+    return result.patch
+  }
+
+  async applyIndexPatch(worktreePath: string, patch: string, reverse: boolean): Promise<void> {
+    await this.mux.request('git.applyPatch', { worktreePath, patch, reverse })
+  }
+
   async bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
     await this.mux.request('git.bulkStage', { worktreePath, filePaths })
   }

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -179,6 +179,8 @@ export type IGitProvider = {
   ): Promise<GitDiffResult>
   stageFile(worktreePath: string, filePath: string): Promise<void>
   unstageFile(worktreePath: string, filePath: string): Promise<void>
+  getFileDiffPatch(worktreePath: string, filePath: string, staged: boolean): Promise<string>
+  applyIndexPatch(worktreePath: string, patch: string, reverse: boolean): Promise<void>
   bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void>
   bulkUnstageFiles(worktreePath: string, filePaths: string[]): Promise<void>
   discardChanges(worktreePath: string, filePath: string): Promise<void>

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -180,7 +180,12 @@ export type IGitProvider = {
   stageFile(worktreePath: string, filePath: string): Promise<void>
   unstageFile(worktreePath: string, filePath: string): Promise<void>
   getFileDiffPatch(worktreePath: string, filePath: string, staged: boolean): Promise<string>
-  applyIndexPatch(worktreePath: string, patch: string, reverse: boolean): Promise<void>
+  applyIndexPatch(
+    worktreePath: string,
+    filePath: string,
+    patch: string,
+    reverse: boolean
+  ): Promise<void>
   bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void>
   bulkUnstageFiles(worktreePath: string, filePaths: string[]): Promise<void>
   discardChanges(worktreePath: string, filePath: string): Promise<void>

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -827,6 +827,7 @@ export class RuntimeGitCommands {
     return { ok: true }
   }
 
+  /** Raw unified diff for one file in a runtime worktree (local or SSH). */
   async getRuntimeGitFileDiffPatch(
     worktreeSelector: string,
     filePath: string,
@@ -851,6 +852,7 @@ export class RuntimeGitCommands {
     }
   }
 
+  /** Apply a hunk patch to the index of a runtime worktree (reverse unstages). */
   async applyRuntimeGitIndexPatch(
     worktreeSelector: string,
     filePath: string,
@@ -858,18 +860,24 @@ export class RuntimeGitCommands {
     reverse: boolean
   ): Promise<{ ok: true }> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
-    // Why: enforce the same worktree-confinement contract as other mutations,
-    // even though the patch body carries its own (git-validated) paths.
-    normalizeRuntimeGitRelativePath(filePath)
+    // Why: confine to the worktree, and bind the patch to this path so it can't
+    // stage unrelated files (enforced again in applyIndexPatch / the relay).
+    const relativePath = normalizeRuntimeGitRelativePath(filePath)
     const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
     if (target.connectionId) {
       if (!provider) {
         throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
       }
-      await provider.applyIndexPatch(target.worktree.path, patch, reverse)
+      await provider.applyIndexPatch(target.worktree.path, relativePath, patch, reverse)
       return { ok: true }
     }
-    await applyIndexPatch(target.worktree.path, patch, reverse, localGitOptionsForTarget(target))
+    await applyIndexPatch(
+      target.worktree.path,
+      relativePath,
+      patch,
+      reverse,
+      localGitOptionsForTarget(target)
+    )
     return { ok: true }
   }
 

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -27,6 +27,7 @@ import { getRemoteCommitUrl, getRemoteFileUrl } from '../git/repo'
 import {
   abortMerge,
   abortRebase,
+  applyIndexPatch,
   bulkDiscardChanges,
   bulkStageFiles,
   bulkUnstageFiles,
@@ -38,6 +39,7 @@ import {
   getCommitCompare,
   getCommitDiff,
   getDiff,
+  getFileDiffPatch,
   getStagedCommitContext,
   getStatus as getGitStatus,
   stageFile,
@@ -822,6 +824,52 @@ export class RuntimeGitCommands {
       return { ok: true }
     }
     await unstageFile(target.worktree.path, relativePath, localGitOptionsForTarget(target))
+    return { ok: true }
+  }
+
+  async getRuntimeGitFileDiffPatch(
+    worktreeSelector: string,
+    filePath: string,
+    staged: boolean
+  ): Promise<{ patch: string }> {
+    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const relativePath = normalizeRuntimeGitRelativePath(filePath)
+    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+    if (target.connectionId) {
+      if (!provider) {
+        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+      }
+      return { patch: await provider.getFileDiffPatch(target.worktree.path, relativePath, staged) }
+    }
+    return {
+      patch: await getFileDiffPatch(
+        target.worktree.path,
+        relativePath,
+        staged,
+        localGitOptionsForTarget(target)
+      )
+    }
+  }
+
+  async applyRuntimeGitIndexPatch(
+    worktreeSelector: string,
+    filePath: string,
+    patch: string,
+    reverse: boolean
+  ): Promise<{ ok: true }> {
+    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    // Why: enforce the same worktree-confinement contract as other mutations,
+    // even though the patch body carries its own (git-validated) paths.
+    normalizeRuntimeGitRelativePath(filePath)
+    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+    if (target.connectionId) {
+      if (!provider) {
+        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+      }
+      await provider.applyIndexPatch(target.worktree.path, patch, reverse)
+      return { ok: true }
+    }
+    await applyIndexPatch(target.worktree.path, patch, reverse, localGitOptionsForTarget(target))
     return { ok: true }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4628,6 +4628,10 @@ export class OrcaRuntimeService {
     this.gitCommands.stageRuntimeGitPath.bind(this.gitCommands)
   unstageRuntimeGitPath: RuntimeGitCommands['unstageRuntimeGitPath'] =
     this.gitCommands.unstageRuntimeGitPath.bind(this.gitCommands)
+  getRuntimeGitFileDiffPatch: RuntimeGitCommands['getRuntimeGitFileDiffPatch'] =
+    this.gitCommands.getRuntimeGitFileDiffPatch.bind(this.gitCommands)
+  applyRuntimeGitIndexPatch: RuntimeGitCommands['applyRuntimeGitIndexPatch'] =
+    this.gitCommands.applyRuntimeGitIndexPatch.bind(this.gitCommands)
   bulkStageRuntimeGitPaths: RuntimeGitCommands['bulkStageRuntimeGitPaths'] =
     this.gitCommands.bulkStageRuntimeGitPaths.bind(this.gitCommands)
   bulkUnstageRuntimeGitPaths: RuntimeGitCommands['bulkUnstageRuntimeGitPaths'] =

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -27,6 +27,18 @@ export const GitDiff = GitFilePath.extend({
   compareAgainstHead: z.boolean().optional()
 })
 
+export const GitDiffPatch = GitFilePath.extend({
+  staged: z.boolean()
+})
+
+export const GitApplyPatch = GitFilePath.extend({
+  patch: z
+    .unknown()
+    .transform((v) => (typeof v === 'string' ? v : ''))
+    .pipe(z.string().min(1, 'Missing patch')),
+  reverse: z.boolean()
+})
+
 export const GitBranchCompare = WorktreeSelector.extend({
   baseRef: z
     .unknown()

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -13,6 +13,8 @@ import {
   GitCommitDiff,
   GitDiscoverCommitMessageModels,
   GitDiff,
+  GitDiffPatch,
+  GitApplyPatch,
   GitFilePath,
   GitForkSync,
   GitGenerateCommitMessage,
@@ -312,6 +314,23 @@ export const GIT_METHODS: RpcMethod[] = [
     params: GitFilePath,
     handler: async (params, { runtime }) =>
       runtime.unstageRuntimeGitPath(params.worktree, params.filePath)
+  }),
+  defineMethod({
+    name: 'git.diffPatch',
+    params: GitDiffPatch,
+    handler: async (params, { runtime }) =>
+      runtime.getRuntimeGitFileDiffPatch(params.worktree, params.filePath, params.staged)
+  }),
+  defineMethod({
+    name: 'git.applyPatch',
+    params: GitApplyPatch,
+    handler: async (params, { runtime }) =>
+      runtime.applyRuntimeGitIndexPatch(
+        params.worktree,
+        params.filePath,
+        params.patch,
+        params.reverse
+      )
   }),
   defineMethod({
     name: 'git.bulkUnstage',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2270,6 +2270,19 @@ export type PreloadApi = {
       filePath: string
       connectionId?: string
     }) => Promise<void>
+    diffPatch: (args: {
+      worktreePath: string
+      filePath: string
+      staged: boolean
+      connectionId?: string
+    }) => Promise<{ patch: string }>
+    applyPatch: (args: {
+      worktreePath: string
+      filePath: string
+      patch: string
+      reverse: boolean
+      connectionId?: string
+    }) => Promise<void>
     bulkUnstage: (args: {
       worktreePath: string
       filePaths: string[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2664,6 +2664,19 @@ const api = {
       filePath: string
       connectionId?: string
     }): Promise<void> => ipcRenderer.invoke('git:unstage', args),
+    diffPatch: (args: {
+      worktreePath: string
+      filePath: string
+      staged: boolean
+      connectionId?: string
+    }): Promise<{ patch: string }> => ipcRenderer.invoke('git:diffPatch', args),
+    applyPatch: (args: {
+      worktreePath: string
+      filePath: string
+      patch: string
+      reverse: boolean
+      connectionId?: string
+    }): Promise<void> => ipcRenderer.invoke('git:applyPatch', args),
     bulkUnstage: (args: {
       worktreePath: string
       filePaths: string[]

--- a/src/relay/git-handler-hunk-staging.test.ts
+++ b/src/relay/git-handler-hunk-staging.test.ts
@@ -1,0 +1,108 @@
+// Relay per-hunk diff/apply round-trip (diffPatch -> build -> applyPatch); split
+// from git-handler-staging.test.ts to stay under the max-lines cap.
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import * as path from 'path'
+import * as fs from 'fs/promises'
+import { mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { execFileSync } from 'child_process'
+import { GitHandler } from './git-handler'
+import { RelayContext } from './context'
+import { buildHunkPatch, parseFileDiff } from '../shared/git-hunk-patch'
+import {
+  createMockDispatcher,
+  gitInit,
+  gitCommit,
+  type MockDispatcher,
+  type RelayDispatcher
+} from './git-handler-test-setup'
+
+const ORIGINAL = `${Array.from({ length: 12 }, (_, i) => String(i + 1)).join('\n')}\n`
+const MODIFIED = ORIGINAL.replace('2\n', '2x\n').replace('11\n', '11x\n')
+
+function cachedDiff(repo: string): string {
+  return execFileSync('git', ['diff', '--cached', '--', 'file.txt'], {
+    cwd: repo,
+    encoding: 'utf-8'
+  })
+}
+
+describe('GitHandler — per-hunk staging', () => {
+  let dispatcher: MockDispatcher
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-git-hunk-'))
+    dispatcher = createMockDispatcher()
+    const ctx = new RelayContext()
+    // eslint-disable-next-line no-new
+    new GitHandler(dispatcher as unknown as RelayDispatcher, ctx)
+    gitInit(tmpDir)
+    writeFileSync(path.join(tmpDir, 'file.txt'), ORIGINAL)
+    gitCommit(tmpDir, 'initial')
+    writeFileSync(path.join(tmpDir, 'file.txt'), MODIFIED)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns the unified diff via git.diffPatch', async () => {
+    const result = (await dispatcher.callRequest('git.diffPatch', {
+      worktreePath: tmpDir,
+      filePath: 'file.txt',
+      staged: false
+    })) as { patch: string }
+    expect(result.patch).toContain('@@')
+    expect(parseFileDiff(result.patch).hunks).toHaveLength(2)
+  })
+
+  it('stages a single hunk via git.applyPatch', async () => {
+    const { patch } = (await dispatcher.callRequest('git.diffPatch', {
+      worktreePath: tmpDir,
+      filePath: 'file.txt',
+      staged: false
+    })) as { patch: string }
+    const single = buildHunkPatch(parseFileDiff(patch), [0])
+
+    await dispatcher.callRequest('git.applyPatch', {
+      worktreePath: tmpDir,
+      filePath: 'file.txt',
+      patch: single,
+      reverse: false
+    })
+
+    expect(cachedDiff(tmpDir)).toContain('+2x')
+    expect(cachedDiff(tmpDir)).not.toContain('+11x')
+  })
+
+  it('unstages a single hunk via git.applyPatch with reverse', async () => {
+    execFileSync('git', ['add', 'file.txt'], { cwd: tmpDir, stdio: 'pipe' })
+    const { patch } = (await dispatcher.callRequest('git.diffPatch', {
+      worktreePath: tmpDir,
+      filePath: 'file.txt',
+      staged: true
+    })) as { patch: string }
+    const single = buildHunkPatch(parseFileDiff(patch), [1])
+
+    await dispatcher.callRequest('git.applyPatch', {
+      worktreePath: tmpDir,
+      filePath: 'file.txt',
+      patch: single,
+      reverse: true
+    })
+
+    expect(cachedDiff(tmpDir)).toContain('+2x')
+    expect(cachedDiff(tmpDir)).not.toContain('+11x')
+  })
+
+  it('rejects a path that escapes the worktree', async () => {
+    await expect(
+      dispatcher.callRequest('git.diffPatch', {
+        worktreePath: tmpDir,
+        filePath: '../escape.txt',
+        staged: false
+      })
+    ).rejects.toThrow(/outside the worktree/)
+  })
+})

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -69,6 +69,8 @@ export class GitHandler {
     this.dispatcher.onRequest('git.diff', (p) => this.getDiff(p))
     this.dispatcher.onRequest('git.stage', (p) => this.stage(p))
     this.dispatcher.onRequest('git.unstage', (p) => this.unstage(p))
+    this.dispatcher.onRequest('git.diffPatch', (p) => this.getDiffPatch(p))
+    this.dispatcher.onRequest('git.applyPatch', (p, context) => this.applyPatch(p, context))
     this.dispatcher.onRequest('git.bulkStage', (p) => this.bulkStage(p))
     this.dispatcher.onRequest('git.bulkUnstage', (p) => this.bulkUnstage(p))
     this.dispatcher.onRequest('git.abortMerge', (p) => this.abortMerge(p))
@@ -198,6 +200,87 @@ export class GitHandler {
     const worktreePath = params.worktreePath as string
     const filePath = params.filePath as string
     await this.git(['restore', '--staged', '--', filePath], worktreePath)
+  }
+
+  private async getDiffPatch(params: Record<string, unknown>) {
+    const worktreePath = params.worktreePath as string
+    const filePath = params.filePath as string
+    // Why: filePath is relative; reject traversal before passing it to git diff.
+    const resolved = path.resolve(worktreePath, filePath)
+    const rel = path.relative(path.resolve(worktreePath), resolved)
+    if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+      throw new Error(`Path "${filePath}" resolves outside the worktree`)
+    }
+    const staged = params.staged === true
+    const { stdout } = await this.git(
+      ['diff', ...(staged ? ['--cached'] : []), '--no-color', '--no-ext-diff', '--', filePath],
+      worktreePath
+    )
+    return { patch: stdout }
+  }
+
+  private async applyPatch(params: Record<string, unknown>, context?: RequestContext) {
+    const worktreePath = params.worktreePath as string
+    const patch = params.patch as string
+    const reverse = params.reverse === true
+    // Why: dedicated index-only op with fixed args — no path args and no exec
+    // allowlist surface; git apply itself rejects patch paths escaping the repo.
+    await this.gitWithStdin(
+      ['apply', '--cached', ...(reverse ? ['--reverse'] : [])],
+      worktreePath,
+      patch,
+      context?.signal
+    )
+  }
+
+  private gitWithStdin(
+    args: string[],
+    cwd: string,
+    input: string,
+    signal?: AbortSignal
+  ): Promise<{ stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn('git', args, {
+        cwd: expandTilde(cwd),
+        env: buildRelayCommandEnv(),
+        windowsHide: true
+      })
+      let stdout = ''
+      let stderr = ''
+      let settled = false
+      const finish = (error: Error | null): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        if (error) {
+          reject(Object.assign(error, { stdout, stderr }))
+          return
+        }
+        resolve({ stdout, stderr })
+      }
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf-8')
+      })
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf-8')
+      })
+      child.on('error', finish)
+      child.on('close', (code) =>
+        code === 0 ? finish(null) : finish(new Error(`git exited with ${code}: ${stderr.trim()}`))
+      )
+      signal?.addEventListener(
+        'abort',
+        () => {
+          child.kill()
+          finish(new Error('git apply aborted'))
+        },
+        { once: true }
+      )
+      // Why: git may exit before draining stdin (malformed patch) → EPIPE.
+      child.stdin?.on('error', () => {})
+      child.stdin?.end(input)
+    })
   }
 
   private async bulkStage(params: Record<string, unknown>) {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -12,6 +12,7 @@ import {
   parseWorktreeList
 } from './git-handler-utils'
 import { parseNumstat } from '../shared/git-uncommitted-line-stats'
+import { patchTouchesOnlyPath } from '../shared/git-hunk-patch'
 import {
   computeDiff,
   branchCompare as branchCompareOp,
@@ -221,10 +222,14 @@ export class GitHandler {
 
   private async applyPatch(params: Record<string, unknown>, context?: RequestContext) {
     const worktreePath = params.worktreePath as string
+    const filePath = params.filePath as string
     const patch = params.patch as string
     const reverse = params.reverse === true
-    // Why: dedicated index-only op with fixed args — no path args and no exec
-    // allowlist surface; git apply itself rejects patch paths escaping the repo.
+    // Why: bind the patch to the expected path — git apply honors every file
+    // header it's given, so a stray patch could otherwise stage unrelated files.
+    if (!patchTouchesOnlyPath(patch, filePath)) {
+      throw new Error(`Patch does not match the expected path "${filePath}"`)
+    }
     await this.gitWithStdin(
       ['apply', '--cached', ...(reverse ? ['--reverse'] : [])],
       worktreePath,
@@ -247,6 +252,8 @@ export class GitHandler {
       })
       let stdout = ''
       let stderr = ''
+      let stdoutBytes = 0
+      let stderrBytes = 0
       let settled = false
       const finish = (error: Error | null): void => {
         if (settled) {
@@ -259,10 +266,24 @@ export class GitHandler {
         }
         resolve({ stdout, stderr })
       }
+      // Why: bound the buffers so a pathological git invocation can't blow up
+      // relay memory (mirrors the MAX_GIT_BUFFER cap on this.git()).
       child.stdout?.on('data', (chunk: Buffer) => {
+        stdoutBytes += chunk.byteLength
+        if (stdoutBytes > MAX_GIT_BUFFER) {
+          child.kill()
+          finish(new Error('git stdout exceeded maxBuffer.'))
+          return
+        }
         stdout += chunk.toString('utf-8')
       })
       child.stderr?.on('data', (chunk: Buffer) => {
+        stderrBytes += chunk.byteLength
+        if (stderrBytes > MAX_GIT_BUFFER) {
+          child.kill()
+          finish(new Error('git stderr exceeded maxBuffer.'))
+          return
+        }
         stderr += chunk.toString('utf-8')
       })
       child.on('error', finish)

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -214,7 +214,18 @@ export class GitHandler {
     }
     const staged = params.staged === true
     const { stdout } = await this.git(
-      ['diff', ...(staged ? ['--cached'] : []), '--no-color', '--no-ext-diff', '--', filePath],
+      // Why: core.quotePath=false keeps non-ASCII paths literal so the patch's
+      // file headers match the validated path (git octal-quotes them otherwise).
+      [
+        '-c',
+        'core.quotePath=false',
+        'diff',
+        ...(staged ? ['--cached'] : []),
+        '--no-color',
+        '--no-ext-diff',
+        '--',
+        filePath
+      ],
       worktreePath
     )
     return { patch: stdout }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2966,6 +2966,46 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
   background: rgba(59, 130, 246, 0.14);
 }
 
+.orca-diff-hunk-stage-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 18px;
+  padding: 0 7px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  border: 1px solid color-mix(in srgb, var(--foreground) 22%, var(--border));
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--foreground) 5%, var(--editor-surface));
+  color: color-mix(in srgb, var(--foreground) 78%, var(--muted-foreground));
+  cursor: pointer;
+  z-index: 5;
+  white-space: nowrap;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--foreground) 12%, transparent);
+  transition:
+    color 100ms ease,
+    background-color 100ms ease,
+    border-color 100ms ease,
+    opacity 100ms ease;
+}
+
+.orca-diff-hunk-stage-btn:hover {
+  color: var(--primary);
+  border-color: color-mix(in srgb, var(--primary) 52%, var(--border));
+  background: color-mix(in srgb, var(--primary) 12%, var(--background));
+}
+
+.orca-diff-hunk-stage-btn:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 1px;
+}
+
+.orca-diff-hunk-stage-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .dark .orca-diff-comment-range-highlight {
   background: rgba(96, 165, 250, 0.18);
 }

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -20,8 +20,10 @@ import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
 import {
   getRuntimeGitBranchDiff,
   getRuntimeGitCommitDiff,
-  getRuntimeGitDiff
+  getRuntimeGitDiff,
+  getRuntimeGitStatus
 } from '@/runtime/runtime-git-client'
+import type { DiffSectionHunkStaging } from './useDiffSectionHunkStaging'
 import '@/lib/monaco-setup'
 import { Button } from '@/components/ui/button'
 import {
@@ -187,6 +189,7 @@ export default function CombinedDiffViewer({
   viewStateKey: string
 }): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
+  const setGitStatus = useAppStore((s) => s.setGitStatus)
   const gitStatusEntries = useAppStore(
     (s) => s.gitStatusByWorktree[file.worktreeId] ?? EMPTY_GIT_STATUS_ENTRIES
   )
@@ -357,6 +360,50 @@ export default function CombinedDiffViewer({
 
   const isBranchMode = file.diffSource === 'combined-branch'
   const isCommitMode = file.diffSource === 'combined-commit'
+
+  const hunkStagingOwnerSettings = React.useMemo(
+    () => settingsForRuntimeOwner(settings, file.runtimeEnvironmentId),
+    [settings, file.runtimeEnvironmentId]
+  )
+  const refreshGitStatusAfterHunkApply = useCallback(async (): Promise<void> => {
+    if (!file.worktreeId) {
+      return
+    }
+    try {
+      const connectionId = getConnectionId(file.worktreeId) ?? undefined
+      const status = await getRuntimeGitStatus({
+        settings: hunkStagingOwnerSettings,
+        worktreeId: file.worktreeId,
+        worktreePath: file.filePath,
+        connectionId
+      })
+      setGitStatus(file.worktreeId, status)
+    } catch {
+      // Best-effort: the diff/status will also refresh on the next status poll.
+    }
+  }, [file.worktreeId, file.filePath, hunkStagingOwnerSettings, setGitStatus])
+  // Per-hunk staging only applies to the local working-tree changes view, not
+  // read-only branch/commit comparisons.
+  const hunkStaging = React.useMemo<DiffSectionHunkStaging | undefined>(() => {
+    if (isBranchMode || isCommitMode || !file.worktreeId) {
+      return undefined
+    }
+    return {
+      worktreePath: file.filePath,
+      connectionId: getConnectionId(file.worktreeId) ?? undefined,
+      settings: hunkStagingOwnerSettings,
+      onApplied: () => {
+        void refreshGitStatusAfterHunkApply()
+      }
+    }
+  }, [
+    isBranchMode,
+    isCommitMode,
+    file.worktreeId,
+    file.filePath,
+    hunkStagingOwnerSettings,
+    refreshGitStatusAfterHunkApply
+  ])
   const branchCompare =
     file.branchCompare?.baseOid && file.branchCompare.headOid && file.branchCompare.mergeBase
       ? file.branchCompare
@@ -1598,6 +1645,7 @@ export default function CombinedDiffViewer({
                         setSections={setSections}
                         modifiedEditorsRef={modifiedEditorsRef}
                         handleSectionSaveRef={handleSectionSaveRef}
+                        hunkStaging={hunkStaging}
                         renderHeaderTrailingContent={(section) => {
                           const fileNotes = diffCommentsForWorktree.filter(
                             (comment) => comment.filePath === section.path

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -34,6 +34,7 @@ import { disposeUnattachedMonacoModelPaths } from './diff-monaco-model-disposal'
 import { getLiveDiffSectionRenderLimit } from './diff-section-live-render-limit'
 import { useDiffSectionFallbackCleanup } from './useDiffSectionFallbackCleanup'
 import { submitDiffSectionComment } from './diff-section-comment-submit'
+import { useDiffSectionHunkStaging, type DiffSectionHunkStaging } from './useDiffSectionHunkStaging'
 
 export function DiffSectionItem({
   section,
@@ -58,7 +59,8 @@ export function DiffSectionItem({
   setSectionHeights,
   setSections,
   modifiedEditorsRef,
-  handleSectionSaveRef
+  handleSectionSaveRef,
+  hunkStaging
 }: {
   section: DiffSection
   index: number
@@ -90,6 +92,7 @@ export function DiffSectionItem({
   setSections: React.Dispatch<React.SetStateAction<DiffSection[]>>
   modifiedEditorsRef: MutableRefObject<Map<number, monacoEditor.IStandaloneCodeEditor>>
   handleSectionSaveRef: MutableRefObject<(index: number) => Promise<void>>
+  hunkStaging?: DiffSectionHunkStaging
 }): React.JSX.Element {
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const addDiffComment = useAppStore((s) => s.addDiffComment)
@@ -132,6 +135,8 @@ export function DiffSectionItem({
     lineHeight: number
   } | null>(null)
   const hasLineCommentAction = Boolean(worktreeId || onAddLineComment)
+
+  useDiffSectionHunkStaging({ section, worktreeId, modifiedEditor, hunkStaging })
 
   const disposeDiffModels = useCallback(() => {
     window.setTimeout(() => {

--- a/src/renderer/src/components/editor/useDiffHunkStageDecorator.test.tsx
+++ b/src/renderer/src/components/editor/useDiffHunkStageDecorator.test.tsx
@@ -122,8 +122,7 @@ describe('useDiffHunkStageDecorator', () => {
     expect(onApplyHunk).not.toHaveBeenCalled()
   })
 
-  it('mounts no button without an editor', async () => {
-    const { host } = makeEditor()
+  it('mounts no button anywhere without an editor', async () => {
     await render({
       editor: null,
       hunks: HUNKS,
@@ -131,6 +130,7 @@ describe('useDiffHunkStageDecorator', () => {
       disabled: false,
       onApplyHunk: vi.fn()
     })
-    expect(btn(host)).toBeNull()
+    // The hook appends to editor.getDomNode(); with no editor it must touch nothing.
+    expect(document.querySelector('.orca-diff-hunk-stage-btn')).toBeNull()
   })
 })

--- a/src/renderer/src/components/editor/useDiffHunkStageDecorator.test.tsx
+++ b/src/renderer/src/components/editor/useDiffHunkStageDecorator.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useDiffHunkStageDecorator } from './useDiffHunkStageDecorator'
+import type { DiffHunk } from '../../../../shared/git-hunk-patch'
+
+type MoveArg = { target: { position?: { lineNumber: number } }; event?: unknown }
+type Handlers = { move?: (e: MoveArg) => void; leave?: () => void; scroll?: () => void }
+
+function makeEditor(): { editor: unknown; host: HTMLElement; handlers: Handlers } {
+  const host = document.createElement('div')
+  const handlers: Handlers = {}
+  const editor = {
+    getDomNode: () => host,
+    getOption: () => 19,
+    getTopForLineNumber: (ln: number) => ln * 19,
+    getScrollTop: () => 0,
+    onMouseMove: (cb: (e: MoveArg) => void) => ((handlers.move = cb), { dispose() {} }),
+    onMouseLeave: (cb: () => void) => ((handlers.leave = cb), { dispose() {} }),
+    onDidScrollChange: (cb: () => void) => ((handlers.scroll = cb), { dispose() {} })
+  }
+  return { editor, host, handlers }
+}
+
+// hunk 0 covers modified lines 1-3, hunk 1 covers lines 11-12.
+const HUNKS: DiffHunk[] = [
+  {
+    index: 0,
+    header: '@@ -1,2 +1,3 @@',
+    lines: [],
+    newStart: 1,
+    newLineCount: 3,
+    oldStart: 1,
+    oldLineCount: 2
+  },
+  {
+    index: 1,
+    header: '@@ -10,1 +11,2 @@',
+    lines: [],
+    newStart: 11,
+    newLineCount: 2,
+    oldStart: 10,
+    oldLineCount: 1
+  }
+]
+
+function btn(host: HTMLElement): HTMLButtonElement {
+  return host.querySelector('.orca-diff-hunk-stage-btn') as HTMLButtonElement
+}
+
+const roots: Root[] = []
+function Probe(props: Parameters<typeof useDiffHunkStageDecorator>[0]): null {
+  useDiffHunkStageDecorator(props)
+  return null
+}
+async function render(props: Parameters<typeof useDiffHunkStageDecorator>[0]): Promise<void> {
+  const root = createRoot(document.createElement('div'))
+  roots.push(root)
+  await act(async () => {
+    root.render(<Probe {...props} />)
+  })
+}
+
+afterEach(() => {
+  for (const root of roots) {
+    act(() => root.unmount())
+  }
+  roots.length = 0
+})
+
+describe('useDiffHunkStageDecorator', () => {
+  it('reveals the pill on hover within a hunk and stages it on click', async () => {
+    const { editor, host, handlers } = makeEditor()
+    const onApplyHunk = vi.fn()
+    await render({
+      editor: editor as never,
+      hunks: HUNKS,
+      label: 'Stage hunk',
+      disabled: false,
+      onApplyHunk
+    })
+
+    act(() => handlers.move?.({ target: { position: { lineNumber: 12 } } }))
+    expect(btn(host).style.display).not.toBe('none')
+    expect(btn(host).textContent).toBe('Stage hunk')
+
+    act(() => btn(host).dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onApplyHunk).toHaveBeenCalledWith(1)
+  })
+
+  it('hides the pill over lines outside any hunk', async () => {
+    const { editor, host, handlers } = makeEditor()
+    await render({
+      editor: editor as never,
+      hunks: HUNKS,
+      label: 'Stage hunk',
+      disabled: false,
+      onApplyHunk: vi.fn()
+    })
+    act(() => handlers.move?.({ target: { position: { lineNumber: 2 } } }))
+    expect(btn(host).style.display).not.toBe('none')
+    act(() => handlers.move?.({ target: { position: { lineNumber: 6 } } }))
+    expect(btn(host).style.display).toBe('none')
+  })
+
+  it('does not stage while disabled', async () => {
+    const { editor, host, handlers } = makeEditor()
+    const onApplyHunk = vi.fn()
+    await render({
+      editor: editor as never,
+      hunks: HUNKS,
+      label: 'Unstage hunk',
+      disabled: true,
+      onApplyHunk
+    })
+    act(() => handlers.move?.({ target: { position: { lineNumber: 2 } } }))
+    expect(btn(host).disabled).toBe(true)
+    act(() => btn(host).dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onApplyHunk).not.toHaveBeenCalled()
+  })
+
+  it('mounts no button without an editor', async () => {
+    const { host } = makeEditor()
+    await render({
+      editor: null,
+      hunks: HUNKS,
+      label: 'Stage hunk',
+      disabled: false,
+      onApplyHunk: vi.fn()
+    })
+    expect(btn(host)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/useDiffHunkStageDecorator.tsx
+++ b/src/renderer/src/components/editor/useDiffHunkStageDecorator.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react'
+import * as monaco from 'monaco-editor'
+import type { editor as monacoEditor } from 'monaco-editor'
+import type { DiffHunk } from '../../../../shared/git-hunk-patch'
+
+// Reveals a single stage/unstage pill on hover over a hunk, anchored to the
+// hovered line and pinned to the editor's right edge. Absolute positioning (not
+// a view zone) keeps it out of the layout — so it can't desync the combined
+// diff's height virtualization or scroll horizontally with the content.
+
+const BTN_HEIGHT = 18
+
+type DiffHunkStageDecoratorArgs = {
+  editor: monacoEditor.ICodeEditor | null
+  hunks: readonly DiffHunk[]
+  label: string
+  /** Disabled while an apply is in flight so a hunk isn't double-submitted. */
+  disabled: boolean
+  onApplyHunk: (hunkIndex: number) => void
+}
+
+export function useDiffHunkStageDecorator({
+  editor,
+  hunks,
+  label,
+  disabled,
+  onApplyHunk
+}: DiffHunkStageDecoratorArgs): void {
+  const onApplyHunkRef = useRef(onApplyHunk)
+  onApplyHunkRef.current = onApplyHunk
+  const disabledRef = useRef(disabled)
+  disabledRef.current = disabled
+  const hunksRef = useRef(hunks)
+  hunksRef.current = hunks
+  const labelRef = useRef(label)
+  labelRef.current = label
+
+  useEffect(() => {
+    if (!editor) {
+      return
+    }
+    const host = editor.getDomNode()
+    if (!host) {
+      return
+    }
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'orca-diff-hunk-stage-btn'
+    button.style.position = 'absolute'
+    button.style.right = '16px'
+    button.style.zIndex = '6'
+    button.style.display = 'none'
+    host.appendChild(button)
+    let activeHunk = -1
+
+    const lineHeight = (): number => editor.getOption(monaco.editor.EditorOption.lineHeight) || 19
+    const hunkForLine = (line: number): DiffHunk | undefined =>
+      hunksRef.current.find(
+        (h) => line >= h.newStart && line < h.newStart + Math.max(1, h.newLineCount)
+      )
+
+    const showAtLine = (line: number, hunk: DiffHunk): void => {
+      const top = editor.getTopForLineNumber(line) - editor.getScrollTop()
+      button.style.top = `${Math.round(top + (lineHeight() - BTN_HEIGHT) / 2)}px`
+      button.textContent = labelRef.current
+      button.disabled = disabledRef.current
+      button.style.display = 'inline-flex'
+      activeHunk = hunk.index
+    }
+    const hide = (): void => {
+      button.style.display = 'none'
+      activeHunk = -1
+    }
+
+    const onMove = editor.onMouseMove((e) => {
+      const src = e.event?.browserEvent as MouseEvent | undefined
+      if (src && button.contains(src.target as Node)) {
+        return
+      }
+      const line = e.target.position?.lineNumber
+      const hunk = line == null ? undefined : hunkForLine(line)
+      if (line == null || !hunk) {
+        hide()
+        return
+      }
+      showAtLine(line, hunk)
+    })
+    const onLeave = editor.onMouseLeave(() => hide())
+    const onScroll = editor.onDidScrollChange(() => {
+      if (activeHunk < 0) {
+        return
+      }
+      const hunk = hunksRef.current.find((h) => h.index === activeHunk)
+      if (hunk) {
+        showAtLine(hunk.newStart, hunk)
+      }
+    })
+
+    button.addEventListener('mousedown', (ev) => ev.stopPropagation())
+    button.addEventListener('click', (ev) => {
+      ev.preventDefault()
+      ev.stopPropagation()
+      if (disabledRef.current || activeHunk < 0) {
+        return
+      }
+      onApplyHunkRef.current(activeHunk)
+    })
+
+    return () => {
+      onMove.dispose()
+      onLeave.dispose()
+      onScroll.dispose()
+      button.remove()
+    }
+  }, [editor])
+}

--- a/src/renderer/src/components/editor/useDiffHunkStageDecorator.tsx
+++ b/src/renderer/src/components/editor/useDiffHunkStageDecorator.tsx
@@ -3,10 +3,8 @@ import * as monaco from 'monaco-editor'
 import type { editor as monacoEditor } from 'monaco-editor'
 import type { DiffHunk } from '../../../../shared/git-hunk-patch'
 
-// Reveals a single stage/unstage pill on hover over a hunk, anchored to the
-// hovered line and pinned to the editor's right edge. Absolute positioning (not
-// a view zone) keeps it out of the layout — so it can't desync the combined
-// diff's height virtualization or scroll horizontally with the content.
+/** Reveals a stage/unstage pill on hover over a hunk, pinned to the editor's
+ * right edge — absolute (not a view zone) so it stays out of the layout. */
 
 const BTN_HEIGHT = 18
 

--- a/src/renderer/src/components/editor/useDiffSectionHunkStaging.ts
+++ b/src/renderer/src/components/editor/useDiffSectionHunkStaging.ts
@@ -15,8 +15,8 @@ export type DiffSectionHunkStaging = {
   onApplied: () => void
 }
 
-// Wires per-hunk staging onto a working-tree diff section; inert for binary,
-// read-only, errored, or dirty sections that can't safely round-trip a patch.
+/** Wires per-hunk staging onto a working-tree diff section; inert for binary,
+ * read-only, errored, or dirty sections that can't safely round-trip a patch. */
 export function useDiffSectionHunkStaging({
   section,
   worktreeId,

--- a/src/renderer/src/components/editor/useDiffSectionHunkStaging.ts
+++ b/src/renderer/src/components/editor/useDiffSectionHunkStaging.ts
@@ -1,0 +1,89 @@
+import { useCallback, useState } from 'react'
+import type { editor as monacoEditor } from 'monaco-editor'
+import { toast } from 'sonner'
+import { buildHunkPatch } from '../../../../shared/git-hunk-patch'
+import { applyRuntimeGitIndexPatch, type RuntimeGitContext } from '@/runtime/runtime-git-client'
+import type { DiffSection } from './diff-section-types'
+import { useDiffHunkStageDecorator } from './useDiffHunkStageDecorator'
+import { useDiffSectionHunks } from './useDiffSectionHunks'
+
+export type DiffSectionHunkStaging = {
+  worktreePath: string
+  connectionId?: string
+  settings: RuntimeGitContext['settings']
+  /** Refresh git status after an apply so the staged/unstaged split updates. */
+  onApplied: () => void
+}
+
+// Wires per-hunk staging onto a working-tree diff section; inert for binary,
+// read-only, errored, or dirty sections that can't safely round-trip a patch.
+export function useDiffSectionHunkStaging({
+  section,
+  worktreeId,
+  modifiedEditor,
+  hunkStaging
+}: {
+  section: DiffSection
+  worktreeId?: string
+  modifiedEditor: monacoEditor.ICodeEditor | null
+  hunkStaging?: DiffSectionHunkStaging
+}): void {
+  const isStagedArea = section.area === 'staged'
+  const active =
+    Boolean(hunkStaging) &&
+    (section.area === 'unstaged' || section.area === 'staged') &&
+    !section.dirty &&
+    !section.error &&
+    section.diffResult?.kind === 'text'
+  const [applyingHunk, setApplyingHunk] = useState(false)
+  const parsedHunkDiff = useDiffSectionHunks({
+    enabled: active,
+    worktreeId,
+    worktreePath: hunkStaging?.worktreePath ?? '',
+    connectionId: hunkStaging?.connectionId,
+    settings: hunkStaging?.settings,
+    filePath: section.path,
+    staged: isStagedArea,
+    contentGeneration: section.contentGeneration
+  })
+  const handleApplyHunk = useCallback(
+    async (hunkIndex: number): Promise<void> => {
+      if (!hunkStaging) {
+        return
+      }
+      const patch = buildHunkPatch(parsedHunkDiff, [hunkIndex])
+      if (!patch) {
+        return
+      }
+      setApplyingHunk(true)
+      try {
+        await applyRuntimeGitIndexPatch(
+          {
+            settings: hunkStaging.settings,
+            worktreeId,
+            worktreePath: hunkStaging.worktreePath,
+            connectionId: hunkStaging.connectionId
+          },
+          { filePath: section.path, patch, reverse: isStagedArea }
+        )
+      } catch (error) {
+        toast.error(isStagedArea ? 'Failed to unstage hunk' : 'Failed to stage hunk', {
+          description: error instanceof Error ? error.message : undefined
+        })
+      } finally {
+        setApplyingHunk(false)
+        // Why: refresh on success and failure — a failed apply usually means the
+        // diff moved under us, so re-fetching realigns the remaining hunks.
+        hunkStaging.onApplied()
+      }
+    },
+    [hunkStaging, parsedHunkDiff, worktreeId, section.path, isStagedArea]
+  )
+  useDiffHunkStageDecorator({
+    editor: active ? modifiedEditor : null,
+    hunks: parsedHunkDiff.hunks,
+    label: isStagedArea ? 'Unstage hunk' : 'Stage hunk',
+    disabled: applyingHunk,
+    onApplyHunk: handleApplyHunk
+  })
+}

--- a/src/renderer/src/components/editor/useDiffSectionHunks.test.tsx
+++ b/src/renderer/src/components/editor/useDiffSectionHunks.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ getPatch: vi.fn() }))
+vi.mock('@/runtime/runtime-git-client', () => ({
+  getRuntimeGitFileDiffPatch: mocks.getPatch
+}))
+
+import { useDiffSectionHunks } from './useDiffSectionHunks'
+import type { ParsedFileDiff } from '../../../../shared/git-hunk-patch'
+
+const PATCH = [
+  'diff --git a/foo.ts b/foo.ts',
+  'index 1111111..2222222 100644',
+  '--- a/foo.ts',
+  '+++ b/foo.ts',
+  '@@ -1,2 +1,3 @@',
+  ' a',
+  '+b',
+  ' c',
+  ''
+].join('\n')
+
+type Props = Parameters<typeof useDiffSectionHunks>[0]
+const BASE: Props = {
+  enabled: true,
+  worktreeId: 'wt',
+  worktreePath: '/repo',
+  connectionId: undefined,
+  settings: null,
+  filePath: 'foo.ts',
+  staged: false,
+  contentGeneration: 0
+}
+
+let latest: ParsedFileDiff | null = null
+const roots: Root[] = []
+
+function Probe(props: Props): null {
+  latest = useDiffSectionHunks(props)
+  return null
+}
+
+async function renderProbe(props: Props): Promise<void> {
+  const root = createRoot(document.createElement('div'))
+  roots.push(root)
+  await act(async () => {
+    root.render(<Probe {...props} />)
+  })
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+afterEach(() => {
+  for (const root of roots) {
+    act(() => root.unmount())
+  }
+  roots.length = 0
+  latest = null
+  mocks.getPatch.mockReset()
+})
+
+describe('useDiffSectionHunks', () => {
+  it('fetches and parses hunks when enabled', async () => {
+    mocks.getPatch.mockResolvedValue(PATCH)
+    await renderProbe(BASE)
+    expect(latest?.hunks).toHaveLength(1)
+    expect(mocks.getPatch).toHaveBeenCalledWith(
+      { settings: null, worktreeId: 'wt', worktreePath: '/repo', connectionId: undefined },
+      { filePath: 'foo.ts', staged: false }
+    )
+  })
+
+  it('does not fetch and stays empty when disabled', async () => {
+    await renderProbe({ ...BASE, enabled: false })
+    expect(latest?.hunks).toHaveLength(0)
+    expect(mocks.getPatch).not.toHaveBeenCalled()
+  })
+
+  it('falls back to empty hunks when the fetch fails', async () => {
+    mocks.getPatch.mockRejectedValue(new Error('git.diffPatch unavailable'))
+    await renderProbe(BASE)
+    expect(latest?.hunks).toHaveLength(0)
+  })
+})

--- a/src/renderer/src/components/editor/useDiffSectionHunks.ts
+++ b/src/renderer/src/components/editor/useDiffSectionHunks.ts
@@ -4,8 +4,8 @@ import { parseFileDiff, type ParsedFileDiff } from '../../../../shared/git-hunk-
 
 const EMPTY: ParsedFileDiff = { headerLines: [], hunks: [], isBinary: false }
 
-// Fetches the per-file unified diff and parses its hunks; refetches on
-// contentGeneration so anchors track the live file. git is the source of truth.
+/** Fetches the per-file unified diff and parses its hunks; refetches on
+ * contentGeneration so anchors track the live file. git is the source of truth. */
 export function useDiffSectionHunks(args: {
   enabled: boolean
   worktreeId?: string

--- a/src/renderer/src/components/editor/useDiffSectionHunks.ts
+++ b/src/renderer/src/components/editor/useDiffSectionHunks.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+import { getRuntimeGitFileDiffPatch, type RuntimeGitContext } from '@/runtime/runtime-git-client'
+import { parseFileDiff, type ParsedFileDiff } from '../../../../shared/git-hunk-patch'
+
+const EMPTY: ParsedFileDiff = { headerLines: [], hunks: [], isBinary: false }
+
+// Fetches the per-file unified diff and parses its hunks; refetches on
+// contentGeneration so anchors track the live file. git is the source of truth.
+export function useDiffSectionHunks(args: {
+  enabled: boolean
+  worktreeId?: string
+  worktreePath: string
+  connectionId?: string
+  settings: RuntimeGitContext['settings']
+  filePath: string
+  staged: boolean
+  contentGeneration?: number
+}): ParsedFileDiff {
+  const {
+    enabled,
+    worktreeId,
+    worktreePath,
+    connectionId,
+    settings,
+    filePath,
+    staged,
+    contentGeneration
+  } = args
+  const [parsed, setParsed] = useState<ParsedFileDiff>(EMPTY)
+
+  useEffect(() => {
+    if (!enabled) {
+      setParsed(EMPTY)
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const patch = await getRuntimeGitFileDiffPatch(
+          { settings, worktreeId, worktreePath, connectionId },
+          { filePath, staged }
+        )
+        if (!cancelled) {
+          setParsed(parseFileDiff(patch))
+        }
+      } catch {
+        // Why: failure (e.g. an older relay without git.diffPatch) just hides the
+        // per-hunk controls; file-level staging in Source Control still works.
+        if (!cancelled) {
+          setParsed(EMPTY)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [
+    enabled,
+    worktreeId,
+    worktreePath,
+    connectionId,
+    settings,
+    filePath,
+    staged,
+    contentGeneration
+  ])
+
+  return parsed
+}

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -734,6 +734,7 @@ export async function unstageRuntimeGitPath(
   )
 }
 
+/** Raw unified diff for one file, routed to the active runtime (local/SSH/env). */
 export async function getRuntimeGitFileDiffPatch(
   context: RuntimeGitContext,
   args: { filePath: string; staged: boolean }
@@ -761,6 +762,7 @@ export async function getRuntimeGitFileDiffPatch(
   return result.patch
 }
 
+/** Apply a hunk patch to the index (reverse unstages), routed to the runtime. */
 export async function applyRuntimeGitIndexPatch(
   context: RuntimeGitContext,
   args: { filePath: string; patch: string; reverse: boolean }

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -734,6 +734,61 @@ export async function unstageRuntimeGitPath(
   )
 }
 
+export async function getRuntimeGitFileDiffPatch(
+  context: RuntimeGitContext,
+  args: { filePath: string; staged: boolean }
+): Promise<string> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    const result = await window.api.git.diffPatch({
+      worktreePath: context.worktreePath,
+      filePath: args.filePath,
+      staged: args.staged,
+      connectionId: context.connectionId
+    })
+    return result.patch
+  }
+  const result = await callRuntimeRpc<{ patch: string }>(
+    target,
+    'git.diffPatch',
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      filePath: args.filePath,
+      staged: args.staged
+    },
+    { timeoutMs: 15_000 }
+  )
+  return result.patch
+}
+
+export async function applyRuntimeGitIndexPatch(
+  context: RuntimeGitContext,
+  args: { filePath: string; patch: string; reverse: boolean }
+): Promise<void> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    await window.api.git.applyPatch({
+      worktreePath: context.worktreePath,
+      filePath: args.filePath,
+      patch: args.patch,
+      reverse: args.reverse,
+      connectionId: context.connectionId
+    })
+    return
+  }
+  await callRuntimeRpc(
+    target,
+    'git.applyPatch',
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      filePath: args.filePath,
+      patch: args.patch,
+      reverse: args.reverse
+    },
+    { timeoutMs: 15_000 }
+  )
+}
+
 export async function bulkUnstageRuntimeGitPaths(
   context: RuntimeGitContext,
   filePaths: string[]

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1541,6 +1541,23 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
       mutateGitPaths('git.bulkStage', worktreePath, filePaths),
     unstage: async ({ worktreePath, filePath }) =>
       mutateGitPath('git.unstage', worktreePath, filePath),
+    diffPatch: async ({ worktreePath, filePath, staged }) => {
+      const file = await resolveRuntimeFilePath(filePath, worktreePath)
+      return callRuntimeResult('git.diffPatch', {
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
+        filePath: file.relativePath,
+        staged
+      })
+    },
+    applyPatch: async ({ worktreePath, filePath, patch, reverse }) => {
+      const file = await resolveRuntimeFilePath(filePath, worktreePath)
+      await callRuntimeResult('git.applyPatch', {
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
+        filePath: file.relativePath,
+        patch,
+        reverse
+      })
+    },
     bulkUnstage: async ({ worktreePath, filePaths }) =>
       mutateGitPaths('git.bulkUnstage', worktreePath, filePaths),
     discard: async ({ worktreePath, filePath }) =>

--- a/src/shared/git-hunk-patch.test.ts
+++ b/src/shared/git-hunk-patch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildHunkPatch, parseFileDiff } from './git-hunk-patch'
+import { buildHunkPatch, parseFileDiff, patchTouchesOnlyPath } from './git-hunk-patch'
 
 const TWO_HUNK = [
   'diff --git a/foo.ts b/foo.ts',
@@ -147,5 +147,26 @@ describe('buildHunkPatch', () => {
     const parsed = parseFileDiff(TWO_HUNK)
     expect(buildHunkPatch(parsed, [])).toBe('')
     expect(buildHunkPatch({ headerLines: [], hunks: parsed.hunks, isBinary: false }, [0])).toBe('')
+  })
+})
+
+describe('patchTouchesOnlyPath', () => {
+  it('accepts a patch whose only path matches', () => {
+    expect(patchTouchesOnlyPath(TWO_HUNK, 'foo.ts')).toBe(true)
+  })
+
+  it('rejects a patch that targets a different path', () => {
+    expect(patchTouchesOnlyPath(TWO_HUNK, 'bar.ts')).toBe(false)
+  })
+
+  it('rejects an empty / header-less patch', () => {
+    expect(patchTouchesOnlyPath('', 'foo.ts')).toBe(false)
+  })
+
+  it('normalizes backslashes in the expected path', () => {
+    const patch = ['diff --git a/dir/x.ts b/dir/x.ts', '--- a/dir/x.ts', '+++ b/dir/x.ts', ''].join(
+      '\n'
+    )
+    expect(patchTouchesOnlyPath(patch, 'dir\\x.ts')).toBe(true)
   })
 })

--- a/src/shared/git-hunk-patch.test.ts
+++ b/src/shared/git-hunk-patch.test.ts
@@ -169,4 +169,12 @@ describe('patchTouchesOnlyPath', () => {
     )
     expect(patchTouchesOnlyPath(patch, 'dir\\x.ts')).toBe(true)
   })
+
+  // git leaves spaces literal and (with core.quotePath=false) non-ASCII literal.
+  it.each(['my file.ts', 'café.ts'])('accepts the unquoted path %s', (name) => {
+    const patch = [`diff --git a/${name} b/${name}`, `--- a/${name}`, `+++ b/${name}`, ''].join(
+      '\n'
+    )
+    expect(patchTouchesOnlyPath(patch, name)).toBe(true)
+  })
 })

--- a/src/shared/git-hunk-patch.test.ts
+++ b/src/shared/git-hunk-patch.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { buildHunkPatch, parseFileDiff } from './git-hunk-patch'
+
+const TWO_HUNK = [
+  'diff --git a/foo.ts b/foo.ts',
+  'index 83db48f..f735c2d 100644',
+  '--- a/foo.ts',
+  '+++ b/foo.ts',
+  '@@ -1,3 +1,4 @@',
+  ' line1',
+  '+added',
+  ' line2',
+  ' line3',
+  '@@ -10,2 +11,3 @@ ctx',
+  ' x',
+  '+y',
+  ' z',
+  ''
+].join('\n')
+
+describe('parseFileDiff', () => {
+  it('splits header from hunks and reads @@ ranges', () => {
+    const parsed = parseFileDiff(TWO_HUNK)
+    expect(parsed.headerLines).toEqual([
+      'diff --git a/foo.ts b/foo.ts',
+      'index 83db48f..f735c2d 100644',
+      '--- a/foo.ts',
+      '+++ b/foo.ts'
+    ])
+    expect(parsed.hunks).toHaveLength(2)
+    expect(parsed.hunks[0]).toMatchObject({
+      index: 0,
+      header: '@@ -1,3 +1,4 @@',
+      oldStart: 1,
+      oldLineCount: 3,
+      newStart: 1,
+      newLineCount: 4
+    })
+    expect(parsed.hunks[1]).toMatchObject({ index: 1, newStart: 11, newLineCount: 3 })
+    expect(parsed.isBinary).toBe(false)
+  })
+
+  it('defaults an omitted line count to 1', () => {
+    const parsed = parseFileDiff(['--- a/x', '+++ b/x', '@@ -5 +5,2 @@', ' a', '+b', ''].join('\n'))
+    expect(parsed.hunks[0]).toMatchObject({
+      oldStart: 5,
+      oldLineCount: 1,
+      newStart: 5,
+      newLineCount: 2
+    })
+  })
+
+  it('flags binary diffs and yields no hunks', () => {
+    const parsed = parseFileDiff(
+      [
+        'diff --git a/logo.png b/logo.png',
+        'index aaa..bbb 100644',
+        'Binary files a/logo.png and b/logo.png differ',
+        ''
+      ].join('\n')
+    )
+    expect(parsed.isBinary).toBe(true)
+    expect(parsed.hunks).toHaveLength(0)
+  })
+
+  it('parses a new file as a single hunk anchored at line 1', () => {
+    const parsed = parseFileDiff(
+      [
+        'diff --git a/new.ts b/new.ts',
+        'new file mode 100644',
+        'index 0000000..abc1234',
+        '--- /dev/null',
+        '+++ b/new.ts',
+        '@@ -0,0 +1,2 @@',
+        '+a',
+        '+b',
+        ''
+      ].join('\n')
+    )
+    expect(parsed.hunks).toHaveLength(1)
+    expect(parsed.hunks[0]).toMatchObject({
+      oldStart: 0,
+      oldLineCount: 0,
+      newStart: 1,
+      newLineCount: 2
+    })
+  })
+
+  it('keeps the "\\ No newline at end of file" marker inside its hunk', () => {
+    const parsed = parseFileDiff(
+      [
+        '--- a/x',
+        '+++ b/x',
+        '@@ -1 +1 @@',
+        '-old',
+        '+new',
+        '\\ No newline at end of file',
+        ''
+      ].join('\n')
+    )
+    expect(parsed.hunks[0].lines).toEqual(['-old', '+new', '\\ No newline at end of file'])
+  })
+
+  it('treats a bare empty body line as a blank context line of the hunk', () => {
+    const parsed = parseFileDiff(
+      ['--- a/x', '+++ b/x', '@@ -1,2 +1,3 @@', ' a', '', '+b', ''].join('\n')
+    )
+    expect(parsed.hunks).toHaveLength(1)
+    expect(parsed.hunks[0].lines).toEqual([' a', '', '+b'])
+  })
+
+  it('returns an empty result for empty input', () => {
+    expect(parseFileDiff('')).toEqual({ headerLines: [], hunks: [], isBinary: false })
+  })
+})
+
+describe('buildHunkPatch', () => {
+  it('emits the header plus only the selected hunk', () => {
+    const parsed = parseFileDiff(TWO_HUNK)
+    expect(buildHunkPatch(parsed, [1])).toBe(
+      [
+        'diff --git a/foo.ts b/foo.ts',
+        'index 83db48f..f735c2d 100644',
+        '--- a/foo.ts',
+        '+++ b/foo.ts',
+        '@@ -10,2 +11,3 @@ ctx',
+        ' x',
+        '+y',
+        ' z',
+        ''
+      ].join('\n')
+    )
+  })
+
+  it('round-trips the original bytes when every hunk is selected', () => {
+    const parsed = parseFileDiff(TWO_HUNK)
+    expect(buildHunkPatch(parsed, [0, 1])).toBe(TWO_HUNK)
+  })
+
+  it('preserves CRLF content lines through a round-trip', () => {
+    const crlf = ['--- a/x', '+++ b/x', '@@ -1 +1 @@', '-old\r', '+new\r', ''].join('\n')
+    const parsed = parseFileDiff(crlf)
+    expect(buildHunkPatch(parsed, [0])).toBe(crlf)
+  })
+
+  it('returns empty string for an empty selection or a headerless diff', () => {
+    const parsed = parseFileDiff(TWO_HUNK)
+    expect(buildHunkPatch(parsed, [])).toBe('')
+    expect(buildHunkPatch({ headerLines: [], hunks: parsed.hunks, isBinary: false }, [0])).toBe('')
+  })
+})

--- a/src/shared/git-hunk-patch.ts
+++ b/src/shared/git-hunk-patch.ts
@@ -1,0 +1,112 @@
+// Parse a single-file unified diff into hunks and rebuild a minimal patch from a
+// selection. Hunks are kept verbatim so the result applies with `git apply` as-is.
+
+export type DiffHunk = {
+  /** 0-based position within the file diff. Stable id for selection. */
+  index: number
+  /** The `@@ -a,b +c,d @@ …` line, kept verbatim. */
+  header: string
+  /** Body lines (context/+/-/`\ No newline`), without line terminators. */
+  lines: string[]
+  /** 1-based start line on the new (modified) side — the UI anchor. */
+  newStart: number
+  newLineCount: number
+  oldStart: number
+  oldLineCount: number
+}
+
+export type ParsedFileDiff = {
+  /** Lines before the first hunk: `diff --git`, `index`, `---`, `+++`. */
+  headerLines: string[]
+  hunks: DiffHunk[]
+  /** Binary or rename-only diffs have no textual hunks to stage per-hunk. */
+  isBinary: boolean
+}
+
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/
+
+function isHunkBodyLine(line: string): boolean {
+  if (line.length === 0) {
+    // Why: git emits a bare empty line for an unchanged blank context line
+    // (the leading space is dropped). It still belongs to the current hunk.
+    return true
+  }
+  const c = line.at(0)
+  return c === ' ' || c === '+' || c === '-' || c === '\\'
+}
+
+/**
+ * Parse a single-file unified diff. Splits on `\n` only so CRLF content lines
+ * keep their `\r` and round-trip byte-for-byte through {@link buildHunkPatch}.
+ */
+export function parseFileDiff(patchText: string): ParsedFileDiff {
+  const empty: ParsedFileDiff = { headerLines: [], hunks: [], isBinary: false }
+  if (!patchText) {
+    return empty
+  }
+  const lines = patchText.split('\n')
+  // Why: a trailing newline produces a final empty element that is not part of
+  // the diff; drop it so it doesn't get re-added as spurious content.
+  if (lines.at(-1) === '') {
+    lines.pop()
+  }
+
+  const headerLines: string[] = []
+  let i = 0
+  let isBinary = false
+  while (i < lines.length && !HUNK_HEADER.test(lines[i])) {
+    if (lines[i].startsWith('Binary files ') || lines[i].startsWith('GIT binary patch')) {
+      isBinary = true
+    }
+    headerLines.push(lines[i])
+    i++
+  }
+
+  const hunks: DiffHunk[] = []
+  while (i < lines.length) {
+    const match = HUNK_HEADER.exec(lines[i])
+    if (!match) {
+      break
+    }
+    const header = lines[i]
+    i++
+    const body: string[] = []
+    while (i < lines.length && !HUNK_HEADER.test(lines[i]) && isHunkBodyLine(lines[i])) {
+      body.push(lines[i])
+      i++
+    }
+    hunks.push({
+      index: hunks.length,
+      header,
+      lines: body,
+      oldStart: Number(match[1]),
+      oldLineCount: match[2] === undefined ? 1 : Number(match[2]),
+      newStart: Number(match[3]),
+      newLineCount: match[4] === undefined ? 1 : Number(match[4])
+    })
+  }
+
+  return { headerLines, hunks, isBinary }
+}
+
+/**
+ * Rebuild a patch containing only the selected hunks. The file header is kept
+ * intact; each selected hunk is emitted verbatim, so `git apply --cached`
+ * accepts it without `--recount`. Returns `''` when nothing applies.
+ */
+export function buildHunkPatch(parsed: ParsedFileDiff, selectedIndexes: readonly number[]): string {
+  if (parsed.headerLines.length === 0 || selectedIndexes.length === 0) {
+    return ''
+  }
+  const wanted = new Set(selectedIndexes)
+  const selected = parsed.hunks.filter((hunk) => wanted.has(hunk.index))
+  if (selected.length === 0) {
+    return ''
+  }
+  const out: string[] = [...parsed.headerLines]
+  for (const hunk of selected) {
+    out.push(hunk.header, ...hunk.lines)
+  }
+  // Why: git apply rejects a patch whose final hunk line lacks a terminator.
+  return `${out.join('\n')}\n`
+}

--- a/src/shared/git-hunk-patch.ts
+++ b/src/shared/git-hunk-patch.ts
@@ -110,3 +110,25 @@ export function buildHunkPatch(parsed: ParsedFileDiff, selectedIndexes: readonly
   // Why: git apply rejects a patch whose final hunk line lacks a terminator.
   return `${out.join('\n')}\n`
 }
+
+const DIFF_GIT_HEADER = /^diff --git a\/(.+) b\/(.+)$/
+
+function diffPatchPaths(patchText: string): string[] {
+  const paths = new Set<string>()
+  for (const line of patchText.split('\n')) {
+    const match = DIFF_GIT_HEADER.exec(line)
+    if (match) {
+      paths.add(match[1])
+      paths.add(match[2])
+    }
+  }
+  return [...paths]
+}
+
+/** True when `patch` only touches `filePath` — guards `git apply --cached`
+ * against a patch that would stage unrelated repo paths. */
+export function patchTouchesOnlyPath(patchText: string, filePath: string): boolean {
+  const want = filePath.replace(/\\/g, '/')
+  const paths = diffPatchPaths(patchText)
+  return paths.length > 0 && paths.every((path) => path === want)
+}


### PR DESCRIPTION
## What this adds

Per-hunk **Stage hunk** / **Unstage hunk** in the combined diff viewer. Hovering a hunk in the working-tree changes reveals a pill that stages just that hunk (or unstages it, on a staged section) — closing the gap left by file-level staging (#334, and the overlapping #2429).

This follows @nwparker's scoped breakdown on #2429:
- **git is the source of truth for hunks.** The renderer fetches the per-file unified diff (new `git.diffPatch`), parses it, rebuilds a minimal patch for the selected hunk, and applies it with `git apply --cached [--reverse]` (new `git.applyPatch`). `git apply`'s atomicity is the staleness guard — if the worktree moved under the virtualized diff, the patch fails cleanly and the view refreshes, so the index is never corrupted.
- **Local + SSH + runtime** via dedicated RPCs; the relay `git.exec` allowlist is left closed (a dedicated `git.applyPatch` handler pipes the patch over its own stdin path).
- **Gated off** for binary, read-only branch/commit, errored, and dirty (unsaved-edit) sections.
- The control is a hover-revealed pill positioned with absolute layout (not a view zone), so it never affects the combined diff's height virtualization or scrolls with content.

Scoped to whole-hunk stage/unstage (what @AmethystLiang invited on #334). Sub-hunk/line-range selection is a clean follow-up on the same patch API.

## Tests

- `src/shared/git-hunk-patch.test.ts` — unified-diff parse + sub-patch rebuild (binary, new/deleted file, no-newline-at-eof, CRLF round-trip, multi-hunk subset).
- `src/main/git/status-hunk-patch.test.ts` — local `getFileDiffPatch` + `applyIndexPatch` against real git (stage hunk, unstage via reverse, stale-patch rejection).
- `src/relay/git-handler-hunk-staging.test.ts` — relay `git.diffPatch` / `git.applyPatch` round-trip against real git + path-traversal rejection.
- `src/renderer/src/components/editor/useDiffSectionHunks.test.tsx` + `useDiffHunkStageDecorator.test.tsx` — fetch/parse hook and the hover decorator (reveal, click, disabled gating).

`pnpm typecheck`, `pnpm lint` (oxlint), `pnpm build:desktop`, and the full suite pass.

## AI code review summary

- **Cross-platform:** the stdin git runner routes through the existing WSL-aware `gitSpawn`; no hardcoded path separators or modifier keys. macOS/Linux/Windows safe.
- **SSH / remote / local:** all three paths implemented and tested — local (`status.ts`), SSH (`SshGitProvider` → relay handler with its own stdin pipe), and runtime (RPC). Older relays without `git.diffPatch` degrade gracefully (per-hunk controls just don't appear; file-level staging still works).
- **Agent / integration compat:** no agent- or integration-specific logic touched.
- **Git provider compat:** purely local-git plumbing (`git diff` / `git apply --cached`); provider-neutral, nothing GitHub-specific.
- **Performance:** the patch fetch is one `git diff` per stageable section, refetched only when the diff reloads; the control is hover-driven and adds no view zones, so it doesn't perturb the combined diff's height virtualization.
- **UI quality:** the pill mirrors the existing diff-comment affordance's tokens/sizing (STYLEGUIDE §match-the-nearest-sibling); no new color/shadow/font values.
- **Security:** `git apply` is restricted to `--cached` (index only); the relay handler takes no path arguments (patch on stdin), and git apply itself rejects patch paths escaping the repo; file paths are validated for worktree confinement at every boundary.

## Screenshots
- Hover → "Stage hunk" pill on an unstaged hunk.
- After staging one hunk → the file splits into CHANGES + STAGED CHANGES, the diff shows only what's left, Commit enables.
<img width="1856" height="1267" alt="pr-hover-stage" src="https://github.com/user-attachments/assets/c2d7fe88-7605-40dd-954c-3c83a24ecbe3" />
<img width="1856" height="1267" alt="04-after-stage" src="https://github.com/user-attachments/assets/8e863ec7-591f-483c-8354-ee46c8941306" />

X handle: @dannymundyy

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5950">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

In the combined diff viewer you can stage or unstage a single hunk instead of the whole file. Hover a hunk to get a stage/unstage control for just that change.
