### PR TITLE
Improve Claude usage refresh fallback behavior

### DIFF
--- a/docs/claude-usage-tracking-codexbar-parity.md
+++ b/docs/claude-usage-tracking-codexbar-parity.md
@@ -1,0 +1,391 @@
+# Claude Usage Tracking: CodexBar Parity Plan
+
+## Goal
+
+Make Orca's Claude usage limit tracking behave like CodexBar's Claude implementation: automatic, resilient, and source-aware internally, without asking users to choose between OAuth, CLI, or other data sources.
+
+This plan intentionally does not introduce new product behavior from scratch. Each proposed change is based on CodexBar's existing implementation.
+
+## User-Facing Principle
+
+Users should not need to pick a usage source.
+
+The normal product behavior should remain automatic:
+
+- Try the best live Claude usage source.
+- Repair or fall back when a source fails.
+- Keep the last useful usage snapshot visible when refresh is deferred or temporarily unavailable.
+- Show a specific, actionable status only when Orca cannot recover automatically.
+
+Any "source planner" described below is internal plumbing only. It should not imply a visible source picker for normal users.
+
+## CodexBar References
+
+CodexBar's Claude implementation already separates source selection from execution:
+
+- `ClaudeSourcePlanner.resolve(...)` builds an ordered automatic plan.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeSourcePlanner.swift:173`
+- App auto mode tries OAuth, then CLI, then web.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeSourcePlanner.swift:173`
+- CLI runtime auto mode tries web, then CLI.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeSourcePlanner.swift:181`
+- `ClaudeUsageFetcher.StepExecutor` executes the selected path.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:461`
+- OAuth failures can trigger delegated Claude CLI refresh, then credentials are reloaded and OAuth is retried.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:324`
+- OAuth credential loading accounts for Keychain prompt policy and cached credentials.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:250`
+- Claude source types are explicit: auto, api, oauth, web, cli.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageDataSource.swift:3`
+
+CodexBar's Codex implementation is also a useful pattern for fallback discipline:
+
+- Auto mode tries OAuth, then CLI.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift:43`
+- Codex OAuth refresh is performed before usage fetch when credentials need refresh.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift:169`
+- Fallback from OAuth to CLI is limited to failures the CLI can plausibly repair.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift:199`
+- Codex CLI usage is fetched through `codex app-server` JSON-RPC.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/UsageFetcher.swift:1012`
+
+## Current Orca Behavior To Preserve Or Change
+
+Orca currently reads Claude OAuth credentials and calls Anthropic's OAuth usage endpoint:
+
+- OAuth usage endpoint and headers are in `claude-fetcher.ts`.
+  Reference: `src/main/rate-limits/claude-fetcher.ts:24`
+- OAuth credential reads intentionally let the server decide whether a token is valid because local expiry metadata is not authoritative.
+  Reference: `src/main/rate-limits/claude-fetcher.ts:80`
+- System-default Keychain lookup intentionally mirrors Claude's legacy service ordering.
+  Reference: `src/main/rate-limits/claude-fetcher.ts:193`
+- Renderer currently maps many auth-looking failures into "Refresh failed" / softer auth copy.
+  Reference: `src/renderer/src/components/status-bar/tooltip.tsx:115`
+
+Preserve:
+
+- Managed-account safety around live Claude sessions and refresh-token rotation.
+- System-default support.
+- Existing OAuth usage endpoint mapping.
+- Existing PTY fallback parser behavior where safe.
+
+Change:
+
+- Do not treat a single OAuth failure as overall Claude usage failure.
+- Distinguish deferred, recoverable, fallbackable, and terminal failures.
+- Use CLI fallback and delegated refresh intentionally, following CodexBar's shape.
+
+## Proposed Changes
+
+### 1. Add An Internal Claude Usage Refresh Plan
+
+Create an internal planner that returns ordered attempts for the current account/runtime state.
+
+Initial app automatic order should match CodexBar's app auto ordering:
+
+1. OAuth usage API.
+2. CLI/PTY usage fallback.
+3. Web usage source later, only if Orca intentionally adopts CodexBar's web/cookie machinery.
+
+CodexBar basis:
+
+- `ClaudeSourcePlanner.makeSteps` app auto returns OAuth, CLI, web.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeSourcePlanner.swift:173`
+- `ClaudeUsageDataSource` defines source identifiers separately from execution.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageDataSource.swift:3`
+
+Orca implementation target:
+
+- Add a focused module near `src/main/rate-limits/`, for example `claude-usage-refresh-plan.ts`.
+- Keep it internal to main-process rate-limit refresh.
+- Do not expose a normal user setting for source selection.
+
+### 2. Add Source Attempt Execution
+
+Separate "which source should be tried" from "how each source fetches usage."
+
+CodexBar basis:
+
+- `StepExecutor.loadLatestUsage` switches on source and executes OAuth, web, or CLI.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:461`
+
+Orca implementation target:
+
+- Split Claude refresh into source attempt functions:
+  - `fetchClaudeUsageViaOAuth(...)`
+  - `fetchClaudeUsageViaCli(...)`
+  - possible future `fetchClaudeUsageViaWeb(...)`
+- Keep the existing OAuth endpoint logic in the OAuth attempt.
+- Reuse existing `fetchViaPty` for the CLI attempt.
+
+### 3. Classify OAuth Failures Before Deciding What To Do
+
+Add structured OAuth failure classification.
+
+Failure kinds should include:
+
+- missing credentials
+- stale or unauthorized access token
+- refreshable credentials present but access token unavailable
+- delegated refresh required
+- delegated refresh deferred by live Claude session
+- Keychain denied or unavailable
+- missing required scope
+- network/proxy/DNS failure
+- Anthropic server failure
+- response parse failure
+- rate-limited usage endpoint
+
+CodexBar basis:
+
+- Codex fallback is intentionally limited to specific OAuth credential/auth errors.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift:199`
+- Claude OAuth maps credential/fetch errors distinctly before retrying or surfacing.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:286`
+- Missing Claude OAuth scope gets a specific actionable message.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:444`
+
+Orca implementation target:
+
+- Add `claude-usage-error-classification.ts`.
+- Use classification to decide:
+  - retry OAuth after delegated refresh
+  - fall back to CLI
+  - defer because live Claude owns refresh
+  - surface terminal error
+
+### 4. Add Delegated Claude CLI Refresh For Safe Cases
+
+When OAuth credentials appear stale or access is unauthorized, let Claude CLI repair its own credentials, then re-read credentials and retry OAuth once.
+
+CodexBar basis:
+
+- Expired Claude OAuth credentials can trigger `loadAfterDelegatedRefresh`.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:324`
+- CodexBar asserts delegated refresh is allowed in the current interaction context before running it.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:345`
+- After delegated refresh, CodexBar invalidates changed credential caches, syncs Keychain without prompt, reloads credentials, and retries OAuth.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:369`
+
+Orca implementation target:
+
+- Add a guarded delegated refresh step for system-default accounts and managed accounts only when no live Claude PTY owns the same credentials.
+- After delegation, re-run Orca's existing credential read order and retry the OAuth usage request once.
+- Keep this disabled for cases where Orca already knows live Claude is using/rotating that credential set.
+
+### 5. Preserve Managed Live-Session Safety, But Change The State
+
+Current Orca managed-account behavior avoids rotating refresh tokens while a live Claude terminal may rotate them. Keep that safety rule.
+
+Change the user-visible outcome from generic failure to a deferred state.
+
+CodexBar basis:
+
+- Delegated refresh is gated by interaction policy and can be unavailable rather than blindly attempted.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:345`
+- CodexBar tracks delegated refresh outcomes and reports them distinctly.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:350`
+
+Orca implementation target:
+
+- Add a first-class `deferredByLiveClaudeSession` usage refresh outcome.
+- Keep last successful snapshot visible if present.
+- Tooltip/status should say the refresh is waiting for the live Claude session rather than "Refresh failed."
+
+### 6. Apply The Same Recovery Logic To System Default
+
+Do not assume failures are managed-account only.
+
+System default can still fail when:
+
+- Keychain access is denied.
+- Claude rotated credentials and Orca has stale cached data.
+- The access token is rejected by the OAuth usage endpoint.
+- Required scope is missing.
+- Network/proxy settings block `api.anthropic.com`.
+
+CodexBar basis:
+
+- OAuth credential loading accounts for cached credentials, Keychain prompt policy, and Keychain access.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:250`
+- Post-delegation retry re-reads credentials instead of reusing the stale token.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:408`
+
+Orca implementation target:
+
+- Use the same internal plan for system default and managed accounts.
+- For system default, allow delegated refresh when safe.
+- Re-read Keychain / `.credentials.json` after any delegated repair.
+
+### 7. Store Attempt Metadata With Usage State
+
+Add metadata to Claude provider state so the renderer can show precise state without parsing raw error strings.
+
+Suggested metadata:
+
+- `source`
+- `attemptedSources`
+- `failureKind`
+- `credentialSource`
+- `authProvenance`
+- `deferredByLiveClaudeSession`
+- `lastSuccessfulSource`
+
+CodexBar basis:
+
+- Source labels are preserved in fetch results for Codex OAuth and CLI.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift:132`
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift:253`
+- Claude planner logs selected source and ordered steps.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:512`
+
+Orca implementation target:
+
+- Extend shared rate-limit types conservatively.
+- Keep renderer copy based on structured state, not regex-only string matching.
+- Continue to include sanitized diagnostics in main-process logs.
+
+### 8. Replace Generic UI Failure For Known States
+
+Known recoverable or deferred states should not render as "Refresh failed."
+
+Suggested user-facing states:
+
+- `Waiting for Claude session`
+- `Refreshing sign-in`
+- `Claude CLI unavailable`
+- `Network issue`
+- `Usage unavailable`
+- `Refresh failed` only for unknown or terminal failures
+
+CodexBar basis:
+
+- Claude OAuth failures distinguish expired/delegated-refresh states from generic parse/network failure.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:338`
+- Codex OAuth refresh errors include specific relogin messages for expired/revoked/reused refresh tokens.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift:17`
+
+Orca implementation target:
+
+- Update status-bar tooltip mapping to prefer structured `failureKind`.
+- Keep the current auth regex fallback only for older/unstructured provider errors.
+
+### 9. Add Debug-Only Source Visibility, Not A Normal Picker
+
+Normal users should see automatic behavior only.
+
+For debugging/support, it is useful to expose what happened:
+
+- attempted OAuth
+- delegated refresh attempted/skipped
+- attempted CLI
+- final source used
+- sanitized failure kind
+
+CodexBar basis:
+
+- CodexBar has explicit source labels and source modes, but the app default remains automatic.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift:35`
+- Claude planner can describe selected and ordered sources.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeSourcePlanner.swift:99`
+
+Orca implementation target:
+
+- Add internal logs and possibly a debug tooltip line.
+- Avoid a normal user-facing setting unless support data later proves it is needed.
+
+### 10. Defer Web/Cookie Source Until After OAuth + CLI Parity
+
+Do not implement Claude web/cookie tracking in the first pass.
+
+CodexBar basis:
+
+- CodexBar supports web as a later fallback source in Claude app auto.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeSourcePlanner.swift:177`
+- CodexBar's web paths are substantial and involve browser session/cookie machinery.
+  Reference: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift:100`
+
+Orca implementation target:
+
+- Put web source behind a future milestone.
+- First match the high-value resilience behavior: OAuth classification, delegated refresh, CLI fallback, deferred live-session state.
+
+## Suggested PR Sequence
+
+### PR 1: Internal Plan + Structured Outcomes
+
+- Add internal Claude usage refresh plan.
+- Add structured source attempt result and failure classification.
+- Preserve existing behavior by executing only the current OAuth path first.
+- Update logs and tests around classification.
+
+CodexBar references:
+
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeSourcePlanner.swift:173`
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:461`
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift:199`
+
+### PR 2: CLI Fallback In Automatic Mode
+
+- Add CLI source attempt using existing PTY parser.
+- Fall back from OAuth to CLI for classified recoverable/auth cases.
+- Preserve last successful snapshot when fallback fails.
+
+CodexBar references:
+
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeSourcePlanner.swift:173`
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:461`
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/UsageFetcher.swift:1012`
+
+### PR 3: Delegated Refresh + Retry
+
+- Add safe delegated Claude CLI refresh for stale OAuth states.
+- Re-read credentials after delegation.
+- Retry OAuth once.
+- Do not run delegated refresh when a live managed Claude session owns the credential rotation.
+
+CodexBar references:
+
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:324`
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:345`
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:369`
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:408`
+
+### PR 4: Renderer State Copy
+
+- Replace generic `Refresh failed` for known Claude states.
+- Prefer structured failure/deferred metadata over error regexes.
+- Keep regex fallback for unstructured errors.
+
+CodexBar references:
+
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:338`
+- `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift:17`
+
+## Test Plan
+
+Add unit tests for:
+
+- OAuth success remains OAuth success.
+- OAuth missing credentials falls back to CLI.
+- OAuth unauthorized attempts delegated refresh when safe.
+- Delegated refresh re-reads credentials and retries OAuth once.
+- Managed live Claude session returns deferred state instead of generic failure.
+- System-default stale credentials use the same repair path.
+- Missing scope produces actionable message.
+- Network failure is classified separately from auth failure.
+- CLI fallback unavailable preserves last known snapshot when present.
+- Renderer maps known states to specific labels.
+
+CodexBar references:
+
+- Source planning: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeSourcePlanner.swift:173`
+- OAuth delegated refresh: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift:324`
+- Fallback discipline: `/Users/jinwoohong/stably/codexbar/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift:199`
+
+## Non-Goals
+
+- Do not add a normal user-facing source picker.
+- Do not add Claude web/cookie tracking in the first implementation pass.
+- Do not weaken managed-account live-session token safety.
+- Do not rely on raw error-message regexes as the primary control flow.

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -372,7 +372,7 @@ describe('fetchClaudeRateLimits', () => {
     expect(fetchViaPty).not.toHaveBeenCalled()
   })
 
