### PR TITLE
Prevent delayed agent follow-up hangs

### DIFF
--- a/src/renderer/src/lib/agent-followup-delivery.test.ts
+++ b/src/renderer/src/lib/agent-followup-delivery.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  inspectRuntimeTerminalProcess,
+  sendRuntimePtyInputVerified
+} from '@/runtime/runtime-terminal-inspection'
+import { sendFollowupPromptWhenAgentReady } from './agent-followup-delivery'
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  inspectRuntimeTerminalProcess: vi.fn(),
+  sendRuntimePtyInputVerified: vi.fn()
+}))
+
+describe('sendFollowupPromptWhenAgentReady', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(inspectRuntimeTerminalProcess).mockReset()
+    vi.mocked(sendRuntimePtyInputVerified).mockReset()
+    vi.mocked(sendRuntimePtyInputVerified).mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends the follow-up once the expected agent owns the PTY', async () => {
+    vi.mocked(inspectRuntimeTerminalProcess).mockResolvedValue({
+      foregroundProcess: 'codex',
+      hasChildProcesses: false
+    })
+
+    await expect(
+      sendFollowupPromptWhenAgentReady({
+        ptyId: 'pty-1',
+        expectedProcess: 'codex',
+        prompt: 'review this',
+        settings: { activeRuntimeEnvironmentId: 'runtime-1' }
+      })
+    ).resolves.toBe(true)
+
+    expect(sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      { activeRuntimeEnvironmentId: 'runtime-1' },
+      'pty-1',
+      'review this\r'
+    )
+  })
+
+  it('honors the readiness deadline when process inspection hangs', async () => {
+    vi.mocked(inspectRuntimeTerminalProcess).mockReturnValue(new Promise(() => {}))
+
+    const promise = sendFollowupPromptWhenAgentReady({
+      ptyId: 'pty-1',
+      expectedProcess: 'codex',
+      prompt: 'review this',
+      settings: { activeRuntimeEnvironmentId: 'runtime-1' }
+    })
+
+    await vi.advanceTimersByTimeAsync(4499)
+    expect(sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(promise).resolves.toBe(false)
+    expect(sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/agent-followup-delivery.test.ts
+++ b/src/renderer/src/lib/agent-followup-delivery.test.ts
@@ -54,9 +54,11 @@ describe('sendFollowupPromptWhenAgentReady', () => {
       settings: { activeRuntimeEnvironmentId: 'runtime-1' }
     })
 
-    await vi.advanceTimersByTimeAsync(4499)
+    // Why: stay just under the 4.5s readiness budget; delivery must not resolve early.
+    await vi.advanceTimersByTimeAsync(4_499)
     expect(sendRuntimePtyInputVerified).not.toHaveBeenCalled()
 
+    // Why: crossing the budget boundary must resolve false without writing.
     await vi.advanceTimersByTimeAsync(1)
 
     await expect(promise).resolves.toBe(false)
@@ -119,9 +121,11 @@ describe('sendFollowupPromptWhenAgentReady', () => {
         settings: { activeRuntimeEnvironmentId: 'runtime-1' }
       })
 
-      await vi.advanceTimersByTimeAsync(4499)
+      // Why: stay just under the 4.5s readiness budget; delivery must not resolve early.
+      await vi.advanceTimersByTimeAsync(4_499)
       expect(sendRuntimePtyInputVerified).not.toHaveBeenCalled()
 
+      // Why: crossing the budget boundary must resolve false without writing.
       await vi.advanceTimersByTimeAsync(1)
 
       await expect(promise).resolves.toBe(false)

--- a/src/renderer/src/lib/agent-followup-delivery.test.ts
+++ b/src/renderer/src/lib/agent-followup-delivery.test.ts
@@ -62,4 +62,70 @@ describe('sendFollowupPromptWhenAgentReady', () => {
     await expect(promise).resolves.toBe(false)
     expect(sendRuntimePtyInputVerified).not.toHaveBeenCalled()
   })
+
+  it('ignores transient inspection failures while budget remains and sends once after a match', async () => {
+    vi.mocked(inspectRuntimeTerminalProcess)
+      .mockRejectedValueOnce(new Error('runtime unavailable'))
+      .mockRejectedValueOnce(new Error('pty not ready'))
+      .mockResolvedValue({
+        foregroundProcess: 'codex',
+        hasChildProcesses: true
+      })
+
+    const promise = sendFollowupPromptWhenAgentReady({
+      ptyId: 'pty-1',
+      expectedProcess: 'codex',
+      prompt: 'review this',
+      settings: { activeRuntimeEnvironmentId: 'runtime-1' }
+    })
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    await expect(promise).resolves.toBe(true)
+    expect(inspectRuntimeTerminalProcess).toHaveBeenCalledTimes(3)
+    expect(sendRuntimePtyInputVerified).toHaveBeenCalledTimes(1)
+    expect(sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      { activeRuntimeEnvironmentId: 'runtime-1' },
+      'pty-1',
+      'review this\r'
+    )
+  })
+
+  it.each([
+    {
+      name: 'repeated transient failures',
+      setupInspection: () => {
+        vi.mocked(inspectRuntimeTerminalProcess).mockRejectedValue(new Error('runtime unavailable'))
+      }
+    },
+    {
+      name: 'non-matching foreground processes',
+      setupInspection: () => {
+        vi.mocked(inspectRuntimeTerminalProcess).mockResolvedValue({
+          foregroundProcess: 'bash',
+          hasChildProcesses: false
+        })
+      }
+    }
+  ])(
+    'returns false by the deadline for $name and never writes to the PTY',
+    async ({ setupInspection }) => {
+      setupInspection()
+
+      const promise = sendFollowupPromptWhenAgentReady({
+        ptyId: 'pty-1',
+        expectedProcess: 'codex',
+        prompt: 'review this',
+        settings: { activeRuntimeEnvironmentId: 'runtime-1' }
+      })
+
+      await vi.advanceTimersByTimeAsync(4499)
+      expect(sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+
+      await expect(promise).resolves.toBe(false)
+      expect(sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/src/renderer/src/lib/agent-followup-delivery.ts
+++ b/src/renderer/src/lib/agent-followup-delivery.ts
@@ -6,6 +6,8 @@ import { isExpectedAgentProcess } from '../../../shared/agent-process-recognitio
 import type { GlobalSettings } from '../../../shared/types'
 
 type RuntimeOwnerSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+// Why: stalled remote process inspection must not extend delayed-startup
+// cleanup beyond the existing follow-up readiness window.
 const FOLLOWUP_READY_TIMEOUT_MS = 4500
 const FOLLOWUP_READY_POLL_MS = 150
 

--- a/src/renderer/src/lib/agent-followup-delivery.ts
+++ b/src/renderer/src/lib/agent-followup-delivery.ts
@@ -6,6 +6,8 @@ import { isExpectedAgentProcess } from '../../../shared/agent-process-recognitio
 import type { GlobalSettings } from '../../../shared/types'
 
 type RuntimeOwnerSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+const FOLLOWUP_READY_TIMEOUT_MS = 4500
+const FOLLOWUP_READY_POLL_MS = 150
 
 export async function sendFollowupPromptWhenAgentReady(args: {
   ptyId: string
@@ -31,12 +33,16 @@ async function waitForAgentForeground(
   expectedProcess: string,
   settings: RuntimeOwnerSettings
 ): Promise<boolean> {
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    if (attempt > 0) {
-      await new Promise((resolve) => globalThis.setTimeout(resolve, 150))
-    }
+  const deadline = Date.now() + FOLLOWUP_READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
     try {
-      const process = await inspectRuntimeTerminalProcess(settings, ptyId)
+      const process = await withDeadline(
+        inspectRuntimeTerminalProcess(settings, ptyId),
+        Math.max(0, deadline - Date.now())
+      )
+      if (!process) {
+        return false
+      }
       const foreground = process.foregroundProcess?.toLowerCase() ?? ''
       if (isExpectedAgentProcess(foreground, expectedProcess)) {
         return true
@@ -44,6 +50,29 @@ async function waitForAgentForeground(
     } catch {
       // Ignore transient PTY inspection failures and keep polling.
     }
+    const delayMs = Math.min(FOLLOWUP_READY_POLL_MS, Math.max(0, deadline - Date.now()))
+    if (delayMs > 0) {
+      await new Promise((resolve) => globalThis.setTimeout(resolve, delayMs))
+    }
   }
   return false
+}
+
+function withDeadline<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
+  if (timeoutMs <= 0) {
+    return Promise.resolve(null)
+  }
+  return new Promise((resolve, reject) => {
+    const timer = globalThis.setTimeout(() => resolve(null), timeoutMs)
+    promise.then(
+      (value) => {
+        globalThis.clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        globalThis.clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
 }


### PR DESCRIPTION
## Summary
- Bounds delayed follow-up agent readiness waits by the intended 4.5s polling budget.
- Races each remote process inspection against the remaining deadline so SSH/runtime inspection stalls do not stretch failed delivery attempts.
- Adds deterministic fake-timer coverage for success, hanging inspection, transient failures, and non-matching foreground processes.

## Brennan YOLO Lite
- Design approach: preserve existing follow-up delivery behavior, but replace the fixed 30 x 150 ms attempt loop with a deadline-driven loop and per-inspection deadline race.
- Design review: delegated design review completed clean after strengthening validation for transient inspection failures and non-matching foreground processes.
- Implementation: added the deadline helper and expanded follow-up delivery tests; no prompt payload, runtime settings, or visible UI behavior changed.
- Deviations: none from the reviewed design. This is intentionally local to follow-up delivery rather than changing the shared runtime inspection contract.
- Completeness verification: delegated verification returned complete against `.tmp/followup-readiness-budget-design.md`.
- Code review: two independent `review-code` agents returned `No issues found.` in the same round.
- Brennan validation: delegated `brennan-test-changes` returned `land`.

## Screenshots
- No visual change. This PR changes a non-visual exported delayed follow-up delivery helper. Manual evidence is captured as behavior logs instead of an uninformative UI screenshot.

## Manual Validation
- Evidence: `/tmp/brennan-pr6145-followup-validation-20260623T072113Z/manual-followup-validation-verbose.log`
- Direct helper harness imported `agent-followup-delivery.ts` and used real timers:
  - Hung inspection timed out in 4505 ms, returned `false`, wrote 0 times.
  - Transient inspection failures retried, matched `codex` on the third inspection, wrote exactly once with `\r`.
  - Non-matching `bash` foreground timed out in 4501 ms, wrote 0 times.
- Accepted gap: Electron UI validation was not meaningful because this PR has no visible control or rendered state. The changed product behavior is the delayed delivery helper’s PTY write/no-write behavior.

## Testing Checklist
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/agent-followup-delivery.test.ts src/renderer/src/lib/agent-paste-draft.test.ts src/renderer/src/lib/new-workspace.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` — 237 passed
- [x] `pnpm run typecheck:web`
- [x] `pnpm exec oxlint src/renderer/src/lib/agent-followup-delivery.ts src/renderer/src/lib/agent-followup-delivery.test.ts`
- [x] `git diff --check`
- [x] `git diff --check origin/main...HEAD`
- [x] `pnpm run typecheck` in Brennan validation
- [x] Full `pnpm run lint` attempted in Brennan validation; failed on pre-existing unrelated localization catalog keys outside this PR diff. Log: `/tmp/brennan-pr6145-followup-validation-20260623T072113Z/full-lint.log`

## AI Review Report
- Design review: clean after validation checklist improvements.
- Completeness verification: complete; no omissions or blockers.
- Code review round: both reviewers returned `No issues found.`
- CodeRabbit: initial timeout-constant comment addressed in `0cd2477`; test-boundary comment addressed in `9b9276968`; refreshed review reports no actionable comments.

## Security Audit
- Does not add new permissions, IPC channels, telemetry, persistence, network calls, or external side effects.
- Preserves the existing safety property: follow-up text is only written after a positive expected-process match.
- Fail-closed behavior: if runtime inspection hangs, rejects repeatedly, or sees the wrong foreground process, no prompt text is written to the PTY.

## Notes
- SSH/remoting is the key risk surface. Runtime owner settings are passed through unchanged, and stalled remote process inspection can no longer extend the caller-owned readiness budget.
- No migration or feature flag required.
- Scratch design doc: `.tmp/followup-readiness-budget-design.md`.

## Post-PR Stabilization
- Waited 8 minutes after each push before checking CodeRabbit/CI.
- PR check `verify` passed after the final push (`9b9276968`).
- CodeRabbit refreshed review reports no actionable comments. Remaining docstring-coverage warning is non-actionable because this repo prefers short why-comments over broad docstring padding.
