### PR TITLE
Handle stale daemon terminal sessions on disconnect

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -388,6 +388,24 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(exits).toEqual([{ id: 'old-session', code: -1 }])
       expect(adapter.getActiveSessionIds()).toEqual(['new-session'])
     })
+
+    it('does not exit surviving sessions when a synthetic exit listener throws', async () => {
+      adapter.onExit(() => {
+        throw new Error('listener failed')
+      })
+
+      const internals = adapter as unknown as {
+        activeSessionIds: Set<string>
+        probeAliveSessionIds: () => Promise<Set<string>>
+        reconcileAfterDaemonDisconnect: () => Promise<void>
+      }
+      internals.activeSessionIds.add('dead-session')
+      internals.activeSessionIds.add('live-session')
+      internals.probeAliveSessionIds = vi.fn(async () => new Set(['live-session']))
+
+      await expect(internals.reconcileAfterDaemonDisconnect()).rejects.toThrow('listener failed')
+      expect(adapter.getActiveSessionIds()).toEqual(['live-session'])
+    })
   })
 
   describe('spawn with sessionId (reattach)', () => {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -286,6 +286,110 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       await waitFor(() => exits.length > 0)
       expect(exits[0]).toEqual({ id, code: 42 })
     })
+
+    it('fans out synthetic exits when the daemon connection drops', async () => {
+      const exits: { id: string; code: number }[] = []
+      adapter.onExit((payload) => exits.push(payload))
+
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+      await server.shutdown()
+
+      await waitFor(() => exits.length > 0)
+      expect(exits[0]).toEqual({ id, code: -1 })
+      expect(adapter.getActiveSessionIds()).toEqual([])
+    })
+
+    it('keeps sessions active when a dropped socket can reconnect to the same daemon', async () => {
+      const exits: { id: string; code: number }[] = []
+      adapter.onExit((payload) => exits.push(payload))
+
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+      const clients = (
+        server as unknown as {
+          clients: Map<string, { streamSocket: { destroy(): void } | null }>
+        }
+      ).clients
+      const originalStreamSocket = [...clients.values()][0]?.streamSocket
+      expect(originalStreamSocket).toBeTruthy()
+
+      originalStreamSocket?.destroy()
+
+      await waitFor(() =>
+        [...clients.values()].some(
+          (client) => client.streamSocket !== null && client.streamSocket !== originalStreamSocket
+        )
+      )
+      expect(exits).toEqual([])
+      expect(adapter.getActiveSessionIds()).toEqual([id])
+
+      adapter.write(id, 'after-reconnect')
+      await waitFor(() =>
+        vi.mocked(lastSubprocess.write).mock.calls.some(([data]) => data === 'after-reconnect')
+      )
+    })
+
+    it('does not reconnect a disposed adapter when disconnect reconciliation finishes late', async () => {
+      const exits: { id: string; code: number }[] = []
+      adapter.onExit((payload) => exits.push(payload))
+
+      const internals = adapter as unknown as {
+        activeSessionIds: Set<string>
+        probeAliveSessionIds: () => Promise<Set<string>>
+        reconcileAfterDaemonDisconnect: () => Promise<void>
+        client: { ensureConnected: () => Promise<void>; disconnect: () => void }
+      }
+      internals.activeSessionIds.add('sess-a')
+      internals.probeAliveSessionIds = vi.fn(async () => new Set(['sess-a']))
+
+      let releaseReconnect: (() => void) | undefined
+      const reconnectStarted = vi.fn()
+      internals.client = {
+        ensureConnected: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              reconnectStarted()
+              releaseReconnect = resolve
+            })
+        ),
+        disconnect: vi.fn()
+      }
+
+      const reconcile = internals.reconcileAfterDaemonDisconnect()
+      await waitFor(() => reconnectStarted.mock.calls.length > 0)
+      adapter.dispose()
+      releaseReconnect?.()
+      await reconcile
+
+      expect(exits).toEqual([])
+      expect(vi.mocked(internals.client.disconnect).mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('only exits sessions present when a late disconnect reconciliation fails', async () => {
+      const exits: { id: string; code: number }[] = []
+      adapter.onExit((payload) => exits.push(payload))
+
+      const internals = adapter as unknown as {
+        activeSessionIds: Set<string>
+        probeAliveSessionIds: () => Promise<Set<string>>
+        reconcileAfterDaemonDisconnect: () => Promise<void>
+      }
+      let rejectProbe: ((err: Error) => void) | undefined
+      internals.probeAliveSessionIds = vi.fn(
+        () =>
+          new Promise<Set<string>>((_, reject) => {
+            rejectProbe = reject
+          })
+      )
+      internals.activeSessionIds.add('old-session')
+
+      const reconcile = internals.reconcileAfterDaemonDisconnect()
+      internals.activeSessionIds.add('new-session')
+      rejectProbe?.(new Error('probe failed'))
+      await reconcile
+
+      expect(exits).toEqual([{ id: 'old-session', code: -1 }])
+      expect(adapter.getActiveSessionIds()).toEqual(['new-session'])
+    })
   })
 
   describe('spawn with sessionId (reattach)', () => {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -406,6 +406,35 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       await expect(internals.reconcileAfterDaemonDisconnect()).rejects.toThrow('listener failed')
       expect(adapter.getActiveSessionIds()).toEqual(['live-session'])
     })
