### PR TITLE
Add a per-call background lane for event-driven project refresh

### DIFF
--- a/src/main/ipc/runtime-environment-call-queue.ts
+++ b/src/main/ipc/runtime-environment-call-queue.ts
@@ -5,7 +5,8 @@ const runtimeCallQueuePool = new RuntimeRpcCallQueuePool()
 export function enqueueRuntimeCall<T>(
   selector: string,
   method: string,
-  run: () => Promise<T>
+  run: () => Promise<T>,
+  options?: { background?: boolean }
 ): Promise<T> {
-  return runtimeCallQueuePool.enqueue(selector, method, run)
+  return runtimeCallQueuePool.enqueue(selector, method, run, options)
 }

--- a/src/main/ipc/runtime-environment-transport-routing.ts
+++ b/src/main/ipc/runtime-environment-transport-routing.ts
@@ -71,44 +71,50 @@ export async function callRuntimeEnvironment(
   selector: string,
   method: string,
   params: unknown,
-  timeoutMs?: number
+  timeoutMs?: number,
+  background?: boolean
 ): Promise<RuntimeRpcResponse<unknown>> {
   const environment = resolveEnvironment(userDataPath, selector)
-  return enqueueRuntimeCall(environment.id, method, async () => {
-    const currentEnvironment = resolveEnvironment(userDataPath, environment.id)
-    const pairing = getPreferredPairingOffer(currentEnvironment)
-    const effectiveTimeoutMs = timeoutMs ?? DEFAULT_REMOTE_RUNTIME_TIMEOUT_MS
-    if (shouldUseCachedRequestConnection(method)) {
-      const response = await sendRemoteRuntimeConnectionRequest(
-        currentEnvironment.id,
-        pairing,
-        method,
-        params,
-        effectiveTimeoutMs
-      )
+  return enqueueRuntimeCall(
+    environment.id,
+    method,
+    async () => {
+      const currentEnvironment = resolveEnvironment(userDataPath, environment.id)
+      const pairing = getPreferredPairingOffer(currentEnvironment)
+      const effectiveTimeoutMs = timeoutMs ?? DEFAULT_REMOTE_RUNTIME_TIMEOUT_MS
+      if (shouldUseCachedRequestConnection(method)) {
+        const response = await sendRemoteRuntimeConnectionRequest(
+          currentEnvironment.id,
+          pairing,
+          method,
+          params,
+          effectiveTimeoutMs
+        )
+        markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
+        return response
+      }
+      if (
+        method !== 'status.get' &&
+        (await supportsSharedControl(userDataPath, currentEnvironment, pairing, effectiveTimeoutMs))
+      ) {
+        const response = await sendRemoteRuntimeSharedControlRequest(
+          currentEnvironment.id,
+          pairing,
+          method,
+          params,
+          effectiveTimeoutMs
+        )
+        markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
+        return response
+      }
+      // Why: startup/control-plane RPCs use the proven one-shot path so repo
+      // hydration cannot be coupled to a stale terminal-control connection.
+      const response = await sendRemoteRuntimeRequest(pairing, method, params, effectiveTimeoutMs)
       markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
       return response
-    }
-    if (
-      method !== 'status.get' &&
-      (await supportsSharedControl(userDataPath, currentEnvironment, pairing, effectiveTimeoutMs))
-    ) {
-      const response = await sendRemoteRuntimeSharedControlRequest(
-        currentEnvironment.id,
-        pairing,
-        method,
-        params,
-        effectiveTimeoutMs
-      )
-      markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
-      return response
-    }
-    // Why: startup/control-plane RPCs use the proven one-shot path so repo
-    // hydration cannot be coupled to a stale terminal-control connection.
-    const response = await sendRemoteRuntimeRequest(pairing, method, params, effectiveTimeoutMs)
-    markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
-    return response
-  })
+    },
+    { background }
+  )
 }
 
 export async function subscribeRuntimeEnvironment(

--- a/src/main/ipc/runtime-environments.test.ts
+++ b/src/main/ipc/runtime-environments.test.ts
@@ -1188,6 +1188,105 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     await expect(bg3).resolves.toMatchObject({ ok: true })
   })
 
