### PR TITLE
Fix hold dictation release handling

### DIFF
--- a/src/renderer/src/components/dictation/use-hold-dictation-gesture.test.tsx
+++ b/src/renderer/src/components/dictation/use-hold-dictation-gesture.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+
+import { createRef, type MutableRefObject } from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DictationState } from '../../../../shared/speech-types'
+import type { GlobalSettings } from '../../../../shared/types'
+import type { DictationInsertionTarget } from './dictation-insertion-target'
+import { useHoldDictationGesture } from './use-hold-dictation-gesture'
+
+const originalUserAgent = navigator.userAgent
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+let dictationStateRef: MutableRefObject<DictationState>
+let holdGestureActiveRef: MutableRefObject<boolean>
+let insertionTargetRef: MutableRefObject<DictationInsertionTarget | null>
+let intentionalTargetCancellationRef: MutableRefObject<boolean>
+let startDictation: ReturnType<typeof vi.fn<() => void>>
+let stopDictation: ReturnType<typeof vi.fn<() => void>>
+
+function setUserAgent(userAgent: string): void {
+  Object.defineProperty(navigator, 'userAgent', {
+    configurable: true,
+    value: userAgent
+  })
+}
+
+function holdSettings(): GlobalSettings {
+  return {
+    voice: {
+      enabled: true,
+      sttModel: 'test-model',
+      dictationMode: 'hold'
+    }
+  } as GlobalSettings
+}
+
+function Probe(): null {
+  useHoldDictationGesture({
+    dictationStateRef,
+    holdGestureActiveRef,
+    insertionTargetRef,
+    intentionalTargetCancellationRef,
+    keybindings: {},
+    settings: holdSettings(),
+    startDictation,
+    stopDictation
+  })
+  return null
+}
+
+function dispatchKeyDown(init: KeyboardEventInit): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+  window.dispatchEvent(event)
+  return event
+}
+
+function dispatchKeyUp(init: KeyboardEventInit): KeyboardEvent {
+  const event = new KeyboardEvent('keyup', { bubbles: true, cancelable: true, ...init })
+  window.dispatchEvent(event)
+  return event
+}
+
+async function renderProbe(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<Probe />)
+  })
+}
+
+beforeEach(() => {
+  setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)')
+  dictationStateRef = createRef<DictationState>() as MutableRefObject<DictationState>
+  dictationStateRef.current = 'idle'
+  holdGestureActiveRef = createRef<boolean>() as MutableRefObject<boolean>
+  holdGestureActiveRef.current = false
+  insertionTargetRef = createRef<DictationInsertionTarget | null>()
+  insertionTargetRef.current = null
+  intentionalTargetCancellationRef = createRef<boolean>() as MutableRefObject<boolean>
+  intentionalTargetCancellationRef.current = false
+  startDictation = vi.fn<() => void>()
+  stopDictation = vi.fn<() => void>()
+})
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root?.unmount()
+    })
+  }
+  root = null
+  container?.remove()
+  container = null
+  setUserAgent(originalUserAgent)
+  vi.clearAllMocks()
+})
+
+describe('useHoldDictationGesture', () => {
+  it('stops when the shortcut key is released after the modifier', async () => {
+    await renderProbe()
+
+    act(() => {
+      dispatchKeyDown({ key: 'e', code: 'KeyE', metaKey: true })
+    })
+    dictationStateRef.current = 'listening'
+
+    act(() => {
+      dispatchKeyUp({ key: 'e', code: 'KeyE', metaKey: false })
+    })
+
+    expect(startDictation).toHaveBeenCalledTimes(1)
+    expect(stopDictation).toHaveBeenCalledTimes(1)
+    expect(holdGestureActiveRef.current).toBe(false)
+  })
+
+  it('stops when the required modifier is released before the shortcut key', async () => {
+    await renderProbe()
+
+    act(() => {
+      dispatchKeyDown({ key: 'e', code: 'KeyE', metaKey: true })
+    })
+    dictationStateRef.current = 'listening'
+
+    act(() => {
+      dispatchKeyUp({ key: 'Meta', code: 'MetaLeft', metaKey: false })
+    })
+
+    expect(startDictation).toHaveBeenCalledTimes(1)
+    expect(stopDictation).toHaveBeenCalledTimes(1)
+    expect(holdGestureActiveRef.current).toBe(false)
+  })
+
+  it('ignores unrelated key releases while the shortcut is held', async () => {
+    await renderProbe()
+
+    act(() => {
+      dispatchKeyDown({ key: 'e', code: 'KeyE', metaKey: true })
+    })
+    dictationStateRef.current = 'listening'
+
+    act(() => {
+      dispatchKeyUp({ key: 'x', code: 'KeyX', metaKey: true })
+    })
+
+    expect(startDictation).toHaveBeenCalledTimes(1)
+    expect(stopDictation).not.toHaveBeenCalled()
+    expect(holdGestureActiveRef.current).toBe(true)
+  })
+})