+
+    it('exits surviving sessions if the primary client cannot reconnect after probing', async () => {
+      const exits: { id: string; code: number }[] = []
+      adapter.onExit((payload) => exits.push(payload))
+
+      const internals = adapter as unknown as {
+        activeSessionIds: Set<string>
+        probeAliveSessionIds: () => Promise<Set<string>>
+        reconcileAfterDaemonDisconnect: () => Promise<void>
+        client: { ensureConnected: () => Promise<void>; disconnect: () => void }
+      }
+      internals.activeSessionIds.add('dead-session')
+      internals.activeSessionIds.add('live-session')
+      internals.probeAliveSessionIds = vi.fn(async () => new Set(['live-session']))
+      internals.client = {
+        ensureConnected: vi.fn(async () => {
+          throw new Error('reconnect failed')
+        }),
+        disconnect: vi.fn()
+      }
+
+      await internals.reconcileAfterDaemonDisconnect()
+
+      expect(exits).toEqual([
+        { id: 'dead-session', code: -1 },
+        { id: 'live-session', code: -1 }
+      ])
+      expect(adapter.getActiveSessionIds()).toEqual([])
+    })
   })
 
   describe('spawn with sessionId (reattach)', () => {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -322,10 +322,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(exits).toEqual([])
       expect(adapter.getActiveSessionIds()).toEqual([id])
 
-      adapter.write(id, 'after-reconnect')
-      await waitFor(() =>
-        vi.mocked(lastSubprocess.write).mock.calls.some(([data]) => data === 'after-reconnect')
-      )
+      const sessions = await adapter.listSessions()
+      expect(sessions.some((session) => session.sessionId === id)).toBe(true)
     })
 
     it('does not reconnect a disposed adapter when disconnect reconciliation finishes late', async () => {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -324,6 +324,11 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       const sessions = await adapter.listSessions()
       expect(sessions.some((session) => session.sessionId === id)).toBe(true)
+
+      lastSubprocess._simulateExit(42)
+      await waitFor(() => exits.length > 0)
+      expect(exits).toEqual([{ id, code: 42 }])
+      expect(adapter.getActiveSessionIds()).toEqual([])
     })
 
     it('does not reconnect a disposed adapter when disconnect reconciliation finishes late', async () => {
@@ -398,13 +403,61 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         activeSessionIds: Set<string>
         probeAliveSessionIds: () => Promise<Set<string>>
         reconcileAfterDaemonDisconnect: () => Promise<void>
+        client: {
+          ensureConnected: () => Promise<void>
+          request: (type: string, payload: unknown) => Promise<unknown>
+          disconnect: () => void
+        }
       }
       internals.activeSessionIds.add('dead-session')
       internals.activeSessionIds.add('live-session')
       internals.probeAliveSessionIds = vi.fn(async () => new Set(['live-session']))
+      internals.client = {
+        ensureConnected: vi.fn(async () => undefined),
+        request: vi.fn(async () => ({
+          isNew: false,
+          snapshot: null,
+          pid: null,
+          shellState: 'unsupported'
+        })),
+        disconnect: vi.fn()
+      }
 
       await expect(internals.reconcileAfterDaemonDisconnect()).rejects.toThrow('listener failed')
+      expect(internals.client.ensureConnected).toHaveBeenCalledTimes(1)
       expect(adapter.getActiveSessionIds()).toEqual(['live-session'])
+    })
+
+    it('clears all dead synthetic-exit state before propagating a listener error', async () => {
+      adapter.onExit(() => {
+        throw new Error('listener failed')
+      })
+
+      const internals = adapter as unknown as {
+        activeSessionIds: Set<string>
+        dirtySessionVersions: Map<string, number>
+        coldRestoreCache: Map<string, { scrollback: string; cwd: string; oscLinks?: unknown[] }>
+        probeAliveSessionIds: () => Promise<Set<string>>
+        reattachSurvivedSessions: (sessionIds: string[]) => Promise<string[]>
+        reconcileAfterDaemonDisconnect: () => Promise<void>
+      }
+      internals.activeSessionIds.add('dead-session-a')
+      internals.activeSessionIds.add('dead-session-b')
+      internals.activeSessionIds.add('live-session')
+      internals.dirtySessionVersions.set('dead-session-a', 1)
+      internals.dirtySessionVersions.set('dead-session-b', 1)
+      internals.dirtySessionVersions.set('live-session', 1)
+      internals.coldRestoreCache.set('dead-session-a', { scrollback: 'a', cwd: '/tmp' })
+      internals.coldRestoreCache.set('dead-session-b', { scrollback: 'b', cwd: '/tmp' })
+      internals.coldRestoreCache.set('live-session', { scrollback: 'live', cwd: '/tmp' })
+      internals.probeAliveSessionIds = vi.fn(async () => new Set(['live-session']))
+      internals.reattachSurvivedSessions = vi.fn(async () => [])
+
+      await expect(internals.reconcileAfterDaemonDisconnect()).rejects.toThrow('listener failed')
+
+      expect(adapter.getActiveSessionIds()).toEqual(['live-session'])
+      expect([...internals.dirtySessionVersions.keys()]).toEqual(['live-session'])
+      expect([...internals.coldRestoreCache.keys()]).toEqual(['live-session'])
     })
 
     it('exits surviving sessions if the primary client cannot reconnect after probing', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -521,19 +521,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return
     }
 