-  it('does not mask OAuth auth failures with the PTY fallback', async () => {
+  it('uses CLI fallback for OAuth auth failures when automatic repair is safe', async () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
@@ -403,11 +403,88 @@ describe('fetchClaudeRateLimits', () => {
 
     await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
       provider: 'claude',
-      status: 'error',
-      error: 'Invalid OAuth token.'
+      status: 'ok',
+      session: { usedPercent: 56 },
+      usageMetadata: {
+        source: 'cli',
+        attemptedSources: ['oauth', 'cli']
+      }
     })
 
-    expect(fetchViaPty).not.toHaveBeenCalled()
+    expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
+  })
+
+  it('re-reads credentials and retries OAuth once after CLI repair', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'stale-oauth-token',
+            refreshToken: 'refresh-token',
+            expiresAt: Date.now() - 60_000
+          }
+        })
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'repaired-oauth-token',
+            refreshToken: 'refresh-token-2',
+            expiresAt: Date.now() + 60_000
+          }
+        })
+      )
+    netFetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              type: 'authentication_error',
+              message: 'Invalid OAuth token.'
+            }
+          }),
+          { status: 401 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            five_hour: { utilization: 14 },
+            seven_day: { utilization: 27 }
+          }),
+          { status: 200 }
+        )
+      )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      session: { usedPercent: 14 },
+      weekly: { usedPercent: 27 },
+      usageMetadata: {
+        source: 'oauth',
+        attemptedSources: ['oauth', 'cli'],
+        credentialSource: 'scoped-keychain'
+      }
+    })
+
+    expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
+    expect(netFetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer repaired-oauth-token'
+        })
+      })
+    )
   })
 
   it('explains auth failures when a live Claude terminal owns managed refresh', async () => {
@@ -447,6 +524,31 @@ describe('fetchClaudeRateLimits', () => {
       status: 'error',
       error:
         'Claude usage refresh is waiting for the live Claude terminal to rotate its credentials.'
+    })
+
+    expect(fetchViaPty).not.toHaveBeenCalled()
+  })
+
+  it('does not start CLI fallback when live Claude owns managed refresh and no token is readable', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
+      stripAuthEnv: false,
+      managedRefreshDeferredByLivePty: true,
+      provenance: 'managed:account-1'
+    }
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error:
+        'Claude usage refresh is waiting for the live Claude terminal to rotate its credentials.',
+      usageMetadata: {
+        failureKind: 'deferred-by-live-session',
+        deferredByLiveClaudeSession: true,
+        attemptedSources: []
+      }
     })
 
     expect(fetchViaPty).not.toHaveBeenCalled()
