### PR TITLE
fix: improve terminal contrast in light themes (Tango Light + xterm minimumContrastRatio)

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -83,6 +83,10 @@ describe('buildDefaultTerminalOptions', () => {
     expect(buildDefaultTerminalOptions().scrollbar?.width).toBe(7)
   })
 
+  it('enables xterm contrast correction for low-contrast CLI colors', () => {
+    expect(buildDefaultTerminalOptions().minimumContrastRatio).toBe(4.5)
+  })
+
   it('only uses inactive outline for block cursors', () => {
     expect(resolveTerminalCursorInactiveStyle('block')).toBe('outline')
     expect(resolveTerminalCursorInactiveStyle('bar')).toBe('bar')

--- a/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
@@ -27,6 +27,9 @@ export function buildDefaultTerminalOptions(): ITerminalOptions {
     fontWeightBold: '500',
     scrollback: 10000,
     allowTransparency: false,
+    // Why: agent CLIs sometimes render body text with ANSI white/bright-white
+    // on light themes; xterm can keep those cells readable across renderers.
+    minimumContrastRatio: 4.5,
     // Why: on macOS, non-US layouts rely on Option to compose characters like @ and €.
     macOptionIsMeta: false,
     macOptionClickForcesSelection: true,

--- a/src/renderer/src/lib/terminal-theme.test.ts
+++ b/src/renderer/src/lib/terminal-theme.test.ts
@@ -261,6 +261,26 @@ describe('default dark terminal theme selection contrast', () => {
   })
 })
 
+describe('default light terminal theme ANSI contrast', () => {
+  it('keeps CLI body/header ANSI colors readable on the terminal background', () => {
+    const theme = getBuiltinTheme(DEFAULT_TERMINAL_THEME_LIGHT)
+
+    expect(theme, `${DEFAULT_TERMINAL_THEME_LIGHT} should exist`).not.toBeNull()
+    if (!theme?.background) {
+      throw new Error(`${DEFAULT_TERMINAL_THEME_LIGHT} is missing a background color`)
+    }
+
+    for (const key of ['cyan', 'white', 'brightCyan', 'brightWhite'] as const) {
+      const color = theme[key]
+      expect(color, `${DEFAULT_TERMINAL_THEME_LIGHT}.${key} should be defined`).toBeDefined()
+      if (!color) {
+        throw new Error(`${DEFAULT_TERMINAL_THEME_LIGHT}.${key} is missing`)
+      }
+      expect(contrastRatio(color, theme.background)).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+})
+
 describe('isTerminalBackgroundLight', () => {
   it('classifies common terminal background color formats by luminance', () => {
     const split = vi.spyOn(String.prototype, 'split')

--- a/src/renderer/src/lib/terminal-themes/defaults.ts
+++ b/src/renderer/src/lib/terminal-themes/defaults.ts
@@ -38,18 +38,20 @@ export const DEFAULT_TERMINAL_THEMES: TerminalThemeMap = {
     black: '#2e3436',
     red: '#cc0000',
     green: '#4e9a06',
-    yellow: '#c4a000',
+    // Why: Claude-style previews use ANSI accent colors for readable text,
+    // so the light theme cannot keep Tango's near-white legacy values.
+    yellow: '#8e7700',
     blue: '#3465a4',
     magenta: '#75507b',
-    cyan: '#06989a',
-    white: '#d3d7cf',
+    cyan: '#05727e',
+    white: '#6a6a6a',
     brightBlack: '#555753',
     brightRed: '#ef2929',
-    brightGreen: '#8ae234',
-    brightYellow: '#fce94f',
-    brightBlue: '#729fcf',
+    brightGreen: '#1b7a1b',
+    brightYellow: '#6d5a00',
+    brightBlue: '#204a87',
     brightMagenta: '#ad7fa8',
-    brightCyan: '#34e2e2',
-    brightWhite: '#eeeeec'
+    brightCyan: '#034b50',
+    brightWhite: '#3d3d3d'
   }
 }


### PR DESCRIPTION
## What

The Builtin Tango Light theme had 9 ANSI colors with contrast ratios below 3:1 against its white (#ffffff) background. CLI tools that render body text, file contents, and headers using ANSI white/bright-white produced unreadable output in light mode.

## Fix (two layers)

### Layer 1 — Theme colors (`defaults.ts`)
Darkened 9 low-contrast ANSI colors to readable Tango palette shades:

| Color | Before | After | Contrast |
|-------|--------|-------|----------|
| white | #d3d7cf | #6a6a6a | 1.5:1 → 5.4:1 |
| brightWhite | #eeeeec | #3d3d3d | 1.2:1 → 10.9:1 |
| cyan | #06989a | #05727e | 3.5:1 → 5.7:1 |
| brightCyan | #34e2e2 | #034b50 | 1.6:1 → 9.9:1 |
| yellow | #c4a000 | #8e7700 | 2.5:1 → 4.4:1 |
| brightGreen | #8ae234 | #1b7a1b | 1.6:1 → 5.5:1 |
| brightYellow | #fce94f | #6d5a00 | 1.2:1 → 6.7:1 |
| brightBlue | #729fcf | #204a87 | 2.8:1 → 8.8:1 |
| brightCyan | #34e2e2 | #034b50 | 1.6:1 → 9.9:1 |

### Layer 2 — Renderer safety net (`pane-terminal-options.ts`)
Enabled xterm.js `minimumContrastRatio: 4.5`. This auto-adjusts any low-contrast foreground color at render time — protecting ALL themes including user-imported custom themes.

### Layer 3 — Tests
- `terminal-theme.test.ts`: asserts Tango Light key ANSI colors (cyan, white, brightCyan, brightWhite) pass ≥4.5:1 contrast
- `pane-lifecycle.test.ts`: asserts `minimumContrastRatio` is enabled in default terminal options

## Verification

- All existing tests pass
- Typecheck passes
- Lint passes

X: @askrygg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->