### PR TITLE
Preserve same-id repos across hosts

### DIFF
--- a/src/renderer/src/lib/repo-runtime-owner.test.ts
+++ b/src/renderer/src/lib/repo-runtime-owner.test.ts
@@ -19,6 +19,21 @@ describe('getRuntimeEnvironmentIdForRepo', () => {
     ).toBe('owner-runtime')
   })
 
+  it('matches duplicate repos against encoded focused runtime host ids', () => {
+    expect(
+      getRuntimeEnvironmentIdForRepo(
+        {
+          settings: { activeRuntimeEnvironmentId: 'prod/server' },
+          repos: [
+            { id: 'repo-1', connectionId: null, executionHostId: 'local' },
+            { id: 'repo-1', connectionId: null, executionHostId: 'runtime:prod%2Fserver' }
+          ]
+        },
+        'repo-1'
+      )
+    ).toBe('prod/server')
+  })
+
   it('keeps explicit local repos local while a runtime is focused', () => {
     expect(
       getRuntimeEnvironmentIdForRepo(

--- a/src/renderer/src/lib/repo-runtime-owner.ts
+++ b/src/renderer/src/lib/repo-runtime-owner.ts
@@ -1,4 +1,9 @@
-import { getRepoExecutionHostId, parseExecutionHostId } from '../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  toRuntimeExecutionHostId
+} from '../../../shared/execution-host'
 import type { GlobalSettings, Repo } from '../../../shared/types'
 
 export type RepoRuntimeOwnerState = {
@@ -13,13 +18,25 @@ export function getRuntimeEnvironmentIdForRepo(
   if (!repoId) {
     return null
   }
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repos = state.repos?.filter((entry) => entry.id === repoId) ?? []
+  const repo = getActiveHostRepo(state, repos) ?? repos[0]
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
     return parsed?.kind === 'runtime' ? parsed.environmentId : null
   }
   return state.settings?.activeRuntimeEnvironmentId?.trim() || null
+}
+
+function getActiveHostRepo(
+  state: RepoRuntimeOwnerState,
+  repos: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[]
+): Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> | undefined {
+  const activeRuntimeId = state.settings?.activeRuntimeEnvironmentId?.trim()
+  const activeHostId = activeRuntimeId
+    ? toRuntimeExecutionHostId(activeRuntimeId)
+    : LOCAL_EXECUTION_HOST_ID
+  return repos.find((repo) => getRepoExecutionHostId(repo) === activeHostId)
 }
 
 export function getSettingsForRepoRuntimeOwner(

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/types'
+import { mergeFetchedReposForHost } from './repo-host-refresh-merge'
+
+function repo(id: string, hostId: ExecutionHostId, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path: `/${hostId}/${id}`,
+    displayName: id,
+    badgeColor: '#000000',
+    addedAt: 1,
+    executionHostId: hostId,
+    ...overrides
+  }
+}
+
+function idsByHost(repos: readonly Repo[]): Record<string, string[]> {
+  const result: Record<string, string[]> = {}
+  for (const entry of repos) {
+    const hostId = getRepoExecutionHostId(entry)
+    result[hostId] ??= []
+    result[hostId].push(entry.id)
+  }
+  return result
+}
+
+describe('mergeFetchedReposForHost', () => {
+  it('refreshes one host without dropping repos owned by another host', () => {
+    const previous = [
+      repo('local-a', 'local'),
+      repo('runtime-a', 'runtime:env-a'),
+      repo('runtime-stale', 'runtime:env-a')
+    ]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('runtime-a', 'runtime:env-a', { displayName: 'runtime renamed' })],
+      'runtime:env-a'
+    )
+
+    expect(idsByHost(merged)).toEqual({
+      local: ['local-a'],
+      'runtime:env-a': ['runtime-a']
+    })
+    expect(merged.find((entry) => entry.id === 'runtime-a')?.displayName).toBe('runtime renamed')
+  })
+
+  it('matches repos by host and id instead of id alone', () => {
+    const previous = [
+      repo('same-id', 'local', { path: '/local/orca' }),
+      repo('same-id', 'runtime:env-a', { path: '/srv/orca-old' })
+    ]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('same-id', 'runtime:env-a', { path: '/srv/orca-new' })],
+      'runtime:env-a'
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(merged.find((entry) => getRepoExecutionHostId(entry) === 'local')?.path).toBe(
+      '/local/orca'
+    )
+    expect(merged.find((entry) => getRepoExecutionHostId(entry) === 'runtime:env-a')?.path).toBe(
+      '/srv/orca-new'
+    )
+  })
+
+  it('adds a same-id repo on a new host without replacing the existing host repo', () => {
+    const previous = [repo('same-id', 'local', { path: '/local/orca' })]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('same-id', 'runtime:env-a', { path: '/srv/orca' })],
+      'runtime:env-a'
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(idsByHost(merged)).toEqual({
+      local: ['same-id'],
+      'runtime:env-a': ['same-id']
+    })
+  })
+})

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.ts
@@ -1,0 +1,34 @@
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/types'
+import { reconcileFetchedRepos } from './repo-identity-reconcile'
+
+function getRepoOwnerKey(repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>): string {
+  // Why: repo ids are only guaranteed unique inside one host's store. A runtime
+  // refresh must not replace a same-id local or sibling-runtime checkout.
+  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
+}
+
+export function mergeFetchedReposForHost(
+  previous: readonly Repo[],
+  fetched: Repo[],
+  hostId: ExecutionHostId
+): Repo[] {
+  const fetchedOwnerKeys = new Set(fetched.map(getRepoOwnerKey))
+  const preserved = previous.filter((repo) => {
+    const existingHostId = getRepoExecutionHostId(repo)
+    return existingHostId !== hostId || fetchedOwnerKeys.has(getRepoOwnerKey(repo))
+  })
+  const merged = [...preserved]
+  const indexByOwnerKey = new Map(merged.map((repo, index) => [getRepoOwnerKey(repo), index]))
+  for (const repo of fetched) {
+    const ownerKey = getRepoOwnerKey(repo)
+    const existingIndex = indexByOwnerKey.get(ownerKey)
+    if (existingIndex === undefined) {
+      indexByOwnerKey.set(ownerKey, merged.length)
+      merged.push(repo)
+      continue
+    }
+    merged[existingIndex] = repo
+  }
+  return reconcileFetchedRepos(previous, merged)
+}

