### PR TITLE
fix: Persist custom macOS dock icon

### DIFF
--- a/src/main/app-icon.test.ts
+++ b/src/main/app-icon.test.ts
@@ -36,11 +36,19 @@ vi.mock('../../resources/app-icons/orca-watercolor.png?asset', () => ({
   default: 'watercolor-icon'
 }))
 
+vi.mock('../../resources/app-icons/orca-watercolor.png?asset&asarUnpack', () => ({
+  default: 'watercolor-icon-unpacked'
+}))
+
 vi.mock('../../resources/app-icons/orca-blue.png?asset', () => ({
   default: 'blue-icon'
 }))
 
-import { applyAppIcon, getAppIconPath } from './app-icon'
+vi.mock('../../resources/app-icons/orca-blue.png?asset&asarUnpack', () => ({
+  default: 'blue-icon-unpacked'
+}))
+
+import { applyAppIcon, getAppIconPath, persistMacDockIcon } from './app-icon'
 
 describe('app icon selection', () => {
   beforeEach(() => {
@@ -75,5 +83,50 @@ describe('app icon selection', () => {
       expect(dockSetIconMock).not.toHaveBeenCalled()
     }
     expect(windowSetIconMock).toHaveBeenCalledWith(image)
+  })
+
+  it('persists a custom macOS dock icon to the app bundle for inactive Dock pins', () => {
+    const execFile = vi.fn()
+
+    persistMacDockIcon('watercolor', {
+      appBundlePath: '/Applications/Orca.app',
+      execFile,
+      isDevApp: false,
+      platform: 'darwin'
+    })
+
+    expect(execFile).toHaveBeenCalledWith(
+      '/usr/bin/osascript',
+      expect.arrayContaining(['-e', expect.stringContaining('setIcon:image forFile:appPath')]),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          ORCA_APP_BUNDLE_PATH: '/Applications/Orca.app',
+          ORCA_APP_ICON_PATH: 'watercolor-icon-unpacked'
+        })
+      }),
+      expect.any(Function)
+    )
+  })
+
+  it('clears Finder custom icon metadata when switching macOS back to the classic icon', () => {
+    const execFile = vi.fn()
+
+    persistMacDockIcon('classic', {
+      appBundlePath: '/Applications/Orca.app',
+      execFile,
+      isDevApp: false,
+      platform: 'darwin'
+    })
+
+    expect(execFile).toHaveBeenCalledWith(
+      '/usr/bin/xattr',
+      ['-d', 'com.apple.FinderInfo', '/Applications/Orca.app'],
+      expect.any(Function)
+    )
+    expect(execFile).toHaveBeenCalledWith(
+      '/usr/bin/xattr',
+      ['-d', 'com.apple.ResourceFork', '/Applications/Orca.app'],
+      expect.any(Function)
+    )
   })
 })

--- a/src/main/app-icon.test.ts
+++ b/src/main/app-icon.test.ts
@@ -129,4 +129,37 @@ describe('app icon selection', () => {
       expect.any(Function)
     )
   })
+
+  it('warns for non-benign failures when clearing Finder custom icon metadata', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const execFile = vi.fn(
+      (
+        _file: string,
+        args: string[],
+        optionsOrCallback: unknown,
+        callback?: (error: Error | null) => void
+      ) => {
+        const onComplete =
+          typeof optionsOrCallback === 'function'
+            ? (optionsOrCallback as (error: Error | null) => void)
+            : callback
+        onComplete?.(new Error(args[1] === 'com.apple.FinderInfo' ? 'No such xattr' : 'EACCES'))
+      }
+    )
+
+    persistMacDockIcon('classic', {
+      appBundlePath: '/Applications/Orca.app',
+      execFile,
+      isDevApp: false,
+      platform: 'darwin'
+    })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[app-icon] failed to clear macOS dock icon metadata com.apple.ResourceFork:',
+      expect.any(Error)
+    )
+
+    warnSpy.mockRestore()
+  })
 })

