### PR TITLE
Keep workspace board above the status bar

### DIFF
--- a/src/renderer/src/components/sidebar/Sidebar.test.tsx
+++ b/src/renderer/src/components/sidebar/Sidebar.test.tsx
@@ -45,8 +45,18 @@ vi.mock('./SidebarToolbar', () => ({
 }))
 
 vi.mock('./WorkspaceKanbanDrawer', () => ({
-  default: ({ leftSidebarStyle }: { leftSidebarStyle?: CSSProperties }) => (
-    <div data-testid="workspace-kanban-drawer" style={leftSidebarStyle} />
+  default: ({
+    leftSidebarStyle,
+    statusBarVisible
+  }: {
+    leftSidebarStyle?: CSSProperties
+    statusBarVisible: boolean
+  }) => (
+    <div
+      data-testid="workspace-kanban-drawer"
+      data-status-bar-visible={String(statusBarVisible)}
+      style={leftSidebarStyle}
+    />
   )
 }))
 
@@ -76,7 +86,7 @@ vi.mock('./useWorkspaceBoardPanel', () => ({
 
 import Sidebar from './index'
 
-function setSidebarState(settings: GlobalSettings): void {
+function setSidebarState(settings: GlobalSettings, statusBarVisible = true): void {
   mocks.state = {
     activeModal: null,
     fetchAllWorktrees: vi.fn(),
@@ -84,7 +94,8 @@ function setSidebarState(settings: GlobalSettings): void {
     setSidebarWidth: vi.fn(),
     settings,
     sidebarOpen: true,
-    sidebarWidth: 320
+    sidebarWidth: 320,
+    statusBarVisible
   }
 }
 
@@ -111,5 +122,14 @@ describe('Sidebar', () => {
     expect(markup).toContain('--worktree-sidebar-foreground:#f0f4f8')
     expect(markup).toContain('data-testid="workspace-kanban-drawer"')
     expect(markup.match(/--worktree-sidebar:#101820/g)).toHaveLength(2)
+  })
+
+  it('passes status bar visibility into the workspace board drawer', () => {
+    setSidebarState(getDefaultSettings('/tmp'), false)
+
+    const markup = renderSidebar()
+
+    expect(markup).toContain('data-testid="workspace-kanban-drawer"')
+    expect(markup).toContain('data-status-bar-visible="false"')
   })
 })

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.task-status-sync.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.task-status-sync.test.tsx
@@ -297,6 +297,7 @@ describe('WorkspaceKanbanDrawer task status sync wiring', () => {
     expect(sheet?.style.height).toBe('auto')
     expect(overlay?.style.top).toBe('36px')
     expect(overlay?.style.bottom).toBe('0px')
+    expect(overlay?.style.pointerEvents).toBe('none')
   })
 
   it('syncs Linear after a document-drop status move when the setting is enabled', () => {

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.task-status-sync.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.task-status-sync.test.tsx
@@ -58,8 +58,21 @@ vi.mock('sonner', () => ({
 
 vi.mock('@/components/ui/sheet', () => ({
   Sheet: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SheetContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-slot="sheet-content">{children}</div>
+  SheetContent: ({
+    children,
+    overlayStyle,
+    style
+  }: {
+    children: React.ReactNode
+    overlayStyle?: React.CSSProperties
+    style?: React.CSSProperties
+  }) => (
+    <>
+      <div data-slot="sheet-overlay" style={overlayStyle} />
+      <div data-slot="sheet-content" style={style}>
+        {children}
+      </div>
+    </>
   )
 }))
 
@@ -201,7 +214,7 @@ function repo(overrides: Partial<Repo> = {}): Repo {
   } as Repo
 }
 
-function renderDrawer(item: Worktree, enabled = true): void {
+function renderDrawer(item: Worktree, enabled = true, statusBarVisible = true): void {
   const updateWorktreeMeta = vi.fn()
   const updateWorktreesMeta = vi.fn()
   const recordFeatureInteraction = vi.fn()
@@ -226,6 +239,7 @@ function renderDrawer(item: Worktree, enabled = true): void {
     root.render(
       <WorkspaceKanbanDrawer
         open={true}
+        statusBarVisible={statusBarVisible}
         dragPreview={false}
         preserveOpenForMenu={false}
         onOpenChange={vi.fn()}
@@ -258,6 +272,33 @@ afterEach(() => {
 })
 
 describe('WorkspaceKanbanDrawer task status sync wiring', () => {
+  it('reserves the status bar row in the board sheet and overlay when visible', () => {
+    renderDrawer(worktree(), true, true)
+
+    const sheet = document.querySelector<HTMLElement>('[data-slot="sheet-content"]')
+    const overlay = document.querySelector<HTMLElement>('[data-slot="sheet-overlay"]')
+
+    expect(sheet?.style.top).toBe('36px')
+    expect(sheet?.style.bottom).toBe('24px')
+    expect(sheet?.style.height).toBe('auto')
+    expect(overlay?.style.top).toBe('36px')
+    expect(overlay?.style.bottom).toBe('24px')
+    expect(overlay?.style.pointerEvents).toBe('none')
+  })
+
+  it('keeps the board sheet and overlay flush to the viewport bottom when status bar is hidden', () => {
+    renderDrawer(worktree(), true, false)
+
+    const sheet = document.querySelector<HTMLElement>('[data-slot="sheet-content"]')
+    const overlay = document.querySelector<HTMLElement>('[data-slot="sheet-overlay"]')
+
+    expect(sheet?.style.top).toBe('36px')
+    expect(sheet?.style.bottom).toBe('0px')
+    expect(sheet?.style.height).toBe('auto')
+    expect(overlay?.style.top).toBe('36px')
+    expect(overlay?.style.bottom).toBe('0px')
+  })
+
   it('syncs Linear after a document-drop status move when the setting is enabled', () => {
     const item = worktree()
     renderDrawer(item)

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -46,11 +46,15 @@ import { translate } from '@/i18n/i18n'
 type WorkspaceKanbanDrawerProps = {
   leftSidebarStyle?: React.CSSProperties
   open: boolean
+  statusBarVisible: boolean
   dragPreview: boolean
   preserveOpenForMenu: boolean
   onOpenChange: (open: boolean) => void
   onMenuOpenChange: (open: boolean) => void
 }
+
+const WORKSPACE_TOP_CHROME_HEIGHT = 36
+const STATUS_BAR_RESERVE_HEIGHT = 24
 
 function formatTaskStatusSyncMessage(message: WorkspaceBoardTaskStatusSyncMessage): string {
   switch (message.kind) {
@@ -129,6 +133,7 @@ function formatTaskStatusSyncDescription(result: WorkspaceBoardTaskStatusSyncRes
 export default function WorkspaceKanbanDrawer({
   leftSidebarStyle,
   open,
+  statusBarVisible,
   dragPreview,
   preserveOpenForMenu,
   onOpenChange,
@@ -632,6 +637,9 @@ export default function WorkspaceKanbanDrawer({
   const drawerLeftCss = sidebarOpen
     ? `var(--workspace-sidebar-live-width, ${sidebarWidth}px)`
     : '0px'
+  // Why: App reserves a bottom status row while visible; the portalled board
+  // must share that viewport bound instead of covering the status controls.
+  const drawerBottom = `${statusBarVisible ? STATUS_BAR_RESERVE_HEIGHT : 0}px`
 
   return (
     <Sheet open={open} onOpenChange={handleSheetOpenChange} modal={false}>
@@ -639,15 +647,21 @@ export default function WorkspaceKanbanDrawer({
         side="left"
         showCloseButton={false}
         className="workspace-kanban-sheet-content bg-worktree-sidebar p-0 sm:max-w-none"
-        overlayStyle={{ top: 36, left: drawerLeftCss, pointerEvents: 'none' }}
+        overlayStyle={{
+          top: WORKSPACE_TOP_CHROME_HEIGHT,
+          bottom: drawerBottom,
+          left: drawerLeftCss,
+          pointerEvents: 'none'
+        }}
         style={
           {
             ...leftSidebarStyle,
             // Why: the board is a companion to the workspace sidebar, so it
             // expands from the sidebar edge instead of covering the sidebar.
             left: drawerLeftCss,
-            top: 36,
-            height: 'calc(100% - 36px)',
+            top: WORKSPACE_TOP_CHROME_HEIGHT,
+            bottom: drawerBottom,
+            height: 'auto',
             width: `min(calc(100vw - ${drawerLeftCss}), 1294px)`
           } as React.CSSProperties
         }

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -44,6 +44,7 @@ function Sidebar({
   const settings = useAppStore((s) => s.settings)
   const fetchAllWorktrees = useAppStore((s) => s.fetchAllWorktrees)
   const activeModal = useAppStore((s) => s.activeModal)
+  const statusBarVisible = useAppStore((s) => s.statusBarVisible)
   const systemPrefersDark = useSystemPrefersDark()
   const leftSidebarStyle = useMemo(
     () => resolveLeftSidebarStyleVariables(settings, systemPrefersDark),
@@ -201,6 +202,7 @@ function Sidebar({
         <WorkspaceKanbanDrawer
           leftSidebarStyle={leftSidebarStyle}
           open={workspaceBoardRenderedOpen}
+          statusBarVisible={statusBarVisible}
           dragPreview={workspaceBoardDragPreviewOpen}
           preserveOpenForMenu={workspaceBoardMenuOpen}
           onOpenChange={handleWorkspaceBoardOpenChange}


### PR DESCRIPTION
## Summary

The workspace board now respects the app's bottom status bar reserve when the status/agent-usage row is visible. The drawer keeps its existing sidebar attachment and width behavior, but its portalled Sheet content and pointer-transparent overlay use matching `top` and `bottom` viewport bounds so the board ends above the status row.

## Design Approach

- Use `statusBarVisible` from the app store as the source of truth, matching the `App` shell's status-bar/fallback reservation.
- Pass that state from `Sidebar` into `WorkspaceKanbanDrawer`.
- Replace the board's fixed `height: calc(100% - 36px)` sizing with `top: 36px`, `bottom: 24px|0px`, and `height: auto` so the existing Sheet `h-full` class cannot override the bottom reserve.
- Keep colors, tokens, shadows, component primitives, left offset, width cap, drag preview, and sidebar resize behavior unchanged.

## Pipeline Evidence

- Design review: `auto-design-review-fix` returned READY after one fix iteration and final clean verification.
- Implementation: changed only `WorkspaceKanbanDrawer`, `Sidebar`, and focused tests. No deviations from the reviewed design.
- Completeness verification: read-only verifier confirmed every design requirement was implemented; remaining screenshot evidence gap was covered by `brennan-test-changes`.
- Code review loop: two independent `review-code` reviewers returned clean in the same round.
- CodeRabbit: first pass had one actionable test-completeness nit, fixed in `924302ff2`; refreshed review reported no actionable comments.

## Validation

- [x] `git diff --check`
- [x] Focused vitest: `src/renderer/src/components/sidebar/Sidebar.test.tsx` and `src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.task-status-sync.test.tsx` passed, 11 tests total.
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `brennan-test-changes` verdict: land.
- [x] Electron product-surface validation on exact worktree identity: `devBranch` was `brennanb2025/fix-board-overlap`, `devRepoRoot` was `/Users/thebr/orca/workspaces/orca/tang`.
- [x] Real UI workflow: opened the Workspace board through the sidebar Workspace board button with `demo-project` active.
- [x] Layout measurement: viewport height `865`, board bottom `841`, status row top `843.5`, board CSS bottom inset `24px`.
- [x] Hit-testing: bottom Resource Manager control resolved to the actual button (`sameButton: true`).
- [x] Renderer console: 0 errors during validation.

## Screenshot Evidence

Captured locally and not committed:

- `.playwright-cli/workspace-board-statusbar-no-overlap-demo-project-2026-06-22.png`

## Post-PR Stabilization

- [x] Waited 8 minutes after opening the PR, reviewed CodeRabbit and checks.
- [x] Fixed the actionable CodeRabbit test nit by also asserting overlay pointer events in the hidden-status-bar branch.
- [x] Pushed the follow-up commit and waited 8 minutes again.
- [x] Refreshed CodeRabbit review reported no actionable comments.
- [x] PR check `verify` passed.

## Assumptions / Residual Risk

- The status bar height remains 24px, matching the existing `App` fallback row (`h-6 min-h-[24px]`).
- This is renderer layout only; no SSH, runtime RPC, external CLI, provider auth, or git-provider behavior changed.
