### PR TITLE
fix(terminal): don't apply native-Windows ConPTY cursor stripping to remote serve PTYs

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -57,7 +57,7 @@ import {
   writeTerminalOutput
 } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { recordAgentHibernationPaneOutput } from '@/lib/agent-hibernation-output-activity'
-import { isLocalNativeWindowsPty } from '@/lib/pane-manager/windows-pty-compatibility'
+import { isLocalNativeWindowsConpty } from '@/lib/pane-manager/windows-pty-compatibility'
 import { recordTerminalOutput, restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
@@ -97,7 +97,10 @@ import {
   cancelScheduledHiddenOutputRestore,
   scheduleHiddenOutputRestore
 } from './hidden-output-restore-scheduler'
-import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  getExecutionHostIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree
+} from '@/lib/worktree-runtime-owner'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
 import { resolveAgentStatusTerminalTitle } from '@/lib/agent-status-terminal-title'
@@ -1606,11 +1609,18 @@ export function connectPanePty(
   const connectionId = getConnectionId(deps.worktreeId) ?? null
   const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find((t) => t.id === deps.tabId)
   const shellOverride = tab?.shellOverride
-  const isNativeWindowsConpty = isLocalNativeWindowsPty({
+  // Why: a serve/remote-runtime pane has no SSH connectionId and a Linux cwd, so
+  // the native-Windows ConPTY heuristic misfires on a Windows client and wrongly
+  // enables ConPTY synchronized-output protection — which strips an agent's
+  // transient cursor-show (?25h) and leaves the cursor invisible. The execution
+  // host is the authoritative signal: only a 'local' host is a local native PTY.
+  const executionHostId = getExecutionHostIdForWorktree(state, deps.worktreeId)
+  const isNativeWindowsConpty = isLocalNativeWindowsConpty({
     userAgent: navigator.userAgent,
     connectionId,
     cwd: deps.cwd,
-    shellOverride
+    shellOverride,
+    executionHostId
   })
   const shouldApplyNativeWindowsRewriteRefresh = isNativeWindowsConpty
   const shouldProtectNativeWindowsSynchronizedOutput = isNativeWindowsConpty

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1611,7 +1611,7 @@ export function connectPanePty(
   const shellOverride = tab?.shellOverride
   // Why: a serve/remote-runtime pane has no SSH connectionId and a Linux cwd, so
   // the native-Windows ConPTY heuristic misfires on a Windows client and wrongly
-  // enables ConPTY synchronized-output protection — which strips an agent's
+  // enables ConPTY synchronized-output protection, which strips an agent's
   // transient cursor-show (?25h) and leaves the cursor invisible. The execution
   // host is the authoritative signal: only a 'local' host is a local native PTY.
   const executionHostId = getExecutionHostIdForWorktree(state, deps.worktreeId)

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
@@ -118,6 +118,12 @@ describe('isLocalNativeWindowsConpty', () => {
     cwd: 'C:\\repo',
     shellOverride: 'powershell.exe'
   } as const
+  const remoteServePaneOnWindowsClientContext = {
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+    connectionId: null,
+    cwd: '/home/me/repo',
+    shellOverride: null
+  } as const
 
   it('treats a local-execution-host Windows pane as a native ConPTY', () => {
     expect(
@@ -127,13 +133,13 @@ describe('isLocalNativeWindowsConpty', () => {
 
   it('does NOT treat a remote-runtime (serve) pane as a native ConPTY even when the raw Windows heuristic matches', () => {
     // Regression: a serve-hosted pane on a Windows client has no SSH connectionId
-    // and (after path mapping) a Windows-looking cwd, so isLocalNativeWindowsPty
-    // returns true. Without the execution-host gate, ConPTY transient cursor-show
-    // (?25h) stripping is wrongly applied and the agent cursor disappears.
-    expect(isLocalNativeWindowsPty(localNativeWindowsContext)).toBe(true)
+    // and a Linux cwd, so isLocalNativeWindowsPty returns true. Without the
+    // execution-host gate, ConPTY transient cursor-show (?25h) stripping is
+    // wrongly applied and the agent cursor disappears.
+    expect(isLocalNativeWindowsPty(remoteServePaneOnWindowsClientContext)).toBe(true)
     expect(
       isLocalNativeWindowsConpty({
-        ...localNativeWindowsContext,
+        ...remoteServePaneOnWindowsClientContext,
         executionHostId: 'runtime:my-serve'
       })
     ).toBe(false)

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildWindowsPtyCompatibilityOptions,
+  isLocalNativeWindowsConpty,
   isLocalNativeWindowsPty
 } from './windows-pty-compatibility'
 
@@ -103,6 +104,73 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
         connectionId: 'ssh-1',
         cwd: 'C:\\repo',
         shellOverride: 'powershell.exe'
+      })
+    ).toBe(false)
+  })
+})
+
+describe('isLocalNativeWindowsConpty', () => {
+  // A genuine local native Windows ConPTY (Windows UA, no SSH connectionId,
+  // Windows cwd) on a 'local' execution host must keep the ConPTY workarounds.
+  const localNativeWindowsContext = {
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+    connectionId: null,
+    cwd: 'C:\\repo',
+    shellOverride: 'powershell.exe'
+  } as const
+
+  it('treats a local-execution-host Windows pane as a native ConPTY', () => {
+    expect(
+      isLocalNativeWindowsConpty({ ...localNativeWindowsContext, executionHostId: 'local' })
+    ).toBe(true)
+  })
+
+  it('does NOT treat a remote-runtime (serve) pane as a native ConPTY even when the raw Windows heuristic matches', () => {
+    // Regression: a serve-hosted pane on a Windows client has no SSH connectionId
+    // and (after path mapping) a Windows-looking cwd, so isLocalNativeWindowsPty
+    // returns true. Without the execution-host gate, ConPTY transient cursor-show
+    // (?25h) stripping is wrongly applied and the agent cursor disappears.
+    expect(isLocalNativeWindowsPty(localNativeWindowsContext)).toBe(true)
+    expect(
+      isLocalNativeWindowsConpty({
+        ...localNativeWindowsContext,
+        executionHostId: 'runtime:my-serve'
+      })
+    ).toBe(false)
+  })
+
+  it('does NOT treat an SSH-runtime pane as a native ConPTY', () => {
+    expect(
+      isLocalNativeWindowsConpty({
+        ...localNativeWindowsContext,
+        executionHostId: 'ssh:my-host'
+      })
+    ).toBe(false)
+  })
+
+  it('stays false on a local host when the pane is not a native Windows PTY', () => {
+    // Non-Windows client: the raw heuristic is false, so the gate result is false
+    // regardless of the local execution host.
+    expect(
+      isLocalNativeWindowsConpty({
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)',
+        connectionId: null,
+        cwd: '/repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      })
+    ).toBe(false)
+  })
+
+  it('does not let a local execution host re-enable protection the raw heuristic already suppressed', () => {
+    // Guards the AND: even on a 'local' host, a Windows pane excluded for a
+    // non-execution-host reason (here an SSH connectionId) must stay false, so a
+    // future refactor cannot make the local host bypass the raw checks.
+    expect(
+      isLocalNativeWindowsConpty({
+        ...localNativeWindowsContext,
+        connectionId: 'ssh-1',
+        executionHostId: 'local'
       })
     ).toBe(false)
   })

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
@@ -66,7 +66,7 @@ export function isLocalNativeWindowsPty(context: WindowsPtyCompatibilityContext)
  * Why this is gated on the execution host: a serve/remote-runtime pane on a
  * Windows client has no SSH `connectionId` and a Linux `cwd`, so
  * `isLocalNativeWindowsPty` misfires and classifies it as local. The execution
- * host is the authoritative signal — only a `'local'` host is a real local
+ * host is the authoritative signal: only a `'local'` host is a real local
  * native PTY. Remote panes resolve to `runtime:<env>` (or `ssh:<target>`) and
  * must be excluded, otherwise ConPTY transient cursor-show (`?25h`) stripping is
  * wrongly applied to them and a repainting agent's cursor disappears.

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
@@ -1,5 +1,6 @@
 import type { ITerminalOptions } from '@xterm/xterm'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../../shared/execution-host'
 
 export type WindowsPtyCompatibilityContext = {
   userAgent?: string
@@ -56,4 +57,22 @@ export function isLocalNativeWindowsPty(context: WindowsPtyCompatibilityContext)
     return false
   }
   return true
+}
+
+/**
+ * Whether a pane is a genuine local native Windows ConPTY that needs the ConPTY
+ * cursor/synchronized-output workarounds.
+ *
+ * Why this is gated on the execution host: a serve/remote-runtime pane on a
+ * Windows client has no SSH `connectionId` and a Linux `cwd`, so
+ * `isLocalNativeWindowsPty` misfires and classifies it as local. The execution
+ * host is the authoritative signal — only a `'local'` host is a real local
+ * native PTY. Remote panes resolve to `runtime:<env>` (or `ssh:<target>`) and
+ * must be excluded, otherwise ConPTY transient cursor-show (`?25h`) stripping is
+ * wrongly applied to them and a repainting agent's cursor disappears.
+ */
+export function isLocalNativeWindowsConpty(
+  context: WindowsPtyCompatibilityContext & { executionHostId: ExecutionHostId }
+): boolean {
+  return context.executionHostId === LOCAL_EXECUTION_HOST_ID && isLocalNativeWindowsPty(context)
 }


### PR DESCRIPTION
Closes #6008

## Summary

The text cursor is invisible for the entire time a repainting CLI agent (`claude` / Claude Code)
runs in a **serve-hosted (remote-runtime) terminal on a Windows client**, and reappears on exit.
Local terminals and non-Windows clients are unaffected. This scopes the native-Windows ConPTY
cursor protection to genuinely local native PTYs so it stops corrupting remote panes.

## Root cause

On a Windows client, a serve/remote-runtime pane has **no SSH `connectionId`** (`null`) and a
**Linux `cwd`**. `isLocalNativeWindowsPty()` misfires on that shape and classifies the remote pane
as a local native Windows ConPTY. That enables ConPTY synchronized-output protection, whose write
path runs `stripTransientCursorShows` — which strips the agent's transient `ESC[?25h` cursor-show
sequences, so the cursor is never drawn while the agent runs. The stripper keeps the final
non-transient `?25h`, so the shell cursor returns on exit (the observed symptom). Windows-only
because the heuristic requires a Windows user agent.

## Fix

Renderer-only. The native-Windows-ConPTY decision is extracted into a pure, unit-testable predicate
`isLocalNativeWindowsConpty()` in
`src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts`, gated on the authoritative
**execution host**. Only `executionHostId === 'local'` is a real local native PTY; serve/remote
panes resolve to `runtime:<env>` (or `ssh:<target>`) and are excluded. The single production caller
(`src/renderer/src/components/terminal-pane/pty-connection.ts`) passes the host into the predicate:

```ts
// windows-pty-compatibility.ts
export function isLocalNativeWindowsConpty(
  context: WindowsPtyCompatibilityContext & { executionHostId: ExecutionHostId }
): boolean {
  return context.executionHostId === LOCAL_EXECUTION_HOST_ID && isLocalNativeWindowsPty(context)
}

// pty-connection.ts (connectPanePty)
const executionHostId = getExecutionHostIdForWorktree(state, deps.worktreeId)
const isNativeWindowsConpty = isLocalNativeWindowsConpty({
  userAgent: navigator.userAgent, connectionId, cwd: deps.cwd, shellOverride, executionHostId
})
```

Extracting the predicate (rather than inlining `executionHostId === 'local' && …`) lets the
regression test import the exact production logic, so a future Windows-only re-narrow can't silently
pass CI on Linux. No serve-side, main-process, preload, or native-module changes. This is a strict
*narrowing* of an existing gate — it can only turn the protection OFF for panes that should never
have had it, never ON for new panes.

Files changed (3): `pty-connection.ts` (wire to predicate), `windows-pty-compatibility.ts` (new
predicate), `windows-pty-compatibility.test.ts` (5 regression tests). Net +101/−4.

## Visual change

This is a visible change: in a `claude` session in a serve pane on the Windows client the
text cursor goes from **absent for the whole session** (the bug) to **drawn normally while the
agent runs** (after the fix). Verified by a live on-screen check on a Windows client paired to a
Linux `orca serve`. No screenshots attached.

## Testing

Run on a clean `origin/main + this change` worktree:

- [x] `pnpm lint` — **pass** (oxlint, switch-exhaustiveness, styled-scrollbars, localization catalog + coverage)
- [x] `pnpm typecheck` — **pass** (node, cli, web tsconfigs)
- [x] `pnpm test` — **pass for this change**: the 5 new predicate tests pass and the change adds
      **zero** regressions. Verified by running the full suite twice on the same machine:
      pristine `origin/main` and `origin/main + this change` produced an **identical** failure set
      (the pre-existing failures are environmental — this dev box runs Node 20 while the repo
      requires Node 24); the only delta was **+5 passing tests** (the new ones).
- [x] `pnpm build:desktop` — **pass** (main + preload + renderer + web all bundle; the renderer
      bundle includes this change)
- [ ] `pnpm build:native` — not run here: it compiles unrelated native C++ modules and needs the
      Node 24 toolchain (`fs.globSync` in the postinstall native rebuild). A renderer-only TS change
      cannot affect it; it will run in CI on Node 24.

**Regression test (done):** the boolean was extracted into a pure predicate
`isLocalNativeWindowsConpty()` imported by both production and the test, so a Windows-only re-narrow
cannot silently pass CI on Linux. Tests assert: `local` host + raw-true → `true`; `runtime:<env>`
and `ssh:<target>` hosts → `false` even when the raw Windows heuristic returns `true` (the bug
scenario, explicitly asserted); non-Windows client → `false`; and `local` host cannot re-enable
protection the raw heuristic already suppressed.

## Cross-platform / SSH

The change is keyed on `executionHostId`, not on platform. macOS/Linux clients already returned
`false` from the raw heuristic, so their behavior is unchanged; Windows local native ConPTYs still
resolve to `'local'` and keep the protection. SSH panes carry a `connectionId` so the raw heuristic
already excluded them; serve/remote panes are now correctly excluded too. The execution-host routing
this relies on is the same model used by the git/file/terminal-stream clients.

## AI Review Report

Reviewed by two independent AI coding agents — Gemini (t2, via the Antigravity CLI) and a separate
reviewer agent — each verifying the findings against the actual source rather than a summary. **Both
returned PASS, with no critical or major findings.** Coverage of the required dimensions:

- **Cross-platform (macOS / Linux / Windows):** Low risk. The gate keys on `executionHostId`, not on
  platform; macOS/Linux clients already return `false` from the raw Windows heuristic and are
  unchanged, while genuine local Windows ConPTYs resolve to `'local'` and keep the protection. No
  platform-conditional code paths were added.
- **SSH / remote / local:** Low risk — this is the fix's purpose. `local` keeps the protection;
  `runtime:<env>` and `ssh:<target>` are excluded. `getExecutionHostIdForWorktree` resolves folder
  workspaces, explicit repo owners, and the active-runtime fallback.
- **Agent / integration compatibility:** Low risk; a strict improvement that restores the repainting
  CLI-agent cursor on remote panes. Local-agent behaviour is unchanged. No agent-specific branching.
- **Performance:** No risk. The gate is evaluated **once per pane connection** in `connectPanePty`
  (`pty-connection.ts:1617-1626`); the per-write PTY output path (`writePtyOutputToXterm`) only reads
  the pre-computed boolean. Zero added cost on the hot path.
- **UI quality:** No regression for genuine local Windows ConPTY panes — they still satisfy
  `executionHostId === 'local'` and keep cursor-show stripping + synchronized-output protection
  (positive-control test present).
- **Test quality:** 5 new predicate tests. The regression test asserts the raw heuristic misfires
  (`isLocalNativeWindowsPty` → `true`) yet the gated predicate returns `false` for `runtime:`/`ssh:`
  hosts — it would fail without the fix. Positive control + AND-integrity cases present.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface.
The only added import is the same-repo `LOCAL_EXECUTION_HOST_ID` / `ExecutionHostId`. No new regex or
string manipulation is added to the PTY stream; the change *narrows* the scope of the pre-existing
`?25h` `indexOf`-based stripping (no ReDoS — there is no regex on the stream). One pre-existing,
out-of-scope observation surfaced by review: a `\x1b[?25h` sequence split across PTY chunks is not
matched by the single-string stripper — this PR neither introduces nor worsens it and in fact reduces
exposure by removing remote panes from that path. No security follow-up is required for this change.

## Follow-up (out of scope for this PR)

`buildWindowsPtyCompatibilityOptions` (used by `use-terminal-pane-lifecycle.ts`) still calls the
ungated `isLocalNativeWindowsPty` and would similarly misfire on a serve pane — but it only selects
xterm's `windowsPty` backend/build-number wrap heuristic, **not** the cursor-show stripping path, so
it does not cause this bug. Tracking it as a separate consistency follow-up (#6022 / PR #6027) rather
than widening this single-topic fix.

## Alternatives considered

- **Serve-side coalescing** of the output burst so the stripper isn't needed — rejected: the
  stripper was never meant to run on remote panes at all; the correct fix is to stop misclassifying
  them, not to compensate downstream.
- **Broadening the protection to remote PTYs** (an earlier, abandoned approach) — empirically wrong:
  the protection is what *causes* the bug here, so adding more of it made it worse.

Contributor: GitHub @LesleyMurfin.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6009">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
