### PR TITLE
[codex] Add multi-host repo refresh properties

### DIFF
--- a/docs/reference/multi-server-property-test-worksheet.md
+++ b/docs/reference/multi-server-property-test-worksheet.md
@@ -1,0 +1,42 @@
+# Multi-Server Repo Refresh Test Worksheet
+
+## Scenario
+
+Orca can show the same project from more than one execution host: local, SSH, and
+runtime server. A user may add `orca` locally, connect to a server that has its
+own `orca` checkout, switch focus between the hosts, then reload the app with
+`Cmd+Shift+R`.
+
+The test harness needs to catch state crossing those host boundaries. Refreshing
+server B must not remove, overwrite, or re-own the local checkout for project A.
+
+## Invariants
+
+- Repo identity is scoped by execution host plus repo id.
+- A shared provider project can merge multiple host checkouts into one
+  `Project`, but each checkout keeps its own `ProjectHostSetup`.
+- Runtime-fetched repos are stamped with `executionHostId: runtime:<env>`.
+- Local repos are stamped with `executionHostId: local`.
+- Refreshing one host replaces only that host's fetched repos.
+- Generated add, remove, rename, reorder, and refresh sequences preserve every
+  host partition.
+- Project source repo ids remain the union of the surviving host checkouts.
+
+## Current Coverage
+
+- `src/renderer/src/store/slices/repo-host-refresh-merge.test.ts`
+  checks host-scoped repo merge behavior directly.
+- `src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts`
+  checks shared project compatibility after one host refreshes.
+- `src/renderer/src/store/slices/multi-host-repo-refresh.property.test.ts`
+  runs seeded operation sequences across local and two runtime hosts.
+- `src/renderer/src/store/slices/repos-multi-host-refresh.test.ts`
+  drives the renderer store through local IPC and runtime RPC refreshes.
+
+## Next Seams
+
+- Worktree refresh: `src/renderer/src/store/slices/worktrees.ts`.
+- Reload event routing: `src/renderer/src/hooks/useIpcEvents.ts`.
+- Session partitioning: `src/renderer/src/lib/workspace-session-host-split.ts`
+  and `src/renderer/src/lib/workspace-session-host-persistence.ts`.
+- Main persistence: `src/main/persistence.ts` host-keyed workspace sessions.