--- a/src/main/app-icon.test.ts
+++ b/src/main/app-icon.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   browserWindowGetAllWindowsMock,
@@ -50,6 +51,24 @@ vi.mock('../../resources/app-icons/orca-blue.png?asset&asarUnpack', () => ({
 
 import { applyAppIcon, getAppIconPath, persistMacDockIcon } from './app-icon'
 
+function waitForQueuedPersistence(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
+async function waitForQueuedPersistenceMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function createMockChildProcess(): EventEmitter & { kill: ReturnType<typeof vi.fn> } {
+  const childProcess = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> }
+  childProcess.kill = vi.fn(() => {
+    childProcess.emit('exit')
+    return true
+  })
+  return childProcess
+}
+
 describe('app icon selection', () => {
   beforeEach(() => {
     browserWindowGetAllWindowsMock.mockReset()
@@ -57,6 +76,10 @@ describe('app icon selection', () => {
     dockSetIconMock.mockReset()
     windowSetIconMock.mockReset()
     isMock.dev = false
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('resolves classic, watercolor, blue, and invalid icon ids', () => {
@@ -85,8 +108,21 @@ describe('app icon selection', () => {
     expect(windowSetIconMock).toHaveBeenCalledWith(image)
   })
 
-  it('persists a custom macOS dock icon to the app bundle for inactive Dock pins', () => {
-    const execFile = vi.fn()
+  it('persists a custom macOS dock icon to the app bundle for inactive Dock pins', async () => {
+    const execFile = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        optionsOrCallback: unknown,
+        callback?: (error: Error | null) => void
+      ) => {
+        const onComplete =
+          typeof optionsOrCallback === 'function'
+            ? (optionsOrCallback as (error: Error | null) => void)
+            : callback
+        onComplete?.(null)
+      }
+    )
 
     persistMacDockIcon('watercolor', {
       appBundlePath: '/Applications/Orca.app',
@@ -94,6 +130,7 @@ describe('app icon selection', () => {
       isDevApp: false,
       platform: 'darwin'
     })
+    await waitForQueuedPersistence()
 
     expect(execFile).toHaveBeenCalledWith(
       '/usr/bin/osascript',
@@ -108,8 +145,21 @@ describe('app icon selection', () => {
     )
   })
 
-  it('clears Finder custom icon metadata when switching macOS back to the classic icon', () => {
-    const execFile = vi.fn()
+  it('clears the AppKit icon and Finder metadata when switching macOS back to classic', async () => {
+    const execFile = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        optionsOrCallback: unknown,
+        callback?: (error: Error | null) => void
+      ) => {
+        const onComplete =
+          typeof optionsOrCallback === 'function'
+            ? (optionsOrCallback as (error: Error | null) => void)
+            : callback
+        onComplete?.(null)
+      }
+    )
 
     persistMacDockIcon('classic', {
       appBundlePath: '/Applications/Orca.app',
@@ -117,24 +167,46 @@ describe('app icon selection', () => {
       isDevApp: false,
       platform: 'darwin'
     })
+    await waitForQueuedPersistence()
 
+    expect(execFile).toHaveBeenNthCalledWith(
+      1,
+      '/usr/bin/osascript',
+      expect.arrayContaining([
+        '-e',
+        expect.stringContaining('setIcon:(missing value) forFile:appPath')
+      ]),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          ORCA_APP_BUNDLE_PATH: '/Applications/Orca.app'
+        }),
+        timeout: 10_000
+      }),
+      expect.any(Function)
+    )
     expect(execFile).toHaveBeenCalledWith(
       '/usr/bin/xattr',
       ['-d', 'com.apple.FinderInfo', '/Applications/Orca.app'],
+      expect.objectContaining({
+        timeout: 10_000
+      }),
       expect.any(Function)
     )
     expect(execFile).toHaveBeenCalledWith(
       '/usr/bin/xattr',
       ['-d', 'com.apple.ResourceFork', '/Applications/Orca.app'],
+      expect.objectContaining({
+        timeout: 10_000
+      }),
       expect.any(Function)
     )
   })
 
-  it('warns for non-benign failures when clearing Finder custom icon metadata', () => {
+  it('warns for non-benign failures when clearing Finder custom icon metadata', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const execFile = vi.fn(
       (
-        _file: string,
+        file: string,
         args: string[],
         optionsOrCallback: unknown,
         callback?: (error: Error | null) => void
@@ -143,6 +215,10 @@ describe('app icon selection', () => {
           typeof optionsOrCallback === 'function'
             ? (optionsOrCallback as (error: Error | null) => void)
             : callback
+        if (file !== '/usr/bin/xattr') {
+          onComplete?.(null)
+          return
+        }
         onComplete?.(new Error(args[1] === 'com.apple.FinderInfo' ? 'No such xattr' : 'EACCES'))
       }
     )
@@ -153,11 +229,221 @@ describe('app icon selection', () => {
       isDevApp: false,
       platform: 'darwin'
     })
+    await waitForQueuedPersistence()
 
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(warnSpy).toHaveBeenCalledWith(
       '[app-icon] failed to clear macOS dock icon metadata com.apple.ResourceFork:',
       expect.any(Error)
+    )
+
+    warnSpy.mockRestore()
+  })
+
+  it('warns when the AppKit classic icon reset fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const execFile = vi.fn(
+      (
+        file: string,
+        _args: string[],
+        optionsOrCallback: unknown,
+        callback?: (error: Error | null) => void
+      ) => {
+        const onComplete =
+          typeof optionsOrCallback === 'function'
+            ? (optionsOrCallback as (error: Error | null) => void)
+            : callback
+        onComplete?.(file === '/usr/bin/osascript' ? new Error('reset denied') : null)
+      }
+    )
+
+    persistMacDockIcon('classic', {
+      appBundlePath: '/Applications/Orca.app',
+      execFile,
+      isDevApp: false,
+      platform: 'darwin'
+    })
+    await waitForQueuedPersistence()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[app-icon] failed to clear macOS dock icon:',
+      expect.any(Error)
+    )
+
+    warnSpy.mockRestore()
+  })
+
+  it('serializes rapid macOS dock icon persistence so the last icon request wins', async () => {
+    const pendingCallbacks: (() => void)[] = []
+    const execFile = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        optionsOrCallback: unknown,
+        callback?: (error: Error | null) => void
+      ) => {
+        const onComplete =
+          typeof optionsOrCallback === 'function'
+            ? (optionsOrCallback as (error: Error | null) => void)
+            : callback
+        pendingCallbacks.push(() => onComplete?.(null))
+      }
+    )
+
+    persistMacDockIcon('watercolor', {
+      appBundlePath: '/Applications/Orca.app',
+      execFile,
+      isDevApp: false,
+      platform: 'darwin'
+    })
+    await waitForQueuedPersistence()
+
+    persistMacDockIcon('blue', {
+      appBundlePath: '/Applications/Orca.app',
+      execFile,
+      isDevApp: false,
+      platform: 'darwin'
+    })
+    persistMacDockIcon('classic', {
+      appBundlePath: '/Applications/Orca.app',
+      execFile,
+      isDevApp: false,
+      platform: 'darwin'
+    })
+
+    expect(execFile).toHaveBeenCalledTimes(1)
+    expect(execFile).toHaveBeenCalledWith(
+      '/usr/bin/osascript',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          ORCA_APP_ICON_PATH: 'watercolor-icon-unpacked'
+        })
+      }),
+      expect.any(Function)
+    )
+
+    pendingCallbacks.shift()?.()
+    await waitForQueuedPersistence()
+
+    expect(execFile).toHaveBeenCalledTimes(2)
+    expect(execFile).not.toHaveBeenCalledWith(
+      '/usr/bin/osascript',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          ORCA_APP_ICON_PATH: 'blue-icon-unpacked'
+        })
+      }),
+      expect.any(Function)
+    )
+    expect(execFile).toHaveBeenNthCalledWith(
+      2,
+      '/usr/bin/osascript',
+      expect.arrayContaining([
+        '-e',
+        expect.stringContaining('setIcon:(missing value) forFile:appPath')
+      ]),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          ORCA_APP_BUNDLE_PATH: '/Applications/Orca.app'
+        }),
+        timeout: 10_000
+      }),
+      expect.any(Function)
+    )
+    pendingCallbacks.shift()?.()
+    await waitForQueuedPersistence()
+
+    expect(execFile).toHaveBeenCalledTimes(4)
+    expect(execFile).toHaveBeenNthCalledWith(
+      3,
+      '/usr/bin/xattr',
+      ['-d', 'com.apple.FinderInfo', '/Applications/Orca.app'],
+      expect.objectContaining({
+        timeout: 10_000
+      }),
+      expect.any(Function)
+    )
+    expect(execFile).toHaveBeenNthCalledWith(
+      4,
+      '/usr/bin/xattr',
+      ['-d', 'com.apple.ResourceFork', '/Applications/Orca.app'],
+      expect.objectContaining({
+        timeout: 10_000
+      }),
+      expect.any(Function)
+    )
+
+    for (const completeCommand of pendingCallbacks) {
+      completeCommand()
+    }
+    await waitForQueuedPersistence()
+  })
+
+  it('continues macOS dock icon persistence when a command never completes', async () => {
+    vi.useFakeTimers()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const hungChildProcess = createMockChildProcess()
+    const execFile = vi.fn(
+      (
+        _file: string,
+        _args: string[],
+        optionsOrCallback: unknown,
+        callback?: (error: Error | null) => void
+      ) => {
+        if (execFile.mock.calls.length === 1) {
+          return hungChildProcess
+        }
+        const onComplete =
+          typeof optionsOrCallback === 'function'
+            ? (optionsOrCallback as (error: Error | null) => void)
+            : callback
+        onComplete?.(null)
+        return undefined
+      }
+    )
+
+    persistMacDockIcon('watercolor', {
+      appBundlePath: '/Applications/Orca.app',
+      execFile,
+      isDevApp: false,
+      platform: 'darwin'
+    })
+    await waitForQueuedPersistenceMicrotasks()
+
+    persistMacDockIcon('blue', {
+      appBundlePath: '/Applications/Orca.app',
+      execFile,
+      isDevApp: false,
+      platform: 'darwin'
+    })
+
+    expect(execFile).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    await waitForQueuedPersistenceMicrotasks()
+
+    expect(hungChildProcess.kill).not.toHaveBeenCalled()
+    expect(execFile).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await waitForQueuedPersistenceMicrotasks()
+
+    expect(warnSpy).toHaveBeenCalledWith('[app-icon] timed out persisting macOS dock icon')
+    expect(hungChildProcess.kill).toHaveBeenCalledTimes(1)
+    expect(execFile).toHaveBeenCalledTimes(2)
+    expect(execFile).toHaveBeenNthCalledWith(
+      2,
+      '/usr/bin/osascript',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          ORCA_APP_ICON_PATH: 'blue-icon-unpacked'
+        }),
+        timeout: 10_000
+      }),
+      expect.any(Function)
     )
 
     warnSpy.mockRestore()

--- a/src/main/app-icon.ts
+++ b/src/main/app-icon.ts
@@ -1,9 +1,13 @@
+import { execFile as execFileChildProcess, type ExecFileOptions } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
 import { app, BrowserWindow, nativeImage } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import classicIcon from '../../resources/icon.png?asset'
 import classicDevIcon from '../../resources/icon-dev.png?asset'
 import watercolorIcon from '../../resources/app-icons/orca-watercolor.png?asset'
+import watercolorMacDockIcon from '../../resources/app-icons/orca-watercolor.png?asset&asarUnpack'
 import blueIcon from '../../resources/app-icons/orca-blue.png?asset'
+import blueMacDockIcon from '../../resources/app-icons/orca-blue.png?asset&asarUnpack'
 import { normalizeAppIconId, type AppIconId } from '../shared/app-icon'
 
 const APP_ICON_PATHS = {
@@ -12,12 +16,103 @@ const APP_ICON_PATHS = {
   blue: blueIcon
 } satisfies Record<AppIconId, string>
 
+const MAC_DOCK_ICON_PATHS = {
+  watercolor: watercolorMacDockIcon,
+  blue: blueMacDockIcon
+} satisfies Record<Exclude<AppIconId, 'classic'>, string>
+
+type ExecFile = (
+  file: string,
+  args: string[],
+  optionsOrCallback: ExecFileOptions | ((error: Error | null) => void),
+  callback?: (error: Error | null) => void
+) => unknown
+
+type PersistMacDockIconOptions = {
+  appBundlePath?: string
+  execFile?: ExecFile
+  isDevApp?: boolean
+  platform?: NodeJS.Platform
+}
+
+const MAC_DOCK_ICON_SCRIPT = [
+  'use framework "AppKit"',
+  'use scripting additions',
+  'set appPath to system attribute "ORCA_APP_BUNDLE_PATH"',
+  'set iconPath to system attribute "ORCA_APP_ICON_PATH"',
+  "set image to current application's NSImage's alloc()'s initWithContentsOfFile:iconPath",
+  'if image is missing value then error "Orca app icon image could not be loaded"',
+  "set ok to current application's NSWorkspace's sharedWorkspace()'s setIcon:image forFile:appPath options:0",
+  'if ok is false then error "Orca app icon could not be persisted"'
+]
+
+const defaultExecFile: ExecFile = (file, args, optionsOrCallback, callback) => {
+  if (typeof optionsOrCallback === 'function') {
+    return execFileChildProcess(file, args, optionsOrCallback)
+  }
+  return execFileChildProcess(file, args, optionsOrCallback, callback ?? (() => {}))
+}
+
 export function getAppIconPath(value: unknown): string {
   return APP_ICON_PATHS[normalizeAppIconId(value)]
 }
 
 export function createAppIconImage(value: unknown): Electron.NativeImage {
   return nativeImage.createFromPath(getAppIconPath(value))
+}
+
+function getMacAppBundlePath(): string | undefined {
+  const appBundlePath = resolve(dirname(app.getPath('exe')), '..', '..')
+  return appBundlePath.endsWith('.app') ? appBundlePath : undefined
+}
+
+function runMacCustomIconCommand(
+  execFile: ExecFile,
+  appBundlePath: string,
+  iconPath: string
+): void {
+  execFile(
+    '/usr/bin/osascript',
+    MAC_DOCK_ICON_SCRIPT.flatMap((line) => ['-e', line]),
+    {
+      env: {
+        ...process.env,
+        ORCA_APP_BUNDLE_PATH: appBundlePath,
+        ORCA_APP_ICON_PATH: iconPath
+      }
+    },
+    (error) => {
+      if (error) {
+        console.warn('[app-icon] failed to persist macOS dock icon:', error)
+      }
+    }
+  )
+}
+
+function clearMacCustomIconMetadata(execFile: ExecFile, appBundlePath: string): void {
+  execFile('/usr/bin/xattr', ['-d', 'com.apple.FinderInfo', appBundlePath], () => {})
+  execFile('/usr/bin/xattr', ['-d', 'com.apple.ResourceFork', appBundlePath], () => {})
+}
+
+export function persistMacDockIcon(value: unknown, options: PersistMacDockIconOptions = {}): void {
+  const platform = options.platform ?? process.platform
+  const isDevApp = options.isDevApp ?? (is.dev || !app.isPackaged)
+  if (platform !== 'darwin' || isDevApp) {
+    return
+  }
+  const appBundlePath = options.appBundlePath ?? getMacAppBundlePath()
+  if (!appBundlePath) {
+    return
+  }
+  const execFile = options.execFile ?? defaultExecFile
+  const iconId = normalizeAppIconId(value)
+  if (iconId === 'classic') {
+    clearMacCustomIconMetadata(execFile, appBundlePath)
+    return
+  }
+  // Why: a stopped app's Dock tile is resolved from Finder metadata, not
+  // Electron's live app.dock.setIcon state.
+  runMacCustomIconCommand(execFile, appBundlePath, MAC_DOCK_ICON_PATHS[iconId])
 }
 
 export function applyAppIcon(value: unknown): void {
@@ -33,4 +128,5 @@ export function applyAppIcon(value: unknown): void {
       window.setIcon(image)
     }
   }
+  persistMacDockIcon(value)
 }

