### PR TITLE
Resolve and clear push targets for linked hosted reviews

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13314,7 +13314,8 @@ export class OrcaRuntimeService {
 
   async updateManagedWorktreeMeta(
     worktreeSelector: string,
-    updates: Partial<WorktreeMeta> & {
+    updates: Omit<Partial<WorktreeMeta>, 'pushTarget'> & {
+      pushTarget?: GitPushTarget | null
       lineage?: {
         parentWorktree?: string
         noParent?: boolean
@@ -13326,6 +13327,26 @@ export class OrcaRuntimeService {
     }
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
     const { lineage, ...metaUpdates } = updates
+    const shouldClearPushTarget =
+      Object.prototype.hasOwnProperty.call(metaUpdates, 'pushTarget') &&
+      metaUpdates.pushTarget === null
+    const normalizedMetaUpdates: Partial<WorktreeMeta> = shouldClearPushTarget
+      ? { ...metaUpdates, pushTarget: undefined }
+      : (metaUpdates as Partial<WorktreeMeta>)
+    const persistedMetaUpdates: Partial<WorktreeMeta> = omitUndefinedProperties(
+      normalizedMetaUpdates.displayName !== undefined
+        ? {
+            ...normalizedMetaUpdates,
+            pendingFirstAgentMessageRename: false,
+            firstAgentMessageRenameError: null
+          }
+        : normalizedMetaUpdates
+    )
+    if (shouldClearPushTarget) {
+      // Why: omitUndefinedProperties protects ordinary optional RPC fields, but
+      // pushTarget:null is an explicit request to remove persisted target metadata.
+      persistedMetaUpdates.pushTarget = undefined
+    }
     if (lineage?.noParent === true) {
       this.store.removeWorktreeLineage?.(worktree.id)
       this.store.removeWorkspaceLineage?.(worktreeWorkspaceKey(worktree.id))
@@ -13365,20 +13386,7 @@ export class OrcaRuntimeService {
         createdAt
       })
     }
-    this.store.setWorktreeMeta(
-      worktree.id,
-      stripOrcaProvenanceMetaUpdates(
-        omitUndefinedProperties(
-          metaUpdates.displayName !== undefined
-            ? {
-                ...metaUpdates,
-                pendingFirstAgentMessageRename: false,
-                firstAgentMessageRenameError: null
-              }
-            : metaUpdates
-        )
-      )
-    )
+    this.store.setWorktreeMeta(worktree.id, stripOrcaProvenanceMetaUpdates(persistedMetaUpdates))
     // Why: unlike renderer-initiated optimistic updates, CLI callers need an
     // explicit push so the editor refreshes metadata changed outside the UI.
     this.invalidateResolvedWorktreeCache()

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -201,6 +201,7 @@ export const WorktreeSet = WorktreeSelector.extend({
       branchName: z.string(),
       remoteUrl: OptionalString
     })
+    .nullable()
     .optional(),
   diffComments: z.array(z.unknown()).optional(),
   mobileDiffReview: z.unknown().optional(),

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -623,6 +623,31 @@ describe('worktree RPC methods', () => {
     )
   })
 
+  it('forwards push target clears through worktree.set', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateManagedWorktreeMeta: vi.fn().mockResolvedValue({ id: 'wt-1' })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('worktree.set', {
+        worktree: 'id:wt-1',
+        linkedPR: null,
+        pushTarget: null
+      })
+    )
+
+    expect(response).toMatchObject({ ok: true })
+    expect(runtime.updateManagedWorktreeMeta).toHaveBeenCalledWith(
+      'id:wt-1',
+      expect.objectContaining({
+        linkedPR: null,
+        pushTarget: null
+      })
+    )
+  })
+
   it('rejects worktree.set when both parent and no-parent are supplied', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -253,6 +253,7 @@ import {
   SourceControlHeaderToolbar
 } from './source-control-header-toolbar'
 import {
+  hasPositiveHostedReviewNumberLink,
   hasResolvableHostedReviewPushTargetLink,
   hasUsableHostedReviewPushTarget,
   resolveHostedReviewActionUpstreamStatus,
@@ -1416,12 +1417,14 @@ function SourceControlInner(): React.JSX.Element {
     linkedGitLabMR,
     linkedGiteaPR
   ])
-  const hasHostedReviewLink =
-    (linkedGitHubPR ?? fallbackGitHubPRNumber) !== null ||
-    linkedGitLabMR !== null ||
-    linkedBitbucketPR !== null ||
-    linkedAzureDevOpsPR !== null ||
-    linkedGiteaPR !== null
+  const hasHostedReviewLink = hasPositiveHostedReviewNumberLink({
+    linkedGitHubPR,
+    fallbackGitHubPR: fallbackGitHubPRNumber,
+    linkedGitLabMR,
+    linkedBitbucketPR,
+    linkedAzureDevOpsPR,
+    linkedGiteaPR
+  })
   // Why: when activeRepo.connectionId is truthy, neither the SourceControl
   // effect below nor WorktreeCard.tsx fetches hostedReview for this branch,
   // so hostedReviewEntry would stay undefined forever and would permanently
@@ -1456,7 +1459,8 @@ function SourceControlInner(): React.JSX.Element {
   ])
   const canUseHostedReviewPushTarget = hasUsableHostedReviewPushTarget({
     pushTarget: activeWorktree?.pushTarget,
-    upstreamStatus: remoteStatus
+    upstreamStatus: remoteStatus,
+    hasResolvableHostedReviewPushTargetLink: hasResolvableReviewPushTargetLink
   })
   const hostedReviewStateForActions = resolveHostedReviewStateForActions({
     hostedReviewState: hostedReview?.state ?? null,

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -252,6 +252,12 @@ import {
   shouldShowSourceControlCompareUnavailableCard,
   SourceControlHeaderToolbar
 } from './source-control-header-toolbar'
+import {
+  hasResolvableHostedReviewPushTargetLink,
+  hasUsableHostedReviewPushTarget,
+  resolveHostedReviewActionUpstreamStatus,
+  resolveHostedReviewStateForActions
+} from './source-control-hosted-review-push-target'
 export { HostedReviewHeaderLink } from './hosted-review-header-chrome'
 import {
   createRunningCommitMessageGenerationRecord,
@@ -783,6 +789,7 @@ function SourceControlInner(): React.JSX.Element {
   const beginGitBranchCompareRequest = useAppStore((s) => s.beginGitBranchCompareRequest)
   const setGitBranchCompareResult = useAppStore((s) => s.setGitBranchCompareResult)
   const fetchUpstreamStatus = useAppStore((s) => s.fetchUpstreamStatus)
+  const ensureHostedReviewPushTarget = useAppStore((s) => s.ensureHostedReviewPushTarget)
   const setUpstreamStatus = useAppStore((s) => s.setUpstreamStatus)
   const pushBranch = useAppStore((s) => s.pushBranch)
   const pullBranch = useAppStore((s) => s.pullBranch)
@@ -1409,7 +1416,7 @@ function SourceControlInner(): React.JSX.Element {
     linkedGitLabMR,
     linkedGiteaPR
   ])
-  const hasLinkedHostedReview =
+  const hasHostedReviewLink =
     (linkedGitHubPR ?? fallbackGitHubPRNumber) !== null ||
     linkedGitLabMR !== null ||
     linkedBitbucketPR !== null ||
@@ -1422,7 +1429,58 @@ function SourceControlInner(): React.JSX.Element {
   // and no upstream. Skip the loading state for those repos so the publish
   // gate doesn't latch.
   const isHostedReviewStateLoading =
-    !activeRepo?.connectionId && hasLinkedHostedReview && hostedReviewEntry === undefined
+    !activeRepo?.connectionId && hasHostedReviewLink && hostedReviewEntry === undefined
+  const hasResolvableReviewPushTargetLink = hasResolvableHostedReviewPushTargetLink({
+    linkedGitHubPR,
+    linkedGitLabMR
+  })
+  useEffect(() => {
+    // Why: resolving review heads can hit provider/SSH APIs, so keep it tied
+    // to the visible Source Control branch view like the adjacent PR polling.
+    if (!isBranchVisible || isFolder || !activeWorktreeId || activeWorktree?.pushTarget) {
+      return
+    }
+    if (!hasResolvableReviewPushTargetLink) {
+      return
+    }
+    void ensureHostedReviewPushTarget(activeWorktreeId)
+  }, [
+    activeWorktree?.pushTarget,
+    activeWorktreeId,
+    ensureHostedReviewPushTarget,
+    hasResolvableReviewPushTargetLink,
+    isBranchVisible,
+    isFolder,
+    linkedGitHubPR,
+    linkedGitLabMR
+  ])
+  const canUseHostedReviewPushTarget = hasUsableHostedReviewPushTarget({
+    pushTarget: activeWorktree?.pushTarget,
+    upstreamStatus: remoteStatus
+  })
+  const hostedReviewStateForActions = resolveHostedReviewStateForActions({
+    hostedReviewState: hostedReview?.state ?? null,
+    hasResolvableHostedReviewPushTargetLink: hasResolvableReviewPushTargetLink
+  })
+  const remoteStatusForActions: typeof remoteStatus = useMemo(
+    () =>
+      resolveHostedReviewActionUpstreamStatus({
+        hasHostedReviewLink,
+        hasResolvableHostedReviewPushTargetLink: hasResolvableReviewPushTargetLink,
+        hostedReviewState: hostedReviewStateForActions,
+        isHostedReviewStateLoading,
+        canUseHostedReviewPushTarget,
+        upstreamStatus: remoteStatus
+      }),
+    [
+      canUseHostedReviewPushTarget,
+      hasHostedReviewLink,
+      hasResolvableReviewPushTargetLink,
+      hostedReviewStateForActions,
+      isHostedReviewStateLoading,
+      remoteStatus
+    ]
+  )
   useEffect(() => {
     if (
       !isBranchVisible ||
@@ -3771,16 +3829,15 @@ function SourceControlInner(): React.JSX.Element {
       hasUnresolvedConflicts: unresolvedConflicts.length > 0,
       isCommitting,
       isRemoteOperationActive: isRemoteOperationActive || isAbortingOperation,
-      upstreamStatus: remoteStatus,
-      prState: hostedReview?.state ?? null,
+      upstreamStatus: remoteStatusForActions,
+      prState: hostedReviewStateForActions,
       isPRStateLoading: isHostedReviewStateLoading,
       inFlightRemoteOpKind,
       hostedReviewCreation,
       branchCommitsAhead:
         branchSummary?.status === 'ready' ? (branchSummary.commitsAhead ?? 0) : undefined,
       hasCurrentBranch: Boolean(branchName),
-      canPushLinkedReviewWithoutUpstream:
-        Boolean(activeWorktree?.pushTarget) || remoteStatus?.hasConfiguredPushTarget === true,
+      canPushLinkedReviewWithoutUpstream: canUseHostedReviewPushTarget,
       isPrIntentInFlight: isCreatePrIntentInFlight
     })
   }, [
@@ -3795,13 +3852,13 @@ function SourceControlInner(): React.JSX.Element {
     inFlightRemoteOpKind,
     hostedReviewCreation,
     isHostedReviewStateLoading,
-    hostedReview?.state,
-    activeWorktree?.pushTarget,
+    hostedReviewStateForActions,
+    canUseHostedReviewPushTarget,
     isCreatePrIntentInFlight,
     branchSummary?.commitsAhead,
     branchSummary?.status,
     branchName,
-    remoteStatus,
+    remoteStatusForActions,
     unresolvedConflicts.length
   ])
 
@@ -3890,8 +3947,8 @@ function SourceControlInner(): React.JSX.Element {
         isCommitting,
         isRemoteOperationActive: isRemoteOperationActive || isAbortingOperation,
         conflictOperation,
-        upstreamStatus: remoteStatus,
-        prState: hostedReview?.state ?? null,
+        upstreamStatus: remoteStatusForActions,
+        prState: hostedReviewStateForActions,
         isPRStateLoading: isHostedReviewStateLoading,
         inFlightRemoteOpKind,
         hostedReviewCreation,
@@ -3899,8 +3956,7 @@ function SourceControlInner(): React.JSX.Element {
         branchCommitsAhead:
           branchSummary?.status === 'ready' ? (branchSummary.commitsAhead ?? 0) : undefined,
         hasCurrentBranch: Boolean(branchName),
-        canPushLinkedReviewWithoutUpstream:
-          Boolean(activeWorktree?.pushTarget) || remoteStatus?.hasConfiguredPushTarget === true,
+        canPushLinkedReviewWithoutUpstream: canUseHostedReviewPushTarget,
         rebaseBaseRef: effectiveBaseRef
       }),
     [
@@ -3918,14 +3974,14 @@ function SourceControlInner(): React.JSX.Element {
       isCreatingPr,
       isCreatePrIntentInFlight,
       isHostedReviewStateLoading,
-      hostedReview?.state,
+      hostedReviewStateForActions,
       prGenerating,
-      activeWorktree?.pushTarget,
+      canUseHostedReviewPushTarget,
       branchSummary?.commitsAhead,
       branchSummary?.status,
       branchName,
       effectiveBaseRef,
-      remoteStatus,
+      remoteStatusForActions,
       unresolvedConflicts.length
     ]
   )

--- a/src/renderer/src/components/right-sidebar/source-control-hosted-review-push-target.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-hosted-review-push-target.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  hasPositiveHostedReviewNumberLink,
   hasResolvableHostedReviewPushTargetLink,
   hasUsableHostedReviewPushTarget,
   resolveHostedReviewActionUpstreamStatus,
@@ -93,8 +94,21 @@ describe('resolveHostedReviewActionUpstreamStatus', () => {
     expect(
       resolveHostedReviewActionUpstreamStatus({
         hasHostedReviewLink: true,
-        hasResolvableHostedReviewPushTargetLink: false,
+        hasResolvableHostedReviewPushTargetLink: true,
         hostedReviewState: 'closed',
+        isHostedReviewStateLoading: false,
+        canUseHostedReviewPushTarget: false,
+        upstreamStatus: unrelatedUpstream
+      })
+    ).toBe(unrelatedUpstream)
+  })
+
+  it('does not alter status for merged reviews', () => {
+    expect(
+      resolveHostedReviewActionUpstreamStatus({
+        hasHostedReviewLink: true,
+        hasResolvableHostedReviewPushTargetLink: true,
+        hostedReviewState: 'merged',
         isHostedReviewStateLoading: false,
         canUseHostedReviewPushTarget: false,
         upstreamStatus: unrelatedUpstream
@@ -108,8 +122,23 @@ describe('hasResolvableHostedReviewPushTargetLink', () => {
     expect(hasResolvableHostedReviewPushTargetLink({ linkedGitHubPR: 12 })).toBe(true)
     expect(hasResolvableHostedReviewPushTargetLink({ linkedGitLabMR: 34 })).toBe(true)
     expect(hasResolvableHostedReviewPushTargetLink({ linkedGitHubPR: null })).toBe(false)
+    expect(hasResolvableHostedReviewPushTargetLink({ linkedGitHubPR: 0 })).toBe(false)
+    expect(hasResolvableHostedReviewPushTargetLink({ linkedGitLabMR: -1 })).toBe(false)
+    expect(hasResolvableHostedReviewPushTargetLink({ linkedGitLabMR: 1.5 })).toBe(false)
     expect(hasResolvableHostedReviewPushTargetLink({ linkedGitHubPR: Number.NaN })).toBe(false)
     expect(hasResolvableHostedReviewPushTargetLink({})).toBe(false)
+  })
+})
+
+describe('hasPositiveHostedReviewNumberLink', () => {
+  it('accepts positive hosted-review metadata and rejects invalid values', () => {
+    expect(hasPositiveHostedReviewNumberLink({ fallbackGitHubPR: 12 })).toBe(true)
+    expect(hasPositiveHostedReviewNumberLink({ linkedBitbucketPR: 34 })).toBe(true)
+    expect(hasPositiveHostedReviewNumberLink({ linkedAzureDevOpsPR: 56 })).toBe(true)
+    expect(hasPositiveHostedReviewNumberLink({ linkedGiteaPR: 78 })).toBe(true)
+    expect(hasPositiveHostedReviewNumberLink({ linkedGitHubPR: 0, linkedGitLabMR: -1 })).toBe(false)
+    expect(hasPositiveHostedReviewNumberLink({ linkedGitHubPR: Number.NaN })).toBe(false)
+    expect(hasPositiveHostedReviewNumberLink({})).toBe(false)
   })
 })
 
@@ -157,9 +186,27 @@ describe('hasUsableHostedReviewPushTarget', () => {
     ).toBe(true)
     expect(
       hasUsableHostedReviewPushTarget({
+        pushTarget: { remoteName: 'fork', branchName: 'feature' },
+        upstreamStatus: { hasUpstream: true, upstreamName: 'fork/feature', ahead: 1, behind: 0 }
+      })
+    ).toBe(true)
+    expect(
+      hasUsableHostedReviewPushTarget({
         upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0, hasConfiguredPushTarget: true }
       })
     ).toBe(true)
+    expect(
+      hasUsableHostedReviewPushTarget({
+        hasResolvableHostedReviewPushTargetLink: true,
+        upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0, hasConfiguredPushTarget: true }
+      })
+    ).toBe(false)
+    expect(
+      hasUsableHostedReviewPushTarget({
+        pushTarget: { remoteName: 'fork', branchName: 'feature' },
+        upstreamStatus: unrelatedUpstream
+      })
+    ).toBe(false)
     expect(hasUsableHostedReviewPushTarget({ upstreamStatus: unrelatedUpstream })).toBe(false)
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control-hosted-review-push-target.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-hosted-review-push-target.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hasResolvableHostedReviewPushTargetLink,
+  hasUsableHostedReviewPushTarget,
+  resolveHostedReviewActionUpstreamStatus,
+  resolveHostedReviewStateForActions
+} from './source-control-hosted-review-push-target'
+
+const unrelatedUpstream = {
+  hasUpstream: true,
+  upstreamName: 'origin/helper-branch',
+  ahead: 1,
+  behind: 0
+}
+
+describe('resolveHostedReviewActionUpstreamStatus', () => {
+  it('blocks action status from using a local upstream while linked review state is loading', () => {
+    expect(
+      resolveHostedReviewActionUpstreamStatus({
+        hasHostedReviewLink: true,
+        hasResolvableHostedReviewPushTargetLink: false,
+        hostedReviewState: null,
+        isHostedReviewStateLoading: true,
+        canUseHostedReviewPushTarget: false,
+        upstreamStatus: unrelatedUpstream
+      })
+    ).toEqual({ hasUpstream: false, ahead: 0, behind: 0 })
+  })
+
+  it('blocks action status from using a local upstream for open reviews without a target', () => {
+    expect(
+      resolveHostedReviewActionUpstreamStatus({
+        hasHostedReviewLink: true,
+        hasResolvableHostedReviewPushTargetLink: false,
+        hostedReviewState: 'open',
+        isHostedReviewStateLoading: false,
+        canUseHostedReviewPushTarget: false,
+        upstreamStatus: unrelatedUpstream
+      })
+    ).toEqual({ hasUpstream: false, ahead: 0, behind: 0 })
+  })
+
+  it('blocks explicit linked review metadata even when review state is unavailable', () => {
+    expect(
+      resolveHostedReviewActionUpstreamStatus({
+        hasHostedReviewLink: true,
+        hasResolvableHostedReviewPushTargetLink: true,
+        hostedReviewState: null,
+        isHostedReviewStateLoading: false,
+        canUseHostedReviewPushTarget: false,
+        upstreamStatus: unrelatedUpstream
+      })
+    ).toEqual({ hasUpstream: false, ahead: 0, behind: 0 })
+  })
+
+  it('does not block unknown-state review links when no target lookup exists', () => {
+    expect(
+      resolveHostedReviewActionUpstreamStatus({
+        hasHostedReviewLink: true,
+        hasResolvableHostedReviewPushTargetLink: false,
+        hostedReviewState: null,
+        isHostedReviewStateLoading: false,
+        canUseHostedReviewPushTarget: false,
+        upstreamStatus: unrelatedUpstream
+      })
+    ).toBe(unrelatedUpstream)
+  })
+
+  it('keeps action status on the review target once one is usable', () => {
+    expect(
+      resolveHostedReviewActionUpstreamStatus({
+        hasHostedReviewLink: true,
+        hasResolvableHostedReviewPushTargetLink: true,
+        hostedReviewState: 'open',
+        isHostedReviewStateLoading: false,
+        canUseHostedReviewPushTarget: true,
+        upstreamStatus: {
+          hasUpstream: true,
+          upstreamName: 'pr-user-repo/user/feature',
+          ahead: 2,
+          behind: 0
+        }
+      })
+    ).toEqual({
+      hasUpstream: true,
+      upstreamName: 'pr-user-repo/user/feature',
+      ahead: 2,
+      behind: 0
+    })
+  })
+
+  it('does not alter status for closed reviews', () => {
+    expect(
+      resolveHostedReviewActionUpstreamStatus({
+        hasHostedReviewLink: true,
+        hasResolvableHostedReviewPushTargetLink: false,
+        hostedReviewState: 'closed',
+        isHostedReviewStateLoading: false,
+        canUseHostedReviewPushTarget: false,
+        upstreamStatus: unrelatedUpstream
+      })
+    ).toBe(unrelatedUpstream)
+  })
+})
+
+describe('hasResolvableHostedReviewPushTargetLink', () => {
+  it('accepts only hosted-review links with supported target lookup APIs', () => {
+    expect(hasResolvableHostedReviewPushTargetLink({ linkedGitHubPR: 12 })).toBe(true)
+    expect(hasResolvableHostedReviewPushTargetLink({ linkedGitLabMR: 34 })).toBe(true)
+    expect(hasResolvableHostedReviewPushTargetLink({ linkedGitHubPR: null })).toBe(false)
+    expect(hasResolvableHostedReviewPushTargetLink({ linkedGitHubPR: Number.NaN })).toBe(false)
+    expect(hasResolvableHostedReviewPushTargetLink({})).toBe(false)
+  })
+})
+
+describe('resolveHostedReviewStateForActions', () => {
+  it('treats explicit linked review metadata as open when live state is unavailable', () => {
+    expect(
+      resolveHostedReviewStateForActions({
+        hostedReviewState: null,
+        hasResolvableHostedReviewPushTargetLink: true
+      })
+    ).toBe('open')
+  })
+
+  it('preserves known hosted review states', () => {
+    expect(
+      resolveHostedReviewStateForActions({
+        hostedReviewState: 'merged',
+        hasResolvableHostedReviewPushTargetLink: true
+      })
+    ).toBe('merged')
+    expect(
+      resolveHostedReviewStateForActions({
+        hostedReviewState: 'closed',
+        hasResolvableHostedReviewPushTargetLink: false
+      })
+    ).toBe('closed')
+  })
+
+  it('leaves unknown review state empty when no target lookup exists', () => {
+    expect(
+      resolveHostedReviewStateForActions({
+        hostedReviewState: null,
+        hasResolvableHostedReviewPushTargetLink: false
+      })
+    ).toBeNull()
+  })
+})
+
+describe('hasUsableHostedReviewPushTarget', () => {
+  it('accepts either persisted target metadata or branch-configured push metadata', () => {
+    expect(
+      hasUsableHostedReviewPushTarget({
+        pushTarget: { remoteName: 'fork', branchName: 'feature' }
+      })
+    ).toBe(true)
+    expect(
+      hasUsableHostedReviewPushTarget({
+        upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0, hasConfiguredPushTarget: true }
+      })
+    ).toBe(true)
+    expect(hasUsableHostedReviewPushTarget({ upstreamStatus: unrelatedUpstream })).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-hosted-review-push-target.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-hosted-review-push-target.ts
@@ -1,11 +1,46 @@
 import type { GitPushTarget, GitUpstreamStatus } from '../../../../shared/types'
 import type { HostedReviewState } from '../../../../shared/hosted-review'
+import { getPublishTargetDisplayName } from '../../../../shared/git-publish-target-status'
 
 export function hasUsableHostedReviewPushTarget(args: {
   pushTarget?: GitPushTarget
   upstreamStatus?: GitUpstreamStatus
+  hasResolvableHostedReviewPushTargetLink?: boolean
 }): boolean {
-  return Boolean(args.pushTarget) || args.upstreamStatus?.hasConfiguredPushTarget === true
+  if (args.pushTarget) {
+    return (
+      args.upstreamStatus === undefined ||
+      args.upstreamStatus.upstreamName === getPublishTargetDisplayName(args.pushTarget)
+    )
+  }
+  if (args.hasResolvableHostedReviewPushTargetLink) {
+    // Why: a bare branch-config flag does not identify which review head it will
+    // push to; resolver-backed links need hydrated target metadata to prove it.
+    return false
+  }
+  return args.upstreamStatus?.hasConfiguredPushTarget === true
+}
+
+function isResolvableHostedReviewNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+export function hasPositiveHostedReviewNumberLink(args: {
+  linkedGitHubPR?: number | null
+  fallbackGitHubPR?: number | null
+  linkedGitLabMR?: number | null
+  linkedBitbucketPR?: number | null
+  linkedAzureDevOpsPR?: number | null
+  linkedGiteaPR?: number | null
+}): boolean {
+  return (
+    isResolvableHostedReviewNumber(args.linkedGitHubPR) ||
+    isResolvableHostedReviewNumber(args.fallbackGitHubPR) ||
+    isResolvableHostedReviewNumber(args.linkedGitLabMR) ||
+    isResolvableHostedReviewNumber(args.linkedBitbucketPR) ||
+    isResolvableHostedReviewNumber(args.linkedAzureDevOpsPR) ||
+    isResolvableHostedReviewNumber(args.linkedGiteaPR)
+  )
 }
 
 export function hasResolvableHostedReviewPushTargetLink(args: {
@@ -13,8 +48,8 @@ export function hasResolvableHostedReviewPushTargetLink(args: {
   linkedGitLabMR?: number | null
 }): boolean {
   return (
-    (typeof args.linkedGitHubPR === 'number' && Number.isFinite(args.linkedGitHubPR)) ||
-    (typeof args.linkedGitLabMR === 'number' && Number.isFinite(args.linkedGitLabMR))
+    isResolvableHostedReviewNumber(args.linkedGitHubPR) ||
+    isResolvableHostedReviewNumber(args.linkedGitLabMR)
   )
 }
 
@@ -29,7 +64,7 @@ export function resolveHostedReviewActionUpstreamStatus(args: {
   const hostedReviewMayStillNeedItsOwnTarget =
     // Why: SSH-backed linked reviews may not fetch live review state, but
     // their explicit link metadata still needs target-safe push behavior.
-    args.hasResolvableHostedReviewPushTargetLink ||
+    (args.hasResolvableHostedReviewPushTargetLink && !args.hostedReviewState) ||
     args.isHostedReviewStateLoading ||
     args.hostedReviewState === 'open' ||
     args.hostedReviewState === 'draft'

--- a/src/renderer/src/components/right-sidebar/source-control-hosted-review-push-target.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-hosted-review-push-target.ts
@@ -1,0 +1,58 @@
+import type { GitPushTarget, GitUpstreamStatus } from '../../../../shared/types'
+import type { HostedReviewState } from '../../../../shared/hosted-review'
+
+export function hasUsableHostedReviewPushTarget(args: {
+  pushTarget?: GitPushTarget
+  upstreamStatus?: GitUpstreamStatus
+}): boolean {
+  return Boolean(args.pushTarget) || args.upstreamStatus?.hasConfiguredPushTarget === true
+}
+
+export function hasResolvableHostedReviewPushTargetLink(args: {
+  linkedGitHubPR?: number | null
+  linkedGitLabMR?: number | null
+}): boolean {
+  return (
+    (typeof args.linkedGitHubPR === 'number' && Number.isFinite(args.linkedGitHubPR)) ||
+    (typeof args.linkedGitLabMR === 'number' && Number.isFinite(args.linkedGitLabMR))
+  )
+}
+
+export function resolveHostedReviewActionUpstreamStatus(args: {
+  hasHostedReviewLink: boolean
+  hasResolvableHostedReviewPushTargetLink: boolean
+  hostedReviewState?: HostedReviewState | null
+  isHostedReviewStateLoading: boolean
+  canUseHostedReviewPushTarget: boolean
+  upstreamStatus?: GitUpstreamStatus
+}): GitUpstreamStatus | undefined {
+  const hostedReviewMayStillNeedItsOwnTarget =
+    // Why: SSH-backed linked reviews may not fetch live review state, but
+    // their explicit link metadata still needs target-safe push behavior.
+    args.hasResolvableHostedReviewPushTargetLink ||
+    args.isHostedReviewStateLoading ||
+    args.hostedReviewState === 'open' ||
+    args.hostedReviewState === 'draft'
+  if (
+    args.hasHostedReviewLink &&
+    hostedReviewMayStillNeedItsOwnTarget &&
+    !args.canUseHostedReviewPushTarget
+  ) {
+    // Why: a linked hosted review can coexist with an unrelated branch upstream;
+    // push/status actions must not use that upstream until the review target is known.
+    return { hasUpstream: false, ahead: 0, behind: 0 }
+  }
+  return args.upstreamStatus
+}
+
+export function resolveHostedReviewStateForActions(args: {
+  hostedReviewState?: HostedReviewState | null
+  hasResolvableHostedReviewPushTargetLink: boolean
+}): HostedReviewState | null {
+  if (args.hostedReviewState) {
+    return args.hostedReviewState
+  }
+  // Why: SSH-backed linked reviews may not have live review state, but Publish
+  // Branch is unsafe until the linked review target is usable.
+  return args.hasResolvableHostedReviewPushTargetLink ? 'open' : null
+}

--- a/src/renderer/src/lib/github-links.test.ts
+++ b/src/renderer/src/lib/github-links.test.ts
@@ -51,6 +51,9 @@ describe('parseGitHubIssueOrPRNumber', () => {
   })
 
   it('rejects invalid GitHub item URLs', () => {
+    expect(parseGitHubIssueOrPRNumber('0')).toBeNull()
+    expect(parseGitHubIssueOrPRNumber('#0')).toBeNull()
+    expect(parseGitHubIssueOrPRNumber('https://github.com/o/r/pull/0')).toBeNull()
     expect(
       parseGitHubIssueOrPRNumber('https://github.com/o/r/pull/not-a-number/changes')
     ).toBeNull()
@@ -117,6 +120,8 @@ describe('parseGitHubIssueOrPRLink', () => {
   })
 
   it('rejects non-GitHub and malformed item URLs', () => {
+    expect(parseGitHubIssueOrPRLink('https://github.com/o/r/pull/0')).toBeNull()
+    expect(parseGitHubIssueOrPRLink('https://github.com/o/r/issues/0')).toBeNull()
     expect(parseGitHubIssueOrPRLink('https://github.com/o/r/pull/not-a-number/changes')).toBeNull()
     expect(parseGitHubIssueOrPRLink('https://github.com/o/r/pull/')).toBeNull()
     expect(parseGitHubIssueOrPRLink('https://github.com/o/r/issues/123abc')).toBeNull()

--- a/src/renderer/src/lib/github-links.ts
+++ b/src/renderer/src/lib/github-links.ts
@@ -24,6 +24,11 @@ function matchGitHubItemPath(url: URL): RegExpExecArray | null {
   return GH_ITEM_PATH_RE.exec(url.pathname.replace(/\/+$/, ''))
 }
 
+function parseGitHubItemNumber(value: string): number | null {
+  const parsed = Number.parseInt(value, 10)
+  return parsed > 0 ? parsed : null
+}
+
 /**
  * Parses a GitHub issue/PR reference from plain input.
  * Supports issue/PR numbers (e.g. "42"), "#42", and full GitHub URLs.
@@ -36,7 +41,7 @@ export function parseGitHubIssueOrPRNumber(input: string): number | null {
 
   const numeric = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed
   if (/^\d+$/.test(numeric)) {
-    return Number.parseInt(numeric, 10)
+    return parseGitHubItemNumber(numeric)
   }
 
   let url: URL
@@ -55,7 +60,7 @@ export function parseGitHubIssueOrPRNumber(input: string): number | null {
     return null
   }
 
-  return Number.parseInt(match[4], 10)
+  return parseGitHubItemNumber(match[4])
 }
 
 /**
@@ -87,11 +92,15 @@ export function parseGitHubIssueOrPRLink(input: string): {
   if (!match) {
     return null
   }
+  const number = parseGitHubItemNumber(match[4])
+  if (number === null) {
+    return null
+  }
 
   return {
     slug: { owner: match[1], repo: match[2] },
     type: match[3].toLowerCase() === 'pull' ? 'pr' : 'issue',
-    number: Number.parseInt(match[4], 10)
+    number
   }
 }
 

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -189,6 +189,7 @@ export type WorktreeSlice = {
     updates: Partial<WorktreeMeta>,
     options?: WorktreeMetaUpdateOptions
   ) => Promise<void>
+  ensureHostedReviewPushTarget: (worktreeId: string) => Promise<void>
   updateWorktreesMeta: (
     updatesByWorktreeId: ReadonlyMap<string, Partial<WorktreeMeta>>
   ) => Promise<void>

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -2815,6 +2815,209 @@ describe('worktree remote runtime mutations', () => {
     expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toEqual(pushTarget)
   })
 
+  it('clears a stale push target when unlinking the GitHub PR that supplied it', async () => {
+    const store = createTestStore()
+    const pushTarget = { remoteName: 'fork', branchName: 'owner/old-pr' }
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      linkedPR: 2548,
+      pushTarget
+    })
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().updateWorktreeMeta(wt.id, { linkedPR: null })
+
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { linkedPR: null, pushTarget: undefined }
+    })
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toBeUndefined()
+  })
+
+  it('clears an older GitHub link and target when replacing it with a GitLab MR', async () => {
+    const store = createTestStore()
+    const oldPushTarget = { remoteName: 'fork', branchName: 'owner/old-pr' }
+    const newPushTarget = { remoteName: 'upstream', branchName: 'owner/new-mr' }
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      branch: 'refs/heads/review-branch',
+      linkedPR: 2548,
+      pushTarget: oldPushTarget
+    })
+    const fetchHostedReviewForBranch = vi.fn().mockResolvedValue(null)
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] },
+      fetchHostedReviewForBranch
+    } as Partial<AppState>)
+
+    await store.getState().updateWorktreeMeta(wt.id, { linkedGitLabMR: 42 })
+
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { linkedGitLabMR: 42, linkedPR: null, pushTarget: undefined }
+    })
+    expect(store.getState().worktreesByRepo.repo1[0]).toMatchObject({
+      linkedPR: null,
+      linkedGitLabMR: 42
+    })
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toBeUndefined()
+    expect(fetchHostedReviewForBranch).toHaveBeenCalledWith('/repo1', 'review-branch', {
+      repoId: 'repo1',
+      linkedGitHubPR: null,
+      linkedGitLabMR: 42,
+      linkedBitbucketPR: null,
+      linkedAzureDevOpsPR: null,
+      linkedGiteaPR: null,
+      force: true
+    })
+
+    mockApi.worktrees.updateMeta.mockClear()
+    mockApi.worktrees.resolveMrBase.mockResolvedValueOnce({
+      baseBranch: 'upstream/main',
+      pushTarget: newPushTarget
+    })
+
+    await store.getState().ensureHostedReviewPushTarget(wt.id)
+
+    expect(mockApi.worktrees.resolveMrBase).toHaveBeenCalledWith({
+      repoId: 'repo1',
+      mrIid: 42
+    })
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { pushTarget: newPushTarget }
+    })
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toEqual(newPushTarget)
+  })
+
+  it('resolves a manually linked GitHub PR through the worktree owner runtime', async () => {
+    const store = createTestStore()
+    const pushTarget = { remoteName: 'fork', branchName: 'owner-runtime/manual-pr' }
+    const wt = makeWorktree({
+      id: 'repo1::/remote/wt1',
+      repoId: 'repo1',
+      path: '/remote/wt1',
+      hostId: 'runtime:owner-env'
+    })
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'worktree.resolvePrBase') {
+        return Promise.resolve({
+          id: 'rpc-owner-resolve-pr-base',
+          ok: true,
+          result: { baseBranch: 'fork-head', pushTarget },
+          _meta: { runtimeId: 'owner-env' }
+        })
+      }
+      if (method === 'worktree.set') {
+        return Promise.resolve({
+          id: 'rpc-owner-set-worktree',
+          ok: true,
+          result: { worktree: { ...wt, linkedPR: 2548, pushTarget } },
+          _meta: { runtimeId: 'owner-env' }
+        })
+      }
+      throw new Error(`Unexpected runtime method ${method}`)
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'focused-env' } as never,
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().updateWorktreeMeta(wt.id, { linkedPR: 2548 })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'owner-env',
+      method: 'worktree.resolvePrBase',
+      params: { repo: 'repo1', prNumber: 2548 },
+      timeoutMs: 30_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'owner-env',
+      method: 'worktree.set',
+      params: { worktree: `id:${wt.id}`, linkedPR: 2548, pushTarget },
+      timeoutMs: 15_000
+    })
+    expect(mockApi.worktrees.resolvePrBase).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toEqual(pushTarget)
+  })
+
+  it('sends a runtime clear when unlinking a review-owned push target', async () => {
+    const store = createTestStore()
+    const pushTarget = { remoteName: 'fork', branchName: 'owner-runtime/old-pr' }
+    const wt = makeWorktree({
+      id: 'repo1::/remote/wt1',
+      repoId: 'repo1',
+      path: '/remote/wt1',
+      hostId: 'runtime:owner-env',
+      linkedPR: 2548,
+      pushTarget
+    })
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'worktree.set') {
+        return Promise.resolve({
+          id: 'rpc-owner-clear-worktree',
+          ok: true,
+          result: { worktree: { ...wt, linkedPR: null, pushTarget: undefined } },
+          _meta: { runtimeId: 'owner-env' }
+        })
+      }
+      throw new Error(`Unexpected runtime method ${method}`)
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'focused-env' } as never,
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().updateWorktreeMeta(wt.id, { linkedPR: null })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'owner-env',
+      method: 'worktree.set',
+      params: { worktree: `id:${wt.id}`, linkedPR: null, pushTarget: null },
+      timeoutMs: 15_000
+    })
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toBeUndefined()
+  })
+
+  it('does not resolve a push target when metadata carries an invalid GitHub PR number', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().updateWorktreeMeta(wt.id, { linkedPR: 0 })
+
+    expect(mockApi.worktrees.resolvePrBase).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { linkedPR: 0 }
+    })
+  })
+
   it('does not resolve a push target when re-saving the same linked GitHub PR', async () => {
     const store = createTestStore()
     const wt = makeWorktree({
@@ -2930,6 +3133,62 @@ describe('worktree remote runtime mutations', () => {
     expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toEqual(pushTarget)
   })
 
+  it('hydrates a host-stamped linked GitHub PR push target through the worktree owner runtime', async () => {
+    const store = createTestStore()
+    const pushTarget = { remoteName: 'fork', branchName: 'feature/owner-runtime-pr' }
+    const wt = makeWorktree({
+      id: 'repo1::/path/owner-runtime-wt',
+      repoId: 'repo1',
+      path: '/path/owner-runtime-wt',
+      hostId: 'runtime:owner-env',
+      linkedPR: 5571
+    })
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'worktree.resolvePrBase') {
+        return Promise.resolve({
+          id: 'rpc-owner-resolve-pr-base',
+          ok: true,
+          result: { baseBranch: 'fork-head', pushTarget },
+          _meta: { runtimeId: 'owner-env' }
+        })
+      }
+      if (method === 'worktree.set') {
+        return Promise.resolve({
+          id: 'rpc-owner-set-worktree',
+          ok: true,
+          result: { worktree: { ...wt, pushTarget } },
+          _meta: { runtimeId: 'owner-env' }
+        })
+      }
+      throw new Error(`Unexpected runtime method ${method}`)
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'focused-env' } as never,
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().ensureHostedReviewPushTarget(wt.id)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'owner-env',
+      method: 'worktree.resolvePrBase',
+      params: { repo: 'repo1', prNumber: 5571 },
+      timeoutMs: 30_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'owner-env',
+      method: 'worktree.set',
+      params: { worktree: `id:${wt.id}`, pushTarget },
+      timeoutMs: 15_000
+    })
+    expect(mockApi.worktrees.resolvePrBase).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toEqual(pushTarget)
+  })
+
   it('hydrates an SSH-owned linked GitHub PR push target through local IPC when a runtime is focused', async () => {
     const store = createTestStore()
     const pushTarget = { remoteName: 'fork', branchName: 'feature/ssh-pr' }
@@ -3025,6 +3284,35 @@ describe('worktree remote runtime mutations', () => {
       updates: { pushTarget }
     })
     expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toEqual(pushTarget)
+  })
+
+  it('skips push target hydration for invalid linked review numbers', async () => {
+    const store = createTestStore()
+    const github = makeWorktree({
+      id: 'repo1::/path/github',
+      repoId: 'repo1',
+      path: '/path/github',
+      linkedPR: 0
+    })
+    const gitlab = makeWorktree({
+      id: 'repo1::/path/gitlab',
+      repoId: 'repo1',
+      path: '/path/gitlab',
+      linkedGitLabMR: -1
+    })
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [github, gitlab] }
+    } as Partial<AppState>)
+
+    await store.getState().ensureHostedReviewPushTarget(github.id)
+    await store.getState().ensureHostedReviewPushTarget(gitlab.id)
+
+    expect(mockApi.worktrees.resolvePrBase).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.resolveMrBase).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
   })
 
   it('waits for branch confirmation before linking a terminal PR URL for a known push target', async () => {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -65,6 +65,7 @@ const mockApi = {
     remove: vi.fn().mockResolvedValue(undefined),
     forceDeletePreservedBranch: vi.fn().mockResolvedValue({ deleted: true }),
     resolvePrBase: vi.fn(),
+    resolveMrBase: vi.fn(),
     updateMeta: vi.fn().mockResolvedValue(undefined),
     updateLineage: vi.fn().mockResolvedValue(null)
   },
@@ -2836,6 +2837,194 @@ describe('worktree remote runtime mutations', () => {
       worktreeId: wt.id,
       updates: { linkedPR: 2548 }
     })
+  })
+
+  it('hydrates a missing push target for an existing linked GitHub PR', async () => {
+    const store = createTestStore()
+    const pushTarget = {
+      remoteName: 'pr-tmchow-orca',
+      branchName: 'tmchow/worktree-delete-button'
+    }
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      linkedPR: 5571
+    })
+    mockApi.worktrees.resolvePrBase.mockResolvedValueOnce({
+      baseBranch: 'fork-head',
+      pushTarget
+    })
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().ensureHostedReviewPushTarget(wt.id)
+
+    expect(mockApi.worktrees.resolvePrBase).toHaveBeenCalledWith({
+      repoId: 'repo1',
+      prNumber: 5571
+    })
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { pushTarget }
+    })
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toEqual(pushTarget)
+  })
+
+  it('hydrates a missing linked GitHub PR push target through the active remote runtime', async () => {
+    const store = createTestStore()
+    const pushTarget = { remoteName: 'fork', branchName: 'feature/runtime-pr' }
+    const wt = makeWorktree({
+      id: 'repo1::/path/runtime-wt',
+      repoId: 'repo1',
+      path: '/path/runtime-wt',
+      linkedPR: 5571
+    })
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'worktree.resolvePrBase') {
+        return Promise.resolve({
+          id: 'rpc-resolve-pr-base',
+          ok: true,
+          result: { baseBranch: 'fork-head', pushTarget },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'worktree.set') {
+        return Promise.resolve({
+          id: 'rpc-set-worktree',
+          ok: true,
+          result: { worktree: { ...wt, pushTarget } },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method ${method}`)
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().ensureHostedReviewPushTarget(wt.id)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'worktree.resolvePrBase',
+      params: { repo: 'repo1', prNumber: 5571 },
+      timeoutMs: 30_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'worktree.set',
+      params: { worktree: `id:${wt.id}`, pushTarget },
+      timeoutMs: 15_000
+    })
+    expect(mockApi.worktrees.resolvePrBase).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toEqual(pushTarget)
+  })
+
+  it('hydrates an SSH-owned linked GitHub PR push target through local IPC when a runtime is focused', async () => {
+    const store = createTestStore()
+    const pushTarget = { remoteName: 'fork', branchName: 'feature/ssh-pr' }
+    const wt = makeWorktree({
+      id: 'repo-ssh::/home/orca/runtime-wt',
+      repoId: 'repo-ssh',
+      path: '/home/orca/runtime-wt',
+      linkedPR: 5571
+    })
+    mockApi.worktrees.resolvePrBase.mockResolvedValueOnce({
+      baseBranch: 'fork-head',
+      pushTarget
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [
+        {
+          id: 'repo-ssh',
+          path: '/home/orca/repo',
+          displayName: 'SSH Repo',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-1'
+        }
+      ],
+      worktreesByRepo: { 'repo-ssh': [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().ensureHostedReviewPushTarget(wt.id)
+
+    expect(mockApi.worktrees.resolvePrBase).toHaveBeenCalledWith({
+      repoId: 'repo-ssh',
+      prNumber: 5571
+    })
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { pushTarget }
+    })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo['repo-ssh'][0]?.pushTarget).toEqual(pushTarget)
+  })
+
+  it('keeps a linked review without a derivable target unmodified', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      linkedPR: 5571
+    })
+    mockApi.worktrees.resolvePrBase.mockResolvedValueOnce({ baseBranch: 'fork-head' })
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().ensureHostedReviewPushTarget(wt.id)
+
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toBeUndefined()
+  })
+
+  it('hydrates a missing push target for an existing linked GitLab MR when supported', async () => {
+    const store = createTestStore()
+    const pushTarget = { remoteName: 'upstream', branchName: 'feature/mr' }
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      linkedGitLabMR: 42
+    })
+    mockApi.worktrees.resolveMrBase.mockResolvedValueOnce({
+      baseBranch: 'upstream/feature/mr',
+      pushTarget
+    })
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().ensureHostedReviewPushTarget(wt.id)
+
+    expect(mockApi.worktrees.resolveMrBase).toHaveBeenCalledWith({
+      repoId: 'repo1',
+      mrIid: 42
+    })
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { pushTarget }
+    })
+    expect(store.getState().worktreesByRepo.repo1[0]?.pushTarget).toEqual(pushTarget)
   })
 
   it('waits for branch confirmation before linking a terminal PR URL for a known push target', async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -67,6 +67,7 @@ const WORKTREE_REFRESH_CONCURRENCY = 5
 const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
+const hostedReviewPushTargetLookupsInFlight = new Set<string>()
 
 async function mapReposForWorktreeRefresh<T>(
   repos: readonly { id: string }[],
@@ -924,7 +925,7 @@ async function persistWorktreeMeta(
   )
 }
 
-async function resolveLinkedPrPushTarget(
+async function resolveGitHubReviewPushTarget(
   settings: AppState['settings'],
   repoId: string,
   prNumber: number
@@ -952,6 +953,57 @@ async function resolveLinkedPrPushTarget(
     )
     return undefined
   }
+}
+
+async function resolveGitLabReviewPushTarget(
+  settings: AppState['settings'],
+  repoId: string,
+  mrIid: number
+): Promise<GitPushTarget | undefined> {
+  try {
+    const target = getActiveRuntimeTarget(settings)
+    const result =
+      target.kind === 'local'
+        ? await window.api.worktrees.resolveMrBase({ repoId, mrIid })
+        : await callRuntimeRpc<
+            | { baseBranch: string; compareBaseRef?: string; pushTarget?: GitPushTarget }
+            | {
+                error: string
+              }
+          >(target, 'worktree.resolveMrBase', { repo: repoId, mrIid }, { timeoutMs: 30_000 })
+    if ('error' in result) {
+      console.warn(`Failed to resolve push target for MR !${mrIid}: ${result.error}`)
+      return undefined
+    }
+    return result.pushTarget
+  } catch (error) {
+    console.warn(
+      `Failed to resolve push target for MR !${mrIid}:`,
+      error instanceof Error ? error.message : error
+    )
+    return undefined
+  }
+}
+
+function getHostedReviewPushTargetLookup(worktree: Worktree): {
+  key: string
+  resolve: (settings: AppState['settings']) => Promise<GitPushTarget | undefined>
+} | null {
+  if (typeof worktree.linkedPR === 'number' && Number.isFinite(worktree.linkedPR)) {
+    const prNumber = worktree.linkedPR
+    return {
+      key: `${worktree.id}:github:${prNumber}`,
+      resolve: (settings) => resolveGitHubReviewPushTarget(settings, worktree.repoId, prNumber)
+    }
+  }
+  if (typeof worktree.linkedGitLabMR === 'number' && Number.isFinite(worktree.linkedGitLabMR)) {
+    const mrIid = worktree.linkedGitLabMR
+    return {
+      key: `${worktree.id}:gitlab:${mrIid}`,
+      resolve: (settings) => resolveGitLabReviewPushTarget(settings, worktree.repoId, mrIid)
+    }
+  }
+  return null
 }
 
 // Every worktree-id-keyed store map the rename path re-keys on a folder move, so a
@@ -2402,7 +2454,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       existingWorktree &&
       existingWorktree.linkedPR !== linkedPrForPushTarget &&
       !existingWorktree.pushTarget
-        ? await resolveLinkedPrPushTarget(
+        ? await resolveGitHubReviewPushTarget(
             settingsForRepoOwner(get(), existingWorktree.repoId),
             existingWorktree.repoId,
             linkedPrForPushTarget
@@ -2563,6 +2615,37 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       }
       console.error('Failed to update worktree meta:', err)
       void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+    }
+  },
+
+  ensureHostedReviewPushTarget: async (worktreeId) => {
+    const worktree = get().getKnownWorktreeById(worktreeId)
+    if (!worktree || worktree.pushTarget) {
+      return
+    }
+    const lookup = getHostedReviewPushTargetLookup(worktree)
+    if (!lookup || hostedReviewPushTargetLookupsInFlight.has(lookup.key)) {
+      return
+    }
+    hostedReviewPushTargetLookupsInFlight.add(lookup.key)
+    try {
+      const resolvedPushTarget = await lookup.resolve(settingsForRepoOwner(get(), worktree.repoId))
+      if (!resolvedPushTarget) {
+        return
+      }
+      const current = get().getKnownWorktreeById(worktreeId)
+      if (!current || current.pushTarget) {
+        return
+      }
+      const currentLookup = getHostedReviewPushTargetLookup(current)
+      if (currentLookup?.key !== lookup.key) {
+        return
+      }
+      // Why: old linked-review worktrees can lose metadata while their branch
+      // tracks a helper ref; restoring the review head target keeps push/status aligned.
+      await get().updateWorktreeMeta(worktreeId, { pushTarget: resolvedPushTarget })
+    } finally {
+      hostedReviewPushTargetLookupsInFlight.delete(lookup.key)
     }
   },
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -920,7 +920,10 @@ async function persistWorktreeMeta(
   await callRuntimeRpc(
     target,
     'worktree.set',
-    { worktree: toRuntimeWorktreeSelector(worktreeId), ...updates },
+    {
+      worktree: toRuntimeWorktreeSelector(worktreeId),
+      ...encodePushTargetClearForRuntimeRpc(updates)
+    },
     { timeoutMs: 15_000 }
   )
 }
@@ -989,21 +992,104 @@ function getHostedReviewPushTargetLookup(worktree: Worktree): {
   key: string
   resolve: (settings: AppState['settings']) => Promise<GitPushTarget | undefined>
 } | null {
-  if (typeof worktree.linkedPR === 'number' && Number.isFinite(worktree.linkedPR)) {
+  const hostScope = worktree.hostId ?? ''
+  if (isPositiveHostedReviewNumber(worktree.linkedPR)) {
     const prNumber = worktree.linkedPR
     return {
-      key: `${worktree.id}:github:${prNumber}`,
+      key: `${worktree.id}:${hostScope}:github:${prNumber}`,
       resolve: (settings) => resolveGitHubReviewPushTarget(settings, worktree.repoId, prNumber)
     }
   }
-  if (typeof worktree.linkedGitLabMR === 'number' && Number.isFinite(worktree.linkedGitLabMR)) {
+  if (isPositiveHostedReviewNumber(worktree.linkedGitLabMR)) {
     const mrIid = worktree.linkedGitLabMR
     return {
-      key: `${worktree.id}:gitlab:${mrIid}`,
+      key: `${worktree.id}:${hostScope}:gitlab:${mrIid}`,
       resolve: (settings) => resolveGitLabReviewPushTarget(settings, worktree.repoId, mrIid)
     }
   }
   return null
+}
+
+function isPositiveHostedReviewNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+type HostedReviewLinkKey =
+  | 'linkedPR'
+  | 'linkedGitLabMR'
+  | 'linkedBitbucketPR'
+  | 'linkedAzureDevOpsPR'
+  | 'linkedGiteaPR'
+
+const HOSTED_REVIEW_LINK_KEYS: readonly HostedReviewLinkKey[] = [
+  'linkedPR',
+  'linkedGitLabMR',
+  'linkedBitbucketPR',
+  'linkedAzureDevOpsPR',
+  'linkedGiteaPR'
+]
+
+function getPositiveHostedReviewLinkUpdateKey(
+  updates: Partial<WorktreeMeta>
+): HostedReviewLinkKey | null {
+  for (const key of HOSTED_REVIEW_LINK_KEYS) {
+    if (isPositiveHostedReviewNumber(updates[key])) {
+      return key
+    }
+  }
+  return null
+}
+
+function clearOlderHostedReviewLinksForReplacement(
+  updates: Partial<WorktreeMeta>,
+  existingWorktree: Worktree
+): Partial<WorktreeMeta> {
+  const replacementKey = getPositiveHostedReviewLinkUpdateKey(updates)
+  if (!replacementKey) {
+    return updates
+  }
+  let normalized = updates
+  for (const key of HOSTED_REVIEW_LINK_KEYS) {
+    if (key === replacementKey || existingWorktree[key] == null) {
+      continue
+    }
+    // Why: one branch can only push to one hosted-review head; keeping older
+    // provider links lets stale metadata win the target lookup after replacement.
+    normalized = normalized === updates ? { ...updates } : normalized
+    normalized[key] = null
+  }
+  return normalized
+}
+
+function getHostedReviewLinkForMetaRefresh(
+  updates: Partial<WorktreeMeta>,
+  existingWorktree: Worktree | undefined,
+  key: HostedReviewLinkKey
+): number | null {
+  return Object.prototype.hasOwnProperty.call(updates, key)
+    ? (updates[key] ?? null)
+    : (existingWorktree?.[key] ?? null)
+}
+
+function hasExplicitPushTargetClear(updates: Partial<WorktreeMeta>): boolean {
+  return (
+    Object.prototype.hasOwnProperty.call(updates, 'pushTarget') && updates.pushTarget === undefined
+  )
+}
+
+type RuntimeWorktreeMetaUpdates = Omit<Partial<WorktreeMeta>, 'pushTarget'> & {
+  pushTarget?: GitPushTarget | null
+}
+
+function encodePushTargetClearForRuntimeRpc(
+  updates: Partial<WorktreeMeta>
+): RuntimeWorktreeMetaUpdates {
+  if (!hasExplicitPushTargetClear(updates)) {
+    return updates
+  }
+  // Why: remote runtime RPC is JSON-shaped and drops undefined fields, so use
+  // null as the wire-only signal for clearing persisted pushTarget metadata.
+  return { ...updates, pushTarget: null }
 }
 
 // Every worktree-id-keyed store map the rename path re-keys on a folder move, so a
@@ -2441,37 +2527,55 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       }
       return
     }
+    const normalizedUpdates = existingWorktree
+      ? clearOlderHostedReviewLinksForReplacement(updates, existingWorktree)
+      : updates
     // Why: manual PR linking only supplies the PR number. Resolve the PR head
     // branch here so Push targets the review branch, but don't repeat that
     // network lookup for no-op linkedPR metadata saves.
-    const linkedPrForPushTarget =
-      typeof updates.linkedPR === 'number' && Number.isFinite(updates.linkedPR)
-        ? updates.linkedPR
-        : null
+    const linkedPrForPushTarget = isPositiveHostedReviewNumber(normalizedUpdates.linkedPR)
+      ? normalizedUpdates.linkedPR
+      : null
     const resolvedPushTarget =
       linkedPrForPushTarget !== null &&
-      updates.pushTarget === undefined &&
+      normalizedUpdates.pushTarget === undefined &&
       existingWorktree &&
       existingWorktree.linkedPR !== linkedPrForPushTarget &&
       !existingWorktree.pushTarget
         ? await resolveGitHubReviewPushTarget(
-            settingsForRepoOwner(get(), existingWorktree.repoId),
+            settingsForWorktreeOwner(get(), worktreeId),
             existingWorktree.repoId,
             linkedPrForPushTarget
           )
         : undefined
+    const existingHostedReviewPushTargetLookup = existingWorktree
+      ? getHostedReviewPushTargetLookup(existingWorktree)
+      : null
+    const nextHostedReviewPushTargetLookup = existingWorktree
+      ? getHostedReviewPushTargetLookup({ ...existingWorktree, ...normalizedUpdates })
+      : null
+    // Why: a pushTarget derived from one linked review must not keep steering
+    // pushes after that review is unlinked or replaced by another provider/id.
+    const shouldClearStaleHostedReviewPushTarget =
+      Boolean(existingWorktree?.pushTarget) &&
+      normalizedUpdates.pushTarget === undefined &&
+      resolvedPushTarget === undefined &&
+      existingHostedReviewPushTargetLookup !== null &&
+      existingHostedReviewPushTargetLookup.key !== nextHostedReviewPushTargetLookup?.key
     const worktreeForUpdate = get().getKnownWorktreeById(worktreeId)
     if (shouldApplyUpdate && !shouldApplyUpdate(worktreeForUpdate)) {
       return
     }
     const shouldRefreshHostedReview =
-      (updates.linkedPR === null && worktreeForUpdate?.linkedPR !== null) ||
-      (updates.linkedGitLabMR === null && (worktreeForUpdate?.linkedGitLabMR ?? null) !== null) ||
-      (updates.linkedBitbucketPR === null &&
+      (normalizedUpdates.linkedPR === null && worktreeForUpdate?.linkedPR !== null) ||
+      (normalizedUpdates.linkedGitLabMR === null &&
+        (worktreeForUpdate?.linkedGitLabMR ?? null) !== null) ||
+      (normalizedUpdates.linkedBitbucketPR === null &&
         (worktreeForUpdate?.linkedBitbucketPR ?? null) !== null) ||
-      (updates.linkedAzureDevOpsPR === null &&
+      (normalizedUpdates.linkedAzureDevOpsPR === null &&
         (worktreeForUpdate?.linkedAzureDevOpsPR ?? null) !== null) ||
-      (updates.linkedGiteaPR === null && (worktreeForUpdate?.linkedGiteaPR ?? null) !== null)
+      (normalizedUpdates.linkedGiteaPR === null &&
+        (worktreeForUpdate?.linkedGiteaPR ?? null) !== null)
     const reviewRepo = shouldRefreshHostedReview
       ? get().repos.find((repo) => repo.id === worktreeForUpdate?.repoId)
       : undefined
@@ -2483,8 +2587,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     // ranking even though the user just touched it. Bumping the timestamp
     // keeps the recency signal fresh so the worktree holds its position.
     const targetEnriched = resolvedPushTarget
-      ? { ...updates, pushTarget: resolvedPushTarget }
-      : updates
+      ? { ...normalizedUpdates, pushTarget: resolvedPushTarget }
+      : shouldClearStaleHostedReviewPushTarget
+        ? { ...normalizedUpdates, pushTarget: undefined }
+        : normalizedUpdates
     const renameCleared =
       'displayName' in targetEnriched
         ? {
@@ -2587,24 +2693,36 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     try {
       await persistWorktreeMeta(settingsForWorktreeOwner(get(), worktreeId), worktreeId, enriched)
       if (reviewRepo && reviewBranch && typeof get().fetchHostedReviewForBranch === 'function') {
-        // Why: the old cache entry may have been populated solely by linkedPR.
-        // Force a no-linked refetch so an in-flight linked lookup cannot keep
-        // showing the manually removed PR.
+        // Why: the old cache entry may have been populated by the previous
+        // provider link. Refetch against the post-update links so stale lookups
+        // cannot keep showing the removed review.
         void get().fetchHostedReviewForBranch(reviewRepo.path, reviewBranch, {
           repoId: reviewRepo.id,
-          linkedGitHubPR: null,
-          linkedGitLabMR:
-            updates.linkedGitLabMR === null ? null : (worktreeForUpdate?.linkedGitLabMR ?? null),
-          linkedBitbucketPR:
-            updates.linkedBitbucketPR === null
-              ? null
-              : (worktreeForUpdate?.linkedBitbucketPR ?? null),
-          linkedAzureDevOpsPR:
-            updates.linkedAzureDevOpsPR === null
-              ? null
-              : (worktreeForUpdate?.linkedAzureDevOpsPR ?? null),
-          linkedGiteaPR:
-            updates.linkedGiteaPR === null ? null : (worktreeForUpdate?.linkedGiteaPR ?? null),
+          linkedGitHubPR: getHostedReviewLinkForMetaRefresh(
+            targetEnriched,
+            worktreeForUpdate,
+            'linkedPR'
+          ),
+          linkedGitLabMR: getHostedReviewLinkForMetaRefresh(
+            targetEnriched,
+            worktreeForUpdate,
+            'linkedGitLabMR'
+          ),
+          linkedBitbucketPR: getHostedReviewLinkForMetaRefresh(
+            targetEnriched,
+            worktreeForUpdate,
+            'linkedBitbucketPR'
+          ),
+          linkedAzureDevOpsPR: getHostedReviewLinkForMetaRefresh(
+            targetEnriched,
+            worktreeForUpdate,
+            'linkedAzureDevOpsPR'
+          ),
+          linkedGiteaPR: getHostedReviewLinkForMetaRefresh(
+            targetEnriched,
+            worktreeForUpdate,
+            'linkedGiteaPR'
+          ),
           force: true
         })
       }
@@ -2629,7 +2747,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     }
     hostedReviewPushTargetLookupsInFlight.add(lookup.key)
     try {
-      const resolvedPushTarget = await lookup.resolve(settingsForRepoOwner(get(), worktree.repoId))
+      const resolvedPushTarget = await lookup.resolve(settingsForWorktreeOwner(get(), worktreeId))
       if (!resolvedPushTarget) {
         return
       }

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -1654,6 +1654,48 @@ describe('web worktree preload API', () => {
       }
     ])
   })
+
+  it('encodes explicit push target clears for runtime worktree updates', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: {
+              worktree: { id: 'repo-1::/workspace/review', path: '/workspace/review' }
+            },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await globals.window.api.worktrees.updateMeta({
+      worktreeId: 'repo-1::/workspace/review',
+      updates: { linkedPR: null, pushTarget: undefined }
+    })
+
+    expect(runtimeCalls).toEqual([
+      {
+        method: 'worktree.set',
+        params: {
+          worktree: 'id:repo-1::/workspace/review',
+          linkedPR: null,
+          pushTarget: null
+        }
+      }
+    ])
+  })
 })
 
 describe('web file preload API', () => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1203,13 +1203,19 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         branchName,
         expectedHead
       }),
-    updateMeta: async ({ worktreeId, updates }) =>
-      (
+    updateMeta: async ({ worktreeId, updates }) => {
+      const rpcUpdates =
+        Object.prototype.hasOwnProperty.call(updates, 'pushTarget') &&
+        updates.pushTarget === undefined
+          ? { ...updates, pushTarget: null }
+          : updates
+      return (
         await callRuntimeResult<{ worktree: Worktree }>('worktree.set', {
           worktree: toRuntimeWorktreeSelector(worktreeId),
-          ...updates
+          ...rpcUpdates
         })
-      ).worktree,
+      ).worktree
+    },
     listLineage: async () =>
       await callRuntimeResult<{
         lineage: Record<string, WorktreeLineage>


### PR DESCRIPTION
## Summary

Clears stale git push targets when unlinking or replacing hosted reviews (GitHub PRs / GitLab MRs), and dynamically resolves push targets for linked hosted reviews when navigating branches in Source Control.

- **RPC & Runtime updates:** Allowed `pushTarget` metadata to be nullable in worktree schemas. Handled explicit `null` to remove/clear the persisted push target in `updateManagedWorktreeMeta`.
- **Source Control UI helpers:** Introduced robust utility functions (`source-control-hosted-review-push-target.ts`) to manage, validate, and query hosted review push targets.
- **Active hydration:** Added a React effect to call `ensureHostedReviewPushTarget` to automatically resolve and update missing review push targets.
- **State Slice updates:** Added `ensureHostedReviewPushTarget` and implemented cleanup of `pushTarget` inside `updateWorktreeMeta` when unlinking or transitioning between PRs/MRs.
- **Input validation:** Hardened GitHub link parsing to reject non-positive/zero ID references (`"0"`, `"#0"`).

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

*Evidence of tests:* Unit tests were added and updated in `worktrees.test.ts`, `worktree.test.ts`, `github-links.test.ts`, and a new dedicated unit test file `source-control-hosted-review-push-target.test.ts` was added.

## AI Review Report

The code review confirmed that resolving review heads or push targets on different git providers (GitHub and GitLab) are cleanly handled under runtime checks.
Cross-platform compatibility was checked, verifying path handling uses standard APIs and does not assume specific path separators. Shortcuts or Electron-specific platform differences are not affected as these changes reside strictly within the runtime RPC schemas, source control state store, link parser, and sidebar components.

## Security Audit

A basic security audit verified:
- **Input Handling**: Hardened `parseGitHubIssueOrPRNumber` and `parseGitHubIssueOrPRLink` to reject non-positive IDs (`"0"` and below).
- **RPC & State Boundaries**: `updateManagedWorktreeMeta` selectively handles the clearing of `pushTarget` avoiding arbitrary object pollution, using explicit `null` checks. No unsafe shell or command execution was added.

## Notes

No platform-specific regressions are expected; the changes are cross-platform compatible and respect workspace configurations across SSH or local execution.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6092">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->