--- a/src/renderer/src/store/slices/multi-host-repo-refresh.property.test.ts
+++ b/src/renderer/src/store/slices/multi-host-repo-refresh.property.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { projectHostSetupProjectionFromRepos } from '../../../../shared/project-host-setup-projection'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import type { ProjectHostSetup, Repo } from '../../../../shared/types'
+import {
+  mergeProjectHostSetupCompatibility,
+  projectCompatibilityFromRepos
+} from './project-host-setup-compatibility-merge'
+import { mergeFetchedReposForHost } from './repo-host-refresh-merge'
+
+const HOSTS = [
+  'local',
+  'runtime:env-a',
+  'runtime:env-b'
+] as const satisfies readonly ExecutionHostId[]
+const PROJECT_ID = 'github:stablyai/orca'
+
+type HostId = (typeof HOSTS)[number]
+type TruthByHost = Record<HostId, Repo[]>
+
+function createRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0
+    return state / 0x100000000
+  }
+}
+
+function pick<T>(random: () => number, values: readonly T[]): T {
+  return values[Math.floor(random() * values.length)] as T
+}
+
+function repo(hostId: HostId, index: number, revision = 0): Repo {
+  const hostSlug = hostId.replace(/[^a-z0-9]+/gi, '-')
+  const id = `${hostSlug}-repo-${index}`
+  return {
+    id,
+    path: `/${hostSlug}/orca-${index}`,
+    displayName: revision > 0 ? `orca ${index}.${revision}` : `orca ${index}`,
+    badgeColor: '#000000',
+    addedAt: index,
+    executionHostId: hostId,
+    upstream: { owner: 'stablyai', repo: 'orca' }
+  }
+}
+
+function cloneRepos(repos: readonly Repo[]): Repo[] {
+  return repos.map((entry) => ({
+    ...entry,
+    upstream: entry.upstream ? { ...entry.upstream } : null
+  }))
+}
+
+function setupKey(setup: ProjectHostSetup): string {
+  return `${setup.hostId}:${setup.repoId}`
+}
+
+function repoKeys(repos: readonly Repo[]): string[] {
+  return repos.map((entry) => `${getRepoExecutionHostId(entry)}:${entry.id}`).sort()
+}
+
+function assertStateMatchesTruth(repos: readonly Repo[], truthByHost: TruthByHost): void {
+  for (const hostId of HOSTS) {
+    expect(
+      repos
+        .filter((entry) => getRepoExecutionHostId(entry) === hostId)
+        .map((entry) => `${entry.id}:${entry.displayName}`)
+        .sort()
+    ).toEqual(truthByHost[hostId].map((entry) => `${entry.id}:${entry.displayName}`).sort())
+  }
+}
+
+function assertCompatibilityMatchesRepos(repos: readonly Repo[]): void {
+  const compatibility = mergeProjectHostSetupCompatibility(
+    projectCompatibilityFromRepos(repos),
+    projectHostSetupProjectionFromRepos(
+      repos.filter((entry) => getRepoExecutionHostId(entry) !== 'local')
+    )
+  )
+  const setups = compatibility.projectHostSetups.map(setupKey).sort()
+  expect(setups).toEqual(repoKeys(repos))
+  expect(
+    compatibility.projects.find((project) => project.id === PROJECT_ID)?.sourceRepoIds.sort()
+  ).toEqual(repos.map((entry) => entry.id).sort())
+}
+
+function applyGeneratedHostOperation(
+  truthByHost: TruthByHost,
+  random: () => number,
+  nextIndexByHost: Record<HostId, number>
+): HostId {
+  const hostId = pick(random, HOSTS)
+  const repos = truthByHost[hostId]
+  const action = pick(random, ['add', 'remove', 'rename', 'reorder'] as const)
+  switch (action) {
+    case 'add': {
+      const index = nextIndexByHost[hostId]
+      nextIndexByHost[hostId] += 1
+      repos.push(repo(hostId, index))
+      break
+    }
+    case 'remove':
+      if (repos.length > 1) {
+        repos.splice(Math.floor(random() * repos.length), 1)
+      }
+      break
+    case 'rename': {
+      const index = Math.floor(random() * repos.length)
+      const current = repos[index]
+      repos[index] = { ...current, displayName: `${current.displayName}*` }
+      break
+    }
+    case 'reorder':
+      repos.reverse()
+      break
+  }
+  return hostId
+}
+
+describe('multi-host repo refresh properties', () => {
+  it('preserves every host partition across generated refresh sequences', () => {
+    for (let seed = 1; seed <= 25; seed += 1) {
+      const random = createRandom(seed)
+      const truthByHost: TruthByHost = {
+        local: [repo('local', 1)],
+        'runtime:env-a': [repo('runtime:env-a', 1)],
+        'runtime:env-b': [repo('runtime:env-b', 1)]
+      }
+      const nextIndexByHost: Record<HostId, number> = {
+        local: 2,
+        'runtime:env-a': 2,
+        'runtime:env-b': 2
+      }
+      let repos: Repo[] = []
+      for (const hostId of HOSTS) {
+        repos = mergeFetchedReposForHost(repos, cloneRepos(truthByHost[hostId]), hostId)
+      }
+
+      for (let step = 0; step < 50; step += 1) {
+        const hostId = applyGeneratedHostOperation(truthByHost, random, nextIndexByHost)
+        repos = mergeFetchedReposForHost(repos, cloneRepos(truthByHost[hostId]), hostId)
+
+        assertStateMatchesTruth(repos, truthByHost)
+        assertCompatibilityMatchesRepos(repos)
+      }
+    }
+  })
+})

