### PR TITLE
fix: refit terminals after bulk mobile restore

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -96,6 +96,7 @@ import {
 import type { TerminalQuickCommand, TerminalQuickCommandScope } from '../../../../shared/types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import { refitAndRefreshAllTerminalPanes } from '@/lib/pane-manager/pane-manager-registry'
 import {
   getTerminalQuickCommandScope,
   isTerminalQuickCommandComplete,
@@ -1894,6 +1895,8 @@ export default function TerminalPane({
         settingsRef.current ?? undefined
       )
       if (restored) {
+        requestAnimationFrame(refitAndRefreshAllTerminalPanes)
+        window.setTimeout(refitAndRefreshAllTerminalPanes, 100)
         focusPane.terminal.focus()
       }
     },

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 import {
+  refitAndRefreshAllTerminalPanes,
   registerLivePaneManager,
   resetAllTerminalWebglAtlases,
   unregisterLivePaneManager
@@ -56,5 +57,55 @@ describe('pane manager registry', () => {
 
     expect(broken.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
     expect(healthy.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+  })
+
+  it('fits and refreshes every registered manager', () => {
+    const first = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      fitAllPanes: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>()
+    }
+    const second = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      fitAllPanes: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>()
+    }
+    registerLivePaneManager(first)
+    registeredManagers.push(first)
+    registerLivePaneManager(second)
+    registeredManagers.push(second)
+
+    refitAndRefreshAllTerminalPanes()
+
+    expect(first.fitAllPanes).toHaveBeenCalledTimes(1)
+    expect(first.refreshAllPanes).toHaveBeenCalledTimes(1)
+    expect(second.fitAllPanes).toHaveBeenCalledTimes(1)
+    expect(second.refreshAllPanes).toHaveBeenCalledTimes(1)
+  })
+
+  it('continues refitting later managers when one manager throws', () => {
+    const broken = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      fitAllPanes: vi.fn<() => void>(() => {
+        throw new Error('pane disposed')
+      }),
+      refreshAllPanes: vi.fn<() => void>()
+    }
+    registerLivePaneManager(broken)
+    registeredManagers.push(broken)
+    const healthy = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      fitAllPanes: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>()
+    }
+    registerLivePaneManager(healthy)
+    registeredManagers.push(healthy)
+
+    expect(() => refitAndRefreshAllTerminalPanes()).not.toThrow()
+
+    expect(broken.fitAllPanes).toHaveBeenCalledTimes(1)
+    expect(broken.refreshAllPanes).not.toHaveBeenCalled()
+    expect(healthy.fitAllPanes).toHaveBeenCalledTimes(1)
+    expect(healthy.refreshAllPanes).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -1,14 +1,16 @@
-type AtlasResettablePaneManager = {
+type RegisteredPaneManager = {
   resetWebglTextureAtlases(): void
+  fitAllPanes?: () => void
+  refreshAllPanes?: () => void
 }
 
-const liveManagers = new Set<AtlasResettablePaneManager>()
+const liveManagers = new Set<RegisteredPaneManager>()
 
-export function registerLivePaneManager(manager: AtlasResettablePaneManager): void {
+export function registerLivePaneManager(manager: RegisteredPaneManager): void {
   liveManagers.add(manager)
 }
 
-export function unregisterLivePaneManager(manager: AtlasResettablePaneManager): void {
+export function unregisterLivePaneManager(manager: RegisteredPaneManager): void {
   liveManagers.delete(manager)
 }
 
@@ -28,6 +30,19 @@ export function resetAllTerminalWebglAtlases(): void {
     } catch {
       // Why: stale WebGL recovery is best-effort during pane teardown; one
       // disposed manager should not prevent sibling terminals from repainting.
+    }
+  }
+}
+
+export function refitAndRefreshAllTerminalPanes(): void {
+  for (const manager of liveManagers) {
+    try {
+      // Why: after bulk desktop restore, background panes may have correct
+      // cols/rows but a stale xterm renderer until focus forces a repaint.
+      manager.fitAllPanes?.()
+      manager.refreshAllPanes?.()
+    } catch {
+      // Why: restore-all is best-effort across live managers during teardown.
     }
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -164,6 +164,18 @@ export class PaneManager {
     fitAllPanesInternal(this.panes)
   }
 
+  refreshAllPanes(): void {
+    for (const pane of this.panes.values()) {
+      try {
+        if (pane.terminal.rows > 0) {
+          pane.terminal.refresh(0, pane.terminal.rows - 1)
+        }
+      } catch {
+        // Why: restore-all repaint is best-effort while panes are mounting or tearing down.
+      }
+    }
+  }
+
   equalizePaneSizes(): void {
     if (this.panes.size < 2) {
       return

--- a/tests/e2e/mobile-banner.spec.ts
+++ b/tests/e2e/mobile-banner.spec.ts
@@ -73,7 +73,7 @@ test('mobile subscribe mounts overlay; collapse → chip; Take back dismisses', 
   await expect(overlay).not.toContainText(/your phone is in control/i)
 
   // Take back from the chip dismisses the overlay. The button calls
-  // runtime.restoreTerminalFit via IPC; main responds with desktop-fit + idle
+  // runtime.restoreTerminalFit via IPC; main responds with desktop-fit + desktop
   // driver events that we mirror here so the renderer state lands on the
   // post-take-back terminal state.
   await overlay.getByRole('button', { name: /take back/i }).click()
@@ -129,7 +129,8 @@ test('restore all refits non-focused restored terminal panes', async ({
   await waitForActiveTerminalManager(orcaPage)
   await splitActiveTerminalPane(orcaPage, 'vertical')
   const ptyIds = await waitForVisiblePanePtyIds(orcaPage, 2)
-  const [inactivePtyId, focusPtyId] = ptyIds
+  const focusPtyId = await waitForActivePanePtyId(orcaPage)
+  const inactivePtyId = ptyIds.find((ptyId) => ptyId !== focusPtyId)
   if (!inactivePtyId || !focusPtyId) {
     throw new Error('Expected two visible terminal panes with PTY bindings')
   }
@@ -249,6 +250,8 @@ async function installRestoreTerminalFitAutoRestoreRecorder(
       __mobileBannerRestoreCalls?: string[]
     }
     testGlobal.__mobileBannerRestoreCalls = []
+    // Why: the production restore path sets desktop control after clearing the
+    // fit override, so this harness mirrors both renderer-facing events.
     ipcMain.removeHandler('runtime:restoreTerminalFit')
     ipcMain.handle('runtime:restoreTerminalFit', (_event, args: { ptyId: string }) => {
       testGlobal.__mobileBannerRestoreCalls?.push(args.ptyId)
@@ -261,7 +264,7 @@ async function installRestoreTerminalFitAutoRestoreRecorder(
         })
         win.webContents.send('runtime:terminalDriverChanged', {
           ptyId: args.ptyId,
-          driver: { kind: 'idle' }
+          driver: { kind: 'desktop' }
         })
       }
       return { restored: true }

--- a/tests/e2e/mobile-banner.spec.ts
+++ b/tests/e2e/mobile-banner.spec.ts
@@ -1,7 +1,11 @@
 import type { ElectronApplication, Page, TestInfo } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { ensureTerminalVisible, waitForSessionReady, waitForActiveWorktree } from './helpers/store'
-import { waitForActivePanePtyId, waitForActiveTerminalManager } from './helpers/terminal'
+import {
+  splitActiveTerminalPane,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
 
 // Why: regression coverage for the mobile-presence-lock UX (PR #1532). Strong
 // DOM assertions guard the "doesn't mount / doesn't dismiss" regression class;
@@ -115,6 +119,47 @@ test('held phone-fit state mounts restore overlay without collapse', async ({
   await expect(overlay).toBeHidden({ timeout: 15_000 })
 })
 
+test('restore all refits non-focused restored terminal panes', async ({
+  orcaPage,
+  electronApp
+}) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage)
+  await splitActiveTerminalPane(orcaPage, 'vertical')
+  const ptyIds = await waitForVisiblePanePtyIds(orcaPage, 2)
+  const [inactivePtyId, focusPtyId] = ptyIds
+  if (!inactivePtyId || !focusPtyId) {
+    throw new Error('Expected two visible terminal panes with PTY bindings')
+  }
+  await installRestoreTerminalFitAutoRestoreRecorder(electronApp)
+
+  await sendHeldPhoneFitIpc(electronApp, { ptyId: inactivePtyId, cols: 45, rows: 20 })
+  await sendHeldPhoneFitIpc(electronApp, { ptyId: focusPtyId, cols: 45, rows: 20 })
+  await expect(orcaPage.locator('.mobile-driver-banner')).toHaveCount(2, { timeout: 15_000 })
+
+  await forcePaneToOneColumn(orcaPage, inactivePtyId)
+  await expect
+    .poll(() => getPaneTerminalCols(orcaPage, inactivePtyId), {
+      message: 'test harness should force the non-focused pane into the bad narrow state'
+    })
+    .toBeLessThanOrEqual(2)
+
+  await orcaPage
+    .locator(`[data-pty-id="${focusPtyId}"] .mobile-driver-banner`)
+    .getByRole('button', { name: /restore all terminals/i })
+    .click()
+
+  await expectRestoreTerminalFitCallSet(electronApp, [inactivePtyId, focusPtyId])
+  await expect
+    .poll(() => getPaneTerminalCols(orcaPage, inactivePtyId), {
+      timeout: 5_000,
+      message: 'Restore all should refit the non-focused restored pane'
+    })
+    .toBeGreaterThan(20)
+})
+
 async function sendMobileSubscribeIpc(
   electronApp: ElectronApplication,
   args: { ptyId: string; cols: number; rows: number }
@@ -196,6 +241,34 @@ async function installRestoreTerminalFitRecorder(electronApp: ElectronApplicatio
   })
 }
 
+async function installRestoreTerminalFitAutoRestoreRecorder(
+  electronApp: ElectronApplication
+): Promise<void> {
+  await electronApp.evaluate(({ BrowserWindow, ipcMain }) => {
+    const testGlobal = globalThis as typeof globalThis & {
+      __mobileBannerRestoreCalls?: string[]
+    }
+    testGlobal.__mobileBannerRestoreCalls = []
+    ipcMain.removeHandler('runtime:restoreTerminalFit')
+    ipcMain.handle('runtime:restoreTerminalFit', (_event, args: { ptyId: string }) => {
+      testGlobal.__mobileBannerRestoreCalls?.push(args.ptyId)
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send('runtime:terminalFitOverrideChanged', {
+          ptyId: args.ptyId,
+          mode: 'desktop-fit',
+          cols: 0,
+          rows: 0
+        })
+        win.webContents.send('runtime:terminalDriverChanged', {
+          ptyId: args.ptyId,
+          driver: { kind: 'idle' }
+        })
+      }
+      return { restored: true }
+    })
+  })
+}
+
 async function expectRestoreTerminalFitCalls(
   electronApp: ElectronApplication,
   expected: string[]
@@ -214,6 +287,80 @@ async function expectRestoreTerminalFitCalls(
       { message: 'restoreTerminalFit should be invoked through the production IPC channel' }
     )
     .toEqual(expected)
+}
+
+async function expectRestoreTerminalFitCallSet(
+  electronApp: ElectronApplication,
+  expected: string[]
+): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        electronApp.evaluate(
+          () =>
+            (
+              globalThis as typeof globalThis & {
+                __mobileBannerRestoreCalls?: string[]
+              }
+            ).__mobileBannerRestoreCalls ?? []
+        ),
+      { message: 'restore all should invoke the production restore channel for each PTY' }
+    )
+    .toEqual(expect.arrayContaining(expected))
+}
+
+async function waitForVisiblePanePtyIds(page: Page, expectedCount: number): Promise<string[]> {
+  let ptyIds: string[] = []
+  await expect
+    .poll(
+      async () => {
+        ptyIds = await page.evaluate(() => {
+          const state = window.__store?.getState()
+          const tabId = state?.activeTabId
+          const manager = tabId ? window.__paneManagers?.get(tabId) : null
+          return (manager?.getPanes?.() ?? [])
+            .map((pane) => pane.container?.dataset?.ptyId ?? null)
+            .filter((ptyId): ptyId is string => Boolean(ptyId))
+        })
+        return ptyIds.length
+      },
+      {
+        timeout: 15_000,
+        message: `Expected ${expectedCount} visible panes with PTY bindings`
+      }
+    )
+    .toBe(expectedCount)
+  return ptyIds
+}
+
+async function forcePaneToOneColumn(page: Page, ptyId: string): Promise<void> {
+  await page.evaluate((targetPtyId) => {
+    for (const manager of window.__paneManagers?.values?.() ?? []) {
+      const pane = manager
+        .getPanes?.()
+        .find((candidate) => candidate.container.dataset.ptyId === targetPtyId)
+      if (pane) {
+        pane.terminal.resize(1, Math.max(8, pane.terminal.rows))
+        pane.terminal.refresh(0, pane.terminal.rows - 1)
+        return
+      }
+    }
+    throw new Error(`No pane found for PTY ${targetPtyId}`)
+  }, ptyId)
+}
+
+async function getPaneTerminalCols(page: Page, ptyId: string): Promise<number> {
+  return page.evaluate((targetPtyId) => {
+    for (const manager of window.__paneManagers?.values?.() ?? []) {
+      const pane = manager
+        .getPanes?.()
+        .find((candidate) => candidate.container.dataset.ptyId === targetPtyId)
+      if (pane) {
+        return pane.terminal.cols
+      }
+    }
+    return 0
+  }, ptyId)
 }
 
 async function expectExpandedOverlayLeavesPaneReadable(page: Page, ptyId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Refit and refresh all live terminal pane managers after bulk "Restore all terminals" clears mobile fit state.
- Add a pane-manager registry path for best-effort global fit + refresh so non-focused restored terminal panes repaint after desktop dimensions come back.
- Add a deterministic E2E harness that forces the same stale narrow xterm state on a non-focused pane, clicks the real restore-all UI, and verifies that pane recovers.

Fixes #5840.

## Repro confidence
The harness does not run through a full organic phone-to-desktop remote session. It reproduces the renderer failure shape from the report: multiple held phone-fit panes, bulk restore, focused pane active, inactive restored pane stuck in a narrow xterm layout unless the global refit/refresh runs.

## Tests
- npm test -- --run src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts src/renderer/src/components/terminal-pane/terminal-fit-restore.test.ts src/main/runtime/fit-override-integration.test.ts src/main/runtime/mobile-subscribe-integration.test.ts
- npm run typecheck
- npx playwright test tests/e2e/mobile-banner.spec.ts --config tests/playwright.config.ts --project=electron-headless