### PR TITLE
feat(activity): reveal thread-row actions on keyboard focus

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1131,7 +1131,7 @@ function ThreadRow({
         // ~3px of internal space above the cap-height that isn't present
         // below the secondary badge row. Symmetric py made the top read
         // heavier; the smaller top pad visually evens the row.
-        'group relative flex w-full cursor-pointer flex-col gap-1 border-b border-border px-3 pt-2.5 pb-3 text-left transition-colors',
+        'group/thread-row relative flex w-full cursor-pointer flex-col gap-1 border-b border-border px-3 pt-2.5 pb-3 text-left transition-colors',
         selected
           ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
           : 'hover:bg-accent/40'
@@ -1213,7 +1213,7 @@ function ThreadRow({
                       'Mark thread unread'
                     )}
                   >
-                    <Bell className="size-3 text-muted-foreground/40 can-hover:opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 group-hover/unread:opacity-100" />
+                    <Bell className="size-3 text-muted-foreground/40 can-hover:opacity-0 transition-opacity group-hover/thread-row:opacity-100 group-focus-within/thread-row:opacity-100 group-hover/unread:opacity-100" />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="left">
@@ -1243,7 +1243,7 @@ function ThreadRow({
             className={cn(
               'ml-auto inline-flex shrink-0 items-center transition-opacity',
               'can-hover:pointer-events-none can-hover:invisible can-hover:opacity-0',
-              'group-hover:pointer-events-auto group-hover:visible group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:visible group-focus-within:opacity-100'
+              'group-hover/thread-row:pointer-events-auto group-hover/thread-row:visible group-hover/thread-row:opacity-100 group-focus-within/thread-row:pointer-events-auto group-focus-within/thread-row:visible group-focus-within/thread-row:opacity-100'
             )}
           >
             <Tooltip>

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1181,8 +1181,8 @@ function ThreadRow({
           {/* Why (bell matches WorktreeCard pattern): unread → amber filled
               bell as a static, non-interactive cue (selecting the thread
               auto-marks it read, so a Mark-read button would be redundant);
-              read → outline Bell that fades in on row hover and acts as
-              Mark-unread. Bare button (no shadcn outline) so it reads as
+              read → outline Bell that fades in on row hover/focus and acts
+              as Mark-unread. Bare button (no shadcn outline) so it reads as
               an inline cue rather than a discrete control square. */}
           <span className="inline-flex size-4 shrink-0 items-center justify-center">
             {thread.unread ? (
@@ -1213,7 +1213,7 @@ function ThreadRow({
                       'Mark thread unread'
                     )}
                   >
-                    <Bell className="size-3 text-muted-foreground/40 can-hover:opacity-0 transition-opacity group-hover:opacity-100 group-hover/unread:opacity-100" />
+                    <Bell className="size-3 text-muted-foreground/40 can-hover:opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 group-hover/unread:opacity-100" />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="left">
@@ -1237,13 +1237,13 @@ function ThreadRow({
             on the title row already holds the unread/Mark-unread state, so
             the navigation action gets its own slot down here aligned with
             the worktree name. On hover-capable pointers, the hidden state
-            keeps the worktree-name's flex-1 width stable across hover. */}
+            keeps the worktree-name's flex-1 width stable until hover or keyboard focus. */}
         {canJump ? (
           <span
             className={cn(
               'ml-auto inline-flex shrink-0 items-center transition-opacity',
               'can-hover:pointer-events-none can-hover:invisible can-hover:opacity-0',
-              'group-hover:pointer-events-auto group-hover:visible group-hover:opacity-100'
+              'group-hover:pointer-events-auto group-hover:visible group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:visible group-focus-within:opacity-100'
             )}
           >
             <Tooltip>


### PR DESCRIPTION
## Summary

Thread-row action affordances (the **Mark-unread** bell and **Jump-to-workspace** button) were revealed only on pointer hover, so keyboard users tabbing into a row never saw them. This adds `group-focus-within:` Tailwind variants alongside the existing `group-hover:` ones so the actions also appear when any control within the row receives keyboard focus.

The row now uses a named Tailwind group, `group/thread-row`, so the hover and focus-within reveal rules do not depend on an unscoped parent `group`.

## Screenshots

Keyboard focus recording: the row actions are hidden before focus and visible once Tab focuses the thread row.

![Activity thread-row actions revealed on keyboard focus](https://share.wolfie.gg/activity-row-actions-focus.gif)

## Testing

- [x] `PATH="$(mise where node@24)/bin:$PATH" pnpm lint`
- [x] `PATH="$(mise where node@24)/bin:$PATH" pnpm build` - completed with existing Vite chunk warnings, Swift `CGWindowListCreateImage` deprecation warnings, and a non-fatal `/usr/local/bin/orca-dev` symlink permission notice.
- [x] `pnpm run typecheck:web`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/activity/ActivityPrototypePage.test.ts` - 20 passed.
- [x] Browser fixture check against the built CSS: before focus, bell opacity `0` and jump wrapper `visibility: hidden`/`pointer-events: none`; after Tab focus, bell opacity `1` and jump wrapper `visibility: visible`/`pointer-events: auto`.
- [x] Existing tests pass; change is CSS-variant-only with no new logic to unit-test.

## AI Review Report

Reviewed the change for accessibility, touch behavior, and Tailwind group coupling. The row root is focusable and now owns the named `group/thread-row` class; descendants use matching `group-hover/thread-row:*` and `group-focus-within/thread-row:*` variants. Existing `can-hover:` hidden-state guards remain intact, so touch devices keep the actions visible.

Findings addressed during review:

- Switched the row reveal rules from an unscoped `group` to `group/thread-row` to avoid accidental coupling with future nested groups.
- Completed the previously unchecked lint and build verification.
- Attached keyboard focus evidence.

Cross-platform: pure CSS class changes, no shortcut, path, shell, Electron IPC, or provider-specific behavior touched. SSH/remote/local behavior is unchanged.

## Security Audit

No input handling, command execution, path/auth/secrets/IPC, dependency, or network changes. CSS-only.

## Notes

- X handle: @wolfie_
