### PR TITLE
Improve Android mobile release dispatch

### DIFF
--- a/.github/workflows/mobile-android-release.yml
+++ b/.github/workflows/mobile-android-release.yml
@@ -8,6 +8,30 @@ on:
     tags:
       - 'mobile-android-v*'
   workflow_dispatch:
+    inputs:
+      bump_patch_version:
+        description: 'Bump the mobile marketing version patch number before release'
+        required: false
+        default: false
+        type: boolean
+      release_version:
+        description: 'Optional exact mobile marketing version override, e.g. 0.0.15'
+        required: false
+        type: string
+      bump_android_version_code:
+        description: 'Increment the Android versionCode before release'
+        required: false
+        default: false
+        type: boolean
+      android_version_code:
+        description: 'Optional exact Android versionCode override'
+        required: false
+        type: string
+      publish_github_release:
+        description: 'Create or update the mobile-android-v<version> GitHub Release'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   android-build:
@@ -41,6 +65,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Resolve release version and version code
+        id: release
+        env:
+          MOBILE_ANDROID_RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          MOBILE_ANDROID_BUMP_PATCH_VERSION: ${{ github.event.inputs.bump_patch_version }}
+          MOBILE_ANDROID_VERSION_CODE: ${{ github.event.inputs.android_version_code }}
+          MOBILE_ANDROID_BUMP_VERSION_CODE: ${{ github.event.inputs.bump_android_version_code }}
+          MOBILE_ANDROID_PUBLISH_RELEASE: ${{ github.event.inputs.publish_github_release }}
+        run: node scripts/prepare-android-release.mjs
+
       - name: Setup JDK 17
         uses: actions/setup-java@v5
         with:
@@ -59,16 +93,39 @@ jobs:
           name: orca-mobile-apk
           path: mobile/android/app/build/outputs/apk/release/*.apk
 
+      - name: Ensure GitHub release tag
+        if: steps.release.outputs.publish_release == 'true' && !startsWith(github.ref, 'refs/tags/mobile-android-v')
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release.outputs.tag }}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists"
+            exit 0
+          fi
+
+          git tag "$tag" "$GITHUB_SHA"
+          git push origin "refs/tags/$tag"
+
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/mobile-android-v')
+        if: steps.release.outputs.publish_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
-          gh release create "$tag" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "Orca Mobile Android $tag" \
-            --prerelease \
-            --latest=false \
-            --generate-notes \
-            android/app/build/outputs/apk/release/*.apk
+          set -euo pipefail
+          tag="${{ steps.release.outputs.tag }}"
+
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber \
+              android/app/build/outputs/apk/release/*.apk
+          else
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Orca Mobile Android $tag" \
+              --prerelease \
+              --latest=false \
+              --generate-notes \
+              android/app/build/outputs/apk/release/*.apk
+          fi

--- a/mobile/scripts/prepare-android-release.mjs
+++ b/mobile/scripts/prepare-android-release.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+const mobileRoot = path.resolve(import.meta.dirname, '..')
+const appConfigPath = process.env.MOBILE_APP_CONFIG_PATH || path.join(mobileRoot, 'app.json')
+const androidTagRefPrefix = 'refs/tags/mobile-android-v'
+const semverPattern = /^\d+\.\d+\.\d+$/
+
+function input(name) {
+  return (process.env[name] || '').trim()
+}
+
+function truthy(value) {
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+function fail(message) {
+  console.error(message)
+  process.exit(1)
+}
+
+function parsePositiveInteger(value, name) {
+  if (!/^\d+$/.test(value)) {
+    fail(`${name} must be a positive integer`)
+  }
+
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    fail(`${name} must be a positive integer`)
+  }
+
+  return parsed
+}
+
+function validateSemver(version, name) {
+  if (!semverPattern.test(version)) {
+    fail(`${name} must use x.y.z format`)
+  }
+}
+
+function bumpPatchVersion(version) {
+  validateSemver(version, 'Current mobile version')
+  const [major, minor, patch] = version.split('.')
+  return `${major}.${minor}.${Number(patch) + 1}`
+}
+
+function writeOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (!outputPath) {
+    return
+  }
+
+  fs.appendFileSync(outputPath, `${name}=${value}\n`)
+}
+
+const config = JSON.parse(fs.readFileSync(appConfigPath, 'utf8'))
+const expo = config.expo || fail('app.json is missing expo config')
+const android = expo.android || fail('app.json is missing expo.android config')
+const currentVersion = String(expo.version || '').trim()
+validateSemver(currentVersion, 'Current mobile version')
+
+const currentVersionCode = Number(android.versionCode)
+if (!Number.isSafeInteger(currentVersionCode) || currentVersionCode <= 0) {
+  fail('Current Android versionCode must be a positive integer')
+}
+
+const githubRef = input('GITHUB_REF')
+const tagVersion = githubRef.startsWith(androidTagRefPrefix)
+  ? githubRef.slice(androidTagRefPrefix.length)
+  : ''
+const requestedVersion = input('MOBILE_ANDROID_RELEASE_VERSION')
+const bumpPatch = truthy(input('MOBILE_ANDROID_BUMP_PATCH_VERSION'))
+
+if (requestedVersion && bumpPatch) {
+  fail('Use either MOBILE_ANDROID_RELEASE_VERSION or MOBILE_ANDROID_BUMP_PATCH_VERSION, not both')
+}
+
+if (tagVersion) {
+  validateSemver(tagVersion, 'Android release tag version')
+}
+
+if (requestedVersion) {
+  validateSemver(requestedVersion, 'MOBILE_ANDROID_RELEASE_VERSION')
+}
+
+if (tagVersion && requestedVersion && requestedVersion !== tagVersion) {
+  fail('MOBILE_ANDROID_RELEASE_VERSION must match the mobile-android-v tag')
+}
+
+if (tagVersion && bumpPatch) {
+  fail('MOBILE_ANDROID_BUMP_PATCH_VERSION is only supported for manual branch runs')
+}
+
+const version =
+  requestedVersion || tagVersion || (bumpPatch ? bumpPatchVersion(currentVersion) : currentVersion)
+
+const requestedVersionCode = input('MOBILE_ANDROID_VERSION_CODE')
+const bumpVersionCode = truthy(input('MOBILE_ANDROID_BUMP_VERSION_CODE'))
+
+if (requestedVersionCode && bumpVersionCode) {
+  fail('Use either MOBILE_ANDROID_VERSION_CODE or MOBILE_ANDROID_BUMP_VERSION_CODE, not both')
+}
+
+const versionCode = requestedVersionCode
+  ? parsePositiveInteger(requestedVersionCode, 'MOBILE_ANDROID_VERSION_CODE')
+  : bumpVersionCode || version !== currentVersion
+    ? currentVersionCode + 1
+    : currentVersionCode
+
+expo.version = version
+android.versionCode = versionCode
+fs.writeFileSync(appConfigPath, `${JSON.stringify(config, null, 2)}\n`)
+
+const tag = `mobile-android-v${version}`
+const publishRelease =
+  githubRef.startsWith(androidTagRefPrefix) || truthy(input('MOBILE_ANDROID_PUBLISH_RELEASE'))
+
+writeOutput('version', version)
+writeOutput('android_version_code', String(versionCode))
+writeOutput('tag', tag)
+writeOutput('publish_release', publishRelease ? 'true' : 'false')
+
+console.log(`Prepared Orca Mobile Android ${version} (${versionCode})`)
+console.log(`Release tag: ${tag}`)
+console.log(`Publish GitHub Release: ${publishRelease ? 'yes' : 'no'}`)


### PR DESCRIPTION
## Summary
- Add manual Android release inputs for optional marketing version bump/override
- Add optional Android versionCode bump/override
- Let manual Android release runs create or update the mobile-android-v<version> GitHub Release, with an artifact-only toggle

## Verification
- node --check mobile/scripts/prepare-android-release.mjs
- ruby -e "require 'yaml'; YAML.safe_load(File.read('.github/workflows/mobile-android-release.yml'), aliases: true); puts 'YAML OK'"
- git diff --check
- temporary app.json resolver checks for bumped publish and artifact-only manual runs
- pre-commit staged hooks: oxlint, oxlint react-doctor config, oxfmt

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6087">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->