### PR TITLE
Hide Codex worker sessions from history

### DIFF
--- a/src/main/ai-vault/session-scanner-codex-workers.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-workers.test.ts
@@ -1,0 +1,129 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { scanAiVaultSessions } from './session-scanner'
+
+let tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
+  tempRoots = []
+})
+
+function jsonLines(records: unknown[]): string {
+  return records.map((record) => JSON.stringify(record)).join('\n')
+}
+
+describe('scanAiVaultSessions Codex worker sessions', () => {
+  it('hides Codex worker transcripts from session history', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-codex-workers-'))
+    tempRoots.push(root)
+    const codexSessionsDir = join(root, 'codex-sessions')
+    await mkdir(join(codexSessionsDir, '2026', '06', '12'), { recursive: true })
+
+    await writeFile(
+      join(codexSessionsDir, '2026', '06', '12', 'rollout-user-session.jsonl'),
+      jsonLines([
+        {
+          timestamp: '2026-06-12T10:00:00.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'user-session',
+            cwd: '/repo/app',
+            thread_source: 'user'
+          }
+        },
+        {
+          timestamp: '2026-06-12T10:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: 'Top-level Codex task' }]
+          }
+        }
+      ])
+    )
+
+    await writeFile(
+      join(codexSessionsDir, '2026', '06', '12', 'rollout-worker-session.jsonl'),
+      jsonLines([
+        {
+          timestamp: '2026-06-12T10:01:00.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'worker-session',
+            cwd: '/repo/app',
+            thread_source: 'subagent'
+          }
+        },
+        {
+          timestamp: '2026-06-12T10:01:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: 'Internal worker task' }]
+          }
+        }
+      ])
+    )
+
+    await writeFile(
+      join(codexSessionsDir, '2026', '06', '12', 'rollout-legacy-worker-session.jsonl'),
+      jsonLines([
+        {
+          timestamp: '2026-06-12T10:02:00.000Z',
+          type: 'session_meta',
+          payload: {
+            id: 'legacy-worker-session',
+            cwd: '/repo/app',
+            source: {
+              subagent: {
+                thread_spawn: {
+                  parent_thread_id: 'user-session',
+                  depth: 1,
+                  agent_nickname: 'Worker'
+                }
+              }
+            }
+          }
+        },
+        {
+          timestamp: '2026-06-12T10:02:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'text', text: 'Legacy internal worker task' }]
+          }
+        }
+      ])
+    )
+
+    const result = await scanAiVaultSessions({
+      claudeProjectsDir: join(root, 'claude-projects'),
+      codexSessionsDir,
+      geminiSessionsDir: join(root, 'gemini-sessions'),
+      copilotSessionsDir: join(root, 'copilot-sessions'),
+      cursorProjectsDir: join(root, 'cursor-projects'),
+      opencodeStorageDir: join(root, 'opencode-storage'),
+      grokSessionsDir: join(root, 'grok-sessions'),
+      devinTranscriptsDir: join(root, 'devin-transcripts'),
+      hermesSessionsDir: join(root, 'hermes-sessions'),
+      rovoSessionsDir: join(root, 'rovo-sessions'),
+      openclawStateDir: join(root, 'openclaw-state'),
+      openclawLegacyStateDir: join(root, 'openclaw-legacy-state'),
+      piSessionsDir: join(root, 'pi-sessions'),
+      droidSessionsDir: join(root, 'droid-sessions'),
+      droidProjectsDir: join(root, 'droid-projects'),
+      kimiSessionsDir: join(root, 'kimi-sessions'),
+      platform: 'darwin'
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.sessionId)).toEqual(['user-session'])
+    expect(result.sessions[0]?.title).toBe('Top-level Codex task')
+  })
+})

--- a/src/main/ai-vault/session-scanner-primary-parsers.ts
+++ b/src/main/ai-vault/session-scanner-primary-parsers.ts
@@ -126,6 +126,11 @@ export async function parseCodexSessionFile(
 
     const payload = asRecord(record.payload)
     if (record.type === 'session_meta' && payload) {
+      if (isCodexWorkerSession(payload)) {
+        // Why: Codex writes internal worker/sub-agent transcripts into the same
+        // history tree; AI Vault should show user-started sessions only.
+        return null
+      }
       const sessionId = extractString(payload.id)
       if (sessionId) {
         accumulator.sessionId = sessionId
@@ -211,6 +216,20 @@ export async function parseCodexSessionFile(
   }
 
   return finalizeSession(accumulator, platform, { codexHome })
+}
+
+function extractCodexThreadSource(payload: Record<string, unknown>): string | null {
+  return extractString(payload.thread_source) ?? extractString(payload.threadSource)
+}
+
+function isCodexWorkerSession(payload: Record<string, unknown>): boolean {
+  const threadSource = extractCodexThreadSource(payload)
+  if (threadSource) {
+    return threadSource.toLowerCase() !== 'user'
+  }
+
+  const source = asRecord(payload.source)
+  return Boolean(asRecord(source?.subagent))
 }
 
 export async function parseGeminiSessionFile(


### PR DESCRIPTION
## Summary
- hide Codex transcripts from AI Vault/session history when `session_meta.thread_source` marks them as non-user/internal worker sessions
- keep older transcripts without `thread_source` visible for compatibility
- add a focused regression test covering a top-level Codex session beside an internal worker transcript

## Test
- `pnpm vitest run --config config/vitest.config.ts src/main/ai-vault/session-scanner-codex-workers.test.ts`

Note: local test run emitted existing environment warnings for Node 25 vs expected Node 24 and `${GITHUB_TOKEN}` in `.npmrc`, but the test passed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6062">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->