--- a/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
@@ -39,6 +39,22 @@ describe('reconcileFetchedRepos', () => {
     expect(result[0]).toBe(next[0])
   })
 
+  it('keys object reuse by repo id and execution host', () => {
+    const previous = [
+      makeRepo('same-id', { executionHostId: 'local', path: '/local/orca' }),
+      makeRepo('same-id', { executionHostId: 'runtime:env-a', path: '/srv/orca' })
+    ]
+    const next = [
+      makeRepo('same-id', { executionHostId: 'runtime:env-a', path: '/srv/orca' }),
+      makeRepo('same-id', { executionHostId: 'local', path: '/local/orca' })
+    ]
+
+    const result = reconcileFetchedRepos(previous, next)
+
+    expect(result[0]).toBe(previous[1])
+    expect(result[1]).toBe(previous[0])
+  })
+
   it('returns a rebuilt array when repos are added or removed', () => {
     const previous = [makeRepo('a')]
     const next = [makeRepo('a'), makeRepo('b')]

--- a/src/renderer/src/store/slices/repo-identity-reconcile.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.ts
@@ -1,3 +1,4 @@
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/types'
 
 // Why: after a drag-reorder we optimistically set `repos`, persist, and main
@@ -27,10 +28,10 @@ function areReposEqual(a: Repo, b: Repo): boolean {
 }
 
 export function reconcileFetchedRepos(previous: readonly Repo[], next: Repo[]): Repo[] {
-  const previousById = new Map(previous.map((repo) => [repo.id, repo]))
+  const previousByIdentity = new Map(previous.map((repo) => [getRepoIdentityKey(repo), repo]))
   let identical = next.length === previous.length
   const reconciled = next.map((repo, index) => {
-    const existing = previousById.get(repo.id)
+    const existing = previousByIdentity.get(getRepoIdentityKey(repo))
     if (existing && areReposEqual(existing, repo)) {
       if (existing !== previous[index]) {
         identical = false
@@ -41,4 +42,8 @@ export function reconcileFetchedRepos(previous: readonly Repo[], next: Repo[]): 
     return repo
   })
   return identical ? (previous as Repo[]) : reconciled
+}
+
+function getRepoIdentityKey(repo: Repo): string {
+  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
 }

--- a/src/renderer/src/store/slices/repo-reorder-host-split.test.ts
+++ b/src/renderer/src/store/slices/repo-reorder-host-split.test.ts
@@ -43,4 +43,21 @@ describe('splitRepoReorderByHost', () => {
     })
     expect(groups).toEqual([{ hostId: 'local', orderedIds: ['a'] }])
   })
+
+  it('keeps duplicate repo ids assigned to their distinct hosts', () => {
+    const groups = splitRepoReorderByHost(
+      ['github:stablyai/orca', 'local-a', 'github:stablyai/orca'],
+      [
+        repo('github:stablyai/orca', 'runtime:env-1'),
+        repo('local-a', 'local'),
+        repo('github:stablyai/orca', 'runtime:env-2')
+      ],
+      { activeRuntimeEnvironmentId: null }
+    )
+    expect(groups).toEqual([
+      { hostId: 'runtime:env-1', orderedIds: ['github:stablyai/orca'] },
+      { hostId: 'local', orderedIds: ['local-a'] },
+      { hostId: 'runtime:env-2', orderedIds: ['github:stablyai/orca'] }
+    ])
+  })
 })