--- a/src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts
+++ b/src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { projectHostSetupProjectionFromRepos } from '../../../../shared/project-host-setup-projection'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { ProjectHostSetup, Repo } from '../../../../shared/types'
+import {
+  mergeProjectHostSetupCompatibility,
+  projectCompatibilityFromRepos
+} from './project-host-setup-compatibility-merge'
+
+function repo(id: string, hostId: ExecutionHostId): Repo {
+  return {
+    id,
+    path: `/${hostId}/${id}`,
+    displayName: 'orca',
+    badgeColor: '#000000',
+    addedAt: 1,
+    executionHostId: hostId,
+    upstream: { owner: 'stablyai', repo: 'orca' }
+  }
+}
+
+function setup(id: string, hostId: ExecutionHostId, repoId: string): ProjectHostSetup {
+  return {
+    id,
+    projectId: 'github:stablyai/orca',
+    hostId,
+    repoId,
+    path: `/${hostId}/${repoId}`,
+    displayName: repoId,
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+describe('mergeProjectHostSetupCompatibility', () => {
+  it('keeps every host checkout in a shared provider project after one host refreshes', () => {
+    const local = repo('local-repo', 'local')
+    const runtime = repo('runtime-repo', 'runtime:env-a')
+    const derived = projectCompatibilityFromRepos([local, runtime])
+    const fetched = projectHostSetupProjectionFromRepos([runtime])
+
+    const compatibility = mergeProjectHostSetupCompatibility(derived, fetched)
+
+    expect(compatibility.projects).toEqual([
+      expect.objectContaining({
+        id: 'github:stablyai/orca',
+        sourceRepoIds: ['local-repo', 'runtime-repo']
+      })
+    ])
+    expect(compatibility.projectHostSetups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ hostId: 'local', repoId: 'local-repo' }),
+        expect.objectContaining({ hostId: 'runtime:env-a', repoId: 'runtime-repo' })
+      ])
+    )
+  })
+
+  it('merges setup rows by host and repo when setup ids collide across hosts', () => {
+    const compatibility = mergeProjectHostSetupCompatibility(
+      {
+        projects: [],
+        projectHostSetups: [setup('same-id', 'local', 'repo-local')]
+      },
+      {
+        projects: [],
+        setups: [setup('same-id', 'runtime:env-a', 'repo-runtime')]
+      }
+    )
+
+    expect(compatibility.projectHostSetups).toEqual([
+      expect.objectContaining({ id: 'same-id', hostId: 'local', repoId: 'repo-local' }),
+      expect.objectContaining({ id: 'same-id', hostId: 'runtime:env-a', repoId: 'repo-runtime' })
+    ])
+  })
+})

