### PR TITLE
Preserve shared project host setups on refresh

### DIFF
--- a/docs/worktree-host-identity-rollout-validation.md
+++ b/docs/worktree-host-identity-rollout-validation.md
@@ -1,0 +1,54 @@
+# Worktree Host Identity Rollout Validation
+
+## Goal
+
+Use host-qualified worktree IDs so the same repo/path on different execution hosts cannot collide:
+
+```text
+orca-worktree://v1?hostId=<host>&repoId=<repo>&path=<absolute-path>
+```
+
+Legacy IDs (`repoId::path`) remain accepted at public and persisted boundaries. Runtime and newly written state should resolve to canonical host-qualified IDs.
+
+## Compatibility Rules
+
+- New worktree IDs are canonical and include `hostId`, `repoId`, and `path`.
+- Legacy `repoId::path` IDs are parsed and accepted for existing sessions, metadata, cleanup requests, terminal selectors, browser scopes, and runtime CLI/mobile calls.
+- When Orca can prove a legacy ID maps to exactly one canonical repo/path/host, it returns and stores the canonical ID.
+- Existing legacy metadata and lineage are read through alias lookups before stamping new canonical metadata.
+- Old daemon PTY ids may remain legacy as PTY ids, but their owning `worktreeId` is canonicalized when the repo/path match is known.
+- Teardown sweeps both canonical and legacy PTY/session prefixes so old sessions are still killed during removal.
+
+## Risks Addressed
+
+- Local and SSH worktrees with the same repo/path no longer share one ID.
+- Legacy metadata remains visible during SSH reconnect/disconnected fallback.
+- Legacy terminal/session ids do not create duplicate runtime buckets after migration.
+- Cleanup preflight and skip-git deferrals accept both old and new ids.
+- Runtime lineage records seeded under legacy ids still attach to canonical worktree rows.
+
+## Automated Evidence
+
+Passing after fixes:
+
+- `pnpm exec vitest run src/shared/worktree-id.test.ts src/main/daemon/pty-session-id.test.ts src/main/ipc/worktrees.test.ts`
+- `pnpm exec vitest run src/main/persistence.test.ts -t "migrateWorktreeIdentity|host-partitioned workspace sessions"`
+- `pnpm exec vitest run src/main/ipc/workspace-cleanup.test.ts src/main/ipc/remote-workspace.test.ts src/shared/remote-workspace-session-projection.test.ts src/main/memory/hydrate-local-pty-registry.test.ts`
+- `pnpm exec vitest run src/main/runtime/orca-runtime.test.ts -t "worktree|ManagedWorktree|listManagedWorktrees|createManagedWorktree"`
+- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts -t "migrateWorktreeIdentity"`
+- `pnpm run typecheck:node`
+- `pnpm run typecheck:web`
+- targeted `oxlint`
+- `git diff --check`
+
+Node engine warning observed locally: repo wants Node 24; validation environment is Node v26.
+
+## Electron Evidence
+
+- Launched Electron with an isolated user data directory.
+- Verified the app identity matched this worktree before interacting.
+- Added a temp git repo and created an Orca-managed worktree through the app.
+- Confirmed the visible sidebar rendered the created workspace.
+- Confirmed store state used a canonical `orca-worktree://v1?...hostId=local...` id.
+- Removed the created workspace through a legacy `repoId::path` id and verified the canonical row disappeared.
+- Shut down only the Electron process launched for validation.

--- a/src/main/daemon/pty-session-id.test.ts
+++ b/src/main/daemon/pty-session-id.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { makeWorktreeKey } from '../../shared/worktree-id'
 import { isSafePtySessionId, mintPtySessionId, parsePtySessionId } from './pty-session-id'
 
 const USER_DATA = '/tmp/orca-userdata'