--- a/src/renderer/src/store/slices/repo-reorder-host-split.ts
+++ b/src/renderer/src/store/slices/repo-reorder-host-split.ts
@@ -25,14 +25,20 @@ export function splitRepoReorderByHost(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
 ): RepoReorderHostGroup[] {
   const focusedHostId = getSettingsFocusedExecutionHostId(settings)
-  const hostByRepoId = new Map<string, string>()
+  const hostIdsByRepoId = new Map<string, string[]>()
   for (const repo of repos) {
     const hasExplicitOwner = Boolean(repo.executionHostId?.trim() || repo.connectionId?.trim())
-    hostByRepoId.set(repo.id, hasExplicitOwner ? getRepoExecutionHostId(repo) : focusedHostId)
+    const hostId = hasExplicitOwner ? getRepoExecutionHostId(repo) : focusedHostId
+    const existing = hostIdsByRepoId.get(repo.id)
+    if (existing) {
+      existing.push(hostId)
+    } else {
+      hostIdsByRepoId.set(repo.id, [hostId])
+    }
   }
   const groups = new Map<string, string[]>()
   for (const id of orderedIds) {
-    const hostId = hostByRepoId.get(id)
+    const hostId = hostIdsByRepoId.get(id)?.shift()
     if (!hostId) {
       continue
     }

--- a/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
+++ b/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const localRepo: Repo = {
+  id: 'same-repo',
+  path: '/Users/alice/orca',
+  displayName: 'local orca',
+  badgeColor: '#000000',
+  addedAt: 1
+}
+
+const runtimeRepo: Repo = {
+  id: 'same-repo',
+  path: '/srv/orca',
+  displayName: 'remote orca',
+  badgeColor: '#111111',
+  addedAt: 2
+}
+
+const reposList = vi.fn()
+const reposUpdate = vi.fn()
+const projectsList = vi.fn()
+const projectsListHostSetups = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposList.mockReset()
+  reposUpdate.mockReset()
+  projectsList.mockReset()
+  projectsListHostSetups.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+  projectsList.mockResolvedValue([])
+  projectsListHostSetups.mockResolvedValue([])
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: {
+        list: reposList,
+        update: reposUpdate
+      },
+      projects: {
+        list: projectsList,
+        listHostSetups: projectsListHostSetups
+      },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('repo slice multi-host refresh', () => {
+  it('keeps same-id local and runtime repos after switching hosts', async () => {
+    reposList.mockResolvedValue([localRepo])
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'repo.list') {
+        return Promise.resolve({
+          id: 'repo-list',
+          ok: true,
+          result: { repos: [runtimeRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'project.list') {
+        return Promise.resolve({
+          id: 'project-list',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          id: 'setup-list',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${method}`)
+    })
+    const store = createTestStore()
+
+    await store.getState().fetchRepos()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().repos).toHaveLength(2)
+    expect(store.getState().repos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: localRepo.id,
+          path: localRepo.path,
+          executionHostId: 'local'
+        }),
+        expect.objectContaining({
+          id: runtimeRepo.id,
+          path: runtimeRepo.path,
+          executionHostId: 'runtime:env-1'
+        })
+      ])
+    )
+  })
+
+  it('updates only the active host repo when ids collide across hosts', async () => {
+    reposList.mockResolvedValue([localRepo])
+    runtimeEnvironmentCall.mockImplementation((request: RuntimeEnvironmentCallRequest) => {
+      const { method } = request
+      if (method === 'repo.list') {
+        return Promise.resolve({
+          id: 'repo-list',
+          ok: true,
+          result: { repos: [runtimeRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'repo.update') {
+        const updates = (request as unknown as { params: { updates: Partial<Repo> } }).params
+          .updates
+        return Promise.resolve({
+          id: 'repo-update',
+          ok: true,
+          result: { repo: { ...runtimeRepo, ...updates } },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'project.list') {
+        return Promise.resolve({
+          id: 'project-list',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          id: 'setup-list',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${method}`)
+    })
+    const store = createTestStore()
+
+    await store.getState().fetchRepos()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    await store.getState().fetchRepos()
+    const updated = await store.getState().updateRepo(runtimeRepo.id, {
+      displayName: 'remote renamed'
+    })
+
+    expect(updated).toBe(true)
+    expect(reposUpdate).not.toHaveBeenCalled()
+    expect(store.getState().repos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: localRepo.id,
+          displayName: localRepo.displayName,
+          executionHostId: 'local'
+        }),
+        expect.objectContaining({
+          id: runtimeRepo.id,
+          displayName: 'remote renamed',
+          executionHostId: 'runtime:env-1'
+        })
+      ])
+    )
+  })
+})

--- a/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
+++ b/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import { createTestStore, makeWorktree } from './store-test-helpers'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+
+const repoId = 'github:stablyai/orca'
+
+const baseRepo: Repo = {
+  id: repoId,
+  path: '/env-one/orca',
+  displayName: 'Orca',
+  badgeColor: '#111',
+  addedAt: 1
+}
+
+const reposRemove = vi.fn()
+const reposReorder = vi.fn()
+const ptyKill = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+function runtimeRepo(environmentId: string, path: string, displayName: string): Repo {
+  return {
+    ...baseRepo,
+    path,
+    displayName,
+    executionHostId: `runtime:${environmentId}`
+  }
+}
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposRemove.mockReset()
+  reposReorder.mockReset()
+  ptyKill.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentCall.mockResolvedValue({
+    id: 'rpc-same-id-host-mutation',
+    ok: true,
+    result: { status: 'applied' },
+    _meta: { runtimeId: 'runtime-remote' }
+  })
+  runtimeEnvironmentTransportCall.mockReset()
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: {
+        remove: reposRemove,
+        reorder: reposReorder
+      },
+      pty: { kill: ptyKill },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('repo slice same-id host mutations', () => {
+  it('keeps sibling host repos and worktrees when removing the active remote host row', async () => {
+    const envOneRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
+    const envTwoRepo = runtimeRepo('env-2', '/env-two/orca', 'Orca on env two')
+    const envOneWorktree = makeWorktree({
+      id: `${repoId}::/env-one/wt`,
+      repoId,
+      path: '/env-one/wt',
+      hostId: 'runtime:env-1'
+    })
+    const envTwoWorktree = makeWorktree({
+      id: `${repoId}::/env-two/wt`,
+      repoId,
+      path: '/env-two/wt',
+      hostId: 'runtime:env-2'
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [envOneRepo, envTwoRepo],
+      activeRepoId: repoId,
+      filterRepoIds: [repoId],
+      worktreesByRepo: { [repoId]: [envOneWorktree, envTwoWorktree] },
+      detectedWorktreesByRepo: {
+        [repoId]: {
+          repoId,
+          authoritative: true,
+          source: 'git',
+          worktrees: [
+            {
+              ...envOneWorktree,
+              ownership: 'orca-managed',
+              selectedCheckout: false,
+              visible: true
+            },
+            { ...envTwoWorktree, ownership: 'orca-managed', selectedCheckout: false, visible: true }
+          ]
+        }
+      },
+      tabsByWorktree: {
+        [envOneWorktree.id]: [{ id: 'tab-env-one', worktreeId: envOneWorktree.id }] as never,
+        [envTwoWorktree.id]: [{ id: 'tab-env-two', worktreeId: envTwoWorktree.id }] as never
+      },
+      ptyIdsByTabId: {
+        'tab-env-one': ['remote:env-one'],
+        'tab-env-two': ['remote:env-two']
+      },
+      lastVisitedAtByWorktreeId: {
+        [envOneWorktree.id]: 1,
+        [envTwoWorktree.id]: 2
+      }
+    })
+
+    await store.getState().removeProject(repoId)
+
+    expect(store.getState().repos).toEqual([envTwoRepo])
+    expect(store.getState().worktreesByRepo[repoId]).toEqual([envTwoWorktree])
+    expect(store.getState().detectedWorktreesByRepo[repoId]?.worktrees).toEqual([
+      expect.objectContaining({ id: envTwoWorktree.id, hostId: 'runtime:env-2' })
+    ])
+    expect(store.getState().tabsByWorktree[envOneWorktree.id]).toBeUndefined()
+    expect(store.getState().tabsByWorktree[envTwoWorktree.id]).toEqual([
+      { id: 'tab-env-two', worktreeId: envTwoWorktree.id }
+    ])
+    expect(store.getState().lastVisitedAtByWorktreeId).toEqual({ [envTwoWorktree.id]: 2 })
+    expect(store.getState().activeRepoId).toBeNull()
+    expect(store.getState().filterRepoIds).toEqual([repoId])
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'repo.rm',
+      params: { repo: repoId },
+      timeoutMs: 15_000
+    })
+    expect(reposRemove).not.toHaveBeenCalled()
+  })
+
+  it('keeps same-id repos from distinct hosts when reordering', async () => {
+    const envOneRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
+    const envTwoRepo = runtimeRepo('env-2', '/env-two/orca', 'Orca on env two')
+    const store = createTestStore()
+    store.setState({ repos: [envOneRepo, envTwoRepo] })
+
+    await store.getState().reorderRepos([repoId, repoId])
+
+    expect(store.getState().repos).toEqual([envOneRepo, envTwoRepo])
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'repo.reorder',
+      params: { orderedIds: [repoId] },
+      timeoutMs: 15_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-2',
+      method: 'repo.reorder',
+      params: { orderedIds: [repoId] },
+      timeoutMs: 15_000
+    })
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -45,7 +45,7 @@ import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
 import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
 import { getRepoIdFromWorktreeId } from './worktree-helpers'
-import { reconcileFetchedRepos } from './repo-identity-reconcile'
+import { mergeFetchedReposForHost } from './repo-host-refresh-merge'
 import { splitRepoReorderByHost } from './repo-reorder-host-split'
 import {
   assertRuntimeEnvironmentCapability,
@@ -187,15 +187,60 @@ function getRepoUpdateChains(get: () => AppState): Map<string, Promise<boolean>>
   return chains
 }
 
-function getKnownRepoWorktreeIds(state: AppState, projectId: string): string[] {
+type RepoOwnedWorktree = { id: string; hostId?: string | null }
+
+function getKnownRepoWorktreeIds(
+  state: AppState,
+  projectId: string,
+  ownerHostId: string,
+  includeLegacyWorktrees: boolean
+): string[] {
   const ids = new Set<string>()
   for (const worktree of state.worktreesByRepo[projectId] ?? []) {
-    ids.add(worktree.id)
+    if (worktreeBelongsToOwner(worktree, ownerHostId, includeLegacyWorktrees)) {
+      ids.add(worktree.id)
+    }
   }
   for (const worktree of state.detectedWorktreesByRepo[projectId]?.worktrees ?? []) {
-    ids.add(worktree.id)
+    if (worktreeBelongsToOwner(worktree, ownerHostId, includeLegacyWorktrees)) {
+      ids.add(worktree.id)
+    }
   }
   return [...ids]
+}
+
+function worktreeBelongsToOwner(
+  worktree: RepoOwnedWorktree,
+  ownerHostId: string,
+  includeLegacyWorktrees: boolean
+): boolean {
+  const hostId = worktree.hostId?.trim()
+  return hostId ? hostId === ownerHostId : includeLegacyWorktrees
+}
+
+function queueReposById(repos: readonly Repo[]): Map<string, Repo[]> {
+  const reposById = new Map<string, Repo[]>()
+  for (const repo of repos) {
+    const existing = reposById.get(repo.id)
+    if (existing) {
+      existing.push(repo)
+    } else {
+      reposById.set(repo.id, [repo])
+    }
+  }
+  return reposById
+}
+
+function reorderReposByIdPermutation(orderedIds: readonly string[], previous: readonly Repo[]) {
+  const reposById = queueReposById(previous)
+  const next: Repo[] = []
+  for (const id of orderedIds) {
+    const repo = reposById.get(id)?.shift()
+    if (repo) {
+      next.push(repo)
+    }
+  }
+  return next.length === previous.length ? next : null
 }
 
 function getRuntimeTargetHostId(
@@ -432,32 +477,6 @@ function mergeById<T extends { id: string }>(base: readonly T[], overlay: readon
   return merged
 }
 
-function mergeFetchedReposForHost(
-  previous: readonly Repo[],
-  fetched: Repo[],
-  hostId: string
-): Repo[] {
-  const fetchedIds = new Set(fetched.map((repo) => repo.id))
-  const preserved = previous.filter((repo) => {
-    const existingHostId = getRepoExecutionHostId(repo)
-    return existingHostId !== hostId || fetchedIds.has(repo.id)
-  })
-  const preservedById = new Map(preserved.map((repo) => [repo.id, repo]))
-  const merged = [...preserved]
-  for (const repo of fetched) {
-    const existingIndex = merged.findIndex((entry) => entry.id === repo.id)
-    if (existingIndex === -1) {
-      merged.push(repo)
-      continue
-    }
-    merged[existingIndex] = repo
-  }
-  return reconcileFetchedRepos(
-    previous,
-    merged.filter((repo) => preservedById.has(repo.id) || fetchedIds.has(repo.id))
-  )
-}
-
 async function fetchReposForTarget(
   target: ReturnType<typeof getActiveRuntimeTarget>,
   currentRepos: readonly Repo[]
@@ -494,6 +513,33 @@ async function fetchReposForTarget(
 
 function settingsForRepoOwner(state: Pick<AppState, 'repos' | 'settings'>, repoId: string) {
   return getSettingsForRepoRuntimeOwner(state, repoId) as AppState['settings']
+}
+
+function hasExplicitRepoOwner(repo: Pick<Repo, 'connectionId' | 'executionHostId'>): boolean {
+  return Boolean(repo.executionHostId?.trim() || repo.connectionId?.trim())
+}
+
+function getRepoMutationOwnerHostId(
+  repos: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[],
+  repoId: string,
+  targetHostId: string
+): string {
+  const candidates = repos.filter((repo) => repo.id === repoId)
+  const targetOwned = candidates.find(
+    (repo) => hasExplicitRepoOwner(repo) && getRepoExecutionHostId(repo) === targetHostId
+  )
+  if (targetOwned) {
+    return targetHostId
+  }
+  const explicitOwner = candidates.find(hasExplicitRepoOwner)
+  return explicitOwner ? getRepoExecutionHostId(explicitOwner) : targetHostId
+}
+
+function isRepoMutationTarget(repo: Repo, repoId: string, ownerHostId: string): boolean {
+  if (repo.id !== repoId) {
+    return false
+  }
+  return !hasExplicitRepoOwner(repo) || getRepoExecutionHostId(repo) === ownerHostId
 }
 
 function getFolderWorkspacePathStatusScopeKey(request: FolderWorkspacePathStatusRequest): string {
@@ -1638,18 +1684,30 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   removeProject: async (projectId) => {
     try {
       const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
+      const targetHostId = getRuntimeTargetHostId(target)
+      const ownerHostId = getRepoMutationOwnerHostId(get().repos, projectId, targetHostId)
+      const removeAllRepoWorktreeState = !get().repos.some(
+        (repo) => repo.id === projectId && !isRepoMutationTarget(repo, projectId, ownerHostId)
+      )
       await (target.kind === 'local'
         ? window.api.repos.remove({ repoId: projectId })
         : callRuntimeRpc(target, 'repo.rm', { repo: projectId }, { timeoutMs: 15_000 }))
 
       get().clearOrcaHookTrustForRepo(projectId)
-      const repoPath = get().repos.find((repo) => repo.id === projectId)?.path
+      const repoPath = get().repos.find((repo) =>
+        isRepoMutationTarget(repo, projectId, ownerHostId)
+      )?.path
       get().evictGitHubRepoCaches(projectId, repoPath)
       const { clearRepoSlugCacheEntry } = await import('../../lib/repo-slug-index')
       clearRepoSlugCacheEntry(projectId)
 
       // Kill PTYs for all worktrees belonging to this repo
-      const worktreeIds = getKnownRepoWorktreeIds(get(), projectId)
+      const worktreeIds = getKnownRepoWorktreeIds(
+        get(),
+        projectId,
+        ownerHostId,
+        removeAllRepoWorktreeState
+      )
       const killedTabIds = new Set<string>()
       const killedPtyIds = new Set<string>()
       if (target.kind === 'environment') {
@@ -1685,10 +1743,31 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       get().purgeWorktreeTerminalState(worktreeIds)
 
       set((s) => {
+        const worktreeIdSet = new Set(worktreeIds)
         const nextWorktrees = { ...s.worktreesByRepo }
-        delete nextWorktrees[projectId]
+        const remainingWorktrees = removeAllRepoWorktreeState
+          ? []
+          : (s.worktreesByRepo[projectId] ?? []).filter(
+              (worktree) => !worktreeIdSet.has(worktree.id)
+            )
+        if (remainingWorktrees.length > 0) {
+          nextWorktrees[projectId] = remainingWorktrees
+        } else {
+          delete nextWorktrees[projectId]
+        }
         const nextDetectedWorktrees = { ...s.detectedWorktreesByRepo }
-        delete nextDetectedWorktrees[projectId]
+        const detected = s.detectedWorktreesByRepo[projectId]
+        const remainingDetectedWorktrees = removeAllRepoWorktreeState
+          ? []
+          : (detected?.worktrees ?? []).filter((worktree) => !worktreeIdSet.has(worktree.id))
+        if (detected && remainingDetectedWorktrees.length > 0) {
+          nextDetectedWorktrees[projectId] = {
+            ...detected,
+            worktrees: remainingDetectedWorktrees
+          }
+        } else {
+          delete nextDetectedWorktrees[projectId]
+        }
         const nextTabs = { ...s.tabsByWorktree }
         const nextLayouts = { ...s.terminalLayoutsByTabId }
         const nextPtyIdsByTabId = { ...s.ptyIdsByTabId }
@@ -1709,7 +1788,6 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         // remove open editor files and per-worktree active-file tracking for
         // all worktrees that belonged to the repo, otherwise orphaned entries
         // would persist in the session save and pollute state.
-        const worktreeIdSet = new Set(worktreeIds)
         const nextOpenFiles = s.openFiles.filter((f) => !worktreeIdSet.has(f.worktreeId))
         const nextActiveFileIdByWorktree = { ...s.activeFileIdByWorktree }
         const nextActiveTabTypeByWorktree = { ...s.activeTabTypeByWorktree }
@@ -1726,19 +1804,27 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         // forever after the repo is removed.
         let nextLastVisitedAtByWorktreeId = s.lastVisitedAtByWorktreeId
         for (const id of Object.keys(s.lastVisitedAtByWorktreeId)) {
-          if (getRepoIdFromWorktreeId(id) === projectId) {
+          const shouldDropTimestamp = removeAllRepoWorktreeState
+            ? getRepoIdFromWorktreeId(id) === projectId
+            : worktreeIdSet.has(id)
+          if (shouldDropTimestamp) {
             if (nextLastVisitedAtByWorktreeId === s.lastVisitedAtByWorktreeId) {
               nextLastVisitedAtByWorktreeId = { ...s.lastVisitedAtByWorktreeId }
             }
             delete nextLastVisitedAtByWorktreeId[id]
           }
         }
-        const nextRepos = s.repos.filter((r) => r.id !== projectId)
+        const nextRepos = s.repos.filter(
+          (repo) => !isRepoMutationTarget(repo, projectId, ownerHostId)
+        )
+        const removedLastRepoWithId = !nextRepos.some((repo) => repo.id === projectId)
         return {
           repos: nextRepos,
           ...projectCompatibilityFromRepos(nextRepos),
           activeRepoId: s.activeRepoId === projectId ? null : s.activeRepoId,
-          filterRepoIds: s.filterRepoIds.filter((id) => id !== projectId),
+          filterRepoIds: removedLastRepoWithId
+            ? s.filterRepoIds.filter((id) => id !== projectId)
+            : s.filterRepoIds,
           worktreesByRepo: nextWorktrees,
           detectedWorktreesByRepo: nextDetectedWorktrees,
           tabsByWorktree: nextTabs,
@@ -1811,10 +1897,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   updateRepo: async (projectId, updates) => {
     const updateRepoChains = getRepoUpdateChains(get)
+    const sanitizedUpdates = sanitizeRepoUpdate(updates)
+    const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
+    const targetHostId = getRuntimeTargetHostId(target)
+    const ownerHostId = getRepoMutationOwnerHostId(get().repos, projectId, targetHostId)
+    const updateKey = `${ownerHostId}\0${projectId}`
     const applyRepoUpdate = async () => {
       try {
-        const sanitizedUpdates = sanitizeRepoUpdate(updates)
-        const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
         const updatedRepo =
           target.kind === 'local'
             ? await window.api.repos.update({ repoId: projectId, updates: sanitizedUpdates })
@@ -1828,7 +1917,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               ).repo
         set((s) => {
           const nextRepos = s.repos.map((r) => {
-            if (r.id !== projectId) {
+            if (!isRepoMutationTarget(r, projectId, ownerHostId)) {
               return r
             }
             if (updatedRepo) {
@@ -1859,16 +1948,16 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return false
       }
     }
-    const previous = updateRepoChains.get(projectId)
+    const previous = updateRepoChains.get(updateKey)
     // Why: repo settings are persisted as full nested values. Preserve call
     // order per repo so a slower IPC/RPC response cannot overwrite newer state.
     const next = previous
       ? previous.catch(() => undefined).then(applyRepoUpdate)
       : applyRepoUpdate()
-    updateRepoChains.set(projectId, next)
+    updateRepoChains.set(updateKey, next)
     const cleanup = () => {
-      if (updateRepoChains.get(projectId) === next) {
-        updateRepoChains.delete(projectId)
+      if (updateRepoChains.get(updateKey) === next) {
+        updateRepoChains.delete(updateKey)
       }
     }
     void next.then(cleanup, cleanup)
@@ -1881,15 +1970,8 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     // Optimistically apply the new order so the sidebar updates instantly;
     // resync only if main rejects (stale permutation due to a racing add/remove).
     const previous = get().repos
-    const byId = new Map(previous.map((r) => [r.id, r]))
-    const next: Repo[] = []
-    for (const id of orderedIds) {
-      const repo = byId.get(id)
-      if (repo) {
-        next.push(repo)
-      }
-    }
-    if (next.length !== previous.length) {
+    const next = reorderReposByIdPermutation(orderedIds, previous)
+    if (!next) {
       // Caller passed a non-permutation — refuse to apply locally.
       return
     }


### PR DESCRIPTION
## Context

Tracking issue: #6032

Remote Orca Servers can report repositories that share the same repo id across different hosts. The store had several paths that treated `repo.id` as globally unique. Refreshing or mutating one host could replace, remove, or reorder the row for another host with the same id. That breaks the SSH and remote-server case where two machines have independent checkouts of the same project.

## Changed

- Reconcile fetched repos by host-qualified identity.
- Preserve same-id repos from other hosts when one host refreshes.
- Route `updateRepo`, `removeProject`, and repo reorder operations to the matching host row.
- Keep worktree ownership checks host-aware so same-id sibling repos keep their worktree and tab state.

## Regression coverage

The tests model two hosts that expose the same repo id, then exercise refresh, update, removal, reorder, and runtime-owner lookup. These fail on `main` because the old store collapses rows by bare `repo.id`.

## Tests

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/repo-identity-reconcile.test.ts src/renderer/src/store/slices/repo-host-refresh-merge.test.ts src/renderer/src/store/slices/repos-multi-host-refresh.test.ts src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts src/renderer/src/store/slices/repo-reorder-host-split.test.ts src/renderer/src/lib/repo-runtime-owner.test.ts src/renderer/src/store/slices/repos-update-serialization.test.ts src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/repo-runtime-owner.ts src/renderer/src/lib/repo-runtime-owner.test.ts src/renderer/src/store/slices/repo-host-refresh-merge.ts src/renderer/src/store/slices/repo-host-refresh-merge.test.ts src/renderer/src/store/slices/repo-identity-reconcile.ts src/renderer/src/store/slices/repo-identity-reconcile.test.ts src/renderer/src/store/slices/repo-reorder-host-split.ts src/renderer/src/store/slices/repo-reorder-host-split.test.ts src/renderer/src/store/slices/repos.ts src/renderer/src/store/slices/repos-multi-host-refresh.test.ts src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts src/renderer/src/store/slices/project-host-setup-compatibility-merge.ts src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts`
- `pnpm run typecheck:web`

## Stack

1. This PR: preserve same-id repos across hosts.
2. #6031: preserve shared project host setup state across host refreshes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6030">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->