--- a/src/renderer/src/store/slices/project-host-setup-compatibility-merge.ts
+++ b/src/renderer/src/store/slices/project-host-setup-compatibility-merge.ts
@@ -1,0 +1,82 @@
+import type { ProjectHostSetupProjection } from '../../../../shared/project-host-setup-projection'
+import { projectHostSetupProjectionFromRepos } from '../../../../shared/project-host-setup-projection'
+import type { Project, ProjectHostSetup, Repo } from '../../../../shared/types'
+
+export type ProjectHostSetupCompatibility = {
+  projects: Project[]
+  projectHostSetups: ProjectHostSetup[]
+}
+
+export function projectCompatibilityFromRepos(
+  repos: readonly Repo[]
+): ProjectHostSetupCompatibility {
+  const projection = projectHostSetupProjectionFromRepos(repos)
+  return {
+    projects: projection.projects,
+    projectHostSetups: projection.setups
+  }
+}
+
+export function mergeProjectHostSetupCompatibility(
+  derived: ProjectHostSetupCompatibility,
+  fetched: ProjectHostSetupProjection
+): ProjectHostSetupCompatibility {
+  const fetchedSetupOwners = new Set(fetched.setups.map(getProjectHostSetupOwnerKey))
+  const derivedSetups = derived.projectHostSetups.filter(
+    (setup) => !fetchedSetupOwners.has(getProjectHostSetupOwnerKey(setup))
+  )
+  const projectHostSetups = mergeByKey(
+    derivedSetups,
+    fetched.setups,
+    getProjectHostSetupOwnerKey,
+    (_base, overlay) => overlay
+  )
+  const setupProjectIds = new Set(projectHostSetups.map((setup) => setup.projectId))
+  const fetchedProjectIds = new Set(fetched.projects.map((project) => project.id))
+  return {
+    projects: mergeByKey(
+      derived.projects,
+      fetched.projects,
+      (project) => project.id,
+      mergeProject
+    ).filter((project) => fetchedProjectIds.has(project.id) || setupProjectIds.has(project.id)),
+    projectHostSetups
+  }
+}
+
+function getProjectHostSetupOwnerKey(setup: ProjectHostSetup): string {
+  // Why: setup ids can come from per-host repo ids. Host + repo is the durable
+  // ownership boundary when one project is checked out on multiple servers.
+  return `${setup.hostId}:${setup.repoId ?? setup.id}`
+}
+
+function mergeProject(base: Project, overlay: Project): Project {
+  return {
+    ...base,
+    ...overlay,
+    // Why: a one-host refresh may fetch a project row that only lists that
+    // host's checkout; keep the other host setups attached to the project.
+    sourceRepoIds: [...new Set([...base.sourceRepoIds, ...overlay.sourceRepoIds])]
+  }
+}
+
+function mergeByKey<T>(
+  base: readonly T[],
+  overlay: readonly T[],
+  getKey: (entry: T) => string,
+  mergeEntry: (base: T, overlay: T) => T
+): T[] {
+  const merged = [...base]
+  const indexByKey = new Map(merged.map((entry, index) => [getKey(entry), index]))
+  for (const entry of overlay) {
+    const key = getKey(entry)
+    const index = indexByKey.get(key)
+    if (index === undefined) {
+      indexByKey.set(key, merged.length)
+      merged.push(entry)
+    } else {
+      merged[index] = mergeEntry(merged[index], entry)
+    }
+  }
+  return merged
+}

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/types'
+import { mergeFetchedReposForHost } from './repo-host-refresh-merge'
+
+function repo(id: string, hostId: ExecutionHostId, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path: `/${hostId}/${id}`,
+    displayName: id,
+    badgeColor: '#000000',
+    addedAt: 1,
+    executionHostId: hostId,
+    ...overrides
+  }
+}
+
+function idsByHost(repos: readonly Repo[]): Record<string, string[]> {
+  const result: Record<string, string[]> = {}
+  for (const entry of repos) {
+    const hostId = getRepoExecutionHostId(entry)
+    result[hostId] ??= []
+    result[hostId].push(entry.id)
+  }
+  return result
+}
+
+describe('mergeFetchedReposForHost', () => {
+  it('refreshes one host without dropping repos owned by another host', () => {
+    const previous = [
+      repo('local-a', 'local'),
+      repo('runtime-a', 'runtime:env-a'),
+      repo('runtime-stale', 'runtime:env-a')
+    ]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('runtime-a', 'runtime:env-a', { displayName: 'runtime renamed' })],
+      'runtime:env-a'
+    )
+
+    expect(idsByHost(merged)).toEqual({
+      local: ['local-a'],
+      'runtime:env-a': ['runtime-a']
+    })
+    expect(merged.find((entry) => entry.id === 'runtime-a')?.displayName).toBe('runtime renamed')
+  })
+
+  it('matches repos by host and id instead of id alone', () => {
+    const previous = [
+      repo('same-id', 'local', { path: '/local/orca' }),
+      repo('same-id', 'runtime:env-a', { path: '/srv/orca-old' })
+    ]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('same-id', 'runtime:env-a', { path: '/srv/orca-new' })],
+      'runtime:env-a'
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(merged.find((entry) => getRepoExecutionHostId(entry) === 'local')?.path).toBe(
+      '/local/orca'
+    )
+    expect(merged.find((entry) => getRepoExecutionHostId(entry) === 'runtime:env-a')?.path).toBe(
+      '/srv/orca-new'
+    )
+  })
+
+  it('adds a same-id repo on a new host without replacing the existing host repo', () => {
+    const previous = [repo('same-id', 'local', { path: '/local/orca' })]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('same-id', 'runtime:env-a', { path: '/srv/orca' })],
+      'runtime:env-a'
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(idsByHost(merged)).toEqual({
+      local: ['same-id'],
+      'runtime:env-a': ['same-id']
+    })
+  })
+})

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.ts
@@ -1,0 +1,41 @@
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/types'
+import { reconcileFetchedRepos } from './repo-identity-reconcile'
+
+function getRepoOwnerKey(repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>): string {
+  // Why: repo ids are only guaranteed unique inside one host's store. A runtime
+  // refresh must not replace a same-id local or sibling-runtime checkout.
+  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
+}
+
+export function mergeFetchedReposForHost(
+  previous: readonly Repo[],
+  fetched: Repo[],
+  hostId: ExecutionHostId
+): Repo[] {
+  const fetchedOwnerKeys = new Set(fetched.map(getRepoOwnerKey))
+  const preserved = previous.filter((repo) => {
+    const existingHostId = getRepoExecutionHostId(repo)
+    return existingHostId !== hostId || fetchedOwnerKeys.has(getRepoOwnerKey(repo))
+  })
+  const preservedOwnerKeys = new Set(preserved.map(getRepoOwnerKey))
+  const merged = [...preserved]
+  const indexByOwnerKey = new Map(merged.map((repo, index) => [getRepoOwnerKey(repo), index]))
+  for (const repo of fetched) {
+    const ownerKey = getRepoOwnerKey(repo)
+    const existingIndex = indexByOwnerKey.get(ownerKey)
+    if (existingIndex === undefined) {
+      indexByOwnerKey.set(ownerKey, merged.length)
+      merged.push(repo)
+      continue
+    }
+    merged[existingIndex] = repo
+  }
+  return reconcileFetchedRepos(
+    previous,
+    merged.filter(
+      (repo) =>
+        preservedOwnerKeys.has(getRepoOwnerKey(repo)) || fetchedOwnerKeys.has(getRepoOwnerKey(repo))
+    )
+  )
+}

