### PR TITLE
Remove duplicate automation worktree badge

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -124,6 +124,10 @@ function renderWorktreeCardMarkup(element: ReactNode): string {
   return renderToStaticMarkup(<>{element}</>)
 }
 
+function countAutomationCreatedLabels(markup: string): number {
+  return markup.match(/Created by automation/g)?.length ?? 0
+}
+
 function getInlineRenameTitleTag(markup: string): string {
   const match = markup.match(/<span[^>]*data-worktree-title-inline-rename=""[^>]*>/)
   expect(match).not.toBeNull()
@@ -456,7 +460,7 @@ describe('WorktreeCard linked PR display', () => {
       />
     )
 
-    expect(markup).toContain('Created by automation')
+    expect(countAutomationCreatedLabels(markup)).toBe(1)
     expect(markup).not.toContain('>Automation</span>')
   }, 20_000)
 
@@ -487,7 +491,7 @@ describe('WorktreeCard linked PR display', () => {
       />
     )
 
-    expect(markup).not.toContain('Created by automation')
+    expect(countAutomationCreatedLabels(markup)).toBe(0)
     expect(markup).not.toContain('>Automation</span>')
     expect(markup).not.toContain('Nightly triage automation')
   }, 20_000)
@@ -519,7 +523,7 @@ describe('WorktreeCard linked PR display', () => {
       />
     )
 
-    expect(markup).toContain('Created by automation')
+    expect(countAutomationCreatedLabels(markup)).toBe(1)
     expect(markup).not.toContain('>Automation</span>')
   }, 20_000)
 
@@ -549,7 +553,7 @@ describe('WorktreeCard linked PR display', () => {
       />
     )
 
-    expect(markup).not.toContain('Created by automation')
+    expect(countAutomationCreatedLabels(markup)).toBe(0)
     expect(markup).not.toContain('>Automation</span>')
     expect(markup).not.toContain('Nightly triage automation')
   })

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -511,7 +511,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const showAutomation = cardProps.includes('automation')
   const showComment = cardProps.includes('comment')
   const showPorts = cardProps.includes('ports')
-  const hasAutomationMetadata = showAutomation && !!worktree.automationProvenance
   const shouldRefreshHostedReview = newCardStyle ? showStatus : showPR
   const detailsHoverControl = useWorktreeCardDetailsHoverControl()
   const hoverDetailsOpen = detailsHoverControl.hoverOpen
@@ -1052,7 +1051,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // carrying a persistent rebase chip while preserving other interruption cues.
   const showConflictOperationBadge =
     !!conflictOperation && conflictOperation !== 'unknown' && conflictOperation !== 'rebase'
-  const hasMetadataBadge = showConflictOperationBadge || hasAutomationMetadata
+  const hasMetadataBadge = showConflictOperationBadge
   const showUnreadQuickAction = !affiliateListMode && showStatus && !newCardStyle
   // Why: the slot owns the tiny unread/status lane; legacy keeps the bell
   // toggle, while the experimental card keeps the status glyph passive.
@@ -1070,7 +1069,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
     showBranch ||
     showDetachedHeadInMetaRow ||
     showConflictOperationBadge ||
-    hasAutomationMetadata ||
     cacheStartedAt != null ||
     showMetaRowDetails
   )
@@ -1540,23 +1538,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 >
                   <GitMerge className="size-2.5" />
                   {CONFLICT_OPERATION_LABELS[conflictOperation]}
-                </Badge>
-              )}
-
-              {hasAutomationMetadata && (
-                <Badge
-                  variant="outline"
-                  className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 gap-1 text-muted-foreground border-border/60 bg-muted/30 leading-none"
-                  title={translate(
-                    'auto.components.sidebar.WorktreeCard.automationCreated',
-                    'Created by automation'
-                  )}
-                  aria-label={translate(
-                    'auto.components.sidebar.WorktreeCard.automationCreated',
-                    'Created by automation'
-                  )}
-                >
-                  <Workflow className="size-2.5" />
                 </Badge>
               )}
 


### PR DESCRIPTION
## Summary
- remove the extra Workflow automation badge from worktree card metadata rows
- keep the existing CalendarClock metadata badge/details as the single automation indicator
- tighten coverage so enabled automation metadata renders exactly one "Created by automation" label

## Tests
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5993">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->