### PR TITLE
fix: recover the terminal WebGL atlas after corrupting text pastes

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -110,7 +110,7 @@ import {
 } from '@/components/terminal-quick-commands/TerminalQuickCommandDialog'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
-import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-paste-recovery'
+import { maybeScheduleWebglAtlasRecoveryForPaste } from './terminal-webgl-paste-recovery'
 import { restoreTerminalFitToDesktop, restoreTerminalFitsToDesktop } from './terminal-fit-restore'
 
 // Why: registry lives in a leaf module so the store slice can import it
@@ -1536,9 +1536,7 @@ export default function TerminalPane({
       if (text) {
         recordTerminalUserInputForLeaf(tabId, pane.leafId)
       }
-      if (options?.recoverImagePasteWebglAtlas) {
-        scheduleImagePasteWebglAtlasRecovery()
-      }
+      maybeScheduleWebglAtlasRecoveryForPaste(plan)
     }
 
     const pasteFromClipboard = (

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -22,7 +22,7 @@ describe('terminal clipboard paste', () => {
 
     expect(pasteText).toHaveBeenCalledWith(
       '/var/folders/3l/b7w02vh17tg5r5s3nhhdf3kh0000gn/T/orca-paste-1760000000000-id.png',
-      { forceBracketedPaste: true, recoverImagePasteWebglAtlas: true }
+      { forceBracketedPaste: true }
     )
   })
 
@@ -100,8 +100,7 @@ describe('terminal clipboard paste', () => {
 
     expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({ connectionId: 'ssh-1' })
     expect(pasteText).toHaveBeenCalledWith('/var/tmp/orca-paste-1760000000000-id.png', {
-      forceBracketedPaste: true,
-      recoverImagePasteWebglAtlas: true
+      forceBracketedPaste: true
     })
   })
 
@@ -117,8 +116,7 @@ describe('terminal clipboard paste', () => {
     })
 
     expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1760000000000-id.png', {
-      forceBracketedPaste: true,
-      recoverImagePasteWebglAtlas: true
+      forceBracketedPaste: true
     })
   })
 
