### PR TITLE
feat(mobile): surface "Link an existing PR" in PR sidebar empty state

### DIFF
--- a/mobile/src/components/pr-sidebar/PrSidebarCreateEmptyState.tsx
+++ b/mobile/src/components/pr-sidebar/PrSidebarCreateEmptyState.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
-import { GitPullRequestArrow, RefreshCw } from 'lucide-react-native'
+import { GitPullRequestArrow, Link2, RefreshCw } from 'lucide-react-native'
 import { colors } from '../../theme/mobile-theme'
 import type { RpcClient } from '../../transport/rpc-client'
 import { resolveMobilePrPrefill, type MobilePrPrefill } from '../../source-control/mobile-pr-create'
 import { fetchWorktreeLinkedPR } from '../../source-control/mobile-pr-link'
 import { openMobilePrUrl } from '../MobilePrComposeSheet'
 import { MobilePrComposeForm } from './MobilePrComposeForm'
+import { MobileLinkPrForm } from './MobileLinkPrForm'
 import { prCreateEmptyStateStyles as styles } from './pr-create-empty-state-styles'
 
 type Props = {
@@ -17,10 +18,11 @@ type Props = {
   onCreated: () => void
 }
 
-type Mode = 'choose' | 'create'
+type Mode = 'choose' | 'create' | 'link'
 
-// Empty state for a branch with no PR. Keep this scoped to desktop's no-PR
-// surface: create/refresh here; linked-PR edits belong outside this panel.
+// Empty state for a branch with no PR: create a new PR, or link an existing one
+// (the no-PR surface is the natural home for linking — desktop's link entry lives
+// on its PR card, but on mobile this is where a user lands with nothing linked).
 export function PrSidebarCreateEmptyState({ client, worktreeId, gitBranch, onCreated }: Props) {
   const [prefill, setPrefill] = useState<MobilePrPrefill | null>(null)
   const [mode, setMode] = useState<Mode>('choose')
@@ -103,6 +105,22 @@ export function PrSidebarCreateEmptyState({ client, worktreeId, gitBranch, onCre
     )
   }
 
+  if (mode === 'link') {
+    return (
+      <View style={styles.composerArea}>
+        <MobileLinkPrForm
+          client={client}
+          worktreeId={worktreeId}
+          onCancel={() => setMode('choose')}
+          onLinked={() => {
+            setMode('choose')
+            onCreated()
+          }}
+        />
+      </View>
+    )
+  }
+
   return (
     <View style={styles.section}>
       <View style={styles.header}>
@@ -148,6 +166,16 @@ export function PrSidebarCreateEmptyState({ client, worktreeId, gitBranch, onCre
               : 'The current branch is not linked to an open PR.'}
         </Text>
         {createWarning ? <Text style={styles.bodyText}>{createWarning}</Text> : null}
+        <Pressable
+          style={({ pressed }) => [styles.linkButton, pressed && styles.linkButtonPressed]}
+          onPress={() => setMode('link')}
+          disabled={!client}
+          accessibilityRole="button"
+          accessibilityLabel="Link an existing pull request"
+        >
+          <Link2 size={14} color={colors.textSecondary} strokeWidth={2.2} />
+          <Text style={styles.linkButtonText}>Link an existing PR</Text>
+        </Pressable>
       </View>
     </View>
   )

--- a/mobile/src/components/pr-sidebar/PrSidebarCreateEmptyState.tsx
+++ b/mobile/src/components/pr-sidebar/PrSidebarCreateEmptyState.tsx
@@ -29,8 +29,7 @@ export function PrSidebarCreateEmptyState({ client, worktreeId, gitBranch, onCre
   const [loading, setLoading] = useState(false)
   const [createWarning, setCreateWarning] = useState<string | null>(null)
   // A persisted linkedPR while the branch shows no PR means the linked PR could
-  // not be resolved. Mention it, but keep link editing out of this desktop-parity
-  // create surface.
+  // not be resolved. Mention it while still allowing the user to relink.
   const [orphanLinkedPR, setOrphanLinkedPR] = useState<number | null>(null)
 
   useEffect(() => {
@@ -167,13 +166,23 @@ export function PrSidebarCreateEmptyState({ client, worktreeId, gitBranch, onCre
         </Text>
         {createWarning ? <Text style={styles.bodyText}>{createWarning}</Text> : null}
         <Pressable
-          style={({ pressed }) => [styles.linkButton, pressed && styles.linkButtonPressed]}
+          style={({ pressed }) => [
+            styles.linkButton,
+            !client && styles.linkButtonDisabled,
+            pressed && styles.linkButtonPressed
+          ]}
           onPress={() => setMode('link')}
           disabled={!client}
           accessibilityRole="button"
           accessibilityLabel="Link an existing pull request"
+          accessibilityState={{ disabled: !client }}
+          hitSlop={6}
         >
-          <Link2 size={14} color={colors.textSecondary} strokeWidth={2.2} />
+          <Link2
+            size={14}
+            color={client ? colors.textSecondary : colors.textMuted}
+            strokeWidth={2.2}
+          />
           <Text style={styles.linkButtonText}>Link an existing PR</Text>
         </Pressable>
       </View>

--- a/mobile/src/components/pr-sidebar/pr-create-empty-state-styles.ts
+++ b/mobile/src/components/pr-sidebar/pr-create-empty-state-styles.ts
@@ -87,10 +87,14 @@ export const prCreateEmptyStateStyles = StyleSheet.create({
   // Secondary link-an-existing-PR affordance, set apart from the body copy.
   linkButton: {
     marginTop: spacing.xs,
+    minHeight: 32,
     alignSelf: 'flex-start',
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xs
+  },
+  linkButtonDisabled: {
+    opacity: 0.5
   },
   linkButtonPressed: {
     opacity: 0.6

--- a/mobile/src/components/pr-sidebar/pr-create-empty-state-styles.ts
+++ b/mobile/src/components/pr-sidebar/pr-create-empty-state-styles.ts
@@ -83,5 +83,21 @@ export const prCreateEmptyStateStyles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: colors.borderSubtle,
     padding: spacing.md
+  },
+  // Secondary link-an-existing-PR affordance, set apart from the body copy.
+  linkButton: {
+    marginTop: spacing.xs,
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs
+  },
+  linkButtonPressed: {
+    opacity: 0.6
+  },
+  linkButtonText: {
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontWeight: '600'
   }
 })


### PR DESCRIPTION
## Summary

Adds a **"Link an existing PR"** entry point to the mobile PR sidebar's no-PR empty state.

The mobile link-PR building blocks already existed and were unit-tested — `MobileLinkPrForm`, `linkMobilePr()`, and `parseGitHubPrReference()` — but nothing rendered the form, so only *unlink* was reachable. This wires up the missing entry point.

### How

In `PrSidebarCreateEmptyState` (the surface shown when a branch has no open PR):
- Add a `'link'` mode alongside `'choose'`/`'create'`
- Render the existing `MobileLinkPrForm` and refetch the sidebar on success
- Add a secondary "Link an existing PR" action (Link2 icon) below the empty-state copy

**Flow:** tap "Link an existing PR" → enter a number, `#123`, or a GitHub URL → `parseGitHubPrReference` validates → `linkMobilePr` calls `worktree.set { linkedPR }` (same RPC desktop uses) → sidebar refetches and shows the PR with full merge/close/unlink actions.

GitHub-scoped by design, matching desktop (the parser and `linkedPR` key are GitHub-only; other providers use separate `linked*` keys).

## Screenshots

UI change is mobile-only: a secondary "Link an existing PR" action with a Link2 icon appears below the empty-state copy on a branch with no open PR; tapping it swaps the composer area to the link form. Verified on a physical Android device (release APK). Screen recording to be attached in the PR conversation rather than committed (per repo policy on PR evidence images).

## Testing

- [x] `pnpm lint` (oxlint clean)
- [x] `pnpm typecheck` (`tsc --noEmit`: 0 errors)
- [x] `pnpm test` (`mobile-pr-link`, `github-pr-link-parse`: passing)
- [ ] `pnpm build` (built the mobile arm64 release APK and verified the flow on a physical Android device; the desktop `pnpm build` is unaffected as this is a mobile-only change)
- [x] Existing unit tests cover `linkMobilePr()` and `parseGitHubPrReference()`; this PR only wires up the already-tested building blocks to a UI entry point, so no new tests were needed

## AI Review Report

Reviewed the diff with an AI coding agent. The change is small and additive: a new `'link'` `Mode` branch, a `Pressable` entry point, and three stylesheet entries. Main risks checked:
- **State handling** — `mode` transitions (`choose`↔`link`) are self-contained; `onLinked` returns to `choose` and triggers the existing `onCreated` refetch, matching the `create` flow.
- **Null safety** — the link action is disabled when `client` is null, mirroring the create button.
- **Cross-platform compatibility** — this is a React Native (Android/mobile) surface, not Electron. No keyboard shortcuts, accelerators, file paths, or shell behavior are touched, so there are no macOS/Linux/Windows desktop platform differences introduced. Iconography and styling use existing theme tokens.

No issues flagged that required code changes. CodeRabbit's automated review reported no actionable comments.

## Security Audit

- **Input handling** — PR reference input is parsed by the existing, unit-tested `parseGitHubPrReference` (accepts a bare number, `#123`, or a github.com URL) before any RPC call; invalid input is rejected client-side.
- **Command execution / path handling** — none introduced; no shell, filesystem, or path operations in this change.
- **IPC / RPC** — linking uses the existing `worktree.set { linkedPR }` RPC that desktop already uses and that is allowlisted for mobile; no new RPC surface is added.
- **Auth / secrets / dependencies** — no auth changes, no secrets, no new dependencies (`lucide-react-native` icons already in use).

No follow-up security work needed.

## Notes

GitHub-scoped by design to match desktop parity. Other git providers use separate `linked*` keys and are out of scope for this entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
