### PR TITLE
Add basic wikilink support to the rich Markdown editor

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -140,6 +140,12 @@
   --input: #e5e5e5;
   --ring: #a1a1a1;
   --terminal-pane-locate: var(--color-blue-600);
+  --markdown-doc-link-color: #0969da;
+  --markdown-doc-link-decoration-color: color-mix(
+    in srgb,
+    var(--markdown-doc-link-color) 45%,
+    transparent
+  );
   --ai-action-accent: var(--color-violet-500);
   --status-success: #15803d;
   --status-success-background: color-mix(in srgb, var(--status-success) 10%, transparent);
@@ -219,6 +225,12 @@
   --input: rgb(255 255 255 / 0.15);
   --ring: #737373;
   --terminal-pane-locate: var(--color-blue-400);
+  --markdown-doc-link-color: #58a6ff;
+  --markdown-doc-link-decoration-color: color-mix(
+    in srgb,
+    var(--markdown-doc-link-color) 45%,
+    transparent
+  );
   --ai-action-accent: var(--color-violet-400);
   --status-success: #86efac;
   --status-success-background: color-mix(in srgb, var(--status-success) 10%, transparent);
@@ -1799,9 +1811,9 @@
 }
 
 .monaco-editor .monaco-markdown-doc-link {
-  color: #58a6ff !important;
+  color: var(--markdown-doc-link-color) !important;
   text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
+  text-decoration-color: var(--markdown-doc-link-decoration-color);
   text-underline-offset: 2px;
 }
 

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -581,6 +581,12 @@
   color: #58a6ff;
 }
 