+    let aliveSessionIds: Set<string>
     try {
-      const aliveSessionIds = await this.probeAliveSessionIds()
-      if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
-        return
-      }
-      const exitedIds = idsAtDisconnect.filter((id) => !aliveSessionIds.has(id))
-      this.fanoutSyntheticExitIds(exitedIds, -1)
-      if (exitedIds.length < idsAtDisconnect.length) {
-        await this.client.ensureConnected()
-        if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
-          this.client.disconnect()
-        }
-      }
+      aliveSessionIds = await this.probeAliveSessionIds()
     } catch {
       if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
         return
@@ -541,6 +531,22 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // Why: if reconnect/listSessions fails, the adapter cannot know whether
       // daemon-backed PTYs still exist. Prefer visible exits over dropped input.
       this.fanoutSyntheticExitIds(idsAtDisconnect, -1)
+      return
+    }
+
+    if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
+      return
+    }
+
+    const exitedIds = idsAtDisconnect.filter((id) => !aliveSessionIds.has(id))
+    this.fanoutSyntheticExitIds(exitedIds, -1)
+    if (exitedIds.length < idsAtDisconnect.length) {
+      await this.client.ensureConnected()
+      if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
+        // Why: a newer disconnect/dispose won the race while reconnecting; undo
+        // this stale reconnect so it cannot keep sockets alive behind teardown.
+        this.client.disconnect()
+      }
     }
   }
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -539,9 +539,21 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     const exitedIds = idsAtDisconnect.filter((id) => !aliveSessionIds.has(id))
+    const survivedIds = idsAtDisconnect.filter((id) => aliveSessionIds.has(id))
     this.fanoutSyntheticExitIds(exitedIds, -1)
