### PR TITLE
Preserve linked work drafts during workspace startup

### DIFF
--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/new-workspace'
 import { resolveQuickCreateLinkedWorkItemPrompt } from '@/lib/linked-work-item-context'
 import { isOrcaCliAvailableForLaunch } from '@/lib/orca-cli-launch-availability'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import {
   buildAgentDraftLaunchPlan,
   buildAgentStartupPlan,
@@ -223,6 +224,11 @@ export async function submitFolderWorkspaceCreate({
     workspacePath: workspace.folderPath,
     connectionId: workspace.connectionId ?? projectGroup.connectionId
   })
+  if (startupPlan && !startupPlan.launchToken) {
+    // Why: delayed delivery must target the exact pane spawned from this queued
+    // startup, so both halves share one renderer-session token.
+    startupPlan.launchToken = createBrowserUuid()
+  }
 
   const startup =
     quickAgent && startupPlan
@@ -230,6 +236,7 @@ export async function submitFolderWorkspaceCreate({
           command: startupPlan.launchCommand,
           ...(startupPlan.env ? { env: startupPlan.env } : {}),
           launchConfig: startupPlan.launchConfig,
+          ...(startupPlan.launchToken ? { launchToken: startupPlan.launchToken } : {}),
           launchAgent: quickAgent,
           ...(startupPlan.startupCommandDelivery
             ? { startupCommandDelivery: startupPlan.startupCommandDelivery }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4077,7 +4077,7 @@ describe('connectPanePty', () => {
       }
     } as StoreState
 
-    connectPanePty(
+    const binding = connectPanePty(
       createPane(1) as never,
       createManager(1) as never,
       createDeps({
@@ -4089,16 +4089,26 @@ describe('connectPanePty', () => {
         }
       }) as never
     )
-    await flushAsyncTicks(20)
-    await new Promise((resolve) => setTimeout(resolve, 70))
+    try {
+      await flushAsyncTicks(20)
+      await new Promise((resolve) => setTimeout(resolve, 70))
 
-    expect(mockStoreState.registerAgentLaunchConfig).toHaveBeenCalledWith(paneKey, launchConfig, {
-      agentType: 'codex',
-      launchToken: 'launch-token-1',
-      tabId: 'tab-1',
-      leafId: LEAF_1
-    })
-    expect(mockStoreState.clearAgentLaunchConfig).toHaveBeenCalledWith(paneKey)
+      expect(mockStoreState.registerAgentLaunchConfig).toHaveBeenCalledWith(paneKey, launchConfig, {
+        agentType: 'codex',
+        launchToken: 'launch-token-1',
+        tabId: 'tab-1',
+        leafId: LEAF_1
+      })
+      expect(mockStoreState.clearAgentLaunchConfig).toHaveBeenCalledWith(paneKey)
+
+      const registerOrder = mockStoreState.registerAgentLaunchConfig.mock.invocationCallOrder[0]
+      const clearOrder = mockStoreState.clearAgentLaunchConfig.mock.invocationCallOrder[0]
+      expect(registerOrder).toBeDefined()
+      expect(clearOrder).toBeDefined()
+      expect(registerOrder!).toBeLessThan(clearOrder!)
+    } finally {
+      binding.dispose()
+    }
   })
 
   it('prefers live-entry launch config for pane cold restore when status survived PTY loss', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4057,6 +4057,50 @@ describe('connectPanePty', () => {
     expect(mockStoreState.clearAgentLaunchConfig).toHaveBeenCalledWith(paneKey)
   })
 
+  it('clears launch config when an agent startup spawn produces no PTY', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    const launchConfig = { agentCommand: 'codex', agentArgs: '', agentEnv: {} }
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_1 },
+          activeLeafId: LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    } as StoreState
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({
+        startup: {
+          command: 'codex',
+          launchConfig,
+          launchToken: 'launch-token-1',
+          launchAgent: 'codex'
+        }
+      }) as never
+    )
+    await flushAsyncTicks(20)
+    await new Promise((resolve) => setTimeout(resolve, 70))
+
+    expect(mockStoreState.registerAgentLaunchConfig).toHaveBeenCalledWith(paneKey, launchConfig, {
+      agentType: 'codex',
+      launchToken: 'launch-token-1',
+      tabId: 'tab-1',
+      leafId: LEAF_1
+    })
+    expect(mockStoreState.clearAgentLaunchConfig).toHaveBeenCalledWith(paneKey)
+  })
+
   it('prefers live-entry launch config for pane cold restore when status survived PTY loss', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('fresh-pty')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -940,6 +940,9 @@ export function connectPanePty(
       leafId: pane.leafId
     })
   }
