### PR TITLE
fix: refit after single terminal restore

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -2146,20 +2146,31 @@ export default function TerminalPane({
     return [...ptyIds]
   }, [])
 
-  const restorePaneTerminalFit = useCallback(async (pane: ManagedPane): Promise<void> => {
-    // Why: local and remote runtime PTYs use different transports, but the
-    // desktop reclaim button should have one visible recovery behavior.
-    const id = paneTransportsRef.current.get(pane.id)?.getPtyId()
-    if (!id) {
-      return
-    }
-    const restored = await restoreTerminalFitToDesktop(id, settingsRef.current ?? undefined)
-    if (restored) {
-      // Why: after the overlay unmounts, focus would otherwise stay on the
-      // removed button/body instead of the terminal the user just reclaimed.
-      pane.terminal.focus()
-    }
+  const scheduleRestoredTerminalRefit = useCallback((): void => {
+    // Why: desktop-fit events can clear runtime state before xterm has repainted;
+    // restore actions get one settled-frame pass that does not depend on focus.
+    requestAnimationFrame(refitAndRefreshAllTerminalPanes)
+    window.setTimeout(refitAndRefreshAllTerminalPanes, 100)
   }, [])
+
+  const restorePaneTerminalFit = useCallback(
+    async (pane: ManagedPane): Promise<void> => {
+      // Why: local and remote runtime PTYs use different transports, but the
+      // desktop reclaim button should have one visible recovery behavior.
+      const id = paneTransportsRef.current.get(pane.id)?.getPtyId()
+      if (!id) {
+        return
+      }
+      const restored = await restoreTerminalFitToDesktop(id, settingsRef.current ?? undefined)
+      if (restored) {
+        scheduleRestoredTerminalRefit()
+        // Why: after the overlay unmounts, focus would otherwise stay on the
+        // removed button/body instead of the terminal the user just reclaimed.
+        pane.terminal.focus()
+      }
+    },
+    [scheduleRestoredTerminalRefit]
+  )
 
   const restoreAllTerminalFits = useCallback(
     async (focusPane: ManagedPane): Promise<void> => {
@@ -2170,12 +2181,11 @@ export default function TerminalPane({
         settingsRef.current ?? undefined
       )
       if (restored) {
-        requestAnimationFrame(refitAndRefreshAllTerminalPanes)
-        window.setTimeout(refitAndRefreshAllTerminalPanes, 100)
+        scheduleRestoredTerminalRefit()
         focusPane.terminal.focus()
       }
     },
-    [getMobileOwnedTerminalPtyIds]
+    [getMobileOwnedTerminalPtyIds, scheduleRestoredTerminalRefit]
   )
 
   const terminalShouldHandleMiddleClick = useCallback(

--- a/tests/e2e/mobile-banner.spec.ts
+++ b/tests/e2e/mobile-banner.spec.ts
@@ -1,6 +1,13 @@
 import type { ElectronApplication, Page, TestInfo } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
-import { ensureTerminalVisible, waitForSessionReady, waitForActiveWorktree } from './helpers/store'
+import {
+  ensureTerminalVisible,
+  getActiveWorktreeId,
+  getAllWorktreeIds,
+  switchToWorktree,
+  waitForSessionReady,
+  waitForActiveWorktree
+} from './helpers/store'
 import {
   splitActiveTerminalPane,
   waitForActivePanePtyId,
@@ -127,13 +134,11 @@ test('restore this terminal refits the active restored pane', async ({ orcaPage,
   const ptyId = await waitForActivePanePtyId(orcaPage)
   await installRestoreTerminalFitAutoRestoreRecorder(electronApp)
 
-  await sendHeldPhoneFitIpc(electronApp, { ptyId, cols: 45, rows: 20 })
+  await sendHeldPhoneFitIpc(electronApp, { ptyId, cols: 1, rows: 20 })
   await expect(orcaPage.locator('.mobile-driver-banner')).toHaveCount(1, { timeout: 15_000 })
-
-  await forcePaneToOneColumn(orcaPage, ptyId)
   await expect
     .poll(() => getPaneTerminalCols(orcaPage, ptyId), {
-      message: 'test harness should force the active pane into the bad narrow state'
+      message: 'test harness should hold the active pane in the bad narrow state'
     })
     .toBeLessThanOrEqual(2)
 
@@ -189,6 +194,71 @@ test('restore all refits non-focused restored terminal panes', async ({
     .poll(() => getPaneTerminalCols(orcaPage, inactivePtyId), {
       timeout: 5_000,
       message: 'Restore all should refit the non-focused restored pane'
+    })
+    .toBeGreaterThan(20)
+})
+
+test('restore all recovers a hidden workspace held at narrow terminal geometry', async ({
+  orcaPage,
+  electronApp
+}) => {
+  await waitForSessionReady(orcaPage)
+  const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+  const secondWorktreeId = (await getAllWorktreeIds(orcaPage)).find(
+    (worktreeId) => worktreeId !== firstWorktreeId
+  )
+  test.skip(!secondWorktreeId, 'hidden-workspace restore repro needs the seeded secondary worktree')
+  if (!secondWorktreeId) {
+    return
+  }
+
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage)
+  const hiddenWorkspacePtyId = await waitForActivePanePtyId(orcaPage)
+  await sendHeldPhoneFitIpc(electronApp, { ptyId: hiddenWorkspacePtyId, cols: 45, rows: 20 })
+  await expect(orcaPage.locator('.mobile-driver-banner')).toHaveCount(1, { timeout: 15_000 })
+
+  await forcePaneToOneColumnAndSwitchWorktree(orcaPage, hiddenWorkspacePtyId, secondWorktreeId)
+  await expect
+    .poll(() => getActiveWorktreeId(orcaPage), {
+      timeout: 5_000,
+      message: 'second worktree should become active before restore-all'
+    })
+    .toBe(secondWorktreeId)
+  await expect
+    .poll(() => getPaneTerminalCols(orcaPage, hiddenWorkspacePtyId), {
+      message: 'test harness should hold workspace 1 in the bad narrow state'
+    })
+    .toBeLessThanOrEqual(2)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage)
+  const activeWorkspacePtyId = await waitForActivePanePtyId(orcaPage)
+  await installRestoreTerminalFitAutoRestoreRecorder(electronApp)
+  await sendHeldPhoneFitIpc(electronApp, { ptyId: activeWorkspacePtyId, cols: 45, rows: 20 })
+  await expect(
+    orcaPage.locator(`[data-pty-id="${activeWorkspacePtyId}"] .mobile-driver-banner`)
+  ).toBeVisible({ timeout: 15_000 })
+
+  await orcaPage
+    .locator(`[data-pty-id="${activeWorkspacePtyId}"] .mobile-driver-banner`)
+    .getByRole('button', { name: /restore all terminals/i })
+    .click()
+
+  await expectRestoreTerminalFitCallSet(electronApp, [hiddenWorkspacePtyId, activeWorkspacePtyId])
+
+  await switchToWorktree(orcaPage, firstWorktreeId)
+  await expect
+    .poll(() => getActiveWorktreeId(orcaPage), {
+      timeout: 5_000,
+      message: 'first worktree should become active after restore-all'
+    })
+    .toBe(firstWorktreeId)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage)
+  await expect
+    .poll(() => getPaneTerminalCols(orcaPage, hiddenWorkspacePtyId), {
+      timeout: 5_000,
+      message: 'Restore all should refit the hidden workspace when it becomes visible'
     })
     .toBeGreaterThan(20)
 })
@@ -382,6 +452,32 @@ async function forcePaneToOneColumn(page: Page, ptyId: string): Promise<void> {
     }
     throw new Error(`No pane found for PTY ${targetPtyId}`)
   }, ptyId)
+}
+
+async function forcePaneToOneColumnAndSwitchWorktree(
+  page: Page,
+  ptyId: string,
+  worktreeId: string
+): Promise<void> {
+  await page.evaluate(
+    ({ targetPtyId, targetWorktreeId }) => {
+      for (const manager of window.__paneManagers?.values?.() ?? []) {
+        const pane = manager
+          .getPanes?.()
+          .find((candidate) => candidate.container.dataset.ptyId === targetPtyId)
+        if (pane) {
+          // Why: the repro needs the desktop surface to inherit a phone-sized
+          // xterm layout after the workspace is no longer visible.
+          pane.terminal.resize(1, Math.max(8, pane.terminal.rows))
+          pane.terminal.refresh(0, pane.terminal.rows - 1)
+          window.__store?.getState().setActiveWorktree(targetWorktreeId)
+          return
+        }
+      }
+      throw new Error(`No pane found for PTY ${targetPtyId}`)
+    },
+    { targetPtyId: ptyId, targetWorktreeId: worktreeId }
+  )
 }
 
 async function getPaneTerminalCols(page: Page, ptyId: string): Promise<number> {

--- a/tests/e2e/mobile-banner.spec.ts
+++ b/tests/e2e/mobile-banner.spec.ts
@@ -119,6 +119,38 @@ test('held phone-fit state mounts restore overlay without collapse', async ({
   await expect(overlay).toBeHidden({ timeout: 15_000 })
 })
 
+test('restore this terminal refits the active restored pane', async ({ orcaPage, electronApp }) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage)
+  const ptyId = await waitForActivePanePtyId(orcaPage)
+  await installRestoreTerminalFitAutoRestoreRecorder(electronApp)
+
+  await sendHeldPhoneFitIpc(electronApp, { ptyId, cols: 45, rows: 20 })
+  await expect(orcaPage.locator('.mobile-driver-banner')).toHaveCount(1, { timeout: 15_000 })
+
+  await forcePaneToOneColumn(orcaPage, ptyId)
+  await expect
+    .poll(() => getPaneTerminalCols(orcaPage, ptyId), {
+      message: 'test harness should force the active pane into the bad narrow state'
+    })
+    .toBeLessThanOrEqual(2)
+
+  await orcaPage
+    .locator(`[data-pty-id="${ptyId}"] .mobile-driver-banner`)
+    .getByRole('button', { name: /restore this terminal/i })
+    .click()
+
+  await expectRestoreTerminalFitCalls(electronApp, [ptyId])
+  await expect
+    .poll(() => getPaneTerminalCols(orcaPage, ptyId), {
+      timeout: 5_000,
+      message: 'Restore this terminal should refit the active restored pane'
+    })
+    .toBeGreaterThan(20)
+})
+
 test('restore all refits non-focused restored terminal panes', async ({
   orcaPage,
   electronApp


### PR DESCRIPTION
## Summary
- Apply the post-restore refit/refresh recovery to "Restore this terminal" as well as the already-merged restore-all path.
- Share the restore-refit scheduling helper between single restore and restore-all.
- Add an active-pane E2E harness: hold xterm at 1-column geometry, click the real "Restore this terminal" button, and assert columns recover.
- Add a multi-workspace restore-all E2E harness: put workspace 1 into held phone-fit state, force the hidden workspace's xterm to 1 column, restore all from workspace 2, then switch back and assert workspace 1 recovers. This simulates the desktop state left by the mobile app rather than launching the real phone app.

Fixes #6085.

## Tests
- npm test -- --run src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts src/renderer/src/components/terminal-pane/terminal-fit-restore.test.ts src/main/runtime/fit-override-integration.test.ts src/main/runtime/mobile-subscribe-integration.test.ts
- npm run typecheck
- npx playwright test tests/e2e/mobile-banner.spec.ts --config tests/playwright.config.ts --project=electron-headless
- npx playwright test tests/e2e/mobile-banner.spec.ts --config tests/playwright.config.ts --project=electron-headless --grep "hidden workspace"
