### PR TITLE
Prevent sidebar crashes from missing worktree titles

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -45,7 +45,10 @@ import {
 import { WorktreeCardPortsDetails, WorktreeCardPortsTrigger } from './WorktreeCardPorts'
 import { writeWorkspaceDragData } from './workspace-status'
 import { getWorktreeCardPrDisplay } from './worktree-card-pr-display'
-import { getWorktreeCardTitleDisplay } from './worktree-card-title-display'
+import {
+  coerceWorktreeCardVisibleTitle,
+  getWorktreeCardTitleDisplay
+} from './worktree-card-title-display'
 import { useWorktreeCardDetailsHoverControl } from './worktree-card-details-hover-state'
 import { isEventTargetInsideCurrentTarget } from './worktree-card-dom-events'
 import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
@@ -502,7 +505,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
     issueTitle: issueDisplay?.title,
     reviewTitle: prDisplay?.title
   })
-  const visibleCardTitle = newCardStyle ? cardTitleDisplay : worktree.displayName
+  const legacyCardTitleDisplay = coerceWorktreeCardVisibleTitle(worktree.displayName)
+  const visibleCardTitle = newCardStyle ? cardTitleDisplay : legacyCardTitleDisplay
   const isDeleting = deleteState?.isDeleting ?? false
   const deleteModifierPressed = useWorkspaceDeleteModifierPressed()
 

