### PR TITLE
fix(terminal): gate Windows ConPTY backend selection on execution host (serve panes)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -788,6 +788,15 @@ function containsCursorRestore(data: string): boolean {
   return hideIndex !== -1 && showIndex > hideIndex && containsCursorPositionSequence(data)
 }
 
+/**
+ * Wires a pane's xterm instance to its PTY data/lifecycle stream and returns a
+ * disposable binding.
+ *
+ * Why it resolves the execution host: the native-Windows ConPTY cursor and
+ * synchronized-output workarounds must apply only to genuinely local Windows
+ * panes, never to serve/remote-runtime panes that merely look local to the raw
+ * heuristic, so the host gates `isLocalNativeWindowsConpty`.
+ */
 export function connectPanePty(
   pane: ManagedPane,
   manager: PaneManager,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -788,15 +788,6 @@ function containsCursorRestore(data: string): boolean {
   return hideIndex !== -1 && showIndex > hideIndex && containsCursorPositionSequence(data)
 }
 
-/**
- * Wires a pane's xterm instance to its PTY data/lifecycle stream and returns a
- * disposable binding.
- *
- * Why it resolves the execution host: the native-Windows ConPTY cursor and
- * synchronized-output workarounds must apply only to genuinely local Windows
- * panes, never to serve/remote-runtime panes that merely look local to the raw
- * heuristic, so the host gates `isLocalNativeWindowsConpty`.
- */
 export function connectPanePty(
   pane: ManagedPane,
   manager: PaneManager,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -346,15 +346,6 @@ export function shouldDetachPaneTransportOnUnmount(args: {
   )
 }
 
-/**
- * React hook that owns a terminal pane's create/attach/teardown lifecycle and
- * keeps its xterm options in sync with the pane's state.
- *
- * Why it resolves the execution host for the Windows-PTY options: the ConPTY
- * compatibility backend must be selected only for genuinely local Windows panes,
- * so the host gates a serve/remote-runtime pane out even when the raw heuristic
- * would classify it as local.
- */
 export function useTerminalPaneLifecycle({
   tabId,
   worktreeId,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -63,6 +63,7 @@ import { connectPanePty } from './pty-connection'
 import type { PtyTransport } from './pty-transport'
 import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
 import { getConnectionId } from '@/lib/connection-context'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { isPaneReplaying, type ReplayingPanesRef } from './replay-guard'
 import { fitAndFocusPanes, fitPanes } from './pane-helpers'
 import { registerRuntimeTerminalTab, scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
@@ -345,6 +346,15 @@ export function shouldDetachPaneTransportOnUnmount(args: {
   )
 }
 
+/**
+ * React hook that owns a terminal pane's create/attach/teardown lifecycle and
+ * keeps its xterm options in sync with the pane's state.
+ *
+ * Why it resolves the execution host for the Windows-PTY options: the ConPTY
+ * compatibility backend must be selected only for genuinely local Windows panes,
+ * so the host gates a serve/remote-runtime pane out even when the raw heuristic
+ * would classify it as local.
+ */
 export function useTerminalPaneLifecycle({
   tabId,
   worktreeId,
@@ -1049,7 +1059,8 @@ export function useTerminalPaneLifecycle({
           osRelease: platformInfo?.osRelease,
           connectionId: getConnectionId(worktreeId),
           cwd: startupCwd,
-          shellOverride: currentTab?.shellOverride
+          shellOverride: currentTab?.shellOverride,
+          executionHostId: getExecutionHostIdForWorktree(storeState, worktreeId)
         })
         return {
           ...windowsPtyCompatibilityOptions,

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
@@ -13,7 +13,8 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
         osRelease: '10.0.26100',
         connectionId: null,
         cwd: 'C:\\repo',
-        shellOverride: null
+        shellOverride: null,
+        executionHostId: 'local'
       })
     ).toEqual({
       windowsPty: { backend: 'conpty', buildNumber: 26100 }
@@ -27,7 +28,8 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
         osRelease: 'bad-release',
         connectionId: null,
         cwd: 'C:\\repo',
-        shellOverride: null
+        shellOverride: null,
+        executionHostId: 'local'
       })
     ).toEqual({
       windowsPty: { backend: 'conpty' }
@@ -41,7 +43,8 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
         osRelease: '10.0.26100',
         connectionId: 'ssh-1',
         cwd: 'C:\\repo',
-        shellOverride: null
+        shellOverride: null,
+        executionHostId: 'local'
       })
     ).toEqual({})
   })
@@ -59,7 +62,8 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
           osRelease: '10.0.26100',
           connectionId: null,
           cwd,
-          shellOverride: null
+          shellOverride: null,
+          executionHostId: 'local'
         })
       ).toEqual({})
     }
@@ -72,7 +76,8 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
         osRelease: '10.0.26100',
         connectionId: null,
         cwd: 'C:\\repo',
