### PR TITLE
Dispose renderer worktree refresh queues

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -810,6 +810,7 @@ export function useIpcEvents(): void {
       }
     }
     const worktreeChangeRefreshQueue = createWorktreeChangeRefreshQueue(handleWorktreesChanged)
+    unsubs.push(worktreeChangeRefreshQueue.dispose)
 
     const activateNotifiedWorktree = async (
       {

--- a/src/renderer/src/hooks/worktree-change-refresh-queue.test.ts
+++ b/src/renderer/src/hooks/worktree-change-refresh-queue.test.ts
@@ -139,4 +139,30 @@ describe('createWorktreeChangeRefreshQueue', () => {
     expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', renamed)
     expect(handler).toHaveBeenNthCalledWith(3, 'repo-1', undefined)
   })
+
+  it('drops queued trailing refreshes after disposal', async () => {
+    const firstRefresh = deferred()
+    const handler = vi.fn().mockReturnValueOnce(firstRefresh.promise).mockResolvedValue(undefined)
+    const queue = createWorktreeChangeRefreshQueue(handler)
+
+    queue.enqueue({ repoId: 'repo-1' })
+    queue.enqueue({ repoId: 'repo-1' })
+    queue.dispose()
+
+    firstRefresh.resolve()
+    await flushPromises()
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores new events after disposal', async () => {
+    const handler = vi.fn(() => Promise.resolve())
+    const queue = createWorktreeChangeRefreshQueue(handler)
+
+    queue.dispose()
+    queue.enqueue({ repoId: 'repo-1' })
+    await flushPromises()
+
+    expect(handler).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/hooks/worktree-change-refresh-queue.ts
+++ b/src/renderer/src/hooks/worktree-change-refresh-queue.ts
@@ -20,6 +20,7 @@ type RepoRefreshState = {
 }
 
 export type WorktreeChangeRefreshQueue = {
+  dispose: () => void
   enqueue: (event: WorktreeChangeEvent) => void
 }
 
@@ -27,11 +28,12 @@ export function createWorktreeChangeRefreshQueue(
   handler: WorktreeChangeRefreshHandler
 ): WorktreeChangeRefreshQueue {
   const states = new Map<string, RepoRefreshState>()
+  let disposed = false
 
   const drain = async (repoId: string, state: RepoRefreshState): Promise<void> => {
     state.running = true
     try {
-      while (state.queue.length > 0) {
+      while (!disposed && state.queue.length > 0) {
         const next = state.queue.shift()
         try {
           await handler(repoId, next?.renamed)
@@ -41,7 +43,7 @@ export function createWorktreeChangeRefreshQueue(
       }
     } finally {
       state.running = false
-      if (state.queue.length === 0) {
+      if (disposed || state.queue.length === 0) {
         states.delete(repoId)
       } else {
         void drain(repoId, state)
@@ -50,7 +52,15 @@ export function createWorktreeChangeRefreshQueue(
   }
 
   return {
+    dispose() {
+      disposed = true
+      states.clear()
+    },
+
     enqueue(event) {
+      if (disposed) {
+        return
+      }
       let state = states.get(event.repoId)
       if (!state) {
         state = { running: false, queue: [] }


### PR DESCRIPTION
## Summary
- add a disposal path to the renderer worktree-change refresh queue
- clear queued trailing refreshes during `useIpcEvents` cleanup
- ignore worktree-change events that arrive after the queue has been disposed

## Why
PR #6020 fixed the deterministic same-repo refresh fan-out pattern, but it did not cover the hook lifecycle edge where already-queued trailing refreshes could continue after IPC listeners are removed. This follow-up keeps the queue scoped to the active `useIpcEvents` subscription lifetime.

## Validation
This still does not prove the literal Windows `renderer` / `reason=killed` / `exit_code=1` crash is eliminated. It hardens the deterministic renderer fan-out path we can test locally; the OneDrive Windows worktree-create/sidebar-switch crash loop remains the manual validation gate.

## Tests
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/hooks/worktree-change-refresh-queue.test.ts`
- `pnpm typecheck:web`
- `pnpm exec oxlint src/renderer/src/hooks/worktree-change-refresh-queue.ts src/renderer/src/hooks/worktree-change-refresh-queue.test.ts src/renderer/src/hooks/useIpcEvents.ts`
- `git diff --check`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6040">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->