### PR TITLE
Fix Windows setup script startup visibility

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1340,6 +1340,36 @@ describe('createPtySubprocess', () => {
     expect(handle!.startupCommandDeliveredInShellArgs).toBe(true)
   })
 
+  it('keeps shell-ready Windows startup commands on PTY stdin delivery', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    let handle: ReturnType<typeof createPtySubprocess>
+    try {
+      handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        shellOverride: 'powershell.exe',
+        command: '& "C:\\repo\\.git\\orca\\setup-runner.cmd"',
+        startupCommandDelivery: 'shell-ready'
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    const lastCall = spawnMock.mock.calls.at(-1)!
+    const encoded = String(lastCall[1][3])
+    const command = Buffer.from(encoded, 'base64').toString('utf16le')
+    expect(command).not.toContain('setup-runner.cmd')
+    expect(handle!.startupCommandDeliveredInShellArgs).toBeUndefined()
+  })
+
   it('keeps oversized Windows startup commands on PTY stdin delivery', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -501,7 +501,8 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       spawnCwd,
       getDefaultCwd(),
       sessionWslContext ?? preferredWslContext,
-      opts.command
+      opts.command,
+      opts.startupCommandDelivery
     )
     shellArgs = resolved.shellArgs
     spawnCwd = resolved.effectiveCwd
@@ -533,7 +534,8 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
               {
                 distro: codexHomeWslInfo.distro
               },
-              opts.command
+              opts.command,
+              opts.startupCommandDelivery
             )
             shellArgs = resolved.shellArgs
             spawnCwd = resolved.effectiveCwd

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -406,7 +406,8 @@ export class LocalPtyProvider implements IPtyProvider {
         cwd,
         defaultCwd,
         worktreeWslContext ?? preferredWslContext,
-        args.command
+        args.command,
+        args.startupCommandDelivery
       )
       shellArgs = resolved.shellArgs
       effectiveCwd = resolved.effectiveCwd
@@ -502,9 +503,16 @@ export class LocalPtyProvider implements IPtyProvider {
             // Why: wsl.exe only imports non-default env vars named in WSLENV.
             addWslEnvKeys(finalEnv, ['CODEX_HOME', 'ORCA_CODEX_HOME'])
             if (!launchWslDistro) {
-              const resolved = resolveWindowsShellLaunchArgs(shellPath, cwd, defaultCwd, {
-                distro: codexHomeWslInfo.distro
-              })
+              const resolved = resolveWindowsShellLaunchArgs(
+                shellPath,
+                cwd,
+                defaultCwd,
+                {
+                  distro: codexHomeWslInfo.distro
+                },
+                args.command,
+                args.startupCommandDelivery
+              )
               shellArgs = resolved.shellArgs
               effectiveCwd = resolved.effectiveCwd
               validationCwd = resolved.validationCwd

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -36,6 +36,19 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(result.startupCommandDeliveredInShellArgs).toBe(true)
   })
 
