### PR TITLE
Keep repos visible when project group metadata is missing

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -1405,6 +1405,49 @@ describe('project groups', () => {
     })
   })
 
+  it('does not render collapsed child-group repos as missing metadata fallbacks', () => {
+    const parentGroup: ProjectGroup = {
+      id: 'parent-group',
+      name: 'Platform',
+      parentPath: '/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const childGroup: ProjectGroup = {
+      ...parentGroup,
+      id: 'child-group',
+      name: 'Services',
+      parentPath: '/platform/services',
+      parentGroupId: parentGroup.id
+    }
+    const repoInChildGroup: Repo = { ...repo, projectGroupId: childGroup.id }
+
+    const rows = buildRows(
+      'repo',
+      [worktree],
+      new Map([[repoInChildGroup.id, repoInChildGroup]]),
+      null,
+      new Set(['project-group:parent-group']),
+      new Map([[repoInChildGroup.id, 0]]),
+      undefined,
+      'manual',
+      {},
+      new Map([[worktree.id, worktree]]),
+      false,
+      undefined,
+      [parentGroup, childGroup]
+    )
+
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
+      'project-group:parent-group'
+    ])
+  })
+
   it('disambiguates duplicate top-level repo basenames without renaming repos', () => {
     const group: ProjectGroup = {
       id: 'group-1',

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -2189,10 +2189,58 @@ describe('project groups', () => {
 
   it('returns both parent Project Group and repo keys for grouped repo reveals', () => {
     const groupedRepo: Repo = { ...repo, projectGroupId: 'group-1' }
+    const group: ProjectGroup = {
+      id: 'group-1',
+      name: 'Platform',
+      parentPath: '/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
 
     expect(
-      getGroupKeysForWorktree('repo', worktree, new Map([[groupedRepo.id, groupedRepo]]), null)
+      getGroupKeysForWorktree(
+        'repo',
+        worktree,
+        new Map([[groupedRepo.id, groupedRepo]]),
+        null,
+        undefined,
+        undefined,
+        [group]
+      )
     ).toEqual(['project-group:group-1', 'repo:repo-1'])
+  })
+
+  it('returns only the repo key for missing Project Group metadata reveals', () => {
+    const groupedRepo: Repo = { ...repo, projectGroupId: 'missing-group' }
+    const loadedGroup: ProjectGroup = {
+      id: 'loaded-group',
+      name: 'Loaded',
+      parentPath: '/loaded',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    expect(
+      getGroupKeysForWorktree(
+        'repo',
+        worktree,
+        new Map([[groupedRepo.id, groupedRepo]]),
+        null,
+        undefined,
+        undefined,
+        [loadedGroup]
+      )
+    ).toEqual(['repo:repo-1'])
   })
 
   it('returns only the repo key for ungrouped repo reveals', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -1365,6 +1365,46 @@ describe('project groups', () => {
     ])
   })
 
+  it('renders repos whose Project Group metadata is missing as top-level repo rows', () => {
+    const group: ProjectGroup = {
+      id: 'group-1',
+      name: 'Platform',
+      parentPath: '/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const repoWithMissingGroup: Repo = { ...repo, projectGroupId: 'missing-group' }
+
+    const rows = buildRows(
+      'repo',
+      [worktree],
+      new Map([[repoWithMissingGroup.id, repoWithMissingGroup]]),
+      null,
+      new Set(),
+      new Map([[repoWithMissingGroup.id, 0]]),
+      undefined,
+      'manual',
+      {},
+      new Map([[worktree.id, worktree]]),
+      false,
+      undefined,
+      [group]
+    )
+
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
+      'project-group:group-1',
+      'repo:repo-1'
+    ])
+    expect(rows.find((row) => row.type === 'header' && row.key === 'repo:repo-1')).toMatchObject({
+      projectGroupDepth: 0
+    })
+  })
+
   it('disambiguates duplicate top-level repo basenames without renaming repos', () => {
     const group: ProjectGroup = {
       id: 'group-1',

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -1155,7 +1155,7 @@ export function buildRows(
 
   const remainingRepoEntries = [...(groupByProjectGroupId.get(null) ?? [])]
   for (const [projectGroupId, entries] of groupByProjectGroupId) {
-    if (projectGroupId === null) {
+    if (projectGroupId === null || projectGroupsById.has(projectGroupId)) {
       continue
     }
     // Why: startup can have repos from hosts whose project-group metadata was

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -1226,9 +1226,15 @@ export function getGroupKeysForWorktree(
   const visited = new Set<string>()
   let currentGroupId = repo?.projectGroupId ?? null
   while (currentGroupId && !visited.has(currentGroupId)) {
+    const group = groupsById.get(currentGroupId)
+    if (!group) {
+      // Why: repos can arrive before their remote Project Group metadata; reveal
+      // keys must match the top-level fallback rows buildRows actually renders.
+      break
+    }
     visited.add(currentGroupId)
     groupIds.unshift(currentGroupId)
-    const parentId = groupsById.get(currentGroupId)?.parentGroupId ?? null
+    const parentId = group.parentGroupId ?? null
     currentGroupId = parentId && groupsById.has(parentId) ? parentId : null
   }
   return [...groupIds.map((id) => getProjectGroupHeaderKey(id)), groupKey]

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -1153,8 +1153,17 @@ export function buildRows(
     appendProjectGroup(projectGroup, 0)
   }
 
+  const remainingRepoEntries = [...(groupByProjectGroupId.get(null) ?? [])]
+  for (const [projectGroupId, entries] of groupByProjectGroupId) {
+    if (projectGroupId === null) {
+      continue
+    }
+    // Why: startup can have repos from hosts whose project-group metadata was
+    // not fetched yet; missing metadata must not make those repos disappear.
+    remainingRepoEntries.push(...entries)
+  }
   appendOrderedGroups(
-    withRepoSectionDisplayLabels(sortRepoEntriesWithinGroup(groupByProjectGroupId.get(null) ?? [])),
+    withRepoSectionDisplayLabels(sortRepoEntriesWithinGroup(remainingRepoEntries)),
     0
   )
 

--- a/src/renderer/src/store/slices/repos-all-hosts.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts.test.ts
@@ -188,7 +188,10 @@ beforeEach(() => {
   })
 })
 
-function configureSharedProjectCompatibilityMocks(): { sharedProjectId: string } {
+function configureSharedProjectCompatibilityMocks(): {
+  sharedProjectId: string
+  sharedRemoteProject: Project
+} {
   const sharedProjectId = 'github:stablyai/orca'
   const localRepoWithIdentity: Repo = {
     ...localRepo,
@@ -262,7 +265,7 @@ function configureSharedProjectCompatibilityMocks(): { sharedProjectId: string }
       _meta: { runtimeId: 'runtime-remote' }
     }
   })
-  return { sharedProjectId }
+  return { sharedProjectId, sharedRemoteProject }
 }
 
 function expectSharedProjectMetadata(projects: readonly Project[], sharedProjectId: string): void {
@@ -323,6 +326,107 @@ describe('fetchReposForAllHosts', () => {
     await store.getState().fetchRuntimeEnvironmentRepos('env-1')
 
     expectSharedProjectMetadata(store.getState().projects, sharedProjectId)
+  })
+
+  it('keeps the local side of a shared project when a runtime refresh removes its repos', async () => {
+    const { sharedProjectId } = configureSharedProjectCompatibilityMocks()
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      if (args.method === 'repo.list') {
+        return {
+          id: 'rpc-repo-list-empty',
+          ok: true,
+          result: { repos: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'project.list') {
+        return {
+          id: 'rpc-project-list-empty',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'projectHostSetup.list') {
+        return {
+          id: 'rpc-project-host-setup-list-empty',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      return {
+        id: 'rpc-other',
+        ok: true,
+        result: {},
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+    const sharedProject = store
+      .getState()
+      .projects.find((project) => project.id === sharedProjectId)
+    expect(sharedProject?.sourceRepoIds).toEqual(['local-repo'])
+    expect(sharedProject?.localWindowsRuntimePreference).toEqual({ kind: 'windows-host' })
+    expect(store.getState().projectHostSetups).toEqual([
+      expect.objectContaining({
+        projectId: sharedProjectId,
+        hostId: 'local',
+        repoId: 'local-repo'
+      })
+    ])
+  })
+
+  it('drops stale runtime repo ownership when project metadata lags behind repo removal', async () => {
+    const { sharedProjectId, sharedRemoteProject } = configureSharedProjectCompatibilityMocks()
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      if (args.method === 'repo.list') {
+        return {
+          id: 'rpc-repo-list-empty',
+          ok: true,
+          result: { repos: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'project.list') {
+        return {
+          id: 'rpc-project-list-stale',
+          ok: true,
+          result: { projects: [sharedRemoteProject] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'projectHostSetup.list') {
+        return {
+          id: 'rpc-project-host-setup-list-empty',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      return {
+        id: 'rpc-other',
+        ok: true,
+        result: {},
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+    expect(
+      store.getState().projects.find((project) => project.id === sharedProjectId)?.sourceRepoIds
+    ).toEqual(['local-repo'])
   })
 
   it('fails soft when a runtime environment is unreachable, keeping local repos', async () => {

--- a/src/renderer/src/store/slices/repos-all-hosts.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts.test.ts
@@ -188,6 +188,89 @@ beforeEach(() => {
   })
 })
 
+function configureSharedProjectCompatibilityMocks(): { sharedProjectId: string } {
+  const sharedProjectId = 'github:stablyai/orca'
+  const localRepoWithIdentity: Repo = {
+    ...localRepo,
+    upstream: { owner: 'stablyai', repo: 'orca' }
+  }
+  const remoteRepoWithIdentity: Repo = {
+    ...remoteRepo,
+    upstream: { owner: 'stablyai', repo: 'orca' }
+  }
+  const sharedLocalProject: Project = {
+    id: sharedProjectId,
+    displayName: 'Orca',
+    badgeColor: '#000',
+    sourceRepoIds: ['local-repo'],
+    localWindowsRuntimePreference: { kind: 'windows-host' },
+    createdAt: 1,
+    updatedAt: 1
+  }
+  const sharedRemoteProject: Project = {
+    id: sharedProjectId,
+    displayName: 'Orca',
+    badgeColor: '#111',
+    sourceRepoIds: ['remote-repo'],
+    createdAt: 2,
+    updatedAt: 2
+  }
+  const sharedLocalSetup: ProjectHostSetup = {
+    ...localProjectHostSetup,
+    projectId: sharedProjectId
+  }
+  const sharedRemoteSetup: ProjectHostSetup = {
+    ...localProjectHostSetup,
+    id: 'remote-setup',
+    projectId: sharedProjectId,
+    repoId: 'remote-repo',
+    path: '/srv/repo',
+    displayName: 'Remote setup'
+  }
+  reposList.mockResolvedValue([localRepoWithIdentity])
+  projectsList.mockResolvedValue([sharedLocalProject])
+  listHostSetups.mockResolvedValue([sharedLocalSetup])
+  runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    if (args.method === 'repo.list') {
+      return {
+        id: 'rpc-repo-list',
+        ok: true,
+        result: { repos: [remoteRepoWithIdentity] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    }
+    if (args.method === 'project.list') {
+      return {
+        id: 'rpc-project-list',
+        ok: true,
+        result: { projects: [sharedRemoteProject] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    }
+    if (args.method === 'projectHostSetup.list') {
+      return {
+        id: 'rpc-project-host-setup-list',
+        ok: true,
+        result: { setups: [sharedRemoteSetup] },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    }
+    return {
+      id: 'rpc-other',
+      ok: true,
+      result: {},
+      _meta: { runtimeId: 'runtime-remote' }
+    }
+  })
+  return { sharedProjectId }
+}
+
+function expectSharedProjectMetadata(projects: readonly Project[], sharedProjectId: string): void {
+  const sharedProject = projects.find((project) => project.id === sharedProjectId)
+  expect([...(sharedProject?.sourceRepoIds ?? [])].sort()).toEqual(['local-repo', 'remote-repo'])
+  expect(sharedProject?.localWindowsRuntimePreference).toEqual({ kind: 'windows-host' })
+}
+
 describe('fetchReposForAllHosts', () => {
   it('loads local + all configured runtime environments even when a remote env is active', async () => {
     // Why: a cold start that restored a remote workspace leaves the remote
@@ -208,89 +291,13 @@ describe('fetchReposForAllHosts', () => {
   })
 
   it('preserves shared project metadata when the same project id is fetched from multiple hosts', async () => {
-    const sharedProjectId = 'github:stablyai/orca'
-    const localRepoWithIdentity: Repo = {
-      ...localRepo,
-      upstream: { owner: 'stablyai', repo: 'orca' }
-    }
-    const remoteRepoWithIdentity: Repo = {
-      ...remoteRepo,
-      upstream: { owner: 'stablyai', repo: 'orca' }
-    }
-    const sharedLocalProject: Project = {
-      id: sharedProjectId,
-      displayName: 'Orca',
-      badgeColor: '#000',
-      sourceRepoIds: ['local-repo'],
-      localWindowsRuntimePreference: { kind: 'windows-host' },
-      createdAt: 1,
-      updatedAt: 1
-    }
-    const sharedRemoteProject: Project = {
-      id: sharedProjectId,
-      displayName: 'Orca',
-      badgeColor: '#111',
-      sourceRepoIds: ['remote-repo'],
-      createdAt: 2,
-      updatedAt: 2
-    }
-    const sharedLocalSetup: ProjectHostSetup = {
-      ...localProjectHostSetup,
-      projectId: sharedProjectId
-    }
-    const sharedRemoteSetup: ProjectHostSetup = {
-      ...localProjectHostSetup,
-      id: 'remote-setup',
-      projectId: sharedProjectId,
-      repoId: 'remote-repo',
-      path: '/srv/repo',
-      displayName: 'Remote setup'
-    }
-    reposList.mockResolvedValue([localRepoWithIdentity])
-    projectsList.mockResolvedValue([sharedLocalProject])
-    listHostSetups.mockResolvedValue([sharedLocalSetup])
-    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
-      if (args.method === 'repo.list') {
-        return {
-          id: 'rpc-repo-list',
-          ok: true,
-          result: { repos: [remoteRepoWithIdentity] },
-          _meta: { runtimeId: 'runtime-remote' }
-        }
-      }
-      if (args.method === 'project.list') {
-        return {
-          id: 'rpc-project-list',
-          ok: true,
-          result: { projects: [sharedRemoteProject] },
-          _meta: { runtimeId: 'runtime-remote' }
-        }
-      }
-      if (args.method === 'projectHostSetup.list') {
-        return {
-          id: 'rpc-project-host-setup-list',
-          ok: true,
-          result: { setups: [sharedRemoteSetup] },
-          _meta: { runtimeId: 'runtime-remote' }
-        }
-      }
-      return {
-        id: 'rpc-other',
-        ok: true,
-        result: {},
-        _meta: { runtimeId: 'runtime-remote' }
-      }
-    })
+    const { sharedProjectId } = configureSharedProjectCompatibilityMocks()
     const store = createTestStore()
     store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
 
     await store.getState().fetchReposForAllHosts()
 
-    const sharedProject = store
-      .getState()
-      .projects.find((project) => project.id === sharedProjectId)
-    expect([...(sharedProject?.sourceRepoIds ?? [])].sort()).toEqual(['local-repo', 'remote-repo'])
-    expect(sharedProject?.localWindowsRuntimePreference).toEqual({ kind: 'windows-host' })
+    expectSharedProjectMetadata(store.getState().projects, sharedProjectId)
     expect(store.getState().projectHostSetups).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -305,6 +312,17 @@ describe('fetchReposForAllHosts', () => {
         })
       ])
     )
+  })
+
+  it('preserves shared project metadata after a runtime-only repo refresh', async () => {
+    const { sharedProjectId } = configureSharedProjectCompatibilityMocks()
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+    expectSharedProjectMetadata(store.getState().projects, sharedProjectId)
   })
 
   it('fails soft when a runtime environment is unreachable, keeping local repos', async () => {

--- a/src/renderer/src/store/slices/repos-all-hosts.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts.test.ts
@@ -188,15 +188,23 @@ beforeEach(() => {
   })
 })
 
-function configureSharedProjectCompatibilityMocks(): {
+function configureSharedProjectCompatibilityMocks(
+  options: {
+    localRepoHasProviderIdentity?: boolean
+    remoteProjectRuntimePreference?: Project['localWindowsRuntimePreference']
+  } = {}
+): {
   sharedProjectId: string
   sharedRemoteProject: Project
 } {
   const sharedProjectId = 'github:stablyai/orca'
-  const localRepoWithIdentity: Repo = {
-    ...localRepo,
-    upstream: { owner: 'stablyai', repo: 'orca' }
-  }
+  const localRepoForSharedProject: Repo =
+    options.localRepoHasProviderIdentity === false
+      ? localRepo
+      : {
+          ...localRepo,
+          upstream: { owner: 'stablyai', repo: 'orca' }
+        }
   const remoteRepoWithIdentity: Repo = {
     ...remoteRepo,
     upstream: { owner: 'stablyai', repo: 'orca' }
@@ -215,6 +223,9 @@ function configureSharedProjectCompatibilityMocks(): {
     displayName: 'Orca',
     badgeColor: '#111',
     sourceRepoIds: ['remote-repo'],
+    ...(options.remoteProjectRuntimePreference
+      ? { localWindowsRuntimePreference: options.remoteProjectRuntimePreference }
+      : {}),
     createdAt: 2,
     updatedAt: 2
   }
@@ -230,7 +241,7 @@ function configureSharedProjectCompatibilityMocks(): {
     path: '/srv/repo',
     displayName: 'Remote setup'
   }
-  reposList.mockResolvedValue([localRepoWithIdentity])
+  reposList.mockResolvedValue([localRepoForSharedProject])
   projectsList.mockResolvedValue([sharedLocalProject])
   listHostSetups.mockResolvedValue([sharedLocalSetup])
   runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
@@ -293,6 +304,92 @@ describe('fetchReposForAllHosts', () => {
     expect(store.getState().projectHostSetups).toContainEqual(localProjectHostSetup)
   })
 
+  it('preserves runtime-owned project metadata during a local-only repo refresh', async () => {
+    const runtimeProject: Project = {
+      id: 'repo:remote-repo',
+      displayName: 'Runtime API project',
+      badgeColor: '#abc',
+      sourceRepoIds: ['remote-repo'],
+      createdAt: 3,
+      updatedAt: 4
+    }
+    const runtimeSetup: ProjectHostSetup = {
+      ...localProjectHostSetup,
+      id: 'runtime-setup',
+      projectId: runtimeProject.id,
+      repoId: 'remote-repo',
+      path: '/srv/repo',
+      displayName: 'Runtime setup',
+      setupState: 'ready',
+      createdAt: 3,
+      updatedAt: 4
+    }
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      if (args.method === 'repo.list') {
+        return {
+          id: 'rpc-repo-list',
+          ok: true,
+          result: { repos: [remoteRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'project.list') {
+        return {
+          id: 'rpc-project-list',
+          ok: true,
+          result: { projects: [runtimeProject] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'projectHostSetup.list') {
+        return {
+          id: 'rpc-project-host-setup-list',
+          ok: true,
+          result: { setups: [runtimeSetup] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      return {
+        id: 'rpc-other',
+        ok: true,
+        result: {},
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+    const store = createTestStore()
+
+    await store.getState().fetchReposForAllHosts()
+    await store.getState().fetchRepos()
+
+    expect(
+      store
+        .getState()
+        .projects.map((project) => project.id)
+        .sort()
+    ).toEqual(['local-project', 'repo:remote-repo'])
+    expect(store.getState().projects.find((project) => project.id === runtimeProject.id)).toEqual(
+      expect.objectContaining({
+        displayName: runtimeProject.displayName,
+        badgeColor: runtimeProject.badgeColor
+      })
+    )
+  })
+
+  it('does not backfill another host repo-derived project during runtime-only refresh', async () => {
+    const store = createTestStore()
+
+    await store.getState().fetchReposForAllHosts()
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+    expect(
+      store
+        .getState()
+        .projects.map((project) => project.id)
+        .sort()
+    ).toEqual(['local-project', 'repo:remote-repo'])
+    expect(store.getState().projects).toContainEqual(localProject)
+  })
+
   it('preserves shared project metadata when the same project id is fetched from multiple hosts', async () => {
     const { sharedProjectId } = configureSharedProjectCompatibilityMocks()
     const store = createTestStore()
@@ -315,6 +412,21 @@ describe('fetchReposForAllHosts', () => {
         })
       ])
     )
+  })
+
+  it('keeps local Windows runtime preference when remote project metadata has its own preference', async () => {
+    const { sharedProjectId } = configureSharedProjectCompatibilityMocks({
+      remoteProjectRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+
+    expect(
+      store.getState().projects.find((project) => project.id === sharedProjectId)
+        ?.localWindowsRuntimePreference
+    ).toEqual({ kind: 'windows-host' })
   })
 
   it('preserves shared project metadata after a runtime-only repo refresh', async () => {
@@ -381,6 +493,129 @@ describe('fetchReposForAllHosts', () => {
         repoId: 'local-repo'
       })
     ])
+  })
+
+  it('preserves API-owned local shared projects when repo identity cannot re-derive them', async () => {
+    const { sharedProjectId } = configureSharedProjectCompatibilityMocks({
+      localRepoHasProviderIdentity: false
+    })
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+    expectSharedProjectMetadata(store.getState().projects, sharedProjectId)
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      if (args.method === 'repo.list') {
+        return {
+          id: 'rpc-repo-list-empty',
+          ok: true,
+          result: { repos: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'project.list') {
+        return {
+          id: 'rpc-project-list-empty',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'projectHostSetup.list') {
+        return {
+          id: 'rpc-project-host-setup-list-empty',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      return {
+        id: 'rpc-other',
+        ok: true,
+        result: {},
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+    expect(store.getState().projects.map((project) => project.id)).toEqual([sharedProjectId])
+    expect(
+      store.getState().projects.find((project) => project.id === sharedProjectId)?.sourceRepoIds
+    ).toEqual(['local-repo'])
+    expect(store.getState().projectHostSetups).toEqual([
+      expect.objectContaining({
+        projectId: sharedProjectId,
+        hostId: 'local',
+        repoId: 'local-repo'
+      })
+    ])
+  })
+
+  it('drops refreshed-host source ownership when that repo no longer matches a shared project', async () => {
+    const { sharedProjectId } = configureSharedProjectCompatibilityMocks()
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      if (args.method === 'repo.list') {
+        return {
+          id: 'rpc-repo-list-reassigned',
+          ok: true,
+          result: { repos: [remoteRepo] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'project.list') {
+        return {
+          id: 'rpc-project-list-empty',
+          ok: true,
+          result: { projects: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'projectHostSetup.list') {
+        return {
+          id: 'rpc-project-host-setup-list-empty',
+          ok: true,
+          result: { setups: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      return {
+        id: 'rpc-other',
+        ok: true,
+        result: {},
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+    expect(
+      store.getState().projects.find((project) => project.id === sharedProjectId)?.sourceRepoIds
+    ).toEqual(['local-repo'])
+    expect(
+      store
+        .getState()
+        .projects.map((project) => project.id)
+        .sort()
+    ).toEqual(['github:stablyai/orca', 'repo:remote-repo'])
+    expect(store.getState().projectHostSetups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          projectId: sharedProjectId,
+          hostId: 'local',
+          repoId: 'local-repo'
+        }),
+        expect.objectContaining({
+          projectId: 'repo:remote-repo',
+          hostId: 'runtime:env-1',
+          repoId: 'remote-repo'
+        })
+      ])
+    )
   })
 
   it('drops stale runtime repo ownership when project metadata lags behind repo removal', async () => {

--- a/src/renderer/src/store/slices/repos-all-hosts.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts.test.ts
@@ -207,6 +207,106 @@ describe('fetchReposForAllHosts', () => {
     expect(store.getState().projectHostSetups).toContainEqual(localProjectHostSetup)
   })
 
+  it('preserves shared project metadata when the same project id is fetched from multiple hosts', async () => {
+    const sharedProjectId = 'github:stablyai/orca'
+    const localRepoWithIdentity: Repo = {
+      ...localRepo,
+      upstream: { owner: 'stablyai', repo: 'orca' }
+    }
+    const remoteRepoWithIdentity: Repo = {
+      ...remoteRepo,
+      upstream: { owner: 'stablyai', repo: 'orca' }
+    }
+    const sharedLocalProject: Project = {
+      id: sharedProjectId,
+      displayName: 'Orca',
+      badgeColor: '#000',
+      sourceRepoIds: ['local-repo'],
+      localWindowsRuntimePreference: { kind: 'windows-host' },
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const sharedRemoteProject: Project = {
+      id: sharedProjectId,
+      displayName: 'Orca',
+      badgeColor: '#111',
+      sourceRepoIds: ['remote-repo'],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const sharedLocalSetup: ProjectHostSetup = {
+      ...localProjectHostSetup,
+      projectId: sharedProjectId
+    }
+    const sharedRemoteSetup: ProjectHostSetup = {
+      ...localProjectHostSetup,
+      id: 'remote-setup',
+      projectId: sharedProjectId,
+      repoId: 'remote-repo',
+      path: '/srv/repo',
+      displayName: 'Remote setup'
+    }
+    reposList.mockResolvedValue([localRepoWithIdentity])
+    projectsList.mockResolvedValue([sharedLocalProject])
+    listHostSetups.mockResolvedValue([sharedLocalSetup])
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      if (args.method === 'repo.list') {
+        return {
+          id: 'rpc-repo-list',
+          ok: true,
+          result: { repos: [remoteRepoWithIdentity] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'project.list') {
+        return {
+          id: 'rpc-project-list',
+          ok: true,
+          result: { projects: [sharedRemoteProject] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      if (args.method === 'projectHostSetup.list') {
+        return {
+          id: 'rpc-project-host-setup-list',
+          ok: true,
+          result: { setups: [sharedRemoteSetup] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      return {
+        id: 'rpc-other',
+        ok: true,
+        result: {},
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+
+    const sharedProject = store
+      .getState()
+      .projects.find((project) => project.id === sharedProjectId)
+    expect([...(sharedProject?.sourceRepoIds ?? [])].sort()).toEqual(['local-repo', 'remote-repo'])
+    expect(sharedProject?.localWindowsRuntimePreference).toEqual({ kind: 'windows-host' })
+    expect(store.getState().projectHostSetups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          projectId: sharedProjectId,
+          hostId: 'local',
+          repoId: 'local-repo'
+        }),
+        expect.objectContaining({
+          projectId: sharedProjectId,
+          hostId: 'runtime:env-1',
+          repoId: 'remote-repo'
+        })
+      ])
+    )
+  })
+
   it('fails soft when a runtime environment is unreachable, keeping local repos', async () => {
     runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
       if (args.method === 'repo.list') {

--- a/src/renderer/src/store/slices/repos-project-runtime.test.ts
+++ b/src/renderer/src/store/slices/repos-project-runtime.test.ts
@@ -135,6 +135,47 @@ describe('repo slice project runtime updates', () => {
     expect(window.api.projects.listHostSetups).toHaveBeenCalled()
   })
 
+  it('clears stale local runtime preferences when local project refresh omits them', async () => {
+    const staleProject: Project = {
+      id: 'local-project',
+      displayName: 'Project',
+      badgeColor: '#000',
+      sourceRepoIds: ['local-repo'],
+      localWindowsRuntimePreference: { kind: 'windows-host' },
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const refreshedProject: Project = {
+      id: staleProject.id,
+      displayName: staleProject.displayName,
+      badgeColor: staleProject.badgeColor,
+      sourceRepoIds: ['local-repo'],
+      createdAt: 1,
+      updatedAt: 2
+    }
+    const setup: ProjectHostSetup = {
+      id: 'setup-1',
+      projectId: staleProject.id,
+      hostId: 'local',
+      repoId: 'local-repo',
+      path: '/local',
+      displayName: 'Local',
+      setupState: 'ready',
+      setupMethod: 'legacy-repo',
+      createdAt: 1,
+      updatedAt: 1
+    }
+    projectsList.mockResolvedValue([refreshedProject])
+    window.api.projects.listHostSetups = vi.fn().mockResolvedValue([setup])
+    reposList.mockResolvedValue([localRepo])
+    const store = createTestStore()
+    store.setState({ projects: [staleProject], projectHostSetups: [setup] })
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().projects[0]?.localWindowsRuntimePreference).toBeUndefined()
+  })
+
   it('updates local project runtime preferences through the projects API', async () => {
     const project: Project = {
       id: 'project-1',
@@ -223,5 +264,62 @@ describe('repo slice project runtime updates', () => {
       timeoutMs: 15_000
     })
     expect(projectsUpdate).not.toHaveBeenCalled()
+  })
+
+  it('preserves shared project source repos when updating local runtime preferences', async () => {
+    const project: Project = {
+      id: 'github:stablyai/orca',
+      displayName: 'Orca',
+      badgeColor: '#000',
+      sourceRepoIds: ['local-repo', 'remote-repo'],
+      createdAt: 1,
+      updatedAt: 2
+    }
+    projectsUpdate.mockResolvedValue({
+      ...project,
+      sourceRepoIds: ['local-repo'],
+      localWindowsRuntimePreference: { kind: 'windows-host' },
+      updatedAt: 3
+    })
+    const store = createTestStore()
+    store.setState({ projects: [project] })
+
+    await store.getState().updateProject(project.id, {
+      localWindowsRuntimePreference: { kind: 'windows-host' }
+    })
+
+    expect(store.getState().projects[0]?.sourceRepoIds).toEqual(['local-repo', 'remote-repo'])
+    expect(store.getState().projects[0]?.localWindowsRuntimePreference).toEqual({
+      kind: 'windows-host'
+    })
+  })
+
+  it('clears local runtime preferences without dropping shared project source repos', async () => {
+    const project: Project = {
+      id: 'github:stablyai/orca',
+      displayName: 'Orca',
+      badgeColor: '#000',
+      sourceRepoIds: ['local-repo', 'remote-repo'],
+      localWindowsRuntimePreference: { kind: 'windows-host' },
+      createdAt: 1,
+      updatedAt: 2
+    }
+    projectsUpdate.mockResolvedValue({
+      id: project.id,
+      displayName: project.displayName,
+      badgeColor: project.badgeColor,
+      sourceRepoIds: ['local-repo'],
+      createdAt: project.createdAt,
+      updatedAt: 3
+    })
+    const store = createTestStore()
+    store.setState({ projects: [project] })
+
+    await store.getState().updateProject(project.id, {
+      localWindowsRuntimePreference: undefined
+    })
+
+    expect(store.getState().projects[0]?.sourceRepoIds).toEqual(['local-repo', 'remote-repo'])
+    expect(store.getState().projects[0]?.localWindowsRuntimePreference).toBeUndefined()
   })
 })

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -495,9 +495,15 @@ function mergeFetchedProjectCompatibilityForHost({
   const fetchedSetupsForHost = fetched.projectHostSetups.filter((setup) => setup.hostId === hostId)
   const preservedSetups = previous.projectHostSetups.filter((setup) => setup.hostId !== hostId)
   const projectHostSetups = mergeById(preservedSetups, fetchedSetupsForHost)
-  const fetchedProjectsForHost = fetched.projects.filter((project) =>
-    getProjectHostIds(project, fetched.projectHostSetups, repos).has(hostId)
-  )
+  const previousProjectById = new Map(previous.projects.map((project) => [project.id, project]))
+  const fetchedProjectsForHost = fetched.projects
+    .filter((project) => getProjectHostIds(project, fetched.projectHostSetups, repos).has(hostId))
+    .map((project) => {
+      const previousProject = previousProjectById.get(project.id)
+      // Why: refreshing one host replaces that host's project record, but
+      // same-id projects can carry metadata learned only from another host.
+      return previousProject ? mergeProjectCompatibilityProject(previousProject, project) : project
+    })
   const preservedProjects = previous.projects.filter(
     (project) => !getProjectHostIds(project, previous.projectHostSetups, repos).has(hostId)
   )

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -434,6 +434,33 @@ function mergeProjectCompatibilityProjects(
   return merged
 }
 
+function getCurrentSourceRepoIds(project: Project, currentRepoIds: ReadonlySet<string>): string[] {
+  return project.sourceRepoIds.filter((repoId) => currentRepoIds.has(repoId))
+}
+
+function projectWithCurrentSourceRepoIds(
+  project: Project,
+  currentRepoIds: ReadonlySet<string>
+): Project {
+  const sourceRepoIds = getCurrentSourceRepoIds(project, currentRepoIds)
+  return sourceRepoIds.length === project.sourceRepoIds.length
+    ? project
+    : { ...project, sourceRepoIds }
+}
+
+function mergePreviousProjectMetadata(
+  previous: Project,
+  current: Project,
+  currentRepoIds: ReadonlySet<string>
+): Project {
+  return {
+    ...mergeProjectCompatibilityProject(previous, current),
+    // Why: fetched project metadata can lag behind repo.list; repo ownership
+    // must track the freshly reconciled repos so removed host repos do not linger.
+    sourceRepoIds: getCurrentSourceRepoIds(current, currentRepoIds)
+  }
+}
+
 function mergeProjectHostSetupCompatibility(
   derived: Pick<RepoSlice, 'projects' | 'projectHostSetups'>,
   fetched: ProjectHostSetupProjection
@@ -496,19 +523,30 @@ function mergeFetchedProjectCompatibilityForHost({
   const preservedSetups = previous.projectHostSetups.filter((setup) => setup.hostId !== hostId)
   const projectHostSetups = mergeById(preservedSetups, fetchedSetupsForHost)
   const previousProjectById = new Map(previous.projects.map((project) => [project.id, project]))
-  const fetchedProjectsForHost = fetched.projects
-    .filter((project) => getProjectHostIds(project, fetched.projectHostSetups, repos).has(hostId))
+  const currentRepoIds = new Set(repos.map((repo) => repo.id))
+  const hasCurrentOwner = (project: Project): boolean =>
+    project.sourceRepoIds.some((repoId) => currentRepoIds.has(repoId)) ||
+    projectHostSetups.some((setup) => setup.projectId === project.id)
+  const fetchedProjects = fetched.projects
+    .filter(
+      (project) =>
+        hasCurrentOwner(project) ||
+        getProjectHostIds(project, fetched.projectHostSetups, repos).has(hostId)
+    )
     .map((project) => {
       const previousProject = previousProjectById.get(project.id)
-      // Why: refreshing one host replaces that host's project record, but
-      // same-id projects can carry metadata learned only from another host.
-      return previousProject ? mergeProjectCompatibilityProject(previousProject, project) : project
+      return previousProject
+        ? mergePreviousProjectMetadata(previousProject, project, currentRepoIds)
+        : projectWithCurrentSourceRepoIds(project, currentRepoIds)
     })
+  const fetchedProjectIds = new Set(fetchedProjects.map((project) => project.id))
   const preservedProjects = previous.projects.filter(
-    (project) => !getProjectHostIds(project, previous.projectHostSetups, repos).has(hostId)
+    (project) =>
+      !fetchedProjectIds.has(project.id) &&
+      !getProjectHostIds(project, previous.projectHostSetups, repos).has(hostId)
   )
   return {
-    projects: mergeProjectCompatibilityProjects(preservedProjects, fetchedProjectsForHost),
+    projects: mergeProjectCompatibilityProjects(preservedProjects, fetchedProjects),
     projectHostSetups
   }
 }

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -434,8 +434,55 @@ function mergeProjectCompatibilityProjects(
   return merged
 }
 
+function mergeUpdatedProjectCompatibilityProject(
+  base: Project,
+  updated: Project,
+  updates: ProjectUpdate
+): Project {
+  const project = mergeProjectCompatibilityProject(base, updated)
+  if ('localWindowsRuntimePreference' in updates) {
+    const localWindowsRuntimePreference =
+      'localWindowsRuntimePreference' in updated
+        ? updated.localWindowsRuntimePreference
+        : updates.localWindowsRuntimePreference
+    // Why: project.update returns one host's project record, but preference
+    // clears must still override the cross-host metadata preservation merge.
+    if (localWindowsRuntimePreference === undefined) {
+      delete project.localWindowsRuntimePreference
+    } else {
+      project.localWindowsRuntimePreference = localWindowsRuntimePreference
+    }
+  }
+  return project
+}
+
 function getCurrentSourceRepoIds(project: Project, currentRepoIds: ReadonlySet<string>): string[] {
   return project.sourceRepoIds.filter((repoId) => currentRepoIds.has(repoId))
+}
+
+function getSourceRepoIdsOutsideHost(
+  project: Project,
+  reposById: ReadonlyMap<string, Repo>,
+  hostId: string
+): string[] {
+  return project.sourceRepoIds.filter((repoId) => {
+    const repo = reposById.get(repoId)
+    return repo && getRepoExecutionHostId(repo) !== hostId
+  })
+}
+
+function getMergedSourceRepoIdsForHostRefresh(
+  previous: Project,
+  current: Project,
+  reposById: ReadonlyMap<string, Repo>,
+  hostId: string
+): string[] {
+  return [
+    ...new Set([
+      ...getSourceRepoIdsOutsideHost(previous, reposById, hostId),
+      ...getCurrentSourceRepoIds(current, new Set(reposById.keys()))
+    ])
+  ]
 }
 
 function projectWithCurrentSourceRepoIds(
@@ -451,13 +498,32 @@ function projectWithCurrentSourceRepoIds(
 function mergePreviousProjectMetadata(
   previous: Project,
   current: Project,
-  currentRepoIds: ReadonlySet<string>
+  reposById: ReadonlyMap<string, Repo>,
+  hostId: string
 ): Project {
+  const project = mergeProjectCompatibilityProject(previous, current)
+  if (hostId === LOCAL_EXECUTION_HOST_ID) {
+    // Why: `localWindowsRuntimePreference` belongs to the local host; a local
+    // refresh that omits it is authoritative and should clear stale renderer state.
+    if ('localWindowsRuntimePreference' in current) {
+      if (current.localWindowsRuntimePreference === undefined) {
+        delete project.localWindowsRuntimePreference
+      } else {
+        project.localWindowsRuntimePreference = current.localWindowsRuntimePreference
+      }
+    } else {
+      delete project.localWindowsRuntimePreference
+    }
+  } else if (previous.localWindowsRuntimePreference !== undefined) {
+    // Why: remote runtimes can have their own local Windows preference; they must
+    // not overwrite the client-local project runtime setting.
+    project.localWindowsRuntimePreference = previous.localWindowsRuntimePreference
+  }
   return {
-    ...mergeProjectCompatibilityProject(previous, current),
+    ...project,
     // Why: fetched project metadata can lag behind repo.list; repo ownership
     // must track the freshly reconciled repos so removed host repos do not linger.
-    sourceRepoIds: getCurrentSourceRepoIds(current, currentRepoIds)
+    sourceRepoIds: getMergedSourceRepoIdsForHostRefresh(previous, current, reposById, hostId)
   }
 }
 
@@ -489,6 +555,18 @@ function getProjectHostIds(
   setups: readonly ProjectHostSetup[],
   repos: readonly Repo[]
 ): Set<string> {
+  const hostIds = getExplicitProjectHostIds(project, setups, repos)
+  if (hostIds.size === 0) {
+    hostIds.add(LOCAL_EXECUTION_HOST_ID)
+  }
+  return hostIds
+}
+
+function getExplicitProjectHostIds(
+  project: Project,
+  setups: readonly ProjectHostSetup[],
+  repos: readonly Repo[]
+): Set<string> {
   const hostIds = new Set<string>()
   const repoById = new Map(repos.map((repo) => [repo.id, repo]))
   for (const setup of setups) {
@@ -501,9 +579,6 @@ function getProjectHostIds(
     if (repo) {
       hostIds.add(getRepoExecutionHostId(repo))
     }
-  }
-  if (hostIds.size === 0) {
-    hostIds.add(LOCAL_EXECUTION_HOST_ID)
   }
   return hostIds
 }
@@ -523,30 +598,47 @@ function mergeFetchedProjectCompatibilityForHost({
   const preservedSetups = previous.projectHostSetups.filter((setup) => setup.hostId !== hostId)
   const projectHostSetups = mergeById(preservedSetups, fetchedSetupsForHost)
   const previousProjectById = new Map(previous.projects.map((project) => [project.id, project]))
+  const reposById = new Map(repos.map((repo) => [repo.id, repo]))
   const currentRepoIds = new Set(repos.map((repo) => repo.id))
-  const hasCurrentOwner = (project: Project): boolean =>
-    project.sourceRepoIds.some((repoId) => currentRepoIds.has(repoId)) ||
-    projectHostSetups.some((setup) => setup.projectId === project.id)
-  const fetchedProjects = fetched.projects
-    .filter(
-      (project) =>
-        hasCurrentOwner(project) ||
-        getProjectHostIds(project, fetched.projectHostSetups, repos).has(hostId)
+  const projectHasHost = (project: Project, setups: readonly ProjectHostSetup[]): boolean =>
+    getProjectHostIds(project, setups, repos).has(hostId)
+  const projectHasCurrentOwnerOutsideHost = (project: Project): boolean =>
+    [...getExplicitProjectHostIds(project, projectHostSetups, repos)].some(
+      (ownerHostId) => ownerHostId !== hostId
     )
+  const fetchedProjects = fetched.projects
+    .filter((project) => {
+      const previousProject = previousProjectById.get(project.id)
+      // Why: repo-derived compatibility projects include every known host.
+      // A one-host refresh should only reconcile that host or prune its stale ownership.
+      return (
+        projectHasHost(project, fetched.projectHostSetups) ||
+        (previousProject ? projectHasHost(previousProject, previous.projectHostSetups) : false)
+      )
+    })
     .map((project) => {
       const previousProject = previousProjectById.get(project.id)
       return previousProject
-        ? mergePreviousProjectMetadata(previousProject, project, currentRepoIds)
+        ? mergePreviousProjectMetadata(previousProject, project, reposById, hostId)
         : projectWithCurrentSourceRepoIds(project, currentRepoIds)
     })
   const fetchedProjectIds = new Set(fetchedProjects.map((project) => project.id))
   const preservedProjects = previous.projects.filter(
     (project) =>
       !fetchedProjectIds.has(project.id) &&
-      !getProjectHostIds(project, previous.projectHostSetups, repos).has(hostId)
+      (!getProjectHostIds(project, previous.projectHostSetups, repos).has(hostId) ||
+        projectHasCurrentOwnerOutsideHost(project))
   )
   return {
-    projects: mergeProjectCompatibilityProjects(preservedProjects, fetchedProjects),
+    projects: mergeProjectCompatibilityProjects(
+      preservedProjects.map((project) => {
+        const sourceRepoIds = getSourceRepoIdsOutsideHost(project, reposById, hostId)
+        return sourceRepoIds.length === project.sourceRepoIds.length
+          ? project
+          : { ...project, sourceRepoIds }
+      }),
+      fetchedProjects
+    ),
     projectHostSetups
   }
 }
@@ -2171,7 +2263,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const runtimePreferenceChanged = 'localWindowsRuntimePreference' in updates
       set((state) => ({
         projects: state.projects.map((project) =>
-          project.id === projectId ? updatedProject : project
+          project.id === projectId
+            ? mergeUpdatedProjectCompatibilityProject(project, updatedProject, updates)
+            : project
         ),
         folderWorkspacePathStatuses: {}
       }))

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -394,6 +394,46 @@ function projectCompatibilityFromRepos(
   }
 }
 
+function mergeProjectCompatibilityProject(base: Project, overlay: Project): Project {
+  const localWindowsRuntimePreference =
+    'localWindowsRuntimePreference' in overlay
+      ? overlay.localWindowsRuntimePreference
+      : base.localWindowsRuntimePreference
+  const project: Project = {
+    ...base,
+    ...overlay,
+    // Why: all-host startup fetches hosts separately; one host's project record
+    // must not erase repo ownership learned from another host with the same id.
+    sourceRepoIds: [...new Set([...base.sourceRepoIds, ...overlay.sourceRepoIds])],
+    createdAt: Math.min(base.createdAt, overlay.createdAt),
+    updatedAt: Math.max(base.updatedAt, overlay.updatedAt)
+  }
+  if (localWindowsRuntimePreference === undefined) {
+    delete project.localWindowsRuntimePreference
+  } else {
+    project.localWindowsRuntimePreference = localWindowsRuntimePreference
+  }
+  return project
+}
+
+function mergeProjectCompatibilityProjects(
+  base: readonly Project[],
+  overlay: readonly Project[]
+): Project[] {
+  const merged = [...base]
+  const indexById = new Map(merged.map((entry, index) => [entry.id, index]))
+  for (const entry of overlay) {
+    const index = indexById.get(entry.id)
+    if (index === undefined) {
+      indexById.set(entry.id, merged.length)
+      merged.push(entry)
+    } else {
+      merged[index] = mergeProjectCompatibilityProject(merged[index]!, entry)
+    }
+  }
+  return merged
+}
+
 function mergeProjectHostSetupCompatibility(
   derived: Pick<RepoSlice, 'projects' | 'projectHostSetups'>,
   fetched: ProjectHostSetupProjection
@@ -406,7 +446,7 @@ function mergeProjectHostSetupCompatibility(
   const setupProjectIds = new Set(projectHostSetups.map((setup) => setup.projectId))
   const fetchedProjectIds = new Set(fetched.projects.map((project) => project.id))
   return {
-    projects: mergeById(derived.projects, fetched.projects).filter(
+    projects: mergeProjectCompatibilityProjects(derived.projects, fetched.projects).filter(
       (project) => fetchedProjectIds.has(project.id) || setupProjectIds.has(project.id)
     ),
     projectHostSetups
@@ -462,7 +502,7 @@ function mergeFetchedProjectCompatibilityForHost({
     (project) => !getProjectHostIds(project, previous.projectHostSetups, repos).has(hostId)
   )
   return {
-    projects: mergeById(preservedProjects, fetchedProjectsForHost),
+    projects: mergeProjectCompatibilityProjects(preservedProjects, fetchedProjectsForHost),
     projectHostSetups
   }
 }


### PR DESCRIPTION
Follow-up to #6079.

## Summary
- Render repo groups as top-level rows when their saved projectGroupId points to metadata that has not loaded yet.
- Preserve shared project compatibility metadata across all-host repo snapshots, including unioned sourceRepoIds and existing localWindowsRuntimePreference when a later host omits it.
- Add focused regression coverage for missing Project Group metadata and cross-host project metadata preservation.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/store/slices/repos-all-hosts.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/repos.test.ts src/renderer/src/store/slices/repos-project-runtime.test.ts src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts src/renderer/src/store/slices/repos-project-host-capability.test.ts src/renderer/src/store/slices/repos-project-groups.test.ts src/renderer/src/store/selectors.test.ts
- pnpm typecheck
- pnpm lint (fails on pre-existing missing localization catalog keys in TerminalInteractionSection.tsx and terminal-pane-appearance-search.ts; oxlint, switch exhaustiveness, and styled-scrollbars completed before the catalog failure)
- pnpm run verify:localization-coverage
- git diff --check