### PR TITLE
Prevent interrupted Codex sessions from resuming after sleep

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -11,6 +11,7 @@ import type * as UseNotificationDispatchModule from './use-notification-dispatch
 import { getEagerPtyBufferHandle } from './pty-dispatcher'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalLayoutSnapshot } from '../../../../shared/types'
+import { collectSleepingAgentSessionRecordsForWorktree } from '@/store/slices/agent-status'
 
 // Repro command:
 //   pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "OpenTUI-style small ANSI redraw"
@@ -514,15 +515,48 @@ describe('connectPanePty', () => {
       markWorktreeUnread: vi.fn(),
       observeTerminalGitHubPullRequestLink: vi.fn(),
       recordTerminalInput: vi.fn(),
-      setAgentStatus: vi.fn((paneKey: string, payload: Record<string, unknown>) => {
-        mockStoreState.agentStatusByPaneKey[paneKey] = {
-          ...payload,
-          paneKey,
-          updatedAt: Date.now(),
-          stateStartedAt: Date.now(),
-          stateHistory: []
+      setAgentStatus: vi.fn(
+        (
+          paneKey: string,
+          payload: Record<string, unknown>,
+          terminalTitle?: string,
+          timing?: { updatedAt?: number; stateStartedAt?: number },
+          routing?: { tabId?: string; worktreeId?: string; terminalHandle?: string },
+          metadata?: { providerSession?: unknown }
+        ) => {
+          const existing = mockStoreState.agentStatusByPaneKey[paneKey] as
+            | Record<string, unknown>
+            | undefined
+          const updatedAt = timing?.updatedAt ?? Date.now()
+          const stateStartedAt =
+            timing?.stateStartedAt ??
+            (existing &&
+            existing.state === payload.state &&
+            typeof existing.stateStartedAt === 'number'
+              ? existing.stateStartedAt
+              : updatedAt)
+
+          if (payload.state === 'done') {
+            delete mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]
+          }
+
+          const providerSession =
+            metadata?.providerSession ?? (existing?.providerSession as unknown | undefined)
+          mockStoreState.agentStatusByPaneKey[paneKey] = {
+            ...existing,
+            ...payload,
+            paneKey,
+            updatedAt,
+            stateStartedAt,
+            terminalTitle: terminalTitle ?? existing?.terminalTitle,
+            stateHistory: existing?.stateHistory ?? [],
+            tabId: routing?.tabId ?? existing?.tabId,
+            worktreeId: routing?.worktreeId ?? existing?.worktreeId,
+            terminalHandle: routing?.terminalHandle ?? existing?.terminalHandle,
+            ...(providerSession ? { providerSession } : {})
+          }
         }
-      }),
+      ),
       removeAgentStatus: vi.fn(),
       dropAgentStatus: vi.fn(),
       markTerminalTabUnread: vi.fn(),
@@ -1726,6 +1760,310 @@ describe('connectPanePty', () => {
       intent: 'ctrl-c'
     })
     expect(mockStoreState.dropAgentStatus).not.toHaveBeenCalled()
+  })
+
+  it('marks a stale Codex working row interrupted after a second idle Ctrl+C', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.agentStatus.inferInterrupt).mockResolvedValue(true)
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState.runtimePaneTitlesByTabId = {
+      'tab-1': {
+        1: 'taimen'
+      }
+    }
+    const providerSession = { key: 'session_id', id: 'codex-session-1' } as const
+    mockStoreState.agentStatusByPaneKey[paneKey] = {
+      state: 'working',
+      prompt: 'sleep 120',
+      updatedAt: 1_000,
+      stateStartedAt: 900,
+      agentType: 'codex',
+      paneKey,
+      terminalTitle: 'taimen',
+      providerSession,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      terminalHandle: 'tab-pty',
+      stateHistory: []
+    }
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'codex',
+      providerSession,
+      prompt: 'sleep 120',
+      state: 'working',
+      capturedAt: 1_050,
+      updatedAt: 1_000,
+      terminalTitle: 'taimen',
+      origin: 'live'
+    }
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x03')
+    await flushAsyncTicks()
+    vi.advanceTimersByTime(500)
+    await flushAsyncTicks()
+
+    expect(window.api.agentStatus.inferInterrupt).toHaveBeenCalledWith({
+      paneKey,
+      baselineUpdatedAt: 1_000,
+      baselineStateStartedAt: 900,
+      baselinePrompt: 'sleep 120',
+      baselineAgentType: 'codex',
+      intent: 'ctrl-c'
+    })
+    expect(mockStoreState.agentStatusByPaneKey[paneKey]).toMatchObject({
+      state: 'done',
+      prompt: 'sleep 120',
+      agentType: 'codex',
+      interrupted: true,
+      providerSession,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      terminalHandle: 'tab-pty'
+    })
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
+    const sleepRecords = collectSleepingAgentSessionRecordsForWorktree(
+      {
+        ...mockStoreState,
+        retainedAgentsByPaneKey: {}
+      } as never,
+      'wt-1',
+      [paneKey]
+    )
+    expect(sleepRecords).not.toHaveProperty(paneKey)
+  })
+
+  it('does not locally mark or neutralize the title when a newer row wins the race', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const inferResult = createDeferred<boolean>()
+    vi.mocked(window.api.agentStatus.inferInterrupt).mockReturnValue(inferResult.promise)
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState.runtimePaneTitlesByTabId = {
+      'tab-1': {
+        1: 'Codex working'
+      }
+    }
+    mockStoreState.agentStatusByPaneKey[paneKey] = {
+      state: 'working',
+      prompt: 'old turn',
+      updatedAt: 1_000,
+      stateStartedAt: 900,
+      agentType: 'codex',
+      paneKey,
+      terminalTitle: 'Codex working',
+      stateHistory: []
+    }
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const deps = createDeps({
+      setRuntimePaneTitle: vi.fn()
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x03')
+    await flushAsyncTicks()
+    vi.advanceTimersByTime(500)
+    await flushAsyncTicks()
+
+    expect(window.api.agentStatus.inferInterrupt).toHaveBeenCalledWith({
+      paneKey,
+      baselineUpdatedAt: 1_000,
+      baselineStateStartedAt: 900,
+      baselinePrompt: 'old turn',
+      baselineAgentType: 'codex',
+      intent: 'ctrl-c'
+    })
+    mockStoreState.agentStatusByPaneKey[paneKey] = {
+      state: 'working',
+      prompt: 'new turn',
+      updatedAt: 1_250,
+      stateStartedAt: 1_250,
+      agentType: 'codex',
+      paneKey,
+      terminalTitle: 'Codex working',
+      stateHistory: []
+    }
+
+    inferResult.resolve(true)
+    await flushAsyncTicks()
+
+    expect(mockStoreState.agentStatusByPaneKey[paneKey]).toMatchObject({
+      state: 'working',
+      prompt: 'new turn',
+      updatedAt: 1_250,
+      stateStartedAt: 1_250
+    })
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+    expect(deps.setRuntimePaneTitle).not.toHaveBeenCalled()
+  })
+
+  it('neutralizes the title when main status already marked the same turn interrupted', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const inferResult = createDeferred<boolean>()
+    vi.mocked(window.api.agentStatus.inferInterrupt).mockReturnValue(inferResult.promise)
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState.runtimePaneTitlesByTabId = {
+      'tab-1': {
+        1: 'Codex working'
+      }
+    }
+    mockStoreState.agentStatusByPaneKey[paneKey] = {
+      state: 'working',
+      prompt: 'old turn',
+      updatedAt: 1_000,
+      stateStartedAt: 900,
+      agentType: 'codex',
+      paneKey,
+      terminalTitle: 'Codex working',
+      stateHistory: []
+    }
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const deps = createDeps({
+      setRuntimePaneTitle: vi.fn()
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x03')
+    await flushAsyncTicks()
+    vi.advanceTimersByTime(500)
+    await flushAsyncTicks()
+
+    mockStoreState.agentStatusByPaneKey[paneKey] = {
+      state: 'done',
+      prompt: 'old turn',
+      updatedAt: 1_250,
+      stateStartedAt: 1_250,
+      agentType: 'codex',
+      paneKey,
+      terminalTitle: 'Codex working',
+      interrupted: true,
+      stateHistory: [
+        {
+          state: 'working',
+          prompt: 'old turn',
+          startedAt: 900
+        }
+      ]
+    }
+
+    inferResult.resolve(true)
+    await flushAsyncTicks()
+
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+    expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'Terminal')
+  })
+
+  it('clears a matching sleeping record if sleep drops the live row before inference resolves', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const inferResult = createDeferred<boolean>()
+    vi.mocked(window.api.agentStatus.inferInterrupt).mockReturnValue(inferResult.promise)
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    const providerSession = { key: 'session_id', id: 'codex-session-1' } as const
+    mockStoreState.agentStatusByPaneKey[paneKey] = {
+      state: 'working',
+      prompt: 'sleep 120',
+      updatedAt: 1_000,
+      stateStartedAt: 900,
+      agentType: 'codex',
+      paneKey,
+      terminalTitle: 'taimen',
+      providerSession,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      terminalHandle: 'tab-pty',
+      stateHistory: []
+    }
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x03')
+    await flushAsyncTicks()
+    vi.advanceTimersByTime(500)
+    await flushAsyncTicks()
+
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'codex',
+      providerSession,
+      prompt: 'sleep 120',
+      state: 'working',
+      capturedAt: 1_120,
+      updatedAt: 1_000,
+      terminalTitle: 'taimen'
+    }
+    delete mockStoreState.agentStatusByPaneKey[paneKey]
+
+    inferResult.resolve(true)
+    await flushAsyncTicks()
+
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
   })
 
   it('keeps inferred interrupted status after the pane settles on a non-agent title', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -935,7 +935,63 @@ export function connectPanePty(
         .inferInterrupt(request)
         .then((applied) => {
           if (applied) {
-            clearInferredInterruptWorkingTitle()
+            const state = useAppStore.getState()
+            const current = state.agentStatusByPaneKey[cacheKey]
+            const sameBaseline =
+              current?.state === 'working' &&
+              current.agentType === request.baselineAgentType &&
+              current.prompt === request.baselinePrompt &&
+              current.updatedAt === request.baselineUpdatedAt &&
+              current.stateStartedAt === request.baselineStateStartedAt
+            const sameInterruptedCompletion =
+              current?.state === 'done' &&
+              current.interrupted === true &&
+              current.agentType === request.baselineAgentType &&
+              current.prompt === request.baselinePrompt &&
+              current.stateHistory?.some(
+                (history) =>
+                  history.state === 'working' &&
+                  history.prompt === request.baselinePrompt &&
+                  history.startedAt === request.baselineStateStartedAt
+              ) === true
+            const sleepingRecord = state.sleepingAgentSessionsByPaneKey[cacheKey]
+            const sameSleepingBaseline =
+              sleepingRecord?.state === 'working' &&
+              sleepingRecord.agent === request.baselineAgentType &&
+              sleepingRecord.prompt === request.baselinePrompt &&
+              sleepingRecord.updatedAt === request.baselineUpdatedAt
+
+            if (sameBaseline) {
+              const inferredAt = Date.now()
+              // Why: sleep capture can run before the main-process inferred
+              // status event round-trips; clear the stale working row locally too.
+              state.setAgentStatus(
+                cacheKey,
+                {
+                  state: 'done',
+                  prompt: current.prompt,
+                  agentType: current.agentType,
+                  interrupted: true
+                },
+                current.terminalTitle,
+                {
+                  updatedAt: inferredAt,
+                  stateStartedAt: inferredAt
+                },
+                {
+                  tabId: deps.tabId,
+                  worktreeId: current.worktreeId ?? deps.worktreeId,
+                  terminalHandle: current.terminalHandle
+                },
+                current.providerSession ? { providerSession: current.providerSession } : undefined
+              )
+            }
+            if (sameBaseline || sameInterruptedCompletion) {
+              clearInferredInterruptWorkingTitle()
+            }
+            if (sameSleepingBaseline) {
+              state.clearSleepingAgentSession(cacheKey)
+            }
           }
           return applied
         })

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -275,6 +275,11 @@ function sleepingRecordFromEntry(args: {
   capturedAt: number
   origin?: SleepingAgentSessionRecord['origin']
 }): SleepingAgentSessionRecord | null {
+  // Why: an inferred Ctrl+C completion is terminal evidence, not a session
+  // that manual sleep should later resume.
+  if (args.entry.state === 'done' && args.entry.interrupted) {
+    return null
+  }
   const agent = args.entry.agentType
   if (!isResumableTuiAgent(agent) || !args.entry.providerSession) {
     return null


### PR DESCRIPTION
## Summary

Fixes the stale agent lifecycle path where a Codex session interrupted with a second idle Ctrl+C could remain `working` in renderer state and later be captured as a resumable sleeping session.

The design keeps main-process `inferInterrupt` as the authority, then mirrors an accepted exact-baseline interrupt locally in the renderer so sleep capture cannot race the status IPC round-trip. It also clears matching sleeping recovery records if manual sleep captured the stale `working` row before the accepted inference resolved, and prevents interrupted `done` rows from being captured as sleeping sessions.

## Design Review

Brennan YOLO Lite design review completed clean after tightening two points:
- prove interrupted `done` rows and existing recovery records cannot become resumable sleep records;
- avoid title cleanup for newer rows, while still handling accepted same-turn interrupted completions.

Scratch design doc was kept out of the product diff.

## Implementation

Changed:
- `pty-connection.ts`: accepted interrupt inference now performs a strict same-baseline local `working -> done/interrupted` mirror, preserves routing/session metadata, clears stale same-turn titles, and clears matching sleeping records from the quick-sleep race.
- `agent-status.ts`: sleep-record construction skips `done` rows marked `interrupted`.
- `pty-connection.test.ts`: added deterministic regressions for stale second Ctrl+C, newer-row protection, main-status-before-promise ordering, quick-sleep capture before inference resolution, and manual sleep non-capture.

Deviation from initial scope: added the narrow collector guard in `agent-status.ts` because preserving provider sessions means an interrupted `done` row otherwise remains technically resumable during manual sleep capture. No wake/resume selection policy was changed.

## Completeness Verification

Read-only completeness verification passed. It confirmed same-baseline gating, title cleanup gating, provider/routing preservation, recovery-record removal, manual sleep filtering, SSH/cross-platform assumptions, and no agent-visible prompt text changes.

## Code Review Loop

Iterative two-reviewer loop completed clean after fixes.

Review findings fixed during the loop:
- handled ordering where main `done/interrupted` status arrives before the `inferInterrupt` promise resolves, so stale working titles are still neutralized for the same interrupted turn;
- handled quick manual sleep capture before delayed inference resolves by clearing only the matching sleeping record after main accepts the interrupt.

Final reviewer pair returned clean / no actionable findings.

## Brennan Test Changes

Final `brennan-test-changes` verdict: land.

Validated:
- focused PTY race coverage for stale row cleanup, newer row protection, title cleanup, and quick-sleep sleeping-record cleanup;
- manual sleep capture exclusion for interrupted `done` rows;
- Electron product-surface store behavior in the exact PR worktree.

Screenshot evidence captured locally and not committed:
- `.validation-evidence/brennan-yolo-lite-electron-2026-06-21.png`

Accepted gap: live Codex/manual double-Ctrl+C provider-session validation was not run because reproducing the stale provider-backed timing requires a real provider session and precise timing in a shared dev profile. The race logic is covered deterministically by focused tests.

## Checks Run

- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/agent-status.test.ts src/renderer/src/store/slices/agent-status-quit-capture.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/store/slices/agent-status.test.ts src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts`

## Post-PR Stabilization

Complete.

- Waited the required 8 minutes after opening the PR before checking automation.
- CodeRabbit posted no actionable comments. Its docstring-coverage pre-merge note is non-actionable for this TypeScript change and did not produce a failing GitHub check.
- GitHub checks passed:
  - `verify`
  - `track-community-pr`
- Final PR merge state: `CLEAN`.

This PR remains open and unmerged.