### PR TITLE
Improve highlight contrast for selected file explorer rows

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -922,6 +922,26 @@
 
 /* ── Sidebar ─────────────────────────────────────────── */
 
+[data-file-explorer-row][data-selected='true'] {
+  /* Why: flat bg-accent ≈ panel background in light mode, so selection mixes
+     foreground into accent and adds an inset ring to stay legible in both themes. */
+  background: color-mix(in srgb, var(--foreground) 8%, var(--accent));
+  box-shadow: inset 0 0 0 1px var(--border);
+  color: var(--accent-foreground);
+}
+
+[data-file-explorer-row][data-selected='true']:hover {
+  background: color-mix(in srgb, var(--foreground) 10%, var(--accent));
+}
+
+.dark [data-file-explorer-row][data-selected='true'] {
+  background: color-mix(in srgb, var(--accent) 70%, transparent);
+}
+
+.dark [data-file-explorer-row][data-selected='true']:hover {
+  background: color-mix(in srgb, var(--accent) 80%, transparent);
+}
+
 .sidebar {
   width: 240px;
   flex-shrink: 0;

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -462,9 +462,12 @@ export function FileExplorerRow({
     >
       <ContextMenuTrigger asChild>
         <button
+          data-file-explorer-row=""
+          data-selected={isSelected ? 'true' : undefined}
           className={cn(
-            'flex w-full items-center gap-1 rounded-sm px-2 py-1 text-left text-xs transition-colors hover:bg-accent hover:text-foreground',
-            isSelected && 'bg-accent text-accent-foreground',
+            'flex w-full items-center gap-1 rounded-sm px-2 py-1 text-left text-xs transition-colors',
+            !isSelected && 'hover:bg-accent hover:text-foreground',
+            isSelected && 'text-accent-foreground',
             isFlashing && 'bg-amber-400/20 ring-1 ring-inset ring-amber-400/70'
           )}
           style={{ paddingLeft: `${node.depth * 16 + 8}px` }}


### PR DESCRIPTION
## Summary

Improves selection contrast and legibility for selected rows in the file explorer by:
- Defining distinct light and dark theme selection backgrounds using `color-mix` with `var(--accent)`.
- Adding an inset ring box-shadow for selection rows in light mode.
- Updating `FileExplorerRow.tsx` to apply custom `data-file-explorer-row` and `data-selected` attributes to support the new CSS rules.

## Screenshots

- TODO: Add screenshots of improved selected row style in both light and dark modes.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

The code review was executed focusing on standard styles, layout behavior, and cross-platform compatibility.
- Verified that the custom CSS uses standard CSS variables (`--foreground`, `--accent`, `--border`, `--accent-foreground`) supported consistently across macOS, Linux, and Windows.
- No shortcuts, shortcuts labels, paths, shell behavior, or platform-specific differences are affected or introduced.

## Security Audit

No security risks were found. The changes are strictly stylistic, only touching CSS colors and simple React attributes without any input handling, command execution, path manipulation, or IPC communication.

## Notes

None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6104">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->