+  it('keeps shell-ready cmd.exe startup commands on stdin delivery', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'cmd.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      'bash C:\\repo\\.git\\orca\\setup-runner.sh',
+      'shell-ready'
+    )
+    expect(result.shellArgs).toEqual(['/K', 'chcp 65001 > nul'])
+    expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
+  })
+
   it('keeps large cmd.exe startup commands on stdin delivery', () => {
     const result = resolveWindowsShellLaunchArgs(
       'cmd.exe',
@@ -102,6 +115,23 @@ describe('resolveWindowsShellLaunchArgs', () => {
     const command = Buffer.from(result.shellArgs[3] ?? '', 'base64').toString('utf16le')
     expect(command).toContain('function Global:prompt')
     expect(command.trimEnd().endsWith("& 'codex' '--no-alt-screen'")).toBe(true)
+  })
+
+  it('keeps shell-ready PowerShell startup commands out of EncodedCommand', () => {
+    const startupCommand = '& "C:\\repo\\.git\\orca\\setup-runner.cmd"'
+    const result = resolveWindowsShellLaunchArgs(
+      'powershell.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      startupCommand,
+      'shell-ready'
+    )
+    expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
+
+    const command = Buffer.from(result.shellArgs[3] ?? '', 'base64').toString('utf16le')
+    expect(command).toContain('function Global:prompt')
+    expect(command).not.toContain(startupCommand)
   })
 
   it('preserves complex PowerShell startup command text through EncodedCommand', () => {

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -10,6 +10,7 @@ import {
   encodePowerShellCommand,
   getPowerShellOsc133Bootstrap
 } from '../powershell-osc133-bootstrap'
+import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 
 const CMD_EXE_COMMAND_LINE_MAX_CHARS = 8191
 const STARTUP_COMMAND_TEXT_MAX_CHARS = 6000
@@ -119,27 +120,30 @@ export function resolveWindowsShellLaunchArgs(
   cwd: string,
   defaultCwd: string,
   wslContext?: WindowsShellWslContext,
-  startupCommand?: string
+  startupCommand?: string,
+  startupCommandDelivery?: StartupCommandDelivery
 ): WindowsShellLaunchArgs {
   const shellBasename = pathWin32.basename(shellPath).toLowerCase()
+  const shellArgStartupCommand =
+    startupCommandDelivery === 'shell-ready' ? undefined : startupCommand
 
   if (shellBasename === 'cmd.exe') {
-    const shellArgStartupCommand = getCmdShellArgStartupCommand(startupCommand)
+    const cmdStartupCommand = getCmdShellArgStartupCommand(shellArgStartupCommand)
     return {
       shellArgs: [
         '/K',
-        shellArgStartupCommand
-          ? `${CMD_UTF8_SETUP_COMMAND} & ${shellArgStartupCommand}`
+        cmdStartupCommand
+          ? `${CMD_UTF8_SETUP_COMMAND} & ${cmdStartupCommand}`
           : CMD_UTF8_SETUP_COMMAND
       ],
-      ...(shellArgStartupCommand ? { startupCommandDeliveredInShellArgs: true } : {}),
+      ...(cmdStartupCommand ? { startupCommandDeliveredInShellArgs: true } : {}),
       effectiveCwd: cwd,
       validationCwd: cwd
     }
   }
 
   if (shellBasename === 'powershell.exe' || shellBasename === 'pwsh.exe') {
-    const powerShellCommand = getPowerShellEncodedCommand(startupCommand)
+    const powerShellCommand = getPowerShellEncodedCommand(shellArgStartupCommand)
     // Why: foreground-process status on Windows depends on OSC 133 C/D, and
     // PowerShell needs a prompt/readline bootstrap after profiles finish.
     return {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -134,6 +134,7 @@ type UseTerminalPaneLifecycleDeps = {
    *  keeping the main terminal interactive. */
   setupSplit?: {
     command: string
+    startupCommandDelivery?: StartupCommandDelivery
     env?: Record<string, string>
     direction: SetupSplitDirection
   } | null
@@ -286,7 +287,11 @@ function hydrateTerminalScrollbackRefs(layout: TerminalLayoutSnapshot): {
     : { layout, hydrated }
 }
 
-type SplitStartupPayload = { command: string; env?: Record<string, string> }
+type SplitStartupPayload = {
+  command: string
+  startupCommandDelivery?: StartupCommandDelivery
+  env?: Record<string, string>
+}
 
 type SplitWithStartupDeps = {
   startup?: SplitStartupPayload | null
@@ -1186,7 +1191,11 @@ export function useTerminalPaneLifecycle({
       if (initialPane) {
         const setupPane = splitPaneWithOneShotStartup(
           ptyDeps,
-          { command: setupSplit.command, env: setupSplit.env },
+          {
+            command: setupSplit.command,
+            startupCommandDelivery: setupSplit.startupCommandDelivery,
+            env: setupSplit.env
+          },
           () => manager.splitPane(initialPane.id, setupSplit.direction)
         )
         issueAutomationAnchorPaneId = setupPane?.id ?? null

--- a/src/renderer/src/lib/worktree-activation.test.ts
+++ b/src/renderer/src/lib/worktree-activation.test.ts
@@ -63,6 +63,7 @@ describe('ensureWorktreeHasInitialTerminal', () => {
     })
     expect(store.queueTabStartupCommand).toHaveBeenCalledWith('tab-2', {
       command: 'bash /tmp/repo/.git/orca/setup-runner.sh',
+      startupCommandDelivery: 'shell-ready',
       env: {
         ORCA_ROOT_PATH: '/tmp/repo',
         ORCA_WORKTREE_PATH: '/tmp/worktrees/wt-1'
@@ -326,6 +327,7 @@ describe('ensureWorktreeHasInitialTerminal', () => {
     expect(store.queueTabStartupCommand).not.toHaveBeenCalled()
     expect(store.queueTabSetupSplit).toHaveBeenCalledWith('tab-1', {
       command: 'bash /tmp/repo/.git/orca/setup-runner.sh',
+      startupCommandDelivery: 'shell-ready',
       env: { ORCA_ROOT_PATH: '/tmp/repo' },
       direction: 'vertical'
     })
@@ -355,6 +357,7 @@ describe('ensureWorktreeHasInitialTerminal', () => {
 
     expect(store.queueTabSetupSplit).toHaveBeenCalledWith('tab-1', {
       command: 'bash /tmp/repo/.git/orca/setup-runner.sh',
+      startupCommandDelivery: 'shell-ready',
       env: { ORCA_ROOT_PATH: '/tmp/repo' },
       direction: 'vertical'
     })
@@ -371,6 +374,7 @@ describe('ensureWorktreeHasInitialTerminal', () => {
 
     expect(store.queueTabSetupSplit).toHaveBeenCalledWith('tab-1', {
       command: 'bash /tmp/repo/.git/orca/setup-runner.sh',
+      startupCommandDelivery: 'shell-ready',
       env: { ORCA_ROOT_PATH: '/tmp/repo' },
       direction: 'horizontal'
     })
@@ -397,6 +401,7 @@ describe('ensureWorktreeHasInitialTerminal', () => {
     })
     expect(store.queueTabStartupCommand).toHaveBeenCalledWith('tab-2', {
       command: 'bash /tmp/repo/.git/orca/setup-runner.sh',
+      startupCommandDelivery: 'shell-ready',
       env: { ORCA_ROOT_PATH: '/tmp/repo' }
     })
     expect(store.queueTabSetupSplit).not.toHaveBeenCalled()

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -558,6 +558,7 @@ function queueSetupAndIssueCommands(
     const mode = useAppStore.getState().settings?.setupScriptLaunchMode ?? 'new-tab'
     const setupCommand = {
       command: buildSetupRunnerCommand(setup.runnerScriptPath),
+      startupCommandDelivery: 'shell-ready' as const,
       env: setup.envVars
     }
     if (mode === 'new-tab') {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -316,7 +316,12 @@ export type TerminalSlice = {
    *  immediately interactive. */
   pendingSetupSplitByTabId: Record<
     string,
-    { command: string; env?: Record<string, string>; direction: SetupSplitDirection }
+    {
+      command: string
+      startupCommandDelivery?: StartupCommandDelivery
+      env?: Record<string, string>
+      direction: SetupSplitDirection
+    }
   >
   /** Queued issue-command-split requests — similar to setup splits but triggered
    *  when an issue is linked during worktree creation and the repo's issue
@@ -474,11 +479,19 @@ export type TerminalSlice = {
   } | null
   queueTabSetupSplit: (
     tabId: string,
-    startup: { command: string; env?: Record<string, string>; direction: SetupSplitDirection }
+    startup: {
+      command: string
+      startupCommandDelivery?: StartupCommandDelivery
+      env?: Record<string, string>
+      direction: SetupSplitDirection
+    }
   ) => void
-  consumeTabSetupSplit: (
-    tabId: string
-  ) => { command: string; env?: Record<string, string>; direction: SetupSplitDirection } | null
+  consumeTabSetupSplit: (tabId: string) => {
+    command: string
+    startupCommandDelivery?: StartupCommandDelivery
+    env?: Record<string, string>
+    direction: SetupSplitDirection
+  } | null
   queueTabIssueCommandSplit: (
     tabId: string,
     issueCommand: { command: string; env?: Record<string, string> }


### PR DESCRIPTION
## Summary
- make workspace setup-script launches request shell-ready startup delivery
- teach Windows shell launch args to honor `startupCommandDelivery: 'shell-ready'` instead of embedding those commands in `cmd.exe` / PowerShell launch args
- thread setup split startup delivery through the terminal pane lifecycle

## Why
PR #6015 fixed PTY bytes that arrive before renderer/daemon listeners are registered, but it missed the actual setup-script UX regression after #5753: short Windows startup commands were embedded directly in shell launch args. That path can start faster, but setup scripts no longer visibly begin with the command being submitted through the interactive shell, so the setup pane appears to start at later tool output like pnpm warnings.

Setup scripts are workspace bootstrap output, not interactive agent fast-launch UX, so they should use the shell-ready stdin path. That restores the visible command/preamble behavior while keeping the earlier PTY buffering fix for genuinely early output.

## Reproduction Harness
- `src/main/providers/windows-shell-args.test.ts` verifies shell-ready cmd.exe and PowerShell startup commands are not embedded in launch args.
- `src/main/daemon/pty-subprocess.test.ts` verifies the daemon Windows subprocess path keeps shell-ready setup commands on PTY stdin.
- `src/renderer/src/lib/worktree-activation.test.ts` verifies setup launches queue `startupCommandDelivery: 'shell-ready'` for both split and background Setup tab modes.

## Test Plan
- `pnpm vitest run --config config/vitest.config.ts src/main/providers/windows-shell-args.test.ts src/main/daemon/pty-subprocess.test.ts src/renderer/src/lib/worktree-activation.test.ts`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- `pnpm exec oxlint --format github`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6097">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->