### PR TITLE
Fix early PTY startup output races

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -756,6 +756,18 @@ describe('createPtySubprocess', () => {
     expect(data).toEqual(['hello'])
   })
 
+  it('replays data emitted before the Session registers onData', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    proc._simulateData('early setup output\r\n')
+    const data: string[] = []
+    handle.onData((d) => data.push(d))
+
+    expect(data).toEqual(['early setup output\r\n'])
+  })
+
   it('routes onExit events', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
@@ -766,6 +778,36 @@ describe('createPtySubprocess', () => {
 
     proc._simulateExit(42)
     expect(codes).toEqual([42])
+  })
+
+  it('replays pre-listener data before a pre-listener exit', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    proc._simulateData('last output\r\n')
+    proc._simulateExit(7)
+    const data: string[] = []
+    const codes: number[] = []
+    handle.onData((d) => data.push(d))
+    handle.onExit((code) => codes.push(code))
+
+    expect(data).toEqual(['last output\r\n'])
+    expect(codes).toEqual([7])
+  })
+
+  it('preserves pre-listener data when onExit is registered before onData', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    proc._simulateData('last output\r\n')
+    proc._simulateExit(7)
+    const events: string[] = []
+    handle.onExit((code) => events.push(`exit:${code}`))
+    handle.onData((data) => events.push(`data:${data}`))
+
+    expect(events).toEqual(['exit:7', 'data:last output\r\n'])
   })
 
   it('sends signal via process.kill', () => {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -46,6 +46,7 @@ const FOREGROUND_AGENT_CACHE_TTL_MS = 1000
 const SHELL_FOREGROUND_REFRESH_RETRY_MS = 5_000
 const STARTUP_AGENT_FOREGROUND_BOOTSTRAP_MS = 5_000
 const PTY_SPAWN_HEALTH_TIMEOUT_MS = 2_000
+const PENDING_PRE_LISTENER_DATA_MAX_CHARS = 512 * 1024
 
 export type PtySubprocessOptions = {
   sessionId: string
@@ -628,9 +629,52 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
 
   let onDataCb: ((data: string) => void) | null = null
   let onExitCb: ((code: number) => void) | null = null
+  let pendingPreListenerData: string[] = []
+  let pendingPreListenerDataChars = 0
+  let pendingPreListenerExitCode: number | null = null
 
-  proc.onData((data) => onDataCb?.(data))
-  proc.onExit(({ exitCode }) => onExitCb?.(exitCode))
+  const bufferPreListenerData = (data: string): void => {
+    // Why: Windows shell-arg startup commands can print before Session wires
+    // this subprocess into the daemon. Preserve that spawn-time race window.
+    pendingPreListenerData.push(data)
+    pendingPreListenerDataChars += data.length
+    while (pendingPreListenerDataChars > PENDING_PRE_LISTENER_DATA_MAX_CHARS) {
+      const removed = pendingPreListenerData.shift()
+      if (removed === undefined) {
+        pendingPreListenerDataChars = 0
+        return
+      }
+      pendingPreListenerDataChars -= removed.length
+    }
+  }
+
+  const flushPreListenerData = (): void => {
+    if (!onDataCb || pendingPreListenerData.length === 0) {
+      return
+    }
+    const pending = pendingPreListenerData
+    pendingPreListenerData = []
+    pendingPreListenerDataChars = 0
+    for (const data of pending) {
+      onDataCb(data)
+    }
+  }
+
+  proc.onData((data) => {
+    if (onDataCb) {
+      onDataCb(data)
+    } else {
+      bufferPreListenerData(data)
+    }
+  })
+  proc.onExit(({ exitCode }) => {
+    if (onExitCb) {
+      flushPreListenerData()
+      onExitCb(exitCode)
+    } else {
+      pendingPreListenerExitCode = exitCode
+    }
+  })
 
   // Why: node-pty's native NAPI layer throws a C++ Napi::Error when
   // write/resize/kill is called on a PTY whose underlying fd is already
@@ -846,9 +890,16 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     },
     onData: (cb) => {
       onDataCb = cb
+      flushPreListenerData()
     },
     onExit: (cb) => {
       onExitCb = cb
+      if (pendingPreListenerExitCode !== null) {
+        const code = pendingPreListenerExitCode
+        pendingPreListenerExitCode = null
+        flushPreListenerData()
+        cb(code)
+      }
     },
     dispose: () => {
       if (disposed) {
@@ -858,6 +909,9 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       dead = true
       onDataCb = null
       onExitCb = null
+      pendingPreListenerData = []
+      pendingPreListenerDataChars = 0
+      pendingPreListenerExitCode = null
       // Why: UnixTerminal.destroy() registers `_socket.once('close', () => this.kill('SIGHUP'))`
       // (unixTerminal.js:219-229). The socket close fires asynchronously; by then
       // the child may have exited and its pid been recycled to an unrelated

--- a/src/renderer/src/components/terminal-pane/pty-data-sidecar-subscriptions.ts
+++ b/src/renderer/src/components/terminal-pane/pty-data-sidecar-subscriptions.ts
@@ -1,0 +1,23 @@
+import { ensurePtyDispatcher, ptyDataSidecars } from './pty-dispatcher'
+
+/** Register a side-channel data watcher for a PTY without taking ownership
+ *  of the primary handler. Returns an unsubscribe fn. */
+export function subscribeToPtyData(ptyId: string, watcher: (data: string) => void): () => void {
+  ensurePtyDispatcher()
+  let set = ptyDataSidecars.get(ptyId)
+  if (!set) {
+    set = new Set()
+    ptyDataSidecars.set(ptyId, set)
+  }
+  set.add(watcher)
+  return () => {
+    const current = ptyDataSidecars.get(ptyId)
+    if (!current) {
+      return
+    }
+    current.delete(watcher)
+    if (current.size === 0) {
+      ptyDataSidecars.delete(ptyId)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
@@ -24,10 +24,12 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
   let dispatcherCallback:
     | ((payload: { id: string; data: string; rawLength?: number }) => void)
     | null = null
+  let exitDispatcherCallback: ((payload: { id: string; code: number }) => void) | null = null
 
   beforeEach(() => {
     vi.resetModules()
     dispatcherCallback = null
+    exitDispatcherCallback = null
     ;(globalThis as { window: typeof window }).window = {
       ...originalWindow,
       api: {
@@ -53,7 +55,12 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
             }
           ),
           onReplay: vi.fn(() => () => {}),
-          onExit: vi.fn(() => () => {})
+          onExit: vi.fn((cb: (payload: { id: string; code: number }) => void) => {
+            if (!exitDispatcherCallback) {
+              exitDispatcherCallback = cb
+            }
+            return () => {}
+          })
         }
       }
     } as unknown as typeof window
@@ -253,5 +260,59 @@ describe('dispatcher → transport → onTitleChange for Pi spinner', () => {
     expect(seenTitles).toContain('Codex ready')
 
     transport.disconnect()
+  })
+
+  it('replays PTY data that arrives before connect() registers the pane handler', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onData = vi.fn()
+    let resolveSpawn: (value: { id: string }) => void = () => {}
+
+    ;(window.api.pty.spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSpawn = resolve
+      })
+    )
+
+    const transport = createIpcPtyTransport()
+    const connectPromise = transport.connect({ url: '', callbacks: { onData } })
+
+    dispatcherCallback?.({ id: 'pty-early', data: 'setup starts here\r\n', rawLength: 19 })
+    expect(onData).not.toHaveBeenCalled()
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-early', 19)
+
+    resolveSpawn({ id: 'pty-early' })
+    await connectPromise
+
+    expect(onData).toHaveBeenCalledWith('setup starts here\r\n', { rawLength: 19 })
+
+    transport.disconnect()
+  })
+
+  it('replays pre-handler PTY data before a pre-handler exit', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const events: string[] = []
+    let resolveSpawn: (value: { id: string }) => void = () => {}
+
+    ;(window.api.pty.spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSpawn = resolve
+      })
+    )
+
+    const transport = createIpcPtyTransport()
+    const connectPromise = transport.connect({
+      url: '',
+      callbacks: {
+        onData: (data) => events.push(`data:${data}`),
+        onExit: (code) => events.push(`exit:${code}`)
+      }
+    })
+
+    dispatcherCallback?.({ id: 'pty-fast-exit', data: 'last line\r\n', rawLength: 11 })
+    exitDispatcherCallback?.({ id: 'pty-fast-exit', code: 3 })
+    resolveSpawn({ id: 'pty-fast-exit' })
+    await connectPromise
+
+    expect(events).toEqual(['data:last line\r\n', 'exit:3'])
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -11,6 +11,11 @@ import type { ProjectExecutionRuntimeResolution } from '../../../../shared/proje
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
 import { ackPtyData, exposeE2eTerminalPtyAckGate } from './terminal-pty-ack-gate'
 import { clampUtf8Tail, type EagerBufferChunk } from './pty-eager-buffer-clamp'
+import {
+  bufferPreHandlerPtyData,
+  bufferPreHandlerPtyExit,
+  clearPreHandlerPtyState
+} from './pty-pre-handler-buffer'
 
 // ── Singleton PTY event dispatcher ───────────────────────────────────
 // One global IPC listener per channel, routes events to transports by
@@ -41,28 +46,6 @@ export const ptyDataHandlers = new Map<string, (data: string, meta?: PtyDataMeta
  *  active subscription; removal is by Set.delete inside the unsubscribe fn. */
 export const ptyDataSidecars = new Map<string, Set<(data: string) => void>>()
 
-/** Register a side-channel data watcher for a PTY without taking ownership
- *  of the primary handler. Returns an unsubscribe fn. ensurePtyDispatcher()
- *  is called automatically so the underlying IPC stream is wired up. */
-export function subscribeToPtyData(ptyId: string, watcher: (data: string) => void): () => void {
-  ensurePtyDispatcher()
-  let set = ptyDataSidecars.get(ptyId)
-  if (!set) {
-    set = new Set()
-    ptyDataSidecars.set(ptyId, set)
-  }
-  set.add(watcher)
-  return () => {
-    const current = ptyDataSidecars.get(ptyId)
-    if (!current) {
-      return
-    }
-    current.delete(watcher)
-    if (current.size === 0) {
-      ptyDataSidecars.delete(ptyId)
-    }
-  }
-}
 /** Per-PTY replay handlers for relay pty.attach replay data. Routed through
  *  a dedicated pty:replay IPC channel so the renderer can engage the replay
  *  guard and suppress xterm auto-replies during replay. */
@@ -105,6 +88,7 @@ export function unregisterPtyDataHandlers(ptyIds: string[]): PtyDataHandlerShutd
     ptyReplayHandlers.delete(id)
     ptyTeardownHandlers.get(id)?.()
     ptyTeardownHandlers.delete(id)
+    clearPreHandlerPtyState(id)
   }
   return snapshots
 }
@@ -142,7 +126,12 @@ export function ensurePtyDispatcher(): void {
         meta ??= {}
         meta.rawLength = payload.rawLength
       }
-      ptyDataHandlers.get(payload.id)?.(payload.data, meta)
+      const handler = ptyDataHandlers.get(payload.id)
+      if (handler) {
+        handler(payload.data, meta)
+      } else {
+        bufferPreHandlerPtyData(payload.id, payload.data, meta)
+      }
       const sidecars = ptyDataSidecars.get(payload.id)
       if (sidecars && sidecars.size > 0) {
         // Why: snapshot the Set before iterating because watchers commonly
@@ -168,7 +157,13 @@ export function ensurePtyDispatcher(): void {
     ptyReplayHandlers.get(payload.id)?.(payload.data)
   })
   window.api.pty.onExit((payload) => {
-    ptyExitHandlers.get(payload.id)?.(payload.code)
+    const handler = ptyExitHandlers.get(payload.id)
+    if (handler) {
+      clearPreHandlerPtyState(payload.id)
+      handler(payload.code)
+    } else {
+      bufferPreHandlerPtyExit(payload.id, payload.code)
+    }
     const sidecars = ptyExitSidecars.get(payload.id)
     if (sidecars && sidecars.size > 0) {
       const snapshot = Array.from(sidecars)

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -1,0 +1,81 @@
+import { clampUtf8Tail } from './pty-eager-buffer-clamp'
+import type { PtyDataMeta } from './pty-dispatcher'
+
+type BufferedPreHandlerPtyData = {
+  data: string
+  bytes: number
+  meta?: PtyDataMeta
+}
+
+const preHandlerPtyData = new Map<string, BufferedPreHandlerPtyData[]>()
+const preHandlerPtyExit = new Map<string, number>()
+
+// Why: Windows startup commands can emit output before pty:spawn resolves and
+// the pane registers its handler. Hold that tiny race window instead of ACKing
+// and dropping the first setup-script bytes.
+const PRE_HANDLER_PTY_DATA_MAX_BYTES = 512 * 1024
+const PRE_HANDLER_PTY_DATA_MAX_PTYS = 64
+
+export function bufferPreHandlerPtyData(ptyId: string, data: string, meta?: PtyDataMeta): void {
+  const chunk = clampUtf8Tail(data, PRE_HANDLER_PTY_DATA_MAX_BYTES)
+  if (!chunk.data) {
+    return
+  }
+  if (!preHandlerPtyData.has(ptyId) && preHandlerPtyData.size >= PRE_HANDLER_PTY_DATA_MAX_PTYS) {
+    const oldestPtyId = preHandlerPtyData.keys().next().value
+    if (typeof oldestPtyId === 'string') {
+      preHandlerPtyData.delete(oldestPtyId)
+    }
+  }
+  const bufferedMeta =
+    meta && chunk.data.length !== data.length && typeof meta.rawLength === 'number'
+      ? { ...meta, rawLength: chunk.bytes }
+      : meta
+  const chunks = preHandlerPtyData.get(ptyId) ?? []
+  chunks.push({
+    data: chunk.data,
+    bytes: chunk.bytes,
+    ...(bufferedMeta ? { meta: bufferedMeta } : {})
+  })
+  let totalBytes = chunks.reduce((total, entry) => total + entry.bytes, 0)
+  while (totalBytes > PRE_HANDLER_PTY_DATA_MAX_BYTES && chunks.length > 1) {
+    totalBytes -= chunks.shift()?.bytes ?? 0
+  }
+  preHandlerPtyData.set(ptyId, chunks)
+}
+
+export function drainPreHandlerPtyData(
+  ptyId: string,
+  handler: (data: string, meta?: PtyDataMeta) => void
+): void {
+  const chunks = preHandlerPtyData.get(ptyId)
+  if (!chunks) {
+    return
+  }
+  preHandlerPtyData.delete(ptyId)
+  for (const chunk of chunks) {
+    handler(chunk.data, chunk.meta)
+  }
+}
+
+export function bufferPreHandlerPtyExit(ptyId: string, code: number): void {
+  preHandlerPtyExit.set(ptyId, code)
+}
+
+export function drainPreHandlerPtyExit(ptyId: string, handler: (code: number) => void): void {
+  const code = preHandlerPtyExit.get(ptyId)
+  if (code === undefined) {
+    return
+  }
+  preHandlerPtyExit.delete(ptyId)
+  handler(code)
+}
+
+export function clearPreHandlerPtyData(ptyId: string): void {
+  preHandlerPtyData.delete(ptyId)
+}
+
+export function clearPreHandlerPtyState(ptyId: string): void {
+  preHandlerPtyData.delete(ptyId)
+  preHandlerPtyExit.delete(ptyId)
+}

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -21,6 +21,7 @@ import {
   ensurePtyDispatcher,
   getEagerPtyBufferHandle
 } from './pty-dispatcher'
+import { drainPreHandlerPtyData, drainPreHandlerPtyExit } from './pty-pre-handler-buffer'
 import type {
   PtyTransport,
   IpcPtyTransportOptions,
@@ -508,7 +509,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         storedCallbacks.onData?.(data)
       }
     })
-    ptyDataHandlers.set(id, (data, meta) => {
+    const dataHandler = (data: string, meta?: PtyDataMeta): void => {
       outputProcessor.processData(
         data,
         storedCallbacks,
@@ -518,7 +519,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         },
         meta
       )
-    })
+    }
+    ptyDataHandlers.set(id, dataHandler)
+    drainPreHandlerPtyData(id, dataHandler)
   }
 
   function clearAccumulatedState(): void {
@@ -635,7 +638,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   }
 
   function registerPtyExitHandler(id: string): void {
-    ptyExitHandlers.set(id, (code) => {
+    const exitHandler = (code: number): void => {
       clearAccumulatedState()
       connected = false
       ptyId = null
@@ -643,7 +646,8 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       storedCallbacks.onExit?.(code)
       storedCallbacks.onDisconnect?.()
       onPtyExit?.(id)
-    })
+    }
+    ptyExitHandlers.set(id, exitHandler)
     // Why: shutdownWorktreeTerminals bypasses the transport layer — it
     // kills PTYs directly via IPC without calling disconnect()/destroy().
     // This teardown callback lets unregisterPtyDataHandlers cancel
@@ -651,6 +655,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     // would otherwise fire stale notifications after the data handler
     // is removed but before the exit event arrives.
     ptyTeardownHandlers.set(id, clearAccumulatedState)
+    drainPreHandlerPtyExit(id, exitHandler)
   }
 
   return {
@@ -699,6 +704,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
 
         registerPtyDataHandler(spawnResult.id)
         registerPtyExitHandler(spawnResult.id)
+        if (!connected || ptyId !== spawnResult.id) {
+          return undefined
+        }
 
         storedCallbacks.onConnect?.()
         storedCallbacks.onStatus?.('shell')
@@ -769,6 +777,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       // recency sort order that reconnectPersistedTerminals preserved.
       registerPtyDataHandler(id)
       registerPtyExitHandler(id)
+      if (!connected || ptyId !== id) {
+        return
+      }
 
       // Why: hidden automation PTYs may have already rendered their TUI into
       // the eager buffer. Clear stale pane contents before replaying that

--- a/src/renderer/src/lib/agent-draft-readiness.ts
+++ b/src/renderer/src/lib/agent-draft-readiness.ts
@@ -1,6 +1,6 @@
 import type { DraftPasteReadySignal } from '../../../shared/tui-agent-config'
 import type { GlobalSettings } from '../../../shared/types'
-import { subscribeToPtyData } from '@/components/terminal-pane/pty-dispatcher'
+import { subscribeToPtyData } from '@/components/terminal-pane/pty-data-sidecar-subscriptions'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 import { subscribeToRuntimeTerminalData } from '@/runtime/runtime-terminal-stream'
 

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -35,7 +35,7 @@ vi.mock('@/store', () => ({
   }
 }))
 
-vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+vi.mock('@/components/terminal-pane/pty-data-sidecar-subscriptions', () => ({
   subscribeToPtyData: testState.subscribeToPtyData
 }))
 

--- a/src/renderer/src/lib/automation-session-observer.ts
+++ b/src/renderer/src/lib/automation-session-observer.ts
@@ -1,4 +1,5 @@
-import { subscribeToPtyData, subscribeToPtyExit } from '@/components/terminal-pane/pty-dispatcher'
+import { subscribeToPtyData } from '@/components/terminal-pane/pty-data-sidecar-subscriptions'
+import { subscribeToPtyExit } from '@/components/terminal-pane/pty-dispatcher'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getRemoteRuntimeTerminalMultiplexer } from '@/runtime/remote-runtime-terminal-multiplexer'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -86,8 +86,11 @@ vi.mock('@/lib/agent-paste-draft', () => ({
 
 vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
   registerEagerPtyBuffer: mockRegisterEagerPtyBuffer,
-  subscribeToPtyData: mockSubscribeToPtyData,
   subscribeToPtyExit: mockSubscribeToPtyExit
+}))
+
+vi.mock('@/components/terminal-pane/pty-data-sidecar-subscriptions', () => ({
+  subscribeToPtyData: mockSubscribeToPtyData
 }))
 
 describe('launchAgentBackgroundSession', () => {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -16,9 +16,9 @@ import type { LaunchSource } from '../../../shared/telemetry-events'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import {
   registerEagerPtyBuffer,
-  subscribeToPtyData,
   subscribeToPtyExit
 } from '@/components/terminal-pane/pty-dispatcher'
+import { subscribeToPtyData } from '@/components/terminal-pane/pty-data-sidecar-subscriptions'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'


### PR DESCRIPTION
## Summary
- buffer daemon PTY output/exit events that arrive before `Session` registers subprocess listeners
- buffer renderer PTY data/exit events that arrive before transport handlers are registered
- cover the startup-output race exposed by Windows shell-arg startup delivery from #5753

## Why
#5753 speeds up Windows startup commands by embedding short commands in shell launch args. That lets setup-script output arrive before the next PTY layer has finished registering listeners. Previously those early chunks could be dropped, so setup panes appeared to start mid-command.

## Test plan
- pnpm vitest run --config config/vitest.config.ts src/main/daemon/pty-subprocess.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm exec oxlint src/main/daemon/pty-subprocess.ts src/main/daemon/pty-subprocess.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher.ts src/renderer/src/components/terminal-pane/pty-transport.ts src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6015">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->