### PR TITLE
Load all hosts' repos at startup so cold start doesn't hide local repos

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -387,6 +387,7 @@ function App(): React.JSX.Element {
     useShallow((s) => ({
       toggleSidebar: s.toggleSidebar,
       fetchRepos: s.fetchRepos,
+      fetchReposForAllHosts: s.fetchReposForAllHosts,
       fetchProjectGroups: s.fetchProjectGroups,
       fetchFolderWorkspaces: s.fetchFolderWorkspaces,
       fetchAllWorktrees: s.fetchAllWorktrees,
@@ -837,7 +838,10 @@ function App(): React.JSX.Element {
         // Load settings first so a persisted remote runtime does not boot against
         // the local filesystem and then hydrate stale local workspace state.
         await actions.fetchSettings()
-        await actions.fetchRepos()
+        // Why: load local + every configured runtime environment (not just the
+        // active one) so a cold start that restored a remote workspace doesn't
+        // hide local repos. The sidebar "All hosts" scope then shows them all.
+        await actions.fetchReposForAllHosts()
         await actions.fetchProjectGroups()
         await actions.fetchFolderWorkspaces()
         await actions.fetchAllWorktrees()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -389,7 +389,9 @@ function App(): React.JSX.Element {
       fetchRepos: s.fetchRepos,
       fetchReposForAllHosts: s.fetchReposForAllHosts,
       fetchProjectGroups: s.fetchProjectGroups,
+      fetchProjectGroupsForAllHosts: s.fetchProjectGroupsForAllHosts,
       fetchFolderWorkspaces: s.fetchFolderWorkspaces,
+      fetchFolderWorkspacesForAllHosts: s.fetchFolderWorkspacesForAllHosts,
       fetchAllWorktrees: s.fetchAllWorktrees,
       fetchWorktreeLineage: s.fetchWorktreeLineage,
       fetchSettings: s.fetchSettings,
@@ -842,8 +844,8 @@ function App(): React.JSX.Element {
         // active one) so a cold start that restored a remote workspace doesn't
         // hide local repos. The sidebar "All hosts" scope then shows them all.
         await actions.fetchReposForAllHosts()
-        await actions.fetchProjectGroups()
-        await actions.fetchFolderWorkspaces()
+        await actions.fetchProjectGroupsForAllHosts()
+        await actions.fetchFolderWorkspacesForAllHosts()
         await actions.fetchAllWorktrees()
         await actions.fetchWorktreeLineage()
         const persistedUI = await window.api.ui.get()

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -11,7 +11,7 @@ describe('renderer startup runtime routing', () => {
 
     expect(startupBlock.indexOf('await actions.fetchSettings()')).toBeGreaterThanOrEqual(0)
     expect(startupBlock.indexOf('await actions.fetchSettings()')).toBeLessThan(
-      startupBlock.indexOf('await actions.fetchRepos()')
+      startupBlock.indexOf('await actions.fetchReposForAllHosts()')
     )
     expect(startupBlock.indexOf('await actions.fetchSettings()')).toBeLessThan(
       startupBlock.indexOf('await actions.fetchAllWorktrees()')

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -913,13 +913,18 @@ export function useIpcEvents(): void {
 
     unsubs.push(
       window.api.repos.onChanged(() => {
+        const state = useAppStore.getState()
         if (isRuntimeEnvironmentActive()) {
-          // Why: this event comes from the local Electron store. While a
-          // runtime server is selected, repo hydration must be driven by the
-          // selected server instead of local-disk changes.
+          // Why: the all-host sidebar includes local repos even when a runtime
+          // is focused, so local store changes must refresh the local slice
+          // without dropping the runtime-owned slices already shown.
+          void (async () => {
+            await state.fetchReposForAllHosts()
+            await state.fetchProjectGroupsForAllHosts()
+            await state.fetchFolderWorkspacesForAllHosts()
+          })()
           return
         }
-        const state = useAppStore.getState()
         void state.fetchProjectGroups()
         void state.fetchFolderWorkspaces()
         void state.fetchRepos()

--- a/src/renderer/src/store/slices/repos-all-hosts.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTestStore } from './store-test-helpers'
-import type { Repo } from '../../../../shared/types'
+import type {
+  FolderWorkspace,
+  Project,
+  ProjectHostSetup,
+  ProjectGroup,
+  Repo
+} from '../../../../shared/types'
 import {
   createCompatibleRuntimeStatusResponseIfNeeded,
   type RuntimeEnvironmentCallRequest
@@ -23,9 +29,91 @@ const remoteRepo: Repo = {
   addedAt: 1
 }
 
+const localProject: Project = {
+  id: 'local-project',
+  displayName: 'Local project',
+  badgeColor: '#000',
+  sourceRepoIds: ['local-repo'],
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const localProjectHostSetup: ProjectHostSetup = {
+  id: 'local-setup',
+  projectId: 'local-project',
+  hostId: 'local',
+  repoId: 'local-repo',
+  path: '/local',
+  displayName: 'Local setup',
+  setupState: 'setting-up',
+  setupMethod: 'imported-existing-folder',
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const localProjectGroup: ProjectGroup = {
+  id: 'local-group',
+  name: 'Local group',
+  parentPath: '/local',
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const remoteProjectGroup: ProjectGroup = {
+  id: 'remote-group',
+  name: 'Remote group',
+  parentPath: '/srv',
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const localFolderWorkspace: FolderWorkspace = {
+  id: 'local-folder',
+  projectGroupId: 'local-group',
+  name: 'Local folder',
+  folderPath: '/local',
+  linkedTask: null,
+  comment: '',
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 1,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const remoteFolderWorkspace: FolderWorkspace = {
+  id: 'remote-folder',
+  projectGroupId: 'remote-group',
+  name: 'Remote folder',
+  folderPath: '/srv',
+  linkedTask: null,
+  comment: '',
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 1,
+  createdAt: 1,
+  updatedAt: 1
+}
+
 const reposList = vi.fn()
 const projectsList = vi.fn()
 const listHostSetups = vi.fn()
+const projectGroupsList = vi.fn()
+const folderWorkspacesList = vi.fn()
 const runtimeEnvironmentsList = vi.fn()
 const runtimeEnvironmentCall = vi.fn()
 const runtimeEnvironmentTransportCall = vi.fn()
@@ -36,14 +124,18 @@ beforeEach(() => {
   reposList.mockReset()
   projectsList.mockReset()
   listHostSetups.mockReset()
+  projectGroupsList.mockReset()
+  folderWorkspacesList.mockReset()
   runtimeEnvironmentsList.mockReset()
   runtimeEnvironmentCall.mockReset()
   runtimeEnvironmentTransportCall.mockReset()
   dispatchEventMock.mockReset()
 
   reposList.mockResolvedValue([localRepo])
-  projectsList.mockResolvedValue([])
-  listHostSetups.mockResolvedValue([])
+  projectsList.mockResolvedValue([localProject])
+  listHostSetups.mockResolvedValue([localProjectHostSetup])
+  projectGroupsList.mockResolvedValue([localProjectGroup])
+  folderWorkspacesList.mockResolvedValue([localFolderWorkspace])
   runtimeEnvironmentsList.mockResolvedValue([{ id: 'env-1', name: 'lobster' }])
   runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
     if (args.method === 'repo.list') {
@@ -51,6 +143,22 @@ beforeEach(() => {
         id: 'rpc-repo-list',
         ok: true,
         result: { repos: [remoteRepo] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    }
+    if (args.method === 'projectGroup.list') {
+      return {
+        id: 'rpc-project-group-list',
+        ok: true,
+        result: { groups: [remoteProjectGroup] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    }
+    if (args.method === 'folderWorkspace.list') {
+      return {
+        id: 'rpc-folder-workspace-list',
+        ok: true,
+        result: { folderWorkspaces: [remoteFolderWorkspace] },
         _meta: { runtimeId: 'runtime-remote' }
       }
     }
@@ -69,6 +177,8 @@ beforeEach(() => {
     api: {
       repos: { list: reposList },
       projects: { list: projectsList, listHostSetups: listHostSetups },
+      projectGroups: { list: projectGroupsList },
+      folderWorkspaces: { list: folderWorkspacesList },
       runtimeEnvironments: {
         call: runtimeEnvironmentTransportCall,
         list: runtimeEnvironmentsList
@@ -93,6 +203,8 @@ describe('fetchReposForAllHosts', () => {
       .repos.map((repo) => repo.id)
       .sort()
     expect(ids).toEqual(['local-repo', 'remote-repo'])
+    expect(store.getState().projects).toContainEqual(localProject)
+    expect(store.getState().projectHostSetups).toContainEqual(localProjectHostSetup)
   })
 
   it('fails soft when a runtime environment is unreachable, keeping local repos', async () => {
@@ -113,5 +225,46 @@ describe('fetchReposForAllHosts', () => {
     await store.getState().fetchReposForAllHosts()
 
     expect(store.getState().repos.map((repo) => repo.id)).toEqual(['local-repo'])
+  })
+
+  it('loads project groups and folder workspaces for every host', async () => {
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchProjectGroupsForAllHosts()
+    await store.getState().fetchFolderWorkspacesForAllHosts()
+
+    expect(store.getState().projectGroups).toEqual([
+      { ...localProjectGroup, executionHostId: 'local' },
+      { ...remoteProjectGroup, executionHostId: 'runtime:env-1' }
+    ])
+    expect(store.getState().folderWorkspaces.map((workspace) => workspace.id)).toEqual([
+      'local-folder',
+      'remote-folder'
+    ])
+  })
+
+  it('keeps local project groups and folder workspaces when a runtime is unreachable', async () => {
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      if (args.method === 'projectGroup.list' || args.method === 'folderWorkspace.list') {
+        throw new Error('runtime_unreachable')
+      }
+      return {
+        id: 'rpc-other',
+        ok: true,
+        result: { repos: [], projects: [], setups: [] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchProjectGroupsForAllHosts()
+    await store.getState().fetchFolderWorkspacesForAllHosts()
+
+    expect(store.getState().projectGroups).toEqual([
+      { ...localProjectGroup, executionHostId: 'local' }
+    ])
+    expect(store.getState().folderWorkspaces).toEqual([localFolderWorkspace])
   })
 })

--- a/src/renderer/src/store/slices/repos-all-hosts.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+import type { Repo } from '../../../../shared/types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+
+const localRepo: Repo = {
+  id: 'local-repo',
+  path: '/local',
+  displayName: 'Local',
+  badgeColor: '#000',
+  addedAt: 1
+}
+
+const remoteRepo: Repo = {
+  id: 'remote-repo',
+  path: '/srv/repo',
+  displayName: 'Remote',
+  badgeColor: '#000',
+  addedAt: 1
+}
+
+const reposList = vi.fn()
+const projectsList = vi.fn()
+const listHostSetups = vi.fn()
+const runtimeEnvironmentsList = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+const dispatchEventMock = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposList.mockReset()
+  projectsList.mockReset()
+  listHostSetups.mockReset()
+  runtimeEnvironmentsList.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+  dispatchEventMock.mockReset()
+
+  reposList.mockResolvedValue([localRepo])
+  projectsList.mockResolvedValue([])
+  listHostSetups.mockResolvedValue([])
+  runtimeEnvironmentsList.mockResolvedValue([{ id: 'env-1', name: 'lobster' }])
+  runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    if (args.method === 'repo.list') {
+      return {
+        id: 'rpc-repo-list',
+        ok: true,
+        result: { repos: [remoteRepo] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    }
+    return {
+      id: 'rpc-other',
+      ok: true,
+      result: { projects: [], setups: [] },
+      _meta: { runtimeId: 'runtime-remote' }
+    }
+  })
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+
+  vi.stubGlobal('window', {
+    api: {
+      repos: { list: reposList },
+      projects: { list: projectsList, listHostSetups: listHostSetups },
+      runtimeEnvironments: {
+        call: runtimeEnvironmentTransportCall,
+        list: runtimeEnvironmentsList
+      }
+    },
+    dispatchEvent: dispatchEventMock
+  })
+})
+
+describe('fetchReposForAllHosts', () => {
+  it('loads local + all configured runtime environments even when a remote env is active', async () => {
+    // Why: a cold start that restored a remote workspace leaves the remote
+    // environment active. The active-host-only fetchRepos would drop local
+    // repos entirely; fetchReposForAllHosts must surface both.
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+
+    const ids = store
+      .getState()
+      .repos.map((repo) => repo.id)
+      .sort()
+    expect(ids).toEqual(['local-repo', 'remote-repo'])
+  })
+
+  it('fails soft when a runtime environment is unreachable, keeping local repos', async () => {
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      if (args.method === 'repo.list') {
+        throw new Error('runtime_unreachable')
+      }
+      return {
+        id: 'rpc-other',
+        ok: true,
+        result: { projects: [], setups: [] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+
+    expect(store.getState().repos.map((repo) => repo.id)).toEqual(['local-repo'])
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -625,6 +625,7 @@ export type RepoSlice = {
   folderWorkspacePathStatuses: Record<string, FolderWorkspacePathStatusCacheEntry>
   activeRepoId: string | null
   fetchRepos: () => Promise<void>
+  fetchReposForAllHosts: () => Promise<void>
   fetchRuntimeEnvironmentRepos: (environmentId: string) => Promise<Repo[]>
   fetchProjectGroups: () => Promise<void>
   fetchFolderWorkspaces: () => Promise<void>
@@ -794,6 +795,58 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     } catch (err) {
       console.error(`Failed to fetch repos for runtime environment ${environmentId}:`, err)
       return []
+    }
+  },
+
+  fetchReposForAllHosts: async () => {
+    // Why: a cold start that restores a remote workspace re-activates that
+    // remote runtime environment, and fetching only the active host hides every
+    // other host's repos (notably all local repos), which reads as "my projects
+    // vanished". Load local + every configured runtime environment so the
+    // sidebar "All hosts" scope shows them together regardless of which
+    // environment is active. Each host fails soft: an unreachable/disconnected
+    // host is skipped without blocking the others.
+    const applyResult = (result: Awaited<ReturnType<typeof fetchReposForTarget>>): void => {
+      const validRepoIds = new Set(result.repos.map((repo) => repo.id))
+      set((s) => ({
+        repos: result.repos,
+        ...result.projectCompatibility,
+        folderWorkspacePathStatuses: {},
+        activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
+        filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+        setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
+          s.setupScriptPromptDismissedRepoIds,
+          validRepoIds
+        )
+      }))
+    }
+
+    // Local first so local repos are present even if a remote fetch stalls.
+    try {
+      applyResult(await fetchReposForTarget({ kind: 'local' }, get().repos))
+    } catch (err) {
+      console.error('Failed to fetch local repos for all-host load:', err)
+    }
+
+    let environments: { id: string }[] = []
+    try {
+      environments = (await window.api.runtimeEnvironments.list()) ?? []
+    } catch (err) {
+      console.warn('Failed to list runtime environments for all-host load:', err)
+    }
+
+    // Sequential to avoid concurrent set() races on the merged repos array.
+    for (const environment of environments) {
+      try {
+        applyResult(
+          await fetchReposForTarget(
+            { kind: 'environment', environmentId: environment.id },
+            get().repos
+          )
+        )
+      } catch (err) {
+        console.warn(`Skipped repos for runtime environment ${environment.id}:`, err)
+      }
     }
   },
 

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -417,6 +417,56 @@ function getProjectHostSetupOwnerKey(setup: ProjectHostSetup): string {
   return `${setup.hostId}:${setup.repoId ?? setup.id}`
 }
 
+function getProjectHostIds(
+  project: Project,
+  setups: readonly ProjectHostSetup[],
+  repos: readonly Repo[]
+): Set<string> {
+  const hostIds = new Set<string>()
+  const repoById = new Map(repos.map((repo) => [repo.id, repo]))
+  for (const setup of setups) {
+    if (setup.projectId === project.id) {
+      hostIds.add(setup.hostId)
+    }
+  }
+  for (const repoId of project.sourceRepoIds) {
+    const repo = repoById.get(repoId)
+    if (repo) {
+      hostIds.add(getRepoExecutionHostId(repo))
+    }
+  }
+  if (hostIds.size === 0) {
+    hostIds.add(LOCAL_EXECUTION_HOST_ID)
+  }
+  return hostIds
+}
+
+function mergeFetchedProjectCompatibilityForHost({
+  previous,
+  fetched,
+  repos,
+  hostId
+}: {
+  previous: Pick<RepoSlice, 'projects' | 'projectHostSetups'>
+  fetched: Pick<RepoSlice, 'projects' | 'projectHostSetups'>
+  repos: readonly Repo[]
+  hostId: string
+}): Pick<RepoSlice, 'projects' | 'projectHostSetups'> {
+  const fetchedSetupsForHost = fetched.projectHostSetups.filter((setup) => setup.hostId === hostId)
+  const preservedSetups = previous.projectHostSetups.filter((setup) => setup.hostId !== hostId)
+  const projectHostSetups = mergeById(preservedSetups, fetchedSetupsForHost)
+  const fetchedProjectsForHost = fetched.projects.filter((project) =>
+    getProjectHostIds(project, fetched.projectHostSetups, repos).has(hostId)
+  )
+  const preservedProjects = previous.projects.filter(
+    (project) => !getProjectHostIds(project, previous.projectHostSetups, repos).has(hostId)
+  )
+  return {
+    projects: mergeById(preservedProjects, fetchedProjectsForHost),
+    projectHostSetups
+  }
+}
+
 function mergeById<T extends { id: string }>(base: readonly T[], overlay: readonly T[]): T[] {
   const merged = [...base]
   const indexById = new Map(merged.map((entry, index) => [entry.id, index]))
@@ -458,6 +508,48 @@ function mergeFetchedReposForHost(
   )
 }
 
+function getProjectGroupHostId(group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>) {
+  if (group.executionHostId) {
+    return group.executionHostId
+  }
+  return group.connectionId ? toSshExecutionHostId(group.connectionId) : LOCAL_EXECUTION_HOST_ID
+}
+
+function mergeFetchedProjectGroupsForHost(
+  previous: readonly ProjectGroup[],
+  fetched: ProjectGroup[],
+  hostId: string
+): ProjectGroup[] {
+  const fetchedIds = new Set(fetched.map((group) => group.id))
+  const preserved = previous.filter((group) => {
+    const existingHostId = getProjectGroupHostId(group)
+    return existingHostId !== hostId || fetchedIds.has(group.id)
+  })
+  return mergeById(preserved, fetched)
+}
+
+function mergeFetchedFolderWorkspacesForHost({
+  previous,
+  fetched,
+  projectGroups,
+  hostId
+}: {
+  previous: readonly FolderWorkspace[]
+  fetched: FolderWorkspace[]
+  projectGroups: readonly ProjectGroup[]
+  hostId: string
+}): FolderWorkspace[] {
+  const fetchedIds = new Set(fetched.map((workspace) => workspace.id))
+  const projectGroupHostIds = new Map(
+    projectGroups.map((group) => [group.id, getProjectGroupHostId(group)])
+  )
+  const preserved = previous.filter((workspace) => {
+    const existingHostId = projectGroupHostIds.get(workspace.projectGroupId)
+    return existingHostId === undefined || existingHostId !== hostId || fetchedIds.has(workspace.id)
+  })
+  return mergeById(preserved, fetched)
+}
+
 async function fetchReposForTarget(
   target: ReturnType<typeof getActiveRuntimeTarget>,
   currentRepos: readonly Repo[]
@@ -490,6 +582,66 @@ async function fetchReposForTarget(
         )
 
   return { repos: reconciledRepos, projectCompatibility, hostId }
+}
+
+async function fetchProjectGroupsForTarget(
+  target: ReturnType<typeof getActiveRuntimeTarget>,
+  currentProjectGroups: readonly ProjectGroup[]
+): Promise<{ projectGroups: ProjectGroup[]; hostId: ReturnType<typeof getRuntimeTargetHostId> }> {
+  const fetchedGroups =
+    target.kind === 'local'
+      ? await window.api.projectGroups.list()
+      : (
+          await callRuntimeRpc<{ groups: ProjectGroup[] }>(target, 'projectGroup.list', undefined, {
+            timeoutMs: 15_000
+          })
+        ).groups
+  const hostId = getRuntimeTargetHostId(target)
+  const ownedGroups = fetchedGroups.map((group) => projectGroupWithFetchedOwner(group, target))
+  return {
+    projectGroups: mergeFetchedProjectGroupsForHost(currentProjectGroups, ownedGroups, hostId),
+    hostId
+  }
+}
+
+async function fetchFolderWorkspacesForTarget(
+  target: ReturnType<typeof getActiveRuntimeTarget>,
+  currentFolderWorkspaces: readonly FolderWorkspace[],
+  projectGroups: readonly ProjectGroup[]
+): Promise<{
+  folderWorkspaces: FolderWorkspace[]
+  hostId: ReturnType<typeof getRuntimeTargetHostId>
+}> {
+  const fetchedFolderWorkspaces =
+    target.kind === 'local'
+      ? await window.api.folderWorkspaces.list()
+      : (
+          await callRuntimeRpc<{ folderWorkspaces: FolderWorkspace[] }>(
+            target,
+            'folderWorkspace.list',
+            undefined,
+            { timeoutMs: 15_000 }
+          )
+        ).folderWorkspaces
+  const hostId = getRuntimeTargetHostId(target)
+  return {
+    folderWorkspaces: mergeFetchedFolderWorkspacesForHost({
+      previous: currentFolderWorkspaces,
+      fetched: fetchedFolderWorkspaces,
+      projectGroups,
+      hostId
+    }),
+    hostId
+  }
+}
+
+async function listRuntimeEnvironmentsForAllHostLoad(): Promise<{ id: string }[]> {
+  try {
+    return (await window.api.runtimeEnvironments.list()) ?? []
+  } catch (err) {
+    console.warn('Failed to list runtime environments for all-host load:', err)
+    return []
+  }
 }
 
 function settingsForRepoOwner(state: Pick<AppState, 'repos' | 'settings'>, repoId: string) {
@@ -628,7 +780,9 @@ export type RepoSlice = {
   fetchReposForAllHosts: () => Promise<void>
   fetchRuntimeEnvironmentRepos: (environmentId: string) => Promise<Repo[]>
   fetchProjectGroups: () => Promise<void>
+  fetchProjectGroupsForAllHosts: () => Promise<void>
   fetchFolderWorkspaces: () => Promise<void>
+  fetchFolderWorkspacesForAllHosts: () => Promise<void>
   addRepo: () => Promise<Repo | null>
   addRepoPath: (path: string, kind?: 'git' | 'folder') => Promise<Repo | null>
   setupProjectExistingFolder: (
@@ -747,9 +901,18 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       } = await fetchReposForTarget(target, get().repos)
       set((s) => {
         const validRepoIds = new Set(reconciledRepos.map((repo) => repo.id))
+        const mergedProjectCompatibility = mergeFetchedProjectCompatibilityForHost({
+          previous: {
+            projects: s.projects,
+            projectHostSetups: s.projectHostSetups
+          },
+          fetched: projectCompatibility,
+          repos: reconciledRepos,
+          hostId
+        })
         return {
           repos: reconciledRepos,
-          ...projectCompatibility,
+          ...mergedProjectCompatibility,
           folderWorkspacePathStatuses: {},
           activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
           filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
@@ -777,16 +940,27 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         hostId
       } = await fetchReposForTarget(target, get().repos)
       const validRepoIds = new Set(reconciledRepos.map((repo) => repo.id))
-      set((s) => ({
-        repos: reconciledRepos,
-        ...projectCompatibility,
-        activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-        filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
-        setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
-          s.setupScriptPromptDismissedRepoIds,
-          validRepoIds
-        )
-      }))
+      set((s) => {
+        const mergedProjectCompatibility = mergeFetchedProjectCompatibilityForHost({
+          previous: {
+            projects: s.projects,
+            projectHostSetups: s.projectHostSetups
+          },
+          fetched: projectCompatibility,
+          repos: reconciledRepos,
+          hostId
+        })
+        return {
+          repos: reconciledRepos,
+          ...mergedProjectCompatibility,
+          activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
+          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+          setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
+            s.setupScriptPromptDismissedRepoIds,
+            validRepoIds
+          )
+        }
+      })
       const fetchedHostRepos = reconciledRepos.filter(
         (repo) => getRepoExecutionHostId(repo) === hostId
       )
@@ -808,17 +982,28 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     // host is skipped without blocking the others.
     const applyResult = (result: Awaited<ReturnType<typeof fetchReposForTarget>>): void => {
       const validRepoIds = new Set(result.repos.map((repo) => repo.id))
-      set((s) => ({
-        repos: result.repos,
-        ...result.projectCompatibility,
-        folderWorkspacePathStatuses: {},
-        activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
-        filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
-        setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
-          s.setupScriptPromptDismissedRepoIds,
-          validRepoIds
-        )
-      }))
+      set((s) => {
+        const mergedProjectCompatibility = mergeFetchedProjectCompatibilityForHost({
+          previous: {
+            projects: s.projects,
+            projectHostSetups: s.projectHostSetups
+          },
+          fetched: result.projectCompatibility,
+          repos: result.repos,
+          hostId: result.hostId
+        })
+        return {
+          repos: result.repos,
+          ...mergedProjectCompatibility,
+          folderWorkspacePathStatuses: {},
+          activeRepoId: s.activeRepoId && validRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
+          filterRepoIds: s.filterRepoIds.filter((projectId) => validRepoIds.has(projectId)),
+          setupScriptPromptDismissedRepoIds: filterSetupScriptPromptDismissalsToValidRepos(
+            s.setupScriptPromptDismissedRepoIds,
+            validRepoIds
+          )
+        }
+      })
       // Why: preserve the safe-auto fork sync that fetchRepos /
       // fetchRuntimeEnvironmentRepos schedule after merging each host, so
       // cold-start (which now routes through here) keeps updating safe-auto forks.
@@ -835,12 +1020,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       console.error('Failed to fetch local repos for all-host load:', err)
     }
 
-    let environments: { id: string }[] = []
-    try {
-      environments = (await window.api.runtimeEnvironments.list()) ?? []
-    } catch (err) {
-      console.warn('Failed to list runtime environments for all-host load:', err)
-    }
+    const environments = await listRuntimeEnvironmentsForAllHostLoad()
 
     // Sequential to avoid concurrent set() races on the merged repos array.
     for (const environment of environments) {
@@ -860,21 +1040,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   fetchProjectGroups: async () => {
     try {
       const target = getActiveRuntimeTarget(get().settings)
-      const projectGroups =
-        target.kind === 'local'
-          ? await window.api.projectGroups.list()
-          : (
-              await callRuntimeRpc<{ groups: ProjectGroup[] }>(
-                target,
-                'projectGroup.list',
-                undefined,
-                {
-                  timeoutMs: 15_000
-                }
-              )
-            ).groups
+      const { projectGroups } = await fetchProjectGroupsForTarget(target, [])
       set({
-        projectGroups: projectGroups.map((group) => projectGroupWithFetchedOwner(group, target)),
+        projectGroups,
         folderWorkspacePathStatuses: {}
       })
     } catch (err) {
@@ -882,23 +1050,88 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
+  fetchProjectGroupsForAllHosts: async () => {
+    // Why: startup renders an all-host sidebar; replacing groups with only the
+    // active host would leave repos from other hosts visible but ungrouped.
+    const applyResult = (result: Awaited<ReturnType<typeof fetchProjectGroupsForTarget>>): void => {
+      set({
+        projectGroups: result.projectGroups,
+        folderWorkspacePathStatuses: {}
+      })
+    }
+
+    try {
+      applyResult(await fetchProjectGroupsForTarget({ kind: 'local' }, get().projectGroups))
+    } catch (err) {
+      console.error('Failed to fetch local project groups for all-host load:', err)
+    }
+
+    const environments = await listRuntimeEnvironmentsForAllHostLoad()
+    for (const environment of environments) {
+      try {
+        applyResult(
+          await fetchProjectGroupsForTarget(
+            { kind: 'environment', environmentId: environment.id },
+            get().projectGroups
+          )
+        )
+      } catch (err) {
+        console.warn(`Skipped project groups for runtime environment ${environment.id}:`, err)
+      }
+    }
+  },
+
   fetchFolderWorkspaces: async () => {
     try {
       const target = getActiveRuntimeTarget(get().settings)
-      const folderWorkspaces =
-        target.kind === 'local'
-          ? await window.api.folderWorkspaces.list()
-          : (
-              await callRuntimeRpc<{ folderWorkspaces: FolderWorkspace[] }>(
-                target,
-                'folderWorkspace.list',
-                undefined,
-                { timeoutMs: 15_000 }
-              )
-            ).folderWorkspaces
+      const { folderWorkspaces } = await fetchFolderWorkspacesForTarget(
+        target,
+        [],
+        get().projectGroups
+      )
       set({ folderWorkspaces, folderWorkspacePathStatuses: {} })
     } catch (err) {
       console.error('Failed to fetch folder workspaces:', err)
+    }
+  },
+
+  fetchFolderWorkspacesForAllHosts: async () => {
+    // Why: folder workspaces are owned through their project groups, so startup
+    // must fetch groups first and then merge each host's folder slice.
+    const applyResult = (
+      result: Awaited<ReturnType<typeof fetchFolderWorkspacesForTarget>>
+    ): void => {
+      set({
+        folderWorkspaces: result.folderWorkspaces,
+        folderWorkspacePathStatuses: {}
+      })
+    }
+
+    try {
+      applyResult(
+        await fetchFolderWorkspacesForTarget(
+          { kind: 'local' },
+          get().folderWorkspaces,
+          get().projectGroups
+        )
+      )
+    } catch (err) {
+      console.error('Failed to fetch local folder workspaces for all-host load:', err)
+    }
+
+    const environments = await listRuntimeEnvironmentsForAllHostLoad()
+    for (const environment of environments) {
+      try {
+        applyResult(
+          await fetchFolderWorkspacesForTarget(
+            { kind: 'environment', environmentId: environment.id },
+            get().folderWorkspaces,
+            get().projectGroups
+          )
+        )
+      } catch (err) {
+        console.warn(`Skipped folder workspaces for runtime environment ${environment.id}:`, err)
+      }
     }
   },
 

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -819,6 +819,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           validRepoIds
         )
       }))
+      // Why: preserve the safe-auto fork sync that fetchRepos /
+      // fetchRuntimeEnvironmentRepos schedule after merging each host, so
+      // cold-start (which now routes through here) keeps updating safe-auto forks.
+      scheduleSafeAutoForkSync(
+        get,
+        result.repos.filter((repo) => getRepoExecutionHostId(repo) === result.hostId)
+      )
     }
 
     // Local first so local repos are present even if a remote fetch stalls.


### PR DESCRIPTION
## Problem

On a **cold start**, the renderer restores the last-active workspace. If that workspace lived on a **remote runtime environment**, `settingsForExecutionHostOwner` (worktrees.ts) re-activates that environment, and startup's `fetchRepos()` then loads **only the active host's repos**.

Symptoms (reproduced on a real multi-host setup):
- All **local repos disappear** from the sidebar. The "All hosts" scope can't help — it only *filters* already-loaded repos (`setWorkspaceHostScope` in ui.ts), and the other host's repos were never fetched.
- Adding a local folder fails with **"Not a valid git repository"**, because with a remote env active the path is validated on the remote host (`addRemoteRepoFromPath` → `gitProvider.isGitRepoAsync`), where it doesn't exist.

This happens on **any** cold start regardless of launcher (Finder, Spotlight, Raycast). Warm activations skip restore, so the app appears fine until the next full quit + relaunch.

### Root cause (verified by experiment)

With `settings.activeRuntimeEnvironmentId` cleared to `null`, a cold start re-set it back to the remote environment id on its own, because the persisted active workspace lived on that host. Clearing the persisted active workspace made the active env stay local and local repos loaded — confirming the restore-driven re-activation is the trigger.

## Fix

Add `fetchReposForAllHosts()` (repos.ts), which loads the **local host plus every configured runtime environment** and merges them into the unified `repos` array (reusing the existing `fetchReposForTarget` / `mergeFetchedReposForHost` merge that already preserves other hosts). Each host **fails soft** — an unreachable/disconnected host is skipped without blocking the others.

Startup (App.tsx) now calls `fetchReposForAllHosts()` instead of the active-host-only `fetchRepos()`, so the sidebar shows local + remote together regardless of which environment is active. `fetchAllWorktrees()` (next in the startup sequence) then loads worktrees for every host's repos, and session hydration already aggregates per-host slices.

## Tests

`repos-all-hosts.test.ts`:
- loads local + all configured runtime environments even when a remote env is active
- fails soft when a runtime environment is unreachable, keeping local repos

`pnpm run typecheck` and `oxlint` pass.

> Note: verified via unit tests + a live root-cause reproduction. A maintainer run across a real multi-host (local + SSH/runtime) setup is worth a sanity check, particularly startup latency when a configured host is offline (fetches are sequential and fail soft; could be parallelized if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6079">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->