### PR TITLE
Fix remote Node.js detection for nvm, mise, asdf, and volta

### DIFF
--- a/src/main/ssh/ssh-remote-node-resolution.test.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SshConnection } from './ssh-connection'
+
+const execCommandMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  execCommand: execCommandMock
+}))
+
+const { resolveRemoteNodePath } = await import('./ssh-remote-node-resolution')
+
+const conn = {} as SshConnection
+
+describe('resolveRemoteNodePath', () => {
+  beforeEach(() => {
+    execCommandMock.mockReset()
+  })
+
+  // ── Login-shell strategy ──────────────────────────────────────────────
+
+  it('resolves node via the user login shell and version-checks the result', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/zsh') // $SHELL
+      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n') // command -v node
+      .mockResolvedValueOnce('v20.11.0\n') // node --version
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
+      '/home/u/.nvm/versions/node/v20.11.0/bin/node'
+    )
+
+    // Why: the login-shell probe must bypass wrapRemoteCommandForPosixShell so
+    // the user's own shell sources its init files (nvm.sh / mise activate).
+    expect(execCommandMock).toHaveBeenNthCalledWith(2, conn, `'/bin/zsh' -lc 'command -v node'`, {
+      wrapCommand: false,
+      timeoutMs: 8_000
+    })
+  })
+
+  it('respects a non-default $SHELL instead of hardcoding bash', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/usr/bin/fish') // $SHELL
+      .mockResolvedValueOnce('/opt/homebrew/bin/node\n')
+      .mockResolvedValueOnce('v22.0.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    expect(execCommandMock).toHaveBeenNthCalledWith(
+      2,
+      conn,
+      `'/usr/bin/fish' -lc 'command -v node'`,
+      { wrapCommand: false, timeoutMs: 8_000 }
+    )
+  })
+
+  it('falls back to /bin/sh when $SHELL is unset', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('') // empty $SHELL → falls back to /bin/sh via ${SHELL:-/bin/sh}
+      .mockResolvedValueOnce('/usr/local/bin/node\n')
+      .mockResolvedValueOnce('v18.19.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
+  })
+
+  it('falls through to path probes when the login shell finds a too-old node', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v10.24.1/bin/node\n') // login shell: node 10
+      .mockResolvedValueOnce('v10.24.1\n') // version check fails (< 18)
+      // Strategy 2: path probe script returns a modern node.
+      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
+      '/home/u/.nvm/versions/node/v20.11.0/bin/node'
+    )
+  })
+
+  it('falls through to path probes when the login shell finds no node', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/zsh') // $SHELL
+      .mockResolvedValueOnce('\n') // command -v node: empty
+      // Path probe finds mise-managed node.
+      .mockResolvedValueOnce('/home/u/.local/share/mise/installs/node/20/bin/node\n')
+      .mockResolvedValueOnce('v20.10.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
+      '/home/u/.local/share/mise/installs/node/20/bin/node'
+    )
+  })
+
+  it('falls through to path probes when the login-shell exec times out', async () => {
+    execCommandMock
+      .mockRejectedValueOnce(new Error('SSH exec channel timed out')) // $SHELL probe hangs
+      .mockResolvedValueOnce('/usr/local/bin/node\n') // path probe
+      .mockResolvedValueOnce('v20.0.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
+  })
+
+  it('probes mise install directories', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('\n') // login shell: no node
+      .mockResolvedValueOnce('/home/u/.local/share/mise/installs/node/20/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    const callScript = execCommandMock.mock.calls[2]![1] as string
+    expect(callScript).toContain('$HOME/.local/share/mise/installs/node/*/bin/node')
+  })
+
+  it('probes asdf install directories', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('\n') // login shell: no node
+      .mockResolvedValueOnce('/home/u/.asdf/installs/nodejs/20.11.0/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    const callScript = execCommandMock.mock.calls[2]![1] as string
+    expect(callScript).toContain('$HOME/.asdf/installs/nodejs/*/bin/node')
+  })
+
+  it('probes volta bin directory', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('\n') // login shell: no node
+      .mockResolvedValueOnce('/home/u/.volta/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    const callScript = execCommandMock.mock.calls[2]![1] as string
+    expect(callScript).toContain('$HOME/.volta/bin/node')
+  })
+
+  it('respects a custom NVM_DIR instead of hardcoding $HOME/.nvm', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('\n') // login shell: no node
+      .mockResolvedValueOnce('/custom/nvm/versions/node/v20.11.0/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    const callScript = execCommandMock.mock.calls[2]![1] as string
+    expect(callScript).toContain('${NVM_DIR:-$HOME/.nvm}/versions/node/*/bin/node')
+  })
+
+  it('uses version sort so nvm picks v20 over v9 (not alphabetical)', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('\n') // login shell: no node
+      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    const callScript = execCommandMock.mock.calls[2]![1] as string
+    expect(callScript).toMatch(/sort -V/)
+  })
+
+  it('rejects a path-probe candidate whose version is below the minimum', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('\n') // login shell: no node
+      // Probe returns two candidates; the first (v10) is too old, the second
+      // (v20) must be selected instead.
+      .mockResolvedValueOnce(
+        '/home/u/.nvm/versions/node/v10.24.1/bin/node\n/home/u/.nvm/versions/node/v20.11.0/bin/node\n'
+      )
+      .mockResolvedValueOnce('v10.24.1\n') // first candidate fails the gate
+      .mockResolvedValueOnce('v20.11.0\n') // second candidate passes
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
+      '/home/u/.nvm/versions/node/v20.11.0/bin/node'
+    )
+  })
+
+  it('accepts Node 18 (the exact minimum) as valid', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('/usr/local/bin/node\n')
+      .mockResolvedValueOnce('v18.0.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
+  })
+
+  // ── Failure ───────────────────────────────────────────────────────────
+
+  it('throws when both strategies find no usable node', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('\n') // login shell: no node
+      .mockResolvedValueOnce('\n') // path probe: empty
+      .mockRejectedValueOnce(new Error('no version')) // version check on nothing
+
+    await expect(resolveRemoteNodePath(conn)).rejects.toThrow(/Node\.js not found/)
+  })
+
+  it('throws when every candidate is below the minimum version', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('/old/node\n') // login shell
+      .mockResolvedValueOnce('v8.17.0\n') // too old
+      .mockResolvedValueOnce('/old/node2\n') // path probe
+      .mockResolvedValueOnce('v6.17.0\n') // too old
+
+    await expect(resolveRemoteNodePath(conn)).rejects.toThrow(/Node\.js not found/)
+  })
+})

--- a/src/main/ssh/ssh-remote-node-resolution.test.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.test.ts
@@ -7,6 +7,8 @@ vi.mock('./ssh-relay-deploy-helpers', () => ({
   execCommand: execCommandMock
 }))
 
