### PR TITLE
Add relay upstream negative cache

### DIFF
--- a/src/relay/git-handler-status-ops.test.ts
+++ b/src/relay/git-handler-status-ops.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GitExec } from './git-handler-ops'
 import { getStatusOp } from './git-handler-status-ops'
+import { clearNoEffectiveUpstreamStatusCache } from './git-status-upstream-negative-cache'
 
 const LARGE_STATUS_ENTRY_COUNT = 150_000
 
@@ -16,14 +17,20 @@ function buildLargeStatusOutput(count: number): string {
   return lines.join('\n')
 }
 
+function buildBranchStatusOutput(head: string, branch: string): string {
+  return [`# branch.oid ${head}`, `# branch.head ${branch}`].join('\n')
+}
+
 describe('getStatusOp', () => {
   let tmpDir: string
 
   beforeEach(() => {
+    clearNoEffectiveUpstreamStatusCache()
     tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-git-status-'))
   })
 
   afterEach(async () => {
+    clearNoEffectiveUpstreamStatusCache()
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
@@ -69,5 +76,51 @@ describe('getStatusOp', () => {
 
     expect(result.didHitLimit).toBeUndefined()
     expect(result.entries).toHaveLength(5)
+  })
+
+  it('caches no-effective-upstream probes across status polls for the same head', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args.includes('status')) {
+        return { stdout: buildBranchStatusOutput('abc123', 'feature'), stderr: '' }
+      }
+      if (args[0] === 'symbolic-ref') {
+        return { stdout: 'feature\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        throw new Error('fatal: no upstream configured for branch feature')
+      }
+      throw new Error(`No upstream fixture for git ${args.join(' ')}`)
+    })
+
+    const first = await getStatusOp(git, { worktreePath: tmpDir })
+    const firstCallCount = git.mock.calls.length
+    const second = await getStatusOp(git, { worktreePath: tmpDir })
+
+    expect(first.upstreamStatus).toEqual({ hasUpstream: false, ahead: 0, behind: 0 })
+    expect(second.upstreamStatus).toEqual(first.upstreamStatus)
+    expect(git.mock.calls).toHaveLength(firstCallCount + 1)
+  })
+
+  it('invalidates cached no-effective-upstream probes when HEAD changes', async () => {
+    let head = 'abc123'
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args.includes('status')) {
+        return { stdout: buildBranchStatusOutput(head, 'feature'), stderr: '' }
+      }
+      if (args[0] === 'symbolic-ref') {
+        return { stdout: 'feature\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        throw new Error('fatal: no upstream configured for branch feature')
+      }
+      throw new Error(`No upstream fixture for git ${args.join(' ')}`)
+    })
+
+    await getStatusOp(git, { worktreePath: tmpDir })
+    const firstCallCount = git.mock.calls.length
+    head = 'def456'
+    await getStatusOp(git, { worktreePath: tmpDir })
+
+    expect(git.mock.calls.length).toBeGreaterThan(firstCallCount + 1)
   })
 })

--- a/src/relay/git-handler-status-ops.test.ts
+++ b/src/relay/git-handler-status-ops.test.ts
@@ -99,28 +99,120 @@ describe('getStatusOp', () => {
     expect(first.upstreamStatus).toEqual({ hasUpstream: false, ahead: 0, behind: 0 })
     expect(second.upstreamStatus).toEqual(first.upstreamStatus)
     expect(git.mock.calls).toHaveLength(firstCallCount + 1)
+    expect(
+      git.mock.calls.filter(([args]) => args[0] === 'rev-parse' && args.includes('HEAD@{u}'))
+    ).toHaveLength(1)
+    expect(
+      git.mock.calls.filter(
+        ([args]) => args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')
+      )
+    ).toHaveLength(1)
   })
 
