### PR TITLE
Refresh workspace PR badges after external PR creation

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment happy-dom
+import React, { type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo, Worktree, WorktreeCardProperty } from '../../../../shared/types'
+
+const fetchHostedReviewForBranch = vi.fn()
+const fetchIssue = vi.fn()
+const fetchLinearIssue = vi.fn()
+const openModal = vi.fn()
+const updateWorktreeMeta = vi.fn()
+
+let worktreeCardProperties: WorktreeCardProperty[] = ['status']
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      deleteStateByWorktreeId: {},
+      fetchHostedReviewForBranch,
+      fetchIssue,
+      fetchLinearIssue,
+      gitConflictOperationByWorktree: {},
+      hostedReviewCache: {
+        'local::repo-1::feature/branch': {
+          data: null,
+          fetchedAt: Date.now(),
+          linkedReviewHintKey: ''
+        }
+      },
+      issueCache: {},
+      linearIssueCache: {},
+      openModal,
+      remoteBranchConflictByWorktreeId: {},
+      settings: { experimentalNewWorktreeCardStyle: true },
+      sshConnectionStates: new Map(),
+      sshTargetLabels: new Map(),
+      updateWorktreeMeta,
+      workspacePortScan: null,
+      worktreeCardProperties
+    })
+}))
+
+vi.mock('@/lib/sidebar-worktree-activation', () => ({
+  activateWorktreeFromSidebar: vi.fn()
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('./CacheTimer', () => ({
+  default: () => null,
+  usePromptCacheCountdownStartedAt: () => null
+}))
+
+vi.mock('./WorktreeCardAgents', () => ({
+  default: () => null
+}))
+
+vi.mock('./SshDisconnectedDialog', () => ({
+  SshDisconnectedDialog: () => null
+}))
+
+vi.mock('./WorktreeContextMenu', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+  CLOSE_ALL_CONTEXT_MENUS_EVENT: 'orca:test-close-context-menus',
+  WORKTREE_NATIVE_CONTEXT_MENU_ATTR: 'data-worktree-native-context-menu',
+  WORKTREE_CONTEXT_MENU_SCOPE_ATTR: 'data-orca-context-menu-scope'
+}))
+
+vi.mock('./use-worktree-activity-status', () => ({
+  useWorktreeActivityStatus: () => 'active'
+}))
+
+function makeRepo(): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'orca',
+    badgeColor: '#999999',
+    addedAt: 1
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'repo-1::/repo/worktrees/branch',
+    repoId: 'repo-1',
+    path: '/repo/worktrees/branch',
+    displayName: 'feature/branch',
+    branch: 'feature/branch',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    ...overrides
+  }
+}
+
+describe('WorktreeCard hosted review refresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    worktreeCardProperties = ['status']
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+    }
+    container?.remove()
+    root = null
+    container = null
+    vi.useRealTimers()
+  })
+
+  it('polls visible hosted review cards after a cached branch miss', async () => {
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    act(() => {
+      root?.render(<WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />)
+    })
+
+    expect(fetchHostedReviewForBranch).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(fetchHostedReviewForBranch).toHaveBeenCalledTimes(2)
+    expect(fetchHostedReviewForBranch).toHaveBeenLastCalledWith('/repo', 'feature/branch', {
+      repoId: 'repo-1',
+      linkedGitHubPR: null,
+      linkedGitLabMR: null,
+      linkedBitbucketPR: null,
+      linkedAzureDevOpsPR: null,
+      linkedGiteaPR: null,
+      staleWhileRevalidate: true
+    })
+  })
+
+  it('does not poll hosted reviews when status and PR surfaces are hidden', async () => {
+    worktreeCardProperties = []
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    act(() => {
+      root?.render(<WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(fetchHostedReviewForBranch).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import React, { type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -117,6 +117,7 @@ type WorktreeCardProps = {
 }
 
 const EMPTY_WORKSPACE_PORTS = []
+const HOSTED_REVIEW_CARD_REFRESH_INTERVAL_MS = 60_000
 
 export function shouldBeginWorktreeRename(
   request: WorktreeRenameRequest | null,
@@ -534,10 +535,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     ) {
       return
     }
-    const refreshHostedReviewIfVisible = (): void => {
-      if (!isWindowVisible()) {
-        return
-      }
+    const refreshHostedReview = (): void => {
       // Why: branch lookup is lossy for fork/deleted-head PRs; reuse a known PR
       // number from explicit metadata whenever we have one.
       void fetchHostedReviewForBranch(repo.path, branch, {
@@ -550,13 +548,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
         staleWhileRevalidate: true
       })
     }
-    refreshHostedReviewIfVisible()
-    window.addEventListener('focus', refreshHostedReviewIfVisible)
-    document.addEventListener('visibilitychange', refreshHostedReviewIfVisible)
-    return () => {
-      window.removeEventListener('focus', refreshHostedReviewIfVisible)
-      document.removeEventListener('visibilitychange', refreshHostedReviewIfVisible)
-    }
+    // Why: PRs created outside Orca (for example `gh pr create`) do not emit a
+    // renderer event; visible-card polling discovers them after an earlier miss.
+    return installWindowVisibilityInterval({
+      run: refreshHostedReview,
+      intervalMs: HOSTED_REVIEW_CARD_REFRESH_INTERVAL_MS
+    })
   }, [
     repo,
     isFolder,


### PR DESCRIPTION
## Summary
- Poll visible workspace-card hosted review metadata while the status/PR surfaces are enabled
- Let externally-created PRs, such as PRs made with `gh pr create`, appear after a cached branch miss
- Keep hidden/disabled hosted review card metadata from polling

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx src/renderer/src/store/slices/hosted-review.test.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/5997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->