### PR TITLE
Use host-qualified worktree identities

### DIFF
--- a/docs/reference/remote-repo-project-identity-notes.md
+++ b/docs/reference/remote-repo-project-identity-notes.md
@@ -1,0 +1,115 @@
+# Remote Repo And Project Identity Notes
+
+## Current Evidence
+
+As of this branch review, we have not proven a current clean user/API flow that creates the same `Repo.id` on two different hosts.
+
+Fresh repo creation paths mint new UUID-backed repo ids:
+
+- Local add/import/clone creates `Repo.id` with `randomUUID()`.
+- SSH add/import/clone also creates `Repo.id` with `randomUUID()`.
+- Remote Orca Server runtime RPC methods for `repo.add`, `repo.create`, and `repo.clone` do not accept caller-supplied repo ids; the runtime creates the repo id.
+- `projectHostSetup.setupExistingFolder` routes through the same repo creation paths.
+- `projectHostSetup.create` can create an independent setup id, but it does not create a `Repo` row and keeps `repoId: ''`.
+
+Therefore, a normal flow like "add the same GitHub repo on local and on a remote server" should produce different repo ids.
+
+## What The Existing Fix Stack Assumes
+
+PRs #6030 and #6031 target the state shape where multiple hosts expose repo rows with the same `Repo.id`, for example:
+
+```ts
+[
+  { id: 'same-repo', path: '/Users/alice/orca', executionHostId: 'local' },
+  { id: 'same-repo', path: '/srv/orca', executionHostId: 'runtime:env-1' }
+]
+```
+
+The current code can represent that shape, and some renderer paths already key repo rows by `(hostId, repoId)`. But the creation path for that shape is not established by the current add/import/clone code. Plausible sources are copied, restored, synced, seeded, or older persisted Remote Orca Server state, but those are not the same as a proven current product flow.
+
+The precise rationale should be:
+
+> Remote Orca Server state is an external persisted authority. If duplicate repo ids are allowed or observed across hosts, physical repo and worktree state must be keyed by host as well as repo id. Without that, bare-`repoId` logic can mutate, remove, or merge the wrong host's state.
+
+It should not be stated as:
+
+> Normal independent multi-host repo setup definitely creates duplicate repo ids.
+
+We have not proven that.
+
+## Repo And Project Model On Main
+
+`Repo`, `Project`, and `ProjectHostSetup` are already distinct concepts on `main`, but the model is transitional.
+
+- `Repo` is the concrete repo record/setup.
+- `Project` is the logical project and has `sourceRepoIds`.
+- `ProjectHostSetup` links a project to a host and, when repo-backed, to a `repoId`.
+
+The compatibility projection derives projects and setups from repos:
+
+```text
+GitHub identity present:
+  projectId = github:<owner>/<repo>
+
+No recognized provider identity:
+  projectId = repo:<repoId>
+```
+
+That means GitHub-backed repos can be many-to-one:
+
+```text
+repoId A -> projectId github:stablyai/orca
+repoId B -> projectId github:stablyai/orca
+```
+
+Fallback repos remain effectively one-to-one:
+
+```text
+repoId A -> projectId repo:<repoId A>
+```
+
+## What #6030 Was Addressing
+
+#6030 made repo-row operations host-aware for the duplicate-`Repo.id` state shape:
+
+- repo refresh should not replace same-id repos from sibling hosts;
+- repo update should target the active/requested host row;
+- repo removal should remove only the intended host row;
+- repo reorder should preserve host-specific rows;
+- runtime-owner lookup should choose the host-specific row.
+
+This is about repo rows.
+
+## What #6031 Was Addressing
+
+#6031 extended the same idea to project-host setup and worktree state:
+
+- project compatibility should not erase another host's project membership;
+- `projectHostSetups` should not collapse by bare repo id;
+- worktree identity should include host context, because legacy worktree ids are `repoId::path`.
+
+This matters if two hosts can expose the same repo id and same path, because both would otherwise produce the same legacy worktree id:
+
+```text
+same-repo::/workspace/orca
+```
+
+The host-qualified worktree key avoids that by including:
+
+```text
+hostId + repoId + path
+```
+
+## Open Decision
+
+Before treating the richer host-qualified worktree id migration as mandatory, we should decide which product invariant we want:
+
+1. `Repo.id` is globally unique across every connected host/runtime.
+   - Then duplicate-id handling is defensive hardening.
+   - The larger worktree id migration may be more than the proven current risk requires.
+
+2. `Repo.id` is only unique inside one host/runtime store.
+   - Then `(hostId, repoId)` is the correct physical repo identity.
+   - Host-qualified worktree ids are the correct physical worktree identity.
+
+The current code mostly mints UUID repo ids, but it also contains host-aware duplicate-id handling. The product contract should be made explicit.

--- a/docs/worktree-host-identity-rollout-validation.md
+++ b/docs/worktree-host-identity-rollout-validation.md
@@ -5,10 +5,12 @@
 Use host-qualified worktree IDs so the same repo/path on different execution hosts cannot collide:
 
 ```text
-orca-worktree://v1?hostId=<host>&repoId=<repo>&path=<absolute-path>
+orca-worktree://v1?hostId=<url-encoded-host>&repoId=<url-encoded-repo>&path=<url-encoded-absolute-path>
 ```
 
 Legacy IDs (`repoId::path`) remain accepted at public and persisted boundaries. Runtime and newly written state should resolve to canonical host-qualified IDs.
+
+All canonical query values are URL-encoded. For example, `/absolute/path` is stored as `path=%2Fabsolute%2Fpath`.
 
 ## Compatibility Rules
 

--- a/docs/worktree-host-identity-rollout-validation.md
+++ b/docs/worktree-host-identity-rollout-validation.md
@@ -1,0 +1,54 @@
+# Worktree Host Identity Rollout Validation
+
+## Goal
+
+Use host-qualified worktree IDs so the same repo/path on different execution hosts cannot collide:
+
+```text
+orca-worktree://v1?hostId=<host>&repoId=<repo>&path=<absolute-path>
+```
+
+Legacy IDs (`repoId::path`) remain accepted at public and persisted boundaries. Runtime and newly written state should resolve to canonical host-qualified IDs.
+
+## Compatibility Rules
+
+- New worktree IDs are canonical and include `hostId`, `repoId`, and `path`.
+- Legacy `repoId::path` IDs are parsed and accepted for existing sessions, metadata, cleanup requests, terminal selectors, browser scopes, and runtime CLI/mobile calls.
+- When Orca can prove a legacy ID maps to exactly one canonical repo/path/host, it returns and stores the canonical ID.
+- Existing legacy metadata and lineage are read through alias lookups before stamping new canonical metadata.
+- Old daemon PTY ids may remain legacy as PTY ids, but their owning `worktreeId` is canonicalized when the repo/path match is known.
+- Teardown sweeps both canonical and legacy PTY/session prefixes so old sessions are still killed during removal.
+
+## Risks Addressed
+
+- Local and SSH worktrees with the same repo/path no longer share one ID.
+- Legacy metadata remains visible during SSH reconnect/disconnected fallback.
+- Legacy terminal/session ids do not create duplicate runtime buckets after migration.
+- Cleanup preflight and skip-git deferrals accept both old and new ids.
+- Runtime lineage records seeded under legacy ids still attach to canonical worktree rows.
+
+## Automated Evidence
+
+Passing after fixes:
+
+- `pnpm exec vitest run src/shared/worktree-id.test.ts src/main/daemon/pty-session-id.test.ts src/main/ipc/worktrees.test.ts`
+- `pnpm exec vitest run src/main/persistence.test.ts -t "migrateWorktreeIdentity|host-partitioned workspace sessions"`
+- `pnpm exec vitest run src/main/ipc/workspace-cleanup.test.ts src/main/ipc/remote-workspace.test.ts src/shared/remote-workspace-session-projection.test.ts src/main/memory/hydrate-local-pty-registry.test.ts`
+- `pnpm exec vitest run src/main/runtime/orca-runtime.test.ts -t "worktree|ManagedWorktree|listManagedWorktrees|createManagedWorktree"`
+- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts -t "migrateWorktreeIdentity"`
+- `pnpm run typecheck:node`
+- `pnpm run typecheck:web`
+- targeted `oxlint`
+- `git diff --check`
+
+Node engine warning observed locally: repo wants Node 24; validation environment is Node v26.
+
+## Electron Evidence
+
+- Launched Electron with an isolated user data directory.
+- Verified the app identity matched this worktree before interacting.
+- Added a temp git repo and created an Orca-managed worktree through the app.
+- Confirmed the visible sidebar rendered the created workspace.
+- Confirmed store state used a canonical `orca-worktree://v1?...hostId=local...` id.
+- Removed the created workspace through a legacy `repoId::path` id and verified the canonical row disappeared.
+- Shut down only the Electron process launched for validation.

--- a/src/main/automations/run-target-resolution.test.ts
+++ b/src/main/automations/run-target-resolution.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import type { Automation } from '../../shared/automations-types'
+import type { ProjectHostSetup, Repo } from '../../shared/types'
+import type { Store } from '../persistence'
+import { resolveAutomationRunTarget } from './run-target-resolution'
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    badgeColor: '#000',
+    addedAt: 1,
+    ...overrides
+  }
+}
+
+function makeSetup(overrides: Partial<ProjectHostSetup> = {}): ProjectHostSetup {
+  return {
+    id: 'shared-setup',
+    projectId: 'project-1',
+    hostId: 'local',
+    repoId: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+  return {
+    id: 'automation-1',
+    name: 'Nightly',
+    prompt: 'Run checks',
+    precheck: null,
+    agentId: 'codex',
+    projectId: 'repo-1',
+    executionTargetType: 'local',
+    executionTargetId: 'local',
+    schedulerOwner: 'local_host_service',
+    workspaceMode: 'new_per_run',
+    workspaceId: null,
+    baseBranch: null,
+    reuseSession: false,
+    timezone: 'UTC',
+    rrule: 'FREQ=DAILY',
+    dtstart: 1,
+    enabled: true,
+    nextRunAt: 2,
+    missedRunPolicy: 'run_once_within_grace',
+    missedRunGraceMinutes: 720,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+describe('resolveAutomationRunTarget', () => {
+  it('matches repeated setup ids by the saved host context', () => {
+    const localRepo = makeRepo({ path: '/local/repo' })
+    const runtimeRepo = makeRepo({ path: '/runtime/repo', executionHostId: 'runtime:gpu' })
+    const store = {
+      getProjectHostSetups: () => [
+        makeSetup({ hostId: 'local', path: '/local/repo' }),
+        makeSetup({ hostId: 'runtime:gpu', path: '/runtime/repo' })
+      ],
+      getRepos: () => [localRepo, runtimeRepo]
+    } as Store
+    const automation = makeAutomation({
+      schedulerOwner: 'remote_host_service',
+      runContext: {
+        kind: 'workspace-run',
+        projectId: 'project-1',
+        hostId: 'runtime:gpu',
+        projectHostSetupId: 'shared-setup',
+        repoId: 'repo-1',
+        path: '/runtime/repo'
+      }
+    })
+
+    expect(
+      resolveAutomationRunTarget(store, automation, { allowRemoteHostScheduling: true })
+    ).toMatchObject({
+      ok: true,
+      cwd: '/runtime/repo',
+      repo: runtimeRepo,
+      setup: expect.objectContaining({ hostId: 'runtime:gpu' })
+    })
+  })
+})

--- a/src/main/automations/run-target-resolution.ts
+++ b/src/main/automations/run-target-resolution.ts
@@ -51,8 +51,22 @@ export function resolveAutomationRunTarget(
 
   const setup = store
     .getProjectHostSetups()
-    .find((candidate) => candidate.id === context.projectHostSetupId)
+    .find(
+      (candidate) =>
+        candidate.id === context.projectHostSetupId &&
+        candidate.projectId === context.projectId &&
+        candidate.hostId === context.hostId &&
+        candidate.repoId === context.repoId
+    )
   if (!setup) {
+    if (
+      store.getProjectHostSetups().some((candidate) => candidate.id === context.projectHostSetupId)
+    ) {
+      return {
+        ok: false,
+        error: 'Automation run target no longer matches the selected project host setup.'
+      }
+    }
     return {
       ok: false,
       error: 'Project is not set up on the selected automation host anymore.'
@@ -75,7 +89,12 @@ export function resolveAutomationRunTarget(
     }
   }
 
-  const repo = store.getRepo(context.repoId)
+  const repo = store
+    .getRepos()
+    .find(
+      (candidate) =>
+        candidate.id === context.repoId && getRepoExecutionHostId(candidate) === context.hostId
+    )
   if (!repo) {
     return {
       ok: false,

--- a/src/main/claude-usage/scanner.ts
+++ b/src/main/claude-usage/scanner.ts
@@ -5,6 +5,7 @@ import { realpath, readdir, stat } from 'fs/promises'
 import { createReadStream } from 'fs'
 import { createInterface } from 'readline'
 import type { Repo } from '../../shared/types'
+import { getUsageRepoKey } from '../usage-worktree-metadata'
 import type {
   ClaudeUsageAttributedTurn,
   ClaudeUsageDailyAggregate,
@@ -671,7 +672,7 @@ export function createWorktreeRefs(
 ): ClaudeUsageWorktreeRef[] {
   const refs: ClaudeUsageWorktreeRef[] = []
   for (const repo of repos) {
-    for (const worktree of worktreesByRepo.get(repo.id) ?? []) {
+    for (const worktree of worktreesByRepo.get(getUsageRepoKey(repo)) ?? []) {
       refs.push({
         repoId: repo.id,
         worktreeId: worktree.worktreeId,

--- a/src/main/codex-usage/scanner.ts
+++ b/src/main/codex-usage/scanner.ts
@@ -5,6 +5,7 @@ import { realpath, readdir, stat } from 'fs/promises'
 import { createInterface } from 'readline'
 import type { Repo } from '../../shared/types'
 import { areWorktreePathsEqual } from '../ipc/worktree-logic'
+import { getUsageRepoKey } from '../usage-worktree-metadata'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { getLegacyCopiedCodexSessionBridgeScanPreference } from '../codex/codex-session-bridge'
 import { canonicalizeUsageWorktreePaths } from '../usage-worktree-canonicalizer'
@@ -1070,7 +1071,7 @@ export function createWorktreeRefs(
 ): CodexUsageWorktreeRef[] {
   const refs: CodexUsageWorktreeRef[] = []
   for (const repo of repos) {
-    for (const worktree of worktreesByRepo.get(repo.id) ?? []) {
+    for (const worktree of worktreesByRepo.get(getUsageRepoKey(repo)) ?? []) {
       refs.push({
         repoId: repo.id,
         worktreeId: worktree.worktreeId,

--- a/src/main/daemon/pty-session-id.test.ts
+++ b/src/main/daemon/pty-session-id.test.ts
@@ -125,6 +125,15 @@ describe('parsePtySessionId', () => {
     expect(parsePtySessionId(mintPtySessionId(wt))).toEqual({ worktreeId: wt })
   })
 
+  it('rejects malformed or non-canonical host-qualified worktree keys', () => {
+    expect(
+      parsePtySessionId('orca-worktree://v1?hostId=local&repoId=repo%ZZ&path=%2Fx@@deadbeef')
+    ).toEqual({ worktreeId: null })
+    expect(
+      parsePtySessionId('orca-worktree://v1?hostId=runtime:gpu&repoId=repo&path=/x@@deadbeef')
+    ).toEqual({ worktreeId: null })
+  })
+
   it('rejects bare UUIDs (no @@)', () => {
     expect(parsePtySessionId(mintPtySessionId())).toEqual({ worktreeId: null })
   })

--- a/src/main/daemon/pty-session-id.test.ts
+++ b/src/main/daemon/pty-session-id.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { makeWorktreeKey } from '../../shared/worktree-id'
 import { isSafePtySessionId, mintPtySessionId, parsePtySessionId } from './pty-session-id'
 
 const USER_DATA = '/tmp/orca-userdata'
@@ -38,6 +39,15 @@ describe('isSafePtySessionId', () => {
     // rejected `/` would break every real daemon spawn.
     const id = mintPtySessionId('repo-abc123::/Users/thebr/work/wt-1')
     expect(isSafePtySessionId(id, USER_DATA)).toBe(true)
+  })
+
+  it('accepts minted ids with host-qualified worktree keys', () => {
+    const worktreeId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: 'repo-abc123',
+      path: '/Users/thebr/work/wt-1'
+    })
+    expect(isSafePtySessionId(mintPtySessionId(worktreeId), USER_DATA)).toBe(true)
   })
 
   it('accepts caller-supplied path-shaped ids that stay inside userData', () => {
@@ -84,6 +94,15 @@ describe('isSafePtySessionId', () => {
 describe('parsePtySessionId', () => {
   it('round-trips a minted id back to its worktreeId', () => {
     const wt = 'repo-abc::/Users/me/wt/feature'
+    expect(parsePtySessionId(mintPtySessionId(wt))).toEqual({ worktreeId: wt })
+  })
+
+  it('round-trips a minted host-qualified worktree key back to its worktreeId', () => {
+    const wt = makeWorktreeKey({
+      hostId: 'runtime:gpu',
+      repoId: 'repo-abc',
+      path: '/srv/orca/worktree'
+    })
     expect(parsePtySessionId(mintPtySessionId(wt))).toEqual({ worktreeId: wt })
   })
 

--- a/src/main/daemon/pty-session-id.test.ts
+++ b/src/main/daemon/pty-session-id.test.ts
@@ -50,6 +50,16 @@ describe('isSafePtySessionId', () => {
     expect(isSafePtySessionId(mintPtySessionId(worktreeId), USER_DATA)).toBe(true)
   })
 
+  it('accepts deep host-qualified worktree keys', () => {
+    const worktreeId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: 'repo-abc123',
+      path: `/Users/thebr/work/${'deep/'.repeat(90)}wt-1`
+    })
+    expect(mintPtySessionId(worktreeId).length).toBeGreaterThan(512)
+    expect(isSafePtySessionId(mintPtySessionId(worktreeId), USER_DATA)).toBe(true)
+  })
+
   it('accepts caller-supplied path-shaped ids that stay inside userData', () => {
     expect(isSafePtySessionId('some-repo::/Users/me/wt/abc@@deadbeef', USER_DATA)).toBe(true)
   })
@@ -58,8 +68,8 @@ describe('isSafePtySessionId', () => {
     expect(isSafePtySessionId('', USER_DATA)).toBe(false)
   })
 
-  it('rejects ids longer than 512 characters', () => {
-    expect(isSafePtySessionId('a'.repeat(513), USER_DATA)).toBe(false)
+  it('rejects ids longer than the bounded safety limit', () => {
+    expect(isSafePtySessionId('a'.repeat(4097), USER_DATA)).toBe(false)
   })
 
   it('rejects ids containing a NUL byte', () => {
@@ -92,6 +102,15 @@ describe('isSafePtySessionId', () => {
 })
 
 describe('parsePtySessionId', () => {
+  it('rejects malformed canonical-looking ids instead of parsing them as legacy', () => {
+    expect(
+      parsePtySessionId('orca-worktree://v1?hostId=bogus&repoId=repo::x&path=%2Fy@@deadbeef')
+    ).toEqual({ worktreeId: null })
+    expect(
+      parsePtySessionId('orca-worktree://v2?hostId=local&repoId=repo::x&path=%2Fy@@deadbeef')
+    ).toEqual({ worktreeId: null })
+  })
+
   it('round-trips a minted id back to its worktreeId', () => {
     const wt = 'repo-abc::/Users/me/wt/feature'
     expect(parsePtySessionId(mintPtySessionId(wt))).toEqual({ worktreeId: wt })

--- a/src/main/daemon/pty-session-id.ts
+++ b/src/main/daemon/pty-session-id.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'crypto'
 import { isAbsolute, join, relative, resolve, sep } from 'path'
 import { PTY_SESSION_ID_SEPARATOR } from '../../shared/pty-session-id-format'
 
+const MAX_PTY_SESSION_ID_LENGTH = 4096
+
 // Why: re-exported here so main-side callers can keep importing
 // `parsePtySessionId` from this module (next to `mintPtySessionId`). The
 // implementation lives in `src/shared/` because the renderer-side merge
@@ -46,7 +48,9 @@ export function mintPtySessionId(worktreeId?: string): string {
  * without false positives on legitimate path-shaped ids.
  */
 export function isSafePtySessionId(id: string, userDataPath: string): boolean {
-  if (id.length === 0 || id.length > 512) {
+  // Why: canonical worktree IDs URL-encode absolute paths before being embedded
+  // in PTY session IDs. Keep a finite cap, but allow realistic deep paths.
+  if (id.length === 0 || id.length > MAX_PTY_SESSION_ID_LENGTH) {
     return false
   }
   if (id.includes('\0')) {

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -18,7 +18,12 @@ import type {
 } from '../../shared/remote-workspace-types'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { WorkspaceSessionState } from '../../shared/types'
-import { getRepoIdFromWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
+import {
+  getRepoIdFromWorktreeId,
+  makeRepoWorktreeKey,
+  splitWorktreeId
+} from '../../shared/worktree-id'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
 import { getRemoteWorkspaceNamespace } from './remote-workspace-namespace'
 import { registerRemoteWorkspaceNotificationHandler } from './remote-workspace-events'
 
@@ -224,6 +229,11 @@ function getExplicitHydratedTargetIds(value: unknown): Set<string> | null {
 }
 
 function targetForWorktree(store: Store, worktreeId: string): string | null {
+  const parsed = splitWorktreeId(worktreeId)
+  if (parsed?.hostId) {
+    const host = parseExecutionHostId(parsed.hostId)
+    return host?.kind === 'ssh' ? host.targetId : null
+  }
   const repoId = getRepoIdFromWorktreeId(worktreeId)
   return store.getRepo(repoId)?.connectionId ?? null
 }
@@ -248,11 +258,11 @@ function importSessionForTarget(
   return importRemoteWorkspaceSession(remote, {
     resolveWorktreeId: (worktreePath) => {
       for (const repo of repoById.values()) {
-        const candidate = `${repo.id}::${worktreePath}`
+        const candidate = makeRepoWorktreeKey(repo, worktreePath)
         // Main does not own the live worktree list for SSH repos, so resolve
         // against repo identity only. Renderer hydration later validates IDs
         // against its fetched worktree list before panes mount.
-        if (splitWorktreeId(candidate)) {
+        if (splitWorktreeId(candidate)?.hostId === getRepoExecutionHostId(repo)) {
           return candidate
         }
       }

--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -1709,9 +1709,13 @@ describe('repos:add + repos:clone', () => {
     })
 
     expect(result).toBe(updated)
-    expect(mockStore.updateRepo).toHaveBeenCalledWith(updated.id, {
-      worktreeBasePath: '../worktrees'
-    })
+    expect(mockStore.updateRepo).toHaveBeenCalledWith(
+      updated.id,
+      {
+        worktreeBasePath: '../worktrees'
+      },
+      undefined
+    )
     expect(prepareLocalWorktreeRootForRepoMock).toHaveBeenCalledWith(mockStore, updated)
     expect(invalidateAuthorizedRootsCacheMock).toHaveBeenCalled()
   })

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -720,6 +720,18 @@ const ProjectHostSetupCreateIpcArgs = z.object({
 
 const ProjectHostSetupUpdateIpcArgs = z.object({
   setupId: z.string().min(1),
+  hostId: z
+    .string()
+    .min(1)
+    .transform((value, ctx) => {
+      const hostId = normalizeExecutionHostId(value)
+      if (!hostId) {
+        ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+        return z.NEVER
+      }
+      return hostId
+    })
+    .optional(),
   updates: z.object({
     displayName: z.string().optional(),
     path: z.string().optional(),
@@ -734,7 +746,19 @@ const ProjectHostSetupUpdateIpcArgs = z.object({
 })
 
 const ProjectHostSetupDeleteIpcArgs = z.object({
-  setupId: z.string().min(1)
+  setupId: z.string().min(1),
+  hostId: z
+    .string()
+    .min(1)
+    .transform((value, ctx) => {
+      const hostId = normalizeExecutionHostId(value)
+      if (!hostId) {
+        ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+        return z.NEVER
+      }
+      return hostId
+    })
+    .optional()
 })
 
 const FolderWorkspaceLinkedTaskArgs = z

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -1883,8 +1883,12 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     }
   )
 
-  ipcMain.handle('repos:remove', async (_event, args: { repoId: string }) => {
-    store.removeProject(args.repoId)
+  ipcMain.handle('repos:remove', async (_event, args: { repoId: string; hostId?: string }) => {
+    const hostId = args.hostId ? normalizeExecutionHostId(args.hostId) : undefined
+    if (args.hostId && !hostId) {
+      throw new Error(`Invalid host ID: ${args.hostId}`)
+    }
+    store.removeProject(args.repoId, hostId ?? undefined)
     invalidateAuthorizedRootsCache()
     notifyReposChanged(mainWindow)
   })
@@ -1895,6 +1899,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
       _event,
       args: {
         repoId: string
+        hostId?: string
         updates: Partial<
           Pick<
             Repo,
@@ -2008,7 +2013,11 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
           updates.sourceControlAi = normalizedSourceControlAi
         }
       }
-      const updated = store.updateRepo(args.repoId, updates)
+      const hostId = args.hostId ? normalizeExecutionHostId(args.hostId) : undefined
+      if (args.hostId && !hostId) {
+        throw new Error(`Invalid host ID: ${args.hostId}`)
+      }
+      const updated = store.updateRepo(args.repoId, updates, hostId ?? undefined)
       if (updated) {
         if ('worktreeBasePath' in updates) {
           void prepareLocalWorktreeRootForRepo(store, updated)

--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -199,6 +199,10 @@ describe('workspace cleanup scan', () => {
 
   it('uses direct metadata lookup for focused disconnected remote preflight', async () => {
     const targetWorktreeId = 'repo-1::/remote/repo-feature'
+    const canonicalTargetWorktreeId = makeRepoWorktreeKey(
+      { ...REPO, connectionId: 'ssh-1' },
+      '/remote/repo-feature'
+    )
     const targetMeta: WorktreeMeta = {
       displayName: 'Remote Feature',
       comment: '',
@@ -229,7 +233,7 @@ describe('workspace cleanup scan', () => {
     expect(getAllWorktreeMeta).not.toHaveBeenCalled()
     expect(result.errors).toEqual([])
     expect(result.candidates[0]).toMatchObject({
-      worktreeId: targetWorktreeId,
+      worktreeId: canonicalTargetWorktreeId,
       path: '/remote/repo-feature',
       blockers: ['ssh-disconnected'],
       git: {
@@ -237,6 +241,114 @@ describe('workspace cleanup scan', () => {
         checkedAt: null
       }
     })
+  })
+
+  it('does not resolve ambiguous legacy focused targets across SSH hosts', async () => {
+    const targetMeta: WorktreeMeta = {
+      displayName: 'Remote Feature',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: NOW - 2 * 24 * 60 * 60 * 1000
+    }
+    const getWorktreeMeta = vi.fn(() => targetMeta)
+    const repos = [
+      { ...REPO, connectionId: 'ssh-1' },
+      { ...REPO, connectionId: 'ssh-2' }
+    ]
+    const store = {
+      getRepos: () => repos,
+      getWorktreeMeta,
+      getAllWorktreeMeta: () => ({})
+    } as unknown as Store
+
+    const result = await scanWorkspaceCleanup(store, {
+      worktreeId: 'repo-1::/remote/repo-feature'
+    })
+
+    expect(getWorktreeMeta).not.toHaveBeenCalled()
+    expect(result.errors).toEqual([])
+    expect(result.candidates).toEqual([])
+  })
+
+  it('uses canonical focused targets to select the exact SSH host', async () => {
+    const repos = [
+      { ...REPO, connectionId: 'ssh-1' },
+      { ...REPO, connectionId: 'ssh-2' }
+    ]
+    const targetWorktreeId = makeRepoWorktreeKey(repos[1], '/remote/repo-feature')
+    const targetMeta: WorktreeMeta = {
+      displayName: 'Remote Feature',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: NOW - 2 * 24 * 60 * 60 * 1000
+    }
+    const getWorktreeMeta = vi.fn((worktreeId: string) =>
+      worktreeId === targetWorktreeId ? targetMeta : undefined
+    )
+    const store = {
+      getRepos: () => repos,
+      getWorktreeMeta,
+      getAllWorktreeMeta: () => ({})
+    } as unknown as Store
+
+    const result = await scanWorkspaceCleanup(store, { worktreeId: targetWorktreeId })
+
+    expect(result.errors).toEqual([])
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0]).toMatchObject({
+      worktreeId: targetWorktreeId,
+      connectionId: 'ssh-2',
+      path: '/remote/repo-feature',
+      blockers: ['ssh-disconnected']
+    })
+  })
+
+  it('does not use ambiguous legacy metadata for canonical focused SSH targets', async () => {
+    const repos = [
+      { ...REPO, connectionId: 'ssh-1' },
+      { ...REPO, connectionId: 'ssh-2' }
+    ]
+    const worktreePath = '/remote/repo-feature'
+    const targetWorktreeId = makeRepoWorktreeKey(repos[1], worktreePath)
+    const legacyWorktreeId = `${REPO.id}::${worktreePath}`
+    const targetMeta: WorktreeMeta = {
+      displayName: 'Ambiguous Legacy Remote Feature',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: NOW - 2 * 24 * 60 * 60 * 1000
+    }
+    const getWorktreeMeta = vi.fn((worktreeId: string) =>
+      worktreeId === legacyWorktreeId ? targetMeta : undefined
+    )
+    const store = {
+      getRepos: () => repos,
+      getWorktreeMeta,
+      getAllWorktreeMeta: () => ({})
+    } as unknown as Store
+
+    const result = await scanWorkspaceCleanup(store, { worktreeId: targetWorktreeId })
+
+    expect(getWorktreeMeta).toHaveBeenCalledWith(legacyWorktreeId)
+    expect(result.errors).toEqual([])
+    expect(result.candidates).toEqual([])
   })
 
   it('scans connected remote workspaces through the SSH git provider', async () => {
@@ -273,6 +385,112 @@ describe('workspace cleanup scan', () => {
       selectedByDefault: true,
       reasons: ['idle-clean']
     })
+  })
+
+  it('uses matching host-stamped legacy metadata during connected remote scans', async () => {
+    const repos = [
+      { ...REPO, connectionId: 'ssh-1' },
+      { ...REPO, connectionId: 'ssh-2' }
+    ]
+    const provider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-feature',
+          head: 'abc123',
+          branch: 'refs/heads/feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      getStatus: vi.fn().mockResolvedValue({
+        entries: [],
+        conflictOperation: 'unknown',
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+      } satisfies GitStatusResult)
+    }
+    getSshGitProviderMock.mockReturnValue(provider)
+    const legacyMeta = {
+      displayName: 'Remote Legacy',
+      linkedPR: null,
+      linkedIssue: null,
+      lastActivityAt: NOW - 40 * 24 * 60 * 60 * 1000,
+      hostId: 'ssh:ssh-1'
+    }
+    const store = {
+      getRepos: () => repos,
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === 'repo-1::/remote/repo-feature' ? legacyMeta : undefined,
+      getAllWorktreeMeta: () => ({})
+    } as unknown as Store
+
+    const result = await scanWorkspaceCleanup(store)
+
+    expect(result.candidates[0]).toMatchObject({
+      worktreeId: makeRepoWorktreeKey(repos[0], '/remote/repo-feature'),
+      displayName: 'Remote Legacy',
+      connectionId: 'ssh-1'
+    })
+    expect(result.candidates[1]).toMatchObject({
+      worktreeId: makeRepoWorktreeKey(repos[1], '/remote/repo-feature'),
+      displayName: 'feature',
+      connectionId: 'ssh-2'
+    })
+  })
+
+  it('ignores hostless legacy metadata during ambiguous connected remote scans', async () => {
+    const repos = [
+      { ...REPO, connectionId: 'ssh-1' },
+      { ...REPO, connectionId: 'ssh-2' }
+    ]
+    const provider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-feature',
+          head: 'abc123',
+          branch: 'refs/heads/feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      getStatus: vi.fn().mockResolvedValue({
+        entries: [],
+        conflictOperation: 'unknown',
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+      } satisfies GitStatusResult)
+    }
+    getSshGitProviderMock.mockReturnValue(provider)
+    const store = {
+      getRepos: () => repos,
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === 'repo-1::/remote/repo-feature'
+          ? {
+              displayName: 'Ambiguous Legacy',
+              linkedPR: null,
+              linkedIssue: null,
+              isPinned: true,
+              lastActivityAt: NOW - 40 * 24 * 60 * 60 * 1000
+            }
+          : undefined,
+      getAllWorktreeMeta: () => ({})
+    } as unknown as Store
+
+    const result = await scanWorkspaceCleanup(store)
+
+    expect(result.candidates).toHaveLength(2)
+    expect(result.candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          worktreeId: makeRepoWorktreeKey(repos[0], '/remote/repo-feature'),
+          displayName: 'feature',
+          blockers: []
+        }),
+        expect.objectContaining({
+          worktreeId: makeRepoWorktreeKey(repos[1], '/remote/repo-feature'),
+          displayName: 'feature',
+          blockers: []
+        })
+      ])
+    )
   })
 
   it('skips connected remote workspaces that fail during broad scans', async () => {
@@ -340,6 +558,60 @@ describe('workspace cleanup scan', () => {
         checkedAt: null
       }
     })
+  })
+
+  it('ignores ambiguous legacy renderer git deferrals across SSH hosts', async () => {
+    const firstProvider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-feature',
+          head: 'abc123',
+          branch: 'refs/heads/feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      getStatus: vi.fn().mockResolvedValue({
+        entries: [],
+        conflictOperation: 'unknown',
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+      } satisfies GitStatusResult)
+    }
+    const secondProvider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-feature',
+          head: 'def456',
+          branch: 'refs/heads/feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      getStatus: vi.fn().mockResolvedValue({
+        entries: [],
+        conflictOperation: 'unknown',
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+      } satisfies GitStatusResult)
+    }
+    getSshGitProviderMock.mockImplementation((connectionId: string) =>
+      connectionId === 'ssh-1' ? firstProvider : secondProvider
+    )
+
+    const result = await scanWorkspaceCleanup(
+      makeStore({
+        repos: [
+          { ...REPO, connectionId: 'ssh-1' },
+          { ...REPO, connectionId: 'ssh-2' }
+        ]
+      }),
+      { skipGitWorktreeIds: ['repo-1::/remote/repo-feature'] }
+    )
+
+    expect(firstProvider.getStatus).toHaveBeenCalledWith('/remote/repo-feature')
+    expect(secondProvider.getStatus).toHaveBeenCalledWith('/remote/repo-feature')
+    expect(result.candidates).toHaveLength(2)
+    expect(result.candidates[0]?.git.clean).toBe(true)
+    expect(result.candidates[1]?.git.clean).toBe(true)
   })
 
   it('uses remote commit presence when a clean inactive workspace has no upstream', async () => {

--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -10,6 +10,7 @@ import type {
   Repo,
   WorktreeMeta
 } from '../../shared/types'
+import { makeRepoWorktreeKey } from '../../shared/worktree-id'
 
 const {
   listRepoWorktreesMock,
@@ -453,7 +454,7 @@ describe('workspace cleanup scan', () => {
     expect(result.errors).toEqual([])
     expect(result.candidates).toHaveLength(LARGE_WORKTREE_COUNT)
     expect(result.candidates[0]).toMatchObject({
-      worktreeId: 'repo-1::/repo-feature-0',
+      worktreeId: makeRepoWorktreeKey(REPO, '/repo-feature-0'),
       path: '/repo-feature-0',
       branch: 'feature-0',
       tier: 'review',
@@ -463,7 +464,7 @@ describe('workspace cleanup scan', () => {
       }
     })
     expect(result.candidates[LARGE_WORKTREE_COUNT - 1]).toMatchObject({
-      worktreeId: `repo-1::/repo-feature-${LARGE_WORKTREE_COUNT - 1}`,
+      worktreeId: makeRepoWorktreeKey(REPO, `/repo-feature-${LARGE_WORKTREE_COUNT - 1}`),
       path: `/repo-feature-${LARGE_WORKTREE_COUNT - 1}`,
       branch: `feature-${LARGE_WORKTREE_COUNT - 1}`
     })

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -618,12 +618,18 @@ function synthesizeDisconnectedSshCandidates(
 ): WorkspaceCleanupCandidate[] {
   const repoWorktreePrefix = `${repo.id}::`
   const repoHostId = getRepoExecutionHostId(repo)
-  const isRepoWorktreeId = (worktreeId: string): boolean => {
+  const isRepoWorktreeId = (worktreeId: string, meta?: WorktreeMeta): boolean => {
     const parsed = parseWorktreeKey(worktreeId)
     if (parsed) {
       return parsed.repoId === repo.id && parsed.hostId === repoHostId
     }
-    return worktreeId.startsWith(repoWorktreePrefix)
+    if (!worktreeId.startsWith(repoWorktreePrefix)) {
+      return false
+    }
+    if (meta?.hostId !== undefined) {
+      return meta.hostId === repoHostId
+    }
+    return hasSingleRepoExecutionHost(repos, repo)
   }
   if (targetWorktreeId) {
     if (!isRepoWorktreeId(targetWorktreeId)) {
@@ -652,14 +658,19 @@ function synthesizeDisconnectedSshCandidates(
   const candidates: WorkspaceCleanupCandidate[] = []
   const allMeta = store.getAllWorktreeMeta()
   for (const worktreeId in allMeta) {
-    if (!Object.hasOwn(allMeta, worktreeId) || !isRepoWorktreeId(worktreeId)) {
+    const meta = allMeta[worktreeId]
+    if (!Object.hasOwn(allMeta, worktreeId) || !isRepoWorktreeId(worktreeId, meta)) {
       continue
     }
-    const meta = allMeta[worktreeId]
     if (!meta || !isWorkspaceInactiveForCleanup(meta, scannedAt)) {
       continue
     }
-    candidates.push(createDisconnectedSshCandidate(repo, scannedAt, worktreeId, meta))
+    const parsed = splitWorktreeId(worktreeId)
+    const candidateWorktreeId =
+      parsed && parsed.repoId === repo.id
+        ? makeRepoWorktreeKey(repo, parsed.worktreePath)
+        : worktreeId
+    candidates.push(createDisconnectedSshCandidate(repo, scannedAt, candidateWorktreeId, meta))
   }
   return candidates
 }

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -19,7 +19,14 @@ import type {
   WorktreeMeta
 } from '../../shared/types'
 import { mergeWorktree } from './worktree-logic'
-import { splitWorktreeId } from '../../shared/worktree-id'
+import {
+  getRepoWorktreeIdAliases,
+  isRepoWorktreeIdAlias,
+  makeRepoWorktreeKey,
+  parseWorktreeKey,
+  splitWorktreeId
+} from '../../shared/worktree-id'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import {
   WORKSPACE_CLEANUP_CLASSIFIER_VERSION,
   applyWorkspaceCleanupPolicy,
@@ -266,13 +273,17 @@ async function scanRepoWorkspaces(args: {
 
   const worktrees = gitWorktrees
     .map((gitWorktree) => {
-      const worktreeId = `${repo.id}::${gitWorktree.path}`
-      const meta = store.getWorktreeMeta(worktreeId)
-      return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+      const worktreeId = makeRepoWorktreeKey(repo, gitWorktree.path)
+      const meta =
+        store.getWorktreeMeta(worktreeId) ??
+        store.getWorktreeMeta(`${repo.id}::${gitWorktree.path}`)
+      return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+        hostId: getRepoExecutionHostId(repo)
+      })
     })
     .filter((worktree) => {
       if (targetWorktreeId) {
-        return worktree.id === targetWorktreeId
+        return isRepoWorktreeIdAlias(repo, worktree.path, targetWorktreeId)
       }
       return (
         !repoIsFolder &&
@@ -287,7 +298,9 @@ async function scanRepoWorkspaces(args: {
       worktree,
       scannedAt,
       provider,
-      skipGit: skipGitWorktreeIds.has(worktree.id),
+      skipGit: [...getRepoWorktreeIdAliases(repo, worktree.path)].some((id) =>
+        skipGitWorktreeIds.has(id)
+      ),
       forceGitCheck: Boolean(targetWorktreeId)
     }).catch((error) => {
       console.error('Workspace cleanup candidate scan failed', error)
@@ -530,20 +543,38 @@ function synthesizeDisconnectedSshCandidates(
   targetWorktreeId?: string
 ): WorkspaceCleanupCandidate[] {
   const repoWorktreePrefix = `${repo.id}::`
+  const repoHostId = getRepoExecutionHostId(repo)
+  const isRepoWorktreeId = (worktreeId: string): boolean => {
+    const parsed = parseWorktreeKey(worktreeId)
+    if (parsed) {
+      return parsed.repoId === repo.id && parsed.hostId === repoHostId
+    }
+    return worktreeId.startsWith(repoWorktreePrefix)
+  }
   if (targetWorktreeId) {
-    if (!targetWorktreeId.startsWith(repoWorktreePrefix)) {
+    if (!isRepoWorktreeId(targetWorktreeId)) {
       return []
     }
     // Why: focused delete preflight names one workspace already; walking all
     // persisted metadata is unnecessary for disconnected SSH repos.
-    const meta = store.getWorktreeMeta(targetWorktreeId)
+    const parsed = splitWorktreeId(targetWorktreeId)
+    const canonicalTargetId =
+      parsed && parsed.repoId === repo.id
+        ? makeRepoWorktreeKey(repo, parsed.worktreePath)
+        : targetWorktreeId
+    const legacyTargetId =
+      parsed && parsed.repoId === repo.id ? `${repo.id}::${parsed.worktreePath}` : targetWorktreeId
+    const meta =
+      store.getWorktreeMeta(targetWorktreeId) ??
+      store.getWorktreeMeta(canonicalTargetId) ??
+      store.getWorktreeMeta(legacyTargetId)
     return meta ? [createDisconnectedSshCandidate(repo, scannedAt, targetWorktreeId, meta)] : []
   }
 
   const candidates: WorkspaceCleanupCandidate[] = []
   const allMeta = store.getAllWorktreeMeta()
   for (const worktreeId in allMeta) {
-    if (!Object.hasOwn(allMeta, worktreeId) || !worktreeId.startsWith(repoWorktreePrefix)) {
+    if (!Object.hasOwn(allMeta, worktreeId) || !isRepoWorktreeId(worktreeId)) {
       continue
     }
     const meta = allMeta[worktreeId]

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -19,13 +19,7 @@ import type {
   WorktreeMeta
 } from '../../shared/types'
 import { mergeWorktree } from './worktree-logic'
-import {
-  getRepoWorktreeIdAliases,
-  isRepoWorktreeIdAlias,
-  makeRepoWorktreeKey,
-  parseWorktreeKey,
-  splitWorktreeId
-} from '../../shared/worktree-id'
+import { makeRepoWorktreeKey, parseWorktreeKey, splitWorktreeId } from '../../shared/worktree-id'
 import { getRepoExecutionHostId } from '../../shared/execution-host'
 import {
   WORKSPACE_CLEANUP_CLASSIFIER_VERSION,
@@ -203,14 +197,30 @@ export async function scanWorkspaceCleanup(
   const repos = store.getRepos()
   const errors: WorkspaceCleanupScanResult['errors'] = []
   const candidates: WorkspaceCleanupCandidate[] = []
+  const canonicalizeWorktreeId = createCanonicalWorktreeIdMapper(repos)
+  const targetWorktreeId =
+    args.worktreeId === undefined ? undefined : canonicalizeWorktreeId(args.worktreeId)
+
+  if (args.worktreeId !== undefined && targetWorktreeId === undefined) {
+    return { scannedAt, candidates, errors }
+  }
+
+  const skipGitWorktreeIds = new Set<string>()
+  for (const worktreeId of args.skipGitWorktreeIds ?? []) {
+    const canonicalWorktreeId = canonicalizeWorktreeId(worktreeId)
+    if (canonicalWorktreeId) {
+      skipGitWorktreeIds.add(canonicalWorktreeId)
+    }
+  }
 
   for (const repo of repos) {
     const result = await scanRepoWorkspaces({
       store,
+      repos,
       repo,
       scannedAt,
-      targetWorktreeId: args.worktreeId,
-      skipGitWorktreeIds: new Set(args.skipGitWorktreeIds ?? [])
+      targetWorktreeId,
+      skipGitWorktreeIds
     })
     appendListItems(candidates, result.candidates)
     appendListItems(errors, result.errors)
@@ -221,16 +231,18 @@ export async function scanWorkspaceCleanup(
 
 async function scanRepoWorkspaces(args: {
   store: Store
+  repos: Repo[]
   repo: Repo
   scannedAt: number
   targetWorktreeId?: string
   skipGitWorktreeIds: Set<string>
 }): Promise<WorkspaceCleanupScanResult> {
-  const { store, repo, scannedAt, targetWorktreeId, skipGitWorktreeIds } = args
+  const { store, repos, repo, scannedAt, targetWorktreeId, skipGitWorktreeIds } = args
   const errors: WorkspaceCleanupScanResult['errors'] = []
   let provider: IGitProvider | null = null
   let gitWorktrees: GitWorktreeInfo[] = []
   const repoIsFolder = isFolderRepo(repo)
+  const repoHostId = getRepoExecutionHostId(repo)
 
   try {
     if (repoIsFolder) {
@@ -243,7 +255,7 @@ async function scanRepoWorkspaces(args: {
         return {
           scannedAt,
           candidates: targetWorktreeId
-            ? synthesizeDisconnectedSshCandidates(store, repo, scannedAt, targetWorktreeId)
+            ? synthesizeDisconnectedSshCandidates(store, repos, repo, scannedAt, targetWorktreeId)
             : [],
           errors: []
         }
@@ -276,14 +288,14 @@ async function scanRepoWorkspaces(args: {
       const worktreeId = makeRepoWorktreeKey(repo, gitWorktree.path)
       const meta =
         store.getWorktreeMeta(worktreeId) ??
-        store.getWorktreeMeta(`${repo.id}::${gitWorktree.path}`)
+        getLegacyWorktreeMetaIfSafe(store, repos, repo, gitWorktree.path)
       return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
-        hostId: getRepoExecutionHostId(repo)
+        hostId: repoHostId
       })
     })
     .filter((worktree) => {
       if (targetWorktreeId) {
-        return isRepoWorktreeIdAlias(repo, worktree.path, targetWorktreeId)
+        return worktree.id === targetWorktreeId
       }
       return (
         !repoIsFolder &&
@@ -298,9 +310,7 @@ async function scanRepoWorkspaces(args: {
       worktree,
       scannedAt,
       provider,
-      skipGit: [...getRepoWorktreeIdAliases(repo, worktree.path)].some((id) =>
-        skipGitWorktreeIds.has(id)
-      ),
+      skipGit: skipGitWorktreeIds.has(worktree.id),
       forceGitCheck: Boolean(targetWorktreeId)
     }).catch((error) => {
       console.error('Workspace cleanup candidate scan failed', error)
@@ -309,6 +319,69 @@ async function scanRepoWorkspaces(args: {
   )
 
   return { scannedAt, candidates, errors }
+}
+
+function getLegacyWorktreeMetaIfSafe(
+  store: Store,
+  repos: Repo[],
+  repo: Repo,
+  worktreePath: string
+): WorktreeMeta | undefined {
+  const meta = store.getWorktreeMeta(`${repo.id}::${worktreePath}`)
+  if (!meta) {
+    return undefined
+  }
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (meta.hostId !== undefined) {
+    return meta.hostId === repoHostId ? meta : undefined
+  }
+  // Why: legacy metadata keys do not name a host, so hostless rows are safe
+  // only while this repo id maps to exactly one execution host.
+  return hasSingleRepoExecutionHost(repos, repo) ? meta : undefined
+}
+
+function hasSingleRepoExecutionHost(repos: Repo[], repo: Repo): boolean {
+  const hostIds = new Set(
+    repos
+      .filter((candidateRepo) => candidateRepo.id === repo.id)
+      .map((candidateRepo) => getRepoExecutionHostId(candidateRepo))
+  )
+  return hostIds.size === 1
+}
+
+function createCanonicalWorktreeIdMapper(
+  repos: Repo[]
+): (worktreeId: string) => string | undefined {
+  const legacyToCanonicalIds = new Map<string, Set<string>>()
+
+  return (worktreeId: string): string | undefined => {
+    if (parseWorktreeKey(worktreeId)) {
+      return worktreeId
+    }
+
+    const parsed = splitWorktreeId(worktreeId)
+    if (!parsed) {
+      return undefined
+    }
+
+    const canonicalIds = legacyToCanonicalIds.get(worktreeId) ?? new Set<string>()
+    if (canonicalIds.size === 0) {
+      for (const repo of repos) {
+        if (repo.id === parsed.repoId) {
+          canonicalIds.add(makeRepoWorktreeKey(repo, parsed.worktreePath))
+        }
+      }
+      legacyToCanonicalIds.set(worktreeId, canonicalIds)
+    }
+
+    // Why: legacy IDs do not carry a host. In multi-host cleanup, accepting
+    // them is safe only when one canonical host-qualified workspace can own it.
+    if (canonicalIds.size !== 1) {
+      return undefined
+    }
+
+    return [...canonicalIds][0]
+  }
 }
 
 async function buildCandidate(args: {
@@ -538,6 +611,7 @@ function buildCandidateFromError(
 
 function synthesizeDisconnectedSshCandidates(
   store: Store,
+  repos: Repo[],
   repo: Repo,
   scannedAt: number,
   targetWorktreeId?: string
@@ -564,10 +638,14 @@ function synthesizeDisconnectedSshCandidates(
         : targetWorktreeId
     const legacyTargetId =
       parsed && parsed.repoId === repo.id ? `${repo.id}::${parsed.worktreePath}` : targetWorktreeId
+    const legacyMeta =
+      parsed && parsed.repoId === repo.id
+        ? getLegacyWorktreeMetaIfSafe(store, repos, repo, parsed.worktreePath)
+        : undefined
     const meta =
       store.getWorktreeMeta(targetWorktreeId) ??
       store.getWorktreeMeta(canonicalTargetId) ??
-      store.getWorktreeMeta(legacyTargetId)
+      (legacyTargetId === canonicalTargetId ? undefined : legacyMeta)
     return meta ? [createDisconnectedSshCandidate(repo, scannedAt, targetWorktreeId, meta)] : []
   }
 

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -3,6 +3,7 @@ single setup-free pure-logic module, and splitting them would make the related
 edge cases harder to audit together. */
 import { posix, resolve } from 'path'
 import { describe, expect, it } from 'vitest'
+import { makeWorktreeKey } from '../../shared/worktree-id'
 import {
   sanitizeWorktreeName,
   sanitizeWorktreeDisplayName,
@@ -372,7 +373,11 @@ describe('mergeWorktree', () => {
     }
     const result = mergeWorktree('repo1', baseGit, meta)
     expect(result).toEqual({
-      id: 'repo1::/workspaces/feature',
+      id: makeWorktreeKey({
+        hostId: 'ssh:openclaw-2',
+        repoId: 'repo1',
+        path: '/workspaces/feature'
+      }),
       repoId: 'repo1',
       path: '/workspaces/feature',
       head: 'abc123',

--- a/src/main/ipc/worktree-metadata-merge.ts
+++ b/src/main/ipc/worktree-metadata-merge.ts
@@ -1,5 +1,10 @@
 import { basename } from 'path'
 import type { GitWorktreeInfo, Worktree, WorktreeMeta } from '../../shared/types'
+import {
+  makeLegacyWorktreeId,
+  makeWorktreeKey,
+  type ParsedCanonicalWorktreeKey
+} from '../../shared/worktree-id'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import { getLinkedWorkItemMetadata } from './worktree-linked-work-item-metadata'
 
@@ -10,15 +15,19 @@ export function mergeWorktree(
   repoId: string,
   git: GitWorktreeInfo,
   meta: WorktreeMeta | undefined,
-  defaultDisplayName?: string
+  defaultDisplayName?: string,
+  canonical?: Pick<ParsedCanonicalWorktreeKey, 'hostId'>
 ): Worktree {
   const branchShort = git.branch.replace(/^refs\/heads\//, '')
+  const hostId = meta?.hostId ?? canonical?.hostId
   return {
-    id: `${repoId}::${git.path}`,
+    id: hostId
+      ? makeWorktreeKey({ hostId, repoId, path: git.path })
+      : makeLegacyWorktreeId(repoId, git.path),
     ...(meta?.instanceId !== undefined ? { instanceId: meta.instanceId } : {}),
     repoId,
     ...(meta?.projectId !== undefined ? { projectId: meta.projectId } : {}),
-    ...(meta?.hostId !== undefined ? { hostId: meta.hostId } : {}),
+    ...(hostId !== undefined ? { hostId } : {}),
     ...(meta?.projectHostSetupId !== undefined
       ? { projectHostSetupId: meta.projectHostSetupId }
       : {}),

--- a/src/main/ipc/worktree-push-target-cleanup.test.ts
+++ b/src/main/ipc/worktree-push-target-cleanup.test.ts
@@ -24,14 +24,22 @@ function forkTarget(overrides: Partial<GitPushTarget> = {}): GitPushTarget {
 }
 
 // Why: cleanup only reads meta.pushTarget, so the rest of WorktreeMeta is irrelevant.
-function metaWith(pushTarget: GitPushTarget | undefined): WorktreeMeta {
-  return { pushTarget } as unknown as WorktreeMeta
+function metaWith(pushTarget: GitPushTarget | undefined, hostId?: string): WorktreeMeta {
+  return { pushTarget, ...(hostId ? { hostId } : {}) } as unknown as WorktreeMeta
 }
 
-function storeOf(entries: Record<string, GitPushTarget | undefined>): WorktreePushTargetStore {
+function storeOf(
+  entries: Record<
+    string,
+    GitPushTarget | undefined | { pushTarget?: GitPushTarget; hostId?: string }
+  >
+): WorktreePushTargetStore {
   const meta: Record<string, WorktreeMeta> = {}
-  for (const [id, pushTarget] of Object.entries(entries)) {
-    meta[id] = metaWith(pushTarget)
+  for (const [id, entry] of Object.entries(entries)) {
+    meta[id] =
+      entry && typeof entry === 'object' && 'hostId' in entry
+        ? metaWith(entry.pushTarget, entry.hostId)
+        : metaWith(entry as GitPushTarget | undefined)
   }
   return { getAllWorktreeMeta: () => meta }
 }
@@ -133,6 +141,24 @@ describe('cleanupUnusedWorktreePushTargetRemoteWithExec', () => {
       exec
     )
     expect(removeCalls(exec)).toEqual([])
+  })
+
+  it('ignores matching push target metadata from a different execution host', async () => {
+    const exec = makeExec()
+    await cleanupUnusedWorktreePushTargetRemoteWithExec(
+      REPO_PATH,
+      'orca-worktree://v1?hostId=local&repoId=repo-1&path=%2Fwt%2Fa',
+      forkTarget(),
+      storeOf({
+        'orca-worktree://v1?hostId=local&repoId=repo-1&path=%2Fwt%2Fa': forkTarget(),
+        'orca-worktree://v1?hostId=runtime%3Agpu&repoId=repo-1&path=%2Fwt%2Fgpu': {
+          pushTarget: forkTarget(),
+          hostId: 'runtime:gpu'
+        }
+      }),
+      exec
+    )
+    expect(removeCalls(exec)).toEqual([['remote', 'remove', FORK_REMOTE]])
   })
 
   it('keeps the remote when another worktree points at the same fork via a differently-named remote', async () => {

--- a/src/main/ipc/worktree-push-target-cleanup.ts
+++ b/src/main/ipc/worktree-push-target-cleanup.ts
@@ -4,9 +4,9 @@
 // the multi-fork cleanup matrix is unit-testable without a real repo.
 
 import type { Store } from '../persistence'
-import type { GitPushTarget } from '../../shared/types'
+import type { GitPushTarget, WorktreeMeta } from '../../shared/types'
 import { parseGitHubOwnerRepo } from '../github/gh-utils'
-import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, parseAnyWorktreeId } from '../../shared/worktree-id'
 import { iterateProcessOutputLines } from '../../shared/process-output-field-scanner'
 
 export type GitRemoteExec = (
@@ -14,6 +14,11 @@ export type GitRemoteExec = (
   cwd: string
 ) => Promise<{ stdout: string; stderr?: string }>
 export type WorktreePushTargetStore = Pick<Store, 'getAllWorktreeMeta'>
+
+function getWorktreeHostId(worktreeId: string, meta?: WorktreeMeta): string | undefined {
+  const parsed = parseAnyWorktreeId(worktreeId)
+  return parsed?.format === 'canonical' ? parsed.hostId : meta?.hostId
+}
 
 export function sameGitHubRemoteUrl(left: string, right: string): boolean {
   if (left === right) {
@@ -31,15 +36,27 @@ export function sameGitHubRemoteUrl(left: string, right: string): boolean {
 
 function isPushTargetUsedByAnotherWorktree(
   store: WorktreePushTargetStore,
-  removedWorktreeId: string,
+  removedWorktreeIds: readonly string[],
   target: GitPushTarget
 ): boolean {
-  const removedRepoId = getRepoIdFromWorktreeId(removedWorktreeId)
+  const removedWorktreeIdSet = new Set(removedWorktreeIds)
+  const removedRepoIds = new Set(
+    removedWorktreeIds.map((worktreeId) => getRepoIdFromWorktreeId(worktreeId))
+  )
+  const removedHostIds = new Set(
+    removedWorktreeIds
+      .map((worktreeId) => getWorktreeHostId(worktreeId))
+      .filter((hostId): hostId is string => Boolean(hostId))
+  )
   return Object.entries(store.getAllWorktreeMeta()).some(([worktreeId, meta]) => {
     // Why: git remotes are repo-local; matching metadata from another repo
     // must not pin this repo's fork remote forever.
-    const belongsToSameRepo = getRepoIdFromWorktreeId(worktreeId) === removedRepoId
-    if (worktreeId === removedWorktreeId || !belongsToSameRepo || !meta.pushTarget) {
+    const belongsToSameRepo = removedRepoIds.has(getRepoIdFromWorktreeId(worktreeId))
+    if (removedWorktreeIdSet.has(worktreeId) || !belongsToSameRepo || !meta.pushTarget) {
+      return false
+    }
+    const candidateHostId = getWorktreeHostId(worktreeId, meta)
+    if (removedHostIds.size > 0 && candidateHostId && !removedHostIds.has(candidateHostId)) {
       return false
     }
     const otherRemoteUrl = meta.pushTarget.remoteUrl
@@ -107,7 +124,7 @@ function isBranchConfigSeparator(code: number): boolean {
 // cleanup matrix without touching a real repo.
 export async function cleanupUnusedWorktreePushTargetRemoteWithExec(
   repoPath: string,
-  removedWorktreeId: string,
+  removedWorktreeId: string | readonly string[],
   target: GitPushTarget | undefined,
   store: WorktreePushTargetStore,
   execGit: GitRemoteExec
@@ -120,7 +137,9 @@ export async function cleanupUnusedWorktreePushTargetRemoteWithExec(
   ) {
     return
   }
-  if (isPushTargetUsedByAnotherWorktree(store, removedWorktreeId, target)) {
+  const removedWorktreeIds =
+    typeof removedWorktreeId === 'string' ? [removedWorktreeId] : removedWorktreeId
+  if (isPushTargetUsedByAnotherWorktree(store, removedWorktreeIds, target)) {
     return
   }
   if (await hasBranchConfigUsingRemote(execGit, repoPath, target)) {

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -864,7 +864,7 @@ function isPushTargetRemoteCreatedByKnownWorktree(
 
 export async function cleanupUnusedWorktreePushTargetRemote(
   repoPath: string,
-  removedWorktreeId: string,
+  removedWorktreeId: string | readonly string[],
   target: GitPushTarget | undefined,
   store: WorktreePushTargetStore,
   gitOptions: { wslDistro?: string } = {}
@@ -1003,7 +1003,7 @@ async function prepareWorktreePushTargetSsh(
 export async function cleanupUnusedWorktreePushTargetRemoteSsh(
   provider: SshGitProvider,
   repoPath: string,
-  removedWorktreeId: string,
+  removedWorktreeId: string | readonly string[],
   target: GitPushTarget | undefined,
   store: WorktreePushTargetStore
 ): Promise<void> {
@@ -1017,7 +1017,7 @@ export async function cleanupUnusedWorktreePushTargetRemoteSsh(
     )
   } catch (error) {
     console.warn(
-      `[worktrees] Failed to clean up remote fork PR remote for ${removedWorktreeId}`,
+      `[worktrees] Failed to clean up remote fork PR remote for ${String(removedWorktreeId)}`,
       error
     )
   }

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -77,7 +77,8 @@ import {
   mergeWorktree,
   areWorktreePathsEqual
 } from './worktree-logic'
-import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, makeRepoWorktreeKey } from '../../shared/worktree-id'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import {
   cleanupUnusedWorktreePushTargetRemoteWithExec,
@@ -206,6 +207,13 @@ function recordWorkspaceLineageForCreatedWorktree(
     capture: { source: 'active-workspace', confidence: 'explicit' },
     createdAt
   })
+}
+
+function getRepoWorktreeId(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string
+): string {
+  return makeRepoWorktreeKey(repo, path)
 }
 
 function countNonEmptyGitOutputLines(output: string): number {
@@ -1451,7 +1459,7 @@ export async function createRemoteWorktree(
   validateWorkspaceLineageParentBeforeCreate(
     store,
     args.parentWorkspace,
-    worktreeWorkspaceKey(`${repo.id}::${remotePath}`)
+    worktreeWorkspaceKey(getRepoWorktreeId(repo, remotePath))
   )
 
   const sparseDirectories = args.sparseCheckout
@@ -1620,7 +1628,7 @@ export async function createRemoteWorktree(
     throw new Error('Worktree created but not found in listing')
   }
 
-  const worktreeId = `${repo.id}::${created.path}`
+  const worktreeId = getRepoWorktreeId(repo, created.path)
   const now = Date.now()
   // Why: PR/MR-created worktrees can start from a head ref/SHA while Source
   // Control must compare against the review target branch.
@@ -1694,7 +1702,11 @@ export async function createRemoteWorktree(
   }
   const { worktree } = timing.timeSync('persist_metadata', () => {
     const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
-    return { worktree: mergeWorktree(repo.id, created, meta) }
+    return {
+      worktree: mergeWorktree(repo.id, created, meta, undefined, {
+        hostId: getRepoExecutionHostId(repo)
+      })
+    }
   })
   const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
 
@@ -2059,7 +2071,7 @@ export async function createLocalWorktree(
   validateWorkspaceLineageParentBeforeCreate(
     store,
     args.parentWorkspace,
-    worktreeWorkspaceKey(`${repo.id}::${worktreePath}`)
+    worktreeWorkspaceKey(getRepoWorktreeId(repo, worktreePath))
   )
 
   if (remoteTrackingRefresh) {
@@ -2227,7 +2239,7 @@ export async function createLocalWorktree(
     throw new Error('Worktree created but not found in listing')
   }
 
-  const worktreeId = `${repo.id}::${created.path}`
+  const worktreeId = getRepoWorktreeId(repo, created.path)
   const now = Date.now()
   // Why: PR/MR-created worktrees can start from a head ref/SHA while Source
   // Control must compare against the review target branch.
@@ -2291,7 +2303,11 @@ export async function createLocalWorktree(
   }
   const { worktree } = timing.timeSync('persist_metadata', () => {
     const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
-    return { worktree: mergeWorktree(repo.id, created, meta) }
+    return {
+      worktree: mergeWorktree(repo.id, created, meta, undefined, {
+        hostId: getRepoExecutionHostId(repo)
+      })
+    }
   })
   const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
   // Why: creation already paid for `git worktree list`; seed the exact roots

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeWorktreeKey } from '../../shared/worktree-id'
 
 const {
   handleMock,
@@ -147,7 +148,8 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     getSettings: vi.fn(),
     getWorktreeMeta: vi.fn(),
     setWorktreeMeta: vi.fn(),
-    removeWorktreeMeta: vi.fn()
+    removeWorktreeMeta: vi.fn(),
+    migrateWorktreeIdentity: vi.fn()
   }
 
   beforeEach(() => {
@@ -187,6 +189,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     store.getWorktreeMeta.mockReset()
     store.setWorktreeMeta.mockReset()
     store.removeWorktreeMeta.mockReset()
+    store.migrateWorktreeIdentity.mockReset()
 
     for (const key of Object.keys(handlers)) {
       delete handlers[key]
@@ -260,6 +263,11 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
   })
 
   it('accepts a newly created Windows worktree when git lists the same path with different separators', async () => {
+    const worktreeId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: 'repo-1',
+      path: 'C:/workspaces/improve-dashboard'
+    })
     listWorktreesMock.mockResolvedValue([
       {
         path: 'C:/workspaces/improve-dashboard',
@@ -283,14 +291,14 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::C:/workspaces/improve-dashboard',
+      worktreeId,
       expect.objectContaining({
         lastActivityAt: expect.any(Number)
       })
     )
     expect(result).toMatchObject({
       worktree: expect.objectContaining({
-        id: 'repo-1::C:/workspaces/improve-dashboard',
+        id: worktreeId,
         path: 'C:/workspaces/improve-dashboard',
         branch: 'refs/heads/improve-dashboard'
       })
@@ -298,6 +306,11 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
   })
 
   it('preserves create-time metadata on the next list when Windows path formatting differs', async () => {
+    const worktreeId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: 'repo-1',
+      path: 'C:/workspaces/improve-dashboard'
+    })
     const worktreeEntry = {
       path: 'C:/workspaces/improve-dashboard',
       head: 'abc123',
@@ -314,8 +327,8 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
       linkedIssue: 123,
       linkedPR: 456
     })
-    store.getWorktreeMeta.mockImplementation((worktreeId: string) =>
-      worktreeId === 'repo-1::C:/workspaces/improve-dashboard'
+    store.getWorktreeMeta.mockImplementation((id: string) =>
+      id === worktreeId
         ? {
             lastActivityAt: 123,
             displayName: 'Improve Dashboard',
@@ -337,7 +350,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
 
     expect(listed).toMatchObject([
       {
-        id: 'repo-1::C:/workspaces/improve-dashboard',
+        id: worktreeId,
         displayName: 'Improve Dashboard',
         linkedIssue: 123,
         linkedPR: 456,

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -3860,6 +3860,50 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('rotates stale canonical parent lineage after a successful SSH worktree scan proves the parent is missing', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1'
+    }
+    const liveChildId = sshWorktreeKey('/remote/live-child', 'repo-ssh', 'conn-1')
+    const missingParentId = sshWorktreeKey('/remote/missing-parent', 'repo-ssh', 'conn-1')
+    const provider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/live-child',
+          head: 'def456',
+          branch: 'refs/heads/live-child',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    store.getAllWorktreeLineage.mockReturnValue({
+      [liveChildId]: {
+        parentWorktreeId: missingParentId,
+        parentWorktreeInstanceId: 'old-parent-instance'
+      }
+    })
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) =>
+      worktreeId === missingParentId ? { instanceId: 'old-parent-instance' } : undefined
+    )
+
+    await handlers['worktrees:list'](null, { repoId: 'repo-ssh' })
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalledWith(liveChildId)
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      missingParentId,
+      expect.objectContaining({ instanceId: expect.any(String) })
+    )
+  })
+
   it('does not repeatedly rotate already-invalid missing parent metadata', async () => {
     const repo = {
       id: 'repo-ssh',
@@ -4170,6 +4214,36 @@ describe('registerWorktreeHandlers', () => {
       })
     ])
     expect(listWorktreesMock).not.toHaveBeenCalled()
+  })
+
+  it('does not migrate hostless legacy folder workspace metadata when the repo id spans hosts', async () => {
+    const localRepo = {
+      id: 'repo-1',
+      path: '/workspace/folder',
+      displayName: 'folder',
+      badgeColor: '#000',
+      addedAt: 0,
+      kind: 'folder' as const
+    }
+    store.getRepos.mockReturnValue([
+      localRepo,
+      {
+        ...localRepo,
+        path: '/runtime/folder',
+        executionHostId: 'runtime:gpu'
+      }
+    ])
+    store.getRepo.mockReturnValue(localRepo)
+    store.getAllWorktreeMeta.mockReturnValue({
+      'repo-1::/workspace/folder': makeWorktreeMeta({
+        instanceId: 'legacy-folder-instance',
+        lastActivityAt: 42
+      })
+    })
+
+    await handlers['worktrees:list'](null, { repoId: 'repo-1' })
+
+    expect(store.migrateWorktreeIdentity).not.toHaveBeenCalled()
   })
 
   it('returns reconstructed rows when an SSH provider is unavailable', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -4,8 +4,17 @@ import { lstat, mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
 import type { CreateWorktreeResult, GitWorktreeInfo, Worktree } from '../../shared/types'
+import { makeRepoWorktreeKey } from '../../shared/worktree-id'
 
 const ORIGINAL_PLATFORM = process.platform
+
+function localWorktreeKey(path: string, repoId = 'repo-1'): string {
+  return makeRepoWorktreeKey({ id: repoId, connectionId: null, executionHostId: null }, path)
+}
+
+function sshWorktreeKey(path: string, repoId = 'repo-ssh', connectionId = 'conn-1'): string {
+  return makeRepoWorktreeKey({ id: repoId, connectionId, executionHostId: null }, path)
+}
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', {
@@ -252,6 +261,7 @@ describe('registerWorktreeHandlers', () => {
     getWorktreeMeta: vi.fn(),
     getAllWorktreeMeta: vi.fn(),
     setWorktreeMeta: vi.fn(),
+    migrateWorktreeIdentity: vi.fn(),
     getProjectHostSetups: vi.fn(),
     removeWorktreeMeta: vi.fn(),
     getAllWorktreeLineage: vi.fn(),
@@ -323,6 +333,7 @@ describe('registerWorktreeHandlers', () => {
       store.getWorktreeMeta,
       store.getAllWorktreeMeta,
       store.setWorktreeMeta,
+      store.migrateWorktreeIdentity,
       store.getProjectHostSetups,
       store.removeWorktreeMeta,
       store.getAllWorktreeLineage,
@@ -703,7 +714,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     const persistedMeta = store.setWorktreeMeta.mock.calls.find(
-      ([worktreeId]) => worktreeId === 'repo-1::/workspace/improve-dashboard'
+      ([worktreeId]) => worktreeId === localWorktreeKey('/workspace/improve-dashboard')
     )?.[1]
     expect(persistedMeta).toBeDefined()
     expect(persistedMeta).not.toHaveProperty('automationProvenance')
@@ -782,7 +793,7 @@ describe('registerWorktreeHandlers', () => {
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::../worktrees/feature',
+      localWorktreeKey('../worktrees/feature'),
       expect.objectContaining({
         orcaCreationWorkspaceLayout: { path: '../worktrees', nestWorkspaces: false }
       })
@@ -888,7 +899,9 @@ describe('registerWorktreeHandlers', () => {
     expect(addWorktreeMock).not.toHaveBeenCalled()
     expect(result.worktree).toEqual(
       expect.objectContaining({
-        id: expect.stringMatching(/^repo-folder::\/workspace\/folder::workspace:[0-9a-f-]{36}$/),
+        id: expect.stringMatching(
+          /^orca-worktree:\/\/v1\?hostId=local&repoId=repo-folder&path=%2Fworkspace%2Ffolder::workspace:[0-9a-f-]{36}$/
+        ),
         repoId: 'repo-folder',
         path: '/workspace/folder',
         displayName: 'folder-session',
@@ -938,7 +951,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(runtimeStub.createTerminal).toHaveBeenNthCalledWith(
       1,
-      'id:repo-1::/workspace/improve-dashboard',
+      `id:${localWorktreeKey('/workspace/improve-dashboard')}`,
       {
         command: 'claude --prefill test',
         env: { ORCA_AGENT_MODE: 'direct' },
@@ -954,7 +967,7 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(runtimeStub.createTerminal).toHaveBeenNthCalledWith(
       2,
-      'id:repo-1::/workspace/improve-dashboard',
+      `id:${localWorktreeKey('/workspace/improve-dashboard')}`,
       {
         title: 'Setup',
         command: 'bash /workspace/repo/.git/orca/setup-runner.sh',
@@ -1023,7 +1036,7 @@ describe('registerWorktreeHandlers', () => {
       { checkoutExistingBranch: true }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/fix-bug-0',
+      localWorktreeKey('/workspace/fix-bug-0'),
       expect.objectContaining({ preserveBranchOnDelete: true })
     )
     expect(result).toMatchObject({
@@ -1083,7 +1096,7 @@ describe('registerWorktreeHandlers', () => {
       { checkoutExistingBranch: true }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/my-folder',
+      localWorktreeKey('/workspace/my-folder'),
       expect.objectContaining({ preserveBranchOnDelete: true })
     )
     expect(result).toMatchObject({
@@ -1213,7 +1226,7 @@ describe('registerWorktreeHandlers', () => {
       { cwd: '/workspace/fix-title' }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/fix-title',
+      localWorktreeKey('/workspace/fix-title'),
       expect.objectContaining({
         baseRef: 'refs/remotes/origin/main',
         linkedPR: 42
@@ -1252,7 +1265,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/fix-title',
+      localWorktreeKey('/workspace/fix-title'),
       expect.objectContaining({
         baseRef: 'refs/remotes/origin/main',
         linkedGitLabMR: 7
@@ -1302,7 +1315,7 @@ describe('registerWorktreeHandlers', () => {
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/bitbucket-title',
+      localWorktreeKey('/workspace/bitbucket-title'),
       expect.objectContaining({ linkedBitbucketPR: 11 })
     )
     expect(getHostedReviewForBranchMock).toHaveBeenCalledWith(
@@ -1540,7 +1553,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         displayName: 'Fix: dashboards for PRs'
       })
@@ -1574,7 +1587,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         linkedIssue: 123,
         linkedPR: 456,
@@ -1611,7 +1624,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         createdWithAgent: 'codex'
       })
@@ -1667,7 +1680,7 @@ describe('registerWorktreeHandlers', () => {
       { cwd: '/workspace/improve-dashboard' }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         pushTarget: expect.objectContaining({
           remoteName: 'pr-prateek-orca',
@@ -1724,7 +1737,7 @@ describe('registerWorktreeHandlers', () => {
       expect.any(Object)
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         pushTarget: expect.objectContaining({
           remoteName: 'pr-contributor-orca',
@@ -2558,7 +2571,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-ssh::/remote/improve-dashboard',
+      sshWorktreeKey('/remote/improve-dashboard'),
       expect.objectContaining({
         linkedIssue: 123,
         linkedPR: 456,
@@ -3134,7 +3147,7 @@ describe('registerWorktreeHandlers', () => {
       '/remote/sparse-dashboard'
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-ssh::/remote/sparse-dashboard',
+      sshWorktreeKey('/remote/sparse-dashboard'),
       expect.objectContaining({
         sparseDirectories: ['apps/mobile', 'packages/shared'],
         baseRef: 'refs/remotes/origin/main',
@@ -3931,9 +3944,9 @@ describe('registerWorktreeHandlers', () => {
     resolveFetch()
     const result = (await createPromise) as CreateWorktreeResult
     expect(addWorktreeMock).toHaveBeenCalled()
-    expect(result.worktree.id).toBe('repo-1::/workspace/improve-dashboard')
+    expect(result.worktree.id).toBe(localWorktreeKey('/workspace/improve-dashboard'))
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({ baseRef: 'refs/remotes/origin/main' })
     )
   })
@@ -3995,7 +4008,7 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(result).toEqual(
       expect.objectContaining({
-        worktree: expect.objectContaining({ id: 'repo-1::/workspace/improve-dashboard' })
+        worktree: expect.objectContaining({ id: localWorktreeKey('/workspace/improve-dashboard') })
       })
     )
   })
@@ -4050,7 +4063,7 @@ describe('registerWorktreeHandlers', () => {
       }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({ baseRef: 'refs/remotes/origin/main' })
     )
     expect(result.localBaseRefUpdateSuggestion).toEqual({
@@ -4108,7 +4121,7 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('lists a synthetic worktree for folder-mode repos', async () => {
-    const rootWorktreeId = 'repo-1::/workspace/folder'
+    const rootWorktreeId = localWorktreeKey('/workspace/folder')
     const priorWorktreeIds = ['repo-1::/workspace/old-folder']
     const rootMeta = makeWorktreeMeta({
       instanceId: 'folder-instance',
@@ -4203,7 +4216,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(listed).toEqual([
       expect.objectContaining({
-        id: 'repo-ssh::/remote/feature-wt',
+        id: sshWorktreeKey('/remote/feature-wt'),
         repoId: 'repo-ssh',
         path: '/remote/feature-wt',
         head: '',
@@ -4233,8 +4246,7 @@ describe('registerWorktreeHandlers', () => {
         ]
       })
     ])
-    expect(store.getWorktreeMeta).not.toHaveBeenCalled()
-    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-ssh::/remote/feature-wt', {
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(sshWorktreeKey('/remote/feature-wt'), {
       projectId: 'repo:repo-ssh',
       hostId: 'ssh:conn-1',
       projectHostSetupId: 'repo-ssh'
@@ -4267,7 +4279,7 @@ describe('registerWorktreeHandlers', () => {
     expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo')
     expect(listed).toEqual([
       expect.objectContaining({
-        id: 'repo-ssh::/remote/feature-wt',
+        id: sshWorktreeKey('/remote/feature-wt'),
         displayName: 'Feature workspace',
         lastActivityAt: 42
       })
@@ -4307,7 +4319,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(listed).toEqual([
       expect.objectContaining({
-        id: 'repo-ssh::/remote/feature-wt',
+        id: sshWorktreeKey('/remote/feature-wt'),
         displayName: 'Good row'
       })
     ])
@@ -4399,11 +4411,11 @@ describe('registerWorktreeHandlers', () => {
     expect(listed).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: 'repo-ssh::/remote/feature-wt',
+          id: sshWorktreeKey('/remote/feature-wt'),
           displayName: 'Remote cached'
         }),
         expect.objectContaining({
-          id: 'repo-local::/workspace/local',
+          id: localWorktreeKey('/workspace/local', 'repo-local'),
           branch: 'refs/heads/main'
         })
       ])
@@ -4437,8 +4449,8 @@ describe('registerWorktreeHandlers', () => {
 
     expect(store.getAllWorktreeMeta).toHaveBeenCalledTimes(1)
     expect(listed).toEqual([
-      expect.objectContaining({ id: 'repo-ssh-a::/remote/a/one' }),
-      expect.objectContaining({ id: 'repo-ssh-b::/remote/b/two' })
+      expect.objectContaining({ id: sshWorktreeKey('/remote/a/one', 'repo-ssh-a', 'conn-1') }),
+      expect.objectContaining({ id: sshWorktreeKey('/remote/b/two', 'repo-ssh-b', 'conn-2') })
     ])
   })
 
@@ -4464,6 +4476,10 @@ describe('registerWorktreeHandlers', () => {
       lastActivityAt: 1_700_000_000_000
     }
     store.setWorktreeMeta.mockReturnValue(stampedMeta)
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/discovered-wt'
+    )
 
     const listed = (await handlers['worktrees:list'](null, { repoId: 'repo-1' })) as {
       id: string
@@ -4471,7 +4487,7 @@ describe('registerWorktreeHandlers', () => {
     }[]
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/discovered-wt',
+      expectedWorktreeId,
       expect.objectContaining({
         lastActivityAt: expect.any(Number),
         projectId: 'repo:repo-1',
@@ -4480,9 +4496,61 @@ describe('registerWorktreeHandlers', () => {
       })
     )
     expect(listed[0]).toMatchObject({
-      id: 'repo-1::/workspace/discovered-wt',
+      id: expectedWorktreeId,
       lastActivityAt: 1_700_000_000_000
     })
+  })
+
+  it('migrates matching legacy worktree metadata to the host-qualified key on discovery', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/legacy-wt',
+        head: 'abc123',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const legacyWorktreeId = 'repo-1::/workspace/legacy-wt'
+    const canonicalWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/legacy-wt'
+    )
+    const legacyMeta = makeWorktreeMeta({
+      instanceId: 'legacy-instance',
+      hostId: 'local',
+      lastActivityAt: 42
+    })
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) => {
+      if (worktreeId === legacyWorktreeId) {
+        return legacyMeta
+      }
+      return undefined
+    })
+    store.setWorktreeMeta.mockReturnValue({
+      ...legacyMeta,
+      projectId: 'repo:repo-1',
+      projectHostSetupId: 'repo-1'
+    })
+
+    const listed = (await handlers['worktrees:list'](null, { repoId: 'repo-1' })) as {
+      id: string
+      lastActivityAt: number
+    }[]
+
+    expect(store.migrateWorktreeIdentity).toHaveBeenCalledWith(
+      legacyWorktreeId,
+      canonicalWorktreeId
+    )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      canonicalWorktreeId,
+      expect.objectContaining({
+        projectId: 'repo:repo-1',
+        hostId: 'local',
+        projectHostSetupId: 'repo-1'
+      })
+    )
+    expect(listed[0]).toMatchObject({ id: canonicalWorktreeId, lastActivityAt: 42 })
   })
 
   it('backfills project-host ownership without re-stamping lastActivityAt for existing meta', async () => {
@@ -4525,8 +4593,12 @@ describe('registerWorktreeHandlers', () => {
       hostId?: string
       projectHostSetupId?: string
     }[]
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/existing-wt'
+    )
 
-    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-1::/workspace/existing-wt', {
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(expectedWorktreeId, {
       projectId: 'repo:repo-1',
       hostId: 'local',
       projectHostSetupId: 'repo-1'
@@ -4596,12 +4668,16 @@ describe('registerWorktreeHandlers', () => {
       hostId?: string
       projectHostSetupId?: string
     }[]
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/existing-wt'
+    )
 
-    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-1::/workspace/existing-wt', {
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(expectedWorktreeId, {
       projectId: 'github:stablyai/orca'
     })
     expect(listed[0]).toMatchObject({
-      id: 'repo-1::/workspace/existing-wt',
+      id: expectedWorktreeId,
       projectId: 'github:stablyai/orca',
       hostId: 'local',
       projectHostSetupId: 'repo-1',
@@ -4704,14 +4780,18 @@ describe('registerWorktreeHandlers', () => {
       projectHostSetupId?: string
       lastActivityAt: number
     }[]
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-ssh', connectionId: 'ssh-target-1', executionHostId: null },
+      '/remote/orca'
+    )
 
     expect(getSshGitProviderMock).toHaveBeenCalledWith('ssh-target-1')
-    expect(store.setWorktreeMeta).toHaveBeenCalledWith('repo-ssh::/remote/orca', {
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(expectedWorktreeId, {
       projectId: 'github:stablyai/orca'
     })
     expect(listed).toEqual([
       expect.objectContaining({
-        id: 'repo-ssh::/remote/orca',
+        id: expectedWorktreeId,
         projectId: 'github:stablyai/orca',
         hostId: 'ssh:ssh-target-1',
         projectHostSetupId: 'repo-ssh',
@@ -4784,9 +4864,13 @@ describe('registerWorktreeHandlers', () => {
       id: string
       instanceId?: string
     }[]
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/existing-wt'
+    )
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/existing-wt',
+      expectedWorktreeId,
       expect.objectContaining({
         instanceId: expect.any(String),
         projectId: 'repo:repo-1',
@@ -4831,11 +4915,15 @@ describe('registerWorktreeHandlers', () => {
       projectHostSetupId: 'repo-1',
       lastActivityAt: 1_700_000_000_000
     })
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/folder'
+    )
 
     await handlers['worktrees:list'](null, { repoId: 'repo-1' })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/folder',
+      expectedWorktreeId,
       expect.objectContaining({
         lastActivityAt: expect.any(Number),
         projectId: 'repo:repo-1',
@@ -4860,6 +4948,10 @@ describe('registerWorktreeHandlers', () => {
     ])
     store.getWorktreeMeta.mockReturnValue(undefined)
     store.setWorktreeMeta.mockReturnValue({ lastActivityAt: 1_700_000_000_000 })
+    const expectedWorktreeId = makeRepoWorktreeKey(
+      { id: 'repo-1', connectionId: null, executionHostId: null },
+      '/workspace/discovered-wt'
+    )
 
     const listed = (await handlers['worktrees:listAll'](null, undefined)) as {
       id: string
@@ -4867,11 +4959,11 @@ describe('registerWorktreeHandlers', () => {
     }[]
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/discovered-wt',
+      expectedWorktreeId,
       expect.objectContaining({ lastActivityAt: expect.any(Number) })
     )
     expect(listed[0]).toMatchObject({
-      id: 'repo-1::/workspace/discovered-wt',
+      id: expectedWorktreeId,
       lastActivityAt: 1_700_000_000_000
     })
   })
@@ -5212,7 +5304,7 @@ describe('registerWorktreeHandlers', () => {
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         sparseDirectories: ['packages/web', 'apps/api'],
         sparseBaseRef: 'origin/main',
@@ -5258,7 +5350,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         sparseDirectories: ['packages/web'],
         sparseBaseRef: 'origin/main',
@@ -5295,7 +5387,7 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::/workspace/improve-dashboard',
+      localWorktreeKey('/workspace/improve-dashboard'),
       expect.objectContaining({
         sparseDirectories: ['packages/web'],
         sparseBaseRef: 'origin/main',

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -4286,6 +4286,51 @@ describe('registerWorktreeHandlers', () => {
     ])
   })
 
+  it('does not reconstruct disconnected SSH rows from another host with the same repo id', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'SSH Repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1'
+    }
+    store.getRepo.mockReturnValue(repo)
+    store.getRepos.mockReturnValue([
+      repo,
+      {
+        ...repo,
+        path: '/remote/repo-2',
+        displayName: 'SSH Repo 2',
+        connectionId: 'conn-2'
+      }
+    ])
+    store.getAllWorktreeMeta.mockReturnValue({
+      [sshWorktreeKey('/remote/conn-1-wt')]: makeWorktreeMeta({
+        displayName: 'Conn 1 canonical'
+      }),
+      [sshWorktreeKey('/remote/conn-2-wt', 'repo-ssh', 'conn-2')]: makeWorktreeMeta({
+        displayName: 'Conn 2 canonical'
+      }),
+      'repo-ssh::/remote/legacy-conn-2-wt': makeWorktreeMeta({
+        hostId: 'ssh:conn-2',
+        displayName: 'Conn 2 legacy'
+      }),
+      'repo-ssh::/remote/ambiguous-legacy-wt': makeWorktreeMeta({
+        displayName: 'Ambiguous legacy'
+      })
+    })
+
+    const listed = await handlers['worktrees:list'](null, { repoId: 'repo-ssh' })
+
+    expect(listed).toEqual([
+      expect.objectContaining({
+        id: sshWorktreeKey('/remote/conn-1-wt'),
+        displayName: 'Conn 1 canonical'
+      })
+    ])
+  })
+
   it('keeps local listing failure behavior as an empty list', async () => {
     listWorktreesMock.mockRejectedValue(new Error('filesystem denied'))
     store.getAllWorktreeMeta.mockReturnValue({
@@ -4502,6 +4547,22 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('migrates matching legacy worktree metadata to the host-qualified key on discovery', async () => {
+    const localRepo = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    store.getRepo.mockReturnValue(localRepo)
+    store.getRepos.mockReturnValue([
+      localRepo,
+      {
+        ...localRepo,
+        path: '/runtime/repo',
+        executionHostId: 'runtime:gpu'
+      }
+    ])
     listWorktreesMock.mockResolvedValue([
       {
         path: '/workspace/legacy-wt',
@@ -4512,10 +4573,7 @@ describe('registerWorktreeHandlers', () => {
       }
     ])
     const legacyWorktreeId = 'repo-1::/workspace/legacy-wt'
-    const canonicalWorktreeId = makeRepoWorktreeKey(
-      { id: 'repo-1', connectionId: null, executionHostId: null },
-      '/workspace/legacy-wt'
-    )
+    const canonicalWorktreeId = makeRepoWorktreeKey(localRepo, '/workspace/legacy-wt')
     const legacyMeta = makeWorktreeMeta({
       instanceId: 'legacy-instance',
       hostId: 'local',
@@ -4551,6 +4609,65 @@ describe('registerWorktreeHandlers', () => {
       })
     )
     expect(listed[0]).toMatchObject({ id: canonicalWorktreeId, lastActivityAt: 42 })
+  })
+
+  it('does not migrate hostless legacy worktree metadata when the repo id spans hosts', async () => {
+    const localRepo = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    store.getRepo.mockReturnValue(localRepo)
+    store.getRepos.mockReturnValue([
+      localRepo,
+      {
+        ...localRepo,
+        path: '/runtime/repo',
+        executionHostId: 'runtime:gpu'
+      }
+    ])
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/legacy-wt',
+        head: 'abc123',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const legacyWorktreeId = 'repo-1::/workspace/legacy-wt'
+    const canonicalWorktreeId = makeRepoWorktreeKey(localRepo, '/workspace/legacy-wt')
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) =>
+      worktreeId === legacyWorktreeId
+        ? makeWorktreeMeta({ instanceId: 'legacy-instance', lastActivityAt: 42 })
+        : undefined
+    )
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => ({
+      ...makeWorktreeMeta(),
+      ...meta
+    }))
+
+    const listed = (await handlers['worktrees:list'](null, { repoId: 'repo-1' })) as {
+      id: string
+      lastActivityAt: number
+    }[]
+
+    expect(store.migrateWorktreeIdentity).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      canonicalWorktreeId,
+      expect.objectContaining({
+        lastActivityAt: expect.any(Number),
+        hostId: 'local'
+      })
+    )
+    expect(store.setWorktreeMeta.mock.calls[0]?.[1]?.lastActivityAt).not.toBe(42)
+    expect(listed[0]).toMatchObject({
+      id: canonicalWorktreeId,
+      lastActivityAt: expect.any(Number)
+    })
+    expect(listed[0]?.lastActivityAt).not.toBe(42)
   })
 
   it('backfills project-host ownership without re-stamping lastActivityAt for existing meta', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -800,6 +800,63 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('uses the requested host when creating a local worktree for same-id repos', async () => {
+    const remoteRepo = {
+      id: 'repo-1',
+      path: '/runtime/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      executionHostId: 'runtime:gpu'
+    }
+    const localRepo = {
+      id: 'repo-1',
+      path: '/local/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    store.getRepos.mockReturnValue([remoteRepo, localRepo])
+    store.getRepo.mockReturnValue(remoteRepo)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/feature',
+        head: 'abc123',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    store.getProjectHostSetups.mockReturnValue([
+      {
+        id: 'repo-1',
+        projectId: 'repo:repo-1',
+        hostId: 'local',
+        repoId: 'repo-1',
+        path: '/local/repo',
+        displayName: 'repo',
+        setupState: 'ready',
+        setupMethod: 'legacy-repo',
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ])
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      hostId: 'local',
+      name: 'feature'
+    })
+
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/local/repo',
+      '/workspace/feature',
+      'feature',
+      'origin/main',
+      false
+    )
+  })
+
   it('registers local worktree roots immediately after create', async () => {
     listWorktreesMock.mockResolvedValue([
       {
@@ -828,6 +885,53 @@ describe('registerWorktreeHandlers', () => {
       resolveRegisteredWorktreePath('/workspace/improve-dashboard', store as never)
     ).resolves.toBe(resolve('/workspace/improve-dashboard'))
     expect(listWorktreesMock).toHaveBeenCalledTimes(listWorktreesCallsAfterCreate)
+  })
+
+  it('uses the requested host when listing detected worktrees for same-id repos', async () => {
+    const remoteRepo = {
+      id: 'repo-1',
+      path: '/runtime/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      executionHostId: 'runtime:gpu'
+    }
+    const localRepo = {
+      id: 'repo-1',
+      path: '/local/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    store.getRepos.mockReturnValue([remoteRepo, localRepo])
+    store.getRepo.mockReturnValue(remoteRepo)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/local/repo',
+        head: 'main',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      },
+      {
+        path: '/local/feature',
+        head: 'abc123',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = (await handlers['worktrees:listDetected'](null, {
+      repoId: 'repo-1',
+      hostId: 'local'
+    })) as { worktrees: { path: string }[] }
+
+    expect(listWorktreesMock).toHaveBeenCalledWith('/local/repo')
+    expect(result.worktrees.map((worktree) => worktree.path)).toEqual([
+      '/local/repo',
+      '/local/feature'
+    ])
   })
 
   it('uses branchNameOverride for the git branch while keeping the sanitized worktree path', async () => {
@@ -2066,6 +2170,55 @@ describe('registerWorktreeHandlers', () => {
 
     expect(first).toEqual(second)
     expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reuse detected worktree scans across same-id repo hosts', async () => {
+    const localRepo = {
+      id: 'repo-1',
+      path: '/local/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    const runtimeRepo = {
+      ...localRepo,
+      path: '/runtime/repo',
+      executionHostId: 'runtime:gpu'
+    }
+    store.getRepos.mockReturnValue([localRepo, runtimeRepo])
+    store.getRepo.mockReturnValue(localRepo)
+    listWorktreesMock
+      .mockResolvedValueOnce([
+        {
+          path: '/local/repo',
+          head: 'local-head',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          path: '/runtime/repo',
+          head: 'runtime-head',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ])
+
+    const local = (await handlers['worktrees:listDetected'](null, {
+      repoId: 'repo-1',
+      hostId: 'local'
+    })) as { worktrees: Worktree[] }
+    const runtime = (await handlers['worktrees:listDetected'](null, {
+      repoId: 'repo-1',
+      hostId: 'runtime:gpu'
+    })) as { worktrees: Worktree[] }
+
+    expect(listWorktreesMock).toHaveBeenCalledTimes(2)
+    expect(local.worktrees[0].path).toBe('/local/repo')
+    expect(runtime.worktrees[0].path).toBe('/runtime/repo')
   })
 
   it('coalesces concurrent authoritative detected worktree scans', async () => {
@@ -5674,6 +5827,46 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('does not remove another host legacy metadata alias for same-id repos', async () => {
+    const localRepo = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    store.getRepo.mockReturnValue(localRepo)
+    store.getRepos.mockReturnValue([
+      localRepo,
+      {
+        ...localRepo,
+        path: '/runtime/repo',
+        executionHostId: 'runtime:gpu'
+      }
+    ])
+    mockKnownFeatureWorktree()
+    removeWorktreeMock.mockResolvedValue(undefined)
+    const canonicalWorktreeId = makeRepoWorktreeKey(localRepo, '/workspace/feature-wt')
+    const legacyWorktreeId = 'repo-1::/workspace/feature-wt'
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) => {
+      if (worktreeId === canonicalWorktreeId) {
+        return makeWorktreeMeta({ hostId: 'local' })
+      }
+      if (worktreeId === legacyWorktreeId) {
+        return makeWorktreeMeta({ hostId: 'runtime:gpu' })
+      }
+      return undefined
+    })
+
+    await handlers['worktrees:remove'](null, {
+      worktreeId: canonicalWorktreeId
+    })
+
+    expect(store.removeWorktreeMeta).toHaveBeenCalledWith(canonicalWorktreeId)
+    expect(store.removeWorktreeMeta).not.toHaveBeenCalledWith(legacyWorktreeId)
+    expect(deleteWorktreeHistoryDirMock).not.toHaveBeenCalledWith(legacyWorktreeId)
+  })
+
   it('refuses to delete the root workspace for folder-mode repos', async () => {
     store.getRepo.mockReturnValue({
       id: 'repo-folder',
@@ -6680,8 +6873,8 @@ describe('registerWorktreeHandlers', () => {
 
     finishRemoval()
     await expect(Promise.all([first, second])).resolves.toEqual([{}, {}])
-    expect(store.removeWorktreeMeta).toHaveBeenCalledTimes(1)
-    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledTimes(1)
+    expect(store.removeWorktreeMeta).toHaveBeenCalledTimes(2)
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledTimes(2)
     expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -583,10 +583,13 @@ function pruneLineageForMissingRepoWorktrees(
       store.removeWorktreeLineage(childId)
       store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
     }
-    if (
+    const parentMissingFromLegacyScan =
       lineage.parentWorktreeId.startsWith(repoPrefix) &&
       !legacyLiveIds.has(lineage.parentWorktreeId)
-    ) {
+    const parentMissingFromCanonicalScan =
+      isCanonicalWorktreeIdForRepoHost(repo, lineage.parentWorktreeId) &&
+      !liveIds.has(lineage.parentWorktreeId)
+    if (parentMissingFromLegacyScan || parentMissingFromCanonicalScan) {
       const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
       if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
         // Why: keep the child lineage so the UI can show "Missing parent", but
@@ -842,12 +845,16 @@ function getCanonicalFolderWorkspaceId(repo: Repo, worktreeId: string): string {
 }
 
 function migrateLegacyFolderWorkspaceMetaIfSafe(store: Store, repo: Repo): void {
+  const hasAmbiguousHost = hasAmbiguousRepoHost(store.getRepos(), repo)
   for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
     if (!isLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
       continue
     }
     const repoHostId = getRepoExecutionHostId(repo)
     if (meta.hostId !== undefined && meta.hostId !== repoHostId) {
+      continue
+    }
+    if (meta.hostId === undefined && hasAmbiguousHost) {
       continue
     }
     store.migrateWorktreeIdentity(worktreeId, getCanonicalFolderWorkspaceId(repo, worktreeId))

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -657,7 +657,9 @@ function listDisconnectedSshWorktrees(
     const worktree = mergeWorktree(
       repo.id,
       synthesizeSshGitWorktree(repo, candidate.path, meta),
-      meta
+      meta,
+      repo.displayName,
+      { hostId: getRepoExecutionHostId(repo) }
     )
     byWorktreeId.delete(worktree.id)
     byWorktreeId.set(worktree.id, worktree)

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -120,7 +120,7 @@ import {
   makeRepoWorktreeKey,
   parseWorktreeKey
 } from '../../shared/worktree-id'
-import { getRepoExecutionHostId } from '../../shared/execution-host'
+import { getRepoExecutionHostId, normalizeExecutionHostId } from '../../shared/execution-host'
 import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 import {
   getLocalProjectGitExecOptions,
@@ -191,6 +191,50 @@ function getRepoWorktreeId(
 
 function getRepoLegacyWorktreeId(repo: Pick<Repo, 'id'>, path: string): string {
   return makeLegacyWorktreeId(repo.id, path)
+}
+
+function getWorktreeRemovalIdAliases(
+  store: Store,
+  repos: Repo[],
+  repo: Repo,
+  worktreePath: string,
+  requestedId: string
+): string[] {
+  const canonicalId = getRepoWorktreeId(repo, worktreePath)
+  const legacyId = getRepoLegacyWorktreeId(repo, worktreePath)
+  const ids = new Set([canonicalId, requestedId])
+  const legacyMeta = store.getWorktreeMeta(legacyId)
+  const repoHostId = getRepoExecutionHostId(repo)
+  const requestedLegacyId = requestedId === legacyId
+  const legacyBelongsToRepoHost = legacyMeta?.hostId === repoHostId
+  const legacySafeWithoutMeta = legacyMeta === undefined
+  const legacyUnambiguous = !hasAmbiguousRepoHost(repos, repo)
+  if (requestedLegacyId || legacyBelongsToRepoHost || legacySafeWithoutMeta || legacyUnambiguous) {
+    ids.add(legacyId)
+  }
+  return [...ids]
+}
+
+function getRemovalWorktreeMeta(
+  store: Store,
+  worktreeIds: readonly string[]
+): WorktreeMeta | undefined {
+  for (const worktreeId of worktreeIds) {
+    const meta = store.getWorktreeMeta(worktreeId)
+    if (meta) {
+      return meta
+    }
+  }
+  return undefined
+}
+
+function removeWorktreeAliasesMetadataAndTransientState(
+  store: Store,
+  worktreeIds: readonly string[]
+): void {
+  for (const worktreeId of worktreeIds) {
+    removeWorktreeMetadataAndTransientState(store, worktreeId)
+  }
 }
 
 function migrateLegacyWorktreeMetaIfSafe(
@@ -382,11 +426,12 @@ type PreservedBranchCleanupTarget = {
 const preservedBranchCleanupByWorktreeId = new Map<string, PreservedBranchCleanupTarget>()
 
 function rememberPreservedBranchCleanupTarget(
-  worktreeId: string,
+  worktreeIds: string | readonly string[],
   result: RemoveWorktreeResult | undefined,
   fallbackHead: string | undefined,
   pushTarget: GitPushTarget | undefined
 ): void {
+  const ids = typeof worktreeIds === 'string' ? [worktreeIds] : worktreeIds
   if (result?.preservedBranch) {
     const head = result.preservedBranch.head ?? fallbackHead
     if (!head) {
@@ -394,14 +439,18 @@ function rememberPreservedBranchCleanupTarget(
         `Cannot safely offer force-delete for preserved branch "${result.preservedBranch.branchName}" without its saved commit.`
       )
     }
-    preservedBranchCleanupByWorktreeId.set(worktreeId, {
-      branchName: result.preservedBranch.branchName,
-      head,
-      ...(pushTarget ? { pushTarget } : {})
-    })
+    for (const worktreeId of ids) {
+      preservedBranchCleanupByWorktreeId.set(worktreeId, {
+        branchName: result.preservedBranch.branchName,
+        head,
+        ...(pushTarget ? { pushTarget } : {})
+      })
+    }
     return
   }
-  preservedBranchCleanupByWorktreeId.delete(worktreeId)
+  for (const worktreeId of ids) {
+    preservedBranchCleanupByWorktreeId.delete(worktreeId)
+  }
 }
 
 function preserveBranchHeadFallback(
@@ -453,9 +502,33 @@ const detectedWorktreeScanCache = new Map<string, DetectedWorktreeScanCacheEntry
 const detectedWorktreeScanInFlight = new Map<string, Promise<GitWorktreeInfo[]>>()
 const detectedWorktreeScanGenerations = new Map<string, number>()
 
+function getDetectedWorktreeScanCacheKey(repo: Repo): string {
+  return JSON.stringify({
+    repoId: repo.id,
+    hostId: getRepoExecutionHostId(repo),
+    path: repo.path
+  })
+}
+
+function isDetectedWorktreeScanCacheKeyForRepo(cacheKey: string, repoId: string): boolean {
+  try {
+    return (JSON.parse(cacheKey) as { repoId?: unknown }).repoId === repoId
+  } catch {
+    return false
+  }
+}
+
 function invalidateDetectedWorktreeScanCache(repoId: string): void {
-  detectedWorktreeScanCache.delete(repoId)
-  detectedWorktreeScanInFlight.delete(repoId)
+  for (const key of detectedWorktreeScanCache.keys()) {
+    if (isDetectedWorktreeScanCacheKeyForRepo(key, repoId)) {
+      detectedWorktreeScanCache.delete(key)
+    }
+  }
+  for (const key of detectedWorktreeScanInFlight.keys()) {
+    if (isDetectedWorktreeScanCacheKeyForRepo(key, repoId)) {
+      detectedWorktreeScanInFlight.delete(key)
+    }
+  }
   detectedWorktreeScanGenerations.set(
     repoId,
     (detectedWorktreeScanGenerations.get(repoId) ?? 0) + 1
@@ -481,34 +554,35 @@ async function listDetectedGitWorktrees(
     }
   }
 
-  const cached = detectedWorktreeScanCache.get(repo.id)
+  const cacheKey = getDetectedWorktreeScanCacheKey(repo)
+  const cached = detectedWorktreeScanCache.get(cacheKey)
   if (cached && cached.expiresAt > Date.now()) {
     return { gitWorktrees: cached.worktrees, fresh: false }
   }
 
-  const inFlight = detectedWorktreeScanInFlight.get(repo.id)
+  const inFlight = detectedWorktreeScanInFlight.get(cacheKey)
   if (inFlight) {
     return { gitWorktrees: await inFlight, fresh: false }
   }
 
   const scan = listRepoWorktrees(repo, getLocalProjectWorktreeGitOptions(store, repo))
   const generation = detectedWorktreeScanGenerations.get(repo.id) ?? 0
-  detectedWorktreeScanInFlight.set(repo.id, scan)
+  detectedWorktreeScanInFlight.set(cacheKey, scan)
   try {
     const gitWorktrees = await scan
     // Why: a create/remove notification can invalidate while the git scan is
     // still running. Do not let that stale scan repopulate the cache afterward.
     const isCurrentGeneration = (detectedWorktreeScanGenerations.get(repo.id) ?? 0) === generation
     if (isCurrentGeneration) {
-      detectedWorktreeScanCache.set(repo.id, {
+      detectedWorktreeScanCache.set(cacheKey, {
         worktrees: gitWorktrees,
         expiresAt: Date.now() + DETECTED_WORKTREE_SCAN_CACHE_TTL_MS
       })
     }
     return { gitWorktrees, fresh: isCurrentGeneration }
   } finally {
-    if (detectedWorktreeScanInFlight.get(repo.id) === scan) {
-      detectedWorktreeScanInFlight.delete(repo.id)
+    if (detectedWorktreeScanInFlight.get(cacheKey) === scan) {
+      detectedWorktreeScanInFlight.delete(cacheKey)
     }
   }
 }
@@ -659,7 +733,7 @@ function getRepoForWorktreeRemoval(
     return fallbackRepo
   }
   const hostIds = new Set(matchingRepos.map((repo) => getRepoExecutionHostId(repo)))
-  // Why: legacy `repoId::path` removal requests are safe only when the repo id
+  // Why: legacy repo-id-only requests are safe only when the repo id
   // belongs to exactly one execution host. Canonical IDs must carry hostId.
   if (hostIds.size !== 1) {
     return undefined
@@ -668,6 +742,25 @@ function getRepoForWorktreeRemoval(
   return fallbackRepo && getRepoExecutionHostId(fallbackRepo) === hostId
     ? fallbackRepo
     : matchingRepos[0]
+}
+
+function getRepoForHostScopedRequest(
+  store: Store,
+  parsed: { repoId: string; hostId?: string }
+): Repo | undefined {
+  const fallbackRepo = store.getRepo(parsed.repoId)
+  if (parsed.hostId === undefined) {
+    return fallbackRepo
+  }
+  if (fallbackRepo && getRepoExecutionHostId(fallbackRepo) === parsed.hostId) {
+    return fallbackRepo
+  }
+  return store
+    .getRepos()
+    .find(
+      (candidate) =>
+        candidate.id === parsed.repoId && getRepoExecutionHostId(candidate) === parsed.hostId
+    )
 }
 
 function isSshWorktreeMetaCandidateForRepo(
@@ -1131,8 +1224,15 @@ export function registerWorktreeHandlers(
     return results.flat()
   })
 
-  ipcMain.handle('worktrees:list', async (_event, args: { repoId: string }) => {
-    const repo = store.getRepo(args.repoId)
+  ipcMain.handle('worktrees:list', async (_event, args: { repoId: string; hostId?: string }) => {
+    const hostId = args.hostId ? normalizeExecutionHostId(args.hostId) : undefined
+    if (args.hostId && !hostId) {
+      throw new Error(`Invalid execution host id: ${args.hostId}`)
+    }
+    const repo = getRepoForHostScopedRequest(store, {
+      repoId: args.repoId,
+      ...(hostId ? { hostId } : {})
+    })
     if (!repo) {
       return []
     }
@@ -1191,8 +1291,18 @@ export function registerWorktreeHandlers(
 
   ipcMain.handle(
     'worktrees:listDetected',
-    async (_event, args: { repoId: string }): Promise<DetectedWorktreeListResult> => {
-      const repo = store.getRepo(args.repoId)
+    async (
+      _event,
+      args: { repoId: string; hostId?: string }
+    ): Promise<DetectedWorktreeListResult> => {
+      const hostId = args.hostId ? normalizeExecutionHostId(args.hostId) : undefined
+      if (args.hostId && !hostId) {
+        throw new Error(`Invalid execution host id: ${args.hostId}`)
+      }
+      const repo = getRepoForHostScopedRequest(store, {
+        repoId: args.repoId,
+        ...(hostId ? { hostId } : {})
+      })
       if (!repo) {
         return {
           repoId: args.repoId,
@@ -1293,7 +1403,19 @@ export function registerWorktreeHandlers(
       // title) and the redactor would have to learn yet another rule;
       // the repo ID is the safer correlator for the bundle.
       return withWorktreeSpan({ stage: 'create' }, async () => {
-        const repo = store.getRepo(args.repoId)
+        const requestedHostId = args.hostId ? normalizeExecutionHostId(args.hostId) : null
+        if (args.hostId && !requestedHostId) {
+          throw new Error(`Invalid execution host id: ${args.hostId}`)
+        }
+        const repo = requestedHostId
+          ? store
+              .getRepos()
+              .find(
+                (candidate) =>
+                  candidate.id === args.repoId &&
+                  getRepoExecutionHostId(candidate) === requestedHostId
+              )
+          : store.getRepo(args.repoId)
         if (!repo) {
           throw new Error(`Repo not found: ${args.repoId}`)
         }
@@ -1482,6 +1604,22 @@ export function registerWorktreeHandlers(
         if (!repo) {
           throw new Error(`Repo not found: ${repoId}`)
         }
+        const removalWorktreeIds = getWorktreeRemovalIdAliases(
+          store,
+          store.getRepos(),
+          repo,
+          worktreePath,
+          args.worktreeId
+        )
+        const clearRemovalState = (options: { clearPreservedBranch?: boolean } = {}) => {
+          for (const worktreeId of removalWorktreeIds) {
+            runtime.clearOptimisticReconcileToken(worktreeId)
+            if (options.clearPreservedBranch) {
+              preservedBranchCleanupByWorktreeId.delete(worktreeId)
+            }
+          }
+          removeWorktreeAliasesMetadataAndTransientState(store, removalWorktreeIds)
+        }
         if (isFolderRepo(repo)) {
           if (isFolderWorkspaceRootIdForRepo(repo, args.worktreeId)) {
             throw new Error(
@@ -1497,8 +1635,7 @@ export function registerWorktreeHandlers(
           }).catch((err) => {
             console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
           })
-          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-          preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+          clearRemovalState({ clearPreservedBranch: true })
           notifyWorktreesChanged(mainWindow, repoId)
           return {}
         }
@@ -1515,7 +1652,7 @@ export function registerWorktreeHandlers(
           : hasLocalWorktreeGitOptions
             ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
             : await listGitWorktreesStrict(repo.path)
-        const removedMeta = store.getWorktreeMeta(args.worktreeId)
+        const removedMeta = getRemovalWorktreeMeta(store, removalWorktreeIds)
         const removedPushTarget = removedMeta?.pushTarget
         const registeredWorktree = findRegisteredDeletableWorktree(
           repo.path,
@@ -1570,7 +1707,7 @@ export function registerWorktreeHandlers(
               await cleanupUnusedWorktreePushTargetRemoteSsh(
                 provider!,
                 repo.path,
-                args.worktreeId,
+                removalWorktreeIds,
                 removedPushTarget,
                 store
               )
@@ -1579,16 +1716,14 @@ export function registerWorktreeHandlers(
               await removeLocalWorktreePath(worktreePath, localWorktreeGitOptions)
               await cleanupUnusedWorktreePushTargetRemote(
                 repo.path,
-                args.worktreeId,
+                removalWorktreeIds,
                 removedPushTarget,
                 store,
                 localWorktreeGitOptions
               )
               invalidateAuthorizedRootsCache()
             }
-            runtime.clearOptimisticReconcileToken(args.worktreeId)
-            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-            preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+            clearRemovalState({ clearPreservedBranch: true })
             notifyWorktreesChanged(mainWindow, repoId)
             return {}
           }
@@ -1605,23 +1740,21 @@ export function registerWorktreeHandlers(
               await cleanupUnusedWorktreePushTargetRemoteSsh(
                 provider!,
                 repo.path,
-                args.worktreeId,
+                removalWorktreeIds,
                 removedPushTarget,
                 store
               )
             } else {
               await cleanupUnusedWorktreePushTargetRemote(
                 repo.path,
-                args.worktreeId,
+                removalWorktreeIds,
                 removedPushTarget,
                 store,
                 localWorktreeGitOptions
               )
               invalidateAuthorizedRootsCache()
             }
-            runtime.clearOptimisticReconcileToken(args.worktreeId)
-            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-            preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+            clearRemovalState({ clearPreservedBranch: true })
             notifyWorktreesChanged(mainWindow, repoId)
             return {}
           }
@@ -1674,18 +1807,17 @@ export function registerWorktreeHandlers(
           await cleanupUnusedWorktreePushTargetRemoteSsh(
             provider!,
             repo.path,
-            args.worktreeId,
+            removalWorktreeIds,
             removedPushTarget,
             store
           )
           rememberPreservedBranchCleanupTarget(
-            args.worktreeId,
+            removalWorktreeIds,
             removalResult,
             registeredWorktree.head,
             removedPushTarget
           )
-          runtime.clearOptimisticReconcileToken(args.worktreeId)
-          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+          clearRemovalState()
           notifyWorktreesChanged(mainWindow, repoId)
           return removalResult ?? {}
         }
@@ -1793,14 +1925,12 @@ export function registerWorktreeHandlers(
             }).catch(() => {})
             await cleanupUnusedWorktreePushTargetRemote(
               repo.path,
-              args.worktreeId,
+              removalWorktreeIds,
               removedPushTarget,
               store,
               localWorktreeGitOptions
             )
-            runtime.clearOptimisticReconcileToken(args.worktreeId)
-            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-            preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+            clearRemovalState({ clearPreservedBranch: true })
             invalidateAuthorizedRootsCache()
             notifyWorktreesChanged(mainWindow, repoId)
             return {}
@@ -1811,19 +1941,18 @@ export function registerWorktreeHandlers(
         }
         await cleanupUnusedWorktreePushTargetRemote(
           repo.path,
-          args.worktreeId,
+          removalWorktreeIds,
           removedPushTarget,
           store,
           localWorktreeGitOptions
         )
         rememberPreservedBranchCleanupTarget(
-          args.worktreeId,
+          removalWorktreeIds,
           removalResult,
           registeredWorktree.head,
           removedPushTarget
         )
-        runtime.clearOptimisticReconcileToken(args.worktreeId)
-        removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+        clearRemovalState()
         invalidateAuthorizedRootsCache()
 
         notifyWorktreesChanged(mainWindow, repoId)
@@ -1846,16 +1975,26 @@ export function registerWorktreeHandlers(
       _event,
       args: { worktreeId: string; branchName: string; expectedHead: string }
     ): Promise<ForceDeleteWorktreeBranchResult> => {
-      const { repoId } = parseWorktreeId(args.worktreeId)
+      const parsedWorktreeId = parseWorktreeId(args.worktreeId) as ReturnType<
+        typeof parseWorktreeId
+      > & { hostId?: string }
+      const { repoId } = parsedWorktreeId
       const cleanupTarget = getPreservedBranchCleanupTarget(
         args.worktreeId,
         args.branchName,
         args.expectedHead
       )
-      const repo = store.getRepo(repoId)
+      const repo = getRepoForWorktreeRemoval(store, parsedWorktreeId)
       if (!repo) {
         throw new Error(`Repo not found: ${repoId}`)
       }
+      const cleanupWorktreeIds = getWorktreeRemovalIdAliases(
+        store,
+        store.getRepos(),
+        repo,
+        parsedWorktreeId.worktreePath,
+        args.worktreeId
+      )
       if (isFolderRepo(repo)) {
         throw new Error('Folder workspaces do not have local Git branches.')
       }
@@ -1871,7 +2010,7 @@ export function registerWorktreeHandlers(
         await cleanupUnusedWorktreePushTargetRemoteSsh(
           provider,
           repo.path,
-          args.worktreeId,
+          cleanupWorktreeIds,
           cleanupTarget.pushTarget,
           store
         )
@@ -1888,14 +2027,16 @@ export function registerWorktreeHandlers(
           : forceDeleteLocalBranch(repo.path, cleanupTarget.branchName, cleanupTarget.head))
         await cleanupUnusedWorktreePushTargetRemote(
           repo.path,
-          args.worktreeId,
+          cleanupWorktreeIds,
           cleanupTarget.pushTarget,
           store,
           localWorktreeGitOptions
         )
       }
 
-      preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+      for (const worktreeId of cleanupWorktreeIds) {
+        preservedBranchCleanupByWorktreeId.delete(worktreeId)
+      }
       return { deleted: true }
     }
   )

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -639,6 +639,34 @@ function hasAmbiguousRepoHost(repos: Repo[], repo: Repo): boolean {
   return hostIds.size > 1
 }
 
+function getRepoForWorktreeRemoval(
+  store: Store,
+  parsed: { repoId: string; hostId?: string }
+): Repo | undefined {
+  const repos = store.getRepos()
+  const matchingRepos = repos.filter((repo) => repo.id === parsed.repoId)
+  const fallbackRepo = store.getRepo(parsed.repoId)
+  if (parsed.hostId !== undefined) {
+    if (fallbackRepo && getRepoExecutionHostId(fallbackRepo) === parsed.hostId) {
+      return fallbackRepo
+    }
+    return matchingRepos.find((candidate) => getRepoExecutionHostId(candidate) === parsed.hostId)
+  }
+  if (matchingRepos.length === 0) {
+    return fallbackRepo
+  }
+  const hostIds = new Set(matchingRepos.map((repo) => getRepoExecutionHostId(repo)))
+  // Why: legacy `repoId::path` removal requests are safe only when the repo id
+  // belongs to exactly one execution host. Canonical IDs must carry hostId.
+  if (hostIds.size !== 1) {
+    return undefined
+  }
+  const [hostId] = hostIds
+  return fallbackRepo && getRepoExecutionHostId(fallbackRepo) === hostId
+    ? fallbackRepo
+    : matchingRepos[0]
+}
+
 function isSshWorktreeMetaCandidateForRepo(
   repos: Repo[],
   repo: Repo,
@@ -1439,8 +1467,11 @@ export function registerWorktreeHandlers(
       // target the same worktree concurrently. Share the destructive backend
       // operation so only one path touches Git and the filesystem.
       const removal = (async (): Promise<RemoveWorktreeResult> => {
-        const { repoId, worktreePath } = parseWorktreeId(args.worktreeId)
-        const repo = store.getRepo(repoId)
+        const parsedWorktreeId = parseWorktreeId(args.worktreeId) as ReturnType<
+          typeof parseWorktreeId
+        > & { hostId?: string }
+        const { repoId, worktreePath } = parsedWorktreeId
+        const repo = getRepoForWorktreeRemoval(store, parsedWorktreeId)
         if (!repo) {
           throw new Error(`Repo not found: ${repoId}`)
         }

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -114,7 +114,13 @@ import {
 } from '../worktree-removal-safety'
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
-import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
+import {
+  FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
+  makeLegacyWorktreeId,
+  makeRepoWorktreeKey,
+  parseWorktreeKey
+} from '../../shared/worktree-id'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 import {
   getLocalProjectGitExecOptions,
@@ -174,6 +180,39 @@ function dedupeGitWorktreesByPath(gitWorktrees: GitWorktreeInfo[]): GitWorktreeI
     uniqueGitWorktrees.push(gitWorktree)
   }
   return uniqueGitWorktrees
+}
+
+function getRepoWorktreeId(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string
+): string {
+  return makeRepoWorktreeKey(repo, path)
+}
+
+function getRepoLegacyWorktreeId(repo: Pick<Repo, 'id'>, path: string): string {
+  return makeLegacyWorktreeId(repo.id, path)
+}
+
+function migrateLegacyWorktreeMetaIfSafe(store: Store, repo: Repo, path: string): void {
+  const canonicalId = getRepoWorktreeId(repo, path)
+  if (store.getWorktreeMeta(canonicalId)) {
+    return
+  }
+  const legacyId = getRepoLegacyWorktreeId(repo, path)
+  const legacyMeta = store.getWorktreeMeta(legacyId)
+  if (!legacyMeta) {
+    return
+  }
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (legacyMeta.hostId !== undefined && legacyMeta.hostId !== repoHostId) {
+    return
+  }
+  store.migrateWorktreeIdentity(legacyId, canonicalId)
+}
+
+function isCanonicalWorktreeIdForRepoHost(repo: Repo, worktreeId: string): boolean {
+  const parsed = parseWorktreeKey(worktreeId)
+  return parsed?.repoId === repo.id && parsed.hostId === getRepoExecutionHostId(repo)
 }
 
 function getProjectHostSetupMetaUpdates(
@@ -506,14 +545,17 @@ function pruneLineageForMissingRepoWorktrees(
   ) {
     return
   }
-  const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
+  const liveIds = new Set(gitWorktrees.map((worktree) => getRepoWorktreeId(repo, worktree.path)))
+  const legacyLiveIds = new Set(
+    gitWorktrees.map((worktree) => getRepoLegacyWorktreeId(repo, worktree.path))
+  )
   const repoPrefix = `${repo.id}::`
   for (const childWorkspaceKey of Object.keys(store.getAllWorkspaceLineage?.() ?? {})) {
     const childScope = parseWorkspaceKey(childWorkspaceKey)
     if (
       childScope?.type === 'worktree' &&
       childScope.worktreeId.startsWith(repoPrefix) &&
-      !liveIds.has(childScope.worktreeId)
+      !legacyLiveIds.has(childScope.worktreeId)
     ) {
       if (isWorkspaceKey(childWorkspaceKey)) {
         store.removeWorkspaceLineage?.(childWorkspaceKey)
@@ -521,7 +563,10 @@ function pruneLineageForMissingRepoWorktrees(
     }
   }
   for (const [childId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-    if (childId.startsWith(repoPrefix) && !liveIds.has(childId)) {
+    if (
+      (childId.startsWith(repoPrefix) && !legacyLiveIds.has(childId)) ||
+      (isCanonicalWorktreeIdForRepoHost(repo, childId) && !liveIds.has(childId))
+    ) {
       // Why: path-derived IDs can disappear and later be reused by a different
       // checkout. Once a successful scan proves the child is gone, drop its
       // lineage so a future same-path worktree cannot inherit it. Missing
@@ -530,7 +575,10 @@ function pruneLineageForMissingRepoWorktrees(
       store.removeWorktreeLineage(childId)
       store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
     }
-    if (lineage.parentWorktreeId.startsWith(repoPrefix) && !liveIds.has(lineage.parentWorktreeId)) {
+    if (
+      lineage.parentWorktreeId.startsWith(repoPrefix) &&
+      !legacyLiveIds.has(lineage.parentWorktreeId)
+    ) {
       const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
       if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
         // Why: keep the child lineage so the UI can show "Missing parent", but
@@ -595,13 +643,16 @@ function listDisconnectedSshWorktrees(
 ): ReturnType<typeof mergeWorktree>[] {
   const byWorktreeId = new Map<string, ReturnType<typeof mergeWorktree>>()
   for (const candidate of metaIndex.get(repo.id) ?? []) {
-    const ownershipUpdates = getProjectHostSetupMetaUpdates(store, repo, candidate.meta)
+    migrateLegacyWorktreeMetaIfSafe(store, repo, candidate.path)
+    const canonicalId = getRepoWorktreeId(repo, candidate.path)
+    const candidateMeta = store.getWorktreeMeta(canonicalId) ?? candidate.meta
+    const ownershipUpdates = getProjectHostSetupMetaUpdates(store, repo, candidateMeta)
     const meta =
       Object.keys(ownershipUpdates).length > 0
-        ? { ...candidate.meta, ...ownershipUpdates }
-        : candidate.meta
+        ? { ...candidateMeta, ...ownershipUpdates }
+        : candidateMeta
     if (Object.keys(ownershipUpdates).length > 0) {
-      store.setWorktreeMeta(candidate.id, ownershipUpdates)
+      store.setWorktreeMeta(canonicalId, ownershipUpdates)
     }
     const worktree = mergeWorktree(
       repo.id,
@@ -623,9 +674,12 @@ function buildDetectedGitWorktrees(
   const knownOrcaLayouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
   const isLegacyRepoForVisibility = isLegacyRepoForExternalWorktreeVisibility(repo)
   return dedupeGitWorktreesByPath(gitWorktrees).map((gitWorktree) => {
-    const worktreeId = `${repo.id}::${gitWorktree.path}`
+    migrateLegacyWorktreeMetaIfSafe(store, repo, gitWorktree.path)
+    const worktreeId = getRepoWorktreeId(repo, gitWorktree.path)
     let meta = store.getWorktreeMeta(worktreeId)
-    const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+    const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+      hostId: getRepoExecutionHostId(repo)
+    })
     const detected = toDetectedWorktree({
       repo,
       worktree,
@@ -641,7 +695,9 @@ function buildDetectedGitWorktrees(
     meta = resolveWorktreeMetaWithDiscoveryBackfill(store, repo, worktreeId)
     return toDetectedWorktree({
       repo,
-      worktree: mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
+      worktree: mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+        hostId: getRepoExecutionHostId(repo)
+      }),
       meta,
       settings,
       knownOrcaLayouts,
@@ -655,21 +711,32 @@ function stampAndMergeVisibleDetectedWorktree(
   repo: Repo,
   detected: DetectedWorktree
 ) {
+  migrateLegacyWorktreeMetaIfSafe(store, repo, detected.path)
   const meta = resolveWorktreeMetaWithDiscoveryBackfill(store, repo, detected.id)
-  return mergeWorktree(repo.id, detected, meta, repo.displayName)
+  return mergeWorktree(repo.id, detected, meta, repo.displayName, {
+    hostId: getRepoExecutionHostId(repo)
+  })
 }
 
 function getFolderWorkspaceRootId(repo: Repo): string {
-  return `${repo.id}::${repo.path}`
+  return getRepoWorktreeId(repo, repo.path)
 }
 
 function getFolderWorkspaceInstanceId(repo: Repo, instanceId: string): string {
   return `${getFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
 }
 
+function getLegacyFolderWorkspaceRootId(repo: Repo): string {
+  return getRepoLegacyWorktreeId(repo, repo.path)
+}
+
 function getFolderWorkspaceInstanceIdentity(repo: Repo, worktreeId: string): string {
   const prefix = `${getFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
-  return worktreeId.startsWith(prefix) ? worktreeId.slice(prefix.length) : randomUUID()
+  const legacyPrefix = `${getLegacyFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
+  if (worktreeId.startsWith(prefix)) {
+    return worktreeId.slice(prefix.length)
+  }
+  return worktreeId.startsWith(legacyPrefix) ? worktreeId.slice(legacyPrefix.length) : randomUUID()
 }
 
 function isFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
@@ -678,6 +745,44 @@ function isFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
     worktreeId === rootId ||
     worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
   )
+}
+
+function isLegacyFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
+  const rootId = getLegacyFolderWorkspaceRootId(repo)
+  return (
+    worktreeId === rootId ||
+    worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
+  )
+}
+
+function isFolderWorkspaceRootIdForRepo(repo: Repo, worktreeId: string): boolean {
+  return (
+    worktreeId === getFolderWorkspaceRootId(repo) ||
+    worktreeId === getLegacyFolderWorkspaceRootId(repo)
+  )
+}
+
+function getCanonicalFolderWorkspaceId(repo: Repo, worktreeId: string): string {
+  if (!isLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
+    return worktreeId
+  }
+  const instanceId = getFolderWorkspaceInstanceIdentity(repo, worktreeId)
+  return worktreeId === getLegacyFolderWorkspaceRootId(repo)
+    ? getFolderWorkspaceRootId(repo)
+    : getFolderWorkspaceInstanceId(repo, instanceId)
+}
+
+function migrateLegacyFolderWorkspaceMetaIfSafe(store: Store, repo: Repo): void {
+  for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
+    if (!isLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
+      continue
+    }
+    const repoHostId = getRepoExecutionHostId(repo)
+    if (meta.hostId !== undefined && meta.hostId !== repoHostId) {
+      continue
+    }
+    store.migrateWorktreeIdentity(worktreeId, getCanonicalFolderWorkspaceId(repo, worktreeId))
+  }
 }
 
 function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta): Worktree {
@@ -726,6 +831,7 @@ function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta
 }
 
 function listFolderWorkspaces(store: Store, repo: Repo): Worktree[] {
+  migrateLegacyFolderWorkspaceMetaIfSafe(store, repo)
   const rootId = getFolderWorkspaceRootId(repo)
   const allMeta = store.getAllWorktreeMeta()
   const ids = Object.keys(allMeta).filter((worktreeId) =>
@@ -1296,7 +1402,7 @@ export function registerWorktreeHandlers(
           throw new Error(`Repo not found: ${repoId}`)
         }
         if (isFolderRepo(repo)) {
-          if (args.worktreeId === getFolderWorkspaceRootId(repo)) {
+          if (isFolderWorkspaceRootIdForRepo(repo, args.worktreeId)) {
             throw new Error(
               'Cannot delete the project root workspace. Remove the folder project instead.'
             )

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -193,7 +193,12 @@ function getRepoLegacyWorktreeId(repo: Pick<Repo, 'id'>, path: string): string {
   return makeLegacyWorktreeId(repo.id, path)
 }
 
-function migrateLegacyWorktreeMetaIfSafe(store: Store, repo: Repo, path: string): void {
+function migrateLegacyWorktreeMetaIfSafe(
+  store: Store,
+  repos: Repo[],
+  repo: Repo,
+  path: string
+): void {
   const canonicalId = getRepoWorktreeId(repo, path)
   if (store.getWorktreeMeta(canonicalId)) {
     return
@@ -205,6 +210,9 @@ function migrateLegacyWorktreeMetaIfSafe(store: Store, repo: Repo, path: string)
   }
   const repoHostId = getRepoExecutionHostId(repo)
   if (legacyMeta.hostId !== undefined && legacyMeta.hostId !== repoHostId) {
+    return
+  }
+  if (legacyMeta.hostId === undefined && hasAmbiguousRepoHost(repos, repo)) {
     return
   }
   store.migrateWorktreeIdentity(legacyId, canonicalId)
@@ -592,6 +600,7 @@ function pruneLineageForMissingRepoWorktrees(
 
 type SshWorktreeMetaCandidate = {
   id: string
+  hostId?: string
   path: string
   meta: WorktreeMeta
 }
@@ -601,7 +610,7 @@ type SshWorktreeMetaIndex = Map<string, SshWorktreeMetaCandidate[]>
 function createSshWorktreeMetaIndex(entries: [string, WorktreeMeta][]): SshWorktreeMetaIndex {
   const index: SshWorktreeMetaIndex = new Map()
   for (const [worktreeId, meta] of entries) {
-    let parsed: { repoId: string; worktreePath: string }
+    let parsed: { repoId: string; worktreePath: string; hostId?: string }
     try {
       parsed = parseWorktreeId(worktreeId)
     } catch (err) {
@@ -615,10 +624,34 @@ function createSshWorktreeMetaIndex(entries: [string, WorktreeMeta][]): SshWorkt
     }
 
     const candidates = index.get(parsed.repoId) ?? []
-    candidates.push({ id: worktreeId, path: parsed.worktreePath, meta })
+    candidates.push({ id: worktreeId, hostId: parsed.hostId, path: parsed.worktreePath, meta })
     index.set(parsed.repoId, candidates)
   }
   return index
+}
+
+function hasAmbiguousRepoHost(repos: Repo[], repo: Repo): boolean {
+  const hostIds = new Set(
+    repos
+      .filter((candidateRepo) => candidateRepo.id === repo.id)
+      .map((candidateRepo) => getRepoExecutionHostId(candidateRepo))
+  )
+  return hostIds.size > 1
+}
+
+function isSshWorktreeMetaCandidateForRepo(
+  repos: Repo[],
+  repo: Repo,
+  candidate: SshWorktreeMetaCandidate
+): boolean {
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (candidate.hostId !== undefined) {
+    return candidate.hostId === repoHostId
+  }
+  if (candidate.meta.hostId !== undefined) {
+    return candidate.meta.hostId === repoHostId
+  }
+  return !hasAmbiguousRepoHost(repos, repo)
 }
 
 function synthesizeSshGitWorktree(repo: Repo, path: string, meta: WorktreeMeta): GitWorktreeInfo {
@@ -638,12 +671,16 @@ function synthesizeSshGitWorktree(repo: Repo, path: string, meta: WorktreeMeta):
 
 function listDisconnectedSshWorktrees(
   store: Store,
+  repos: Repo[],
   repo: Repo,
   metaIndex: SshWorktreeMetaIndex
 ): ReturnType<typeof mergeWorktree>[] {
   const byWorktreeId = new Map<string, ReturnType<typeof mergeWorktree>>()
   for (const candidate of metaIndex.get(repo.id) ?? []) {
-    migrateLegacyWorktreeMetaIfSafe(store, repo, candidate.path)
+    if (!isSshWorktreeMetaCandidateForRepo(repos, repo, candidate)) {
+      continue
+    }
+    migrateLegacyWorktreeMetaIfSafe(store, repos, repo, candidate.path)
     const canonicalId = getRepoWorktreeId(repo, candidate.path)
     const candidateMeta = store.getWorktreeMeta(canonicalId) ?? candidate.meta
     const ownershipUpdates = getProjectHostSetupMetaUpdates(store, repo, candidateMeta)
@@ -658,7 +695,7 @@ function listDisconnectedSshWorktrees(
       repo.id,
       synthesizeSshGitWorktree(repo, candidate.path, meta),
       meta,
-      repo.displayName,
+      undefined,
       { hostId: getRepoExecutionHostId(repo) }
     )
     byWorktreeId.delete(worktree.id)
@@ -669,6 +706,7 @@ function listDisconnectedSshWorktrees(
 
 function buildDetectedGitWorktrees(
   store: Store,
+  repos: Repo[],
   repo: Repo,
   gitWorktrees: GitWorktreeInfo[]
 ): DetectedWorktree[] {
@@ -676,7 +714,7 @@ function buildDetectedGitWorktrees(
   const knownOrcaLayouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
   const isLegacyRepoForVisibility = isLegacyRepoForExternalWorktreeVisibility(repo)
   return dedupeGitWorktreesByPath(gitWorktrees).map((gitWorktree) => {
-    migrateLegacyWorktreeMetaIfSafe(store, repo, gitWorktree.path)
+    migrateLegacyWorktreeMetaIfSafe(store, repos, repo, gitWorktree.path)
     const worktreeId = getRepoWorktreeId(repo, gitWorktree.path)
     let meta = store.getWorktreeMeta(worktreeId)
     const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
@@ -710,10 +748,11 @@ function buildDetectedGitWorktrees(
 
 function stampAndMergeVisibleDetectedWorktree(
   store: Store,
+  repos: Repo[],
   repo: Repo,
   detected: DetectedWorktree
 ) {
-  migrateLegacyWorktreeMetaIfSafe(store, repo, detected.path)
+  migrateLegacyWorktreeMetaIfSafe(store, repos, repo, detected.path)
   const meta = resolveWorktreeMetaWithDiscoveryBackfill(store, repo, detected.id)
   return mergeWorktree(repo.id, detected, meta, repo.displayName, {
     hostId: getRepoExecutionHostId(repo)
@@ -1010,7 +1049,7 @@ export function registerWorktreeHandlers(
               `${repo.connectionId}:${repo.id}`,
               `[worktrees] SSH git provider unavailable; skipping worktree list for repo "${repo.displayName}" (${repo.id}) at ${repo.path} on connection ${repo.connectionId}`
             )
-            return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+            return listDisconnectedSshWorktrees(store, repos, repo, sshWorktreeMetaIndex)
           }
           loggedUnavailableSshGitProviders.delete(`${repo.connectionId}:${repo.id}`)
           try {
@@ -1022,7 +1061,7 @@ export function registerWorktreeHandlers(
               `[worktrees] failed to list worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
               err
             )
-            return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+            return listDisconnectedSshWorktrees(store, repos, repo, sshWorktreeMetaIndex)
           }
         } else {
           gitWorktrees = await listRepoWorktrees(
@@ -1033,9 +1072,9 @@ export function registerWorktreeHandlers(
         rememberLocalWorktreeRoots(store, repo, gitWorktrees)
         pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
         loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
-        return buildDetectedGitWorktrees(store, repo, gitWorktrees)
+        return buildDetectedGitWorktrees(store, repos, repo, gitWorktrees)
           .filter((worktree) => worktree.visible)
-          .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree))
+          .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repos, repo, worktree))
       } catch (err) {
         warnOnce(
           loggedWorktreeListFailures,
@@ -1062,6 +1101,7 @@ export function registerWorktreeHandlers(
     if (!repo) {
       return []
     }
+    const repos = store.getRepos()
     const sshWorktreeMetaIndex = repo.connectionId
       ? createSshWorktreeMetaIndex(Object.entries(store.getAllWorktreeMeta()))
       : new Map()
@@ -1078,7 +1118,7 @@ export function registerWorktreeHandlers(
             `${repo.connectionId}:${repo.id}`,
             `[worktrees] SSH git provider unavailable; skipping worktree list for repo "${repo.displayName}" (${repo.id}) at ${repo.path} on connection ${repo.connectionId}`
           )
-          return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+          return listDisconnectedSshWorktrees(store, repos, repo, sshWorktreeMetaIndex)
         }
         loggedUnavailableSshGitProviders.delete(`${repo.connectionId}:${repo.id}`)
         try {
@@ -1090,7 +1130,7 @@ export function registerWorktreeHandlers(
             `[worktrees] failed to list worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
             err
           )
-          return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+          return listDisconnectedSshWorktrees(store, repos, repo, sshWorktreeMetaIndex)
         }
       } else {
         gitWorktrees = await listRepoWorktrees(repo, getLocalProjectWorktreeGitOptions(store, repo))
@@ -1098,9 +1138,9 @@ export function registerWorktreeHandlers(
       rememberLocalWorktreeRoots(store, repo, gitWorktrees)
       pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
-      return buildDetectedGitWorktrees(store, repo, gitWorktrees)
+      return buildDetectedGitWorktrees(store, repos, repo, gitWorktrees)
         .filter((worktree) => worktree.visible)
-        .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree))
+        .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repos, repo, worktree))
     } catch (err) {
       warnOnce(
         loggedWorktreeListFailures,
@@ -1126,6 +1166,7 @@ export function registerWorktreeHandlers(
           worktrees: []
         }
       }
+      const repos = store.getRepos()
       const sshWorktreeMetaIndex = repo.connectionId
         ? createSshWorktreeMetaIndex(Object.entries(store.getAllWorktreeMeta()))
         : new Map()
@@ -1143,7 +1184,7 @@ export function registerWorktreeHandlers(
         } else if (repo.connectionId) {
           const provider = getSshGitProvider(repo.connectionId)
           if (!provider) {
-            const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+            const worktrees = listDisconnectedSshWorktrees(store, repos, repo, sshWorktreeMetaIndex)
             return {
               repoId: repo.id,
               authoritative: false,
@@ -1166,7 +1207,7 @@ export function registerWorktreeHandlers(
           repoId: repo.id,
           authoritative: true,
           source: 'git',
-          worktrees: buildDetectedGitWorktrees(store, repo, gitWorktrees)
+          worktrees: buildDetectedGitWorktrees(store, repos, repo, gitWorktrees)
         }
       } catch (err) {
         warnOnce(
@@ -1176,7 +1217,7 @@ export function registerWorktreeHandlers(
           err
         )
         if (repo.connectionId) {
-          const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+          const worktrees = listDisconnectedSshWorktrees(store, repos, repo, sshWorktreeMetaIndex)
           return {
             repoId: repo.id,
             authoritative: false,

--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -48,7 +48,11 @@ vi.mock('../repo-worktrees', () => ({
 // test schema-compliant without coupling to anything the hydrator doesn't
 // touch.
 function makeStore(
-  repos: { id: string; connectionId?: string | null }[] = []
+  repos: {
+    id: string
+    connectionId?: string | null
+    executionHostId?: Repo['executionHostId']
+  }[] = []
 ): Pick<Store, 'getRepos'> {
   const built: Repo[] = repos.map((r) => ({
     id: r.id,
@@ -56,7 +60,8 @@ function makeStore(
     displayName: r.id,
     badgeColor: '#000000',
     addedAt: 0,
-    connectionId: r.connectionId ?? null
+    connectionId: r.connectionId ?? null,
+    executionHostId: r.executionHostId ?? null
   }))
   return { getRepos: () => built }
 }
@@ -231,6 +236,28 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
         '/local/Triton'
       )
     )
+  })
+
+  it('skips legacy session ids that map to multiple host-qualified worktrees', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+
+    const ptyId = 'repo-a::/shared/Triton@@cafebabe'
+    const provider = makeProvider([
+      { sessionId: ptyId, pid: 4242, cwd: '/shared/Triton' } as unknown as SessionInfo
+    ])
+    getDaemonProviderMock.mockReturnValue(provider)
+    listRepoWorktreesMock.mockResolvedValue([
+      { path: '/shared/Triton', head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+
+    await hydrate(
+      makeStore([
+        { id: 'repo-a', connectionId: null },
+        { id: 'repo-a', connectionId: null, executionHostId: 'runtime:server-1' }
+      ])
+    )
+
+    expect(listRegisteredPtys()).toHaveLength(0)
   })
 
   it('hydrates large daemon session lists', async () => {

--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -12,6 +12,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../shared/types'
+import { makeRepoWorktreeKey } from '../../shared/worktree-id'
 import type { SessionInfo } from '../daemon/types'
 import type { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
 import type { Store } from '../persistence'
@@ -220,7 +221,16 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     const entry = listRegisteredPtys().find((p) => p.ptyId === ptyId)
     expect(entry).toBeDefined()
     expect(entry!.pid).toBe(4242)
-    expect(entry!.worktreeId).toBe('repo-a::/local/Triton')
+    expect(entry!.worktreeId).toBe(
+      makeRepoWorktreeKey(
+        {
+          id: 'repo-a',
+          connectionId: null,
+          executionHostId: null
+        },
+        '/local/Triton'
+      )
+    )
   })
 
   it('hydrates large daemon session lists', async () => {

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -24,6 +24,7 @@ import type { SessionInfo } from '../daemon/types'
 import { listRegisteredPtys, registerPty } from './pty-registry'
 import { listRepoWorktrees } from '../repo-worktrees'
 import { parsePtySessionId } from '../../shared/pty-session-id-format'
+import { getRepoWorktreeIdAliases, makeRepoWorktreeKey } from '../../shared/worktree-id'
 import type { Store } from '../persistence'
 
 // Why: `attachMainWindowServices` runs on every macOS dock re-activation
@@ -69,11 +70,10 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
     // renderer-side union still covers that case.
     hasHydrated = true
 
-    // Why: build a worktree-id → connectionId map so we can SSH-gate each
-    // session before registering. Live git enumeration matches the path
-    // shape used by `mintPtySessionId` (`${repoId}::${path}`).
+    // Why: build a worktree-id → canonical worktree-id map so old daemon
+    // sessions (`repoId::path`) hydrate into the new host-qualified bucket.
     const repos = store.getRepos()
-    const repoConnectionIdByWorktreeId = new Map<string, string | null>()
+    const canonicalWorktreeIdByAlias = new Map<string, string>()
 
     for (const repo of repos) {
       const connectionId = repo.connectionId ?? null
@@ -84,8 +84,10 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
       }
       const worktrees = await listRepoWorktrees(repo)
       for (const wt of worktrees) {
-        const worktreeId = `${repo.id}::${wt.path}`
-        repoConnectionIdByWorktreeId.set(worktreeId, connectionId)
+        const canonicalWorktreeId = makeRepoWorktreeKey(repo, wt.path)
+        for (const alias of getRepoWorktreeIdAliases(repo, wt.path)) {
+          canonicalWorktreeIdByAlias.set(alias, canonicalWorktreeId)
+        }
       }
     }
 
@@ -114,15 +116,13 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
       // `src/main/ipc/pty.ts`. If the repo isn't in the store, skip the
       // session: we can't prove it's local, and the renderer-side union
       // still surfaces the session at the cost of a missing pid sample.
-      if (!repoConnectionIdByWorktreeId.has(worktreeId)) {
-        continue
-      }
-      if (repoConnectionIdByWorktreeId.get(worktreeId)) {
+      const canonicalWorktreeId = canonicalWorktreeIdByAlias.get(worktreeId)
+      if (!canonicalWorktreeId) {
         continue
       }
       registerPty({
         ptyId: info.sessionId,
-        worktreeId,
+        worktreeId: canonicalWorktreeId,
         sessionId: info.sessionId,
         paneKey: null,
         pid:

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -74,6 +74,7 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
     // sessions (`repoId::path`) hydrate into the new host-qualified bucket.
     const repos = store.getRepos()
     const canonicalWorktreeIdByAlias = new Map<string, string>()
+    const ambiguousAliases = new Set<string>()
 
     for (const repo of repos) {
       const connectionId = repo.connectionId ?? null
@@ -86,6 +87,15 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
       for (const wt of worktrees) {
         const canonicalWorktreeId = makeRepoWorktreeKey(repo, wt.path)
         for (const alias of getRepoWorktreeIdAliases(repo, wt.path)) {
+          const existing = canonicalWorktreeIdByAlias.get(alias)
+          if (existing && existing !== canonicalWorktreeId) {
+            ambiguousAliases.add(alias)
+            canonicalWorktreeIdByAlias.delete(alias)
+            continue
+          }
+          if (ambiguousAliases.has(alias)) {
+            continue
+          }
           canonicalWorktreeIdByAlias.set(alias, canonicalWorktreeId)
         }
       }

--- a/src/main/opencode-usage/scanner.ts
+++ b/src/main/opencode-usage/scanner.ts
@@ -5,6 +5,7 @@ import { homedir } from 'os'
 import { isAbsolute, join, posix, win32 } from 'path'
 import type { Repo } from '../../shared/types'
 import { areWorktreePathsEqual } from '../ipc/worktree-logic'
+import { getUsageRepoKey } from '../usage-worktree-metadata'
 import Database from '../sqlite/sync-database'
 import { columnExists, tableExists } from './schema-helpers'
 import { canonicalizeUsageWorktreePaths } from '../usage-worktree-canonicalizer'
@@ -909,7 +910,7 @@ export function createWorktreeRefs(
 ): OpenCodeUsageWorktreeRef[] {
   const refs: OpenCodeUsageWorktreeRef[] = []
   for (const repo of repos) {
-    for (const worktree of worktreesByRepo.get(repo.id) ?? []) {
+    for (const worktree of worktreesByRepo.get(getUsageRepoKey(repo)) ?? []) {
       refs.push({
         repoId: repo.id,
         worktreeId: worktree.worktreeId,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1406,6 +1406,43 @@ describe('Store', () => {
     })
   })
 
+  it('derives automation contexts from the matching same-id repo host setup', async () => {
+    const store = await createStore()
+    store.addRepo(
+      makeRepo({
+        id: 'same-repo',
+        path: '/local/repo',
+        upstream: { owner: 'stablyai', repo: 'orca' }
+      })
+    )
+    store.addRepo(
+      makeRepo({
+        id: 'same-repo',
+        path: '/runtime/repo',
+        executionHostId: toRuntimeExecutionHostId('gpu-server'),
+        upstream: { owner: 'stablyai', repo: 'orca' }
+      })
+    )
+
+    const automation = store.createAutomation({
+      name: 'Nightly',
+      prompt: 'Run checks',
+      agentId: 'claude',
+      projectId: 'same-repo',
+      workspaceMode: 'new_per_run',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+    })
+
+    expect(automation.runContext).toMatchObject({
+      hostId: 'local',
+      projectHostSetupId: 'same-repo',
+      repoId: 'same-repo',
+      path: '/local/repo'
+    })
+  })
+
   it('marks runtime-owned automations as remote-host scheduled', async () => {
     const store = await createStore()
     store.addRepo(

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2867,6 +2867,26 @@ describe('Store', () => {
     expect(store.getProjectHostSetups().map((setup) => setup.id)).toEqual(['r2'])
   })
 
+  it('removeProject can remove only the requested host for same-id repos', async () => {
+    const store = await createStore()
+    const localRepo = makeRepo({ id: 'same-repo', path: '/local/repo' })
+    const sshRepo = makeRepo({ id: 'same-repo', path: '/remote/repo', connectionId: 'gpu-vm' })
+    const localWorktreeId = makeRepoWorktreeKey(localRepo, '/local/wt')
+    const sshWorktreeId = makeRepoWorktreeKey(sshRepo, '/remote/wt')
+    store.addRepo(localRepo)
+    store.addRepo(sshRepo)
+    store.setWorktreeMeta(localWorktreeId, { displayName: 'local' })
+    store.setWorktreeMeta(sshWorktreeId, { displayName: 'ssh' })
+
+    store.removeProject('same-repo', 'ssh:gpu-vm')
+
+    expect(store.getRepos()).toEqual([
+      expect.objectContaining({ id: 'same-repo', path: '/local/repo' })
+    ])
+    expect(store.getWorktreeMeta(localWorktreeId)?.displayName).toBe('local')
+    expect(store.getWorktreeMeta(sshWorktreeId)).toBeUndefined()
+  })
+
   it('removeProject deletes child and parent lineage for the repo', async () => {
     const store = await createStore()
     store.addRepo(makeRepo({ id: 'r1' }))
@@ -2911,6 +2931,27 @@ describe('Store', () => {
     expect(updated).not.toBeNull()
     expect(updated!.displayName).toBe('renamed')
     expect(store.getRepo('r1')!.displayName).toBe('renamed')
+  })
+
+  it('updateRepo can update only the requested host for same-id repos', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ id: 'same-repo', path: '/local/repo', displayName: 'Local' }))
+    store.addRepo(
+      makeRepo({
+        id: 'same-repo',
+        path: '/remote/repo',
+        displayName: 'Remote',
+        connectionId: 'gpu-vm'
+      })
+    )
+
+    const updated = store.updateRepo('same-repo', { displayName: 'Remote Renamed' }, 'ssh:gpu-vm')
+
+    expect(updated?.displayName).toBe('Remote Renamed')
+    expect(store.getRepos()).toEqual([
+      expect.objectContaining({ path: '/local/repo', displayName: 'Local' }),
+      expect.objectContaining({ path: '/remote/repo', displayName: 'Remote Renamed' })
+    ])
   })
 
   it('updateRepo keeps project host setup compatibility records in sync', async () => {
@@ -3264,6 +3305,32 @@ describe('Store', () => {
     expect(result).toEqual({ project: independentProject, setup: runtimeSetup })
     expect(store.getProjects()).toEqual([independentProject])
     expect(store.getProjectHostSetups()).toEqual([localSetup])
+  })
+
+  it('does not guess which same-id project host setup to delete without hostId', async () => {
+    const independentProject = makeProject({
+      id: 'cloud-project',
+      displayName: 'Cloud Project'
+    })
+    const localSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'local'
+    })
+    const runtimeSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'runtime:gpu-vm'
+    })
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      projects: [independentProject],
+      projectHostSetups: [localSetup, runtimeSetup]
+    })
+    const store = await createStore()
+
+    expect(store.deleteProjectHostSetup({ setupId: 'shared-setup' })).toBeNull()
+    expect(store.getProjectHostSetups()).toEqual([localSetup, runtimeSetup])
   })
 
   it('deletes repo-backed project host setups by removing the compatibility repo', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -37,6 +37,7 @@ import {
 } from '../shared/constants'
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
 import { toRuntimeExecutionHostId, toSshExecutionHostId } from '../shared/execution-host'
+import { makeRepoWorktreeKey } from '../shared/worktree-id'
 import { SshConnectionStore } from './ssh/ssh-connection-store'
 import { setSourceControlActionDefault } from '../shared/source-control-ai-actions'
 
@@ -2787,6 +2788,37 @@ describe('Store', () => {
     expect(store.getWorktreeMeta('r2::/other')!.displayName).toBe('other')
   })
 
+  it('removeProject deletes canonical worktree metadata and lineage for the repo', async () => {
+    const store = await createStore()
+    const repo = makeRepo({ id: 'r1' })
+    const otherRepo = makeRepo({ id: 'r2', path: '/repo2' })
+    const childId = makeRepoWorktreeKey(repo, '/path/child')
+    const parentId = makeRepoWorktreeKey(repo, '/path/parent')
+    const otherId = makeRepoWorktreeKey(otherRepo, '/other')
+    store.addRepo(repo)
+    store.addRepo(otherRepo)
+
+    store.setWorktreeMeta(childId, { displayName: 'child' })
+    store.setWorktreeMeta(otherId, { displayName: 'other' })
+    store.setWorktreeLineage(
+      childId,
+      makeWorktreeLineage({ worktreeId: childId, parentWorktreeId: parentId })
+    )
+    store.setWorkspaceLineage(
+      makeWorkspaceLineage({
+        childWorkspaceKey: worktreeWorkspaceKey(childId),
+        parentWorkspaceKey: worktreeWorkspaceKey(parentId)
+      })
+    )
+
+    store.removeProject('r1')
+
+    expect(store.getWorktreeMeta(childId)).toBeUndefined()
+    expect(store.getWorktreeLineage(childId)).toBeUndefined()
+    expect(store.getWorkspaceLineage(worktreeWorkspaceKey(childId))).toBeUndefined()
+    expect(store.getWorktreeMeta(otherId)?.displayName).toBe('other')
+  })
+
   it('removeProject removes the derived project host setup compatibility record', async () => {
     const store = await createStore()
     store.addRepo(makeRepo({ id: 'r1' }))
@@ -3091,6 +3123,39 @@ describe('Store', () => {
     })
   })
 
+  it('updates same-id repo-backed project host setup metadata on the requested host', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ id: 'same-repo', displayName: 'Local Repo' }))
+    store.addRepo(
+      makeRepo({
+        id: 'same-repo',
+        path: '/remote/repo',
+        displayName: 'Remote Repo',
+        connectionId: 'gpu-vm'
+      })
+    )
+
+    const result = store.updateProjectHostSetup({
+      setupId: 'same-repo',
+      hostId: 'ssh:gpu-vm',
+      updates: { displayName: 'Remote Renamed' }
+    })
+
+    expect(result?.repo).toMatchObject({
+      id: 'same-repo',
+      displayName: 'Remote Renamed',
+      connectionId: 'gpu-vm'
+    })
+    expect(store.getRepos()).toEqual([
+      expect.objectContaining({ id: 'same-repo', displayName: 'Local Repo' }),
+      expect.objectContaining({
+        id: 'same-repo',
+        displayName: 'Remote Renamed',
+        connectionId: 'gpu-vm'
+      })
+    ])
+  })
+
   it('rejects repo-backed project host setup path changes', async () => {
     const store = await createStore()
     store.addRepo(makeRepo({ id: 'r1', path: '/repo' }))
@@ -3178,6 +3243,51 @@ describe('Store', () => {
     expect(store.getProjects()).toEqual([])
     expect(store.getProjectHostSetups()).toEqual([])
     expect(store.getWorktreeMeta('r1::/path/wt1')).toBeUndefined()
+  })
+
+  it('deletes only the same-id repo-backed project host setup on the requested host', async () => {
+    const store = await createStore()
+    const localRepo = makeRepo({ id: 'same-repo', path: '/local/repo', displayName: 'Local Repo' })
+    const remoteRepo = makeRepo({
+      id: 'same-repo',
+      path: '/remote/repo',
+      displayName: 'Remote Repo',
+      connectionId: 'gpu-vm'
+    })
+    const localWorktreeId = makeRepoWorktreeKey(localRepo, '/local/worktree')
+    const remoteWorktreeId = makeRepoWorktreeKey(remoteRepo, '/remote/worktree')
+    const hostStampedLegacyWorktreeId = 'same-repo::/remote/legacy'
+    const hostlessLegacyWorktreeId = 'same-repo::/ambiguous/legacy'
+    store.addRepo(localRepo)
+    store.addRepo(remoteRepo)
+    store.setWorktreeMeta(localWorktreeId, { displayName: 'local' })
+    store.setWorktreeMeta(remoteWorktreeId, { displayName: 'remote' })
+    store.setWorktreeMeta(hostStampedLegacyWorktreeId, {
+      displayName: 'remote legacy',
+      hostId: 'ssh:gpu-vm'
+    })
+    store.setWorktreeMeta(hostlessLegacyWorktreeId, { displayName: 'hostless legacy' })
+
+    const result = store.deleteProjectHostSetup({
+      setupId: 'same-repo',
+      hostId: 'ssh:gpu-vm'
+    })
+
+    expect(result?.repo).toMatchObject({
+      id: 'same-repo',
+      path: '/remote/repo',
+      connectionId: 'gpu-vm'
+    })
+    expect(store.getRepos()).toEqual([
+      expect.objectContaining({ id: 'same-repo', path: '/local/repo' })
+    ])
+    expect(store.getProjectHostSetups()).toEqual([
+      expect.objectContaining({ id: 'same-repo', hostId: 'local' })
+    ])
+    expect(store.getWorktreeMeta(remoteWorktreeId)).toBeUndefined()
+    expect(store.getWorktreeMeta(hostStampedLegacyWorktreeId)).toBeUndefined()
+    expect(store.getWorktreeMeta(localWorktreeId)?.displayName).toBe('local')
+    expect(store.getWorktreeMeta(hostlessLegacyWorktreeId)?.displayName).toBe('hostless legacy')
   })
 
   it('updateRepo preserves repo-backed project host setup method', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2952,6 +2952,51 @@ describe('Store', () => {
     })
   })
 
+  it('updates same-id project host setup metadata on the requested host', async () => {
+    const independentProject = makeProject({
+      id: 'cloud-project',
+      displayName: 'Cloud Project'
+    })
+    const localSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'local',
+      displayName: 'Local'
+    })
+    const runtimeSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'runtime:gpu-vm',
+      displayName: 'GPU VM'
+    })
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      projects: [independentProject],
+      projectHostSetups: [localSetup, runtimeSetup]
+    })
+    const store = await createStore()
+
+    const result = store.updateProjectHostSetup({
+      setupId: 'shared-setup',
+      hostId: 'runtime:gpu-vm',
+      updates: { displayName: 'GPU VM renamed' }
+    })
+
+    expect(result?.setup).toMatchObject({
+      id: 'shared-setup',
+      hostId: 'runtime:gpu-vm',
+      displayName: 'GPU VM renamed'
+    })
+    expect(store.getProjectHostSetups()).toEqual([
+      expect.objectContaining({ id: 'shared-setup', hostId: 'local', displayName: 'Local' }),
+      expect.objectContaining({
+        id: 'shared-setup',
+        hostId: 'runtime:gpu-vm',
+        displayName: 'GPU VM renamed'
+      })
+    ])
+  })
+
   it('creates independent project host setup records for provisioning flows', async () => {
     const store = await createStore()
     store.addRepo({
@@ -3083,6 +3128,40 @@ describe('Store', () => {
     expect(result).toEqual({ project: independentProject, setup: independentSetup })
     expect(store.getProjects()).toEqual([independentProject])
     expect(store.getProjectHostSetups()).toEqual([])
+  })
+
+  it('deletes only the same-id project host setup on the requested host', async () => {
+    const independentProject = makeProject({
+      id: 'cloud-project',
+      displayName: 'Cloud Project'
+    })
+    const localSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'local',
+      displayName: 'Local'
+    })
+    const runtimeSetup = makeProjectHostSetup({
+      id: 'shared-setup',
+      projectId: independentProject.id,
+      hostId: 'runtime:gpu-vm',
+      displayName: 'GPU VM'
+    })
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      projects: [independentProject],
+      projectHostSetups: [localSetup, runtimeSetup]
+    })
+    const store = await createStore()
+
+    const result = store.deleteProjectHostSetup({
+      setupId: 'shared-setup',
+      hostId: 'runtime:gpu-vm'
+    })
+
+    expect(result).toEqual({ project: independentProject, setup: runtimeSetup })
+    expect(store.getProjects()).toEqual([independentProject])
+    expect(store.getProjectHostSetups()).toEqual([localSetup])
   })
 
   it('deletes repo-backed project host setups by removing the compatibility repo', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3326,7 +3326,7 @@ export class Store {
   }
 
   updateProjectHostSetup(args: ProjectHostSetupUpdateArgs): ProjectHostSetupUpdateResult | null {
-    const setup = this.state.projectHostSetups.find((entry) => entry.id === args.setupId)
+    const setup = this.findProjectHostSetup(args)
     if (!setup) {
       return null
     }
@@ -3351,7 +3351,7 @@ export class Store {
   }
 
   deleteProjectHostSetup(args: ProjectHostSetupDeleteArgs): ProjectHostSetupDeleteResult | null {
-    const setup = this.state.projectHostSetups.find((entry) => entry.id === args.setupId)
+    const setup = this.findProjectHostSetup(args)
     if (!setup) {
       return null
     }
@@ -3366,9 +3366,7 @@ export class Store {
       this.removeProject(repo.id)
       return { project, setup, repo: this.hydrateRepo(repo) }
     }
-    this.state.projectHostSetups = this.state.projectHostSetups.filter(
-      (entry) => entry.id !== setup.id
-    )
+    this.state.projectHostSetups = this.state.projectHostSetups.filter((entry) => entry !== setup)
     this.scheduleSave()
     return { project, setup }
   }
@@ -3846,9 +3844,27 @@ export class Store {
       return null
     }
     return {
-      setup: this.state.projectHostSetups.find((entry) => entry.id === setup.id) ?? setup,
+      setup:
+        this.state.projectHostSetups.find(
+          (entry) => entry.id === setup.id && entry.hostId === setup.hostId
+        ) ?? setup,
       repo: updatedRepo
     }
+  }
+
+  private findProjectHostSetup(
+    args: Pick<ProjectHostSetupUpdateArgs, 'setupId' | 'hostId'>
+  ): ProjectHostSetup | undefined {
+    if (args.hostId === undefined) {
+      return this.state.projectHostSetups.find((entry) => entry.id === args.setupId)
+    }
+    const hostId = normalizeExecutionHostId(args.hostId)
+    if (!hostId) {
+      throw new Error(`Invalid host ID: ${args.hostId}`)
+    }
+    return this.state.projectHostSetups.find(
+      (entry) => entry.id === args.setupId && entry.hostId === hostId
+    )
   }
 
   private updateIndependentProjectHostSetup(

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -744,8 +744,11 @@ function getAutomationContextsForRepo(
   const projection = projectHostSetupProjectionFromRepos([repo])
   const projectedProject = projection.projects[0]
   const projectedSetup = projection.setups[0]
+  const repoHostId = getRepoExecutionHostId(repo)
   const setup =
-    projectHostSetups.find((candidate) => candidate.repoId === repo.id) ?? projectedSetup
+    projectHostSetups.find(
+      (candidate) => candidate.repoId === repo.id && candidate.hostId === repoHostId
+    ) ?? projectedSetup
   const runContext = setup
     ? buildWorkspaceRunContext({
         projectId: setup.projectId,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -118,7 +118,11 @@ import {
 import { agentHookServer } from './agent-hooks/server'
 import { pruneLocalTerminalScrollbackBuffers } from '../shared/workspace-session-terminal-buffers'
 import { pruneWorkspaceSessionBrowserHistory } from '../shared/workspace-session-browser-history'
-import { getRepoIdFromWorktreeId, getWorktreePathBasenameFromId } from '../shared/worktree-id'
+import {
+  getRepoIdFromWorktreeId,
+  getWorktreePathBasenameFromId,
+  parseAnyWorktreeId
+} from '../shared/worktree-id'
 import {
   isPathInsideOrEqual,
   normalizeRuntimePathForComparison
@@ -3334,9 +3338,7 @@ export class Store {
     if (!project) {
       return null
     }
-    const repo = setup.repoId
-      ? this.state.repos.find((entry) => entry.id === setup.repoId)
-      : undefined
+    const repo = this.findRepoBackedProjectHostSetupRepo(setup)
     if (repo) {
       const updated = this.updateRepoBackedProjectHostSetup(setup, repo, args.updates)
       const updatedProject = updated
@@ -3359,11 +3361,9 @@ export class Store {
     if (!project) {
       return null
     }
-    const repo = setup.repoId
-      ? this.state.repos.find((entry) => entry.id === setup.repoId)
-      : undefined
+    const repo = this.findRepoBackedProjectHostSetupRepo(setup)
     if (repo) {
-      this.removeProject(repo.id)
+      this.removeRepoBackedProjectHostSetupRepo(repo)
       return { project, setup, repo: this.hydrateRepo(repo) }
     }
     this.state.projectHostSetups = this.state.projectHostSetups.filter((entry) => entry !== setup)
@@ -3680,33 +3680,81 @@ export class Store {
   removeProject(id: string): void {
     this.state.repos = this.state.repos.filter((r) => r.id !== id)
     this.syncProjectHostSetupCompatibilityState()
+    this.cleanupRemovedProjectState(id)
+    this.scheduleSave()
+  }
+
+  private removeRepoBackedProjectHostSetupRepo(repo: Repo): void {
+    const hostId = getRepoExecutionHostId(repo)
+    this.state.repos = this.state.repos.filter(
+      (entry) => entry.id !== repo.id || getRepoExecutionHostId(entry) !== hostId
+    )
+    this.syncProjectHostSetupCompatibilityState()
+    this.cleanupRemovedProjectState(repo.id, hostId)
+    if (!this.state.repos.some((entry) => entry.id === repo.id)) {
+      this.cleanupRemovedProjectState(repo.id)
+    }
+    this.scheduleSave()
+  }
+
+  private cleanupRemovedProjectState(id: string, hostId?: string): void {
     // Why: presets are repo-scoped, so removing the repo means the presets
     // can never be referenced again — drop them with the parent.
-    delete this.state.sparsePresetsByRepo[id]
+    if (hostId === undefined) {
+      delete this.state.sparsePresetsByRepo[id]
+    }
     // Clean up worktree meta for this repo
-    const prefix = `${id}::`
     for (const key of Object.keys(this.state.worktreeMeta)) {
-      if (key.startsWith(prefix)) {
+      if (this.isRemovedProjectWorktreeId(key, id, hostId, this.state.worktreeMeta[key])) {
         delete this.state.worktreeMeta[key]
       }
     }
     for (const [childId, lineage] of Object.entries(this.state.worktreeLineageById)) {
-      if (childId.startsWith(prefix) || lineage.parentWorktreeId.startsWith(prefix)) {
+      if (
+        this.isRemovedProjectWorktreeId(childId, id, hostId) ||
+        this.isRemovedProjectWorktreeId(lineage.parentWorktreeId, id, hostId)
+      ) {
         delete this.state.worktreeLineageById[childId]
       }
     }
     for (const [childKey, lineage] of Object.entries(this.state.workspaceLineageByChildKey)) {
       const childScope = parseWorkspaceKey(childKey)
       const parentScope = parseWorkspaceKey(lineage.parentWorkspaceKey)
-      if (childScope?.type === 'worktree' && childScope.worktreeId.startsWith(prefix)) {
+      if (
+        childScope?.type === 'worktree' &&
+        this.isRemovedProjectWorktreeId(childScope.worktreeId, id, hostId)
+      ) {
         delete this.state.workspaceLineageByChildKey[childKey as WorkspaceKey]
         continue
       }
-      if (parentScope?.type === 'worktree' && parentScope.worktreeId.startsWith(prefix)) {
+      if (
+        parentScope?.type === 'worktree' &&
+        this.isRemovedProjectWorktreeId(parentScope.worktreeId, id, hostId)
+      ) {
         delete this.state.workspaceLineageByChildKey[childKey as WorkspaceKey]
       }
     }
-    this.scheduleSave()
+  }
+
+  private isRemovedProjectWorktreeId(
+    worktreeId: string,
+    repoId: string,
+    hostId?: string,
+    meta?: WorktreeMeta
+  ): boolean {
+    const parsed = parseAnyWorktreeId(worktreeId)
+    if (!parsed || parsed.repoId !== repoId) {
+      return false
+    }
+    if (hostId === undefined) {
+      return true
+    }
+    if (parsed.format === 'canonical') {
+      return parsed.hostId === hostId
+    }
+    // Why: host-specific setup deletion must not guess ownership for hostless
+    // legacy rows when another same-id repo remains.
+    return meta?.hostId === hostId
   }
 
   updateRepo(
@@ -3838,18 +3886,35 @@ export class Store {
     if (updates.setupMethod !== undefined && updates.setupMethod !== 'legacy-repo') {
       repoUpdates.projectHostSetupMethod = updates.setupMethod
     }
-    const updatedRepo =
-      Object.keys(repoUpdates).length > 0 ? this.updateRepo(repo.id, repoUpdates) : repo
-    if (!updatedRepo) {
-      return null
+    if (Object.keys(repoUpdates).length > 0) {
+      const sanitizedUpdates = sanitizeRepoUpdatesForPersistence(repoUpdates)
+      if (
+        'worktreeBasePath' in sanitizedUpdates &&
+        sanitizedUpdates.worktreeBasePath === undefined
+      ) {
+        delete repo.worktreeBasePath
+        delete sanitizedUpdates.worktreeBasePath
+      }
+      Object.assign(repo, sanitizedUpdates)
+      this.syncProjectHostSetupCompatibilityState()
+      this.scheduleSave()
     }
     return {
       setup:
         this.state.projectHostSetups.find(
           (entry) => entry.id === setup.id && entry.hostId === setup.hostId
         ) ?? setup,
-      repo: updatedRepo
+      repo: this.hydrateRepo(repo)
     }
+  }
+
+  private findRepoBackedProjectHostSetupRepo(setup: ProjectHostSetup): Repo | undefined {
+    if (!setup.repoId) {
+      return undefined
+    }
+    return this.state.repos.find(
+      (entry) => entry.id === setup.repoId && getRepoExecutionHostId(entry) === setup.hostId
+    )
   }
 
   private findProjectHostSetup(

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3680,10 +3680,22 @@ export class Store {
     return true
   }
 
-  removeProject(id: string): void {
-    this.state.repos = this.state.repos.filter((r) => r.id !== id)
+  removeProject(id: string, hostId?: string): void {
+    const normalizedHostId = hostId ? normalizeExecutionHostId(hostId) : null
+    if (hostId && !normalizedHostId) {
+      throw new Error(`Invalid host ID: ${hostId}`)
+    }
+    this.state.repos = this.state.repos.filter((repo) => {
+      if (repo.id !== id) {
+        return true
+      }
+      return normalizedHostId !== null && getRepoExecutionHostId(repo) !== normalizedHostId
+    })
     this.syncProjectHostSetupCompatibilityState()
-    this.cleanupRemovedProjectState(id)
+    this.cleanupRemovedProjectState(id, normalizedHostId ?? undefined)
+    if (normalizedHostId !== null && !this.state.repos.some((entry) => entry.id === id)) {
+      this.cleanupRemovedProjectState(id)
+    }
     this.scheduleSave()
   }
 
@@ -3782,9 +3794,17 @@ export class Store {
         | 'projectGroupOrder'
         | 'projectHostSetupMethod'
       >
-    > & { sourceControlAi?: Repo['sourceControlAi'] | null }
+    > & { sourceControlAi?: Repo['sourceControlAi'] | null },
+    hostId?: string
   ): Repo | null {
-    const repo = this.state.repos.find((r) => r.id === id)
+    const normalizedHostId = hostId ? normalizeExecutionHostId(hostId) : null
+    if (hostId && !normalizedHostId) {
+      throw new Error(`Invalid host ID: ${hostId}`)
+    }
+    const repo = this.state.repos.find(
+      (r) =>
+        r.id === id && (normalizedHostId === null || getRepoExecutionHostId(r) === normalizedHostId)
+    )
     if (!repo) {
       return null
     }
@@ -3924,7 +3944,8 @@ export class Store {
     args: Pick<ProjectHostSetupUpdateArgs, 'setupId' | 'hostId'>
   ): ProjectHostSetup | undefined {
     if (args.hostId === undefined) {
-      return this.state.projectHostSetups.find((entry) => entry.id === args.setupId)
+      const matches = this.state.projectHostSetups.filter((entry) => entry.id === args.setupId)
+      return matches.length === 1 ? matches[0] : undefined
     }
     const hostId = normalizeExecutionHostId(args.hostId)
     if (!hostId) {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1856,6 +1856,200 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('does not include stored SSH worktrees from another host during metadata fallback', async () => {
+    const conn1Repo = {
+      id: 'remote-repo',
+      path: '/home/conn-1/repo',
+      displayName: 'remote 1',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const conn2Repo = {
+      ...conn1Repo,
+      path: '/home/conn-2/repo',
+      displayName: 'remote 2',
+      connectionId: 'ssh-2'
+    }
+    const conn1Id = makeSshTestWorktreeId(conn1Repo.id, conn1Repo.connectionId, '/home/conn-1/wt')
+    const conn2Id = makeSshTestWorktreeId(conn2Repo.id, conn2Repo.connectionId, '/home/conn-2/wt')
+    const legacyConn2Id = `${conn2Repo.id}::/home/conn-2/legacy-wt`
+    const ambiguousLegacyId = `${conn2Repo.id}::/home/conn-2/ambiguous-legacy-wt`
+    const metaById: Record<string, WorktreeMeta> = {
+      [conn1Id]: makeWorktreeMeta({ displayName: 'Conn 1' }),
+      [conn2Id]: makeWorktreeMeta({ displayName: 'Conn 2' }),
+      [legacyConn2Id]: makeWorktreeMeta({ hostId: 'ssh:ssh-2', displayName: 'Conn 2 legacy' }),
+      [ambiguousLegacyId]: makeWorktreeMeta({ displayName: 'Ambiguous legacy' })
+    }
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [conn1Repo, conn2Repo],
+      getRepo: (repoId: string) => [conn1Repo, conn2Repo].find((repo) => repo.id === repoId),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...metaById[worktreeId], ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const listed = await runtime.listDetectedManagedWorktrees('path:/home/conn-1/repo')
+
+    expect(listed).toMatchObject({
+      repoId: conn1Repo.id,
+      authoritative: false,
+      source: 'metadata-fallback',
+      worktrees: [
+        {
+          id: conn1Id,
+          path: '/home/conn-1/wt',
+          displayName: 'Conn 1'
+        }
+      ]
+    })
+  })
+
+  it('resolves explicit canonical worktree ids against the parsed host', async () => {
+    const conn1Repo = {
+      id: 'remote-repo',
+      path: '/home/conn-1/repo',
+      displayName: 'remote 1',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const conn2Repo = {
+      ...conn1Repo,
+      path: '/home/conn-2/repo',
+      displayName: 'remote 2',
+      connectionId: 'ssh-2'
+    }
+    const conn1Id = makeSshTestWorktreeId(conn1Repo.id, conn1Repo.connectionId, '/home/conn-1/wt')
+    const conn2Id = makeSshTestWorktreeId(conn2Repo.id, conn2Repo.connectionId, '/home/conn-2/wt')
+    const metaById: Record<string, WorktreeMeta> = {
+      [conn1Id]: makeWorktreeMeta({ displayName: 'Conn 1' }),
+      [conn2Id]: makeWorktreeMeta({ displayName: 'Conn 2' })
+    }
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [conn1Repo, conn2Repo],
+      getRepo: (repoId: string) => [conn1Repo, conn2Repo].find((repo) => repo.id === repoId),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...metaById[worktreeId], ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const conn1Provider = { listWorktrees: vi.fn().mockResolvedValue([]) }
+    const conn2Provider = { listWorktrees: vi.fn().mockResolvedValue([]) }
+    registerSshGitProvider(conn1Repo.connectionId, conn1Provider as never)
+    registerSshGitProvider(conn2Repo.connectionId, conn2Provider as never)
+
+    try {
+      const resolved = await runtime.showManagedWorktree(`id:${conn2Id}`)
+
+      expect(resolved).toMatchObject({
+        id: conn2Id,
+        path: '/home/conn-2/wt',
+        displayName: 'Conn 2',
+        hostId: 'ssh:ssh-2'
+      })
+    } finally {
+      unregisterSshGitProvider(conn1Repo.connectionId)
+      unregisterSshGitProvider(conn2Repo.connectionId)
+    }
+  })
+
+  it('does not migrate hostless legacy metadata for canonical ids when the repo id spans hosts', async () => {
+    const conn1Repo = {
+      id: 'remote-repo',
+      path: '/home/conn-1/repo',
+      displayName: 'remote 1',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const conn2Repo = {
+      ...conn1Repo,
+      path: '/home/conn-2/repo',
+      displayName: 'remote 2',
+      connectionId: 'ssh-2'
+    }
+    const worktreePath = '/home/shared/wt'
+    const conn2Id = makeSshTestWorktreeId(conn2Repo.id, conn2Repo.connectionId, worktreePath)
+    const legacyId = `${conn2Repo.id}::${worktreePath}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [legacyId]: makeWorktreeMeta({ displayName: 'Ambiguous legacy' })
+    }
+    const migrateWorktreeIdentity = vi.fn()
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [conn1Repo, conn2Repo],
+      getRepo: (repoId: string) => [conn1Repo, conn2Repo].find((repo) => repo.id === repoId),
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      migrateWorktreeIdentity,
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...metaById[worktreeId], ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const resolved = await runtime.showManagedWorktree(`id:${conn2Id}`)
+
+    expect(resolved).toMatchObject({
+      id: conn2Id,
+      path: worktreePath,
+      hostId: 'ssh:ssh-2'
+    })
+    expect(resolved.displayName).not.toBe('Ambiguous legacy')
+    expect(migrateWorktreeIdentity).not.toHaveBeenCalled()
+  })
+
+  it('does not resolve hostless legacy worktree ids when the repo id spans hosts', async () => {
+    const conn1Repo = {
+      id: 'remote-repo',
+      path: '/home/conn-1/repo',
+      displayName: 'remote 1',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const conn2Repo = {
+      ...conn1Repo,
+      path: '/home/conn-2/repo',
+      displayName: 'remote 2',
+      connectionId: 'ssh-2'
+    }
+    const legacyId = `${conn1Repo.id}::/home/conn-2/wt`
+    const metaById: Record<string, WorktreeMeta> = {
+      [legacyId]: makeWorktreeMeta({ displayName: 'Ambiguous legacy' })
+    }
+    const migrateWorktreeIdentity = vi.fn()
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [conn1Repo, conn2Repo],
+      getRepo: (repoId: string) => [conn1Repo, conn2Repo].find((repo) => repo.id === repoId),
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      migrateWorktreeIdentity,
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...metaById[worktreeId], ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    await expect(runtime.showManagedWorktree(`id:${legacyId}`)).rejects.toThrow(
+      'selector_not_found'
+    )
+    expect(migrateWorktreeIdentity).not.toHaveBeenCalled()
+  })
+
   it('does not interpret active as a runtime-global worktree selector', async () => {
     const runtime = new OrcaRuntimeService(store)
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -65,7 +65,7 @@ import {
 } from '../../shared/constants'
 import { advertisedUrlWatcher } from '../ports/advertised-url-watcher'
 import { makePaneKey } from '../../shared/stable-pane-id'
-import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
+import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR, makeWorktreeKey } from '../../shared/worktree-id'
 import { RpcDispatcher } from './rpc/dispatcher'
 import type { RpcRequest } from './rpc/core'
 import { TERMINAL_METHODS } from './rpc/methods/terminal'
@@ -713,6 +713,11 @@ const TEST_REPO_ID = 'repo-1'
 const TEST_REPO_PATH = '/tmp/repo'
 const TEST_WORKTREE_PATH = '/tmp/worktree-a'
 const TEST_WORKTREE_ID = `${TEST_REPO_ID}::${TEST_WORKTREE_PATH}`
+const TEST_CANONICAL_WORKTREE_ID = makeWorktreeKey({
+  hostId: 'local',
+  repoId: TEST_REPO_ID,
+  path: TEST_WORKTREE_PATH
+})
 const TEST_FOLDER_PROJECT_GROUP_ID = 'folder-project-group-1'
 const TEST_FOLDER_WORKSPACE_ID = 'folder-workspace-1'
 const TEST_FOLDER_WORKSPACE_KEY = `folder:${TEST_FOLDER_WORKSPACE_ID}`
@@ -1419,7 +1424,7 @@ describe('OrcaRuntimeService', () => {
 
     expect(terminals.terminals).toHaveLength(1)
     expect(terminals.terminals[0]).toMatchObject({
-      worktreeId: TEST_WORKTREE_ID,
+      worktreeId: TEST_CANONICAL_WORKTREE_ID,
       worktreePath: TEST_WORKTREE_PATH
     })
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
@@ -1450,8 +1455,8 @@ describe('OrcaRuntimeService', () => {
 
     expect(listWorktrees).not.toHaveBeenCalled()
     expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([
-      TEST_WORKTREE_ID,
-      TEST_WORKTREE_ID
+      TEST_CANONICAL_WORKTREE_ID,
+      TEST_CANONICAL_WORKTREE_ID
     ])
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
     expect(internals.ptysById.has(ptyId)).toBe(true)
@@ -1487,7 +1492,9 @@ describe('OrcaRuntimeService', () => {
     const terminals = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
 
     expect(listWorktrees).not.toHaveBeenCalled()
-    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([TEST_WORKTREE_ID])
+    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([
+      TEST_CANONICAL_WORKTREE_ID
+    ])
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
     expect(internals.ptysById.has('cwd-only-pty')).toBe(true)
     expect(internals.ptysById.has('nested-controller-pty')).toBe(false)
@@ -1524,7 +1531,9 @@ describe('OrcaRuntimeService', () => {
     const terminals = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
 
     expect(listWorktrees).not.toHaveBeenCalled()
-    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([TEST_WORKTREE_ID])
+    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([
+      TEST_CANONICAL_WORKTREE_ID
+    ])
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
     expect(internals.ptysById.has('cwd-only-pty')).toBe(true)
     expect(internals.ptysById.has('nested-controller-pty')).toBe(false)
@@ -1562,7 +1571,9 @@ describe('OrcaRuntimeService', () => {
     const terminals = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
 
     expect(listWorktrees).not.toHaveBeenCalled()
-    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([TEST_WORKTREE_ID])
+    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([
+      TEST_CANONICAL_WORKTREE_ID
+    ])
     const internals = runtime as unknown as { ptysById: Map<string, unknown> }
     expect(internals.ptysById.has('target-cwd-pty')).toBe(true)
     expect(internals.ptysById.has('sibling-cwd-pty')).toBe(false)
@@ -1784,6 +1795,16 @@ describe('OrcaRuntimeService', () => {
     }
     const mainId = `${remoteRepo.id}::/home/user/repo`
     const childId = `${remoteRepo.id}::/home/user/repo-child`
+    const canonicalMainId = makeWorktreeKey({
+      hostId: 'ssh:ssh-missing',
+      repoId: remoteRepo.id,
+      path: '/home/user/repo'
+    })
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'ssh:ssh-missing',
+      repoId: remoteRepo.id,
+      path: '/home/user/repo-child'
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [mainId]: makeWorktreeMeta({ displayName: 'Remote main' }),
       [childId]: makeWorktreeMeta({ displayName: 'Remote child', linkedPR: 42 })
@@ -1810,14 +1831,14 @@ describe('OrcaRuntimeService', () => {
       truncated: false,
       worktrees: [
         {
-          id: mainId,
+          id: canonicalMainId,
           path: '/home/user/repo',
           branch: '',
           isMainWorktree: true,
           displayName: 'Remote main'
         },
         {
-          id: childId,
+          id: canonicalChildId,
           path: '/home/user/repo-child',
           branch: '',
           isMainWorktree: false,
@@ -1879,7 +1900,7 @@ describe('OrcaRuntimeService', () => {
 
     staleScan.resolve(MOCK_GIT_WORKTREES)
 
-    await expect(staleLookup).resolves.toMatchObject({ id: TEST_WORKTREE_ID })
+    await expect(staleLookup).resolves.toMatchObject({ id: TEST_CANONICAL_WORKTREE_ID })
     await expect(freshLookup).resolves.toMatchObject({
       id: result.worktree.id,
       path: createdWorktree.path
@@ -2790,8 +2811,13 @@ describe('OrcaRuntimeService', () => {
       '/remote/mobile-feature',
       { base: 'origin/main' }
     )
+    const canonicalCreatedId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: TEST_REPO_ID,
+      path: created.path
+    })
     expect(result.worktree).toMatchObject({
-      id: `${TEST_REPO_ID}::${created.path}`,
+      id: canonicalCreatedId,
       path: created.path,
       linkedGitLabIssue: 321,
       linkedGitLabMR: 654
@@ -2830,7 +2856,16 @@ describe('OrcaRuntimeService', () => {
       isMainWorktree: false
     }
     const parentId = `${TEST_REPO_ID}::${parent.path}`
-    const childId = `${TEST_REPO_ID}::${created.path}`
+    const canonicalParentId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: TEST_REPO_ID,
+      path: parent.path
+    })
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: TEST_REPO_ID,
+      path: created.path
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' })
     }
@@ -2882,19 +2917,22 @@ describe('OrcaRuntimeService', () => {
       })
 
       expect(result.worktree).toMatchObject({
-        id: childId,
-        parentWorktreeId: parentId,
+        id: canonicalChildId,
+        parentWorktreeId: canonicalParentId,
         lineage: expect.objectContaining({
-          worktreeId: childId,
-          parentWorktreeId: parentId,
-          worktreeInstanceId: metaById[childId].instanceId,
+          worktreeId: canonicalChildId,
+          parentWorktreeId: canonicalParentId,
+          worktreeInstanceId: metaById[canonicalChildId].instanceId,
           parentWorktreeInstanceId: 'parent-instance',
           origin: 'cli'
         })
       })
       expect(result.lineage).toBe(result.worktree.lineage)
       expect(result.warnings).toEqual([])
-      expect(remoteStore.setWorktreeLineage).toHaveBeenCalledWith(childId, expect.any(Object))
+      expect(remoteStore.setWorktreeLineage).toHaveBeenCalledWith(
+        canonicalChildId,
+        expect.any(Object)
+      )
       expect(addWorktree).not.toHaveBeenCalled()
       expect(listWorktrees).not.toHaveBeenCalled()
     } finally {
@@ -3491,7 +3529,13 @@ describe('OrcaRuntimeService', () => {
     expect(gitProvider.removeWorktree).toHaveBeenCalledWith('/remote/feature', true)
     expect(removeWorktree).not.toHaveBeenCalled()
     expect(listWorktrees).not.toHaveBeenCalled()
-    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(`${TEST_REPO_ID}::/remote/feature`)
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(
+      makeWorktreeKey({
+        hostId: 'ssh:ssh-1',
+        repoId: TEST_REPO_ID,
+        path: '/remote/feature'
+      })
+    )
   })
 
   it('rejects SSH-backed runtime removal of the main worktree before provider deletion', async () => {
@@ -14705,7 +14749,7 @@ describe('OrcaRuntimeService', () => {
       worktrees: [
         {
           workspaceKind: 'git',
-          worktreeId: 'repo-1::/tmp/worktree-a',
+          worktreeId: TEST_CANONICAL_WORKTREE_ID,
           repoId: 'repo-1',
           repo: 'repo',
           path: '/tmp/worktree-a',
@@ -14758,7 +14802,7 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(runtimeStore as never)
 
     const { worktrees } = await runtime.getWorktreePs()
-    const summary = worktrees.find((w) => w.worktreeId === TEST_WORKTREE_ID)
+    const summary = worktrees.find((w) => w.worktreeId === TEST_CANONICAL_WORKTREE_ID)
     expect(summary?.linkedPR).toEqual({ number: 42, state: 'merged' })
   })
 
@@ -14993,7 +15037,7 @@ describe('OrcaRuntimeService', () => {
     const { worktrees } = await runtime.getWorktreePs()
     const active = worktrees.filter((w) => w.isActive)
     expect(active).toHaveLength(1)
-    expect(active[0]?.worktreeId).toBe(TEST_WORKTREE_ID)
+    expect(active[0]?.worktreeId).toBe(TEST_CANONICAL_WORKTREE_ID)
   })
 
   it('includes SSH-backed worktrees in the mobile worktree summary', async () => {
@@ -15012,6 +15056,11 @@ describe('OrcaRuntimeService', () => {
       isBare: false,
       isMainWorktree: false
     }
+    const canonicalRemoteWorktreeId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: remoteRepo.id,
+      path: remoteWorktree.path
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [`${remoteRepo.id}::${remoteWorktree.path}`]: makeWorktreeMeta({
         displayName: 'Remote mobile'
@@ -15037,7 +15086,7 @@ describe('OrcaRuntimeService', () => {
 
     expect(summaries.worktrees).toEqual([
       expect.objectContaining({
-        worktreeId: `${remoteRepo.id}::${remoteWorktree.path}`,
+        worktreeId: canonicalRemoteWorktreeId,
         repoId: remoteRepo.id,
         repo: 'remote-vm',
         path: remoteWorktree.path,
@@ -15824,6 +15873,16 @@ describe('OrcaRuntimeService', () => {
     }
     const childId = `${remoteRepo.id}::/home/user/repo-child`
     const parentId = `${remoteRepo.id}::/home/user/repo-parent`
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: remoteRepo.id,
+      path: '/home/user/repo-child'
+    })
+    const canonicalParentId = makeWorktreeKey({
+      hostId: 'ssh:ssh-1',
+      repoId: remoteRepo.id,
+      path: '/home/user/repo-parent'
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' }),
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' })
@@ -15867,11 +15926,11 @@ describe('OrcaRuntimeService', () => {
 
     expect(listSshWorktrees).toHaveBeenCalledWith(remoteRepo.path)
     expect(setWorktreeLineage).toHaveBeenCalledWith(
-      childId,
+      canonicalChildId,
       expect.objectContaining({
-        worktreeId: childId,
+        worktreeId: canonicalChildId,
         worktreeInstanceId: 'child-instance',
-        parentWorktreeId: parentId,
+        parentWorktreeId: canonicalParentId,
         parentWorktreeInstanceId: 'parent-instance',
         origin: 'manual'
       })
@@ -16128,6 +16187,16 @@ describe('OrcaRuntimeService', () => {
     const childPath = '/tmp/worktree-child'
     const parentId = `${TEST_REPO_ID}::${parentPath}`
     const childId = `${TEST_REPO_ID}::${childPath}`
+    const canonicalParentId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: TEST_REPO_ID,
+      path: parentPath
+    })
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: TEST_REPO_ID,
+      path: childPath
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' }),
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' })
@@ -16169,18 +16238,18 @@ describe('OrcaRuntimeService', () => {
     })
 
     expect(setWorktreeLineage).toHaveBeenCalledWith(
-      childId,
+      canonicalChildId,
       expect.objectContaining({
-        parentWorktreeId: parentId,
+        parentWorktreeId: canonicalParentId,
         parentWorktreeInstanceId: 'parent-instance',
         capture: { source: 'manual-action', confidence: 'explicit' }
       })
     )
     expect(setWorkspaceLineage).toHaveBeenCalledWith(
       expect.objectContaining({
-        childWorkspaceKey: `worktree:${childId}`,
+        childWorkspaceKey: `worktree:${canonicalChildId}`,
         childInstanceId: 'child-instance',
-        parentWorkspaceKey: `worktree:${parentId}`,
+        parentWorkspaceKey: `worktree:${canonicalParentId}`,
         parentInstanceId: 'parent-instance',
         capture: { source: 'manual-action', confidence: 'explicit' }
       })
@@ -16574,6 +16643,16 @@ describe('OrcaRuntimeService', () => {
     const childPath = '/tmp/worktree-child'
     const parentId = `${TEST_REPO_ID}::${parentPath}`
     const childId = `${TEST_REPO_ID}::${childPath}`
+    const canonicalParentId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: TEST_REPO_ID,
+      path: parentPath
+    })
+    const canonicalChildId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: TEST_REPO_ID,
+      path: childPath
+    })
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({
         instanceId: 'parent-instance',
@@ -16624,24 +16703,32 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(runtimeStore as never)
 
     const listed = await runtime.listManagedWorktrees('id:repo-1')
-    const parent = listed.worktrees.find((worktree) => worktree.id === parentId)
-    const child = listed.worktrees.find((worktree) => worktree.id === childId)
+    const parent = listed.worktrees.find((worktree) => worktree.id === canonicalParentId)
+    const child = listed.worktrees.find((worktree) => worktree.id === canonicalChildId)
 
     expect(parent).toMatchObject({
       parentWorktreeId: null,
-      childWorktreeIds: [childId],
+      childWorktreeIds: [canonicalChildId],
       lineage: null
     })
     expect(child).toMatchObject({
-      parentWorktreeId: parentId,
+      parentWorktreeId: canonicalParentId,
       childWorktreeIds: [],
-      lineage: lineageById[childId]
+      lineage: {
+        ...lineageById[childId],
+        worktreeId: canonicalChildId,
+        parentWorktreeId: canonicalParentId
+      }
     })
     await expect(runtime.showManagedWorktree(`id:${childId}`)).resolves.toMatchObject({
-      id: childId,
-      parentWorktreeId: parentId,
+      id: canonicalChildId,
+      parentWorktreeId: canonicalParentId,
       childWorktreeIds: [],
-      lineage: lineageById[childId]
+      lineage: {
+        ...lineageById[childId],
+        worktreeId: canonicalChildId,
+        parentWorktreeId: canonicalParentId
+      }
     })
   })
 
@@ -21242,7 +21329,7 @@ describe('OrcaRuntimeService', () => {
         page: 'page-1'
       })
 
-      expect(snapshotMock).toHaveBeenCalledWith(TEST_WORKTREE_ID, 'page-1')
+      expect(snapshotMock).toHaveBeenCalledWith(TEST_CANONICAL_WORKTREE_ID, 'page-1')
     })
 
     it('routes tab switch and capture start by explicit page id', async () => {
@@ -21361,8 +21448,13 @@ describe('OrcaRuntimeService', () => {
         }
       ])
       const runtime = createRuntime()
+      const worktreeBId = makeWorktreeKey({
+        hostId: 'local',
+        repoId: TEST_REPO_ID,
+        path: '/tmp/worktree-b'
+      })
       const getRegisteredTabsMock = vi.fn((worktreeId?: string) =>
-        worktreeId === `${TEST_REPO_ID}::/tmp/worktree-b` ? new Map() : new Map([['page-1', 1]])
+        worktreeId === worktreeBId ? new Map() : new Map([['page-1', 1]])
       )
 
       runtime.setAgentBrowserBridge({
@@ -21375,7 +21467,7 @@ describe('OrcaRuntimeService', () => {
           worktree: 'path:/tmp/worktree-b'
         })
       ).rejects.toThrow('Browser page page-1 was not found in this worktree')
-      expect(getRegisteredTabsMock).toHaveBeenCalledWith(`${TEST_REPO_ID}::/tmp/worktree-b`)
+      expect(getRegisteredTabsMock).toHaveBeenCalledWith(worktreeBId)
     })
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1608,7 +1608,9 @@ describe('OrcaRuntimeService', () => {
 
   it('matches explicit-id cwd PTYs for folder workspace instance IDs', async () => {
     const folderWorktreeRootId = makeLocalTestWorktreeId(TEST_FOLDER_WORKSPACE_PATH)
-    const folderWorktreeId = `${folderWorktreeRootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}11111111-1111-4111-8111-111111111111`
+    const folderWorktreeId = makeLocalTestWorktreeId(
+      `${TEST_FOLDER_WORKSPACE_PATH}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}11111111-1111-4111-8111-111111111111`
+    )
     vi.mocked(listWorktrees).mockClear()
     vi.mocked(listWorktrees).mockRejectedValue(
       new Error('folder explicit-id fallback should not rescan worktrees')
@@ -20712,6 +20714,48 @@ describe('OrcaRuntimeService', () => {
     )
 
     expect(result).toEqual({ deleted: true })
+    expect(forceDeleteLocalBranchMock).toHaveBeenCalledWith(
+      TEST_REPO_PATH,
+      'feature/test',
+      'def456'
+    )
+  })
+
+  it('cleans canonical and safe legacy runtime aliases when removing a worktree', async () => {
+    const legacyWorktreeId = `${TEST_REPO_ID}::${TEST_WORKTREE_PATH}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [TEST_WORKTREE_ID]: makeWorktreeMeta({ hostId: 'local' }),
+      [legacyWorktreeId]: makeWorktreeMeta({ hostId: 'local' })
+    }
+    const removeWorktreeMeta = vi.fn((worktreeId: string) => {
+      delete metaById[worktreeId]
+    })
+    const runtimeStore = {
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      removeWorktreeMeta
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    await runtime.removeManagedWorktree(TEST_WORKTREE_ID)
+
+    expect(removeWorktreeMeta).toHaveBeenCalledWith(TEST_WORKTREE_ID)
+    expect(removeWorktreeMeta).toHaveBeenCalledWith(legacyWorktreeId)
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(TEST_WORKTREE_ID)
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(legacyWorktreeId)
+  })
+
+  it('force-deletes a preserved branch through a legacy runtime alias', async () => {
+    const legacyWorktreeId = `${TEST_REPO_ID}::${TEST_WORKTREE_PATH}`
+    const runtime = new OrcaRuntimeService(store)
+    vi.mocked(removeWorktree).mockResolvedValue({
+      preservedBranch: { branchName: 'feature/test', head: 'def456' }
+    })
+
+    await runtime.removeManagedWorktree(TEST_WORKTREE_ID)
+    await runtime.forceDeletePreservedBranch(legacyWorktreeId, 'feature/test', 'def456')
+
     expect(forceDeleteLocalBranchMock).toHaveBeenCalledWith(
       TEST_REPO_PATH,
       'feature/test',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -14292,7 +14292,7 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('does not dedupe mobile terminal creates across worktrees with the same clientMutationId', async () => {
-    const otherWorktreeId = `${TEST_REPO_ID}::/tmp/worktree-b`
+    const otherWorktreeId = makeLocalTestWorktreeId('/tmp/worktree-b')
     vi.mocked(listWorktrees).mockResolvedValue([
       ...MOCK_GIT_WORKTREES,
       {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -712,12 +712,16 @@ const TEST_WINDOW_ID = 1
 const TEST_REPO_ID = 'repo-1'
 const TEST_REPO_PATH = '/tmp/repo'
 const TEST_WORKTREE_PATH = '/tmp/worktree-a'
-const TEST_WORKTREE_ID = `${TEST_REPO_ID}::${TEST_WORKTREE_PATH}`
 const TEST_CANONICAL_WORKTREE_ID = makeWorktreeKey({
   hostId: 'local',
   repoId: TEST_REPO_ID,
   path: TEST_WORKTREE_PATH
 })
+const TEST_WORKTREE_ID = TEST_CANONICAL_WORKTREE_ID
+const makeLocalTestWorktreeId = (path: string): string =>
+  makeWorktreeKey({ hostId: 'local', repoId: TEST_REPO_ID, path })
+const makeSshTestWorktreeId = (repoId: string, connectionId: string, path: string): string =>
+  makeWorktreeKey({ hostId: `ssh:${connectionId}`, repoId, path })
 const TEST_FOLDER_PROJECT_GROUP_ID = 'folder-project-group-1'
 const TEST_FOLDER_WORKSPACE_ID = 'folder-workspace-1'
 const TEST_FOLDER_WORKSPACE_KEY = `folder:${TEST_FOLDER_WORKSPACE_ID}`
@@ -1350,7 +1354,7 @@ describe('OrcaRuntimeService', () => {
       tabs: [
         {
           tabId: 'tab-1',
-          worktreeId: 'repo-1::/tmp/worktree-a',
+          worktreeId: TEST_WORKTREE_ID,
           title: 'Claude',
           activeLeafId: 'pane:1',
           layout: null
@@ -1359,7 +1363,7 @@ describe('OrcaRuntimeService', () => {
       leaves: [
         {
           tabId: 'tab-1',
-          worktreeId: 'repo-1::/tmp/worktree-a',
+          worktreeId: TEST_WORKTREE_ID,
           leafId: 'pane:1',
           paneRuntimeId: 1,
           ptyId: 'pty-1'
@@ -1371,7 +1375,7 @@ describe('OrcaRuntimeService', () => {
     const terminals = await runtime.listTerminals('branch:feature/foo')
     expect(terminals.terminals).toHaveLength(1)
     expect(terminals.terminals[0]).toMatchObject({
-      worktreeId: 'repo-1::/tmp/worktree-a',
+      worktreeId: TEST_WORKTREE_ID,
       branch: 'feature/foo',
       ptyId: 'pty-1',
       title: 'Claude',
@@ -1603,7 +1607,8 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('matches explicit-id cwd PTYs for folder workspace instance IDs', async () => {
-    const folderWorktreeId = `${TEST_REPO_ID}::${TEST_FOLDER_WORKSPACE_PATH}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}11111111-1111-4111-8111-111111111111`
+    const folderWorktreeRootId = makeLocalTestWorktreeId(TEST_FOLDER_WORKSPACE_PATH)
+    const folderWorktreeId = `${folderWorktreeRootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}11111111-1111-4111-8111-111111111111`
     vi.mocked(listWorktrees).mockClear()
     vi.mocked(listWorktrees).mockRejectedValue(
       new Error('folder explicit-id fallback should not rescan worktrees')
@@ -1621,7 +1626,9 @@ describe('OrcaRuntimeService', () => {
     const terminals = await runtime.listTerminals(`id:${folderWorktreeId}`)
 
     expect(listWorktrees).not.toHaveBeenCalled()
-    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([folderWorktreeId])
+    expect(terminals.terminals.map((terminal) => terminal.worktreeId)).toEqual([
+      folderWorktreeRootId
+    ])
     expect(terminals.terminals[0]?.worktreePath).toBe(TEST_FOLDER_WORKSPACE_PATH)
   })
 
@@ -1916,8 +1923,18 @@ describe('OrcaRuntimeService', () => {
       addedAt: 1,
       kind: 'folder' as const
     }
-    const rootWorktreeId = 'folder-repo::/workspace/folder'
-    const rootPriorWorktreeIds = ['folder-repo::/workspace/old-folder']
+    const rootWorktreeId = makeWorktreeKey({
+      hostId: 'local',
+      repoId: 'folder-repo',
+      path: '/workspace/folder'
+    })
+    const rootPriorWorktreeIds = [
+      makeWorktreeKey({
+        hostId: 'local',
+        repoId: 'folder-repo',
+        path: '/workspace/old-folder'
+      })
+    ]
     const metaById: Record<string, WorktreeMeta> = {
       [rootWorktreeId]: makeWorktreeMeta({
         instanceId: 'root-instance',
@@ -1958,7 +1975,9 @@ describe('OrcaRuntimeService', () => {
     expect(addWorktreeMock).not.toHaveBeenCalled()
     expect(result.worktree).toEqual(
       expect.objectContaining({
-        id: expect.stringMatching(/^folder-repo::\/workspace\/folder::workspace:[0-9a-f-]{36}$/),
+        id: expect.stringMatching(
+          /^orca-worktree:\/\/v1\?hostId=local&repoId=folder-repo&path=%2Fworkspace%2Ffolder::workspace:[0-9a-f-]{36}$/
+        ),
         repoId: 'folder-repo',
         path: '/workspace/folder',
         displayName: 'folder-session',
@@ -1998,9 +2017,9 @@ describe('OrcaRuntimeService', () => {
       id: result.worktree.id,
       comment: 'note'
     })
-    await expect(
-      runtime.removeManagedWorktree('id:folder-repo::/workspace/folder')
-    ).rejects.toThrow('Cannot delete the project root workspace')
+    await expect(runtime.removeManagedWorktree(`id:${rootWorktreeId}`)).rejects.toThrow(
+      'Cannot delete the project root workspace'
+    )
     deletedWorktreeId = result.worktree.id
     await expect(runtime.removeManagedWorktree(`id:${result.worktree.id}`)).resolves.toEqual({})
     expect(localProvider.shutdown).toHaveBeenCalledWith(`${result.worktree.id}@@pty-1`, {
@@ -2949,7 +2968,7 @@ describe('OrcaRuntimeService', () => {
       isBare: false,
       isMainWorktree: false
     }
-    const childId = `${TEST_REPO_ID}::${created.path}`
+    const childId = makeLocalTestWorktreeId(created.path)
     const metaById: Record<string, WorktreeMeta> = {}
     const workspaceLineageByChildKey: Record<string, WorkspaceLineage> = {}
     const runtimeStore = {
@@ -5037,11 +5056,11 @@ describe('OrcaRuntimeService', () => {
     expect(terminals.terminals).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          worktreeId: `${TEST_REPO_ID}::C:\\Repo`,
+          worktreeId: makeLocalTestWorktreeId('C:\\Repo'),
           worktreePath: 'C:\\Repo'
         }),
         expect.objectContaining({
-          worktreeId: `${TEST_REPO_ID}:://Server/Share/Repo`,
+          worktreeId: makeLocalTestWorktreeId('//Server/Share/Repo'),
           worktreePath: '//Server/Share/Repo'
         })
       ])
@@ -11774,6 +11793,7 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('spawns fresh headless SSH mobile session terminals instead of reattaching synthetic local ids', async () => {
+    const sshWorktreeId = makeSshTestWorktreeId(TEST_REPO_ID, 'ssh-1', TEST_WORKTREE_PATH)
     const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-1' }
     const remoteStore = {
       ...store,
@@ -11790,12 +11810,12 @@ describe('OrcaRuntimeService', () => {
     })
     runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
 
-    await runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`)
+    await runtime.createMobileSessionTerminal(`id:${sshWorktreeId}`)
 
     expect(spawn).toHaveBeenCalledWith(
       expect.objectContaining({
         connectionId: 'ssh-1',
-        worktreeId: TEST_WORKTREE_ID,
+        worktreeId: sshWorktreeId,
         persistHostSessionBinding: true
       })
     )
@@ -13192,14 +13212,15 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('reattaches hydrated SSH headless terminals with the persisted relay identity', async () => {
+    const sshWorktreeId = makeSshTestWorktreeId(TEST_REPO_ID, 'ssh-1', TEST_WORKTREE_PATH)
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({
         tabsByWorktree: {
-          [TEST_WORKTREE_ID]: [
+          [sshWorktreeId]: [
             {
               id: 'host-tab',
               ptyId: 'ssh:ssh-1@@relay-pty',
-              worktreeId: TEST_WORKTREE_ID,
+              worktreeId: sshWorktreeId,
               title: 'Remote Terminal',
               customTitle: null,
               color: null,
@@ -13232,7 +13253,7 @@ describe('OrcaRuntimeService', () => {
     })
     runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
 
-    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab')
+    await runtime.activateMobileSessionTab(`id:${sshWorktreeId}`, 'host-tab')
 
     expect(spawn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -13246,15 +13267,16 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('spawns fresh after an expired hydrated SSH headless reattach clears persistence', async () => {
+    const sshWorktreeId = makeSshTestWorktreeId(TEST_REPO_ID, 'ssh-1', TEST_WORKTREE_PATH)
     const stalePtyId = 'ssh:ssh-1@@relay-pty'
     const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({
         tabsByWorktree: {
-          [TEST_WORKTREE_ID]: [
+          [sshWorktreeId]: [
             {
               id: 'host-tab',
               ptyId: stalePtyId,
-              worktreeId: TEST_WORKTREE_ID,
+              worktreeId: sshWorktreeId,
               title: 'Remote Terminal',
               customTitle: null,
               color: null,
@@ -13282,7 +13304,7 @@ describe('OrcaRuntimeService', () => {
           ...session,
           tabsByWorktree: {
             ...session.tabsByWorktree,
-            [TEST_WORKTREE_ID]: session.tabsByWorktree[TEST_WORKTREE_ID].map((tab) =>
+            [sshWorktreeId]: session.tabsByWorktree[sshWorktreeId].map((tab) =>
               tab.id === 'host-tab' ? { ...tab, ptyId: null } : tab
             )
           },
@@ -13308,9 +13330,9 @@ describe('OrcaRuntimeService', () => {
     runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
 
     await expect(
-      runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab')
+      runtime.activateMobileSessionTab(`id:${sshWorktreeId}`, 'host-tab')
     ).rejects.toThrow('SSH session expired')
-    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab')
+    await runtime.activateMobileSessionTab(`id:${sshWorktreeId}`, 'host-tab')
 
     expect(spawn).toHaveBeenNthCalledWith(
       1,
@@ -13476,14 +13498,15 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('spawns fresh SSH terminals when hydrated persistence has no relay identity', async () => {
+    const sshWorktreeId = makeSshTestWorktreeId(TEST_REPO_ID, 'ssh-1', TEST_WORKTREE_PATH)
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({
         tabsByWorktree: {
-          [TEST_WORKTREE_ID]: [
+          [sshWorktreeId]: [
             {
               id: 'host-tab',
               ptyId: null,
-              worktreeId: TEST_WORKTREE_ID,
+              worktreeId: sshWorktreeId,
               title: 'Remote Terminal',
               customTitle: null,
               color: null,
@@ -13514,7 +13537,7 @@ describe('OrcaRuntimeService', () => {
     })
     runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
 
-    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab')
+    await runtime.activateMobileSessionTab(`id:${sshWorktreeId}`, 'host-tab')
 
     expect(spawn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -15871,8 +15894,16 @@ describe('OrcaRuntimeService', () => {
       addedAt: 1,
       connectionId: 'ssh-1'
     }
-    const childId = `${remoteRepo.id}::/home/user/repo-child`
-    const parentId = `${remoteRepo.id}::/home/user/repo-parent`
+    const childId = makeSshTestWorktreeId(
+      remoteRepo.id,
+      remoteRepo.connectionId,
+      '/home/user/repo-child'
+    )
+    const parentId = makeSshTestWorktreeId(
+      remoteRepo.id,
+      remoteRepo.connectionId,
+      '/home/user/repo-parent'
+    )
     const canonicalChildId = makeWorktreeKey({
       hostId: 'ssh:ssh-1',
       repoId: remoteRepo.id,
@@ -15946,8 +15977,16 @@ describe('OrcaRuntimeService', () => {
       addedAt: 1,
       connectionId: 'ssh-1'
     }
-    const childId = `${remoteRepo.id}::/home/user/repo-child`
-    const parentId = `${remoteRepo.id}::/home/user/repo-parent`
+    const childId = makeSshTestWorktreeId(
+      remoteRepo.id,
+      remoteRepo.connectionId,
+      '/home/user/repo-child'
+    )
+    const parentId = makeSshTestWorktreeId(
+      remoteRepo.id,
+      remoteRepo.connectionId,
+      '/home/user/repo-parent'
+    )
     const metaById: Record<string, WorktreeMeta> = {
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' }),
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' })
@@ -16185,8 +16224,8 @@ describe('OrcaRuntimeService', () => {
   it('keeps workspace lineage in sync when manually reparenting a worktree', async () => {
     const parentPath = '/tmp/worktree-parent'
     const childPath = '/tmp/worktree-child'
-    const parentId = `${TEST_REPO_ID}::${parentPath}`
-    const childId = `${TEST_REPO_ID}::${childPath}`
+    const parentId = makeLocalTestWorktreeId(parentPath)
+    const childId = makeLocalTestWorktreeId(childPath)
     const canonicalParentId = makeWorktreeKey({
       hostId: 'local',
       repoId: TEST_REPO_ID,
@@ -16258,7 +16297,7 @@ describe('OrcaRuntimeService', () => {
 
   it('clears workspace lineage when manually removing a parent', async () => {
     const childPath = '/tmp/worktree-child'
-    const childId = `${TEST_REPO_ID}::${childPath}`
+    const childId = makeLocalTestWorktreeId(childPath)
     const metaById: Record<string, WorktreeMeta> = {
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' })
     }
@@ -16323,8 +16362,8 @@ describe('OrcaRuntimeService', () => {
   it('ignores stale instance-mismatched lineage when validating manual cycle repairs', async () => {
     const parentPath = '/tmp/worktree-a'
     const childPath = '/tmp/worktree-b'
-    const parentId = `${TEST_REPO_ID}::${parentPath}`
-    const childId = `${TEST_REPO_ID}::${childPath}`
+    const parentId = makeLocalTestWorktreeId(parentPath)
+    const childId = makeLocalTestWorktreeId(childPath)
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'new-parent-instance' }),
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' })
@@ -16388,8 +16427,8 @@ describe('OrcaRuntimeService', () => {
   it('rejects lineage updates when upgraded metadata is missing a parent instance id', async () => {
     const parentPath = '/tmp/worktree-parent'
     const childPath = '/tmp/worktree-child'
-    const parentId = `${TEST_REPO_ID}::${parentPath}`
-    const childId = `${TEST_REPO_ID}::${childPath}`
+    const parentId = makeLocalTestWorktreeId(parentPath)
+    const childId = makeLocalTestWorktreeId(childPath)
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta(),
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' })
@@ -16435,8 +16474,8 @@ describe('OrcaRuntimeService', () => {
   it('rotates a missing parent instance during runtime selector scans before same-path reuse', async () => {
     const parentPath = '/tmp/worktree-parent'
     const childPath = '/tmp/worktree-child'
-    const parentId = `${TEST_REPO_ID}::${parentPath}`
-    const childId = `${TEST_REPO_ID}::${childPath}`
+    const parentId = makeLocalTestWorktreeId(parentPath)
+    const childId = makeLocalTestWorktreeId(childPath)
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'old-parent-instance' }),
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' })
@@ -16520,8 +16559,8 @@ describe('OrcaRuntimeService', () => {
   it('does not prune lineage when a runtime local worktree scan fails', async () => {
     const parentPath = '/tmp/worktree-parent'
     const childPath = '/tmp/worktree-child'
-    const parentId = `${TEST_REPO_ID}::${parentPath}`
-    const childId = `${TEST_REPO_ID}::${childPath}`
+    const parentId = makeLocalTestWorktreeId(parentPath)
+    const childId = makeLocalTestWorktreeId(childPath)
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' }),
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' })
@@ -16591,8 +16630,16 @@ describe('OrcaRuntimeService', () => {
       addedAt: 1,
       connectionId: 'ssh-1'
     }
-    const parentId = `${remoteRepo.id}::/home/user/repo-parent`
-    const childId = `${remoteRepo.id}::/home/user/repo-child`
+    const parentId = makeSshTestWorktreeId(
+      remoteRepo.id,
+      remoteRepo.connectionId,
+      '/home/user/repo-parent'
+    )
+    const childId = makeSshTestWorktreeId(
+      remoteRepo.id,
+      remoteRepo.connectionId,
+      '/home/user/repo-child'
+    )
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' }),
       [childId]: makeWorktreeMeta({ instanceId: 'child-instance' })
@@ -16735,8 +16782,8 @@ describe('OrcaRuntimeService', () => {
   it('keeps valid orchestration lineage when caller terminal context is stale', async () => {
     const parentPath = '/tmp/worktree-parent'
     const childPath = '/tmp/workspaces/worker-child'
-    const parentId = `${TEST_REPO_ID}::${parentPath}`
-    const childId = `${TEST_REPO_ID}::${childPath}`
+    const parentId = makeLocalTestWorktreeId(parentPath)
+    const childId = makeLocalTestWorktreeId(childPath)
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({
         instanceId: 'parent-instance',
@@ -16813,8 +16860,8 @@ describe('OrcaRuntimeService', () => {
   it('enriches caller-terminal lineage with active orchestration dispatch context', async () => {
     const workerPath = '/tmp/worktree-worker'
     const childPath = '/tmp/workspaces/worker-child'
-    const childId = `${TEST_REPO_ID}::${childPath}`
-    const workerId = `${TEST_REPO_ID}::${workerPath}`
+    const childId = makeLocalTestWorktreeId(childPath)
+    const workerId = makeLocalTestWorktreeId(workerPath)
     const metaById: Record<string, WorktreeMeta> = {
       [TEST_WORKTREE_ID]: makeWorktreeMeta({
         instanceId: 'parent-instance',
@@ -17205,8 +17252,8 @@ describe('OrcaRuntimeService', () => {
   it('falls back to cwd lineage when the caller terminal handle is stale', async () => {
     const parentPath = '/tmp/worktree-parent'
     const childPath = '/tmp/workspaces/cwd-child'
-    const parentId = `${TEST_REPO_ID}::${parentPath}`
-    const childId = `${TEST_REPO_ID}::${childPath}`
+    const parentId = makeLocalTestWorktreeId(parentPath)
+    const childId = makeLocalTestWorktreeId(childPath)
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance' })
     }
@@ -17312,8 +17359,8 @@ describe('OrcaRuntimeService', () => {
   it('infers orchestration lineage from task-id comments when dispatch is completed', async () => {
     const workerPath = '/tmp/worktree-worker'
     const childPath = '/tmp/workspaces/worker-child'
-    const childId = `${TEST_REPO_ID}::${childPath}`
-    const workerId = `${TEST_REPO_ID}::${workerPath}`
+    const childId = makeLocalTestWorktreeId(childPath)
+    const workerId = makeLocalTestWorktreeId(workerPath)
     const metaById: Record<string, WorktreeMeta> = {
       [workerId]: makeWorktreeMeta({
         instanceId: 'worker-instance',
@@ -17410,8 +17457,8 @@ describe('OrcaRuntimeService', () => {
   it('infers orchestration lineage from task creator when no dispatch context exists', async () => {
     const parentPath = '/tmp/worktree-parent'
     const childPath = '/tmp/workspaces/parent-child'
-    const childId = `${TEST_REPO_ID}::${childPath}`
-    const parentId = `${TEST_REPO_ID}::${parentPath}`
+    const childId = makeLocalTestWorktreeId(childPath)
+    const parentId = makeLocalTestWorktreeId(parentPath)
     const metaById: Record<string, WorktreeMeta> = {
       [parentId]: makeWorktreeMeta({
         instanceId: 'parent-instance',
@@ -19991,7 +20038,7 @@ describe('OrcaRuntimeService', () => {
     try {
       const worktree = await runtime.showManagedWorktree(`path:${duplicatePath}`)
 
-      expect(worktree.id).toBe(`${TEST_REPO_ID}::${duplicatePath}`)
+      expect(worktree.id).toBe(makeLocalTestWorktreeId(duplicatePath))
       expect(worktree.path).toBe(duplicatePath)
     } finally {
       getRepos.mockRestore()
@@ -20690,7 +20737,7 @@ describe('OrcaRuntimeService', () => {
       addedAt: 1,
       connectionId: 'ssh-missing-fs'
     }
-    const worktreeId = `${repo.id}::${localPath}`
+    const worktreeId = makeSshTestWorktreeId(repo.id, repo.connectionId, localPath)
     const metaById: Record<string, WorktreeMeta> = {
       [worktreeId]: makeWorktreeMeta({
         orcaCreatedAt: Date.now(),
@@ -21270,7 +21317,7 @@ describe('OrcaRuntimeService', () => {
 
     expect(listed.worktrees).toMatchObject([
       {
-        id: 'repo-1::C:/workspaces/improve-dashboard',
+        id: makeLocalTestWorktreeId('C:/workspaces/improve-dashboard'),
         displayName: 'Improve Dashboard'
       }
     ])

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1457,16 +1457,24 @@ function mergeRuntimeFolderWorkspace(repo: Repo, worktreeId: string, meta: Workt
 function listRuntimeFolderWorkspaces(
   store: Pick<
     RuntimeStore,
-    'getAllWorktreeMeta' | 'getWorktreeMeta' | 'setWorktreeMeta' | 'migrateWorktreeIdentity'
+    | 'getAllWorktreeMeta'
+    | 'getWorktreeMeta'
+    | 'setWorktreeMeta'
+    | 'migrateWorktreeIdentity'
+    | 'getRepos'
   >,
   repo: Repo
 ): Worktree[] {
+  const hasAmbiguousHost = hasRuntimeAmbiguousRepoHost(store.getRepos(), repo)
   for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
     if (!isRuntimeLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
       continue
     }
     const repoHostId = getRepoExecutionHostId(repo)
     if (meta.hostId !== undefined && meta.hostId !== repoHostId) {
+      continue
+    }
+    if (meta.hostId === undefined && hasAmbiguousHost) {
       continue
     }
     store.migrateWorktreeIdentity?.(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1300,6 +1300,40 @@ function getRuntimeWorktreeMetaForRepoPath(
   return hasRuntimeAmbiguousRepoHost(store.getRepos(), repo) ? undefined : legacyMeta
 }
 
+function getRuntimeWorktreeRemovalIdAliases(
+  store: RuntimeStore,
+  repo: Repo,
+  path: string,
+  requestedId: string
+): string[] {
+  const canonicalId = getRuntimeRepoWorktreeId(repo, path)
+  const legacyId = getRuntimeLegacyRepoWorktreeId(repo, path)
+  const ids = new Set([canonicalId, requestedId])
+  const legacyMeta = store.getWorktreeMeta(legacyId)
+  const repoHostId = getRepoExecutionHostId(repo)
+  const requestedLegacyId = requestedId === legacyId
+  const legacyBelongsToRepoHost = legacyMeta?.hostId === repoHostId
+  const legacySafeWithoutMeta = legacyMeta === undefined
+  const legacyUnambiguous = !hasRuntimeAmbiguousRepoHost(store.getRepos(), repo)
+  if (requestedLegacyId || legacyBelongsToRepoHost || legacySafeWithoutMeta || legacyUnambiguous) {
+    ids.add(legacyId)
+  }
+  return [...ids]
+}
+
+function getRuntimeRemovalWorktreeMeta(
+  store: RuntimeStore,
+  worktreeIds: readonly string[]
+): WorktreeMeta | undefined {
+  for (const worktreeId of worktreeIds) {
+    const meta = store.getWorktreeMeta(worktreeId)
+    if (meta) {
+      return meta
+    }
+  }
+  return undefined
+}
+
 function migrateRuntimeLegacyWorktreeMetaIfSafe(
   store: RuntimeStore,
   repo: Repo,
@@ -14090,6 +14124,15 @@ export class OrcaRuntimeService {
     this.closeHeadlessBrowserPagesForWorktree(worktreeId)
   }
 
+  private removeWorktreeAliasesMetadataAndHistory(
+    store: RuntimeStore,
+    worktreeIds: readonly string[]
+  ): void {
+    for (const worktreeId of worktreeIds) {
+      this.removeWorktreeMetadataAndHistory(store, worktreeId)
+    }
+  }
+
   // Why: headless offscreen browser pages are main-process BrowserWindows that
   // outlive a worktree unless explicitly closed — removing a worktree without
   // closing its open panes leaks the windows for the life of the serve process.
@@ -14103,11 +14146,12 @@ export class OrcaRuntimeService {
   }
 
   private rememberPreservedBranchCleanupTarget(
-    worktreeId: string,
+    worktreeIds: string | readonly string[],
     result: RemoveWorktreeResult | undefined,
     fallbackHead: string | undefined,
     pushTarget: GitPushTarget | undefined
   ): void {
+    const ids = typeof worktreeIds === 'string' ? [worktreeIds] : worktreeIds
     if (result?.preservedBranch) {
       const head = result.preservedBranch.head ?? fallbackHead
       if (!head) {
@@ -14115,14 +14159,18 @@ export class OrcaRuntimeService {
           `Cannot safely offer force-delete for preserved branch "${result.preservedBranch.branchName}" without its saved commit.`
         )
       }
-      this.preservedBranchCleanupByWorktreeId.set(worktreeId, {
-        branchName: result.preservedBranch.branchName,
-        head,
-        ...(pushTarget ? { pushTarget } : {})
-      })
+      for (const worktreeId of ids) {
+        this.preservedBranchCleanupByWorktreeId.set(worktreeId, {
+          branchName: result.preservedBranch.branchName,
+          head,
+          ...(pushTarget ? { pushTarget } : {})
+        })
+      }
       return
     }
-    this.preservedBranchCleanupByWorktreeId.delete(worktreeId)
+    for (const worktreeId of ids) {
+      this.preservedBranchCleanupByWorktreeId.delete(worktreeId)
+    }
   }
 
   private preserveBranchHeadFallback(
@@ -14153,13 +14201,14 @@ export class OrcaRuntimeService {
     const repo = removalTarget
       ? findRuntimeRepoForRemovalTarget(this.store, removalTarget)
       : undefined
-    const canonicalRemovalTargetId =
-      removalTarget && repo ? getRuntimeRepoWorktreeId(repo, removalTarget.path) : undefined
+    const cleanupWorktreeIds =
+      removalTarget && repo
+        ? getRuntimeWorktreeRemovalIdAliases(this.store, repo, removalTarget.path, removalTarget.id)
+        : []
     const cleanupTarget = removalTarget
-      ? (this.preservedBranchCleanupByWorktreeId.get(removalTarget.id) ??
-        (canonicalRemovalTargetId
-          ? this.preservedBranchCleanupByWorktreeId.get(canonicalRemovalTargetId)
-          : undefined))
+      ? cleanupWorktreeIds
+          .map((worktreeId) => this.preservedBranchCleanupByWorktreeId.get(worktreeId))
+          .find((target) => target !== undefined)
       : undefined
     if (
       !removalTarget ||
@@ -14188,7 +14237,7 @@ export class OrcaRuntimeService {
       await cleanupUnusedWorktreePushTargetRemoteSsh(
         provider,
         repo.path,
-        removalTarget.id,
+        cleanupWorktreeIds,
         cleanupTarget.pushTarget,
         this.store
       )
@@ -14204,14 +14253,16 @@ export class OrcaRuntimeService {
         : forceDeleteLocalBranch(repo.path, cleanupTarget.branchName, cleanupTarget.head))
       await cleanupUnusedWorktreePushTargetRemote(
         repo.path,
-        removalTarget.id,
+        cleanupWorktreeIds,
         cleanupTarget.pushTarget,
         this.store,
         localWorktreeGitOptions
       )
     }
 
-    this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+    for (const worktreeId of cleanupWorktreeIds) {
+      this.preservedBranchCleanupByWorktreeId.delete(worktreeId)
+    }
     return { deleted: true }
   }
 
@@ -14265,6 +14316,21 @@ export class OrcaRuntimeService {
         this.notifyWorktreesChanged(repo.id)
         return {}
       }
+      const removalWorktreeIds = getRuntimeWorktreeRemovalIdAliases(
+        store,
+        repo,
+        removalTarget.path,
+        removalTarget.id
+      )
+      const clearRemovalState = (options: { clearPreservedBranch?: boolean } = {}) => {
+        for (const worktreeId of removalWorktreeIds) {
+          this.clearOptimisticReconcileToken(worktreeId)
+          if (options.clearPreservedBranch) {
+            this.preservedBranchCleanupByWorktreeId.delete(worktreeId)
+          }
+        }
+        this.removeWorktreeAliasesMetadataAndHistory(store, removalWorktreeIds)
+      }
       const provider = repo.connectionId ? requireSshGitProvider(repo.connectionId) : null
       const fsProvider = repo.connectionId ? getSshFilesystemProvider(repo.connectionId) : null
       const localWorktreeGitOptions = repo.connectionId
@@ -14276,7 +14342,7 @@ export class OrcaRuntimeService {
         : hasLocalWorktreeGitOptions
           ? await listWorktreesStrict(repo.path, localWorktreeGitOptions)
           : await listWorktreesStrict(repo.path)
-      const removedMeta = store.getWorktreeMeta(removalTarget.id)
+      const removedMeta = getRuntimeRemovalWorktreeMeta(store, removalWorktreeIds)
       const removedPushTarget = removedMeta?.pushTarget ?? removalTarget.pushTarget
       const registeredWorktree = findRegisteredDeletableWorktree(
         repo.path,
@@ -14330,7 +14396,7 @@ export class OrcaRuntimeService {
             await cleanupUnusedWorktreePushTargetRemoteSsh(
               provider!,
               repo.path,
-              removalTarget.id,
+              removalWorktreeIds,
               removedPushTarget,
               store
             )
@@ -14338,15 +14404,13 @@ export class OrcaRuntimeService {
             await removeLocalWorktreePath(removalTarget.path, localWorktreeGitOptions)
             await cleanupUnusedWorktreePushTargetRemote(
               repo.path,
-              removalTarget.id,
+              removalWorktreeIds,
               removedPushTarget,
               store,
               localWorktreeGitOptions
             )
           }
-          this.clearOptimisticReconcileToken(removalTarget.id)
-          this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-          this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+          clearRemovalState({ clearPreservedBranch: true })
           this.invalidateResolvedWorktreeCache()
           invalidateAuthorizedRootsCache()
           this.notifyWorktreesChanged(repo.id)
@@ -14365,20 +14429,18 @@ export class OrcaRuntimeService {
             ? cleanupUnusedWorktreePushTargetRemoteSsh(
                 provider!,
                 repo.path,
-                removalTarget.id,
+                removalWorktreeIds,
                 removedPushTarget,
                 store
               )
             : cleanupUnusedWorktreePushTargetRemote(
                 repo.path,
-                removalTarget.id,
+                removalWorktreeIds,
                 removedPushTarget,
                 store,
                 localWorktreeGitOptions
               ))
-          this.clearOptimisticReconcileToken(removalTarget.id)
-          this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-          this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+          clearRemovalState({ clearPreservedBranch: true })
           this.invalidateResolvedWorktreeCache()
           invalidateAuthorizedRootsCache()
           this.notifyWorktreesChanged(repo.id)
@@ -14399,18 +14461,17 @@ export class OrcaRuntimeService {
         await cleanupUnusedWorktreePushTargetRemoteSsh(
           provider!,
           repo.path,
-          removalTarget.id,
+          removalWorktreeIds,
           removedPushTarget,
           store
         )
         this.rememberPreservedBranchCleanupTarget(
-          removalTarget.id,
+          removalWorktreeIds,
           removalResult,
           registeredWorktree.head,
           removedPushTarget
         )
-        this.clearOptimisticReconcileToken(removalTarget.id)
-        this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
+        clearRemovalState()
         this.invalidateResolvedWorktreeCache()
         invalidateAuthorizedRootsCache()
         this.notifyWorktreesChanged(repo.id)
@@ -14529,14 +14590,12 @@ export class OrcaRuntimeService {
           }).catch(() => {})
           await cleanupUnusedWorktreePushTargetRemote(
             repo.path,
-            removalTarget.id,
+            removalWorktreeIds,
             removedPushTarget,
             store,
             localWorktreeGitOptions
           )
-          this.clearOptimisticReconcileToken(removalTarget.id)
-          this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
-          this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+          clearRemovalState({ clearPreservedBranch: true })
           this.invalidateResolvedWorktreeCache()
           invalidateAuthorizedRootsCache()
           this.notifyWorktreesChanged(repo.id)
@@ -14549,19 +14608,18 @@ export class OrcaRuntimeService {
 
       await cleanupUnusedWorktreePushTargetRemote(
         repo.path,
-        removalTarget.id,
+        removalWorktreeIds,
         removedPushTarget,
         store,
         localWorktreeGitOptions
       )
       this.rememberPreservedBranchCleanupTarget(
-        removalTarget.id,
+        removalWorktreeIds,
         removalResult,
         registeredWorktree.head,
         removedPushTarget
       )
-      this.clearOptimisticReconcileToken(removalTarget.id)
-      this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
+      clearRemovalState()
       this.invalidateResolvedWorktreeCache()
       invalidateAuthorizedRootsCache()
       this.notifyWorktreesChanged(repo.id)
@@ -14856,7 +14914,12 @@ export class OrcaRuntimeService {
     opts: { agent: TuiAgent; prompt: string; title?: string }
   ): Promise<RuntimeTerminalCreate> {
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
-    const repo = this.store?.getRepo(worktree.repoId)
+    const repo = this.store
+      ? findRuntimeRepoForParsedWorktree(this.store.getRepos(), {
+          repoId: worktree.repoId,
+          hostId: worktree.hostId
+        })
+      : undefined
     if (!repo) {
       throw new Error('Repository for the selected workspace is no longer available.')
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -143,9 +143,13 @@ import type { FeatureInteractionId } from '../../shared/feature-interactions'
 import type { TerminalPaneSplitSource } from '../../shared/feature-education-telemetry'
 import {
   FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
+  makeLegacyWorktreeId,
+  makeRepoWorktreeKey,
+  parseWorktreeKey,
   splitWorktreeId,
   splitWorktreeIdForFilesystem
 } from '../../shared/worktree-id'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import {
   getProjectHostSetupForRepo,
   getProjectHostSetupWorktreeMeta
@@ -715,6 +719,7 @@ type RuntimeStore = {
   getWorktreeMeta: Store['getWorktreeMeta']
   setWorktreeMeta: Store['setWorktreeMeta']
   removeWorktreeMeta: Store['removeWorktreeMeta']
+  migrateWorktreeIdentity?: Store['migrateWorktreeIdentity']
   getWorktreeLineage?: Store['getWorktreeLineage']
   getAllWorktreeLineage?: Store['getAllWorktreeLineage']
   setWorktreeLineage?: Store['setWorktreeLineage']
@@ -1217,16 +1222,24 @@ function getRuntimeWorktreeRemovalOptionsKey(force: boolean, runHooks: boolean):
 }
 
 function getRuntimeFolderWorkspaceRootId(repo: Repo): string {
-  return `${repo.id}::${repo.path}`
+  return makeRepoWorktreeKey(repo, repo.path)
 }
 
 function getRuntimeFolderWorkspaceInstanceId(repo: Repo, instanceId: string): string {
   return `${getRuntimeFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
 }
 
+function getRuntimeLegacyFolderWorkspaceRootId(repo: Repo): string {
+  return makeLegacyWorktreeId(repo.id, repo.path)
+}
+
 function getRuntimeFolderWorkspaceInstanceIdentity(repo: Repo, worktreeId: string): string {
   const prefix = `${getRuntimeFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
-  return worktreeId.startsWith(prefix) ? worktreeId.slice(prefix.length) : randomUUID()
+  const legacyPrefix = `${getRuntimeLegacyFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
+  if (worktreeId.startsWith(prefix)) {
+    return worktreeId.slice(prefix.length)
+  }
+  return worktreeId.startsWith(legacyPrefix) ? worktreeId.slice(legacyPrefix.length) : randomUUID()
 }
 
 function isRuntimeFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
@@ -1235,6 +1248,100 @@ function isRuntimeFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): bool
     worktreeId === rootId ||
     worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
   )
+}
+
+function isRuntimeLegacyFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
+  const rootId = getRuntimeLegacyFolderWorkspaceRootId(repo)
+  return (
+    worktreeId === rootId ||
+    worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
+  )
+}
+
+function getRuntimeCanonicalFolderWorkspaceId(repo: Repo, worktreeId: string): string {
+  if (!isRuntimeLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
+    return worktreeId
+  }
+  const instanceId = getRuntimeFolderWorkspaceInstanceIdentity(repo, worktreeId)
+  return worktreeId === getRuntimeLegacyFolderWorkspaceRootId(repo)
+    ? getRuntimeFolderWorkspaceRootId(repo)
+    : getRuntimeFolderWorkspaceInstanceId(repo, instanceId)
+}
+
+function getRuntimeRepoWorktreeId(repo: Repo, path: string): string {
+  return makeRepoWorktreeKey(repo, path)
+}
+
+function getRuntimeLegacyRepoWorktreeId(repo: Repo, path: string): string {
+  return makeLegacyWorktreeId(repo.id, path)
+}
+
+function getRuntimeWorktreeMetaForRepoPath(
+  store: RuntimeStore,
+  repo: Repo,
+  path: string
+): WorktreeMeta | undefined {
+  migrateRuntimeLegacyWorktreeMetaIfSafe(store, repo, path)
+  return (
+    store.getWorktreeMeta(getRuntimeRepoWorktreeId(repo, path)) ??
+    store.getWorktreeMeta(getRuntimeLegacyRepoWorktreeId(repo, path))
+  )
+}
+
+function migrateRuntimeLegacyWorktreeMetaIfSafe(
+  store: RuntimeStore,
+  repo: Repo,
+  path: string
+): void {
+  if (!store.migrateWorktreeIdentity) {
+    return
+  }
+  const canonicalId = getRuntimeRepoWorktreeId(repo, path)
+  if (store.getWorktreeMeta(canonicalId)) {
+    return
+  }
+  const legacyId = getRuntimeLegacyRepoWorktreeId(repo, path)
+  const legacyMeta = store.getWorktreeMeta(legacyId)
+  if (!legacyMeta) {
+    return
+  }
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (legacyMeta.hostId !== undefined && legacyMeta.hostId !== repoHostId) {
+    return
+  }
+  store.migrateWorktreeIdentity(legacyId, canonicalId)
+}
+
+function isRuntimeCanonicalWorktreeIdForRepoHost(repo: Repo, worktreeId: string): boolean {
+  const parsed = parseWorktreeKey(worktreeId)
+  return parsed?.repoId === repo.id && parsed.hostId === getRepoExecutionHostId(repo)
+}
+
+function isRuntimeWorktreeIdAliasForResolved(
+  worktree: Pick<ResolvedWorktree, 'id' | 'repoId' | 'path' | 'hostId'>,
+  worktreeId: string
+): boolean {
+  if (worktree.id === worktreeId) {
+    return true
+  }
+  const parsed = splitWorktreeIdForFilesystem(worktreeId)
+  if (!parsed || parsed.repoId !== worktree.repoId) {
+    return false
+  }
+  if (parsed.hostId !== undefined && worktree.hostId !== parsed.hostId) {
+    return false
+  }
+  return runtimePathsEqual(parsed.worktreePath, worktree.path)
+}
+
+function findResolvedWorktreeForIdAlias(
+  worktrees: readonly ResolvedWorktree[],
+  worktreeId: string
+): ResolvedWorktree | null {
+  const matches = worktrees.filter((worktree) =>
+    isRuntimeWorktreeIdAliasForResolved(worktree, worktreeId)
+  )
+  return matches.length === 1 ? matches[0] : null
 }
 
 function mergeRuntimeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta): Worktree {
@@ -1283,9 +1390,25 @@ function mergeRuntimeFolderWorkspace(repo: Repo, worktreeId: string, meta: Workt
 }
 
 function listRuntimeFolderWorkspaces(
-  store: Pick<RuntimeStore, 'getAllWorktreeMeta' | 'setWorktreeMeta'>,
+  store: Pick<
+    RuntimeStore,
+    'getAllWorktreeMeta' | 'getWorktreeMeta' | 'setWorktreeMeta' | 'migrateWorktreeIdentity'
+  >,
   repo: Repo
 ): Worktree[] {
+  for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
+    if (!isRuntimeLegacyFolderWorkspaceIdForRepo(repo, worktreeId)) {
+      continue
+    }
+    const repoHostId = getRepoExecutionHostId(repo)
+    if (meta.hostId !== undefined && meta.hostId !== repoHostId) {
+      continue
+    }
+    store.migrateWorktreeIdentity?.(
+      worktreeId,
+      getRuntimeCanonicalFolderWorkspaceId(repo, worktreeId)
+    )
+  }
   const rootId = getRuntimeFolderWorkspaceRootId(repo)
   const allMeta = store.getAllWorktreeMeta()
   const ids = Object.keys(allMeta).filter((worktreeId) =>
@@ -7555,8 +7678,7 @@ export class OrcaRuntimeService {
         : null
     const cachedExplicitTargetWorktree =
       explicitTargetWorktreeId && cachedResolvedWorktrees
-        ? (cachedResolvedWorktrees.find((worktree) => worktree.id === explicitTargetWorktreeId) ??
-          null)
+        ? findResolvedWorktreeForIdAlias(cachedResolvedWorktrees, explicitTargetWorktreeId)
         : null
     const parsedExplicitTargetWorktree =
       explicitTargetWorktreeId && !cachedExplicitTargetWorktree
@@ -7566,7 +7688,7 @@ export class OrcaRuntimeService {
       worktreeSelector && !explicitTargetWorktreeId
         ? await this.resolveWorktreeSelector(worktreeSelector)
         : (cachedExplicitTargetWorktree ?? parsedExplicitTargetWorktree)
-    const targetWorktreeId = explicitTargetWorktreeId ?? targetWorktree?.id ?? null
+    const targetWorktreeId = targetWorktree?.id ?? explicitTargetWorktreeId ?? null
     const classificationResolvedWorktreeCache = this.resolvedWorktreeCache
     const classificationResolvedWorktrees =
       targetWorktreeId &&
@@ -7614,9 +7736,13 @@ export class OrcaRuntimeService {
 
     const terminals: RuntimeTerminalSummary[] = []
     const ptyIdsFromLeaves = new Set<string>()
+    const matchesTargetWorktree = (worktreeId: string): boolean =>
+      !targetWorktreeId ||
+      worktreeId === targetWorktreeId ||
+      (targetWorktree ? isRuntimeWorktreeIdAliasForResolved(targetWorktree, worktreeId) : false)
     if (graphEpoch !== null) {
       for (const leaf of this.leaves.values()) {
-        if (targetWorktreeId && leaf.worktreeId !== targetWorktreeId) {
+        if (!matchesTargetWorktree(leaf.worktreeId)) {
           continue
         }
         if (opts.requireFreshPtyLiveness && leaf.ptyId && !refreshedPtyLiveness?.has(leaf.ptyId)) {
@@ -7642,7 +7768,7 @@ export class OrcaRuntimeService {
       if (opts.requireFreshPtyLiveness && !refreshedPtyLiveness?.has(pty.ptyId)) {
         continue
       }
-      if (targetWorktreeId && pty.worktreeId !== targetWorktreeId) {
+      if (!matchesTargetWorktree(pty.worktreeId)) {
         continue
       }
       terminals.push(this.buildPtyTerminalSummary(pty, worktreesById))
@@ -11308,9 +11434,12 @@ export class OrcaRuntimeService {
       this.pruneLineageForMissingRepoWorktrees(repo, scan.worktrees)
     }
     const detected = scan.worktrees.map((gitWorktree) => {
-      const worktreeId = `${repo.id}::${gitWorktree.path}`
-      const meta = this.store?.getWorktreeMeta(worktreeId)
-      const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+      const meta = this.store
+        ? getRuntimeWorktreeMetaForRepoPath(this.store, repo, gitWorktree.path)
+        : undefined
+      const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+        hostId: getRepoExecutionHostId(repo)
+      })
       const detectedWorktree = this.toRuntimeDetectedWorktree(repo, worktree)
       if (scan.ok) {
         return detectedWorktree
@@ -12386,7 +12515,7 @@ export class OrcaRuntimeService {
       throw new Error('Worktree created but not found in listing')
     }
 
-    const worktreeId = `${repo.id}::${created.path}`
+    const worktreeId = getRuntimeRepoWorktreeId(repo, created.path)
     const now = Date.now()
     // Why: PR/MR-created worktrees can start from a head ref/SHA while Source
     // Control must compare against the review target branch.
@@ -12453,7 +12582,9 @@ export class OrcaRuntimeService {
       ...(args.manualOrder !== undefined ? { manualOrder: args.manualOrder } : {}),
       ...(args.workspaceStatus !== undefined ? { workspaceStatus: args.workspaceStatus } : {})
     })
-    const worktree = mergeWorktree(repo.id, created, meta)
+    const worktree = mergeWorktree(repo.id, created, meta, undefined, {
+      hostId: getRepoExecutionHostId(repo)
+    })
     const {
       lineage,
       workspaceLineage,
@@ -13190,7 +13321,21 @@ export class OrcaRuntimeService {
   }
 
   clearOptimisticReconcileToken(worktreeId: string): void {
-    this.optimisticReconcileTokens.delete(worktreeId)
+    for (const id of this.getKnownWorktreeIdAliases(worktreeId)) {
+      this.optimisticReconcileTokens.delete(id)
+    }
+  }
+
+  private getKnownWorktreeIdAliases(worktreeId: string): Set<string> {
+    const ids = new Set([worktreeId])
+    const parsed = splitWorktreeIdForFilesystem(worktreeId)
+    const repo = parsed ? this.store?.getRepo(parsed.repoId) : null
+    if (!parsed || !repo) {
+      return ids
+    }
+    ids.add(getRuntimeRepoWorktreeId(repo, parsed.worktreePath))
+    ids.add(getRuntimeLegacyRepoWorktreeId(repo, parsed.worktreePath))
+    return ids
   }
 
   emitWorktreeBaseStatus(event: WorktreeBaseStatusEvent): void {
@@ -13930,8 +14075,14 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
     const removalTarget = parseExactWorktreeIdSelector(worktreeSelector)
+    const repo = removalTarget ? this.store.getRepo(removalTarget.repoId) : undefined
+    const canonicalRemovalTargetId =
+      removalTarget && repo ? getRuntimeRepoWorktreeId(repo, removalTarget.path) : undefined
     const cleanupTarget = removalTarget
-      ? this.preservedBranchCleanupByWorktreeId.get(removalTarget.id)
+      ? (this.preservedBranchCleanupByWorktreeId.get(removalTarget.id) ??
+        (canonicalRemovalTargetId
+          ? this.preservedBranchCleanupByWorktreeId.get(canonicalRemovalTargetId)
+          : undefined))
       : undefined
     if (
       !removalTarget ||
@@ -13942,7 +14093,6 @@ export class OrcaRuntimeService {
       throw new Error(`No preserved branch cleanup is pending for "${branchName}".`)
     }
 
-    const repo = this.store.getRepo(removalTarget.repoId)
     if (!repo) {
       throw new Error('repo_not_found')
     }
@@ -15433,12 +15583,12 @@ export class OrcaRuntimeService {
     this.assertStableReadyGraph(graphEpoch)
     const ptyIds = new Set<string>()
     for (const leaf of this.leaves.values()) {
-      if (leaf.worktreeId === worktree.id && leaf.ptyId) {
+      if (isRuntimeWorktreeIdAliasForResolved(worktree, leaf.worktreeId) && leaf.ptyId) {
         ptyIds.add(leaf.ptyId)
       }
     }
     for (const pty of this.ptysById.values()) {
-      if (pty.worktreeId === worktree.id && pty.connected) {
+      if (isRuntimeWorktreeIdAliasForResolved(worktree, pty.worktreeId) && pty.connected) {
         ptyIds.add(pty.ptyId)
       }
     }
@@ -15479,7 +15629,7 @@ export class OrcaRuntimeService {
     if (!refreshedPtyLiveness) {
       throw new Error('terminal_liveness_unavailable')
     }
-    const livePtyIds = this.getLivePtyIdsForWorktree(worktree.id, refreshedPtyLiveness)
+    const livePtyIds = this.getLivePtyIdsForWorktree(worktree, refreshedPtyLiveness)
     const targetOnly = opts.targetOnly === true
     const expectedIsLive = [...expected].every((ptyId) => livePtyIds.has(ptyId))
     if (targetOnly ? !expectedIsLive : !setsEqual(livePtyIds, expected)) {
@@ -15511,7 +15661,7 @@ export class OrcaRuntimeService {
         postStopFailure: 'terminal_liveness_unavailable'
       }
     }
-    const remainingLivePtyIds = this.getLivePtyIdsForWorktree(worktree.id, postStopLiveness)
+    const remainingLivePtyIds = this.getLivePtyIdsForWorktree(worktree, postStopLiveness)
     const stoppedTargetsStillLive = [...expected].filter((ptyId) => remainingLivePtyIds.has(ptyId))
     if (targetOnly ? stoppedTargetsStillLive.length > 0 : remainingLivePtyIds.size > 0) {
       return {
@@ -15535,13 +15685,13 @@ export class OrcaRuntimeService {
   }
 
   private getLivePtyIdsForWorktree(
-    worktreeId: string,
+    worktree: ResolvedWorktree,
     freshPtyIds?: ReadonlySet<string>
   ): Set<string> {
     const ptyIds = new Set<string>()
     for (const leaf of this.leaves.values()) {
       if (
-        leaf.worktreeId === worktreeId &&
+        isRuntimeWorktreeIdAliasForResolved(worktree, leaf.worktreeId) &&
         leaf.connected &&
         leaf.ptyId &&
         (!freshPtyIds || freshPtyIds.has(leaf.ptyId))
@@ -15551,7 +15701,7 @@ export class OrcaRuntimeService {
     }
     for (const pty of this.ptysById.values()) {
       if (
-        pty.worktreeId === worktreeId &&
+        isRuntimeWorktreeIdAliasForResolved(worktree, pty.worktreeId) &&
         pty.connected &&
         (!freshPtyIds || freshPtyIds.has(pty.ptyId))
       ) {
@@ -15566,12 +15716,12 @@ export class OrcaRuntimeService {
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
     this.assertStableReadyGraph(graphEpoch)
     for (const leaf of this.leaves.values()) {
-      if (leaf.worktreeId === worktree.id && leaf.ptyId) {
+      if (isRuntimeWorktreeIdAliasForResolved(worktree, leaf.worktreeId) && leaf.ptyId) {
         return true
       }
     }
     for (const pty of this.ptysById.values()) {
-      if (pty.worktreeId === worktree.id && pty.connected) {
+      if (isRuntimeWorktreeIdAliasForResolved(worktree, pty.worktreeId) && pty.connected) {
         return true
       }
     }
@@ -15772,11 +15922,18 @@ export class OrcaRuntimeService {
       const worktreeId = selector.slice(3)
       candidates = worktrees.filter((worktree) => worktree.id === worktreeId)
       if (candidates.length === 0) {
+        candidates = worktrees.filter((worktree) =>
+          isRuntimeWorktreeIdAliasForResolved(worktree, worktreeId)
+        )
+      }
+      if (candidates.length === 0) {
         const parsed = splitWorktreeIdForFilesystem(worktreeId)
         const repo = parsed ? this.store?.getRepo(parsed.repoId) : null
         const fallback =
-          repo?.connectionId && this.store?.getWorktreeMeta(worktreeId)
-            ? this.buildResolvedWorktreeFromId(worktreeId)
+          repo?.connectionId && parsed
+            ? getRuntimeWorktreeMetaForRepoPath(this.requireStore(), repo, parsed.worktreePath)
+              ? this.buildResolvedWorktreeFromId(worktreeId)
+              : null
             : null
         if (fallback !== null) {
           candidates = [fallback]
@@ -15811,6 +15968,7 @@ export class OrcaRuntimeService {
       candidates = worktrees.filter(
         (worktree) =>
           worktree.id === selector ||
+          isRuntimeWorktreeIdAliasForResolved(worktree, selector) ||
           runtimePathsEqual(worktree.path, selector) ||
           branchSelectorMatches(worktree.branch, selector)
       )
@@ -16272,6 +16430,10 @@ export class OrcaRuntimeService {
       return null
     }
     const repo = this.store?.getRepos().find((entry) => entry.id === parsed.repoId)
+    const canonicalWorktreeId =
+      repo && (parsed.hostId === undefined || parsed.hostId === getRepoExecutionHostId(repo))
+        ? getRuntimeRepoWorktreeId(repo, parsed.worktreePath)
+        : worktreeId
     const git = {
       path: parsed.worktreePath,
       head: '',
@@ -16279,11 +16441,20 @@ export class OrcaRuntimeService {
       isBare: false,
       isMainWorktree: repo ? areWorktreePathsEqual(parsed.worktreePath, repo.path) : false
     }
-    const meta = this.store?.getWorktreeMeta(worktreeId)
-    const merged = mergeWorktree(parsed.repoId, git, meta, repo?.displayName)
+    const meta =
+      repo && this.store
+        ? getRuntimeWorktreeMetaForRepoPath(this.store, repo, parsed.worktreePath)
+        : this.store?.getWorktreeMeta(worktreeId)
+    const merged = mergeWorktree(
+      parsed.repoId,
+      git,
+      meta,
+      repo?.displayName,
+      repo ? { hostId: getRepoExecutionHostId(repo) } : undefined
+    )
     return {
       ...merged,
-      id: worktreeId,
+      id: canonicalWorktreeId,
       parentWorktreeId: null,
       childWorktreeIds: [],
       lineage: null,
@@ -16315,15 +16486,14 @@ export class OrcaRuntimeService {
         )
       })
     )
-    worktreeIds.add(targetWorktreeId)
+    worktreeIds.add(targetWorktree.id)
 
     const resolved: ResolvedWorktree[] = []
     for (const worktreeId of worktreeIds) {
-      const worktree =
-        worktreeId === targetWorktreeId
-          ? targetWorktree
-          : this.buildResolvedWorktreeFromId(worktreeId)
-      if (worktree) {
+      const worktree = isRuntimeWorktreeIdAliasForResolved(targetWorktree, worktreeId)
+        ? targetWorktree
+        : this.buildResolvedWorktreeFromId(worktreeId)
+      if (worktree && !resolved.some((entry) => entry.id === worktree.id)) {
         resolved.push(worktree)
       }
     }
@@ -16358,10 +16528,10 @@ export class OrcaRuntimeService {
     if (!this.store) {
       return []
     }
+    const store = this.store
     const now = Date.now()
-    const metaById = this.store.getAllWorktreeMeta() ?? {}
     const perRepoWorktrees = await Promise.all(
-      this.store.getRepos().map(async (repo) => {
+      store.getRepos().map(async (repo) => {
         if (isFolderRepo(repo)) {
           return listRuntimeFolderWorkspaces(this.requireStore(), repo).map((worktree) => ({
             ...worktree,
@@ -16391,15 +16561,17 @@ export class OrcaRuntimeService {
           this.pruneLineageForMissingRepoWorktrees(repo, gitWorktrees)
         }
         return gitWorktrees.map((gitWorktree) => {
-          const worktreeId = `${repo.id}::${gitWorktree.path}`
+          const worktreeId = getRuntimeRepoWorktreeId(repo, gitWorktree.path)
           // Why: lineage validation needs a durable instance ID even when the
           // runtime sees a workspace before the renderer's discovery-stamp path.
-          const existingMeta = metaById[worktreeId]
+          const existingMeta = getRuntimeWorktreeMetaForRepoPath(store, repo, gitWorktree.path)
           const meta =
             existingMeta && existingMeta.instanceId
               ? existingMeta
-              : this.store?.setWorktreeMeta(worktreeId, {})
-          const merged = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+              : store.setWorktreeMeta(worktreeId, existingMeta ?? {})
+          const merged = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
+            hostId: getRepoExecutionHostId(repo)
+          })
           return {
             ...merged,
             parentWorktreeId: null,
@@ -16438,8 +16610,10 @@ export class OrcaRuntimeService {
     const childIdsByParentId = new Map<string, string[]>()
 
     for (const [childId, lineage] of Object.entries(lineageById)) {
-      const child = worktreeById.get(childId)
-      const parent = worktreeById.get(lineage.parentWorktreeId)
+      const child = worktreeById.get(childId) ?? findResolvedWorktreeForIdAlias(worktrees, childId)
+      const parent =
+        worktreeById.get(lineage.parentWorktreeId) ??
+        findResolvedWorktreeForIdAlias(worktrees, lineage.parentWorktreeId)
       if (
         !child ||
         !parent ||
@@ -16450,10 +16624,15 @@ export class OrcaRuntimeService {
         // checkouts from appearing as children of stale same-path lineage.
         continue
       }
-      validLineageByChildId.set(childId, lineage)
-      const children = childIdsByParentId.get(lineage.parentWorktreeId) ?? []
-      children.push(childId)
-      childIdsByParentId.set(lineage.parentWorktreeId, children)
+      const normalizedLineage = {
+        ...lineage,
+        worktreeId: child.id,
+        parentWorktreeId: parent.id
+      }
+      validLineageByChildId.set(child.id, normalizedLineage)
+      const children = childIdsByParentId.get(parent.id) ?? []
+      children.push(child.id)
+      childIdsByParentId.set(parent.id, children)
     }
 
     return worktrees.map((worktree) => {
@@ -16476,14 +16655,19 @@ export class OrcaRuntimeService {
     ) {
       return
     }
-    const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
+    const liveIds = new Set(
+      gitWorktrees.map((worktree) => getRuntimeRepoWorktreeId(repo, worktree.path))
+    )
+    const legacyLiveIds = new Set(
+      gitWorktrees.map((worktree) => getRuntimeLegacyRepoWorktreeId(repo, worktree.path))
+    )
     const repoPrefix = `${repo.id}::`
     for (const childWorkspaceKey of Object.keys(store.getAllWorkspaceLineage?.() ?? {})) {
       const childScope = parseWorkspaceKey(childWorkspaceKey)
       if (
         childScope?.type === 'worktree' &&
         childScope.worktreeId.startsWith(repoPrefix) &&
-        !liveIds.has(childScope.worktreeId)
+        !legacyLiveIds.has(childScope.worktreeId)
       ) {
         if (isWorkspaceKey(childWorkspaceKey)) {
           store.removeWorkspaceLineage?.(childWorkspaceKey)
@@ -16491,7 +16675,10 @@ export class OrcaRuntimeService {
       }
     }
     for (const [childId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-      if (childId.startsWith(repoPrefix) && !liveIds.has(childId)) {
+      if (
+        (childId.startsWith(repoPrefix) && !legacyLiveIds.has(childId)) ||
+        (isRuntimeCanonicalWorktreeIdForRepoHost(repo, childId) && !liveIds.has(childId))
+      ) {
         // Why: runtime selector scans can be the only scan before a path is
         // reused. Once a successful scan proves the child is gone, stale
         // lineage must not survive into the replacement checkout.
@@ -16500,7 +16687,7 @@ export class OrcaRuntimeService {
       }
       if (
         lineage.parentWorktreeId.startsWith(repoPrefix) &&
-        !liveIds.has(lineage.parentWorktreeId)
+        !legacyLiveIds.has(lineage.parentWorktreeId)
       ) {
         const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
         if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
@@ -16722,9 +16909,13 @@ export class OrcaRuntimeService {
     const sessions = sessionsResult.value
     const livePtyIds = new Set(sessions.map((session) => session.id))
     for (const session of sessions) {
-      const worktreeId =
+      const inferredWorktreeId =
         inferWorktreeIdFromPtyId(session.id) ??
         findResolvedWorktreeIdForPath(resolvedWorktrees, session.cwd)
+      const worktreeId = inferredWorktreeId
+        ? (findResolvedWorktreeForIdAlias(resolvedWorktrees, inferredWorktreeId)?.id ??
+          inferredWorktreeId)
+        : null
       if (targetWorktreeId && worktreeId !== targetWorktreeId) {
         continue
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1282,10 +1282,21 @@ function getRuntimeWorktreeMetaForRepoPath(
   path: string
 ): WorktreeMeta | undefined {
   migrateRuntimeLegacyWorktreeMetaIfSafe(store, repo, path)
-  return (
-    store.getWorktreeMeta(getRuntimeRepoWorktreeId(repo, path)) ??
-    store.getWorktreeMeta(getRuntimeLegacyRepoWorktreeId(repo, path))
-  )
+  const canonicalMeta = store.getWorktreeMeta(getRuntimeRepoWorktreeId(repo, path))
+  if (canonicalMeta) {
+    return canonicalMeta
+  }
+  const legacyMeta = store.getWorktreeMeta(getRuntimeLegacyRepoWorktreeId(repo, path))
+  if (!legacyMeta) {
+    return undefined
+  }
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (legacyMeta.hostId !== undefined) {
+    return legacyMeta.hostId === repoHostId ? legacyMeta : undefined
+  }
+  // Why: hostless legacy metadata cannot distinguish two SSH hosts with the
+  // same repo id, even when the selector itself names a canonical host.
+  return hasRuntimeAmbiguousRepoHost(store.getRepos(), repo) ? undefined : legacyMeta
 }
 
 function migrateRuntimeLegacyWorktreeMetaIfSafe(
@@ -1309,12 +1320,58 @@ function migrateRuntimeLegacyWorktreeMetaIfSafe(
   if (legacyMeta.hostId !== undefined && legacyMeta.hostId !== repoHostId) {
     return
   }
+  if (legacyMeta.hostId === undefined && hasRuntimeAmbiguousRepoHost(store.getRepos(), repo)) {
+    return
+  }
   store.migrateWorktreeIdentity(legacyId, canonicalId)
 }
 
 function isRuntimeCanonicalWorktreeIdForRepoHost(repo: Repo, worktreeId: string): boolean {
   const parsed = parseWorktreeKey(worktreeId)
   return parsed?.repoId === repo.id && parsed.hostId === getRepoExecutionHostId(repo)
+}
+
+function isRuntimeWorktreeMetadataForRepoHost(
+  repos: Repo[],
+  repo: Repo,
+  worktreeId: string,
+  meta: WorktreeMeta
+): boolean {
+  const parsed = splitWorktreeId(worktreeId)
+  if (!parsed || parsed.repoId !== repo.id) {
+    return false
+  }
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (parsed.hostId !== undefined) {
+    return parsed.hostId === repoHostId
+  }
+  if (meta.hostId !== undefined) {
+    return meta.hostId === repoHostId
+  }
+  return !hasRuntimeAmbiguousRepoHost(repos, repo)
+}
+
+function hasRuntimeAmbiguousRepoHost(repos: Repo[], repo: Repo): boolean {
+  const hostIds = new Set(
+    repos
+      .filter((candidateRepo) => candidateRepo.id === repo.id)
+      .map((candidateRepo) => getRepoExecutionHostId(candidateRepo))
+  )
+  return hostIds.size > 1
+}
+
+function findRuntimeRepoForParsedWorktree(
+  repos: Repo[],
+  parsed: { repoId: string; hostId?: string }
+): Repo | undefined {
+  const matchingRepos = repos.filter((repo) => repo.id === parsed.repoId)
+  if (parsed.hostId !== undefined) {
+    return matchingRepos.find((repo) => parsed.hostId === getRepoExecutionHostId(repo))
+  }
+  const matchingHostIds = new Set(matchingRepos.map((repo) => getRepoExecutionHostId(repo)))
+  // Why: hostless legacy worktree IDs can name only repo+path, so resolving
+  // them is safe only when that repo id belongs to one execution host.
+  return matchingHostIds.size === 1 ? matchingRepos[0] : undefined
 }
 
 function isRuntimeWorktreeIdAliasForResolved(
@@ -15875,7 +15932,14 @@ export class OrcaRuntimeService {
     const parsed = parseWorkspaceKey(workspaceSelector)
     const worktreeSelector = parsed?.type === 'worktree' ? `id:${parsed.worktreeId}` : selector
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
-    const repo = this.store?.getRepo(worktree.repoId) ?? null
+    const repo = this.store
+      ? (findRuntimeRepoForParsedWorktree(this.store.getRepos(), {
+          repoId: worktree.repoId,
+          hostId: worktree.hostId
+        }) ??
+        this.store.getRepo(worktree.repoId) ??
+        null)
+      : null
     return {
       id: worktree.id,
       path: worktree.path,
@@ -15928,12 +15992,19 @@ export class OrcaRuntimeService {
       }
       if (candidates.length === 0) {
         const parsed = splitWorktreeIdForFilesystem(worktreeId)
-        const repo = parsed ? this.store?.getRepo(parsed.repoId) : null
-        const fallback =
-          repo?.connectionId && parsed
+        const repo =
+          parsed && this.store
+            ? findRuntimeRepoForParsedWorktree(this.store.getRepos(), parsed)
+            : null
+        const hasStoredMeta =
+          repo && parsed
             ? getRuntimeWorktreeMetaForRepoPath(this.requireStore(), repo, parsed.worktreePath)
-              ? this.buildResolvedWorktreeFromId(worktreeId)
-              : null
+            : undefined
+        const hasCanonicalHostMatch =
+          repo && parsed?.hostId !== undefined && parsed.hostId === getRepoExecutionHostId(repo)
+        const fallback =
+          repo?.connectionId && parsed && (hasStoredMeta || hasCanonicalHostMatch)
+            ? this.buildResolvedWorktreeFromId(worktreeId)
             : null
         if (fallback !== null) {
           candidates = [fallback]
@@ -16429,7 +16500,9 @@ export class OrcaRuntimeService {
     if (!parsed?.repoId || !parsed.worktreePath) {
       return null
     }
-    const repo = this.store?.getRepos().find((entry) => entry.id === parsed.repoId)
+    const repo = this.store
+      ? findRuntimeRepoForParsedWorktree(this.store.getRepos(), parsed)
+      : undefined
     const canonicalWorktreeId =
       repo && (parsed.hostId === undefined || parsed.hostId === getRepoExecutionHostId(repo))
         ? getRuntimeRepoWorktreeId(repo, parsed.worktreePath)
@@ -16730,9 +16803,13 @@ export class OrcaRuntimeService {
       return []
     }
     const byWorktreeId = new Map<string, GitWorktreeInfo>()
+    const repos = store.getRepos()
     for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
+      if (!isRuntimeWorktreeMetadataForRepoHost(repos, repo, worktreeId, meta)) {
+        continue
+      }
       const parsed = splitWorktreeId(worktreeId)
-      if (!parsed || parsed.repoId !== repo.id) {
+      if (!parsed) {
         continue
       }
       // Why: this mirrors desktop worktrees:list's disconnected-SSH fallback.

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16685,10 +16685,13 @@ export class OrcaRuntimeService {
         store.removeWorktreeLineage(childId)
         store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
       }
-      if (
+      const parentMissingFromLegacyScan =
         lineage.parentWorktreeId.startsWith(repoPrefix) &&
         !legacyLiveIds.has(lineage.parentWorktreeId)
-      ) {
+      const parentMissingFromCanonicalScan =
+        isRuntimeCanonicalWorktreeIdForRepoHost(repo, lineage.parentWorktreeId) &&
+        !liveIds.has(lineage.parentWorktreeId)
+      if (parentMissingFromLegacyScan || parentMissingFromCanonicalScan) {
         const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
         if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
           // Why: preserving child lineage powers the repair UI, but a missing

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1202,6 +1202,7 @@ async function isRuntimeWorktreePathMissing(
 type RuntimeWorktreeRemovalTarget = {
   id: string
   repoId: string
+  hostId?: string
   path: string
   pushTarget?: GitPushTarget
 }
@@ -1374,6 +1375,13 @@ function findRuntimeRepoForParsedWorktree(
   return matchingHostIds.size === 1 ? matchingRepos[0] : undefined
 }
 
+function findRuntimeRepoForRemovalTarget(
+  store: RuntimeStore,
+  target: RuntimeWorktreeRemovalTarget
+): Repo | undefined {
+  return findRuntimeRepoForParsedWorktree(store.getRepos(), target)
+}
+
 function isRuntimeWorktreeIdAliasForResolved(
   worktree: Pick<ResolvedWorktree, 'id' | 'repoId' | 'path' | 'hostId'>,
   worktreeId: string
@@ -1506,6 +1514,7 @@ function parseExactWorktreeIdSelector(selector: string): RuntimeWorktreeRemovalT
   return {
     id: worktreeId,
     repoId: parsed.repoId,
+    ...(parsed.hostId !== undefined ? { hostId: parsed.hostId } : {}),
     path: parsed.worktreePath
   }
 }
@@ -14041,6 +14050,7 @@ export class OrcaRuntimeService {
       const removalTarget = {
         id: worktree.id,
         repoId: worktree.repoId,
+        ...(worktree.hostId !== undefined ? { hostId: worktree.hostId } : {}),
         path: worktree.path
       }
       return worktree.pushTarget
@@ -14132,7 +14142,9 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
     const removalTarget = parseExactWorktreeIdSelector(worktreeSelector)
-    const repo = removalTarget ? this.store.getRepo(removalTarget.repoId) : undefined
+    const repo = removalTarget
+      ? findRuntimeRepoForRemovalTarget(this.store, removalTarget)
+      : undefined
     const canonicalRemovalTargetId =
       removalTarget && repo ? getRuntimeRepoWorktreeId(repo, removalTarget.path) : undefined
     const cleanupTarget = removalTarget
@@ -14217,7 +14229,7 @@ export class OrcaRuntimeService {
     // Why: runtime callers can race the same workspace through CLI/mobile
     // retries. Share one destructive Git/filesystem operation per worktree ID.
     const removal = (async (): Promise<RemoveWorktreeResult & { warning?: string }> => {
-      const repo = store.getRepo(removalTarget.repoId)
+      const repo = findRuntimeRepoForRemovalTarget(store, removalTarget)
       if (!repo) {
         throw new Error('repo_not_found')
       }

--- a/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
+++ b/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
@@ -69,6 +69,16 @@ const ProjectHostSetupCreate = z.object({
 
 const ProjectHostSetupUpdate = z.object({
   setupId: requiredString('Missing setup ID'),
+  hostId: requiredString('Missing host ID')
+    .transform((value, ctx) => {
+      const hostId = normalizeExecutionHostId(value)
+      if (!hostId) {
+        ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+        return z.NEVER
+      }
+      return hostId
+    })
+    .optional(),
   updates: z.object({
     displayName: OptionalString,
     path: OptionalString,
@@ -83,7 +93,17 @@ const ProjectHostSetupUpdate = z.object({
 })
 
 const ProjectHostSetupDelete = z.object({
-  setupId: requiredString('Missing setup ID')
+  setupId: requiredString('Missing setup ID'),
+  hostId: requiredString('Missing host ID')
+    .transform((value, ctx) => {
+      const hostId = normalizeExecutionHostId(value)
+      if (!hostId) {
+        ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+        return z.NEVER
+      }
+      return hostId
+    })
+    .optional()
 })
 
 export const PROJECT_RUNTIME_METHODS: RpcMethod[] = [

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -15,6 +15,7 @@ import { createRuntimeTransportMetadata, OrcaRuntimeRpcServer } from './runtime-
 import { parsePairingCode } from '../../shared/pairing'
 import { decrypt, deriveSharedKey, encrypt, generateKeyPair } from './rpc/e2ee-crypto'
 import { DeviceRegistry } from './device-registry'
+import { makeWorktreeKey } from '../../shared/worktree-id'
 
 vi.mock('../git/worktree', () => ({
   listWorktrees: vi.fn().mockResolvedValue([
@@ -259,6 +260,25 @@ class FakeWebSocket extends EventEmitter {
 }
 
 describe('OrcaRuntimeRpcServer', () => {
+  const LEGACY_WORKTREE_A_ID = 'repo-1::/tmp/worktree-a'
+  const WORKTREE_A_ID = makeWorktreeKey({
+    hostId: 'local',
+    repoId: 'repo-1',
+    path: '/tmp/worktree-a'
+  })
+  const makeWorktreeMeta = (overrides?: { isUnread?: boolean }) => ({
+    displayName: 'foo',
+    comment: '',
+    linkedIssue: 123,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: overrides?.isUnread ?? false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  })
+
   const makeStore = (overrides?: { isUnread?: boolean }) => ({
     getRepo: (id: string) =>
       makeStore(overrides)
@@ -279,27 +299,20 @@ describe('OrcaRuntimeRpcServer', () => {
         ...makeStore(overrides).getRepo(id),
         ...updates
       }) as never,
-    getAllWorktreeMeta: () => ({
-      'repo-1::/tmp/worktree-a': {
-        displayName: 'foo',
-        comment: '',
-        linkedIssue: 123,
-        linkedPR: null,
-        linkedLinearIssue: null,
-        isArchived: false,
-        isUnread: overrides?.isUnread ?? false,
-        isPinned: false,
-        sortOrder: 0,
-        lastActivityAt: 0
+    getAllWorktreeMeta: () => {
+      const meta = makeWorktreeMeta(overrides)
+      return {
+        [LEGACY_WORKTREE_A_ID]: meta,
+        [WORKTREE_A_ID]: meta
       }
-    }),
+    },
     getWorktreeMeta: (worktreeId: string) =>
-      worktreeId === 'repo-1::/tmp/worktree-a'
+      worktreeId === LEGACY_WORKTREE_A_ID || worktreeId === WORKTREE_A_ID
         ? (makeStore(overrides).getAllWorktreeMeta()[worktreeId] as never)
         : undefined,
     setWorktreeMeta: (_worktreeId: string, meta: Record<string, unknown>) =>
       ({
-        ...makeStore(overrides).getAllWorktreeMeta()['repo-1::/tmp/worktree-a'],
+        ...makeStore(overrides).getAllWorktreeMeta()[WORKTREE_A_ID],
         ...meta
       }) as never,
     removeWorktreeMeta: () => {},
@@ -2240,7 +2253,7 @@ describe('OrcaRuntimeRpcServer', () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
     const runtime = new OrcaRuntimeService(makeStore() as never)
     const server = new OrcaRuntimeRpcServer({ runtime, userDataPath })
-    const worktreeId = 'repo-1::/tmp/worktree-a'
+    const worktreeId = WORKTREE_A_ID
     const leftLeaf = '11111111-1111-4111-8111-111111111111'
     const topLeaf = '22222222-2222-4222-8222-222222222222'
     const bottomLeaf = '33333333-3333-4333-8333-333333333333'
@@ -2507,7 +2520,7 @@ describe('OrcaRuntimeRpcServer', () => {
       ok: true,
       result: {
         terminal: {
-          worktreeId: 'repo-1::/tmp/worktree-a',
+          worktreeId: WORKTREE_A_ID,
           surface: 'background'
         }
       }
@@ -2520,7 +2533,7 @@ describe('OrcaRuntimeRpcServer', () => {
       authToken,
       method: 'session.tabs.list',
       params: {
-        worktree: 'id:repo-1::/tmp/worktree-a'
+        worktree: `id:${WORKTREE_A_ID}`
       }
     })
 
@@ -2609,7 +2622,7 @@ describe('OrcaRuntimeRpcServer', () => {
     const metadata = readRuntimeMetadata(userDataPath)
     const laptopEndpoint = metadata!.transports[0]!.endpoint
     const laptopAuthToken = metadata!.authToken
-    const worktree = 'id:repo-1::/tmp/worktree-a'
+    const worktree = `id:${WORKTREE_A_ID}`
     const leafId = '11111111-1111-4111-8111-111111111111'
 
     try {
@@ -2757,7 +2770,7 @@ describe('OrcaRuntimeRpcServer', () => {
       result: {
         worktrees: [
           {
-            worktreeId: 'repo-1::/tmp/worktree-a',
+            worktreeId: WORKTREE_A_ID,
             repoId: 'repo-1',
             repo: 'repo',
             path: '/tmp/worktree-a',
@@ -2903,7 +2916,7 @@ describe('OrcaRuntimeRpcServer', () => {
         tabs: [
           {
             tabId: 'tab-1',
-            worktreeId: 'repo-1::/tmp/worktree-a',
+            worktreeId: WORKTREE_A_ID,
             title: 'Terminal 1',
             activeLeafId: 'pane:1',
             layout: null

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -1,6 +1,7 @@
 import type { IPtyProvider } from '../providers/types'
 import type { OrcaRuntimeService } from './orca-runtime'
 import { listRegisteredPtys } from '../memory/pty-registry'
+import { makeLegacyWorktreeId, splitWorktreeId } from '../../shared/worktree-id'
 
 export type WorktreeTeardownDeps = {
   runtime?: OrcaRuntimeService
@@ -51,13 +52,15 @@ export async function killAllProcessesForWorktree(
     result.runtimeStopped = r.stopped
   }
 
+  const worktreeIds = getTeardownWorktreeIds(worktreeId)
+
   result.providerStopped = await sweepProviderByPrefix(
-    worktreeId,
+    worktreeIds,
     deps.localProvider,
     deps.onPtyStopped
   )
   result.registryStopped = await sweepRegistryForWorktree(
-    worktreeId,
+    worktreeIds,
     deps.localProvider,
     deps.onPtyStopped
   )
@@ -66,15 +69,15 @@ export async function killAllProcessesForWorktree(
 }
 
 async function sweepProviderByPrefix(
-  worktreeId: string,
+  worktreeIds: ReadonlySet<string>,
   provider: IPtyProvider,
   onPtyStopped?: (ptyId: string) => void
 ): Promise<number> {
-  const prefix = `${worktreeId}@@`
+  const prefixes = [...worktreeIds].map((worktreeId) => `${worktreeId}@@`)
   const sessions = await provider.listProcesses().catch(() => [])
   let killed = 0
   for (const s of sessions) {
-    if (!s.id.startsWith(prefix)) {
+    if (!prefixes.some((prefix) => s.id.startsWith(prefix))) {
       continue
     }
     try {
@@ -90,11 +93,13 @@ async function sweepProviderByPrefix(
 }
 
 async function sweepRegistryForWorktree(
-  worktreeId: string,
+  worktreeIds: ReadonlySet<string>,
   localProvider: IPtyProvider,
   onPtyStopped?: (ptyId: string) => void
 ): Promise<number> {
-  const entries = listRegisteredPtys().filter((r) => r.worktreeId === worktreeId)
+  const entries = listRegisteredPtys().filter(
+    (r) => r.worktreeId !== null && worktreeIds.has(r.worktreeId)
+  )
   let killed = 0
   for (const entry of entries) {
     try {
@@ -106,6 +111,15 @@ async function sweepRegistryForWorktree(
     }
   }
   return killed
+}
+
+function getTeardownWorktreeIds(worktreeId: string): Set<string> {
+  const ids = new Set([worktreeId])
+  const parsed = splitWorktreeId(worktreeId)
+  if (parsed) {
+    ids.add(makeLegacyWorktreeId(parsed.repoId, parsed.worktreePath))
+  }
+  return ids
 }
 
 function clearStoppedPtyState(ptyId: string, onPtyStopped?: (ptyId: string) => void): void {

--- a/src/main/usage-worktree-metadata.test.ts
+++ b/src/main/usage-worktree-metadata.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { makeWorktreeKey } from '../shared/worktree-id'
 import { loadKnownUsageWorktreesByRepo } from './usage-worktree-metadata'
 
 describe('loadKnownUsageWorktreesByRepo', () => {
@@ -36,7 +37,11 @@ describe('loadKnownUsageWorktreesByRepo', () => {
           'repo-1',
           [
             {
-              worktreeId: 'repo-1::/workspace/repo-a',
+              worktreeId: makeWorktreeKey({
+                hostId: 'local',
+                repoId: 'repo-1',
+                path: '/workspace/repo-a'
+              }),
               path: '/workspace/repo-a',
               displayName: 'Repo A'
             },

--- a/src/main/usage-worktree-metadata.test.ts
+++ b/src/main/usage-worktree-metadata.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { makeWorktreeKey } from '../shared/worktree-id'
-import { loadKnownUsageWorktreesByRepo } from './usage-worktree-metadata'
+import { getUsageRepoKey, loadKnownUsageWorktreesByRepo } from './usage-worktree-metadata'
 
 describe('loadKnownUsageWorktreesByRepo', () => {
   it('builds usage worktree refs from repo roots and persisted metadata', () => {
@@ -34,7 +34,7 @@ describe('loadKnownUsageWorktreesByRepo', () => {
     expect(loadKnownUsageWorktreesByRepo(store as never, repos as never)).toEqual(
       new Map([
         [
-          'repo-1',
+          getUsageRepoKey({ id: 'repo-1', connectionId: null, executionHostId: null }),
           [
             {
               worktreeId: makeWorktreeKey({
@@ -55,5 +55,80 @@ describe('loadKnownUsageWorktreesByRepo', () => {
       ])
     )
     expect(store.getAllWorktreeMeta).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps same-id local and runtime repos in separate usage buckets', () => {
+    const store = {
+      getAllWorktreeMeta: vi.fn(() => ({
+        [makeWorktreeKey({
+          hostId: 'local',
+          repoId: 'repo-1',
+          path: '/workspace/local-feature'
+        })]: {
+          displayName: 'Local feature'
+        },
+        [makeWorktreeKey({
+          hostId: 'runtime:server-1',
+          repoId: 'repo-1',
+          path: '/srv/runtime-feature'
+        })]: {
+          displayName: 'Runtime feature'
+        }
+      }))
+    }
+    const localRepo = {
+      id: 'repo-1',
+      path: '/workspace/repo-a',
+      displayName: 'Local Repo'
+    }
+    const runtimeRepo = {
+      id: 'repo-1',
+      path: '/srv/repo-a',
+      displayName: 'Runtime Repo',
+      executionHostId: 'runtime:server-1' as const
+    }
+
+    const result = loadKnownUsageWorktreesByRepo(store as never, [localRepo, runtimeRepo] as never)
+
+    expect(result.get(getUsageRepoKey(localRepo))).toEqual([
+      {
+        worktreeId: makeWorktreeKey({
+          hostId: 'local',
+          repoId: 'repo-1',
+          path: '/workspace/repo-a'
+        }),
+        path: '/workspace/repo-a',
+        displayName: 'Local Repo'
+      },
+      {
+        worktreeId: makeWorktreeKey({
+          hostId: 'local',
+          repoId: 'repo-1',
+          path: '/workspace/local-feature'
+        }),
+        path: '/workspace/local-feature',
+        displayName: 'Local feature'
+      }
+    ])
+    expect(result.get(getUsageRepoKey(runtimeRepo))).toEqual([
+      {
+        worktreeId: makeWorktreeKey({
+          hostId: 'runtime:server-1',
+          repoId: 'repo-1',
+          path: '/srv/repo-a'
+        }),
+        path: '/srv/repo-a',
+        displayName: 'Runtime Repo'
+      },
+      {
+        worktreeId: makeWorktreeKey({
+          hostId: 'runtime:server-1',
+          repoId: 'repo-1',
+          path: '/srv/runtime-feature'
+        }),
+        path: '/srv/runtime-feature',
+        displayName: 'Runtime feature'
+      }
+    ])
   })
 })

--- a/src/main/usage-worktree-metadata.ts
+++ b/src/main/usage-worktree-metadata.ts
@@ -1,6 +1,10 @@
 import { basename } from 'path'
 import type { Repo } from '../shared/types'
-import { splitWorktreeId, splitWorktreeIdForFilesystem } from '../shared/worktree-id'
+import {
+  makeRepoWorktreeKey,
+  splitWorktreeId,
+  splitWorktreeIdForFilesystem
+} from '../shared/worktree-id'
 import { isFolderRepo } from '../shared/repo-kind'
 import type { Store } from './persistence'
 
@@ -26,7 +30,7 @@ export function loadKnownUsageWorktreesByRepo(
   for (const repo of localRepos) {
     worktreesByRepo.set(repo.id, [
       {
-        worktreeId: `${repo.id}::${repo.path}`,
+        worktreeId: makeRepoWorktreeKey(repo, repo.path),
         path: repo.path,
         displayName: repo.displayName || getDefaultUsageWorktreeLabel(repo.path)
       }

--- a/src/main/usage-worktree-metadata.ts
+++ b/src/main/usage-worktree-metadata.ts
@@ -7,6 +7,7 @@ import {
 } from '../shared/worktree-id'
 import { isFolderRepo } from '../shared/repo-kind'
 import type { Store } from './persistence'
+import { getRepoExecutionHostId } from '../shared/execution-host'
 
 export type UsageWorktreeRef = {
   worktreeId: string
@@ -18,44 +19,60 @@ function getDefaultUsageWorktreeLabel(pathValue: string): string {
   return basename(pathValue)
 }
 
+export function getUsageRepoKey(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+): string {
+  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
+}
+
 export function loadKnownUsageWorktreesByRepo(
   store: Pick<Store, 'getAllWorktreeMeta'>,
   repos: Repo[]
 ): Map<string, UsageWorktreeRef[]> {
   const localRepos = repos.filter((repo) => !repo.connectionId)
-  const repoIds = new Set(localRepos.map((repo) => repo.id))
   const worktreesByRepo = new Map<string, UsageWorktreeRef[]>()
   const seenPathsByRepo = new Map<string, Set<string>>()
 
   for (const repo of localRepos) {
-    worktreesByRepo.set(repo.id, [
+    const repoKey = getUsageRepoKey(repo)
+    worktreesByRepo.set(repoKey, [
       {
         worktreeId: makeRepoWorktreeKey(repo, repo.path),
         path: repo.path,
         displayName: repo.displayName || getDefaultUsageWorktreeLabel(repo.path)
       }
     ])
-    seenPathsByRepo.set(repo.id, new Set([repo.path]))
+    seenPathsByRepo.set(repoKey, new Set([repo.path]))
   }
 
   // Why: usage scans are background/opt-in analytics. Do not spawn
   // `git worktree list` here; it can re-touch macOS protected folders.
   for (const [worktreeId, meta] of Object.entries(store.getAllWorktreeMeta())) {
     const parsed = splitWorktreeId(worktreeId)
-    if (!parsed || !repoIds.has(parsed.repoId)) {
+    if (!parsed) {
       continue
     }
-    const repo = localRepos.find((item) => item.id === parsed.repoId)
+    const matchingRepos = localRepos.filter((item) => {
+      if (item.id !== parsed.repoId) {
+        return false
+      }
+      return parsed.hostId === undefined || getRepoExecutionHostId(item) === parsed.hostId
+    })
+    if (matchingRepos.length !== 1) {
+      continue
+    }
+    const [repo] = matchingRepos
+    const repoKey = getUsageRepoKey(repo)
     const worktreePath =
       repo && isFolderRepo(repo)
         ? (splitWorktreeIdForFilesystem(worktreeId)?.worktreePath ?? parsed.worktreePath)
         : parsed.worktreePath
-    const seenPaths = seenPathsByRepo.get(parsed.repoId)
+    const seenPaths = seenPathsByRepo.get(repoKey)
     if (seenPaths?.has(worktreePath)) {
       continue
     }
     seenPaths?.add(worktreePath)
-    worktreesByRepo.get(parsed.repoId)?.push({
+    worktreesByRepo.get(repoKey)?.push({
       worktreeId,
       path: worktreePath,
       displayName: meta.displayName || getDefaultUsageWorktreeLabel(worktreePath)

--- a/src/main/workspace-space-analysis.test.ts
+++ b/src/main/workspace-space-analysis.test.ts
@@ -3,7 +3,8 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Repo } from '../shared/types'
+import type { Repo, WorktreeMeta } from '../shared/types'
+import { makeLegacyWorktreeId, makeRepoWorktreeKey } from '../shared/worktree-id'
 import type { Store } from './persistence'
 
 const { listRepoWorktreesMock, getSshFilesystemProviderMock, getSshGitProviderMock } = vi.hoisted(
@@ -122,6 +123,112 @@ describe('analyzeWorkspaceSpace', () => {
     expect(feature?.reclaimableBytes).toBe(feature?.sizeBytes)
     expect(feature?.topLevelItems[0]?.name).toBe('node_modules')
     expect(result.reclaimableBytes).toBe(feature?.sizeBytes)
+  })
+
+  it('migrates safe legacy worktree metadata during space scans', async () => {
+    const root = tempDir!
+    const repoPath = join(root, 'repo')
+    const featurePath = join(root, 'feature')
+    await mkdir(featurePath, { recursive: true })
+    await writeSizedFile(join(featurePath, 'feature.ts'), 512)
+
+    const repo: Repo = {
+      id: 'repo-1',
+      path: repoPath,
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    const legacyId = makeLegacyWorktreeId(repo.id, featurePath)
+    const canonicalId = makeRepoWorktreeKey(repo, featurePath)
+    const metaById: Record<string, WorktreeMeta> = {
+      [legacyId]: {
+        displayName: 'Legacy Feature',
+        comment: '',
+        linkedIssue: null,
+        linkedPR: null,
+        linkedLinearIssue: null,
+        isArchived: false,
+        isUnread: false,
+        isPinned: false,
+        sortOrder: 0,
+        lastActivityAt: 200
+      }
+    }
+    const migrateWorktreeIdentity = vi.fn((oldId: string, newId: string) => {
+      metaById[newId] = metaById[oldId]!
+      delete metaById[oldId]
+    })
+    const store = {
+      getRepos: () => [repo],
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      migrateWorktreeIdentity
+    } as unknown as Store
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: featurePath,
+        head: 'b',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await analyzeWorkspaceSpace(store)
+
+    expect(migrateWorktreeIdentity).toHaveBeenCalledWith(legacyId, canonicalId)
+    expect(metaById[legacyId]).toBeUndefined()
+    expect(result.worktrees[0]).toMatchObject({
+      displayName: 'Legacy Feature',
+      status: 'ok'
+    })
+  })
+
+  it('ignores legacy worktree metadata from a different host during space scans', async () => {
+    const root = tempDir!
+    const repoPath = join(root, 'repo')
+    const featurePath = join(root, 'feature')
+    await mkdir(featurePath, { recursive: true })
+    await writeSizedFile(join(featurePath, 'feature.ts'), 512)
+
+    const repo: Repo = {
+      id: 'repo-1',
+      path: repoPath,
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    const legacyId = makeLegacyWorktreeId(repo.id, featurePath)
+    const migrateWorktreeIdentity = vi.fn()
+    const store = {
+      getRepos: () => [repo],
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === legacyId
+          ? {
+              displayName: 'Wrong Host',
+              hostId: 'ssh:other',
+              lastActivityAt: 200
+            }
+          : undefined,
+      migrateWorktreeIdentity
+    } as unknown as Store
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: featurePath,
+        head: 'b',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await analyzeWorkspaceSpace(store)
+
+    expect(migrateWorktreeIdentity).not.toHaveBeenCalled()
+    expect(result.worktrees[0]).toMatchObject({
+      displayName: 'feature',
+      status: 'ok'
+    })
   })
 
   it('reports scan progress as repos and worktrees are scanned', async () => {

--- a/src/main/workspace-space-analysis.test.ts
+++ b/src/main/workspace-space-analysis.test.ts
@@ -231,6 +231,57 @@ describe('analyzeWorkspaceSpace', () => {
     })
   })
 
+  it('ignores hostless legacy worktree metadata when repo hosts are ambiguous during space scans', async () => {
+    const root = tempDir!
+    const repoPath = join(root, 'repo')
+    const featurePath = join(root, 'feature')
+    await mkdir(featurePath, { recursive: true })
+    await writeSizedFile(join(featurePath, 'feature.ts'), 512)
+
+    const localRepo: Repo = {
+      id: 'repo-1',
+      path: repoPath,
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    const remoteRepo: Repo = {
+      ...localRepo,
+      path: '/remote/repo',
+      connectionId: 'gpu-vm'
+    }
+    const legacyId = makeLegacyWorktreeId(localRepo.id, featurePath)
+    const migrateWorktreeIdentity = vi.fn()
+    const store = {
+      getRepos: () => [localRepo, remoteRepo],
+      getWorktreeMeta: (worktreeId: string) =>
+        worktreeId === legacyId
+          ? {
+              displayName: 'Ambiguous Legacy',
+              lastActivityAt: 200
+            }
+          : undefined,
+      migrateWorktreeIdentity
+    } as unknown as Store
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: featurePath,
+        head: 'b',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await analyzeWorkspaceSpace(store)
+
+    expect(migrateWorktreeIdentity).not.toHaveBeenCalled()
+    expect(result.worktrees[0]).toMatchObject({
+      displayName: 'feature',
+      status: 'ok'
+    })
+  })
+
   it('reports scan progress as repos and worktrees are scanned', async () => {
     const root = tempDir!
     const repoPath = join(root, 'repo')

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -25,7 +25,7 @@ import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { createFolderWorktree, listRepoWorktrees } from './repo-worktrees'
 import { mergeWorktree } from './ipc/worktree-logic'
 import { getRepoExecutionHostId } from '../shared/execution-host'
-import { makeRepoWorktreeKey } from '../shared/worktree-id'
+import { makeLegacyWorktreeId, makeRepoWorktreeKey } from '../shared/worktree-id'
 
 const WORKTREE_SCAN_CONCURRENCY = 3
 const LOCAL_FS_CONCURRENCY = 48
@@ -800,9 +800,38 @@ async function listWorktreesForSpaceScan(
 
 function mergeForSpaceScan(repo: Repo, gitWorktree: GitWorktreeInfo, store: Store): Worktree {
   const worktreeId = makeRepoWorktreeKey(repo, gitWorktree.path)
-  return mergeWorktree(repo.id, gitWorktree, store.getWorktreeMeta(worktreeId), repo.displayName, {
+  const meta = getWorktreeMetaForSpaceScan(repo, gitWorktree.path, store, worktreeId)
+  return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
     hostId: getRepoExecutionHostId(repo)
   })
+}
+
+function getWorktreeMetaForSpaceScan(
+  repo: Repo,
+  worktreePath: string,
+  store: Store,
+  canonicalId: string
+): ReturnType<Store['getWorktreeMeta']> {
+  const canonicalMeta = store.getWorktreeMeta(canonicalId)
+  if (canonicalMeta) {
+    return canonicalMeta
+  }
+
+  const legacyId = makeLegacyWorktreeId(repo.id, worktreePath)
+  const legacyMeta = store.getWorktreeMeta(legacyId)
+  if (!legacyMeta) {
+    return undefined
+  }
+
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (legacyMeta.hostId !== undefined && legacyMeta.hostId !== repoHostId) {
+    return undefined
+  }
+
+  // Why: space scans are read-heavy, but a safe legacy hit should be upgraded
+  // so future scans do not depend on the unqualified repoId::path key.
+  store.migrateWorktreeIdentity(legacyId, canonicalId)
+  return store.getWorktreeMeta(canonicalId) ?? legacyMeta
 }
 
 function reportProgress(

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -798,9 +798,14 @@ async function listWorktreesForSpaceScan(
   }
 }
 
-function mergeForSpaceScan(repo: Repo, gitWorktree: GitWorktreeInfo, store: Store): Worktree {
+function mergeForSpaceScan(
+  repo: Repo,
+  repos: Repo[],
+  gitWorktree: GitWorktreeInfo,
+  store: Store
+): Worktree {
   const worktreeId = makeRepoWorktreeKey(repo, gitWorktree.path)
-  const meta = getWorktreeMetaForSpaceScan(repo, gitWorktree.path, store, worktreeId)
+  const meta = getWorktreeMetaForSpaceScan(repo, repos, gitWorktree.path, store, worktreeId)
   return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName, {
     hostId: getRepoExecutionHostId(repo)
   })
@@ -808,6 +813,7 @@ function mergeForSpaceScan(repo: Repo, gitWorktree: GitWorktreeInfo, store: Stor
 
 function getWorktreeMetaForSpaceScan(
   repo: Repo,
+  repos: Repo[],
   worktreePath: string,
   store: Store,
   canonicalId: string
@@ -827,11 +833,23 @@ function getWorktreeMetaForSpaceScan(
   if (legacyMeta.hostId !== undefined && legacyMeta.hostId !== repoHostId) {
     return undefined
   }
+  if (legacyMeta.hostId === undefined && hasAmbiguousRepoHostForSpaceScan(repos, repo)) {
+    return undefined
+  }
 
   // Why: space scans are read-heavy, but a safe legacy hit should be upgraded
   // so future scans do not depend on the unqualified repoId::path key.
   store.migrateWorktreeIdentity(legacyId, canonicalId)
   return store.getWorktreeMeta(canonicalId) ?? legacyMeta
+}
+
+function hasAmbiguousRepoHostForSpaceScan(repos: Repo[], repo: Repo): boolean {
+  const hostIds = new Set(
+    repos
+      .filter((candidateRepo) => candidateRepo.id === repo.id)
+      .map((candidateRepo) => getRepoExecutionHostId(candidateRepo))
+  )
+  return hostIds.size > 1
 }
 
 function reportProgress(
@@ -845,6 +863,7 @@ function reportProgress(
 
 async function scanRepo(
   repo: Repo,
+  repos: Repo[],
   scannedAt: number,
   store: Store,
   progress: WorkspaceSpaceProgressState,
@@ -884,7 +903,7 @@ async function scanRepo(
   }
 
   const worktrees = listed.worktrees.map((gitWorktree) =>
-    mergeForSpaceScan(repo, gitWorktree, store)
+    mergeForSpaceScan(repo, repos, gitWorktree, store)
   )
   reportProgress(
     progress,
@@ -968,7 +987,7 @@ export async function analyzeWorkspaceSpace(
   }
   options.onProgress?.({ ...progress })
   const repoResults = await mapLimit(reposToScan, 2, (repo) =>
-    scanRepo(repo, scannedAt, store, progress, options)
+    scanRepo(repo, reposToScan, scannedAt, store, progress, options)
   )
   throwIfAborted(options.signal)
   const repos = repoResults.map((result) => result.summary)

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -24,6 +24,8 @@ import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { createFolderWorktree, listRepoWorktrees } from './repo-worktrees'
 import { mergeWorktree } from './ipc/worktree-logic'
+import { getRepoExecutionHostId } from '../shared/execution-host'
+import { makeRepoWorktreeKey } from '../shared/worktree-id'
 
 const WORKTREE_SCAN_CONCURRENCY = 3
 const LOCAL_FS_CONCURRENCY = 48
@@ -797,8 +799,10 @@ async function listWorktreesForSpaceScan(
 }
 
 function mergeForSpaceScan(repo: Repo, gitWorktree: GitWorktreeInfo, store: Store): Worktree {
-  const worktreeId = `${repo.id}::${gitWorktree.path}`
-  return mergeWorktree(repo.id, gitWorktree, store.getWorktreeMeta(worktreeId), repo.displayName)
+  const worktreeId = makeRepoWorktreeKey(repo, gitWorktree.path)
+  return mergeWorktree(repo.id, gitWorktree, store.getWorktreeMeta(worktreeId), repo.displayName, {
+    hostId: getRepoExecutionHostId(repo)
+  })
 }
 
 function reportProgress(

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -770,10 +770,11 @@ export type PreloadApi = {
       path: string
       kind?: 'git' | 'folder'
     }) => Promise<{ repo: Repo } | { error: string }>
-    remove: (args: { repoId: string }) => Promise<void>
+    remove: (args: { repoId: string; hostId?: string }) => Promise<void>
     reorder: (args: { orderedIds: string[] }) => Promise<{ status: 'applied' | 'rejected' }>
     update: (args: {
       repoId: string
+      hostId?: string
       updates: Partial<
         Pick<
           Repo,
@@ -929,8 +930,11 @@ export type PreloadApi = {
     onChanged: (callback: (data: { repoId: string }) => void) => () => void
   }
   worktrees: {
-    list: (args: { repoId: string }) => Promise<Worktree[]>
-    listDetected: (args: { repoId: string }) => Promise<DetectedWorktreeListResult>
+    list: (args: { repoId: string; hostId?: ExecutionHostId }) => Promise<Worktree[]>
+    listDetected: (args: {
+      repoId: string
+      hostId?: ExecutionHostId
+    }) => Promise<DetectedWorktreeListResult>
     listAll: () => Promise<Worktree[]>
     create: (args: CreateWorktreeArgs) => Promise<CreateWorktreeResult>
     /** Two-phase progress for a background `create`, correlated by

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -111,6 +111,7 @@ import {
   lookupGitHubWorkItemForSource
 } from '@/lib/github-work-item-source-lookup'
 import type { SettingsNavTarget } from '@/lib/settings-navigation-types'
+import { parseRepoSettingsSectionId } from '@/lib/repo-settings-section-id'
 import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overrides'
 import type { BrowserPage, BrowserWorkspace, Worktree } from '../../../shared/types'
 import { isGitRepoKind } from '../../../shared/repo-kind'
@@ -309,10 +310,12 @@ function findBrowserSelection(
 function getSettingsTargetFromSectionId(sectionId: string): {
   pane: SettingsNavTarget
   repoId: string | null
+  repoHostId?: string
   sectionId?: string
 } {
-  if (sectionId.startsWith('repo-')) {
-    return { pane: 'repo', repoId: sectionId.slice('repo-'.length) }
+  const repoSection = parseRepoSettingsSectionId(sectionId)
+  if (repoSection) {
+    return { pane: 'repo', repoId: repoSection.repoId, repoHostId: repoSection.repoHostId }
   }
   return { pane: sectionId as SettingsNavTarget, repoId: null }
 }

--- a/src/renderer/src/components/automations/automation-target-availability.test.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.test.ts
@@ -176,6 +176,43 @@ describe('automation target availability', () => {
     })
   })
 
+  it('matches saved run context setup by id and host when setup ids repeat', () => {
+    const automation = makeAutomation({
+      runContext: {
+        kind: 'workspace-run',
+        projectId: 'project-1',
+        hostId: 'runtime:gpu',
+        projectHostSetupId: 'shared-setup',
+        repoId: 'repo-1',
+        path: '/runtime/repo'
+      }
+    })
+
+    expect(
+      getAutomationTargetAvailability({
+        automation,
+        repo: makeRepo({ path: '/runtime/repo', executionHostId: 'runtime:gpu' }),
+        workspace: makeWorkspace(),
+        projectHostSetups: [
+          makeProjectHostSetup({
+            id: 'shared-setup',
+            hostId: 'local',
+            path: '/local/repo'
+          }),
+          makeProjectHostSetup({
+            id: 'shared-setup',
+            hostId: 'runtime:gpu',
+            path: '/runtime/repo'
+          })
+        ],
+        sshConnectionStates: new Map(),
+        runtimeStatusByEnvironmentId: new Map([
+          ['gpu', { status: makeRuntimeStatus(), checkedAt: 1 }]
+        ])
+      }).reason
+    ).toBe('available')
+  })
+
   it('requires SSH hosts to be connected before manual runs', () => {
     const automation = makeAutomation({
       executionTargetType: 'ssh',

--- a/src/renderer/src/components/automations/automation-target-availability.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.ts
@@ -67,8 +67,9 @@ export function getAutomationTargetAvailability({
   if (!repo) {
     return unavailable('missing-project', 'The target project is no longer available.')
   }
-  if (automation.runContext) {
-    const parsedHost = parseExecutionHostId(automation.runContext.hostId)
+  const runContext = automation.runContext
+  if (runContext) {
+    const parsedHost = parseExecutionHostId(runContext.hostId)
     if (parsedHost?.kind === 'runtime') {
       const runtimeAvailability = getRuntimeAutomationAvailability(
         parsedHost.environmentId,
@@ -79,9 +80,19 @@ export function getAutomationTargetAvailability({
       }
     }
     const setup = projectHostSetups.find(
-      (candidate) => candidate.id === automation.runContext?.projectHostSetupId
+      (candidate) =>
+        candidate.id === runContext.projectHostSetupId &&
+        candidate.projectId === runContext.projectId &&
+        candidate.hostId === runContext.hostId &&
+        candidate.repoId === runContext.repoId
     )
     if (!setup) {
+      if (projectHostSetups.some((candidate) => candidate.id === runContext.projectHostSetupId)) {
+        return unavailable(
+          'host-mismatch',
+          'The saved run host no longer matches this project setup.'
+        )
+      }
       return unavailable(
         'missing-project-host-setup',
         'Project is not set up on the selected automation host anymore.'
@@ -94,13 +105,13 @@ export function getAutomationTargetAvailability({
       )
     }
     if (
-      setup.projectId !== automation.runContext.projectId ||
-      setup.hostId !== automation.runContext.hostId ||
-      setup.repoId !== automation.runContext.repoId ||
-      setup.path !== automation.runContext.path ||
-      automation.runContext.repoId !== repo.id ||
-      automation.runContext.path !== repo.path ||
-      automation.runContext.hostId !== getRepoExecutionHostId(repo)
+      setup.projectId !== runContext.projectId ||
+      setup.hostId !== runContext.hostId ||
+      setup.repoId !== runContext.repoId ||
+      setup.path !== runContext.path ||
+      runContext.repoId !== repo.id ||
+      runContext.path !== repo.path ||
+      runContext.hostId !== getRepoExecutionHostId(repo)
     ) {
       return unavailable(
         'host-mismatch',

--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -3,7 +3,7 @@ import { AlertCircle, FileCode2, LoaderCircle, Plus, RefreshCw } from 'lucide-re
 import { toast } from 'sonner'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import type { Repo, Worktree } from '../../../../shared/types'
-import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, makeRepoWorktreeKey } from '../../../../shared/worktree-id'
 import {
   canInspectLocalMcpConfigRoot,
   inspectMcpConfigContent,
@@ -63,9 +63,26 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     return (
       worktreesForRepo.find((worktree) => worktree.isMainWorktree) ??
       worktreesForRepo.find((worktree) => worktree.path === repo.path) ??
-      worktreesForRepo[0] ?? { id: `${repo.id}::${repo.path}`, path: repo.path }
+      worktreesForRepo[0] ?? {
+        id: makeRepoWorktreeKey(
+          {
+            id: repo.id,
+            connectionId: repo.connectionId,
+            executionHostId: repo.executionHostId
+          },
+          repo.path
+        ),
+        path: repo.path
+      }
     )
-  }, [activeWorktreeId, repo.id, repo.path, worktreesForRepo])
+  }, [
+    activeWorktreeId,
+    repo.connectionId,
+    repo.executionHostId,
+    repo.id,
+    repo.path,
+    worktreesForRepo
+  ])
   const targetWorktreeId = targetWorktree.id
   const targetRootPath = targetWorktree.path
   const detectedCount = useMemo(() => configs.filter((config) => config.exists).length, [configs])

--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import type { Repo, Worktree } from '../../../../shared/types'
 import { getRepoIdFromWorktreeId, makeRepoWorktreeKey } from '../../../../shared/worktree-id'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 import {
   canInspectLocalMcpConfigRoot,
   inspectMcpConfigContent,
@@ -36,7 +37,9 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
   const setActiveWorktree = useAppStore((state) => state.setActiveWorktree)
   const ensureWorktreeRootGroup = useAppStore((state) => state.ensureWorktreeRootGroup)
   const activeWorktreeId = useAppStore((state) => state.activeWorktreeId)
-  const worktreesForRepo = useAppStore((state) => state.worktreesByRepo[repo.id] ?? EMPTY_WORKTREES)
+  const allWorktreesForRepo = useAppStore(
+    (state) => state.worktreesByRepo[repo.id] ?? EMPTY_WORKTREES
+  )
   const sshConnectionStatus = useAppStore((state) =>
     repo.connectionId ? state.sshConnectionStates.get(repo.connectionId)?.status : null
   )
@@ -51,14 +54,20 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
 
   const connectionId = repo.connectionId ?? undefined
   const isWindows = isWindowsUserAgent()
+  const repoHostId = getRepoExecutionHostId(repo)
+  const worktreesForRepo = useMemo(
+    () =>
+      allWorktreesForRepo.filter(
+        (worktree) => (worktree.hostId ?? LOCAL_EXECUTION_HOST_ID) === repoHostId
+      ),
+    [allWorktreesForRepo, repoHostId]
+  )
   const targetWorktree = useMemo(() => {
-    if (activeWorktreeId && getRepoIdFromWorktreeId(activeWorktreeId) === repo.id) {
-      return (
-        worktreesForRepo.find((worktree) => worktree.id === activeWorktreeId) ?? {
-          id: activeWorktreeId,
-          path: repo.path
-        }
-      )
+    const activeWorktree = activeWorktreeId
+      ? worktreesForRepo.find((worktree) => worktree.id === activeWorktreeId)
+      : undefined
+    if (activeWorktree && getRepoIdFromWorktreeId(activeWorktree.id) === repo.id) {
+      return activeWorktree
     }
     return (
       worktreesForRepo.find((worktree) => worktree.isMainWorktree) ??

--- a/src/renderer/src/components/settings/RepositoryHostSetupActions.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupActions.tsx
@@ -43,7 +43,7 @@ type RepositoryHostSetupActionsProps = {
     setupState: 'not-set-up'
     setupMethod: 'provisioned'
   }) => Promise<ProjectHostSetupCreateResult | null>
-  onOpenSetup: (repoId: string) => void
+  onOpenSetup: (setup: Pick<ProjectHostSetup, 'repoId' | 'hostId'>) => void
 }
 
 type SetupStep = 'choose' | 'existing' | 'clone' | 'planned'
@@ -102,7 +102,7 @@ export function RepositoryHostSetupActions({
       })
       if (result) {
         resetFlow()
-        onOpenSetup(result.repo.id)
+        onOpenSetup(result.setup)
       }
     } finally {
       setIsSettingUp(false)
@@ -129,7 +129,7 @@ export function RepositoryHostSetupActions({
       })
       if (result) {
         resetFlow()
-        onOpenSetup(result.repo.id)
+        onOpenSetup(result.setup)
       }
     } finally {
       setIsCloning(false)

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
@@ -197,7 +197,11 @@ describe('RepositoryHostSetupsSection', () => {
     })
 
     expect(openSettingsPage).toHaveBeenCalledTimes(1)
-    expect(openSettingsTarget).toHaveBeenCalledWith({ pane: 'repo', repoId: 'remote-repo' })
+    expect(openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'repo',
+      repoId: 'remote-repo',
+      repoHostId: 'ssh:openclaw%202'
+    })
   })
 
   it('removes independent setup metadata instead of opening an empty repo target', async () => {
@@ -397,7 +401,11 @@ describe('RepositoryHostSetupsSection', () => {
       displayName: 'Orca'
     })
     expect(openSettingsPage).toHaveBeenCalledTimes(1)
-    expect(openSettingsTarget).toHaveBeenCalledWith({ pane: 'repo', repoId: 'remote-repo' })
+    expect(openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'repo',
+      repoId: 'remote-repo',
+      repoHostId: 'ssh:openclaw%202'
+    })
   })
 
   it('clones the project onto another known host from settings', async () => {
@@ -472,7 +480,11 @@ describe('RepositoryHostSetupsSection', () => {
       displayName: 'Orca'
     })
     expect(openSettingsPage).toHaveBeenCalledTimes(1)
-    expect(openSettingsTarget).toHaveBeenCalledWith({ pane: 'repo', repoId: 'remote-repo' })
+    expect(openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'repo',
+      repoId: 'remote-repo',
+      repoHostId: 'ssh:openclaw%202'
+    })
   })
 
   it('creates pending setup metadata for a known host without requiring a path', async () => {

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
@@ -256,9 +256,78 @@ describe('RepositoryHostSetupsSection', () => {
       removeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(deleteProjectHostSetup).toHaveBeenCalledWith({ setupId: 'gpu-setup' })
+    expect(deleteProjectHostSetup).toHaveBeenCalledWith({
+      setupId: 'gpu-setup',
+      hostId: 'runtime:gpu'
+    })
     expect(openSettingsPage).not.toHaveBeenCalled()
     expect(openSettingsTarget).not.toHaveBeenCalled()
+  })
+
+  it('removes the selected same-id setup from its host', async () => {
+    const deleteProjectHostSetup = vi.fn().mockResolvedValue({
+      project: makeProject({ id: 'github:stablyai/orca' }),
+      setup: makeSetup({
+        id: 'shared-setup',
+        projectId: 'github:stablyai/orca',
+        repoId: '',
+        hostId: 'runtime:cpu',
+        path: ''
+      })
+    })
+    const localRepo = makeRepo({
+      id: 'local-repo',
+      displayName: 'Orca',
+      path: '/Users/alice/orca'
+    })
+    useAppStore.setState({
+      repos: [localRepo],
+      projects: [makeProject({ id: 'github:stablyai/orca' })],
+      projectHostSetups: [
+        makeSetup({
+          id: 'local-repo',
+          projectId: 'github:stablyai/orca',
+          repoId: 'local-repo',
+          hostId: 'local',
+          path: '/Users/alice/orca'
+        }),
+        makeSetup({
+          id: 'shared-setup',
+          projectId: 'github:stablyai/orca',
+          repoId: '',
+          hostId: 'runtime:gpu',
+          path: '',
+          setupState: 'setting-up',
+          setupMethod: 'provisioned'
+        }),
+        makeSetup({
+          id: 'shared-setup',
+          projectId: 'github:stablyai/orca',
+          repoId: '',
+          hostId: 'runtime:cpu',
+          path: '',
+          setupState: 'setting-up',
+          setupMethod: 'provisioned'
+        })
+      ],
+      deleteProjectHostSetup
+    })
+
+    renderSection(localRepo)
+
+    const removeButtons = Array.from(container.querySelectorAll('button')).filter(
+      (button) => button.textContent === 'Remove'
+    )
+    expect(removeButtons).toHaveLength(2)
+
+    await act(async () => {
+      removeButtons[1]?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(deleteProjectHostSetup).toHaveBeenCalledWith({
+      setupId: 'shared-setup',
+      hostId: 'runtime:cpu'
+    })
   })
 
   it('sets up the project on another known host from an existing folder path', async () => {

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react'
-import { getExecutionHostLabel } from '../../../../shared/execution-host'
+import { getExecutionHostLabel, getRepoExecutionHostId } from '../../../../shared/execution-host'
 import { buildExecutionHostRegistry } from '../../../../shared/execution-host-registry'
 import { getHostDisplayLabelOverrides } from '../../../../shared/host-setting-overrides'
-import type { Repo } from '../../../../shared/types'
+import type { ProjectHostSetup, Repo } from '../../../../shared/types'
 import { useAppStore } from '../../store'
 import { getProjectHostSetupProjectionFromState } from '../../store/selectors'
 import { cn } from '../../lib/utils'
@@ -22,6 +22,10 @@ type RepositoryHostSetupsSectionProps = {
   forceVisible: boolean
   searchQuery: string
   searchEntries: SettingsSearchEntry[]
+}
+
+function getProjectHostSetupKey(setup: Pick<ProjectHostSetup, 'hostId' | 'id'>): string {
+  return `${setup.hostId}\0${setup.id}`
 }
 
 export function RepositoryHostSetupsSection({
@@ -67,8 +71,9 @@ export function RepositoryHostSetupsSection({
   const projectHostSetupProjection = useAppStore((state) =>
     getProjectHostSetupProjectionFromState(state)
   )
+  const repoHostId = getRepoExecutionHostId(repo)
   const selectedProjectHostSetup = projectHostSetupProjection.setups.find(
-    (setup) => setup.repoId === repo.id
+    (setup) => setup.repoId === repo.id && setup.hostId === repoHostId
   )
   const projectHostSetups = selectedProjectHostSetup
     ? projectHostSetupProjection.setups.filter(
@@ -80,8 +85,11 @@ export function RepositoryHostSetupsSection({
     projectHostSetups,
     hostOptions
   })
+  const selectedProjectHostSetupKey = selectedProjectHostSetup
+    ? getProjectHostSetupKey(selectedProjectHostSetup)
+    : ''
   const hostOptionById = new Map(hostOptions.map((option) => [option.id, option]))
-  const [deletingSetupId, setDeletingSetupId] = useState<string | null>(null)
+  const [deletingSetupKey, setDeletingSetupKey] = useState<string | null>(null)
   const openSetup = (repoId: string) => {
     openSettingsPage()
     openSettingsTarget({ pane: 'repo', repoId })
@@ -116,26 +124,34 @@ export function RepositoryHostSetupsSection({
                 {translate('auto.components.settings.RepositoryPane.viewingHost', 'Viewing host')}
               </span>
               <Select
-                value={repo.id}
-                onValueChange={(repoId) => {
-                  if (repoId === repo.id) {
+                value={selectedProjectHostSetupKey}
+                onValueChange={(setupKey) => {
+                  if (setupKey === selectedProjectHostSetupKey) {
                     return
                   }
-                  openSetup(repoId)
+                  const nextSetup = openableProjectHostSetups.find(
+                    (setup) => getProjectHostSetupKey(setup) === setupKey
+                  )
+                  if (nextSetup) {
+                    openSetup(nextSetup.repoId)
+                  }
                 }}
               >
                 <SelectTrigger className="h-8 w-44 min-w-0 text-xs">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {openableProjectHostSetups.map((setup) => (
-                    <SelectItem key={setup.id} value={setup.repoId}>
-                      <span className="block min-w-0 truncate">
-                        {hostOptionById.get(setup.hostId)?.label ??
-                          getExecutionHostLabel(setup.hostId)}
-                      </span>
-                    </SelectItem>
-                  ))}
+                  {openableProjectHostSetups.map((setup) => {
+                    const setupKey = getProjectHostSetupKey(setup)
+                    return (
+                      <SelectItem key={setupKey} value={setupKey}>
+                        <span className="block min-w-0 truncate">
+                          {hostOptionById.get(setup.hostId)?.label ??
+                            getExecutionHostLabel(setup.hostId)}
+                        </span>
+                      </SelectItem>
+                    )
+                  })}
                 </SelectContent>
               </Select>
             </div>
@@ -150,12 +166,13 @@ export function RepositoryHostSetupsSection({
       </div>
       <div className="divide-y divide-border rounded-md border border-border">
         {projectHostSetups.map((setup) => {
-          const isCurrentSetup = setup.repoId === repo.id
+          const setupKey = getProjectHostSetupKey(setup)
+          const isCurrentSetup = setup.repoId === repo.id && setup.hostId === repoHostId
           const canOpenSetup = setup.repoId.trim().length > 0
-          const canRemoveSetup = !canOpenSetup && deletingSetupId !== setup.id
+          const canRemoveSetup = !canOpenSetup && deletingSetupKey !== setupKey
           return (
             <div
-              key={setup.id}
+              key={setupKey}
               className={cn(
                 'flex w-full items-start gap-3 px-3 py-2.5 text-left transition-colors',
                 isCurrentSetup ? 'bg-muted/30' : ''
@@ -201,9 +218,9 @@ export function RepositoryHostSetupsSection({
                   variant="outline"
                   size="sm"
                   onClick={async () => {
-                    setDeletingSetupId(setup.id)
-                    await deleteProjectHostSetup({ setupId: setup.id })
-                    setDeletingSetupId(null)
+                    setDeletingSetupKey(setupKey)
+                    await deleteProjectHostSetup({ setupId: setup.id, hostId: setup.hostId })
+                    setDeletingSetupKey(null)
                   }}
                 >
                   {translate('auto.components.settings.RepositoryPane.removeSetup', 'Remove')}

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -25,6 +25,7 @@ type RepositoryHostSetupsSectionProps = {
 }
 
 function getProjectHostSetupKey(setup: Pick<ProjectHostSetup, 'hostId' | 'id'>): string {
+  // Why: setup IDs can repeat across hosts after compatibility merges.
   return `${setup.hostId}\0${setup.id}`
 }
 
@@ -219,8 +220,11 @@ export function RepositoryHostSetupsSection({
                   size="sm"
                   onClick={async () => {
                     setDeletingSetupKey(setupKey)
-                    await deleteProjectHostSetup({ setupId: setup.id, hostId: setup.hostId })
-                    setDeletingSetupKey(null)
+                    try {
+                      await deleteProjectHostSetup({ setupId: setup.id, hostId: setup.hostId })
+                    } finally {
+                      setDeletingSetupKey(null)
+                    }
                   }}
                 >
                   {translate('auto.components.settings.RepositoryPane.removeSetup', 'Remove')}

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -91,9 +91,9 @@ export function RepositoryHostSetupsSection({
     : ''
   const hostOptionById = new Map(hostOptions.map((option) => [option.id, option]))
   const [deletingSetupKey, setDeletingSetupKey] = useState<string | null>(null)
-  const openSetup = (repoId: string) => {
+  const openSetup = (setup: Pick<ProjectHostSetup, 'repoId' | 'hostId'>) => {
     openSettingsPage()
-    openSettingsTarget({ pane: 'repo', repoId })
+    openSettingsTarget({ pane: 'repo', repoId: setup.repoId, repoHostId: setup.hostId })
   }
 
   if (
@@ -134,7 +134,7 @@ export function RepositoryHostSetupsSection({
                     (setup) => getProjectHostSetupKey(setup) === setupKey
                   )
                   if (nextSetup) {
-                    openSetup(nextSetup.repoId)
+                    openSetup(nextSetup)
                   }
                 }}
               >
@@ -207,7 +207,7 @@ export function RepositoryHostSetupsSection({
                   variant="outline"
                   size="sm"
                   onClick={() => {
-                    openSetup(setup.repoId)
+                    openSetup(setup)
                   }}
                 >
                   {translate('auto.components.settings.RepositoryPane.openSetup', 'Open')}

--- a/src/renderer/src/components/settings/Settings.load-performance.test.ts
+++ b/src/renderer/src/components/settings/Settings.load-performance.test.ts
@@ -4,6 +4,7 @@ import {
   deriveNeededSectionIds,
   getRuntimeTargetIdentity
 } from './settings-load-performance'
+import { getRepoSettingsSectionId } from '@/lib/repo-settings-section-id'
 
 describe('Settings load-performance helpers', () => {
   it('keeps only eager and active sections mounted for empty search on first paint', () => {
@@ -68,12 +69,23 @@ describe('Settings load-performance helpers', () => {
   })
 
   it('scopes repo hook checks to needed repo sections only', () => {
+    const targetRepo = { id: 'b' }
     const neededRepoIds = deriveNeededRepoIds(
-      [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
-      new Set(['general', 'repo-b'])
+      [{ id: 'a' }, targetRepo, { id: 'c' }],
+      new Set(['general', getRepoSettingsSectionId(targetRepo)])
     )
 
     expect(neededRepoIds).toEqual(['b'])
+  })
+
+  it('distinguishes same-id repo sections by host', () => {
+    const localRepo = { id: 'same-repo' }
+    const remoteRepo = { id: 'same-repo', connectionId: 'gpu-vm' }
+
+    expect(
+      deriveNeededRepoIds([localRepo, remoteRepo], new Set([getRepoSettingsSectionId(remoteRepo)]))
+    ).toEqual(['same-repo'])
+    expect(getRepoSettingsSectionId(localRepo)).not.toBe(getRepoSettingsSectionId(remoteRepo))
   })
 
   it('normalizes runtime target identity for cache invalidation keys', () => {

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -1600,6 +1600,7 @@ function Settings(): React.JSX.Element {
 
                 {repos.map((repo) => {
                   const repoSectionId = getRepoSettingsSectionId(repo)
+                  const repoHostId = getRepoExecutionHostId(repo)
                   const repoHooksState = repoHooksMap[repoSectionId]
                   const project = projectByRepoId.get(repo.id) ?? null
 
@@ -1622,12 +1623,15 @@ function Settings(): React.JSX.Element {
                           hasHooksFile={repoHooksState?.hasHooks ?? false}
                           hooksInspectionReady={Boolean(repoHooksState)}
                           mayNeedUpdate={repoHooksState?.mayNeedUpdate ?? false}
-                          updateRepo={updateRepo}
-                          removeProject={removeProject}
+                          updateRepo={(repoId, updates) =>
+                            updateRepo(repoId, updates, { ownerHostId: repoHostId })
+                          }
+                          removeProject={(repoId) =>
+                            removeProject(repoId, { ownerHostId: repoHostId })
+                          }
                           project={project}
                           isLocalWindowsProject={
-                            getRepoExecutionHostId(repo) === LOCAL_EXECUTION_HOST_ID &&
-                            isWindowsTerminalHost
+                            repoHostId === LOCAL_EXECUTION_HOST_ID && isWindowsTerminalHost
                           }
                           wslAvailable={windowsTerminalCapabilities.wslAvailable}
                           wslDistros={windowsTerminalCapabilities.wslDistros}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -812,6 +812,14 @@ function Settings(): React.JSX.Element {
     }
   }, [runtimeTargetIdentity])
 
+  const repoHookRuntimeSettings = useMemo(
+    () =>
+      ({
+        activeRuntimeEnvironmentId: settings?.activeRuntimeEnvironmentId ?? null
+      }) as typeof settings,
+    [settings?.activeRuntimeEnvironmentId]
+  )
+
   useEffect(() => {
     if (neededRepoSectionIds.length === 0) {
       return
@@ -840,7 +848,7 @@ function Settings(): React.JSX.Element {
         }
         try {
           const result = await checkRuntimeHooks(
-            getRepoOwnerRoutedSettings(settings, repo),
+            getRepoOwnerRoutedSettings(repoHookRuntimeSettings, repo),
             repo.id
           )
           if (stale || requestSeq !== repoHooksRequestSeqRef.current) {
@@ -876,7 +884,7 @@ function Settings(): React.JSX.Element {
     return () => {
       stale = true
     }
-  }, [neededRepoSectionIds, repoBySettingsSectionId, repos, settings])
+  }, [neededRepoSectionIds, repoBySettingsSectionId, repoHookRuntimeSettings, repos])
 
   useEffect(() => {
     const scrollTargetId = pendingScrollTargetRef.current

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -61,6 +61,7 @@ import {
   useWindowsTerminalCapabilities
 } from '@/lib/windows-terminal-capabilities'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { getRepoOwnerRoutedSettings } from '@/lib/repo-runtime-owner'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import {
@@ -83,11 +84,11 @@ import {
 } from '@/hooks/useInstalledAgentSkills'
 import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
 import {
-  deriveNeededRepoIds,
   deriveNeededSectionIds,
   getInitialMountedSectionIds,
   getRuntimeTargetIdentity
 } from './settings-load-performance'
+import { getRepoSettingsSectionId } from '@/lib/repo-settings-section-id'
 import { translate } from '@/i18n/i18n'
 import { getProjectHostSetupProjectionFromState } from '../../store/selectors'
 
@@ -562,10 +563,19 @@ function Settings(): React.JSX.Element {
       return
     }
 
-    const paneSectionId = getSettingsSectionId(
-      settingsNavigationTarget.pane as SettingsNavTarget,
-      settingsNavigationTarget.repoId
-    )
+    const pane = settingsNavigationTarget.pane as SettingsNavTarget
+    const targetRepo =
+      pane === 'repo' && settingsNavigationTarget.repoId
+        ? repos.find(
+            (repo) =>
+              repo.id === settingsNavigationTarget.repoId &&
+              (settingsNavigationTarget.repoHostId === undefined ||
+                getRepoExecutionHostId(repo) === settingsNavigationTarget.repoHostId)
+          )
+        : undefined
+    const paneSectionId = targetRepo
+      ? getRepoSettingsSectionId(targetRepo)
+      : getSettingsSectionId(pane, settingsNavigationTarget.repoId)
     pendingNavSectionRef.current = paneSectionId
     pendingScrollTargetRef.current = settingsNavigationTarget.sectionId ?? paneSectionId
     if (settingsNavigationTarget.intent === 'add-quick-command') {
@@ -581,7 +591,7 @@ function Settings(): React.JSX.Element {
     // scroll effect runs even when the visible section set is otherwise stable.
     setPendingNavRequestTick((tick) => tick + 1)
     clearSettingsTarget()
-  }, [clearSettingsTarget, settings, settingsNavigationTarget])
+  }, [clearSettingsTarget, repos, settings, settingsNavigationTarget])
 
   // Why: only recompute scrollback mode when the byte value actually changes,
   // not on every unrelated settings mutation.
@@ -699,6 +709,10 @@ function Settings(): React.JSX.Element {
     }
     return nextProjectByRepoId
   }, [projectHostSetups, projects, repos])
+  const repoBySettingsSectionId = useMemo(
+    () => new Map(repos.map((repo) => [getRepoSettingsSectionId(repo), repo] as const)),
+    [repos]
+  )
   const neededSectionIds = useMemo(
     () =>
       deriveNeededSectionIds({
@@ -774,16 +788,17 @@ function Settings(): React.JSX.Element {
     }
   }, [neededSectionIds])
 
-  const neededRepoIds = useMemo(
-    () => deriveNeededRepoIds(repos, neededSectionIds),
+  const neededRepoSectionIds = useMemo(
+    () =>
+      repos.map(getRepoSettingsSectionId).filter((sectionId) => neededSectionIds.has(sectionId)),
     [neededSectionIds, repos]
   )
 
   useEffect(() => {
-    const repoIdSet = new Set(repos.map((repo) => repo.id))
+    const repoSectionIdSet = new Set(repos.map(getRepoSettingsSectionId))
     setRepoHooksMap((previous) => {
       const next = Object.fromEntries(
-        Object.entries(previous).filter(([repoId]) => repoIdSet.has(repoId))
+        Object.entries(previous).filter(([repoSectionId]) => repoSectionIdSet.has(repoSectionId))
       ) as Record<string, { hasHooks: boolean; hooks: OrcaHooks | null; mayNeedUpdate: boolean }>
       return Object.keys(next).length === Object.keys(previous).length ? previous : next
     })
@@ -798,47 +813,44 @@ function Settings(): React.JSX.Element {
   }, [runtimeTargetIdentity])
 
   useEffect(() => {
-    if (neededRepoIds.length === 0) {
+    if (neededRepoSectionIds.length === 0) {
       return
     }
 
     let stale = false
     const requestSeq = ++repoHooksRequestSeqRef.current
-    const repoById = new Map(repos.map((repo) => [repo.id, repo] as const))
 
     void Promise.all(
-      neededRepoIds.map(async (repoId) => {
-        const repo = repoById.get(repoId)
+      neededRepoSectionIds.map(async (repoSectionId) => {
+        const repo = repoBySettingsSectionId.get(repoSectionId)
         if (!repo) {
           return
         }
         if (isFolderRepo(repo)) {
           setRepoHooksMap((previous) => {
-            if (previous[repoId]) {
+            if (previous[repoSectionId]) {
               return previous
             }
             return {
               ...previous,
-              [repoId]: { hasHooks: false, hooks: null, mayNeedUpdate: false }
+              [repoSectionId]: { hasHooks: false, hooks: null, mayNeedUpdate: false }
             }
           })
           return
         }
         try {
           const result = await checkRuntimeHooks(
-            runtimeTargetIdentity === 'local'
-              ? { activeRuntimeEnvironmentId: null }
-              : { activeRuntimeEnvironmentId: runtimeTargetIdentity },
-            repoId
+            getRepoOwnerRoutedSettings(settings, repo),
+            repo.id
           )
           if (stale || requestSeq !== repoHooksRequestSeqRef.current) {
             return
           }
           setRepoHooksMap((previous) => {
-            if (!repos.some((entry) => entry.id === repoId)) {
+            if (!repos.some((entry) => getRepoSettingsSectionId(entry) === repoSectionId)) {
               return previous
             }
-            return { ...previous, [repoId]: result }
+            return { ...previous, [repoSectionId]: result }
           })
         } catch {
           // Keep last known value on transient failures.
@@ -846,15 +858,15 @@ function Settings(): React.JSX.Element {
             return
           }
           setRepoHooksMap((previous) => {
-            if (!repos.some((entry) => entry.id === repoId)) {
+            if (!repos.some((entry) => getRepoSettingsSectionId(entry) === repoSectionId)) {
               return previous
             }
-            if (previous[repoId]) {
+            if (previous[repoSectionId]) {
               return previous
             }
             return {
               ...previous,
-              [repoId]: { hasHooks: false, hooks: null, mayNeedUpdate: false }
+              [repoSectionId]: { hasHooks: false, hooks: null, mayNeedUpdate: false }
             }
           })
         }
@@ -864,7 +876,7 @@ function Settings(): React.JSX.Element {
     return () => {
       stale = true
     }
-  }, [neededRepoIds, repos, runtimeTargetIdentity])
+  }, [neededRepoSectionIds, repoBySettingsSectionId, repos, settings])
 
   useEffect(() => {
     const scrollTargetId = pendingScrollTargetRef.current
@@ -1010,7 +1022,7 @@ function Settings(): React.JSX.Element {
   const repoNavSections = visibleNavSections
     .filter((section) => section.id.startsWith('repo-'))
     .map((section) => {
-      const repo = repos.find((entry) => entry.id === section.id.replace('repo-', ''))
+      const repo = repoBySettingsSectionId.get(section.id)
       return {
         ...section,
         badgeColor: repo?.badgeColor,
@@ -1587,13 +1599,13 @@ function Settings(): React.JSX.Element {
                 </SettingsSection>
 
                 {repos.map((repo) => {
-                  const repoSectionId = `repo-${repo.id}`
-                  const repoHooksState = repoHooksMap[repo.id]
+                  const repoSectionId = getRepoSettingsSectionId(repo)
+                  const repoHooksState = repoHooksMap[repoSectionId]
                   const project = projectByRepoId.get(repo.id) ?? null
 
                   return (
                     <SettingsSection
-                      key={repo.id}
+                      key={repoSectionId}
                       id={repoSectionId}
                       title={translate(
                         'auto.components.settings.Settings.3bf149e873',

--- a/src/renderer/src/components/settings/settings-load-performance.ts
+++ b/src/renderer/src/components/settings/settings-load-performance.ts
@@ -1,4 +1,6 @@
 import type { GlobalSettings } from '../../../../shared/types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { getRepoSettingsSectionId } from '@/lib/repo-settings-section-id'
 
 const EAGER_SECTION_IDS = new Set(['general'])
 
@@ -38,10 +40,16 @@ export function deriveNeededSectionIds(args: {
 }
 
 export function deriveNeededRepoIds(
-  repos: readonly { id: string }[],
+  repos: readonly {
+    id: string
+    connectionId?: string | null
+    executionHostId?: ExecutionHostId | null
+  }[],
   neededSectionIds: Set<string>
 ): string[] {
-  return repos.map((repo) => repo.id).filter((repoId) => neededSectionIds.has(`repo-${repoId}`))
+  return repos
+    .filter((repo) => neededSectionIds.has(getRepoSettingsSectionId(repo)))
+    .map((repo) => repo.id)
 }
 
 export function getInitialMountedSectionIds(): Set<string> {

--- a/src/renderer/src/components/terminal-pane/useSessionRestoredBannerDismiss.test.tsx
+++ b/src/renderer/src/components/terminal-pane/useSessionRestoredBannerDismiss.test.tsx
@@ -24,7 +24,7 @@ async function renderProbe(visible: boolean, dismiss = vi.fn()): Promise<HTMLDiv
     root.render(<Probe visible={visible} dismiss={dismiss} />)
   })
 
-  return container.querySelector('[data-testid="pane"]')!
+  return container.querySelector<HTMLDivElement>('[data-testid="pane"]')!
 }
 
 describe('useSessionRestoredBannerDismiss', () => {

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -598,7 +598,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       }),
     [eligibleRepos, projectHostSetups, projects, repoId, workspaceHostScope]
   )
-  const selectedRepo = eligibleRepos.find((repo) => repo.id === repoId)
+  const selectedRepo =
+    selectedWorkspaceTarget.status === 'ready'
+      ? selectedWorkspaceTarget.target.repo
+      : eligibleRepos.find((repo) => repo.id === repoId)
   const selectedRepoAgentLaunchPlatform = useMemo(() => {
     if (!selectedRepo) {
       return CLIENT_PLATFORM
@@ -3113,7 +3116,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         undefined,
         undefined,
         undefined,
-        submitCompareBaseRef
+        submitCompareBaseRef,
+        selectedWorkspaceTarget.status === 'ready'
+          ? { ownerHostId: selectedWorkspaceTarget.target.hostId }
+          : undefined
       )
       const worktree = result.worktree
 
@@ -3220,6 +3226,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     selectedRepoAgentLaunchPlatform,
     selectedRepoIsGit,
     selectedRepoRequiresConnection,
+    selectedWorkspaceTarget,
     showProjectRequiredError,
     settings?.agentCmdOverrides,
     settings?.agentDefaultArgs,

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -499,7 +499,10 @@ describe('useIpcEvents browser tab create routing', () => {
       activeModal: null,
       closeModal: vi.fn(),
       openModal: vi.fn(),
+      activeRepoId: null,
+      activeWorkspaceKey: null,
       activeWorktreeId: 'wt-1',
+      activeTabId: null,
       activeView: 'terminal',
       setActiveRepo: vi.fn(),
       setActiveWorktree: vi.fn(),
@@ -993,7 +996,7 @@ describe('useIpcEvents updater integration', () => {
       clearTabPtyId,
       repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
       worktreesByRepo: {
-        'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1', hostId: 'ssh:conn-1' }]
       },
       tabsByWorktree: {
         'wt-1': [
@@ -3355,7 +3358,10 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           fetchProjectGroups: vi.fn(),
           fetchWorktrees,
           fetchWorktreeLineage,
-          repos: [{ id: 'repo-1' }],
+          repos: [
+            { id: 'repo-1', executionHostId: 'local' },
+            { id: 'repo-1', executionHostId: 'runtime:env-1' }
+          ],
           detectedWorktreesByRepo: {
             'repo-1': {
               repoId: 'repo-1',
@@ -3541,7 +3547,7 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1')
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', { ownerHostId: 'runtime:env-1' })
     expect(fetchWorktreeLineage).toHaveBeenCalledTimes(1)
   })
 })
@@ -3628,13 +3634,32 @@ describe('useIpcEvents agent status snapshot integration', () => {
       clearTabPtyId: vi.fn(),
       updateTabTitle: vi.fn(),
       runtimePaneTitlesByTabId: {},
+      ptyIdsByTabId: {},
       terminalLayoutsByTabId: {},
+      activeTabIdByWorktree: {},
       agentStatusByPaneKey: {},
       recentlyClosedAgentStatusTabIds: {},
       repos: [],
       worktreesByRepo: {},
       tabsByWorktree: {},
       unifiedTabsByWorktree: {},
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      openFiles: [],
+      editorDrafts: {},
+      markdownFrontmatterVisible: {},
+      activeFileIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      browserTabsByWorktree: {},
+      browserPagesByWorkspace: {},
+      activeBrowserTabId: null,
+      activeBrowserTabIdByWorktree: {},
+      browserUrlHistory: [],
+      sshConnectionStates: new Map(),
+      lastKnownRelayPtyIdByTabId: {},
+      lastVisitedAtByWorktreeId: {},
+      defaultTerminalTabsAppliedByWorktreeId: {},
       workspaceSessionReady: false,
       settings: { terminalFontSize: 13 },
       ...overrides
@@ -5293,6 +5318,121 @@ describe('useIpcEvents agent status snapshot integration', () => {
     expect(hydrateTabsSession).not.toHaveBeenCalled()
     expect(hydrateEditorSession).not.toHaveBeenCalled()
     expect(hydrateBrowserSession).not.toHaveBeenCalled()
+  })
+
+  it('applies SSH remote workspace snapshots only to the matching host worktrees', async () => {
+    const hydrateWorkspaceSession = vi.fn()
+    const hydrateTabsSession = vi.fn()
+    const hydrateEditorSession = vi.fn()
+    const hydrateBrowserSession = vi.fn()
+    const onChangedListenerRef: {
+      current:
+        | ((event: {
+            targetId: string
+            sourceClientId?: string
+            snapshot: Record<string, unknown>
+          }) => void)
+        | null
+    } = { current: null }
+    const storeState: StoreLike = buildStoreState({
+      workspaceSessionReady: true,
+      repos: [
+        { id: 'same-repo', executionHostId: 'local' },
+        { id: 'same-repo', connectionId: 'conn-1', executionHostId: 'ssh:conn-1' }
+      ],
+      worktreesByRepo: {
+        'same-repo': [
+          { id: 'same-repo::/local', repoId: 'same-repo', hostId: 'local' },
+          { id: 'same-repo::/remote', repoId: 'same-repo', hostId: 'ssh:conn-1' }
+        ]
+      },
+      tabsByWorktree: {
+        'same-repo::/local': [
+          { id: 'local-tab', ptyId: 'local-pty', worktreeId: 'same-repo::/local', title: 'Local' }
+        ],
+        'same-repo::/remote': [
+          { id: 'old-remote-tab', ptyId: null, worktreeId: 'same-repo::/remote', title: 'Old' }
+        ]
+      },
+      fetchWorktrees: vi.fn(() => Promise.resolve(true)),
+      fetchWorktreeLineage: vi.fn(() => Promise.resolve()),
+      hydrateWorkspaceSession,
+      hydrateTabsSession,
+      hydrateEditorSession,
+      hydrateBrowserSession,
+      markRemoteWorkspaceHydrated: vi.fn(),
+      setRemoteWorkspaceSyncStatus: vi.fn(),
+      reconnectPersistedTerminals: vi.fn(() => Promise.resolve())
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: () => () => {},
+        remoteWorkspace: {
+          clientId: () => Promise.resolve('client-local'),
+          onChanged: (cb: typeof onChangedListenerRef.current) => {
+            onChangedListenerRef.current = cb
+            return () => {}
+          }
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    onChangedListenerRef.current?.({
+      targetId: 'conn-1',
+      sourceClientId: 'client-remote',
+      snapshot: {
+        revision: 2,
+        updatedAt: Date.now(),
+        session: {
+          activeWorktreePath: '/remote',
+          activeTabId: 'remote-tab',
+          tabsByWorktreePath: {
+            '/remote': [
+              {
+                id: 'remote-tab',
+                ptyId: null,
+                worktreePath: '/remote',
+                title: 'Remote',
+                customTitle: null,
+                color: null,
+                sortOrder: 1,
+                createdAt: 1
+              }
+            ]
+          },
+          terminalLayoutsByTabId: {}
+        }
+      }
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(storeState.fetchWorktrees).toHaveBeenCalledWith('same-repo', {
+      ownerHostId: 'ssh:conn-1'
+    })
+    const hydrated = hydrateTabsSession.mock.calls[0]?.[0] as {
+      tabsByWorktree: Record<string, { id: string }[]>
+    }
+    expect(hydrated.tabsByWorktree['same-repo::/local']).toEqual([
+      expect.objectContaining({ id: 'local-tab' })
+    ])
+    expect(hydrated.tabsByWorktree['same-repo::/remote']).toEqual([
+      expect.objectContaining({ id: 'remote-tab' })
+    ])
   })
 
   it('silently discards snapshot entries whose tabs are still unknown', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -3331,8 +3331,65 @@ describe('useIpcEvents CLI-created worktree activation', () => {
   })
 
   it('refreshes active runtime worktrees from remote client events', async () => {
-    const fetchWorktrees = vi.fn()
-    const fetchWorktreeLineage = vi.fn()
+    const purgeWorktreeTerminalState = vi.fn()
+    const removeWorkspaceSpaceWorktrees = vi.fn()
+    const storeState = {
+      fetchRepos: vi.fn(),
+      fetchRuntimeEnvironmentRepos: vi.fn(),
+      fetchProjectGroups: vi.fn(),
+      fetchWorktrees: vi.fn().mockImplementation(async () => {
+        storeState.detectedWorktreesByRepo = {
+          'repo-1': {
+            repoId: 'repo-1',
+            authoritative: true,
+            source: 'git',
+            worktrees: [{ id: 'runtime-wt', hostId: 'runtime:env-1' }]
+          }
+        }
+      }),
+      fetchWorktreeLineage: vi.fn(),
+      repos: [
+        { id: 'repo-1', executionHostId: 'local' },
+        { id: 'repo-1', executionHostId: 'runtime:env-1' }
+      ],
+      detectedWorktreesByRepo: {},
+      worktreesByRepo: {
+        'repo-1': [
+          { id: 'local-wt', repoId: 'repo-1', path: '/local', hostId: 'local' },
+          { id: 'runtime-wt', repoId: 'repo-1', path: '/runtime', hostId: 'runtime:env-1' }
+        ]
+      },
+      purgeWorktreeTerminalState,
+      removeWorkspaceSpaceWorktrees,
+      setUpdateStatus: vi.fn(),
+      activeModal: null,
+      closeModal: vi.fn(),
+      openModal: vi.fn(),
+      getKnownWorktreeById: vi.fn(),
+      activeWorktreeId: 'runtime-wt',
+      activeView: 'terminal',
+      setActiveView: vi.fn(),
+      setActiveRepo: vi.fn(),
+      setActiveWorktree: vi.fn(),
+      revealWorktreeInSidebar: vi.fn(),
+      setIsFullScreen: vi.fn(),
+      updateBrowserPageState: vi.fn(),
+      activeTabType: 'terminal',
+      editorFontZoomLevel: 0,
+      setEditorFontZoomLevel: vi.fn(),
+      setRateLimitsFromPush: vi.fn(),
+      setSshConnectionState: vi.fn(),
+      setSshTargetLabels: vi.fn(),
+      setPortForwards: vi.fn(),
+      clearPortForwards: vi.fn(),
+      setDetectedPorts: vi.fn(),
+      enqueueSshCredentialRequest: vi.fn(),
+      removeSshCredentialRequest: vi.fn(),
+      clearTabPtyId: vi.fn(),
+      settings: { activeRuntimeEnvironmentId: 'env-1', terminalFontSize: 13 }
+    }
+    const fetchWorktrees = storeState.fetchWorktrees
+    const fetchWorktreeLineage = storeState.fetchWorktreeLineage
     let runtimeOnResponse: ((response: unknown) => void) | undefined
     const runtimeSubscribe = vi.fn(async (_args, callbacks) => {
       runtimeOnResponse = (callbacks as { onResponse: (response: unknown) => void }).onResponse
@@ -3352,54 +3409,7 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     vi.doMock('../store', () => ({
       useAppStore: {
         subscribe: vi.fn(() => () => {}),
-        getState: () => ({
-          fetchRepos: vi.fn(),
-          fetchRuntimeEnvironmentRepos: vi.fn(),
-          fetchProjectGroups: vi.fn(),
-          fetchWorktrees,
-          fetchWorktreeLineage,
-          repos: [
-            { id: 'repo-1', executionHostId: 'local' },
-            { id: 'repo-1', executionHostId: 'runtime:env-1' }
-          ],
-          detectedWorktreesByRepo: {
-            'repo-1': {
-              repoId: 'repo-1',
-              authoritative: true,
-              source: 'git',
-              worktrees: [{ id: 'wt-old' }]
-            }
-          },
-          worktreesByRepo: {},
-          purgeWorktreeTerminalState: vi.fn(),
-          removeWorkspaceSpaceWorktrees: vi.fn(),
-          setUpdateStatus: vi.fn(),
-          activeModal: null,
-          closeModal: vi.fn(),
-          openModal: vi.fn(),
-          getKnownWorktreeById: vi.fn(),
-          activeWorktreeId: 'wt-old',
-          activeView: 'terminal',
-          setActiveView: vi.fn(),
-          setActiveRepo: vi.fn(),
-          setActiveWorktree: vi.fn(),
-          revealWorktreeInSidebar: vi.fn(),
-          setIsFullScreen: vi.fn(),
-          updateBrowserPageState: vi.fn(),
-          activeTabType: 'terminal',
-          editorFontZoomLevel: 0,
-          setEditorFontZoomLevel: vi.fn(),
-          setRateLimitsFromPush: vi.fn(),
-          setSshConnectionState: vi.fn(),
-          setSshTargetLabels: vi.fn(),
-          setPortForwards: vi.fn(),
-          clearPortForwards: vi.fn(),
-          setDetectedPorts: vi.fn(),
-          enqueueSshCredentialRequest: vi.fn(),
-          removeSshCredentialRequest: vi.fn(),
-          clearTabPtyId: vi.fn(),
-          settings: { activeRuntimeEnvironmentId: 'env-1', terminalFontSize: 13 }
-        })
+        getState: () => storeState
       }
     }))
 
@@ -3549,6 +3559,8 @@ describe('useIpcEvents CLI-created worktree activation', () => {
 
     expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', { ownerHostId: 'runtime:env-1' })
     expect(fetchWorktreeLineage).toHaveBeenCalledTimes(1)
+    expect(purgeWorktreeTerminalState).not.toHaveBeenCalledWith(['local-wt'])
+    expect(removeWorkspaceSpaceWorktrees).not.toHaveBeenCalledWith(['local-wt'])
   })
 })
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -248,16 +248,38 @@ function isAgentStatusForRecentlyClosedTab(
   return store.recentlyClosedAgentStatusTabIds[tabId] === true
 }
 
-function getAuthoritativeDetectedWorktreeIds(state: AppState, repoId: string): Set<string> | null {
+function getAuthoritativeDetectedWorktreeIds(
+  state: AppState,
+  repoId: string,
+  ownerHostId?: ExecutionHostId
+): Set<string> | null {
   const detected = state.detectedWorktreesByRepo[repoId]
   if (detected?.authoritative !== true) {
     return null
   }
-  return new Set(detected.worktrees.map((worktree) => worktree.id))
+  return new Set(
+    detected.worktrees
+      .filter(
+        (worktree) =>
+          ownerHostId === undefined || (worktree.hostId ?? LOCAL_EXECUTION_HOST_ID) === ownerHostId
+      )
+      .map((worktree) => worktree.id)
+  )
 }
 
-function getVisibleWorktreeIdsForRepo(state: AppState, repoId: string): Set<string> {
-  return new Set((state.worktreesByRepo[repoId] ?? []).map((worktree) => worktree.id))
+function getVisibleWorktreeIdsForRepo(
+  state: AppState,
+  repoId: string,
+  ownerHostId?: ExecutionHostId
+): Set<string> {
+  return new Set(
+    (state.worktreesByRepo[repoId] ?? [])
+      .filter(
+        (worktree) =>
+          ownerHostId === undefined || (worktree.hostId ?? LOCAL_EXECUTION_HOST_ID) === ownerHostId
+      )
+      .map((worktree) => worktree.id)
+  )
 }
 
 function resolveActiveBrowserPageId(state: AppState): string | null {
@@ -870,8 +892,8 @@ export function useIpcEvents(): void {
       // misclassifying the zombie as bound (design §2c, §4.4).
       const state = useAppStore.getState()
       const before =
-        getAuthoritativeDetectedWorktreeIds(state, repoId) ??
-        getVisibleWorktreeIdsForRepo(state, repoId)
+        getAuthoritativeDetectedWorktreeIds(state, repoId, ownerHostId) ??
+        getVisibleWorktreeIdsForRepo(state, repoId, ownerHostId)
       await state.fetchWorktrees(repoId, { ownerHostId })
       await useAppStore.getState().fetchWorktreeLineage()
       // Why: changing the worktree's id unmounts the active pane without
@@ -882,7 +904,7 @@ export function useIpcEvents(): void {
         useAppStore.getState().setActiveWorktree(renamed.newWorktreeId)
       }
       const afterState = useAppStore.getState()
-      const after = getAuthoritativeDetectedWorktreeIds(afterState, repoId)
+      const after = getAuthoritativeDetectedWorktreeIds(afterState, repoId, ownerHostId)
       if (!after) {
         return
       }

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -816,6 +816,7 @@ export function useIpcEvents(): void {
 
     const handleWorktreesChanged = async (
       repoId: string,
+      ownerHostId?: ExecutionHostId,
       renamed?: { oldWorktreeId: string; newWorktreeId: string }
     ): Promise<void> => {
       // Why: a folder rename changes the worktree's path-derived id. Re-key every
@@ -842,7 +843,7 @@ export function useIpcEvents(): void {
       const before =
         getAuthoritativeDetectedWorktreeIds(state, repoId) ??
         getVisibleWorktreeIdsForRepo(state, repoId)
-      await state.fetchWorktrees(repoId)
+      await state.fetchWorktrees(repoId, { ownerHostId })
       await useAppStore.getState().fetchWorktreeLineage()
       // Why: changing the worktree's id unmounts the active pane without
       // re-rendering it under the new id. Now that the list has refreshed,

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -118,6 +118,12 @@ import { titleHasAgentName } from '../../../shared/agent-detection'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { translate } from '@/i18n/i18n'
 import { closeTerminalTab } from '@/components/terminal/terminal-tab-actions'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  toRuntimeExecutionHostId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
 
 function getShortcutPlatform(): NodeJS.Platform {
   if (navigator.userAgent.includes('Mac')) {
@@ -409,26 +415,33 @@ async function prepareRemoteWorkspaceTarget(targetId: string): Promise<boolean> 
     await store.fetchRepos()
     repos = useAppStore.getState().repos.filter((repo) => repo.connectionId === targetId)
   }
-  await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
+  await Promise.all(
+    repos.map((repo) =>
+      useAppStore.getState().fetchWorktrees(repo.id, { ownerHostId: getRepoExecutionHostId(repo) })
+    )
+  )
   await useAppStore.getState().fetchWorktreeLineage()
   return true
 }
 
-function targetRepoIds(targetId: string): Set<string> {
-  return new Set(
-    useAppStore
-      .getState()
-      .repos.filter((repo) => repo.connectionId === targetId)
-      .map((repo) => repo.id)
-  )
-}
-
 function targetWorktreeIds(targetId: string): Set<string> {
-  const repoIds = targetRepoIds(targetId)
+  const repoHosts = useAppStore
+    .getState()
+    .repos.filter((repo) => repo.connectionId === targetId)
+    .map((repo) => ({
+      repoId: repo.id,
+      hostId: getRepoExecutionHostId(repo)
+    }))
   return new Set(
     Object.values(useAppStore.getState().worktreesByRepo)
       .flat()
-      .filter((worktree) => repoIds.has(worktree.repoId))
+      .filter((worktree) =>
+        repoHosts.some(
+          (repo) =>
+            repo.repoId === worktree.repoId &&
+            repo.hostId === (worktree.hostId ?? LOCAL_EXECUTION_HOST_ID)
+        )
+      )
       .map((worktree) => worktree.id)
   )
 }
@@ -954,7 +967,10 @@ export function useIpcEvents(): void {
       }
       if (event.type === 'worktreesChanged') {
         void ensureRuntimeEventRepoKnown(environmentId, event.repoId).then(() =>
-          worktreeChangeRefreshQueue.enqueue({ repoId: event.repoId })
+          worktreeChangeRefreshQueue.enqueue({
+            repoId: event.repoId,
+            ownerHostId: toRuntimeExecutionHostId(environmentId)
+          })
         )
         return
       }
@@ -2534,7 +2550,11 @@ export function useIpcEvents(): void {
       }
 
       if (state.status === 'connected') {
-        void Promise.all(remoteRepos.map((r) => store.fetchWorktrees(r.id))).then(async () => {
+        void Promise.all(
+          remoteRepos.map((repo) =>
+            store.fetchWorktrees(repo.id, { ownerHostId: getRepoExecutionHostId(repo) })
+          )
+        ).then(async () => {
           await useAppStore.getState().fetchWorktreeLineage()
           // Why: terminal panes that failed to spawn (no PTY provider on cold
           // start) sit inert. Bumping generation forces TerminalPane to remount

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -21,6 +21,7 @@ import { nextEditorFontZoomLevel, computeEditorFontSize } from '@/lib/editor-fon
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
+  Repo,
   UpdateStatus,
   WorkspaceSessionState
 } from '../../../shared/types'
@@ -779,7 +780,19 @@ export function getRuntimeProjectRefreshEnvironmentIds(args: {
   ]
 }
 
-async function refreshRuntimeProjectWorktrees(repos: readonly { id: string }[]): Promise<void> {
+type RepoHostIdentity = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+
+function worktreeBelongsToRepoHost(
+  worktree: { repoId: string; hostId?: ExecutionHostId },
+  repo: RepoHostIdentity
+): boolean {
+  return (
+    worktree.repoId === repo.id &&
+    (worktree.hostId ?? LOCAL_EXECUTION_HOST_ID) === getRepoExecutionHostId(repo)
+  )
+}
+
+async function refreshRuntimeProjectWorktrees(repos: readonly RepoHostIdentity[]): Promise<void> {
   let nextIndex = 0
   const failures: { repoId: string; error: unknown }[] = []
   const workerCount = Math.min(RUNTIME_PROJECT_REFRESH_CONCURRENCY, repos.length)
@@ -791,9 +804,12 @@ async function refreshRuntimeProjectWorktrees(repos: readonly { id: string }[]):
       while (nextIndex < repos.length) {
         const index = nextIndex
         nextIndex += 1
-        const repoId = repos[index].id
+        const repo = repos[index]
+        const repoId = repo.id
         try {
-          await useAppStore.getState().fetchWorktrees(repoId)
+          await useAppStore.getState().fetchWorktrees(repoId, {
+            ownerHostId: getRepoExecutionHostId(repo)
+          })
         } catch (error) {
           failures.push({ repoId, error })
         }
@@ -2536,7 +2552,9 @@ export function useIpcEvents(): void {
         const remoteWorktreeIds = new Set(
           Object.values(store.worktreesByRepo)
             .flat()
-            .filter((w) => remoteRepos.some((r) => r.id === w.repoId))
+            .filter((worktree) =>
+              remoteRepos.some((repo) => worktreeBelongsToRepoHost(worktree, repo))
+            )
             .map((w) => w.id)
         )
         for (const worktreeId of remoteWorktreeIds) {
@@ -2560,10 +2578,11 @@ export function useIpcEvents(): void {
           // start) sit inert. Bumping generation forces TerminalPane to remount
           // and retry pty:spawn. Only bump tabs with no live ptyId.
           const freshStore = useAppStore.getState()
-          const remoteRepoIds = new Set(remoteRepos.map((r) => r.id))
           const worktreeIds = Object.values(freshStore.worktreesByRepo)
             .flat()
-            .filter((w) => remoteRepoIds.has(w.repoId))
+            .filter((worktree) =>
+              remoteRepos.some((repo) => worktreeBelongsToRepoHost(worktree, repo))
+            )
             .map((w) => w.id)
 
           for (const worktreeId of worktreeIds) {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -4,6 +4,10 @@ import { dirname, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { buildSettingsNavigationMetadata } from './useSettingsNavigationMetadata'
 import type { Repo } from '../../../shared/types'
+import {
+  getRepoSettingsSectionId,
+  parseRepoSettingsSectionId
+} from '@/lib/repo-settings-section-id'
 
 const repo = {
   id: 'repo-1',
@@ -59,7 +63,7 @@ describe('settings navigation metadata', () => {
     expect(webIds).not.toContain('voice')
     expect(webIds).not.toContain('advanced')
     expect(webIds).toContain('servers')
-    expect(webIds).toContain('repo-repo-1')
+    expect(webIds).toContain(getRepoSettingsSectionId(repo))
   })
 
   it('does not mark installable AI capabilities as beta in the sidebar metadata', () => {
@@ -84,7 +88,7 @@ describe('settings navigation metadata', () => {
     })
 
     const general = sections.find((section) => section.id === 'general')
-    const repoSection = sections.find((section) => section.id === 'repo-repo-1')
+    const repoSection = sections.find((section) => section.id === getRepoSettingsSectionId(repo))
 
     expect(general?.searchEntries.some((entry) => entry.title === 'Default Project Runtime')).toBe(
       false
@@ -103,12 +107,52 @@ describe('settings navigation metadata', () => {
     })
 
     const general = sections.find((section) => section.id === 'general')
-    const repoSection = sections.find((section) => section.id === 'repo-repo-1')
+    const repoSection = sections.find((section) => section.id === getRepoSettingsSectionId(repo))
 
     expect(general?.searchEntries.some((entry) => entry.title === 'Default Project Runtime')).toBe(
       true
     )
     expect(repoSection?.searchEntries.some((entry) => entry.title === 'Project Runtime')).toBe(true)
+  })
+
+  it('distinguishes same-id project settings sections by execution host', () => {
+    const remoteRepo = { ...repo, connectionId: 'openclaw 2' } satisfies Repo
+    const sections = buildSettingsNavigationMetadata({
+      isMac: false,
+      isWindows: false,
+      isWebClient: false,
+      repos: [repo, remoteRepo]
+    })
+
+    expect(sections.map((section) => section.id)).toEqual(
+      expect.arrayContaining([getRepoSettingsSectionId(repo), getRepoSettingsSectionId(remoteRepo)])
+    )
+    expect(getRepoSettingsSectionId(repo)).not.toBe(getRepoSettingsSectionId(remoteRepo))
+  })
+
+  it('does not collide when encoded host and repo ids contain delimiter-like dashes', () => {
+    const left = {
+      ...repo,
+      id: 'bar-baz',
+      connectionId: 'foo'
+    } satisfies Repo
+    const right = {
+      ...repo,
+      id: 'baz',
+      connectionId: 'foo-bar'
+    } satisfies Repo
+
+    expect(getRepoSettingsSectionId(left)).not.toBe(getRepoSettingsSectionId(right))
+  })
+
+  it('parses repo settings section ids for Cmd+J settings navigation', () => {
+    const remoteRepo = { ...repo, connectionId: 'openclaw 2' } satisfies Repo
+
+    expect(parseRepoSettingsSectionId(getRepoSettingsSectionId(remoteRepo))).toEqual({
+      repoId: remoteRepo.id,
+      repoHostId: 'ssh:openclaw%202'
+    })
+    expect(parseRepoSettingsSectionId('repo-repo-1')).toBeNull()
   })
 
   it('keeps Windows client-only terminal settings out of Windows-host metadata', () => {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -153,6 +153,7 @@ describe('settings navigation metadata', () => {
       repoHostId: 'ssh:openclaw%202'
     })
     expect(parseRepoSettingsSectionId('repo-repo-1')).toBeNull()
+    expect(parseRepoSettingsSectionId('repo-local:%ZZ')).toBeNull()
   })
 
   it('keeps Windows client-only terminal settings out of Windows-host metadata', () => {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -71,6 +71,7 @@ import { getStatsPaneSearchEntries } from '@/components/stats/stats-search'
 import { getExperimentalPaneSearchEntries } from '@/components/settings/experimental-search'
 import { getRepositoryPaneSearchEntries } from '@/components/settings/repository-search'
 import { isWebClientLocation } from '@/lib/web-client-location'
+import { getRepoSettingsSectionId } from '@/lib/repo-settings-section-id'
 import {
   getCachedWindowsTerminalCapabilities,
   getWindowsTerminalCapabilityOwnerKey
@@ -485,7 +486,7 @@ export function buildSettingsNavigationMetadata({
       group: 'experimental'
     },
     ...repos.map((repo) => ({
-      id: `repo-${repo.id}`,
+      id: getRepoSettingsSectionId(repo),
       title: repo.displayName,
       description: `${getRepoKindLabel(repo)} • ${repo.path}`,
       icon: SlidersHorizontal,

--- a/src/renderer/src/hooks/worktree-change-refresh-queue.test.ts
+++ b/src/renderer/src/hooks/worktree-change-refresh-queue.test.ts
@@ -28,13 +28,13 @@ describe('createWorktreeChangeRefreshQueue', () => {
     queue.enqueue({ repoId: 'repo-1' })
 
     expect(handler).toHaveBeenCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith('repo-1', undefined)
+    expect(handler).toHaveBeenCalledWith('repo-1', undefined, undefined)
 
     firstRefresh.resolve()
     await flushPromises()
 
     expect(handler).toHaveBeenCalledTimes(2)
-    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined)
+    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined, undefined)
   })
 
   it('does not overlap refreshes for the same repo', async () => {
@@ -73,8 +73,8 @@ describe('createWorktreeChangeRefreshQueue', () => {
     queue.enqueue({ repoId: 'repo-2' })
 
     expect(handler).toHaveBeenCalledTimes(2)
-    expect(handler).toHaveBeenNthCalledWith(1, 'repo-1', undefined)
-    expect(handler).toHaveBeenNthCalledWith(2, 'repo-2', undefined)
+    expect(handler).toHaveBeenNthCalledWith(1, 'repo-1', undefined, undefined)
+    expect(handler).toHaveBeenNthCalledWith(2, 'repo-2', undefined, undefined)
 
     repoOneRefresh.resolve()
     await flushPromises()
@@ -100,8 +100,8 @@ describe('createWorktreeChangeRefreshQueue', () => {
       await flushPromises()
 
       expect(handler).toHaveBeenCalledTimes(3)
-      expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', renamed)
-      expect(handler).toHaveBeenNthCalledWith(3, 'repo-1', undefined)
+      expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined, renamed)
+      expect(handler).toHaveBeenNthCalledWith(3, 'repo-1', undefined, undefined)
     } finally {
       consoleError.mockRestore()
     }
@@ -116,8 +116,8 @@ describe('createWorktreeChangeRefreshQueue', () => {
     queue.enqueue({ repoId: 'repo-1', renamed })
     await flushPromises()
 
-    expect(handler).toHaveBeenNthCalledWith(1, 'repo-1', undefined)
-    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', renamed)
+    expect(handler).toHaveBeenNthCalledWith(1, 'repo-1', undefined, undefined)
+    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined, renamed)
   })
 
   it('keeps a plain refresh queued after a rename', async () => {
@@ -136,8 +136,8 @@ describe('createWorktreeChangeRefreshQueue', () => {
     await flushPromises()
 
     expect(handler).toHaveBeenCalledTimes(3)
-    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', renamed)
-    expect(handler).toHaveBeenNthCalledWith(3, 'repo-1', undefined)
+    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined, renamed)
+    expect(handler).toHaveBeenNthCalledWith(3, 'repo-1', undefined, undefined)
   })
 
   it('drops queued trailing refreshes after disposal', async () => {

--- a/src/renderer/src/hooks/worktree-change-refresh-queue.ts
+++ b/src/renderer/src/hooks/worktree-change-refresh-queue.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from '../../../shared/execution-host'
+
 type WorktreeRename = {
   oldWorktreeId: string
   newWorktreeId: string
@@ -5,16 +7,23 @@ type WorktreeRename = {
 
 type WorktreeChangeEvent = {
   repoId: string
+  ownerHostId?: ExecutionHostId
   renamed?: WorktreeRename
 }
 
-type WorktreeChangeRefreshHandler = (repoId: string, renamed?: WorktreeRename) => Promise<void>
+type WorktreeChangeRefreshHandler = (
+  repoId: string,
+  ownerHostId?: ExecutionHostId,
+  renamed?: WorktreeRename
+) => Promise<void>
 
 type QueuedWorktreeChange = {
   renamed?: WorktreeRename
 }
 
 type RepoRefreshState = {
+  repoId: string
+  ownerHostId?: ExecutionHostId
   running: boolean
   queue: QueuedWorktreeChange[]
 }
@@ -30,13 +39,16 @@ export function createWorktreeChangeRefreshQueue(
   const states = new Map<string, RepoRefreshState>()
   let disposed = false
 
-  const drain = async (repoId: string, state: RepoRefreshState): Promise<void> => {
+  const getRefreshKey = (event: Pick<WorktreeChangeEvent, 'repoId' | 'ownerHostId'>) =>
+    `${event.ownerHostId ?? 'focused'}\0${event.repoId}`
+
+  const drain = async (key: string, state: RepoRefreshState): Promise<void> => {
     state.running = true
     try {
       while (!disposed && state.queue.length > 0) {
         const next = state.queue.shift()
         try {
-          await handler(repoId, next?.renamed)
+          await handler(state.repoId, state.ownerHostId, next?.renamed)
         } catch (error) {
           console.error('Failed to refresh changed worktrees:', error)
         }
@@ -44,9 +56,9 @@ export function createWorktreeChangeRefreshQueue(
     } finally {
       state.running = false
       if (disposed || state.queue.length === 0) {
-        states.delete(repoId)
+        states.delete(key)
       } else {
-        void drain(repoId, state)
+        void drain(key, state)
       }
     }
   }
@@ -61,10 +73,11 @@ export function createWorktreeChangeRefreshQueue(
       if (disposed) {
         return
       }
-      let state = states.get(event.repoId)
+      const key = getRefreshKey(event)
+      let state = states.get(key)
       if (!state) {
-        state = { running: false, queue: [] }
-        states.set(event.repoId, state)
+        state = { repoId: event.repoId, ownerHostId: event.ownerHostId, running: false, queue: [] }
+        states.set(key, state)
       }
 
       if (event.renamed) {
@@ -79,7 +92,7 @@ export function createWorktreeChangeRefreshQueue(
       }
 
       if (!state.running) {
-        void drain(event.repoId, state)
+        void drain(key, state)
       }
     }
   }

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -228,4 +228,66 @@ describe('project-host workspace target resolution', () => {
       }
     })
   })
+
+  it('resolves same-id repos by setup host instead of repo id alone', () => {
+    const repos = [
+      makeRepo('orca', { path: '/repos/local-orca' }),
+      makeRepo('orca', { executionHostId: 'runtime:gpu', path: '/repos/runtime-orca' })
+    ]
+    const projects = [makeProject('github:stablyai/orca', ['orca'])]
+    const projectHostSetups = [
+      makeSetup('shared-setup', 'github:stablyai/orca', 'local', 'orca'),
+      makeSetup('shared-setup', 'github:stablyai/orca', 'runtime:gpu', 'orca')
+    ]
+
+    expect(
+      resolveWorkspaceCreationTarget({
+        eligibleRepos: repos,
+        projects,
+        projectHostSetups,
+        projectHostSetupId: 'shared-setup',
+        hostId: 'local'
+      })
+    ).toMatchObject({
+      status: 'ready',
+      target: {
+        hostId: 'local',
+        repoId: 'orca',
+        repo: {
+          path: '/repos/local-orca'
+        }
+      }
+    })
+  })
+
+  it('keeps legacy fallback setup on the selected repo host for same-id repos', () => {
+    const repos = [
+      makeRepo('orca', { path: '/repos/local-orca' }),
+      makeRepo('orca', { executionHostId: 'runtime:gpu', path: '/repos/runtime-orca' })
+    ]
+    const projects = [makeProject('github:stablyai/orca', ['orca'])]
+    const projectHostSetups = [
+      makeSetup('runtime-setup', 'github:stablyai/orca', 'runtime:gpu', 'orca'),
+      makeSetup('local-setup', 'github:stablyai/orca', 'local', 'orca')
+    ]
+
+    expect(
+      resolveWorkspaceCreationTarget({
+        eligibleRepos: repos,
+        projects,
+        projectHostSetups,
+        activeRepoId: 'orca',
+        focusedHostScope: 'local'
+      })
+    ).toMatchObject({
+      status: 'ready',
+      target: {
+        hostId: 'local',
+        projectHostSetupId: 'local-setup',
+        repo: {
+          path: '/repos/local-orca'
+        }
+      }
+    })
+  })
 })

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -229,6 +229,55 @@ describe('project-host workspace target resolution', () => {
     })
   })
 
+  it('uses focused host when resolving an explicit same-id setup without hostId', () => {
+    const repos = [
+      makeRepo('orca-local'),
+      makeRepo('orca-runtime', { executionHostId: 'runtime:gpu' })
+    ]
+    const projects = [makeProject('github:stablyai/orca', ['orca-local', 'orca-runtime'])]
+    const projectHostSetups = [
+      makeSetup('shared-setup', 'github:stablyai/orca', 'local', 'orca-local'),
+      makeSetup('shared-setup', 'github:stablyai/orca', 'runtime:gpu', 'orca-runtime')
+    ]
+
+    expect(
+      resolveWorkspaceCreationTarget({
+        eligibleRepos: repos,
+        projects,
+        projectHostSetups,
+        projectHostSetupId: 'shared-setup',
+        focusedHostScope: 'runtime:gpu'
+      })
+    ).toMatchObject({
+      status: 'ready',
+      target: {
+        hostId: 'runtime:gpu',
+        repoId: 'orca-runtime'
+      }
+    })
+  })
+
+  it('does not guess an explicit same-id setup when host focus is ambiguous', () => {
+    const repos = [
+      makeRepo('orca-local'),
+      makeRepo('orca-runtime', { executionHostId: 'runtime:gpu' })
+    ]
+    const projects = [makeProject('github:stablyai/orca', ['orca-local', 'orca-runtime'])]
+    const projectHostSetups = [
+      makeSetup('shared-setup', 'github:stablyai/orca', 'local', 'orca-local'),
+      makeSetup('shared-setup', 'github:stablyai/orca', 'runtime:gpu', 'orca-runtime')
+    ]
+
+    expect(
+      resolveWorkspaceCreationTarget({
+        eligibleRepos: repos,
+        projects,
+        projectHostSetups,
+        projectHostSetupId: 'shared-setup'
+      })
+    ).toEqual({ status: 'unavailable', reason: 'setup-not-found' })
+  })
+
   it('resolves same-id repos by setup host instead of repo id alone', () => {
     const repos = [
       makeRepo('orca', { path: '/repos/local-orca' }),

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -200,4 +200,32 @@ describe('project-host workspace target resolution', () => {
       reason: 'setup-not-ready'
     })
   })
+
+  it('resolves an explicit same-id setup on the requested host', () => {
+    const repos = [
+      makeRepo('orca-local'),
+      makeRepo('orca-runtime', { executionHostId: 'runtime:gpu' })
+    ]
+    const projects = [makeProject('github:stablyai/orca', ['orca-local', 'orca-runtime'])]
+    const projectHostSetups = [
+      makeSetup('shared-setup', 'github:stablyai/orca', 'local', 'orca-local'),
+      makeSetup('shared-setup', 'github:stablyai/orca', 'runtime:gpu', 'orca-runtime')
+    ]
+
+    expect(
+      resolveWorkspaceCreationTarget({
+        eligibleRepos: repos,
+        projects,
+        projectHostSetups,
+        projectHostSetupId: 'shared-setup',
+        hostId: 'runtime:gpu'
+      })
+    ).toMatchObject({
+      status: 'ready',
+      target: {
+        hostId: 'runtime:gpu',
+        repoId: 'orca-runtime'
+      }
+    })
+  })
 })

--- a/src/renderer/src/lib/project-host-workspace-target.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.ts
@@ -1,7 +1,8 @@
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
   type ExecutionHostId,
-  type ExecutionHostScope
+  type ExecutionHostScope,
+  getRepoExecutionHostId
 } from '../../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
 import type { Project, ProjectHostSetup, Repo } from '../../../shared/types'
@@ -75,11 +76,21 @@ function isReadySetup(setup: ProjectHostSetup): boolean {
   return setup.setupState === 'ready'
 }
 
+function getRepoSetupHostKey(repoId: string, hostId: ExecutionHostId): string {
+  return `${hostId}\0${repoId}`
+}
+
+function createRepoBySetupHost(repos: readonly Repo[]): ReadonlyMap<string, Repo> {
+  return new Map(
+    repos.map((repo) => [getRepoSetupHostKey(repo.id, getRepoExecutionHostId(repo)), repo])
+  )
+}
+
 function createTarget(
   setup: ProjectHostSetup,
-  repoById: ReadonlyMap<string, Repo>
+  repoBySetupHost: ReadonlyMap<string, Repo>
 ): WorkspaceCreationTarget | null {
-  const repo = repoById.get(setup.repoId)
+  const repo = repoBySetupHost.get(getRepoSetupHostKey(setup.repoId, setup.hostId))
   if (!repo) {
     return null
   }
@@ -95,19 +106,32 @@ function createTarget(
 
 function findReadySetupTarget(
   setups: readonly ProjectHostSetup[],
-  repoById: ReadonlyMap<string, Repo>,
+  repoBySetupHost: ReadonlyMap<string, Repo>,
   predicate: (setup: ProjectHostSetup) => boolean
 ): WorkspaceCreationTarget | null {
   for (const setup of setups) {
     if (!isReadySetup(setup) || !predicate(setup)) {
       continue
     }
-    const target = createTarget(setup, repoById)
+    const target = createTarget(setup, repoBySetupHost)
     if (target) {
       return target
     }
   }
   return null
+}
+
+function findLegacyFallbackRepo(
+  repos: readonly Repo[],
+  repoId: string,
+  focusedHostScope?: ExecutionHostScope | null
+): Repo | undefined {
+  const matches = repos.filter((repo) => repo.id === repoId)
+  const focusedHostId =
+    focusedHostScope && focusedHostScope !== ALL_EXECUTION_HOSTS_SCOPE ? focusedHostScope : null
+  return focusedHostId
+    ? (matches.find((repo) => getRepoExecutionHostId(repo) === focusedHostId) ?? matches[0])
+    : matches[0]
 }
 
 export function resolveWorkspaceCreationTarget(
@@ -119,7 +143,7 @@ export function resolveWorkspaceCreationTarget(
   }
 
   const model = getProjectSetupModel(input)
-  const repoById = new Map(eligibleRepos.map((repo) => [repo.id, repo]))
+  const repoBySetupHost = createRepoBySetupHost(eligibleRepos)
   const setups = model?.setups ?? []
 
   if (projectHostSetupId) {
@@ -132,7 +156,7 @@ export function resolveWorkspaceCreationTarget(
     if (!isReadySetup(setup)) {
       return { status: 'unavailable', reason: 'setup-not-ready' }
     }
-    const target = createTarget(setup, repoById)
+    const target = createTarget(setup, repoBySetupHost)
     if (target) {
       return { status: 'ready', target }
     }
@@ -152,7 +176,7 @@ export function resolveWorkspaceCreationTarget(
     }
     const target = findReadySetupTarget(
       setups,
-      repoById,
+      repoBySetupHost,
       (setup) => setup.projectId === projectId && setup.hostId === hostId
     )
     if (target) {
@@ -167,14 +191,18 @@ export function resolveWorkspaceCreationTarget(
     const focusedTarget = focusedHostId
       ? findReadySetupTarget(
           setups,
-          repoById,
+          repoBySetupHost,
           (setup) => setup.projectId === projectId && setup.hostId === focusedHostId
         )
       : null
     if (focusedTarget) {
       return { status: 'ready', target: focusedTarget }
     }
-    const target = findReadySetupTarget(setups, repoById, (setup) => setup.projectId === projectId)
+    const target = findReadySetupTarget(
+      setups,
+      repoBySetupHost,
+      (setup) => setup.projectId === projectId
+    )
     if (target) {
       return { status: 'ready', target }
     }
@@ -182,22 +210,25 @@ export function resolveWorkspaceCreationTarget(
   }
 
   if (hostId) {
-    const target = findReadySetupTarget(setups, repoById, (setup) => setup.hostId === hostId)
+    const target = findReadySetupTarget(setups, repoBySetupHost, (setup) => setup.hostId === hostId)
     if (target) {
       return { status: 'ready', target }
     }
   }
 
   const repoId = resolveComposerRepoId(input)
-  const legacyRepo = repoId ? repoById.get(repoId) : null
+  const legacyRepo = repoId ? findLegacyFallbackRepo(eligibleRepos, repoId, focusedHostScope) : null
   if (!legacyRepo) {
     return { status: 'unavailable', reason: 'no-eligible-repo' }
   }
 
+  const legacyRepoHostId = getRepoExecutionHostId(legacyRepo)
   const legacySetup =
-    setups.find((setup) => setup.repoId === legacyRepo.id && isReadySetup(setup)) ??
-    projectHostSetupProjectionFromRepos([legacyRepo]).setups[0]
-  const legacyTarget = legacySetup ? createTarget(legacySetup, repoById) : null
+    setups.find(
+      (setup) =>
+        setup.repoId === legacyRepo.id && setup.hostId === legacyRepoHostId && isReadySetup(setup)
+    ) ?? projectHostSetupProjectionFromRepos([legacyRepo]).setups[0]
+  const legacyTarget = legacySetup ? createTarget(legacySetup, repoBySetupHost) : null
   if (!legacyTarget) {
     return { status: 'unavailable', reason: 'setup-not-found' }
   }

--- a/src/renderer/src/lib/project-host-workspace-target.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.ts
@@ -147,9 +147,18 @@ export function resolveWorkspaceCreationTarget(
   const setups = model?.setups ?? []
 
   if (projectHostSetupId) {
-    const setup = setups.find(
+    const matchingSetups = setups.filter(
       (entry) => entry.id === projectHostSetupId && (!hostId || entry.hostId === hostId)
     )
+    const focusedHostId =
+      focusedHostScope && focusedHostScope !== ALL_EXECUTION_HOSTS_SCOPE ? focusedHostScope : null
+    const setup = hostId
+      ? matchingSetups[0]
+      : focusedHostId
+        ? matchingSetups.find((entry) => entry.hostId === focusedHostId)
+        : matchingSetups.length === 1
+          ? matchingSetups[0]
+          : undefined
     if (!setup) {
       return { status: 'unavailable', reason: 'setup-not-found' }
     }

--- a/src/renderer/src/lib/project-host-workspace-target.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.ts
@@ -123,7 +123,9 @@ export function resolveWorkspaceCreationTarget(
   const setups = model?.setups ?? []
 
   if (projectHostSetupId) {
-    const setup = setups.find((entry) => entry.id === projectHostSetupId)
+    const setup = setups.find(
+      (entry) => entry.id === projectHostSetupId && (!hostId || entry.hostId === hostId)
+    )
     if (!setup) {
       return { status: 'unavailable', reason: 'setup-not-found' }
     }

--- a/src/renderer/src/lib/repo-runtime-owner.test.ts
+++ b/src/renderer/src/lib/repo-runtime-owner.test.ts
@@ -19,6 +19,21 @@ describe('getRuntimeEnvironmentIdForRepo', () => {
     ).toBe('owner-runtime')
   })
 
+  it('matches duplicate repos against encoded focused runtime host ids', () => {
+    expect(
+      getRuntimeEnvironmentIdForRepo(
+        {
+          settings: { activeRuntimeEnvironmentId: 'prod/server' },
+          repos: [
+            { id: 'repo-1', connectionId: null, executionHostId: 'local' },
+            { id: 'repo-1', connectionId: null, executionHostId: 'runtime:prod%2Fserver' }
+          ]
+        },
+        'repo-1'
+      )
+    ).toBe('prod/server')
+  })
+
   it('keeps explicit local repos local while a runtime is focused', () => {
     expect(
       getRuntimeEnvironmentIdForRepo(

--- a/src/renderer/src/lib/repo-settings-section-id.ts
+++ b/src/renderer/src/lib/repo-settings-section-id.ts
@@ -18,7 +18,13 @@ export function parseRepoSettingsSectionId(
   if (separatorIndex <= 0 || separatorIndex >= payload.length - 1) {
     return null
   }
-  const repoHostId = decodeURIComponent(payload.slice(0, separatorIndex))
-  const repoId = decodeURIComponent(payload.slice(separatorIndex + 1))
+  let repoHostId: string
+  let repoId: string
+  try {
+    repoHostId = decodeURIComponent(payload.slice(0, separatorIndex))
+    repoId = decodeURIComponent(payload.slice(separatorIndex + 1))
+  } catch {
+    return null
+  }
   return repoId && repoHostId ? { repoId, repoHostId } : null
 }

--- a/src/renderer/src/lib/repo-settings-section-id.ts
+++ b/src/renderer/src/lib/repo-settings-section-id.ts
@@ -1,0 +1,24 @@
+import type { Repo } from '../../../shared/types'
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
+
+export function getRepoSettingsSectionId(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+): string {
+  return `repo-${encodeURIComponent(getRepoExecutionHostId(repo))}:${encodeURIComponent(repo.id)}`
+}
+
+export function parseRepoSettingsSectionId(
+  sectionId: string
+): { repoId: string; repoHostId: string } | null {
+  if (!sectionId.startsWith('repo-')) {
+    return null
+  }
+  const payload = sectionId.slice('repo-'.length)
+  const separatorIndex = payload.indexOf(':')
+  if (separatorIndex <= 0 || separatorIndex >= payload.length - 1) {
+    return null
+  }
+  const repoHostId = decodeURIComponent(payload.slice(0, separatorIndex))
+  const repoId = decodeURIComponent(payload.slice(separatorIndex + 1))
+  return repoId && repoHostId ? { repoId, repoHostId } : null
+}

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -112,7 +112,8 @@ describe('worktree creation flow agent trust preflight', () => {
     expect(preflight).toContain('connectionId?: string | null')
     expect(preflight).toContain('...(connectionId ? { connectionId } : {})')
     expect(createFlow).toContain('repoConnectionId')
-    expect(createFlow).toContain('repo.id === worktree.repoId')
+    expect(createFlow).toContain('request.workspaceRunContext?.hostId ?? worktree.hostId')
+    expect(createFlow).toContain('getRepoExecutionHostId(candidate) === repoHostId')
     expect(createFlow).toContain(
       'await preflightAgentTrust(request, worktree.path, repoConnectionId)'
     )

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -17,6 +17,7 @@ import {
 import type { CreateWorktreeResult } from '../../../shared/types'
 import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
 import { createBrowserUuid } from '@/lib/browser-uuid'
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
 
 // Why: mirrors the startup-opt the composer used to build inline. The renderer
 // only seeds the first terminal when the backend did not already spawn it.
@@ -111,7 +112,10 @@ async function executeWorktreeCreation(
         request.linkedBitbucketPR,
         request.linkedAzureDevOpsPR,
         request.linkedGiteaPR,
-        request.compareBaseRef
+        request.compareBaseRef,
+        request.workspaceRunContext?.hostId
+          ? { ownerHostId: request.workspaceRunContext.hostId }
+          : undefined
       )
   } catch (error) {
     // Why: a missing entry means the user cancelled mid-flight — abandon
@@ -153,8 +157,16 @@ async function executeWorktreeCreation(
   const startupOpt = buildStartupOpt(request, backendSpawned)
 
   if (worktree.path) {
-    const repoConnectionId =
-      useAppStore.getState().repos.find((repo) => repo.id === worktree.repoId)?.connectionId ?? null
+    const repoHostId = request.workspaceRunContext?.hostId ?? worktree.hostId
+    const repos = useAppStore.getState().repos
+    const repo =
+      repoHostId !== undefined
+        ? repos.find(
+            (candidate) =>
+              candidate.id === worktree.repoId && getRepoExecutionHostId(candidate) === repoHostId
+          )
+        : repos.find((candidate) => candidate.id === worktree.repoId)
+    const repoConnectionId = repo?.connectionId ?? null
     await preflightAgentTrust(request, worktree.path, repoConnectionId)
   }
 

--- a/src/renderer/src/lib/worktree-runtime-owner.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.test.ts
@@ -47,6 +47,48 @@ describe('getSettingsForWorktreeRuntimeOwner', () => {
     })
   })
 
+  it('uses the worktree host when duplicate repo ids exist on local and runtime hosts', () => {
+    const duplicateState: WorktreeRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: null },
+      repos: [
+        { id: 'same-repo', connectionId: null, executionHostId: 'local' },
+        { id: 'same-repo', connectionId: null, executionHostId: 'runtime:env-1' }
+      ],
+      worktreesByRepo: {
+        'same-repo': [
+          { id: 'same-repo::/local/wt', repoId: 'same-repo', hostId: 'local' },
+          { id: 'same-repo::/runtime/wt', repoId: 'same-repo', hostId: 'runtime:env-1' }
+        ]
+      }
+    }
+
+    expect(getSettingsForWorktreeRuntimeOwner(duplicateState, 'same-repo::/runtime/wt')).toEqual({
+      activeRuntimeEnvironmentId: 'env-1'
+    })
+    expect(getExecutionHostIdForWorktree(duplicateState, 'same-repo::/runtime/wt')).toBe(
+      'runtime:env-1'
+    )
+  })
+
+  it('uses a stamped worktree host even before the matching repo row is loaded', () => {
+    const partialState: WorktreeRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: 'focused-env' },
+      repos: [],
+      worktreesByRepo: {
+        'same-repo': [
+          { id: 'same-repo::/runtime/wt', repoId: 'same-repo', hostId: 'runtime:env-1' }
+        ]
+      }
+    }
+
+    expect(getSettingsForWorktreeRuntimeOwner(partialState, 'same-repo::/runtime/wt')).toEqual({
+      activeRuntimeEnvironmentId: 'env-1'
+    })
+    expect(getExecutionHostIdForWorktree(partialState, 'same-repo::/runtime/wt')).toBe(
+      'runtime:env-1'
+    )
+  })
+
   it('routes folder workspaces to their project group runtime owner', () => {
     expect(getSettingsForWorktreeRuntimeOwner(state, 'folder:runtime-folder')).toEqual({
       activeRuntimeEnvironmentId: 'folder-env'

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/types'
+import { mergeFetchedReposForHost } from './repo-host-refresh-merge'
+
+function repo(id: string, hostId: ExecutionHostId, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path: `/${hostId}/${id}`,
+    displayName: id,
+    badgeColor: '#000000',
+    addedAt: 1,
+    executionHostId: hostId,
+    ...overrides
+  }
+}
+
+function idsByHost(repos: readonly Repo[]): Record<string, string[]> {
+  const result: Record<string, string[]> = {}
+  for (const entry of repos) {
+    const hostId = getRepoExecutionHostId(entry)
+    result[hostId] ??= []
+    result[hostId].push(entry.id)
+  }
+  return result
+}
+
+describe('mergeFetchedReposForHost', () => {
+  it('refreshes one host without dropping repos owned by another host', () => {
+    const previous = [
+      repo('local-a', 'local'),
+      repo('runtime-a', 'runtime:env-a'),
+      repo('runtime-stale', 'runtime:env-a')
+    ]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('runtime-a', 'runtime:env-a', { displayName: 'runtime renamed' })],
+      'runtime:env-a'
+    )
+
+    expect(idsByHost(merged)).toEqual({
+      local: ['local-a'],
+      'runtime:env-a': ['runtime-a']
+    })
+    expect(merged.find((entry) => entry.id === 'runtime-a')?.displayName).toBe('runtime renamed')
+  })
+
+  it('matches repos by host and id instead of id alone', () => {
+    const previous = [
+      repo('same-id', 'local', { path: '/local/orca' }),
+      repo('same-id', 'runtime:env-a', { path: '/srv/orca-old' })
+    ]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('same-id', 'runtime:env-a', { path: '/srv/orca-new' })],
+      'runtime:env-a'
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(merged.find((entry) => getRepoExecutionHostId(entry) === 'local')?.path).toBe(
+      '/local/orca'
+    )
+    expect(merged.find((entry) => getRepoExecutionHostId(entry) === 'runtime:env-a')?.path).toBe(
+      '/srv/orca-new'
+    )
+  })
+
+  it('adds a same-id repo on a new host without replacing the existing host repo', () => {
+    const previous = [repo('same-id', 'local', { path: '/local/orca' })]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [repo('same-id', 'runtime:env-a', { path: '/srv/orca' })],
+      'runtime:env-a'
+    )
+
+    expect(merged).toHaveLength(2)
+    expect(idsByHost(merged)).toEqual({
+      local: ['same-id'],
+      'runtime:env-a': ['same-id']
+    })
+  })
+})

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.test.ts
@@ -83,4 +83,20 @@ describe('mergeFetchedReposForHost', () => {
       'runtime:env-a': ['same-id']
     })
   })
+
+  it('applies the fetched order for the refreshed host', () => {
+    const local = repo('local-a', 'local')
+    const runtimeA = repo('runtime-a', 'runtime:env-a')
+    const runtimeB = repo('runtime-b', 'runtime:env-a')
+    const runtimeC = repo('runtime-c', 'runtime:env-a')
+    const previous = [local, runtimeA, runtimeB, runtimeC]
+
+    const merged = mergeFetchedReposForHost(
+      previous,
+      [runtimeC, runtimeB, runtimeA],
+      'runtime:env-a'
+    )
+
+    expect(merged).toEqual([local, runtimeC, runtimeB, runtimeA])
+  })
 })

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.ts
@@ -1,0 +1,34 @@
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/types'
+import { reconcileFetchedRepos } from './repo-identity-reconcile'
+
+function getRepoOwnerKey(repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>): string {
+  // Why: repo ids are only guaranteed unique inside one host's store. A runtime
+  // refresh must not replace a same-id local or sibling-runtime checkout.
+  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
+}
+
+export function mergeFetchedReposForHost(
+  previous: readonly Repo[],
+  fetched: Repo[],
+  hostId: ExecutionHostId
+): Repo[] {
+  const fetchedOwnerKeys = new Set(fetched.map(getRepoOwnerKey))
+  const preserved = previous.filter((repo) => {
+    const existingHostId = getRepoExecutionHostId(repo)
+    return existingHostId !== hostId || fetchedOwnerKeys.has(getRepoOwnerKey(repo))
+  })
+  const merged = [...preserved]
+  const indexByOwnerKey = new Map(merged.map((repo, index) => [getRepoOwnerKey(repo), index]))
+  for (const repo of fetched) {
+    const ownerKey = getRepoOwnerKey(repo)
+    const existingIndex = indexByOwnerKey.get(ownerKey)
+    if (existingIndex === undefined) {
+      indexByOwnerKey.set(ownerKey, merged.length)
+      merged.push(repo)
+      continue
+    }
+    merged[existingIndex] = repo
+  }
+  return reconcileFetchedRepos(previous, merged)
+}

--- a/src/renderer/src/store/slices/repo-host-refresh-merge.ts
+++ b/src/renderer/src/store/slices/repo-host-refresh-merge.ts
@@ -2,33 +2,17 @@ import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared
 import type { Repo } from '../../../../shared/types'
 import { reconcileFetchedRepos } from './repo-identity-reconcile'
 
-function getRepoOwnerKey(repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>): string {
-  // Why: repo ids are only guaranteed unique inside one host's store. A runtime
-  // refresh must not replace a same-id local or sibling-runtime checkout.
-  return `${getRepoExecutionHostId(repo)}\0${repo.id}`
-}
-
 export function mergeFetchedReposForHost(
   previous: readonly Repo[],
   fetched: Repo[],
   hostId: ExecutionHostId
 ): Repo[] {
-  const fetchedOwnerKeys = new Set(fetched.map(getRepoOwnerKey))
-  const preserved = previous.filter((repo) => {
-    const existingHostId = getRepoExecutionHostId(repo)
-    return existingHostId !== hostId || fetchedOwnerKeys.has(getRepoOwnerKey(repo))
-  })
-  const merged = [...preserved]
-  const indexByOwnerKey = new Map(merged.map((repo, index) => [getRepoOwnerKey(repo), index]))
-  for (const repo of fetched) {
-    const ownerKey = getRepoOwnerKey(repo)
-    const existingIndex = indexByOwnerKey.get(ownerKey)
-    if (existingIndex === undefined) {
-      indexByOwnerKey.set(ownerKey, merged.length)
-      merged.push(repo)
-      continue
-    }
-    merged[existingIndex] = repo
+  const firstHostIndex = previous.findIndex((repo) => getRepoExecutionHostId(repo) === hostId)
+  const preserved = previous.filter((repo) => getRepoExecutionHostId(repo) !== hostId)
+  if (firstHostIndex === -1) {
+    return reconcileFetchedRepos(previous, [...preserved, ...fetched])
   }
+  const insertAt = Math.min(firstHostIndex, preserved.length)
+  const merged = [...preserved.slice(0, insertAt), ...fetched, ...preserved.slice(insertAt)]
   return reconcileFetchedRepos(previous, merged)
 }

--- a/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
+++ b/src/renderer/src/store/slices/repo-identity-reconcile.test.ts
@@ -40,6 +40,22 @@ describe('reconcileFetchedRepos', () => {
     expect(result[0]).toBe(next[0])
   })
 
+  it('keys object reuse by repo id and execution host', () => {
+    const previous = [
+      makeRepo('same-id', { executionHostId: 'local', path: '/local/orca' }),
+      makeRepo('same-id', { executionHostId: 'runtime:env-a', path: '/srv/orca' })
+    ]
+    const next = [
+      makeRepo('same-id', { executionHostId: 'runtime:env-a', path: '/srv/orca' }),
+      makeRepo('same-id', { executionHostId: 'local', path: '/local/orca' })
+    ]
+
+    const result = reconcileFetchedRepos(previous, next)
+
+    expect(result[0]).toBe(previous[1])
+    expect(result[1]).toBe(previous[0])
+  })
+
   it('returns a rebuilt array when repos are added or removed', () => {
     const previous = [makeRepo('a')]
     const next = [makeRepo('a'), makeRepo('b')]

--- a/src/renderer/src/store/slices/repos-host-identity-routing.test.ts
+++ b/src/renderer/src/store/slices/repos-host-identity-routing.test.ts
@@ -127,6 +127,7 @@ describe('repo slice host identity routing', () => {
     ])
     expect(reposUpdate).toHaveBeenCalledWith({
       repoId: 'same-repo',
+      hostId: 'local',
       updates: { displayName: 'Local Renamed' }
     })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
@@ -148,6 +149,7 @@ describe('repo slice host identity routing', () => {
     ])
     expect(reposUpdate).toHaveBeenCalledWith({
       repoId: 'same-repo',
+      hostId: 'local',
       updates: { displayName: 'Local Renamed' }
     })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
@@ -285,7 +287,7 @@ describe('repo slice host identity routing', () => {
     expect(store.getState().projects).toEqual([
       expect.objectContaining({ id: 'repo:same-repo', sourceRepoIds: ['same-repo'] })
     ])
-    expect(reposRemove).toHaveBeenCalledWith({ repoId: 'same-repo' })
+    expect(reposRemove).toHaveBeenCalledWith({ repoId: 'same-repo', hostId: 'local' })
     expect(ptyKill).toHaveBeenCalledWith('local-pty')
     expect(ptyKill).not.toHaveBeenCalledWith('remote-pty')
   })
@@ -319,7 +321,7 @@ describe('repo slice host identity routing', () => {
 
     expect(store.getState().repos).toEqual([remoteDuplicate])
     expect(store.getState().worktreesByRepo['same-repo']).toEqual([remoteWorktree])
-    expect(reposRemove).toHaveBeenCalledWith({ repoId: 'same-repo' })
+    expect(reposRemove).toHaveBeenCalledWith({ repoId: 'same-repo', hostId: 'local' })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: 'repo.rm' })
     )

--- a/src/renderer/src/store/slices/repos-host-identity-routing.test.ts
+++ b/src/renderer/src/store/slices/repos-host-identity-routing.test.ts
@@ -109,6 +109,31 @@ describe('repo slice host identity routing', () => {
     })
   })
 
+  it('updates the requested owner host even when settings focus points elsewhere', async () => {
+    reposUpdate.mockResolvedValue(undefined)
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [localDuplicate, remoteDuplicate]
+    })
+
+    await store
+      .getState()
+      .updateRepo('same-repo', { displayName: 'Local Renamed' }, { ownerHostId: 'local' })
+
+    expect(store.getState().repos).toEqual([
+      { ...localDuplicate, displayName: 'Local Renamed' },
+      remoteDuplicate
+    ])
+    expect(reposUpdate).toHaveBeenCalledWith({
+      repoId: 'same-repo',
+      updates: { displayName: 'Local Renamed' }
+    })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'repo.update' })
+    )
+  })
+
   it('updates a legacy local duplicate without overwriting an explicit remote sibling', async () => {
     const { executionHostId: _executionHostId, ...legacyLocalDuplicate } = localDuplicate
     reposUpdate.mockResolvedValue(undefined)
@@ -261,6 +286,43 @@ describe('repo slice host identity routing', () => {
       expect.objectContaining({ id: 'repo:same-repo', sourceRepoIds: ['same-repo'] })
     ])
     expect(reposRemove).toHaveBeenCalledWith({ repoId: 'same-repo' })
+    expect(ptyKill).toHaveBeenCalledWith('local-pty')
+    expect(ptyKill).not.toHaveBeenCalledWith('remote-pty')
+  })
+
+  it('removes the requested owner host even when settings focus points elsewhere', async () => {
+    const localWorktree = makeWorktree({
+      id: 'same-repo::/local/wt',
+      repoId: 'same-repo'
+    })
+    const remoteWorktree = makeWorktree({
+      id: 'same-repo::/remote/wt',
+      repoId: 'same-repo',
+      hostId: 'runtime:env-1'
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [localDuplicate, remoteDuplicate],
+      worktreesByRepo: { 'same-repo': [localWorktree, remoteWorktree] },
+      tabsByWorktree: {
+        [localWorktree.id]: [{ id: 'local-tab', worktreeId: localWorktree.id }] as never,
+        [remoteWorktree.id]: [{ id: 'remote-tab', worktreeId: remoteWorktree.id }] as never
+      },
+      ptyIdsByTabId: {
+        'local-tab': ['local-pty'],
+        'remote-tab': ['remote-pty']
+      }
+    })
+
+    await store.getState().removeProject('same-repo', { ownerHostId: 'local' })
+
+    expect(store.getState().repos).toEqual([remoteDuplicate])
+    expect(store.getState().worktreesByRepo['same-repo']).toEqual([remoteWorktree])
+    expect(reposRemove).toHaveBeenCalledWith({ repoId: 'same-repo' })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'repo.rm' })
+    )
     expect(ptyKill).toHaveBeenCalledWith('local-pty')
     expect(ptyKill).not.toHaveBeenCalledWith('remote-pty')
   })

--- a/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
+++ b/src/renderer/src/store/slices/repos-multi-host-refresh.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const localRepo: Repo = {
+  id: 'same-repo',
+  path: '/Users/alice/orca',
+  displayName: 'local orca',
+  badgeColor: '#000000',
+  addedAt: 1
+}
+
+const runtimeRepo: Repo = {
+  id: 'same-repo',
+  path: '/srv/orca',
+  displayName: 'remote orca',
+  badgeColor: '#111111',
+  addedAt: 2
+}
+
+const reposList = vi.fn()
+const reposUpdate = vi.fn()
+const projectsList = vi.fn()
+const projectsListHostSetups = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposList.mockReset()
+  reposUpdate.mockReset()
+  projectsList.mockReset()
+  projectsListHostSetups.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+  projectsList.mockResolvedValue([])
+  projectsListHostSetups.mockResolvedValue([])
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: {
+        list: reposList,
+        update: reposUpdate
+      },
+      projects: {
+        list: projectsList,
+        listHostSetups: projectsListHostSetups
+      },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('repo slice multi-host refresh', () => {
+  it('keeps same-id local and runtime repos after switching hosts', async () => {
+    reposList.mockResolvedValue([localRepo])
+    runtimeEnvironmentCall.mockImplementation(({ method }: RuntimeEnvironmentCallRequest) => {
+      if (method === 'repo.list') {
+        return Promise.resolve({
+          id: 'repo-list',
+          ok: true,
+          result: { repos: [runtimeRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'project.list') {
+        return Promise.resolve({
+          id: 'project-list',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          id: 'setup-list',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${method}`)
+    })
+    const store = createTestStore()
+
+    await store.getState().fetchRepos()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    await store.getState().fetchRepos()
+
+    expect(store.getState().repos).toHaveLength(2)
+    expect(store.getState().repos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: localRepo.id,
+          path: localRepo.path,
+          executionHostId: 'local'
+        }),
+        expect.objectContaining({
+          id: runtimeRepo.id,
+          path: runtimeRepo.path,
+          executionHostId: 'runtime:env-1'
+        })
+      ])
+    )
+  })
+
+  it('updates only the active host repo when ids collide across hosts', async () => {
+    reposList.mockResolvedValue([localRepo])
+    runtimeEnvironmentCall.mockImplementation((request: RuntimeEnvironmentCallRequest) => {
+      const { method } = request
+      if (method === 'repo.list') {
+        return Promise.resolve({
+          id: 'repo-list',
+          ok: true,
+          result: { repos: [runtimeRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'repo.update') {
+        const updates = (request as unknown as { params: { updates: Partial<Repo> } }).params
+          .updates
+        return Promise.resolve({
+          id: 'repo-update',
+          ok: true,
+          result: { repo: { ...runtimeRepo, ...updates } },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'project.list') {
+        return Promise.resolve({
+          id: 'project-list',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({
+          id: 'setup-list',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected runtime method: ${method}`)
+    })
+    const store = createTestStore()
+
+    await store.getState().fetchRepos()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    await store.getState().fetchRepos()
+    const updated = await store.getState().updateRepo(runtimeRepo.id, {
+      displayName: 'remote renamed'
+    })
+
+    expect(updated).toBe(true)
+    expect(reposUpdate).not.toHaveBeenCalled()
+    expect(store.getState().repos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: localRepo.id,
+          displayName: localRepo.displayName,
+          executionHostId: 'local'
+        }),
+        expect.objectContaining({
+          id: runtimeRepo.id,
+          displayName: 'remote renamed',
+          executionHostId: 'runtime:env-1'
+        })
+      ])
+    )
+  })
+})

--- a/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
@@ -186,8 +186,8 @@ describe('project group deletion store routing', () => {
       failedProjectRemovals: []
     })
 
-    expect(reposRemove).toHaveBeenCalledWith({ repoId: 'direct' })
-    expect(reposRemove).toHaveBeenCalledWith({ repoId: 'nested' })
+    expect(reposRemove).toHaveBeenCalledWith({ repoId: 'direct', hostId: 'local' })
+    expect(reposRemove).toHaveBeenCalledWith({ repoId: 'nested', hostId: 'local' })
     expect(store.getState().repos).toEqual([siblingRepo])
   })
 

--- a/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
@@ -10,6 +10,7 @@ import { createTestStore } from './store-test-helpers'
 const projectsCreateHostSetup = vi.fn()
 const projectsUpdateHostSetup = vi.fn()
 const projectsDeleteHostSetup = vi.fn()
+const projectsSetupExistingFolder = vi.fn()
 const runtimeEnvironmentCall = vi.fn()
 const runtimeEnvironmentTransportCall = vi.fn()
 
@@ -49,6 +50,7 @@ beforeEach(() => {
   projectsCreateHostSetup.mockReset()
   projectsUpdateHostSetup.mockReset()
   projectsDeleteHostSetup.mockReset()
+  projectsSetupExistingFolder.mockReset()
   runtimeEnvironmentCall.mockReset()
   runtimeEnvironmentTransportCall.mockReset()
   runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
@@ -62,7 +64,8 @@ beforeEach(() => {
       projects: {
         createHostSetup: projectsCreateHostSetup,
         updateHostSetup: projectsUpdateHostSetup,
-        deleteHostSetup: projectsDeleteHostSetup
+        deleteHostSetup: projectsDeleteHostSetup,
+        setupExistingFolder: projectsSetupExistingFolder
       },
       runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
     }
@@ -263,6 +266,63 @@ describe('repo slice project host setup lifecycle', () => {
       params: {
         setupId: runtimeSetup.id,
         hostId: runtimeSetup.hostId
+      },
+      timeoutMs: 15_000
+    })
+  })
+
+  it('keeps same-id setup metadata on other hosts when setting up an existing folder', async () => {
+    const localSetup: ProjectHostSetup = {
+      ...runtimeSetup,
+      hostId: 'local',
+      displayName: 'Local'
+    }
+    const completedRuntimeSetup: ProjectHostSetup = {
+      ...runtimeSetup,
+      displayName: 'GPU VM connected',
+      repoId: runtimeRepo.id
+    }
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-setup-existing-folder',
+      ok: true,
+      result: {
+        result: {
+          project,
+          repo: runtimeRepo,
+          setup: completedRuntimeSetup
+        }
+      },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      projects: [project],
+      repos: [],
+      projectHostSetups: [localSetup, runtimeSetup],
+      settings: { activeRuntimeEnvironmentId: null } as never
+    })
+
+    await expect(
+      store.getState().setupProjectExistingFolder({
+        projectId: project.id,
+        hostId: runtimeSetup.hostId,
+        path: runtimeRepo.path
+      })
+    ).resolves.toEqual({
+      project,
+      repo: runtimeRepo,
+      setup: completedRuntimeSetup
+    })
+
+    expect(store.getState().projectHostSetups).toEqual([localSetup, completedRuntimeSetup])
+    expect(projectsSetupExistingFolder).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectHostSetup.setupExistingFolder',
+      params: {
+        projectId: project.id,
+        hostId: runtimeSetup.hostId,
+        path: runtimeRepo.path
       },
       timeoutMs: 15_000
     })

--- a/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
@@ -141,6 +141,58 @@ describe('repo slice project host setup lifecycle', () => {
     })
   })
 
+  it('updates same-id project host setup through the requested host', async () => {
+    const localSetup: ProjectHostSetup = {
+      ...runtimeSetup,
+      hostId: 'local',
+      displayName: 'Local'
+    }
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-update-setup',
+      ok: true,
+      result: {
+        result: {
+          project,
+          setup: { ...runtimeSetup, displayName: 'GPU VM renamed' }
+        }
+      },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      projectHostSetups: [localSetup, runtimeSetup],
+      settings: { activeRuntimeEnvironmentId: null } as never
+    })
+
+    await expect(
+      store.getState().updateProjectHostSetup({
+        setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId,
+        updates: { displayName: 'GPU VM renamed' }
+      })
+    ).resolves.toEqual({
+      project,
+      setup: { ...runtimeSetup, displayName: 'GPU VM renamed' },
+      repo: undefined
+    })
+
+    expect(projectsUpdateHostSetup).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectHostSetup.update',
+      params: {
+        setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId,
+        updates: { displayName: 'GPU VM renamed' }
+      },
+      timeoutMs: 15_000
+    })
+    expect(store.getState().projectHostSetups).toEqual([
+      localSetup,
+      { ...runtimeSetup, displayName: 'GPU VM renamed' }
+    ])
+  })
+
   it('deletes runtime-owned project host setups through their owning runtime', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'rpc-delete-setup',
@@ -169,6 +221,49 @@ describe('repo slice project host setup lifecycle', () => {
       selector: 'env-1',
       method: 'projectHostSetup.delete',
       params: { setupId: runtimeSetup.id },
+      timeoutMs: 15_000
+    })
+  })
+
+  it('deletes same-id project host setup through the requested host', async () => {
+    const localSetup: ProjectHostSetup = {
+      ...runtimeSetup,
+      hostId: 'local',
+      displayName: 'Local'
+    }
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-delete-setup',
+      ok: true,
+      result: { result: { project, setup: runtimeSetup } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      projects: [project],
+      projectHostSetups: [localSetup, runtimeSetup],
+      settings: { activeRuntimeEnvironmentId: null } as never
+    })
+
+    await expect(
+      store.getState().deleteProjectHostSetup({
+        setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId
+      })
+    ).resolves.toEqual({
+      project,
+      setup: runtimeSetup,
+      repo: undefined
+    })
+
+    expect(projectsDeleteHostSetup).not.toHaveBeenCalled()
+    expect(store.getState().projectHostSetups).toEqual([localSetup])
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectHostSetup.delete',
+      params: {
+        setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId
+      },
       timeoutMs: 15_000
     })
   })

--- a/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
+++ b/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import { createTestStore, makeWorktree } from './store-test-helpers'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+
+const repoId = 'github:stablyai/orca'
+
+const baseRepo: Repo = {
+  id: repoId,
+  path: '/env-one/orca',
+  displayName: 'Orca',
+  badgeColor: '#111',
+  addedAt: 1
+}
+
+const reposRemove = vi.fn()
+const reposReorder = vi.fn()
+const ptyKill = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+function runtimeRepo(environmentId: string, path: string, displayName: string): Repo {
+  return {
+    ...baseRepo,
+    path,
+    displayName,
+    executionHostId: `runtime:${environmentId}`
+  }
+}
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposRemove.mockReset()
+  reposReorder.mockReset()
+  ptyKill.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentCall.mockResolvedValue({
+    id: 'rpc-same-id-host-mutation',
+    ok: true,
+    result: { status: 'applied' },
+    _meta: { runtimeId: 'runtime-remote' }
+  })
+  runtimeEnvironmentTransportCall.mockReset()
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: {
+        remove: reposRemove,
+        reorder: reposReorder
+      },
+      pty: { kill: ptyKill },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('repo slice same-id host mutations', () => {
+  it('keeps sibling host repos and worktrees when removing the active remote host row', async () => {
+    const envOneRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
+    const envTwoRepo = runtimeRepo('env-2', '/env-two/orca', 'Orca on env two')
+    const envOneWorktree = makeWorktree({
+      id: `${repoId}::/env-one/wt`,
+      repoId,
+      path: '/env-one/wt',
+      hostId: 'runtime:env-1'
+    })
+    const envTwoWorktree = makeWorktree({
+      id: `${repoId}::/env-two/wt`,
+      repoId,
+      path: '/env-two/wt',
+      hostId: 'runtime:env-2'
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [envOneRepo, envTwoRepo],
+      activeRepoId: repoId,
+      filterRepoIds: [repoId],
+      worktreesByRepo: { [repoId]: [envOneWorktree, envTwoWorktree] },
+      detectedWorktreesByRepo: {
+        [repoId]: {
+          repoId,
+          authoritative: true,
+          source: 'git',
+          worktrees: [
+            {
+              ...envOneWorktree,
+              ownership: 'orca-managed',
+              selectedCheckout: false,
+              visible: true
+            },
+            { ...envTwoWorktree, ownership: 'orca-managed', selectedCheckout: false, visible: true }
+          ]
+        }
+      },
+      tabsByWorktree: {
+        [envOneWorktree.id]: [{ id: 'tab-env-one', worktreeId: envOneWorktree.id }] as never,
+        [envTwoWorktree.id]: [{ id: 'tab-env-two', worktreeId: envTwoWorktree.id }] as never
+      },
+      ptyIdsByTabId: {
+        'tab-env-one': ['remote:env-one'],
+        'tab-env-two': ['remote:env-two']
+      },
+      lastVisitedAtByWorktreeId: {
+        [envOneWorktree.id]: 1,
+        [envTwoWorktree.id]: 2
+      }
+    })
+
+    await store.getState().removeProject(repoId)
+
+    expect(store.getState().repos).toEqual([envTwoRepo])
+    expect(store.getState().worktreesByRepo[repoId]).toEqual([envTwoWorktree])
+    expect(store.getState().detectedWorktreesByRepo[repoId]?.worktrees).toEqual([
+      expect.objectContaining({ id: envTwoWorktree.id, hostId: 'runtime:env-2' })
+    ])
+    expect(store.getState().tabsByWorktree[envOneWorktree.id]).toBeUndefined()
+    expect(store.getState().tabsByWorktree[envTwoWorktree.id]).toEqual([
+      { id: 'tab-env-two', worktreeId: envTwoWorktree.id }
+    ])
+    expect(store.getState().lastVisitedAtByWorktreeId).toEqual({ [envTwoWorktree.id]: 2 })
+    expect(store.getState().activeRepoId).toBeNull()
+    expect(store.getState().filterRepoIds).toEqual([repoId])
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'repo.rm',
+      params: { repo: repoId },
+      timeoutMs: 15_000
+    })
+    expect(reposRemove).not.toHaveBeenCalled()
+  })
+
+  it('keeps same-id repos from distinct hosts when reordering', async () => {
+    const envOneRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
+    const envTwoRepo = runtimeRepo('env-2', '/env-two/orca', 'Orca on env two')
+    const store = createTestStore()
+    store.setState({ repos: [envOneRepo, envTwoRepo] })
+
+    await store.getState().reorderRepos([repoId, repoId])
+
+    expect(store.getState().repos).toEqual([envOneRepo, envTwoRepo])
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'repo.reorder',
+      params: { orderedIds: [repoId] },
+      timeoutMs: 15_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-2',
+      method: 'repo.reorder',
+      params: { orderedIds: [repoId] },
+      timeoutMs: 15_000
+    })
+  })
+})

--- a/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
+++ b/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
@@ -136,6 +136,55 @@ describe('repo slice same-id host mutations', () => {
     expect(reposRemove).not.toHaveBeenCalled()
   })
 
+  it('removes legacy local worktrees without dropping a same-id runtime sibling', async () => {
+    const legacyLocalRepo = { ...baseRepo, path: '/local/orca', displayName: 'Local Orca' }
+    const envRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
+    const legacyLocalWorktree = makeWorktree({
+      id: `${repoId}::/local/wt`,
+      repoId,
+      path: '/local/wt'
+    })
+    const envWorktree = makeWorktree({
+      id: `${repoId}::/env-one/wt`,
+      repoId,
+      path: '/env-one/wt',
+      hostId: 'runtime:env-1'
+    })
+    const store = createTestStore()
+    store.setState({
+      repos: [legacyLocalRepo, envRepo],
+      worktreesByRepo: { [repoId]: [legacyLocalWorktree, envWorktree] },
+      tabsByWorktree: {
+        [legacyLocalWorktree.id]: [
+          { id: 'tab-local', worktreeId: legacyLocalWorktree.id }
+        ] as never,
+        [envWorktree.id]: [{ id: 'tab-env', worktreeId: envWorktree.id }] as never
+      },
+      ptyIdsByTabId: {
+        'tab-local': ['local-pty'],
+        'tab-env': ['remote:env-one']
+      },
+      lastVisitedAtByWorktreeId: {
+        [legacyLocalWorktree.id]: 1,
+        [envWorktree.id]: 2
+      }
+    })
+
+    await store.getState().removeProject(repoId)
+
+    expect(reposRemove).toHaveBeenCalledWith({ repoId })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'repo.rm' })
+    )
+    expect(store.getState().repos).toEqual([envRepo])
+    expect(store.getState().worktreesByRepo[repoId]).toEqual([envWorktree])
+    expect(store.getState().tabsByWorktree[legacyLocalWorktree.id]).toBeUndefined()
+    expect(store.getState().tabsByWorktree[envWorktree.id]).toEqual([
+      { id: 'tab-env', worktreeId: envWorktree.id }
+    ])
+    expect(store.getState().lastVisitedAtByWorktreeId).toEqual({ [envWorktree.id]: 2 })
+  })
+
   it('keeps same-id repos from distinct hosts when reordering', async () => {
     const envOneRepo = runtimeRepo('env-1', '/env-one/orca', 'Orca on env one')
     const envTwoRepo = runtimeRepo('env-2', '/env-two/orca', 'Orca on env two')

--- a/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
+++ b/src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts
@@ -172,7 +172,7 @@ describe('repo slice same-id host mutations', () => {
 
     await store.getState().removeProject(repoId)
 
-    expect(reposRemove).toHaveBeenCalledWith({ repoId })
+    expect(reposRemove).toHaveBeenCalledWith({ repoId, hostId: 'local' })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: 'repo.rm' })
     )

--- a/src/renderer/src/store/slices/repos-update-serialization.test.ts
+++ b/src/renderer/src/store/slices/repos-update-serialization.test.ts
@@ -141,7 +141,7 @@ describe('repo update serialization', () => {
       } as never
     })
 
-    expect(reposUpdate).toHaveBeenCalledWith({ repoId: localRepo.id, updates: {} })
+    expect(reposUpdate).toHaveBeenCalledWith({ repoId: localRepo.id, hostId: 'local', updates: {} })
     expect(store.getState().repos[0]?.repoIcon).toBeUndefined()
   })
 })

--- a/src/renderer/src/store/slices/repos.test.ts
+++ b/src/renderer/src/store/slices/repos.test.ts
@@ -209,6 +209,7 @@ describe('repo slice runtime routing', () => {
     expect(store.getState().repos[0]?.displayName).toBe('SSH Renamed')
     expect(reposUpdate).toHaveBeenCalledWith({
       repoId: sshRepo.id,
+      hostId: 'ssh:ssh-1',
       updates: { displayName: 'SSH Renamed' }
     })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
@@ -664,7 +665,7 @@ describe('repo slice runtime routing', () => {
 
     expect(store.getState().repos).toEqual([])
     expect(store.getState().activeRepoId).toBeNull()
-    expect(reposRemove).toHaveBeenCalledWith({ repoId: sshRepo.id })
+    expect(reposRemove).toHaveBeenCalledWith({ repoId: sshRepo.id, hostId: 'ssh:ssh-1' })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
 
@@ -685,7 +686,7 @@ describe('repo slice runtime routing', () => {
 
     expect(store.getState().repos).toEqual([localRepo])
     expect(store.getState().lastVisitedAtByWorktreeId).toEqual({ [localWorktreeId]: 200 })
-    expect(reposRemove).toHaveBeenCalledWith({ repoId: sshRepo.id })
+    expect(reposRemove).toHaveBeenCalledWith({ repoId: sshRepo.id, hostId: 'ssh:ssh-1' })
   })
 
   it('drops persisted visit timestamps for removed unhydrated runtime repos', async () => {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -2377,7 +2377,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
             hostId: ownerHostId
           }),
           activeRepoId: s.activeRepoId === projectId ? null : s.activeRepoId,
-          filterRepoIds: s.filterRepoIds.filter((id) => id !== projectId),
+          filterRepoIds: nextRepos.some((repo) => repo.id === projectId)
+            ? s.filterRepoIds
+            : s.filterRepoIds.filter((id) => id !== projectId),
           worktreesByRepo: nextWorktrees,
           detectedWorktreesByRepo: nextDetectedWorktrees,
           tabsByWorktree: nextTabs,

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1968,8 +1968,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         const nextProjects = s.projects.some((entry) => entry.id === result.project.id)
           ? s.projects.map((entry) => (entry.id === result.project.id ? result.project : entry))
           : [...s.projects, result.project]
-        const nextSetups = s.projectHostSetups.some((entry) => entry.id === setup.id)
-          ? s.projectHostSetups.map((entry) => (entry.id === setup.id ? setup : entry))
+        const nextSetups = s.projectHostSetups.some((entry) => isSameProjectHostSetup(entry, setup))
+          ? s.projectHostSetups.map((entry) =>
+              isSameProjectHostSetup(entry, setup) ? setup : entry
+            )
           : [...s.projectHostSetups, setup]
         return {
           repos: nextRepos,

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -68,6 +68,7 @@ import { translate } from '@/i18n/i18n'
 import {
   getRepoExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
   parseExecutionHostId,
   toRuntimeExecutionHostId,
   toSshExecutionHostId
@@ -226,6 +227,24 @@ function getProjectSetupRuntimeTarget(
   return parsedHost?.kind === 'runtime'
     ? { kind: 'environment', environmentId: parsedHost.environmentId }
     : { kind: 'local' }
+}
+
+function findProjectHostSetupByMutationArgs(
+  setups: readonly ProjectHostSetup[],
+  args: Pick<ProjectHostSetupUpdateArgs, 'setupId' | 'hostId'>
+): ProjectHostSetup | undefined {
+  if (args.hostId === undefined) {
+    return setups.find((setup) => setup.id === args.setupId)
+  }
+  const hostId = normalizeExecutionHostId(args.hostId)
+  if (!hostId) {
+    throw new Error(`Invalid host ID: ${args.hostId}`)
+  }
+  return setups.find((setup) => setup.id === args.setupId && setup.hostId === hostId)
+}
+
+function isSameProjectHostSetup(a: ProjectHostSetup, b: ProjectHostSetup): boolean {
+  return a.id === b.id && a.hostId === b.hostId
 }
 
 function getProjectUpdateRuntimeTarget(
@@ -1993,8 +2012,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         projects: s.projects.some((entry) => entry.id === result.project.id)
           ? s.projects.map((entry) => (entry.id === result.project.id ? result.project : entry))
           : [...s.projects, result.project],
-        projectHostSetups: s.projectHostSetups.some((entry) => entry.id === setup.id)
-          ? s.projectHostSetups.map((entry) => (entry.id === setup.id ? setup : entry))
+        projectHostSetups: s.projectHostSetups.some((entry) => isSameProjectHostSetup(entry, setup))
+          ? s.projectHostSetups.map((entry) =>
+              isSameProjectHostSetup(entry, setup) ? setup : entry
+            )
           : [...s.projectHostSetups, setup]
       }))
       return { project: result.project, setup }
@@ -2011,7 +2032,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   updateProjectHostSetup: async (args) => {
     try {
-      const currentSetup = get().projectHostSetups.find((setup) => setup.id === args.setupId)
+      const currentSetup = findProjectHostSetupByMutationArgs(get().projectHostSetups, args)
       const target = currentSetup
         ? getProjectSetupRuntimeTarget(currentSetup.hostId)
         : { kind: 'local' as const }
@@ -2041,8 +2062,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         projects: s.projects.some((entry) => entry.id === result.project.id)
           ? s.projects.map((entry) => (entry.id === result.project.id ? result.project : entry))
           : [...s.projects, result.project],
-        projectHostSetups: s.projectHostSetups.some((entry) => entry.id === setup.id)
-          ? s.projectHostSetups.map((entry) => (entry.id === setup.id ? setup : entry))
+        projectHostSetups: s.projectHostSetups.some((entry) => isSameProjectHostSetup(entry, setup))
+          ? s.projectHostSetups.map((entry) =>
+              isSameProjectHostSetup(entry, setup) ? setup : entry
+            )
           : [...s.projectHostSetups, setup]
       }))
       return { ...result, repo, setup }
@@ -2059,7 +2082,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   deleteProjectHostSetup: async (args) => {
     try {
-      const currentSetup = get().projectHostSetups.find((setup) => setup.id === args.setupId)
+      const currentSetup = findProjectHostSetupByMutationArgs(get().projectHostSetups, args)
       const target = currentSetup
         ? getProjectSetupRuntimeTarget(currentSetup.hostId)
         : { kind: 'local' as const }
@@ -2079,7 +2102,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const repoHostId = repo ? getRepoExecutionHostId(repo) : null
       set((s) => {
         const projectHostSetups = s.projectHostSetups.filter(
-          (setup) => setup.id !== result.setup.id
+          (setup) => !isSameProjectHostSetup(setup, result.setup)
         )
         const repos =
           repo && repoHostId

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -71,7 +71,8 @@ import {
   normalizeExecutionHostId,
   parseExecutionHostId,
   toRuntimeExecutionHostId,
-  toSshExecutionHostId
+  toSshExecutionHostId,
+  type ExecutionHostId
 } from '../../../../shared/execution-host'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import { formatFolderWorkspaceCreateError } from '../../lib/folder-workspace-path-status'
@@ -1150,9 +1151,13 @@ export type RepoSlice = {
     groupId: string | null,
     order?: number
   ) => Promise<boolean>
-  removeProject: (projectId: string) => Promise<void>
+  removeProject: (projectId: string, options?: { ownerHostId?: ExecutionHostId }) => Promise<void>
   updateProject: (projectId: string, updates: ProjectUpdate) => Promise<boolean>
-  updateRepo: (projectId: string, updates: RepoUpdate) => Promise<boolean>
+  updateRepo: (
+    projectId: string,
+    updates: RepoUpdate,
+    options?: { ownerHostId?: ExecutionHostId }
+  ) => Promise<boolean>
   setActiveRepo: (projectId: string | null) => void
   reorderRepos: (orderedIds: string[]) => Promise<void>
 }
@@ -2241,14 +2246,19 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  removeProject: async (projectId) => {
+  removeProject: async (projectId, options) => {
     try {
-      const ownerRepo = findRepoForHost(get().repos, projectId, { settings: get().settings })
+      const ownerRepo = findRepoForHost(get().repos, projectId, {
+        hostId: options?.ownerHostId,
+        settings: get().settings
+      })
       if (!ownerRepo) {
         return
       }
       const ownerHostId = getRepoExecutionHostId(ownerRepo)
-      const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
+      const target = options?.ownerHostId
+        ? getProjectSetupRuntimeTarget(ownerHostId)
+        : getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
       await (target.kind === 'local'
         ? window.api.repos.remove({ repoId: projectId })
         : callRuntimeRpc(target, 'repo.rm', { repo: projectId }, { timeoutMs: 15_000 }))
@@ -2452,9 +2462,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  updateRepo: async (projectId, updates) => {
+  updateRepo: async (projectId, updates, options) => {
     const updateRepoChains = getRepoUpdateChains(get)
-    const ownerRepo = findRepoForHost(get().repos, projectId, { settings: get().settings })
+    const ownerRepo = findRepoForHost(get().repos, projectId, {
+      hostId: options?.ownerHostId,
+      settings: get().settings
+    })
     if (!ownerRepo) {
       return false
     }

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -235,7 +235,8 @@ function findProjectHostSetupByMutationArgs(
   args: Pick<ProjectHostSetupUpdateArgs, 'setupId' | 'hostId'>
 ): ProjectHostSetup | undefined {
   if (args.hostId === undefined) {
-    return setups.find((setup) => setup.id === args.setupId)
+    const matches = setups.filter((setup) => setup.id === args.setupId)
+    return matches.length === 1 ? matches[0] : undefined
   }
   const hostId = normalizeExecutionHostId(args.hostId)
   if (!hostId) {
@@ -284,7 +285,7 @@ function scheduleSafeAutoForkSync(get: () => AppState, repos: readonly Repo[]): 
     }
     const promise = syncRuntimeGitForkDefaultBranch(
       {
-        settings: settingsForRepoOwner(get(), repo.id),
+        settings: settingsForRepoOwner(get(), repo.id, getRepoExecutionHostId(repo)),
         worktreeId: repo.id,
         worktreePath: repo.path,
         connectionId: repo.connectionId ?? undefined
@@ -901,8 +902,15 @@ async function listRuntimeEnvironmentsForAllHostLoad(): Promise<{ id: string }[]
   }
 }
 
-function settingsForRepoOwner(state: Pick<AppState, 'repos' | 'settings'>, repoId: string) {
-  const repo = findRepoForHost(state.repos, repoId, { settings: state.settings })
+function settingsForRepoOwner(
+  state: Pick<AppState, 'repos' | 'settings'>,
+  repoId: string,
+  hostId?: ExecutionHostId | null
+) {
+  const repo = findRepoForHost(state.repos, repoId, {
+    ...(hostId ? { hostId } : {}),
+    settings: state.settings
+  })
   if (!repo) {
     return state.settings
   }
@@ -2260,7 +2268,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         ? getProjectSetupRuntimeTarget(ownerHostId)
         : getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
       await (target.kind === 'local'
-        ? window.api.repos.remove({ repoId: projectId })
+        ? window.api.repos.remove({ repoId: projectId, hostId: ownerHostId })
         : callRuntimeRpc(target, 'repo.rm', { repo: projectId }, { timeoutMs: 15_000 }))
 
       get().clearOrcaHookTrustForRepo(projectId)
@@ -2488,7 +2496,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         const target = ownerTarget
         const updatedRepo =
           target.kind === 'local'
-            ? await window.api.repos.update({ repoId: projectId, updates: sanitizedUpdates })
+            ? await window.api.repos.update({
+                repoId: projectId,
+                hostId: ownerHostId,
+                updates: sanitizedUpdates
+              })
             : (
                 await callRuntimeRpc<{ repo: Repo }>(
                   target,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -696,6 +696,7 @@ export type UISlice = {
   settingsNavigationTarget: {
     pane: SettingsNavTarget
     repoId: string | null
+    repoHostId?: string
     sectionId?: string
     intent?: 'add-quick-command'
   } | null

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -21,6 +21,7 @@ import type {
   WorkspaceKey
 } from '../../../../shared/types'
 import type { TerminalGitHubPRLink } from '@/lib/terminal-github-pr-link-detector'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type {
   PendingWorktreeCreation,
   WorktreeCreationPhase
@@ -111,7 +112,10 @@ export type WorktreeSlice = {
    */
   hasHydratedWorktreePurge: boolean
   fetchDetectedWorktrees: (repoId: string) => Promise<DetectedWorktreeListResult | null>
-  fetchWorktrees: (repoId: string, options?: { requireAuthoritative?: boolean }) => Promise<boolean>
+  fetchWorktrees: (
+    repoId: string,
+    options?: { requireAuthoritative?: boolean; ownerHostId?: ExecutionHostId }
+  ) => Promise<boolean>
   fetchAllWorktrees: () => Promise<void>
   fetchWorktreeLineage: () => Promise<void>
   updateWorktreeLineage: (

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -156,7 +156,10 @@ export type WorktreeSlice = {
     compareBaseRef?: string,
     // Why: reserved for automation-dispatch flows so host-side provenance can
     // be minted securely; regular create callers should omit this.
-    options?: { automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest'] }
+    options?: {
+      automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest']
+      ownerHostId?: ExecutionHostId
+    }
   ) => Promise<CreateWorktreeResult>
   /** Register an in-flight background creation and make it the active surface. */
   beginPendingWorktreeCreation: (entry: PendingWorktreeCreation) => void

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -133,6 +133,7 @@ function createTestStore() {
         expandedDirs: {},
         gitStatusByWorktree: {},
         gitStatusHeadByWorktree: {},
+        gitStatusHugeByWorktree: {},
         gitIgnoredPathsByWorktree: {},
         gitConflictOperationByWorktree: {},
         trackedConflictPathsByWorktree: {},
@@ -144,6 +145,8 @@ function createTestStore() {
         activeBrowserTabIdByWorktree: {},
         browserTabsByWorktree: {},
         recentlyClosedBrowserTabsByWorktree: {},
+        recentlyClosedEditorTabsByWorktree: {},
+        remoteStatusesByWorktree: {},
         activeTabTypeByWorktree: {},
         rightSidebarTab: 'explorer' as const,
         rightSidebarTabByWorktree: {},
@@ -5003,6 +5006,11 @@ describe('migrateWorktreeIdentity', () => {
   const OLD = 'repo1::/ws/cunner'
   const NEW = 'repo1::/ws/worktree-creation-spinner'
   const CANONICAL = makeWorktreeKey({ hostId: 'local', repoId: 'repo1', path: '/ws/cunner' })
+  const WORKTREE_ID_VALUE_MIGRATED_KEYS = new Set([
+    'browserPagesByWorkspace',
+    'recentlyClosedBrowserPagesByWorkspace',
+    'sleepingAgentSessionsByPaneKey'
+  ])
 
   function makeMigrationMapValue(
     key: (typeof WORKTREE_ID_KEYED_MAP_KEYS)[number],
@@ -5026,10 +5034,23 @@ describe('migrateWorktreeIdentity', () => {
         return [{ id: 'unified1', worktreeId }]
       case 'groupsByWorktree':
         return [{ id: 'group1', worktreeId }]
+      case 'recentlyClosedEditorTabsByWorktree':
+        return [{ id: 'file1', worktreeId }]
       default:
         return { marker: key }
     }
   }
+
+  it('keeps the worktree-id keyed map list in sync with store fields', () => {
+    const declared = new Set<keyof AppState>(WORKTREE_ID_KEYED_MAP_KEYS)
+    const state = createTestStore().getState()
+    const uncovered = Object.keys(state)
+      .filter((key) => key.includes('ByWorktree'))
+      .filter((key) => !declared.has(key as keyof AppState))
+      .filter((key) => !WORKTREE_ID_VALUE_MIGRATED_KEYS.has(key))
+
+    expect(uncovered).toEqual([])
+  })
 
   it('re-keys worktree-scoped maps, pointers, the Set, and openFiles old->new', () => {
     const store = createTestStore()
@@ -5052,6 +5073,7 @@ describe('migrateWorktreeIdentity', () => {
       groupsByWorktree: { [OLD]: [{ id: 'group1', worktreeId: OLD }] },
       gitStatusByWorktree: { [OLD]: [{ path: 'a.ts' }] },
       gitStatusHeadByWorktree: { [OLD]: 'head-old' },
+      gitStatusHugeByWorktree: { [OLD]: { limit: 10_000 } },
       gitBranchCompareRequestStatusHeadByWorktree: { [OLD]: 'head-old' },
       lastVisitedAtByWorktreeId: { [OLD]: 123 },
       defaultTerminalTabsAppliedByWorktreeId: { [OLD]: true },
@@ -5095,12 +5117,12 @@ describe('migrateWorktreeIdentity', () => {
     expect(s.groupsByWorktree[NEW]?.[0]?.worktreeId).toBe(NEW)
     expect(s.gitStatusByWorktree[NEW]).toEqual([{ path: 'a.ts' }])
     expect(s.gitStatusHeadByWorktree[NEW]).toBe('head-old')
+    expect(s.gitStatusHugeByWorktree[NEW]).toEqual({ limit: 10_000 })
     expect(s.gitBranchCompareRequestStatusHeadByWorktree[NEW]).toBe('head-old')
     expect(s.rightSidebarExplorerViewByWorktree[OLD]).toBeUndefined()
     expect(s.rightSidebarExplorerViewByWorktree[NEW]).toBe('search')
     expect(s.lastVisitedAtByWorktreeId[NEW]).toBe(123)
     expect(s.defaultTerminalTabsAppliedByWorktreeId[NEW]).toBe(true)
-    // The two maps absent from the purge list are still re-keyed.
     expect(s.recentlyClosedEditorTabsByWorktree[NEW]).toEqual([{ id: 'f1', worktreeId: NEW }])
     expect(s.remoteStatusesByWorktree[NEW]).toEqual({ ahead: 1 })
     expect(s.everActivatedWorktreeIds.has(NEW)).toBe(true)

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -764,7 +764,10 @@ describe('fetchWorktrees', () => {
 
     await store.getState().fetchWorktrees('repo-ssh')
 
-    expect(mockApi.worktrees.listDetected).toHaveBeenCalledWith({ repoId: 'repo-ssh' })
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledWith({
+      repoId: 'repo-ssh',
+      hostId: 'ssh:ssh-1'
+    })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
     // Why: SSH worktrees are fetched via local IPC but belong to the SSH host;
     // they must carry the repo's ssh host id, not the local default.
@@ -1736,6 +1739,66 @@ describe('createWorktree base status merge', () => {
     })
   })
 
+  it('passes the owner host through local create IPC payloads', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1'
+    })
+    store.setState({
+      repos: [
+        {
+          id: 'repo1',
+          path: '/path/repo1',
+          displayName: 'repo1',
+          badgeColor: '#000',
+          addedAt: 0
+        }
+      ]
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: wt })
+
+    await store
+      .getState()
+      .createWorktree(
+        'repo1',
+        'feature',
+        'origin/main',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { ownerHostId: 'local' }
+      )
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoId: 'repo1',
+        name: 'feature',
+        hostId: 'local'
+      })
+    )
+  })
+
   it('stamps the owning runtime host onto worktrees created on a remote runtime', async () => {
     const store = createTestStore()
     const created = makeWorktree({
@@ -1773,6 +1836,29 @@ describe('createWorktree base status merge', () => {
     expect(store.getState().worktreesByRepo['repo-remote']?.[0]).toEqual({
       ...created,
       hostId: 'runtime:env-1'
+    })
+  })
+
+  it('passes the owner host through local detected-list refreshes', async () => {
+    const store = createTestStore()
+    store.setState({
+      repos: [
+        {
+          id: 'repo1',
+          path: '/path/repo1',
+          displayName: 'repo1',
+          badgeColor: '#000',
+          addedAt: 0
+        }
+      ]
+    } as Partial<AppState>)
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(makeDetectedResult('repo1', []))
+
+    await store.getState().fetchWorktrees('repo1', { ownerHostId: 'local' })
+
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledWith({
+      repoId: 'repo1',
+      hostId: 'local'
     })
   })
 
@@ -2893,6 +2979,57 @@ describe('worktree remote runtime mutations', () => {
     })
     expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
     expect(store.getState().worktreesByRepo.repo1[0]?.comment).toBe('remote note')
+  })
+
+  it('refreshes the owner host when remote metadata persistence loses the selector', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      hostId: 'runtime:env-1'
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      repos: [
+        {
+          id: 'repo1',
+          path: '/local/repo1',
+          displayName: 'repo1',
+          badgeColor: '#000',
+          addedAt: 0
+        },
+        {
+          id: 'repo1',
+          path: '/remote/repo1',
+          displayName: 'repo1',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'runtime:env-1'
+        }
+      ],
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+    runtimeEnvironmentCall
+      .mockRejectedValueOnce(new Error('runtime_selector_not_found'))
+      .mockResolvedValueOnce({
+        id: 'rpc-refresh',
+        ok: true,
+        result: makeDetectedResult('repo1', [wt]),
+        _meta: { runtimeId: 'runtime-remote' }
+      })
+
+    await store.getState().updateWorktreeMeta(wt.id, { comment: 'remote note' })
+    await Promise.resolve()
+
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        selector: 'env-1',
+        method: 'worktree.detectedList'
+      })
+    )
+    expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
   })
 
   it('persists SSH-owned worktree metadata through local IPC even when a runtime is focused', async () => {
@@ -4371,7 +4508,10 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
         expect.objectContaining({ id: refreshedRemoteWorktree.id, hostId: 'runtime:env-1' })
       ])
     )
-    expect(mockApi.worktrees.listDetected).toHaveBeenCalledWith({ repoId: 'same-repo' })
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledWith({
+      repoId: 'same-repo',
+      hostId: 'local'
+    })
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'worktree.detectedList',

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -83,7 +83,7 @@ const mockApi = {
 // @ts-expect-error -- test shim
 globalThis.window = { api: mockApi }
 
-import { createWorktreeSlice } from './worktrees'
+import { createWorktreeSlice, WORKTREE_ID_KEYED_MAP_KEYS } from './worktrees'
 import type { PendingWorktreeCreation } from '@/lib/pending-worktree-creation'
 import { getHostedReviewCacheKey } from './hosted-review'
 import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from './github-cache-key'
@@ -93,6 +93,7 @@ import {
 } from '../../components/browser-pane/webview-registry'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
+import { makeWorktreeKey } from '../../../../shared/worktree-id'
 
 function resetRemoteRuntimeMocks() {
   clearRuntimeCompatibilityCacheForTests()
@@ -5001,6 +5002,34 @@ describe('setWorktreesPinnedAndReveal', () => {
 describe('migrateWorktreeIdentity', () => {
   const OLD = 'repo1::/ws/cunner'
   const NEW = 'repo1::/ws/worktree-creation-spinner'
+  const CANONICAL = makeWorktreeKey({ hostId: 'local', repoId: 'repo1', path: '/ws/cunner' })
+
+  function makeMigrationMapValue(
+    key: (typeof WORKTREE_ID_KEYED_MAP_KEYS)[number],
+    worktreeId: string
+  ): unknown {
+    switch (key) {
+      case 'worktreeLineageById':
+        return makeLineage({ worktreeId, parentWorktreeId: 'repo1::/ws/parent' })
+      case 'tabsByWorktree':
+        return [{ id: 'tab1', worktreeId }]
+      case 'browserTabsByWorktree':
+        return [{ id: 'browser1', worktreeId }]
+      case 'recentlyClosedBrowserTabsByWorktree':
+        return [
+          {
+            workspace: { id: 'closed-browser', worktreeId },
+            pages: [{ id: 'closed-page', worktreeId }]
+          }
+        ]
+      case 'unifiedTabsByWorktree':
+        return [{ id: 'unified1', worktreeId }]
+      case 'groupsByWorktree':
+        return [{ id: 'group1', worktreeId }]
+      default:
+        return { marker: key }
+    }
+  }
 
   it('re-keys worktree-scoped maps, pointers, the Set, and openFiles old->new', () => {
     const store = createTestStore()
@@ -5081,6 +5110,50 @@ describe('migrateWorktreeIdentity', () => {
     expect(s.sleepingAgentSessionsByPaneKey['tab1:leaf']?.worktreeId).toBe(NEW)
     // Tab-id-keyed state is untouched — the tab survives with the same id.
     expect(s.terminalLayoutsByTabId.tab1).toBeDefined()
+  })
+
+  it('moves every declared worktree-id keyed map and lineage relationship to the canonical id', () => {
+    const store = createTestStore()
+    const childId = 'repo1::/ws/child'
+    const mapState = Object.fromEntries(
+      WORKTREE_ID_KEYED_MAP_KEYS.map((key) => [key, { [OLD]: makeMigrationMapValue(key, OLD) }])
+    ) as Partial<AppState>
+
+    store.setState({
+      ...mapState,
+      worktreeLineageById: {
+        [OLD]: makeLineage({ worktreeId: OLD, parentWorktreeId: 'repo1::/ws/parent' }),
+        [childId]: makeLineage({ worktreeId: childId, parentWorktreeId: OLD })
+      },
+      workspaceLineageByChildKey: {
+        [worktreeWorkspaceKey(OLD)]: makeWorkspaceLineage({
+          childWorkspaceKey: worktreeWorkspaceKey(OLD),
+          parentWorkspaceKey: folderWorkspaceKey('folder-parent')
+        }),
+        [worktreeWorkspaceKey(childId)]: makeWorkspaceLineage({
+          childWorkspaceKey: worktreeWorkspaceKey(childId),
+          parentWorkspaceKey: worktreeWorkspaceKey(OLD)
+        })
+      }
+    } as unknown as Partial<AppState>)
+
+    store.getState().migrateWorktreeIdentity(OLD, CANONICAL)
+    const s = store.getState()
+
+    for (const key of WORKTREE_ID_KEYED_MAP_KEYS) {
+      const map = s[key] as Record<string, unknown>
+      expect(map[OLD], `${key} retained the legacy key`).toBeUndefined()
+      expect(map[CANONICAL], `${key} did not receive the canonical key`).toBeDefined()
+    }
+    expect(s.worktreeLineageById[CANONICAL]).toMatchObject({ worktreeId: CANONICAL })
+    expect(s.worktreeLineageById[childId]).toMatchObject({ parentWorktreeId: CANONICAL })
+    expect(s.workspaceLineageByChildKey[worktreeWorkspaceKey(OLD)]).toBeUndefined()
+    expect(s.workspaceLineageByChildKey[worktreeWorkspaceKey(CANONICAL)]).toMatchObject({
+      childWorkspaceKey: worktreeWorkspaceKey(CANONICAL)
+    })
+    expect(s.workspaceLineageByChildKey[worktreeWorkspaceKey(childId)]).toMatchObject({
+      parentWorkspaceKey: worktreeWorkspaceKey(CANONICAL)
+    })
   })
 
   it('is a no-op when the ids match', () => {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -5036,7 +5036,35 @@ describe('migrateWorktreeIdentity', () => {
         return [{ id: 'group1', worktreeId }]
       case 'recentlyClosedEditorTabsByWorktree':
         return [{ id: 'file1', worktreeId }]
-      default:
+      case 'deleteStateByWorktreeId':
+      case 'baseStatusByWorktreeId':
+      case 'remoteBranchConflictByWorktreeId':
+      case 'fileSearchStateByWorktree':
+      case 'activeBrowserTabIdByWorktree':
+      case 'activeFileIdByWorktree':
+      case 'activeTabTypeByWorktree':
+      case 'activeTabIdByWorktree':
+      case 'tabBarOrderByWorktree':
+      case 'pendingReconnectTabByWorktree':
+      case 'rightSidebarTabByWorktree':
+      case 'rightSidebarExplorerViewByWorktree':
+      case 'layoutByWorktree':
+      case 'activeGroupIdByWorktree':
+      case 'gitStatusByWorktree':
+      case 'gitStatusHeadByWorktree':
+      case 'gitStatusHugeByWorktree':
+      case 'gitIgnoredPathsByWorktree':
+      case 'gitConflictOperationByWorktree':
+      case 'trackedConflictPathsByWorktree':
+      case 'gitBranchChangesByWorktree':
+      case 'gitBranchCompareSummaryByWorktree':
+      case 'gitBranchCompareRequestKeyByWorktree':
+      case 'gitBranchCompareRequestStatusHeadByWorktree':
+      case 'remoteStatusesByWorktree':
+      case 'showDotfilesByWorktree':
+      case 'expandedDirs':
+      case 'lastVisitedAtByWorktreeId':
+      case 'defaultTerminalTabsAppliedByWorktreeId':
         return { marker: key }
     }
   }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -425,6 +425,7 @@ describe('fetchWorktrees', () => {
   it('keeps the last known worktree list when a refresh transiently returns empty', async () => {
     const store = createTestStore()
     const existing = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    const previousDetected = makeDetectedResult('repo1', [existing])
 
     mockApi.worktrees.listDetected.mockResolvedValueOnce(
       makeDetectedResult('repo1', [], {
@@ -432,11 +433,18 @@ describe('fetchWorktrees', () => {
         source: 'metadata-fallback'
       })
     )
-    store.setState({ worktreesByRepo: { repo1: [existing] }, sortEpoch: 7 } as Partial<AppState>)
+    store.setState({
+      worktreesByRepo: { repo1: [existing] },
+      detectedWorktreesByRepo: { repo1: previousDetected },
+      sortEpoch: 7
+    } as Partial<AppState>)
 
     const result = await store.getState().fetchWorktrees('repo1')
 
     expect(store.getState().worktreesByRepo.repo1).toEqual([existing])
+    expect(store.getState().detectedWorktreesByRepo.repo1.worktrees).toEqual(
+      previousDetected.worktrees
+    )
     expect(store.getState().sortEpoch).toBe(7)
     expect(result).toBe(false)
   })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -16,8 +16,7 @@ import type {
   WorktreeLineage,
   WorkspaceLineage,
   WorkspaceKey,
-  WorktreeMeta,
-  Repo
+  WorktreeMeta
 } from '../../../../shared/types'
 import type { RuntimeWorktreeListResult } from '../../../../shared/runtime-types'
 import {
@@ -450,6 +449,11 @@ function mergeDetectedWorktreesForHost(
   hostId: ExecutionHostId,
   options?: WorktreeHostMatchOptions
 ): DetectedWorktreeListResult {
+  if (!refreshed.authoritative && refreshed.worktrees.length === 0 && current) {
+    // Why: a non-authoritative empty scan means the backend could not prove the
+    // host is empty. Preserve cached rows instead of deleting display metadata.
+    return { ...refreshed, worktrees: current.worktrees }
+  }
   const refreshedForHost = refreshed.worktrees.map((worktree) => withRepoHostId(worktree, hostId))
   return {
     ...refreshed,
@@ -1770,7 +1774,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   fetchWorktrees: async (repoId, options) => {
     try {
       const ownerState = get()
-      const hostId = repoHostId(ownerState, repoId)
+      const hostId = repoHostId(ownerState, repoId, options?.ownerHostId)
       const settings = settingsForRepoOwner(ownerState, repoId, hostId)
       const detected = await listDetectedWorktreesForRepo(settings, repoId)
       if (options?.requireAuthoritative && !detected.authoritative) {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -797,7 +797,8 @@ function settingsForWorktreeOwner(
 
 async function listDetectedWorktreesForRepo(
   settings: AppState['settings'],
-  repoId: string
+  repoId: string,
+  ownerHostId?: ExecutionHostId
 ): Promise<DetectedWorktreeListResult> {
   const target = getActiveRuntimeTarget(settings)
   if (target.kind === 'local') {
@@ -805,9 +806,12 @@ async function listDetectedWorktreesForRepo(
       listDetected?: typeof window.api.worktrees.listDetected
     }
     if (typeof worktreesApi.listDetected === 'function') {
-      return worktreesApi.listDetected({ repoId })
+      return worktreesApi.listDetected({ repoId, ...(ownerHostId ? { hostId: ownerHostId } : {}) })
     }
-    const legacyWorktrees = await worktreesApi.list({ repoId })
+    const legacyWorktrees = await worktreesApi.list({
+      repoId,
+      ...(ownerHostId ? { hostId: ownerHostId } : {})
+    })
     return toLegacyDetectedWorktreeResult(repoId, { worktrees: legacyWorktrees })
   }
   try {
@@ -1020,6 +1024,18 @@ function getWorktreeHostId(
   }
   const repo = findRepoForHost(state.repos, repoId, { settings: state.settings })
   return repo ? getRepoExecutionHostId(repo) : null
+}
+
+function refreshWorktreeOwner(
+  state: Pick<
+    AppState,
+    'repos' | 'settings' | 'worktreesByRepo' | 'detectedWorktreesByRepo' | 'fetchWorktrees'
+  >,
+  worktreeId: string
+): void {
+  const repoId = getRepoIdFromWorktreeId(worktreeId)
+  const ownerHostId = getWorktreeHostId(state, worktreeId)
+  void state.fetchWorktrees(repoId, ownerHostId ? { ownerHostId } : undefined)
 }
 
 function mergeLineageForHost(
@@ -1758,7 +1774,12 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
   fetchDetectedWorktrees: async (repoId) => {
     try {
-      const result = await listDetectedWorktreesForRepo(settingsForRepoOwner(get(), repoId), repoId)
+      const hostId = repoHostId(get(), repoId)
+      const result = await listDetectedWorktreesForRepo(
+        settingsForRepoOwner(get(), repoId, hostId),
+        repoId,
+        hostId
+      )
       set((s) =>
         areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[repoId], result)
           ? s
@@ -1776,7 +1797,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const ownerState = get()
       const hostId = repoHostId(ownerState, repoId, options?.ownerHostId)
       const settings = settingsForRepoOwner(ownerState, repoId, hostId)
-      const detected = await listDetectedWorktreesForRepo(settings, repoId)
+      const detected = await listDetectedWorktreesForRepo(settings, repoId, hostId)
       if (options?.requireAuthoritative && !detected.authoritative) {
         return false
       }
@@ -1901,7 +1922,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       await mapReposForWorktreeRefresh(repos, async (r) => {
         const hostId = getRepoExecutionHostId(r)
         const settings = settingsForKnownRepoOwner(get().settings, r)
-        const detected = await listDetectedWorktreesForRepo(settings, r.id)
+        const detected = await listDetectedWorktreesForRepo(settings, r.id, hostId)
         const worktrees = toVisibleWorktrees(detected, hostId)
         set((s) => {
           const matchOptions = worktreeHostMatchOptions(s, r.id, hostId)
@@ -1959,7 +1980,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           const hostId = getRepoExecutionHostId(r)
           const detected = await listDetectedWorktreesForRepo(
             settingsForKnownRepoOwner(get().settings, r),
-            r.id
+            r.id,
+            hostId
           )
           const list = toVisibleWorktrees(detected, hostId)
           const current = get().worktreesByRepo[r.id]
@@ -2261,9 +2283,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ...(linkedGiteaPR !== undefined ? { linkedGiteaPR } : {}),
             ...(startup ? { startup } : {}),
             ...(creationId ? { creationId } : {}),
+            ...(options?.ownerHostId ? { hostId: options.ownerHostId } : {}),
             ...(automationProvenanceRequest ? { automationProvenanceRequest } : {})
           }
-          const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), repoId))
+          const ownerHostId = options?.ownerHostId
+          const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), repoId, ownerHostId))
           const result =
             target.kind === 'local'
               ? await window.api.worktrees.create(createArgs)
@@ -2325,7 +2349,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           // then produces a duplicate entry in worktreesByRepo, which gives
           // React duplicate keys and can corrupt terminal DOM containers.
           set((s) => {
-            const createdWorktree = withRepoHostId(result.worktree, repoHostId(s, repoId))
+            const createdWorktree = withRepoHostId(
+              result.worktree,
+              repoHostId(s, repoId, ownerHostId)
+            )
             const current = s.worktreesByRepo[repoId] ?? []
             const alreadyPresent = current.some((w) => w.id === createdWorktree.id)
             const nextWorktrees = alreadyPresent
@@ -3069,11 +3096,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       }
     } catch (err) {
       if (isRuntimeSelectorNotFoundError(err)) {
-        void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+        refreshWorktreeOwner(get(), worktreeId)
         return
       }
       console.error('Failed to update worktree meta:', err)
-      void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+      refreshWorktreeOwner(get(), worktreeId)
     }
   },
 
@@ -3147,11 +3174,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           )
         } catch (err) {
           if (isRuntimeSelectorNotFoundError(err)) {
-            void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+            refreshWorktreeOwner(get(), worktreeId)
             return
           }
           console.error('Failed to update worktree meta:', err)
-          void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+          refreshWorktreeOwner(get(), worktreeId)
         }
       })
     )
@@ -3232,11 +3259,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       lastActivityAt: now
     }).catch((err) => {
       if (isRuntimeSelectorNotFoundError(err)) {
-        void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+        refreshWorktreeOwner(get(), worktreeId)
         return
       }
       console.error('Failed to persist unread worktree state:', err)
-      void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+      refreshWorktreeOwner(get(), worktreeId)
     })
   },
 
@@ -3342,11 +3369,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       isUnread: false
     }).catch((err) => {
       if (isRuntimeSelectorNotFoundError(err)) {
-        void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+        refreshWorktreeOwner(get(), worktreeId)
         return
       }
       console.error('Failed to persist cleared unread worktree state:', err)
-      void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+      refreshWorktreeOwner(get(), worktreeId)
     })
   },
 
@@ -3403,7 +3430,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         return
       }
       console.error('Failed to persist worktree activity timestamp:', err)
-      void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+      refreshWorktreeOwner(get(), worktreeId)
     })
   },
 
@@ -3825,11 +3852,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         updates
       ).catch((err) => {
         if (isRuntimeSelectorNotFoundError(err)) {
-          void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+          refreshWorktreeOwner(get(), worktreeId)
           return
         }
         console.error('Failed to persist worktree activation state:', err)
-        void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+        refreshWorktreeOwner(get(), worktreeId)
       })
     }
   },

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -15,7 +15,9 @@ import type {
   RemoveWorktreeResult,
   WorktreeLineage,
   WorkspaceLineage,
-  WorktreeMeta
+  WorkspaceKey,
+  WorktreeMeta,
+  Repo
 } from '../../../../shared/types'
 import type { RuntimeWorktreeListResult } from '../../../../shared/runtime-types'
 import {
@@ -1247,7 +1249,7 @@ function encodePushTargetClearForRuntimeRpc(
 // new `*ByWorktree` map is not silently missed when a worktree id changes. Maps keyed
 // by tab id or file id are deliberately NOT here — tabs and files keep their ids across
 // a worktree rename.
-const WORKTREE_ID_KEYED_MAP_KEYS = [
+export const WORKTREE_ID_KEYED_MAP_KEYS = [
   'worktreeLineageById',
   'tabsByWorktree',
   'deleteStateByWorktreeId',
@@ -1283,6 +1285,36 @@ const WORKTREE_ID_KEYED_MAP_KEYS = [
   'defaultTerminalTabsAppliedByWorktreeId'
 ] as const satisfies readonly (keyof AppState)[]
 
+function migrateWorkspaceLineageForWorktreeIdentity(
+  lineageByChildKey: Record<string, WorkspaceLineage>,
+  oldWorkspaceKey: WorkspaceKey,
+  newWorkspaceKey: WorkspaceKey
+): Record<string, WorkspaceLineage> {
+  let changed = false
+  const next: Record<string, WorkspaceLineage> = {}
+  for (const [childKey, lineage] of Object.entries(lineageByChildKey)) {
+    const nextChildKey = childKey === oldWorkspaceKey ? newWorkspaceKey : childKey
+    const nextLineage =
+      lineage.childWorkspaceKey === oldWorkspaceKey ||
+      lineage.parentWorkspaceKey === oldWorkspaceKey
+        ? {
+            ...lineage,
+            childWorkspaceKey:
+              lineage.childWorkspaceKey === oldWorkspaceKey
+                ? newWorkspaceKey
+                : lineage.childWorkspaceKey,
+            parentWorkspaceKey:
+              lineage.parentWorkspaceKey === oldWorkspaceKey
+                ? newWorkspaceKey
+                : lineage.parentWorkspaceKey
+          }
+        : lineage
+    changed = changed || nextChildKey !== childKey || nextLineage !== lineage
+    next[nextChildKey] = nextLineage
+  }
+  return changed ? next : lineageByChildKey
+}
+
 /**
  * Re-key every worktree-id-keyed map (plus the Set, openFiles[].worktreeId, and
  * the active/renaming pointers) from `oldWorktreeId` to `newWorktreeId` after a
@@ -1301,6 +1333,8 @@ function buildWorktreeRenameState(
   if (oldWorktreeId === newWorktreeId) {
     return {}
   }
+  const oldWorkspaceKey = worktreeWorkspaceKey(oldWorktreeId)
+  const newWorkspaceKey = worktreeWorkspaceKey(newWorktreeId)
   const renamed: Record<string, unknown> = {}
   const renameKey = <T>(
     key: keyof AppState,
@@ -1317,7 +1351,14 @@ function buildWorktreeRenameState(
   }
   const withNewWorktreeId = <T extends { worktreeId: string }>(value: T): T =>
     value.worktreeId === oldWorktreeId ? { ...value, worktreeId: newWorktreeId } : value
+  const withNewLineageWorktreeIds = (lineage: WorktreeLineage): WorktreeLineage => ({
+    ...lineage,
+    worktreeId: lineage.worktreeId === oldWorktreeId ? newWorktreeId : lineage.worktreeId,
+    parentWorktreeId:
+      lineage.parentWorktreeId === oldWorktreeId ? newWorktreeId : lineage.parentWorktreeId
+  })
   const renameValueByKey: Partial<Record<(typeof WORKTREE_ID_KEYED_MAP_KEYS)[number], unknown>> = {
+    worktreeLineageById: withNewLineageWorktreeIds,
     tabsByWorktree: (tabs: { worktreeId: string }[]) => tabs.map(withNewWorktreeId),
     browserTabsByWorktree: (workspaces: { worktreeId: string }[]) =>
       workspaces.map(withNewWorktreeId),
@@ -1335,6 +1376,28 @@ function buildWorktreeRenameState(
   for (const key of WORKTREE_ID_KEYED_MAP_KEYS) {
     renameKey(key, renameValueByKey[key] as ((value: unknown) => unknown) | undefined)
   }
+  const currentLineage =
+    (renamed.worktreeLineageById as Record<string, WorktreeLineage> | undefined) ??
+    s.worktreeLineageById
+  const lineageWithUpdatedParents = Object.values(currentLineage).some(
+    (lineage) => lineage.worktreeId === oldWorktreeId || lineage.parentWorktreeId === oldWorktreeId
+  )
+    ? Object.fromEntries(
+        Object.entries(currentLineage).map(([worktreeId, lineage]) => [
+          worktreeId,
+          withNewLineageWorktreeIds(lineage)
+        ])
+      )
+    : currentLineage
+  if (lineageWithUpdatedParents !== s.worktreeLineageById) {
+    renamed.worktreeLineageById = lineageWithUpdatedParents
+  }
+  const currentWorkspaceLineage = s.workspaceLineageByChildKey ?? {}
+  const workspaceLineageByChildKey = migrateWorkspaceLineageForWorktreeIdentity(
+    currentWorkspaceLineage,
+    oldWorkspaceKey,
+    newWorkspaceKey
+  )
   // Re-key these on rename so a renamed worktree keeps its editor-undo + push/pull
   // state. (Both removal paths — buildWorktreePurgeState and the single
   // removeWorktree reducer — now also purge them on removal.)
@@ -1406,6 +1469,9 @@ function buildWorktreeRenameState(
       : {}),
     ...(sleepingAgentSessionsByPaneKey !== s.sleepingAgentSessionsByPaneKey
       ? { sleepingAgentSessionsByPaneKey }
+      : {}),
+    ...(workspaceLineageByChildKey !== currentWorkspaceLineage
+      ? { workspaceLineageByChildKey }
       : {}),
     ...(s.activeWorktreeId === oldWorktreeId ? { activeWorktreeId: newWorktreeId } : {}),
     // The active workspace key derives from the worktree id, so keep it in sync when the active worktree is renamed.

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1272,6 +1272,7 @@ export const WORKTREE_ID_KEYED_MAP_KEYS = [
   'activeGroupIdByWorktree',
   'gitStatusByWorktree',
   'gitStatusHeadByWorktree',
+  'gitStatusHugeByWorktree',
   'gitIgnoredPathsByWorktree',
   'gitConflictOperationByWorktree',
   'trackedConflictPathsByWorktree',
@@ -1279,6 +1280,8 @@ export const WORKTREE_ID_KEYED_MAP_KEYS = [
   'gitBranchCompareSummaryByWorktree',
   'gitBranchCompareRequestKeyByWorktree',
   'gitBranchCompareRequestStatusHeadByWorktree',
+  'recentlyClosedEditorTabsByWorktree',
+  'remoteStatusesByWorktree',
   'showDotfilesByWorktree',
   'expandedDirs',
   'lastVisitedAtByWorktreeId',
@@ -1371,7 +1374,9 @@ function buildWorktreeRenameState(
         pages: snapshot.pages.map(withNewWorktreeId)
       })),
     unifiedTabsByWorktree: (tabs: { worktreeId: string }[]) => tabs.map(withNewWorktreeId),
-    groupsByWorktree: (groups: { worktreeId: string }[]) => groups.map(withNewWorktreeId)
+    groupsByWorktree: (groups: { worktreeId: string }[]) => groups.map(withNewWorktreeId),
+    recentlyClosedEditorTabsByWorktree: (files: { worktreeId: string }[]) =>
+      files.map(withNewWorktreeId)
   }
   for (const key of WORKTREE_ID_KEYED_MAP_KEYS) {
     renameKey(key, renameValueByKey[key] as ((value: unknown) => unknown) | undefined)
@@ -1398,14 +1403,6 @@ function buildWorktreeRenameState(
     oldWorkspaceKey,
     newWorkspaceKey
   )
-  // Re-key these on rename so a renamed worktree keeps its editor-undo + push/pull
-  // state. (Both removal paths — buildWorktreePurgeState and the single
-  // removeWorktree reducer — now also purge them on removal.)
-  renameKey('recentlyClosedEditorTabsByWorktree', (files: { worktreeId: string }[]) =>
-    files.map(withNewWorktreeId)
-  )
-  renameKey('remoteStatusesByWorktree')
-
   const openFiles = s.openFiles?.some((f) => f.worktreeId === oldWorktreeId)
     ? s.openFiles.map((f) =>
         f.worktreeId === oldWorktreeId ? { ...f, worktreeId: newWorktreeId } : f

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -198,6 +198,27 @@ describe('project host setup projection', () => {
       projectHostSetupId: 'remote-repo'
     })
   })
+
+  it('derives workspace ownership metadata from the matching repo host setup', () => {
+    const localRepo = repo({
+      id: 'same-repo',
+      path: '/Users/alice/orca',
+      displayName: 'orca'
+    })
+    const remoteRepo = repo({
+      id: 'same-repo',
+      path: '/home/alice/orca',
+      displayName: 'orca remote',
+      connectionId: 'openclaw 2'
+    })
+    const projection = projectHostSetupProjectionFromRepos([localRepo, remoteRepo])
+
+    expect(getProjectHostSetupWorktreeMeta(projection.setups, remoteRepo)).toEqual({
+      projectId: 'repo:same-repo',
+      hostId: 'ssh:openclaw%202',
+      projectHostSetupId: 'same-repo'
+    })
+  })
 })
 
 describe('isGitHubBackedRepo', () => {

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -149,8 +149,9 @@ export function getProjectHostSetupForRepo(
   setups: readonly ProjectHostSetup[],
   repo: Repo
 ): ProjectHostSetup {
+  const hostId = getRepoExecutionHostId(repo)
   return (
-    setups.find((setup) => setup.repoId === repo.id) ??
+    setups.find((setup) => setup.repoId === repo.id && setup.hostId === hostId) ??
     projectHostSetupProjectionFromRepos([repo]).setups[0]
   )
 }

--- a/src/shared/pty-session-id-format.ts
+++ b/src/shared/pty-session-id-format.ts
@@ -15,7 +15,8 @@ import { normalizeExecutionHostId } from './execution-host'
 
 export const PTY_SESSION_ID_SEPARATOR = '@@'
 export const WORKTREE_ID_SEPARATOR = '::'
-const WORKTREE_KEY_PREFIX = 'orca-worktree://v1?'
+const WORKTREE_KEY_SCHEME = 'orca-worktree://'
+const WORKTREE_KEY_PREFIX = `${WORKTREE_KEY_SCHEME}v1?`
 
 function isCanonicalWorktreeKey(candidate: string): boolean {
   if (!candidate.startsWith(WORKTREE_KEY_PREFIX)) {
@@ -55,6 +56,9 @@ export function parsePtySessionId(sessionId: string): { worktreeId: string | nul
   const candidate = sessionId.slice(0, idx)
   if (isCanonicalWorktreeKey(candidate)) {
     return { worktreeId: candidate }
+  }
+  if (candidate.startsWith(WORKTREE_KEY_SCHEME)) {
+    return { worktreeId: null }
   }
   // Why: require non-empty halves on both sides of `::` so degenerate
   // ids like `::@@…`, `repo::@@…`, or `::path@@…` don't synthesize a

--- a/src/shared/pty-session-id-format.ts
+++ b/src/shared/pty-session-id-format.ts
@@ -11,8 +11,31 @@
  * can import.
  */
 
+import { normalizeExecutionHostId } from './execution-host'
+
 export const PTY_SESSION_ID_SEPARATOR = '@@'
 export const WORKTREE_ID_SEPARATOR = '::'
+const WORKTREE_KEY_PREFIX = 'orca-worktree://v1?'
+
+function isCanonicalWorktreeKey(candidate: string): boolean {
+  if (!candidate.startsWith(WORKTREE_KEY_PREFIX)) {
+    return false
+  }
+  const params = new URLSearchParams(candidate.slice(WORKTREE_KEY_PREFIX.length))
+  const keys = [...params.keys()]
+  return (
+    keys.length === 3 &&
+    keys[0] === 'hostId' &&
+    keys[1] === 'repoId' &&
+    keys[2] === 'path' &&
+    params.getAll('hostId').length === 1 &&
+    params.getAll('repoId').length === 1 &&
+    params.getAll('path').length === 1 &&
+    normalizeExecutionHostId(params.get('hostId')) !== null &&
+    (params.get('repoId')?.length ?? 0) > 0 &&
+    (params.get('path')?.length ?? 0) > 0
+  )
+}
 
 /**
  * Recover the owning worktreeId from a minted session id.
@@ -30,6 +53,9 @@ export function parsePtySessionId(sessionId: string): { worktreeId: string | nul
     return { worktreeId: null }
   }
   const candidate = sessionId.slice(0, idx)
+  if (isCanonicalWorktreeKey(candidate)) {
+    return { worktreeId: candidate }
+  }
   // Why: require non-empty halves on both sides of `::` so degenerate
   // ids like `::@@…`, `repo::@@…`, or `::path@@…` don't synthesize a
   // phantom worktreeId for memory attribution.

--- a/src/shared/pty-session-id-format.ts
+++ b/src/shared/pty-session-id-format.ts
@@ -11,31 +11,13 @@
  * can import.
  */
 
-import { normalizeExecutionHostId } from './execution-host'
+import { parseStrictWorktreeKey, WORKTREE_KEY_SCHEME } from './worktree-key-format'
 
 export const PTY_SESSION_ID_SEPARATOR = '@@'
 export const WORKTREE_ID_SEPARATOR = '::'
-const WORKTREE_KEY_SCHEME = 'orca-worktree://'
-const WORKTREE_KEY_PREFIX = `${WORKTREE_KEY_SCHEME}v1?`
 
 function isCanonicalWorktreeKey(candidate: string): boolean {
-  if (!candidate.startsWith(WORKTREE_KEY_PREFIX)) {
-    return false
-  }
-  const params = new URLSearchParams(candidate.slice(WORKTREE_KEY_PREFIX.length))
-  const keys = [...params.keys()]
-  return (
-    keys.length === 3 &&
-    keys[0] === 'hostId' &&
-    keys[1] === 'repoId' &&
-    keys[2] === 'path' &&
-    params.getAll('hostId').length === 1 &&
-    params.getAll('repoId').length === 1 &&
-    params.getAll('path').length === 1 &&
-    normalizeExecutionHostId(params.get('hostId')) !== null &&
-    (params.get('repoId')?.length ?? 0) > 0 &&
-    (params.get('path')?.length ?? 0) > 0
-  )
+  return parseStrictWorktreeKey(candidate) !== null
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -184,6 +184,7 @@ export type ProjectHostSetupCloneArgs = {
 
 export type ProjectHostSetupUpdateArgs = {
   setupId: string
+  hostId?: ExecutionHostId
   updates: Partial<
     Pick<
       ProjectHostSetup,
@@ -200,6 +201,7 @@ export type ProjectHostSetupUpdateArgs = {
 
 export type ProjectHostSetupDeleteArgs = {
   setupId: string
+  hostId?: ExecutionHostId
 }
 
 export type ProjectHostSetupResult = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1947,6 +1947,8 @@ export type SparsePreset = {
 
 export type CreateWorktreeArgs = {
   repoId: string
+  /** Disambiguates same-id repos across local/SSH/runtime hosts. */
+  hostId?: ExecutionHostId
   name: string
   /** Optional user-facing label to persist separately from the git-safe
    *  branch/path seed. Used when a workspace is created from a GitHub or

--- a/src/shared/worktree-id.test.ts
+++ b/src/shared/worktree-id.test.ts
@@ -114,6 +114,11 @@ describe('parseWorktreeKey', () => {
     expect(parseWorktreeKey('orca-worktree://v2?hostId=local&repoId=repo&path=%2Fx')).toBeNull()
     expect(parseWorktreeKey('orca-worktree://v1?hostId=bogus&repoId=repo&path=%2Fx')).toBeNull()
   })
+
+  it('rejects malformed percent encoding', () => {
+    expect(parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo%ZZ&path=%2Fx')).toBeNull()
+    expect(parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo&path=%E0%A4%A')).toBeNull()
+  })
 })
 
 describe('parseAnyWorktreeId', () => {

--- a/src/shared/worktree-id.test.ts
+++ b/src/shared/worktree-id.test.ts
@@ -132,6 +132,15 @@ describe('parseAnyWorktreeId', () => {
       worktreePath: '/abs/path'
     })
   })
+
+  it('rejects malformed canonical-looking ids instead of parsing them as legacy', () => {
+    expect(
+      parseAnyWorktreeId('orca-worktree://v1?hostId=bogus&repoId=repo::x&path=%2Fy')
+    ).toBeNull()
+    expect(
+      parseAnyWorktreeId('orca-worktree://v2?hostId=local&repoId=repo::x&path=%2Fy')
+    ).toBeNull()
+  })
 })
 
 describe('isLegacyWorktreeId', () => {
@@ -143,6 +152,12 @@ describe('isLegacyWorktreeId', () => {
       )
     ).toBe(false)
     expect(isLegacyWorktreeId('repo-123')).toBe(false)
+    expect(isLegacyWorktreeId('orca-worktree://v1?hostId=bogus&repoId=repo::x&path=%2Fy')).toBe(
+      false
+    )
+    expect(isLegacyWorktreeId('orca-worktree://v2?hostId=local&repoId=repo::x&path=%2Fy')).toBe(
+      false
+    )
   })
 })
 
@@ -162,6 +177,11 @@ describe('splitWorktreeId', () => {
 
   it('returns null when there is no separator', () => {
     expect(splitWorktreeId('just-a-repo-id')).toBeNull()
+  })
+
+  it('rejects malformed canonical-looking ids instead of splitting on legacy separators', () => {
+    expect(splitWorktreeId('orca-worktree://v1?hostId=bogus&repoId=repo::x&path=%2Fy')).toBeNull()
+    expect(splitWorktreeId('orca-worktree://v2?hostId=local&repoId=repo::x&path=%2Fy')).toBeNull()
   })
 
   it('returns null for an empty input', () => {

--- a/src/shared/worktree-id.test.ts
+++ b/src/shared/worktree-id.test.ts
@@ -119,6 +119,13 @@ describe('parseWorktreeKey', () => {
     expect(parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo%ZZ&path=%2Fx')).toBeNull()
     expect(parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo&path=%E0%A4%A')).toBeNull()
   })
+
+  it('rejects non-canonical unescaped key parts', () => {
+    expect(
+      parseWorktreeKey('orca-worktree://v1?hostId=runtime:gpu&repoId=repo&path=%2Fx')
+    ).toBeNull()
+    expect(parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo&path=/x')).toBeNull()
+  })
 })
 
 describe('parseAnyWorktreeId', () => {

--- a/src/shared/worktree-id.test.ts
+++ b/src/shared/worktree-id.test.ts
@@ -3,6 +3,11 @@ import {
   WORKTREE_ID_SEPARATOR,
   getRepoIdFromWorktreeId,
   getWorktreePathBasenameFromId,
+  isLegacyWorktreeId,
+  makeRepoWorktreeKey,
+  makeWorktreeKey,
+  parseAnyWorktreeId,
+  parseWorktreeKey,
   splitWorktreeId,
   splitWorktreeIdForFilesystem
 } from './worktree-id'
@@ -16,6 +21,14 @@ describe('WORKTREE_ID_SEPARATOR', () => {
 describe('getRepoIdFromWorktreeId', () => {
   it('returns the repo id for a canonical worktree id', () => {
     expect(getRepoIdFromWorktreeId('repo-123::/abs/path')).toBe('repo-123')
+  })
+
+  it('returns the repo id for a host-qualified worktree key', () => {
+    expect(
+      getRepoIdFromWorktreeId(
+        makeWorktreeKey({ hostId: 'runtime:gpu', repoId: 'repo-123', path: '/abs/path' })
+      )
+    ).toBe('repo-123')
   })
 
   it('returns the whole input when there is no separator', () => {
@@ -43,12 +56,108 @@ describe('getRepoIdFromWorktreeId', () => {
   })
 })
 
+describe('makeWorktreeKey', () => {
+  it('creates a canonical host-qualified key with stable parameter order', () => {
+    expect(
+      makeWorktreeKey({ hostId: 'local', repoId: 'repo-123', path: '/Users/alice/orca' })
+    ).toBe('orca-worktree://v1?hostId=local&repoId=repo-123&path=%2FUsers%2Falice%2Forca')
+  })
+
+  it('encodes host ids, repo ids, POSIX paths, and Windows paths without delimiter collisions', () => {
+    const key = makeWorktreeKey({
+      hostId: 'ssh:openclaw%202',
+      repoId: 'repo::with spaces',
+      path: 'C:\\Users\\Alice\\repo::workspace'
+    })
+
+    expect(parseWorktreeKey(key)).toEqual({
+      hostId: 'ssh:openclaw%202',
+      repoId: 'repo::with spaces',
+      worktreePath: 'C:\\Users\\Alice\\repo::workspace'
+    })
+  })
+
+  it('builds keys from repo execution ownership', () => {
+    expect(
+      makeRepoWorktreeKey(
+        { id: 'repo-123', connectionId: null, executionHostId: 'runtime:gpu' },
+        '/srv/repo'
+      )
+    ).toBe('orca-worktree://v1?hostId=runtime%3Agpu&repoId=repo-123&path=%2Fsrv%2Frepo')
+  })
+})
+
+describe('parseWorktreeKey', () => {
+  it('parses a valid canonical key', () => {
+    expect(
+      parseWorktreeKey('orca-worktree://v1?hostId=runtime%3Agpu&repoId=repo-123&path=%2Fsrv%2Frepo')
+    ).toEqual({ hostId: 'runtime:gpu', repoId: 'repo-123', worktreePath: '/srv/repo' })
+  })
+
+  it('rejects legacy ids', () => {
+    expect(parseWorktreeKey('repo-123::/abs/path')).toBeNull()
+  })
+
+  it('rejects missing, empty, duplicate, reordered, and unknown fields', () => {
+    expect(parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo')).toBeNull()
+    expect(parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo&path=')).toBeNull()
+    expect(
+      parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo&path=%2Fx&path=%2Fy')
+    ).toBeNull()
+    expect(parseWorktreeKey('orca-worktree://v1?repoId=repo&hostId=local&path=%2Fx')).toBeNull()
+    expect(
+      parseWorktreeKey('orca-worktree://v1?hostId=local&repoId=repo&path=%2Fx&extra=1')
+    ).toBeNull()
+  })
+
+  it('rejects unknown versions and invalid hosts', () => {
+    expect(parseWorktreeKey('orca-worktree://v2?hostId=local&repoId=repo&path=%2Fx')).toBeNull()
+    expect(parseWorktreeKey('orca-worktree://v1?hostId=bogus&repoId=repo&path=%2Fx')).toBeNull()
+  })
+})
+
+describe('parseAnyWorktreeId', () => {
+  it('distinguishes canonical and legacy ids', () => {
+    const canonical = makeWorktreeKey({ hostId: 'local', repoId: 'repo-123', path: '/abs/path' })
+
+    expect(parseAnyWorktreeId(canonical)).toEqual({
+      format: 'canonical',
+      hostId: 'local',
+      repoId: 'repo-123',
+      worktreePath: '/abs/path'
+    })
+    expect(parseAnyWorktreeId('repo-123::/abs/path')).toEqual({
+      format: 'legacy',
+      repoId: 'repo-123',
+      worktreePath: '/abs/path'
+    })
+  })
+})
+
+describe('isLegacyWorktreeId', () => {
+  it('returns true only for legacy ids', () => {
+    expect(isLegacyWorktreeId('repo-123::/abs/path')).toBe(true)
+    expect(
+      isLegacyWorktreeId(
+        makeWorktreeKey({ hostId: 'local', repoId: 'repo-123', path: '/abs/path' })
+      )
+    ).toBe(false)
+    expect(isLegacyWorktreeId('repo-123')).toBe(false)
+  })
+})
+
 describe('splitWorktreeId', () => {
   it('splits a canonical worktree id into repo id and path', () => {
     expect(splitWorktreeId('repo-123::/abs/path')).toEqual({
       repoId: 'repo-123',
       worktreePath: '/abs/path'
     })
+  })
+
+  it('splits a host-qualified worktree key into host, repo id, and path', () => {
+    expect(
+      splitWorktreeId(makeWorktreeKey({ hostId: 'local', repoId: 'repo-123', path: '/abs/path' }))
+    ).toEqual({ hostId: 'local', repoId: 'repo-123', worktreePath: '/abs/path' })
   })
 
   it('returns null when there is no separator', () => {
@@ -90,6 +199,18 @@ describe('splitWorktreeIdForFilesystem', () => {
     expect(
       splitWorktreeIdForFilesystem('repo::/folder::workspace:123e4567-e89b-12d3-a456-426614174000')
     ).toEqual({ repoId: 'repo', worktreePath: '/folder' })
+  })
+
+  it('strips folder workspace instance suffixes from host-qualified keys', () => {
+    expect(
+      splitWorktreeIdForFilesystem(
+        makeWorktreeKey({
+          hostId: 'local',
+          repoId: 'repo',
+          path: '/folder::workspace:123e4567-e89b-12d3-a456-426614174000'
+        })
+      )
+    ).toEqual({ hostId: 'local', repoId: 'repo', worktreePath: '/folder' })
   })
 })
 

--- a/src/shared/worktree-id.ts
+++ b/src/shared/worktree-id.ts
@@ -35,13 +35,13 @@ function encodeKeyPart(value: string): string {
   return encodeURIComponent(value)
 }
 
-function readSingleParam(params: URLSearchParams, key: string): string | null {
-  const values = params.getAll(key)
-  if (values.length !== 1) {
+function decodeStrictKeyPart(value: string): string | null {
+  try {
+    const decoded = decodeURIComponent(value)
+    return decoded.length > 0 ? decoded : null
+  } catch {
     return null
   }
-  const [value] = values
-  return value.length > 0 ? value : null
 }
 
 export function makeLegacyWorktreeId(repoId: string, path: string): string {
@@ -91,14 +91,30 @@ export function parseWorktreeKey(worktreeId: string): ParsedCanonicalWorktreeKey
     return null
   }
   const query = worktreeId.slice(WORKTREE_KEY_PREFIX.length)
-  const params = new URLSearchParams(query)
-  const keys = [...params.keys()]
-  if (keys.length !== 3 || keys[0] !== 'hostId' || keys[1] !== 'repoId' || keys[2] !== 'path') {
+  const parts = query.split('&')
+  if (parts.length !== 3) {
     return null
   }
-  const rawHostId = readSingleParam(params, 'hostId')
-  const rawRepoId = readSingleParam(params, 'repoId')
-  const rawPath = readSingleParam(params, 'path')
+  const expectedKeys = ['hostId', 'repoId', 'path'] as const
+  const values: Partial<Record<(typeof expectedKeys)[number], string>> = {}
+  for (const [index, part] of parts.entries()) {
+    const separatorIndex = part.indexOf('=')
+    if (separatorIndex <= 0) {
+      return null
+    }
+    const key = part.slice(0, separatorIndex)
+    if (key !== expectedKeys[index]) {
+      return null
+    }
+    const decoded = decodeStrictKeyPart(part.slice(separatorIndex + 1))
+    if (decoded === null) {
+      return null
+    }
+    values[key] = decoded
+  }
+  const rawHostId = values.hostId
+  const rawRepoId = values.repoId
+  const rawPath = values.path
   if (!rawHostId || !rawRepoId || !rawPath) {
     return null
   }

--- a/src/shared/worktree-id.ts
+++ b/src/shared/worktree-id.ts
@@ -1,23 +1,136 @@
 import { WORKTREE_ID_SEPARATOR } from './pty-session-id-format'
+import {
+  getRepoExecutionHostId,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from './execution-host'
+import type { Repo } from './types'
 
 export { WORKTREE_ID_SEPARATOR } from './pty-session-id-format'
 
 export type ParsedWorktreeId = {
   repoId: string
   worktreePath: string
+  hostId?: ExecutionHostId
 }
 
+export type ParsedCanonicalWorktreeKey = {
+  hostId: ExecutionHostId
+  repoId: string
+  worktreePath: string
+}
+
+export type ParsedAnyWorktreeId =
+  | ({ format: 'canonical' } & ParsedCanonicalWorktreeKey)
+  | ({ format: 'legacy' } & ParsedWorktreeId)
+
 export const FOLDER_WORKSPACE_INSTANCE_SEPARATOR = '::workspace:'
+const WORKTREE_KEY_PREFIX = 'orca-worktree://v1?'
 const FOLDER_WORKSPACE_INSTANCE_SUFFIX = new RegExp(
   `${FOLDER_WORKSPACE_INSTANCE_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[0-9a-f-]{36}$`
 )
 
+function encodeKeyPart(value: string): string {
+  return encodeURIComponent(value)
+}
+
+function readSingleParam(params: URLSearchParams, key: string): string | null {
+  const values = params.getAll(key)
+  if (values.length !== 1) {
+    return null
+  }
+  const [value] = values
+  return value.length > 0 ? value : null
+}
+
+export function makeLegacyWorktreeId(repoId: string, path: string): string {
+  return `${repoId}${WORKTREE_ID_SEPARATOR}${path}`
+}
+
+export function makeWorktreeKey(input: {
+  hostId: ExecutionHostId
+  repoId: string
+  path: string
+}): string {
+  return `${WORKTREE_KEY_PREFIX}${[
+    `hostId=${encodeKeyPart(input.hostId)}`,
+    `repoId=${encodeKeyPart(input.repoId)}`,
+    `path=${encodeKeyPart(input.path)}`
+  ].join('&')}`
+}
+
+export function makeRepoWorktreeKey(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string
+): string {
+  return makeWorktreeKey({
+    hostId: getRepoExecutionHostId(repo),
+    repoId: repo.id,
+    path
+  })
+}
+
+export function getRepoWorktreeIdAliases(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string
+): Set<string> {
+  return new Set([makeRepoWorktreeKey(repo, path), makeLegacyWorktreeId(repo.id, path)])
+}
+
+export function isRepoWorktreeIdAlias(
+  repo: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+  path: string,
+  worktreeId: string
+): boolean {
+  return getRepoWorktreeIdAliases(repo, path).has(worktreeId)
+}
+
+export function parseWorktreeKey(worktreeId: string): ParsedCanonicalWorktreeKey | null {
+  if (!worktreeId.startsWith(WORKTREE_KEY_PREFIX)) {
+    return null
+  }
+  const query = worktreeId.slice(WORKTREE_KEY_PREFIX.length)
+  const params = new URLSearchParams(query)
+  const keys = [...params.keys()]
+  if (keys.length !== 3 || keys[0] !== 'hostId' || keys[1] !== 'repoId' || keys[2] !== 'path') {
+    return null
+  }
+  const rawHostId = readSingleParam(params, 'hostId')
+  const rawRepoId = readSingleParam(params, 'repoId')
+  const rawPath = readSingleParam(params, 'path')
+  if (!rawHostId || !rawRepoId || !rawPath) {
+    return null
+  }
+  const hostId = normalizeExecutionHostId(rawHostId)
+  if (!hostId) {
+    return null
+  }
+  return { hostId, repoId: rawRepoId, worktreePath: rawPath }
+}
+
+export function parseAnyWorktreeId(worktreeId: string): ParsedAnyWorktreeId | null {
+  const canonical = parseWorktreeKey(worktreeId)
+  if (canonical) {
+    return { format: 'canonical', ...canonical }
+  }
+  const legacy = splitLegacyWorktreeId(worktreeId)
+  return legacy ? { format: 'legacy', ...legacy } : null
+}
+
+export function isLegacyWorktreeId(worktreeId: string): boolean {
+  return !parseWorktreeKey(worktreeId) && splitLegacyWorktreeId(worktreeId) !== null
+}
+
 export function getRepoIdFromWorktreeId(worktreeId: string): string {
+  const canonical = parseWorktreeKey(worktreeId)
+  if (canonical) {
+    return canonical.repoId
+  }
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)
   return separatorIdx === -1 ? worktreeId : worktreeId.slice(0, separatorIdx)
 }
 
-export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
+function splitLegacyWorktreeId(worktreeId: string): ParsedWorktreeId | null {
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)
   if (separatorIdx === -1) {
     return null
@@ -28,12 +141,21 @@ export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
   }
 }
 
+export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
+  const canonical = parseWorktreeKey(worktreeId)
+  if (canonical) {
+    return canonical
+  }
+  return splitLegacyWorktreeId(worktreeId)
+}
+
 export function splitWorktreeIdForFilesystem(worktreeId: string): ParsedWorktreeId | null {
   const parsed = splitWorktreeId(worktreeId)
   if (!parsed) {
     return null
   }
   return {
+    ...(parsed.hostId !== undefined ? { hostId: parsed.hostId } : {}),
     repoId: parsed.repoId,
     // Why: folder projects can have multiple workspace sessions backed by the
     // same directory. Their IDs carry a UUID suffix, but filesystem callers

--- a/src/shared/worktree-id.ts
+++ b/src/shared/worktree-id.ts
@@ -1,10 +1,11 @@
 import { WORKTREE_ID_SEPARATOR } from './pty-session-id-format'
-import {
-  getRepoExecutionHostId,
-  normalizeExecutionHostId,
-  type ExecutionHostId
-} from './execution-host'
+import { getRepoExecutionHostId, type ExecutionHostId } from './execution-host'
 import type { Repo } from './types'
+import {
+  WORKTREE_KEY_SCHEME,
+  formatWorktreeKey,
+  parseStrictWorktreeKey
+} from './worktree-key-format'
 
 export { WORKTREE_ID_SEPARATOR } from './pty-session-id-format'
 
@@ -25,24 +26,9 @@ export type ParsedAnyWorktreeId =
   | ({ format: 'legacy' } & ParsedWorktreeId)
 
 export const FOLDER_WORKSPACE_INSTANCE_SEPARATOR = '::workspace:'
-const WORKTREE_KEY_SCHEME = 'orca-worktree://'
-const WORKTREE_KEY_PREFIX = `${WORKTREE_KEY_SCHEME}v1?`
 const FOLDER_WORKSPACE_INSTANCE_SUFFIX = new RegExp(
   `${FOLDER_WORKSPACE_INSTANCE_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[0-9a-f-]{36}$`
 )
-
-function encodeKeyPart(value: string): string {
-  return encodeURIComponent(value)
-}
-
-function decodeStrictKeyPart(value: string): string | null {
-  try {
-    const decoded = decodeURIComponent(value)
-    return decoded.length > 0 ? decoded : null
-  } catch {
-    return null
-  }
-}
 
 export function makeLegacyWorktreeId(repoId: string, path: string): string {
   return `${repoId}${WORKTREE_ID_SEPARATOR}${path}`
@@ -53,11 +39,7 @@ export function makeWorktreeKey(input: {
   repoId: string
   path: string
 }): string {
-  return `${WORKTREE_KEY_PREFIX}${[
-    `hostId=${encodeKeyPart(input.hostId)}`,
-    `repoId=${encodeKeyPart(input.repoId)}`,
-    `path=${encodeKeyPart(input.path)}`
-  ].join('&')}`
+  return formatWorktreeKey(input)
 }
 
 export function makeRepoWorktreeKey(
@@ -87,42 +69,7 @@ export function isRepoWorktreeIdAlias(
 }
 
 export function parseWorktreeKey(worktreeId: string): ParsedCanonicalWorktreeKey | null {
-  if (!worktreeId.startsWith(WORKTREE_KEY_PREFIX)) {
-    return null
-  }
-  const query = worktreeId.slice(WORKTREE_KEY_PREFIX.length)
-  const parts = query.split('&')
-  if (parts.length !== 3) {
-    return null
-  }
-  const expectedKeys = ['hostId', 'repoId', 'path'] as const
-  const values: Partial<Record<(typeof expectedKeys)[number], string>> = {}
-  for (const [index, part] of parts.entries()) {
-    const separatorIndex = part.indexOf('=')
-    if (separatorIndex <= 0) {
-      return null
-    }
-    const key = part.slice(0, separatorIndex)
-    if (key !== expectedKeys[index]) {
-      return null
-    }
-    const decoded = decodeStrictKeyPart(part.slice(separatorIndex + 1))
-    if (decoded === null) {
-      return null
-    }
-    values[key] = decoded
-  }
-  const rawHostId = values.hostId
-  const rawRepoId = values.repoId
-  const rawPath = values.path
-  if (!rawHostId || !rawRepoId || !rawPath) {
-    return null
-  }
-  const hostId = normalizeExecutionHostId(rawHostId)
-  if (!hostId) {
-    return null
-  }
-  return { hostId, repoId: rawRepoId, worktreePath: rawPath }
+  return parseStrictWorktreeKey(worktreeId)
 }
 
 export function parseAnyWorktreeId(worktreeId: string): ParsedAnyWorktreeId | null {

--- a/src/shared/worktree-id.ts
+++ b/src/shared/worktree-id.ts
@@ -25,7 +25,8 @@ export type ParsedAnyWorktreeId =
   | ({ format: 'legacy' } & ParsedWorktreeId)
 
 export const FOLDER_WORKSPACE_INSTANCE_SEPARATOR = '::workspace:'
-const WORKTREE_KEY_PREFIX = 'orca-worktree://v1?'
+const WORKTREE_KEY_SCHEME = 'orca-worktree://'
+const WORKTREE_KEY_PREFIX = `${WORKTREE_KEY_SCHEME}v1?`
 const FOLDER_WORKSPACE_INSTANCE_SUFFIX = new RegExp(
   `${FOLDER_WORKSPACE_INSTANCE_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[0-9a-f-]{36}$`
 )
@@ -113,12 +114,19 @@ export function parseAnyWorktreeId(worktreeId: string): ParsedAnyWorktreeId | nu
   if (canonical) {
     return { format: 'canonical', ...canonical }
   }
+  if (worktreeId.startsWith(WORKTREE_KEY_SCHEME)) {
+    return null
+  }
   const legacy = splitLegacyWorktreeId(worktreeId)
   return legacy ? { format: 'legacy', ...legacy } : null
 }
 
 export function isLegacyWorktreeId(worktreeId: string): boolean {
-  return !parseWorktreeKey(worktreeId) && splitLegacyWorktreeId(worktreeId) !== null
+  return (
+    !worktreeId.startsWith(WORKTREE_KEY_SCHEME) &&
+    !parseWorktreeKey(worktreeId) &&
+    splitLegacyWorktreeId(worktreeId) !== null
+  )
 }
 
 export function getRepoIdFromWorktreeId(worktreeId: string): string {
@@ -145,6 +153,9 @@ export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
   const canonical = parseWorktreeKey(worktreeId)
   if (canonical) {
     return canonical
+  }
+  if (worktreeId.startsWith(WORKTREE_KEY_SCHEME)) {
+    return null
   }
   return splitLegacyWorktreeId(worktreeId)
 }

--- a/src/shared/worktree-key-format.ts
+++ b/src/shared/worktree-key-format.ts
@@ -1,0 +1,77 @@
+import { normalizeExecutionHostId, type ExecutionHostId } from './execution-host'
+
+export type ParsedWorktreeKeyParts = {
+  hostId: ExecutionHostId
+  repoId: string
+  worktreePath: string
+}
+
+export const WORKTREE_KEY_SCHEME = 'orca-worktree://'
+export const WORKTREE_KEY_PREFIX = `${WORKTREE_KEY_SCHEME}v1?`
+
+function encodeKeyPart(value: string): string {
+  return encodeURIComponent(value)
+}
+
+function decodeStrictKeyPart(value: string): string | null {
+  try {
+    const decoded = decodeURIComponent(value)
+    return decoded.length > 0 ? decoded : null
+  } catch {
+    return null
+  }
+}
+
+export function formatWorktreeKey(input: {
+  hostId: ExecutionHostId
+  repoId: string
+  path: string
+}): string {
+  return `${WORKTREE_KEY_PREFIX}${[
+    `hostId=${encodeKeyPart(input.hostId)}`,
+    `repoId=${encodeKeyPart(input.repoId)}`,
+    `path=${encodeKeyPart(input.path)}`
+  ].join('&')}`
+}
+
+export function parseStrictWorktreeKey(worktreeId: string): ParsedWorktreeKeyParts | null {
+  if (!worktreeId.startsWith(WORKTREE_KEY_PREFIX)) {
+    return null
+  }
+  const query = worktreeId.slice(WORKTREE_KEY_PREFIX.length)
+  const parts = query.split('&')
+  if (parts.length !== 3) {
+    return null
+  }
+  const expectedKeys = ['hostId', 'repoId', 'path'] as const
+  const values: Partial<Record<(typeof expectedKeys)[number], string>> = {}
+  for (const [index, part] of parts.entries()) {
+    const separatorIndex = part.indexOf('=')
+    if (separatorIndex <= 0) {
+      return null
+    }
+    const key = part.slice(0, separatorIndex)
+    if (key !== expectedKeys[index]) {
+      return null
+    }
+    const decoded = decodeStrictKeyPart(part.slice(separatorIndex + 1))
+    if (decoded === null) {
+      return null
+    }
+    values[key] = decoded
+  }
+  const rawHostId = values.hostId
+  const rawRepoId = values.repoId
+  const rawPath = values.path
+  if (!rawHostId || !rawRepoId || !rawPath) {
+    return null
+  }
+  const hostId = normalizeExecutionHostId(rawHostId)
+  if (!hostId) {
+    return null
+  }
+  if (formatWorktreeKey({ hostId, repoId: rawRepoId, path: rawPath }) !== worktreeId) {
+    return null
+  }
+  return { hostId, repoId: rawRepoId, worktreePath: rawPath }
+}


### PR DESCRIPTION
## Summary
- consolidate the fixes from #6030 and #6031 for same-id repos/project host setups across hosts
- add canonical host-qualified worktree IDs while keeping legacy `repoId::path` IDs accepted at compatibility and persistence boundaries
- migrate renderer/main/runtime state aliases so metadata, lineage, terminals, cleanup, and reconnect state follow the canonical ID
- harden the renderer migration contract so new `*ByWorktree*` maps cannot be silently missed

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/repos-remote.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/worktree-id.test.ts src/main/daemon/pty-session-id.test.ts src/main/persistence.test.ts src/main/ipc/worktrees.test.ts src/main/ipc/repos-remote.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/runtime-rpc.test.ts src/renderer/src/store/slices/repos-host-identity-routing.test.ts src/renderer/src/store/slices/repos-same-id-host-mutations.test.ts src/renderer/src/store/slices/repos-update-serialization.test.ts src/renderer/src/store/slices/repos.test.ts src/renderer/src/lib/project-host-workspace-target.test.ts src/renderer/src/store/slices/worktrees.test.ts src/main/ipc/worktree-push-target-cleanup.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts` (15 files, 1377 tests)
- [x] Electron validation on this exact PR worktree: `window.api.app.getIdentity()` reported branch `codex/host-qualified-worktree-identities` and root `/Users/jinwoohong/orca/workspaces/orca/review-orca-server-prs`.
- [x] Local disposable `demo-project`: added project, created a worktree from `main`, verified the visible sidebar row, verified the worktree ID was `orca-worktree://v1?...hostId=local...`, verified `git worktree list --porcelain`, then removed it through Orca and confirmed no test branch/path remained.
- [x] Non-git folder project: added a disposable `kind: "folder"` project, created a folder workspace, and verified the main and child folder workspace IDs were host-qualified with `hostId=local`.
- [x] SSH live validation using a throwaway Debian Docker target, not localhost SSH: built relay with `pnpm build:relay`, connected target `ssh-1782331073601-etpfjo`, registered remote `/work/demo-project`, created/listed/removed `/work/ssh-id-e2e-1782331210923`, verified visible SSH project/worktree rows, and confirmed remote `git worktree list --porcelain`, branch list, and `/work` had no test artifacts after cleanup.
- [x] Mock paired-runtime validation: started a temporary `OrcaRuntimeRpcServer` with real E2EE WebSocket pairing, added it through `window.api.runtimeEnvironments.addFromPairingCode`, verified `runtimeEnvironments.getStatus`, then exercised `repo.list`, `worktree.list`, `worktree.create`, and `worktree.rm` through `window.api.runtimeEnvironments.call`. The created runtime worktree ID was `orca-worktree://v1?...hostId=runtime%3Amock-paired&repoId=mock-repo-1...`, and list count returned to 1 after removal.
- [x] Cleanup: removed disposable repos from the isolated Orca profile, removed local temp repos/folders, removed the SSH Docker container/temp key/profile, closed Playwright, and stopped only the Electron process launched for validation.

Notes:
- Local commands ran on Node v26.0.0 while the repo engine warning asks for Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6096">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