@@ -38,6 +39,15 @@ describe('isSafePtySessionId', () => {
     // rejected `/` would break every real daemon spawn.
     const id = mintPtySessionId('repo-abc123::/Users/thebr/work/wt-1')
     expect(isSafePtySessionId(id, USER_DATA)).toBe(true)
+  })
+
+  it('accepts minted ids with host-qualified worktree keys', () => {
+    const worktreeId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: 'repo-abc123',
+      path: '/Users/thebr/work/wt-1'
+    })
+    expect(isSafePtySessionId(mintPtySessionId(worktreeId), USER_DATA)).toBe(true)
   })
 
   it('accepts caller-supplied path-shaped ids that stay inside userData', () => {
@@ -84,6 +94,15 @@ describe('isSafePtySessionId', () => {
 describe('parsePtySessionId', () => {
   it('round-trips a minted id back to its worktreeId', () => {
     const wt = 'repo-abc::/Users/me/wt/feature'
+    expect(parsePtySessionId(mintPtySessionId(wt))).toEqual({ worktreeId: wt })
+  })
+
+  it('round-trips a minted host-qualified worktree key back to its worktreeId', () => {
+    const wt = makeWorktreeKey({
+      hostId: 'runtime:gpu',
+      repoId: 'repo-abc',
+      path: '/srv/orca/worktree'
+    })
     expect(parsePtySessionId(mintPtySessionId(wt))).toEqual({ worktreeId: wt })
   })
 

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -18,7 +18,12 @@ import type {
 } from '../../shared/remote-workspace-types'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { WorkspaceSessionState } from '../../shared/types'
-import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
+import {
+  getRepoIdFromWorktreeId,
+  makeRepoWorktreeKey,
+  splitWorktreeId
+} from '../../shared/worktree-id'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
 import { getRemoteWorkspaceNamespace } from './remote-workspace-namespace'
 import { registerRemoteWorkspaceNotificationHandler } from './remote-workspace-events'
 
@@ -224,6 +229,11 @@ function getExplicitHydratedTargetIds(value: unknown): Set<string> | null {
 }
 
 function targetForWorktree(store: Store, worktreeId: string): string | null {
+  const parsed = splitWorktreeId(worktreeId)
+  if (parsed?.hostId) {
+    const host = parseExecutionHostId(parsed.hostId)
+    return host?.kind === 'ssh' ? host.targetId : null
+  }
   const repoId = getRepoIdFromWorktreeId(worktreeId)
   return store.getRepo(repoId)?.connectionId ?? null
 }
@@ -248,11 +258,11 @@ function importSessionForTarget(
   return importRemoteWorkspaceSession(remote, {
     resolveWorktreeId: (worktreePath) => {
       for (const repo of repoById.values()) {
-        const candidate = `${repo.id}::${worktreePath}`
+        const candidate = makeRepoWorktreeKey(repo, worktreePath)
         // Main does not own the live worktree list for SSH repos, so resolve
         // against repo identity only. Renderer hydration later validates IDs
         // against its fetched worktree list before panes mount.
-        if (splitWorktreeId(candidate)) {
+        if (splitWorktreeId(candidate)?.hostId === getRepoExecutionHostId(repo)) {
           return candidate
         }
       }

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -720,6 +720,18 @@ const ProjectHostSetupCreateIpcArgs = z.object({
 
 const ProjectHostSetupUpdateIpcArgs = z.object({
   setupId: z.string().min(1),
+  hostId: z
+    .string()
+    .min(1)
+    .transform((value, ctx) => {
+      const hostId = normalizeExecutionHostId(value)
+      if (!hostId) {
+        ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+        return z.NEVER
+      }
+      return hostId
+    })
+    .optional(),
   updates: z.object({
     displayName: z.string().optional(),
     path: z.string().optional(),
@@ -734,7 +746,19 @@ const ProjectHostSetupUpdateIpcArgs = z.object({
 })
 
 const ProjectHostSetupDeleteIpcArgs = z.object({
-  setupId: z.string().min(1)
+  setupId: z.string().min(1),
+  hostId: z
+    .string()
+    .min(1)
+    .transform((value, ctx) => {
+      const hostId = normalizeExecutionHostId(value)
+      if (!hostId) {
+        ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+        return z.NEVER
+      }
+      return hostId
+    })
+    .optional()
 })
 
 const FolderWorkspaceLinkedTaskArgs = z

--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -10,6 +10,7 @@ import type {
   Repo,
   WorktreeMeta
 } from '../../shared/types'
+import { makeRepoWorktreeKey } from '../../shared/worktree-id'
 
 const {
   listRepoWorktreesMock,
@@ -453,7 +454,7 @@ describe('workspace cleanup scan', () => {
     expect(result.errors).toEqual([])
     expect(result.candidates).toHaveLength(LARGE_WORKTREE_COUNT)
     expect(result.candidates[0]).toMatchObject({
-      worktreeId: 'repo-1::/repo-feature-0',
+      worktreeId: makeRepoWorktreeKey(REPO, '/repo-feature-0'),
       path: '/repo-feature-0',
       branch: 'feature-0',
       tier: 'review',
@@ -463,7 +464,7 @@ describe('workspace cleanup scan', () => {
       }
     })
     expect(result.candidates[LARGE_WORKTREE_COUNT - 1]).toMatchObject({
-      worktreeId: `repo-1::/repo-feature-${LARGE_WORKTREE_COUNT - 1}`,
+      worktreeId: makeRepoWorktreeKey(REPO, `/repo-feature-${LARGE_WORKTREE_COUNT - 1}`),
       path: `/repo-feature-${LARGE_WORKTREE_COUNT - 1}`,
       branch: `feature-${LARGE_WORKTREE_COUNT - 1}`
     })

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -19,7 +19,14 @@ import type {
   WorktreeMeta
 } from '../../shared/types'
 import { mergeWorktree } from './worktree-logic'
-import { splitWorktreeId } from '../../shared/worktree-id'
+import {
+  getRepoWorktreeIdAliases,
+  isRepoWorktreeIdAlias,
+  makeRepoWorktreeKey,
+  parseWorktreeKey,
+  splitWorktreeId
+} from '../../shared/worktree-id'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import {
   WORKSPACE_CLEANUP_CLASSIFIER_VERSION,
   applyWorkspaceCleanupPolicy,
@@ -266,13 +273,17 @@ async function scanRepoWorkspaces(args: {
 
   const worktrees = gitWorktrees
     .map((gitWorktree) => {
-      const worktreeId = `${repo.id}::${gitWorktree.path}`
-      const meta = store.getWorktreeMeta(worktreeId)
-      return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+      const worktreeId = makeRepoWorktreeKey(repo, gitWorktree.path)
+      const meta =
+        store.getWorktreeMeta(worktreeId) ??
+        store.getWorktreeMeta(`${repo.id}::${gitWorktree.path}`)
+      return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+        hostId: getRepoExecutionHostId(repo)
+      })
     })
     .filter((worktree) => {
       if (targetWorktreeId) {
-        return worktree.id === targetWorktreeId
+        return isRepoWorktreeIdAlias(repo, worktree.path, targetWorktreeId)
       }
       return (
         !repoIsFolder &&
@@ -287,7 +298,9 @@ async function scanRepoWorkspaces(args: {
       worktree,
       scannedAt,
       provider,
-      skipGit: skipGitWorktreeIds.has(worktree.id),
+      skipGit: [...getRepoWorktreeIdAliases(repo, worktree.path)].some((id) =>
+        skipGitWorktreeIds.has(id)
+      ),
       forceGitCheck: Boolean(targetWorktreeId)
     }).catch((error) => {
       console.error('Workspace cleanup candidate scan failed', error)
@@ -530,20 +543,38 @@ function synthesizeDisconnectedSshCandidates(
   targetWorktreeId?: string
 ): WorkspaceCleanupCandidate[] {
   const repoWorktreePrefix = `${repo.id}::`
+  const repoHostId = getRepoExecutionHostId(repo)
+  const isRepoWorktreeId = (worktreeId: string): boolean => {
+    const parsed = parseWorktreeKey(worktreeId)
+    if (parsed) {
+      return parsed.repoId === repo.id && parsed.hostId === repoHostId
+    }
+    return worktreeId.startsWith(repoWorktreePrefix)
+  }
   if (targetWorktreeId) {
-    if (!targetWorktreeId.startsWith(repoWorktreePrefix)) {
+    if (!isRepoWorktreeId(targetWorktreeId)) {
       return []
     }
     // Why: focused delete preflight names one workspace already; walking all
     // persisted metadata is unnecessary for disconnected SSH repos.
-    const meta = store.getWorktreeMeta(targetWorktreeId)
+    const parsed = splitWorktreeId(targetWorktreeId)
+    const canonicalTargetId =
+      parsed && parsed.repoId === repo.id
+        ? makeRepoWorktreeKey(repo, parsed.worktreePath)
+        : targetWorktreeId
+    const legacyTargetId =
+      parsed && parsed.repoId === repo.id ? `${repo.id}::${parsed.worktreePath}` : targetWorktreeId
+    const meta =
+      store.getWorktreeMeta(targetWorktreeId) ??
+      store.getWorktreeMeta(canonicalTargetId) ??
+      store.getWorktreeMeta(legacyTargetId)
     return meta ? [createDisconnectedSshCandidate(repo, scannedAt, targetWorktreeId, meta)] : []
   }
 
   const candidates: WorkspaceCleanupCandidate[] = []
   const allMeta = store.getAllWorktreeMeta()
   for (const worktreeId in allMeta) {
-    if (!Object.hasOwn(allMeta, worktreeId) || !worktreeId.startsWith(repoWorktreePrefix)) {
+    if (!Object.hasOwn(allMeta, worktreeId) || !isRepoWorktreeId(worktreeId)) {
       continue
     }
     const meta = allMeta[worktreeId]

--- a/src/main/ipc/worktree-metadata-merge.ts
+++ b/src/main/ipc/worktree-metadata-merge.ts
@@ -1,5 +1,10 @@
 import { basename } from 'path'
 import type { GitWorktreeInfo, Worktree, WorktreeMeta } from '../../shared/types'
+import {
+  makeLegacyWorktreeId,
+  makeWorktreeKey,
+  type ParsedCanonicalWorktreeKey
+} from '../../shared/worktree-id'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import { getLinkedWorkItemMetadata } from './worktree-linked-work-item-metadata'
 
@@ -10,15 +15,19 @@ export function mergeWorktree(
   repoId: string,
   git: GitWorktreeInfo,
   meta: WorktreeMeta | undefined,
-  defaultDisplayName?: string
+  defaultDisplayName?: string,
+  canonical?: Pick<ParsedCanonicalWorktreeKey, 'hostId'>
 ): Worktree {
   const branchShort = git.branch.replace(/^refs\/heads\//, '')
+  const hostId = meta?.hostId ?? canonical?.hostId
   return {
-    id: `${repoId}::${git.path}`,
+    id: hostId
+      ? makeWorktreeKey({ hostId, repoId, path: git.path })
+      : makeLegacyWorktreeId(repoId, git.path),
     ...(meta?.instanceId !== undefined ? { instanceId: meta.instanceId } : {}),
     repoId,
     ...(meta?.projectId !== undefined ? { projectId: meta.projectId } : {}),
-    ...(meta?.hostId !== undefined ? { hostId: meta.hostId } : {}),
+    ...(hostId !== undefined ? { hostId } : {}),
     ...(meta?.projectHostSetupId !== undefined
       ? { projectHostSetupId: meta.projectHostSetupId }
       : {}),

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -76,7 +76,8 @@ import {
   mergeWorktree,
   areWorktreePathsEqual
 } from './worktree-logic'
-import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, makeRepoWorktreeKey } from '../../shared/worktree-id'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import {
   cleanupUnusedWorktreePushTargetRemoteWithExec,
@@ -205,6 +206,13 @@ function recordWorkspaceLineageForCreatedWorktree(
     capture: { source: 'active-workspace', confidence: 'explicit' },
     createdAt
   })
+}
+
+function getRepoWorktreeId(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string
+): string {
+  return makeRepoWorktreeKey(repo, path)
 }
 
 function countNonEmptyGitOutputLines(output: string): number {
@@ -1447,7 +1455,7 @@ export async function createRemoteWorktree(
   validateWorkspaceLineageParentBeforeCreate(
     store,
     args.parentWorkspace,
-    worktreeWorkspaceKey(`${repo.id}::${remotePath}`)
+    worktreeWorkspaceKey(getRepoWorktreeId(repo, remotePath))
   )
 
   const sparseDirectories = args.sparseCheckout
@@ -1616,7 +1624,7 @@ export async function createRemoteWorktree(
     throw new Error('Worktree created but not found in listing')
   }
 
-  const worktreeId = `${repo.id}::${created.path}`
+  const worktreeId = getRepoWorktreeId(repo, created.path)
   const now = Date.now()
   // Why: PR/MR-created worktrees can start from a head ref/SHA while Source
   // Control must compare against the review target branch.
@@ -1690,7 +1698,11 @@ export async function createRemoteWorktree(
   }
   const { worktree } = timing.timeSync('persist_metadata', () => {
     const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
-    return { worktree: mergeWorktree(repo.id, created, meta) }
+    return {
+      worktree: mergeWorktree(repo.id, created, meta, undefined, {
+        hostId: getRepoExecutionHostId(repo)
+      })
+    }
   })
   const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
 
@@ -2055,7 +2067,7 @@ export async function createLocalWorktree(
   validateWorkspaceLineageParentBeforeCreate(
     store,
     args.parentWorkspace,
-    worktreeWorkspaceKey(`${repo.id}::${worktreePath}`)
+    worktreeWorkspaceKey(getRepoWorktreeId(repo, worktreePath))
   )
 
   if (remoteTrackingRefresh) {
@@ -2223,7 +2235,7 @@ export async function createLocalWorktree(
     throw new Error('Worktree created but not found in listing')
   }
 
-  const worktreeId = `${repo.id}::${created.path}`
+  const worktreeId = getRepoWorktreeId(repo, created.path)
   const now = Date.now()
   // Why: PR/MR-created worktrees can start from a head ref/SHA while Source
   // Control must compare against the review target branch.
@@ -2287,7 +2299,11 @@ export async function createLocalWorktree(
   }
   const { worktree } = timing.timeSync('persist_metadata', () => {
     const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
-    return { worktree: mergeWorktree(repo.id, created, meta) }
+    return {
+      worktree: mergeWorktree(repo.id, created, meta, undefined, {
+        hostId: getRepoExecutionHostId(repo)
+      })
+    }
   })
   const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
   // Why: creation already paid for `git worktree list`; seed the exact roots

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -4,8 +4,17 @@ import { lstat, mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
 import type { CreateWorktreeResult } from '../../shared/types'
+import { makeRepoWorktreeKey } from '../../shared/worktree-id'
 
 const ORIGINAL_PLATFORM = process.platform
+
+function localWorktreeKey(path: string, repoId = 'repo-1'): string {
+  return makeRepoWorktreeKey({ id: repoId, connectionId: null, executionHostId: null }, path)
+}
+
+function sshWorktreeKey(path: string, repoId = 'repo-ssh', connectionId = 'conn-1'): string {
+  return makeRepoWorktreeKey({ id: repoId, connectionId, executionHostId: null }, path)
+}
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', {
@@ -249,6 +258,7 @@ describe('registerWorktreeHandlers', () => {
     getWorktreeMeta: vi.fn(),
     getAllWorktreeMeta: vi.fn(),
     setWorktreeMeta: vi.fn(),
+    migrateWorktreeIdentity: vi.fn(),
     getProjectHostSetups: vi.fn(),
     removeWorktreeMeta: vi.fn(),
     getAllWorktreeLineage: vi.fn(),
@@ -319,6 +329,7 @@ describe('registerWorktreeHandlers', () => {
       store.getWorktreeMeta,
       store.getAllWorktreeMeta,
       store.setWorktreeMeta,
+      store.migrateWorktreeIdentity,
       store.getProjectHostSetups,
       store.removeWorktreeMeta,
       store.getAllWorktreeLineage,
@@ -699,7 +710,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     const persistedMeta = store.setWorktreeMeta.mock.calls.find(
-      ([worktreeId]) => worktreeId === 'repo-1::/workspace/improve-dashboard'
+      ([worktreeId]) => worktreeId === localWorktreeKey('/workspace/improve-dashboard')
     )?.[1]
     expect(persistedMeta).toBeDefined()
     expect(persistedMeta).not.toHaveProperty('automationProvenance')
@@ -778,7 +789,7 @@ describe('registerWorktreeHandlers', () => {
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::../worktrees/feature',
+      localWorktreeKey('../worktrees/feature'),
       expect.objectContaining({
         orcaCreationWorkspaceLayout: { path: '../worktrees', nestWorkspaces: false }
       })
@@ -884,7 +895,9 @@ describe('registerWorktreeHandlers', () => {
     expect(addWorktreeMock).not.toHaveBeenCalled()
     expect(result.worktree).toEqual(
       expect.objectContaining({
-        id: expect.stringMatching(/^repo-folder::\/workspace\/folder::workspace:[0-9a-f-]{36}$/),
+        id: expect.stringMatching(
+          /^orca-worktree:\/\/v1\?hostId=local&repoId=repo-folder&path=%2Fworkspace%2Ffolder::workspace:[0-9a-f-]{36}$/
+        ),
         repoId: 'repo-folder',
         path: '/workspace/folder',
         displayName: 'folder-session',
@@ -934,7 +947,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(runtimeStub.createTerminal).toHaveBeenNthCalledWith(
       1,
-      'id:repo-1::/workspace/improve-dashboard',
+      `id:${localWorktreeKey('/workspace/improve-dashboard')}`,
       {
         command: 'claude --prefill test',
         env: { ORCA_AGENT_MODE: 'direct' },
@@ -950,7 +963,7 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(runtimeStub.createTerminal).toHaveBeenNthCalledWith(
       2,
-      'id:repo-1::/workspace/improve-dashboard',
+      `id:${localWorktreeKey('/workspace/improve-dashboard')}`,
       {
         title: 'Setup',
         command: 'bash /workspace/repo/.git/orca/setup-runner.sh',
@@ -1019,7 +1032,7 @@ describe('registerWorktreeHandlers', () => {
       { checkoutExistingBranch: true }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/fix-bug-0',
+      localWorktreeKey('/workspace/fix-bug-0'),
       expect.objectContaining({ preserveBranchOnDelete: true })
     )
     expect(result).toMatchObject({
@@ -1079,7 +1092,7 @@ describe('registerWorktreeHandlers', () => {
       { checkoutExistingBranch: true }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/my-folder',
+      localWorktreeKey('/workspace/my-folder'),
       expect.objectContaining({ preserveBranchOnDelete: true })
     )
     expect(result).toMatchObject({
@@ -1209,7 +1222,7 @@ describe('registerWorktreeHandlers', () => {
       { cwd: '/workspace/fix-title' }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/fix-title',
+      localWorktreeKey('/workspace/fix-title'),
       expect.objectContaining({
         baseRef: 'refs/remotes/origin/main',
         linkedPR: 42
@@ -1248,7 +1261,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/fix-title',
+      localWorktreeKey('/workspace/fix-title'),
       expect.objectContaining({
         baseRef: 'refs/remotes/origin/main',
         linkedGitLabMR: 7
@@ -1298,7 +1311,7 @@ describe('registerWorktreeHandlers', () => {
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/bitbucket-title',
+      localWorktreeKey('/workspace/bitbucket-title'),
       expect.objectContaining({ linkedBitbucketPR: 11 })
     )
     expect(getHostedReviewForBranchMock).toHaveBeenCalledWith(
@@ -1536,7 +1549,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         displayName: 'Fix: dashboards for PRs'
       })
@@ -1570,7 +1583,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         linkedIssue: 123,
         linkedPR: 456,
@@ -1607,7 +1620,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         createdWithAgent: 'codex'
       })
@@ -1663,7 +1676,7 @@ describe('registerWorktreeHandlers', () => {
       { cwd: '/workspace/improve-dashboard' }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         pushTarget: expect.objectContaining({
           remoteName: 'pr-prateek-orca',
@@ -1720,7 +1733,7 @@ describe('registerWorktreeHandlers', () => {
       expect.any(Object)
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         pushTarget: expect.objectContaining({
           remoteName: 'pr-contributor-orca',
@@ -2247,7 +2260,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-ssh::/remote/improve-dashboard',
+      sshWorktreeKey('/remote/improve-dashboard'),
       expect.objectContaining({
         linkedIssue: 123,
         linkedPR: 456,
@@ -2823,7 +2836,7 @@ describe('registerWorktreeHandlers', () => {
       '/remote/sparse-dashboard'
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-ssh::/remote/sparse-dashboard',
+      sshWorktreeKey('/remote/sparse-dashboard'),
       expect.objectContaining({
         sparseDirectories: ['apps/mobile', 'packages/shared'],
         baseRef: 'refs/remotes/origin/main',
@@ -3620,9 +3633,9 @@ describe('registerWorktreeHandlers', () => {
     resolveFetch()
     const result = (await createPromise) as CreateWorktreeResult
     expect(addWorktreeMock).toHaveBeenCalled()
-    expect(result.worktree.id).toBe('repo-1::/workspace/improve-dashboard')
+    expect(result.worktree.id).toBe(localWorktreeKey('/workspace/improve-dashboard'))
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({ baseRef: 'refs/remotes/origin/main' })
     )
   })
@@ -3684,7 +3697,7 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(result).toEqual(
       expect.objectContaining({
-        worktree: expect.objectContaining({ id: 'repo-1::/workspace/improve-dashboard' })
+        worktree: expect.objectContaining({ id: localWorktreeKey('/workspace/improve-dashboard') })
       })
     )
   })
@@ -3739,7 +3752,7 @@ describe('registerWorktreeHandlers', () => {
       }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({ baseRef: 'refs/remotes/origin/main' })
     )
     expect(result.localBaseRefUpdateSuggestion).toEqual({
@@ -3797,7 +3810,7 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('lists a synthetic worktree for folder-mode repos', async () => {
-    const rootWorktreeId = 'repo-1::/workspace/folder'
+    const rootWorktreeId = localWorktreeKey('/workspace/folder')
     const priorWorktreeIds = ['repo-1::/workspace/old-folder']
     const rootMeta = makeWorktreeMeta({
       instanceId: 'folder-instance',
@@ -3892,7 +3905,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(listed).toEqual([
       expect.objectContaining({
-        id: 'repo-ssh::/remote/feature-wt',
+        id: sshWorktreeKey('/remote/feature-wt'),
         repoId: 'repo-ssh',
         path: '/remote/feature-wt',
         head: '',
@@ -3922,8 +3935,7 @@ describe('registerWorktreeHandlers', () => {
         ]
       })
     ])
-    expect(store.getWorktreeMeta).not.toHaveBeenCalled()
-    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-ssh::/remote/feature-wt', {
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(sshWorktreeKey('/remote/feature-wt'), {
       projectId: 'repo:repo-ssh',
       hostId: 'ssh:conn-1',
       projectHostSetupId: 'repo-ssh'
@@ -3956,7 +3968,7 @@ describe('registerWorktreeHandlers', () => {
     expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo')
     expect(listed).toEqual([
       expect.objectContaining({
-        id: 'repo-ssh::/remote/feature-wt',
+        id: sshWorktreeKey('/remote/feature-wt'),
         displayName: 'Feature workspace',
         lastActivityAt: 42
       })
@@ -3996,7 +4008,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(listed).toEqual([
       expect.objectContaining({
-        id: 'repo-ssh::/remote/feature-wt',
+        id: sshWorktreeKey('/remote/feature-wt'),
         displayName: 'Good row'
       })
     ])
@@ -4088,11 +4100,11 @@ describe('registerWorktreeHandlers', () => {
     expect(listed).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: 'repo-ssh::/remote/feature-wt',
+          id: sshWorktreeKey('/remote/feature-wt'),
           displayName: 'Remote cached'
         }),
         expect.objectContaining({
-          id: 'repo-local::/workspace/local',
+          id: localWorktreeKey('/workspace/local', 'repo-local'),
           branch: 'refs/heads/main'
         })
       ])
@@ -4126,8 +4138,8 @@ describe('registerWorktreeHandlers', () => {
 
     expect(store.getAllWorktreeMeta).toHaveBeenCalledTimes(1)
     expect(listed).toEqual([
-      expect.objectContaining({ id: 'repo-ssh-a::/remote/a/one' }),
-      expect.objectContaining({ id: 'repo-ssh-b::/remote/b/two' })
+      expect.objectContaining({ id: sshWorktreeKey('/remote/a/one', 'repo-ssh-a', 'conn-1') }),
+      expect.objectContaining({ id: sshWorktreeKey('/remote/b/two', 'repo-ssh-b', 'conn-2') })
     ])
   })
 
@@ -4153,6 +4165,10 @@ describe('registerWorktreeHandlers', () => {
       lastActivityAt: 1_700_000_000_000
     }
     store.setWorktreeMeta.mockReturnValue(stampedMeta)
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/discovered-wt'
+    )
 
     const listed = (await handlers['worktrees:list'](null, { repoId: 'repo-1' })) as {
       id: string
@@ -4160,7 +4176,7 @@ describe('registerWorktreeHandlers', () => {
     }[]
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/discovered-wt',
+      expectedWorktreeId,
       expect.objectContaining({
         lastActivityAt: expect.any(Number),
         projectId: 'repo:repo-1',
@@ -4169,9 +4185,61 @@ describe('registerWorktreeHandlers', () => {
       })
     )
     expect(listed[0]).toMatchObject({
-      id: 'repo-1::/workspace/discovered-wt',
+      id: expectedWorktreeId,
       lastActivityAt: 1_700_000_000_000
     })
+  })
+
+  it('migrates matching legacy worktree metadata to the host-qualified key on discovery', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/legacy-wt',
+        head: 'abc123',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const legacyWorktreeId = 'repo-1::/workspace/legacy-wt'
+    const canonicalWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/legacy-wt'
+    )
+    const legacyMeta = makeWorktreeMeta({
+      instanceId: 'legacy-instance',
+      hostId: 'local',
+      lastActivityAt: 42
+    })
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) => {
+      if (worktreeId === legacyWorktreeId) {
+        return legacyMeta
+      }
+      return undefined
+    })
+    store.setWorktreeMeta.mockReturnValue({
+      ...legacyMeta,
+      projectId: 'repo:repo-1',
+      projectHostSetupId: 'repo-1'
+    })
+
+    const listed = (await handlers['worktrees:list'](null, { repoId: 'repo-1' })) as {
+      id: string
+      lastActivityAt: number
+    }[]
+
+    expect(store.migrateWorktreeIdentity).toHaveBeenCalledWith(
+      legacyWorktreeId,
+      canonicalWorktreeId
+    )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      canonicalWorktreeId,
+      expect.objectContaining({
+        projectId: 'repo:repo-1',
+        hostId: 'local',
+        projectHostSetupId: 'repo-1'
+      })
+    )
+    expect(listed[0]).toMatchObject({ id: canonicalWorktreeId, lastActivityAt: 42 })
   })
 
   it('backfills project-host ownership without re-stamping lastActivityAt for existing meta', async () => {
@@ -4214,8 +4282,12 @@ describe('registerWorktreeHandlers', () => {
       hostId?: string
       projectHostSetupId?: string
     }[]
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/existing-wt'
+    )
 
-    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-1::/workspace/existing-wt', {
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(expectedWorktreeId, {
       projectId: 'repo:repo-1',
       hostId: 'local',
       projectHostSetupId: 'repo-1'
@@ -4285,12 +4357,16 @@ describe('registerWorktreeHandlers', () => {
       hostId?: string
       projectHostSetupId?: string
     }[]
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/existing-wt'
+    )
 
-    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-1::/workspace/existing-wt', {
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(expectedWorktreeId, {
       projectId: 'github:stablyai/orca'
     })
     expect(listed[0]).toMatchObject({
-      id: 'repo-1::/workspace/existing-wt',
+      id: expectedWorktreeId,
       projectId: 'github:stablyai/orca',
       hostId: 'local',
       projectHostSetupId: 'repo-1',
@@ -4393,14 +4469,18 @@ describe('registerWorktreeHandlers', () => {
       projectHostSetupId?: string
       lastActivityAt: number
     }[]
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-ssh', connectionId: 'ssh-target-1', executionHostId: null },
+      '/remote/orca'
+    )
 
     expect(getSshGitProviderMock).toHaveBeenCalledWith('ssh-target-1')
-    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-ssh::/remote/orca', {
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(expectedWorktreeId, {
       projectId: 'github:stablyai/orca'
     })
     expect(listed).toEqual([
       expect.objectContaining({
-        id: 'repo-ssh::/remote/orca',
+        id: expectedWorktreeId,
         projectId: 'github:stablyai/orca',
         hostId: 'ssh:ssh-target-1',
         projectHostSetupId: 'repo-ssh',
@@ -4473,9 +4553,13 @@ describe('registerWorktreeHandlers', () => {
       id: string
       instanceId?: string
     }[]
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/existing-wt'
+    )
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/existing-wt',
+      expectedWorktreeId,
       expect.objectContaining({
         instanceId: expect.any(String),
         projectId: 'repo:repo-1',
@@ -4520,11 +4604,15 @@ describe('registerWorktreeHandlers', () => {
       projectHostSetupId: 'repo-1',
       lastActivityAt: 1_700_000_000_000
     })
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/folder'
+    )
 
     await handlers['worktrees:list'](null, { repoId: 'repo-1' })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/folder',
+      expectedWorktreeId,
       expect.objectContaining({
         lastActivityAt: expect.any(Number),
         projectId: 'repo:repo-1',
@@ -4549,6 +4637,10 @@ describe('registerWorktreeHandlers', () => {
     ])
     store.getWorktreeMeta.mockReturnValue(undefined)
     store.setWorktreeMeta.mockReturnValue({ lastActivityAt: 1_700_000_000_000 })
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/discovered-wt'
+    )
 
     const listed = (await handlers['worktrees:listAll'](null, undefined)) as {
       id: string
@@ -4556,11 +4648,11 @@ describe('registerWorktreeHandlers', () => {
     }[]
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/discovered-wt',
+      expectedWorktreeId,
       expect.objectContaining({ lastActivityAt: expect.any(Number) })
     )
     expect(listed[0]).toMatchObject({
-      id: 'repo-1::/workspace/discovered-wt',
+      id: expectedWorktreeId,
       lastActivityAt: 1_700_000_000_000
     })
   })
@@ -4901,7 +4993,7 @@ describe('registerWorktreeHandlers', () => {
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         sparseDirectories: ['packages/web', 'apps/api'],
         sparseBaseRef: 'origin/main',
@@ -4947,7 +5039,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         sparseDirectories: ['packages/web'],
         sparseBaseRef: 'origin/main',
@@ -4984,7 +5076,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         sparseDirectories: ['packages/web'],
         sparseBaseRef: 'origin/main',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -113,7 +113,13 @@ import {
 } from '../worktree-removal-safety'
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
-import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
+import {
+  FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
+  makeLegacyWorktreeId,
+  makeRepoWorktreeKey,
+  parseWorktreeKey
+} from '../../shared/worktree-id'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 import {
   getLocalProjectGitExecOptions,
@@ -173,6 +179,39 @@ function dedupeGitWorktreesByPath(gitWorktrees: GitWorktreeInfo[]): GitWorktreeI
     uniqueGitWorktrees.push(gitWorktree)
   }
   return uniqueGitWorktrees
+}
+
+function getRepoWorktreeId(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string
+): string {
+  return makeRepoWorktreeKey(repo, path)
+}
+
+function getRepoLegacyWorktreeId(repo: Pick<Repo, 'id'>, path: string): string {
+  return makeLegacyWorktreeId(repo.id, path)
+}
+
+function migrateLegacyWorktreeMetaIfSafe(store: Store, repo: Repo, path: string): void {
+  const canonicalId = getRepoWorktreeId(repo, path)
+  if (store.getWorktreeMeta(canonicalId)) {
+    return
+  }
+  const legacyId = getRepoLegacyWorktreeId(repo, path)
+  const legacyMeta = store.getWorktreeMeta(legacyId)
+  if (!legacyMeta) {
+    return
+  }
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (legacyMeta.hostId !== undefined && legacyMeta.hostId !== repoHostId) {
+    return
+  }
+  store.migrateWorktreeIdentity(legacyId, canonicalId)
+}
+
+function isCanonicalWorktreeIdForRepoHost(repo: Repo, worktreeId: string): boolean {
+  const parsed = parseWorktreeKey(worktreeId)
+  return parsed?.repoId === repo.id && parsed.hostId === getRepoExecutionHostId(repo)
 }
 
 function getProjectHostSetupMetaUpdates(
@@ -428,14 +467,17 @@ function pruneLineageForMissingRepoWorktrees(
   ) {
     return
   }
-  const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
+  const liveIds = new Set(gitWorktrees.map((worktree) => getRepoWorktreeId(repo, worktree.path)))
+  const legacyLiveIds = new Set(
+    gitWorktrees.map((worktree) => getRepoLegacyWorktreeId(repo, worktree.path))
+  )
   const repoPrefix = `${repo.id}::`
   for (const childWorkspaceKey of Object.keys(store.getAllWorkspaceLineage?.() ?? {})) {
     const childScope = parseWorkspaceKey(childWorkspaceKey)
     if (
       childScope?.type === 'worktree' &&
       childScope.worktreeId.startsWith(repoPrefix) &&
-      !liveIds.has(childScope.worktreeId)
+      !legacyLiveIds.has(childScope.worktreeId)
     ) {
       if (isWorkspaceKey(childWorkspaceKey)) {
         store.removeWorkspaceLineage?.(childWorkspaceKey)
@@ -443,7 +485,10 @@ function pruneLineageForMissingRepoWorktrees(
     }
   }
   for (const [childId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-    if (childId.startsWith(repoPrefix) && !liveIds.has(childId)) {
+    if (
+      (childId.startsWith(repoPrefix) && !legacyLiveIds.has(childId)) ||
+      (isCanonicalWorktreeIdForRepoHost(repo, childId) && !liveIds.has(childId))
+    ) {
       // Why: path-derived IDs can disappear and later be reused by a different
       // checkout. Once a successful scan proves the child is gone, drop its
       // lineage so a future same-path worktree cannot inherit it. Missing
@@ -452,7 +497,10 @@ function pruneLineageForMissingRepoWorktrees(
       store.removeWorktreeLineage(childId)
       store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
     }
-    if (lineage.parentWorktreeId.startsWith(repoPrefix) && !liveIds.has(lineage.parentWorktreeId)) {
+    if (
+      lineage.parentWorktreeId.startsWith(repoPrefix) &&
+      !legacyLiveIds.has(lineage.parentWorktreeId)
+    ) {
       const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
       if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
         // Why: keep the child lineage so the UI can show "Missing parent", but
@@ -517,13 +565,16 @@ function listDisconnectedSshWorktrees(
 ): ReturnType<typeof mergeWorktree>[] {
   const byWorktreeId = new Map<string, ReturnType<typeof mergeWorktree>>()
   for (const candidate of metaIndex.get(repo.id) ?? []) {
-    const ownershipUpdates = getProjectHostSetupMetaUpdates(store, repo, candidate.meta)
+    migrateLegacyWorktreeMetaIfSafe(store, repo, candidate.path)
+    const canonicalId = getRepoWorktreeId(repo, candidate.path)
+    const candidateMeta = store.getWorktreeMeta(canonicalId) ?? candidate.meta
+    const ownershipUpdates = getProjectHostSetupMetaUpdates(store, repo, candidateMeta)
     const meta =
       Object.keys(ownershipUpdates).length > 0
-        ? { ...candidate.meta, ...ownershipUpdates }
-        : candidate.meta
+        ? { ...candidateMeta, ...ownershipUpdates }
+        : candidateMeta
     if (Object.keys(ownershipUpdates).length > 0) {
-      store.setWorktreeMeta(candidate.id, ownershipUpdates)
+      store.setWorktreeMeta(canonicalId, ownershipUpdates)
     }
     const worktree = mergeWorktree(
       repo.id,
@@ -545,9 +596,12 @@ function buildDetectedGitWorktrees(
   const knownOrcaLayouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
   const isLegacyRepoForVisibility = isLegacyRepoForExternalWorktreeVisibility(repo)
   return dedupeGitWorktreesByPath(gitWorktrees).map((gitWorktree) => {
-    const worktreeId = `${repo.id}::${gitWorktree.path}`
+    migrateLegacyWorktreeMetaIfSafe(store, repo, gitWorktree.path)
+    const worktreeId = getRepoWorktreeId(repo, gitWorktree.path)
     let meta = store.getWorktreeMeta(worktreeId)
-    const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+    const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+      hostId: getRepoExecutionHostId(repo)
+    })
     const detected = toDetectedWorktree({
       repo,
       worktree,
@@ -563,7 +617,9 @@ function buildDetectedGitWorktrees(
     meta = resolveWorktreeMetaWithDiscoveryBackfill(store, repo, worktreeId)
     return toDetectedWorktree({
       repo,
-      worktree: mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
+      worktree: mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+        hostId: getRepoExecutionHostId(repo)
+      }),
       meta,
       settings,
       knownOrcaLayouts,
@@ -577,21 +633,32 @@ function stampAndMergeVisibleDetectedWorktree(
   repo: Repo,
   detected: DetectedWorktree
 ) {
+  migrateLegacyWorktreeMetaIfSafe(store, repo, detected.path)
   const meta = resolveWorktreeMetaWithDiscoveryBackfill(store, repo, detected.id)
-  return mergeWorktree(repo.id, detected, meta, repo.displayName)
+  return mergeWorktree(repo.id, detected, meta, repo.displayName, {
+    hostId: getRepoExecutionHostId(repo)
+  })
 }
 
 function getFolderWorkspaceRootId(repo: Repo): string {
-  return `${repo.id}::${repo.path}`
+  return getRepoWorktreeId(repo, repo.path)
 }
 
 function getFolderWorkspaceInstanceId(repo: Repo, instanceId: string): string {
   return `${getFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
 }
 
+function getLegacyFolderWorkspaceRootId(repo: Repo): string {
+  return getRepoLegacyWorktreeId(repo, repo.path)
+}
+
 function getFolderWorkspaceInstanceIdentity(repo: Repo, worktreeId: string): string {
   const prefix = `${getFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
-  return worktreeId.startsWith(prefix) ? worktreeId.slice(prefix.length) : randomUUID()
+  const legacyPrefix = `${getLegacyFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
+  if (worktreeId.startsWith(prefix)) {
+    return worktreeId.slice(prefix.length)
+  }
+  return worktreeId.startsWith(legacyPrefix) ? worktreeId.slice(legacyPrefix.length) : randomUUID()
 }
 
 function isFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
@@ -600,6 +667,44 @@ function isFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
     worktreeId === rootId ||
     worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
   )
+}
+
+function isLegacyFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
+  const rootId = getLegacyFolderWorkspaceRootId(repo)
+  return (
+    worktreeId === rootId ||
+    worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
+  )
+}
+
+function isFolderWorkspaceRootIdForRepo(repo: Repo, worktreeId: string): boolean {
+  return (
+    worktreeId === getFolderWorkspaceRootId(repo) ||
+    worktreeId === getLegacyFolderWorkspaceRootId(repo)
+  )
+}
+
+function getCanonicalFolderWorkspaceId(repo: Repo, worktreeId: string): string {
+  if (!isLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
+    return worktreeId
+  }
+  const instanceId = getFolderWorkspaceInstanceIdentity(repo, worktreeId)
+  return worktreeId === getLegacyFolderWorkspaceRootId(repo)
+    ? getFolderWorkspaceRootId(repo)
+    : getFolderWorkspaceInstanceId(repo, instanceId)
+}
+
+function migrateLegacyFolderWorkspaceMetaIfSafe(store: Store, repo: Repo): void {
+  for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
+    if (!isLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
+      continue
+    }
+    const repoHostId = getRepoExecutionHostId(repo)
+    if (meta.hostId !== undefined && meta.hostId !== repoHostId) {
+      continue
+    }
+    store.migrateWorktreeIdentity(worktreeId, getCanonicalFolderWorkspaceId(repo, worktreeId))
+  }
 }
 
 function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta): Worktree {
@@ -648,6 +753,7 @@ function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta
 }
 
 function listFolderWorkspaces(store: Store, repo: Repo): Worktree[] {
+  migrateLegacyFolderWorkspaceMetaIfSafe(store, repo)
   const rootId = getFolderWorkspaceRootId(repo)
   const allMeta = store.getAllWorktreeMeta()
   const ids = Object.keys(allMeta).filter((worktreeId) =>
@@ -1216,7 +1322,7 @@ export function registerWorktreeHandlers(
           throw new Error(`Repo not found: ${repoId}`)
         }
         if (isFolderRepo(repo)) {
-          if (args.worktreeId === getFolderWorkspaceRootId(repo)) {
+          if (isFolderWorkspaceRootIdForRepo(repo, args.worktreeId)) {
             throw new Error(
               'Cannot delete the project root workspace. Remove the folder project instead.'
             )

--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -12,6 +12,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../shared/types'
+import { makeRepoWorktreeKey } from '../../shared/worktree-id'
 import type { SessionInfo } from '../daemon/types'
 import type { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
 import type { Store } from '../persistence'
@@ -220,7 +221,16 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     const entry = listRegisteredPtys().find((p) => p.ptyId === ptyId)
     expect(entry).toBeDefined()
     expect(entry!.pid).toBe(4242)
-    expect(entry!.worktreeId).toBe('repo-a::/local/Triton')
+    expect(entry!.worktreeId).toBe(
+      makeRepoWorktreeKey(
+        {
+          id: 'repo-a',
+          connectionId: null,
+          executionHostId: null
+        },
+        '/local/Triton'
+      )
+    )
   })
 
   it('hydrates large daemon session lists', async () => {

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -24,6 +24,7 @@ import type { SessionInfo } from '../daemon/types'
 import { listRegisteredPtys, registerPty } from './pty-registry'
 import { listRepoWorktrees } from '../repo-worktrees'
 import { parsePtySessionId } from '../../shared/pty-session-id-format'
+import { getRepoWorktreeIdAliases, makeRepoWorktreeKey } from '../../shared/worktree-id'
 import type { Store } from '../persistence'
 
 // Why: `attachMainWindowServices` runs on every macOS dock re-activation
@@ -69,11 +70,10 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
     // renderer-side union still covers that case.
     hasHydrated = true
 
-    // Why: build a worktree-id → connectionId map so we can SSH-gate each
-    // session before registering. Live git enumeration matches the path
-    // shape used by `mintPtySessionId` (`${repoId}::${path}`).
+    // Why: build a worktree-id → canonical worktree-id map so old daemon
+    // sessions (`repoId::path`) hydrate into the new host-qualified bucket.
     const repos = store.getRepos()
-    const repoConnectionIdByWorktreeId = new Map<string, string | null>()
+    const canonicalWorktreeIdByAlias = new Map<string, string>()
 
     for (const repo of repos) {
       const connectionId = repo.connectionId ?? null
@@ -84,8 +84,10 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
       }
       const worktrees = await listRepoWorktrees(repo)
       for (const wt of worktrees) {
-        const worktreeId = `${repo.id}::${wt.path}`
-        repoConnectionIdByWorktreeId.set(worktreeId, connectionId)
+        const canonicalWorktreeId = makeRepoWorktreeKey(repo, wt.path)
+        for (const alias of getRepoWorktreeIdAliases(repo, wt.path)) {
+          canonicalWorktreeIdByAlias.set(alias, canonicalWorktreeId)
+        }
       }
     }
 
@@ -114,15 +116,13 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
       // `src/main/ipc/pty.ts`. If the repo isn't in the store, skip the
       // session: we can't prove it's local, and the renderer-side union
       // still surfaces the session at the cost of a missing pid sample.
-      if (!repoConnectionIdByWorktreeId.has(worktreeId)) {
-        continue
-      }
-      if (repoConnectionIdByWorktreeId.get(worktreeId)) {
+      const canonicalWorktreeId = canonicalWorktreeIdByAlias.get(worktreeId)
+      if (!canonicalWorktreeId) {
         continue
       }
       registerPty({
         ptyId: info.sessionId,
-        worktreeId,
+        worktreeId: canonicalWorktreeId,
         sessionId: info.sessionId,
         paneKey: null,
         pid:

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2896,6 +2896,51 @@ describe('Store', () => {
     })
   })
 
+  it('updates same-id project host setup metadata on the requested host', async () => {
+    const independentProject = makeProject({
+      id: 'cloud-project',
+      displayName: 'Cloud Project'
+    })
+    const localSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'local',
+      displayName: 'Local'
+    })
+    const runtimeSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'runtime:gpu-vm',
+      displayName: 'GPU VM'
+    })
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      projects: [independentProject],
+      projectHostSetups: [localSetup, runtimeSetup]
+    })
+    const store = await createStore()
+
+    const result = store.updateProjectHostSetup({
+      setupId: 'shared-setup',
+      hostId: 'runtime:gpu-vm',
+      updates: { displayName: 'GPU VM renamed' }
+    })
+
+    expect(result?.setup).toMatchObject({
+      id: 'shared-setup',
+      hostId: 'runtime:gpu-vm',
+      displayName: 'GPU VM renamed'
+    })
+    expect(store.getProjectHostSetups()).toEqual([
+      expect.objectContaining({ id: 'shared-setup', hostId: 'local', displayName: 'Local' }),
+      expect.objectContaining({
+        id: 'shared-setup',
+        hostId: 'runtime:gpu-vm',
+        displayName: 'GPU VM renamed'
+      })
+    ])
+  })
+
   it('creates independent project host setup records for provisioning flows', async () => {
     const store = await createStore()
     store.addRepo({
@@ -3027,6 +3072,40 @@ describe('Store', () => {
     expect(result).toEqual({ project: independentProject, setup: independentSetup })
     expect(store.getProjects()).toEqual([independentProject])
     expect(store.getProjectHostSetups()).toEqual([])
+  })
+
+  it('deletes only the same-id project host setup on the requested host', async () => {
+    const independentProject = makeProject({
+      id: 'cloud-project',
+      displayName: 'Cloud Project'
+    })
+    const localSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'local',
+      displayName: 'Local'
+    })
+    const runtimeSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'runtime:gpu-vm',
+      displayName: 'GPU VM'
+    })
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      projects: [independentProject],
+      projectHostSetups: [localSetup, runtimeSetup]
+    })
+    const store = await createStore()
+
+    const result = store.deleteProjectHostSetup({
+      setupId: 'shared-setup',
+      hostId: 'runtime:gpu-vm'
+    })
+
+    expect(result).toEqual({ project: independentProject, setup: runtimeSetup })
+    expect(store.getProjects()).toEqual([independentProject])
+    expect(store.getProjectHostSetups()).toEqual([localSetup])
   })
 
   it('deletes repo-backed project host setups by removing the compatibility repo', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3298,7 +3298,7 @@ export class Store {
   }
 
   updateProjectHostSetup(args: ProjectHostSetupUpdateArgs): ProjectHostSetupUpdateResult | null {
-    const setup = this.state.projectHostSetups.find((entry) => entry.id === args.setupId)
+    const setup = this.findProjectHostSetup(args)
     if (!setup) {
       return null
     }
@@ -3323,7 +3323,7 @@ export class Store {
   }
 
   deleteProjectHostSetup(args: ProjectHostSetupDeleteArgs): ProjectHostSetupDeleteResult | null {
-    const setup = this.state.projectHostSetups.find((entry) => entry.id === args.setupId)
+    const setup = this.findProjectHostSetup(args)
     if (!setup) {
       return null
     }
@@ -3338,9 +3338,7 @@ export class Store {
       this.removeProject(repo.id)
       return { project, setup, repo: this.hydrateRepo(repo) }
     }
-    this.state.projectHostSetups = this.state.projectHostSetups.filter(
-      (entry) => entry.id !== setup.id
-    )
+    this.state.projectHostSetups = this.state.projectHostSetups.filter((entry) => entry !== setup)
     this.scheduleSave()
     return { project, setup }
   }
@@ -3818,9 +3816,27 @@ export class Store {
       return null
     }
     return {
-      setup: this.state.projectHostSetups.find((entry) => entry.id === setup.id) ?? setup,
+      setup:
+        this.state.projectHostSetups.find(
+          (entry) => entry.id === setup.id && entry.hostId === setup.hostId
+        ) ?? setup,
       repo: updatedRepo
     }
+  }
+
+  private findProjectHostSetup(
+    args: Pick<ProjectHostSetupUpdateArgs, 'setupId' | 'hostId'>
+  ): ProjectHostSetup | undefined {
+    if (args.hostId === undefined) {
+      return this.state.projectHostSetups.find((entry) => entry.id === args.setupId)
+    }
+    const hostId = normalizeExecutionHostId(args.hostId)
+    if (!hostId) {
+      throw new Error(`Invalid host ID: ${args.hostId}`)
+    }
+    return this.state.projectHostSetups.find(
+      (entry) => entry.id === args.setupId && entry.hostId === hostId
+    )
   }
 
   private updateIndependentProjectHostSetup(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -61,7 +61,7 @@ import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/s
 import { DEFAULT_REPO_BADGE_COLOR, getDefaultWorkspaceSession } from '../../shared/constants'
 import { advertisedUrlWatcher } from '../ports/advertised-url-watcher'
 import { makePaneKey } from '../../shared/stable-pane-id'
-import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
+import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR, makeWorktreeKey } from '../../shared/worktree-id'
 import { RpcDispatcher } from './rpc/dispatcher'
 import type { RpcRequest } from './rpc/core'
 import { TERMINAL_METHODS } from './rpc/methods/terminal'
@@ -709,6 +709,11 @@ const TEST_REPO_ID = 'repo-1'
 const TEST_REPO_PATH = '/tmp/repo'
 const TEST_WORKTREE_PATH = '/tmp/worktree-a'
 const TEST_WORKTREE_ID = `${TEST_REPO_ID}::${TEST_WORKTREE_PATH}`
+const TEST_CANONICAL_WORKTREE_ID = makeWorktreeKey({
+  hostId: 'local',
+  repoId: TEST_REPO_ID,
+  path: TEST_WORKTREE_PATH
+})
 const TEST_FOLDER_PROJECT_GROUP_ID = 'folder-project-group-1'
 const TEST_FOLDER_WORKSPACE_ID = 'folder-workspace-1'
 const TEST_FOLDER_WORKSPACE_KEY = `folder:${TEST_FOLDER_WORKSPACE_ID}`
@@ -1415,7 +1420,7 @@ describe('OrcaRuntimeService', () => {
 
     expect(terminals.terminals).toHaveLength(1)
     expect(terminals.terminals[0]).toMatchObject({
-      worktreeId: TEST_WORKTREE_ID,
+      worktreeId: TEST_CANONICAL_WORKTREE_ID,
       worktreePath: TEST_WORKTREE_PATH
     })
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
@@ -1446,8 +1451,8 @@ describe('OrcaRuntimeService', () => {
 
     expect(listWorktrees).not.toHaveBeenCalled()
     expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([
-      TEST_WORKTREE_ID,
-      TEST_WORKTREE_ID
+      TEST_CANONICAL_WORKTREE_ID,
+      TEST_CANONICAL_WORKTREE_ID
     ])
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
     expect(internals.ptysById.has(ptyId)).toBe(true)
@@ -1483,7 +1488,9 @@ describe('OrcaRuntimeService', () => {
     const terminals = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
 
     expect(listWorktrees).not.toHaveBeenCalled()
-    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([TEST_WORKTREE_ID])
+    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([
+      TEST_CANONICAL_WORKTREE_ID
+    ])
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
     expect(internals.ptysById.has('cwd-only-pty')).toBe(true)
     expect(internals.ptysById.has('nested-controller-pty')).toBe(false)
@@ -1520,7 +1527,9 @@ describe('OrcaRuntimeService', () => {
     const terminals = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
 
     expect(listWorktrees).not.toHaveBeenCalled()
-    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([TEST_WORKTREE_ID])
+    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([
+      TEST_CANONICAL_WORKTREE_ID
+    ])
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
     expect(internals.ptysById.has('cwd-only-pty')).toBe(true)
     expect(internals.ptysById.has('nested-controller-pty')).toBe(false)
@@ -1558,7 +1567,9 @@ describe('OrcaRuntimeService', () => {
     const terminals = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
 
     expect(listWorktrees).not.toHaveBeenCalled()
-    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([TEST_WORKTREE_ID])
+    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([
+      TEST_CANONICAL_WORKTREE_ID
+    ])
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
     expect(internals.ptysById.has('target-cwd-pty')).toBe(true)
     expect(internals.ptysById.has('sibling-cwd-pty')).toBe(false)
@@ -1780,6 +1791,16 @@ describe('OrcaRuntimeService', () => {
     }
     const mainId = `${remoteRepo.id}::/home/user/repo`
     const childId = `${remoteRepo.id}::/home/user/repo-child`
+    const canonicalMainId = makeWorktreeKey({
+      hostId: 'ssh:ssh-missing',
+      repoId: remoteRepo.id,
+      path: '/home/user/repo'
+    })
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'ssh:ssh-missing',
+      repoId: remoteRepo.id,
+      path: '/home/user/repo-child'
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [mainId]: makeWorktreeMeta({ displayName: 'Remote main' }),
       [childId]: makeWorktreeMeta({ displayName: 'Remote child', linkedPR: 42 })
@@ -1806,14 +1827,14 @@ describe('OrcaRuntimeService', () => {
       truncated: false,
       worktrees: [
         {
-          id: mainId,
+          id: canonicalMainId,
           path: '/home/user/repo',
           branch: '',
           isMainWorktree: true,
           displayName: 'Remote main'
         },
         {
-          id: childId,
+          id: canonicalChildId,
           path: '/home/user/repo-child',
           branch: '',
           isMainWorktree: false,
@@ -1856,7 +1877,7 @@ describe('OrcaRuntimeService', () => {
 
     staleScan.resolve(MOCK_GIT_WORKTREES)
 
-    await expect(staleLookup).resolves.toMatchObject({ id: TEST_WORKTREE_ID })
+    await expect(staleLookup).resolves.toMatchObject({ id: TEST_CANONICAL_WORKTREE_ID })
     await expect(freshLookup).resolves.toMatchObject({
       id: result.worktree.id,
       path: createdWorktree.path
@@ -2767,8 +2788,13 @@ describe('OrcaRuntimeService', () => {
       '/remote/mobile-feature',
       { base: 'origin/main' }
     )
+    const canonicalCreatedId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: TEST_REPO_ID,
+      path: created.path
+    })
     expect(result.worktree).toMatchObject({
-      id: `${TEST_REPO_ID}::${created.path}`,
+      id: canonicalCreatedId,
       path: created.path,
       linkedGitLabIssue: 321,
       linkedGitLabMR: 654
@@ -2807,7 +2833,16 @@ describe('OrcaRuntimeService', () => {
       isMainWorktree: false
     }
     const parentId = `${TEST_REPO_ID}::${parent.path}`
-    const childId = `${TEST_REPO_ID}::${created.path}`
+    const canonicalParentId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: TEST_REPO_ID,
+      path: parent.path
+    })
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: TEST_REPO_ID,
+      path: created.path
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' })
     }
@@ -2859,19 +2894,22 @@ describe('OrcaRuntimeService', () => {
       })
 
       expect(result.worktree).toMatchObject({
-        id: childId,
-        parentWorktreeId: parentId,
+        id: canonicalChildId,
+        parentWorktreeId: canonicalParentId,
         lineage: expect.objectContaining({
-          worktreeId: childId,
-          parentWorktreeId: parentId,
-          worktreeInstanceId: metaById[childId].instanceId,
+          worktreeId: canonicalChildId,
+          parentWorktreeId: canonicalParentId,
+          worktreeInstanceId: metaById[canonicalChildId].instanceId,
           parentWorktreeInstanceId: 'parent-instance',
           origin: 'cli'
         })
       })
       expect(result.lineage).toBe(result.worktree.lineage)
       expect(result.warnings).toEqual([])
-      expect(remoteStore.setWorktreeLineage).toHaveBeenCalledWith(childId, expect.any(Object))
+      expect(remoteStore.setWorktreeLineage).toHaveBeenCalledWith(
+        canonicalChildId,
+        expect.any(Object)
+      )
       expect(addWorktree).not.toHaveBeenCalled()
       expect(listWorktrees).not.toHaveBeenCalled()
     } finally {
@@ -3468,7 +3506,13 @@ describe('OrcaRuntimeService', () => {
     expect(gitProvider.removeWorktree).toHaveBeenCalledWith('/remote/feature', true)
     expect(removeWorktree).not.toHaveBeenCalled()
     expect(listWorktrees).not.toHaveBeenCalled()
-    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(`${TEST_REPO_ID}::/remote/feature`)
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(
+      makeWorktreeKey({
+        hostId: 'ssh:ssh-1',
+        repoId: TEST_REPO_ID,
+        path: '/remote/feature'
+      })
+    )
   })
 
   it('rejects SSH-backed runtime removal of the main worktree before provider deletion', async () => {
@@ -14392,7 +14436,7 @@ describe('OrcaRuntimeService', () => {
       worktrees: [
         {
           workspaceKind: 'git',
-          worktreeId: 'repo-1::/tmp/worktree-a',
+          worktreeId: TEST_CANONICAL_WORKTREE_ID,
           repoId: 'repo-1',
           repo: 'repo',
           path: '/tmp/worktree-a',
@@ -14443,7 +14487,7 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(runtimeStore as never)
 
     const { worktrees } = await runtime.getWorktreePs()
-    const summary = worktrees.find((w) => w.worktreeId === TEST_WORKTREE_ID)
+    const summary = worktrees.find((w) => w.worktreeId === TEST_CANONICAL_WORKTREE_ID)
     expect(summary?.linkedPR).toEqual({ number: 42, state: 'merged' })
   })
 
@@ -14678,7 +14722,7 @@ describe('OrcaRuntimeService', () => {
     const { worktrees } = await runtime.getWorktreePs()
     const active = worktrees.filter((w) => w.isActive)
     expect(active).toHaveLength(1)
-    expect(active[0]?.worktreeId).toBe(TEST_WORKTREE_ID)
+    expect(active[0]?.worktreeId).toBe(TEST_CANONICAL_WORKTREE_ID)
   })
 
   it('includes SSH-backed worktrees in the mobile worktree summary', async () => {
@@ -14697,6 +14741,11 @@ describe('OrcaRuntimeService', () => {
       isBare: false,
       isMainWorktree: false
     }
+    const canonicalRemoteWorktreeId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: remoteRepo.id,
+      path: remoteWorktree.path
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [`${remoteRepo.id}::${remoteWorktree.path}`]: makeWorktreeMeta({
         displayName: 'Remote mobile'
@@ -14722,7 +14771,7 @@ describe('OrcaRuntimeService', () => {
 
     expect(summaries.worktrees).toEqual([
       expect.objectContaining({
-        worktreeId: `${remoteRepo.id}::${remoteWorktree.path}`,
+        worktreeId: canonicalRemoteWorktreeId,
         repoId: remoteRepo.id,
         repo: 'remote-vm',
         path: remoteWorktree.path,
@@ -15509,6 +15558,16 @@ describe('OrcaRuntimeService', () => {
     }
     const childId = `${remoteRepo.id}::/home/user/repo-child`
     const parentId = `${remoteRepo.id}::/home/user/repo-parent`
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: remoteRepo.id,
+      path: '/home/user/repo-child'
+    })
+    const canonicalParentId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: remoteRepo.id,
+      path: '/home/user/repo-parent'
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' }),
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' })
@@ -15552,11 +15611,11 @@ describe('OrcaRuntimeService', () => {
 
     expect(listSshWorktrees).toHaveBeenCalledWith(remoteRepo.path)
     expect(setWorktreeLineage).toHaveBeenCalledWith(
-      childId,
+      canonicalChildId,
       expect.objectContaining({
-        worktreeId: childId,
+        worktreeId: canonicalChildId,
         worktreeInstanceId: 'child-instance',
-        parentWorktreeId: parentId,
+        parentWorktreeId: canonicalParentId,
         parentWorktreeInstanceId: 'parent-instance',
         origin: 'manual'
       })
@@ -15813,6 +15872,16 @@ describe('OrcaRuntimeService', () => {
     const childPath = '/tmp/worktree-child'
     const parentId = `${TEST_REPO_ID}::${parentPath}`
     const childId = `${TEST_REPO_ID}::${childPath}`
+    const canonicalParentId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: TEST_REPO_ID,
+      path: parentPath
+    })
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: TEST_REPO_ID,
+      path: childPath
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' }),
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' })
@@ -15854,18 +15923,18 @@ describe('OrcaRuntimeService', () => {
     })
 
     expect(setWorktreeLineage).toHaveBeenCalledWith(
-      childId,
+      canonicalChildId,
       expect.objectContaining({
-        parentWorktreeId: parentId,
+        parentWorktreeId: canonicalParentId,
         parentWorktreeInstanceId: 'parent-instance',
         capture: { source: 'manual-action', confidence: 'explicit' }
       })
     )
     expect(setWorkspaceLineage).toHaveBeenCalledWith(
       expect.objectContaining({
-        childWorkspaceKey: `worktree:${childId}`,
+        childWorkspaceKey: `worktree:${canonicalChildId}`,
         childInstanceId: 'child-instance',
-        parentWorkspaceKey: `worktree:${parentId}`,
+        parentWorkspaceKey: `worktree:${canonicalParentId}`,
         parentInstanceId: 'parent-instance',
         capture: { source: 'manual-action', confidence: 'explicit' }
       })
@@ -16259,6 +16328,16 @@ describe('OrcaRuntimeService', () => {
     const childPath = '/tmp/worktree-child'
     const parentId = `${TEST_REPO_ID}::${parentPath}`
     const childId = `${TEST_REPO_ID}::${childPath}`
+    const canonicalParentId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: TEST_REPO_ID,
+      path: parentPath
+    })
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: TEST_REPO_ID,
+      path: childPath
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({
         instanceId: 'parent-instance',
@@ -16309,24 +16388,32 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(runtimeStore as never)
 
     const listed = await runtime.listManagedWorktrees('id:repo-1')
-    const parent = listed.worktrees.find((worktree) => worktree.id === parentId)
-    const child = listed.worktrees.find((worktree) => worktree.id === childId)
+    const parent = listed.worktrees.find((worktree) => worktree.id === canonicalParentId)
+    const child = listed.worktrees.find((worktree) => worktree.id === canonicalChildId)
 
     expect(parent).toMatchObject({
       parentWorktreeId: null,
-      childWorktreeIds: [childId],
+      childWorktreeIds: [canonicalChildId],
       lineage: null
     })
     expect(child).toMatchObject({
-      parentWorktreeId: parentId,
+      parentWorktreeId: canonicalParentId,
       childWorktreeIds: [],
-      lineage: lineageById[childId]
+      lineage: {
+        ...lineageById[childId],
+        worktreeId: canonicalChildId,
+        parentWorktreeId: canonicalParentId
+      }
     })
     await expect(runtime.showManagedWorktree(`id:${childId}`)).resolves.toMatchObject({
-      id: childId,
-      parentWorktreeId: parentId,
+      id: canonicalChildId,
+      parentWorktreeId: canonicalParentId,
       childWorktreeIds: [],
-      lineage: lineageById[childId]
+      lineage: {
+        ...lineageById[childId],
+        worktreeId: canonicalChildId,
+        parentWorktreeId: canonicalParentId
+      }
     })
   })
 
@@ -20927,7 +21014,7 @@ describe('OrcaRuntimeService', () => {
         page: 'page-1'
       })
 
-      expect(snapshotMock).toHaveBeenCalledWith(TEST_WORKTREE_ID, 'page-1')
+      expect(snapshotMock).toHaveBeenCalledWith(TEST_CANONICAL_WORKTREE_ID, 'page-1')
     })
 
     it('routes tab switch and capture start by explicit page id', async () => {
@@ -21046,8 +21133,13 @@ describe('OrcaRuntimeService', () => {
         }
       ])
       const runtime = createRuntime()
+      const worktreeBId = makeWorktreeKey({
+        hostId: 'local',
+        repoId: TEST_REPO_ID,
+        path: '/tmp/worktree-b'
+      })
       const getRegisteredTabsMock = vi.fn((worktreeId?: string) =>
-        worktreeId === `${TEST_REPO_ID}::/tmp/worktree-b` ? new Map() : new Map([['page-1', 1]])
+        worktreeId === worktreeBId ? new Map() : new Map([['page-1', 1]])
       )
 
       runtime.setAgentBrowserBridge({
@@ -21060,7 +21152,7 @@ describe('OrcaRuntimeService', () => {
           worktree: 'path:/tmp/worktree-b'
         })
       ).rejects.toThrow('Browser page page-1 was not found in this worktree')
-      expect(getRegisteredTabsMock).toHaveBeenCalledWith(`${TEST_REPO_ID}::/tmp/worktree-b`)
+      expect(getRegisteredTabsMock).toHaveBeenCalledWith(worktreeBId)
     })
   })
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -143,9 +143,13 @@ import type { FeatureInteractionId } from '../../shared/feature-interactions'
 import type { TerminalPaneSplitSource } from '../../shared/feature-education-telemetry'
 import {
   FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
+  makeLegacyWorktreeId,
+  makeRepoWorktreeKey,
+  parseWorktreeKey,
   splitWorktreeId,
   splitWorktreeIdForFilesystem
 } from '../../shared/worktree-id'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import {
   getProjectHostSetupForRepo,
   getProjectHostSetupWorktreeMeta
@@ -711,6 +715,7 @@ type RuntimeStore = {
   getWorktreeMeta: Store['getWorktreeMeta']
   setWorktreeMeta: Store['setWorktreeMeta']
   removeWorktreeMeta: Store['removeWorktreeMeta']
+  migrateWorktreeIdentity?: Store['migrateWorktreeIdentity']
   getWorktreeLineage?: Store['getWorktreeLineage']
   getAllWorktreeLineage?: Store['getAllWorktreeLineage']
   setWorktreeLineage?: Store['setWorktreeLineage']
@@ -1213,16 +1218,24 @@ function getRuntimeWorktreeRemovalOptionsKey(force: boolean, runHooks: boolean):
 }
 
 function getRuntimeFolderWorkspaceRootId(repo: Repo): string {
-  return `${repo.id}::${repo.path}`
+  return makeRepoWorktreeKey(repo, repo.path)
 }
 
 function getRuntimeFolderWorkspaceInstanceId(repo: Repo, instanceId: string): string {
   return `${getRuntimeFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
 }
 
+function getRuntimeLegacyFolderWorkspaceRootId(repo: Repo): string {
+  return makeLegacyWorktreeId(repo.id, repo.path)
+}
+
 function getRuntimeFolderWorkspaceInstanceIdentity(repo: Repo, worktreeId: string): string {
   const prefix = `${getRuntimeFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
-  return worktreeId.startsWith(prefix) ? worktreeId.slice(prefix.length) : randomUUID()
+  const legacyPrefix = `${getRuntimeLegacyFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
+  if (worktreeId.startsWith(prefix)) {
+    return worktreeId.slice(prefix.length)
+  }
+  return worktreeId.startsWith(legacyPrefix) ? worktreeId.slice(legacyPrefix.length) : randomUUID()
 }
 
 function isRuntimeFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
@@ -1231,6 +1244,100 @@ function isRuntimeFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): bool
     worktreeId === rootId ||
     worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
   )
+}
+
+function isRuntimeLegacyFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
+  const rootId = getRuntimeLegacyFolderWorkspaceRootId(repo)
+  return (
+    worktreeId === rootId ||
+    worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
+  )
+}
+
+function getRuntimeCanonicalFolderWorkspaceId(repo: Repo, worktreeId: string): string {
+  if (!isRuntimeLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
+    return worktreeId
+  }
+  const instanceId = getRuntimeFolderWorkspaceInstanceIdentity(repo, worktreeId)
+  return worktreeId === getRuntimeLegacyFolderWorkspaceRootId(repo)
+    ? getRuntimeFolderWorkspaceRootId(repo)
+    : getRuntimeFolderWorkspaceInstanceId(repo, instanceId)
+}
+
+function getRuntimeRepoWorktreeId(repo: Repo, path: string): string {
+  return makeRepoWorktreeKey(repo, path)
+}
+
+function getRuntimeLegacyRepoWorktreeId(repo: Repo, path: string): string {
+  return makeLegacyWorktreeId(repo.id, path)
+}
+
+function getRuntimeWorktreeMetaForRepoPath(
+  store: RuntimeStore,
+  repo: Repo,
+  path: string
+): WorktreeMeta | undefined {
+  migrateRuntimeLegacyWorktreeMetaIfSafe(store, repo, path)
+  return (
+    store.getWorktreeMeta(getRuntimeRepoWorktreeId(repo, path)) ??
+    store.getWorktreeMeta(getRuntimeLegacyRepoWorktreeId(repo, path))
+  )
+}
+
+function migrateRuntimeLegacyWorktreeMetaIfSafe(
+  store: RuntimeStore,
+  repo: Repo,
+  path: string
+): void {
+  if (!store.migrateWorktreeIdentity) {
+    return
+  }
+  const canonicalId = getRuntimeRepoWorktreeId(repo, path)
+  if (store.getWorktreeMeta(canonicalId)) {
+    return
+  }
+  const legacyId = getRuntimeLegacyRepoWorktreeId(repo, path)
+  const legacyMeta = store.getWorktreeMeta(legacyId)
+  if (!legacyMeta) {
+    return
+  }
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (legacyMeta.hostId !== undefined && legacyMeta.hostId !== repoHostId) {
+    return
+  }
+  store.migrateWorktreeIdentity(legacyId, canonicalId)
+}
+
+function isRuntimeCanonicalWorktreeIdForRepoHost(repo: Repo, worktreeId: string): boolean {
+  const parsed = parseWorktreeKey(worktreeId)
+  return parsed?.repoId === repo.id && parsed.hostId === getRepoExecutionHostId(repo)
+}
+
+function isRuntimeWorktreeIdAliasForResolved(
+  worktree: Pick<ResolvedWorktree, 'id' | 'repoId' | 'path' | 'hostId'>,
+  worktreeId: string
+): boolean {
+  if (worktree.id === worktreeId) {
+    return true
+  }
+  const parsed = splitWorktreeIdForFilesystem(worktreeId)
+  if (!parsed || parsed.repoId !== worktree.repoId) {
+    return false
+  }
+  if (parsed.hostId !== undefined && worktree.hostId !== parsed.hostId) {
+    return false
+  }
+  return runtimePathsEqual(parsed.worktreePath, worktree.path)
+}
+
+function findResolvedWorktreeForIdAlias(
+  worktrees: readonly ResolvedWorktree[],
+  worktreeId: string
+): ResolvedWorktree | null {
+  const matches = worktrees.filter((worktree) =>
+    isRuntimeWorktreeIdAliasForResolved(worktree, worktreeId)
+  )
+  return matches.length === 1 ? matches[0] : null
 }
 
 function mergeRuntimeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta): Worktree {
@@ -1279,9 +1386,25 @@ function mergeRuntimeFolderWorkspace(repo: Repo, worktreeId: string, meta: Workt
 }
 
 function listRuntimeFolderWorkspaces(
-  store: Pick<RuntimeStore, 'getAllWorktreeMeta' | 'setWorktreeMeta'>,
+  store: Pick<
+    RuntimeStore,
+    'getAllWorktreeMeta' | 'getWorktreeMeta' | 'setWorktreeMeta' | 'migrateWorktreeIdentity'
+  >,
   repo: Repo
 ): Worktree[] {
+  for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
+    if (!isRuntimeLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
+      continue
+    }
+    const repoHostId = getRepoExecutionHostId(repo)
+    if (meta.hostId !== undefined && meta.hostId !== repoHostId) {
+      continue
+    }
+    store.migrateWorktreeIdentity?.(
+      worktreeId,
+      getRuntimeCanonicalFolderWorkspaceId(repo, worktreeId)
+    )
+  }
   const rootId = getRuntimeFolderWorkspaceRootId(repo)
   const allMeta = store.getAllWorktreeMeta()
   const ids = Object.keys(allMeta).filter((worktreeId) =>
@@ -7545,8 +7668,7 @@ export class OrcaRuntimeService {
         : null
     const cachedExplicitTargetWorktree =
       explicitTargetWorktreeId && cachedResolvedWorktrees
-        ? (cachedResolvedWorktrees.find((worktree) => worktree.id === explicitTargetWorktreeId) ??
-          null)
+        ? findResolvedWorktreeForIdAlias(cachedResolvedWorktrees, explicitTargetWorktreeId)
         : null
     const parsedExplicitTargetWorktree =
       explicitTargetWorktreeId && !cachedExplicitTargetWorktree
@@ -7556,7 +7678,7 @@ export class OrcaRuntimeService {
       worktreeSelector && !explicitTargetWorktreeId
         ? await this.resolveWorktreeSelector(worktreeSelector)
         : (cachedExplicitTargetWorktree ?? parsedExplicitTargetWorktree)
-    const targetWorktreeId = explicitTargetWorktreeId ?? targetWorktree?.id ?? null
+    const targetWorktreeId = targetWorktree?.id ?? explicitTargetWorktreeId ?? null
     const classificationResolvedWorktreeCache = this.resolvedWorktreeCache
     const classificationResolvedWorktrees =
       targetWorktreeId &&
@@ -7604,9 +7726,13 @@ export class OrcaRuntimeService {
 
     const terminals: RuntimeTerminalSummary[] = []
     const ptyIdsFromLeaves = new Set<string>()
+    const matchesTargetWorktree = (worktreeId: string): boolean =>
+      !targetWorktreeId ||
+      worktreeId === targetWorktreeId ||
+      (targetWorktree ? isRuntimeWorktreeIdAliasForResolved(targetWorktree, worktreeId) : false)
     if (graphEpoch !== null) {
       for (const leaf of this.leaves.values()) {
-        if (targetWorktreeId && leaf.worktreeId !== targetWorktreeId) {
+        if (!matchesTargetWorktree(leaf.worktreeId)) {
           continue
         }
         if (opts.requireFreshPtyLiveness && leaf.ptyId && !refreshedPtyLiveness?.has(leaf.ptyId)) {
@@ -7632,7 +7758,7 @@ export class OrcaRuntimeService {
       if (opts.requireFreshPtyLiveness && !refreshedPtyLiveness?.has(pty.ptyId)) {
         continue
       }
-      if (targetWorktreeId && pty.worktreeId !== targetWorktreeId) {
+      if (!matchesTargetWorktree(pty.worktreeId)) {
         continue
       }
       terminals.push(this.buildPtyTerminalSummary(pty, worktreesById))
@@ -11288,9 +11414,12 @@ export class OrcaRuntimeService {
       this.pruneLineageForMissingRepoWorktrees(repo, scan.worktrees)
     }
     const detected = scan.worktrees.map((gitWorktree) => {
-      const worktreeId = `${repo.id}::${gitWorktree.path}`
-      const meta = this.store?.getWorktreeMeta(worktreeId)
-      const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+      const meta = this.store
+        ? getRuntimeWorktreeMetaForRepoPath(this.store, repo, gitWorktree.path)
+        : undefined
+      const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+        hostId: getRepoExecutionHostId(repo)
+      })
       const detectedWorktree = this.toRuntimeDetectedWorktree(repo, worktree)
       if (scan.ok) {
         return detectedWorktree
@@ -12365,7 +12494,7 @@ export class OrcaRuntimeService {
       throw new Error('Worktree created but not found in listing')
     }
 
-    const worktreeId = `${repo.id}::${created.path}`
+    const worktreeId = getRuntimeRepoWorktreeId(repo, created.path)
     const now = Date.now()
     // Why: PR/MR-created worktrees can start from a head ref/SHA while Source
     // Control must compare against the review target branch.
@@ -12432,7 +12561,9 @@ export class OrcaRuntimeService {
       ...(args.manualOrder !== undefined ? { manualOrder: args.manualOrder } : {}),
       ...(args.workspaceStatus !== undefined ? { workspaceStatus: args.workspaceStatus } : {})
     })
-    const worktree = mergeWorktree(repo.id, created, meta)
+    const worktree = mergeWorktree(repo.id, created, meta, undefined, {
+      hostId: getRepoExecutionHostId(repo)
+    })
     const {
       lineage,
       workspaceLineage,
@@ -13169,7 +13300,21 @@ export class OrcaRuntimeService {
   }
 
   clearOptimisticReconcileToken(worktreeId: string): void {
-    this.optimisticReconcileTokens.delete(worktreeId)
+    for (const id of this.getKnownWorktreeIdAliases(worktreeId)) {
+      this.optimisticReconcileTokens.delete(id)
+    }
+  }
+
+  private getKnownWorktreeIdAliases(worktreeId: string): Set<string> {
+    const ids = new Set([worktreeId])
+    const parsed = splitWorktreeIdForFilesystem(worktreeId)
+    const repo = parsed ? this.store?.getRepo(parsed.repoId) : null
+    if (!parsed || !repo) {
+      return ids
+    }
+    ids.add(getRuntimeRepoWorktreeId(repo, parsed.worktreePath))
+    ids.add(getRuntimeLegacyRepoWorktreeId(repo, parsed.worktreePath))
+    return ids
   }
 
   emitWorktreeBaseStatus(event: WorktreeBaseStatusEvent): void {
@@ -13901,8 +14046,14 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
     const removalTarget = parseExactWorktreeIdSelector(worktreeSelector)
+    const repo = removalTarget ? this.store.getRepo(removalTarget.repoId) : undefined
+    const canonicalRemovalTargetId =
+      removalTarget && repo ? getRuntimeRepoWorktreeId(repo, removalTarget.path) : undefined
     const cleanupTarget = removalTarget
-      ? this.preservedBranchCleanupByWorktreeId.get(removalTarget.id)
+      ? (this.preservedBranchCleanupByWorktreeId.get(removalTarget.id) ??
+        (canonicalRemovalTargetId
+          ? this.preservedBranchCleanupByWorktreeId.get(canonicalRemovalTargetId)
+          : undefined))
       : undefined
     if (
       !removalTarget ||
@@ -13913,7 +14064,6 @@ export class OrcaRuntimeService {
       throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
     }
 
-    const repo = this.store.getRepo(removalTarget.repoId)
     if (!repo) {
       throw new Error('repo_not_found')
     }
@@ -15354,12 +15504,12 @@ export class OrcaRuntimeService {
     this.assertStableReadyGraph(graphEpoch)
     const ptyIds = new Set<string>()
     for (const leaf of this.leaves.values()) {
-      if (leaf.worktreeId === worktree.id && leaf.ptyId) {
+      if (isRuntimeWorktreeIdAliasForResolved(worktree, leaf.worktreeId) && leaf.ptyId) {
         ptyIds.add(leaf.ptyId)
       }
     }
     for (const pty of this.ptysById.values()) {
-      if (pty.worktreeId === worktree.id && pty.connected) {
+      if (isRuntimeWorktreeIdAliasForResolved(worktree, pty.worktreeId) && pty.connected) {
         ptyIds.add(pty.ptyId)
       }
     }
@@ -15400,7 +15550,7 @@ export class OrcaRuntimeService {
     if (!refreshedPtyLiveness) {
       throw new Error('terminal_liveness_unavailable')
     }
-    const livePtyIds = this.getLivePtyIdsForWorktree(worktree.id, refreshedPtyLiveness)
+    const livePtyIds = this.getLivePtyIdsForWorktree(worktree, refreshedPtyLiveness)
     const targetOnly = opts.targetOnly === true
     const expectedIsLive = [...expected].every((ptyId) => livePtyIds.has(ptyId))
     if (targetOnly ? !expectedIsLive : !setsEqual(livePtyIds, expected)) {
@@ -15432,7 +15582,7 @@ export class OrcaRuntimeService {
         postStopFailure: 'terminal_liveness_unavailable'
       }
     }
-    const remainingLivePtyIds = this.getLivePtyIdsForWorktree(worktree.id, postStopLiveness)
+    const remainingLivePtyIds = this.getLivePtyIdsForWorktree(worktree, postStopLiveness)
     const stoppedTargetsStillLive = [...expected].filter((ptyId) => remainingLivePtyIds.has(ptyId))
     if (targetOnly ? stoppedTargetsStillLive.length > 0 : remainingLivePtyIds.size > 0) {
       return {
@@ -15456,13 +15606,13 @@ export class OrcaRuntimeService {
   }
 
   private getLivePtyIdsForWorktree(
-    worktreeId: string,
+    worktree: ResolvedWorktree,
     freshPtyIds?: ReadonlySet<string>
   ): Set<string> {
     const ptyIds = new Set<string>()
     for (const leaf of this.leaves.values()) {
       if (
-        leaf.worktreeId === worktreeId &&
+        isRuntimeWorktreeIdAliasForResolved(worktree, leaf.worktreeId) &&
         leaf.connected &&
         leaf.ptyId &&
         (!freshPtyIds || freshPtyIds.has(leaf.ptyId))
@@ -15472,7 +15622,7 @@ export class OrcaRuntimeService {
     }
     for (const pty of this.ptysById.values()) {
       if (
-        pty.worktreeId === worktreeId &&
+        isRuntimeWorktreeIdAliasForResolved(worktree, pty.worktreeId) &&
         pty.connected &&
         (!freshPtyIds || freshPtyIds.has(pty.ptyId))
       ) {
@@ -15487,12 +15637,12 @@ export class OrcaRuntimeService {
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
     this.assertStableReadyGraph(graphEpoch)
     for (const leaf of this.leaves.values()) {
-      if (leaf.worktreeId === worktree.id && leaf.ptyId) {
+      if (isRuntimeWorktreeIdAliasForResolved(worktree, leaf.worktreeId) && leaf.ptyId) {
         return true
       }
     }
     for (const pty of this.ptysById.values()) {
-      if (pty.worktreeId === worktree.id && pty.connected) {
+      if (isRuntimeWorktreeIdAliasForResolved(worktree, pty.worktreeId) && pty.connected) {
         return true
       }
     }
@@ -15678,11 +15828,18 @@ export class OrcaRuntimeService {
       const worktreeId = selector.slice(3)
       candidates = worktrees.filter((worktree) => worktree.id === worktreeId)
       if (candidates.length === 0) {
+        candidates = worktrees.filter((worktree) =>
+          isRuntimeWorktreeIdAliasForResolved(worktree, worktreeId)
+        )
+      }
+      if (candidates.length === 0) {
         const parsed = splitWorktreeIdForFilesystem(worktreeId)
         const repo = parsed ? this.store?.getRepo(parsed.repoId) : null
         const fallback =
-          repo?.connectionId && this.store?.getWorktreeMeta(worktreeId)
-            ? this.buildResolvedWorktreeFromId(worktreeId)
+          repo?.connectionId && parsed
+            ? getRuntimeWorktreeMetaForRepoPath(this.requireStore(), repo, parsed.worktreePath)
+              ? this.buildResolvedWorktreeFromId(worktreeId)
+              : null
             : null
         if (fallback !== null) {
           candidates = [fallback]
@@ -15717,6 +15874,7 @@ export class OrcaRuntimeService {
       candidates = worktrees.filter(
         (worktree) =>
           worktree.id === selector ||
+          isRuntimeWorktreeIdAliasForResolved(worktree, selector) ||
           runtimePathsEqual(worktree.path, selector) ||
           branchSelectorMatches(worktree.branch, selector)
       )
@@ -16178,6 +16336,10 @@ export class OrcaRuntimeService {
       return null
     }
     const repo = this.store?.getRepos().find((entry) => entry.id === parsed.repoId)
+    const canonicalWorktreeId =
+      repo && (parsed.hostId === undefined || parsed.hostId === getRepoExecutionHostId(repo))
+        ? getRuntimeRepoWorktreeId(repo, parsed.worktreePath)
+        : worktreeId
     const git = {
       path: parsed.worktreePath,
       head: '',
@@ -16185,11 +16347,20 @@ export class OrcaRuntimeService {
       isBare: false,
       isMainWorktree: repo ? areWorktreePathsEqual(parsed.worktreePath, repo.path) : false
     }
-    const meta = this.store?.getWorktreeMeta(worktreeId)
-    const merged = mergeWorktree(parsed.repoId, git, meta, repo?.displayName)
+    const meta =
+      repo && this.store
+        ? getRuntimeWorktreeMetaForRepoPath(this.store, repo, parsed.worktreePath)
+        : this.store?.getWorktreeMeta(worktreeId)
+    const merged = mergeWorktree(
+      parsed.repoId,
+      git,
+      meta,
+      repo?.displayName,
+      repo ? { hostId: getRepoExecutionHostId(repo) } : undefined
+    )
     return {
       ...merged,
-      id: worktreeId,
+      id: canonicalWorktreeId,
       parentWorktreeId: null,
       childWorktreeIds: [],
       lineage: null,
@@ -16221,15 +16392,14 @@ export class OrcaRuntimeService {
         )
       })
     )
-    worktreeIds.add(targetWorktreeId)
+    worktreeIds.add(targetWorktree.id)
 
     const resolved: ResolvedWorktree[] = []
     for (const worktreeId of worktreeIds) {
-      const worktree =
-        worktreeId === targetWorktreeId
-          ? targetWorktree
-          : this.buildResolvedWorktreeFromId(worktreeId)
-      if (worktree) {
+      const worktree = isRuntimeWorktreeIdAliasForResolved(targetWorktree, worktreeId)
+        ? targetWorktree
+        : this.buildResolvedWorktreeFromId(worktreeId)
+      if (worktree && !resolved.some((entry) => entry.id === worktree.id)) {
         resolved.push(worktree)
       }
     }
@@ -16264,10 +16434,10 @@ export class OrcaRuntimeService {
     if (!this.store) {
       return []
     }
+    const store = this.store
     const now = Date.now()
-    const metaById = this.store.getAllWorktreeMeta() ?? {}
     const perRepoWorktrees = await Promise.all(
-      this.store.getRepos().map(async (repo) => {
+      store.getRepos().map(async (repo) => {
         if (isFolderRepo(repo)) {
           return listRuntimeFolderWorkspaces(this.requireStore(), repo).map((worktree) => ({
             ...worktree,
@@ -16297,15 +16467,17 @@ export class OrcaRuntimeService {
           this.pruneLineageForMissingRepoWorktrees(repo, gitWorktrees)
         }
         return gitWorktrees.map((gitWorktree) => {
-          const worktreeId = `${repo.id}::${gitWorktree.path}`
+          const worktreeId = getRuntimeRepoWorktreeId(repo, gitWorktree.path)
           // Why: lineage validation needs a durable instance ID even when the
           // runtime sees a workspace before the renderer's discovery-stamp path.
-          const existingMeta = metaById[worktreeId]
+          const existingMeta = getRuntimeWorktreeMetaForRepoPath(store, repo, gitWorktree.path)
           const meta =
             existingMeta && existingMeta.instanceId
               ? existingMeta
-              : this.store?.setWorktreeMeta(worktreeId, {})
-          const merged = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+              : store.setWorktreeMeta(worktreeId, existingMeta ?? {})
+          const merged = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+            hostId: getRepoExecutionHostId(repo)
+          })
           return {
             ...merged,
             parentWorktreeId: null,
@@ -16344,8 +16516,10 @@ export class OrcaRuntimeService {
     const childIdsByParentId = new Map<string, string[]>()
 
     for (const [childId, lineage] of Object.entries(lineageById)) {
-      const child = worktreeById.get(childId)
-      const parent = worktreeById.get(lineage.parentWorktreeId)
+      const child = worktreeById.get(childId) ?? findResolvedWorktreeForIdAlias(worktrees, childId)
+      const parent =
+        worktreeById.get(lineage.parentWorktreeId) ??
+        findResolvedWorktreeForIdAlias(worktrees, lineage.parentWorktreeId)
       if (
         !child ||
         !parent ||
@@ -16356,10 +16530,15 @@ export class OrcaRuntimeService {
         // checkouts from appearing as children of stale same-path lineage.
         continue
       }
-      validLineageByChildId.set(childId, lineage)
-      const children = childIdsByParentId.get(lineage.parentWorktreeId) ?? []
-      children.push(childId)
-      childIdsByParentId.set(lineage.parentWorktreeId, children)
+      const normalizedLineage = {
+        ...lineage,
+        worktreeId: child.id,
+        parentWorktreeId: parent.id
+      }
+      validLineageByChildId.set(child.id, normalizedLineage)
+      const children = childIdsByParentId.get(parent.id) ?? []
+      children.push(child.id)
+      childIdsByParentId.set(parent.id, children)
     }
 
     return worktrees.map((worktree) => {
@@ -16382,14 +16561,19 @@ export class OrcaRuntimeService {
     ) {
       return
     }
-    const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
+    const liveIds = new Set(
+      gitWorktrees.map((worktree) => getRuntimeRepoWorktreeId(repo, worktree.path))
+    )
+    const legacyLiveIds = new Set(
+      gitWorktrees.map((worktree) => getRuntimeLegacyRepoWorktreeId(repo, worktree.path))
+    )
     const repoPrefix = `${repo.id}::`
     for (const childWorkspaceKey of Object.keys(store.getAllWorkspaceLineage?.() ?? {})) {
       const childScope = parseWorkspaceKey(childWorkspaceKey)
       if (
         childScope?.type === 'worktree' &&
         childScope.worktreeId.startsWith(repoPrefix) &&
-        !liveIds.has(childScope.worktreeId)
+        !legacyLiveIds.has(childScope.worktreeId)
       ) {
         if (isWorkspaceKey(childWorkspaceKey)) {
           store.removeWorkspaceLineage?.(childWorkspaceKey)
@@ -16397,7 +16581,10 @@ export class OrcaRuntimeService {
       }
     }
     for (const [childId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-      if (childId.startsWith(repoPrefix) && !liveIds.has(childId)) {
+      if (
+        (childId.startsWith(repoPrefix) && !legacyLiveIds.has(childId)) ||
+        (isRuntimeCanonicalWorktreeIdForRepoHost(repo, childId) && !liveIds.has(childId))
+      ) {
         // Why: runtime selector scans can be the only scan before a path is
         // reused. Once a successful scan proves the child is gone, stale
         // lineage must not survive into the replacement checkout.
@@ -16406,7 +16593,7 @@ export class OrcaRuntimeService {
       }
       if (
         lineage.parentWorktreeId.startsWith(repoPrefix) &&
-        !liveIds.has(lineage.parentWorktreeId)
+        !legacyLiveIds.has(lineage.parentWorktreeId)
       ) {
         const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
         if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
@@ -16628,9 +16815,13 @@ export class OrcaRuntimeService {
     const sessions = sessionsResult.value
     const livePtyIds = new Set(sessions.map((session) => session.id))
     for (const session of sessions) {
-      const worktreeId =
+      const inferredWorktreeId =
         inferWorktreeIdFromPtyId(session.id) ??
         findResolvedWorktreeIdForPath(resolvedWorktrees, session.cwd)
+      const worktreeId = inferredWorktreeId
+        ? (findResolvedWorktreeForIdAlias(resolvedWorktrees, inferredWorktreeId)?.id ??
+          inferredWorktreeId)
+        : null
       if (targetWorktreeId && worktreeId !== targetWorktreeId) {
         continue
       }

--- a/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
+++ b/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
@@ -69,6 +69,16 @@ const ProjectHostSetupCreate = z.object({
 
 const ProjectHostSetupUpdate = z.object({
   setupId: requiredString('Missing setup ID'),
+  hostId: requiredString('Missing host ID')
+    .transform((value, ctx) => {
+      const hostId = normalizeExecutionHostId(value)
+      if (!hostId) {
+        ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+        return z.NEVER
+      }
+      return hostId
+    })
+    .optional(),
   updates: z.object({
     displayName: OptionalString,
     path: OptionalString,
@@ -83,7 +93,17 @@ const ProjectHostSetupUpdate = z.object({
 })
 
 const ProjectHostSetupDelete = z.object({
-  setupId: requiredString('Missing setup ID')
+  setupId: requiredString('Missing setup ID'),
+  hostId: requiredString('Missing host ID')
+    .transform((value, ctx) => {
+      const hostId = normalizeExecutionHostId(value)
+      if (!hostId) {
+        ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+        return z.NEVER
+      }
+      return hostId
+    })
+    .optional()
 })
 
 export const PROJECT_RUNTIME_METHODS: RpcMethod[] = [

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -1,6 +1,7 @@
 import type { IPtyProvider } from '../providers/types'
 import type { OrcaRuntimeService } from './orca-runtime'
 import { listRegisteredPtys } from '../memory/pty-registry'
+import { makeLegacyWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
 
 export type WorktreeTeardownDeps = {
   runtime?: OrcaRuntimeService
@@ -51,13 +52,15 @@ export async function killAllProcessesForWorktree(
     result.runtimeStopped = r.stopped
   }
 
+  const worktreeIds = getTeardownWorktreeIds(worktreeId)
+
   result.providerStopped = await sweepProviderByPrefix(
-    worktreeId,
+    worktreeIds,
     deps.localProvider,
     deps.onPtyStopped
   )
   result.registryStopped = await sweepRegistryForWorktree(
-    worktreeId,
+    worktreeIds,
     deps.localProvider,
     deps.onPtyStopped
   )
@@ -66,15 +69,15 @@ export async function killAllProcessesForWorktree(
 }
 
 async function sweepProviderByPrefix(
-  worktreeId: string,
+  worktreeIds: ReadonlySet<string>,
   provider: IPtyProvider,
   onPtyStopped?: (ptyId: string) => void
 ): Promise<number> {
-  const prefix = `${worktreeId}@@`
+  const prefixes = [...worktreeIds].map((worktreeId) => `${worktreeId}@@`)
   const sessions = await provider.listProcesses().catch(() => [])
   let killed = 0
   for (const s of sessions) {
-    if (!s.id.startsWith(prefix)) {
+    if (!prefixes.some((prefix) => s.id.startsWith(prefix))) {
       continue
     }
     try {
@@ -90,11 +93,13 @@ async function sweepProviderByPrefix(
 }
 
 async function sweepRegistryForWorktree(
-  worktreeId: string,
+  worktreeIds: ReadonlySet<string>,
   localProvider: IPtyProvider,
   onPtyStopped?: (ptyId: string) => void
 ): Promise<number> {
-  const entries = listRegisteredPtys().filter((r) => r.worktreeId === worktreeId)
+  const entries = listRegisteredPtys().filter(
+    (r) => r.worktreeId !== null && worktreeIds.has(r.worktreeId)
+  )
   let killed = 0
   for (const entry of entries) {
     try {
@@ -106,6 +111,15 @@ async function sweepRegistryForWorktree(
     }
   }
   return killed
+}
+
+function getTeardownWorktreeIds(worktreeId: string): Set<string> {
+  const ids = new Set([worktreeId])
+  const parsed = splitWorktreeId(worktreeId)
+  if (parsed) {
+    ids.add(makeLegacyWorktreeId(parsed.repoId, parsed.worktreePath))
+  }
+  return ids
 }
 
 function clearStoppedPtyState(ptyId: string, onPtyStopped?: (ptyId: string) => void): void {

--- a/src/main/usage-worktree-metadata.ts
+++ b/src/main/usage-worktree-metadata.ts
@@ -1,6 +1,10 @@
 import { basename } from 'path'
 import type { Repo } from '../shared/types'
-import { splitWorktreeId, splitWorktreeIdForFilesystem } from '../shared/worktree-id'
+import {
+  makeRepoWorktreeKey,
+  splitWorktreeId,
+  splitWorktreeIdForFilesystem
+} from '../shared/worktree-id'
 import { isFolderRepo } from '../shared/repo-kind'
 import type { Store } from './persistence'
 
@@ -26,7 +30,7 @@ export function loadKnownUsageWorktreesByRepo(
   for (const repo of localRepos) {
     worktreesByRepo.set(repo.id, [
       {
-        worktreeId: `${repo.id}::${repo.path}`,
+        worktreeId: makeRepoWorktreeKey(repo, repo.path),
         path: repo.path,
         displayName: repo.displayName || getDefaultUsageWorktreeLabel(repo.path)
       }

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -24,6 +24,8 @@ import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { createFolderWorktree, listRepoWorktrees } from './repo-worktrees'
 import { mergeWorktree } from './ipc/worktree-logic'
+import { getRepoExecutionHostId } from '../shared/execution-host'
+import { makeRepoWorktreeKey } from '../shared/worktree-id'
 
 const WORKTREE_SCAN_CONCURRENCY = 3
 const LOCAL_FS_CONCURRENCY = 48
@@ -797,8 +799,10 @@ async function listWorktreesForSpaceScan(
 }
 
 function mergeForSpaceScan(repo: Repo, gitWorktree: GitWorktreeInfo, store: Store): Worktree {
-  const worktreeId = `${repo.id}::${gitWorktree.path}`
-  return mergeWorktree(repo.id, gitWorktree, store.getWorktreeMeta(worktreeId), repo.displayName)
+  const worktreeId = makeRepoWorktreeKey(repo, gitWorktree.path)
+  return mergeWorktree(repo.id, gitWorktree, store.getWorktreeMeta(worktreeId), repo.displayName, {
+    hostId: getRepoExecutionHostId(repo)
+  })
 }
 
 function reportProgress(

--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -3,7 +3,7 @@ import { AlertCircle, FileCode2, LoaderCircle, Plus, RefreshCw } from 'lucide-re
 import { toast } from 'sonner'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import type { Repo, Worktree } from '../../../../shared/types'
-import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, makeRepoWorktreeKey } from '../../../../shared/worktree-id'
 import {
   canInspectLocalMcpConfigRoot,
   inspectMcpConfigContent,
@@ -63,9 +63,26 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     return (
       worktreesForRepo.find((worktree) => worktree.isMainWorktree) ??
       worktreesForRepo.find((worktree) => worktree.path === repo.path) ??
-      worktreesForRepo[0] ?? { id: `${repo.id}::${repo.path}`, path: repo.path }
+      worktreesForRepo[0] ?? {
+        id: makeRepoWorktreeKey(
+          {
+            id: repo.id,
+            connectionId: repo.connectionId,
+            executionHostId: repo.executionHostId
+          },
+          repo.path
+        ),
+        path: repo.path
+      }
     )
-  }, [activeWorktreeId, repo.id, repo.path, worktreesForRepo])
+  }, [
+    activeWorktreeId,
+    repo.connectionId,
+    repo.executionHostId,
+    repo.id,
+    repo.path,
+    worktreesForRepo
+  ])
   const targetWorktreeId = targetWorktree.id
   const targetRootPath = targetWorktree.path
   const detectedCount = useMemo(() => configs.filter((config) => config.exists).length, [configs])

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
@@ -256,9 +256,78 @@ describe('RepositoryHostSetupsSection', () => {
       removeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(deleteProjectHostSetup).toHaveBeenCalledWith({ setupId: 'gpu-setup' })
+    expect(deleteProjectHostSetup).toHaveBeenCalledWith({
+      setupId: 'gpu-setup',
+      hostId: 'runtime:gpu'
+    })
     expect(openSettingsPage).not.toHaveBeenCalled()
     expect(openSettingsTarget).not.toHaveBeenCalled()
+  })
+
+  it('removes the selected same-id setup from its host', async () => {
+    const deleteProjectHostSetup = vi.fn().mockResolvedValue({
+      project: makeProject({ id: 'github:stablyai/orca' }),
+      setup: makeSetup({
+        id: 'shared-setup',
+        projectId: 'github:stablyai/orca',
+        repoId: '',
+        hostId: 'runtime:cpu',
+        path: ''
+      })
+    })
+    const localRepo = makeRepo({
+      id: 'local-repo',
+      displayName: 'Orca',
+      path: '/Users/alice/orca'
+    })
+    useAppStore.setState({
+      repos: [localRepo],
+      projects: [makeProject({ id: 'github:stablyai/orca' })],
+      projectHostSetups: [
+        makeSetup({
+          id: 'local-repo',
+          projectId: 'github:stablyai/orca',
+          repoId: 'local-repo',
+          hostId: 'local',
+          path: '/Users/alice/orca'
+        }),
+        makeSetup({
+          id: 'shared-setup',
+          projectId: 'github:stablyai/orca',
+          repoId: '',
+          hostId: 'runtime:gpu',
+          path: '',
+          setupState: 'setting-up',
+          setupMethod: 'provisioned'
+        }),
+        makeSetup({
+          id: 'shared-setup',
+          projectId: 'github:stablyai/orca',
+          repoId: '',
+          hostId: 'runtime:cpu',
+          path: '',
+          setupState: 'setting-up',
+          setupMethod: 'provisioned'
+        })
+      ],
+      deleteProjectHostSetup
+    })
+
+    renderSection(localRepo)
+
+    const removeButtons = Array.from(container.querySelectorAll('button')).filter(
+      (button) => button.textContent === 'Remove'
+    )
+    expect(removeButtons).toHaveLength(2)
+
+    await act(async () => {
+      removeButtons[1]?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(deleteProjectHostSetup).toHaveBeenCalledWith({
+      setupId: 'shared-setup',
+      hostId: 'runtime:cpu'
+    })
   })
 
   it('sets up the project on another known host from an existing folder path', async () => {

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react'
-import { getExecutionHostLabel } from '../../../../shared/execution-host'
+import { getExecutionHostLabel, getRepoExecutionHostId } from '../../../../shared/execution-host'
 import { buildExecutionHostRegistry } from '../../../../shared/execution-host-registry'
 import { getHostDisplayLabelOverrides } from '../../../../shared/host-setting-overrides'
-import type { Repo } from '../../../../shared/types'
+import type { ProjectHostSetup, Repo } from '../../../../shared/types'
 import { useAppStore } from '../../store'
 import { getProjectHostSetupProjectionFromState } from '../../store/selectors'
 import { cn } from '../../lib/utils'
@@ -22,6 +22,10 @@ type RepositoryHostSetupsSectionProps = {
   forceVisible: boolean
   searchQuery: string
   searchEntries: SettingsSearchEntry[]
+}
+
+function getProjectHostSetupKey(setup: Pick<ProjectHostSetup, 'hostId' | 'id'>): string {
+  return `${setup.hostId}\0${setup.id}`
 }
 
 export function RepositoryHostSetupsSection({
@@ -67,8 +71,9 @@ export function RepositoryHostSetupsSection({
   const projectHostSetupProjection = useAppStore((state) =>
     getProjectHostSetupProjectionFromState(state)
   )
+  const repoHostId = getRepoExecutionHostId(repo)
   const selectedProjectHostSetup = projectHostSetupProjection.setups.find(
-    (setup) => setup.repoId === repo.id
+    (setup) => setup.repoId === repo.id && setup.hostId === repoHostId
   )
   const projectHostSetups = selectedProjectHostSetup
     ? projectHostSetupProjection.setups.filter(
@@ -80,8 +85,11 @@ export function RepositoryHostSetupsSection({
     projectHostSetups,
     hostOptions
   })
+  const selectedProjectHostSetupKey = selectedProjectHostSetup
+    ? getProjectHostSetupKey(selectedProjectHostSetup)
+    : ''
   const hostOptionById = new Map(hostOptions.map((option) => [option.id, option]))
-  const [deletingSetupId, setDeletingSetupId] = useState<string | null>(null)
+  const [deletingSetupKey, setDeletingSetupKey] = useState<string | null>(null)
   const openSetup = (repoId: string) => {
     openSettingsPage()
     openSettingsTarget({ pane: 'repo', repoId })
@@ -116,26 +124,34 @@ export function RepositoryHostSetupsSection({
                 {translate('auto.components.settings.RepositoryPane.viewingHost', 'Viewing host')}
               </span>
               <Select
-                value={repo.id}
-                onValueChange={(repoId) => {
-                  if (repoId === repo.id) {
+                value={selectedProjectHostSetupKey}
+                onValueChange={(setupKey) => {
+                  if (setupKey === selectedProjectHostSetupKey) {
                     return
                   }
-                  openSetup(repoId)
+                  const nextSetup = openableProjectHostSetups.find(
+                    (setup) => getProjectHostSetupKey(setup) === setupKey
+                  )
+                  if (nextSetup) {
+                    openSetup(nextSetup.repoId)
+                  }
                 }}
               >
                 <SelectTrigger className="h-8 w-44 min-w-0 text-xs">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {openableProjectHostSetups.map((setup) => (
-                    <SelectItem key={setup.id} value={setup.repoId}>
-                      <span className="block min-w-0 truncate">
-                        {hostOptionById.get(setup.hostId)?.label ??
-                          getExecutionHostLabel(setup.hostId)}
-                      </span>
-                    </SelectItem>
-                  ))}
+                  {openableProjectHostSetups.map((setup) => {
+                    const setupKey = getProjectHostSetupKey(setup)
+                    return (
+                      <SelectItem key={setupKey} value={setupKey}>
+                        <span className="block min-w-0 truncate">
+                          {hostOptionById.get(setup.hostId)?.label ??
+                            getExecutionHostLabel(setup.hostId)}
+                        </span>
+                      </SelectItem>
+                    )
+                  })}
                 </SelectContent>
               </Select>
             </div>
@@ -150,12 +166,13 @@ export function RepositoryHostSetupsSection({
       </div>
       <div className="divide-y divide-border rounded-md border border-border">
         {projectHostSetups.map((setup) => {
-          const isCurrentSetup = setup.repoId === repo.id
+          const setupKey = getProjectHostSetupKey(setup)
+          const isCurrentSetup = setup.repoId === repo.id && setup.hostId === repoHostId
           const canOpenSetup = setup.repoId.trim().length > 0
-          const canRemoveSetup = !canOpenSetup && deletingSetupId !== setup.id
+          const canRemoveSetup = !canOpenSetup && deletingSetupKey !== setupKey
           return (
             <div
-              key={setup.id}
+              key={setupKey}
               className={cn(
                 'flex w-full items-start gap-3 px-3 py-2.5 text-left transition-colors',
                 isCurrentSetup ? 'bg-muted/30' : ''
@@ -201,9 +218,9 @@ export function RepositoryHostSetupsSection({
                   variant="outline"
                   size="sm"
                   onClick={async () => {
-                    setDeletingSetupId(setup.id)
-                    await deleteProjectHostSetup({ setupId: setup.id })
-                    setDeletingSetupId(null)
+                    setDeletingSetupKey(setupKey)
+                    await deleteProjectHostSetup({ setupId: setup.id, hostId: setup.hostId })
+                    setDeletingSetupKey(null)
                   }}
                 >
                   {translate('auto.components.settings.RepositoryPane.removeSetup', 'Remove')}

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -456,7 +456,10 @@ describe('useIpcEvents browser tab create routing', () => {
       activeModal: null,
       closeModal: vi.fn(),
       openModal: vi.fn(),
+      activeRepoId: null,
+      activeWorkspaceKey: null,
       activeWorktreeId: 'wt-1',
+      activeTabId: null,
       activeView: 'terminal',
       setActiveRepo: vi.fn(),
       setActiveWorktree: vi.fn(),
@@ -950,7 +953,7 @@ describe('useIpcEvents updater integration', () => {
       clearTabPtyId,
       repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
       worktreesByRepo: {
-        'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1', hostId: 'ssh:conn-1' }]
       },
       tabsByWorktree: {
         'wt-1': [
@@ -3247,7 +3250,10 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           fetchProjectGroups: vi.fn(),
           fetchWorktrees,
           fetchWorktreeLineage,
-          repos: [{ id: 'repo-1' }],
+          repos: [
+            { id: 'repo-1', executionHostId: 'local' },
+            { id: 'repo-1', executionHostId: 'runtime:env-1' }
+          ],
           detectedWorktreesByRepo: {
             'repo-1': {
               repoId: 'repo-1',
@@ -3433,7 +3439,7 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1')
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', { ownerHostId: 'runtime:env-1' })
     expect(fetchWorktreeLineage).toHaveBeenCalledTimes(1)
   })
 })
@@ -3520,12 +3526,31 @@ describe('useIpcEvents agent status snapshot integration', () => {
       clearTabPtyId: vi.fn(),
       updateTabTitle: vi.fn(),
       runtimePaneTitlesByTabId: {},
+      ptyIdsByTabId: {},
       terminalLayoutsByTabId: {},
+      activeTabIdByWorktree: {},
       agentStatusByPaneKey: {},
       repos: [],
       worktreesByRepo: {},
       tabsByWorktree: {},
       unifiedTabsByWorktree: {},
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      openFiles: [],
+      editorDrafts: {},
+      markdownFrontmatterVisible: {},
+      activeFileIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      browserTabsByWorktree: {},
+      browserPagesByWorkspace: {},
+      activeBrowserTabId: null,
+      activeBrowserTabIdByWorktree: {},
+      browserUrlHistory: [],
+      sshConnectionStates: new Map(),
+      lastKnownRelayPtyIdByTabId: {},
+      lastVisitedAtByWorktreeId: {},
+      defaultTerminalTabsAppliedByWorktreeId: {},
       workspaceSessionReady: false,
       settings: { terminalFontSize: 13 },
       ...overrides
@@ -5062,6 +5087,121 @@ describe('useIpcEvents agent status snapshot integration', () => {
     expect(hydrateTabsSession).not.toHaveBeenCalled()
     expect(hydrateEditorSession).not.toHaveBeenCalled()
     expect(hydrateBrowserSession).not.toHaveBeenCalled()
+  })
+
+  it('applies SSH remote workspace snapshots only to the matching host worktrees', async () => {
+    const hydrateWorkspaceSession = vi.fn()
+    const hydrateTabsSession = vi.fn()
+    const hydrateEditorSession = vi.fn()
+    const hydrateBrowserSession = vi.fn()
+    const onChangedListenerRef: {
+      current:
+        | ((event: {
+            targetId: string
+            sourceClientId?: string
+            snapshot: Record<string, unknown>
+          }) => void)
+        | null
+    } = { current: null }
+    const storeState: StoreLike = buildStoreState({
+      workspaceSessionReady: true,
+      repos: [
+        { id: 'same-repo', executionHostId: 'local' },
+        { id: 'same-repo', connectionId: 'conn-1', executionHostId: 'ssh:conn-1' }
+      ],
+      worktreesByRepo: {
+        'same-repo': [
+          { id: 'same-repo::/local', repoId: 'same-repo', hostId: 'local' },
+          { id: 'same-repo::/remote', repoId: 'same-repo', hostId: 'ssh:conn-1' }
+        ]
+      },
+      tabsByWorktree: {
+        'same-repo::/local': [
+          { id: 'local-tab', ptyId: 'local-pty', worktreeId: 'same-repo::/local', title: 'Local' }
+        ],
+        'same-repo::/remote': [
+          { id: 'old-remote-tab', ptyId: null, worktreeId: 'same-repo::/remote', title: 'Old' }
+        ]
+      },
+      fetchWorktrees: vi.fn(() => Promise.resolve(true)),
+      fetchWorktreeLineage: vi.fn(() => Promise.resolve()),
+      hydrateWorkspaceSession,
+      hydrateTabsSession,
+      hydrateEditorSession,
+      hydrateBrowserSession,
+      markRemoteWorkspaceHydrated: vi.fn(),
+      setRemoteWorkspaceSyncStatus: vi.fn(),
+      reconnectPersistedTerminals: vi.fn(() => Promise.resolve())
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: () => () => {},
+        remoteWorkspace: {
+          clientId: () => Promise.resolve('client-local'),
+          onChanged: (cb: typeof onChangedListenerRef.current) => {
+            onChangedListenerRef.current = cb
+            return () => {}
+          }
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    onChangedListenerRef.current?.({
+      targetId: 'conn-1',
+      sourceClientId: 'client-remote',
+      snapshot: {
+        revision: 2,
+        updatedAt: Date.now(),
+        session: {
+          activeWorktreePath: '/remote',
+          activeTabId: 'remote-tab',
+          tabsByWorktreePath: {
+            '/remote': [
+              {
+                id: 'remote-tab',
+                ptyId: null,
+                worktreePath: '/remote',
+                title: 'Remote',
+                customTitle: null,
+                color: null,
+                sortOrder: 1,
+                createdAt: 1
+              }
+            ]
+          },
+          terminalLayoutsByTabId: {}
+        }
+      }
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(storeState.fetchWorktrees).toHaveBeenCalledWith('same-repo', {
+      ownerHostId: 'ssh:conn-1'
+    })
+    const hydrated = hydrateTabsSession.mock.calls[0]?.[0] as {
+      tabsByWorktree: Record<string, { id: string }[]>
+    }
+    expect(hydrated.tabsByWorktree['same-repo::/local']).toEqual([
+      expect.objectContaining({ id: 'local-tab' })
+    ])
+    expect(hydrated.tabsByWorktree['same-repo::/remote']).toEqual([
+      expect.objectContaining({ id: 'remote-tab' })
+    ])
   })
 
   it('silently discards snapshot entries whose tabs are still unknown', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -116,6 +116,11 @@ import { titleHasAgentName } from '../../../shared/agent-detection'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { translate } from '@/i18n/i18n'
 import { closeTerminalTab } from '@/components/terminal/terminal-tab-actions'
+import {
+  getRepoExecutionHostId,
+  toRuntimeExecutionHostId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
 
 function getShortcutPlatform(): NodeJS.Platform {
   if (navigator.userAgent.includes('Mac')) {
@@ -395,26 +400,26 @@ async function prepareRemoteWorkspaceTarget(targetId: string): Promise<boolean> 
     await store.fetchRepos()
     repos = useAppStore.getState().repos.filter((repo) => repo.connectionId === targetId)
   }
-  await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
+  await Promise.all(
+    repos.map((repo) =>
+      useAppStore.getState().fetchWorktrees(repo.id, { ownerHostId: getRepoExecutionHostId(repo) })
+    )
+  )
   await useAppStore.getState().fetchWorktreeLineage()
   return true
 }
 
-function targetRepoIds(targetId: string): Set<string> {
-  return new Set(
-    useAppStore
-      .getState()
-      .repos.filter((repo) => repo.connectionId === targetId)
-      .map((repo) => repo.id)
-  )
+function targetRepoHosts(targetId: string): Map<string, ExecutionHostId> {
+  const repos = useAppStore.getState().repos.filter((repo) => repo.connectionId === targetId)
+  return new Map(repos.map((repo) => [repo.id, getRepoExecutionHostId(repo)]))
 }
 
 function targetWorktreeIds(targetId: string): Set<string> {
-  const repoIds = targetRepoIds(targetId)
+  const repoHosts = targetRepoHosts(targetId)
   return new Set(
     Object.values(useAppStore.getState().worktreesByRepo)
       .flat()
-      .filter((worktree) => repoIds.has(worktree.repoId))
+      .filter((worktree) => repoHosts.get(worktree.repoId) === worktree.hostId)
       .map((worktree) => worktree.id)
   )
 }
@@ -740,6 +745,7 @@ export function useIpcEvents(): void {
 
     const handleWorktreesChanged = async (
       repoId: string,
+      ownerHostId?: ExecutionHostId,
       renamed?: { oldWorktreeId: string; newWorktreeId: string }
     ): Promise<void> => {
       // Why: a folder rename changes the worktree's path-derived id. Re-key every
@@ -766,7 +772,9 @@ export function useIpcEvents(): void {
       const before =
         getAuthoritativeDetectedWorktreeIds(state, repoId) ??
         getVisibleWorktreeIdsForRepo(state, repoId)
-      await state.fetchWorktrees(repoId)
+      await (ownerHostId
+        ? state.fetchWorktrees(repoId, { ownerHostId })
+        : state.fetchWorktrees(repoId))
       await useAppStore.getState().fetchWorktreeLineage()
       // Why: changing the worktree's id unmounts the active pane without
       // re-rendering it under the new id. Now that the list has refreshed,
@@ -818,7 +826,7 @@ export function useIpcEvents(): void {
         startup,
         defaultTabs
       }: Extract<RuntimeClientEvent, { type: 'activateWorktree' }>,
-      options: { allowRuntimeEnvironment: boolean }
+      options: { allowRuntimeEnvironment: boolean; ownerHostId?: ExecutionHostId }
     ): Promise<void> => {
       if (!options.allowRuntimeEnvironment && isRuntimeEnvironmentActive()) {
         // Why: local CLI-created worktree events carry local repo/worktree
@@ -830,7 +838,9 @@ export function useIpcEvents(): void {
       // Why: fetch worktrees first so the activation helper can resolve
       // the CLI-created worktree via findWorktreeById — it arrived from
       // the main process and is not yet in the renderer state.
-      await useAppStore.getState().fetchWorktrees(repoId)
+      await (options.ownerHostId
+        ? useAppStore.getState().fetchWorktrees(repoId, { ownerHostId: options.ownerHostId })
+        : useAppStore.getState().fetchWorktrees(repoId))
       const existsAfterFetch = Boolean(useAppStore.getState().getKnownWorktreeById(worktreeId))
       // Why: route through activateAndRevealWorktree so CLI-created
       // worktrees share the canonical activation path with UI-created
@@ -852,7 +862,12 @@ export function useIpcEvents(): void {
       environmentId: string,
       repoId: string
     ): Promise<void> => {
-      if ((useAppStore.getState().repos ?? []).some((repo) => repo.id === repoId)) {
+      const ownerHostId = toRuntimeExecutionHostId(environmentId)
+      if (
+        (useAppStore.getState().repos ?? []).some(
+          (repo) => repo.id === repoId && getRepoExecutionHostId(repo) === ownerHostId
+        )
+      ) {
         return
       }
       await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
@@ -862,14 +877,23 @@ export function useIpcEvents(): void {
       if (event.type === 'reposChanged') {
         const state = useAppStore.getState()
         void state.fetchRuntimeEnvironmentRepos(environmentId).then(async (repos) => {
-          await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
+          await Promise.all(
+            repos.map((repo) =>
+              useAppStore
+                .getState()
+                .fetchWorktrees(repo.id, { ownerHostId: getRepoExecutionHostId(repo) })
+            )
+          )
           await useAppStore.getState().fetchWorktreeLineage()
         })
         return
       }
       if (event.type === 'worktreesChanged') {
         void ensureRuntimeEventRepoKnown(environmentId, event.repoId).then(() =>
-          worktreeChangeRefreshQueue.enqueue({ repoId: event.repoId })
+          worktreeChangeRefreshQueue.enqueue({
+            repoId: event.repoId,
+            ownerHostId: toRuntimeExecutionHostId(environmentId)
+          })
         )
         return
       }
@@ -883,7 +907,12 @@ export function useIpcEvents(): void {
         return
       }
       void ensureRuntimeEventRepoKnown(environmentId, event.repoId)
-        .then(() => activateNotifiedWorktree(event, { allowRuntimeEnvironment: true }))
+        .then(() =>
+          activateNotifiedWorktree(event, {
+            allowRuntimeEnvironment: true,
+            ownerHostId: toRuntimeExecutionHostId(environmentId)
+          })
+        )
         .catch((error) => {
           console.error('Failed to activate runtime-created worktree:', error)
         })
@@ -2394,7 +2423,12 @@ export function useIpcEvents(): void {
         const remoteWorktreeIds = new Set(
           Object.values(store.worktreesByRepo)
             .flat()
-            .filter((w) => remoteRepos.some((r) => r.id === w.repoId))
+            .filter((worktree) =>
+              remoteRepos.some(
+                (repo) =>
+                  repo.id === worktree.repoId && worktree.hostId === getRepoExecutionHostId(repo)
+              )
+            )
             .map((w) => w.id)
         )
         for (const worktreeId of remoteWorktreeIds) {
@@ -2408,16 +2442,24 @@ export function useIpcEvents(): void {
       }
 
       if (state.status === 'connected') {
-        void Promise.all(remoteRepos.map((r) => store.fetchWorktrees(r.id))).then(async () => {
+        void Promise.all(
+          remoteRepos.map((repo) =>
+            store.fetchWorktrees(repo.id, { ownerHostId: getRepoExecutionHostId(repo) })
+          )
+        ).then(async () => {
           await useAppStore.getState().fetchWorktreeLineage()
           // Why: terminal panes that failed to spawn (no PTY provider on cold
           // start) sit inert. Bumping generation forces TerminalPane to remount
           // and retry pty:spawn. Only bump tabs with no live ptyId.
           const freshStore = useAppStore.getState()
-          const remoteRepoIds = new Set(remoteRepos.map((r) => r.id))
           const worktreeIds = Object.values(freshStore.worktreesByRepo)
             .flat()
-            .filter((w) => remoteRepoIds.has(w.repoId))
+            .filter((worktree) =>
+              remoteRepos.some(
+                (repo) =>
+                  repo.id === worktree.repoId && worktree.hostId === getRepoExecutionHostId(repo)
+              )
+            )
             .map((w) => w.id)
 
           for (const worktreeId of worktreeIds) {

--- a/src/renderer/src/hooks/worktree-change-refresh-queue.ts
+++ b/src/renderer/src/hooks/worktree-change-refresh-queue.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from '../../../shared/execution-host'
+
 type WorktreeRename = {
   oldWorktreeId: string
   newWorktreeId: string
@@ -5,16 +7,23 @@ type WorktreeRename = {
 
 type WorktreeChangeEvent = {
   repoId: string
+  ownerHostId?: ExecutionHostId
   renamed?: WorktreeRename
 }
 
-type WorktreeChangeRefreshHandler = (repoId: string, renamed?: WorktreeRename) => Promise<void>
+type WorktreeChangeRefreshHandler = (
+  repoId: string,
+  ownerHostId?: ExecutionHostId,
+  renamed?: WorktreeRename
+) => Promise<void>
 
 type QueuedWorktreeChange = {
   renamed?: WorktreeRename
 }
 
 type RepoRefreshState = {
+  repoId: string
+  ownerHostId?: ExecutionHostId
   running: boolean
   queue: QueuedWorktreeChange[]
 }
@@ -28,13 +37,16 @@ export function createWorktreeChangeRefreshQueue(
 ): WorktreeChangeRefreshQueue {
   const states = new Map<string, RepoRefreshState>()
 
-  const drain = async (repoId: string, state: RepoRefreshState): Promise<void> => {
+  const getRefreshKey = (event: Pick<WorktreeChangeEvent, 'repoId' | 'ownerHostId'>) =>
+    `${event.ownerHostId ?? 'focused'}\0${event.repoId}`
+
+  const drain = async (key: string, state: RepoRefreshState): Promise<void> => {
     state.running = true
     try {
       while (state.queue.length > 0) {
         const next = state.queue.shift()
         try {
-          await handler(repoId, next?.renamed)
+          await handler(state.repoId, state.ownerHostId, next?.renamed)
         } catch (error) {
           console.error('Failed to refresh changed worktrees:', error)
         }
@@ -42,19 +54,20 @@ export function createWorktreeChangeRefreshQueue(
     } finally {
       state.running = false
       if (state.queue.length === 0) {
-        states.delete(repoId)
+        states.delete(key)
       } else {
-        void drain(repoId, state)
+        void drain(key, state)
       }
     }
   }
 
   return {
     enqueue(event) {
-      let state = states.get(event.repoId)
+      const key = getRefreshKey(event)
+      let state = states.get(key)
       if (!state) {
-        state = { running: false, queue: [] }
-        states.set(event.repoId, state)
+        state = { repoId: event.repoId, ownerHostId: event.ownerHostId, running: false, queue: [] }
+        states.set(key, state)
       }
 
       if (event.renamed) {
@@ -69,7 +82,7 @@ export function createWorktreeChangeRefreshQueue(
       }
 
       if (!state.running) {
-        void drain(event.repoId, state)
+        void drain(key, state)
       }
     }
   }

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -200,4 +200,32 @@ describe('project-host workspace target resolution', () => {
       reason: 'setup-not-ready'
     })
   })
+
+  it('resolves an explicit same-id setup on the requested host', () => {
+    const repos = [
+      makeRepo('orca-local'),
+      makeRepo('orca-runtime', { executionHostId: 'runtime:gpu' })
+    ]
+    const projects = [makeProject('github:stablyai/orca', ['orca-local', 'orca-runtime'])]
+    const projectHostSetups = [
+      makeSetup('shared-setup', 'github:stablyai/orca', 'local', 'orca-local'),
+      makeSetup('shared-setup', 'github:stablyai/orca', 'runtime:gpu', 'orca-runtime')
+    ]
+
+    expect(
+      resolveWorkspaceCreationTarget({
+        eligibleRepos: repos,
+        projects,
+        projectHostSetups,
+        projectHostSetupId: 'shared-setup',
+        hostId: 'runtime:gpu'
+      })
+    ).toMatchObject({
+      status: 'ready',
+      target: {
+        hostId: 'runtime:gpu',
+        repoId: 'orca-runtime'
+      }
+    })
+  })
 })

--- a/src/renderer/src/lib/project-host-workspace-target.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.ts
@@ -123,7 +123,9 @@ export function resolveWorkspaceCreationTarget(
   const setups = model?.setups ?? []
 
   if (projectHostSetupId) {
-    const setup = setups.find((entry) => entry.id === projectHostSetupId)
+    const setup = setups.find(
+      (entry) => entry.id === projectHostSetupId && (!hostId || entry.hostId === hostId)
+    )
     if (!setup) {
       return { status: 'unavailable', reason: 'setup-not-found' }
     }

--- a/src/renderer/src/lib/repo-runtime-owner.test.ts
+++ b/src/renderer/src/lib/repo-runtime-owner.test.ts
@@ -19,6 +19,21 @@ describe('getRuntimeEnvironmentIdForRepo', () => {
     ).toBe('owner-runtime')
   })
 
+  it('matches duplicate repos against encoded focused runtime host ids', () => {
+    expect(
+      getRuntimeEnvironmentIdForRepo(
+        {
+          settings: { activeRuntimeEnvironmentId: 'prod/server' },
+          repos: [
+            { id: 'repo-1', connectionId: null, executionHostId: 'local' },
+            { id: 'repo-1', connectionId: null, executionHostId: 'runtime:prod%2Fserver' }
+          ]
+        },
+        'repo-1'
+      )
+    ).toBe('prod/server')
+  })
+
   it('keeps explicit local repos local while a runtime is focused', () => {
     expect(
       getRuntimeEnvironmentIdForRepo(

--- a/src/renderer/src/lib/repo-runtime-owner.ts
+++ b/src/renderer/src/lib/repo-runtime-owner.ts
@@ -1,4 +1,9 @@
-import { getRepoExecutionHostId, parseExecutionHostId } from '../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  toRuntimeExecutionHostId
+} from '../../../shared/execution-host'
 import type { GlobalSettings, Repo } from '../../../shared/types'
 
 export type RepoRuntimeOwnerState = {
@@ -13,13 +18,25 @@ export function getRuntimeEnvironmentIdForRepo(
   if (!repoId) {
     return null
   }
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repos = state.repos?.filter((entry) => entry.id === repoId) ?? []
+  const repo = getActiveHostRepo(state, repos) ?? repos[0]
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
     return parsed?.kind === 'runtime' ? parsed.environmentId : null
   }
   return state.settings?.activeRuntimeEnvironmentId?.trim() || null
+}
+
+function getActiveHostRepo(
+  state: RepoRuntimeOwnerState,
+  repos: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[]
+): Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> | undefined {
+  const activeRuntimeId = state.settings?.activeRuntimeEnvironmentId?.trim()
+  const activeHostId = activeRuntimeId
+    ? toRuntimeExecutionHostId(activeRuntimeId)
+    : LOCAL_EXECUTION_HOST_ID
+  return repos.find((repo) => getRepoExecutionHostId(repo) === activeHostId)
 }
 
 export function getSettingsForRepoRuntimeOwner(

--- a/src/renderer/src/lib/worktree-runtime-owner.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.test.ts
@@ -42,6 +42,48 @@ describe('getSettingsForWorktreeRuntimeOwner', () => {
     })
   })
 
+  it('uses the worktree host when duplicate repo ids exist on local and runtime hosts', () => {
+    const duplicateState: WorktreeRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: null },
+      repos: [
+        { id: 'same-repo', connectionId: null, executionHostId: 'local' },
+        { id: 'same-repo', connectionId: null, executionHostId: 'runtime:env-1' }
+      ],
+      worktreesByRepo: {
+        'same-repo': [
+          { id: 'same-repo::/local/wt', repoId: 'same-repo', hostId: 'local' },
+          { id: 'same-repo::/runtime/wt', repoId: 'same-repo', hostId: 'runtime:env-1' }
+        ]
+      }
+    }
+
+    expect(getSettingsForWorktreeRuntimeOwner(duplicateState, 'same-repo::/runtime/wt')).toEqual({
+      activeRuntimeEnvironmentId: 'env-1'
+    })
+    expect(getExecutionHostIdForWorktree(duplicateState, 'same-repo::/runtime/wt')).toBe(
+      'runtime:env-1'
+    )
+  })
+
+  it('uses a stamped worktree host even before the matching repo row is loaded', () => {
+    const partialState: WorktreeRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: 'focused-env' },
+      repos: [],
+      worktreesByRepo: {
+        'same-repo': [
+          { id: 'same-repo::/runtime/wt', repoId: 'same-repo', hostId: 'runtime:env-1' }
+        ]
+      }
+    }
+
+    expect(getSettingsForWorktreeRuntimeOwner(partialState, 'same-repo::/runtime/wt')).toEqual({
+      activeRuntimeEnvironmentId: 'env-1'
+    })
+    expect(getExecutionHostIdForWorktree(partialState, 'same-repo::/runtime/wt')).toBe(
+      'runtime:env-1'
+    )
+  })
+
   it('routes folder workspaces to their project group runtime owner', () => {
     expect(getSettingsForWorktreeRuntimeOwner(state, 'folder:runtime-folder')).toEqual({
       activeRuntimeEnvironmentId: 'folder-env'

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -13,22 +13,43 @@ import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
 export type WorktreeRuntimeOwnerState = {
   repos?: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[]
   settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
-  worktreesByRepo?: Record<string, readonly Pick<Worktree, 'id' | 'repoId'>[]>
+  worktreesByRepo?: Record<string, readonly Pick<Worktree, 'id' | 'repoId' | 'hostId'>[]>
   folderWorkspaces?: readonly Pick<FolderWorkspace, 'id' | 'projectGroupId'>[]
   projectGroups?: readonly Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>[]
 }
 
-function findWorktreeRepoId(
+function findWorktree(
   worktreesByRepo: WorktreeRuntimeOwnerState['worktreesByRepo'],
   worktreeId: string
-): string | null {
+): Pick<Worktree, 'id' | 'repoId' | 'hostId'> | null {
   for (const worktrees of Object.values(worktreesByRepo ?? {})) {
     const match = worktrees.find((worktree) => worktree.id === worktreeId)
     if (match) {
-      return match.repoId
+      return match
     }
   }
   return null
+}
+
+function getWorktreeHostId(
+  state: WorktreeRuntimeOwnerState,
+  worktreeId: string
+): ExecutionHostId | null {
+  return findWorktree(state.worktreesByRepo, worktreeId)?.hostId ?? null
+}
+
+function findRepoForWorktree(
+  state: WorktreeRuntimeOwnerState,
+  worktreeId: string
+): Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> | undefined {
+  const worktree = findWorktree(state.worktreesByRepo, worktreeId)
+  const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
+  if (worktree?.hostId) {
+    return state.repos?.find(
+      (entry) => entry.id === repoId && getRepoExecutionHostId(entry) === worktree.hostId
+    )
+  }
+  return state.repos?.find((entry) => entry.id === repoId)
 }
 
 function findFolderProjectGroup(
@@ -86,13 +107,15 @@ export function getRuntimeEnvironmentIdForWorktree(
   if (workspaceScope?.type === 'folder') {
     return getRuntimeEnvironmentIdForFolderWorkspace(state, workspaceScope.folderWorkspaceId)
   }
-  const repoId =
-    findWorktreeRepoId(state.worktreesByRepo, worktreeId) ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repo = findRepoForWorktree(state, worktreeId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
     return parsed?.kind === 'runtime' ? parsed.environmentId : null
+  }
+  const parsedWorktreeHost = parseExecutionHostId(getWorktreeHostId(state, worktreeId))
+  if (parsedWorktreeHost) {
+    return parsedWorktreeHost.kind === 'runtime' ? parsedWorktreeHost.environmentId : null
   }
   return state.settings?.activeRuntimeEnvironmentId?.trim() || null
 }
@@ -108,12 +131,14 @@ export function getExecutionHostIdForWorktree(
   if (workspaceScope?.type === 'folder') {
     return getExecutionHostIdForFolderWorkspace(state, workspaceScope.folderWorkspaceId)
   }
-  const repoId =
-    findWorktreeRepoId(state.worktreesByRepo, worktreeId) ?? getRepoIdFromWorktreeId(worktreeId)
-  const repo = state.repos?.find((entry) => entry.id === repoId)
+  const repo = findRepoForWorktree(state, worktreeId)
   const hasExplicitOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
   if (repo && hasExplicitOwner) {
     return getRepoExecutionHostId(repo)
+  }
+  const worktreeHostId = getWorktreeHostId(state, worktreeId)
+  if (worktreeHostId) {
+    return worktreeHostId
   }
   const environmentId = state.settings?.activeRuntimeEnvironmentId?.trim()
   return environmentId ? `runtime:${encodeURIComponent(environmentId)}` : 'local'

--- a/src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts
+++ b/src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { projectHostSetupProjectionFromRepos } from '../../../../shared/project-host-setup-projection'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { ProjectHostSetup, Repo } from '../../../../shared/types'
+import {
+  mergeProjectHostSetupCompatibility,
+  projectCompatibilityFromRepos
+} from './project-host-setup-compatibility-merge'
+
+function repo(id: string, hostId: ExecutionHostId): Repo {
+  return {
+    id,
+    path: `/${hostId}/${id}`,
+    displayName: 'orca',
+    badgeColor: '#000000',
+    addedAt: 1,
+    executionHostId: hostId,
+    upstream: { owner: 'stablyai', repo: 'orca' }
+  }
+}
+
+function setup(
+  id: string,
+  hostId: ExecutionHostId,
+  repoId: string,
+  projectId = 'github:stablyai/orca'
+): ProjectHostSetup {
+  return {
+    id,
+    projectId,
+    hostId,
+    repoId,
+    path: `/${hostId}/${repoId}`,
+    displayName: repoId,
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+describe('mergeProjectHostSetupCompatibility', () => {
+  it('keeps every host checkout in a shared provider project after one host refreshes', () => {
+    const local = repo('local-repo', 'local')
+    const runtime = repo('runtime-repo', 'runtime:env-a')
+    const derived = projectCompatibilityFromRepos([local, runtime])
+    const fetched = projectHostSetupProjectionFromRepos([runtime])
+
+    const compatibility = mergeProjectHostSetupCompatibility(derived, fetched)
+
+    expect(compatibility.projects).toEqual([
+      expect.objectContaining({
+        id: 'github:stablyai/orca',
+        sourceRepoIds: ['local-repo', 'runtime-repo']
+      })
+    ])
+    expect(compatibility.projectHostSetups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ hostId: 'local', repoId: 'local-repo' }),
+        expect.objectContaining({ hostId: 'runtime:env-a', repoId: 'runtime-repo' })
+      ])
+    )
+  })
+
+  it('merges setup rows by host and repo when setup ids collide across hosts', () => {
+    const compatibility = mergeProjectHostSetupCompatibility(
+      {
+        projects: [],
+        projectHostSetups: [setup('same-id', 'local', 'repo-local')]
+      },
+      {
+        projects: [],
+        setups: [setup('same-id', 'runtime:env-a', 'repo-runtime')]
+      }
+    )
+
+    expect(compatibility.projectHostSetups).toEqual([
+      expect.objectContaining({ id: 'same-id', hostId: 'local', repoId: 'repo-local' }),
+      expect.objectContaining({ id: 'same-id', hostId: 'runtime:env-a', repoId: 'repo-runtime' })
+    ])
+  })
+
+  it('keeps independent same-host setups whose repo id is empty', () => {
+    const compatibility = mergeProjectHostSetupCompatibility(
+      {
+        projects: [],
+        projectHostSetups: [setup('setup-a', 'runtime:env-a', '', 'github:stablyai/orca')]
+      },
+      {
+        projects: [],
+        setups: [setup('setup-b', 'runtime:env-a', '', 'github:stablyai/other')]
+      }
+    )
+
+    expect(compatibility.projectHostSetups).toEqual([
+      expect.objectContaining({ id: 'setup-a', repoId: '', projectId: 'github:stablyai/orca' }),
+      expect.objectContaining({ id: 'setup-b', repoId: '', projectId: 'github:stablyai/other' })
+    ])
+  })
+})

--- a/src/renderer/src/store/slices/project-host-setup-compatibility-merge.ts
+++ b/src/renderer/src/store/slices/project-host-setup-compatibility-merge.ts
@@ -1,0 +1,78 @@
+import type { ProjectHostSetupProjection } from '../../../../shared/project-host-setup-projection'
+import { projectHostSetupProjectionFromRepos } from '../../../../shared/project-host-setup-projection'
+import type { Project, ProjectHostSetup, Repo } from '../../../../shared/types'
+
+export type ProjectHostSetupCompatibility = {
+  projects: Project[]
+  projectHostSetups: ProjectHostSetup[]
+}
+
+export function projectCompatibilityFromRepos(
+  repos: readonly Repo[]
+): ProjectHostSetupCompatibility {
+  const projection = projectHostSetupProjectionFromRepos(repos)
+  return {
+    projects: projection.projects,
+    projectHostSetups: projection.setups
+  }
+}
+
+export function mergeProjectHostSetupCompatibility(
+  derived: ProjectHostSetupCompatibility,
+  fetched: ProjectHostSetupProjection
+): ProjectHostSetupCompatibility {
+  const projectHostSetups = mergeByKey(
+    derived.projectHostSetups,
+    fetched.setups,
+    getProjectHostSetupOwnerKey,
+    (_base, overlay) => overlay
+  )
+  const setupProjectIds = new Set(projectHostSetups.map((setup) => setup.projectId))
+  const fetchedProjectIds = new Set(fetched.projects.map((project) => project.id))
+  return {
+    projects: mergeByKey(
+      derived.projects,
+      fetched.projects,
+      (project) => project.id,
+      mergeProject
+    ).filter((project) => fetchedProjectIds.has(project.id) || setupProjectIds.has(project.id)),
+    projectHostSetups
+  }
+}
+
+function getProjectHostSetupOwnerKey(setup: ProjectHostSetup): string {
+  // Why: repo-backed setups are owned by host + repo; independent setups store
+  // an empty repoId and must fall back to their setup id.
+  return `${setup.hostId}\0${setup.repoId || setup.id}`
+}
+
+function mergeProject(base: Project, overlay: Project): Project {
+  return {
+    ...base,
+    ...overlay,
+    // Why: a one-host refresh may fetch a project row that only lists that
+    // host's checkout; keep the other host setups attached to the project.
+    sourceRepoIds: [...new Set([...base.sourceRepoIds, ...overlay.sourceRepoIds])]
+  }
+}
+
+function mergeByKey<T>(
+  base: readonly T[],
+  overlay: readonly T[],
+  getKey: (entry: T) => string,
+  mergeEntry: (base: T, overlay: T) => T
+): T[] {
+  const merged = [...base]
+  const indexByKey = new Map(merged.map((entry, index) => [getKey(entry), index]))
+  for (const entry of overlay) {
+    const key = getKey(entry)
+    const index = indexByKey.get(key)
+    if (index === undefined) {
+      indexByKey.set(key, merged.length)
+      merged.push(entry)
+    } else {
+      merged[index] = mergeEntry(merged[index], entry)
+    }
+  }
+  return merged
+}

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/types'
+import { mergeFetchedReposForHost } from './repo-host-refresh-merge'
+
+function repo(id: string, hostId: ExecutionHostId, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path: `/${hostId}/${id}`,
+    displayName: id,
+    badgeColor: '#000000',
+    addedAt: 1,
+    executionHostId: hostId,
+    ...overrides
+  }
+}
+
+function idsByHost(repos: readonly Repo[]): Record<string, string[]> {
+  const result: Record<string, string[]> = {}
+  for (const entry of repos) {
+    const hostId = getRepoExecutionHostId(entry)
+    result[hostId] ??= []
+    result[hostId].push(entry.id)
+  }
+  return result
+}
+
+describe('mergeFetchedReposForHost', () => {
+  it('refreshes one host without dropping repos owned by another host', () => {
+    const previous = [
+      repo('local-a', 'local'),
+      repo('runtime-a', 'runtime:env-a'),
+      repo('runtime-stale', 'runtime:env-a')
+    ]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('runtime-a', 'runtime:env-a', { displayName: 'runtime renamed' })],
+      'runtime:env-a'
+    )
+
+    expect(idsByHost(merged)).toEqual({
+      local: ['local-a'],
+      'runtime:env-a': ['runtime-a']
+    })
+    expect(merged.find((entry) => entry.id === 'runtime-a')?.displayName).toBe('runtime renamed')
+  })
+
+  it('matches repos by host and id instead of id alone', () => {
+    const previous = [
+      repo('same-id', 'local', { path: '/local/orca' }),
+      repo('same-id', 'runtime:env-a', { path: '/srv/orca-old' })
+    ]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('same-id', 'runtime:env-a', { path: '/srv/orca-new' })],
+      'runtime:env-a'
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(merged.find((entry) => getRepoExecutionHostId(entry) === 'local')?.path).toBe(
+      '/local/orca'
+    )
+    expect(merged.find((entry) => getRepoExecutionHostId(entry) === 'runtime:env-a')?.path).toBe(
+      '/srv/orca-new'
+    )
+  })
+
+  it('adds a same-id repo on a new host without replacing the existing host repo', () => {
+    const previous = [repo('same-id', 'local', { path: '/local/orca' })]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('same-id', 'runtime:env-a', { path: '/srv/orca' })],
+      'runtime:env-a'
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(idsByHost(merged)).toEqual({
+      local: ['same-id'],
+      'runtime:env-a': ['same-id']
+    })
+  })
+})

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
@@ -83,4 +83,20 @@ describe('mergeFetchedReposForHost', () => {
       'runtime:env-a': ['same-id']
     })
   })
+
+  it('applies the fetched order for the refreshed host', () => {
+    const local = repo('local-a', 'local')
+    const runtimeA = repo('runtime-a', 'runtime:env-a')
+    const runtimeB = repo('runtime-b', 'runtime:env-a')
+    const runtimeC = repo('runtime-c', 'runtime:env-a')
+    const previous = [local, runtimeA, runtimeB, runtimeC]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [runtimeC, runtimeB, runtimeA],
+      'runtime:env-a'
+    )
+
+    expect(merged).toEqual([local, runtimeC, runtimeB, runtimeA])
+  })
 })

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.ts
@@ -1,0 +1,34 @@
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/types'
+import { reconcileFetchedRepos } from './repo-identity-reconcile'
+
+function getRepoOwnerKey(repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>): string {
+  // Why: repo ids are only guaranteed unique inside one host's store. A runtime
+  // refresh must not replace a same-id local or sibling-runtime checkout.
+  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
+}
+
+export function mergeFetchedReposForHost(
+  previous: readonly Repo[],
+  fetched: Repo[],
+  hostId: ExecutionHostId
+): Repo[] {
+  const fetchedOwnerKeys = new Set(fetched.map(getRepoOwnerKey))
+  const preserved = previous.filter((repo) => {
+    const existingHostId = getRepoExecutionHostId(repo)
+    return existingHostId !== hostId || fetchedOwnerKeys.has(getRepoOwnerKey(repo))
+  })
+  const merged = [...preserved]
+  const indexByOwnerKey = new Map(merged.map((repo, index) => [getRepoOwnerKey(repo), index]))
+  for (const repo of fetched) {
+    const ownerKey = getRepoOwnerKey(repo)
+    const existingIndex = indexByOwnerKey.get(ownerKey)
+    if (existingIndex === undefined) {
+      indexByOwnerKey.set(ownerKey, merged.length)
+      merged.push(repo)
+      continue
+    }
+    merged[existingIndex] = repo
+  }
+  return reconcileFetchedRepos(previous, merged)
+}

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.ts
@@ -2,33 +2,17 @@ import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared
 import type { Repo } from '../../../../shared/types'
 import { reconcileFetchedRepos } from './repo-identity-reconcile'
 
-function getRepoOwnerKey(repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>): string {
-  // Why: repo ids are only guaranteed unique inside one host's store. A runtime
-  // refresh must not replace a same-id local or sibling-runtime checkout.
-  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
-}
-
 export function mergeFetchedReposForHost(
   previous: readonly Repo[],
   fetched: Repo[],
   hostId: ExecutionHostId
 ): Repo[] {
-  const fetchedOwnerKeys = new Set(fetched.map(getRepoOwnerKey))
-  const preserved = previous.filter((repo) => {
-    const existingHostId = getRepoExecutionHostId(repo)
-    return existingHostId !== hostId || fetchedOwnerKeys.has(getRepoOwnerKey(repo))
-  })
-  const merged = [...preserved]
-  const indexByOwnerKey = new Map(merged.map((repo, index) => [getRepoOwnerKey(repo), index]))
-  for (const repo of fetched) {
-    const ownerKey = getRepoOwnerKey(repo)
-    const existingIndex = indexByOwnerKey.get(ownerKey)
-    if (existingIndex === undefined) {
-      indexByOwnerKey.set(ownerKey, merged.length)
-      merged.push(repo)
-      continue
-    }
-    merged[existingIndex] = repo
+  const firstHostIndex = previous.findIndex((repo) => getRepoExecutionHostId(repo) === hostId)
+  const preserved = previous.filter((repo) => getRepoExecutionHostId(repo) !== hostId)
+  if (firstHostIndex === -1) {
+    return reconcileFetchedRepos(previous, [...preserved, ...fetched])
   }
+  const insertAt = Math.min(firstHostIndex, preserved.length)
+  const merged = [...preserved.slice(0, insertAt), ...fetched, ...preserved.slice(insertAt)]
   return reconcileFetchedRepos(previous, merged)
 }

--- a/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
@@ -39,6 +39,22 @@ describe('reconcileFetchedRepos', () => {
     expect(result[0]).toBe(next[0])
   })
 
+  it('keys object reuse by repo id and execution host', () => {
+    const previous = [
+      makeRepo('same-id', { executionHostId: 'local', path: '/local/orca' }),
+      makeRepo('same-id', { executionHostId: 'runtime:env-a', path: '/srv/orca' })
+    ]
+    const next = [
+      makeRepo('same-id', { executionHostId: 'runtime:env-a', path: '/srv/orca' }),
+      makeRepo('same-id', { executionHostId: 'local', path: '/local/orca' })
+    ]
+
+    const result = reconcileFetchedRepos(previous, next)
+
+    expect(result[0]).toBe(previous[1])
+    expect(result[1]).toBe(previous[0])
+  })
+
   it('returns a rebuilt array when repos are added or removed', () => {
     const previous = [makeRepo('a')]
     const next = [makeRepo('a'), makeRepo('b')]

--- a/src/renderer/src/store/slices/repo-identity-reconcile.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.ts
@@ -1,3 +1,4 @@
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/types'
 
 // Why: after a drag-reorder we optimistically set `repos`, persist, and main
@@ -27,10 +28,10 @@ function areReposEqual(a: Repo, b: Repo): boolean {
 }
 
 export function reconcileFetchedRepos(previous: readonly Repo[], next: Repo[]): Repo[] {
-  const previousById = new Map(previous.map((repo) => [repo.id, repo]))
+  const previousByIdentity = new Map(previous.map((repo) => [getRepoIdentityKey(repo), repo]))
   let identical = next.length === previous.length
   const reconciled = next.map((repo, index) => {
-    const existing = previousById.get(repo.id)
+    const existing = previousByIdentity.get(getRepoIdentityKey(repo))
     if (existing && areReposEqual(existing, repo)) {
       if (existing !== previous[index]) {
         identical = false
@@ -41,4 +42,8 @@ export function reconcileFetchedRepos(previous: readonly Repo[], next: Repo[]): 
     return repo
   })
   return identical ? (previous as Repo[]) : reconciled
+}
+
+function getRepoIdentityKey(repo: Repo): string {
+  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
 }

--- a/src/renderer/src/store/slices/repo-reorder-host-split.test.ts
+++ b/src/renderer/src/store/slices/repo-reorder-host-split.test.ts
@@ -43,4 +43,21 @@ describe('splitRepoReorderByHost', () => {
     })
     expect(groups).toEqual([{ hostId: 'local', orderedIds: ['a'] }])
   })
+
+  it('keeps duplicate repo ids assigned to their distinct hosts', () => {
+    const groups = splitRepoReorderByHost(
+      ['github:stablyai/orca', 'local-a', 'github:stablyai/orca'],
+      [
+        repo('github:stablyai/orca', 'runtime:env-1'),
+        repo('local-a', 'local'),
+        repo('github:stablyai/orca', 'runtime:env-2')
+      ],
+      { activeRuntimeEnvironmentId: null }
+    )
+    expect(groups).toEqual([
+      { hostId: 'runtime:env-1', orderedIds: ['github:stablyai/orca'] },
+      { hostId: 'local', orderedIds: ['local-a'] },
+      { hostId: 'runtime:env-2', orderedIds: ['github:stablyai/orca'] }
+    ])
+  })
 })

--- a/src/renderer/src/store/slices/repo-reorder-host-split.ts
+++ b/src/renderer/src/store/slices/repo-reorder-host-split.ts
@@ -25,14 +25,20 @@ export function splitRepoReorderByHost(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
 ): RepoReorderHostGroup[] {
   const focusedHostId = getSettingsFocusedExecutionHostId(settings)
-  const hostByRepoId = new Map<string, string>()
+  const hostIdsByRepoId = new Map<string, string[]>()
   for (const repo of repos) {
     const hasExplicitOwner = Boolean(repo.executionHostId?.trim() || repo.connectionId?.trim())
-    hostByRepoId.set(repo.id, hasExplicitOwner ? getRepoExecutionHostId(repo) : focusedHostId)
+    const hostId = hasExplicitOwner ? getRepoExecutionHostId(repo) : focusedHostId
+    const existing = hostIdsByRepoId.get(repo.id)
+    if (existing) {
+      existing.push(hostId)
+    } else {
+      hostIdsByRepoId.set(repo.id, [hostId])
+    }
   }
   const groups = new Map<string, string[]>()
   for (const id of orderedIds) {
-    const hostId = hostByRepoId.get(id)
+    const hostId = hostIdsByRepoId.get(id)?.shift()
     if (!hostId) {
       continue
     }

--- a/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
+++ b/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const localRepo: Repo = {
+  id: 'same-repo',
+  path: '/Users/alice/orca',
+  displayName: 'local orca',
+  badgeColor: '#000000',
+  addedAt: 1
+}
+
+const runtimeRepo: Repo = {
+  id: 'same-repo',
+  path: '/srv/orca',
+  displayName: 'remote orca',
+  badgeColor: '#111111',
+  addedAt: 2
+}
+
+const reposList = vi.fn()
+const reposUpdate = vi.fn()
+const projectsList = vi.fn()
+const projectsListHostSetups = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposList.mockReset()
+  reposUpdate.mockReset()
+  projectsList.mockReset()
+  projectsListHostSetups.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+  projectsList.mockResolvedValue([])
+  projectsListHostSetups.mockResolvedValue([])
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: {
+        list: reposList,
+        update: reposUpdate
+      },
+      projects: {
+        list: projectsList,
+        listHostSetups: projectsListHostSetups
+      },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('repo slice multi-host refresh', () => {
+  it('keeps same-id local and runtime repos after switching hosts', async () => {
+    reposList.mockResolvedValue([localRepo])
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'repo.list') {
+        return Promise.resolve({
+          id: 'repo-list',
+          ok: true,
+          result: { repos: [runtimeRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'project.list') {
+        return Promise.resolve({
+          id: 'project-list',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          id: 'setup-list',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${method}`)
+    })
+    const store = createTestStore()
+
+    await store.getState().fetchRepos()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().repos).toHaveLength(2)
+    expect(store.getState().repos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: localRepo.id,
+          path: localRepo.path,
+          executionHostId: 'local'
+        }),
+        expect.objectContaining({
+          id: runtimeRepo.id,
+          path: runtimeRepo.path,
+          executionHostId: 'runtime:env-1'
+        })
+      ])
+    )
+  })
+
+  it('updates only the active host repo when ids collide across hosts', async () => {
+    reposList.mockResolvedValue([localRepo])
+    runtimeEnvironmentCall.mockImplementation((request: RuntimeEnvironmentCallRequest) => {
+      const { method } = request
+      if (method === 'repo.list') {
+        return Promise.resolve({
+          id: 'repo-list',
+          ok: true,
+          result: { repos: [runtimeRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'repo.update') {
+        const updates = (request as unknown as { params: { updates: Partial<Repo> } }).params
+          .updates
+        return Promise.resolve({
+          id: 'repo-update',
+          ok: true,
+          result: { repo: { ...runtimeRepo, ...updates } },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'project.list') {
+        return Promise.resolve({
+          id: 'project-list',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          id: 'setup-list',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${method}`)
+    })
+    const store = createTestStore()
+
+    await store.getState().fetchRepos()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    await store.getState().fetchRepos()
+    const updated = await store.getState().updateRepo(runtimeRepo.id, {
+      displayName: 'remote renamed'
+    })
+
+    expect(updated).toBe(true)
+    expect(reposUpdate).not.toHaveBeenCalled()
+    expect(store.getState().repos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: localRepo.id,
+          displayName: localRepo.displayName,
+          executionHostId: 'local'
+        }),
+        expect.objectContaining({
+          id: runtimeRepo.id,
+          displayName: 'remote renamed',
+          executionHostId: 'runtime:env-1'
+        })
+      ])
+    )
+  })
+})

--- a/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
+++ b/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
@@ -77,6 +77,16 @@ const projectsListHostSetups = vi.fn()
 const runtimeEnvironmentCall = vi.fn()
 const runtimeEnvironmentTransportCall = vi.fn()
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
 beforeEach(() => {
   clearRuntimeCompatibilityCacheForTests()
   reposList.mockReset()
@@ -272,6 +282,106 @@ describe('repo slice multi-host refresh', () => {
       expect.arrayContaining([
         expect.objectContaining({ hostId: 'local', repoId: localProjectRepo.id }),
         expect.objectContaining({ hostId: 'runtime:env-1', repoId: runtimeProjectRepo.id })
+      ])
+    )
+  })
+
+  it('does not update a legacy local repo when the active runtime owns a same-id row', async () => {
+    const legacyLocalRepo = { ...localRepo }
+    const runtimeOwnedRepo = { ...runtimeRepo, executionHostId: 'runtime:env-1' as const }
+    runtimeEnvironmentCall.mockImplementation((request: RuntimeEnvironmentCallRequest) => {
+      if (request.method === 'repo.update') {
+        const updates = (request as unknown as { params: { updates: Partial<Repo> } }).params
+          .updates
+        return Promise.resolve({
+          id: 'repo-update',
+          ok: true,
+          result: { repo: { ...runtimeRepo, ...updates } },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${request.method}`)
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [legacyLocalRepo, runtimeOwnedRepo]
+    })
+
+    const updated = await store.getState().updateRepo(runtimeRepo.id, {
+      displayName: 'remote renamed'
+    })
+
+    expect(updated).toBe(true)
+    expect(reposUpdate).not.toHaveBeenCalled()
+    expect(store.getState().repos).toEqual([
+      expect.objectContaining({
+        id: localRepo.id,
+        displayName: localRepo.displayName
+      }),
+      expect.objectContaining({
+        id: runtimeRepo.id,
+        displayName: 'remote renamed',
+        executionHostId: 'runtime:env-1'
+      })
+    ])
+  })
+
+  it('merges concurrent local and runtime refreshes against the latest repo state', async () => {
+    const localList = deferred<Repo[]>()
+    const runtimeList = deferred<{
+      id: string
+      ok: true
+      result: { repos: Repo[] }
+      _meta: { runtimeId: string }
+    }>()
+    reposList.mockReturnValue(localList.promise)
+    runtimeEnvironmentCall.mockImplementation((request: RuntimeEnvironmentCallRequest) => {
+      if (request.method === 'repo.list') {
+        return runtimeList.promise
+      }
+      if (request.method === 'project.list') {
+        return Promise.resolve({
+          id: 'project-list',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (request.method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          id: 'setup-list',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${request.method}`)
+    })
+    const store = createTestStore()
+
+    const localRefresh = store.getState().fetchRepos()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    const runtimeRefresh = store.getState().fetchRepos()
+
+    runtimeList.resolve({
+      id: 'repo-list',
+      ok: true,
+      result: { repos: [runtimeRepo] },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    await runtimeRefresh
+    expect(store.getState().repos).toEqual([
+      expect.objectContaining({ id: runtimeRepo.id, executionHostId: 'runtime:env-1' })
+    ])
+
+    localList.resolve([localRepo])
+    await localRefresh
+
+    expect(store.getState().repos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: localRepo.id, executionHostId: 'local' }),
+        expect.objectContaining({ id: runtimeRepo.id, executionHostId: 'runtime:env-1' })
       ])
     )
   })

--- a/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
+++ b/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Repo } from '../../../../shared/types'
+import type { Project, ProjectHostSetup, Repo } from '../../../../shared/types'
 import {
   createCompatibleRuntimeStatusResponseIfNeeded,
   type RuntimeEnvironmentCallRequest
@@ -21,6 +21,53 @@ const runtimeRepo: Repo = {
   displayName: 'remote orca',
   badgeColor: '#111111',
   addedAt: 2
+}
+
+const PROJECT_ID = 'github:stablyai/orca'
+
+const localProjectRepo: Repo = {
+  id: 'local-repo',
+  path: '/Users/alice/shared-orca',
+  displayName: 'local shared orca',
+  badgeColor: '#000000',
+  addedAt: 1,
+  upstream: { owner: 'stablyai', repo: 'orca' }
+}
+
+const runtimeProjectRepo: Repo = {
+  id: 'runtime-repo',
+  path: '/srv/shared-orca',
+  displayName: 'remote shared orca',
+  badgeColor: '#111111',
+  addedAt: 2,
+  upstream: { owner: 'stablyai', repo: 'orca' }
+}
+
+function project(sourceRepoIds: string[]): Project {
+  return {
+    id: PROJECT_ID,
+    displayName: 'orca',
+    badgeColor: '#000000',
+    sourceRepoIds,
+    providerIdentity: { provider: 'github', owner: 'stablyai', repo: 'orca' },
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+function setup(hostId: 'local' | `runtime:${string}`, repo: Repo): ProjectHostSetup {
+  return {
+    id: repo.id,
+    projectId: PROJECT_ID,
+    hostId,
+    repoId: repo.id,
+    path: repo.path,
+    displayName: repo.displayName,
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1
+  }
 }
 
 const reposList = vi.fn()
@@ -174,6 +221,57 @@ describe('repo slice multi-host refresh', () => {
           displayName: 'remote renamed',
           executionHostId: 'runtime:env-1'
         })
+      ])
+    )
+  })
+
+  it('keeps every host checkout in a shared provider project after switching hosts', async () => {
+    reposList.mockResolvedValue([localProjectRepo])
+    projectsList.mockResolvedValue([project([localProjectRepo.id])])
+    projectsListHostSetups.mockResolvedValue([setup('local', localProjectRepo)])
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'repo.list') {
+        return Promise.resolve({
+          id: 'repo-list',
+          ok: true,
+          result: { repos: [runtimeProjectRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'project.list') {
+        return Promise.resolve({
+          id: 'project-list',
+          ok: true,
+          result: { projects: [project([runtimeProjectRepo.id])] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          id: 'setup-list',
+          ok: true,
+          result: { setups: [setup('runtime:env-1', runtimeProjectRepo)] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${method}`)
+    })
+    const store = createTestStore()
+
+    await store.getState().fetchRepos()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects).toEqual([
+      expect.objectContaining({
+        id: PROJECT_ID,
+        sourceRepoIds: [localProjectRepo.id, runtimeProjectRepo.id]
+      })
+    ])
+    expect(store.getState().projectHostSetups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ hostId: 'local', repoId: localProjectRepo.id }),
+        expect.objectContaining({ hostId: 'runtime:env-1', repoId: runtimeProjectRepo.id })
       ])
     )
   })

--- a/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
@@ -141,6 +141,58 @@ describe('repo slice project host setup lifecycle', () => {
     })
   })
 
+  it('updates same-id project host setup through the requested host', async () => {
+    const localSetup: ProjectHostSetup = {
+      ...runtimeSetup,
+      hostId: 'local',
+      displayName: 'Local'
+    }
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-update-setup',
+      ok: true,
+      result: {
+        result: {
+          project,
+          setup: { ...runtimeSetup, displayName: 'GPU VM renamed' }
+        }
+      },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      projectHostSetups: [localSetup, runtimeSetup],
+      settings: { activeRuntimeEnvironmentId: null } as never
+    })
+
+    await expect(
+      store.getState().updateProjectHostSetup({
+        setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId,
+        updates: { displayName: 'GPU VM renamed' }
+      })
+    ).resolves.toEqual({
+      project,
+      setup: { ...runtimeSetup, displayName: 'GPU VM renamed' },
+      repo: undefined
+    })
+
+    expect(projectsUpdateHostSetup).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectHostSetup.update',
+      params: {
+        setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId,
+        updates: { displayName: 'GPU VM renamed' }
+      },
+      timeoutMs: 15_000
+    })
+    expect(store.getState().projectHostSetups).toEqual([
+      localSetup,
+      { ...runtimeSetup, displayName: 'GPU VM renamed' }
+    ])
+  })
+
   it('deletes runtime-owned project host setups through their owning runtime', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'rpc-delete-setup',
@@ -169,6 +221,49 @@ describe('repo slice project host setup lifecycle', () => {
       selector: 'env-1',
       method: 'projectHostSetup.delete',
       params: { setupId: runtimeSetup.id },
+      timeoutMs: 15_000
+    })
+  })
+
+  it('deletes same-id project host setup through the requested host', async () => {
+    const localSetup: ProjectHostSetup = {
+      ...runtimeSetup,
+      hostId: 'local',
+      displayName: 'Local'
+    }
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-delete-setup',
+      ok: true,
+      result: { result: { project, setup: runtimeSetup } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      projects: [project],
+      projectHostSetups: [localSetup, runtimeSetup],
+      settings: { activeRuntimeEnvironmentId: null } as never
+    })
+
+    await expect(
+      store.getState().deleteProjectHostSetup({
+        setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId
+      })
+    ).resolves.toEqual({
+      project,
+      setup: runtimeSetup,
+      repo: undefined
+    })
+
+    expect(projectsDeleteHostSetup).not.toHaveBeenCalled()
+    expect(store.getState().projectHostSetups).toEqual([localSetup])
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectHostSetup.delete',
+      params: {
+        setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId
+      },
       timeoutMs: 15_000
     })
   })

--- a/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
+++ b/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import { createTestStore, makeWorktree } from './store-test-helpers'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+
+const repoId = 'github:stablyai/orca'
+
+const baseRepo: Repo = {
+  id: repoId,
+  path: '/env-one/orca',
+  displayName: 'Orca',
+  badgeColor: '#111',
+  addedAt: 1
+}
+
+const reposRemove = vi.fn()
+const reposReorder = vi.fn()
+const ptyKill = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+function runtimeRepo(environmentId: string, path: string, displayName: string): Repo {
+  return {
+    ...baseRepo,
+    path,
+    displayName,
+    executionHostId: `runtime:${environmentId}`
+  }
+}
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposRemove.mockReset()
+  reposReorder.mockReset()
+  ptyKill.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentCall.mockResolvedValue({
+    id: 'rpc-same-id-host-mutation',
+    ok: true,
+    result: { status: 'applied' },
+    _meta: { runtimeId: 'runtime-remote' }
+  })
+  runtimeEnvironmentTransportCall.mockReset()
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: {
+        remove: reposRemove,
+        reorder: reposReorder
+      },
+      pty: { kill: ptyKill },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('repo slice same-id host mutations', () => {
+  it('keeps sibling host repos and worktrees when removing the active remote host row', async () => {
+    const envOneRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
+    const envTwoRepo = runtimeRepo('env-2', '/env-two/orca', 'Orca on env two')
+    const envOneWorktree = makeWorktree({
+      id: `${repoId}::/env-one/wt`,
+      repoId,
+      path: '/env-one/wt',
+      hostId: 'runtime:env-1'
+    })
+    const envTwoWorktree = makeWorktree({
+      id: `${repoId}::/env-two/wt`,
+      repoId,
+      path: '/env-two/wt',
+      hostId: 'runtime:env-2'
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [envOneRepo, envTwoRepo],
+      activeRepoId: repoId,
+      filterRepoIds: [repoId],
+      worktreesByRepo: { [repoId]: [envOneWorktree, envTwoWorktree] },
+      detectedWorktreesByRepo: {
+        [repoId]: {
+          repoId,
+          authoritative: true,
+          source: 'git',
+          worktrees: [
+            {
+              ...envOneWorktree,
+              ownership: 'orca-managed',
+              selectedCheckout: false,
+              visible: true
+            },
+            { ...envTwoWorktree, ownership: 'orca-managed', selectedCheckout: false, visible: true }
+          ]
+        }
+      },
+      tabsByWorktree: {
+        [envOneWorktree.id]: [{ id: 'tab-env-one', worktreeId: envOneWorktree.id }] as never,
+        [envTwoWorktree.id]: [{ id: 'tab-env-two', worktreeId: envTwoWorktree.id }] as never
+      },
+      ptyIdsByTabId: {
+        'tab-env-one': ['remote:env-one'],
+        'tab-env-two': ['remote:env-two']
+      },
+      lastVisitedAtByWorktreeId: {
+        [envOneWorktree.id]: 1,
+        [envTwoWorktree.id]: 2
+      }
+    })
+
+    await store.getState().removeProject(repoId)
+
+    expect(store.getState().repos).toEqual([envTwoRepo])
+    expect(store.getState().worktreesByRepo[repoId]).toEqual([envTwoWorktree])
+    expect(store.getState().detectedWorktreesByRepo[repoId]?.worktrees).toEqual([
+      expect.objectContaining({ id: envTwoWorktree.id, hostId: 'runtime:env-2' })
+    ])
+    expect(store.getState().tabsByWorktree[envOneWorktree.id]).toBeUndefined()
+    expect(store.getState().tabsByWorktree[envTwoWorktree.id]).toEqual([
+      { id: 'tab-env-two', worktreeId: envTwoWorktree.id }
+    ])
+    expect(store.getState().lastVisitedAtByWorktreeId).toEqual({ [envTwoWorktree.id]: 2 })
+    expect(store.getState().activeRepoId).toBeNull()
+    expect(store.getState().filterRepoIds).toEqual([repoId])
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'repo.rm',
+      params: { repo: repoId },
+      timeoutMs: 15_000
+    })
+    expect(reposRemove).not.toHaveBeenCalled()
+  })
+
+  it('keeps same-id repos from distinct hosts when reordering', async () => {
+    const envOneRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
+    const envTwoRepo = runtimeRepo('env-2', '/env-two/orca', 'Orca on env two')
+    const store = createTestStore()
+    store.setState({ repos: [envOneRepo, envTwoRepo] })
+
+    await store.getState().reorderRepos([repoId, repoId])
+
+    expect(store.getState().repos).toEqual([envOneRepo, envTwoRepo])
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'repo.reorder',
+      params: { orderedIds: [repoId] },
+      timeoutMs: 15_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-2',
+      method: 'repo.reorder',
+      params: { orderedIds: [repoId] },
+      timeoutMs: 15_000
+    })
+  })
+})

--- a/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
+++ b/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
@@ -136,6 +136,55 @@ describe('repo slice same-id host mutations', () => {
     expect(reposRemove).not.toHaveBeenCalled()
   })
 
+  it('removes legacy local worktrees without dropping a same-id runtime sibling', async () => {
+    const legacyLocalRepo = { ...baseRepo, path: '/local/orca', displayName: 'Local Orca' }
+    const envRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
+    const legacyLocalWorktree = makeWorktree({
+      id: `${repoId}::/local/wt`,
+      repoId,
+      path: '/local/wt'
+    })
+    const envWorktree = makeWorktree({
+      id: `${repoId}::/env-one/wt`,
+      repoId,
+      path: '/env-one/wt',
+      hostId: 'runtime:env-1'
+    })
+    const store = createTestStore()
+    store.setState({
+      repos: [legacyLocalRepo, envRepo],
+      worktreesByRepo: { [repoId]: [legacyLocalWorktree, envWorktree] },
+      tabsByWorktree: {
+        [legacyLocalWorktree.id]: [
+          { id: 'tab-local', worktreeId: legacyLocalWorktree.id }
+        ] as never,
+        [envWorktree.id]: [{ id: 'tab-env', worktreeId: envWorktree.id }] as never
+      },
+      ptyIdsByTabId: {
+        'tab-local': ['local-pty'],
+        'tab-env': ['remote:env-one']
+      },
+      lastVisitedAtByWorktreeId: {
+        [legacyLocalWorktree.id]: 1,
+        [envWorktree.id]: 2
+      }
+    })
+
+    await store.getState().removeProject(repoId)
+
+    expect(reposRemove).toHaveBeenCalledWith({ repoId })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'repo.rm' })
+    )
+    expect(store.getState().repos).toEqual([envRepo])
+    expect(store.getState().worktreesByRepo[repoId]).toEqual([envWorktree])
+    expect(store.getState().tabsByWorktree[legacyLocalWorktree.id]).toBeUndefined()
+    expect(store.getState().tabsByWorktree[envWorktree.id]).toEqual([
+      { id: 'tab-env', worktreeId: envWorktree.id }
+    ])
+    expect(store.getState().lastVisitedAtByWorktreeId).toEqual({ [envWorktree.id]: 2 })
+  })
+
   it('keeps same-id repos from distinct hosts when reordering', async () => {
     const envOneRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
     const envTwoRepo = runtimeRepo('env-2', '/env-two/orca', 'Orca on env two')

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -48,6 +48,10 @@ import { getRepoIdFromWorktreeId } from './worktree-helpers'
 import { mergeFetchedReposForHost } from './repo-host-refresh-merge'
 import { splitRepoReorderByHost } from './repo-reorder-host-split'
 import {
+  mergeProjectHostSetupCompatibility,
+  projectCompatibilityFromRepos
+} from './project-host-setup-compatibility-merge'
+import {
   assertRuntimeEnvironmentCapability,
   callRuntimeRpc,
   getActiveRuntimeTarget
@@ -429,54 +433,6 @@ async function assertProjectHostSetupMutationRuntimeCapabilities(
   )
 }
 
-function projectCompatibilityFromRepos(
-  repos: readonly Repo[]
-): Pick<RepoSlice, 'projects' | 'projectHostSetups'> {
-  const projection = projectHostSetupProjectionFromRepos(repos)
-  return {
-    projects: projection.projects,
-    projectHostSetups: projection.setups
-  }
-}
-
-function mergeProjectHostSetupCompatibility(
-  derived: Pick<RepoSlice, 'projects' | 'projectHostSetups'>,
-  fetched: ProjectHostSetupProjection
-): Pick<RepoSlice, 'projects' | 'projectHostSetups'> {
-  const fetchedSetupOwners = new Set(fetched.setups.map(getProjectHostSetupOwnerKey))
-  const derivedSetups = derived.projectHostSetups.filter(
-    (setup) => !fetchedSetupOwners.has(getProjectHostSetupOwnerKey(setup))
-  )
-  const projectHostSetups = mergeById(derivedSetups, fetched.setups)
-  const setupProjectIds = new Set(projectHostSetups.map((setup) => setup.projectId))
-  const fetchedProjectIds = new Set(fetched.projects.map((project) => project.id))
-  return {
-    projects: mergeById(derived.projects, fetched.projects).filter(
-      (project) => fetchedProjectIds.has(project.id) || setupProjectIds.has(project.id)
-    ),
-    projectHostSetups
-  }
-}
-
-function getProjectHostSetupOwnerKey(setup: ProjectHostSetup): string {
-  return `${setup.hostId}:${setup.repoId ?? setup.id}`
-}
-
-function mergeById<T extends { id: string }>(base: readonly T[], overlay: readonly T[]): T[] {
-  const merged = [...base]
-  const indexById = new Map(merged.map((entry, index) => [entry.id, index]))
-  for (const entry of overlay) {
-    const index = indexById.get(entry.id)
-    if (index === undefined) {
-      indexById.set(entry.id, merged.length)
-      merged.push(entry)
-    } else {
-      merged[index] = entry
-    }
-  }
-  return merged
-}
-
 async function fetchReposForTarget(
   target: ReturnType<typeof getActiveRuntimeTarget>,
   currentRepos: readonly Repo[]
@@ -497,16 +453,10 @@ async function fetchReposForTarget(
   const repos = fetchedRepos.map((repo) => repoWithFetchedOwner(repo, target))
   const fetchedProjectCompatibility = await fetchProjectHostSetupCompatibility(target, repos)
   const reconciledRepos = mergeFetchedReposForHost(currentRepos, repos, hostId)
-  const projectCompatibility =
-    target.kind === 'local'
-      ? mergeProjectHostSetupCompatibility(
-          projectCompatibilityFromRepos(reconciledRepos),
-          fetchedProjectCompatibility
-        )
-      : mergeProjectHostSetupCompatibility(
-          projectCompatibilityFromRepos(reconciledRepos),
-          fetchedProjectCompatibility
-        )
+  const projectCompatibility = mergeProjectHostSetupCompatibility(
+    projectCompatibilityFromRepos(reconciledRepos),
+    fetchedProjectCompatibility
+  )
 
   return { repos: reconciledRepos, projectCompatibility, hostId }
 }

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -220,7 +220,9 @@ function worktreeBelongsToOwner(
   includeLegacyWorktrees: boolean
 ): boolean {
   const hostId = worktree.hostId?.trim()
-  return hostId ? hostId === ownerHostId : includeLegacyWorktrees
+  return hostId
+    ? hostId === ownerHostId
+    : includeLegacyWorktrees || ownerHostId === LOCAL_EXECUTION_HOST_ID
 }
 
 function queueReposById(repos: readonly Repo[]): Map<string, Repo[]> {
@@ -452,12 +454,9 @@ async function assertProjectHostSetupMutationRuntimeCapabilities(
   )
 }
 
-async function fetchReposForTarget(
-  target: ReturnType<typeof getActiveRuntimeTarget>,
-  currentRepos: readonly Repo[]
-): Promise<{
+async function fetchReposForTarget(target: ReturnType<typeof getActiveRuntimeTarget>): Promise<{
   repos: Repo[]
-  projectCompatibility: Pick<RepoSlice, 'projects' | 'projectHostSetups'>
+  fetchedProjectCompatibility: ProjectHostSetupProjection
   hostId: ReturnType<typeof getRuntimeTargetHostId>
 }> {
   const fetchedRepos =
@@ -471,13 +470,7 @@ async function fetchReposForTarget(
   const hostId = getRuntimeTargetHostId(target)
   const repos = fetchedRepos.map((repo) => repoWithFetchedOwner(repo, target))
   const fetchedProjectCompatibility = await fetchProjectHostSetupCompatibility(target, repos)
-  const reconciledRepos = mergeFetchedReposForHost(currentRepos, repos, hostId)
-  const projectCompatibility = mergeProjectHostSetupCompatibility(
-    projectCompatibilityFromRepos(reconciledRepos),
-    fetchedProjectCompatibility
-  )
-
-  return { repos: reconciledRepos, projectCompatibility, hostId }
+  return { repos, fetchedProjectCompatibility, hostId }
 }
 
 function settingsForRepoOwner(state: Pick<AppState, 'repos' | 'settings'>, repoId: string) {
@@ -494,9 +487,7 @@ function getRepoMutationOwnerHostId(
   targetHostId: string
 ): string {
   const candidates = repos.filter((repo) => repo.id === repoId)
-  const targetOwned = candidates.find(
-    (repo) => hasExplicitRepoOwner(repo) && getRepoExecutionHostId(repo) === targetHostId
-  )
+  const targetOwned = candidates.find((repo) => getRepoExecutionHostId(repo) === targetHostId)
   if (targetOwned) {
     return targetHostId
   }
@@ -504,11 +495,21 @@ function getRepoMutationOwnerHostId(
   return explicitOwner ? getRepoExecutionHostId(explicitOwner) : targetHostId
 }
 
-function isRepoMutationTarget(repo: Repo, repoId: string, ownerHostId: string): boolean {
+function isRepoMutationTarget(
+  repo: Repo,
+  repoId: string,
+  ownerHostId: string,
+  hasExplicitSameIdRepo: boolean
+): boolean {
   if (repo.id !== repoId) {
     return false
   }
-  return !hasExplicitRepoOwner(repo) || getRepoExecutionHostId(repo) === ownerHostId
+  // Why: legacy rows without an owner are local unless no host-stamped sibling
+  // exists; otherwise remote mutations can still collapse an older local row.
+  if (hasExplicitRepoOwner(repo) || hasExplicitSameIdRepo) {
+    return getRepoExecutionHostId(repo) === ownerHostId
+  }
+  return true
 }
 
 function getFolderWorkspacePathStatusScopeKey(request: FolderWorkspacePathStatusRequest): string {
@@ -754,12 +755,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   fetchRepos: async () => {
     try {
       const target = getActiveRuntimeTarget(get().settings)
-      const {
-        repos: reconciledRepos,
-        projectCompatibility,
-        hostId
-      } = await fetchReposForTarget(target, get().repos)
+      const { repos, fetchedProjectCompatibility, hostId } = await fetchReposForTarget(target)
       set((s) => {
+        const reconciledRepos = mergeFetchedReposForHost(s.repos, repos, hostId)
+        const projectCompatibility = mergeProjectHostSetupCompatibility(
+          projectCompatibilityFromRepos(reconciledRepos),
+          fetchedProjectCompatibility
+        )
         const validRepoIds = new Set(reconciledRepos.map((repo) => repo.id))
         return {
           repos: reconciledRepos,
@@ -775,7 +777,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       })
       scheduleSafeAutoForkSync(
         get,
-        reconciledRepos.filter((repo) => getRepoExecutionHostId(repo) === hostId)
+        repos.filter((repo) => getRepoExecutionHostId(repo) === hostId)
       )
     } catch (err) {
       console.error('Failed to fetch repos:', err)
@@ -785,25 +787,26 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   fetchRuntimeEnvironmentRepos: async (environmentId) => {
     try {
       const target = { kind: 'environment' as const, environmentId }
-      const {
-        repos: reconciledRepos,
-        projectCompatibility,
-        hostId
-      } = await fetchReposForTarget(target, get().repos)
-      const validRepoIds = new Set(reconciledRepos.map((repo) => repo.id))
-      set((s) => ({
-        repos: reconciledRepos,
-        ...projectCompatibility,
-        activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-        filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
-        setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
-          s.setupScriptPromptDismissedRepoIds,
-          validRepoIds
+      const { repos, fetchedProjectCompatibility, hostId } = await fetchReposForTarget(target)
+      set((s) => {
+        const reconciledRepos = mergeFetchedReposForHost(s.repos, repos, hostId)
+        const projectCompatibility = mergeProjectHostSetupCompatibility(
+          projectCompatibilityFromRepos(reconciledRepos),
+          fetchedProjectCompatibility
         )
-      }))
-      const fetchedHostRepos = reconciledRepos.filter(
-        (repo) => getRepoExecutionHostId(repo) === hostId
-      )
+        const validRepoIds = new Set(reconciledRepos.map((repo) => repo.id))
+        return {
+          repos: reconciledRepos,
+          ...projectCompatibility,
+          activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
+          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+          setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
+            s.setupScriptPromptDismissedRepoIds,
+            validRepoIds
+          )
+        }
+      })
+      const fetchedHostRepos = repos.filter((repo) => getRepoExecutionHostId(repo) === hostId)
       scheduleSafeAutoForkSync(get, fetchedHostRepos)
       return fetchedHostRepos
     } catch (err) {
@@ -1659,8 +1662,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
       const targetHostId = getRuntimeTargetHostId(target)
       const ownerHostId = getRepoMutationOwnerHostId(get().repos, projectId, targetHostId)
+      const hasExplicitSameIdRepo = get().repos.some(
+        (repo) => repo.id === projectId && hasExplicitRepoOwner(repo)
+      )
       const removeAllRepoWorktreeState = !get().repos.some(
-        (repo) => repo.id === projectId && !isRepoMutationTarget(repo, projectId, ownerHostId)
+        (repo) =>
+          repo.id === projectId &&
+          !isRepoMutationTarget(repo, projectId, ownerHostId, hasExplicitSameIdRepo)
       )
       await (target.kind === 'local'
         ? window.api.repos.remove({ repoId: projectId })
@@ -1668,7 +1676,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
       get().clearOrcaHookTrustForRepo(projectId)
       const repoPath = get().repos.find((repo) =>
-        isRepoMutationTarget(repo, projectId, ownerHostId)
+        isRepoMutationTarget(repo, projectId, ownerHostId, hasExplicitSameIdRepo)
       )?.path
       get().evictGitHubRepoCaches(projectId, repoPath)
       const { clearRepoSlugCacheEntry } = await import('../../lib/repo-slug-index')
@@ -1788,7 +1796,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           }
         }
         const nextRepos = s.repos.filter(
-          (repo) => !isRepoMutationTarget(repo, projectId, ownerHostId)
+          (repo) => !isRepoMutationTarget(repo, projectId, ownerHostId, hasExplicitSameIdRepo)
         )
         const removedLastRepoWithId = !nextRepos.some((repo) => repo.id === projectId)
         return {
@@ -1874,6 +1882,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
     const targetHostId = getRuntimeTargetHostId(target)
     const ownerHostId = getRepoMutationOwnerHostId(get().repos, projectId, targetHostId)
+    const hasExplicitSameIdRepo = get().repos.some(
+      (repo) => repo.id === projectId && hasExplicitRepoOwner(repo)
+    )
     const updateKey = `${ownerHostId}\0${projectId}`
     const applyRepoUpdate = async () => {
       try {
@@ -1890,7 +1901,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               ).repo
         set((s) => {
           const nextRepos = s.repos.map((r) => {
-            if (!isRepoMutationTarget(r, projectId, ownerHostId)) {
+            if (!isRepoMutationTarget(r, projectId, ownerHostId, hasExplicitSameIdRepo)) {
               return r
             }
             if (updatedRepo) {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -67,6 +67,7 @@ import { translate } from '@/i18n/i18n'
 import {
   getRepoExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
   parseExecutionHostId,
   toRuntimeExecutionHostId,
   toSshExecutionHostId
@@ -262,6 +263,24 @@ function getProjectSetupRuntimeTarget(
   return parsedHost?.kind === 'runtime'
     ? { kind: 'environment', environmentId: parsedHost.environmentId }
     : { kind: 'local' }
+}
+
+function findProjectHostSetupByMutationArgs(
+  setups: readonly ProjectHostSetup[],
+  args: Pick<ProjectHostSetupUpdateArgs, 'setupId' | 'hostId'>
+): ProjectHostSetup | undefined {
+  if (args.hostId === undefined) {
+    return setups.find((setup) => setup.id === args.setupId)
+  }
+  const hostId = normalizeExecutionHostId(args.hostId)
+  if (!hostId) {
+    throw new Error(`Invalid host ID: ${args.hostId}`)
+  }
+  return setups.find((setup) => setup.id === args.setupId && setup.hostId === hostId)
+}
+
+function isSameProjectHostSetup(a: ProjectHostSetup, b: ProjectHostSetup): boolean {
+  return a.id === b.id && a.hostId === b.hostId
 }
 
 function getProjectUpdateRuntimeTarget(
@@ -1415,8 +1434,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         projects: s.projects.some((entry) => entry.id === result.project.id)
           ? s.projects.map((entry) => (entry.id === result.project.id ? result.project : entry))
           : [...s.projects, result.project],
-        projectHostSetups: s.projectHostSetups.some((entry) => entry.id === setup.id)
-          ? s.projectHostSetups.map((entry) => (entry.id === setup.id ? setup : entry))
+        projectHostSetups: s.projectHostSetups.some((entry) => isSameProjectHostSetup(entry, setup))
+          ? s.projectHostSetups.map((entry) =>
+              isSameProjectHostSetup(entry, setup) ? setup : entry
+            )
           : [...s.projectHostSetups, setup]
       }))
       return { project: result.project, setup }
@@ -1433,7 +1454,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   updateProjectHostSetup: async (args) => {
     try {
-      const currentSetup = get().projectHostSetups.find((setup) => setup.id === args.setupId)
+      const currentSetup = findProjectHostSetupByMutationArgs(get().projectHostSetups, args)
       const target = currentSetup
         ? getProjectSetupRuntimeTarget(currentSetup.hostId)
         : { kind: 'local' as const }
@@ -1460,8 +1481,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         projects: s.projects.some((entry) => entry.id === result.project.id)
           ? s.projects.map((entry) => (entry.id === result.project.id ? result.project : entry))
           : [...s.projects, result.project],
-        projectHostSetups: s.projectHostSetups.some((entry) => entry.id === setup.id)
-          ? s.projectHostSetups.map((entry) => (entry.id === setup.id ? setup : entry))
+        projectHostSetups: s.projectHostSetups.some((entry) => isSameProjectHostSetup(entry, setup))
+          ? s.projectHostSetups.map((entry) =>
+              isSameProjectHostSetup(entry, setup) ? setup : entry
+            )
           : [...s.projectHostSetups, setup]
       }))
       return { ...result, repo, setup }
@@ -1478,7 +1501,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   deleteProjectHostSetup: async (args) => {
     try {
-      const currentSetup = get().projectHostSetups.find((setup) => setup.id === args.setupId)
+      const currentSetup = findProjectHostSetupByMutationArgs(get().projectHostSetups, args)
       const target = currentSetup
         ? getProjectSetupRuntimeTarget(currentSetup.hostId)
         : { kind: 'local' as const }
@@ -1497,7 +1520,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const repo = result.repo ? repoWithFetchedOwner(result.repo, target) : undefined
       set((s) => {
         const projectHostSetups = s.projectHostSetups.filter(
-          (setup) => setup.id !== result.setup.id
+          (setup) => !isSameProjectHostSetup(setup, result.setup)
         )
         const repos = repo ? s.repos.filter((entry) => entry.id !== repo.id) : s.repos
         const projects =

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -45,7 +45,7 @@ import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
 import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
 import { getRepoIdFromWorktreeId } from './worktree-helpers'
-import { reconcileFetchedRepos } from './repo-identity-reconcile'
+import { mergeFetchedReposForHost } from './repo-host-refresh-merge'
 import { splitRepoReorderByHost } from './repo-reorder-host-split'
 import {
   assertRuntimeEnvironmentCapability,
@@ -187,15 +187,60 @@ function getRepoUpdateChains(get: () => AppState): Map<string, Promise<boolean>>
   return chains
 }
 
-function getKnownRepoWorktreeIds(state: AppState, projectId: string): string[] {
+type RepoOwnedWorktree = { id: string; hostId?: string | null }
+
+function getKnownRepoWorktreeIds(
+  state: AppState,
+  projectId: string,
+  ownerHostId: string,
+  includeLegacyWorktrees: boolean
+): string[] {
   const ids = new Set<string>()
   for (const worktree of state.worktreesByRepo[projectId] ?? []) {
-    ids.add(worktree.id)
+    if (worktreeBelongsToOwner(worktree, ownerHostId, includeLegacyWorktrees)) {
+      ids.add(worktree.id)
+    }
   }
   for (const worktree of state.detectedWorktreesByRepo[projectId]?.worktrees ?? []) {
-    ids.add(worktree.id)
+    if (worktreeBelongsToOwner(worktree, ownerHostId, includeLegacyWorktrees)) {
+      ids.add(worktree.id)
+    }
   }
   return [...ids]
+}
+
+function worktreeBelongsToOwner(
+  worktree: RepoOwnedWorktree,
+  ownerHostId: string,
+  includeLegacyWorktrees: boolean
+): boolean {
+  const hostId = worktree.hostId?.trim()
+  return hostId ? hostId === ownerHostId : includeLegacyWorktrees
+}
+
+function queueReposById(repos: readonly Repo[]): Map<string, Repo[]> {
+  const reposById = new Map<string, Repo[]>()
+  for (const repo of repos) {
+    const existing = reposById.get(repo.id)
+    if (existing) {
+      existing.push(repo)
+    } else {
+      reposById.set(repo.id, [repo])
+    }
+  }
+  return reposById
+}
+
+function reorderReposByIdPermutation(orderedIds: readonly string[], previous: readonly Repo[]) {
+  const reposById = queueReposById(previous)
+  const next: Repo[] = []
+  for (const id of orderedIds) {
+    const repo = reposById.get(id)?.shift()
+    if (repo) {
+      next.push(repo)
+    }
+  }
+  return next.length === previous.length ? next : null
 }
 
 function getRuntimeTargetHostId(
@@ -432,32 +477,6 @@ function mergeById<T extends { id: string }>(base: readonly T[], overlay: readon
   return merged
 }
 
-function mergeFetchedReposForHost(
-  previous: readonly Repo[],
-  fetched: Repo[],
-  hostId: string
-): Repo[] {
-  const fetchedIds = new Set(fetched.map((repo) => repo.id))
-  const preserved = previous.filter((repo) => {
-    const existingHostId = getRepoExecutionHostId(repo)
-    return existingHostId !== hostId || fetchedIds.has(repo.id)
-  })
-  const preservedById = new Map(preserved.map((repo) => [repo.id, repo]))
-  const merged = [...preserved]
-  for (const repo of fetched) {
-    const existingIndex = merged.findIndex((entry) => entry.id === repo.id)
-    if (existingIndex === -1) {
-      merged.push(repo)
-      continue
-    }
-    merged[existingIndex] = repo
-  }
-  return reconcileFetchedRepos(
-    previous,
-    merged.filter((repo) => preservedById.has(repo.id) || fetchedIds.has(repo.id))
-  )
-}
-
 async function fetchReposForTarget(
   target: ReturnType<typeof getActiveRuntimeTarget>,
   currentRepos: readonly Repo[]
@@ -494,6 +513,33 @@ async function fetchReposForTarget(
 
 function settingsForRepoOwner(state: Pick<AppState, 'repos' | 'settings'>, repoId: string) {
   return getSettingsForRepoRuntimeOwner(state, repoId) as AppState['settings']
+}
+
+function hasExplicitRepoOwner(repo: Pick<Repo, 'connectionId' | 'executionHostId'>): boolean {
+  return Boolean(repo.executionHostId?.trim() || repo.connectionId?.trim())
+}
+
+function getRepoMutationOwnerHostId(
+  repos: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[],
+  repoId: string,
+  targetHostId: string
+): string {
+  const candidates = repos.filter((repo) => repo.id === repoId)
+  const targetOwned = candidates.find(
+    (repo) => hasExplicitRepoOwner(repo) && getRepoExecutionHostId(repo) === targetHostId
+  )
+  if (targetOwned) {
+    return targetHostId
+  }
+  const explicitOwner = candidates.find(hasExplicitRepoOwner)
+  return explicitOwner ? getRepoExecutionHostId(explicitOwner) : targetHostId
+}
+
+function isRepoMutationTarget(repo: Repo, repoId: string, ownerHostId: string): boolean {
+  if (repo.id !== repoId) {
+    return false
+  }
+  return !hasExplicitRepoOwner(repo) || getRepoExecutionHostId(repo) === ownerHostId
 }
 
 function getFolderWorkspacePathStatusScopeKey(request: FolderWorkspacePathStatusRequest): string {
@@ -1638,18 +1684,30 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   removeProject: async (projectId) => {
     try {
       const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
+      const targetHostId = getRuntimeTargetHostId(target)
+      const ownerHostId = getRepoMutationOwnerHostId(get().repos, projectId, targetHostId)
+      const removeAllRepoWorktreeState = !get().repos.some(
+        (repo) => repo.id === projectId && !isRepoMutationTarget(repo, projectId, ownerHostId)
+      )
       await (target.kind === 'local'
         ? window.api.repos.remove({ repoId: projectId })
         : callRuntimeRpc(target, 'repo.rm', { repo: projectId }, { timeoutMs: 15_000 }))
 
       get().clearOrcaHookTrustForRepo(projectId)
-      const repoPath = get().repos.find((repo) => repo.id === projectId)?.path
+      const repoPath = get().repos.find((repo) =>
+        isRepoMutationTarget(repo, projectId, ownerHostId)
+      )?.path
       get().evictGitHubRepoCaches(projectId, repoPath)
       const { clearRepoSlugCacheEntry } = await import('../../lib/repo-slug-index')
       clearRepoSlugCacheEntry(projectId)
 
       // Kill PTYs for all worktrees belonging to this repo
-      const worktreeIds = getKnownRepoWorktreeIds(get(), projectId)
+      const worktreeIds = getKnownRepoWorktreeIds(
+        get(),
+        projectId,
+        ownerHostId,
+        removeAllRepoWorktreeState
+      )
       const killedTabIds = new Set<string>()
       const killedPtyIds = new Set<string>()
       if (target.kind === 'environment') {
@@ -1685,10 +1743,31 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       get().purgeWorktreeTerminalState(worktreeIds)
 
       set((s) => {
+        const worktreeIdSet = new Set(worktreeIds)
         const nextWorktrees = { ...s.worktreesByRepo }
-        delete nextWorktrees[projectId]
+        const remainingWorktrees = removeAllRepoWorktreeState
+          ? []
+          : (s.worktreesByRepo[projectId] ?? []).filter(
+              (worktree) => !worktreeIdSet.has(worktree.id)
+            )
+        if (remainingWorktrees.length > 0) {
+          nextWorktrees[projectId] = remainingWorktrees
+        } else {
+          delete nextWorktrees[projectId]
+        }
         const nextDetectedWorktrees = { ...s.detectedWorktreesByRepo }
-        delete nextDetectedWorktrees[projectId]
+        const detected = s.detectedWorktreesByRepo[projectId]
+        const remainingDetectedWorktrees = removeAllRepoWorktreeState
+          ? []
+          : (detected?.worktrees ?? []).filter((worktree) => !worktreeIdSet.has(worktree.id))
+        if (detected && remainingDetectedWorktrees.length > 0) {
+          nextDetectedWorktrees[projectId] = {
+            ...detected,
+            worktrees: remainingDetectedWorktrees
+          }
+        } else {
+          delete nextDetectedWorktrees[projectId]
+        }
         const nextTabs = { ...s.tabsByWorktree }
         const nextLayouts = { ...s.terminalLayoutsByTabId }
         const nextPtyIdsByTabId = { ...s.ptyIdsByTabId }
@@ -1709,7 +1788,6 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         // remove open editor files and per-worktree active-file tracking for
         // all worktrees that belonged to the repo, otherwise orphaned entries
         // would persist in the session save and pollute state.
-        const worktreeIdSet = new Set(worktreeIds)
         const nextOpenFiles = s.openFiles.filter((f) => !worktreeIdSet.has(f.worktreeId))
         const nextActiveFileIdByWorktree = { ...s.activeFileIdByWorktree }
         const nextActiveTabTypeByWorktree = { ...s.activeTabTypeByWorktree }
@@ -1726,19 +1804,27 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         // forever after the repo is removed.
         let nextLastVisitedAtByWorktreeId = s.lastVisitedAtByWorktreeId
         for (const id of Object.keys(s.lastVisitedAtByWorktreeId)) {
-          if (getRepoIdFromWorktreeId(id) === projectId) {
+          const shouldDropTimestamp = removeAllRepoWorktreeState
+            ? getRepoIdFromWorktreeId(id) === projectId
+            : worktreeIdSet.has(id)
+          if (shouldDropTimestamp) {
             if (nextLastVisitedAtByWorktreeId === s.lastVisitedAtByWorktreeId) {
               nextLastVisitedAtByWorktreeId = { ...s.lastVisitedAtByWorktreeId }
             }
             delete nextLastVisitedAtByWorktreeId[id]
           }
         }
-        const nextRepos = s.repos.filter((r) => r.id !== projectId)
+        const nextRepos = s.repos.filter(
+          (repo) => !isRepoMutationTarget(repo, projectId, ownerHostId)
+        )
+        const removedLastRepoWithId = !nextRepos.some((repo) => repo.id === projectId)
         return {
           repos: nextRepos,
           ...projectCompatibilityFromRepos(nextRepos),
           activeRepoId: s.activeRepoId === projectId ? null : s.activeRepoId,
-          filterRepoIds: s.filterRepoIds.filter((id) => id !== projectId),
+          filterRepoIds: removedLastRepoWithId
+            ? s.filterRepoIds.filter((id) => id !== projectId)
+            : s.filterRepoIds,
           worktreesByRepo: nextWorktrees,
           detectedWorktreesByRepo: nextDetectedWorktrees,
           tabsByWorktree: nextTabs,
@@ -1811,10 +1897,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   updateRepo: async (projectId, updates) => {
     const updateRepoChains = getRepoUpdateChains(get)
+    const sanitizedUpdates = sanitizeRepoUpdate(updates)
+    const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
+    const targetHostId = getRuntimeTargetHostId(target)
+    const ownerHostId = getRepoMutationOwnerHostId(get().repos, projectId, targetHostId)
+    const updateKey = `${ownerHostId}\0${projectId}`
     const applyRepoUpdate = async () => {
       try {
-        const sanitizedUpdates = sanitizeRepoUpdate(updates)
-        const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
         const updatedRepo =
           target.kind === 'local'
             ? await window.api.repos.update({ repoId: projectId, updates: sanitizedUpdates })
@@ -1828,7 +1917,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               ).repo
         set((s) => {
           const nextRepos = s.repos.map((r) => {
-            if (r.id !== projectId) {
+            if (!isRepoMutationTarget(r, projectId, ownerHostId)) {
               return r
             }
             if (updatedRepo) {
@@ -1859,16 +1948,16 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return false
       }
     }
-    const previous = updateRepoChains.get(projectId)
+    const previous = updateRepoChains.get(updateKey)
     // Why: repo settings are persisted as full nested values. Preserve call
     // order per repo so a slower IPC/RPC response cannot overwrite newer state.
     const next = previous
       ? previous.catch(() => undefined).then(applyRepoUpdate)
       : applyRepoUpdate()
-    updateRepoChains.set(projectId, next)
+    updateRepoChains.set(updateKey, next)
     const cleanup = () => {
-      if (updateRepoChains.get(projectId) === next) {
-        updateRepoChains.delete(projectId)
+      if (updateRepoChains.get(updateKey) === next) {
+        updateRepoChains.delete(updateKey)
       }
     }
     void next.then(cleanup, cleanup)
@@ -1881,15 +1970,8 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     // Optimistically apply the new order so the sidebar updates instantly;
     // resync only if main rejects (stale permutation due to a racing add/remove).
     const previous = get().repos
-    const byId = new Map(previous.map((r) => [r.id, r]))
-    const next: Repo[] = []
-    for (const id of orderedIds) {
-      const repo = byId.get(id)
-      if (repo) {
-        next.push(repo)
-      }
-    }
-    if (next.length !== previous.length) {
+    const next = reorderReposByIdPermutation(orderedIds, previous)
+    if (!next) {
       // Caller passed a non-permutation — refuse to apply locally.
       return
     }

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -21,6 +21,7 @@ import type {
   WorkspaceKey
 } from '../../../../shared/types'
 import type { TerminalGitHubPRLink } from '@/lib/terminal-github-pr-link-detector'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type {
   PendingWorktreeCreation,
   WorktreeCreationPhase
@@ -111,7 +112,10 @@ export type WorktreeSlice = {
    */
   hasHydratedWorktreePurge: boolean
   fetchDetectedWorktrees: (repoId: string) => Promise<DetectedWorktreeListResult | null>
-  fetchWorktrees: (repoId: string, options?: { requireAuthoritative?: boolean }) => Promise<boolean>
+  fetchWorktrees: (
+    repoId: string,
+    options?: { requireAuthoritative?: boolean; ownerHostId?: ExecutionHostId }
+  ) => Promise<boolean>
   fetchAllWorktrees: () => Promise<void>
   fetchWorktreeLineage: () => Promise<void>
   updateWorktreeLineage: (

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -82,7 +82,7 @@ const mockApi = {
 // @ts-expect-error -- test shim
 globalThis.window = { api: mockApi }
 
-import { createWorktreeSlice } from './worktrees'
+import { createWorktreeSlice, WORKTREE_ID_KEYED_MAP_KEYS } from './worktrees'
 import type { PendingWorktreeCreation } from '@/lib/pending-worktree-creation'
 import { getHostedReviewCacheKey } from './hosted-review'
 import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from './github-cache-key'
@@ -92,6 +92,7 @@ import {
 } from '../../components/browser-pane/webview-registry'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
+import { makeWorktreeKey } from '../../../../shared/worktree-id'
 
 function resetRemoteRuntimeMocks() {
   clearRuntimeCompatibilityCacheForTests()
@@ -4448,6 +4449,34 @@ describe('setWorktreesPinnedAndReveal', () => {
 describe('migrateWorktreeIdentity', () => {
   const OLD = 'repo1::/ws/cunner'
   const NEW = 'repo1::/ws/worktree-creation-spinner'
+  const CANONICAL = makeWorktreeKey({ hostId: 'local', repoId: 'repo1', path: '/ws/cunner' })
+
+  function makeMigrationMapValue(
+    key: (typeof WORKTREE_ID_KEYED_MAP_KEYS)[number],
+    worktreeId: string
+  ): unknown {
+    switch (key) {
+      case 'worktreeLineageById':
+        return makeLineage({ worktreeId, parentWorktreeId: 'repo1::/ws/parent' })
+      case 'tabsByWorktree':
+        return [{ id: 'tab1', worktreeId }]
+      case 'browserTabsByWorktree':
+        return [{ id: 'browser1', worktreeId }]
+      case 'recentlyClosedBrowserTabsByWorktree':
+        return [
+          {
+            workspace: { id: 'closed-browser', worktreeId },
+            pages: [{ id: 'closed-page', worktreeId }]
+          }
+        ]
+      case 'unifiedTabsByWorktree':
+        return [{ id: 'unified1', worktreeId }]
+      case 'groupsByWorktree':
+        return [{ id: 'group1', worktreeId }]
+      default:
+        return { marker: key }
+    }
+  }
 
   it('re-keys worktree-scoped maps, pointers, the Set, and openFiles old->new', () => {
     const store = createTestStore()
@@ -4528,6 +4557,50 @@ describe('migrateWorktreeIdentity', () => {
     expect(s.sleepingAgentSessionsByPaneKey['tab1:leaf']?.worktreeId).toBe(NEW)
     // Tab-id-keyed state is untouched — the tab survives with the same id.
     expect(s.terminalLayoutsByTabId.tab1).toBeDefined()
+  })
+
+  it('moves every declared worktree-id keyed map and lineage relationship to the canonical id', () => {
+    const store = createTestStore()
+    const childId = 'repo1::/ws/child'
+    const mapState = Object.fromEntries(
+      WORKTREE_ID_KEYED_MAP_KEYS.map((key) => [key, { [OLD]: makeMigrationMapValue(key, OLD) }])
+    ) as Partial<AppState>
+
+    store.setState({
+      ...mapState,
+      worktreeLineageById: {
+        [OLD]: makeLineage({ worktreeId: OLD, parentWorktreeId: 'repo1::/ws/parent' }),
+        [childId]: makeLineage({ worktreeId: childId, parentWorktreeId: OLD })
+      },
+      workspaceLineageByChildKey: {
+        [worktreeWorkspaceKey(OLD)]: makeWorkspaceLineage({
+          childWorkspaceKey: worktreeWorkspaceKey(OLD),
+          parentWorkspaceKey: folderWorkspaceKey('folder-parent')
+        }),
+        [worktreeWorkspaceKey(childId)]: makeWorkspaceLineage({
+          childWorkspaceKey: worktreeWorkspaceKey(childId),
+          parentWorkspaceKey: worktreeWorkspaceKey(OLD)
+        })
+      }
+    } as unknown as Partial<AppState>)
+
+    store.getState().migrateWorktreeIdentity(OLD, CANONICAL)
+    const s = store.getState()
+
+    for (const key of WORKTREE_ID_KEYED_MAP_KEYS) {
+      const map = s[key] as Record<string, unknown>
+      expect(map[OLD], `${key} retained the legacy key`).toBeUndefined()
+      expect(map[CANONICAL], `${key} did not receive the canonical key`).toBeDefined()
+    }
+    expect(s.worktreeLineageById[CANONICAL]).toMatchObject({ worktreeId: CANONICAL })
+    expect(s.worktreeLineageById[childId]).toMatchObject({ parentWorktreeId: CANONICAL })
+    expect(s.workspaceLineageByChildKey[worktreeWorkspaceKey(OLD)]).toBeUndefined()
+    expect(s.workspaceLineageByChildKey[worktreeWorkspaceKey(CANONICAL)]).toMatchObject({
+      childWorkspaceKey: worktreeWorkspaceKey(CANONICAL)
+    })
+    expect(s.workspaceLineageByChildKey[worktreeWorkspaceKey(childId)]).toMatchObject({
+      parentWorkspaceKey: worktreeWorkspaceKey(CANONICAL)
+    })
   })
 
   it('is a no-op when the ids match', () => {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -702,7 +702,8 @@ describe('fetchWorktrees', () => {
       id: 'repo1::/remote/wt1',
       repoId: 'repo1',
       path: '/remote/wt1',
-      branch: 'refs/heads/remote'
+      branch: 'refs/heads/remote',
+      hostId: 'runtime:env-1'
     })
     store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
     runtimeEnvironmentCall.mockResolvedValue({
@@ -724,13 +725,60 @@ describe('fetchWorktrees', () => {
     expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
   })
 
+  it('preserves legacy hostless local worktrees when a same-id runtime host refreshes', async () => {
+    const store = createTestStore()
+    const repoId = 'same-repo'
+    const local = makeWorktree({
+      id: `${repoId}::/local/wt`,
+      repoId,
+      path: '/local/wt'
+    })
+    const remote = makeWorktree({
+      id: `${repoId}::/runtime/wt`,
+      repoId,
+      path: '/runtime/wt',
+      hostId: 'runtime:env-1'
+    })
+    store.setState({
+      repos: [
+        { id: repoId, path: '/local/repo', displayName: 'local', badgeColor: '#000', addedAt: 0 },
+        {
+          id: repoId,
+          path: '/runtime/repo',
+          displayName: 'runtime',
+          badgeColor: '#111',
+          addedAt: 1,
+          executionHostId: 'runtime:env-1'
+        }
+      ],
+      worktreesByRepo: { [repoId]: [local] },
+      detectedWorktreesByRepo: { [repoId]: makeDetectedResult(repoId, [local]) },
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never
+    } as Partial<AppState>)
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'runtime-worktrees',
+      ok: true,
+      result: makeDetectedResult(repoId, [remote]),
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+
+    await store.getState().fetchWorktrees(repoId, { ownerHostId: 'runtime:env-1' })
+
+    expect(store.getState().worktreesByRepo[repoId]).toEqual([local, remote])
+    const detected = store.getState().detectedWorktreesByRepo[repoId].worktrees
+    expect(detected[0]).toMatchObject({ id: local.id })
+    expect(detected[0]).not.toHaveProperty('hostId')
+    expect(detected[1]).toMatchObject({ id: remote.id, hostId: 'runtime:env-1' })
+  })
+
   it('fetches SSH repo worktrees through local IPC even when a runtime is focused', async () => {
     const store = createTestStore()
     const sshWorktree = makeWorktree({
       id: 'repo-ssh::/home/orca/wt1',
       repoId: 'repo-ssh',
       path: '/home/orca/wt1',
-      branch: 'refs/heads/ssh'
+      branch: 'refs/heads/ssh',
+      hostId: 'ssh:ssh-1'
     })
     store.setState({
       settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
@@ -762,7 +810,8 @@ describe('fetchWorktrees', () => {
       id: 'repo1::/remote/wt1',
       repoId: 'repo1',
       path: '/remote/wt1',
-      branch: 'refs/heads/remote'
+      branch: 'refs/heads/remote',
+      hostId: 'runtime:env-1'
     })
     store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
     runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) =>
@@ -815,7 +864,8 @@ describe('fetchWorktrees', () => {
       id: 'repo1::/remote/wt1',
       repoId: 'repo1',
       path: '/remote/wt1',
-      branch: 'refs/heads/remote'
+      branch: 'refs/heads/remote',
+      hostId: 'runtime:env-1'
     })
     const lineage = makeLineage({ worktreeId: initial.id })
     const refreshed = { ...initial, lineage }
@@ -871,7 +921,8 @@ describe('fetchWorktrees', () => {
       id: 'repo1::/remote/wt1',
       repoId: 'repo1',
       path: '/remote/wt1',
-      branch: 'refs/heads/remote'
+      branch: 'refs/heads/remote',
+      hostId: 'runtime:env-1'
     })
     const staleLineage = makeLineage({
       worktreeId: worktree.id,
@@ -915,7 +966,8 @@ describe('fetchWorktrees', () => {
       id: 'repo1::/remote/wt1',
       repoId: 'repo1',
       path: '/remote/wt1',
-      branch: 'refs/heads/remote'
+      branch: 'refs/heads/remote',
+      hostId: 'runtime:env-1'
     })
     const staleLineage = makeLineage({ worktreeId: refreshed.id })
     store.setState({
@@ -3681,6 +3733,86 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
       }
     })
     expect(store.getState().hasHydratedWorktreePurge).toBe(true)
+  })
+
+  it('refreshes same-id repos on separate hosts without clobbering sibling worktrees', async () => {
+    const store = createTestStore()
+    const repoId = 'same-repo'
+    const localWorktree = makeWorktree({
+      id: `${repoId}::/local/wt`,
+      repoId,
+      path: '/local/wt',
+      hostId: 'local'
+    })
+    const runtimeWorktree = makeWorktree({
+      id: `${repoId}::/runtime/wt`,
+      repoId,
+      path: '/runtime/wt',
+      hostId: 'runtime:env-1'
+    })
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      makeDetectedResult(repoId, [localWorktree])
+    )
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'worktree.detectedList') {
+        return Promise.resolve({
+          id: 'runtime-worktrees',
+          ok: true,
+          result: makeDetectedResult(repoId, [runtimeWorktree]),
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${method}`)
+    })
+    store.setState({
+      repos: [
+        {
+          id: repoId,
+          path: '/local/repo',
+          displayName: 'local',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'local'
+        },
+        {
+          id: repoId,
+          path: '/runtime/repo',
+          displayName: 'runtime',
+          badgeColor: '#111',
+          addedAt: 1,
+          executionHostId: 'runtime:env-1'
+        }
+      ],
+      detectedWorktreesByRepo: {
+        [repoId]: makeDetectedResult(repoId, [localWorktree, runtimeWorktree], {
+          authoritative: false,
+          source: 'metadata-fallback'
+        })
+      },
+      tabsByWorktree: {
+        [localWorktree.id]: [{ id: 'local-tab', worktreeId: localWorktree.id }] as never,
+        [runtimeWorktree.id]: [{ id: 'runtime-tab', worktreeId: runtimeWorktree.id }] as never
+      }
+    } as Partial<AppState>)
+
+    await store.getState().fetchAllWorktrees()
+
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledWith({ repoId })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'worktree.detectedList',
+      params: { repo: repoId },
+      timeoutMs: 15_000
+    })
+    expect(store.getState().worktreesByRepo[repoId]).toEqual([localWorktree, runtimeWorktree])
+    expect(store.getState().detectedWorktreesByRepo[repoId].worktrees).toEqual([
+      expect.objectContaining({ id: localWorktree.id, hostId: 'local' }),
+      expect.objectContaining({ id: runtimeWorktree.id, hostId: 'runtime:env-1' })
+    ])
+    expect(store.getState().tabsByWorktree).toEqual({
+      [localWorktree.id]: [{ id: 'local-tab', worktreeId: localWorktree.id }],
+      [runtimeWorktree.id]: [{ id: 'runtime-tab', worktreeId: runtimeWorktree.id }]
+    })
   })
 
   it('bounds concurrent repo scans during hydration-time refresh', async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -15,7 +15,8 @@ import type {
   RemoveWorktreeResult,
   WorktreeLineage,
   WorkspaceLineage,
-  WorktreeMeta
+  WorktreeMeta,
+  Repo
 } from '../../../../shared/types'
 import type { RuntimeWorktreeListResult } from '../../../../shared/runtime-types'
 import {
@@ -45,6 +46,7 @@ import { translate } from '@/i18n/i18n'
 import {
   getRepoExecutionHostId,
   getSettingsFocusedExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
@@ -69,9 +71,14 @@ const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
 
+type WorktreeRefreshRepo = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+type WorktreeRefreshResult =
+  | { repoId: string; ok: boolean; detected: DetectedWorktreeListResult }
+  | { repoId: string; ok: false }
+
 async function mapReposForWorktreeRefresh<T>(
-  repos: readonly { id: string }[],
-  mapper: (repo: { id: string }) => Promise<T>
+  repos: readonly WorktreeRefreshRepo[],
+  mapper: (repo: WorktreeRefreshRepo) => Promise<T>
 ): Promise<T[]> {
   const results = Array<T>(repos.length)
   let nextIndex = 0
@@ -313,6 +320,94 @@ function toVisibleWorktree(worktree: DetectedWorktreeListResult['worktrees'][num
 
 function toVisibleWorktrees(result: DetectedWorktreeListResult): Worktree[] {
   return result.worktrees.filter((worktree) => worktree.visible).map(toVisibleWorktree)
+}
+
+function worktreeBelongsToHost(
+  worktree: Pick<Worktree, 'hostId'>,
+  hostId: ExecutionHostId,
+  treatHostlessAsLocal: boolean
+) {
+  if (worktree.hostId) {
+    return worktree.hostId === hostId
+  }
+  return treatHostlessAsLocal ? hostId === LOCAL_EXECUTION_HOST_ID : true
+}
+
+function withWorktreeHost<T extends Worktree>(worktree: T, hostId: ExecutionHostId): T {
+  return worktree.hostId || hostId === LOCAL_EXECUTION_HOST_ID ? worktree : { ...worktree, hostId }
+}
+
+function withDetectedWorktreeHost(
+  result: DetectedWorktreeListResult,
+  hostId: ExecutionHostId
+): DetectedWorktreeListResult {
+  return {
+    ...result,
+    worktrees: result.worktrees.map((worktree) => withWorktreeHost(worktree, hostId))
+  }
+}
+
+function spliceHostWorktrees<T extends Worktree>(
+  previous: readonly T[],
+  fetched: readonly T[],
+  hostId: ExecutionHostId,
+  treatHostlessAsLocal: boolean
+): T[] {
+  const firstHostIndex = previous.findIndex((worktree) =>
+    worktreeBelongsToHost(worktree, hostId, treatHostlessAsLocal)
+  )
+  const preserved = previous.filter(
+    (worktree) => !worktreeBelongsToHost(worktree, hostId, treatHostlessAsLocal)
+  )
+  if (firstHostIndex === -1) {
+    return [...preserved, ...fetched]
+  }
+  const insertAt = Math.min(firstHostIndex, preserved.length)
+  return [...preserved.slice(0, insertAt), ...fetched, ...preserved.slice(insertAt)]
+}
+
+function mergeDetectedWorktreesForHost(
+  previous: DetectedWorktreeListResult | undefined,
+  fetched: DetectedWorktreeListResult,
+  hostId: ExecutionHostId,
+  treatHostlessAsLocal: boolean
+): DetectedWorktreeListResult {
+  const fetchedWithHost = withDetectedWorktreeHost(fetched, hostId)
+  if (!previous) {
+    return fetchedWithHost
+  }
+  const preserved = previous.worktrees.filter(
+    (worktree) => !worktreeBelongsToHost(worktree, hostId, treatHostlessAsLocal)
+  )
+  return {
+    ...fetchedWithHost,
+    authoritative:
+      preserved.length > 0
+        ? previous.authoritative && fetchedWithHost.authoritative
+        : fetchedWithHost.authoritative,
+    worktrees: spliceHostWorktrees(
+      previous.worktrees,
+      fetchedWithHost.worktrees,
+      hostId,
+      treatHostlessAsLocal
+    )
+  }
+}
+
+function mergeVisibleWorktreesForHost(
+  previous: readonly Worktree[] | undefined,
+  fetched: readonly Worktree[],
+  hostId: ExecutionHostId,
+  treatHostlessAsLocal: boolean
+): Worktree[] {
+  const fetchedWithHost = fetched.map((worktree) => withWorktreeHost(worktree, hostId))
+  return spliceHostWorktrees(previous ?? [], fetchedWithHost, hostId, treatHostlessAsLocal)
+}
+
+function shouldTreatHostlessWorktreesAsLocal(state: Pick<AppState, 'repos'>, repoId: string) {
+  return state.repos.some(
+    (repo) => repo.id === repoId && getRepoExecutionHostId(repo) === LOCAL_EXECUTION_HOST_ID
+  )
 }
 
 function getHydratedSessionWorktreeIdsForRepo(state: AppState, repoId: string): string[] {
@@ -569,31 +664,44 @@ function replaceWorktreeInRepoLists(
   }
 }
 
-function settingsForRepoOwner(state: Pick<AppState, 'repos' | 'settings'>, repoId: string) {
-  const repo = state.repos.find((entry) => entry.id === repoId)
+function getRepoOwnerForWorktreeRefresh(
+  state: Pick<AppState, 'repos' | 'settings'>,
+  repoId: string,
+  ownerHostId?: ExecutionHostId
+) {
+  const candidates = state.repos.filter((entry) => entry.id === repoId)
+  if (ownerHostId) {
+    return candidates.find((repo) => getRepoExecutionHostId(repo) === ownerHostId)
+  }
+  const focusedHostId = getSettingsFocusedExecutionHostId(state.settings)
+  return candidates.find((repo) => getRepoExecutionHostId(repo) === focusedHostId) ?? candidates[0]
+}
+
+function settingsForRepoOwner(
+  state: Pick<AppState, 'repos' | 'settings'>,
+  repoId: string,
+  ownerHostId?: ExecutionHostId
+) {
+  const repo = getRepoOwnerForWorktreeRefresh(state, repoId, ownerHostId)
   if (!repo) {
     return state.settings
   }
-  if (!repo.executionHostId && !repo.connectionId) {
+  if (!ownerHostId && !repo.executionHostId && !repo.connectionId) {
     return state.settings
   }
-  const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
-  if (parsed?.kind === 'runtime') {
-    return state.settings
-      ? { ...state.settings, activeRuntimeEnvironmentId: parsed.environmentId }
-      : ({ activeRuntimeEnvironmentId: parsed.environmentId } as AppState['settings'])
+  return settingsForExecutionHostOwner(state.settings, getRepoExecutionHostId(repo))
+}
+
+function getRepoOwnerHostIdForWorktreeRefresh(
+  state: Pick<AppState, 'repos' | 'settings'>,
+  repoId: string,
+  ownerHostId?: ExecutionHostId
+): ExecutionHostId {
+  if (ownerHostId) {
+    return ownerHostId
   }
-  if (parsed?.kind === 'local' && state.settings?.activeRuntimeEnvironmentId) {
-    return { ...state.settings, activeRuntimeEnvironmentId: null }
-  }
-  if (parsed?.kind !== 'ssh') {
-    return state.settings
-  }
-  // Why: SSH repos are owned by the desktop client/SSH provider, not the
-  // currently focused runtime server.
-  return state.settings
-    ? { ...state.settings, activeRuntimeEnvironmentId: null }
-    : ({ activeRuntimeEnvironmentId: null } as AppState['settings'])
+  const repo = getRepoOwnerForWorktreeRefresh(state, repoId)
+  return repo ? getRepoExecutionHostId(repo) : getSettingsFocusedExecutionHostId(state.settings)
 }
 
 function settingsForExecutionHostOwner(
@@ -1383,15 +1491,29 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
   fetchWorktrees: async (repoId, options) => {
     try {
-      const settings = settingsForRepoOwner(get(), repoId)
-      const detected = await listDetectedWorktreesForRepo(settings, repoId)
-      if (options?.requireAuthoritative && !detected.authoritative) {
+      const ownerHostId = getRepoOwnerHostIdForWorktreeRefresh(get(), repoId, options?.ownerHostId)
+      const settings = settingsForRepoOwner(get(), repoId, ownerHostId)
+      const detectedForHost = await listDetectedWorktreesForRepo(settings, repoId)
+      if (options?.requireAuthoritative && !detectedForHost.authoritative) {
         return false
       }
-      const worktrees = toVisibleWorktrees(detected)
+      const worktreesForHost = toVisibleWorktrees(detectedForHost)
       const current = get().worktreesByRepo[repoId]
-      if (areWorktreesEqual(current, worktrees)) {
+      const treatHostlessAsLocal = shouldTreatHostlessWorktreesAsLocal(get(), repoId)
+      const nextWorktrees = mergeVisibleWorktreesForHost(
+        current,
+        worktreesForHost,
+        ownerHostId,
+        treatHostlessAsLocal
+      )
+      if (areWorktreesEqual(current, nextWorktrees)) {
         set((s) => {
+          const detected = mergeDetectedWorktreesForHost(
+            s.detectedWorktreesByRepo[repoId],
+            detectedForHost,
+            ownerHostId,
+            shouldTreatHostlessWorktreesAsLocal(s, repoId)
+          )
           const removedIds = getRemovedWorktreeIdsAfterAuthoritativeScan(s, repoId, detected)
           if (
             areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[repoId], detected) &&
@@ -1405,7 +1527,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           }
         })
         await refreshRemoteWorktreeLineageBestEffort(settings, set)
-        return detected.authoritative
+        return detectedForHost.authoritative
       }
 
       // Why: `git worktree list` can fail transiently (e.g. concurrent git
@@ -1415,14 +1537,42 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // badge then shows raw worktree IDs instead of display names, and click-
       // to-navigate silently fails because findWorktreeById returns undefined.
       // Keep the stale-but-correct data until the next successful refresh.
-      if (!detected.authoritative && worktrees.length === 0 && current && current.length > 0) {
+      const currentForHost = current?.filter((worktree) =>
+        worktreeBelongsToHost(worktree, ownerHostId, treatHostlessAsLocal)
+      )
+      if (
+        !detectedForHost.authoritative &&
+        worktreesForHost.length === 0 &&
+        currentForHost &&
+        currentForHost.length > 0
+      ) {
         set((s) => ({
-          detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [repoId]: detected }
+          detectedWorktreesByRepo: {
+            ...s.detectedWorktreesByRepo,
+            [repoId]: mergeDetectedWorktreesForHost(
+              s.detectedWorktreesByRepo[repoId],
+              detectedForHost,
+              ownerHostId,
+              shouldTreatHostlessWorktreesAsLocal(s, repoId)
+            )
+          }
         }))
         return false
       }
 
       set((s) => {
+        const detected = mergeDetectedWorktreesForHost(
+          s.detectedWorktreesByRepo[repoId],
+          detectedForHost,
+          ownerHostId,
+          shouldTreatHostlessWorktreesAsLocal(s, repoId)
+        )
+        const worktrees = mergeVisibleWorktreesForHost(
+          s.worktreesByRepo[repoId],
+          worktreesForHost,
+          ownerHostId,
+          shouldTreatHostlessWorktreesAsLocal(s, repoId)
+        )
         // Why: hidden worktrees are not in worktreesByRepo. Purge decisions
         // must diff against the previous authoritative detected list so hiding
         // does not delete state, and deleting a hidden worktree still does.
@@ -1439,7 +1589,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         }
       })
       await refreshRemoteWorktreeLineageBestEffort(settings, set)
-      return detected.authoritative
+      return detectedForHost.authoritative
     } catch (err) {
       console.error(`Failed to fetch worktrees for repo ${repoId}:`, err)
       return false
@@ -1453,7 +1603,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     // calls just need to refresh each repo's cached list. No need to
     // double-probe the IPC for the per-repo success signal.
     if (get().hasHydratedWorktreePurge) {
-      await mapReposForWorktreeRefresh(repos, (r) => get().fetchWorktrees(r.id))
+      await mapReposForWorktreeRefresh(repos, (r) =>
+        get().fetchWorktrees(r.id, { ownerHostId: getRepoExecutionHostId(r) })
+      )
       return
     }
 
@@ -1470,34 +1622,67 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     // then apply that same payload to state instead of listing each repo again.
     const results = await mapReposForWorktreeRefresh(
       repos,
-      async (
-        r
-      ): Promise<
-        | { repoId: string; ok: boolean; detected: DetectedWorktreeListResult }
-        | { repoId: string; ok: false }
-      > => {
+      async (r): Promise<WorktreeRefreshResult> => {
         try {
-          const detected = await listDetectedWorktreesForRepo(
-            settingsForRepoOwner(get(), r.id),
+          const ownerHostId = getRepoExecutionHostId(r)
+          const detectedForHost = await listDetectedWorktreesForRepo(
+            settingsForRepoOwner(get(), r.id, ownerHostId),
             r.id
           )
-          const list = toVisibleWorktrees(detected)
+          const list = toVisibleWorktrees(detectedForHost)
           const current = get().worktreesByRepo[r.id]
+          const treatHostlessAsLocal = shouldTreatHostlessWorktreesAsLocal(get(), r.id)
+          const nextWorktrees = mergeVisibleWorktreesForHost(
+            current,
+            list,
+            ownerHostId,
+            treatHostlessAsLocal
+          )
           if (
-            !areWorktreesEqual(current, list) &&
-            !(list.length === 0 && current && current.length > 0 && !detected.authoritative)
+            !areWorktreesEqual(current, nextWorktrees) &&
+            !(
+              list.length === 0 &&
+              current?.some((worktree) =>
+                worktreeBelongsToHost(worktree, ownerHostId, treatHostlessAsLocal)
+              ) &&
+              !detectedForHost.authoritative
+            )
           ) {
-            set((s) => ({
-              worktreesByRepo: { ...s.worktreesByRepo, [r.id]: list },
-              detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [r.id]: detected },
-              sortEpoch: s.sortEpoch + 1
-            }))
+            set((s) => {
+              const detected = mergeDetectedWorktreesForHost(
+                s.detectedWorktreesByRepo[r.id],
+                detectedForHost,
+                ownerHostId,
+                shouldTreatHostlessWorktreesAsLocal(s, r.id)
+              )
+              return {
+                worktreesByRepo: {
+                  ...s.worktreesByRepo,
+                  [r.id]: mergeVisibleWorktreesForHost(
+                    s.worktreesByRepo[r.id],
+                    list,
+                    ownerHostId,
+                    shouldTreatHostlessWorktreesAsLocal(s, r.id)
+                  )
+                },
+                detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [r.id]: detected },
+                sortEpoch: s.sortEpoch + 1
+              }
+            })
           } else {
             set((s) => ({
-              detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [r.id]: detected }
+              detectedWorktreesByRepo: {
+                ...s.detectedWorktreesByRepo,
+                [r.id]: mergeDetectedWorktreesForHost(
+                  s.detectedWorktreesByRepo[r.id],
+                  detectedForHost,
+                  ownerHostId,
+                  shouldTreatHostlessWorktreesAsLocal(s, r.id)
+                )
+              }
             }))
           }
-          return { repoId: r.id, ok: detected.authoritative, detected }
+          return { repoId: r.id, ok: detectedForHost.authoritative, detected: detectedForHost }
         } catch (err) {
           console.error(`Failed to fetch worktrees for repo ${r.id}:`, err)
           return { repoId: r.id, ok: false as const }
@@ -1517,11 +1702,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     // Why: floating is persisted renderer state, but not a repo worktree that
     // authoritative runtime scans can return.
     validIds.add(FLOATING_TERMINAL_WORKTREE_ID)
-    for (const result of Object.values(get().detectedWorktreesByRepo)) {
-      if (!result.authoritative) {
+    for (const result of results) {
+      if (!('detected' in result) || !result.ok) {
         continue
       }
-      for (const w of result.worktrees) {
+      for (const w of result.detected.worktrees) {
         validIds.add(w.id)
       }
     }

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -15,6 +15,7 @@ import type {
   RemoveWorktreeResult,
   WorktreeLineage,
   WorkspaceLineage,
+  WorkspaceKey,
   WorktreeMeta,
   Repo
 } from '../../../../shared/types'
@@ -1032,7 +1033,7 @@ async function resolveLinkedPrPushTarget(
 // new `*ByWorktree` map is not silently missed when a worktree id changes. Maps keyed
 // by tab id or file id are deliberately NOT here — tabs and files keep their ids across
 // a worktree rename.
-const WORKTREE_ID_KEYED_MAP_KEYS = [
+export const WORKTREE_ID_KEYED_MAP_KEYS = [
   'worktreeLineageById',
   'tabsByWorktree',
   'deleteStateByWorktreeId',
@@ -1068,6 +1069,36 @@ const WORKTREE_ID_KEYED_MAP_KEYS = [
   'defaultTerminalTabsAppliedByWorktreeId'
 ] as const satisfies readonly (keyof AppState)[]
 
+function migrateWorkspaceLineageForWorktreeIdentity(
+  lineageByChildKey: Record<string, WorkspaceLineage>,
+  oldWorkspaceKey: WorkspaceKey,
+  newWorkspaceKey: WorkspaceKey
+): Record<string, WorkspaceLineage> {
+  let changed = false
+  const next: Record<string, WorkspaceLineage> = {}
+  for (const [childKey, lineage] of Object.entries(lineageByChildKey)) {
+    const nextChildKey = childKey === oldWorkspaceKey ? newWorkspaceKey : childKey
+    const nextLineage =
+      lineage.childWorkspaceKey === oldWorkspaceKey ||
+      lineage.parentWorkspaceKey === oldWorkspaceKey
+        ? {
+            ...lineage,
+            childWorkspaceKey:
+              lineage.childWorkspaceKey === oldWorkspaceKey
+                ? newWorkspaceKey
+                : lineage.childWorkspaceKey,
+            parentWorkspaceKey:
+              lineage.parentWorkspaceKey === oldWorkspaceKey
+                ? newWorkspaceKey
+                : lineage.parentWorkspaceKey
+          }
+        : lineage
+    changed = changed || nextChildKey !== childKey || nextLineage !== lineage
+    next[nextChildKey] = nextLineage
+  }
+  return changed ? next : lineageByChildKey
+}
+
 /**
  * Re-key every worktree-id-keyed map (plus the Set, openFiles[].worktreeId, and
  * the active/renaming pointers) from `oldWorktreeId` to `newWorktreeId` after a
@@ -1086,6 +1117,8 @@ function buildWorktreeRenameState(
   if (oldWorktreeId === newWorktreeId) {
     return {}
   }
+  const oldWorkspaceKey = worktreeWorkspaceKey(oldWorktreeId)
+  const newWorkspaceKey = worktreeWorkspaceKey(newWorktreeId)
   const renamed: Record<string, unknown> = {}
   const renameKey = <T>(
     key: keyof AppState,
@@ -1102,7 +1135,14 @@ function buildWorktreeRenameState(
   }
   const withNewWorktreeId = <T extends { worktreeId: string }>(value: T): T =>
     value.worktreeId === oldWorktreeId ? { ...value, worktreeId: newWorktreeId } : value
+  const withNewLineageWorktreeIds = (lineage: WorktreeLineage): WorktreeLineage => ({
+    ...lineage,
+    worktreeId: lineage.worktreeId === oldWorktreeId ? newWorktreeId : lineage.worktreeId,
+    parentWorktreeId:
+      lineage.parentWorktreeId === oldWorktreeId ? newWorktreeId : lineage.parentWorktreeId
+  })
   const renameValueByKey: Partial<Record<(typeof WORKTREE_ID_KEYED_MAP_KEYS)[number], unknown>> = {
+    worktreeLineageById: withNewLineageWorktreeIds,
     tabsByWorktree: (tabs: { worktreeId: string }[]) => tabs.map(withNewWorktreeId),
     browserTabsByWorktree: (workspaces: { worktreeId: string }[]) =>
       workspaces.map(withNewWorktreeId),
@@ -1120,6 +1160,28 @@ function buildWorktreeRenameState(
   for (const key of WORKTREE_ID_KEYED_MAP_KEYS) {
     renameKey(key, renameValueByKey[key] as ((value: unknown) => unknown) | undefined)
   }
+  const currentLineage =
+    (renamed.worktreeLineageById as Record<string, WorktreeLineage> | undefined) ??
+    s.worktreeLineageById
+  const lineageWithUpdatedParents = Object.values(currentLineage).some(
+    (lineage) => lineage.worktreeId === oldWorktreeId || lineage.parentWorktreeId === oldWorktreeId
+  )
+    ? Object.fromEntries(
+        Object.entries(currentLineage).map(([worktreeId, lineage]) => [
+          worktreeId,
+          withNewLineageWorktreeIds(lineage)
+        ])
+      )
+    : currentLineage
+  if (lineageWithUpdatedParents !== s.worktreeLineageById) {
+    renamed.worktreeLineageById = lineageWithUpdatedParents
+  }
+  const currentWorkspaceLineage = s.workspaceLineageByChildKey ?? {}
+  const workspaceLineageByChildKey = migrateWorkspaceLineageForWorktreeIdentity(
+    currentWorkspaceLineage,
+    oldWorkspaceKey,
+    newWorkspaceKey
+  )
   // Re-key these on rename so a renamed worktree keeps its editor-undo + push/pull
   // state. (Both removal paths — buildWorktreePurgeState and the single
   // removeWorktree reducer — now also purge them on removal.)
@@ -1191,6 +1253,9 @@ function buildWorktreeRenameState(
       : {}),
     ...(sleepingAgentSessionsByPaneKey !== s.sleepingAgentSessionsByPaneKey
       ? { sleepingAgentSessionsByPaneKey }
+      : {}),
+    ...(workspaceLineageByChildKey !== currentWorkspaceLineage
+      ? { workspaceLineageByChildKey }
       : {}),
     ...(s.activeWorktreeId === oldWorktreeId ? { activeWorktreeId: newWorktreeId } : {}),
     // The active workspace key derives from the worktree id, so keep it in sync when the active worktree is renamed.

--- a/src/shared/pty-session-id-format.ts
+++ b/src/shared/pty-session-id-format.ts
@@ -11,8 +11,31 @@
  * can import.
  */
 
+import { normalizeExecutionHostId } from './execution-host'
+
 export const PTY_SESSION_ID_SEPARATOR = '@@'
 export const WORKTREE_ID_SEPARATOR = '::'
+const WORKTREE_KEY_PREFIX = 'orca-worktree://v1?'
+
+function isCanonicalWorktreeKey(candidate: string): boolean {
+  if (!candidate.startsWith(WORKTREE_KEY_PREFIX)) {
+    return false
+  }
+  const params = new URLSearchParams(candidate.slice(WORKTREE_KEY_PREFIX.length))
+  const keys = [...params.keys()]
+  return (
+    keys.length === 3 &&
+    keys[0] === 'hostId' &&
+    keys[1] === 'repoId' &&
+    keys[2] === 'path' &&
+    params.getAll('hostId').length === 1 &&
+    params.getAll('repoId').length === 1 &&
+    params.getAll('path').length === 1 &&
+    normalizeExecutionHostId(params.get('hostId')) !== null &&
+    (params.get('repoId')?.length ?? 0) > 0 &&
+    (params.get('path')?.length ?? 0) > 0
+  )
+}
 
 /**
  * Recover the owning worktreeId from a minted session id.
@@ -30,6 +53,9 @@ export function parsePtySessionId(sessionId: string): { worktreeId: string | nul
     return { worktreeId: null }
   }
   const candidate = sessionId.slice(0, idx)
+  if (isCanonicalWorktreeKey(candidate)) {
+    return { worktreeId: candidate }
+  }
   // Why: require non-empty halves on both sides of `::` so degenerate
   // ids like `::@@…`, `repo::@@…`, or `::path@@…` don't synthesize a
   // phantom worktreeId for memory attribution.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -184,6 +184,7 @@ export type ProjectHostSetupCloneArgs = {
 
 export type ProjectHostSetupUpdateArgs = {
   setupId: string
+  hostId?: ExecutionHostId
   updates: Partial<
     Pick<
       ProjectHostSetup,
@@ -200,6 +201,7 @@ export type ProjectHostSetupUpdateArgs = {
 
 export type ProjectHostSetupDeleteArgs = {
   setupId: string
+  hostId?: ExecutionHostId
 }
 
 export type ProjectHostSetupResult = {

--- a/src/shared/worktree-id.test.ts
+++ b/src/shared/worktree-id.test.ts
@@ -3,6 +3,11 @@ import {
   WORKTREE_ID_SEPARATOR,
   getRepoIdFromWorktreeId,
   getWorktreePathBasenameFromId,
+  isLegacyWorktreeId,
+  makeRepoWorktreeKey,
+  makeWorktreeKey,
+  parseAnyWorktreeId,
+  parseWorktreeKey,
   splitWorktreeId,
   splitWorktreeIdForFilesystem
 } from './worktree-id'
@@ -16,6 +21,14 @@ describe('WORKTREE_ID_SEPARATOR', () => {
 describe('getRepoIdFromWorktreeId', () => {
   it('returns the repo id for a canonical worktree id', () => {
     expect(getRepoIdFromWorktreeId('repo-123::/abs/path')).toBe('repo-123')
+  })
+
+  it('returns the repo id for a host-qualified worktree key', () => {
+    expect(
+      getRepoIdFromWorktreeId(
+        makeWorktreeKey({ hostId: 'runtime:gpu', repoId: 'repo-123', path: '/abs/path' })
+      )
+    ).toBe('repo-123')
   })
 
   it('returns the whole input when there is no separator', () => {
@@ -43,12 +56,108 @@ describe('getRepoIdFromWorktreeId', () => {
   })
 })
 
+describe('makeWorktreeKey', () => {
+  it('creates a canonical host-qualified key with stable parameter order', () => {
+    expect(
+      makeWorktreeKey({ hostId: 'local', repoId: 'repo-123', path: '/Users/alice/orca' })
+    ).toBe('orca-worktree://v1?hostId=local&repoId=repo-123&path=%2FUsers%2Falice%2Forca')
+  })
+
+  it('encodes host ids, repo ids, POSIX paths, and Windows paths without delimiter collisions', () => {
+    const key = makeWorktreeKey({
+      hostId: 'ssh:openclaw%202',
+      repoId: 'repo::with spaces',
+      path: 'C:\\Users\\Alice\\repo::workspace'
+    })
+
+    expect(parseWorktreeKey(key)).toEqual({
+      hostId: 'ssh:openclaw%202',
+      repoId: 'repo::with spaces',
+      worktreePath: 'C:\\Users\\Alice\\repo::workspace'
+    })
+  })
+
+  it('builds keys from repo execution ownership', () => {
+    expect(
+      makeRepoWorktreeKey(
+        { id: 'repo-123', connectionId: null, executionHostId: 'runtime:gpu' },
+        '/srv/repo'
+      )
+    ).toBe('orca-worktree://v1?hostId=runtime%3Agpu&repoId=repo-123&path=%2Fsrv%2Frepo')
+  })
+})
+
+describe('parseWorktreeKey', () => {
+  it('parses a valid canonical key', () => {
+    expect(
+      parseWorktreeKey('orca-worktree://v1?hostId=runtime%3Agpu&repoId=repo-123&path=%2Fsrv%2Frepo')
+    ).toEqual({ hostId: 'runtime:gpu', repoId: 'repo-123', worktreePath: '/srv/repo' })
+  })
+
+  it('rejects legacy ids', () => {
+    expect(parseWorktreeKey('repo-123::/abs/path')).toBeNull()
+  })
+
+  it('rejects missing, empty, duplicate, reordered, and unknown fields', () => {
+    expect(parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo')).toBeNull()
+    expect(parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo&path=')).toBeNull()
+    expect(
+      parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo&path=%2Fx&path=%2Fy')
+    ).toBeNull()
+    expect(parseWorktreeKey('orca-worktree://v1?repoId=repo&hostId=local&path=%2Fx')).toBeNull()
+    expect(
+      parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo&path=%2Fx&extra=1')
+    ).toBeNull()
+  })
+
+  it('rejects unknown versions and invalid hosts', () => {
+    expect(parseWorktreeKey('orca-worktree://v2?hostId=local&repoId=repo&path=%2Fx')).toBeNull()
+    expect(parseWorktreeKey('orca-worktree://v1?hostId=bogus&repoId=repo&path=%2Fx')).toBeNull()
+  })
+})
+
+describe('parseAnyWorktreeId', () => {
+  it('distinguishes canonical and legacy ids', () => {
+    const canonical = makeWorktreeKey({ hostId: 'local', repoId: 'repo-123', path: '/abs/path' })
+
+    expect(parseAnyWorktreeId(canonical)).toEqual({
+      format: 'canonical',
+      hostId: 'local',
+      repoId: 'repo-123',
+      worktreePath: '/abs/path'
+    })
+    expect(parseAnyWorktreeId('repo-123::/abs/path')).toEqual({
+      format: 'legacy',
+      repoId: 'repo-123',
+      worktreePath: '/abs/path'
+    })
+  })
+})
+
+describe('isLegacyWorktreeId', () => {
+  it('returns true only for legacy ids', () => {
+    expect(isLegacyWorktreeId('repo-123::/abs/path')).toBe(true)
+    expect(
+      isLegacyWorktreeId(
+        makeWorktreeKey({ hostId: 'local', repoId: 'repo-123', path: '/abs/path' })
+      )
+    ).toBe(false)
+    expect(isLegacyWorktreeId('repo-123')).toBe(false)
+  })
+})
+
 describe('splitWorktreeId', () => {
   it('splits a canonical worktree id into repo id and path', () => {
     expect(splitWorktreeId('repo-123::/abs/path')).toEqual({
       repoId: 'repo-123',
       worktreePath: '/abs/path'
     })
+  })
+
+  it('splits a host-qualified worktree key into host, repo id, and path', () => {
+    expect(
+      splitWorktreeId(makeWorktreeKey({ hostId: 'local', repoId: 'repo-123', path: '/abs/path' }))
+    ).toEqual({ hostId: 'local', repoId: 'repo-123', worktreePath: '/abs/path' })
   })
 
   it('returns null when there is no separator', () => {
@@ -90,6 +199,18 @@ describe('splitWorktreeIdForFilesystem', () => {
     expect(
       splitWorktreeIdForFilesystem('repo::/folder::workspace:123e4567-e89b-12d3-a456-426614174000')
     ).toEqual({ repoId: 'repo', worktreePath: '/folder' })
+  })
+
+  it('strips folder workspace instance suffixes from host-qualified keys', () => {
+    expect(
+      splitWorktreeIdForFilesystem(
+        makeWorktreeKey({
+          hostId: 'local',
+          repoId: 'repo',
+          path: '/folder::workspace:123e4567-e89b-12d3-a456-426614174000'
+        })
+      )
+    ).toEqual({ hostId: 'local', repoId: 'repo', worktreePath: '/folder' })
   })
 })
 

--- a/src/shared/worktree-id.ts
+++ b/src/shared/worktree-id.ts
@@ -1,23 +1,136 @@
 import { WORKTREE_ID_SEPARATOR } from './pty-session-id-format'
+import {
+  getRepoExecutionHostId,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from './execution-host'
+import type { Repo } from './types'
 
 export { WORKTREE_ID_SEPARATOR } from './pty-session-id-format'
 
 export type ParsedWorktreeId = {
   repoId: string
   worktreePath: string
+  hostId?: ExecutionHostId
 }
 
+export type ParsedCanonicalWorktreeKey = {
+  hostId: ExecutionHostId
+  repoId: string
+  worktreePath: string
+}
+
+export type ParsedAnyWorktreeId =
+  | ({ format: 'canonical' } & ParsedCanonicalWorktreeKey)
+  | ({ format: 'legacy' } & ParsedWorktreeId)
+
 export const FOLDER_WORKSPACE_INSTANCE_SEPARATOR = '::workspace:'
+const WORKTREE_KEY_PREFIX = 'orca-worktree://v1?'
 const FOLDER_WORKSPACE_INSTANCE_SUFFIX = new RegExp(
   `${FOLDER_WORKSPACE_INSTANCE_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[0-9a-f-]{36}$`
 )
 
+function encodeKeyPart(value: string): string {
+  return encodeURIComponent(value)
+}
+
+function readSingleParam(params: URLSearchParams, key: string): string | null {
+  const values = params.getAll(key)
+  if (values.length !== 1) {
+    return null
+  }
+  const [value] = values
+  return value.length > 0 ? value : null
+}
+
+export function makeLegacyWorktreeId(repoId: string, path: string): string {
+  return `${repoId}${WORKTREE_ID_SEPARATOR}${path}`
+}
+
+export function makeWorktreeKey(input: {
+  hostId: ExecutionHostId
+  repoId: string
+  path: string
+}): string {
+  return `${WORKTREE_KEY_PREFIX}${[
+    `hostId=${encodeKeyPart(input.hostId)}`,
+    `repoId=${encodeKeyPart(input.repoId)}`,
+    `path=${encodeKeyPart(input.path)}`
+  ].join('&')}`
+}
+
+export function makeRepoWorktreeKey(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string
+): string {
+  return makeWorktreeKey({
+    hostId: getRepoExecutionHostId(repo),
+    repoId: repo.id,
+    path
+  })
+}
+
+export function getRepoWorktreeIdAliases(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string
+): Set<string> {
+  return new Set([makeRepoWorktreeKey(repo, path), makeLegacyWorktreeId(repo.id, path)])
+}
+
+export function isRepoWorktreeIdAlias(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string,
+  worktreeId: string
+): boolean {
+  return getRepoWorktreeIdAliases(repo, path).has(worktreeId)
+}
+
+export function parseWorktreeKey(worktreeId: string): ParsedCanonicalWorktreeKey | null {
+  if (!worktreeId.startsWith(WORKTREE_KEY_PREFIX)) {
+    return null
+  }
+  const query = worktreeId.slice(WORKTREE_KEY_PREFIX.length)
+  const params = new URLSearchParams(query)
+  const keys = [...params.keys()]
+  if (keys.length !== 3 || keys[0] !== 'hostId' || keys[1] !== 'repoId' || keys[2] !== 'path') {
+    return null
+  }
+  const rawHostId = readSingleParam(params, 'hostId')
+  const rawRepoId = readSingleParam(params, 'repoId')
+  const rawPath = readSingleParam(params, 'path')
+  if (!rawHostId || !rawRepoId || !rawPath) {
+    return null
+  }
+  const hostId = normalizeExecutionHostId(rawHostId)
+  if (!hostId) {
+    return null
+  }
+  return { hostId, repoId: rawRepoId, worktreePath: rawPath }
+}
+
+export function parseAnyWorktreeId(worktreeId: string): ParsedAnyWorktreeId | null {
+  const canonical = parseWorktreeKey(worktreeId)
+  if (canonical) {
+    return { format: 'canonical', ...canonical }
+  }
+  const legacy = splitLegacyWorktreeId(worktreeId)
+  return legacy ? { format: 'legacy', ...legacy } : null
+}
+
+export function isLegacyWorktreeId(worktreeId: string): boolean {
+  return !parseWorktreeKey(worktreeId) && splitLegacyWorktreeId(worktreeId) !== null
+}
+
 export function getRepoIdFromWorktreeId(worktreeId: string): string {
+  const canonical = parseWorktreeKey(worktreeId)
+  if (canonical) {
+    return canonical.repoId
+  }
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)
   return separatorIdx === -1 ? worktreeId : worktreeId.slice(0, separatorIdx)
 }
 
-export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
+function splitLegacyWorktreeId(worktreeId: string): ParsedWorktreeId | null {
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)
   if (separatorIdx === -1) {
     return null
@@ -28,12 +141,21 @@ export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
   }
 }
 
+export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
+  const canonical = parseWorktreeKey(worktreeId)
+  if (canonical) {
+    return canonical
+  }
+  return splitLegacyWorktreeId(worktreeId)
+}
+
 export function splitWorktreeIdForFilesystem(worktreeId: string): ParsedWorktreeId | null {
   const parsed = splitWorktreeId(worktreeId)
   if (!parsed) {
     return null
   }
   return {
+    ...(parsed.hostId !== undefined ? { hostId: parsed.hostId } : {}),
     repoId: parsed.repoId,
     // Why: folder projects can have multiple workspace sessions backed by the
     // same directory. Their IDs carry a UUID suffix, but filesystem callers


### PR DESCRIPTION
## Context

Tracking issue: #6032

This is the second PR in the Remote Orca Servers state stack. It should be reviewed after #6030. The branch includes #6030's commit until that PR lands because GitHub cannot use a fork-only branch as the base for an upstream PR.

Once repo refresh is host-aware, shared projects still have a second failure mode: project compatibility and `projectHostSetups` can be reconciled with bare repo ids. When the same project exists on a local host and a Remote Orca Server, refreshing one host can drop the other host from compatibility and setup state.

## Changed

- Merge project compatibility by host-qualified source repo identity.
- Keep `projectHostSetups` for sibling hosts during a host-specific refresh.
- Preserve setup rows without a `repoId` by falling back to setup id on the same host, so empty setup rows do not collapse.

## Regression coverage

The new tests create a shared project with host-specific repo state, then refresh one host. On `main`, the refresh drops the other host from `sourceRepoIds` or collapses setup rows. With this stack, both hosts keep their project state.

## Tests

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/repo-identity-reconcile.test.ts src/renderer/src/store/slices/repo-host-refresh-merge.test.ts src/renderer/src/store/slices/repos-multi-host-refresh.test.ts src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts src/renderer/src/store/slices/repo-reorder-host-split.test.ts src/renderer/src/lib/repo-runtime-owner.test.ts src/renderer/src/store/slices/repos-update-serialization.test.ts src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/repo-runtime-owner.ts src/renderer/src/lib/repo-runtime-owner.test.ts src/renderer/src/store/slices/repo-host-refresh-merge.ts src/renderer/src/store/slices/repo-host-refresh-merge.test.ts src/renderer/src/store/slices/repo-identity-reconcile.ts src/renderer/src/store/slices/repo-identity-reconcile.test.ts src/renderer/src/store/slices/repo-reorder-host-split.ts src/renderer/src/store/slices/repo-reorder-host-split.test.ts src/renderer/src/store/slices/repos.ts src/renderer/src/store/slices/repos-multi-host-refresh.test.ts src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts src/renderer/src/store/slices/project-host-setup-compatibility-merge.ts src/renderer/src/store/slices/project-host-setup-compatibility-merge.test.ts`
- `pnpm run typecheck:web`

## Stack

1. #6030: preserve same-id repos across hosts.
2. This PR: preserve shared project host setup state across host refreshes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6031">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->