@@ -505,6 +607,47 @@ describe('fetchClaudeRateLimits', () => {
       provider: 'claude',
       status: 'error',
       error: 'Claude OAuth access token unavailable'
+    })
+
+    expect(fetchViaPty).not.toHaveBeenCalled()
+  })
+
+  it('falls back to CLI when OAuth credentials are missing in automatic mode', async () => {
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir: '/Users/test/.claude',
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      session: { usedPercent: 56 },
+      usageMetadata: {
+        source: 'cli',
+        attemptedSources: ['cli'],
+        credentialSource: 'none'
+      }
+    })
+
+    expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
+  })
+
+  it('surfaces Keychain read failures as structured usage metadata when CLI fallback is disabled', async () => {
+    vi.mocked(readActiveClaudeKeychainCredentials).mockRejectedValueOnce(
+      new Error('security timed out after 3000ms')
+    )
+
+    await expect(fetchClaudeRateLimits({ allowPtyFallback: false })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'Claude Keychain credentials unavailable',
+      usageMetadata: {
+        failureKind: 'keychain-unavailable',
+        attemptedSources: [],
+        credentialSource: 'none'
+      }
     })
 
     expect(fetchViaPty).not.toHaveBeenCalled()

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -653,6 +653,31 @@ describe('fetchClaudeRateLimits', () => {
     expect(fetchViaPty).not.toHaveBeenCalled()
   })
 
+  it('uses CLI fallback when Keychain is unavailable in automatic mode', async () => {
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir: '/Users/test/.claude',
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentials).mockRejectedValueOnce(
+      new Error('security timed out after 3000ms')
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      session: { usedPercent: 56 },
+      usageMetadata: {
+        source: 'cli',
+        attemptedSources: ['cli'],
+        credentialSource: 'none'
+      }
+    })
+
+    expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
+  })
+
   it('does not read inactive managed credentials from unowned auth paths', async () => {
     setPlatform('linux')
     tempDir = mkdtempSync(join(tmpdir(), 'orca-claude-fetcher-'))

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -6,7 +6,13 @@ import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { net, session } from 'electron'
-import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+import type {
+  ProviderRateLimits,
+  RateLimitWindow,
+  UsageRateLimitFailureKind,
+  UsageRateLimitMetadata,
+  UsageRateLimitSource
+} from '../../shared/rate-limit-types'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { fetchViaPty } from './claude-pty'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
@@ -28,6 +34,12 @@ import {
 import { createOAuthUsageError, OAuthUsageError } from './claude-oauth-usage-error'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
+import { resolveClaudeUsageRefreshPlan } from './claude-usage-refresh-plan'
+import {
+  classifyClaudeCredentialAbsence,
+  classifyClaudeOAuthUsageError,
+  type ClaudeUsageErrorClassification
+} from './claude-usage-error-classification'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
@@ -69,6 +81,7 @@ type OAuthCredentialReadResult = {
   token: string | null
   hasRefreshableCredentials: boolean
   source: OAuthCredentialSource
+  keychainUnavailable?: boolean
 }
 
 type OAuthCredentialReadOptions = {
@@ -118,6 +131,15 @@ function emptyOAuthCredentialReadResult(): OAuthCredentialReadResult {
   }
 }
 
+function keychainUnavailableOAuthCredentialReadResult(): OAuthCredentialReadResult {
+  return {
+    token: null,
+    hasRefreshableCredentials: false,
+    source: 'none',
+    keychainUnavailable: true
+  }
+}
+
 /**
  * Read OAuth token from macOS Keychain.
  * Why: Claude Code 2.1+ scopes OAuth Keychain services by CLAUDE_CONFIG_DIR;
@@ -140,7 +162,12 @@ async function readFromKeychain(configDir?: string): Promise<OAuthCredentialRead
     if (legacyCredentials.token) {
       return legacyCredentials
     }
-    return scopedCredentials.hasRefreshableCredentials ? scopedCredentials : legacyCredentials
+    if (legacyCredentials.hasRefreshableCredentials) {
+      return legacyCredentials
+    }
+    return scopedCredentials.keychainUnavailable || legacyCredentials.keychainUnavailable
+      ? keychainUnavailableOAuthCredentialReadResult()
+      : legacyCredentials
   }
 
   try {
@@ -149,7 +176,7 @@ async function readFromKeychain(configDir?: string): Promise<OAuthCredentialRead
       ? parseOAuthCredentialsJson(credentials, 'legacy-keychain')
       : emptyOAuthCredentialReadResult()
   } catch {
-    return emptyOAuthCredentialReadResult()
+    return keychainUnavailableOAuthCredentialReadResult()
   }
 }
 
@@ -163,7 +190,7 @@ async function readCredentialsFromStrictKeychain(
       ? parseOAuthCredentialsJson(credentials, source)
       : emptyOAuthCredentialReadResult()
   } catch {
-    return emptyOAuthCredentialReadResult()
+    return keychainUnavailableOAuthCredentialReadResult()
   }
 }
 
@@ -209,6 +236,10 @@ async function readOAuthCredentials(
     return fromFile
   }
 
+  if (fromKeychain.keychainUnavailable) {
+    return fromKeychain
+  }
+
   return emptyOAuthCredentialReadResult()
 }
 
@@ -239,6 +270,7 @@ function buildClaudeUsageFetchDiagnostic(
     wslDistro: authPreparation?.wslDistro ?? null,
     hasExplicitClaudeConfigDir: Boolean(authPreparation?.envPatch.CLAUDE_CONFIG_DIR),
     credentialSource: oauthCredentials.source,
+    keychainUnavailable: oauthCredentials.keychainUnavailable,
     hasRefreshableCredentials: oauthCredentials.hasRefreshableCredentials
   }
 }
@@ -269,6 +301,10 @@ type OAuthUsageWindow = {
 type OAuthUsageResponse = {
   five_hour?: OAuthUsageWindow
   seven_day?: OAuthUsageWindow
+}
+
+type ClaudeUsageAttemptState = {
+  attemptedSources: UsageRateLimitSource[]
 }
 
 function parseResetDescription(isoString: string | undefined): string | null {
@@ -349,6 +385,169 @@ async function fetchViaOAuth(token: string): Promise<ProviderRateLimits> {
   }
 }
 
+function recordAttempt(
+  state: ClaudeUsageAttemptState,
+  source: UsageRateLimitSource
+): UsageRateLimitSource[] {
+  if (!state.attemptedSources.includes(source)) {
+    state.attemptedSources.push(source)
+  }
+  return state.attemptedSources
+}
+
+function withClaudeUsageMetadata(
+  limits: ProviderRateLimits,
+  metadata: UsageRateLimitMetadata
+): ProviderRateLimits {
+  return {
+    ...limits,
+    usageMetadata: {
+      ...limits.usageMetadata,
+      ...metadata,
+      attemptedSources: metadata.attemptedSources ?? limits.usageMetadata?.attemptedSources
+    }
+  }
+}
+
+function makeClaudeUsageResult(
+  status: ProviderRateLimits['status'],
+  error: string | null,
+  metadata: UsageRateLimitMetadata
+): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error,
+    status,
+    usageMetadata: metadata
+  }
+}
+
+function metadataForAttempt(input: {
+  attemptedSources: UsageRateLimitSource[]
+  oauthCredentials: OAuthCredentialReadResult
+  authPreparation?: ClaudeRuntimeAuthPreparation
+  source?: UsageRateLimitSource
+  failureKind?: UsageRateLimitFailureKind
+  deferredByLiveClaudeSession?: boolean
+}): UsageRateLimitMetadata {
+  return {
+    source: input.source,
+    attemptedSources: [...input.attemptedSources],
+    failureKind: input.failureKind,
+    credentialSource: input.oauthCredentials.source,
+    authProvenance: input.authPreparation?.provenance ?? 'system',
+    deferredByLiveClaudeSession: input.deferredByLiveClaudeSession
+  }
+}
+
+async function fetchClaudeUsageViaCli(input: {
+  authPreparation?: ClaudeRuntimeAuthPreparation
+  oauthCredentials: OAuthCredentialReadResult
+  attempts: ClaudeUsageAttemptState
+}): Promise<ProviderRateLimits> {
+  recordAttempt(input.attempts, 'cli')
+  const limits = await fetchViaPty({ authPreparation: input.authPreparation })
+  return withClaudeUsageMetadata(
+    limits,
+    metadataForAttempt({
+      attemptedSources: input.attempts.attemptedSources,
+      oauthCredentials: input.oauthCredentials,
+      authPreparation: input.authPreparation,
+      source: 'cli'
+    })
+  )
+}
+
+function shouldDeferForLiveClaude(
+  authPreparation: ClaudeRuntimeAuthPreparation | undefined,
+  classification: ClaudeUsageErrorClassification
+): boolean {
+  return Boolean(
+    authPreparation?.managedRefreshDeferredByLivePty &&
+    (classification.failureKind === 'stale-token' ||
+      classification.failureKind === 'refreshable-credentials-without-token' ||
+      classification.failureKind === 'deferred-by-live-session')
+  )
+}
+
+function liveClaudeDeferredResult(input: {
+  attempts: ClaudeUsageAttemptState
+  oauthCredentials: OAuthCredentialReadResult
+  authPreparation?: ClaudeRuntimeAuthPreparation
+}): ProviderRateLimits {
+  return makeClaudeUsageResult('error', LIVE_CLAUDE_REFRESH_DEFERRED_MESSAGE, {
+    ...metadataForAttempt({
+      attemptedSources: input.attempts.attemptedSources,
+      oauthCredentials: input.oauthCredentials,
+      authPreparation: input.authPreparation,
+      failureKind: 'deferred-by-live-session',
+      deferredByLiveClaudeSession: true
+    })
+  })
+}
+
+function errorResultForClassification(input: {
+  error: unknown
+  classification: ClaudeUsageErrorClassification
+  attempts: ClaudeUsageAttemptState
+  oauthCredentials: OAuthCredentialReadResult
+  authPreparation?: ClaudeRuntimeAuthPreparation
+}): ProviderRateLimits {
+  const message =
+    input.error instanceof Error ? input.error.message : String(input.error || 'Unknown error')
+  return makeClaudeUsageResult('error', withMacTailscaleDnsHint(message), {
+    ...metadataForAttempt({
+      attemptedSources: input.attempts.attemptedSources,
+      oauthCredentials: input.oauthCredentials,
+      authPreparation: input.authPreparation,
+      failureKind: input.classification.failureKind
+    })
+  })
+}
+
+async function attemptCliRepairThenRetryOAuth(input: {
+  options?: FetchClaudeRateLimitsOptions
+  attempts: ClaudeUsageAttemptState
+  oauthCredentials: OAuthCredentialReadResult
+}): Promise<ProviderRateLimits | null> {
+  let cliResult: ProviderRateLimits | null = null
+  try {
+    cliResult = await fetchClaudeUsageViaCli({
+      authPreparation: input.options?.authPreparation,
+      oauthCredentials: input.oauthCredentials,
+      attempts: input.attempts
+    })
+  } catch (err) {
+    warnClaudeUsageFetchFailure(input.options?.authPreparation, input.oauthCredentials, err)
+  }
+
+  const refreshedCredentials = await readOAuthCredentials(
+    resolveOAuthCredentialReadOptions(input.options?.authPreparation)
+  )
+  if (refreshedCredentials.token) {
+    recordAttempt(input.attempts, 'oauth')
+    try {
+      const oauthRetry = await fetchViaOAuth(refreshedCredentials.token)
+      return withClaudeUsageMetadata(
+        oauthRetry,
+        metadataForAttempt({
+          attemptedSources: input.attempts.attemptedSources,
+          oauthCredentials: refreshedCredentials,
+          authPreparation: input.options?.authPreparation,
+          source: 'oauth'
+        })
+      )
+    } catch (err) {
+      warnClaudeUsageFetchFailure(input.options?.authPreparation, refreshedCredentials, err)
+    }
+  }
+
+  return cliResult
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -361,103 +560,189 @@ export type FetchClaudeRateLimitsOptions = {
 export async function fetchClaudeRateLimits(
   options?: FetchClaudeRateLimitsOptions
 ): Promise<ProviderRateLimits> {
+  const attempts: ClaudeUsageAttemptState = { attemptedSources: [] }
+  const allowCliFallback = options?.allowPtyFallback !== false
+  const plan = resolveClaudeUsageRefreshPlan({
+    authPreparation: options?.authPreparation,
+    allowCliFallback
+  })
+
   if (options?.authPreparation?.runtime === 'wsl' && !options.authPreparation.wslLinuxConfigDir) {
-    return {
-      provider: 'claude',
-      session: null,
-      weekly: null,
-      updatedAt: Date.now(),
-      error: `WSL Claude config unavailable for ${options.authPreparation.wslDistro ?? 'default distro'}`,
-      status: 'error'
-    }
+    return makeClaudeUsageResult(
+      'error',
+      `WSL Claude config unavailable for ${options.authPreparation.wslDistro ?? 'default distro'}`,
+      {
+        attemptedSources: [],
+        failureKind: 'cli-unavailable',
+        authProvenance: options.authPreparation.provenance
+      }
+    )
   }
 
-  // Path A: try OAuth API if we have a genuine OAuth token
   const oauthCredentials = await readOAuthCredentials(
     resolveOAuthCredentialReadOptions(options?.authPreparation)
   )
-  if (oauthCredentials.token) {
+
+  if (plan.steps.some((step) => step.source === 'oauth') && oauthCredentials.token) {
+    recordAttempt(attempts, 'oauth')
     try {
-      return await fetchViaOAuth(oauthCredentials.token)
+      const limits = await fetchViaOAuth(oauthCredentials.token)
+      return withClaudeUsageMetadata(
+        limits,
+        metadataForAttempt({
+          attemptedSources: attempts.attemptedSources,
+          oauthCredentials,
+          authPreparation: options?.authPreparation,
+          source: 'oauth'
+        })
+      )
     } catch (err) {
       warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, err)
-      if (
-        options?.authPreparation?.managedRefreshDeferredByLivePty &&
-        err instanceof OAuthUsageError &&
-        (err.status === 401 || err.status === 403)
-      ) {
-        return {
-          provider: 'claude',
-          session: null,
-          weekly: null,
-          updatedAt: Date.now(),
-          error: LIVE_CLAUDE_REFRESH_DEFERRED_MESSAGE,
-          status: 'error'
+      const classification = classifyClaudeOAuthUsageError(err)
+
+      if (shouldDeferForLiveClaude(options?.authPreparation, classification)) {
+        return liveClaudeDeferredResult({
+          attempts,
+          oauthCredentials,
+          authPreparation: options?.authPreparation
+        })
+      }
+
+      if (classification.shouldAttemptDelegatedRefresh && allowCliFallback) {
+        const repaired = await attemptCliRepairThenRetryOAuth({
+          options,
+          attempts,
+          oauthCredentials
+        })
+        if (repaired) {
+          return repaired
         }
       }
-      if (
-        options?.allowPtyFallback === false ||
-        (err instanceof OAuthUsageError && err.skipPtyFallback)
-      ) {
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        return {
-          provider: 'claude',
-          session: null,
-          weekly: null,
-          updatedAt: Date.now(),
-          error: withMacTailscaleDnsHint(message),
-          status: 'error'
+
+      if (classification.shouldAttemptCliFallback && allowCliFallback) {
+        try {
+          return await fetchClaudeUsageViaCli({
+            authPreparation: options?.authPreparation,
+            oauthCredentials,
+            attempts
+          })
+        } catch (ptyError) {
+          warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, ptyError)
         }
       }
-      // OAuth API failed — fall through to PTY scraping as a backup
-      // for subscription users whose token may still be valid for the CLI.
+
+      return errorResultForClassification({
+        error: err,
+        classification,
+        attempts,
+        oauthCredentials,
+        authPreparation: options?.authPreparation
+      })
     }
   }
 
-  // Path B: PTY fallback — only for subscription plan users (Max/Pro)
-  // whose OAuth credentials exist. This remains a fallback for older Claude
-  // auth shapes and transient OAuth failures.
-  if (oauthCredentials.token || oauthCredentials.hasRefreshableCredentials) {
-    if (options?.allowPtyFallback === false) {
-      return {
-        provider: 'claude',
-        session: null,
-        weekly: null,
-        updatedAt: Date.now(),
-        error: options?.authPreparation?.managedRefreshDeferredByLivePty
-          ? LIVE_CLAUDE_REFRESH_DEFERRED_MESSAGE
-          : 'Claude OAuth access token unavailable',
-        status: 'error'
-      }
-    }
-    try {
-      return await fetchViaPty({ authPreparation: options?.authPreparation })
-    } catch (err) {
-      warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, err)
-      const message = err instanceof Error ? err.message : 'Unknown error'
-      return {
-        provider: 'claude',
-        session: null,
-        weekly: null,
-        updatedAt: Date.now(),
-        error: withMacTailscaleDnsHint(message),
-        status: 'error'
-      }
+  const credentialClassification = classifyClaudeCredentialAbsence({
+    hasRefreshableCredentials: oauthCredentials.hasRefreshableCredentials,
+    keychainUnavailable: oauthCredentials.keychainUnavailable,
+    managedRefreshDeferredByLivePty: options?.authPreparation?.managedRefreshDeferredByLivePty
+  })
+
+  if (shouldDeferForLiveClaude(options?.authPreparation, credentialClassification)) {
+    return liveClaudeDeferredResult({
+      attempts,
+      oauthCredentials,
+      authPreparation: options?.authPreparation
+    })
+  }
+
+  if (
+    oauthCredentials.hasRefreshableCredentials &&
+    credentialClassification.shouldAttemptDelegatedRefresh &&
+    allowCliFallback
+  ) {
+    const repaired = await attemptCliRepairThenRetryOAuth({
+      options,
+      attempts,
+      oauthCredentials
+    })
+    if (repaired) {
+      return repaired
     }
   }
 
-  // No OAuth token found — user authenticates via API key.
-  // Why: plan usage limits (session/weekly) only exist for Claude Max/Pro
-  // subscription plans. API key users are billed per-token and don't have
-  // rate limit windows to display.
-  return {
-    provider: 'claude',
-    session: null,
-    weekly: null,
-    updatedAt: Date.now(),
-    error: 'No subscription plan — API key billing',
-    status: 'unavailable'
+  if (
+    (oauthCredentials.token || oauthCredentials.hasRefreshableCredentials) &&
+    credentialClassification.shouldAttemptCliFallback &&
+    allowCliFallback
+  ) {
+    try {
+      return await fetchClaudeUsageViaCli({
+        authPreparation: options?.authPreparation,
+        oauthCredentials,
+        attempts
+      })
+    } catch (err) {
+      warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, err)
+      return makeClaudeUsageResult('error', withMacTailscaleDnsHint(describeError(err)), {
+        ...metadataForAttempt({
+          attemptedSources: attempts.attemptedSources,
+          oauthCredentials,
+          authPreparation: options?.authPreparation,
+          failureKind:
+            credentialClassification.failureKind === 'keychain-unavailable'
+              ? 'keychain-unavailable'
+              : 'cli-unavailable'
+        })
+      })
+    }
   }
+
+  if (oauthCredentials.keychainUnavailable) {
+    return makeClaudeUsageResult('error', 'Claude Keychain credentials unavailable', {
+      ...metadataForAttempt({
+        attemptedSources: attempts.attemptedSources,
+        oauthCredentials,
+        authPreparation: options?.authPreparation,
+        failureKind: 'keychain-unavailable'
+      })
+    })
+  }
+
+  if (oauthCredentials.hasRefreshableCredentials) {
+    return makeClaudeUsageResult('error', 'Claude OAuth access token unavailable', {
+      ...metadataForAttempt({
+        attemptedSources: attempts.attemptedSources,
+        oauthCredentials,
+        authPreparation: options?.authPreparation,
+        failureKind: credentialClassification.failureKind
+      })
+    })
+  }
+
+  if (allowCliFallback && plan.steps.some((step) => step.source === 'cli')) {
+    try {
+      return await fetchClaudeUsageViaCli({
+        authPreparation: options?.authPreparation,
+        oauthCredentials,
+        attempts
+      })
+    } catch (err) {
+      warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, err)
+    }
+  }
+
+  return makeClaudeUsageResult('unavailable', 'No subscription plan — API key billing', {
+    ...metadataForAttempt({
+      attemptedSources: attempts.attemptedSources,
+      oauthCredentials,
+      authPreparation: options?.authPreparation,
+      failureKind: 'missing-credentials'
+    })
+  })
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error'
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -671,7 +671,9 @@ export async function fetchClaudeRateLimits(
   }
 
   if (
-    (oauthCredentials.token || oauthCredentials.hasRefreshableCredentials) &&
+    (oauthCredentials.token ||
+      oauthCredentials.hasRefreshableCredentials ||
+      oauthCredentials.keychainUnavailable) &&
     credentialClassification.shouldAttemptCliFallback &&
     allowCliFallback
   ) {

--- a/src/main/rate-limits/claude-usage-error-classification.test.ts
+++ b/src/main/rate-limits/claude-usage-error-classification.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyClaudeCredentialAbsence,
+  classifyClaudeOAuthUsageError
+} from './claude-usage-error-classification'
+import { OAuthUsageError } from './claude-oauth-usage-error'
+
+describe('classifyClaudeOAuthUsageError', () => {
+  it('treats OAuth unauthorized as stale-token repair/fallback', () => {
+    expect(
+      classifyClaudeOAuthUsageError(new OAuthUsageError('Invalid OAuth token', 401, true))
+    ).toMatchObject({
+      failureKind: 'stale-token',
+      shouldAttemptDelegatedRefresh: true,
+      shouldAttemptCliFallback: true,
+      terminal: false
+    })
+  })
+
+  it('keeps usage rate limits terminal', () => {
+    expect(
+      classifyClaudeOAuthUsageError(new OAuthUsageError('Claude usage is rate limited', 429, true))
+    ).toMatchObject({
+      failureKind: 'rate-limited',
+      shouldAttemptDelegatedRefresh: false,
+      shouldAttemptCliFallback: false,
+      terminal: true
+    })
+  })
+
+  it('classifies missing OAuth scope as actionable terminal state', () => {
+    expect(
+      classifyClaudeOAuthUsageError(
+        new OAuthUsageError("missing required scope 'user:profile'", 403, true)
+      )
+    ).toMatchObject({
+      failureKind: 'missing-scope',
+      terminal: true
+    })
+  })
+
+  it('allows CLI fallback for network-shaped failures', () => {
+    expect(classifyClaudeOAuthUsageError(new Error('fetch failed: ENOTFOUND'))).toMatchObject({
+      failureKind: 'network',
+      shouldAttemptCliFallback: true,
+      shouldAttemptDelegatedRefresh: false
+    })
+  })
+})
+
+describe('classifyClaudeCredentialAbsence', () => {
+  it('classifies refresh-only credentials as repairable', () => {
+    expect(classifyClaudeCredentialAbsence({ hasRefreshableCredentials: true })).toMatchObject({
+      failureKind: 'refreshable-credentials-without-token',
+      shouldAttemptDelegatedRefresh: true,
+      shouldAttemptCliFallback: true
+    })
+  })
+
+  it('classifies Keychain read failures separately from missing credentials', () => {
+    expect(
+      classifyClaudeCredentialAbsence({
+        hasRefreshableCredentials: false,
+        keychainUnavailable: true
+      })
+    ).toMatchObject({
+      failureKind: 'keychain-unavailable',
+      shouldAttemptCliFallback: true,
+      shouldAttemptDelegatedRefresh: false
+    })
+  })
+
+  it('classifies live Claude ownership as a deferred state', () => {
+    expect(
+      classifyClaudeCredentialAbsence({
+        hasRefreshableCredentials: true,
+        managedRefreshDeferredByLivePty: true
+      })
+    ).toMatchObject({
+      failureKind: 'deferred-by-live-session',
+      terminal: true
+    })
+  })
+})

--- a/src/main/rate-limits/claude-usage-error-classification.ts
+++ b/src/main/rate-limits/claude-usage-error-classification.ts
@@ -1,0 +1,84 @@
+import type { UsageRateLimitFailureKind } from '../../shared/rate-limit-types'
+import { OAuthUsageError } from './claude-oauth-usage-error'
+
+export type ClaudeUsageErrorClassification = {
+  failureKind: UsageRateLimitFailureKind
+  shouldAttemptCliFallback: boolean
+  shouldAttemptDelegatedRefresh: boolean
+  terminal: boolean
+}
+
+export function classifyClaudeOAuthUsageError(error: unknown): ClaudeUsageErrorClassification {
+  if (error instanceof OAuthUsageError) {
+    if (error.status === 429) {
+      return terminal('rate-limited')
+    }
+    if (error.status === 401) {
+      return recoverableAuth('stale-token')
+    }
+    if (error.status === 403) {
+      return error.message.includes('user:profile')
+        ? terminal('missing-scope')
+        : recoverableAuth('stale-token')
+    }
+    if (error.status >= 500) {
+      return fallbackOnly('server')
+    }
+    return terminal('usage-unavailable')
+  }
+
+  if (error instanceof SyntaxError) {
+    return fallbackOnly('parse')
+  }
+
+  const message = error instanceof Error ? error.message : String(error)
+  if (/\babort|network|econn|enotfound|etimedout|fetch failed|dns\b/i.test(message)) {
+    return fallbackOnly('network')
+  }
+
+  return fallbackOnly('unknown')
+}
+
+export function classifyClaudeCredentialAbsence(input: {
+  hasRefreshableCredentials: boolean
+  keychainUnavailable?: boolean
+  managedRefreshDeferredByLivePty?: boolean
+}): ClaudeUsageErrorClassification {
+  if (input.managedRefreshDeferredByLivePty) {
+    return terminal('deferred-by-live-session')
+  }
+  if (input.keychainUnavailable) {
+    return fallbackOnly('keychain-unavailable')
+  }
+  if (input.hasRefreshableCredentials) {
+    return recoverableAuth('refreshable-credentials-without-token')
+  }
+  return terminal('missing-credentials')
+}
+
+function recoverableAuth(failureKind: UsageRateLimitFailureKind): ClaudeUsageErrorClassification {
+  return {
+    failureKind,
+    shouldAttemptCliFallback: true,
+    shouldAttemptDelegatedRefresh: true,
+    terminal: false
+  }
+}
+
+function fallbackOnly(failureKind: UsageRateLimitFailureKind): ClaudeUsageErrorClassification {
+  return {
+    failureKind,
+    shouldAttemptCliFallback: true,
+    shouldAttemptDelegatedRefresh: false,
+    terminal: false
+  }
+}
+
+function terminal(failureKind: UsageRateLimitFailureKind): ClaudeUsageErrorClassification {
+  return {
+    failureKind,
+    shouldAttemptCliFallback: false,
+    shouldAttemptDelegatedRefresh: false,
+    terminal: true
+  }
+}

--- a/src/main/rate-limits/claude-usage-refresh-plan.test.ts
+++ b/src/main/rate-limits/claude-usage-refresh-plan.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { resolveClaudeUsageRefreshPlan } from './claude-usage-refresh-plan'
 
 describe('resolveClaudeUsageRefreshPlan', () => {
-  it('uses CodexBar-style app auto ordering when CLI fallback is available', () => {
+  it('uses OAuth then CLI app auto ordering when CLI fallback is available', () => {
     expect(resolveClaudeUsageRefreshPlan({ allowCliFallback: true }).steps).toEqual([
       { source: 'oauth', reason: 'app-auto-preferred-oauth' },
       { source: 'cli', reason: 'app-auto-fallback-cli' }

--- a/src/main/rate-limits/claude-usage-refresh-plan.test.ts
+++ b/src/main/rate-limits/claude-usage-refresh-plan.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { resolveClaudeUsageRefreshPlan } from './claude-usage-refresh-plan'
+
+describe('resolveClaudeUsageRefreshPlan', () => {
+  it('uses CodexBar-style app auto ordering when CLI fallback is available', () => {
+    expect(resolveClaudeUsageRefreshPlan({ allowCliFallback: true }).steps).toEqual([
+      { source: 'oauth', reason: 'app-auto-preferred-oauth' },
+      { source: 'cli', reason: 'app-auto-fallback-cli' }
+    ])
+  })
+
+  it('keeps web deferred and internal-only for the first parity pass', () => {
+    expect(resolveClaudeUsageRefreshPlan({ allowCliFallback: true }).webDeferred).toBe(true)
+  })
+
+  it('omits CLI fallback for unresolved WSL Claude config', () => {
+    expect(
+      resolveClaudeUsageRefreshPlan({
+        allowCliFallback: true,
+        authPreparation: {
+          configDir: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.claude',
+          runtime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxConfigDir: null,
+          envPatch: {},
+          stripAuthEnv: true,
+          provenance: 'wsl:Ubuntu:system'
+        }
+      }).steps
+    ).toEqual([{ source: 'oauth', reason: 'app-auto-preferred-oauth' }])
+  })
+})

--- a/src/main/rate-limits/claude-usage-refresh-plan.ts
+++ b/src/main/rate-limits/claude-usage-refresh-plan.ts
@@ -1,0 +1,47 @@
+import type { UsageRateLimitSource } from '../../shared/rate-limit-types'
+import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
+
+export type ClaudeUsageRefreshStep = {
+  source: UsageRateLimitSource
+  reason: 'app-auto-preferred-oauth' | 'app-auto-fallback-cli' | 'future-web-fallback-deferred'
+}
+
+export type ClaudeUsageRefreshPlanInput = {
+  authPreparation?: ClaudeRuntimeAuthPreparation
+  allowCliFallback: boolean
+}
+
+export type ClaudeUsageRefreshPlan = {
+  steps: ClaudeUsageRefreshStep[]
+  webDeferred: boolean
+}
+
+export function resolveClaudeUsageRefreshPlan(
+  input: ClaudeUsageRefreshPlanInput
+): ClaudeUsageRefreshPlan {
+  const steps: ClaudeUsageRefreshStep[] = [
+    {
+      source: 'oauth',
+      reason: 'app-auto-preferred-oauth'
+    }
+  ]
+
+  if (input.allowCliFallback && isCliPlausiblyAvailable(input.authPreparation)) {
+    steps.push({
+      source: 'cli',
+      reason: 'app-auto-fallback-cli'
+    })
+  }
+
+  return {
+    steps,
+    webDeferred: true
+  }
+}
+
+function isCliPlausiblyAvailable(authPreparation?: ClaudeRuntimeAuthPreparation): boolean {
+  if (authPreparation?.runtime === 'wsl') {
+    return Boolean(authPreparation.wslDistro && authPreparation.wslLinuxConfigDir)
+  }
+  return true
+}

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -353,7 +353,7 @@ describe('RateLimitService', () => {
     expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchClaudeRateLimits).toHaveBeenCalledWith({
       authPreparation: undefined,
-      allowPtyFallback: false
+      allowPtyFallback: true
     })
     expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchGeminiRateLimits).toHaveBeenCalledTimes(1)
@@ -459,7 +459,7 @@ describe('RateLimitService', () => {
         wslLinuxConfigDir: '/home/jin/.claude',
         stripAuthEnv: true
       }),
-      allowPtyFallback: false
+      allowPtyFallback: true
     })
     expect(service.getState().claudeTarget).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
   })
@@ -519,7 +519,7 @@ describe('RateLimitService', () => {
     })
 
     expect(fetchClaudeRateLimits).toHaveBeenLastCalledWith(
-      expect.objectContaining({ allowPtyFallback: false })
+      expect.objectContaining({ allowPtyFallback: true })
     )
 
     expect(service.getState().inactiveClaudeAccounts).not.toEqual(

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -793,8 +793,8 @@ export class RateLimitService {
   }
 
   private shouldAllowClaudePtyFallback(): boolean {
-    // Why: CodexBar-style auto recovery uses Claude CLI as the next source,
-    // but Windows hidden PTY support remains less reliable than host/WSL shells.
+    // Why: automatic recovery uses Claude CLI as the next source, but Windows
+    // hidden PTY support remains less reliable than host/WSL shells.
     return process.platform !== 'win32'
   }
 

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -792,6 +792,12 @@ export class RateLimitService {
     return process.platform !== 'win32'
   }
 
+  private shouldAllowClaudePtyFallback(): boolean {
+    // Why: CodexBar-style auto recovery uses Claude CLI as the next source,
+    // but Windows hidden PTY support remains less reliable than host/WSL shells.
+    return process.platform !== 'win32'
+  }
+
   private withFetchingStatus(
     current: ProviderRateLimits | null,
     provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi'
@@ -855,9 +861,7 @@ export class RateLimitService {
       await Promise.allSettled([
         fetchClaudeRateLimits({
           authPreparation: claudeAuthPreparation,
-          // Why: active quota refreshes run on startup/focus/timers. They must
-          // never spawn hidden Claude Code, which can trigger macOS App Data TCC.
-          allowPtyFallback: false
+          allowPtyFallback: this.shouldAllowClaudePtyFallback()
         }),
         missingWslCodexHome ??
           fetchCodexRateLimits({
@@ -1032,9 +1036,7 @@ export class RateLimitService {
 
     const claude = await fetchClaudeRateLimits({
       authPreparation: claudeAuthPreparation,
-      // Why: account-change refreshes share the same automatic active quota
-      // surface as startup/timer refreshes, so keep them API-only as well.
-      allowPtyFallback: false
+      allowPtyFallback: this.shouldAllowClaudePtyFallback()
     }).catch(
       (err): ProviderRateLimits => ({
         provider: 'claude',
@@ -1069,7 +1071,14 @@ export class RateLimitService {
   ): ProviderRateLimits {
     // Fresh data is fine — use it
     if (fresh.status === 'ok') {
-      return fresh
+      return {
+        ...fresh,
+        usageMetadata: {
+          ...fresh.usageMetadata,
+          lastSuccessfulSource:
+            fresh.usageMetadata?.source ?? fresh.usageMetadata?.lastSuccessfulSource
+        }
+      }
     }
 
     // Explicitly unavailable — user likely cleared a setting. Discard any stale
@@ -1103,7 +1112,13 @@ export class RateLimitService {
     return {
       ...previous,
       error: fresh.error,
-      status: 'error'
+      status: 'error',
+      usageMetadata: {
+        ...previous.usageMetadata,
+        ...fresh.usageMetadata,
+        lastSuccessfulSource:
+          previous.usageMetadata?.lastSuccessfulSource ?? previous.usageMetadata?.source
+      }
     }
   }
 

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -840,7 +840,9 @@ describe('updater', () => {
   })
 
   it('runs a fresh prerelease check when Shift-click promotes an in-flight stable check', async () => {
+    vi.useFakeTimers()
     let resolveStableTags: (value: { tags: string[]; state: 'no-newer' }) => void = () => {}
+    let resolveStableCheck: () => void = () => {}
     fetchNewerReleaseTagsMock
       .mockImplementationOnce(
         () =>
@@ -849,7 +851,14 @@ describe('updater', () => {
           })
       )
       .mockResolvedValueOnce({ tags: ['v1.4.36-rc.5'], state: 'ready' })
-    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    autoUpdaterMock.checkForUpdates
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStableCheck = resolve
+          })
+      )
+      .mockResolvedValueOnce(undefined)
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
 
@@ -870,7 +879,10 @@ describe('updater', () => {
       expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
     })
 
+    autoUpdaterMock.emit('checking-for-update')
     autoUpdaterMock.emit('update-not-available')
+    await vi.advanceTimersByTimeAsync(0)
+    resolveStableCheck()
 
     await vi.waitFor(() => {
       expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.35', 2, {

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -1,5 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+
+vi.mock('@/lib/agent-catalog', () => ({
+  AgentIcon: () => null
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, values?: Record<string, string>) => {
+    let result = fallback
+    for (const [key, value] of Object.entries(values ?? {})) {
+      result = result.replace(`{{${key}}}`, value)
+    }
+    return result
+  }
+}))
+
 import {
   formatResetCreditExpiry,
   formatResetCountdown,
@@ -148,12 +163,54 @@ describe('provider usage error copy', () => {
   it('keeps live-Claude refresh deferral copy visible', () => {
     const p = provider({
       error:
-        'Claude usage refresh is waiting for the live Claude terminal to rotate its credentials.'
+        'Claude usage refresh is waiting for the live Claude terminal to rotate its credentials.',
+      usageMetadata: {
+        failureKind: 'deferred-by-live-session',
+        deferredByLiveClaudeSession: true
+      }
     })
 
+    expect(getProviderUsageStatusLabel(p)).toBe('Waiting for Claude session')
     expect(getProviderUsageErrorMessage(p)).toBe(
-      'Claude usage refresh is waiting for the live Claude terminal to rotate its credentials.'
+      'Claude usage will refresh after the live Claude terminal rotates its credentials.'
     )
+  })
+
+  it('uses structured Claude failure kinds before raw auth regexes', () => {
+    const p = provider({
+      error: 'Invalid OAuth token.',
+      usageMetadata: {
+        failureKind: 'stale-token',
+        attemptedSources: ['oauth', 'cli']
+      }
+    })
+
+    expect(getProviderUsageStatusLabel(p)).toBe('Refreshing sign-in')
+    expect(getProviderUsageErrorMessage(p)).toBe(
+      'Claude sign-in is being refreshed. Agent sessions may still be signed in.'
+    )
+  })
+
+  it('uses structured network copy for Claude usage failures', () => {
+    const p = provider({
+      error: 'Network error while refreshing OAuth usage: ECONNRESET',
+      usageMetadata: { failureKind: 'network' }
+    })
+
+    expect(getProviderUsageStatusLabel(p)).toBe('Network issue')
+    expect(getProviderUsageErrorMessage(p)).toBe(
+      'Claude usage could not be refreshed because the network request failed.'
+    )
+  })
+
+  it('uses structured Keychain copy for Claude usage failures', () => {
+    const p = provider({
+      error: 'Claude Keychain credentials unavailable',
+      usageMetadata: { failureKind: 'keychain-unavailable' }
+    })
+
+    expect(getProviderUsageStatusLabel(p)).toBe('Sign-in unavailable')
+    expect(getProviderUsageErrorMessage(p)).toBe('Claude sign-in credentials could not be read.')
   })
 })
 

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -2,6 +2,17 @@ import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rat
 import { AgentIcon } from '@/lib/agent-catalog'
 import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { translate } from '@/i18n/i18n'
+import {
+  getProviderDisplayName,
+  getProviderUsageErrorMessage,
+  getProviderUsageStatusLabel
+} from './usage-error-copy'
+
+export {
+  getProviderDisplayName,
+  getProviderUsageErrorMessage,
+  getProviderUsageStatusLabel
+} from './usage-error-copy'
 
 // ---------------------------------------------------------------------------
 // Formatting helpers
@@ -85,82 +96,6 @@ export function ProviderIcon({ provider }: { provider: string }): React.JSX.Elem
   return <ClaudeIcon size={13} />
 }
 
-export function getProviderDisplayName(provider: ProviderRateLimits['provider']): string {
-  if (provider === 'claude') {
-    return 'Claude'
-  }
-  if (provider === 'codex') {
-    return 'Codex'
-  }
-  if (provider === 'gemini') {
-    return 'Gemini'
-  }
-  if (provider === 'opencode-go') {
-    return 'OpenCode Go'
-  }
-  if (provider === 'kimi') {
-    return 'Kimi'
-  }
-  return provider
-}
-
-function isUsageRateLimitError(message: string | null): boolean {
-  return Boolean(message && /\brate[- ]?limits?\b|\brate[- ]?limited\b/i.test(message))
-}
-
-const USAGE_AUTH_ERROR_PATTERNS = [
-  // Why: "OAuth" can be an upstream route label; only credential/session wording
-  // should hide raw details behind the softer usage-refresh copy.
-  /\binvalid (?:authentication )?credentials?\b/i,
-  /\b(?:no|missing|invalid|expired|stale|unavailable) (?:oauth )?(?:access token|refresh token|token|credentials?|auth(?:entication)? session|auth cookie)\b/i,
-  /\b(?:access token|refresh token|token|credentials?|auth(?:entication)? session|auth cookie) (?:is |are |was |were |could not be |cannot be |can't be )?(?:missing|unavailable|invalid|expired|stale|used|refreshed|loaded|found)\b/i,
-  /\bcredentials?[ -]file (?:is |was )?(?:missing|unavailable|invalid|expired|stale)\b/i,
-  /\b(?:access token|refresh token|token|credentials?|auth(?:entication)? session|auth cookie) not (?:found|available)\b/i,
-  /\b(?:token data|tokens?) (?:is |are )?not available\b/i,
-  /\bauth (?:is missing|tokens are missing|does not expose)\b/i,
-  /\bunauthori[sz]ed\b/i,
-  /\bunauthenticated\b/i,
-  /\bplease reauthenticate\b/i,
-  /\bsign in\b/i,
-  /\blogged in to another account\b/i,
-  /\bnot logged in\b/i,
-  /\blog[ -]?in\b/i,
-  /\blog(?:ged)? out\b/i
-]
-
-function isUsageAuthError(message: string | null): boolean {
-  return Boolean(message && USAGE_AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(message)))
-}
-
-export function getProviderUsageStatusLabel(p: ProviderRateLimits): string {
-  if (isUsageRateLimitError(p.error)) {
-    return translate('auto.components.status.bar.tooltip.7ad719c4bf', 'Limited')
-  }
-  return translate('auto.components.status.bar.tooltip.e740f92596', 'Refresh failed')
-}
-
-export function getProviderUsageErrorMessage(p: ProviderRateLimits): string {
-  const fallback = translate(
-    'auto.components.status.bar.tooltip.2c35eca8d4',
-    'Unable to fetch usage'
-  )
-  if (!p.error) {
-    return fallback
-  }
-  if (isUsageRateLimitError(p.error)) {
-    return p.error
-  }
-  if (isUsageAuthError(p.error)) {
-    const name = getProviderDisplayName(p.provider)
-    return translate(
-      'auto.components.status.bar.tooltip.8418ec448d',
-      '{{value0}} usage could not be refreshed. Agent sessions may still be signed in.',
-      { value0: name }
-    )
-  }
-  return p.error
-}
-
 function ErrorMessage({
   message,
   label,
@@ -175,17 +110,22 @@ function ErrorMessage({
 }): React.JSX.Element {
   const labelClass = inverted ? 'text-background/80' : 'text-foreground/85'
   const detailClass = inverted ? 'text-background/55' : 'text-muted-foreground'
+  const genericRefreshLabel = translate(
+    'auto.components.status.bar.tooltip.e740f92596',
+    'Refresh failed'
+  )
+  const staleRefreshLabel = translate(
+    'auto.components.status.bar.tooltip.a9a318b7a3',
+    'Refresh failed — showing cached data'
+  )
+  const resolvedLabel =
+    stale && (!label || label === genericRefreshLabel)
+      ? staleRefreshLabel
+      : (label ?? genericRefreshLabel)
 
   return (
     <div className="space-y-0.5">
-      <div className={`text-[11px] font-medium ${labelClass}`}>
-        {stale
-          ? translate(
-              'auto.components.status.bar.tooltip.a9a318b7a3',
-              'Refresh failed — showing cached data'
-            )
-          : (label ?? translate('auto.components.status.bar.tooltip.e740f92596', 'Refresh failed'))}
-      </div>
+      <div className={`text-[11px] font-medium ${labelClass}`}>{resolvedLabel}</div>
       <div className={detailClass}>{message}</div>
     </div>
   )

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -1,0 +1,138 @@
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import { translate } from '@/i18n/i18n'
+
+export function getProviderDisplayName(provider: ProviderRateLimits['provider']): string {
+  if (provider === 'claude') {
+    return 'Claude'
+  }
+  if (provider === 'codex') {
+    return 'Codex'
+  }
+  if (provider === 'gemini') {
+    return 'Gemini'
+  }
+  if (provider === 'opencode-go') {
+    return 'OpenCode Go'
+  }
+  if (provider === 'kimi') {
+    return 'Kimi'
+  }
+  return provider
+}
+
+function isUsageRateLimitError(message: string | null): boolean {
+  return Boolean(message && /\brate[- ]?limits?\b|\brate[- ]?limited\b/i.test(message))
+}
+
+const USAGE_AUTH_ERROR_PATTERNS = [
+  // Why: "OAuth" can be an upstream route label; only credential/session wording
+  // should hide raw details behind the softer usage-refresh copy.
+  /\binvalid (?:authentication )?credentials?\b/i,
+  /\b(?:no|missing|invalid|expired|stale|unavailable) (?:oauth )?(?:access token|refresh token|token|credentials?|auth(?:entication)? session|auth cookie)\b/i,
+  /\b(?:access token|refresh token|token|credentials?|auth(?:entication)? session|auth cookie) (?:is |are |was |were |could not be |cannot be |can't be )?(?:missing|unavailable|invalid|expired|stale|used|refreshed|loaded|found)\b/i,
+  /\bcredentials?[ -]file (?:is |was )?(?:missing|unavailable|invalid|expired|stale)\b/i,
+  /\b(?:access token|refresh token|token|credentials?|auth(?:entication)? session|auth cookie) not (?:found|available)\b/i,
+  /\b(?:token data|tokens?) (?:is |are )?not available\b/i,
+  /\bauth (?:is missing|tokens are missing|does not expose)\b/i,
+  /\bunauthori[sz]ed\b/i,
+  /\bunauthenticated\b/i,
+  /\bplease reauthenticate\b/i,
+  /\bsign in\b/i,
+  /\blogged in to another account\b/i,
+  /\bnot logged in\b/i,
+  /\blog[ -]?in\b/i,
+  /\blog(?:ged)? out\b/i
+]
+
+function isUsageAuthError(message: string | null): boolean {
+  return Boolean(message && USAGE_AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(message)))
+}
+
+export function getProviderUsageStatusLabel(p: ProviderRateLimits): string {
+  if (p.provider === 'claude') {
+    switch (p.usageMetadata?.failureKind) {
+      case 'deferred-by-live-session':
+        return translate(
+          'auto.components.status.bar.tooltip.0d8d7cfe15',
+          'Waiting for Claude session'
+        )
+      case 'stale-token':
+      case 'refreshable-credentials-without-token':
+      case 'delegated-refresh-required':
+        return translate('auto.components.status.bar.tooltip.1804cd8c3f', 'Refreshing sign-in')
+      case 'network':
+        return translate('auto.components.status.bar.tooltip.f8f0f9d8cc', 'Network issue')
+      case 'keychain-unavailable':
+        return translate('auto.components.status.bar.tooltip.bf2e739f18', 'Sign-in unavailable')
+      case 'cli-unavailable':
+      case 'usage-unavailable':
+        return translate('auto.components.status.bar.tooltip.f8b8dbed85', 'Usage unavailable')
+      default:
+        break
+    }
+  }
+  if (isUsageRateLimitError(p.error)) {
+    return translate('auto.components.status.bar.tooltip.7ad719c4bf', 'Limited')
+  }
+  return translate('auto.components.status.bar.tooltip.e740f92596', 'Refresh failed')
+}
+
+export function getProviderUsageErrorMessage(p: ProviderRateLimits): string {
+  const fallback = translate(
+    'auto.components.status.bar.tooltip.2c35eca8d4',
+    'Unable to fetch usage'
+  )
+  if (!p.error) {
+    return fallback
+  }
+  if (p.provider === 'claude') {
+    switch (p.usageMetadata?.failureKind) {
+      case 'deferred-by-live-session':
+        return translate(
+          'auto.components.status.bar.tooltip.3d3c9c0c1f',
+          'Claude usage will refresh after the live Claude terminal rotates its credentials.'
+        )
+      case 'stale-token':
+      case 'refreshable-credentials-without-token':
+      case 'delegated-refresh-required':
+        return translate(
+          'auto.components.status.bar.tooltip.42fdd4da1d',
+          'Claude sign-in is being refreshed. Agent sessions may still be signed in.'
+        )
+      case 'missing-scope':
+        return p.error
+      case 'network':
+        return translate(
+          'auto.components.status.bar.tooltip.c06c1d215d',
+          'Claude usage could not be refreshed because the network request failed.'
+        )
+      case 'keychain-unavailable':
+        return translate(
+          'auto.components.status.bar.tooltip.cabdc2a9e0',
+          'Claude sign-in credentials could not be read.'
+        )
+      case 'server':
+      case 'parse':
+      case 'usage-unavailable':
+      case 'cli-unavailable':
+        return translate(
+          'auto.components.status.bar.tooltip.a7517cccb6',
+          'Claude usage is unavailable right now.'
+        )
+      default:
+        break
+    }
+  }
+  if (isUsageRateLimitError(p.error)) {
+    return p.error
+  }
+  if (isUsageAuthError(p.error)) {
+    const name = getProviderDisplayName(p.provider)
+    return translate(
+      'auto.components.status.bar.tooltip.8418ec448d',
+      '{{value0}} usage could not be refreshed. Agent sessions may still be signed in.',
+      { value0: name }
+    )
+  }
+  return p.error
+}

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -15,6 +15,34 @@ export type RateLimitBucket = RateLimitWindow & {
   name: string
 }
 
+export type UsageRateLimitSource = 'oauth' | 'cli' | 'web'
+
+export type UsageRateLimitFailureKind =
+  | 'missing-credentials'
+  | 'stale-token'
+  | 'refreshable-credentials-without-token'
+  | 'delegated-refresh-required'
+  | 'deferred-by-live-session'
+  | 'keychain-unavailable'
+  | 'missing-scope'
+  | 'network'
+  | 'server'
+  | 'parse'
+  | 'rate-limited'
+  | 'cli-unavailable'
+  | 'usage-unavailable'
+  | 'unknown'
+
+export type UsageRateLimitMetadata = {
+  source?: UsageRateLimitSource
+  attemptedSources?: UsageRateLimitSource[]
+  failureKind?: UsageRateLimitFailureKind
+  credentialSource?: string
+  authProvenance?: string
+  deferredByLiveClaudeSession?: boolean
+  lastSuccessfulSource?: UsageRateLimitSource
+}
+
 export type ProviderRateLimits = {
   provider: 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'kimi'
   /** 5-hour session window, null if not available. */
@@ -43,6 +71,7 @@ export type ProviderRateLimits = {
   /** Human-readable error message, null when status is 'ok'. */
   error: string | null
   status: ProviderRateLimitStatus
+  usageMetadata?: UsageRateLimitMetadata
 }
 
 export type CodexRateLimitResetOutcome = 'reset' | 'nothingToReset' | 'noCredit' | 'alreadyRedeemed'


### PR DESCRIPTION
## Summary

- Add an internal Claude usage refresh plan and OAuth/CLI source execution path.
- Classify Claude OAuth and credential failures, then use structured metadata for fallback/defer/UI copy instead of raw string parsing alone.
- Add safe automatic CLI fallback, OAuth retry after CLI repair, managed live-session defer handling, Keychain-unavailable metadata, and stale snapshot metadata preservation.
- Split status-bar usage error copy into a focused module to keep the tooltip file under the line limit.

## Review

- Ran an independent Orca subagent review focused on hidden PTY fallback safety, managed live-session defer behavior, metadata/stale policy, renderer copy, and implementation-plan mismatches.
- Addressed the actionable findings by preventing managed live-session no-token cases from falling through to CLI fallback and by adding structured Keychain-unavailable classification/copy.
- The remaining hidden PTY note is intentional for app auto mode, while retaining the existing non-Windows/WSL/live-session guardrails.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/claude-fetcher.test.ts src/main/rate-limits/claude-usage-error-classification.test.ts src/main/rate-limits/claude-usage-refresh-plan.test.ts src/main/rate-limits/service.test.ts src/renderer/src/components/status-bar/tooltip.test.ts`
- `pnpm run typecheck`
- `pnpm exec oxlint src/main/rate-limits/claude-fetcher.ts src/main/rate-limits/claude-fetcher.test.ts src/main/rate-limits/claude-usage-error-classification.ts src/main/rate-limits/claude-usage-error-classification.test.ts src/main/rate-limits/claude-usage-refresh-plan.ts src/main/rate-limits/claude-usage-refresh-plan.test.ts src/main/rate-limits/service.ts src/main/rate-limits/service.test.ts src/renderer/src/components/status-bar/tooltip.tsx src/renderer/src/components/status-bar/usage-error-copy.ts src/renderer/src/components/status-bar/tooltip.test.ts src/shared/rate-limit-types.ts`
- `pnpm exec oxfmt --check src/main/rate-limits/claude-fetcher.ts src/main/rate-limits/claude-fetcher.test.ts src/main/rate-limits/claude-usage-error-classification.ts src/main/rate-limits/claude-usage-error-classification.test.ts src/main/rate-limits/claude-usage-refresh-plan.ts src/main/rate-limits/claude-usage-refresh-plan.test.ts src/main/rate-limits/service.ts src/main/rate-limits/service.test.ts src/renderer/src/components/status-bar/tooltip.tsx src/renderer/src/components/status-bar/usage-error-copy.ts src/renderer/src/components/status-bar/tooltip.test.ts src/shared/rate-limit-types.ts`

Note: local shell reports the repo's standard Node engine warning because it is using Node v26 while the repo expects Node 24; commands above passed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5995">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->