### PR TITLE
fix(terminal): attach dropped image files via bracketed paste

### DIFF
--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -14,6 +14,7 @@ import {
   ingestRgJsonLine,
   SEARCH_TIMEOUT_MS as SHARED_SEARCH_TIMEOUT_MS
 } from '../shared/text-search'
+import { IMAGE_FILE_MIME_TYPES } from '../shared/image-file-extensions'
 import type { SearchResult as SharedSearchResult } from '../shared/types'
 
 // ─── Constants ───────────────────────────────────────────────────────
@@ -31,14 +32,7 @@ export const SEARCH_TIMEOUT_MS = SHARED_SEARCH_TIMEOUT_MS
 export const DEFAULT_MAX_RESULTS = 2000
 
 export const IMAGE_MIME_TYPES: Record<string, string> = {
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
-  '.svg': 'image/svg+xml',
-  '.webp': 'image/webp',
-  '.bmp': 'image/bmp',
-  '.ico': 'image/x-icon',
+  ...IMAGE_FILE_MIME_TYPES,
   '.pdf': 'application/pdf'
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-drop-image-path.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-image-path.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { isImageDropPath } from './terminal-drop-image-path'
+
+describe('isImageDropPath', () => {
+  it('detects common image extensions case-insensitively', () => {
+    for (const path of [
+      '/repo/shot.png',
+      '/repo/shot.PNG',
+      '/repo/a.jpg',
+      '/repo/a.jpeg',
+      '/repo/a.gif',
+      '/repo/icon.svg',
+      '/repo/a.webp',
+      '/repo/a.bmp',
+      '/repo/a.ico',
+      'C:\\Users\\me\\Pictures\\diagram.PnG'
+    ]) {
+      expect(isImageDropPath(path)).toBe(true)
+    }
+  })
+
+  it('rejects non-image and extension-less paths', () => {
+    for (const path of [
+      '/repo/index.ts',
+      '/repo/notes.md',
+      '/repo/archive.tar.gz',
+      '/repo/Makefile',
+      '/repo/.gitignore'
+    ]) {
+      expect(isImageDropPath(path)).toBe(false)
+    }
+  })
+
+  it('does not classify directory components with dots as images', () => {
+    expect(isImageDropPath('/home/jane.png/photo')).toBe(false)
+    expect(isImageDropPath('/home/jane.doe/screenshot')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-drop-image-path.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-image-path.ts
@@ -1,21 +1,13 @@
+import { IMAGE_FILE_EXTENSIONS } from '../../../../shared/image-file-extensions'
+import type { TerminalTargetShell } from './terminal-drop-shell'
+
 // Why: dropped image files should be handed to terminal TUIs (Claude Code,
 // Codex, etc.) as image attachments, which those tools detect from a
 // *bracketed paste* of the file path — exactly how clipboard screenshot paste
-// already works in Orca (see terminal-clipboard-paste.ts + issue #2842). To
-// decide which dropped paths get that treatment we need a cheap, shell-agnostic
-// image-extension check. The extension set mirrors IMAGE_MIME_TYPES in
-// src/relay/fs-handler-utils.ts so "what Orca considers an image" stays
-// consistent across the app.
-const IMAGE_DROP_EXTENSIONS = new Set([
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.svg',
-  '.webp',
-  '.bmp',
-  '.ico'
-])
+// already works in Orca (see terminal-clipboard-paste.ts + issue #2842).
+const IMAGE_DROP_EXTENSIONS = new Set(IMAGE_FILE_EXTENSIONS)
+const POSIX_RAW_IMAGE_DROP_UNSAFE_RE = /["'`$;&|<>(){}[\]*?!#\\]/
+const WINDOWS_RAW_IMAGE_DROP_UNSAFE_RE = /["'`$;&|<>(){}[\]*?!#^%]/
 
 /**
  * Returns true when `path` looks like a local/remote image file based on its
@@ -33,4 +25,23 @@ export function isImageDropPath(path: string): boolean {
     return false
   }
   return IMAGE_DROP_EXTENSIONS.has(path.slice(lastDot).toLowerCase())
+}
+
+export function canPasteImageDropPathRaw(path: string, targetShell: TerminalTargetShell): boolean {
+  if (hasControlByte(path)) {
+    return false
+  }
+  const unsafeRe =
+    targetShell === 'windows' ? WINDOWS_RAW_IMAGE_DROP_UNSAFE_RE : POSIX_RAW_IMAGE_DROP_UNSAFE_RE
+  return !unsafeRe.test(path)
+}
+
+function hasControlByte(path: string): boolean {
+  for (let i = 0; i < path.length; i += 1) {
+    const code = path.charCodeAt(i)
+    if (code < 0x20 || code === 0x7f) {
+      return true
+    }
+  }
+  return false
 }

--- a/src/renderer/src/components/terminal-pane/terminal-drop-image-path.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-image-path.ts
@@ -1,0 +1,36 @@
+// Why: dropped image files should be handed to terminal TUIs (Claude Code,
+// Codex, etc.) as image attachments, which those tools detect from a
+// *bracketed paste* of the file path — exactly how clipboard screenshot paste
+// already works in Orca (see terminal-clipboard-paste.ts + issue #2842). To
+// decide which dropped paths get that treatment we need a cheap, shell-agnostic
+// image-extension check. The extension set mirrors IMAGE_MIME_TYPES in
+// src/relay/fs-handler-utils.ts so "what Orca considers an image" stays
+// consistent across the app.
+const IMAGE_DROP_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.webp',
+  '.bmp',
+  '.ico'
+])
+
+/**
+ * Returns true when `path` looks like a local/remote image file based on its
+ * extension. Handles POSIX (`/`) and Windows (`\`) separators and is
+ * case-insensitive. The extension must be part of the basename, so directory
+ * components with dots (e.g. `/home/jane.doe/photo`) are not misclassified.
+ */
+export function isImageDropPath(path: string): boolean {
+  const lastDot = path.lastIndexOf('.')
+  if (lastDot === -1) {
+    return false
+  }
+  const lastSeparator = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+  if (lastDot < lastSeparator) {
+    return false
+  }
+  return IMAGE_DROP_EXTENSIONS.has(path.slice(lastDot).toLowerCase())
+}

--- a/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.test.ts
@@ -144,6 +144,61 @@ describe('terminal drop path writer', () => {
     )
   })
 
+  it('falls back to shell escaping for image paths with POSIX shell metacharacters', async () => {
+    const sendInput = vi.fn(() => true)
+    const sendInputAccepted = vi.fn(async () => true)
+    const { manager, pane } = createManager()
+    const transport = createTransport(sendInput, 'pty-1', sendInputAccepted)
+
+    await writeTerminalDropPathsToCapturedTarget({
+      dropTarget: { paneId: pane.id, leafId: pane.leafId, ptyId: 'pty-1', transport } as never,
+      manager: manager as never,
+      paneTransports: new Map([[pane.id, transport]]) as never,
+      paths: ['/repo/a.png; touch /tmp/pwned #.png'],
+      targetShell: 'posix'
+    })
+
+    expect(sendInputAccepted).toHaveBeenCalledWith("'/repo/a.png; touch /tmp/pwned #.png' ")
+  })
+
+  it('falls back to shell escaping for image paths with Windows shell metacharacters', async () => {
+    const sendInput = vi.fn(() => true)
+    const sendInputAccepted = vi.fn(async () => true)
+    const { manager, pane } = createManager()
+    const transport = createTransport(sendInput, 'pty-1', sendInputAccepted)
+
+    await writeTerminalDropPathsToCapturedTarget({
+      dropTarget: { paneId: pane.id, leafId: pane.leafId, ptyId: 'pty-1', transport } as never,
+      manager: manager as never,
+      paneTransports: new Map([[pane.id, transport]]) as never,
+      paths: ['C:\\Users\\me\\Pictures\\a&b.png'],
+      targetShell: 'windows'
+    })
+
+    expect(sendInputAccepted).toHaveBeenCalledWith('"C:\\Users\\me\\Pictures\\a&b.png" ')
+  })
+
+  it('separates an image paste from a following image path that must be shell escaped', async () => {
+    const sendInput = vi.fn(() => true)
+    const sendInputAccepted = vi.fn(async () => true)
+    const { manager, pane } = createManager()
+    const transport = createTransport(sendInput, 'pty-1', sendInputAccepted)
+
+    await writeTerminalDropPathsToCapturedTarget({
+      dropTarget: { paneId: pane.id, leafId: pane.leafId, ptyId: 'pty-1', transport } as never,
+      manager: manager as never,
+      paneTransports: new Map([[pane.id, transport]]) as never,
+      paths: ['/repo/shot.png', '/repo/a.png; touch /tmp/pwned #.png'],
+      targetShell: 'posix'
+    })
+
+    expect(sendInputAccepted).toHaveBeenNthCalledWith(
+      1,
+      `${wrapTerminalBracketedPasteText('/repo/shot.png')} `
+    )
+    expect(sendInputAccepted).toHaveBeenNthCalledWith(2, "'/repo/a.png; touch /tmp/pwned #.png' ")
+  })
+
   it('times out dropped path writes that never receive PTY acknowledgement', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { wrapTerminalBracketedPasteText } from './terminal-bracketed-paste'
 import { writeTerminalDropPathsToCapturedTarget } from './terminal-drop-path-writer'
 
 function createTransport(
@@ -49,6 +50,49 @@ describe('terminal drop path writer', () => {
     expect(sendInputAccepted).toHaveBeenCalledTimes(1)
     expect(sendInputAccepted).toHaveBeenCalledWith('/repo/a.ts ')
     expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('writes dropped image paths as a bracketed paste of the raw path', async () => {
+    const sendInput = vi.fn(() => true)
+    const sendInputAccepted = vi.fn(async () => true)
+    const { manager, pane } = createManager()
+    const transport = createTransport(sendInput, 'pty-1', sendInputAccepted)
+
+    const result = await writeTerminalDropPathsToCapturedTarget({
+      dropTarget: { paneId: pane.id, leafId: pane.leafId, ptyId: 'pty-1', transport } as never,
+      manager: manager as never,
+      paneTransports: new Map([[pane.id, transport]]) as never,
+      paths: ['/repo/My Screenshot.png'],
+      targetShell: 'posix'
+    })
+
+    expect(result).toEqual({ sentAnyPath: true, targetCurrent: true, pathsWritten: 1 })
+    // Why: image attachment detection in terminal TUIs keys off bracketed paste
+    // of the literal path — no shell-escaping, no trailing space.
+    expect(sendInputAccepted).toHaveBeenCalledWith(
+      wrapTerminalBracketedPasteText('/repo/My Screenshot.png')
+    )
+  })
+
+  it('keeps shell-escaped input for mixed image and non-image drops', async () => {
+    const sendInput = vi.fn(() => true)
+    const sendInputAccepted = vi.fn(async () => true)
+    const { manager, pane } = createManager()
+    const transport = createTransport(sendInput, 'pty-1', sendInputAccepted)
+
+    await writeTerminalDropPathsToCapturedTarget({
+      dropTarget: { paneId: pane.id, leafId: pane.leafId, ptyId: 'pty-1', transport } as never,
+      manager: manager as never,
+      paneTransports: new Map([[pane.id, transport]]) as never,
+      paths: ['/repo/a.ts', '/repo/shot.png'],
+      targetShell: 'posix'
+    })
+
+    expect(sendInputAccepted).toHaveBeenNthCalledWith(1, '/repo/a.ts ')
+    expect(sendInputAccepted).toHaveBeenNthCalledWith(
+      2,
+      wrapTerminalBracketedPasteText('/repo/shot.png')
+    )
   })
 
   it('times out dropped path writes that never receive PTY acknowledgement', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.test.ts
@@ -95,6 +95,55 @@ describe('terminal drop path writer', () => {
     )
   })
 
+  it('separates an image paste from a following non-image path', async () => {
+    const sendInput = vi.fn(() => true)
+    const sendInputAccepted = vi.fn(async () => true)
+    const { manager, pane } = createManager()
+    const transport = createTransport(sendInput, 'pty-1', sendInputAccepted)
+
+    await writeTerminalDropPathsToCapturedTarget({
+      dropTarget: { paneId: pane.id, leafId: pane.leafId, ptyId: 'pty-1', transport } as never,
+      manager: manager as never,
+      paneTransports: new Map([[pane.id, transport]]) as never,
+      paths: ['/repo/shot.png', '/repo/a.ts'],
+      targetShell: 'posix'
+    })
+
+    // Why: the image paste carries no trailing space of its own, so a following
+    // non-image path would collide with it without an explicit separator.
+    expect(sendInputAccepted).toHaveBeenNthCalledWith(
+      1,
+      `${wrapTerminalBracketedPasteText('/repo/shot.png')} `
+    )
+    expect(sendInputAccepted).toHaveBeenNthCalledWith(2, '/repo/a.ts ')
+  })
+
+  it('does not insert a separator between back-to-back image pastes', async () => {
+    const sendInput = vi.fn(() => true)
+    const sendInputAccepted = vi.fn(async () => true)
+    const { manager, pane } = createManager()
+    const transport = createTransport(sendInput, 'pty-1', sendInputAccepted)
+
+    await writeTerminalDropPathsToCapturedTarget({
+      dropTarget: { paneId: pane.id, leafId: pane.leafId, ptyId: 'pty-1', transport } as never,
+      manager: manager as never,
+      paneTransports: new Map([[pane.id, transport]]) as never,
+      paths: ['/repo/one.png', '/repo/two.png'],
+      targetShell: 'posix'
+    })
+
+    // Why: bracketed pastes are self-delimiting; a stray space would land in the
+    // TUI input between the two attachments.
+    expect(sendInputAccepted).toHaveBeenNthCalledWith(
+      1,
+      wrapTerminalBracketedPasteText('/repo/one.png')
+    )
+    expect(sendInputAccepted).toHaveBeenNthCalledWith(
+      2,
+      wrapTerminalBracketedPasteText('/repo/two.png')
+    )
+  })
+
   it('times out dropped path writes that never receive PTY acknowledgement', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.ts
@@ -37,7 +37,7 @@ export async function writeTerminalDropPathsToCapturedTarget({
 }): Promise<TerminalDropPathWriteResult> {
   let sentAnyPath = false
   let pathsWritten = 0
-  for (const path of paths) {
+  for (const [index, path] of paths.entries()) {
     // Why: acknowledged PTY writes are async, so a multi-path drop can outlive
     // the pane or PTY it originally targeted.
     const liveTransport = getCurrentTerminalDropTransport(manager, paneTransports, dropTarget)
@@ -50,8 +50,16 @@ export async function writeTerminalDropPathsToCapturedTarget({
     // Shell-escaping would corrupt the file-existence check those tools run on
     // the pasted path, so images bypass it. Non-image drops keep the original
     // shell-escaped, space-separated behaviour for use in shell commands.
+    //
+    // Image payloads carry no trailing space of their own, so when an image is
+    // immediately followed by a non-image path the two would otherwise collide
+    // (`<bracketed-paste>/repo/a.ts`). Add a single separating space in that
+    // case only — back-to-back image pastes are self-delimiting and a stray
+    // space between them would land in the TUI input.
+    const nextPath = paths[index + 1]
+    const needsSeparatorAfterImage = nextPath !== undefined && !isImageDropPath(nextPath)
     const payload = isImageDropPath(path)
-      ? wrapTerminalBracketedPasteText(path)
+      ? `${wrapTerminalBracketedPasteText(path)}${needsSeparatorAfterImage ? ' ' : ''}`
       : `${shellEscapePath(path, targetShell)} `
     const writeResult = await runTerminalPasteOperationWithTimeout(
       () => writeTerminalPastePtyInput(liveTransport, payload),

--- a/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.ts
@@ -1,6 +1,8 @@
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { shellEscapePath } from './pane-helpers'
 import type { PtyTransport } from './pty-transport'
+import { wrapTerminalBracketedPasteText } from './terminal-bracketed-paste'
+import { isImageDropPath } from './terminal-drop-image-path'
 import {
   type CapturedTerminalDropTarget,
   getCurrentTerminalDropTransport
@@ -42,8 +44,17 @@ export async function writeTerminalDropPathsToCapturedTarget({
     if (!liveTransport) {
       return { sentAnyPath, targetCurrent: false, pathsWritten, failureReason: 'target-stale' }
     }
+    // Why: image drops are attachment payloads for terminal TUIs, which detect
+    // them from a bracketed paste of the raw (un-escaped) path — mirroring the
+    // clipboard screenshot flow (terminal-clipboard-paste.ts, issue #2842).
+    // Shell-escaping would corrupt the file-existence check those tools run on
+    // the pasted path, so images bypass it. Non-image drops keep the original
+    // shell-escaped, space-separated behaviour for use in shell commands.
+    const payload = isImageDropPath(path)
+      ? wrapTerminalBracketedPasteText(path)
+      : `${shellEscapePath(path, targetShell)} `
     const writeResult = await runTerminalPasteOperationWithTimeout(
-      () => writeTerminalPastePtyInput(liveTransport, `${shellEscapePath(path, targetShell)} `),
+      () => writeTerminalPastePtyInput(liveTransport, payload),
       operationTimeoutMs
     )
     if (writeResult.timedOut) {

--- a/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-path-writer.ts
@@ -2,7 +2,7 @@ import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { shellEscapePath } from './pane-helpers'
 import type { PtyTransport } from './pty-transport'
 import { wrapTerminalBracketedPasteText } from './terminal-bracketed-paste'
-import { isImageDropPath } from './terminal-drop-image-path'
+import { canPasteImageDropPathRaw, isImageDropPath } from './terminal-drop-image-path'
 import {
   type CapturedTerminalDropTarget,
   getCurrentTerminalDropTransport
@@ -48,17 +48,23 @@ export async function writeTerminalDropPathsToCapturedTarget({
     // them from a bracketed paste of the raw (un-escaped) path — mirroring the
     // clipboard screenshot flow (terminal-clipboard-paste.ts, issue #2842).
     // Shell-escaping would corrupt the file-existence check those tools run on
-    // the pasted path, so images bypass it. Non-image drops keep the original
-    // shell-escaped, space-separated behaviour for use in shell commands.
+    // the pasted path, so safe image paths bypass it. Unsafe image paths and
+    // non-image drops keep the original shell-escaped, space-separated
+    // behaviour for use in shell commands.
     //
     // Image payloads carry no trailing space of their own, so when an image is
     // immediately followed by a non-image path the two would otherwise collide
     // (`<bracketed-paste>/repo/a.ts`). Add a single separating space in that
     // case only — back-to-back image pastes are self-delimiting and a stray
     // space between them would land in the TUI input.
+    const pathIsRawPasteImage = isImageDropPath(path) && canPasteImageDropPathRaw(path, targetShell)
     const nextPath = paths[index + 1]
-    const needsSeparatorAfterImage = nextPath !== undefined && !isImageDropPath(nextPath)
-    const payload = isImageDropPath(path)
+    const nextPathIsRawPasteImage =
+      nextPath !== undefined &&
+      isImageDropPath(nextPath) &&
+      canPasteImageDropPathRaw(nextPath, targetShell)
+    const needsSeparatorAfterImage = nextPath !== undefined && !nextPathIsRawPasteImage
+    const payload = pathIsRawPasteImage
       ? `${wrapTerminalBracketedPasteText(path)}${needsSeparatorAfterImage ? ' ' : ''}`
       : `${shellEscapePath(path, targetShell)} `
     const writeResult = await runTerminalPasteOperationWithTimeout(

--- a/src/shared/image-file-extensions.ts
+++ b/src/shared/image-file-extensions.ts
@@ -1,0 +1,12 @@
+export const IMAGE_FILE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon'
+}
+
+export const IMAGE_FILE_EXTENSIONS = Object.freeze(Object.keys(IMAGE_FILE_MIME_TYPES))


### PR DESCRIPTION
## Summary

Dragging an image file into a terminal pane inserted the **literal file path** instead of an `[Image]` attachment placeholder in terminal TUIs (Claude Code, Codex, etc.).

Root cause: the native drop writer (`terminal-drop-path-writer.ts`) sends the shell-escaped path as **raw PTY input**. Terminal TUIs only turn a path into an image attachment when it arrives as a **bracketed paste** (`ESC[200~ … ESC[201~`). iTerm2 and Warp wrap dropped paths in bracketed paste, so the placeholder works there — and Orca's own **clipboard** screenshot flow already does this via `forceBracketedPaste` (#2842). Only the **drag-and-drop** path was missing it.

Fix: route dropped **image** files (detected by extension, mirroring `IMAGE_MIME_TYPES` in `src/relay/fs-handler-utils.ts`) through `wrapTerminalBracketedPasteText` with the **raw, un-escaped** path — so the file-existence check those tools run on the pasted path succeeds, matching the clipboard behavior. Non-image drops keep the original shell-escaped, space-separated behavior for use in shell commands.

This works for local, SSH, and runtime drops, since they all funnel through `writeTerminalDropPathsToCapturedTarget`.

## Screenshots

No visual change (terminal byte stream only). Behavioral change: dropping `foo.png` now yields an `[Image]` attachment in Claude Code / Codex instead of a raw path.

## Testing

- [x] `pnpm test` — ran the affected files (`terminal-drop-image-path.test.ts`, `terminal-drop-path-writer.test.ts`): **8 passed**. Full suite not run locally.
- [x] lint — `oxlint` clean on the 4 changed files. Full `pnpm lint` (localization catalog etc.) not run locally.
- [ ] `pnpm typecheck` — not run locally (heavy `tsgo` full-project run); changes are small and types are trivial.
- [ ] `pnpm build` — not run locally.
- [x] Added unit tests covering image detection (incl. case-insensitivity, Windows separators, dotted directories) and the writer branch (image → bracketed paste of raw path; mixed image/non-image drops keep escaping).

## AI Review Report

Reviewed with Claude Code. Checks and outcomes:
- **Correctness:** image branch must use the raw path (no shell-escaping) so the TUI's file-exists check matches; verified against the clipboard flow which pastes the raw temp path. Confirmed `wrapTerminalBracketedPasteText` already sanitizes embedded `ESC`.
- **Cross-platform (macOS/Linux/Windows):** `isImageDropPath` handles both `/` and `\` separators and is case-insensitive; the dot must be in the basename so dotted directories (`/home/jane.doe/photo`) aren't misclassified. The image branch is shell-agnostic; the `posix`/`windows` shell-escaping path is untouched for non-image drops, so Windows command usage is unchanged.
- **Scope:** only the per-path payload construction changed; PTY backpressure, timeout, and stale-target handling are untouched.

## Security Audit

- **Path handling:** no path is executed; the dropped path is wrapped in constant bracketed-paste markers and written to the PTY. Bracketed paste prevents the receiving shell from executing the content. Embedded `ESC` bytes are neutralized by `sanitizeTerminalPasteText` inside `wrapTerminalBracketedPasteText`.
- **Command execution / IPC / secrets:** none introduced; no new IPC surface, no shell invocation, no dependency changes.
- Follow-up: none required.

## Notes

- Extension set mirrors `IMAGE_MIME_TYPES` (`.png/.jpg/.jpeg/.gif/.svg/.webp/.bmp/.ico`) to keep "what Orca considers an image" consistent app-wide.
- Trade-off (intentional, matches the clipboard flow): dropping an image into a plain (non-TUI) shell now inserts the raw path via bracketed paste rather than a shell-escaped string. Orca's agent-terminal use case is the dominant one, and the clipboard flow already made this same choice.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6013">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->