### PR TITLE
fix: restore Linux chrome-sandbox postinstall

### DIFF
--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -109,6 +109,8 @@ describe('Electron runtime package contract', () => {
 
     expect(afterInstallScript).toContain('chrome-sandbox')
     expect(afterInstallScript).toContain('unshare --user true')
+    expect(afterInstallScript).toContain('/proc/sys/kernel/unprivileged_userns_clone')
+    expect(afterInstallScript).toContain('/proc/sys/user/max_user_namespaces')
     expect(afterInstallScript).toContain('chmod 4755 "$sandbox"')
     expect(afterInstallScript).toContain('chmod 0755 "$sandbox"')
   })

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -101,6 +101,18 @@ describe('Electron runtime package contract', () => {
     expect(publishLinuxStep.with.command).toBe('${{ matrix.release_command }}')
   })
 
+  it('keeps Linux postinstall repairing Chromium sandbox permissions', () => {
+    const afterInstallScript = readFileSync(
+      join(projectDir, 'resources/linux/packaging/after-install.sh'),
+      'utf8'
+    )
+
+    expect(afterInstallScript).toContain('chrome-sandbox')
+    expect(afterInstallScript).toContain('unshare --user true')
+    expect(afterInstallScript).toContain('chmod 4755 "$sandbox"')
+    expect(afterInstallScript).toContain('chmod 0755 "$sandbox"')
+  })
+
   it('lets release-cut tag a version that is already present on main', () => {
     const releaseWorkflow = readFileSync(
       join(projectDir, '.github/workflows/release-cut.yml'),

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -108,11 +108,8 @@ describe('Electron runtime package contract', () => {
     )
 
     expect(afterInstallScript).toContain('chrome-sandbox')
-    expect(afterInstallScript).toContain('unshare --user true')
-    expect(afterInstallScript).toContain('/proc/sys/kernel/unprivileged_userns_clone')
-    expect(afterInstallScript).toContain('/proc/sys/user/max_user_namespaces')
     expect(afterInstallScript).toContain('chmod 4755 "$sandbox"')
-    expect(afterInstallScript).toContain('chmod 0755 "$sandbox"')
+    expect(afterInstallScript).not.toContain('chmod 0755 "$sandbox"')
   })
 
   it('lets release-cut tag a version that is already present on main', () => {

--- a/resources/linux/packaging/after-install.sh
+++ b/resources/linux/packaging/after-install.sh
@@ -15,11 +15,33 @@ for dir in /opt/Orca /opt/orca-ide /opt/orca; do
   sandbox="$dir/chrome-sandbox"
   if [ -f "$sandbox" ]; then
     # Why: this custom postinst replaces electron-builder's default script, so
-    # it must preserve Chromium's Linux sandbox permission repair.
+    # it must preserve Chromium's sandbox repair for normal desktop users.
+    userns_available=1
     if ! { [ -L /proc/self/ns/user ] && unshare --user true; }; then
-      chmod 4755 "$sandbox" || true
-    else
+      userns_available=0
+    fi
+    if [ -r /proc/sys/kernel/unprivileged_userns_clone ] &&
+      [ "$(cat /proc/sys/kernel/unprivileged_userns_clone)" != "1" ]; then
+      userns_available=0
+    fi
+    if [ -r /proc/sys/user/max_user_namespaces ]; then
+      max_user_namespaces="$(cat /proc/sys/user/max_user_namespaces)"
+      case "$max_user_namespaces" in
+        '' | *[!0-9]*)
+          userns_available=0
+          ;;
+        *)
+          if [ "$max_user_namespaces" -le 0 ]; then
+            userns_available=0
+          fi
+          ;;
+      esac
+    fi
+
+    if [ "$userns_available" -eq 1 ]; then
       chmod 0755 "$sandbox" || true
+    else
+      chmod 4755 "$sandbox" || true
     fi
   fi
 

--- a/resources/linux/packaging/after-install.sh
+++ b/resources/linux/packaging/after-install.sh
@@ -14,35 +14,9 @@ link="/usr/bin/orca-ide"
 for dir in /opt/Orca /opt/orca-ide /opt/orca; do
   sandbox="$dir/chrome-sandbox"
   if [ -f "$sandbox" ]; then
-    # Why: this custom postinst replaces electron-builder's default script, so
-    # it must preserve Chromium's sandbox repair for normal desktop users.
-    userns_available=1
-    if ! { [ -L /proc/self/ns/user ] && unshare --user true; }; then
-      userns_available=0
-    fi
-    if [ -r /proc/sys/kernel/unprivileged_userns_clone ] &&
-      [ "$(cat /proc/sys/kernel/unprivileged_userns_clone)" != "1" ]; then
-      userns_available=0
-    fi
-    if [ -r /proc/sys/user/max_user_namespaces ]; then
-      max_user_namespaces="$(cat /proc/sys/user/max_user_namespaces)"
-      case "$max_user_namespaces" in
-        '' | *[!0-9]*)
-          userns_available=0
-          ;;
-        *)
-          if [ "$max_user_namespaces" -le 0 ]; then
-            userns_available=0
-          fi
-          ;;
-      esac
-    fi
-
-    if [ "$userns_available" -eq 1 ]; then
-      chmod 0755 "$sandbox" || true
-    else
-      chmod 4755 "$sandbox" || true
-    fi
+    # Why: packaged Linux installs must leave Chromium's sandbox helper usable
+    # on hosts where unprivileged user namespaces are unavailable.
+    chmod 4755 "$sandbox" || true
   fi
 
   shim="$dir/resources/bin/orca-ide"

