### PR TITLE
Resolve path-specific connection IDs in mixed folder workspaces

### DIFF
--- a/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   readRuntimeFileContent: vi.fn(),
   getRuntimeGitDiff: vi.fn(),
   getConnectionId: vi.fn(),
+  getConnectionIdForFile: vi.fn(),
   getState: vi.fn()
 }))
 
@@ -33,7 +34,8 @@ vi.mock('@/runtime/runtime-git-client', () => ({
 }))
 
 vi.mock('@/lib/connection-context', () => ({
-  getConnectionId: mocks.getConnectionId
+  getConnectionId: mocks.getConnectionId,
+  getConnectionIdForFile: mocks.getConnectionIdForFile
 }))
 
 vi.mock('@/store', () => ({
@@ -95,6 +97,8 @@ describe('useEditorPanelContentState', () => {
     mocks.getRuntimeGitDiff.mockReset()
     mocks.getConnectionId.mockReset()
     mocks.getConnectionId.mockReturnValue(undefined)
+    mocks.getConnectionIdForFile.mockReset()
+    mocks.getConnectionIdForFile.mockReturnValue(undefined)
     mocks.getState.mockReset()
     mocks.getState.mockReturnValue({ settings: null })
   })
@@ -106,6 +110,40 @@ describe('useEditorPanelContentState', () => {
     container?.remove()
     container = null
     root = null
+  })
+
+  it('loads folder workspace files through the path-specific SSH connection', async () => {
+    const activeFile = createOpenFile({
+      filePath: '/home/neil/platform/api/src/file.ts',
+      relativePath: 'api/src/file.ts',
+      worktreeId: 'folder:folder-workspace-1'
+    })
+    mocks.getConnectionIdForFile.mockReturnValue('ssh-1')
+    mocks.readRuntimeFileContent.mockResolvedValue({ content: 'remote content', isBinary: false })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(<HookProbe activeFile={activeFile} openFiles={[activeFile]} />)
+    })
+
+    await vi.waitFor(() =>
+      expect(latestFileContents[activeFile.id]?.content).toBe('remote content')
+    )
+    expect(mocks.getConnectionIdForFile).toHaveBeenCalledWith(
+      'folder:folder-workspace-1',
+      '/home/neil/platform/api/src/file.ts'
+    )
+    expect(mocks.readRuntimeFileContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/home/neil/platform/api/src/file.ts',
+        relativePath: 'api/src/file.ts',
+        worktreeId: 'folder:folder-workspace-1',
+        connectionId: 'ssh-1'
+      })
+    )
   })
 
   it('reloads a clean file when its file content reload nonce changes', async () => {

--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -3,7 +3,7 @@
    make the hook coordination harder to audit. */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { OpenFile } from '@/store/slices/editor'
-import { getConnectionId } from '@/lib/connection-context'
+import { getConnectionId, getConnectionIdForFile } from '@/lib/connection-context'
 import { joinPath } from '@/lib/path'
 import { useAppStore } from '@/store'
 import { getRuntimeFileReadScope, readRuntimeFileContent } from '@/runtime/runtime-file-client'
@@ -95,7 +95,7 @@ export function useEditorPanelContentState({
       relativePath?: string
     ): Promise<void> => {
       try {
-        const connectionId = getConnectionId(worktreeId ?? null) ?? undefined
+        const connectionId = getConnectionIdForFile(worktreeId ?? null, filePath) ?? undefined
         const restoredOpenFile = openFilesRef.current.find((file) => file.id === id)
         const activeSettings = useAppStore.getState().settings
         const readSettings = settingsForRuntimeOwner(
@@ -305,7 +305,12 @@ export function useEditorPanelContentState({
         return
       }
       if (!fileContents[fileToLoad.id]) {
-        void loadFileContent(fileToLoad.filePath, fileToLoad.id, fileToLoad.worktreeId)
+        void loadFileContent(
+          fileToLoad.filePath,
+          fileToLoad.id,
+          fileToLoad.worktreeId,
+          fileToLoad.relativePath
+        )
       }
       if (isChangesMode && !diffContents[fileToLoad.id]) {
         void loadDiffContent(fileToLoad)

--- a/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
+++ b/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
@@ -15,7 +15,12 @@ type EditorViewModeByFile = ReturnType<typeof useAppStore.getState>['editorViewM
 
 type UseEditorPanelExternalContentEventsParams = {
   loadDiffContent: (file: OpenFile | null, options?: { force?: boolean }) => Promise<void>
-  loadFileContent: (filePath: string, id: string, worktreeId?: string) => Promise<void>
+  loadFileContent: (
+    filePath: string,
+    id: string,
+    worktreeId?: string,
+    relativePath?: string
+  ) => Promise<void>
   openFilesRef: MutableRefObject<OpenFile[]>
   editorViewModeRef: MutableRefObject<EditorViewModeByFile>
   setFileContents: Dispatch<SetStateAction<Record<string, FileContent>>>
@@ -38,7 +43,7 @@ export function useEditorPanelExternalContentEvents({
       }
       for (const file of getOpenFilesForExternalFileChange(openFilesRef.current, detail)) {
         if (file.mode === 'edit' || file.mode === 'markdown-preview') {
-          void loadFileContent(file.filePath, file.id, file.worktreeId)
+          void loadFileContent(file.filePath, file.id, file.worktreeId, file.relativePath)
           if (editorViewModeRef.current[file.id] === 'changes') {
             void loadDiffContent(file, { force: true })
           }

--- a/src/renderer/src/components/editor/useEditorPanelFileLoadRetry.ts
+++ b/src/renderer/src/components/editor/useEditorPanelFileLoadRetry.ts
@@ -8,7 +8,12 @@ type UseEditorPanelFileLoadRetryParams = {
   activeFile: OpenFile | null
   fileContents: Record<string, FileContent>
   fileLoadRetryAttemptsRef: MutableRefObject<Record<string, number>>
-  loadFileContent: (filePath: string, id: string, worktreeId?: string) => Promise<void>
+  loadFileContent: (
+    filePath: string,
+    id: string,
+    worktreeId?: string,
+    relativePath?: string
+  ) => Promise<void>
   openFilesRef: MutableRefObject<OpenFile[]>
   setFileContents: Dispatch<SetStateAction<Record<string, FileContent>>>
 }
@@ -66,7 +71,12 @@ export function useEditorPanelFileLoadRetry({
         delete next[currentFile.id]
         return next
       })
-      void loadFileContent(currentFile.filePath, currentFile.id, currentFile.worktreeId)
+      void loadFileContent(
+        currentFile.filePath,
+        currentFile.id,
+        currentFile.worktreeId,
+        currentFile.relativePath
+      )
     }, delayMs)
     return () => window.clearTimeout(timeoutId)
   }, [

--- a/src/renderer/src/lib/connection-context.test.ts
+++ b/src/renderer/src/lib/connection-context.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import type { Repo } from '../../../shared/types'
 import { useAppStore } from '@/store'
-import { getConnectionId } from './connection-context'
+import { getConnectionId, getConnectionIdForFile } from './connection-context'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 
 const initialState = useAppStore.getInitialState()
@@ -192,6 +192,7 @@ describe('getConnectionId', () => {
   })
 
   it('returns undefined for folder workspaces with mixed local and SSH repos', () => {
+    const workspaceKey = folderWorkspaceKey('folder-workspace-1')
     useAppStore.setState({
       folderWorkspaces: [
         {
@@ -240,7 +241,12 @@ describe('getConnectionId', () => {
       worktreesByRepo: {}
     })
 
-    expect(getConnectionId(folderWorkspaceKey('folder-workspace-1'))).toBeUndefined()
+    expect(getConnectionId(workspaceKey)).toBeUndefined()
+    expect(getConnectionIdForFile(workspaceKey, '/home/neil/platform/api/src/index.ts')).toBe(
+      'ssh-1'
+    )
+    expect(getConnectionIdForFile(workspaceKey, '/home/neil/platform/web/src/index.ts')).toBeNull()
+    expect(getConnectionIdForFile(workspaceKey, '/home/neil/platform/README.md')).toBeUndefined()
   })
 
   it('keeps explicit folder workspace provenance isolated from unrelated same-path SSH repos', () => {

--- a/src/renderer/src/lib/connection-context.ts
+++ b/src/renderer/src/lib/connection-context.ts
@@ -1,7 +1,11 @@
 import { useAppStore } from '@/store'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
-import { getFolderWorkspaceConnectionId } from './folder-workspace-connection'
+import { isPathInsideOrEqual } from '../../../shared/cross-platform-path'
+import {
+  getFolderWorkspaceCandidateRepos,
+  getFolderWorkspaceConnectionId
+} from './folder-workspace-connection'
 
 /**
  * Resolve the SSH connectionId for a worktree. Returns null for local repos,
@@ -30,4 +34,42 @@ export function getConnectionId(worktreeId: string | null): string | null | unde
     return undefined
   }
   return repo.connectionId ?? null
+}
+
+export function getConnectionIdForFile(
+  worktreeId: string | null,
+  filePath: string
+): string | null | undefined {
+  const connectionId = getConnectionId(worktreeId)
+  if (connectionId !== undefined || !worktreeId) {
+    return connectionId
+  }
+  const parsedWorkspaceKey = parseWorkspaceKey(worktreeId)
+  if (parsedWorkspaceKey?.type !== 'folder') {
+    return undefined
+  }
+  // Why: mixed local/SSH folder workspaces cannot pick one owner globally, but
+  // a concrete file path can still belong unambiguously to a child repo.
+  const state = useAppStore.getState()
+  const candidateRepos = getFolderWorkspaceCandidateRepos(
+    state,
+    parsedWorkspaceKey.folderWorkspaceId
+  )
+  return resolveConnectionIdForRepoPath(candidateRepos, filePath)
+}
+
+function resolveConnectionIdForRepoPath(
+  repos: readonly { path: string; connectionId?: string | null }[],
+  filePath: string
+): string | null | undefined {
+  const matchingRepos = repos
+    .filter((repo) => isPathInsideOrEqual(repo.path, filePath))
+    .sort((a, b) => b.path.length - a.path.length)
+  const longestPath = matchingRepos[0]?.path
+  if (!longestPath) {
+    return undefined
+  }
+  const bestMatches = matchingRepos.filter((repo) => repo.path.length === longestPath.length)
+  const connectionIds = new Set(bestMatches.map((repo) => repo.connectionId ?? null))
+  return connectionIds.size === 1 ? ([...connectionIds][0] ?? null) : undefined
 }

--- a/src/renderer/src/lib/folder-workspace-connection.ts
+++ b/src/renderer/src/lib/folder-workspace-connection.ts
@@ -40,6 +40,24 @@ function getFolderScopeCandidateRepos(args: {
   ]
 }
 
+export function getFolderWorkspaceCandidateRepos(
+  state: FolderWorkspaceConnectionState,
+  folderWorkspaceId: string
+): Repo[] {
+  const workspace = state.folderWorkspaces.find((entry) => entry.id === folderWorkspaceId)
+  if (!workspace) {
+    return []
+  }
+  const group = state.projectGroups.find((entry) => entry.id === workspace.projectGroupId)
+  return getFolderScopeCandidateRepos({
+    folderPath: workspace.folderPath,
+    projectGroupId: workspace.projectGroupId,
+    connectionId: workspace.connectionId ?? group?.connectionId ?? null,
+    projectGroups: state.projectGroups,
+    repos: state.repos
+  })
+}
+
 export function getFolderWorkspaceConnectionId(
   state: FolderWorkspaceConnectionState,
   folderWorkspaceId: string
@@ -48,16 +66,11 @@ export function getFolderWorkspaceConnectionId(
   if (!workspace) {
     return undefined
   }
-  const group = state.projectGroups.find((entry) => entry.id === workspace.projectGroupId)
-  const scopeConnectionId = workspace.connectionId ?? group?.connectionId ?? null
-
-  const candidateRepos = getFolderScopeCandidateRepos({
-    folderPath: workspace.folderPath,
-    projectGroupId: workspace.projectGroupId,
-    connectionId: scopeConnectionId,
-    projectGroups: state.projectGroups,
-    repos: state.repos
-  })
+  const scopeConnectionId =
+    workspace.connectionId ??
+    state.projectGroups.find((entry) => entry.id === workspace.projectGroupId)?.connectionId ??
+    null
+  const candidateRepos = getFolderWorkspaceCandidateRepos(state, folderWorkspaceId)
   let hasLocalRepo = false
   const connectionIds = new Set<string>()
   for (const repo of candidateRepos) {


### PR DESCRIPTION
## Summary

Resolves an issue where remote files failed to read or load in folder workspaces that contain a mix of local and remote (SSH) repositories. Previously, a single connection ID could not be determined globally for mixed folder workspaces, resulting in an undefined connection. This PR introduces file-path-specific connection ID lookup, identifying the correct SSH connection ID for a given file by matching its path against candidate repositories within the workspace group.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Unit tests were added and updated in `useEditorPanelContentState.test.tsx` and `connection-context.test.ts` to verify that mixed folder workspace file content is successfully loaded through path-specific connections.

## AI Review Report

The review checked the resolution of path-specific connection IDs. It confirmed that using `isPathInsideOrEqual` guarantees cross-platform path matching safety on macOS, Linux, and Windows. Sorting repos by path length ensures that nested repository hierarchies resolve to the most specific repository. No keyboard shortcuts, UI accelerators, or platform-specific UI changes were added, keeping behavior consistent across all operating systems.

## Security Audit

Reviewed path matching and connection lookup. The lookup utilizes `isPathInsideOrEqual` from `cross-platform-path` to safely check if file paths reside within configured repository workspaces, preventing path traversal or out-of-bounds reads. No direct command execution or shell interactions were added. Connection IDs are securely retrieved from current internal application state.

## Notes

Path matching is cross-platform compatible and robust against varying OS path formats.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5971">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->