--- a/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
@@ -39,6 +39,22 @@ describe('reconcileFetchedRepos', () => {
     expect(result[0]).toBe(next[0])
   })
 
+  it('keys object reuse by repo id and execution host', () => {
+    const previous = [
+      makeRepo('same-id', { executionHostId: 'local', path: '/local/orca' }),
+      makeRepo('same-id', { executionHostId: 'runtime:env-a', path: '/srv/orca' })
+    ]
+    const next = [
+      makeRepo('same-id', { executionHostId: 'runtime:env-a', path: '/srv/orca' }),
+      makeRepo('same-id', { executionHostId: 'local', path: '/local/orca' })
+    ]
+
+    const result = reconcileFetchedRepos(previous, next)
+
+    expect(result[0]).toBe(previous[1])
+    expect(result[1]).toBe(previous[0])
+  })
+
   it('returns a rebuilt array when repos are added or removed', () => {
     const previous = [makeRepo('a')]
     const next = [makeRepo('a'), makeRepo('b')]

--- a/src/renderer/src/store/slices/repo-identity-reconcile.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.ts
@@ -1,3 +1,4 @@
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/types'
 
 // Why: after a drag-reorder we optimistically set `repos`, persist, and main
@@ -27,10 +28,10 @@ function areReposEqual(a: Repo, b: Repo): boolean {
 }
 
 export function reconcileFetchedRepos(previous: readonly Repo[], next: Repo[]): Repo[] {
-  const previousById = new Map(previous.map((repo) => [repo.id, repo]))
+  const previousByIdentity = new Map(previous.map((repo) => [getRepoIdentityKey(repo), repo]))
   let identical = next.length === previous.length
   const reconciled = next.map((repo, index) => {
-    const existing = previousById.get(repo.id)
+    const existing = previousByIdentity.get(getRepoIdentityKey(repo))
     if (existing && areReposEqual(existing, repo)) {
       if (existing !== previous[index]) {
         identical = false
@@ -41,4 +42,8 @@ export function reconcileFetchedRepos(previous: readonly Repo[], next: Repo[]): 
     return repo
   })
   return identical ? (previous as Repo[]) : reconciled
+}
+
+function getRepoIdentityKey(repo: Repo): string {
+  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
 }

--- a/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
+++ b/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Project, ProjectHostSetup, Repo } from '../../../../shared/types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const PROJECT_ID = 'github:stablyai/orca'
+
+const localRepo: Repo = {
+  id: 'local-repo',
+  path: '/Users/alice/orca',
+  displayName: 'orca',
+  badgeColor: '#000000',
+  addedAt: 1,
+  upstream: { owner: 'stablyai', repo: 'orca' }
+}
+
+const runtimeRepo: Repo = {
+  id: 'runtime-repo',
+  path: '/srv/orca',
+  displayName: 'orca',
+  badgeColor: '#111111',
+  addedAt: 2,
+  upstream: { owner: 'stablyai', repo: 'orca' }
+}
+
+function project(sourceRepoIds: string[]): Project {
+  return {
+    id: PROJECT_ID,
+    displayName: 'orca',
+    badgeColor: '#000000',
+    sourceRepoIds,
+    providerIdentity: { provider: 'github', owner: 'stablyai', repo: 'orca' },
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+function setup(hostId: 'local' | `runtime:${string}`, repoId: string): ProjectHostSetup {
+  return {
+    id: repoId,
+    projectId: PROJECT_ID,
+    hostId,
+    repoId,
+    path: repoId === localRepo.id ? localRepo.path : runtimeRepo.path,
+    displayName: 'orca',
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+const reposList = vi.fn()
+const projectsList = vi.fn()
+const projectsListHostSetups = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposList.mockReset()
+  projectsList.mockReset()
+  projectsListHostSetups.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: {
+        list: reposList
+      },
+      projects: {
+        list: projectsList,
+        listHostSetups: projectsListHostSetups
+      },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('repo slice multi-host refresh', () => {
+  it('keeps local and runtime checkouts for the same project after switching hosts', async () => {
+    reposList.mockResolvedValue([localRepo])
+    projectsList.mockResolvedValue([project([localRepo.id])])
+    projectsListHostSetups.mockResolvedValue([setup('local', localRepo.id)])
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'repo.list') {
+        return Promise.resolve({
+          id: 'repo-list',
+          ok: true,
+          result: { repos: [runtimeRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'project.list') {
+        return Promise.resolve({
+          id: 'project-list',
+          ok: true,
+          result: { projects: [project([runtimeRepo.id])] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          id: 'setup-list',
+          ok: true,
+          result: { setups: [setup('runtime:env-1', runtimeRepo.id)] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${method}`)
+    })
+    const store = createTestStore()
+
+    await store.getState().fetchRepos()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().repos).toEqual([
+      expect.objectContaining({ id: localRepo.id, executionHostId: 'local' }),
+      expect.objectContaining({ id: runtimeRepo.id, executionHostId: 'runtime:env-1' })
+    ])
+    expect(store.getState().projects).toEqual([
+      expect.objectContaining({
+        id: PROJECT_ID,
+        sourceRepoIds: [localRepo.id, runtimeRepo.id]
+      })
+    ])
+    expect(store.getState().projectHostSetups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ hostId: 'local', repoId: localRepo.id }),
+        expect.objectContaining({ hostId: 'runtime:env-1', repoId: runtimeRepo.id })
+      ])
+    )
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -45,8 +45,12 @@ import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
 import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
 import { getRepoIdFromWorktreeId } from './worktree-helpers'
-import { reconcileFetchedRepos } from './repo-identity-reconcile'
+import { mergeFetchedReposForHost } from './repo-host-refresh-merge'
 import { splitRepoReorderByHost } from './repo-reorder-host-split'
+import {
+  mergeProjectHostSetupCompatibility,
+  projectCompatibilityFromRepos
+} from './project-host-setup-compatibility-merge'
 import {
   assertRuntimeEnvironmentCapability,
   callRuntimeRpc,
@@ -381,80 +385,6 @@ async function assertProjectHostSetupMutationRuntimeCapabilities(
     WORKSPACE_RUN_CONTEXT_RUNTIME_CAPABILITY,
     'The selected Orca server does not support explicit workspace run hosts yet. Update Orca on the server and try again.',
     15_000
-  )
-}
-
-function projectCompatibilityFromRepos(
-  repos: readonly Repo[]
-): Pick<RepoSlice, 'projects' | 'projectHostSetups'> {
-  const projection = projectHostSetupProjectionFromRepos(repos)
-  return {
-    projects: projection.projects,
-    projectHostSetups: projection.setups
-  }
-}
-
-function mergeProjectHostSetupCompatibility(
-  derived: Pick<RepoSlice, 'projects' | 'projectHostSetups'>,
-  fetched: ProjectHostSetupProjection
-): Pick<RepoSlice, 'projects' | 'projectHostSetups'> {
-  const fetchedSetupOwners = new Set(fetched.setups.map(getProjectHostSetupOwnerKey))
-  const derivedSetups = derived.projectHostSetups.filter(
-    (setup) => !fetchedSetupOwners.has(getProjectHostSetupOwnerKey(setup))
-  )
-  const projectHostSetups = mergeById(derivedSetups, fetched.setups)
-  const setupProjectIds = new Set(projectHostSetups.map((setup) => setup.projectId))
-  const fetchedProjectIds = new Set(fetched.projects.map((project) => project.id))
-  return {
-    projects: mergeById(derived.projects, fetched.projects).filter(
-      (project) => fetchedProjectIds.has(project.id) || setupProjectIds.has(project.id)
-    ),
-    projectHostSetups
-  }
-}
-
-function getProjectHostSetupOwnerKey(setup: ProjectHostSetup): string {
-  return `${setup.hostId}:${setup.repoId ?? setup.id}`
-}
-
-function mergeById<T extends { id: string }>(base: readonly T[], overlay: readonly T[]): T[] {
-  const merged = [...base]
-  const indexById = new Map(merged.map((entry, index) => [entry.id, index]))
-  for (const entry of overlay) {
-    const index = indexById.get(entry.id)
-    if (index === undefined) {
-      indexById.set(entry.id, merged.length)
-      merged.push(entry)
-    } else {
-      merged[index] = entry
-    }
-  }
-  return merged
-}
-
-function mergeFetchedReposForHost(
-  previous: readonly Repo[],
-  fetched: Repo[],
-  hostId: string
-): Repo[] {
-  const fetchedIds = new Set(fetched.map((repo) => repo.id))
-  const preserved = previous.filter((repo) => {
-    const existingHostId = getRepoExecutionHostId(repo)
-    return existingHostId !== hostId || fetchedIds.has(repo.id)
-  })
-  const preservedById = new Map(preserved.map((repo) => [repo.id, repo]))
-  const merged = [...preserved]
-  for (const repo of fetched) {
-    const existingIndex = merged.findIndex((entry) => entry.id === repo.id)
-    if (existingIndex === -1) {
-      merged.push(repo)
-      continue
-    }
-    merged[existingIndex] = repo
-  }
-  return reconcileFetchedRepos(
-    previous,
-    merged.filter((repo) => preservedById.has(repo.id) || fetchedIds.has(repo.id))
   )
 }
 


### PR DESCRIPTION
## Summary
- Add a worksheet for multi-server repo refresh invariants and future seams.
- Extract host-scoped repo refresh and project/setup compatibility merge helpers.
- Add direct, generated, and store-level tests for local/runtime project refresh state.

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/repo-host-refresh-merge.test.ts src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts src/renderer/src/store/slices/multi-host-repo-refresh.property.test.ts src/renderer/src/store/slices/repos-multi-host-refresh.test.ts src/renderer/src/store/slices/repo-identity-reconcile.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/store/slices/repo-host-refresh-merge.ts src/renderer/src/store/slices/repo-host-refresh-merge.test.ts src/renderer/src/store/slices/project-host-setup-compatibility-merge.ts src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts src/renderer/src/store/slices/multi-host-repo-refresh.property.test.ts src/renderer/src/store/slices/repos-multi-host-refresh.test.ts src/renderer/src/store/slices/repo-identity-reconcile.ts src/renderer/src/store/slices/repo-identity-reconcile.test.ts src/renderer/src/store/slices/repos.ts`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->