### PR TITLE
fix: match workspace tab divider line colors with rest of UI

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -1038,7 +1038,7 @@ function TabBarInner({
             // a different box than the tab's own `border-t`, producing a
             // heavier-looking L-corner at the leftmost tab when inactive.
             className={[
-              'terminal-tab-strip flex h-full min-w-0 max-w-full flex-1 items-stretch overflow-x-auto overflow-y-hidden border-r border-border',
+              'terminal-tab-strip flex h-full min-w-0 max-w-full flex-1 items-stretch overflow-x-auto overflow-y-hidden border-r border-border/70',
               getTabStripScrollMaskClassName(tabStripOverflowState)
             ]
               .filter(Boolean)


### PR DESCRIPTION
Fixes #5906

## Summary

The divider line on the workspace tab strip had a different opacity compared to other divider lines in the application. Changed from `border-border` (full opacity) to `border-border/70` to match the standard divider styling used throughout the UI.

## Changes

- src/renderer/src/components/tab-bar/TabBar.tsx: Changed workspace tab strip border from `border-r border-border` to `border-r border-border/70` for consistent divider opacity.

## Screenshots

No visual change - subtle opacity adjustment only.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Manual testing performed

## AI Review Report

Change is a single-char CSS value: border-border to border-border/70. No cross-platform concerns; the Tailwind opacity modifier works identically on macOS, Linux, and Windows.

## Security Audit

No security impact - CSS-only change to border opacity.

## Notes

This is a visual consistency fix. The workspace tab strip divider now renders at 70% opacity matching other dividers in the application.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5987">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->