### PR TITLE
Provide TestFlight changelog for external sharing

### DIFF
--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -18,6 +18,10 @@ on:
         description: 'Optional exact iOS marketing version override, e.g. 0.0.15'
         required: false
         type: string
+      testflight_changelog:
+        description: 'Optional TestFlight external tester changelog'
+        required: false
+        type: string
 
 jobs:
   ios-build:
@@ -115,6 +119,7 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TESTFLIGHT_CHANGELOG: ${{ github.event.inputs.testflight_changelog }}
           # Keep fastlane non-interactive and quiet about analytics in CI.
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_HIDE_CHANGELOG: '1'

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -28,6 +28,7 @@ BUILD_OUTPUT_DIRECTORY = File.join(MOBILE_ROOT, "build")
 SCHEME = "Orca"
 BUNDLE_ID = "com.stably.orca.mobile"
 TESTFLIGHT_GROUPS = ["peeps"].freeze
+DEFAULT_TESTFLIGHT_CHANGELOG = "Latest Orca Mobile updates and fixes.".freeze
 
 def app_store_connect_api_key_from_env
   app_store_connect_api_key(
@@ -68,6 +69,11 @@ def resolve_requested_version(options, config)
 
   current_version = current_mobile_version(config)
   truthy_option?(options[:bump_patch]) ? bump_patch_version(current_version) : current_version
+end
+
+def testflight_changelog
+  changelog = ENV.fetch("TESTFLIGHT_CHANGELOG", "").strip
+  changelog.empty? ? DEFAULT_TESTFLIGHT_CHANGELOG : changelog
 end
 
 platform :ios do
@@ -143,6 +149,9 @@ platform :ios do
       distribute_external: true,
       groups: TESTFLIGHT_GROUPS,
       notify_external_testers: true,
+      # Why: fastlane requires release notes when distributing to external
+      # TestFlight testers, even for CI-triggered smoke releases.
+      changelog: testflight_changelog,
     )
   end
 end


### PR DESCRIPTION
## Summary
- Add an optional `testflight_changelog` manual workflow input for iOS releases
- Pass TestFlight release notes into Fastlane uploads
- Provide a default changelog so external TestFlight sharing does not fail when the input is omitted

## Context
The Mobile iOS Release run failed after the IPA was built and exported because Fastlane requires a changelog when `distribute_external: true` is enabled:
https://github.com/stablyai/orca/actions/runs/27919689794

## Verification
- ruby -c mobile/fastlane/Fastfile
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile-ios-release.yml'); puts 'YAML OK'"
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6006">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->