@@ -136,8 +134,7 @@ describe('terminal clipboard paste', () => {
 
     expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({ connectionId: undefined })
     expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1760000000000-id.png', {
-      forceBracketedPaste: true,
-      recoverImagePasteWebglAtlas: true
+      forceBracketedPaste: true
     })
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -80,8 +80,9 @@ export async function pasteTerminalClipboard({
     const result = await pasteText(filePath, {
       // Why: a generated clipboard-image path is terminal image injection, not
       // ordinary one-line text. Keep it off the Ctrl+C stale-text paste path.
-      forceBracketedPaste: true,
-      recoverImagePasteWebglAtlas: true
+      // WebGL atlas recovery now keys off the resulting bracketed paste, so it
+      // covers this image path and corrupting text pastes (issue #5960) alike.
+      forceBracketedPaste: true
     })
     if (result === false) {
       return { status: 'skipped', reason: 'image-paste-rejected' }

--- a/src/renderer/src/components/terminal-pane/terminal-paste-model.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-model.ts
@@ -46,7 +46,6 @@ export type TerminalPastePlan = {
 export type TerminalPasteTextOptions = {
   forceBracketedPaste?: boolean
   forceBracketedPasteForMultiline?: boolean
-  recoverImagePasteWebglAtlas?: boolean
 }
 
 export type TerminalPasteExecutionReason =

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-paste-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-paste-recovery.test.ts
@@ -3,9 +3,12 @@ import {
   registerLivePaneManager,
   unregisterLivePaneManager
 } from '@/lib/pane-manager/pane-manager-registry'
-import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-paste-recovery'
+import {
+  maybeScheduleWebglAtlasRecoveryForPaste,
+  schedulePasteWebglAtlasRecovery
+} from './terminal-webgl-paste-recovery'
 
-describe('terminal image paste WebGL recovery', () => {
+describe('terminal paste WebGL recovery', () => {
   const registeredManagers: { resetWebglTextureAtlases(): void }[] = []
 
   function registerManager(): { resetWebglTextureAtlases: Mock<() => void> } {
@@ -38,7 +41,7 @@ describe('terminal image paste WebGL recovery', () => {
     const manager = registerManager()
     const otherManager = registerManager()
 
-    scheduleImagePasteWebglAtlasRecovery()
+    schedulePasteWebglAtlasRecovery()
 
     expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
     rafCallbacks[0]?.(0)
@@ -56,7 +59,7 @@ describe('terminal image paste WebGL recovery', () => {
     vi.stubGlobal('requestAnimationFrame', undefined)
     const manager = registerManager()
 
-    scheduleImagePasteWebglAtlasRecovery()
+    schedulePasteWebglAtlasRecovery()
 
     expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
     vi.advanceTimersByTime(0)
@@ -80,7 +83,31 @@ describe('terminal image paste WebGL recovery', () => {
     registerLivePaneManager(manager)
     registeredManagers.push(manager)
 
-    expect(() => scheduleImagePasteWebglAtlasRecovery()).not.toThrow()
+    expect(() => schedulePasteWebglAtlasRecovery()).not.toThrow()
     expect(() => vi.runAllTimers()).not.toThrow()
+  })
+
+  describe('maybeScheduleWebglAtlasRecoveryForPaste', () => {
+    it('recovers the atlas after a bracketed paste (image or corrupting text)', () => {
+      vi.useFakeTimers()
+      vi.stubGlobal('requestAnimationFrame', undefined)
+      const manager = registerManager()
+
+      maybeScheduleWebglAtlasRecoveryForPaste({ bracketed: true })
+
+      vi.advanceTimersByTime(500)
+      expect(manager.resetWebglTextureAtlases).toHaveBeenCalled()
+    })
+
+    it('skips recovery for a direct (non-bracketed) paste', () => {
+      vi.useFakeTimers()
+      vi.stubGlobal('requestAnimationFrame', undefined)
+      const manager = registerManager()
+
+      maybeScheduleWebglAtlasRecoveryForPaste({ bracketed: false })
+
+      vi.advanceTimersByTime(500)
+      expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-paste-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-paste-recovery.ts
@@ -1,6 +1,6 @@
 import { resetAllTerminalWebglAtlases } from '@/lib/pane-manager/pane-manager-registry'
 
-const IMAGE_PASTE_ATLAS_RECOVERY_DELAYS_MS = [120, 500]
+const PASTE_ATLAS_RECOVERY_DELAYS_MS = [120, 500]
 
 function scheduleNextFrame(callback: () => void): void {
   if (typeof globalThis.requestAnimationFrame === 'function') {
@@ -21,12 +21,22 @@ function resetAtlases(): void {
   }
 }
 
-export function scheduleImagePasteWebglAtlasRecovery(): void {
-  // Why: Claude Code redraws its image chip immediately after bracketed paste,
-  // and xterm WebGL atlas corruption can appear after that redraw without a
-  // context-loss event. A few cheap resets cover the post-paste paint window.
+export function schedulePasteWebglAtlasRecovery(): void {
+  // Why: a TUI (e.g. Claude Code) redraws immediately after a bracketed paste —
+  // an image chip, or a pasted URL/text — and xterm WebGL atlas corruption can
+  // appear after that redraw without a context-loss event. A few cheap resets
+  // cover the post-paste paint window.
   scheduleNextFrame(() => resetAtlases())
-  for (const delayMs of IMAGE_PASTE_ATLAS_RECOVERY_DELAYS_MS) {
+  for (const delayMs of PASTE_ATLAS_RECOVERY_DELAYS_MS) {
     globalThis.setTimeout(() => resetAtlases(), delayMs)
+  }
+}
+
+// Recover the atlas only after bracketed pastes — those trigger the TUI redraw
+// that can corrupt it (image paste, or a long text/URL paste, issue #5960).
+// Direct (non-bracketed) pastes don't redraw enough to need it.
+export function maybeScheduleWebglAtlasRecoveryForPaste(plan: { bracketed: boolean }): void {
+  if (plan.bracketed) {
+    schedulePasteWebglAtlasRecovery()
   }
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -23,7 +23,7 @@ import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
 import { isTerminalPanePasteTargetCurrent } from './terminal-paste-target-state'
 import { writeTerminalPastePtyInput } from './terminal-pty-paste-writer'
-import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-paste-recovery'
+import { maybeScheduleWebglAtlasRecoveryForPaste } from './terminal-webgl-paste-recovery'
 import {
   REQUEST_ACTIVE_TERMINAL_PANE_SPLIT_EVENT,
   type RequestActiveTerminalPaneSplitDetail
@@ -242,9 +242,7 @@ export function useTerminalPaneContextMenu({
     if (text) {
       recordTerminalUserInputForLeaf(tabId, pane.leafId)
     }
-    if (options?.recoverImagePasteWebglAtlas) {
-      scheduleImagePasteWebglAtlasRecovery()
-    }
+    maybeScheduleWebglAtlasRecoveryForPaste(plan)
     return true
   }
 


### PR DESCRIPTION
Fixes #5960

## What

Pasting a long link or block of text into a TUI (e.g. Claude Code) could leave the terminal's fonts **garbled / unreadable** until a repaint. This was xterm's shared WebGL **glyph-atlas corruption**, the same failure class Orca already recovers from for image pastes — but recovery was scheduled only on the image path, so corrupting **text** pastes were left broken.

| Before | After |
|---|---|
| Recovery scheduled only when `recoverImagePasteWebglAtlas` was set (image paste path) | Recovery scheduled after **any bracketed paste** — image injection *and* corrupting text/URL pastes |

## Why

The corruption appears after the **redraw that follows a bracketed paste** (the TUI re-renders its input/image chip). That redraw is the real trigger — and it happens for bracketed text pastes too, not just images. The recovery gate was keyed off an image-only caller flag, so it never fired for the text path that this issue reports.

## How

- Gate atlas recovery on the resolved paste plan's existing **`bracketed`** flag instead of the image-only `recoverImagePasteWebglAtlas` option, via one shared helper `maybeScheduleWebglAtlasRecoveryForPaste(plan)` used by both paste consumers (`use-terminal-pane-context-menu.ts`, `TerminalPane.tsx`).
- Image injection is force-bracketed, so it keeps recovering exactly as before; the `recoverImagePasteWebglAtlas` option is now redundant and is removed.
- Only **bracketed** pastes recover — direct (non-bracketed) short pastes don't redraw enough to corrupt the atlas, so they incur no recovery churn.
- The recovery helper itself is unchanged (the cheap next-frame + 120ms + 500ms resets across all live terminals) — only what triggers it changed; renamed `scheduleImagePasteWebglAtlasRecovery` → `schedulePasteWebglAtlasRecovery` since it's no longer image-specific.

## Testing

- New unit tests assert the gate: a **bracketed** paste schedules recovery; a **direct** paste does not. Existing reset-mechanics and image-path tests still pass (image-path expectations updated to drop the removed flag).
- `pnpm typecheck`, `oxlint`, `oxfmt`, `build:web`, and the full suite (**19,740 passing**) are green.

## Scope / honesty

- This intentionally **broadens** atlas recovery from image-only to all bracketed pastes — the bug shows bracketed text pastes corrupt the atlas too. The resets are cheap and only run on a bracketed paste (a user-initiated action), so the added churn is minimal.
- The WebGL glyph-atlas corruption is timing/GPU/font/TUI-dependent and hard to reproduce deterministically, so the fix could not be verified live end-to-end. It applies the **same recovery** that already resolves the image-paste corruption to the text path that triggers the identical redraw; the gating logic is covered by unit tests.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6025">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->