### PR TITLE
Bound TestFlight processing wait

### DIFF
--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -22,6 +22,10 @@ on:
         description: 'Optional TestFlight external tester changelog'
         required: false
         type: string
+      testflight_processing_timeout_seconds:
+        description: 'Optional TestFlight processing wait timeout in seconds'
+        required: false
+        type: string
 
 jobs:
   ios-build:
@@ -120,6 +124,7 @@ jobs:
           ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TESTFLIGHT_CHANGELOG: ${{ github.event.inputs.testflight_changelog }}
+          TESTFLIGHT_PROCESSING_TIMEOUT_SECONDS: ${{ github.event.inputs.testflight_processing_timeout_seconds }}
           # Keep fastlane non-interactive and quiet about analytics in CI.
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_HIDE_CHANGELOG: '1'

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -29,6 +29,7 @@ SCHEME = "Orca"
 BUNDLE_ID = "com.stably.orca.mobile"
 TESTFLIGHT_GROUPS = ["peeps"].freeze
 DEFAULT_TESTFLIGHT_CHANGELOG = "Latest Orca Mobile updates and fixes.".freeze
+DEFAULT_TESTFLIGHT_PROCESSING_TIMEOUT_SECONDS = 20 * 60
 
 def app_store_connect_api_key_from_env
   app_store_connect_api_key(
@@ -74,6 +75,15 @@ end
 def testflight_changelog
   changelog = ENV.fetch("TESTFLIGHT_CHANGELOG", "").strip
   changelog.empty? ? DEFAULT_TESTFLIGHT_CHANGELOG : changelog
+end
+
+def testflight_processing_timeout_seconds
+  value = ENV.fetch("TESTFLIGHT_PROCESSING_TIMEOUT_SECONDS", "").strip
+  return DEFAULT_TESTFLIGHT_PROCESSING_TIMEOUT_SECONDS if value.empty?
+
+  timeout_seconds = Integer(value, exception: false)
+  UI.user_error!("TESTFLIGHT_PROCESSING_TIMEOUT_SECONDS must be a positive integer") unless timeout_seconds&.positive?
+  timeout_seconds
 end
 
 platform :ios do
@@ -152,6 +162,7 @@ platform :ios do
       # Why: fastlane requires release notes when distributing to external
       # TestFlight testers, even for CI-triggered smoke releases.
       changelog: testflight_changelog,
+      wait_processing_timeout_duration: testflight_processing_timeout_seconds,
     )
   end
 end


### PR DESCRIPTION
## Summary
- Add a Mobile iOS Release input for the TestFlight processing wait timeout
- Default external TestFlight processing waits to 20 minutes instead of waiting indefinitely
- Validate custom timeout values before upload starts

## Verification
- ruby -c mobile/fastlane/Fastfile
- ruby -e "require 'yaml'; YAML.safe_load(File.read('.github/workflows/mobile-ios-release.yml'), aliases: true); puts 'YAML OK'"
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6017">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->