+.markdown-light .markdown-body .markdown-doc-link,
+.markdown-dark .markdown-body .markdown-doc-link {
+  color: var(--markdown-doc-link-color);
+  text-decoration-color: var(--markdown-doc-link-decoration-color);
+}
+
 .markdown-light .markdown-body .markdown-doc-link-broken,
 .markdown-dark .markdown-body .markdown-doc-link-broken {
   color: var(--muted-foreground);

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -1261,14 +1261,10 @@
 /* ── Doc Links ───────────────────────────────────────── */
 
 .rich-markdown-editor .rich-markdown-doc-link {
-  color: #0969da;
+  color: var(--markdown-doc-link-color);
   text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
+  text-decoration-color: var(--markdown-doc-link-decoration-color);
   text-underline-offset: 2px;
-}
-
-.dark .rich-markdown-editor .rich-markdown-doc-link {
-  color: #58a6ff;
 }
 
 .rich-markdown-editor .rich-markdown-doc-link.rich-markdown-doc-link--missing {
@@ -1289,14 +1285,10 @@
 /* In-progress [[target]] text while cursor is inside. Matches the committed
    doc-link styling so the visual doesn't jump when the atom node takes over. */
 .rich-markdown-editor .rich-markdown-doc-link-preview {
-  color: #0969da;
+  color: var(--markdown-doc-link-color);
   text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
+  text-decoration-color: var(--markdown-doc-link-decoration-color);
   text-underline-offset: 2px;
-}
-
-.dark .rich-markdown-editor .rich-markdown-doc-link-preview {
-  color: #58a6ff;
 }
 
 .rich-markdown-editor .rich-markdown-doc-link-preview.rich-markdown-doc-link-preview--missing {

--- a/src/renderer/src/components/editor/markdown-doc-link-create.test.ts
+++ b/src/renderer/src/components/editor/markdown-doc-link-create.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { joinPath } from '@/lib/path'
 import {
   createMissingMarkdownDocLinkDocument,
   getInitialMarkdownDocLinkDocumentContent
@@ -12,13 +13,15 @@ describe('getInitialMarkdownDocLinkDocumentContent', () => {
 
 describe('createMissingMarkdownDocLinkDocument', () => {
   it('creates a missing markdown target and returns its document record', async () => {
+    const worktreePath = joinPath('repo', 'workspace')
+    const targetPath = joinPath(worktreePath, 'docs/setup guide.md')
     const pathExists = vi.fn().mockResolvedValue(false)
     const createPath = vi.fn().mockResolvedValue(undefined)
     const writeFile = vi.fn().mockResolvedValue(undefined)
     const context = {
       settings: { activeRuntimeEnvironmentId: null },
       worktreeId: 'wt-1',
-      worktreePath: '/repo'
+      worktreePath
     }
 
     await expect(
@@ -26,21 +29,23 @@ describe('createMissingMarkdownDocLinkDocument', () => {
         actions: { createPath, pathExists, writeFile },
         context,
         target: 'docs/setup guide#Install steps',
-        worktreePath: '/repo'
+        worktreePath
       })
     ).resolves.toEqual({
-      filePath: '/repo/docs/setup guide.md',
+      filePath: targetPath,
       relativePath: 'docs/setup guide.md',
       basename: 'setup guide.md',
       name: 'setup guide'
     })
 
-    expect(pathExists).toHaveBeenCalledWith(context, '/repo/docs/setup guide.md')
-    expect(createPath).toHaveBeenCalledWith(context, '/repo/docs/setup guide.md', 'file')
-    expect(writeFile).toHaveBeenCalledWith(context, '/repo/docs/setup guide.md', '# setup guide\n')
+    expect(pathExists).toHaveBeenCalledWith(context, targetPath)
+    expect(createPath).toHaveBeenCalledWith(context, targetPath, 'file')
+    expect(writeFile).toHaveBeenCalledWith(context, targetPath, '# setup guide\n')
   })
 
   it('opens an existing target without rewriting it', async () => {
+    const worktreePath = joinPath('repo', 'workspace')
+    const targetPath = joinPath(worktreePath, 'notes/todo.md')
     const pathExists = vi.fn().mockResolvedValue(true)
     const createPath = vi.fn()
     const writeFile = vi.fn()
@@ -51,17 +56,44 @@ describe('createMissingMarkdownDocLinkDocument', () => {
         context: {
           settings: { activeRuntimeEnvironmentId: null },
           worktreeId: 'wt-1',
-          worktreePath: '/repo'
+          worktreePath
         },
         target: 'notes/todo.md',
-        worktreePath: '/repo'
+        worktreePath
       })
     ).resolves.toMatchObject({
-      filePath: '/repo/notes/todo.md',
+      filePath: targetPath,
       relativePath: 'notes/todo.md'
     })
 
     expect(createPath).not.toHaveBeenCalled()
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  it('treats create-if-missing races as existing targets', async () => {
+    const worktreePath = joinPath('repo', 'workspace')
+    const targetPath = joinPath(worktreePath, 'notes/race.md')
+    const pathExists = vi.fn().mockResolvedValue(false)
+    const createPath = vi.fn().mockRejectedValue(new Error('EEXIST: file already exists'))
+    const writeFile = vi.fn()
+    const context = {
+      settings: { activeRuntimeEnvironmentId: null },
+      worktreeId: 'wt-1',
+      worktreePath
+    }
+
+    await expect(
+      createMissingMarkdownDocLinkDocument({
+        actions: { createPath, pathExists, writeFile },
+        context,
+        target: 'notes/race',
+        worktreePath
+      })
+    ).resolves.toMatchObject({
+      filePath: targetPath,
+      relativePath: 'notes/race.md'
+    })
+
     expect(writeFile).not.toHaveBeenCalled()
   })
 
@@ -76,10 +108,10 @@ describe('createMissingMarkdownDocLinkDocument', () => {
         context: {
           settings: { activeRuntimeEnvironmentId: null },
           worktreeId: 'wt-1',
-          worktreePath: '/repo'
+          worktreePath: joinPath('repo', 'workspace')
         },
         target: '../outside',
-        worktreePath: '/repo'
+        worktreePath: joinPath('repo', 'workspace')
       })
     ).resolves.toBeNull()
 

--- a/src/renderer/src/components/editor/markdown-doc-link-create.test.ts
+++ b/src/renderer/src/components/editor/markdown-doc-link-create.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createMissingMarkdownDocLinkDocument,
+  getInitialMarkdownDocLinkDocumentContent
+} from './markdown-doc-link-create'
+
+describe('getInitialMarkdownDocLinkDocumentContent', () => {
+  it('creates a heading from the note title', () => {
+    expect(getInitialMarkdownDocLinkDocumentContent('Project Notes')).toBe('# Project Notes\n')
+  })
+})
+
+describe('createMissingMarkdownDocLinkDocument', () => {
+  it('creates a missing markdown target and returns its document record', async () => {
+    const pathExists = vi.fn().mockResolvedValue(false)
+    const createPath = vi.fn().mockResolvedValue(undefined)
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const context = {
+      settings: { activeRuntimeEnvironmentId: null },
+      worktreeId: 'wt-1',
+      worktreePath: '/repo'
+    }
+
+    await expect(
+      createMissingMarkdownDocLinkDocument({
+        actions: { createPath, pathExists, writeFile },
+        context,
+        target: 'docs/setup guide#Install steps',
+        worktreePath: '/repo'
+      })
+    ).resolves.toEqual({
+      filePath: '/repo/docs/setup guide.md',
+      relativePath: 'docs/setup guide.md',
+      basename: 'setup guide.md',
+      name: 'setup guide'
+    })
+
+    expect(pathExists).toHaveBeenCalledWith(context, '/repo/docs/setup guide.md')
+    expect(createPath).toHaveBeenCalledWith(context, '/repo/docs/setup guide.md', 'file')
+    expect(writeFile).toHaveBeenCalledWith(context, '/repo/docs/setup guide.md', '# setup guide\n')
+  })
+
+  it('opens an existing target without rewriting it', async () => {
+    const pathExists = vi.fn().mockResolvedValue(true)
+    const createPath = vi.fn()
+    const writeFile = vi.fn()
+
+    await expect(
+      createMissingMarkdownDocLinkDocument({
+        actions: { createPath, pathExists, writeFile },
+        context: {
+          settings: { activeRuntimeEnvironmentId: null },
+          worktreeId: 'wt-1',
+          worktreePath: '/repo'
+        },
+        target: 'notes/todo.md',
+        worktreePath: '/repo'
+      })
+    ).resolves.toMatchObject({
+      filePath: '/repo/notes/todo.md',
+      relativePath: 'notes/todo.md'
+    })
+
+    expect(createPath).not.toHaveBeenCalled()
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsafe targets', async () => {
+    const pathExists = vi.fn()
+    const createPath = vi.fn()
+    const writeFile = vi.fn()
+
+    await expect(
+      createMissingMarkdownDocLinkDocument({
+        actions: { createPath, pathExists, writeFile },
+        context: {
+          settings: { activeRuntimeEnvironmentId: null },
+          worktreeId: 'wt-1',
+          worktreePath: '/repo'
+        },
+        target: '../outside',
+        worktreePath: '/repo'
+      })
+    ).resolves.toBeNull()
+
+    expect(pathExists).not.toHaveBeenCalled()
+    expect(createPath).not.toHaveBeenCalled()
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/markdown-doc-link-create.ts
+++ b/src/renderer/src/components/editor/markdown-doc-link-create.ts
@@ -34,6 +34,11 @@ function createMarkdownDocumentRecord(
   }
 }
 
+function isRuntimeFileExistsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
+  return message.includes('eexist') || message.includes('already exists')
+}
+
 export function getInitialMarkdownDocLinkDocumentContent(title: string): string {
   return `# ${title}\n`
 }
@@ -58,7 +63,14 @@ export async function createMissingMarkdownDocLinkDocument({
     return document
   }
 
-  await actions.createPath(context, document.filePath, 'file')
+  try {
+    await actions.createPath(context, document.filePath, 'file')
+  } catch (err) {
+    if (isRuntimeFileExistsError(err)) {
+      return document
+    }
+    throw err
+  }
   await actions.writeFile(
     context,
     document.filePath,

--- a/src/renderer/src/components/editor/markdown-doc-link-create.ts
+++ b/src/renderer/src/components/editor/markdown-doc-link-create.ts
@@ -1,0 +1,68 @@
+import type { MarkdownDocument } from '../../../../shared/types'
+import { basename, joinPath } from '@/lib/path'
+import {
+  createRuntimePath,
+  runtimePathExists,
+  writeRuntimeFile,
+  type RuntimeFileOperationArgs
+} from '@/runtime/runtime-file-client'
+import { getCreatableMarkdownDocLinkTarget, stripMarkdownExtension } from './markdown-doc-links'
+
+type RuntimeFileActions = {
+  createPath: typeof createRuntimePath
+  pathExists: typeof runtimePathExists
+  writeFile: typeof writeRuntimeFile
+}
+
+type CreateMissingMarkdownDocLinkDocumentArgs = {
+  actions?: RuntimeFileActions
+  context: RuntimeFileOperationArgs
+  target: string
+  worktreePath: string
+}
+
+function createMarkdownDocumentRecord(
+  worktreePath: string,
+  relativePath: string
+): MarkdownDocument {
+  const fileName = basename(relativePath)
+  return {
+    filePath: joinPath(worktreePath, relativePath),
+    relativePath,
+    basename: fileName,
+    name: stripMarkdownExtension(fileName)
+  }
+}
+
+export function getInitialMarkdownDocLinkDocumentContent(title: string): string {
+  return `# ${title}\n`
+}
+
+export async function createMissingMarkdownDocLinkDocument({
+  actions = {
+    createPath: createRuntimePath,
+    pathExists: runtimePathExists,
+    writeFile: writeRuntimeFile
+  },
+  context,
+  target,
+  worktreePath
+}: CreateMissingMarkdownDocLinkDocumentArgs): Promise<MarkdownDocument | null> {
+  const creatable = getCreatableMarkdownDocLinkTarget(target)
+  if (!creatable) {
+    return null
+  }
+
+  const document = createMarkdownDocumentRecord(worktreePath, creatable.relativePath)
+  if (await actions.pathExists(context, document.filePath)) {
+    return document
+  }
+
+  await actions.createPath(context, document.filePath, 'file')
+  await actions.writeFile(
+    context,
+    document.filePath,
+    getInitialMarkdownDocLinkDocumentContent(creatable.title)
+  )
+  return document
+}

--- a/src/renderer/src/components/editor/markdown-doc-link-toasts.ts
+++ b/src/renderer/src/components/editor/markdown-doc-link-toasts.ts
@@ -1,0 +1,81 @@
+import { toast } from 'sonner'
+import type { MarkdownDocument } from '../../../../shared/types'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
+import { translate } from '@/i18n/i18n'
+import { getCreatableMarkdownDocLinkTarget } from './markdown-doc-links'
+
+type MissingDocLinkToastOptions = {
+  onCreate: (target: string) => Promise<void>
+  target: string
+}
+
+export function showInvalidMarkdownDocLinkTargetToast(): void {
+  toast.error(
+    translate(
+      'auto.components.editor.markdown.doc.link.toasts.3ac54dda7f',
+      'Cannot create note from this link'
+    )
+  )
+}
+
+export function showCreatedMarkdownDocLinkToast(relativePath: string): void {
+  toast.success(
+    translate('auto.components.editor.markdown.doc.link.toasts.86a480c022', 'Note created'),
+    { description: relativePath }
+  )
+}
+
+export function showMissingMarkdownDocLinkCreateToast({
+  onCreate,
+  target
+}: MissingDocLinkToastOptions): void {
+  const creatable = getCreatableMarkdownDocLinkTarget(target)
+  if (!creatable) {
+    showInvalidMarkdownDocLinkTargetToast()
+    return
+  }
+
+  toast.info(
+    translate('auto.components.editor.markdown.doc.link.toasts.dd5af2ab74', 'Note not found'),
+    {
+      description: creatable.relativePath,
+      action: {
+        label: translate(
+          'auto.components.editor.markdown.doc.link.toasts.53b9d723ef',
+          'Create note'
+        ),
+        onClick: () => {
+          void onCreate(target).catch((err) => {
+            toast.error(
+              extractIpcErrorMessage(
+                err,
+                translate(
+                  'auto.components.editor.markdown.doc.link.toasts.e3cfe7a2d5',
+                  'Failed to create note'
+                )
+              )
+            )
+          })
+        }
+      }
+    }
+  )
+}
+
+export function showAmbiguousMarkdownDocLinkToast(matches: MarkdownDocument[]): void {
+  const previewMatches = matches
+    .slice(0, 3)
+    .map((match) => match.relativePath)
+    .join(', ')
+  const overflowCount = matches.length - 3
+  const description =
+    overflowCount > 0 ? `${previewMatches}, +${overflowCount} more` : previewMatches
+
+  toast.warning(
+    translate(
+      'auto.components.editor.markdown.doc.link.toasts.0c8765cd46',
+      'Document link is ambiguous'
+    ),
+    { description }
+  )
+}

--- a/src/renderer/src/components/editor/markdown-doc-link-toasts.ts
+++ b/src/renderer/src/components/editor/markdown-doc-link-toasts.ts
@@ -68,8 +68,12 @@ export function showAmbiguousMarkdownDocLinkToast(matches: MarkdownDocument[]): 
     .map((match) => match.relativePath)
     .join(', ')
   const overflowCount = matches.length - 3
-  const description =
-    overflowCount > 0 ? `${previewMatches}, +${overflowCount} more` : previewMatches
+  const overflowSuffix = translate(
+    'auto.components.editor.markdown.doc.link.toasts.2f55cdad12',
+    '+{{value0}} more',
+    { value0: overflowCount }
+  )
+  const description = overflowCount > 0 ? `${previewMatches}, ${overflowSuffix}` : previewMatches
 
   toast.warning(
     translate(

--- a/src/renderer/src/components/editor/markdown-doc-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-doc-links.test.ts
@@ -247,6 +247,8 @@ describe('getCreatableMarkdownDocLinkTarget', () => {
     expect(getCreatableMarkdownDocLinkTarget('/absolute')).toBeNull()
     expect(getCreatableMarkdownDocLinkTarget('C:\\repo\\note')).toBeNull()
     expect(getCreatableMarkdownDocLinkTarget('bad|alias')).toBeNull()
+    expect(getCreatableMarkdownDocLinkTarget('bad\tname')).toBeNull()
+    expect(getCreatableMarkdownDocLinkTarget('bad\u007fname')).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/editor/markdown-doc-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-doc-links.test.ts
@@ -6,6 +6,7 @@ import type { MarkdownDocument } from '../../../../shared/types'
 import {
   createMarkdownDocumentIndex,
   createMarkdownDocLinkHref,
+  getCreatableMarkdownDocLinkTarget,
   getMarkdownDocLinkAnchor,
   parseMarkdownDocLinkHref,
   remarkMarkdownDocLinks,
@@ -48,6 +49,39 @@ describe('splitMarkdownDocLinkText', () => {
     expect(splitMarkdownDocLinkText('See [[docs/setup-guide.md|Setup Guide]].')).toEqual([
       { type: 'text', value: 'See ' },
       { type: 'docLink', target: 'docs/setup-guide.md', label: 'Setup Guide' },
+      { type: 'text', value: '.' }
+    ])
+  })
+
+  it('splits heading and block-fragment doc links', () => {
+    expect(splitMarkdownDocLinkText('See [[docs/setup-guide.md#Install steps]].')).toEqual([
+      { type: 'text', value: 'See ' },
+      {
+        type: 'docLink',
+        target: 'docs/setup-guide.md#Install steps',
+        label: 'docs/setup-guide.md#Install steps'
+      },
+      { type: 'text', value: '.' }
+    ])
+    expect(splitMarkdownDocLinkText('See [[docs/setup-guide.md#^block-id]].')).toEqual([
+      { type: 'text', value: 'See ' },
+      {
+        type: 'docLink',
+        target: 'docs/setup-guide.md#^block-id',
+        label: 'docs/setup-guide.md#^block-id'
+      },
+      { type: 'text', value: '.' }
+    ])
+  })
+
+  it('treats embedded doc links as a leading marker plus doc link', () => {
+    expect(splitMarkdownDocLinkText('Embed ![[docs/setup-guide.md#^block-id]].')).toEqual([
+      { type: 'text', value: 'Embed !' },
+      {
+        type: 'docLink',
+        target: 'docs/setup-guide.md#^block-id',
+        label: 'docs/setup-guide.md#^block-id'
+      },
       { type: 'text', value: '.' }
     ])
   })
@@ -96,6 +130,15 @@ describe('resolveMarkdownDocLink', () => {
     const index = createMarkdownDocumentIndex(documents)
 
     expect(resolveMarkdownDocLink('docs/setup-guide#Install steps', index)).toMatchObject({
+      status: 'resolved',
+      document: { relativePath: 'docs/setup-guide.md' }
+    })
+  })
+
+  it('resolves block refs against the document target', () => {
+    const index = createMarkdownDocumentIndex(documents)
+
+    expect(resolveMarkdownDocLink('docs/setup-guide#^block-id', index)).toMatchObject({
       status: 'resolved',
       document: { relativePath: 'docs/setup-guide.md' }
     })
@@ -170,12 +213,53 @@ describe('doc link hrefs', () => {
   })
 })
 
+describe('getCreatableMarkdownDocLinkTarget', () => {
+  it('normalizes missing note targets to markdown files', () => {
+    expect(getCreatableMarkdownDocLinkTarget('Project Notes')).toEqual({
+      relativePath: 'Project Notes.md',
+      title: 'Project Notes'
+    })
+    expect(getCreatableMarkdownDocLinkTarget('docs/setup-guide.md#Install steps')).toEqual({
+      relativePath: 'docs/setup-guide.md',
+      title: 'setup-guide'
+    })
+    expect(getCreatableMarkdownDocLinkTarget('docs\\setup-guide')).toEqual({
+      relativePath: 'docs/setup-guide.md',
+      title: 'setup-guide'
+    })
+  })
+
+  it('preserves explicit markdown-family extensions', () => {
+    expect(getCreatableMarkdownDocLinkTarget('notes/readme.MDX')).toEqual({
+      relativePath: 'notes/readme.MDX',
+      title: 'readme'
+    })
+    expect(getCreatableMarkdownDocLinkTarget('notes/readme.markdown')).toEqual({
+      relativePath: 'notes/readme.markdown',
+      title: 'readme'
+    })
+  })
+
+  it('rejects unsafe or unsupported create targets', () => {
+    expect(getCreatableMarkdownDocLinkTarget('')).toBeNull()
+    expect(getCreatableMarkdownDocLinkTarget('#Heading')).toBeNull()
+    expect(getCreatableMarkdownDocLinkTarget('../outside')).toBeNull()
+    expect(getCreatableMarkdownDocLinkTarget('/absolute')).toBeNull()
+    expect(getCreatableMarkdownDocLinkTarget('C:\\repo\\note')).toBeNull()
+    expect(getCreatableMarkdownDocLinkTarget('bad|alias')).toBeNull()
+  })
+})
+
 describe('getMarkdownDocLinkAnchor', () => {
   it('extracts preview heading anchor ids from doc link targets', () => {
     expect(getMarkdownDocLinkAnchor('docs/setup-guide#Install steps')).toBe('install-steps')
     expect(getMarkdownDocLinkAnchor('docs/setup-guide#What is new?')).toBe('what-is-new')
     expect(getMarkdownDocLinkAnchor('docs/setup-guide#install-steps')).toBe('install-steps')
     expect(getMarkdownDocLinkAnchor('docs/setup-guide')).toBeNull()
+  })
+
+  it('does not treat block refs as heading anchors', () => {
+    expect(getMarkdownDocLinkAnchor('docs/setup-guide#^block-id')).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/editor/markdown-doc-links.ts
+++ b/src/renderer/src/components/editor/markdown-doc-links.ts
@@ -67,6 +67,16 @@ export function getMarkdownDocLinkDocumentTarget(target: string): string {
   return target.slice(0, hashIndex)
 }
 
+function hasDocLinkControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    if (code <= 31 || code === 127) {
+      return true
+    }
+  }
+  return false
+}
+
 export function getCreatableMarkdownDocLinkTarget(
   target: string
 ): CreatableMarkdownDocLinkTarget | null {
@@ -92,8 +102,8 @@ export function getCreatableMarkdownDocLinkTarget(
         !segment ||
         segment === '.' ||
         segment === '..' ||
-        segment.includes('\0') ||
-        /[\r\n#<>:"|?*[\]]/.test(segment)
+        hasDocLinkControlCharacter(segment) ||
+        /[#<>:"|?*[\]]/.test(segment)
     )
   ) {
     return null

--- a/src/renderer/src/components/editor/markdown-doc-links.ts
+++ b/src/renderer/src/components/editor/markdown-doc-links.ts
@@ -42,6 +42,11 @@ export type MarkdownDocLinkResolution =
   | { status: 'missing' }
   | { status: 'ambiguous'; matches: MarkdownDocument[] }
 
+export type CreatableMarkdownDocLinkTarget = {
+  relativePath: string
+  title: string
+}
+
 export function stripMarkdownExtension(value: string): string {
   const lower = value.toLowerCase()
   for (const extension of ['.markdown', '.mdx', '.md']) {
@@ -52,7 +57,7 @@ export function stripMarkdownExtension(value: string): string {
   return value
 }
 
-function getMarkdownDocLinkDocumentTarget(target: string): string {
+export function getMarkdownDocLinkDocumentTarget(target: string): string {
   const hashIndex = target.indexOf('#')
   if (hashIndex <= 0) {
     return target
@@ -62,12 +67,55 @@ function getMarkdownDocLinkDocumentTarget(target: string): string {
   return target.slice(0, hashIndex)
 }
 
+export function getCreatableMarkdownDocLinkTarget(
+  target: string
+): CreatableMarkdownDocLinkTarget | null {
+  const documentTarget = getMarkdownDocLinkDocumentTarget(target).trim()
+  if (!documentTarget) {
+    return null
+  }
+  const normalized = documentTarget.replaceAll('\\', '/').replace(/\/+/g, '/')
+  if (
+    !normalized ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('~') ||
+    /^[A-Za-z]:/.test(normalized) ||
+    normalized.endsWith('/')
+  ) {
+    return null
+  }
+
+  const segments = normalized.split('/')
+  if (
+    segments.some(
+      (segment) =>
+        !segment ||
+        segment === '.' ||
+        segment === '..' ||
+        segment.includes('\0') ||
+        /[\r\n#<>:"|?*[\]]/.test(segment)
+    )
+  ) {
+    return null
+  }
+
+  const relativePath = /\.(?:md|mdx|markdown)$/i.test(normalized) ? normalized : `${normalized}.md`
+  const fileName = segments.at(-1) ?? ''
+  const title = stripMarkdownExtension(fileName).trim()
+  return title ? { relativePath, title } : null
+}
+
 export function getMarkdownDocLinkAnchor(target: string): string | null {
   const hashIndex = target.indexOf('#')
   if (hashIndex === -1 || hashIndex === target.length - 1) {
     return null
   }
   const anchor = target.slice(hashIndex + 1).trim()
+  if (anchor.startsWith('^')) {
+    // Why: Obsidian block refs are not heading anchors. Open the document for
+    // now and add block-level navigation when Orca indexes block anchors.
+    return null
+  }
   return anchor ? slugMarkdownHeading(anchor) : null
 }
 

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -192,6 +192,30 @@ describe('rich markdown round trip', () => {
     )
   })
 
+  it('preserves ordinary markdown links around doc links', () => {
+    expect(
+      roundTripMarkdown('Read [the setup guide](docs/setup-guide.md) and [[notes/todo.md]]\n')
+    ).toBe('Read [the setup guide](docs/setup-guide.md) and [[notes/todo.md]]')
+  })
+
+  it('preserves doc links with heading and block fragments', () => {
+    expect(roundTripMarkdown('See [[docs/setup-guide.md#Install steps]]\n')).toBe(
+      'See [[docs/setup-guide.md#Install steps]]'
+    )
+    expect(roundTripMarkdown('See [[docs/setup-guide.md#^block-id]]\n')).toBe(
+      'See [[docs/setup-guide.md#^block-id]]'
+    )
+  })
+
+  it('preserves embedded doc links as embed syntax', () => {
+    expect(roundTripMarkdown('Embed ![[docs/setup-guide.md]]\n')).toBe(
+      'Embed ![[docs/setup-guide.md]]'
+    )
+    expect(roundTripMarkdown('Embed ![[docs/setup-guide.md#^block-id]]\n')).toBe(
+      'Embed ![[docs/setup-guide.md#^block-id]]'
+    )
+  })
+
   it('does not encode invalid doc links', () => {
     const result = roundTripMarkdown('Empty [[]] and blank alias [[a|]]\n')
     expect(result).toContain('[[]]')

--- a/src/renderer/src/components/editor/rich-markdown-editor-click-routing.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-editor-click-routing.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest'
+import type { MutableRefObject } from 'react'
+import type { Editor } from '@tiptap/react'
+import type { EditorView } from '@tiptap/pm/view'
+import { handleRichMarkdownEditorClick } from './rich-markdown-editor-click-routing'
+
+function createDocLinkClickOptions({
+  event,
+  isMac,
+  nodeAt = () => ({
+    type: { name: 'markdownDocLink' },
+    attrs: { target: 'docs/setup-guide.md#Install steps' }
+  })
+}: {
+  event: Pick<MouseEvent, 'ctrlKey' | 'metaKey' | 'shiftKey'>
+  isMac: boolean
+  nodeAt?: () => { type: { name: string }; attrs: Record<string, unknown> } | null
+}): Parameters<typeof handleRichMarkdownEditorClick>[0] {
+  const onOpenDocLink = vi.fn()
+  const view = {
+    state: {
+      doc: {
+        nodeAt
+      }
+    }
+  } as unknown as EditorView
+
+  return {
+    activateMarkdownLink: vi.fn(),
+    editorRef: { current: {} as Editor } as MutableRefObject<Editor | null>,
+    event: event as MouseEvent,
+    filePath: '/repo/current.md',
+    isMac,
+    markdownCommentsRef: { current: [] },
+    markdownSourceLineOffsetRef: { current: 0 },
+    onOpenDocLinkRef: { current: onOpenDocLink },
+    pos: 1,
+    rootRef: { current: null },
+    scrollRichMarkdownReviewNoteCardIntoView: vi.fn(),
+    settings: {},
+    view,
+    worktreeId: 'worktree-1',
+    worktreeRoot: '/repo'
+  }
+}
+
+describe('handleRichMarkdownEditorClick doc links', () => {
+  it('opens doc links on Mac command-click', () => {
+    const options = createDocLinkClickOptions({
+      event: { metaKey: true, ctrlKey: false, shiftKey: false },
+      isMac: true
+    })
+
+    expect(handleRichMarkdownEditorClick(options)).toBe(true)
+    expect(options.onOpenDocLinkRef.current).toHaveBeenCalledWith(
+      'docs/setup-guide.md#Install steps'
+    )
+  })
+
+  it('opens doc links on non-Mac control-click', () => {
+    const options = createDocLinkClickOptions({
+      event: { metaKey: false, ctrlKey: true, shiftKey: false },
+      isMac: false
+    })
+
+    expect(handleRichMarkdownEditorClick(options)).toBe(true)
+    expect(options.onOpenDocLinkRef.current).toHaveBeenCalledWith(
+      'docs/setup-guide.md#Install steps'
+    )
+  })
+
+  it('opens doc links from the clicked node-view DOM target', () => {
+    const docLink = document.createElement('span')
+    docLink.setAttribute('data-doc-link-target', 'docs/dom-target.md')
+    const label = document.createElement('span')
+    docLink.appendChild(label)
+    const event = new MouseEvent('click', { metaKey: true })
+    Object.defineProperty(event, 'target', { value: label })
+    const options = createDocLinkClickOptions({
+      event,
+      isMac: true,
+      nodeAt: () => null
+    })
+
+    expect(handleRichMarkdownEditorClick(options)).toBe(true)
+    expect(options.onOpenDocLinkRef.current).toHaveBeenCalledWith('docs/dom-target.md')
+  })
+
+  it('leaves plain clicks available for cursor placement', () => {
+    const options = createDocLinkClickOptions({
+      event: { metaKey: false, ctrlKey: false, shiftKey: false },
+      isMac: true
+    })
+
+    expect(handleRichMarkdownEditorClick(options)).toBe(false)
+    expect(options.onOpenDocLinkRef.current).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-editor-click-routing.ts
+++ b/src/renderer/src/components/editor/rich-markdown-editor-click-routing.ts
@@ -92,6 +92,11 @@ export function handleRichMarkdownEditorClick({
       worktreeRoot
     })
   }
+  const clickedDocLinkTarget = getClickedDocLinkTarget(event)
+  if (clickedDocLinkTarget) {
+    onOpenDocLinkRef.current?.(clickedDocLinkTarget)
+    return true
+  }
   if (clickedNode?.type.name === 'markdownDocLink') {
     onOpenDocLinkRef.current?.(clickedNode.attrs.target as string)
     return true
@@ -122,6 +127,14 @@ export function handleRichMarkdownEditorClick({
     runtimeEnvironmentId
   })
   return true
+}
+
+function getClickedDocLinkTarget(event: MouseEvent): string {
+  const target = event.target
+  if (typeof Element === 'undefined' || !(target instanceof Element)) {
+    return ''
+  }
+  return target.closest('[data-doc-link-target]')?.getAttribute('data-doc-link-target') ?? ''
 }
 
 function activateMarkdownImageClick({

--- a/src/renderer/src/components/editor/useMarkdownDocuments.test.tsx
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.test.tsx
@@ -1,0 +1,267 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MarkdownDocument } from '../../../../shared/types'
+import type { OpenFile } from '@/store/slices/editor'
+import { useMarkdownDocuments } from './useMarkdownDocuments'
+
+const mocks = vi.hoisted(() => ({
+  createMissingMarkdownDocLinkDocument: vi.fn(),
+  listRuntimeMarkdownDocuments: vi.fn(),
+  openFile: vi.fn(),
+  openMarkdownPreview: vi.fn(),
+  statRuntimePath: vi.fn(),
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastWarning: vi.fn()
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  listRuntimeMarkdownDocuments: mocks.listRuntimeMarkdownDocuments,
+  statRuntimePath: mocks.statRuntimePath
+}))
+
+vi.mock('./markdown-doc-link-create', () => ({
+  createMissingMarkdownDocLinkDocument: mocks.createMissingMarkdownDocLinkDocument
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    info: mocks.toastInfo,
+    success: mocks.toastSuccess,
+    warning: mocks.toastWarning
+  }
+}))
+
+vi.mock('@/store', () => {
+  const state = {
+    openFile: mocks.openFile,
+    openMarkdownPreview: mocks.openMarkdownPreview,
+    settings: { activeRuntimeEnvironmentId: null },
+    worktreesByRepo: {
+      repo: [{ id: 'wt-1', path: '/repo', repoId: 'repo', name: 'main' }]
+    }
+  }
+  const useAppStore = (selector: (value: typeof state) => unknown): unknown => selector(state)
+  useAppStore.getState = () => state
+  return { useAppStore }
+})
+
+type HookResult = ReturnType<typeof useMarkdownDocuments>
+
+const activeFile: OpenFile = {
+  filePath: '/repo/current.md',
+  id: '/repo/current.md',
+  isDirty: false,
+  language: 'markdown',
+  mode: 'edit',
+  relativePath: 'current.md',
+  runtimeEnvironmentId: null,
+  worktreeId: 'wt-1'
+}
+
+let latestHook: HookResult | null = null
+const roots: Root[] = []
+
+function HookProbe(): null {
+  latestHook = useMarkdownDocuments(activeFile, true, 'rich', vi.fn())
+  return null
+}
+
+async function renderHookProbe(): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(<HookProbe />)
+  })
+  await flushPromises()
+}
+
+async function flushPromises(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function hookResult(): HookResult {
+  if (!latestHook) {
+    throw new Error('Hook has not rendered')
+  }
+  return latestHook
+}
+
+const existingDocument: MarkdownDocument = {
+  basename: 'Existing.md',
+  filePath: '/repo/Existing.md',
+  name: 'Existing',
+  relativePath: 'Existing.md'
+}
+
+describe('useMarkdownDocuments', () => {
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    latestHook = null
+    mocks.createMissingMarkdownDocLinkDocument.mockReset()
+    mocks.listRuntimeMarkdownDocuments.mockReset()
+    mocks.openFile.mockReset()
+    mocks.openMarkdownPreview.mockReset()
+    mocks.statRuntimePath.mockReset()
+    mocks.toastError.mockReset()
+    mocks.toastInfo.mockReset()
+    mocks.toastSuccess.mockReset()
+    mocks.toastWarning.mockReset()
+    mocks.listRuntimeMarkdownDocuments.mockResolvedValue([])
+    mocks.statRuntimePath.mockResolvedValue({ isDirectory: false })
+  })
+
+  afterEach(() => {
+    roots.splice(0).forEach((root) => {
+      act(() => root.unmount())
+    })
+    document.body.replaceChildren()
+  })
+
+  it('refreshes a stale document index before opening an existing doc link', async () => {
+    mocks.listRuntimeMarkdownDocuments
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([existingDocument])
+
+    await renderHookProbe()
+
+    hookResult().onOpenDocLink('Existing')
+    await flushPromises()
+
+    expect(mocks.openFile).toHaveBeenCalledWith({
+      filePath: existingDocument.filePath,
+      language: 'markdown',
+      mode: 'edit',
+      relativePath: existingDocument.relativePath,
+      runtimeEnvironmentId: null,
+      worktreeId: 'wt-1'
+    })
+    expect(mocks.toastInfo).not.toHaveBeenCalled()
+  })
+
+  it('warns when a doc link target is ambiguous', async () => {
+    const firstMatch: MarkdownDocument = {
+      basename: 'Topic.md',
+      filePath: '/repo/notes/Topic.md',
+      name: 'Topic',
+      relativePath: 'notes/Topic.md'
+    }
+    const secondMatch: MarkdownDocument = {
+      basename: 'Topic.md',
+      filePath: '/repo/archive/Topic.md',
+      name: 'Topic',
+      relativePath: 'archive/Topic.md'
+    }
+    mocks.listRuntimeMarkdownDocuments.mockResolvedValue([firstMatch, secondMatch])
+
+    await renderHookProbe()
+
+    hookResult().onOpenDocLink('Topic')
+    await flushPromises()
+
+    expect(mocks.toastWarning).toHaveBeenCalledWith('Document link is ambiguous', {
+      description: 'notes/Topic.md, archive/Topic.md'
+    })
+    expect(mocks.openFile).not.toHaveBeenCalled()
+    expect(mocks.toastInfo).not.toHaveBeenCalled()
+  })
+
+  it('opens heading-fragment doc links as editable documents', async () => {
+    mocks.listRuntimeMarkdownDocuments.mockResolvedValue([existingDocument])
+
+    await renderHookProbe()
+
+    hookResult().onOpenDocLink('Existing#Install steps')
+    await flushPromises()
+
+    expect(mocks.openFile).toHaveBeenCalledWith({
+      filePath: existingDocument.filePath,
+      language: 'markdown',
+      mode: 'edit',
+      relativePath: existingDocument.relativePath,
+      runtimeEnvironmentId: null,
+      worktreeId: 'wt-1'
+    })
+    expect(mocks.openMarkdownPreview).not.toHaveBeenCalled()
+  })
+
+  it('opens block-fragment doc links as editable documents', async () => {
+    mocks.listRuntimeMarkdownDocuments.mockResolvedValue([existingDocument])
+
+    await renderHookProbe()
+
+    hookResult().onOpenDocLink('Existing#^block-id')
+    await flushPromises()
+
+    expect(mocks.openFile).toHaveBeenCalledWith({
+      filePath: existingDocument.filePath,
+      language: 'markdown',
+      mode: 'edit',
+      relativePath: existingDocument.relativePath,
+      runtimeEnvironmentId: null,
+      worktreeId: 'wt-1'
+    })
+    expect(mocks.openMarkdownPreview).not.toHaveBeenCalled()
+  })
+
+  it('offers to create a missing doc link and opens the created note', async () => {
+    const createdDocument: MarkdownDocument = {
+      basename: 'New Note.md',
+      filePath: '/repo/New Note.md',
+      name: 'New Note',
+      relativePath: 'New Note.md'
+    }
+    mocks.createMissingMarkdownDocLinkDocument.mockResolvedValue(createdDocument)
+
+    await renderHookProbe()
+
+    hookResult().onOpenDocLink('New Note')
+    await flushPromises()
+
+    expect(mocks.toastInfo).toHaveBeenCalledWith(
+      'Note not found',
+      expect.objectContaining({
+        action: expect.objectContaining({ label: 'Create note' }),
+        description: 'New Note.md'
+      })
+    )
+
+    const toastOptions = mocks.toastInfo.mock.calls[0]?.[1] as {
+      action?: { onClick?: () => void }
+    }
+    toastOptions.action?.onClick?.()
+    await flushPromises()
+
+    expect(mocks.createMissingMarkdownDocLinkDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: 'New Note',
+        worktreePath: '/repo'
+      })
+    )
+    expect(mocks.openFile).toHaveBeenCalledWith({
+      filePath: createdDocument.filePath,
+      language: 'markdown',
+      mode: 'edit',
+      relativePath: createdDocument.relativePath,
+      runtimeEnvironmentId: null,
+      worktreeId: 'wt-1'
+    })
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Note created', {
+      description: 'New Note.md'
+    })
+  })
+})

--- a/src/renderer/src/components/editor/useMarkdownDocuments.test.tsx
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   listRuntimeMarkdownDocuments: vi.fn(),
   openFile: vi.fn(),
   openMarkdownPreview: vi.fn(),
+  onSave: vi.fn(),
   statRuntimePath: vi.fn(),
   toastError: vi.fn(),
   toastInfo: vi.fn(),
@@ -72,7 +73,7 @@ let latestHook: HookResult | null = null
 const roots: Root[] = []
 
 function HookProbe(): null {
-  latestHook = useMarkdownDocuments(activeFile, true, 'rich', vi.fn())
+  latestHook = useMarkdownDocuments(activeFile, true, 'rich', mocks.onSave)
   return null
 }
 
@@ -116,12 +117,14 @@ describe('useMarkdownDocuments', () => {
     mocks.listRuntimeMarkdownDocuments.mockReset()
     mocks.openFile.mockReset()
     mocks.openMarkdownPreview.mockReset()
+    mocks.onSave.mockReset()
     mocks.statRuntimePath.mockReset()
     mocks.toastError.mockReset()
     mocks.toastInfo.mockReset()
     mocks.toastSuccess.mockReset()
     mocks.toastWarning.mockReset()
     mocks.listRuntimeMarkdownDocuments.mockResolvedValue([])
+    mocks.onSave.mockResolvedValue(undefined)
     mocks.statRuntimePath.mockResolvedValue({ isDirectory: false })
   })
 
@@ -177,6 +180,44 @@ describe('useMarkdownDocuments', () => {
       description: 'notes/Topic.md, archive/Topic.md'
     })
     expect(mocks.openFile).not.toHaveBeenCalled()
+    expect(mocks.toastInfo).not.toHaveBeenCalled()
+  })
+
+  it('uses cached current documents when a doc-link refresh is superseded', async () => {
+    let resolveDocLinkRefresh = (_documents: MarkdownDocument[]): void => {}
+    let resolveSaveRefresh = (_documents: MarkdownDocument[]): void => {}
+    const docLinkRefresh = new Promise<MarkdownDocument[]>((resolve) => {
+      resolveDocLinkRefresh = resolve
+    })
+    const saveRefresh = new Promise<MarkdownDocument[]>((resolve) => {
+      resolveSaveRefresh = resolve
+    })
+    mocks.listRuntimeMarkdownDocuments
+      .mockResolvedValueOnce([])
+      .mockReturnValueOnce(docLinkRefresh)
+      .mockReturnValueOnce(saveRefresh)
+
+    await renderHookProbe()
+
+    hookResult().onOpenDocLink('Existing')
+    await flushPromises()
+    const savePromise = hookResult().mdSave('# updated')
+    await flushPromises()
+
+    resolveSaveRefresh([existingDocument])
+    await flushPromises()
+    resolveDocLinkRefresh([])
+    await flushPromises()
+    await savePromise
+
+    expect(mocks.openFile).toHaveBeenCalledWith({
+      filePath: existingDocument.filePath,
+      language: 'markdown',
+      mode: 'edit',
+      relativePath: existingDocument.relativePath,
+      runtimeEnvironmentId: null,
+      worktreeId: 'wt-1'
+    })
     expect(mocks.toastInfo).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/editor/useMarkdownDocuments.ts
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.ts
@@ -6,11 +6,14 @@ import { getConnectionId } from '@/lib/connection-context'
 import { listRuntimeMarkdownDocuments, statRuntimePath } from '@/runtime/runtime-file-client'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import type { MarkdownViewMode, OpenFile } from '@/store/slices/editor'
+import { createMissingMarkdownDocLinkDocument } from './markdown-doc-link-create'
 import {
-  createMarkdownDocumentIndex,
-  getMarkdownDocLinkAnchor,
-  resolveMarkdownDocLink
-} from './markdown-doc-links'
+  showAmbiguousMarkdownDocLinkToast,
+  showCreatedMarkdownDocLinkToast,
+  showInvalidMarkdownDocLinkTargetToast,
+  showMissingMarkdownDocLinkCreateToast
+} from './markdown-doc-link-toasts'
+import { createMarkdownDocumentIndex, resolveMarkdownDocLink } from './markdown-doc-links'
 
 type OpenMarkdownDocumentOptions = {
   anchor?: string | null
@@ -57,9 +60,9 @@ export function useMarkdownDocuments(
 
   const connectionId = getConnectionId(worktreeId)
 
-  const refreshMarkdownDocuments = useCallback(async (): Promise<void> => {
+  const refreshMarkdownDocuments = useCallback(async (): Promise<MarkdownDocument[]> => {
     if (!worktreeId || !worktreePath) {
-      return
+      return []
     }
 
     const requestId = requestRef.current + 1
@@ -78,12 +81,13 @@ export function useMarkdownDocuments(
         worktreePath
       )
       if (requestRef.current !== requestId) {
-        return
+        return documents
       }
       setMarkdownDocumentsByWorktree((prev) => ({
         ...prev,
         [worktreeId]: documents
       }))
+      return documents
     } catch (err) {
       console.error('Failed to list markdown documents:', err)
       if (requestRef.current === requestId) {
@@ -92,6 +96,7 @@ export function useMarkdownDocuments(
           [worktreeId]: []
         }))
       }
+      return []
     }
   }, [activeFile.runtimeEnvironmentId, connectionId, worktreeId, worktreePath])
 
@@ -179,7 +184,10 @@ export function useMarkdownDocuments(
   )
 
   const mdSave = useCallback(
-    (content: string) => onSave(content).then(() => refreshMarkdownDocuments()),
+    async (content: string) => {
+      await onSave(content)
+      await refreshMarkdownDocuments()
+    },
     [onSave, refreshMarkdownDocuments]
   )
 
@@ -188,16 +196,71 @@ export function useMarkdownDocuments(
     [markdownDocuments]
   )
 
+  const createAndOpenMissingDocLink = useCallback(
+    async (target: string): Promise<void> => {
+      if (!worktreeId || !worktreePath) {
+        return
+      }
+      const createdDocument = await createMissingMarkdownDocLinkDocument({
+        context: {
+          settings: settingsForRuntimeOwner(
+            useAppStore.getState().settings,
+            activeFile.runtimeEnvironmentId
+          ),
+          worktreeId,
+          worktreePath,
+          connectionId: connectionId ?? undefined
+        },
+        target,
+        worktreePath
+      })
+      if (!createdDocument) {
+        showInvalidMarkdownDocLinkTargetToast()
+        return
+      }
+
+      await refreshMarkdownDocuments()
+      await openMarkdownDocument(createdDocument)
+      showCreatedMarkdownDocLinkToast(createdDocument.relativePath)
+    },
+    [
+      activeFile.runtimeEnvironmentId,
+      connectionId,
+      openMarkdownDocument,
+      refreshMarkdownDocuments,
+      worktreeId,
+      worktreePath
+    ]
+  )
+
   const onOpenDocLink = useCallback(
     (target: string) => {
-      const resolution = resolveMarkdownDocLink(target, docIndex)
-      if (resolution.status === 'resolved') {
-        void openMarkdownDocument(resolution.document, {
-          anchor: getMarkdownDocLinkAnchor(target)
-        })
-      }
+      void (async () => {
+        let resolution = resolveMarkdownDocLink(target, docIndex)
+        if (resolution.status !== 'resolved') {
+          const refreshedDocuments = await refreshMarkdownDocuments()
+          resolution = resolveMarkdownDocLink(
+            target,
+            createMarkdownDocumentIndex(refreshedDocuments)
+          )
+        }
+        if (resolution.status === 'resolved') {
+          await openMarkdownDocument(resolution.document)
+          return
+        }
+        if (resolution.status === 'missing') {
+          showMissingMarkdownDocLinkCreateToast({
+            onCreate: createAndOpenMissingDocLink,
+            target
+          })
+          return
+        }
+        if (resolution.status === 'ambiguous') {
+          showAmbiguousMarkdownDocLinkToast(resolution.matches)
+        }
+      })()
     },
-    [docIndex, openMarkdownDocument]
+    [createAndOpenMissingDocLink, docIndex, openMarkdownDocument, refreshMarkdownDocuments]
   )
 
   return { markdownDocuments, openMarkdownDocument, onOpenDocLink, previewProps, mdSave }

--- a/src/renderer/src/components/editor/useMarkdownDocuments.ts
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.ts
@@ -49,7 +49,9 @@ export function useMarkdownDocuments(
   const [markdownDocumentsByWorktree, setMarkdownDocumentsByWorktree] = useState<
     Record<string, MarkdownDocument[]>
   >({})
+  const markdownDocumentsByWorktreeRef = useRef(markdownDocumentsByWorktree)
   const requestRef = useRef(0)
+  markdownDocumentsByWorktreeRef.current = markdownDocumentsByWorktree
 
   const worktreePath = useMemo(() => {
     if (!worktreeId) {
@@ -81,7 +83,7 @@ export function useMarkdownDocuments(
         worktreePath
       )
       if (requestRef.current !== requestId) {
-        return documents
+        return markdownDocumentsByWorktreeRef.current[worktreeId] ?? []
       }
       setMarkdownDocumentsByWorktree((prev) => ({
         ...prev,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10722,7 +10722,8 @@
                 "dd5af2ab74": "Note not found",
                 "53b9d723ef": "Create note",
                 "e3cfe7a2d5": "Failed to create note",
-                "0c8765cd46": "Document link is ambiguous"
+                "0c8765cd46": "Document link is ambiguous",
+                "2f55cdad12": "+{{value0}} more"
               }
             }
           }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10713,6 +10713,18 @@
               "2fd2b44073": "Editable only in code mode because this file contains reference-style links.",
               "57128b73e1": "Editable only in code mode because this file contains HTML, JSX, or MDX."
             }
+          },
+          "doc": {
+            "link": {
+              "toasts": {
+                "3ac54dda7f": "Cannot create note from this link",
+                "86a480c022": "Note created",
+                "dd5af2ab74": "Note not found",
+                "53b9d723ef": "Create note",
+                "e3cfe7a2d5": "Failed to create note",
+                "0c8765cd46": "Document link is ambiguous"
+              }
+            }
           }
         },
         "rich": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10722,7 +10722,8 @@
                 "dd5af2ab74": "Note not found",
                 "53b9d723ef": "Create note",
                 "e3cfe7a2d5": "Failed to create note",
-                "0c8765cd46": "Document link is ambiguous"
+                "0c8765cd46": "Document link is ambiguous",
+                "2f55cdad12": "+{{value0}} more"
               }
             }
           }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10713,6 +10713,18 @@
               "2fd2b44073": "Editable solo en modo código porque este archivo contiene enlaces de estilo de referencia.",
               "57128b73e1": "Editable solo en modo código porque este archivo contiene HTML, JSX o MDX."
             }
+          },
+          "doc": {
+            "link": {
+              "toasts": {
+                "3ac54dda7f": "Cannot create note from this link",
+                "86a480c022": "Note created",
+                "dd5af2ab74": "Note not found",
+                "53b9d723ef": "Create note",
+                "e3cfe7a2d5": "Failed to create note",
+                "0c8765cd46": "Document link is ambiguous"
+              }
+            }
           }
         },
         "rich": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10722,7 +10722,8 @@
                 "dd5af2ab74": "Note not found",
                 "53b9d723ef": "Create note",
                 "e3cfe7a2d5": "Failed to create note",
-                "0c8765cd46": "Document link is ambiguous"
+                "0c8765cd46": "Document link is ambiguous",
+                "2f55cdad12": "+{{value0}} more"
               }
             }
           }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10713,6 +10713,18 @@
               "2fd2b44073": "このファイルには参照形式のリンクが含まれているため、コード モードでのみ編集できます。",
               "57128b73e1": "このファイルには HTML、JSX、または MDX が含まれているため、コード モードでのみ編集できます。"
             }
+          },
+          "doc": {
+            "link": {
+              "toasts": {
+                "3ac54dda7f": "Cannot create note from this link",
+                "86a480c022": "Note created",
+                "dd5af2ab74": "Note not found",
+                "53b9d723ef": "Create note",
+                "e3cfe7a2d5": "Failed to create note",
+                "0c8765cd46": "Document link is ambiguous"
+              }
+            }
           }
         },
         "rich": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10722,7 +10722,8 @@
                 "dd5af2ab74": "Note not found",
                 "53b9d723ef": "Create note",
                 "e3cfe7a2d5": "Failed to create note",
-                "0c8765cd46": "Document link is ambiguous"
+                "0c8765cd46": "Document link is ambiguous",
+                "2f55cdad12": "+{{value0}} more"
               }
             }
           }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10713,6 +10713,18 @@
               "2fd2b44073": "이 파일에는 참조 스타일 링크가 포함되어 있으므로 코드 모드에서만 편집할 수 있습니다.",
               "57128b73e1": "이 파일에는 HTML, JSX 또는 MDX가 포함되어 있으므로 코드 모드에서만 편집할 수 있습니다."
             }
+          },
+          "doc": {
+            "link": {
+              "toasts": {
+                "3ac54dda7f": "Cannot create note from this link",
+                "86a480c022": "Note created",
+                "dd5af2ab74": "Note not found",
+                "53b9d723ef": "Create note",
+                "e3cfe7a2d5": "Failed to create note",
+                "0c8765cd46": "Document link is ambiguous"
+              }
+            }
           }
         },
         "rich": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10722,7 +10722,8 @@
                 "dd5af2ab74": "Note not found",
                 "53b9d723ef": "Create note",
                 "e3cfe7a2d5": "Failed to create note",
-                "0c8765cd46": "Document link is ambiguous"
+                "0c8765cd46": "Document link is ambiguous",
+                "2f55cdad12": "+{{value0}} more"
               }
             }
           }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10713,6 +10713,18 @@
               "2fd2b44073": "只能在代码模式下编辑，因为该文件包含引用样式链接。",
               "57128b73e1": "只能在代码模式下编辑，因为该文件包含 HTML、JSX 或 MDX。"
             }
+          },
+          "doc": {
+            "link": {
+              "toasts": {
+                "3ac54dda7f": "Cannot create note from this link",
+                "86a480c022": "Note created",
+                "dd5af2ab74": "Note not found",
+                "53b9d723ef": "Create note",
+                "e3cfe7a2d5": "Failed to create note",
+                "0c8765cd46": "Document link is ambiguous"
+              }
+            }
           }
         },
         "rich": {

--- a/tests/e2e/markdown-wikilinks.spec.ts
+++ b/tests/e2e/markdown-wikilinks.spec.ts
@@ -1,0 +1,152 @@
+import path from 'path'
+import { rm, writeFile } from 'fs/promises'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  cleanupMarkdownFixture,
+  createMarkdownFixture,
+  getActiveWorktreeContext,
+  openMarkdownFixture,
+  waitForRichMarkdownEditor
+} from './helpers/markdown-ordered-list-exit'
+
+async function getRichMarkdownSource(page: Parameters<typeof waitForRichMarkdownEditor>[0]) {
+  return page.evaluate(() => {
+    const editor = document.querySelector('.rich-markdown-editor') as
+      | (Element & {
+          editor?: {
+            getMarkdown?: () => string
+          }
+        })
+      | null
+    return editor?.editor?.getMarkdown?.() ?? null
+  })
+}
+
+async function clickDocLink(page: Parameters<typeof waitForRichMarkdownEditor>[0], text: string) {
+  await page
+    .locator('.rich-markdown-doc-link', { hasText: text })
+    .first()
+    .click({
+      modifiers: ['Control', 'Meta']
+    })
+}
+
+test.describe('Markdown wikilinks', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('preserves wikilink syntax and opens an existing target', async ({ orcaPage }, testInfo) => {
+    const context = await getActiveWorktreeContext(orcaPage)
+    const filesToClean: string[] = []
+
+    try {
+      const targetName = `wikilink-target-${testInfo.workerIndex}-${Date.now()}`
+      const targetFilePath = path.join(context.rootPath, `${targetName}.md`)
+      await writeFile(
+        targetFilePath,
+        '# Target Note\n\n## Target Heading\n\nBlock content ^block-id\n'
+      )
+      filesToClean.push(targetFilePath)
+      const sourceMarkdown = [
+        '# Source',
+        '',
+        `See [[${targetName}|Target alias]], [[${targetName}#Target Heading]], and [[${targetName}#^block-id]].`,
+        '',
+        `Embed ![[${targetName}#^block-id]].`,
+        '',
+        '`[[not-a-link]]`',
+        ''
+      ].join('\n')
+      const sourceFilePath = await createMarkdownFixture(
+        context,
+        'wikilink-source',
+        testInfo.workerIndex,
+        sourceMarkdown
+      )
+      filesToClean.push(sourceFilePath)
+
+      await openMarkdownFixture(orcaPage, context, sourceFilePath)
+      await waitForRichMarkdownEditor(orcaPage)
+
+      await expect(orcaPage.locator('.rich-markdown-doc-link')).toHaveCount(4, { timeout: 5_000 })
+      await expect(
+        orcaPage.locator('.rich-markdown-doc-link', { hasText: 'Target alias' })
+      ).toBeVisible()
+
+      await expect
+        .poll(async () => getRichMarkdownSource(orcaPage), {
+          timeout: 10_000,
+          message: 'rich markdown source did not preserve wikilink syntax'
+        })
+        .toContain(`![[${targetName}#^block-id]]`)
+      await expect.poll(async () => getRichMarkdownSource(orcaPage)).toContain('`[[not-a-link]]`')
+
+      await clickDocLink(orcaPage, 'Target alias')
+
+      await expect
+        .poll(
+          async () =>
+            orcaPage.evaluate(() => {
+              const state = window.__store?.getState()
+              return state?.openFiles.find((file) => file.id === state.activeFileId)?.filePath
+            }),
+          { timeout: 5_000, message: 'existing wikilink target did not become active' }
+        )
+        .toBe(targetFilePath)
+    } finally {
+      await Promise.all(filesToClean.map((filePath) => cleanupMarkdownFixture(filePath)))
+    }
+  })
+
+  test('offers to create a missing wikilink target', async ({ orcaPage }, testInfo) => {
+    const context = await getActiveWorktreeContext(orcaPage)
+    const missingTarget = `wikilink-missing-${testInfo.workerIndex}-${Date.now()}`
+    const missingTargetPath = path.join(context.rootPath, `${missingTarget}.md`)
+    let sourceFilePath: string | null = null
+
+    try {
+      sourceFilePath = await createMarkdownFixture(
+        context,
+        'wikilink-missing-source',
+        testInfo.workerIndex,
+        `# Source\n\nCreate [[${missingTarget}]].\n`
+      )
+      await openMarkdownFixture(orcaPage, context, sourceFilePath)
+      await waitForRichMarkdownEditor(orcaPage)
+
+      await clickDocLink(orcaPage, missingTarget)
+      await expect(orcaPage.getByText('Note not found')).toBeVisible({ timeout: 5_000 })
+      await orcaPage.getByRole('button', { name: 'Create note' }).click()
+
+      await expect
+        .poll(
+          async () =>
+            orcaPage.evaluate(() => {
+              const state = window.__store?.getState()
+              return state?.openFiles.find((file) => file.id === state.activeFileId)?.filePath
+            }),
+          { timeout: 5_000, message: 'created wikilink target did not become active' }
+        )
+        .toBe(missingTargetPath)
+
+      await expect
+        .poll(
+          async () => {
+            const source = await getRichMarkdownSource(orcaPage)
+            return source?.trimEnd() ?? null
+          },
+          {
+            timeout: 10_000,
+            message: 'created wikilink target did not load with initial heading'
+          }
+        )
+        .toBe(`# ${missingTarget}`)
+    } finally {
+      await cleanupMarkdownFixture(sourceFilePath)
+      await rm(missingTargetPath, { force: true })
+    }
+  })
+})

