### PR TITLE
Show GitHub issue workspaces immediately while they initialize

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -134,6 +134,7 @@ import {
   findGithubWorkItemWorkspaceAttachment,
   getGithubWorkItemWorkspaceAttachmentLabel
 } from '@/lib/github-work-item-workspace-attachment'
+import { createGitHubWorkItemWorkspaceInBackground } from '@/lib/github-work-item-background-create'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
 import GitHubItemDialog, { type ItemDialogTab } from '@/components/GitHubItemDialog'
@@ -6196,17 +6197,16 @@ export default function TaskPage(): React.JSX.Element {
 
   const handleUseWorkItem = useCallback(
     (item: GitHubWorkItem): void => {
-      // Why: open the unified New Workspace dialog pre-filled with the work
-      // item as the selected source so the user can confirm name / agent /
-      // setup before the worktree is created. Earlier the "Use" CTA created
-      // and activated the worktree synchronously, which was disorienting —
-      // the worktree appeared in the sidebar before the user had a chance
-      // to review it. The composer already owns the prefill flow. Telemetry
-      // attribution flows via `openComposerForItem` (sets telemetrySource).
       useAppStore.getState().recordFeatureInteraction('github-tasks')
-      openComposerForItem(item)
+      void createGitHubWorkItemWorkspaceInBackground({
+        item,
+        repoId: item.repoId,
+        taskSourceContext: getTaskPageRepoSourceContext(repoMap.get(item.repoId), 'github'),
+        telemetrySource: 'sidebar',
+        openModalFallback: () => openComposerForItem(item)
+      })
     },
-    [openComposerForItem]
+    [openComposerForItem, repoMap]
   )
 
   const handleOpenOrUseGitHubWorkItem = useCallback(

--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -534,6 +534,8 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
       if (!workItem) {
         return
       }
+      // Why: issue #4756 changes the TaskPage "Create workspace" path only.
+      // Project view still means "start work now", so it stays on direct launch.
       void launchWorkItemDirect({
         item: workItem,
         repoId: matched.id,
@@ -806,6 +808,8 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
           onUse={(item) => {
             const current = resolvedDialogRepoItem
             setDialogRepoItem(null)
+            // Why: issue #4756 keeps project-view actions on the direct
+            // "start work now" path instead of the TaskPage background-create flow.
             void launchWorkItemDirect({
               item,
               repoId: current.workItem.repoId,

--- a/src/renderer/src/components/task-page-github-background-create-boundary.test.ts
+++ b/src/renderer/src/components/task-page-github-background-create-boundary.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const TASK_PAGE_SOURCE = readFileSync(join(__dirname, 'TaskPage.tsx'), 'utf8')
+const PROJECT_VIEW_SOURCE = readFileSync(
+  join(__dirname, 'github-project', 'ProjectViewWrapper.tsx'),
+  'utf8'
+)
+
+function sourceBetween(source: string, startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('GitHub workspace creation source boundaries', () => {
+  it('routes the TaskPage GitHub create path through background creation first', () => {
+    const section = sourceBetween(
+      TASK_PAGE_SOURCE,
+      'const handleUseWorkItem = useCallback(',
+      'const handleOpenOrUseGitHubWorkItem = useCallback('
+    )
+
+    expect(section).toContain('createGitHubWorkItemWorkspaceInBackground({')
+    expect(section).toContain('openModalFallback: () => openComposerForItem(item)')
+    expect(section).not.toContain("openModal('new-workspace-composer'")
+  })
+
+  it('keeps project-view GitHub actions on the direct start-work path for issue #4756', () => {
+    const section = sourceBetween(PROJECT_VIEW_SOURCE, 'void launchWorkItemDirect({', '})\n    },')
+
+    expect(PROJECT_VIEW_SOURCE).toContain('issue #4756')
+    expect(section).toContain("launchSource: 'task_page'")
+    expect(section).not.toContain('createGitHubWorkItemWorkspaceInBackground')
+  })
+})

--- a/src/renderer/src/components/task-page-github-background-create-boundary.test.ts
+++ b/src/renderer/src/components/task-page-github-background-create-boundary.test.ts
@@ -30,9 +30,14 @@ describe('GitHub workspace creation source boundaries', () => {
   })
 
   it('keeps project-view GitHub actions on the direct start-work path for issue #4756', () => {
-    const section = sourceBetween(PROJECT_VIEW_SOURCE, 'void launchWorkItemDirect({', '})\n    },')
+    const section = sourceBetween(
+      PROJECT_VIEW_SOURCE,
+      '// Why: issue #4756 keeps project-view actions on the direct',
+      'openModalFallback: () => {'
+    )
 
     expect(PROJECT_VIEW_SOURCE).toContain('issue #4756')
+    expect(section).toContain('void launchWorkItemDirect({')
     expect(section).toContain("launchSource: 'task_page'")
     expect(section).not.toContain('createGitHubWorkItemWorkspaceInBackground')
   })

--- a/src/renderer/src/lib/github-work-item-background-create.test.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.test.ts
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+import type { GitHubWorkItem, Repo } from '../../../shared/types'
+
+vi.mock('@/lib/tui-agent-startup', () => ({
+  buildAgentDraftLaunchPlan: vi.fn(() => null),
+  buildAgentStartupPlan: vi.fn(() => ({
+    agent: 'codex',
+    launchCommand: 'codex',
+    expectedProcess: 'codex',
+    followupPrompt: null,
+    launchConfig: { kind: 'shell', command: 'codex' }
+  }))
+}))
+
+vi.mock('@/lib/telemetry', () => ({
+  tuiAgentToAgentKind: (agent: string) => agent
+}))
+
+import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '@/lib/tui-agent-startup'
+import { createGitHubWorkItemWorkspaceInBackground } from './github-work-item-background-create'
+
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/repo',
+  displayName: 'orca',
+  badgeColor: 'blue',
+  addedAt: 1
+}
+
+function makeIssue(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {
+  return {
+    id: 'I_42',
+    repoId: 'repo-1',
+    type: 'issue',
+    number: 42,
+    title: 'Make issue workspace creation async',
+    url: 'https://github.com/stablyai/orca/issues/42',
+    state: 'open',
+    author: null,
+    labels: [],
+    assignees: [],
+    createdAt: '2026-06-22T00:00:00Z',
+    updatedAt: '2026-06-22T00:00:00Z',
+    commentsCount: 0,
+    ...overrides
+  } as GitHubWorkItem
+}
+
+function makeStore(overrides: Partial<ReturnType<typeof baseStore>> = {}) {
+  return { ...baseStore(), ...overrides }
+}
+
+function baseStore() {
+  return {
+    repos: [repo],
+    settings: {
+      activeRuntimeEnvironmentId: null,
+      defaultTuiAgent: 'codex' as const,
+      disabledTuiAgents: []
+    },
+    ensureDetectedAgents: vi.fn().mockResolvedValue([]),
+    ensureRemoteDetectedAgents: vi.fn().mockResolvedValue([])
+  }
+}
+
+function makeDeps(store = makeStore()) {
+  return {
+    getStore: () => store,
+    hasPendingCreate: vi.fn(() => true),
+    resolveSetupDecision: vi.fn().mockResolvedValue({ kind: 'decided', decision: 'inherit' }),
+    resolvePrStartPoint: vi.fn(),
+    confirmHooks: vi.fn().mockResolvedValue('run'),
+    beginBackgroundCreate: vi.fn(() => 'creation-1'),
+    continueBackgroundCreate: vi.fn(() => true),
+    removePendingCreate: vi.fn(),
+    toastError: vi.fn()
+  }
+}
+
+describe('createGitHubWorkItemWorkspaceInBackground', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('starts a background issue workspace without opening the composer', async () => {
+    const deps = makeDeps()
+    const openModalFallback = vi.fn()
+
+    const result = await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        telemetrySource: 'sidebar',
+        openModalFallback
+      },
+      deps
+    )
+
+    expect(result).toEqual({ kind: 'background-started' })
+    expect(openModalFallback).not.toHaveBeenCalled()
+    expect(deps.beginBackgroundCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoId: 'repo-1',
+        name: 'issue-42-make-issue-workspace',
+        displayName: 'Issue 42 Make Issue Workspace',
+        linkedIssue: 42,
+        telemetrySource: 'sidebar',
+        setupDecision: 'inherit',
+        agent: null
+      })
+    )
+    expect(deps.continueBackgroundCreate).toHaveBeenCalledWith(
+      'creation-1',
+      expect.objectContaining({
+        repoId: 'repo-1',
+        name: 'issue-42-make-issue-workspace',
+        displayName: 'Issue 42 Make Issue Workspace',
+        linkedIssue: 42,
+        telemetrySource: 'sidebar',
+        setupDecision: 'inherit',
+        agent: null,
+        startupPlan: null,
+        quickPrompt: '',
+        quickTelemetry: null
+      })
+    )
+  })
+
+  it('shows the pending workspace before async preflight resolves', async () => {
+    let resolveSetupDecision: ((value: { kind: 'decided'; decision: 'inherit' }) => void) | null =
+      null
+    const deps = makeDeps()
+    deps.resolveSetupDecision.mockImplementation(
+      () =>
+        new Promise<{ kind: 'decided'; decision: 'inherit' }>((resolve) => {
+          resolveSetupDecision = resolve
+        })
+    )
+
+    const pending = createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback: vi.fn()
+      },
+      deps
+    )
+
+    expect(deps.beginBackgroundCreate).toHaveBeenCalledTimes(1)
+    expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
+
+    expect(resolveSetupDecision).not.toBeNull()
+    resolveSetupDecision!({ kind: 'decided', decision: 'inherit' })
+    await pending
+
+    expect(deps.continueBackgroundCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the preferred quick agent when one is available', async () => {
+    const store = makeStore({
+      ensureDetectedAgents: vi.fn().mockResolvedValue(['codex'])
+    })
+    const deps = makeDeps(store)
+
+    await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback: vi.fn()
+      },
+      deps
+    )
+
+    const continueCall = deps.continueBackgroundCreate.mock.calls[0] as unknown[] | undefined
+    expect(continueCall).toBeDefined()
+    const request = continueCall?.[1] as WorktreeCreationRequest
+    expect(request.agent).toBe('codex')
+    expect(request.startupPlan?.launchCommand).toBe('codex')
+    expect(request.startup).toBeUndefined()
+    expect(request.quickTelemetry).toEqual({
+      agent_kind: 'codex',
+      launch_source: 'new_workspace_composer',
+      request_kind: 'new'
+    })
+    expect(buildAgentStartupPlan).toHaveBeenCalled()
+  })
+
+  it('stops before opening the composer when the staged create is cancelled during setup preflight', async () => {
+    let resolveSetupDecision: ((value: { kind: 'needs-modal' }) => void) | null = null
+    const deps = makeDeps()
+    deps.resolveSetupDecision.mockImplementation(
+      () =>
+        new Promise<{ kind: 'needs-modal' }>((resolve) => {
+          resolveSetupDecision = resolve
+        })
+    )
+    const openModalFallback = vi.fn()
+
+    const pending = createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback
+      },
+      deps
+    )
+
+    deps.hasPendingCreate.mockReturnValue(false)
+    expect(resolveSetupDecision).not.toBeNull()
+    resolveSetupDecision!({ kind: 'needs-modal' })
+
+    expect(await pending).toEqual({ kind: 'background-started' })
+    expect(openModalFallback).not.toHaveBeenCalled()
+    expect(deps.removePendingCreate).not.toHaveBeenCalled()
+    expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
+  })
+
+  it('stops before hook trust and agent detection when the staged create is cancelled', async () => {
+    let resolveSetupDecision: ((value: { kind: 'decided'; decision: 'inherit' }) => void) | null =
+      null
+    const deps = makeDeps()
+    deps.resolveSetupDecision.mockImplementation(
+      () =>
+        new Promise<{ kind: 'decided'; decision: 'inherit' }>((resolve) => {
+          resolveSetupDecision = resolve
+        })
+    )
+
+    const pending = createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback: vi.fn()
+      },
+      deps
+    )
+
+    deps.hasPendingCreate.mockReturnValue(false)
+    expect(resolveSetupDecision).not.toBeNull()
+    resolveSetupDecision!({ kind: 'decided', decision: 'inherit' })
+
+    expect(await pending).toEqual({ kind: 'background-started' })
+    expect(deps.confirmHooks).not.toHaveBeenCalled()
+    expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the composer when setup policy requires an explicit choice', async () => {
+    const deps = makeDeps()
+    deps.resolveSetupDecision.mockResolvedValueOnce({ kind: 'needs-modal' })
+    const openModalFallback = vi.fn()
+
+    const result = await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback
+      },
+      deps
+    )
+
+    expect(result).toEqual({ kind: 'fallback', reason: 'setup-ask' })
+    expect(openModalFallback).toHaveBeenCalledTimes(1)
+    expect(deps.removePendingCreate).toHaveBeenCalledWith('creation-1')
+    expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the composer when PR start point cannot be resolved', async () => {
+    const deps = makeDeps()
+    deps.resolvePrStartPoint.mockRejectedValueOnce(new Error('No PR head'))
+    const openModalFallback = vi.fn()
+
+    const result = await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue({ type: 'pr', number: 7, url: 'https://github.com/stablyai/orca/pull/7' }),
+        repoId: 'repo-1',
+        openModalFallback
+      },
+      deps
+    )
+
+    expect(result).toEqual({ kind: 'fallback', reason: 'pr-start-point' })
+    expect(deps.toastError).toHaveBeenCalledWith('No PR head')
+    expect(openModalFallback).toHaveBeenCalledTimes(1)
+    expect(deps.removePendingCreate).toHaveBeenCalledWith('creation-1')
+    expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
+  })
+
+  it('includes resolved PR start-point data in the background request', async () => {
+    const deps = makeDeps()
+    deps.resolvePrStartPoint.mockResolvedValueOnce({
+      baseBranch: 'feature/from-pr',
+      pushTarget: { remote: 'origin', branch: 'feature/from-pr' },
+      branchNameOverride: 'feature/from-pr',
+      compareBaseRef: 'main'
+    })
+
+    await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue({ type: 'pr', number: 7, url: 'https://github.com/stablyai/orca/pull/7' }),
+        repoId: 'repo-1',
+        openModalFallback: vi.fn()
+      },
+      deps
+    )
+
+    expect(deps.continueBackgroundCreate).toHaveBeenCalledWith(
+      'creation-1',
+      expect.objectContaining({
+        linkedPR: 7,
+        baseBranch: 'feature/from-pr',
+        pushTarget: { remote: 'origin', branch: 'feature/from-pr' },
+        branchNameOverride: 'feature/from-pr',
+        compareBaseRef: 'main'
+      })
+    )
+  })
+
+  it('prefers native draft startup when the agent supports it', async () => {
+    vi.mocked(buildAgentDraftLaunchPlan).mockReturnValueOnce({
+      agent: 'codex',
+      launchCommand: 'codex --prompt-file',
+      expectedProcess: 'codex',
+      launchConfig: { agentCommand: 'codex', agentArgs: '--prompt-file', agentEnv: {} }
+    })
+    const store = makeStore({
+      ensureDetectedAgents: vi.fn().mockResolvedValue(['codex'])
+    })
+    const deps = makeDeps(store)
+
+    await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback: vi.fn()
+      },
+      deps
+    )
+
+    const continueCall = deps.continueBackgroundCreate.mock.calls[0] as unknown[] | undefined
+    expect(continueCall).toBeDefined()
+    const request = continueCall?.[1] as WorktreeCreationRequest
+    expect(request.startupPlan?.launchCommand).toBe('codex --prompt-file')
+    expect(request.startup?.command).toBe('codex --prompt-file')
+    expect(buildAgentStartupPlan).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/github-work-item-background-create.test.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.test.ts
@@ -60,7 +60,8 @@ function baseStore() {
       disabledTuiAgents: []
     },
     ensureDetectedAgents: vi.fn().mockResolvedValue([]),
-    ensureRemoteDetectedAgents: vi.fn().mockResolvedValue([])
+    ensureRemoteDetectedAgents: vi.fn().mockResolvedValue([]),
+    ensureRuntimeDetectedAgents: vi.fn().mockResolvedValue([])
   }
 }
 
@@ -184,6 +185,47 @@ describe('createGitHubWorkItemWorkspaceInBackground', () => {
       request_kind: 'new'
     })
     expect(buildAgentStartupPlan).toHaveBeenCalled()
+  })
+
+  it('uses runtime-owned detection and indeterminate progress for runtime repos', async () => {
+    const runtimeRepo: Repo = {
+      ...repo,
+      executionHostId: 'runtime:env-1'
+    }
+    const store = makeStore({
+      repos: [runtimeRepo],
+      ensureDetectedAgents: vi.fn().mockResolvedValue([]),
+      ensureRemoteDetectedAgents: vi.fn().mockResolvedValue([]),
+      ensureRuntimeDetectedAgents: vi.fn().mockResolvedValue(['codex'])
+    })
+    const deps = makeDeps(store)
+
+    await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback: vi.fn()
+      },
+      deps
+    )
+
+    expect(store.ensureRuntimeDetectedAgents).toHaveBeenCalledWith('env-1')
+    expect(store.ensureDetectedAgents).not.toHaveBeenCalled()
+    expect(store.ensureRemoteDetectedAgents).not.toHaveBeenCalled()
+    expect(deps.beginBackgroundCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeCreateProgressMode: 'indeterminate',
+        workspaceRunContext: expect.objectContaining({
+          hostId: 'runtime:env-1',
+          repoId: 'repo-1'
+        })
+      })
+    )
+    const continueCall = deps.continueBackgroundCreate.mock.calls[0] as unknown[] | undefined
+    expect(continueCall).toBeDefined()
+    const request = continueCall?.[1] as WorktreeCreationRequest
+    expect(request.worktreeCreateProgressMode).toBe('indeterminate')
+    expect(request.agent).toBe('codex')
   })
 
   it('stops before opening the composer when the staged create is cancelled during setup preflight', async () => {

--- a/src/renderer/src/lib/github-work-item-background-create.test.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.test.ts
@@ -288,6 +288,38 @@ describe('createGitHubWorkItemWorkspaceInBackground', () => {
     expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
   })
 
+  it('falls back without staging when the runtime host platform is unknown', async () => {
+    const runtimeRepo: Repo = {
+      ...repo,
+      executionHostId: 'runtime:env-1'
+    }
+    const deps = makeDeps(
+      makeStore({
+        repos: [runtimeRepo],
+        runtimeStatusByEnvironmentId: new Map([
+          ['env-1', { status: makeRuntimeStatus({ runtimeId: 'runtime-env-1' }), checkedAt: 1 }]
+        ])
+      })
+    )
+    const openModalFallback = vi.fn()
+
+    const result = await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback
+      },
+      deps
+    )
+
+    expect(result).toEqual({ kind: 'fallback', reason: 'host-unavailable' })
+    expect(openModalFallback).toHaveBeenCalledTimes(1)
+    expect(deps.beginBackgroundCreate).not.toHaveBeenCalled()
+    expect(deps.resolveSetupDecision).not.toHaveBeenCalled()
+    expect(deps.confirmHooks).not.toHaveBeenCalled()
+    expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
+  })
+
   it('uses the preferred quick agent when one is available', async () => {
     const store = makeStore({
       ensureDetectedAgents: vi.fn().mockResolvedValue(['codex'])
@@ -325,7 +357,13 @@ describe('createGitHubWorkItemWorkspaceInBackground', () => {
     const store = makeStore({
       repos: [runtimeRepo],
       runtimeStatusByEnvironmentId: new Map([
-        ['env-1', { status: makeRuntimeStatus({ runtimeId: 'runtime-env-1' }), checkedAt: 1 }]
+        [
+          'env-1',
+          {
+            status: makeRuntimeStatus({ runtimeId: 'runtime-env-1', hostPlatform: 'win32' }),
+            checkedAt: 1
+          }
+        ]
       ]),
       ensureDetectedAgents: vi.fn().mockResolvedValue([]),
       ensureRemoteDetectedAgents: vi.fn().mockResolvedValue([]),
@@ -359,6 +397,34 @@ describe('createGitHubWorkItemWorkspaceInBackground', () => {
     const request = continueCall?.[1] as WorktreeCreationRequest
     expect(request.worktreeCreateProgressMode).toBe('indeterminate')
     expect(request.agent).toBe('codex')
+    expect(buildAgentStartupPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'win32' })
+    )
+  })
+
+  it('falls back before creating when the selected agent startup plan cannot be built', async () => {
+    vi.mocked(buildAgentStartupPlan).mockReturnValueOnce(null)
+    const store = makeStore({
+      ensureDetectedAgents: vi.fn().mockResolvedValue(['codex'])
+    })
+    const deps = makeDeps(store)
+    const openModalFallback = vi.fn()
+
+    const result = await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback
+      },
+      deps
+    )
+
+    expect(result).toEqual({ kind: 'fallback', reason: 'agent-startup' })
+    expect(deps.toastError).toHaveBeenCalledWith('Could not build the agent launch command.')
+    expect(deps.removePendingCreate).toHaveBeenCalledWith('creation-1')
+    expect(deps.setActiveView).toHaveBeenCalledWith('tasks')
+    expect(openModalFallback).toHaveBeenCalledTimes(1)
+    expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
   })
 
   it('stops before opening the composer when the staged create is cancelled during setup preflight', async () => {

--- a/src/renderer/src/lib/github-work-item-background-create.test.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.test.ts
@@ -53,7 +53,9 @@ function makeStore(overrides: Partial<ReturnType<typeof baseStore>> = {}) {
 
 function baseStore() {
   return {
+    activeView: 'tasks' as const,
     repos: [repo],
+    pendingWorktreeCreations: {},
     settings: {
       activeRuntimeEnvironmentId: null,
       defaultTuiAgent: 'codex' as const,
@@ -68,13 +70,17 @@ function baseStore() {
 function makeDeps(store = makeStore()) {
   return {
     getStore: () => store,
+    getActiveView: vi.fn(() => store.activeView),
     hasPendingCreate: vi.fn(() => true),
+    isPendingCreateActive: vi.fn(() => true),
     resolveSetupDecision: vi.fn().mockResolvedValue({ kind: 'decided', decision: 'inherit' }),
     resolvePrStartPoint: vi.fn(),
     confirmHooks: vi.fn().mockResolvedValue('run'),
     beginBackgroundCreate: vi.fn(() => 'creation-1'),
     continueBackgroundCreate: vi.fn(() => true),
+    activatePendingCreate: vi.fn(),
     removePendingCreate: vi.fn(),
+    setActiveView: vi.fn(),
     toastError: vi.fn()
   }
 }
@@ -156,6 +162,50 @@ describe('createGitHubWorkItemWorkspaceInBackground', () => {
     await pending
 
     expect(deps.continueBackgroundCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses an existing pending issue create instead of staging a duplicate', async () => {
+    const pendingRequest: WorktreeCreationRequest = {
+      repoId: 'repo-1',
+      name: 'issue-42-make-issue-workspace',
+      setupDecision: 'inherit',
+      linkedIssue: 42,
+      agent: null,
+      pendingFirstAgentMessageRename: false,
+      note: '',
+      startupPlan: null,
+      quickPrompt: '',
+      quickTelemetry: null
+    }
+    const deps = makeDeps(
+      makeStore({
+        pendingWorktreeCreations: {
+          'creation-existing': {
+            creationId: 'creation-existing',
+            phase: 'preparing',
+            status: 'creating',
+            indeterminate: false,
+            loaderVisible: true,
+            request: pendingRequest
+          }
+        }
+      })
+    )
+
+    const result = await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback: vi.fn()
+      },
+      deps
+    )
+
+    expect(result).toEqual({ kind: 'background-started' })
+    expect(deps.activatePendingCreate).toHaveBeenCalledWith('creation-existing')
+    expect(deps.beginBackgroundCreate).not.toHaveBeenCalled()
+    expect(deps.resolveSetupDecision).not.toHaveBeenCalled()
+    expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
   })
 
   it('uses the preferred quick agent when one is available', async () => {
@@ -304,7 +354,26 @@ describe('createGitHubWorkItemWorkspaceInBackground', () => {
     expect(result).toEqual({ kind: 'fallback', reason: 'setup-ask' })
     expect(openModalFallback).toHaveBeenCalledTimes(1)
     expect(deps.removePendingCreate).toHaveBeenCalledWith('creation-1')
+    expect(deps.setActiveView).toHaveBeenCalledWith('tasks')
     expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
+  })
+
+  it('leaves the current view alone on fallback after the user leaves the staged create', async () => {
+    const deps = makeDeps()
+    deps.resolveSetupDecision.mockResolvedValueOnce({ kind: 'needs-modal' })
+    deps.isPendingCreateActive.mockReturnValueOnce(false)
+
+    await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback: vi.fn()
+      },
+      deps
+    )
+
+    expect(deps.removePendingCreate).toHaveBeenCalledWith('creation-1')
+    expect(deps.setActiveView).not.toHaveBeenCalled()
   })
 
   it('falls back to the composer when PR start point cannot be resolved', async () => {
@@ -325,6 +394,7 @@ describe('createGitHubWorkItemWorkspaceInBackground', () => {
     expect(deps.toastError).toHaveBeenCalledWith('No PR head')
     expect(openModalFallback).toHaveBeenCalledTimes(1)
     expect(deps.removePendingCreate).toHaveBeenCalledWith('creation-1')
+    expect(deps.setActiveView).toHaveBeenCalledWith('tasks')
     expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/github-work-item-background-create.test.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+import type { RuntimeStatus } from '../../../shared/runtime-types'
 import type { GitHubWorkItem, Repo } from '../../../shared/types'
+import {
+  MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+  RUNTIME_PROTOCOL_VERSION
+} from '../../../shared/protocol-version'
 
 vi.mock('@/lib/tui-agent-startup', () => ({
   buildAgentDraftLaunchPlan: vi.fn(() => null),
@@ -26,6 +31,20 @@ const repo: Repo = {
   displayName: 'orca',
   badgeColor: 'blue',
   addedAt: 1
+}
+
+function makeRuntimeStatus(overrides: Partial<RuntimeStatus> = {}): RuntimeStatus {
+  return {
+    runtimeId: 'runtime-1',
+    rendererGraphEpoch: 1,
+    graphStatus: 'ready',
+    authoritativeWindowId: null,
+    liveTabCount: 0,
+    liveLeafCount: 0,
+    runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+    minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+    ...overrides
+  }
 }
 
 function makeIssue(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {
@@ -56,6 +75,8 @@ function baseStore() {
     activeView: 'tasks' as const,
     repos: [repo],
     pendingWorktreeCreations: {},
+    sshConnectionStates: new Map(),
+    runtimeStatusByEnvironmentId: new Map(),
     settings: {
       activeRuntimeEnvironmentId: null,
       defaultTuiAgent: 'codex' as const,
@@ -208,6 +229,65 @@ describe('createGitHubWorkItemWorkspaceInBackground', () => {
     expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
   })
 
+  it('falls back without staging when the SSH repo is disconnected', async () => {
+    const sshRepo: Repo = {
+      ...repo,
+      connectionId: 'devbox'
+    }
+    const deps = makeDeps(
+      makeStore({
+        repos: [sshRepo],
+        sshConnectionStates: new Map([['devbox', { status: 'disconnected' }]])
+      })
+    )
+    const openModalFallback = vi.fn()
+
+    const result = await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback
+      },
+      deps
+    )
+
+    expect(result).toEqual({ kind: 'fallback', reason: 'host-unavailable' })
+    expect(openModalFallback).toHaveBeenCalledTimes(1)
+    expect(deps.beginBackgroundCreate).not.toHaveBeenCalled()
+    expect(deps.resolveSetupDecision).not.toHaveBeenCalled()
+    expect(deps.confirmHooks).not.toHaveBeenCalled()
+  })
+
+  it('falls back without staging when the runtime repo is unreachable', async () => {
+    const runtimeRepo: Repo = {
+      ...repo,
+      executionHostId: 'runtime:env-1'
+    }
+    const deps = makeDeps(
+      makeStore({
+        repos: [runtimeRepo],
+        runtimeStatusByEnvironmentId: new Map([['env-1', { status: null, checkedAt: 1 }]])
+      })
+    )
+    const openModalFallback = vi.fn()
+
+    const result = await createGitHubWorkItemWorkspaceInBackground(
+      {
+        item: makeIssue(),
+        repoId: 'repo-1',
+        openModalFallback
+      },
+      deps
+    )
+
+    expect(result).toEqual({ kind: 'fallback', reason: 'host-unavailable' })
+    expect(openModalFallback).toHaveBeenCalledTimes(1)
+    expect(deps.beginBackgroundCreate).not.toHaveBeenCalled()
+    expect(deps.resolveSetupDecision).not.toHaveBeenCalled()
+    expect(deps.confirmHooks).not.toHaveBeenCalled()
+    expect(deps.continueBackgroundCreate).not.toHaveBeenCalled()
+  })
+
   it('uses the preferred quick agent when one is available', async () => {
     const store = makeStore({
       ensureDetectedAgents: vi.fn().mockResolvedValue(['codex'])
@@ -244,6 +324,9 @@ describe('createGitHubWorkItemWorkspaceInBackground', () => {
     }
     const store = makeStore({
       repos: [runtimeRepo],
+      runtimeStatusByEnvironmentId: new Map([
+        ['env-1', { status: makeRuntimeStatus({ runtimeId: 'runtime-env-1' }), checkedAt: 1 }]
+      ]),
       ensureDetectedAgents: vi.fn().mockResolvedValue([]),
       ensureRemoteDetectedAgents: vi.fn().mockResolvedValue([]),
       ensureRuntimeDetectedAgents: vi.fn().mockResolvedValue(['codex'])

--- a/src/renderer/src/lib/github-work-item-background-create.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.ts
@@ -1,0 +1,168 @@
+import { toast } from 'sonner'
+
+import { useAppStore } from '@/store'
+import {
+  beginBackgroundWorktreePreparation,
+  continueBackgroundWorktreeCreation
+} from '@/lib/worktree-creation-flow'
+import {
+  buildGitHubWorkItemBackendStartup,
+  buildGitHubWorkItemStartupPlan,
+  buildInitialGitHubWorkItemRequest,
+  type GitHubWorkItemBackgroundStoreSnapshot,
+  resolvePreferredQuickAgentForGitHubWorkItem
+} from '@/lib/github-work-item-background-request'
+import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+import {
+  resolveDirectPrStartPoint,
+  resolveDirectSetupDecision
+} from '@/lib/launch-work-item-direct-preflight'
+import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
+import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import type { GitHubWorkItem, SetupDecision } from '../../../shared/types'
+import type { TaskSourceContext, WorkspaceRunContext } from '../../../shared/task-source-context'
+
+export type BackgroundGitHubWorkItemCreateResult =
+  | { kind: 'background-started' }
+  | { kind: 'error' }
+  | { kind: 'fallback'; reason: 'repo-missing' | 'setup-ask' | 'pr-start-point' }
+
+type BackgroundGitHubWorkItemCreateDeps = {
+  getStore: () => GitHubWorkItemBackgroundStoreSnapshot
+  hasPendingCreate: (creationId: string) => boolean
+  resolveSetupDecision: typeof resolveDirectSetupDecision
+  resolvePrStartPoint: typeof resolveDirectPrStartPoint
+  confirmHooks: (
+    store: GitHubWorkItemBackgroundStoreSnapshot,
+    repoId: string,
+    scope: 'setup'
+  ) => ReturnType<typeof ensureHooksConfirmed>
+  beginBackgroundCreate: typeof beginBackgroundWorktreePreparation
+  continueBackgroundCreate: typeof continueBackgroundWorktreeCreation
+  removePendingCreate: (creationId: string) => void
+  toastError: (message: string) => void
+}
+
+export type BackgroundGitHubWorkItemCreateArgs = {
+  item: GitHubWorkItem
+  repoId: string
+  taskSourceContext?: TaskSourceContext | null
+  workspaceRunContext?: WorkspaceRunContext | null
+  telemetrySource?: WorktreeCreationRequest['telemetrySource']
+  openModalFallback: () => void
+}
+
+const DEFAULT_DEPS: BackgroundGitHubWorkItemCreateDeps = {
+  getStore: () => useAppStore.getState(),
+  hasPendingCreate: (creationId) =>
+    useAppStore.getState().pendingWorktreeCreations[creationId] != null,
+  resolveSetupDecision: resolveDirectSetupDecision,
+  resolvePrStartPoint: resolveDirectPrStartPoint,
+  confirmHooks: (store, repoId, scope) =>
+    ensureHooksConfirmed(store as ReturnType<typeof useAppStore.getState>, repoId, scope),
+  beginBackgroundCreate: beginBackgroundWorktreePreparation,
+  continueBackgroundCreate: continueBackgroundWorktreeCreation,
+  removePendingCreate: (creationId) =>
+    useAppStore.getState().removePendingWorktreeCreation(creationId),
+  toastError: (message) => toast.error(message)
+}
+
+export async function createGitHubWorkItemWorkspaceInBackground(
+  args: BackgroundGitHubWorkItemCreateArgs,
+  deps: BackgroundGitHubWorkItemCreateDeps = DEFAULT_DEPS
+): Promise<BackgroundGitHubWorkItemCreateResult> {
+  const store = deps.getStore()
+  const repo = store.repos.find((candidate) => candidate.id === args.repoId)
+  if (!repo) {
+    args.openModalFallback()
+    return { kind: 'fallback', reason: 'repo-missing' }
+  }
+
+  const initialRequest = buildInitialGitHubWorkItemRequest(args, repo)
+  const creationId = deps.beginBackgroundCreate(initialRequest)
+
+  try {
+    const repoOwnerSettings = getSettingsForRepoRuntimeOwner(store, args.repoId)
+    const setupResolution = await deps.resolveSetupDecision(args.repoId, repo, repoOwnerSettings)
+    if (!deps.hasPendingCreate(creationId)) {
+      return { kind: 'background-started' }
+    }
+    if (setupResolution.kind === 'needs-modal') {
+      deps.removePendingCreate(creationId)
+      args.openModalFallback()
+      return { kind: 'fallback', reason: 'setup-ask' }
+    }
+
+    let baseBranch: string | undefined
+    let pushTarget: WorktreeCreationRequest['pushTarget']
+    let branchNameOverride: string | undefined
+    let compareBaseRef: string | undefined
+    if (args.item.type === 'pr' && args.item.number) {
+      try {
+        const result = await deps.resolvePrStartPoint(
+          args.repoId,
+          args.item.number,
+          repoOwnerSettings,
+          args.item
+        )
+        baseBranch = result.baseBranch
+        pushTarget = result.pushTarget
+        branchNameOverride = result.branchNameOverride
+        compareBaseRef = result.compareBaseRef
+        if (!deps.hasPendingCreate(creationId)) {
+          return { kind: 'background-started' }
+        }
+      } catch (error) {
+        if (!deps.hasPendingCreate(creationId)) {
+          return { kind: 'background-started' }
+        }
+        deps.toastError(error instanceof Error ? error.message : 'Unable to resolve pull request.')
+        deps.removePendingCreate(creationId)
+        args.openModalFallback()
+        return { kind: 'fallback', reason: 'pr-start-point' }
+      }
+    }
+
+    const trustDecision = await deps.confirmHooks(store, args.repoId, 'setup')
+    if (!deps.hasPendingCreate(creationId)) {
+      return { kind: 'background-started' }
+    }
+    const setupDecision: SetupDecision =
+      trustDecision === 'skip' ? 'skip' : setupResolution.decision
+    const agent = await resolvePreferredQuickAgentForGitHubWorkItem(store, repo)
+    if (!deps.hasPendingCreate(creationId)) {
+      return { kind: 'background-started' }
+    }
+    const { startupPlan, quickPrompt, quickTelemetry } = buildGitHubWorkItemStartupPlan({
+      agent,
+      item: args.item,
+      repo,
+      store
+    })
+    const backendStartup = buildGitHubWorkItemBackendStartup(agent, startupPlan, quickTelemetry)
+
+    const request: WorktreeCreationRequest = {
+      ...initialRequest,
+      ...(baseBranch ? { baseBranch } : {}),
+      ...(compareBaseRef ? { compareBaseRef } : {}),
+      setupDecision,
+      ...(pushTarget ? { pushTarget } : {}),
+      agent,
+      ...(branchNameOverride ? { branchNameOverride } : {}),
+      ...(backendStartup ? { startup: backendStartup } : {}),
+      startupPlan,
+      quickPrompt,
+      quickTelemetry
+    }
+
+    deps.continueBackgroundCreate(creationId, request)
+    return { kind: 'background-started' }
+  } catch (error) {
+    if (!deps.hasPendingCreate(creationId)) {
+      return { kind: 'background-started' }
+    }
+    deps.removePendingCreate(creationId)
+    deps.toastError(error instanceof Error ? error.message : 'Unable to prepare workspace.')
+    return { kind: 'error' }
+  }
+}

--- a/src/renderer/src/lib/github-work-item-background-create.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.ts
@@ -84,6 +84,8 @@ export async function createGitHubWorkItemWorkspaceInBackground(
   try {
     const repoOwnerSettings = getSettingsForRepoRuntimeOwner(store, args.repoId)
     const setupResolution = await deps.resolveSetupDecision(args.repoId, repo, repoOwnerSettings)
+    // Why: once the staged row disappears, the user already cancelled or moved
+    // on, so every later preflight await must exit without reopening UI.
     if (!deps.hasPendingCreate(creationId)) {
       return { kind: 'background-started' }
     }

--- a/src/renderer/src/lib/github-work-item-background-create.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.ts
@@ -17,6 +17,7 @@ import {
   resolveDirectPrStartPoint,
   resolveDirectSetupDecision
 } from '@/lib/launch-work-item-direct-preflight'
+import { agentLaunchCommandErrorMessage } from '@/lib/launch-work-item-direct-messages'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
 import { getRepoExecutionHostId, parseExecutionHostId } from '../../../shared/execution-host'
@@ -34,7 +35,7 @@ export type BackgroundGitHubWorkItemCreateResult =
   | { kind: 'error' }
   | {
       kind: 'fallback'
-      reason: 'repo-missing' | 'host-unavailable' | 'setup-ask' | 'pr-start-point'
+      reason: 'repo-missing' | 'host-unavailable' | 'setup-ask' | 'pr-start-point' | 'agent-startup'
     }
 
 type AppActiveView = ReturnType<typeof useAppStore.getState>['activeView']
@@ -121,6 +122,9 @@ function repoHostUnavailable(store: GitHubWorkItemBackgroundStoreSnapshot, repo:
   }
   const status = store.runtimeStatusByEnvironmentId.get(host.environmentId)?.status
   if (!status) {
+    return true
+  }
+  if (!status.hostPlatform) {
     return true
   }
   const compatibility = evaluateRuntimeCompat({
@@ -234,6 +238,12 @@ export async function createGitHubWorkItemWorkspaceInBackground(
       repo,
       store
     })
+    if (agent && !startupPlan) {
+      deps.toastError(agentLaunchCommandErrorMessage())
+      abandonStagedCreate(creationId, restoreView, deps)
+      args.openModalFallback()
+      return { kind: 'fallback', reason: 'agent-startup' }
+    }
     const backendStartup = buildGitHubWorkItemBackendStartup(agent, startupPlan, quickTelemetry)
 
     const request: WorktreeCreationRequest = {

--- a/src/renderer/src/lib/github-work-item-background-create.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.ts
@@ -19,13 +19,23 @@ import {
 } from '@/lib/launch-work-item-direct-preflight'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../../shared/execution-host'
+import { evaluateRuntimeCompat } from '../../../shared/protocol-compat'
+import {
+  MIN_COMPATIBLE_RUNTIME_SERVER_VERSION,
+  RUNTIME_PROTOCOL_VERSION
+} from '../../../shared/protocol-version'
 import type { GitHubWorkItem, SetupDecision } from '../../../shared/types'
+import type { Repo } from '../../../shared/types'
 import type { TaskSourceContext, WorkspaceRunContext } from '../../../shared/task-source-context'
 
 export type BackgroundGitHubWorkItemCreateResult =
   | { kind: 'background-started' }
   | { kind: 'error' }
-  | { kind: 'fallback'; reason: 'repo-missing' | 'setup-ask' | 'pr-start-point' }
+  | {
+      kind: 'fallback'
+      reason: 'repo-missing' | 'host-unavailable' | 'setup-ask' | 'pr-start-point'
+    }
 
 type AppActiveView = ReturnType<typeof useAppStore.getState>['activeView']
 
@@ -101,6 +111,28 @@ function findPendingGitHubWorkItemCreate(
   return match?.creationId ?? null
 }
 
+function repoHostUnavailable(store: GitHubWorkItemBackgroundStoreSnapshot, repo: Repo): boolean {
+  const host = parseExecutionHostId(getRepoExecutionHostId(repo))
+  if (host?.kind === 'ssh') {
+    return store.sshConnectionStates.get(host.targetId)?.status !== 'connected'
+  }
+  if (host?.kind !== 'runtime') {
+    return false
+  }
+  const status = store.runtimeStatusByEnvironmentId.get(host.environmentId)?.status
+  if (!status) {
+    return true
+  }
+  const compatibility = evaluateRuntimeCompat({
+    clientProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+    minCompatibleServerProtocolVersion: MIN_COMPATIBLE_RUNTIME_SERVER_VERSION,
+    serverProtocolVersion: status.runtimeProtocolVersion ?? status.protocolVersion,
+    serverMinCompatibleClientProtocolVersion:
+      status.minCompatibleRuntimeClientVersion ?? status.minCompatibleMobileVersion
+  })
+  return compatibility.kind === 'blocked'
+}
+
 function abandonStagedCreate(
   creationId: string,
   restoreView: AppActiveView,
@@ -131,6 +163,12 @@ export async function createGitHubWorkItemWorkspaceInBackground(
   if (existingPendingCreateId) {
     deps.activatePendingCreate(existingPendingCreateId)
     return { kind: 'background-started' }
+  }
+  // Why: disconnected hosts make hook and agent probes fall back to skip/no-agent;
+  // keep the old composer gate so Retry cannot reuse degraded preflight values.
+  if (repoHostUnavailable(store, repo)) {
+    args.openModalFallback()
+    return { kind: 'fallback', reason: 'host-unavailable' }
   }
 
   const restoreView = deps.getActiveView()

--- a/src/renderer/src/lib/github-work-item-background-create.ts
+++ b/src/renderer/src/lib/github-work-item-background-create.ts
@@ -27,9 +27,13 @@ export type BackgroundGitHubWorkItemCreateResult =
   | { kind: 'error' }
   | { kind: 'fallback'; reason: 'repo-missing' | 'setup-ask' | 'pr-start-point' }
 
+type AppActiveView = ReturnType<typeof useAppStore.getState>['activeView']
+
 type BackgroundGitHubWorkItemCreateDeps = {
   getStore: () => GitHubWorkItemBackgroundStoreSnapshot
+  getActiveView: () => AppActiveView
   hasPendingCreate: (creationId: string) => boolean
+  isPendingCreateActive: (creationId: string) => boolean
   resolveSetupDecision: typeof resolveDirectSetupDecision
   resolvePrStartPoint: typeof resolveDirectPrStartPoint
   confirmHooks: (
@@ -39,7 +43,9 @@ type BackgroundGitHubWorkItemCreateDeps = {
   ) => ReturnType<typeof ensureHooksConfirmed>
   beginBackgroundCreate: typeof beginBackgroundWorktreePreparation
   continueBackgroundCreate: typeof continueBackgroundWorktreeCreation
+  activatePendingCreate: (creationId: string) => void
   removePendingCreate: (creationId: string) => void
+  setActiveView: (view: AppActiveView) => void
   toastError: (message: string) => void
 }
 
@@ -54,17 +60,59 @@ export type BackgroundGitHubWorkItemCreateArgs = {
 
 const DEFAULT_DEPS: BackgroundGitHubWorkItemCreateDeps = {
   getStore: () => useAppStore.getState(),
+  getActiveView: () => useAppStore.getState().activeView,
   hasPendingCreate: (creationId) =>
     useAppStore.getState().pendingWorktreeCreations[creationId] != null,
+  isPendingCreateActive: (creationId) =>
+    useAppStore.getState().activePendingCreationId === creationId,
   resolveSetupDecision: resolveDirectSetupDecision,
   resolvePrStartPoint: resolveDirectPrStartPoint,
   confirmHooks: (store, repoId, scope) =>
     ensureHooksConfirmed(store as ReturnType<typeof useAppStore.getState>, repoId, scope),
   beginBackgroundCreate: beginBackgroundWorktreePreparation,
   continueBackgroundCreate: continueBackgroundWorktreeCreation,
+  activatePendingCreate: (creationId) => {
+    const store = useAppStore.getState()
+    store.setActivePendingWorktreeCreation(creationId)
+    store.setActiveView('terminal')
+    store.setSidebarOpen(true)
+  },
   removePendingCreate: (creationId) =>
     useAppStore.getState().removePendingWorktreeCreation(creationId),
+  setActiveView: (view) => useAppStore.getState().setActiveView(view),
   toastError: (message) => toast.error(message)
+}
+
+function findPendingGitHubWorkItemCreate(
+  store: GitHubWorkItemBackgroundStoreSnapshot,
+  request: WorktreeCreationRequest
+): string | null {
+  if (!request.linkedIssue && !request.linkedPR) {
+    return null
+  }
+  const match = Object.values(store.pendingWorktreeCreations).find((entry) => {
+    const pending = entry.request
+    return (
+      pending.repoId === request.repoId &&
+      pending.linkedIssue === request.linkedIssue &&
+      pending.linkedPR === request.linkedPR
+    )
+  })
+  return match?.creationId ?? null
+}
+
+function abandonStagedCreate(
+  creationId: string,
+  restoreView: AppActiveView,
+  deps: BackgroundGitHubWorkItemCreateDeps
+): void {
+  // Why: fallback paths abandon the temporary creation surface, so return to the
+  // flow that launched it unless the user already activated something else.
+  const shouldRestoreView = deps.isPendingCreateActive(creationId)
+  deps.removePendingCreate(creationId)
+  if (shouldRestoreView) {
+    deps.setActiveView(restoreView)
+  }
 }
 
 export async function createGitHubWorkItemWorkspaceInBackground(
@@ -79,6 +127,13 @@ export async function createGitHubWorkItemWorkspaceInBackground(
   }
 
   const initialRequest = buildInitialGitHubWorkItemRequest(args, repo)
+  const existingPendingCreateId = findPendingGitHubWorkItemCreate(store, initialRequest)
+  if (existingPendingCreateId) {
+    deps.activatePendingCreate(existingPendingCreateId)
+    return { kind: 'background-started' }
+  }
+
+  const restoreView = deps.getActiveView()
   const creationId = deps.beginBackgroundCreate(initialRequest)
 
   try {
@@ -90,7 +145,7 @@ export async function createGitHubWorkItemWorkspaceInBackground(
       return { kind: 'background-started' }
     }
     if (setupResolution.kind === 'needs-modal') {
-      deps.removePendingCreate(creationId)
+      abandonStagedCreate(creationId, restoreView, deps)
       args.openModalFallback()
       return { kind: 'fallback', reason: 'setup-ask' }
     }
@@ -119,7 +174,7 @@ export async function createGitHubWorkItemWorkspaceInBackground(
           return { kind: 'background-started' }
         }
         deps.toastError(error instanceof Error ? error.message : 'Unable to resolve pull request.')
-        deps.removePendingCreate(creationId)
+        abandonStagedCreate(creationId, restoreView, deps)
         args.openModalFallback()
         return { kind: 'fallback', reason: 'pr-start-point' }
       }
@@ -163,7 +218,7 @@ export async function createGitHubWorkItemWorkspaceInBackground(
     if (!deps.hasPendingCreate(creationId)) {
       return { kind: 'background-started' }
     }
-    deps.removePendingCreate(creationId)
+    abandonStagedCreate(creationId, restoreView, deps)
     deps.toastError(error instanceof Error ? error.message : 'Unable to prepare workspace.')
     return { kind: 'error' }
   }

--- a/src/renderer/src/lib/github-work-item-background-request.ts
+++ b/src/renderer/src/lib/github-work-item-background-request.ts
@@ -54,6 +54,8 @@ export function buildGitHubWorkItemBackendStartup(
   startupPlan: AgentStartupPlan | null,
   quickTelemetry: AgentStartedTelemetry | null
 ): WorktreeCreationRequest['startup'] {
+  // Why: draft/followup launches still need the renderer to finish terminal
+  // setup, so only self-contained startup plans can move into createWorktree.
   if (!agent || !startupPlan || startupPlan.draftPrompt || startupPlan.followupPrompt) {
     return undefined
   }

--- a/src/renderer/src/lib/github-work-item-background-request.ts
+++ b/src/renderer/src/lib/github-work-item-background-request.ts
@@ -1,0 +1,226 @@
+import type { useAppStore } from '@/store'
+import {
+  buildAgentDraftLaunchPlan,
+  buildAgentStartupPlan,
+  type AgentStartupPlan
+} from '@/lib/tui-agent-startup'
+import { resolveQuickCreateLinkedWorkItemPrompt } from '@/lib/linked-work-item-context'
+import { pickQuickWorkspaceAgent } from '@/lib/quick-workspace-agent-selection'
+import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+import { CLIENT_PLATFORM, getWorkspaceIntentName, getWorkspaceSeedName } from '@/lib/new-workspace'
+import { getLocalRepoProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import { resolveSourceControlLaunchPlatform } from '@/lib/source-control-launch-platform'
+import {
+  resolveTuiAgentLaunchArgs,
+  resolveTuiAgentLaunchEnv
+} from '../../../shared/tui-agent-launch-defaults'
+import { tuiAgentToAgentKind } from '@/lib/telemetry'
+import type { GitHubWorkItem, GlobalSettings, Repo, TuiAgent } from '../../../shared/types'
+import type { TaskSourceContext, WorkspaceRunContext } from '../../../shared/task-source-context'
+import type { AgentStartedTelemetry } from '@/lib/worktree-activation'
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
+import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
+
+export type GitHubWorkItemBackgroundStoreSnapshot = {
+  repos: readonly Repo[]
+  settings:
+    | Partial<
+        Pick<
+          GlobalSettings,
+          | 'activeRuntimeEnvironmentId'
+          | 'defaultTuiAgent'
+          | 'disabledTuiAgents'
+          | 'agentCmdOverrides'
+          | 'agentDefaultArgs'
+          | 'agentDefaultEnv'
+        >
+      >
+    | null
+    | undefined
+  ensureDetectedAgents: ReturnType<typeof useAppStore.getState>['ensureDetectedAgents']
+  ensureRemoteDetectedAgents: ReturnType<typeof useAppStore.getState>['ensureRemoteDetectedAgents']
+}
+
+export type BuildInitialGitHubWorkItemRequestArgs = {
+  item: GitHubWorkItem
+  repoId: string
+  taskSourceContext?: TaskSourceContext | null
+  workspaceRunContext?: WorkspaceRunContext | null
+  telemetrySource?: WorktreeCreationRequest['telemetrySource']
+}
+
+export function buildGitHubWorkItemBackendStartup(
+  agent: TuiAgent | null,
+  startupPlan: AgentStartupPlan | null,
+  quickTelemetry: AgentStartedTelemetry | null
+): WorktreeCreationRequest['startup'] {
+  if (!agent || !startupPlan || startupPlan.draftPrompt || startupPlan.followupPrompt) {
+    return undefined
+  }
+  return {
+    command: startupPlan.launchCommand,
+    ...(startupPlan.env ? { env: startupPlan.env } : {}),
+    launchConfig: startupPlan.launchConfig,
+    launchAgent: agent,
+    ...(startupPlan.startupCommandDelivery
+      ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
+      : {}),
+    ...(quickTelemetry ? { telemetry: quickTelemetry } : {})
+  }
+}
+
+function getWorkspaceRunContextForRepo(
+  repo: Repo,
+  provided: WorkspaceRunContext | null | undefined
+): WorkspaceRunContext | null {
+  if (provided) {
+    return provided
+  }
+  const projection = projectHostSetupProjectionFromRepos([repo])
+  const project = projection.projects[0]
+  const setup = projection.setups[0]
+  if (!project || !setup) {
+    return null
+  }
+  return {
+    kind: 'workspace-run',
+    projectId: project.id,
+    hostId: getRepoExecutionHostId(repo),
+    projectHostSetupId: setup.id,
+    repoId: repo.id,
+    path: repo.path
+  }
+}
+
+export async function resolvePreferredQuickAgentForGitHubWorkItem(
+  store: GitHubWorkItemBackgroundStoreSnapshot,
+  repo: Repo
+): Promise<TuiAgent | null> {
+  const detectedAgents = repo.connectionId
+    ? await store.ensureRemoteDetectedAgents(repo.connectionId)
+    : await store.ensureDetectedAgents()
+  return pickQuickWorkspaceAgent(
+    store.settings?.defaultTuiAgent,
+    detectedAgents,
+    store.settings?.disabledTuiAgents
+  )
+}
+
+export function buildGitHubWorkItemStartupPlan(args: {
+  agent: TuiAgent | null
+  item: GitHubWorkItem
+  repo: Repo
+  store: GitHubWorkItemBackgroundStoreSnapshot
+}): {
+  startupPlan: AgentStartupPlan | null
+  quickPrompt: string
+  quickTelemetry: AgentStartedTelemetry | null
+} {
+  const { agent, item, repo, store } = args
+  if (!agent) {
+    return { startupPlan: null, quickPrompt: '', quickTelemetry: null }
+  }
+  const { prompt: quickPrompt, draftPrompt } = resolveQuickCreateLinkedWorkItemPrompt(item, '', {
+    cliAvailable: false
+  })
+  const projectRuntime = repo.connectionId
+    ? undefined
+    : getLocalRepoProjectExecutionRuntimeContext(
+        store as ReturnType<typeof useAppStore.getState>,
+        repo.id,
+        CLIENT_PLATFORM
+      )
+  const platform = resolveSourceControlLaunchPlatform({
+    connectionId: repo.connectionId,
+    worktreePath: repo.path,
+    projectRuntime
+  })
+  const draftLaunchPlan = draftPrompt
+    ? buildAgentDraftLaunchPlan({
+        agent,
+        draft: draftPrompt,
+        cmdOverrides: store.settings?.agentCmdOverrides ?? {},
+        agentArgs: resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs),
+        agentEnv: resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv),
+        platform
+      })
+    : null
+  const startupPlan = draftLaunchPlan
+    ? {
+        agent: draftLaunchPlan.agent,
+        launchCommand: draftLaunchPlan.launchCommand,
+        expectedProcess: draftLaunchPlan.expectedProcess,
+        followupPrompt: null,
+        launchConfig: draftLaunchPlan.launchConfig,
+        ...(draftLaunchPlan.startupCommandDelivery
+          ? { startupCommandDelivery: draftLaunchPlan.startupCommandDelivery }
+          : {}),
+        ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
+      }
+    : buildAgentStartupPlan({
+        agent,
+        prompt: quickPrompt,
+        cmdOverrides: store.settings?.agentCmdOverrides ?? {},
+        agentArgs: resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs),
+        agentEnv: resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv),
+        platform,
+        allowEmptyPromptLaunch: true
+      })
+  if (startupPlan && draftPrompt && !draftLaunchPlan) {
+    startupPlan.draftPrompt = draftPrompt
+  }
+  return {
+    startupPlan,
+    quickPrompt,
+    quickTelemetry: {
+      agent_kind: tuiAgentToAgentKind(agent),
+      launch_source: 'new_workspace_composer',
+      request_kind: 'new'
+    }
+  }
+}
+
+function getGitHubWorkItemName(item: GitHubWorkItem): { seedName: string; displayName?: string } {
+  const intent =
+    item.number !== null
+      ? getWorkspaceIntentName({
+          sourceText: item.title,
+          workItem: { type: item.type, number: item.number, title: item.title }
+        })
+      : null
+  return {
+    seedName: getWorkspaceSeedName({
+      explicitName: intent?.seedName ?? '',
+      prompt: '',
+      linkedIssueNumber: item.type === 'issue' ? item.number : null,
+      linkedPR: item.type === 'pr' ? item.number : null
+    }),
+    ...(intent?.displayName ? { displayName: intent.displayName } : {})
+  }
+}
+
+export function buildInitialGitHubWorkItemRequest(
+  args: BuildInitialGitHubWorkItemRequestArgs,
+  repo: Repo
+): WorktreeCreationRequest {
+  const { seedName, displayName } = getGitHubWorkItemName(args.item)
+  const workspaceRunContext = getWorkspaceRunContextForRepo(repo, args.workspaceRunContext)
+  return {
+    repoId: args.repoId,
+    worktreeCreateProgressMode: repo.connectionId ? 'indeterminate' : 'stepped',
+    ...(args.taskSourceContext ? { taskSourceContext: args.taskSourceContext } : {}),
+    ...(workspaceRunContext ? { workspaceRunContext } : {}),
+    name: seedName,
+    ...(displayName ? { displayName } : {}),
+    ...(args.item.type === 'issue' && args.item.number ? { linkedIssue: args.item.number } : {}),
+    ...(args.item.type === 'pr' && args.item.number ? { linkedPR: args.item.number } : {}),
+    ...(args.telemetrySource ? { telemetrySource: args.telemetrySource } : {}),
+    setupDecision: 'inherit',
+    agent: null,
+    pendingFirstAgentMessageRename: false,
+    note: '',
+    startupPlan: null,
+    quickPrompt: '',
+    quickTelemetry: null
+  }
+}

--- a/src/renderer/src/lib/github-work-item-background-request.ts
+++ b/src/renderer/src/lib/github-work-item-background-request.ts
@@ -18,7 +18,7 @@ import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import type { GitHubWorkItem, GlobalSettings, Repo, TuiAgent } from '../../../shared/types'
 import type { TaskSourceContext, WorkspaceRunContext } from '../../../shared/task-source-context'
 import type { AgentStartedTelemetry } from '@/lib/worktree-activation'
-import { getRepoExecutionHostId } from '../../../shared/execution-host'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
 
 export type GitHubWorkItemBackgroundStoreSnapshot = {
@@ -39,6 +39,9 @@ export type GitHubWorkItemBackgroundStoreSnapshot = {
     | undefined
   ensureDetectedAgents: ReturnType<typeof useAppStore.getState>['ensureDetectedAgents']
   ensureRemoteDetectedAgents: ReturnType<typeof useAppStore.getState>['ensureRemoteDetectedAgents']
+  ensureRuntimeDetectedAgents: ReturnType<
+    typeof useAppStore.getState
+  >['ensureRuntimeDetectedAgents']
 }
 
 export type BuildInitialGitHubWorkItemRequestArgs = {
@@ -98,9 +101,13 @@ export async function resolvePreferredQuickAgentForGitHubWorkItem(
   store: GitHubWorkItemBackgroundStoreSnapshot,
   repo: Repo
 ): Promise<TuiAgent | null> {
-  const detectedAgents = repo.connectionId
-    ? await store.ensureRemoteDetectedAgents(repo.connectionId)
-    : await store.ensureDetectedAgents()
+  const host = parseExecutionHostId(getRepoExecutionHostId(repo))
+  const detectedAgents =
+    host?.kind === 'ssh'
+      ? await store.ensureRemoteDetectedAgents(host.targetId)
+      : host?.kind === 'runtime'
+        ? await store.ensureRuntimeDetectedAgents(host.environmentId)
+        : await store.ensureDetectedAgents()
   return pickQuickWorkspaceAgent(
     store.settings?.defaultTuiAgent,
     detectedAgents,
@@ -207,9 +214,10 @@ export function buildInitialGitHubWorkItemRequest(
 ): WorktreeCreationRequest {
   const { seedName, displayName } = getGitHubWorkItemName(args.item)
   const workspaceRunContext = getWorkspaceRunContextForRepo(repo, args.workspaceRunContext)
+  const ownerHost = parseExecutionHostId(getRepoExecutionHostId(repo))
   return {
     repoId: args.repoId,
-    worktreeCreateProgressMode: repo.connectionId ? 'indeterminate' : 'stepped',
+    worktreeCreateProgressMode: ownerHost?.kind === 'local' ? 'stepped' : 'indeterminate',
     ...(args.taskSourceContext ? { taskSourceContext: args.taskSourceContext } : {}),
     ...(workspaceRunContext ? { workspaceRunContext } : {}),
     name: seedName,

--- a/src/renderer/src/lib/github-work-item-background-request.ts
+++ b/src/renderer/src/lib/github-work-item-background-request.ts
@@ -27,6 +27,10 @@ import { projectHostSetupProjectionFromRepos } from '../../../shared/project-hos
 export type GitHubWorkItemBackgroundStoreSnapshot = {
   repos: readonly Repo[]
   pendingWorktreeCreations: Record<string, PendingWorktreeCreation>
+  sshConnectionStates: ReturnType<typeof useAppStore.getState>['sshConnectionStates']
+  runtimeStatusByEnvironmentId: ReturnType<
+    typeof useAppStore.getState
+  >['runtimeStatusByEnvironmentId']
   settings:
     | Partial<
         Pick<

--- a/src/renderer/src/lib/github-work-item-background-request.ts
+++ b/src/renderer/src/lib/github-work-item-background-request.ts
@@ -6,7 +6,10 @@ import {
 } from '@/lib/tui-agent-startup'
 import { resolveQuickCreateLinkedWorkItemPrompt } from '@/lib/linked-work-item-context'
 import { pickQuickWorkspaceAgent } from '@/lib/quick-workspace-agent-selection'
-import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+import type {
+  PendingWorktreeCreation,
+  WorktreeCreationRequest
+} from '@/lib/pending-worktree-creation'
 import { CLIENT_PLATFORM, getWorkspaceIntentName, getWorkspaceSeedName } from '@/lib/new-workspace'
 import { getLocalRepoProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { resolveSourceControlLaunchPlatform } from '@/lib/source-control-launch-platform'
@@ -23,6 +26,7 @@ import { projectHostSetupProjectionFromRepos } from '../../../shared/project-hos
 
 export type GitHubWorkItemBackgroundStoreSnapshot = {
   repos: readonly Repo[]
+  pendingWorktreeCreations: Record<string, PendingWorktreeCreation>
   settings:
     | Partial<
         Pick<

--- a/src/renderer/src/lib/github-work-item-background-request.ts
+++ b/src/renderer/src/lib/github-work-item-background-request.ts
@@ -136,6 +136,32 @@ export async function resolvePreferredQuickAgentForGitHubWorkItem(
   )
 }
 
+function resolveGitHubWorkItemLaunchPlatform(
+  store: GitHubWorkItemBackgroundStoreSnapshot,
+  repo: Repo
+): NodeJS.Platform {
+  const host = parseExecutionHostId(getRepoExecutionHostId(repo))
+  if (host?.kind === 'runtime') {
+    // Why: the background runtime path gates on hostPlatform before this point;
+    // POSIX is safer than client PowerShell if another caller violates that.
+    return (
+      store.runtimeStatusByEnvironmentId.get(host.environmentId)?.status?.hostPlatform ?? 'linux'
+    )
+  }
+  const projectRuntime = repo.connectionId
+    ? undefined
+    : getLocalRepoProjectExecutionRuntimeContext(
+        store as ReturnType<typeof useAppStore.getState>,
+        repo.id,
+        CLIENT_PLATFORM
+      )
+  return resolveSourceControlLaunchPlatform({
+    connectionId: repo.connectionId,
+    worktreePath: repo.path,
+    projectRuntime
+  })
+}
+
 export function buildGitHubWorkItemStartupPlan(args: {
   agent: TuiAgent | null
   item: GitHubWorkItem
@@ -151,18 +177,9 @@ export function buildGitHubWorkItemStartupPlan(args: {
     return { startupPlan: null, quickPrompt: '', quickTelemetry: null }
   }
   const { prompt: quickPrompt, draftPrompt } = resolveGitHubWorkItemPrompt(item)
-  const projectRuntime = repo.connectionId
-    ? undefined
-    : getLocalRepoProjectExecutionRuntimeContext(
-        store as ReturnType<typeof useAppStore.getState>,
-        repo.id,
-        CLIENT_PLATFORM
-      )
-  const platform = resolveSourceControlLaunchPlatform({
-    connectionId: repo.connectionId,
-    worktreePath: repo.path,
-    projectRuntime
-  })
+  // Why: runtime-owned repos launch on their owner host, not on the client
+  // desktop, so startup shell quoting must use the runtime platform.
+  const platform = resolveGitHubWorkItemLaunchPlatform(store, repo)
   const draftLaunchPlan = draftPrompt
     ? buildAgentDraftLaunchPlan({
         agent,

--- a/src/renderer/src/lib/github-work-item-background-request.ts
+++ b/src/renderer/src/lib/github-work-item-background-request.ts
@@ -52,6 +52,19 @@ export type BuildInitialGitHubWorkItemRequestArgs = {
   telemetrySource?: WorktreeCreationRequest['telemetrySource']
 }
 
+type QuickCreateLinkedWorkItemPromptResult = ReturnType<
+  typeof resolveQuickCreateLinkedWorkItemPrompt
+>
+
+function resolveGitHubWorkItemPrompt(item: GitHubWorkItem): QuickCreateLinkedWorkItemPromptResult {
+  const resolver = resolveQuickCreateLinkedWorkItemPrompt as unknown as (
+    linkedWorkItem: GitHubWorkItem,
+    note: string,
+    opts?: { cliAvailable: boolean }
+  ) => QuickCreateLinkedWorkItemPromptResult
+  return resolver(item, '', { cliAvailable: false })
+}
+
 export function buildGitHubWorkItemBackendStartup(
   agent: TuiAgent | null,
   startupPlan: AgentStartupPlan | null,
@@ -129,9 +142,7 @@ export function buildGitHubWorkItemStartupPlan(args: {
   if (!agent) {
     return { startupPlan: null, quickPrompt: '', quickTelemetry: null }
   }
-  const { prompt: quickPrompt, draftPrompt } = resolveQuickCreateLinkedWorkItemPrompt(item, '', {
-    cliAvailable: false
-  })
+  const { prompt: quickPrompt, draftPrompt } = resolveGitHubWorkItemPrompt(item)
   const projectRuntime = repo.connectionId
     ? undefined
     : getLocalRepoProjectExecutionRuntimeContext(

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -12,10 +12,11 @@ import type { AgentStartedTelemetry } from '@/lib/worktree-activation'
 import type { TaskSourceContext, WorkspaceRunContext } from '../../../shared/task-source-context'
 
 /** Two-phase status reported by the main process while a worktree is created.
+ *  `preparing` covers renderer-side preflight before `createWorktree` starts;
  *  `fetching` covers the base-ref git fetch; `creating` covers `git worktree
- *  add`. The remote/runtime path emits neither, so consumers must tolerate a
- *  phase that never advances past `fetching`. */
-export type WorktreeCreationPhase = 'fetching' | 'creating'
+ *  add`. The remote/runtime path emits neither create phase, so consumers must
+ *  tolerate a preparation state that jumps straight to completion. */
+export type WorktreeCreationPhase = 'preparing' | 'fetching' | 'creating'
 
 export type WorktreeCreationProgressMode = 'stepped' | 'indeterminate'
 
@@ -103,6 +104,9 @@ export function getCreationProgressLabel(
 ): string {
   if (entry.indeterminate) {
     return 'Setting up your workspace…'
+  }
+  if (entry.phase === 'preparing') {
+    return 'Preparing workspace…'
   }
   return entry.phase === 'creating' ? 'Creating worktree…' : 'Fetching base branch…'
 }

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -6,6 +6,9 @@ import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
 const store = {
   settings: { activeRuntimeEnvironmentId: null as string | null },
   beginPendingWorktreeCreation: vi.fn(),
+  updatePendingWorktreeCreation: vi.fn(),
+  pendingWorktreeCreations: { 'creation-1': { creationId: 'creation-1' } },
+  setActivePendingWorktreeCreation: vi.fn(),
   setActiveView: vi.fn(),
   setSidebarOpen: vi.fn(),
   createWorktree: vi.fn(() => new Promise(() => {}))
@@ -34,7 +37,11 @@ vi.mock('@/lib/new-workspace', () => ({
   ensureAgentStartupInTerminal: vi.fn()
 }))
 
-import { runBackgroundWorktreeCreation } from './worktree-creation-flow'
+import {
+  beginBackgroundWorktreePreparation,
+  continueBackgroundWorktreeCreation,
+  runBackgroundWorktreeCreation
+} from './worktree-creation-flow'
 
 const FLOW_SOURCE = readFileSync(join(__dirname, 'worktree-creation-flow.ts'), 'utf8')
 
@@ -93,6 +100,47 @@ describe('runBackgroundWorktreeCreation', () => {
         })
       })
     )
+  })
+})
+
+describe('staged background worktree creation', () => {
+  it('shows a pending preparing row before async preflight finishes', () => {
+    store.beginPendingWorktreeCreation.mockClear()
+
+    const creationId = beginBackgroundWorktreePreparation(makeRequest({ displayName: 'Issue 42' }))
+
+    expect(creationId).toBe('creation-1')
+    expect(store.beginPendingWorktreeCreation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creationId: 'creation-1',
+        phase: 'preparing',
+        request: expect.objectContaining({ displayName: 'Issue 42' })
+      })
+    )
+  })
+
+  it('replaces the staged request before the create starts', () => {
+    store.updatePendingWorktreeCreation.mockClear()
+    store.createWorktree.mockClear()
+
+    const request = makeRequest({ setupDecision: 'run' })
+    const started = continueBackgroundWorktreeCreation('creation-1', request)
+
+    expect(started).toBe(true)
+    expect(store.updatePendingWorktreeCreation).toHaveBeenCalledWith(
+      'creation-1',
+      expect.objectContaining({
+        phase: 'fetching',
+        request
+      })
+    )
+    expect(store.createWorktree).toHaveBeenCalledTimes(1)
+    const createCall = store.createWorktree.mock.calls[0] as unknown[] | undefined
+    expect(createCall).toBeDefined()
+    expect(createCall?.[0]).toBe('repo-1')
+    expect(createCall?.[1]).toBe('feature')
+    expect(createCall?.[3]).toBe('run')
+    expect(createCall?.[18]).toBe('creation-1')
   })
 })
 

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -50,6 +50,29 @@ function getWorktreeCreationIndeterminate(request: WorktreeCreationRequest): boo
   return getActiveRuntimeTarget(useAppStore.getState().settings).kind !== 'local'
 }
 
+function revealPendingCreation(
+  creationId: string,
+  request: WorktreeCreationRequest,
+  phase: 'preparing' | 'fetching'
+): void {
+  const store = useAppStore.getState()
+  const indeterminate = getWorktreeCreationIndeterminate(request)
+  store.beginPendingWorktreeCreation({
+    creationId,
+    phase,
+    status: 'creating',
+    indeterminate,
+    // Why: the creation surface owns the tab strip immediately. Delaying this
+    // caused the real workspace tab bar to flash out when the debounce elapsed.
+    loaderVisible: true,
+    request
+  })
+  // Why: the creation panel only renders under the terminal view (App content
+  // router), so force it active so the panel is what fills the content area.
+  store.setActiveView('terminal')
+  store.setSidebarOpen(true)
+}
+
 async function preflightAgentTrust(
   request: WorktreeCreationRequest,
   path: string,
@@ -215,26 +238,37 @@ export function runBackgroundWorktreeCreation(request: WorktreeCreationRequest):
   // Why: crypto.randomUUID is undefined in non-secure browser contexts (LAN web
   // client over plain HTTP). createBrowserUuid falls back to getRandomValues.
   const creationId = createBrowserUuid()
+  revealPendingCreation(creationId, request, 'fetching')
+  void executeWorktreeCreation(creationId, request)
+}
+
+/** Stage a pending entry before async preflight so the UI shows immediate progress. */
+export function beginBackgroundWorktreePreparation(request: WorktreeCreationRequest): string {
+  const creationId = createBrowserUuid()
+  revealPendingCreation(creationId, request, 'preparing')
+  return creationId
+}
+
+/** Continue a staged pending entry once async preflight has produced a final request. */
+export function continueBackgroundWorktreeCreation(
+  creationId: string,
+  request: WorktreeCreationRequest
+): boolean {
   const store = useAppStore.getState()
-  // Why: the remote/runtime create path emits no progress events, so the stepped
-  // checklist would freeze on step 1. Use the request's captured repo owner so
-  // Retry does not change shape when focus moves to another runtime.
-  const indeterminate = getWorktreeCreationIndeterminate(request)
-  store.beginPendingWorktreeCreation({
-    creationId,
+  if (!store.pendingWorktreeCreations[creationId]) {
+    return false
+  }
+  store.updatePendingWorktreeCreation(creationId, {
     phase: 'fetching',
     status: 'creating',
-    indeterminate,
-    // Why: the creation surface owns the tab strip immediately. Delaying this
-    // caused the real workspace tab bar to flash out when the debounce elapsed.
-    loaderVisible: true,
+    error: undefined,
     request
   })
-  // Why: the creation panel only renders under the terminal view (App content
-  // router), so force it active so the panel is what fills the content area.
+  store.setActivePendingWorktreeCreation(creationId)
   store.setActiveView('terminal')
   store.setSidebarOpen(true)
   void executeWorktreeCreation(creationId, request)
+  return true
 }
 
 /** Re-run a failed creation from its panel, reusing the captured request. */

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -156,8 +156,7 @@ export type WorktreeSlice = {
   ) => Promise<CreateWorktreeResult>
   /** Register an in-flight background creation and make it the active surface. */
   beginPendingWorktreeCreation: (entry: PendingWorktreeCreation) => void
-  /** Merge a status patch (phase/error/status/loaderVisible) into an existing
-   *  pending entry. */
+  /** Merge a status patch into an existing pending entry. */
   updatePendingWorktreeCreation: (
     creationId: string,
     patch: {
@@ -165,6 +164,7 @@ export type WorktreeSlice = {
       status?: 'creating' | 'error'
       error?: string
       loaderVisible?: boolean
+      request?: PendingWorktreeCreation['request']
     }
   ) => void
   /** Drop a pending entry (on success or dismiss), clearing the active surface

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -5133,6 +5133,20 @@ describe('pending worktree creation state', () => {
     expect(store.getState().pendingWorktreeCreations.c1.phase).toBe('creating')
   })
 
+  it('updatePendingWorktreeCreation can replace the retryable request during preflight', () => {
+    const store = createTestStore()
+    store.getState().beginPendingWorktreeCreation(makePendingCreation('c1'))
+
+    store.getState().updatePendingWorktreeCreation('c1', {
+      request: {
+        ...store.getState().pendingWorktreeCreations.c1.request,
+        setupDecision: 'run'
+      }
+    })
+
+    expect(store.getState().pendingWorktreeCreations.c1.request.setupDecision).toBe('run')
+  })
+
   it('updatePendingWorktreeCreation is a no-op for an unknown id', () => {
     const store = createTestStore()
     const before = store.getState().pendingWorktreeCreations


### PR DESCRIPTION
## Summary
- stage GitHub issue workspace creation through the existing pending-worktree UI so TaskPage creates a workspace entry immediately instead of blocking on the composer
- keep the staged request updatable through async preflight, preserve linked issue startup context, and stop cleanly if the pending create is cancelled
- leave project-view GitHub actions on their existing direct "start work now" path for issue #4756

## User-visible flow / modal behavior
- The fix reduces invisible/blocking wait: after clicking TaskPage GitHub issue `Create workspace`, Orca stages the pending workspace row and loading panel immediately, before async setup/PR/agent preflight completes.
- The setup hook trust modal can still appear when the repo's `orca.yaml` setup script needs user approval. That modal is intentional safety UI; the corrected behavior is that the pending workspace is already visible behind it instead of the user waiting with no workspace feedback.
- This does not make setup/git work itself faster; it makes the flow backgrounded and visibly in progress so the user is not stuck wondering whether the click did anything.

## Design approach
- wrote a scratch design doc in ignored space covering the bug validation, two-phase pending-create flow, fallback cases, SSH/runtime handling, and validation plan
- reused the existing pending-worktree row/panel instead of inventing a new UI surface
- added a renderer-only `preparing` phase so the sidebar row and loading panel render before setup/PR/agent preflight resolves

## Design review
- delegated design review on the scratch doc completed clean with no remaining actionable findings

## Implementation
- `TaskPage` now routes GitHub `Create workspace` through a background helper first and only falls back to the composer when interactive setup choices are actually required
- added `github-work-item-background-create.ts` and `github-work-item-background-request.ts` to build the staged request, preserve linked-work-item startup context, and continue the existing background create flow after preflight
- extended pending creation state to support staged request replacement and the new `preparing` phase
- preserved project-view direct-launch behavior with a why-comment scoped to issue #4756

## Deviations
- none from the reviewed design beyond keeping project-view on its intentional direct-launch semantics

## Completeness verification
- delegated completeness pass result: complete
- remaining blockers: none
- accepted gap from that pass: Electron screenshot validation was partial in the verifier run and was completed afterward in the primary validation pass below

## Code review loop
- round 1 reviewer A: clean
- round 1 reviewer B: clean
- no actionable findings remained from the same review round
- flow-regression subagent review after clarifying modal behavior:
  - TaskPage user-flow review: clean
  - pending-creation/runtime reviews found runtime-owned repos would use local agent detection and stepped progress
  - fixed in follow-up commit `8a53b4a6c` by routing runtime-owned repos through `ensureRuntimeDetectedAgents` and indeterminate progress, with regression coverage
- second flow-regression subagent review after the runtime fix:
  - execution-host parity review: clean
  - pending lifecycle review found fallback paths could leave the user on Terminal after abandoning the staged pending row and opening the composer
  - TaskPage flow review found repeated clicks could stage duplicate pending creates for the same GitHub issue/PR
  - fixed both in follow-up commit `b9538daf7`: fallback paths restore the launching view when the staged create is still active, and duplicate clicks reveal the existing pending create instead of starting preflight again
- continuous review-code loop after `b9538daf7`:
  - TaskPage flow reviewer: clean
  - lifecycle/data-contract reviewer: clean
  - SSH/runtime parity reviewer found disconnected SSH/runtime repos could capture degraded setup/agent preflight values and then Retry with those stale values after reconnect
  - fixed in follow-up commit `fdb8b4fac` by preserving the composer host-availability gate before staging background creates; disconnected/unreachable/blocked host paths fall back without creating a pending retry entry
  - final review-code round after `fdb8b4fac`: host/parity reviewer clean, TaskPage flow reviewer clean, data-contract reviewer clean
- continued review-code loop after `fdb8b4fac` found two more flow/parity regressions:
  - runtime-owned background creates built agent startup shell quoting from the client platform instead of the runtime host platform
  - invalid selected-agent startup plans could create an agent-marked workspace without launching the agent
  - fixed in follow-up commit `545955048`: runtime host platform is required before staging background creates, startup planning uses the runtime host platform, missing runtime platform falls back to composer before staging, and invalid agent startup plans abandon the staged row with composer fallback
  - final review-code round after `545955048`: runtime/platform reviewer clean, TaskPage flow reviewer clean

## Brennan test changes
- delegated `brennan-test-changes` pass ran and initially stopped short of the real click verdict while setting up a disposable validation target
- the missing real UI validation was then completed in the primary worker on the actual Orca Electron surface for this issue:
  - identity verified as `/Users/thebr/orca/workspaces/orca/issue-4756-issue-workspace-background`
  - clicked the real TaskPage GitHub issue `Create workspace` flow
  - observed immediate pending sidebar row + loading panel before creation completed
  - dismissed the hook-trust safety gate with `Don't run`, then verified the real workspace row became active and the backing store reflected the created linked issue workspace
- delegated final verdict before follow-up nits: land after fixes
- accepted gap from that delegated verdict: local full `pnpm run lint` still fails on pre-existing localization catalog keys in `src/renderer/src/components/settings/TerminalInteractionSection.tsx`, outside this diff

## Manual validation evidence
- before-state evidence from initial repro:
  - `.playwright-cli/issue-4756-initial.png`
  - `.playwright-cli/issue-4756-after-repo.png`
- after-state evidence from the fixed flow:
  - `.playwright-cli/page-2026-06-23T05-03-14-881Z.png` (pending row + loading panel + hook-trust modal)
  - `.playwright-cli/page-2026-06-23T05-03-45-051Z.png` (resulting real workspace active after continuing)
- supporting snapshots/logs:
  - `.playwright-cli/page-2026-06-23T05-03-00-265Z.yml`
  - `.playwright-cli/page-2026-06-23T05-03-27-204Z.yml`
  - `.playwright-cli/console-2026-06-23T05-03-00-222Z.log`

## Checks run
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/worktree-creation/WorktreeCreationPanel.test.tsx src/renderer/src/components/task-page-github-background-create-boundary.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/TaskPage.tsx src/renderer/src/components/github-project/ProjectViewWrapper.tsx src/renderer/src/lib/pending-worktree-creation.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/lib/worktree-creation-flow.ts src/renderer/src/store/slices/worktree-helpers.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/task-page-github-background-create-boundary.test.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/github-work-item-background-create.ts src/renderer/src/lib/github-work-item-background-request.ts`
- `git diff --check`
- targeted follow-up after CodeRabbit nits:
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/components/task-page-github-background-create-boundary.test.ts`
  - `pnpm exec oxlint src/renderer/src/components/task-page-github-background-create-boundary.test.ts src/renderer/src/lib/github-work-item-background-request.ts src/renderer/src/lib/github-work-item-background-create.ts`
- targeted follow-up after flow-regression subagent review:
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/components/task-page-github-background-create-boundary.test.ts`
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/worktree-creation/WorktreeCreationPanel.test.tsx src/renderer/src/components/task-page-github-background-create-boundary.test.ts`
  - `pnpm run typecheck:web`
  - `pnpm exec oxlint src/renderer/src/components/TaskPage.tsx src/renderer/src/components/github-project/ProjectViewWrapper.tsx src/renderer/src/lib/pending-worktree-creation.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/lib/worktree-creation-flow.ts src/renderer/src/store/slices/worktree-helpers.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/task-page-github-background-create-boundary.test.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/github-work-item-background-create.ts src/renderer/src/lib/github-work-item-background-request.ts`
  - `git diff --check`
- targeted follow-up after second flow-regression subagent review:
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/github-work-item-background-create.test.ts`
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/worktree-creation/WorktreeCreationPanel.test.tsx src/renderer/src/components/task-page-github-background-create-boundary.test.ts`
  - `pnpm run typecheck:web`
  - `pnpm exec oxlint src/renderer/src/lib/github-work-item-background-create.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/github-work-item-background-request.ts`
  - `git diff --check`
- targeted follow-up after host-availability review:
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/github-work-item-background-create.test.ts`
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/worktree-creation/WorktreeCreationPanel.test.tsx src/renderer/src/components/task-page-github-background-create-boundary.test.ts`
  - `pnpm run typecheck:web`
  - `pnpm exec oxlint src/renderer/src/lib/github-work-item-background-create.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/github-work-item-background-request.ts`
  - `git diff --check`
- targeted follow-up after runtime/platform and agent-startup review:
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/worktree-creation/WorktreeCreationPanel.test.tsx src/renderer/src/components/task-page-github-background-create-boundary.test.ts`
  - `pnpm run typecheck:web`
  - `pnpm exec oxlint src/renderer/src/components/TaskPage.tsx src/renderer/src/components/github-project/ProjectViewWrapper.tsx src/renderer/src/lib/pending-worktree-creation.ts src/renderer/src/lib/worktree-creation-flow.test.ts src/renderer/src/lib/worktree-creation-flow.ts src/renderer/src/store/slices/worktree-helpers.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/task-page-github-background-create-boundary.test.ts src/renderer/src/lib/github-work-item-background-create.test.ts src/renderer/src/lib/github-work-item-background-create.ts src/renderer/src/lib/github-work-item-background-request.ts`
  - `git diff --check`
- `pnpm run lint` fails on pre-existing localization catalog keys outside this diff:
  - `src/renderer/src/components/settings/TerminalInteractionSection.tsx`
  - `src/renderer/src/components/settings/terminal-pane-appearance-search.ts`

## Post-PR stabilization
- waited the required `sleep 480` after opening the PR, reviewed CodeRabbit plus PR checks, and applied the three actionable maintainability nits CodeRabbit raised
- pushed follow-up commit `e08f9e12e` (`Clarify background workspace creation guards`)
- waited another `sleep 480` after that push
- pushed follow-up commit `8a53b4a6c` (`Handle runtime-owned GitHub background creates`) after flow-regression review found the runtime-owned repo issue
- pushed follow-up commit `2fb7fe6f` (`Keep GitHub background prompt helper base-compatible`) after CI exposed a base-compatibility issue
- `verify` passed on `2fb7fe6f`
- pushed follow-up commit `b9538daf7` (`Guard GitHub background create regressions`) after the second flow-regression review found the fallback-view and duplicate-click issues
- `verify` passed on `b9538daf7`
- pushed follow-up commit `fdb8b4fac` (`Preserve host availability gate for GitHub background creates`) after continuous review found the disconnected-host stale-retry issue
- `verify` passed on `fdb8b4fac`
- pushed follow-up commit `545955048` (`Guard GitHub background agent startup parity`) after continued review found runtime host-platform quoting and invalid startup-plan fallback issues
- `verify` passed on `545955048`
- remaining CodeRabbit note is the non-blocking docstring coverage warning on the PR summary comment

## Risks / assumptions
- hook-trust can still show as an explicit safety gate; the fix is that the pending workspace row appears immediately instead of waiting on composer/preflight
- the deterministic perf proof is the new test coverage asserting the pending row is staged before async preflight resolves
- duplicate-click regression coverage now asserts an existing pending GitHub issue create is reused rather than staging another workspace create
- disconnected SSH/runtime regression coverage now asserts the background path falls back before staging, so retry cannot reuse degraded preflight values
- runtime platform regression coverage now asserts runtime-owned startup plans use the runtime host platform and unknown runtime host platforms fall back before staging
- invalid agent-startup regression coverage now asserts the staged row is abandoned and the composer fallback opens instead of creating an agent-marked workspace with no launch