+// Why: await import() is required so vi.mock() above registers before the
+// module under test is evaluated. Static import would bypass the mock.
 const { resolveRemoteNodePath } = await import('./ssh-remote-node-resolution')
 
 const conn = {} as SshConnection
@@ -16,158 +18,88 @@ describe('resolveRemoteNodePath', () => {
     execCommandMock.mockReset()
   })
 
-  // ── Login-shell strategy ──────────────────────────────────────────────
+  // ── Path-probe strategy (runs first) ───────────────────────────────────
 
-  it('resolves node via the user login shell and version-checks the result', async () => {
+  it('resolves system node via the path probe', async () => {
     execCommandMock
-      .mockResolvedValueOnce('/bin/zsh') // $SHELL
-      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n') // command -v node
-      .mockResolvedValueOnce('v20.11.0\n') // node --version
-
-    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
-      '/home/u/.nvm/versions/node/v20.11.0/bin/node'
-    )
-
-    // Why: the login-shell probe must bypass wrapRemoteCommandForPosixShell so
-    // the user's own shell sources its init files (nvm.sh / mise activate).
-    expect(execCommandMock).toHaveBeenNthCalledWith(2, conn, `'/bin/zsh' -lc 'command -v node'`, {
-      wrapCommand: false,
-      timeoutMs: 8_000
-    })
-  })
-
-  it('respects a non-default $SHELL instead of hardcoding bash', async () => {
-    execCommandMock
-      .mockResolvedValueOnce('/usr/bin/fish') // $SHELL
-      .mockResolvedValueOnce('/opt/homebrew/bin/node\n')
-      .mockResolvedValueOnce('v22.0.0\n')
-
-    await resolveRemoteNodePath(conn)
-
-    expect(execCommandMock).toHaveBeenNthCalledWith(
-      2,
-      conn,
-      `'/usr/bin/fish' -lc 'command -v node'`,
-      { wrapCommand: false, timeoutMs: 8_000 }
-    )
-  })
-
-  it('falls back to /bin/sh when $SHELL is unset', async () => {
-    execCommandMock
-      .mockResolvedValueOnce('') // empty $SHELL → falls back to /bin/sh via ${SHELL:-/bin/sh}
-      .mockResolvedValueOnce('/usr/local/bin/node\n')
-      .mockResolvedValueOnce('v18.19.0\n')
-
-    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
-  })
-
-  it('falls through to path probes when the login shell finds a too-old node', async () => {
-    execCommandMock
-      .mockResolvedValueOnce('/bin/bash') // $SHELL
-      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v10.24.1/bin/node\n') // login shell: node 10
-      .mockResolvedValueOnce('v10.24.1\n') // version check fails (< 18)
-      // Strategy 2: path probe script returns a modern node.
-      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n')
-      .mockResolvedValueOnce('v20.11.0\n')
-
-    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
-      '/home/u/.nvm/versions/node/v20.11.0/bin/node'
-    )
-  })
-
-  it('falls through to path probes when the login shell finds no node', async () => {
-    execCommandMock
-      .mockResolvedValueOnce('/bin/zsh') // $SHELL
-      .mockResolvedValueOnce('\n') // command -v node: empty
-      // Path probe finds mise-managed node.
-      .mockResolvedValueOnce('/home/u/.local/share/mise/installs/node/20/bin/node\n')
-      .mockResolvedValueOnce('v20.10.0\n')
-
-    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
-      '/home/u/.local/share/mise/installs/node/20/bin/node'
-    )
-  })
-
-  it('falls through to path probes when the login-shell exec times out', async () => {
-    execCommandMock
-      .mockRejectedValueOnce(new Error('SSH exec channel timed out')) // $SHELL probe hangs
       .mockResolvedValueOnce('/usr/local/bin/node\n') // path probe
-      .mockResolvedValueOnce('v20.0.0\n')
+      .mockResolvedValueOnce('v20.0.0\n') // version check
 
     await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
   })
 
   it('probes mise install directories', async () => {
     execCommandMock
-      .mockResolvedValueOnce('/bin/bash') // $SHELL
-      .mockResolvedValueOnce('\n') // login shell: no node
       .mockResolvedValueOnce('/home/u/.local/share/mise/installs/node/20/bin/node\n')
       .mockResolvedValueOnce('v20.11.0\n')
 
     await resolveRemoteNodePath(conn)
 
-    const callScript = execCommandMock.mock.calls[2]![1] as string
+    const callScript = execCommandMock.mock.calls[0]![1] as string
     expect(callScript).toContain('$HOME/.local/share/mise/installs/node/*/bin/node')
   })
 
   it('probes asdf install directories', async () => {
     execCommandMock
-      .mockResolvedValueOnce('/bin/bash') // $SHELL
-      .mockResolvedValueOnce('\n') // login shell: no node
       .mockResolvedValueOnce('/home/u/.asdf/installs/nodejs/20.11.0/bin/node\n')
       .mockResolvedValueOnce('v20.11.0\n')
 
     await resolveRemoteNodePath(conn)
 
-    const callScript = execCommandMock.mock.calls[2]![1] as string
+    const callScript = execCommandMock.mock.calls[0]![1] as string
     expect(callScript).toContain('$HOME/.asdf/installs/nodejs/*/bin/node')
   })
 
   it('probes volta bin directory', async () => {
     execCommandMock
-      .mockResolvedValueOnce('/bin/bash') // $SHELL
-      .mockResolvedValueOnce('\n') // login shell: no node
       .mockResolvedValueOnce('/home/u/.volta/bin/node\n')
       .mockResolvedValueOnce('v20.11.0\n')
 
     await resolveRemoteNodePath(conn)
 
-    const callScript = execCommandMock.mock.calls[2]![1] as string
+    const callScript = execCommandMock.mock.calls[0]![1] as string
     expect(callScript).toContain('$HOME/.volta/bin/node')
   })
 
   it('respects a custom NVM_DIR instead of hardcoding $HOME/.nvm', async () => {
     execCommandMock
-      .mockResolvedValueOnce('/bin/bash') // $SHELL
-      .mockResolvedValueOnce('\n') // login shell: no node
       .mockResolvedValueOnce('/custom/nvm/versions/node/v20.11.0/bin/node\n')
       .mockResolvedValueOnce('v20.11.0\n')
 
     await resolveRemoteNodePath(conn)
 
-    const callScript = execCommandMock.mock.calls[2]![1] as string
+    const callScript = execCommandMock.mock.calls[0]![1] as string
     expect(callScript).toContain('${NVM_DIR:-$HOME/.nvm}/versions/node/*/bin/node')
   })
 
   it('uses version sort so nvm picks v20 over v9 (not alphabetical)', async () => {
     execCommandMock
-      .mockResolvedValueOnce('/bin/bash') // $SHELL
-      .mockResolvedValueOnce('\n') // login shell: no node
       .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n')
       .mockResolvedValueOnce('v20.11.0\n')
 
     await resolveRemoteNodePath(conn)
 
-    const callScript = execCommandMock.mock.calls[2]![1] as string
+    const callScript = execCommandMock.mock.calls[0]![1] as string
     expect(callScript).toMatch(/sort -V/)
   })
 
