### PR TITLE
Fix Fira Code ligature repaint in terminals

### DIFF
--- a/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
@@ -68,8 +68,10 @@ vi.mock('@xterm/xterm', () => ({
     open: Mock
     write: Mock
     reset: Mock
+    refresh: Mock
     dispose: Mock
     loadAddon: Mock
+    rows: number
 
     constructor(options: Record<string, unknown>) {
       this.options = { ...options }

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
@@ -9,8 +9,10 @@ type MockTerminalInstance = {
   open: Mock
   write: Mock
   reset: Mock
+  refresh: Mock
   dispose: Mock
   loadAddon: Mock
+  rows: number
 }
 
 type MockLigaturesAddonInstance = {
@@ -78,7 +80,9 @@ vi.mock('@xterm/xterm', () => ({
       })
       this.write = vi.fn()
       this.reset = vi.fn()
+      this.refresh = vi.fn()
       this.dispose = vi.fn()
+      this.rows = Number(options.rows)
       this.loadAddon = vi.fn(() => {
         if (mockXterm.nextLoadAddonError) {
           throw mockXterm.nextLoadAddonError
@@ -228,6 +232,7 @@ describe('TerminalSettingsPreview terminal lifecycle', () => {
     const addon = mockLigaturesAddon.instances[0]
     expect(terminal.loadAddon).toHaveBeenCalledOnce()
     expect(terminal.loadAddon).toHaveBeenCalledWith(addon)
+    expect(terminal.refresh).toHaveBeenCalledWith(0, 14)
 
     runCleanups()
     expect(addon.dispose).toHaveBeenCalledOnce()

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -260,6 +260,9 @@ export function TerminalSettingsPreview({
       try {
         terminal.loadAddon(addon)
         ligaturesAddonRef.current = addon
+        // Why: the preview writes its sample before this effect runs; repaint
+        // so already-rendered operators switch to ligature glyphs immediately.
+        terminal.refresh(0, terminal.rows - 1)
       } catch (err) {
         addon.dispose()
         console.warn('[settings preview] ligatures addon failed to attach', err)

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -6,7 +6,7 @@ import {
   markComplexScriptOutput,
   resetTerminalWebglSuggestion
 } from './pane-webgl-renderer'
-import { openTerminal } from './pane-lifecycle'
+import { attachLigatures, openTerminal } from './pane-lifecycle'
 import {
   buildDefaultTerminalOptions,
   DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY,
@@ -345,6 +345,18 @@ describe('attachWebgl', () => {
     attachWebgl(pane)
 
     expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('attachLigatures', () => {
+  it('refreshes existing rows after loading the ligatures addon', () => {
+    const pane = createPane()
+
+    attachLigatures(pane)
+
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+    expect(pane.ligaturesAddon).not.toBeNull()
   })
 })
 

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -286,6 +286,9 @@ export function attachLigatures(pane: ManagedPaneInternal): void {
     const ligaturesAddon = new LigaturesAddon()
     pane.terminal.loadAddon(ligaturesAddon)
     pane.ligaturesAddon = ligaturesAddon
+    // Why: ligatures can be enabled after rows already rendered, especially
+    // from Settings. Force existing glyph runs to be recomputed immediately.
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
     // Why: the WebGL renderer builds its glyph texture atlas at activation
     // time, so `font-feature-settings` applied after WebGL loaded won't
     // reach the GPU-rendered cells until the atlas is rebuilt. The upstream


### PR DESCRIPTION
## Summary
- refresh terminal rows immediately after the ligatures addon attaches in live panes
- refresh the settings terminal preview after enabling ligatures so pre-rendered sample text updates
- add lifecycle regression coverage for both attachment paths

Fixes #6055.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
- pnpm exec oxfmt --check src/renderer/src/lib/pane-manager/pane-lifecycle.ts src/renderer/src/components/settings/TerminalSettingsPreview.tsx src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
- git diff --check

Note: local commands emitted the existing Node engine warning because this shell is Node v26 while the repo asks for Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