--- a/resources/linux/packaging/after-install.sh
+++ b/resources/linux/packaging/after-install.sh
@@ -12,6 +12,17 @@ set -e
 link="/usr/bin/orca-ide"
 
 for dir in /opt/Orca /opt/orca-ide /opt/orca; do
+  sandbox="$dir/chrome-sandbox"
+  if [ -f "$sandbox" ]; then
+    # Why: this custom postinst replaces electron-builder's default script, so
+    # it must preserve Chromium's Linux sandbox permission repair.
+    if ! { [ -L /proc/self/ns/user ] && unshare --user true; }; then
+      chmod 4755 "$sandbox" || true
+    else
+      chmod 0755 "$sandbox" || true
+    fi
+  fi
+
   shim="$dir/resources/bin/orca-ide"
   if [ -x "$shim" ]; then
     # Only manage our own symlink; never clobber an unrelated /usr/bin/orca-ide.


### PR DESCRIPTION
## Summary
- restore Chromium `chrome-sandbox` permission repair in the custom Linux postinstall script
- keep the existing `/usr/bin/orca-ide` symlink setup for headless hosts
- add a packaging contract test so the sandbox repair does not get dropped again

## Root cause
`deb.afterInstall`/`rpm.afterInstall` point at Orca's custom `resources/linux/packaging/after-install.sh`. That custom script replaced electron-builder's default Linux postinstall script, which normally repairs `/opt/<app>/chrome-sandbox` permissions. Without that repair, `.deb` installs can leave `chrome-sandbox` as `0755`, and Electron aborts before launch on hosts that need the SUID sandbox helper.

Introduced by `c9460ed63` (`Put the orca CLI on PATH at install time for headless hosts`), first stable affected: `v1.4.82`.

Fixes #6093.

## Verification
- Reproduced against published `v1.4.91` `.deb` in `ubuntu:24.04` Docker:
  - `/opt/Orca/chrome-sandbox` installed as `0755 root root`
  - launching as a non-root user failed with Chromium's `SUID sandbox helper binary was found, but is not configured correctly` fatal and exit `133`
- Ran targeted test:
  - `pnpm vitest run config/scripts/package-electron-runtime-contract.test.mjs`
- Built a local Linux `.deb` inside a Linux Docker container:
  - `dist/orca-ide_1.4.92-rc.0_amd64.deb`
- Fresh installed the fixed `.deb` in `ubuntu:24.04` Docker:
  - on a container where user namespaces are unavailable, `chrome-sandbox` installed as `4755 root root`
  - launch progressed past the original SUID fatal; unprivileged Docker then failed later on namespace restrictions, which is a separate container limitation
- Launched the fixed `.deb` in a privileged Docker container:
  - no original SUID fatal
  - app ran under `xvfb-run` until the expected timeout
- Verified upgrade path:
  - install `v1.4.91`: `chrome-sandbox` was `0755 root root`
  - upgrade to fixed `.deb`: `chrome-sandbox` changed to `4755 root root`

Made with [Orca](https://github.com/stablyai/orca) 🐋
