### PR TITLE
Classify Claude CLI usage unavailable state

### DIFF
--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -634,6 +634,34 @@ describe('fetchClaudeRateLimits', () => {
     expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
   })
 
+  it('marks CLI plan usage shell results as usage unavailable', async () => {
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir: '/Users/test/.claude',
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(fetchViaPty).mockResolvedValueOnce({
+      provider: 'claude',
+      session: null,
+      weekly: null,
+      updatedAt: 1,
+      error: 'Claude plan usage is unavailable for this Claude CLI session.',
+      status: 'error'
+    })
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'Claude plan usage is unavailable for this Claude CLI session.',
+      usageMetadata: {
+        source: 'cli',
+        attemptedSources: ['cli'],
+        failureKind: 'usage-unavailable'
+      }
+    })
+  })
+
   it('surfaces Keychain read failures as structured usage metadata when CLI fallback is disabled', async () => {
     vi.mocked(readActiveClaudeKeychainCredentials).mockRejectedValueOnce(
       new Error('security timed out after 3000ms')

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -443,6 +443,21 @@ function metadataForAttempt(input: {
   }
 }
 
+function classifyClaudeCliUsageFailure(
+  limits: ProviderRateLimits
+): UsageRateLimitFailureKind | undefined {
+  if (!limits.error) {
+    return undefined
+  }
+  if (/rate limited/i.test(limits.error)) {
+    return 'rate-limited'
+  }
+  if (/plan usage is unavailable|usage is unavailable/i.test(limits.error)) {
+    return 'usage-unavailable'
+  }
+  return 'cli-unavailable'
+}
+
 async function fetchClaudeUsageViaCli(input: {
   authPreparation?: ClaudeRuntimeAuthPreparation
   oauthCredentials: OAuthCredentialReadResult
@@ -456,7 +471,8 @@ async function fetchClaudeUsageViaCli(input: {
       attemptedSources: input.attempts.attemptedSources,
       oauthCredentials: input.oauthCredentials,
       authPreparation: input.authPreparation,
-      source: 'cli'
+      source: 'cli',
+      failureKind: classifyClaudeCliUsageFailure(limits)
     })
   )
 }

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -212,6 +212,16 @@ describe('provider usage error copy', () => {
     expect(getProviderUsageStatusLabel(p)).toBe('Sign-in unavailable')
     expect(getProviderUsageErrorMessage(p)).toBe('Claude sign-in credentials could not be read.')
   })
+
+  it('uses structured unavailable copy for Claude CLI usage shell failures', () => {
+    const p = provider({
+      error: 'Claude plan usage is unavailable for this Claude CLI session.',
+      usageMetadata: { failureKind: 'usage-unavailable' }
+    })
+
+    expect(getProviderUsageStatusLabel(p)).toBe('Usage unavailable')
+    expect(getProviderUsageErrorMessage(p)).toBe('Claude usage is unavailable right now.')
+  })
 })
 
 describe('getWindowSections', () => {


### PR DESCRIPTION
## Summary
- classify Claude CLI usage-shell failures as usage unavailable metadata
- show the structured Usage unavailable tooltip copy instead of raw refresh-failed copy
- add regression coverage for the fetcher metadata and status-bar copy

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/claude-fetcher.test.ts src/renderer/src/components/status-bar/tooltip.test.ts
- pnpm exec oxfmt --check src/main/rate-limits/claude-fetcher.ts src/main/rate-limits/claude-fetcher.test.ts src/renderer/src/components/status-bar/tooltip.test.ts
- pnpm exec oxlint src/main/rate-limits/claude-fetcher.ts src/main/rate-limits/claude-fetcher.test.ts src/renderer/src/components/status-bar/tooltip.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6065">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->