### PR TITLE
Fix project icon colors in workspace sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/project-header-color.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-color.test.ts
@@ -39,6 +39,16 @@ describe('resolveProjectGroupHeaderColor', () => {
     ).toBe(REPO_COLORS[5])
   })
 
+  it('returns the repo color for provider-backed project headers', () => {
+    expect(
+      resolveProjectGroupHeaderColor({
+        groupBy: 'repo',
+        headerKey: 'project:github:stablyai/orca',
+        badgeColor: REPO_COLORS[6]
+      })
+    ).toBe(REPO_COLORS[6])
+  })
+
   it('falls back to gray for unknown project group headers', () => {
     expect(
       resolveProjectGroupHeaderColor({

--- a/src/renderer/src/components/sidebar/project-header-color.ts
+++ b/src/renderer/src/components/sidebar/project-header-color.ts
@@ -2,6 +2,7 @@ import { DEFAULT_REPO_BADGE_COLOR, REPO_COLORS } from '../../../../shared/consta
 import { normalizeRepoBadgeColor } from '../../../../shared/repo-badge-color'
 
 const PROJECT_GROUP_HEADER_KEY_PREFIX = 'repo:'
+const PROVIDER_PROJECT_HEADER_KEY_PREFIX = 'project:'
 
 export function resolveRepoHeaderColor(badgeColor: string | null | undefined): string {
   const normalizedBadgeColor = normalizeRepoBadgeColor(badgeColor)
@@ -19,9 +20,13 @@ export function resolveProjectGroupHeaderColor(args: {
   headerKey: string
   badgeColor: string | null | undefined
 }): string | undefined {
-  // Why: pinned headers can appear while grouped by repo, but only repo:* headers
-  // represent a repo folder whose user-authored badge color should be shown.
-  if (args.groupBy !== 'repo' || !args.headerKey.startsWith(PROJECT_GROUP_HEADER_KEY_PREFIX)) {
+  // Why: pinned/project-folder headers can appear while grouped by repo; only
+  // actual project headers should inherit user-authored project colors.
+  if (
+    args.groupBy !== 'repo' ||
+    (!args.headerKey.startsWith(PROJECT_GROUP_HEADER_KEY_PREFIX) &&
+      !args.headerKey.startsWith(PROVIDER_PROJECT_HEADER_KEY_PREFIX))
+  ) {
     return undefined
   }
   return resolveRepoHeaderColor(args.badgeColor)


### PR DESCRIPTION
## Summary
- allow provider-backed project headers to use saved project icon colors
- add coverage for project header color resolution

Fixes #5798

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/project-header-color.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts