### PR TITLE
fix: throttle stall helpers and stale terminal restores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ notes/artifacts/
 # Playwright
 test-results/
 playwright-report/
+.perf-validation/
 
 # Agent skill installations (machine-local, populated by agent tooling)
 /.claude/skills/

--- a/config/scripts/benchmark-artifact-comparison.test.mjs
+++ b/config/scripts/benchmark-artifact-comparison.test.mjs
@@ -156,6 +156,76 @@ describe('benchmark artifact comparison', () => {
     ).toMatchObject({ status: 'improved', unit: 'ms' })
   })
 
+  it('aggregates duplicate Playwright scenario metrics before comparison', () => {
+    const dir = makeTempDir()
+    const baselinePath = writeArtifact(dir, 'baseline-playwright-duplicates.json', {
+      suites: [
+        {
+          specs: [
+            {
+              tests: [
+                {
+                  annotations: [
+                    {
+                      type: 'opencode-duplicate',
+                      description: 'median=80.0ms rendererQueuedChars=1000'
+                    },
+                    {
+                      type: 'opencode-duplicate',
+                      description: 'median=100.0ms rendererQueuedChars=1400'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+    const candidatePath = writeArtifact(dir, 'candidate-playwright-duplicates.json', {
+      suites: [
+        {
+          specs: [
+            {
+              tests: [
+                {
+                  annotations: [
+                    {
+                      type: 'opencode-duplicate',
+                      description: 'median=60.0ms rendererQueuedChars=800'
+                    },
+                    {
+                      type: 'opencode-duplicate',
+                      description: 'median=70.0ms rendererQueuedChars=1000'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+
+    const comparison = comparePaths(baselinePath, candidatePath)
+    const duplicateMedianMetrics = comparison.metrics.filter(
+      (metric) => metric.key === 'opencode-duplicate.median'
+    )
+
+    expect(duplicateMedianMetrics).toHaveLength(1)
+    expect(duplicateMedianMetrics[0]).toMatchObject({
+      absoluteDelta: -25,
+      baseline: 90,
+      candidate: 65,
+      percentDelta: -27.8,
+      status: 'improved',
+      unit: 'ms'
+    })
+    expect(
+      comparison.metrics.filter((metric) => metric.key === 'opencode-duplicate.rendererQueuedChars')
+    ).toHaveLength(1)
+  })
+
   it('supports higher-is-better metrics for generic summary artifacts', () => {
     const dir = makeTempDir()
     const baselinePath = writeArtifact(dir, 'generic-baseline.json', {

--- a/config/scripts/benchmark-artifact-comparison.test.mjs
+++ b/config/scripts/benchmark-artifact-comparison.test.mjs
@@ -1,0 +1,249 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  compareBenchmarkArtifacts,
+  parseBenchmarkComparisonArgs
+} from './compare-benchmark-artifacts.mjs'
+
+const scriptPath = 'config/scripts/compare-benchmark-artifacts.mjs'
+const tempDirs = []
+
+function makeTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-benchmark-comparison-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function writeArtifact(dir, name, artifact) {
+  const artifactPath = join(dir, name)
+  writeFileSync(artifactPath, JSON.stringify(artifact))
+  return artifactPath
+}
+
+function comparePaths(baselinePath, candidatePath, extra = {}) {
+  return compareBenchmarkArtifacts({
+    baselinePath,
+    candidatePath,
+    now: () => new Date('2026-06-21T12:00:00.000Z'),
+    title: 'Test Compare',
+    ...extra
+  })
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { force: true, recursive: true })
+  }
+})
+
+describe('benchmark artifact comparison', () => {
+  it('parses required CLI flags and rejects missing paths', () => {
+    expect(() => parseBenchmarkComparisonArgs(['--baseline'])).toThrow('--baseline requires a path')
+    expect(() => parseBenchmarkComparisonArgs(['--candidate'])).toThrow(
+      '--candidate requires a path'
+    )
+    expect(() => parseBenchmarkComparisonArgs(['--candidate', 'candidate.json'])).toThrow(
+      'Usage: node config/scripts/compare-benchmark-artifacts.mjs --baseline <path> --candidate <path> [--title <title>] [--output <path>] [--json-output <path>] [--higher-is-better <metric-key> ...]'
+    )
+  })
+
+  it('compares startup-style summary median metrics and skips null candidates', () => {
+    const dir = makeTempDir()
+    const baselinePath = writeArtifact(dir, 'baseline.json', {
+      label: 'baseline',
+      summaryMedianMs: {
+        missingLater: 5,
+        spawnToAppReady: 25,
+        totalToDidFinishLoad: 100
+      }
+    })
+    const candidatePath = writeArtifact(dir, 'candidate.json', {
+      label: 'candidate',
+      summaryMedianMs: {
+        missingLater: null,
+        spawnToAppReady: 30,
+        totalToDidFinishLoad: 40
+      }
+    })
+
+    const comparison = comparePaths(baselinePath, candidatePath)
+
+    expect(comparison.schemaVersion).toBe(1)
+    expect(comparison.createdAt).toBe('2026-06-21T12:00:00.000Z')
+    expect(comparison.baseline.label).toBe('baseline')
+    expect(comparison.candidate.label).toBe('candidate')
+    expect(
+      comparison.metrics.find((metric) => metric.key === 'totalToDidFinishLoad')
+    ).toMatchObject({
+      absoluteDelta: -60,
+      baseline: 100,
+      candidate: 40,
+      percentDelta: -60,
+      status: 'improved',
+      unit: 'ms'
+    })
+    expect(comparison.metrics.find((metric) => metric.key === 'spawnToAppReady')).toMatchObject({
+      status: 'regressed'
+    })
+    expect(comparison.skippedMetrics).toContainEqual({
+      key: 'missingLater',
+      reason: 'missing candidate metric'
+    })
+  })
+
+  it('compares numeric Playwright annotation metrics and omits metadata fields', () => {
+    const dir = makeTempDir()
+    const baselinePath = writeArtifact(dir, 'baseline-playwright.json', {
+      suites: [
+        {
+          suites: [
+            {
+              specs: [
+                {
+                  tests: [
+                    {
+                      annotations: [
+                        {
+                          type: 'opencode-scale-same-workspace-50',
+                          description:
+                            'panes=50 frames=60 median=80.0ms worst=120.0ms rendererQueuedChars=1000 samples=1,2'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+    const candidatePath = writeArtifact(dir, 'candidate-playwright.json', {
+      suites: [
+        {
+          specs: [
+            {
+              tests: [
+                {
+                  annotations: [
+                    {
+                      type: 'opencode-scale-same-workspace-50',
+                      description:
+                        'panes=50 frames=60 median=60.0ms worst=100.0ms rendererQueuedChars=800 samples=1,2'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+
+    const comparison = comparePaths(baselinePath, candidatePath)
+    const metricKeys = comparison.metrics.map((metric) => metric.key)
+
+    expect(metricKeys).toContain('opencode-scale-same-workspace-50.median')
+    expect(metricKeys).toContain('opencode-scale-same-workspace-50.rendererQueuedChars')
+    expect(metricKeys).not.toContain('opencode-scale-same-workspace-50.panes')
+    expect(metricKeys).not.toContain('opencode-scale-same-workspace-50.frames')
+    expect(metricKeys).not.toContain('opencode-scale-same-workspace-50.samples')
+    expect(
+      comparison.metrics.find((metric) => metric.key === 'opencode-scale-same-workspace-50.median')
+    ).toMatchObject({ status: 'improved', unit: 'ms' })
+  })
+
+  it('supports higher-is-better metrics for generic summary artifacts', () => {
+    const dir = makeTempDir()
+    const baselinePath = writeArtifact(dir, 'generic-baseline.json', {
+      summary: {
+        totalBytes: 2048,
+        totalCpuPercent: { mean: 80 },
+        throughput: 10
+      }
+    })
+    const candidatePath = writeArtifact(dir, 'generic-candidate.json', {
+      summary: {
+        totalBytes: 1024,
+        totalCpuPercent: { mean: 70 },
+        throughput: 12
+      }
+    })
+
+    const comparison = comparePaths(baselinePath, candidatePath, {
+      higherIsBetter: new Set(['summary.throughput'])
+    })
+
+    expect(comparison.metrics.find((metric) => metric.key === 'summary.throughput')).toMatchObject({
+      direction: 'higher-is-better',
+      status: 'improved'
+    })
+    expect(comparison.metrics.find((metric) => metric.key === 'summary.totalBytes')).toMatchObject({
+      unit: 'bytes'
+    })
+    expect(
+      comparison.metrics.find((metric) => metric.key === 'summary.totalCpuPercent.mean')
+    ).toMatchObject({
+      unit: '%'
+    })
+  })
+
+  it('writes Markdown and JSON reports from the CLI while printing Markdown', () => {
+    const dir = makeTempDir()
+    const baselinePath = writeArtifact(dir, 'baseline.json', {
+      label: 'baseline',
+      summaryMedianMs: { totalToDidFinishLoad: 100 }
+    })
+    const candidatePath = writeArtifact(dir, 'candidate.json', {
+      label: 'candidate',
+      summaryMedianMs: { totalToDidFinishLoad: 40 }
+    })
+    const markdownPath = join(dir, 'nested', 'comparison.md')
+    const jsonPath = join(dir, 'nested', 'comparison.json')
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        '--baseline',
+        baselinePath,
+        '--candidate',
+        candidatePath,
+        '--title',
+        'Test Compare',
+        '--output',
+        markdownPath,
+        '--json-output',
+        jsonPath
+      ],
+      { cwd: process.cwd(), encoding: 'utf8' }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('| Metric | Baseline | Candidate | Delta | Delta % | Result |')
+    expect(result.stdout).toContain(
+      '| totalToDidFinishLoad | 100.0ms | 40.0ms | -60.0ms | -60.0% | improved |'
+    )
+    expect(existsSync(markdownPath)).toBe(true)
+    expect(existsSync(jsonPath)).toBe(true)
+    expect(JSON.parse(readFileSync(jsonPath, 'utf8')).schemaVersion).toBe(1)
+  })
+
+  it('fails unsupported artifacts in the CLI', () => {
+    const dir = makeTempDir()
+    const baselinePath = writeArtifact(dir, 'baseline.json', { hello: 'world' })
+    const candidatePath = writeArtifact(dir, 'candidate.json', { hello: 'world' })
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, '--baseline', baselinePath, '--candidate', candidatePath],
+      { cwd: process.cwd(), encoding: 'utf8' }
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('unsupported benchmark artifact')
+  })
+})

--- a/config/scripts/check-terminal-perf-report-budgets.mjs
+++ b/config/scripts/check-terminal-perf-report-budgets.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from 'node:fs'
 import { basename } from 'node:path'
+import { collectTerminalPerfRows, readJsonReport } from './terminal-perf-report-annotations.mjs'
 
 const reportPaths = process.argv.slice(2)
 if (reportPaths[0] === '--') {
@@ -24,55 +24,6 @@ const BUDGETS = {
   maxRendererQueuedChars: 2 * 1024 * 1024,
   maxRendererPeakQueuedChars: 2 * 1024 * 1024,
   maxRendererDroppedBacklogs: 0
-}
-
-function readJsonReport(path) {
-  const raw = readFileSync(path, 'utf8')
-  const start = raw.indexOf('{')
-  const end = raw.lastIndexOf('}')
-  if (start === -1 || end <= start) {
-    throw new Error(`${path}: no JSON object found`)
-  }
-  return JSON.parse(raw.slice(start, end + 1))
-}
-
-function parseAnnotationDescription(description) {
-  const values = {}
-  for (const part of description.split(/\s+/)) {
-    const index = part.indexOf('=')
-    if (index === -1) {
-      continue
-    }
-    values[part.slice(0, index)] = part.slice(index + 1)
-  }
-  return values
-}
-
-function collectTerminalPerfRows(report, source) {
-  const rows = []
-  const visitSuite = (suite) => {
-    for (const spec of suite.specs ?? []) {
-      for (const test of spec.tests ?? []) {
-        for (const annotation of test.annotations ?? []) {
-          if (!annotation.type.startsWith('opencode-')) {
-            continue
-          }
-          rows.push({
-            source,
-            scenario: annotation.type,
-            ...parseAnnotationDescription(annotation.description ?? '')
-          })
-        }
-      }
-    }
-    for (const child of suite.suites ?? []) {
-      visitSuite(child)
-    }
-  }
-  for (const suite of report.suites ?? []) {
-    visitSuite(suite)
-  }
-  return rows
 }
 
 function parseMs(value, fieldName, row, failures) {

--- a/config/scripts/compare-benchmark-artifacts.mjs
+++ b/config/scripts/compare-benchmark-artifacts.mjs
@@ -116,7 +116,7 @@ function normalizeNumericObject(path, artifact, kind, values, unitForKey) {
 
 function normalizePlaywrightArtifact(path, artifact) {
   const rows = collectTerminalPerfRows(artifact, basename(path), { typePrefix: 'opencode-' })
-  const metrics = []
+  const groupedMetrics = new Map()
   for (const row of rows) {
     for (const [field, rawValue] of Object.entries(row)) {
       if (PLAYWRIGHT_METADATA_FIELDS.has(field)) {
@@ -126,19 +126,30 @@ function normalizePlaywrightArtifact(path, artifact) {
       if (parsed == null) {
         continue
       }
-      metrics.push({
-        direction: 'lower-is-better',
-        key: `${row.scenario}.${field}`,
+      const key = `${row.scenario}.${field}`
+      const metricGroup = groupedMetrics.get(key) ?? {
         unit: parsed.unit,
-        value: parsed.value
-      })
+        values: []
+      }
+      metricGroup.values.push(parsed.value)
+      groupedMetrics.set(key, metricGroup)
     }
   }
+  const metrics = [...groupedMetrics.entries()].map(([key, metricGroup]) => ({
+    direction: 'lower-is-better',
+    key,
+    unit: metricGroup.unit,
+    value: mean(metricGroup.values)
+  }))
   return {
     kind: 'playwright',
     label: artifactLabel(path, artifact),
     metrics
   }
+}
+
+function mean(values) {
+  return values.reduce((sum, value) => sum + value, 0) / values.length
 }
 
 function parseMetricValue(rawValue) {

--- a/config/scripts/compare-benchmark-artifacts.mjs
+++ b/config/scripts/compare-benchmark-artifacts.mjs
@@ -1,0 +1,351 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { basename, dirname } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { collectTerminalPerfRows } from './terminal-perf-report-annotations.mjs'
+
+const USAGE =
+  'Usage: node config/scripts/compare-benchmark-artifacts.mjs --baseline <path> --candidate <path> [--title <title>] [--output <path>] [--json-output <path>] [--higher-is-better <metric-key> ...]'
+
+const PLAYWRIGHT_METADATA_FIELDS = new Set(['source', 'scenario', 'panes', 'frames', 'samples'])
+
+export function parseBenchmarkComparisonArgs(argv = process.argv.slice(2)) {
+  const args = argv[0] === '--' ? argv.slice(1) : [...argv]
+  const parsed = {
+    higherIsBetter: new Set(),
+    title: 'Benchmark comparison'
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index]
+    if (flag === '--baseline') {
+      parsed.baselinePath = readRequiredValue(args, ++index, '--baseline requires a path')
+      continue
+    }
+    if (flag === '--candidate') {
+      parsed.candidatePath = readRequiredValue(args, ++index, '--candidate requires a path')
+      continue
+    }
+    if (flag === '--title') {
+      parsed.title = readRequiredValue(args, ++index, '--title requires a value')
+      continue
+    }
+    if (flag === '--output') {
+      parsed.outputPath = readRequiredValue(args, ++index, '--output requires a path')
+      continue
+    }
+    if (flag === '--json-output') {
+      parsed.jsonOutputPath = readRequiredValue(args, ++index, '--json-output requires a path')
+      continue
+    }
+    if (flag === '--higher-is-better') {
+      let consumed = 0
+      while (args[index + 1] != null && !args[index + 1].startsWith('--')) {
+        parsed.higherIsBetter.add(args[index + 1])
+        index += 1
+        consumed += 1
+      }
+      if (consumed === 0) {
+        throw new Error('--higher-is-better requires a metric key')
+      }
+      continue
+    }
+    throw new Error(USAGE)
+  }
+
+  if (!parsed.baselinePath) {
+    throw new Error(USAGE)
+  }
+  if (!parsed.candidatePath) {
+    throw new Error(USAGE)
+  }
+  return parsed
+}
+
+function readRequiredValue(args, index, message) {
+  const value = args[index]
+  if (value == null || value.startsWith('--')) {
+    throw new Error(message)
+  }
+  return value
+}
+
+export function readBenchmarkArtifact(path) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+export function normalizeBenchmarkArtifact(path, artifact = readBenchmarkArtifact(path)) {
+  if (artifact?.summaryMedianMs != null) {
+    return normalizeNumericObject(path, artifact, 'startup', artifact.summaryMedianMs, () => 'ms')
+  }
+  if (artifact?.summaryMedian != null) {
+    return normalizeNumericObject(path, artifact, 'daemon', artifact.summaryMedian, (key) =>
+      key.endsWith('Count') || key.endsWith('After') ? 'count' : 'ms'
+    )
+  }
+  if (artifact?.suites != null) {
+    return normalizePlaywrightArtifact(path, artifact)
+  }
+  if (artifact?.summary != null) {
+    return normalizeSummaryArtifact(path, artifact)
+  }
+  throw new Error(
+    `${path}: unsupported benchmark artifact; expected summaryMedianMs, summaryMedian, Playwright suites, or top-level summary`
+  )
+}
+
+function artifactLabel(path, artifact) {
+  return typeof artifact?.label === 'string' && artifact.label.length > 0
+    ? artifact.label
+    : basename(path)
+}
+
+function normalizeNumericObject(path, artifact, kind, values, unitForKey) {
+  return {
+    kind,
+    label: artifactLabel(path, artifact),
+    metrics: Object.entries(values ?? {})
+      .filter(([, value]) => Number.isFinite(value))
+      .map(([key, value]) => ({
+        direction: 'lower-is-better',
+        key,
+        unit: unitForKey(key),
+        value
+      }))
+  }
+}
+
+function normalizePlaywrightArtifact(path, artifact) {
+  const rows = collectTerminalPerfRows(artifact, basename(path), { typePrefix: 'opencode-' })
+  const metrics = []
+  for (const row of rows) {
+    for (const [field, rawValue] of Object.entries(row)) {
+      if (PLAYWRIGHT_METADATA_FIELDS.has(field)) {
+        continue
+      }
+      const parsed = parseMetricValue(rawValue)
+      if (parsed == null) {
+        continue
+      }
+      metrics.push({
+        direction: 'lower-is-better',
+        key: `${row.scenario}.${field}`,
+        unit: parsed.unit,
+        value: parsed.value
+      })
+    }
+  }
+  return {
+    kind: 'playwright',
+    label: artifactLabel(path, artifact),
+    metrics
+  }
+}
+
+function parseMetricValue(rawValue) {
+  if (typeof rawValue === 'string') {
+    const msMatch = rawValue.match(/^(-?\d+(?:\.\d+)?)ms$/)
+    if (msMatch) {
+      return { unit: 'ms', value: Number(msMatch[1]) }
+    }
+  }
+  const numericValue = Number(rawValue)
+  if (!Number.isFinite(numericValue)) {
+    return null
+  }
+  return { unit: 'count', value: numericValue }
+}
+
+function normalizeSummaryArtifact(path, artifact) {
+  const metrics = []
+  flattenSummary(metrics, ['summary'], artifact.summary)
+  return {
+    kind: 'summary',
+    label: artifactLabel(path, artifact),
+    metrics
+  }
+}
+
+function flattenSummary(metrics, pathParts, value) {
+  if (Number.isFinite(value)) {
+    const key = pathParts.join('.')
+    metrics.push({
+      direction: 'lower-is-better',
+      key,
+      unit: unitForSummaryKey(pathParts),
+      value
+    })
+    return
+  }
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return
+  }
+  for (const [childKey, childValue] of Object.entries(value)) {
+    flattenSummary(metrics, [...pathParts, childKey], childValue)
+  }
+}
+
+function unitForSummaryKey(pathParts) {
+  if (pathParts.some((part) => part.endsWith('CpuPercent'))) {
+    return '%'
+  }
+  if (pathParts.some((part) => part.endsWith('Bytes'))) {
+    return 'bytes'
+  }
+  return ''
+}
+
+export function compareBenchmarkArtifacts({
+  baselinePath,
+  candidatePath,
+  title = 'Benchmark comparison',
+  higherIsBetter = new Set(),
+  now = () => new Date()
+}) {
+  const baseline = normalizeBenchmarkArtifact(baselinePath)
+  const candidate = normalizeBenchmarkArtifact(candidatePath)
+  const candidateMetrics = new Map(candidate.metrics.map((metric) => [metric.key, metric]))
+  const baselineMetrics = new Map(baseline.metrics.map((metric) => [metric.key, metric]))
+  const metrics = []
+  const skippedMetrics = []
+
+  for (const baselineMetric of baseline.metrics) {
+    const candidateMetric = candidateMetrics.get(baselineMetric.key)
+    if (!isComparableMetric(baselineMetric)) {
+      skippedMetrics.push({ key: baselineMetric.key, reason: 'missing baseline metric' })
+      continue
+    }
+    if (!isComparableMetric(candidateMetric)) {
+      skippedMetrics.push({ key: baselineMetric.key, reason: 'missing candidate metric' })
+      continue
+    }
+    const direction = higherIsBetter.has(baselineMetric.key)
+      ? 'higher-is-better'
+      : baselineMetric.direction
+    metrics.push(compareMetric(baselineMetric, candidateMetric, direction))
+  }
+
+  for (const candidateMetric of candidate.metrics) {
+    if (!baselineMetrics.has(candidateMetric.key)) {
+      skippedMetrics.push({ key: candidateMetric.key, reason: 'missing baseline metric' })
+    }
+  }
+
+  if (metrics.length === 0) {
+    throw new Error('No comparable benchmark metrics found.')
+  }
+
+  return {
+    schemaVersion: 1,
+    createdAt: now().toISOString(),
+    title,
+    baseline: {
+      path: baselinePath,
+      label: baseline.label,
+      kind: baseline.kind
+    },
+    candidate: {
+      path: candidatePath,
+      label: candidate.label,
+      kind: candidate.kind
+    },
+    metrics,
+    skippedMetrics
+  }
+}
+
+function isComparableMetric(metric) {
+  return metric != null && Number.isFinite(metric.value)
+}
+
+function compareMetric(baselineMetric, candidateMetric, direction) {
+  const rawDelta = candidateMetric.value - baselineMetric.value
+  const absoluteDelta = roundOneDecimal(rawDelta)
+  const percentDelta =
+    baselineMetric.value === 0
+      ? null
+      : roundOneDecimal((rawDelta / Math.abs(baselineMetric.value)) * 100)
+  return {
+    key: baselineMetric.key,
+    unit: baselineMetric.unit,
+    direction,
+    baseline: baselineMetric.value,
+    candidate: candidateMetric.value,
+    absoluteDelta,
+    percentDelta,
+    status: metricStatus(absoluteDelta, direction)
+  }
+}
+
+function roundOneDecimal(value) {
+  return Math.round(value * 10) / 10
+}
+
+function metricStatus(absoluteDelta, direction) {
+  if (absoluteDelta === 0) {
+    return 'unchanged'
+  }
+  if (direction === 'higher-is-better') {
+    return absoluteDelta > 0 ? 'improved' : 'regressed'
+  }
+  return absoluteDelta < 0 ? 'improved' : 'regressed'
+}
+
+export function formatBenchmarkComparisonMarkdown(comparison) {
+  const lines = [
+    `# ${comparison.title}`,
+    '',
+    `Baseline: \`${comparison.baseline.label}\` (\`${comparison.baseline.path}\`)`,
+    `Candidate: \`${comparison.candidate.label}\` (\`${comparison.candidate.path}\`)`,
+    `Generated: ${comparison.createdAt}`,
+    '',
+    '| Metric | Baseline | Candidate | Delta | Delta % | Result |',
+    '|---|---:|---:|---:|---:|---|'
+  ]
+  for (const metric of comparison.metrics) {
+    lines.push(
+      `| ${metric.key} | ${formatMetricValue(metric.baseline, metric.unit)} | ${formatMetricValue(metric.candidate, metric.unit)} | ${formatMetricValue(metric.absoluteDelta, metric.unit)} | ${formatPercent(metric.percentDelta)} | ${metric.status} |`
+    )
+  }
+  if (comparison.skippedMetrics.length > 0) {
+    lines.push('', '## Skipped metrics')
+    for (const skippedMetric of comparison.skippedMetrics) {
+      lines.push(`- ${skippedMetric.key}: ${skippedMetric.reason}`)
+    }
+  }
+  return `${lines.join('\n')}\n`
+}
+
+function formatMetricValue(value, unit) {
+  return `${Number(value).toFixed(1)}${unit}`
+}
+
+function formatPercent(value) {
+  return value == null ? '' : `${value.toFixed(1)}%`
+}
+
+export function runBenchmarkComparisonCli(args = {}) {
+  const argv = args.argv ?? process.argv.slice(2)
+  const parsed = parseBenchmarkComparisonArgs(argv)
+  const comparison = compareBenchmarkArtifacts(parsed)
+  const markdown = formatBenchmarkComparisonMarkdown(comparison)
+  if (parsed.outputPath) {
+    mkdirSync(dirname(parsed.outputPath), { recursive: true })
+    writeFileSync(parsed.outputPath, markdown)
+  }
+  if (parsed.jsonOutputPath) {
+    mkdirSync(dirname(parsed.jsonOutputPath), { recursive: true })
+    writeFileSync(parsed.jsonOutputPath, `${JSON.stringify(comparison, null, 2)}\n`)
+  }
+  const stdout = args.stdout ?? process.stdout
+  stdout.write(markdown)
+  return comparison
+}
+
+if (process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    runBenchmarkComparisonCli()
+  } catch (error) {
+    console.error(error.message)
+    process.exit(1)
+  }
+}

--- a/config/scripts/perf-validation-pod-scaffold.mjs
+++ b/config/scripts/perf-validation-pod-scaffold.mjs
@@ -5,68 +5,115 @@ import { fileURLToPath } from 'node:url'
 
 const DEFAULT_ARTIFACT_ROOT = '.perf-validation'
 
-function playwrightCommand({ artifactDir, prefix, repeatEach, specs, variant }) {
-  return joinCommand([
-    'pnpm run ensure:electron-runtime && pnpm exec playwright test',
-    specs,
-    '--config tests/playwright.config.ts --project electron-headless --workers=1',
-    `--repeat-each=${repeatEach}`,
-    '--reporter=json',
-    `--output ${shellArg(joinArtifact(artifactDir, `playwright-${variant}`))}`,
-    `> ${shellArg(joinArtifact(artifactDir, `${prefix}-${variant}-playwright.json`))}`
-  ])
+const RUNNER_SCRIPT = 'config/scripts/run-perf-validation-pod.mjs'
+
+function playwrightRunPlan({ artifactDir, prefix, repeatEach, specs, variant }) {
+  const outputDir = joinArtifact(artifactDir, `playwright-${variant}`)
+  const stdoutFile = joinArtifact(artifactDir, `${prefix}-${variant}-playwright.json`)
+  return {
+    artifactPath: stdoutFile,
+    steps: [
+      { args: ['run', 'ensure:electron-runtime'], command: 'pnpm' },
+      {
+        args: [
+          'exec',
+          'playwright',
+          'test',
+          ...specs,
+          '--config',
+          'tests/playwright.config.ts',
+          '--project',
+          'electron-headless',
+          '--workers=1',
+          `--repeat-each=${repeatEach}`,
+          '--reporter=json',
+          '--output',
+          outputDir
+        ],
+        command: 'pnpm',
+        stdoutFile
+      }
+    ]
+  }
 }
 
 const PODS = {
   'ssh-relay-batching': {
     requiresDocker: true,
-    artifact: (variant) => `ssh-relay-${variant}.jsonl`,
-    command: (variant, { artifactDir }) =>
-      joinCommand([
-        envCommand(
-          'ORCA_E2E_SSH_DOCKER_PERF_JSON',
-          joinArtifact(artifactDir, `ssh-relay-${variant}.jsonl`)
-        ),
-        'pnpm run test:e2e:ssh-docker-perf -- --repeat-each=5 --reporter=json',
-        `--output ${shellArg(joinArtifact(artifactDir, `playwright-${variant}`))}`,
-        `> ${shellArg(joinArtifact(artifactDir, `ssh-relay-${variant}-playwright.json`))}`
-      ])
+    runPlan: (variant, { artifactDir }) => {
+      const stdoutFile = joinArtifact(artifactDir, `ssh-relay-${variant}-playwright.json`)
+      return {
+        artifactPath: joinArtifact(artifactDir, `ssh-relay-${variant}.jsonl`),
+        steps: [
+          {
+            args: [
+              'run',
+              'test:e2e:ssh-docker-perf',
+              '--',
+              '--repeat-each=5',
+              '--reporter=json',
+              '--output',
+              joinArtifact(artifactDir, `playwright-${variant}`)
+            ],
+            command: 'pnpm',
+            env: {
+              ORCA_E2E_SSH_DOCKER_PERF_JSON: joinArtifact(artifactDir, `ssh-relay-${variant}.jsonl`)
+            },
+            stdoutFile
+          }
+        ]
+      }
+    }
   },
   'git-status-coalescing': {
     requiresDocker: false,
-    artifact: (variant) => `git-status-${variant}.json`,
-    command: (variant, { artifactDir }) =>
-      joinCommand([
-        envCommand(
-          'ORCA_GIT_STATUS_COALESCING_BENCH_JSON',
-          joinArtifact(artifactDir, `git-status-${variant}.json`)
-        ),
-        'pnpm exec vitest run --config config/vitest.config.ts src/main/git/status.test.ts',
-        '-t "benchmarks concurrent status burst subprocess pressure"'
-      ])
+    runPlan: (variant, { artifactDir }) => ({
+      artifactPath: joinArtifact(artifactDir, `git-status-${variant}.json`),
+      steps: [
+        {
+          args: [
+            'exec',
+            'vitest',
+            'run',
+            '--config',
+            'config/vitest.config.ts',
+            'src/main/git/status.test.ts',
+            '-t',
+            'benchmarks concurrent status burst subprocess pressure'
+          ],
+          command: 'pnpm',
+          env: {
+            ORCA_GIT_STATUS_COALESCING_BENCH_JSON: joinArtifact(
+              artifactDir,
+              `git-status-${variant}.json`
+            )
+          }
+        }
+      ]
+    })
   },
   'terminal-scheduler-adaptive': {
     requiresDocker: false,
-    artifact: (variant) => `terminal-scheduler-${variant}-playwright.json`,
-    command: (variant, { artifactDir }) =>
-      playwrightCommand({
+    runPlan: (variant, { artifactDir }) =>
+      playwrightRunPlan({
         artifactDir,
         prefix: 'terminal-scheduler',
         repeatEach: 5,
-        specs:
-          'tests/e2e/terminal-output-scheduler.spec.ts tests/e2e/terminal-typing-latency.spec.ts',
+        specs: [
+          'tests/e2e/terminal-output-scheduler.spec.ts',
+          'tests/e2e/terminal-typing-latency.spec.ts'
+        ],
         variant
       })
   },
   'startup-hydration-overlap': {
     requiresDocker: false,
-    artifact: (variant) => `startup-hydration-${variant}-playwright.json`,
-    command: (variant, { artifactDir }) =>
-      playwrightCommand({
+    runPlan: (variant, { artifactDir }) =>
+      playwrightRunPlan({
         artifactDir,
         prefix: 'startup-hydration',
         repeatEach: 10,
-        specs: 'tests/e2e/startup-hydration-perf.spec.ts',
+        specs: ['tests/e2e/startup-hydration-perf.spec.ts'],
         variant
       })
   }
@@ -80,15 +127,19 @@ function joinCommand(parts) {
   return parts.join(' ')
 }
 
-function shellArg(value) {
-  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) {
-    return value
-  }
-  return `'${value.replaceAll("'", "'\\''")}'`
-}
-
-function envCommand(name, value) {
-  return `${name}=${shellArg(value)}`
+function runnerCommand({ artifactRoot, pod, runId, variant }) {
+  return joinCommand([
+    'node',
+    RUNNER_SCRIPT,
+    '--pod',
+    pod,
+    '--run-id',
+    runId,
+    '--artifact-root',
+    artifactRoot,
+    '--variant',
+    variant
+  ])
 }
 
 function defaultRunId(now = new Date()) {
@@ -161,7 +212,7 @@ export function buildPerfValidationPodScaffold({
     throw new Error(`Unsupported pod: ${pod}`)
   }
   const artifactDir = joinArtifact(artifactRoot, runId, pod)
-  const commandContext = { artifactDir, cwd, pod, runId }
+  const commandContext = { artifactDir, artifactRoot, cwd, pod, runId }
   const preflightChecks = [
     { command: ['git', 'status', '--short'], name: 'git-clean' },
     { command: ['pnpm', '--version'], name: 'pnpm' }
@@ -170,18 +221,37 @@ export function buildPerfValidationPodScaffold({
     preflightChecks.push({ command: ['docker', 'info'], name: 'docker-daemon' })
   }
 
+  const baselineRunPlan = definition.runPlan('baseline', commandContext)
+  const candidateRunPlan = definition.runPlan('candidate', commandContext)
+
   return {
     artifactDir,
-    baselineArtifactPath: joinArtifact(artifactDir, definition.artifact('baseline')),
-    baselineCommand: definition.command('baseline', commandContext),
-    candidateArtifactPath: joinArtifact(artifactDir, definition.artifact('candidate')),
-    candidateCommand: definition.command('candidate', commandContext),
+    baselineArtifactPath: baselineRunPlan.artifactPath,
+    baselineCommand: runnerCommand({ artifactRoot, pod, runId, variant: 'baseline' }),
+    candidateArtifactPath: candidateRunPlan.artifactPath,
+    candidateCommand: runnerCommand({ artifactRoot, pod, runId, variant: 'candidate' }),
     pod,
     preflightChecks,
     resultPacketPath: joinArtifact(artifactDir, 'result-packet.json'),
     runId,
     worktreePath: cwd
   }
+}
+
+export function buildPerfValidationRunPlan(scaffold, variant) {
+  const definition = PODS[scaffold.pod]
+  if (!definition) {
+    throw new Error(`Unsupported pod: ${scaffold.pod}`)
+  }
+  if (!['baseline', 'candidate'].includes(variant)) {
+    throw new Error(`Unsupported variant: ${variant}`)
+  }
+  return definition.runPlan(variant, {
+    artifactDir: scaffold.artifactDir,
+    cwd: scaffold.worktreePath,
+    pod: scaffold.pod,
+    runId: scaffold.runId
+  })
 }
 
 function commandOutput(result, key) {

--- a/config/scripts/perf-validation-pod-scaffold.mjs
+++ b/config/scripts/perf-validation-pod-scaffold.mjs
@@ -1,0 +1,324 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_ARTIFACT_ROOT = '.perf-validation'
+
+function playwrightCommand({ artifactDir, prefix, repeatEach, specs, variant }) {
+  return joinCommand([
+    'pnpm run ensure:electron-runtime && pnpm exec playwright test',
+    specs,
+    '--config tests/playwright.config.ts --project electron-headless --workers=1',
+    `--repeat-each=${repeatEach}`,
+    '--reporter=json',
+    `--output ${shellArg(joinArtifact(artifactDir, `playwright-${variant}`))}`,
+    `> ${shellArg(joinArtifact(artifactDir, `${prefix}-${variant}-playwright.json`))}`
+  ])
+}
+
+const PODS = {
+  'ssh-relay-batching': {
+    requiresDocker: true,
+    artifact: (variant) => `ssh-relay-${variant}.jsonl`,
+    command: (variant, { artifactDir }) =>
+      joinCommand([
+        envCommand(
+          'ORCA_E2E_SSH_DOCKER_PERF_JSON',
+          joinArtifact(artifactDir, `ssh-relay-${variant}.jsonl`)
+        ),
+        'pnpm run test:e2e:ssh-docker-perf -- --repeat-each=5 --reporter=json',
+        `--output ${shellArg(joinArtifact(artifactDir, `playwright-${variant}`))}`,
+        `> ${shellArg(joinArtifact(artifactDir, `ssh-relay-${variant}-playwright.json`))}`
+      ])
+  },
+  'git-status-coalescing': {
+    requiresDocker: false,
+    artifact: (variant) => `git-status-${variant}.json`,
+    command: (variant, { artifactDir }) =>
+      joinCommand([
+        envCommand(
+          'ORCA_GIT_STATUS_COALESCING_BENCH_JSON',
+          joinArtifact(artifactDir, `git-status-${variant}.json`)
+        ),
+        'pnpm exec vitest run --config config/vitest.config.ts src/main/git/status.test.ts',
+        '-t "benchmarks concurrent status burst subprocess pressure"'
+      ])
+  },
+  'terminal-scheduler-adaptive': {
+    requiresDocker: false,
+    artifact: (variant) => `terminal-scheduler-${variant}-playwright.json`,
+    command: (variant, { artifactDir }) =>
+      playwrightCommand({
+        artifactDir,
+        prefix: 'terminal-scheduler',
+        repeatEach: 5,
+        specs:
+          'tests/e2e/terminal-output-scheduler.spec.ts tests/e2e/terminal-typing-latency.spec.ts',
+        variant
+      })
+  },
+  'startup-hydration-overlap': {
+    requiresDocker: false,
+    artifact: (variant) => `startup-hydration-${variant}-playwright.json`,
+    command: (variant, { artifactDir }) =>
+      playwrightCommand({
+        artifactDir,
+        prefix: 'startup-hydration',
+        repeatEach: 10,
+        specs: 'tests/e2e/startup-hydration-perf.spec.ts',
+        variant
+      })
+  }
+}
+
+function joinArtifact(...parts) {
+  return path.join(...parts).replaceAll(path.sep, '/')
+}
+
+function joinCommand(parts) {
+  return parts.join(' ')
+}
+
+function shellArg(value) {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) {
+    return value
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+function envCommand(name, value) {
+  return `${name}=${shellArg(value)}`
+}
+
+function defaultRunId(now = new Date()) {
+  return now
+    .toISOString()
+    .replaceAll(':', '-')
+    .replace(/\.\d{3}Z$/, 'Z')
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return value
+}
+
+export function parsePerfValidationPodArgs(argv, env = process.env) {
+  const options = {
+    artifactRoot: env.ORCA_PERF_VALIDATION_ARTIFACT_ROOT || DEFAULT_ARTIFACT_ROOT,
+    check: false,
+    json: false,
+    pod: env.ORCA_PERF_VALIDATION_POD || null,
+    runId: env.ORCA_PERF_VALIDATION_RUN_ID || defaultRunId()
+  }
+
+  if (argv[0] === '--') {
+    argv = argv.slice(1)
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--pod') {
+      options.pod = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--run-id') {
+      options.runId = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--artifact-root') {
+      options.artifactRoot = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--check') {
+      options.check = true
+    } else if (arg === '--json') {
+      options.json = true
+    } else if (arg === '--help') {
+      options.help = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!options.help && !options.pod) {
+    throw new Error('--pod is required')
+  }
+  if (options.pod && !PODS[options.pod]) {
+    throw new Error(`Unsupported pod: ${options.pod}`)
+  }
+  return options
+}
+
+export function buildPerfValidationPodScaffold({
+  artifactRoot = DEFAULT_ARTIFACT_ROOT,
+  cwd = process.cwd(),
+  pod,
+  runId = defaultRunId()
+}) {
+  const definition = PODS[pod]
+  if (!definition) {
+    throw new Error(`Unsupported pod: ${pod}`)
+  }
+  const artifactDir = joinArtifact(artifactRoot, runId, pod)
+  const commandContext = { artifactDir, cwd, pod, runId }
+  const preflightChecks = [
+    { command: ['git', 'status', '--short'], name: 'git-clean' },
+    { command: ['pnpm', '--version'], name: 'pnpm' }
+  ]
+  if (definition.requiresDocker) {
+    preflightChecks.push({ command: ['docker', 'info'], name: 'docker-daemon' })
+  }
+
+  return {
+    artifactDir,
+    baselineArtifactPath: joinArtifact(artifactDir, definition.artifact('baseline')),
+    baselineCommand: definition.command('baseline', commandContext),
+    candidateArtifactPath: joinArtifact(artifactDir, definition.artifact('candidate')),
+    candidateCommand: definition.command('candidate', commandContext),
+    pod,
+    preflightChecks,
+    resultPacketPath: joinArtifact(artifactDir, 'result-packet.json'),
+    runId,
+    worktreePath: cwd
+  }
+}
+
+function commandOutput(result, key) {
+  const value = result[key]
+  const text = Buffer.isBuffer(value) ? value.toString('utf8') : String(value ?? '')
+  return text.replace(/\s+$/u, '')
+}
+
+function runCheck(check, spawnSyncImpl, cwd) {
+  const [command, ...args] = check.command
+  const result = spawnSyncImpl(command, args, { cwd, encoding: 'utf8' })
+  const stdout = commandOutput(result, 'stdout')
+  const stderr = commandOutput(result, 'stderr')
+  const status = result.status ?? (result.signal ? 1 : 0)
+
+  if (check.name === 'git-clean' && stdout.length > 0) {
+    return {
+      details: stdout,
+      name: check.name,
+      ok: false,
+      reason: 'worktree has uncommitted changes'
+    }
+  }
+
+  if (status !== 0) {
+    return {
+      details: stdout,
+      name: check.name,
+      ok: false,
+      reason: stderr || stdout || `${command} exited with status ${status}`
+    }
+  }
+
+  return { name: check.name, ok: true }
+}
+
+export function runPerfValidationPodPreflight({
+  mkdirSyncImpl = mkdirSync,
+  scaffold,
+  spawnSyncImpl = spawnSync
+}) {
+  mkdirSyncImpl(scaffold.artifactDir, { recursive: true })
+  const checks = scaffold.preflightChecks.map((check) =>
+    runCheck(check, spawnSyncImpl, scaffold.worktreePath)
+  )
+  return {
+    checks,
+    ok: checks.every((check) => check.ok),
+    resultPacketPath: scaffold.resultPacketPath
+  }
+}
+
+export function makeResultPacketTemplate(scaffold, preflight = null) {
+  return {
+    artifactDir: scaffold.artifactDir,
+    baseline: {
+      artifactPath: scaffold.baselineArtifactPath,
+      command: scaffold.baselineCommand,
+      median: null,
+      tail: null
+    },
+    branch: null,
+    candidate: {
+      artifactPath: scaffold.candidateArtifactPath,
+      command: scaffold.candidateCommand,
+      median: null,
+      tail: null
+    },
+    decision: null,
+    filesChanged: [],
+    pod: scaffold.pod,
+    preflight,
+    resultPacketPath: scaffold.resultPacketPath,
+    runId: scaffold.runId,
+    thresholdPassed: null,
+    worktreePath: scaffold.worktreePath
+  }
+}
+
+function printText(scaffold, preflight) {
+  console.log(`Pod: ${scaffold.pod}`)
+  console.log(`Run ID: ${scaffold.runId}`)
+  console.log(`Artifact dir: ${scaffold.artifactDir}`)
+  console.log(`Result packet: ${scaffold.resultPacketPath}`)
+  if (preflight) {
+    for (const check of preflight.checks) {
+      console.log(
+        `${check.ok ? 'PASS' : 'FAIL'} ${check.name}${check.reason ? `: ${check.reason}` : ''}`
+      )
+    }
+  }
+  console.log('\nBaseline command:')
+  console.log(scaffold.baselineCommand)
+  console.log('\nCandidate command:')
+  console.log(scaffold.candidateCommand)
+}
+
+function usage() {
+  return `Usage: node config/scripts/perf-validation-pod-scaffold.mjs --pod <name> [options]\n\nPods:\n${Object.keys(
+    PODS
+  )
+    .map((pod) => `  - ${pod}`)
+    .join(
+      '\n'
+    )}\n\nOptions:\n  --run-id <id>         Shared validation run id\n  --artifact-root <dir> Durable artifact root (default ${DEFAULT_ARTIFACT_ROOT})\n  --check              Run local preflight checks and create artifact dir\n  --json               Print JSON scaffold and packet template\n`
+}
+
+export function runPerfValidationPodScaffoldCli({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  env = process.env,
+  stdout = console.log
+} = {}) {
+  try {
+    const options = parsePerfValidationPodArgs(argv, env)
+    if (options.help) {
+      stdout(usage())
+      return 0
+    }
+    const scaffold = buildPerfValidationPodScaffold({ ...options, cwd })
+    const preflight = options.check ? runPerfValidationPodPreflight({ scaffold }) : null
+    const packet = makeResultPacketTemplate(scaffold, preflight)
+    if (options.check) {
+      writeFileSync(scaffold.resultPacketPath, `${JSON.stringify(packet, null, 2)}\n`)
+    }
+    if (options.json) {
+      stdout(JSON.stringify({ packet, scaffold }, null, 2))
+    } else {
+      printText(scaffold, preflight)
+    }
+    return preflight?.ok === false ? 1 : 0
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    return 1
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(runPerfValidationPodScaffoldCli())
+}

--- a/config/scripts/perf-validation-pod-scaffold.test.mjs
+++ b/config/scripts/perf-validation-pod-scaffold.test.mjs
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildPerfValidationPodScaffold,
+  parsePerfValidationPodArgs,
+  runPerfValidationPodPreflight
+} from './perf-validation-pod-scaffold.mjs'
+
+function makeSpawnSync(resultsByCommand) {
+  const calls = []
+  const spawnSyncImpl = vi.fn((command, args, options) => {
+    calls.push({ args, command, options })
+    const key = [command, ...args].join(' ')
+    return resultsByCommand[key] ?? { signal: null, status: 0, stdout: '', stderr: '' }
+  })
+  return { calls, spawnSyncImpl }
+}
+
+describe('perf-validation-pod-scaffold', () => {
+  it('parses pod, run id, artifact root, and check mode', () => {
+    expect(
+      parsePerfValidationPodArgs([
+        '--pod',
+        'ssh-relay-batching',
+        '--run-id',
+        'run-1',
+        '--artifact-root',
+        '.perf',
+        '--check',
+        '--json'
+      ])
+    ).toEqual({
+      artifactRoot: '.perf',
+      check: true,
+      json: true,
+      pod: 'ssh-relay-batching',
+      runId: 'run-1'
+    })
+  })
+
+  it('accepts the separator forwarded by pnpm run', () => {
+    expect(parsePerfValidationPodArgs(['--', '--pod', 'git-status-coalescing'])).toMatchObject({
+      pod: 'git-status-coalescing'
+    })
+  })
+
+  it('builds durable Playwright artifacts outside test-results', () => {
+    const scaffold = buildPerfValidationPodScaffold({
+      artifactRoot: '.perf-validation',
+      cwd: '/repo/worktree',
+      pod: 'terminal-scheduler-adaptive',
+      runId: '2026-06-21T23-00'
+    })
+
+    expect(scaffold.artifactDir).toBe(
+      '.perf-validation/2026-06-21T23-00/terminal-scheduler-adaptive'
+    )
+    expect(scaffold.baselineCommand).toContain(
+      '--output .perf-validation/2026-06-21T23-00/terminal-scheduler-adaptive/playwright-baseline'
+    )
+    expect(scaffold.baselineCommand).toContain('--reporter=json')
+    expect(scaffold.baselineCommand).toContain(
+      '> .perf-validation/2026-06-21T23-00/terminal-scheduler-adaptive/terminal-scheduler-baseline-playwright.json'
+    )
+    expect(scaffold.baselineCommand).not.toContain('> test-results/')
+    expect(scaffold.resultPacketPath).toBe(
+      '.perf-validation/2026-06-21T23-00/terminal-scheduler-adaptive/result-packet.json'
+    )
+  })
+
+  it('adds Docker daemon preflight only for the SSH relay pod', () => {
+    const ssh = buildPerfValidationPodScaffold({
+      pod: 'ssh-relay-batching',
+      runId: 'run-1'
+    })
+    const git = buildPerfValidationPodScaffold({
+      pod: 'git-status-coalescing',
+      runId: 'run-1'
+    })
+
+    expect(ssh.preflightChecks.map((check) => check.name)).toContain('docker-daemon')
+    expect(git.preflightChecks.map((check) => check.name)).not.toContain('docker-daemon')
+  })
+
+  it('fails preflight before benchmark work when Docker is unavailable', () => {
+    const scaffold = buildPerfValidationPodScaffold({
+      pod: 'ssh-relay-batching',
+      runId: 'run-1'
+    })
+    const { spawnSyncImpl } = makeSpawnSync({
+      'git status --short': { signal: null, status: 0, stdout: '', stderr: '' },
+      'pnpm --version': { signal: null, status: 0, stdout: '10.24.0\n', stderr: '' },
+      'docker info': {
+        signal: null,
+        status: 1,
+        stdout: '',
+        stderr: 'Cannot connect to the Docker daemon'
+      }
+    })
+
+    const result = runPerfValidationPodPreflight({ scaffold, spawnSyncImpl })
+
+    expect(result.ok).toBe(false)
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        name: 'docker-daemon',
+        ok: false,
+        reason: 'Cannot connect to the Docker daemon'
+      })
+    )
+  })
+
+  it('rejects dirty worktrees before baseline artifacts are created', () => {
+    const scaffold = buildPerfValidationPodScaffold({
+      pod: 'startup-hydration-overlap',
+      runId: 'run-1'
+    })
+    const { spawnSyncImpl } = makeSpawnSync({
+      'git status --short': { signal: null, status: 0, stdout: ' M src/App.tsx\n', stderr: '' },
+      'pnpm --version': { signal: null, status: 0, stdout: '10.24.0\n', stderr: '' }
+    })
+
+    const result = runPerfValidationPodPreflight({ scaffold, spawnSyncImpl })
+
+    expect(result.ok).toBe(false)
+    expect(result.checks[0]).toEqual({
+      name: 'git-clean',
+      ok: false,
+      reason: 'worktree has uncommitted changes',
+      details: ' M src/App.tsx'
+    })
+  })
+})

--- a/config/scripts/perf-validation-pod-scaffold.test.mjs
+++ b/config/scripts/perf-validation-pod-scaffold.test.mjs
@@ -4,6 +4,7 @@ import {
   parsePerfValidationPodArgs,
   runPerfValidationPodPreflight
 } from './perf-validation-pod-scaffold.mjs'
+import { runPerfValidationPodVariant } from './run-perf-validation-pod.mjs'
 
 function makeSpawnSync(resultsByCommand) {
   const calls = []
@@ -43,7 +44,7 @@ describe('perf-validation-pod-scaffold', () => {
     })
   })
 
-  it('builds durable Playwright artifacts outside test-results', () => {
+  it('builds cross-platform Node runner commands with durable Playwright artifacts', () => {
     const scaffold = buildPerfValidationPodScaffold({
       artifactRoot: '.perf-validation',
       cwd: '/repo/worktree',
@@ -54,17 +55,41 @@ describe('perf-validation-pod-scaffold', () => {
     expect(scaffold.artifactDir).toBe(
       '.perf-validation/2026-06-21T23-00/terminal-scheduler-adaptive'
     )
-    expect(scaffold.baselineCommand).toContain(
-      '--output .perf-validation/2026-06-21T23-00/terminal-scheduler-adaptive/playwright-baseline'
+    expect(scaffold.baselineCommand).toBe(
+      'node config/scripts/run-perf-validation-pod.mjs --pod terminal-scheduler-adaptive --run-id 2026-06-21T23-00 --artifact-root .perf-validation --variant baseline'
     )
-    expect(scaffold.baselineCommand).toContain('--reporter=json')
-    expect(scaffold.baselineCommand).toContain(
-      '> .perf-validation/2026-06-21T23-00/terminal-scheduler-adaptive/terminal-scheduler-baseline-playwright.json'
+    expect(scaffold.baselineCommand).not.toMatch(/\s&&\s|>|\b[A-Za-z_][A-Za-z0-9_]*=/u)
+    expect(scaffold.baselineArtifactPath).toBe(
+      '.perf-validation/2026-06-21T23-00/terminal-scheduler-adaptive/terminal-scheduler-baseline-playwright.json'
     )
-    expect(scaffold.baselineCommand).not.toContain('> test-results/')
     expect(scaffold.resultPacketPath).toBe(
       '.perf-validation/2026-06-21T23-00/terminal-scheduler-adaptive/result-packet.json'
     )
+  })
+
+  it('builds Node runner commands without POSIX shell syntax for every pod', () => {
+    for (const pod of [
+      'ssh-relay-batching',
+      'git-status-coalescing',
+      'terminal-scheduler-adaptive',
+      'startup-hydration-overlap'
+    ]) {
+      const scaffold = buildPerfValidationPodScaffold({
+        artifactRoot: '.perf-validation',
+        pod,
+        runId: 'run-1'
+      })
+
+      expect(scaffold.baselineCommand).toBe(
+        `node config/scripts/run-perf-validation-pod.mjs --pod ${pod} --run-id run-1 --artifact-root .perf-validation --variant baseline`
+      )
+      expect(scaffold.candidateCommand).toBe(
+        `node config/scripts/run-perf-validation-pod.mjs --pod ${pod} --run-id run-1 --artifact-root .perf-validation --variant candidate`
+      )
+      expect(`${scaffold.baselineCommand}\n${scaffold.candidateCommand}`).not.toMatch(
+        /\s&&\s|>|\b[A-Za-z_][A-Za-z0-9_]*=/u
+      )
+    }
   })
 
   it('adds Docker daemon preflight only for the SSH relay pod', () => {
@@ -97,7 +122,11 @@ describe('perf-validation-pod-scaffold', () => {
       }
     })
 
-    const result = runPerfValidationPodPreflight({ scaffold, spawnSyncImpl })
+    const result = runPerfValidationPodPreflight({
+      mkdirSyncImpl: vi.fn(),
+      scaffold,
+      spawnSyncImpl
+    })
 
     expect(result.ok).toBe(false)
     expect(result.checks).toContainEqual(
@@ -107,6 +136,128 @@ describe('perf-validation-pod-scaffold', () => {
         reason: 'Cannot connect to the Docker daemon'
       })
     )
+  })
+
+  it('runs Playwright pods without shell redirection or POSIX env assignment', () => {
+    const scaffold = buildPerfValidationPodScaffold({
+      artifactRoot: '.perf-validation',
+      cwd: '/repo/worktree',
+      pod: 'terminal-scheduler-adaptive',
+      runId: 'run-1'
+    })
+    const writes = []
+    const { calls, spawnSyncImpl } = makeSpawnSync({
+      'pnpm run ensure:electron-runtime': { signal: null, status: 0, stdout: '', stderr: '' },
+      'pnpm exec playwright test tests/e2e/terminal-output-scheduler.spec.ts tests/e2e/terminal-typing-latency.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --repeat-each=5 --reporter=json --output .perf-validation/run-1/terminal-scheduler-adaptive/playwright-baseline':
+        {
+          signal: null,
+          status: 0,
+          stdout: '{"status":"passed"}\n',
+          stderr: ''
+        }
+    })
+
+    const result = runPerfValidationPodVariant({
+      scaffold,
+      mkdirSyncImpl: vi.fn(),
+      spawnSyncImpl,
+      variant: 'baseline',
+      writeFileSyncImpl: (file, content) => writes.push({ content, file })
+    })
+
+    expect(result).toEqual({ ok: true, status: 0 })
+    expect(calls).toEqual([
+      {
+        args: ['run', 'ensure:electron-runtime'],
+        command: 'pnpm',
+        options: { cwd: '/repo/worktree', encoding: 'utf8', env: process.env }
+      },
+      {
+        args: [
+          'exec',
+          'playwright',
+          'test',
+          'tests/e2e/terminal-output-scheduler.spec.ts',
+          'tests/e2e/terminal-typing-latency.spec.ts',
+          '--config',
+          'tests/playwright.config.ts',
+          '--project',
+          'electron-headless',
+          '--workers=1',
+          '--repeat-each=5',
+          '--reporter=json',
+          '--output',
+          '.perf-validation/run-1/terminal-scheduler-adaptive/playwright-baseline'
+        ],
+        command: 'pnpm',
+        options: { cwd: '/repo/worktree', encoding: 'utf8', env: process.env }
+      }
+    ])
+    expect(writes).toEqual([
+      {
+        content: '{"status":"passed"}\n',
+        file: '.perf-validation/run-1/terminal-scheduler-adaptive/terminal-scheduler-baseline-playwright.json'
+      }
+    ])
+  })
+
+  it('passes perf artifact paths through explicit env instead of inline shell assignment', () => {
+    const scaffold = buildPerfValidationPodScaffold({
+      artifactRoot: '.perf-validation',
+      cwd: '/repo/worktree',
+      pod: 'ssh-relay-batching',
+      runId: 'run-1'
+    })
+    const writes = []
+    const { calls, spawnSyncImpl } = makeSpawnSync({
+      'pnpm run test:e2e:ssh-docker-perf -- --repeat-each=5 --reporter=json --output .perf-validation/run-1/ssh-relay-batching/playwright-candidate':
+        {
+          signal: null,
+          status: 0,
+          stdout: '{"status":"passed"}\n',
+          stderr: ''
+        }
+    })
+
+    const result = runPerfValidationPodVariant({
+      env: { PATH: '/bin' },
+      scaffold,
+      mkdirSyncImpl: vi.fn(),
+      spawnSyncImpl,
+      variant: 'candidate',
+      writeFileSyncImpl: (file, content) => writes.push({ content, file })
+    })
+
+    expect(result).toEqual({ ok: true, status: 0 })
+    expect(calls).toEqual([
+      {
+        args: [
+          'run',
+          'test:e2e:ssh-docker-perf',
+          '--',
+          '--repeat-each=5',
+          '--reporter=json',
+          '--output',
+          '.perf-validation/run-1/ssh-relay-batching/playwright-candidate'
+        ],
+        command: 'pnpm',
+        options: {
+          cwd: '/repo/worktree',
+          encoding: 'utf8',
+          env: {
+            ORCA_E2E_SSH_DOCKER_PERF_JSON:
+              '.perf-validation/run-1/ssh-relay-batching/ssh-relay-candidate.jsonl',
+            PATH: '/bin'
+          }
+        }
+      }
+    ])
+    expect(writes).toEqual([
+      {
+        content: '{"status":"passed"}\n',
+        file: '.perf-validation/run-1/ssh-relay-batching/ssh-relay-candidate-playwright.json'
+      }
+    ])
   })
 
   it('rejects dirty worktrees before baseline artifacts are created', () => {
@@ -119,7 +270,11 @@ describe('perf-validation-pod-scaffold', () => {
       'pnpm --version': { signal: null, status: 0, stdout: '10.24.0\n', stderr: '' }
     })
 
-    const result = runPerfValidationPodPreflight({ scaffold, spawnSyncImpl })
+    const result = runPerfValidationPodPreflight({
+      mkdirSyncImpl: vi.fn(),
+      scaffold,
+      spawnSyncImpl
+    })
 
     expect(result.ok).toBe(false)
     expect(result.checks[0]).toEqual({

--- a/config/scripts/run-perf-validation-pod.mjs
+++ b/config/scripts/run-perf-validation-pod.mjs
@@ -1,0 +1,144 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import {
+  buildPerfValidationPodScaffold,
+  buildPerfValidationRunPlan
+} from './perf-validation-pod-scaffold.mjs'
+
+const DEFAULT_ARTIFACT_ROOT = '.perf-validation'
+
+function requireValue(argv, index, flag) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return value
+}
+
+export function parseRunPerfValidationPodArgs(argv, env = process.env) {
+  const options = {
+    artifactRoot: env.ORCA_PERF_VALIDATION_ARTIFACT_ROOT || DEFAULT_ARTIFACT_ROOT,
+    pod: env.ORCA_PERF_VALIDATION_POD || null,
+    runId: env.ORCA_PERF_VALIDATION_RUN_ID || null,
+    variant: null
+  }
+
+  if (argv[0] === '--') {
+    argv = argv.slice(1)
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--pod') {
+      options.pod = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--run-id') {
+      options.runId = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--artifact-root') {
+      options.artifactRoot = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--variant') {
+      options.variant = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--help') {
+      options.help = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (options.help) {
+    return options
+  }
+  if (!options.pod) {
+    throw new Error('--pod is required')
+  }
+  if (!options.runId) {
+    throw new Error('--run-id is required')
+  }
+  if (!['baseline', 'candidate'].includes(options.variant)) {
+    throw new Error('--variant must be baseline or candidate')
+  }
+  return options
+}
+
+function commandOutput(result, key) {
+  const value = result[key]
+  const text = Buffer.isBuffer(value) ? value.toString('utf8') : String(value ?? '')
+  return text.replace(/\s+$/u, '')
+}
+
+function rawCommandOutput(result, key) {
+  const value = result[key]
+  return Buffer.isBuffer(value) ? value.toString('utf8') : String(value ?? '')
+}
+
+export function runPerfValidationPodVariant({
+  env = process.env,
+  mkdirSyncImpl = mkdirSync,
+  scaffold,
+  spawnSyncImpl = spawnSync,
+  variant,
+  writeFileSyncImpl = writeFileSync
+}) {
+  const runPlan = buildPerfValidationRunPlan(scaffold, variant)
+  mkdirSyncImpl(scaffold.artifactDir, { recursive: true })
+
+  for (const step of runPlan.steps) {
+    const stepEnv = step.env ? { ...env, ...step.env } : env
+    const result = spawnSyncImpl(step.command, step.args, {
+      cwd: scaffold.worktreePath,
+      encoding: 'utf8',
+      env: stepEnv
+    })
+    if (step.stdoutFile) {
+      writeFileSyncImpl(step.stdoutFile, rawCommandOutput(result, 'stdout'))
+    }
+
+    const status = result.status ?? (result.signal ? 1 : 0)
+    if (status !== 0) {
+      return {
+        ok: false,
+        reason: commandOutput(result, 'stderr') || commandOutput(result, 'stdout'),
+        status
+      }
+    }
+  }
+
+  return { ok: true, status: 0 }
+}
+
+function usage() {
+  return `Usage: node config/scripts/run-perf-validation-pod.mjs --pod <name> --run-id <id> --variant <baseline|candidate> [options]\n\nOptions:\n  --artifact-root <dir> Durable artifact root (default ${DEFAULT_ARTIFACT_ROOT})\n`
+}
+
+export function runPerfValidationPodCli({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  env = process.env,
+  stdout = console.log
+} = {}) {
+  try {
+    const options = parseRunPerfValidationPodArgs(argv, env)
+    if (options.help) {
+      stdout(usage())
+      return 0
+    }
+    const scaffold = buildPerfValidationPodScaffold({ ...options, cwd })
+    const result = runPerfValidationPodVariant({ env, scaffold, variant: options.variant })
+    if (!result.ok && result.reason) {
+      console.error(result.reason)
+    }
+    return result.status
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    return 1
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(runPerfValidationPodCli())
+}

--- a/config/scripts/summarize-terminal-perf-report.mjs
+++ b/config/scripts/summarize-terminal-perf-report.mjs
@@ -1,5 +1,5 @@
-import { readFileSync } from 'node:fs'
 import { basename } from 'node:path'
+import { collectTerminalPerfRows, readJsonReport } from './terminal-perf-report-annotations.mjs'
 
 const reportPaths = process.argv.slice(2)
 if (reportPaths[0] === '--') {
@@ -11,55 +11,6 @@ if (reportPaths.length === 0) {
     'Usage: node config/scripts/summarize-terminal-perf-report.mjs <playwright-json>...'
   )
   process.exit(1)
-}
-
-function readJsonReport(path) {
-  const raw = readFileSync(path, 'utf8')
-  const start = raw.indexOf('{')
-  const end = raw.lastIndexOf('}')
-  if (start === -1 || end <= start) {
-    throw new Error(`${path}: no JSON object found`)
-  }
-  return JSON.parse(raw.slice(start, end + 1))
-}
-
-function parseAnnotationDescription(description) {
-  const values = {}
-  for (const part of description.split(/\s+/)) {
-    const index = part.indexOf('=')
-    if (index === -1) {
-      continue
-    }
-    values[part.slice(0, index)] = part.slice(index + 1)
-  }
-  return values
-}
-
-function collectTerminalPerfRows(report, source) {
-  const rows = []
-  const visitSuite = (suite) => {
-    for (const spec of suite.specs ?? []) {
-      for (const test of spec.tests ?? []) {
-        for (const annotation of test.annotations ?? []) {
-          if (!annotation.type.startsWith('opencode-')) {
-            continue
-          }
-          rows.push({
-            source,
-            scenario: annotation.type,
-            ...parseAnnotationDescription(annotation.description ?? '')
-          })
-        }
-      }
-    }
-    for (const child of suite.suites ?? []) {
-      visitSuite(child)
-    }
-  }
-  for (const suite of report.suites ?? []) {
-    visitSuite(suite)
-  }
-  return rows
 }
 
 function markdownCell(value) {

--- a/config/scripts/summarize-terminal-perf-report.test.mjs
+++ b/config/scripts/summarize-terminal-perf-report.test.mjs
@@ -1,0 +1,63 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const scriptPath = 'config/scripts/summarize-terminal-perf-report.mjs'
+const tempDirs = []
+
+function writeReport() {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-terminal-perf-summary-'))
+  tempDirs.push(dir)
+  const reportPath = join(dir, 'report.json')
+  writeFileSync(
+    reportPath,
+    JSON.stringify({
+      suites: [
+        {
+          specs: [
+            {
+              tests: [
+                {
+                  annotations: [
+                    {
+                      type: 'opencode-scale',
+                      description: 'panes=50 frames=60 median=12.3ms rendererQueuedChars=1000'
+                    },
+                    {
+                      type: 'browser-unrelated',
+                      description: 'panes=1 median=999.0ms'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+  )
+  return reportPath
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { force: true, recursive: true })
+  }
+})
+
+describe('summarize-terminal-perf-report', () => {
+  it('prints only OpenCode terminal perf annotation rows', () => {
+    const output = execFileSync(process.execPath, [scriptPath, writeReport()], {
+      cwd: process.cwd(),
+      encoding: 'utf8'
+    })
+
+    expect(output).toContain('| Source | Scenario | Panes | Frames | Median |')
+    expect(output).toContain('| report.json | opencode-scale | 50 | 60 | 12.3ms |')
+    expect(output).toContain('1000')
+    expect(output).not.toContain('browser-unrelated')
+    expect(output).not.toContain('999.0ms')
+  })
+})

--- a/config/scripts/terminal-perf-report-annotations.mjs
+++ b/config/scripts/terminal-perf-report-annotations.mjs
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs'
+
+export function readJsonReport(path) {
+  const raw = readFileSync(path, 'utf8')
+  const start = raw.indexOf('{')
+  const end = raw.lastIndexOf('}')
+  if (start === -1 || end <= start) {
+    throw new Error(`${path}: no JSON object found`)
+  }
+  return JSON.parse(raw.slice(start, end + 1))
+}
+
+export function parseAnnotationDescription(description) {
+  const values = {}
+  for (const part of description.split(/\s+/)) {
+    const index = part.indexOf('=')
+    if (index === -1) {
+      continue
+    }
+    values[part.slice(0, index)] = part.slice(index + 1)
+  }
+  return values
+}
+
+export function collectTerminalPerfRows(report, source, options = {}) {
+  const { typePrefix = 'opencode-' } = options
+  const rows = []
+  const visitSuite = (suite) => {
+    for (const spec of suite.specs ?? []) {
+      for (const test of spec.tests ?? []) {
+        for (const annotation of test.annotations ?? []) {
+          if (!annotation.type.startsWith(typePrefix)) {
+            continue
+          }
+          rows.push({
+            source,
+            scenario: annotation.type,
+            ...parseAnnotationDescription(annotation.description ?? '')
+          })
+        }
+      }
+    }
+    for (const child of suite.suites ?? []) {
+      visitSuite(child)
+    }
+  }
+  for (const suite of report.suites ?? []) {
+    visitSuite(suite)
+  }
+  return rows
+}

--- a/config/scripts/terminal-perf-report-annotations.test.mjs
+++ b/config/scripts/terminal-perf-report-annotations.test.mjs
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  collectTerminalPerfRows,
+  parseAnnotationDescription,
+  readJsonReport
+} from './terminal-perf-report-annotations.mjs'
+
+const tempDirs = []
+
+function makeReportPath(content) {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-terminal-perf-annotations-'))
+  tempDirs.push(dir)
+  const reportPath = join(dir, 'report.json')
+  writeFileSync(reportPath, content)
+  return reportPath
+}
+
+function makeNestedReport() {
+  return {
+    suites: [
+      {
+        specs: [
+          {
+            tests: [
+              {
+                annotations: [
+                  {
+                    type: 'browser-unrelated',
+                    description: 'median=999.0ms'
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        suites: [
+          {
+            specs: [
+              {
+                tests: [
+                  {
+                    annotations: [
+                      {
+                        type: 'opencode-scale',
+                        description: 'panes=50 median=12.3ms ignored-token rendererQueuedChars=1000'
+                      },
+                      {
+                        type: 'terminal-scale',
+                        description: 'panes=25 median=7.0ms'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { force: true, recursive: true })
+  }
+})
+
+describe('terminal perf report annotations', () => {
+  it('parses key-value annotation description segments only', () => {
+    expect(parseAnnotationDescription('panes=50 no-equals median=12.3ms name=a=b')).toEqual({
+      median: '12.3ms',
+      name: 'a=b',
+      panes: '50'
+    })
+  })
+
+  it('reads JSON reports surrounded by noisy process output', () => {
+    const reportPath = makeReportPath(
+      `noise before\n${JSON.stringify({ suites: [] })}\nnoise after`
+    )
+
+    expect(readJsonReport(reportPath)).toEqual({ suites: [] })
+  })
+
+  it('collects nested OpenCode annotations by default', () => {
+    expect(collectTerminalPerfRows(makeNestedReport(), 'report.json')).toEqual([
+      {
+        median: '12.3ms',
+        panes: '50',
+        rendererQueuedChars: '1000',
+        scenario: 'opencode-scale',
+        source: 'report.json'
+      }
+    ])
+  })
+
+  it('supports a custom annotation type prefix', () => {
+    expect(
+      collectTerminalPerfRows(makeNestedReport(), 'report.json', { typePrefix: 'terminal-' })
+    ).toEqual([
+      {
+        median: '7.0ms',
+        panes: '25',
+        scenario: 'terminal-scale',
+        source: 'report.json'
+      }
+    ])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -80,7 +80,10 @@
     "test:e2e:ssh-docker-perf": "node config/scripts/run-ssh-docker-perf-e2e.mjs",
     "test:e2e:headful": "pnpm run ensure:electron-runtime && npx playwright test --config tests/playwright.config.ts --project electron-headful",
     "test:e2e:computer": "vitest run --config tests/e2e/vitest.config.ts",
-    "bench:idle-cpu": "pnpm run ensure:electron-runtime && node config/scripts/run-idle-cpu-benchmark.mjs"
+    "bench:idle-cpu": "pnpm run ensure:electron-runtime && node config/scripts/run-idle-cpu-benchmark.mjs",
+    "bench:startup": "pnpm run ensure:electron-runtime && node tools/benchmarks/startup-time-bench.mjs",
+    "bench:daemon-coldstart": "pnpm run ensure:electron-runtime && node tools/benchmarks/daemon-coldstart-bench.mjs",
+    "bench:compare": "node config/scripts/compare-benchmark-artifacts.mjs"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "bench:idle-cpu": "pnpm run ensure:electron-runtime && node config/scripts/run-idle-cpu-benchmark.mjs",
     "bench:startup": "pnpm run ensure:electron-runtime && node tools/benchmarks/startup-time-bench.mjs",
     "bench:daemon-coldstart": "pnpm run ensure:electron-runtime && node tools/benchmarks/daemon-coldstart-bench.mjs",
-    "bench:compare": "node config/scripts/compare-benchmark-artifacts.mjs"
+    "bench:compare": "node config/scripts/compare-benchmark-artifacts.mjs",
+    "perf:pod:scaffold": "node config/scripts/perf-validation-pod-scaffold.mjs"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",

--- a/src/main/computer/macos-computer-use-permission-status.test.ts
+++ b/src/main/computer/macos-computer-use-permission-status.test.ts
@@ -180,6 +180,26 @@ describe('getComputerUsePermissionStatus', () => {
     expect(rm).toHaveBeenCalledTimes(1)
   })
 
+  it('does not back off status-file polling timeouts', async () => {
+    vi.useFakeTimers()
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+    vi.mocked(stat).mockRejectedValue(new Error('missing'))
+
+    const timedOutStatus = getComputerUsePermissionStatus()
+    await vi.advanceTimersByTimeAsync(5_000)
+    await expect(timedOutStatus).rejects.toMatchObject({
+      name: 'RuntimeClientError',
+      code: 'accessibility_error',
+      message: 'Timed out checking permissions'
+    })
+
+    vi.mocked(stat).mockResolvedValue({} as Awaited<ReturnType<typeof stat>>)
+    await expect(getComputerUsePermissionStatus()).resolves.toMatchObject({
+      helperUnavailableReason: null
+    })
+    expect(spawn).toHaveBeenCalledTimes(2)
+  })
+
   it('wraps permission status helper launch failures', async () => {
     const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
     const child = {

--- a/src/main/computer/macos-computer-use-permission-status.test.ts
+++ b/src/main/computer/macos-computer-use-permission-status.test.ts
@@ -44,6 +44,7 @@ describe('getComputerUsePermissionStatus', () => {
   const originalPlatform = process.platform
 
   beforeEach(() => {
+    vi.resetModules()
     vi.mocked(spawn).mockClear()
     vi.mocked(spawnSync).mockClear()
     vi.mocked(execFileSync).mockReset()
@@ -66,6 +67,117 @@ describe('getComputerUsePermissionStatus', () => {
   afterEach(() => {
     vi.useRealTimers()
     setPlatform(originalPlatform)
+  })
+
+  it('coalesces concurrent permission status probes into one helper launch', async () => {
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+    mockPermissionStatus('{"accessibility":"granted","screenshots":"not-granted"}')
+
+    const firstStatus = getComputerUsePermissionStatus()
+    const secondStatus = getComputerUsePermissionStatus()
+
+    await expect(firstStatus).resolves.toMatchObject({
+      helperUnavailableReason: null,
+      permissions: [
+        { id: 'accessibility', status: 'granted' },
+        { id: 'screenshots', status: 'not-granted' }
+      ]
+    })
+    await expect(secondStatus).resolves.toMatchObject({
+      helperUnavailableReason: null,
+      permissions: [
+        { id: 'accessibility', status: 'granted' },
+        { id: 'screenshots', status: 'not-granted' }
+      ]
+    })
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(spawn).toHaveBeenCalledWith(
+      '/usr/bin/open',
+      [
+        '-n',
+        '/Applications/Orca Computer Use.app',
+        '--args',
+        '--permission-status-file',
+        permissionStatusPath
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    )
+    expect(mkdtemp).toHaveBeenCalledTimes(1)
+    expect(rm).toHaveBeenCalledTimes(1)
+    expect(rm).toHaveBeenCalledWith(permissionStatusTempDir, {
+      recursive: true,
+      force: true
+    })
+  })
+
+  it('backs off recent permission status launch failures with a stable error', async () => {
+    vi.useFakeTimers()
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+    const child = {
+      stdout: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
+      stderr: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
+      on: vi.fn((event: string, callback: (error: Error) => void) => {
+        if (event === 'error') {
+          queueMicrotask(() => callback(new Error('spawn ENOENT /private/path')))
+        }
+        return child
+      }),
+      off: vi.fn(() => child),
+      unref: vi.fn()
+    }
+    vi.mocked(spawn).mockImplementationOnce(() => child as unknown as ReturnType<typeof spawn>)
+
+    const expectedError = {
+      name: 'RuntimeClientError',
+      code: 'accessibility_error',
+      message: 'Could not check permissions: failed to launch helper'
+    }
+    await expect(getComputerUsePermissionStatus()).rejects.toMatchObject(expectedError)
+    await expect(getComputerUsePermissionStatus()).rejects.toMatchObject(expectedError)
+    expect(spawn).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    await expect(getComputerUsePermissionStatus()).resolves.toMatchObject({
+      helperUnavailableReason: null
+    })
+    expect(spawn).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares an in-flight permission status launch failure across concurrent callers', async () => {
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+    const handlers: { error?: (error: Error) => void } = {}
+    const child = {
+      stdout: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
+      stderr: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
+      on: vi.fn((event: string, callback: (error: Error) => void) => {
+        if (event === 'error') {
+          handlers.error = callback
+        }
+        return child
+      }),
+      off: vi.fn(() => child),
+      unref: vi.fn()
+    }
+    vi.mocked(spawn).mockImplementationOnce(() => child as unknown as ReturnType<typeof spawn>)
+
+    const firstStatus = getComputerUsePermissionStatus()
+    const secondStatus = getComputerUsePermissionStatus()
+    await vi.waitFor(() => expect(handlers.error).toBeDefined())
+    handlers.error?.(new Error('spawn ENOENT /private/path'))
+
+    const results = await Promise.allSettled([firstStatus, secondStatus])
+    for (const result of results) {
+      expect(result.status).toBe('rejected')
+      if (result.status === 'rejected') {
+        expect(result.reason).toMatchObject({
+          name: 'RuntimeClientError',
+          code: 'accessibility_error',
+          message: 'Could not check permissions: failed to launch helper'
+        })
+      }
+    }
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(rm).toHaveBeenCalledTimes(1)
   })
 
   it('wraps permission status helper launch failures', async () => {

--- a/src/main/computer/macos-computer-use-permission-status.ts
+++ b/src/main/computer/macos-computer-use-permission-status.ts
@@ -36,7 +36,7 @@ export function getComputerUsePermissionStatus(): Promise<ComputerUsePermissionS
 
   const probePromise = getComputerUsePermissionStatusAsync()
     .catch((error: unknown) => {
-      if (error instanceof RuntimeClientError) {
+      if (error instanceof RuntimeClientError && isPermissionStatusLaunchFailure(error)) {
         rememberPermissionStatusLaunchFailure(error)
       }
       throw error
@@ -61,6 +61,13 @@ function getRecentPermissionStatusLaunchFailure(now = Date.now()): RuntimeClient
   return new RuntimeClientError(
     recentPermissionStatusLaunchFailure.code,
     recentPermissionStatusLaunchFailure.message
+  )
+}
+
+function isPermissionStatusLaunchFailure(error: RuntimeClientError): boolean {
+  return (
+    error.message.startsWith('Could not check permissions:') ||
+    error.message === 'Timed out launching permission helper'
   )
 }
 

--- a/src/main/computer/macos-computer-use-permission-status.ts
+++ b/src/main/computer/macos-computer-use-permission-status.ts
@@ -15,9 +15,61 @@ import {
 import { RuntimeClientError } from './runtime-client-error'
 
 const PERMISSION_STATUS_HELPER_LAUNCH_TIMEOUT_MS = 5_000
+const PERMISSION_STATUS_FAILURE_BACKOFF_MS = 10_000
+
+let permissionStatusProbePromise: Promise<ComputerUsePermissionStatusResult> | null = null
+let recentPermissionStatusLaunchFailure: {
+  expiresAt: number
+  code: string
+  message: string
+} | null = null
 
 export function getComputerUsePermissionStatus(): Promise<ComputerUsePermissionStatusResult> {
-  return getComputerUsePermissionStatusAsync()
+  if (permissionStatusProbePromise) {
+    return permissionStatusProbePromise
+  }
+
+  const recentFailure = getRecentPermissionStatusLaunchFailure()
+  if (recentFailure) {
+    return Promise.reject(recentFailure)
+  }
+
+  const probePromise = getComputerUsePermissionStatusAsync()
+    .catch((error: unknown) => {
+      if (error instanceof RuntimeClientError) {
+        rememberPermissionStatusLaunchFailure(error)
+      }
+      throw error
+    })
+    .finally(() => {
+      if (permissionStatusProbePromise === probePromise) {
+        permissionStatusProbePromise = null
+      }
+    })
+  permissionStatusProbePromise = probePromise
+  return probePromise
+}
+
+function getRecentPermissionStatusLaunchFailure(now = Date.now()): RuntimeClientError | null {
+  if (!recentPermissionStatusLaunchFailure) {
+    return null
+  }
+  if (now >= recentPermissionStatusLaunchFailure.expiresAt) {
+    recentPermissionStatusLaunchFailure = null
+    return null
+  }
+  return new RuntimeClientError(
+    recentPermissionStatusLaunchFailure.code,
+    recentPermissionStatusLaunchFailure.message
+  )
+}
+
+function rememberPermissionStatusLaunchFailure(error: RuntimeClientError, now = Date.now()): void {
+  recentPermissionStatusLaunchFailure = {
+    expiresAt: now + PERMISSION_STATUS_FAILURE_BACKOFF_MS,
+    code: error.code,
+    message: error.message
+  }
 }
 
 async function getComputerUsePermissionStatusAsync(): Promise<ComputerUsePermissionStatusResult> {

--- a/src/main/computer/macos-computer-use-permissions.test.ts
+++ b/src/main/computer/macos-computer-use-permissions.test.ts
@@ -150,6 +150,64 @@ describe('openComputerUsePermissions', () => {
     )
   })
 
+  it('shares the prerequisite status probe while preserving targeted setup launches', async () => {
+    resolveHelperAppPathMock.mockReturnValue('/Applications/Orca Computer Use.app')
+    mockPermissionStatus('{"accessibility":"not-granted","screenshots":"not-granted"}')
+
+    await expect(
+      Promise.all([
+        openComputerUsePermissions('accessibility'),
+        openComputerUsePermissions('screenshots')
+      ])
+    ).resolves.toHaveLength(2)
+
+    const openCalls = vi.mocked(spawn).mock.calls.filter(([command]) => command === '/usr/bin/open')
+    const statusLaunches = openCalls.filter(([, args]) =>
+      (args as string[]).includes('--permission-status-file')
+    )
+    const accessibilityLaunches = openCalls.filter(([, args]) => {
+      const helperArgs = args as string[]
+      return helperArgs.includes('--permission') && helperArgs.includes('accessibility')
+    })
+    const screenshotsLaunches = openCalls.filter(([, args]) => {
+      const helperArgs = args as string[]
+      return helperArgs.includes('--permission') && helperArgs.includes('screenshots')
+    })
+    expect(statusLaunches).toHaveLength(1)
+    expect(accessibilityLaunches).toHaveLength(1)
+    expect(screenshotsLaunches).toHaveLength(1)
+    expect(spawnSync).toHaveBeenCalledWith(
+      '/usr/bin/pkill',
+      ['-f', 'orca-computer-use-macos[[:space:]]+--permission([[:space:]]|$)'],
+      { stdio: 'ignore' }
+    )
+    expect(spawnSync).toHaveBeenCalledWith(
+      '/usr/bin/pkill',
+      ['-f', 'orca-computer-use-macos[[:space:]]+--permissions([[:space:]]|$)'],
+      { stdio: 'ignore' }
+    )
+
+    const setupLaunchOrders = vi.mocked(spawn).mock.invocationCallOrder.filter((_, index) => {
+      const args = vi.mocked(spawn).mock.calls[index]?.[1] as string[] | undefined
+      return args?.includes('--permission')
+    })
+    const pkillCalls = vi.mocked(spawnSync).mock.calls
+    for (const setupLaunchOrder of setupLaunchOrders) {
+      const priorPkillPatterns = vi
+        .mocked(spawnSync)
+        .mock.invocationCallOrder.flatMap((order, index) => {
+          const pattern = pkillCalls[index]?.[1]?.[1]
+          return order < setupLaunchOrder && pattern ? [pattern] : []
+        })
+      expect(priorPkillPatterns).toContain(
+        'orca-computer-use-macos[[:space:]]+--permission([[:space:]]|$)'
+      )
+      expect(priorPkillPatterns).toContain(
+        'orca-computer-use-macos[[:space:]]+--permissions([[:space:]]|$)'
+      )
+    }
+  })
+
   it('launches a targeted permission helper even when that permission is already granted', async () => {
     resolveHelperAppPathMock.mockReturnValue('/Applications/Orca Computer Use.app')
     mockPermissionStatus('{"accessibility":"granted","screenshots":"not-granted"}')

--- a/src/main/computer/macos-native-provider-client.test.ts
+++ b/src/main/computer/macos-native-provider-client.test.ts
@@ -117,6 +117,180 @@ describe('MacOSNativeProviderClient', () => {
     vi.useRealTimers()
   })
 
+  it('coalesces concurrent native provider startup attempts', async () => {
+    const pendingConnects: {
+      resolve: (socket: FakeSocket) => void
+    }[] = []
+    connectMacOSProviderSocketMock.mockImplementation(
+      async () =>
+        await new Promise<FakeSocket>((resolve) => {
+          pendingConnects.push({ resolve })
+        })
+    )
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const firstCall = client.capabilities()
+    const secondCall = client.capabilities()
+    await vi.waitFor(() => expect(pendingConnects).toHaveLength(1))
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    expect(connectMacOSProviderSocketMock).toHaveBeenCalledTimes(1)
+
+    const socket = new FakeSocket()
+    pendingConnects[0]!.resolve(socket)
+    await vi.waitFor(() => expect(socket.writes).toHaveLength(2))
+
+    const firstRequest = JSON.parse(socket.writes[0]!) as { id: number }
+    const secondRequest = JSON.parse(socket.writes[1]!) as { id: number }
+    const capabilities = { protocolVersion: 1, supports: {} }
+    socket.emit(
+      'data',
+      `${JSON.stringify({ id: firstRequest.id, ok: true, result: capabilities })}\n`
+    )
+    socket.emit(
+      'data',
+      `${JSON.stringify({ id: secondRequest.id, ok: true, result: capabilities })}\n`
+    )
+
+    await expect(firstCall).resolves.toEqual(capabilities)
+    await expect(secondCall).resolves.toEqual(capabilities)
+  })
+
+  it('backs off recent native provider startup failures without spawning another helper', async () => {
+    connectMacOSProviderSocketMock.mockRejectedValueOnce(new Error('socket did not open'))
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    await expect(client.capabilities()).rejects.toMatchObject({
+      code: 'accessibility_error',
+      message: 'socket did not open'
+    })
+    await expect(client.capabilities()).rejects.toMatchObject({
+      code: 'accessibility_error',
+      message: 'socket did not open'
+    })
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    const thirdCall = client.capabilities()
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    const socket = sockets[0]!
+    await vi.waitFor(() => expect(socket.writes).toHaveLength(1))
+    const request = JSON.parse(socket.writes[0]!) as { id: number }
+    socket.emit(
+      'data',
+      `${JSON.stringify({
+        id: request.id,
+        ok: true,
+        result: { protocolVersion: 1, supports: {} }
+      })}\n`
+    )
+
+    await expect(thirdCall).resolves.toMatchObject({ protocolVersion: 1 })
+    expect(spawnMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not remember superseded startup as a launch failure', async () => {
+    const pendingConnects: {
+      resolve: (socket: FakeSocket) => void
+    }[] = []
+    connectMacOSProviderSocketMock.mockImplementation(
+      async () =>
+        await new Promise<FakeSocket>((resolve) => {
+          pendingConnects.push({ resolve })
+        })
+    )
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const firstCall = client.capabilities()
+    await vi.waitFor(() => expect(pendingConnects).toHaveLength(1))
+    client.shutdown()
+
+    const secondCall = client.capabilities()
+    await vi.waitFor(() => expect(pendingConnects).toHaveLength(2))
+    const secondSocket = new FakeSocket()
+    pendingConnects[1]!.resolve(secondSocket)
+    await vi.waitFor(() => expect(secondSocket.writes).toHaveLength(1))
+    const secondRequest = JSON.parse(secondSocket.writes[0]!) as { id: number }
+
+    pendingConnects[0]!.resolve(new FakeSocket())
+    await expect(firstCall).rejects.toThrow('native macOS provider startup was superseded')
+    secondSocket.emit(
+      'data',
+      `${JSON.stringify({
+        id: secondRequest.id,
+        ok: true,
+        result: macOSProviderCapabilities()
+      })}\n`
+    )
+    await expect(secondCall).resolves.toMatchObject({ protocolVersion: 1 })
+
+    secondSocket.emit('close')
+    const thirdCall = client.action('click', {
+      app: 'TextEdit',
+      elementIndex: 0
+    })
+    await vi.waitFor(() => expect(pendingConnects).toHaveLength(3))
+    const thirdSocket = new FakeSocket()
+    pendingConnects[2]!.resolve(thirdSocket)
+    await vi.waitFor(() => expect(thirdSocket.writes).toHaveLength(1))
+    const thirdRequest = JSON.parse(thirdSocket.writes[0]!) as { id: number }
+    thirdSocket.emit(
+      'data',
+      `${JSON.stringify({
+        id: thirdRequest.id,
+        ok: true,
+        result: {
+          snapshot: {},
+          action: { path: 'native', actionName: 'AXPress', fallbackReason: null }
+        }
+      })}\n`
+    )
+
+    await expect(thirdCall).resolves.toMatchObject({
+      action: { path: 'native', actionName: 'AXPress' }
+    })
+  })
+
+  it('does not back off native action errors after startup succeeds', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const actionCall = client.action('click', {
+      app: 'TextEdit',
+      elementIndex: 0
+    })
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    const socket = sockets[0]!
+    await vi.waitFor(() => expect(socket.writes).toHaveLength(1))
+    const handshakeRequest = JSON.parse(socket.writes[0]!) as { id: number }
+    socket.emit(
+      'data',
+      `${JSON.stringify({
+        id: handshakeRequest.id,
+        ok: true,
+        result: macOSProviderCapabilities()
+      })}\n`
+    )
+    await vi.waitFor(() => expect(socket.writes).toHaveLength(2))
+    const actionRequest = JSON.parse(socket.writes[1]!) as { id: number }
+    socket.emit(
+      'data',
+      `${JSON.stringify({
+        id: actionRequest.id,
+        ok: false,
+        error: { code: 'action_failed', message: 'native action failed' }
+      })}\n`
+    )
+
+    await expect(actionCall).rejects.toMatchObject({
+      code: 'action_failed',
+      message: 'native action failed'
+    })
+    await expect(client.capabilities()).resolves.toMatchObject({ protocolVersion: 1 })
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
   it('ignores stale socket data, close, and error after a replacement socket starts', async () => {
     const { MacOSNativeProviderClient } = await loadClientModule()
     const client = new MacOSNativeProviderClient()

--- a/src/main/computer/macos-native-provider-client.ts
+++ b/src/main/computer/macos-native-provider-client.ts
@@ -26,9 +26,8 @@ import {
 import { validateComputerProviderActionParams } from './computer-provider-action-validation'
 import { normalizeComputerActionResult } from './computer-action-verification-normalization'
 import { RuntimeClientError } from './runtime-client-error'
-
+import { NativeProviderStartupFailureBackoff } from './macos-native-provider-startup-failure-backoff'
 const REQUEST_TIMEOUT_MS = 60_000
-
 export class MacOSNativeProviderClient {
   private socket: net.Socket | null = null
   private socketStartPromise: Promise<net.Socket> | null = null
@@ -41,6 +40,7 @@ export class MacOSNativeProviderClient {
   private providerCapabilities: ComputerProviderCapabilities | null = null
   private socketListenerCleanup: (() => void) | null = null
   private socketStartGeneration = 0
+  private readonly socketStartFailureBackoff = new NativeProviderStartupFailureBackoff()
   async listApps(): Promise<ComputerListAppsResult> {
     return (await this.call('listApps', {})) as ComputerListAppsResult
   }
@@ -71,6 +71,7 @@ export class MacOSNativeProviderClient {
     this.socketStartGeneration++
     this.providerCapabilities = null
     this.socketBuffer = ''
+    this.socketStartFailureBackoff.clear()
     this.cleanupActiveSocketListeners()
     if (socket && !socket.destroyed) {
       const id = this.nextId++
@@ -176,10 +177,22 @@ export class MacOSNativeProviderClient {
     if (this.socketStartPromise) {
       return await this.socketStartPromise
     }
+    const recentFailure = this.socketStartFailureBackoff.get()
+    if (recentFailure) {
+      throw recentFailure
+    }
     const socketStartPromise = this.startSocket(helperExecutablePath)
     this.socketStartPromise = socketStartPromise
     try {
-      return await socketStartPromise
+      const socket = await socketStartPromise
+      this.socketStartFailureBackoff.clear()
+      return socket
+    } catch (error) {
+      const wrapped = this.socketStartFailureBackoff.normalize(error)
+      if (this.socketStartFailureBackoff.shouldRemember(wrapped)) {
+        this.socketStartFailureBackoff.remember(wrapped)
+      }
+      throw wrapped
     } finally {
       if (this.socketStartPromise === socketStartPromise) {
         this.socketStartPromise = null
@@ -253,27 +266,23 @@ export class MacOSNativeProviderClient {
   }
   private handleTransportError(socket: net.Socket, error: Error): void {
     // Why: stale socket errors can arrive after shutdown/restart.
-    if (this.socket !== socket) {
-      return
-    }
-    this.cleanupActiveSocketListeners()
-    // Why: an active transport error makes the helper socket unreliable for the next request.
-    this.socket = null
-    this.socketBuffer = ''
-    if (!socket.destroyed) {
-      socket.destroy()
-    }
-    this.cleanupSocketDirectory()
-    this.rejectPending(new RuntimeClientError('accessibility_error', error.message))
+    this.invalidateActiveSocket(
+      socket,
+      new RuntimeClientError('accessibility_error', error.message)
+    )
   }
   private invalidateActiveSocketAfterWriteFailure(
     socket: net.Socket,
     error: RuntimeClientError
   ): void {
+    this.invalidateActiveSocket(socket, error)
+  }
+  private invalidateActiveSocket(socket: net.Socket, error: RuntimeClientError): void {
     if (this.socket !== socket) {
       return
     }
     this.cleanupActiveSocketListeners()
+    // Why: an active transport error makes the helper socket unreliable for the next request.
     this.socket = null
     this.socketBuffer = ''
     if (!socket.destroyed) {

--- a/src/main/computer/macos-native-provider-startup-failure-backoff.ts
+++ b/src/main/computer/macos-native-provider-startup-failure-backoff.ts
@@ -1,0 +1,51 @@
+import { RuntimeClientError } from './runtime-client-error'
+
+const SOCKET_START_FAILURE_BACKOFF_MS = 10_000
+const SUPERSEDED_STARTUP_MESSAGE = 'native macOS provider startup was superseded'
+
+type StoredSocketStartFailure = {
+  expiresAt: number
+  code: string
+  message: string
+}
+
+export class NativeProviderStartupFailureBackoff {
+  private recentFailure: StoredSocketStartFailure | null = null
+
+  get(now = Date.now()): RuntimeClientError | null {
+    if (!this.recentFailure) {
+      return null
+    }
+    if (now >= this.recentFailure.expiresAt) {
+      this.clear()
+      return null
+    }
+    return new RuntimeClientError(this.recentFailure.code, this.recentFailure.message)
+  }
+
+  remember(error: RuntimeClientError, now = Date.now()): void {
+    this.recentFailure = {
+      expiresAt: now + SOCKET_START_FAILURE_BACKOFF_MS,
+      code: error.code,
+      message: error.message
+    }
+  }
+
+  clear(): void {
+    this.recentFailure = null
+  }
+
+  normalize(error: unknown): RuntimeClientError {
+    if (error instanceof RuntimeClientError) {
+      return error
+    }
+    return new RuntimeClientError(
+      'accessibility_error',
+      error instanceof Error ? error.message : String(error)
+    )
+  }
+
+  shouldRemember(error: RuntimeClientError): boolean {
+    return error.message !== SUPERSEDED_STARTUP_MESSAGE
+  }
+}

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -250,7 +250,7 @@ vi.mock('./daemon-pty-adapter', () => ({
       this.options = opts
       this.callOrder = []
       this.getActiveSessionIds = vi.fn(() => [] as string[])
-      this.fanoutSyntheticExits = vi.fn(() => {
+      this.fanoutSyntheticExits = vi.fn(async () => {
         this.callOrder.push('fanoutSyntheticExits')
       })
       this.listProcesses = vi.fn(async () => [])
@@ -383,7 +383,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     originalAdapter.getActiveSessionIds.mockImplementation(() => [...activeIds])
 
     const order: string[] = []
-    originalAdapter.fanoutSyntheticExits.mockImplementation(() => {
+    originalAdapter.fanoutSyntheticExits.mockImplementation(async () => {
       order.push('fanout')
       activeIds = []
     })
@@ -401,6 +401,31 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     // The load-bearing ordering invariant: the synthetic exits must reach
     // the renderer *before* listeners are torn down. Step 1 before Step 2.
     expect(order).toEqual(['fanout', 'unbind'])
+  })
+
+  it('awaits synthetic exit cleanup before unbinding listeners', async () => {
+    const mod = await importFresh()
+    await mod.initDaemonPtyProvider()
+
+    const originalAdapter = adapterInstances[0]
+    let resolveFanout: (() => void) | undefined
+    const fanoutDeferred = new Promise<void>((resolve) => {
+      resolveFanout = resolve
+    })
+    originalAdapter.fanoutSyntheticExits.mockImplementation(async () => {
+      await fanoutDeferred
+    })
+
+    const restart = mod.restartDaemon()
+    await Promise.resolve()
+
+    expect(unbindLocalProviderListenersMock).not.toHaveBeenCalled()
+
+    resolveFanout?.()
+    await restart
+
+    expect(unbindLocalProviderListenersMock).toHaveBeenCalled()
+    expect(originalAdapter.fanoutSyntheticExits).toHaveBeenCalledWith(-1)
   })
 
   it('reuses the existing DaemonSpawner across restart (resetHandle + ensureRunning on same instance)', async () => {
@@ -591,7 +616,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     // load-bearing observable is `resetHandle` — it fires *after* cleanup
     // returns. So we instrument the spawner instead.
     const trace: string[] = []
-    originalAdapter.fanoutSyntheticExits.mockImplementation(() => trace.push('fanout'))
+    originalAdapter.fanoutSyntheticExits.mockImplementation(async () => {
+      trace.push('fanout')
+    })
     unbindLocalProviderListenersMock.mockImplementation(() => trace.push('unbind'))
     originalSpawner.resetHandle.mockImplementation(() => trace.push('resetHandle'))
     const originalEnsureRunning = originalSpawner.ensureRunning

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -478,7 +478,7 @@ async function runRestartDaemon(): Promise<RestartDaemonResult> {
   // without this the renderer would never see exits and would black-hole
   // writes against the disposed adapter.
   const killedCount = currentOnly.getActiveSessionIds().length
-  currentOnly.fanoutSyntheticExits(-1)
+  await currentOnly.fanoutSyntheticExits(-1)
 
   // Step 2: detach renderer listeners from the current adapter. Must happen
   // AFTER step 1 so the synthesized exits actually reach the renderer, and

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { HistoryReader } from './history-reader'
 import { DaemonServer } from './daemon-server'
 import { getHistorySessionDirName } from './history-paths'
 import type { SubprocessHandle } from './session'
@@ -769,12 +770,11 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(existsSync(join(historyDir, getHistorySessionDirName(id)))).toBe(true)
 
       await historyAdapter.shutdown(id, { immediate: true })
-      await new Promise((r) => setTimeout(r, 50))
 
       expect(existsSync(join(historyDir, getHistorySessionDirName(id)))).toBe(false)
     })
 
-    it('writes a final checkpoint before keepHistory shutdown', async () => {
+    it('does not remove or tombstone history on keepHistory shutdown', async () => {
       historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
 
       const { id } = await historyAdapter.spawn({
@@ -788,11 +788,15 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       lastSubprocess._simulateData('fresh output before sleep\r\n')
       await historyAdapter.shutdown(id, { immediate: true, keepHistory: true })
 
+      const sessionDir = join(historyDir, getHistorySessionDirName(id))
+      const meta = JSON.parse(readFileSync(join(sessionDir, 'meta.json'), 'utf-8'))
+      expect(existsSync(sessionDir)).toBe(true)
+      expect(meta.endedAt).toBeNull()
       expect(checkpointSpy).toHaveBeenCalledWith(
         id,
         expect.objectContaining({ snapshotAnsi: expect.stringContaining('fresh output') })
       )
-      expect(existsSync(join(historyDir, getHistorySessionDirName(id)))).toBe(true)
+      expect(new HistoryReader(historyDir).detectColdRestore(id)).not.toBeNull()
     })
 
     it('returns cold restore data when disk history has unclean shutdown', async () => {
@@ -1296,7 +1300,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(active).toHaveLength(2)
     })
 
-    it('emits a synthetic exit for every active id with the supplied code', () => {
+    it('emits a synthetic exit for every active id with the supplied code', async () => {
       const exits: { id: string; code: number }[] = []
       adapter.onExit((payload) => exits.push(payload))
 
@@ -1306,7 +1310,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         internals.activeSessionIds.add(id)
       }
 
-      adapter.fanoutSyntheticExits(-1)
+      await adapter.fanoutSyntheticExits(-1)
 
       expect(exits).toHaveLength(3)
       expect(exits.map((e) => e.id).sort()).toEqual([...ids].sort())
@@ -1315,22 +1319,22 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       }
     })
 
-    it('clears activeSessionIds after fanout so a second call is a no-op', () => {
+    it('clears activeSessionIds after fanout so a second call is a no-op', async () => {
       const exits: { id: string; code: number }[] = []
       adapter.onExit((payload) => exits.push(payload))
 
       const internals = adapter as unknown as { activeSessionIds: Set<string> }
       internals.activeSessionIds.add('sess-a')
 
-      adapter.fanoutSyntheticExits(-1)
+      await adapter.fanoutSyntheticExits(-1)
       expect(exits).toHaveLength(1)
       expect(adapter.getActiveSessionIds()).toEqual([])
 
-      adapter.fanoutSyntheticExits(-1)
+      await adapter.fanoutSyntheticExits(-1)
       expect(exits).toHaveLength(1)
     })
 
-    it('propagates to every registered exit listener in order', () => {
+    it('propagates to every registered exit listener in order', async () => {
       const aExits: { id: string; code: number }[] = []
       const bExits: { id: string; code: number }[] = []
       adapter.onExit((payload) => aExits.push(payload))
@@ -1339,10 +1343,54 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       const internals = adapter as unknown as { activeSessionIds: Set<string> }
       internals.activeSessionIds.add('sess-a')
 
-      adapter.fanoutSyntheticExits(-1)
+      await adapter.fanoutSyntheticExits(-1)
 
       expect(aExits).toEqual([{ id: 'sess-a', code: -1 }])
       expect(bExits).toEqual([{ id: 'sess-a', code: -1 }])
+    })
+
+    it('clears dirty, checkpoint, cold restore, initial cwd, and tombstones history', async () => {
+      const historyDir = join(dir, 'history')
+      const historyAdapter = new DaemonPtyAdapter({
+        socketPath,
+        tokenPath,
+        historyPath: historyDir
+      })
+      try {
+        const exits: { id: string; code: number }[] = []
+        historyAdapter.onExit((payload) => exits.push(payload))
+
+        const { id } = await historyAdapter.spawn({
+          cols: 80,
+          rows: 24,
+          cwd: '/fanout-cwd',
+          sessionId: 'fanout-history'
+        })
+        const internals = historyAdapter as unknown as {
+          dirtySessionVersions: Map<string, number>
+          sessionsNeedingFullCheckpoint: Set<string>
+          coldRestoreCache: Map<string, { scrollback: string; cwd: string; oscLinks?: unknown[] }>
+          initialCwds: Map<string, string>
+        }
+
+        lastSubprocess._simulateData('dirty output\r\n')
+        await waitFor(() => internals.dirtySessionVersions.has(id))
+        internals.sessionsNeedingFullCheckpoint.add(id)
+        internals.coldRestoreCache.set(id, { scrollback: 'restore', cwd: '/fanout-cwd' })
+        expect(internals.initialCwds.get(id)).toBe('/fanout-cwd')
+
+        await historyAdapter.fanoutSyntheticExits(-1)
+
+        expect(historyAdapter.getActiveSessionIds()).toEqual([])
+        expect(internals.dirtySessionVersions.has(id)).toBe(false)
+        expect(internals.sessionsNeedingFullCheckpoint.has(id)).toBe(false)
+        expect(internals.coldRestoreCache.has(id)).toBe(false)
+        expect(internals.initialCwds.has(id)).toBe(false)
+        expect(new HistoryReader(historyDir).detectColdRestore(id)).toBeNull()
+        expect(exits).toEqual([{ id, code: -1 }])
+      } finally {
+        historyAdapter.dispose()
+      }
     })
   })
 })

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -315,9 +315,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // re-spawns and the cold-restore reader needs the dir intact. Caller
     // indicates intent via opts.keepHistory.
     if (this.historyManager && !opts.keepHistory) {
-      void this.historyManager
-        .removeSession(id)
-        .catch((err) => console.warn('[history] removeSession failed:', id, err))
+      try {
+        await this.historyManager.removeSession(id)
+      } catch (err) {
+        console.warn('[history] removeSession failed:', id, err)
+      }
     }
 
     // Why: tombstone rejects reattach against a session the user explicitly
@@ -485,13 +487,24 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // writes to a disposed adapter forever. Reuses the existing exitListeners
   // path so downstream cleanup (clearProviderPtyState, markClaudePtyExited,
   // renderer pty:exit) runs exactly as it does on natural exit.
-  fanoutSyntheticExits(code: number): void {
+  async fanoutSyntheticExits(code: number): Promise<void> {
     const ids = [...this.activeSessionIds]
     this.activeSessionIds.clear()
     this.dirtySessionVersions.clear()
     this.stopCheckpointTimer()
     for (const id of ids) {
       this.coldRestoreCache.delete(id)
+      this.sessionsNeedingFullCheckpoint.delete(id)
+      this.initialCwds.delete(id)
+    }
+    if (this.historyManager) {
+      try {
+        await this.historyManager.tombstoneSessions(ids, code)
+      } catch (err) {
+        console.warn('[history] tombstoneSessions failed during synthetic exit fanout:', err)
+      }
+    }
+    for (const id of ids) {
       // Why: listener throws are intentionally *not* caught — matches the
       // natural onExit fanout in setupEventRouting, so synthetic exits don't
       // diverge in error semantics from real ones. A throwing listener is a
@@ -828,7 +841,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
     // Why: replacing the daemon kills its sessions without daemon-side exit
     // fanout. Emit exits first so renderer panes do not write to dead PTYs.
-    this.fanoutSyntheticExits(-1)
+    await this.fanoutSyntheticExits(-1)
     if (!this.respawnPromise) {
       this.respawnPromise = this.doRespawn(
         '[daemon] macOS system resolver unavailable - respawning daemon'

--- a/src/main/daemon/history-manager.test.ts
+++ b/src/main/daemon/history-manager.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { mkdtempSync, rmSync, readFileSync, existsSync, chmodSync } from 'fs'
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+  chmodSync,
+  mkdirSync,
+  writeFileSync
+} from 'fs'
 import { HistoryManager } from './history-manager'
 import type { TerminalSnapshot, TerminalModes } from './types'
 import { getHistorySessionDirName } from './history-paths'
@@ -192,6 +200,54 @@ describe('HistoryManager', () => {
 
       expect(dataA.snapshotAnsi).toBe('session-a')
       expect(dataB.snapshotAnsi).toBe('session-b')
+    })
+  })
+
+  describe('tombstoneSession', () => {
+    it('marks a writer-backed open session ended', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
+
+      await mgr.tombstoneSession('sess-1', -1)
+
+      const meta = JSON.parse(readFileSync(sessionPath(dir, 'sess-1', 'meta.json'), 'utf-8'))
+      expect(meta.endedAt).not.toBeNull()
+      expect(meta.exitCode).toBe(-1)
+    })
+
+    it('marks a writerless session ended', async () => {
+      const sessionDir = join(dir, getHistorySessionDirName('writerless'))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/tmp',
+          cols: 80,
+          rows: 24,
+          startedAt: '2026-04-15T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+
+      await mgr.tombstoneSession('writerless')
+
+      const meta = JSON.parse(readFileSync(sessionPath(dir, 'writerless', 'meta.json'), 'utf-8'))
+      expect(meta.endedAt).not.toBeNull()
+      expect(meta.exitCode).toBeNull()
+    })
+
+    it('tombstoneSessions marks each session ended', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp/a', cols: 80, rows: 24 })
+      await mgr.openSession('sess-2', { cwd: '/tmp/b', cols: 80, rows: 24 })
+
+      await mgr.tombstoneSessions(['sess-1', 'sess-2'], -1)
+
+      const meta1 = JSON.parse(readFileSync(sessionPath(dir, 'sess-1', 'meta.json'), 'utf-8'))
+      const meta2 = JSON.parse(readFileSync(sessionPath(dir, 'sess-2', 'meta.json'), 'utf-8'))
+      expect(meta1.endedAt).not.toBeNull()
+      expect(meta1.exitCode).toBe(-1)
+      expect(meta2.endedAt).not.toBeNull()
+      expect(meta2.exitCode).toBe(-1)
     })
   })
 

--- a/src/main/daemon/history-manager.test.ts
+++ b/src/main/daemon/history-manager.test.ts
@@ -249,6 +249,28 @@ describe('HistoryManager', () => {
       expect(meta2.endedAt).not.toBeNull()
       expect(meta2.exitCode).toBe(-1)
     })
+
+    it.skipIf(process.platform === 'win32')(
+      'continues tombstoning later sessions after a write error',
+      async () => {
+        const errors: { sessionId: string; error: Error }[] = []
+        mgr = new HistoryManager(dir, {
+          onWriteError: (sessionId, error) => errors.push({ sessionId, error })
+        })
+        await mgr.openSession('blocked', { cwd: '/tmp/a', cols: 80, rows: 24 })
+        await mgr.openSession('later', { cwd: '/tmp/b', cols: 80, rows: 24 })
+        const blockedMetaPath = sessionPath(dir, 'blocked', 'meta.json')
+        chmodSync(blockedMetaPath, 0o444)
+
+        await mgr.tombstoneSessions(['blocked', 'later'], -1)
+
+        chmodSync(blockedMetaPath, 0o644)
+        const laterMeta = JSON.parse(readFileSync(sessionPath(dir, 'later', 'meta.json'), 'utf-8'))
+        expect(errors[0].sessionId).toBe('blocked')
+        expect(laterMeta.endedAt).not.toBeNull()
+        expect(laterMeta.exitCode).toBe(-1)
+      }
+    )
   })
 
   describe('dispose', () => {

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -311,7 +311,13 @@ export class HistoryManager {
     exitCode: number | null = null
   ): Promise<void> {
     for (const sessionId of sessionIds) {
-      await this.tombstoneSession(sessionId, exitCode)
+      try {
+        await this.tombstoneSession(sessionId, exitCode)
+      } catch (err) {
+        // Why: restart fanout must clean every session it can; one corrupt or
+        // unwritable meta file should not leave later sessions restorable.
+        this.handleWriteError(sessionId, err)
+      }
     }
   }
 

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -299,6 +299,22 @@ export class HistoryManager {
     }
   }
 
+  async tombstoneSession(sessionId: string, exitCode: number | null = null): Promise<void> {
+    this.writers.delete(sessionId)
+    this.disabledSessions.delete(sessionId)
+    const dir = join(this.basePath, getHistorySessionDirName(sessionId))
+    this.updateMeta(dir, { endedAt: new Date().toISOString(), exitCode })
+  }
+
+  async tombstoneSessions(
+    sessionIds: Iterable<string>,
+    exitCode: number | null = null
+  ): Promise<void> {
+    for (const sessionId of sessionIds) {
+      await this.tombstoneSession(sessionId, exitCode)
+    }
+  }
+
   async removeSession(sessionId: string): Promise<void> {
     this.writers.delete(sessionId)
     this.disabledSessions.delete(sessionId)

--- a/src/main/daemon/history-reader.test.ts
+++ b/src/main/daemon/history-reader.test.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
 import { HistoryReader } from './history-reader'
 import { getHistorySessionDirName } from './history-paths'
 import type { SessionMeta } from './history-manager'
+import { encodeLogBatch, encodeLogHeader } from './terminal-history-log'
 
 function createTestDir(): string {
   return mkdtempSync(join(tmpdir(), 'history-reader-test-'))
@@ -267,6 +268,32 @@ describe('HistoryReader', () => {
 
       const restorable = reader.listRestorable()
       expect(restorable).toEqual(['alive'])
+    })
+
+    it('skips endedAt:null sessions with no restore payload', () => {
+      const sessionDir = join(dir, getHistorySessionDirName('meta-only'))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(join(sessionDir, 'meta.json'), JSON.stringify(makeMeta()))
+
+      expect(reader.listRestorable()).toEqual([])
+    })
+
+    it('keeps endedAt:null sessions with checkpoint payload', () => {
+      writeSessionWithCheckpoint(dir, 'checkpoint-alive', makeMeta(), makeCheckpoint())
+
+      expect(reader.listRestorable()).toEqual(['checkpoint-alive'])
+    })
+
+    it('keeps endedAt:null sessions with incremental log payload', () => {
+      const sessionDir = join(dir, getHistorySessionDirName('log-alive'))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(join(sessionDir, 'meta.json'), JSON.stringify(makeMeta()))
+      writeFileSync(
+        join(sessionDir, 'output.log'),
+        Buffer.concat([encodeLogHeader(0), encodeLogBatch(0, [{ kind: 'output', data: 'data' }])])
+      )
+
+      expect(reader.listRestorable()).toEqual(['log-alive'])
     })
 
     it('returns empty array when no sessions exist', () => {

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { readFileSync, existsSync, readdirSync } from 'fs'
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import type { SessionMeta } from './history-manager'
 import type { TerminalCheckpointFile, TerminalModes } from './types'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
@@ -90,12 +90,56 @@ export class HistoryReader {
         continue
       }
       const meta = this.readMeta(sessionId)
-      if (meta && meta.endedAt === null) {
+      if (meta && meta.endedAt === null && this.hasRestorablePayload(sessionId)) {
         restorable.push(sessionId)
       }
     }
 
     return restorable
+  }
+
+  private hasRestorablePayload(sessionId: string): boolean {
+    const sessionDir = join(this.basePath, getHistorySessionDirName(sessionId))
+    return (
+      this.hasCheckpointPayload(sessionDir) ||
+      this.hasIncrementalLogPayload(sessionDir) ||
+      this.hasLegacyScrollbackPayload(sessionDir)
+    )
+  }
+
+  private hasCheckpointPayload(sessionDir: string): boolean {
+    try {
+      const checkpoint = JSON.parse(readFileSync(join(sessionDir, 'checkpoint.json'), 'utf-8'))
+      return (
+        (typeof checkpoint.snapshotAnsi === 'string' && checkpoint.snapshotAnsi.length > 0) ||
+        (typeof checkpoint.scrollbackAnsi === 'string' && checkpoint.scrollbackAnsi.length > 0)
+      )
+    } catch {
+      return false
+    }
+  }
+
+  private hasIncrementalLogPayload(sessionDir: string): boolean {
+    let logBuffer: Buffer
+    try {
+      logBuffer = readFileSync(join(sessionDir, 'output.log'))
+    } catch {
+      return false
+    }
+    const log = decodeTerminalHistoryLog(logBuffer)
+    return log !== null && log.batches.some((batch) => batch.records.length > 0)
+  }
+
+  private hasLegacyScrollbackPayload(sessionDir: string): boolean {
+    return this.fileHasBytes(join(sessionDir, 'scrollback.bin'))
+  }
+
+  private fileHasBytes(path: string): boolean {
+    try {
+      return statSync(path).size > 0
+    } catch {
+      return false
+    }
   }
 
   // Why a scratch emulator: replaying base + raw records through the same

--- a/src/main/observability/instrumentation.test.ts
+++ b/src/main/observability/instrumentation.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _resetTracerForTests, setActiveSink, type TracerSink } from './tracer'
+import {
+  _gitSpanSamplingBucketCountForTests,
+  _resetGitSpanSamplingForTests,
+  withGitSpan
+} from './instrumentation'
+
+type SpanRecord = {
+  readonly name: string
+  readonly durationMs: number
+  readonly attributes: Record<string, unknown>
+  readonly exit: { readonly _tag: string; readonly cause?: string }
+}
+
+type CapturedSink = TracerSink & {
+  readonly records: SpanRecord[]
+}
+
+function isSpanRecord(record: unknown): record is SpanRecord {
+  return (
+    record !== null &&
+    typeof record === 'object' &&
+    'name' in record &&
+    typeof record.name === 'string' &&
+    'durationMs' in record &&
+    typeof record.durationMs === 'number' &&
+    'attributes' in record &&
+    record.attributes !== null &&
+    typeof record.attributes === 'object' &&
+    'exit' in record &&
+    record.exit !== null &&
+    typeof record.exit === 'object' &&
+    '_tag' in record.exit &&
+    typeof record.exit._tag === 'string'
+  )
+}
+
+function makeCapturingSink(): CapturedSink {
+  const records: SpanRecord[] = []
+  return {
+    records,
+    push(record) {
+      if (!isSpanRecord(record)) {
+        throw new Error('expected span record')
+      }
+      records.push(record)
+    },
+    flush() {
+      /* no-op */
+    },
+    close() {
+      /* no-op */
+    }
+  }
+}
+
+let sink: CapturedSink
+let nowMs = 1_700_000_000_000
+
+async function runGitSpan(
+  meta: { args: readonly string[]; cwd?: string },
+  durationMs: number,
+  fail = false
+) {
+  vi.setSystemTime(nowMs)
+  const promise = withGitSpan(meta, async () => {
+    vi.setSystemTime(nowMs + durationMs)
+    if (fail) {
+      throw new Error('git failed')
+    }
+    return 'ok'
+  })
+  nowMs += durationMs + 1
+  return await promise
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  nowMs = 1_700_000_000_000
+  _resetGitSpanSamplingForTests()
+  sink = makeCapturingSink()
+  setActiveSink(sink)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  _resetGitSpanSamplingForTests()
+  _resetTracerForTests()
+})
+
+describe('withGitSpan sampling', () => {
+  it('bounds fast successful repeated git spans by subcommand and cwd while preserving important spans', async () => {
+    for (let i = 0; i < 10_000; i++) {
+      await runGitSpan({ args: ['status', '--short'], cwd: '/repo' }, 5)
+    }
+
+    const repeatedFastSuccesses = sink.records.filter(
+      (record) =>
+        record.name === 'git.exec' &&
+        record.exit._tag === 'Success' &&
+        record.attributes['git.subcommand'] === 'status' &&
+        record.attributes.cwd === '/repo' &&
+        record.durationMs < 250
+    )
+    expect(repeatedFastSuccesses.length).toBeGreaterThan(0)
+    expect(repeatedFastSuccesses.length).toBeLessThan(200)
+
+    await expect(runGitSpan({ args: ['status'], cwd: '/repo' }, 5, true)).rejects.toThrow(
+      'git failed'
+    )
+    await runGitSpan({ args: ['status'], cwd: '/repo' }, 275)
+    await runGitSpan({ args: ['branch'], cwd: '/repo' }, 5)
+    await runGitSpan({ args: ['status'], cwd: '/other-repo' }, 5)
+
+    expect(
+      sink.records.some(
+        (record) =>
+          record.exit._tag === 'Failure' &&
+          record.attributes['git.subcommand'] === 'status' &&
+          record.attributes.cwd === '/repo'
+      )
+    ).toBe(true)
+    expect(
+      sink.records.some(
+        (record) =>
+          record.exit._tag === 'Success' &&
+          record.durationMs >= 250 &&
+          record.attributes['git.subcommand'] === 'status' &&
+          record.attributes.cwd === '/repo'
+      )
+    ).toBe(true)
+    expect(
+      sink.records.some(
+        (record) =>
+          record.exit._tag === 'Success' &&
+          record.attributes['git.subcommand'] === 'branch' &&
+          record.attributes.cwd === '/repo'
+      )
+    ).toBe(true)
+    expect(
+      sink.records.some(
+        (record) =>
+          record.exit._tag === 'Success' &&
+          record.attributes['git.subcommand'] === 'status' &&
+          record.attributes.cwd === '/other-repo'
+      )
+    ).toBe(true)
+  })
+  it('parses git subcommands after global options without changing arg count', async () => {
+    await runGitSpan({ args: ['-c', 'core.quotePath=false', 'status', '--short'], cwd: '/repo' }, 5)
+
+    expect(sink.records[0]?.attributes['git.subcommand']).toBe('status')
+    expect(sink.records[0]?.attributes['git.arg_count']).toBe(4)
+  })
+
+  it('prunes stale git sampling buckets and caps unique cwd buckets', async () => {
+    for (let i = 0; i < 700; i++) {
+      await runGitSpan({ args: ['status'], cwd: `/repo-${i}` }, 5)
+    }
+
+    expect(_gitSpanSamplingBucketCountForTests()).toBeLessThanOrEqual(512)
+
+    nowMs += 60_000
+    await runGitSpan({ args: ['status'], cwd: '/fresh-repo' }, 5)
+
+    expect(_gitSpanSamplingBucketCountForTests()).toBe(1)
+  })
+})

--- a/src/main/observability/instrumentation.ts
+++ b/src/main/observability/instrumentation.ts
@@ -23,29 +23,164 @@
 
 import { withSpan, type ActiveSpan } from './tracer'
 
+const GIT_FAST_SUCCESS_THRESHOLD_MS = 250
+const GIT_FAST_SUCCESS_WINDOW_MS = 60_000
+const GIT_FAST_SUCCESS_BUDGET_PER_WINDOW = 60
+const GIT_SAMPLING_MAX_BUCKETS = 512
+
+// Why: trace captures showed `git status --short` bursts dominating payloads.
+// Keep enough fast successes for timing shape while bounding memory and volume.
+const GIT_GLOBAL_OPTIONS_WITH_OPERAND = new Set([
+  '-c',
+  '-C',
+  '--git-dir',
+  '--work-tree',
+  '--config-env',
+  '--namespace',
+  '--exec-path',
+  '--super-prefix',
+  '--pathspec-from-file'
+])
+const GIT_GLOBAL_FLAGS = new Set([
+  '--bare',
+  '--no-pager',
+  '--paginate',
+  '--literal-pathspecs',
+  '--glob-pathspecs',
+  '--noglob-pathspecs',
+  '--icase-pathspecs',
+  '--no-optional-locks',
+  '--pathspec-file-nul'
+])
+
+type GitSamplingBucket = {
+  windowStartMs: number
+  emitted: number
+}
+
+const gitSamplingBuckets = new Map<string, GitSamplingBucket>()
+
+function gitSubcommandFromArgs(args: readonly string[]): string {
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (!arg) {
+      continue
+    }
+    if (arg === '--') {
+      return '<none>'
+    }
+    if (GIT_GLOBAL_OPTIONS_WITH_OPERAND.has(arg)) {
+      index += 1
+      continue
+    }
+    if (
+      arg.startsWith('--git-dir=') ||
+      arg.startsWith('--work-tree=') ||
+      arg.startsWith('--config-env=') ||
+      arg.startsWith('--namespace=') ||
+      arg.startsWith('--exec-path=') ||
+      arg.startsWith('--super-prefix=') ||
+      arg.startsWith('--pathspec-from-file=') ||
+      (arg.startsWith('-c') && arg.length > 2) ||
+      (arg.startsWith('-C') && arg.length > 2)
+    ) {
+      continue
+    }
+    if (GIT_GLOBAL_FLAGS.has(arg)) {
+      continue
+    }
+    if (arg.startsWith('-')) {
+      continue
+    }
+    return arg
+  }
+  return '<none>'
+}
+
+function pruneGitSamplingBuckets(nowMs: number): void {
+  for (const [key, bucket] of gitSamplingBuckets) {
+    if (nowMs - bucket.windowStartMs >= GIT_FAST_SUCCESS_WINDOW_MS) {
+      gitSamplingBuckets.delete(key)
+    }
+  }
+  while (gitSamplingBuckets.size > GIT_SAMPLING_MAX_BUCKETS) {
+    let oldestKey: string | undefined
+    let oldestWindowStartMs = Number.POSITIVE_INFINITY
+    for (const [key, bucket] of gitSamplingBuckets) {
+      if (bucket.windowStartMs < oldestWindowStartMs) {
+        oldestKey = key
+        oldestWindowStartMs = bucket.windowStartMs
+      }
+    }
+    if (oldestKey === undefined) {
+      return
+    }
+    gitSamplingBuckets.delete(oldestKey)
+  }
+}
+
+function gitSamplingKey(meta: GitSpanArgs): string {
+  return `${gitSubcommandFromArgs(meta.args)}\u0000${meta.cwd ?? '<none>'}`
+}
+
+function shouldRecordGitSpan(
+  meta: GitSpanArgs,
+  record: { durationMs: number; startTimeUnixNano: string; exit: { _tag: string } }
+): boolean {
+  if (record.exit._tag !== 'Success' || record.durationMs >= GIT_FAST_SUCCESS_THRESHOLD_MS) {
+    return true
+  }
+
+  const nowMs = Number(BigInt(record.startTimeUnixNano) / 1_000_000n)
+  pruneGitSamplingBuckets(nowMs)
+  const key = gitSamplingKey(meta)
+  const bucket = gitSamplingBuckets.get(key)
+  if (!bucket) {
+    gitSamplingBuckets.set(key, { windowStartMs: nowMs, emitted: 1 })
+    pruneGitSamplingBuckets(nowMs)
+    return true
+  }
+  if (bucket.emitted < GIT_FAST_SUCCESS_BUDGET_PER_WINDOW) {
+    bucket.emitted += 1
+    return true
+  }
+  return false
+}
+
+function addGitAttributes(span: ActiveSpan, meta: GitSpanArgs): void {
+  span.setAttribute('git.subcommand', gitSubcommandFromArgs(meta.args))
+  // Why: git args can contain commit messages, branch names, remotes, or
+  // paths. Keep cardinality without copying user-authored content.
+  span.setAttribute('git.arg_count', meta.args.length)
+  if (meta.cwd) {
+    span.setAttribute('cwd', meta.cwd)
+  }
+}
+
+export function _resetGitSpanSamplingForTests(): void {
+  gitSamplingBuckets.clear()
+}
+
+export function _gitSpanSamplingBucketCountForTests(): number {
+  return gitSamplingBuckets.size
+}
+
 export type GitSpanArgs = {
   readonly args: readonly string[]
   readonly cwd?: string
 }
 
-/** Wrap a git execution in a `git.exec` span. The first argument typically
- *  is the subcommand (`status`, `clone`, `pull`); promoting it to its own
- *  attribute makes it grep-friendly without pulling the full args array
- *  into a single comma-joined string in dashboards. */
+/** Wrap a git execution in a `git.exec` span. Git accepts global options before
+ *  the subcommand; promoting the parsed command to its own attribute makes it
+ *  grep-friendly without copying the full args array into dashboards. */
 export async function withGitSpan<T>(meta: GitSpanArgs, fn: () => Promise<T>): Promise<T> {
   return withSpan(
     'git.exec',
     async (span) => {
-      span.setAttribute('git.subcommand', meta.args[0] ?? '<none>')
-      // Why: git args can contain commit messages, branch names, remotes, or
-      // paths. Keep cardinality without copying user-authored content.
-      span.setAttribute('git.arg_count', meta.args.length)
-      if (meta.cwd) {
-        span.setAttribute('cwd', meta.cwd)
-      }
+      addGitAttributes(span, meta)
       return await fn()
     },
-    { attributes: { kind: 'git' } }
+    { attributes: { kind: 'git' }, shouldRecord: (record) => shouldRecordGitSpan(meta, record) }
   )
 }
 

--- a/src/main/observability/tracer.ts
+++ b/src/main/observability/tracer.ts
@@ -128,10 +128,16 @@ export function getActiveSpanContext(): SpanContext | undefined {
  * This is the function 90% of call sites should reach for: it keeps span
  * lifetime scoped to the async work it measures.
  */
+type SpanRecordDecision = (record: RedactableSpan) => boolean
+
 export async function withSpan<T>(
   name: string,
   fn: (span: ActiveSpan) => Promise<T> | T,
-  options?: { kind?: string; attributes?: Record<string, unknown> }
+  options?: {
+    kind?: string
+    attributes?: Record<string, unknown>
+    shouldRecord?: SpanRecordDecision
+  }
 ): Promise<T> {
   const span = startSpan(name, options)
   try {
@@ -157,7 +163,11 @@ export async function withSpan<T>(
  */
 export function startSpan(
   name: string,
-  options?: { kind?: string; attributes?: Record<string, unknown> }
+  options?: {
+    kind?: string
+    attributes?: Record<string, unknown>
+    shouldRecord?: SpanRecordDecision
+  }
 ): ActiveSpan {
   if (!activeSink) {
     return noopSpan
@@ -201,6 +211,10 @@ export function startSpan(
       attributes: Object.fromEntries(pending.attributes),
       events: pending.events,
       exit
+    }
+
+    if (options?.shouldRecord && !options.shouldRecord(record)) {
+      return
     }
 
     const redacted = redactSpan(record, 'client')

--- a/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
@@ -235,7 +235,7 @@ describe('SourceControl compare summary', () => {
     expect(onRetry).toHaveBeenCalledTimes(1)
   })
 
-  it('omits the whole compare row when the branch has no commits ahead', () => {
+  it('keeps clean compare row visible with refresh controls', () => {
     const cleanSummary = { ...readySummary, commitsAhead: 0 }
     const node = CompareSummary({
       summary: cleanSummary,
@@ -243,11 +243,13 @@ describe('SourceControl compare summary', () => {
       onRetry: vi.fn()
     })
 
-    expect(shouldShowCompareSummary(cleanSummary)).toBe(false)
-    expect(node).toBeNull()
+    expect(shouldShowCompareSummary(cleanSummary)).toBe(true)
     const text = collectText(node)
-    expect(text).not.toContain('0 commits ahead')
-    expect(text).not.toContain('origin/main')
+    expect(text).toContain('0 ahead')
+    expect(collectCompareSummaryToolbarLabels(node)).toEqual([
+      'Change base ref',
+      'Refresh branch compare'
+    ])
   })
 
   it('keeps non-zero summary copy compact', () => {
@@ -280,23 +282,20 @@ describe('SourceControl compare summary', () => {
     expect(BRANCH_REFRESH_INTERVAL_MS).toBe(30_000)
   })
 
-  it('polls ready branch compare only when visible branch state can change', () => {
+  it('keeps ready branch compare polling active so external git changes wake clean state', () => {
     expect(
       shouldPollBranchCompare({
-        summary: null,
-        branchEntryCount: 0
+        summary: null
       })
     ).toBe(true)
     expect(
       shouldPollBranchCompare({
-        summary: { ...readySummary, commitsAhead: 0 },
-        branchEntryCount: 0
+        summary: { ...readySummary, commitsAhead: 0 }
       })
-    ).toBe(false)
+    ).toBe(true)
     expect(
       shouldPollBranchCompare({
-        summary: { ...readySummary, commitsAhead: 0 },
-        branchEntryCount: 1
+        summary: readySummary
       })
     ).toBe(true)
   })
@@ -305,7 +304,6 @@ describe('SourceControl compare summary', () => {
     expect(
       shouldPollBranchCompare({
         summary: { ...readySummary, baseRef: 'origin/old', commitsAhead: 0 },
-        branchEntryCount: 0,
         currentBaseRef: 'origin/main'
       })
     ).toBe(true)
@@ -314,26 +312,22 @@ describe('SourceControl compare summary', () => {
   it('keeps transient branch compare errors retryable but stops terminal statuses', () => {
     expect(
       shouldPollBranchCompare({
-        summary: { ...readySummary, status: 'error', errorMessage: 'Unable to compare' },
-        branchEntryCount: 0
+        summary: { ...readySummary, status: 'error', errorMessage: 'Unable to compare' }
       })
     ).toBe(true)
     expect(
       shouldPollBranchCompare({
-        summary: { ...readySummary, status: 'invalid-base' },
-        branchEntryCount: 0
+        summary: { ...readySummary, status: 'invalid-base' }
       })
     ).toBe(false)
     expect(
       shouldPollBranchCompare({
-        summary: { ...readySummary, status: 'no-merge-base' },
-        branchEntryCount: 0
+        summary: { ...readySummary, status: 'no-merge-base' }
       })
     ).toBe(false)
     expect(
       shouldPollBranchCompare({
-        summary: { ...readySummary, status: 'unborn-head' },
-        branchEntryCount: 0
+        summary: { ...readySummary, status: 'unborn-head' }
       })
     ).toBe(false)
   })

--- a/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
@@ -1,9 +1,13 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  BRANCH_REFRESH_INTERVAL_MS,
   CompareSummary,
   CompareSummaryToolbarButton,
+  refreshSourceControlAfterRemoteAction,
   resolveSourceControlBaseRef,
   resolveSourceControlPickerBaseRef,
+  shouldPollBranchCompare,
   shouldShowCompareSummary
 } from './SourceControl'
 import type { GitBranchCompareSummary } from '../../../../shared/types'
@@ -75,6 +79,8 @@ const readySummary: GitBranchCompareSummary = {
   commitsAhead: 1,
   status: 'ready'
 }
+
+const sourceControlSource = readFileSync(new URL('./SourceControl.tsx', import.meta.url), 'utf8')
 
 describe('SourceControl compare summary', () => {
   it('prefers the worktree creation base for branch compare', () => {
@@ -271,5 +277,86 @@ describe('SourceControl compare summary', () => {
     })
 
     expect(collectCompareSummaryToolbarLabels(node)).toEqual(['Change base ref', 'Retry'])
+  })
+
+  it('polls branch compare every 30 seconds', () => {
+    expect(BRANCH_REFRESH_INTERVAL_MS).toBe(30_000)
+    expect(sourceControlSource).toContain('intervalMs: BRANCH_REFRESH_INTERVAL_MS')
+  })
+
+  it('polls ready branch compare only when visible branch state can change', () => {
+    expect(
+      shouldPollBranchCompare({
+        summary: null,
+        branchEntryCount: 0
+      })
+    ).toBe(true)
+    expect(
+      shouldPollBranchCompare({
+        summary: { ...readySummary, commitsAhead: 0 },
+        branchEntryCount: 0
+      })
+    ).toBe(false)
+    expect(
+      shouldPollBranchCompare({
+        summary: { ...readySummary, commitsAhead: 0 },
+        branchEntryCount: 1
+      })
+    ).toBe(true)
+  })
+
+  it('polls stale branch compare base refs so repaired bases refresh', () => {
+    expect(
+      shouldPollBranchCompare({
+        summary: { ...readySummary, baseRef: 'origin/old', commitsAhead: 0 },
+        branchEntryCount: 0,
+        currentBaseRef: 'origin/main'
+      })
+    ).toBe(true)
+  })
+
+  it('keeps transient branch compare errors retryable but stops terminal statuses', () => {
+    expect(
+      shouldPollBranchCompare({
+        summary: { ...readySummary, status: 'error', errorMessage: 'Unable to compare' },
+        branchEntryCount: 0
+      })
+    ).toBe(true)
+    expect(
+      shouldPollBranchCompare({
+        summary: { ...readySummary, status: 'invalid-base' },
+        branchEntryCount: 0
+      })
+    ).toBe(false)
+    expect(
+      shouldPollBranchCompare({
+        summary: { ...readySummary, status: 'no-merge-base' },
+        branchEntryCount: 0
+      })
+    ).toBe(false)
+    expect(
+      shouldPollBranchCompare({
+        summary: { ...readySummary, status: 'unborn-head' },
+        branchEntryCount: 0
+      })
+    ).toBe(false)
+  })
+
+  it('keeps immediate refresh paths for remote actions', () => {
+    const refreshGitStatus = vi.fn(async () => {})
+    const refreshBranchCompare = vi.fn(async () => {})
+    const refreshGitHistory = vi.fn(async () => {})
+
+    refreshSourceControlAfterRemoteAction({
+      refreshGitStatus,
+      refreshBranchCompare,
+      refreshGitHistory
+    })
+
+    expect(refreshGitStatus).toHaveBeenCalledTimes(1)
+    expect(refreshBranchCompare).toHaveBeenCalledTimes(1)
+    expect(refreshGitHistory).toHaveBeenCalledTimes(1)
+    // Direct commit, manual, retry, and base-ref refresh paths remain component-level
+    // behavior covered by the existing UI wiring; keep this test on the pure helper.
   })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import {
   BRANCH_REFRESH_INTERVAL_MS,
@@ -79,8 +78,6 @@ const readySummary: GitBranchCompareSummary = {
   commitsAhead: 1,
   status: 'ready'
 }
-
-const sourceControlSource = readFileSync(new URL('./SourceControl.tsx', import.meta.url), 'utf8')
 
 describe('SourceControl compare summary', () => {
   it('prefers the worktree creation base for branch compare', () => {
@@ -281,7 +278,6 @@ describe('SourceControl compare summary', () => {
 
   it('polls branch compare every 30 seconds', () => {
     expect(BRANCH_REFRESH_INTERVAL_MS).toBe(30_000)
-    expect(sourceControlSource).toContain('intervalMs: BRANCH_REFRESH_INTERVAL_MS')
   })
 
   it('polls ready branch compare only when visible branch state can change', () => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -4542,28 +4542,15 @@ function SourceControlInner(): React.JSX.Element {
   const refreshGitHistoryRef = useRef(refreshGitHistory)
   refreshGitHistoryRef.current = refreshGitHistory
 
-  const branchSummaryStatus = branchSummary?.status
-  const branchSummaryBaseRef = branchSummary?.baseRef
-  const branchSummaryCommitsAhead = branchSummary?.commitsAhead
-
-  const shouldPollCurrentBranchCompare = useMemo(() => {
-    if (!branchSummaryStatus || branchSummaryStatus === 'loading') {
-      return true
-    }
-    if (effectiveBaseRef && branchSummaryBaseRef !== effectiveBaseRef) {
-      return true
-    }
-    if (branchSummaryStatus === 'ready') {
-      return (branchSummaryCommitsAhead ?? 0) > 0 || branchEntries.length > 0
-    }
-    return branchSummaryStatus === 'error'
-  }, [
-    branchEntries.length,
-    branchSummaryBaseRef,
-    branchSummaryCommitsAhead,
-    branchSummaryStatus,
-    effectiveBaseRef
-  ])
+  const shouldPollCurrentBranchCompare = useMemo(
+    () =>
+      shouldPollBranchCompare({
+        summary: branchSummary ?? null,
+        branchEntryCount: branchEntries.length,
+        currentBaseRef: effectiveBaseRef
+      }),
+    [branchEntries.length, branchSummary, effectiveBaseRef]
+  )
 
   useEffect(() => {
     if (

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -460,7 +460,7 @@ const CONFLICTS_SECTION_LABEL = {
 }
 
 // Why: 5s branch compare polling churned git subprocesses in large repos.
-// Explicit commit, remote, manual, and base-ref refresh paths still run immediately.
+// Keep a 30s visible-window poll so clean hidden rows can wake after external git changes.
 export const BRANCH_REFRESH_INTERVAL_MS = 30_000
 // Why: row action buttons host Radix Tooltip triggers. Keeping the overlay
 // measurable prevents transient top-left tooltip placement during hover.
@@ -4546,10 +4546,9 @@ function SourceControlInner(): React.JSX.Element {
     () =>
       shouldPollBranchCompare({
         summary: branchSummary ?? null,
-        branchEntryCount: branchEntries.length,
         currentBaseRef: effectiveBaseRef
       }),
-    [branchEntries.length, branchSummary, effectiveBaseRef]
+    [branchSummary, effectiveBaseRef]
   )
 
   useEffect(() => {
@@ -4564,9 +4563,9 @@ function SourceControlInner(): React.JSX.Element {
       return
     }
 
-    // Why: branch compare shells out to git every tick. The panel only needs
-    // background freshness while Orca is visible and there is branch UI worth
-    // refreshing; hidden-window time should not burn subprocess work or timer wakeups.
+    // Why: branch compare shells out to git every tick. Keep the low-frequency
+    // visible-window poll even for clean hidden rows so external git changes
+    // eventually wake the branch state without requiring a manual refresh.
     return installWindowVisibilityInterval({
       run: () => void refreshBranchCompareRef.current(),
       intervalMs: BRANCH_REFRESH_INTERVAL_MS
@@ -6773,10 +6772,9 @@ export function CommitArea({
 
 export function shouldPollBranchCompare(input: {
   summary: GitBranchCompareSummary | null
-  branchEntryCount: number
   currentBaseRef?: string | null
 }): boolean {
-  const { summary, branchEntryCount, currentBaseRef } = input
+  const { summary, currentBaseRef } = input
   if (!summary || summary.status === 'loading') {
     return true
   }
@@ -6784,7 +6782,7 @@ export function shouldPollBranchCompare(input: {
     return true
   }
   if (summary.status === 'ready') {
-    return (summary.commitsAhead ?? 0) > 0 || branchEntryCount > 0
+    return true
   }
   return summary.status === 'error'
 }
@@ -6793,10 +6791,7 @@ export function shouldShowCompareSummary(summary: GitBranchCompareSummary | null
   if (!summary || summary.status === 'loading') {
     return true
   }
-  if (summary.status !== 'ready') {
-    return true
-  }
-  return typeof summary.commitsAhead === 'number' && summary.commitsAhead > 0
+  return true
 }
 
 export function CompareSummary({
@@ -6850,14 +6845,10 @@ export function CompareSummary({
   }
 
   const commitsAhead = summary.commitsAhead
-  const showCommitsAhead = typeof commitsAhead === 'number' && commitsAhead > 0
-  const commitsAheadTitle = showCommitsAhead
-    ? `${commitsAhead} ${commitsAhead === 1 ? 'commit' : 'commits'} ahead of ${summary.baseRef}`
-    : undefined
-
-  if (!showCommitsAhead) {
-    return null
-  }
+  const commitsAheadTitle =
+    typeof commitsAhead === 'number'
+      ? `${commitsAhead} ${commitsAhead === 1 ? 'commit' : 'commits'} ahead of ${summary.baseRef}`
+      : undefined
 
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -459,7 +459,9 @@ const CONFLICTS_SECTION_LABEL = {
   fallback: 'Conflicts'
 }
 
-const BRANCH_REFRESH_INTERVAL_MS = 5000
+// Why: 5s branch compare polling churned git subprocesses in large repos.
+// Explicit commit, remote, manual, and base-ref refresh paths still run immediately.
+export const BRANCH_REFRESH_INTERVAL_MS = 30_000
 // Why: row action buttons host Radix Tooltip triggers. Keeping the overlay
 // measurable prevents transient top-left tooltip placement during hover.
 const SOURCE_CONTROL_ROW_ACTION_OVERLAY_CLASS =
@@ -1845,7 +1847,7 @@ function SourceControlInner(): React.JSX.Element {
         //
         // Then fire-and-forget refreshBranchCompare so the "Committed on
         // Branch" section repopulates as soon as the IPC returns instead of
-        // waiting up to 5 seconds for the next poll. Unawaited on purpose:
+        // waiting for the next poll. Unawaited on purpose:
         // compound flows (runCompoundCommitAction) need handleCommit to
         // resolve immediately so the push step starts without delay. Errors
         // here are best-effort — the polling tick will retry.
@@ -4384,8 +4386,8 @@ function SourceControlInner(): React.JSX.Element {
     // getBaseRefDefault corrected a stale cross-repo value).  Polling retries
     // — whether the previous result was 'ready' *or* an error — keep the
     // current UI visible until the new IPC result arrives.  Resetting to
-    // 'loading' on every 5-second poll when the compare is in an error state
-    // caused a visible loading→error→loading→error flicker.
+    // 'loading' on every poll when the compare is in an error state caused a
+    // visible loading→error→loading→error flicker.
     const baseRefChanged = existingSummary && existingSummary.baseRef !== effectiveBaseRef
     const shouldResetToLoading = !existingSummary || baseRefChanged
     if (shouldResetToLoading) {
@@ -4444,7 +4446,7 @@ function SourceControlInner(): React.JSX.Element {
     branchCompareInFlightRef.current = true
     const runPromise = (async (): Promise<void> => {
       // Why: branch compare shells out to git on a timer and can exceed the
-      // 5s poll interval on large repos. Keep one compare chain in flight and
+      // 30s poll interval on large repos. Keep one compare chain in flight and
       // collapse skipped ticks into one trailing refresh instead of stacking
       // subprocesses while preserving the await contract for direct callers.
       try {
@@ -4540,19 +4542,56 @@ function SourceControlInner(): React.JSX.Element {
   const refreshGitHistoryRef = useRef(refreshGitHistory)
   refreshGitHistoryRef.current = refreshGitHistory
 
+  const branchSummaryStatus = branchSummary?.status
+  const branchSummaryBaseRef = branchSummary?.baseRef
+  const branchSummaryCommitsAhead = branchSummary?.commitsAhead
+
+  const shouldPollCurrentBranchCompare = useMemo(() => {
+    if (!branchSummaryStatus || branchSummaryStatus === 'loading') {
+      return true
+    }
+    if (effectiveBaseRef && branchSummaryBaseRef !== effectiveBaseRef) {
+      return true
+    }
+    if (branchSummaryStatus === 'ready') {
+      return (branchSummaryCommitsAhead ?? 0) > 0 || branchEntries.length > 0
+    }
+    return branchSummaryStatus === 'error'
+  }, [
+    branchEntries.length,
+    branchSummaryBaseRef,
+    branchSummaryCommitsAhead,
+    branchSummaryStatus,
+    effectiveBaseRef
+  ])
+
   useEffect(() => {
-    if (!activeWorktreeId || !worktreePath || !isBranchVisible || !effectiveBaseRef || isFolder) {
+    if (
+      !activeWorktreeId ||
+      !worktreePath ||
+      !isBranchVisible ||
+      !effectiveBaseRef ||
+      isFolder ||
+      !shouldPollCurrentBranchCompare
+    ) {
       return
     }
 
     // Why: branch compare shells out to git every tick. The panel only needs
-    // background freshness while Orca is visible; hidden-window time should not
-    // burn subprocess work or timer wakeups.
+    // background freshness while Orca is visible and there is branch UI worth
+    // refreshing; hidden-window time should not burn subprocess work or timer wakeups.
     return installWindowVisibilityInterval({
       run: () => void refreshBranchCompareRef.current(),
       intervalMs: BRANCH_REFRESH_INTERVAL_MS
     })
-  }, [activeWorktreeId, effectiveBaseRef, isBranchVisible, isFolder, worktreePath])
+  }, [
+    activeWorktreeId,
+    effectiveBaseRef,
+    isBranchVisible,
+    isFolder,
+    shouldPollCurrentBranchCompare,
+    worktreePath
+  ])
 
   useEffect(() => {
     // Why: history shells out to git. Defer the first load until the user
@@ -6743,6 +6782,24 @@ export function CommitArea({
       )}
     </div>
   )
+}
+
+export function shouldPollBranchCompare(input: {
+  summary: GitBranchCompareSummary | null
+  branchEntryCount: number
+  currentBaseRef?: string | null
+}): boolean {
+  const { summary, branchEntryCount, currentBaseRef } = input
+  if (!summary || summary.status === 'loading') {
+    return true
+  }
+  if (currentBaseRef && summary.baseRef !== currentBaseRef) {
+    return true
+  }
+  if (summary.status === 'ready') {
+    return (summary.commitsAhead ?? 0) > 0 || branchEntryCount > 0
+  }
+  return summary.status === 'error'
 }
 
 export function shouldShowCompareSummary(summary: GitBranchCompareSummary | null): boolean {


### PR DESCRIPTION
## Summary

Reduces several Orca stall and stale-state paths across performance validation, macOS helper startup, terminal history, observability, and Source Control:

- Makes perf-validation pod scaffolding cross-platform by generating Node runner commands and executing benchmark steps with `spawnSync(command, args, { env })`, not POSIX shell one-liners, redirection, or inline env assignment.
- Coalesces concurrent macOS computer-use permission status probes into one helper launch, and backs off recent helper launch/open failures for 10 seconds with the same RuntimeClientError code/message. Status-file polling timeouts are not cached, so explicit permission setup is not blocked by a helper that launched but failed to report.
- Adds the same 10-second post-failure cooldown to native macOS provider socket startup, while preserving explicit shutdown/retry behavior and avoiding cooldown for superseded startups or action-level errors.
- Makes terminal-history restore listings payload-aware, adds writerless tombstoning, makes tombstone fanout per-session best-effort, and waits for app-side history cleanup during daemon restart before unbinding provider listeners.
- Keeps Source Control branch compare refreshable after clean external git changes by preserving the compare row/refresh affordance at `0 ahead` and retaining the visible-window polling path.
- Adds bounded git-span sampling for observability so fast successful git spans do not flood telemetry while preserving slow/error spans.

X: @wolfie_

## Screenshots

Source Control compare row now remains visible at clean state so the user keeps the refresh/base controls instead of losing the row when the branch is `0 ahead`.

Screenshot/recording not attached from this local run. The changed surface is covered by `SourceControl.compare-summary.test.ts`, which asserts the `0 ahead` row and toolbar controls render.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
  - Default Node 25 attempt still fails on existing/unrelated local-environment issues: `window.localStorage.clear is not a function` renderer failures and `SSH_ASKPASS` env expectation in `runner-command-exec.test.ts`.
  - Passed with repo Node 24 fallback: `SSH_ASKPASS="" /Users/wolfgangschoenberger/.local/share/mise/installs/node/24.17.0/bin/node config/scripts/ensure-native-runtime.mjs --runtime=node && SSH_ASKPASS="" /Users/wolfgangschoenberger/.local/share/mise/installs/node/24.17.0/bin/node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts --maxWorkers 4` - 1968 files passed, 19695 tests passed, 2 files skipped, 13 tests skipped.
- [x] `pnpm build`
- [x] Added/updated regression tests for perf scaffold portability, helper probe coalescing, launch-failure backoff, permission status timeout non-caching, native provider startup coalescing/backoff, superseded-startup exclusion, action-error non-poisoning, manual setup launch preservation, payload-aware restore listing, writerless/per-session tombstoning, awaited shutdown removal, keepHistory restore preservation, awaited restart fanout tombstoning, git-span sampling, and Source Control clean compare refresh controls.

Additional verification:

- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/perf-validation-pod-scaffold.test.mjs` - 1 file passed, 7 tests passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts` - 1 file passed, 18 tests passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/computer/macos-computer-use-permission-status.test.ts src/main/computer/macos-computer-use-permissions.test.ts` - 2 files passed, 18 tests passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/history-manager.test.ts src/main/daemon/daemon-pty-adapter.test.ts` - 2 files passed, 96 tests passed.
- `pnpm exec oxlint config/scripts/perf-validation-pod-scaffold.mjs config/scripts/run-perf-validation-pod.mjs config/scripts/perf-validation-pod-scaffold.test.mjs src/main/computer/macos-computer-use-permission-status.ts src/main/computer/macos-computer-use-permission-status.test.ts src/main/computer/macos-native-provider-client.ts src/main/daemon/history-manager.ts src/main/daemon/history-manager.test.ts src/renderer/src/components/right-sidebar/SourceControl.tsx src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts` - passed.

## AI Review Report

Reviewed the implementation for stall-loop behavior, restart sequencing, cross-platform command execution, and stale Source Control state. Review findings addressed in the latest push:

- Perf validation scaffold no longer emits POSIX-only shell syntax. Generated commands call `node config/scripts/run-perf-validation-pod.mjs ...`, and the runner uses argument arrays, explicit env merges, and Node file writes for captured stdout.
- Source Control clean branch compare no longer loses the visible refresh/base controls at `0 ahead`, and the ready-state polling path remains active so external git changes can wake the compare state.
- Permission-status cooldown is limited to helper launch/open failures. A status-file polling timeout is still returned to the caller, but it does not cache a 10-second failure that blocks manual setup retries.
- Terminal tombstoning is now per-session best-effort, so one unwritable meta file does not prevent later restart-killed sessions from being tombstoned.

Cross-platform check: no shortcut changes. Path handling remains through Node `path`/existing history utilities. The perf runner avoids shell syntax for macOS/Linux/Windows compatibility. macOS helper cooldown remains isolated to macOS computer-use modules. Terminal-history tombstoning remains provider-neutral and preserves SSH/remote keepHistory behavior.

## Security Audit

No new dependencies, auth, secrets, or external IPC surfaces. The perf runner executes fixed repo commands with explicit argument arrays rather than shell interpolation. The permission-status and provider cooldowns store only error code/message plus expiry in memory. Terminal-history changes read/update existing history files with guarded parse/stat/write handling and keep reader-side data deletion out of `HistoryReader`. Explicit non-keepHistory shutdown still removes history only after provider kill succeeds; keepHistory remains available for sleep/exact-stop recovery.

## Notes

- Cooldown is intentionally fixed at 10 seconds for both permission helper launch/open failures and native provider socket startup failures.
- Missing helper app/executable still returns unavailable status and does not poison the permission status cooldown.
- Restart-killed terminal histories are tombstoned instead of deleted; explicit user shutdown without keepHistory remains the deletion path.
- `gh pr checks` currently reports no checks for this branch from the CLI. If GitHub shows an `action_required` workflow in the web UI, it still needs maintainer/user approval there.
