### PR TITLE
Remove deferred sidebar worktree activation

### DIFF
--- a/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
@@ -13,33 +13,13 @@ const mocks = vi.hoisted(() => {
       }
     }),
     tabsByWorktree: {} as Record<string, { id: string }[]>,
-    ptyIdsByTabId: {} as Record<string, string[]>,
-    browserTabsByWorktree: {} as Record<string, { id: string }[]>,
-    openFiles: [] as { worktreeId: string }[]
+    ptyIdsByTabId: {} as Record<string, string[]>
   }
   const activateAndRevealWorktree = vi.fn()
-  const markInputQuietSchedulerInput = vi.fn()
-  const pendingCallbacks: (() => void)[] = []
-  const pendingCancels: ReturnType<typeof vi.fn>[] = []
-  const scheduleAfterInputQuiet = vi.fn((callback: () => void) => {
-    let cancelled = false
-    const cancel = vi.fn(() => {
-      cancelled = true
-    })
-    pendingCallbacks.push(() => {
-      if (!cancelled) {
-        callback()
-      }
-    })
-    pendingCancels.push(cancel)
-    return cancel
-  })
+  const activateAndRevealFolderWorkspace = vi.fn()
   return {
+    activateAndRevealFolderWorkspace,
     activateAndRevealWorktree,
-    markInputQuietSchedulerInput,
-    pendingCallbacks,
-    pendingCancels,
-    scheduleAfterInputQuiet,
     state,
     toastError: vi.fn()
   }
@@ -52,12 +32,8 @@ vi.mock('@/store', () => ({
 }))
 
 vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealFolderWorkspace: mocks.activateAndRevealFolderWorkspace,
   activateAndRevealWorktree: mocks.activateAndRevealWorktree
-}))
-
-vi.mock('@/lib/input-quiet-scheduler', () => ({
-  markInputQuietSchedulerInput: mocks.markInputQuietSchedulerInput,
-  scheduleAfterInputQuiet: mocks.scheduleAfterInputQuiet
 }))
 
 vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
@@ -65,13 +41,10 @@ vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
 import { activateWorktreeFromSidebar } from '@/lib/sidebar-worktree-activation'
 import { runSleepWorktrees } from './sleep-worktree-flow'
 
