### PR TITLE
Default new worktree card style on for fresh profiles

### DIFF
--- a/src/cli/handlers/agent-hooks.test.ts
+++ b/src/cli/handlers/agent-hooks.test.ts
@@ -1,0 +1,111 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState } from '../../shared/constants'
+import type { PersistedState } from '../../shared/types'
+import type { HandlerContext } from '../dispatch'
+
+const {
+  applyAgentStatusHooksEnabledMock,
+  getDefaultUserDataPathMock,
+  getManagedAgentHookStatusesMock
+} = vi.hoisted(() => ({
+  applyAgentStatusHooksEnabledMock: vi.fn(),
+  getDefaultUserDataPathMock: vi.fn(),
+  getManagedAgentHookStatusesMock: vi.fn()
+}))
+
+vi.mock('../runtime-client', () => {
+  class RuntimeClientError extends Error {
+    readonly code: string
+
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  return {
+    RuntimeClientError,
+    getDefaultUserDataPath: getDefaultUserDataPathMock
+  }
+})
+
+vi.mock('../../main/agent-hooks/managed-agent-hook-controls', () => ({
+  applyAgentStatusHooksEnabled: applyAgentStatusHooksEnabledMock,
+  getManagedAgentHookStatuses: getManagedAgentHookStatusesMock
+}))
+
+import { AGENT_HOOK_HANDLERS } from './agent-hooks'
+
+function readDataFile(userDataPath: string): PersistedState {
+  return JSON.parse(readFileSync(join(userDataPath, 'orca-data.json'), 'utf-8')) as PersistedState
+}
+
+function writeDataFile(userDataPath: string, state: PersistedState): void {
+  mkdirSync(userDataPath, { recursive: true })
+  writeFileSync(join(userDataPath, 'orca-data.json'), JSON.stringify(state, null, 2), 'utf-8')
+}
+
+function createOfflineClient() {
+  return {
+    getCliStatus: vi.fn().mockResolvedValue({ result: { runtime: { reachable: false } } }),
+    call: vi.fn()
+  }
+}
+
+async function runAgentHooksOff(userDataPath: string): Promise<void> {
+  getDefaultUserDataPathMock.mockReturnValue(userDataPath)
+  await AGENT_HOOK_HANDLERS['agent hooks off']({
+    flags: new Map(),
+    client: createOfflineClient() as HandlerContext['client'],
+    cwd: userDataPath,
+    json: true
+  })
+}
+
+describe('agent hooks CLI handler', () => {
+  let userDataPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-agent-hooks-cli-'))
+    applyAgentStatusHooksEnabledMock.mockReturnValue([])
+    getManagedAgentHookStatusesMock.mockReturnValue([])
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('keeps the fresh-profile new card style default when creating offline settings', async () => {
+    await runAgentHooksOff(userDataPath)
+
+    const persisted = readDataFile(userDataPath)
+
+    expect(persisted.settings.experimentalNewWorktreeCardStyle).toBe(true)
+    expect(persisted.settings.agentStatusHooksEnabled).toBe(false)
+  })
+
+  it('defaults missing new card style on while offline-updated onboarding is open', async () => {
+    const existing = getDefaultPersistedState(userDataPath)
+    delete existing.settings.experimentalNewWorktreeCardStyle
+    writeDataFile(userDataPath, existing)
+
+    await runAgentHooksOff(userDataPath)
+
+    expect(readDataFile(userDataPath).settings.experimentalNewWorktreeCardStyle).toBe(true)
+  })
+
+  it('preserves an existing explicit new card style opt-out when updating offline settings', async () => {
+    const existing = getDefaultPersistedState(userDataPath)
+    existing.settings.experimentalNewWorktreeCardStyle = false
+    writeDataFile(userDataPath, existing)
+
+    await runAgentHooksOff(userDataPath)
+
+    expect(readDataFile(userDataPath).settings.experimentalNewWorktreeCardStyle).toBe(false)
+  })
+})

--- a/src/cli/handlers/agent-hooks.ts
+++ b/src/cli/handlers/agent-hooks.ts
@@ -31,7 +31,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function readPersistedState(dataPath: string): PersistedState {
   if (!existsSync(dataPath)) {
-    return getDefaultPersistedState(homedir())
+    const defaults = getDefaultPersistedState(homedir())
+    return {
+      ...defaults,
+      settings: {
+        ...defaults.settings,
+        // Why: offline CLI can create the first profile before desktop load;
+        // match the Store fresh-install default instead of pinning old cards.
+        experimentalNewWorktreeCardStyle: true
+      }
+    }
   }
   try {
     const parsed = JSON.parse(readFileSync(dataPath, 'utf-8'))
@@ -74,9 +83,14 @@ function readEnabledFromDisk(): boolean {
 function updateEnabledOnDisk(enabled: boolean): string {
   const dataPath = getDataPath()
   const state = readPersistedState(dataPath)
+  const experimentalNewWorktreeCardStyle =
+    state.settings?.experimentalNewWorktreeCardStyle ?? state.onboarding?.closedAt === null
   state.settings = {
     ...getDefaultPersistedState(homedir()).settings,
     ...state.settings,
+    // Why: offline CLI can run before Store.load(); mirror its open-onboarding
+    // default without overriding a saved user opt-out.
+    experimentalNewWorktreeCardStyle,
     agentStatusHooksEnabled: enabled
   }
   writePersistedState(dataPath, state)

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -489,6 +489,7 @@ describe('Store', () => {
     expect(settings.experimentalActivity).toBe(false)
     expect(settings.experimentalActivityDefaultedOffForAllUsers).toBe(true)
     expect(settings.experimentalTerminalAttention).toBe(false)
+    expect(settings.experimentalNewWorktreeCardStyle).toBe(true)
     expect(settings.floatingTerminalEnabled).toBe(true)
     expect(settings.floatingTerminalDefaultedForAllUsers).toBe(true)
     expect(settings.notifications.customSoundPath).toBeNull()
@@ -617,6 +618,57 @@ describe('Store', () => {
 
     expect(store.getOnboarding().closedAt).toBeNull()
     expect(store.getUI().setupGuideSidebarDismissed).toBe(false)
+  })
+
+  it('defaults new worktree card style on while onboarding is open', async () => {
+    writeDataFile({
+      settings: {},
+      onboarding: {
+        flowVersion: ONBOARDING_FLOW_VERSION,
+        closedAt: null,
+        outcome: null,
+        lastCompletedStep: -1,
+        checklist: {}
+      },
+      ui: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().experimentalNewWorktreeCardStyle).toBe(true)
+  })
+
+  it('preserves explicit new worktree card style opt-out while onboarding is open', async () => {
+    writeDataFile({
+      settings: {
+        experimentalNewWorktreeCardStyle: false
+      },
+      onboarding: {
+        flowVersion: ONBOARDING_FLOW_VERSION,
+        closedAt: null,
+        outcome: null,
+        lastCompletedStep: -1,
+        checklist: {}
+      },
+      ui: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().experimentalNewWorktreeCardStyle).toBe(false)
+  })
+
+  it('keeps new worktree card style off for existing users backfilled as completed', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      settings: {},
+      ui: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getOnboarding().closedAt).not.toBeNull()
+    expect(store.getSettings().experimentalNewWorktreeCardStyle).toBe(false)
   })
 
   it('treats persisted false setup guide sidebar dismissal as stale once onboarding is closed', async () => {
@@ -1668,6 +1720,7 @@ describe('Store', () => {
     const store = await createStore()
     expect(store.getRepos()).toEqual([])
     expect(store.getSettings().theme).toBe('system')
+    expect(store.getSettings().experimentalNewWorktreeCardStyle).toBe(false)
   })
 
   // ── 4. Schema migration: merges with defaults ───────────────────────
@@ -8169,6 +8222,7 @@ describe('Store', () => {
     expect(t!.installId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
     )
+    expect(store.getSettings().experimentalNewWorktreeCardStyle).toBe(false)
   })
 
   it('preserves an already-migrated telemetry block on subsequent launches', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1048,6 +1048,10 @@ function resolveSetupGuideSidebarDismissedOnLoad(
   return onboarding.closedAt !== null || persistedDismissed === true
 }
 
+function shouldDefaultNewWorktreeCardStyleOn(onboarding: OnboardingState): boolean {
+  return onboarding.closedAt === null
+}
+
 // Why: read a settings field that was removed from GlobalSettings but can
 // still exist on disk. One-shot use for the inline-agents migration.
 function readDeprecatedExperimentFlag(parsed: PersistedState | undefined): boolean {
@@ -2653,6 +2657,16 @@ export class Store {
         if (!parsed.onboarding) {
           this.loadNeedsSave = true
         }
+        const defaultNewWorktreeCardStyle =
+          shouldDefaultNewWorktreeCardStyleOn(normalizedOnboarding)
+        const migratedExperimentalNewWorktreeCardStyle =
+          parsed.settings?.experimentalNewWorktreeCardStyle ?? defaultNewWorktreeCardStyle
+        if (
+          parsed.settings?.experimentalNewWorktreeCardStyle === undefined &&
+          defaultNewWorktreeCardStyle
+        ) {
+          this.loadNeedsSave = true
+        }
         const normalizedProjectGroups = normalizeProjectGroups(parsed.projectGroups)
         const loadedCompactWorktreeCards =
           parsed.settings?.compactWorktreeCards ??
@@ -2705,6 +2719,9 @@ export class Store {
             ...migratedTerminalCursorStyle,
             experimentalActivity: migratedExperimentalActivity,
             experimentalActivityDefaultedOffForAllUsers: true,
+            // Why: open first-run onboarding is the local fresh-install signal;
+            // closed/backfilled onboarding identifies existing profiles.
+            experimentalNewWorktreeCardStyle: migratedExperimentalNewWorktreeCardStyle,
             // Why: compact worktree cards graduated from Experimental; preserve
             // the old opt-in for profiles written during the rollout.
             compactWorktreeCards: loadedCompactWorktreeCards,
@@ -2977,7 +2994,18 @@ export class Store {
     }
 
     if (result === null) {
-      result = getDefaultPersistedState(homedir())
+      const defaults = getDefaultPersistedState(homedir())
+      const isFreshDefaultProfile =
+        !fileExistedOnLoad && shouldDefaultNewWorktreeCardStyleOn(defaults.onboarding)
+      result = {
+        ...defaults,
+        settings: {
+          ...defaults.settings,
+          // Why: a corrupt existing data file also falls back to defaults; only
+          // the absent-file path is a true fresh install.
+          experimentalNewWorktreeCardStyle: isFreshDefaultProfile
+        }
+      }
     }
 
     const workspaceSession = pruneWorkspaceSessionBrowserHistory(


### PR DESCRIPTION
## Summary

Defaults the experimental new worktree card style (`experimentalNewWorktreeCardStyle`) to `true` for fresh installs and fresh profiles with open onboarding flows. This ensures that new users immediately experience the modern card style. Existing profiles (with completed onboarding) retain their previous style to prevent unexpected visual changes, and any explicit user opt-outs are fully preserved.

This default is maintained both on desktop load (via the Store persistence) and when running the offline agent-hooks CLI commands (which can write initial profiles before desktop load).

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

*Tests added/updated:*
- New CLI handler tests in `src/cli/handlers/agent-hooks.test.ts` verifying default preferences when writing settings offline.
- New Store tests in `src/main/persistence.test.ts` verifying default logic on onboarding open, explicit opt-out preservation, and keeping it off for existing completed onboarding profiles.

## AI Review Report

This change was reviewed with focus on profile transition logic and offline CLI behavior.
- Verified that offline profile initialization correctly respects the same onboarding state resolution logic as the desktop Store.
- Verified that an existing explicit opt-out of `experimentalNewWorktreeCardStyle` is not overridden.
- Cross-platform check: The code utilizes `homedir()` and Node's `path` utilities (e.g. `join`) to handle profile paths cross-platform, ensuring safety on macOS, Linux, and Windows. No platform-specific shortcuts, labels, or IPC differences are introduced.

## Security Audit

- Checked path handling: Uses robust standard profile paths via `getDataPath()` and `homedir()`.
- Checked IPC/data flow: Uses the standard serialization flow of `Store`. No new shell commands, IPC messages, or unsafe inputs are processed.

## Notes

None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6047">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->