### PR TITLE
fix: publish linux release matrix artifacts

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -894,7 +894,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Publish release artifacts (Linux)
-        if: matrix.platform == 'linux'
+        if: matrix.platform == 'linux-x64' || matrix.platform == 'linux-arm64'
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 30

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -86,6 +86,21 @@ describe('Electron runtime package contract', () => {
     )
   })
 
+  it('publishes both Linux release matrix entries', () => {
+    const releaseWorkflow = readFileSync(
+      join(projectDir, '.github/workflows/release-cut.yml'),
+      'utf8'
+    )
+    const parsedWorkflow = parse(releaseWorkflow)
+    const publishLinuxStep = parsedWorkflow.jobs.build.steps.find(
+      (step) => step.name === 'Publish release artifacts (Linux)'
+    )
+
+    expect(publishLinuxStep.if).toContain("matrix.platform == 'linux-x64'")
+    expect(publishLinuxStep.if).toContain("matrix.platform == 'linux-arm64'")
+    expect(publishLinuxStep.with.command).toBe('${{ matrix.release_command }}')
+  })
+
   it('lets release-cut tag a version that is already present on main', () => {
     const releaseWorkflow = readFileSync(
       join(projectDir, '.github/workflows/release-cut.yml'),


### PR DESCRIPTION
## Summary
- fix the release-cut Linux publish condition for the split linux-x64/linux-arm64 matrix
- add a contract test so both Linux release matrix entries remain covered by the publish step

## Why
The v1.4.92-rc.0 draft release only uploaded macOS assets. In run 27983651452, both Linux matrix entries used platform values linux-x64/linux-arm64, but the publish step still checked matrix.platform == 'linux', so it skipped publishing Linux artifacts. The later telemetry verify then failed because no packaged Linux dist existed to inspect.

## Test
- pnpm exec vitest run config/scripts/package-electron-runtime-contract.test.mjs config/scripts/verify-release-required-assets.test.mjs config/scripts/electron-builder-config.test.mjs