### PR TITLE
feat: add workspace tab navigation and terminal unread shortcuts

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -313,9 +313,10 @@ export function setupGuestShortcutForwarding(args: {
       return true
     }
 
-    // Why: Cmd/Ctrl+Alt+[ / ] cycles across every tab type. Handled before
-    // the generic modifier-chord gate below because that gate rejects Alt.
-    // Mirrors the Alt-exempt branch pattern used for worktreeHistoryNavigate.
+    // Why: tab switching must leave the guest before Chromium handles it.
+    // Keep this before the generic modifier-chord branch so the default
+    // Mod+Shift+ArrowLeft/Right chord routes through the renderer-owned
+    // workspace tab model instead of Chromium guest history/selection handling.
     const switchAllTypesDirection = keybindingMatchesAction(
       'tab.nextAllTypes',
       input,

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1566,8 +1566,8 @@ describe('browserManager', () => {
       },
       {
         type: 'keyDown',
-        code: 'BracketRight',
-        key: '}',
+        code: 'ArrowRight',
+        key: 'ArrowRight',
         meta: isDarwin,
         control: !isDarwin,
         alt: false,
@@ -1629,7 +1629,7 @@ describe('browserManager', () => {
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:newBrowserTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:newTerminalTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTab', 1)
+    expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTabAcrossAllTypes', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:switchTerminalTab', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:openQuickOpen')
     expect(rendererSendMock).toHaveBeenNthCalledWith(7, 'ui:focusBrowserAddressBar')

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -92,11 +92,13 @@ import {
   isFloatingWorkspacePanelFocused,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
+import { markActiveTerminalUnread } from '@/lib/terminal-unread-marking'
 import {
   keybindingMatchesAction,
   type KeybindingActionId,
   type KeybindingContext
 } from '../../../shared/keybindings'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { matchesRecentTabSwitcherChord } from '../../../shared/window-shortcut-policy'
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { useContextualTour } from './contextual-tours/use-contextual-tour'
@@ -1483,14 +1485,23 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
-      // Cmd/Ctrl+Shift+] and Cmd/Ctrl+Shift+[ - switch tabs (scoped to the
-      // active tab type). Cmd/Ctrl+Alt+] and Cmd/Ctrl+Alt+[ cycles across
-      // every tab type as an escape hatch from the type-scoped default, and
-      // matches the platform tab-switch chord on macOS.
-      // Why: use e.code instead of e.key because on macOS, Shift+[ reports '{'
-      // as the key value (the shifted character), not '['. Option+[ also
-      // composes to dead-key / punctuation on many layouts, so matching on
-      // event.key would miss the chord entirely on non-US layouts.
+      if (context === 'terminal' && !e.repeat && matchShortcut('terminal.markUnread')) {
+        e.preventDefault()
+        e.stopPropagation()
+        e.stopImmediatePropagation()
+        notifyTerminalCapture('terminal.markUnread')
+        markActiveTerminalUnread(
+          floatingWorkspaceFocused ? FLOATING_TERMINAL_WORKTREE_ID : undefined
+        )
+        return
+      }
+
+      // Cmd/Ctrl+Shift+Right and Cmd/Ctrl+Shift+Left switch across every
+      // visible workspace tab. Same-type cycling remains available for
+      // custom keybindings.
+      // Why: keybinding matching stays centralized so user overrides and
+      // non-US keyboard layouts behave consistently across terminal, browser,
+      // and renderer-owned shortcut paths.
       const switchSameTypeDirection = matchShortcut('tab.nextSameType')
         ? 1
         : matchShortcut('tab.previousSameType')

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -1378,10 +1378,10 @@ describe('FloatingTerminalPanel close behavior', () => {
 
     keydownListener({
       altKey: false,
-      code: 'BracketRight',
+      code: 'ArrowRight',
       ctrlKey: false,
       defaultPrevented: false,
-      key: ']',
+      key: 'ArrowRight',
       metaKey: true,
       preventDefault,
       repeat: false,

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -36,6 +36,7 @@ import {
   isFloatingWorkspaceTerminalInputTarget,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
+import { markActiveTerminalUnread } from '@/lib/terminal-unread-marking'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import {
@@ -1133,6 +1134,12 @@ export function FloatingTerminalPanel({
       }
 
       if (handleFloatingPanelShortcutAction(event, consume)) {
+        return
+      }
+
+      if (context === 'terminal' && matches('terminal.markUnread')) {
+        consume()
+        markActiveTerminalUnread(FLOATING_TERMINAL_WORKTREE_ID)
         return
       }
 

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -2081,7 +2081,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       const nextWorktreeId = worktreeRows[nextIndex].worktree.id
       // Why: keyboard cycling between worktrees is still real navigation, so
       // it must flow through the same activation helper that records history.
-      activateAndRevealWorktree(nextWorktreeId)
+      // Preserve unread because cycling is scanning, not content interaction.
+      activateAndRevealWorktree(nextWorktreeId, { preserveUnread: true })
 
       const rowIndex = renderRows.findIndex((row) => renderRowContainsWorktree(row, nextWorktreeId))
       if (rowIndex !== -1) {
@@ -2129,6 +2130,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         markDirectScrollInput()
         navigateWorktree(direction)
         e.preventDefault()
+        // Why: workspace cycling is an app shortcut. If it reaches xterm's
+        // keydown listener, the old terminal pane treats it as interaction and
+        // clears unread before the workspace switch completes.
+        e.stopPropagation()
+        e.stopImmediatePropagation()
       }
     }
 

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -18,7 +18,7 @@ export type ActiveTabNavOrderIds = {
 /**
  * Compute the visible tab-strip order for a single group.
  *
- * Why: keyboard navigation (Cmd/Ctrl+Shift+[ / ]) and the IPC switch-tab
+ * Why: keyboard navigation (Cmd/Ctrl+Shift+Left/Right) and the IPC switch-tab
  * shortcut must walk tabs in the same order the TabBar renders them. The
  * TabBar derives its order from `group.tabOrder` (the canonical split-group
  * state, updated by drag/drop via `reorderUnifiedTabs`). Reading from the

--- a/src/renderer/src/components/terminal/tab-type-cycle.ts
+++ b/src/renderer/src/components/terminal/tab-type-cycle.ts
@@ -44,7 +44,7 @@ type GetNextTabAcrossAllTypesParams = {
   direction: number
 }
 
-// Why: companion to getNextTabWithinActiveType for the Cmd/Ctrl+Alt+Shift+]/[
+// Why: companion to getNextTabWithinActiveType for the default
 // "cycle across every tab" chord. Keeps the same dual-id matching semantics
 // (prefer the active group's unified tabId to disambiguate split layouts, fall
 // back to the backing entity id) so behavior matches what the TabBar renders.

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -18,9 +18,8 @@ type CycleContext = {
 }
 
 /**
- * Shared setup for the Cmd/Ctrl+Shift+[ / ] chords (both the type-scoped and
- * across-all-types variants). Returns null when there is no active worktree
- * or the visible nav has at most one tab (nothing to cycle).
+ * Shared setup for workspace tab cycling chords. Returns null when there is no
+ * active worktree or the visible nav has at most one tab (nothing to cycle).
  */
 function resolveCycleContext(): CycleContext | null {
   const store = useAppStore.getState()
@@ -87,7 +86,7 @@ export function activateCyclableTab(store: AppStoreState, next: TypeCyclableTab)
 }
 
 /**
- * Handle Cmd/Ctrl+Shift+[ / ] direction switching within the active tab type.
+ * Handle user-bound same-type tab switching.
  * Extracted from useIpcEvents to keep file size under the max-lines lint threshold.
  * Returns true if a tab switch occurred, false otherwise.
  */
@@ -114,14 +113,8 @@ export function handleSwitchTab(direction: number): boolean {
 }
 
 /**
- * Handle Cmd/Ctrl+Alt+Shift+[ / ] cycling across every visible tab,
+ * Handle Cmd/Ctrl+Shift+Left/Right cycling across every visible tab,
  * regardless of tab type.
- *
- * Why: companion chord to the type-scoped Cmd/Ctrl+Shift+[ / ] that ships as
- * the default. The type-scoped chord is the VS Code-style per-pane cycle;
- * this one gives users an escape hatch back to the pre-scope "cycle through
- * everything" behavior without needing a settings toggle (see PR #1281
- * discussion). Returns true if a tab switch occurred, false otherwise.
  */
 export function handleSwitchTabAcrossAllTypes(direction: number): boolean {
   const ctx = resolveCycleContext()

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6256,7 +6256,19 @@
           "ab20575a8a": "off",
           "ab3a1f9068": "wsl.exe",
           "ask_before_closing_running_terminals_title": "Ask Before Closing Running Terminals",
-          "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent."
+          "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent.",
+          "scrollSpeed": {
+            "title": "Scroll Speed",
+            "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed.",
+            "helper": "Adjust how wheel input feels in scrollback and in mouse-aware terminal apps.",
+            "reset": "Reset",
+            "normal": "Normal",
+            "normalDescription": "Scrollback wheel multiplier.",
+            "fast": "Fast",
+            "fastDescription": "Extra multiplier while scrolling with a modifier key.",
+            "tui": "TUI",
+            "tuiDescription": "Discrete wheel reports for full-screen terminal apps."
+          }
         },
         "TerminalSettingsPreview": {
           "a63953a48a": "Preview {{value0}} theme",
@@ -7892,7 +7904,11 @@
             "0fe0073f0c": "Default terminal font size for new panes and live updates.",
             "5930244899": "Font Size",
             "ask_before_closing_running_terminals_title": "Ask Before Closing Running Terminals",
-            "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent."
+            "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent.",
+            "scrollSpeed": {
+              "title": "Scroll Speed",
+              "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed."
+            }
           },
           "windows": {
             "search": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6219,7 +6219,19 @@
           "ab20575a8a": "apagado",
           "ab3a1f9068": "wsl.exe",
           "ask_before_closing_running_terminals_title": "Ask Before Closing Running Terminals",
-          "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent."
+          "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent.",
+          "scrollSpeed": {
+            "title": "Scroll Speed",
+            "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed.",
+            "helper": "Adjust how wheel input feels in scrollback and in mouse-aware terminal apps.",
+            "reset": "Reset",
+            "normal": "Normal",
+            "normalDescription": "Scrollback wheel multiplier.",
+            "fast": "Fast",
+            "fastDescription": "Extra multiplier while scrolling with a modifier key.",
+            "tui": "TUI",
+            "tuiDescription": "Discrete wheel reports for full-screen terminal apps."
+          }
         },
         "TerminalSettingsPreview": {
           "a63953a48a": "Vista previa del tema {{value0}}",
@@ -7855,7 +7867,11 @@
               "keyword_custom": "custom"
             },
             "ask_before_closing_running_terminals_title": "Ask Before Closing Running Terminals",
-            "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent."
+            "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent.",
+            "scrollSpeed": {
+              "title": "Scroll Speed",
+              "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed."
+            }
           },
           "windows": {
             "search": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6241,7 +6241,19 @@
           "ab20575a8a": "オフ",
           "ab3a1f9068": "wsl.exe",
           "ask_before_closing_running_terminals_title": "Ask Before Closing Running Terminals",
-          "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent."
+          "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent.",
+          "scrollSpeed": {
+            "title": "Scroll Speed",
+            "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed.",
+            "helper": "Adjust how wheel input feels in scrollback and in mouse-aware terminal apps.",
+            "reset": "Reset",
+            "normal": "Normal",
+            "normalDescription": "Scrollback wheel multiplier.",
+            "fast": "Fast",
+            "fastDescription": "Extra multiplier while scrolling with a modifier key.",
+            "tui": "TUI",
+            "tuiDescription": "Discrete wheel reports for full-screen terminal apps."
+          }
         },
         "TerminalSettingsPreview": {
           "a63953a48a": "{{value0}} テーマのプレビュー",
@@ -7877,7 +7889,11 @@
             "0fe0073f0c": "新規ペインとライブ アップデートのデフォルトの terminal フォント サイズ。",
             "5930244899": "フォントサイズ",
             "ask_before_closing_running_terminals_title": "Ask Before Closing Running Terminals",
-            "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent."
+            "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent.",
+            "scrollSpeed": {
+              "title": "Scroll Speed",
+              "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed."
+            }
           },
           "windows": {
             "search": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6204,7 +6204,19 @@
           "ab20575a8a": "끄기",
           "ab3a1f9068": "wsl.exe",
           "ask_before_closing_running_terminals_title": "실행 중인 Terminals을 닫기 전에 확인",
-          "ask_before_closing_running_terminals_description": "실행 중인 명령이나 agent가 있는 terminal을 닫기 전에 확인 창을 표시합니다."
+          "ask_before_closing_running_terminals_description": "실행 중인 명령이나 agent가 있는 terminal을 닫기 전에 확인 창을 표시합니다.",
+          "scrollSpeed": {
+            "title": "Scroll Speed",
+            "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed.",
+            "helper": "Adjust how wheel input feels in scrollback and in mouse-aware terminal apps.",
+            "reset": "Reset",
+            "normal": "Normal",
+            "normalDescription": "Scrollback wheel multiplier.",
+            "fast": "Fast",
+            "fastDescription": "Extra multiplier while scrolling with a modifier key.",
+            "tui": "TUI",
+            "tuiDescription": "Discrete wheel reports for full-screen terminal apps."
+          }
         },
         "TerminalSettingsPreview": {
           "a63953a48a": "{{value0}} 테마 미리보기",
@@ -7840,7 +7852,11 @@
               "keyword_custom": "custom"
             },
             "ask_before_closing_running_terminals_title": "실행 중인 Terminals을 닫기 전에 확인",
-            "ask_before_closing_running_terminals_description": "실행 중인 명령이나 agent가 있는 terminal을 닫기 전에 확인을 표시합니다."
+            "ask_before_closing_running_terminals_description": "실행 중인 명령이나 agent가 있는 terminal을 닫기 전에 확인을 표시합니다.",
+            "scrollSpeed": {
+              "title": "Scroll Speed",
+              "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed."
+            }
           },
           "windows": {
             "search": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6204,7 +6204,19 @@
           "ab20575a8a": "关",
           "ab3a1f9068": "执行程序",
           "ask_before_closing_running_terminals_title": "关闭运行中的 Terminal 前询问",
-          "ask_before_closing_running_terminals_description": "在关闭有运行中命令或 agent 的 terminal 前显示确认。"
+          "ask_before_closing_running_terminals_description": "在关闭有运行中命令或 agent 的 terminal 前显示确认。",
+          "scrollSpeed": {
+            "title": "Scroll Speed",
+            "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed.",
+            "helper": "Adjust how wheel input feels in scrollback and in mouse-aware terminal apps.",
+            "reset": "Reset",
+            "normal": "Normal",
+            "normalDescription": "Scrollback wheel multiplier.",
+            "fast": "Fast",
+            "fastDescription": "Extra multiplier while scrolling with a modifier key.",
+            "tui": "TUI",
+            "tuiDescription": "Discrete wheel reports for full-screen terminal apps."
+          }
         },
         "TerminalSettingsPreview": {
           "a63953a48a": "预览 {{value0}} 主题",
@@ -7840,7 +7852,11 @@
               "keyword_custom": "自定义"
             },
             "ask_before_closing_running_terminals_title": "关闭运行中的 Terminal 前询问",
-            "ask_before_closing_running_terminals_description": "在关闭有运行中命令或 agent 的 terminal 前显示确认。"
+            "ask_before_closing_running_terminals_description": "在关闭有运行中命令或 agent 的 terminal 前显示确认。",
+            "scrollSpeed": {
+              "title": "Scroll Speed",
+              "description": "Tune normal terminal scrollback, fast modifier scrolling, and full-screen TUI wheel speed."
+            }
           },
           "windows": {
             "search": {

--- a/src/renderer/src/lib/terminal-unread-marking.test.ts
+++ b/src/renderer/src/lib/terminal-unread-marking.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Tab, TabGroup, TerminalTab } from '../../../shared/types'
+import {
+  getActiveTerminalTabIdForUnread,
+  markTerminalUnreadForWorktree,
+  type TerminalUnreadMarkingStore
+} from './terminal-unread-marking'
+
+function terminalTab(id: string, worktreeId = 'wt-1'): TerminalTab {
+  return {
+    id,
+    ptyId: null,
+    worktreeId,
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function unifiedTab(
+  id: string,
+  entityId: string,
+  contentType: Tab['contentType'],
+  worktreeId = 'wt-1'
+): Tab {
+  return {
+    id,
+    entityId,
+    groupId: 'group-1',
+    worktreeId,
+    contentType,
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function group(activeTabId: string | null, tabOrder: string[]): TabGroup {
+  return {
+    id: 'group-1',
+    worktreeId: 'wt-1',
+    activeTabId,
+    tabOrder,
+    recentTabIds: tabOrder
+  }
+}
+
+function store(overrides: Partial<TerminalUnreadMarkingStore> = {}): TerminalUnreadMarkingStore {
+  return {
+    activeGroupIdByWorktree: {},
+    activeTabId: 'term-1',
+    activeTabIdByWorktree: { 'wt-1': 'term-1' },
+    activeTabType: 'terminal',
+    activeTabTypeByWorktree: { 'wt-1': 'terminal' },
+    activeWorktreeId: 'wt-1',
+    browserTabsByWorktree: {},
+    groupsByWorktree: {},
+    markTerminalTabUnread: vi.fn(),
+    markWorktreeUnread: vi.fn(),
+    openFiles: [],
+    tabBarOrderByWorktree: { 'wt-1': ['term-1'] },
+    tabsByWorktree: { 'wt-1': [terminalTab('term-1')] },
+    unifiedTabsByWorktree: {},
+    ...overrides
+  }
+}
+
+describe('terminal unread marking', () => {
+  it('marks the active terminal tab and worktree unread', () => {
+    const state = store()
+
+    expect(markTerminalUnreadForWorktree(state, 'wt-1')).toBe(true)
+    expect(state.markTerminalTabUnread).toHaveBeenCalledWith('term-1')
+    expect(state.markWorktreeUnread).toHaveBeenCalledWith('wt-1')
+  })
+
+  it('uses the active split-group terminal tab when available', () => {
+    const state = store({
+      activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+      groupsByWorktree: { 'wt-1': [group('unified-term-2', ['unified-term-1', 'unified-term-2'])] },
+      tabsByWorktree: { 'wt-1': [terminalTab('term-1'), terminalTab('term-2')] },
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          unifiedTab('unified-term-1', 'term-1', 'terminal'),
+          unifiedTab('unified-term-2', 'term-2', 'terminal')
+        ]
+      }
+    })
+
+    expect(getActiveTerminalTabIdForUnread(state, 'wt-1')).toBe('term-2')
+  })
+
+  it('does not mark unread when the active split-group tab is not terminal', () => {
+    const state = store({
+      activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+      groupsByWorktree: { 'wt-1': [group('unified-file', ['unified-term', 'unified-file'])] },
+      openFiles: [
+        {
+          id: 'file-1',
+          filePath: '/tmp/file.md',
+          relativePath: 'file.md',
+          worktreeId: 'wt-1',
+          language: 'markdown',
+          isDirty: false,
+          mode: 'edit'
+        }
+      ],
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          unifiedTab('unified-term', 'term-1', 'terminal'),
+          unifiedTab('unified-file', 'file-1', 'editor')
+        ]
+      }
+    })
+
+    expect(markTerminalUnreadForWorktree(state, 'wt-1')).toBe(false)
+    expect(state.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(state.markWorktreeUnread).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/terminal-unread-marking.ts
+++ b/src/renderer/src/lib/terminal-unread-marking.ts
@@ -1,0 +1,77 @@
+import { getActiveTabNavOrder } from '@/components/tab-bar/group-tab-order'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+
+export type TerminalUnreadMarkingStore = Pick<
+  AppState,
+  | 'activeGroupIdByWorktree'
+  | 'activeTabId'
+  | 'activeTabIdByWorktree'
+  | 'activeTabType'
+  | 'activeTabTypeByWorktree'
+  | 'activeWorktreeId'
+  | 'browserTabsByWorktree'
+  | 'groupsByWorktree'
+  | 'markTerminalTabUnread'
+  | 'markWorktreeUnread'
+  | 'openFiles'
+  | 'tabBarOrderByWorktree'
+  | 'tabsByWorktree'
+  | 'unifiedTabsByWorktree'
+>
+
+export function getActiveTerminalTabIdForUnread(
+  store: TerminalUnreadMarkingStore,
+  worktreeId: string
+): string | null {
+  const activeGroupId = store.activeGroupIdByWorktree[worktreeId]
+  const activeGroup = activeGroupId
+    ? (store.groupsByWorktree[worktreeId] ?? []).find((group) => group.id === activeGroupId)
+    : undefined
+  if (activeGroup?.activeTabId) {
+    const visibleActiveTab = getActiveTabNavOrder(store, worktreeId).find(
+      (entry) => entry.tabId === activeGroup.activeTabId
+    )
+    return visibleActiveTab?.type === 'terminal' ? visibleActiveTab.id : null
+  }
+
+  const activeTabType =
+    store.activeTabTypeByWorktree[worktreeId] ??
+    (store.activeWorktreeId === worktreeId ? store.activeTabType : 'terminal')
+  if (activeTabType !== 'terminal') {
+    return null
+  }
+
+  const activeTabId =
+    store.activeTabIdByWorktree[worktreeId] ??
+    (store.activeWorktreeId === worktreeId ? store.activeTabId : null)
+  if (!activeTabId) {
+    return null
+  }
+
+  return (store.tabsByWorktree[worktreeId] ?? []).some((tab) => tab.id === activeTabId)
+    ? activeTabId
+    : null
+}
+
+export function markTerminalUnreadForWorktree(
+  store: TerminalUnreadMarkingStore,
+  worktreeId: string
+): boolean {
+  const tabId = getActiveTerminalTabIdForUnread(store, worktreeId)
+  if (!tabId) {
+    return false
+  }
+
+  // Why: the manual shortcut should create the same tab-level and workspace
+  // attention signal as a terminal bell/agent-complete event.
+  store.markTerminalTabUnread(tabId)
+  store.markWorktreeUnread(worktreeId)
+  return true
+}
+
+export function markActiveTerminalUnread(worktreeIdOverride?: string): boolean {
+  const store = useAppStore.getState()
+  const worktreeId = worktreeIdOverride ?? store.activeWorktreeId
+  return worktreeId ? markTerminalUnreadForWorktree(store, worktreeId) : false
+}

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -271,6 +271,7 @@ export function activateAndRevealWorktree(
     sidebarRevealBehavior?: PendingSidebarWorktreeReveal['behavior']
     notifyHostRuntime?: boolean
     revealInSidebar?: boolean
+    preserveUnread?: boolean
   }
 ): ActivateAndRevealResult | false {
   const state = useAppStore.getState()
@@ -300,8 +301,8 @@ export function activateAndRevealWorktree(
   }
 
   // 3. Core activation: sets activeWorktreeId, restores per-worktree state,
-  // clears unread, bumps dead PTY generations, triggers GitHub refresh
-  state.setActiveWorktree(worktreeId)
+  // optionally clears unread, bumps dead PTY generations, triggers GitHub refresh
+  state.setActiveWorktree(worktreeId, opts?.preserveUnread ? { preserveUnread: true } : undefined)
   const postActivationState = useAppStore.getState()
   const ownerRuntimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(postActivationState, wt.id)
   if (opts?.notifyHostRuntime !== false && isWebRuntimeSessionActive(ownerRuntimeEnvironmentId)) {

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -104,7 +104,14 @@ const mockApi = {
 // @ts-expect-error -- mock
 globalThis.window = { api: mockApi }
 
-import { createTestStore, makeOpenFile, makeTabGroup, makeUnifiedTab } from './store-test-helpers'
+import {
+  createTestStore,
+  makeOpenFile,
+  makeTab,
+  makeTabGroup,
+  makeUnifiedTab,
+  makeWorktree
+} from './store-test-helpers'
 
 const WT = 'repo1::/tmp/feature'
 
@@ -616,6 +623,83 @@ describe('TabsSlice', () => {
       store.getState().activateTab(t2.id)
 
       expect(store.getState().unreadTerminalTabs[t2TerminalId]).toBeUndefined()
+    })
+
+    it('clears workspace unread when activating the last unread terminal tab', () => {
+      mockApi.worktrees.updateMeta.mockClear()
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
+      store.getState().activateTab(t1.id)
+      store.setState({
+        activeWorktreeId: WT,
+        worktreesByRepo: {
+          repo1: [makeWorktree({ id: WT, repoId: 'repo1', isUnread: true })]
+        },
+        unreadTerminalTabs: { [t2.entityId]: true as const }
+      })
+
+      store.getState().activateTab(t2.id)
+
+      expect(store.getState().unreadTerminalTabs[t2.entityId]).toBeUndefined()
+      expect(store.getState().worktreesByRepo.repo1[0].isUnread).toBe(false)
+      expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+        worktreeId: WT,
+        updates: { isUnread: false }
+      })
+    })
+
+    it('keeps workspace unread while sibling terminal tabs are still unread', () => {
+      mockApi.worktrees.updateMeta.mockClear()
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
+      store.getState().activateTab(t1.id)
+      store.setState({
+        activeWorktreeId: WT,
+        worktreesByRepo: {
+          repo1: [makeWorktree({ id: WT, repoId: 'repo1', isUnread: true })]
+        },
+        unreadTerminalTabs: {
+          [t1.entityId]: true as const,
+          [t2.entityId]: true as const
+        }
+      })
+
+      store.getState().activateTab(t2.id)
+
+      expect(store.getState().unreadTerminalTabs[t2.entityId]).toBeUndefined()
+      expect(store.getState().unreadTerminalTabs[t1.entityId]).toBe(true)
+      expect(store.getState().worktreesByRepo.repo1[0].isUnread).toBe(true)
+      expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('setActiveTab', () => {
+    it('clears workspace unread when activating the last unread terminal tab', () => {
+      mockApi.worktrees.updateMeta.mockClear()
+      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
+      store.setState({
+        activeWorktreeId: WT,
+        worktreesByRepo: {
+          repo1: [makeWorktree({ id: WT, repoId: 'repo1', isUnread: true })]
+        },
+        tabsByWorktree: {
+          [WT]: [
+            makeTab({ id: t1.entityId, worktreeId: WT }),
+            makeTab({ id: t2.entityId, worktreeId: WT })
+          ]
+        },
+        unreadTerminalTabs: { [t2.entityId]: true as const }
+      })
+
+      store.getState().setActiveTab(t2.entityId)
+
+      expect(store.getState().unreadTerminalTabs[t2.entityId]).toBeUndefined()
+      expect(store.getState().worktreesByRepo.repo1[0].isUnread).toBe(false)
+      expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+        worktreeId: WT,
+        updates: { isUnread: false }
+      })
     })
   })
 

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -34,6 +34,24 @@ import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 
+function worktreeHasUnreadTerminalTab(
+  state: Pick<AppState, 'unifiedTabsByWorktree'>,
+  worktreeId: string,
+  unreadTerminalTabs: Record<string, true>
+): boolean {
+  const terminalEntityIds = new Set(
+    (state.unifiedTabsByWorktree[worktreeId] ?? [])
+      .filter((tab) => tab.contentType === 'terminal')
+      .map((tab) => tab.entityId)
+  )
+  for (const terminalEntityId of Object.keys(unreadTerminalTabs)) {
+    if (terminalEntityIds.has(terminalEntityId)) {
+      return true
+    }
+  }
+  return false
+}
+
 export type TabSplitDirection = 'left' | 'right' | 'up' | 'down'
 
 export type TabsSlice = {
@@ -744,6 +762,7 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     findTabByEntityInGroup(get().unifiedTabsByWorktree, worktreeId, groupId, entityId, contentType),
 
   activateTab: (tabId, opts) => {
+    let worktreeIdToClearUnread: string | null = null
     set((state) => {
       const found = findTabAndWorktree(state.unifiedTabsByWorktree, tabId)
       if (!found) {
@@ -768,6 +787,14 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
               return copy
             })()
           : state.unreadTerminalTabs
+      if (
+        nextUnreadTerminalTabs !== state.unreadTerminalTabs &&
+        !worktreeHasUnreadTerminalTab(state, worktreeId, nextUnreadTerminalTabs)
+      ) {
+        // Why: the sidebar dot mirrors terminal attention. Once the selected
+        // tab was the last unread terminal in this workspace, dismiss both.
+        worktreeIdToClearUnread = worktreeId
+      }
       return {
         unifiedTabsByWorktree: opts?.preservePreview
           ? state.unifiedTabsByWorktree
@@ -808,6 +835,9 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
           : {})
       }
     })
+    if (worktreeIdToClearUnread) {
+      get().clearWorktreeUnread(worktreeIdToClearUnread)
+    }
   },
 
   closeUnifiedTab: (tabId, opts) => {
@@ -1169,7 +1199,8 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     return groupId
   },
 
-  focusGroup: (worktreeId, groupId) =>
+  focusGroup: (worktreeId, groupId) => {
+    let worktreeIdToClearUnread: string | null = null
     set((state) => {
       const nextActiveGroupIdByWorktree = {
         ...state.activeGroupIdByWorktree,
@@ -1214,6 +1245,14 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
               return changed ? copy : state.unreadTerminalTabs
             })()
           : state.unreadTerminalTabs
+      if (
+        nextUnreadTerminalTabs !== state.unreadTerminalTabs &&
+        !worktreeHasUnreadTerminalTab(state, worktreeId, nextUnreadTerminalTabs)
+      ) {
+        // Why: split-group focus can acknowledge multiple terminal tabs at
+        // once; clear the workspace dot only after the last one is dismissed.
+        worktreeIdToClearUnread = worktreeId
+      }
       return {
         activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
         // Why: only write unreadTerminalTabs back into state when it actually
@@ -1233,7 +1272,11 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
           groupId
         )
       }
-    }),
+    })
+    if (worktreeIdToClearUnread) {
+      get().clearWorktreeUnread(worktreeIdToClearUnread)
+    }
+  },
 
   closeEmptyGroup: (worktreeId, groupId) => {
     const state = get()

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -131,6 +131,20 @@ function getTerminalTabOwnerWorktreeId(
   return terminalTabOwnerCache.get(tabId) ?? null
 }
 
+function worktreeHasUnreadTerminalTab(
+  tabsByWorktree: Record<string, TerminalTab[]>,
+  worktreeId: string,
+  unreadTerminalTabs: Record<string, true>
+): boolean {
+  const worktreeTabs = tabsByWorktree[worktreeId] ?? []
+  for (const tab of worktreeTabs) {
+    if (unreadTerminalTabs[tab.id]) {
+      return true
+    }
+  }
+  return false
+}
+
 function updateUnifiedTerminalLabel(
   unifiedTabs: Tab[],
   terminalTabId: string,
@@ -1110,6 +1124,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   setActiveTab: (tabId) => {
+    let worktreeIdToClearUnread: string | null = null
     set((s) => {
       // Why: focusing a terminal tab clears the tab-level bell — the user has
       // moved to this tab.
@@ -1135,6 +1150,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
               return copy
             })()
           : s.unreadTerminalTabs
+      if (
+        tabOwnerWorktreeId &&
+        nextUnreadTerminalTabs !== s.unreadTerminalTabs &&
+        !worktreeHasUnreadTerminalTab(s.tabsByWorktree, tabOwnerWorktreeId, nextUnreadTerminalTabs)
+      ) {
+        // Why: keyboard tab cycling lands directly in this legacy terminal-tab
+        // path, so it must dismiss the workspace dot with the last tab bell.
+        worktreeIdToClearUnread = tabOwnerWorktreeId
+      }
       // Why: only write the global activeTabId when the tab belongs to the
       // currently active worktree. markTerminalTabUnread treats activeTabId
       // as "the tab the user is looking at" and suppresses BELs on it; if we
@@ -1153,6 +1177,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         unreadTerminalTabs: nextUnreadTerminalTabs
       }
     })
+    if (worktreeIdToClearUnread) {
+      get().clearWorktreeUnread(worktreeIdToClearUnread)
+    }
     const item = Object.values(get().unifiedTabsByWorktree)
       .flat()
       .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -45,6 +45,10 @@ export type WorktreeRenameRequest = {
   rowKey?: string
 }
 
+export type SetActiveWorktreeOptions = {
+  preserveUnread?: boolean
+}
+
 export type WorktreeSlice = {
   worktreesByRepo: Record<string, Worktree[]>
   detectedWorktreesByRepo: Record<string, DetectedWorktreeListResult>
@@ -228,7 +232,7 @@ export type WorktreeSlice = {
    * fresh visit.
    */
   seedActiveWorktreeLastVisitedIfMissing: () => void
-  setActiveWorktree: (worktreeId: string | null) => void
+  setActiveWorktree: (worktreeId: string | null, options?: SetActiveWorktreeOptions) => void
   setActiveFolderWorkspace: (folderWorkspaceId: string) => void
   setRenamingWorktreeId: (request: string | WorktreeRenameRequest | null) => void
   allWorktrees: () => Worktree[]

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -4088,6 +4088,25 @@ describe('worktree unread (show-until-interact)', () => {
       })
     )
   })
+
+  it('preserves unread state when activation is used only for keyboard cycling', () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      isUnread: true
+    })
+    store.setState({
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    store.getState().setActiveWorktree(wt.id, { preserveUnread: true })
+
+    expect(store.getState().activeWorktreeId).toBe(wt.id)
+    expect(store.getState().worktreesByRepo.repo1[0].isUnread).toBe(true)
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+  })
 })
 
 // Why: design §4.4 — the hydration-time purge must be gated behind a

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -3156,7 +3156,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     })
   },
 
-  setActiveWorktree: (worktreeId) => {
+  setActiveWorktree: (worktreeId, options) => {
     if (worktreeId && shouldDeferActivationTerminalPrep()) {
       markInputQuietSchedulerInput()
     }
@@ -3182,7 +3182,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       }
 
       const worktree = findKnownWorktreeById(s, worktreeId)
-      shouldClearUnread = Boolean(worktree?.isUnread)
+      shouldClearUnread = options?.preserveUnread === true ? false : Boolean(worktree?.isUnread)
 
       // Restore per-worktree editor state
       // Why: Search now lives under Explorer, so the files/search sub-route

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -215,6 +215,83 @@ describe('keybindings', () => {
     })
   })
 
+  it('defaults shifted arrow tab switching to all visible tab types', () => {
+    expect(getEffectiveKeybindingsForAction('tab.nextSameType', 'darwin')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('tab.previousSameType', 'darwin')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('tab.nextAllTypes', 'darwin')).toEqual([
+      'Mod+Shift+ArrowRight'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.previousAllTypes', 'linux')).toEqual([
+      'Mod+Shift+ArrowLeft'
+    ])
+    expect(
+      keybindingMatchesAction(
+        'tab.nextAllTypes',
+        {
+          key: 'ArrowRight',
+          code: 'ArrowRight',
+          control: false,
+          meta: true,
+          alt: false,
+          shift: true
+        },
+        'darwin'
+      )
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction(
+        'tab.previousAllTypes',
+        {
+          key: 'ArrowLeft',
+          code: 'ArrowLeft',
+          control: true,
+          meta: false,
+          alt: false,
+          shift: true
+        },
+        'linux'
+      )
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction(
+        'tab.nextAllTypes',
+        {
+          key: '}',
+          code: 'BracketRight',
+          control: false,
+          meta: true,
+          alt: false,
+          shift: true
+        },
+        'darwin'
+      )
+    ).toBe(false)
+  })
+
+  it('defaults mark active terminal unread to macOS only', () => {
+    expect(getEffectiveKeybindingsForAction('terminal.markUnread', 'darwin')).toEqual([
+      'Mod+Shift+U'
+    ])
+    expect(getEffectiveKeybindingsForAction('terminal.markUnread', 'linux')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('terminal.markUnread', 'win32')).toEqual([])
+    expect(
+      keybindingMatchesAction(
+        'terminal.markUnread',
+        {
+          key: 'u',
+          code: 'KeyU',
+          control: false,
+          meta: true,
+          alt: false,
+          shift: true
+        },
+        'darwin',
+        undefined,
+        { context: 'terminal', terminalShortcutPolicy: 'terminal-first' }
+      )
+    ).toBe(true)
+  })
+
   it('defines macOS-only rename shortcuts that stay conflict-free', () => {
     expect(getEffectiveKeybindingsForAction('tab.rename', 'darwin')).toEqual(['Mod+R'])
     expect(getEffectiveKeybindingsForAction('tab.rename', 'linux')).toEqual([])
@@ -719,7 +796,7 @@ describe('keybindings', () => {
     ).toBe(false)
   })
 
-  it('matches logical bracket shortcuts on JIS keyboards without changing code fallback', () => {
+  it('matches custom JIS bracket shortcuts without changing code fallback', () => {
     const jisLeftBracket = {
       key: '[',
       code: 'BracketRight',
@@ -738,11 +815,18 @@ describe('keybindings', () => {
     }
     const jisLeftBracketShifted = { ...jisLeftBracket, key: '{', shift: true }
     const jisRightBracketShifted = { ...jisRightBracket, key: '}', shift: true }
+    const allTypesBracketOverrides = {
+      'tab.previousAllTypes': ['Mod+Shift+BracketLeft', 'Mod+Alt+BracketLeft'],
+      'tab.nextAllTypes': ['Mod+Shift+BracketRight', 'Mod+Alt+BracketRight']
+    }
 
     expect(
-      keybindingMatchesAction('tab.previousSameType', jisLeftBracketShifted, 'darwin', {
-        'tab.previousSameType': ['Mod+Shift+BracketLeft']
-      })
+      keybindingMatchesAction(
+        'tab.previousAllTypes',
+        jisLeftBracketShifted,
+        'darwin',
+        allTypesBracketOverrides
+      )
     ).toBe(true)
     expect(
       keybindingMatchesAction('tab.previousSameType', jisRightBracketShifted, 'darwin', {
@@ -750,9 +834,12 @@ describe('keybindings', () => {
       })
     ).toBe(false)
     expect(
-      keybindingMatchesAction('tab.nextSameType', jisRightBracketShifted, 'darwin', {
-        'tab.nextSameType': ['Mod+Shift+BracketRight']
-      })
+      keybindingMatchesAction(
+        'tab.nextAllTypes',
+        jisRightBracketShifted,
+        'darwin',
+        allTypesBracketOverrides
+      )
     ).toBe(true)
     expect(
       keybindingMatchesAction('tab.nextSameType', jisLeftBracketShifted, 'darwin', {
@@ -767,16 +854,27 @@ describe('keybindings', () => {
     expect(keybindingMatchesAction('terminal.focusNextPane', jisRightBracket, 'darwin')).toBe(true)
 
     expect(
-      keybindingMatchesAction('tab.previousAllTypes', { ...jisLeftBracket, alt: true }, 'darwin')
+      keybindingMatchesAction(
+        'tab.previousAllTypes',
+        { ...jisLeftBracket, alt: true },
+        'darwin',
+        allTypesBracketOverrides
+      )
     ).toBe(true)
     expect(
-      keybindingMatchesAction('tab.nextAllTypes', { ...jisRightBracket, alt: true }, 'darwin')
+      keybindingMatchesAction(
+        'tab.nextAllTypes',
+        { ...jisRightBracket, alt: true },
+        'darwin',
+        allTypesBracketOverrides
+      )
     ).toBe(true)
     expect(
       keybindingMatchesAction(
         'tab.previousAllTypes',
         { ...jisLeftBracket, control: true, meta: false, alt: true },
-        'linux'
+        'linux',
+        allTypesBracketOverrides
       )
     ).toBe(true)
     expect(
@@ -790,7 +888,8 @@ describe('keybindings', () => {
       keybindingMatchesAction(
         'tab.nextAllTypes',
         { ...jisRightBracket, control: true, meta: false, alt: true },
-        'linux'
+        'linux',
+        allTypesBracketOverrides
       )
     ).toBe(true)
 
@@ -800,6 +899,21 @@ describe('keybindings', () => {
       })
     ).toBe(false)
 
+    expect(
+      keybindingMatchesAction(
+        'tab.nextAllTypes',
+        {
+          key: 'Dead',
+          code: 'BracketRight',
+          control: false,
+          meta: true,
+          alt: false,
+          shift: true
+        },
+        'darwin',
+        allTypesBracketOverrides
+      )
+    ).toBe(true)
     expect(
       keybindingMatchesAction(
         'tab.nextSameType',
@@ -842,6 +956,21 @@ describe('keybindings', () => {
           shift: false
         },
         'linux'
+      )
+    ).toBe(false)
+    expect(
+      keybindingMatchesAction(
+        'tab.previousAllTypes',
+        {
+          key: 'Dead',
+          code: 'BracketLeft',
+          control: true,
+          meta: false,
+          alt: true,
+          shift: false
+        },
+        'linux',
+        allTypesBracketOverrides
       )
     ).toBe(true)
   })
@@ -952,12 +1081,21 @@ describe('keybindings', () => {
       alt: true,
       shift: false
     }
+    const overrides = {
+      'tab.previousAllTypes': ['Mod+Alt+BracketLeft'],
+      'tab.nextAllTypes': ['Mod+Alt+BracketRight']
+    }
 
     expect(keybindingMatchesAction('tab.previousAllTypes', macOptionLeftBracket, 'darwin')).toBe(
-      true
+      false
     )
+    expect(
+      keybindingMatchesAction('tab.previousAllTypes', macOptionLeftBracket, 'darwin', overrides)
+    ).toBe(true)
     expect(keybindingMatchesAction('tab.nextAllTypes', macOptionLeftBracket, 'darwin')).toBe(false)
-    expect(keybindingMatchesAction('tab.nextAllTypes', macOptionRightBracket, 'darwin')).toBe(true)
+    expect(
+      keybindingMatchesAction('tab.nextAllTypes', macOptionRightBracket, 'darwin', overrides)
+    ).toBe(true)
     expect(keybindingMatchesAction('tab.previousAllTypes', macOptionRightBracket, 'darwin')).toBe(
       false
     )

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -268,12 +268,14 @@ describe('keybindings', () => {
     ).toBe(false)
   })
 
-  it('defaults mark active terminal unread to macOS only', () => {
+  it('defaults mark active terminal unread to macOS and Windows only', () => {
     expect(getEffectiveKeybindingsForAction('terminal.markUnread', 'darwin')).toEqual([
       'Mod+Shift+U'
     ])
     expect(getEffectiveKeybindingsForAction('terminal.markUnread', 'linux')).toEqual([])
-    expect(getEffectiveKeybindingsForAction('terminal.markUnread', 'win32')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('terminal.markUnread', 'win32')).toEqual([
+      'Mod+Shift+U'
+    ])
     expect(
       keybindingMatchesAction(
         'terminal.markUnread',
@@ -286,6 +288,22 @@ describe('keybindings', () => {
           shift: true
         },
         'darwin',
+        undefined,
+        { context: 'terminal', terminalShortcutPolicy: 'terminal-first' }
+      )
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction(
+        'terminal.markUnread',
+        {
+          key: 'u',
+          code: 'KeyU',
+          control: true,
+          meta: false,
+          alt: false,
+          shift: true
+        },
+        'win32',
         undefined,
         { context: 'terminal', terminalShortcutPolicy: 'terminal-first' }
       )

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -827,12 +827,12 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Terminal Panes',
     scope: 'terminal',
     searchKeywords: ['shortcut', 'terminal', 'unread', 'attention', 'bell'],
-    // Why: Ctrl+Shift+U is terminal/Unicode input on Linux, so only macOS gets
-    // a default. Users can still bind the action explicitly on other platforms.
+    // Why: Ctrl+Shift+U is terminal/Unicode input on Linux, so keep that
+    // platform unbound while defaulting the shortcut on macOS and Windows.
     defaultBindings: {
       darwin: ['Mod+Shift+U'],
       linux: [],
-      win32: []
+      win32: ['Mod+Shift+U']
     }
   },
   {

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -95,6 +95,7 @@ export type KeybindingActionId =
   | 'terminal.paste'
   | 'terminal.search'
   | 'terminal.clear'
+  | 'terminal.markUnread'
   | 'terminal.focusNextPane'
   | 'terminal.focusPreviousPane'
   | 'terminal.equalizePaneSizes'
@@ -555,7 +556,7 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Tab Navigation',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'next', 'switch', 'cycle'],
-    defaultBindings: platformBindings(['Mod+Shift+BracketRight'])
+    defaultBindings: platformBindings([])
   },
   {
     id: 'tab.previousSameType',
@@ -563,23 +564,23 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Tab Navigation',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'previous', 'switch', 'cycle'],
-    defaultBindings: platformBindings(['Mod+Shift+BracketLeft'])
+    defaultBindings: platformBindings([])
   },
   {
     id: 'tab.nextAllTypes',
-    title: 'Next tab (all types)',
+    title: 'Next tab',
     group: 'Tab Navigation',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'next', 'switch', 'cycle', 'all', 'any'],
-    defaultBindings: platformBindings(['Mod+Alt+BracketRight'])
+    defaultBindings: platformBindings(['Mod+Shift+ArrowRight'])
   },
   {
     id: 'tab.previousAllTypes',
-    title: 'Previous tab (all types)',
+    title: 'Previous tab',
     group: 'Tab Navigation',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'previous', 'switch', 'cycle', 'all', 'any'],
-    defaultBindings: platformBindings(['Mod+Alt+BracketLeft'])
+    defaultBindings: platformBindings(['Mod+Shift+ArrowLeft'])
   },
   {
     id: 'tab.previousRecent',
@@ -819,6 +820,20 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'terminal',
     searchKeywords: ['shortcut', 'pane', 'clear'],
     defaultBindings: platformBindings(['Mod+K'])
+  },
+  {
+    id: 'terminal.markUnread',
+    title: 'Mark active terminal unread',
+    group: 'Terminal Panes',
+    scope: 'terminal',
+    searchKeywords: ['shortcut', 'terminal', 'unread', 'attention', 'bell'],
+    // Why: Ctrl+Shift+U is terminal/Unicode input on Linux, so only macOS gets
+    // a default. Users can still bind the action explicitly on other platforms.
+    defaultBindings: {
+      darwin: ['Mod+Shift+U'],
+      linux: [],
+      win32: []
+    }
   },
   {
     id: 'terminal.focusNextPane',

--- a/tests/e2e/tabs.spec.ts
+++ b/tests/e2e/tabs.spec.ts
@@ -161,12 +161,12 @@ test.describe('Tabs', () => {
    * - New tab works
    *
    * Why: we still use the store's `setActiveTab` for the switch itself (the
-   * hotkey path that used to be here turned out to target bracket-chord next/
+   * hotkey path that used to be here turned out to target shifted-arrow next/
    * prev tab cycling, not arbitrary tab selection), but the final assertion
    * checks DOM `data-active` to prove the selection actually paints onto the
    * right tab element.
    */
-  test('Cmd/Ctrl+Shift+] and Cmd/Ctrl+Shift+[ switch between tabs', async ({ orcaPage }) => {
+  test('Cmd/Ctrl+Shift+Right and Cmd/Ctrl+Shift+Left switch between tabs', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
 
     // Ensure we have at least 2 tabs — use the real "+" flow so a render
@@ -280,7 +280,7 @@ test.describe('Tabs', () => {
   })
 
   /**
-   * Regression: after a drag-reorder, Cmd/Ctrl+Shift+[ must walk tabs in
+   * Regression: after a drag-reorder, Cmd/Ctrl+Shift+Left must walk tabs in
    * the new visible order. The pre-fix bug read a stale legacy order
    * (`tabBarOrderByWorktree`), so pressing "left" three times cycled
    * 3 → 1 → 2 instead of 3 → 2 → 1 once tabs had been rearranged.
@@ -289,7 +289,7 @@ test.describe('Tabs', () => {
    * the load-bearing check — it fails if the shortcut walks the right store
    * id but the tab bar stops painting the active indicator on that tab.
    */
-  test('Cmd/Ctrl+Shift+[ walks tabs in drag-reordered order', async ({ orcaPage }) => {
+  test('Cmd/Ctrl+Shift+Left walks tabs in drag-reordered order', async ({ orcaPage }) => {
     const isMac = process.platform === 'darwin'
     const mod = isMac ? 'Meta' : 'Control'
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
@@ -346,11 +346,11 @@ test.describe('Tabs', () => {
     }, a)
     await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(a)
 
-    await orcaPage.keyboard.press(`${mod}+Shift+BracketLeft`)
+    await orcaPage.keyboard.press(`${mod}+Shift+ArrowLeft`)
     await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(c)
     await expect(tabLocator(orcaPage, c)).toHaveAttribute('data-active', 'true')
 
-    await orcaPage.keyboard.press(`${mod}+Shift+BracketLeft`)
+    await orcaPage.keyboard.press(`${mod}+Shift+ArrowLeft`)
     await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(b)
     await expect(tabLocator(orcaPage, b)).toHaveAttribute('data-active', 'true')
   })

--- a/tests/e2e/terminal-panes.spec.ts
+++ b/tests/e2e/terminal-panes.spec.ts
@@ -1050,8 +1050,8 @@ test.describe('Terminal Panes', () => {
     const activeType = await getActiveTabType(orcaPage)
     expect(activeType).toBe('terminal')
 
-    // Switch back to the previous tab with Cmd/Ctrl+Shift+[
-    await pressShortcut(orcaPage, 'BracketLeft', { shift: true })
+    // Switch back to the previous tab with Cmd/Ctrl+Shift+Left
+    await pressShortcut(orcaPage, 'ArrowLeft', { shift: true })
 
     // Verify the marker is still present
     await expect
@@ -1059,7 +1059,7 @@ test.describe('Terminal Panes', () => {
       .toBe(true)
 
     // Clean up the extra tab
-    await pressShortcut(orcaPage, 'BracketRight', { shift: true })
+    await pressShortcut(orcaPage, 'ArrowRight', { shift: true })
     await pressShortcut(orcaPage, 'w')
   })
 

--- a/tests/e2e/terminal-shortcuts.spec.ts
+++ b/tests/e2e/terminal-shortcuts.spec.ts
@@ -643,7 +643,7 @@ test.describe('Terminal Shortcuts', () => {
     ).toBeVisible()
     await focusFloatingTerminal(orcaPage)
 
-    await orcaPage.keyboard.press(`${mod}+Shift+BracketRight`)
+    await orcaPage.keyboard.press(`${mod}+Shift+ArrowRight`)
     await expect
       .poll(() => getActiveFloatingTerminalTabId(orcaPage), {
         timeout: 5_000,
@@ -658,7 +658,7 @@ test.describe('Terminal Shortcuts', () => {
       .toBe(scenario.backgroundFirstTabId)
 
     await focusFloatingTerminal(orcaPage)
-    await orcaPage.keyboard.press(`${mod}+Shift+BracketLeft`)
+    await orcaPage.keyboard.press(`${mod}+Shift+ArrowLeft`)
     await expect
       .poll(() => getActiveFloatingTerminalTabId(orcaPage), {
         timeout: 5_000,


### PR DESCRIPTION
## Summary

This PR adds the keyboard workflow for moving through workspace tabs and manually flagging terminal work as unread: Command/Ctrl+Shift+Left/Right now cycles across every visible tab type in the active workspace, and Command+Shift+U on macOS or Ctrl+Shift+U on Windows marks the current terminal tab and workspace unread.

The unread-state fixes support that workflow rather than define it. Keyboard workspace navigation now preserves a manually marked terminal as unread, and returning to the unread terminal clears the workspace unread badge once no unread terminal tabs remain.

Terminal-focused bracket shortcuts remain scoped to terminal pane focus, so existing terminal pane navigation can keep working without taking over the global all-tab navigation shortcut.

## Screenshots

No visual layout change. Behavior was verified in the running Electron dev app during development.

## Testing

- [x] `pnpm lint` (Node 24)
- [x] `pnpm typecheck` (Node 24)
- [x] `pnpm vitest run --config config/vitest.config.ts src/shared/keybindings.test.ts` (Node 24)
- [x] `pnpm test` (Node 24; 20197 passed, 21 skipped)
- [x] `pnpm build` (Node 24; completed with the existing `/usr/local/bin/orca-dev` symlink permission warning and macOS `CGWindowListCreateImage` deprecation warning)
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed keyboard routing, terminal and floating-terminal handling, tab activation, workspace activation, and unread clearing paths. The review explicitly checked macOS, Linux, and Windows shortcut behavior: the all-tab navigation shortcut uses shared `Mod` bindings, the mark-unread shortcut defaults on macOS and Windows, and Linux remains unbound for mark-unread to avoid the terminal Ctrl+Shift+U Unicode-input conflict.

The review also checked SSH, remote, and local compatibility. These changes only affect renderer/store event handling and do not assume local shell, path, process, credential, or provider behavior. Performance risk is low because unread checks scan only the active workspace's terminal tabs during explicit activation or shortcut actions. UI quality risk is limited to existing unread indicators; no layout, color, typography, or style tokens changed. Supported agent, integration, and git-provider compatibility were reviewed; no provider-specific review code, integration protocol, agent command, or terminal transport behavior was introduced.

## Security Audit

No new IPC channels, command execution, dependency, network, filesystem, auth, or secret-handling surface was added. The security review focused on keyboard-event interception and stale unread state; consumed shortcuts are limited to registered app keybindings and terminal input is only stopped after a recognized workspace-navigation action.

## Notes

- Command/Ctrl+Shift+Left/Right now cycles across all visible tab types in a workspace.
- Command+Shift+U on macOS and Ctrl+Shift+U on Windows mark the active terminal tab and workspace unread.
- Linux remains unbound by default for mark-unread to avoid terminal/Unicode input conflicts; users can still bind it manually.
- Command/Ctrl+Shift+Up/Down preserves manually marked unread state while navigating workspaces.
- Synced locale catalog keys required by current main lint for terminal scroll-speed settings.
- X/Twitter: not provided

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5.5_xhigh](https://img.shields.io/badge/GPT--5.5_xhigh-000000)

## ELI5

Keyboard shortcuts cycle all visible workspace tabs and mark the current terminal unread. Manual unread state is preserved when you navigate so “mark unread” stays meaningful.
