### PR TITLE
feat(activity): focus filter with Cmd/Ctrl+F in Agents view

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -770,6 +770,8 @@ describe('activity filter focus shortcut', () => {
 
   it('prevents default, focuses, and selects only for handled filter shortcuts', () => {
     let prevented = 0
+    let stopped = 0
+    let stoppedImmediate = 0
     let focused = 0
     let selected = 0
     const input = {
@@ -786,6 +788,9 @@ describe('activity filter focus shortcut', () => {
     const terminalElement = {
       classList: { contains: (className: string) => className === 'xterm-helper-textarea' }
     } as unknown as Element
+    const terminalPortalTarget = {
+      contains: (target: Element) => target === terminalElement
+    } as unknown as HTMLElement
 
     expect(
       handleActivityFilterFocusShortcut({
@@ -798,6 +803,12 @@ describe('activity filter focus shortcut', () => {
           altKey: false,
           preventDefault: () => {
             prevented += 1
+          },
+          stopPropagation: () => {
+            stopped += 1
+          },
+          stopImmediatePropagation: () => {
+            stoppedImmediate += 1
           }
         },
         input,
@@ -806,6 +817,8 @@ describe('activity filter focus shortcut', () => {
       })
     ).toBe(true)
     expect(prevented).toBe(1)
+    expect(stopped).toBe(1)
+    expect(stoppedImmediate).toBe(1)
     expect(focused).toBe(1)
     expect(selected).toBe(1)
 
@@ -820,14 +833,22 @@ describe('activity filter focus shortcut', () => {
           altKey: false,
           preventDefault: () => {
             prevented += 1
+          },
+          stopPropagation: () => {
+            stopped += 1
+          },
+          stopImmediatePropagation: () => {
+            stoppedImmediate += 1
           }
         },
         input,
         isMac: true,
-        terminalPortalTargets: []
+        terminalPortalTargets: [terminalPortalTarget]
       })
     ).toBe(false)
     expect(prevented).toBe(1)
+    expect(stopped).toBe(1)
+    expect(stoppedImmediate).toBe(1)
     expect(focused).toBe(1)
     expect(selected).toBe(1)
   })
@@ -849,6 +870,12 @@ describe('activity filter focus shortcut', () => {
           altKey: false,
           preventDefault: () => {
             prevented += 1
+          },
+          stopPropagation: () => {
+            throw new Error('unavailable input must not stop propagation')
+          },
+          stopImmediatePropagation: () => {
+            throw new Error('unavailable input must not stop immediate propagation')
           }
         },
         input: null,
@@ -870,12 +897,18 @@ describe('activity filter focus shortcut', () => {
       classList: { contains: () => false }
     } as unknown as Element
     const portalTarget = {
-      contains: (target: Element) => target === portalChild
+      contains: (target: Element) => target === portalChild || target === terminalTextarea
     } as unknown as HTMLElement
+    const hiddenWorkbenchTerminal = {
+      classList: { contains: (className: string) => className === 'xterm-helper-textarea' }
+    } as unknown as Element
     expect(shouldIgnoreActivityFilterFocusShortcutTarget(terminalTextarea, [portalTarget])).toBe(
       true
     )
     expect(shouldIgnoreActivityFilterFocusShortcutTarget(portalChild, [portalTarget])).toBe(true)
     expect(shouldIgnoreActivityFilterFocusShortcutTarget(outside, [portalTarget])).toBe(false)
+    expect(
+      shouldIgnoreActivityFilterFocusShortcutTarget(hiddenWorkbenchTerminal, [portalTarget])
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -13,6 +13,9 @@ import {
   ACTIVITY_SEARCH_QUERY_MAX_BYTES,
   activityThreadResponseRenderPreview,
   activityThreadMatchesSearchQuery,
+  handleActivityFilterFocusShortcut,
+  isActivityFilterFocusShortcut,
+  shouldIgnoreActivityFilterFocusShortcutTarget,
   buildActivityThreadGroups,
   buildActivityEvents,
   buildAgentPaneThreads,
@@ -722,5 +725,118 @@ describe('activity thread grouping', () => {
 
   it('returns no groups for empty thread input', () => {
     expect(buildActivityThreadGroups([], 'status')).toEqual([])
+  })
+})
+
+describe('activity filter focus shortcut', () => {
+  it('matches Cmd+F on Mac and Ctrl+F elsewhere without extra modifiers', () => {
+    expect(
+      isActivityFilterFocusShortcut(
+        { key: 'f', metaKey: true, ctrlKey: false, shiftKey: false, altKey: false },
+        true
+      )
+    ).toBe(true)
+    expect(
+      isActivityFilterFocusShortcut(
+        { key: 'F', metaKey: false, ctrlKey: true, shiftKey: false, altKey: false },
+        false
+      )
+    ).toBe(true)
+    expect(
+      isActivityFilterFocusShortcut(
+        { key: 'f', metaKey: false, ctrlKey: true, shiftKey: false, altKey: false },
+        true
+      )
+    ).toBe(false)
+    expect(
+      isActivityFilterFocusShortcut(
+        { key: 'f', metaKey: true, ctrlKey: false, shiftKey: true, altKey: false },
+        true
+      )
+    ).toBe(false)
+  })
+
+  it('prevents default, focuses, and selects only for handled filter shortcuts', () => {
+    let prevented = 0
+    let focused = 0
+    let selected = 0
+    const input = {
+      focus: () => {
+        focused += 1
+      },
+      select: () => {
+        selected += 1
+      }
+    } as Pick<HTMLInputElement, 'focus' | 'select'>
+    const activeElement = {
+      classList: { contains: () => false }
+    } as unknown as Element
+    const terminalElement = {
+      classList: { contains: (className: string) => className === 'xterm-helper-textarea' }
+    } as unknown as Element
+
+    expect(
+      handleActivityFilterFocusShortcut({
+        activeElement,
+        event: {
+          key: 'f',
+          metaKey: true,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          preventDefault: () => {
+            prevented += 1
+          }
+        },
+        input,
+        isMac: true,
+        terminalPortalTargets: []
+      })
+    ).toBe(true)
+    expect(prevented).toBe(1)
+    expect(focused).toBe(1)
+    expect(selected).toBe(1)
+
+    expect(
+      handleActivityFilterFocusShortcut({
+        activeElement: terminalElement,
+        event: {
+          key: 'f',
+          metaKey: true,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          preventDefault: () => {
+            prevented += 1
+          }
+        },
+        input,
+        isMac: true,
+        terminalPortalTargets: []
+      })
+    ).toBe(false)
+    expect(prevented).toBe(1)
+    expect(focused).toBe(1)
+    expect(selected).toBe(1)
+  })
+
+  it('ignores shortcut handling while terminal-owned elements have focus', () => {
+    const terminalTextarea = {
+      classList: { contains: (className: string) => className === 'xterm-helper-textarea' }
+    } as unknown as Element
+    const portalChild = {
+      classList: { contains: () => false }
+    } as unknown as Element
+    const outside = {
+      classList: { contains: () => false }
+    } as unknown as Element
+    const portalTarget = {
+      contains: (target: Element) => target === portalChild
+    } as unknown as HTMLElement
+    expect(shouldIgnoreActivityFilterFocusShortcutTarget(terminalTextarea, [portalTarget])).toBe(
+      true
+    )
+    expect(shouldIgnoreActivityFilterFocusShortcutTarget(portalChild, [portalTarget])).toBe(true)
+    expect(shouldIgnoreActivityFilterFocusShortcutTarget(outside, [portalTarget])).toBe(false)
   })
 })

--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -754,6 +754,18 @@ describe('activity filter focus shortcut', () => {
         true
       )
     ).toBe(false)
+    expect(
+      isActivityFilterFocusShortcut(
+        { key: 'f', metaKey: true, ctrlKey: true, shiftKey: false, altKey: false },
+        true
+      )
+    ).toBe(false)
+    expect(
+      isActivityFilterFocusShortcut(
+        { key: 'f', metaKey: true, ctrlKey: true, shiftKey: false, altKey: false },
+        false
+      )
+    ).toBe(false)
   })
 
   it('prevents default, focuses, and selects only for handled filter shortcuts', () => {
@@ -818,6 +830,33 @@ describe('activity filter focus shortcut', () => {
     expect(prevented).toBe(1)
     expect(focused).toBe(1)
     expect(selected).toBe(1)
+  })
+
+  it('does not prevent default when the filter input is unavailable', () => {
+    let prevented = 0
+    const activeElement = {
+      classList: { contains: () => false }
+    } as unknown as Element
+
+    expect(
+      handleActivityFilterFocusShortcut({
+        activeElement,
+        event: {
+          key: 'f',
+          metaKey: true,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          preventDefault: () => {
+            prevented += 1
+          }
+        },
+        input: null,
+        isMac: true,
+        terminalPortalTargets: []
+      })
+    ).toBe(false)
+    expect(prevented).toBe(0)
   })
 
   it('ignores shortcut handling while terminal-owned elements have focus', () => {

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1045,9 +1045,8 @@ export function shouldIgnoreActivityFilterFocusShortcutTarget(
   if (!target) {
     return false
   }
-  if (target.classList.contains('xterm-helper-textarea')) {
-    return true
-  }
+  // Why: the workspace terminal stays mounted while Activity is open; only the
+  // Activity-portaled terminal should keep Cmd/Ctrl+F for terminal search.
   return terminalPortalTargets.some((portalTarget) => portalTarget?.contains(target) ?? false)
 }
 
@@ -1061,7 +1060,14 @@ export function handleActivityFilterFocusShortcut({
   activeElement: Element | null
   event: Pick<
     KeyboardEvent,
-    'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'preventDefault' | 'shiftKey'
+    | 'altKey'
+    | 'ctrlKey'
+    | 'key'
+    | 'metaKey'
+    | 'preventDefault'
+    | 'shiftKey'
+    | 'stopImmediatePropagation'
+    | 'stopPropagation'
   >
   input: Pick<HTMLInputElement, 'focus' | 'select'> | null
   isMac?: boolean
@@ -1077,6 +1083,10 @@ export function handleActivityFilterFocusShortcut({
     return false
   }
   event.preventDefault()
+  // Why: hidden workspace xterms can retain focus behind Activity; capture-phase
+  // handling must stop the chord before xterm forwards it to a local/SSH PTY.
+  event.stopPropagation()
+  event.stopImmediatePropagation()
   input.focus()
   input.select()
   return true
@@ -1620,8 +1630,8 @@ export default function ActivityPrototypePage(): React.JSX.Element {
       })
     }
 
-    window.addEventListener('keydown', focusActivityFilter)
-    return () => window.removeEventListener('keydown', focusActivityFilter)
+    window.addEventListener('keydown', focusActivityFilter, { capture: true })
+    return () => window.removeEventListener('keydown', focusActivityFilter, { capture: true })
   }, [activePortalTargetEl, inactivePortalTargetEl])
 
   const markThreadRead = (thread: AgentPaneThread): void => {

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1035,7 +1035,7 @@ export function isActivityFilterFocusShortcut(
   if (event.key.toLowerCase() !== 'f' || event.shiftKey || event.altKey) {
     return false
   }
-  return isMac ? event.metaKey : event.ctrlKey
+  return isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
 }
 
 export function shouldIgnoreActivityFilterFocusShortcutTarget(
@@ -1073,9 +1073,12 @@ export function handleActivityFilterFocusShortcut({
   if (!isActivityFilterFocusShortcut(event, isMac)) {
     return false
   }
+  if (!input) {
+    return false
+  }
   event.preventDefault()
-  input?.focus()
-  input?.select()
+  input.focus()
+  input.select()
   return true
 }
 

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: this prototype keeps the real-data adapter
 and current visual skeleton together until the next refinement pass decides
 which pieces become production modules. */
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import {
   Bell,
@@ -1028,6 +1028,57 @@ export function activityThreadMatchesSearchQuery({
   return threadSearchText(thread).includes(trimmedQuery.toLowerCase())
 }
 
+export function isActivityFilterFocusShortcut(
+  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
+  isMac = navigator.userAgent.includes('Mac')
+): boolean {
+  if (event.key.toLowerCase() !== 'f' || event.shiftKey || event.altKey) {
+    return false
+  }
+  return isMac ? event.metaKey : event.ctrlKey
+}
+
+export function shouldIgnoreActivityFilterFocusShortcutTarget(
+  target: Element | null,
+  terminalPortalTargets: (HTMLElement | null)[]
+): boolean {
+  if (!target) {
+    return false
+  }
+  if (target.classList.contains('xterm-helper-textarea')) {
+    return true
+  }
+  return terminalPortalTargets.some((portalTarget) => portalTarget?.contains(target) ?? false)
+}
+
+export function handleActivityFilterFocusShortcut({
+  activeElement,
+  event,
+  input,
+  isMac,
+  terminalPortalTargets
+}: {
+  activeElement: Element | null
+  event: Pick<
+    KeyboardEvent,
+    'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'preventDefault' | 'shiftKey'
+  >
+  input: Pick<HTMLInputElement, 'focus' | 'select'> | null
+  isMac?: boolean
+  terminalPortalTargets: (HTMLElement | null)[]
+}): boolean {
+  if (shouldIgnoreActivityFilterFocusShortcutTarget(activeElement, terminalPortalTargets)) {
+    return false
+  }
+  if (!isActivityFilterFocusShortcut(event, isMac)) {
+    return false
+  }
+  event.preventDefault()
+  input?.focus()
+  input?.select()
+  return true
+}
+
 function ThreadAgentStateIndicator({ thread }: { thread: AgentPaneThread }): React.JSX.Element {
   const state = threadAgentState(thread)
   const label = threadAgentStateLabel(thread)
@@ -1283,6 +1334,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   const [readFilter, setReadFilter] = useState<ThreadReadFilter>('all')
   const [groupBy, setGroupBy] = useState<ActivityGroupBy>('status')
   const [query, setQuery] = useState('')
+  const activityFilterInputRef = useRef<HTMLInputElement | null>(null)
   const [compactMode, setCompactMode] = useState(false)
   const [selectedPaneKey, setSelectedPaneKey] = useState<string | null>(null)
   const [displayedPaneKey, setDisplayedPaneKey] = useState<string | null>(null)
@@ -1555,6 +1607,20 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     }
   }, [])
 
+  useEffect(() => {
+    const focusActivityFilter = (event: KeyboardEvent): void => {
+      handleActivityFilterFocusShortcut({
+        activeElement: document.activeElement,
+        event,
+        input: activityFilterInputRef.current,
+        terminalPortalTargets: [activePortalTargetEl, inactivePortalTargetEl]
+      })
+    }
+
+    window.addEventListener('keydown', focusActivityFilter)
+    return () => window.removeEventListener('keydown', focusActivityFilter)
+  }, [activePortalTargetEl, inactivePortalTargetEl])
+
   const markThreadRead = (thread: AgentPaneThread): void => {
     storeData.acknowledgeAgents([thread.paneKey])
   }
@@ -1660,6 +1726,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
               <div className="relative min-w-0 flex-1">
                 <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
                 <Input
+                  ref={activityFilterInputRef}
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
                   placeholder={translate(


### PR DESCRIPTION
## Summary

Adds a **Cmd+F** (macOS) / **Ctrl+F** (Windows/Linux) keyboard shortcut in the Agents/Activity view that focuses the filter input and selects its current contents, matching the search-focus affordance other surfaces already have.

The handler early-returns when the embedded xterm terminal owns focus (`xterm-helper-textarea`, or focus inside the Activity terminal portal), so it never hijacks native find while the terminal is active. Modifier detection is Mac-vs-non-Mac aware: it requires the platform modifier (`metaKey` on macOS, `ctrlKey` elsewhere) and rejects the opposite platform modifier as well as Shift/Alt-modified chords, so `Cmd+Ctrl+F` / `Ctrl+Meta+F` do not trigger it.

Part of the Agents-view keyboard-parity audit (T1).

## Screenshots

No visual change. Adds a keyboard shortcut; focus ring appears on the existing filter input.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (web project clean; full typecheck also passes via `build:desktop`)
- [x] `pnpm test` (`ActivityPrototypePage.test.ts`: 24 passed)
- [x] `pnpm build` (`build:desktop`: relay + cli + electron-vite + web all built; local `orca-dev` symlink step needs sudo and is unrelated to this change)
- [x] Added focused unit tests: shortcut matching (Cmd vs Ctrl by platform, uppercase F, Shift rejection, **extra Ctrl/Meta rejection on both platforms**), **null-input no-op**, and terminal-focus ignore behavior.

## AI Review Report

Reviewed shortcut-match and ignore-target logic, both extracted as pure helpers and unit-tested. Cross-platform: explicitly branches `metaKey` (mac) vs `ctrlKey` (win/linux) via the existing `navigator.userAgent` Mac check used elsewhere in the codebase, and requires the opposite platform modifier to be absent. The handler returns false (no `preventDefault`) when the filter input ref is unavailable, so it never suppresses native find without focusing anything. No path/shell/label concerns. Electron: standard renderer keydown; native Find is only preempted when Activity is focused and the terminal is not.

## Security Audit

No input handling beyond reading key modifiers, no command execution, no path/auth/secrets/IPC changes, no new dependencies.

## Notes

Manual QA still recommended before merge: macOS Cmd+F and Windows/Linux Ctrl+F focus/select the filter, and Cmd/Ctrl+F is not hijacked while the embedded terminal owns focus. A short screen recording will be attached.

X handle: @wolfie_
