### PR TITLE
Preserve Worktree object identity across scans (cut re-render churn behind #6109 OOM)

### DIFF
--- a/src/renderer/src/store/slices/worktrees-reconcile-identity.test.ts
+++ b/src/renderer/src/store/slices/worktrees-reconcile-identity.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { reconcileWorktreeIdentities } from './worktrees'
+import { makeWorktree } from './store-test-helpers'
+
+// Why: runtime worktree scans return fresh Worktree objects each poll. Preserving
+// the existing object identity for unchanged worktrees keeps WorktreeCard's
+// React.memo effective, avoiding the re-render churn that retains render scopes
+// (stablyai/orca#6109).
+describe('reconcileWorktreeIdentities', () => {
+  it('reuses the existing object identity for structurally-unchanged worktrees', () => {
+    const a = makeWorktree({ id: 'a', repoId: 'r', branch: 'refs/heads/a' })
+    const b = makeWorktree({ id: 'b', repoId: 'r', branch: 'refs/heads/b' })
+    const current = [a, b]
+    // fresh objects with identical content (new identities, as a scan returns)
+    const next = [{ ...a }, { ...b }]
+
+    const result = reconcileWorktreeIdentities(current, next)
+
+    expect(result[0]).toBe(a) // identity preserved
+    expect(result[1]).toBe(b)
+  })
+
+  it('uses the new object only for the worktree whose content changed', () => {
+    const a = makeWorktree({ id: 'a', repoId: 'r', lastActivityAt: 1 })
+    const b = makeWorktree({ id: 'b', repoId: 'r', lastActivityAt: 1 })
+    const current = [a, b]
+    const changedB = { ...b, lastActivityAt: 2 } // e.g. agent activity ticked
+    const next = [{ ...a }, changedB]
+
+    const result = reconcileWorktreeIdentities(current, next)
+
+    expect(result[0]).toBe(a) // unchanged -> identity preserved
+    expect(result[1]).toBe(changedB) // changed -> new identity
+  })
+
+  it('returns the next list unchanged when there is no prior list', () => {
+    const next = [makeWorktree({ id: 'a', repoId: 'r' })]
+    expect(reconcileWorktreeIdentities(undefined, next)).toBe(next)
+    expect(reconcileWorktreeIdentities([], next)).toBe(next)
+  })
+
+  it('matches by id, preserving identity across reordering', () => {
+    const a = makeWorktree({ id: 'a', repoId: 'r' })
+    const b = makeWorktree({ id: 'b', repoId: 'r' })
+    const next = [{ ...b }, { ...a }] // reordered, same content
+    const result = reconcileWorktreeIdentities([a, b], next)
+    expect(result[0]).toBe(b)
+    expect(result[1]).toBe(a)
+  })
+})

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -183,63 +183,84 @@ function areLineageRecordsEqual(
   )
 }
 