--- a/src/main/app-icon.ts
+++ b/src/main/app-icon.ts
@@ -1,4 +1,8 @@
-import { execFile as execFileChildProcess, type ExecFileOptions } from 'node:child_process'
+import {
+  execFile as execFileChildProcess,
+  type ChildProcess,
+  type ExecFileOptions
+} from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { app, BrowserWindow, nativeImage } from 'electron'
 import { is } from '@electron-toolkit/utils'
@@ -28,6 +32,8 @@ type ExecFile = (
   callback?: (error: Error | null) => void
 ) => unknown
 
+type MacDockIconChildProcess = Pick<ChildProcess, 'kill' | 'once'>
+
 type PersistMacDockIconOptions = {
   appBundlePath?: string
   execFile?: ExecFile
@@ -46,12 +52,26 @@ const MAC_DOCK_ICON_SCRIPT = [
   'if ok is false then error "Orca app icon could not be persisted"'
 ]
 
+const MAC_DOCK_ICON_CLEAR_SCRIPT = [
+  'use framework "AppKit"',
+  'use scripting additions',
+  'set appPath to system attribute "ORCA_APP_BUNDLE_PATH"',
+  "set ok to current application's NSWorkspace's sharedWorkspace()'s setIcon:(missing value) forFile:appPath options:0",
+  'if ok is false then error "Orca app icon could not be cleared"'
+]
+
+const MAC_DOCK_ICON_COMMAND_TIMEOUT_MS = 10_000
+const MAC_DOCK_ICON_COMMAND_FALLBACK_MS = 1_000
+
 const defaultExecFile: ExecFile = (file, args, optionsOrCallback, callback) => {
   if (typeof optionsOrCallback === 'function') {
     return execFileChildProcess(file, args, optionsOrCallback)
   }
   return execFileChildProcess(file, args, optionsOrCallback, callback ?? (() => {}))
 }
+
+let macDockIconPersistenceGeneration = 0
+let macDockIconPersistenceQueue = Promise.resolve()
 
 export function getAppIconPath(value: unknown): string {
   return APP_ICON_PATHS[normalizeAppIconId(value)]
@@ -70,36 +90,173 @@ function runMacCustomIconCommand(
   execFile: ExecFile,
   appBundlePath: string,
   iconPath: string
-): void {
-  execFile(
-    '/usr/bin/osascript',
-    MAC_DOCK_ICON_SCRIPT.flatMap((line) => ['-e', line]),
-    {
+): Promise<void> {
+  return runBoundedMacDockIconCommand({
+    args: MAC_DOCK_ICON_SCRIPT.flatMap((line) => ['-e', line]),
+    execFile,
+    file: '/usr/bin/osascript',
+    onError: (error) => {
+      console.warn('[app-icon] failed to persist macOS dock icon:', error)
+    },
+    options: {
       env: {
         ...process.env,
         ORCA_APP_BUNDLE_PATH: appBundlePath,
         ORCA_APP_ICON_PATH: iconPath
       }
     },
-    (error) => {
-      if (error) {
-        console.warn('[app-icon] failed to persist macOS dock icon:', error)
-      }
-    }
+    timeoutWarning: '[app-icon] timed out persisting macOS dock icon'
+  })
+}
+
+type BoundedMacDockIconCommandOptions = {
+  args: string[]
+  execFile: ExecFile
+  file: string
+  onError: (error: Error) => void
+  options?: ExecFileOptions
+  timeoutWarning: string
+}
+
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value))
+}
+
+function isMacDockIconChildProcess(value: unknown): value is MacDockIconChildProcess {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'kill' in value &&
+    typeof value.kill === 'function' &&
+    'once' in value &&
+    typeof value.once === 'function'
   )
 }
 