-    if (exitedIds.length < idsAtDisconnect.length) {
-      await this.client.ensureConnected()
+
+    if (survivedIds.length > 0) {
+      // Why: if the probe can see live sessions but the primary client still
+      // cannot reconnect, keeping those sessions "active" would black-hole input.
+      try {
+        await this.client.ensureConnected()
+      } catch {
+        if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
+          return
+        }
+        this.fanoutSyntheticExitIds(survivedIds, -1)
+        return
+      }
       if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
         // Why: a newer disconnect/dispose won the race while reconnecting; undo
         // this stale reconnect so it cannot keep sockets alive behind teardown.

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -69,6 +69,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private dataListeners: ((payload: { id: string; data: string }) => void)[] = []
   private exitListeners: ((payload: { id: string; code: number }) => void)[] = []
   private removeEventListener: (() => void) | null = null
+  private removeDisconnectedListener: (() => void) | null = null
   private initialCwds = new Map<string, string>()
   // Why: React re-renders and StrictMode double-mounts can call createOrAttach
   // for a session the user just killed. Without tombstones, the daemon would
@@ -90,6 +91,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private sessionsNeedingFullCheckpoint = new Set<string>()
   private checkpointTimer: ReturnType<typeof setTimeout> | null = null
   private checkpointInFlight: Promise<void> | null = null
+  private isDisposed = false
+  private disconnectReconcileGeneration = 0
   // Why: checkpoint-based persistence requires the getSnapshot RPC (v4+).
   // Legacy daemons reject it, causing noisy log spam every 5 seconds.
   private supportsCheckpoints: boolean
@@ -112,6 +115,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.respawnFn = opts.respawn ?? null
     this.supportsCheckpoints = this.protocolVersion >= 4
     this.supportsIncrementalCheckpoints = this.protocolVersion >= 13
+    this.removeDisconnectedListener = this.client.onDisconnected(() => {
+      void this.reconcileAfterDaemonDisconnect()
+    })
   }
 
   getHistoryManager(): HistoryManager | null {
@@ -486,11 +492,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // path so downstream cleanup (clearProviderPtyState, markClaudePtyExited,
   // renderer pty:exit) runs exactly as it does on natural exit.
   fanoutSyntheticExits(code: number): void {
-    const ids = [...this.activeSessionIds]
-    this.activeSessionIds.clear()
-    this.dirtySessionVersions.clear()
-    this.stopCheckpointTimer()
+    this.fanoutSyntheticExitIds([...this.activeSessionIds], code)
+  }
+
+  private fanoutSyntheticExitIds(ids: string[], code: number): void {
     for (const id of ids) {
+      if (!this.activeSessionIds.delete(id)) {
+        continue
+      }
+      this.dirtySessionVersions.delete(id)
       this.coldRestoreCache.delete(id)
       // Why: listener throws are intentionally *not* caught — matches the
       // natural onExit fanout in setupEventRouting, so synthetic exits don't
@@ -500,6 +510,54 @@ export class DaemonPtyAdapter implements IPtyProvider {
       for (const listener of [...this.exitListeners]) {
         listener({ id, code })
       }
+    }
+    this.stopCheckpointTimerIfIdle()
+  }
+
+  private async reconcileAfterDaemonDisconnect(): Promise<void> {
+    const generation = ++this.disconnectReconcileGeneration
+    const idsAtDisconnect = [...this.activeSessionIds]
+    if (this.isDisposed || idsAtDisconnect.length === 0) {
+      return
+    }
+
+    try {
+      const aliveSessionIds = await this.probeAliveSessionIds()
+      if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
+        return
+      }
+      const exitedIds = idsAtDisconnect.filter((id) => !aliveSessionIds.has(id))
+      this.fanoutSyntheticExitIds(exitedIds, -1)
+      if (exitedIds.length < idsAtDisconnect.length) {
+        await this.client.ensureConnected()
+        if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
+          this.client.disconnect()
+        }
+      }
+    } catch {
+      if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
+        return
+      }
+      // Why: if reconnect/listSessions fails, the adapter cannot know whether
+      // daemon-backed PTYs still exist. Prefer visible exits over dropped input.
+      this.fanoutSyntheticExitIds(idsAtDisconnect, -1)
+    }
+  }
+
+  private async probeAliveSessionIds(): Promise<Set<string>> {
+    const probeClient = new DaemonClient({
+      socketPath: this.socketPath,
+      tokenPath: this.tokenPath,
+      protocolVersion: this.protocolVersion
+    })
+    try {
+      await probeClient.ensureConnected()
+      const result = await probeClient.request<ListSessionsResult>('listSessions', undefined)
+      return new Set(
+        result.sessions.filter((session) => session.isAlive).map((session) => session.sessionId)
+      )
+    } finally {
+      probeClient.disconnect()
     }
   }
 
