### PR TITLE
Restore agent history after worktree renames

### DIFF
--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -355,6 +355,7 @@ describe('mergeWorktree', () => {
       lastActivityAt: 1000,
       workspaceStatus: 'in-review',
       diffComments: [],
+      priorWorktreeIds: ['repo1::/workspaces/old-feature'],
       automationProvenance: {
         kind: 'created-by-automation' as const,
         automationId: 'automation-1',
@@ -401,6 +402,7 @@ describe('mergeWorktree', () => {
       lastActivityAt: 1000,
       workspaceStatus: 'in-review',
       diffComments: [],
+      priorWorktreeIds: ['repo1::/workspaces/old-feature'],
       automationProvenance: {
         kind: 'created-by-automation',
         automationId: 'automation-1',

--- a/src/main/ipc/worktree-metadata-merge.ts
+++ b/src/main/ipc/worktree-metadata-merge.ts
@@ -62,6 +62,7 @@ export function mergeWorktree(
       : {}),
     ...(meta?.baseRef !== undefined ? { baseRef: meta.baseRef } : {}),
     ...(meta?.pushTarget !== undefined ? { pushTarget: meta.pushTarget } : {}),
+    ...(meta?.priorWorktreeIds !== undefined ? { priorWorktreeIds: meta.priorWorktreeIds } : {}),
     workspaceStatus: meta?.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
     // Why: diff comments are persisted on WorktreeMeta and forwarded verbatim
     // so the renderer store mirrors on-disk state.

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -3795,6 +3795,15 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('lists a synthetic worktree for folder-mode repos', async () => {
+    const rootWorktreeId = 'repo-1::/workspace/folder'
+    const priorWorktreeIds = ['repo-1::/workspace/old-folder']
+    const rootMeta = makeWorktreeMeta({
+      instanceId: 'folder-instance',
+      projectId: 'repo:repo-1',
+      hostId: 'local',
+      projectHostSetupId: 'repo-1',
+      priorWorktreeIds
+    })
     store.getRepos.mockReturnValue([
       {
         id: 'repo-1',
@@ -3813,18 +3822,25 @@ describe('registerWorktreeHandlers', () => {
       addedAt: 0,
       kind: 'folder'
     })
+    store.getAllWorktreeMeta.mockReturnValue({
+      [rootWorktreeId]: rootMeta
+    })
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) =>
+      worktreeId === rootWorktreeId ? rootMeta : undefined
+    )
 
     const listed = await handlers['worktrees:list'](null, { repoId: 'repo-1' })
 
     expect(listed).toEqual([
       expect.objectContaining({
-        id: 'repo-1::/workspace/folder',
+        id: rootWorktreeId,
         repoId: 'repo-1',
         path: '/workspace/folder',
         displayName: 'folder',
         branch: '',
         head: '',
-        isMainWorktree: true
+        isMainWorktree: true,
+        priorWorktreeIds
       })
     ])
     expect(listWorktreesMock).not.toHaveBeenCalled()

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -640,6 +640,7 @@ function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta
     ...(meta.automationProvenance !== undefined
       ? { automationProvenance: meta.automationProvenance }
       : {}),
+    ...(meta.priorWorktreeIds !== undefined ? { priorWorktreeIds: meta.priorWorktreeIds } : {}),
     workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
     diffComments: meta.diffComments,
     mobileDiffReview: meta.mobileDiffReview

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1872,7 +1872,14 @@ describe('OrcaRuntimeService', () => {
       addedAt: 1,
       kind: 'folder' as const
     }
-    const metaById: Record<string, WorktreeMeta> = {}
+    const rootWorktreeId = 'folder-repo::/workspace/folder'
+    const rootPriorWorktreeIds = ['folder-repo::/workspace/old-folder']
+    const metaById: Record<string, WorktreeMeta> = {
+      [rootWorktreeId]: makeWorktreeMeta({
+        instanceId: 'root-instance',
+        priorWorktreeIds: rootPriorWorktreeIds
+      })
+    }
     const runtimeStore = {
       ...store,
       getRepos: () => [folderRepo],
@@ -1931,8 +1938,9 @@ describe('OrcaRuntimeService', () => {
       totalCount: 2,
       worktrees: [
         expect.objectContaining({
-          id: 'folder-repo::/workspace/folder',
-          isMainWorktree: true
+          id: rootWorktreeId,
+          isMainWorktree: true,
+          priorWorktreeIds: rootPriorWorktreeIds
         }),
         expect.objectContaining({
           id: result.worktree.id,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1226,6 +1226,7 @@ function mergeRuntimeFolderWorkspace(repo: Repo, worktreeId: string, meta: Workt
     ...(meta.automationProvenance !== undefined
       ? { automationProvenance: meta.automationProvenance }
       : {}),
+    ...(meta.priorWorktreeIds !== undefined ? { priorWorktreeIds: meta.priorWorktreeIds } : {}),
     workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
     diffComments: meta.diffComments,
     mobileDiffReview: meta.mobileDiffReview

--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -48,6 +48,7 @@ export default function AiVaultPanel(): React.JSX.Element {
 
   const isRemoteWorktree = Boolean(activeRepo?.connectionId)
   const activeWorktreePath = activeWorktree?.path ?? null
+  // Why: AI Vault ownership is cwd-based, so we must consider live worktrees across all repos.
   const liveWorktrees = useMemo(() => Object.values(worktreesByRepo).flat(), [worktreesByRepo])
   const activeWorktreePaths = useMemo(
     () => deriveAiVaultWorkspaceScopePaths(activeWorktree ?? null, liveWorktrees),

--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -4,7 +4,12 @@ import { buildAiVaultResumeCommandForWorktree } from '@/lib/ai-vault-resume-comm
 import { launchAiVaultSessionInNewTab } from '@/lib/launch-ai-vault-session'
 import { useAppStore } from '@/store'
 import { useActiveWorktree, useRepoById } from '@/store/selectors'
-import { agentLabel, filterAiVaultSessions, groupAiVaultSessions } from './ai-vault-session-filters'
+import {
+  agentLabel,
+  deriveAiVaultWorkspaceScopePaths,
+  filterAiVaultSessions,
+  groupAiVaultSessions
+} from './ai-vault-session-filters'
 import {
   AI_VAULT_AGENTS,
   type AiVaultAgent,
@@ -25,6 +30,7 @@ export default function AiVaultPanel(): React.JSX.Element {
   const activeWorktree = useActiveWorktree()
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
   const agentCmdOverrides = useAppStore((s) => s.settings?.agentCmdOverrides ?? {})
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const [query, setQuery] = useState('')
   const [scope, setScope] = useState<AiVaultScope>('workspace')
   const [sort, setSort] = useState<AiVaultSort>('updated')
@@ -42,6 +48,11 @@ export default function AiVaultPanel(): React.JSX.Element {
 
   const isRemoteWorktree = Boolean(activeRepo?.connectionId)
   const activeWorktreePath = activeWorktree?.path ?? null
+  const liveWorktrees = useMemo(() => Object.values(worktreesByRepo).flat(), [worktreesByRepo])
+  const activeWorktreePaths = useMemo(
+    () => deriveAiVaultWorkspaceScopePaths(activeWorktree ?? null, liveWorktrees),
+    [activeWorktree, liveWorktrees]
+  )
   const hasAllAgentsSelected = agents.length === AI_VAULT_AGENTS.length
   const viewAdjustmentCount =
     (hasAllAgentsSelected ? 0 : 1) +
@@ -107,10 +118,10 @@ export default function AiVaultPanel(): React.JSX.Element {
         agents,
         scope,
         sort,
-        activeWorktreePath,
+        activeWorktreePaths,
         hideEmptySessions
       }),
-    [activeWorktreePath, agents, hideEmptySessions, query, scope, sessions, sort]
+    [activeWorktreePaths, agents, hideEmptySessions, query, scope, sessions, sort]
   )
 
   const groups = useMemo(

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import {
   AI_VAULT_SESSION_FILTER_QUERY_MAX_BYTES,
+  deriveAiVaultWorkspaceScopePaths,
   filterAiVaultSessions,
   folderLabel,
   groupAiVaultSessions,
@@ -50,10 +51,52 @@ describe('filterAiVaultSessions', () => {
         agents: ['claude'],
         scope: 'workspace',
         sort: 'updated',
-        activeWorktreePath: '/Users/ada/repo',
+        activeWorktreePaths: ['/Users/ada/repo'],
         hideEmptySessions: true
       }).map((session) => session.id)
     ).toEqual(['claude:1'])
+  })
+
+  it('matches workspace sessions under prior renamed worktree paths', () => {
+    const sessions: AiVaultSession[] = [
+      {
+        ...baseSession,
+        id: 'claude:old-path',
+        cwd: '/Users/ada/workspaces/orca/bream/src'
+      },
+      {
+        ...baseSession,
+        id: 'claude:other-path',
+        cwd: '/Users/ada/workspaces/other/bream'
+      }
+    ]
+
+    expect(
+      filterAiVaultSessions(sessions, {
+        query: '',
+        agents: ['claude'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: [
+          '/Users/ada/workspaces/orca/fix-agent-history',
+          '/Users/ada/workspaces/orca/bream'
+        ],
+        hideEmptySessions: true
+      }).map((session) => session.id)
+    ).toEqual(['claude:old-path'])
+  })
+
+  it('returns no workspace matches when active workspace paths are empty', () => {
+    expect(
+      filterAiVaultSessions([baseSession], {
+        query: '',
+        agents: ['claude'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: [],
+        hideEmptySessions: true
+      })
+    ).toEqual([])
   })
 
   it('hides empty metadata-only sessions when requested', () => {
@@ -71,7 +114,7 @@ describe('filterAiVaultSessions', () => {
         agents: ['claude'],
         scope: 'all',
         sort: 'updated',
-        activeWorktreePath: null,
+        activeWorktreePaths: [],
         hideEmptySessions: true
       }).map((session) => session.id)
     ).toEqual(['claude:1'])
@@ -81,7 +124,7 @@ describe('filterAiVaultSessions', () => {
       agents: ['claude'],
       scope: 'all',
       sort: 'updated',
-      activeWorktreePath: null,
+      activeWorktreePaths: [],
       hideEmptySessions: false
     }).map((session) => session.id)
 
@@ -108,7 +151,7 @@ describe('filterAiVaultSessions', () => {
           agents: ['claude'],
           scope: 'all',
           sort: 'updated',
-          activeWorktreePath: null,
+          activeWorktreePaths: [],
           hideEmptySessions: true
         }
       ).map((session) => session.id)
@@ -140,7 +183,7 @@ describe('filterAiVaultSessions', () => {
           agents: ['claude'],
           scope: 'all',
           sort: 'updated',
-          activeWorktreePath: null,
+          activeWorktreePaths: [],
           hideEmptySessions: true
         }
       )
@@ -161,7 +204,7 @@ describe('filterAiVaultSessions', () => {
           agents: ['claude'],
           scope: 'workspace',
           sort: 'updated',
-          activeWorktreePath: 'c:\\users\\ada\\repo',
+          activeWorktreePaths: ['c:\\users\\ada\\repo'],
           hideEmptySessions: true
         }
       )
@@ -182,10 +225,116 @@ describe('filterAiVaultSessions', () => {
         agents: ['claude'],
         scope: 'all',
         sort: 'updated',
-        activeWorktreePath: null,
+        activeWorktreePaths: [],
         hideEmptySessions: false
       })
     ).toEqual([])
+  })
+})
+
+describe('deriveAiVaultWorkspaceScopePaths', () => {
+  it('includes current and same-repo prior filesystem paths', () => {
+    expect(
+      deriveAiVaultWorkspaceScopePaths({
+        id: 'repo1::/Users/ada/workspaces/orca/fix-agent-history',
+        repoId: 'repo1',
+        path: '/Users/ada/workspaces/orca/fix-agent-history',
+        priorWorktreeIds: ['repo1::/Users/ada/workspaces/orca/bream']
+      })
+    ).toEqual(['/Users/ada/workspaces/orca/fix-agent-history', '/Users/ada/workspaces/orca/bream'])
+  })
+
+  it('strips folder-workspace instance suffixes from prior ids', () => {
+    expect(
+      deriveAiVaultWorkspaceScopePaths({
+        id: 'repo1::/Users/ada/folders/orca',
+        repoId: 'repo1',
+        path: '/Users/ada/folders/orca',
+        priorWorktreeIds: [
+          'repo1::/Users/ada/folders/old-orca::workspace:123e4567-e89b-12d3-a456-426614174000'
+        ]
+      })
+    ).toEqual(['/Users/ada/folders/orca', '/Users/ada/folders/old-orca'])
+  })
+
+  it('ignores malformed, different-repo, relative, empty, and duplicate aliases', () => {
+    expect(
+      deriveAiVaultWorkspaceScopePaths({
+        id: 'repo1::C:\\Users\\Ada\\Repo',
+        repoId: 'repo1',
+        path: 'C:\\Users\\Ada\\Repo',
+        priorWorktreeIds: [
+          'not-a-worktree-id',
+          'repo2::C:\\Users\\Ada\\OldRepo',
+          'repo1::relative/path',
+          'repo1::',
+          'repo1::c:\\users\\ada\\repo',
+          'repo1::C:\\Users\\Ada\\OldRepo'
+        ]
+      })
+    ).toEqual(['C:\\Users\\Ada\\Repo', 'C:\\Users\\Ada\\OldRepo'])
+  })
+
+  it('ignores prior paths claimed by another live worktree in the same repo', () => {
+    expect(
+      deriveAiVaultWorkspaceScopePaths(
+        {
+          id: 'repo1::/Users/ada/workspaces/orca/fix-agent-history',
+          repoId: 'repo1',
+          path: '/Users/ada/workspaces/orca/fix-agent-history',
+          priorWorktreeIds: [
+            'repo1::/Users/ada/workspaces/orca/bream',
+            'repo1::/Users/ada/workspaces/orca/unclaimed-old-path'
+          ]
+        },
+        [
+          {
+            id: 'repo1::/Users/ada/workspaces/orca/fix-agent-history',
+            repoId: 'repo1',
+            path: '/Users/ada/workspaces/orca/fix-agent-history'
+          },
+          {
+            id: 'repo1::/Users/ada/workspaces/orca/bream',
+            repoId: 'repo1',
+            path: '/Users/ada/workspaces/orca/bream'
+          }
+        ]
+      )
+    ).toEqual([
+      '/Users/ada/workspaces/orca/fix-agent-history',
+      '/Users/ada/workspaces/orca/unclaimed-old-path'
+    ])
+  })
+
+  it('ignores prior paths claimed by another live worktree in a different repo', () => {
+    expect(
+      deriveAiVaultWorkspaceScopePaths(
+        {
+          id: 'repo1::/Users/ada/workspaces/orca/fix-agent-history',
+          repoId: 'repo1',
+          path: '/Users/ada/workspaces/orca/fix-agent-history',
+          priorWorktreeIds: [
+            'repo1::/Users/ada/workspaces/orca/bream',
+            'repo1::/Users/ada/workspaces/orca/unclaimed-old-path'
+          ]
+        },
+        [
+          {
+            id: 'repo1::/Users/ada/workspaces/orca/fix-agent-history',
+            repoId: 'repo1',
+            path: '/Users/ada/workspaces/orca/fix-agent-history'
+          },
+          {
+            id: 'repo2::/Users/ada/workspaces/orca/bream',
+            repoId: 'repo2',
+            path: '/Users/ada/workspaces/orca/bream'
+          }
+        ]
+      )
+    ).toEqual([
+      '/Users/ada/workspaces/orca/fix-agent-history',
+      '/Users/ada/workspaces/orca/unclaimed-old-path'
+    ])
   })
 })
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.ts
@@ -1,5 +1,7 @@
 import {
   isPathInsideOrEqual,
+  isRuntimePathAbsolute,
+  normalizeRuntimePathForComparison,
   normalizeRuntimePathSeparators
 } from '../../../../shared/cross-platform-path'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
@@ -11,6 +13,8 @@ import type {
   AiVaultSort
 } from '../../../../shared/ai-vault-types'
 import { aiVaultAgentLabel } from '../../../../shared/ai-vault-types'
+import type { Worktree } from '../../../../shared/types'
+import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree-id'
 import { sessionPreviewSearchText } from './ai-vault-session-display'
 
 export type AiVaultSessionFilterState = {
@@ -18,7 +22,7 @@ export type AiVaultSessionFilterState = {
   agents: readonly AiVaultAgent[]
   scope: AiVaultScope
   sort: AiVaultSort
-  activeWorktreePath: string | null
+  activeWorktreePaths: readonly string[]
   hideEmptySessions: boolean
 }
 
@@ -62,16 +66,43 @@ export function filterAiVaultSessions(
       if (filters.hideEmptySessions && session.messageCount === 0) {
         return false
       }
-      if (
-        filters.scope === 'workspace' &&
-        filters.activeWorktreePath &&
-        (!session.cwd || !isPathInsideOrEqual(filters.activeWorktreePath, session.cwd))
-      ) {
-        return false
+      if (filters.scope === 'workspace') {
+        const cwd = session.cwd
+        if (
+          !cwd ||
+          !filters.activeWorktreePaths.some((pathValue) => isPathInsideOrEqual(pathValue, cwd))
+        ) {
+          return false
+        }
       }
       return matchesQuery(session, parsedQuery)
     })
     .sort((left, right) => compareSessions(left, right, filters.sort))
+}
+
+export function deriveAiVaultWorkspaceScopePaths(
+  activeWorktree: Pick<Worktree, 'id' | 'path' | 'priorWorktreeIds' | 'repoId'> | null,
+  liveWorktrees: readonly Pick<Worktree, 'id' | 'path' | 'repoId'>[] = []
+): string[] {
+  if (!activeWorktree) {
+    return []
+  }
+
+  const paths: string[] = []
+  addAiVaultWorkspaceScopePath(paths, activeWorktree.path)
+
+  for (const priorWorktreeId of activeWorktree.priorWorktreeIds ?? []) {
+    const parsed = splitWorktreeIdForFilesystem(priorWorktreeId)
+    if (!parsed || parsed.repoId !== activeWorktree.repoId) {
+      continue
+    }
+    if (isAiVaultWorkspaceScopePathClaimed(parsed.worktreePath, activeWorktree, liveWorktrees)) {
+      continue
+    }
+    addAiVaultWorkspaceScopePath(paths, parsed.worktreePath)
+  }
+
+  return paths
 }
 
 export function groupAiVaultSessions(
@@ -178,6 +209,38 @@ function compareSessions(left: AiVaultSession, right: AiVaultSession, sort: AiVa
 
 function getFolderGroupKey(pathValue: string | null): string {
   return pathValue ? normalizeRuntimePathSeparators(pathValue).toLowerCase() : 'unknown'
+}
+
+function addAiVaultWorkspaceScopePath(paths: string[], pathValue: string): void {
+  const trimmedPath = pathValue.trim()
+  if (!trimmedPath || !isRuntimePathAbsolute(trimmedPath)) {
+    return
+  }
+  const comparisonPath = normalizeRuntimePathForComparison(trimmedPath)
+  if (
+    paths.some((existingPath) => normalizeRuntimePathForComparison(existingPath) === comparisonPath)
+  ) {
+    return
+  }
+  paths.push(trimmedPath)
+}
+
+function isAiVaultWorkspaceScopePathClaimed(
+  pathValue: string,
+  activeWorktree: Pick<Worktree, 'id'>,
+  liveWorktrees: readonly Pick<Worktree, 'id' | 'path'>[]
+): boolean {
+  const trimmedPath = pathValue.trim()
+  if (!trimmedPath || !isRuntimePathAbsolute(trimmedPath)) {
+    return false
+  }
+  const comparisonPath = normalizeRuntimePathForComparison(trimmedPath)
+  // AI Vault sessions are keyed by cwd only, so any live worktree now owning this path wins.
+  return liveWorktrees.some(
+    (worktree) =>
+      worktree.id !== activeWorktree.id &&
+      normalizeRuntimePathForComparison(worktree.path) === comparisonPath
+  )
 }
 
 function tokenizeQuery(query: string): string[] {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -394,6 +394,29 @@ describe('fetchWorktrees', () => {
     expect(store.getState().sortEpoch).toBe(8)
   })
 
+  it('updates the repo entry when only prior worktree id aliases change', async () => {
+    const store = createTestStore()
+    const existing = makeWorktree({
+      id: 'repo1::/path/current-name',
+      repoId: 'repo1',
+      path: '/path/current-name'
+    })
+    const refreshed = makeWorktree({
+      id: 'repo1::/path/current-name',
+      repoId: 'repo1',
+      path: '/path/current-name',
+      priorWorktreeIds: ['repo1::/path/old-name']
+    })
+
+    mockApi.worktrees.list.mockResolvedValue([refreshed])
+    store.setState({ worktreesByRepo: { repo1: [existing] }, sortEpoch: 7 } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([refreshed])
+    expect(store.getState().sortEpoch).toBe(8)
+  })
+
   it('keeps the last known worktree list when a refresh transiently returns empty', async () => {
     const store = createTestStore()
     const existing = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -263,6 +263,7 @@ function areWorktreesEqual(current: Worktree[] | undefined, next: Worktree[]): b
       worktree.pushTarget?.remoteUrl === candidate.pushTarget?.remoteUrl &&
       worktree.sparseBaseRef === candidate.sparseBaseRef &&
       arraysShallowEqual(worktree.sparseDirectories, candidate.sparseDirectories) &&
+      arraysShallowEqual(worktree.priorWorktreeIds, candidate.priorWorktreeIds) &&
       (worktree as WorktreeWithLineage).parentWorktreeId ===
         (candidate as WorktreeWithLineage).parentWorktreeId &&
       arraysShallowEqual(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -493,6 +493,8 @@ export type Worktree = {
   baseRef?: string
   /** Remote/branch Orca should publish review commits to when it created this worktree. */
   pushTarget?: GitPushTarget
+  /** Path-derived worktree ids this worktree had before folder renames. */
+  priorWorktreeIds?: string[]
   workspaceStatus?: WorkspaceStatus
   diffComments?: DiffComment[]
   mobileDiffReview?: MobileDiffReviewState


### PR DESCRIPTION
## Summary
- Preserve `priorWorktreeIds` when worktree metadata is merged into main/runtime worktree models.
- Include safe prior folder aliases in Agent Session History Workspace scope so sessions started before a branch/worktree/folder rename remain visible.
- Exclude prior paths that are now claimed by any live worktree, including worktrees from other repos, because AI Vault sessions are keyed by cwd.
- Keep renderer worktree equality sensitive to alias-only metadata updates.

## Design
- Wrote a scratch design doc at `design-docs/fix-agent-history-renamed-worktree.md`; it is ignored and not part of this product PR.
- Design-review subagent returned clean after requiring that `priorWorktreeIds` be exposed/forwarded through the worktree model.

## Implementation
- Added optional `priorWorktreeIds` to the renderer/shared worktree type and forwarding paths.
- Derived workspace-scope AI Vault paths from the active worktree plus validated same-repo prior ids.
- Guarded reused old paths by checking all live worktrees, not only active-repo worktrees.
- Added tests for renamed paths, malformed/different-repo aliases, folder-workspace suffix stripping, same-repo and cross-repo path reuse, and alias-only store refreshes.

## Verification
- Completeness verification: implementation matched the reviewed design.
- Code review loop: final two-reviewer round returned no actionable findings.
- Brennan test changes: verdict `land`.

## Electron Evidence
Screenshots were captured as ignored validation artifacts and are not committed:
- `validation-screenshots/agent-history-before-prior-alias-worktree-scope.png`
- `validation-screenshots/agent-history-prior-alias-worktree-scope.png`
- `validation-screenshots/agent-history-prior-alias-all-scope.png`

Electron validation covered:
- Before alias: Worktree scope showed only current session.
- After alias: Worktree scope showed current plus unclaimed prior session.
- Claimed same-repo and cross-repo prior paths were excluded from Worktree scope.
- All scope still showed all seeded validation sessions.

## Local Checks
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts src/renderer/src/store/slices/worktrees.test.ts src/main/ipc/worktree-logic.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts` — 819 passed.
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec oxfmt --check` on touched files.
- `git diff --check`

## AI Review Report
- Design review: clean after forwarding `priorWorktreeIds` through public worktree models.
- Implementation completeness verification: complete against the reviewed design.
- Code review loop: final two independent reviewers returned clean.
- CodeRabbit: one actionable comment was fixed in `39222a08` by documenting why AI Vault scopes against all live worktrees. Refreshed CodeRabbit review reported no actionable comments.
- Cross-platform: uses existing runtime path normalization and absolute-path checks; tests cover POSIX and Windows-style paths.
- SSH: no renderer filesystem probing or local-only path discovery was added; the feature uses persisted metadata from existing worktree surfaces.

## Security Audit
- Input handling: malformed, empty, relative, duplicate, and different-repo prior ids are ignored for alias expansion.
- Path handling: old paths are normalized for comparison, and a prior alias is dropped if any live worktree currently owns that cwd.
- IPC/data exposure: only existing worktree metadata is forwarded to the renderer; no new external command, filesystem scan, or network behavior was added.

## Post-PR Stabilization
- Waited 8 minutes after opening the PR, reviewed CodeRabbit and checks, fixed the one actionable CodeRabbit line comment, and pushed `39222a08`.
- Waited another 8 minutes after the follow-up push.
- Final PR checks: `verify` passed.
- Final CodeRabbit state: no actionable comments. CodeRabbit still shows a generic docstring-coverage warning; I am treating it as non-actionable for this repo because the changed code follows the local style of brief why-comments rather than broad function docstrings.

## Assumptions / Gaps
- Electron preload API is non-writable, so the CDP pass could not monkeypatch `worktrees.listDetected` to force the live IPC refresh path. The mounted UI state refresh was validated in Electron, and the exact `fetchWorktrees` equality behavior is covered by unit tests.