-        shellOverride: 'C:\\Windows\\System32\\wsl.exe'
+        shellOverride: 'C:\\Windows\\System32\\wsl.exe',
+        executionHostId: 'local'
       })
     ).toEqual({})
   })
@@ -84,7 +89,38 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
         osRelease: '23.0.0',
         connectionId: null,
         cwd: '/repo',
-        shellOverride: null
+        shellOverride: null,
+        executionHostId: 'local'
+      })
+    ).toEqual({})
+  })
+
+  it('does NOT return ConPTY options for a serve/remote-runtime pane even when the raw Windows heuristic matches', () => {
+    // Regression: a serve pane on a Windows client has no SSH connectionId and a
+    // Linux cwd, so the raw heuristic matches; the execution-host gate must still
+    // exclude it so a remote Linux PTY is not given the native-Windows ConPTY backend.
+    const serveContext = {
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      osRelease: '10.0.26100',
+      connectionId: null,
+      cwd: '/home/me/workspaces/repo',
+      shellOverride: null
+    } as const
+    expect(isLocalNativeWindowsPty(serveContext)).toBe(true)
+    expect(
+      buildWindowsPtyCompatibilityOptions({ ...serveContext, executionHostId: 'runtime:my-serve' })
+    ).toEqual({})
+  })
+
+  it('does NOT return ConPTY options for an SSH-runtime pane', () => {
+    expect(
+      buildWindowsPtyCompatibilityOptions({
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        osRelease: '10.0.26100',
+        connectionId: null,
+        cwd: 'C:\\repo',
+        shellOverride: null,
+        executionHostId: 'ssh:my-host'
       })
     ).toEqual({})
   })

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
@@ -31,10 +31,21 @@ function parseWindowsBuildNumber(osRelease: string | null | undefined): number |
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
 }
 