+  const clearRegisteredStartupLaunchConfig = (): void => {
+    useAppStore.getState().clearAgentLaunchConfig(cacheKey)
+  }
   const pendingSpawnKey = cacheKey
   const neutralTerminalTitle = (): string => {
     const state = useAppStore.getState()
@@ -2411,6 +2414,14 @@ export function connectPanePty(
           }
           if (resolvedPtyId) {
             clearSleepingRecordAfterColdRestoreSpawn(coldRestoreOverride)
+          } else if (
+            paneStartup?.launchConfig ||
+            (startupOverride && 'launchConfig' in startupOverride)
+          ) {
+            // Why: delayed draft/follow-up delivery keys off this launch
+            // registry. If spawn produced no PTY, the launch is no longer a
+            // viable delivery target and must not wait for a future pane.
+            clearRegisteredStartupLaunchConfig()
           }
           const gen = await preSignalPromise
           if (typeof gen === 'number' && resolvedPtyId) {
@@ -2427,6 +2438,9 @@ export function connectPanePty(
           return resolvedPtyId
         })
         .catch(async () => {
+          if (paneStartup?.launchConfig || (startupOverride && 'launchConfig' in startupOverride)) {
+            clearRegisteredStartupLaunchConfig()
+          }
           const gen = await preSignalPromise
           if (typeof gen === 'number') {
             void window.api.pty.clearPendingPaneSerializer(cacheKey, gen).catch(() => {})

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -9,6 +9,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
 import { getAgentLaunchPlatformForRepo } from '@/lib/agent-launch-platform'
 import { getAgentCatalog } from '@/lib/agent-catalog'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import {
   parseGitHubIssueOrPRNumber,
   parseGitHubIssueOrPRLink,
@@ -3119,6 +3120,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             }
           : undefined
       const backendSpawnedStartup = result.startupTerminal?.spawned === true
+      if (startupPlan && !backendSpawnedStartup && !startupPlan.launchToken) {
+        // Why: delayed delivery must target the exact pane spawned from this
+        // queued startup, so both halves share one renderer-session token.
+        startupPlan.launchToken = createBrowserUuid()
+      }
       const activation = activateAndRevealWorktree(worktree.id, {
         sidebarRevealBehavior: 'auto',
         setup: result.setup,
@@ -3130,6 +3136,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                 command: startupPlan.launchCommand,
                 ...(startupPlan.env ? { env: startupPlan.env } : {}),
                 launchConfig: startupPlan.launchConfig,
+                ...(startupPlan.launchToken ? { launchToken: startupPlan.launchToken } : {}),
                 launchAgent: tuiAgent,
                 ...(startupPlan.startupCommandDelivery
                   ? { startupCommandDelivery: startupPlan.startupCommandDelivery }

--- a/src/renderer/src/lib/agent-followup-delivery.ts
+++ b/src/renderer/src/lib/agent-followup-delivery.ts
@@ -1,0 +1,49 @@
+import {
+  inspectRuntimeTerminalProcess,
+  sendRuntimePtyInputVerified
+} from '@/runtime/runtime-terminal-inspection'
+import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
+import type { GlobalSettings } from '../../../shared/types'
+
+type RuntimeOwnerSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+
+export async function sendFollowupPromptWhenAgentReady(args: {
+  ptyId: string
+  expectedProcess: string
+  prompt: string
+  settings: RuntimeOwnerSettings
+}): Promise<boolean> {
+  const { ptyId, expectedProcess, prompt, settings } = args
+  if (!(await waitForAgentForeground(ptyId, expectedProcess, settings))) {
+    return false
+  }
+  try {
+    return await sendRuntimePtyInputVerified(settings, ptyId, `${prompt}\r`)
+  } catch {
+    return false
+  }
+}
+
+// Why: delayed follow-ups must not type into an arbitrary shell. Require a
+// positive expected-process match before writing user/task text to the PTY.
+async function waitForAgentForeground(
+  ptyId: string,
+  expectedProcess: string,
+  settings: RuntimeOwnerSettings
+): Promise<boolean> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (attempt > 0) {
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 150))
+    }
+    try {
+      const process = await inspectRuntimeTerminalProcess(settings, ptyId)
+      const foreground = process.foregroundProcess?.toLowerCase() ?? ''
+      if (isExpectedAgentProcess(foreground, expectedProcess)) {
+        return true
+      }
+    } catch {
+      // Ignore transient PTY inspection failures and keep polling.
+    }
+  }
+  return false
+}

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -6,6 +6,7 @@ import {
   chunkAgentDraftPasteContent,
   getSettingsForAgentTabRuntimeOwner,
   iterateAgentDraftPasteContentChunks,
+  pasteDraftToAgentPtyWhenReady,
   pasteDraftWhenAgentReady,
   sendAgentDraftPasteContent,
   sendBracketedPasteToRunningAgent
@@ -273,6 +274,30 @@ describe('pasteDraftWhenAgentReady', () => {
       'pty-1',
       PASTED_ISSUE_URL
     )
+  })
+
+  it('honors the fallback inspection deadline for pty-bound draft paste', async () => {
+    const onTimeout = vi.fn()
+    testState.inspectRuntimeTerminalProcess.mockReturnValue(new Promise(() => {}))
+
+    const promise = pasteDraftToAgentPtyWhenReady({
+      tabId: 'tab-1',
+      ptyId: 'pty-1',
+      content: ISSUE_URL,
+      agent: 'codex',
+      forcePaste: true,
+      timeoutMs: 1,
+      onTimeout
+    })
+    await flushMicrotasks()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await flushMicrotasks(5)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    await expect(promise).resolves.toBe(false)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
   })
 
   it('routes tab-owned paste writes through the worktree runtime owner', async () => {

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -244,7 +244,13 @@ async function waitForExpectedAgentOnPty(
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     try {
-      const process = await inspectRuntimeTerminalProcess(settings, ptyId)
+      const process = await withDeadline(
+        inspectRuntimeTerminalProcess(settings, ptyId),
+        Math.max(0, deadline - Date.now())
+      )
+      if (!process) {
+        return false
+      }
       const foreground = process.foregroundProcess?.toLowerCase() ?? ''
       if (isExpectedAgentProcess(foreground, expectedProcess)) {
         return true
@@ -252,7 +258,29 @@ async function waitForExpectedAgentOnPty(
     } catch {
       // Ignore transient PTY inspection failures and keep polling.
     }
-    await new Promise<void>((resolve) => window.setTimeout(resolve, 120))
+    const delayMs = Math.min(120, Math.max(0, deadline - Date.now()))
+    if (delayMs > 0) {
+      await new Promise<void>((resolve) => window.setTimeout(resolve, delayMs))
+    }
   }
   return false
+}
+
+function withDeadline<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
+  if (timeoutMs <= 0) {
+    return Promise.resolve(null)
+  }
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(() => resolve(null), timeoutMs)
+    promise.then(
+      (value) => {
+        window.clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        window.clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
 }

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -1,7 +1,10 @@
 import type { TuiAgent } from '../../../shared/types'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { useAppStore } from '@/store'
-import { sendRuntimePtyInputVerified } from '@/runtime/runtime-terminal-inspection'
+import {
+  inspectRuntimeTerminalProcess,
+  sendRuntimePtyInputVerified
+} from '@/runtime/runtime-terminal-inspection'
 import {
   BRACKETED_PASTE_END,
   BRACKETED_PASTE_START,
@@ -12,6 +15,7 @@ import { getSettingsForWorktreeRuntimeOwner } from './worktree-runtime-owner'
 import type { GlobalSettings } from '../../../shared/types'
 import { sendAgentDraftPasteContent } from './agent-draft-paste-content'
 import { waitForAgentDraftInputReady } from './agent-draft-readiness'
+import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
 export {
   AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES,
   AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES,
@@ -123,6 +127,45 @@ export async function pasteDraftWhenAgentReady(args: {
   })
 }
 
+export async function pasteDraftToAgentPtyWhenReady(args: {
+  tabId: string
+  ptyId: string
+  content: string
+  agent?: TuiAgent
+  submit?: boolean
+  forcePaste?: boolean
+  timeoutMs?: number
+  onTimeout?: () => void
+}): Promise<boolean> {
+  const { tabId, ptyId, content, agent, submit, forcePaste, timeoutMs, onTimeout } = args
+  const agentConfig = agent ? TUI_AGENT_CONFIG[agent] : null
+
+  if (!forcePaste && (agentConfig?.draftPromptFlag || agentConfig?.draftPromptEnvVar)) {
+    return false
+  }
+
+  const budget = timeoutMs ?? READINESS_TIMEOUT_MS
+  const settings = getSettingsForAgentTabRuntimeOwner(tabId)
+  const readySignal = agentConfig?.draftPasteReadySignal ?? 'render-quiet-after-bracketed-paste'
+  const ready = await waitForAgentDraftInputReady(ptyId, budget, readySignal, settings)
+  if (!ready) {
+    const fallbackReady = agentConfig
+      ? await waitForExpectedAgentOnPty(ptyId, agentConfig.expectedProcess, 1000, settings)
+      : false
+    if (!fallbackReady) {
+      onTimeout?.()
+      return false
+    }
+  }
+
+  return await sendBracketedPasteToAgent({
+    settings,
+    ptyId,
+    content,
+    submit: submit === true
+  })
+}
+
 export async function submitPromptToAgentTab(args: {
   tabId: string
   content: string
@@ -190,4 +233,26 @@ async function waitForPtyId(tabId: string, timeoutMs: number): Promise<string | 
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50))
   }
   return null
+}
+
+async function waitForExpectedAgentOnPty(
+  ptyId: string,
+  expectedProcess: string,
+  timeoutMs: number,
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const process = await inspectRuntimeTerminalProcess(settings, ptyId)
+      const foreground = process.foregroundProcess?.toLowerCase() ?? ''
+      if (isExpectedAgentProcess(foreground, expectedProcess)) {
+        return true
+      }
+    } catch {
+      // Ignore transient PTY inspection failures and keep polling.
+    }
+    await new Promise<void>((resolve) => window.setTimeout(resolve, 120))
+  }
+  return false
 }

--- a/src/renderer/src/lib/agent-startup-delayed-delivery.ts
+++ b/src/renderer/src/lib/agent-startup-delayed-delivery.ts
@@ -166,7 +166,9 @@ function flushPendingAgentStartupDeliveries(): void {
     // owns success or failure. Consume before awaiting so store churn cannot
     // duplicate a linked-work-item draft.
     if (beginAgentStartupDeliveryAttempt(delivery)) {
-      void delivery.deliver(tabId, ptyId, delivery.startup)
+      void delivery.deliver(tabId, ptyId, delivery.startup).catch((error) => {
+        console.warn('Queued agent startup delivery failed', error)
+      })
     }
   }
   stopPendingAgentStartupSubscriptionIfIdle()

--- a/src/renderer/src/lib/agent-startup-delayed-delivery.ts
+++ b/src/renderer/src/lib/agent-startup-delayed-delivery.ts
@@ -1,0 +1,210 @@
+import { useAppStore } from '@/store'
+import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+import { parsePaneKey } from '../../../shared/stable-pane-id'
+
+type AppStoreSnapshot = ReturnType<typeof useAppStore.getState>
+
+type PendingAgentStartupDelivery = {
+  worktreeId: string
+  tabId: string
+  launchToken: string
+  startup: AgentStartupPlan
+  deliver: (tabId: string, ptyId: string, startup: AgentStartupPlan) => Promise<void>
+}
+
+const pendingAgentStartupDeliveries = new Map<string, PendingAgentStartupDelivery>()
+const consumedAgentStartupDeliveries = new Set<string>()
+const staleStartupRecheckTimers = new Map<string, ReturnType<typeof globalThis.setTimeout>>()
+let unsubscribePendingAgentStartupDeliveries: (() => void) | null = null
+
+export function resolveAgentStartupTabId(
+  state: AppStoreSnapshot,
+  worktreeId: string,
+  primaryTabId: string | null | undefined
+): string | null {
+  // Why: the caller may know the exact tab that received the queued startup
+  // command. Prefer it over focus-derived state, which can change mid-create.
+  return (
+    primaryTabId ??
+    state.activeTabIdByWorktree[worktreeId] ??
+    state.tabsByWorktree[worktreeId]?.[0]?.id ??
+    null
+  )
+}
+
+export function getAgentStartupTabPtyId(
+  state: AppStoreSnapshot,
+  tabId: string,
+  launchToken: string
+): string | null {
+  const livePtyIds = new Set(state.ptyIdsByTabId[tabId] ?? [])
+  if (livePtyIds.size === 0) {
+    return null
+  }
+  for (const [paneKey, entry] of Object.entries(state.agentLaunchConfigByPaneKey ?? {})) {
+    const identity = entry.identity
+    if (identity.tabId !== tabId || identity.launchToken !== launchToken) {
+      continue
+    }
+    const leafId = identity.leafId ?? parsePaneKey(paneKey)?.leafId
+    if (!leafId) {
+      continue
+    }
+    const ptyId = state.terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[leafId]
+    if (ptyId && livePtyIds.has(ptyId)) {
+      return ptyId
+    }
+  }
+  return null
+}
+
+function worktreeStillOwnsStartupTab(
+  state: AppStoreSnapshot,
+  worktreeId: string,
+  tabId: string
+): boolean {
+  return (state.tabsByWorktree[worktreeId] ?? []).some((tab) => tab.id === tabId)
+}
+
+function getPendingStartupLaunchToken(state: AppStoreSnapshot, tabId: string): string | undefined {
+  return state.pendingStartupByTabId?.[tabId]?.launchToken
+}
+
+function hasRegisteredStartupLaunch(
+  state: AppStoreSnapshot,
+  tabId: string,
+  launchToken: string
+): boolean {
+  return Object.values(state.agentLaunchConfigByPaneKey ?? {}).some(
+    (entry) => entry.identity.tabId === tabId && entry.identity.launchToken === launchToken
+  )
+}
+
+function ensurePendingAgentStartupSubscription(): void {
+  if (unsubscribePendingAgentStartupDeliveries) {
+    return
+  }
+  unsubscribePendingAgentStartupDeliveries = useAppStore.subscribe(() => {
+    flushPendingAgentStartupDeliveries()
+  })
+}
+
+function stopPendingAgentStartupSubscriptionIfIdle(): void {
+  if (pendingAgentStartupDeliveries.size > 0 || !unsubscribePendingAgentStartupDeliveries) {
+    return
+  }
+  unsubscribePendingAgentStartupDeliveries()
+  unsubscribePendingAgentStartupDeliveries = null
+}
+
+export function queuePendingAgentStartupDelivery(delivery: PendingAgentStartupDelivery): void {
+  const key = deliveryKey(delivery)
+  if (consumedAgentStartupDeliveries.has(key)) {
+    return
+  }
+  pendingAgentStartupDeliveries.set(key, delivery)
+  ensurePendingAgentStartupSubscription()
+  flushPendingAgentStartupDeliveries()
+}
+
+export function resetAgentStartupDelayedDeliveryForTests(): void {
+  pendingAgentStartupDeliveries.clear()
+  consumedAgentStartupDeliveries.clear()
+  for (const timer of staleStartupRecheckTimers.values()) {
+    globalThis.clearTimeout(timer)
+  }
+  staleStartupRecheckTimers.clear()
+  unsubscribePendingAgentStartupDeliveries?.()
+  unsubscribePendingAgentStartupDeliveries = null
+}
+
+export function beginAgentStartupDeliveryAttempt(args: {
+  worktreeId: string
+  tabId: string
+  launchToken: string
+}): boolean {
+  const key = deliveryKey(args)
+  if (consumedAgentStartupDeliveries.has(key)) {
+    return false
+  }
+  consumedAgentStartupDeliveries.add(key)
+  pendingAgentStartupDeliveries.delete(key)
+  clearStaleStartupRecheck(key)
+  return true
+}
+
+function deliveryKey(
+  delivery: Pick<PendingAgentStartupDelivery, 'worktreeId' | 'tabId' | 'launchToken'>
+): string {
+  return `${delivery.worktreeId}\0${delivery.tabId}\0${delivery.launchToken}`
+}
+
+function flushPendingAgentStartupDeliveries(): void {
+  const state = useAppStore.getState()
+  for (const [key, delivery] of pendingAgentStartupDeliveries) {
+    const { tabId, launchToken } = delivery
+    if (!worktreeStillOwnsStartupTab(state, delivery.worktreeId, tabId)) {
+      pendingAgentStartupDeliveries.delete(key)
+      continue
+    }
+    const queuedLaunchToken = getPendingStartupLaunchToken(state, tabId)
+    const launchRegistered = hasRegisteredStartupLaunch(state, tabId, launchToken)
+    if (queuedLaunchToken !== launchToken && !launchRegistered && queuedLaunchToken !== undefined) {
+      pendingAgentStartupDeliveries.delete(key)
+      clearStaleStartupRecheck(key)
+      continue
+    }
+    if (queuedLaunchToken === undefined && !launchRegistered) {
+      scheduleStaleStartupRecheck(key)
+      continue
+    }
+    const ptyId = getAgentStartupTabPtyId(state, tabId, launchToken)
+    if (!ptyId) {
+      continue
+    }
+    // Why: once the launch-bound PTY exists, the bounded readiness/paste path
+    // owns success or failure. Consume before awaiting so store churn cannot
+    // duplicate a linked-work-item draft.
+    if (beginAgentStartupDeliveryAttempt(delivery)) {
+      void delivery.deliver(tabId, ptyId, delivery.startup)
+    }
+  }
+  stopPendingAgentStartupSubscriptionIfIdle()
+}
+
+function scheduleStaleStartupRecheck(key: string): void {
+  if (staleStartupRecheckTimers.has(key)) {
+    return
+  }
+  staleStartupRecheckTimers.set(
+    key,
+    globalThis.setTimeout(() => {
+      staleStartupRecheckTimers.delete(key)
+      const delivery = pendingAgentStartupDeliveries.get(key)
+      if (!delivery) {
+        stopPendingAgentStartupSubscriptionIfIdle()
+        return
+      }
+      const state = useAppStore.getState()
+      const queuedLaunchToken = getPendingStartupLaunchToken(state, delivery.tabId)
+      if (
+        queuedLaunchToken === undefined &&
+        !hasRegisteredStartupLaunch(state, delivery.tabId, delivery.launchToken)
+      ) {
+        pendingAgentStartupDeliveries.delete(key)
+      } else {
+        flushPendingAgentStartupDeliveries()
+      }
+      stopPendingAgentStartupSubscriptionIfIdle()
+    }, 1000)
+  )
+}
+
+function clearStaleStartupRecheck(key: string): void {
+  const timer = staleStartupRecheckTimers.get(key)
+  if (!timer) {
+    return
+  }
+  globalThis.clearTimeout(timer)
+  staleStartupRecheckTimers.delete(key)
+}

--- a/src/renderer/src/lib/new-workspace.test.ts
+++ b/src/renderer/src/lib/new-workspace.test.ts
@@ -1,27 +1,72 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   mockInspectRuntimeTerminalProcess,
   mockSendRuntimePtyInputVerified,
-  mockPasteDraftWhenAgentReady,
+  mockPasteDraftToAgentPtyWhenReady,
   mockTrack,
-  store
+  store,
+  storeListeners,
+  startupLeafId
 } = vi.hoisted(() => ({
   mockInspectRuntimeTerminalProcess: vi.fn(),
   mockSendRuntimePtyInputVerified: vi.fn(),
-  mockPasteDraftWhenAgentReady: vi.fn(),
+  mockPasteDraftToAgentPtyWhenReady: vi.fn(),
   mockTrack: vi.fn(),
+  storeListeners: new Set<(state: unknown, previousState: unknown) => void>(),
+  startupLeafId: '11111111-1111-4111-8111-111111111111',
   store: {
     settings: {},
     activeTabIdByWorktree: { 'wt-1': 'tab-1' } as Record<string, string>,
     tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] } as Record<string, { id: string }[]>,
-    ptyIdsByTabId: { 'tab-1': ['pty-1'] } as Record<string, string[]>
+    ptyIdsByTabId: { 'tab-1': ['pty-1'] } as Record<string, string[]>,
+    pendingStartupByTabId: {} as Record<string, { launchToken?: string }>,
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { '11111111-1111-4111-8111-111111111111': 'pty-1' }
+      }
+    } as Record<
+      string,
+      {
+        root: null
+        activeLeafId: null
+        expandedLeafId: null
+        ptyIdsByLeafId?: Record<string, string>
+      }
+    >,
+    agentLaunchConfigByPaneKey: {
+      'tab-1:11111111-1111-4111-8111-111111111111': {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: {
+          tabId: 'tab-1',
+          leafId: '11111111-1111-4111-8111-111111111111',
+          launchToken: 'launch-token-1'
+        }
+      }
+    } as Record<
+      string,
+      {
+        launchConfig: { agentCommand: string; agentArgs: string; agentEnv: Record<string, string> }
+        registeredAt: number
+        identity: { tabId?: string; leafId?: string; launchToken?: string }
+      }
+    >
   }
 }))
 
 vi.mock('@/store', () => ({
   useAppStore: {
-    getState: () => store
+    getState: () => store,
+    subscribe: (listener: (state: unknown, previousState: unknown) => void) => {
+      storeListeners.add(listener)
+      return () => {
+        storeListeners.delete(listener)
+      }
+    }
   }
 }))
 
