### PR TITLE
Fix mobile iOS Fastlane paths

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -19,8 +19,12 @@ require "json"
 
 default_platform(:ios)
 
-APP_CONFIG_PATH = "app.json"
-WORKSPACE = "ios/Orca.xcworkspace"
+MOBILE_ROOT = File.expand_path("..", __dir__)
+# Why: fastlane executes lanes from mobile/fastlane even when GitHub Actions
+# starts in mobile/, so release file paths must be rooted at the mobile app.
+APP_CONFIG_PATH = File.join(MOBILE_ROOT, "app.json")
+WORKSPACE = File.join(MOBILE_ROOT, "ios", "Orca.xcworkspace")
+BUILD_OUTPUT_DIRECTORY = File.join(MOBILE_ROOT, "build")
 SCHEME = "Orca"
 BUNDLE_ID = "com.stably.orca.mobile"
 TESTFLIGHT_GROUPS = ["peeps"].freeze
@@ -126,7 +130,7 @@ platform :ios do
           BUNDLE_ID => profile_name,
         },
       },
-      output_directory: "build",
+      output_directory: BUILD_OUTPUT_DIRECTORY,
       output_name: "Orca.ipa",
       clean: true,
     )


### PR DESCRIPTION
## Summary
- root mobile iOS Fastlane paths at the mobile app directory
- fixes release lane failure where Fastlane runs from mobile/fastlane and could not find app.json
- also keeps archive output in mobile/build for the artifact upload step

## Verification
- ruby -c mobile/fastlane/Fastfile
- Ruby harness from mobile/fastlane loads APP_CONFIG_PATH and reads expo.version from mobile/app.json

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6004">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->