### PR TITLE
Remove Mobile settings enable toggle

### DIFF
--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -1,11 +1,7 @@
-import type { GlobalSettings } from '../../../../shared/types'
-import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
-import { matchesSettingsSearch } from './settings-search'
-import { useAppStore } from '../../store'
 import { MobilePane } from './MobilePane'
 import {
-  getMobileEnableSearchEntry,
+  getMobileOverviewSearchEntry,
   getMobileSettingsPaneSearchEntries
 } from './mobile-settings-search'
 import { translate } from '@/i18n/i18n'
@@ -15,100 +11,50 @@ const ORCA_IOS_APP_STORE_URL = 'https://apps.apple.com/app/orca-ide/id6766130217
 const ORCA_ANDROID_APK_URL =
   'https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.14/app-release.apk'
 
-type MobileSettingsPaneProps = {
-  settings: GlobalSettings
-  updateSettings: (updates: Partial<GlobalSettings>) => void
-}
-
-export function MobileSettingsPane({
-  settings,
-  updateSettings
-}: MobileSettingsPaneProps): React.JSX.Element {
-  const searchQuery = useAppStore((s) => s.settingsSearchQuery)
-  const showEnableSetting =
-    !settings.experimentalMobile ||
-    matchesSettingsSearch(searchQuery, [getMobileEnableSearchEntry()])
-
+export function MobileSettingsPane(): React.JSX.Element {
   return (
     <div className="space-y-4">
-      {showEnableSetting ? (
-        <SearchableSetting
-          title={translate('auto.components.settings.MobileSettingsPane.e7a3ae8c4e', 'Mobile')}
-          description={translate(
-            'auto.components.settings.MobileSettingsPane.174f4a3c6d',
-            'Control terminals and agents from your phone.'
-          )}
-          keywords={getMobileEnableSearchEntry().keywords}
-          className="space-y-3 py-2"
-        >
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0 shrink space-y-1.5">
-              <Label>
-                {translate('auto.components.settings.MobileSettingsPane.e7a3ae8c4e', 'Mobile')}
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                {translate(
-                  'auto.components.settings.MobileSettingsPane.c8491c17ef',
-                  'Control Orca from your phone by scanning a QR code. Beta / early preview - expect bugs and breaking changes. Get the iOS app from the'
-                )}{' '}
-                <button
-                  type="button"
-                  onClick={() => void window.api.shell.openUrl(ORCA_IOS_APP_STORE_URL)}
-                  className="cursor-pointer underline underline-offset-2 hover:text-foreground"
-                >
-                  {translate('auto.components.settings.MobileSettingsPane.b5a2ed83ff', 'App Store')}
-                </button>{' '}
-                {translate(
-                  'auto.components.settings.MobileSettingsPane.b0088412a1',
-                  'or the Android APK from'
-                )}{' '}
-                <button
-                  type="button"
-                  // Why: Android is moving to Google Play soon, but until then
-                  // link directly to the pinned APK asset for the current mobile release.
-                  onClick={() => void window.api.shell.openUrl(ORCA_ANDROID_APK_URL)}
-                  className="cursor-pointer underline underline-offset-2 hover:text-foreground"
-                >
-                  {translate(
-                    'auto.components.settings.MobileSettingsPane.9a3c280e49',
-                    'GitHub Releases'
-                  )}
-                </button>
-                .
-              </p>
-            </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={settings.experimentalMobile}
-              onClick={() => {
-                const nextEnabled = !settings.experimentalMobile
-                if (nextEnabled) {
-                  useAppStore.getState().recordFeatureInteraction('mobile-pairing')
-                }
-                updateSettings({
-                  experimentalMobile: nextEnabled
-                })
-              }}
-              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-                settings.experimentalMobile ? 'bg-foreground' : 'bg-muted-foreground/30'
-              }`}
-            >
-              <span
-                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
-                  settings.experimentalMobile ? 'translate-x-4' : 'translate-x-0.5'
-                }`}
-              />
-            </button>
-          </div>
-        </SearchableSetting>
-      ) : null}
+      <SearchableSetting
+        title={translate('auto.components.settings.MobileSettingsPane.e7a3ae8c4e', 'Mobile')}
+        description={translate(
+          'auto.components.settings.MobileSettingsPane.174f4a3c6d',
+          'Control terminals and agents from your phone.'
+        )}
+        keywords={getMobileOverviewSearchEntry().keywords}
+        className="space-y-3 py-2"
+      >
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.MobileSettingsPane.c8491c17ef',
+            'Control Orca from your phone by scanning a QR code. Get the iOS app from the'
+          )}{' '}
+          <button
+            type="button"
+            onClick={() => void window.api.shell.openUrl(ORCA_IOS_APP_STORE_URL)}
+            className="cursor-pointer underline underline-offset-2 hover:text-foreground"
+          >
+            {translate('auto.components.settings.MobileSettingsPane.b5a2ed83ff', 'App Store')}
+          </button>{' '}
+          {translate(
+            'auto.components.settings.MobileSettingsPane.b0088412a1',
+            'or the Android APK from'
+          )}{' '}
+          <button
+            type="button"
+            // Why: Android is moving to Google Play soon, but until then
+            // link directly to the pinned APK asset for the current mobile release.
+            onClick={() => void window.api.shell.openUrl(ORCA_ANDROID_APK_URL)}
+            className="cursor-pointer underline underline-offset-2 hover:text-foreground"
+          >
+            {translate('auto.components.settings.MobileSettingsPane.9a3c280e49', 'GitHub Releases')}
+          </button>
+          .
+        </p>
+      </SearchableSetting>
 