-  it('rejects a path-probe candidate whose version is below the minimum', async () => {
+  it('joins probes with newlines, not ||, so a missing dir does not mask later probes', async () => {
     execCommandMock
-      .mockResolvedValueOnce('/bin/bash') // $SHELL
-      .mockResolvedValueOnce('\n') // login shell: no node
-      // Probe returns two candidates; the first (v10) is too old, the second
-      // (v20) must be selected instead.
+      .mockResolvedValueOnce('/usr/local/bin/node\n')
+      .mockResolvedValueOnce('v20.0.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    const callScript = execCommandMock.mock.calls[0]![1] as string
+    // Why: `||` short-circuits on exit-0 from empty `ls | sort -V | tail -1`,
+    // which would hide fnm/mise/asdf/volta behind a missing nvm dir.
+    expect(callScript).not.toContain('||')
+  })
+
+  it('rejects a path-probe candidate whose version is below the minimum', async () => {
+    // Probe returns two candidates; the first (v10) is too old, the second
+    // (v20) must be selected instead.
+    execCommandMock
       .mockResolvedValueOnce(
         '/home/u/.nvm/versions/node/v10.24.1/bin/node\n/home/u/.nvm/versions/node/v20.11.0/bin/node\n'
       )
@@ -181,31 +113,109 @@ describe('resolveRemoteNodePath', () => {
 
   it('accepts Node 18 (the exact minimum) as valid', async () => {
     execCommandMock
-      .mockResolvedValueOnce('/bin/bash') // $SHELL
       .mockResolvedValueOnce('/usr/local/bin/node\n')
       .mockResolvedValueOnce('v18.0.0\n')
 
     await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
   })
 
-  // ── Failure ───────────────────────────────────────────────────────────
-
-  it('throws when both strategies find no usable node', async () => {
+  it('deduplicates repeated candidate paths before version-checking', async () => {
+    // Why: some managers leave stale shims that resolve to the same binary;
+    // we should not version-check the same path twice.
     execCommandMock
-      .mockResolvedValueOnce('/bin/bash') // $SHELL
-      .mockResolvedValueOnce('\n') // login shell: no node
+      .mockResolvedValueOnce('/usr/local/bin/node\n/usr/local/bin/node\n')
+      .mockResolvedValueOnce('v20.0.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
+    expect(execCommandMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to the login shell when path probes find nothing', async () => {
+    execCommandMock
       .mockResolvedValueOnce('\n') // path probe: empty
-      .mockRejectedValueOnce(new Error('no version')) // version check on nothing
+      .mockResolvedValueOnce('/bin/zsh') // $SHELL
+      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n') // command -v node
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
+      '/home/u/.nvm/versions/node/v20.11.0/bin/node'
+    )
+
+    expect(execCommandMock).toHaveBeenNthCalledWith(3, conn, `'/bin/zsh' -lc 'command -v node'`, {
+      wrapCommand: false,
+      timeoutMs: 8_000
+    })
+  })
+
+  it('falls back to the login shell when every path-probe candidate is too old', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/old/node\n') // path probe
+      .mockResolvedValueOnce('v10.24.1\n') // too old
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe(
+      '/home/u/.nvm/versions/node/v20.11.0/bin/node'
+    )
+  })
+
+  // ── Login-shell strategy (fallback) ───────────────────────────────────
+
+  it('respects a non-default $SHELL instead of hardcoding bash', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('\n') // path probe: empty
+      .mockResolvedValueOnce('/usr/bin/fish') // $SHELL
+      .mockResolvedValueOnce('/opt/homebrew/bin/node\n')
+      .mockResolvedValueOnce('v22.0.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    expect(execCommandMock).toHaveBeenNthCalledWith(
+      3,
+      conn,
+      `'/usr/bin/fish' -lc 'command -v node'`,
+      { wrapCommand: false, timeoutMs: 8_000 }
+    )
+  })
+
+  it('uses /bin/sh when the $SHELL probe returns empty', async () => {
+    // Why: ${SHELL:-/bin/sh} expands to /bin/sh only when $SHELL is unset or
+    // empty. If $SHELL is set, its value is echoed; an empty echo means the
+    // probe itself failed, so we return null rather than guessing a shell.
+    execCommandMock
+      .mockResolvedValueOnce('\n') // path probe: empty
+      .mockResolvedValueOnce('') // $SHELL probe returns empty → tryResolveViaLoginShell returns null
 
     await expect(resolveRemoteNodePath(conn)).rejects.toThrow(/Node\.js not found/)
   })
 
-  it('throws when every candidate is below the minimum version', async () => {
+  // ── Failure ───────────────────────────────────────────────────────────
+
+  it('throws when both strategies find no usable node', async () => {
     execCommandMock
+      .mockResolvedValueOnce('\n') // path probe: empty
       .mockResolvedValueOnce('/bin/bash') // $SHELL
-      .mockResolvedValueOnce('/old/node\n') // login shell
+      .mockResolvedValueOnce('\n') // command -v node: empty
+
+    await expect(resolveRemoteNodePath(conn)).rejects.toThrow(/Node\.js not found/)
+  })
+
+  it('throws when the path-probe exec fails and the login shell finds nothing', async () => {
+    execCommandMock
+      .mockRejectedValueOnce(new Error('SSH exec channel failed')) // path probe errors
+      .mockResolvedValueOnce('/bin/zsh') // $SHELL
+      .mockResolvedValueOnce('\n') // command -v node: empty
+
+    await expect(resolveRemoteNodePath(conn)).rejects.toThrow(/Node\.js not found/)
+  })
+
+  it('throws when every candidate across both strategies is below the minimum', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/old/node\n') // path probe
       .mockResolvedValueOnce('v8.17.0\n') // too old
-      .mockResolvedValueOnce('/old/node2\n') // path probe
+      .mockResolvedValueOnce('/bin/bash') // $SHELL
+      .mockResolvedValueOnce('/old/node2\n') // login shell
       .mockResolvedValueOnce('v6.17.0\n') // too old
 
     await expect(resolveRemoteNodePath(conn)).rejects.toThrow(/Node\.js not found/)

--- a/src/main/ssh/ssh-remote-node-resolution.test.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SshConnection } from './ssh-connection'
 
@@ -36,7 +40,7 @@ describe('resolveRemoteNodePath', () => {
     await resolveRemoteNodePath(conn)
 
     const callScript = execCommandMock.mock.calls[0]![1] as string
-    expect(callScript).toContain('$HOME/.local/share/mise/installs/node/*/bin/node')
+    expect(callScript).toContain('"$HOME/.local/share/mise/installs/node"/*/bin/node')
   })
 
   it('probes asdf install directories', async () => {
@@ -47,7 +51,7 @@ describe('resolveRemoteNodePath', () => {
     await resolveRemoteNodePath(conn)
 
     const callScript = execCommandMock.mock.calls[0]![1] as string
-    expect(callScript).toContain('$HOME/.asdf/installs/nodejs/*/bin/node')
+    expect(callScript).toContain('"$HOME/.asdf/installs/nodejs"/*/bin/node')
   })
 
   it('probes volta bin directory', async () => {
@@ -69,10 +73,25 @@ describe('resolveRemoteNodePath', () => {
     await resolveRemoteNodePath(conn)
 
     const callScript = execCommandMock.mock.calls[0]![1] as string
-    expect(callScript).toContain('${NVM_DIR:-$HOME/.nvm}/versions/node/*/bin/node')
+    expect(callScript).toContain('nvm_dirs=${NVM_DIR:-"$HOME/.nvm"}')
+    expect(callScript).toContain('NVM_DIR[[:space:]]*=')
+    expect(callScript).toContain('"$nvm_dir"/versions/node/*/bin/node')
   })
 
-  it('uses version sort so nvm picks v20 over v9 (not alphabetical)', async () => {
+  it('quotes version-manager directory prefixes while leaving globs active', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/home/u/.fnm/node-versions/v20.11.0/installation/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    const callScript = execCommandMock.mock.calls[0]![1] as string
+    expect(callScript).toContain('"$HOME/.fnm/node-versions"/*/installation/bin/node')
+    expect(callScript).toContain('"$HOME/.local/share/mise/installs/node"/*/bin/node')
+    expect(callScript).toContain('"$HOME/.asdf/installs/nodejs"/*/bin/node')
+  })
+
+  it('does not depend on GNU sort when probing version-manager directories', async () => {
     execCommandMock
       .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n')
       .mockResolvedValueOnce('v20.11.0\n')
@@ -80,7 +99,45 @@ describe('resolveRemoteNodePath', () => {
     await resolveRemoteNodePath(conn)
 
     const callScript = execCommandMock.mock.calls[0]![1] as string
-    expect(callScript).toMatch(/sort -V/)
+    expect(callScript).not.toContain('sort -V')
+  })
+
+  it('keeps the path-probe script successful when optional directories are missing', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    const callScript = execCommandMock.mock.calls[0]![1] as string
+    expect(callScript.trimEnd()).toMatch(/\ntrue$/)
+  })
+
+  it('expands tilde NVM_DIR assignments from shell dotfiles', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('/home/u/.nvm/versions/node/v20.11.0/bin/node\n')
+      .mockResolvedValueOnce('v20.11.0\n')
+
+    await resolveRemoteNodePath(conn)
+
+    const callScript = execCommandMock.mock.calls[0]![1] as string
+    const home = mkdtempSync(path.join(os.tmpdir(), 'orca-nvm-probe-'))
+    try {
+      const nodePath = path.join(home, 'tilde-nvm/versions/node/v20.11.0/bin/node')
+      mkdirSync(path.dirname(nodePath), { recursive: true })
+      writeFileSync(nodePath, '#!/bin/sh\nprintf "v20.11.0\\n"\n')
+      chmodSync(nodePath, 0o755)
+      writeFileSync(path.join(home, '.zshrc'), 'export NVM_DIR=~/tilde-nvm\n')
+
+      const output = execFileSync('/bin/sh', ['-c', callScript], {
+        encoding: 'utf8',
+        env: { HOME: home, PATH: '/usr/bin:/bin' }
+      })
+
+      expect(output.split('\n')).toContain(nodePath)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
   })
 
   it('joins probes with newlines, not ||, so a missing dir does not mask later probes', async () => {
@@ -91,9 +148,9 @@ describe('resolveRemoteNodePath', () => {
     await resolveRemoteNodePath(conn)
 
     const callScript = execCommandMock.mock.calls[0]![1] as string
-    // Why: `||` short-circuits on exit-0 from empty `ls | sort -V | tail -1`,
-    // which would hide fnm/mise/asdf/volta behind a missing nvm dir.
-    expect(callScript).not.toContain('||')
+    // Why: an `||` chain would stop after the first successful probe and hide
+    // later version managers that may hold the first usable Node.
+    expect(callScript).not.toMatch(/node\b.*\|\|/)
   })
 
   it('rejects a path-probe candidate whose version is below the minimum', async () => {
@@ -179,15 +236,18 @@ describe('resolveRemoteNodePath', () => {
     )
   })
 
-  it('uses /bin/sh when the $SHELL probe returns empty', async () => {
-    // Why: ${SHELL:-/bin/sh} expands to /bin/sh only when $SHELL is unset or
-    // empty. If $SHELL is set, its value is echoed; an empty echo means the
-    // probe itself failed, so we return null rather than guessing a shell.
+  it('uses /bin/sh when the remote shell expansion falls back to it', async () => {
     execCommandMock
       .mockResolvedValueOnce('\n') // path probe: empty
-      .mockResolvedValueOnce('') // $SHELL probe returns empty → tryResolveViaLoginShell returns null
+      .mockResolvedValueOnce('/bin/sh\n') // ${SHELL:-/bin/sh}
+      .mockResolvedValueOnce('/usr/local/bin/node\n')
+      .mockResolvedValueOnce('v20.0.0\n')
 
-    await expect(resolveRemoteNodePath(conn)).rejects.toThrow(/Node\.js not found/)
+    await expect(resolveRemoteNodePath(conn)).resolves.toBe('/usr/local/bin/node')
+    expect(execCommandMock).toHaveBeenNthCalledWith(3, conn, `'/bin/sh' -c 'command -v node'`, {
+      wrapCommand: false,
+      timeoutMs: 8_000
+    })
   })
 
   // ── Failure ───────────────────────────────────────────────────────────

--- a/src/main/ssh/ssh-remote-node-resolution.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.ts
@@ -1,12 +1,24 @@
 import type { SshConnection } from './ssh-connection'
-import { execCommand } from './ssh-relay-deploy-helpers'
+import { shellEscape } from './ssh-connection-utils'
 import type { RemoteHostPlatform } from './ssh-remote-platform'
 import { isWindowsRemoteHost, normalizeWindowsRemotePath } from './ssh-remote-platform'
 import { powerShellCommand } from './ssh-remote-powershell'
+import { execCommand } from './ssh-relay-deploy-helpers'
 
-// Why: non-login SSH shells (the default for `exec`) don't source
-// .bashrc/.zshrc, so node installed via nvm/fnm/Homebrew isn't in PATH.
-// We try common locations and fall back to a login-shell `which`.
+// Why: the relay requires Node.js 18+. Version managers like nvm keep every
+// installed version on disk, so a naive "highest version" glob can hand back
+// Node 8/10/12 and crash the relay on launch. Gate every candidate on this.
+const MIN_NODE_MAJOR = 18
+
+// Why: version-manager shells are the reliable discovery path — nvm/mise/asdf
+// hook into shell init files and only expose node via PATH after sourcing.
+// A login shell under the user's $SHELL sources the right init files for their
+// configuration, which is where these managers put their activation hooks.
+// Give it a short timeout: interactive configs (conda prompts, etc.) can hang
+// a login shell, and we don't want one slow shell config to block the whole
+// resolution.
+const LOGIN_SHELL_PROBE_TIMEOUT_MS = 8_000
+
 export async function resolveRemoteNodePath(
   conn: SshConnection,
   host?: RemoteHostPlatform
@@ -15,46 +27,137 @@ export async function resolveRemoteNodePath(
     return resolveRemoteWindowsNodePath(conn)
   }
 
+  // Strategy 1: ask the user's own login shell where node is. This is the only
+  // path that runs version-manager init hooks (nvm.sh, `mise activate`,
+  // `asdf.sh`), so it finds node even when the manager puts nothing on PATH
+  // directly. We deliberately bypass wrapRemoteCommandForPosixShell here so
+  // the user's shell — not /bin/sh — parses the command and sources its own
+  // init files.
+  const loginShellPath = await tryResolveViaLoginShell(conn)
+  if (loginShellPath) {
+    return loginShellPath
+  }
+
+  // Strategy 2: probe well-known version-manager install directories directly.
+  // Covers users whose login shell hangs/times out, whose shell init is
+  // misconfigured, or whose $SHELL doesn't match the manager they use.
+  const probedPath = await tryResolveViaKnownPaths(conn)
+  if (probedPath) {
+    return probedPath
+  }
+
+  throwNodeNotFound()
+}
+
+// Run `command -v node` under the user's login shell, then verify the result
+// meets the minimum version. Returns null on any failure (shell missing, no
+// node found, version too old, timeout) so callers fall through to path probes.
+async function tryResolveViaLoginShell(conn: SshConnection): Promise<string | null> {
+  try {
+    // Why: $SHELL is the user's configured login shell (set by chsh / passwd).
+    // Using it — rather than hardcoding bash — means zsh users whose nvm/mise
+    // hooks live in ~/.zshrc get found too. We fall back to sh if $SHELL is
+    // unset (rare, e.g. restricted accounts).
+    const shellResult = await execCommand(conn, 'echo "${SHELL:-/bin/sh}"', {
+      timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS
+    })
+    const shell = shellResult.trim().split('\n')[0]
+    if (!shell) {
+      return null
+    }
+
+    const nodePath = await execCommand(conn, `${shellEscape(shell)} -lc 'command -v node'`, {
+      wrapCommand: false,
+      timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS
+    })
+    const candidate = nodePath.trim().split('\n')[0]
+    if (!candidate) {
+      return null
+    }
+
+    if (await nodeMeetsVersionRequirement(conn, candidate)) {
+      console.log(`[ssh-relay] Found node via login shell (${shell}): ${candidate}`)
+      return candidate
+    }
+  } catch {
+    // Fall through to path probes.
+  }
+  return null
+}
+
+// Probe the on-disk install directories of every common Node version manager
+// plus system package-manager locations. Returns the first candidate that
+// both exists and meets the minimum version.
+async function tryResolveViaKnownPaths(conn: SshConnection): Promise<string | null> {
   const script = [
+    // System / package-manager installs.
     'command -v node 2>/dev/null',
     'command -v /usr/local/bin/node 2>/dev/null',
     'command -v /opt/homebrew/bin/node 2>/dev/null',
-    // Why: nvm installs into a versioned directory. `ls -1` sorts
-    // alphabetically, which misorders versions (e.g. v9 > v18). Pipe
-    // through `sort -V` (version sort) so we pick the highest version.
-    'ls -1 $HOME/.nvm/versions/node/*/bin/node 2>/dev/null | sort -V | tail -1',
     'command -v $HOME/.local/bin/node 2>/dev/null',
-    'command -v $HOME/.fnm/aliases/default/bin/node 2>/dev/null'
+    // nvm: respect $NVM_DIR (common dotfiles override it); fall back to the
+    // default ~/.nvm. `ls -1` sorts alphabetically, which misorders versions
+    // (v9 > v18); pipe through `sort -V` so we pick the highest version.
+    'ls -1 ${NVM_DIR:-$HOME/.nvm}/versions/node/*/bin/node 2>/dev/null | sort -V | tail -1',
+    // fnm: default alias symlink, then versioned dirs as a fallback.
+    'command -v $HOME/.fnm/aliases/default/bin/node 2>/dev/null',
+    'ls -1 $HOME/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1',
+    // mise (formerly rtx): shims dir, then versioned installs.
+    'command -v $HOME/.local/share/mise/shims/node 2>/dev/null',
+    'ls -1 $HOME/.local/share/mise/installs/node/*/bin/node 2>/dev/null | sort -V | tail -1',
+    // asdf: shims dir, then versioned installs.
+    'command -v $HOME/.asdf/shims/node 2>/dev/null',
+    'ls -1 $HOME/.asdf/installs/nodejs/*/bin/node 2>/dev/null | sort -V | tail -1',
+    // volta: single bin dir with the active version symlinked in.
+    'command -v $HOME/.volta/bin/node 2>/dev/null',
+    // n: installs into /usr/local or a user-local prefix.
+    'command -v /usr/local/n/versions/node/*/bin/node 2>/dev/null'
   ].join(' || ')
 
   try {
     const result = await execCommand(conn, script)
-    const nodePath = result.trim().split('\n')[0]
-    if (nodePath) {
-      console.log(`[ssh-relay] Found node at: ${nodePath}`)
-      return nodePath
+    const candidates = result
+      .trim()
+      .split('\n')
+      .filter((line) => line.length > 0)
+
+    // Why: the `||` chain exits 0 as soon as one clause prints a path, so the
+    // first line is our candidate. But if the shell emits multiple lines (some
+    // managers leave stale shims), validate each in order and keep the first
+    // that meets the version gate.
+    for (const candidate of candidates) {
+      if (await nodeMeetsVersionRequirement(conn, candidate)) {
+        console.log(`[ssh-relay] Found node via path probe: ${candidate}`)
+        return candidate
+      }
     }
   } catch {
-    // Fall through to login shell attempt
+    // All probes failed.
   }
+  return null
+}
 
-  // Why: last resort — source the full login profile. This is separated into
-  // its own exec because `bash -lc` can hang on remotes with interactive
-  // shell configs (conda prompts, etc.). If this times out, the error message
-  // from execCommand will tell us it was the login shell attempt.
+// Returns true if `nodePath` runs and reports Node >= MIN_NODE_MAJOR.
+// Caches nothing — this runs at most twice per resolution (login shell + first
+// path-probe candidate), and the exec round-trip dominates.
+async function nodeMeetsVersionRequirement(
+  conn: SshConnection,
+  nodePath: string
+): Promise<boolean> {
   try {
-    console.log('[ssh-relay] Trying login shell to find node...')
-    const result = await execCommand(conn, "bash -lc 'command -v node' 2>/dev/null")
-    const nodePath = result.trim().split('\n')[0]
-    if (nodePath) {
-      console.log(`[ssh-relay] Found node via login shell: ${nodePath}`)
-      return nodePath
+    const versionOutput = await execCommand(conn, `${shellEscape(nodePath)} --version`, {
+      wrapCommand: false
+    })
+    const match = versionOutput.trim().match(/^v?(\d+)/)
+    if (!match) {
+      return false
     }
+    const major = Number.parseInt(match[1]!, 10)
+    return major >= MIN_NODE_MAJOR
   } catch {
-    // Fall through
+    // Binary missing or fails to run — not usable.
+    return false
   }
-
-  throwNodeNotFound()
 }
 
 async function resolveRemoteWindowsNodePath(conn: SshConnection): Promise<string> {

--- a/src/main/ssh/ssh-remote-node-resolution.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.ts
@@ -44,39 +44,54 @@ export async function resolveRemoteNodePath(
 }
 
 // Probe the on-disk install directories of every common Node version manager
-// plus system package-manager locations. Every probe runs unconditionally
-// (joined by newlines, not ||) so a missing directory prints nothing rather
-// than short-circuiting later probes. Returns the first candidate that meets
-// the minimum version.
+// plus system package-manager locations. Every probe runs unconditionally so
+// a missing directory prints nothing rather than short-circuiting later
+// probes. Returns the first candidate that meets the minimum version.
 async function tryResolveViaKnownPaths(conn: SshConnection): Promise<string | null> {
-  // Why: joining with newlines instead of `||` is intentional. An empty
-  // `ls | sort -V | tail -1` exits 0 even when it finds nothing, so an `||`
-  // chain would stop at that clause and never check fnm/mise/asdf/volta.
-  // With newlines every probe runs and contributes whatever path it finds.
-  const script = [
-    // System / package-manager installs.
-    'command -v node 2>/dev/null',
-    'command -v /usr/local/bin/node 2>/dev/null',
-    'command -v /opt/homebrew/bin/node 2>/dev/null',
-    'command -v $HOME/.local/bin/node 2>/dev/null',
-    // nvm: respect $NVM_DIR (common dotfiles override it); fall back to the
-    // default ~/.nvm. `ls -1` sorts alphabetically, which misorders versions
-    // (v9 > v18); pipe through `sort -V` so we pick the highest version.
-    'ls -1 ${NVM_DIR:-$HOME/.nvm}/versions/node/*/bin/node 2>/dev/null | sort -V | tail -1',
-    // fnm: default alias symlink, then versioned dirs as a fallback.
-    'command -v $HOME/.fnm/aliases/default/bin/node 2>/dev/null',
-    'ls -1 $HOME/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1',
-    // mise (formerly rtx): shims dir, then versioned installs.
-    'command -v $HOME/.local/share/mise/shims/node 2>/dev/null',
-    'ls -1 $HOME/.local/share/mise/installs/node/*/bin/node 2>/dev/null | sort -V | tail -1',
-    // asdf: shims dir, then versioned installs.
-    'command -v $HOME/.asdf/shims/node 2>/dev/null',
-    'ls -1 $HOME/.asdf/installs/nodejs/*/bin/node 2>/dev/null | sort -V | tail -1',
-    // volta: single bin dir with the active version symlinked in.
-    'command -v $HOME/.volta/bin/node 2>/dev/null',
-    // n: installs into /usr/local or a user-local prefix.
-    'command -v /usr/local/n/versions/node/*/bin/node 2>/dev/null'
-  ].join('\n')
+  const script = `
+command -v node 2>/dev/null
+nvm_dirs=\${NVM_DIR:-"$HOME/.nvm"}
+for nvm_file in "$HOME/.profile" "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.zprofile" "$HOME/.zshrc"
+do
+  [ -r "$nvm_file" ] || continue
+  nvm_dir_from_file=$(sed -n 's/^[[:space:]]*export[[:space:]][[:space:]]*NVM_DIR[[:space:]]*=[[:space:]]*//p; s/^[[:space:]]*NVM_DIR[[:space:]]*=[[:space:]]*//p' "$nvm_file" | tail -n 1)
+  case "$nvm_dir_from_file" in
+    \\"*\\") nvm_dir_from_file=\${nvm_dir_from_file#\\"}; nvm_dir_from_file=\${nvm_dir_from_file%%\\"*} ;;
+    \\'*\\') nvm_dir_from_file=\${nvm_dir_from_file#\\'}; nvm_dir_from_file=\${nvm_dir_from_file%%\\'*} ;;
+    *) nvm_dir_from_file=\${nvm_dir_from_file%%[[:space:]]*} ;;
+  esac
+  case "$nvm_dir_from_file" in
+    '$HOME'*) nvm_dir_from_file="$HOME\${nvm_dir_from_file#'$HOME'}" ;;
+    "~/"*) nvm_dir_from_file="$HOME/\${nvm_dir_from_file#\\~/}" ;;
+  esac
+  [ -n "$nvm_dir_from_file" ] && nvm_dirs="$nvm_dirs
+$nvm_dir_from_file"
+done
+printf '%s\\n' "$nvm_dirs" | while IFS= read -r nvm_dir
+do
+  [ -n "$nvm_dir" ] || continue
+  for candidate in "$nvm_dir"/versions/node/*/bin/node
+  do
+    [ -x "$candidate" ] && printf '%s\\n' "$candidate"
+  done
+done
+for candidate in \\
+  /usr/local/bin/node \\
+  /opt/homebrew/bin/node \\
+  "$HOME/.local/bin/node" \\
+  "$HOME/.fnm/aliases/default/bin/node" \\
+  "$HOME/.fnm/node-versions"/*/installation/bin/node \\
+  "$HOME/.local/share/mise/shims/node" \\
+  "$HOME/.local/share/mise/installs/node"/*/bin/node \\
+  "$HOME/.asdf/shims/node" \\
+  "$HOME/.asdf/installs/nodejs"/*/bin/node \\
+  "$HOME/.volta/bin/node" \\
+  /usr/local/n/versions/node/*/bin/node
+do
+  [ -x "$candidate" ] && printf '%s\\n' "$candidate"
+done
+true
+`
 
   try {
     const result = await execCommand(conn, script)
@@ -115,7 +130,7 @@ async function tryResolveViaLoginShell(conn: SshConnection): Promise<string | nu
       return null
     }
 
-    const nodePath = await execCommand(conn, `${shellEscape(shell)} -lc 'command -v node'`, {
+    const nodePath = await execCommand(conn, buildCommandInShell(shell, 'command -v node'), {
       wrapCommand: false,
       timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS
     })
@@ -132,6 +147,14 @@ async function tryResolveViaLoginShell(conn: SshConnection): Promise<string | nu
     // Fall through.
   }
   return null
+}
+
+function buildCommandInShell(shell: string, command: string): string {
+  const shellName = shell.split('/').at(-1)
+  // Why: dash and POSIX sh do not require `-l`; when $SHELL falls back to
+  // /bin/sh, prefer a portable command over login-shell semantics.
+  const mode = shellName === 'sh' || shellName === 'dash' ? '-c' : '-lc'
+  return `${shellEscape(shell)} ${mode} ${shellEscape(command)}`
 }
 
 // Returns true if `nodePath` runs and reports Node >= MIN_NODE_MAJOR.

--- a/src/main/ssh/ssh-remote-node-resolution.ts
+++ b/src/main/ssh/ssh-remote-node-resolution.ts
@@ -10,13 +10,9 @@ import { execCommand } from './ssh-relay-deploy-helpers'
 // Node 8/10/12 and crash the relay on launch. Gate every candidate on this.
 const MIN_NODE_MAJOR = 18
 
-// Why: version-manager shells are the reliable discovery path — nvm/mise/asdf
-// hook into shell init files and only expose node via PATH after sourcing.
-// A login shell under the user's $SHELL sources the right init files for their
-// configuration, which is where these managers put their activation hooks.
-// Give it a short timeout: interactive configs (conda prompts, etc.) can hang
-// a login shell, and we don't want one slow shell config to block the whole
-// resolution.
+// Why: the login-shell fallback catches custom PATH setups in ~/.profile that
+// the path probes don't cover. Interactive configs (conda prompts, etc.) can
+// hang a login shell, so keep this short.
 const LOGIN_SHELL_PROBE_TIMEOUT_MS = 8_000
 
 export async function resolveRemoteNodePath(
@@ -27,68 +23,36 @@ export async function resolveRemoteNodePath(
     return resolveRemoteWindowsNodePath(conn)
   }
 
-  // Strategy 1: ask the user's own login shell where node is. This is the only
-  // path that runs version-manager init hooks (nvm.sh, `mise activate`,
-  // `asdf.sh`), so it finds node even when the manager puts nothing on PATH
-  // directly. We deliberately bypass wrapRemoteCommandForPosixShell here so
-  // the user's shell — not /bin/sh — parses the command and sources its own
-  // init files.
-  const loginShellPath = await tryResolveViaLoginShell(conn)
-  if (loginShellPath) {
-    return loginShellPath
-  }
-
-  // Strategy 2: probe well-known version-manager install directories directly.
-  // Covers users whose login shell hangs/times out, whose shell init is
-  // misconfigured, or whose $SHELL doesn't match the manager they use.
+  // Strategy 1: probe well-known install directories for every common Node
+  // version manager (nvm, fnm, mise, asdf, volta, n) plus system locations.
+  // This doesn't depend on shell startup-file semantics — bash -lc skips
+  // .bashrc and zsh -lc skips .zshrc, but those are exactly the files where
+  // nvm/mise/asdf hooks live. Probing directories directly is deterministic.
   const probedPath = await tryResolveViaKnownPaths(conn)
   if (probedPath) {
     return probedPath
   }
 
+  // Strategy 2 (fallback): ask the user's login shell. Catches custom PATH
+  // setups in ~/.profile / ~/.bash_profile that the probes don't cover.
+  const loginShellPath = await tryResolveViaLoginShell(conn)
+  if (loginShellPath) {
+    return loginShellPath
+  }
+
   throwNodeNotFound()
 }
 
-// Run `command -v node` under the user's login shell, then verify the result
-// meets the minimum version. Returns null on any failure (shell missing, no
-// node found, version too old, timeout) so callers fall through to path probes.
-async function tryResolveViaLoginShell(conn: SshConnection): Promise<string | null> {
-  try {
-    // Why: $SHELL is the user's configured login shell (set by chsh / passwd).
-    // Using it — rather than hardcoding bash — means zsh users whose nvm/mise
-    // hooks live in ~/.zshrc get found too. We fall back to sh if $SHELL is
-    // unset (rare, e.g. restricted accounts).
-    const shellResult = await execCommand(conn, 'echo "${SHELL:-/bin/sh}"', {
-      timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS
-    })
-    const shell = shellResult.trim().split('\n')[0]
-    if (!shell) {
-      return null
-    }
-
-    const nodePath = await execCommand(conn, `${shellEscape(shell)} -lc 'command -v node'`, {
-      wrapCommand: false,
-      timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS
-    })
-    const candidate = nodePath.trim().split('\n')[0]
-    if (!candidate) {
-      return null
-    }
-
-    if (await nodeMeetsVersionRequirement(conn, candidate)) {
-      console.log(`[ssh-relay] Found node via login shell (${shell}): ${candidate}`)
-      return candidate
-    }
-  } catch {
-    // Fall through to path probes.
-  }
-  return null
-}
-
 // Probe the on-disk install directories of every common Node version manager
-// plus system package-manager locations. Returns the first candidate that
-// both exists and meets the minimum version.
+// plus system package-manager locations. Every probe runs unconditionally
+// (joined by newlines, not ||) so a missing directory prints nothing rather
+// than short-circuiting later probes. Returns the first candidate that meets
+// the minimum version.
 async function tryResolveViaKnownPaths(conn: SshConnection): Promise<string | null> {
+  // Why: joining with newlines instead of `||` is intentional. An empty
+  // `ls | sort -V | tail -1` exits 0 even when it finds nothing, so an `||`
+  // chain would stop at that clause and never check fnm/mise/asdf/volta.
+  // With newlines every probe runs and contributes whatever path it finds.
   const script = [
     // System / package-manager installs.
     'command -v node 2>/dev/null',
@@ -112,34 +76,67 @@ async function tryResolveViaKnownPaths(conn: SshConnection): Promise<string | nu
     'command -v $HOME/.volta/bin/node 2>/dev/null',
     // n: installs into /usr/local or a user-local prefix.
     'command -v /usr/local/n/versions/node/*/bin/node 2>/dev/null'
-  ].join(' || ')
+  ].join('\n')
 
   try {
     const result = await execCommand(conn, script)
-    const candidates = result
-      .trim()
-      .split('\n')
-      .filter((line) => line.length > 0)
-
-    // Why: the `||` chain exits 0 as soon as one clause prints a path, so the
-    // first line is our candidate. But if the shell emits multiple lines (some
-    // managers leave stale shims), validate each in order and keep the first
-    // that meets the version gate.
-    for (const candidate of candidates) {
+    const seen = new Set<string>()
+    for (const line of result.split('\n')) {
+      const candidate = line.trim()
+      if (!candidate || seen.has(candidate)) {
+        continue
+      }
+      seen.add(candidate)
       if (await nodeMeetsVersionRequirement(conn, candidate)) {
         console.log(`[ssh-relay] Found node via path probe: ${candidate}`)
         return candidate
       }
     }
   } catch {
-    // All probes failed.
+    // Fall through to login shell.
+  }
+  return null
+}
+
+// Run `command -v node` under the user's login shell, then verify the result
+// meets the minimum version. Returns null on any failure (shell missing, no
+// node found, version too old, timeout) so callers fall through to the error.
+async function tryResolveViaLoginShell(conn: SshConnection): Promise<string | null> {
+  try {
+    // Why: $SHELL is the user's configured login shell (set by chsh / passwd).
+    // Using it — rather than hardcoding bash — means zsh/fish users whose
+    // custom PATH hooks live in profile files get coverage too. We fall back
+    // to sh if $SHELL is unset (rare, e.g. restricted accounts).
+    const shellResult = await execCommand(conn, 'echo "${SHELL:-/bin/sh}"', {
+      timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS
+    })
+    const shell = shellResult.trim().split('\n')[0]
+    if (!shell) {
+      return null
+    }
+
+    const nodePath = await execCommand(conn, `${shellEscape(shell)} -lc 'command -v node'`, {
+      wrapCommand: false,
+      timeoutMs: LOGIN_SHELL_PROBE_TIMEOUT_MS
+    })
+    const candidate = nodePath.trim().split('\n')[0]
+    if (!candidate) {
+      return null
+    }
+
+    if (await nodeMeetsVersionRequirement(conn, candidate)) {
+      console.log(`[ssh-relay] Found node via login shell (${shell}): ${candidate}`)
+      return candidate
+    }
+  } catch {
+    // Fall through.
   }
   return null
 }
 
 // Returns true if `nodePath` runs and reports Node >= MIN_NODE_MAJOR.
-// Caches nothing — this runs at most twice per resolution (login shell + first
-// path-probe candidate), and the exec round-trip dominates.
+// Caches nothing — this runs at most a few times per resolution (one per
+// candidate), and the exec round-trip dominates.
 async function nodeMeetsVersionRequirement(
   conn: SshConnection,
   nodePath: string


### PR DESCRIPTION
## What

Fixes remote Node.js detection failing when node is installed via a version manager (nvm with a custom \$NVM_DIR, mise, asdf, volta) or when the user's login shell is zsh/fish rather than bash.

## Why it was broken

Remote Node resolution (`resolveRemoteNodePath`) had two compounding bugs:

1. **The SSH exec transport runs every command under `/bin/sh`**, which never sources shell init files (`.bashrc`/`.zshrc`/`nvm.sh`/`mise activate`). The only init-aware path was a hardcoded `bash -lc 'command -v node'` fallback — which misses zsh/fish users (their hooks live in `~/.zshrc`, not sourced by bash) and can hang on interactive configs (conda prompts) until the 30s exec timeout.

2. **The fixed-path probe missed most version managers** and had no version gate:
   - nvm was hardcoded to `~/.nvm` (broke custom \$NVM_DIR, a common dotfiles pattern).
   - **mise, asdf, volta, and n had no probes at all.**
   - nvm's "highest version" glob used `sort -V` but there was no `node --version` check, so it could return Node 8/10/12 and crash the relay on launch (relay requires Node 18+).

## The fix

Two strategies, tried in order, each version-gating every candidate against the relay's Node 18+ requirement:

- **Strategy 1 — path probes (first).** Probe well-known install directories for every common version manager: nvm (respecting \$NVM_DIR), fnm, mise, asdf, volta, n, plus system locations. Probes are joined with **newlines, not `||`** — an empty `ls | sort -V | tail -1` exits 0, so `||` would short-circuit and mask later probes (fnm/mise/asdf/volta behind a missing nvm dir). Candidates are deduplicated before the version gate.
- **Strategy 2 — login shell (fallback).** Resolve \$SHELL and run `command -v node` through it as a login shell, bypassing `wrapRemoteCommandForPosixShell`. Catches custom PATH setups in `~/.profile` / `~/.bash_profile`. Short 8s timeout. Note: this is the fallback, not the primary path, because `bash -lc` skips `~/.bashrc` and `zsh -lc` skips `~/.zshrc` — exactly where nvm/mise/asdf hooks commonly live — so the deterministic path probes are more reliable.

## Screenshots

No visual change. This is a backend SSH-layer fix; no UI or interaction behavior changes.

## Tests

New test file `ssh-remote-node-resolution.test.ts` (17 cases) covering:
- Path-probe resolution for system node, mise, asdf, volta, and `NVM_DIR`-overridden nvm.
- Newline-joined probes (no `||` short-circuit) and candidate deduplication.
- Version-sort and version-gate edges (Node 18 accepted; Node 10 rejected; mixed candidates select the first valid one).
- Login-shell fallback: custom \$SHELL (fish), empty \$SHELL probe, fallback after empty probes, fallback after all-too-old probes.
- Failure cases: no node anywhere; path-probe exec failure; every candidate below minimum.

Full existing `src/main/ssh/` suite stays green (454 passed, 1 skipped live-host).

## Code review summary

- **Cross-platform:** POSIX path affects Linux + macOS remotes; Windows path (`resolveRemoteWindowsNodePath`) is unchanged. No new platform assumptions introduced.
- **SSH/remote/local:** Change is remote-only by design; local relay install is unaffected.
- **Performance:** Path probes run in a single exec round-trip (one script, newline-joined); the version gate adds one exec per candidate but stops at the first valid one. The login-shell fallback only runs when probes find nothing, capped at 8s. Negligible vs. the relay deploy that follows.
- **Security:** No new shell interpolation; \$SHELL and node paths are passed through the existing `shellEscape`. No user input reaches the probe strings.
- **Agent/integration/git-provider:** N/A.

## X

@thekvnxyz