@@ -546,11 +604,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   dispose(): void {
+    this.isDisposed = true
+    this.disconnectReconcileGeneration++
     this.stopCheckpointTimer()
     this.dirtySessionVersions.clear()
     this.coldRestoreCache.clear()
     this.removeEventListener?.()
     this.removeEventListener = null
+    this.removeDisconnectedListener?.()
+    this.removeDisconnectedListener = null
     // Why: final checkpoints are written daemon-side in TerminalHost.dispose()
     // which has direct access to sessions. The adapter only marks sessions as
     // cleanly ended here so they don't trigger false cold restores.
@@ -569,6 +631,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // We write a final checkpoint before disconnecting so that if the daemon
   // later crashes while Orca is closed, checkpoint.json has recovery data.
   async disconnectOnly(): Promise<void> {
+    this.isDisposed = true
+    this.disconnectReconcileGeneration++
     this.stopCheckpointTimer()
     // Why: wait for any in-flight timer pass to finish before starting
     // the final checkpoint. Otherwise both passes race on the shared tmp
@@ -586,6 +650,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.coldRestoreCache.clear()
     this.removeEventListener?.()
     this.removeEventListener = null
+    this.removeDisconnectedListener?.()
+    this.removeDisconnectedListener = null
     this.client.disconnect()
   }
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -82,6 +82,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   // second mount until the renderer explicitly acknowledges it.
   private coldRestoreCache = new Map<string, ColdRestorePayload>()
   private activeSessionIds = new Set<string>()
+  private sessionSizes = new Map<string, { cols: number; rows: number }>()
   private dirtySessionVersions = new Map<string, number>()
   // Why: a cold-restored session is a fresh shell whose on-disk checkpoint and
   // log belong to the pre-crash session. Incremental appends would land on
@@ -187,6 +188,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     if (effectiveCwd) {
       this.initialCwds.set(sessionId, effectiveCwd)
     }
+    this.sessionSizes.set(sessionId, { cols: effectiveCols, rows: effectiveRows })
 
     // Why: the daemon RPC returns the shell pid of the backing subprocess.
     // Surfacing it through PtySpawnResult lets ipc/pty register with the
@@ -283,6 +285,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       cols: 80,
       rows: 24
     })
