### PR TITLE
feat(activity): close Agents view on Escape from Activity chrome

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -51,6 +51,7 @@ import {
   setActivityTerminalPortals,
   type ActivityTerminalPortalTarget
 } from './activity-terminal-portal'
+import { shouldCloseActivityPageOnEscapeKey } from './activity-escape-close'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import {
@@ -1742,9 +1743,22 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     storeData.acknowledgeAgents(unreadKeys)
   }
 
+  const handleActivityPageKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!shouldCloseActivityPageOnEscapeKey(event, document.activeElement)) {
+      return
+    }
+
+    event.preventDefault()
+    useAppStore.getState().closeActivityPage()
+  }, [])
+
   // Why (page padding): no top/horizontal padding so the page reaches the window edges; the titlebar and the right pane's title row (pt-2) supply the top spacing.
   return (
-    <div ref={setActivityPageRef} className="flex h-full min-h-0 flex-col bg-background pb-3">
+    <div
+      ref={setActivityPageRef}
+      className="flex h-full min-h-0 flex-col bg-background pb-3"
+      onKeyDown={handleActivityPageKeyDown}
+    >
       <main className="flex min-h-0 flex-1 overflow-hidden">
         <aside
           ref={threadListRef}

--- a/src/renderer/src/components/activity/activity-escape-close.dom.test.ts
+++ b/src/renderer/src/components/activity/activity-escape-close.dom.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+import { shouldCloseActivityPageOnEscapeKey } from './activity-escape-close'
+
+// Why: the helper unit tests cover the decision logic with hand-built objects.
+// These tests exercise the real integration seam instead: actual focused DOM
+// nodes resolved through document.activeElement, with real classList/closest,
+// matching the markup ActivityPrototypePage renders (focusable thread rows and
+// the data-activity-terminal-slot-id terminal portal). This catches drift in
+// the class name, the slot-id selector, or the focus assumptions that the
+// pure-object mocks cannot.
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+const ESCAPE = { key: 'Escape', defaultPrevented: false } as const
+
+describe('shouldCloseActivityPageOnEscapeKey (real DOM focus)', () => {
+  it('closes when a focused thread row owns focus', () => {
+    document.body.innerHTML = `<div role="button" tabindex="0" id="thread-row"></div>`
+    const row = document.getElementById('thread-row')
+    row?.focus()
+
+    expect(document.activeElement).toBe(row)
+    expect(shouldCloseActivityPageOnEscapeKey(ESCAPE, document.activeElement)).toBe(true)
+  })
+
+  it('closes when the search filter input owns focus', () => {
+    document.body.innerHTML = `<input id="activity-filter" type="text" />`
+    const input = document.getElementById('activity-filter')
+    input?.focus()
+
+    expect(document.activeElement).toBe(input)
+    expect(shouldCloseActivityPageOnEscapeKey(ESCAPE, document.activeElement)).toBe(true)
+  })
+
+  it('does not close when a real xterm-helper-textarea owns focus', () => {
+    document.body.innerHTML = `
+      <div data-activity-terminal-slot-id="primary">
+        <textarea class="xterm-helper-textarea"></textarea>
+      </div>
+    `
+    const textarea = document.querySelector('.xterm-helper-textarea')
+    if (textarea instanceof HTMLTextAreaElement) {
+      textarea.focus()
+    }
+
+    expect(document.activeElement).toBe(textarea)
+    expect(shouldCloseActivityPageOnEscapeKey(ESCAPE, document.activeElement)).toBe(false)
+  })
+
+  it('does not close when focus is a descendant of the terminal portal slot', () => {
+    document.body.innerHTML = `
+      <div data-activity-terminal-slot-id="secondary">
+        <div tabindex="0" id="terminal-child"></div>
+      </div>
+    `
+    const child = document.getElementById('terminal-child')
+    child?.focus()
+
+    expect(document.activeElement).toBe(child)
+    expect(shouldCloseActivityPageOnEscapeKey(ESCAPE, document.activeElement)).toBe(false)
+  })
+
+  it('still ignores already-handled Escape and non-Escape keys from real chrome', () => {
+    document.body.innerHTML = `<div role="button" tabindex="0" id="thread-row"></div>`
+    document.getElementById('thread-row')?.focus()
+
+    expect(
+      shouldCloseActivityPageOnEscapeKey(
+        { key: 'Escape', defaultPrevented: true },
+        document.activeElement
+      )
+    ).toBe(false)
+    expect(
+      shouldCloseActivityPageOnEscapeKey(
+        { key: 'Enter', defaultPrevented: false },
+        document.activeElement
+      )
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/activity/activity-escape-close.test.ts
+++ b/src/renderer/src/components/activity/activity-escape-close.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { shouldCloseActivityPageOnEscapeKey } from './activity-escape-close'
+
+describe('activity Escape close handling', () => {
+  it('closes for unhandled Escape from Activity chrome', () => {
+    expect(shouldCloseActivityPageOnEscapeKey({ key: 'Escape', defaultPrevented: false }, {})).toBe(
+      true
+    )
+  })
+
+  it('ignores already-handled Escape and non-Escape keys', () => {
+    expect(shouldCloseActivityPageOnEscapeKey({ key: 'Escape', defaultPrevented: true }, {})).toBe(
+      false
+    )
+    expect(shouldCloseActivityPageOnEscapeKey({ key: 'Enter', defaultPrevented: false }, {})).toBe(
+      false
+    )
+  })
+
+  it('does not close when the Activity terminal owns focus', () => {
+    const xtermElement = {
+      classList: {
+        contains: (token: string) => token === 'xterm-helper-textarea'
+      }
+    }
+
+    expect(
+      shouldCloseActivityPageOnEscapeKey({ key: 'Escape', defaultPrevented: false }, xtermElement)
+    ).toBe(false)
+  })
+
+  it('does not close when focus is inside the Activity terminal portal', () => {
+    const portalElement = {
+      closest: (selector: string) => (selector === '[data-activity-terminal-slot-id]' ? {} : null)
+    }
+
+    expect(
+      shouldCloseActivityPageOnEscapeKey({ key: 'Escape', defaultPrevented: false }, portalElement)
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/activity/activity-escape-close.ts
+++ b/src/renderer/src/components/activity/activity-escape-close.ts
@@ -1,0 +1,61 @@
+import type React from 'react'
+
+// Why: the Activity terminal portal slots tag their DOM with this attribute so
+// embedded xterm focus can be distinguished from ordinary Activity chrome. Keep
+// the selector in sync with the data-activity-terminal-slot-id targets rendered
+// by ActivityPrototypePage.
+const ACTIVITY_TERMINAL_PORTAL_SELECTOR = '[data-activity-terminal-slot-id]'
+const XTERM_HELPER_TEXTAREA_CLASS = 'xterm-helper-textarea'
+
+type ActivityEscapeKeyEvent = Pick<React.KeyboardEvent<HTMLDivElement>, 'defaultPrevented' | 'key'>
+
+function hasClassListContains(
+  value: unknown
+): value is { classList: { contains: (token: string) => boolean } } {
+  if (typeof value !== 'object' || value === null || !('classList' in value)) {
+    return false
+  }
+  const { classList } = value
+  return (
+    typeof classList === 'object' &&
+    classList !== null &&
+    'contains' in classList &&
+    typeof classList.contains === 'function'
+  )
+}
+
+function hasClosest(value: unknown): value is { closest: (selector: string) => unknown } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'closest' in value &&
+    typeof value.closest === 'function'
+  )
+}
+
+function isElementWithXtermHelperClass(activeElement: unknown): boolean {
+  return (
+    hasClassListContains(activeElement) &&
+    activeElement.classList.contains(XTERM_HELPER_TEXTAREA_CLASS)
+  )
+}
+
+function isElementInsideActivityTerminalPortal(activeElement: unknown): boolean {
+  return (
+    hasClosest(activeElement) && Boolean(activeElement.closest(ACTIVITY_TERMINAL_PORTAL_SELECTOR))
+  )
+}
+
+export function shouldCloseActivityPageOnEscapeKey(
+  { defaultPrevented, key }: ActivityEscapeKeyEvent,
+  activeElement: unknown
+): boolean {
+  if (key !== 'Escape' || defaultPrevented) {
+    return false
+  }
+
+  return (
+    !isElementWithXtermHelperClass(activeElement) &&
+    !isElementInsideActivityTerminalPortal(activeElement)
+  )
+}


### PR DESCRIPTION
## Summary

Pressing **Escape** while focus is within the Agents/Activity page chrome (the filter input, a thread row, or other list UI) now closes the Activity view via the existing `closeActivityPage()` store action.

The handler is attached as a root-level `onKeyDown` on the Activity page container, so it is naturally scoped to "focus is within Activity chrome". It explicitly does **not** close the view when:
- the embedded xterm terminal owns focus (`document.activeElement` carries `xterm-helper-textarea`, or focus is inside `[data-activity-terminal-slot-id]`), or
- the event was already handled (`event.defaultPrevented`). Portaled overlays (Radix Select/Tooltip/Dialog) generally handle Escape via their own callbacks and stay outside this root handler's event path; respecting `defaultPrevented` covers any child that does bubble through after calling `preventDefault`.

## Screenshots

Escape-to-close is an interaction change. A recording is pending; keep draft until it is attached or maintainers waive visual evidence.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (web project: clean)
- [ ] `pnpm test` - not run repo-wide.
- [x] Targeted `activity-escape-close*.test.ts` and `ActivityPrototypePage.test.ts`: 29 passed.
- [x] `pnpm build`
- [x] Added focused unit tests for the close-decision helper: normal Activity chrome, already-handled events, xterm helper-textarea focus, and focus inside the terminal portal.
- [x] Added real-DOM wiring tests (`activity-escape-close.dom.test.ts`, happy-dom): a focused thread row, the filter input, a real `xterm-helper-textarea`, and a terminal-portal descendant resolved through `document.activeElement`. Verified by mutation: breaking the slot-id selector fails the portal test, so this guards against class-name/selector drift rather than adding shallow coverage.

## AI Review Report

Change is small and localized to the Activity surface. Reviewed: the close decision is isolated in a pure helper (`shouldCloseActivityPageOnEscapeKey`) in `activity-escape-close.ts`, unit-tested in `activity-escape-close.test.ts`; `ActivityPrototypePage.tsx` only wires the root `onKeyDown`. Cross-platform: Escape is platform-neutral; no shell/path/label differences. No Electron-specific surface touched beyond the renderer component.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or IPC changes. Pure renderer keyboard handling reading `document.activeElement`. No new dependencies.

## Notes

Terminal-focus safety is the key constraint and is covered by tests. Draft pending screenshots/recording of the dismissal and manual QA against an open agent terminal.

X handle: @wolfie_


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6045">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## ELI5

Pressing Escape while focus is on the Agents/Activity chrome closes the Activity view. Escape does not close it when the embedded terminal itself has focus.
