### PR TITLE
Fix WSL agent session history

### DIFF
--- a/src/main/ai-vault/session-scanner-droid-kimi-sources.ts
+++ b/src/main/ai-vault/session-scanner-droid-kimi-sources.ts
@@ -1,0 +1,61 @@
+import { homedir } from 'os'
+import { basename, dirname, join } from 'path'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { discoverFiles } from './session-scanner-discovery'
+import { resolveKimiSessionsDir } from './session-scanner-kimi-paths'
+import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner-types'
+
+const DROID_SESSIONS_DIR = join(homedir(), '.factory', 'sessions')
+
+export function droidDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return [
+    ...sessionRootDirs(options.droidSessionsDir ?? DROID_SESSIONS_DIR, wslHomeDirs, [
+      '.factory',
+      'sessions'
+    ]),
+    ...sessionRootDirs(
+      options.droidProjectsDir ?? join(homedir(), '.factory', 'projects'),
+      wslHomeDirs,
+      ['.factory', 'projects']
+    )
+  ].map((rootDir) =>
+    discoverFiles({ rootDir, limit, agent: 'droid', issues, extensions: ['.jsonl'] })
+  )
+}
+
+export function kimiDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return sessionRootDirs(resolveKimiSessionsDir(options.kimiSessionsDir), wslHomeDirs, [
+    '.kimi-code',
+    'sessions'
+  ]).map((rootDir) =>
+    discoverFiles({
+      rootDir,
+      limit,
+      agent: 'kimi',
+      issues,
+      extensions: ['.json'],
+      // Why: each Kimi session is <sessions>/wd_*/session_*/state.json; match
+      // only those (not the sibling agents/*/wire.jsonl transcripts).
+      filePredicate: (path) =>
+        basename(path) === 'state.json' && basename(dirname(path)).startsWith('session_')
+    })
+  )
+}
+
+function sessionRootDirs(
+  hostRootDir: string,
+  wslHomeDirs: readonly string[],
+  segments: readonly string[]
+): string[] {
+  return [hostRootDir, ...wslHomeDirs.map((homeDir) => join(homeDir, ...segments))]
+}

