### PR TITLE
Reduce repeated git probes during worktree refresh

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -110,7 +110,8 @@ import {
   updatePRTitle,
   _getMergeQueueCacheSizeForTests,
   _resetOwnerRepoCache,
-  _resetMergeQueueCacheForTests
+  _resetMergeQueueCacheForTests,
+  __resetTrackedUpstreamBranchCacheForTests
 } from './client'
 
 describe('checkOrcaStarred', () => {
@@ -179,6 +180,7 @@ describe('getPRForBranch', () => {
     acquireMock.mockResolvedValue(undefined)
     _resetOwnerRepoCache()
     _resetMergeQueueCacheForTests()
+    __resetTrackedUpstreamBranchCacheForTests()
   })
 
   it('queries GitHub by head branch when the remote is on github.com', async () => {
@@ -1158,6 +1160,104 @@ describe('getPRForBranch', () => {
       title: 'Hydrated upstream branch PR',
       headSha: 'upstream-head-oid'
     })
+  })
+
+  it('does not repeat missing tracked-upstream probes during PR refresh polling', async () => {
+    resolvePRRepositoryCandidatesMock.mockResolvedValue({
+      candidates: [{ owner: 'acme', repo: 'widgets' }],
+      headRepo: { owner: 'acme', repo: 'widgets' }
+    })
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: JSON.stringify([]) })
+    gitExecFileAsyncMock.mockRejectedValue(
+      new Error("fatal: no upstream configured for branch 'no-pr-branch'")
+    )
+
+    await getPRForBranch('/repo-root', 'no-pr-branch')
+    await getPRForBranch('/repo-root', 'no-pr-branch')
+    await getPRForBranch('/repo-root', 'no-pr-branch')
+
+    const trackedUpstreamCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) =>
+      (args as string[]).includes('no-pr-branch@{upstream}')
+    )
+    expect(trackedUpstreamCalls).toHaveLength(1)
+  })
+
+  it('coalesces concurrent missing tracked-upstream probes', async () => {
+    resolvePRRepositoryCandidatesMock.mockResolvedValue({
+      candidates: [{ owner: 'acme', repo: 'widgets' }],
+      headRepo: { owner: 'acme', repo: 'widgets' }
+    })
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: JSON.stringify([]) })
+    gitExecFileAsyncMock.mockImplementation(async () => {
+      await Promise.resolve()
+      throw new Error("fatal: no upstream configured for branch 'no-pr-branch'")
+    })
+
+    await Promise.all([
+      getPRForBranch('/repo-root', 'no-pr-branch'),
+      getPRForBranch('/repo-root', 'no-pr-branch'),
+      getPRForBranch('/repo-root', 'no-pr-branch')
+    ])
+
+    const trackedUpstreamCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) =>
+      (args as string[]).includes('no-pr-branch@{upstream}')
+    )
+    expect(trackedUpstreamCalls).toHaveLength(1)
+  })
+
+  it('keeps missing tracked-upstream probes separate for host and WSL runtimes', async () => {
+    resolvePRRepositoryCandidatesMock.mockResolvedValue({
+      candidates: [{ owner: 'acme', repo: 'widgets' }],
+      headRepo: { owner: 'acme', repo: 'widgets' }
+    })
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: JSON.stringify([]) })
+    gitExecFileAsyncMock.mockRejectedValue(
+      new Error("fatal: no upstream configured for branch 'no-pr-branch'")
+    )
+
+    await getPRForBranch('/repo-root', 'no-pr-branch')
+    await getPRForBranch('/repo-root', 'no-pr-branch', null, null, null, {
+      localGitExecOptions: { wslDistro: 'Ubuntu' }
+    })
+    await getPRForBranch('/repo-root', 'no-pr-branch')
+    await getPRForBranch('/repo-root', 'no-pr-branch', null, null, null, {
+      localGitExecOptions: { wslDistro: 'Ubuntu' }
+    })
+
+    const trackedUpstreamCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) =>
+      (args as string[]).includes('no-pr-branch@{upstream}')
+    )
+    expect(trackedUpstreamCalls).toHaveLength(2)
+    expect(trackedUpstreamCalls[0][1]).toEqual({ cwd: '/repo-root' })
+    expect(trackedUpstreamCalls[1][1]).toEqual({
+      cwd: '/repo-root',
+      wslDistro: 'Ubuntu'
+    })
+  })
+
+  it('rechecks missing tracked-upstream probes after the null-cache TTL expires', async () => {
+    vi.useFakeTimers()
+    try {
+      resolvePRRepositoryCandidatesMock.mockResolvedValue({
+        candidates: [{ owner: 'acme', repo: 'widgets' }],
+        headRepo: { owner: 'acme', repo: 'widgets' }
+      })
+      ghExecFileAsyncMock.mockResolvedValue({ stdout: JSON.stringify([]) })
+      gitExecFileAsyncMock
+        .mockRejectedValueOnce(new Error("fatal: no upstream configured for branch 'feature'"))
+        .mockResolvedValueOnce({ stdout: 'origin/contributor/original\n', stderr: '' })
+
+      await getPRForBranch('/repo-root', 'feature')
+      await vi.advanceTimersByTimeAsync(30_001)
+      await getPRForBranch('/repo-root', 'feature')
+
+      const trackedUpstreamCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) =>
+        (args as string[]).includes('feature@{upstream}')
+      )
+      expect(trackedUpstreamCalls).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('uses the tracked upstream remote owner for fork branch lookup', async () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2273,6 +2273,20 @@ type TrackedUpstreamBranch = {
   branchName: string
 }
 
+const TRACKED_UPSTREAM_NULL_CACHE_TTL_MS = 30_000
+
+type TrackedUpstreamNullCacheEntry = {
+  expiresAt: number
+}
+
+const trackedUpstreamNullCache = new Map<string, TrackedUpstreamNullCacheEntry>()
+const trackedUpstreamInFlight = new Map<string, Promise<TrackedUpstreamBranch | null>>()
+
+export function __resetTrackedUpstreamBranchCacheForTests(): void {
+  trackedUpstreamNullCache.clear()
+  trackedUpstreamInFlight.clear()
+}
+
 function parseTrackedUpstreamBranch(
   upstreamRef: string,
   branchName: string
@@ -2285,6 +2299,63 @@ function parseTrackedUpstreamBranch(
 }
 
 async function getTrackedUpstreamBranch(
+  repoPath: string,
+  branchName: string,
+  connectionId?: string | null,
+  localGitOptions: { wslDistro?: string } = {}
+): Promise<TrackedUpstreamBranch | null> {
+  const cacheKey = getTrackedUpstreamBranchCacheKey(
+    repoPath,
+    branchName,
+    connectionId,
+    localGitOptions
+  )
+  const now = Date.now()
+  const cachedNull = trackedUpstreamNullCache.get(cacheKey)
+  if (cachedNull && cachedNull.expiresAt > now) {
+    return null
+  }
+  if (cachedNull) {
+    trackedUpstreamNullCache.delete(cacheKey)
+  }
+
+  const inFlight = trackedUpstreamInFlight.get(cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  const probe = probeTrackedUpstreamBranch(repoPath, branchName, connectionId, localGitOptions)
+  trackedUpstreamInFlight.set(cacheKey, probe)
+  try {
+    const result = await probe
+    if (result) {
+      trackedUpstreamNullCache.delete(cacheKey)
+    } else {
+      trackedUpstreamNullCache.set(cacheKey, {
+        expiresAt: now + TRACKED_UPSTREAM_NULL_CACHE_TTL_MS
+      })
+    }
+    return result
+  } finally {
+    if (trackedUpstreamInFlight.get(cacheKey) === probe) {
+      trackedUpstreamInFlight.delete(cacheKey)
+    }
+  }
+}
+
+function getTrackedUpstreamBranchCacheKey(
+  repoPath: string,
+  branchName: string,
+  connectionId?: string | null,
+  localGitOptions: { wslDistro?: string } = {}
+): string {
+  const runtimeKey = connectionId
+    ? `ssh:${connectionId}`
+    : `local:${localGitOptions.wslDistro ?? 'host'}`
+  return [runtimeKey, repoPath, branchName].join('\0')
+}
+
+async function probeTrackedUpstreamBranch(
   repoPath: string,
   branchName: string,
   connectionId?: string | null,

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2304,6 +2304,8 @@ async function getTrackedUpstreamBranch(
   connectionId?: string | null,
   localGitOptions: { wslDistro?: string } = {}
 ): Promise<TrackedUpstreamBranch | null> {
+  // Why: branches without configured upstreams are stable misses during PR
+  // polling; cache only nulls so positive PR discovery stays fresh.
   const cacheKey = getTrackedUpstreamBranchCacheKey(
     repoPath,
     branchName,

--- a/src/main/ipc/worktree-change-invalidators.ts
+++ b/src/main/ipc/worktree-change-invalidators.ts
@@ -1,0 +1,20 @@
+const worktreeChangeInvalidators = new Set<(repoId: string) => void>()
+
+export function registerWorktreeChangeInvalidator(
+  invalidator: (repoId: string) => void
+): () => void {
+  worktreeChangeInvalidators.add(invalidator)
+  return () => {
+    worktreeChangeInvalidators.delete(invalidator)
+  }
+}
+
+export function runWorktreeChangeInvalidators(repoId: string): void {
+  for (const invalidator of worktreeChangeInvalidators) {
+    invalidator(repoId)
+  }
+}
+
+export function __resetWorktreeChangeInvalidatorsForTests(): void {
+  worktreeChangeInvalidators.clear()
+}

--- a/src/main/ipc/worktree-change-invalidators.ts
+++ b/src/main/ipc/worktree-change-invalidators.ts
@@ -10,8 +10,13 @@ export function registerWorktreeChangeInvalidator(
 }
 
 export function runWorktreeChangeInvalidators(repoId: string): void {
-  for (const invalidator of worktreeChangeInvalidators) {
-    invalidator(repoId)
+  const invalidators = Array.from(worktreeChangeInvalidators)
+  for (const invalidator of invalidators) {
+    try {
+      invalidator(repoId)
+    } catch (error) {
+      console.warn('[worktrees] worktree change invalidator failed:', error)
+    }
   }
 }
 

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1329,6 +1329,8 @@ async function getRemoteLocalBaseRefUpdateSuggestionForWorktreeCreate(
 }
 
 export function notifyWorktreesChanged(mainWindow: BrowserWindow, repoId: string): void {
+  // Why: invalidate detected-worktree caches before renderer observers react,
+  // so follow-up listDetected reads post-change state.
   runWorktreeChangeInvalidators(repoId)
   if (!mainWindow.isDestroyed()) {
     mainWindow.webContents.send('worktrees:changed', { repoId })

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -57,6 +57,7 @@ import type { SshGitProvider } from '../providers/ssh-git-provider'
 import { TUI_AGENT_CONFIG, isTuiAgent } from '../../shared/tui-agent-config'
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { getSshGitUsername } from '../git/git-username'
+import { runWorktreeChangeInvalidators } from './worktree-change-invalidators'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -1328,6 +1329,7 @@ async function getRemoteLocalBaseRefUpdateSuggestionForWorktreeCreate(
 }
 
 export function notifyWorktreesChanged(mainWindow: BrowserWindow, repoId: string): void {
+  runWorktreeChangeInvalidators(repoId)
   if (!mainWindow.isDestroyed()) {
     mainWindow.webContents.send('worktrees:changed', { repoId })
   }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -2151,6 +2151,59 @@ describe('registerWorktreeHandlers', () => {
     }
   })
 
+  it('starts the detected scan cache TTL after a slow scan completes', async () => {
+    vi.useFakeTimers()
+    try {
+      listWorktreesMock
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              setTimeout(
+                () =>
+                  resolve([
+                    {
+                      path: '/workspace/repo',
+                      head: 'main-head',
+                      branch: 'refs/heads/main',
+                      isBare: false,
+                      isMainWorktree: true
+                    }
+                  ]),
+                6_000
+              )
+            })
+        )
+        .mockResolvedValueOnce([
+          {
+            path: '/workspace/repo',
+            head: 'main-head',
+            branch: 'refs/heads/main',
+            isBare: false,
+            isMainWorktree: true
+          },
+          {
+            path: '/workspace/new-worktree',
+            head: 'feature-head',
+            branch: 'refs/heads/feature',
+            isBare: false,
+            isMainWorktree: false
+          }
+        ])
+
+      const first = handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+      await vi.advanceTimersByTimeAsync(6_000)
+      await first
+      const second = (await handlers['worktrees:listDetected'](null, {
+        repoId: 'repo-1'
+      })) as { worktrees: Worktree[] }
+
+      expect(second.worktrees.map((worktree) => worktree.path)).toEqual(['/workspace/repo'])
+      expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('invalidates the detected scan cache before worktree change notifications', async () => {
     listWorktreesMock
       .mockResolvedValueOnce([

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { lstat, mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
-import type { CreateWorktreeResult } from '../../shared/types'
+import type { CreateWorktreeResult, GitWorktreeInfo, Worktree } from '../../shared/types'
 
 const ORIGINAL_PLATFORM = process.platform
 
@@ -226,9 +226,12 @@ vi.mock('./pty', () => ({
   getLocalPtyProvider: getLocalPtyProviderMock
 }))
 
-import { __resetSshWorktreeCreateFetchCacheForTests } from './worktree-remote'
+import {
+  __resetSshWorktreeCreateFetchCacheForTests,
+  notifyWorktreesChanged
+} from './worktree-remote'
 import { invalidateAuthorizedRootsCache, resolveRegisteredWorktreePath } from './filesystem-auth'
-import { registerWorktreeHandlers } from './worktrees'
+import { __resetDetectedWorktreeScanCacheForTests, registerWorktreeHandlers } from './worktrees'
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => unknown>
 
@@ -272,6 +275,7 @@ describe('registerWorktreeHandlers', () => {
   beforeEach(() => {
     setPlatform(ORIGINAL_PLATFORM)
     __resetSshWorktreeCreateFetchCacheForTests()
+    __resetDetectedWorktreeScanCacheForTests()
     invalidateAuthorizedRootsCache()
     for (const m of [
       handleMock,
@@ -2031,6 +2035,260 @@ describe('registerWorktreeHandlers', () => {
       source: 'git',
       worktrees: [expect.objectContaining({ path: '/workspace/repo' })]
     })
+  })
+
+  it('reuses a recent authoritative detected worktree scan', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'main-head',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    const first = await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+    const second = await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+
+    expect(first).toEqual(second)
+    expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces concurrent authoritative detected worktree scans', async () => {
+    listWorktreesMock.mockImplementation(async () => {
+      await Promise.resolve()
+      return [
+        {
+          path: '/workspace/repo',
+          head: 'main-head',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ]
+    })
+
+    await Promise.all([
+      handlers['worktrees:listDetected'](null, { repoId: 'repo-1' }),
+      handlers['worktrees:listDetected'](null, { repoId: 'repo-1' }),
+      handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+    ])
+
+    expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rechecks detected worktree metadata while reusing a cached raw scan', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'main-head',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    let currentMeta = makeWorktreeMeta({ isPinned: false })
+    store.getWorktreeMeta.mockImplementation(() => currentMeta)
+    store.setWorktreeMeta.mockImplementation(() => currentMeta)
+    const first = (await handlers['worktrees:listDetected'](null, {
+      repoId: 'repo-1'
+    })) as { worktrees: Worktree[] }
+    currentMeta = makeWorktreeMeta({ isPinned: true })
+    const second = (await handlers['worktrees:listDetected'](null, {
+      repoId: 'repo-1'
+    })) as { worktrees: Worktree[] }
+
+    expect(first.worktrees[0].isPinned).toBe(false)
+    expect(second.worktrees[0].isPinned).toBe(true)
+    expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rescans detected worktrees after the scan cache TTL expires', async () => {
+    vi.useFakeTimers()
+    try {
+      listWorktreesMock
+        .mockResolvedValueOnce([
+          {
+            path: '/workspace/repo',
+            head: 'main-head',
+            branch: 'refs/heads/main',
+            isBare: false,
+            isMainWorktree: true
+          }
+        ])
+        .mockResolvedValueOnce([
+          {
+            path: '/workspace/repo',
+            head: 'main-head',
+            branch: 'refs/heads/main',
+            isBare: false,
+            isMainWorktree: true
+          },
+          {
+            path: '/workspace/new-worktree',
+            head: 'feature-head',
+            branch: 'refs/heads/feature',
+            isBare: false,
+            isMainWorktree: false
+          }
+        ])
+
+      await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+      await vi.advanceTimersByTimeAsync(5_001)
+      const second = (await handlers['worktrees:listDetected'](null, {
+        repoId: 'repo-1'
+      })) as { worktrees: Worktree[] }
+
+      expect(second.worktrees.map((worktree) => worktree.path)).toEqual([
+        '/workspace/repo',
+        '/workspace/new-worktree'
+      ])
+      expect(listWorktreesMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('invalidates the detected scan cache before worktree change notifications', async () => {
+    listWorktreesMock
+      .mockResolvedValueOnce([
+        {
+          path: '/workspace/repo',
+          head: 'main-head',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          path: '/workspace/repo',
+          head: 'main-head',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: '/workspace/new-worktree',
+          head: 'feature-head',
+          branch: 'refs/heads/feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+
+    await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+    notifyWorktreesChanged(mainWindow as never, 'repo-1')
+    const second = (await handlers['worktrees:listDetected'](null, {
+      repoId: 'repo-1'
+    })) as { worktrees: Worktree[] }
+
+    expect(second.worktrees).toHaveLength(2)
+    expect(listWorktreesMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rescans detected worktrees after the local create flow notifies worktree changes', async () => {
+    listWorktreesMock
+      .mockResolvedValueOnce([
+        {
+          path: '/workspace/repo',
+          head: 'main-head',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          path: '/workspace/repo',
+          head: 'main-head',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: '/workspace/improve-dashboard',
+          head: 'feature-head',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          path: '/workspace/repo',
+          head: 'main-head',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: '/workspace/improve-dashboard',
+          head: 'feature-head',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+
+    await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard'
+    })
+    const detected = (await handlers['worktrees:listDetected'](null, {
+      repoId: 'repo-1'
+    })) as { worktrees: Worktree[] }
+
+    expect(detected.worktrees.map((worktree) => worktree.path)).toEqual([
+      '/workspace/repo',
+      '/workspace/improve-dashboard'
+    ])
+    expect(listWorktreesMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not run fresh-scan side effects from a detected scan invalidated while in flight', async () => {
+    let resolveScan: (worktrees: GitWorktreeInfo[]) => void = () => {}
+    listWorktreesMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve as (worktrees: GitWorktreeInfo[]) => void
+        })
+    )
+    store.getAllWorktreeLineage.mockReturnValue({
+      'repo-1::/workspace/new-worktree': {
+        worktreeId: 'repo-1::/workspace/new-worktree',
+        worktreeInstanceId: 'child-instance',
+        parentWorktreeId: 'repo-1::/workspace/repo',
+        parentWorktreeInstanceId: 'parent-instance',
+        origin: 'manual',
+        capture: {
+          source: 'manual-action',
+          confidence: 'explicit'
+        },
+        createdAt: 0
+      }
+    })
+
+    const pendingList = handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+    await Promise.resolve()
+    notifyWorktreesChanged(mainWindow as never, 'repo-1')
+    resolveScan([
+      {
+        path: '/workspace/repo',
+        head: 'main-head',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    await pendingList
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(listWorktreesMock).toHaveBeenCalledTimes(1)
   })
 
   it('fetches the same-repo PR head via the SSH tracking-ref RPC, not git.exec', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -434,9 +434,8 @@ async function listDetectedGitWorktrees(
     }
   }
 
-  const now = Date.now()
   const cached = detectedWorktreeScanCache.get(repo.id)
-  if (cached && cached.expiresAt > now) {
+  if (cached && cached.expiresAt > Date.now()) {
     return { gitWorktrees: cached.worktrees, fresh: false }
   }
 
@@ -456,7 +455,7 @@ async function listDetectedGitWorktrees(
     if (isCurrentGeneration) {
       detectedWorktreeScanCache.set(repo.id, {
         worktrees: gitWorktrees,
-        expiresAt: now + DETECTED_WORKTREE_SCAN_CACHE_TTL_MS
+        expiresAt: Date.now() + DETECTED_WORKTREE_SCAN_CACHE_TTL_MS
       })
     }
     return { gitWorktrees, fresh: isCurrentGeneration }

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -388,6 +388,8 @@ function getPreservedBranchCleanupTarget(
 const loggedUnavailableSshGitProviders = new Set<string>()
 const loggedWorktreeListFailures = new Set<string>()
 const loggedMalformedWorktreeMetaKeys = new Set<string>()
+// Why: absorb renderer polling bursts while keeping external worktree-change
+// lag bounded to one short refresh window.
 const DETECTED_WORKTREE_SCAN_CACHE_TTL_MS = 5_000
 
 type DetectedWorktreeScanCacheEntry = {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -77,6 +77,7 @@ import {
   cleanupUnusedWorktreePushTargetRemoteSsh,
   notifyWorktreesChanged
 } from './worktree-remote'
+import { registerWorktreeChangeInvalidator } from './worktree-change-invalidators'
 import {
   invalidateAuthorizedRootsCache,
   isENOENT,
@@ -387,6 +388,82 @@ function getPreservedBranchCleanupTarget(
 const loggedUnavailableSshGitProviders = new Set<string>()
 const loggedWorktreeListFailures = new Set<string>()
 const loggedMalformedWorktreeMetaKeys = new Set<string>()
+const DETECTED_WORKTREE_SCAN_CACHE_TTL_MS = 5_000
+
+type DetectedWorktreeScanCacheEntry = {
+  expiresAt: number
+  worktrees: GitWorktreeInfo[]
+}
+
+type DetectedWorktreeScanResult = {
+  gitWorktrees: GitWorktreeInfo[]
+  fresh: boolean
+}
+
+const detectedWorktreeScanCache = new Map<string, DetectedWorktreeScanCacheEntry>()
+const detectedWorktreeScanInFlight = new Map<string, Promise<GitWorktreeInfo[]>>()
+const detectedWorktreeScanGenerations = new Map<string, number>()
+
+function invalidateDetectedWorktreeScanCache(repoId: string): void {
+  detectedWorktreeScanCache.delete(repoId)
+  detectedWorktreeScanInFlight.delete(repoId)
+  detectedWorktreeScanGenerations.set(
+    repoId,
+    (detectedWorktreeScanGenerations.get(repoId) ?? 0) + 1
+  )
+}
+
+registerWorktreeChangeInvalidator(invalidateDetectedWorktreeScanCache)
+
+export function __resetDetectedWorktreeScanCacheForTests(): void {
+  detectedWorktreeScanCache.clear()
+  detectedWorktreeScanInFlight.clear()
+  detectedWorktreeScanGenerations.clear()
+}
+
+async function listDetectedGitWorktrees(
+  store: Store,
+  repo: Repo
+): Promise<DetectedWorktreeScanResult> {
+  if (repo.connectionId || isFolderRepo(repo)) {
+    return {
+      gitWorktrees: await listRepoWorktrees(repo, getLocalProjectWorktreeGitOptions(store, repo)),
+      fresh: true
+    }
+  }
+
+  const now = Date.now()
+  const cached = detectedWorktreeScanCache.get(repo.id)
+  if (cached && cached.expiresAt > now) {
+    return { gitWorktrees: cached.worktrees, fresh: false }
+  }
+
+  const inFlight = detectedWorktreeScanInFlight.get(repo.id)
+  if (inFlight) {
+    return { gitWorktrees: await inFlight, fresh: false }
+  }
+
+  const scan = listRepoWorktrees(repo, getLocalProjectWorktreeGitOptions(store, repo))
+  const generation = detectedWorktreeScanGenerations.get(repo.id) ?? 0
+  detectedWorktreeScanInFlight.set(repo.id, scan)
+  try {
+    const gitWorktrees = await scan
+    // Why: a create/remove notification can invalidate while the git scan is
+    // still running. Do not let that stale scan repopulate the cache afterward.
+    const isCurrentGeneration = (detectedWorktreeScanGenerations.get(repo.id) ?? 0) === generation
+    if (isCurrentGeneration) {
+      detectedWorktreeScanCache.set(repo.id, {
+        worktrees: gitWorktrees,
+        expiresAt: now + DETECTED_WORKTREE_SCAN_CACHE_TTL_MS
+      })
+    }
+    return { gitWorktrees, fresh: isCurrentGeneration }
+  } finally {
+    if (detectedWorktreeScanInFlight.get(repo.id) === scan) {
+      detectedWorktreeScanInFlight.delete(repo.id)
+    }
+  }
+}
 
 function warnOnce(keySet: Set<string>, key: string, message: string, error?: unknown): void {
   if (keySet.has(key)) {
@@ -946,6 +1023,7 @@ export function registerWorktreeHandlers(
 
       try {
         let gitWorktrees: GitWorktreeInfo[]
+        let freshScan = true
         if (isFolderRepo(repo)) {
           return {
             repoId: repo.id,
@@ -966,13 +1044,14 @@ export function registerWorktreeHandlers(
           }
           gitWorktrees = await provider.listWorktrees(repo.path)
         } else {
-          gitWorktrees = await listRepoWorktrees(
-            repo,
-            getLocalProjectWorktreeGitOptions(store, repo)
-          )
+          const scan = await listDetectedGitWorktrees(store, repo)
+          gitWorktrees = scan.gitWorktrees
+          freshScan = scan.fresh
         }
-        rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-        pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+        if (freshScan) {
+          rememberLocalWorktreeRoots(store, repo, gitWorktrees)
+          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+        }
         loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
         return {
           repoId: repo.id,

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -17,7 +17,8 @@ const {
   registerPtyHandlersMock,
   hydrateLocalPtyRegistryAtBootMock,
   setupAutoUpdaterMock,
-  browserManagerUnregisterAllMock
+  browserManagerUnregisterAllMock,
+  runWorktreeChangeInvalidatorsMock
 } = vi.hoisted(() => ({
   onMock: vi.fn(),
   removeAllListenersMock: vi.fn(),
@@ -33,7 +34,8 @@ const {
   registerPtyHandlersMock: vi.fn(),
   hydrateLocalPtyRegistryAtBootMock: vi.fn(),
   setupAutoUpdaterMock: vi.fn(),
-  browserManagerUnregisterAllMock: vi.fn()
+  browserManagerUnregisterAllMock: vi.fn(),
+  runWorktreeChangeInvalidatorsMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -62,6 +64,10 @@ vi.mock('../ipc/repos', () => ({
 
 vi.mock('../ipc/worktrees', () => ({
   registerWorktreeHandlers: registerWorktreeHandlersMock
+}))
+
+vi.mock('../ipc/worktree-change-invalidators', () => ({
+  runWorktreeChangeInvalidators: runWorktreeChangeInvalidatorsMock
 }))
 
 vi.mock('../ipc/pty', () => ({
@@ -592,5 +598,9 @@ describe('attachMainWindowServices', () => {
         }
       ]
     ])
+    expect(runWorktreeChangeInvalidatorsMock).toHaveBeenCalledWith('repo-1')
+    expect(runWorktreeChangeInvalidatorsMock.mock.invocationCallOrder[0]).toBeLessThan(
+      sendMock.mock.invocationCallOrder[0]
+    )
   })
 })

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -218,6 +218,8 @@ function registerRuntimeWindowLifecycle(
   }
   runtime.setNotifier({
     worktreesChanged: (repoId, renamed) => {
+      // Why: clear detected-worktree scan caches before renderer listeners
+      // handle this event, preventing stale TTL reads after mutations.
       runWorktreeChangeInvalidators(repoId)
       send('worktrees:changed', renamed ? { repoId, renamed } : { repoId })
     },

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -36,6 +36,7 @@ import { isNativeFileDropPayload, type NativeFileDropPayload } from '../../share
 import { requestMobileMarkdownFromRenderer } from './mobile-markdown-request-relay'
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
 import type { ClaudeAccountSelectionTarget } from '../claude-accounts/runtime-selection'
+import { runWorktreeChangeInvalidators } from '../ipc/worktree-change-invalidators'
 
 let appReloadHandlerTokenCounter = 0
 let activeAppReloadHandlerToken: number | null = null
@@ -216,8 +217,10 @@ function registerRuntimeWindowLifecycle(
     }
   }
   runtime.setNotifier({
-    worktreesChanged: (repoId, renamed) =>
-      send('worktrees:changed', renamed ? { repoId, renamed } : { repoId }),
+    worktreesChanged: (repoId, renamed) => {
+      runWorktreeChangeInvalidators(repoId)
+      send('worktrees:changed', renamed ? { repoId, renamed } : { repoId })
+    },
     worktreeBaseStatus: (event) => send('worktree:baseStatus', event),
     worktreeRemoteBranchConflict: (event) => send('worktree:remoteBranchConflict', event),
     reposChanged: () => send('repos:changed'),


### PR DESCRIPTION
## Summary

Reduces repeated git subprocess churn seen in crash report `a219317b-4f81-42cb-89dd-872657f4ae21` by:

- caching successful local `worktrees:listDetected` raw `GitWorktreeInfo[]` scans for 5 seconds with in-flight coalescing
- rebuilding detected worktree payloads from current metadata/settings on cache hits
- invalidating detected-scan caches before worktree change notifications from both IPC and runtime notifier paths
- adding a null-only, in-flight coalesced 30-second cache for missing tracked-upstream branch probes keyed by local/WSL/SSH runtime, repo path, and branch

The cache intentionally skips SSH/folder worktree listing for safety; SSH-relevant tracked-upstream behavior remains on the existing provider path and is covered by focused tests.

## Crash Evidence / Classification

Crash classification: likely renderer OOM pressure from git polling/subprocess churn with retained trace/error payloads.

Evidence from the downloaded diagnostics:

- renderer heap rose from about `2222MB / 2995MB` to the `3586MB` V8 limit before renderer exit code 5
- `10,369` `git.exec` spans
- `9,934` `git worktree` probes
- `112` failed `git remote get-url upstream` probes
- `141` no-upstream branch failures

This change removes the dominant measured repeated worktree-list probe pattern and the smaller stable-negative tracked-upstream fallback probes.

## Design Review

- Scratch design doc: `tmp/git-upstream-probe-memory-crash-design.md` (not committed)
- Initial design review flagged that the original upstream-only mitigation overclaimed because the trace was dominated by `git worktree` churn.
- Revised design targeted local detected-worktree scan caching plus tracked-upstream null caching.
- Follow-up design review was clean enough for implementation.

## Implementation / Deviations

- Initial implementation subagent was blocked by account limits, so the main agent implemented the reviewed design.
- A later implementation completion subagent reviewed and patched one race: if a detected scan is invalidated while in flight, it no longer runs fresh-scan side effects like lineage pruning.
- CodeRabbit follow-up fixed invalidator resilience, added why-comments for the non-obvious cache/notification ordering, and moved the detected-scan TTL start to scan completion with a regression test.
- Added regression tests for cache hits, concurrent coalescing, TTL expiry, slow-scan TTL start, metadata rebuild, create-flow invalidation, in-flight invalidation, host/WSL cache separation, and tracked-upstream TTL/coalescing.

## Completeness Verification

- First completeness pass found the need for a real `worktrees:create` flow invalidation test and a direct host/WSL cache identity regression.
- Both gaps were fixed.
- Final completeness pass: complete; no actionable omissions/blockers.

## Code Review

Two independent reviewers in the same round returned clean.

Reviewer A:
- no issues found
- reviewed diff against `origin/main`
- ran worktree, GitHub client, status-upstream churn, window service tests plus diff check

Reviewer B:
- no issues found
- reviewed invalidation paths, cache keying, SSH/WSL handling, concurrency behavior, and accidental instruction text
- ran relevant focused tests plus diff check

## Brennan Test Changes

Verdict: `land`

Validation matrix covered:

- `worktrees:listDetected` local cache: repeated calls, concurrent calls, TTL expiry, metadata rebuild during cache hit, mutation invalidation, stale in-flight scan side effects
- worktree change notifications: invalidator runs before `worktrees:changed`
- GitHub tracked-upstream null cache: repeated/concurrent no-upstream misses, TTL recheck, WSL/local cache separation, existing positive/SSH tracked-upstream behavior
- no screenshot evidence: non-UI main-process cache/performance fix; no Electron UI surface changed

Accepted gap:

- Full `pnpm run lint` was reported by the validation subagent as failing in repo-global localization verification for unrelated `TerminalInteractionSection.tsx` keys outside this diff. Changed-file lint passed.

## Tests

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/worktrees.test.ts -t "detected"`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/github/client.test.ts -t "tracked[- ]upstream"`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/worktrees.test.ts src/main/window/attach-main-window-services.test.ts src/main/github/client.test.ts src/main/git/status-upstream-probe-churn.test.ts` (`248 passed` after CodeRabbit fixes)
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec oxlint src/main/ipc/worktree-change-invalidators.ts src/main/ipc/worktrees.ts src/main/ipc/worktree-remote.ts src/main/ipc/worktrees.test.ts src/main/window/attach-main-window-services.ts src/main/window/attach-main-window-services.test.ts src/main/github/client.ts src/main/github/client.test.ts`
- [x] `git diff --check`
- [x] GitHub PR Checks / `verify` passed

## Post-PR Stabilization

Complete.

- Waited 8 minutes after opening the PR.
- Fixed CodeRabbit's first round comments: added cache rationale comments and isolated invalidator failures.
- Waited 8 minutes after pushing that fix.
- Fixed CodeRabbit's second round comments: documented invalidation-before-notify ordering and started the detected-scan TTL after slow scans complete, with a regression test.
- Waited 8 minutes after the second fix.
- Latest CodeRabbit review reported no actionable comments.
- GitHub `verify` check passed.

Non-actionable note: CodeRabbit's pre-merge summary still shows a generic docstring-coverage warning; it did not produce actionable review comments after the final commit.

## Residual Risk

- External worktree changes outside Orca can lag up to 5 seconds.
- Newly configured differently named upstream branches can lag up to 30 seconds after a cached null.
- This removes the measured subprocess/error-trace churn but does not prove the exact renderer heap retention mechanism.
