### PR TITLE
Fix Open In launcher path classification

### DIFF
--- a/src/main/external-editor-launch.test.ts
+++ b/src/main/external-editor-launch.test.ts
@@ -28,6 +28,35 @@ describe('resolveExternalEditorLaunchSpec', () => {
     })
   })
 
+  it('treats an existing POSIX executable path with spaces as an executable launcher', () => {
+    const ideaPath = '/Users/me/Library/Application Support/JetBrains/Toolbox/scripts/idea'
+    expect(
+      resolveExternalEditorLaunchSpec(ideaPath, '/tmp/workspace', {
+        platform: 'darwin',
+        fileExists: (candidate) => candidate === ideaPath
+      })
+    ).toEqual({
+      kind: 'executable',
+      hideWindowsConsole: true,
+      spawnCmd: ideaPath,
+      spawnArgs: ['/tmp/workspace']
+    })
+  })
+
+  it('keeps absolute POSIX commands with arguments on the shell launch path', () => {
+    expect(
+      resolveExternalEditorLaunchSpec('/usr/local/bin/code --reuse-window', '/tmp/workspace', {
+        platform: 'darwin',
+        fileExists: () => false
+      })
+    ).toEqual({
+      kind: 'shell',
+      hideWindowsConsole: true,
+      spawnCmd: '/bin/sh',
+      spawnArgs: ['-c', '/usr/local/bin/code --reuse-window /tmp/workspace']
+    })
+  })
+
   it('runs compound Windows commands through cmd.exe', () => {
     expect(
       resolveExternalEditorLaunchSpec('start "" notepad', 'C:\\note.md', { platform: 'win32' })

--- a/src/main/external-editor-launch.ts
+++ b/src/main/external-editor-launch.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { basename, posix, win32 } from 'node:path'
 import { resolveCliCommand } from './codex-cli/command'
 import { getCmdExePath } from './win32-utils'
@@ -65,12 +66,36 @@ function stripMatchingQuotes(value: string): string {
   return trimmed
 }
 
-function isDirectExecutablePath(command: string, platform: NodeJS.Platform): boolean {
+function hasMatchingOuterQuotes(value: string): boolean {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+  return (quote === '"' || quote === "'") && trimmed.endsWith(quote)
+}
+
+function isWindowsExecutablePath(command: string): boolean {
+  return win32.isAbsolute(command) && /\.(?:cmd|exe|bat|com)$/i.test(command)
+}
+
+function isDirectExecutablePath(
+  command: string,
+  platform: NodeJS.Platform,
+  fileExists: (path: string) => boolean
+): boolean {
   const unquoted = stripMatchingQuotes(command)
   if (!/[\\/]/.test(unquoted)) {
     return false
   }
-  return platform === 'win32' ? win32.isAbsolute(unquoted) : posix.isAbsolute(unquoted)
+  const isAbsolutePath =
+    platform === 'win32' ? win32.isAbsolute(unquoted) : posix.isAbsolute(unquoted)
+  if (!isAbsolutePath) {
+    return false
+  }
+  if (!/\s/.test(unquoted) || hasMatchingOuterQuotes(command)) {
+    return true
+  }
+  // Why: unquoted POSIX paths can contain spaces, but so can shell commands
+  // with arguments. Only an existing path is safe to treat as one executable.
+  return platform === 'win32' ? isWindowsExecutablePath(unquoted) : fileExists(unquoted)
 }
 
 function shouldShowWindowsConsole(
@@ -119,12 +144,13 @@ function buildShellLaunchSpec(
 export function resolveExternalEditorLaunchSpec(
   command: string | undefined,
   pathValue: string,
-  options: { platform?: NodeJS.Platform } = {}
+  options: { platform?: NodeJS.Platform; fileExists?: (path: string) => boolean } = {}
 ): ExternalEditorLaunchSpec {
   const platform = options.platform ?? process.platform
+  const fileExists = options.fileExists ?? existsSync
   const trimmed = command?.trim() || EXTERNAL_EDITOR_CLI_COMMAND
 
-  if (isDirectExecutablePath(trimmed, platform)) {
+  if (isDirectExecutablePath(trimmed, platform, fileExists)) {
     const editorCommand = stripMatchingQuotes(trimmed)
     return {
       kind: 'executable',


### PR DESCRIPTION
## Summary
- keep existing absolute executable paths with spaces on the direct spawn path
- keep absolute commands with arguments on the shell path instead of treating the whole command string as an executable
- preserve the Windows NeoVim console behavior from #6026

Fixes #5983
Incorporates the core fix from #5984 while preserving the newer launcher behavior from #6026.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/external-editor-launch.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/shell.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/external-editor-launch.ts src/main/external-editor-launch.test.ts src/main/ipc/shell.ts src/main/ipc/shell.test.ts`
- Electron E2E via CDP on `Jinwoo-H/fix-open-in-launcher-classification`: called `window.api.shell.openInExternalEditor` with a temp executable under `Application Support/.../idea`; returned `{ ok: true }` and the spawned script wrote the workspace argument. Also called the same IPC with an absolute shell command containing args; returned `{ ok: true }` and wrote a shell marker.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6098">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->