--- a/src/renderer/src/components/dictation/use-hold-dictation-gesture.ts
+++ b/src/renderer/src/components/dictation/use-hold-dictation-gesture.ts
@@ -5,6 +5,15 @@ import type { DictationState } from '../../../../shared/speech-types'
 import type { GlobalSettings } from '../../../../shared/types'
 import type { DictationInsertionTarget } from './dictation-insertion-target'
 
+type HoldReleaseGesture = {
+  key: string
+  code: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+}
+
 type HoldDictationGestureOptions = {
   dictationStateRef: MutableRefObject<DictationState>
   holdGestureActiveRef: MutableRefObject<boolean>
@@ -14,6 +23,40 @@ type HoldDictationGestureOptions = {
   settings: GlobalSettings | null
   startDictation: () => Promise<void> | void
   stopDictation: () => Promise<void> | void
+}
+
+function normalizeEventKey(key: string): string {
+  return key.length === 1 ? key.toLowerCase() : key
+}
+
+function captureReleaseGesture(e: KeyboardEvent): HoldReleaseGesture {
+  return {
+    key: normalizeEventKey(e.key),
+    code: e.code,
+    metaKey: e.metaKey,
+    ctrlKey: e.ctrlKey,
+    altKey: e.altKey,
+    shiftKey: e.shiftKey
+  }
+}
+
+function keyReleased(e: KeyboardEvent, gesture: HoldReleaseGesture): boolean {
+  return normalizeEventKey(e.key) === gesture.key || (e.code !== '' && e.code === gesture.code)
+}
+
+function requiredModifierReleased(e: KeyboardEvent, gesture: HoldReleaseGesture): boolean {
+  switch (e.key) {
+    case 'Meta':
+      return gesture.metaKey
+    case 'Control':
+      return gesture.ctrlKey
+    case 'Alt':
+      return gesture.altKey
+    case 'Shift':
+      return gesture.shiftKey
+    default:
+      return false
+  }
 }
 
 export function useHoldDictationGesture({
@@ -34,6 +77,9 @@ export function useHoldDictationGesture({
     if (mode !== 'hold') {
       return
     }
+    // Why: keyUp can arrive after the modifier is already released, so the
+    // original shortcut no longer matches even though the held chord ended.
+    let activeReleaseGesture: HoldReleaseGesture | null = null
 
     const handleKeyDown = (e: KeyboardEvent): void => {
       if (keybindingMatchesAction('voice.dictation', e, getShortcutPlatform(), keybindings)) {
@@ -43,6 +89,7 @@ export function useHoldDictationGesture({
         e.preventDefault()
         e.stopPropagation()
         holdGestureActiveRef.current = true
+        activeReleaseGesture = captureReleaseGesture(e)
         if (dictationStateRef.current === 'idle') {
           void startDictation()
         }
@@ -53,14 +100,20 @@ export function useHoldDictationGesture({
       if (!holdGestureActiveRef.current) {
         return
       }
-      if (!keybindingMatchesAction('voice.dictation', e, getShortcutPlatform(), keybindings)) {
+      if (
+        !activeReleaseGesture ||
+        (!keyReleased(e, activeReleaseGesture) &&
+          !requiredModifierReleased(e, activeReleaseGesture))
+      ) {
         return
       }
       if (dictationStateRef.current === 'idle' || dictationStateRef.current === 'stopping') {
         holdGestureActiveRef.current = false
+        activeReleaseGesture = null
         return
       }
       holdGestureActiveRef.current = false
+      activeReleaseGesture = null
       void stopDictation()
     }
 
@@ -69,6 +122,7 @@ export function useHoldDictationGesture({
         return
       }
       holdGestureActiveRef.current = false
+      activeReleaseGesture = null
       if (dictationStateRef.current !== 'idle' && dictationStateRef.current !== 'stopping') {
         insertionTargetRef.current = null
         intentionalTargetCancellationRef.current = true


### PR DESCRIPTION
## Summary
- remember the shortcut chord that starts hold-mode dictation
- stop dictation when the shortcut key or a required modifier is released
- add regression coverage for macOS Cmd+E release-order behavior

## Regression
PR #4908 extracted hold dictation into a hook and made keyup require the full voice shortcut to still match. If Cmd is released before E, the E keyup has metaKey=false, so the session stayed stuck in Listening.

## Test plan
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/dictation/use-hold-dictation-gesture.test.tsx
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/dictation/use-hold-dictation-gesture.ts src/renderer/src/components/dictation/use-hold-dictation-gesture.test.tsx

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6003">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->