### PR TITLE
Fix source control base branch truncation

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control-branch-context-row.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-branch-context-row.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { SourceControlBranchContextRow } from './source-control-branch-context-row'
+import type { GitBranchCompareSummary } from '../../../../shared/types'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+const readySummary: GitBranchCompareSummary = {
+  baseRef: 'refs/remotes/origin/FRONT-192-ZisVoucherStrip',
+  baseOid: 'base',
+  compareRef: 'feature',
+  headOid: 'head',
+  mergeBase: 'base',
+  changedFiles: 0,
+  commitsAhead: 0,
+  status: 'ready'
+}
+
+describe('SourceControlBranchContextRow', () => {
+  it('lets the base ref use the full available header width', () => {
+    const markup = renderToStaticMarkup(
+      <SourceControlBranchContextRow
+        summary={readySummary}
+        compareBaseRef={null}
+        onChangeBaseRef={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('refs/remotes/origin/FRONT-192-ZisVoucherStrip')
+    expect(markup).toContain('max-w-full')
+    expect(markup).toContain('min-w-0 flex-1')
+    expect(markup).not.toContain('max-w-[9rem]')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-branch-context-row.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-branch-context-row.tsx
@@ -25,7 +25,7 @@ function BaseRefButton({
   return (
     <button
       type="button"
-      className="min-w-0 max-w-[9rem] truncate rounded-sm border-0 bg-transparent p-0 text-left font-mono text-[10.5px] font-medium text-foreground/90 underline decoration-border underline-offset-2 hover:text-foreground hover:decoration-foreground"
+      className="min-w-0 max-w-full truncate rounded-sm border-0 bg-transparent p-0 text-left font-mono text-[10.5px] font-medium text-foreground/90 underline decoration-border underline-offset-2 hover:text-foreground hover:decoration-foreground"
       onClick={onClick}
       title={`${title} (${baseRef})`}
     >
@@ -90,11 +90,13 @@ export function SourceControlBranchContextRow({
         <span className="shrink-0 text-muted-foreground">
           {translate('auto.components.right.sidebar.SourceControl.e8a1c4b203', 'vs')}
         </span>
-        <BaseRefButton
-          baseRef={displayedBaseRef}
-          onClick={onChangeBaseRef}
-          title={changeBaseTitle}
-        />
+        <span className="min-w-0 flex-1">
+          <BaseRefButton
+            baseRef={displayedBaseRef}
+            onClick={onChangeBaseRef}
+            title={changeBaseTitle}
+          />
+        </span>
       </div>
     )
   }
@@ -102,11 +104,13 @@ export function SourceControlBranchContextRow({
   if (summary.status !== 'ready') {
     return (
       <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-        <BaseRefButton
-          baseRef={displayedBaseRef}
-          onClick={onChangeBaseRef}
-          title={changeBaseTitle}
-        />
+        <span className="min-w-0 flex-1">
+          <BaseRefButton
+            baseRef={displayedBaseRef}
+            onClick={onChangeBaseRef}
+            title={changeBaseTitle}
+          />
+        </span>
         <span className="min-w-0 flex-1 truncate" title={summary.errorMessage ?? undefined}>
           {summary.errorMessage ??
             translate(
@@ -131,15 +135,17 @@ export function SourceControlBranchContextRow({
 
   return (
     <div className="flex min-w-0 items-center justify-between gap-1.5 text-[11px] text-muted-foreground">
-      <div className="flex min-w-0 items-center gap-1.5">
+      <div className="flex min-w-0 flex-1 items-center gap-1.5">
         <span className="shrink-0">
           {translate('auto.components.right.sidebar.SourceControl.e8a1c4b203', 'vs')}
         </span>
-        <BaseRefButton
-          baseRef={displayedBaseRef}
-          onClick={onChangeBaseRef}
-          title={changeBaseTitle}
-        />
+        <span className="min-w-0 flex-1">
+          <BaseRefButton
+            baseRef={displayedBaseRef}
+            onClick={onChangeBaseRef}
+            title={changeBaseTitle}
+          />
+        </span>
       </div>
       {stats.length > 0 ? (
         <span className="inline-flex shrink-0 items-center gap-1.5">


### PR DESCRIPTION
Fixes #6132

## Summary
- remove the fixed 9rem cap from the Source Control base-ref button
- let the base-ref slot flex across available header width before stats/actions
- add a regression test for the long base-ref layout classes

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/source-control-branch-context-row.test.tsx src/renderer/src/components/right-sidebar/source-control-branch-context-stats.test.ts
- pnpm typecheck
- pnpm exec oxlint src/renderer/src/components/right-sidebar/source-control-branch-context-row.tsx src/renderer/src/components/right-sidebar/source-control-branch-context-row.test.tsx
- Electron screenshot proof captured locally at validation-screenshots/issue-6132-base-branch-full-width-wide.png (not committed)

Note: full `pnpm lint` currently fails on unrelated missing localization catalog keys in `src/renderer/src/components/settings/TerminalInteractionSection.tsx`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
