### PR TITLE
Fix terminal font chooser filtering

### DIFF
--- a/src/renderer/src/components/settings/SettingsFormControls.font-autocomplete.test.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.font-autocomplete.test.tsx
@@ -82,6 +82,35 @@ describe('FontAutocomplete', () => {
     ).toBe('JetBrains Mono')
   })
 
+  it('shows the full list on focus when the committed font has multiple matching suggestions', async () => {
+    function Harness(): ReactNode {
+      const [value, setValue] = useState('Cascadia Mono')
+      return (
+        <FontAutocomplete
+          value={value}
+          suggestions={['Arial', 'Cascadia Code', 'Cascadia Mono', 'Cascadia Mono PL', 'Consolas']}
+          onChange={setValue}
+        />
+      )
+    }
+
+    await act(async () => {
+      root.render(<Harness />)
+    })
+
+    await act(async () => {
+      getInput().focus()
+    })
+
+    expect(getOptionLabels()).toEqual([
+      'Arial',
+      'Cascadia Code',
+      'Cascadia Mono',
+      'Cascadia Mono PL',
+      'Consolas'
+    ])
+  })
+
   it('keeps typed searches filtered even after the value updates', async () => {
     function Harness(): ReactNode {
       const [value, setValue] = useState('Geist')

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -630,12 +630,10 @@ export function FontAutocomplete({
     () => filterFontSuggestions(suggestions, query),
     [suggestions, query]
   )
-  // Why: a committed font fills the input, but typed searches can also mirror
-  // into `value`; only expand exact matches outside an active search session.
+  // Why: the committed font fills the input, but opening the chooser should
+  // still reveal every installed font instead of only fonts sharing that name.
   const visibleSuggestions =
-    !isFilteringQuery && normalizedQuery === normalizedValue && filteredSuggestions.length <= 1
-      ? suggestions
-      : filteredSuggestions
+    !isFilteringQuery && normalizedQuery === normalizedValue ? suggestions : filteredSuggestions
 
   // Why: sync the highlighted index during render rather than via useEffect so
   // the correct item is highlighted on the very first paint after open/filter


### PR DESCRIPTION
## Summary
- Show the full terminal font list when the chooser opens on the committed font value, even when multiple installed fonts share that prefix.
- Keep active typed searches filtered.
- Add a regression test covering the Windows/Cascadia-style case from STA-572.

## Test
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/SettingsFormControls.font-autocomplete.test.tsx

Closes STA-589.

Context: STA-572 / Slack feedback from hatton.