-function clearMacCustomIconMetadata(execFile: ExecFile, appBundlePath: string): void {
-  const clearAttribute = (attribute: string): void => {
-    execFile('/usr/bin/xattr', ['-d', attribute, appBundlePath], (error) => {
-      if (error && !error.message.includes('No such xattr')) {
-        console.warn(`[app-icon] failed to clear macOS dock icon metadata ${attribute}:`, error)
+function runBoundedMacDockIconCommand({
+  args,
+  execFile,
+  file,
+  onError,
+  options,
+  timeoutWarning
+}: BoundedMacDockIconCommandOptions): Promise<void> {
+  return new Promise((resolve) => {
+    let childProcess: MacDockIconChildProcess | undefined
+    let settled = false
+    let forceFallback: NodeJS.Timeout | undefined
+
+    const finish = (error: Error | null): void => {
+      if (settled) {
+        return
       }
+      settled = true
+      clearTimeout(fallback)
+      if (forceFallback) {
+        clearTimeout(forceFallback)
+      }
+      if (error) {
+        onError(error)
+      }
+      resolve()
+    }
+
+    const finishAfterFallback = (): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (forceFallback) {
+        clearTimeout(forceFallback)
+      }
+      console.warn(timeoutWarning)
+      resolve()
+    }
+
+    const fallback = setTimeout(() => {
+      if (settled) {
+        return
+      }
+      if (!childProcess) {
+        finishAfterFallback()
+        return
+      }
+      // Why: the queue must not release while an older icon process can still win.
+      childProcess.once('exit', finishAfterFallback)
+      childProcess.once('close', finishAfterFallback)
+      forceFallback = setTimeout(finishAfterFallback, MAC_DOCK_ICON_COMMAND_FALLBACK_MS)
+      childProcess.kill()
+    }, MAC_DOCK_ICON_COMMAND_TIMEOUT_MS + MAC_DOCK_ICON_COMMAND_FALLBACK_MS)
+
+    try {
+      const maybeChildProcess = execFile(
+        file,
+        args,
+        {
+          ...options,
+          timeout: MAC_DOCK_ICON_COMMAND_TIMEOUT_MS
+        },
+        finish
+      )
+      if (isMacDockIconChildProcess(maybeChildProcess)) {
+        childProcess = maybeChildProcess
+      }
+    } catch (error) {
+      finish(toError(error))
+    }
+  })
+}
+
+function handleMacDockIconQueueError(error: unknown): void {
+  console.warn('[app-icon] failed to persist macOS dock icon:', error)
+}
+
+function enqueueMacDockIconPersistence(work: () => Promise<void>): void {
+  macDockIconPersistenceQueue = macDockIconPersistenceQueue
+    .catch(handleMacDockIconQueueError)
+    .then(work)
+    .catch(handleMacDockIconQueueError)
+}
+
+function clearMacCustomIconMetadata(execFile: ExecFile, appBundlePath: string): Promise<void> {
+  const clearAppKitIcon = (): Promise<void> => {
+    return runBoundedMacDockIconCommand({
+      args: MAC_DOCK_ICON_CLEAR_SCRIPT.flatMap((line) => ['-e', line]),
+      execFile,
+      file: '/usr/bin/osascript',
+      onError: (error) => {
+        console.warn('[app-icon] failed to clear macOS dock icon:', error)
+      },
+      options: {
+        env: {
+          ...process.env,
+          ORCA_APP_BUNDLE_PATH: appBundlePath
+        }
+      },
+      timeoutWarning: '[app-icon] timed out clearing macOS dock icon'
     })
   }
 
-  clearAttribute('com.apple.FinderInfo')
-  clearAttribute('com.apple.ResourceFork')
+  const clearAttribute = (attribute: string): Promise<void> => {
+    return runBoundedMacDockIconCommand({
+      args: ['-d', attribute, appBundlePath],
+      execFile,
+      file: '/usr/bin/xattr',
+      onError: (error) => {
+        if (!error.message.includes('No such xattr')) {
+          console.warn(`[app-icon] failed to clear macOS dock icon metadata ${attribute}:`, error)
+        }
+      },
+      timeoutWarning: `[app-icon] timed out clearing macOS dock icon metadata ${attribute}`
+    })
+  }
+
+  return clearAppKitIcon().then(() =>
+    Promise.all([
+      clearAttribute('com.apple.FinderInfo'),
+      clearAttribute('com.apple.ResourceFork')
+    ]).then(() => {})
+  )
 }
 
 export function persistMacDockIcon(value: unknown, options: PersistMacDockIconOptions = {}): void {
@@ -114,13 +271,20 @@ export function persistMacDockIcon(value: unknown, options: PersistMacDockIconOp
   }
   const execFile = options.execFile ?? defaultExecFile
   const iconId = normalizeAppIconId(value)
-  if (iconId === 'classic') {
-    clearMacCustomIconMetadata(execFile, appBundlePath)
-    return
-  }
-  // Why: a stopped app's Dock tile is resolved from Finder metadata, not
-  // Electron's live app.dock.setIcon state.
-  runMacCustomIconCommand(execFile, appBundlePath, MAC_DOCK_ICON_PATHS[iconId])
+  const generation = ++macDockIconPersistenceGeneration
+  enqueueMacDockIconPersistence(async () => {
+    // Why: stale queued writes must not reapply an older Dock pin icon.
+    if (generation !== macDockIconPersistenceGeneration) {
+      return
+    }
+    if (iconId === 'classic') {
+      await clearMacCustomIconMetadata(execFile, appBundlePath)
+      return
+    }
+    // Why: a stopped app's Dock tile is resolved from Finder metadata, not
+    // Electron's live app.dock.setIcon state.
+    await runMacCustomIconCommand(execFile, appBundlePath, MAC_DOCK_ICON_PATHS[iconId])
+  })
 }
 
 export function applyAppIcon(value: unknown): void {

--- a/src/main/app-icon.ts
+++ b/src/main/app-icon.ts
@@ -90,8 +90,16 @@ function runMacCustomIconCommand(
 }
 
 function clearMacCustomIconMetadata(execFile: ExecFile, appBundlePath: string): void {
-  execFile('/usr/bin/xattr', ['-d', 'com.apple.FinderInfo', appBundlePath], () => {})
-  execFile('/usr/bin/xattr', ['-d', 'com.apple.ResourceFork', appBundlePath], () => {})
+  const clearAttribute = (attribute: string): void => {
+    execFile('/usr/bin/xattr', ['-d', attribute, appBundlePath], (error) => {
+      if (error && !error.message.includes('No such xattr')) {
+        console.warn(`[app-icon] failed to clear macOS dock icon metadata ${attribute}:`, error)
+      }
+    })
+  }
+
+  clearAttribute('com.apple.FinderInfo')
+  clearAttribute('com.apple.ResourceFork')
 }
 
 export function persistMacDockIcon(value: unknown, options: PersistMacDockIconOptions = {}): void {


### PR DESCRIPTION
## Summary

Persist the selected custom macOS app icon to the `.app` bundle's Finder icon metadata so Dock pins keep the chosen icon after Orca quits.

## Root Cause

The existing app icon setting only updated Electron's live `app.dock.setIcon` and open windows. macOS resolves a stopped pinned app's Dock tile from LaunchServices/Finder metadata, so the custom choice disappeared once the process exited.

## Changes

- Added a packaged-macOS persistence step that writes the custom icon via AppKit `NSWorkspace.setIcon`.
- Used `?asset&asarUnpack` for custom dock icon assets so the AppKit script can read them from disk outside `app.asar`.
- Clear Finder custom icon metadata when switching back to the Classic icon.
- Added unit coverage for custom icon persistence and Classic reset behavior.

## Validation

- `pnpm vitest run --config config/vitest.config.ts src/main/app-icon.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/app-icon.ts src/main/app-icon.test.ts`
- Native macOS `osascript` smoke test confirmed Finder icon metadata is written on a temporary `.app` bundle.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6088">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->