+  it('honors an explicit background flag for a normally-foreground refresh method', async () => {
+    registerRuntimeEnvironmentHandlers()
+    const pendingBackground: ((value: unknown) => void)[] = []
+    sendRemoteRuntimeRequestMock.mockImplementation(async (_pairing, method) => {
+      if (method === 'status.get') {
+        return {
+          id: 'status',
+          ok: true,
+          result: { runtimeId: 'runtime-remote', capabilities: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      return await new Promise((resolve) => pendingBackground.push(resolve))
+    })
+    sendRemoteRuntimeConnectionRequestMock.mockResolvedValue({
+      id: 'terminal-send',
+      ok: true,
+      result: { send: { accepted: true } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+
+    const add = handler<
+      { name: string; pairingCode: string },
+      { environment: { id: string; name: string } }
+    >('runtimeEnvironments:addFromPairingCode')
+    await add(null, { name: 'desk', pairingCode: pairingCode() })
+
+    const call = handler<
+      {
+        selector: string
+        method: string
+        params?: unknown
+        timeoutMs?: number
+        background?: boolean
+      },
+      { ok: true; result: unknown }
+    >('runtimeEnvironments:call')
+
+    // repo.list/project.list are NOT background methods, but background:true demotes them to the
+    // background lane. Two saturate the background concurrency (default 2); a third must queue.
+    const demotedRepoList = call(null, { selector: 'desk', method: 'repo.list', background: true })
+    const demotedProjectList = call(null, {
+      selector: 'desk',
+      method: 'project.list',
+      background: true
+    })
+    const demotedHostSetup = call(null, {
+      selector: 'desk',
+      method: 'projectHostSetup.list',
+      background: true
+    })
+    await vi.waitFor(() =>
+      expect(sendRemoteRuntimeRequestMock.mock.calls.map((c) => c[1])).toEqual([
+        'status.get',
+        'repo.list',
+        'project.list'
+      ])
+    )
+
+    // A foreground terminal.send must overtake the background lane capped at 2 in-flight.
+    const foreground = call(null, {
+      selector: 'desk',
+      method: 'terminal.send',
+      params: { terminal: 'term-1', text: 'a' }
+    })
+    await expect(foreground).resolves.toMatchObject({
+      ok: true,
+      result: { send: { accepted: true } }
+    })
+    // projectHostSetup.list is still queued (background lane saturated) — proves demotion.
+    expect(pendingBackground).toHaveLength(2)
+    expect(sendRemoteRuntimeRequestMock.mock.calls.map((c) => c[1])).not.toContain(
+      'projectHostSetup.list'
+    )
+
+    // Once the foreground call drains, the demoted background calls resolve.
+    pendingBackground.shift()?.({
+      id: 'repo-list',
+      ok: true,
+      result: { repos: [] },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    pendingBackground.shift()?.({
+      id: 'project-list',
+      ok: true,
+      result: { projects: [] },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    await expect(demotedRepoList).resolves.toMatchObject({ ok: true })
+    await expect(demotedProjectList).resolves.toMatchObject({ ok: true })
+    pendingBackground.shift()?.({
+      id: 'project-host-setup-list',
+      ok: true,
+      result: {},
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    await expect(demotedHostSetup).resolves.toMatchObject({ ok: true })
+  })
+
   it('starts and stops streaming subscriptions for a saved remote runtime', async () => {
     registerRuntimeEnvironmentHandlers()
     const close = vi.fn()

--- a/src/main/ipc/runtime-environments.ts
+++ b/src/main/ipc/runtime-environments.ts
@@ -126,14 +126,21 @@ export function registerRuntimeEnvironmentHandlers(): void {
     'runtimeEnvironments:call',
     async (
       _event,
-      args: { selector: string; method: string; params?: unknown; timeoutMs?: number }
+      args: {
+        selector: string
+        method: string
+        params?: unknown
+        timeoutMs?: number
+        background?: boolean
+      }
     ): Promise<RuntimeRpcResponse<unknown>> => {
       return callRuntimeEnvironment(
         getUserDataPath(),
         args.selector,
         args.method,
         args.params,
-        args.timeoutMs
+        args.timeoutMs,
+        args.background
       )
     }
   )

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2566,6 +2566,7 @@ export type PreloadApi = {
       method: string
       params?: unknown
       timeoutMs?: number
+      background?: boolean
     }) => Promise<RuntimeRpcResponse<unknown>>
     subscribe: (
       args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3533,6 +3533,7 @@ const api = {
       method: string
       params?: unknown
       timeoutMs?: number
+      background?: boolean
     }): Promise<RuntimeRpcResponse<unknown>> =>
       ipcRenderer.invoke('runtimeEnvironments:call', args),
     subscribe: async (

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -3816,8 +3816,616 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
+    // Why: worktreesChanged is the same server-pushed client-event stream as
+    // reposChanged, so its refresh rides the background lane too — symmetric
+    // treatment keeps a multi-server worktree storm off the foreground lane.
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', { background: true })
+    expect(fetchWorktreeLineage).toHaveBeenCalledWith({ background: true })
+  })
+
+  it('routes the event-driven project refresh onto the background lane', async () => {
+    const fetchRuntimeEnvironmentRepos = vi.fn().mockResolvedValue([{ id: 'repo-1' }])
+    const fetchWorktrees = vi.fn().mockResolvedValue(true)
+    const fetchWorktreeLineage = vi.fn()
+    let runtimeOnResponse: ((response: unknown) => void) | undefined
+    const runtimeSubscribe = vi.fn(async (_args, callbacks) => {
+      runtimeOnResponse = (callbacks as { onResponse: (response: unknown) => void }).onResponse
+      return { unsubscribe: vi.fn(), sendBinary: vi.fn() }
+    })
+
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return {
+        ...actual,
+        useEffect: (effect: () => void | (() => void)) => {
+          effect()
+        }
+      }
+    })
+
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => ({
+          fetchRepos: vi.fn(),
+          fetchRuntimeEnvironmentRepos,
+          fetchProjectGroups: vi.fn(),
+          fetchWorktrees,
+          fetchWorktreeLineage,
+          repos: [{ id: 'repo-1' }],
+          detectedWorktreesByRepo: {},
+          worktreesByRepo: {},
+          purgeWorktreeTerminalState: vi.fn(),
+          removeWorkspaceSpaceWorktrees: vi.fn(),
+          setUpdateStatus: vi.fn(),
+          activeModal: null,
+          closeModal: vi.fn(),
+          openModal: vi.fn(),
+          getKnownWorktreeById: vi.fn(),
+          activeWorktreeId: null,
+          activeView: 'terminal',
+          setActiveView: vi.fn(),
+          setActiveRepo: vi.fn(),
+          setActiveWorktree: vi.fn(),
+          revealWorktreeInSidebar: vi.fn(),
+          setIsFullScreen: vi.fn(),
+          updateBrowserPageState: vi.fn(),
+          activeTabType: 'terminal',
+          editorFontZoomLevel: 0,
+          setEditorFontZoomLevel: vi.fn(),
+          setRateLimitsFromPush: vi.fn(),
+          setSshConnectionState: vi.fn(),
+          setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
+          enqueueSshCredentialRequest: vi.fn(),
+          removeSshCredentialRequest: vi.fn(),
+          clearTabPtyId: vi.fn(),
+          settings: { activeRuntimeEnvironmentId: 'env-1', terminalFontSize: 13 }
+        })
+      }
+    }))
+
+    vi.doMock('@/lib/ui-zoom', () => ({ applyUIZoom: vi.fn() }))
+    vi.doMock('@/lib/worktree-activation', () => ({
+      activateAndRevealWorktree: vi.fn(),
+      ensureWorktreeHasInitialTerminal: vi.fn()
+    }))
+    vi.doMock('@/components/sidebar/visible-worktrees', () => ({
+      getVisibleWorktreeIds: () => []
+    }))
+    vi.doMock('@/lib/editor-font-zoom', () => ({
+      nextEditorFontZoomLevel: vi.fn(() => 0),
+      computeEditorFontSize: vi.fn(() => 13)
+    }))
+    vi.doMock('@/components/settings/SettingsConstants', () => ({
+      zoomLevelToPercent: vi.fn(() => 100),
+      ZOOM_MIN: -3,
+      ZOOM_MAX: 3
+    }))
+    vi.doMock('@/lib/zoom-events', () => ({ dispatchZoomLevelChanged: vi.fn() }))
+
+    vi.stubGlobal('window', {
+      api: {
+        repos: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
+        runtimeEnvironments: { subscribe: runtimeSubscribe },
+        ui: {
+          onStateChanged: () => () => {},
+          onOpenSettings: () => () => {},
+          onOpenFeatureTour: () => () => {},
+          onToggleLeftSidebar: () => () => {},
+          onToggleRightSidebar: () => () => {},
+          onToggleWorktreePalette: () => () => {},
+          onToggleFloatingTerminal: () => () => {},
+          onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
+          onOpenTasks: () => () => {},
+          onJumpToWorktreeIndex: () => () => {},
+          onJumpToTabIndex: () => () => {},
+          onWorktreeHistoryNavigate: () => () => {},
+          onActivateWorktree: () => () => {},
+          onCreateTerminal: () => () => {},
+          onRequestTerminalCreate: () => () => {},
+          replyTerminalCreate: () => {},
+          onSplitTerminal: () => () => {},
+          onRenameTerminal: () => () => {},
+          onFocusTerminal: () => () => {},
+          onFocusEditorTab: () => () => {},
+          onCloseSessionTab: () => () => {},
+          onMoveSessionTab: () => () => {},
+          onOpenFileFromMobile: () => () => {},
+          onOpenDiffFromMobile: () => () => {},
+          onCloseTerminal: () => () => {},
+          onSleepWorktree: () => () => {},
+          onNewBrowserTab: () => () => {},
+          onNewMarkdownTab: () => () => {},
+          onRequestTabCreate: () => () => {},
+          replyTabCreate: () => {},
+          onRequestTabClose: () => () => {},
+          replyTabClose: () => {},
+          onRequestTabSetProfile: () => () => {},
+          replyTabSetProfile: () => {},
+          onNewTerminalTab: () => () => {},
+          onCloseActiveTab: () => () => {},
+          onSwitchTab: () => () => {},
+          onSwitchTabAcrossAllTypes: () => () => {},
+          onSwitchRecentTab: () => () => {},
+          onSwitchTerminalTab: () => () => {},
+          onToggleStatusBar: () => () => {},
+          onFullscreenChanged: () => () => {},
+          onTerminalZoom: () => () => {},
+          getZoomLevel: () => 0,
+          set: vi.fn()
+        },
+        settings: { onChanged: () => () => {} },
+        updater: {
+          getStatus: () => Promise.resolve({ state: 'idle' }),
+          onStatus: () => () => {},
+          onClearDismissal: () => () => {}
+        },
+        browser: {
+          onGuestLoadFailed: () => () => {},
+          onOpenLinkInOrcaTab: () => () => {},
+          onNavigationUpdate: () => () => {},
+          onActivateView: () => () => {},
+          onPaneFocus: () => () => {}
+        },
+        rateLimits: {
+          get: () => Promise.resolve({ limits: {}, lastUpdatedAt: Date.now() }),
+          onUpdate: () => () => {}
+        },
+        ssh: {
+          listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
+          getState: () => Promise.resolve(null),
+          onStateChanged: () => () => {},
+          onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
+          onCredentialResolved: () => () => {}
+        },
+        runtime: {
+          getTerminalFitOverrides: () => Promise.resolve([]),
+          getTerminalDrivers: () => Promise.resolve([]),
+          getBrowserDrivers: () => Promise.resolve([]),
+          onTerminalFitOverrideChanged: () => () => {},
+          onTerminalDriverChanged: () => () => {},
+          onBrowserDriverChanged: () => () => {}
+        },
+        agentStatus: { onSet: () => () => {} }
+      }
+    })
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (!runtimeOnResponse) {
+      throw new Error('Expected runtime client event callbacks')
+    }
+    runtimeOnResponse({ ok: true, result: { type: 'reposChanged' } })
+    // Wait past the scheduler's 250ms debounce, then drain microtasks.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // The whole event-driven project refresh (repos + worktrees + lineage) must
+    // ride the background lane so a per-server refresh storm yields transport
+    // capacity to user-initiated runtime calls.
+    expect(fetchRuntimeEnvironmentRepos).toHaveBeenCalledWith('env-1', { background: true })
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', { background: true })
+    expect(fetchWorktreeLineage).toHaveBeenCalledWith({ background: true })
+  })
+
+  it('routes worktreesChanged repo discovery onto the background lane', async () => {
+    const fetchRuntimeEnvironmentRepos = vi.fn().mockResolvedValue([{ id: 'repo-1' }])
+    const fetchWorktrees = vi.fn().mockResolvedValue(true)
+    const fetchWorktreeLineage = vi.fn()
+    let runtimeOnResponse: ((response: unknown) => void) | undefined
+    const runtimeSubscribe = vi.fn(async (_args, callbacks) => {
+      runtimeOnResponse = (callbacks as { onResponse: (response: unknown) => void }).onResponse
+      return { unsubscribe: vi.fn(), sendBinary: vi.fn() }
+    })
+
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return {
+        ...actual,
+        useEffect: (effect: () => void | (() => void)) => {
+          effect()
+        }
+      }
+    })
+
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => ({
+          fetchRepos: vi.fn(),
+          fetchRuntimeEnvironmentRepos,
+          fetchProjectGroups: vi.fn(),
+          fetchWorktrees,
+          fetchWorktreeLineage,
+          // Repo is NOT yet known to the renderer, so ensureRuntimeEventRepoKnown
+          // must discover it via fetchRuntimeEnvironmentRepos before refreshing.
+          repos: [],
+          detectedWorktreesByRepo: {},
+          worktreesByRepo: {},
+          purgeWorktreeTerminalState: vi.fn(),
+          removeWorkspaceSpaceWorktrees: vi.fn(),
+          setUpdateStatus: vi.fn(),
+          activeModal: null,
+          closeModal: vi.fn(),
+          openModal: vi.fn(),
+          getKnownWorktreeById: vi.fn(),
+          activeWorktreeId: null,
+          activeView: 'terminal',
+          setActiveView: vi.fn(),
+          setActiveRepo: vi.fn(),
+          setActiveWorktree: vi.fn(),
+          revealWorktreeInSidebar: vi.fn(),
+          setIsFullScreen: vi.fn(),
+          updateBrowserPageState: vi.fn(),
+          activeTabType: 'terminal',
+          editorFontZoomLevel: 0,
+          setEditorFontZoomLevel: vi.fn(),
+          setRateLimitsFromPush: vi.fn(),
+          setSshConnectionState: vi.fn(),
+          setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
+          enqueueSshCredentialRequest: vi.fn(),
+          removeSshCredentialRequest: vi.fn(),
+          clearTabPtyId: vi.fn(),
+          settings: { activeRuntimeEnvironmentId: 'env-1', terminalFontSize: 13 }
+        })
+      }
+    }))
+
+    vi.doMock('@/lib/ui-zoom', () => ({ applyUIZoom: vi.fn() }))
+    vi.doMock('@/lib/worktree-activation', () => ({
+      activateAndRevealWorktree: vi.fn(),
+      ensureWorktreeHasInitialTerminal: vi.fn()
+    }))
+    vi.doMock('@/components/sidebar/visible-worktrees', () => ({
+      getVisibleWorktreeIds: () => []
+    }))
+    vi.doMock('@/lib/editor-font-zoom', () => ({
+      nextEditorFontZoomLevel: vi.fn(() => 0),
+      computeEditorFontSize: vi.fn(() => 13)
+    }))
+    vi.doMock('@/components/settings/SettingsConstants', () => ({
+      zoomLevelToPercent: vi.fn(() => 100),
+      ZOOM_MIN: -3,
+      ZOOM_MAX: 3
+    }))
+    vi.doMock('@/lib/zoom-events', () => ({ dispatchZoomLevelChanged: vi.fn() }))
+
+    vi.stubGlobal('window', {
+      api: {
+        repos: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
+        runtimeEnvironments: { subscribe: runtimeSubscribe },
+        ui: {
+          onStateChanged: () => () => {},
+          onOpenSettings: () => () => {},
+          onOpenFeatureTour: () => () => {},
+          onToggleLeftSidebar: () => () => {},
+          onToggleRightSidebar: () => () => {},
+          onToggleWorktreePalette: () => () => {},
+          onToggleFloatingTerminal: () => () => {},
+          onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
+          onOpenTasks: () => () => {},
+          onJumpToWorktreeIndex: () => () => {},
+          onJumpToTabIndex: () => () => {},
+          onWorktreeHistoryNavigate: () => () => {},
+          onActivateWorktree: () => () => {},
+          onCreateTerminal: () => () => {},
+          onRequestTerminalCreate: () => () => {},
+          replyTerminalCreate: () => {},
+          onSplitTerminal: () => () => {},
+          onRenameTerminal: () => () => {},
+          onFocusTerminal: () => () => {},
+          onFocusEditorTab: () => () => {},
+          onCloseSessionTab: () => () => {},
+          onMoveSessionTab: () => () => {},
+          onOpenFileFromMobile: () => () => {},
+          onOpenDiffFromMobile: () => () => {},
+          onCloseTerminal: () => () => {},
+          onSleepWorktree: () => () => {},
+          onNewBrowserTab: () => () => {},
+          onNewMarkdownTab: () => () => {},
+          onRequestTabCreate: () => () => {},
+          replyTabCreate: () => {},
+          onRequestTabClose: () => () => {},
+          replyTabClose: () => {},
+          onRequestTabSetProfile: () => () => {},
+          replyTabSetProfile: () => {},
+          onNewTerminalTab: () => () => {},
+          onCloseActiveTab: () => () => {},
+          onSwitchTab: () => () => {},
+          onSwitchTabAcrossAllTypes: () => () => {},
+          onSwitchRecentTab: () => () => {},
+          onSwitchTerminalTab: () => () => {},
+          onToggleStatusBar: () => () => {},
+          onFullscreenChanged: () => () => {},
+          onTerminalZoom: () => () => {},
+          getZoomLevel: () => 0,
+          set: vi.fn()
+        },
+        settings: { onChanged: () => () => {} },
+        updater: {
+          getStatus: () => Promise.resolve({ state: 'idle' }),
+          onStatus: () => () => {},
+          onClearDismissal: () => () => {}
+        },
+        browser: {
+          onGuestLoadFailed: () => () => {},
+          onOpenLinkInOrcaTab: () => () => {},
+          onNavigationUpdate: () => () => {},
+          onActivateView: () => () => {},
+          onPaneFocus: () => () => {}
+        },
+        rateLimits: {
+          get: () => Promise.resolve({ limits: {}, lastUpdatedAt: Date.now() }),
+          onUpdate: () => () => {}
+        },
+        ssh: {
+          listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
+          getState: () => Promise.resolve(null),
+          onStateChanged: () => () => {},
+          onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
+          onCredentialResolved: () => () => {}
+        },
+        runtime: {
+          getTerminalFitOverrides: () => Promise.resolve([]),
+          getTerminalDrivers: () => Promise.resolve([]),
+          getBrowserDrivers: () => Promise.resolve([]),
+          onTerminalFitOverrideChanged: () => () => {},
+          onTerminalDriverChanged: () => () => {},
+          onBrowserDriverChanged: () => () => {}
+        },
+        agentStatus: { onSet: () => () => {} }
+      }
+    })
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (!runtimeOnResponse) {
+      throw new Error('Expected runtime client event callbacks')
+    }
+    runtimeOnResponse({ ok: true, result: { type: 'worktreesChanged', repoId: 'repo-1' } })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // ensureRuntimeEventRepoKnown's discovery fetch is part of the same
+    // worktreesChanged refresh, so it must ride the background lane too.
+    expect(fetchRuntimeEnvironmentRepos).toHaveBeenCalledWith('env-1', { background: true })
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', { background: true })
+  })
+
+  it('keeps runtime activateWorktree on the foreground lane', async () => {
+    const fetchRuntimeEnvironmentRepos = vi.fn().mockResolvedValue([{ id: 'repo-1' }])
+    const fetchWorktrees = vi.fn().mockResolvedValue(true)
+    const fetchWorktreeLineage = vi.fn()
+    let runtimeOnResponse: ((response: unknown) => void) | undefined
+    const runtimeSubscribe = vi.fn(async (_args, callbacks) => {
+      runtimeOnResponse = (callbacks as { onResponse: (response: unknown) => void }).onResponse
+      return { unsubscribe: vi.fn(), sendBinary: vi.fn() }
+    })
+
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return {
+        ...actual,
+        useEffect: (effect: () => void | (() => void)) => {
+          effect()
+        }
+      }
+    })
+
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => ({
+          fetchRepos: vi.fn(),
+          fetchRuntimeEnvironmentRepos,
+          fetchProjectGroups: vi.fn(),
+          fetchWorktrees,
+          fetchWorktreeLineage,
+          repos: [],
+          detectedWorktreesByRepo: {},
+          worktreesByRepo: {},
+          purgeWorktreeTerminalState: vi.fn(),
+          removeWorkspaceSpaceWorktrees: vi.fn(),
+          setUpdateStatus: vi.fn(),
+          activeModal: null,
+          closeModal: vi.fn(),
+          openModal: vi.fn(),
+          getKnownWorktreeById: vi.fn(),
+          activeWorktreeId: null,
+          activeView: 'terminal',
+          setActiveView: vi.fn(),
+          setActiveRepo: vi.fn(),
+          setActiveWorktree: vi.fn(),
+          revealWorktreeInSidebar: vi.fn(),
+          setIsFullScreen: vi.fn(),
+          updateBrowserPageState: vi.fn(),
+          activeTabType: 'terminal',
+          editorFontZoomLevel: 0,
+          setEditorFontZoomLevel: vi.fn(),
+          setRateLimitsFromPush: vi.fn(),
+          setSshConnectionState: vi.fn(),
+          setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
+          enqueueSshCredentialRequest: vi.fn(),
+          removeSshCredentialRequest: vi.fn(),
+          clearTabPtyId: vi.fn(),
+          settings: { activeRuntimeEnvironmentId: 'env-1', terminalFontSize: 13 }
+        })
+      }
+    }))
+
+    vi.doMock('@/lib/ui-zoom', () => ({ applyUIZoom: vi.fn() }))
+    vi.doMock('@/lib/worktree-activation', () => ({
+      activateAndRevealWorktree: vi.fn(),
+      ensureWorktreeHasInitialTerminal: vi.fn()
+    }))
+    vi.doMock('@/components/sidebar/visible-worktrees', () => ({
+      getVisibleWorktreeIds: () => []
+    }))
+    vi.doMock('@/lib/editor-font-zoom', () => ({
+      nextEditorFontZoomLevel: vi.fn(() => 0),
+      computeEditorFontSize: vi.fn(() => 13)
+    }))
+    vi.doMock('@/components/settings/SettingsConstants', () => ({
+      zoomLevelToPercent: vi.fn(() => 100),
+      ZOOM_MIN: -3,
+      ZOOM_MAX: 3
+    }))
+    vi.doMock('@/lib/zoom-events', () => ({ dispatchZoomLevelChanged: vi.fn() }))
+
+    vi.stubGlobal('window', {
+      api: {
+        repos: { onChanged: () => () => {} },
+        worktrees: {
+          onChanged: () => () => {},
+          onBaseStatus: () => () => {},
+          onRemoteBranchConflict: () => () => {}
+        },
+        runtimeEnvironments: { subscribe: runtimeSubscribe },
+        ui: {
+          onStateChanged: () => () => {},
+          onOpenSettings: () => () => {},
+          onOpenFeatureTour: () => () => {},
+          onToggleLeftSidebar: () => () => {},
+          onToggleRightSidebar: () => () => {},
+          onToggleWorktreePalette: () => () => {},
+          onToggleFloatingTerminal: () => () => {},
+          onOpenQuickOpen: () => () => {},
+          onOpenNewWorkspace: () => () => {},
+          onOpenTasks: () => () => {},
+          onJumpToWorktreeIndex: () => () => {},
+          onJumpToTabIndex: () => () => {},
+          onWorktreeHistoryNavigate: () => () => {},
+          onActivateWorktree: () => () => {},
+          onCreateTerminal: () => () => {},
+          onRequestTerminalCreate: () => () => {},
+          replyTerminalCreate: () => {},
+          onSplitTerminal: () => () => {},
+          onRenameTerminal: () => () => {},
+          onFocusTerminal: () => () => {},
+          onFocusEditorTab: () => () => {},
+          onCloseSessionTab: () => () => {},
+          onMoveSessionTab: () => () => {},
+          onOpenFileFromMobile: () => () => {},
+          onOpenDiffFromMobile: () => () => {},
+          onCloseTerminal: () => () => {},
+          onSleepWorktree: () => () => {},
+          onNewBrowserTab: () => () => {},
+          onNewMarkdownTab: () => () => {},
+          onRequestTabCreate: () => () => {},
+          replyTabCreate: () => {},
+          onRequestTabClose: () => () => {},
+          replyTabClose: () => {},
+          onRequestTabSetProfile: () => () => {},
+          replyTabSetProfile: () => {},
+          onNewTerminalTab: () => () => {},
+          onCloseActiveTab: () => () => {},
+          onSwitchTab: () => () => {},
+          onSwitchTabAcrossAllTypes: () => () => {},
+          onSwitchRecentTab: () => () => {},
+          onSwitchTerminalTab: () => () => {},
+          onToggleStatusBar: () => () => {},
+          onFullscreenChanged: () => () => {},
+          onTerminalZoom: () => () => {},
+          getZoomLevel: () => 0,
+          set: vi.fn()
+        },
+        settings: { onChanged: () => () => {} },
+        updater: {
+          getStatus: () => Promise.resolve({ state: 'idle' }),
+          onStatus: () => () => {},
+          onClearDismissal: () => () => {}
+        },
+        browser: {
+          onGuestLoadFailed: () => () => {},
+          onOpenLinkInOrcaTab: () => () => {},
+          onNavigationUpdate: () => () => {},
+          onActivateView: () => () => {},
+          onPaneFocus: () => () => {}
+        },
+        rateLimits: {
+          get: () => Promise.resolve({ limits: {}, lastUpdatedAt: Date.now() }),
+          onUpdate: () => () => {}
+        },
+        ssh: {
+          listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
+          getState: () => Promise.resolve(null),
+          onStateChanged: () => () => {},
+          onCredentialRequest: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
+          onCredentialResolved: () => () => {}
+        },
+        runtime: {
+          getTerminalFitOverrides: () => Promise.resolve([]),
+          getTerminalDrivers: () => Promise.resolve([]),
+          getBrowserDrivers: () => Promise.resolve([]),
+          onTerminalFitOverrideChanged: () => () => {},
+          onTerminalDriverChanged: () => () => {},
+          onBrowserDriverChanged: () => () => {}
+        },
+        agentStatus: { onSet: () => () => {} }
+      }
+    })
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (!runtimeOnResponse) {
+      throw new Error('Expected runtime client event callbacks')
+    }
+    runtimeOnResponse({
+      ok: true,
+      result: { type: 'activateWorktree', repoId: 'repo-1', worktreeId: 'wt-1' }
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // activateWorktree carries user-facing intent (a CLI-created worktree the
+    // user wants revealed immediately), so its fetches must stay on the
+    // foreground lane — never silently demoted to background by the shared
+    // ensureRuntimeEventRepoKnown helper.
+    // No options object (undefined) means the call defaults to the foreground
+    // lane — the opposite of the worktreesChanged path's { background: true }.
+    expect(fetchRuntimeEnvironmentRepos).toHaveBeenCalledWith('env-1', undefined)
+    expect(fetchRuntimeEnvironmentRepos).not.toHaveBeenCalledWith('env-1', { background: true })
     expect(fetchWorktrees).toHaveBeenCalledWith('repo-1')
-    expect(fetchWorktreeLineage).toHaveBeenCalledTimes(1)
+    expect(fetchWorktrees).not.toHaveBeenCalledWith('repo-1', { background: true })
   })
 })
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -765,7 +765,10 @@ export function getRuntimeProjectRefreshEnvironmentIds(args: {
   ]
 }
 