--- a/src/main/ai-vault/session-scanner-source-discovery.ts
+++ b/src/main/ai-vault/session-scanner-source-discovery.ts
@@ -1,0 +1,290 @@
+import { homedir } from 'os'
+import { basename, join } from 'path'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { uniqueCodexSessionsDirs } from './session-scanner-codex-paths'
+import { discoverFiles, discoverOpenClawFiles } from './session-scanner-discovery'
+import { droidDiscoveries, kimiDiscoveries } from './session-scanner-droid-kimi-sources'
+import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner-types'
+import { normalizePiSessionsDir } from './session-scanner-values'
+
+const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects')
+export const DEFAULT_CODEX_HOME_DIR = join(homedir(), '.codex')
+const CODEX_HOME_DIR = process.env.CODEX_HOME?.trim() || DEFAULT_CODEX_HOME_DIR
+const CODEX_SESSIONS_DIR = join(CODEX_HOME_DIR, 'sessions')
+const GEMINI_SESSIONS_DIR = join(homedir(), '.gemini', 'tmp')
+const COPILOT_SESSIONS_DIR = join(
+  process.env.COPILOT_HOME?.trim() || join(homedir(), '.copilot'),
+  'session-state'
+)
+const CURSOR_PROJECTS_DIR = join(homedir(), '.cursor', 'projects')
+const OPENCODE_STORAGE_DIR = join(
+  process.env.OPENCODE_CONFIG_DIR?.trim() || join(homedir(), '.local', 'share', 'opencode'),
+  'storage'
+)
+const GROK_SESSIONS_DIR = join(
+  process.env.GROK_HOME?.trim() || join(homedir(), '.grok'),
+  'sessions'
+)
+const HERMES_SESSIONS_DIR = join(homedir(), '.hermes', 'sessions')
+const ROVO_SESSIONS_DIR = join(homedir(), '.rovodev', 'sessions')
+const OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_DIR?.trim() || join(homedir(), '.openclaw')
+const PI_SESSIONS_DIR = normalizePiSessionsDir(
+  process.env.PI_CODING_AGENT_DIR?.trim() || join(homedir(), '.pi', 'agent', 'sessions')
+)
+// Why: Devin ATIF transcripts are stored under <DEVIN_HOME>/transcripts.
+const DEVIN_TRANSCRIPTS_DIR = join(
+  process.env.DEVIN_HOME?.trim() || join(homedir(), '.local', 'share', 'devin', 'cli'),
+  'transcripts'
+)
+
+export async function discoverAiVaultSessionSources(args: {
+  options: AiVaultScanOptions
+  limitPerAgent: number
+  issues: AiVaultScanIssue[]
+}): Promise<SessionFileDiscovery[]> {
+  const { options, limitPerAgent, issues } = args
+  const wslHomeDirs = normalizedWslHomeDirs(options.wslHomeDirs)
+  const codexSessionsDirs = uniqueCodexSessionsDirs([
+    options.codexSessionsDir ?? CODEX_SESSIONS_DIR,
+    ...wslHomeDirs.map((homeDir) => join(homeDir, '.codex', 'sessions')),
+    // Why: Orca-launched WSL Codex sessions use an Orca-owned CODEX_HOME,
+    // not the user's default ~/.codex history root.
+    ...wslHomeDirs.map((homeDir) =>
+      join(homeDir, '.local', 'share', 'orca', 'codex-runtime-home', 'home', 'sessions')
+    ),
+    ...(options.additionalCodexSessionsDirs ?? [])
+  ])
+
+  return Promise.all<SessionFileDiscovery>([
+    ...claudeDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
+    ...codexDiscoveries(codexSessionsDirs, limitPerAgent, issues),
+    ...standardDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
+    openClawDiscovery(options, wslHomeDirs, limitPerAgent, issues),
+    ...droidDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
+    ...kimiDiscoveries(options, wslHomeDirs, limitPerAgent, issues)
+  ])
+}
+
+function claudeDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return [
+    options.claudeProjectsDir ?? CLAUDE_PROJECTS_DIR,
+    ...wslHomeDirs.map((homeDir) => join(homeDir, '.claude', 'projects'))
+  ].map((rootDir) =>
+    discoverFiles({ rootDir, limit, agent: 'claude', issues, extensions: ['.jsonl'] })
+  )
+}
+
+function codexDiscoveries(
+  rootDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return rootDirs.map((rootDir) =>
+    discoverFiles({ rootDir, limit, agent: 'codex', issues, extensions: ['.jsonl'] })
+  )
+}
+
+function standardDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return [
+    ...sessionRootDirs(options.geminiSessionsDir ?? GEMINI_SESSIONS_DIR, wslHomeDirs, [
+      '.gemini',
+      'tmp'
+    ]).map((rootDir) =>
+      discoverFiles({ rootDir, limit, agent: 'gemini', issues, extensions: ['.json', '.jsonl'] })
+    ),
+    ...sessionRootDirs(options.copilotSessionsDir ?? COPILOT_SESSIONS_DIR, wslHomeDirs, [
+      '.copilot',
+      'session-state'
+    ]).map((rootDir) =>
+      discoverFiles({ rootDir, limit, agent: 'copilot', issues, extensions: ['.jsonl'] })
+    ),
+    ...cursorDiscoveries(options, wslHomeDirs, limit, issues),
+    ...opencodeDiscoveries(options, wslHomeDirs, limit, issues),
+    ...grokDiscoveries(options, wslHomeDirs, limit, issues),
+    ...devinDiscoveries(options, wslHomeDirs, limit, issues),
+    ...hermesDiscoveries(options, wslHomeDirs, limit, issues),
+    ...rovoDiscoveries(options, wslHomeDirs, limit, issues),
+    ...piDiscoveries(options, wslHomeDirs, limit, issues)
+  ]
+}
+
+function cursorDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return sessionRootDirs(options.cursorProjectsDir ?? CURSOR_PROJECTS_DIR, wslHomeDirs, [
+    '.cursor',
+    'projects'
+  ]).map((rootDir) =>
+    discoverFiles({
+      rootDir,
+      limit,
+      agent: 'cursor',
+      issues,
+      extensions: ['.jsonl'],
+      filePredicate: (path) => path.split(/[\\/]/).includes('agent-transcripts')
+    })
+  )
+}
+
+function opencodeDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return sessionRootDirs(
+    join(options.opencodeStorageDir ?? OPENCODE_STORAGE_DIR, 'session'),
+    wslHomeDirs,
+    ['.local', 'share', 'opencode', 'storage', 'session']
+  ).map((rootDir) =>
+    discoverFiles({ rootDir, limit, agent: 'opencode', issues, extensions: ['.json'] })
+  )
+}
+
+function grokDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return sessionRootDirs(options.grokSessionsDir ?? GROK_SESSIONS_DIR, wslHomeDirs, [
+    '.grok',
+    'sessions'
+  ]).map((rootDir) =>
+    discoverFiles({
+      rootDir,
+      limit,
+      agent: 'grok',
+      issues,
+      extensions: ['.json'],
+      filePredicate: (path) => basename(path) === 'summary.json'
+    })
+  )
+}
+
+function devinDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return sessionRootDirs(options.devinTranscriptsDir ?? DEVIN_TRANSCRIPTS_DIR, wslHomeDirs, [
+    '.local',
+    'share',
+    'devin',
+    'cli',
+    'transcripts'
+  ]).map((rootDir) =>
+    discoverFiles({ rootDir, limit, agent: 'devin', issues, extensions: ['.json'] })
+  )
+}
+
+function hermesDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return sessionRootDirs(options.hermesSessionsDir ?? HERMES_SESSIONS_DIR, wslHomeDirs, [
+    '.hermes',
+    'sessions'
+  ]).map((rootDir) =>
+    discoverFiles({
+      rootDir,
+      limit,
+      agent: 'hermes',
+      issues,
+      extensions: ['.json'],
+      filePredicate: (path) => basename(path).startsWith('session_')
+    })
+  )
+}
+
+function rovoDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return sessionRootDirs(options.rovoSessionsDir ?? ROVO_SESSIONS_DIR, wslHomeDirs, [
+    '.rovodev',
+    'sessions'
+  ]).map((rootDir) =>
+    discoverFiles({
+      rootDir,
+      limit,
+      agent: 'rovo',
+      issues,
+      extensions: ['.json'],
+      filePredicate: (path) => basename(path) === 'metadata.json'
+    })
+  )
+}
+
+function piDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  return sessionRootDirs(options.piSessionsDir ?? PI_SESSIONS_DIR, wslHomeDirs, [
+    '.pi',
+    'agent',
+    'sessions'
+  ]).map((rootDir) =>
+    discoverFiles({ rootDir, limit, agent: 'pi', issues, extensions: ['.jsonl'] })
+  )
+}
+
+function openClawDiscovery(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery> {
+  return discoverOpenClawFiles({
+    rootDirs: [
+      options.openclawStateDir ?? OPENCLAW_STATE_DIR,
+      options.openclawLegacyStateDir ?? join(homedir(), '.clawdbot'),
+      ...wslHomeDirs.map((homeDir) => join(homeDir, '.openclaw')),
+      ...wslHomeDirs.map((homeDir) => join(homeDir, '.clawdbot'))
+    ],
+    limit,
+    issues
+  })
+}
+
+function normalizedWslHomeDirs(homeDirs: readonly string[] | undefined): string[] {
+  const seen = new Set<string>()
+  const unique: string[] = []
+  for (const homeDir of homeDirs ?? []) {
+    const trimmed = homeDir.trim()
+    if (!trimmed || seen.has(trimmed)) {
+      continue
+    }
+    seen.add(trimmed)
+    unique.push(trimmed)
+  }
+  return unique
+}
+
+function sessionRootDirs(
+  hostRootDir: string,
+  wslHomeDirs: readonly string[],
+  segments: readonly string[]
+): string[] {
+  return [hostRootDir, ...wslHomeDirs.map((homeDir) => join(homeDir, ...segments))]
+}

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -9,6 +9,7 @@ export type AiVaultScanOptions = {
   claudeProjectsDir?: string
   codexSessionsDir?: string
   additionalCodexSessionsDirs?: readonly string[]
+  wslHomeDirs?: readonly string[]
   geminiSessionsDir?: string
   copilotSessionsDir?: string
   cursorProjectsDir?: string

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -252,6 +252,76 @@ describe('scanAiVaultSessions', () => {
     })
   })
 
