### PR TITLE
Fix WorktreeCard render-scope retention in virtual rows

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -87,6 +87,7 @@ import {
   getActiveStickyIndexesForScroll,
   getStickyHeaderIndexes,
   getVirtualRowTransform,
+  pruneStaleVirtualRowElementCache,
   shouldUseHeaderTopSpacing,
   type RenderRow
 } from './worktree-list-virtual-rows'
@@ -1941,6 +1942,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     () => renderRows.map(getRenderRowKey).join('\n'),
     [renderRows]
   )
+  const activeRenderRowKeys = useMemo(() => new Set(renderRows.map(getRenderRowKey)), [renderRows])
   const totalSize = virtualizer.getTotalSize()
   const virtualItems = virtualizer.getVirtualItems()
   const activeStickyIndexes = getActiveStickyIndexesForScroll({
@@ -1976,6 +1978,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   )
 
   useLayoutEffect(() => {
+    pruneStaleVirtualRowElementCache({
+      activeRowKeys: activeRenderRowKeys,
+      virtualizer
+    })
     // Why: after delete/collapse, TanStack may briefly retain the removed row's
     // cached element. Measuring that disconnected node reports 0px and corrupts
     // the next row's slot, so measure only elements whose DOM key still matches
@@ -1983,7 +1989,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     measureMountedRows()
     const frameId = window.requestAnimationFrame(measureMountedRows)
     return () => window.cancelAnimationFrame(frameId)
-  }, [prCacheLen, issueCacheLen, measureMountedRows, renderRowKeySignature])
+  }, [
+    activeRenderRowKeys,
+    prCacheLen,
+    issueCacheLen,
+    measureMountedRows,
+    renderRowKeySignature,
+    virtualizer
+  ])
 
   useVirtualizedScrollAnchor({
     anchorRef: scrollAnchorRef,

--- a/src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts
@@ -5,6 +5,7 @@ import {
   extractWorktreeVirtualRowIndexes,
   getActiveStickyIndexesForScroll,
   getStickyHeaderIndexes,
+  pruneStaleVirtualRowElementCache,
   type RenderRow
 } from './worktree-list-virtual-rows'
 
@@ -142,5 +143,51 @@ describe('extractWorktreeVirtualRowIndexes', () => {
       rows
     })
     expect(indexes).toContain(0)
+  })
+})
+
+describe('pruneStaleVirtualRowElementCache', () => {
+  it('removes stale measured row elements before they retain old WorktreeCard scopes', () => {
+    const activeElement = {
+      isConnected: true,
+      getAttribute: (name: string) =>
+        name === 'data-worktree-virtual-row-key' ? 'wt:active' : null
+    } as Element
+    const staleElement = {
+      isConnected: false,
+      getAttribute: (name: string) => (name === 'data-worktree-virtual-row-key' ? 'wt:stale' : null)
+    } as Element
+    const connectedStaleElement = {
+      isConnected: true,
+      getAttribute: (name: string) =>
+        name === 'data-worktree-virtual-row-key' ? 'wt:connected-stale' : null
+    } as Element
+    const retainedScope = {
+      defaultHostId: 'runtime:env-1',
+      handlerName: 'handleOpenReviewInOrca'
+    }
+    Object.assign(staleElement, { __retainedWorktreeCardScopeForTest: retainedScope })
+
+    const virtualizer = {
+      elementsCache: new Map<string, Element>([
+        ['wt:active', activeElement],
+        ['wt:stale', staleElement],
+        ['wt:connected-stale', connectedStaleElement]
+      ]),
+      measureElement: (element: Element | null) => {
+        if (element) {
+          throw new Error('stale cache pruning should not remeasure rows')
+        }
+      }
+    }
+
+    pruneStaleVirtualRowElementCache({
+      activeRowKeys: new Set(['wt:active']),
+      virtualizer
+    })
+
+    expect(virtualizer.elementsCache.get('wt:active')).toBe(activeElement)
+    expect(virtualizer.elementsCache.has('wt:stale')).toBe(false)
+    expect(virtualizer.elementsCache.get('wt:connected-stale')).toBe(connectedStaleElement)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
@@ -76,6 +76,31 @@ export function getVirtualRowTransform(start: number): string {
   return `translateY(${start}px)`
 }
 
+type VirtualRowElementCache<TElement extends Element> = {
+  elementsCache: Map<unknown, TElement>
+  measureElement: (node: TElement | null) => void
+}
+
+export function pruneStaleVirtualRowElementCache<TElement extends Element>({
+  activeRowKeys,
+  virtualizer
+}: {
+  activeRowKeys: ReadonlySet<string>
+  virtualizer: VirtualRowElementCache<TElement>
+}): void {
+  virtualizer.measureElement(null)
+  for (const [key, element] of virtualizer.elementsCache) {
+    const rowKey = String(key)
+    if (activeRowKeys.has(rowKey) || element.isConnected) {
+      continue
+    }
+    // Why: measured row nodes retain their React fiber tree. Once TanStack's
+    // public null-measure cleanup has run, drop any disconnected stale key left
+    // behind so old WorktreeCard scopes do not survive runtime-host row churn.
+    virtualizer.elementsCache.delete(key)
+  }
+}
+
 export function getStickyHeaderIndexes(rows: readonly RenderRow[]): number[] {
   const indexes: number[] = []
   rows.forEach((row, index) => {


### PR DESCRIPTION
## Summary
- prune stale TanStack virtual row elements by current WorktreeList row key
- detach stale measured rows before they can retain old WorktreeCard React fiber/render scopes
- add a focused regression test for runtime-host-like retained card scope data in a stale virtual row cache entry

Fixes #6109.

## Root Cause
The renderer heap evidence pointed at retained WorktreeCard handler scopes capturing runtime `defaultHostId` values. The retaining path I found was WorktreeList's virtualizer element cache: stale measured row elements can retain their React fiber tree after row identity changes. While runtime hosts are active, row/cache churn can leave old WorktreeCard scopes reachable through those stale virtual row elements.

## Repro Harness
Added `pruneStaleVirtualRowElementCache` coverage in `worktree-list-virtual-rows.test.ts`. The test models a stale virtual row element retaining a WorktreeCard-like runtime scope and verifies the stale row is evicted and unobserved while active rows remain cached.

This is a focused retention repro, not a full 20-40 minute live renderer OOM soak.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts src/renderer/src/store/slices/repos-all-hosts.test.ts src/renderer/src/store/slices/repos-project-groups.test.ts`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/github.test.ts --testNamePattern "does not enqueue|connected SSH-backed|runtime|local GitHub PR refresh events|PR refresh"`
- `pnpm oxlint src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts src/renderer/src/components/sidebar/WorktreeList.tsx`
- `pnpm tsgo --noEmit -p config/tsconfig.tc.web.json`
- `git diff --check`

Note: local commands emitted the existing Node engine warning because this shell is on Node v26 while the repo declares Node 24.

## Residual Risk
I did not reproduce the full production OOM in a long-running Electron runtime/SSH session. This PR fixes a concrete retaining path matching the heap retainer shape, but a live heap soak is still the best confirmation that there is no second retaining root.

Made with [Orca](https://github.com/stablyai/orca) 🐋