+function isWorktreeContentEqual(worktree: Worktree, candidate: Worktree): boolean {
+  return (
+    worktree.id === candidate.id &&
+    worktree.instanceId === candidate.instanceId &&
+    worktree.repoId === candidate.repoId &&
+    worktree.projectId === candidate.projectId &&
+    worktree.hostId === candidate.hostId &&
+    worktree.projectHostSetupId === candidate.projectHostSetupId &&
+    worktree.path === candidate.path &&
+    worktree.head === candidate.head &&
+    worktree.branch === candidate.branch &&
+    worktree.isBare === candidate.isBare &&
+    worktree.isMainWorktree === candidate.isMainWorktree &&
+    worktree.isSparse === candidate.isSparse &&
+    worktree.displayName === candidate.displayName &&
+    worktree.comment === candidate.comment &&
+    worktree.linkedIssue === candidate.linkedIssue &&
+    worktree.linkedPR === candidate.linkedPR &&
+    worktree.linkedGitLabMR === candidate.linkedGitLabMR &&
+    worktree.linkedGitLabIssue === candidate.linkedGitLabIssue &&
+    worktree.linkedBitbucketPR === candidate.linkedBitbucketPR &&
+    worktree.linkedAzureDevOpsPR === candidate.linkedAzureDevOpsPR &&
+    worktree.linkedGiteaPR === candidate.linkedGiteaPR &&
+    worktree.isArchived === candidate.isArchived &&
+    worktree.isUnread === candidate.isUnread &&
+    worktree.isPinned === candidate.isPinned &&
+    worktree.sortOrder === candidate.sortOrder &&
+    worktree.manualOrder === candidate.manualOrder &&
+    worktree.lastActivityAt === candidate.lastActivityAt &&
+    worktree.workspaceStatus === candidate.workspaceStatus &&
+    worktree.createdWithAgent === candidate.createdWithAgent &&
+    worktree.pendingFirstAgentMessageRename === candidate.pendingFirstAgentMessageRename &&
+    worktree.firstAgentMessageRenameError === candidate.firstAgentMessageRenameError &&
+    worktree.baseRef === candidate.baseRef &&
+    worktree.pushTarget?.remoteName === candidate.pushTarget?.remoteName &&
+    worktree.pushTarget?.branchName === candidate.pushTarget?.branchName &&
+    worktree.pushTarget?.remoteUrl === candidate.pushTarget?.remoteUrl &&
+    worktree.sparseBaseRef === candidate.sparseBaseRef &&
+    arraysShallowEqual(worktree.sparseDirectories, candidate.sparseDirectories) &&
+    arraysShallowEqual(worktree.priorWorktreeIds, candidate.priorWorktreeIds) &&
+    (worktree as WorktreeWithLineage).parentWorktreeId ===
+      (candidate as WorktreeWithLineage).parentWorktreeId &&
+    arraysShallowEqual(
+      (worktree as WorktreeWithLineage).childWorktreeIds,
+      (candidate as WorktreeWithLineage).childWorktreeIds
+    ) &&
+    areLineageRecordsEqual(
+      (worktree as WorktreeWithLineage).lineage,
+      (candidate as WorktreeWithLineage).lineage
+    )
+  )
+}
+
 function areWorktreesEqual(current: Worktree[] | undefined, next: Worktree[]): boolean {
   if (!current || current.length !== next.length) {
     return false
   }
+  return current.every((worktree, index) => isWorktreeContentEqual(worktree, next[index]))
+}
 
-  return current.every((worktree, index) => {
-    const candidate = next[index]
-    return (
-      worktree.id === candidate.id &&
-      worktree.instanceId === candidate.instanceId &&
-      worktree.repoId === candidate.repoId &&
-      worktree.projectId === candidate.projectId &&
-      worktree.hostId === candidate.hostId &&
-      worktree.projectHostSetupId === candidate.projectHostSetupId &&
-      worktree.path === candidate.path &&
-      worktree.head === candidate.head &&
-      worktree.branch === candidate.branch &&
-      worktree.isBare === candidate.isBare &&
-      worktree.isMainWorktree === candidate.isMainWorktree &&
-      worktree.isSparse === candidate.isSparse &&
-      worktree.displayName === candidate.displayName &&
-      worktree.comment === candidate.comment &&
-      worktree.linkedIssue === candidate.linkedIssue &&
-      worktree.linkedPR === candidate.linkedPR &&
-      worktree.linkedGitLabMR === candidate.linkedGitLabMR &&
-      worktree.linkedGitLabIssue === candidate.linkedGitLabIssue &&
-      worktree.linkedBitbucketPR === candidate.linkedBitbucketPR &&
-      worktree.linkedAzureDevOpsPR === candidate.linkedAzureDevOpsPR &&
-      worktree.linkedGiteaPR === candidate.linkedGiteaPR &&
-      worktree.isArchived === candidate.isArchived &&
-      worktree.isUnread === candidate.isUnread &&
-      worktree.isPinned === candidate.isPinned &&
-      worktree.sortOrder === candidate.sortOrder &&
-      worktree.manualOrder === candidate.manualOrder &&
-      worktree.lastActivityAt === candidate.lastActivityAt &&
-      worktree.workspaceStatus === candidate.workspaceStatus &&
-      worktree.createdWithAgent === candidate.createdWithAgent &&
-      worktree.pendingFirstAgentMessageRename === candidate.pendingFirstAgentMessageRename &&
-      worktree.firstAgentMessageRenameError === candidate.firstAgentMessageRenameError &&
-      worktree.baseRef === candidate.baseRef &&
-      worktree.pushTarget?.remoteName === candidate.pushTarget?.remoteName &&
-      worktree.pushTarget?.branchName === candidate.pushTarget?.branchName &&
-      worktree.pushTarget?.remoteUrl === candidate.pushTarget?.remoteUrl &&
-      worktree.sparseBaseRef === candidate.sparseBaseRef &&
-      arraysShallowEqual(worktree.sparseDirectories, candidate.sparseDirectories) &&
-      arraysShallowEqual(worktree.priorWorktreeIds, candidate.priorWorktreeIds) &&
-      (worktree as WorktreeWithLineage).parentWorktreeId ===
-        (candidate as WorktreeWithLineage).parentWorktreeId &&
-      arraysShallowEqual(
-        (worktree as WorktreeWithLineage).childWorktreeIds,
-        (candidate as WorktreeWithLineage).childWorktreeIds
-      ) &&
-      areLineageRecordsEqual(
-        (worktree as WorktreeWithLineage).lineage,
-        (candidate as WorktreeWithLineage).lineage
-      )
-    )
+// Why: a fresh worktree scan returns brand-new Worktree objects every time. When
+// even one worktree changes (e.g. lastActivityAt ticks while an agent runs), the
+// whole list is replaced, so structurally-unchanged worktrees also get new object
+// identities — breaking WorktreeCard's React.memo and re-rendering every card on
+// each update. Those render scopes are retained (see stablyai/orca#6109), so the
+// heap grows ~one worktree-list copy per render. Reuse the existing object for any
+// worktree whose content is unchanged so memo'd cards skip the re-render.
+export function reconcileWorktreeIdentities(
+  current: Worktree[] | undefined,
+  next: Worktree[]
+): Worktree[] {
+  if (!current || current.length === 0) {
+    return next
+  }
+  const byId = new Map(current.map((worktree) => [worktree.id, worktree]))
+  return next.map((worktree) => {
+    const previous = byId.get(worktree.id)
+    return previous && isWorktreeContentEqual(previous, worktree) ? previous : worktree
   })
 }
 
@@ -1432,7 +1453,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           // Why: active worktrees can change branches entirely from a terminal.
           // We refresh that live git identity into renderer state, but only bump
           // sortEpoch when git actually reports a different worktree payload.
-          worktreesByRepo: { ...s.worktreesByRepo, [repoId]: worktrees },
+          worktreesByRepo: {
+            ...s.worktreesByRepo,
+            [repoId]: reconcileWorktreeIdentities(s.worktreesByRepo[repoId], worktrees)
+          },
           detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [repoId]: detected },
           sortEpoch: s.sortEpoch + 1,
           ...(removedIds.length > 0 ? buildWorktreePurgeState(s, removedIds) : {})
@@ -1488,7 +1512,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             !(list.length === 0 && current && current.length > 0 && !detected.authoritative)
           ) {
             set((s) => ({
-              worktreesByRepo: { ...s.worktreesByRepo, [r.id]: list },
+              worktreesByRepo: {
+                ...s.worktreesByRepo,
+                [r.id]: reconcileWorktreeIdentities(s.worktreesByRepo[r.id], list)
+              },
               detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [r.id]: detected },
               sortEpoch: s.sortEpoch + 1
             }))