+  it('indexes WSL home session roots', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-wsl-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const wslHome = join(root, 'wsl', 'Ubuntu', 'home', 'ada')
+    await mkdir(join(wslHome, '.claude', 'projects', 'repo'), { recursive: true })
+    await mkdir(
+      join(wslHome, '.local', 'share', 'orca', 'codex-runtime-home', 'home', 'sessions'),
+      {
+        recursive: true
+      }
+    )
+
+    await writeFile(
+      join(wslHome, '.claude', 'projects', 'repo', 'claude-wsl.jsonl'),
+      jsonLines([
+        {
+          type: 'user',
+          sessionId: 'claude-wsl',
+          timestamp: '2026-06-10T10:00:00.000Z',
+          cwd: '/home/ada/repo',
+          message: { role: 'user', content: 'Claude WSL title' }
+        }
+      ])
+    )
+    await writeFile(
+      join(
+        wslHome,
+        '.local',
+        'share',
+        'orca',
+        'codex-runtime-home',
+        'home',
+        'sessions',
+        'codex-wsl.jsonl'
+      ),
+      jsonLines([
+        {
+          timestamp: '2026-06-10T10:01:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'codex-wsl', cwd: '/home/ada/repo' }
+        },
+        {
+          timestamp: '2026-06-10T10:01:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: 'Codex WSL title' }]
+          }
+        }
+      ])
+    )
+
+    const result = await scanAiVaultSessions({
+      ...roots,
+      wslHomeDirs: [wslHome],
+      platform: 'win32'
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.title).sort()).toEqual([
+      'Claude WSL title',
+      'Codex WSL title'
+    ])
+    expect(result.sessions.find((session) => session.agent === 'codex')?.codexHome).toBe(
+      join(wslHome, '.local', 'share', 'orca', 'codex-runtime-home', 'home')
+    )
+  })
+
   it('skips hidden Codex context blocks when choosing session titles', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-codex-hidden-context-'))
     tempRoots.push(root)

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -1,5 +1,3 @@
-import { homedir } from 'os'
-import { basename, dirname, join } from 'path'
 import type {
   AiVaultListResult,
   AiVaultScanIssue,
@@ -7,54 +5,21 @@ import type {
 } from '../../shared/ai-vault-types'
 import { sessionSortTime } from './session-scanner-accumulator'
 import { parseAgentSessionFile } from './session-scanner-agent-parser'
-import { codexHomeForSessionsDir, uniqueCodexSessionsDirs } from './session-scanner-codex-paths'
-import { discoverFiles, discoverOpenClawFiles } from './session-scanner-discovery'
-import { resolveKimiSessionsDir } from './session-scanner-kimi-paths'
+import { codexHomeForSessionsDir } from './session-scanner-codex-paths'
+import {
+  DEFAULT_CODEX_HOME_DIR,
+  discoverAiVaultSessionSources
+} from './session-scanner-source-discovery'
 import type {
   AiVaultScanOptions,
   SessionFileCandidate,
-  SessionFileDiscovery,
   SessionParseResult
 } from './session-scanner-types'
-import {
-  clampPositiveInteger,
-  errorMessage,
-  normalizePiSessionsDir
-} from './session-scanner-values'
+import { clampPositiveInteger, errorMessage } from './session-scanner-values'
 
 const DEFAULT_LIMIT = 1000
 const DEFAULT_SCAN_LIMIT_PER_AGENT = 1000
 const SESSION_PARSE_CONCURRENCY = 8
-const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects')
-const DEFAULT_CODEX_HOME_DIR = join(homedir(), '.codex')
-const CODEX_HOME_DIR = process.env.CODEX_HOME?.trim() || DEFAULT_CODEX_HOME_DIR
-const CODEX_SESSIONS_DIR = join(CODEX_HOME_DIR, 'sessions')
-const GEMINI_SESSIONS_DIR = join(homedir(), '.gemini', 'tmp')
-const COPILOT_SESSIONS_DIR = join(
-  process.env.COPILOT_HOME?.trim() || join(homedir(), '.copilot'),
-  'session-state'
-)
-const CURSOR_PROJECTS_DIR = join(homedir(), '.cursor', 'projects')
-const OPENCODE_STORAGE_DIR = join(
-  process.env.OPENCODE_CONFIG_DIR?.trim() || join(homedir(), '.local', 'share', 'opencode'),
-  'storage'
-)
-const GROK_SESSIONS_DIR = join(
-  process.env.GROK_HOME?.trim() || join(homedir(), '.grok'),
-  'sessions'
-)
-const HERMES_SESSIONS_DIR = join(homedir(), '.hermes', 'sessions')
-const ROVO_SESSIONS_DIR = join(homedir(), '.rovodev', 'sessions')
-const OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_DIR?.trim() || join(homedir(), '.openclaw')
-const PI_SESSIONS_DIR = normalizePiSessionsDir(
-  process.env.PI_CODING_AGENT_DIR?.trim() || join(homedir(), '.pi', 'agent', 'sessions')
-)
-const DROID_SESSIONS_DIR = join(homedir(), '.factory', 'sessions')
-// Why: Devin ATIF transcripts are stored under <DEVIN_HOME>/transcripts.
-const DEVIN_TRANSCRIPTS_DIR = join(
-  process.env.DEVIN_HOME?.trim() || join(homedir(), '.local', 'share', 'devin', 'cli'),
-  'transcripts'
-)
 
 export async function scanAiVaultSessions(
   options: AiVaultScanOptions = {}
@@ -63,129 +28,7 @@ export async function scanAiVaultSessions(
   const limitPerAgent = clampPositiveInteger(options.limitPerAgent, DEFAULT_SCAN_LIMIT_PER_AGENT)
   const platform = options.platform ?? process.platform
   const issues: AiVaultScanIssue[] = []
-  const codexSessionsDirs = uniqueCodexSessionsDirs([
-    options.codexSessionsDir ?? CODEX_SESSIONS_DIR,
-    ...(options.additionalCodexSessionsDirs ?? [])
-  ])
-
-  const discoveries = await Promise.all<SessionFileDiscovery>([
-    discoverFiles({
-      rootDir: options.claudeProjectsDir ?? CLAUDE_PROJECTS_DIR,
-      limit: limitPerAgent,
-      agent: 'claude',
-      issues,
-      extensions: ['.jsonl']
-    }),
-    ...codexSessionsDirs.map((rootDir) =>
-      discoverFiles({
-        rootDir,
-        limit: limitPerAgent,
-        agent: 'codex',
-        issues,
-        extensions: ['.jsonl']
-      })
-    ),
-    discoverFiles({
-      rootDir: options.geminiSessionsDir ?? GEMINI_SESSIONS_DIR,
-      limit: limitPerAgent,
-      agent: 'gemini',
-      issues,
-      extensions: ['.json', '.jsonl']
-    }),
-    discoverFiles({
-      rootDir: options.copilotSessionsDir ?? COPILOT_SESSIONS_DIR,
-      limit: limitPerAgent,
-      agent: 'copilot',
-      issues,
-      extensions: ['.jsonl']
-    }),
-    discoverFiles({
-      rootDir: options.cursorProjectsDir ?? CURSOR_PROJECTS_DIR,
-      limit: limitPerAgent,
-      agent: 'cursor',
-      issues,
-      extensions: ['.jsonl'],
-      filePredicate: (path) => path.split(/[\\/]/).includes('agent-transcripts')
-    }),
-    discoverFiles({
-      rootDir: join(options.opencodeStorageDir ?? OPENCODE_STORAGE_DIR, 'session'),
-      limit: limitPerAgent,
-      agent: 'opencode',
-      issues,
-      extensions: ['.json']
-    }),
-    discoverFiles({
-      rootDir: options.grokSessionsDir ?? GROK_SESSIONS_DIR,
-      limit: limitPerAgent,
-      agent: 'grok',
-      issues,
-      extensions: ['.json'],
-      filePredicate: (path) => basename(path) === 'summary.json'
-    }),
-    discoverFiles({
-      rootDir: options.devinTranscriptsDir ?? DEVIN_TRANSCRIPTS_DIR,
-      limit: limitPerAgent,
-      agent: 'devin',
-      issues,
-      extensions: ['.json']
-    }),
-    discoverFiles({
-      rootDir: options.hermesSessionsDir ?? HERMES_SESSIONS_DIR,
-      limit: limitPerAgent,
-      agent: 'hermes',
-      issues,
-      extensions: ['.json'],
-      filePredicate: (path) => basename(path).startsWith('session_')
-    }),
-    discoverFiles({
-      rootDir: options.rovoSessionsDir ?? ROVO_SESSIONS_DIR,
-      limit: limitPerAgent,
-      agent: 'rovo',
-      issues,
-      extensions: ['.json'],
-      filePredicate: (path) => basename(path) === 'metadata.json'
-    }),
-    discoverOpenClawFiles({
-      rootDirs: [
-        options.openclawStateDir ?? OPENCLAW_STATE_DIR,
-        options.openclawLegacyStateDir ?? join(homedir(), '.clawdbot')
-      ],
-      limit: limitPerAgent,
-      issues
-    }),
-    discoverFiles({
-      rootDir: options.piSessionsDir ?? PI_SESSIONS_DIR,
-      limit: limitPerAgent,
-      agent: 'pi',
-      issues,
-      extensions: ['.jsonl']
-    }),
-    discoverFiles({
-      rootDir: options.droidSessionsDir ?? DROID_SESSIONS_DIR,
-      limit: limitPerAgent,
-      agent: 'droid',
-      issues,
-      extensions: ['.jsonl']
-    }),
-    discoverFiles({
-      rootDir: options.droidProjectsDir ?? join(homedir(), '.factory', 'projects'),
-      limit: limitPerAgent,
-      agent: 'droid',
-      issues,
-      extensions: ['.jsonl']
-    }),
-    discoverFiles({
-      rootDir: resolveKimiSessionsDir(options.kimiSessionsDir),
-      limit: limitPerAgent,
-      agent: 'kimi',
-      issues,
-      extensions: ['.json'],
-      // Why: each Kimi session is <sessions>/wd_*/session_*/state.json; match
-      // only those (not the sibling agents/*/wire.jsonl transcripts).
-      filePredicate: (path) =>
-        basename(path) === 'state.json' && basename(dirname(path)).startsWith('session_')
-    })
-  ])
+  const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
 
   const candidates = discoveries
     .flatMap((discovery) =>

--- a/src/main/ipc/ai-vault.ts
+++ b/src/main/ipc/ai-vault.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 import { join } from 'path'
 import { scanAiVaultSessions } from '../ai-vault/session-scanner'
+import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
 import type { AiVaultListArgs, AiVaultListResult } from '../../shared/ai-vault-types'
 
 const AI_VAULT_CACHE_TTL_MS = 15_000
@@ -36,7 +37,12 @@ async function listAiVaultSessions(args?: AiVaultListArgs): Promise<AiVaultListR
   const additionalCodexSessionsDirs =
     handlerOptions.getAdditionalCodexHomePaths?.().map((homePath) => join(homePath, 'sessions')) ??
     []
-  inflightList = scanAiVaultSessions({ limit: args?.limit, additionalCodexSessionsDirs })
+  inflightList = (async () =>
+    scanAiVaultSessions({
+      limit: args?.limit,
+      additionalCodexSessionsDirs,
+      wslHomeDirs: await getAiVaultWslHomeDirs()
+    }))()
     .then((result) => {
       cachedList = {
         key,
@@ -57,4 +63,14 @@ export function registerAiVaultHandlers(options: AiVaultHandlerOptions = {}): vo
   ipcMain.handle('aiVault:listSessions', (_event, args?: AiVaultListArgs) =>
     listAiVaultSessions(args)
   )
+}
+
+async function getAiVaultWslHomeDirs(): Promise<string[]> {
+  if (process.platform !== 'win32') {
+    return []
+  }
+  const homes = await Promise.all(
+    (await listWslDistrosAsync()).map((distro) => getWslHomeAsync(distro))
+  )
+  return homes.filter((homeDir): homeDir is string => Boolean(homeDir))
 }

--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'child_process'
+import { execFile, execFileSync } from 'child_process'
 import { parseWslUncPath } from '../shared/wsl-paths'
 
 export type WslPathInfo = {
@@ -115,6 +115,26 @@ export function listWslDistros(): string[] {
   }
 }
 
+export async function listWslDistrosAsync(): Promise<string[]> {
+  if (wslDistroCache !== null) {
+    return wslDistroCache
+  }
+
+  if (process.platform !== 'win32') {
+    wslDistroCache = []
+    return wslDistroCache
+  }
+
+  try {
+    const output = await execFileUtf8('wsl.exe', ['--list', '--quiet'])
+    wslDistroCache = normalizeWslListOutput(output).filter(isUserWslDistro)
+    return wslDistroCache
+  } catch {
+    wslDistroCache = []
+    return wslDistroCache
+  }
+}
+
 export function hasCachedWslDistros(): boolean {
   return wslDistroCache !== null
 }
@@ -146,6 +166,28 @@ export function getWslHome(distro: string): string | null {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000
     }).trim()
+
+    if (!home || !home.startsWith('/')) {
+      return null
+    }
+
+    const uncPath = toWindowsWslPath(home, distro)
+    wslHomeCache.set(distro, uncPath)
+    return uncPath
+  } catch {
+    return null
+  }
+}
+
+export async function getWslHomeAsync(distro: string): Promise<string | null> {
+  if (wslHomeCache.has(distro)) {
+    return wslHomeCache.get(distro)!
+  }
+
+  try {
+    const home = (
+      await execFileUtf8('wsl.exe', ['-d', distro, '--', 'bash', '-c', 'echo $HOME'])
+    ).trim()
 
     if (!home || !home.startsWith('/')) {
       return null
@@ -209,4 +251,16 @@ export function _setWslCachesForTests(args: {
 }): void {
   wslAvailableCache = args.available ?? null
   wslDistroCache = args.distros ?? null
+}
+
+function execFileUtf8(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { encoding: 'utf-8', timeout: 5000 }, (error, stdout) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(stdout)
+    })
+  })
 }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
@@ -211,6 +211,27 @@ describe('filterAiVaultSessions', () => {
     ).toHaveLength(1)
   })
 
+  it('matches WSL UNC workspace paths against Linux session cwd values', () => {
+    expect(
+      filterAiVaultSessions(
+        [
+          {
+            ...baseSession,
+            cwd: '/home/ada/repo/app'
+          }
+        ],
+        {
+          query: '',
+          agents: ['claude'],
+          scope: 'workspace',
+          sort: 'updated',
+          activeWorktreePaths: [String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`],
+          hideEmptySessions: true
+        }
+      )
+    ).toHaveLength(1)
+  })
+
   it('returns no sessions for oversized pasted queries before reading session fields', () => {
     const unreadableSession = { ...baseSession }
     Object.defineProperty(unreadableSession, 'agent', {

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.ts
@@ -5,6 +5,7 @@ import {
   normalizeRuntimePathSeparators
 } from '../../../../shared/cross-platform-path'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
+import { parseWslUncPath } from '../../../../shared/wsl-paths'
 import type {
   AiVaultAgent,
   AiVaultGroup,
@@ -70,7 +71,9 @@ export function filterAiVaultSessions(
         const cwd = session.cwd
         if (
           !cwd ||
-          !filters.activeWorktreePaths.some((pathValue) => isPathInsideOrEqual(pathValue, cwd))
+          !filters.activeWorktreePaths.some((pathValue) =>
+            isAiVaultSessionInWorkspacePath(pathValue, cwd)
+          )
         ) {
           return false
         }
@@ -223,6 +226,21 @@ function addAiVaultWorkspaceScopePath(paths: string[], pathValue: string): void 
     return
   }
   paths.push(trimmedPath)
+}
+
+function isAiVaultSessionInWorkspacePath(workspacePath: string, sessionCwd: string): boolean {
+  if (isPathInsideOrEqual(workspacePath, sessionCwd)) {
+    return true
+  }
+
+  const workspaceWslPath = parseWslUncPath(workspacePath)
+  if (!workspaceWslPath) {
+    return false
+  }
+
+  // WSL agent transcripts record Linux cwd values even when Orca stores the
+  // active worktree as a Windows UNC path.
+  return isPathInsideOrEqual(workspaceWslPath.linuxPath, sessionCwd)
 }
 
 function isAiVaultWorkspaceScopePathClaimed(

--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -93,4 +93,23 @@ describe('ai vault resume command runtime', () => {
 
     expect(getAiVaultResumePlatform(state, 'repo-1::worktree-1')).toBe('linux')
   })
+
+  it('converts WSL UNC Codex homes before building Linux resume commands', () => {
+    const state = makeState({
+      worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo'
+    })
+
+    expect(
+      buildAiVaultResumeCommandForWorktree({
+        state,
+        worktreeId: 'repo-1::worktree-1',
+        session: {
+          agent: 'codex',
+          sessionId: 'session one',
+          cwd: '/home/alice/repo',
+          codexHome: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex'
+        }
+      })
+    ).toBe("cd '/home/alice/repo' && CODEX_HOME='/home/alice/.codex' codex resume 'session one'")
+  })
 })

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -16,14 +16,27 @@ export function buildAiVaultResumeCommandForWorktree(args: {
   commandOverride?: string | null
 }): string {
   const platform = getAiVaultResumePlatform(args.state, args.worktreeId)
+  const codexHome = getAiVaultResumeCodexHome(args.session.codexHome, platform)
   return buildAiVaultResumeCommand({
     agent: args.session.agent,
     sessionId: args.session.sessionId,
     cwd: args.session.cwd,
     platform,
     commandOverride: args.commandOverride,
-    codexHome: args.session.codexHome
+    codexHome
   })
+}
+
+function getAiVaultResumeCodexHome(
+  codexHome: string | null,
+  platform: NodeJS.Platform
+): string | null {
+  // Why: WSL UNC Codex homes must be POSIX when invoking Linux commands.
+  // Keep original paths unchanged for non-Linux targets.
+  if (!codexHome || platform !== 'linux') {
+    return codexHome
+  }
+  return parseWslUncPath(codexHome)?.linuxPath ?? codexHome
 }
 
 export function getAiVaultResumePlatform(


### PR DESCRIPTION
## Summary
- Scan AI Vault session history from WSL home directories, including WSL Codex runtime homes.
- Match WSL UNC workspace paths against Linux transcript cwd values in workspace scope.
- Convert WSL UNC Codex homes to Linux paths for WSL resume commands.
- Keep WSL home discovery asynchronous on the AI Vault IPC path to avoid blocking Electron main.

## Screenshots
No visual change.

## AI Review Report
- Cross-platform path handling: WSL UNC paths are only translated when matching against Linux cwd values or building Linux resume commands; Windows/macOS/Linux host paths keep the existing comparison and command behavior.
- IPC/runtime behavior: WSL distro/home discovery now uses async cached helpers instead of synchronous `execFileSync` on `aiVault:listSessions`.
- Regression coverage: added tests for WSL session scanning, WSL workspace filtering, and WSL Codex resume command conversion.

## Security Audit
- No shell strings are introduced for WSL probing; WSL discovery uses `execFile` argv arrays with a timeout.
- Resume command construction continues through the existing AI Vault quoting helpers.
- IPC only adds local WSL home directories as scan roots; remote/SSH session behavior is unchanged.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts src/main/ai-vault/session-scanner.test.ts src/renderer/src/lib/ai-vault-resume-command.test.ts src/main/wsl.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web