-  it('invalidates cached no-effective-upstream probes when HEAD changes', async () => {
-    let head = 'abc123'
+  it('coalesces concurrent no-effective-upstream probes', async () => {
     const git = vi.fn<GitExec>(async (args) => {
       if (args.includes('status')) {
-        return { stdout: buildBranchStatusOutput(head, 'feature'), stderr: '' }
+        return { stdout: buildBranchStatusOutput('abc123', 'feature'), stderr: '' }
       }
       if (args[0] === 'symbolic-ref') {
         return { stdout: 'feature\n', stderr: '' }
       }
       if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        await Promise.resolve()
         throw new Error('fatal: no upstream configured for branch feature')
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')) {
+        await Promise.resolve()
+        throw new Error('missing remote branch')
+      }
+      throw new Error(`No upstream fixture for git ${args.join(' ')}`)
+    })
+
+    await Promise.all([
+      getStatusOp(git, { worktreePath: tmpDir }),
+      getStatusOp(git, { worktreePath: tmpDir }),
+      getStatusOp(git, { worktreePath: tmpDir })
+    ])
+
+    expect(
+      git.mock.calls.filter(([args]) => args[0] === 'rev-parse' && args.includes('HEAD@{u}'))
+    ).toHaveLength(1)
+    expect(
+      git.mock.calls.filter(
+        ([args]) => args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')
+      )
+    ).toHaveLength(1)
+  })
+
+  it('invalidates cached no-effective-upstream probes when the branch changes', async () => {
+    let branch = 'feature'
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args.includes('status')) {
+        return { stdout: buildBranchStatusOutput('abc123', branch), stderr: '' }
+      }
+      if (args[0] === 'symbolic-ref') {
+        return { stdout: `${branch}\n`, stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        throw new Error(`fatal: no upstream configured for branch ${branch}`)
+      }
+      if (args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/origin/'))) {
+        throw new Error('missing remote branch')
       }
       throw new Error(`No upstream fixture for git ${args.join(' ')}`)
     })
 
     await getStatusOp(git, { worktreePath: tmpDir })
-    const firstCallCount = git.mock.calls.length
-    head = 'def456'
+    branch = 'other-feature'
     await getStatusOp(git, { worktreePath: tmpDir })
 
-    expect(git.mock.calls.length).toBeGreaterThan(firstCallCount + 1)
+    expect(
+      git.mock.calls
+        .filter(
+          ([args]) =>
+            args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/origin/'))
+        )
+        .map(([args]) => args.at(-1))
+    ).toEqual(['refs/remotes/origin/feature', 'refs/remotes/origin/other-feature'])
+  })
+
+  it('does not cache a configured push target signal', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args.includes('status')) {
+        return { stdout: buildBranchStatusOutput('abc123', 'feature/fix'), stderr: '' }
+      }
+      if (args[0] === 'symbolic-ref') {
+        return { stdout: 'feature/fix\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        throw new Error('fatal: no upstream configured for branch feature/fix')
+      }
+      if (args[0] === 'config' && args.includes('branch.feature/fix.pushRemote')) {
+        return { stdout: 'fork\n', stderr: '' }
+      }
+      if (args[0] === 'config' && args.includes('remote.pushDefault')) {
+        throw new Error('missing push default')
+      }
+      if (args[0] === 'config' && args.includes('branch.feature/fix.remote')) {
+        return { stdout: 'fork\n', stderr: '' }
+      }
+      if (args[0] === 'config' && args.includes('branch.feature/fix.merge')) {
+        return { stdout: 'refs/heads/feature/fix\n', stderr: '' }
+      }
+      if (args[0] === 'config' && args.includes('branch.feature/fix.base')) {
+        throw new Error('missing branch base')
+      }
+      if (args[0] === 'rev-parse' && args.some((arg) => arg.startsWith('refs/remotes/'))) {
+        throw new Error('missing remote branch')
+      }
+      throw new Error(`No upstream fixture for git ${args.join(' ')}`)
+    })
+
+    await getStatusOp(git, { worktreePath: tmpDir })
+    await getStatusOp(git, { worktreePath: tmpDir })
+
+    expect(
+      git.mock.calls.filter(([args]) => args[0] === 'rev-parse' && args.includes('HEAD@{u}'))
+    ).toHaveLength(2)
   })
 })

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -11,14 +11,8 @@ import { parseUnmergedEntry } from './git-handler-utils'
 import { parseStatusOutput } from './git-status-output-parser'
 import type { GitExec } from './git-handler-ops'
 import type { GitUpstreamStatus } from '../shared/types'
-import {
-  getEffectiveGitUpstreamStatus,
-  splitRemoteBranchName
-} from '../shared/git-effective-upstream'
-import {
-  cacheNoEffectiveUpstreamStatus,
-  readCachedNoEffectiveUpstreamStatus
-} from './git-status-upstream-negative-cache'
+import { splitRemoteBranchName } from '../shared/git-effective-upstream'
+import { readOrProbeNoEffectiveUpstreamStatus } from './git-status-upstream-negative-cache'
 import {
   applyLineStats,
   collectUntrackedAdditions,
@@ -137,13 +131,13 @@ export async function getStatusOp(
 
     if (!didHitLimit) {
       if (shouldProbeEffectiveUpstreamStatus(branch, upstreamStatus?.upstreamName)) {
-        const cachedStatus = readCachedNoEffectiveUpstreamStatus({ worktreePath, branch, head })
-        if (cachedStatus) {
-          upstreamStatus = cachedStatus
-        } else {
+        const branchName = getShortBranchName(branch)
+        if (branchName) {
           try {
-            upstreamStatus = await getEffectiveGitUpstreamStatus((args) => git(args, worktreePath))
-            cacheNoEffectiveUpstreamStatus({ worktreePath, branch, head }, upstreamStatus)
+            upstreamStatus = await readOrProbeNoEffectiveUpstreamStatus(
+              { worktreePath, branchName, upstreamName: upstreamStatus?.upstreamName },
+              (args) => git(args, worktreePath)
+            )
           } catch {
             // Why: status polling should keep returning working-tree entries even
             // if the richer upstream probe hits a transient SSH/git ref error.

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -16,6 +16,10 @@ import {
   splitRemoteBranchName
 } from '../shared/git-effective-upstream'
 import {
+  cacheNoEffectiveUpstreamStatus,
+  readCachedNoEffectiveUpstreamStatus
+} from './git-status-upstream-negative-cache'
+import {
   applyLineStats,
   collectUntrackedAdditions,
   parseNumstat,
@@ -133,11 +137,17 @@ export async function getStatusOp(
 
     if (!didHitLimit) {
       if (shouldProbeEffectiveUpstreamStatus(branch, upstreamStatus?.upstreamName)) {
-        try {
-          upstreamStatus = await getEffectiveGitUpstreamStatus((args) => git(args, worktreePath))
-        } catch {
-          // Why: status polling should keep returning working-tree entries even
-          // if the richer upstream probe hits a transient SSH/git ref error.
+        const cachedStatus = readCachedNoEffectiveUpstreamStatus({ worktreePath, branch, head })
+        if (cachedStatus) {
+          upstreamStatus = cachedStatus
+        } else {
+          try {
+            upstreamStatus = await getEffectiveGitUpstreamStatus((args) => git(args, worktreePath))
+            cacheNoEffectiveUpstreamStatus({ worktreePath, branch, head }, upstreamStatus)
+          } catch {
+            // Why: status polling should keep returning working-tree entries even
+            // if the richer upstream probe hits a transient SSH/git ref error.
+          }
         }
       }
 

--- a/src/relay/git-status-upstream-negative-cache.ts
+++ b/src/relay/git-status-upstream-negative-cache.ts
@@ -49,6 +49,8 @@ function cacheNoEffectiveUpstreamStatus(
     noEffectiveUpstreamByIdentity.delete(cacheKey)
     return
   }
+  // Why: only cache negatives after probing origin/<branch>; other resolution
+  // paths can fail without proving the same-name publish branch is absent.
   if (!probedSameNameOriginRef) {
     return
   }

--- a/src/relay/git-status-upstream-negative-cache.ts
+++ b/src/relay/git-status-upstream-negative-cache.ts
@@ -1,11 +1,13 @@
+import { getEffectiveGitUpstreamStatus } from '../shared/git-effective-upstream'
+import type { GitCommandRunner } from '../shared/git-effective-upstream'
 import type { GitUpstreamStatus } from '../shared/types'
 
-const NO_EFFECTIVE_UPSTREAM_CACHE_TTL_MS = 5 * 60_000
+const NO_EFFECTIVE_UPSTREAM_CACHE_TTL_MS = 30_000
 
 type NoEffectiveUpstreamCacheIdentity = {
   worktreePath: string
-  branch?: string
-  head?: string
+  branchName: string
+  upstreamName?: string
 }
 
 type NoEffectiveUpstreamCacheEntry = {
@@ -14,41 +16,84 @@ type NoEffectiveUpstreamCacheEntry = {
 }
 
 const noEffectiveUpstreamByIdentity = new Map<string, NoEffectiveUpstreamCacheEntry>()
+const noEffectiveUpstreamInFlight = new Map<string, Promise<GitUpstreamStatus>>()
 
 function noEffectiveUpstreamCacheKey(identity: NoEffectiveUpstreamCacheIdentity): string {
-  return [identity.worktreePath, identity.branch ?? '', identity.head ?? ''].join('\0')
+  return [identity.worktreePath, identity.branchName, identity.upstreamName ?? ''].join('\0')
 }
 
-export function readCachedNoEffectiveUpstreamStatus(
-  identity: NoEffectiveUpstreamCacheIdentity,
+function readCachedNoEffectiveUpstreamStatus(
+  cacheKey: string,
   nowMs = Date.now()
 ): GitUpstreamStatus | null {
-  const key = noEffectiveUpstreamCacheKey(identity)
-  const entry = noEffectiveUpstreamByIdentity.get(key)
+  const entry = noEffectiveUpstreamByIdentity.get(cacheKey)
   if (!entry) {
     return null
   }
   if (entry.expiresAt <= nowMs) {
-    noEffectiveUpstreamByIdentity.delete(key)
+    noEffectiveUpstreamByIdentity.delete(cacheKey)
     return null
   }
   return entry.status
 }
 
-export function cacheNoEffectiveUpstreamStatus(
-  identity: NoEffectiveUpstreamCacheIdentity,
+function cacheNoEffectiveUpstreamStatus(
+  cacheKey: string,
   status: GitUpstreamStatus,
+  probedSameNameOriginRef: boolean,
   nowMs = Date.now()
 ): void {
-  if (status.hasUpstream) {
+  // Why: hasConfiguredPushTarget controls publish behavior; keep that signal
+  // fresh rather than serving a stale positive from status polling.
+  if (status.hasUpstream || status.hasConfiguredPushTarget) {
+    noEffectiveUpstreamByIdentity.delete(cacheKey)
     return
   }
-  noEffectiveUpstreamByIdentity.set(noEffectiveUpstreamCacheKey(identity), {
+  if (!probedSameNameOriginRef) {
+    return
+  }
+  noEffectiveUpstreamByIdentity.set(cacheKey, {
     status,
     expiresAt: nowMs + NO_EFFECTIVE_UPSTREAM_CACHE_TTL_MS
   })
 }
 
+export async function readOrProbeNoEffectiveUpstreamStatus(
+  identity: NoEffectiveUpstreamCacheIdentity,
+  runGit: GitCommandRunner
+): Promise<GitUpstreamStatus> {
+  const cacheKey = noEffectiveUpstreamCacheKey(identity)
+  const cachedStatus = readCachedNoEffectiveUpstreamStatus(cacheKey)
+  if (cachedStatus) {
+    return cachedStatus
+  }
+
+  const inFlight = noEffectiveUpstreamInFlight.get(cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  let probedSameNameOriginRef = false
+  const probe = getEffectiveGitUpstreamStatus((args) => {
+    if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${identity.branchName}`)) {
+      probedSameNameOriginRef = true
+    }
+    return runGit(args)
+  }).then((status) => {
+    cacheNoEffectiveUpstreamStatus(cacheKey, status, probedSameNameOriginRef)
+    return status
+  })
+  noEffectiveUpstreamInFlight.set(cacheKey, probe)
+  try {
+    return await probe
+  } finally {
+    if (noEffectiveUpstreamInFlight.get(cacheKey) === probe) {
+      noEffectiveUpstreamInFlight.delete(cacheKey)
+    }
+  }
+}
+
 export function clearNoEffectiveUpstreamStatusCache(): void {
   noEffectiveUpstreamByIdentity.clear()
+  noEffectiveUpstreamInFlight.clear()
 }

--- a/src/relay/git-status-upstream-negative-cache.ts
+++ b/src/relay/git-status-upstream-negative-cache.ts
@@ -1,0 +1,54 @@
+import type { GitUpstreamStatus } from '../shared/types'
+
+const NO_EFFECTIVE_UPSTREAM_CACHE_TTL_MS = 5 * 60_000
+
+type NoEffectiveUpstreamCacheIdentity = {
+  worktreePath: string
+  branch?: string
+  head?: string
+}
+
+type NoEffectiveUpstreamCacheEntry = {
+  status: GitUpstreamStatus
+  expiresAt: number
+}
+
+const noEffectiveUpstreamByIdentity = new Map<string, NoEffectiveUpstreamCacheEntry>()
+
+function noEffectiveUpstreamCacheKey(identity: NoEffectiveUpstreamCacheIdentity): string {
+  return [identity.worktreePath, identity.branch ?? '', identity.head ?? ''].join('\0')
+}
+
+export function readCachedNoEffectiveUpstreamStatus(
+  identity: NoEffectiveUpstreamCacheIdentity,
+  nowMs = Date.now()
+): GitUpstreamStatus | null {
+  const key = noEffectiveUpstreamCacheKey(identity)
+  const entry = noEffectiveUpstreamByIdentity.get(key)
+  if (!entry) {
+    return null
+  }
+  if (entry.expiresAt <= nowMs) {
+    noEffectiveUpstreamByIdentity.delete(key)
+    return null
+  }
+  return entry.status
+}
+
+export function cacheNoEffectiveUpstreamStatus(
+  identity: NoEffectiveUpstreamCacheIdentity,
+  status: GitUpstreamStatus,
+  nowMs = Date.now()
+): void {
+  if (status.hasUpstream) {
+    return
+  }
+  noEffectiveUpstreamByIdentity.set(noEffectiveUpstreamCacheKey(identity), {
+    status,
+    expiresAt: nowMs + NO_EFFECTIVE_UPSTREAM_CACHE_TTL_MS
+  })
+}
+
+export function clearNoEffectiveUpstreamStatusCache(): void {
+  noEffectiveUpstreamByIdentity.clear()
+}

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -459,9 +459,7 @@ const CONFLICTS_SECTION_LABEL = {
   fallback: 'Conflicts'
 }
 
-// Why: Windows AppHang traces showed visible source-control branch-compare
-// polling spawning git chains continuously; direct actions still refresh eagerly.
-const BRANCH_REFRESH_INTERVAL_MS = 60_000
+const BRANCH_REFRESH_INTERVAL_MS = 5000
 // Why: row action buttons host Radix Tooltip triggers. Keeping the overlay
 // measurable prevents transient top-left tooltip placement during hover.
 const SOURCE_CONTROL_ROW_ACTION_OVERLAY_CLASS =

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -459,7 +459,9 @@ const CONFLICTS_SECTION_LABEL = {
   fallback: 'Conflicts'
 }
 
-const BRANCH_REFRESH_INTERVAL_MS = 5000
+// Why: Windows AppHang traces showed visible source-control branch-compare
+// polling spawning git chains continuously; direct actions still refresh eagerly.
+const BRANCH_REFRESH_INTERVAL_MS = 60_000
 // Why: row action buttons host Radix Tooltip triggers. Keeping the overlay
 // measurable prevents transient top-left tooltip placement during hover.
 const SOURCE_CONTROL_ROW_ACTION_OVERLAY_CLASS =


### PR DESCRIPTION
﻿## Summary
- Add relay/SSH parity for the local upstream negative cache that already exists on `main`.
- Cache only safe "no effective upstream" results for 30s, coalesce overlapping relay probes, and avoid caching configured push-target signals.
- Keep #6002's Source Control polling behavior untouched; this PR does not include terminal rendering/scheduler changes.

## Evidence
- Windows hang traces showed repeated git status/upstream subprocess chains during normal polling.
- `main` already applies this protection in the local git-status path; this applies the same semantics to the relay/SSH path.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/status-upstream-probe-churn.test.ts src/relay/git-handler-status-ops.test.ts`
- `pnpm exec oxlint src/relay/git-status-upstream-negative-cache.ts src/relay/git-handler-status-ops.ts src/relay/git-handler-status-ops.test.ts`

## Tradeoff
- Like `main`, a newly-created same-name remote branch may take up to 30s to be discovered by passive status polling after a cached negative probe. Configured push targets are not cached.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/stablyai/orca/pull/6105">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