+/**
+ * xterm options that select the native-Windows ConPTY backend, returned only for
+ * a genuine local Windows pane and `{}` otherwise.
+ *
+ * Why it requires `executionHostId`: a serve/remote-runtime pane on a Windows
+ * client looks local to the raw heuristic (no SSH `connectionId`, Linux `cwd`),
+ * so gating on the execution host keeps the ConPTY backend off remote PTYs.
+ */
 export function buildWindowsPtyCompatibilityOptions(
-  context: WindowsPtyCompatibilityContext
+  context: WindowsPtyCompatibilityContext & { executionHostId: ExecutionHostId }
 ): Partial<ITerminalOptions> {
-  if (!isLocalNativeWindowsPty(context)) {
+  // Why: a serve/remote-runtime pane on a Windows client has no SSH connectionId
+  // and a Linux cwd, so isLocalNativeWindowsPty alone misfires and would hand a
+  // remote PTY xterm's native-Windows ConPTY backend. Gate on the execution host.
+  if (!isLocalNativeWindowsConpty(context)) {
     return {}
   }
   const buildNumber = parseWindowsBuildNumber(context.osRelease)
@@ -46,6 +57,11 @@ export function buildWindowsPtyCompatibilityOptions(
   }
 }
 
+/**
+ * Raw client-side heuristic for a native-Windows ConPTY pane (Windows UA, no SSH
+ * connection, non-WSL cwd/shell). Necessary but not sufficient: it cannot tell a
+ * local pane from a serve pane, so callers gate it with `isLocalNativeWindowsConpty`.
+ */
 export function isLocalNativeWindowsPty(context: WindowsPtyCompatibilityContext): boolean {
   if (!isWindowsUserAgent(context.userAgent)) {
     return false

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
@@ -42,9 +42,6 @@ function parseWindowsBuildNumber(osRelease: string | null | undefined): number |
 export function buildWindowsPtyCompatibilityOptions(
   context: WindowsPtyCompatibilityContext & { executionHostId: ExecutionHostId }
 ): Partial<ITerminalOptions> {
-  // Why: a serve/remote-runtime pane on a Windows client has no SSH connectionId
-  // and a Linux cwd, so isLocalNativeWindowsPty alone misfires and would hand a
-  // remote PTY xterm's native-Windows ConPTY backend. Gate on the execution host.
   if (!isLocalNativeWindowsConpty(context)) {
     return {}
   }


### PR DESCRIPTION
Closes #6022

> ⚠️ **Stacked on #6009** — please review/merge that first.
> This PR is built on top of `fix/remote-runtime-cursor-conpty-strip` and **reuses the
> `isLocalNativeWindowsConpty()` predicate introduced by #6009**. Because that branch isn't in this
> repo, the diff below currently also contains #6009's commit (`a2b5d567`); once #6009 merges to
> `main`, this PR automatically reduces to the single follow-up commit (`4684fb2d`). Review only the
> commit titled *"gate Windows ConPTY backend selection on execution host"* here.

## Summary

Follow-up to #6009. Same root misclassification, a different consumer. On a **Windows client**, a
**serve/remote-runtime** pane has no SSH `connectionId` (`null`) and a Linux cwd, so the ungated
`isLocalNativeWindowsPty()` misfires and `buildWindowsPtyCompatibilityOptions()` hands the remote
pane xterm's **native-Windows ConPTY backend** (`{ windowsPty: { backend: 'conpty', buildNumber } }`).

Unlike #6009 (which fixed the cursor-show stripping path → invisible cursor), this path only selects
xterm's `windowsPty` backend + ConPTY build-number line-wrap heuristic. It does **not** cause the
invisible cursor; its effect is a wrong PTY backend / reflow heuristic applied to a remote Linux PTY.
Lower severity, same incorrect classification — fixed here for consistency.

## Fix

Renderer-only, one production call site. `buildWindowsPtyCompatibilityOptions` now takes the
authoritative `executionHostId` and gates on the **same** `isLocalNativeWindowsConpty()` predicate
#6009 added — only `executionHostId === 'local'` is a real local native PTY; serve/remote panes
resolve to `runtime:<env>` (or `ssh:<target>`) and are excluded. The single caller
(`use-terminal-pane-lifecycle.ts`) already has `worktreeId` and store state in scope, so it passes
`getExecutionHostIdForWorktree(state, worktreeId)` in — no extra plumbing. Strict narrowing: can only
turn the ConPTY backend selection OFF for panes that should never have had it.

Follow-up commit changes (3 files): `windows-pty-compatibility.ts` (gate the builder),
`use-terminal-pane-lifecycle.ts` (wire the execution host), `windows-pty-compatibility.test.ts`
(+2 gating tests; existing cases updated for the new required field). Net +50/−9.

## Visual change

No visual change — this selects the correct xterm PTY backend for remote panes; there is no
user-visible UI difference.

## Testing

Run on the stacked worktree (`origin/main` + #6009 + this change):

- [x] `pnpm test` — **14/14** in `windows-pty-compatibility.test.ts` (the 2 new gating tests assert a
      serve `runtime:<env>` pane and an `ssh:<target>` pane both return `{}` even though the raw
      Windows heuristic matches). Zero regressions vs the stacked baseline.
- [x] `pnpm typecheck` — **pass** (node, cli, web).
- [x] `pnpm lint` — **pass** (oxlint, localization catalog + coverage).
- [ ] `pnpm build:native` — not run locally (needs the Node 24 toolchain); renderer-only TS change
      cannot affect it; runs in CI.

## Live confirmation (running Windows client, Orca 1.4.88)

Inspected the live renderer of a Windows client paired to a Linux `orca serve` over the Chrome
DevTools protocol:

- Store: the active pane's repo is `connectionId: null`, `executionHostId: "runtime:fed1eb27-…"`
  (all open repos resolve to that `runtime:` host; none `local`).
- The live xterm `Terminal` instances for those serve panes carry
  `options.windowsPty = { backend: "conpty", buildNumber: 26200 }` — the native-Windows ConPTY
  backend, currently applied to remote Linux PTYs. This is the misfire active on a shipping client.

## AI Review Report

Reviewed by an independent AI coding agent that verified every claim against the actual source (the
delta vs the #6009 tip, `a2b5d567..4684fb2d`) rather than a summary. **Verdict: PASS — no critical or
major findings.** Coverage of the required dimensions:

- **Cross-platform (macOS / Linux / Windows):** Low risk. On non-Windows clients the Windows-UA check
  is `false` → returns `{}` regardless of `executionHostId`; the change only narrows Windows
  behaviour. No platform-conditional code paths added.
- **SSH / remote / local:** Correctly distinguished — `local` keeps the ConPTY options;
  `runtime:<env>` and `ssh:<target>` return `{}` (both tested).
- **Agent / integration compatibility:** Low risk. No agent-specific branching; this is the
  consistency sibling of the agent-facing #6009.
- **Performance:** Negligible. Runs at `terminalOptions` construction (pane (re)build), not
  per-keystroke/per-frame; `getExecutionHostIdForWorktree` is a small linear lookup.
- **UI quality:** Genuine local Windows panes still receive the ConPTY options (positive-control test
  present); no regression to the common case.
- **Test quality:** 14/14 pass. The serve test pre-asserts the raw heuristic misfires
  (`isLocalNativeWindowsPty` → `true`) then asserts `{}` — it would fail before the fix. Positive and
  SSH controls present.
- One **minor**, explicitly out-of-scope note: the active-runtime fallback in
  `worktree-runtime-owner.ts:118-119` could in theory false-exclude a local repo — but that is
  pre-existing #6009 logic, unchanged by this PR.

## Security Audit

No new input parsing, command execution, path handling, auth, secrets, IPC, or dependency surface.
`executionHostId` is an internal enum-like union; the `runtime:` / `ssh:` IDs are URI-encoded
upstream. The change is a boolean tightening of an existing gate. No risks identified; no follow-up
needed.

## Scope

Single-topic, per CONTRIBUTING. The cursor-stripping fix is #6009; this is the PTY-backend sibling.

Contributor: GitHub @LesleyMurfin.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6027">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
