### PR TITLE
Document Orca CLI card status

### DIFF
--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Use the public `orca` CLI to operate Orca-managed worktrees, folder contexts,
   terminals, repos, automations, worktree comments, and the browser embedded
   inside the Orca app. Use when the user says "$orca-cli", "use orca cli",
-  "Orca worktree", "child worktree", "spawn codex/claude in a worktree",
+  "Orca worktree", "child worktree", "cardStatus", "spawn codex/claude in a worktree",
   "read/wait/send Orca terminal", "terminal send", "Orca browser", or "control
   the browser inside Orca". Prefer this over raw `git worktree`, ad hoc PTYs,
   Playwright, or Computer Use when the task touches Orca-managed state. Use
@@ -61,6 +61,7 @@ orca worktree create --name child-task --agent codex --prompt "hi" --json
 orca worktree create --name independent-task --no-parent --json
 orca worktree set --worktree id:<worktreeId> --display-name "My Task" --json
 orca worktree set --worktree active --comment "reproduced bug; testing fix" --json
+orca worktree set --worktree active --workspace-status in-review --json
 orca worktree rm --worktree id:<worktreeId> --force --json
 ```
 
@@ -107,6 +108,8 @@ orca worktree set --worktree active --comment "fix implemented; running integrat
 ```
 
 Update after meaningful state changes such as repro, fix, validation, handoff, or blocker. Keep comments short/current; failures are best-effort unless Orca state was requested.
+
+Card status uses `--workspace-status <id>`; defaults are `todo`, `in-progress`, `in-review`, `completed`.
 
 ## Terminals
 


### PR DESCRIPTION
@hatton

## Summary
- Document `orca worktree set --workspace-status <id>` in `orca-cli`.
- Add `cardStatus` discovery text.

## Verification
- YAML frontmatter parses.