@@ -31,7 +76,12 @@ vi.mock('@/runtime/runtime-terminal-inspection', () => ({
 }))
 
 vi.mock('@/lib/agent-paste-draft', () => ({
-  pasteDraftWhenAgentReady: mockPasteDraftWhenAgentReady
+  getSettingsForAgentTabRuntimeOwner: () => store.settings,
+  pasteDraftToAgentPtyWhenReady: mockPasteDraftToAgentPtyWhenReady
+}))
+
+vi.mock('@/lib/browser-uuid', () => ({
+  createBrowserUuid: () => 'launch-token-1'
 }))
 
 vi.mock('@/lib/telemetry', () => ({
@@ -44,6 +94,7 @@ import {
   getWorkspaceSeedName,
   isGitLabIssueUrl
 } from './new-workspace'
+import { resetAgentStartupDelayedDeliveryForTests } from './agent-startup-delayed-delivery'
 
 describe('getWorkspaceSeedName', () => {
   it('prefers an explicit name', () => {
@@ -171,17 +222,40 @@ describe('isGitLabIssueUrl', () => {
 
 describe('ensureAgentStartupInTerminal prompt delivery', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     vi.clearAllMocks()
+    storeListeners.clear()
     store.settings = {}
     store.activeTabIdByWorktree = { 'wt-1': 'tab-1' }
     store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1' }] }
     store.ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+    store.pendingStartupByTabId = {}
+    store.terminalLayoutsByTabId = {
+      'tab-1': {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [startupLeafId]: 'pty-1' }
+      }
+    }
+    store.agentLaunchConfigByPaneKey = {
+      [`tab-1:${startupLeafId}`]: {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: { tabId: 'tab-1', leafId: startupLeafId, launchToken: 'launch-token-1' }
+      }
+    }
     mockInspectRuntimeTerminalProcess.mockResolvedValue({
       foregroundProcess: 'aider',
       hasChildProcesses: true
     })
     mockSendRuntimePtyInputVerified.mockResolvedValue(true)
-    mockPasteDraftWhenAgentReady.mockResolvedValue(true)
+    mockPasteDraftToAgentPtyWhenReady.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    resetAgentStartupDelayedDeliveryForTests()
   })
 
   it('sends a follow-up prompt through the terminal runtime without renderer telemetry', async () => {
@@ -249,10 +323,12 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       }
     })
 
-    expect(mockPasteDraftWhenAgentReady).toHaveBeenCalledWith({
+    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledWith({
       tabId: 'tab-1',
+      ptyId: 'pty-1',
       content: 'review this before sending',
-      agent: 'claude'
+      agent: 'claude',
+      forcePaste: true
     })
     expect(mockTrack).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
   })
@@ -261,6 +337,21 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
     store.activeTabIdByWorktree = { 'wt-1': 'setup-tab' }
     store.tabsByWorktree = { 'wt-1': [{ id: 'setup-tab' }, { id: 'agent-tab' }] }
     store.ptyIdsByTabId = { 'setup-tab': ['setup-pty'], 'agent-tab': ['agent-pty'] }
+    store.terminalLayoutsByTabId = {
+      'agent-tab': {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [startupLeafId]: 'agent-pty' }
+      }
+    }
+    store.agentLaunchConfigByPaneKey = {
+      [`agent-tab:${startupLeafId}`]: {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: { tabId: 'agent-tab', leafId: startupLeafId, launchToken: 'launch-token-1' }
+      }
+    }
 
     await ensureAgentStartupInTerminal({
       worktreeId: 'wt-1',
@@ -275,11 +366,357 @@ describe('ensureAgentStartupInTerminal prompt delivery', () => {
       }
     })
 
-    expect(mockPasteDraftWhenAgentReady).toHaveBeenCalledWith({
+    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledWith({
       tabId: 'agent-tab',
+      ptyId: 'agent-pty',
       content: 'Linear context draft',
-      agent: 'codex'
+      agent: 'codex',
+      forcePaste: true
     })
+  })
+
+  it('pastes a draft after the seeded tab receives a delayed PTY', async () => {
+    vi.useFakeTimers()
+    store.ptyIdsByTabId = {}
+    store.terminalLayoutsByTabId = {}
+    store.agentLaunchConfigByPaneKey = {}
+    store.pendingStartupByTabId = { 'tab-1': { launchToken: 'launch-token-1' } }
+
+    const delivery = ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup: {
+        agent: 'codex',
+        launchCommand: 'codex',
+        expectedProcess: 'codex',
+        followupPrompt: null,
+        launchConfig: { agentArgs: '', agentEnv: {} },
+        draftPrompt: 'https://github.com/stablyai/orca/pull/2051'
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await delivery
+
+    expect(mockPasteDraftToAgentPtyWhenReady).not.toHaveBeenCalled()
+
+    store.ptyIdsByTabId = { 'tab-1': ['pty-delayed'] }
+    store.pendingStartupByTabId = {}
+    store.terminalLayoutsByTabId = {
+      'tab-1': {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [startupLeafId]: 'pty-delayed' }
+      }
+    }
+    store.agentLaunchConfigByPaneKey = {
+      [`tab-1:${startupLeafId}`]: {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: { tabId: 'tab-1', leafId: startupLeafId, launchToken: 'launch-token-1' }
+      }
+    }
+    for (const listener of storeListeners) {
+      listener(store, store)
+    }
+
+    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
+    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledWith({
+      tabId: 'tab-1',
+      ptyId: 'pty-delayed',
+      content: 'https://github.com/stablyai/orca/pull/2051',
+      agent: 'codex',
+      forcePaste: true
+    })
+  })
+
+  it('keeps waiting when a non-startup split PTY appears before the startup PTY', async () => {
+    vi.useFakeTimers()
+    store.ptyIdsByTabId = {}
+    store.terminalLayoutsByTabId = {}
+    store.agentLaunchConfigByPaneKey = {}
+    store.pendingStartupByTabId = { 'tab-1': { launchToken: 'launch-token-1' } }
+
+    const delivery = ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup: {
+        agent: 'codex',
+        launchCommand: 'codex',
+        expectedProcess: 'codex',
+        followupPrompt: null,
+        launchConfig: { agentArgs: '', agentEnv: {} },
+        draftPrompt: 'linked draft'
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await delivery
+
+    const splitLeafId = '22222222-2222-4222-8222-222222222222'
+    store.ptyIdsByTabId = { 'tab-1': ['split-pty'] }
+    store.terminalLayoutsByTabId = {
+      'tab-1': {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [splitLeafId]: 'split-pty' }
+      }
+    }
+    store.agentLaunchConfigByPaneKey = {
+      [`tab-1:${splitLeafId}`]: {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: { tabId: 'tab-1', leafId: splitLeafId, launchToken: 'other-token' }
+      }
+    }
+    for (const listener of storeListeners) {
+      listener(store, store)
+    }
+
+    expect(mockPasteDraftToAgentPtyWhenReady).not.toHaveBeenCalled()
+
+    store.ptyIdsByTabId = { 'tab-1': ['split-pty', 'startup-pty'] }
+    store.terminalLayoutsByTabId = {
+      'tab-1': {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [splitLeafId]: 'split-pty', [startupLeafId]: 'startup-pty' }
+      }
+    }
+    store.agentLaunchConfigByPaneKey = {
+      [`tab-1:${splitLeafId}`]: {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: { tabId: 'tab-1', leafId: splitLeafId, launchToken: 'other-token' }
+      },
+      [`tab-1:${startupLeafId}`]: {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 2,
+        identity: { tabId: 'tab-1', leafId: startupLeafId, launchToken: 'launch-token-1' }
+      }
+    }
+    for (const listener of storeListeners) {
+      listener(store, store)
+    }
+
+    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
+    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledWith({
+      tabId: 'tab-1',
+      ptyId: 'startup-pty',
+      content: 'linked draft',
+      agent: 'codex',
+      forcePaste: true
+    })
+  })
+
+  it('does not duplicate delayed delivery across repeated store updates', async () => {
+    vi.useFakeTimers()
+    store.ptyIdsByTabId = {}
+    store.terminalLayoutsByTabId = {}
+    store.agentLaunchConfigByPaneKey = {}
+    store.pendingStartupByTabId = { 'tab-1': { launchToken: 'launch-token-1' } }
+
+    const delivery = ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup: {
+        agent: 'codex',
+        launchCommand: 'codex',
+        expectedProcess: 'codex',
+        followupPrompt: null,
+        launchConfig: { agentArgs: '', agentEnv: {} },
+        draftPrompt: 'linked draft'
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await delivery
+
+    store.ptyIdsByTabId = { 'tab-1': ['pty-delayed'] }
+    store.pendingStartupByTabId = {}
+    store.terminalLayoutsByTabId = {
+      'tab-1': {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [startupLeafId]: 'pty-delayed' }
+      }
+    }
+    store.agentLaunchConfigByPaneKey = {
+      [`tab-1:${startupLeafId}`]: {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: { tabId: 'tab-1', leafId: startupLeafId, launchToken: 'launch-token-1' }
+      }
+    }
+    for (const listener of storeListeners) {
+      listener(store, store)
+      listener(store, store)
+    }
+
+    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not duplicate immediate delivery for the same launch token', async () => {
+    const startup = {
+      agent: 'codex' as const,
+      launchCommand: 'codex',
+      expectedProcess: 'codex',
+      followupPrompt: null,
+      launchConfig: { agentArgs: '', agentEnv: {} },
+      draftPrompt: 'linked draft',
+      launchToken: 'launch-token-1'
+    }
+
+    await ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup
+    })
+    await ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup
+    })
+
+    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps one delayed subscription and tears it down after delivery drains', async () => {
+    vi.useFakeTimers()
+    store.ptyIdsByTabId = {}
+    store.terminalLayoutsByTabId = {}
+    store.agentLaunchConfigByPaneKey = {}
+    store.pendingStartupByTabId = { 'tab-1': { launchToken: 'launch-token-1' } }
+    const startup = {
+      agent: 'codex' as const,
+      launchCommand: 'codex',
+      expectedProcess: 'codex',
+      followupPrompt: null,
+      launchConfig: { agentArgs: '', agentEnv: {} },
+      draftPrompt: 'linked draft',
+      launchToken: 'launch-token-1'
+    }
+
+    const first = ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup
+    })
+    const second = ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await Promise.all([first, second])
+
+    expect(storeListeners.size).toBe(1)
+
+    store.ptyIdsByTabId = { 'tab-1': ['pty-delayed'] }
+    store.pendingStartupByTabId = {}
+    store.terminalLayoutsByTabId = {
+      'tab-1': {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [startupLeafId]: 'pty-delayed' }
+      }
+    }
+    store.agentLaunchConfigByPaneKey = {
+      [`tab-1:${startupLeafId}`]: {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: { tabId: 'tab-1', leafId: startupLeafId, launchToken: 'launch-token-1' }
+      }
+    }
+    for (const listener of storeListeners) {
+      listener(store, store)
+    }
+
+    expect(mockPasteDraftToAgentPtyWhenReady).toHaveBeenCalledTimes(1)
+    expect(storeListeners.size).toBe(0)
+  })
+
+  it('does not let a newer same-tab launch satisfy an older pending delivery', async () => {
+    vi.useFakeTimers()
+    store.ptyIdsByTabId = {}
+    store.terminalLayoutsByTabId = {}
+    store.agentLaunchConfigByPaneKey = {}
+    store.pendingStartupByTabId = { 'tab-1': { launchToken: 'launch-token-old' } }
+
+    const delivery = ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      primaryTabId: 'tab-1',
+      startup: {
+        agent: 'codex',
+        launchCommand: 'codex',
+        expectedProcess: 'codex',
+        followupPrompt: null,
+        launchConfig: { agentArgs: '', agentEnv: {} },
+        draftPrompt: 'old linked draft',
+        launchToken: 'launch-token-old'
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await delivery
+
+    store.pendingStartupByTabId = { 'tab-1': { launchToken: 'launch-token-new' } }
+    for (const listener of storeListeners) {
+      listener(store, store)
+    }
+
+    store.ptyIdsByTabId = { 'tab-1': ['pty-new'] }
+    store.pendingStartupByTabId = {}
+    store.terminalLayoutsByTabId = {
+      'tab-1': {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [startupLeafId]: 'pty-new' }
+      }
+    }
+    store.agentLaunchConfigByPaneKey = {
+      [`tab-1:${startupLeafId}`]: {
+        launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+        registeredAt: 1,
+        identity: { tabId: 'tab-1', leafId: startupLeafId, launchToken: 'launch-token-old' }
+      }
+    }
+    for (const listener of storeListeners) {
+      listener(store, store)
+    }
+
+    expect(mockPasteDraftToAgentPtyWhenReady).not.toHaveBeenCalled()
+  })
+
+  it('does not write a delayed follow-up prompt on readiness timeout', async () => {
+    vi.useFakeTimers()
+    mockInspectRuntimeTerminalProcess.mockResolvedValue({
+      foregroundProcess: 'zsh',
+      hasChildProcesses: false
+    })
+
+    const delivery = ensureAgentStartupInTerminal({
+      worktreeId: 'wt-1',
+      startup: {
+        agent: 'aider',
+        launchCommand: 'aider',
+        expectedProcess: 'aider',
+        followupPrompt: 'fix the spinner',
+        launchConfig: { agentArgs: '', agentEnv: {} }
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await delivery
+
+    expect(mockSendRuntimePtyInputVerified).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -319,6 +319,8 @@ async function deliverAgentStartupToTerminal(
       ptyId,
       content: draftPrompt,
       agent: startup.agent,
+      // Why: startup.draftPrompt is only attached after native draft launch
+      // planning is unavailable, so this paste is the first delivery attempt.
       forcePaste: true
     })
   }
@@ -326,6 +328,8 @@ async function deliverAgentStartupToTerminal(
 
 function ensureStartupLaunchToken(startup: AgentStartupPlan): string {
   if (!startup.launchToken) {
+    // Why: delayed delivery retries must reuse the startup plan's launch token
+    // so they match the pane launch registration for this agent.
     startup.launchToken = createBrowserUuid()
   }
   return startup.launchToken

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -1,16 +1,21 @@
 import { useAppStore } from '@/store'
-import { pasteDraftWhenAgentReady } from '@/lib/agent-paste-draft'
 import {
-  inspectRuntimeTerminalProcess,
-  sendRuntimePtyInputVerified
-} from '@/runtime/runtime-terminal-inspection'
+  getSettingsForAgentTabRuntimeOwner,
+  pasteDraftToAgentPtyWhenReady
+} from '@/lib/agent-paste-draft'
+import { sendFollowupPromptWhenAgentReady } from '@/lib/agent-followup-delivery'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
-import { isShellProcess } from '@/lib/tui-agent-startup'
 import type { LinkedWorkItemContext } from '@/lib/linked-work-item-context'
+import {
+  beginAgentStartupDeliveryAttempt,
+  getAgentStartupTabPtyId,
+  queuePendingAgentStartupDelivery,
+  resolveAgentStartupTabId
+} from '@/lib/agent-startup-delayed-delivery'
 import type { FolderWorkspaceLinkedTask, OrcaHooks, TaskViewPresetId } from '../../../shared/types'
 import { resolveHookCommandSourcePolicy } from '../../../shared/hook-command-source-policy'
-import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
 import { slugifyForWorkspaceName } from '../../../shared/workspace-name'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 export { getLinkedWorkItemSuggestedName } from '../../../shared/workspace-name'
 export { getLinkedWorkItemWorkspaceName } from '../../../shared/workspace-name'
 export { getWorkspaceIntentName } from '../../../shared/workspace-name'
@@ -244,6 +249,7 @@ export async function ensureAgentStartupInTerminal(args: {
   if (startup.followupPrompt === null && draftPrompt === null) {
     return
   }
+  const launchToken = ensureStartupLaunchToken(startup)
 
   // Why: poll until a terminal tab + PTY exists for the worktree before we
   // can interact with it. Activation creates the tab synchronously but the
@@ -252,79 +258,75 @@ export async function ensureAgentStartupInTerminal(args: {
   let ptyId: string | null = null
   for (let attempt = 0; attempt < 30; attempt += 1) {
     if (attempt > 0) {
-      await new Promise((resolve) => window.setTimeout(resolve, 150))
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 150))
     }
     const state = useAppStore.getState()
-    // Why: workspace activation tells us the exact tab that received the agent
-    // startup command. Use it for draft paste instead of re-deriving from
-    // active tab state, which can move while setup/background panes mount.
-    tabId =
-      primaryTabId ??
-      state.activeTabIdByWorktree[worktreeId] ??
-      state.tabsByWorktree[worktreeId]?.[0]?.id ??
-      null
+    tabId = resolveAgentStartupTabId(state, worktreeId, primaryTabId)
     if (!tabId) {
       continue
     }
-    ptyId = state.ptyIdsByTabId[tabId]?.[0] ?? null
+    ptyId = getAgentStartupTabPtyId(state, tabId, launchToken)
     if (ptyId) {
       break
     }
   }
   if (!tabId || !ptyId) {
+    if (tabId) {
+      // Why: background-created workspaces can remain unmounted longer than a
+      // bounded readiness wait. Keep the draft/follow-up tied to the seeded
+      // tab until opening the workspace creates its PTY.
+      queuePendingAgentStartupDelivery({
+        worktreeId,
+        tabId,
+        launchToken,
+        startup,
+        deliver: deliverAgentStartupToTerminal
+      })
+    }
     return
   }
 
+  if (beginAgentStartupDeliveryAttempt({ worktreeId, tabId, launchToken })) {
+    await deliverAgentStartupToTerminal(tabId, ptyId, startup)
+  }
+}
+
+async function deliverAgentStartupToTerminal(
+  tabId: string,
+  ptyId: string,
+  startup: AgentStartupPlan
+): Promise<void> {
+  const draftPrompt = startup.draftPrompt ?? null
+  const runtimeSettings = getSettingsForAgentTabRuntimeOwner(tabId)
   // Why: followupPrompt is the legacy path for stdin-after-start agents
   // (aider, goose, etc.) that need their initial prompt typed into the live
   // session and submitted. Wait until the agent owns the PTY before writing.
   if (startup.followupPrompt) {
-    await waitForAgentForeground(ptyId, startup.expectedProcess)
-    await sendFollowupPrompt(ptyId, startup.followupPrompt)
+    await sendFollowupPromptWhenAgentReady({
+      ptyId,
+      expectedProcess: startup.expectedProcess,
+      prompt: startup.followupPrompt,
+      settings: runtimeSettings
+    })
   }
 
   // Why: draftPrompt uses bracketed-paste so the URL lands atomically in the
   // agent's input buffer (no per-char echo, no auto-submit). Shared with the
   // launch-work-item-direct flow so both behave identically.
   if (draftPrompt) {
-    await pasteDraftWhenAgentReady({
+    await pasteDraftToAgentPtyWhenReady({
       tabId,
+      ptyId,
       content: draftPrompt,
-      agent: startup.agent
+      agent: startup.agent,
+      forcePaste: true
     })
   }
 }
 
-async function sendFollowupPrompt(ptyId: string, prompt: string): Promise<boolean> {
-  try {
-    return await sendRuntimePtyInputVerified(useAppStore.getState().settings, ptyId, `${prompt}\r`)
-  } catch {
-    return false
+function ensureStartupLaunchToken(startup: AgentStartupPlan): string {
+  if (!startup.launchToken) {
+    startup.launchToken = createBrowserUuid()
   }
-}
-
-// Why: legacy followupPrompt path used `agentOwnsForeground` exclusively (with
-// a hasChildProcesses fallback after several polls). Preserve that behavior so
-// stdin-after-start agents still receive their prompt under the same
-// conditions. Returns when the agent appears ready or the budget expires.
-async function waitForAgentForeground(ptyId: string, expectedProcess: string): Promise<void> {
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    if (attempt > 0) {
-      await new Promise((resolve) => window.setTimeout(resolve, 150))
-    }
-    try {
-      const process = await inspectRuntimeTerminalProcess(useAppStore.getState().settings, ptyId)
-      const foreground = process.foregroundProcess?.toLowerCase() ?? ''
-      if (isExpectedAgentProcess(foreground, expectedProcess)) {
-        return
-      }
-      if (attempt >= 4 && !isShellProcess(foreground)) {
-        if (process.hasChildProcesses) {
-          return
-        }
-      }
-    } catch {
-      // Ignore transient PTY inspection failures and keep polling.
-    }
-  }
+  return startup.launchToken
 }

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -32,6 +32,7 @@ function buildStartupOpt(
     command: plan.launchCommand,
     ...(plan.env ? { env: plan.env } : {}),
     launchConfig: plan.launchConfig,
+    ...(plan.launchToken ? { launchToken: plan.launchToken } : {}),
     ...(request.agent ? { launchAgent: request.agent } : {}),
     ...(plan.startupCommandDelivery ? { startupCommandDelivery: plan.startupCommandDelivery } : {}),
     // Why: command-code shows its prompt in the tab status before the first
@@ -144,6 +145,11 @@ async function executeWorktreeCreation(
   }
 
   const backendSpawned = result.startupTerminal?.spawned === true
+  if (request.startupPlan && !backendSpawned && !request.startupPlan.launchToken) {
+    // Why: delayed delivery must target the exact pane spawned from this queued
+    // startup, so both halves of the handoff share one renderer-session token.
+    request.startupPlan.launchToken = createBrowserUuid()
+  }
   const startupOpt = buildStartupOpt(request, backendSpawned)
 
   if (worktree.path) {

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -25,6 +25,7 @@ export type AgentStartupPlan = {
   expectedProcess: string
   followupPrompt: string | null
   launchConfig: SleepingAgentLaunchConfig
+  launchToken?: string
   draftPrompt?: string | null
   env?: Record<string, string>
   startupCommandDelivery?: StartupCommandDelivery


### PR DESCRIPTION
## Summary
- Preserves linked work item draft/follow-up delivery when a new workspace's agent terminal mounts after the initial startup wait.
- Binds delayed delivery to the startup launch token and pane PTY instead of the first PTY in a tab, so setup/split panes cannot steal or cancel the draft.
- Adds PTY-bound draft paste and stricter follow-up delivery that only writes after the expected agent process is positively observed.

## Brennan YOLO Lite
- Design approach: renderer-session delayed delivery manager keyed by worktree, tab, and launch token; startup payloads carry the same launch token used by terminal launch registration; delivery consumes before async paste/readiness work.
- Design review: delegated `auto-design-review-fix` completed; review strengthened the design around launch identity, PTY binding, native fallback paste, follow-up safety, and validation.
- Implementation: reconciled to the reviewed design with launch-token plumbing through worktree/folder startup paths, PTY-bound paste helper, follow-up readiness helper, stale spawn cleanup, and focused regressions.
- Deviations: none from the final reviewed design; renderer-session persistence remains intentionally scoped to the existing startup-command lifetime.
- Completeness verification: delegated read-only verification initially found gaps; fixes were applied; final verification returned complete for code review.
- Code review: two independent `review-code` agents returned clean in the same round.
- Brennan validation: delegated `brennan-test-changes` returned `land`.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/new-workspace.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` — 208 passed
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-creation-flow.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check --cached`
- Post-commit: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/new-workspace.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` — 208 passed
- CodeRabbit follow-up: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/agent-paste-draft.test.ts src/renderer/src/lib/new-workspace.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` — 231 passed
- CodeRabbit follow-up: `pnpm run typecheck:web`
- CodeRabbit follow-up: `pnpm exec oxlint src/renderer/src/lib/agent-paste-draft.ts src/renderer/src/lib/agent-paste-draft.test.ts src/renderer/src/lib/agent-startup-delayed-delivery.ts src/renderer/src/lib/new-workspace.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- CodeRabbit follow-up: `git diff --check`

## Electron Validation
- Launched exact worktree via CDP and verified identity: `mantaray @ brennanb2025/worktree-pr-link`, root `/Users/thebr/orca/workspaces/orca/mantaray`.
- Used disposable non-Orca `demo-project`.
- Verified no draft delivery before the startup PTY existed.
- Activated the workspace so `TerminalPane` consumed pending startup and spawned the launch-token-bound PTY.
- Verified draft delivery occurred after readiness and did not repeat after store updates.
- Evidence captured locally:
  - `/var/folders/nk/tt6kt56s3hn9rv32dj7kymv00000gn/T/orca-mantaray-startup-delivery-evidence.txt`
  - `/var/folders/nk/tt6kt56s3hn9rv32dj7kymv00000gn/T/orca-mantaray-startup-delivery-terminal.png`

## Accepted Gaps
- Validation setup used store/API calls for setup, then activated through the product terminal path; it did not click through the full create-workspace modal.
- Agent readiness was simulated through Orca's PTY sidecar rather than a live external provider session.
- The terminal buffer displayed the draft string twice from one bracketed paste due to shell echo/reprint; duplicate-delivery proof was that the count did not increase after repeated store updates.

## Post-PR Stabilization
- Waited the required 8 minutes after opening the PR.
- Initial CodeRabbit sweep found three actionable comments plus two nits. Follow-up commit `8752eab99` addressed the bounded fallback timeout, fire-and-forget rejection handling, launch-token mutation comment, and pane-binding test hardening.
- The native-prefill/`forcePaste` comment was reviewed as a false positive: `startup.draftPrompt` is attached only after native draft launch planning is unavailable, so the paste is the first delivery attempt. Added a code comment documenting that invariant.
- Waited the required 8 minutes after the follow-up push. CodeRabbit's refreshed review reported no actionable comments for `8752eab99`.
- Stage posted a non-actionable chapter summary.
- PR checks: `verify` passed after the follow-up push.