-      {settings.experimentalMobile ? (
-        <div className="rounded-xl border border-border/60 bg-card/50 p-4">
-          <MobilePane />
-        </div>
-      ) : null}
+      <div className="rounded-xl border border-border/60 bg-card/50 p-4">
+        <MobilePane />
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -1513,9 +1513,7 @@ function Settings(): React.JSX.Element {
                       )}
                       searchEntries={getSectionSearchEntries('mobile')}
                     >
-                      {isSectionMounted('mobile') ? (
-                        <MobileSettingsPane settings={settings} updateSettings={updateSettings} />
-                      ) : null}
+                      {isSectionMounted('mobile') ? <MobileSettingsPane /> : null}
                     </SettingsSection>
                   </>
                 ) : null}

--- a/src/renderer/src/components/settings/mobile-settings-search.ts
+++ b/src/renderer/src/components/settings/mobile-settings-search.ts
@@ -4,7 +4,7 @@ import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 
-export const getMobileEnableSearchEntry = createLocalizedCatalog(
+export const getMobileOverviewSearchEntry = createLocalizedCatalog(
   (): SettingsSearchEntry => ({
     title: translate('auto.components.settings.mobile.settings.search.ffd52a96e4', 'Mobile'),
     description: translate(
@@ -49,14 +49,11 @@ export const getMobileEnableSearchEntry = createLocalizedCatalog(
         'auto.components.settings.mobile.settings.search.8d4ba0ef09',
         'beta'
       ),
-      ...translateSearchKeyword(
-        'auto.components.settings.mobile.settings.search.b730ff7049',
-        'experimental'
-      )
+      ...translateSearchKeyword('auto.components.settings.mobile.settings.search.b730ff7049', 'app')
     ]
   })
 )
 
 export const getMobileSettingsPaneSearchEntries = createLocalizedCatalog(
-  (): SettingsSearchEntry[] => [getMobileEnableSearchEntry(), ...getMobilePaneSearchEntries()]
+  (): SettingsSearchEntry[] => [getMobileOverviewSearchEntry(), ...getMobilePaneSearchEntries()]
 )


### PR DESCRIPTION
## Summary
- remove the obsolete Mobile enable switch
- always show Mobile settings controls
- update Mobile settings copy and search metadata now that the feature is always available

## Verification
- pnpm run typecheck:web
- pnpm run verify:localization-catalog
- pnpm run verify:localization-coverage
- pnpm exec oxlint src/renderer/src/components/settings/MobileSettingsPane.tsx src/renderer/src/components/settings/Settings.tsx src/renderer/src/components/settings/mobile-settings-search.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6070">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->