### PR TITLE
fix(runtime): require sustained quiescence for tui-idle waits

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6998,6 +6998,61 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('does not report tui-idle while a name-only agent title keeps streaming output', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+
+      // 'Codex' is a name-only title → detectAgentStatusFromTitle defaults it to
+      // 'idle' even though the agent is actively working (the spinner and "esc to
+      // interrupt" live in the terminal body, not the OSC title). Pre-fix this
+      // made tui-idle satisfy in ~0s mid-work.
+      runtime.onPtyData('pty-bg', '\x1b]0;Codex\x07working 1\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+
+      // Keep streaming: each chunk refreshes lastOutputAt, so the debounce
+      // window never elapses and the wait must not resolve.
+      for (let i = 2; i <= 6; i++) {
+        runtime.onPtyData('pty-bg', `working ${i}\n`, Date.now())
+        await vi.advanceTimersByTimeAsync(2_000)
+      }
+      expect(settled).toBe(false)
+
+      // Agent finishes: output goes quiet. After >= TUI_IDLE_QUIESCENCE_MS the
+      // sustained-idle debounce elapses and the wait resolves.
+      await vi.advanceTimersByTimeAsync(4_000)
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resolves tui-idle from a Codex ready prompt preview', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -8228,12 +8228,13 @@ export class OrcaRuntimeService {
       if (condition === 'tui-idle' && ptyBlockedReason) {
         return buildPtyTerminalWaitBlockedResult(handle, condition, pty.pty, ptyBlockedReason)
       }
-      if (condition === 'tui-idle' && pty.pty.lastAgentStatus === 'idle') {
+      if (condition === 'tui-idle' && this.hasSustainedTuiIdle(pty.pty)) {
         return buildPtyTerminalWaitResult(handle, condition, pty.pty)
       }
       if (
         condition === 'tui-idle' &&
-        (this.getAdoptedPtyExplicitIdleStatus(pty.pty) === 'idle' ||
+        ((this.getAdoptedPtyExplicitIdleStatus(pty.pty) === 'idle' &&
+          !this.isTuiOutputActive(pty.pty)) ||
           isKnownReadyPromptPreview(ptyWaitText))
       ) {
         return buildPtyTerminalWaitResult(handle, condition, pty.pty)
@@ -8288,10 +8289,11 @@ export class OrcaRuntimeService {
               waiter,
               buildPtyTerminalWaitBlockedResult(handle, condition, live.pty, blockedReason)
             )
-          } else if (live.pty.lastAgentStatus === 'idle') {
+          } else if (this.hasSustainedTuiIdle(live.pty)) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
           } else if (
-            this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' ||
+            (this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' &&
+              !this.isTuiOutputActive(live.pty)) ||
             isKnownReadyPromptPreview(livePtyWaitText)
           ) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
@@ -8318,13 +8320,15 @@ export class OrcaRuntimeService {
     // detection that powers the renderer's "Task complete" notifications.
     // Why: only 'idle' satisfies tui-idle, not 'permission'. Permission means the
     // agent is blocked on user approval, not finished with its task.
-    if (condition === 'tui-idle' && leaf.lastAgentStatus === 'idle') {
+    if (condition === 'tui-idle' && this.hasSustainedTuiIdle(leaf)) {
       return buildTerminalWaitResult(handle, condition, leaf)
     }
     if (condition === 'tui-idle') {
       const fastPathTitle = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
       if (
-        (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
+        (fastPathTitle &&
+          detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle' &&
+          !this.isTuiOutputActive(leaf)) ||
         isKnownReadyPromptPreview(leafWaitText)
       ) {
         return buildTerminalWaitResult(handle, condition, leaf)
@@ -8390,7 +8394,7 @@ export class OrcaRuntimeService {
               waiter,
               buildTerminalWaitBlockedResult(handle, condition, live.leaf, blockedReason)
             )
-          } else if (live.leaf.lastAgentStatus === 'idle') {
+          } else if (this.hasSustainedTuiIdle(live.leaf)) {
             // Why: don't clear lastAgentStatus here. It's a factual record of the
             // last detected OSC state, not a one-shot signal. Clearing it causes
             // subsequent tui-idle waiters to hang even though the agent is idle —
@@ -8402,7 +8406,9 @@ export class OrcaRuntimeService {
             // preview/title until the waiter resolves or hits its timeout.
             const fastPathTitle = live.leaf.paneTitle ?? this.tabs.get(live.leaf.tabId)?.title
             if (
-              (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
+              (fastPathTitle &&
+                detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle' &&
+                !this.isTuiOutputActive(live.leaf)) ||
               isKnownReadyPromptPreview(liveLeafWaitText)
             ) {
               this.resolveWaiter(waiter, buildTerminalWaitResult(handle, condition, live.leaf))
@@ -17870,6 +17876,36 @@ export class OrcaRuntimeService {
     }
   }
 
+  // Why: a single OSC-title 'idle' sample is not proof an agent finished. Agents
+  // render their working spinner and "esc to interrupt" in the terminal BODY,
+  // and detectAgentStatusFromTitle() defaults a name-only agent title (e.g.
+  // "Devin", "Codex", "aider") to 'idle'. So an actively-working agent is
+  // routinely reported idle by its title alone, which made `terminal wait --for
+  // tui-idle` fire in ~0s mid-work. While output is still streaming, the
+  // terminal is by definition not idle regardless of what the title says.
+  private isTuiOutputActive(target: { lastOutputAt: number | null }): boolean {
+    if (!target.lastOutputAt) {
+      return false
+    }
+    return Date.now() - target.lastOutputAt < TUI_IDLE_QUIESCENCE_MS
+  }
+
+  // Why: treat a title-derived 'idle' status as satisfying tui-idle only after
+  // output has been quiet for TUI_IDLE_QUIESCENCE_MS — i.e. require *sustained*
+  // idle (debounce). A genuinely finished agent stops emitting, so the debounce
+  // window elapses; an agent that merely flashed an idle-looking title mid-work
+  // keeps producing output and never satisfies. Body-level prompt detection
+  // (isKnownReadyPromptPreview) is a direct "cursor at input prompt" signal and
+  // stays immediate; adopted/daemon handles with no PTY output stream
+  // (lastOutputAt == null) have nothing to debounce, so their title signal
+  // also stands.
+  private hasSustainedTuiIdle(target: {
+    lastAgentStatus: AgentStatus | null
+    lastOutputAt: number | null
+  }): boolean {
+    return target.lastAgentStatus === 'idle' && !this.isTuiOutputActive(target)
+  }
+
   private resolveTuiIdleWaiters(leaf: RuntimeLeafRecord): void {
     const handle = this.handleByLeafKey.get(this.getLeafKey(leaf.tabId, leaf.leafId))
     if (!handle) {
@@ -17880,7 +17916,10 @@ export class OrcaRuntimeService {
       return
     }
     for (const waiter of [...waiters]) {
-      if (waiter.condition === 'tui-idle') {
+      // Why: only resolve once idle is *sustained*. The transition fires the
+      // instant an idle-looking title arrives, which is itself fresh output; the
+      // fallback poll re-checks and resolves once output goes quiet.
+      if (waiter.condition === 'tui-idle' && this.hasSustainedTuiIdle(leaf)) {
         this.resolveWaiter(waiter, buildTerminalWaitResult(handle, 'tui-idle', leaf))
       }
     }
@@ -17915,7 +17954,8 @@ export class OrcaRuntimeService {
       return
     }
     for (const waiter of [...waiters]) {
-      if (waiter.condition === 'tui-idle') {
+      // Why: only resolve once idle is *sustained* (see resolveTuiIdleWaiters).
+      if (waiter.condition === 'tui-idle' && this.hasSustainedTuiIdle(pty)) {
         this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, 'tui-idle', pty))
       }
     }
@@ -17935,7 +17975,7 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
-        if (leaf.lastAgentStatus === 'idle') {
+        if (this.hasSustainedTuiIdle(leaf)) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -17948,7 +17988,7 @@ export class OrcaRuntimeService {
         const pollTitle = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
         if (pollTitle) {
           const titleStatus = detectExplicitIdleStatusFromTitle(pollTitle)
-          if (titleStatus === 'idle') {
+          if (titleStatus === 'idle' && !this.isTuiOutputActive(leaf)) {
             if (waiter.pollInterval) {
               clearInterval(waiter.pollInterval)
               waiter.pollInterval = null
@@ -18022,7 +18062,7 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
-        if (pty.lastAgentStatus === 'idle') {
+        if (this.hasSustainedTuiIdle(pty)) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -18046,7 +18086,8 @@ export class OrcaRuntimeService {
         // Why: background PTY handles can later be adopted by the renderer.
         // Use that live xterm title as the same readiness signal as leaf handles.
         if (
-          this.getAdoptedPtyExplicitIdleStatus(pty) === 'idle' ||
+          (this.getAdoptedPtyExplicitIdleStatus(pty) === 'idle' &&
+            !this.isTuiOutputActive(pty)) ||
           isKnownReadyPromptPreview(ptyWaitText)
         ) {
           if (waiter.pollInterval) {


### PR DESCRIPTION
## Problem

`orca terminal wait --terminal <h> --for tui-idle --timeout-ms 30000 --json` returns in ~0s
with `{"satisfied": true, "status": "running"}` even when the target agent TUI is **actively
working** (spinner animating, output streaming, `esc to interrupt` visible). That makes
`tui-idle` useless as a "task done" signal — it fires mid-work.

Fixes #6011.

## Root cause

Two compounding defects:

1. **`detectAgentStatusFromTitle` defaults agent titles to `idle`** (`src/shared/agent-detection.ts`).
   A title with an agent name but no explicit working marker (no braille spinner, no
   `working|thinking|running`, no Claude `. ` prefix, no `action required|permission|waiting`)
   falls through to `return 'idle'`. Agents render their spinner / `esc to interrupt` in the
   terminal **body**, not the OSC **title**, so a busy agent with a name-only title
   (`Devin`, `Codex`, `aider`, …) is classified `idle`.

2. **The tui-idle wait trusts a single instantaneous title sample** (`src/main/runtime/orca-runtime.ts`,
   `waitForTerminal`). It returns satisfied the moment `lastAgentStatus === 'idle'` — the exact
   value (1) mis-computes — with no sustained-idle requirement. The existing
   `TUI_IDLE_QUIESCENCE_MS = 3000` debounce is only consulted in the foreground-process
   fallback (which runs only when `lastAgentStatus === null`), so a title-derived `idle`
   bypasses it.

## Fix

Require **sustained** idle: a title-derived `idle` satisfies `tui-idle` only after PTY output
has been quiet for `TUI_IDLE_QUIESCENCE_MS`. An actively-working agent keeps producing output,
so `lastOutputAt` stays recent and the wait does not fire; when it finishes, output stops and
the debounce elapses.

Two small helpers (`isTuiOutputActive`, `hasSustainedTuiIdle`) replace the bare
`lastAgentStatus === 'idle'` checks at every title-derived satisfaction site:

- synchronous fast paths (pty + leaf)
- in-promise registration checks (pty + leaf)
- fallback polls (`startPtyTuiIdleFallbackPoll`, `startTuiIdleFallbackPoll`)
- working→idle transition resolvers (`resolvePtyTuiIdleWaiters`, `resolveTuiIdleWaiters`)

Preserved as-is:
- **Body-level ready-prompt detection** (`isKnownReadyPromptPreview`) stays immediate — it
  directly detects the cursor at the input prompt, the strongest idle signal.
- **Adopted / daemon handles with no PTY output stream** (`lastOutputAt == null`) keep their
  explicit-title signal, so the existing "resolve from renderer ready title" /
  "resolve from Codex/Antigravity ready prompt" tests still pass.

Defect (1)'s broad default-to-idle is intentionally left in place (it's a renderer-shared
classifier driving badges/indicators); the debounce neutralizes its impact on `tui-idle`
without changing UI semantics. Tightening it could be a follow-up.

## Tests

Adds `does not report tui-idle while a name-only agent title keeps streaming output`:
a `Codex` (name-only → defaults to `idle`) agent that streams output must **not** satisfy
`tui-idle` while output is flowing, and **must** satisfy once output goes quiet for
`TUI_IDLE_QUIESCENCE_MS`. (Fails before this change — the fast path resolved in ~0s.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6012">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

`terminal wait --for tui-idle` could return success while an agent was still working. Idle waits now require sustained quiet so “done” is not reported mid-spinner.