### PR DESCRIPTION
## Context
Targeted mitigation for the renderer OOM in #6109. Heap analysis of a long-running session with an active runtime environment shows the renderer retaining **thousands of full copies of the worktree list** — retained `WorktreeCard` render scopes each capture the worktree array they rendered.

## Root mechanism this addresses
A worktree scan returns **brand-new `Worktree` objects every time**. The store already skips the update when the *entire* list is unchanged (`areWorktreesEqual`), but when even one worktree changes — e.g. `lastActivityAt` ticks while an agent runs — the whole list is replaced, so **structurally-unchanged worktrees also get new object identities**. That breaks `WorktreeCard`'s `React.memo` and re-renders **every** card on **every** update, maximizing how fast the leaked render scopes accumulate.

## Change
`reconcileWorktreeIdentities(current, next)` reuses the existing object for any worktree whose content is unchanged (matched by `id`), so only genuinely-changed worktrees get a new identity and memo'd cards skip the re-render. Applied at both write sites (`fetchWorktrees`, `fetchAllWorktrees`). `isWorktreeContentEqual` is extracted from `areWorktreesEqual` so both share one comparison — no behavior change to equality.

Effect: with N worktrees and one changing per scan, re-renders drop from N to 1 per update. It also bounds the heavy payload — retained scopes now share `Worktree` identities instead of each holding a fresh copy.

## Honesty note
This reduces the re-render **churn** that drives the leak; the underlying render-scope/fiber retention (the `_handler`/`_event`/`onDispose` + `FiberNode` retainers documented in #6109) is a separate root cause tracked there. This is a high-confidence, low-risk mitigation, not necessarily the complete fix.

## Tests
`worktrees-reconcile-identity.test.ts` (4 cases: identity preserved when unchanged, new identity only for changed, passthrough with no prior list, identity preserved across reorder). Existing 137 worktree-slice tests still pass; `pnpm run typecheck` + `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)