### PR TITLE
fix(file-explorer): allow filtered folder toggles

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -7,6 +7,7 @@ import { WorktreeOpenInMenuItems } from '@/components/sidebar/WorktreeOpenInMenu
 import { FileExplorerToolbar } from './FileExplorerToolbar'
 import { FileExplorerNameFilter } from './FileExplorerNameFilter'
 import { FileExplorerViewSwitch } from './FileExplorerViewSwitch'
+import { getNextNameFilterCollapsedPaths } from './file-explorer-name-filter-projection'
 import {
   downloadRemoteFile,
   FileExplorerRow,
@@ -279,6 +280,16 @@ beforeEach(() => {
   toastErrorMock.mockReset()
   toastSuccessMock.mockReset()
   delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+})
+
+describe('getNextNameFilterCollapsedPaths', () => {
+  it('collapses expanded filtered folders and expands collapsed filtered folders', () => {
+    const collapsed = getNextNameFilterCollapsedPaths(new Set(), '/repo/src', true)
+    expect([...collapsed]).toEqual(['/repo/src'])
+
+    const expanded = getNextNameFilterCollapsedPaths(collapsed, '/repo/src', false)
+    expect([...expanded]).toEqual([])
+  })
 })
 
 describe('FileExplorerToolbar', () => {

--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -7,7 +7,10 @@ import { WorktreeOpenInMenuItems } from '@/components/sidebar/WorktreeOpenInMenu
 import { FileExplorerToolbar } from './FileExplorerToolbar'
 import { FileExplorerNameFilter } from './FileExplorerNameFilter'
 import { FileExplorerViewSwitch } from './FileExplorerViewSwitch'
-import { getNextNameFilterCollapsedPaths } from './file-explorer-name-filter-projection'
+import {
+  getNameFilterCollapsedPathsAfterExpand,
+  getNextNameFilterCollapsedPaths
+} from './file-explorer-name-filter-projection'
 import {
   downloadRemoteFile,
   FileExplorerRow,
@@ -289,6 +292,15 @@ describe('getNextNameFilterCollapsedPaths', () => {
 
     const expanded = getNextNameFilterCollapsedPaths(collapsed, '/repo/src', false)
     expect([...expanded]).toEqual([])
+  })
+
+  it('expands filtered folders without toggling unrelated collapsed paths', () => {
+    const expanded = getNameFilterCollapsedPathsAfterExpand(
+      new Set(['/repo/docs', '/repo/src']),
+      '/repo/src'
+    )
+
+    expect([...expanded]).toEqual(['/repo/docs'])
   })
 })
 

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -23,7 +23,10 @@ import { SearchResultsPane } from './SearchResultsPane'
 import { useFileSearchPanel } from './useFileSearchPanel'
 import { FileExplorerTreeStatus } from './FileExplorerTreeStatus'
 import { FileExplorerVirtualRows } from './FileExplorerVirtualRows'
-import { isFileExplorerNameFilterQueryTooLarge } from './file-explorer-name-filter-projection'
+import {
+  getNextNameFilterCollapsedPaths,
+  isFileExplorerNameFilterQueryTooLarge
+} from './file-explorer-name-filter-projection'
 import { splitPathSegments } from './path-tree'
 import { buildFolderStatusMap, buildStatusMap } from './status-display'
 import { useFileDeletion } from './useFileDeletion'
@@ -55,6 +58,9 @@ function FileExplorerFiles(): React.JSX.Element {
   const showRightSidebarFiles = useAppStore((s) => s.showRightSidebarFiles)
   const showRightSidebarSearch = useAppStore((s) => s.showRightSidebarSearch)
   const [nameFilterQuery, setNameFilterQuery] = useState('')
+  const [nameFilterCollapsedPaths, setNameFilterCollapsedPaths] = useState<Set<string>>(
+    () => new Set()
+  )
   const searchPanel = useFileSearchPanel(explorerView)
 
   const handleSelectExplorerView = useCallback(
@@ -125,6 +131,9 @@ function FileExplorerFiles(): React.JSX.Element {
     [nameFilterQuery]
   )
   const hasNameFilter = isFilesViewActive && hasNameFilterQuery
+  useEffect(() => {
+    setNameFilterCollapsedPaths((current) => (current.size > 0 ? new Set() : current))
+  }, [hasNameFilter, nameFilterQuery])
   const nameFilterFiles = useRuntimeFileListForWorktree({
     enabled: hasNameFilter && !nameFilterQueryTooLarge,
     worktreeId: activeWorktreeId
@@ -162,14 +171,17 @@ function FileExplorerFiles(): React.JSX.Element {
     expanded,
     activeRepoSupportsGit && isFilesViewActive,
     showDotfiles,
-    nameFilterSource
+    nameFilterSource,
+    hasNameFilter ? nameFilterCollapsedPaths : null
   )
   const rowExpandedPaths = useMemo(
     () =>
-      nameFilterExpandedPaths.size > 0
-        ? new Set([...expanded, ...nameFilterExpandedPaths])
-        : expanded,
-    [expanded, nameFilterExpandedPaths]
+      hasNameFilter
+        ? nameFilterExpandedPaths
+        : nameFilterExpandedPaths.size > 0
+          ? new Set([...expanded, ...nameFilterExpandedPaths])
+          : expanded,
+    [expanded, hasNameFilter, nameFilterExpandedPaths]
   )
   const visibleRowCount = rowProjection.getVisibleCount()
   const manualRefresh = useFileExplorerManualRefresh(refreshTree)
@@ -433,12 +445,19 @@ function FileExplorerFiles(): React.JSX.Element {
     () => rowProjection.getRowsByPaths(selectedPaths),
     [rowProjection, selectedPaths]
   )
+  const handleToggleNameFilterDir = useCallback(
+    (_worktreeId: string, dirPath: string) => {
+      setNameFilterCollapsedPaths((current) =>
+        getNextNameFilterCollapsedPaths(current, dirPath, rowExpandedPaths.has(dirPath))
+      )
+    },
+    [rowExpandedPaths]
+  )
   const { handleClick, handleDoubleClick, handleWheelCapture } = useFileExplorerHandlers({
     activeWorktreeId,
     openFile,
     makePreviewFilePermanent,
-    toggleDir,
-    canToggleDirectories: !hasNameFilter,
+    toggleDir: hasNameFilter ? handleToggleNameFilterDir : toggleDir,
     loadDir,
     statPath,
     markPathAsDirectory,
@@ -466,13 +485,13 @@ function FileExplorerFiles(): React.JSX.Element {
     containerRef: explorerShellRef,
     rowProjection,
     expandedPaths: rowExpandedPaths,
-    canToggleDirectories: !hasNameFilter,
+    canToggleDirectories: true,
     inlineInput,
     selectedPaths,
     selectedNode,
     activateNode,
     moveSelection,
-    toggleDir,
+    toggleDir: hasNameFilter ? handleToggleNameFilterDir : toggleDir,
     startRename,
     requestDelete,
     requestDeleteAll,

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -24,6 +24,7 @@ import { useFileSearchPanel } from './useFileSearchPanel'
 import { FileExplorerTreeStatus } from './FileExplorerTreeStatus'
 import { FileExplorerVirtualRows } from './FileExplorerVirtualRows'
 import {
+  getNameFilterCollapsedPathsAfterExpand,
   getNextNameFilterCollapsedPaths,
   isFileExplorerNameFilterQueryTooLarge
 } from './file-explorer-name-filter-projection'
@@ -455,6 +456,11 @@ function FileExplorerFiles(): React.JSX.Element {
     },
     [rowExpandedPaths]
   )
+  const handleExpandNameFilterDir = useCallback((dirPath: string) => {
+    setNameFilterCollapsedPaths((current) =>
+      getNameFilterCollapsedPathsAfterExpand(current, dirPath)
+    )
+  }, [])
   const { handleClick, handleDoubleClick, handleWheelCapture } = useFileExplorerHandlers({
     activeWorktreeId,
     openFile,
@@ -725,9 +731,11 @@ function FileExplorerFiles(): React.JSX.Element {
                 onMoveDrop={handleMoveDrop}
                 onDragTargetChange={setDropTargetDir}
                 onDragSourceChange={setDragSourcePath}
-                onDragExpandDir={handleDragExpandDir}
+                onDragExpandDir={hasNameFilter ? handleExpandNameFilterDir : handleDragExpandDir}
                 onNativeDragTargetChange={setNativeDropTargetDir}
-                onNativeDragExpandDir={handleNativeDragExpandDir}
+                onNativeDragExpandDir={
+                  hasNameFilter ? handleExpandNameFilterDir : handleNativeDragExpandDir
+                }
                 dropTargetDir={dropTargetDir}
                 dragSourcePath={dragSourcePath}
                 nativeDropTargetDir={nativeDropTargetDir}

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -132,8 +132,10 @@ function FileExplorerFiles(): React.JSX.Element {
   )
   const hasNameFilter = isFilesViewActive && hasNameFilterQuery
   useEffect(() => {
-    setNameFilterCollapsedPaths((current) => (current.size > 0 ? new Set() : current))
-  }, [hasNameFilter, nameFilterQuery])
+    if (!hasNameFilter) {
+      setNameFilterCollapsedPaths((current) => (current.size > 0 ? new Set() : current))
+    }
+  }, [hasNameFilter])
   const nameFilterFiles = useRuntimeFileListForWorktree({
     enabled: hasNameFilter && !nameFilterQueryTooLarge,
     worktreeId: activeWorktreeId

--- a/src/renderer/src/components/right-sidebar/file-explorer-keyboard-navigation.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-keyboard-navigation.ts
@@ -158,8 +158,8 @@ export function applyFileExplorerNavigation(ctx: NavigationContext, e: KeyboardE
   if (resolved.type === 'toggle-expand' || resolved.type === 'toggle-collapse') {
     e.preventDefault()
     e.stopPropagation()
-    // Why: name-filtered rows are a projection, so toggles should not mutate
-    // persisted expansion state while filtering is suppressing directory toggles.
+    // Why: callers can disable directory toggles for projected or transient trees
+    // where mutating persisted expansion state would be misleading.
     if (ctx.activeWorktreeId && ctx.canToggleDirectories !== false) {
       ctx.handlers.toggleDir(ctx.activeWorktreeId, resolved.dirPath)
     }

--- a/src/renderer/src/components/right-sidebar/file-explorer-name-filter-projection.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-name-filter-projection.ts
@@ -30,6 +30,18 @@ export function getNextNameFilterCollapsedPaths(
   return next
 }
 
+export function getNameFilterCollapsedPathsAfterExpand(
+  collapsedPaths: ReadonlySet<string>,
+  dirPath: string
+): Set<string> {
+  if (!collapsedPaths.has(dirPath)) {
+    return new Set(collapsedPaths)
+  }
+  const next = new Set(collapsedPaths)
+  next.delete(dirPath)
+  return next
+}
+
 export function isFileExplorerNameFilterQueryTooLarge(
   query: string | undefined,
   maxBytes = FILE_EXPLORER_NAME_FILTER_QUERY_MAX_BYTES

--- a/src/renderer/src/components/right-sidebar/file-explorer-name-filter-projection.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-name-filter-projection.ts
@@ -16,6 +16,20 @@ export type FileExplorerNameFilterProjectionSource = {
 
 export const FILE_EXPLORER_NAME_FILTER_QUERY_MAX_BYTES = 2 * 1024
 
+export function getNextNameFilterCollapsedPaths(
+  collapsedPaths: ReadonlySet<string>,
+  dirPath: string,
+  isExpanded: boolean
+): Set<string> {
+  const next = new Set(collapsedPaths)
+  if (isExpanded) {
+    next.add(dirPath)
+  } else {
+    next.delete(dirPath)
+  }
+  return next
+}
+
 export function isFileExplorerNameFilterQueryTooLarge(
   query: string | undefined,
   maxBytes = FILE_EXPLORER_NAME_FILTER_QUERY_MAX_BYTES
@@ -119,12 +133,14 @@ function createSyntheticNode(
 }
 
 export function createNameFilteredFileExplorerProjection({
+  collapsedPaths,
   ignoredSet,
   nameFilter,
   showDotfiles,
   showGitIgnoredFiles,
   worktreePath
 }: {
+  collapsedPaths?: ReadonlySet<string>
   ignoredSet: Set<string>
   nameFilter: FileExplorerNameFilterProjectionSource
   showDotfiles: boolean
@@ -180,14 +196,15 @@ export function createNameFilteredFileExplorerProjection({
     }
   }
 
-  appendNameFilteredEntries(rootChildren.values(), visibleFlatRows, rowsByPath)
+  appendNameFilteredEntries(rootChildren.values(), visibleFlatRows, rowsByPath, collapsedPaths)
   return createFileExplorerRowProjectionFromParts(visibleFlatRows, rowsByPath)
 }
 
 function appendNameFilteredEntries(
   entries: Iterable<SyntheticTreeEntry>,
   visibleFlatRows: TreeNode[],
-  rowsByPath: Map<string, TreeNode>
+  rowsByPath: Map<string, TreeNode>,
+  collapsedPaths?: ReadonlySet<string>
 ): void {
   const sortedEntries = Array.from(entries).sort((a, b) => {
     if (a.node.isDirectory !== b.node.isDirectory) {
@@ -198,8 +215,13 @@ function appendNameFilteredEntries(
   for (const entry of sortedEntries) {
     visibleFlatRows.push(entry.node)
     rowsByPath.set(entry.node.path, entry.node)
-    if (entry.children.size > 0) {
-      appendNameFilteredEntries(entry.children.values(), visibleFlatRows, rowsByPath)
+    if (entry.children.size > 0 && !collapsedPaths?.has(entry.node.path)) {
+      appendNameFilteredEntries(
+        entry.children.values(),
+        visibleFlatRows,
+        rowsByPath,
+        collapsedPaths
+      )
     }
   }
 }

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
@@ -168,6 +168,31 @@ describe('file explorer visible row projection', () => {
     ])
   })
 
+  it('hides descendants under collapsed folders while a file-name filter is active', () => {
+    const projection = createVisibleFileExplorerRowProjection(
+      input({
+        '/repo': [row('docs', true, 0), row('src', true, 0)]
+      }),
+      {
+        ignoredSet: new Set(),
+        nameFilter: {
+          query: 'ts',
+          relativePaths: ['docs/guide.ts', 'src/components/FileExplorer.tsx', 'src/index.ts']
+        },
+        nameFilterCollapsedPaths: new Set(['/repo/src']),
+        showDotfiles: true,
+        showGitIgnoredFiles: true
+      }
+    )
+
+    expect(projection.getVisibleSlice(0, 10).map((entry) => entry.relativePath)).toEqual([
+      'docs',
+      'docs/guide.ts',
+      'src'
+    ])
+    expect([...getFileExplorerNameFilterExpandedPaths(projection, 'ts')]).toEqual(['/repo/docs'])
+  })
+
   it('does not fall back to the partial cached tree while recursive file filtering is loading', () => {
     const projection = createVisibleFileExplorerRowProjection(
       input(

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
@@ -30,6 +30,7 @@ export type IgnoredPathResult = {
 type VisibleFileExplorerRowProjectionOptions = {
   ignoredSet: Set<string>
   nameFilter?: FileExplorerNameFilterProjectionSource | null
+  nameFilterCollapsedPaths?: ReadonlySet<string> | null
   showDotfiles: boolean
   showGitIgnoredFiles: boolean
 }
@@ -81,6 +82,7 @@ export function createVisibleFileExplorerRowProjection(
   }
   if (options.nameFilter) {
     return createNameFilteredFileExplorerProjection({
+      collapsedPaths: options.nameFilterCollapsedPaths ?? undefined,
       ignoredSet: options.ignoredSet,
       nameFilter: options.nameFilter,
       showDotfiles: options.showDotfiles,
@@ -149,7 +151,8 @@ export function useFileExplorerVisibleRowProjection(
   expanded: Set<string>,
   activeRepoSupportsGit: boolean,
   showDotfiles: boolean,
-  nameFilter: FileExplorerNameFilterProjectionSource | null
+  nameFilter: FileExplorerNameFilterProjectionSource | null,
+  nameFilterCollapsedPaths: ReadonlySet<string> | null = null
 ): {
   rowProjection: FileExplorerRowProjection
   ignoredByRelativePath: Set<string>
@@ -235,11 +238,21 @@ export function useFileExplorerVisibleRowProjection(
         {
           ignoredSet,
           nameFilter,
+          nameFilterCollapsedPaths,
           showDotfiles,
           showGitIgnoredFiles
         }
       ),
-    [dirCache, expanded, ignoredSet, nameFilter, showDotfiles, showGitIgnoredFiles, worktreePath]
+    [
+      dirCache,
+      expanded,
+      ignoredSet,
+      nameFilter,
+      nameFilterCollapsedPaths,
+      showDotfiles,
+      showGitIgnoredFiles,
+      worktreePath
+    ]
   )
   const nameFilterExpandedPaths = useMemo(
     () => getFileExplorerNameFilterExpandedPaths(rowProjection, nameFilter?.query ?? ''),


### PR DESCRIPTION
## Summary
- Allow directory rows to expand and collapse while file-name filtering is active.
- Keep filtered collapse state transient so normal persisted file explorer expansion is unchanged.
- Add regression coverage for the filtered projection and toggle helper.

Closes #5715

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts src/renderer/src/components/right-sidebar/file-explorer-keyboard-navigation.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run build:desktop` (passes; local `/usr/local/bin/orca-dev` symlink permission warning and existing Vite chunk/dynamic-import warnings)

## Notes
- No platform-specific shortcuts, path handling, SSH behavior, auth, or trust boundary changes.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5977">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->