### PR TITLE
Delayed auto-focus for mobile workspace name input

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -47,6 +47,7 @@ import { BottomDrawer } from '../../../src/components/BottomDrawer'
 import { ConfirmModal } from '../../../src/components/ConfirmModal'
 import { MobileMarkdown } from '../../../src/components/MobileMarkdown'
 import { MobileAgentIcon } from '../../../src/components/MobileAgentIcon'
+import { MobileWorkspaceNameInput } from '../../../src/components/MobileWorkspaceNameInput'
 import { MobileSyntaxSegments } from '../../../src/components/MobileSyntaxSegments'
 import { PickerModal, type PickerOption } from '../../../src/components/PickerModal'
 import { TaskProviderLogo } from '../../../src/components/TaskProviderLogo'
@@ -4870,7 +4871,6 @@ export default function MobileTasksScreen() {
       }
     ]
   }, [runtimeTaskSettings.disabledTuiAgents, workspaceAgent, workspaceDetectedAgentIds])
-
   const openWorkspaceCreate = useCallback((item: ActionableTaskItem, repoIdOverride?: string) => {
     const suggestedName = taskWorkspaceSuggestedName(item)
     setWorkspaceCreateDraft({ item, ...(repoIdOverride ? { repoIdOverride } : {}) })
@@ -10977,14 +10977,12 @@ export default function MobileTasksScreen() {
                 <Text style={styles.workspaceCreateLabel}>
                   Workspace Name <Text style={styles.workspaceCreateLabelHint}>[Optional]</Text>
                 </Text>
-                <TextInput
+                <MobileWorkspaceNameInput
                   style={styles.input}
                   value={workspaceNameDraft}
                   onChangeText={handleWorkspaceNameDraftChange}
-                  placeholder="Workspace name"
                   placeholderTextColor={colors.textMuted}
-                  autoCapitalize="none"
-                  autoCorrect={false}
+                  shouldAutoFocus={taskUiReady && workspaceCreateDraft !== null}
                 />
               </View>
 

--- a/mobile/src/components/MobileWorkspaceNameInput.tsx
+++ b/mobile/src/components/MobileWorkspaceNameInput.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react'
+import { TextInput, type TextInputProps } from 'react-native'
+
+const MOBILE_WORKSPACE_NAME_FOCUS_DELAY_MS = 220
+
+type MobileWorkspaceNameInputProps = TextInputProps & {
+  shouldAutoFocus: boolean
+  focusKey?: unknown
+}
+
+export function MobileWorkspaceNameInput({
+  shouldAutoFocus,
+  focusKey,
+  ...props
+}: MobileWorkspaceNameInputProps) {
+  const inputRef = useRef<TextInput>(null)
+
+  useEffect(() => {
+    if (!shouldAutoFocus) {
+      return
+    }
+
+    // Why: bottom drawers animate in before the field is visually settled;
+    // focusing after the animation makes mobile soft keyboards appear reliably.
+    const timeout = setTimeout(() => {
+      inputRef.current?.focus()
+    }, MOBILE_WORKSPACE_NAME_FOCUS_DELAY_MS)
+
+    return () => clearTimeout(timeout)
+  }, [focusKey, shouldAutoFocus])
+
+  return (
+    <TextInput
+      ref={inputRef}
+      placeholder="Workspace name"
+      autoCapitalize="none"
+      autoCorrect={false}
+      showSoftInputOnFocus
+      {...props}
+    />
+  )
+}

--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -16,6 +16,7 @@ import { colors, spacing, radii, typography } from '../theme/mobile-theme'
 import { BottomDrawer } from './BottomDrawer'
 import { PickerListDrawer } from './PickerListDrawer'
 import { MobileAgentIcon } from './MobileAgentIcon'
+import { MobileWorkspaceNameInput } from './MobileWorkspaceNameInput'
 import { getSuggestedCreatureName } from './worktree-name-suggestion'
 import { deriveWorkspaceSshGate, workspaceSshStatusLabel } from '../tasks/workspace-ssh-gate'
 import { WORKTREE_CREATE_TIMEOUT_MS } from '../tasks/workspace-create-timeout'
@@ -751,18 +752,15 @@ function NewWorktreeModalContent({
               <Text style={styles.label}>
                 Workspace Name <Text style={styles.labelHint}>[Optional]</Text>
               </Text>
-              <TextInput
+              <MobileWorkspaceNameInput
                 style={styles.input}
                 value={name}
                 onChangeText={(t) => {
                   setName(t)
                   setError('')
                 }}
-                placeholder="Workspace name"
                 placeholderTextColor={colors.textMuted}
-                autoCapitalize="none"
-                autoCorrect={false}
-                autoFocus={repos.length <= 1}
+                shouldAutoFocus={visible && !loading && repos.length > 0}
                 returnKeyType="done"
                 onSubmitEditing={() => {
                   if (canCreate) {


### PR DESCRIPTION
## Summary

Introduces the `MobileWorkspaceNameInput` component to handle delayed auto-focus for mobile workspace creation. Bottom drawers animate in before the text field is visually settled; focusing after a short 220ms delay ensures mobile soft keyboards appear reliably.

- Replaced standard `TextInput` with `MobileWorkspaceNameInput` in `tasks.tsx` (workspace draft name input) and `NewWorktreeModal.tsx`.

## Screenshots

- No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

The code review checked:
- React Native lifecycle safety: confirmed the `setTimeout` ref in `MobileWorkspaceNameInput` is properly cleared in the `useEffect` cleanup function to prevent memory leaks.
- Prop propagation: confirmed that custom props are separated and all other `TextInputProps` are passed correctly to the underlying React Native `TextInput` using `{...props}`.
- Cross-platform check: these changes are confined to React Native mobile code and do not affect desktop Electron paths or deskop OS (macOS/Linux/Windows) integrations.

## Security Audit

Basic security audit passed:
- No command execution, path manipulation, or IPC integrations were added or modified.
- No security risks identified.

## Notes

The delayed autofocus delay is set to 220ms, which is optimized for mobile transition animations.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5968">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->