--- a/tests/e2e/markdown-wikilinks.spec.ts
+++ b/tests/e2e/markdown-wikilinks.spec.ts
@@ -10,6 +10,8 @@ import {
   waitForRichMarkdownEditor
 } from './helpers/markdown-ordered-list-exit'
 
+const DOC_LINK_CLICK_MODIFIER = process.platform === 'darwin' ? 'Meta' : 'Control'
+
 async function getRichMarkdownSource(page: Parameters<typeof waitForRichMarkdownEditor>[0]) {
   return page.evaluate(() => {
     const editor = document.querySelector('.rich-markdown-editor') as
@@ -28,7 +30,7 @@ async function clickDocLink(page: Parameters<typeof waitForRichMarkdownEditor>[0
     .locator('.rich-markdown-doc-link', { hasText: text })
     .first()
     .click({
-      modifiers: ['Control', 'Meta']
+      modifiers: [DOC_LINK_CLICK_MODIFIER]
     })
 }
 


### PR DESCRIPTION
## Summary

This adds first-class Obsidian-style wikilink support to Orca's existing Markdown doc-link system.

User-visible behavior:

- Rich Markdown now preserves and renders wikilinks such as `[[Note]]`, `[[Note|Alias]]`, `[[Note#Heading]]`, `[[Note#^block-id]]`, `![[Note]]`, and `![[Note#^block-id]]`.
- Cmd/Ctrl-clicking a resolved wikilink opens the target Markdown document in the editor.
- Missing wikilinks show a `Create note` toast action instead of silently failing.
- Ambiguous wikilinks show a warning with candidate paths instead of silently doing nothing.
- Wikilink colors are exposed through CSS variables so themes/downstream builds can adjust contrast without patching feature code.

Intentionally extends Orca's existing `markdownDocLink` machinery.

## Related Issue

Refs #3040. This is a first slice of Obsidian-style note-link support and does not close the broader backlinks/graph request.

## Scope Notes

This PR preserves heading and block fragments from existing Obsidian conventions but does not navigate to them yet.

For this first slice:

- `[[Note#Heading]]` opens `Note` at document level.
- `[[Note#^block-id]]` opens `Note` at document level.
- `![[Note]]` and `![[Note#^block-id]]` preserve embed syntax, but rich inline embed rendering is deferred.

Fragment-aware navigation and rich embed rendering could be follow-up PRs.

## Implementation Notes

- Reuses Orca's existing Markdown document index and `markdownDocLink` atom.
- Adds safe missing-target creation through runtime file APIs, so local, SSH, and remote runtime worktrees follow the same path.
- Keeps unresolved or ambiguous behaviors explicit with toast feedback.
- Keeps current visual defaults while exposing:
  - `--markdown-doc-link-color`
  - `--markdown-doc-link-decoration-color`
- Applies doc-link colors consistently to rich editor links, in-progress rich editor `[[...]]` previews, Markdown preview links, and Monaco source-mode decorations.

## Tests / Verification

Passed:

```bash
pnpm lint
pnpm typecheck
pnpm build
```

Passed focused wikilink tests:

```bash
pnpm vitest run --config config/vitest.config.ts \
  src/renderer/src/components/editor/markdown-round-trip.test.ts \
  src/renderer/src/components/editor/markdown-doc-links.test.ts \
  src/renderer/src/components/editor/markdown-doc-link-create.test.ts \
  src/renderer/src/components/editor/rich-markdown-editor-click-routing.test.ts \
  src/renderer/src/components/editor/useMarkdownDocuments.test.tsx
```

Passed Electron smoke test:

```bash
npx playwright test tests/e2e/markdown-wikilinks.spec.ts \
  --config tests/playwright.config.ts \
  --project electron-headless \
  --workers=1
```

Additional checks passed:

```bash
pnpm run verify:localization-catalog
pnpm run verify:localization-coverage
git diff --check
```

Known local baseline issue:

```bash
pnpm test
```

fails on clean `main` in unrelated sidebar tests with:

```text
TypeError: window.localStorage.clear is not a function
```

Affected files on clean `main`:

- `src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx`
- `src/renderer/src/components/sidebar/SidebarToolbar.test.tsx`

Confirmed by stashing the wikilinks changes and running full `pnpm test` on clean `main`; same failure reproduced there.

## Screenshots / Recordings

Not attached. The UI change is limited to rich Markdown/source/preview doc-link rendering and toast feedback; the Electron smoke test covers the interaction paths.

## Cross-Platform / Remote / Integration Review

- Cross-platform: modifier-click behavior uses Orca's existing runtime Mac vs non-Mac modifier handling; no platform-specific paths or shell assumptions were added.
- SSH/remote/local: missing-note creation uses `createRuntimePath`, `runtimePathExists`, and `writeRuntimeFile`, preserving Orca's runtime/SSH file routing.
- Git provider compatibility: no Git provider logic is touched.
- Agent/integration compatibility: no CLI-agent, task tracker, browser, GitHub/GitLab/Jira/Linear, or automation-specific behavior is touched.
- Performance: resolved clicks use the existing Markdown document index. Missing/ambiguous clicks refresh the Markdown document list once to avoid stale-index false negatives; no hot render-loop filesystem work was added.
- UI quality: doc-link color now uses theme CSS variables with the existing colors as defaults; missing and ambiguous cases provide explicit feedback.
- Security: creatable wikilink targets reject absolute paths, traversal, empty segments, Windows drive/UNC-like paths, control characters, and invalid filename characters before writing.

## Reviewer Notes

- The PR deliberately does not implement full Obsidian block-reference navigation or inline embed rendering.
- `[[Note#Heading]]` and `[[Note#^block-id]]` are preserved and resolve the document, but click opens the document at top level for now.
- The branch includes source-mode, rich-editor, and preview styling through shared doc-link CSS variables.



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5964">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
