### PR TITLE
[codex] stabilize jcode chat integration closeout

### DIFF
--- a/HANDOFF-JCODE.md
+++ b/HANDOFF-JCODE.md
@@ -1,0 +1,45 @@
+# jcode-in-orca 桌面应用 — HANDOFF（2026-06-22）
+
+> 给 compact 后 / 新 session 接手用。读完这份就能继续。用户 = Srain（非技术、讨厌终端、中文、偏好稳定可双击的 GUI app）。
+
+## 0. 一句话目标
+给非技术用户做一个 **Claude-app 式聊天界面**的 AI 编码 agent 桌面应用，基于 fork 的 orca，后端是 jcode（`jcode run --ndjson`），含 **brain-local/hands-remote**（模型在本机、bash 在远程 SSH）。
+
+## 1. 资产位置
+- **orca fork（主体）**：`/Users/vinny/orca-study`，分支 **`jcode-integration`**（clone 自 stablyai/orca @ 988c070，MIT）。所有 orca 侧的 jcode 集成都在这。
+- **jcode fork（后端二进制）**：`/Users/vinny/jccode`（Rust）。二进制软链 `/Users/vinny/.cargo/bin/jcode` → `~/jccode/target/debug/jcode`。含 `--remote-exec`（brain-local）+ `-C` remote-exec 感知（commit 0f0028d）。
+- **打包好的 app（用户日常用这个）**：**`/Applications/Orca.app`**（从 orca-study `build:unpack` 产出，Node 24 构建，ad-hoc 签名）。
+- **旧 Tauri 应用 jccode**：`/Users/vinny/jcode-desktop`（原始聊天优先 app；是"转回 jccode"那条备选方向的现成底座）。
+
+## 2. 构建 / 重打包（关键，务必照做）
+- **dev 模式**：`pnpm dev`（electron-vite）—— **脆，窗口会消失**；renderer 改动热重载，**main 进程改动要完整重启**（Cmd+R 不够）。不建议给用户用。
+- **打包正式 app（必须用 Node 24）**：默认 `node` 是 `/Users/vinny/.local/bin/node`=v22.23（会让 `node:sqlite` 的 afterPack 校验失败）；**v24.11 在 `/usr/local/bin/node`**。命令：
+  ```
+  cd /Users/vinny/orca-study && export PATH="/usr/local/bin:$PATH" && /usr/local/bin/node /Users/vinny/.local/bin/pnpm run build:unpack
+  ```
+  产物 `dist/mac-arm64/Orca.app` → 安装：`pkill -f "Orca.app/Contents/MacOS/Orca"; rm -rf /Applications/Orca.app && cp -R /Users/vinny/orca-study/dist/mac-arm64/Orca.app /Applications/Orca.app; open /Applications/Orca.app`（本地构建无下载隔离，双击直接开）。
+- **jcode 二进制改动**：`cd /Users/vinny/jccode && cargo build` 即更新软链二进制；**app 调的是外部 jcode，不用重打包 orca**。
+- **验证门**：`/Users/vinny/.local/bin/pnpm run typecheck` + `... run lint:switch-exhaustiveness`。（`pnpm run lint` 全量里 check-styled-scrollbars 对 3 个 chat-pane 文件预存失败，与我们无关。）
+
+## 3. 已做出来 & 已验证（orca jcode-integration 关键提交）
+聊天核心(M0–M3)：注册 jcode agent、气泡视图、工具卡片+diff+流式+多轮(--resume)+停止、brain-local。
+之后：聊天 tab 头+切换/worktree切换不丢；Claude 风布局；中文 IME 修复；**对话磁盘持久化**(`src/main/jcode/jcode-conversation-store.ts`)+ Recent chats + 左侧项目栏「JCODE 聊天」可重开；**自定义 provider**(设置→AI提供商账户→自定义 Provider → `jcode provider add --api-key-stdin` → `--provider-profile`)；**附件**(原生选择器/文本/拖拽/跨设备 scp，**图片二进制安全**+25MB上限)；**`/` 菜单**(orca 快捷命令 + 项目级 `.claude/skills`)；jcode 强制进所有启动器(`preflight.ts` ALWAYS_AVAILABLE_LOCAL_AGENT_IDS)；**自动更新已关**；**远程 Git 项目修复**(`jcode-remote-exec.ts` 处理 worktree-scope，不再 ENOENT)；**报错人话**(`jcode-error-messages.ts`)；关 tab 杀进程；JCODE_BIN 走 PATH 解析。
+jcode 二进制：`--remote-exec` + `-C` 在 remote-exec 下只设远程目录(不本机 chdir)。
+**用户已确认：本地 + 远程 Git 项目聊天都能用了（"消息没什么问题了"）。**
+
+## 4. 待办 / 已知问题
+- **✅ 远程 Git 项目 + 附件 + jcode 工具：已验证真能在 spark 上跑**(用户实测 bash/identify 都出结果)。自定义 provider 真实端点也能用(用户实测远程项目里工具在跑)。
+- **✅ 问题2 — 详细模型选择器(2026-06-22 完成,orca 侧)**:composer 模型 chip 现在由真实目录驱动 `jcode model list --json`(新 IPC `jcodeProviders.listModels` → `JcodeModelCatalog {provider,selected_model,models[],routes[]}`)。按 provider 分组、每个模型显示**可用性**(routes[].available；不可用标"需登录")、当前模型打勾、底部"刷新模型列表"、"Auto → <真实解析模型>"。`routeProviderToId` 把显示名映射回 `-p` id;选模型同时定 provider+model。catalog 里没有的 provider(gemini/openrouter…)收进"更多 Provider"子菜单。**"Auto"现在真 auto**:`buildArgs` 默认 `-p auto`(原来硬编码 openai)+ ChatPane 默认 prop 改 'auto'。文件:`chat-pane/jcode-providers.ts`(catalog hook+分组+映射)、`ChatComposer.tsx`(整个 chip 重写为 DropdownMenuItem+Check)、`main/ipc/jcode-providers.ts`(listModels,顺手把硬编码 JCODE_BIN 换成 resolveJcodeBin)。
+- **✅ 问题1 — 看图(2026-06-22 完成,jcode 内核 + orca 双侧)**:发现内核**早就能收图**(ACP 通道证明 `run_once_streaming_mpsc` 接受 `images: Vec<(mime,base64)>` 并建 `ContentBlock::Image`),只是 `run` 没开口子。改动:jcode 加 `run --image <PATH>`(可重复)→ args.rs/dispatch.rs/commands.rs(`load_images_for_run` 读文件+magic-byte 猜 mime+base64,只在 ndjson 首轮发图)。**已实测通过**:`jcode run --image /tmp/jcode-vision-test.png --ndjson "..."` → 模型准确读出"VISION-OK-42 / 红色矩形 / 蓝色圆"。orca 侧:`jcode-attachments.ts` 加 `isVisionImagePath/extractImagePaths/nonImageAttachments`(png/jpg/jpeg/gif/webp);`jcode-chat-session.ts` startTurn 把图片附件抽出来走 `--image`(本地路径,remote-exec 也读本地,不再 scp/不再 weave),其余附件照旧;buildArgs 加 imagePaths 参数。`cargo build` 已更新软链二进制。
+- **✅ 问题3 — MCP / 连接器(2026-06-22 完成,orca 侧;内核早有)**:发现 jcode **早就全套 MCP**(stdio-only:`McpServerConfig{command,args,env,shared}`,配置 `~/.jcode/mcp.json` Claude-Desktop 格式,自动从 `~/.claude/mcp.json`+Codex 导入,MCP 工具已接进 agent 工具表;用户已有 vault-write+node_repl)。orca 侧加管理界面:新 IPC `jcodeMcp.get/set`(`main/ipc/jcode-mcp.ts` 读写全局 `~/.jcode/mcp.json`,写前备份 .bak)+ 设置页"连接器/MCP"区(`AccountsPane.tsx` JcodeMcpSection:列/增/删,字段 name/command/args/env)+ composer"+菜单"的 Connectors→跳设置该区、Plugins→技能页(不再是 Soon)。**远程/托管连接器(IBKR 这种)走 stdio 桥**:command=npx args=[mcp-remote, https://…]。MCP 工具调用本来就以 tool 事件流过 ndjson,会在聊天里显示。
+- **自定义 provider 真实端点**：链路已用假 provider 验证打到端点；用户真实 URL+key 用起来了(远程项目工具在跑)，可视为通。
+- QA 审计剩余(次要)：`listConversations` 每次重读所有文件→历史多会卡(应加索引)；`/` 只在输入框句首触发；远端 `/tmp/orca-jcode-attachments` 不清理；无凭证时 provider 报错引导差；未发送草稿关 tab 丢失；SSH 断时附件被丢但气泡仍显示"已附加"；流式中关 tab 丢事件。完整清单见本 session 的 QA workflow 输出。
+
+## 5. ⏳ 悬而未决：方向决策
+**继续打磨 orca vs 转回 jccode。** 之前代码审计 + 市场调研(`/Users/vinny/jcode-desktop/{ORCA-CHATFIRST-AUDIT.md,AI-CODING-LANDSCAPE-2026.md}`)都指向 **jccode 更适合做纯聊天产品**(orca 是终端复用器，掰成聊天优先一直在逆架构；jccode 天生聊天优先)。用户当时选"先修 bug 再看"。**现在 bug 修得差不多了 → 可重新评估。**
+
+## 6. 协作铁律（记忆里也有）
+- **不要用 computer-use 截图验证**，用户自己验（且本机点击有 Dock 命中 bug）；崩溃用读日志诊断。
+- 命令给**纯净可复制**(无行内 `#` 注释)。
+- 偏好 GUI / 非技术语言 / 中文。
+- 自动更新别让用户点(已在代码关掉；未签名版本也装不上)。

--- a/HANDOFF-JCODE.md
+++ b/HANDOFF-JCODE.md
@@ -25,7 +25,9 @@
 聊天核心(M0–M3)：注册 jcode agent、气泡视图、工具卡片+diff+流式+多轮(--resume)+停止、brain-local。
 之后：聊天 tab 头+切换/worktree切换不丢；Claude 风布局；中文 IME 修复；**对话磁盘持久化**(`src/main/jcode/jcode-conversation-store.ts`)+ Recent chats + 左侧项目栏「JCODE 聊天」可重开；**自定义 provider**(设置→AI提供商账户→自定义 Provider → `jcode provider add --api-key-stdin` → `--provider-profile`)；**附件**(原生选择器/文本/拖拽/跨设备 scp，**图片二进制安全**+25MB上限)；**`/` 菜单**(orca 快捷命令 + 项目级 `.claude/skills`)；jcode 强制进所有启动器(`preflight.ts` ALWAYS_AVAILABLE_LOCAL_AGENT_IDS)；**自动更新已关**；**远程 Git 项目修复**(`jcode-remote-exec.ts` 处理 worktree-scope，不再 ENOENT)；**报错人话**(`jcode-error-messages.ts`)；关 tab 杀进程；JCODE_BIN 走 PATH 解析。
 jcode 二进制：`--remote-exec` + `-C` 在 remote-exec 下只设远程目录(不本机 chdir)。
-**用户已确认：本地 + 远程 Git 项目聊天都能用了（"消息没什么问题了"）。**
+**用户已确认：本地 + 远程 Git 项目聊天都能用了（"消息没什么问题了"）。看图也实测成功（用户："测试成功"）。**
+
+**2026-06-22 收尾**：三个功能已提交 —— orca-study `a20a388`(jcode-integration)、jccode `feat/run-image-vision` 分支 `6571316`(从 main 切出)。另在 `~/orca-study/.claude/skills/` 建了 5 个开发流程技能(rebuild-app / verify-gates / add-chat-feature / jcode-kernel-change / probe-jcode)——**注意 `.gitignore:105` 把 `/.claude/skills/` 排除了,技能只在本机磁盘、不进 git(orca 约定:项目技能本地私有);jcode 的 `/` 菜单按文件系统发现,照常生效**。/Applications 的 app 是看图实测那次的构建;之后只做了纯重构(model picker 拆到 `ChatModelPicker.tsx` 过 max-lines 闸,行为不变),想让二进制==已提交源码可再跑一次 rebuild-app(非必须)。
 
 ## 4. 待办 / 已知问题
 - **✅ 远程 Git 项目 + 附件 + jcode 工具：已验证真能在 spark 上跑**(用户实测 bash/identify 都出结果)。自定义 provider 真实端点也能用(用户实测远程项目里工具在跑)。

--- a/HANDOFF-JCODE.md
+++ b/HANDOFF-JCODE.md
@@ -45,3 +45,16 @@ jcode 二进制：`--remote-exec` + `-C` 在 remote-exec 下只设远程目录(�
 - 命令给**纯净可复制**(无行内 `#` 注释)。
 - 偏好 GUI / 非技术语言 / 中文。
 - 自动更新别让用户点(已在代码关掉；未签名版本也装不上)。
+
+## 7. 2026-06-22 closeout validation evidence
+- 当前分支：`jcode-integration`。收尾提交已覆盖 scrollbar gate、localization gate、jcode session store 拆分、jcode binary resolution、remote attachment lifecycle cleanup/hardening、remote upload command exit-code 校验、附件测试 fixture 拆分。
+- `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm run typecheck`：PASS。
+- `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm run lint`：PASS；包含 `lint:switch-exhaustiveness`、`check:styled-scrollbars`、`verify:localization-catalog`、`verify:localization-coverage`。
+- `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm exec vitest run --config config/vitest.config.ts src/main/jcode/jcode-attachments.test.ts src/main/jcode/jcode-remote-exec.test.ts`：PASS，2 files / 16 tests。
+- `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm run test`：FAIL only in non-jcode PTY tests during full-suite concurrency/resource load: `src/main/daemon/node-pty-fd-leak.test.ts` timed out, `src/main/daemon/shell-ready.test.ts` had 3 marker assertions, `src/main/pty/omp-shell-wrapper.node-pty.test.ts` had 3 bash PTY timeouts. Focused rerun of those exact 3 files passed: 3 files / 27 tests. Treat as documented full-suite PTY flake until reproduced outside concurrent full run.
+- `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/node-pty-fd-leak.test.ts src/main/daemon/shell-ready.test.ts src/main/pty/omp-shell-wrapper.node-pty.test.ts`：PASS，3 files / 27 tests.
+- `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm run build:unpack`：PASS. Built `dist/mac-arm64/Orca.app`, version `1.4.89-rc.0`, size about `1.0G`, ad-hoc signed, notarization skipped by config.
+- Manual GUI smoke was not performed in this pass. User-side checks still recommended before daily use: open rebuilt app, start jcode local chat, start remote SSH project chat, send image attachment, verify model picker, verify MCP settings read/write.
+- Remote/fork hygiene: `git remote -v` still shows `origin=https://github.com/stablyai/orca` for fetch and push. No user-owned fork remote is configured, so do not push from this checkout until a fork remote is added.
+- Product-direction decision: keep this Orca fork as the current closeout target while SSH project management, worktrees, review UI, and existing Orca shell are core value. Re-open the jcode-desktop direction only if the durable product narrows to a Claude-app-style chat shell and Orca's terminal/worktree architecture becomes net drag again.
+- Residual non-blocking limitation: remote attachment upload assumes POSIX remote tools and paths (`/tmp`, `mkdir`, `base64 -d`, `rm`). Unsupported SSH targets fail closed and report attachments as not copied; no live SSH integration test was run in this closeout pass.

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -143,6 +143,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     ...overrides,
     localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault ?? { kind: 'windows-host' },
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
+    jcodeCustomProviders: overrides.jcodeCustomProviders ?? [],
     appFontFamily,
     agentStatusHooksEnabled,
     tabAutoGenerateTitle

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -147,6 +147,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     ...overrides,
     localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault ?? { kind: 'windows-host' },
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
+    jcodeCustomProviders: overrides.jcodeCustomProviders ?? [],
     appFontFamily,
     agentStatusHooksEnabled,
     tabAutoGenerateTitle

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -120,6 +120,12 @@ function getBaseVersionManagerDirectories(platform: NodeJS.Platform, homePath: s
   // Why: bun uses ~/.bun/bin on all platforms for globally installed packages.
   directories.push(join(homePath, '.bun', 'bin'))
 
+  // Why: Rust/Cargo-installed binaries (e.g. Orca's integrated jcode agent)
+  // land in ~/.cargo/bin, which GUI-launched Orca often does not inherit on
+  // PATH. Probe it directly so cargo-installed CLIs resolve without a shell
+  // re-hydration. Same convention on all platforms.
+  directories.push(join(homePath, '.cargo', 'bin'))
+
   return directories
 }
 

--- a/src/main/ipc/jcode-mcp.ts
+++ b/src/main/ipc/jcode-mcp.ts
@@ -1,0 +1,141 @@
+// Why: lets the renderer manage jcode's MCP servers ("connectors") from the GUI.
+// jcode reads stdio MCP servers from ~/.jcode/mcp.json (Claude-Desktop format)
+// and exposes their tools to the agent automatically — so the only work here is
+// a safe read/write bridge for that one global file. We deliberately manage ONLY
+// the global file; jcode still merges project-local (.jcode/mcp.json) and the
+// .claude/mcp.json compat file on its own.
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { ipcMain } from 'electron'
+import {
+  JCODE_MCP_GET_CHANNEL,
+  JCODE_MCP_SET_CHANNEL,
+  type JcodeMcpActionResult,
+  type JcodeMcpConfigResult,
+  type JcodeMcpServer,
+  type JcodeMcpSetArgs
+} from '../../shared/jcode-chat-types'
+
+const NAME_RE = /^[a-zA-Z0-9_.-]+$/
+
+function mcpJsonPath(): string {
+  return join(homedir(), '.jcode', 'mcp.json')
+}
+
+/** On-disk shape jcode expects. */
+type OnDiskServer = {
+  command: string
+  args?: string[]
+  env?: Record<string, string>
+  shared?: boolean
+}
+type OnDiskConfig = { servers?: Record<string, OnDiskServer> }
+
+function readConfig(): { servers: JcodeMcpServer[] } {
+  const path = mcpJsonPath()
+  if (!existsSync(path)) {
+    return { servers: [] }
+  }
+  const raw = readFileSync(path, 'utf8')
+  const parsed = JSON.parse(raw) as OnDiskConfig
+  const servers: JcodeMcpServer[] = Object.entries(parsed.servers ?? {}).map(([name, value]) => ({
+    name,
+    command: typeof value.command === 'string' ? value.command : '',
+    args: Array.isArray(value.args) ? value.args.filter((a) => typeof a === 'string') : [],
+    env:
+      value.env && typeof value.env === 'object'
+        ? Object.fromEntries(
+            Object.entries(value.env).filter(([, v]) => typeof v === 'string') as [string, string][]
+          )
+        : {},
+    shared: value.shared !== false
+  }))
+  // Stable order for the UI.
+  servers.sort((a, b) => a.name.localeCompare(b.name))
+  return { servers }
+}
+
+function getMcpConfig(): JcodeMcpConfigResult {
+  try {
+    const { servers } = readConfig()
+    return { ok: true, servers, path: mcpJsonPath() }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      servers: [],
+      path: mcpJsonPath()
+    }
+  }
+}
+
+function validateServers(servers: JcodeMcpServer[]): string | null {
+  if (!Array.isArray(servers)) {
+    return 'Invalid request.'
+  }
+  const seen = new Set<string>()
+  for (const server of servers) {
+    const name = server?.name?.trim()
+    if (!name || !NAME_RE.test(name)) {
+      return `Server name "${name ?? ''}" is invalid (letters, numbers, ".", "-", "_" only).`
+    }
+    if (seen.has(name)) {
+      return `Duplicate server name "${name}".`
+    }
+    seen.add(name)
+    if (!server.command?.trim()) {
+      return `Server "${name}" needs a command.`
+    }
+    if (server.args && !Array.isArray(server.args)) {
+      return `Server "${name}" args must be a list.`
+    }
+  }
+  return null
+}
+
+function setMcpConfig(args: JcodeMcpSetArgs): JcodeMcpActionResult {
+  const servers = args?.servers
+  const validationError = validateServers(servers)
+  if (validationError) {
+    return { ok: false, error: validationError }
+  }
+  try {
+    const path = mcpJsonPath()
+    const dir = dirname(path)
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+    // Keep a single-level backup before overwriting user data.
+    if (existsSync(path)) {
+      try {
+        copyFileSync(path, `${path}.bak`)
+      } catch {
+        // Non-fatal: proceed without a backup rather than block the save.
+      }
+    }
+    const onDisk: OnDiskConfig = { servers: {} }
+    for (const server of servers) {
+      onDisk.servers![server.name.trim()] = {
+        command: server.command.trim(),
+        args: (server.args ?? []).map((a) => a).filter((a) => a.length > 0),
+        env: server.env ?? {},
+        shared: server.shared !== false
+      }
+    }
+    writeFileSync(path, `${JSON.stringify(onDisk, null, 2)}\n`, 'utf8')
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export function registerJcodeMcpHandlers(): void {
+  ipcMain.removeHandler(JCODE_MCP_GET_CHANNEL)
+  ipcMain.handle(JCODE_MCP_GET_CHANNEL, () => getMcpConfig())
+
+  ipcMain.removeHandler(JCODE_MCP_SET_CHANNEL)
+  ipcMain.handle(JCODE_MCP_SET_CHANNEL, (_event, raw: unknown) =>
+    setMcpConfig(raw as JcodeMcpSetArgs)
+  )
+}

--- a/src/main/ipc/jcode-providers.ts
+++ b/src/main/ipc/jcode-providers.ts
@@ -9,17 +9,17 @@
 import { spawn } from 'node:child_process'
 import { ipcMain } from 'electron'
 import {
+  JCODE_MODELS_LIST_CHANNEL,
   JCODE_PROVIDERS_ADD_CHANNEL,
   JCODE_PROVIDERS_LIST_CHANNEL,
   type JcodeCustomProvider,
+  type JcodeModelCatalog,
+  type JcodeModelRoute,
   type JcodeProviderActionResult,
   type JcodeProviderAddArgs,
   type JcodeProviderAuth
 } from '../../shared/jcode-chat-types'
-
-// Mirrors the pinned absolute path used by jcode-chat-session.ts: jcode is
-// installed via cargo and Electron's PATH is often empty.
-const JCODE_BIN = '/Users/vinny/.cargo/bin/jcode'
+import { resolveJcodeBin } from '../jcode/jcode-binary'
 
 const NAME_RE = /^[a-zA-Z0-9_-]+$/
 const ALLOWED_AUTH: readonly JcodeProviderAuth[] = ['bearer', 'api-key', 'none']
@@ -77,7 +77,7 @@ function runJcode(
   return new Promise((resolve, reject) => {
     let child: ReturnType<typeof spawn>
     try {
-      child = spawn(JCODE_BIN, argv, { env: process.env })
+      child = spawn(resolveJcodeBin(), argv, { env: process.env })
     } catch (error) {
       reject(error instanceof Error ? error : new Error(String(error)))
       return
@@ -194,6 +194,71 @@ async function listProviders(): Promise<{
   }
 }
 
+/** Shell `jcode model list --json` and return the real model catalog (provider,
+ *  selected model, full model list, and per-model availability routes) that the
+ *  composer's detailed picker renders. We use the AUTO catalog (no `-p`) on
+ *  purpose: it returns the usable models for the resolved provider PLUS the
+ *  cross-provider routes with availability, and it never trips jcode's
+ *  interactive credential-approval gate that `-p claude` would. */
+async function listModels(): Promise<JcodeModelCatalog> {
+  let result: { code: number | null; stdout: string; stderr: string }
+  try {
+    result = await runJcode(['model', 'list', '--json', '--no-update'])
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      models: [],
+      routes: []
+    }
+  }
+  if (result.code !== 0) {
+    return {
+      ok: false,
+      error: result.stderr.trim() || `jcode model list exited with code ${result.code}`,
+      models: [],
+      routes: []
+    }
+  }
+  try {
+    const parsed = JSON.parse(result.stdout) as {
+      provider?: string
+      selected_model?: string
+      models?: string[]
+      routes?: { provider?: string; model?: string; method?: string; available?: boolean }[]
+    }
+    const routes: JcodeModelRoute[] = Array.isArray(parsed.routes)
+      ? parsed.routes
+          .filter(
+            (r): r is { provider: string; model: string; method?: string; available?: boolean } =>
+              typeof r?.provider === 'string' && typeof r?.model === 'string'
+          )
+          .map((r) => ({
+            provider: r.provider,
+            model: r.model,
+            method: typeof r.method === 'string' ? r.method : undefined,
+            available: r.available === true
+          }))
+      : []
+    return {
+      ok: true,
+      provider: typeof parsed.provider === 'string' ? parsed.provider : undefined,
+      selectedModel: typeof parsed.selected_model === 'string' ? parsed.selected_model : undefined,
+      models: Array.isArray(parsed.models)
+        ? parsed.models.filter((m) => typeof m === 'string')
+        : [],
+      routes
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : 'Failed to parse jcode model list output.',
+      models: [],
+      routes: []
+    }
+  }
+}
+
 export function registerJcodeProviderHandlers(): void {
   ipcMain.removeHandler(JCODE_PROVIDERS_ADD_CHANNEL)
   ipcMain.handle(JCODE_PROVIDERS_ADD_CHANNEL, (_event, raw: unknown) =>
@@ -202,4 +267,7 @@ export function registerJcodeProviderHandlers(): void {
 
   ipcMain.removeHandler(JCODE_PROVIDERS_LIST_CHANNEL)
   ipcMain.handle(JCODE_PROVIDERS_LIST_CHANNEL, () => listProviders())
+
+  ipcMain.removeHandler(JCODE_MODELS_LIST_CHANNEL)
+  ipcMain.handle(JCODE_MODELS_LIST_CHANNEL, () => listModels())
 }

--- a/src/main/ipc/jcode-providers.ts
+++ b/src/main/ipc/jcode-providers.ts
@@ -1,0 +1,205 @@
+// Why: lets the renderer add a custom OpenAI-compatible provider profile to the
+// jcode CLI (base URL + model + API key) and list the built-in providers. The
+// jcode CLI already persists a `[providers.<name>]` profile and stores the key
+// in its private env file via `jcode provider add ... --api-key-stdin`; this
+// module is the thin, safe bridge.
+//
+// SECURITY: the API key is written to the child's STDIN (never passed as an
+// argv flag, which would leak via `ps`/process listing) and is never logged.
+import { spawn } from 'node:child_process'
+import { ipcMain } from 'electron'
+import {
+  JCODE_PROVIDERS_ADD_CHANNEL,
+  JCODE_PROVIDERS_LIST_CHANNEL,
+  type JcodeCustomProvider,
+  type JcodeProviderActionResult,
+  type JcodeProviderAddArgs,
+  type JcodeProviderAuth
+} from '../../shared/jcode-chat-types'
+
+// Mirrors the pinned absolute path used by jcode-chat-session.ts: jcode is
+// installed via cargo and Electron's PATH is often empty.
+const JCODE_BIN = '/Users/vinny/.cargo/bin/jcode'
+
+const NAME_RE = /^[a-zA-Z0-9_-]+$/
+const ALLOWED_AUTH: readonly JcodeProviderAuth[] = ['bearer', 'api-key', 'none']
+
+function fail(error: string): JcodeProviderActionResult {
+  return { ok: false, error }
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    // Allow http(s); http only for localhost-style custom gateways.
+    if (url.protocol === 'https:') {
+      return true
+    }
+    if (url.protocol === 'http:') {
+      return url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+/** Validate the add args. Returns null when valid, else an error message. */
+function validateAddArgs(args: JcodeProviderAddArgs): string | null {
+  if (!args || typeof args !== 'object') {
+    return 'Invalid request.'
+  }
+  const name = args.name?.trim()
+  if (!name || !NAME_RE.test(name)) {
+    return 'Profile name must be non-empty and contain only letters, numbers, "-" or "_".'
+  }
+  const baseUrl = args.baseUrl?.trim()
+  if (!baseUrl || !isHttpsUrl(baseUrl)) {
+    return 'Base URL must be a valid https URL (e.g. https://llm.example.com/v1).'
+  }
+  const model = args.model?.trim()
+  if (!model) {
+    return 'Model id is required.'
+  }
+  if (args.auth !== undefined && !ALLOWED_AUTH.includes(args.auth)) {
+    return 'Auth must be one of bearer, api-key, or none.'
+  }
+  return null
+}
+
+/** Spawn jcode and resolve with {code, stdout, stderr}. Optionally write a
+ *  secret to stdin (used for --api-key-stdin). The secret is NEVER part of argv
+ *  and is NEVER logged. */
+function runJcode(
+  argv: string[],
+  stdin?: string
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof spawn>
+    try {
+      child = spawn(JCODE_BIN, argv, { env: process.env })
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error(String(error)))
+      return
+    }
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.setEncoding('utf8')
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr?.setEncoding('utf8')
+    child.stderr?.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+    child.on('error', (error: Error) => reject(error))
+    child.on('close', (code) => resolve({ code, stdout, stderr }))
+    if (stdin !== undefined) {
+      child.stdin?.write(stdin)
+    }
+    child.stdin?.end()
+  })
+}
+
+async function addProvider(args: JcodeProviderAddArgs): Promise<JcodeProviderActionResult> {
+  const validationError = validateAddArgs(args)
+  if (validationError) {
+    return fail(validationError)
+  }
+  const name = args.name.trim()
+  const baseUrl = args.baseUrl.trim()
+  const model = args.model.trim()
+  const auth: JcodeProviderAuth = args.auth ?? 'bearer'
+  const hasKey = typeof args.apiKey === 'string' && args.apiKey.length > 0
+
+  // `provider add <NAME> --base-url <URL> --model <MODEL> [--auth ...]
+  //   [--auth-header H] [--api-key-stdin | --no-api-key] --json --overwrite`
+  const argv = [
+    'provider',
+    'add',
+    name,
+    '--base-url',
+    baseUrl,
+    '--model',
+    model,
+    '--auth',
+    auth,
+    '--json',
+    '--overwrite',
+    '--no-update'
+  ]
+  if (args.authHeader?.trim()) {
+    argv.push('--auth-header', args.authHeader.trim())
+  }
+  if (hasKey) {
+    argv.push('--api-key-stdin')
+  } else {
+    argv.push('--no-api-key')
+  }
+
+  let result: { code: number | null; stdout: string; stderr: string }
+  try {
+    result = await runJcode(argv, hasKey ? args.apiKey : undefined)
+  } catch (error) {
+    return fail(error instanceof Error ? error.message : String(error))
+  }
+  if (result.code !== 0) {
+    return fail(
+      result.stderr.trim() ||
+        result.stdout.trim() ||
+        `jcode provider add exited with code ${result.code === null ? 'null' : String(result.code)}`
+    )
+  }
+
+  // The non-secret profile we persist on the orca side regardless of the exact
+  // shape jcode's --json returns (we already validated the inputs).
+  const provider: JcodeCustomProvider = { name, baseUrl, model, auth }
+  return { ok: true, provider }
+}
+
+type BuiltinProvider = {
+  id: string
+  display_name?: string
+  detail?: string
+  recommended?: boolean
+}
+
+async function listProviders(): Promise<{
+  ok: boolean
+  error?: string
+  builtins: BuiltinProvider[]
+}> {
+  let result: { code: number | null; stdout: string; stderr: string }
+  try {
+    result = await runJcode(['provider', 'list', '--json', '--no-update'])
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      builtins: []
+    }
+  }
+  if (result.code !== 0) {
+    return {
+      ok: false,
+      error: result.stderr.trim() || `jcode provider list exited with code ${result.code}`,
+      builtins: []
+    }
+  }
+  try {
+    const parsed = JSON.parse(result.stdout) as { providers?: BuiltinProvider[] }
+    return { ok: true, builtins: Array.isArray(parsed.providers) ? parsed.providers : [] }
+  } catch {
+    return { ok: true, builtins: [] }
+  }
+}
+
+export function registerJcodeProviderHandlers(): void {
+  ipcMain.removeHandler(JCODE_PROVIDERS_ADD_CHANNEL)
+  ipcMain.handle(JCODE_PROVIDERS_ADD_CHANNEL, (_event, raw: unknown) =>
+    addProvider(raw as JcodeProviderAddArgs)
+  )
+
+  ipcMain.removeHandler(JCODE_PROVIDERS_LIST_CHANNEL)
+  ipcMain.handle(JCODE_PROVIDERS_LIST_CHANNEL, () => listProviders())
+}

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -13,7 +13,9 @@ const {
   getAzureDevOpsAuthStatusMock,
   getGiteaAuthStatusMock,
   resolveCliCommandsMock,
-  mergePersistedWindowsPathMock
+  mergePersistedWindowsPathMock,
+  resolveJcodeBinMock,
+  hasJcodeBinEnvOverrideMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   execFileMock: vi.fn(),
@@ -25,7 +27,9 @@ const {
   getAzureDevOpsAuthStatusMock: vi.fn(),
   getGiteaAuthStatusMock: vi.fn(),
   resolveCliCommandsMock: vi.fn(),
-  mergePersistedWindowsPathMock: vi.fn()
+  mergePersistedWindowsPathMock: vi.fn(),
+  resolveJcodeBinMock: vi.fn(),
+  hasJcodeBinEnvOverrideMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -73,6 +77,11 @@ vi.mock('../gitea/client', () => ({
   getGiteaAuthStatus: getGiteaAuthStatusMock
 }))
 
+vi.mock('../jcode/jcode-binary', () => ({
+  resolveJcodeBin: resolveJcodeBinMock,
+  hasJcodeBinEnvOverride: hasJcodeBinEnvOverrideMock
+}))
+
 import {
   _resetPreflightCache,
   detectInstalledAgents,
@@ -111,6 +120,10 @@ describe('preflight', () => {
     getAzureDevOpsAuthStatusMock.mockReset()
     getGiteaAuthStatusMock.mockReset()
     mergePersistedWindowsPathMock.mockReset()
+    resolveJcodeBinMock.mockReset()
+    hasJcodeBinEnvOverrideMock.mockReset()
+    resolveJcodeBinMock.mockReturnValue('/opt/orca/bin/jcode')
+    hasJcodeBinEnvOverrideMock.mockReturnValue(false)
     // Why: existing tests should keep treating `which` as the only source
     // unless a case explicitly exercises the install-dir fallback.
     resolveCliCommandsMock.mockReset()
@@ -487,8 +500,8 @@ describe('preflight', () => {
       throw new Error('not found')
     })
 
-    // Why: jcode is force-unioned into the local detected set so Orca's own
-    // integrated chat agent is always launchable regardless of `which jcode`.
+    // Why: test setup simulates a local jcode binary resolved outside PATH, so
+    // the integrated chat agent remains launchable when generic detection misses it.
     await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'cursor', 'jcode'])
   })
 
@@ -555,8 +568,36 @@ describe('preflight', () => {
       throw new Error('EACCES: permission denied')
     })
 
-    // Why: even with zero real detections, jcode is force-unioned into the
-    // local set so the integrated chat agent is never hidden from launch surfaces.
+    await expect(detectInstalledAgents()).resolves.toEqual(['jcode'])
+  })
+
+  it('does not force-add jcode when the resolver only returns the bare command', async () => {
+    resolveJcodeBinMock.mockReturnValue('jcode')
+    execFileAsyncMock.mockImplementation(async (command) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      throw new Error('not found')
+    })
+    resolveCliCommandsMock.mockImplementation(
+      (commands: string[]) => new Map(commands.map((cmd) => [cmd, cmd]))
+    )
+
+    await expect(detectInstalledAgents()).resolves.toEqual([])
+  })
+
+  it('force-adds jcode when the resolver returns a real local binary path', async () => {
+    resolveJcodeBinMock.mockReturnValue('/opt/orca/bin/jcode')
+    execFileAsyncMock.mockImplementation(async (command) => {
+      if (command !== 'which') {
+        throw new Error(`unexpected command ${String(command)}`)
+      }
+      throw new Error('not found')
+    })
+    resolveCliCommandsMock.mockImplementation(
+      (commands: string[]) => new Map(commands.map((cmd) => [cmd, cmd]))
+    )
+
     await expect(detectInstalledAgents()).resolves.toEqual(['jcode'])
   })
 

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -487,7 +487,9 @@ describe('preflight', () => {
       throw new Error('not found')
     })
 
-    await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'cursor'])
+    // Why: jcode is force-unioned into the local detected set so Orca's own
+    // integrated chat agent is always launchable regardless of `which jcode`.
+    await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'cursor', 'jcode'])
   })
 
   it('detects agents via the install-dir resolver when which fails (stripped GUI PATH)', async () => {
@@ -517,7 +519,7 @@ describe('preflight', () => {
         )
     )
 
-    await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'codex', 'opencode'])
+    await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'codex', 'opencode', 'jcode'])
     expect(resolveCliCommandsMock).toHaveBeenCalledTimes(1)
   })
 
@@ -536,7 +538,7 @@ describe('preflight', () => {
       (commands: string[]) => new Map(commands.map((cmd) => [cmd, cmd]))
     )
 
-    await expect(detectInstalledAgents()).resolves.toEqual(['claude'])
+    await expect(detectInstalledAgents()).resolves.toEqual(['claude', 'jcode'])
     expect(resolveCliCommandsMock).toHaveBeenCalledTimes(1)
     expect(resolveCliCommandsMock).toHaveBeenCalledWith(expect.not.arrayContaining(['claude']))
   })
@@ -553,7 +555,9 @@ describe('preflight', () => {
       throw new Error('EACCES: permission denied')
     })
 
-    await expect(detectInstalledAgents()).resolves.toEqual([])
+    // Why: even with zero real detections, jcode is force-unioned into the
+    // local set so the integrated chat agent is never hidden from launch surfaces.
+    await expect(detectInstalledAgents()).resolves.toEqual(['jcode'])
   })
 
   it('registers agent detection through the shared launch config commands', async () => {
@@ -572,7 +576,11 @@ describe('preflight', () => {
 
     registerPreflightHandlers()
 
-    await expect(handlers['preflight:detectAgents']()).resolves.toEqual(['openclaude', 'cursor'])
+    await expect(handlers['preflight:detectAgents']()).resolves.toEqual([
+      'openclaude',
+      'cursor',
+      'jcode'
+    ])
   })
 
   it('detects Mistral Vibe from the installed vibe executable', async () => {
@@ -586,7 +594,7 @@ describe('preflight', () => {
       throw new Error('not found')
     })
 
-    await expect(detectInstalledAgents()).resolves.toEqual(['mistral-vibe'])
+    await expect(detectInstalledAgents()).resolves.toEqual(['mistral-vibe', 'jcode'])
   })
 
   it('deduplicates Mistral Vibe when both current and legacy executables exist', async () => {
@@ -600,7 +608,7 @@ describe('preflight', () => {
       throw new Error('not found')
     })
 
-    await expect(detectInstalledAgents()).resolves.toEqual(['mistral-vibe'])
+    await expect(detectInstalledAgents()).resolves.toEqual(['mistral-vibe', 'jcode'])
   })
 
   it('sends aliased detection commands through the SSH remote preflight path', async () => {
@@ -821,7 +829,7 @@ describe('preflight', () => {
     }
 
     expect(result).toEqual({
-      agents: ['opencode'],
+      agents: ['opencode', 'jcode'],
       addedPathSegments: ['/Users/test/.opencode/bin'],
       shellHydrationOk: true,
       pathSource: 'shell_hydrate',
@@ -858,7 +866,7 @@ describe('preflight', () => {
 
     expect(result.shellHydrationOk).toBe(false)
     expect(result.addedPathSegments).toEqual([])
-    expect(result.agents).toEqual(['claude'])
+    expect(result.agents).toEqual(['claude', 'jcode'])
     // Why: drives the agent_picks `on_path:false` triage in dashboard 1562016.
     // Without these fields we cannot distinguish "hydration failed" from
     // "user genuinely doesn't have the binary."

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -14,8 +14,7 @@ const {
   getGiteaAuthStatusMock,
   resolveCliCommandsMock,
   mergePersistedWindowsPathMock,
-  resolveJcodeBinMock,
-  hasJcodeBinEnvOverrideMock
+  resolveJcodeBinMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   execFileMock: vi.fn(),
@@ -28,8 +27,7 @@ const {
   getGiteaAuthStatusMock: vi.fn(),
   resolveCliCommandsMock: vi.fn(),
   mergePersistedWindowsPathMock: vi.fn(),
-  resolveJcodeBinMock: vi.fn(),
-  hasJcodeBinEnvOverrideMock: vi.fn()
+  resolveJcodeBinMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -78,8 +76,7 @@ vi.mock('../gitea/client', () => ({
 }))
 
 vi.mock('../jcode/jcode-binary', () => ({
-  resolveJcodeBin: resolveJcodeBinMock,
-  hasJcodeBinEnvOverride: hasJcodeBinEnvOverrideMock
+  resolveJcodeBin: resolveJcodeBinMock
 }))
 
 import {
@@ -121,9 +118,7 @@ describe('preflight', () => {
     getGiteaAuthStatusMock.mockReset()
     mergePersistedWindowsPathMock.mockReset()
     resolveJcodeBinMock.mockReset()
-    hasJcodeBinEnvOverrideMock.mockReset()
     resolveJcodeBinMock.mockReturnValue('/opt/orca/bin/jcode')
-    hasJcodeBinEnvOverrideMock.mockReturnValue(false)
     // Why: existing tests should keep treating `which` as the only source
     // unless a case explicitly exercises the install-dir fallback.
     resolveCliCommandsMock.mockReset()
@@ -571,7 +566,9 @@ describe('preflight', () => {
     await expect(detectInstalledAgents()).resolves.toEqual(['jcode'])
   })
 
-  it('does not force-add jcode when the resolver only returns the bare command', async () => {
+  it('does not force-add jcode when an env override is rejected by the resolver', async () => {
+    const originalOverride = process.env.ORCA_JCODE_BIN
+    process.env.ORCA_JCODE_BIN = '/tmp/orca-missing-jcode'
     resolveJcodeBinMock.mockReturnValue('jcode')
     execFileAsyncMock.mockImplementation(async (command) => {
       if (command !== 'which') {
@@ -583,7 +580,15 @@ describe('preflight', () => {
       (commands: string[]) => new Map(commands.map((cmd) => [cmd, cmd]))
     )
 
-    await expect(detectInstalledAgents()).resolves.toEqual([])
+    try {
+      await expect(detectInstalledAgents()).resolves.toEqual([])
+    } finally {
+      if (originalOverride === undefined) {
+        delete process.env.ORCA_JCODE_BIN
+      } else {
+        process.env.ORCA_JCODE_BIN = originalOverride
+      }
+    }
   })
 
   it('force-adds jcode when the resolver returns a real local binary path', async () => {

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -149,6 +149,22 @@ function uniqueAgentIds(ids: Iterable<string>): string[] {
   return [...new Set(ids)]
 }
 
+// Why: jcode is Orca's own integrated chat agent. Its chat backend
+// (src/main/jcode/jcode-chat-session.ts) spawns the binary via a pinned
+// absolute path, so it does NOT depend on `which jcode` resolving at runtime.
+// PATH detection for ~/.cargo/bin is flaky on a cold GUI launch, which would
+// otherwise hide jcode from every launch surface (the tab "+" palette,
+// QuickLaunchButton, the new-workspace composer) since those gate on the
+// detected set. Force-include it on the LOCAL host only so it is always
+// launchable, while every other agent stays gated on real detection. Remote
+// (SSH) and WSL hosts use separate detection paths and must NOT be forced —
+// the local cargo binary is not present there.
+const ALWAYS_AVAILABLE_LOCAL_AGENT_IDS: readonly string[] = ['jcode']
+
+function withForcedLocalAgents(ids: Iterable<string>): string[] {
+  return uniqueAgentIds([...ids, ...ALWAYS_AVAILABLE_LOCAL_AGENT_IDS])
+}
+
 async function detectCommandRuntime(
   command: string,
   context?: PreflightRuntimeContext
@@ -192,7 +208,11 @@ export async function detectInstalledAgents(context?: PreflightRuntimeContext): 
     id,
     installed: installedOnPath || installDirCommands.has(cmd)
   }))
-  return uniqueAgentIds(checks.filter((c) => c.installed).map((c) => c.id))
+  // Why: force-union jcode into the LOCAL detected set so it shows up and is
+  // launchable in every launch surface even when `which jcode` fails to resolve
+  // ~/.cargo/bin on a cold GUI launch. The WSL branch above returns before this
+  // point, so remote hosts are unaffected.
+  return withForcedLocalAgents(checks.filter((c) => c.installed).map((c) => c.id))
 }
 
 export type RefreshAgentsResult = {

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -15,6 +15,7 @@ import { runPreflightCommandInWsl } from './preflight-wsl-command'
 import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
 import { buildLocalPreflightEnv } from './preflight-local-env'
 import { getPreflightWslTarget, type PreflightRuntimeContext } from './preflight-runtime-target'
+import { hasJcodeBinEnvOverride, resolveJcodeBin } from '../jcode/jcode-binary'
 const execFileAsync = promisify(execFile)
 const PREFLIGHT_COMMAND_TIMEOUT_MS = 5000
 
@@ -149,20 +150,10 @@ function uniqueAgentIds(ids: Iterable<string>): string[] {
   return [...new Set(ids)]
 }
 
-// Why: jcode is Orca's own integrated chat agent. Its chat backend
-// (src/main/jcode/jcode-chat-session.ts) spawns the binary via a pinned
-// absolute path, so it does NOT depend on `which jcode` resolving at runtime.
-// PATH detection for ~/.cargo/bin is flaky on a cold GUI launch, which would
-// otherwise hide jcode from every launch surface (the tab "+" palette,
-// QuickLaunchButton, the new-workspace composer) since those gate on the
-// detected set. Force-include it on the LOCAL host only so it is always
-// launchable, while every other agent stays gated on real detection. Remote
-// (SSH) and WSL hosts use separate detection paths and must NOT be forced —
-// the local cargo binary is not present there.
-const ALWAYS_AVAILABLE_LOCAL_AGENT_IDS: readonly string[] = ['jcode']
-
-function withForcedLocalAgents(ids: Iterable<string>): string[] {
-  return uniqueAgentIds([...ids, ...ALWAYS_AVAILABLE_LOCAL_AGENT_IDS])
+// Why: a bare resolver result means preflight should not advertise jcode on a fresh host.
+function withResolvableLocalJcode(ids: Iterable<string>): string[] {
+  const shouldAddJcode = resolveJcodeBin() !== 'jcode' || hasJcodeBinEnvOverride()
+  return uniqueAgentIds(shouldAddJcode ? [...ids, 'jcode'] : ids)
 }
 
 async function detectCommandRuntime(
@@ -208,11 +199,7 @@ export async function detectInstalledAgents(context?: PreflightRuntimeContext): 
     id,
     installed: installedOnPath || installDirCommands.has(cmd)
   }))
-  // Why: force-union jcode into the LOCAL detected set so it shows up and is
-  // launchable in every launch surface even when `which jcode` fails to resolve
-  // ~/.cargo/bin on a cold GUI launch. The WSL branch above returns before this
-  // point, so remote hosts are unaffected.
-  return withForcedLocalAgents(checks.filter((c) => c.installed).map((c) => c.id))
+  return withResolvableLocalJcode(checks.filter((c) => c.installed).map((c) => c.id))
 }
 
 export type RefreshAgentsResult = {

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -15,7 +15,7 @@ import { runPreflightCommandInWsl } from './preflight-wsl-command'
 import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
 import { buildLocalPreflightEnv } from './preflight-local-env'
 import { getPreflightWslTarget, type PreflightRuntimeContext } from './preflight-runtime-target'
-import { hasJcodeBinEnvOverride, resolveJcodeBin } from '../jcode/jcode-binary'
+import { resolveJcodeBin } from '../jcode/jcode-binary'
 const execFileAsync = promisify(execFile)
 const PREFLIGHT_COMMAND_TIMEOUT_MS = 5000
 
@@ -152,8 +152,7 @@ function uniqueAgentIds(ids: Iterable<string>): string[] {
 
 // Why: a bare resolver result means preflight should not advertise jcode on a fresh host.
 function withResolvableLocalJcode(ids: Iterable<string>): string[] {
-  const shouldAddJcode = resolveJcodeBin() !== 'jcode' || hasJcodeBinEnvOverride()
-  return uniqueAgentIds(shouldAddJcode ? [...ids, 'jcode'] : ids)
+  return uniqueAgentIds(resolveJcodeBin() === 'jcode' ? ids : [...ids, 'jcode'])
 }
 
 async function detectCommandRuntime(

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1622,11 +1622,46 @@ export function registerPtyHandlers(
     assertFolderWorkspacePathUsable(status)
   }
 
+  // Why (M3 brain-local / hands-remote): a folder workspace marked
+  // isRemoteExecOnly runs the agent LOCALLY (local model/auth) while bash
+  // executes on the remote host via jcode's --remote-exec. For PTY spawns that
+  // means we must NOT route through the SSH provider even though the workspace
+  // carries a connectionId — the process (jcode TUI / shell) runs on this
+  // machine. Resolve here whether a given worktree key is such a workspace.
+  const getRemoteExecOnlyFolderWorkspace = (
+    worktreeId: string | undefined
+  ): { connectionId: string; host: string } | null => {
+    if (!store || typeof worktreeId !== 'string') {
+      return null
+    }
+    const workspaceScope = parseWorkspaceKey(worktreeId)
+    if (workspaceScope?.type !== 'folder') {
+      return null
+    }
+    const workspace = store.getFolderWorkspace(workspaceScope.folderWorkspaceId)
+    if (!workspace?.isRemoteExecOnly || !workspace.connectionId) {
+      return null
+    }
+    const target = store.getSshTarget(workspace.connectionId)
+    // Prefer the OpenSSH config alias (so ProxyJump/identity from ~/.ssh/config
+    // apply) and fall back to the raw host. jcode resolves the SSH host itself.
+    const host = target?.configHost?.trim() || target?.host?.trim()
+    if (!host) {
+      return null
+    }
+    return { connectionId: workspace.connectionId, host }
+  }
+
   // Why: the runtime controller must route through getProviderForPty() so that
   // CLI commands (terminal.send, terminal.stop) work for both local and remote PTYs.
   // Hardcoding localProvider.getPtyProcess() would silently fail for remote PTYs.
   runtime?.setPtyController({
     spawn: async (args) => {
+      // M3 brain-local: see the pty:spawn handler — a remote-exec-only workspace
+      // runs the agent locally, so route this spawn through the local provider.
+      if (getRemoteExecOnlyFolderWorkspace(args.worktreeId)) {
+        args.connectionId = null
+      }
       const startupPromise = getLocalPtyStartupPromise(args.connectionId)
       if (startupPromise) {
         await startupPromise
@@ -2140,6 +2175,15 @@ export function registerPtyHandlers(
         }
       }
     ) => {
+      // M3 brain-local: a remote-exec-only workspace runs jcode LOCALLY (only
+      // bash is remoted via --remote-exec), so clear connectionId here. Every
+      // downstream decision in this handler keys on args.connectionId; nulling
+      // it makes the entire spawn take the local provider + local host-env path
+      // (so jcode gets local auth) without touching each reference individually.
+      const remoteExecOnly = getRemoteExecOnlyFolderWorkspace(args.worktreeId)
+      if (remoteExecOnly) {
+        args.connectionId = null
+      }
       const startupPromise = getLocalPtyStartupPromise(args.connectionId)
       if (startupPromise) {
         await startupPromise

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -33,6 +33,8 @@ const {
   registerAgentHookHandlersMock,
   registerAgentTrustHandlersMock,
   registerClaudeAccountHandlersMock,
+  registerJcodeProviderHandlersMock,
+  registerJcodeMcpHandlersMock,
   registerClipboardHandlersMock,
   setTrustedClipboardRendererWebContentsIdMock,
   registerUpdaterHandlersMock,
@@ -84,6 +86,8 @@ const {
   registerAgentHookHandlersMock: vi.fn(),
   registerAgentTrustHandlersMock: vi.fn(),
   registerClaudeAccountHandlersMock: vi.fn(),
+  registerJcodeProviderHandlersMock: vi.fn(),
+  registerJcodeMcpHandlersMock: vi.fn(),
   registerClipboardHandlersMock: vi.fn(),
   setTrustedClipboardRendererWebContentsIdMock: vi.fn(),
   registerUpdaterHandlersMock: vi.fn(),
@@ -259,6 +263,14 @@ vi.mock('./claude-accounts', () => ({
   registerClaudeAccountHandlers: registerClaudeAccountHandlersMock
 }))
 
+vi.mock('./jcode-providers', () => ({
+  registerJcodeProviderHandlers: registerJcodeProviderHandlersMock
+}))
+
+vi.mock('./jcode-mcp', () => ({
+  registerJcodeMcpHandlers: registerJcodeMcpHandlersMock
+}))
+
 vi.mock('../window/attach-main-window-services', () => ({
   registerUpdaterHandlers: registerUpdaterHandlersMock
 }))
@@ -328,6 +340,8 @@ describe('registerCoreHandlers', () => {
     registerAgentHookHandlersMock.mockReset()
     registerAgentTrustHandlersMock.mockReset()
     registerClaudeAccountHandlersMock.mockReset()
+    registerJcodeProviderHandlersMock.mockReset()
+    registerJcodeMcpHandlersMock.mockReset()
     registerClipboardHandlersMock.mockReset()
     setTrustedClipboardRendererWebContentsIdMock.mockReset()
     registerUpdaterHandlersMock.mockReset()
@@ -390,6 +404,8 @@ describe('registerCoreHandlers', () => {
     expect(registerAgentHookHandlersMock).toHaveBeenCalledWith(runtime)
     expect(registerPetHandlersMock).toHaveBeenCalled()
     expect(registerClaudeAccountHandlersMock).toHaveBeenCalledWith(claudeAccounts)
+    expect(registerJcodeProviderHandlersMock).toHaveBeenCalled()
+    expect(registerJcodeMcpHandlersMock).toHaveBeenCalled()
     expect(registerRateLimitHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerGitHubHandlersMock).toHaveBeenCalledWith(store, stats)
     expect(registerLinearHandlersMock).toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -49,6 +49,7 @@ import { registerCodexAccountHandlers } from './codex-accounts'
 import { registerAgentHookHandlers } from './agent-hooks'
 import { registerAgentTrustHandlers } from './agent-trust'
 import { registerClaudeAccountHandlers } from './claude-accounts'
+import { registerJcodeProviderHandlers } from './jcode-providers'
 import { registerUpdaterHandlers } from '../window/attach-main-window-services'
 import {
   registerClipboardHandlers,
@@ -113,6 +114,7 @@ export function registerCoreHandlers(
   registerAgentHookHandlers(runtime)
   registerAgentTrustHandlers()
   registerClaudeAccountHandlers(claudeAccounts)
+  registerJcodeProviderHandlers()
   registerRateLimitHandlers(rateLimits)
   registerGitHubHandlers(store, stats)
   registerGitLabHandlers(store)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -50,6 +50,7 @@ import { registerAgentHookHandlers } from './agent-hooks'
 import { registerAgentTrustHandlers } from './agent-trust'
 import { registerClaudeAccountHandlers } from './claude-accounts'
 import { registerJcodeProviderHandlers } from './jcode-providers'
+import { registerJcodeMcpHandlers } from './jcode-mcp'
 import { registerUpdaterHandlers } from '../window/attach-main-window-services'
 import {
   registerClipboardHandlers,
@@ -115,6 +116,7 @@ export function registerCoreHandlers(
   registerAgentTrustHandlers()
   registerClaudeAccountHandlers(claudeAccounts)
   registerJcodeProviderHandlers()
+  registerJcodeMcpHandlers()
   registerRateLimitHandlers(rateLimits)
   registerGitHubHandlers(store, stats)
   registerGitLabHandlers(store)

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -776,7 +776,12 @@ const FolderWorkspaceUpdateArgs = z.object({
     createdWithAgent: z.string().refine(isTuiAgent).optional(),
     pendingFirstAgentMessageRename: z.boolean().optional(),
     firstAgentMessageRenameError: z.string().nullable().optional(),
-    lastActivityAt: z.number().finite().optional()
+    lastActivityAt: z.number().finite().optional(),
+    // brain-local / hands-remote (M3): the SSH target whose host is passed to
+    // jcode --remote-exec, plus the flag that opts this workspace into running
+    // the agent locally while bash runs on that host.
+    connectionId: z.string().nullable().optional(),
+    isRemoteExecOnly: z.boolean().optional()
   })
 })
 

--- a/src/main/jcode/jcode-attachments.test-fixtures.ts
+++ b/src/main/jcode/jcode-attachments.test-fixtures.ts
@@ -1,0 +1,112 @@
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { vi } from 'vitest'
+import type { JcodeChatSendPayload } from '../../shared/jcode-chat-types'
+
+type MockChannel = EventEmitter & { stderr: EventEmitter }
+type MockFn = ReturnType<typeof vi.fn>
+type MockChildProcess = EventEmitter & {
+  killed: boolean
+  kill: MockFn
+  stderr: EventEmitter & { setEncoding: MockFn }
+  stdout: EventEmitter & { setEncoding: MockFn }
+}
+export type MockMainWindow = {
+  isDestroyed: () => boolean
+  on: MockFn
+  webContents: {
+    isDestroyed: () => boolean
+    send: MockFn
+  }
+}
+
+export const VALID_REMOTE_ATTACHMENT_DIR =
+  '/tmp/orca-jcode-attachments-00000000-0000-4000-8000-000000000000'
+
+function autoClosingChannel(exitCode = 0): MockChannel {
+  const channel = new EventEmitter() as MockChannel
+  channel.stderr = new EventEmitter()
+  setTimeout(() => {
+    channel.emit('exit', exitCode)
+    channel.emit('close')
+  }, 0)
+  return channel
+}
+
+export function makeSshConnection(
+  options: {
+    status?: string
+    failCleanup?: boolean
+    commandExitCode?: (command: string) => number
+  } = {}
+) {
+  const status = options.status ?? 'connected'
+  return {
+    exec: vi.fn((command: string) => {
+      if (options.failCleanup && command.startsWith('rm -rf -- ')) {
+        return Promise.reject(new Error('cleanup failed'))
+      }
+      return Promise.resolve(autoClosingChannel(options.commandExitCode?.(command) ?? 0))
+    }),
+    getState: vi.fn(() => ({ status })),
+    writeFile: vi.fn(() => Promise.resolve())
+  }
+}
+
+export type MockSshConnection = ReturnType<typeof makeSshConnection>
+
+const tempDirs: string[] = []
+
+export function makeTempFile(name: string, contents: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'orca-jcode-attachments-'))
+  tempDirs.push(dir)
+  const filePath = path.join(dir, name)
+  writeFileSync(filePath, contents)
+  return filePath
+}
+
+export function cleanupTempFiles(): void {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+export function payload(extra: Partial<JcodeChatSendPayload> = {}): JcodeChatSendPayload {
+  return { sessionKey: 'session-1', prompt: 'hello', ...extra }
+}
+
+export function makeChildProcess(): MockChildProcess {
+  const child = new EventEmitter() as MockChildProcess
+  child.killed = false
+  child.kill = vi.fn(() => {
+    child.killed = true
+    return true
+  })
+  child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+  child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+  return child
+}
+
+export function makeMainWindow(): MockMainWindow {
+  const webContents = {
+    isDestroyed: vi.fn(() => false),
+    send: vi.fn()
+  }
+  return {
+    isDestroyed: vi.fn(() => false),
+    on: vi.fn(),
+    webContents
+  }
+}
+
+export async function waitUntil(condition: () => boolean, message: string): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (condition()) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error(message)
+}

--- a/src/main/jcode/jcode-attachments.test.ts
+++ b/src/main/jcode/jcode-attachments.test.ts
@@ -1,0 +1,289 @@
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  JCODE_CHAT_EVENT_CHANNEL,
+  JCODE_CHAT_SEND_CHANNEL,
+  type JcodeChatSendPayload
+} from '../../shared/jcode-chat-types'
+
+const {
+  applySkillInjectionMock,
+  deleteConversationMock,
+  getSshConnectionManagerMock,
+  ipcHandleMock,
+  ipcListeners,
+  ipcOnMock,
+  ipcRemoveAllListenersMock,
+  ipcRemoveHandlerMock,
+  listConversationsMock,
+  loadConversationMock,
+  registerJcodeSkillsHandlerMock,
+  resolveJcodeBinMock,
+  resolveRemoteExecMock,
+  saveConversationMock,
+  spawnMock
+} = vi.hoisted(() => ({
+  applySkillInjectionMock: vi.fn(),
+  deleteConversationMock: vi.fn(),
+  getSshConnectionManagerMock: vi.fn(),
+  ipcHandleMock: vi.fn(),
+  ipcListeners: new Map<string, (event: unknown, raw: unknown) => void>(),
+  ipcOnMock: vi.fn(),
+  ipcRemoveAllListenersMock: vi.fn(),
+  ipcRemoveHandlerMock: vi.fn(),
+  listConversationsMock: vi.fn(),
+  loadConversationMock: vi.fn(),
+  registerJcodeSkillsHandlerMock: vi.fn(),
+  resolveJcodeBinMock: vi.fn(),
+  resolveRemoteExecMock: vi.fn(),
+  saveConversationMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  dialog: { showOpenDialog: vi.fn() },
+  ipcMain: {
+    handle: ipcHandleMock,
+    on: ipcOnMock,
+    removeAllListeners: ipcRemoveAllListenersMock,
+    removeHandler: ipcRemoveHandlerMock
+  }
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('../ipc/ssh', () => ({
+  getSshConnectionManager: getSshConnectionManagerMock
+}))
+
+vi.mock('./jcode-binary', () => ({
+  resolveJcodeBin: resolveJcodeBinMock
+}))
+
+vi.mock('./jcode-conversation-store', () => ({
+  deleteConversation: deleteConversationMock,
+  listConversations: listConversationsMock,
+  loadConversation: loadConversationMock,
+  saveConversation: saveConversationMock
+}))
+
+vi.mock('./jcode-remote-exec', () => ({
+  resolveRemoteExec: resolveRemoteExecMock
+}))
+
+vi.mock('./jcode-skills', () => ({
+  applySkillInjection: applySkillInjectionMock,
+  registerJcodeSkillsHandler: registerJcodeSkillsHandlerMock
+}))
+
+import { cleanupRemoteAttachmentDir, resolveTurnPrompt } from './jcode-attachments'
+import { registerJcodeChatHandlers } from './jcode-chat-session'
+
+type MockChannel = EventEmitter & { stderr: EventEmitter }
+
+function autoClosingChannel(): MockChannel {
+  const channel = new EventEmitter() as MockChannel
+  channel.stderr = new EventEmitter()
+  setTimeout(() => channel.emit('close'), 0)
+  return channel
+}
+
+function makeSshConnection(options: { status?: string; failCleanup?: boolean } = {}) {
+  const status = options.status ?? 'connected'
+  return {
+    exec: vi.fn((command: string) => {
+      if (options.failCleanup && command.startsWith('rm -rf -- ')) {
+        return Promise.reject(new Error('cleanup failed'))
+      }
+      return Promise.resolve(autoClosingChannel())
+    }),
+    getState: vi.fn(() => ({ status })),
+    writeFile: vi.fn(() => Promise.resolve())
+  }
+}
+
+function setSshConnection(connection: ReturnType<typeof makeSshConnection>): void {
+  getSshConnectionManagerMock.mockReturnValue({
+    getConnection: vi.fn(() => connection)
+  })
+}
+
+const tempDirs: string[] = []
+
+function makeTempFile(name: string, contents: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'orca-jcode-attachments-'))
+  tempDirs.push(dir)
+  const filePath = path.join(dir, name)
+  writeFileSync(filePath, contents)
+  return filePath
+}
+
+function payload(extra: Partial<JcodeChatSendPayload> = {}): JcodeChatSendPayload {
+  return { sessionKey: 'session-1', prompt: 'hello', ...extra }
+}
+
+function makeChildProcess() {
+  const child = new EventEmitter() as EventEmitter & {
+    killed: boolean
+    kill: ReturnType<typeof vi.fn>
+    stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+    stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+  }
+  child.killed = false
+  child.kill = vi.fn(() => {
+    child.killed = true
+    return true
+  })
+  child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+  child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+  return child
+}
+
+function makeMainWindow() {
+  const webContents = {
+    isDestroyed: vi.fn(() => false),
+    send: vi.fn()
+  }
+  return {
+    isDestroyed: vi.fn(() => false),
+    on: vi.fn(),
+    webContents
+  }
+}
+
+async function waitUntil(condition: () => boolean, message: string): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (condition()) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error(message)
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  ipcListeners.clear()
+  ipcOnMock.mockImplementation(
+    (channel: string, handler: (event: unknown, raw: unknown) => void) => {
+      ipcListeners.set(channel, handler)
+    }
+  )
+  ipcRemoveAllListenersMock.mockImplementation((channel: string) => {
+    ipcListeners.delete(channel)
+  })
+  resolveJcodeBinMock.mockReturnValue('/usr/local/bin/jcode')
+  resolveRemoteExecMock.mockReturnValue({ host: null, connectionId: null, remotePath: null })
+  applySkillInjectionMock.mockImplementation((_skillName: string | undefined, promptText: string) =>
+    Promise.resolve(promptText)
+  )
+  getSshConnectionManagerMock.mockReturnValue({ getConnection: vi.fn(() => undefined) })
+})
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('resolveTurnPrompt cleanup metadata', () => {
+  it('returns no cleanup target for a local turn with no attachments', async () => {
+    await expect(
+      resolveTurnPrompt(payload(), { host: null, connectionId: null, remotePath: null })
+    ).resolves.toEqual({ prompt: 'hello', cleanup: null })
+  })
+
+  it('returns the remote cleanup target when an attachment is copied', async () => {
+    const filePath = makeTempFile('note.txt', 'attachment contents')
+    const connection = makeSshConnection()
+    setSshConnection(connection)
+
+    const result = await resolveTurnPrompt(
+      payload({ attachments: [{ kind: 'file', path: filePath, name: 'note.txt' }] }),
+      { host: 'remote-host', connectionId: 'conn-1', remotePath: '/remote/project' }
+    )
+
+    expect(result.cleanup?.connectionId).toBe('conn-1')
+    expect(result.cleanup?.remoteDir).toMatch(/^\/tmp\/orca-jcode-attachments\//)
+    expect(result.prompt).toContain(`${result.cleanup?.remoteDir}/note.txt`)
+    expect(connection.writeFile).toHaveBeenCalledWith(
+      `${result.cleanup?.remoteDir}/note.txt.b64`,
+      Buffer.from('attachment contents').toString('base64')
+    )
+  })
+})
+
+describe('cleanupRemoteAttachmentDir', () => {
+  it('no-ops when the SSH connection is disconnected', async () => {
+    const connection = makeSshConnection({ status: 'disconnected' })
+    setSshConnection(connection)
+
+    await cleanupRemoteAttachmentDir('conn-1', '/tmp/orca-jcode-attachments/stale')
+
+    expect(connection.exec).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsafe directories outside the attachment root', async () => {
+    const connection = makeSshConnection()
+    setSshConnection(connection)
+
+    await cleanupRemoteAttachmentDir('conn-1', '/tmp/orca-other/stale')
+    await cleanupRemoteAttachmentDir('conn-1', '/tmp/orca-jcode-attachments/../outside')
+
+    expect(connection.exec).not.toHaveBeenCalled()
+  })
+
+  it('shell-quotes the remote attachment directory', async () => {
+    const connection = makeSshConnection()
+    setSshConnection(connection)
+
+    await cleanupRemoteAttachmentDir('conn-1', "/tmp/orca-jcode-attachments/dir with 'quote")
+
+    expect(connection.exec).toHaveBeenCalledWith(
+      "rm -rf -- '/tmp/orca-jcode-attachments/dir with '\\''quote'"
+    )
+  })
+})
+
+describe('jcode chat session attachment cleanup', () => {
+  it('cleans remote uploads after child close without surfacing cleanup failure', async () => {
+    const filePath = makeTempFile('turn.txt', 'remote turn')
+    const connection = makeSshConnection({ failCleanup: true })
+    const child = makeChildProcess()
+    const mainWindow = makeMainWindow()
+    setSshConnection(connection)
+    spawnMock.mockReturnValue(child)
+    resolveRemoteExecMock.mockReturnValue({
+      host: 'remote-host',
+      connectionId: 'conn-1',
+      remotePath: '/remote/project'
+    })
+
+    registerJcodeChatHandlers(mainWindow as never)
+    const sendHandler = ipcListeners.get(JCODE_CHAT_SEND_CHANNEL)
+    if (!sendHandler) {
+      throw new Error('send handler was not registered')
+    }
+    sendHandler(
+      { sender: mainWindow.webContents },
+      payload({ attachments: [{ kind: 'file', path: filePath, name: 'turn.txt' }] })
+    )
+
+    await waitUntil(() => spawnMock.mock.calls.length === 1, 'jcode was not spawned')
+    child.emit('close', 0)
+    await waitUntil(
+      () => connection.exec.mock.calls.some(([command]) => command.startsWith('rm -rf -- ')),
+      'cleanup command was not attempted'
+    )
+
+    const eventTypes = mainWindow.webContents.send.mock.calls
+      .filter(([channel]) => channel === JCODE_CHAT_EVENT_CHANNEL)
+      .map(([, message]) => (message as { event: { type: string } }).event.type)
+    expect(eventTypes).toEqual(['exit'])
+  })
+})

--- a/src/main/jcode/jcode-attachments.test.ts
+++ b/src/main/jcode/jcode-attachments.test.ts
@@ -1,13 +1,16 @@
-import { EventEmitter } from 'node:events'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { JCODE_CHAT_EVENT_CHANNEL, JCODE_CHAT_SEND_CHANNEL } from '../../shared/jcode-chat-types'
 import {
-  JCODE_CHAT_EVENT_CHANNEL,
-  JCODE_CHAT_SEND_CHANNEL,
-  type JcodeChatSendPayload
-} from '../../shared/jcode-chat-types'
+  cleanupTempFiles,
+  makeChildProcess,
+  makeMainWindow,
+  makeSshConnection,
+  makeTempFile,
+  payload,
+  VALID_REMOTE_ATTACHMENT_DIR,
+  waitUntil,
+  type MockSshConnection
+} from './jcode-attachments.test-fixtures'
 
 const {
   applySkillInjectionMock,
@@ -84,97 +87,10 @@ vi.mock('./jcode-skills', () => ({
 import { cleanupRemoteAttachmentDir, resolveTurnPrompt } from './jcode-attachments'
 import { registerJcodeChatHandlers } from './jcode-chat-session'
 
-type MockChannel = EventEmitter & { stderr: EventEmitter }
-const VALID_REMOTE_ATTACHMENT_DIR =
-  '/tmp/orca-jcode-attachments-00000000-0000-4000-8000-000000000000'
-
-function autoClosingChannel(exitCode = 0): MockChannel {
-  const channel = new EventEmitter() as MockChannel
-  channel.stderr = new EventEmitter()
-  setTimeout(() => {
-    channel.emit('exit', exitCode)
-    channel.emit('close')
-  }, 0)
-  return channel
-}
-
-function makeSshConnection(
-  options: {
-    status?: string
-    failCleanup?: boolean
-    commandExitCode?: (command: string) => number
-  } = {}
-) {
-  const status = options.status ?? 'connected'
-  return {
-    exec: vi.fn((command: string) => {
-      if (options.failCleanup && command.startsWith('rm -rf -- ')) {
-        return Promise.reject(new Error('cleanup failed'))
-      }
-      return Promise.resolve(autoClosingChannel(options.commandExitCode?.(command) ?? 0))
-    }),
-    getState: vi.fn(() => ({ status })),
-    writeFile: vi.fn(() => Promise.resolve())
-  }
-}
-
-function setSshConnection(connection: ReturnType<typeof makeSshConnection>): void {
+function setSshConnection(connection: MockSshConnection): void {
   getSshConnectionManagerMock.mockReturnValue({
     getConnection: vi.fn(() => connection)
   })
-}
-
-const tempDirs: string[] = []
-
-function makeTempFile(name: string, contents: string): string {
-  const dir = mkdtempSync(path.join(tmpdir(), 'orca-jcode-attachments-'))
-  tempDirs.push(dir)
-  const filePath = path.join(dir, name)
-  writeFileSync(filePath, contents)
-  return filePath
-}
-
-function payload(extra: Partial<JcodeChatSendPayload> = {}): JcodeChatSendPayload {
-  return { sessionKey: 'session-1', prompt: 'hello', ...extra }
-}
-
-function makeChildProcess() {
-  const child = new EventEmitter() as EventEmitter & {
-    killed: boolean
-    kill: ReturnType<typeof vi.fn>
-    stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
-    stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
-  }
-  child.killed = false
-  child.kill = vi.fn(() => {
-    child.killed = true
-    return true
-  })
-  child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
-  child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
-  return child
-}
-
-function makeMainWindow() {
-  const webContents = {
-    isDestroyed: vi.fn(() => false),
-    send: vi.fn()
-  }
-  return {
-    isDestroyed: vi.fn(() => false),
-    on: vi.fn(),
-    webContents
-  }
-}
-
-async function waitUntil(condition: () => boolean, message: string): Promise<void> {
-  for (let attempt = 0; attempt < 40; attempt += 1) {
-    if (condition()) {
-      return
-    }
-    await new Promise((resolve) => setTimeout(resolve, 0))
-  }
-  throw new Error(message)
 }
 
 beforeEach(() => {
@@ -197,9 +113,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true })
-  }
+  cleanupTempFiles()
 })
 
 describe('resolveTurnPrompt cleanup metadata', () => {

--- a/src/main/jcode/jcode-attachments.test.ts
+++ b/src/main/jcode/jcode-attachments.test.ts
@@ -85,6 +85,8 @@ import { cleanupRemoteAttachmentDir, resolveTurnPrompt } from './jcode-attachmen
 import { registerJcodeChatHandlers } from './jcode-chat-session'
 
 type MockChannel = EventEmitter & { stderr: EventEmitter }
+const VALID_REMOTE_ATTACHMENT_DIR =
+  '/tmp/orca-jcode-attachments-00000000-0000-4000-8000-000000000000'
 
 function autoClosingChannel(): MockChannel {
   const channel = new EventEmitter() as MockChannel
@@ -209,12 +211,14 @@ describe('resolveTurnPrompt cleanup metadata', () => {
     )
 
     expect(result.cleanup?.connectionId).toBe('conn-1')
-    expect(result.cleanup?.remoteDir).toMatch(/^\/tmp\/orca-jcode-attachments\//)
+    expect(result.cleanup?.remoteDir).toMatch(/^\/tmp\/orca-jcode-attachments-[0-9a-f-]{36}$/)
     expect(result.prompt).toContain(`${result.cleanup?.remoteDir}/note.txt`)
     expect(connection.writeFile).toHaveBeenCalledWith(
       `${result.cleanup?.remoteDir}/note.txt.b64`,
       Buffer.from('attachment contents').toString('base64')
     )
+    expect(connection.exec).toHaveBeenCalledWith(expect.stringMatching(/^umask 077 && mkdir -- '/))
+    expect(connection.exec).not.toHaveBeenCalledWith(expect.stringContaining('mkdir -p'))
   })
 })
 
@@ -223,7 +227,7 @@ describe('cleanupRemoteAttachmentDir', () => {
     const connection = makeSshConnection({ status: 'disconnected' })
     setSshConnection(connection)
 
-    await cleanupRemoteAttachmentDir('conn-1', '/tmp/orca-jcode-attachments/stale')
+    await cleanupRemoteAttachmentDir('conn-1', VALID_REMOTE_ATTACHMENT_DIR)
 
     expect(connection.exec).not.toHaveBeenCalled()
   })
@@ -234,6 +238,8 @@ describe('cleanupRemoteAttachmentDir', () => {
 
     await cleanupRemoteAttachmentDir('conn-1', '/tmp/orca-other/stale')
     await cleanupRemoteAttachmentDir('conn-1', '/tmp/orca-jcode-attachments/../outside')
+    await cleanupRemoteAttachmentDir('conn-1', '/tmp/orca-jcode-attachments/stale')
+    await cleanupRemoteAttachmentDir('conn-1', `${VALID_REMOTE_ATTACHMENT_DIR}/child`)
 
     expect(connection.exec).not.toHaveBeenCalled()
   })
@@ -242,11 +248,9 @@ describe('cleanupRemoteAttachmentDir', () => {
     const connection = makeSshConnection()
     setSshConnection(connection)
 
-    await cleanupRemoteAttachmentDir('conn-1', "/tmp/orca-jcode-attachments/dir with 'quote")
+    await cleanupRemoteAttachmentDir('conn-1', VALID_REMOTE_ATTACHMENT_DIR)
 
-    expect(connection.exec).toHaveBeenCalledWith(
-      "rm -rf -- '/tmp/orca-jcode-attachments/dir with '\\''quote'"
-    )
+    expect(connection.exec).toHaveBeenCalledWith(`rm -rf -- '${VALID_REMOTE_ATTACHMENT_DIR}'`)
   })
 })
 

--- a/src/main/jcode/jcode-attachments.test.ts
+++ b/src/main/jcode/jcode-attachments.test.ts
@@ -88,21 +88,30 @@ type MockChannel = EventEmitter & { stderr: EventEmitter }
 const VALID_REMOTE_ATTACHMENT_DIR =
   '/tmp/orca-jcode-attachments-00000000-0000-4000-8000-000000000000'
 
-function autoClosingChannel(): MockChannel {
+function autoClosingChannel(exitCode = 0): MockChannel {
   const channel = new EventEmitter() as MockChannel
   channel.stderr = new EventEmitter()
-  setTimeout(() => channel.emit('close'), 0)
+  setTimeout(() => {
+    channel.emit('exit', exitCode)
+    channel.emit('close')
+  }, 0)
   return channel
 }
 
-function makeSshConnection(options: { status?: string; failCleanup?: boolean } = {}) {
+function makeSshConnection(
+  options: {
+    status?: string
+    failCleanup?: boolean
+    commandExitCode?: (command: string) => number
+  } = {}
+) {
   const status = options.status ?? 'connected'
   return {
     exec: vi.fn((command: string) => {
       if (options.failCleanup && command.startsWith('rm -rf -- ')) {
         return Promise.reject(new Error('cleanup failed'))
       }
-      return Promise.resolve(autoClosingChannel())
+      return Promise.resolve(autoClosingChannel(options.commandExitCode?.(command) ?? 0))
     }),
     getState: vi.fn(() => ({ status })),
     writeFile: vi.fn(() => Promise.resolve())
@@ -220,6 +229,42 @@ describe('resolveTurnPrompt cleanup metadata', () => {
     expect(connection.exec).toHaveBeenCalledWith(expect.stringMatching(/^umask 077 && mkdir -- '/))
     expect(connection.exec).not.toHaveBeenCalledWith(expect.stringContaining('mkdir -p'))
   })
+
+  it('treats remote temp directory creation failure as an attachment copy failure', async () => {
+    const filePath = makeTempFile('note.txt', 'attachment contents')
+    const connection = makeSshConnection({
+      commandExitCode: (command) => (command.startsWith('umask 077 && mkdir -- ') ? 1 : 0)
+    })
+    setSshConnection(connection)
+
+    const result = await resolveTurnPrompt(
+      payload({ attachments: [{ kind: 'file', path: filePath, name: 'note.txt' }] }),
+      { host: 'remote-host', connectionId: 'conn-1', remotePath: '/remote/project' }
+    )
+
+    expect(result.cleanup).toBeNull()
+    expect(connection.writeFile).not.toHaveBeenCalled()
+    expect(result.prompt).toContain('could NOT be copied to the remote host')
+    expect(result.prompt).toContain(filePath)
+  })
+
+  it('does not report a copied attachment when remote base64 decode fails', async () => {
+    const filePath = makeTempFile('note.txt', 'attachment contents')
+    const connection = makeSshConnection({
+      commandExitCode: (command) => (command.includes('base64 -d') ? 1 : 0)
+    })
+    setSshConnection(connection)
+
+    const result = await resolveTurnPrompt(
+      payload({ attachments: [{ kind: 'file', path: filePath, name: 'note.txt' }] }),
+      { host: 'remote-host', connectionId: 'conn-1', remotePath: '/remote/project' }
+    )
+
+    expect(result.cleanup?.remoteDir).toMatch(/^\/tmp\/orca-jcode-attachments-[0-9a-f-]{36}$/)
+    expect(result.prompt).toContain('could NOT be copied to the remote host')
+    expect(result.prompt).toContain(filePath)
+    expect(result.prompt).not.toContain(`${result.cleanup?.remoteDir}/note.txt`)
+  })
 })
 
 describe('cleanupRemoteAttachmentDir', () => {
@@ -255,6 +300,38 @@ describe('cleanupRemoteAttachmentDir', () => {
 })
 
 describe('jcode chat session attachment cleanup', () => {
+  it('keeps remote-exec image attachments local via --image', async () => {
+    const filePath = makeTempFile('photo.png', 'image bytes')
+    const connection = makeSshConnection()
+    const child = makeChildProcess()
+    const mainWindow = makeMainWindow()
+    setSshConnection(connection)
+    spawnMock.mockReturnValue(child)
+    resolveRemoteExecMock.mockReturnValue({
+      host: 'remote-host',
+      connectionId: 'conn-1',
+      remotePath: '/remote/project'
+    })
+
+    registerJcodeChatHandlers(mainWindow as never)
+    const sendHandler = ipcListeners.get(JCODE_CHAT_SEND_CHANNEL)
+    if (!sendHandler) {
+      throw new Error('send handler was not registered')
+    }
+    sendHandler(
+      { sender: mainWindow.webContents },
+      payload({ attachments: [{ kind: 'file', path: filePath, name: 'photo.png' }] })
+    )
+
+    await waitUntil(() => spawnMock.mock.calls.length === 1, 'jcode was not spawned')
+
+    const args = spawnMock.mock.calls[0]?.[1] as string[]
+    expect(args).toContain('--image')
+    expect(args).toContain(filePath)
+    expect(connection.writeFile).not.toHaveBeenCalled()
+    expect(connection.exec).not.toHaveBeenCalled()
+  })
+
   it('cleans remote uploads after child close without surfacing cleanup failure', async () => {
     const filePath = makeTempFile('turn.txt', 'remote turn')
     const connection = makeSshConnection({ failCleanup: true })
@@ -289,5 +366,40 @@ describe('jcode chat session attachment cleanup', () => {
       .filter(([channel]) => channel === JCODE_CHAT_EVENT_CHANNEL)
       .map(([, message]) => (message as { event: { type: string } }).event.type)
     expect(eventTypes).toEqual(['exit'])
+  })
+
+  it('cleans remote uploads when child spawn throws', async () => {
+    const filePath = makeTempFile('turn.txt', 'remote turn')
+    const connection = makeSshConnection()
+    const mainWindow = makeMainWindow()
+    setSshConnection(connection)
+    spawnMock.mockImplementation(() => {
+      throw new Error('spawn failed')
+    })
+    resolveRemoteExecMock.mockReturnValue({
+      host: 'remote-host',
+      connectionId: 'conn-1',
+      remotePath: '/remote/project'
+    })
+
+    registerJcodeChatHandlers(mainWindow as never)
+    const sendHandler = ipcListeners.get(JCODE_CHAT_SEND_CHANNEL)
+    if (!sendHandler) {
+      throw new Error('send handler was not registered')
+    }
+    sendHandler(
+      { sender: mainWindow.webContents },
+      payload({ attachments: [{ kind: 'file', path: filePath, name: 'turn.txt' }] })
+    )
+
+    await waitUntil(
+      () => connection.exec.mock.calls.some(([command]) => command.startsWith('rm -rf -- ')),
+      'cleanup command was not attempted'
+    )
+
+    const eventTypes = mainWindow.webContents.send.mock.calls
+      .filter(([channel]) => channel === JCODE_CHAT_EVENT_CHANNEL)
+      .map(([, message]) => (message as { event: { type: string } }).event.type)
+    expect(eventTypes).toEqual(['error'])
   })
 })

--- a/src/main/jcode/jcode-attachments.ts
+++ b/src/main/jcode/jcode-attachments.ts
@@ -106,6 +106,65 @@ function runRemoteCommand(
   })
 }
 
+/** A live SSH connection object (as returned by the connection manager). */
+export type SshConnection = NonNullable<
+  ReturnType<NonNullable<ReturnType<typeof getSshConnectionManager>>['getConnection']>
+>
+
+/** Resolve a live, connected SSH connection by id, or null. Shared by the skill
+ *  discovery module so it can read remote `.claude/skills` over the same SSH
+ *  transport that attachment copying uses. */
+export function getLiveSshConnection(connectionId: string): SshConnection | null {
+  const conn = getSshConnectionManager()?.getConnection(connectionId)
+  if (!conn || conn.getState().status !== 'connected') {
+    return null
+  }
+  return conn
+}
+
+/** Run a remote command over SSH and CAPTURE its stdout (unlike runRemoteCommand,
+ *  which discards output). Resolves with the accumulated stdout on a zero exit;
+ *  resolves with null on any non-zero/failed exit so callers can treat a missing
+ *  file or directory as "no skills here" rather than throwing. Best-effort, with
+ *  a bound so a hung channel can't stall skill discovery forever. */
+export function runRemoteCapture(conn: SshConnection, command: string): Promise<string | null> {
+  const TIMEOUT_MS = 10_000
+  return new Promise((resolve) => {
+    conn
+      .exec(command)
+      .then((channel) => {
+        let stdout = ''
+        let exitCode: number | null = null
+        let settled = false
+        const finish = (value: string | null): void => {
+          if (settled) {
+            return
+          }
+          settled = true
+          if (timer) {
+            clearTimeout(timer)
+          }
+          resolve(value)
+        }
+        const timer = setTimeout(() => finish(null), TIMEOUT_MS)
+        if (typeof timer.unref === 'function') {
+          timer.unref()
+        }
+        channel.on('data', (data: Buffer) => {
+          stdout += data.toString()
+        })
+        channel.stderr?.on('data', () => {})
+        channel.on('exit', (code: number | null) => {
+          exitCode = code
+        })
+        channel.on('close', () => finish(exitCode === 0 ? stdout : null))
+        channel.on('error', () => finish(null))
+        channel.stderr?.on('error', () => {})
+      })
+      .catch(() => resolve(null))
+  })
+}
+
 /** Resolve the final prompt string for a turn by weaving in any attachments.
  *  For LOCAL sessions, file attachments are referenced by their local path. For
  *  remote-exec sessions, each local file is copied to a remote temp dir over the

--- a/src/main/jcode/jcode-attachments.ts
+++ b/src/main/jcode/jcode-attachments.ts
@@ -47,6 +47,36 @@ export function weaveAttachmentsIntoPrompt(
   return `${base ? `${base}\n\n` : ''}${sections.join('\n\n')}`
 }
 
+// Image formats vision models accept directly. These attachments are sent to
+// jcode via `run --image <localPath>` (read locally, even under --remote-exec)
+// instead of being woven into the prompt as a path or copied to the remote host.
+const VISION_IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp'])
+
+/** True when a path looks like a vision-readable image. */
+export function isVisionImagePath(path: string): boolean {
+  const dot = path.lastIndexOf('.')
+  if (dot < 0) {
+    return false
+  }
+  return VISION_IMAGE_EXTENSIONS.has(path.slice(dot + 1).toLowerCase())
+}
+
+/** Local paths of image file attachments to pass via `jcode run --image`. */
+export function extractImagePaths(attachments: JcodeChatAttachment[]): string[] {
+  return attachments
+    .filter(
+      (a): a is Extract<JcodeChatAttachment, { kind: 'file' }> =>
+        a.kind === 'file' && isVisionImagePath(a.path)
+    )
+    .map((a) => a.path)
+}
+
+/** Attachments that still get woven into the prompt — everything EXCEPT vision
+ *  images (those go via --image so the model actually sees them). */
+export function nonImageAttachments(attachments: JcodeChatAttachment[]): JcodeChatAttachment[] {
+  return attachments.filter((a) => !(a.kind === 'file' && isVisionImagePath(a.path)))
+}
+
 /** Split a mixed attachment list into file vs text buckets, normalizing names. */
 export function partitionAttachments(attachments: JcodeChatAttachment[]): {
   files: { path: string; name: string }[]

--- a/src/main/jcode/jcode-attachments.ts
+++ b/src/main/jcode/jcode-attachments.ts
@@ -1,0 +1,193 @@
+// Why: jcode's headless `run` has no --file/--attach flag — it only reads files
+// it is TOLD about by path (via its own READ/BASH tools) and consumes inline
+// content from the prompt text. So composer attachments are delivered by WEAVING
+// them into the prompt string: file paths as a clearly-labelled list jcode can
+// read, and text blobs fenced inline so they don't bloat the input box.
+//
+// For remote-exec (brain-local) sessions the agent runs locally but its bash/read
+// tools execute on the REMOTE host, so a local path is meaningless there. The
+// caller copies each local file to a remote temp dir first and passes the rewritten
+// REMOTE path here; this module stays transport-agnostic and only formats text.
+import { readFile } from 'node:fs/promises'
+import { basename } from 'node:path'
+import type { JcodeChatAttachment, JcodeChatSendPayload } from '../../shared/jcode-chat-types'
+import { getSshConnectionManager } from '../ipc/ssh'
+
+/** A file attachment after any path rewriting (e.g. local -> remote temp). */
+export type ResolvedFileAttachment = {
+  /** The path jcode should read (local for local sessions; remote for remote-exec). */
+  path: string
+  /** Display name for the prompt list. */
+  name: string
+}
+
+/** Weave resolved file paths + inline text blobs into the final prompt jcode
+ *  receives. The user's typed text stays the lead; attachments are appended in
+ *  clearly-delimited blocks so the model treats them as context. Returns the
+ *  original prompt unchanged when there is nothing to attach. */
+export function weaveAttachmentsIntoPrompt(
+  userPrompt: string,
+  files: ResolvedFileAttachment[],
+  texts: { name: string; content: string }[]
+): string {
+  const sections: string[] = []
+  if (files.length > 0) {
+    const lines = files.map((f) => `- ${f.path}`).join('\n')
+    sections.push(`[Attached files]\n${lines}`)
+  }
+  for (const text of texts) {
+    // Fence with a label so multiple text attachments stay distinguishable and
+    // the model doesn't confuse them with the instruction.
+    sections.push(`[Attached text: ${text.name}]\n\`\`\`\n${text.content}\n\`\`\``)
+  }
+  if (sections.length === 0) {
+    return userPrompt
+  }
+  const base = userPrompt.trim()
+  return `${base ? `${base}\n\n` : ''}${sections.join('\n\n')}`
+}
+
+/** Split a mixed attachment list into file vs text buckets, normalizing names. */
+export function partitionAttachments(attachments: JcodeChatAttachment[]): {
+  files: { path: string; name: string }[]
+  texts: { name: string; content: string }[]
+} {
+  const files: { path: string; name: string }[] = []
+  const texts: { name: string; content: string }[] = []
+  for (const attachment of attachments) {
+    if (attachment.kind === 'file') {
+      files.push({ path: attachment.path, name: attachment.name || basename(attachment.path) })
+    } else {
+      texts.push({ name: attachment.name || 'text', content: attachment.content })
+    }
+  }
+  return { files, texts }
+}
+
+/** Build a unique-ish remote temp directory name for one chat turn's uploads.
+ *  Kept short + filesystem-safe; uniqueness comes from the timestamp + random. */
+export function buildRemoteAttachmentDir(): string {
+  const stamp = Date.now().toString(36)
+  const rand = Math.random().toString(36).slice(2, 8)
+  return `/tmp/orca-jcode-attachments/${stamp}-${rand}`
+}
+
+/** brain-local (M3) resolution for a chat turn: the remote-exec host (for
+ *  `--remote-exec`) and the SSH connectionId backing it (for copying local
+ *  attachments to the remote host). `connectionId` is only set when the host was
+ *  derived from a workspace SSH target; an ad-hoc `remoteExecHost` override has no
+ *  connection to copy through. */
+export type RemoteExecResolution = { host: string | null; connectionId: string | null }
+
+/** Minimal single-quote shell escaping for a POSIX path argument. */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+/** Run a remote command over an SSH connection and resolve when it closes.
+ *  Best-effort: rejects only on channel-open failure. */
+function runRemoteCommand(
+  conn: NonNullable<
+    ReturnType<NonNullable<ReturnType<typeof getSshConnectionManager>>['getConnection']>
+  >,
+  command: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    conn
+      .exec(command)
+      .then((channel) => {
+        channel.on('close', () => resolve())
+        channel.on('error', (err: Error) => reject(err))
+        // Drain so the channel can close.
+        channel.on('data', () => {})
+        channel.stderr?.on('data', () => {})
+      })
+      .catch(reject)
+  })
+}
+
+/** Resolve the final prompt string for a turn by weaving in any attachments.
+ *  For LOCAL sessions, file attachments are referenced by their local path. For
+ *  remote-exec sessions, each local file is copied to a remote temp dir over the
+ *  workspace's live SSH connection and the REMOTE path is referenced instead, so
+ *  jcode's remote bash/read tools can see it. If the remote copy can't run (no
+ *  live connection / no SFTP transport / read failure) the local file is dropped
+ *  from the list and a note is appended so the turn still proceeds honestly. */
+export async function resolveTurnPrompt(
+  payload: JcodeChatSendPayload,
+  remote: RemoteExecResolution
+): Promise<string> {
+  const attachments = payload.attachments ?? []
+  if (attachments.length === 0) {
+    return payload.prompt
+  }
+  const { files, texts } = partitionAttachments(attachments)
+
+  // Local session (or remote with no copyable connection): refer to local paths.
+  if (!remote.host || !remote.connectionId) {
+    if (remote.host && files.length > 0) {
+      // Remote-exec via an ad-hoc host override with no SSH connection to copy
+      // through: be honest that local files won't be readable remotely.
+      const note = {
+        name: 'note',
+        content:
+          'The following local files could NOT be sent to the remote host (no SSH connection available); ' +
+          `they are not readable by the remote agent:\n${files.map((f) => `- ${f.path}`).join('\n')}`
+      }
+      return weaveAttachmentsIntoPrompt(payload.prompt, [], [...texts, note])
+    }
+    return weaveAttachmentsIntoPrompt(
+      payload.prompt,
+      files.map((f) => ({ path: f.path, name: f.name })),
+      texts
+    )
+  }
+
+  // Remote-exec session with a live workspace SSH connection: copy each local
+  // file to a remote temp dir and reference the remote path.
+  const { resolved, failed } = await copyFilesToRemote(files, remote.connectionId)
+  const extraTexts = [...texts]
+  if (failed.length > 0) {
+    extraTexts.push({
+      name: 'note',
+      content:
+        'The following local files could NOT be copied to the remote host and are not readable ' +
+        `by the remote agent:\n${failed.map((f) => `- ${f.path}`).join('\n')}`
+    })
+  }
+  return weaveAttachmentsIntoPrompt(payload.prompt, resolved, extraTexts)
+}
+
+/** Copy local files to a fresh remote temp dir over an SSH connection. Returns
+ *  resolved remote paths and any files that could not be copied (left local). */
+async function copyFilesToRemote(
+  files: { path: string; name: string }[],
+  connectionId: string
+): Promise<{ resolved: ResolvedFileAttachment[]; failed: { path: string; name: string }[] }> {
+  const resolved: ResolvedFileAttachment[] = []
+  const failed: { path: string; name: string }[] = []
+  if (files.length === 0) {
+    return { resolved, failed }
+  }
+  const conn = getSshConnectionManager()?.getConnection(connectionId)
+  if (!conn || conn.getState().status !== 'connected') {
+    return { resolved, failed: [...files] }
+  }
+  const remoteDir = buildRemoteAttachmentDir()
+  try {
+    await runRemoteCommand(conn, `mkdir -p ${shellQuote(remoteDir)}`)
+  } catch {
+    return { resolved, failed: [...files] }
+  }
+  for (const file of files) {
+    try {
+      const contents = await readFile(file.path)
+      const remotePath = `${remoteDir}/${basename(file.path)}`
+      await conn.writeFile(remotePath, contents.toString('utf8'))
+      resolved.push({ path: remotePath, name: file.name })
+    } catch {
+      failed.push(file)
+    }
+  }
+  return { resolved, failed }
+}

--- a/src/main/jcode/jcode-attachments.ts
+++ b/src/main/jcode/jcode-attachments.ts
@@ -8,6 +8,7 @@
 // tools execute on the REMOTE host, so a local path is meaningless there. The
 // caller copies each local file to a remote temp dir first and passes the rewritten
 // REMOTE path here; this module stays transport-agnostic and only formats text.
+import { randomUUID } from 'node:crypto'
 import { readFile, stat } from 'node:fs/promises'
 import { basename, posix as pathPosix } from 'node:path'
 import type { JcodeChatAttachment, JcodeChatSendPayload } from '../../shared/jcode-chat-types'
@@ -95,11 +96,9 @@ export function partitionAttachments(attachments: JcodeChatAttachment[]): {
 }
 
 /** Build a unique-ish remote temp directory name for one chat turn's uploads.
- *  Kept short + filesystem-safe; uniqueness comes from the timestamp + random. */
+ *  Created directly under /tmp so no shared app temp parent can be symlinked. */
 export function buildRemoteAttachmentDir(): string {
-  const stamp = Date.now().toString(36)
-  const rand = Math.random().toString(36).slice(2, 8)
-  return `/tmp/orca-jcode-attachments/${stamp}-${rand}`
+  return `/tmp/orca-jcode-attachments-${randomUUID()}`
 }
 
 /** brain-local (M3) resolution for a chat turn: the remote-exec host (for
@@ -130,14 +129,19 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
-const REMOTE_ATTACHMENT_ROOT = '/tmp/orca-jcode-attachments/'
+const REMOTE_ATTACHMENT_PREFIX = '/tmp/orca-jcode-attachments-'
+const REMOTE_ATTACHMENT_SUFFIX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 function safeRemoteAttachmentDir(remoteDir: string): string | null {
   if (remoteDir.includes('\0')) {
     return null
   }
   const normalized = pathPosix.normalize(remoteDir)
-  return normalized.startsWith(REMOTE_ATTACHMENT_ROOT) ? normalized : null
+  if (normalized !== remoteDir || !normalized.startsWith(REMOTE_ATTACHMENT_PREFIX)) {
+    return null
+  }
+  const suffix = normalized.slice(REMOTE_ATTACHMENT_PREFIX.length)
+  return REMOTE_ATTACHMENT_SUFFIX.test(suffix) ? normalized : null
 }
 
 /** Per-file size cap for remote attachment transfer. Large files would block the
@@ -352,7 +356,7 @@ async function copyFilesToRemote(
   }
   const remoteDir = buildRemoteAttachmentDir()
   try {
-    await runRemoteCommand(conn, `mkdir -p ${shellQuote(remoteDir)}`)
+    await runRemoteCommand(conn, `umask 077 && mkdir -- ${shellQuote(remoteDir)}`)
   } catch {
     return { resolved, failed: [...files], oversize, remoteDir: null }
   }

--- a/src/main/jcode/jcode-attachments.ts
+++ b/src/main/jcode/jcode-attachments.ts
@@ -8,7 +8,7 @@
 // tools execute on the REMOTE host, so a local path is meaningless there. The
 // caller copies each local file to a remote temp dir first and passes the rewritten
 // REMOTE path here; this module stays transport-agnostic and only formats text.
-import { readFile } from 'node:fs/promises'
+import { readFile, stat } from 'node:fs/promises'
 import { basename } from 'node:path'
 import type { JcodeChatAttachment, JcodeChatSendPayload } from '../../shared/jcode-chat-types'
 import { getSshConnectionManager } from '../ipc/ssh'
@@ -89,6 +89,11 @@ export type RemoteExecResolution = {
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
+
+/** Per-file size cap for remote attachment transfer. Large files would block the
+ *  main process (read + base64) and bloat the SSH channel; refuse them with a
+ *  clear note instead. 25 MiB matches the cap surfaced to the user. */
+export const MAX_REMOTE_ATTACHMENT_BYTES = 25 * 1024 * 1024
 
 /** Run a remote command over an SSH connection and resolve when it closes.
  *  Best-effort: rejects only on channel-open failure. */
@@ -210,8 +215,17 @@ export async function resolveTurnPrompt(
 
   // Remote-exec session with a live workspace SSH connection: copy each local
   // file to a remote temp dir and reference the remote path.
-  const { resolved, failed } = await copyFilesToRemote(files, remote.connectionId)
+  const { resolved, failed, oversize } = await copyFilesToRemote(files, remote.connectionId)
   const extraTexts = [...texts]
+  if (oversize.length > 0) {
+    const capMb = Math.round(MAX_REMOTE_ATTACHMENT_BYTES / (1024 * 1024))
+    extraTexts.push({
+      name: 'note',
+      content:
+        `The following files exceed the ${capMb}MB attachment limit and were NOT sent to the ` +
+        `remote host:\n${oversize.map((f) => `- ${f.path}`).join('\n')}`
+    })
+  }
   if (failed.length > 0) {
     extraTexts.push({
       name: 'note',
@@ -224,35 +238,61 @@ export async function resolveTurnPrompt(
 }
 
 /** Copy local files to a fresh remote temp dir over an SSH connection. Returns
- *  resolved remote paths and any files that could not be copied (left local). */
+ *  resolved remote paths, files that could not be copied (left local), and files
+ *  refused for exceeding the size cap.
+ *
+ *  Binary-safe: we base64-encode the raw bytes locally and decode them on the
+ *  remote via `base64 -d`. The previous implementation did
+ *  `contents.toString('utf8')` before writeFile, which CORRUPTS any non-UTF8
+ *  file (images, PDFs, zips) — invalid byte sequences get replaced with U+FFFD.
+ *  Sending base64 over the (text-only) writeFile transport round-trips the exact
+ *  bytes regardless of transport (SFTP or system-ssh `cat`). */
 async function copyFilesToRemote(
   files: { path: string; name: string }[],
   connectionId: string
-): Promise<{ resolved: ResolvedFileAttachment[]; failed: { path: string; name: string }[] }> {
+): Promise<{
+  resolved: ResolvedFileAttachment[]
+  failed: { path: string; name: string }[]
+  oversize: { path: string; name: string }[]
+}> {
   const resolved: ResolvedFileAttachment[] = []
   const failed: { path: string; name: string }[] = []
+  const oversize: { path: string; name: string }[] = []
   if (files.length === 0) {
-    return { resolved, failed }
+    return { resolved, failed, oversize }
   }
   const conn = getSshConnectionManager()?.getConnection(connectionId)
   if (!conn || conn.getState().status !== 'connected') {
-    return { resolved, failed: [...files] }
+    return { resolved, failed: [...files], oversize }
   }
   const remoteDir = buildRemoteAttachmentDir()
   try {
     await runRemoteCommand(conn, `mkdir -p ${shellQuote(remoteDir)}`)
   } catch {
-    return { resolved, failed: [...files] }
+    return { resolved, failed: [...files], oversize }
   }
   for (const file of files) {
     try {
+      // Cheap size gate first so an oversized file never gets read into memory.
+      const info = await stat(file.path)
+      if (info.size > MAX_REMOTE_ATTACHMENT_BYTES) {
+        oversize.push(file)
+        continue
+      }
       const contents = await readFile(file.path)
       const remotePath = `${remoteDir}/${basename(file.path)}`
-      await conn.writeFile(remotePath, contents.toString('utf8'))
+      // Write base64 to a sidecar file, then decode to the real path on the
+      // remote so the bytes are preserved exactly (no utf8 mangling).
+      const b64Path = `${remotePath}.b64`
+      await conn.writeFile(b64Path, contents.toString('base64'))
+      await runRemoteCommand(
+        conn,
+        `base64 -d ${shellQuote(b64Path)} > ${shellQuote(remotePath)} && rm -f ${shellQuote(b64Path)}`
+      )
       resolved.push({ path: remotePath, name: file.name })
     } catch {
       failed.push(file)
     }
   }
-  return { resolved, failed }
+  return { resolved, failed, oversize }
 }

--- a/src/main/jcode/jcode-attachments.ts
+++ b/src/main/jcode/jcode-attachments.ts
@@ -9,7 +9,7 @@
 // caller copies each local file to a remote temp dir first and passes the rewritten
 // REMOTE path here; this module stays transport-agnostic and only formats text.
 import { readFile, stat } from 'node:fs/promises'
-import { basename } from 'node:path'
+import { basename, posix as pathPosix } from 'node:path'
 import type { JcodeChatAttachment, JcodeChatSendPayload } from '../../shared/jcode-chat-types'
 import { getSshConnectionManager } from '../ipc/ssh'
 
@@ -115,9 +115,29 @@ export type RemoteExecResolution = {
   remotePath: string | null
 }
 
+export type RemoteAttachmentCleanupTarget = {
+  connectionId: string
+  remoteDir: string
+}
+
+export type ResolvedTurnPrompt = {
+  prompt: string
+  cleanup: RemoteAttachmentCleanupTarget | null
+}
+
 /** Minimal single-quote shell escaping for a POSIX path argument. */
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+const REMOTE_ATTACHMENT_ROOT = '/tmp/orca-jcode-attachments/'
+
+function safeRemoteAttachmentDir(remoteDir: string): string | null {
+  if (remoteDir.includes('\0')) {
+    return null
+  }
+  const normalized = pathPosix.normalize(remoteDir)
+  return normalized.startsWith(REMOTE_ATTACHMENT_ROOT) ? normalized : null
 }
 
 /** Per-file size cap for remote attachment transfer. Large files would block the
@@ -161,6 +181,28 @@ export function getLiveSshConnection(connectionId: string): SshConnection | null
     return null
   }
   return conn
+}
+
+export async function cleanupRemoteAttachmentDir(
+  connectionId: string | null | undefined,
+  remoteDir: string | null | undefined
+): Promise<void> {
+  if (!connectionId || !remoteDir) {
+    return
+  }
+  const safeDir = safeRemoteAttachmentDir(remoteDir)
+  if (!safeDir) {
+    return
+  }
+  const conn = getLiveSshConnection(connectionId)
+  if (!conn) {
+    return
+  }
+  try {
+    await runRemoteCommand(conn, `rm -rf -- ${shellQuote(safeDir)}`)
+  } catch {
+    // Best-effort cleanup must never change the chat result.
+  }
 }
 
 /** Run a remote command over SSH and CAPTURE its stdout (unlike runRemoteCommand,
@@ -216,10 +258,10 @@ export function runRemoteCapture(conn: SshConnection, command: string): Promise<
 export async function resolveTurnPrompt(
   payload: JcodeChatSendPayload,
   remote: RemoteExecResolution
-): Promise<string> {
+): Promise<ResolvedTurnPrompt> {
   const attachments = payload.attachments ?? []
   if (attachments.length === 0) {
-    return payload.prompt
+    return { prompt: payload.prompt, cleanup: null }
   }
   const { files, texts } = partitionAttachments(attachments)
 
@@ -234,18 +276,27 @@ export async function resolveTurnPrompt(
           'The following local files could NOT be sent to the remote host (no SSH connection available); ' +
           `they are not readable by the remote agent:\n${files.map((f) => `- ${f.path}`).join('\n')}`
       }
-      return weaveAttachmentsIntoPrompt(payload.prompt, [], [...texts, note])
+      return {
+        prompt: weaveAttachmentsIntoPrompt(payload.prompt, [], [...texts, note]),
+        cleanup: null
+      }
     }
-    return weaveAttachmentsIntoPrompt(
-      payload.prompt,
-      files.map((f) => ({ path: f.path, name: f.name })),
-      texts
-    )
+    return {
+      prompt: weaveAttachmentsIntoPrompt(
+        payload.prompt,
+        files.map((f) => ({ path: f.path, name: f.name })),
+        texts
+      ),
+      cleanup: null
+    }
   }
 
   // Remote-exec session with a live workspace SSH connection: copy each local
   // file to a remote temp dir and reference the remote path.
-  const { resolved, failed, oversize } = await copyFilesToRemote(files, remote.connectionId)
+  const { resolved, failed, oversize, remoteDir } = await copyFilesToRemote(
+    files,
+    remote.connectionId
+  )
   const extraTexts = [...texts]
   if (oversize.length > 0) {
     const capMb = Math.round(MAX_REMOTE_ATTACHMENT_BYTES / (1024 * 1024))
@@ -264,7 +315,10 @@ export async function resolveTurnPrompt(
         `by the remote agent:\n${failed.map((f) => `- ${f.path}`).join('\n')}`
     })
   }
-  return weaveAttachmentsIntoPrompt(payload.prompt, resolved, extraTexts)
+  return {
+    prompt: weaveAttachmentsIntoPrompt(payload.prompt, resolved, extraTexts),
+    cleanup: remoteDir ? { connectionId: remote.connectionId, remoteDir } : null
+  }
 }
 
 /** Copy local files to a fresh remote temp dir over an SSH connection. Returns
@@ -284,22 +338,23 @@ async function copyFilesToRemote(
   resolved: ResolvedFileAttachment[]
   failed: { path: string; name: string }[]
   oversize: { path: string; name: string }[]
+  remoteDir: string | null
 }> {
   const resolved: ResolvedFileAttachment[] = []
   const failed: { path: string; name: string }[] = []
   const oversize: { path: string; name: string }[] = []
   if (files.length === 0) {
-    return { resolved, failed, oversize }
+    return { resolved, failed, oversize, remoteDir: null }
   }
   const conn = getSshConnectionManager()?.getConnection(connectionId)
   if (!conn || conn.getState().status !== 'connected') {
-    return { resolved, failed: [...files], oversize }
+    return { resolved, failed: [...files], oversize, remoteDir: null }
   }
   const remoteDir = buildRemoteAttachmentDir()
   try {
     await runRemoteCommand(conn, `mkdir -p ${shellQuote(remoteDir)}`)
   } catch {
-    return { resolved, failed: [...files], oversize }
+    return { resolved, failed: [...files], oversize, remoteDir: null }
   }
   for (const file of files) {
     try {
@@ -324,5 +379,5 @@ async function copyFilesToRemote(
       failed.push(file)
     }
   }
-  return { resolved, failed, oversize }
+  return { resolved, failed, oversize, remoteDir }
 }

--- a/src/main/jcode/jcode-attachments.ts
+++ b/src/main/jcode/jcode-attachments.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto'
 import { readFile, stat } from 'node:fs/promises'
 import { basename, posix as pathPosix } from 'node:path'
 import type { JcodeChatAttachment, JcodeChatSendPayload } from '../../shared/jcode-chat-types'
-import { getSshConnectionManager } from '../ipc/ssh'
+import { getLiveSshConnection, runRemoteCommand, shellQuote } from './jcode-ssh-command'
 
 /** A file attachment after any path rewriting (e.g. local -> remote temp). */
 export type ResolvedFileAttachment = {
@@ -124,11 +124,6 @@ export type ResolvedTurnPrompt = {
   cleanup: RemoteAttachmentCleanupTarget | null
 }
 
-/** Minimal single-quote shell escaping for a POSIX path argument. */
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`
-}
-
 const REMOTE_ATTACHMENT_PREFIX = '/tmp/orca-jcode-attachments-'
 const REMOTE_ATTACHMENT_SUFFIX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
@@ -148,44 +143,6 @@ function safeRemoteAttachmentDir(remoteDir: string): string | null {
  *  main process (read + base64) and bloat the SSH channel; refuse them with a
  *  clear note instead. 25 MiB matches the cap surfaced to the user. */
 export const MAX_REMOTE_ATTACHMENT_BYTES = 25 * 1024 * 1024
-
-/** Run a remote command over an SSH connection and resolve when it closes.
- *  Best-effort: rejects only on channel-open failure. */
-function runRemoteCommand(
-  conn: NonNullable<
-    ReturnType<NonNullable<ReturnType<typeof getSshConnectionManager>>['getConnection']>
-  >,
-  command: string
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    conn
-      .exec(command)
-      .then((channel) => {
-        channel.on('close', () => resolve())
-        channel.on('error', (err: Error) => reject(err))
-        // Drain so the channel can close.
-        channel.on('data', () => {})
-        channel.stderr?.on('data', () => {})
-      })
-      .catch(reject)
-  })
-}
-
-/** A live SSH connection object (as returned by the connection manager). */
-export type SshConnection = NonNullable<
-  ReturnType<NonNullable<ReturnType<typeof getSshConnectionManager>>['getConnection']>
->
-
-/** Resolve a live, connected SSH connection by id, or null. Shared by the skill
- *  discovery module so it can read remote `.claude/skills` over the same SSH
- *  transport that attachment copying uses. */
-export function getLiveSshConnection(connectionId: string): SshConnection | null {
-  const conn = getSshConnectionManager()?.getConnection(connectionId)
-  if (!conn || conn.getState().status !== 'connected') {
-    return null
-  }
-  return conn
-}
 
 export async function cleanupRemoteAttachmentDir(
   connectionId: string | null | undefined,
@@ -207,49 +164,6 @@ export async function cleanupRemoteAttachmentDir(
   } catch {
     // Best-effort cleanup must never change the chat result.
   }
-}
-
-/** Run a remote command over SSH and CAPTURE its stdout (unlike runRemoteCommand,
- *  which discards output). Resolves with the accumulated stdout on a zero exit;
- *  resolves with null on any non-zero/failed exit so callers can treat a missing
- *  file or directory as "no skills here" rather than throwing. Best-effort, with
- *  a bound so a hung channel can't stall skill discovery forever. */
-export function runRemoteCapture(conn: SshConnection, command: string): Promise<string | null> {
-  const TIMEOUT_MS = 10_000
-  return new Promise((resolve) => {
-    conn
-      .exec(command)
-      .then((channel) => {
-        let stdout = ''
-        let exitCode: number | null = null
-        let settled = false
-        const finish = (value: string | null): void => {
-          if (settled) {
-            return
-          }
-          settled = true
-          if (timer) {
-            clearTimeout(timer)
-          }
-          resolve(value)
-        }
-        const timer = setTimeout(() => finish(null), TIMEOUT_MS)
-        if (typeof timer.unref === 'function') {
-          timer.unref()
-        }
-        channel.on('data', (data: Buffer) => {
-          stdout += data.toString()
-        })
-        channel.stderr?.on('data', () => {})
-        channel.on('exit', (code: number | null) => {
-          exitCode = code
-        })
-        channel.on('close', () => finish(exitCode === 0 ? stdout : null))
-        channel.on('error', () => finish(null))
-        channel.stderr?.on('error', () => {})
-      })
-      .catch(() => resolve(null))
-  })
 }
 
 /** Resolve the final prompt string for a turn by weaving in any attachments.
@@ -350,8 +264,8 @@ async function copyFilesToRemote(
   if (files.length === 0) {
     return { resolved, failed, oversize, remoteDir: null }
   }
-  const conn = getSshConnectionManager()?.getConnection(connectionId)
-  if (!conn || conn.getState().status !== 'connected') {
+  const conn = getLiveSshConnection(connectionId)
+  if (!conn) {
     return { resolved, failed: [...files], oversize, remoteDir: null }
   }
   const remoteDir = buildRemoteAttachmentDir()

--- a/src/main/jcode/jcode-attachments.ts
+++ b/src/main/jcode/jcode-attachments.ts
@@ -76,8 +76,14 @@ export function buildRemoteAttachmentDir(): string {
  *  `--remote-exec`) and the SSH connectionId backing it (for copying local
  *  attachments to the remote host). `connectionId` is only set when the host was
  *  derived from a workspace SSH target; an ad-hoc `remoteExecHost` override has no
- *  connection to copy through. */
-export type RemoteExecResolution = { host: string | null; connectionId: string | null }
+ *  connection to copy through. `remotePath` is the remote project working dir of
+ *  the workspace/worktree (used by a later phase to pass `-C <remotePath>` so the
+ *  remote bash runs in the project dir); null when unknown or for local turns. */
+export type RemoteExecResolution = {
+  host: string | null
+  connectionId: string | null
+  remotePath: string | null
+}
 
 /** Minimal single-quote shell escaping for a POSIX path argument. */
 function shellQuote(value: string): string {

--- a/src/main/jcode/jcode-binary.test.ts
+++ b/src/main/jcode/jcode-binary.test.ts
@@ -1,0 +1,89 @@
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { resolveJcodeBinForEnvironment } from './jcode-binary'
+
+function makeFileCheck(existingFiles: readonly string[]): (candidate: string) => boolean {
+  const files = new Set(existingFiles)
+  return (candidate) => files.has(candidate)
+}
+
+describe('resolveJcodeBinForEnvironment', () => {
+  it('prefers ORCA_JCODE_BIN when it points at an existing file', () => {
+    const envPath = '/tmp/orca-jcode-env/jcode'
+    const shellPath = '/opt/orca-jcode-shell/jcode'
+    const execFileSyncMock = vi.fn(() => `${shellPath}\n`)
+
+    expect(
+      resolveJcodeBinForEnvironment({
+        env: { ORCA_JCODE_BIN: envPath, SHELL: '/bin/zsh' },
+        homeDir: '/home/orca-test',
+        execFileSync: execFileSyncMock,
+        isExistingFile: makeFileCheck([envPath, shellPath])
+      })
+    ).toBe(envPath)
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('prefers a login-shell command -v result when it is an existing absolute path', () => {
+    const shellPath = '/opt/orca-jcode-shell/jcode'
+    const cargoPath = path.posix.join('/home/orca-test', '.cargo', 'bin', 'jcode')
+    const execFileSyncMock = vi.fn(() => `jcode is ${shellPath}\n${shellPath}\n`)
+
+    expect(
+      resolveJcodeBinForEnvironment({
+        env: { SHELL: '/bin/zsh' },
+        platform: 'linux',
+        homeDir: '/home/orca-test',
+        execFileSync: execFileSyncMock,
+        isExistingFile: makeFileCheck([shellPath, cargoPath])
+      })
+    ).toBe(shellPath)
+    expect(execFileSyncMock).toHaveBeenCalledWith('/bin/zsh', ['-lc', 'command -v jcode'], {
+      encoding: 'utf8',
+      timeout: 5000
+    })
+  })
+
+  it.each([
+    {
+      platform: 'linux' as const,
+      homeDir: '/home/orca-test',
+      cargoPath: path.posix.join('/home/orca-test', '.cargo', 'bin', 'jcode')
+    },
+    {
+      platform: 'win32' as const,
+      homeDir: 'C:\\Users\\OrcaTest',
+      cargoPath: path.win32.join('C:\\Users\\OrcaTest', '.cargo', 'bin', 'jcode.exe')
+    }
+  ])(
+    'falls back to the platform cargo bin on $platform without a hardcoded user path',
+    ({ platform, homeDir, cargoPath }) => {
+      expect(
+        resolveJcodeBinForEnvironment({
+          env: {},
+          platform,
+          homeDir,
+          execFileSync: vi.fn(() => {
+            throw new Error('not found')
+          }),
+          isExistingFile: makeFileCheck([cargoPath])
+        })
+      ).toBe(cargoPath)
+      expect(cargoPath).toContain(homeDir)
+    }
+  )
+
+  it('returns bare jcode when no configured, shell, or cargo candidate exists', () => {
+    expect(
+      resolveJcodeBinForEnvironment({
+        env: {},
+        platform: 'linux',
+        homeDir: '/home/orca-test',
+        execFileSync: vi.fn(() => {
+          throw new Error('not found')
+        }),
+        isExistingFile: makeFileCheck([])
+      })
+    ).toBe('jcode')
+  })
+})

--- a/src/main/jcode/jcode-binary.test.ts
+++ b/src/main/jcode/jcode-binary.test.ts
@@ -1,14 +1,16 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { resolveJcodeBinForEnvironment } from './jcode-binary'
 
-function makeFileCheck(existingFiles: readonly string[]): (candidate: string) => boolean {
-  const files = new Set(existingFiles)
+function makeRunnableCheck(runnableFiles: readonly string[]): (candidate: string) => boolean {
+  const files = new Set(runnableFiles)
   return (candidate) => files.has(candidate)
 }
 
 describe('resolveJcodeBinForEnvironment', () => {
-  it('prefers ORCA_JCODE_BIN when it points at an existing file', () => {
+  it('prefers ORCA_JCODE_BIN when it points at a runnable file', () => {
     const envPath = '/tmp/orca-jcode-env/jcode'
     const shellPath = '/opt/orca-jcode-shell/jcode'
     const execFileSyncMock = vi.fn(() => `${shellPath}\n`)
@@ -18,13 +20,38 @@ describe('resolveJcodeBinForEnvironment', () => {
         env: { ORCA_JCODE_BIN: envPath, SHELL: '/bin/zsh' },
         homeDir: '/home/orca-test',
         execFileSync: execFileSyncMock,
-        isExistingFile: makeFileCheck([envPath, shellPath])
+        isRunnableFile: makeRunnableCheck([envPath, shellPath])
       })
     ).toBe(envPath)
     expect(execFileSyncMock).not.toHaveBeenCalled()
   })
 
-  it('prefers a login-shell command -v result when it is an existing absolute path', () => {
+  it.runIf(process.platform !== 'win32')(
+    'skips a POSIX env override file that exists but is not executable',
+    () => {
+      const tempDir = mkdtempSync(path.join(tmpdir(), 'orca-jcode-bin-'))
+      try {
+        const candidate = path.join(tempDir, 'jcode')
+        writeFileSync(candidate, '#!/bin/sh\n')
+        chmodSync(candidate, 0o600)
+
+        expect(
+          resolveJcodeBinForEnvironment({
+            env: { ORCA_JCODE_BIN: candidate },
+            platform: 'linux',
+            homeDir: path.join(tempDir, 'home'),
+            execFileSync: vi.fn(() => {
+              throw new Error('not found')
+            })
+          })
+        ).toBe('jcode')
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it('prefers a login-shell command -v result when it is a runnable absolute path', () => {
     const shellPath = '/opt/orca-jcode-shell/jcode'
     const cargoPath = path.posix.join('/home/orca-test', '.cargo', 'bin', 'jcode')
     const execFileSyncMock = vi.fn(() => `jcode is ${shellPath}\n${shellPath}\n`)
@@ -35,7 +62,7 @@ describe('resolveJcodeBinForEnvironment', () => {
         platform: 'linux',
         homeDir: '/home/orca-test',
         execFileSync: execFileSyncMock,
-        isExistingFile: makeFileCheck([shellPath, cargoPath])
+        isRunnableFile: makeRunnableCheck([shellPath, cargoPath])
       })
     ).toBe(shellPath)
     expect(execFileSyncMock).toHaveBeenCalledWith('/bin/zsh', ['-lc', 'command -v jcode'], {
@@ -66,7 +93,7 @@ describe('resolveJcodeBinForEnvironment', () => {
           execFileSync: vi.fn(() => {
             throw new Error('not found')
           }),
-          isExistingFile: makeFileCheck([cargoPath])
+          isRunnableFile: makeRunnableCheck([cargoPath])
         })
       ).toBe(cargoPath)
       expect(cargoPath).toContain(homeDir)
@@ -82,7 +109,36 @@ describe('resolveJcodeBinForEnvironment', () => {
         execFileSync: vi.fn(() => {
           throw new Error('not found')
         }),
-        isExistingFile: makeFileCheck([])
+        isRunnableFile: makeRunnableCheck([])
+      })
+    ).toBe('jcode')
+  })
+
+  it('skips a non-runnable POSIX env override and uses the runnable shell result', () => {
+    const envPath = '/tmp/orca-jcode-env/not-runnable'
+    const shellPath = '/opt/orca-jcode-shell/jcode'
+
+    expect(
+      resolveJcodeBinForEnvironment({
+        env: { ORCA_JCODE_BIN: envPath, SHELL: '/bin/zsh' },
+        platform: 'linux',
+        homeDir: '/home/orca-test',
+        execFileSync: vi.fn(() => `${shellPath}\n`),
+        isRunnableFile: makeRunnableCheck([shellPath])
+      })
+    ).toBe(shellPath)
+  })
+
+  it('returns bare jcode when the POSIX cargo candidate is not runnable', () => {
+    expect(
+      resolveJcodeBinForEnvironment({
+        env: {},
+        platform: 'linux',
+        homeDir: '/home/orca-test',
+        execFileSync: vi.fn(() => {
+          throw new Error('not found')
+        }),
+        isRunnableFile: makeRunnableCheck([])
       })
     ).toBe('jcode')
   })

--- a/src/main/jcode/jcode-binary.ts
+++ b/src/main/jcode/jcode-binary.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { statSync } from 'node:fs'
+import { accessSync, constants, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
 
@@ -21,12 +21,20 @@ export type JcodeBinResolutionEnvironment = {
   platform?: NodeJS.Platform
   homeDir?: string
   execFileSync?: ExecFileSyncText
-  isExistingFile?: (candidate: string) => boolean
+  isRunnableFile?: (candidate: string) => boolean
 }
 
-function isExistingFile(candidate: string): boolean {
+function isRunnableFile(candidate: string, platform: NodeJS.Platform): boolean {
   try {
-    return statSync(candidate).isFile()
+    if (!statSync(candidate).isFile()) {
+      return false
+    }
+    // Why: Windows has extension-based execution semantics; for jcode.exe,
+    // regular-file existence is the portable check Node can rely on here.
+    if (platform !== 'win32') {
+      accessSync(candidate, constants.X_OK)
+    }
+    return true
   } catch {
     return false
   }
@@ -34,10 +42,6 @@ function isExistingFile(candidate: string): boolean {
 
 function pathForPlatform(platform: NodeJS.Platform): PathTools {
   return platform === 'win32' ? path.win32 : path.posix
-}
-
-export function hasJcodeBinEnvOverride(env: NodeJS.ProcessEnv = process.env): boolean {
-  return Boolean(env[JCODE_BIN_ENV]?.trim())
 }
 
 function getLoginShell(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string | null {
@@ -54,13 +58,13 @@ function getLoginShell(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): strin
 function findExistingAbsolutePath(
   output: string,
   pathTools: PathTools,
-  fileExists: (candidate: string) => boolean
+  fileIsRunnable: (candidate: string) => boolean
 ): string | null {
   return (
     output
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .find((line) => pathTools.isAbsolute(line) && fileExists(line)) ?? null
+      .find((line) => pathTools.isAbsolute(line) && fileIsRunnable(line)) ?? null
   )
 }
 
@@ -69,10 +73,10 @@ export function resolveJcodeBinForEnvironment({
   platform = process.platform,
   homeDir = homedir(),
   execFileSync: runExecFileSync = execFileSync as ExecFileSyncText,
-  isExistingFile: fileExists = isExistingFile
+  isRunnableFile: fileIsRunnable = (candidate) => isRunnableFile(candidate, platform)
 }: JcodeBinResolutionEnvironment = {}): string {
   const envOverride = env[JCODE_BIN_ENV]?.trim()
-  if (envOverride && fileExists(envOverride)) {
+  if (envOverride && fileIsRunnable(envOverride)) {
     return envOverride
   }
 
@@ -86,7 +90,7 @@ export function resolveJcodeBinForEnvironment({
           timeout: LOGIN_SHELL_TIMEOUT_MS
         }),
         pathTools,
-        fileExists
+        fileIsRunnable
       )
       if (commandPath) {
         return commandPath
@@ -98,7 +102,7 @@ export function resolveJcodeBinForEnvironment({
 
   const cargoBinaryName = platform === 'win32' ? 'jcode.exe' : JCODE_COMMAND
   const cargoCandidate = pathTools.join(homeDir, '.cargo', 'bin', cargoBinaryName)
-  if (fileExists(cargoCandidate)) {
+  if (fileIsRunnable(cargoCandidate)) {
     return cargoCandidate
   }
 

--- a/src/main/jcode/jcode-binary.ts
+++ b/src/main/jcode/jcode-binary.ts
@@ -1,43 +1,116 @@
-// Why: jcode is installed via cargo. Under Electron the inherited PATH is often
-// empty/minimal, so we can't rely on a bare `jcode`. Prefer resolving it from
-// the user's LOGIN shell (which sources their profile and has the real PATH,
-// e.g. ~/.cargo/bin), and fall back to the pinned cargo path only if that fails.
-// The fallback keeps parity with the desktop prototype / CLI verification path.
 import { execFileSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
 
-const JCODE_BIN_FALLBACK = '/Users/vinny/.cargo/bin/jcode'
+const JCODE_COMMAND = 'jcode'
+const JCODE_BIN_ENV = 'ORCA_JCODE_BIN'
+const LOGIN_SHELL_TIMEOUT_MS = 5000
 
 let cachedJcodeBin: string | null = null
 
-/** Resolve the jcode binary path once, lazily. Tries the user's login shell
- *  (so the real PATH from their profile applies) via `command -v jcode`; on any
- *  failure or empty result, falls back to the pinned cargo path if it exists,
- *  else the bare name (lets spawn surface a clear ENOENT). Cached after first
- *  resolution since PATH does not change within a process lifetime. */
+type ExecFileSyncText = (
+  file: string,
+  args: readonly string[],
+  options: { encoding: 'utf8'; timeout: number }
+) => string
+type PathTools = typeof path.posix
+
+export type JcodeBinResolutionEnvironment = {
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform
+  homeDir?: string
+  execFileSync?: ExecFileSyncText
+  isExistingFile?: (candidate: string) => boolean
+}
+
+function isExistingFile(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile()
+  } catch {
+    return false
+  }
+}
+
+function pathForPlatform(platform: NodeJS.Platform): PathTools {
+  return platform === 'win32' ? path.win32 : path.posix
+}
+
+export function hasJcodeBinEnvOverride(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env[JCODE_BIN_ENV]?.trim())
+}
+
+function getLoginShell(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string | null {
+  const configuredShell = env.SHELL?.trim()
+  if (configuredShell) {
+    return configuredShell
+  }
+  if (platform === 'win32') {
+    return null
+  }
+  return platform === 'darwin' ? '/bin/zsh' : '/bin/sh'
+}
+
+function findExistingAbsolutePath(
+  output: string,
+  pathTools: PathTools,
+  fileExists: (candidate: string) => boolean
+): string | null {
+  return (
+    output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => pathTools.isAbsolute(line) && fileExists(line)) ?? null
+  )
+}
+
+export function resolveJcodeBinForEnvironment({
+  env = process.env,
+  platform = process.platform,
+  homeDir = homedir(),
+  execFileSync: runExecFileSync = execFileSync as ExecFileSyncText,
+  isExistingFile: fileExists = isExistingFile
+}: JcodeBinResolutionEnvironment = {}): string {
+  const envOverride = env[JCODE_BIN_ENV]?.trim()
+  if (envOverride && fileExists(envOverride)) {
+    return envOverride
+  }
+
+  const pathTools = pathForPlatform(platform)
+  const loginShell = getLoginShell(env, platform)
+  if (loginShell) {
+    try {
+      const commandPath = findExistingAbsolutePath(
+        runExecFileSync(loginShell, ['-lc', 'command -v jcode'], {
+          encoding: 'utf8',
+          timeout: LOGIN_SHELL_TIMEOUT_MS
+        }),
+        pathTools,
+        fileExists
+      )
+      if (commandPath) {
+        return commandPath
+      }
+    } catch {
+      // Login shell unavailable or jcode not on PATH; fall through to cargo.
+    }
+  }
+
+  const cargoBinaryName = platform === 'win32' ? 'jcode.exe' : JCODE_COMMAND
+  const cargoCandidate = pathTools.join(homeDir, '.cargo', 'bin', cargoBinaryName)
+  if (fileExists(cargoCandidate)) {
+    return cargoCandidate
+  }
+
+  return JCODE_COMMAND
+}
+
+/** Resolve once lazily. The final bare name is intentional: it lets spawn surface
+ * a clear ENOENT when no configured, shell, or cargo binary exists. */
 export function resolveJcodeBin(): string {
   if (cachedJcodeBin) {
     return cachedJcodeBin
   }
-  const loginShell = process.env.SHELL?.trim() || '/bin/zsh'
-  try {
-    const out = execFileSync(loginShell, ['-lc', 'command -v jcode'], {
-      encoding: 'utf8',
-      timeout: 5000
-    }).trim()
-    // `command -v` can return multiple lines for shell functions/aliases; take
-    // the first absolute path it reports.
-    const candidate = out
-      .split('\n')
-      .map((l) => l.trim())
-      .find((l) => l.startsWith('/'))
-    if (candidate && existsSync(candidate)) {
-      cachedJcodeBin = candidate
-      return cachedJcodeBin
-    }
-  } catch {
-    // Login shell unavailable or jcode not on PATH — fall through to fallback.
-  }
-  cachedJcodeBin = existsSync(JCODE_BIN_FALLBACK) ? JCODE_BIN_FALLBACK : 'jcode'
+  cachedJcodeBin = resolveJcodeBinForEnvironment()
   return cachedJcodeBin
 }

--- a/src/main/jcode/jcode-binary.ts
+++ b/src/main/jcode/jcode-binary.ts
@@ -1,0 +1,43 @@
+// Why: jcode is installed via cargo. Under Electron the inherited PATH is often
+// empty/minimal, so we can't rely on a bare `jcode`. Prefer resolving it from
+// the user's LOGIN shell (which sources their profile and has the real PATH,
+// e.g. ~/.cargo/bin), and fall back to the pinned cargo path only if that fails.
+// The fallback keeps parity with the desktop prototype / CLI verification path.
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+const JCODE_BIN_FALLBACK = '/Users/vinny/.cargo/bin/jcode'
+
+let cachedJcodeBin: string | null = null
+
+/** Resolve the jcode binary path once, lazily. Tries the user's login shell
+ *  (so the real PATH from their profile applies) via `command -v jcode`; on any
+ *  failure or empty result, falls back to the pinned cargo path if it exists,
+ *  else the bare name (lets spawn surface a clear ENOENT). Cached after first
+ *  resolution since PATH does not change within a process lifetime. */
+export function resolveJcodeBin(): string {
+  if (cachedJcodeBin) {
+    return cachedJcodeBin
+  }
+  const loginShell = process.env.SHELL?.trim() || '/bin/zsh'
+  try {
+    const out = execFileSync(loginShell, ['-lc', 'command -v jcode'], {
+      encoding: 'utf8',
+      timeout: 5000
+    }).trim()
+    // `command -v` can return multiple lines for shell functions/aliases; take
+    // the first absolute path it reports.
+    const candidate = out
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.startsWith('/'))
+    if (candidate && existsSync(candidate)) {
+      cachedJcodeBin = candidate
+      return cachedJcodeBin
+    }
+  } catch {
+    // Login shell unavailable or jcode not on PATH — fall through to fallback.
+  }
+  cachedJcodeBin = existsSync(JCODE_BIN_FALLBACK) ? JCODE_BIN_FALLBACK : 'jcode'
+  return cachedJcodeBin
+}

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -9,7 +9,9 @@ import { type BrowserWindow, ipcMain } from 'electron'
 import {
   JCODE_CHAT_EVENT_CHANNEL,
   JCODE_CHAT_SEND_CHANNEL,
+  JCODE_CHAT_STOP_CHANNEL,
   type JcodeChatSendPayload,
+  type JcodeChatStopPayload,
   type JcodeNdjsonEvent
 } from '../../shared/jcode-chat-types'
 
@@ -21,6 +23,10 @@ const JCODE_BIN = '/Users/vinny/.cargo/bin/jcode'
 /** One in-flight turn per sessionKey. A new send for the same key cancels the
  *  previous child first (defensive — the renderer should not double-send). */
 const activeChildren = new Map<string, ChildProcessWithoutNullStreams>()
+
+/** sessionKeys whose child was killed by an explicit user Stop. Used so the
+ *  'close' handler emits a 'stopped' event instead of a spurious 'error'. */
+const stoppedKeys = new Set<string>()
 
 function sendEvent(mainWindow: BrowserWindow, sessionKey: string, event: JcodeNdjsonEvent): void {
   if (mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) {
@@ -52,6 +58,9 @@ function buildArgs(payload: JcodeChatSendPayload): string[] {
 
 function startTurn(mainWindow: BrowserWindow, payload: JcodeChatSendPayload): void {
   const { sessionKey } = payload
+
+  // A fresh turn supersedes any pending Stop bookkeeping for this pane.
+  stoppedKeys.delete(sessionKey)
 
   // Defensive: kill any prior in-flight child for this pane before starting.
   const prior = activeChildren.get(sessionKey)
@@ -117,6 +126,7 @@ function startTurn(mainWindow: BrowserWindow, payload: JcodeChatSendPayload): vo
 
   child.on('close', (code: number | null) => {
     activeChildren.delete(sessionKey)
+    const wasStopped = stoppedKeys.delete(sessionKey)
     // Flush any trailing partial line that lacked a newline.
     const trailing = stdoutBuffer.trim()
     if (trailing) {
@@ -126,7 +136,10 @@ function startTurn(mainWindow: BrowserWindow, payload: JcodeChatSendPayload): vo
         sendEvent(mainWindow, sessionKey, { type: 'text_delta', text: trailing })
       }
     }
-    if (code !== 0) {
+    if (wasStopped) {
+      // User pressed Stop: a non-zero/kill exit is expected, not an error.
+      sendEvent(mainWindow, sessionKey, { type: 'stopped' })
+    } else if (code !== 0) {
       sendEvent(mainWindow, sessionKey, {
         type: 'error',
         error:
@@ -153,6 +166,28 @@ export function registerJcodeChatHandlers(mainWindow: BrowserWindow): void {
     startTurn(mainWindow, payload)
   })
 
+  // Stop: kill the in-flight child for a pane. The 'close' handler then emits a
+  // 'stopped' event (rather than 'error') because the key is flagged here.
+  ipcMain.removeAllListeners(JCODE_CHAT_STOP_CHANNEL)
+  ipcMain.on(JCODE_CHAT_STOP_CHANNEL, (event, raw: unknown) => {
+    if (event.sender !== mainWindow.webContents) {
+      return
+    }
+    const payload = raw as JcodeChatStopPayload
+    if (!payload || typeof payload.sessionKey !== 'string') {
+      return
+    }
+    const child = activeChildren.get(payload.sessionKey)
+    if (child && !child.killed) {
+      stoppedKeys.add(payload.sessionKey)
+      try {
+        child.kill()
+      } catch {
+        stoppedKeys.delete(payload.sessionKey)
+      }
+    }
+  })
+
   mainWindow.on('closed', () => {
     for (const child of activeChildren.values()) {
       if (!child.killed) {
@@ -164,6 +199,8 @@ export function registerJcodeChatHandlers(mainWindow: BrowserWindow): void {
       }
     }
     activeChildren.clear()
+    stoppedKeys.clear()
     ipcMain.removeAllListeners(JCODE_CHAT_SEND_CHANNEL)
+    ipcMain.removeAllListeners(JCODE_CHAT_STOP_CHANNEL)
   })
 }

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -5,6 +5,7 @@
 // emits NDJSON then exits. Conversations continue via --resume <sessionId>,
 // captured from the 'start'/'done' events on a previous turn.
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import os from 'node:os'
 import { type BrowserWindow, dialog, ipcMain } from 'electron'
 import type { Store } from '../persistence'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
@@ -70,7 +71,14 @@ function buildArgs(
   if (payload.model?.trim()) {
     args.push('-m', payload.model.trim())
   }
-  if (payload.cwd?.trim()) {
+  // jcode's `-C/--cwd` does a LOCAL std::env::set_current_dir for ANY value,
+  // independent of --remote-exec (startup.rs parse_and_prepare_args). For a
+  // remote turn payload.cwd is the REMOTE project path, which does not exist on
+  // the Mac, so passing -C would crash the local process with ENOENT. Omit -C
+  // for remote turns; the remote bash then runs in the remote login home (~).
+  // (A jcode-binary change is needed to make -C set ONLY the remote working dir
+  // under --remote-exec — see jcodeBinaryFollowup.) Local turns keep -C as-is.
+  if (!remoteExecHost && payload.cwd?.trim()) {
     args.push('-C', payload.cwd.trim())
   }
   if (payload.resumeSessionId?.trim()) {
@@ -87,8 +95,14 @@ function buildArgs(
 }
 
 /** Resolve the brain-local (M3) remote-exec host for a chat turn.
- *  Priority: the worktree's SSH target host when its folder workspace is
- *  `isRemoteExecOnly`, else the explicit `payload.remoteExecHost` override.
+ *  A jcode chat opened in ANY connectionId-remote folder workspace implies
+ *  remote execution: jcode runs locally (local auth/model) but its bash/read
+ *  tools execute on the remote host. So we emit --remote-exec whenever the
+ *  worktree's folder workspace has an SSH connection — not only when the user
+ *  manually toggled `isRemoteExecOnly`. (The folderPath of such a worktree is a
+ *  REMOTE path that does not exist on the Mac, so running fully local would both
+ *  crash the spawn and execute bash against a nonexistent local dir.)
+ *  Falls back to the explicit `payload.remoteExecHost` override.
  *  Returns host null when this turn should run fully local (no --remote-exec). */
 function resolveRemoteExec(
   store: Store | undefined,
@@ -98,7 +112,9 @@ function resolveRemoteExec(
     const scope = parseWorkspaceKey(payload.worktreeId)
     if (scope?.type === 'folder') {
       const workspace = store.getFolderWorkspace(scope.folderWorkspaceId)
-      if (workspace?.isRemoteExecOnly && workspace.connectionId) {
+      // Key off the SSH connection presence: any connectionId-remote worktree
+      // (whether or not isRemoteExecOnly was explicitly set) runs brain-local.
+      if (workspace?.connectionId) {
         const target = store.getSshTarget(workspace.connectionId)
         // Prefer the OpenSSH config alias so ~/.ssh/config (ProxyJump/identity)
         // applies; fall back to the raw host. jcode resolves the host itself.
@@ -147,10 +163,19 @@ async function startTurn(
     return
   }
 
+  // The Node child_process `cwd` MUST be a directory that exists on THIS (local)
+  // machine — jcode itself always runs locally, even for brain-local turns. For a
+  // remote worktree payload.cwd is the REMOTE project path (e.g. /home/srain/...)
+  // which does not exist on the Mac; passing it to spawn() throws `spawn ENOENT`.
+  // So for remote turns we anchor the local process at the user's home dir; the
+  // remote bash working dir is governed by --remote-exec, not this cwd. Local
+  // turns continue to spawn in the worktree's (local) folder path.
+  const localSpawnCwd = remoteExecHost ? os.homedir() : payload.cwd?.trim() || undefined
+
   let child: ChildProcessWithoutNullStreams
   try {
     child = spawn(JCODE_BIN, buildArgs(payload, remoteExecHost, resolvedPrompt), {
-      cwd: payload.cwd?.trim() || undefined,
+      cwd: localSpawnCwd,
       env: process.env
     })
   } catch (error) {

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -29,14 +29,10 @@ import {
   saveConversation
 } from './jcode-conversation-store'
 import { resolveTurnPrompt } from './jcode-attachments'
+import { resolveJcodeBin } from './jcode-binary'
 import { friendlyChildError } from './jcode-error-messages'
 import { resolveRemoteExec } from './jcode-remote-exec'
 import { applySkillInjection, registerJcodeSkillsHandler } from './jcode-skills'
-
-// Why: jcode is installed via cargo; the absolute path avoids depending on the
-// (often empty under Electron) PATH. Mirrors the pinned tool path the desktop
-// prototype and CLI verification use.
-const JCODE_BIN = '/Users/vinny/.cargo/bin/jcode'
 
 /** One in-flight turn per sessionKey. A new send for the same key cancels the
  *  previous child first (defensive — the renderer should not double-send). */
@@ -157,7 +153,7 @@ async function startTurn(
   let child: ChildProcessWithoutNullStreams
   try {
     child = spawn(
-      JCODE_BIN,
+      resolveJcodeBin(),
       buildArgs(payload, remoteExecHost, resolvedPrompt, remote.remotePath),
       {
         cwd: localSpawnCwd,

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -56,7 +56,8 @@ function sendEvent(mainWindow: BrowserWindow, sessionKey: string, event: JcodeNd
 function buildArgs(
   payload: JcodeChatSendPayload,
   remoteExecHost: string | null,
-  resolvedPrompt: string
+  resolvedPrompt: string,
+  remotePath: string | null
 ): string[] {
   // A named custom profile (from `jcode provider add`) is selected with
   // `--provider-profile <name>` (which IMPLIES openai-compatible) and MUST NOT
@@ -73,14 +74,18 @@ function buildArgs(
   if (payload.model?.trim()) {
     args.push('-m', payload.model.trim())
   }
-  // jcode's `-C/--cwd` does a LOCAL std::env::set_current_dir for ANY value,
-  // independent of --remote-exec (startup.rs parse_and_prepare_args). For a
-  // remote turn payload.cwd is the REMOTE project path, which does not exist on
-  // the Mac, so passing -C would crash the local process with ENOENT. Omit -C
-  // for remote turns; the remote bash then runs in the remote login home (~).
-  // (A jcode-binary change is needed to make -C set ONLY the remote working dir
-  // under --remote-exec — see jcodeBinaryFollowup.) Local turns keep -C as-is.
-  if (!remoteExecHost && payload.cwd?.trim()) {
+  // jcode's `-C/--cwd` behavior is now remote-exec-aware (startup.rs
+  // parse_and_prepare_args + run_single_message_command): under --remote-exec it
+  // does NOT chdir locally but instead seeds the session working_dir so the remote
+  // bash `cd`s into the project dir. So for a remote turn we pass -C <remotePath>
+  // (the worktree's remote folderPath from resolveRemoteExec) — the remote bash
+  // then runs in the project dir instead of the remote login home (~). For a local
+  // turn -C is the local project path as before.
+  if (remoteExecHost) {
+    if (remotePath?.trim()) {
+      args.push('-C', remotePath.trim())
+    }
+  } else if (payload.cwd?.trim()) {
     args.push('-C', payload.cwd.trim())
   }
   if (payload.resumeSessionId?.trim()) {
@@ -151,10 +156,14 @@ async function startTurn(
 
   let child: ChildProcessWithoutNullStreams
   try {
-    child = spawn(JCODE_BIN, buildArgs(payload, remoteExecHost, resolvedPrompt), {
-      cwd: localSpawnCwd,
-      env: process.env
-    })
+    child = spawn(
+      JCODE_BIN,
+      buildArgs(payload, remoteExecHost, resolvedPrompt, remote.remotePath),
+      {
+        cwd: localSpawnCwd,
+        env: process.env
+      }
+    )
   } catch (error) {
     sendEvent(mainWindow, sessionKey, {
       type: 'error',

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -9,13 +9,24 @@ import { type BrowserWindow, ipcMain } from 'electron'
 import type { Store } from '../persistence'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import {
+  JCODE_CHAT_DELETE_CHANNEL,
   JCODE_CHAT_EVENT_CHANNEL,
+  JCODE_CHAT_LIST_CHANNEL,
+  JCODE_CHAT_LOAD_CHANNEL,
+  JCODE_CHAT_SAVE_CHANNEL,
   JCODE_CHAT_SEND_CHANNEL,
   JCODE_CHAT_STOP_CHANNEL,
+  type JcodeChatSavePayload,
   type JcodeChatSendPayload,
   type JcodeChatStopPayload,
   type JcodeNdjsonEvent
 } from '../../shared/jcode-chat-types'
+import {
+  deleteConversation,
+  listConversations,
+  loadConversation,
+  saveConversation
+} from './jcode-conversation-store'
 
 // Why: jcode is installed via cargo; the absolute path avoids depending on the
 // (often empty under Electron) PATH. Mirrors the pinned tool path the desktop
@@ -222,6 +233,56 @@ export function registerJcodeChatHandlers(mainWindow: BrowserWindow, store?: Sto
     }
   })
 
+  // ─── Durable persistence (BUG 1/2) ──────────────────────────────────────
+  // The renderer reduces NDJSON events into full conversation state (messages +
+  // tool cards + --resume id) already, so the simplest faithful backing store is
+  // to let it send a snapshot on turn boundaries and persist that verbatim. This
+  // avoids re-deriving the tool-card shape in main and keeps tool/diff rendering
+  // identical after rehydrate.
+  ipcMain.removeHandler(JCODE_CHAT_SAVE_CHANNEL)
+  ipcMain.handle(JCODE_CHAT_SAVE_CHANNEL, (event, raw: unknown) => {
+    if (event.sender !== mainWindow.webContents) {
+      return false
+    }
+    const payload = raw as JcodeChatSavePayload
+    if (!payload?.record || typeof payload.record.sessionKey !== 'string') {
+      return false
+    }
+    return saveConversation(payload.record)
+  })
+
+  ipcMain.removeHandler(JCODE_CHAT_LIST_CHANNEL)
+  ipcMain.handle(JCODE_CHAT_LIST_CHANNEL, (event) => {
+    if (event.sender !== mainWindow.webContents) {
+      return []
+    }
+    return listConversations()
+  })
+
+  ipcMain.removeHandler(JCODE_CHAT_LOAD_CHANNEL)
+  ipcMain.handle(JCODE_CHAT_LOAD_CHANNEL, (event, raw: unknown) => {
+    if (event.sender !== mainWindow.webContents) {
+      return null
+    }
+    const sessionKey = typeof raw === 'string' ? raw : (raw as { sessionKey?: string })?.sessionKey
+    if (typeof sessionKey !== 'string') {
+      return null
+    }
+    return loadConversation(sessionKey)
+  })
+
+  ipcMain.removeHandler(JCODE_CHAT_DELETE_CHANNEL)
+  ipcMain.handle(JCODE_CHAT_DELETE_CHANNEL, (event, raw: unknown) => {
+    if (event.sender !== mainWindow.webContents) {
+      return false
+    }
+    const sessionKey = typeof raw === 'string' ? raw : (raw as { sessionKey?: string })?.sessionKey
+    if (typeof sessionKey !== 'string') {
+      return false
+    }
+    return deleteConversation(sessionKey)
+  })
+
   mainWindow.on('closed', () => {
     for (const child of activeChildren.values()) {
       if (!child.killed) {
@@ -236,5 +297,9 @@ export function registerJcodeChatHandlers(mainWindow: BrowserWindow, store?: Sto
     stoppedKeys.clear()
     ipcMain.removeAllListeners(JCODE_CHAT_SEND_CHANNEL)
     ipcMain.removeAllListeners(JCODE_CHAT_STOP_CHANNEL)
+    ipcMain.removeHandler(JCODE_CHAT_SAVE_CHANNEL)
+    ipcMain.removeHandler(JCODE_CHAT_LIST_CHANNEL)
+    ipcMain.removeHandler(JCODE_CHAT_LOAD_CHANNEL)
+    ipcMain.removeHandler(JCODE_CHAT_DELETE_CHANNEL)
   })
 }

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -1,0 +1,169 @@
+// Why: jcode's chat-bubble view (M1) needs CLEAN newline-delimited JSON on
+// stdout, so it is spawned with node child_process — NOT a PTY. A PTY would
+// inject terminal control sequences and line-wrapping that corrupt the JSON
+// stream. Each `jcode run ... --ndjson <prompt>` invocation is one-shot: it
+// emits NDJSON then exits. Conversations continue via --resume <sessionId>,
+// captured from the 'start'/'done' events on a previous turn.
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { type BrowserWindow, ipcMain } from 'electron'
+import {
+  JCODE_CHAT_EVENT_CHANNEL,
+  JCODE_CHAT_SEND_CHANNEL,
+  type JcodeChatSendPayload,
+  type JcodeNdjsonEvent
+} from '../../shared/jcode-chat-types'
+
+// Why: jcode is installed via cargo; the absolute path avoids depending on the
+// (often empty under Electron) PATH. Mirrors the pinned tool path the desktop
+// prototype and CLI verification use.
+const JCODE_BIN = '/Users/vinny/.cargo/bin/jcode'
+
+/** One in-flight turn per sessionKey. A new send for the same key cancels the
+ *  previous child first (defensive — the renderer should not double-send). */
+const activeChildren = new Map<string, ChildProcessWithoutNullStreams>()
+
+function sendEvent(mainWindow: BrowserWindow, sessionKey: string, event: JcodeNdjsonEvent): void {
+  if (mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) {
+    return
+  }
+  mainWindow.webContents.send(JCODE_CHAT_EVENT_CHANNEL, { sessionKey, event })
+}
+
+function buildArgs(payload: JcodeChatSendPayload): string[] {
+  const provider = payload.provider?.trim() || 'openai'
+  const args = ['run', '-p', provider]
+  if (payload.model?.trim()) {
+    args.push('-m', payload.model.trim())
+  }
+  if (payload.cwd?.trim()) {
+    args.push('-C', payload.cwd.trim())
+  }
+  if (payload.resumeSessionId?.trim()) {
+    args.push('--resume', payload.resumeSessionId.trim())
+  }
+  // brain-local (M3): unused until then, but wired so the chat path needs no
+  // further changes when remote-exec lands.
+  if (payload.remoteExecHost?.trim()) {
+    args.push('--remote-exec', payload.remoteExecHost.trim())
+  }
+  args.push('--ndjson', payload.prompt)
+  return args
+}
+
+function startTurn(mainWindow: BrowserWindow, payload: JcodeChatSendPayload): void {
+  const { sessionKey } = payload
+
+  // Defensive: kill any prior in-flight child for this pane before starting.
+  const prior = activeChildren.get(sessionKey)
+  if (prior && !prior.killed) {
+    try {
+      prior.kill()
+    } catch {
+      // ignore
+    }
+  }
+
+  let child: ChildProcessWithoutNullStreams
+  try {
+    child = spawn(JCODE_BIN, buildArgs(payload), {
+      cwd: payload.cwd?.trim() || undefined,
+      env: process.env
+    })
+  } catch (error) {
+    sendEvent(mainWindow, sessionKey, {
+      type: 'error',
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return
+  }
+
+  activeChildren.set(sessionKey, child)
+
+  // Why: stdout arrives in arbitrary chunks; NDJSON lines can be split across
+  // chunks. Buffer the partial trailing line and only parse complete lines.
+  let stdoutBuffer = ''
+  let stderrBuffer = ''
+
+  child.stdout.setEncoding('utf8')
+  child.stdout.on('data', (chunk: string) => {
+    stdoutBuffer += chunk
+    let newlineIndex = stdoutBuffer.indexOf('\n')
+    while (newlineIndex !== -1) {
+      const line = stdoutBuffer.slice(0, newlineIndex).trim()
+      stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1)
+      if (line) {
+        try {
+          const event = JSON.parse(line) as JcodeNdjsonEvent
+          sendEvent(mainWindow, sessionKey, event)
+        } catch {
+          // Why: non-JSON noise on stdout (banners, etc.) is forwarded as a
+          // text_delta so it is visible rather than silently dropped.
+          sendEvent(mainWindow, sessionKey, { type: 'text_delta', text: line })
+        }
+      }
+      newlineIndex = stdoutBuffer.indexOf('\n')
+    }
+  })
+
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', (chunk: string) => {
+    stderrBuffer += chunk
+  })
+
+  child.on('error', (error: Error) => {
+    activeChildren.delete(sessionKey)
+    sendEvent(mainWindow, sessionKey, { type: 'error', error: error.message })
+  })
+
+  child.on('close', (code: number | null) => {
+    activeChildren.delete(sessionKey)
+    // Flush any trailing partial line that lacked a newline.
+    const trailing = stdoutBuffer.trim()
+    if (trailing) {
+      try {
+        sendEvent(mainWindow, sessionKey, JSON.parse(trailing) as JcodeNdjsonEvent)
+      } catch {
+        sendEvent(mainWindow, sessionKey, { type: 'text_delta', text: trailing })
+      }
+    }
+    if (code !== 0) {
+      sendEvent(mainWindow, sessionKey, {
+        type: 'error',
+        error:
+          stderrBuffer.trim() || `jcode exited with code ${code === null ? 'null' : String(code)}`
+      })
+    }
+    // Always emit a terminal 'exit' so the renderer can finalize UI even when
+    // jcode forgot to emit a 'done' (e.g. crash mid-turn).
+    sendEvent(mainWindow, sessionKey, { type: 'exit', code })
+  })
+}
+
+export function registerJcodeChatHandlers(mainWindow: BrowserWindow): void {
+  // Re-registration safe (macOS window recreate): drop the previous listener.
+  ipcMain.removeAllListeners(JCODE_CHAT_SEND_CHANNEL)
+  ipcMain.on(JCODE_CHAT_SEND_CHANNEL, (event, raw: unknown) => {
+    if (event.sender !== mainWindow.webContents) {
+      return
+    }
+    const payload = raw as JcodeChatSendPayload
+    if (!payload || typeof payload.sessionKey !== 'string' || typeof payload.prompt !== 'string') {
+      return
+    }
+    startTurn(mainWindow, payload)
+  })
+
+  mainWindow.on('closed', () => {
+    for (const child of activeChildren.values()) {
+      if (!child.killed) {
+        try {
+          child.kill()
+        } catch {
+          // ignore
+        }
+      }
+    }
+    activeChildren.clear()
+    ipcMain.removeAllListeners(JCODE_CHAT_SEND_CHANNEL)
+  })
+}

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -30,6 +30,7 @@ import {
   saveConversation
 } from './jcode-conversation-store'
 import { resolveTurnPrompt, type RemoteExecResolution } from './jcode-attachments'
+import { applySkillInjection, registerJcodeSkillsHandler } from './jcode-skills'
 
 // Why: jcode is installed via cargo; the absolute path avoids depending on the
 // (often empty under Electron) PATH. Mirrors the pinned tool path the desktop
@@ -162,6 +163,15 @@ async function startTurn(
     })
     return
   }
+
+  // FEATURE B: prepend a selected skill's SKILL.md body (re-discovered from cwd +
+  // worktreeId so remote skills resolve over SSH). Non-fatal if missing.
+  resolvedPrompt = await applySkillInjection(
+    payload.skillName,
+    resolvedPrompt,
+    { cwd: payload.cwd, worktreeId: payload.worktreeId },
+    store
+  )
 
   // The Node child_process `cwd` MUST be a directory that exists on THIS (local)
   // machine — jcode itself always runs locally, even for brain-local turns. For a
@@ -361,6 +371,10 @@ export function registerJcodeChatHandlers(mainWindow: BrowserWindow, store?: Sto
     }
     return deleteConversation(sessionKey)
   })
+
+  // FEATURE B: skills-list IPC for the "/" menu (handler + cleanup live in
+  // jcode-skills to keep this module under budget).
+  registerJcodeSkillsHandler(mainWindow, store)
 
   mainWindow.on('closed', () => {
     for (const child of activeChildren.values()) {

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -5,7 +5,7 @@
 // emits NDJSON then exits. Conversations continue via --resume <sessionId>,
 // captured from the 'start'/'done' events on a previous turn.
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import { type BrowserWindow, ipcMain } from 'electron'
+import { type BrowserWindow, dialog, ipcMain } from 'electron'
 import type { Store } from '../persistence'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import {
@@ -13,6 +13,7 @@ import {
   JCODE_CHAT_EVENT_CHANNEL,
   JCODE_CHAT_LIST_CHANNEL,
   JCODE_CHAT_LOAD_CHANNEL,
+  JCODE_CHAT_PICK_FILES_CHANNEL,
   JCODE_CHAT_SAVE_CHANNEL,
   JCODE_CHAT_SEND_CHANNEL,
   JCODE_CHAT_STOP_CHANNEL,
@@ -27,6 +28,7 @@ import {
   loadConversation,
   saveConversation
 } from './jcode-conversation-store'
+import { resolveTurnPrompt, type RemoteExecResolution } from './jcode-attachments'
 
 // Why: jcode is installed via cargo; the absolute path avoids depending on the
 // (often empty under Electron) PATH. Mirrors the pinned tool path the desktop
@@ -48,7 +50,11 @@ function sendEvent(mainWindow: BrowserWindow, sessionKey: string, event: JcodeNd
   mainWindow.webContents.send(JCODE_CHAT_EVENT_CHANNEL, { sessionKey, event })
 }
 
-function buildArgs(payload: JcodeChatSendPayload, remoteExecHost: string | null): string[] {
+function buildArgs(
+  payload: JcodeChatSendPayload,
+  remoteExecHost: string | null,
+  resolvedPrompt: string
+): string[] {
   // A named custom profile (from `jcode provider add`) is selected with
   // `--provider-profile <name>` (which IMPLIES openai-compatible) and MUST NOT
   // also pass `-p`; doing both would be ambiguous. It takes precedence over the
@@ -76,18 +82,18 @@ function buildArgs(payload: JcodeChatSendPayload, remoteExecHost: string | null)
   if (remoteExecHost) {
     args.push('--remote-exec', remoteExecHost)
   }
-  args.push('--ndjson', payload.prompt)
+  args.push('--ndjson', resolvedPrompt)
   return args
 }
 
 /** Resolve the brain-local (M3) remote-exec host for a chat turn.
  *  Priority: the worktree's SSH target host when its folder workspace is
  *  `isRemoteExecOnly`, else the explicit `payload.remoteExecHost` override.
- *  Returns null when this turn should run fully local (no --remote-exec). */
-function resolveRemoteExecHost(
+ *  Returns host null when this turn should run fully local (no --remote-exec). */
+function resolveRemoteExec(
   store: Store | undefined,
   payload: JcodeChatSendPayload
-): string | null {
+): RemoteExecResolution {
   if (store && typeof payload.worktreeId === 'string') {
     const scope = parseWorkspaceKey(payload.worktreeId)
     if (scope?.type === 'folder') {
@@ -98,21 +104,22 @@ function resolveRemoteExecHost(
         // applies; fall back to the raw host. jcode resolves the host itself.
         const host = target?.configHost?.trim() || target?.host?.trim()
         if (host) {
-          return host
+          return { host, connectionId: workspace.connectionId }
         }
       }
     }
   }
-  return payload.remoteExecHost?.trim() || null
+  return { host: payload.remoteExecHost?.trim() || null, connectionId: null }
 }
 
-function startTurn(
+async function startTurn(
   mainWindow: BrowserWindow,
   store: Store | undefined,
   payload: JcodeChatSendPayload
-): void {
+): Promise<void> {
   const { sessionKey } = payload
-  const remoteExecHost = resolveRemoteExecHost(store, payload)
+  const remote = resolveRemoteExec(store, payload)
+  const remoteExecHost = remote.host
 
   // A fresh turn supersedes any pending Stop bookkeeping for this pane.
   stoppedKeys.delete(sessionKey)
@@ -127,9 +134,22 @@ function startTurn(
     }
   }
 
+  // Weave attachments into the prompt (copying local files to the remote host
+  // first for remote-exec sessions). Done before spawn so jcode sees the paths.
+  let resolvedPrompt: string
+  try {
+    resolvedPrompt = await resolveTurnPrompt(payload, remote)
+  } catch (error) {
+    sendEvent(mainWindow, sessionKey, {
+      type: 'error',
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return
+  }
+
   let child: ChildProcessWithoutNullStreams
   try {
-    child = spawn(JCODE_BIN, buildArgs(payload, remoteExecHost), {
+    child = spawn(JCODE_BIN, buildArgs(payload, remoteExecHost, resolvedPrompt), {
       cwd: payload.cwd?.trim() || undefined,
       env: process.env
     })
@@ -218,7 +238,31 @@ export function registerJcodeChatHandlers(mainWindow: BrowserWindow, store?: Sto
     if (!payload || typeof payload.sessionKey !== 'string' || typeof payload.prompt !== 'string') {
       return
     }
-    startTurn(mainWindow, store, payload)
+    // startTurn is async (it may copy attachments to a remote host before spawn);
+    // it reports its own failures as 'error' events, so swallow here.
+    void startTurn(mainWindow, store, payload).catch((error) => {
+      sendEvent(mainWindow, payload.sessionKey, {
+        type: 'error',
+        error: error instanceof Error ? error.message : String(error)
+      })
+    })
+  })
+
+  // Native multi-select file picker for composer attachments. Returns ABSOLUTE
+  // paths (empty array on cancel) so the renderer can show removable chips and
+  // the main process can read/copy the files at send time.
+  ipcMain.removeHandler(JCODE_CHAT_PICK_FILES_CHANNEL)
+  ipcMain.handle(JCODE_CHAT_PICK_FILES_CHANNEL, async (event) => {
+    if (event.sender !== mainWindow.webContents) {
+      return []
+    }
+    const result = await dialog.showOpenDialog(mainWindow, {
+      properties: ['openFile', 'multiSelections']
+    })
+    if (result.canceled) {
+      return []
+    }
+    return result.filePaths
   })
 
   // Stop: kill the in-flight child for a pane. The 'close' handler then emits a
@@ -307,6 +351,7 @@ export function registerJcodeChatHandlers(mainWindow: BrowserWindow, store?: Sto
     stoppedKeys.clear()
     ipcMain.removeAllListeners(JCODE_CHAT_SEND_CHANNEL)
     ipcMain.removeAllListeners(JCODE_CHAT_STOP_CHANNEL)
+    ipcMain.removeHandler(JCODE_CHAT_PICK_FILES_CHANNEL)
     ipcMain.removeHandler(JCODE_CHAT_SAVE_CHANNEL)
     ipcMain.removeHandler(JCODE_CHAT_LIST_CHANNEL)
     ipcMain.removeHandler(JCODE_CHAT_LOAD_CHANNEL)

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -8,7 +8,6 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import os from 'node:os'
 import { type BrowserWindow, dialog, ipcMain } from 'electron'
 import type { Store } from '../persistence'
-import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import {
   JCODE_CHAT_DELETE_CHANNEL,
   JCODE_CHAT_EVENT_CHANNEL,
@@ -29,7 +28,9 @@ import {
   loadConversation,
   saveConversation
 } from './jcode-conversation-store'
-import { resolveTurnPrompt, type RemoteExecResolution } from './jcode-attachments'
+import { resolveTurnPrompt } from './jcode-attachments'
+import { friendlyChildError } from './jcode-error-messages'
+import { resolveRemoteExec } from './jcode-remote-exec'
 import { applySkillInjection, registerJcodeSkillsHandler } from './jcode-skills'
 
 // Why: jcode is installed via cargo; the absolute path avoids depending on the
@@ -93,40 +94,6 @@ function buildArgs(
   }
   args.push('--ndjson', resolvedPrompt)
   return args
-}
-
-/** Resolve the brain-local (M3) remote-exec host for a chat turn.
- *  A jcode chat opened in ANY connectionId-remote folder workspace implies
- *  remote execution: jcode runs locally (local auth/model) but its bash/read
- *  tools execute on the remote host. So we emit --remote-exec whenever the
- *  worktree's folder workspace has an SSH connection — not only when the user
- *  manually toggled `isRemoteExecOnly`. (The folderPath of such a worktree is a
- *  REMOTE path that does not exist on the Mac, so running fully local would both
- *  crash the spawn and execute bash against a nonexistent local dir.)
- *  Falls back to the explicit `payload.remoteExecHost` override.
- *  Returns host null when this turn should run fully local (no --remote-exec). */
-function resolveRemoteExec(
-  store: Store | undefined,
-  payload: JcodeChatSendPayload
-): RemoteExecResolution {
-  if (store && typeof payload.worktreeId === 'string') {
-    const scope = parseWorkspaceKey(payload.worktreeId)
-    if (scope?.type === 'folder') {
-      const workspace = store.getFolderWorkspace(scope.folderWorkspaceId)
-      // Key off the SSH connection presence: any connectionId-remote worktree
-      // (whether or not isRemoteExecOnly was explicitly set) runs brain-local.
-      if (workspace?.connectionId) {
-        const target = store.getSshTarget(workspace.connectionId)
-        // Prefer the OpenSSH config alias so ~/.ssh/config (ProxyJump/identity)
-        // applies; fall back to the raw host. jcode resolves the host itself.
-        const host = target?.configHost?.trim() || target?.host?.trim()
-        if (host) {
-          return { host, connectionId: workspace.connectionId }
-        }
-      }
-    }
-  }
-  return { host: payload.remoteExecHost?.trim() || null, connectionId: null }
 }
 
 async function startTurn(
@@ -231,7 +198,10 @@ async function startTurn(
 
   child.on('error', (error: Error) => {
     activeChildren.delete(sessionKey)
-    sendEvent(mainWindow, sessionKey, { type: 'error', error: error.message })
+    sendEvent(mainWindow, sessionKey, {
+      type: 'error',
+      error: friendlyChildError(error.message, remoteExecHost)
+    })
   })
 
   child.on('close', (code: number | null) => {
@@ -250,10 +220,11 @@ async function startTurn(
       // User pressed Stop: a non-zero/kill exit is expected, not an error.
       sendEvent(mainWindow, sessionKey, { type: 'stopped' })
     } else if (code !== 0) {
+      const raw =
+        stderrBuffer.trim() || `jcode exited with code ${code === null ? 'null' : String(code)}`
       sendEvent(mainWindow, sessionKey, {
         type: 'error',
-        error:
-          stderrBuffer.trim() || `jcode exited with code ${code === null ? 'null' : String(code)}`
+        error: friendlyChildError(raw, remoteExecHost)
       })
     }
     // Always emit a terminal 'exit' so the renderer can finalize UI even when

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -28,7 +28,7 @@ import {
   loadConversation,
   saveConversation
 } from './jcode-conversation-store'
-import { resolveTurnPrompt } from './jcode-attachments'
+import { resolveTurnPrompt, extractImagePaths, nonImageAttachments } from './jcode-attachments'
 import { resolveJcodeBin } from './jcode-binary'
 import { friendlyChildError } from './jcode-error-messages'
 import { resolveRemoteExec } from './jcode-remote-exec'
@@ -53,7 +53,8 @@ function buildArgs(
   payload: JcodeChatSendPayload,
   remoteExecHost: string | null,
   resolvedPrompt: string,
-  remotePath: string | null
+  remotePath: string | null,
+  imagePaths: string[]
 ): string[] {
   // A named custom profile (from `jcode provider add`) is selected with
   // `--provider-profile <name>` (which IMPLIES openai-compatible) and MUST NOT
@@ -64,7 +65,9 @@ function buildArgs(
   if (profile) {
     args = ['run', '--provider-profile', profile]
   } else {
-    const provider = payload.provider?.trim() || 'openai'
+    // "auto" lets jcode resolve the best authed provider (matches the composer's
+    // "Auto" chip). A concrete id is passed only when the user picks one.
+    const provider = payload.provider?.trim() || 'auto'
     args = ['run', '-p', provider]
   }
   if (payload.model?.trim()) {
@@ -93,6 +96,11 @@ function buildArgs(
   if (remoteExecHost) {
     args.push('--remote-exec', remoteExecHost)
   }
+  // Vision: image attachments are read LOCALLY by jcode and sent as image content
+  // blocks. Options must precede the positional <MESSAGE>, so push before --ndjson.
+  for (const imagePath of imagePaths) {
+    args.push('--image', imagePath)
+  }
   args.push('--ndjson', resolvedPrompt)
   return args
 }
@@ -119,17 +127,33 @@ async function startTurn(
     }
   }
 
-  // Weave attachments into the prompt (copying local files to the remote host
-  // first for remote-exec sessions). Done before spawn so jcode sees the paths.
+  // Vision: pull out image attachments — they ride `--image` (read LOCALLY by
+  // jcode, even under --remote-exec) instead of being woven into the prompt or
+  // copied to the remote host. Everything else still gets woven.
+  const allAttachments = payload.attachments ?? []
+  const imagePaths = extractImagePaths(allAttachments)
+  const promptPayload =
+    imagePaths.length > 0
+      ? { ...payload, attachments: nonImageAttachments(allAttachments) }
+      : payload
+
+  // Weave (non-image) attachments into the prompt (copying local files to the
+  // remote host first for remote-exec sessions). Done before spawn.
   let resolvedPrompt: string
   try {
-    resolvedPrompt = await resolveTurnPrompt(payload, remote)
+    resolvedPrompt = await resolveTurnPrompt(promptPayload, remote)
   } catch (error) {
     sendEvent(mainWindow, sessionKey, {
       type: 'error',
       error: error instanceof Error ? error.message : String(error)
     })
     return
+  }
+
+  // If the user attached only image(s) with no typed text, give the model a
+  // default instruction so the positional message isn't empty.
+  if (imagePaths.length > 0 && !resolvedPrompt.trim()) {
+    resolvedPrompt = 'Describe the attached image(s).'
   }
 
   // FEATURE B: prepend a selected skill's SKILL.md body (re-discovered from cwd +
@@ -154,7 +178,7 @@ async function startTurn(
   try {
     child = spawn(
       resolveJcodeBin(),
-      buildArgs(payload, remoteExecHost, resolvedPrompt, remote.remotePath),
+      buildArgs(payload, remoteExecHost, resolvedPrompt, remote.remotePath, imagePaths),
       {
         cwd: localSpawnCwd,
         env: process.env

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -6,6 +6,8 @@
 // captured from the 'start'/'done' events on a previous turn.
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { type BrowserWindow, ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import {
   JCODE_CHAT_EVENT_CHANNEL,
   JCODE_CHAT_SEND_CHANNEL,
@@ -35,7 +37,7 @@ function sendEvent(mainWindow: BrowserWindow, sessionKey: string, event: JcodeNd
   mainWindow.webContents.send(JCODE_CHAT_EVENT_CHANNEL, { sessionKey, event })
 }
 
-function buildArgs(payload: JcodeChatSendPayload): string[] {
+function buildArgs(payload: JcodeChatSendPayload, remoteExecHost: string | null): string[] {
   const provider = payload.provider?.trim() || 'openai'
   const args = ['run', '-p', provider]
   if (payload.model?.trim()) {
@@ -47,17 +49,49 @@ function buildArgs(payload: JcodeChatSendPayload): string[] {
   if (payload.resumeSessionId?.trim()) {
     args.push('--resume', payload.resumeSessionId.trim())
   }
-  // brain-local (M3): unused until then, but wired so the chat path needs no
-  // further changes when remote-exec lands.
-  if (payload.remoteExecHost?.trim()) {
-    args.push('--remote-exec', payload.remoteExecHost.trim())
+  // brain-local / hands-remote (M3): jcode itself runs LOCALLY (local auth/model)
+  // — only bash executes on this remote host. The host is resolved authoritatively
+  // from the worktree's SSH target in the main process; see resolveRemoteExecHost.
+  if (remoteExecHost) {
+    args.push('--remote-exec', remoteExecHost)
   }
   args.push('--ndjson', payload.prompt)
   return args
 }
 
-function startTurn(mainWindow: BrowserWindow, payload: JcodeChatSendPayload): void {
+/** Resolve the brain-local (M3) remote-exec host for a chat turn.
+ *  Priority: the worktree's SSH target host when its folder workspace is
+ *  `isRemoteExecOnly`, else the explicit `payload.remoteExecHost` override.
+ *  Returns null when this turn should run fully local (no --remote-exec). */
+function resolveRemoteExecHost(
+  store: Store | undefined,
+  payload: JcodeChatSendPayload
+): string | null {
+  if (store && typeof payload.worktreeId === 'string') {
+    const scope = parseWorkspaceKey(payload.worktreeId)
+    if (scope?.type === 'folder') {
+      const workspace = store.getFolderWorkspace(scope.folderWorkspaceId)
+      if (workspace?.isRemoteExecOnly && workspace.connectionId) {
+        const target = store.getSshTarget(workspace.connectionId)
+        // Prefer the OpenSSH config alias so ~/.ssh/config (ProxyJump/identity)
+        // applies; fall back to the raw host. jcode resolves the host itself.
+        const host = target?.configHost?.trim() || target?.host?.trim()
+        if (host) {
+          return host
+        }
+      }
+    }
+  }
+  return payload.remoteExecHost?.trim() || null
+}
+
+function startTurn(
+  mainWindow: BrowserWindow,
+  store: Store | undefined,
+  payload: JcodeChatSendPayload
+): void {
   const { sessionKey } = payload
+  const remoteExecHost = resolveRemoteExecHost(store, payload)
 
   // A fresh turn supersedes any pending Stop bookkeeping for this pane.
   stoppedKeys.delete(sessionKey)
@@ -74,7 +108,7 @@ function startTurn(mainWindow: BrowserWindow, payload: JcodeChatSendPayload): vo
 
   let child: ChildProcessWithoutNullStreams
   try {
-    child = spawn(JCODE_BIN, buildArgs(payload), {
+    child = spawn(JCODE_BIN, buildArgs(payload, remoteExecHost), {
       cwd: payload.cwd?.trim() || undefined,
       env: process.env
     })
@@ -152,7 +186,7 @@ function startTurn(mainWindow: BrowserWindow, payload: JcodeChatSendPayload): vo
   })
 }
 
-export function registerJcodeChatHandlers(mainWindow: BrowserWindow): void {
+export function registerJcodeChatHandlers(mainWindow: BrowserWindow, store?: Store): void {
   // Re-registration safe (macOS window recreate): drop the previous listener.
   ipcMain.removeAllListeners(JCODE_CHAT_SEND_CHANNEL)
   ipcMain.on(JCODE_CHAT_SEND_CHANNEL, (event, raw: unknown) => {
@@ -163,7 +197,7 @@ export function registerJcodeChatHandlers(mainWindow: BrowserWindow): void {
     if (!payload || typeof payload.sessionKey !== 'string' || typeof payload.prompt !== 'string') {
       return
     }
-    startTurn(mainWindow, payload)
+    startTurn(mainWindow, store, payload)
   })
 
   // Stop: kill the in-flight child for a pane. The 'close' handler then emits a

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -1,9 +1,5 @@
-// Why: jcode's chat-bubble view (M1) needs CLEAN newline-delimited JSON on
-// stdout, so it is spawned with node child_process — NOT a PTY. A PTY would
-// inject terminal control sequences and line-wrapping that corrupt the JSON
-// stream. Each `jcode run ... --ndjson <prompt>` invocation is one-shot: it
-// emits NDJSON then exits. Conversations continue via --resume <sessionId>,
-// captured from the 'start'/'done' events on a previous turn.
+// Why: chat bubbles need clean NDJSON stdout, so jcode runs as child_process,
+// not a PTY. Each turn is one-shot; conversation continuity uses --resume.
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import os from 'node:os'
 import { type BrowserWindow, dialog, ipcMain } from 'electron'
@@ -28,7 +24,12 @@ import {
   loadConversation,
   saveConversation
 } from './jcode-conversation-store'
-import { resolveTurnPrompt, extractImagePaths, nonImageAttachments } from './jcode-attachments'
+import {
+  cleanupRemoteAttachmentDir,
+  resolveTurnPrompt,
+  extractImagePaths,
+  nonImageAttachments
+} from './jcode-attachments'
 import { resolveJcodeBin } from './jcode-binary'
 import { friendlyChildError } from './jcode-error-messages'
 import { resolveRemoteExec } from './jcode-remote-exec'
@@ -56,35 +57,21 @@ function buildArgs(
   remotePath: string | null,
   imagePaths: string[]
 ): string[] {
-  // A named custom profile (from `jcode provider add`) is selected with
-  // `--provider-profile <name>` (which IMPLIES openai-compatible) and MUST NOT
-  // also pass `-p`; doing both would be ambiguous. It takes precedence over the
-  // built-in `-p provider` path. `-m model` still overrides the profile default.
+  // Custom profiles imply openai-compatible; passing both profile and -p would
+  // be ambiguous. `-m model` still overrides the profile default.
   const profile = payload.providerProfile?.trim()
-  let args: string[]
-  if (profile) {
-    args = ['run', '--provider-profile', profile]
-  } else {
-    // "auto" lets jcode resolve the best authed provider (matches the composer's
-    // "Auto" chip). A concrete id is passed only when the user picks one.
-    const provider = payload.provider?.trim() || 'auto'
-    args = ['run', '-p', provider]
-  }
+  // "auto" matches the composer chip; concrete ids are used only when selected.
+  const args = profile
+    ? ['run', '--provider-profile', profile]
+    : ['run', '-p', payload.provider?.trim() || 'auto']
   if (payload.model?.trim()) {
     args.push('-m', payload.model.trim())
   }
-  // jcode's `-C/--cwd` behavior is now remote-exec-aware (startup.rs
-  // parse_and_prepare_args + run_single_message_command): under --remote-exec it
-  // does NOT chdir locally but instead seeds the session working_dir so the remote
-  // bash `cd`s into the project dir. So for a remote turn we pass -C <remotePath>
-  // (the worktree's remote folderPath from resolveRemoteExec) — the remote bash
-  // then runs in the project dir instead of the remote login home (~). For a local
-  // turn -C is the local project path as before.
-  if (remoteExecHost) {
-    if (remotePath?.trim()) {
-      args.push('-C', remotePath.trim())
-    }
-  } else if (payload.cwd?.trim()) {
+  // Under --remote-exec, -C seeds the remote session working_dir instead of
+  // chdiring locally. Local turns keep using the local project path.
+  if (remoteExecHost && remotePath?.trim()) {
+    args.push('-C', remotePath.trim())
+  } else if (!remoteExecHost && payload.cwd?.trim()) {
     args.push('-C', payload.cwd.trim())
   }
   if (payload.resumeSessionId?.trim()) {
@@ -98,9 +85,7 @@ function buildArgs(
   }
   // Vision: image attachments are read LOCALLY by jcode and sent as image content
   // blocks. Options must precede the positional <MESSAGE>, so push before --ndjson.
-  for (const imagePath of imagePaths) {
-    args.push('--image', imagePath)
-  }
+  args.push(...imagePaths.flatMap((imagePath) => ['--image', imagePath]))
   args.push('--ndjson', resolvedPrompt)
   return args
 }
@@ -137,11 +122,13 @@ async function startTurn(
       ? { ...payload, attachments: nonImageAttachments(allAttachments) }
       : payload
 
-  // Weave (non-image) attachments into the prompt (copying local files to the
-  // remote host first for remote-exec sessions). Done before spawn.
+  // Weave non-image attachments into the prompt; remote turns may upload files first.
   let resolvedPrompt: string
+  let attachmentCleanup: { connectionId: string; remoteDir: string } | null = null
   try {
-    resolvedPrompt = await resolveTurnPrompt(promptPayload, remote)
+    const turnPrompt = await resolveTurnPrompt(promptPayload, remote)
+    resolvedPrompt = turnPrompt.prompt
+    attachmentCleanup = turnPrompt.cleanup
   } catch (error) {
     sendEvent(mainWindow, sessionKey, {
       type: 'error',
@@ -156,8 +143,6 @@ async function startTurn(
     resolvedPrompt = 'Describe the attached image(s).'
   }
 
-  // FEATURE B: prepend a selected skill's SKILL.md body (re-discovered from cwd +
-  // worktreeId so remote skills resolve over SSH). Non-fatal if missing.
   resolvedPrompt = await applySkillInjection(
     payload.skillName,
     resolvedPrompt,
@@ -165,13 +150,8 @@ async function startTurn(
     store
   )
 
-  // The Node child_process `cwd` MUST be a directory that exists on THIS (local)
-  // machine — jcode itself always runs locally, even for brain-local turns. For a
-  // remote worktree payload.cwd is the REMOTE project path (e.g. /home/srain/...)
-  // which does not exist on the Mac; passing it to spawn() throws `spawn ENOENT`.
-  // So for remote turns we anchor the local process at the user's home dir; the
-  // remote bash working dir is governed by --remote-exec, not this cwd. Local
-  // turns continue to spawn in the worktree's (local) folder path.
+  // jcode runs locally even for brain-local turns, so remote worktrees must not
+  // become spawn cwd; --remote-exec owns the remote bash working directory.
   const localSpawnCwd = remoteExecHost ? os.homedir() : payload.cwd?.trim() || undefined
 
   let child: ChildProcessWithoutNullStreams
@@ -185,6 +165,7 @@ async function startTurn(
       }
     )
   } catch (error) {
+    void cleanupRemoteAttachmentDir(attachmentCleanup?.connectionId, attachmentCleanup?.remoteDir)
     sendEvent(mainWindow, sessionKey, {
       type: 'error',
       error: error instanceof Error ? error.message : String(error)
@@ -208,8 +189,7 @@ async function startTurn(
       stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1)
       if (line) {
         try {
-          const event = JSON.parse(line) as JcodeNdjsonEvent
-          sendEvent(mainWindow, sessionKey, event)
+          sendEvent(mainWindow, sessionKey, JSON.parse(line) as JcodeNdjsonEvent)
         } catch {
           // Why: non-JSON noise on stdout (banners, etc.) is forwarded as a
           // text_delta so it is visible rather than silently dropped.
@@ -259,6 +239,7 @@ async function startTurn(
     // Always emit a terminal 'exit' so the renderer can finalize UI even when
     // jcode forgot to emit a 'done' (e.g. crash mid-turn).
     sendEvent(mainWindow, sessionKey, { type: 'exit', code })
+    void cleanupRemoteAttachmentDir(attachmentCleanup?.connectionId, attachmentCleanup?.remoteDir)
   })
 }
 
@@ -322,12 +303,7 @@ export function registerJcodeChatHandlers(mainWindow: BrowserWindow, store?: Sto
     }
   })
 
-  // ─── Durable persistence (BUG 1/2) ──────────────────────────────────────
-  // The renderer reduces NDJSON events into full conversation state (messages +
-  // tool cards + --resume id) already, so the simplest faithful backing store is
-  // to let it send a snapshot on turn boundaries and persist that verbatim. This
-  // avoids re-deriving the tool-card shape in main and keeps tool/diff rendering
-  // identical after rehydrate.
+  // Renderer snapshots are already the conversation truth, including tool cards.
   ipcMain.removeHandler(JCODE_CHAT_SAVE_CHANNEL)
   ipcMain.handle(JCODE_CHAT_SAVE_CHANNEL, (event, raw: unknown) => {
     if (event.sender !== mainWindow.webContents) {

--- a/src/main/jcode/jcode-chat-session.ts
+++ b/src/main/jcode/jcode-chat-session.ts
@@ -49,8 +49,18 @@ function sendEvent(mainWindow: BrowserWindow, sessionKey: string, event: JcodeNd
 }
 
 function buildArgs(payload: JcodeChatSendPayload, remoteExecHost: string | null): string[] {
-  const provider = payload.provider?.trim() || 'openai'
-  const args = ['run', '-p', provider]
+  // A named custom profile (from `jcode provider add`) is selected with
+  // `--provider-profile <name>` (which IMPLIES openai-compatible) and MUST NOT
+  // also pass `-p`; doing both would be ambiguous. It takes precedence over the
+  // built-in `-p provider` path. `-m model` still overrides the profile default.
+  const profile = payload.providerProfile?.trim()
+  let args: string[]
+  if (profile) {
+    args = ['run', '--provider-profile', profile]
+  } else {
+    const provider = payload.provider?.trim() || 'openai'
+    args = ['run', '-p', provider]
+  }
   if (payload.model?.trim()) {
     args.push('-m', payload.model.trim())
   }

--- a/src/main/jcode/jcode-conversation-store.ts
+++ b/src/main/jcode/jcode-conversation-store.ts
@@ -1,0 +1,157 @@
+// Why (BUG 1, durable persistence): jcode chat conversations used to live only
+// in renderer memory (chat-session-store.ts) and the backend kept no transcript,
+// so conversations were lost on app restart, could not be listed, and a closed
+// chat tab could not be reopened. This module is the on-disk backing store in
+// the main process. It mirrors persistence.ts patterns: per-conversation JSON
+// under <userData>/jcode-conversations/<sessionKey>.json, written atomically via
+// a temp-file + rename so a crash mid-write never corrupts an existing record.
+//
+// The renderer remains the live layer (in-memory external store); it sends a
+// snapshot on turn boundaries (start + done/error/stopped) which we persist, and
+// reads back via list()/load() to rehydrate a (re)opened chat tab.
+import { app } from 'electron'
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { join } from 'node:path'
+import type {
+  JcodeConversationRecord,
+  JcodeConversationSummary
+} from '../../shared/jcode-chat-types'
+
+// Why: cap transcript size so a very long conversation cannot grow its JSON file
+// unboundedly. We keep the most recent N messages — older turns drop off. This
+// bounds disk + load cost while preserving recent --resume continuity context.
+const MAX_PERSISTED_MESSAGES = 2000
+
+let conversationsDir: string | null = null
+
+function getDir(): string {
+  if (!conversationsDir) {
+    conversationsDir = join(app.getPath('userData'), 'jcode-conversations')
+  }
+  if (!existsSync(conversationsDir)) {
+    mkdirSync(conversationsDir, { recursive: true })
+  }
+  return conversationsDir
+}
+
+// Why: sessionKeys are renderer-generated UUIDs/tab ids, but defend against any
+// path-traversal-shaped key reaching the filesystem by allowing only safe chars.
+function isSafeKey(sessionKey: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(sessionKey) && sessionKey !== '.' && sessionKey !== '..'
+}
+
+function fileFor(sessionKey: string): string | null {
+  if (!isSafeKey(sessionKey)) {
+    return null
+  }
+  return join(getDir(), `${sessionKey}.json`)
+}
+
+function clampRecord(record: JcodeConversationRecord): JcodeConversationRecord {
+  if (record.messages.length <= MAX_PERSISTED_MESSAGES) {
+    return record
+  }
+  return {
+    ...record,
+    messages: record.messages.slice(record.messages.length - MAX_PERSISTED_MESSAGES)
+  }
+}
+
+/** Persist (overwrite) a full conversation record atomically. Tolerates errors
+ *  (logs + returns false) so a disk hiccup never breaks the live chat turn. */
+export function saveConversation(record: JcodeConversationRecord): boolean {
+  const file = fileFor(record.sessionKey)
+  if (!file) {
+    return false
+  }
+  const tmpFile = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
+  try {
+    const toWrite = clampRecord({ ...record, updatedAt: record.updatedAt || Date.now() })
+    writeFileSync(tmpFile, JSON.stringify(toWrite, null, 2), 'utf-8')
+    renameSync(tmpFile, file)
+    return true
+  } catch (error) {
+    // Why: best-effort — a failed snapshot must not break the conversation.
+    console.error('[jcode-conversation-store] failed to save', record.sessionKey, error)
+    try {
+      if (existsSync(tmpFile)) {
+        unlinkSync(tmpFile)
+      }
+    } catch {
+      // ignore tmp cleanup failure
+    }
+    return false
+  }
+}
+
+/** Load one conversation record, or null if missing/corrupt. */
+export function loadConversation(sessionKey: string): JcodeConversationRecord | null {
+  const file = fileFor(sessionKey)
+  if (!file || !existsSync(file)) {
+    return null
+  }
+  try {
+    const raw = readFileSync(file, 'utf-8')
+    const parsed = JSON.parse(raw) as JcodeConversationRecord
+    if (typeof parsed?.sessionKey !== 'string' || !Array.isArray(parsed.messages)) {
+      return null
+    }
+    return parsed
+  } catch (error) {
+    console.error('[jcode-conversation-store] failed to load', sessionKey, error)
+    return null
+  }
+}
+
+/** List conversation summaries (no transcript body), newest first. */
+export function listConversations(): JcodeConversationSummary[] {
+  let entries: string[]
+  try {
+    entries = readdirSync(getDir())
+  } catch {
+    return []
+  }
+  const summaries: JcodeConversationSummary[] = []
+  for (const name of entries) {
+    if (!name.endsWith('.json')) {
+      continue
+    }
+    const record = loadConversation(name.slice(0, -'.json'.length))
+    if (!record) {
+      continue
+    }
+    summaries.push({
+      sessionKey: record.sessionKey,
+      worktreeId: record.worktreeId,
+      cwd: record.cwd,
+      title: record.title,
+      updatedAt: record.updatedAt,
+      resumeSessionId: record.resumeSessionId
+    })
+  }
+  summaries.sort((a, b) => b.updatedAt - a.updatedAt)
+  return summaries
+}
+
+/** Delete a conversation's on-disk record. Returns true if a file was removed. */
+export function deleteConversation(sessionKey: string): boolean {
+  const file = fileFor(sessionKey)
+  if (!file || !existsSync(file)) {
+    return false
+  }
+  try {
+    unlinkSync(file)
+    return true
+  } catch (error) {
+    console.error('[jcode-conversation-store] failed to delete', sessionKey, error)
+    return false
+  }
+}

--- a/src/main/jcode/jcode-error-messages.test.ts
+++ b/src/main/jcode/jcode-error-messages.test.ts
@@ -3,7 +3,7 @@ import { friendlyChildError } from './jcode-error-messages'
 
 describe('friendlyChildError', () => {
   it('maps jcode ENOENT to a "找不到 jcode" message keeping the raw detail', () => {
-    const msg = friendlyChildError('spawn /Users/vinny/.cargo/bin/jcode ENOENT', null)
+    const msg = friendlyChildError('spawn /tmp/orca-jcode-bin/jcode ENOENT', null)
     expect(msg).toContain('找不到 jcode 程序')
     expect(msg).toContain('ENOENT')
   })

--- a/src/main/jcode/jcode-error-messages.test.ts
+++ b/src/main/jcode/jcode-error-messages.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { friendlyChildError } from './jcode-error-messages'
+
+describe('friendlyChildError', () => {
+  it('maps jcode ENOENT to a "找不到 jcode" message keeping the raw detail', () => {
+    const msg = friendlyChildError('spawn /Users/vinny/.cargo/bin/jcode ENOENT', null)
+    expect(msg).toContain('找不到 jcode 程序')
+    expect(msg).toContain('ENOENT')
+  })
+
+  it('maps an SSH connection failure to a remote-host message naming the host', () => {
+    const msg = friendlyChildError(
+      'ssh: connect to host comfyui-host port 22: Connection refused',
+      'comfyui-host'
+    )
+    expect(msg).toContain('无法连接远程主机 comfyui-host')
+    expect(msg).toContain('Connection refused')
+  })
+
+  it('does NOT apply the remote-host mapping when there is no remote host', () => {
+    const msg = friendlyChildError('Connection refused', null)
+    expect(msg).toBe('Connection refused')
+  })
+
+  it('passes a generic non-zero-exit message through unchanged', () => {
+    expect(friendlyChildError('jcode exited with code 1', null)).toBe('jcode exited with code 1')
+  })
+
+  it('falls back to a generic message for empty input', () => {
+    expect(friendlyChildError('   ', null)).toBe('jcode 运行出错')
+  })
+})

--- a/src/main/jcode/jcode-error-messages.ts
+++ b/src/main/jcode/jcode-error-messages.ts
@@ -1,5 +1,5 @@
 // Why: when the jcode child errors or exits non-zero, the chat surfaces the raw
-// message (e.g. `spawn /Users/vinny/.cargo/bin/jcode ENOENT`) as a red bubble.
+// message (e.g. `spawn /tmp/orca-jcode-bin/jcode ENOENT`) as a red bubble.
 // For a non-technical user that is noise. This maps common failures to a plain-
 // language, actionable lead line (Chinese) while keeping the raw detail appended
 // in parentheses so a power user can still diagnose.
@@ -12,7 +12,7 @@
 export function friendlyChildError(raw: string, host: string | null): string {
   const detail = raw.trim()
   const lower = detail.toLowerCase()
-  // jcode binary missing on PATH / at the pinned cargo path.
+  // jcode binary missing on PATH or at the configured absolute path.
   if (lower.includes('enoent') && lower.includes('jcode')) {
     return `找不到 jcode 程序 — 请确认已安装 jcode（${detail}）`
   }

--- a/src/main/jcode/jcode-error-messages.ts
+++ b/src/main/jcode/jcode-error-messages.ts
@@ -1,0 +1,42 @@
+// Why: when the jcode child errors or exits non-zero, the chat surfaces the raw
+// message (e.g. `spawn /Users/vinny/.cargo/bin/jcode ENOENT`) as a red bubble.
+// For a non-technical user that is noise. This maps common failures to a plain-
+// language, actionable lead line (Chinese) while keeping the raw detail appended
+// in parentheses so a power user can still diagnose.
+
+/** Map a raw jcode/child-process failure to a plain-language, actionable message
+ *  for a non-technical user. Leads with the friendly Chinese line; keeps the raw
+ *  detail appended (in parentheses). `host` is the remote-exec host when this turn
+ *  ran brain-local, used to name the host in connection-failure messages (and to
+ *  avoid mislabeling a local failure as a remote one). */
+export function friendlyChildError(raw: string, host: string | null): string {
+  const detail = raw.trim()
+  const lower = detail.toLowerCase()
+  // jcode binary missing on PATH / at the pinned cargo path.
+  if (lower.includes('enoent') && lower.includes('jcode')) {
+    return `找不到 jcode 程序 — 请确认已安装 jcode（${detail}）`
+  }
+  // Remote host unreachable / SSH transport down (only meaningful for remote turns).
+  if (host && isRemoteConnectionFailure(lower)) {
+    return `无法连接远程主机 ${host} — 请检查 SSH 连接（${detail}）`
+  }
+  // Generic non-zero exit with no specific stderr signature.
+  return detail || 'jcode 运行出错'
+}
+
+/** Heuristic: does this (lowercased) stderr/error text look like an SSH/remote
+ *  connection failure rather than an in-agent error? */
+function isRemoteConnectionFailure(lower: string): boolean {
+  return (
+    lower.includes('connection refused') ||
+    lower.includes('connection reset') ||
+    lower.includes('connection closed') ||
+    lower.includes('timed out') ||
+    lower.includes('timeout') ||
+    lower.includes('no route to host') ||
+    lower.includes('could not resolve') ||
+    lower.includes('host key') ||
+    lower.includes('permission denied') ||
+    lower.includes('ssh')
+  )
+}

--- a/src/main/jcode/jcode-remote-exec.test.ts
+++ b/src/main/jcode/jcode-remote-exec.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import type { Store } from '../persistence'
+import type { JcodeChatSendPayload } from '../../shared/jcode-chat-types'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import { resolveRemoteExec } from './jcode-remote-exec'
+
+/** Minimal Store stub: only the lookups resolveRemoteExec touches. */
+function makeStore(overrides: Partial<Record<keyof Store, unknown>>): Store {
+  return {
+    getFolderWorkspace: () => undefined,
+    getRepo: () => undefined,
+    getSshTarget: () => undefined,
+    ...overrides
+  } as unknown as Store
+}
+
+function payload(extra: Partial<JcodeChatSendPayload>): JcodeChatSendPayload {
+  return { sessionKey: 's', prompt: 'p', ...extra } as JcodeChatSendPayload
+}
+
+describe('resolveRemoteExec', () => {
+  it('resolves a GIT worktree (raw repoId::path id) to host + connection + remote path', () => {
+    const store = makeStore({
+      getRepo: (id: string) =>
+        id === 'repo-1' ? { id: 'repo-1', connectionId: 'conn-1' } : undefined,
+      getSshTarget: (id: string) =>
+        id === 'conn-1' ? { configHost: 'comfyui-host', host: '10.0.0.5' } : undefined
+    })
+    const result = resolveRemoteExec(store, payload({ worktreeId: 'repo-1::/home/srain/ComfyUI' }))
+    expect(result).toEqual({
+      host: 'comfyui-host',
+      connectionId: 'conn-1',
+      remotePath: '/home/srain/ComfyUI'
+    })
+  })
+
+  it('resolves a worktree:-prefixed git worktree key the same way', () => {
+    const store = makeStore({
+      getRepo: () => ({ id: 'repo-1', connectionId: 'conn-1' }),
+      getSshTarget: () => ({ host: '10.0.0.5' })
+    })
+    const result = resolveRemoteExec(
+      store,
+      payload({ worktreeId: worktreeWorkspaceKey('repo-1::/home/srain/ComfyUI') })
+    )
+    expect(result.host).toBe('10.0.0.5')
+    expect(result.connectionId).toBe('conn-1')
+    expect(result.remotePath).toBe('/home/srain/ComfyUI')
+  })
+
+  it('still resolves a remote FOLDER workspace via folderPath', () => {
+    const store = makeStore({
+      getFolderWorkspace: (id: string) =>
+        id === 'fw-1' ? { connectionId: 'conn-2', folderPath: '/srv/proj' } : undefined,
+      getSshTarget: () => ({ configHost: 'folder-host' })
+    })
+    const result = resolveRemoteExec(store, payload({ worktreeId: folderWorkspaceKey('fw-1') }))
+    expect(result).toEqual({
+      host: 'folder-host',
+      connectionId: 'conn-2',
+      remotePath: '/srv/proj'
+    })
+  })
+
+  it('returns local (host null) for a git worktree whose repo has no connection', () => {
+    const store = makeStore({ getRepo: () => ({ id: 'repo-1', connectionId: null }) })
+    const result = resolveRemoteExec(store, payload({ worktreeId: 'repo-1::/Users/me/proj' }))
+    expect(result).toEqual({ host: null, connectionId: null, remotePath: null })
+  })
+
+  it('falls back to payload.cwd for the remote path when the worktree path is empty', () => {
+    const store = makeStore({
+      getRepo: () => ({ id: 'repo-1', connectionId: 'conn-1' }),
+      getSshTarget: () => ({ host: 'h' })
+    })
+    // No `::` separator → no path segment; cwd carries the remote path.
+    const result = resolveRemoteExec(
+      store,
+      payload({ worktreeId: 'repo-1', cwd: '/remote/from/cwd' })
+    )
+    expect(result.remotePath).toBe('/remote/from/cwd')
+  })
+
+  it('honors the explicit remoteExecHost override with no store binding', () => {
+    const result = resolveRemoteExec(undefined, payload({ remoteExecHost: 'adhoc-host' }))
+    expect(result).toEqual({ host: 'adhoc-host', connectionId: null, remotePath: null })
+  })
+})

--- a/src/main/jcode/jcode-remote-exec.ts
+++ b/src/main/jcode/jcode-remote-exec.ts
@@ -1,0 +1,77 @@
+// brain-local / hands-remote (M3) host resolution for a jcode chat turn.
+// A jcode chat opened in ANY connectionId-remote workspace implies remote
+// execution: jcode itself runs LOCALLY (local auth/model) but its bash/read tools
+// execute on the remote host via `--remote-exec <host>`. We therefore emit
+// --remote-exec whenever the workspace is bound to an SSH connection — not only
+// when the user manually toggled `isRemoteExecOnly`. (The folderPath / worktree
+// path of such a workspace is a REMOTE path that does not exist on the Mac, so
+// running fully local would both crash the spawn and execute bash against a
+// nonexistent local dir.)
+import type { Store } from '../persistence'
+import { parseWorkspaceKey } from '../../shared/workspace-scope'
+import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
+import type { JcodeChatSendPayload } from '../../shared/jcode-chat-types'
+import type { RemoteExecResolution } from './jcode-attachments'
+
+/** Resolve the SSH host string for a connection, preferring the OpenSSH config
+ *  alias so ~/.ssh/config (ProxyJump/identity) applies; falls back to the raw
+ *  host. jcode resolves the host itself. Returns null when no usable host. */
+function resolveSshHost(store: Store, connectionId: string): string | null {
+  const target = store.getSshTarget(connectionId)
+  return target?.configHost?.trim() || target?.host?.trim() || null
+}
+
+/** Resolve the SSH connectionId + remote working dir for the workspace this chat
+ *  turn is bound to, or null when it is local / unresolvable. Handles both shapes
+ *  flowing through `payload.worktreeId`:
+ *   - FOLDER workspaces — id is a `folder:<id>` workspace key; remote path is the
+ *     FolderWorkspace.folderPath.
+ *   - GIT worktrees (project "类型: Git") — id is the RAW `${repoId}::${path}`
+ *     worktree id (NOT `worktree:`-prefixed). The connectionId lives on the owning
+ *     Repo; the worktree's path segment IS the remote working dir. Without this
+ *     branch a remote git project resolved host=null and the turn ran LOCAL with
+ *     cwd = the remote path → `spawn ... ENOENT`. */
+function resolveWorkspaceConnection(
+  store: Store,
+  worktreeId: string,
+  payloadCwd: string | undefined
+): { connectionId: string; remotePath: string | null } | null {
+  const scope = parseWorkspaceKey(worktreeId)
+  if (scope?.type === 'folder') {
+    const workspace = store.getFolderWorkspace(scope.folderWorkspaceId)
+    return workspace?.connectionId
+      ? { connectionId: workspace.connectionId, remotePath: workspace.folderPath?.trim() || null }
+      : null
+  }
+  const rawWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
+  const repoId = getRepoIdFromWorktreeId(rawWorktreeId)
+  const repo = repoId ? store.getRepo(repoId) : undefined
+  if (!repo?.connectionId) {
+    return null
+  }
+  // payloadCwd carries the worktree's remote path from the renderer; the
+  // worktree-id path segment is the authoritative fallback.
+  const remotePath =
+    splitWorktreeIdForFilesystem(rawWorktreeId)?.worktreePath?.trim() || payloadCwd?.trim() || null
+  return { connectionId: repo.connectionId, remotePath }
+}
+
+/** Resolve the brain-local remote-exec target for a chat turn. Returns host null
+ *  (and connectionId/remotePath null) when the turn should run fully local.
+ *  Falls back to the explicit `payload.remoteExecHost` override. */
+export function resolveRemoteExec(
+  store: Store | undefined,
+  payload: JcodeChatSendPayload
+): RemoteExecResolution {
+  const bound =
+    store && typeof payload.worktreeId === 'string' && payload.worktreeId.length > 0
+      ? resolveWorkspaceConnection(store, payload.worktreeId, payload.cwd)
+      : null
+  if (bound) {
+    const host = resolveSshHost(store!, bound.connectionId)
+    if (host) {
+      return { host, connectionId: bound.connectionId, remotePath: bound.remotePath }
+    }
+  }
+  return { host: payload.remoteExecHost?.trim() || null, connectionId: null, remotePath: null }
+}

--- a/src/main/jcode/jcode-skills.ts
+++ b/src/main/jcode/jcode-skills.ts
@@ -25,7 +25,7 @@ import {
   type JcodeSkillsListPayload,
   type JcodeSkillsListResult
 } from '../../shared/jcode-chat-types'
-import { getLiveSshConnection, runRemoteCapture, type SshConnection } from './jcode-attachments'
+import { getLiveSshConnection, runRemoteCapture, type SshConnection } from './jcode-ssh-command'
 
 /** Split a SKILL.md into its YAML frontmatter object + instruction body. A file
  *  with no leading `---` frontmatter yields empty frontmatter and the whole text

--- a/src/main/jcode/jcode-skills.ts
+++ b/src/main/jcode/jcode-skills.ts
@@ -1,0 +1,337 @@
+// FEATURE B: discover + parse SKILL.md files so the jcode chat "/" menu can list
+// real skills for the current project (like Claude Code's "/"). jcode headless
+// has NO native skill loader — skills are just SKILL.md files (YAML frontmatter
+// `name` + `description`/`when_to_use`, body = instructions). We scan three
+// source classes, parse each, and on select inject the body into the prompt.
+//
+//   1. project-local  <projectRoot>/.claude/skills/<name>/SKILL.md
+//   2. global         ~/.claude/skills/<name>/SKILL.md  (mostly symlinks)
+//   3. plugin         <installPath>/skills/<name>/SKILL.md  (namespaced plugin:skill)
+//
+// For a REMOTE worktree the project-local skills live on the SSH host, so we read
+// them over the same connection used for attachments; on failure we skip them and
+// flag `degraded` so only global + plugin skills are returned.
+import { readFile, readdir, stat } from 'node:fs/promises'
+import os from 'node:os'
+import { join } from 'node:path'
+import { type BrowserWindow, ipcMain } from 'electron'
+import { parse as parseYaml } from 'yaml'
+import { parseWorkspaceKey } from '../../shared/workspace-scope'
+import type { Store } from '../persistence'
+import {
+  JCODE_SKILLS_LIST_CHANNEL,
+  type JcodeSkill,
+  type JcodeSkillSource,
+  type JcodeSkillsListPayload,
+  type JcodeSkillsListResult
+} from '../../shared/jcode-chat-types'
+import { getLiveSshConnection, runRemoteCapture, type SshConnection } from './jcode-attachments'
+
+/** Split a SKILL.md into its YAML frontmatter object + instruction body. A file
+ *  with no leading `---` frontmatter yields empty frontmatter and the whole text
+ *  as the body. Tolerates a missing closing fence by treating the rest as body. */
+function parseSkillFile(
+  content: string,
+  dirName: string
+): { name: string; description: string; body: string } {
+  let frontmatter: Record<string, unknown> = {}
+  let body = content
+  if (content.startsWith('---')) {
+    // First line is `---`; find the closing `---` on its own line.
+    const closeMatch = content.match(/\n---[ \t]*(\r?\n|$)/)
+    if (closeMatch && typeof closeMatch.index === 'number') {
+      const yamlText = content.slice(3, closeMatch.index)
+      body = content.slice(closeMatch.index + closeMatch[0].length)
+      try {
+        const parsed = parseYaml(yamlText)
+        if (parsed && typeof parsed === 'object') {
+          frontmatter = parsed as Record<string, unknown>
+        }
+      } catch {
+        // Malformed frontmatter: fall back to the directory name + empty desc.
+      }
+    }
+  }
+  const name = asString(frontmatter.name) || dirName
+  const description = asString(frontmatter.description) || asString(frontmatter.when_to_use) || ''
+  return { name, description: collapse(description), body: body.trim() }
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+/** Collapse internal whitespace/newlines to single spaces for a one-line menu
+ *  hint. The full multi-paragraph description would blow up the popover. */
+function collapse(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+/** Read + parse one local SKILL.md, returning a JcodeSkill or null if unreadable. */
+async function readLocalSkill(
+  skillDir: string,
+  dirName: string,
+  source: JcodeSkillSource,
+  pluginId?: string
+): Promise<JcodeSkill | null> {
+  try {
+    const content = await readFile(join(skillDir, 'SKILL.md'), 'utf8')
+    const { name, description, body } = parseSkillFile(content, dirName)
+    return { name, description, body, source, ...(pluginId ? { pluginId } : {}) }
+  } catch {
+    return null
+  }
+}
+
+/** Enumerate `<root>/<name>/SKILL.md` skills under a local skills root. Follows
+ *  symlinks (the global ~/.claude/skills entries are mostly symlinks). Returns []
+ *  when the root doesn't exist. */
+async function scanLocalSkillsRoot(
+  root: string,
+  source: JcodeSkillSource,
+  pluginId?: string
+): Promise<JcodeSkill[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(root)
+  } catch {
+    return []
+  }
+  const skills = await Promise.all(
+    entries.map(async (entry) => {
+      const skillDir = join(root, entry)
+      try {
+        // stat (not lstat) so symlinked skill dirs are followed.
+        const info = await stat(skillDir)
+        if (!info.isDirectory()) {
+          return null
+        }
+      } catch {
+        return null
+      }
+      return readLocalSkill(skillDir, entry, source, pluginId)
+    })
+  )
+  return skills.filter((s): s is JcodeSkill => s !== null)
+}
+
+/** Plugin skill dirs from ~/.claude/plugins/installed_plugins.json. Each plugin
+ *  may expose `<installPath>/skills/<name>/SKILL.md`; names are namespaced as
+ *  `plugin:skill` (mirroring Claude Code) to avoid collisions across plugins. */
+async function scanPluginSkills(home: string): Promise<JcodeSkill[]> {
+  let manifest: unknown
+  try {
+    const raw = await readFile(join(home, '.claude/plugins/installed_plugins.json'), 'utf8')
+    manifest = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  const plugins = (manifest as { plugins?: Record<string, unknown> })?.plugins
+  if (!plugins || typeof plugins !== 'object') {
+    return []
+  }
+  const out: JcodeSkill[] = []
+  for (const [pluginId, installs] of Object.entries(plugins)) {
+    if (!Array.isArray(installs)) {
+      continue
+    }
+    // A plugin can have multiple installs; the first with a skills/ dir wins.
+    for (const install of installs) {
+      const installPath = (install as { installPath?: unknown })?.installPath
+      if (typeof installPath !== 'string') {
+        continue
+      }
+      const skills = await scanLocalSkillsRoot(join(installPath, 'skills'), 'plugin', pluginId)
+      if (skills.length > 0) {
+        // Namespace as plugin:skill. The plugin id is `name@marketplace`; use the
+        // leading name segment for a compact, Claude-Code-like prefix.
+        const prefix = pluginId.split('@')[0]
+        for (const skill of skills) {
+          out.push({ ...skill, name: `${prefix}:${skill.name}` })
+        }
+        break
+      }
+    }
+  }
+  return out
+}
+
+/** Read remote project-local `.claude/skills` over an SSH connection. Lists the
+ *  skill dirs, then cats each SKILL.md, parsing the same way as local skills.
+ *  Returns null when the directory can't be listed (no skills / unreadable). */
+async function scanRemoteProjectSkills(
+  conn: SshConnection,
+  projectRoot: string
+): Promise<JcodeSkill[] | null> {
+  const root = `${projectRoot.replace(/\/+$/, '')}/.claude/skills`
+  // List immediate subdirectories (skill names). -1p marks dirs with a trailing /.
+  const listing = await runRemoteCapture(conn, `command ls -1Ap ${shellQuote(root)} 2>/dev/null`)
+  if (listing === null) {
+    return null
+  }
+  const dirNames = listing
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith('/') && line !== './' && line !== '../')
+    .map((line) => line.slice(0, -1))
+  const skills: JcodeSkill[] = []
+  for (const dirName of dirNames) {
+    const filePath = `${root}/${dirName}/SKILL.md`
+    const content = await runRemoteCapture(conn, `cat ${shellQuote(filePath)} 2>/dev/null`)
+    if (content === null) {
+      continue
+    }
+    const { name, description, body } = parseSkillFile(content, dirName)
+    skills.push({ name, description, body, source: 'project' })
+  }
+  return skills
+}
+
+/** POSIX single-quote escaping for a path argument in a remote command. */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+/** Resolve a remote project's SSH connection + remote root from the worktree id,
+ *  mirroring resolveRemoteExec in jcode-chat-session. Returns null for a local
+ *  worktree (or when the workspace has no SSH connection). */
+function resolveRemoteProject(
+  store: Store | undefined,
+  worktreeId: string | undefined
+): { connectionId: string } | null {
+  if (!store || typeof worktreeId !== 'string') {
+    return null
+  }
+  const scope = parseWorkspaceKey(worktreeId)
+  if (scope?.type !== 'folder') {
+    return null
+  }
+  const workspace = store.getFolderWorkspace(scope.folderWorkspaceId)
+  if (workspace?.connectionId) {
+    return { connectionId: workspace.connectionId }
+  }
+  return null
+}
+
+/** De-dupe skills by name with precedence project > global > plugin: an earlier
+ *  source wins, so a project skill shadows a global one of the same name. */
+function dedupeByName(groups: JcodeSkill[][]): JcodeSkill[] {
+  const seen = new Set<string>()
+  const out: JcodeSkill[] = []
+  for (const group of groups) {
+    for (const skill of group) {
+      if (seen.has(skill.name)) {
+        continue
+      }
+      seen.add(skill.name)
+      out.push(skill)
+    }
+  }
+  return out
+}
+
+/** Discover all skills available to the current chat pane. For a LOCAL worktree
+ *  this scans <cwd>/.claude/skills + ~/.claude/skills + plugin skills. For a
+ *  REMOTE worktree the project-local skills are read over SSH; if that fails the
+ *  result is flagged `degraded` and only global + plugin skills are returned. */
+export async function discoverSkills(
+  payload: JcodeSkillsListPayload,
+  store?: Store
+): Promise<JcodeSkillsListResult> {
+  const home = os.homedir()
+  const cwd = payload.cwd?.trim()
+  const remote = resolveRemoteProject(store, payload.worktreeId)
+
+  // Global + plugin skills are always local to this machine.
+  const [globalSkills, pluginSkills] = await Promise.all([
+    scanLocalSkillsRoot(join(home, '.claude/skills'), 'global'),
+    scanPluginSkills(home)
+  ])
+
+  let projectSkills: JcodeSkill[] = []
+  let degraded = false
+  if (remote) {
+    // Remote worktree: read project-local skills over the live SSH connection.
+    const conn = getLiveSshConnection(remote.connectionId)
+    if (conn && cwd) {
+      const remoteSkills = await scanRemoteProjectSkills(conn, cwd)
+      if (remoteSkills === null) {
+        degraded = true
+      } else {
+        projectSkills = remoteSkills
+      }
+    } else {
+      // No live connection (or no cwd) — project-local skills are unavailable.
+      degraded = true
+    }
+  } else if (cwd) {
+    // Local worktree: scan the project root's .claude/skills.
+    projectSkills = await scanLocalSkillsRoot(join(cwd, '.claude/skills'), 'project')
+  }
+
+  const skills = dedupeByName([projectSkills, globalSkills, pluginSkills])
+  return { skills, ...(degraded ? { degraded: true } : {}) }
+}
+
+/** Look up a single skill's injectable body by name for the current pane. Used at
+ *  send time to prepend the SKILL.md instructions to the prompt. Returns null if
+ *  the named skill can't be found. */
+export async function findSkillForInjection(
+  skillName: string,
+  payload: JcodeSkillsListPayload,
+  store?: Store
+): Promise<JcodeSkill | null> {
+  const { skills } = await discoverSkills(payload, store)
+  return skills.find((s) => s.name === skillName) ?? null
+}
+
+/** Build the prompt-injection block for a selected skill, prepended ahead of the
+ *  user's message so the headless model follows the skill's instructions. */
+export function buildSkillInjection(skill: JcodeSkill, userPrompt: string): string {
+  const block = `Use the "${skill.name}" skill. Follow these instructions:\n\n${skill.body}`
+  const base = userPrompt.trim()
+  return `${block}\n\n---\n\n${base}`
+}
+
+/** Register the FEATURE B skills-list IPC handler (and its cleanup on window
+ *  close). Kept here so the handler + its discovery logic live together and the
+ *  chat-session module stays under budget. Safe to call on window recreate. */
+export function registerJcodeSkillsHandler(mainWindow: BrowserWindow, store?: Store): void {
+  ipcMain.removeHandler(JCODE_SKILLS_LIST_CHANNEL)
+  ipcMain.handle(JCODE_SKILLS_LIST_CHANNEL, (event, raw: unknown) => {
+    if (event.sender !== mainWindow.webContents) {
+      return { skills: [] }
+    }
+    const payload = (raw ?? {}) as JcodeSkillsListPayload
+    return discoverSkills({ cwd: payload.cwd, worktreeId: payload.worktreeId }, store)
+  })
+  mainWindow.on('closed', () => {
+    ipcMain.removeHandler(JCODE_SKILLS_LIST_CHANNEL)
+  })
+}
+
+/** Resolve the selected skill (if any) and PREPEND its SKILL.md body to the
+ *  prompt. Re-discovers the skill from cwd + worktreeId so remote-project skills
+ *  resolve over SSH. A missing/un-named skill is non-fatal: the prompt is
+ *  returned unchanged so the turn still proceeds. */
+export async function applySkillInjection(
+  skillName: string | undefined,
+  resolvedPrompt: string,
+  context: { cwd?: string; worktreeId?: string },
+  store?: Store
+): Promise<string> {
+  const name = skillName?.trim()
+  if (!name) {
+    return resolvedPrompt
+  }
+  try {
+    const skill = await findSkillForInjection(
+      name,
+      { cwd: context.cwd, worktreeId: context.worktreeId },
+      store
+    )
+    return skill ? buildSkillInjection(skill, resolvedPrompt) : resolvedPrompt
+  } catch {
+    return resolvedPrompt
+  }
+}

--- a/src/main/jcode/jcode-ssh-command.ts
+++ b/src/main/jcode/jcode-ssh-command.ts
@@ -1,0 +1,102 @@
+import { getSshConnectionManager } from '../ipc/ssh'
+
+/** A live SSH connection object returned by the connection manager. */
+export type SshConnection = NonNullable<
+  ReturnType<NonNullable<ReturnType<typeof getSshConnectionManager>>['getConnection']>
+>
+
+/** Minimal single-quote shell escaping for a POSIX path argument. */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+/** Resolve a live, connected SSH connection by id, or null. */
+export function getLiveSshConnection(connectionId: string): SshConnection | null {
+  const conn = getSshConnectionManager()?.getConnection(connectionId)
+  if (!conn || conn.getState().status !== 'connected') {
+    return null
+  }
+  return conn
+}
+
+/** Run a remote command over SSH and require a zero exit status. */
+export function runRemoteCommand(conn: SshConnection, command: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    conn
+      .exec(command)
+      .then((channel) => {
+        let exitCode: number | null = null
+        let stderr = ''
+        let settled = false
+        const finish = (error?: Error): void => {
+          if (settled) {
+            return
+          }
+          settled = true
+          if (error) {
+            reject(error)
+          } else {
+            resolve()
+          }
+        }
+        channel.on('exit', (code: number | null) => {
+          exitCode = code
+        })
+        channel.on('close', () => {
+          if (exitCode === 0) {
+            finish()
+            return
+          }
+          const suffix = exitCode === null ? 'without an exit code' : `with exit code ${exitCode}`
+          const detail = stderr.trim() ? `: ${stderr.trim()}` : ''
+          finish(new Error(`Remote command failed ${suffix}${detail}`))
+        })
+        channel.on('error', (err: Error) => finish(err))
+        // Drain so the channel can close.
+        channel.on('data', () => {})
+        channel.stderr?.on('data', (data: Buffer | string) => {
+          stderr += data.toString()
+        })
+      })
+      .catch(reject)
+  })
+}
+
+/** Run a remote command over SSH and capture stdout. */
+export function runRemoteCapture(conn: SshConnection, command: string): Promise<string | null> {
+  const TIMEOUT_MS = 10_000
+  return new Promise((resolve) => {
+    conn
+      .exec(command)
+      .then((channel) => {
+        let stdout = ''
+        let exitCode: number | null = null
+        let settled = false
+        const finish = (value: string | null): void => {
+          if (settled) {
+            return
+          }
+          settled = true
+          if (timer) {
+            clearTimeout(timer)
+          }
+          resolve(value)
+        }
+        const timer = setTimeout(() => finish(null), TIMEOUT_MS)
+        if (typeof timer.unref === 'function') {
+          timer.unref()
+        }
+        channel.on('data', (data: Buffer) => {
+          stdout += data.toString()
+        })
+        channel.stderr?.on('data', () => {})
+        channel.on('exit', (code: number | null) => {
+          exitCode = code
+        })
+        channel.on('close', () => finish(exitCode === 0 ? stdout : null))
+        channel.on('error', () => finish(null))
+        channel.stderr?.on('error', () => {})
+      })
+      .catch(() => resolve(null))
+  })
+}

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3573,6 +3573,12 @@ export class Store {
     if (updates.lastActivityAt !== undefined && Number.isFinite(updates.lastActivityAt)) {
       workspace.lastActivityAt = updates.lastActivityAt
     }
+    if (updates.connectionId !== undefined) {
+      workspace.connectionId = updates.connectionId
+    }
+    if (updates.isRemoteExecOnly !== undefined) {
+      workspace.isRemoteExecOnly = updates.isRemoteExecOnly
+    }
     workspace.updatedAt = Date.now()
     this.scheduleSave()
     return workspace

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3518,6 +3518,8 @@ export class Store {
         | 'pendingFirstAgentMessageRename'
         | 'firstAgentMessageRenameError'
         | 'lastActivityAt'
+        | 'connectionId'
+        | 'isRemoteExecOnly'
       >
     >
   ): FolderWorkspace | null {

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// jcode fork: re-enable the production-disabled updater for this dormant-logic
+// test suite (see DISABLE_AUTO_UPDATE in updater.ts). Must precede any import.
+process.env.JCODE_ENABLE_AUTO_UPDATE = '1'
+
 const { appMock, browserWindowMock, nativeUpdaterMock, autoUpdaterMock, isMock, killAllPtyMock } =
   vi.hoisted(() => {
     const appEventHandlers = new Map<string, ((...args: unknown[]) => void)[]>()

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// jcode fork: re-enable the production-disabled updater for this dormant-logic
+// test suite (see DISABLE_AUTO_UPDATE in updater.ts). Must precede any import.
+process.env.JCODE_ENABLE_AUTO_UPDATE = '1'
+
 const {
   appMock,
   browserWindowMock,

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1,6 +1,13 @@
 /* eslint-disable max-lines */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// jcode fork: the updater is HARD-DISABLED in production (see DISABLE_AUTO_UPDATE
+// in updater.ts) so the app can never self-update to upstream orca. These tests
+// validate the dormant upstream updater logic, so re-enable it for this suite via
+// the test-only env override. Set before any `await import('./updater')` so the
+// module-eval-time read sees it (vi.resetModules re-reads it each beforeEach).
+process.env.JCODE_ENABLE_AUTO_UPDATE = '1'
+
 const {
   appMock,
   browserWindowMock,

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -30,6 +30,21 @@ type CheckFailureSource = 'event' | 'promise' | 'fallback-promise'
 type MissingManifestPrereleaseFallbackResult = { userInitiated: boolean }
 type PrimaryEventSuppression = { failureKey: string; error: unknown }
 
+// jcode fork: HARD-DISABLE the auto-updater.
+// Why: this is a custom fork (jcode integration). The packaged app's release
+// feed points at upstream orca (github.com/stablyai/orca/releases). If the
+// updater ran, it would download + install an upstream orca build, REPLACING
+// the jcode fork entirely (losing all jcode functionality). That is
+// unacceptable. We early-return from every check entry point so no upstream
+// release is ever fetched, prompted, downloaded, or installed. This is a
+// single clean guard; flip to false only if this fork is ever published to its
+// own release feed.
+//
+// The env override (JCODE_ENABLE_AUTO_UPDATE=1) exists ONLY so the upstream
+// updater unit-test suite can still exercise the (now-dormant) updater logic;
+// it is never set in production, so the packaged jcode app is always disabled.
+const DISABLE_AUTO_UPDATE = process.env.JCODE_ENABLE_AUTO_UPDATE !== '1'
+
 const AUTO_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
 const AUTO_UPDATE_RETRY_INTERVAL_MS = 60 * 60 * 1000
 const NUDGE_POLL_INTERVAL_MS = 30 * 60 * 1000
@@ -716,6 +731,10 @@ export function checkForUpdates(): void {
   // attribute makes the always-success semantics explicit and queryable
   // (so a dashboard tile can't accidentally treat this span's success rate
   // as the actual update-check success rate).
+  // jcode fork: programmatic check entry point is also disabled.
+  if (DISABLE_AUTO_UPDATE) {
+    return
+  }
   void withUpdaterSpan({ stage: 'check' }, async (span) => {
     span.setAttribute('updater.outcome', 'launched')
     runBackgroundUpdateCheck()
@@ -736,6 +755,12 @@ function enableIncludePrerelease(): void {
 
 /** Menu-triggered check — delegates feedback to renderer toasts via userInitiated flag */
 export function checkForUpdatesFromMenu(options?: { includePrerelease?: boolean }): void {
+  // jcode fork: a manual "Check for Updates" click must also do nothing, so the
+  // menu/Settings/IPC paths can never pull an upstream orca release.
+  if (DISABLE_AUTO_UPDATE) {
+    sendStatus({ state: 'not-available', userInitiated: true })
+    return
+  }
   if (!app.isPackaged || is.dev) {
     sendStatus({ state: 'not-available', userInitiated: true })
     return
@@ -889,6 +914,15 @@ export function setupAutoUpdater(
   _getDismissedUpdateNudgeId = opts?.getDismissedUpdateNudgeId ?? null
   _setPendingUpdateNudgeId = opts?.setPendingUpdateNudgeId ?? null
   _setDismissedUpdateNudgeId = opts?.setDismissedUpdateNudgeId ?? null
+
+  // jcode fork: never wire up checks/nudges/scheduled-timers/event-handlers.
+  // Returning here means we never call setFeedURL, checkForUpdates, the nudge
+  // poller, or the resume/focus daily-check handlers — so the app cannot
+  // self-update to upstream orca. App startup is unaffected (this function is
+  // best-effort; callers don't depend on a return value or side effects).
+  if (DISABLE_AUTO_UPDATE) {
+    return
+  }
 
   if (!app.isPackaged && !is.dev) {
     return

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -110,7 +110,7 @@ export function attachMainWindowServices(
   // child_process (not a PTY) and streams parsed NDJSON events to the renderer.
   // Registered here so it is reinstalled on macOS window recreation like the
   // other per-window IPC surfaces.
-  registerJcodeChatHandlers(mainWindow)
+  registerJcodeChatHandlers(mainWindow, store)
   registerSshHandlers(store, () => mainWindow, runtime)
   registerRemoteWorkspaceHandlers(store, () => mainWindow)
   registerFileDropRelay(mainWindow)

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -11,6 +11,7 @@ import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
 import { getLocalPtyProvider, registerPtyHandlers } from '../ipc/pty'
 import { registerDaemonManagementHandlers } from '../ipc/pty-management'
 import { registerSshHandlers } from '../ipc/ssh'
+import { registerJcodeChatHandlers } from '../jcode/jcode-chat-session'
 import { registerRemoteWorkspaceHandlers } from '../ipc/remote-workspace'
 import { browserManager } from '../browser/browser-manager'
 import { hasSystemMediaAccess, requestSystemMediaAccess } from '../browser/browser-media-access'
@@ -105,6 +106,11 @@ export function attachMainWindowServices(
         )
       })
   }
+  // Why: jcode's chat-bubble view (M1) spawns `jcode run --ndjson` via
+  // child_process (not a PTY) and streams parsed NDJSON events to the renderer.
+  // Registered here so it is reinstalled on macOS window recreation like the
+  // other per-window IPC surfaces.
+  registerJcodeChatHandlers(mainWindow)
   registerSshHandlers(store, () => mainWindow, runtime)
   registerRemoteWorkspaceHandlers(store, () => mainWindow)
   registerFileDropRelay(mainWindow)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -11,6 +11,7 @@ import type {
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
 import type { ReadClipboardTextOptions } from '../shared/clipboard-text'
 import type { AppIdentity } from '../shared/app-identity'
+import type { JcodeChatEventMessage, JcodeChatSendPayload } from '../shared/jcode-chat-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { TaskSourceContext } from '../shared/task-source-context'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
@@ -754,6 +755,10 @@ export type AppApi = {
 }
 
 export type PreloadApi = {
+  jcodeChat: {
+    send: (payload: JcodeChatSendPayload) => void
+    onEvent: (callback: (message: JcodeChatEventMessage) => void) => () => void
+  }
   app: AppApi
   platform: {
     get: () => {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -19,7 +19,9 @@ import type {
   JcodeConversationRecord,
   JcodeConversationSummary,
   JcodeProviderActionResult,
-  JcodeProviderAddArgs
+  JcodeProviderAddArgs,
+  JcodeSkillsListPayload,
+  JcodeSkillsListResult
 } from '../shared/jcode-chat-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { TaskSourceContext } from '../shared/task-source-context'
@@ -779,6 +781,9 @@ export type PreloadApi = {
     /** Open a native multi-select file picker; resolves to ABSOLUTE paths (empty
      *  array on cancel). Backs the composer "Add files" action. */
     pickFiles: () => Promise<string[]>
+    /** FEATURE B: list SKILL.md skills (project-local + global + plugin) for the
+     *  current pane's cwd/worktree. Backs the "/" menu Skills group. */
+    listSkills: (payload: JcodeSkillsListPayload) => Promise<JcodeSkillsListResult>
   }
   /** Custom OpenAI-compatible provider profiles for jcode chat. */
   jcodeProviders: {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -18,6 +18,10 @@ import type {
   JcodeChatStopPayload,
   JcodeConversationRecord,
   JcodeConversationSummary,
+  JcodeMcpActionResult,
+  JcodeMcpConfigResult,
+  JcodeMcpSetArgs,
+  JcodeModelCatalog,
   JcodeProviderActionResult,
   JcodeProviderAddArgs,
   JcodeSkillsListPayload,
@@ -795,6 +799,15 @@ export type PreloadApi = {
     }>
     /** Add a custom profile via `jcode provider add` (API key over stdin). */
     add: (args: JcodeProviderAddArgs) => Promise<JcodeProviderActionResult>
+    /** Real model catalog from `jcode model list --json` for the detailed picker. */
+    listModels: () => Promise<JcodeModelCatalog>
+  }
+  /** MCP servers ("connectors") for jcode chat — the global ~/.jcode/mcp.json. */
+  jcodeMcp: {
+    /** Read the managed global MCP server list. */
+    get: () => Promise<JcodeMcpConfigResult>
+    /** Overwrite the managed global MCP server list. */
+    set: (args: JcodeMcpSetArgs) => Promise<JcodeMcpActionResult>
   }
   app: AppApi
   platform: {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -923,6 +923,8 @@ export type PreloadApi = {
           | 'pendingFirstAgentMessageRename'
           | 'firstAgentMessageRenameError'
           | 'lastActivityAt'
+          | 'connectionId'
+          | 'isRemoteExecOnly'
         >
       >
     }) => Promise<FolderWorkspace | null>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -13,8 +13,11 @@ import type { ReadClipboardTextOptions } from '../shared/clipboard-text'
 import type { AppIdentity } from '../shared/app-identity'
 import type {
   JcodeChatEventMessage,
+  JcodeChatSavePayload,
   JcodeChatSendPayload,
-  JcodeChatStopPayload
+  JcodeChatStopPayload,
+  JcodeConversationRecord,
+  JcodeConversationSummary
 } from '../shared/jcode-chat-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { TaskSourceContext } from '../shared/task-source-context'
@@ -763,6 +766,14 @@ export type PreloadApi = {
     send: (payload: JcodeChatSendPayload) => void
     stop: (payload: JcodeChatStopPayload) => void
     onEvent: (callback: (message: JcodeChatEventMessage) => void) => () => void
+    /** Persist a conversation snapshot to disk (turn boundaries). */
+    saveConversation: (payload: JcodeChatSavePayload) => Promise<boolean>
+    /** List persisted conversations (newest first), no transcript body. */
+    listConversations: () => Promise<JcodeConversationSummary[]>
+    /** Load a persisted conversation for rehydration, or null if absent. */
+    loadConversation: (sessionKey: string) => Promise<JcodeConversationRecord | null>
+    /** Remove a persisted conversation from disk. */
+    deleteConversation: (sessionKey: string) => Promise<boolean>
   }
   app: AppApi
   platform: {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -11,7 +11,11 @@ import type {
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
 import type { ReadClipboardTextOptions } from '../shared/clipboard-text'
 import type { AppIdentity } from '../shared/app-identity'
-import type { JcodeChatEventMessage, JcodeChatSendPayload } from '../shared/jcode-chat-types'
+import type {
+  JcodeChatEventMessage,
+  JcodeChatSendPayload,
+  JcodeChatStopPayload
+} from '../shared/jcode-chat-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { TaskSourceContext } from '../shared/task-source-context'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
@@ -757,6 +761,7 @@ export type AppApi = {
 export type PreloadApi = {
   jcodeChat: {
     send: (payload: JcodeChatSendPayload) => void
+    stop: (payload: JcodeChatStopPayload) => void
     onEvent: (callback: (message: JcodeChatEventMessage) => void) => () => void
   }
   app: AppApi

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -776,6 +776,9 @@ export type PreloadApi = {
     loadConversation: (sessionKey: string) => Promise<JcodeConversationRecord | null>
     /** Remove a persisted conversation from disk. */
     deleteConversation: (sessionKey: string) => Promise<boolean>
+    /** Open a native multi-select file picker; resolves to ABSOLUTE paths (empty
+     *  array on cancel). Backs the composer "Add files" action. */
+    pickFiles: () => Promise<string[]>
   }
   /** Custom OpenAI-compatible provider profiles for jcode chat. */
   jcodeProviders: {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -17,7 +17,9 @@ import type {
   JcodeChatSendPayload,
   JcodeChatStopPayload,
   JcodeConversationRecord,
-  JcodeConversationSummary
+  JcodeConversationSummary,
+  JcodeProviderActionResult,
+  JcodeProviderAddArgs
 } from '../shared/jcode-chat-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { TaskSourceContext } from '../shared/task-source-context'
@@ -774,6 +776,17 @@ export type PreloadApi = {
     loadConversation: (sessionKey: string) => Promise<JcodeConversationRecord | null>
     /** Remove a persisted conversation from disk. */
     deleteConversation: (sessionKey: string) => Promise<boolean>
+  }
+  /** Custom OpenAI-compatible provider profiles for jcode chat. */
+  jcodeProviders: {
+    /** List jcode's built-in providers (custom profiles are tracked in settings). */
+    list: () => Promise<{
+      ok: boolean
+      error?: string
+      builtins: { id: string; display_name?: string; detail?: string; recommended?: boolean }[]
+    }>
+    /** Add a custom profile via `jcode provider add` (API key over stdin). */
+    add: (args: JcodeProviderAddArgs) => Promise<JcodeProviderActionResult>
   }
   app: AppApi
   platform: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,6 +17,7 @@ import {
   JCODE_CHAT_STOP_CHANNEL,
   JCODE_PROVIDERS_ADD_CHANNEL,
   JCODE_PROVIDERS_LIST_CHANNEL,
+  JCODE_SKILLS_LIST_CHANNEL,
   type JcodeChatEventMessage,
   type JcodeChatSavePayload,
   type JcodeChatSendPayload,
@@ -24,7 +25,9 @@ import {
   type JcodeConversationRecord,
   type JcodeConversationSummary,
   type JcodeProviderActionResult,
-  type JcodeProviderAddArgs
+  type JcodeProviderAddArgs,
+  type JcodeSkillsListPayload,
+  type JcodeSkillsListResult
 } from '../shared/jcode-chat-types'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
@@ -455,7 +458,11 @@ const api = {
       ipcRenderer.invoke(JCODE_CHAT_DELETE_CHANNEL, sessionKey),
     // Open a native multi-select file picker; resolves to ABSOLUTE paths (empty
     // on cancel). Used by the composer "Add files" action.
-    pickFiles: (): Promise<string[]> => ipcRenderer.invoke(JCODE_CHAT_PICK_FILES_CHANNEL)
+    pickFiles: (): Promise<string[]> => ipcRenderer.invoke(JCODE_CHAT_PICK_FILES_CHANNEL),
+    // FEATURE B: list SKILL.md skills (project-local + global + plugin) for the
+    // current pane's cwd/worktree. Backs the "/" menu Skills group.
+    listSkills: (payload: JcodeSkillsListPayload): Promise<JcodeSkillsListResult> =>
+      ipcRenderer.invoke(JCODE_SKILLS_LIST_CHANNEL, payload)
   },
 
   // Custom OpenAI-compatible provider profiles for jcode chat. `add` shells to

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,12 +14,16 @@ import {
   JCODE_CHAT_SAVE_CHANNEL,
   JCODE_CHAT_SEND_CHANNEL,
   JCODE_CHAT_STOP_CHANNEL,
+  JCODE_PROVIDERS_ADD_CHANNEL,
+  JCODE_PROVIDERS_LIST_CHANNEL,
   type JcodeChatEventMessage,
   type JcodeChatSavePayload,
   type JcodeChatSendPayload,
   type JcodeChatStopPayload,
   type JcodeConversationRecord,
-  type JcodeConversationSummary
+  type JcodeConversationSummary,
+  type JcodeProviderActionResult,
+  type JcodeProviderAddArgs
 } from '../shared/jcode-chat-types'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
@@ -448,6 +452,19 @@ const api = {
       ipcRenderer.invoke(JCODE_CHAT_LOAD_CHANNEL, sessionKey),
     deleteConversation: (sessionKey: string): Promise<boolean> =>
       ipcRenderer.invoke(JCODE_CHAT_DELETE_CHANNEL, sessionKey)
+  },
+
+  // Custom OpenAI-compatible provider profiles for jcode chat. `add` shells to
+  // `jcode provider add ... --api-key-stdin` (API key delivered over stdin in
+  // the main process, never as an argv flag).
+  jcodeProviders: {
+    list: (): Promise<{
+      ok: boolean
+      error?: string
+      builtins: { id: string; display_name?: string; detail?: string; recommended?: boolean }[]
+    }> => ipcRenderer.invoke(JCODE_PROVIDERS_LIST_CHANNEL),
+    add: (args: JcodeProviderAddArgs): Promise<JcodeProviderActionResult> =>
+      ipcRenderer.invoke(JCODE_PROVIDERS_ADD_CHANNEL, args)
   },
   app: {
     getIdentity: (): Promise<AppIdentity> => ipcRenderer.invoke('app:getIdentity'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,6 +6,12 @@ import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
+import {
+  JCODE_CHAT_EVENT_CHANNEL,
+  JCODE_CHAT_SEND_CHANNEL,
+  type JcodeChatEventMessage,
+  type JcodeChatSendPayload
+} from '../shared/jcode-chat-types'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
@@ -407,6 +413,19 @@ document.addEventListener(
 
 // Custom APIs for renderer
 const api = {
+  // Why: jcode chat-bubble view (M1). `send` fires one headless turn; `onEvent`
+  // subscribes to the streamed NDJSON events the main process forwards.
+  jcodeChat: {
+    send: (payload: JcodeChatSendPayload): void => {
+      ipcRenderer.send(JCODE_CHAT_SEND_CHANNEL, payload)
+    },
+    onEvent: (callback: (message: JcodeChatEventMessage) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, message: JcodeChatEventMessage): void =>
+        callback(message)
+      ipcRenderer.on(JCODE_CHAT_EVENT_CHANNEL, listener)
+      return () => ipcRenderer.removeListener(JCODE_CHAT_EVENT_CHANNEL, listener)
+    }
+  },
   app: {
     getIdentity: (): Promise<AppIdentity> => ipcRenderer.invoke('app:getIdentity'),
     getFeatureWallAssetBaseUrl: (): Promise<string> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ import {
   JCODE_CHAT_EVENT_CHANNEL,
   JCODE_CHAT_LIST_CHANNEL,
   JCODE_CHAT_LOAD_CHANNEL,
+  JCODE_CHAT_PICK_FILES_CHANNEL,
   JCODE_CHAT_SAVE_CHANNEL,
   JCODE_CHAT_SEND_CHANNEL,
   JCODE_CHAT_STOP_CHANNEL,
@@ -451,7 +452,10 @@ const api = {
     loadConversation: (sessionKey: string): Promise<JcodeConversationRecord | null> =>
       ipcRenderer.invoke(JCODE_CHAT_LOAD_CHANNEL, sessionKey),
     deleteConversation: (sessionKey: string): Promise<boolean> =>
-      ipcRenderer.invoke(JCODE_CHAT_DELETE_CHANNEL, sessionKey)
+      ipcRenderer.invoke(JCODE_CHAT_DELETE_CHANNEL, sessionKey),
+    // Open a native multi-select file picker; resolves to ABSOLUTE paths (empty
+    // on cancel). Used by the composer "Add files" action.
+    pickFiles: (): Promise<string[]> => ipcRenderer.invoke(JCODE_CHAT_PICK_FILES_CHANNEL)
   },
 
   // Custom OpenAI-compatible provider profiles for jcode chat. `add` shells to

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,12 +7,19 @@ import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
 import {
+  JCODE_CHAT_DELETE_CHANNEL,
   JCODE_CHAT_EVENT_CHANNEL,
+  JCODE_CHAT_LIST_CHANNEL,
+  JCODE_CHAT_LOAD_CHANNEL,
+  JCODE_CHAT_SAVE_CHANNEL,
   JCODE_CHAT_SEND_CHANNEL,
   JCODE_CHAT_STOP_CHANNEL,
   type JcodeChatEventMessage,
+  type JcodeChatSavePayload,
   type JcodeChatSendPayload,
-  type JcodeChatStopPayload
+  type JcodeChatStopPayload,
+  type JcodeConversationRecord,
+  type JcodeConversationSummary
 } from '../shared/jcode-chat-types'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
@@ -429,7 +436,18 @@ const api = {
         callback(message)
       ipcRenderer.on(JCODE_CHAT_EVENT_CHANNEL, listener)
       return () => ipcRenderer.removeListener(JCODE_CHAT_EVENT_CHANNEL, listener)
-    }
+    },
+    // Why (BUG 1, persistence): durable backing store. The renderer snapshots a
+    // conversation on turn boundaries; main writes it to disk so it survives
+    // restart and a closed chat tab can be reopened + rehydrated.
+    saveConversation: (payload: JcodeChatSavePayload): Promise<boolean> =>
+      ipcRenderer.invoke(JCODE_CHAT_SAVE_CHANNEL, payload),
+    listConversations: (): Promise<JcodeConversationSummary[]> =>
+      ipcRenderer.invoke(JCODE_CHAT_LIST_CHANNEL),
+    loadConversation: (sessionKey: string): Promise<JcodeConversationRecord | null> =>
+      ipcRenderer.invoke(JCODE_CHAT_LOAD_CHANNEL, sessionKey),
+    deleteConversation: (sessionKey: string): Promise<boolean> =>
+      ipcRenderer.invoke(JCODE_CHAT_DELETE_CHANNEL, sessionKey)
   },
   app: {
     getIdentity: (): Promise<AppIdentity> => ipcRenderer.invoke('app:getIdentity'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,8 +9,10 @@ import type { AppIdentity } from '../shared/app-identity'
 import {
   JCODE_CHAT_EVENT_CHANNEL,
   JCODE_CHAT_SEND_CHANNEL,
+  JCODE_CHAT_STOP_CHANNEL,
   type JcodeChatEventMessage,
-  type JcodeChatSendPayload
+  type JcodeChatSendPayload,
+  type JcodeChatStopPayload
 } from '../shared/jcode-chat-types'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
@@ -418,6 +420,9 @@ const api = {
   jcodeChat: {
     send: (payload: JcodeChatSendPayload): void => {
       ipcRenderer.send(JCODE_CHAT_SEND_CHANNEL, payload)
+    },
+    stop: (payload: JcodeChatStopPayload): void => {
+      ipcRenderer.send(JCODE_CHAT_STOP_CHANNEL, payload)
     },
     onEvent: (callback: (message: JcodeChatEventMessage) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, message: JcodeChatEventMessage): void =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,9 @@ import {
   JCODE_CHAT_SAVE_CHANNEL,
   JCODE_CHAT_SEND_CHANNEL,
   JCODE_CHAT_STOP_CHANNEL,
+  JCODE_MCP_GET_CHANNEL,
+  JCODE_MCP_SET_CHANNEL,
+  JCODE_MODELS_LIST_CHANNEL,
   JCODE_PROVIDERS_ADD_CHANNEL,
   JCODE_PROVIDERS_LIST_CHANNEL,
   JCODE_SKILLS_LIST_CHANNEL,
@@ -24,6 +27,10 @@ import {
   type JcodeChatStopPayload,
   type JcodeConversationRecord,
   type JcodeConversationSummary,
+  type JcodeMcpActionResult,
+  type JcodeMcpConfigResult,
+  type JcodeMcpSetArgs,
+  type JcodeModelCatalog,
   type JcodeProviderActionResult,
   type JcodeProviderAddArgs,
   type JcodeSkillsListPayload,
@@ -475,7 +482,15 @@ const api = {
       builtins: { id: string; display_name?: string; detail?: string; recommended?: boolean }[]
     }> => ipcRenderer.invoke(JCODE_PROVIDERS_LIST_CHANNEL),
     add: (args: JcodeProviderAddArgs): Promise<JcodeProviderActionResult> =>
-      ipcRenderer.invoke(JCODE_PROVIDERS_ADD_CHANNEL, args)
+      ipcRenderer.invoke(JCODE_PROVIDERS_ADD_CHANNEL, args),
+    listModels: (): Promise<JcodeModelCatalog> => ipcRenderer.invoke(JCODE_MODELS_LIST_CHANNEL)
+  },
+  // MCP servers ("connectors") for jcode chat — manages the global
+  // ~/.jcode/mcp.json that jcode loads stdio MCP servers from.
+  jcodeMcp: {
+    get: (): Promise<JcodeMcpConfigResult> => ipcRenderer.invoke(JCODE_MCP_GET_CHANNEL),
+    set: (args: JcodeMcpSetArgs): Promise<JcodeMcpActionResult> =>
+      ipcRenderer.invoke(JCODE_MCP_SET_CHANNEL, args)
   },
   app: {
     getIdentity: (): Promise<AppIdentity> => ipcRenderer.invoke('app:getIdentity'),

--- a/src/renderer/src/components/chat-pane/ChatComposer.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { ArrowUp, Mic, Paperclip, Plug, Plus, Puzzle, Slash, Square, Type } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import {
   DropdownMenu,
@@ -156,7 +157,14 @@ export function ChatComposer({
               if (text && text.length > LARGE_PASTE_THRESHOLD) {
                 event.preventDefault()
                 const firstLine = text.split('\n', 1)[0].trim().slice(0, 40)
-                onAddText(text, firstLine ? `Pasted: ${firstLine}…` : 'Pasted text')
+                onAddText(
+                  text,
+                  firstLine
+                    ? translate('jcode.chat.attachment.pastedWithPreview', 'Pasted: {{value0}}…', {
+                        value0: firstLine
+                      })
+                    : translate('jcode.chat.attachment.pastedText', 'Pasted text')
+                )
               }
             }}
             onKeyDown={(event) => {
@@ -201,7 +209,10 @@ export function ChatComposer({
                 onSend()
               }
             }}
-            placeholder="Message jcode…  (type / for commands)"
+            placeholder={translate(
+              'jcode.chat.composer.placeholder',
+              'Message jcode... (type / for commands)'
+            )}
             rows={1}
             className="max-h-[200px] w-full resize-none bg-transparent px-1 py-1.5 text-sm outline-none placeholder:text-muted-foreground"
           />
@@ -213,7 +224,7 @@ export function ChatComposer({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                aria-label="Add to message"
+                aria-label={translate('jcode.chat.composer.addMenuAria', 'Add to message')}
                 className="flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               >
                 <Plus className="size-4" />
@@ -227,26 +238,33 @@ export function ChatComposer({
                 }}
               >
                 <Paperclip className="size-4" />
-                Add files
+                {translate('jcode.chat.composer.addFiles', 'Add files')}
               </DropdownMenuItem>
               <DropdownMenuItem
                 onSelect={() => {
                   window.requestAnimationFrame(() => {
-                    const text = window.prompt('Paste or type text to attach:')
+                    const text = window.prompt(
+                      translate('jcode.chat.composer.textPrompt', 'Paste or type text to attach:')
+                    )
                     if (text && text.trim()) {
                       const firstLine = text.split('\n', 1)[0].trim().slice(0, 40)
-                      onAddText(text, firstLine ? firstLine : 'Text')
+                      onAddText(
+                        text,
+                        firstLine
+                          ? firstLine
+                          : translate('jcode.chat.attachment.defaultTextName', 'Text')
+                      )
                     }
                   })
                 }}
               >
                 <Type className="size-4" />
-                Add text
+                {translate('jcode.chat.composer.addText', 'Add text')}
               </DropdownMenuItem>
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>
                   <Slash className="size-4" />
-                  Quick commands
+                  {translate('jcode.chat.composer.quickCommands', 'Quick commands')}
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="min-w-[16rem]">
                   {SLASH_COMMANDS.map((command) => (
@@ -269,11 +287,11 @@ export function ChatComposer({
                 }}
               >
                 <Plug className="size-4" />
-                连接器 / Connectors
+                {translate('jcode.chat.composer.connectors', 'Connectors')}
               </DropdownMenuItem>
               <DropdownMenuItem onSelect={() => openSkillsPage()}>
                 <Puzzle className="size-4" />
-                技能 / Skills
+                {translate('jcode.chat.composer.skills', 'Skills')}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -297,14 +315,19 @@ export function ChatComposer({
                   <button
                     type="button"
                     disabled
-                    aria-label="Voice input"
+                    aria-label={translate('jcode.chat.composer.voiceInputAria', 'Voice input')}
                     className="flex size-8 cursor-not-allowed items-center justify-center rounded-full text-muted-foreground opacity-50"
                   >
                     <Mic className="size-4" />
                   </button>
                 </span>
               </TooltipTrigger>
-              <TooltipContent>语音转写需安装语音技能</TooltipContent>
+              <TooltipContent>
+                {translate(
+                  'jcode.chat.composer.voiceSkillRequired',
+                  'Voice transcription requires a voice skill'
+                )}
+              </TooltipContent>
             </Tooltip>
           </TooltipProvider>
 
@@ -313,7 +336,7 @@ export function ChatComposer({
             <button
               type="button"
               onClick={onStop}
-              aria-label="Stop"
+              aria-label={translate('jcode.chat.composer.stopAria', 'Stop')}
               className="flex size-8 items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-90"
             >
               <Square className="size-3.5 fill-current" />
@@ -323,7 +346,7 @@ export function ChatComposer({
               type="button"
               onClick={onSend}
               disabled={!value.trim() && attachments.length === 0 && !selectedSkillName}
-              aria-label="Send"
+              aria-label={translate('jcode.chat.composer.sendAria', 'Send')}
               className={cn(
                 'flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity',
                 'disabled:cursor-not-allowed disabled:opacity-40'

--- a/src/renderer/src/components/chat-pane/ChatComposer.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   ArrowUp,
   ChevronDown,
@@ -33,8 +33,9 @@ import {
   findProfileOption,
   findProviderOption
 } from './jcode-providers'
-import { SLASH_COMMANDS, filterSlashCommands, type SlashCommand } from './chat-slash-commands'
-import { ChatAttachmentChips, SlashCommandPopover } from './ChatComposerExtras'
+import { SLASH_COMMANDS } from './chat-slash-commands'
+import { useChatSlashMenu } from './use-chat-slash-menu'
+import { ChatAttachmentChips, SkillChip, SlashCommandPopover } from './ChatComposerExtras'
 
 // Why: the composer is the Claude-app-style bottom bar. It owns the unsent
 // draft text (local state) and the auto-growing textarea, but the provider/model
@@ -67,7 +68,11 @@ export function ChatComposer({
   onAddFiles,
   onAddText,
   onRemoveAttachment,
-  onSlashAction
+  onSlashAction,
+  cwd,
+  worktreeId,
+  selectedSkillName,
+  onSelectSkill
 }: {
   value: string
   onChange: (next: string) => void
@@ -97,12 +102,37 @@ export function ChatComposer({
   onRemoveAttachment: (index: number) => void
   /** Run an orca-side "/" action (start new chat / reopen last). */
   onSlashAction: (action: 'clear' | 'resume') => void
+  /** FEATURE B: project root + worktree for skill discovery, the skill armed for
+   *  the next send (shows a chip; null = none), and the arm/disarm callback. */
+  cwd?: string
+  worktreeId?: string
+  selectedSkillName?: string | null
+  onSelectSkill: (skillName: string | null) => void
 }): React.JSX.Element {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [menuOpen, setMenuOpen] = useState(false)
-  // Slash menu is shown when the draft is exactly a "/query" with no spaces yet.
-  const [slashOpen, setSlashOpen] = useState(false)
-  const [slashIndex, setSlashIndex] = useState(0)
+
+  // FEATURE B: the "/" menu (orca quick commands + skills) is owned by the hook;
+  // selecting a skill row arms it via onSelectSkill.
+  const {
+    slashOpen,
+    slashIndex,
+    setSlashIndex,
+    setSlashOpen,
+    commands: slashCommandRows,
+    skills: slashSkillRows,
+    flatMatches,
+    degraded: skillsDegraded,
+    runSlashCommand
+  } = useChatSlashMenu({
+    value,
+    cwd,
+    worktreeId,
+    textareaRef,
+    onChange,
+    onSlashAction,
+    onSelectSkill
+  })
 
   // Auto-grow the textarea up to a max height, then scroll internally.
   useEffect(() => {
@@ -113,37 +143,6 @@ export function ChatComposer({
     el.style.height = 'auto'
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`
   }, [value])
-
-  // Derive whether the "/" menu should be visible and which commands match.
-  const slashQuery =
-    value.startsWith('/') && !value.includes(' ') && !value.includes('\n')
-      ? value.slice(1).toLowerCase()
-      : null
-  const slashMatches = slashQuery === null ? [] : filterSlashCommands(slashQuery)
-
-  // Keep the menu open state in sync with whether there is a "/" query + matches.
-  useEffect(() => {
-    const shouldOpen = slashQuery !== null && slashMatches.length > 0
-    setSlashOpen(shouldOpen)
-    if (shouldOpen) {
-      setSlashIndex(0)
-    }
-  }, [slashQuery, slashMatches.length])
-
-  const runSlashCommand = useCallback(
-    (command: SlashCommand) => {
-      if (command.kind === 'template') {
-        onChange(command.template)
-      } else {
-        // Action: clear the "/command" draft, then run it.
-        onChange('')
-        onSlashAction(command.action)
-      }
-      setSlashOpen(false)
-      window.requestAnimationFrame(() => textareaRef.current?.focus())
-    },
-    [onChange, onSlashAction]
-  )
 
   const profileOptions = buildProfileOptions(customProviders)
   // The active option is either a custom profile or a built-in provider.
@@ -166,13 +165,18 @@ export function ChatComposer({
         {/* Attachment chips above the textarea. */}
         <ChatAttachmentChips attachments={attachments} onRemove={onRemoveAttachment} />
 
+        {/* FEATURE B: armed-skill chip (the skill body is injected on send). */}
+        <SkillChip name={selectedSkillName} onRemove={() => onSelectSkill(null)} />
+
         <div className="relative">
           {slashOpen ? (
             <SlashCommandPopover
-              matches={slashMatches}
+              commands={slashCommandRows}
+              skills={slashSkillRows}
               activeIndex={slashIndex}
               onHover={setSlashIndex}
               onPick={runSlashCommand}
+              degraded={skillsDegraded}
             />
           ) : null}
 
@@ -192,20 +196,20 @@ export function ChatComposer({
             }}
             onKeyDown={(event) => {
               // Slash menu keyboard nav takes priority while open.
-              if (slashOpen && slashMatches.length > 0) {
+              if (slashOpen && flatMatches.length > 0) {
                 if (event.key === 'ArrowDown') {
                   event.preventDefault()
-                  setSlashIndex((i) => (i + 1) % slashMatches.length)
+                  setSlashIndex((i) => (i + 1) % flatMatches.length)
                   return
                 }
                 if (event.key === 'ArrowUp') {
                   event.preventDefault()
-                  setSlashIndex((i) => (i - 1 + slashMatches.length) % slashMatches.length)
+                  setSlashIndex((i) => (i - 1 + flatMatches.length) % flatMatches.length)
                   return
                 }
                 if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
                   event.preventDefault()
-                  runSlashCommand(slashMatches[slashIndex])
+                  runSlashCommand(flatMatches[slashIndex])
                   return
                 }
                 if (event.key === 'Escape') {
@@ -426,7 +430,7 @@ export function ChatComposer({
             <button
               type="button"
               onClick={onSend}
-              disabled={!value.trim() && attachments.length === 0}
+              disabled={!value.trim() && attachments.length === 0 && !selectedSkillName}
               aria-label="Send"
               className={cn(
                 'flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity',

--- a/src/renderer/src/components/chat-pane/ChatComposer.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposer.tsx
@@ -1,24 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
-import {
-  ArrowUp,
-  ChevronDown,
-  Mic,
-  Paperclip,
-  Plug,
-  Plus,
-  Puzzle,
-  Slash,
-  Square,
-  Type
-} from 'lucide-react'
+import { ArrowUp, Mic, Paperclip, Plug, Plus, Puzzle, Slash, Square, Type } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -27,15 +14,10 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { JcodeChatAttachment, JcodeCustomProvider } from '../../../../shared/jcode-chat-types'
-import {
-  JCODE_PROVIDERS,
-  buildProfileOptions,
-  findProfileOption,
-  findProviderOption
-} from './jcode-providers'
 import { SLASH_COMMANDS } from './chat-slash-commands'
 import { useChatSlashMenu } from './use-chat-slash-menu'
 import { ChatAttachmentChips, SkillChip, SlashCommandPopover } from './ChatComposerExtras'
+import { ChatModelPicker } from './ChatModelPicker'
 
 // Why: the composer is the Claude-app-style bottom bar. It owns the unsent
 // draft text (local state) and the auto-growing textarea, but the provider/model
@@ -46,12 +28,6 @@ import { ChatAttachmentChips, SkillChip, SlashCommandPopover } from './ChatCompo
 // Pasted text larger than this is auto-converted into a collapsible text
 // attachment chip instead of bloating the textarea.
 const LARGE_PASTE_THRESHOLD = 1200
-
-// Sentinel radio values for the special chip rows.
-const AUTO_VALUE = '__auto__'
-// Custom profiles are namespaced so their value never collides with a built-in
-// provider id in the shared radio group.
-const PROFILE_PREFIX = 'profile:'
 
 export function ChatComposer({
   value,
@@ -111,6 +87,10 @@ export function ChatComposer({
 }): React.JSX.Element {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [menuOpen, setMenuOpen] = useState(false)
+  // "+menu" navigation: Connectors -> the MCP settings section; Plugins -> Skills.
+  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+  const openSkillsPage = useAppStore((s) => s.openSkillsPage)
 
   // FEATURE B: the "/" menu (orca quick commands + skills) is owned by the hook;
   // selecting a skill row arms it via onSelectSkill.
@@ -143,21 +123,6 @@ export function ChatComposer({
     el.style.height = 'auto'
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`
   }, [value])
-
-  const profileOptions = buildProfileOptions(customProviders)
-  // The active option is either a custom profile or a built-in provider.
-  const activeProfileOption = findProfileOption(customProviders, providerProfile)
-  const providerOption = activeProfileOption ?? findProviderOption(provider)
-  // Radio value: profile selection is namespaced; built-in is the raw id; Auto
-  // when neither is set.
-  const radioValue = providerProfile
-    ? `${PROFILE_PREFIX}${providerProfile}`
-    : (provider ?? AUTO_VALUE)
-  const chipLabel = providerOption
-    ? model
-      ? `${providerOption.label} · ${model}`
-      : providerOption.label
-    : 'Auto'
 
   return (
     <div className="mx-auto w-full max-w-3xl">
@@ -293,107 +258,34 @@ export function ChatComposer({
                 </DropdownMenuSubContent>
               </DropdownMenuSub>
               <DropdownMenuSeparator />
-              <DropdownMenuItem disabled>
+              <DropdownMenuItem
+                onSelect={() => {
+                  openSettingsTarget({
+                    pane: 'accounts',
+                    repoId: null,
+                    sectionId: 'accounts-jcode-mcp'
+                  })
+                  openSettingsPage()
+                }}
+              >
                 <Plug className="size-4" />
-                Connectors
-                <span className="ml-auto text-xs text-muted-foreground">Soon</span>
+                连接器 / Connectors
               </DropdownMenuItem>
-              <DropdownMenuItem disabled>
+              <DropdownMenuItem onSelect={() => openSkillsPage()}>
                 <Puzzle className="size-4" />
-                Plugins
-                <span className="ml-auto text-xs text-muted-foreground">Soon</span>
+                技能 / Skills
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {/* Provider / model chip ("Auto" by default) */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="flex h-8 items-center gap-1 rounded-full px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                {chipLabel}
-                <ChevronDown className="size-3.5" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="min-w-[15rem]">
-              <DropdownMenuLabel>Model</DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={radioValue}
-                onValueChange={(next) => {
-                  if (next === AUTO_VALUE) {
-                    onSelectProvider({
-                      provider: undefined,
-                      providerProfile: undefined,
-                      model: undefined
-                    })
-                    return
-                  }
-                  if (next.startsWith(PROFILE_PREFIX)) {
-                    const name = next.slice(PROFILE_PREFIX.length)
-                    const option = findProfileOption(customProviders, name)
-                    onSelectProvider({
-                      provider: undefined,
-                      providerProfile: name,
-                      model: option?.models?.[0]
-                    })
-                    return
-                  }
-                  const option = findProviderOption(next)
-                  onSelectProvider({
-                    provider: next,
-                    providerProfile: undefined,
-                    model: option?.models?.[0]
-                  })
-                }}
-              >
-                <DropdownMenuRadioItem value={AUTO_VALUE}>
-                  Auto
-                  <span className="ml-auto text-xs text-muted-foreground">default</span>
-                </DropdownMenuRadioItem>
-                {JCODE_PROVIDERS.map((entry) => (
-                  <DropdownMenuRadioItem key={entry.id} value={entry.id}>
-                    {entry.label}
-                  </DropdownMenuRadioItem>
-                ))}
-                {profileOptions.length > 0 ? (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuLabel>自定义 Provider</DropdownMenuLabel>
-                    {profileOptions.map((entry) => (
-                      <DropdownMenuRadioItem
-                        key={`${PROFILE_PREFIX}${entry.id}`}
-                        value={`${PROFILE_PREFIX}${entry.id}`}
-                      >
-                        {entry.label}
-                      </DropdownMenuRadioItem>
-                    ))}
-                  </>
-                ) : null}
-              </DropdownMenuRadioGroup>
-              {providerOption?.models && providerOption.models.length > 0 ? (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel>{providerOption.label} model</DropdownMenuLabel>
-                  <DropdownMenuRadioGroup
-                    value={model ?? providerOption.models[0]}
-                    onValueChange={(next) =>
-                      // Preserve whichever of provider/profile is active when only
-                      // the model changes.
-                      onSelectProvider({ provider, providerProfile, model: next })
-                    }
-                  >
-                    {providerOption.models.map((modelId) => (
-                      <DropdownMenuRadioItem key={modelId} value={modelId}>
-                        {modelId}
-                      </DropdownMenuRadioItem>
-                    ))}
-                  </DropdownMenuRadioGroup>
-                </>
-              ) : null}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {/* Provider / model chip ("Auto" by default) — detailed picker. */}
+          <ChatModelPicker
+            provider={provider}
+            providerProfile={providerProfile}
+            model={model}
+            customProviders={customProviders}
+            onSelectProvider={onSelectProvider}
+          />
 
           <div className="flex-1" />
 

--- a/src/renderer/src/components/chat-pane/ChatComposer.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposer.tsx
@@ -121,7 +121,20 @@ export function ChatComposer({
           value={value}
           onChange={(event) => onChange(event.target.value)}
           onKeyDown={(event) => {
-            if (event.key === 'Enter' && !event.shiftKey) {
+            // Why (BUG 3, IME): guard the Enter-to-send against IME composition.
+            // While composing Chinese/Japanese/etc., pressing Enter COMMITS the
+            // candidate — it must not trigger a send. `isComposing`/keyCode 229
+            // mark an in-progress composition; firing onSend() there both sends a
+            // half-typed prompt AND lets compositionend re-fill the textarea after
+            // ChatPane's setInput('') runs, so the box still shows text. Skipping
+            // send during composition fixes both the premature send and the
+            // text-not-cleared symptom.
+            if (
+              event.key === 'Enter' &&
+              !event.shiftKey &&
+              !event.nativeEvent.isComposing &&
+              event.keyCode !== 229
+            ) {
               event.preventDefault()
               onSend()
             }

--- a/src/renderer/src/components/chat-pane/ChatComposer.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposer.tsx
@@ -25,7 +25,19 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { JCODE_PROVIDERS, findProviderOption } from './jcode-providers'
+import type { JcodeCustomProvider } from '../../../../shared/jcode-chat-types'
+import {
+  JCODE_PROVIDERS,
+  buildProfileOptions,
+  findProfileOption,
+  findProviderOption
+} from './jcode-providers'
+
+// Sentinel radio values for the special chip rows.
+const AUTO_VALUE = '__auto__'
+// Custom profiles are namespaced so their value never collides with a built-in
+// provider id in the shared radio group.
+const PROFILE_PREFIX = 'profile:'
 
 // Why: the composer is the Claude-app-style bottom bar. It owns the unsent
 // draft text (local state) and the auto-growing textarea, but the provider/model
@@ -51,7 +63,9 @@ export function ChatComposer({
   onStop,
   isStreaming,
   provider,
+  providerProfile,
   model,
+  customProviders,
   onSelectProvider
 }: {
   value: string
@@ -59,11 +73,17 @@ export function ChatComposer({
   onSend: () => void
   onStop: () => void
   isStreaming: boolean
-  /** Selected provider id, or undefined for "Auto". */
+  /** Selected built-in provider id, or undefined for "Auto"/profile. */
   provider: string | undefined
+  /** Selected custom provider profile name, or undefined. Mutually exclusive
+   *  with `provider`. */
+  providerProfile?: string | undefined
   model: string | undefined
+  /** User-added custom OpenAI-compatible profiles to surface in the picker. */
+  customProviders?: JcodeCustomProvider[]
   onSelectProvider: (selection: {
-    provider: string | undefined
+    provider?: string | undefined
+    providerProfile?: string | undefined
     model?: string | undefined
   }) => void
 }): React.JSX.Element {
@@ -106,7 +126,15 @@ export function ChatComposer({
     [insertToken]
   )
 
-  const providerOption = findProviderOption(provider)
+  const profileOptions = buildProfileOptions(customProviders)
+  // The active option is either a custom profile or a built-in provider.
+  const activeProfileOption = findProfileOption(customProviders, providerProfile)
+  const providerOption = activeProfileOption ?? findProviderOption(provider)
+  // Radio value: profile selection is namespaced; built-in is the raw id; Auto
+  // when neither is set.
+  const radioValue = providerProfile
+    ? `${PROFILE_PREFIX}${providerProfile}`
+    : (provider ?? AUTO_VALUE)
   const chipLabel = providerOption
     ? model
       ? `${providerOption.label} · ${model}`
@@ -220,17 +248,35 @@ export function ChatComposer({
             <DropdownMenuContent align="start" className="min-w-[15rem]">
               <DropdownMenuLabel>Model</DropdownMenuLabel>
               <DropdownMenuRadioGroup
-                value={provider ?? '__auto__'}
+                value={radioValue}
                 onValueChange={(next) => {
-                  if (next === '__auto__') {
-                    onSelectProvider({ provider: undefined, model: undefined })
+                  if (next === AUTO_VALUE) {
+                    onSelectProvider({
+                      provider: undefined,
+                      providerProfile: undefined,
+                      model: undefined
+                    })
+                    return
+                  }
+                  if (next.startsWith(PROFILE_PREFIX)) {
+                    const name = next.slice(PROFILE_PREFIX.length)
+                    const option = findProfileOption(customProviders, name)
+                    onSelectProvider({
+                      provider: undefined,
+                      providerProfile: name,
+                      model: option?.models?.[0]
+                    })
                     return
                   }
                   const option = findProviderOption(next)
-                  onSelectProvider({ provider: next, model: option?.models?.[0] })
+                  onSelectProvider({
+                    provider: next,
+                    providerProfile: undefined,
+                    model: option?.models?.[0]
+                  })
                 }}
               >
-                <DropdownMenuRadioItem value="__auto__">
+                <DropdownMenuRadioItem value={AUTO_VALUE}>
                   Auto
                   <span className="ml-auto text-xs text-muted-foreground">default</span>
                 </DropdownMenuRadioItem>
@@ -239,6 +285,20 @@ export function ChatComposer({
                     {entry.label}
                   </DropdownMenuRadioItem>
                 ))}
+                {profileOptions.length > 0 ? (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel>自定义 Provider</DropdownMenuLabel>
+                    {profileOptions.map((entry) => (
+                      <DropdownMenuRadioItem
+                        key={`${PROFILE_PREFIX}${entry.id}`}
+                        value={`${PROFILE_PREFIX}${entry.id}`}
+                      >
+                        {entry.label}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </>
+                ) : null}
               </DropdownMenuRadioGroup>
               {providerOption?.models && providerOption.models.length > 0 ? (
                 <>
@@ -246,7 +306,11 @@ export function ChatComposer({
                   <DropdownMenuLabel>{providerOption.label} model</DropdownMenuLabel>
                   <DropdownMenuRadioGroup
                     value={model ?? providerOption.models[0]}
-                    onValueChange={(next) => onSelectProvider({ provider, model: next })}
+                    onValueChange={(next) =>
+                      // Preserve whichever of provider/profile is active when only
+                      // the model changes.
+                      onSelectProvider({ provider, providerProfile, model: next })
+                    }
                   >
                     {providerOption.models.map((modelId) => (
                       <DropdownMenuRadioItem key={modelId} value={modelId}>

--- a/src/renderer/src/components/chat-pane/ChatComposer.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposer.tsx
@@ -8,7 +8,8 @@ import {
   Plus,
   Puzzle,
   Slash,
-  Square
+  Square,
+  Type
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
@@ -25,36 +26,31 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import type { JcodeCustomProvider } from '../../../../shared/jcode-chat-types'
+import type { JcodeChatAttachment, JcodeCustomProvider } from '../../../../shared/jcode-chat-types'
 import {
   JCODE_PROVIDERS,
   buildProfileOptions,
   findProfileOption,
   findProviderOption
 } from './jcode-providers'
+import { SLASH_COMMANDS, filterSlashCommands, type SlashCommand } from './chat-slash-commands'
+import { ChatAttachmentChips, SlashCommandPopover } from './ChatComposerExtras'
+
+// Why: the composer is the Claude-app-style bottom bar. It owns the unsent
+// draft text (local state) and the auto-growing textarea, but the provider/model
+// selection AND the pending attachments are lifted to the chat-session-store via
+// props so they persist per sessionKey across tab switches. Keeping it a
+// separate component keeps ChatPane focused on the message list + send wiring.
+
+// Pasted text larger than this is auto-converted into a collapsible text
+// attachment chip instead of bloating the textarea.
+const LARGE_PASTE_THRESHOLD = 1200
 
 // Sentinel radio values for the special chip rows.
 const AUTO_VALUE = '__auto__'
 // Custom profiles are namespaced so their value never collides with a built-in
 // provider id in the shared radio group.
 const PROFILE_PREFIX = 'profile:'
-
-// Why: the composer is the Claude-app-style bottom bar. It owns the unsent
-// draft text (local state) and the auto-growing textarea, but the provider/model
-// selection is lifted to the chat-session-store via props so it persists per
-// sessionKey across tab switches. Keeping it a separate component keeps ChatPane
-// focused on the message list + send wiring.
-
-// A small, discoverable set of jcode slash commands. Selecting one inserts the
-// token into the draft so the user can complete it. jcode resolves the actual
-// skill; this is just an affordance.
-const SLASH_COMMANDS: { command: string; hint: string }[] = [
-  { command: '/init', hint: 'Summarize the project into context' },
-  { command: '/review', hint: 'Review the current diff' },
-  { command: '/security-review', hint: 'Audit changes for vulnerabilities' },
-  { command: '/run', hint: 'Run the app to verify a change' },
-  { command: '/compact', hint: 'Compact the conversation' }
-]
 
 export function ChatComposer({
   value,
@@ -66,7 +62,12 @@ export function ChatComposer({
   providerProfile,
   model,
   customProviders,
-  onSelectProvider
+  onSelectProvider,
+  attachments,
+  onAddFiles,
+  onAddText,
+  onRemoveAttachment,
+  onSlashAction
 }: {
   value: string
   onChange: (next: string) => void
@@ -86,10 +87,22 @@ export function ChatComposer({
     providerProfile?: string | undefined
     model?: string | undefined
   }) => void
+  /** Pending attachments for the next turn (files + text blobs). */
+  attachments: JcodeChatAttachment[]
+  /** Open the native file picker and attach the chosen absolute paths. */
+  onAddFiles: () => void
+  /** Attach a text blob (from "Add text" or a large paste). */
+  onAddText: (content: string, name?: string) => void
+  /** Remove a pending attachment by index. */
+  onRemoveAttachment: (index: number) => void
+  /** Run an orca-side "/" action (start new chat / reopen last). */
+  onSlashAction: (action: 'clear' | 'resume') => void
 }): React.JSX.Element {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const [menuOpen, setMenuOpen] = useState(false)
+  // Slash menu is shown when the draft is exactly a "/query" with no spaces yet.
+  const [slashOpen, setSlashOpen] = useState(false)
+  const [slashIndex, setSlashIndex] = useState(0)
 
   // Auto-grow the textarea up to a max height, then scroll internally.
   useEffect(() => {
@@ -101,29 +114,35 @@ export function ChatComposer({
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`
   }, [value])
 
-  const insertToken = useCallback(
-    (token: string) => {
-      const needsSpace = value.length > 0 && !value.endsWith(' ') && !value.endsWith('\n')
-      onChange(`${value}${needsSpace ? ' ' : ''}${token} `)
-      // Refocus so the user can keep typing after picking from a menu.
+  // Derive whether the "/" menu should be visible and which commands match.
+  const slashQuery =
+    value.startsWith('/') && !value.includes(' ') && !value.includes('\n')
+      ? value.slice(1).toLowerCase()
+      : null
+  const slashMatches = slashQuery === null ? [] : filterSlashCommands(slashQuery)
+
+  // Keep the menu open state in sync with whether there is a "/" query + matches.
+  useEffect(() => {
+    const shouldOpen = slashQuery !== null && slashMatches.length > 0
+    setSlashOpen(shouldOpen)
+    if (shouldOpen) {
+      setSlashIndex(0)
+    }
+  }, [slashQuery, slashMatches.length])
+
+  const runSlashCommand = useCallback(
+    (command: SlashCommand) => {
+      if (command.kind === 'template') {
+        onChange(command.template)
+      } else {
+        // Action: clear the "/command" draft, then run it.
+        onChange('')
+        onSlashAction(command.action)
+      }
+      setSlashOpen(false)
       window.requestAnimationFrame(() => textareaRef.current?.focus())
     },
-    [value, onChange]
-  )
-
-  const onPickFiles = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const files = event.target.files
-      if (files && files.length > 0) {
-        const names = Array.from(files)
-          .map((file) => file.name)
-          .join(' ')
-        insertToken(names)
-      }
-      // Reset so picking the same file again re-fires change.
-      event.target.value = ''
-    },
-    [insertToken]
+    [onChange, onSlashAction]
   )
 
   const profileOptions = buildProfileOptions(customProviders)
@@ -144,44 +163,82 @@ export function ChatComposer({
   return (
     <div className="mx-auto w-full max-w-3xl">
       <div className="flex flex-col gap-1 rounded-2xl border border-input bg-background px-3 py-2 shadow-sm transition-colors focus-within:border-ring">
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          onKeyDown={(event) => {
-            // Why (BUG 3, IME): guard the Enter-to-send against IME composition.
-            // While composing Chinese/Japanese/etc., pressing Enter COMMITS the
-            // candidate — it must not trigger a send. `isComposing`/keyCode 229
-            // mark an in-progress composition; firing onSend() there both sends a
-            // half-typed prompt AND lets compositionend re-fill the textarea after
-            // ChatPane's setInput('') runs, so the box still shows text. Skipping
-            // send during composition fixes both the premature send and the
-            // text-not-cleared symptom.
-            if (
-              event.key === 'Enter' &&
-              !event.shiftKey &&
-              !event.nativeEvent.isComposing &&
-              event.keyCode !== 229
-            ) {
-              event.preventDefault()
-              onSend()
-            }
-          }}
-          placeholder="Message jcode…"
-          rows={1}
-          className="max-h-[200px] w-full resize-none bg-transparent px-1 py-1.5 text-sm outline-none placeholder:text-muted-foreground"
-        />
-        <div className="flex items-center gap-1.5">
-          {/* Hidden native picker for "Add files". Browser-native to avoid a new
-              IPC surface; we append the chosen file name(s) into the draft. */}
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="hidden"
-            onChange={onPickFiles}
-          />
+        {/* Attachment chips above the textarea. */}
+        <ChatAttachmentChips attachments={attachments} onRemove={onRemoveAttachment} />
 
+        <div className="relative">
+          {slashOpen ? (
+            <SlashCommandPopover
+              matches={slashMatches}
+              activeIndex={slashIndex}
+              onHover={setSlashIndex}
+              onPick={runSlashCommand}
+            />
+          ) : null}
+
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            onPaste={(event) => {
+              // Auto-convert a very large paste into a collapsible text attachment
+              // so big content doesn't bloat the input box.
+              const text = event.clipboardData.getData('text')
+              if (text && text.length > LARGE_PASTE_THRESHOLD) {
+                event.preventDefault()
+                const firstLine = text.split('\n', 1)[0].trim().slice(0, 40)
+                onAddText(text, firstLine ? `Pasted: ${firstLine}…` : 'Pasted text')
+              }
+            }}
+            onKeyDown={(event) => {
+              // Slash menu keyboard nav takes priority while open.
+              if (slashOpen && slashMatches.length > 0) {
+                if (event.key === 'ArrowDown') {
+                  event.preventDefault()
+                  setSlashIndex((i) => (i + 1) % slashMatches.length)
+                  return
+                }
+                if (event.key === 'ArrowUp') {
+                  event.preventDefault()
+                  setSlashIndex((i) => (i - 1 + slashMatches.length) % slashMatches.length)
+                  return
+                }
+                if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+                  event.preventDefault()
+                  runSlashCommand(slashMatches[slashIndex])
+                  return
+                }
+                if (event.key === 'Escape') {
+                  event.preventDefault()
+                  setSlashOpen(false)
+                  return
+                }
+              }
+              // Why (BUG 3, IME): guard the Enter-to-send against IME composition.
+              // While composing Chinese/Japanese/etc., pressing Enter COMMITS the
+              // candidate — it must not trigger a send. `isComposing`/keyCode 229
+              // mark an in-progress composition; firing onSend() there both sends a
+              // half-typed prompt AND lets compositionend re-fill the textarea after
+              // ChatPane's setInput('') runs, so the box still shows text. Skipping
+              // send during composition fixes both the premature send and the
+              // text-not-cleared symptom.
+              if (
+                event.key === 'Enter' &&
+                !event.shiftKey &&
+                !event.nativeEvent.isComposing &&
+                event.keyCode !== 229
+              ) {
+                event.preventDefault()
+                onSend()
+              }
+            }}
+            placeholder="Message jcode…  (type / for commands)"
+            rows={1}
+            className="max-h-[200px] w-full resize-none bg-transparent px-1 py-1.5 text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+
+        <div className="flex items-center gap-1.5">
           {/* "+" menu */}
           <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
             <DropdownMenuTrigger asChild>
@@ -197,25 +254,36 @@ export function ChatComposer({
               <DropdownMenuItem
                 onSelect={() => {
                   // Defer so the menu closes before the OS dialog opens.
-                  window.requestAnimationFrame(() => fileInputRef.current?.click())
+                  window.requestAnimationFrame(() => onAddFiles())
                 }}
               >
                 <Paperclip className="size-4" />
-                Add files or photos
+                Add files
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => {
+                  window.requestAnimationFrame(() => {
+                    const text = window.prompt('Paste or type text to attach:')
+                    if (text && text.trim()) {
+                      const firstLine = text.split('\n', 1)[0].trim().slice(0, 40)
+                      onAddText(text, firstLine ? firstLine : 'Text')
+                    }
+                  })
+                }}
+              >
+                <Type className="size-4" />
+                Add text
               </DropdownMenuItem>
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>
                   <Slash className="size-4" />
-                  Slash commands
+                  Quick commands
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="min-w-[16rem]">
-                  {SLASH_COMMANDS.map((entry) => (
-                    <DropdownMenuItem
-                      key={entry.command}
-                      onSelect={() => insertToken(entry.command)}
-                    >
-                      <span className="font-medium">{entry.command}</span>
-                      <span className="ml-auto text-xs text-muted-foreground">{entry.hint}</span>
+                  {SLASH_COMMANDS.map((command) => (
+                    <DropdownMenuItem key={command.id} onSelect={() => runSlashCommand(command)}>
+                      <span className="font-medium">{command.label}</span>
+                      <span className="ml-auto text-xs text-muted-foreground">{command.hint}</span>
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuSubContent>
@@ -358,7 +426,7 @@ export function ChatComposer({
             <button
               type="button"
               onClick={onSend}
-              disabled={!value.trim()}
+              disabled={!value.trim() && attachments.length === 0}
               aria-label="Send"
               className={cn(
                 'flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity',

--- a/src/renderer/src/components/chat-pane/ChatComposer.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposer.tsx
@@ -1,0 +1,298 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  ArrowUp,
+  ChevronDown,
+  Mic,
+  Paperclip,
+  Plug,
+  Plus,
+  Puzzle,
+  Slash,
+  Square
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { JCODE_PROVIDERS, findProviderOption } from './jcode-providers'
+
+// Why: the composer is the Claude-app-style bottom bar. It owns the unsent
+// draft text (local state) and the auto-growing textarea, but the provider/model
+// selection is lifted to the chat-session-store via props so it persists per
+// sessionKey across tab switches. Keeping it a separate component keeps ChatPane
+// focused on the message list + send wiring.
+
+// A small, discoverable set of jcode slash commands. Selecting one inserts the
+// token into the draft so the user can complete it. jcode resolves the actual
+// skill; this is just an affordance.
+const SLASH_COMMANDS: { command: string; hint: string }[] = [
+  { command: '/init', hint: 'Summarize the project into context' },
+  { command: '/review', hint: 'Review the current diff' },
+  { command: '/security-review', hint: 'Audit changes for vulnerabilities' },
+  { command: '/run', hint: 'Run the app to verify a change' },
+  { command: '/compact', hint: 'Compact the conversation' }
+]
+
+export function ChatComposer({
+  value,
+  onChange,
+  onSend,
+  onStop,
+  isStreaming,
+  provider,
+  model,
+  onSelectProvider
+}: {
+  value: string
+  onChange: (next: string) => void
+  onSend: () => void
+  onStop: () => void
+  isStreaming: boolean
+  /** Selected provider id, or undefined for "Auto". */
+  provider: string | undefined
+  model: string | undefined
+  onSelectProvider: (selection: {
+    provider: string | undefined
+    model?: string | undefined
+  }) => void
+}): React.JSX.Element {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  // Auto-grow the textarea up to a max height, then scroll internally.
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el) {
+      return
+    }
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`
+  }, [value])
+
+  const insertToken = useCallback(
+    (token: string) => {
+      const needsSpace = value.length > 0 && !value.endsWith(' ') && !value.endsWith('\n')
+      onChange(`${value}${needsSpace ? ' ' : ''}${token} `)
+      // Refocus so the user can keep typing after picking from a menu.
+      window.requestAnimationFrame(() => textareaRef.current?.focus())
+    },
+    [value, onChange]
+  )
+
+  const onPickFiles = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = event.target.files
+      if (files && files.length > 0) {
+        const names = Array.from(files)
+          .map((file) => file.name)
+          .join(' ')
+        insertToken(names)
+      }
+      // Reset so picking the same file again re-fires change.
+      event.target.value = ''
+    },
+    [insertToken]
+  )
+
+  const providerOption = findProviderOption(provider)
+  const chipLabel = providerOption
+    ? model
+      ? `${providerOption.label} · ${model}`
+      : providerOption.label
+    : 'Auto'
+
+  return (
+    <div className="mx-auto w-full max-w-3xl">
+      <div className="flex flex-col gap-1 rounded-2xl border border-input bg-background px-3 py-2 shadow-sm transition-colors focus-within:border-ring">
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+              event.preventDefault()
+              onSend()
+            }
+          }}
+          placeholder="Message jcode…"
+          rows={1}
+          className="max-h-[200px] w-full resize-none bg-transparent px-1 py-1.5 text-sm outline-none placeholder:text-muted-foreground"
+        />
+        <div className="flex items-center gap-1.5">
+          {/* Hidden native picker for "Add files". Browser-native to avoid a new
+              IPC surface; we append the chosen file name(s) into the draft. */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={onPickFiles}
+          />
+
+          {/* "+" menu */}
+          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Add to message"
+                className="flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <Plus className="size-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="min-w-[14rem]">
+              <DropdownMenuItem
+                onSelect={() => {
+                  // Defer so the menu closes before the OS dialog opens.
+                  window.requestAnimationFrame(() => fileInputRef.current?.click())
+                }}
+              >
+                <Paperclip className="size-4" />
+                Add files or photos
+              </DropdownMenuItem>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <Slash className="size-4" />
+                  Slash commands
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="min-w-[16rem]">
+                  {SLASH_COMMANDS.map((entry) => (
+                    <DropdownMenuItem
+                      key={entry.command}
+                      onSelect={() => insertToken(entry.command)}
+                    >
+                      <span className="font-medium">{entry.command}</span>
+                      <span className="ml-auto text-xs text-muted-foreground">{entry.hint}</span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem disabled>
+                <Plug className="size-4" />
+                Connectors
+                <span className="ml-auto text-xs text-muted-foreground">Soon</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem disabled>
+                <Puzzle className="size-4" />
+                Plugins
+                <span className="ml-auto text-xs text-muted-foreground">Soon</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Provider / model chip ("Auto" by default) */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="flex h-8 items-center gap-1 rounded-full px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                {chipLabel}
+                <ChevronDown className="size-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="min-w-[15rem]">
+              <DropdownMenuLabel>Model</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={provider ?? '__auto__'}
+                onValueChange={(next) => {
+                  if (next === '__auto__') {
+                    onSelectProvider({ provider: undefined, model: undefined })
+                    return
+                  }
+                  const option = findProviderOption(next)
+                  onSelectProvider({ provider: next, model: option?.models?.[0] })
+                }}
+              >
+                <DropdownMenuRadioItem value="__auto__">
+                  Auto
+                  <span className="ml-auto text-xs text-muted-foreground">default</span>
+                </DropdownMenuRadioItem>
+                {JCODE_PROVIDERS.map((entry) => (
+                  <DropdownMenuRadioItem key={entry.id} value={entry.id}>
+                    {entry.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+              {providerOption?.models && providerOption.models.length > 0 ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel>{providerOption.label} model</DropdownMenuLabel>
+                  <DropdownMenuRadioGroup
+                    value={model ?? providerOption.models[0]}
+                    onValueChange={(next) => onSelectProvider({ provider, model: next })}
+                  >
+                    {providerOption.models.map((modelId) => (
+                      <DropdownMenuRadioItem key={modelId} value={modelId}>
+                        {modelId}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <div className="flex-1" />
+
+          {/* Mic / voice — disabled until a speech skill is wired in. */}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span tabIndex={-1}>
+                  <button
+                    type="button"
+                    disabled
+                    aria-label="Voice input"
+                    className="flex size-8 cursor-not-allowed items-center justify-center rounded-full text-muted-foreground opacity-50"
+                  >
+                    <Mic className="size-4" />
+                  </button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>语音转写需安装语音技能</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
+          {/* Send / Stop */}
+          {isStreaming ? (
+            <button
+              type="button"
+              onClick={onStop}
+              aria-label="Stop"
+              className="flex size-8 items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-90"
+            >
+              <Square className="size-3.5 fill-current" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onSend}
+              disabled={!value.trim()}
+              aria-label="Send"
+              className={cn(
+                'flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity',
+                'disabled:cursor-not-allowed disabled:opacity-40'
+              )}
+            >
+              <ArrowUp className="size-4" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/chat-pane/ChatComposerExtras.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposerExtras.tsx
@@ -1,11 +1,17 @@
 import { FileText, Paperclip, Puzzle, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
 import type { JcodeChatAttachment } from '../../../../shared/jcode-chat-types'
 import type { SlashCommand } from './chat-slash-commands'
 
 /** A short, human label for an attachment chip. */
 function attachmentLabel(attachment: JcodeChatAttachment): string {
-  return attachment.name || (attachment.kind === 'file' ? attachment.path : 'text')
+  return (
+    attachment.name ||
+    (attachment.kind === 'file'
+      ? attachment.path
+      : translate('jcode.chat.attachment.defaultTextName', 'Text'))
+  )
 }
 
 /** Removable chips for the composer's pending attachments (files + text blobs),
@@ -36,7 +42,7 @@ export function ChatAttachmentChips({
           <span className="truncate">{attachmentLabel(attachment)}</span>
           <button
             type="button"
-            aria-label="Remove attachment"
+            aria-label={translate('jcode.chat.attachment.removeAria', 'Remove attachment')}
             className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
             onClick={() => onRemove(index)}
           >
@@ -100,10 +106,12 @@ export function SkillChip({
     <div className="flex flex-wrap gap-1.5 px-1 pb-1">
       <span className="inline-flex max-w-[16rem] items-center gap-1.5 rounded-md border border-primary/40 bg-primary/10 px-2 py-1 text-xs text-foreground">
         <Puzzle className="size-3 shrink-0 text-primary" />
-        <span className="truncate">skill: {name}</span>
+        <span className="truncate">
+          {translate('jcode.chat.skillChip.prefix', 'Skill:')} {name}
+        </span>
         <button
           type="button"
-          aria-label="Remove skill"
+          aria-label={translate('jcode.chat.skillChip.removeAria', 'Remove skill')}
           className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
           onClick={onRemove}
         >
@@ -139,7 +147,7 @@ export function SlashCommandPopover({
       {commands.length > 0 ? (
         <>
           <div className="border-b border-border px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            Orca quick commands
+            {translate('jcode.chat.slash.commandsHeading', 'Orca quick commands')}
           </div>
           {commands.map((command, i) => (
             <SlashRow
@@ -156,7 +164,7 @@ export function SlashCommandPopover({
       {skills.length > 0 ? (
         <>
           <div className="border-y border-border px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            Skills
+            {translate('jcode.chat.slash.skillsHeading', 'Skills')}
           </div>
           {skills.map((command, i) => (
             <SlashRow
@@ -173,7 +181,10 @@ export function SlashCommandPopover({
       ) : null}
       {degraded ? (
         <div className="border-t border-border px-2.5 py-1.5 text-[11px] text-muted-foreground">
-          Project skills on the remote host were unavailable; showing global skills only.
+          {translate(
+            'jcode.chat.slash.projectSkillsUnavailable',
+            'Project skills on the remote host were unavailable; showing global skills only.'
+          )}
         </div>
       ) : null}
     </div>

--- a/src/renderer/src/components/chat-pane/ChatComposerExtras.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposerExtras.tsx
@@ -135,7 +135,7 @@ export function SlashCommandPopover({
   degraded?: boolean
 }): React.JSX.Element {
   return (
-    <div className="absolute bottom-full left-0 z-20 mb-1 max-h-72 w-full max-w-sm overflow-y-auto rounded-lg border border-border bg-popover shadow-md">
+    <div className="absolute bottom-full left-0 z-20 mb-1 max-h-72 w-full max-w-sm overflow-y-auto scrollbar-sleek rounded-lg border border-border bg-popover shadow-md">
       {commands.length > 0 ? (
         <>
           <div className="border-b border-border px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">

--- a/src/renderer/src/components/chat-pane/ChatComposerExtras.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposerExtras.tsx
@@ -1,4 +1,4 @@
-import { FileText, Paperclip, X } from 'lucide-react'
+import { FileText, Paperclip, Puzzle, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { JcodeChatAttachment } from '../../../../shared/jcode-chat-types'
 import type { SlashCommand } from './chat-slash-commands'
@@ -48,42 +48,134 @@ export function ChatAttachmentChips({
   )
 }
 
-/** The "/"-triggered quick-command popover, anchored above the textarea. */
-export function SlashCommandPopover({
-  matches,
+/** One selectable row inside the slash popover. `index` is the FLAT index across
+ *  both groups so keyboard nav (activeIndex) works uniformly. */
+function SlashRow({
+  command,
+  index,
   activeIndex,
   onHover,
   onPick
 }: {
-  matches: SlashCommand[]
+  command: SlashCommand
+  index: number
   activeIndex: number
   onHover: (index: number) => void
   onPick: (command: SlashCommand) => void
 }): React.JSX.Element {
   return (
-    <div className="absolute bottom-full left-0 z-20 mb-1 w-full max-w-sm overflow-hidden rounded-lg border border-border bg-popover shadow-md">
-      <div className="border-b border-border px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-        Orca quick commands
-      </div>
-      {matches.map((command, index) => (
+    <button
+      type="button"
+      className={cn(
+        'flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm transition-colors',
+        index === activeIndex ? 'bg-muted' : 'hover:bg-muted'
+      )}
+      onMouseEnter={() => onHover(index)}
+      onMouseDown={(event) => {
+        // mousedown so the textarea doesn't lose focus before we act.
+        event.preventDefault()
+        onPick(command)
+      }}
+    >
+      <span className="truncate font-medium">{command.label}</span>
+      <span className="ml-auto truncate pl-2 text-xs text-muted-foreground">{command.hint}</span>
+    </button>
+  )
+}
+
+/** FEATURE B: a chip for the skill armed for the next send. Its SKILL.md body is
+ *  injected into the prompt by the main process; this only shows the name + a ✕
+ *  to disarm. Renders nothing when no skill is armed. */
+export function SkillChip({
+  name,
+  onRemove
+}: {
+  name: string | null | undefined
+  onRemove: () => void
+}): React.JSX.Element | null {
+  if (!name) {
+    return null
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5 px-1 pb-1">
+      <span className="inline-flex max-w-[16rem] items-center gap-1.5 rounded-md border border-primary/40 bg-primary/10 px-2 py-1 text-xs text-foreground">
+        <Puzzle className="size-3 shrink-0 text-primary" />
+        <span className="truncate">skill: {name}</span>
         <button
-          key={command.id}
           type="button"
-          className={cn(
-            'flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm transition-colors',
-            index === activeIndex ? 'bg-muted' : 'hover:bg-muted'
-          )}
-          onMouseEnter={() => onHover(index)}
-          onMouseDown={(event) => {
-            // mousedown so the textarea doesn't lose focus before we act.
-            event.preventDefault()
-            onPick(command)
-          }}
+          aria-label="Remove skill"
+          className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+          onClick={onRemove}
         >
-          <span className="font-medium">{command.label}</span>
-          <span className="ml-auto text-xs text-muted-foreground">{command.hint}</span>
+          <X className="size-3" />
         </button>
-      ))}
+      </span>
+    </div>
+  )
+}
+
+/** The "/"-triggered popover, anchored above the textarea. Renders two grouped
+ *  sections — orca quick commands + project/global skills — with a single FLAT
+ *  active index so ↑/↓ moves across both. The flat order is `commands` then
+ *  `skills`; the caller computes activeIndex against that same concatenation. */
+export function SlashCommandPopover({
+  commands,
+  skills,
+  activeIndex,
+  onHover,
+  onPick,
+  degraded
+}: {
+  commands: SlashCommand[]
+  skills: SlashCommand[]
+  activeIndex: number
+  onHover: (index: number) => void
+  onPick: (command: SlashCommand) => void
+  /** True when a remote project's project-local skills could not be read. */
+  degraded?: boolean
+}): React.JSX.Element {
+  return (
+    <div className="absolute bottom-full left-0 z-20 mb-1 max-h-72 w-full max-w-sm overflow-y-auto rounded-lg border border-border bg-popover shadow-md">
+      {commands.length > 0 ? (
+        <>
+          <div className="border-b border-border px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Orca quick commands
+          </div>
+          {commands.map((command, i) => (
+            <SlashRow
+              key={command.id}
+              command={command}
+              index={i}
+              activeIndex={activeIndex}
+              onHover={onHover}
+              onPick={onPick}
+            />
+          ))}
+        </>
+      ) : null}
+      {skills.length > 0 ? (
+        <>
+          <div className="border-y border-border px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Skills
+          </div>
+          {skills.map((command, i) => (
+            <SlashRow
+              key={command.id}
+              command={command}
+              // Flat index continues after the commands group.
+              index={commands.length + i}
+              activeIndex={activeIndex}
+              onHover={onHover}
+              onPick={onPick}
+            />
+          ))}
+        </>
+      ) : null}
+      {degraded ? (
+        <div className="border-t border-border px-2.5 py-1.5 text-[11px] text-muted-foreground">
+          Project skills on the remote host were unavailable; showing global skills only.
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/components/chat-pane/ChatComposerExtras.tsx
+++ b/src/renderer/src/components/chat-pane/ChatComposerExtras.tsx
@@ -1,0 +1,89 @@
+import { FileText, Paperclip, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { JcodeChatAttachment } from '../../../../shared/jcode-chat-types'
+import type { SlashCommand } from './chat-slash-commands'
+
+/** A short, human label for an attachment chip. */
+function attachmentLabel(attachment: JcodeChatAttachment): string {
+  return attachment.name || (attachment.kind === 'file' ? attachment.path : 'text')
+}
+
+/** Removable chips for the composer's pending attachments (files + text blobs),
+ *  rendered above the textarea. Renders nothing when there are no attachments. */
+export function ChatAttachmentChips({
+  attachments,
+  onRemove
+}: {
+  attachments: JcodeChatAttachment[]
+  onRemove: (index: number) => void
+}): React.JSX.Element | null {
+  if (attachments.length === 0) {
+    return null
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5 px-1 pb-1">
+      {attachments.map((attachment, index) => (
+        <span
+          key={`${attachment.kind}-${index}-${attachmentLabel(attachment)}`}
+          className="inline-flex max-w-[16rem] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-xs text-foreground"
+          title={attachment.kind === 'file' ? attachment.path : attachment.name}
+        >
+          {attachment.kind === 'file' ? (
+            <Paperclip className="size-3 shrink-0 text-muted-foreground" />
+          ) : (
+            <FileText className="size-3 shrink-0 text-muted-foreground" />
+          )}
+          <span className="truncate">{attachmentLabel(attachment)}</span>
+          <button
+            type="button"
+            aria-label="Remove attachment"
+            className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+            onClick={() => onRemove(index)}
+          >
+            <X className="size-3" />
+          </button>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/** The "/"-triggered quick-command popover, anchored above the textarea. */
+export function SlashCommandPopover({
+  matches,
+  activeIndex,
+  onHover,
+  onPick
+}: {
+  matches: SlashCommand[]
+  activeIndex: number
+  onHover: (index: number) => void
+  onPick: (command: SlashCommand) => void
+}): React.JSX.Element {
+  return (
+    <div className="absolute bottom-full left-0 z-20 mb-1 w-full max-w-sm overflow-hidden rounded-lg border border-border bg-popover shadow-md">
+      <div className="border-b border-border px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        Orca quick commands
+      </div>
+      {matches.map((command, index) => (
+        <button
+          key={command.id}
+          type="button"
+          className={cn(
+            'flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm transition-colors',
+            index === activeIndex ? 'bg-muted' : 'hover:bg-muted'
+          )}
+          onMouseEnter={() => onHover(index)}
+          onMouseDown={(event) => {
+            // mousedown so the textarea doesn't lose focus before we act.
+            event.preventDefault()
+            onPick(command)
+          }}
+        >
+          <span className="font-medium">{command.label}</span>
+          <span className="ml-auto text-xs text-muted-foreground">{command.hint}</span>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/chat-pane/ChatModelPicker.tsx
+++ b/src/renderer/src/components/chat-pane/ChatModelPicker.tsx
@@ -1,0 +1,225 @@
+import { Fragment } from 'react'
+import { Check, ChevronDown, RefreshCw } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import type { JcodeCustomProvider } from '../../../../shared/jcode-chat-types'
+import {
+  JCODE_PROVIDERS,
+  buildProfileOptions,
+  findProfileOption,
+  findProviderOption,
+  groupCatalogRoutes,
+  useJcodeModelCatalog
+} from './jcode-providers'
+
+// Why: the detailed model picker (Claude/Codex-app style) is its own component
+// so the composer file stays under the repo's max-lines lint. It is driven by the
+// REAL catalog (`jcode model list --json`): models grouped by provider, per-model
+// availability, the current model checked, and an accurate "Auto → <resolved>".
+
+// Custom profiles are namespaced so their React keys never collide with a
+// built-in provider id.
+const PROFILE_PREFIX = 'profile:'
+
+export type ModelSelection = {
+  provider?: string | undefined
+  providerProfile?: string | undefined
+  model?: string | undefined
+}
+
+export function ChatModelPicker({
+  provider,
+  providerProfile,
+  model,
+  customProviders,
+  onSelectProvider
+}: {
+  /** Selected built-in provider id, or undefined for "Auto"/profile. */
+  provider: string | undefined
+  /** Selected custom provider profile name (mutually exclusive with provider). */
+  providerProfile?: string | undefined
+  model: string | undefined
+  customProviders?: JcodeCustomProvider[]
+  onSelectProvider: (selection: ModelSelection) => void
+}): React.JSX.Element {
+  const { catalog, loading: catalogLoading, refresh: refreshCatalog } = useJcodeModelCatalog()
+  const modelGroups = groupCatalogRoutes(catalog)
+  const catalogProviderIds = new Set(modelGroups.map((group) => group.providerId))
+  // Built-in providers NOT present in the catalog (e.g. Gemini/OpenRouter that
+  // aren't authed yet) stay reachable as provider-only picks under "更多 Provider".
+  const otherProviders = JCODE_PROVIDERS.filter((entry) => !catalogProviderIds.has(entry.id))
+
+  const profileOptions = buildProfileOptions(customProviders)
+  const activeProfileOption = findProfileOption(customProviders, providerProfile)
+  const isAuto = !provider && !providerProfile
+  // Chip: show the concrete model when one is picked (Claude/Codex style), else
+  // the provider label, else "Auto".
+  const chipLabel = providerProfile
+    ? model
+      ? `${activeProfileOption?.label ?? providerProfile} · ${model}`
+      : (activeProfileOption?.label ?? providerProfile)
+    : model
+      ? model
+      : provider
+        ? (findProviderOption(provider)?.label ?? provider)
+        : 'Auto'
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex h-8 items-center gap-1 rounded-full px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          {chipLabel}
+          <ChevronDown className="size-3.5" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="max-h-[60vh] min-w-[17rem] overflow-y-auto">
+        <DropdownMenuLabel>模型 Model</DropdownMenuLabel>
+
+        {/* Auto — show what jcode actually resolves it to. */}
+        <DropdownMenuItem
+          onSelect={() =>
+            onSelectProvider({ provider: undefined, providerProfile: undefined, model: undefined })
+          }
+        >
+          <Check className={cn('size-3.5', isAuto ? 'opacity-100' : 'opacity-0')} />
+          <span className="font-medium">Auto</span>
+          <span className="ml-auto text-xs text-muted-foreground">
+            {catalog?.selectedModel ? `→ ${catalog.selectedModel}` : '自动选择'}
+          </span>
+        </DropdownMenuItem>
+
+        {/* Real catalog, grouped by provider with per-model availability. */}
+        {modelGroups.map((group) => (
+          <Fragment key={group.providerDisplay}>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              {group.providerDisplay}
+            </DropdownMenuLabel>
+            {group.models.map((entry) => {
+              const active = !providerProfile && provider === group.providerId && model === entry.id
+              return (
+                <DropdownMenuItem
+                  key={entry.id}
+                  onSelect={() =>
+                    onSelectProvider({
+                      provider: group.providerId,
+                      providerProfile: undefined,
+                      model: entry.id
+                    })
+                  }
+                >
+                  <Check className={cn('size-3.5', active ? 'opacity-100' : 'opacity-0')} />
+                  <span className={cn('truncate', !entry.available && 'text-muted-foreground')}>
+                    {entry.id}
+                  </span>
+                  {!entry.available ? (
+                    <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
+                      需登录
+                    </span>
+                  ) : null}
+                </DropdownMenuItem>
+              )
+            })}
+          </Fragment>
+        ))}
+
+        {/* User-added custom OpenAI-compatible profiles. */}
+        {profileOptions.length > 0 ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              自定义 Provider
+            </DropdownMenuLabel>
+            {profileOptions.map((entry) => {
+              const active = providerProfile === entry.id
+              return (
+                <DropdownMenuItem
+                  key={`${PROFILE_PREFIX}${entry.id}`}
+                  onSelect={() =>
+                    onSelectProvider({
+                      provider: undefined,
+                      providerProfile: entry.id,
+                      model: entry.models?.[0]
+                    })
+                  }
+                >
+                  <Check className={cn('size-3.5', active ? 'opacity-100' : 'opacity-0')} />
+                  <span className="truncate">{entry.label}</span>
+                  {entry.models?.[0] ? (
+                    <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
+                      {entry.models[0]}
+                    </span>
+                  ) : null}
+                </DropdownMenuItem>
+              )
+            })}
+          </>
+        ) : null}
+
+        {/* Providers not in the catalog (not authed yet) — provider-only pick. */}
+        {otherProviders.length > 0 ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>更多 Provider</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="max-h-[50vh] overflow-y-auto">
+                {otherProviders.map((entry) => {
+                  const active = !providerProfile && provider === entry.id && !model
+                  return (
+                    <DropdownMenuItem
+                      key={entry.id}
+                      onSelect={() =>
+                        onSelectProvider({
+                          provider: entry.id,
+                          providerProfile: undefined,
+                          model: undefined
+                        })
+                      }
+                    >
+                      <Check className={cn('size-3.5', active ? 'opacity-100' : 'opacity-0')} />
+                      {entry.label}
+                    </DropdownMenuItem>
+                  )
+                })}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </>
+        ) : null}
+
+        {catalog && !catalog.ok ? (
+          <>
+            <DropdownMenuSeparator />
+            <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
+              无法读取模型列表{catalog.error ? `:${catalog.error}` : ''}
+            </div>
+          </>
+        ) : null}
+
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={(event) => {
+            // Keep the menu open so the user sees the refreshed list.
+            event.preventDefault()
+            refreshCatalog()
+          }}
+        >
+          <RefreshCw className={cn('size-3.5', catalogLoading && 'animate-spin')} />
+          刷新模型列表
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/chat-pane/ChatModelPicker.tsx
+++ b/src/renderer/src/components/chat-pane/ChatModelPicker.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react'
 import { Check, ChevronDown, RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -62,6 +63,7 @@ export function ChatModelPicker({
   const profileOptions = buildProfileOptions(customProviders)
   const activeProfileOption = findProfileOption(customProviders, providerProfile)
   const isAuto = !provider && !providerProfile
+  const autoLabel = translate('jcode.chat.modelPicker.auto', 'Auto')
   // Chip: show the concrete model when one is picked (Claude/Codex style), else
   // the provider label, else "Auto".
   const chipLabel = providerProfile
@@ -72,7 +74,7 @@ export function ChatModelPicker({
       ? model
       : provider
         ? (findProviderOption(provider)?.label ?? provider)
-        : 'Auto'
+        : autoLabel
 
   return (
     <DropdownMenu>
@@ -89,7 +91,9 @@ export function ChatModelPicker({
         align="start"
         className="max-h-[60vh] min-w-[17rem] overflow-y-auto scrollbar-sleek"
       >
-        <DropdownMenuLabel>模型 Model</DropdownMenuLabel>
+        <DropdownMenuLabel>
+          {translate('jcode.chat.modelPicker.modelLabel', 'Model')}
+        </DropdownMenuLabel>
 
         {/* Auto — show what jcode actually resolves it to. */}
         <DropdownMenuItem
@@ -98,9 +102,11 @@ export function ChatModelPicker({
           }
         >
           <Check className={cn('size-3.5', isAuto ? 'opacity-100' : 'opacity-0')} />
-          <span className="font-medium">Auto</span>
+          <span className="font-medium">{autoLabel}</span>
           <span className="ml-auto text-xs text-muted-foreground">
-            {catalog?.selectedModel ? `→ ${catalog.selectedModel}` : '自动选择'}
+            {catalog?.selectedModel
+              ? `→ ${catalog.selectedModel}`
+              : translate('jcode.chat.modelPicker.autoSelect', 'Auto-select')}
           </span>
         </DropdownMenuItem>
 
@@ -130,7 +136,7 @@ export function ChatModelPicker({
                   </span>
                   {!entry.available ? (
                     <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
-                      需登录
+                      {translate('jcode.chat.modelPicker.signInRequired', 'Sign in required')}
                     </span>
                   ) : null}
                 </DropdownMenuItem>
@@ -144,7 +150,7 @@ export function ChatModelPicker({
           <>
             <DropdownMenuSeparator />
             <DropdownMenuLabel className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-              自定义 Provider
+              {translate('jcode.chat.modelPicker.customProvider', 'Custom provider')}
             </DropdownMenuLabel>
             {profileOptions.map((entry) => {
               const active = providerProfile === entry.id
@@ -177,7 +183,9 @@ export function ChatModelPicker({
           <>
             <DropdownMenuSeparator />
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger>更多 Provider</DropdownMenuSubTrigger>
+              <DropdownMenuSubTrigger>
+                {translate('jcode.chat.modelPicker.moreProviders', 'More providers')}
+              </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="max-h-[50vh] overflow-y-auto scrollbar-sleek">
                 {otherProviders.map((entry) => {
                   const active = !providerProfile && provider === entry.id && !model
@@ -206,7 +214,8 @@ export function ChatModelPicker({
           <>
             <DropdownMenuSeparator />
             <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
-              无法读取模型列表{catalog.error ? `:${catalog.error}` : ''}
+              {translate('jcode.chat.modelPicker.modelListError', 'Unable to read model list')}
+              {catalog.error ? `: ${catalog.error}` : ''}
             </div>
           </>
         ) : null}
@@ -220,7 +229,7 @@ export function ChatModelPicker({
           }}
         >
           <RefreshCw className={cn('size-3.5', catalogLoading && 'animate-spin')} />
-          刷新模型列表
+          {translate('jcode.chat.modelPicker.refreshModels', 'Refresh model list')}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/renderer/src/components/chat-pane/ChatModelPicker.tsx
+++ b/src/renderer/src/components/chat-pane/ChatModelPicker.tsx
@@ -85,7 +85,10 @@ export function ChatModelPicker({
           <ChevronDown className="size-3.5" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="max-h-[60vh] min-w-[17rem] overflow-y-auto">
+      <DropdownMenuContent
+        align="start"
+        className="max-h-[60vh] min-w-[17rem] overflow-y-auto scrollbar-sleek"
+      >
         <DropdownMenuLabel>模型 Model</DropdownMenuLabel>
 
         {/* Auto — show what jcode actually resolves it to. */}
@@ -175,7 +178,7 @@ export function ChatModelPicker({
             <DropdownMenuSeparator />
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>更多 Provider</DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="max-h-[50vh] overflow-y-auto">
+              <DropdownMenuSubContent className="max-h-[50vh] overflow-y-auto scrollbar-sleek">
                 {otherProviders.map((entry) => {
                   const active = !providerProfile && provider === entry.id && !model
                   return (

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -1,27 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import type { JcodeChatEventMessage, JcodeNdjsonEvent } from '../../../../shared/jcode-chat-types'
+import { JcodeToolCard, type JcodeToolCall } from './JcodeToolCard'
 
-// Why: M1 chat-bubble view for the jcode agent. Talking to jcode shows replies
-// as chat bubbles instead of a raw terminal. The NDJSON parsing/render logic is
-// ported from the proven jcode-desktop prototype (src/app.js): text_delta
-// streams into the assistant bubble; tool_* events render a one-line placeholder
-// (full tool cards are M2); the jcode session_id from 'start'/'done' is captured
-// for --resume so the conversation continues across turns.
+// Why: M2 enriches the M1 jcode chat-bubble view. Tool calls render as cards
+// (name + pretty args + output/error, bash special-cased, diffs colorized);
+// text_delta streams smoothly into the assistant bubble; connection_phase shows
+// as a subtle status line; 'error' renders an error bubble; the jcode session_id
+// from 'start'/'done' is captured and passed as --resume so the conversation
+// continues across turns; input is disabled while streaming and a Stop button
+// kills the in-flight jcode child. Parsing mirrors the jcode-desktop prototype
+// (src/app.js) and the documented --ndjson schema.
 
 type ChatRole = 'user' | 'assistant'
-
-type ToolPlaceholder = {
-  id: string
-  name: string
-}
 
 type ChatMessage = {
   id: string
   role: ChatRole
   text: string
-  /** One-line placeholders for tool calls seen during this assistant turn. */
-  tools?: ToolPlaceholder[]
+  /** Tool calls seen during this assistant turn, in arrival order. */
+  tools?: JcodeToolCall[]
   isError?: boolean
 }
 
@@ -68,6 +66,24 @@ export default function ChatPane({
     setMessages((prev) => prev.map((m) => (m.id === targetId ? mutate(m) : m)))
   }, [])
 
+  /** Insert-or-update a tool call on the streaming assistant message by id. */
+  const upsertTool = useCallback(
+    (id: string, mutate: (call: JcodeToolCall) => JcodeToolCall, fallbackName = 'tool') => {
+      appendToStreaming((m) => {
+        const tools = m.tools ?? []
+        const index = tools.findIndex((t) => t.id === id)
+        if (index === -1) {
+          const created = mutate({ id, name: fallbackName, rawInput: '', status: 'running' })
+          return { ...m, tools: [...tools, created] }
+        }
+        const next = tools.slice()
+        next[index] = mutate(next[index])
+        return { ...m, tools: next }
+      })
+    },
+    [appendToStreaming]
+  )
+
   const finalizeTurn = useCallback(() => {
     setIsStreaming(false)
     setStatusDetail(null)
@@ -106,17 +122,40 @@ export default function ChatPane({
           }
           break
         }
-        case 'tool_start':
-        case 'tool_exec': {
-          const id = strField(event, 'id') ?? `${event.type}-${Date.now()}`
+        case 'tool_start': {
+          const id = strField(event, 'id') ?? `tool-${Date.now()}`
           const name = strField(event, 'name') ?? 'tool'
-          appendToStreaming((m) => {
-            const tools = m.tools ?? []
-            if (tools.some((t) => t.id === id)) {
-              return m
-            }
-            return { ...m, tools: [...tools, { id, name }] }
-          })
+          upsertTool(id, (call) => ({ ...call, name }), name)
+          break
+        }
+        case 'tool_input': {
+          // Why: args stream as JSON-string fragments; concatenate them so the
+          // card can parse the full object once complete.
+          const id = strField(event, 'id')
+          const delta = strField(event, 'delta') ?? ''
+          if (id) {
+            upsertTool(id, (call) => ({ ...call, rawInput: call.rawInput + delta }))
+          }
+          break
+        }
+        case 'tool_exec': {
+          const id = strField(event, 'id') ?? `tool-${Date.now()}`
+          const name = strField(event, 'name') ?? 'tool'
+          upsertTool(id, (call) => ({ ...call, status: 'running' }), name)
+          break
+        }
+        case 'tool_done': {
+          const id = strField(event, 'id')
+          const errorText = strField(event, 'error')
+          const output = strField(event, 'output')
+          if (id) {
+            upsertTool(id, (call) => ({
+              ...call,
+              output: output ?? call.output,
+              error: errorText ?? undefined,
+              status: errorText ? 'error' : 'done'
+            }))
+          }
           break
         }
         case 'done': {
@@ -140,21 +179,30 @@ export default function ChatPane({
           finalizeTurn()
           break
         }
+        case 'stopped': {
+          // User pressed Stop: annotate the bubble and close the turn.
+          appendToStreaming((m) => ({
+            ...m,
+            text: m.text ? `${m.text}\n\n(stopped)` : '(stopped)'
+          }))
+          finalizeTurn()
+          break
+        }
         case 'exit': {
-          // Terminal safety net: if the child exited without 'done'/'error',
-          // close the turn so the composer re-enables.
+          // Terminal safety net: if the child exited without 'done'/'error'/
+          // 'stopped', close the turn so the composer re-enables.
           if (streamingIdRef.current) {
             finalizeTurn()
           }
           break
         }
         default:
-          // Ignore unknown / not-yet-rendered event kinds (tool_input,
-          // tool_done, message_end, tokens, connection_type) for M1.
+          // Ignore unknown / not-rendered event kinds (connection_type,
+          // message_end, tokens).
           break
       }
     },
-    [appendToStreaming, finalizeTurn]
+    [appendToStreaming, upsertTool, finalizeTurn]
   )
 
   useEffect(() => {
@@ -193,6 +241,14 @@ export default function ChatPane({
     })
   }, [input, isStreaming, sessionKey, provider, model, cwd])
 
+  const stop = useCallback(() => {
+    if (!isStreaming) {
+      return
+    }
+    setStatusDetail('Stopping…')
+    window.api.jcodeChat.stop({ sessionKey })
+  }, [isStreaming, sessionKey])
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-4 py-4">
@@ -209,7 +265,7 @@ export default function ChatPane({
               >
                 <div
                   className={cn(
-                    'max-w-[85%] whitespace-pre-wrap break-words rounded-lg px-3 py-2 text-sm',
+                    'max-w-[85%] rounded-lg px-3 py-2 text-sm',
                     message.role === 'user'
                       ? 'bg-primary text-primary-foreground'
                       : 'bg-muted text-foreground',
@@ -217,15 +273,20 @@ export default function ChatPane({
                   )}
                 >
                   {message.tools && message.tools.length > 0 ? (
-                    <div className="mb-1 flex flex-col gap-0.5">
+                    <div className="mb-2 flex flex-col gap-1.5">
                       {message.tools.map((tool) => (
-                        <div key={tool.id} className="text-xs text-muted-foreground">
-                          {`⚙ ${tool.name}`}
-                        </div>
+                        <JcodeToolCard key={tool.id} call={tool} />
                       ))}
                     </div>
                   ) : null}
-                  {message.text || (message.role === 'assistant' && isStreaming ? '…' : '')}
+                  <div className="whitespace-pre-wrap break-words">
+                    {message.text ||
+                      (message.role === 'assistant' &&
+                      isStreaming &&
+                      (!message.tools || message.tools.length === 0)
+                        ? '…'
+                        : '')}
+                  </div>
                 </div>
               </div>
             ))}
@@ -233,7 +294,12 @@ export default function ChatPane({
         )}
       </div>
       {statusDetail ? (
-        <div className="px-4 pb-1 text-xs text-muted-foreground">{statusDetail}</div>
+        <div className="px-4 pb-1 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="size-1.5 animate-pulse rounded-full bg-primary" />
+            {statusDetail}
+          </span>
+        </div>
       ) : null}
       <div className="border-t border-border p-3">
         <div className="mx-auto flex w-full max-w-3xl items-end gap-2">
@@ -248,20 +314,34 @@ export default function ChatPane({
             }}
             placeholder="Message jcode…"
             rows={1}
-            className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            disabled={isStreaming}
+            className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
           />
-          <button
-            type="button"
-            onClick={send}
-            disabled={isStreaming || !input.trim()}
-            className={cn(
-              'rounded-md px-3 py-2 text-sm font-medium',
-              'bg-primary text-primary-foreground',
-              'disabled:cursor-not-allowed disabled:opacity-50'
-            )}
-          >
-            Send
-          </button>
+          {isStreaming ? (
+            <button
+              type="button"
+              onClick={stop}
+              className={cn(
+                'rounded-md px-3 py-2 text-sm font-medium',
+                'bg-destructive text-destructive-foreground'
+              )}
+            >
+              Stop
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={send}
+              disabled={!input.trim()}
+              className={cn(
+                'rounded-md px-3 py-2 text-sm font-medium',
+                'bg-primary text-primary-foreground',
+                'disabled:cursor-not-allowed disabled:opacity-50'
+              )}
+            >
+              Send
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -3,7 +3,13 @@ import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { JcodeToolCard } from './JcodeToolCard'
-import { startChatTurn, setChatStatusDetail, useChatSession } from './chat-session-store'
+import {
+  setChatComposerSelection,
+  setChatStatusDetail,
+  startChatTurn,
+  useChatSession
+} from './chat-session-store'
+import { ChatComposer } from './ChatComposer'
 
 // Why: M2 enriches the M1 jcode chat-bubble view. Tool calls render as cards
 // (name + pretty args + output/error, bash special-cased, diffs colorized);
@@ -93,8 +99,12 @@ export default function ChatPane({
   model?: string
 }): React.JSX.Element {
   // Why: conversation state is read from the external store keyed by sessionKey,
-  // so it survives this component unmounting on tab switches.
-  const { messages, isStreaming, statusDetail, resumeSessionId } = useChatSession(sessionKey)
+  // so it survives this component unmounting on tab switches. The composer's
+  // provider/model selection also lives in the store (composerProvider/Model)
+  // so the chip choice persists across tab switches; only the unsent draft text
+  // is local component state.
+  const { messages, isStreaming, statusDetail, resumeSessionId, composerProvider, composerModel } =
+    useChatSession(sessionKey)
   const [input, setInput] = useState('')
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -115,13 +125,25 @@ export default function ChatPane({
     window.api.jcodeChat.send({
       sessionKey,
       prompt,
-      provider,
-      model,
+      // composerProvider undefined ("Auto") falls back to this pane's default.
+      provider: composerProvider ?? provider,
+      model: composerModel ?? model,
       cwd,
       worktreeId,
       resumeSessionId
     })
-  }, [input, isStreaming, sessionKey, provider, model, cwd, worktreeId, resumeSessionId])
+  }, [
+    input,
+    isStreaming,
+    sessionKey,
+    provider,
+    model,
+    composerProvider,
+    composerModel,
+    cwd,
+    worktreeId,
+    resumeSessionId
+  ])
 
   const stop = useCallback(() => {
     if (!isStreaming) {
@@ -132,100 +154,75 @@ export default function ChatPane({
   }, [isStreaming, sessionKey])
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+    <div className="flex h-full min-h-0 w-full flex-col bg-background text-foreground">
       <RemoteExecBanner worktreeId={worktreeId} />
-      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-4 py-4">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
         {messages.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Ask jcode anything. Replies stream in as chat bubbles.
+          <div className="flex h-full flex-col items-center justify-center px-6 text-center">
+            <div className="text-base font-medium text-foreground">Message jcode to start</div>
+            <div className="mt-1 text-sm text-muted-foreground">
+              Replies stream in. Tool calls and diffs render inline.
+            </div>
           </div>
         ) : (
-          <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
-            {messages.map((message) => (
-              <div
-                key={message.id}
-                className={cn('flex', message.role === 'user' ? 'justify-end' : 'justify-start')}
-              >
-                <div
-                  className={cn(
-                    'max-w-[85%] rounded-lg px-3 py-2 text-sm',
-                    message.role === 'user'
-                      ? 'bg-primary text-primary-foreground'
-                      : 'bg-muted text-foreground',
-                    message.isError && 'bg-destructive/15 text-destructive'
-                  )}
-                >
-                  {message.tools && message.tools.length > 0 ? (
-                    <div className="mb-2 flex flex-col gap-1.5">
-                      {message.tools.map((tool) => (
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-6 py-6">
+            {messages.map((message) => {
+              const hasTools = !!message.tools && message.tools.length > 0
+              const placeholder =
+                message.role === 'assistant' && isStreaming && !hasTools && !message.text ? '…' : ''
+              if (message.role === 'user') {
+                return (
+                  <div key={message.id} className="flex justify-end">
+                    <div className="max-w-[85%] rounded-2xl bg-primary px-4 py-2.5 text-sm text-primary-foreground whitespace-pre-wrap break-words">
+                      {message.text}
+                    </div>
+                  </div>
+                )
+              }
+              return (
+                <div key={message.id} className="flex flex-col gap-2">
+                  {hasTools ? (
+                    <div className="flex flex-col gap-1.5">
+                      {message.tools!.map((tool) => (
                         <JcodeToolCard key={tool.id} call={tool} />
                       ))}
                     </div>
                   ) : null}
-                  <div className="whitespace-pre-wrap break-words">
-                    {message.text ||
-                      (message.role === 'assistant' &&
-                      isStreaming &&
-                      (!message.tools || message.tools.length === 0)
-                        ? '…'
-                        : '')}
-                  </div>
+                  {message.text || placeholder ? (
+                    <div
+                      className={cn(
+                        'text-sm leading-relaxed whitespace-pre-wrap break-words',
+                        message.isError ? 'text-destructive' : 'text-foreground'
+                      )}
+                    >
+                      {message.text || placeholder}
+                    </div>
+                  ) : null}
                 </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </div>
-      {statusDetail ? (
-        <div className="px-4 pb-1 text-xs text-muted-foreground">
-          <span className="inline-flex items-center gap-1.5">
-            <span className="size-1.5 animate-pulse rounded-full bg-primary" />
-            {statusDetail}
-          </span>
-        </div>
-      ) : null}
-      <div className="border-t border-border p-3">
-        <div className="mx-auto flex w-full max-w-3xl items-end gap-2">
-          <textarea
-            value={input}
-            onChange={(event) => setInput(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
-                event.preventDefault()
-                send()
-              }
-            }}
-            placeholder="Message jcode…"
-            rows={1}
-            disabled={isStreaming}
-            className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-          />
-          {isStreaming ? (
-            <button
-              type="button"
-              onClick={stop}
-              className={cn(
-                'rounded-md px-3 py-2 text-sm font-medium',
-                'bg-destructive text-destructive-foreground'
-              )}
-            >
-              Stop
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={send}
-              disabled={!input.trim()}
-              className={cn(
-                'rounded-md px-3 py-2 text-sm font-medium',
-                'bg-primary text-primary-foreground',
-                'disabled:cursor-not-allowed disabled:opacity-50'
-              )}
-            >
-              Send
-            </button>
-          )}
-        </div>
+      <div className="px-4 pt-1 pb-3">
+        {statusDetail ? (
+          <div className="mx-auto mb-1.5 w-full max-w-3xl px-1 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="size-1.5 animate-pulse rounded-full bg-primary" />
+              {statusDetail}
+            </span>
+          </div>
+        ) : null}
+        <ChatComposer
+          value={input}
+          onChange={setInput}
+          onSend={send}
+          onStop={stop}
+          isStreaming={isStreaming}
+          provider={composerProvider}
+          model={composerModel}
+          onSelectProvider={(selection) => setChatComposerSelection(sessionKey, selection)}
+        />
       </div>
     </div>
   )

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -2,14 +2,93 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import type { JcodeConversationSummary } from '../../../../shared/jcode-chat-types'
+import { reopenChatConversation } from '@/lib/launch-chat-agent-tab'
 import { JcodeToolCard } from './JcodeToolCard'
 import {
+  deleteChatConversation,
+  hydrateChatSession,
+  listChatConversations,
   setChatComposerSelection,
+  setChatSessionContext,
   setChatStatusDetail,
   startChatTurn,
   useChatSession
 } from './chat-session-store'
 import { ChatComposer } from './ChatComposer'
+
+// Why (BUG 1/2, reopen): the empty state of a chat tab is a self-contained,
+// chat-feature-owned place to surface "Recent chats" — durable conversations
+// persisted to disk. Clicking one recreates its chat tab (reusing the stored
+// sessionKey as the tab id) and rehydrates the transcript. This is intentionally
+// NOT wired into orca's general PTY-agent sidebar (WorktreeCardAgents), which is
+// a different system; see notImplemented in the handoff.
+function RecentChats({
+  worktreeId,
+  excludeSessionKey
+}: {
+  worktreeId?: string
+  excludeSessionKey: string
+}): React.JSX.Element | null {
+  const [recents, setRecents] = useState<JcodeConversationSummary[]>([])
+
+  const refresh = useCallback(() => {
+    void listChatConversations().then((rows) =>
+      setRecents(rows.filter((row) => row.sessionKey !== excludeSessionKey))
+    )
+  }, [excludeSessionKey])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  if (recents.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="mt-6 w-full max-w-md text-left">
+      <div className="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Recent chats
+      </div>
+      <div className="flex flex-col gap-1">
+        {recents.slice(0, 8).map((row) => (
+          <div
+            key={row.sessionKey}
+            className="group flex items-center gap-2 rounded-lg border border-border px-3 py-2 transition-colors hover:bg-muted"
+          >
+            <button
+              type="button"
+              className="min-w-0 flex-1 text-left"
+              onClick={() => {
+                void reopenChatConversation({
+                  conversation: row,
+                  fallbackWorktreeId: worktreeId
+                })
+              }}
+            >
+              <div className="truncate text-sm text-foreground">{row.title}</div>
+              <div className="text-xs text-muted-foreground">
+                {new Date(row.updatedAt).toLocaleString()}
+              </div>
+            </button>
+            <button
+              type="button"
+              aria-label="Delete chat"
+              className="shrink-0 rounded px-2 py-1 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+              onClick={() => {
+                deleteChatConversation(row.sessionKey)
+                refresh()
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 // Why: M2 enriches the M1 jcode chat-bubble view. Tool calls render as cards
 // (name + pretty args + output/error, bash special-cased, diffs colorized);
@@ -108,6 +187,25 @@ export default function ChatPane({
   const [input, setInput] = useState('')
   const scrollRef = useRef<HTMLDivElement>(null)
 
+  // Why (BUG 1, persistence): register this pane's context so disk snapshots are
+  // complete, and rehydrate from disk on mount for a known conversation. The
+  // store's hydrate is a no-op when the session already has live in-memory
+  // messages (kept across a tab switch), so this only fills an empty session
+  // after restart or a reopen. Running it on mount keeps tool-card/diff render
+  // identical because we round-trip the reduced message shape verbatim.
+  useEffect(() => {
+    setChatSessionContext(sessionKey, { worktreeId, cwd })
+    let cancelled = false
+    void window.api.jcodeChat.loadConversation(sessionKey).then((record) => {
+      if (!cancelled && record) {
+        hydrateChatSession(record)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [sessionKey, worktreeId, cwd])
+
   useEffect(() => {
     const bottom = scrollRef.current
     if (bottom) {
@@ -163,6 +261,7 @@ export default function ChatPane({
             <div className="mt-1 text-sm text-muted-foreground">
               Replies stream in. Tool calls and diffs render inline.
             </div>
+            <RecentChats worktreeId={worktreeId} excludeSessionKey={sessionKey} />
           </div>
         ) : (
           <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-6 py-6">

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import type { JcodeChatEventMessage, JcodeNdjsonEvent } from '../../../../shared/jcode-chat-types'
 import { JcodeToolCard, type JcodeToolCall } from './JcodeToolCard'
 
@@ -28,14 +30,75 @@ function strField(event: JcodeNdjsonEvent, key: string): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
+/** Minimal brain-local (M3) affordance: for a folder-scoped chat pane whose
+ *  workspace has an SSH connection, show whether jcode is running brain-local
+ *  (agent local, bash on the remote host via --remote-exec) and let the user
+ *  toggle it. The host itself is resolved authoritatively in the main process;
+ *  here we only surface the SSH target label and the on/off flag. Renders
+ *  nothing for local workspaces or workspaces without an SSH connection. */
+function RemoteExecBanner({ worktreeId }: { worktreeId?: string }): React.JSX.Element | null {
+  const parsedScope = worktreeId ? parseWorkspaceKey(worktreeId) : null
+  const folderWorkspaceId =
+    parsedScope?.type === 'folder' ? parsedScope.folderWorkspaceId : undefined
+  const workspace = useAppStore((state) =>
+    folderWorkspaceId
+      ? state.folderWorkspaces.find((entry) => entry.id === folderWorkspaceId)
+      : undefined
+  )
+  const updateFolderWorkspace = useAppStore((state) => state.updateFolderWorkspace)
+  const targetLabel = useAppStore((state) =>
+    workspace?.connectionId ? (state.sshTargetLabels.get(workspace.connectionId) ?? null) : null
+  )
+
+  // Only meaningful when the workspace is bound to an SSH connection: that host
+  // is what jcode --remote-exec runs bash on.
+  if (!workspace?.connectionId || !folderWorkspaceId) {
+    return null
+  }
+  const enabled = workspace.isRemoteExecOnly === true
+  const hostText = targetLabel ?? workspace.connectionId
+
+  return (
+    <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-1.5 text-xs">
+      <span className="text-muted-foreground">
+        {enabled ? (
+          <>
+            Brain-local: jcode runs locally, bash on <span className="font-medium">{hostText}</span>
+          </>
+        ) : (
+          <>Local jcode (bash also local)</>
+        )}
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          void updateFolderWorkspace(folderWorkspaceId, { isRemoteExecOnly: !enabled })
+        }}
+        className={cn(
+          'rounded px-2 py-0.5 font-medium',
+          enabled
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-muted text-foreground hover:bg-muted/80'
+        )}
+      >
+        {enabled ? 'Hands remote: on' : 'Hands remote: off'}
+      </button>
+    </div>
+  )
+}
+
 export default function ChatPane({
   sessionKey,
   cwd,
+  worktreeId,
   provider = 'openai',
   model
 }: {
   sessionKey: string
   cwd?: string
+  /** Worktree / folder-workspace key. Threaded to main so it can resolve
+   *  brain-local (M3): a remote-exec-only workspace gets --remote-exec <host>. */
+  worktreeId?: string
   provider?: string
   model?: string
 }): React.JSX.Element {
@@ -237,9 +300,10 @@ export default function ChatPane({
       provider,
       model,
       cwd,
+      worktreeId,
       resumeSessionId: resumeSessionIdRef.current
     })
-  }, [input, isStreaming, sessionKey, provider, model, cwd])
+  }, [input, isStreaming, sessionKey, provider, model, cwd, worktreeId])
 
   const stop = useCallback(() => {
     if (!isStreaming) {
@@ -251,6 +315,7 @@ export default function ChatPane({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+      <RemoteExecBanner worktreeId={worktreeId} />
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-4 py-4">
         {messages.length === 0 ? (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -6,12 +6,15 @@ import type {
   JcodeConversationSummary,
   JcodeCustomProvider
 } from '../../../../shared/jcode-chat-types'
-import { reopenChatConversation } from '@/lib/launch-chat-agent-tab'
+import { launchChatAgentTab, reopenChatConversation } from '@/lib/launch-chat-agent-tab'
 import { JcodeToolCard } from './JcodeToolCard'
 import {
+  addChatAttachments,
+  clearChatAttachments,
   deleteChatConversation,
   hydrateChatSession,
   listChatConversations,
+  removeChatAttachment,
   setChatComposerSelection,
   setChatSessionContext,
   setChatStatusDetail,
@@ -196,7 +199,8 @@ export default function ChatPane({
     resumeSessionId,
     composerProvider,
     composerModel,
-    composerProviderProfile
+    composerProviderProfile,
+    pendingAttachments
   } = useChatSession(sessionKey)
   // Custom OpenAI-compatible profiles the user added in Settings. Defensive
   // against settings not yet hydrated.
@@ -233,17 +237,32 @@ export default function ChatPane({
 
   const send = useCallback(() => {
     const prompt = input.trim()
-    if (!prompt || isStreaming) {
+    const attachments = pendingAttachments
+    // Allow sending with attachments only (no typed text), but require at least
+    // one of the two.
+    if ((!prompt && attachments.length === 0) || isStreaming) {
       return
     }
-    startChatTurn(sessionKey, prompt)
+    // Record a transcript-visible user message. The main process weaves the
+    // attachment paths/text into the prompt jcode actually receives; here we
+    // append a short human-readable summary so the bubble reflects what was sent.
+    const summary =
+      attachments.length > 0
+        ? `${prompt ? `${prompt}\n\n` : ''}[Attached: ${attachments
+            .map((a) => a.name || (a.kind === 'file' ? a.path : 'text'))
+            .join(', ')}]`
+        : prompt
+    startChatTurn(sessionKey, summary)
     setInput('')
+    clearChatAttachments(sessionKey)
+    const sharedAttachments = attachments.length > 0 ? attachments : undefined
     if (composerProviderProfile) {
       // Custom OpenAI-compatible profile: main emits `--provider-profile <name>`
       // and OMITS `-p`. The model defaults to the profile's, overridable by -m.
       window.api.jcodeChat.send({
         sessionKey,
         prompt,
+        attachments: sharedAttachments,
         providerProfile: composerProviderProfile,
         model: composerModel,
         cwd,
@@ -254,6 +273,7 @@ export default function ChatPane({
       window.api.jcodeChat.send({
         sessionKey,
         prompt,
+        attachments: sharedAttachments,
         // composerProvider undefined ("Auto") falls back to this pane's default.
         provider: composerProvider ?? provider,
         model: composerModel ?? model,
@@ -264,6 +284,7 @@ export default function ChatPane({
     }
   }, [
     input,
+    pendingAttachments,
     isStreaming,
     sessionKey,
     provider,
@@ -284,8 +305,75 @@ export default function ChatPane({
     window.api.jcodeChat.stop({ sessionKey })
   }, [isStreaming, sessionKey])
 
+  // Native file picker -> attach the chosen ABSOLUTE paths as removable chips.
+  const addFiles = useCallback(() => {
+    void window.api.jcodeChat.pickFiles().then((paths) => {
+      if (paths.length === 0) {
+        return
+      }
+      addChatAttachments(
+        sessionKey,
+        paths.map((path) => ({
+          kind: 'file' as const,
+          path,
+          name: path.split('/').pop() || path
+        }))
+      )
+    })
+  }, [sessionKey])
+
+  const addText = useCallback(
+    (content: string, name?: string) => {
+      addChatAttachments(sessionKey, [{ kind: 'text', content, name: name?.trim() || 'Text' }])
+    },
+    [sessionKey]
+  )
+
+  // orca-side "/" actions: /clear opens a fresh chat tab; /resume reopens the
+  // most-recent OTHER conversation. Both are orca-provided, not jcode skills.
+  const runSlashAction = useCallback(
+    (action: 'clear' | 'resume') => {
+      if (action === 'clear') {
+        if (worktreeId) {
+          launchChatAgentTab({ agent: 'jcode', worktreeId })
+        }
+        return
+      }
+      void listChatConversations().then((rows) => {
+        const last = rows.find((row) => row.sessionKey !== sessionKey)
+        if (last) {
+          void reopenChatConversation({ conversation: last, fallbackWorktreeId: worktreeId })
+        }
+      })
+    },
+    [sessionKey, worktreeId]
+  )
+
+  // Native OS drag-and-drop of files onto the chat pane. The preload resolves
+  // dropped File objects to absolute paths (renderer cannot) and routes drops
+  // landing on a `data-native-file-drop-target="composer"` element here.
+  useEffect(() => {
+    const unsubscribe = window.api.ui.onFileDrop((data) => {
+      if (data.target !== 'composer' || !Array.isArray(data.paths) || data.paths.length === 0) {
+        return
+      }
+      addChatAttachments(
+        sessionKey,
+        data.paths.map((path) => ({
+          kind: 'file' as const,
+          path,
+          name: path.split('/').pop() || path
+        }))
+      )
+    })
+    return unsubscribe
+  }, [sessionKey])
+
   return (
-    <div className="flex h-full min-h-0 w-full flex-col bg-background text-foreground">
+    <div
+      className="flex h-full min-h-0 w-full flex-col bg-background text-foreground"
+      data-native-file-drop-target="composer"
+    >
       <RemoteExecBanner worktreeId={worktreeId} />
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
         {messages.length === 0 ? (
@@ -356,6 +444,11 @@ export default function ChatPane({
           model={composerModel}
           customProviders={customProviders}
           onSelectProvider={(selection) => setChatComposerSelection(sessionKey, selection)}
+          attachments={pendingAttachments}
+          onAddFiles={addFiles}
+          onAddText={addText}
+          onRemoveAttachment={(index) => removeChatAttachment(sessionKey, index)}
+          onSlashAction={runSlashAction}
         />
       </div>
     </div>

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -1,17 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
-import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
-import type {
-  JcodeConversationSummary,
-  JcodeCustomProvider
-} from '../../../../shared/jcode-chat-types'
+import { ChatProjectBadge } from './ChatProjectBadge'
+import { RecentChats } from './ChatRecentChats'
+import type { JcodeCustomProvider } from '../../../../shared/jcode-chat-types'
 import { launchChatAgentTab, reopenChatConversation } from '@/lib/launch-chat-agent-tab'
 import { JcodeToolCard } from './JcodeToolCard'
 import {
   addChatAttachments,
   clearChatAttachments,
-  deleteChatConversation,
   hydrateChatSession,
   listChatConversations,
   removeChatAttachment,
@@ -27,79 +24,6 @@ import { ChatComposer } from './ChatComposer'
 // new array each render (which would thrash the subscription).
 const EMPTY_CUSTOM_PROVIDERS: JcodeCustomProvider[] = []
 
-// Why (BUG 1/2, reopen): the empty state of a chat tab is a self-contained,
-// chat-feature-owned place to surface "Recent chats" — durable conversations
-// persisted to disk. Clicking one recreates its chat tab (reusing the stored
-// sessionKey as the tab id) and rehydrates the transcript. This is intentionally
-// NOT wired into orca's general PTY-agent sidebar (WorktreeCardAgents), which is
-// a different system; see notImplemented in the handoff.
-function RecentChats({
-  worktreeId,
-  excludeSessionKey
-}: {
-  worktreeId?: string
-  excludeSessionKey: string
-}): React.JSX.Element | null {
-  const [recents, setRecents] = useState<JcodeConversationSummary[]>([])
-
-  const refresh = useCallback(() => {
-    void listChatConversations().then((rows) =>
-      setRecents(rows.filter((row) => row.sessionKey !== excludeSessionKey))
-    )
-  }, [excludeSessionKey])
-
-  useEffect(() => {
-    refresh()
-  }, [refresh])
-
-  if (recents.length === 0) {
-    return null
-  }
-
-  return (
-    <div className="mt-6 w-full max-w-md text-left">
-      <div className="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Recent chats
-      </div>
-      <div className="flex flex-col gap-1">
-        {recents.slice(0, 8).map((row) => (
-          <div
-            key={row.sessionKey}
-            className="group flex items-center gap-2 rounded-lg border border-border px-3 py-2 transition-colors hover:bg-muted"
-          >
-            <button
-              type="button"
-              className="min-w-0 flex-1 text-left"
-              onClick={() => {
-                void reopenChatConversation({
-                  conversation: row,
-                  fallbackWorktreeId: worktreeId
-                })
-              }}
-            >
-              <div className="truncate text-sm text-foreground">{row.title}</div>
-              <div className="text-xs text-muted-foreground">
-                {new Date(row.updatedAt).toLocaleString()}
-              </div>
-            </button>
-            <button
-              type="button"
-              aria-label="Delete chat"
-              className="shrink-0 rounded px-2 py-1 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
-              onClick={() => {
-                deleteChatConversation(row.sessionKey)
-                refresh()
-              }}
-            >
-              Delete
-            </button>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
 // Why: M2 enriches the M1 jcode chat-bubble view. Tool calls render as cards
 // (name + pretty args + output/error, bash special-cased, diffs colorized);
 // text_delta streams smoothly into the assistant bubble; connection_phase shows
@@ -114,63 +38,6 @@ function RecentChats({
 // module level), not in this component's local state. That makes ChatPane safe
 // to unmount/remount on tab switches — switching away and back restores the same
 // conversation with --resume continuity intact.
-
-/** Minimal brain-local (M3) affordance: for a folder-scoped chat pane whose
- *  workspace has an SSH connection, show whether jcode is running brain-local
- *  (agent local, bash on the remote host via --remote-exec) and let the user
- *  toggle it. The host itself is resolved authoritatively in the main process;
- *  here we only surface the SSH target label and the on/off flag. Renders
- *  nothing for local workspaces or workspaces without an SSH connection. */
-function RemoteExecBanner({ worktreeId }: { worktreeId?: string }): React.JSX.Element | null {
-  const parsedScope = worktreeId ? parseWorkspaceKey(worktreeId) : null
-  const folderWorkspaceId =
-    parsedScope?.type === 'folder' ? parsedScope.folderWorkspaceId : undefined
-  const workspace = useAppStore((state) =>
-    folderWorkspaceId
-      ? state.folderWorkspaces.find((entry) => entry.id === folderWorkspaceId)
-      : undefined
-  )
-  const updateFolderWorkspace = useAppStore((state) => state.updateFolderWorkspace)
-  const targetLabel = useAppStore((state) =>
-    workspace?.connectionId ? (state.sshTargetLabels.get(workspace.connectionId) ?? null) : null
-  )
-
-  // Only meaningful when the workspace is bound to an SSH connection: that host
-  // is what jcode --remote-exec runs bash on.
-  if (!workspace?.connectionId || !folderWorkspaceId) {
-    return null
-  }
-  const enabled = workspace.isRemoteExecOnly === true
-  const hostText = targetLabel ?? workspace.connectionId
-
-  return (
-    <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-1.5 text-xs">
-      <span className="text-muted-foreground">
-        {enabled ? (
-          <>
-            Brain-local: jcode runs locally, bash on <span className="font-medium">{hostText}</span>
-          </>
-        ) : (
-          <>Local jcode (bash also local)</>
-        )}
-      </span>
-      <button
-        type="button"
-        onClick={() => {
-          void updateFolderWorkspace(folderWorkspaceId, { isRemoteExecOnly: !enabled })
-        }}
-        className={cn(
-          'rounded px-2 py-0.5 font-medium',
-          enabled
-            ? 'bg-primary text-primary-foreground'
-            : 'bg-muted text-foreground hover:bg-muted/80'
-        )}
-      >
-        {enabled ? 'Hands remote: on' : 'Hands remote: off'}
-      </button>
-    </div>
-  )
-}
 
 export default function ChatPane({
   sessionKey,
@@ -402,7 +269,7 @@ export default function ChatPane({
       className="flex h-full min-h-0 w-full flex-col bg-background text-foreground"
       data-native-file-drop-target="composer"
     >
-      <RemoteExecBanner worktreeId={worktreeId} />
+      <ChatProjectBadge worktreeId={worktreeId} cwd={cwd} />
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
         {messages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center px-6 text-center">

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
-import type { JcodeConversationSummary } from '../../../../shared/jcode-chat-types'
+import type {
+  JcodeConversationSummary,
+  JcodeCustomProvider
+} from '../../../../shared/jcode-chat-types'
 import { reopenChatConversation } from '@/lib/launch-chat-agent-tab'
 import { JcodeToolCard } from './JcodeToolCard'
 import {
@@ -16,6 +19,10 @@ import {
   useChatSession
 } from './chat-session-store'
 import { ChatComposer } from './ChatComposer'
+
+// Stable empty reference so the useAppStore selector fallback doesn't produce a
+// new array each render (which would thrash the subscription).
+const EMPTY_CUSTOM_PROVIDERS: JcodeCustomProvider[] = []
 
 // Why (BUG 1/2, reopen): the empty state of a chat tab is a self-contained,
 // chat-feature-owned place to surface "Recent chats" — durable conversations
@@ -182,8 +189,19 @@ export default function ChatPane({
   // provider/model selection also lives in the store (composerProvider/Model)
   // so the chip choice persists across tab switches; only the unsent draft text
   // is local component state.
-  const { messages, isStreaming, statusDetail, resumeSessionId, composerProvider, composerModel } =
-    useChatSession(sessionKey)
+  const {
+    messages,
+    isStreaming,
+    statusDetail,
+    resumeSessionId,
+    composerProvider,
+    composerModel,
+    composerProviderProfile
+  } = useChatSession(sessionKey)
+  // Custom OpenAI-compatible profiles the user added in Settings. Defensive
+  // against settings not yet hydrated.
+  const customProviders =
+    useAppStore((s) => s.settings?.jcodeCustomProviders) ?? EMPTY_CUSTOM_PROVIDERS
   const [input, setInput] = useState('')
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -220,16 +238,30 @@ export default function ChatPane({
     }
     startChatTurn(sessionKey, prompt)
     setInput('')
-    window.api.jcodeChat.send({
-      sessionKey,
-      prompt,
-      // composerProvider undefined ("Auto") falls back to this pane's default.
-      provider: composerProvider ?? provider,
-      model: composerModel ?? model,
-      cwd,
-      worktreeId,
-      resumeSessionId
-    })
+    if (composerProviderProfile) {
+      // Custom OpenAI-compatible profile: main emits `--provider-profile <name>`
+      // and OMITS `-p`. The model defaults to the profile's, overridable by -m.
+      window.api.jcodeChat.send({
+        sessionKey,
+        prompt,
+        providerProfile: composerProviderProfile,
+        model: composerModel,
+        cwd,
+        worktreeId,
+        resumeSessionId
+      })
+    } else {
+      window.api.jcodeChat.send({
+        sessionKey,
+        prompt,
+        // composerProvider undefined ("Auto") falls back to this pane's default.
+        provider: composerProvider ?? provider,
+        model: composerModel ?? model,
+        cwd,
+        worktreeId,
+        resumeSessionId
+      })
+    }
   }, [
     input,
     isStreaming,
@@ -238,6 +270,7 @@ export default function ChatPane({
     model,
     composerProvider,
     composerModel,
+    composerProviderProfile,
     cwd,
     worktreeId,
     resumeSessionId
@@ -319,7 +352,9 @@ export default function ChatPane({
           onStop={stop}
           isStreaming={isStreaming}
           provider={composerProvider}
+          providerProfile={composerProviderProfile}
           model={composerModel}
+          customProviders={customProviders}
           onSelectProvider={(selection) => setChatComposerSelection(sessionKey, selection)}
         />
       </div>

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -270,7 +270,7 @@ export default function ChatPane({
       data-native-file-drop-target="composer"
     >
       <ChatProjectBadge worktreeId={worktreeId} cwd={cwd} />
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
         {messages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center px-6 text-center">
             <div className="text-base font-medium text-foreground">Message jcode to start</div>

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import { ChatProjectBadge } from './ChatProjectBadge'
 import { RecentChats } from './ChatRecentChats'
@@ -128,13 +129,25 @@ export default function ChatPane({
     }
     const extras: string[] = []
     if (selectedSkillName) {
-      extras.push(`skill: ${selectedSkillName}`)
+      extras.push(
+        translate('jcode.chat.transcript.skillSummary', 'Skill: {{value0}}', {
+          value0: selectedSkillName
+        })
+      )
     }
     if (attachments.length > 0) {
       extras.push(
-        `Attached: ${attachments
-          .map((a) => a.name || (a.kind === 'file' ? a.path : 'text'))
-          .join(', ')}`
+        translate('jcode.chat.transcript.attachmentSummary', 'Attached: {{value0}}', {
+          value0: attachments
+            .map(
+              (a) =>
+                a.name ||
+                (a.kind === 'file'
+                  ? a.path
+                  : translate('jcode.chat.attachment.defaultTextName', 'Text'))
+            )
+            .join(', ')
+        })
       )
     }
     if (extras.length > 0) {
@@ -196,7 +209,7 @@ export default function ChatPane({
     if (!isStreaming) {
       return
     }
-    setChatStatusDetail(sessionKey, 'Stopping…')
+    setChatStatusDetail(sessionKey, translate('jcode.chat.status.stopping', 'Stopping...'))
     window.api.jcodeChat.stop({ sessionKey })
   }, [isStreaming, sessionKey])
 
@@ -219,7 +232,13 @@ export default function ChatPane({
 
   const addText = useCallback(
     (content: string, name?: string) => {
-      addChatAttachments(sessionKey, [{ kind: 'text', content, name: name?.trim() || 'Text' }])
+      addChatAttachments(sessionKey, [
+        {
+          kind: 'text',
+          content,
+          name: name?.trim() || translate('jcode.chat.attachment.defaultTextName', 'Text')
+        }
+      ])
     },
     [sessionKey]
   )
@@ -273,9 +292,14 @@ export default function ChatPane({
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
         {messages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center px-6 text-center">
-            <div className="text-base font-medium text-foreground">Message jcode to start</div>
+            <div className="text-base font-medium text-foreground">
+              {translate('jcode.chat.empty.title', 'Message jcode to start')}
+            </div>
             <div className="mt-1 text-sm text-muted-foreground">
-              Replies stream in. Tool calls and diffs render inline.
+              {translate(
+                'jcode.chat.empty.description',
+                'Replies stream in. Tool calls and diffs render inline.'
+              )}
             </div>
             <RecentChats worktreeId={worktreeId} excludeSessionKey={sessionKey} />
           </div>

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -176,7 +176,10 @@ export default function ChatPane({
   sessionKey,
   cwd,
   worktreeId,
-  provider = 'openai',
+  // "Auto" by default: jcode resolves the best authed provider/model, which the
+  // composer chip surfaces as "Auto → <model>". A real id is only passed when a
+  // caller pins one.
+  provider = 'auto',
   model
 }: {
   sessionKey: string

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -207,6 +207,10 @@ export default function ChatPane({
   const customProviders =
     useAppStore((s) => s.settings?.jcodeCustomProviders) ?? EMPTY_CUSTOM_PROVIDERS
   const [input, setInput] = useState('')
+  // FEATURE B: a skill armed from the "/" menu for the next send. Its SKILL.md
+  // body is injected into the prompt by the main process at send time; here we
+  // only carry the name (and show a chip). Cleared after each send.
+  const [selectedSkillName, setSelectedSkillName] = useState<string | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   // Why (BUG 1, persistence): register this pane's context so disk snapshots are
@@ -238,23 +242,41 @@ export default function ChatPane({
   const send = useCallback(() => {
     const prompt = input.trim()
     const attachments = pendingAttachments
-    // Allow sending with attachments only (no typed text), but require at least
-    // one of the two.
-    if ((!prompt && attachments.length === 0) || isStreaming) {
+    // Allow sending with attachments only or a skill only (no typed text), but
+    // require at least one of the three.
+    if ((!prompt && attachments.length === 0 && !selectedSkillName) || isStreaming) {
       return
     }
     // Record a transcript-visible user message. The main process weaves the
-    // attachment paths/text into the prompt jcode actually receives; here we
-    // append a short human-readable summary so the bubble reflects what was sent.
-    const summary =
-      attachments.length > 0
-        ? `${prompt ? `${prompt}\n\n` : ''}[Attached: ${attachments
-            .map((a) => a.name || (a.kind === 'file' ? a.path : 'text'))
-            .join(', ')}]`
-        : prompt
+    // attachment paths/text into the prompt jcode actually receives (and prepends
+    // a selected skill's body); here we append a short human-readable summary so
+    // the bubble reflects what was sent — including a "skill: <name>" hint, but
+    // NOT the heavy SKILL.md body (kept out of the transcript).
+    const parts: string[] = []
+    if (prompt) {
+      parts.push(prompt)
+    }
+    const extras: string[] = []
+    if (selectedSkillName) {
+      extras.push(`skill: ${selectedSkillName}`)
+    }
+    if (attachments.length > 0) {
+      extras.push(
+        `Attached: ${attachments
+          .map((a) => a.name || (a.kind === 'file' ? a.path : 'text'))
+          .join(', ')}`
+      )
+    }
+    if (extras.length > 0) {
+      parts.push(`[${extras.join(' · ')}]`)
+    }
+    const summary = parts.join('\n\n')
     startChatTurn(sessionKey, summary)
     setInput('')
     clearChatAttachments(sessionKey)
+    // Skill is single-shot: arm once, consume on this send.
+    const skillName = selectedSkillName ?? undefined
+    setSelectedSkillName(null)
     const sharedAttachments = attachments.length > 0 ? attachments : undefined
     if (composerProviderProfile) {
       // Custom OpenAI-compatible profile: main emits `--provider-profile <name>`
@@ -267,7 +289,8 @@ export default function ChatPane({
         model: composerModel,
         cwd,
         worktreeId,
-        resumeSessionId
+        resumeSessionId,
+        skillName
       })
     } else {
       window.api.jcodeChat.send({
@@ -279,7 +302,8 @@ export default function ChatPane({
         model: composerModel ?? model,
         cwd,
         worktreeId,
-        resumeSessionId
+        resumeSessionId,
+        skillName
       })
     }
   }, [
@@ -294,7 +318,8 @@ export default function ChatPane({
     composerProviderProfile,
     cwd,
     worktreeId,
-    resumeSessionId
+    resumeSessionId,
+    selectedSkillName
   ])
 
   const stop = useCallback(() => {
@@ -449,6 +474,10 @@ export default function ChatPane({
           onAddText={addText}
           onRemoveAttachment={(index) => removeChatAttachment(sessionKey, index)}
           onSlashAction={runSlashAction}
+          cwd={cwd}
+          worktreeId={worktreeId}
+          selectedSkillName={selectedSkillName}
+          onSelectSkill={setSelectedSkillName}
         />
       </div>
     </div>

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -1,0 +1,269 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
+import type { JcodeChatEventMessage, JcodeNdjsonEvent } from '../../../../shared/jcode-chat-types'
+
+// Why: M1 chat-bubble view for the jcode agent. Talking to jcode shows replies
+// as chat bubbles instead of a raw terminal. The NDJSON parsing/render logic is
+// ported from the proven jcode-desktop prototype (src/app.js): text_delta
+// streams into the assistant bubble; tool_* events render a one-line placeholder
+// (full tool cards are M2); the jcode session_id from 'start'/'done' is captured
+// for --resume so the conversation continues across turns.
+
+type ChatRole = 'user' | 'assistant'
+
+type ToolPlaceholder = {
+  id: string
+  name: string
+}
+
+type ChatMessage = {
+  id: string
+  role: ChatRole
+  text: string
+  /** One-line placeholders for tool calls seen during this assistant turn. */
+  tools?: ToolPlaceholder[]
+  isError?: boolean
+}
+
+function strField(event: JcodeNdjsonEvent, key: string): string | undefined {
+  const value = event[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+export default function ChatPane({
+  sessionKey,
+  cwd,
+  provider = 'openai',
+  model
+}: {
+  sessionKey: string
+  cwd?: string
+  provider?: string
+  model?: string
+}): React.JSX.Element {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const [isStreaming, setIsStreaming] = useState(false)
+  const [statusDetail, setStatusDetail] = useState<string | null>(null)
+
+  // Why: refs hold turn-scoped mutable state that must not trigger re-renders on
+  // every NDJSON delta. The assistant message id being streamed into, and the
+  // jcode session id to resume on the next turn.
+  const streamingIdRef = useRef<string | null>(null)
+  const resumeSessionIdRef = useRef<string | undefined>(undefined)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const bottom = scrollRef.current
+    if (bottom) {
+      bottom.scrollTop = bottom.scrollHeight
+    }
+  }, [messages, statusDetail])
+
+  const appendToStreaming = useCallback((mutate: (msg: ChatMessage) => ChatMessage) => {
+    const targetId = streamingIdRef.current
+    if (!targetId) {
+      return
+    }
+    setMessages((prev) => prev.map((m) => (m.id === targetId ? mutate(m) : m)))
+  }, [])
+
+  const finalizeTurn = useCallback(() => {
+    setIsStreaming(false)
+    setStatusDetail(null)
+    streamingIdRef.current = null
+  }, [])
+
+  const handleEvent = useCallback(
+    (event: JcodeNdjsonEvent) => {
+      switch (event.type) {
+        case 'start': {
+          const id = strField(event, 'session_id')
+          if (id) {
+            resumeSessionIdRef.current = id
+          }
+          break
+        }
+        case 'status_detail': {
+          const detail = strField(event, 'detail')
+          if (detail) {
+            setStatusDetail(detail)
+          }
+          break
+        }
+        case 'connection_phase': {
+          const phase = strField(event, 'phase')
+          if (phase) {
+            setStatusDetail(phase)
+          }
+          break
+        }
+        case 'text_delta': {
+          const text = strField(event, 'text') ?? ''
+          if (text) {
+            setStatusDetail(null)
+            appendToStreaming((m) => ({ ...m, text: m.text + text }))
+          }
+          break
+        }
+        case 'tool_start':
+        case 'tool_exec': {
+          const id = strField(event, 'id') ?? `${event.type}-${Date.now()}`
+          const name = strField(event, 'name') ?? 'tool'
+          appendToStreaming((m) => {
+            const tools = m.tools ?? []
+            if (tools.some((t) => t.id === id)) {
+              return m
+            }
+            return { ...m, tools: [...tools, { id, name }] }
+          })
+          break
+        }
+        case 'done': {
+          // Why: jcode may include the full final text in 'done' even when no
+          // text_delta arrived (e.g. cached); backfill an empty bubble.
+          const id = strField(event, 'session_id')
+          if (id) {
+            resumeSessionIdRef.current = id
+          }
+          const finalText = strField(event, 'text')
+          if (finalText) {
+            appendToStreaming((m) => (m.text ? m : { ...m, text: finalText }))
+          }
+          finalizeTurn()
+          break
+        }
+        case 'error': {
+          const message =
+            strField(event, 'error') ?? strField(event, 'message') ?? 'Unknown jcode error'
+          appendToStreaming((m) => ({ ...m, text: m.text + message, isError: true }))
+          finalizeTurn()
+          break
+        }
+        case 'exit': {
+          // Terminal safety net: if the child exited without 'done'/'error',
+          // close the turn so the composer re-enables.
+          if (streamingIdRef.current) {
+            finalizeTurn()
+          }
+          break
+        }
+        default:
+          // Ignore unknown / not-yet-rendered event kinds (tool_input,
+          // tool_done, message_end, tokens, connection_type) for M1.
+          break
+      }
+    },
+    [appendToStreaming, finalizeTurn]
+  )
+
+  useEffect(() => {
+    const unsubscribe = window.api.jcodeChat.onEvent((message: JcodeChatEventMessage) => {
+      if (message.sessionKey !== sessionKey) {
+        return
+      }
+      handleEvent(message.event)
+    })
+    return unsubscribe
+  }, [sessionKey, handleEvent])
+
+  const send = useCallback(() => {
+    const prompt = input.trim()
+    if (!prompt || isStreaming) {
+      return
+    }
+    const userId = `user-${Date.now()}`
+    const assistantId = `assistant-${Date.now()}`
+    setMessages((prev) => [
+      ...prev,
+      { id: userId, role: 'user', text: prompt },
+      { id: assistantId, role: 'assistant', text: '' }
+    ])
+    streamingIdRef.current = assistantId
+    setInput('')
+    setIsStreaming(true)
+    setStatusDetail('Thinking…')
+    window.api.jcodeChat.send({
+      sessionKey,
+      prompt,
+      provider,
+      model,
+      cwd,
+      resumeSessionId: resumeSessionIdRef.current
+    })
+  }, [input, isStreaming, sessionKey, provider, model, cwd])
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-4 py-4">
+        {messages.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Ask jcode anything. Replies stream in as chat bubbles.
+          </div>
+        ) : (
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
+            {messages.map((message) => (
+              <div
+                key={message.id}
+                className={cn('flex', message.role === 'user' ? 'justify-end' : 'justify-start')}
+              >
+                <div
+                  className={cn(
+                    'max-w-[85%] whitespace-pre-wrap break-words rounded-lg px-3 py-2 text-sm',
+                    message.role === 'user'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted text-foreground',
+                    message.isError && 'bg-destructive/15 text-destructive'
+                  )}
+                >
+                  {message.tools && message.tools.length > 0 ? (
+                    <div className="mb-1 flex flex-col gap-0.5">
+                      {message.tools.map((tool) => (
+                        <div key={tool.id} className="text-xs text-muted-foreground">
+                          {`⚙ ${tool.name}`}
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                  {message.text || (message.role === 'assistant' && isStreaming ? '…' : '')}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      {statusDetail ? (
+        <div className="px-4 pb-1 text-xs text-muted-foreground">{statusDetail}</div>
+      ) : null}
+      <div className="border-t border-border p-3">
+        <div className="mx-auto flex w-full max-w-3xl items-end gap-2">
+          <textarea
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault()
+                send()
+              }
+            }}
+            placeholder="Message jcode…"
+            rows={1}
+            className="flex-1 resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          />
+          <button
+            type="button"
+            onClick={send}
+            disabled={isStreaming || !input.trim()}
+            className={cn(
+              'rounded-md px-3 py-2 text-sm font-medium',
+              'bg-primary text-primary-foreground',
+              'disabled:cursor-not-allowed disabled:opacity-50'
+            )}
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/chat-pane/ChatPane.tsx
+++ b/src/renderer/src/components/chat-pane/ChatPane.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
-import type { JcodeChatEventMessage, JcodeNdjsonEvent } from '../../../../shared/jcode-chat-types'
-import { JcodeToolCard, type JcodeToolCall } from './JcodeToolCard'
+import { JcodeToolCard } from './JcodeToolCard'
+import { startChatTurn, setChatStatusDetail, useChatSession } from './chat-session-store'
 
 // Why: M2 enriches the M1 jcode chat-bubble view. Tool calls render as cards
 // (name + pretty args + output/error, bash special-cased, diffs colorized);
@@ -13,22 +13,12 @@ import { JcodeToolCard, type JcodeToolCall } from './JcodeToolCard'
 // continues across turns; input is disabled while streaming and a Stop button
 // kills the in-flight jcode child. Parsing mirrors the jcode-desktop prototype
 // (src/app.js) and the documented --ndjson schema.
-
-type ChatRole = 'user' | 'assistant'
-
-type ChatMessage = {
-  id: string
-  role: ChatRole
-  text: string
-  /** Tool calls seen during this assistant turn, in arrival order. */
-  tools?: JcodeToolCall[]
-  isError?: boolean
-}
-
-function strField(event: JcodeNdjsonEvent, key: string): string | undefined {
-  const value = event[key]
-  return typeof value === 'string' ? value : undefined
-}
+//
+// Why (BUG 1, persistence): the conversation + --resume id now live in
+// chat-session-store (a per-sessionKey external store that subscribes to IPC at
+// module level), not in this component's local state. That makes ChatPane safe
+// to unmount/remount on tab switches — switching away and back restores the same
+// conversation with --resume continuity intact.
 
 /** Minimal brain-local (M3) affordance: for a folder-scoped chat pane whose
  *  workspace has an SSH connection, show whether jcode is running brain-local
@@ -102,16 +92,10 @@ export default function ChatPane({
   provider?: string
   model?: string
 }): React.JSX.Element {
-  const [messages, setMessages] = useState<ChatMessage[]>([])
+  // Why: conversation state is read from the external store keyed by sessionKey,
+  // so it survives this component unmounting on tab switches.
+  const { messages, isStreaming, statusDetail, resumeSessionId } = useChatSession(sessionKey)
   const [input, setInput] = useState('')
-  const [isStreaming, setIsStreaming] = useState(false)
-  const [statusDetail, setStatusDetail] = useState<string | null>(null)
-
-  // Why: refs hold turn-scoped mutable state that must not trigger re-renders on
-  // every NDJSON delta. The assistant message id being streamed into, and the
-  // jcode session id to resume on the next turn.
-  const streamingIdRef = useRef<string | null>(null)
-  const resumeSessionIdRef = useRef<string | undefined>(undefined)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -121,179 +105,13 @@ export default function ChatPane({
     }
   }, [messages, statusDetail])
 
-  const appendToStreaming = useCallback((mutate: (msg: ChatMessage) => ChatMessage) => {
-    const targetId = streamingIdRef.current
-    if (!targetId) {
-      return
-    }
-    setMessages((prev) => prev.map((m) => (m.id === targetId ? mutate(m) : m)))
-  }, [])
-
-  /** Insert-or-update a tool call on the streaming assistant message by id. */
-  const upsertTool = useCallback(
-    (id: string, mutate: (call: JcodeToolCall) => JcodeToolCall, fallbackName = 'tool') => {
-      appendToStreaming((m) => {
-        const tools = m.tools ?? []
-        const index = tools.findIndex((t) => t.id === id)
-        if (index === -1) {
-          const created = mutate({ id, name: fallbackName, rawInput: '', status: 'running' })
-          return { ...m, tools: [...tools, created] }
-        }
-        const next = tools.slice()
-        next[index] = mutate(next[index])
-        return { ...m, tools: next }
-      })
-    },
-    [appendToStreaming]
-  )
-
-  const finalizeTurn = useCallback(() => {
-    setIsStreaming(false)
-    setStatusDetail(null)
-    streamingIdRef.current = null
-  }, [])
-
-  const handleEvent = useCallback(
-    (event: JcodeNdjsonEvent) => {
-      switch (event.type) {
-        case 'start': {
-          const id = strField(event, 'session_id')
-          if (id) {
-            resumeSessionIdRef.current = id
-          }
-          break
-        }
-        case 'status_detail': {
-          const detail = strField(event, 'detail')
-          if (detail) {
-            setStatusDetail(detail)
-          }
-          break
-        }
-        case 'connection_phase': {
-          const phase = strField(event, 'phase')
-          if (phase) {
-            setStatusDetail(phase)
-          }
-          break
-        }
-        case 'text_delta': {
-          const text = strField(event, 'text') ?? ''
-          if (text) {
-            setStatusDetail(null)
-            appendToStreaming((m) => ({ ...m, text: m.text + text }))
-          }
-          break
-        }
-        case 'tool_start': {
-          const id = strField(event, 'id') ?? `tool-${Date.now()}`
-          const name = strField(event, 'name') ?? 'tool'
-          upsertTool(id, (call) => ({ ...call, name }), name)
-          break
-        }
-        case 'tool_input': {
-          // Why: args stream as JSON-string fragments; concatenate them so the
-          // card can parse the full object once complete.
-          const id = strField(event, 'id')
-          const delta = strField(event, 'delta') ?? ''
-          if (id) {
-            upsertTool(id, (call) => ({ ...call, rawInput: call.rawInput + delta }))
-          }
-          break
-        }
-        case 'tool_exec': {
-          const id = strField(event, 'id') ?? `tool-${Date.now()}`
-          const name = strField(event, 'name') ?? 'tool'
-          upsertTool(id, (call) => ({ ...call, status: 'running' }), name)
-          break
-        }
-        case 'tool_done': {
-          const id = strField(event, 'id')
-          const errorText = strField(event, 'error')
-          const output = strField(event, 'output')
-          if (id) {
-            upsertTool(id, (call) => ({
-              ...call,
-              output: output ?? call.output,
-              error: errorText ?? undefined,
-              status: errorText ? 'error' : 'done'
-            }))
-          }
-          break
-        }
-        case 'done': {
-          // Why: jcode may include the full final text in 'done' even when no
-          // text_delta arrived (e.g. cached); backfill an empty bubble.
-          const id = strField(event, 'session_id')
-          if (id) {
-            resumeSessionIdRef.current = id
-          }
-          const finalText = strField(event, 'text')
-          if (finalText) {
-            appendToStreaming((m) => (m.text ? m : { ...m, text: finalText }))
-          }
-          finalizeTurn()
-          break
-        }
-        case 'error': {
-          const message =
-            strField(event, 'error') ?? strField(event, 'message') ?? 'Unknown jcode error'
-          appendToStreaming((m) => ({ ...m, text: m.text + message, isError: true }))
-          finalizeTurn()
-          break
-        }
-        case 'stopped': {
-          // User pressed Stop: annotate the bubble and close the turn.
-          appendToStreaming((m) => ({
-            ...m,
-            text: m.text ? `${m.text}\n\n(stopped)` : '(stopped)'
-          }))
-          finalizeTurn()
-          break
-        }
-        case 'exit': {
-          // Terminal safety net: if the child exited without 'done'/'error'/
-          // 'stopped', close the turn so the composer re-enables.
-          if (streamingIdRef.current) {
-            finalizeTurn()
-          }
-          break
-        }
-        default:
-          // Ignore unknown / not-rendered event kinds (connection_type,
-          // message_end, tokens).
-          break
-      }
-    },
-    [appendToStreaming, upsertTool, finalizeTurn]
-  )
-
-  useEffect(() => {
-    const unsubscribe = window.api.jcodeChat.onEvent((message: JcodeChatEventMessage) => {
-      if (message.sessionKey !== sessionKey) {
-        return
-      }
-      handleEvent(message.event)
-    })
-    return unsubscribe
-  }, [sessionKey, handleEvent])
-
   const send = useCallback(() => {
     const prompt = input.trim()
     if (!prompt || isStreaming) {
       return
     }
-    const userId = `user-${Date.now()}`
-    const assistantId = `assistant-${Date.now()}`
-    setMessages((prev) => [
-      ...prev,
-      { id: userId, role: 'user', text: prompt },
-      { id: assistantId, role: 'assistant', text: '' }
-    ])
-    streamingIdRef.current = assistantId
+    startChatTurn(sessionKey, prompt)
     setInput('')
-    setIsStreaming(true)
-    setStatusDetail('Thinking…')
     window.api.jcodeChat.send({
       sessionKey,
       prompt,
@@ -301,15 +119,15 @@ export default function ChatPane({
       model,
       cwd,
       worktreeId,
-      resumeSessionId: resumeSessionIdRef.current
+      resumeSessionId
     })
-  }, [input, isStreaming, sessionKey, provider, model, cwd, worktreeId])
+  }, [input, isStreaming, sessionKey, provider, model, cwd, worktreeId, resumeSessionId])
 
   const stop = useCallback(() => {
     if (!isStreaming) {
       return
     }
-    setStatusDetail('Stopping…')
+    setChatStatusDetail(sessionKey, 'Stopping…')
     window.api.jcodeChat.stop({ sessionKey })
   }, [isStreaming, sessionKey])
 

--- a/src/renderer/src/components/chat-pane/ChatProjectBadge.tsx
+++ b/src/renderer/src/components/chat-pane/ChatProjectBadge.tsx
@@ -1,0 +1,111 @@
+import { Cloud, Monitor } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import {
+  getRepoIdFromWorktreeId,
+  splitWorktreeIdForFilesystem
+} from '../../../../shared/worktree-id'
+
+/** Always-on binding badge for a chat pane: shows WHICH project the chat is bound
+ *  to, its working dir, and whether it runs 本地 (local) or 远程 (on an SSH host).
+ *  Resolved from the chat's OWN worktreeId/cwd (NOT the globally-active workspace),
+ *  so a chat created in project A keeps showing A even if the sidebar now
+ *  highlights B — which is exactly the confusion that prompted this. Handles both
+ *  folder workspaces and git worktrees (the previous version only handled folder
+ *  workspaces, so a remote GIT project like ComfyUI showed nothing). For a folder
+ *  workspace bound to SSH it keeps the brain-local on/off toggle; a remote git
+ *  worktree is always brain-local (jcode local, bash on the host). Lives in its
+ *  own file so ChatPane stays under the max-lines lint. */
+export function ChatProjectBadge({
+  worktreeId,
+  cwd
+}: {
+  worktreeId?: string
+  cwd?: string
+}): React.JSX.Element | null {
+  const scope = worktreeId ? parseWorkspaceKey(worktreeId) : null
+  const folderWorkspaceId = scope?.type === 'folder' ? scope.folderWorkspaceId : undefined
+  // A raw `repoId::path` worktree id has no `worktree:`/`folder:` prefix, so
+  // parseWorkspaceKey returns null — fall back to the raw value for git worktrees.
+  const rawWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
+  const repoId =
+    !folderWorkspaceId && rawWorktreeId ? getRepoIdFromWorktreeId(rawWorktreeId) : undefined
+
+  const folderWorkspace = useAppStore((state) =>
+    folderWorkspaceId
+      ? state.folderWorkspaces.find((entry) => entry.id === folderWorkspaceId)
+      : undefined
+  )
+  const repo = useAppStore((state) =>
+    repoId ? state.repos.find((entry) => entry.id === repoId) : undefined
+  )
+  const updateFolderWorkspace = useAppStore((state) => state.updateFolderWorkspace)
+  const connectionId = folderWorkspace?.connectionId ?? repo?.connectionId ?? null
+  const hostLabel = useAppStore((state) =>
+    connectionId ? (state.sshTargetLabels.get(connectionId) ?? connectionId) : null
+  )
+
+  if (!worktreeId) {
+    return null
+  }
+
+  const path =
+    cwd?.trim() ||
+    folderWorkspace?.folderPath ||
+    (rawWorktreeId ? (splitWorktreeIdForFilesystem(rawWorktreeId)?.worktreePath ?? null) : null)
+  const projectName =
+    repo?.displayName ||
+    (folderWorkspace?.folderPath ? folderWorkspace.folderPath.split('/').pop() : undefined) ||
+    (path ? path.split('/').pop() : undefined) ||
+    '工作区'
+  const isRemote = !!connectionId
+  // The folder-workspace toggle (brain-local on/off) is only meaningful for a
+  // folder workspace bound to SSH; a remote git worktree is always brain-local.
+  const showFolderToggle = !!folderWorkspaceId && !!folderWorkspace?.connectionId
+  const folderEnabled = folderWorkspace?.isRemoteExecOnly === true
+
+  return (
+    <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-1.5 text-xs">
+      <div className="flex min-w-0 items-center gap-1.5">
+        {isRemote ? (
+          <Cloud className="size-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <Monitor className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <span className="shrink-0 font-medium text-foreground">{projectName}</span>
+        {path ? (
+          <span className="truncate text-muted-foreground" title={path}>
+            {path}
+          </span>
+        ) : null}
+        <span
+          className={cn(
+            'shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium',
+            isRemote ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
+          )}
+        >
+          {isRemote ? `远程 · ${hostLabel}` : '本地'}
+        </span>
+      </div>
+      {showFolderToggle ? (
+        <button
+          type="button"
+          onClick={() => {
+            void updateFolderWorkspace(folderWorkspaceId!, { isRemoteExecOnly: !folderEnabled })
+          }}
+          className={cn(
+            'shrink-0 rounded px-2 py-0.5 font-medium',
+            folderEnabled
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-muted text-foreground hover:bg-muted/80'
+          )}
+        >
+          {folderEnabled ? 'Hands remote: on' : 'Hands remote: off'}
+        </button>
+      ) : isRemote ? (
+        <span className="shrink-0 text-[10px] text-muted-foreground">brain-local（自动）</span>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/chat-pane/ChatProjectBadge.tsx
+++ b/src/renderer/src/components/chat-pane/ChatProjectBadge.tsx
@@ -1,5 +1,6 @@
 import { Cloud, Monitor } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
@@ -58,7 +59,7 @@ export function ChatProjectBadge({
     repo?.displayName ||
     (folderWorkspace?.folderPath ? folderWorkspace.folderPath.split('/').pop() : undefined) ||
     (path ? path.split('/').pop() : undefined) ||
-    '工作区'
+    translate('jcode.chat.projectBadge.fallbackProject', 'Workspace')
   const isRemote = !!connectionId
   // The folder-workspace toggle (brain-local on/off) is only meaningful for a
   // folder workspace bound to SSH; a remote git worktree is always brain-local.
@@ -85,7 +86,11 @@ export function ChatProjectBadge({
             isRemote ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
           )}
         >
-          {isRemote ? `远程 · ${hostLabel}` : '本地'}
+          {isRemote
+            ? translate('jcode.chat.projectBadge.remoteWithHost', 'Remote · {{value0}}', {
+                value0: hostLabel ?? ''
+              })
+            : translate('jcode.chat.projectBadge.local', 'Local')}
         </span>
       </div>
       {showFolderToggle ? (
@@ -101,10 +106,14 @@ export function ChatProjectBadge({
               : 'bg-muted text-foreground hover:bg-muted/80'
           )}
         >
-          {folderEnabled ? 'Hands remote: on' : 'Hands remote: off'}
+          {folderEnabled
+            ? translate('jcode.chat.projectBadge.handsRemoteOn', 'Hands remote: on')
+            : translate('jcode.chat.projectBadge.handsRemoteOff', 'Hands remote: off')}
         </button>
       ) : isRemote ? (
-        <span className="shrink-0 text-[10px] text-muted-foreground">brain-local（自动）</span>
+        <span className="shrink-0 text-[10px] text-muted-foreground">
+          {translate('jcode.chat.projectBadge.brainLocalAuto', 'brain-local (auto)')}
+        </span>
       ) : null}
     </div>
   )

--- a/src/renderer/src/components/chat-pane/ChatRecentChats.tsx
+++ b/src/renderer/src/components/chat-pane/ChatRecentChats.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from 'react'
+import { reopenChatConversation } from '@/lib/launch-chat-agent-tab'
+import {
+  deleteChatConversation,
+  listChatConversations
+} from '@/components/chat-pane/chat-session-store'
+import type { JcodeConversationSummary } from '../../../../shared/jcode-chat-types'
+
+// Why (BUG 1/2, reopen): the empty state of a chat tab is a self-contained,
+// chat-feature-owned place to surface "Recent chats" — durable conversations
+// persisted to disk. Clicking one recreates its chat tab (reusing the stored
+// sessionKey as the tab id) and rehydrates the transcript. This is intentionally
+// NOT wired into orca's general PTY-agent sidebar (WorktreeCardAgents), which is
+// a different system; see notImplemented in the handoff. Lives in its own file so
+// ChatPane stays under the max-lines lint.
+export function RecentChats({
+  worktreeId,
+  excludeSessionKey
+}: {
+  worktreeId?: string
+  excludeSessionKey: string
+}): React.JSX.Element | null {
+  const [recents, setRecents] = useState<JcodeConversationSummary[]>([])
+
+  const refresh = useCallback(() => {
+    void listChatConversations().then((rows) =>
+      setRecents(rows.filter((row) => row.sessionKey !== excludeSessionKey))
+    )
+  }, [excludeSessionKey])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  if (recents.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="mt-6 w-full max-w-md text-left">
+      <div className="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Recent chats
+      </div>
+      <div className="flex flex-col gap-1">
+        {recents.slice(0, 8).map((row) => (
+          <div
+            key={row.sessionKey}
+            className="group flex items-center gap-2 rounded-lg border border-border px-3 py-2 transition-colors hover:bg-muted"
+          >
+            <button
+              type="button"
+              className="min-w-0 flex-1 text-left"
+              onClick={() => {
+                void reopenChatConversation({
+                  conversation: row,
+                  fallbackWorktreeId: worktreeId
+                })
+              }}
+            >
+              <div className="truncate text-sm text-foreground">{row.title}</div>
+              <div className="text-xs text-muted-foreground">
+                {new Date(row.updatedAt).toLocaleString()}
+              </div>
+            </button>
+            <button
+              type="button"
+              aria-label="Delete chat"
+              className="shrink-0 rounded px-2 py-1 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+              onClick={() => {
+                deleteChatConversation(row.sessionKey)
+                refresh()
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/chat-pane/ChatRecentChats.tsx
+++ b/src/renderer/src/components/chat-pane/ChatRecentChats.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { translate } from '@/i18n/i18n'
 import { reopenChatConversation } from '@/lib/launch-chat-agent-tab'
 import {
   deleteChatConversation,
@@ -39,7 +40,7 @@ export function RecentChats({
   return (
     <div className="mt-6 w-full max-w-md text-left">
       <div className="mb-2 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Recent chats
+        {translate('jcode.chat.recents.heading', 'Recent chats')}
       </div>
       <div className="flex flex-col gap-1">
         {recents.slice(0, 8).map((row) => (
@@ -64,14 +65,14 @@ export function RecentChats({
             </button>
             <button
               type="button"
-              aria-label="Delete chat"
+              aria-label={translate('jcode.chat.recents.deleteAria', 'Delete chat')}
               className="shrink-0 rounded px-2 py-1 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
               onClick={() => {
                 deleteChatConversation(row.sessionKey)
                 refresh()
               }}
             >
-              Delete
+              {translate('jcode.chat.recents.delete', 'Delete')}
             </button>
           </div>
         ))}

--- a/src/renderer/src/components/chat-pane/JcodeToolCard.tsx
+++ b/src/renderer/src/components/chat-pane/JcodeToolCard.tsx
@@ -3,6 +3,7 @@
 // to show the command + its output the way the jcode-desktop prototype does, and
 // any output that looks like a unified diff is rendered with the diff colorizer.
 import { useState } from 'react'
+import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import { UnifiedDiff, looksLikeUnifiedDiff } from './jcode-diff'
 
@@ -100,7 +101,9 @@ export function JcodeToolCard({ call }: { call: JcodeToolCall }): React.JSX.Elem
           ) : call.output !== undefined && call.output !== '' ? (
             <OutputBlock text={call.output} />
           ) : call.status === 'running' ? (
-            <div className={cn('text-muted-foreground')}>running…</div>
+            <div className={cn('text-muted-foreground')}>
+              {translate('jcode.chat.toolCard.running', 'Running...')}
+            </div>
           ) : null}
         </div>
       ) : null}

--- a/src/renderer/src/components/chat-pane/JcodeToolCard.tsx
+++ b/src/renderer/src/components/chat-pane/JcodeToolCard.tsx
@@ -51,7 +51,7 @@ function OutputBlock({ text }: { text: string }): React.JSX.Element {
     return <UnifiedDiff text={text} />
   }
   return (
-    <pre className="max-h-72 overflow-auto rounded-md bg-background/60 p-2 font-mono text-xs leading-relaxed whitespace-pre-wrap break-words">
+    <pre className="max-h-72 overflow-auto scrollbar-sleek rounded-md bg-background/60 p-2 font-mono text-xs leading-relaxed whitespace-pre-wrap break-words">
       {text}
     </pre>
   )

--- a/src/renderer/src/components/chat-pane/JcodeToolCard.tsx
+++ b/src/renderer/src/components/chat-pane/JcodeToolCard.tsx
@@ -1,0 +1,109 @@
+// Why: M2 renders each jcode tool call as a card (name, pretty args, output or
+// error) instead of the M1 one-line placeholder. The bash tool is special-cased
+// to show the command + its output the way the jcode-desktop prototype does, and
+// any output that looks like a unified diff is rendered with the diff colorizer.
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { UnifiedDiff, looksLikeUnifiedDiff } from './jcode-diff'
+
+/** Lifecycle/render state of one tool call, accumulated from tool_start /
+ *  tool_input (concatenated arg deltas) / tool_exec / tool_done events. */
+export type JcodeToolCall = {
+  id: string
+  name: string
+  /** Concatenated tool_input deltas (a JSON string fragment). */
+  rawInput: string
+  /** Set once tool_done arrives. */
+  output?: string
+  error?: string
+  status: 'running' | 'done' | 'error'
+}
+
+function parseArgs(rawInput: string): Record<string, unknown> | null {
+  const trimmed = rawInput.trim()
+  if (!trimmed) {
+    return null
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+function prettyArgs(args: Record<string, unknown>): string {
+  return JSON.stringify(args, null, 2)
+}
+
+function statusGlyph(status: JcodeToolCall['status']): string {
+  if (status === 'running') {
+    return '⏳'
+  }
+  if (status === 'error') {
+    return '✕'
+  }
+  return '✓'
+}
+
+function OutputBlock({ text }: { text: string }): React.JSX.Element {
+  if (looksLikeUnifiedDiff(text)) {
+    return <UnifiedDiff text={text} />
+  }
+  return (
+    <pre className="max-h-72 overflow-auto rounded-md bg-background/60 p-2 font-mono text-xs leading-relaxed whitespace-pre-wrap break-words">
+      {text}
+    </pre>
+  )
+}
+
+export function JcodeToolCard({ call }: { call: JcodeToolCall }): React.JSX.Element {
+  const [open, setOpen] = useState(true)
+  const args = parseArgs(call.rawInput)
+  const isBash = call.name === 'bash' || call.name === 'shell'
+  const bashCommand =
+    isBash && args && typeof args.command === 'string' ? (args.command as string) : null
+
+  return (
+    <div className="rounded-md border border-border bg-background/40 text-xs">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center gap-2 px-2 py-1.5 text-left font-medium"
+      >
+        <span>{statusGlyph(call.status)}</span>
+        <span className="text-foreground">{call.name}</span>
+        {bashCommand ? (
+          <span className="truncate font-mono text-muted-foreground">{bashCommand}</span>
+        ) : null}
+        <span className="ml-auto text-muted-foreground">{open ? '▾' : '▸'}</span>
+      </button>
+      {open ? (
+        <div className="flex flex-col gap-1.5 border-t border-border px-2 py-1.5">
+          {bashCommand ? (
+            <pre className="overflow-x-auto rounded-md bg-background/60 p-2 font-mono text-xs whitespace-pre-wrap break-words">
+              {`$ ${bashCommand}`}
+            </pre>
+          ) : args ? (
+            <pre className="overflow-x-auto rounded-md bg-background/60 p-2 font-mono text-xs whitespace-pre-wrap break-words">
+              {prettyArgs(args)}
+            </pre>
+          ) : call.rawInput.trim() ? (
+            <pre className="overflow-x-auto rounded-md bg-background/60 p-2 font-mono text-xs whitespace-pre-wrap break-words">
+              {call.rawInput}
+            </pre>
+          ) : null}
+          {call.error ? (
+            <div className="rounded-md bg-destructive/15 p-2 text-destructive">
+              <OutputBlock text={call.error} />
+            </div>
+          ) : call.output !== undefined && call.output !== '' ? (
+            <OutputBlock text={call.output} />
+          ) : call.status === 'running' ? (
+            <div className={cn('text-muted-foreground')}>running…</div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/chat-pane/chat-session-record.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-record.ts
@@ -1,0 +1,49 @@
+import type { JcodeConversationRecord } from '../../../../shared/jcode-chat-types'
+import type { JcodeToolCall } from './JcodeToolCard'
+import type { ChatMessage, ChatSessionContext, ChatSessionState } from './chat-session-types'
+
+/** First non-empty user message, trimmed, as a human title for "Recent chats". */
+export function deriveChatSessionTitle(state: ChatSessionState): string {
+  const firstUser = state.messages.find((m) => m.role === 'user' && m.text.trim())
+  const text = firstUser?.text.trim() ?? 'New chat'
+  return text.length > 80 ? `${text.slice(0, 77)}…` : text
+}
+
+function persistedMessagesFromState(state: ChatSessionState): JcodeConversationRecord['messages'] {
+  return state.messages.map((m) => ({
+    id: m.id,
+    role: m.role,
+    text: m.text,
+    ...(m.tools ? { tools: m.tools } : {}),
+    ...(m.isError ? { isError: m.isError } : {})
+  }))
+}
+
+export function buildJcodeConversationRecord(
+  sessionKey: string,
+  state: ChatSessionState,
+  context: ChatSessionContext | undefined
+): JcodeConversationRecord {
+  return {
+    sessionKey,
+    worktreeId: context?.worktreeId,
+    cwd: context?.cwd,
+    title: deriveChatSessionTitle(state),
+    updatedAt: Date.now(),
+    resumeSessionId: state.resumeSessionId,
+    composerProvider: state.composerProvider,
+    composerModel: state.composerModel,
+    composerProviderProfile: state.composerProviderProfile,
+    messages: persistedMessagesFromState(state)
+  }
+}
+
+export function chatMessagesFromRecord(record: JcodeConversationRecord): ChatMessage[] {
+  return record.messages.map((m) => ({
+    id: m.id,
+    role: m.role,
+    text: m.text,
+    tools: Array.isArray(m.tools) ? (m.tools as JcodeToolCall[]) : undefined,
+    isError: m.isError
+  }))
+}

--- a/src/renderer/src/components/chat-pane/chat-session-reducer.test.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-reducer.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { reduceJcodeEvent } from './chat-session-reducer'
+import type { ChatSessionState } from './chat-session-types'
+
+function streamingState(): ChatSessionState {
+  return {
+    messages: [
+      { id: 'user-1', role: 'user', text: 'Run tests' },
+      { id: 'assistant-1', role: 'assistant', text: '' }
+    ],
+    isStreaming: true,
+    statusDetail: 'Thinking...',
+    resumeSessionId: undefined,
+    streamingId: 'assistant-1',
+    composerProvider: undefined,
+    composerModel: undefined,
+    composerProviderProfile: undefined,
+    pendingAttachments: []
+  }
+}
+
+describe('reduceJcodeEvent', () => {
+  it('accumulates streamed assistant text and finalizes on done', () => {
+    const withStart = reduceJcodeEvent(streamingState(), {
+      type: 'start',
+      session_id: 'session-a'
+    })
+    const withText = reduceJcodeEvent(withStart, { type: 'text_delta', text: 'hello' })
+    const done = reduceJcodeEvent(withText, {
+      type: 'done',
+      session_id: 'session-b',
+      text: 'ignored final text'
+    })
+
+    expect(done.resumeSessionId).toBe('session-b')
+    expect(done.messages.at(-1)?.text).toBe('hello')
+    expect(done.isStreaming).toBe(false)
+    expect(done.statusDetail).toBeNull()
+    expect(done.streamingId).toBeNull()
+  })
+
+  it('upserts tool events on the streaming assistant message', () => {
+    const withTool = [
+      { type: 'tool_start', id: 'tool-1', name: 'bash' },
+      { type: 'tool_input', id: 'tool-1', delta: '{"command":' },
+      { type: 'tool_input', id: 'tool-1', delta: '"pnpm test"}' },
+      { type: 'tool_done', id: 'tool-1', output: 'ok' }
+    ].reduce(reduceJcodeEvent, streamingState())
+
+    expect(withTool.messages.at(-1)?.tools).toEqual([
+      {
+        id: 'tool-1',
+        name: 'bash',
+        rawInput: '{"command":"pnpm test"}',
+        output: 'ok',
+        error: undefined,
+        status: 'done'
+      }
+    ])
+  })
+
+  it('finalizes error and stopped events with transcript text', () => {
+    const error = reduceJcodeEvent(streamingState(), {
+      type: 'error',
+      message: 'failed'
+    })
+    const stopped = reduceJcodeEvent(
+      {
+        ...streamingState(),
+        messages: [{ id: 'assistant-1', role: 'assistant', text: 'partial' }]
+      },
+      { type: 'stopped' }
+    )
+
+    expect(error.messages.at(-1)).toMatchObject({ text: 'failed', isError: true })
+    expect(error.isStreaming).toBe(false)
+    expect(stopped.messages.at(-1)?.text).toBe('partial\n\n(stopped)')
+    expect(stopped.streamingId).toBeNull()
+  })
+})

--- a/src/renderer/src/components/chat-pane/chat-session-reducer.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-reducer.ts
@@ -1,0 +1,149 @@
+import type { JcodeNdjsonEvent } from '../../../../shared/jcode-chat-types'
+import type { JcodeToolCall } from './JcodeToolCard'
+import type { ChatMessage, ChatSessionState } from './chat-session-types'
+
+function strField(event: JcodeNdjsonEvent, key: string): string | undefined {
+  const value = event[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+/** Insert-or-update a tool call on the streaming assistant message by id. */
+function upsertTool(
+  state: ChatSessionState,
+  id: string,
+  mutate: (call: JcodeToolCall) => JcodeToolCall,
+  fallbackName = 'tool'
+): ChatSessionState {
+  const targetId = state.streamingId
+  if (!targetId) {
+    return state
+  }
+  return {
+    ...state,
+    messages: state.messages.map((m) => {
+      if (m.id !== targetId) {
+        return m
+      }
+      const tools = m.tools ?? []
+      const index = tools.findIndex((t) => t.id === id)
+      if (index === -1) {
+        const created = mutate({ id, name: fallbackName, rawInput: '', status: 'running' })
+        return { ...m, tools: [...tools, created] }
+      }
+      const next = tools.slice()
+      next[index] = mutate(next[index])
+      return { ...m, tools: next }
+    })
+  }
+}
+
+function appendToStreaming(
+  state: ChatSessionState,
+  mutate: (msg: ChatMessage) => ChatMessage
+): ChatSessionState {
+  const targetId = state.streamingId
+  if (!targetId) {
+    return state
+  }
+  return {
+    ...state,
+    messages: state.messages.map((m) => (m.id === targetId ? mutate(m) : m))
+  }
+}
+
+function finalizeTurn(state: ChatSessionState): ChatSessionState {
+  return { ...state, isStreaming: false, statusDetail: null, streamingId: null }
+}
+
+export function reduceJcodeEvent(
+  previous: ChatSessionState,
+  event: JcodeNdjsonEvent
+): ChatSessionState {
+  switch (event.type) {
+    case 'start': {
+      const id = strField(event, 'session_id')
+      return id ? { ...previous, resumeSessionId: id } : previous
+    }
+    case 'status_detail': {
+      const detail = strField(event, 'detail')
+      return detail ? { ...previous, statusDetail: detail } : previous
+    }
+    case 'connection_phase': {
+      const phase = strField(event, 'phase')
+      return phase ? { ...previous, statusDetail: phase } : previous
+    }
+    case 'text_delta': {
+      const text = strField(event, 'text') ?? ''
+      if (!text) {
+        return previous
+      }
+      return appendToStreaming({ ...previous, statusDetail: null }, (m) => ({
+        ...m,
+        text: m.text + text
+      }))
+    }
+    case 'tool_start': {
+      const id = strField(event, 'id') ?? `tool-${Date.now()}`
+      const name = strField(event, 'name') ?? 'tool'
+      return upsertTool(previous, id, (call) => ({ ...call, name }), name)
+    }
+    case 'tool_input': {
+      const id = strField(event, 'id')
+      const delta = strField(event, 'delta') ?? ''
+      if (!id) {
+        return previous
+      }
+      return upsertTool(previous, id, (call) => ({ ...call, rawInput: call.rawInput + delta }))
+    }
+    case 'tool_exec': {
+      const id = strField(event, 'id') ?? `tool-${Date.now()}`
+      const name = strField(event, 'name') ?? 'tool'
+      return upsertTool(previous, id, (call) => ({ ...call, status: 'running' }), name)
+    }
+    case 'tool_done': {
+      const id = strField(event, 'id')
+      const errorText = strField(event, 'error')
+      const output = strField(event, 'output')
+      if (!id) {
+        return previous
+      }
+      return upsertTool(previous, id, (call) => ({
+        ...call,
+        output: output ?? call.output,
+        error: errorText ?? undefined,
+        status: errorText ? 'error' : 'done'
+      }))
+    }
+    case 'done': {
+      const id = strField(event, 'session_id')
+      let next = id ? { ...previous, resumeSessionId: id } : previous
+      const finalText = strField(event, 'text')
+      if (finalText) {
+        next = appendToStreaming(next, (m) => (m.text ? m : { ...m, text: finalText }))
+      }
+      return finalizeTurn(next)
+    }
+    case 'error': {
+      const message =
+        strField(event, 'error') ?? strField(event, 'message') ?? 'Unknown jcode error'
+      const next = appendToStreaming(previous, (m) => ({
+        ...m,
+        text: m.text + message,
+        isError: true
+      }))
+      return finalizeTurn(next)
+    }
+    case 'stopped': {
+      const next = appendToStreaming(previous, (m) => ({
+        ...m,
+        text: m.text ? `${m.text}\n\n(stopped)` : '(stopped)'
+      }))
+      return finalizeTurn(next)
+    }
+    case 'exit': {
+      return previous.streamingId ? finalizeTurn(previous) : previous
+    }
+    default:
+      return previous
+  }
+}

--- a/src/renderer/src/components/chat-pane/chat-session-store.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-store.ts
@@ -23,6 +23,12 @@ import type { JcodeToolCall } from './JcodeToolCard'
 // ChatPane becomes a thin view that reads/writes this store, so unmount/remount
 // is lossless and --resume continuity survives tab switches.
 
+/** Fired on the renderer DOM whenever the durable jcode conversation set may
+ *  have changed (a turn boundary persisted, or a conversation was deleted).
+ *  Best-effort signal for lightweight "Recent chats" surfaces (e.g. the sidebar
+ *  per-worktree list) to re-fetch without polling. */
+export const JCODE_CHAT_CONVERSATIONS_CHANGED_EVENT = 'jcode-chat:conversations-changed'
+
 export type ChatRole = 'user' | 'assistant'
 
 export type ChatMessage = {
@@ -123,6 +129,13 @@ function schedulePersist(sessionKey: string): void {
       return
     }
     void window.api.jcodeChat.saveConversation({ record: buildRecord(sessionKey, state) })
+    // Why: notify best-effort listeners (e.g. the sidebar per-worktree "Recent
+    // chats" list) that the durable conversation set changed on a turn boundary,
+    // so they can re-fetch without polling. Renderer-only DOM event; harmless in
+    // non-DOM test envs guarded by the typeof check.
+    if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+      window.dispatchEvent(new CustomEvent(JCODE_CHAT_CONVERSATIONS_CHANGED_EVENT))
+    }
   }, 250)
   saveTimers.set(sessionKey, timer)
 }
@@ -478,6 +491,9 @@ export function deleteChatConversation(sessionKey: string): void {
   listeners.delete(sessionKey)
   sessionContexts.delete(sessionKey)
   void window.api.jcodeChat.deleteConversation(sessionKey)
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(new CustomEvent(JCODE_CHAT_CONVERSATIONS_CHANGED_EVENT))
+  }
 }
 
 /** List persisted conversations (newest first) for a "Recent chats" surface. */

--- a/src/renderer/src/components/chat-pane/chat-session-store.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-store.ts
@@ -1,5 +1,13 @@
+/* eslint-disable max-lines -- Why: the jcode chat store keeps the NDJSON event
+   reducer, the live per-sessionKey external store, and its on-disk persistence
+   backing (snapshot/hydrate/list/delete) together so the full conversation
+   state contract is reviewable as one unit, mirroring persistence.ts. */
 import { useSyncExternalStore } from 'react'
-import type { JcodeChatEventMessage, JcodeNdjsonEvent } from '../../../../shared/jcode-chat-types'
+import type {
+  JcodeChatEventMessage,
+  JcodeConversationRecord,
+  JcodeNdjsonEvent
+} from '../../../../shared/jcode-chat-types'
 import type { JcodeToolCall } from './JcodeToolCard'
 
 // Why (BUG 1, persistence): the jcode chat conversation used to live in
@@ -53,6 +61,73 @@ const EMPTY_SESSION: ChatSessionState = {
 
 const sessions = new Map<string, ChatSessionState>()
 const listeners = new Map<string, Set<() => void>>()
+
+// Why (BUG 1, persistence): the live in-memory store is backed by disk in the
+// main process. To write a full JcodeConversationRecord we need per-session
+// context (worktreeId/cwd) that lives in ChatPane props, not in the event
+// stream. ChatPane registers it on mount via setChatSessionContext so a snapshot
+// written from anywhere (e.g. a turn that finished while the tab was hidden) is
+// complete. Sessions seeded by rehydrate are also marked here.
+type ChatSessionContext = { worktreeId?: string; cwd?: string }
+const sessionContexts = new Map<string, ChatSessionContext>()
+
+// Debounce timers per sessionKey so rapid turn-boundary saves coalesce and we
+// never write on every text_delta.
+const saveTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+/** First non-empty user message, trimmed, as a human title for "Recent chats". */
+function deriveTitle(state: ChatSessionState): string {
+  const firstUser = state.messages.find((m) => m.role === 'user' && m.text.trim())
+  const text = firstUser?.text.trim() ?? 'New chat'
+  return text.length > 80 ? `${text.slice(0, 77)}…` : text
+}
+
+function buildRecord(sessionKey: string, state: ChatSessionState): JcodeConversationRecord {
+  const ctx = sessionContexts.get(sessionKey)
+  return {
+    sessionKey,
+    worktreeId: ctx?.worktreeId,
+    cwd: ctx?.cwd,
+    title: deriveTitle(state),
+    updatedAt: Date.now(),
+    resumeSessionId: state.resumeSessionId,
+    composerProvider: state.composerProvider,
+    composerModel: state.composerModel,
+    messages: state.messages.map((m) => ({
+      id: m.id,
+      role: m.role,
+      text: m.text,
+      ...(m.tools ? { tools: m.tools } : {}),
+      ...(m.isError ? { isError: m.isError } : {})
+    }))
+  }
+}
+
+/** Persist a session snapshot to disk (debounced). Called on turn boundaries.
+ *  No-op for empty conversations so we don't create files for blank tabs. */
+function schedulePersist(sessionKey: string): void {
+  const existing = saveTimers.get(sessionKey)
+  if (existing) {
+    clearTimeout(existing)
+  }
+  const timer = setTimeout(() => {
+    saveTimers.delete(sessionKey)
+    const state = sessions.get(sessionKey)
+    if (!state || state.messages.length === 0) {
+      return
+    }
+    void window.api.jcodeChat.saveConversation({ record: buildRecord(sessionKey, state) })
+  }, 250)
+  saveTimers.set(sessionKey, timer)
+}
+
+/** Register per-session context (worktreeId/cwd) for the disk record. Called by
+ *  ChatPane on mount; safe to call repeatedly. */
+export function setChatSessionContext(sessionKey: string, context: ChatSessionContext): void {
+  sessionContexts.set(sessionKey, context)
+}
+
+const TURN_BOUNDARY_EVENTS = new Set(['start', 'done', 'error', 'stopped', 'exit'])
 
 function getSession(sessionKey: string): ChatSessionState {
   return sessions.get(sessionKey) ?? EMPTY_SESSION
@@ -236,6 +311,12 @@ function ensureIpcSubscription(): void {
       return
     }
     setSession(sessionKey, (state) => reduceEvent(state, message.event))
+    // Why (BUG 1): persist on turn boundaries (done/error/stopped/exit), not on
+    // every text_delta, so we capture the final transcript + --resume id without
+    // thrashing disk. 'start' is handled at startChatTurn (records the prompt).
+    if (TURN_BOUNDARY_EVENTS.has(message.event.type)) {
+      schedulePersist(sessionKey)
+    }
   })
 }
 
@@ -282,6 +363,46 @@ export function startChatTurn(sessionKey: string, prompt: string): void {
     isStreaming: true,
     statusDetail: 'Thinking…'
   }))
+  // Why (BUG 1): persist at the start of a turn so the user prompt is durable
+  // even if jcode crashes before emitting any event.
+  schedulePersist(sessionKey)
+}
+
+/** Seed the in-memory store for a sessionKey from a loaded on-disk conversation.
+ *  Called before/at ChatPane mount when reopening a known conversation so the
+ *  rehydrated view matches the persisted transcript + --resume continuity. Does
+ *  not overwrite a session that already has live messages (avoids clobbering a
+ *  conversation that was kept in memory across a tab switch). */
+export function hydrateChatSession(record: JcodeConversationRecord): void {
+  const existing = sessions.get(record.sessionKey)
+  if (existing && existing.messages.length > 0) {
+    sessionContexts.set(record.sessionKey, {
+      worktreeId: record.worktreeId,
+      cwd: record.cwd
+    })
+    return
+  }
+  sessionContexts.set(record.sessionKey, {
+    worktreeId: record.worktreeId,
+    cwd: record.cwd
+  })
+  setSession(record.sessionKey, (state) => ({
+    ...state,
+    messages: record.messages.map((m) => ({
+      id: m.id,
+      role: m.role,
+      text: m.text,
+      tools: Array.isArray(m.tools) ? (m.tools as JcodeToolCall[]) : undefined,
+      isError: m.isError
+    })),
+    // A rehydrated turn is never mid-stream.
+    isStreaming: false,
+    statusDetail: null,
+    streamingId: null,
+    resumeSessionId: record.resumeSessionId,
+    composerProvider: record.composerProvider,
+    composerModel: record.composerModel
+  }))
 }
 
 export function setChatStatusDetail(sessionKey: string, detail: string | null): void {
@@ -303,9 +424,54 @@ export function setChatComposerSelection(
   }))
 }
 
-/** Drop a session's state. Called when its chat tab is closed so the Map does
- *  not grow unboundedly across the app's lifetime. */
+/** Drop a session's IN-MEMORY state. Called when its chat tab is closed so the
+ *  Map does not grow unboundedly across the app's lifetime.
+ *
+ *  Why (BUG 1/2): this is in-memory eviction ONLY — it must NOT delete the
+ *  on-disk transcript. A closed jcode chat stays in "Recent chats" and can be
+ *  reopened + rehydrated. To flush the latest live state before evicting, we
+ *  persist synchronously-ish (debounced timers are cleared and a final save is
+ *  issued) so nothing typed before close is lost. Use deleteChatConversation to
+ *  remove the durable record. */
 export function disposeChatSession(sessionKey: string): void {
+  const pending = saveTimers.get(sessionKey)
+  if (pending) {
+    clearTimeout(pending)
+    saveTimers.delete(sessionKey)
+  }
+  const state = sessions.get(sessionKey)
+  if (state && state.messages.length > 0) {
+    void window.api.jcodeChat.saveConversation({ record: buildRecord(sessionKey, state) })
+  }
   sessions.delete(sessionKey)
   listeners.delete(sessionKey)
+  sessionContexts.delete(sessionKey)
+}
+
+/** Permanently delete a conversation's durable record (and evict memory). Used
+ *  when the user removes a chat from "Recent chats". */
+export function deleteChatConversation(sessionKey: string): void {
+  const pending = saveTimers.get(sessionKey)
+  if (pending) {
+    clearTimeout(pending)
+    saveTimers.delete(sessionKey)
+  }
+  sessions.delete(sessionKey)
+  listeners.delete(sessionKey)
+  sessionContexts.delete(sessionKey)
+  void window.api.jcodeChat.deleteConversation(sessionKey)
+}
+
+/** List persisted conversations (newest first) for a "Recent chats" surface. */
+export async function listChatConversations(): Promise<
+  Awaited<ReturnType<typeof window.api.jcodeChat.listConversations>>
+> {
+  return window.api.jcodeChat.listConversations()
+}
+
+/** Load a persisted conversation record (transcript + context) by sessionKey. */
+export async function loadChatConversation(
+  sessionKey: string
+): Promise<JcodeConversationRecord | null> {
+  return window.api.jcodeChat.loadConversation(sessionKey)
 }

--- a/src/renderer/src/components/chat-pane/chat-session-store.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-store.ts
@@ -2,7 +2,8 @@ import { useSyncExternalStore } from 'react'
 import type {
   JcodeChatAttachment,
   JcodeChatEventMessage,
-  JcodeConversationRecord
+  JcodeConversationRecord,
+  JcodeConversationSummary
 } from '../../../../shared/jcode-chat-types'
 import { buildJcodeConversationRecord, chatMessagesFromRecord } from './chat-session-record'
 import { reduceJcodeEvent } from './chat-session-reducer'
@@ -60,6 +61,15 @@ const sessionContexts = new Map<string, ChatSessionContext>()
 // never write on every text_delta.
 const saveTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
+function getJcodeChatApi(): typeof window.api.jcodeChat | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  // Why: sidebar/card tests and web shells can render without Electron preload;
+  // persisted jcode chats are simply unavailable in that environment.
+  return window.api?.jcodeChat ?? null
+}
+
 /** Persist a session snapshot to disk (debounced). Called on turn boundaries.
  *  No-op for empty conversations so we don't create files for blank tabs. */
 function schedulePersist(sessionKey: string): void {
@@ -73,7 +83,7 @@ function schedulePersist(sessionKey: string): void {
     if (!state || state.messages.length === 0) {
       return
     }
-    void window.api.jcodeChat.saveConversation({
+    void getJcodeChatApi()?.saveConversation({
       record: buildJcodeConversationRecord(sessionKey, state, sessionContexts.get(sessionKey))
     })
     // Why: notify best-effort listeners (e.g. the sidebar per-worktree "Recent
@@ -125,8 +135,12 @@ function ensureIpcSubscription(): void {
   if (ipcSubscribed) {
     return
   }
+  const api = getJcodeChatApi()
+  if (!api) {
+    return
+  }
   ipcSubscribed = true
-  window.api.jcodeChat.onEvent((message: JcodeChatEventMessage) => {
+  api.onEvent((message: JcodeChatEventMessage) => {
     const sessionKey = message.sessionKey
     // Only reduce for sessions we know about (a chat tab that has sent at least
     // one prompt). Ignore stray events for unknown keys.
@@ -308,7 +322,8 @@ export function disposeChatSession(sessionKey: string): void {
   // tab mid-turn leaves the spawned jcode process running (and burning tokens)
   // with no UI attached to it. The main-side handler safely no-ops when there is
   // no active child, so calling it unconditionally is harmless.
-  window.api.jcodeChat.stop({ sessionKey })
+  const api = getJcodeChatApi()
+  api?.stop({ sessionKey })
   const pending = saveTimers.get(sessionKey)
   if (pending) {
     clearTimeout(pending)
@@ -316,7 +331,7 @@ export function disposeChatSession(sessionKey: string): void {
   }
   const state = sessions.get(sessionKey)
   if (state && state.messages.length > 0) {
-    void window.api.jcodeChat.saveConversation({
+    void api?.saveConversation({
       record: buildJcodeConversationRecord(sessionKey, state, sessionContexts.get(sessionKey))
     })
   }
@@ -336,22 +351,20 @@ export function deleteChatConversation(sessionKey: string): void {
   sessions.delete(sessionKey)
   listeners.delete(sessionKey)
   sessionContexts.delete(sessionKey)
-  void window.api.jcodeChat.deleteConversation(sessionKey)
+  void getJcodeChatApi()?.deleteConversation(sessionKey)
   if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
     window.dispatchEvent(new CustomEvent(JCODE_CHAT_CONVERSATIONS_CHANGED_EVENT))
   }
 }
 
 /** List persisted conversations (newest first) for a "Recent chats" surface. */
-export async function listChatConversations(): Promise<
-  Awaited<ReturnType<typeof window.api.jcodeChat.listConversations>>
-> {
-  return window.api.jcodeChat.listConversations()
+export async function listChatConversations(): Promise<JcodeConversationSummary[]> {
+  return (await getJcodeChatApi()?.listConversations()) ?? []
 }
 
 /** Load a persisted conversation record (transcript + context) by sessionKey. */
 export async function loadChatConversation(
   sessionKey: string
 ): Promise<JcodeConversationRecord | null> {
-  return window.api.jcodeChat.loadConversation(sessionKey)
+  return (await getJcodeChatApi()?.loadConversation(sessionKey)) ?? null
 }

--- a/src/renderer/src/components/chat-pane/chat-session-store.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-store.ts
@@ -1,0 +1,289 @@
+import { useSyncExternalStore } from 'react'
+import type { JcodeChatEventMessage, JcodeNdjsonEvent } from '../../../../shared/jcode-chat-types'
+import type { JcodeToolCall } from './JcodeToolCard'
+
+// Why (BUG 1, persistence): the jcode chat conversation used to live in
+// ChatPane's component-local React state. Because TabGroupPanel only mounts
+// ChatPane while its tab is active, switching to another tab unmounted the
+// component and destroyed the messages AND the jcode --resume session id, so
+// returning to the tab showed an empty conversation with broken continuity.
+//
+// This module hoists that state into a tiny external store keyed by sessionKey
+// (the chat tab id). The store subscribes to the 'jcode-chat:event' IPC stream
+// once at module load — independent of whether any ChatPane is mounted — so
+// deltas keep flowing into the right session even while its tab is hidden.
+// ChatPane becomes a thin view that reads/writes this store, so unmount/remount
+// is lossless and --resume continuity survives tab switches.
+
+export type ChatRole = 'user' | 'assistant'
+
+export type ChatMessage = {
+  id: string
+  role: ChatRole
+  text: string
+  /** Tool calls seen during this assistant turn, in arrival order. */
+  tools?: JcodeToolCall[]
+  isError?: boolean
+}
+
+export type ChatSessionState = {
+  messages: ChatMessage[]
+  isStreaming: boolean
+  statusDetail: string | null
+  /** jcode session id to pass as --resume on the next turn. */
+  resumeSessionId: string | undefined
+  /** Id of the assistant message currently being streamed into, if any. */
+  streamingId: string | null
+}
+
+const EMPTY_SESSION: ChatSessionState = {
+  messages: [],
+  isStreaming: false,
+  statusDetail: null,
+  resumeSessionId: undefined,
+  streamingId: null
+}
+
+const sessions = new Map<string, ChatSessionState>()
+const listeners = new Map<string, Set<() => void>>()
+
+function getSession(sessionKey: string): ChatSessionState {
+  return sessions.get(sessionKey) ?? EMPTY_SESSION
+}
+
+function emit(sessionKey: string): void {
+  const set = listeners.get(sessionKey)
+  if (set) {
+    for (const listener of set) {
+      listener()
+    }
+  }
+}
+
+function setSession(
+  sessionKey: string,
+  mutate: (state: ChatSessionState) => ChatSessionState
+): void {
+  const next = mutate(getSession(sessionKey))
+  sessions.set(sessionKey, next)
+  emit(sessionKey)
+}
+
+function strField(event: JcodeNdjsonEvent, key: string): string | undefined {
+  const value = event[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+/** Insert-or-update a tool call on the streaming assistant message by id. */
+function upsertTool(
+  state: ChatSessionState,
+  id: string,
+  mutate: (call: JcodeToolCall) => JcodeToolCall,
+  fallbackName = 'tool'
+): ChatSessionState {
+  const targetId = state.streamingId
+  if (!targetId) {
+    return state
+  }
+  return {
+    ...state,
+    messages: state.messages.map((m) => {
+      if (m.id !== targetId) {
+        return m
+      }
+      const tools = m.tools ?? []
+      const index = tools.findIndex((t) => t.id === id)
+      if (index === -1) {
+        const created = mutate({ id, name: fallbackName, rawInput: '', status: 'running' })
+        return { ...m, tools: [...tools, created] }
+      }
+      const next = tools.slice()
+      next[index] = mutate(next[index])
+      return { ...m, tools: next }
+    })
+  }
+}
+
+function appendToStreaming(
+  state: ChatSessionState,
+  mutate: (msg: ChatMessage) => ChatMessage
+): ChatSessionState {
+  const targetId = state.streamingId
+  if (!targetId) {
+    return state
+  }
+  return {
+    ...state,
+    messages: state.messages.map((m) => (m.id === targetId ? mutate(m) : m))
+  }
+}
+
+function finalizeTurn(state: ChatSessionState): ChatSessionState {
+  return { ...state, isStreaming: false, statusDetail: null, streamingId: null }
+}
+
+function reduceEvent(state: ChatSessionState, event: JcodeNdjsonEvent): ChatSessionState {
+  switch (event.type) {
+    case 'start': {
+      const id = strField(event, 'session_id')
+      return id ? { ...state, resumeSessionId: id } : state
+    }
+    case 'status_detail': {
+      const detail = strField(event, 'detail')
+      return detail ? { ...state, statusDetail: detail } : state
+    }
+    case 'connection_phase': {
+      const phase = strField(event, 'phase')
+      return phase ? { ...state, statusDetail: phase } : state
+    }
+    case 'text_delta': {
+      const text = strField(event, 'text') ?? ''
+      if (!text) {
+        return state
+      }
+      return appendToStreaming({ ...state, statusDetail: null }, (m) => ({
+        ...m,
+        text: m.text + text
+      }))
+    }
+    case 'tool_start': {
+      const id = strField(event, 'id') ?? `tool-${Date.now()}`
+      const name = strField(event, 'name') ?? 'tool'
+      return upsertTool(state, id, (call) => ({ ...call, name }), name)
+    }
+    case 'tool_input': {
+      const id = strField(event, 'id')
+      const delta = strField(event, 'delta') ?? ''
+      if (!id) {
+        return state
+      }
+      return upsertTool(state, id, (call) => ({ ...call, rawInput: call.rawInput + delta }))
+    }
+    case 'tool_exec': {
+      const id = strField(event, 'id') ?? `tool-${Date.now()}`
+      const name = strField(event, 'name') ?? 'tool'
+      return upsertTool(state, id, (call) => ({ ...call, status: 'running' }), name)
+    }
+    case 'tool_done': {
+      const id = strField(event, 'id')
+      const errorText = strField(event, 'error')
+      const output = strField(event, 'output')
+      if (!id) {
+        return state
+      }
+      return upsertTool(state, id, (call) => ({
+        ...call,
+        output: output ?? call.output,
+        error: errorText ?? undefined,
+        status: errorText ? 'error' : 'done'
+      }))
+    }
+    case 'done': {
+      const id = strField(event, 'session_id')
+      let next = id ? { ...state, resumeSessionId: id } : state
+      const finalText = strField(event, 'text')
+      if (finalText) {
+        next = appendToStreaming(next, (m) => (m.text ? m : { ...m, text: finalText }))
+      }
+      return finalizeTurn(next)
+    }
+    case 'error': {
+      const message =
+        strField(event, 'error') ?? strField(event, 'message') ?? 'Unknown jcode error'
+      const next = appendToStreaming(state, (m) => ({
+        ...m,
+        text: m.text + message,
+        isError: true
+      }))
+      return finalizeTurn(next)
+    }
+    case 'stopped': {
+      const next = appendToStreaming(state, (m) => ({
+        ...m,
+        text: m.text ? `${m.text}\n\n(stopped)` : '(stopped)'
+      }))
+      return finalizeTurn(next)
+    }
+    case 'exit': {
+      return state.streamingId ? finalizeTurn(state) : state
+    }
+    default:
+      return state
+  }
+}
+
+let ipcSubscribed = false
+
+/** Subscribe the module to the jcode chat IPC stream exactly once. Routes each
+ *  event into its session's reducer regardless of which tab is mounted. */
+function ensureIpcSubscription(): void {
+  if (ipcSubscribed) {
+    return
+  }
+  ipcSubscribed = true
+  window.api.jcodeChat.onEvent((message: JcodeChatEventMessage) => {
+    const sessionKey = message.sessionKey
+    // Only reduce for sessions we know about (a chat tab that has sent at least
+    // one prompt). Ignore stray events for unknown keys.
+    if (!sessions.has(sessionKey)) {
+      return
+    }
+    setSession(sessionKey, (state) => reduceEvent(state, message.event))
+  })
+}
+
+export function subscribeChatSession(sessionKey: string, listener: () => void): () => void {
+  ensureIpcSubscription()
+  let set = listeners.get(sessionKey)
+  if (!set) {
+    set = new Set()
+    listeners.set(sessionKey, set)
+  }
+  set.add(listener)
+  return () => {
+    set?.delete(listener)
+    if (set && set.size === 0) {
+      listeners.delete(sessionKey)
+    }
+  }
+}
+
+export function getChatSessionSnapshot(sessionKey: string): ChatSessionState {
+  return getSession(sessionKey)
+}
+
+export function useChatSession(sessionKey: string): ChatSessionState {
+  return useSyncExternalStore(
+    (listener) => subscribeChatSession(sessionKey, listener),
+    () => getChatSessionSnapshot(sessionKey)
+  )
+}
+
+/** Record a user prompt + create the assistant placeholder, marking the session
+ *  streaming. Returns nothing; the view re-renders via the store subscription. */
+export function startChatTurn(sessionKey: string, prompt: string): void {
+  const userId = `user-${Date.now()}`
+  const assistantId = `assistant-${Date.now()}`
+  setSession(sessionKey, (state) => ({
+    ...state,
+    messages: [
+      ...state.messages,
+      { id: userId, role: 'user', text: prompt },
+      { id: assistantId, role: 'assistant', text: '' }
+    ],
+    streamingId: assistantId,
+    isStreaming: true,
+    statusDetail: 'Thinking…'
+  }))
+}
+
+export function setChatStatusDetail(sessionKey: string, detail: string | null): void {
+  setSession(sessionKey, (state) => ({ ...state, statusDetail: detail }))
+}
+
+/** Drop a session's state. Called when its chat tab is closed so the Map does
+ *  not grow unboundedly across the app's lifetime. */
+export function disposeChatSession(sessionKey: string): void {
+  sessions.delete(sessionKey)
+  listeners.delete(sessionKey)
+}

--- a/src/renderer/src/components/chat-pane/chat-session-store.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-store.ts
@@ -47,6 +47,10 @@ export type ChatSessionState = {
    *  `undefined` provider means "Auto" (let ChatPane's default apply). */
   composerProvider: string | undefined
   composerModel: string | undefined
+  /** Selected custom provider profile name (from a `jcode provider add` profile).
+   *  Mutually exclusive with composerProvider: when set, the turn is sent with
+   *  `providerProfile` (-> `--provider-profile`) instead of `provider` (-> -p). */
+  composerProviderProfile: string | undefined
 }
 
 const EMPTY_SESSION: ChatSessionState = {
@@ -56,7 +60,8 @@ const EMPTY_SESSION: ChatSessionState = {
   resumeSessionId: undefined,
   streamingId: null,
   composerProvider: undefined,
-  composerModel: undefined
+  composerModel: undefined,
+  composerProviderProfile: undefined
 }
 
 const sessions = new Map<string, ChatSessionState>()
@@ -93,6 +98,7 @@ function buildRecord(sessionKey: string, state: ChatSessionState): JcodeConversa
     resumeSessionId: state.resumeSessionId,
     composerProvider: state.composerProvider,
     composerModel: state.composerModel,
+    composerProviderProfile: state.composerProviderProfile,
     messages: state.messages.map((m) => ({
       id: m.id,
       role: m.role,
@@ -401,7 +407,8 @@ export function hydrateChatSession(record: JcodeConversationRecord): void {
     streamingId: null,
     resumeSessionId: record.resumeSessionId,
     composerProvider: record.composerProvider,
-    composerModel: record.composerModel
+    composerModel: record.composerModel,
+    composerProviderProfile: record.composerProviderProfile
   }))
 }
 
@@ -409,17 +416,28 @@ export function setChatStatusDetail(sessionKey: string, detail: string | null): 
   setSession(sessionKey, (state) => ({ ...state, statusDetail: detail }))
 }
 
-/** Persist the composer's provider/model selection per sessionKey so the chip
- *  choice survives tab switches (ChatPane unmount/remount). Pass `undefined`
- *  provider to mean "Auto". Setting a provider clears the model unless one is
- *  given, since models are provider-specific. */
+/** The composer chip selection. A built-in provider and a custom profile are
+ *  mutually exclusive; "Auto" is `provider: undefined, providerProfile: undefined`. */
+export type ChatComposerSelection = {
+  provider?: string | undefined
+  /** Custom profile name; when set, `provider` is ignored on send. */
+  providerProfile?: string | undefined
+  model?: string | undefined
+}
+
+/** Persist the composer's provider/profile/model selection per sessionKey so the
+ *  chip choice survives tab switches (ChatPane unmount/remount). Pass everything
+ *  undefined to mean "Auto". A built-in provider and a custom profile are
+ *  mutually exclusive — selecting one clears the other. When `model` is omitted
+ *  the previous model is kept. */
 export function setChatComposerSelection(
   sessionKey: string,
-  selection: { provider: string | undefined; model?: string | undefined }
+  selection: ChatComposerSelection
 ): void {
   setSession(sessionKey, (state) => ({
     ...state,
-    composerProvider: selection.provider,
+    composerProvider: selection.providerProfile ? undefined : selection.provider,
+    composerProviderProfile: selection.providerProfile,
     composerModel: 'model' in selection ? selection.model : state.composerModel
   }))
 }

--- a/src/renderer/src/components/chat-pane/chat-session-store.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-store.ts
@@ -34,6 +34,11 @@ export type ChatSessionState = {
   resumeSessionId: string | undefined
   /** Id of the assistant message currently being streamed into, if any. */
   streamingId: string | null
+  /** Composer toolbar selection (Claude-style provider/model chip). Persisted
+   *  per sessionKey so it survives ChatPane unmount/remount on tab switches.
+   *  `undefined` provider means "Auto" (let ChatPane's default apply). */
+  composerProvider: string | undefined
+  composerModel: string | undefined
 }
 
 const EMPTY_SESSION: ChatSessionState = {
@@ -41,7 +46,9 @@ const EMPTY_SESSION: ChatSessionState = {
   isStreaming: false,
   statusDetail: null,
   resumeSessionId: undefined,
-  streamingId: null
+  streamingId: null,
+  composerProvider: undefined,
+  composerModel: undefined
 }
 
 const sessions = new Map<string, ChatSessionState>()
@@ -279,6 +286,21 @@ export function startChatTurn(sessionKey: string, prompt: string): void {
 
 export function setChatStatusDetail(sessionKey: string, detail: string | null): void {
   setSession(sessionKey, (state) => ({ ...state, statusDetail: detail }))
+}
+
+/** Persist the composer's provider/model selection per sessionKey so the chip
+ *  choice survives tab switches (ChatPane unmount/remount). Pass `undefined`
+ *  provider to mean "Auto". Setting a provider clears the model unless one is
+ *  given, since models are provider-specific. */
+export function setChatComposerSelection(
+  sessionKey: string,
+  selection: { provider: string | undefined; model?: string | undefined }
+): void {
+  setSession(sessionKey, (state) => ({
+    ...state,
+    composerProvider: selection.provider,
+    composerModel: 'model' in selection ? selection.model : state.composerModel
+  }))
 }
 
 /** Drop a session's state. Called when its chat tab is closed so the Map does

--- a/src/renderer/src/components/chat-pane/chat-session-store.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-store.ts
@@ -4,6 +4,7 @@
    state contract is reviewable as one unit, mirroring persistence.ts. */
 import { useSyncExternalStore } from 'react'
 import type {
+  JcodeChatAttachment,
   JcodeChatEventMessage,
   JcodeConversationRecord,
   JcodeNdjsonEvent
@@ -57,6 +58,11 @@ export type ChatSessionState = {
    *  Mutually exclusive with composerProvider: when set, the turn is sent with
    *  `providerProfile` (-> `--provider-profile`) instead of `provider` (-> -p). */
   composerProviderProfile: string | undefined
+  /** Pending composer attachments (files + text blobs) for the NEXT turn.
+   *  Persisted per sessionKey so they survive a tab switch before send; cleared
+   *  by clearChatAttachments after the turn is dispatched. NOT persisted to disk
+   *  (they are folded into the prompt the transcript already records). */
+  pendingAttachments: JcodeChatAttachment[]
 }
 
 const EMPTY_SESSION: ChatSessionState = {
@@ -67,7 +73,8 @@ const EMPTY_SESSION: ChatSessionState = {
   streamingId: null,
   composerProvider: undefined,
   composerModel: undefined,
-  composerProviderProfile: undefined
+  composerProviderProfile: undefined,
+  pendingAttachments: []
 }
 
 const sessions = new Map<string, ChatSessionState>()
@@ -453,6 +460,47 @@ export function setChatComposerSelection(
     composerProviderProfile: selection.providerProfile,
     composerModel: 'model' in selection ? selection.model : state.composerModel
   }))
+}
+
+/** Append composer attachments (files and/or text blobs) for the next turn.
+ *  De-dupes file attachments by absolute path so re-picking the same file is a
+ *  no-op. Stored in the per-sessionKey external store so chips survive a tab
+ *  switch before the user hits send. */
+export function addChatAttachments(sessionKey: string, attachments: JcodeChatAttachment[]): void {
+  if (attachments.length === 0) {
+    return
+  }
+  setSession(sessionKey, (state) => {
+    const existingPaths = new Set(
+      state.pendingAttachments.filter((a) => a.kind === 'file').map((a) => a.path)
+    )
+    const next = state.pendingAttachments.slice()
+    for (const attachment of attachments) {
+      if (attachment.kind === 'file') {
+        if (existingPaths.has(attachment.path)) {
+          continue
+        }
+        existingPaths.add(attachment.path)
+      }
+      next.push(attachment)
+    }
+    return { ...state, pendingAttachments: next }
+  })
+}
+
+/** Remove one pending attachment by index (chip ✕). */
+export function removeChatAttachment(sessionKey: string, index: number): void {
+  setSession(sessionKey, (state) => ({
+    ...state,
+    pendingAttachments: state.pendingAttachments.filter((_, i) => i !== index)
+  }))
+}
+
+/** Clear all pending attachments (called after a turn is dispatched). */
+export function clearChatAttachments(sessionKey: string): void {
+  setSession(sessionKey, (state) =>
+    state.pendingAttachments.length === 0 ? state : { ...state, pendingAttachments: [] }
+  )
 }
 
 /** Drop a session's IN-MEMORY state. Called when its chat tab is closed so the

--- a/src/renderer/src/components/chat-pane/chat-session-store.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-store.ts
@@ -513,6 +513,11 @@ export function clearChatAttachments(sessionKey: string): void {
  *  issued) so nothing typed before close is lost. Use deleteChatConversation to
  *  remove the durable record. */
 export function disposeChatSession(sessionKey: string): void {
+  // Kill any in-flight jcode child for this pane. Without this, closing a chat
+  // tab mid-turn leaves the spawned jcode process running (and burning tokens)
+  // with no UI attached to it. The main-side handler safely no-ops when there is
+  // no active child, so calling it unconditionally is harmless.
+  window.api.jcodeChat.stop({ sessionKey })
   const pending = saveTimers.get(sessionKey)
   if (pending) {
     clearTimeout(pending)

--- a/src/renderer/src/components/chat-pane/chat-session-store.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-store.ts
@@ -1,15 +1,18 @@
-/* eslint-disable max-lines -- Why: the jcode chat store keeps the NDJSON event
-   reducer, the live per-sessionKey external store, and its on-disk persistence
-   backing (snapshot/hydrate/list/delete) together so the full conversation
-   state contract is reviewable as one unit, mirroring persistence.ts. */
 import { useSyncExternalStore } from 'react'
 import type {
   JcodeChatAttachment,
   JcodeChatEventMessage,
-  JcodeConversationRecord,
-  JcodeNdjsonEvent
+  JcodeConversationRecord
 } from '../../../../shared/jcode-chat-types'
-import type { JcodeToolCall } from './JcodeToolCard'
+import { buildJcodeConversationRecord, chatMessagesFromRecord } from './chat-session-record'
+import { reduceJcodeEvent } from './chat-session-reducer'
+import type { ChatSessionContext, ChatSessionState } from './chat-session-types'
+export type {
+  ChatMessage,
+  ChatRole,
+  ChatSessionContext,
+  ChatSessionState
+} from './chat-session-types'
 
 // Why (BUG 1, persistence): the jcode chat conversation used to live in
 // ChatPane's component-local React state. Because TabGroupPanel only mounts
@@ -29,41 +32,6 @@ import type { JcodeToolCall } from './JcodeToolCard'
  *  Best-effort signal for lightweight "Recent chats" surfaces (e.g. the sidebar
  *  per-worktree list) to re-fetch without polling. */
 export const JCODE_CHAT_CONVERSATIONS_CHANGED_EVENT = 'jcode-chat:conversations-changed'
-
-export type ChatRole = 'user' | 'assistant'
-
-export type ChatMessage = {
-  id: string
-  role: ChatRole
-  text: string
-  /** Tool calls seen during this assistant turn, in arrival order. */
-  tools?: JcodeToolCall[]
-  isError?: boolean
-}
-
-export type ChatSessionState = {
-  messages: ChatMessage[]
-  isStreaming: boolean
-  statusDetail: string | null
-  /** jcode session id to pass as --resume on the next turn. */
-  resumeSessionId: string | undefined
-  /** Id of the assistant message currently being streamed into, if any. */
-  streamingId: string | null
-  /** Composer toolbar selection (Claude-style provider/model chip). Persisted
-   *  per sessionKey so it survives ChatPane unmount/remount on tab switches.
-   *  `undefined` provider means "Auto" (let ChatPane's default apply). */
-  composerProvider: string | undefined
-  composerModel: string | undefined
-  /** Selected custom provider profile name (from a `jcode provider add` profile).
-   *  Mutually exclusive with composerProvider: when set, the turn is sent with
-   *  `providerProfile` (-> `--provider-profile`) instead of `provider` (-> -p). */
-  composerProviderProfile: string | undefined
-  /** Pending composer attachments (files + text blobs) for the NEXT turn.
-   *  Persisted per sessionKey so they survive a tab switch before send; cleared
-   *  by clearChatAttachments after the turn is dispatched. NOT persisted to disk
-   *  (they are folded into the prompt the transcript already records). */
-  pendingAttachments: JcodeChatAttachment[]
-}
 
 const EMPTY_SESSION: ChatSessionState = {
   messages: [],
@@ -86,41 +54,11 @@ const listeners = new Map<string, Set<() => void>>()
 // stream. ChatPane registers it on mount via setChatSessionContext so a snapshot
 // written from anywhere (e.g. a turn that finished while the tab was hidden) is
 // complete. Sessions seeded by rehydrate are also marked here.
-type ChatSessionContext = { worktreeId?: string; cwd?: string }
 const sessionContexts = new Map<string, ChatSessionContext>()
 
 // Debounce timers per sessionKey so rapid turn-boundary saves coalesce and we
 // never write on every text_delta.
 const saveTimers = new Map<string, ReturnType<typeof setTimeout>>()
-
-/** First non-empty user message, trimmed, as a human title for "Recent chats". */
-function deriveTitle(state: ChatSessionState): string {
-  const firstUser = state.messages.find((m) => m.role === 'user' && m.text.trim())
-  const text = firstUser?.text.trim() ?? 'New chat'
-  return text.length > 80 ? `${text.slice(0, 77)}…` : text
-}
-
-function buildRecord(sessionKey: string, state: ChatSessionState): JcodeConversationRecord {
-  const ctx = sessionContexts.get(sessionKey)
-  return {
-    sessionKey,
-    worktreeId: ctx?.worktreeId,
-    cwd: ctx?.cwd,
-    title: deriveTitle(state),
-    updatedAt: Date.now(),
-    resumeSessionId: state.resumeSessionId,
-    composerProvider: state.composerProvider,
-    composerModel: state.composerModel,
-    composerProviderProfile: state.composerProviderProfile,
-    messages: state.messages.map((m) => ({
-      id: m.id,
-      role: m.role,
-      text: m.text,
-      ...(m.tools ? { tools: m.tools } : {}),
-      ...(m.isError ? { isError: m.isError } : {})
-    }))
-  }
-}
 
 /** Persist a session snapshot to disk (debounced). Called on turn boundaries.
  *  No-op for empty conversations so we don't create files for blank tabs. */
@@ -135,7 +73,9 @@ function schedulePersist(sessionKey: string): void {
     if (!state || state.messages.length === 0) {
       return
     }
-    void window.api.jcodeChat.saveConversation({ record: buildRecord(sessionKey, state) })
+    void window.api.jcodeChat.saveConversation({
+      record: buildJcodeConversationRecord(sessionKey, state, sessionContexts.get(sessionKey))
+    })
     // Why: notify best-effort listeners (e.g. the sidebar per-worktree "Recent
     // chats" list) that the durable conversation set changed on a turn boundary,
     // so they can re-fetch without polling. Renderer-only DOM event; harmless in
@@ -177,149 +117,6 @@ function setSession(
   emit(sessionKey)
 }
 
-function strField(event: JcodeNdjsonEvent, key: string): string | undefined {
-  const value = event[key]
-  return typeof value === 'string' ? value : undefined
-}
-
-/** Insert-or-update a tool call on the streaming assistant message by id. */
-function upsertTool(
-  state: ChatSessionState,
-  id: string,
-  mutate: (call: JcodeToolCall) => JcodeToolCall,
-  fallbackName = 'tool'
-): ChatSessionState {
-  const targetId = state.streamingId
-  if (!targetId) {
-    return state
-  }
-  return {
-    ...state,
-    messages: state.messages.map((m) => {
-      if (m.id !== targetId) {
-        return m
-      }
-      const tools = m.tools ?? []
-      const index = tools.findIndex((t) => t.id === id)
-      if (index === -1) {
-        const created = mutate({ id, name: fallbackName, rawInput: '', status: 'running' })
-        return { ...m, tools: [...tools, created] }
-      }
-      const next = tools.slice()
-      next[index] = mutate(next[index])
-      return { ...m, tools: next }
-    })
-  }
-}
-
-function appendToStreaming(
-  state: ChatSessionState,
-  mutate: (msg: ChatMessage) => ChatMessage
-): ChatSessionState {
-  const targetId = state.streamingId
-  if (!targetId) {
-    return state
-  }
-  return {
-    ...state,
-    messages: state.messages.map((m) => (m.id === targetId ? mutate(m) : m))
-  }
-}
-
-function finalizeTurn(state: ChatSessionState): ChatSessionState {
-  return { ...state, isStreaming: false, statusDetail: null, streamingId: null }
-}
-
-function reduceEvent(state: ChatSessionState, event: JcodeNdjsonEvent): ChatSessionState {
-  switch (event.type) {
-    case 'start': {
-      const id = strField(event, 'session_id')
-      return id ? { ...state, resumeSessionId: id } : state
-    }
-    case 'status_detail': {
-      const detail = strField(event, 'detail')
-      return detail ? { ...state, statusDetail: detail } : state
-    }
-    case 'connection_phase': {
-      const phase = strField(event, 'phase')
-      return phase ? { ...state, statusDetail: phase } : state
-    }
-    case 'text_delta': {
-      const text = strField(event, 'text') ?? ''
-      if (!text) {
-        return state
-      }
-      return appendToStreaming({ ...state, statusDetail: null }, (m) => ({
-        ...m,
-        text: m.text + text
-      }))
-    }
-    case 'tool_start': {
-      const id = strField(event, 'id') ?? `tool-${Date.now()}`
-      const name = strField(event, 'name') ?? 'tool'
-      return upsertTool(state, id, (call) => ({ ...call, name }), name)
-    }
-    case 'tool_input': {
-      const id = strField(event, 'id')
-      const delta = strField(event, 'delta') ?? ''
-      if (!id) {
-        return state
-      }
-      return upsertTool(state, id, (call) => ({ ...call, rawInput: call.rawInput + delta }))
-    }
-    case 'tool_exec': {
-      const id = strField(event, 'id') ?? `tool-${Date.now()}`
-      const name = strField(event, 'name') ?? 'tool'
-      return upsertTool(state, id, (call) => ({ ...call, status: 'running' }), name)
-    }
-    case 'tool_done': {
-      const id = strField(event, 'id')
-      const errorText = strField(event, 'error')
-      const output = strField(event, 'output')
-      if (!id) {
-        return state
-      }
-      return upsertTool(state, id, (call) => ({
-        ...call,
-        output: output ?? call.output,
-        error: errorText ?? undefined,
-        status: errorText ? 'error' : 'done'
-      }))
-    }
-    case 'done': {
-      const id = strField(event, 'session_id')
-      let next = id ? { ...state, resumeSessionId: id } : state
-      const finalText = strField(event, 'text')
-      if (finalText) {
-        next = appendToStreaming(next, (m) => (m.text ? m : { ...m, text: finalText }))
-      }
-      return finalizeTurn(next)
-    }
-    case 'error': {
-      const message =
-        strField(event, 'error') ?? strField(event, 'message') ?? 'Unknown jcode error'
-      const next = appendToStreaming(state, (m) => ({
-        ...m,
-        text: m.text + message,
-        isError: true
-      }))
-      return finalizeTurn(next)
-    }
-    case 'stopped': {
-      const next = appendToStreaming(state, (m) => ({
-        ...m,
-        text: m.text ? `${m.text}\n\n(stopped)` : '(stopped)'
-      }))
-      return finalizeTurn(next)
-    }
-    case 'exit': {
-      return state.streamingId ? finalizeTurn(state) : state
-    }
-    default:
-      return state
-  }
-}
-
 let ipcSubscribed = false
 
 /** Subscribe the module to the jcode chat IPC stream exactly once. Routes each
@@ -336,7 +133,7 @@ function ensureIpcSubscription(): void {
     if (!sessions.has(sessionKey)) {
       return
     }
-    setSession(sessionKey, (state) => reduceEvent(state, message.event))
+    setSession(sessionKey, (state) => reduceJcodeEvent(state, message.event))
     // Why (BUG 1): persist on turn boundaries (done/error/stopped/exit), not on
     // every text_delta, so we capture the final transcript + --resume id without
     // thrashing disk. 'start' is handled at startChatTurn (records the prompt).
@@ -414,13 +211,7 @@ export function hydrateChatSession(record: JcodeConversationRecord): void {
   })
   setSession(record.sessionKey, (state) => ({
     ...state,
-    messages: record.messages.map((m) => ({
-      id: m.id,
-      role: m.role,
-      text: m.text,
-      tools: Array.isArray(m.tools) ? (m.tools as JcodeToolCall[]) : undefined,
-      isError: m.isError
-    })),
+    messages: chatMessagesFromRecord(record),
     // A rehydrated turn is never mid-stream.
     isStreaming: false,
     statusDetail: null,
@@ -525,7 +316,9 @@ export function disposeChatSession(sessionKey: string): void {
   }
   const state = sessions.get(sessionKey)
   if (state && state.messages.length > 0) {
-    void window.api.jcodeChat.saveConversation({ record: buildRecord(sessionKey, state) })
+    void window.api.jcodeChat.saveConversation({
+      record: buildJcodeConversationRecord(sessionKey, state, sessionContexts.get(sessionKey))
+    })
   }
   sessions.delete(sessionKey)
   listeners.delete(sessionKey)

--- a/src/renderer/src/components/chat-pane/chat-session-types.ts
+++ b/src/renderer/src/components/chat-pane/chat-session-types.ts
@@ -1,0 +1,39 @@
+import type { JcodeChatAttachment } from '../../../../shared/jcode-chat-types'
+import type { JcodeToolCall } from './JcodeToolCard'
+
+export type ChatRole = 'user' | 'assistant'
+
+export type ChatMessage = {
+  id: string
+  role: ChatRole
+  text: string
+  /** Tool calls seen during this assistant turn, in arrival order. */
+  tools?: JcodeToolCall[]
+  isError?: boolean
+}
+
+export type ChatSessionState = {
+  messages: ChatMessage[]
+  isStreaming: boolean
+  statusDetail: string | null
+  /** jcode session id to pass as --resume on the next turn. */
+  resumeSessionId: string | undefined
+  /** Id of the assistant message currently being streamed into, if any. */
+  streamingId: string | null
+  /** Composer toolbar selection (Claude-style provider/model chip). Persisted
+   *  per sessionKey so it survives ChatPane unmount/remount on tab switches.
+   *  `undefined` provider means "Auto" (let ChatPane's default apply). */
+  composerProvider: string | undefined
+  composerModel: string | undefined
+  /** Selected custom provider profile name (from a `jcode provider add` profile).
+   *  Mutually exclusive with composerProvider: when set, the turn is sent with
+   *  `providerProfile` (-> `--provider-profile`) instead of `provider` (-> -p). */
+  composerProviderProfile: string | undefined
+  /** Pending composer attachments (files + text blobs) for the NEXT turn.
+   *  Persisted per sessionKey so they survive a tab switch before send; cleared
+   *  by clearChatAttachments after the turn is dispatched. NOT persisted to disk
+   *  (they are folded into the prompt the transcript already records). */
+  pendingAttachments: JcodeChatAttachment[]
+}
+
+export type ChatSessionContext = { worktreeId?: string; cwd?: string }

--- a/src/renderer/src/components/chat-pane/chat-slash-commands.ts
+++ b/src/renderer/src/components/chat-pane/chat-slash-commands.ts
@@ -8,6 +8,7 @@
 // Skills).
 
 import type { JcodeSkill } from '../../../../shared/jcode-chat-types'
+import { translate } from '@/i18n/i18n'
 
 export type SlashCommand =
   | { id: string; label: string; hint: string; kind: 'template'; template: string }
@@ -26,34 +27,84 @@ export type SlashCommand =
 export const SLASH_COMMANDS: SlashCommand[] = [
   {
     id: 'explain',
-    label: '/explain',
-    hint: 'Explain this code',
+    get label() {
+      return translate('jcode.chat.slash.explain.label', '/explain')
+    },
+    get hint() {
+      return translate('jcode.chat.slash.explain.hint', 'Explain this code')
+    },
     kind: 'template',
-    template: 'Explain how the code in this project works, focusing on '
+    get template() {
+      return translate(
+        'jcode.chat.slash.explain.template',
+        'Explain how the code in this project works, focusing on '
+      )
+    }
   },
   {
     id: 'review',
-    label: '/review',
-    hint: 'Review for bugs',
+    get label() {
+      return translate('jcode.chat.slash.review.label', '/review')
+    },
+    get hint() {
+      return translate('jcode.chat.slash.review.hint', 'Review for bugs')
+    },
     kind: 'template',
-    template: 'Review the current changes for bugs, edge cases, and correctness issues.'
+    get template() {
+      return translate(
+        'jcode.chat.slash.review.template',
+        'Review the current changes for bugs, edge cases, and correctness issues.'
+      )
+    }
   },
   {
     id: 'tests',
-    label: '/tests',
-    hint: 'Write tests',
+    get label() {
+      return translate('jcode.chat.slash.tests.label', '/tests')
+    },
+    get hint() {
+      return translate('jcode.chat.slash.tests.hint', 'Write tests')
+    },
     kind: 'template',
-    template: 'Write tests covering '
+    get template() {
+      return translate('jcode.chat.slash.tests.template', 'Write tests covering ')
+    }
   },
   {
     id: 'summarize',
-    label: '/summarize',
-    hint: 'Summarize',
+    get label() {
+      return translate('jcode.chat.slash.summarize.label', '/summarize')
+    },
+    get hint() {
+      return translate('jcode.chat.slash.summarize.hint', 'Summarize')
+    },
     kind: 'template',
-    template: 'Summarize '
+    get template() {
+      return translate('jcode.chat.slash.summarize.template', 'Summarize ')
+    }
   },
-  { id: 'clear', label: '/clear', hint: 'Start a new chat', kind: 'action', action: 'clear' },
-  { id: 'resume', label: '/resume', hint: 'Reopen last chat', kind: 'action', action: 'resume' }
+  {
+    id: 'clear',
+    get label() {
+      return translate('jcode.chat.slash.clear.label', '/clear')
+    },
+    get hint() {
+      return translate('jcode.chat.slash.clear.hint', 'Start a new chat')
+    },
+    kind: 'action',
+    action: 'clear'
+  },
+  {
+    id: 'resume',
+    get label() {
+      return translate('jcode.chat.slash.resume.label', '/resume')
+    },
+    get hint() {
+      return translate('jcode.chat.slash.resume.hint', 'Reopen last chat')
+    },
+    kind: 'action',
+    action: 'resume'
+  }
 ]
 
 /** Truncate a long skill description to a single menu-friendly line. */
@@ -62,12 +113,22 @@ function truncate(text: string, max = 80): string {
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean
 }
 
+function skillSourceLabel(source: JcodeSkill['source']): string {
+  if (source === 'project') {
+    return translate('jcode.chat.slash.skillSource.project', 'Project skill')
+  }
+  if (source === 'global') {
+    return translate('jcode.chat.slash.skillSource.global', 'Global skill')
+  }
+  return translate('jcode.chat.slash.skillSource.plugin', 'Plugin skill')
+}
+
 /** Map a discovered skill to a slash-menu command. */
 export function skillToCommand(skill: JcodeSkill): SlashCommand {
   return {
     id: `skill:${skill.name}`,
     label: `/${skill.name}`,
-    hint: truncate(skill.description) || skill.source,
+    hint: truncate(skill.description) || skillSourceLabel(skill.source),
     kind: 'skill',
     skillName: skill.name,
     source: skill.source

--- a/src/renderer/src/components/chat-pane/chat-slash-commands.ts
+++ b/src/renderer/src/components/chat-pane/chat-slash-commands.ts
@@ -1,0 +1,52 @@
+// orca-side "/" quick commands for the jcode chat composer. These are
+// ORCA-provided prompt templates + actions, NOT jcode skills (jcode headless has
+// none). A 'template' inserts/replaces the draft text; an 'action' runs a
+// composer-level callback (e.g. start a new chat). The composer surfaces these
+// both in the "+" menu and via a "/"-triggered filterable popover.
+
+export type SlashCommand =
+  | { id: string; label: string; hint: string; kind: 'template'; template: string }
+  | { id: string; label: string; hint: string; kind: 'action'; action: 'clear' | 'resume' }
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  {
+    id: 'explain',
+    label: '/explain',
+    hint: 'Explain this code',
+    kind: 'template',
+    template: 'Explain how the code in this project works, focusing on '
+  },
+  {
+    id: 'review',
+    label: '/review',
+    hint: 'Review for bugs',
+    kind: 'template',
+    template: 'Review the current changes for bugs, edge cases, and correctness issues.'
+  },
+  {
+    id: 'tests',
+    label: '/tests',
+    hint: 'Write tests',
+    kind: 'template',
+    template: 'Write tests covering '
+  },
+  {
+    id: 'summarize',
+    label: '/summarize',
+    hint: 'Summarize',
+    kind: 'template',
+    template: 'Summarize '
+  },
+  { id: 'clear', label: '/clear', hint: 'Start a new chat', kind: 'action', action: 'clear' },
+  { id: 'resume', label: '/resume', hint: 'Reopen last chat', kind: 'action', action: 'resume' }
+]
+
+/** Filter the slash commands for a "/query" (query is the text after the slash,
+ *  lowercased). Matches on the command token prefix or a substring of the hint. */
+export function filterSlashCommands(query: string): SlashCommand[] {
+  return SLASH_COMMANDS.filter(
+    (command) =>
+      command.label.slice(1).toLowerCase().startsWith(query) ||
+      command.hint.toLowerCase().includes(query)
+  )
+}

--- a/src/renderer/src/components/chat-pane/chat-slash-commands.ts
+++ b/src/renderer/src/components/chat-pane/chat-slash-commands.ts
@@ -1,12 +1,27 @@
 // orca-side "/" quick commands for the jcode chat composer. These are
 // ORCA-provided prompt templates + actions, NOT jcode skills (jcode headless has
 // none). A 'template' inserts/replaces the draft text; an 'action' runs a
-// composer-level callback (e.g. start a new chat). The composer surfaces these
-// both in the "+" menu and via a "/"-triggered filterable popover.
+// composer-level callback (e.g. start a new chat). FEATURE B adds a 'skill' kind:
+// selecting it records a skill name to inject into the NEXT send (the main
+// process prepends the SKILL.md body). The composer surfaces these both in the
+// "+" menu and via a "/"-triggered filterable popover (two groups: Commands +
+// Skills).
+
+import type { JcodeSkill } from '../../../../shared/jcode-chat-types'
 
 export type SlashCommand =
   | { id: string; label: string; hint: string; kind: 'template'; template: string }
   | { id: string; label: string; hint: string; kind: 'action'; action: 'clear' | 'resume' }
+  | {
+      id: string
+      label: string
+      hint: string
+      kind: 'skill'
+      /** Skill name passed to jcodeChat.send so main injects its body. */
+      skillName: string
+      /** Source for the group sub-label (project/global/plugin). */
+      source: JcodeSkill['source']
+    }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
   {
@@ -41,8 +56,46 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { id: 'resume', label: '/resume', hint: 'Reopen last chat', kind: 'action', action: 'resume' }
 ]
 
-/** Filter the slash commands for a "/query" (query is the text after the slash,
- *  lowercased). Matches on the command token prefix or a substring of the hint. */
+/** Truncate a long skill description to a single menu-friendly line. */
+function truncate(text: string, max = 80): string {
+  const clean = text.trim()
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean
+}
+
+/** Map a discovered skill to a slash-menu command. */
+export function skillToCommand(skill: JcodeSkill): SlashCommand {
+  return {
+    id: `skill:${skill.name}`,
+    label: `/${skill.name}`,
+    hint: truncate(skill.description) || skill.source,
+    kind: 'skill',
+    skillName: skill.name,
+    source: skill.source
+  }
+}
+
+/** Two filtered groups for a "/query" (query is the text after the slash,
+ *  lowercased). The orca quick-commands always show; skills are matched the same
+ *  way. The (potentially large) global skill list is gated behind >=1 typed char
+ *  so an empty "/" doesn't dump ~100 rows — project skills always show. */
+export function filterSlashGroups(
+  query: string,
+  skills: JcodeSkill[]
+): { commands: SlashCommand[]; skills: SlashCommand[] } {
+  const matchesQuery = (label: string, hint: string): boolean =>
+    label.slice(1).toLowerCase().startsWith(query) || hint.toLowerCase().includes(query)
+
+  const commands = SLASH_COMMANDS.filter((command) => matchesQuery(command.label, command.hint))
+
+  const skillCommands = skills
+    .filter((skill) => query.length > 0 || skill.source === 'project')
+    .map(skillToCommand)
+    .filter((command) => matchesQuery(command.label, command.hint))
+
+  return { commands, skills: skillCommands }
+}
+
+/** Legacy single-list filter kept for the "+" menu callers. */
 export function filterSlashCommands(query: string): SlashCommand[] {
   return SLASH_COMMANDS.filter(
     (command) =>

--- a/src/renderer/src/components/chat-pane/jcode-diff.tsx
+++ b/src/renderer/src/components/chat-pane/jcode-diff.tsx
@@ -1,0 +1,63 @@
+// Why: jcode tool results sometimes carry a unified diff (file edits, `git diff`
+// output). Orca's editor diff viewer is CodeMirror-bound and tightly coupled to
+// the editor lifecycle, so for the lightweight chat-bubble view we render a
+// self-contained colorized unified diff — the same approach the proven
+// jcode-desktop prototype uses (src/app.js `colorDiff`), adapted to orca's
+// Tailwind theme tokens.
+import { cn } from '@/lib/utils'
+
+/** Heuristic: does this string look like a unified diff we should render as one?
+ *  Requires a hunk header plus at least one +/- body line so plain prose with a
+ *  stray leading '-' is not mistaken for a diff. */
+export function looksLikeUnifiedDiff(text: string): boolean {
+  if (!text) {
+    return false
+  }
+  const hasHunk = /^@@ .* @@/m.test(text) || /^diff --git /m.test(text)
+  const hasChange = /^[+-]/m.test(text)
+  return hasHunk && hasChange
+}
+
+type DiffLineKind = 'add' | 'del' | 'hunk' | 'meta' | 'ctx'
+
+function classifyLine(line: string): DiffLineKind {
+  if (line.startsWith('@@')) {
+    return 'hunk'
+  }
+  if (line.startsWith('+++') || line.startsWith('---') || line.startsWith('diff --git')) {
+    return 'meta'
+  }
+  if (line.startsWith('+')) {
+    return 'add'
+  }
+  if (line.startsWith('-')) {
+    return 'del'
+  }
+  return 'ctx'
+}
+
+export function UnifiedDiff({ text }: { text: string }): React.JSX.Element {
+  const lines = text.replace(/\n$/, '').split('\n')
+  return (
+    <pre className="overflow-x-auto rounded-md bg-background/60 p-2 font-mono text-xs leading-relaxed">
+      {lines.map((line, index) => {
+        const kind = classifyLine(line)
+        return (
+          <div
+            // eslint-disable-next-line react/no-array-index-key -- Why: diff lines have no stable id; order is fixed for a given static diff string.
+            key={index}
+            className={cn(
+              'whitespace-pre',
+              kind === 'add' && 'bg-green-500/15 text-green-600 dark:text-green-400',
+              kind === 'del' && 'bg-red-500/15 text-red-600 dark:text-red-400',
+              kind === 'hunk' && 'text-primary',
+              kind === 'meta' && 'text-muted-foreground'
+            )}
+          >
+            {line === '' ? ' ' : line}
+          </div>
+        )
+      })}
+    </pre>
+  )
+}

--- a/src/renderer/src/components/chat-pane/jcode-providers.ts
+++ b/src/renderer/src/components/chat-pane/jcode-providers.ts
@@ -4,7 +4,8 @@
 // for a rarely-changing list). "Auto" is represented by an undefined provider
 // in the chat-session-store, which falls back to ChatPane's default provider.
 
-import type { JcodeCustomProvider } from '../../../../shared/jcode-chat-types'
+import { useEffect, useState } from 'react'
+import type { JcodeCustomProvider, JcodeModelCatalog } from '../../../../shared/jcode-chat-types'
 
 export type JcodeProviderOption = {
   /** jcode provider id passed as -p. */
@@ -63,4 +64,112 @@ export function findProfileOption(
     return undefined
   }
   return buildProfileOptions(profiles).find((entry) => entry.id === name)
+}
+
+// ─── Real model catalog (jcode model list --json) ───────────────────────────
+// The detailed picker (Claude/Codex-app style) is driven by the REAL catalog
+// instead of the static JCODE_PROVIDERS model hints above. We map each route's
+// provider DISPLAY name back to the `-p` provider id so selecting a model also
+// pins the right provider/auth source.
+
+const ROUTE_PROVIDER_TO_ID: Record<string, string> = {
+  openai: 'openai',
+  anthropic: 'claude',
+  'anthropic/claude': 'claude',
+  claude: 'claude',
+  google: 'gemini',
+  gemini: 'gemini',
+  'jcode subscription': 'jcode',
+  jcode: 'jcode',
+  openrouter: 'openrouter',
+  xai: 'xai',
+  groq: 'groq',
+  mistral: 'mistral',
+  cerebras: 'cerebras',
+  deepinfra: 'deepinfra',
+  perplexity: 'perplexity'
+}
+
+/** Map a `jcode model list` route provider display name to its `-p` id. */
+export function routeProviderToId(display: string): string {
+  const key = display.trim().toLowerCase()
+  return ROUTE_PROVIDER_TO_ID[key] ?? key.replace(/[^a-z0-9]+/g, '-')
+}
+
+export type JcodeModelGroup = {
+  /** Provider display name as jcode reports it, e.g. "OpenAI". */
+  providerDisplay: string
+  /** Mapped `-p` provider id, e.g. "openai". */
+  providerId: string
+  models: { id: string; available: boolean; method?: string }[]
+}
+
+/** Group a catalog's routes by provider, with authed providers first. */
+export function groupCatalogRoutes(catalog: JcodeModelCatalog | null): JcodeModelGroup[] {
+  if (!catalog?.routes?.length) {
+    return []
+  }
+  const byProvider = new Map<string, JcodeModelGroup>()
+  for (const route of catalog.routes) {
+    let group = byProvider.get(route.provider)
+    if (!group) {
+      group = {
+        providerDisplay: route.provider,
+        providerId: routeProviderToId(route.provider),
+        models: []
+      }
+      byProvider.set(route.provider, group)
+    }
+    group.models.push({ id: route.model, available: route.available, method: route.method })
+  }
+  return [...byProvider.values()].sort((a, b) => {
+    const aRank = a.models.some((m) => m.available) ? 0 : 1
+    const bRank = b.models.some((m) => m.available) ? 0 : 1
+    return aRank - bRank || a.providerDisplay.localeCompare(b.providerDisplay)
+  })
+}
+
+// Module-level cache so the catalog is fetched once per app run (not per chip
+// open). `refresh` forces a re-fetch (e.g. after the user logs into a provider).
+let catalogPromise: Promise<JcodeModelCatalog> | null = null
+
+export function fetchModelCatalog(force = false): Promise<JcodeModelCatalog> {
+  if (force || !catalogPromise) {
+    catalogPromise = window.api.jcodeProviders.listModels().catch(
+      (error: unknown): JcodeModelCatalog => ({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+        models: [],
+        routes: []
+      })
+    )
+  }
+  return catalogPromise
+}
+
+/** React hook: load the real model catalog (cached). `refresh()` re-fetches. */
+export function useJcodeModelCatalog(): {
+  catalog: JcodeModelCatalog | null
+  loading: boolean
+  refresh: () => void
+} {
+  const [catalog, setCatalog] = useState<JcodeModelCatalog | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const load = (force: boolean): void => {
+    setLoading(true)
+    fetchModelCatalog(force)
+      .then((next) => {
+        setCatalog(next)
+        setLoading(false)
+      })
+      .catch(() => setLoading(false))
+  }
+
+  useEffect(() => {
+    load(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { catalog, loading, refresh: () => load(true) }
 }

--- a/src/renderer/src/components/chat-pane/jcode-providers.ts
+++ b/src/renderer/src/components/chat-pane/jcode-providers.ts
@@ -5,6 +5,7 @@
 // in the chat-session-store, which falls back to ChatPane's default provider.
 
 import { useEffect, useState } from 'react'
+import { translate } from '@/i18n/i18n'
 import type { JcodeCustomProvider, JcodeModelCatalog } from '../../../../shared/jcode-chat-types'
 
 export type JcodeProviderOption = {
@@ -22,12 +23,45 @@ export type JcodeProviderOption = {
 /** Curated subset of `jcode provider list`, covering the common cases the brief
  *  asks for plus a few high-traffic ones. Not exhaustive on purpose. */
 export const JCODE_PROVIDERS: JcodeProviderOption[] = [
-  { id: 'jcode', label: 'Jcode Subscription' },
-  { id: 'claude', label: 'Claude', models: ['claude-opus-4-8', 'claude-sonnet-4-5'] },
-  { id: 'openai', label: 'OpenAI', models: ['gpt-5.5', 'gpt-5-mini'] },
-  { id: 'gemini', label: 'Gemini', models: ['gemini-2.5-pro', 'gemini-2.5-flash'] },
-  { id: 'openrouter', label: 'OpenRouter' },
-  { id: 'openai-compatible', label: 'OpenAI-compatible' }
+  {
+    id: 'jcode',
+    get label() {
+      return translate('jcode.chat.provider.jcodeSubscription', 'Jcode Subscription')
+    }
+  },
+  {
+    id: 'claude',
+    get label() {
+      return translate('jcode.chat.provider.claude', 'Claude')
+    },
+    models: ['claude-opus-4-8', 'claude-sonnet-4-5']
+  },
+  {
+    id: 'openai',
+    get label() {
+      return translate('jcode.chat.provider.openai', 'OpenAI')
+    },
+    models: ['gpt-5.5', 'gpt-5-mini']
+  },
+  {
+    id: 'gemini',
+    get label() {
+      return translate('jcode.chat.provider.gemini', 'Gemini')
+    },
+    models: ['gemini-2.5-pro', 'gemini-2.5-flash']
+  },
+  {
+    id: 'openrouter',
+    get label() {
+      return translate('jcode.chat.provider.openrouter', 'OpenRouter')
+    }
+  },
+  {
+    id: 'openai-compatible',
+    get label() {
+      return translate('jcode.chat.provider.openaiCompatible', 'OpenAI-compatible')
+    }
+  }
 ]
 
 export function findProviderOption(id: string | undefined): JcodeProviderOption | undefined {

--- a/src/renderer/src/components/chat-pane/jcode-providers.ts
+++ b/src/renderer/src/components/chat-pane/jcode-providers.ts
@@ -1,0 +1,32 @@
+// Why: the composer's Claude-style model/provider chip needs a list to pick
+// from. We use a small curated static set that mirrors `jcode provider list`
+// rather than shelling out per render (which would add an IPC surface + latency
+// for a rarely-changing list). "Auto" is represented by an undefined provider
+// in the chat-session-store, which falls back to ChatPane's default provider.
+
+export type JcodeProviderOption = {
+  /** jcode provider id passed as -p. */
+  id: string
+  /** Human label shown in the chip dropdown. */
+  label: string
+  /** Optional suggested model ids (passed as -m). First is the default chip. */
+  models?: string[]
+}
+
+/** Curated subset of `jcode provider list`, covering the common cases the brief
+ *  asks for plus a few high-traffic ones. Not exhaustive on purpose. */
+export const JCODE_PROVIDERS: JcodeProviderOption[] = [
+  { id: 'jcode', label: 'Jcode Subscription' },
+  { id: 'claude', label: 'Claude', models: ['claude-opus-4-8', 'claude-sonnet-4-5'] },
+  { id: 'openai', label: 'OpenAI', models: ['gpt-5.5', 'gpt-5-mini'] },
+  { id: 'gemini', label: 'Gemini', models: ['gemini-2.5-pro', 'gemini-2.5-flash'] },
+  { id: 'openrouter', label: 'OpenRouter' },
+  { id: 'openai-compatible', label: 'OpenAI-compatible' }
+]
+
+export function findProviderOption(id: string | undefined): JcodeProviderOption | undefined {
+  if (!id) {
+    return undefined
+  }
+  return JCODE_PROVIDERS.find((entry) => entry.id === id)
+}

--- a/src/renderer/src/components/chat-pane/jcode-providers.ts
+++ b/src/renderer/src/components/chat-pane/jcode-providers.ts
@@ -4,6 +4,8 @@
 // for a rarely-changing list). "Auto" is represented by an undefined provider
 // in the chat-session-store, which falls back to ChatPane's default provider.
 
+import type { JcodeCustomProvider } from '../../../../shared/jcode-chat-types'
+
 export type JcodeProviderOption = {
   /** jcode provider id passed as -p. */
   id: string
@@ -11,6 +13,9 @@ export type JcodeProviderOption = {
   label: string
   /** Optional suggested model ids (passed as -m). First is the default chip. */
   models?: string[]
+  /** Discriminates a built-in `-p provider` from a custom `--provider-profile`.
+   *  Defaults to 'builtin' for the static list below. */
+  kind?: 'builtin' | 'profile'
 }
 
 /** Curated subset of `jcode provider list`, covering the common cases the brief
@@ -29,4 +34,33 @@ export function findProviderOption(id: string | undefined): JcodeProviderOption 
     return undefined
   }
   return JCODE_PROVIDERS.find((entry) => entry.id === id)
+}
+
+/** Map the user's persisted custom provider profiles into chip options. A
+ *  selected option here carries `kind: 'profile'`, so the composer routes the
+ *  selection to the chat payload's `providerProfile` (which the main process
+ *  emits as `--provider-profile <name>`) rather than `-p provider`. */
+export function buildProfileOptions(
+  profiles: JcodeCustomProvider[] | undefined
+): JcodeProviderOption[] {
+  if (!profiles || profiles.length === 0) {
+    return []
+  }
+  return profiles.map((profile) => ({
+    id: profile.name,
+    label: profile.name,
+    models: profile.model ? [profile.model] : undefined,
+    kind: 'profile'
+  }))
+}
+
+/** Resolve a custom profile option by name, or undefined. */
+export function findProfileOption(
+  profiles: JcodeCustomProvider[] | undefined,
+  name: string | undefined
+): JcodeProviderOption | undefined {
+  if (!name) {
+    return undefined
+  }
+  return buildProfileOptions(profiles).find((entry) => entry.id === name)
 }

--- a/src/renderer/src/components/chat-pane/use-chat-slash-menu.ts
+++ b/src/renderer/src/components/chat-pane/use-chat-slash-menu.ts
@@ -1,0 +1,120 @@
+// FEATURE B: the jcode chat composer's "/" menu state, extracted from
+// ChatComposer so the component stays under the max-lines budget. Owns: the
+// "/query" derivation, the (lazily fetched) per-pane skill list, the two filtered
+// groups (orca commands + skills), the flat keyboard index, and the open/index
+// sync. The composer renders the popover + textarea and delegates row activation
+// back here via runSlashCommand.
+import { useCallback, useEffect, useState, type RefObject } from 'react'
+import type { JcodeSkill } from '../../../../shared/jcode-chat-types'
+import { filterSlashGroups, type SlashCommand } from './chat-slash-commands'
+
+export type ChatSlashMenu = {
+  /** Whether the "/" popover is open. */
+  slashOpen: boolean
+  /** Active (highlighted) flat row index across both groups. */
+  slashIndex: number
+  setSlashIndex: React.Dispatch<React.SetStateAction<number>>
+  setSlashOpen: React.Dispatch<React.SetStateAction<boolean>>
+  /** Filtered orca quick-command rows. */
+  commands: SlashCommand[]
+  /** Filtered skill rows. */
+  skills: SlashCommand[]
+  /** commands ++ skills, for keyboard nav (matches popover flat index). */
+  flatMatches: SlashCommand[]
+  /** True when a remote project's project-local skills couldn't be read. */
+  degraded: boolean
+  /** Activate a row: insert a template, arm a skill, or run an action. */
+  runSlashCommand: (command: SlashCommand) => void
+}
+
+export function useChatSlashMenu({
+  value,
+  cwd,
+  worktreeId,
+  textareaRef,
+  onChange,
+  onSlashAction,
+  onSelectSkill
+}: {
+  value: string
+  cwd?: string
+  worktreeId?: string
+  textareaRef: RefObject<HTMLTextAreaElement | null>
+  onChange: (next: string) => void
+  onSlashAction: (action: 'clear' | 'resume') => void
+  onSelectSkill: (skillName: string | null) => void
+}): ChatSlashMenu {
+  const [slashOpen, setSlashOpen] = useState(false)
+  const [slashIndex, setSlashIndex] = useState(0)
+  const [skills, setSkills] = useState<JcodeSkill[]>([])
+  const [degraded, setDegraded] = useState(false)
+
+  // The draft is a "/query" when it starts with "/" and has no space/newline yet.
+  const isSlashDraft = value.startsWith('/') && !value.includes(' ') && !value.includes('\n')
+  const slashQuery = isSlashDraft ? value.slice(1).toLowerCase() : null
+
+  // Fetch the skill list lazily when the "/" menu is active (and on cwd/worktree
+  // change). Cheap to refetch; gated so we don't touch the filesystem/SSH unless
+  // the user actually opens the menu.
+  useEffect(() => {
+    if (!isSlashDraft) {
+      return
+    }
+    let cancelled = false
+    void window.api.jcodeChat.listSkills({ cwd, worktreeId }).then((result) => {
+      if (cancelled) {
+        return
+      }
+      setSkills(result.skills)
+      setDegraded(result.degraded === true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isSlashDraft, cwd, worktreeId])
+
+  const groups =
+    slashQuery === null ? { commands: [], skills: [] } : filterSlashGroups(slashQuery, skills)
+  const flatMatches: SlashCommand[] = [...groups.commands, ...groups.skills]
+
+  // Open/index sync: open while there is a query with matches; reset highlight.
+  useEffect(() => {
+    const shouldOpen = slashQuery !== null && flatMatches.length > 0
+    setSlashOpen(shouldOpen)
+    if (shouldOpen) {
+      setSlashIndex(0)
+    }
+  }, [slashQuery, flatMatches.length])
+
+  const runSlashCommand = useCallback(
+    (command: SlashCommand) => {
+      if (command.kind === 'template') {
+        onChange(command.template)
+      } else if (command.kind === 'skill') {
+        // Arm the skill for the NEXT send (main injects its SKILL.md body). Clear
+        // the "/query" draft so the user can type their message; a chip shows it.
+        onSelectSkill(command.skillName)
+        onChange('')
+      } else {
+        // Action: clear the "/command" draft, then run it.
+        onChange('')
+        onSlashAction(command.action)
+      }
+      setSlashOpen(false)
+      window.requestAnimationFrame(() => textareaRef.current?.focus())
+    },
+    [onChange, onSlashAction, onSelectSkill, textareaRef]
+  )
+
+  return {
+    slashOpen,
+    slashIndex,
+    setSlashIndex,
+    setSlashOpen,
+    commands: groups.commands,
+    skills: groups.skills,
+    flatMatches,
+    degraded,
+    runSlashCommand
+  }
+}

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -607,6 +607,7 @@ function JcodeMcpSection(): React.JSX.Element {
         ...translateSearchKeyword('jcode.settings.accounts.keyword.server', 'server'),
         ...translateSearchKeyword('jcode.settings.accounts.keyword.tool', 'tool'),
         ...translateSearchKeyword('jcode.settings.accounts.keyword.ibkr', 'ibkr'),
+        'plugin',
         ...translateSearchKeyword('jcode.settings.accounts.keyword.connectorZh', '连接器'),
         ...translateSearchKeyword('jcode.settings.accounts.keyword.pluginZh', '插件'),
         ...translateSearchKeyword(

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -15,7 +15,7 @@ import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Separator } from '../ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
-import { AlertTriangle, Loader2, Plus, RefreshCw, Trash2 } from 'lucide-react'
+import { AlertTriangle, Loader2, Plug, Plus, RefreshCw, Trash2 } from 'lucide-react'
 import { useAppStore } from '../../store'
 import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from '../status-bar/icons'
 import { toast } from 'sonner'
@@ -23,12 +23,17 @@ import {
   getAccountsClaudeSearchEntries,
   getAccountsCodexSearchEntries,
   getAccountsGeminiSearchEntries,
+  getAccountsJcodeMcpSearchEntries,
   getAccountsJcodeProvidersSearchEntries,
   getAccountsLocationSearchEntries,
   getAccountsOpencodeSearchEntries,
   getAccountsPaneSearchEntries
 } from './accounts-search'
-import type { JcodeCustomProvider, JcodeProviderAuth } from '../../../../shared/jcode-chat-types'
+import type {
+  JcodeCustomProvider,
+  JcodeMcpServer,
+  JcodeProviderAuth
+} from '../../../../shared/jcode-chat-types'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
 import { matchesSettingsSearch } from './settings-search'
@@ -414,6 +419,237 @@ function JcodeCustomProvidersSection({
           Add provider
         </Button>
       </div>
+    </SearchableSetting>
+  )
+}
+
+/** Parse a textarea of args (one per line) into a trimmed list. */
+function parseArgsText(text: string): string[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
+/** Parse a textarea of "KEY=value" lines into an env map. */
+function parseEnvText(text: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+    const eq = trimmed.indexOf('=')
+    if (eq <= 0) {
+      continue
+    }
+    const key = trimmed.slice(0, eq).trim()
+    const value = trimmed.slice(eq + 1).trim()
+    if (key) {
+      env[key] = value
+    }
+  }
+  return env
+}
+
+/** "连接器 / MCP" — add/list stdio MCP servers (connectors) for jcode chat. These
+ *  are written to the global ~/.jcode/mcp.json, which jcode loads automatically
+ *  and exposes the servers' tools to the agent. Remote/hosted connectors work
+ *  via a stdio bridge, e.g. command "npx" args ["mcp-remote", "https://…"]. */
+function JcodeMcpSection(): React.JSX.Element {
+  const [servers, setServers] = useState<JcodeMcpServer[]>([])
+  const [configPath, setConfigPath] = useState<string | undefined>(undefined)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [name, setName] = useState('')
+  const [command, setCommand] = useState('')
+  const [argsText, setArgsText] = useState('')
+  const [envText, setEnvText] = useState('')
+
+  const reload = async (): Promise<void> => {
+    setLoading(true)
+    try {
+      const result = await window.api.jcodeMcp.get()
+      if (!result.ok) {
+        toast.error(result.error ?? 'Failed to read MCP config.')
+      }
+      setServers(result.servers)
+      setConfigPath(result.path)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void reload()
+  }, [])
+
+  const resetForm = (): void => {
+    setName('')
+    setCommand('')
+    setArgsText('')
+    setEnvText('')
+  }
+
+  const onAdd = async (): Promise<void> => {
+    if (!name.trim() || !command.trim()) {
+      toast.error('Name and command are required.')
+      return
+    }
+    setBusy(true)
+    try {
+      const next: JcodeMcpServer = {
+        name: name.trim(),
+        command: command.trim(),
+        args: parseArgsText(argsText),
+        env: parseEnvText(envText),
+        shared: true
+      }
+      const merged = [...servers.filter((s) => s.name !== next.name), next]
+      const result = await window.api.jcodeMcp.set({ servers: merged })
+      if (!result.ok) {
+        toast.error(result.error ?? 'Failed to save MCP server.')
+        return
+      }
+      toast.success(`Connected "${next.name}". Restart a chat to load its tools.`)
+      resetForm()
+      await reload()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onRemove = async (serverName: string): Promise<void> => {
+    setBusy(true)
+    try {
+      const result = await window.api.jcodeMcp.set({
+        servers: servers.filter((s) => s.name !== serverName)
+      })
+      if (!result.ok) {
+        toast.error(result.error ?? 'Failed to remove MCP server.')
+        return
+      }
+      toast.success(`Removed "${serverName}".`)
+      await reload()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <SearchableSetting
+      title="连接器 / MCP"
+      description="Connect MCP servers so jcode can use their tools (e.g. a vault, a browser, or a broker like IBKR). Remote servers work via a stdio bridge: command npx, args mcp-remote then the URL."
+      keywords={[
+        'jcode',
+        'mcp',
+        'connector',
+        'connectors',
+        'server',
+        'tool',
+        'ibkr',
+        '连接器',
+        '插件',
+        'model context protocol'
+      ]}
+      className="space-y-3"
+    >
+      {loading ? (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          Loading…
+        </div>
+      ) : servers.length > 0 ? (
+        <div className="space-y-2">
+          {servers.map((server) => (
+            <div
+              key={server.name}
+              className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-2"
+            >
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{server.name}</div>
+                <div className="truncate text-xs text-muted-foreground">
+                  {server.command} {server.args.join(' ')}
+                </div>
+              </div>
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={busy}
+                onClick={() => void onRemove(server.name)}
+                className="h-7 shrink-0 text-xs text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">No connectors yet.</p>
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label>Name</Label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="my-connector"
+            spellCheck={false}
+            className="text-xs"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label>Command</Label>
+          <Input
+            value={command}
+            onChange={(e) => setCommand(e.target.value)}
+            placeholder="npx"
+            spellCheck={false}
+            className="text-xs"
+          />
+        </div>
+        <div className="space-y-1 sm:col-span-2">
+          <Label>Args (one per line)</Label>
+          <textarea
+            value={argsText}
+            onChange={(e) => setArgsText(e.target.value)}
+            placeholder={'-y\n@modelcontextprotocol/server-filesystem\n/path/to/dir'}
+            spellCheck={false}
+            rows={3}
+            className="w-full resize-y rounded-md border border-input bg-background px-2 py-1.5 text-xs outline-none focus-visible:border-ring"
+          />
+        </div>
+        <div className="space-y-1 sm:col-span-2">
+          <Label>Env (KEY=value, one per line)</Label>
+          <textarea
+            value={envText}
+            onChange={(e) => setEnvText(e.target.value)}
+            placeholder={'API_KEY=...\nREGION=us'}
+            spellCheck={false}
+            rows={2}
+            className="w-full resize-y rounded-md border border-input bg-background px-2 py-1.5 text-xs outline-none focus-visible:border-ring"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button size="sm" disabled={busy} onClick={() => void onAdd()}>
+          {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
+          Add connector
+        </Button>
+        <Button size="sm" variant="ghost" disabled={loading} onClick={() => void reload()}>
+          <RefreshCw className={`size-3.5 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {configPath ? (
+        <p className="text-[11px] text-muted-foreground">
+          Stored in <code className="rounded bg-muted px-1 py-0.5">{configPath}</code>. Restart a
+          chat to pick up changes.
+        </p>
+      ) : null}
     </SearchableSetting>
   )
 }
@@ -1523,6 +1759,21 @@ export function AccountsPane({
           </p>
         </div>
         <JcodeCustomProvidersSection settings={settings} updateSettings={updateSettings} />
+      </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, getAccountsJcodeMcpSearchEntries()) ? (
+      <section key="jcode-mcp" id="accounts-jcode-mcp" className="space-y-4 scroll-mt-6">
+        <div className="space-y-1">
+          <h3 className="flex items-center gap-2 text-sm font-semibold">
+            <Plug size={16} />
+            连接器 / MCP
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            Connect MCP servers so jcode can use their tools — a vault, a browser, a broker like
+            IBKR. jcode loads them automatically and shows their tool calls in chat.
+          </p>
+        </div>
+        <JcodeMcpSection />
       </section>
     ) : null
   ].filter(Boolean)

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -23,10 +23,12 @@ import {
   getAccountsClaudeSearchEntries,
   getAccountsCodexSearchEntries,
   getAccountsGeminiSearchEntries,
+  getAccountsJcodeProvidersSearchEntries,
   getAccountsLocationSearchEntries,
   getAccountsOpencodeSearchEntries,
   getAccountsPaneSearchEntries
 } from './accounts-search'
+import type { JcodeCustomProvider, JcodeProviderAuth } from '../../../../shared/jcode-chat-types'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
 import { matchesSettingsSearch } from './settings-search'
@@ -237,6 +239,183 @@ function getSelectedAccountRuntime(
     }
   }
   return { runtime: 'host', label: getHostRuntimeLabel() }
+}
+
+/** "自定义 Provider" — add/list custom OpenAI-compatible provider profiles for
+ *  jcode chat. The API key is sent to the main process which writes it to
+ *  `jcode provider add --api-key-stdin` (over stdin, never argv) and is NOT
+ *  persisted in GlobalSettings; only the non-secret profile is mirrored there
+ *  so the composer can list/select it. */
+function JcodeCustomProvidersSection({
+  settings,
+  updateSettings
+}: {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}): React.JSX.Element {
+  const providers = settings.jcodeCustomProviders ?? []
+  const [name, setName] = useState('')
+  const [baseUrl, setBaseUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [model, setModel] = useState('')
+  const [auth, setAuth] = useState<JcodeProviderAuth>('bearer')
+  const [busy, setBusy] = useState(false)
+
+  const resetForm = (): void => {
+    setName('')
+    setBaseUrl('')
+    setApiKey('')
+    setModel('')
+    setAuth('bearer')
+  }
+
+  const onAdd = async (): Promise<void> => {
+    if (!name.trim() || !baseUrl.trim() || !model.trim()) {
+      toast.error('Name, base URL, and model are required.')
+      return
+    }
+    setBusy(true)
+    try {
+      const result = await window.api.jcodeProviders.add({
+        name: name.trim(),
+        baseUrl: baseUrl.trim(),
+        model: model.trim(),
+        auth,
+        apiKey: apiKey.length > 0 ? apiKey : undefined
+      })
+      if (!result.ok || !result.provider) {
+        toast.error(result.error ?? 'Failed to add provider.')
+        return
+      }
+      // Mirror the non-secret profile into settings (upsert by name).
+      const next: JcodeCustomProvider[] = [
+        ...providers.filter((p) => p.name !== result.provider!.name),
+        result.provider
+      ]
+      updateSettings({ jcodeCustomProviders: next })
+      toast.success(`Added provider "${result.provider.name}".`)
+      resetForm()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onRemove = (providerName: string): void => {
+    updateSettings({
+      jcodeCustomProviders: providers.filter((p) => p.name !== providerName)
+    })
+    toast.success(`Removed provider "${providerName}".`)
+  }
+
+  return (
+    <SearchableSetting
+      title="自定义 Provider"
+      description="Add a custom OpenAI-compatible provider (base URL + API key + model) for jcode chat."
+      keywords={[
+        'jcode',
+        'provider',
+        'custom',
+        'openai',
+        'compatible',
+        'base url',
+        'api key',
+        'endpoint',
+        'gateway',
+        '自定义'
+      ]}
+      className="space-y-3"
+    >
+      {providers.length > 0 ? (
+        <div className="space-y-2">
+          {providers.map((provider) => (
+            <div
+              key={provider.name}
+              className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-2"
+            >
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{provider.name}</div>
+                <div className="truncate text-xs text-muted-foreground">
+                  {provider.model} · {provider.baseUrl}
+                </div>
+              </div>
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => onRemove(provider.name)}
+                className="h-7 shrink-0 text-xs text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label>Name</Label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="my-gateway"
+            spellCheck={false}
+            className="text-xs"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label>Model</Label>
+          <Input
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder="gpt-4o"
+            spellCheck={false}
+            className="text-xs"
+          />
+        </div>
+        <div className="space-y-1 sm:col-span-2">
+          <Label>Base URL</Label>
+          <Input
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            placeholder="https://llm.example.com/v1"
+            spellCheck={false}
+            className="text-xs"
+          />
+        </div>
+        <div className="space-y-1 sm:col-span-2">
+          <Label>API Key</Label>
+          <Input
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder="sk-… (stored in jcode's private env file)"
+            spellCheck={false}
+            className="text-xs"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label>Auth</Label>
+          <Select value={auth} onValueChange={(v) => setAuth(v as JcodeProviderAuth)}>
+            <SelectTrigger className="text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="bearer">Bearer</SelectItem>
+              <SelectItem value="api-key">API key header</SelectItem>
+              <SelectItem value="none">None</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div>
+        <Button size="sm" disabled={busy} onClick={() => void onAdd()}>
+          {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
+          Add provider
+        </Button>
+      </div>
+    </SearchableSetting>
+  )
 }
 
 export function AccountsPane({
@@ -1325,6 +1504,25 @@ export function AccountsPane({
             ).
           </p>
         </SearchableSetting>
+      </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, getAccountsJcodeProvidersSearchEntries()) ? (
+      <section
+        key="jcode-custom-providers"
+        id="accounts-jcode-providers"
+        className="space-y-4 scroll-mt-6"
+      >
+        <div className="space-y-1">
+          <h3 className="flex items-center gap-2 text-sm font-semibold">
+            <OpenAIIcon size={16} />
+            自定义 Provider
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            Add a custom OpenAI-compatible endpoint (base URL + API key + model) and pick it in the
+            jcode chat composer.
+          </p>
+        </div>
+        <JcodeCustomProvidersSection settings={settings} updateSettings={updateSettings} />
       </section>
     ) : null
   ].filter(Boolean)

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -37,6 +37,7 @@ import type {
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
 import { matchesSettingsSearch } from './settings-search'
+import { translateSearchKeyword } from './settings-search-keywords'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import {
   Dialog,
@@ -276,7 +277,12 @@ function JcodeCustomProvidersSection({
 
   const onAdd = async (): Promise<void> => {
     if (!name.trim() || !baseUrl.trim() || !model.trim()) {
-      toast.error('Name, base URL, and model are required.')
+      toast.error(
+        translate(
+          'jcode.settings.accounts.providers.requiredFields',
+          'Name, base URL, and model are required.'
+        )
+      )
       return
     }
     setBusy(true)
@@ -289,7 +295,10 @@ function JcodeCustomProvidersSection({
         apiKey: apiKey.length > 0 ? apiKey : undefined
       })
       if (!result.ok || !result.provider) {
-        toast.error(result.error ?? 'Failed to add provider.')
+        toast.error(
+          result.error ??
+            translate('jcode.settings.accounts.providers.addFailed', 'Failed to add provider.')
+        )
         return
       }
       // Mirror the non-secret profile into settings (upsert by name).
@@ -298,7 +307,11 @@ function JcodeCustomProvidersSection({
         result.provider
       ]
       updateSettings({ jcodeCustomProviders: next })
-      toast.success(`Added provider "${result.provider.name}".`)
+      toast.success(
+        translate('jcode.settings.accounts.providers.added', 'Added provider "{{value0}}".', {
+          value0: result.provider.name
+        })
+      )
       resetForm()
     } finally {
       setBusy(false)
@@ -309,24 +322,31 @@ function JcodeCustomProvidersSection({
     updateSettings({
       jcodeCustomProviders: providers.filter((p) => p.name !== providerName)
     })
-    toast.success(`Removed provider "${providerName}".`)
+    toast.success(
+      translate('jcode.settings.accounts.providers.removed', 'Removed provider "{{value0}}".', {
+        value0: providerName
+      })
+    )
   }
 
   return (
     <SearchableSetting
-      title="自定义 Provider"
-      description="Add a custom OpenAI-compatible provider (base URL + API key + model) for jcode chat."
+      title={translate('jcode.settings.accounts.providers.title', 'Custom provider')}
+      description={translate(
+        'jcode.settings.accounts.providers.formDescription',
+        'Add a custom OpenAI-compatible provider for jcode chat.'
+      )}
       keywords={[
-        'jcode',
-        'provider',
-        'custom',
-        'openai',
-        'compatible',
-        'base url',
-        'api key',
-        'endpoint',
-        'gateway',
-        '自定义'
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.jcode', 'jcode'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.provider', 'provider'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.custom', 'custom'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.openai', 'openai'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.compatible', 'compatible'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.baseUrl', 'base url'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.apiKey', 'api key'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.endpoint', 'endpoint'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.gateway', 'gateway'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.customZh', '自定义')
       ]}
       className="space-y-3"
     >
@@ -358,56 +378,71 @@ function JcodeCustomProvidersSection({
 
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-1">
-          <Label>Name</Label>
+          <Label>{translate('jcode.settings.accounts.providers.nameLabel', 'Name')}</Label>
           <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="my-gateway"
+            placeholder={translate(
+              'jcode.settings.accounts.providers.namePlaceholder',
+              'my-gateway'
+            )}
             spellCheck={false}
             className="text-xs"
           />
         </div>
         <div className="space-y-1">
-          <Label>Model</Label>
+          <Label>{translate('jcode.settings.accounts.providers.modelLabel', 'Model')}</Label>
           <Input
             value={model}
             onChange={(e) => setModel(e.target.value)}
-            placeholder="gpt-4o"
+            placeholder={translate('jcode.settings.accounts.providers.modelPlaceholder', 'gpt-4o')}
             spellCheck={false}
             className="text-xs"
           />
         </div>
         <div className="space-y-1 sm:col-span-2">
-          <Label>Base URL</Label>
+          <Label>{translate('jcode.settings.accounts.providers.baseUrlLabel', 'Base URL')}</Label>
           <Input
             value={baseUrl}
             onChange={(e) => setBaseUrl(e.target.value)}
-            placeholder="https://llm.example.com/v1"
+            placeholder={translate(
+              'jcode.settings.accounts.providers.baseUrlPlaceholder',
+              'https://llm.example.com/v1'
+            )}
             spellCheck={false}
             className="text-xs"
           />
         </div>
         <div className="space-y-1 sm:col-span-2">
-          <Label>API Key</Label>
+          <Label>{translate('jcode.settings.accounts.providers.apiKeyLabel', 'API Key')}</Label>
           <Input
             type="password"
             value={apiKey}
             onChange={(e) => setApiKey(e.target.value)}
-            placeholder="sk-… (stored in jcode's private env file)"
+            placeholder={translate(
+              'jcode.settings.accounts.providers.apiKeyPlaceholder',
+              "sk-... (stored in jcode's private env file)"
+            )}
             spellCheck={false}
             className="text-xs"
           />
         </div>
         <div className="space-y-1">
-          <Label>Auth</Label>
+          <Label>{translate('jcode.settings.accounts.providers.authLabel', 'Auth')}</Label>
           <Select value={auth} onValueChange={(v) => setAuth(v as JcodeProviderAuth)}>
             <SelectTrigger className="text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="bearer">Bearer</SelectItem>
-              <SelectItem value="api-key">API key header</SelectItem>
-              <SelectItem value="none">None</SelectItem>
+              <SelectItem value="bearer">
+                {translate('jcode.settings.accounts.providers.authBearer', 'Bearer')}
+              </SelectItem>
+              <SelectItem value="api-key">
+                {translate('jcode.settings.accounts.providers.authApiKeyHeader', 'API key header')}
+              </SelectItem>
+              <SelectItem value="none">
+                {translate('jcode.settings.accounts.providers.authNone', 'None')}
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -416,7 +451,7 @@ function JcodeCustomProvidersSection({
       <div>
         <Button size="sm" disabled={busy} onClick={() => void onAdd()}>
           {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
-          Add provider
+          {translate('jcode.settings.accounts.providers.addProvider', 'Add provider')}
         </Button>
       </div>
     </SearchableSetting>
@@ -471,7 +506,10 @@ function JcodeMcpSection(): React.JSX.Element {
     try {
       const result = await window.api.jcodeMcp.get()
       if (!result.ok) {
-        toast.error(result.error ?? 'Failed to read MCP config.')
+        toast.error(
+          result.error ??
+            translate('jcode.settings.accounts.mcp.readFailed', 'Failed to read MCP config.')
+        )
       }
       setServers(result.servers)
       setConfigPath(result.path)
@@ -493,7 +531,9 @@ function JcodeMcpSection(): React.JSX.Element {
 
   const onAdd = async (): Promise<void> => {
     if (!name.trim() || !command.trim()) {
-      toast.error('Name and command are required.')
+      toast.error(
+        translate('jcode.settings.accounts.mcp.requiredFields', 'Name and command are required.')
+      )
       return
     }
     setBusy(true)
@@ -508,10 +548,19 @@ function JcodeMcpSection(): React.JSX.Element {
       const merged = [...servers.filter((s) => s.name !== next.name), next]
       const result = await window.api.jcodeMcp.set({ servers: merged })
       if (!result.ok) {
-        toast.error(result.error ?? 'Failed to save MCP server.')
+        toast.error(
+          result.error ??
+            translate('jcode.settings.accounts.mcp.saveFailed', 'Failed to save MCP server.')
+        )
         return
       }
-      toast.success(`Connected "${next.name}". Restart a chat to load its tools.`)
+      toast.success(
+        translate(
+          'jcode.settings.accounts.mcp.connected',
+          'Connected "{{value0}}". Restart a chat to load its tools.',
+          { value0: next.name }
+        )
+      )
       resetForm()
       await reload()
     } finally {
@@ -526,10 +575,17 @@ function JcodeMcpSection(): React.JSX.Element {
         servers: servers.filter((s) => s.name !== serverName)
       })
       if (!result.ok) {
-        toast.error(result.error ?? 'Failed to remove MCP server.')
+        toast.error(
+          result.error ??
+            translate('jcode.settings.accounts.mcp.removeFailed', 'Failed to remove MCP server.')
+        )
         return
       }
-      toast.success(`Removed "${serverName}".`)
+      toast.success(
+        translate('jcode.settings.accounts.mcp.removed', 'Removed "{{value0}}".', {
+          value0: serverName
+        })
+      )
       await reload()
     } finally {
       setBusy(false)
@@ -538,26 +594,32 @@ function JcodeMcpSection(): React.JSX.Element {
 
   return (
     <SearchableSetting
-      title="连接器 / MCP"
-      description="Connect MCP servers so jcode can use their tools (e.g. a vault, a browser, or a broker like IBKR). Remote servers work via a stdio bridge: command npx, args mcp-remote then the URL."
+      title={translate('jcode.settings.accounts.mcp.title', 'MCP connectors')}
+      description={translate(
+        'jcode.settings.accounts.mcp.formDescription',
+        'Connect MCP servers so jcode can use their tools.'
+      )}
       keywords={[
-        'jcode',
-        'mcp',
-        'connector',
-        'connectors',
-        'server',
-        'tool',
-        'ibkr',
-        '连接器',
-        '插件',
-        'model context protocol'
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.jcode', 'jcode'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.mcp', 'mcp'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.connector', 'connector'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.connectors', 'connectors'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.server', 'server'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.tool', 'tool'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.ibkr', 'ibkr'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.connectorZh', '连接器'),
+        ...translateSearchKeyword('jcode.settings.accounts.keyword.pluginZh', '插件'),
+        ...translateSearchKeyword(
+          'jcode.settings.accounts.keyword.modelContextProtocol',
+          'model context protocol'
+        )
       ]}
       className="space-y-3"
     >
       {loading ? (
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Loader2 className="size-3.5 animate-spin" />
-          Loading…
+          {translate('jcode.settings.accounts.mcp.loading', 'Loading...')}
         </div>
       ) : servers.length > 0 ? (
         <div className="space-y-2">
@@ -585,47 +647,57 @@ function JcodeMcpSection(): React.JSX.Element {
           ))}
         </div>
       ) : (
-        <p className="text-xs text-muted-foreground">No connectors yet.</p>
+        <p className="text-xs text-muted-foreground">
+          {translate('jcode.settings.accounts.mcp.empty', 'No connectors yet.')}
+        </p>
       )}
 
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-1">
-          <Label>Name</Label>
+          <Label>{translate('jcode.settings.accounts.mcp.nameLabel', 'Name')}</Label>
           <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="my-connector"
+            placeholder={translate('jcode.settings.accounts.mcp.namePlaceholder', 'my-connector')}
             spellCheck={false}
             className="text-xs"
           />
         </div>
         <div className="space-y-1">
-          <Label>Command</Label>
+          <Label>{translate('jcode.settings.accounts.mcp.commandLabel', 'Command')}</Label>
           <Input
             value={command}
             onChange={(e) => setCommand(e.target.value)}
-            placeholder="npx"
+            placeholder={translate('jcode.settings.accounts.mcp.commandPlaceholder', 'npx')}
             spellCheck={false}
             className="text-xs"
           />
         </div>
         <div className="space-y-1 sm:col-span-2">
-          <Label>Args (one per line)</Label>
+          <Label>{translate('jcode.settings.accounts.mcp.argsLabel', 'Args (one per line)')}</Label>
           <textarea
             value={argsText}
             onChange={(e) => setArgsText(e.target.value)}
-            placeholder={'-y\n@modelcontextprotocol/server-filesystem\n/path/to/dir'}
+            placeholder={translate(
+              'jcode.settings.accounts.mcp.argsPlaceholder',
+              '-y\n@modelcontextprotocol/server-filesystem\n/path/to/dir'
+            )}
             spellCheck={false}
             rows={3}
             className="w-full resize-y rounded-md border border-input bg-background px-2 py-1.5 text-xs outline-none focus-visible:border-ring"
           />
         </div>
         <div className="space-y-1 sm:col-span-2">
-          <Label>Env (KEY=value, one per line)</Label>
+          <Label>
+            {translate('jcode.settings.accounts.mcp.envLabel', 'Env (KEY=value, one per line)')}
+          </Label>
           <textarea
             value={envText}
             onChange={(e) => setEnvText(e.target.value)}
-            placeholder={'API_KEY=...\nREGION=us'}
+            placeholder={translate(
+              'jcode.settings.accounts.mcp.envPlaceholder',
+              'API_KEY=...\nREGION=us'
+            )}
             spellCheck={false}
             rows={2}
             className="w-full resize-y rounded-md border border-input bg-background px-2 py-1.5 text-xs outline-none focus-visible:border-ring"
@@ -636,18 +708,22 @@ function JcodeMcpSection(): React.JSX.Element {
       <div className="flex items-center gap-2">
         <Button size="sm" disabled={busy} onClick={() => void onAdd()}>
           {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
-          Add connector
+          {translate('jcode.settings.accounts.mcp.addConnector', 'Add connector')}
         </Button>
         <Button size="sm" variant="ghost" disabled={loading} onClick={() => void reload()}>
           <RefreshCw className={`size-3.5 ${loading ? 'animate-spin' : ''}`} />
-          Refresh
+          {translate('jcode.settings.accounts.mcp.refresh', 'Refresh')}
         </Button>
       </div>
 
       {configPath ? (
         <p className="text-[11px] text-muted-foreground">
-          Stored in <code className="rounded bg-muted px-1 py-0.5">{configPath}</code>. Restart a
-          chat to pick up changes.
+          {translate('jcode.settings.accounts.mcp.storedIn', 'Stored in')}{' '}
+          <code className="rounded bg-muted px-1 py-0.5">{configPath}</code>.{' '}
+          {translate(
+            'jcode.settings.accounts.mcp.restartChatForChanges',
+            'Restart a chat to pick up changes.'
+          )}
         </p>
       ) : null}
     </SearchableSetting>
@@ -1751,11 +1827,13 @@ export function AccountsPane({
         <div className="space-y-1">
           <h3 className="flex items-center gap-2 text-sm font-semibold">
             <OpenAIIcon size={16} />
-            自定义 Provider
+            {translate('jcode.settings.accounts.providers.title', 'Custom provider')}
           </h3>
           <p className="text-xs text-muted-foreground">
-            Add a custom OpenAI-compatible endpoint (base URL + API key + model) and pick it in the
-            jcode chat composer.
+            {translate(
+              'jcode.settings.accounts.providers.sectionDescription',
+              'Add a custom OpenAI-compatible endpoint and pick it in the jcode chat composer.'
+            )}
           </p>
         </div>
         <JcodeCustomProvidersSection settings={settings} updateSettings={updateSettings} />
@@ -1766,11 +1844,13 @@ export function AccountsPane({
         <div className="space-y-1">
           <h3 className="flex items-center gap-2 text-sm font-semibold">
             <Plug size={16} />
-            连接器 / MCP
+            {translate('jcode.settings.accounts.mcp.title', 'MCP connectors')}
           </h3>
           <p className="text-xs text-muted-foreground">
-            Connect MCP servers so jcode can use their tools — a vault, a browser, a broker like
-            IBKR. jcode loads them automatically and shows their tool calls in chat.
+            {translate(
+              'jcode.settings.accounts.mcp.sectionDescription',
+              'Connect MCP servers so jcode can use their tools in chat.'
+            )}
           </p>
         </div>
         <JcodeMcpSection />

--- a/src/renderer/src/components/settings/SshTargetCard.tsx
+++ b/src/renderer/src/components/settings/SshTargetCard.tsx
@@ -22,7 +22,13 @@ import { translate } from '@/i18n/i18n'
 // ── Shared status helpers ────────────────────────────────────────────
 
 export const STATUS_LABELS: Record<SshConnectionStatus, string> = {
-  disconnected: 'Disconnected',
+  // Why (BUG 2): orca never auto-connects, so a freshly added/idle host sits in
+  // the 'disconnected' state. The old "Disconnected" label read like an error to
+  // non-technical users. Relabel the idle state to the neutral "Not connected"
+  // (gray dot stays). Error/auth-failed states are unchanged.
+  get disconnected() {
+    return translate('auto.components.settings.SshTargetCard.idleNotConnected', 'Not connected')
+  },
   connecting: 'Connecting\u2026',
   'auth-failed': 'Auth failed',
   'deploying-relay': 'Deploying relay\u2026',
@@ -265,7 +271,23 @@ export function SshTargetCard({
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium">{target.label}</span>
           <span className={`size-2 shrink-0 rounded-full ${statusColor(status)}`} />
-          <span className="text-[11px] text-muted-foreground">{STATUS_LABELS[status]}</span>
+          {status === 'disconnected' ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="cursor-default text-[11px] text-muted-foreground">
+                  {STATUS_LABELS[status]}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4}>
+                {translate(
+                  'auto.components.settings.SshTargetCard.idleNotConnectedHint',
+                  'Click “Connect” to start a session (brain-local needs no connection).'
+                )}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="text-[11px] text-muted-foreground">{STATUS_LABELS[status]}</span>
+          )}
         </div>
         <p className="truncate text-xs text-muted-foreground">
           {endpoint}

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -173,41 +173,48 @@ export const getAccountsOpencodeSearchEntries = createLocalizedCatalog(() => [
 
 export const getAccountsJcodeProvidersSearchEntries = createLocalizedCatalog(() => [
   {
-    title: '自定义 Provider',
-    description:
-      'Add a custom OpenAI-compatible provider (base URL + API key + model) for jcode chat.',
+    title: translate('jcode.settings.accounts.providers.title', 'Custom provider'),
+    description: translate(
+      'jcode.settings.accounts.providers.description',
+      'Add a custom OpenAI-compatible provider for jcode chat.'
+    ),
     keywords: [
-      'jcode',
-      'provider',
-      'custom',
-      'openai',
-      'compatible',
-      'base url',
-      'api key',
-      'endpoint',
-      'gateway',
-      '自定义'
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.jcode', 'jcode'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.provider', 'provider'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.custom', 'custom'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.openai', 'openai'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.compatible', 'compatible'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.baseUrl', 'base url'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.apiKey', 'api key'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.endpoint', 'endpoint'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.gateway', 'gateway'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.customZh', '自定义')
     ]
   }
 ])
 
 export const getAccountsJcodeMcpSearchEntries = createLocalizedCatalog(() => [
   {
-    title: '连接器 / MCP',
-    description:
-      'Connect MCP servers (connectors) so jcode can use their tools, like IBKR or a vault.',
+    title: translate('jcode.settings.accounts.mcp.title', 'MCP connectors'),
+    description: translate(
+      'jcode.settings.accounts.mcp.description',
+      'Connect MCP servers so jcode can use their tools.'
+    ),
     keywords: [
-      'jcode',
-      'mcp',
-      'connector',
-      'connectors',
-      'server',
-      'tool',
-      'plugin',
-      'ibkr',
-      '连接器',
-      '插件',
-      'model context protocol'
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.jcode', 'jcode'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.mcp', 'mcp'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.connector', 'connector'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.connectors', 'connectors'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.server', 'server'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.tool', 'tool'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.plugin', 'plugin'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.ibkr', 'ibkr'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.connectorZh', '连接器'),
+      ...translateSearchKeyword('jcode.settings.accounts.keyword.pluginZh', '插件'),
+      ...translateSearchKeyword(
+        'jcode.settings.accounts.keyword.modelContextProtocol',
+        'model context protocol'
+      )
     ]
   }
 ])

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -171,10 +171,31 @@ export const getAccountsOpencodeSearchEntries = createLocalizedCatalog(() => [
   }
 ])
 
+export const getAccountsJcodeProvidersSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: '自定义 Provider',
+    description:
+      'Add a custom OpenAI-compatible provider (base URL + API key + model) for jcode chat.',
+    keywords: [
+      'jcode',
+      'provider',
+      'custom',
+      'openai',
+      'compatible',
+      'base url',
+      'api key',
+      'endpoint',
+      'gateway',
+      '自定义'
+    ]
+  }
+])
+
 export const getAccountsPaneSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   ...getAccountsLocationSearchEntries(),
   ...getAccountsClaudeSearchEntries(),
   ...getAccountsCodexSearchEntries(),
   ...getAccountsGeminiSearchEntries(),
-  ...getAccountsOpencodeSearchEntries()
+  ...getAccountsOpencodeSearchEntries(),
+  ...getAccountsJcodeProvidersSearchEntries()
 ])

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -191,11 +191,33 @@ export const getAccountsJcodeProvidersSearchEntries = createLocalizedCatalog(() 
   }
 ])
 
+export const getAccountsJcodeMcpSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: '连接器 / MCP',
+    description:
+      'Connect MCP servers (connectors) so jcode can use their tools, like IBKR or a vault.',
+    keywords: [
+      'jcode',
+      'mcp',
+      'connector',
+      'connectors',
+      'server',
+      'tool',
+      'plugin',
+      'ibkr',
+      '连接器',
+      '插件',
+      'model context protocol'
+    ]
+  }
+])
+
 export const getAccountsPaneSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   ...getAccountsLocationSearchEntries(),
   ...getAccountsClaudeSearchEntries(),
   ...getAccountsCodexSearchEntries(),
   ...getAccountsGeminiSearchEntries(),
   ...getAccountsOpencodeSearchEntries(),
-  ...getAccountsJcodeProvidersSearchEntries()
+  ...getAccountsJcodeProvidersSearchEntries(),
+  ...getAccountsJcodeMcpSearchEntries()
 ])

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -324,7 +324,12 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
         createError={createError}
         isCreating={isCreating}
         hostSelector={<AddRepoHostSelectorSlot hostSelection={hostSelection} />}
-        showRemoteAction={false}
+        // Why (BUG 3): surface the already-built "Project on SSH host" remote
+        // action so the remote-SSH project entry is reachable. Only show it when
+        // the host dropdown is in local mode — in ssh/runtime mode the primary
+        // Browse action already opens the remote/runtime browse step, so the
+        // dedicated remote action would be redundant.
+        showRemoteAction={selectedHostKind !== 'ssh' && selectedHostKind !== 'runtime'}
         browseHostKind={
           selectedHostKind === 'ssh' || selectedHostKind === 'runtime' ? selectedHostKind : 'local'
         }

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -23,6 +23,7 @@ import WorktreeContextMenu from './WorktreeContextMenu'
 import { SshDisconnectedDialog } from './SshDisconnectedDialog'
 import { AutoRenameFailedDialog } from './AutoRenameFailedDialog'
 import WorktreeCardAgents from './WorktreeCardAgents'
+import WorktreeCardJcodeChats from './WorktreeCardJcodeChats'
 import { WorktreeCardStatusSlot } from './WorktreeCardStatusSlot'
 import { cn } from '@/lib/utils'
 import { activateWorktreeFromSidebar } from '@/lib/sidebar-worktree-activation'
@@ -1602,6 +1603,15 @@ const WorktreeCard = React.memo(function WorktreeCard({
             className={hasMetaRow || remoteBranchConflict ? 'mt-0' : '-mt-1'}
           />
         )}
+
+        {/* Why: jcode chats are headless chat tabs (no PTY / no agent-status
+             paneKey), so they never appear in WorktreeCardAgents above. Render
+             a distinct per-worktree "jcode 聊天" list sourced from the durable
+             conversation store; clicking a row reopens + rehydrates the chat.
+             Rendered unconditionally (not gated on showInlineAgentList) so chats
+             stay reachable even when the PTY-agent inline list is hidden; the
+             component self-hides when this worktree has no chats. */}
+        <WorktreeCardJcodeChats worktreeId={worktree.id} />
 
         {showLineageChildChip && (
           <div

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -73,7 +73,8 @@ let capturedRowActivations: {
 
 const activationMocks = vi.hoisted(() => ({
   activateAndRevealWorktree: vi.fn(),
-  activateTabAndFocusPane: vi.fn()
+  activateTabAndFocusPane: vi.fn(),
+  resumeRetainedAgentByPaneKey: vi.fn()
 }))
 
 vi.mock('@/store', () => ({
@@ -98,6 +99,10 @@ vi.mock('@/lib/worktree-activation', () => ({
 
 vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
   activateTabAndFocusPane: activationMocks.activateTabAndFocusPane
+}))
+
+vi.mock('@/lib/resume-sleeping-agent-session', () => ({
+  resumeRetainedAgentByPaneKey: activationMocks.resumeRetainedAgentByPaneKey
 }))
 
 vi.mock('./useWorktreeAgentRows', () => ({
@@ -260,7 +265,12 @@ describe('WorktreeCardAgents', () => {
     expect(markup).toContain('data-pane-key="tab-1:2"')
   })
 
-  it('keeps retained completion rows passive when activated', async () => {
+  it('resumes a retained completion row when activated (GOAL 2)', async () => {
+    // Why: a retained "done" row's tab/PTY is gone, so there is no live pane to
+    // focus — activating it now reveals the worktree and attempts to restore the
+    // captured agent session via the resume path (instead of the old no-op that
+    // left the user staring at a blank terminal). The resume helper itself
+    // decides whether a session is actually resumable.
     mockAgentActivityDisplayMode = 'full'
     mockAgents = [mockAgent({ rowSource: 'retained', state: 'done' })]
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
@@ -269,8 +279,10 @@ describe('WorktreeCardAgents', () => {
     expect(capturedRowActivations).toHaveLength(1)
     capturedRowActivations[0].onActivate('tab-1', 'tab-1:1')
 
-    expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    // No live tab to focus, but the worktree is revealed and resume is attempted.
     expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.resumeRetainedAgentByPaneKey).toHaveBeenCalledWith('wt-1', 'tab-1:1')
   })
 
   it('shows orchestration child agent rows under their parent by default', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -4,6 +4,7 @@
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { resumeRetainedAgentByPaneKey } from '@/lib/resume-sleeping-agent-session'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
 import DashboardAgentRow from '@/components/dashboard/DashboardAgentRow'
 import { useNow } from '@/components/dashboard/useNow'
@@ -218,10 +219,20 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     },
     [worktreeId]
   )
-  const handleActivateRetainedAgent = useCallback(() => {
-    // Why: hibernation-retained rows are passive completion evidence. Activating
-    // the worktree would resume sleeping sessions, so the row itself is inert.
-  }, [])
+  const handleActivateRetainedAgent = useCallback(
+    (_tabId: string, paneKey: string) => {
+      // Why (GOAL 2): a retained row is a "done" agent whose tab/PTY is gone, so
+      // there is nothing to focus — the old no-op (and any stale tab activation)
+      // left the user looking at a blank terminal. When orca captured a
+      // resumable provider session for that done agent, relaunch it through the
+      // existing resume path (`<agent> --resume <id>`) so the prior Claude/Hermes
+      // session is restored in a fresh tab. If the row isn't resumable (no
+      // captured session), fall through to the prior inert behavior.
+      activateAndRevealWorktree(worktreeId)
+      resumeRetainedAgentByPaneKey(worktreeId, paneKey)
+    },
+    [worktreeId]
+  )
 
   // Why: own one 30s tick per non-empty inline list. Cards with zero agents
   // never mount this component (see WorktreeCardAgents), so idle worktrees

--- a/src/renderer/src/components/sidebar/WorktreeCardJcodeChats.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardJcodeChats.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react'
+import { Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { reopenChatConversation } from '@/lib/launch-chat-agent-tab'
+import { launchChatAgentTab, reopenChatConversation } from '@/lib/launch-chat-agent-tab'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import {
   deleteChatConversation,
   listChatConversations,
@@ -73,9 +75,16 @@ const WorktreeCardJcodeChats = React.memo(function WorktreeCardJcodeChats({
     }
   }, [refresh])
 
-  if (chats.length === 0) {
-    return null
-  }
+  // Start a NEW chat bound to THIS worktree. We activate the worktree FIRST
+  // (setActiveWorktree sets activeWorktreeId + activeWorkspaceKey together, which
+  // also resyncs them if a remote-project selection had left them split), so the
+  // new chat tab is created in — and visible under — the right project. This is
+  // the reliable, project-scoped creation path (mirrors how PTY agents launch
+  // from their worktree row), unlike the global "+" which uses the active state.
+  const startNewChat = useCallback(() => {
+    activateAndRevealWorktree(worktreeId)
+    launchChatAgentTab({ agent: 'jcode', worktreeId })
+  }, [worktreeId])
 
   const now = Date.now()
 
@@ -92,8 +101,19 @@ const WorktreeCardJcodeChats = React.memo(function WorktreeCardJcodeChats({
       aria-label="jcode chats"
       data-jcode-chats-list="true"
     >
-      <div className="px-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-        jcode 聊天
+      <div className="flex items-center justify-between px-1">
+        <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          jcode 聊天
+        </span>
+        <button
+          type="button"
+          aria-label="在此项目新建 jcode 聊天"
+          title="在此项目新建 jcode 聊天"
+          className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-worktree-sidebar-accent hover:text-foreground"
+          onClick={startNewChat}
+        >
+          <Plus className="size-3" />
+        </button>
       </div>
       {chats.slice(0, MAX_CHATS).map((row) => (
         <div

--- a/src/renderer/src/components/sidebar/WorktreeCardJcodeChats.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardJcodeChats.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { cn } from '@/lib/utils'
+import { reopenChatConversation } from '@/lib/launch-chat-agent-tab'
+import {
+  deleteChatConversation,
+  listChatConversations,
+  JCODE_CHAT_CONVERSATIONS_CHANGED_EVENT
+} from '@/components/chat-pane/chat-session-store'
+import type { JcodeConversationSummary } from '../../../../shared/jcode-chat-types'
+
+/** Number of recent jcode chats shown per worktree card before truncating. */
+const MAX_CHATS = 4
+
+function formatTimeAgo(ts: number, now: number): string {
+  const delta = now - ts
+  if (delta < 60_000) {
+    return 'just now'
+  }
+  const minutes = Math.floor(delta / 60_000)
+  if (minutes < 60) {
+    return `${minutes}m ago`
+  }
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `${hours}h ago`
+  }
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+type Props = {
+  worktreeId: string
+  className?: string
+}
+
+/**
+ * Per-worktree "jcode chats" list rendered inline in the left project sidebar
+ * under a worktree card. Distinct from WorktreeCardAgents (orca's PTY-agent
+ * status rows): jcode chats are headless chat tabs persisted to disk by
+ * jcode-conversation-store, never register a paneKey/agent-status, and so would
+ * otherwise be invisible in the sidebar.
+ *
+ * Source: window.api.jcodeChat.listConversations() (via listChatConversations),
+ * filtered to this worktree by the record's stored worktreeId. Clicking a row
+ * goes through reopenChatConversation — the same path the in-pane RECENT CHATS
+ * empty-state uses — so it recreates the chat tab (reusing the stored sessionKey
+ * as the tab id) and rehydrates the transcript.
+ *
+ * Refresh: on mount and whenever a jcode turn boundary persists or a chat is
+ * deleted (JCODE_CHAT_CONVERSATIONS_CHANGED_EVENT, best-effort DOM event).
+ */
+const WorktreeCardJcodeChats = React.memo(function WorktreeCardJcodeChats({
+  worktreeId,
+  className
+}: Props) {
+  const [chats, setChats] = useState<JcodeConversationSummary[]>([])
+
+  const refresh = useCallback(() => {
+    void listChatConversations().then((rows) => {
+      setChats(rows.filter((row) => row.worktreeId === worktreeId))
+    })
+  }, [worktreeId])
+
+  useEffect(() => {
+    refresh()
+    // Why: re-fetch on the best-effort change signal the chat store fires on
+    // turn boundaries / deletes, so a finished chat appears without reopening
+    // the sidebar. Falls back to the mount fetch when no events arrive.
+    const onChanged = (): void => refresh()
+    window.addEventListener(JCODE_CHAT_CONVERSATIONS_CHANGED_EVENT, onChanged)
+    return () => {
+      window.removeEventListener(JCODE_CHAT_CONVERSATIONS_CHANGED_EVENT, onChanged)
+    }
+  }, [refresh])
+
+  if (chats.length === 0) {
+    return null
+  }
+
+  const now = Date.now()
+
+  return (
+    // Why: swallow bubbling so clicks on these rows don't reach WorktreeCard's
+    // activate / edit-meta handlers, matching WorktreeCardAgents behavior.
+    <div
+      className={cn('flex flex-col mt-1 gap-0.5', className)}
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      role="group"
+      aria-label="jcode chats"
+      data-jcode-chats-list="true"
+    >
+      <div className="px-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        jcode 聊天
+      </div>
+      {chats.slice(0, MAX_CHATS).map((row) => (
+        <div
+          key={row.sessionKey}
+          className="group/jcode-chat-row relative flex items-center gap-1.5 rounded-md px-1 py-0.5 hover:bg-worktree-sidebar-accent"
+        >
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+            onClick={() => {
+              void reopenChatConversation({
+                conversation: row,
+                fallbackWorktreeId: worktreeId
+              })
+            }}
+          >
+            <span className="shrink-0 text-[10px] leading-none text-muted-foreground">💬</span>
+            <span className="min-w-0 flex-1 truncate text-xs text-foreground">{row.title}</span>
+            <span className="shrink-0 text-[10px] leading-none text-muted-foreground">
+              {formatTimeAgo(row.updatedAt, now)}
+            </span>
+          </button>
+          <button
+            type="button"
+            aria-label="Delete chat"
+            className="shrink-0 rounded px-1 text-[10px] leading-none text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover/jcode-chat-row:opacity-100"
+            onClick={() => {
+              deleteChatConversation(row.sessionKey)
+              refresh()
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+})
+
+export default WorktreeCardJcodeChats

--- a/src/renderer/src/components/sidebar/WorktreeCardJcodeChats.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardJcodeChats.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
 import { launchChatAgentTab, reopenChatConversation } from '@/lib/launch-chat-agent-tab'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import {
@@ -16,18 +17,20 @@ const MAX_CHATS = 4
 function formatTimeAgo(ts: number, now: number): string {
   const delta = now - ts
   if (delta < 60_000) {
-    return 'just now'
+    return translate('jcode.sidebar.chats.time.justNow', 'just now')
   }
   const minutes = Math.floor(delta / 60_000)
   if (minutes < 60) {
-    return `${minutes}m ago`
+    return translate('jcode.sidebar.chats.time.minutesAgo', '{{value0}}m ago', {
+      value0: minutes
+    })
   }
   const hours = Math.floor(minutes / 60)
   if (hours < 24) {
-    return `${hours}h ago`
+    return translate('jcode.sidebar.chats.time.hoursAgo', '{{value0}}h ago', { value0: hours })
   }
   const days = Math.floor(hours / 24)
-  return `${days}d ago`
+  return translate('jcode.sidebar.chats.time.daysAgo', '{{value0}}d ago', { value0: days })
 }
 
 type Props = {
@@ -98,17 +101,17 @@ const WorktreeCardJcodeChats = React.memo(function WorktreeCardJcodeChats({
       onMouseDown={(e) => e.stopPropagation()}
       onPointerDown={(e) => e.stopPropagation()}
       role="group"
-      aria-label="jcode chats"
+      aria-label={translate('jcode.sidebar.chats.groupAria', 'jcode chats')}
       data-jcode-chats-list="true"
     >
       <div className="flex items-center justify-between px-1">
         <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-          jcode 聊天
+          {translate('jcode.sidebar.chats.heading', 'jcode chats')}
         </span>
         <button
           type="button"
-          aria-label="在此项目新建 jcode 聊天"
-          title="在此项目新建 jcode 聊天"
+          aria-label={translate('jcode.sidebar.chats.newChatAria', 'New jcode chat here')}
+          title={translate('jcode.sidebar.chats.newChatTitle', 'New jcode chat here')}
           className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-worktree-sidebar-accent hover:text-foreground"
           onClick={startNewChat}
         >
@@ -138,7 +141,7 @@ const WorktreeCardJcodeChats = React.memo(function WorktreeCardJcodeChats({
           </button>
           <button
             type="button"
-            aria-label="Delete chat"
+            aria-label={translate('jcode.sidebar.chats.deleteAria', 'Delete chat')}
             className="shrink-0 rounded px-1 text-[10px] leading-none text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover/jcode-chat-row:opacity-100"
             onClick={() => {
               deleteChatConversation(row.sessionKey)

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -175,6 +175,13 @@ type TabItem =
       isPinned: boolean
       data: Tab
     }
+  | {
+      type: 'chat'
+      id: string
+      unifiedTabId: string
+      isPinned: boolean
+      data: Tab
+    }
 
 function getTabDragLabel(item: TabItem, generatedTitlesEnabled: boolean): string {
   if (item.type === 'terminal') {
@@ -185,6 +192,9 @@ function getTabDragLabel(item: TabItem, generatedTitlesEnabled: boolean): string
   }
   if (item.type === 'simulator') {
     return item.data.label || 'Mobile Emulator'
+  }
+  if (item.type === 'chat') {
+    return item.data.label || 'jcode'
   }
   return getEditorDisplayLabel(item.data)
 }
@@ -831,6 +841,13 @@ function TabBarInner({
         .map((t) => t.id),
     [unifiedTabs, resolvedGroupId]
   )
+  const chatTabIds = useMemo(
+    () =>
+      (unifiedTabs ?? [])
+        .filter((t) => t.groupId === resolvedGroupId && t.contentType === 'chat')
+        .map((t) => t.id),
+    [unifiedTabs, resolvedGroupId]
+  )
 
   // Build the unified ordered list, reconciling stored order with current items
   const orderedItems = useMemo(() => {
@@ -839,7 +856,8 @@ function TabBarInner({
       terminalIds,
       editorFileIds,
       browserTabIds,
-      simulatorTabIds
+      simulatorTabIds,
+      chatTabIds
     )
     const items: TabItem[] = []
     for (const id of ids) {
@@ -890,6 +908,17 @@ function TabBarInner({
         })
         continue
       }
+      const chatUnified = unifiedTabByVisibleId.get(id)
+      if (chatUnified && chatUnified.contentType === 'chat') {
+        items.push({
+          type: 'chat',
+          id,
+          unifiedTabId: chatUnified.id,
+          isPinned: chatUnified.isPinned === true,
+          data: chatUnified
+        })
+        continue
+      }
     }
     return items
   }, [
@@ -898,6 +927,7 @@ function TabBarInner({
     editorFileIds,
     browserTabIds,
     simulatorTabIds,
+    chatTabIds,
     terminalMap,
     editorMap,
     browserMap,
@@ -931,6 +961,12 @@ function TabBarInner({
       }
       if (item.type === 'simulator') {
         return activeTabType === 'simulator' && item.id === activeSimulatorTabId
+      }
+      if (item.type === 'chat') {
+        // Why: chat maps to the 'editor' visible-tab type (toVisibleTabType) and
+        // is selected via activeFileId (TabGroupPanel sets activeFileId to the
+        // chat tab id), so it shares the editor active-id plumbing.
+        return activeTabType === 'editor' && activeFileId === item.id
       }
       return (
         (activeTabType === 'editor' || activeTabType === 'simulator') && activeFileId === item.id
@@ -1134,6 +1170,47 @@ function TabBarInner({
                     key={item.id}
                     file={simFile}
                     isActive={activeTabType === 'simulator' && item.id === activeSimulatorTabId}
+                    isPinned={item.isPinned}
+                    hasTabsToRight={index < orderedItems.length - 1}
+                    statusByRelativePath={statusByRelativePath}
+                    onActivate={() => onActivateFile?.(item.id)}
+                    onClose={() => onCloseFile?.(item.id)}
+                    onCloseToRight={() => onCloseToRight(item.id)}
+                    onCloseAll={() => onCloseAllFiles?.()}
+                    onMakePermanent={() => {}}
+                    onTogglePin={() => togglePinned(item)}
+                    onSplitGroup={(direction, sourceVisibleTabId) =>
+                      onCreateSplitGroup?.(direction, sourceVisibleTabId)
+                    }
+                    dragData={dragData}
+                    dropIndicator={dropIndicatorByVisibleId.get(item.id) ?? null}
+                    includeTopTabBorder={includeTopTabBorder}
+                  />
+                )
+              }
+              if (item.type === 'chat') {
+                // Why: chat tabs render a header in the strip by reusing
+                // EditorFileTab (chat maps to the 'editor' visible-tab type). A
+                // synthetic OpenFile carries only the label so the tab is
+                // clickable/closable like an editor; the real chat surface is
+                // rendered by TabGroupPanel keyed on the same tab id.
+                const chatLabel = item.data.label || 'jcode'
+                const chatFile: OpenFile & { tabId: string } = {
+                  id: item.id,
+                  tabId: item.id,
+                  filePath: chatLabel,
+                  relativePath: chatLabel,
+                  worktreeId,
+                  language: 'chat',
+                  isPreview: false,
+                  isDirty: false,
+                  mode: 'edit'
+                }
+                return (
+                  <EditorFileTab
+                    key={item.id}
+                    file={chatFile}
+                    isActive={activeTabType === 'editor' && activeFileId === item.id}
                     isPinned={item.isPinned}
                     hasTabsToRight={index < orderedItems.length - 1}
                     statusByRelativePath={statusByRelativePath}

--- a/src/renderer/src/components/tab-bar/group-tab-order.test.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.test.ts
@@ -63,6 +63,21 @@ function simulatorTab(id: string, groupId: string, sortOrder: number): Tab {
   }
 }
 
+function chatTab(id: string, groupId: string, sortOrder: number): Tab {
+  return {
+    id,
+    entityId: id,
+    groupId,
+    worktreeId: 'wt',
+    contentType: 'chat',
+    label: 'jcode',
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
 describe('getGroupVisibleTabOrder', () => {
   it('returns active-group refs with backing ids plus unified tab ids', () => {
     const group: TabGroup = {
@@ -185,6 +200,38 @@ describe('getGroupVisibleTabOrder', () => {
     ).toEqual([
       { type: 'terminal', id: 'term-1', tabId: 'tab-t1' },
       { type: 'simulator', id: 'tab-s1', tabId: 'tab-s1' },
+      { type: 'editor', id: '/repo/file.md', tabId: 'tab-e1' }
+    ])
+  })
+
+  it('includes chat tabs keyed by unified tab id, emitted as the editor visible-type (regression: chat dropped from keyboard nav)', () => {
+    // A jcode chat tab has no editor file entity; its entityId defaults to its
+    // own tab id and is never in editorEntityIds. Before the fix it fell into
+    // the editor branch's entity check and was silently dropped, making the
+    // chat tab invisible to Ctrl+Tab / next-prev tab cycling. It maps to the
+    // 'editor' visible-tab type, so it must be emitted as such with its tab id.
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-c1',
+      tabOrder: ['tab-t1', 'tab-c1', 'tab-e1']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      chatTab('tab-c1', 'g1', 1),
+      editorTab('tab-e1', 'g1', '/repo/file.md', 2)
+    ]
+    expect(
+      getGroupVisibleTabOrder(
+        group,
+        tabs,
+        new Set(['term-1']),
+        new Set(['/repo/file.md']),
+        new Set()
+      )
+    ).toEqual([
+      { type: 'terminal', id: 'term-1', tabId: 'tab-t1' },
+      { type: 'editor', id: 'tab-c1', tabId: 'tab-c1' },
       { type: 'editor', id: '/repo/file.md', tabId: 'tab-e1' }
     ])
   })

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -13,6 +13,7 @@ export type ActiveTabNavOrderIds = {
   editorIds?: string[]
   browserIds?: string[]
   simulatorIds?: string[]
+  chatIds?: string[]
 }
 
 /**
@@ -65,6 +66,7 @@ export function getGroupVisibleTabOrder(
   const seenBrowsers = new Set<string>()
   const seenEditors = new Set<string>()
   const seenSimulators = new Set<string>()
+  const seenChats = new Set<string>()
   for (const unifiedId of group.tabOrder) {
     const tab = tabsById.get(unifiedId)
     if (!tab) {
@@ -88,6 +90,20 @@ export function getGroupVisibleTabOrder(
       }
       seenSimulators.add(tab.id)
       result.push({ type: 'simulator', id: tab.id, tabId: tab.id })
+    } else if (tab.contentType === 'chat') {
+      // Why: chat maps to the 'editor' visible-tab type (toVisibleTabType) and
+      // has no editor file entity — its entityId defaults to its own tab id and
+      // is never in editorEntityIds, so the final editor branch would silently
+      // drop it from keyboard nav order. Mirror the simulator precedent and key
+      // by the unified tab id. Emit type 'editor' so the existing editor
+      // activation/active-key plumbing (activateCyclableTab, getActiveVisible-
+      // TabKey via group.activeTabId) handles chat without a new union member:
+      // chat activation sets activeTabType 'editor' + group.activeTabId = tab.id.
+      if (seenChats.has(tab.id)) {
+        continue
+      }
+      seenChats.add(tab.id)
+      result.push({ type: 'editor', id: tab.id, tabId: tab.id })
     } else {
       if (!editorEntityIds.has(tab.entityId) || seenEditors.has(tab.id)) {
         continue
@@ -137,6 +153,11 @@ export function getActiveTabNavOrder(
     (state.unifiedTabsByWorktree[worktreeId] ?? [])
       .filter((tab) => tab.contentType === 'simulator')
       .map((tab) => tab.id)
+  const chatIds =
+    ids.chatIds ??
+    (state.unifiedTabsByWorktree[worktreeId] ?? [])
+      .filter((tab) => tab.contentType === 'chat')
+      .map((tab) => tab.id)
 
   const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
   const group = activeGroupId
@@ -163,12 +184,14 @@ export function getActiveTabNavOrder(
     terminalIds,
     editorIds,
     browserIds,
-    simulatorIds
+    simulatorIds,
+    chatIds
   )
   const terminalIdSet = new Set(terminalIds)
   const editorIdSet = new Set(editorIds)
   const browserIdSet = new Set(browserIds)
   const simulatorIdSet = new Set(simulatorIds)
+  const chatIdSet = new Set(chatIds)
   const result: VisibleTabRef[] = []
   for (const id of visibleIds) {
     if (terminalIdSet.has(id)) {
@@ -179,6 +202,11 @@ export function getActiveTabNavOrder(
       result.push({ type: 'browser', id })
     } else if (simulatorIdSet.has(id)) {
       result.push({ type: 'simulator', id })
+    } else if (chatIdSet.has(id)) {
+      // Why: chat maps to the 'editor' visible-tab type; emit type 'editor'
+      // with the chat tab id so activation/active-key plumbing matches the
+      // active-group path above.
+      result.push({ type: 'editor', id })
     }
   }
   return result

--- a/src/renderer/src/components/tab-bar/reconcile-order.ts
+++ b/src/renderer/src/components/tab-bar/reconcile-order.ts
@@ -8,9 +8,16 @@ export function reconcileTabOrder(
   terminalIds: string[],
   editorIds: string[],
   browserIds: string[] = [],
-  simulatorIds: string[] = []
+  simulatorIds: string[] = [],
+  chatIds: string[] = []
 ): string[] {
-  const validIds = new Set([...terminalIds, ...editorIds, ...browserIds, ...simulatorIds])
+  const validIds = new Set([
+    ...terminalIds,
+    ...editorIds,
+    ...browserIds,
+    ...simulatorIds,
+    ...chatIds
+  ])
   // Why: storedOrder is persisted group tab order and is mutated by many
   // codepaths (drop/move/reorder/hydrate). A stale or racey write can leave
   // the same tab id twice in the list, which surfaces as React's "two
@@ -25,7 +32,7 @@ export function reconcileTabOrder(
       inResult.add(id)
     }
   }
-  for (const id of [...terminalIds, ...editorIds, ...browserIds, ...simulatorIds]) {
+  for (const id of [...terminalIds, ...editorIds, ...browserIds, ...simulatorIds, ...chatIds]) {
     if (!inResult.has(id)) {
       result.push(id)
       inResult.add(id)

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -405,7 +405,7 @@ export default function TabGroupPanel({
             >
               {/* Why: key the chat session by the tab id so each jcode chat tab
                   keeps an independent conversation / --resume session. */}
-              <ChatPane sessionKey={activeTab.id} cwd={chatCwd} />
+              <ChatPane sessionKey={activeTab.id} cwd={chatCwd} worktreeId={worktreeId} />
             </Suspense>
           </div>
         )}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -26,6 +26,7 @@ import { tabGroupBodyAnchorName } from './tab-group-body-anchor'
 import { translate } from '@/i18n/i18n'
 
 const EditorPanel = lazy(() => import('../editor/EditorPanel'))
+const ChatPane = lazy(() => import('../chat-pane/ChatPane'))
 
 export default function TabGroupPanel({
   groupId,
@@ -381,10 +382,29 @@ export default function TabGroupPanel({
           />
         ) : null}
         {activeDropZone ? <TabGroupDropOverlay zone={activeDropZone} /> : null}
+        {activeTab && activeTab.contentType === 'chat' && (
+          <div className="absolute inset-0 flex min-h-0 min-w-0">
+            <Suspense
+              fallback={
+                <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+                  {translate(
+                    'auto.components.tab.group.TabGroupPanel.814fb04c43',
+                    'Loading chat...'
+                  )}
+                </div>
+              }
+            >
+              {/* Why: key the chat session by the tab id so each jcode chat tab
+                  keeps an independent conversation / --resume session. */}
+              <ChatPane sessionKey={activeTab.id} />
+            </Suspense>
+          </div>
+        )}
         {activeTab &&
           activeTab.contentType !== 'terminal' &&
           activeTab.contentType !== 'browser' &&
-          activeTab.contentType !== 'simulator' && (
+          activeTab.contentType !== 'simulator' &&
+          activeTab.contentType !== 'chat' && (
             <div className="absolute inset-0 flex min-h-0 min-w-0">
               {/* Why: split groups render editor content inside a plain relative pane body
                   instead of the legacy flex column in Terminal.tsx. */}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -55,6 +55,15 @@ export default function TabGroupPanel({
 }): React.JSX.Element {
   const rightSidebarOpen = useAppStore((state) => state.rightSidebarOpen)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
+  // Why: chat tabs run `jcode run --ndjson` in this worktree's directory, so
+  // ChatPane needs the worktree's absolute path as cwd. Without it the headless
+  // jcode session would default to the app's process cwd and operate on the
+  // wrong tree. Provider/model fall back to ChatPane's defaults (openai today,
+  // matching the jcode agent config); they live here so a future per-agent
+  // override has a single wiring point.
+  const chatCwd = useAppStore(
+    (state) => state.allWorktrees?.().find((worktree) => worktree.id === worktreeId)?.path
+  )
 
   const model = useTabGroupWorkspaceModel({ groupId, worktreeId })
   const { activeTab, browserItems, commands, editorItems, tabBarOrder, terminalTabs } = model
@@ -396,7 +405,7 @@ export default function TabGroupPanel({
             >
               {/* Why: key the chat session by the tab id so each jcode chat tab
                   keeps an independent conversation / --resume session. */}
-              <ChatPane sessionKey={activeTab.id} />
+              <ChatPane sessionKey={activeTab.id} cwd={chatCwd} />
             </Suspense>
           </div>
         )}

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -41,7 +41,7 @@ export type TabDragItemData = {
   groupId: string
   unifiedTabId: string
   visibleTabId: string
-  tabType: 'terminal' | 'editor' | 'browser' | 'simulator'
+  tabType: 'terminal' | 'editor' | 'browser' | 'simulator' | 'chat'
   /** Rendered by the DragOverlay ghost that follows the cursor across
    *  groups. Source tab strips use overflow-hidden, so without the overlay
    *  the dragged tab would be invisible once the cursor leaves its own

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -26,6 +26,7 @@ import {
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { openTabBarEntry, type TabCreateEntryArgs } from '../tab-bar/tab-create-entry-action'
 import { openMobileEmulatorTab } from '@/lib/open-mobile-emulator-tab'
+import { disposeChatSession } from '../chat-pane/chat-session-store'
 import { ensureSimulatorTab, getSimulatorTabForWorktree } from '@/lib/ensure-simulator-tab'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { browserWorkspaceHasRemoteOwner } from '@/runtime/remote-browser-tab-ownership'
@@ -276,7 +277,14 @@ export function useTabGroupWorkspaceModel({
         destroyWorkspaceWebviews(browserState.browserPagesByWorkspace, item.entityId)
         closeBrowserTab(item.entityId)
         closeUnifiedTab(item.id)
-      } else if (item.contentType === 'simulator') {
+      } else if (item.contentType === 'simulator' || item.contentType === 'chat') {
+        // Why: chat tabs have no editor/browser/terminal entity to tear down;
+        // removing the unified tab is the whole close. Evict the chat
+        // conversation state (keyed by tab id) so the external store does not
+        // retain closed sessions.
+        if (item.contentType === 'chat') {
+          disposeChatSession(item.id)
+        }
         closeUnifiedTab(item.id)
       } else {
         const canCloseTab = closeEditorIfUnreferenced(item.entityId, item.id)
@@ -341,7 +349,10 @@ export function useTabGroupWorkspaceModel({
           closeUnifiedTab(item.id)
         } else if (item.contentType === 'terminal') {
           closeTab(item.entityId)
-        } else if (item.contentType === 'simulator') {
+        } else if (item.contentType === 'simulator' || item.contentType === 'chat') {
+          if (item.contentType === 'chat') {
+            disposeChatSession(item.id)
+          }
           closeUnifiedTab(item.id)
         } else {
           const canCloseTab = closeEditorIfUnreferenced(item.entityId, item.id)
@@ -417,6 +428,11 @@ export function useTabGroupWorkspaceModel({
       if (item.contentType === 'simulator') {
         setActiveTabType('simulator')
         // simulator has no editor file entity
+      } else if (item.contentType === 'chat') {
+        // Why: chat maps to the 'editor' visible-tab type but has no editor file
+        // entity. Flip the surface to editor (so TabGroupPanel shows the chat
+        // pane, selected via the active tab id) without binding a phantom file.
+        setActiveTabType('editor')
       } else {
         setActiveFile(item.entityId)
         setActiveTabType('editor')

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "Copy",
             "c2f0b72b8d": "Insert",
             "925f49f210": "Expand Pane",
-            "df766809e0": "Collapse Pane",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "Collapse Pane"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Restart daemon",
@@ -8471,8 +8470,8 @@
             "a1f2c8d901": "View"
           },
           "SourceControl": {
-            "conflictsSection": "Conflicts",
             "1406954883": "Clear all notes...",
+            "conflictsSection": "Conflicts",
             "cc05b2d088": "Open in File Explorer",
             "03194cfff4": "Local session state derived from a conflict you opened here.",
             "413a3ba113": "conflict",
@@ -9185,9 +9184,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "View"
           }
         }
       },
@@ -11679,6 +11675,189 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    }
+  },
+  "jcode": {
+    "chat": {
+      "attachment": {
+        "pastedWithPreview": "Pasted: {{value0}}…",
+        "pastedText": "Pasted text",
+        "defaultTextName": "Text",
+        "removeAria": "Remove attachment"
+      },
+      "composer": {
+        "placeholder": "Message jcode... (type / for commands)",
+        "addMenuAria": "Add to message",
+        "addFiles": "Add files",
+        "textPrompt": "Paste or type text to attach:",
+        "addText": "Add text",
+        "quickCommands": "Quick commands",
+        "connectors": "Connectors",
+        "skills": "Skills",
+        "voiceInputAria": "Voice input",
+        "voiceSkillRequired": "Voice transcription requires a voice skill",
+        "stopAria": "Stop",
+        "sendAria": "Send"
+      },
+      "skillChip": {
+        "prefix": "Skill:",
+        "removeAria": "Remove skill"
+      },
+      "slash": {
+        "commandsHeading": "Orca quick commands",
+        "skillsHeading": "Skills",
+        "projectSkillsUnavailable": "Project skills on the remote host were unavailable; showing global skills only.",
+        "explain": {
+          "label": "/explain",
+          "hint": "Explain this code",
+          "template": "Explain how the code in this project works, focusing on "
+        },
+        "review": {
+          "label": "/review",
+          "hint": "Review for bugs",
+          "template": "Review the current changes for bugs, edge cases, and correctness issues."
+        },
+        "tests": {
+          "label": "/tests",
+          "hint": "Write tests",
+          "template": "Write tests covering "
+        },
+        "summarize": {
+          "label": "/summarize",
+          "hint": "Summarize",
+          "template": "Summarize "
+        },
+        "clear": {
+          "label": "/clear",
+          "hint": "Start a new chat"
+        },
+        "resume": {
+          "label": "/resume",
+          "hint": "Reopen last chat"
+        },
+        "skillSource": {
+          "project": "Project skill",
+          "global": "Global skill",
+          "plugin": "Plugin skill"
+        }
+      },
+      "modelPicker": {
+        "auto": "Auto",
+        "modelLabel": "Model",
+        "autoSelect": "Auto-select",
+        "signInRequired": "Sign in required",
+        "customProvider": "Custom provider",
+        "moreProviders": "More providers",
+        "modelListError": "Unable to read model list",
+        "refreshModels": "Refresh model list"
+      },
+      "transcript": {
+        "skillSummary": "Skill: {{value0}}",
+        "attachmentSummary": "Attached: {{value0}}"
+      },
+      "status": {
+        "stopping": "Stopping..."
+      },
+      "empty": {
+        "title": "Message jcode to start",
+        "description": "Replies stream in. Tool calls and diffs render inline."
+      },
+      "projectBadge": {
+        "fallbackProject": "Workspace",
+        "remoteWithHost": "Remote · {{value0}}",
+        "local": "Local",
+        "handsRemoteOn": "Hands remote: on",
+        "handsRemoteOff": "Hands remote: off",
+        "brainLocalAuto": "brain-local (auto)"
+      },
+      "recents": {
+        "heading": "Recent chats",
+        "deleteAria": "Delete chat",
+        "delete": "Delete"
+      },
+      "toolCard": {
+        "running": "Running..."
+      },
+      "provider": {
+        "jcodeSubscription": "Jcode Subscription",
+        "claude": "Claude",
+        "openai": "OpenAI",
+        "gemini": "Gemini",
+        "openrouter": "OpenRouter",
+        "openaiCompatible": "OpenAI-compatible"
+      },
+      "tabLabel": "jcode"
+    },
+    "settings": {
+      "accounts": {
+        "providers": {
+          "requiredFields": "Name, base URL, and model are required.",
+          "addFailed": "Failed to add provider.",
+          "added": "Added provider \"{{value0}}\".",
+          "removed": "Removed provider \"{{value0}}\".",
+          "title": "Custom provider",
+          "formDescription": "Add a custom OpenAI-compatible provider for jcode chat.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-gateway",
+          "modelLabel": "Model",
+          "modelPlaceholder": "gpt-4o",
+          "baseUrlLabel": "Base URL",
+          "baseUrlPlaceholder": "https://llm.example.com/v1",
+          "apiKeyLabel": "API Key",
+          "apiKeyPlaceholder": "sk-... (stored in jcode's private env file)",
+          "authLabel": "Auth",
+          "authBearer": "Bearer",
+          "authApiKeyHeader": "API key header",
+          "authNone": "None",
+          "addProvider": "Add provider",
+          "sectionDescription": "Add a custom OpenAI-compatible endpoint and pick it in the jcode chat composer.",
+          "description": "Add a custom OpenAI-compatible provider for jcode chat."
+        },
+        "mcp": {
+          "readFailed": "Failed to read MCP config.",
+          "requiredFields": "Name and command are required.",
+          "saveFailed": "Failed to save MCP server.",
+          "connected": "Connected \"{{value0}}\". Restart a chat to load its tools.",
+          "removeFailed": "Failed to remove MCP server.",
+          "removed": "Removed \"{{value0}}\".",
+          "title": "MCP connectors",
+          "formDescription": "Connect MCP servers so jcode can use their tools.",
+          "loading": "Loading...",
+          "empty": "No connectors yet.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-connector",
+          "commandLabel": "Command",
+          "commandPlaceholder": "npx",
+          "argsLabel": "Args (one per line)",
+          "argsPlaceholder": "-y\n@modelcontextprotocol/server-filesystem\n/path/to/dir",
+          "envLabel": "Env (KEY=value, one per line)",
+          "envPlaceholder": "API_KEY=...\nREGION=us",
+          "addConnector": "Add connector",
+          "refresh": "Refresh",
+          "storedIn": "Stored in",
+          "restartChatForChanges": "Restart a chat to pick up changes.",
+          "sectionDescription": "Connect MCP servers so jcode can use their tools in chat.",
+          "description": "Connect MCP servers so jcode can use their tools."
+        }
+      }
+    },
+    "sidebar": {
+      "chats": {
+        "time": {
+          "justNow": "just now",
+          "minutesAgo": "{{value0}}m ago",
+          "hoursAgo": "{{value0}}h ago",
+          "daysAgo": "{{value0}}d ago"
+        },
+        "groupAria": "jcode chats",
+        "heading": "jcode chats",
+        "newChatAria": "New jcode chat here",
+        "newChatTitle": "New jcode chat here",
+        "deleteAria": "Delete chat"
+      }
+    },
+    "agentCatalog": {
+      "label": "J-Code"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6043,7 +6043,9 @@
           "c77f1abfe3": "Ending remote terminals",
           "18968ede9e": "Error",
           "f0871e6bfb": "connect",
-          "47e94bd6ba": "connected"
+          "47e94bd6ba": "connected",
+          "idleNotConnected": "Not connected",
+          "idleNotConnectedHint": "Click “Connect” to start a session (brain-local needs no connection)."
         },
         "SshTargetDestructiveActions": {
           "7e66942808": "This will stop active terminal sessions on this SSH target. Reconnecting will not restore them.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "Borrar pantalla",
             "8c17d6786d": "Cerrar panel",
-            "copyTerminalId": "Copiar ID de terminal",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "Copiar ID del panel",
             "39809d152f": "Establecer título…",
             "06c2b0f043": "Igualar tamaños de paneles",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "Copiar",
             "c2f0b72b8d": "Insertar",
             "925f49f210": "Expandir panel",
-            "df766809e0": "Contraer panel",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "Contraer panel"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Reiniciar demonio",
@@ -6006,7 +6005,9 @@
           "c77f1abfe3": "Terminar con terminales remotos",
           "18968ede9e": "Error",
           "f0871e6bfb": "conectar",
-          "47e94bd6ba": "conectado"
+          "47e94bd6ba": "conectado",
+          "idleNotConnected": "Not connected",
+          "idleNotConnectedHint": "Click “Connect” to start a session (brain-local needs no connection)."
         },
         "SshTargetDestructiveActions": {
           "7e66942808": "Esto detendrá las sesiones de terminal activas en este destino SSH. Volver a conectarlos no los restaurará.",
@@ -8469,8 +8470,8 @@
             "a1f2c8d901": "Ver"
           },
           "SourceControl": {
-            "conflictsSection": "Conflictos",
             "1406954883": "Borrar todas las notas...",
+            "conflictsSection": "Conflictos",
             "cc05b2d088": "Abrir en el Explorador de archivos",
             "03194cfff4": "Estado de la sesión local derivado de un conflicto que abrió aquí.",
             "413a3ba113": "conflicto",
@@ -9106,7 +9107,16 @@
             "daysAgo": "{{value0}}d ago",
             "monthsAgo": "{{value0}}mo ago",
             "yearsAgo": "{{value0}}y ago",
-            "sessionId": "ID de sesión"
+            "sessionId": "ID de sesión",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "Resume {{value0}} session",
@@ -9123,7 +9133,14 @@
             "hideDetails": "Ocultar detalles",
             "showDetails": "Mostrar detalles",
             "moreSessionActions": "Más acciones de sesión",
-            "moreActions": "Más acciones"
+            "moreActions": "Más acciones",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "Buscar archivos",
@@ -9167,9 +9184,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "Ver"
           }
         }
       },
@@ -11661,6 +11675,189 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    }
+  },
+  "jcode": {
+    "chat": {
+      "attachment": {
+        "pastedWithPreview": "Pasted: {{value0}}…",
+        "pastedText": "Pasted text",
+        "defaultTextName": "Text",
+        "removeAria": "Remove attachment"
+      },
+      "composer": {
+        "placeholder": "Message jcode... (type / for commands)",
+        "addMenuAria": "Add to message",
+        "addFiles": "Add files",
+        "textPrompt": "Paste or type text to attach:",
+        "addText": "Add text",
+        "quickCommands": "Quick commands",
+        "connectors": "Connectors",
+        "skills": "Skills",
+        "voiceInputAria": "Voice input",
+        "voiceSkillRequired": "Voice transcription requires a voice skill",
+        "stopAria": "Stop",
+        "sendAria": "Send"
+      },
+      "skillChip": {
+        "prefix": "Skill:",
+        "removeAria": "Remove skill"
+      },
+      "slash": {
+        "commandsHeading": "Orca quick commands",
+        "skillsHeading": "Skills",
+        "projectSkillsUnavailable": "Project skills on the remote host were unavailable; showing global skills only.",
+        "explain": {
+          "label": "/explain",
+          "hint": "Explain this code",
+          "template": "Explain how the code in this project works, focusing on "
+        },
+        "review": {
+          "label": "/review",
+          "hint": "Review for bugs",
+          "template": "Review the current changes for bugs, edge cases, and correctness issues."
+        },
+        "tests": {
+          "label": "/tests",
+          "hint": "Write tests",
+          "template": "Write tests covering "
+        },
+        "summarize": {
+          "label": "/summarize",
+          "hint": "Summarize",
+          "template": "Summarize "
+        },
+        "clear": {
+          "label": "/clear",
+          "hint": "Start a new chat"
+        },
+        "resume": {
+          "label": "/resume",
+          "hint": "Reopen last chat"
+        },
+        "skillSource": {
+          "project": "Project skill",
+          "global": "Global skill",
+          "plugin": "Plugin skill"
+        }
+      },
+      "modelPicker": {
+        "auto": "Auto",
+        "modelLabel": "Model",
+        "autoSelect": "Auto-select",
+        "signInRequired": "Sign in required",
+        "customProvider": "Custom provider",
+        "moreProviders": "More providers",
+        "modelListError": "Unable to read model list",
+        "refreshModels": "Refresh model list"
+      },
+      "transcript": {
+        "skillSummary": "Skill: {{value0}}",
+        "attachmentSummary": "Attached: {{value0}}"
+      },
+      "status": {
+        "stopping": "Stopping..."
+      },
+      "empty": {
+        "title": "Message jcode to start",
+        "description": "Replies stream in. Tool calls and diffs render inline."
+      },
+      "projectBadge": {
+        "fallbackProject": "Workspace",
+        "remoteWithHost": "Remote · {{value0}}",
+        "local": "Local",
+        "handsRemoteOn": "Hands remote: on",
+        "handsRemoteOff": "Hands remote: off",
+        "brainLocalAuto": "brain-local (auto)"
+      },
+      "recents": {
+        "heading": "Recent chats",
+        "deleteAria": "Delete chat",
+        "delete": "Delete"
+      },
+      "toolCard": {
+        "running": "Running..."
+      },
+      "provider": {
+        "jcodeSubscription": "Jcode Subscription",
+        "claude": "Claude",
+        "openai": "OpenAI",
+        "gemini": "Gemini",
+        "openrouter": "OpenRouter",
+        "openaiCompatible": "OpenAI-compatible"
+      },
+      "tabLabel": "jcode"
+    },
+    "settings": {
+      "accounts": {
+        "providers": {
+          "requiredFields": "Name, base URL, and model are required.",
+          "addFailed": "Failed to add provider.",
+          "added": "Added provider \"{{value0}}\".",
+          "removed": "Removed provider \"{{value0}}\".",
+          "title": "Custom provider",
+          "formDescription": "Add a custom OpenAI-compatible provider for jcode chat.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-gateway",
+          "modelLabel": "Model",
+          "modelPlaceholder": "gpt-4o",
+          "baseUrlLabel": "Base URL",
+          "baseUrlPlaceholder": "https://llm.example.com/v1",
+          "apiKeyLabel": "API Key",
+          "apiKeyPlaceholder": "sk-... (stored in jcode's private env file)",
+          "authLabel": "Auth",
+          "authBearer": "Bearer",
+          "authApiKeyHeader": "API key header",
+          "authNone": "None",
+          "addProvider": "Add provider",
+          "sectionDescription": "Add a custom OpenAI-compatible endpoint and pick it in the jcode chat composer.",
+          "description": "Add a custom OpenAI-compatible provider for jcode chat."
+        },
+        "mcp": {
+          "readFailed": "Failed to read MCP config.",
+          "requiredFields": "Name and command are required.",
+          "saveFailed": "Failed to save MCP server.",
+          "connected": "Connected \"{{value0}}\". Restart a chat to load its tools.",
+          "removeFailed": "Failed to remove MCP server.",
+          "removed": "Removed \"{{value0}}\".",
+          "title": "MCP connectors",
+          "formDescription": "Connect MCP servers so jcode can use their tools.",
+          "loading": "Loading...",
+          "empty": "No connectors yet.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-connector",
+          "commandLabel": "Command",
+          "commandPlaceholder": "npx",
+          "argsLabel": "Args (one per line)",
+          "argsPlaceholder": "-y\n@modelcontextprotocol/server-filesystem\n/path/to/dir",
+          "envLabel": "Env (KEY=value, one per line)",
+          "envPlaceholder": "API_KEY=...\nREGION=us",
+          "addConnector": "Add connector",
+          "refresh": "Refresh",
+          "storedIn": "Stored in",
+          "restartChatForChanges": "Restart a chat to pick up changes.",
+          "sectionDescription": "Connect MCP servers so jcode can use their tools in chat.",
+          "description": "Connect MCP servers so jcode can use their tools."
+        }
+      }
+    },
+    "sidebar": {
+      "chats": {
+        "time": {
+          "justNow": "just now",
+          "minutesAgo": "{{value0}}m ago",
+          "hoursAgo": "{{value0}}h ago",
+          "daysAgo": "{{value0}}d ago"
+        },
+        "groupAria": "jcode chats",
+        "heading": "jcode chats",
+        "newChatAria": "New jcode chat here",
+        "newChatTitle": "New jcode chat here",
+        "deleteAria": "Delete chat"
+      }
+    },
+    "agentCatalog": {
+      "label": "J-Code"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "クリアスクリーン",
             "8c17d6786d": "ペインを閉じる",
-            "copyTerminalId": "Terminal ID をコピー",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "ペインIDのコピー",
             "39809d152f": "タイトルを設定…",
             "06c2b0f043": "ペインのサイズを均等化する",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "コピー",
             "c2f0b72b8d": "入れる",
             "925f49f210": "ペインを展開する",
-            "df766809e0": "ペインを折りたたむ",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "ペインを折りたたむ"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "デーモンを再起動します",
@@ -6028,7 +6027,9 @@
           "c77f1abfe3": "リモート terminals の終了",
           "18968ede9e": "エラー",
           "f0871e6bfb": "接続",
-          "47e94bd6ba": "接続されています"
+          "47e94bd6ba": "接続されています",
+          "idleNotConnected": "Not connected",
+          "idleNotConnectedHint": "Click “Connect” to start a session (brain-local needs no connection)."
         },
         "SshTargetDestructiveActions": {
           "7e66942808": "これにより、この SSH ターゲット上のアクティブな terminal セッションが停止されます。再接続しても復元されません。",
@@ -8469,8 +8470,8 @@
             "a1f2c8d901": "表示"
           },
           "SourceControl": {
-            "conflictsSection": "競合",
             "1406954883": "すべてのメモをクリアします...",
+            "conflictsSection": "競合",
             "cc05b2d088": "ファイルエクスプローラーで開く",
             "03194cfff4": "ここで開いた競合から派生したローカル セッション状態。",
             "413a3ba113": "競合",
@@ -9106,7 +9107,16 @@
             "daysAgo": "{{value0}}d ago",
             "monthsAgo": "{{value0}}mo ago",
             "yearsAgo": "{{value0}}y ago",
-            "sessionId": "セッション ID"
+            "sessionId": "セッション ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "Resume {{value0}} session",
@@ -9123,7 +9133,14 @@
             "hideDetails": "詳細を非表示",
             "showDetails": "詳細を表示",
             "moreSessionActions": "セッションのその他の操作",
-            "moreActions": "その他の操作"
+            "moreActions": "その他の操作",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "ファイルを検索",
@@ -9167,9 +9184,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "表示"
           }
         }
       },
@@ -11661,6 +11675,189 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    }
+  },
+  "jcode": {
+    "chat": {
+      "attachment": {
+        "pastedWithPreview": "Pasted: {{value0}}…",
+        "pastedText": "Pasted text",
+        "defaultTextName": "Text",
+        "removeAria": "Remove attachment"
+      },
+      "composer": {
+        "placeholder": "Message jcode... (type / for commands)",
+        "addMenuAria": "Add to message",
+        "addFiles": "Add files",
+        "textPrompt": "Paste or type text to attach:",
+        "addText": "Add text",
+        "quickCommands": "Quick commands",
+        "connectors": "Connectors",
+        "skills": "Skills",
+        "voiceInputAria": "Voice input",
+        "voiceSkillRequired": "Voice transcription requires a voice skill",
+        "stopAria": "Stop",
+        "sendAria": "Send"
+      },
+      "skillChip": {
+        "prefix": "Skill:",
+        "removeAria": "Remove skill"
+      },
+      "slash": {
+        "commandsHeading": "Orca quick commands",
+        "skillsHeading": "Skills",
+        "projectSkillsUnavailable": "Project skills on the remote host were unavailable; showing global skills only.",
+        "explain": {
+          "label": "/explain",
+          "hint": "Explain this code",
+          "template": "Explain how the code in this project works, focusing on "
+        },
+        "review": {
+          "label": "/review",
+          "hint": "Review for bugs",
+          "template": "Review the current changes for bugs, edge cases, and correctness issues."
+        },
+        "tests": {
+          "label": "/tests",
+          "hint": "Write tests",
+          "template": "Write tests covering "
+        },
+        "summarize": {
+          "label": "/summarize",
+          "hint": "Summarize",
+          "template": "Summarize "
+        },
+        "clear": {
+          "label": "/clear",
+          "hint": "Start a new chat"
+        },
+        "resume": {
+          "label": "/resume",
+          "hint": "Reopen last chat"
+        },
+        "skillSource": {
+          "project": "Project skill",
+          "global": "Global skill",
+          "plugin": "Plugin skill"
+        }
+      },
+      "modelPicker": {
+        "auto": "Auto",
+        "modelLabel": "Model",
+        "autoSelect": "Auto-select",
+        "signInRequired": "Sign in required",
+        "customProvider": "Custom provider",
+        "moreProviders": "More providers",
+        "modelListError": "Unable to read model list",
+        "refreshModels": "Refresh model list"
+      },
+      "transcript": {
+        "skillSummary": "Skill: {{value0}}",
+        "attachmentSummary": "Attached: {{value0}}"
+      },
+      "status": {
+        "stopping": "Stopping..."
+      },
+      "empty": {
+        "title": "Message jcode to start",
+        "description": "Replies stream in. Tool calls and diffs render inline."
+      },
+      "projectBadge": {
+        "fallbackProject": "Workspace",
+        "remoteWithHost": "Remote · {{value0}}",
+        "local": "Local",
+        "handsRemoteOn": "Hands remote: on",
+        "handsRemoteOff": "Hands remote: off",
+        "brainLocalAuto": "brain-local (auto)"
+      },
+      "recents": {
+        "heading": "Recent chats",
+        "deleteAria": "Delete chat",
+        "delete": "Delete"
+      },
+      "toolCard": {
+        "running": "Running..."
+      },
+      "provider": {
+        "jcodeSubscription": "Jcode Subscription",
+        "claude": "Claude",
+        "openai": "OpenAI",
+        "gemini": "Gemini",
+        "openrouter": "OpenRouter",
+        "openaiCompatible": "OpenAI-compatible"
+      },
+      "tabLabel": "jcode"
+    },
+    "settings": {
+      "accounts": {
+        "providers": {
+          "requiredFields": "Name, base URL, and model are required.",
+          "addFailed": "Failed to add provider.",
+          "added": "Added provider \"{{value0}}\".",
+          "removed": "Removed provider \"{{value0}}\".",
+          "title": "Custom provider",
+          "formDescription": "Add a custom OpenAI-compatible provider for jcode chat.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-gateway",
+          "modelLabel": "Model",
+          "modelPlaceholder": "gpt-4o",
+          "baseUrlLabel": "Base URL",
+          "baseUrlPlaceholder": "https://llm.example.com/v1",
+          "apiKeyLabel": "API Key",
+          "apiKeyPlaceholder": "sk-... (stored in jcode's private env file)",
+          "authLabel": "Auth",
+          "authBearer": "Bearer",
+          "authApiKeyHeader": "API key header",
+          "authNone": "None",
+          "addProvider": "Add provider",
+          "sectionDescription": "Add a custom OpenAI-compatible endpoint and pick it in the jcode chat composer.",
+          "description": "Add a custom OpenAI-compatible provider for jcode chat."
+        },
+        "mcp": {
+          "readFailed": "Failed to read MCP config.",
+          "requiredFields": "Name and command are required.",
+          "saveFailed": "Failed to save MCP server.",
+          "connected": "Connected \"{{value0}}\". Restart a chat to load its tools.",
+          "removeFailed": "Failed to remove MCP server.",
+          "removed": "Removed \"{{value0}}\".",
+          "title": "MCP connectors",
+          "formDescription": "Connect MCP servers so jcode can use their tools.",
+          "loading": "Loading...",
+          "empty": "No connectors yet.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-connector",
+          "commandLabel": "Command",
+          "commandPlaceholder": "npx",
+          "argsLabel": "Args (one per line)",
+          "argsPlaceholder": "-y\n@modelcontextprotocol/server-filesystem\n/path/to/dir",
+          "envLabel": "Env (KEY=value, one per line)",
+          "envPlaceholder": "API_KEY=...\nREGION=us",
+          "addConnector": "Add connector",
+          "refresh": "Refresh",
+          "storedIn": "Stored in",
+          "restartChatForChanges": "Restart a chat to pick up changes.",
+          "sectionDescription": "Connect MCP servers so jcode can use their tools in chat.",
+          "description": "Connect MCP servers so jcode can use their tools."
+        }
+      }
+    },
+    "sidebar": {
+      "chats": {
+        "time": {
+          "justNow": "just now",
+          "minutesAgo": "{{value0}}m ago",
+          "hoursAgo": "{{value0}}h ago",
+          "daysAgo": "{{value0}}d ago"
+        },
+        "groupAria": "jcode chats",
+        "heading": "jcode chats",
+        "newChatAria": "New jcode chat here",
+        "newChatTitle": "New jcode chat here",
+        "deleteAria": "Delete chat"
+      }
+    },
+    "agentCatalog": {
+      "label": "J-Code"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "화면 지우기",
             "8c17d6786d": "창 닫기",
-            "copyTerminalId": "터미널 ID 복사",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "창 ID 복사",
             "39809d152f": "제목 설정…",
             "06c2b0f043": "창 크기 균등화",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "복사",
             "c2f0b72b8d": "삽입",
             "925f49f210": "창 확장",
-            "df766809e0": "창 축소",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "창 축소"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "데몬 재시작",
@@ -5991,7 +5990,9 @@
           "c77f1abfe3": "원격 terminals 종료 중",
           "18968ede9e": "오류",
           "f0871e6bfb": "연결",
-          "47e94bd6ba": "연결됨"
+          "47e94bd6ba": "연결됨",
+          "idleNotConnected": "Not connected",
+          "idleNotConnectedHint": "Click “Connect” to start a session (brain-local needs no connection)."
         },
         "SshTargetDestructiveActions": {
           "7e66942808": "그러면 이 SSH 대상에서 활성 terminal 세션이 중지됩니다. 다시 연결해도 복원되지 않습니다.",
@@ -8469,8 +8470,8 @@
             "a1f2c8d901": "보기"
           },
           "SourceControl": {
-            "conflictsSection": "충돌",
             "1406954883": "모든 메모 지우기...",
+            "conflictsSection": "충돌",
             "cc05b2d088": "파일 탐색기에서 열기",
             "03194cfff4": "여기에서 연 충돌에서 파생된 로컬 세션 상태입니다.",
             "413a3ba113": "충돌",
@@ -9106,7 +9107,16 @@
             "daysAgo": "{{value0}}일 전",
             "monthsAgo": "{{value0}}개월 전",
             "yearsAgo": "{{value0}}년 전",
-            "sessionId": "세션 ID"
+            "sessionId": "세션 ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "{{value0}} 세션 재개",
@@ -9123,7 +9133,14 @@
             "hideDetails": "세부정보 숨기기",
             "showDetails": "세부정보 표시",
             "moreSessionActions": "세션 추가 작업",
-            "moreActions": "추가 작업"
+            "moreActions": "추가 작업",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "파일 찾기",
@@ -9167,9 +9184,6 @@
                 "copyCommand": "명령 복사"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "보기"
           }
         }
       },
@@ -11661,6 +11675,189 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    }
+  },
+  "jcode": {
+    "chat": {
+      "attachment": {
+        "pastedWithPreview": "Pasted: {{value0}}…",
+        "pastedText": "Pasted text",
+        "defaultTextName": "Text",
+        "removeAria": "Remove attachment"
+      },
+      "composer": {
+        "placeholder": "Message jcode... (type / for commands)",
+        "addMenuAria": "Add to message",
+        "addFiles": "Add files",
+        "textPrompt": "Paste or type text to attach:",
+        "addText": "Add text",
+        "quickCommands": "Quick commands",
+        "connectors": "Connectors",
+        "skills": "Skills",
+        "voiceInputAria": "Voice input",
+        "voiceSkillRequired": "Voice transcription requires a voice skill",
+        "stopAria": "Stop",
+        "sendAria": "Send"
+      },
+      "skillChip": {
+        "prefix": "Skill:",
+        "removeAria": "Remove skill"
+      },
+      "slash": {
+        "commandsHeading": "Orca quick commands",
+        "skillsHeading": "Skills",
+        "projectSkillsUnavailable": "Project skills on the remote host were unavailable; showing global skills only.",
+        "explain": {
+          "label": "/explain",
+          "hint": "Explain this code",
+          "template": "Explain how the code in this project works, focusing on "
+        },
+        "review": {
+          "label": "/review",
+          "hint": "Review for bugs",
+          "template": "Review the current changes for bugs, edge cases, and correctness issues."
+        },
+        "tests": {
+          "label": "/tests",
+          "hint": "Write tests",
+          "template": "Write tests covering "
+        },
+        "summarize": {
+          "label": "/summarize",
+          "hint": "Summarize",
+          "template": "Summarize "
+        },
+        "clear": {
+          "label": "/clear",
+          "hint": "Start a new chat"
+        },
+        "resume": {
+          "label": "/resume",
+          "hint": "Reopen last chat"
+        },
+        "skillSource": {
+          "project": "Project skill",
+          "global": "Global skill",
+          "plugin": "Plugin skill"
+        }
+      },
+      "modelPicker": {
+        "auto": "Auto",
+        "modelLabel": "Model",
+        "autoSelect": "Auto-select",
+        "signInRequired": "Sign in required",
+        "customProvider": "Custom provider",
+        "moreProviders": "More providers",
+        "modelListError": "Unable to read model list",
+        "refreshModels": "Refresh model list"
+      },
+      "transcript": {
+        "skillSummary": "Skill: {{value0}}",
+        "attachmentSummary": "Attached: {{value0}}"
+      },
+      "status": {
+        "stopping": "Stopping..."
+      },
+      "empty": {
+        "title": "Message jcode to start",
+        "description": "Replies stream in. Tool calls and diffs render inline."
+      },
+      "projectBadge": {
+        "fallbackProject": "Workspace",
+        "remoteWithHost": "Remote · {{value0}}",
+        "local": "Local",
+        "handsRemoteOn": "Hands remote: on",
+        "handsRemoteOff": "Hands remote: off",
+        "brainLocalAuto": "brain-local (auto)"
+      },
+      "recents": {
+        "heading": "Recent chats",
+        "deleteAria": "Delete chat",
+        "delete": "Delete"
+      },
+      "toolCard": {
+        "running": "Running..."
+      },
+      "provider": {
+        "jcodeSubscription": "Jcode Subscription",
+        "claude": "Claude",
+        "openai": "OpenAI",
+        "gemini": "Gemini",
+        "openrouter": "OpenRouter",
+        "openaiCompatible": "OpenAI-compatible"
+      },
+      "tabLabel": "jcode"
+    },
+    "settings": {
+      "accounts": {
+        "providers": {
+          "requiredFields": "Name, base URL, and model are required.",
+          "addFailed": "Failed to add provider.",
+          "added": "Added provider \"{{value0}}\".",
+          "removed": "Removed provider \"{{value0}}\".",
+          "title": "Custom provider",
+          "formDescription": "Add a custom OpenAI-compatible provider for jcode chat.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-gateway",
+          "modelLabel": "Model",
+          "modelPlaceholder": "gpt-4o",
+          "baseUrlLabel": "Base URL",
+          "baseUrlPlaceholder": "https://llm.example.com/v1",
+          "apiKeyLabel": "API Key",
+          "apiKeyPlaceholder": "sk-... (stored in jcode's private env file)",
+          "authLabel": "Auth",
+          "authBearer": "Bearer",
+          "authApiKeyHeader": "API key header",
+          "authNone": "None",
+          "addProvider": "Add provider",
+          "sectionDescription": "Add a custom OpenAI-compatible endpoint and pick it in the jcode chat composer.",
+          "description": "Add a custom OpenAI-compatible provider for jcode chat."
+        },
+        "mcp": {
+          "readFailed": "Failed to read MCP config.",
+          "requiredFields": "Name and command are required.",
+          "saveFailed": "Failed to save MCP server.",
+          "connected": "Connected \"{{value0}}\". Restart a chat to load its tools.",
+          "removeFailed": "Failed to remove MCP server.",
+          "removed": "Removed \"{{value0}}\".",
+          "title": "MCP connectors",
+          "formDescription": "Connect MCP servers so jcode can use their tools.",
+          "loading": "Loading...",
+          "empty": "No connectors yet.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-connector",
+          "commandLabel": "Command",
+          "commandPlaceholder": "npx",
+          "argsLabel": "Args (one per line)",
+          "argsPlaceholder": "-y\n@modelcontextprotocol/server-filesystem\n/path/to/dir",
+          "envLabel": "Env (KEY=value, one per line)",
+          "envPlaceholder": "API_KEY=...\nREGION=us",
+          "addConnector": "Add connector",
+          "refresh": "Refresh",
+          "storedIn": "Stored in",
+          "restartChatForChanges": "Restart a chat to pick up changes.",
+          "sectionDescription": "Connect MCP servers so jcode can use their tools in chat.",
+          "description": "Connect MCP servers so jcode can use their tools."
+        }
+      }
+    },
+    "sidebar": {
+      "chats": {
+        "time": {
+          "justNow": "just now",
+          "minutesAgo": "{{value0}}m ago",
+          "hoursAgo": "{{value0}}h ago",
+          "daysAgo": "{{value0}}d ago"
+        },
+        "groupAria": "jcode chats",
+        "heading": "jcode chats",
+        "newChatAria": "New jcode chat here",
+        "newChatTitle": "New jcode chat here",
+        "deleteAria": "Delete chat"
+      }
+    },
+    "agentCatalog": {
+      "label": "J-Code"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5991,7 +5991,9 @@
           "c77f1abfe3": "结束远程 terminals",
           "18968ede9e": "错误",
           "f0871e6bfb": "连接",
-          "47e94bd6ba": "已连接"
+          "47e94bd6ba": "已连接",
+          "idleNotConnected": "未连接",
+          "idleNotConnectedHint": "点“连接”启动会话（brain-local 无需连接）。"
         },
         "SshTargetDestructiveActions": {
           "7e66942808": "这将停止此 SSH 目标上的活动 terminal 会话。重新连接不会恢复它们。",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2307,7 +2307,7 @@
           "TerminalContextMenu": {
             "b4cdd9314e": "清晰的屏幕",
             "8c17d6786d": "关闭窗格",
-            "copyTerminalId": "复制终端 ID",
+            "copyTerminalId": "Copy Terminal ID",
             "2cf85a6a55": "复制窗格 ID",
             "39809d152f": "设置标题...",
             "06c2b0f043": "均衡窗格大小",
@@ -2322,8 +2322,7 @@
             "f3eeb1de13": "复制",
             "c2f0b72b8d": "插入",
             "925f49f210": "展开窗格",
-            "df766809e0": "折叠窗格",
-            "copyTerminalId": "Copy Terminal ID"
+            "df766809e0": "折叠窗格"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "重新启动守护进程",
@@ -8471,8 +8470,8 @@
             "a1f2c8d901": "查看"
           },
           "SourceControl": {
-            "conflictsSection": "冲突",
             "1406954883": "清除所有笔记...",
+            "conflictsSection": "冲突",
             "cc05b2d088": "在文件资源管理器中打开",
             "03194cfff4": "本地会话状态源自您在此处打开的冲突。",
             "413a3ba113": "冲突",
@@ -9108,7 +9107,16 @@
             "daysAgo": "{{value0}} 天前",
             "monthsAgo": "{{value0}} 个月前",
             "yearsAgo": "{{value0}} 年前",
-            "sessionId": "会话 ID"
+            "sessionId": "会话 ID",
+            "originalAsk": "Original ask",
+            "latestTurns": "Latest turns",
+            "noPreviewAvailable": "No conversation preview available",
+            "messageCount": "{{value0}} msgs",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "AiVaultSessionRow": {
             "resumeAgentSession": "恢复 {{value0}} 会话",
@@ -9125,7 +9133,14 @@
             "hideDetails": "隐藏详情",
             "showDetails": "显示详情",
             "moreSessionActions": "更多会话操作",
-            "moreActions": "更多操作"
+            "moreActions": "更多操作",
+            "noPreviewAvailable": "No conversation preview available",
+            "dragToResume": "Drag to resume in a new tab",
+            "userRole": "You",
+            "agentRole": "Agent",
+            "toolRole": "Tool",
+            "systemRole": "System",
+            "sessionRole": "Session"
           },
           "FileExplorerNameFilter": {
             "26fb73c6e3": "查找文件",
@@ -9169,9 +9184,6 @@
                 "copyCommand": "Copy command"
               }
             }
-          },
-          "SourceControlEntryContextMenu": {
-            "a1f2c8d901": "查看"
           }
         }
       },
@@ -11663,6 +11675,189 @@
           "91b5c8d7e6": "GitLab"
         }
       }
+    }
+  },
+  "jcode": {
+    "chat": {
+      "attachment": {
+        "pastedWithPreview": "Pasted: {{value0}}…",
+        "pastedText": "Pasted text",
+        "defaultTextName": "Text",
+        "removeAria": "Remove attachment"
+      },
+      "composer": {
+        "placeholder": "Message jcode... (type / for commands)",
+        "addMenuAria": "Add to message",
+        "addFiles": "Add files",
+        "textPrompt": "Paste or type text to attach:",
+        "addText": "Add text",
+        "quickCommands": "Quick commands",
+        "connectors": "Connectors",
+        "skills": "Skills",
+        "voiceInputAria": "Voice input",
+        "voiceSkillRequired": "Voice transcription requires a voice skill",
+        "stopAria": "Stop",
+        "sendAria": "Send"
+      },
+      "skillChip": {
+        "prefix": "Skill:",
+        "removeAria": "Remove skill"
+      },
+      "slash": {
+        "commandsHeading": "Orca quick commands",
+        "skillsHeading": "Skills",
+        "projectSkillsUnavailable": "Project skills on the remote host were unavailable; showing global skills only.",
+        "explain": {
+          "label": "/explain",
+          "hint": "Explain this code",
+          "template": "Explain how the code in this project works, focusing on "
+        },
+        "review": {
+          "label": "/review",
+          "hint": "Review for bugs",
+          "template": "Review the current changes for bugs, edge cases, and correctness issues."
+        },
+        "tests": {
+          "label": "/tests",
+          "hint": "Write tests",
+          "template": "Write tests covering "
+        },
+        "summarize": {
+          "label": "/summarize",
+          "hint": "Summarize",
+          "template": "Summarize "
+        },
+        "clear": {
+          "label": "/clear",
+          "hint": "Start a new chat"
+        },
+        "resume": {
+          "label": "/resume",
+          "hint": "Reopen last chat"
+        },
+        "skillSource": {
+          "project": "Project skill",
+          "global": "Global skill",
+          "plugin": "Plugin skill"
+        }
+      },
+      "modelPicker": {
+        "auto": "Auto",
+        "modelLabel": "Model",
+        "autoSelect": "Auto-select",
+        "signInRequired": "Sign in required",
+        "customProvider": "Custom provider",
+        "moreProviders": "More providers",
+        "modelListError": "Unable to read model list",
+        "refreshModels": "Refresh model list"
+      },
+      "transcript": {
+        "skillSummary": "Skill: {{value0}}",
+        "attachmentSummary": "Attached: {{value0}}"
+      },
+      "status": {
+        "stopping": "Stopping..."
+      },
+      "empty": {
+        "title": "Message jcode to start",
+        "description": "Replies stream in. Tool calls and diffs render inline."
+      },
+      "projectBadge": {
+        "fallbackProject": "Workspace",
+        "remoteWithHost": "Remote · {{value0}}",
+        "local": "Local",
+        "handsRemoteOn": "Hands remote: on",
+        "handsRemoteOff": "Hands remote: off",
+        "brainLocalAuto": "brain-local (auto)"
+      },
+      "recents": {
+        "heading": "Recent chats",
+        "deleteAria": "Delete chat",
+        "delete": "Delete"
+      },
+      "toolCard": {
+        "running": "Running..."
+      },
+      "provider": {
+        "jcodeSubscription": "Jcode Subscription",
+        "claude": "Claude",
+        "openai": "OpenAI",
+        "gemini": "Gemini",
+        "openrouter": "OpenRouter",
+        "openaiCompatible": "OpenAI-compatible"
+      },
+      "tabLabel": "jcode"
+    },
+    "settings": {
+      "accounts": {
+        "providers": {
+          "requiredFields": "Name, base URL, and model are required.",
+          "addFailed": "Failed to add provider.",
+          "added": "Added provider \"{{value0}}\".",
+          "removed": "Removed provider \"{{value0}}\".",
+          "title": "Custom provider",
+          "formDescription": "Add a custom OpenAI-compatible provider for jcode chat.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-gateway",
+          "modelLabel": "Model",
+          "modelPlaceholder": "gpt-4o",
+          "baseUrlLabel": "Base URL",
+          "baseUrlPlaceholder": "https://llm.example.com/v1",
+          "apiKeyLabel": "API Key",
+          "apiKeyPlaceholder": "sk-... (stored in jcode's private env file)",
+          "authLabel": "Auth",
+          "authBearer": "Bearer",
+          "authApiKeyHeader": "API key header",
+          "authNone": "None",
+          "addProvider": "Add provider",
+          "sectionDescription": "Add a custom OpenAI-compatible endpoint and pick it in the jcode chat composer.",
+          "description": "Add a custom OpenAI-compatible provider for jcode chat."
+        },
+        "mcp": {
+          "readFailed": "Failed to read MCP config.",
+          "requiredFields": "Name and command are required.",
+          "saveFailed": "Failed to save MCP server.",
+          "connected": "Connected \"{{value0}}\". Restart a chat to load its tools.",
+          "removeFailed": "Failed to remove MCP server.",
+          "removed": "Removed \"{{value0}}\".",
+          "title": "MCP connectors",
+          "formDescription": "Connect MCP servers so jcode can use their tools.",
+          "loading": "Loading...",
+          "empty": "No connectors yet.",
+          "nameLabel": "Name",
+          "namePlaceholder": "my-connector",
+          "commandLabel": "Command",
+          "commandPlaceholder": "npx",
+          "argsLabel": "Args (one per line)",
+          "argsPlaceholder": "-y\n@modelcontextprotocol/server-filesystem\n/path/to/dir",
+          "envLabel": "Env (KEY=value, one per line)",
+          "envPlaceholder": "API_KEY=...\nREGION=us",
+          "addConnector": "Add connector",
+          "refresh": "Refresh",
+          "storedIn": "Stored in",
+          "restartChatForChanges": "Restart a chat to pick up changes.",
+          "sectionDescription": "Connect MCP servers so jcode can use their tools in chat.",
+          "description": "Connect MCP servers so jcode can use their tools."
+        }
+      }
+    },
+    "sidebar": {
+      "chats": {
+        "time": {
+          "justNow": "just now",
+          "minutesAgo": "{{value0}}m ago",
+          "hoursAgo": "{{value0}}h ago",
+          "daysAgo": "{{value0}}d ago"
+        },
+        "groupAria": "jcode chats",
+        "heading": "jcode chats",
+        "newChatAria": "New jcode chat here",
+        "newChatTitle": "New jcode chat here",
+        "deleteAria": "Delete chat"
+      }
+    },
+    "agentCatalog": {
+      "label": "J-Code"
     }
   }
 }

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -279,6 +279,12 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     cmd: 'openclaw',
     faviconDomain: 'openclaw.ai',
     homepageUrl: 'https://github.com/openclaw/openclaw'
+  },
+  {
+    id: 'jcode',
+    label: 'J-Code',
+    cmd: 'jcode',
+    homepageUrl: 'https://github.com/1jehuang/jcode'
   }
 ])
 

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -282,7 +282,7 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
   },
   {
     id: 'jcode',
-    label: 'J-Code',
+    label: translate('jcode.agentCatalog.label', 'J-Code'),
     cmd: 'jcode',
     homepageUrl: 'https://github.com/1jehuang/jcode'
   }

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -188,7 +188,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   copilot: true,
   grok: true,
   devin: true,
-  ante: true
+  ante: true,
+  jcode: true
 }
 
 export function agentTypeToIconAgent(agentType: AgentType | null | undefined): TuiAgent | null {

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -22,6 +22,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+import { launchChatAgentTab } from '@/lib/launch-chat-agent-tab'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import type { TuiAgent } from '../../../shared/types'
 import type { LaunchSource } from '../../../shared/telemetry-events'
@@ -123,6 +124,15 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   const store = useAppStore.getState()
   const worktree = store.allWorktrees?.().find((entry: { id: string }) => entry.id === worktreeId)
   const repo = worktree ? store.repos?.find((entry) => entry.id === worktree.repoId) : null
+
+  // Why: chat-mode agents (jcode, M1) bypass the PTY/terminal startup machinery
+  // entirely — they render in a 'chat' tab driven by ChatPane (`jcode run
+  // --ndjson`). Consuming renderMode here is what makes the chat view reachable
+  // at runtime instead of falling back to a bare terminal.
+  if (TUI_AGENT_CONFIG[agent].renderMode === 'chat') {
+    return launchChatAgentTab({ agent, worktreeId, groupId, quickCommandLabel })
+  }
+
   const resolvedLaunchPlatform =
     launchPlatform ??
     (repo

--- a/src/renderer/src/lib/launch-chat-agent-tab.ts
+++ b/src/renderer/src/lib/launch-chat-agent-tab.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '@/store'
+import { translate } from '@/i18n/i18n'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import type { TuiAgent } from '../../../shared/types'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
@@ -33,7 +34,7 @@ export function launchChatAgentTab(args: {
   const store = useAppStore.getState()
   const chatTab = store.createUnifiedTab(worktreeId, 'chat', {
     ...(groupId ? { targetGroupId: groupId } : {}),
-    label: 'jcode',
+    label: translate('jcode.chat.tabLabel', 'jcode'),
     ...(quickCommandLabel !== undefined ? { quickCommandLabel } : {}),
     activate: true
   })
@@ -106,7 +107,7 @@ export async function reopenChatConversation(args: {
     // Critical: reuse the stored sessionKey as the tab id so store keys match.
     id: conversation.sessionKey,
     ...(groupId ? { targetGroupId: groupId } : {}),
-    label: 'jcode',
+    label: translate('jcode.chat.tabLabel', 'jcode'),
     activate: true
   })
   store.setActiveTabType('editor')

--- a/src/renderer/src/lib/launch-chat-agent-tab.ts
+++ b/src/renderer/src/lib/launch-chat-agent-tab.ts
@@ -1,0 +1,54 @@
+import { useAppStore } from '@/store'
+import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+import type { TuiAgent } from '../../../shared/types'
+import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+
+export type ChatAgentLaunchResult = {
+  tabId: string
+  startupPlan: AgentStartupPlan
+  pasteDraftAfterLaunch: boolean
+}
+
+/**
+ * Launch a chat-mode agent (jcode, M1) into a 'chat' content-type tab.
+ *
+ * Why: chat-mode agents are not hosted in an xterm PTY. They run headless via
+ * `jcode run --ndjson` inside ChatPane, which spawns its own child process per
+ * turn. So instead of building a shell startup command and a terminal tab, we
+ * create a unified tab with contentType 'chat' and flip the visible surface to
+ * editor (chat maps to the editor visible-tab type). This is the wiring that
+ * makes TUI_AGENT_CONFIG[agent].renderMode === 'chat' actually reach
+ * TabGroupPanel's chat render branch — without it the chat view is unreachable
+ * and the agent falls back to a bare terminal.
+ */
+export function launchChatAgentTab(args: {
+  agent: TuiAgent
+  worktreeId: string
+  groupId?: string
+  quickCommandLabel?: string | null
+}): ChatAgentLaunchResult {
+  const { agent, worktreeId, groupId, quickCommandLabel } = args
+  const store = useAppStore.getState()
+  const chatTab = store.createUnifiedTab(worktreeId, 'chat', {
+    ...(groupId ? { targetGroupId: groupId } : {}),
+    label: 'jcode',
+    ...(quickCommandLabel !== undefined ? { quickCommandLabel } : {}),
+    activate: true
+  })
+  // Why: 'chat' maps to the 'editor' visible-tab type (see toVisibleTabType),
+  // so the worktree must show the editor surface or the new chat tab stays
+  // hidden behind whatever terminal/browser surface was active.
+  store.setActiveTabType('editor')
+  return {
+    tabId: chatTab.id,
+    // Why: chat mode has no shell startup command; surface a minimal plan so
+    // callers keep the non-null result contract (QuickLaunch reads tabId).
+    startupPlan: {
+      agent,
+      launchCommand: '',
+      expectedProcess: TUI_AGENT_CONFIG[agent].expectedProcess,
+      followupPrompt: null
+    },
+    pasteDraftAfterLaunch: false
+  }
+}

--- a/src/renderer/src/lib/launch-chat-agent-tab.ts
+++ b/src/renderer/src/lib/launch-chat-agent-tab.ts
@@ -2,6 +2,8 @@ import { useAppStore } from '@/store'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import type { TuiAgent } from '../../../shared/types'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+import { hydrateChatSession, loadChatConversation } from '@/components/chat-pane/chat-session-store'
+import type { JcodeConversationSummary } from '../../../shared/jcode-chat-types'
 
 export type ChatAgentLaunchResult = {
   tabId: string
@@ -51,4 +53,62 @@ export function launchChatAgentTab(args: {
     },
     pasteDraftAfterLaunch: false
   }
+}
+
+/**
+ * Reopen a previously-closed (or restart-lost) jcode chat conversation.
+ *
+ * Why (BUG 1/2, reopen): jcode chat tabs are unified tabs whose conversation
+ * lives in chat-session-store keyed by the tab id (== sessionKey). A closed chat
+ * leaves a durable on-disk record (see jcode-conversation-store). To reopen it we
+ * recreate a unified 'chat' tab with the SAME id as the stored sessionKey so the
+ * store key lines up, then rehydrate that key from disk. Using the stored
+ * worktreeId keeps the tab in its original group; callers that no longer have
+ * that worktree must pass a fallback.
+ *
+ * Returns the (re)created tab id, or null when no worktree context is available.
+ */
+export async function reopenChatConversation(args: {
+  conversation: Pick<JcodeConversationSummary, 'sessionKey' | 'worktreeId'>
+  /** Used when the stored worktreeId is missing (worktree gone since restart). */
+  fallbackWorktreeId?: string
+  groupId?: string
+}): Promise<string | null> {
+  const { conversation, fallbackWorktreeId, groupId } = args
+  const worktreeId = conversation.worktreeId ?? fallbackWorktreeId
+  if (!worktreeId) {
+    // Why: a chat tab must live in some worktree/group. With neither the stored
+    // worktree nor a fallback we cannot place it; caller should supply a fallback.
+    return null
+  }
+
+  const store = useAppStore.getState()
+
+  // If a tab with this id is already open, just activate it (idempotent reopen).
+  const existing = (store.unifiedTabsByWorktree[worktreeId] ?? []).find(
+    (tab) => tab.id === conversation.sessionKey
+  )
+  if (existing) {
+    store.activateTab(conversation.sessionKey)
+    store.setActiveTabType('editor')
+    return conversation.sessionKey
+  }
+
+  // Rehydrate the in-memory store BEFORE the tab mounts so ChatPane paints the
+  // restored transcript immediately (ChatPane also rehydrates on mount as a
+  // belt-and-suspenders path, but that one is a no-op once we've seeded here).
+  const record = await loadChatConversation(conversation.sessionKey)
+  if (record) {
+    hydrateChatSession(record)
+  }
+
+  const chatTab = store.createUnifiedTab(worktreeId, 'chat', {
+    // Critical: reuse the stored sessionKey as the tab id so store keys match.
+    id: conversation.sessionKey,
+    ...(groupId ? { targetGroupId: groupId } : {}),
+    label: 'jcode',
+    activate: true
+  })
+  store.setActiveTabType('editor')
+  return chatTab.id
 }

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -11,6 +11,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { collectSleepingAgentSessionRecordsForWorktree } from '@/store/slices/agent-status'
 import { translate } from '@/i18n/i18n'
 
 function getResumeLaunchPlatform(worktreeId: string): NodeJS.Platform {
@@ -87,6 +88,35 @@ function launchSleepingAgentSession(record: SleepingAgentSessionRecord): boolean
   state.setActiveTabType('terminal')
   appendTabToWorktreeOrder(record.worktreeId, tab.id)
   return true
+}
+
+/**
+ * Resume a single RETAINED ("done") agent row by its paneKey, restoring the
+ * past Claude/Hermes session instead of leaving the row inert.
+ *
+ * Why (GOAL 2, blank-terminal fix): a retained agent's tab/PTY is gone, so the
+ * sidebar's handleActivateRetainedAgent was an intentional no-op — clicking it
+ * did nothing (and a stale tab activation would render a blank terminal). But
+ * orca already captures a resumable session id for done agents: a retained
+ * entry whose agentType is resumable and that carries a providerSession can be
+ * converted into a SleepingAgentSessionRecord and relaunched through the SAME
+ * proven path worktree activation uses (buildAgentResumeStartupPlan ->
+ * `<agent> --resume <id>`), which makes the CLI replay/continue the prior
+ * session in a fresh terminal tab. This reuses collectSleepingAgentSessionRecordsForWorktree
+ * (no origin -> not filtered) so we don't duplicate the record-shaping logic.
+ *
+ * Returns true when a session was relaunched; false when the row is not
+ * resumable (no resumable agentType / no providerSession), in which case the
+ * caller should keep its prior inert behavior.
+ */
+export function resumeRetainedAgentByPaneKey(worktreeId: string, paneKey: string): boolean {
+  const state = useAppStore.getState()
+  const records = collectSleepingAgentSessionRecordsForWorktree(state, worktreeId, [paneKey])
+  const record = records[paneKey]
+  if (!record) {
+    return false
+  }
+  return launchSleepingAgentSession(record)
 }
 
 export function resumeSleepingAgentSessionsForWorktree(worktreeId: string): number {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -702,6 +702,8 @@ export type RepoSlice = {
         | 'pendingFirstAgentMessageRename'
         | 'firstAgentMessageRenameError'
         | 'lastActivityAt'
+        | 'connectionId'
+        | 'isRemoteExecOnly'
       >
     >
   ) => Promise<boolean>

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -1782,6 +1782,55 @@ describe('TabsSlice', () => {
       })
     })
 
+    // Why: regression for the jcode chat tab vanishing from the tab bar after
+    // switching worktrees and back. Reconcile runs on every worktree activation;
+    // a 'chat' tab has no runtime liveness collection (its conversation lives in
+    // chat-session-store keyed by tab id), so before the fix it fell through to
+    // the editor liveness check and was dropped from validTabs / group.tabOrder.
+    it('keeps chat tabs because their conversation state lives outside the tab model', () => {
+      const groupId = 'g-chat'
+      store.setState({
+        unifiedTabsByWorktree: {
+          [WT]: [
+            {
+              id: 'chat-1',
+              entityId: 'chat-1',
+              groupId,
+              worktreeId: WT,
+              contentType: 'chat',
+              label: 'jcode',
+              customLabel: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        groupsByWorktree: {
+          [WT]: [
+            {
+              id: groupId,
+              worktreeId: WT,
+              activeTabId: 'chat-1',
+              tabOrder: ['chat-1']
+            }
+          ]
+        },
+        layoutByWorktree: { [WT]: { type: 'leaf', groupId } },
+        activeGroupIdByWorktree: { [WT]: groupId },
+        tabsByWorktree: { [WT]: [] }
+      })
+
+      const result = store.getState().reconcileWorktreeTabModel(WT)
+      const state = store.getState()
+
+      expect(result.renderableTabCount).toBe(1)
+      expect(result.activeRenderableTabId).toBe('chat-1')
+      expect(state.unifiedTabsByWorktree[WT].map((tab) => tab.id)).toEqual(['chat-1'])
+      expect(state.groupsByWorktree[WT][0].tabOrder).toEqual(['chat-1'])
+      expect(state.groupsByWorktree[WT][0].activeTabId).toBe('chat-1')
+    })
+
     it('collapses empty split groups when reconciliation drops a stale tab', () => {
       const terminalGroupId = 'g-terminal'
       const staleGroupId = 'g-stale'

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -1732,6 +1732,19 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       if (tab.contentType === 'simulator') {
         return true
       }
+      // Why: jcode 'chat' tabs (ChatPane) have no runtime liveness collection
+      // the way terminals (PTYs), editors (openFiles), and browsers
+      // (browserTabsByWorktree) do — a chat tab is "live" simply by existing in
+      // the unified tab model, with its conversation kept in chat-session-store
+      // keyed by the tab id. Without this branch a chat tab falls through to the
+      // editor check below, where liveEditorIds never contains its entityId, so
+      // it is filtered out of validTabs and dropped from group.tabOrder. That is
+      // exactly why a chat tab vanished from the tab bar after switching away
+      // from its worktree and back (reconcileWorktreeTabModel runs on each
+      // activation). Treat chat like simulator: always renderable while present.
+      if (tab.contentType === 'chat') {
+        return true
+      }
       return liveEditorIds.has(tab.entityId)
     }
 

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -46,7 +46,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   copilot: 'copilot',
   grok: 'grok',
   devin: 'devin',
-  ante: 'ante'
+  ante: 'ante',
+  jcode: 'jcode'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -32,6 +32,7 @@ export type WellKnownAgentType =
   | 'hermes'
   | 'devin'
   | 'ante'
+  | 'jcode'
   | 'unknown'
 export type AgentType = WellKnownAgentType | (string & {})
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -308,6 +308,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     opencodeSessionCookie: '',
     opencodeWorkspaceId: '',
     geminiCliOAuthEnabled: false,
+    jcodeCustomProviders: [],
     agentCmdOverrides: {},
     agentDefaultArgs: { ...DEFAULT_TUI_AGENT_ARGS },
     agentDefaultEnv: { ...DEFAULT_TUI_AGENT_ENV },

--- a/src/shared/folder-workspaces.ts
+++ b/src/shared/folder-workspaces.ts
@@ -106,6 +106,9 @@ export function normalizeFolderWorkspaces(
           : raw.connectionId === null
             ? null
             : (group?.connectionId ?? null),
+      // brain-local / hands-remote (M3): persist the opt-in flag. Only emit the
+      // key when true so existing (local) workspaces serialize unchanged.
+      ...(raw.isRemoteExecOnly === true ? { isRemoteExecOnly: true } : {}),
       linkedTask: normalizeFolderWorkspaceLinkedTask(raw.linkedTask),
       comment: typeof raw.comment === 'string' ? raw.comment : '',
       isArchived: raw.isArchived === true,

--- a/src/shared/jcode-chat-types.ts
+++ b/src/shared/jcode-chat-types.ts
@@ -135,6 +135,53 @@ export type JcodeSkillsListPayload = {
 
 export const JCODE_SKILLS_LIST_CHANNEL = 'jcode-skills:list'
 
+// ─── MCP servers / connectors ───────────────────────────────────────────────
+// jcode loads stdio MCP servers from ~/.jcode/mcp.json (Claude-Desktop format:
+// { "servers": { "<name>": { command, args, env, shared } } }) and exposes their
+// tools to the agent. orca manages the GLOBAL file so the user can add/remove
+// connectors from the GUI. Remote/hosted MCP servers work via a stdio bridge,
+// e.g. command "npx", args ["mcp-remote", "https://…"].
+
+/** Renderer -> main: read the global ~/.jcode/mcp.json server list. */
+export const JCODE_MCP_GET_CHANNEL = 'jcodeMcp:get'
+/** Renderer -> main: overwrite the global ~/.jcode/mcp.json server list. */
+export const JCODE_MCP_SET_CHANNEL = 'jcodeMcp:set'
+
+/** One stdio MCP server entry (mirrors jcode's McpServerConfig). */
+export type JcodeMcpServer = {
+  /** Server name == its key in mcp.json. */
+  name: string
+  /** Executable to spawn (stdio transport), e.g. "npx" or an absolute path. */
+  command: string
+  /** Arguments passed to the command. */
+  args: string[]
+  /** Extra environment variables for the child process. */
+  env: Record<string, string>
+  /** Whether the server may be shared across sessions (jcode default: true). */
+  shared: boolean
+}
+
+/** Result of jcodeMcp:get. */
+export type JcodeMcpConfigResult = {
+  ok: boolean
+  error?: string
+  /** Servers from the global ~/.jcode/mcp.json (the file orca manages). */
+  servers: JcodeMcpServer[]
+  /** Absolute path to the managed file (shown in the UI). */
+  path?: string
+}
+
+/** Renderer -> main args for jcodeMcp:set. */
+export type JcodeMcpSetArgs = {
+  servers: JcodeMcpServer[]
+}
+
+/** Result of jcodeMcp:set. */
+export type JcodeMcpActionResult = {
+  ok: boolean
+  error?: string
+}
+
 /** Authentication style jcode uses for a custom OpenAI-compatible provider. */
 export type JcodeProviderAuth = 'bearer' | 'api-key' | 'none'
 
@@ -178,6 +225,36 @@ export type JcodeProviderActionResult = {
 
 export const JCODE_PROVIDERS_LIST_CHANNEL = 'jcodeProviders:list'
 export const JCODE_PROVIDERS_ADD_CHANNEL = 'jcodeProviders:add'
+/** Renderer -> main: shell `jcode model list --json` for the real model catalog
+ *  (provider/availability/routes) used by the composer's detailed model picker. */
+export const JCODE_MODELS_LIST_CHANNEL = 'jcodeProviders:listModels'
+
+/** One per-model route from `jcode model list --json`: which provider serves the
+ *  model, the auth method, and whether it's usable right now (authed). */
+export type JcodeModelRoute = {
+  /** Provider DISPLAY name as jcode reports it, e.g. "OpenAI", "Anthropic". */
+  provider: string
+  model: string
+  /** Auth method, e.g. "oauth" | "api_key". Informational. */
+  method?: string
+  /** True when this model can be used now (provider is authed). */
+  available: boolean
+}
+
+/** Parsed result of `jcode model list --json` for the composer picker. */
+export type JcodeModelCatalog = {
+  ok: boolean
+  /** Normalized error message when ok === false. */
+  error?: string
+  /** Currently resolved provider display name (what "Auto" picks). */
+  provider?: string
+  /** Currently resolved model id (what "Auto" picks). */
+  selectedModel?: string
+  /** Flat list of model ids in the resolved provider's catalog. */
+  models: string[]
+  /** Per-model provider + availability routing. */
+  routes: JcodeModelRoute[]
+}
 
 export const JCODE_CHAT_SEND_CHANNEL = 'jcode-chat:send'
 export const JCODE_CHAT_STOP_CHANNEL = 'jcode-chat:stop'

--- a/src/shared/jcode-chat-types.ts
+++ b/src/shared/jcode-chat-types.ts
@@ -1,0 +1,42 @@
+// Why: shared between the main-process jcode chat session spawner and the
+// renderer ChatPane so both agree on the IPC payload shape. jcode emits
+// newline-delimited JSON ("--ndjson"); we forward each parsed object verbatim
+// as `event` plus a synthetic `sessionKey` so the renderer can route events to
+// the correct chat pane.
+
+/** One parsed jcode --ndjson line. Loosely typed on purpose: jcode owns the
+ *  schema and may add event kinds; the renderer switches on `type` and ignores
+ *  unknown kinds. The documented kinds (see HANDOFF / M1 brief) are:
+ *  start | status_detail | connection_phase | connection_type | tool_start |
+ *  tool_input | tool_exec | tool_done | text_delta | message_end | tokens |
+ *  done | error. */
+export type JcodeNdjsonEvent = {
+  type: string
+  [key: string]: unknown
+}
+
+/** Envelope the main process sends to the renderer over 'jcode-chat:event'. */
+export type JcodeChatEventMessage = {
+  sessionKey: string
+  event: JcodeNdjsonEvent
+}
+
+/** Payload the renderer sends over 'jcode-chat:send' to start one turn. */
+export type JcodeChatSendPayload = {
+  /** Stable per-pane key (tab/worktree id) used to route events back. */
+  sessionKey: string
+  prompt: string
+  /** jcode provider id, e.g. 'openai'. */
+  provider?: string
+  /** jcode model id, e.g. 'gpt-5.5'. */
+  model?: string
+  /** Working directory passed to jcode via -C. */
+  cwd?: string
+  /** jcode session id (from a prior 'start'/'done' event) to continue a turn. */
+  resumeSessionId?: string
+  /** brain-local (M3): only bash runs over SSH on this host. Wired now, used later. */
+  remoteExecHost?: string
+}
+
+export const JCODE_CHAT_SEND_CHANNEL = 'jcode-chat:send'
+export const JCODE_CHAT_EVENT_CHANNEL = 'jcode-chat:event'

--- a/src/shared/jcode-chat-types.ts
+++ b/src/shared/jcode-chat-types.ts
@@ -40,7 +40,14 @@ export type JcodeChatSendPayload = {
   cwd?: string
   /** jcode session id (from a prior 'start'/'done' event) to continue a turn. */
   resumeSessionId?: string
-  /** brain-local (M3): only bash runs over SSH on this host. Wired now, used later. */
+  /** Worktree / folder-workspace key for this chat pane. The MAIN process uses
+   *  it to resolve brain-local (M3) state authoritatively from its Store: if the
+   *  folder workspace is `isRemoteExecOnly`, jcode is spawned LOCALLY with
+   *  `--remote-exec <host>` (host from the workspace's SSH target). */
+  worktreeId?: string
+  /** brain-local (M3): explicit override for the remote-exec host. Normally the
+   *  main process resolves the host from `worktreeId`; this is only honored when
+   *  no worktree-derived host is available (e.g. ad-hoc callers). */
   remoteExecHost?: string
 }
 

--- a/src/shared/jcode-chat-types.ts
+++ b/src/shared/jcode-chat-types.ts
@@ -80,7 +80,60 @@ export type JcodeChatSendPayload = {
    *  main process resolves the host from `worktreeId`; this is only honored when
    *  no worktree-derived host is available (e.g. ad-hoc callers). */
   remoteExecHost?: string
+  /** FEATURE B: name of a skill the user picked from the "/" menu. The main
+   *  process re-discovers it (cwd + worktreeId) and prepends its SKILL.md body to
+   *  the prompt so the headless model follows it. Kept out of the transcript
+   *  bubble (the renderer shows only the user's text + a small skill chip). */
+  skillName?: string
 }
+
+// ─── FEATURE B: project-specific skills in the "/" menu ─────────────────────
+// jcode headless has no native skill loader. "Skills" are SKILL.md files (YAML
+// frontmatter `name` + `description`/`when_to_use`, body = instructions) living
+// in three source classes: project-local <projectRoot>/.claude/skills/<name>/,
+// global ~/.claude/skills/<name>/ (mostly symlinks), and plugin skill dirs from
+// ~/.claude/plugins/installed_plugins.json. The main process discovers + parses
+// them; on select, the chosen skill's BODY is injected into the outgoing prompt
+// so the headless model follows it (no jcode-binary change required).
+
+/** Where a discovered skill came from (for grouping/precedence in the menu). */
+export type JcodeSkillSource = 'project' | 'global' | 'plugin'
+
+/** One discovered SKILL.md. `body` is the post-frontmatter instruction text that
+ *  is injected into the prompt when the skill is selected. */
+export type JcodeSkill = {
+  /** Skill name (frontmatter `name`, or the directory name). Plugin skills are
+   *  namespaced as `plugin:skill` to mirror Claude Code and avoid collisions. */
+  name: string
+  /** One-line-ish summary (frontmatter `description` || `when_to_use`). */
+  description: string
+  /** Instruction body after the frontmatter, injected on select. */
+  body: string
+  source: JcodeSkillSource
+  /** Owning plugin id for `source === 'plugin'` (e.g. superpowers@marketplace). */
+  pluginId?: string
+}
+
+/** Result of a skills-list call. `degraded` is true when a remote project's
+ *  project-local skills could not be read (no live SSH connection), so only
+ *  global + plugin skills are returned. */
+export type JcodeSkillsListResult = {
+  skills: JcodeSkill[]
+  /** True when project-local (remote) skills were unavailable; UI may note it. */
+  degraded?: boolean
+}
+
+/** Renderer -> main payload to list skills for the current chat pane. */
+export type JcodeSkillsListPayload = {
+  /** Project root for project-local `.claude/skills` discovery (the pane's cwd).
+   *  For a remote worktree this is the REMOTE path; main resolves the SSH target
+   *  from `worktreeId` and reads it over the connection. */
+  cwd?: string
+  /** Worktree / folder-workspace key so main can resolve a remote project. */
+  worktreeId?: string
+}
+
+export const JCODE_SKILLS_LIST_CHANNEL = 'jcode-skills:list'
 
 /** Authentication style jcode uses for a custom OpenAI-compatible provider. */
 export type JcodeProviderAuth = 'bearer' | 'api-key' | 'none'

--- a/src/shared/jcode-chat-types.ts
+++ b/src/shared/jcode-chat-types.ts
@@ -54,3 +54,66 @@ export type JcodeChatSendPayload = {
 export const JCODE_CHAT_SEND_CHANNEL = 'jcode-chat:send'
 export const JCODE_CHAT_STOP_CHANNEL = 'jcode-chat:stop'
 export const JCODE_CHAT_EVENT_CHANNEL = 'jcode-chat:event'
+
+// ─── Durable persistence (BUG 1/2) ─────────────────────────────────────────
+// jcode conversations are mirrored to disk in the main process so they survive
+// app restart and a closed chat tab can be reopened + rehydrated. The renderer
+// keeps its in-memory external store as the live layer; disk is the backing
+// store. A conversation is keyed by `sessionKey` (the chat tab id), which the
+// renderer recreates with a stable id on reopen so the keys line up.
+
+/** A single persisted chat message (mirrors the renderer ChatMessage, but with
+ *  the tool-call shape kept structural so shared code needn't import renderer
+ *  types). Loosely typed `tools` because the tool-card shape lives in the
+ *  renderer; the store round-trips it verbatim. */
+export type JcodePersistedMessage = {
+  id: string
+  role: 'user' | 'assistant'
+  text: string
+  tools?: unknown[]
+  isError?: boolean
+}
+
+/** The full on-disk record for one conversation. */
+export type JcodeConversationRecord = {
+  /** Stable conversation id == the chat tab's sessionKey on first create. */
+  sessionKey: string
+  /** Worktree / folder-workspace key, so reopen can recreate the tab in place. */
+  worktreeId?: string
+  /** cwd the chat was launched with (best-effort; informational). */
+  cwd?: string
+  /** Human label for lists ("Recent chats"). Derived from the first user prompt. */
+  title: string
+  /** Last-activity timestamp (ms) for sorting recents. */
+  updatedAt: number
+  /** jcode --resume id so a reopened chat continues the same jcode session. */
+  resumeSessionId?: string
+  /** Persisted composer chip selection. */
+  composerProvider?: string
+  composerModel?: string
+  /** The transcript. Capped to a max length on write to bound file growth. */
+  messages: JcodePersistedMessage[]
+}
+
+/** Lightweight row returned by listConversations (no transcript body). */
+export type JcodeConversationSummary = {
+  sessionKey: string
+  worktreeId?: string
+  cwd?: string
+  title: string
+  updatedAt: number
+  resumeSessionId?: string
+}
+
+export const JCODE_CHAT_LIST_CHANNEL = 'jcode-chat:listConversations'
+export const JCODE_CHAT_LOAD_CHANNEL = 'jcode-chat:loadConversation'
+export const JCODE_CHAT_DELETE_CHANNEL = 'jcode-chat:deleteConversation'
+/** Renderer -> main: persist a snapshot of the live conversation state. */
+export const JCODE_CHAT_SAVE_CHANNEL = 'jcode-chat:saveConversation'
+
+/** Payload the renderer sends to persist a conversation snapshot. Sent on turn
+ *  boundaries (start + done/error/stopped/exit), debounced, so we capture the
+ *  full transcript and the latest --resume id without thrashing disk. */
+export type JcodeChatSavePayload = {
+  record: JcodeConversationRecord
+}

--- a/src/shared/jcode-chat-types.ts
+++ b/src/shared/jcode-chat-types.ts
@@ -34,6 +34,11 @@ export type JcodeChatSendPayload = {
   prompt: string
   /** jcode provider id, e.g. 'openai'. */
   provider?: string
+  /** Named custom OpenAI-compatible provider profile (from `jcode provider add`).
+   *  When set, the main process spawns jcode with `--provider-profile <name>`
+   *  (which IMPLIES openai-compatible) and OMITS `-p`. Takes precedence over
+   *  `provider`. `-m model` is still honored to override the profile default. */
+  providerProfile?: string
   /** jcode model id, e.g. 'gpt-5.5'. */
   model?: string
   /** Working directory passed to jcode via -C. */
@@ -50,6 +55,50 @@ export type JcodeChatSendPayload = {
    *  no worktree-derived host is available (e.g. ad-hoc callers). */
   remoteExecHost?: string
 }
+
+/** Authentication style jcode uses for a custom OpenAI-compatible provider. */
+export type JcodeProviderAuth = 'bearer' | 'api-key' | 'none'
+
+/** A user-added custom OpenAI-compatible provider profile. The API key is NOT
+ *  stored here — it lives in jcode's private provider env file (written via
+ *  `jcode provider add --api-key-stdin`). This record only mirrors the
+ *  non-secret config so the composer + settings can list profiles. */
+export type JcodeCustomProvider = {
+  /** Profile name; passed to jcode as `--provider-profile <name>`. */
+  name: string
+  /** OpenAI-compatible base URL, e.g. https://llm.example.com/v1 */
+  baseUrl: string
+  /** Default model id for this profile. */
+  model: string
+  /** Auth style; defaults to 'bearer' when omitted. */
+  auth?: JcodeProviderAuth
+}
+
+/** Renderer -> main args to add a custom provider. The API key (when present)
+ *  is delivered over the child's STDIN, never as an argv flag. */
+export type JcodeProviderAddArgs = {
+  name: string
+  baseUrl: string
+  model: string
+  auth?: JcodeProviderAuth
+  /** Optional custom auth header name (jcode `--auth-header`). */
+  authHeader?: string
+  /** API key value; written to jcode's stdin via `--api-key-stdin`. When empty
+   *  / omitted the provider is added with `--no-api-key`. */
+  apiKey?: string
+}
+
+/** Result of a jcodeProviders:add / :list call. */
+export type JcodeProviderActionResult = {
+  ok: boolean
+  /** Normalized error message when ok === false. */
+  error?: string
+  /** The persisted (non-secret) profile, on a successful add. */
+  provider?: JcodeCustomProvider
+}
+
+export const JCODE_PROVIDERS_LIST_CHANNEL = 'jcodeProviders:list'
+export const JCODE_PROVIDERS_ADD_CHANNEL = 'jcodeProviders:add'
 
 export const JCODE_CHAT_SEND_CHANNEL = 'jcode-chat:send'
 export const JCODE_CHAT_STOP_CHANNEL = 'jcode-chat:stop'
@@ -91,6 +140,9 @@ export type JcodeConversationRecord = {
   /** Persisted composer chip selection. */
   composerProvider?: string
   composerModel?: string
+  /** Persisted custom provider profile selection (mutually exclusive with
+   *  composerProvider; when set the chip points at a `jcode provider add` profile). */
+  composerProviderProfile?: string
   /** The transcript. Capped to a max length on write to bound file growth. */
   messages: JcodePersistedMessage[]
 }

--- a/src/shared/jcode-chat-types.ts
+++ b/src/shared/jcode-chat-types.ts
@@ -27,11 +27,37 @@ export type JcodeChatStopPayload = {
   sessionKey: string
 }
 
+/** An attachment the user added to a chat turn via the composer. Two kinds:
+ *  - 'file': an absolute LOCAL path chosen by the native picker or dropped onto
+ *    the pane. For remote-exec sessions the main process copies it to the remote
+ *    host and rewrites the referenced path before invoking jcode.
+ *  - 'text': an inline blob (e.g. a large paste) that should travel in the prompt
+ *    fenced, instead of bloating the textarea. */
+export type JcodeChatAttachment =
+  | {
+      kind: 'file'
+      /** Absolute local path. */
+      path: string
+      /** Display name (basename) for the chip. */
+      name: string
+    }
+  | {
+      kind: 'text'
+      /** Short label for the chip (e.g. "Pasted text"). */
+      name: string
+      /** The full text content; woven into the prompt fenced on send. */
+      content: string
+    }
+
 /** Payload the renderer sends over 'jcode-chat:send' to start one turn. */
 export type JcodeChatSendPayload = {
   /** Stable per-pane key (tab/worktree id) used to route events back. */
   sessionKey: string
   prompt: string
+  /** Files/text the user attached in the composer. The main process weaves them
+   *  into the prompt jcode actually receives (and, for remote-exec sessions,
+   *  copies local files to the remote host first). */
+  attachments?: JcodeChatAttachment[]
   /** jcode provider id, e.g. 'openai'. */
   provider?: string
   /** Named custom OpenAI-compatible provider profile (from `jcode provider add`).
@@ -103,6 +129,9 @@ export const JCODE_PROVIDERS_ADD_CHANNEL = 'jcodeProviders:add'
 export const JCODE_CHAT_SEND_CHANNEL = 'jcode-chat:send'
 export const JCODE_CHAT_STOP_CHANNEL = 'jcode-chat:stop'
 export const JCODE_CHAT_EVENT_CHANNEL = 'jcode-chat:event'
+/** Renderer -> main: open a native multi-select file picker; resolves to the
+ *  chosen ABSOLUTE paths (empty array on cancel). */
+export const JCODE_CHAT_PICK_FILES_CHANNEL = 'jcode-chat:pickFiles'
 
 // ─── Durable persistence (BUG 1/2) ─────────────────────────────────────────
 // jcode conversations are mirrored to disk in the main process so they survive

--- a/src/shared/jcode-chat-types.ts
+++ b/src/shared/jcode-chat-types.ts
@@ -21,6 +21,12 @@ export type JcodeChatEventMessage = {
   event: JcodeNdjsonEvent
 }
 
+/** Payload the renderer sends over 'jcode-chat:stop' to cancel an in-flight turn. */
+export type JcodeChatStopPayload = {
+  /** Stable per-pane key whose in-flight jcode child should be killed. */
+  sessionKey: string
+}
+
 /** Payload the renderer sends over 'jcode-chat:send' to start one turn. */
 export type JcodeChatSendPayload = {
   /** Stable per-pane key (tab/worktree id) used to route events back. */
@@ -39,4 +45,5 @@ export type JcodeChatSendPayload = {
 }
 
 export const JCODE_CHAT_SEND_CHANNEL = 'jcode-chat:send'
+export const JCODE_CHAT_STOP_CHANNEL = 'jcode-chat:stop'
 export const JCODE_CHAT_EVENT_CHANNEL = 'jcode-chat:event'

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -102,6 +102,7 @@ export const AGENT_KIND_VALUES = [
   'grok',
   'devin',
   'ante',
+  'jcode',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -52,6 +52,10 @@ export type TuiAgentConfig = {
    * `›` prompt only when the composer row exists, so Orca can paste as soon
    * as that prompt appears after bracketed paste is enabled. */
   draftPasteReadySignal?: DraftPasteReadySignal
+  /** Why: how Orca renders this agent's session. 'terminal' (default) hosts the
+   * agent's TUI in an xterm PTY. 'chat' renders the jcode chat-bubble view
+   * (ChatPane) driven by `jcode run --ndjson`. Only jcode uses 'chat' today. */
+  renderMode?: 'terminal' | 'chat'
 }
 
 export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
@@ -337,7 +341,10 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     // the bare TUI and injects the composed prompt after startup over the PTY.
     launchCmd: 'jcode',
     expectedProcess: 'jcode',
-    promptInjectionMode: 'stdin-after-start'
+    promptInjectionMode: 'stdin-after-start',
+    // Why: jcode is rendered as a chat-bubble view (M1) backed by
+    // `jcode run --ndjson` instead of a hosted TUI in a PTY.
+    renderMode: 'chat'
   }
 }
 

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -327,6 +327,17 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     // `followupPrompt` to the PTY as plain input + Enter after startup (not
     // bracketed paste). Use `draftPrompt` / agent-paste-draft for review-before-send.
     promptInjectionMode: 'stdin-after-start'
+  },
+  jcode: {
+    detectCmd: 'jcode',
+    // Why: bare `jcode` launches the interactive TUI. The argv-prompt paths
+    // (`jcode run <message>`) are one-shot headless modes that emit output and
+    // exit, which would tear down the hosted session. jcode exposes no
+    // documented `--prefill`-style flag to seed the composer, so Orca starts
+    // the bare TUI and injects the composed prompt after startup over the PTY.
+    launchCmd: 'jcode',
+    expectedProcess: 'jcode',
+    promptInjectionMode: 'stdin-after-start'
   }
 }
 

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -288,15 +288,21 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
   },
   hermes: {
     detectCmd: 'hermes',
-    // Why: bare `hermes` opens the classic REPL in recent Hermes releases;
-    // `--tui` starts the full-screen agent UI Orca is designed to host.
-    launchCmd: 'hermes --tui',
+    // Why: top-level `hermes --tui` boots Hermes's MESSAGING gateway (WhatsApp/
+    // Slack), which exits(1) in a loop when that integration isn't configured —
+    // spamming "error: gateway exited (1)". The `chat` subcommand is the actual
+    // interactive agent and needs no messaging gateway (verified: `hermes chat
+    // -q ...` replies cleanly). So launch the agent directly.
+    launchCmd: 'hermes chat',
     expectedProcess: 'hermes',
     promptInjectionMode: 'stdin-after-start'
   },
   openclaw: {
     detectCmd: 'openclaw',
-    launchCmd: 'openclaw',
+    // Why: bare `openclaw` just prints usage. `openclaw chat` is the interactive
+    // terminal UI (alias for `tui --local`), which runs the embedded local agent
+    // runtime — no separately-started Gateway server required.
+    launchCmd: 'openclaw chat',
     expectedProcess: 'openclaw',
     promptInjectionMode: 'stdin-after-start'
   },

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -38,7 +38,8 @@ export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   hermes: 'Hermes',
   openclaw: 'OpenClaw',
   copilot: 'GitHub Copilot',
-  grok: 'Grok'
+  grok: 'Grok',
+  jcode: 'J-Code'
 }
 
 /** Canonical agent id list derived from the exhaustive display-name record,

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -36,7 +36,8 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'rovo',
   'hermes',
   'devin',
-  'openclaw'
+  'openclaw',
+  'jcode'
 ] as const satisfies readonly TuiAgent[]
 
 // Why: fresh installs should expose Claude Agent Teams in agent pickers; the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2237,6 +2237,7 @@ export type TuiAgent =
   | 'grok' // xAI Grok CLI
   | 'devin' // Devin CLI
   | 'ante' // Ante (Antigma Labs)
+  | 'jcode' // J-Code (Claude Max / ChatGPT Pro subscriptions)
 
 export type TaskViewPresetId = 'all' | 'issues' | 'review' | 'my-issues' | 'my-prs' | 'prs'
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -754,6 +754,10 @@ export type TabContentType =
   | 'check-details'
   | 'browser'
   | 'simulator'
+  // Why: jcode chat-bubble view (M1). A 'chat' tab renders ChatPane (streamed
+  // NDJSON chat bubbles) instead of an xterm terminal. It shares the editor
+  // pane body slot in TabGroupPanel and maps to the 'editor' visible-tab type.
+  | 'chat'
 
 export type WorkspaceVisibleTabType = 'terminal' | 'editor' | 'browser' | 'simulator'
 export type CtrlTabOrderMode = 'mru' | 'sequential'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -24,6 +24,7 @@ import type { GitBranchChangeStatus } from './git-status-types'
 import type { KeybindingOverrides, TerminalShortcutPolicy } from './keybindings'
 import type { RepoIcon } from './repo-icon'
 import type { AppIconId } from './app-icon'
+import type { JcodeCustomProvider } from './jcode-chat-types'
 import type {
   RepoSourceControlAiOverrides,
   SourceControlAiSettings
@@ -2640,6 +2641,11 @@ export type GlobalSettings = {
   /** Whether to extract OAuth credentials from the local Gemini CLI installation
    *  for rate-limit fetching. Disabled by default for explicit opt-in. */
   geminiCliOAuthEnabled: boolean
+  /** User-added custom OpenAI-compatible provider profiles for jcode chat. The
+   *  API keys are NOT stored here — they live in jcode's private provider env
+   *  file (written via `jcode provider add --api-key-stdin`). This mirrors the
+   *  non-secret config so the composer + settings can list/select profiles. */
+  jcodeCustomProviders: JcodeCustomProvider[]
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */
   agentCmdOverrides: Partial<Record<TuiAgent, string>>
   /** Per-agent default CLI arguments appended after the binary/path and before prompts. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -309,6 +309,13 @@ export type FolderWorkspace = {
   folderPath: string
   /** SSH target ID for folder workspaces whose folder path lives remotely. */
   connectionId?: string | null
+  /** brain-local / hands-remote (M3): when true this folder workspace runs the
+   *  agent (jcode) LOCALLY — local model/auth/agent-loop — but executes bash on
+   *  the remote `connectionId` host via jcode's `--remote-exec <host>`. Such a
+   *  workspace therefore has BOTH a `connectionId` (the SSH target whose host is
+   *  passed to --remote-exec) AND `isRemoteExecOnly: true`. Spawns for it bypass
+   *  the SSH PTY provider and use the LOCAL provider so jcode gets local auth. */
+  isRemoteExecOnly?: boolean
   linkedTask: FolderWorkspaceLinkedTask | null
   comment: string
   isArchived: boolean

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -139,7 +139,11 @@ const tabContentTypeSchema = z.enum([
   'conflict-review',
   'check-details',
   'browser',
-  'simulator'
+  'simulator',
+  // Why: jcode chat-bubble view (M1). Must stay in sync with TabContentType in
+  // src/shared/types.ts — once a 'chat' tab is persisted, session restore
+  // safeParse would otherwise reject it and drop the tab/workspace state.
+  'chat'
 ])
 
 const workspaceVisibleTabTypeSchema = z.enum(['terminal', 'editor', 'browser', 'simulator'])


### PR DESCRIPTION
## Summary

This closes out the jcode chat integration branch by stabilizing repository gates and hardening the jcode desktop wrapper paths.

Key changes:
- Restores styled scrollbar and localization gates for new jcode UI surfaces.
- Splits jcode chat session store responsibilities to avoid max-lines disables.
- Replaces user-specific jcode binary fallback paths with cross-platform resolution and accurate preflight reporting.
- Hardens remote attachment upload and cleanup: generated per-turn temp dirs, path validation, best-effort cleanup after child close and spawn failure, and remote command exit-code checks before reporting uploads as copied.
- Adds focused jcode attachment/remote-exec tests and records closeout validation evidence in `HANDOFF-JCODE.md`.

## Validation

- PASS: `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm run typecheck`
- PASS: `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm run lint`
- PASS: `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm exec vitest run --config config/vitest.config.ts src/main/jcode/jcode-attachments.test.ts src/main/jcode/jcode-remote-exec.test.ts`
- PASS: `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/node-pty-fd-leak.test.ts src/main/daemon/shell-ready.test.ts src/main/pty/omp-shell-wrapper.node-pty.test.ts`
- PASS: `export PATH="/usr/local/bin:$PATH"; /usr/local/bin/node /Users/vinny/.local/bin/pnpm run build:unpack`

Full-suite note:
- `pnpm run test` completed with only non-jcode PTY concurrency/resource failures in `node-pty-fd-leak`, `shell-ready`, and `omp-shell-wrapper`; the exact failing files passed when rerun focused.

## Residual Risk

Remote attachment upload assumes POSIX remote tools/paths (`/tmp`, `mkdir`, `base64 -d`, `rm`). Unsupported SSH targets fail closed and report attachments as not copied. No live SSH integration test was run in this closeout pass.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6052">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->