-async function refreshRuntimeProjectWorktrees(repos: readonly { id: string }[]): Promise<void> {
+async function refreshRuntimeProjectWorktrees(
+  repos: readonly { id: string }[],
+  options?: { background?: boolean }
+): Promise<void> {
   let nextIndex = 0
   const failures: { repoId: string; error: unknown }[] = []
   const workerCount = Math.min(RUNTIME_PROJECT_REFRESH_CONCURRENCY, repos.length)
@@ -779,7 +782,7 @@ async function refreshRuntimeProjectWorktrees(repos: readonly { id: string }[]):
         nextIndex += 1
         const repoId = repos[index].id
         try {
-          await useAppStore.getState().fetchWorktrees(repoId)
+          await useAppStore.getState().fetchWorktrees(repoId, options)
         } catch (error) {
           failures.push({ repoId, error })
         }
@@ -841,8 +844,11 @@ export function useIpcEvents(): void {
       const before =
         getAuthoritativeDetectedWorktreeIds(state, repoId) ??
         getVisibleWorktreeIdsForRepo(state, repoId)
-      await state.fetchWorktrees(repoId)
-      await useAppStore.getState().fetchWorktreeLineage()
+      // Why: worktreesChanged is server-pushed (not user-initiated), same as
+      // reposChanged — ride the background lane so a multi-server worktree
+      // storm yields transport capacity to the foreground.
+      await state.fetchWorktrees(repoId, { background: true })
+      await useAppStore.getState().fetchWorktreeLineage({ background: true })
       // Why: changing the worktree's id unmounts the active pane without
       // re-rendering it under the new id. Now that the list has refreshed,
       // re-activate the renamed worktree so its tab model reconciles and the
@@ -926,19 +932,25 @@ export function useIpcEvents(): void {
 
     const ensureRuntimeEventRepoKnown = async (
       environmentId: string,
-      repoId: string
+      repoId: string,
+      options?: { background?: boolean }
     ): Promise<void> => {
       if ((useAppStore.getState().repos ?? []).some((repo) => repo.id === repoId)) {
         return
       }
-      await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
+      await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId, options)
     }
 
     const runtimeProjectRefreshScheduler = createRuntimeProjectRefreshScheduler({
       refresh: async (environmentId) => {
-        const repos = await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
-        await refreshRuntimeProjectWorktrees(repos)
-        await useAppStore.getState().fetchWorktreeLineage()
+        // Why: this event-driven project refresh rides the background lane so a
+        // per-server refresh storm yields transport capacity to user-initiated
+        // runtime calls instead of competing on the foreground lane.
+        const repos = await useAppStore
+          .getState()
+          .fetchRuntimeEnvironmentRepos(environmentId, { background: true })
+        await refreshRuntimeProjectWorktrees(repos, { background: true })
+        await useAppStore.getState().fetchWorktreeLineage({ background: true })
       },
       onError: (error) => {
         console.error('Failed to refresh runtime projects:', error)
@@ -951,9 +963,12 @@ export function useIpcEvents(): void {
         return
       }
       if (event.type === 'worktreesChanged') {
-        void ensureRuntimeEventRepoKnown(environmentId, event.repoId).then(() =>
-          worktreeChangeRefreshQueue.enqueue({ repoId: event.repoId })
-        )
+        // Why: repo discovery here is part of the background worktree refresh,
+        // so it rides the background lane too. The activateWorktree path below
+        // keeps the default foreground lane for its user-facing reveal.
+        void ensureRuntimeEventRepoKnown(environmentId, event.repoId, {
+          background: true
+        }).then(() => worktreeChangeRefreshQueue.enqueue({ repoId: event.repoId }))
         return
       }
       if (event.type === 'linearLinkedIssueUpdated') {

--- a/src/renderer/src/runtime/runtime-rpc-client.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   callRuntimeRpc,
   assertRuntimeEnvironmentCapability,
   clearRuntimeCompatibilityCacheForTests,
   getActiveRuntimeTarget,
+  markRuntimeEnvironmentCompatible,
   RuntimeRpcCallError,
   unwrapRuntimeRpcResult
 } from './runtime-rpc-client'
@@ -301,5 +302,60 @@ describe('runtime RPC client routing', () => {
       expect((error as RuntimeRpcCallError).code).toBe('method_not_found')
       expect((error as RuntimeRpcCallError).response).toBe(failure)
     }
+  })
+})
+
+describe('callRuntimeRpc background flag', () => {
+  const callMock = vi.fn()
+
+  beforeEach(() => {
+    clearRuntimeCompatibilityCacheForTests()
+    callMock.mockReset()
+    callMock.mockResolvedValue({
+      id: 'rpc',
+      ok: true,
+      result: { repos: [] },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    ;(globalThis as { window?: unknown }).window = {
+      api: {
+        runtimeEnvironments: { call: callMock },
+        runtime: { call: vi.fn() }
+      }
+    }
+  })
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window
+  })
+
+  it('forwards background to runtimeEnvironments.call for an environment target', async () => {
+    // Cache compatibility so the status.get probe does not run for this test.
+    markRuntimeEnvironmentCompatible('env-1')
+    await callRuntimeRpc({ kind: 'environment', environmentId: 'env-1' }, 'repo.list', undefined, {
+      background: true,
+      timeoutMs: 15_000
+    })
+    expect(callMock).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'repo.list',
+      params: undefined,
+      timeoutMs: 15_000,
+      background: true
+    })
+  })
+
+  it('omits background when not provided (undefined)', async () => {
+    markRuntimeEnvironmentCompatible('env-1')
+    await callRuntimeRpc({ kind: 'environment', environmentId: 'env-1' }, 'repo.list', undefined, {
+      timeoutMs: 15_000
+    })
+    expect(callMock).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'repo.list',
+      params: undefined,
+      timeoutMs: 15_000,
+      background: undefined
+    })
   })
 })

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -47,7 +47,11 @@ export async function callRuntimeRpc<TResult>(
   target: RuntimeClientTarget,
   method: string,
   params?: unknown,
-  options: { timeoutMs?: number; suppressFeatureInteraction?: boolean } = {}
+  options: {
+    timeoutMs?: number
+    suppressFeatureInteraction?: boolean
+    background?: boolean
+  } = {}
 ): Promise<TResult> {
   if (target.kind === 'environment' && method !== 'status.get') {
     await ensureRuntimeEnvironmentCompatible(target.environmentId, options.timeoutMs)
@@ -60,7 +64,10 @@ export async function callRuntimeRpc<TResult>(
           selector: target.environmentId,
           method,
           params: nextParams,
-          timeoutMs: options.timeoutMs
+          timeoutMs: options.timeoutMs,
+          // Why: only the event-driven refresh storm opts in; user-initiated calls
+          // to the same method leave background undefined and stay foreground.
+          background: options.background
         })
   return unwrapRuntimeRpcResult<TResult>(response as RuntimeRpcResponse<TResult>)
 }

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -328,7 +328,8 @@ function setupWithFetchedOwner(
 
 async function fetchProjectHostSetupCompatibility(
   target: ReturnType<typeof getActiveRuntimeTarget>,
-  repos: readonly Repo[]
+  repos: readonly Repo[],
+  options?: { background?: boolean }
 ): Promise<ProjectHostSetupProjection> {
   try {
     if (target.kind === 'local') {
@@ -351,10 +352,12 @@ async function fetchProjectHostSetupCompatibility(
     await assertProjectHostSetupRuntimeCapability(target)
     const [projectResponse, setupResponse] = await Promise.all([
       callRuntimeRpc<{ projects: Project[] }>(target, 'project.list', undefined, {
-        timeoutMs: 15_000
+        timeoutMs: 15_000,
+        background: options?.background
       }),
       callRuntimeRpc<{ setups: ProjectHostSetup[] }>(target, 'projectHostSetup.list', undefined, {
-        timeoutMs: 15_000
+        timeoutMs: 15_000,
+        background: options?.background
       })
     ])
     return {
@@ -789,7 +792,8 @@ function mergeFetchedFolderWorkspacesForHost({
 
 async function fetchReposForTarget(
   target: ReturnType<typeof getActiveRuntimeTarget>,
-  currentRepos: readonly Repo[]
+  currentRepos: readonly Repo[],
+  options?: { background?: boolean }
 ): Promise<{
   repos: Repo[]
   projectCompatibility: Pick<RepoSlice, 'projects' | 'projectHostSetups'>
@@ -800,12 +804,17 @@ async function fetchReposForTarget(
       ? await window.api.repos.list()
       : (
           await callRuntimeRpc<{ repos: Repo[] }>(target, 'repo.list', undefined, {
-            timeoutMs: 15_000
+            timeoutMs: 15_000,
+            background: options?.background
           })
         ).repos
   const hostId = getRuntimeTargetHostId(target)
   const repos = fetchedRepos.map((repo) => repoWithFetchedOwner(repo, target))
-  const fetchedProjectCompatibility = await fetchProjectHostSetupCompatibility(target, repos)
+  const fetchedProjectCompatibility = await fetchProjectHostSetupCompatibility(
+    target,
+    repos,
+    options
+  )
   const reconciledRepos = mergeFetchedReposForHost(currentRepos, repos, hostId)
   const projectCompatibility =
     target.kind === 'local'
@@ -1034,7 +1043,10 @@ export type RepoSlice = {
   activeRepoId: string | null
   fetchRepos: () => Promise<void>
   fetchReposForAllHosts: () => Promise<void>
-  fetchRuntimeEnvironmentRepos: (environmentId: string) => Promise<Repo[]>
+  fetchRuntimeEnvironmentRepos: (
+    environmentId: string,
+    options?: { background?: boolean }
+  ) => Promise<Repo[]>
   fetchProjectGroups: () => Promise<void>
   fetchProjectGroupsForAllHosts: () => Promise<void>
   fetchFolderWorkspaces: () => Promise<void>
@@ -1187,14 +1199,14 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  fetchRuntimeEnvironmentRepos: async (environmentId) => {
+  fetchRuntimeEnvironmentRepos: async (environmentId, options) => {
     try {
       const target = { kind: 'environment' as const, environmentId }
       const {
         repos: reconciledRepos,
         projectCompatibility,
         hostId
-      } = await fetchReposForTarget(target, get().repos)
+      } = await fetchReposForTarget(target, get().repos, options)
       const validRepoIds = new Set(reconciledRepos.map((repo) => repo.id))
       set((s) => {
         const mergedProjectCompatibility = mergeFetchedProjectCompatibilityForHost({

--- a/src/renderer/src/store/slices/runtime-environment-repos-background.test.ts
+++ b/src/renderer/src/store/slices/runtime-environment-repos-background.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callRuntimeRpcMock = vi.fn()
+
+vi.mock('../../runtime/runtime-rpc-client', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    callRuntimeRpc: (...args: unknown[]) => callRuntimeRpcMock(...args)
+  }
+})
+
+describe('fetchRuntimeEnvironmentRepos background option', () => {
+  beforeEach(() => {
+    callRuntimeRpcMock.mockReset()
+    callRuntimeRpcMock.mockImplementation((_target: unknown, method: string) => {
+      if (method === 'repo.list') {
+        return Promise.resolve({ repos: [] })
+      }
+      if (method === 'project.list') {
+        return Promise.resolve({ projects: [] })
+      }
+      if (method === 'projectHostSetup.list') {
+        return Promise.resolve({ setups: [] })
+      }
+      return Promise.resolve({})
+    })
+    // Why: assertProjectHostSetupRuntimeCapability calls window.api.runtimeEnvironments.call
+    // directly for the status probe — mock it with a valid protocol version and capability.
+    const runtimeEnvironmentCallMock = vi.fn().mockResolvedValue({
+      id: 'status',
+      ok: true,
+      result: {
+        runtimeId: 'runtime-1',
+        runtimeProtocolVersion: 3,
+        minCompatibleRuntimeClientVersion: 2,
+        capabilities: ['project-host-setup.v1']
+      },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    ;(globalThis as { window?: unknown }).window = {
+      api: { runtimeEnvironments: { call: runtimeEnvironmentCallMock } }
+    }
+  })
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window
+    vi.restoreAllMocks()
+  })
+
+  it('forwards background:true to repo.list/project.list/projectHostSetup.list', async () => {
+    const { createTestStore } = await import('./store-test-helpers')
+    const store = createTestStore()
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1', { background: true })
+
+    const repoListCall = callRuntimeRpcMock.mock.calls.find((c) => c[1] === 'repo.list')
+    const projectListCall = callRuntimeRpcMock.mock.calls.find((c) => c[1] === 'project.list')
+    const setupListCall = callRuntimeRpcMock.mock.calls.find(
+      (c) => c[1] === 'projectHostSetup.list'
+    )
+    expect(repoListCall?.[3]).toMatchObject({ background: true })
+    expect(projectListCall?.[3]).toMatchObject({ background: true })
+    expect(setupListCall?.[3]).toMatchObject({ background: true })
+  })
+
+  it('defaults to foreground (background undefined) when no option is given', async () => {
+    const { createTestStore } = await import('./store-test-helpers')
+    const store = createTestStore()
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+    const repoListCall = callRuntimeRpcMock.mock.calls.find((c) => c[1] === 'repo.list')
+    expect(repoListCall?.[3]?.background).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -111,9 +111,12 @@ export type WorktreeSlice = {
    */
   hasHydratedWorktreePurge: boolean
   fetchDetectedWorktrees: (repoId: string) => Promise<DetectedWorktreeListResult | null>
-  fetchWorktrees: (repoId: string, options?: { requireAuthoritative?: boolean }) => Promise<boolean>
+  fetchWorktrees: (
+    repoId: string,
+    options?: { requireAuthoritative?: boolean; background?: boolean }
+  ) => Promise<boolean>
   fetchAllWorktrees: () => Promise<void>
-  fetchWorktreeLineage: () => Promise<void>
+  fetchWorktreeLineage: (options?: { background?: boolean }) => Promise<void>
   updateWorktreeLineage: (
     worktreeId: string,
     args: { parentWorktreeId?: string; noParent?: boolean }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -725,6 +725,35 @@ describe('fetchWorktrees', () => {
     expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
   })
 
+  it('forwards the background flag to both the detected-list and best-effort lineage calls', async () => {
+    const store = createTestStore()
+    const remote = makeWorktree({
+      id: 'repo1::/remote/wt1',
+      repoId: 'repo1',
+      path: '/remote/wt1',
+      branch: 'refs/heads/remote'
+    })
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: makeDetectedResult('repo1', [remote]),
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+
+    await store.getState().fetchWorktrees('repo1', { background: true })
+
+    // Both the worktree scan and the best-effort lineage follow-up must ride the
+    // background lane; the lineage call is the one that previously leaked onto
+    // the foreground lane.
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'worktree.detectedList', background: true })
+    )
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'worktree.lineageList', background: true })
+    )
+  })
+
   it('fetches SSH repo worktrees through local IPC even when a runtime is focused', async () => {
     const store = createTestStore()
     const sshWorktree = makeWorktree({
@@ -1165,6 +1194,31 @@ describe('worktree lineage state', () => {
     })
     expect(mockApi.worktrees.listLineage).not.toHaveBeenCalled()
     expect(store.getState().worktreeLineageById).toEqual({ [lineage.worktreeId]: lineage })
+  })
+
+  it('forwards the background flag to the remote lineage call', async () => {
+    const store = createTestStore()
+    const lineage = makeLineage()
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-lineage-list',
+      ok: true,
+      result: { lineage: { [lineage.worktreeId]: lineage } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: {}
+    } as Partial<AppState>)
+
+    await store.getState().fetchWorktreeLineage({ background: true })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: 'env-1',
+        method: 'worktree.lineageList',
+        background: true
+      })
+    )
   })
 
   it('updates lineage through the active remote runtime environment', async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -791,7 +791,8 @@ function settingsForWorktreeOwner(
 
 async function listDetectedWorktreesForRepo(
   settings: AppState['settings'],
-  repoId: string
+  repoId: string,
+  options?: { background?: boolean }
 ): Promise<DetectedWorktreeListResult> {
   const target = getActiveRuntimeTarget(settings)
   if (target.kind === 'local') {
@@ -809,7 +810,7 @@ async function listDetectedWorktreesForRepo(
       target,
       'worktree.detectedList',
       { repo: repoId },
-      { timeoutMs: 15_000 }
+      { timeoutMs: 15_000, background: options?.background }
     )
   } catch (error) {
     if (!isRuntimeMethodNotFoundError(error)) {
@@ -819,13 +820,16 @@ async function listDetectedWorktreesForRepo(
       target,
       'worktree.list',
       { repo: repoId, limit: REMOTE_WORKTREE_LIST_PARITY_LIMIT },
-      { timeoutMs: 15_000 }
+      { timeoutMs: 15_000, background: options?.background }
     )
     return toLegacyDetectedWorktreeResult(repoId, legacy)
   }
 }
 
-async function listWorktreeLineageForRuntime(settings: AppState['settings']): Promise<{
+async function listWorktreeLineageForRuntime(
+  settings: AppState['settings'],
+  options?: { background?: boolean }
+): Promise<{
   worktreeLineageById: Record<string, WorktreeLineage>
   workspaceLineageByChildKey: Record<string, WorkspaceLineage>
 }> {
@@ -852,7 +856,10 @@ async function listWorktreeLineageForRuntime(settings: AppState['settings']): Pr
     await callRuntimeRpc<{
       lineage: Record<string, WorktreeLineage>
       workspaceLineage?: Record<string, WorkspaceLineage>
-    }>(target, 'worktree.lineageList', undefined, { timeoutMs: 15_000 })
+    }>(target, 'worktree.lineageList', undefined, {
+      timeoutMs: 15_000,
+      background: options?.background
+    })
   )
 }
 
@@ -958,9 +965,10 @@ function applyWorktreeLineageUpdate(
 
 async function refreshWorktreeLineageForSettings(
   settings: AppState['settings'],
-  set: Parameters<StateCreator<AppState>>[0]
+  set: Parameters<StateCreator<AppState>>[0],
+  options?: { background?: boolean }
 ): Promise<void> {
-  const lineage = await listWorktreeLineageForRuntime(settings)
+  const lineage = await listWorktreeLineageForRuntime(settings, options)
   const hostId = getSettingsFocusedExecutionHostId(settings)
   set((s) => ({
     worktreeLineageById: mergeLineageForHost(s, hostId, lineage.worktreeLineageById),
@@ -974,13 +982,14 @@ async function refreshWorktreeLineageForSettings(
 
 async function refreshRemoteWorktreeLineageBestEffort(
   settings: AppState['settings'],
-  set: (partial: Partial<AppState> | ((state: AppState) => Partial<AppState>)) => void
+  set: (partial: Partial<AppState> | ((state: AppState) => Partial<AppState>)) => void,
+  options?: { background?: boolean }
 ): Promise<void> {
   if (getActiveRuntimeTarget(settings).kind === 'local') {
     return
   }
   try {
-    const lineage = await listWorktreeLineageForRuntime(settings)
+    const lineage = await listWorktreeLineageForRuntime(settings, options)
     const hostId = getSettingsFocusedExecutionHostId(settings)
     set((s) => ({
       worktreeLineageById: mergeLineageForHost(s, hostId, lineage.worktreeLineageById),
@@ -1709,7 +1718,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const ownerState = get()
       const hostId = repoHostId(ownerState, repoId)
       const settings = settingsForRepoOwner(ownerState, repoId, hostId)
-      const detected = await listDetectedWorktreesForRepo(settings, repoId)
+      const detected = await listDetectedWorktreesForRepo(settings, repoId, {
+        background: options?.background
+      })
       if (options?.requireAuthoritative && !detected.authoritative) {
         return false
       }
@@ -1761,7 +1772,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ...(removedIds.length > 0 ? buildWorktreePurgeState(s, removedIds) : {})
           }
         })
-        await refreshRemoteWorktreeLineageBestEffort(settings, set)
+        await refreshRemoteWorktreeLineageBestEffort(settings, set, {
+          background: options?.background
+        })
         return detected.authoritative
       }
 
@@ -1816,7 +1829,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           ...(removedIds.length > 0 ? buildWorktreePurgeState(s, removedIds) : {})
         }
       })
-      await refreshRemoteWorktreeLineageBestEffort(settings, set)
+      await refreshRemoteWorktreeLineageBestEffort(settings, set, {
+        background: options?.background
+      })
       return detected.authoritative
     } catch (err) {
       console.error(`Failed to fetch worktrees for repo ${repoId}:`, err)
@@ -1975,11 +1990,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     set({ hasHydratedWorktreePurge: true })
   },
 
-  fetchWorktreeLineage: async () => {
+  fetchWorktreeLineage: async (options) => {
     try {
       // Why: lineage is a focused-host refresh — fetch from the focused host and
       // host-merge so other hosts' previously fetched lineage is preserved.
-      await refreshWorktreeLineageForSettings(get().settings, set)
+      await refreshWorktreeLineageForSettings(get().settings, set, options)
     } catch (err) {
       console.error('Failed to fetch worktree lineage:', err)
     }

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -2878,3 +2878,66 @@ describe('web GitLab preload API', () => {
     ])
   })
 })
+
+describe('web runtimeEnvironments background lane parity', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.doUnmock('./web-runtime-client')
+    vi.restoreAllMocks()
+  })
+
+  it('demotes an explicit-background runtimeEnvironments.call behind a foreground call', async () => {
+    const started: string[] = []
+    const pending: ((value: RuntimeRpcResponse<unknown>) => void)[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        async call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          started.push(method)
+          if (method === 'repo.list') {
+            return await new Promise((resolve) => pending.push(resolve))
+          }
+          return {
+            id: `call-${started.length}`,
+            ok: true,
+            result: {},
+            _meta: { runtimeId: 'runtime-1' }
+          }
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const selector = 'web-env-1' // id written by writeStoredRuntimeEnvironment
+    const demoted = globals.window.api.runtimeEnvironments.call({
+      selector,
+      method: 'repo.list',
+      background: true
+    })
+    await vi.waitFor(() => expect(started).toEqual(['repo.list']))
+
+    // A foreground call must overtake the in-flight-capped background repo.list.
+    const foreground = await globals.window.api.runtimeEnvironments.call({
+      selector,
+      method: 'terminal.send'
+    })
+    expect(foreground).toMatchObject({ ok: true })
+    expect(started).toEqual(['repo.list', 'terminal.send'])
+
+    pending.shift()?.({
+      id: 'repo-list',
+      ok: true,
+      result: {},
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    await expect(demoted).resolves.toMatchObject({ ok: true })
+  })
+})

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1027,8 +1027,8 @@ function createRuntimeEnvironmentsApi(): NonNullable<Partial<PreloadApi>['runtim
     },
     getStatus: ({ selector, timeoutMs }) =>
       callEnvironmentEnvelope<RuntimeStatus>(selector, 'status.get', undefined, timeoutMs),
-    call: ({ selector, method, params, timeoutMs }) =>
-      callEnvironmentEnvelope(selector, method, params, timeoutMs),
+    call: ({ selector, method, params, timeoutMs, background }) =>
+      callEnvironmentEnvelope(selector, method, params, timeoutMs, background),
     subscribe: async ({ selector, method, params, timeoutMs }, callbacks) => {
       const environment = resolveEnvironment(selector)
       const client = getClientForEnvironment(environment)
@@ -2508,11 +2508,17 @@ async function callEnvironmentEnvelope<TResult = unknown>(
   selector: string,
   method: string,
   params?: unknown,
-  timeoutMs?: number
+  timeoutMs?: number,
+  background?: boolean
 ): Promise<RuntimeRpcResponse<TResult>> {
   const environment = resolveEnvironment(selector)
-  const response = await runtimeCallQueuePool.enqueue(environment.id, method, () =>
-    getClientForEnvironment(environment).call(method, params, { timeoutMs })
+  // Why: web shares the same RuntimeRpcCallQueuePool, so forwarding the flag keeps
+  // background-lane behavior identical to desktop for cross-env refresh calls.
+  const response = await runtimeCallQueuePool.enqueue(
+    environment.id,
+    method,
+    () => getClientForEnvironment(environment).call(method, params, { timeoutMs }),
+    { background }
   )
   updateEnvironmentFromResponse(environment, response)
   return response as RuntimeRpcResponse<TResult>

--- a/src/shared/runtime-rpc-call-queue.test.ts
+++ b/src/shared/runtime-rpc-call-queue.test.ts
@@ -79,4 +79,90 @@ describe('runtime RPC call queue', () => {
     )
     expect(started).toEqual(Array.from({ length: 71 }, (_, index) => index))
   })
+
+  it('routes an explicit background flag to the background lane for a foreground method', async () => {
+    const queue = new RuntimeRpcCallQueuePool(2, 1)
+    const started: string[] = []
+    const pending: ((value: string) => void)[] = []
+    const enqueuePending = (
+      method: string,
+      label: string,
+      options?: { background?: boolean }
+    ): Promise<string> =>
+      queue.enqueue(
+        'web-runtime',
+        method,
+        async () => {
+          started.push(label)
+          return await new Promise<string>((resolve) => pending.push(resolve))
+        },
+        options
+      )
+
+    // repo.list is NOT a background method, but the explicit flag forces the background lane.
+    const demoted = enqueuePending('repo.list', 'demoted', { background: true })
+    const otherBackground = enqueuePending('hostedReview.forBranch', 'other-background')
+    await vi.waitFor(() => expect(started).toEqual(['demoted']))
+
+    const foreground = queue.enqueue('web-runtime', 'terminal.send', async () => {
+      started.push('foreground')
+      return 'foreground'
+    })
+    await expect(foreground).resolves.toBe('foreground')
+    // The demoted repo.list is starved behind the foreground call, proving it took the background lane.
+    expect(started).toEqual(['demoted', 'foreground'])
+
+    pending.shift()?.('demoted')
+    await expect(demoted).resolves.toBe('demoted')
+    await vi.waitFor(() => expect(started).toEqual(['demoted', 'foreground', 'other-background']))
+    pending.shift()?.('other-background')
+    await expect(otherBackground).resolves.toBe('other-background')
+  })
+
+  it('honors an explicit foreground flag overriding a background method', async () => {
+    const queue = new RuntimeRpcCallQueuePool(2, 1)
+    const started: string[] = []
+    const pending: ((value: string) => void)[] = []
+    const background = queue.enqueue('web-runtime', 'github.prForBranch', async () => {
+      started.push('background')
+      return await new Promise<string>((resolve) => pending.push(resolve))
+    })
+    await vi.waitFor(() => expect(started).toEqual(['background']))
+
+    // git.status classifies as background, but background:false forces the foreground lane,
+    // so it runs immediately rather than being capped behind the in-flight background slot.
+    const forcedForeground = queue.enqueue(
+      'web-runtime',
+      'git.status',
+      async () => {
+        started.push('forced-foreground')
+        return 'forced-foreground'
+      },
+      { background: false }
+    )
+    await expect(forcedForeground).resolves.toBe('forced-foreground')
+    expect(started).toEqual(['background', 'forced-foreground'])
+
+    pending.shift()?.('background')
+    await expect(background).resolves.toBe('background')
+  })
+
+  it('falls back to method classification when no background option is given', async () => {
+    const queue = new RuntimeRpcCallQueuePool(2, 1)
+    const started: string[] = []
+    const background = queue.enqueue('web-runtime', 'github.prForBranch', async () => {
+      started.push('background')
+      return await new Promise<string>(() => {})
+    })
+    await vi.waitFor(() => expect(started).toEqual(['background']))
+
+    // repo.list with no options stays foreground (fallback unchanged), so it runs immediately.
+    const foreground = queue.enqueue('web-runtime', 'repo.list', async () => {
+      started.push('foreground')
+      return 'foreground'
+    })
+    await expect(foreground).resolves.toBe('foreground')
+    expect(started).toEqual(['background', 'foreground'])
+    void background
+  })
 })

--- a/src/shared/runtime-rpc-call-queue.ts
+++ b/src/shared/runtime-rpc-call-queue.ts
@@ -40,11 +40,19 @@ export class RuntimeRpcCallQueuePool {
     private readonly backgroundConcurrency = DEFAULT_REMOTE_RUNTIME_BACKGROUND_CALL_CONCURRENCY
   ) {}
 
-  enqueue<T>(selector: string, method: string, run: () => Promise<T>): Promise<T> {
+  enqueue<T>(
+    selector: string,
+    method: string,
+    run: () => Promise<T>,
+    options?: { background?: boolean }
+  ): Promise<T> {
     const queue = this.getQueue(selector)
     return new Promise<T>((resolve, reject) => {
       const call: QueuedRuntimeCall<T> = {
-        background: isBackgroundRuntimeMethod(method),
+        // Why: per-call-site demotion wins so the event-driven refresh storm yields
+        // the foreground lane, while same-method user actions stay foreground; absent
+        // the flag we keep the existing method-name classification.
+        background: options?.background ?? isBackgroundRuntimeMethod(method),
         run,
         resolve,
         reject


### PR DESCRIPTION
## Summary

Runtime RPC calls are sorted onto a foreground/background lane by method name
(`isBackgroundRuntimeMethod`). The event-driven project refresh fired by
server-pushed client events — `reposChanged` fanning out to repos, worktrees,
and lineage, and `worktreesChanged` refreshing worktrees, lineage, and (for an
unknown repo) discovery — fires methods (`repo.list`, `project.list`,
`worktree.detectedList`, `worktree.lineageList`) that are **not** on that list,
so the refresh storm lands on the foreground lane and competes with
user-initiated calls for transport capacity. With several remote servers
connected this is a visible jank source on every remote event.

This adds a per-call `background` override that flows end-to-end through the RPC
call queue → main call routing → renderer/preload/web call paths → renderer
fetch helpers. The queue keeps the existing method-name classification as the
default and lets a call site opt in:

```ts
background: options?.background ?? isBackgroundRuntimeMethod(method)
```

Both server-pushed refresh paths are then routed through it:

- the `runtimeProjectRefreshScheduler` refresh for `reposChanged` (repos +
  worktrees + best-effort lineage), and
- the `worktreesChanged` refresh (worktrees + lineage, plus its
  `ensureRuntimeEventRepoKnown` repo discovery) — the same `runtime.clientEvents`
  stream, treated symmetrically.

**No change to *what* is refreshed — only *which lane*,** so the all-host
project model still refreshes every connected environment exactly as before.

## Screenshots

No visual change.

## Testing

Rebased onto latest `origin/main` (v1.4.98-rc.1); the rebase is clean (no conflicts).

- [x] `pnpm lint` — clean (oxlint type-aware + localization catalog/parity all pass)
- [x] `pnpm typecheck` — green (3 tsgo projects)
- [x] `pnpm test` — full suite on the rebased base: **20735 passed, 23 failed,
  75 skipped**. All 23 failures are pre-existing and live in files this PR does
  not touch (verified zero overlap with the changed file set — git-handler,
  omp-shell-wrapper, automation-schedules, pr-comment `localStorage`,
  Linear/SidebarToolbar, hook-service). The 7 changed/affected test files pass
  329/329 in a focused run.
- [x] `pnpm build` — green on the rebased base (desktop web bundle built in ~35s;
  native build is a no-op on Linux). Only a pre-existing chunk-size advisory, no errors.
- [x] Added or updated high-quality tests that would catch regressions:
  - per-call override + background-lane saturation/yield (`runtime-rpc-call-queue.test.ts`)
  - flag forwarding through main routing, renderer client, and the web envelope
  - `fetchWorktrees(..., { background: true })` carries `background: true` on
    **both** `worktree.detectedList` and the best-effort `worktree.lineageList`
  - the `reposChanged` scheduler refresh issues repos + worktrees + lineage all
    with `{ background: true }` (`useIpcEvents.test.ts`)
  - the `worktreesChanged` refresh + its repo discovery ride the background lane,
    while the `activateWorktree` reveal path stays on the foreground lane
    (`useIpcEvents.test.ts`)

## AI Review Report

Reviewed with multiple independent AI passes. Risks checked: flag continuity
across every layer (queue → main → preload → web → renderer); the three lane
cases (explicit `true` demotes, explicit `false` forces foreground, `undefined`
falls back to method classification); and that no active-only / single-env gate
was introduced that would break the all-host project model. Two real issues were
caught and fixed during review:

- `fetchWorktrees`'s best-effort lineage follow-up
  (`refreshRemoteWorktreeLineageBestEffort`) was not forwarding `background`, so
  the event-driven refresh still issued a foreground `worktree.lineageList`; it
  now threads the flag and a regression test guards both lineage call sites.
- the `worktreesChanged` refresh was still entirely on the foreground lane while
  the sibling `reposChanged` refresh was demoted — an asymmetry in the same
  client-event handler. The `worktreesChanged` worktrees/lineage refresh and its
  repo discovery now ride the background lane too, with the `activateWorktree`
  reveal path kept on the foreground lane (it carries user-facing intent) via an
  explicit option on the shared `ensureRuntimeEventRepoKnown` helper. Symmetric
  tests lock both lanes.

Cross-platform: no platform-specific paths are touched — the change is shared RPC
plumbing plus renderer store logic, with no OS-specific shortcuts, labels, path
handling, or shell behavior. The `background` flag rides the existing call
envelope used identically on macOS, Linux, and Windows.

## Security Audit

The only new data crossing the IPC boundary is an optional boolean `background`
flag on the runtime call envelope. It is not user input; it carries no path,
command, secret, or auth material; and it only selects which in-process queue
lane a call uses — it cannot change the selector, method, or params. No new input
handling, command execution, or dependency surface. No follow-up needed.

## Notes

- **Scope**: both server-pushed event-driven refreshes — the `reposChanged`
  scheduler refresh and the `worktreesChanged` refresh (list + lineage + repo
  discovery) — are demoted to the background lane, treated symmetrically since
  they share the same `runtime.clientEvents` stream. User-initiated calls, the
  `activateWorktree` reveal path (a CLI-created worktree the user wants shown
  immediately), and the `status.get` control-plane compatibility probe stay on
  the foreground lane on purpose — the probe gates connection/compatibility UI
  and should not yield.
- **Known limitation (pre-existing, out of scope)**: the event-driven refresh
  resolves the target host from focused settings rather than the event's
  `environmentId`, and repo discovery matches on the bare `repo.id`, so two
  servers sharing a repo id can cross-refresh. This is existing behavior — not
  introduced here — and is being addressed by the upstream host-qualified
  identity stack (#6030 / #6031 / #6096); moving these refreshes onto the
  background lane does not change it.
- **Interacts with #5266** (stale-worktree-refresh guard): that PR adds a
  request-id staleness guard to the same `fetchWorktrees`. Routing these callers
  onto the (slower) background lane widens the stale-overwrite window #5266
  addresses, and the two conflict textually in `worktrees.ts`. Whichever lands
  second should reconcile so the background path is also covered by the
  staleness guard.

## ELI5

Event-driven project refresh RPC was treated as foreground work and could stall the UI during storms of change events. Those refreshes use a dedicated background lane.
