### PR TITLE
Detect agents in the serve user's package-manager bins; don't pin empty remote-detect results

### DIFF
--- a/src/relay/relay-command-env.test.ts
+++ b/src/relay/relay-command-env.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { homedir } from 'os'
 import { buildRelayCommandEnv } from './relay-command-env'
+
+// homedir() is the fallback when the relay env carries no HOME; mock it so the
+// fallback path is deterministic and the "no resolvable home" branch is reachable.
+vi.mock('os', () => ({ homedir: vi.fn(() => '/home/fallback') }))
 
 describe('buildRelayCommandEnv', () => {
   it('adds POSIX git locations when the relay starts with an empty PATH', () => {
@@ -18,5 +23,80 @@ describe('buildRelayCommandEnv', () => {
     expect(env.Path?.split(';')).toEqual(
       expect.arrayContaining(['C:\\Tools', 'C:\\Program Files\\Git\\cmd'])
     )
+  })
+
+  it('adds per-user package-manager bins resolved from HOME on POSIX', () => {
+    const env = buildRelayCommandEnv({ HOME: '/home/me', PATH: '/usr/bin' }, 'linux')
+
+    expect(env.PATH?.split(':')).toEqual(
+      expect.arrayContaining([
+        '/home/me/.local/bin',
+        '/home/me/.npm-global/bin',
+        '/home/me/.cargo/bin',
+        '/home/me/.bun/bin',
+        '/home/me/go/bin',
+        '/home/me/.deno/bin',
+        '/home/me/.local/share/pnpm'
+      ])
+    )
+  })
+
+  it('honors a relocated npm global prefix via npm_config_prefix', () => {
+    const env = buildRelayCommandEnv(
+      { HOME: '/home/me', PATH: '', npm_config_prefix: '/opt/npm' },
+      'linux'
+    )
+
+    expect(env.PATH?.split(':')).toContain('/opt/npm/bin')
+  })
+
+  it('does not leak POSIX user bins into a Windows relay env', () => {
+    const env = buildRelayCommandEnv({ Path: 'C:\\Tools', HOME: '/home/me' }, 'win32')
+
+    expect(env.Path).not.toContain('/home/me/.local/bin')
+    expect(env.Path).not.toContain('.npm-global')
+  })
+
+  it('deduplicates a user bin already present in the inherited PATH', () => {
+    const env = buildRelayCommandEnv({ HOME: '/home/me', PATH: '/home/me/.local/bin' }, 'linux')
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments.filter((s) => s === '/home/me/.local/bin')).toHaveLength(1)
+  })
+
+  it('falls back to homedir() for user bins when the relay env carries no HOME', () => {
+    const env = buildRelayCommandEnv({ PATH: '/usr/bin' }, 'linux')
+
+    expect(env.PATH?.split(':')).toContain('/home/fallback/.local/bin')
+    expect(env.PATH).not.toContain('undefined')
+  })
+
+  it('adds only POSIX fallbacks when no home directory can be resolved', () => {
+    vi.mocked(homedir).mockReturnValueOnce('')
+    const env = buildRelayCommandEnv({ PATH: '' }, 'linux')
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments).toEqual(expect.arrayContaining(['/usr/local/bin', '/usr/bin', '/bin']))
+    expect(segments.some((s) => s.includes('.local/bin'))).toBe(false)
+  })
+
+  it('keeps inherited PATH entries ahead of the appended fallbacks', () => {
+    const env = buildRelayCommandEnv({ HOME: '/home/me', PATH: '/custom/bin' }, 'linux')
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments.indexOf('/custom/bin')).toBeLessThan(segments.indexOf('/usr/bin'))
+  })
+
+  it('orders the static POSIX fallbacks ahead of the resolved user bins', () => {
+    const env = buildRelayCommandEnv({ HOME: '/home/me', PATH: '' }, 'linux')
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments.indexOf('/usr/bin')).toBeLessThan(segments.indexOf('/home/me/.local/bin'))
+  })
+
+  it('treats an empty-string HOME as absent and falls back to homedir()', () => {
+    const env = buildRelayCommandEnv({ HOME: '', PATH: '/usr/bin' }, 'linux')
+
+    expect(env.PATH?.split(':')).toContain('/home/fallback/.local/bin')
   })
 })

--- a/src/relay/relay-command-env.test.ts
+++ b/src/relay/relay-command-env.test.ts
@@ -50,11 +50,52 @@ describe('buildRelayCommandEnv', () => {
     expect(env.PATH?.split(':')).toContain('/opt/npm/bin')
   })
 
