### PR TITLE
fix(jira): send non-browser User-Agent to avoid XSRF 403 on issue search/create

### DIFF
--- a/src/main/jira/client.test.ts
+++ b/src/main/jira/client.test.ts
@@ -170,28 +170,33 @@ describe('Jira client credential storage', () => {
     )
   })
 
-  it('sends a non-browser User-Agent so Jira does not fail POSTs with "XSRF check failed"', async () => {
+  it('sends a non-browser User-Agent on Jira POST requests', async () => {
     // Why: Electron's net.fetch defaults to a Chrome User-Agent, which trips
     // Atlassian's XSRF filter on POST/PUT REST calls (issue search, create,
     // update, comment) even under API-token auth, surfacing as a 403.
     const siteId = 'site-alpha'
     writeJiraFiles(siteId, 'token-alpha')
     netFetchMock.mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          accountId: 'account-alpha',
-          displayName: 'Ada',
-          emailAddress: 'ada@example.com'
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+      new Response(JSON.stringify({ issues: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
     )
     const jira = await loadClientModule({ encryptionAvailable: true })
+    const client = jira.getClients(siteId)[0]
 
-    await jira.testConnection(siteId)
+    if (!client) {
+      throw new Error('Expected stored Jira client')
+    }
+
+    await jira.jiraRequest(client, '/rest/api/3/search/jql', {
+      method: 'POST',
+      body: JSON.stringify({ jql: 'project = ALP' })
+    })
 
     const headers = netFetchMock.mock.calls[0]?.[1]?.headers as Headers
     const userAgent = headers.get('User-Agent') ?? ''
+    expect(netFetchMock.mock.calls[0]?.[1]?.method).toBe('POST')
     expect(userAgent).toBe('Orca')
     expect(userAgent).not.toMatch(/Mozilla|Chrome|Safari|AppleWebKit/i)
   })
@@ -420,6 +425,8 @@ describe('Jira client credential storage', () => {
 
     expect(resolveProxyMock).toHaveBeenCalledWith('https://example.atlassian.net/rest/api/3/myself')
     expect(netFetchMock).toHaveBeenCalledTimes(1)
+    const headers = netFetchMock.mock.calls[0]?.[1]?.headers as Headers
+    expect(headers.get('User-Agent')).toBe('Orca')
     expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/jira/client.test.ts
+++ b/src/main/jira/client.test.ts
@@ -170,6 +170,32 @@ describe('Jira client credential storage', () => {
     )
   })
 
+  it('sends a non-browser User-Agent so Jira does not fail POSTs with "XSRF check failed"', async () => {
+    // Why: Electron's net.fetch defaults to a Chrome User-Agent, which trips
+    // Atlassian's XSRF filter on POST/PUT REST calls (issue search, create,
+    // update, comment) even under API-token auth, surfacing as a 403.
+    const siteId = 'site-alpha'
+    writeJiraFiles(siteId, 'token-alpha')
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          accountId: 'account-alpha',
+          displayName: 'Ada',
+          emailAddress: 'ada@example.com'
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const jira = await loadClientModule({ encryptionAvailable: true })
+
+    await jira.testConnection(siteId)
+
+    const headers = netFetchMock.mock.calls[0]?.[1]?.headers as Headers
+    const userAgent = headers.get('User-Agent') ?? ''
+    expect(userAgent).toBe('Orca')
+    expect(userAgent).not.toMatch(/Mozilla|Chrome|Safari|AppleWebKit/i)
+  })
+
   it('does not pass encrypted safeStorage bytes to Jira when encryption is unavailable', async () => {
     const siteId = 'site-alpha'
     const tokenPath = tokenPathForSite(siteId)

--- a/src/main/jira/client.ts
+++ b/src/main/jira/client.ts
@@ -21,6 +21,13 @@ import type {
   JiraViewer
 } from '../../shared/types'
 
+// Why: Atlassian's XSRF filter rejects POST/PUT REST calls that carry a browser
+// User-Agent, failing them with "XSRF check failed" even under API-token auth.
+// Electron's net.fetch sends a Chrome UA, so issue search/create/update/comment
+// all 403'd while GET calls (connect, /myself) passed. A non-browser UA is the
+// reliable fix; X-Atlassian-Token: no-check is not honored for this case.
+const JIRA_API_USER_AGENT = 'Orca'
+
 const MAX_CONCURRENT = 4
 let running = 0
 const queue: (() => void)[] = []
@@ -364,6 +371,7 @@ async function requestWithCredentials(
   const headers = new Headers(init?.headers)
   headers.set('Accept', 'application/json')
   headers.set('Content-Type', 'application/json')
+  headers.set('User-Agent', JIRA_API_USER_AGENT)
   headers.set('Authorization', authHeader(email, apiToken))
   const response = await jiraFetch(`${siteUrl}${path}`, {
     ...init,
@@ -407,6 +415,7 @@ export async function jiraRequest<T>(
   const headers = new Headers(init?.headers)
   headers.set('Accept', 'application/json')
   headers.set('Content-Type', 'application/json')
+  headers.set('User-Agent', JIRA_API_USER_AGENT)
   headers.set('Authorization', client.authorization)
   const response = await jiraFetch(`${client.site.siteUrl}${path}`, {
     ...init,


### PR DESCRIPTION
## What this fixes

Connecting a Jira Cloud site succeeds, but **no issues ever load** — every preset (Assigned / Reported / All Open / Done) and any JQL search shows *"No Jira issues found."* The same breakage silently affects creating issues, editing fields, commenting, and status transitions.

## Root cause

Jira Cloud's XSRF filter rejects **POST/PUT** REST calls that carry a **browser `User-Agent`**, responding `403` with body `XSRF check failed` — even under valid API-token (Basic) auth. Orca issues Jira requests via Electron's `net.fetch`, which rides the Chromium stack and sends a Chrome `User-Agent`.

That's why the failure looked so selective:
- **GET** calls (`/rest/api/3/myself` during connect) are exempt from XSRF → connecting worked, so the UI reported "connected."
- **POST** calls (`/rest/api/3/search/jql`, issue create, update, comment, transitions) all tripped the filter → 403.

`searchIssues` treats a non-401 error as a soft failure and returns `[]`, so the 403 surfaced to users as an empty backlog rather than an error.

## The change

Send an explicit non-browser `User-Agent` (`Orca`) on Jira REST requests, in both auth helpers (`jiraRequest` and `requestWithCredentials`) in `src/main/jira/client.ts`. This is the reliable, documented workaround for this Atlassian behavior; `X-Atlassian-Token: no-check` was tried and does **not** resolve this particular case.

~9 lines + a regression test. No API surface, type, or UI changes.

## Testing

- New unit test asserts a non-browser `User-Agent` is set on outgoing Jira calls (`src/main/jira/client.test.ts`) — `12/12` pass in that file.
- Verified live in a dev build against a real Jira Cloud site: before the change, all presets returned `403 / "XSRF check failed"`; after, issues load correctly across projects.
- Full gate green locally: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`.

## AI code-review summary

- **Cross-platform:** No platform-specific code; the header is set uniformly for macOS/Linux/Windows. No path, keyboard, or OS-API assumptions touched.
- **SSH / remote runtime:** The change is in the local-runtime Jira client path; it adds a request header only and doesn't assume local-only execution. Remote-runtime RPC callers are unaffected.
- **Git-provider compatibility:** N/A — Jira integration only; no source-control/review code touched.
- **Risk:** Minimal. A static request header; no behavior change for already-working GET calls. Worst case is a server that dislikes the UA, which is far less likely than the current browser-UA rejection.

## Notes / possible follow-ups (not in this PR)

- The `User-Agent` value is a plain `Orca`; happy to enrich it with the app version (e.g. `Orca/<version>`) if preferred.
- Separately, `searchIssues` masking a real error as an empty result made this hard to diagnose — surfacing search failures in the Tasks panel would be a worthwhile follow-up. Glad to open a PR for that if of interest.

## Screenshots

Before: connected but every preset shows "No Jira issues found." After: issues populate across projects. (Adding before/after screenshots to the PR conversation.)

---

🐳 Submitted by the **Orca Whisperer** — chased this one from "connection bug" through XSRF to a one-line fix.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5957">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->