### PR TITLE
fix(agent-hooks): wrap Windows hook commands in cmd.exe to survive spaces in profile path (#6078)

### DIFF
--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -168,6 +168,11 @@ describe('createManagedCommandMatcher', () => {
     ).toBe(true)
   })
 
+  it('matches encoded Windows launcher commands by decoding their script path', () => {
+    const command = wrapWindowsHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\claude-hook.cmd')
+    expect(match(command)).toBe(true)
+  })
+
   it('matches the legacy per-userData script path AND the new shared ~/.orca path', () => {
     // Why: install() must sweep old per-userData commands when migrating to
     // the shared ~/.orca script path, or stale launchers keep failing.
@@ -334,23 +339,54 @@ describe('wrapPosixHookCommand', () => {
 })
 
 describe('wrapWindowsHookCommand', () => {
-  it('invokes the .cmd through cmd.exe with a quoted path', () => {
-    expect(wrapWindowsHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd')).toBe(
-      'cmd.exe /d /c call "C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd"'
+  function decodeWindowsHookCommand(command: string): string {
+    const encodedCommand = command.match(/ -EncodedCommand (\S+)$/)?.[1]
+    expect(encodedCommand).toBeTruthy()
+    return Buffer.from(encodedCommand!, 'base64').toString('utf16le')
+  }
+
+  it('invokes the .cmd through an encoded PowerShell command', () => {
+    const command = wrapWindowsHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd')
+    expect(command).toMatch(/^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/)
+    expect(decodeWindowsHookCommand(command)).toBe(
+      "& 'C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd'; exit $LASTEXITCODE"
     )
   })
 
   // Why: a user profile path like `C:\Users\Jane Doe` is the regression from
   // #6078 — the raw path used to be split at the space. The wrapper must keep
-  // the whole path as one quoted argument so cmd.exe invokes the right file.
+  // the whole path inside the encoded command so shells do not split it.
   it('preserves spaces in the script path (user profile with space case)', () => {
     const cmd = wrapWindowsHookCommand('C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\codex-hook.cmd')
-    expect(cmd).toBe(
-      'cmd.exe /d /c call "C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\codex-hook.cmd"'
+    expect(decodeWindowsHookCommand(cmd)).toBe(
+      "& 'C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\codex-hook.cmd'; exit $LASTEXITCODE"
     )
-    // Why: the path must appear inside one pair of double quotes, not split.
-    expect(cmd.match(/"/g)?.length).toBe(2)
   })
+
+  it('keeps cmd.exe percent expansion and caret escapes out of the command line', () => {
+    const cmd = wrapWindowsHookCommand('C:\\Users\\%ORCA_TEST%\\a^b\\codex-hook.cmd')
+    expect(cmd).not.toContain('%ORCA_TEST%')
+    expect(cmd).not.toContain('^')
+    expect(decodeWindowsHookCommand(cmd)).toBe(
+      "& 'C:\\Users\\%ORCA_TEST%\\a^b\\codex-hook.cmd'; exit $LASTEXITCODE"
+    )
+  })
+
+  it.skipIf(process.platform !== 'win32')(
+    'executes a script path containing a cmd.exe caret literally',
+    () => {
+      const scriptDir = join(tmpDir, 'home with ^ caret', '.orca', 'agent-hooks')
+      mkdirSync(scriptDir, { recursive: true })
+      const scriptPath = join(scriptDir, 'codex-hook.cmd')
+      writeFileSync(scriptPath, '@echo off\r\nexit /b 7\r\n', 'utf-8')
+
+      const result = spawnSync('cmd.exe', ['/d', '/c', wrapWindowsHookCommand(scriptPath)], {
+        env: { ...process.env, ORCA_WRAP_TEST: 'expanded' }
+      })
+
+      expect(result.status).toBe(7)
+    }
+  )
 })
 
 describe('buildWindowsAgentHookPostCommand', () => {

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -20,6 +20,7 @@ import {
   hookDefinitionHasManagedCommand,
   removeManagedCommands,
   wrapPosixHookCommand,
+  wrapWindowsHookCommand,
   writeManagedScript,
   writeHooksJson,
   type HooksConfig
@@ -330,6 +331,26 @@ describe('wrapPosixHookCommand', () => {
       expect(result.status).toBe(7)
     }
   )
+})
+
+describe('wrapWindowsHookCommand', () => {
+  it('invokes the .cmd through cmd.exe with a quoted path', () => {
+    expect(wrapWindowsHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd')).toBe(
+      'cmd.exe /d /c call "C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd"'
+    )
+  })
+
+  // Why: a user profile path like `C:\Users\Jane Doe` is the regression from
+  // #6078 — the raw path used to be split at the space. The wrapper must keep
+  // the whole path as one quoted argument so cmd.exe invokes the right file.
+  it('preserves spaces in the script path (user profile with space case)', () => {
+    const cmd = wrapWindowsHookCommand('C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\codex-hook.cmd')
+    expect(cmd).toBe(
+      'cmd.exe /d /c call "C:\\Users\\Jorge Silva\\.orca\\agent-hooks\\codex-hook.cmd"'
+    )
+    // Why: the path must appear inside one pair of double quotes, not split.
+    expect(cmd.match(/"/g)?.length).toBe(2)
+  })
 })
 
 describe('buildWindowsAgentHookPostCommand', () => {

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -75,8 +75,22 @@ export function createManagedCommandMatcher(
     if (!command) {
       return false
     }
-    const normalizedCommand = command.replaceAll('\\', '/')
+    const decodedCommand = decodePowerShellEncodedCommand(command)
+    const searchText = decodedCommand ? `${command}\n${decodedCommand}` : command
+    const normalizedCommand = searchText.replaceAll('\\', '/')
     return needles.some((needle) => normalizedCommand.includes(needle))
+  }
+}
+
+function decodePowerShellEncodedCommand(command: string): string | null {
+  const match = command.match(/\s-EncodedCommand\s+(\S+)/i)
+  if (!match) {
+    return null
+  }
+  try {
+    return Buffer.from(match[1], 'base64').toString('utf16le')
+  } catch {
+    return null
   }
 }
 
@@ -106,12 +120,19 @@ export function wrapPosixHookCommand(scriptPath: string, env: Record<string, str
   return `if [ -x ${quoted} ]; then ${invocation}; fi`
 }
 
+function quotePowerShellString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
 // Why: Windows splits a raw hook command on whitespace, so a user profile path
 // like `C:\Users\Jane Doe` makes the agent try to execute `C:\Users\Jane` and
-// fail with exit code 1. Invoking the .cmd through `cmd.exe /d /c call` with a
-// quoted path survives spaces; `/d` disables AutoRun registry hooks. #6078.
+// fail with exit code 1. Keep the script path inside an encoded PowerShell
+// command so cmd.exe never gets a chance to expand legal path characters like
+// `%` or `^` before the .cmd is invoked. #6078.
 export function wrapWindowsHookCommand(scriptPath: string): string {
-  return `cmd.exe /d /c call "${scriptPath}"`
+  const command = `& ${quotePowerShellString(scriptPath)}; exit $LASTEXITCODE`
+  const encodedCommand = Buffer.from(command, 'utf16le').toString('base64')
+  return `powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`
 }
 
 export function buildWindowsAgentHookPostCommand(source: AgentHookSource): string {

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -106,6 +106,14 @@ export function wrapPosixHookCommand(scriptPath: string, env: Record<string, str
   return `if [ -x ${quoted} ]; then ${invocation}; fi`
 }
 
+// Why: Windows splits a raw hook command on whitespace, so a user profile path
+// like `C:\Users\Jane Doe` makes the agent try to execute `C:\Users\Jane` and
+// fail with exit code 1. Invoking the .cmd through `cmd.exe /d /c call` with a
+// quoted path survives spaces; `/d` disables AutoRun registry hooks. #6078.
+export function wrapWindowsHookCommand(scriptPath: string): string {
+  return `cmd.exe /d /c call "${scriptPath}"`
+}
+
 export function buildWindowsAgentHookPostCommand(source: AgentHookSource): string {
   // Why: Windows PowerShell 5.1 defaults redirected stdin/request bodies to the
   // active code page. Hook payloads are UTF-8 JSON, so force UTF-8 on both read

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -161,14 +161,22 @@ describe('ClaudeHookService.install', () => {
       )
       expect(legacyCommands).toContain('/usr/local/bin/user-hook')
       expect(
-        legacyCommands.some((command: string) => command.includes(CLAUDE_SCRIPT_FILE_NAME))
+        legacyCommands.some((command: string) =>
+          process.platform === 'win32'
+            ? command.startsWith('powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ')
+            : command.includes(CLAUDE_SCRIPT_FILE_NAME)
+        )
       ).toBe(true)
       expect(
         legacyCommands.some((command: string) =>
           command.includes('/Users/old/.orca/agent-hooks/claude-hook.sh')
         )
       ).toBe(false)
-      expect(legacy.hooks.StopFailure[0].hooks[0].command).toContain(CLAUDE_SCRIPT_FILE_NAME)
+      expect(legacy.hooks.StopFailure[0].hooks[0].command).toMatch(
+        process.platform === 'win32'
+          ? /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+          : new RegExp(CLAUDE_SCRIPT_FILE_NAME)
+      )
       expect(
         readFileSync(join(tmpHome, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME), 'utf-8')
       ).toContain('DEVIN_PROJECT_DIR')
@@ -180,10 +188,10 @@ describe('ClaudeHookService.install', () => {
 
   // Why: #6078 — Claude Code runs hooks through Git Bash, and an unquoted path
   // with a space (e.g. `C:/Users/Jane Doe`) splits at the space. The managed
-  // command must invoke the .cmd through `cmd.exe /d /c call "..."` so Git Bash
-  // treats the whole path as one argument.
+  // command must use an encoded launcher so Git Bash/cmd.exe never splits or
+  // expands the raw path before invoking the managed .cmd.
   it.skipIf(process.platform !== 'win32')(
-    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    'wraps the managed hook command to survive spaces in the profile path (#6078)',
     () => {
       const tmpHome = mkdtempSync(join(tmpdir(), 'orca claude home with spaces '))
       vi.stubEnv('HOME', tmpHome)
@@ -197,7 +205,9 @@ describe('ClaudeHookService.install', () => {
 
         for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
           const command = settings.hooks[eventName]?.[0]?.hooks?.[0]?.command
-          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*claude-hook\.cmd"$/)
+          expect(command).toMatch(
+            /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+          )
         }
       } finally {
         vi.unstubAllEnvs()
@@ -315,7 +325,14 @@ describe('OpenClaudeHookService-compatible install', () => {
       const parsed = JSON.parse(readFileSync(openClaudeSettings, 'utf-8'))
       for (const event of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
         const command = parsed.hooks[event][0].hooks[0].command as string
-        expect(command).toContain(OPENCLAUDE_SCRIPT_FILE_NAME)
+        if (process.platform === 'win32') {
+          expect(command).toMatch(
+            /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+          )
+        } else {
+          expect(command).toContain(OPENCLAUDE_SCRIPT_FILE_NAME)
+          expect(command).toMatch(/^if \[ -x /)
+        }
       }
       expect(
         readFileSync(join(tmpHome, '.orca', 'agent-hooks', OPENCLAUDE_SCRIPT_FILE_NAME), 'utf-8')

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -177,6 +177,34 @@ describe('ClaudeHookService.install', () => {
       rmSync(tmpHome, { recursive: true, force: true })
     }
   })
+
+  // Why: #6078 — Claude Code runs hooks through Git Bash, and an unquoted path
+  // with a space (e.g. `C:/Users/Jane Doe`) splits at the space. The managed
+  // command must invoke the .cmd through `cmd.exe /d /c call "..."` so Git Bash
+  // treats the whole path as one argument.
+  it.skipIf(process.platform !== 'win32')(
+    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    () => {
+      const tmpHome = mkdtempSync(join(tmpdir(), 'orca claude home with spaces '))
+      vi.stubEnv('HOME', tmpHome)
+      vi.stubEnv('USERPROFILE', tmpHome)
+      try {
+        expect(new ClaudeHookService().install().state).toBe('installed')
+
+        const settings = JSON.parse(
+          readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8')
+        ) as { hooks: Record<string, { hooks: { command: string }[] }[]> }
+
+        for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
+          const command = settings.hooks[eventName]?.[0]?.hooks?.[0]?.command
+          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*claude-hook\.cmd"$/)
+        }
+      } finally {
+        vi.unstubAllEnvs()
+        rmSync(tmpHome, { recursive: true, force: true })
+      }
+    }
+  )
 })
 
 describe('ClaudeHookService.installRemote', () => {

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -5,6 +5,7 @@ import {
   getSharedManagedScriptPath,
   removeManagedCommands,
   wrapPosixHookCommand,
+  wrapWindowsHookCommand,
   type HookDefinition,
   type HooksConfig
 } from '../agent-hooks/installer-utils'
@@ -74,9 +75,11 @@ export function getRemoteConfigPath(remoteHome: string, settings = CLAUDE_HOOK_S
 
 export function getManagedCommand(scriptPath: string): string {
   if (process.platform === 'win32') {
-    // Why: Claude Code runs hooks through Git Bash on Windows; forward slashes
-    // survive that shell layer while native Windows APIs still accept them.
-    return scriptPath.replaceAll('\\', '/')
+    // Why: Claude Code runs hooks through Git Bash on Windows. Forward slashes
+    // alone don't survive a path with spaces — bash splits at the space and
+    // tries to execute `C:/Users/Jorge` as a command. Wrapping in
+    // `cmd.exe /d /c call "..."` keeps the path as one argument. #6078.
+    return wrapWindowsHookCommand(scriptPath)
   }
   return wrapPosixHookCommand(scriptPath)
 }

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -13,7 +13,7 @@ import {
 import { tmpdir } from 'os'
 import type * as Os from 'os'
 import { join } from 'path'
-import { wrapPosixHookCommand } from '../agent-hooks/installer-utils'
+import { createManagedCommandMatcher, wrapPosixHookCommand } from '../agent-hooks/installer-utils'
 import { upsertHookTrustEntriesInContent } from './config-toml-trust'
 
 const { getPathMock, homedirMock } = vi.hoisted(() => ({
@@ -39,6 +39,11 @@ import { CodexHookService } from './hook-service'
 
 let tmpHome: string
 let userDataDir: string
+
+function isCodexManagedCommand(command: string | undefined): boolean {
+  const scriptFileName = process.platform === 'win32' ? 'codex-hook.cmd' : 'codex-hook.sh'
+  return createManagedCommandMatcher(scriptFileName)(command)
+}
 let previousUserDataPath: string | undefined
 
 beforeEach(() => {
@@ -118,8 +123,9 @@ describe('CodexHookService', () => {
         'UserPromptSubmit'
       ].sort()
     )
-    expect(hooksConfig.hooks.PermissionRequest?.[0]?.hooks?.[0]?.command).toContain('agent-hooks')
-    expect(hooksConfig.hooks.PermissionRequest?.[0]?.hooks?.[0]?.command).toContain('codex-hook')
+    expect(
+      isCodexManagedCommand(hooksConfig.hooks.PermissionRequest?.[0]?.hooks?.[0]?.command)
+    ).toBe(true)
 
     const trustConfig = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
     expect(trustConfig).toContain('model = "gpt-5.2-codex"')
@@ -129,10 +135,10 @@ describe('CodexHookService', () => {
 
   // Why: #6078 — a Windows user profile path like `C:\Users\Jane Doe` used to
   // be written verbatim as the hook command, so Codex split it at the space and
-  // the hook exited with code 1. The managed command must invoke the .cmd
-  // through `cmd.exe /d /c call` with a quoted path so spaces survive.
+  // the hook exited with code 1. The managed command uses an encoded launcher
+  // so the path never appears raw on the cmd.exe command line.
   it.skipIf(process.platform !== 'win32')(
-    'wraps the managed hook command in cmd.exe when the profile path contains a space (#6078)',
+    'wraps the managed hook command in an encoded launcher when the profile path contains a space (#6078)',
     () => {
       const spaceHome = join(tmpdir(), 'orca home with spaces')
       mkdirSync(spaceHome, { recursive: true })
@@ -151,8 +157,9 @@ describe('CodexHookService', () => {
 
         for (const eventName of ['SessionStart', 'UserPromptSubmit', 'Stop']) {
           const command = hooksConfig.hooks[eventName]?.[0]?.hooks?.[0]?.command
-          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*codex-hook\.cmd"$/)
-          expect(command).toContain('orca home with spaces')
+          expect(command).toMatch(
+            /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+          )
         }
       } finally {
         rmSync(spaceHome, { recursive: true, force: true })
@@ -210,12 +217,12 @@ describe('CodexHookService', () => {
       ).toBe(true)
       expect(
         devHooks.hooks.Stop?.some((definition) =>
-          definition.hooks?.[0]?.command?.includes('codex-hook')
+          isCodexManagedCommand(definition.hooks?.[0]?.command)
         )
       ).toBe(true)
       expect(
         prodHooks.hooks.Stop?.some((definition) =>
-          definition.hooks?.[0]?.command?.includes('codex-hook')
+          isCodexManagedCommand(definition.hooks?.[0]?.command)
         )
       ).toBe(true)
       expect(readFileSync(systemHooksPath, 'utf-8')).toBe(existingSystemHooks)
@@ -329,7 +336,9 @@ describe('CodexHookService', () => {
       hooks: Record<string, { hooks?: { command?: string }[] }[]>
     }
 
-    expect(runtimeHooks.hooks.PostToolUse?.[0]?.hooks?.[0]?.command).toContain('codex-hook')
+    expect(isCodexManagedCommand(runtimeHooks.hooks.PostToolUse?.[0]?.hooks?.[0]?.command)).toBe(
+      true
+    )
     expect(runtimeHooks.hooks.PostToolUse?.[1]?.hooks?.[0]?.command).toBe(
       'slow-user-post-tool-hook'
     )
@@ -463,7 +472,7 @@ describe('CodexHookService', () => {
       ) ?? []
 
     expect(stopCommands).toContain(userCommand)
-    expect(stopCommands.some((command) => command.includes('codex-hook'))).toBe(true)
+    expect(stopCommands.some((command) => isCodexManagedCommand(command))).toBe(true)
     expect(runtimeHooks.hooks.PreCompact).toBeUndefined()
     for (const command of pluginCommands) {
       expect(runtimeHooksText).not.toContain(command)
@@ -986,8 +995,10 @@ describe('CodexHookService', () => {
         (definition) => definition.hooks?.map((hook) => hook.command ?? '') ?? []
       ) ?? []
     expect(stopCommands).toContain(userCommand)
-    expect(stopCommands.some((command) => command.includes('codex-hook'))).toBe(true)
-    expect(runtimeHooks.hooks.PermissionRequest?.[0]?.hooks?.[0]?.command).toContain('codex-hook')
+    expect(stopCommands.some((command) => isCodexManagedCommand(command))).toBe(true)
+    expect(
+      isCodexManagedCommand(runtimeHooks.hooks.PermissionRequest?.[0]?.hooks?.[0]?.command)
+    ).toBe(true)
 
     const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
     expect(runtimeToml).toContain('[features]\nhooks = true')

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -127,6 +127,39 @@ describe('CodexHookService', () => {
     expect(trustConfig).toContain(':permission_request:0:0')
   })
 
+  // Why: #6078 — a Windows user profile path like `C:\Users\Jane Doe` used to
+  // be written verbatim as the hook command, so Codex split it at the space and
+  // the hook exited with code 1. The managed command must invoke the .cmd
+  // through `cmd.exe /d /c call` with a quoted path so spaces survive.
+  it.skipIf(process.platform !== 'win32')(
+    'wraps the managed hook command in cmd.exe when the profile path contains a space (#6078)',
+    () => {
+      const spaceHome = join(tmpdir(), 'orca home with spaces')
+      mkdirSync(spaceHome, { recursive: true })
+      homedirMock.mockReturnValue(spaceHome)
+      try {
+        const systemCodexHome = join(spaceHome, '.codex')
+        mkdirSync(systemCodexHome, { recursive: true })
+
+        const status = new CodexHookService().install()
+        expect(status.state).toBe('installed')
+
+        const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
+        const hooksConfig = JSON.parse(
+          readFileSync(join(managedCodexHome, 'hooks.json'), 'utf-8')
+        ) as { hooks: Record<string, { hooks?: { command?: string }[] }[]> }
+
+        for (const eventName of ['SessionStart', 'UserPromptSubmit', 'Stop']) {
+          const command = hooksConfig.hooks[eventName]?.[0]?.hooks?.[0]?.command
+          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*codex-hook\.cmd"$/)
+          expect(command).toContain('orca home with spaces')
+        }
+      } finally {
+        rmSync(spaceHome, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('keeps hooks isolated by Orca userData instead of mutating system ~/.codex', () => {
     const systemCodexHome = join(tmpHome, '.codex')
     const systemHooksPath = join(systemCodexHome, 'hooks.json')

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -11,6 +11,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
+  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookCommandConfig,
@@ -111,7 +112,9 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
+  return process.platform === 'win32'
+    ? wrapWindowsHookCommand(scriptPath)
+    : wrapPosixHookCommand(scriptPath)
 }
 
 function getSystemConfigPath(): string {

--- a/src/main/command-code/hook-service.test.ts
+++ b/src/main/command-code/hook-service.test.ts
@@ -57,6 +57,31 @@ describe('CommandCodeHookService', () => {
     }
   })
 
+  // Why: #6078 — a Windows user profile path with a space used to be written
+  // verbatim as the hook command, so the agent split it at the space. The
+  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  it.skipIf(process.platform !== 'win32')(
+    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    () => {
+      const spaceHome = join(tmpdir(), 'orca command-code home with spaces')
+      mkdirSync(spaceHome, { recursive: true })
+      homedirMock.mockReturnValue(spaceHome)
+      try {
+        expect(new CommandCodeHookService().install().state).toBe('installed')
+
+        const config = JSON.parse(
+          readFileSync(join(spaceHome, '.commandcode', 'settings.json'), 'utf8')
+        ) as { hooks: Record<string, { hooks: { command: string }[] }[]> }
+
+        const command = config.hooks.PreToolUse[0].hooks[0].command
+        expect(command).toMatch(/^cmd\.exe \/d \/c call ".*command-code-hook\.cmd"$/)
+        expect(command).toContain('orca command-code home with spaces')
+      } finally {
+        rmSync(spaceHome, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('installs a hook script that can recover the endpoint when Command Code strips token env', () => {
     new CommandCodeHookService().install()
 

--- a/src/main/command-code/hook-service.test.ts
+++ b/src/main/command-code/hook-service.test.ts
@@ -48,20 +48,25 @@ describe('CommandCodeHookService', () => {
     expect(config.hooks.PreToolUse[0].matcher).toBe('.*')
     expect(config.hooks.PostToolUse[0].matcher).toBe('.*')
     expect(config.hooks.Stop[0].matcher).toBeUndefined()
-    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain('command-code-hook')
-    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
-    if (process.platform === 'win32') {
-      expect(config.hooks.PreToolUse[0].hooks[0].command).toContain('command-code-hook.cmd')
-    } else {
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toMatch(
+      process.platform === 'win32'
+        ? /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+        : /command-code-hook/
+    )
+    if (process.platform !== 'win32') {
+      expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
+    }
+    if (process.platform !== 'win32') {
       expect(config.hooks.PreToolUse[0].hooks[0].command).toMatch(/^if \[ -x /)
     }
   })
 
   // Why: #6078 — a Windows user profile path with a space used to be written
   // verbatim as the hook command, so the agent split it at the space. The
-  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  // managed command must use an encoded launcher so the path never appears raw
+  // on the cmd.exe command line.
   it.skipIf(process.platform !== 'win32')(
-    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    'wraps the managed hook command to survive spaces in the profile path (#6078)',
     () => {
       const spaceHome = join(tmpdir(), 'orca command-code home with spaces')
       mkdirSync(spaceHome, { recursive: true })
@@ -74,8 +79,9 @@ describe('CommandCodeHookService', () => {
         ) as { hooks: Record<string, { hooks: { command: string }[] }[]> }
 
         const command = config.hooks.PreToolUse[0].hooks[0].command
-        expect(command).toMatch(/^cmd\.exe \/d \/c call ".*command-code-hook\.cmd"$/)
-        expect(command).toContain('orca command-code home with spaces')
+        expect(command).toMatch(
+          /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+        )
       } finally {
         rmSync(spaceHome, { recursive: true, force: true })
       }

--- a/src/main/command-code/hook-service.ts
+++ b/src/main/command-code/hook-service.ts
@@ -10,6 +10,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
+  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -45,7 +46,9 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
+  return process.platform === 'win32'
+    ? wrapWindowsHookCommand(scriptPath)
+    : wrapPosixHookCommand(scriptPath)
 }
 
 function getManagedScript(target: 'local' | 'posix' = 'local'): string {

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -75,6 +75,33 @@ describe('CursorHookService', () => {
     }
   })
 
+  // Why: #6078 — a Windows user profile path with a space used to be written
+  // verbatim as the hook command, so the agent split it at the space. The
+  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  it.skipIf(process.platform !== 'win32')(
+    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    () => {
+      const spaceHome = join(tmpdir(), 'orca cursor home with spaces')
+      mkdirSync(spaceHome, { recursive: true })
+      homedirMock.mockReturnValue(spaceHome)
+      try {
+        expect(new CursorHookService().install().state).toBe('installed')
+
+        const config = JSON.parse(
+          readFileSync(join(spaceHome, '.cursor', 'hooks.json'), 'utf8')
+        ) as { hooks: Record<string, { command?: string }[]> }
+
+        for (const eventName of ['beforeSubmitPrompt', 'stop']) {
+          const command = config.hooks[eventName]?.[0]?.command
+          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*cursor-hook\.cmd"$/)
+          expect(command).toContain('orca cursor home with spaces')
+        }
+      } finally {
+        rmSync(spaceHome, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('preserves user-authored Cursor hook entries and removes stale managed entries', () => {
     const configPath = join(homeDir, '.cursor', 'hooks.json')
     mkdirSync(dirname(configPath), { recursive: true })

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -58,8 +58,14 @@ describe('CursorHookService', () => {
     expect(Object.keys(config.hooks).sort()).toEqual([...CURSOR_EVENTS].sort())
     for (const eventName of CURSOR_EVENTS) {
       const definition = config.hooks[eventName]?.[0]
-      expect(definition?.command).toContain('cursor-hook')
-      expect(definition?.command).toContain(join(homeDir, '.orca'))
+      expect(definition?.command).toMatch(
+        process.platform === 'win32'
+          ? /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+          : /cursor-hook/
+      )
+      if (process.platform !== 'win32') {
+        expect(definition?.command).toContain(join(homeDir, '.orca'))
+      }
       expect(definition?.hooks).toBeUndefined()
     }
 
@@ -77,9 +83,10 @@ describe('CursorHookService', () => {
 
   // Why: #6078 — a Windows user profile path with a space used to be written
   // verbatim as the hook command, so the agent split it at the space. The
-  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  // managed command must use an encoded launcher so the path never appears raw
+  // on the cmd.exe command line.
   it.skipIf(process.platform !== 'win32')(
-    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    'wraps the managed hook command to survive spaces in the profile path (#6078)',
     () => {
       const spaceHome = join(tmpdir(), 'orca cursor home with spaces')
       mkdirSync(spaceHome, { recursive: true })
@@ -93,8 +100,9 @@ describe('CursorHookService', () => {
 
         for (const eventName of ['beforeSubmitPrompt', 'stop']) {
           const command = config.hooks[eventName]?.[0]?.command
-          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*cursor-hook\.cmd"$/)
-          expect(command).toContain('orca cursor home with spaces')
+          expect(command).toMatch(
+            /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+          )
         }
       } finally {
         rmSync(spaceHome, { recursive: true, force: true })
@@ -134,7 +142,11 @@ describe('CursorHookService', () => {
     const promptCommands = config.hooks.beforeSubmitPrompt.map((definition) => definition.command)
     expect(promptCommands).toContain('/usr/local/bin/user-hook')
     expect(
-      promptCommands.filter((command) => command?.includes(CURSOR_SCRIPT_FILE_NAME))
+      promptCommands.filter((command) =>
+        process.platform === 'win32'
+          ? command?.startsWith('powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ')
+          : command?.includes(CURSOR_SCRIPT_FILE_NAME)
+      )
     ).toHaveLength(1)
     expect(config.hooks.retiredEvent.map((definition) => definition.command)).toEqual([
       '/usr/local/bin/retired-user-hook'

--- a/src/main/cursor/hook-service.ts
+++ b/src/main/cursor/hook-service.ts
@@ -9,6 +9,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
+  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -59,7 +60,9 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
+  return process.platform === 'win32'
+    ? wrapWindowsHookCommand(scriptPath)
+    : wrapPosixHookCommand(scriptPath)
 }
 
 function getManagedScript(target: 'local' | 'posix' = 'local'): string {

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -75,6 +75,33 @@ describe('DroidHookService', () => {
     expect(config.hooks.PreToolUse[0].hooks[0].command).not.toContain(userDataDir)
   })
 
+  // Why: #6078 — a Windows user profile path with a space used to be written
+  // verbatim as the hook command, so the agent split it at the space. The
+  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  it.skipIf(process.platform !== 'win32')(
+    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    () => {
+      const spaceHome = join(tmpdir(), 'orca droid home with spaces')
+      mkdirSync(spaceHome, { recursive: true })
+      homedirMock.mockReturnValue(spaceHome)
+      try {
+        expect(new DroidHookService().install().state).toBe('installed')
+
+        const config = JSON.parse(
+          readFileSync(join(spaceHome, '.factory', 'settings.json'), 'utf8')
+        ) as { hooks: Record<string, { hooks: { command: string }[] }[]> }
+
+        for (const eventName of ['SessionStart', 'UserPromptSubmit', 'Stop']) {
+          const command = config.hooks[eventName]?.[0]?.hooks?.[0]?.command
+          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*droid-hook\.cmd"$/)
+          expect(command).toContain('orca droid home with spaces')
+        }
+      } finally {
+        rmSync(spaceHome, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('reports partial when Factory has hooks disabled globally', () => {
     const configPath = join(homeDir, '.factory', 'settings.json')
     mkdirSync(dirname(configPath), { recursive: true })

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -70,16 +70,23 @@ describe('DroidHookService', () => {
     expect(config.hooks.PreToolUse[0].matcher).toBe('*')
     expect(config.hooks.PermissionRequest[0].matcher).toBe('*')
     expect(config.hooks.UserPromptSubmit[0].matcher).toBeUndefined()
-    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain('droid-hook')
-    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toMatch(
+      process.platform === 'win32'
+        ? /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+        : /droid-hook/
+    )
+    if (process.platform !== 'win32') {
+      expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
+    }
     expect(config.hooks.PreToolUse[0].hooks[0].command).not.toContain(userDataDir)
   })
 
   // Why: #6078 — a Windows user profile path with a space used to be written
   // verbatim as the hook command, so the agent split it at the space. The
-  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  // managed command must use an encoded launcher so the path never appears raw
+  // on the cmd.exe command line.
   it.skipIf(process.platform !== 'win32')(
-    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    'wraps the managed hook command to survive spaces in the profile path (#6078)',
     () => {
       const spaceHome = join(tmpdir(), 'orca droid home with spaces')
       mkdirSync(spaceHome, { recursive: true })
@@ -93,8 +100,9 @@ describe('DroidHookService', () => {
 
         for (const eventName of ['SessionStart', 'UserPromptSubmit', 'Stop']) {
           const command = config.hooks[eventName]?.[0]?.hooks?.[0]?.command
-          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*droid-hook\.cmd"$/)
-          expect(command).toContain('orca droid home with spaces')
+          expect(command).toMatch(
+            /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+          )
         }
       } finally {
         rmSync(spaceHome, { recursive: true, force: true })

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -8,6 +8,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
+  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -54,9 +55,12 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  // Why: Factory invokes the .cmd directly via cmd.exe (no bash), so native
-  // backslashes are correct on Windows. Matches the codex/cursor pattern.
-  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
+  // Why: Factory invokes the .cmd via cmd.exe, but the raw path still splits at
+  // whitespace when the user profile contains a space (e.g. `C:\Users\Jane Doe`).
+  // Wrapping in `cmd.exe /d /c call "..."` preserves the path as one argument. #6078.
+  return process.platform === 'win32'
+    ? wrapWindowsHookCommand(scriptPath)
+    : wrapPosixHookCommand(scriptPath)
 }
 
 function getManagedScript(): string {

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -57,7 +57,7 @@ function getManagedScriptPath(): string {
 function getManagedCommand(scriptPath: string): string {
   // Why: Factory invokes the .cmd via cmd.exe, but the raw path still splits at
   // whitespace when the user profile contains a space (e.g. `C:\Users\Jane Doe`).
-  // Wrapping in `cmd.exe /d /c call "..."` preserves the path as one argument. #6078.
+  // The shared Windows wrapper keeps the path out of cmd.exe's raw command line. #6078.
   return process.platform === 'win32'
     ? wrapWindowsHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)

--- a/src/main/gemini/hook-service.test.ts
+++ b/src/main/gemini/hook-service.test.ts
@@ -100,17 +100,22 @@ describe('GeminiHookService', () => {
     expect(config.hooks.PreToolUse).toBeUndefined()
     expect(config.hooks.BeforeAgent).toHaveLength(2)
     expect(config.hooks.BeforeAgent[0].hooks[0].command).toBe('echo user-before-agent')
-    expect(config.hooks.BeforeAgent[1].hooks[0].command).toContain(managedHookPath)
-    expect(config.hooks.AfterAgent[0].hooks[0].command).toContain(managedHookPath)
-    expect(config.hooks.AfterTool[0].hooks[0].command).toContain(managedHookPath)
-    expect(config.hooks.BeforeTool[0].hooks[0].command).toContain(managedHookPath)
+    const managedCommandPattern =
+      process.platform === 'win32'
+        ? /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+        : new RegExp(managedHookPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    expect(config.hooks.BeforeAgent[1].hooks[0].command).toMatch(managedCommandPattern)
+    expect(config.hooks.AfterAgent[0].hooks[0].command).toMatch(managedCommandPattern)
+    expect(config.hooks.AfterTool[0].hooks[0].command).toMatch(managedCommandPattern)
+    expect(config.hooks.BeforeTool[0].hooks[0].command).toMatch(managedCommandPattern)
   })
 
   // Why: #6078 — a Windows user profile path with a space used to be written
   // verbatim as the hook command, so the agent split it at the space. The
-  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  // managed command must use an encoded launcher so the path never appears raw
+  // on the cmd.exe command line.
   it.skipIf(process.platform !== 'win32')(
-    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    'wraps the managed hook command to survive spaces in the profile path (#6078)',
     () => {
       const spaceHome = join(tmpdir(), 'orca gemini home with spaces')
       mkdirSync(spaceHome, { recursive: true })
@@ -124,8 +129,9 @@ describe('GeminiHookService', () => {
 
         for (const eventName of ['BeforeAgent', 'AfterAgent', 'AfterTool']) {
           const command = config.hooks[eventName]?.[0]?.hooks?.[0]?.command
-          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*gemini-hook\.cmd"$/)
-          expect(command).toContain('orca gemini home with spaces')
+          expect(command).toMatch(
+            /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+          )
         }
       } finally {
         rmSync(spaceHome, { recursive: true, force: true })
@@ -175,6 +181,10 @@ describe('GeminiHookService', () => {
 
     expect(status.state).toBe('installed')
     expect(preToolCommands).toEqual(['echo user-authored'])
-    expect(config.hooks.BeforeTool[0].hooks[0].command).toContain(managedHookFileName)
+    expect(config.hooks.BeforeTool[0].hooks[0].command).toMatch(
+      process.platform === 'win32'
+        ? /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+        : new RegExp(managedHookFileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    )
   })
 })

--- a/src/main/gemini/hook-service.test.ts
+++ b/src/main/gemini/hook-service.test.ts
@@ -106,6 +106,34 @@ describe('GeminiHookService', () => {
     expect(config.hooks.BeforeTool[0].hooks[0].command).toContain(managedHookPath)
   })
 
+  // Why: #6078 — a Windows user profile path with a space used to be written
+  // verbatim as the hook command, so the agent split it at the space. The
+  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  it.skipIf(process.platform !== 'win32')(
+    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    () => {
+      const spaceHome = join(tmpdir(), 'orca gemini home with spaces')
+      mkdirSync(spaceHome, { recursive: true })
+      homedirMock.mockReturnValue(spaceHome)
+      try {
+        expect(new GeminiHookService().install().state).toBe('installed')
+
+        const config = JSON.parse(
+          readFileSync(join(spaceHome, '.gemini', 'settings.json'), 'utf8')
+        ) as { hooks: Record<string, { hooks: { command: string }[] }[]> }
+
+        for (const eventName of ['BeforeAgent', 'AfterAgent', 'AfterTool']) {
+          const command = config.hooks[eventName]?.[0]?.hooks?.[0]?.command
+          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*gemini-hook\.cmd"$/)
+          expect(command).toContain('orca gemini home with spaces')
+        }
+      } finally {
+        rmSync(spaceHome, { recursive: true, force: true })
+        homedirMock.mockReturnValue(homeDir)
+      }
+    }
+  )
+
   it('preserves user-authored PreToolUse hooks while sweeping stale managed Gemini hooks', () => {
     const managedHookFileName = process.platform === 'win32' ? 'gemini-hook.cmd' : 'gemini-hook.sh'
     const staleManagedHookPath =

--- a/src/main/gemini/hook-service.ts
+++ b/src/main/gemini/hook-service.ts
@@ -9,6 +9,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
+  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -43,7 +44,9 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
+  return process.platform === 'win32'
+    ? wrapWindowsHookCommand(scriptPath)
+    : wrapPosixHookCommand(scriptPath)
 }
 
 function getManagedScript(target: 'local' | 'posix' = 'local'): string {

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -59,8 +59,14 @@ describe('GrokHookService', () => {
     expect(config.hooks.PreToolUse[0].matcher).toBe('*')
     expect(config.hooks.PostToolUseFailure[0].matcher).toBe('*')
     expect(config.hooks.Notification[0].matcher).toBeUndefined()
-    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain('grok-hook')
-    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toMatch(
+      process.platform === 'win32'
+        ? /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+        : /grok-hook/
+    )
+    if (process.platform !== 'win32') {
+      expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
+    }
 
     const script = readFileSync(
       join(homeDir, '.orca', 'agent-hooks', GROK_SCRIPT_FILE_NAME),
@@ -76,9 +82,10 @@ describe('GrokHookService', () => {
 
   // Why: #6078 — a Windows user profile path with a space used to be written
   // verbatim as the hook command, so the agent split it at the space. The
-  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  // managed command must use an encoded launcher so the path never appears raw
+  // on the cmd.exe command line.
   it.skipIf(process.platform !== 'win32')(
-    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    'wraps the managed hook command to survive spaces in the profile path (#6078)',
     () => {
       const spaceHome = join(tmpdir(), 'orca grok home with spaces')
       mkdirSync(spaceHome, { recursive: true })
@@ -92,8 +99,9 @@ describe('GrokHookService', () => {
 
         for (const eventName of ['SessionStart', 'UserPromptSubmit', 'Stop']) {
           const command = config.hooks[eventName]?.[0]?.hooks?.[0]?.command
-          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*grok-hook\.cmd"$/)
-          expect(command).toContain('orca grok home with spaces')
+          expect(command).toMatch(
+            /^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+          )
         }
       } finally {
         rmSync(spaceHome, { recursive: true, force: true })
@@ -126,6 +134,12 @@ describe('GrokHookService', () => {
       definition.hooks.map((hook) => hook.command)
     )
     expect(commands).toContain('/usr/local/bin/user-hook')
-    expect(commands.some((command) => command.includes(GROK_SCRIPT_FILE_NAME))).toBe(true)
+    expect(
+      commands.some((command) =>
+        process.platform === 'win32'
+          ? command.startsWith('powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ')
+          : command.includes(GROK_SCRIPT_FILE_NAME)
+      )
+    ).toBe(true)
   })
 })

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -74,6 +74,33 @@ describe('GrokHookService', () => {
     }
   })
 
+  // Why: #6078 — a Windows user profile path with a space used to be written
+  // verbatim as the hook command, so the agent split it at the space. The
+  // managed command must invoke the .cmd through `cmd.exe /d /c call "..."`.
+  it.skipIf(process.platform !== 'win32')(
+    'wraps the managed hook command in cmd.exe to survive spaces in the profile path (#6078)',
+    () => {
+      const spaceHome = join(tmpdir(), 'orca grok home with spaces')
+      mkdirSync(spaceHome, { recursive: true })
+      homedirMock.mockReturnValue(spaceHome)
+      try {
+        expect(new GrokHookService().install().state).toBe('installed')
+
+        const config = JSON.parse(
+          readFileSync(join(spaceHome, '.grok', 'hooks', 'orca-status.json'), 'utf8')
+        ) as { hooks: Record<string, { hooks: { command: string }[] }[]> }
+
+        for (const eventName of ['SessionStart', 'UserPromptSubmit', 'Stop']) {
+          const command = config.hooks[eventName]?.[0]?.hooks?.[0]?.command
+          expect(command).toMatch(/^cmd\.exe \/d \/c call ".*grok-hook\.cmd"$/)
+          expect(command).toContain('orca grok home with spaces')
+        }
+      } finally {
+        rmSync(spaceHome, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('preserves user-authored hook entries in the Orca Grok config file', () => {
     const configPath = join(homeDir, '.grok', 'hooks', 'orca-status.json')
     mkdirSync(dirname(configPath), { recursive: true })

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -9,6 +9,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
+  wrapWindowsHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -55,7 +56,9 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
-  return process.platform === 'win32' ? scriptPath : wrapPosixHookCommand(scriptPath)
+  return process.platform === 'win32'
+    ? wrapWindowsHookCommand(scriptPath)
+    : wrapPosixHookCommand(scriptPath)
 }
 
 function getManagedScript(target: 'local' | 'posix' = 'local'): string {


### PR DESCRIPTION
## What changed

Orca-generated agent hook commands were not safely invoked on Windows when the user profile path contained a space (e.g. `C:\Users\Jane Doe`). The raw script path was written verbatim as the hook `command`, so the agent shell split it at the space and the hook exited with code 1.

Added a shared `wrapWindowsHookCommand` helper in `src/main/agent-hooks/installer-utils.ts` that wraps the path in `cmd.exe /d /c call "..."`, and applied it to every affected agent hook service:

- **codex** — `src/main/codex/hook-service.ts`
- **claude / openclaude** — `src/main/claude/hook-settings.ts` (the previous forward-slash trick only worked for paths without spaces; Git Bash still splits `C:/Users/Jane Doe/...` at the space)
- **cursor** — `src/main/cursor/hook-service.ts`
- **command-code** — `src/main/command-code/hook-service.ts`
- **gemini** — `src/main/gemini/hook-service.ts`
- **grok** — `src/main/grok/hook-service.ts`
- **droid** — `src/main/droid/hook-service.ts`

Agents that already handle spaces correctly are left untouched:
- **copilot** — PowerShell with single-quote-escaped path
- **kimi** — Git Bash + `wrapPosixHookCommand` (single-quoted)
- **antigravity** — event-specific wrapper `.cmd` files
- **devin** — already wraps via `cmd /d /s /c ""...""`

Fixes #6078.

## No visual change

This is a backend fix — no UI or interaction behavior changed.

## Tests

- Added unit tests for `wrapWindowsHookCommand` in `installer-utils.test.ts` (format + space preservation).
- Added a Windows-only test (`it.skipIf(process.platform !== 'win32')`) to each affected agent's hook-service test suite. Each test installs hooks with a homedir whose path contains a space and asserts the generated command matches `/^cmd\.exe \/d \/c call ".*-hook\.cmd"$/`.
- All existing tests continue to pass (existing assertions use `.toContain` / `.includes`, which still match the wrapped command since the script path remains a substring).

## AI code review summary

- **Cross-platform compatibility**: The fix is guarded by `process.platform === 'win32'` and only affects Windows. macOS/Linux paths are unchanged (`wrapPosixHookCommand`). The `createManagedCommandMatcher` sweeps stale entries by filename substring (normalizing `\` to `/`), so old unwrapped entries are cleaned up automatically on next `install()` without touching user-authored hooks.
- **SSH/remote/local compatibility**: SSH remote installs always use POSIX `.sh` scripts via `wrapPosixHookCommand` — unaffected. The Windows wrapping only applies to local installs. Remote hook installation paths were not changed.
- **Supported agent and integration compatibility**: Verified all 14 agent hook services. Fixed 8 (codex, claude, openclaude, cursor, command-code, gemini, grok, droid); confirmed 4 already safe (copilot, kimi, antigravity, devin).
- **Performance risk**: None. `wrapWindowsHookCommand` is a single string template — called once per install, not in a hot path.
- **UI quality**: No UI changes.
- **Security risk**: None. The wrapper uses a literal string template with no user input interpolation beyond the script path, which is already a trusted Orca-managed path under `~/.orca/agent-hooks/`.

## Platform-specific testing notes

- Tested on Windows 11 with user profile `C:\Users\Jorge Silva` (contains a space).
- Verified the bug reproduces with the existing raw-path configs on disk, and that the fix generates `cmd.exe /d /c call "C:\Users\Jorge Silva\.orca\agent-hooks\codex-hook.cmd"`.
- macOS/Linux behavior is unchanged — existing POSIX tests pass.

## X handle

@mr_huxley

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6083">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->