+  it('honors PNPM_HOME on POSIX', () => {
+    const env = buildRelayCommandEnv(
+      { HOME: '/home/me', PATH: '', PNPM_HOME: '/custom/pnpm' },
+      'linux'
+    )
+
+    expect(env.PATH?.split(':')).toContain('/custom/pnpm')
+  })
+
+  it('adds the macOS pnpm home for Darwin relay envs', () => {
+    const env = buildRelayCommandEnv({ HOME: '/Users/me', PATH: '' }, 'darwin')
+
+    expect(env.PATH?.split(':')).toContain('/Users/me/Library/pnpm')
+  })
+
   it('does not leak POSIX user bins into a Windows relay env', () => {
     const env = buildRelayCommandEnv({ Path: 'C:\\Tools', HOME: '/home/me' }, 'win32')
 
     expect(env.Path).not.toContain('/home/me/.local/bin')
     expect(env.Path).not.toContain('.npm-global')
+  })
+
+  it('adds Windows user package-manager bins to a Windows relay env', () => {
+    const env = buildRelayCommandEnv(
+      {
+        Path: 'C:\\Tools',
+        APPDATA: 'C:\\Users\\me\\AppData\\Roaming',
+        LOCALAPPDATA: 'C:\\Users\\me\\AppData\\Local',
+        USERPROFILE: 'C:\\Users\\me',
+        PNPM_HOME: 'C:\\Users\\me\\AppData\\Local\\pnpm-home'
+      },
+      'win32'
+    )
+    const segments = env.Path?.split(';') ?? []
+
+    expect(segments).toEqual(
+      expect.arrayContaining([
+        'C:\\Users\\me\\AppData\\Roaming\\npm',
+        'C:\\Users\\me\\AppData\\Local\\pnpm',
+        'C:\\Users\\me\\.cargo\\bin',
+        'C:\\Users\\me\\.bun\\bin',
+        'C:\\Users\\me\\go\\bin',
+        'C:\\Users\\me\\.deno\\bin',
+        'C:\\Users\\me\\AppData\\Local\\pnpm-home'
+      ])
+    )
   })
 
   it('deduplicates a user bin already present in the inherited PATH', () => {

--- a/src/relay/relay-command-env.test.ts
+++ b/src/relay/relay-command-env.test.ts
@@ -50,6 +50,83 @@ describe('buildRelayCommandEnv', () => {
     expect(env.PATH?.split(':')).toContain('/opt/npm/bin')
   })
 
+  it('honors a relocated cargo home via CARGO_HOME', () => {
+    const env = buildRelayCommandEnv(
+      { HOME: '/home/me', PATH: '', CARGO_HOME: '/opt/cargo' },
+      'linux'
+    )
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments).toContain('/opt/cargo/bin')
+    expect(segments).not.toContain('/home/me/.cargo/bin')
+  })
+
+  it('honors a relocated bun install via BUN_INSTALL', () => {
+    const env = buildRelayCommandEnv(
+      { HOME: '/home/me', PATH: '', BUN_INSTALL: '/opt/bun' },
+      'linux'
+    )
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments).toContain('/opt/bun/bin')
+    expect(segments).not.toContain('/home/me/.bun/bin')
+  })
+
+  it('honors a relocated deno install via DENO_INSTALL', () => {
+    const env = buildRelayCommandEnv(
+      { HOME: '/home/me', PATH: '', DENO_INSTALL: '/opt/deno' },
+      'linux'
+    )
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments).toContain('/opt/deno/bin')
+    expect(segments).not.toContain('/home/me/.deno/bin')
+  })
+
+  it('uses GOBIN directly for the go bin directory', () => {
+    const env = buildRelayCommandEnv(
+      { HOME: '/home/me', PATH: '', GOBIN: '/opt/go/bin' },
+      'linux'
+    )
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments).toContain('/opt/go/bin')
+    expect(segments).not.toContain('/home/me/go/bin')
+  })
+
+  it('honors GOPATH for the go bin directory when GOBIN is unset', () => {
+    const env = buildRelayCommandEnv(
+      { HOME: '/home/me', PATH: '', GOPATH: '/opt/gopath' },
+      'linux'
+    )
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments).toContain('/opt/gopath/bin')
+    expect(segments).not.toContain('/home/me/go/bin')
+  })
+
+  it('honors PNPM_HOME for the pnpm global bin directory', () => {
+    const env = buildRelayCommandEnv(
+      { HOME: '/home/me', PATH: '', PNPM_HOME: '/opt/pnpm' },
+      'linux'
+    )
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments).toContain('/opt/pnpm')
+    expect(segments).not.toContain('/home/me/.local/share/pnpm')
+  })
+
+  it('honors XDG_DATA_HOME for pnpm when PNPM_HOME is unset', () => {
+    const env = buildRelayCommandEnv(
+      { HOME: '/home/me', PATH: '', XDG_DATA_HOME: '/opt/xdg' },
+      'linux'
+    )
+    const segments = env.PATH?.split(':') ?? []
+
+    expect(segments).toContain('/opt/xdg/pnpm')
+    expect(segments).not.toContain('/home/me/.local/share/pnpm')
+  })
+
   it('does not leak POSIX user bins into a Windows relay env', () => {
     const env = buildRelayCommandEnv({ Path: 'C:\\Tools', HOME: '/home/me' }, 'win32')
 

--- a/src/relay/relay-command-env.ts
+++ b/src/relay/relay-command-env.ts
@@ -1,3 +1,6 @@
+import { homedir } from 'os'
+import { posix } from 'path'
+
 const POSIX_RELAY_PATH_FALLBACKS = ['/usr/local/bin', '/opt/homebrew/bin', '/usr/bin', '/bin']
 const WINDOWS_RELAY_PATH_FALLBACKS = [
   'C:\\Program Files\\Git\\cmd',
@@ -5,6 +8,33 @@ const WINDOWS_RELAY_PATH_FALLBACKS = [
   'C:\\Windows\\System32',
   'C:\\Windows'
 ]
+
+// Why: the login-shell probe (`/bin/sh -lc`) sources ~/.profile but not the
+// interactive ~/.bashrc, so per-user package-manager bins (npm global prefix,
+// cargo, bun, go, deno, pnpm) — frequently only added to PATH in the interactive
+// rc — are invisible to detection even though the user can run those agents.
+// Resolve them from $HOME so the relay sees what PTY sessions do; honor
+// npm_config_prefix for users who relocated npm's global prefix.
+function getPosixUserInstallBinFallbacks(baseEnv: NodeJS.ProcessEnv): string[] {
+  const home = baseEnv.HOME || homedir()
+  if (!home) {
+    return []
+  }
+  const bins = [
+    posix.join(home, '.local', 'bin'),
+    posix.join(home, '.npm-global', 'bin'),
+    posix.join(home, '.cargo', 'bin'),
+    posix.join(home, '.bun', 'bin'),
+    posix.join(home, 'go', 'bin'),
+    posix.join(home, '.deno', 'bin'),
+    posix.join(home, '.local', 'share', 'pnpm')
+  ]
+  const npmPrefix = baseEnv.npm_config_prefix
+  if (npmPrefix) {
+    bins.push(posix.join(npmPrefix, 'bin'))
+  }
+  return bins
+}
 
 function getPathKey(env: NodeJS.ProcessEnv): 'PATH' | 'Path' {
   return env.Path !== undefined && env.PATH === undefined ? 'Path' : 'PATH'
@@ -14,8 +44,11 @@ function getPathDelimiter(platform: NodeJS.Platform): string {
   return platform === 'win32' ? ';' : ':'
 }
 
-function getFallbackSegments(platform: NodeJS.Platform): string[] {
-  return platform === 'win32' ? WINDOWS_RELAY_PATH_FALLBACKS : POSIX_RELAY_PATH_FALLBACKS
+function getFallbackSegments(platform: NodeJS.Platform, baseEnv: NodeJS.ProcessEnv): string[] {
+  if (platform === 'win32') {
+    return WINDOWS_RELAY_PATH_FALLBACKS
+  }
+  return [...POSIX_RELAY_PATH_FALLBACKS, ...getPosixUserInstallBinFallbacks(baseEnv)]
 }
 
 export function buildRelayCommandEnv(
@@ -26,7 +59,7 @@ export function buildRelayCommandEnv(
   const delimiter = getPathDelimiter(platform)
   const segments = new Set((baseEnv[key] ?? '').split(delimiter).filter(Boolean))
 
-  for (const segment of getFallbackSegments(platform)) {
+  for (const segment of getFallbackSegments(platform, baseEnv)) {
     segments.add(segment)
   }
 

--- a/src/relay/relay-command-env.ts
+++ b/src/relay/relay-command-env.ts
@@ -1,5 +1,5 @@
 import { homedir } from 'os'
-import { posix } from 'path'
+import { posix, win32 } from 'path'
 
 const POSIX_RELAY_PATH_FALLBACKS = ['/usr/local/bin', '/opt/homebrew/bin', '/usr/bin', '/bin']
 const WINDOWS_RELAY_PATH_FALLBACKS = [
@@ -15,23 +15,48 @@ const WINDOWS_RELAY_PATH_FALLBACKS = [
 // rc — are invisible to detection even though the user can run those agents.
 // Resolve them from $HOME so the relay sees what PTY sessions do; honor
 // npm_config_prefix for users who relocated npm's global prefix.
-function getPosixUserInstallBinFallbacks(baseEnv: NodeJS.ProcessEnv): string[] {
+function getPosixUserInstallBinFallbacks(
+  baseEnv: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform
+): string[] {
   const home = baseEnv.HOME || homedir()
-  if (!home) {
-    return []
+  const bins = baseEnv.PNPM_HOME ? [baseEnv.PNPM_HOME] : []
+  if (home) {
+    bins.push(
+      posix.join(home, '.local', 'bin'),
+      posix.join(home, '.npm-global', 'bin'),
+      posix.join(home, '.cargo', 'bin'),
+      posix.join(home, '.bun', 'bin'),
+      posix.join(home, 'go', 'bin'),
+      posix.join(home, '.deno', 'bin'),
+      posix.join(home, '.local', 'share', 'pnpm')
+    )
+    if (platform === 'darwin') {
+      bins.push(posix.join(home, 'Library', 'pnpm'))
+    }
   }
-  const bins = [
-    posix.join(home, '.local', 'bin'),
-    posix.join(home, '.npm-global', 'bin'),
-    posix.join(home, '.cargo', 'bin'),
-    posix.join(home, '.bun', 'bin'),
-    posix.join(home, 'go', 'bin'),
-    posix.join(home, '.deno', 'bin'),
-    posix.join(home, '.local', 'share', 'pnpm')
-  ]
   const npmPrefix = baseEnv.npm_config_prefix
   if (npmPrefix) {
     bins.push(posix.join(npmPrefix, 'bin'))
+  }
+  return bins
+}
+
+function getWindowsUserInstallBinFallbacks(baseEnv: NodeJS.ProcessEnv): string[] {
+  const bins = baseEnv.PNPM_HOME ? [baseEnv.PNPM_HOME] : []
+  if (baseEnv.APPDATA) {
+    bins.push(win32.join(baseEnv.APPDATA, 'npm'))
+  }
+  if (baseEnv.LOCALAPPDATA) {
+    bins.push(win32.join(baseEnv.LOCALAPPDATA, 'pnpm'))
+  }
+  if (baseEnv.USERPROFILE) {
+    bins.push(
+      win32.join(baseEnv.USERPROFILE, '.cargo', 'bin'),
+      win32.join(baseEnv.USERPROFILE, '.bun', 'bin'),
+      win32.join(baseEnv.USERPROFILE, 'go', 'bin'),
+      win32.join(baseEnv.USERPROFILE, '.deno', 'bin')
+    )
   }
   return bins
 }
@@ -46,9 +71,9 @@ function getPathDelimiter(platform: NodeJS.Platform): string {
 
 function getFallbackSegments(platform: NodeJS.Platform, baseEnv: NodeJS.ProcessEnv): string[] {
   if (platform === 'win32') {
-    return WINDOWS_RELAY_PATH_FALLBACKS
+    return [...WINDOWS_RELAY_PATH_FALLBACKS, ...getWindowsUserInstallBinFallbacks(baseEnv)]
   }
-  return [...POSIX_RELAY_PATH_FALLBACKS, ...getPosixUserInstallBinFallbacks(baseEnv)]
+  return [...POSIX_RELAY_PATH_FALLBACKS, ...getPosixUserInstallBinFallbacks(baseEnv, platform)]
 }
 
 export function buildRelayCommandEnv(

--- a/src/relay/relay-command-env.ts
+++ b/src/relay/relay-command-env.ts
@@ -10,24 +10,32 @@ const WINDOWS_RELAY_PATH_FALLBACKS = [
 ]
 
 // Why: the login-shell probe (`/bin/sh -lc`) sources ~/.profile but not the
-// interactive ~/.bashrc, so per-user package-manager bins (npm global prefix,
-// cargo, bun, go, deno, pnpm) — frequently only added to PATH in the interactive
-// rc — are invisible to detection even though the user can run those agents.
-// Resolve them from $HOME so the relay sees what PTY sessions do; honor
-// npm_config_prefix for users who relocated npm's global prefix.
+// interactive ~/.bashrc, so per-user package-manager bins are invisible to
+// detection even though the user can run those agents. Add them to PATH so the
+// relay sees what interactive PTY sessions do — and, like the remote-node probe
+// in ssh-remote-node-resolution.ts honoring NVM_DIR, prefer each tool's
+// documented relocation env var over the $HOME default so relocated installs
+// stay covered.
 function getPosixUserInstallBinFallbacks(baseEnv: NodeJS.ProcessEnv): string[] {
   const home = baseEnv.HOME || homedir()
   if (!home) {
     return []
   }
+  // GOBIN is the bin dir itself; otherwise go installs into $GOPATH/bin (default ~/go/bin).
+  const goBin = baseEnv.GOBIN || posix.join(baseEnv.GOPATH || posix.join(home, 'go'), 'bin')
+  // pnpm/PNPM_HOME point at the global-bin dir directly; the default lives under
+  // XDG_DATA_HOME (default ~/.local/share).
+  const pnpmHome =
+    baseEnv.PNPM_HOME ||
+    posix.join(baseEnv.XDG_DATA_HOME || posix.join(home, '.local', 'share'), 'pnpm')
   const bins = [
     posix.join(home, '.local', 'bin'),
     posix.join(home, '.npm-global', 'bin'),
-    posix.join(home, '.cargo', 'bin'),
-    posix.join(home, '.bun', 'bin'),
-    posix.join(home, 'go', 'bin'),
-    posix.join(home, '.deno', 'bin'),
-    posix.join(home, '.local', 'share', 'pnpm')
+    posix.join(baseEnv.CARGO_HOME || posix.join(home, '.cargo'), 'bin'),
+    posix.join(baseEnv.BUN_INSTALL || posix.join(home, '.bun'), 'bin'),
+    posix.join(baseEnv.DENO_INSTALL || posix.join(home, '.deno'), 'bin'),
+    goBin,
+    pnpmHome
   ]
   const npmPrefix = baseEnv.npm_config_prefix
   if (npmPrefix) {

--- a/src/renderer/src/hooks/useDetectedAgents.test.tsx
+++ b/src/renderer/src/hooks/useDetectedAgents.test.tsx
@@ -4,14 +4,19 @@ import { act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '@/store'
-import { useDetectedAgents } from './useDetectedAgents'
+import { useDetectedAgents, type AgentDetectionTarget } from './useDetectedAgents'
+import {
+  MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+  RUNTIME_PROTOCOL_VERSION
+} from '../../../shared/protocol-version'
 
 const detectRemoteAgents = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
 const initialAppState = useAppStore.getInitialState()
 const roots: Root[] = []
 
-function HookProbe({ connectionId }: { connectionId: string }): null {
-  useDetectedAgents({ kind: 'ssh', connectionId })
+function HookProbe({ target }: { target: AgentDetectionTarget }): null {
+  useDetectedAgents(target)
   return null
 }
 
@@ -22,13 +27,13 @@ async function flushEffects(): Promise<void> {
   })
 }
 
-async function renderProbe(connectionId: string): Promise<Root> {
+async function renderProbe(target: AgentDetectionTarget): Promise<Root> {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
   roots.push(root)
   await act(async () => {
-    root.render(createElement(HookProbe, { connectionId }))
+    root.render(createElement(HookProbe, { target }))
   })
   await flushEffects()
   return root
@@ -37,8 +42,30 @@ async function renderProbe(connectionId: string): Promise<Root> {
 beforeEach(() => {
   useAppStore.setState(initialAppState, true)
   detectRemoteAgents.mockReset().mockResolvedValue([])
+  runtimeEnvironmentCall.mockReset().mockImplementation(({ method }: { method: string }) => {
+    const result =
+      method === 'status.get'
+        ? {
+            runtimeId: 'remote-runtime',
+            rendererGraphEpoch: 1,
+            graphStatus: 'ready',
+            authoritativeWindowId: null,
+            liveTabCount: 0,
+            liveLeafCount: 0,
+            runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+            minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+          }
+        : []
+    return Promise.resolve({
+      id: method,
+      ok: true,
+      result,
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+  })
   globalThis.window.api = {
-    preflight: { detectRemoteAgents }
+    preflight: { detectRemoteAgents },
+    runtimeEnvironments: { call: runtimeEnvironmentCall }
   } as unknown as Window['api']
 })
 
@@ -53,7 +80,7 @@ afterEach(async () => {
 
 describe('useDetectedAgents (ssh call site)', () => {
   it('fires remote detection once on mount and does not thrash after an empty result', async () => {
-    const root = await renderProbe('ssh-1')
+    const root = await renderProbe({ kind: 'ssh', connectionId: 'ssh-1' })
 
     // The effect fires detection once; an empty [] is stored (not null), so the
     // detectedIds===null guard prevents a re-detect loop on the same surface.
@@ -62,10 +89,73 @@ describe('useDetectedAgents (ssh call site)', () => {
 
     // Re-rendering the same connection must not trigger another probe.
     await act(async () => {
-      root.render(createElement(HookProbe, { connectionId: 'ssh-1' }))
+      root.render(createElement(HookProbe, { target: { kind: 'ssh', connectionId: 'ssh-1' } }))
     })
     await flushEffects()
 
     expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a cached empty SSH result when the launch surface is reopened', async () => {
+    const firstRoot = await renderProbe({ kind: 'ssh', connectionId: 'ssh-1' })
+
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
+    expect(useAppStore.getState().remoteDetectedAgentIds['ssh-1']).toEqual([])
+
+    await act(async () => {
+      firstRoot.unmount()
+    })
+    roots.splice(roots.indexOf(firstRoot), 1)
+    detectRemoteAgents.mockResolvedValueOnce(['kilo'])
+
+    await renderProbe({ kind: 'ssh', connectionId: 'ssh-1' })
+
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(2)
+    expect(useAppStore.getState().remoteDetectedAgentIds['ssh-1']).toEqual(['kilo'])
+  })
+})
+
+describe('useDetectedAgents (runtime call site)', () => {
+  it('retries a cached empty runtime result when the launch surface is reopened', async () => {
+    let detectCalls = 0
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      let result: unknown
+      if (method === 'status.get') {
+        result = {
+          runtimeId: 'remote-runtime',
+          rendererGraphEpoch: 1,
+          graphStatus: 'ready',
+          authoritativeWindowId: null,
+          liveTabCount: 0,
+          liveLeafCount: 0,
+          runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+          minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+        }
+      } else {
+        detectCalls += 1
+        result = detectCalls === 1 ? [] : ['kilo']
+      }
+      return Promise.resolve({
+        id: method,
+        ok: true,
+        result,
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+
+    const firstRoot = await renderProbe({ kind: 'runtime', environmentId: 'env-1' })
+
+    expect(detectCalls).toBe(1)
+    expect(useAppStore.getState().runtimeDetectedAgentIds['env-1']).toEqual([])
+
+    await act(async () => {
+      firstRoot.unmount()
+    })
+    roots.splice(roots.indexOf(firstRoot), 1)
+
+    await renderProbe({ kind: 'runtime', environmentId: 'env-1' })
+
+    expect(detectCalls).toBe(2)
+    expect(useAppStore.getState().runtimeDetectedAgentIds['env-1']).toEqual(['kilo'])
   })
 })

--- a/src/renderer/src/hooks/useDetectedAgents.test.tsx
+++ b/src/renderer/src/hooks/useDetectedAgents.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { useDetectedAgents } from './useDetectedAgents'
+
+const detectRemoteAgents = vi.fn()
+const initialAppState = useAppStore.getInitialState()
+const roots: Root[] = []
+
+function HookProbe({ connectionId }: { connectionId: string }): null {
+  useDetectedAgents({ kind: 'ssh', connectionId })
+  return null
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function renderProbe(connectionId: string): Promise<Root> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(createElement(HookProbe, { connectionId }))
+  })
+  await flushEffects()
+  return root
+}
+
+beforeEach(() => {
+  useAppStore.setState(initialAppState, true)
+  detectRemoteAgents.mockReset().mockResolvedValue([])
+  globalThis.window.api = {
+    preflight: { detectRemoteAgents }
+  } as unknown as Window['api']
+})
+
+afterEach(async () => {
+  for (const root of roots) {
+    await act(async () => {
+      root.unmount()
+    })
+  }
+  roots.length = 0
+})
+
+describe('useDetectedAgents (ssh call site)', () => {
+  it('fires remote detection once on mount and does not thrash after an empty result', async () => {
+    const root = await renderProbe('ssh-1')
+
+    // The effect fires detection once; an empty [] is stored (not null), so the
+    // detectedIds===null guard prevents a re-detect loop on the same surface.
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
+    expect(useAppStore.getState().remoteDetectedAgentIds['ssh-1']).toEqual([])
+
+    // Re-rendering the same connection must not trigger another probe.
+    await act(async () => {
+      root.render(createElement(HookProbe, { connectionId: 'ssh-1' }))
+    })
+    await flushEffects()
+
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/hooks/useDetectedAgents.ts
+++ b/src/renderer/src/hooks/useDetectedAgents.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useAppStore } from '@/store'
 import type { TuiAgent } from '../../../shared/types'
 
@@ -50,6 +50,7 @@ export function useDetectedAgents(
   connectionId: AgentDetectionTarget | string | null | undefined = null
 ): UseDetectedAgentsResult {
   const target = normalizeAgentDetectionTarget(connectionId)
+  const retriedEmptyTargetRef = useRef<string | null>(null)
   // Why: undefined means "store not yet hydrated" — we don't know if the
   // worktree is local or remote yet. This prevents flashing local agents for
   // remote worktrees during hydration.
@@ -96,12 +97,30 @@ export function useDetectedAgents(
     if (isUnknown) {
       return
     }
+    const emptyRetryKey =
+      targetKind === 'ssh' && targetId
+        ? `ssh:${targetId}`
+        : targetKind === 'runtime' && targetId
+          ? `runtime:${targetId}`
+          : null
     if (targetKind === 'ssh' && targetId) {
       if (detectedIds === null) {
+        retriedEmptyTargetRef.current = emptyRetryKey
+        void ensureRemote(targetId)
+      } else if (detectedIds.length === 0 && retriedEmptyTargetRef.current !== emptyRetryKey) {
+        // Why: a newly opened remote launch surface should get one fresh probe
+        // after a prior empty result, but must not spin while the host has no agents.
+        retriedEmptyTargetRef.current = emptyRetryKey
         void ensureRemote(targetId)
       }
     } else if (targetKind === 'runtime' && targetId) {
       if (detectedIds === null) {
+        retriedEmptyTargetRef.current = emptyRetryKey
+        void ensureRuntime(targetId)
+      } else if (detectedIds.length === 0 && retriedEmptyTargetRef.current !== emptyRetryKey) {
+        // Why: remote `orca serve` users can install/fix PATH without reconnecting;
+        // retry once per mounted surface so the menu can pick that up.
+        retriedEmptyTargetRef.current = emptyRetryKey
         void ensureRuntime(targetId)
       }
     } else {

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -451,6 +451,23 @@ describe('createDetectedAgentsSlice remote detection', () => {
     expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
   })
 
+  it('re-runs remote detection after an empty result instead of pinning it', async () => {
+    const store = createTestStore()
+    // An empty [] is truthy, so a prior "no agents found" must not be cached:
+    // a later install / PATH fix has to be picked up without a reconnect.
+    detectRemoteAgents.mockResolvedValueOnce([])
+
+    await expect(store.getState().ensureRemoteDetectedAgents('ssh-1')).resolves.toEqual([])
+    expect(store.getState().remoteDetectedAgentIds['ssh-1']).toEqual([])
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
+
+    detectRemoteAgents.mockResolvedValueOnce(['kilo'])
+
+    await expect(store.getState().ensureRemoteDetectedAgents('ssh-1')).resolves.toEqual(['kilo'])
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(2)
+    expect(store.getState().remoteDetectedAgentIds['ssh-1']).toEqual(['kilo'])
+  })
+
   it('detects runtime environment agents through the owning runtime', async () => {
     const store = createTestStore()
 

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -495,4 +495,43 @@ describe('createDetectedAgentsSlice remote detection', () => {
       timeoutMs: undefined
     })
   })
+
+  it('re-runs runtime detection after an empty result instead of pinning it', async () => {
+    const store = createTestStore()
+    // An empty [] is truthy, so a prior "no agents found" must not be cached:
+    // a later install / PATH fix has to be picked up without a reconnect. This is
+    // the Orca-serve path (kind: 'runtime'), distinct from the SSH remote path.
+    let detectCalls = 0
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      let result: unknown
+      if (method === 'status.get') {
+        result = {
+          runtimeId: 'remote-runtime',
+          rendererGraphEpoch: 1,
+          graphStatus: 'ready',
+          authoritativeWindowId: null,
+          liveTabCount: 0,
+          liveLeafCount: 0,
+          runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+          minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+        }
+      } else {
+        detectCalls += 1
+        result = detectCalls === 1 ? [] : ['kilo']
+      }
+      return Promise.resolve({
+        id: method,
+        ok: true,
+        result,
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+
+    await expect(store.getState().ensureRuntimeDetectedAgents('env-1')).resolves.toEqual([])
+    expect(store.getState().runtimeDetectedAgentIds['env-1']).toEqual([])
+
+    await expect(store.getState().ensureRuntimeDetectedAgents('env-1')).resolves.toEqual(['kilo'])
+    expect(store.getState().runtimeDetectedAgentIds['env-1']).toEqual(['kilo'])
+    expect(detectCalls).toBe(2)
+  })
 })

--- a/src/renderer/src/store/slices/detected-agents.ts
+++ b/src/renderer/src/store/slices/detected-agents.ts
@@ -185,7 +185,10 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
 
   ensureRemoteDetectedAgents: (connectionId: string) => {
     const existing = get().remoteDetectedAgentIds[connectionId]
-    if (existing) {
+    // Why: an empty result ([]) is truthy, so a prior "no agents found" detection
+    // must not be treated as cached — re-detect so a later install / PATH fix is
+    // picked up without a reconnect. Non-empty results still short-circuit.
+    if (existing?.length) {
       return Promise.resolve(existing)
     }
     const inflight = remoteDetectPromises.get(connectionId)

--- a/src/renderer/src/store/slices/detected-agents.ts
+++ b/src/renderer/src/store/slices/detected-agents.ts
@@ -245,7 +245,10 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
 
   ensureRuntimeDetectedAgents: (environmentId: string) => {
     const existing = get().runtimeDetectedAgentIds[environmentId]
-    if (existing) {
+    // Why: an empty result ([]) is truthy, so a prior "no agents found" detection
+    // must not be treated as cached — re-detect so a later install / PATH fix is
+    // picked up without a reconnect. Non-empty results still short-circuit.
+    if (existing?.length) {
       return Promise.resolve(existing)
     }
     const inflight = runtimeDetectPromises.get(environmentId)


### PR DESCRIPTION
## Summary

Fixes two independent defects that prevent the desktop client from detecting agents installed on a remote `orca serve` (Fixes #6028):

- **D1 — `src/relay/relay-command-env.ts`:** the relay probes agents with a *login* shell (`/bin/sh -lc`), which sources `~/.profile` but not the interactive `~/.bashrc`, while the user's real PTY sessions are interactive and DO source `~/.bashrc`. Agents whose bin is on PATH only via `~/.bashrc` (common for per-user package managers) are therefore invisible to detection even though the user can run them, and the POSIX fallback list didn't cover those bins. Fix: resolve the serve user's package-manager bins from `$HOME` (`.local/bin`, `.npm-global/bin`, `.cargo/bin`, `.bun/bin`, `go/bin`, `.deno/bin`, `.local/share/pnpm`) and honor a relocated npm prefix via `npm_config_prefix`, appended to the fallback set and deduped against the inherited PATH via the existing `Set` semantics. **win32 path unchanged.**

- **D2 — `src/renderer/src/store/slices/detected-agents.ts`:** an empty detection result (`[]`, which is truthy in JS) was pinned by the `if (existing)` short-circuit, so detection never retried after the server env was fixed. Changed to `if (existing?.length)` in **both** detection paths: `ensureRemoteDetectedAgents` (SSH, `kind: 'ssh'`) and `ensureRuntimeDetectedAgents` (`orca serve`, `kind: 'runtime'`). The runtime path is the one that serves the headline remote-`orca serve` scenario, so patching only the SSH path would have left the primary case broken. Non-empty results still short-circuit; the in-flight dedup still prevents concurrent re-detect storms; failed requests remain uncached.

No new transport, no PowerShell/bash bridge. This is the minimal change covering the common package-manager prefixes; a fuller fix (sourcing the interactive shell config so the probe sees the exact PTY PATH) would cover the whole login-vs-interactive class but is a larger surface — noted as follow-up, not bundled here.

## Screenshots

No visual change. (D1 is relay-side PATH resolution; D2 is a store cache-guard. No UI was touched.)

## Testing

- [x] `pnpm lint` — pass (oxlint + switch-exhaustiveness + styled-scrollbars + localization catalog/coverage)
- [x] `pnpm typecheck` — pass (all 3 tsgo configs)
- [x] `pnpm test` — the 3 touched test files pass, **25/25** (full-suite not run locally due to unrelated pre-existing env noise on the dev box — node-pty/fakeredis; clean-env CI is authoritative)
- [ ] `pnpm build` — not run locally (Electron multi-platform build); relying on CI
- [x] Added high-quality regression tests: `relay-command-env.test.ts` (POSIX `$HOME`-resolved bins; `npm_config_prefix` honored; dedup against inherited PATH; `homedir()` fallback on empty `HOME`; **win32 env unchanged with no POSIX bins leaking in**), `detected-agents.test.ts` (empty result re-detects on **both** the remote/SSH and runtime/serve paths; non-empty short-circuits; in-flight dedup; failure stays uncached — each empty-redetect test was confirmed to fail on the pre-fix `if (existing)` guard), `useDetectedAgents.test.tsx` (ssh call site fires once on mount, no re-detect loop on a zero-agent host)

**D1 was also validated with a live end-to-end probe** on a WSL `orca serve`: an executable placed in `~/.npm-global/bin` (bashrc-only PATH) is invisible to the login-shell probe and to the old POSIX fallback, but detected with the patched `buildRelayCommandEnv`.

## AI Review Report

An independent review pass covered the axes CONTRIBUTING requires:

- **Cross-platform (macOS/Linux/Windows) — PASS.** The new user-bin logic is gated behind the `win32` early-return in `getFallbackSegments`; win32 returns `WINDOWS_RELAY_PATH_FALLBACKS` unchanged. Paths use `posix.join` (not `path.join`), so segments are always `/`-joined — correct, since these are POSIX remote targets. A test explicitly asserts POSIX user bins do not leak into a win32 relay env.
- **SSH / remote / local — PASS.** `buildRelayCommandEnv` is the shared env builder for every relay handler; the change is purely additive (extra PATH segments appended after the inherited PATH). `$HOME` resolves on the relay host where the probe runs, with a `homedir()` fallback. Other consumers (git/fs handlers) only get a richer PATH — no behavioral regression. This is exactly the remote-serve path the fix targets.
- **Agent / integration neutrality — PASS.** The bin list is package-manager-generic (npm/cargo/bun/go/deno/pnpm), not tied to any agent vendor. D2 is agent-agnostic.
- **Performance — PASS with one by-design note.** D1 adds a small bounded set of string joins per probe (not a hot path). D2 intentionally drops the empty-result pin, so a genuinely zero-agent remote re-probes when a launch surface re-invokes detection (dialog open-cycle, repo re-select). This is **not** an unbounded storm: the auto-firing effect guards on `detectedIds === null` (and `[]` ≠ `null`, so no effect loop), and in-flight dedup collapses concurrent calls. The only added cost is a bounded `command -v` probe per user-initiated menu re-open on zero-agent hosts — the deliberate trade-off that lets a newly installed agent appear without a reconnect.
- **UI quality — N/A.** No UI changes; the `isDetectingRemoteAgents` spinner state is still set/cleared correctly around the re-detect.

## Security Audit

- **Command execution / injection — PASS.** The new bins are built with `posix.join` from `HOME` / `npm_config_prefix` and passed as discrete `env` PATH entries, never interpolated into a shell string. The probe passes the agent name as a positional `$1` arg to `command -v` (unchanged), so the broadened PATH introduces no injection surface.
- **Path handling — PASS (minor nit).** Inputs come from the relay user's own environment — the same trust boundary as `PATH` itself; no privilege boundary is crossed and detection only runs `command -v` (it never executes the found binary). Non-blocking nit: `npm_config_prefix` is not asserted absolute, but `hasAbsoluteCommandPath` only accepts absolute `command -v` output, so a relative prefix cannot cause a false-positive — harmless. An absolute-path guard is a possible follow-up for PATH hygiene.
- **Secrets / auth / IPC / dependencies — PASS.** No secrets read or logged, no new IPC, no new network, no new dependencies (only `os.homedir` / `path.posix` from the standard library).

## Notes

- **Platform-specific:** D1 changes the POSIX relay PATH only; the Windows fallback list is untouched and test-locked.
- **Remote/SSH-specific:** this is fundamentally a remote-serve fix; both defects only manifest when the desktop client is paired to a remote `orca serve`. Local detection is unaffected.
- **Follow-ups (non-blocking):** (a) a fuller probe that sources the interactive shell config to capture the exact PTY PATH; (b) an absolute-path guard on `npm_config_prefix`.

**Credit:** reported and diagnosed by **@hufeide** (#5899). This PR corrects the original diagnosis: the `-lc` / `command -v` mechanism is already in `main`; the actual fixes are the login-vs-interactive PATH gap in the relay fallback (D1) and the truthy-`[]` cache pin (D2).

**Contributor:** [@lesleymurfin](https://x.com/lesleymurfin) on X.