--- a/src/renderer/src/components/sidebar/worktree-card-title-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-title-display.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { getWorktreeCardTitleDisplay } from './worktree-card-title-display'
+import {
+  coerceWorktreeCardVisibleTitle,
+  getWorktreeCardTitleDisplay
+} from './worktree-card-title-display'
 
 describe('worktree card title display', () => {
   it('keeps custom workspace titles', () => {
@@ -10,6 +13,14 @@ describe('worktree card title display', () => {
         reviewTitle: 'Fix stale PR'
       })
     ).toBe('Custom workspace')
+
+    expect(
+      getWorktreeCardTitleDisplay({
+        storedDisplayName: '  Custom workspace  ',
+        branchName: 'feature/custom',
+        reviewTitle: 'Fix stale PR'
+      })
+    ).toBe('  Custom workspace  ')
   })
 
   it('uses linked work titles instead of repeating the branch as the card title', () => {
@@ -48,5 +59,64 @@ describe('worktree card title display', () => {
         branchName: 'test454545'
       })
     ).toBe('test454545')
+  })
+
+  it('uses linked work titles when the stored title is nullish and the branch is usable', () => {
+    expect(
+      getWorktreeCardTitleDisplay({
+        storedDisplayName: undefined,
+        branchName: 'feature/local-branch',
+        reviewTitle: 'Fix stale GH PR'
+      })
+    ).toBe('Fix stale GH PR')
+
+    expect(
+      getWorktreeCardTitleDisplay({
+        storedDisplayName: null,
+        branchName: 'feature/local-branch',
+        issueTitle: 'Fix stale issue'
+      })
+    ).toBe('Fix stale issue')
+  })
+
+  it('treats blank stored titles as absent', () => {
+    expect(
+      getWorktreeCardTitleDisplay({
+        storedDisplayName: '   ',
+        branchName: 'feature/local-branch'
+      })
+    ).toBe('')
+
+    expect(
+      getWorktreeCardTitleDisplay({
+        storedDisplayName: '',
+        branchName: 'feature/local-branch',
+        linearIssueTitle: 'Fix stale Linear issue'
+      })
+    ).toBe('Fix stale Linear issue')
+  })
+
+  it('skips linked-title replacement when the branch name is nullish or blank', () => {
+    expect(
+      getWorktreeCardTitleDisplay({
+        storedDisplayName: 'Custom workspace',
+        branchName: undefined,
+        reviewTitle: 'Fix stale GH PR'
+      })
+    ).toBe('Custom workspace')
+
+    expect(
+      getWorktreeCardTitleDisplay({
+        storedDisplayName: null,
+        branchName: '   ',
+        reviewTitle: 'Fix stale GH PR'
+      })
+    ).toBe('')
+  })
+
+  it('coerces legacy visible titles before downstream title operations', () => {
+    expect(coerceWorktreeCardVisibleTitle(undefined).trim()).toBe('')
+    expect(coerceWorktreeCardVisibleTitle(null).trim()).toBe('')
+    expect(coerceWorktreeCardVisibleTitle('  Custom workspace  ')).toBe('  Custom workspace  ')
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-card-title-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-title-display.ts
@@ -1,9 +1,14 @@
 type WorktreeCardTitleDisplayInput = {
-  storedDisplayName: string
-  branchName: string
+  storedDisplayName: string | null | undefined
+  branchName: string | null | undefined
   linearIssueTitle?: string | null
   issueTitle?: string | null
   reviewTitle?: string | null
+}
+
+function normalizeComparableTitle(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
 }
 
 function normalizeTitle(value: string | null | undefined): string | null {
@@ -17,8 +22,19 @@ function normalizeTitle(value: string | null | undefined): string | null {
   return trimmed
 }
 
-function isBranchTitle(displayName: string, branchName: string): boolean {
-  return displayName.trim() === branchName.trim()
+function isBranchTitle(
+  displayName: string | null | undefined,
+  branchName: string | null | undefined
+): boolean {
+  const normalizedDisplayName = normalizeComparableTitle(displayName)
+  const normalizedBranchName = normalizeComparableTitle(branchName)
+  return normalizedDisplayName !== null && normalizedDisplayName === normalizedBranchName
+}
+
+export function coerceWorktreeCardVisibleTitle(value: string | null | undefined): string {
+  // Why: the legacy card path can bypass title selection but still feeds trim()
+  // and inline rename props, so nullish persisted titles stop at this boundary.
+  return typeof value === 'string' ? value : ''
 }
 
 export function getWorktreeCardTitleDisplay({
@@ -28,8 +44,16 @@ export function getWorktreeCardTitleDisplay({
   issueTitle,
   reviewTitle
 }: WorktreeCardTitleDisplayInput): string {
-  if (!branchName || !isBranchTitle(storedDisplayName, branchName)) {
-    return storedDisplayName
+  const normalizedStoredDisplayName = normalizeComparableTitle(storedDisplayName)
+  const normalizedBranchName = normalizeComparableTitle(branchName)
+  const visibleStoredDisplayName = coerceWorktreeCardVisibleTitle(storedDisplayName)
+
+  if (!normalizedBranchName) {
+    return normalizedStoredDisplayName ? visibleStoredDisplayName : ''
+  }
+
+  if (normalizedStoredDisplayName && !isBranchTitle(storedDisplayName, branchName)) {
+    return visibleStoredDisplayName
   }
 
   // Why: branch names are available in hover/details; the closed card title
@@ -38,6 +62,6 @@ export function getWorktreeCardTitleDisplay({
     normalizeTitle(linearIssueTitle) ??
     normalizeTitle(issueTitle) ??
     normalizeTitle(reviewTitle) ??
-    storedDisplayName
+    (normalizedStoredDisplayName ? visibleStoredDisplayName : '')
   )
 }

--- a/src/renderer/src/components/sidebar/worktree-card-title-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-title-display.ts
@@ -23,11 +23,9 @@ function normalizeTitle(value: string | null | undefined): string | null {
 }
 
 function isBranchTitle(
-  displayName: string | null | undefined,
-  branchName: string | null | undefined
+  normalizedDisplayName: string | null,
+  normalizedBranchName: string | null
 ): boolean {
-  const normalizedDisplayName = normalizeComparableTitle(displayName)
-  const normalizedBranchName = normalizeComparableTitle(branchName)
   return normalizedDisplayName !== null && normalizedDisplayName === normalizedBranchName
 }
 
@@ -52,7 +50,10 @@ export function getWorktreeCardTitleDisplay({
     return normalizedStoredDisplayName ? visibleStoredDisplayName : ''
   }
 
-  if (normalizedStoredDisplayName && !isBranchTitle(storedDisplayName, branchName)) {
+  if (
+    normalizedStoredDisplayName &&
+    !isBranchTitle(normalizedStoredDisplayName, normalizedBranchName)
+  ) {
     return visibleStoredDisplayName
   }
 


### PR DESCRIPTION
## Summary
- Harden the sidebar worktree title display path so nullish or blank persisted `displayName` / branch values cannot crash `.trim()` during render.
- Preserve meaningful custom titles exactly, continue preferring confirmed linked work titles only when the stored title is absent or branch-equivalent, and return an empty string for fully absent title data.
- Coerce the legacy `WorktreeCard` title path before downstream title operations so both legacy and new-card rendering receive strings.
- Avoid redundant title normalization so the sidebar render path trims each compared title once.

## Screenshots
No visual change. Electron validation rendered temporary sidebar worktrees with nullish display names and confirmed the card stayed stable without fresh title render errors.

## Design Review
- Created scratch design doc at `design-docs/sidebar-title-nullish-crash-design.md` (ignored, not committed).
- `auto-design-review-fix` completed clean after Iteration 3.
- Design review expanded scope to include the legacy `WorktreeCard` title path and deferred broader persisted-data normalization as out of scope.

## Implementation / Completeness
- Implementation followed the reviewed design with no deviations.
- Completeness verification found no blockers and confirmed the product diff is limited to the title helper, focused tests, and `WorktreeCard` legacy boundary coercion.
- Lazy chunk `SyntaxError` crash reports were already fixed elsewhere and are not part of this PR.

## AI Review Report
- Round 1 valid reviewers: both returned `No issues found`.
- One attempted review reported unrelated Jira files that were not in `git diff`; validated as not applicable and replaced with a fresh reviewer.
- Cross-platform/SSH/provider review: pure renderer string handling only; no filesystem paths, subprocesses, keyboard shortcuts, provider APIs, SSH-specific assumptions, polling, or agent-visible text changed.
- Residual non-blocking gap noted by reviewers: no full `WorktreeCard` mount regression test, accepted because the extracted title boundary and helper-level crash repro are directly tested and Electron validation exercised both title paths.

## Security Audit
- Input handling: nullish/blank persisted worktree title data is treated as absent before string operations.
- Privacy/data: no telemetry, network calls, provider requests, logs, prompt text, or external side effects added.
- Runtime risk: no async work, polling, subprocesses, migrations, or cache changes added.

## Testing Checklist
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-card-title-display.test.ts` (9 tests)
- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [x] Pre-commit staged-file checks: `oxlint`, React doctor lint, `oxfmt --write`
- [x] Electron validation via `brennan-test-changes`: launched this branch/root on CDP port 9335, verified identity, rendered temporary in-memory `demo-project` sidebar worktrees with `displayName: null` in legacy mode and `displayName: undefined` in new-card mode, and observed no fresh in-page errors or console errors for the title render passes.
- [x] Perf sanity: no polling, subprocesses, effects, store subscribers, cache invalidation, migrations, or extra render-path fanout; compared title strings are normalized once.
- [ ] `pnpm run lint` full run: failed only in unrelated localization catalog checks for `src/renderer/src/components/settings/TerminalInteractionSection.tsx` scroll-speed keys, outside this PR's three-file sidebar diff.

## Post-PR Stabilization
- [x] Waited 8 minutes after PR open with `sleep 480` before first sweep.
- [x] CodeRabbit posted no actionable comments.
- [x] PR checks passed after initial PR open: `verify` and `track-community-pr`.
- [x] After perf follow-up push, waited another 8 minutes with `sleep 480`; refreshed CodeRabbit again posted no actionable comments.
- [x] Final post-follow-up `verify` check passed.