-describe('sleep flow vs queued slept-workspace activation', () => {
+describe('sleep flow vs slept-workspace activation', () => {
   beforeEach(() => {
     mocks.activateAndRevealWorktree.mockClear()
-    mocks.markInputQuietSchedulerInput.mockClear()
-    mocks.scheduleAfterInputQuiet.mockClear()
-    mocks.pendingCallbacks.length = 0
-    mocks.pendingCancels.length = 0
+    mocks.activateAndRevealFolderWorkspace.mockClear()
     mocks.toastError.mockClear()
     mocks.state.activeWorktreeId = 'wt-parent'
     mocks.state.setActiveWorktree.mockClear()
@@ -93,26 +66,22 @@ describe('sleep flow vs queued slept-workspace activation', () => {
       'tab-child-2': ['pty-child-2'],
       'tab-child-3': ['pty-child-3']
     }
-    mocks.state.browserTabsByWorktree = {}
-    mocks.state.openFiles = []
   })
 
-  it('does not let an old slept-parent activation fire after sleeping children', async () => {
+  it('does not leave behind a delayed parent activation after sleeping children', async () => {
     await runSleepWorktrees(['wt-parent'])
 
     expect(mocks.state.activeWorktreeId).toBeNull()
     expect(mocks.state.ptyIdsByTabId['tab-parent']).toEqual([])
 
-    // A normal click on the slept parent row during selection setup queues a
-    // wake internally, even though the user is just trying to select children.
     activateWorktreeFromSidebar('wt-parent')
-    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
-    expect(mocks.pendingCallbacks).toHaveLength(1)
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledTimes(1)
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-parent', {
+      revealInSidebar: false
+    })
 
     await runSleepWorktrees(['wt-child-1', 'wt-child-2', 'wt-child-3'])
-    mocks.pendingCallbacks[0]?.()
 
-    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
-    expect(mocks.pendingCancels[0]).toHaveBeenCalledTimes(1)
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -14,9 +14,7 @@ const mocks = vi.hoisted(() => {
   const toastError = vi.fn()
   const markWorktreeSleepIntent = vi.fn()
   const clearWorktreeSleepIntent = vi.fn()
-  const cancelPendingSidebarWorktreeActivation = vi.fn()
   return {
-    cancelPendingSidebarWorktreeActivation,
     clearWorktreeSleepIntent,
     markWorktreeSleepIntent,
     state,
@@ -35,9 +33,6 @@ vi.mock('@/lib/worktree-sleep-intent', () => ({
   clearWorktreeSleepIntent: mocks.clearWorktreeSleepIntent,
   markWorktreeSleepIntent: mocks.markWorktreeSleepIntent
 }))
-vi.mock('@/lib/sidebar-worktree-activation', () => ({
-  cancelPendingSidebarWorktreeActivation: mocks.cancelPendingSidebarWorktreeActivation
-}))
 
 import { runSleepWorktree, runSleepWorktrees } from './sleep-worktree-flow'
 
@@ -51,7 +46,6 @@ describe('runSleepWorktree', () => {
     mocks.state.consumeSuppressedPtyExit.mockClear()
     mocks.markWorktreeSleepIntent.mockClear()
     mocks.clearWorktreeSleepIntent.mockClear()
-    mocks.cancelPendingSidebarWorktreeActivation.mockClear()
     mocks.toastError.mockClear()
     mocks.state.activeWorktreeId = null
     mocks.state.tabsByWorktree = {}
@@ -74,15 +68,6 @@ describe('runSleepWorktree', () => {
     const browsersCallOrder = mocks.state.shutdownWorktreeBrowsers.mock.invocationCallOrder[0]
     const terminalsCallOrder = mocks.state.shutdownWorktreeTerminals.mock.invocationCallOrder[0]
     expect(browsersCallOrder).toBeLessThan(terminalsCallOrder)
-  })
-
-  it('cancels a queued sidebar wake before sleeping worktrees', async () => {
-    await runSleepWorktrees(['wt-1', 'wt-2'])
-
-    expect(mocks.cancelPendingSidebarWorktreeActivation).toHaveBeenCalledTimes(1)
-    const cancelCall = mocks.cancelPendingSidebarWorktreeActivation.mock.invocationCallOrder[0]
-    const browserCall = mocks.state.shutdownWorktreeBrowsers.mock.invocationCallOrder[0]
-    expect(cancelCall).toBeLessThan(browserCall)
   })
 
   it('clears activeWorktreeId before teardown when the slept worktree is active', async () => {

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -1,7 +1,6 @@
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { clearWorktreeSleepIntent, markWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
-import { cancelPendingSidebarWorktreeActivation } from '@/lib/sidebar-worktree-activation'
 import { VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } from '@/hooks/useVirtualizedScrollAnchor'
 import { translate } from '@/i18n/i18n'
 import { PINNED_GROUP_KEY } from './worktree-list-groups'
@@ -106,9 +105,6 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
   if (worktreeIds.length === 0) {
     return
   }
-  // Why: clicking a slept sidebar row queues a delayed wake. A later Sleep
-  // command is the newer intent, so do not let that stale wake respawn PTYs.
-  cancelPendingSidebarWorktreeActivation()
   const {
     activeWorktreeId,
     setActiveWorktree,

--- a/src/renderer/src/lib/sidebar-worktree-activation.test.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.test.ts
@@ -1,45 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => {
-  const state = {
-    tabsByWorktree: {} as Record<string, { id: string }[]>,
-    ptyIdsByTabId: {} as Record<string, string[]>,
-    browserTabsByWorktree: {} as Record<string, { id: string }[]>,
-    openFiles: [] as { worktreeId: string }[]
-  }
-  const activateAndRevealWorktree = vi.fn()
-  const activateAndRevealFolderWorkspace = vi.fn()
-  const markInputQuietSchedulerInput = vi.fn()
-  const pendingCallbacks: (() => void)[] = []
-  const pendingCancels: ReturnType<typeof vi.fn>[] = []
-  const scheduleAfterInputQuiet = vi.fn((callback: () => void) => {
-    let cancelled = false
-    const cancel = vi.fn(() => {
-      cancelled = true
-    })
-    pendingCallbacks.push(() => {
-      if (!cancelled) {
-        callback()
-      }
-    })
-    pendingCancels.push(cancel)
-    return cancel
-  })
-  return {
-    activateAndRevealWorktree,
-    activateAndRevealFolderWorkspace,
-    markInputQuietSchedulerInput,
-    pendingCallbacks,
-    pendingCancels,
-    scheduleAfterInputQuiet,
-    state
-  }
-})
-
-vi.mock('@/store', () => ({
-  useAppStore: {
-    getState: () => mocks.state
-  }
+const mocks = vi.hoisted(() => ({
+  activateAndRevealFolderWorkspace: vi.fn(),
+  activateAndRevealWorktree: vi.fn()
 }))
 
 vi.mock('@/lib/worktree-activation', () => ({
@@ -47,52 +10,30 @@ vi.mock('@/lib/worktree-activation', () => ({
   activateAndRevealWorktree: mocks.activateAndRevealWorktree
 }))
 
-vi.mock('@/lib/input-quiet-scheduler', () => ({
-  markInputQuietSchedulerInput: mocks.markInputQuietSchedulerInput,
-  scheduleAfterInputQuiet: mocks.scheduleAfterInputQuiet
-}))
-
-import {
-  activateWorktreeFromSidebar,
-  cancelPendingSidebarWorktreeActivation
-} from './sidebar-worktree-activation'
+import { activateWorktreeFromSidebar } from './sidebar-worktree-activation'
 
 describe('sidebar worktree activation', () => {
   beforeEach(() => {
-    delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
-    cancelPendingSidebarWorktreeActivation()
     mocks.activateAndRevealWorktree.mockClear()
     mocks.activateAndRevealFolderWorkspace.mockClear()
-    mocks.markInputQuietSchedulerInput.mockClear()
-    mocks.scheduleAfterInputQuiet.mockClear()
-    mocks.pendingCallbacks.length = 0
-    mocks.pendingCancels.length = 0
-    mocks.state.tabsByWorktree = {}
-    mocks.state.ptyIdsByTabId = {}
-    mocks.state.browserTabsByWorktree = {}
-    mocks.state.openFiles = []
   })
 
-  it('cancels a queued slept-workspace activation', () => {
-    mocks.state.tabsByWorktree = { 'wt-parent': [{ id: 'tab-1' }] }
-    mocks.state.ptyIdsByTabId = { 'tab-1': [] }
-
-    activateWorktreeFromSidebar('wt-parent')
-    cancelPendingSidebarWorktreeActivation()
-
-    expect(mocks.pendingCancels[0]).toHaveBeenCalledTimes(1)
-    mocks.pendingCallbacks[0]?.()
-    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
-  })
-
-  it('does not defer a workspace with a live PTY', () => {
-    mocks.state.tabsByWorktree = { 'wt-live': [{ id: 'tab-1' }] }
-    mocks.state.ptyIdsByTabId = { 'tab-1': ['pty-1'] }
-
+  it('activates a clicked worktree immediately without sidebar reveal', () => {
     activateWorktreeFromSidebar('wt-live')
 
-    expect(mocks.scheduleAfterInputQuiet).not.toHaveBeenCalled()
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-live', {
+      revealInSidebar: false
+    })
+    expect(mocks.activateAndRevealFolderWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('does not defer slept worktree selection behind terminal wake work', () => {
+    activateWorktreeFromSidebar('wt-slept')
+
+    // Why: setActiveWorktree already defers terminal prep where needed. The
+    // sidebar click itself must switch app state immediately.
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledTimes(1)
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-slept', {
       revealInSidebar: false
     })
   })
@@ -102,19 +43,5 @@ describe('sidebar worktree activation', () => {
 
     expect(mocks.activateAndRevealFolderWorkspace).toHaveBeenCalledWith('folder-workspace-1')
     expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
-    expect(mocks.scheduleAfterInputQuiet).not.toHaveBeenCalled()
-  })
-
-  it('does not defer slept workspace activation in the web client', () => {
-    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
-    mocks.state.tabsByWorktree = { 'wt-web-slept': [{ id: 'tab-1' }] }
-    mocks.state.ptyIdsByTabId = { 'tab-1': [] }
-
-    activateWorktreeFromSidebar('wt-web-slept')
-
-    expect(mocks.scheduleAfterInputQuiet).not.toHaveBeenCalled()
-    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-web-slept', {
-      revealInSidebar: false
-    })
   })
 })

--- a/src/renderer/src/lib/sidebar-worktree-activation.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.ts
@@ -1,75 +1,17 @@
-import { useAppStore } from '@/store'
 import {
   activateAndRevealFolderWorkspace,
   activateAndRevealWorktree
 } from '@/lib/worktree-activation'
-import { tabHasLivePty } from '@/lib/tab-has-live-pty'
-import { markInputQuietSchedulerInput, scheduleAfterInputQuiet } from '@/lib/input-quiet-scheduler'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 
-const SLEPT_WORKTREE_ACTIVATION_INPUT_QUIET_MS = 450
-const SLEPT_WORKTREE_ACTIVATION_IDLE_TIMEOUT_MS = 120
-
-let pendingSidebarWorktreeActivation: {
-  worktreeId: string
-  cancel: () => void
-} | null = null
-
-export function cancelPendingSidebarWorktreeActivation(): void {
-  pendingSidebarWorktreeActivation?.cancel()
-  pendingSidebarWorktreeActivation = null
-}
-
-function shouldDeferSidebarWorktreeActivation(worktreeId: string): boolean {
-  // Why: web clients should activate immediately to avoid host/session churn and wake lag.
-  if ((globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ === true) {
-    return false
-  }
-  const state = useAppStore.getState()
-  const tabs = state.tabsByWorktree[worktreeId] ?? []
-  if (tabs.length === 0) {
-    return false
-  }
-  if ((state.browserTabsByWorktree[worktreeId] ?? []).length > 0) {
-    return false
-  }
-  if (state.openFiles.some((file) => file.worktreeId === worktreeId)) {
-    return false
-  }
-  return tabs.every((tab) => !tabHasLivePty(state.ptyIdsByTabId, tab.id))
-}
-
 export function activateWorktreeFromSidebar(worktreeId: string): void {
-  cancelPendingSidebarWorktreeActivation()
   const workspaceScope = parseWorkspaceKey(worktreeId)
   if (workspaceScope?.type === 'folder') {
     activateAndRevealFolderWorkspace(workspaceScope.folderWorkspaceId)
     return
   }
 
-  const activate = (): void => {
-    if (pendingSidebarWorktreeActivation?.worktreeId === worktreeId) {
-      pendingSidebarWorktreeActivation = null
-    }
-    // Why: sidebar clicks already happen on a visible row; revealing again can
-    // jump duplicate pinned/canonical entries back to the first mounted copy.
-    activateAndRevealWorktree(worktreeId, { revealInSidebar: false })
-  }
-
-  if (!shouldDeferSidebarWorktreeActivation(worktreeId)) {
-    activate()
-    return
-  }
-
-  markInputQuietSchedulerInput()
-  // Why: a slept workspace may remount terminals. Keep that work cancellable so
-  // a quick "changed my mind" click is never queued behind the first wake.
-  pendingSidebarWorktreeActivation = {
-    worktreeId,
-    cancel: scheduleAfterInputQuiet(activate, {
-      delayMs: 0,
-      quietMs: SLEPT_WORKTREE_ACTIVATION_INPUT_QUIET_MS,
-      idleTimeoutMs: SLEPT_WORKTREE_ACTIVATION_IDLE_TIMEOUT_MS
-    })
-  }
+  // Why: sidebar clicks already happen on a visible row; revealing again can
+  // jump duplicate pinned/canonical entries back to the first mounted copy.
+  activateAndRevealWorktree(worktreeId, { revealInSidebar: false })
 }


### PR DESCRIPTION
## Summary

Remove deferred sidebar worktree activation and simplify the activation flow. Previously, sidebar clicks on slept worktrees were deferred/queued using an `input-quiet-scheduler` to avoid race conditions with sleep commands. Worktrees are now activated immediately upon click, as the underlying store already handles terminal preparation deferral where needed.

## Screenshots

No visual change.

## Testing

Updated the unit and integration tests to verify immediate sidebar worktree activation and removed tests for the obsolete scheduling and cancellation logic.

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the elimination of the `input-quiet-scheduler` dependency from sidebar worktree activation. Checked for cross-platform compatibility across macOS, Linux, and Windows, confirming that no platform-specific shortcuts, labels, paths, or Electron behaviors are impacted. Verified that the test suite has been updated to assert immediate synchronous activation.

## Security Audit

No security, input handling, command execution, path handling, or IPC risks were identified, as this is a client-side state management refactor.

## Notes

None.