### PR TITLE
Align folder workspace sidebar indentation

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -337,14 +337,33 @@ function makeFolderWorkspacePathStatusState(): Record<string, unknown> {
   }
 }
 
-function setFolderWorkspaceFixtureState(): void {
+function setFolderWorkspaceFixtureState(
+  options: {
+    createdFrom?: ProjectGroup['createdFrom']
+    nestedGroup?: boolean
+  } = {}
+): void {
+  const parentGroup: ProjectGroup | null = options.nestedGroup
+    ? {
+        id: 'folder-parent-group-1',
+        name: 'Parent Folder Group',
+        parentPath: '/tmp/lineage-order',
+        parentGroupId: null,
+        createdFrom: 'folder-scan',
+        tabOrder: 0,
+        isCollapsed: false,
+        color: null,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    : null
   const group: ProjectGroup = {
     id: 'folder-group-1',
     name: 'Folder Group',
     parentPath: '/tmp/lineage-order/folder',
-    parentGroupId: null,
-    createdFrom: 'manual',
-    tabOrder: 0,
+    parentGroupId: parentGroup?.id ?? null,
+    createdFrom: options.createdFrom ?? 'folder-scan',
+    tabOrder: parentGroup ? 1 : 0,
     isCollapsed: false,
     color: null,
     createdAt: 1,
@@ -374,7 +393,7 @@ function setFolderWorkspaceFixtureState(): void {
     pendingRevealWorktree: null,
     prCache: {},
     prVisibleRefreshGeneration: 0,
-    projectGroups: [group],
+    projectGroups: parentGroup ? [parentGroup, group] : [group],
     ptyIdsByTabId: {},
     reorderRepos: vi.fn(),
     reportVisibleGitHubPRRefreshCandidates: vi.fn(),
@@ -486,17 +505,35 @@ function setLineageFixtureState(
   options: {
     childWorktreeOverrides?: Partial<Worktree>
     deletingWorktreeIds?: string[]
+    folderBackedProjectGroup?: boolean
+    projectGroupDepth?: number
     projectGrouped?: boolean
     unreadWorktreeIds?: string[]
   } = {}
 ): void {
+  const projectGroupDepth = Math.max(0, Math.floor(options.projectGroupDepth ?? 0))
+  const parentProjectGroups: ProjectGroup[] = Array.from(
+    { length: projectGroupDepth },
+    (_, index) => ({
+      id: `project-group-parent-${index + 1}`,
+      name: `Parent ${index + 1}`,
+      parentPath: `/tmp/lineage-order/parent-${index + 1}`,
+      parentGroupId: index === 0 ? null : `project-group-parent-${index}`,
+      createdFrom: options.folderBackedProjectGroup ? 'folder-scan' : 'manual',
+      tabOrder: index,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    })
+  )
   const projectGroup: ProjectGroup = {
     id: 'project-group-1',
     name: 'Personal',
     parentPath: '/tmp/lineage-order',
-    parentGroupId: null,
-    createdFrom: 'manual',
-    tabOrder: 0,
+    parentGroupId: projectGroupDepth > 0 ? `project-group-parent-${projectGroupDepth}` : null,
+    createdFrom: options.folderBackedProjectGroup ? 'folder-scan' : 'manual',
+    tabOrder: projectGroupDepth,
     isCollapsed: false,
     color: null,
     createdAt: 1,
@@ -559,7 +596,7 @@ function setLineageFixtureState(
     pendingRevealWorktree: null,
     prCache: {},
     prVisibleRefreshGeneration: 0,
-    projectGroups: options.projectGrouped ? [projectGroup] : [],
+    projectGroups: options.projectGrouped ? [...parentProjectGroups, projectGroup] : [],
     ptyIdsByTabId: {},
     reorderRepos: vi.fn(),
     reportVisibleGitHubPRRefreshCandidates: vi.fn(),
@@ -749,7 +786,9 @@ async function renderWorktreeListMarkup(): Promise<string> {
 
 function getCardOpeningTag(markup: string, worktreeId: string): string {
   return (
-    markup.match(new RegExp(`<section[^>]*data-worktree-card-id="${worktreeId}"[^>]*>`))?.[0] ?? ''
+    markup.match(
+      new RegExp(`<section[^>]*data-worktree-card-id="${escapeRegExp(worktreeId)}"[^>]*>`)
+    )?.[0] ?? ''
   )
 }
 
@@ -758,9 +797,47 @@ function getOptionOpeningTag(markup: string, worktreeId: string): string {
   // worktree id is the suffix after the encoded ':' group separator.
   return (
     markup.match(
-      new RegExp(`<div[^>]*id="worktree-list-option-[^"]*%3A${worktreeId}"[^>]*>`)
+      new RegExp(`<div[^>]*id="worktree-list-option-[^"]*%3A${escapeRegExp(worktreeId)}"[^>]*>`)
     )?.[0] ?? ''
   )
+}
+
+function getFolderWorkspaceSurfaceOpeningTag(markup: string, folderWorkspaceId: string): string {
+  return (
+    markup.match(
+      new RegExp(
+        `<div[^>]*id="worktree-list-option-[^"]*%3A${escapeRegExp(folderWorkspaceId)}"[^>]*>` +
+          `[\\s\\S]*?<div class="relative"[^>]*>`
+      )
+    )?.[0] ?? ''
+  )
+}
+
+function getDataNumber(openingTag: string, attribute: string): number {
+  return Number(openingTag.match(new RegExp(`${attribute}="(\\d+)"`))?.[1] ?? 0)
+}
+
+function getPaddingLeft(openingTag: string): number {
+  return Number(openingTag.match(/padding-left:(\d+)px/)?.[1] ?? 0)
+}
+
+function getFlushCardContentStart(args: {
+  cardContentIndent: number
+  surfaceInset: number
+}): number {
+  const flushCardMargin = 4
+  const flushCardMinimumInset = 2
+  const flushCardPullback = 4
+
+  return (
+    args.surfaceInset +
+    flushCardMargin +
+    Math.max(flushCardMinimumInset, args.cardContentIndent - flushCardPullback)
+  )
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 describe('WorktreeList lineage child card renderer', () => {
@@ -945,6 +1022,59 @@ describe('WorktreeList lineage child card renderer', () => {
     )
   })
 
+  it('keeps folder workspace cards one compact step under their group header', async () => {
+    setFolderWorkspaceFixtureState()
+    const markup = await renderWorktreeListMarkup()
+    const folderWorktreeId = folderWorkspaceKey('folder-workspace-1')
+    const cardOpeningTag = getCardOpeningTag(markup, folderWorktreeId)
+    const surfaceOpeningTag = getFolderWorkspaceSurfaceOpeningTag(markup, 'folder-workspace-1')
+    const cardContentIndent = getDataNumber(cardOpeningTag, 'data-content-indent')
+
+    expect(cardOpeningTag).toContain('data-content-indent="6"')
+    expect(cardOpeningTag).toContain('data-flush-surface="true"')
+    expect(
+      getFlushCardContentStart({
+        cardContentIndent,
+        surfaceInset: getPaddingLeft(surfaceOpeningTag)
+      })
+    ).toBe(20)
+  })
+
+  it('preserves manual folder workspace indentation outside folder-scanned groups', async () => {
+    setFolderWorkspaceFixtureState({ createdFrom: 'manual' })
+    const markup = await renderWorktreeListMarkup()
+    const folderWorktreeId = folderWorkspaceKey('folder-workspace-1')
+    const cardOpeningTag = getCardOpeningTag(markup, folderWorktreeId)
+    const surfaceOpeningTag = getFolderWorkspaceSurfaceOpeningTag(markup, 'folder-workspace-1')
+    const cardContentIndent = getDataNumber(cardOpeningTag, 'data-content-indent')
+
+    expect(cardOpeningTag).toContain('data-content-indent="24"')
+    expect(
+      getFlushCardContentStart({
+        cardContentIndent,
+        surfaceInset: getPaddingLeft(surfaceOpeningTag)
+      })
+    ).toBe(38)
+  })
+
+  it('caps nested folder workspace surfaces to keep compact final anchors', async () => {
+    setFolderWorkspaceFixtureState({ nestedGroup: true })
+    const markup = await renderWorktreeListMarkup()
+    const folderWorktreeId = folderWorkspaceKey('folder-workspace-1')
+    const cardOpeningTag = getCardOpeningTag(markup, folderWorktreeId)
+    const surfaceOpeningTag = getFolderWorkspaceSurfaceOpeningTag(markup, 'folder-workspace-1')
+    const cardContentIndent = getDataNumber(cardOpeningTag, 'data-content-indent')
+
+    expect(surfaceOpeningTag).toContain('padding-left:24px')
+    expect(cardOpeningTag).toContain('data-content-indent="6"')
+    expect(
+      getFlushCardContentStart({
+        cardContentIndent,
+        surfaceInset: getPaddingLeft(surfaceOpeningTag)
+      })
+    ).toBe(30)
+  })
+
   it('points aria-activedescendant at the natural row for active pinned duplicates', async () => {
     setPinnedDuplicateFixtureState()
     const markup = await renderWorktreeListMarkup()
@@ -1017,5 +1147,46 @@ describe('WorktreeList lineage child card renderer', () => {
     expect(parentRow).toContain('padding-left:14px')
     expect(getCardOpeningTag(markup, 'parent')).toContain('data-content-indent="24"')
     expect(getCardOpeningTag(markup, 'parent')).toContain('data-flush-surface="true"')
+  })
+
+  it('keeps repo worktrees shallower inside folder-scanned project groups', async () => {
+    setLineageFixtureState('repo', { folderBackedProjectGroup: true, projectGrouped: true })
+    const markup = await renderWorktreeListMarkup()
+
+    const parentRow = getOptionOpeningTag(markup, 'parent')
+    const cardOpeningTag = getCardOpeningTag(markup, 'parent')
+    const cardContentIndent = getDataNumber(cardOpeningTag, 'data-content-indent')
+
+    expect(parentRow).toContain('padding-left:14px')
+    expect(cardOpeningTag).toContain('data-content-indent="16"')
+    expect(cardOpeningTag).toContain('data-flush-surface="true"')
+    expect(
+      getFlushCardContentStart({
+        cardContentIndent,
+        surfaceInset: getPaddingLeft(parentRow)
+      })
+    ).toBe(30)
+  })
+
+  it('caps deeply nested folder-scanned repo worktree surfaces at the compact anchor', async () => {
+    setLineageFixtureState('repo', {
+      folderBackedProjectGroup: true,
+      projectGrouped: true,
+      projectGroupDepth: 3
+    })
+    const markup = await renderWorktreeListMarkup()
+
+    const parentRow = getOptionOpeningTag(markup, 'parent')
+    const cardOpeningTag = getCardOpeningTag(markup, 'parent')
+    const cardContentIndent = getDataNumber(cardOpeningTag, 'data-content-indent')
+
+    expect(parentRow).toContain('padding-left:54px')
+    expect(cardOpeningTag).toContain('data-content-indent="6"')
+    expect(
+      getFlushCardContentStart({
+        cardContentIndent,
+        surfaceInset: getPaddingLeft(parentRow)
+      })
+    ).toBe(60)
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -221,6 +221,10 @@ import { buildImportedWorktreesCardCandidates } from './imported-worktrees-card-
 import {
   WORKTREE_SECTION_HEADER_PADDING_LEFT,
   LINEAGE_CHILDREN_INLINE_OFFSET,
+  getFolderBackedRepoWorktreeCardContentIndent,
+  getFolderBackedRepoWorktreeCardSurfaceInset,
+  getFolderWorkspaceCardContentIndent,
+  getFolderWorkspaceCardSurfaceInset,
   getLineageChildrenInlineStyle,
   getLineageNestedRowGeometry,
   getProjectGroupHeaderPaddingLeft,
@@ -1213,6 +1217,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const settings = useAppStore((s) => s.settings)
   const newCardStyle = settings?.experimentalNewWorktreeCardStyle === true
   const reorderRepos = useAppStore((s) => s.reorderRepos)
+  const folderBackedProjectGroupIds = useMemo(
+    () =>
+      new Set(
+        projectGroups
+          .filter((group) => group.createdFrom === 'folder-scan')
+          .map((group) => group.id)
+      ),
+    [projectGroups]
+  )
 
   useEffect(
     () =>
@@ -4191,14 +4204,25 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               const lineageToggleGroupKey = itemRow.lineageGroupKey
               const experimentalNewWorktreeCardStyle =
                 settings?.experimentalNewWorktreeCardStyle === true
+              const projectGroupId = itemRow.repo?.projectGroupId
+              const isFolderBackedRepoChild =
+                groupBy === 'repo' &&
+                Boolean(projectGroupId && folderBackedProjectGroupIds.has(projectGroupId))
               // Why: experimental in-card lineage inherits the parent surface;
               // legacy cards keep the old depth-based nested row geometry.
               const paddingDepth = nested ? Math.max(0, itemRow.depth - 1) : itemRow.depth
-              const inheritedCardContentIndent = getWorktreeCardContentIndent({
-                isGrouped: groupBy !== 'none',
-                groupDepth: itemRow.groupDepth,
-                lineageDepth: 0
-              })
+              const getCardContentIndent = (lineageDepth: number): number =>
+                isFolderBackedRepoChild
+                  ? getFolderBackedRepoWorktreeCardContentIndent({
+                      groupDepth: itemRow.groupDepth,
+                      lineageDepth
+                    })
+                  : getWorktreeCardContentIndent({
+                      isGrouped: groupBy !== 'none',
+                      groupDepth: itemRow.groupDepth,
+                      lineageDepth
+                    })
+              const inheritedCardContentIndent = getCardContentIndent(0)
               const nestedLineageGeometry = nested
                 ? getLineageNestedRowGeometry({
                     experimentalNewWorktreeCardStyle,
@@ -4208,17 +4232,25 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 : null
               // Why: grouped rows inherit their project/group header depth,
               // while the card surface still spans the full hit/background row.
-              const paddingLeft = getWorktreeCardContentIndent({
-                isGrouped: !nested && groupBy !== 'none',
-                groupDepth: itemRow.groupDepth,
-                lineageDepth: paddingDepth
-              })
+              const paddingLeft =
+                nested && groupBy !== 'none'
+                  ? getWorktreeCardContentIndent({
+                      isGrouped: false,
+                      groupDepth: itemRow.groupDepth,
+                      lineageDepth: paddingDepth
+                    })
+                  : getCardContentIndent(paddingDepth)
               const surfaceInset = nested
                 ? nestedLineageGeometry!.surfaceInset
-                : getWorktreeCardSurfaceInset({
-                    isGrouped: groupBy !== 'none',
-                    groupDepth: itemRow.groupDepth
-                  })
+                : isFolderBackedRepoChild
+                  ? getFolderBackedRepoWorktreeCardSurfaceInset({
+                      groupDepth: itemRow.groupDepth,
+                      lineageDepth: paddingDepth
+                    })
+                  : getWorktreeCardSurfaceInset({
+                      isGrouped: groupBy !== 'none',
+                      groupDepth: itemRow.groupDepth
+                    })
               const cardContentIndent = nested
                 ? nestedLineageGeometry!.cardContentIndent
                 : Math.max(0, paddingLeft - surfaceInset)
@@ -4458,18 +4490,29 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 folderWorkspacePathStatus?.exists === false &&
                 (isConfirmedStaleFolderPathStatus(folderWorkspacePathStatus) ||
                   folderWorkspacePathStatus.reason === 'ambiguous-connection')
-              const contentIndent = getWorktreeCardContentIndent({
-                isGrouped: groupBy !== 'none',
-                groupDepth: folderWorkspaceRow.groupDepth,
-                lineageDepth: folderWorkspaceRow.depth
-              })
+              const isFolderBackedWorkspaceChild =
+                groupBy === 'repo' && folderWorkspaceRow.projectGroup.createdFrom === 'folder-scan'
+              const contentIndent = isFolderBackedWorkspaceChild
+                ? getFolderWorkspaceCardContentIndent({
+                    groupDepth: folderWorkspaceRow.groupDepth
+                  })
+                : getWorktreeCardContentIndent({
+                    isGrouped: groupBy !== 'none',
+                    groupDepth: folderWorkspaceRow.groupDepth,
+                    lineageDepth: folderWorkspaceRow.depth
+                  })
               // Why: folder workspace surfaces should step inward with their
               // project-group nesting, matching lineage child card surfaces
               // instead of spanning from the sidebar edge at every depth.
-              const surfaceInset = getWorktreeCardSurfaceInset({
-                isGrouped: groupBy !== 'none',
-                groupDepth: folderWorkspaceRow.groupDepth
-              })
+              const surfaceInset = isFolderBackedWorkspaceChild
+                ? getFolderWorkspaceCardSurfaceInset({
+                    isGrouped: true,
+                    groupDepth: folderWorkspaceRow.groupDepth
+                  })
+                : getWorktreeCardSurfaceInset({
+                    isGrouped: groupBy !== 'none',
+                    groupDepth: folderWorkspaceRow.groupDepth
+                  })
               const insetContentIndent = Math.max(0, contentIndent - surfaceInset)
               return (
                 <div

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.test.ts
@@ -6,6 +6,10 @@ import {
   LINEAGE_NESTED_ROW_SURFACE_INSET,
   WORKTREE_CARD_SURFACE_MARGIN,
   WORKTREE_SECTION_HEADER_PADDING_LEFT,
+  getFolderBackedRepoWorktreeCardContentIndent,
+  getFolderBackedRepoWorktreeCardSurfaceInset,
+  getFolderWorkspaceCardContentIndent,
+  getFolderWorkspaceCardSurfaceInset,
   getFlushWorktreeCardPaddingLeft,
   getLineageChildrenInlineStyle,
   getLineageEffectiveChildStart,
@@ -41,6 +45,35 @@ describe('worktree list indentation', () => {
     expect(getWorktreeCardContentIndent({ isGrouped: true, groupDepth: 1, lineageDepth: 2 })).toBe(
       74
     )
+  })
+
+  it('uses compact header rhythm for folder-scanned repo worktree content', () => {
+    expect(getFolderBackedRepoWorktreeCardContentIndent({ groupDepth: 1, lineageDepth: 0 })).toBe(
+      30
+    )
+    expect(getFolderBackedRepoWorktreeCardContentIndent({ groupDepth: 2, lineageDepth: 0 })).toBe(
+      40
+    )
+    expect(getFolderBackedRepoWorktreeCardContentIndent({ groupDepth: 1, lineageDepth: 1 })).toBe(
+      48
+    )
+  })
+
+  it('caps folder-scanned repo worktree surfaces before they overshoot the compact anchor', () => {
+    expect(getFolderBackedRepoWorktreeCardSurfaceInset({ groupDepth: 1, lineageDepth: 0 })).toBe(14)
+    expect(getFolderBackedRepoWorktreeCardSurfaceInset({ groupDepth: 4, lineageDepth: 0 })).toBe(54)
+    expect(getFolderBackedRepoWorktreeCardSurfaceInset({ groupDepth: 4, lineageDepth: 1 })).toBe(56)
+  })
+
+  it('keeps folder workspace content one step under its owning group', () => {
+    expect(getFolderWorkspaceCardContentIndent({ groupDepth: 1 })).toBe(20)
+    expect(getFolderWorkspaceCardContentIndent({ groupDepth: 2 })).toBe(30)
+  })
+
+  it('caps folder workspace surfaces before they overshoot the compact content anchor', () => {
+    expect(getFolderWorkspaceCardSurfaceInset({ isGrouped: true, groupDepth: 1 })).toBe(14)
+    expect(getFolderWorkspaceCardSurfaceInset({ isGrouped: true, groupDepth: 2 })).toBe(24)
+    expect(getFolderWorkspaceCardSurfaceInset({ isGrouped: false, groupDepth: 2 })).toBe(0)
   })
 
   it('caps header indentation separately from workspace content indentation', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-indentation.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-indentation.ts
@@ -48,6 +48,57 @@ export function getWorktreeCardContentIndent(args: {
   return (groupSteps + clampDepth(args.lineageDepth)) * SIDEBAR_TREE_INDENT + projectCardIndent
 }
 
+export function getFolderBackedRepoWorktreeCardContentIndent(args: {
+  groupDepth: number
+  lineageDepth: number
+}): number {
+  // Why: folder-scanned groups indent repo headers by the compact header step;
+  // worktree rows should follow that rhythm instead of adding a full tree step.
+  return (
+    getProjectGroupHeaderPaddingLeft(args.groupDepth) +
+    PROJECT_GROUP_HEADER_BASE_PADDING +
+    clampDepth(args.lineageDepth) * SIDEBAR_TREE_INDENT
+  )
+}
+
+export function getFolderBackedRepoWorktreeCardSurfaceInset(args: {
+  groupDepth: number
+  lineageDepth: number
+}): number {
+  const contentAnchor = getFolderBackedRepoWorktreeCardContentIndent(args)
+  const genericSurfaceInset = getWorktreeCardSurfaceInset({
+    isGrouped: true,
+    groupDepth: args.groupDepth
+  })
+  const maxSurfaceInset =
+    contentAnchor - WORKTREE_CARD_SURFACE_MARGIN - FLUSH_CARD_MIN_CONTENT_INSET
+
+  // Why: compact folder-backed repo rows still use flush-card margin/padding;
+  // cap the surface before those fixed insets overshoot the target anchor.
+  return Math.min(genericSurfaceInset, Math.max(0, maxSurfaceInset))
+}
+
+export function getFolderWorkspaceCardContentIndent(args: { groupDepth: number }): number {
+  const parentGroupDepth = Math.max(0, clampDepth(args.groupDepth) - 1)
+  // Why: folder workspaces are direct children of their owning folder group,
+  // so they advance by the same compact header step as group -> repo.
+  return getProjectGroupHeaderPaddingLeft(parentGroupDepth) + PROJECT_GROUP_HEADER_INDENT
+}
+
+export function getFolderWorkspaceCardSurfaceInset(args: {
+  isGrouped: boolean
+  groupDepth: number
+}): number {
+  const contentAnchor = getFolderWorkspaceCardContentIndent({ groupDepth: args.groupDepth })
+  const genericSurfaceInset = getWorktreeCardSurfaceInset(args)
+  const maxSurfaceInset =
+    contentAnchor - WORKTREE_CARD_SURFACE_MARGIN - FLUSH_CARD_MIN_CONTENT_INSET
+
+  // Why: flush cards add their own margin and minimum padding, so deep folder
+  // workspace surfaces must be capped to keep the final content anchor compact.
+  return Math.min(genericSurfaceInset, Math.max(0, maxSurfaceInset))
+}
+
 export function getWorktreeCardSurfaceInset(args: {
   isGrouped: boolean
   groupDepth: number


### PR DESCRIPTION
## Summary

Align folder-scanned Workspaces sidebar indentation so each visible hierarchy step advances evenly across folder groups, folder workspaces, repo rows, and repo worktrees.

Design approach:
- Keep the existing sidebar/card rendering model, but add explicit compact geometry helpers for folder-scanned project groups.
- Use stable folder-backed membership (`createdFrom === 'folder-scan'` and `repo.projectGroupId`) instead of relying on visible header order, so host section wrapping does not affect indentation.
- Treat the final icon/text anchor as the invariant. Card surface inset is capped where needed so `WorktreeCard` flush margin and minimum padding cannot push folder workspace or repo worktree content past the compact rhythm.
- Preserve manual project groups, ungrouped rows, lineage child-card geometry, path status indicators, SSH/runtime ownership, and row ordering.

## Brennan YOLO Lite Evidence

Design review:
- Scratch design doc: `design-docs/folder-workspace-sidebar-indentation.md` (ignored, not committed).
- `auto-design-review-fix` completed clean by exit condition. Iteration 3 found no P0/P1 issues.
- Accepted design direction: tactical local geometry helpers now; future single `visualDepth`/`treeLevel` cleanup remains out of scope.

Implementation:
- Added compact folder-scanned repo worktree and folder workspace content helpers.
- Added capped surface inset helpers for direct folder workspaces and folder-backed repo worktrees.
- Scoped compact behavior to folder-scanned groups only.
- Added rendered final-anchor tests that include card surface inset, flush margin, and flush padding.
- Deviation from reviewed design: none. One review-raised P2 risk for deeply nested repo worktrees was fixed before PR.

Completeness verification:
- Read-only verification passed after fixing a TypeScript narrowing issue in the folder-backed workspace branch.
- Verified stable project group id membership, direct folder workspace row shape, capped surface inset behavior, manual/ungrouped preservation, host wrapping independence, and focused test coverage.

Code review loop:
- Round 1: two reviewers both found a medium issue where deeply nested folder-scanned repo worktrees could overshoot due to uncapped generic surface inset.
- Fix: added `getFolderBackedRepoWorktreeCardSurfaceInset`, renderer wiring, helper coverage, and a deep DOM final-anchor regression.
- Round 2: both reviewers returned `No issues found.`

`brennan-test-changes`:
- Final verdict: `land`.
- Electron identity verified branch `brennanb2025/fix-workspace-indentation`, root `/Users/thebr/orca/workspaces/orca/humpback`.
- Used a disposable local nested repo because `demo-project` was unavailable.
- Exercised the real Workspaces sidebar after importing through folder-scan APIs.
- Visible chains covered root, one-level, two-level, and three-level folder-scanned groups.
- Measured group labels, folder workspace titles, repo labels, and repo worktree titles with consistent 10px hierarchy deltas.
- Deep capped surface case verified: deepest repo worktree row had `padding-left: 54px`, surface `left: 62`, title `left: 83`.

Manual screenshot evidence:
- `.tmp/brennan-stage7/sidebar-indentation-full.png`
- `.tmp/brennan-stage7/sidebar-indentation-viewport.png`

Checks run:
- `git diff --check`
- `node config/scripts/ensure-native-runtime.mjs --runtime=node && pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts src/renderer/src/components/sidebar/worktree-list-indentation.test.ts`
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts src/renderer/src/components/sidebar/worktree-list-indentation.ts src/renderer/src/components/sidebar/worktree-list-indentation.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- Electron validation via `REMOTE_DEBUGGING_PORT=9334 ORCA_DEV_USER_DATA_PATH=<temp> node config/scripts/run-electron-vite-dev.mjs` plus Playwright CDP measurement and screenshots.

Post-PR stabilization:
- Waited the required 8 minutes after opening the PR.
- CodeRabbit posted: no actionable comments generated.
- CodeRabbit docstring coverage warning was treated as non-actionable for this TypeScript UI change.
- GitHub checks passed: `verify` and `track-community-pr`.
- PR merge state: clean.

Assumptions / remaining risk:
- This is renderer-only layout math. No SSH, runtime RPC, git provider, filesystem, or persisted-state behavior changed.
- Screenshot files are scratch evidence and intentionally not committed.