+    this.sessionSizes.set(id, { cols: 80, rows: 24 })
   }
 
   hasPty(id: string): boolean {
@@ -296,6 +299,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
   resize(id: string, cols: number, rows: number): void {
     this.markSessionDirty(id)
+    this.sessionSizes.set(id, { cols, rows })
     this.client.notify('resize', { sessionId: id, cols, rows })
   }
 
@@ -307,6 +311,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
     await this.client.request('kill', { sessionId: id, immediate: opts.immediate ?? false })
     this.activeSessionIds.delete(id)
+    this.sessionSizes.delete(id)
     this.dirtySessionVersions.delete(id)
     this.coldRestoreCache.delete(id)
     // Why: the !keepHistory close path doesn't take a final checkpoint, so a
@@ -496,22 +501,23 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   private fanoutSyntheticExitIds(ids: string[], code: number): void {
-    for (const id of ids) {
-      if (!this.activeSessionIds.delete(id)) {
-        continue
-      }
+    const activeExitIds = [...new Set(ids)].filter((id) => this.activeSessionIds.has(id))
+    for (const id of activeExitIds) {
+      this.activeSessionIds.delete(id)
+      this.sessionSizes.delete(id)
       this.dirtySessionVersions.delete(id)
       this.coldRestoreCache.delete(id)
-      // Why: listener throws are intentionally *not* caught — matches the
-      // natural onExit fanout in setupEventRouting, so synthetic exits don't
-      // diverge in error semantics from real ones. A throwing listener is a
-      // bug that should surface loudly, not be silently swallowed.
+      this.sessionsNeedingFullCheckpoint.delete(id)
+    }
+    this.stopCheckpointTimerIfIdle()
+    for (const id of activeExitIds) {
+      // Why: cleanup must finish before notification because listener throws
+      // intentionally propagate, matching natural onExit fanout semantics.
       // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
       for (const listener of [...this.exitListeners]) {
         listener({ id, code })
       }
     }
-    this.stopCheckpointTimerIfIdle()
   }
 
   private async reconcileAfterDaemonDisconnect(): Promise<void> {
@@ -540,26 +546,52 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
     const exitedIds = idsAtDisconnect.filter((id) => !aliveSessionIds.has(id))
     const survivedIds = idsAtDisconnect.filter((id) => aliveSessionIds.has(id))
-    this.fanoutSyntheticExitIds(exitedIds, -1)
+    let syntheticExitIds = exitedIds
 
     if (survivedIds.length > 0) {
       // Why: if the probe can see live sessions but the primary client still
       // cannot reconnect, keeping those sessions "active" would black-hole input.
       try {
         await this.client.ensureConnected()
+        syntheticExitIds = [...exitedIds, ...(await this.reattachSurvivedSessions(survivedIds))]
       } catch {
         if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
           return
         }
-        this.fanoutSyntheticExitIds(survivedIds, -1)
-        return
+        syntheticExitIds = [...exitedIds, ...survivedIds]
       }
       if (this.isDisposed || generation !== this.disconnectReconcileGeneration) {
         // Why: a newer disconnect/dispose won the race while reconnecting; undo
         // this stale reconnect so it cannot keep sockets alive behind teardown.
         this.client.disconnect()
+        return
       }
     }
+
+    this.fanoutSyntheticExitIds(syntheticExitIds, -1)
+  }
+
+  private async reattachSurvivedSessions(sessionIds: string[]): Promise<string[]> {
+    const failedIds: string[] = []
+    for (const sessionId of sessionIds) {
+      const size = this.sessionSizes.get(sessionId) ?? { cols: 80, rows: 24 }
+      try {
+        // Why: reconnecting the sockets is not enough. The daemon Session still
+        // holds callbacks that close over the old stream client until reattach.
+        const result = await this.client.request<CreateOrAttachResult>('createOrAttach', {
+          sessionId,
+          cols: size.cols,
+          rows: size.rows
+        })
+        if (result.isNew) {
+          failedIds.push(sessionId)
+          await this.client.request('kill', { sessionId, immediate: true }).catch(() => {})
+        }
+      } catch {
+        failedIds.push(sessionId)
+      }
+    }
+    return failedIds
   }
 
   private async probeAliveSessionIds(): Promise<Set<string>> {
@@ -979,6 +1011,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         }
       } else if (event.event === 'exit') {
         this.activeSessionIds.delete(event.sessionId)
+        this.sessionSizes.delete(event.sessionId)
         this.dirtySessionVersions.delete(event.sessionId)
         this.coldRestoreCache.delete(event.sessionId)
         // Why: an exited session can never be checkpointed again, so its pending


### PR DESCRIPTION
## Summary
- reconcile daemon-backed terminal sessions when the daemon client disconnects
- emit synthetic exits only for sessions no longer alive in the daemon, avoiding dropped terminal input for stale sessions
- guard disconnect reconciliation against app quit/dispose races and late failures

## Review
- Ran an independent subagent regression review focused on daemon disconnects, intentional shutdown, warm reattach, restart sequencing, legacy routing, and transient disconnect handling.
- Addressed its findings by adding dispose/generation guards and snapshot-scoped fallback exits.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-pty-adapter.test.ts --maxWorkers=1
- pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/client.test.ts src/main/daemon/daemon-init.test.ts src/main/daemon/daemon-pty-router.test.ts --maxWorkers=1
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
