### PR TITLE
feat: open worktree with default agent instead of terminal

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -150,7 +150,8 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
     appFontFamily,
     agentStatusHooksEnabled,
-    tabAutoGenerateTitle
+    tabAutoGenerateTitle,
+    openWorktreeWithAgent: overrides.openWorktreeWithAgent ?? false
   }
 }
 

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -154,7 +154,8 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
     appFontFamily,
     agentStatusHooksEnabled,
-    tabAutoGenerateTitle
+    tabAutoGenerateTitle,
+    openWorktreeWithAgent: overrides.openWorktreeWithAgent ?? false
   }
 }
 

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -838,6 +838,26 @@ export function AgentsPane({
         wslCapabilitiesLoading={wslCapabilitiesLoading}
       />
 
+      {/* Why: only show the "open with agent" toggle when the user has picked a
+          concrete default agent. With Auto or blank, launching on worktree
+          click would either be unpredictable (Auto) or a no-op (blank). */}
+      {defaultAgent !== null && defaultAgent !== 'blank' && (
+        <SettingsSwitchRow
+          checked={settings.openWorktreeWithAgent}
+          onChange={() => {
+            updateSettings({ openWorktreeWithAgent: !settings.openWorktreeWithAgent })
+          }}
+          label={translate(
+            'auto.components.settings.AgentsPane.openWorktreeWithAgentTitle',
+            'Open worktrees with default agent'
+          )}
+          description={translate(
+            'auto.components.settings.AgentsPane.openWorktreeWithAgentDescription',
+            'When you click a worktree with no open tabs, launch the default agent instead of a blank terminal. Worktrees created with a specific agent always reopen that agent.'
+          )}
+        />
+      )}
+
       <AgentStatusHooksSetting settings={settings} updateSettings={updateSettings} />
 
       <AgentGeneratedTabTitlesSetting settings={settings} updateSettings={updateSettings} />

--- a/src/renderer/src/lib/worktree-activation-default-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-default-agent.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { activateAndRevealWorktree } from './worktree-activation'
+import { resetWebSessionTabsSnapshotFreshnessForTests } from '@/runtime/web-session-tabs-sync'
+import { resetWebRuntimeWakeTerminalRespawnForTests } from '@/runtime/web-runtime-wake-terminal-respawn'
+import type { Worktree } from '../../../shared/types'
+
+const initialAppStoreState = useAppStore.getState()
+
+function makePlainWorktree(): Worktree {
+  return {
+    id: 'repo-1::/workspace/feature',
+    repoId: 'repo-1',
+    path: '/workspace/feature',
+    head: 'abc123',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'feature',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    // Why: no createdWithAgent — this worktree was created externally (git
+    // worktree add), so the default-agent fallback is the only path that
+    // can launch an agent.
+    createdWithAgent: undefined
+  }
+}
+
+function seedEmptyWorktree(worktree: Worktree, settingsOverrides: Record<string, unknown> = {}) {
+  const revealWorktreeInSidebar = vi.fn()
+  useAppStore.setState({
+    repos: [
+      {
+        id: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000000',
+        addedAt: 0
+      }
+    ],
+    worktreesByRepo: { 'repo-1': [worktree] },
+    activeRepoId: 'repo-1',
+    activeView: 'terminal',
+    tabsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    layoutByWorktree: {},
+    activeGroupIdByWorktree: {},
+    openFiles: [],
+    browserTabsByWorktree: {},
+    activeFileIdByWorktree: {},
+    activeBrowserTabIdByWorktree: {},
+    activeTabTypeByWorktree: {},
+    activeTabIdByWorktree: {},
+    tabBarOrderByWorktree: {},
+    pendingStartupByTabId: {},
+    settings: {
+      agentCmdOverrides: {},
+      setupScriptLaunchMode: 'new-tab',
+      ...settingsOverrides
+    } as unknown as ReturnType<typeof useAppStore.getState>['settings'],
+    markWorktreeVisited: vi.fn(),
+    recordWorktreeVisit: vi.fn(),
+    refreshGitHubForWorktreeIfStale: vi.fn(),
+    revealWorktreeInSidebar
+  })
+  return { revealWorktreeInSidebar }
+}
+
+afterEach(() => {
+  delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+  vi.unstubAllGlobals()
+  resetWebSessionTabsSnapshotFreshnessForTests()
+  resetWebRuntimeWakeTerminalRespawnForTests()
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+describe('activateAndRevealWorktree default agent reopen', () => {
+  it('launches the default agent when openWorktreeWithAgent is enabled and no createdWithAgent', () => {
+    const worktree = makePlainWorktree()
+    seedEmptyWorktree(worktree, {
+      openWorktreeWithAgent: true,
+      defaultTuiAgent: 'codex',
+      disabledTuiAgents: []
+    })
+
+    const result = activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const reopenedTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(result).toEqual({ primaryTabId: reopenedTab?.id })
+    expect(reopenedTab).toBeDefined()
+    expect(state.pendingStartupByTabId[reopenedTab!.id]).toEqual({
+      command: "codex '--dangerously-bypass-approvals-and-sandbox'",
+      env: {},
+      launchAgent: 'codex',
+      launchConfig: {
+        agentCommand: "codex '--dangerously-bypass-approvals-and-sandbox'",
+        agentArgs: '--dangerously-bypass-approvals-and-sandbox',
+        agentEnv: {}
+      },
+      launchToken: expect.any(String),
+      telemetry: {
+        agent_kind: 'codex',
+        launch_source: 'sidebar',
+        request_kind: 'default'
+      }
+    })
+  })
+
+  it('falls back to a plain terminal when openWorktreeWithAgent is disabled', () => {
+    const worktree = makePlainWorktree()
+    seedEmptyWorktree(worktree, {
+      openWorktreeWithAgent: false,
+      defaultTuiAgent: 'codex',
+      disabledTuiAgents: []
+    })
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const reopenedTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(reopenedTab).toBeDefined()
+    // Why: no launchAgent / startup payload means a plain terminal.
+    expect(state.pendingStartupByTabId[reopenedTab!.id]).toBeUndefined()
+  })
+
+  it('falls back to a plain terminal when defaultTuiAgent is null (auto)', () => {
+    const worktree = makePlainWorktree()
+    seedEmptyWorktree(worktree, {
+      openWorktreeWithAgent: true,
+      defaultTuiAgent: null,
+      disabledTuiAgents: []
+    })
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const reopenedTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(reopenedTab).toBeDefined()
+    expect(state.pendingStartupByTabId[reopenedTab!.id]).toBeUndefined()
+  })
+
+  it('falls back to a plain terminal when defaultTuiAgent is blank', () => {
+    const worktree = makePlainWorktree()
+    seedEmptyWorktree(worktree, {
+      openWorktreeWithAgent: true,
+      defaultTuiAgent: 'blank',
+      disabledTuiAgents: []
+    })
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const reopenedTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(reopenedTab).toBeDefined()
+    expect(state.pendingStartupByTabId[reopenedTab!.id]).toBeUndefined()
+  })
+
+  it('falls back to a plain terminal when the default agent is disabled', () => {
+    const worktree = makePlainWorktree()
+    seedEmptyWorktree(worktree, {
+      openWorktreeWithAgent: true,
+      defaultTuiAgent: 'codex',
+      disabledTuiAgents: ['codex']
+    })
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const reopenedTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(reopenedTab).toBeDefined()
+    expect(state.pendingStartupByTabId[reopenedTab!.id]).toBeUndefined()
+  })
+
+  it('createdWithAgent takes precedence over the default agent', () => {
+    // Why: worktree created with gemini, default is codex — should reopen gemini.
+    const worktree: Worktree = { ...makePlainWorktree(), createdWithAgent: 'gemini' }
+    seedEmptyWorktree(worktree, {
+      openWorktreeWithAgent: true,
+      defaultTuiAgent: 'codex',
+      disabledTuiAgents: []
+    })
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const reopenedTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(reopenedTab).toBeDefined()
+    expect(state.pendingStartupByTabId[reopenedTab!.id]?.launchAgent).toBe('gemini')
+    expect(state.pendingStartupByTabId[reopenedTab!.id]?.telemetry?.request_kind).toBe('resume')
+  })
+})

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -45,6 +45,7 @@ import {
 } from '../../../shared/tui-agent-launch-defaults'
 import { isTuiAgent } from '../../../shared/tui-agent-config'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
+import { isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import {
@@ -273,6 +274,64 @@ function buildCreatedAgentReopenStartup(worktree: Worktree): WorktreeStartupPayl
   }
 }
 
+function buildDefaultAgentReopenStartup(
+  state: ReturnType<typeof useAppStore.getState>,
+  worktree: Worktree
+): WorktreeStartupPayload | undefined {
+  // Why: opt-in setting. When disabled (default), worktrees open a plain
+  // terminal exactly as before.
+  if (!state.settings?.openWorktreeWithAgent) {
+    return undefined
+  }
+  const agent = state.settings?.defaultTuiAgent
+  // Why: 'blank' and null mean the user explicitly chose no agent — respect
+  // that and fall through to a plain terminal.
+  if (!isTuiAgent(agent)) {
+    return undefined
+  }
+  if (!isTuiAgentEnabled(agent, state.settings?.disabledTuiAgents)) {
+    return undefined
+  }
+
+  const repo = state.repos.find((entry) => entry.id === worktree.repoId)
+  const launchPlatform = repo
+    ? getAgentLaunchPlatformForRepo(
+        repo,
+        repo.connectionId ? undefined : getLocalProjectExecutionRuntimeContext(state, worktree.id)
+      )
+    : CLIENT_PLATFORM
+
+  const startupPlan = buildAgentStartupPlan({
+    agent,
+    prompt: '',
+    cmdOverrides: state.settings?.agentCmdOverrides ?? {},
+    agentArgs: resolveTuiAgentLaunchArgs(agent, state.settings?.agentDefaultArgs),
+    agentEnv: resolveTuiAgentLaunchEnv(agent, state.settings?.agentDefaultEnv),
+    platform: launchPlatform,
+    allowEmptyPromptLaunch: true
+  })
+  if (!startupPlan) {
+    return undefined
+  }
+
+  return {
+    command: startupPlan.launchCommand,
+    ...(startupPlan.env ? { env: startupPlan.env } : {}),
+    launchConfig: startupPlan.launchConfig,
+    launchAgent: agent,
+    ...(startupPlan.startupCommandDelivery
+      ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
+      : {}),
+    telemetry: {
+      agent_kind: tuiAgentToAgentKind(agent),
+      launch_source: 'sidebar',
+      // Why: 'default' distinguishes "user's global default agent" from
+      // 'resume' (worktree was created with this specific agent).
+      request_kind: 'default'
+    }
+  }
+}
+
 export function activateAndRevealWorktree(
   worktreeId: string,
   opts?: {
@@ -356,7 +415,9 @@ export function activateAndRevealWorktree(
   const primaryTabId = ensureWorktreeHasInitialTerminal(
     useAppStore.getState(),
     worktreeId,
-    opts?.startup ?? buildCreatedAgentReopenStartup(wt),
+    opts?.startup ??
+      buildCreatedAgentReopenStartup(wt) ??
+      buildDefaultAgentReopenStartup(useAppStore.getState(), wt),
     opts?.setup,
     opts?.issueCommand,
     opts?.defaultTabs

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -229,6 +229,14 @@ export function activateAndRevealFolderWorkspace(
   return { primaryTabId }
 }
 
+/**
+ * Build a startup payload that reopens the agent a worktree was originally
+ * created with (`createdWithAgent`). Returns `undefined` when the worktree
+ * has no creation agent, so the caller can fall through to the default-agent
+ * or plain-terminal path.
+ * @param worktree - The worktree being activated.
+ * @returns A startup payload to resume the creation agent, or `undefined`.
+ */
 function buildCreatedAgentReopenStartup(worktree: Worktree): WorktreeStartupPayload | undefined {
   const agent = worktree.createdWithAgent
   if (!isTuiAgent(agent)) {
@@ -274,6 +282,18 @@ function buildCreatedAgentReopenStartup(worktree: Worktree): WorktreeStartupPayl
   }
 }
 
+/**
+ * Build a startup payload that launches the user's global `defaultTuiAgent`
+ * when activating a worktree with no existing tabs. Only fires when the
+ * `openWorktreeWithAgent` setting is enabled and the default agent is a
+ * valid, enabled TUI agent (not 'blank' or null). Lower priority than
+ * `buildCreatedAgentReopenStartup` so worktrees created with a specific
+ * agent always reopen that agent.
+ * @param state - Current app store state (for settings + repo lookup).
+ * @param worktree - The worktree being activated.
+ * @returns A startup payload to launch the default agent, or `undefined` to
+ *   fall through to a plain terminal.
+ */
 function buildDefaultAgentReopenStartup(
   state: ReturnType<typeof useAppStore.getState>,
   worktree: Worktree

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -304,6 +304,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     activeClaudeManagedAccountId: null,
     terminalScopeHistoryByWorktree: true,
     defaultTuiAgent: null,
+    openWorktreeWithAgent: false,
     disabledTuiAgents: [...DEFAULT_DISABLED_TUI_AGENTS],
     claudeAgentTeamsDefaultDisabledMigrated: true,
     skipDeleteWorktreeConfirm: false,

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -219,7 +219,7 @@ export const launchSourceSchema = z.enum([
 ])
 export type LaunchSource = z.infer<typeof launchSourceSchema>
 
-export const requestKindSchema = z.enum(['new', 'resume', 'followup'])
+export const requestKindSchema = z.enum(['new', 'resume', 'followup', 'default'])
 export type RequestKind = z.infer<typeof requestKindSchema>
 
 export const featureWallTileIdSchema = z.enum([

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2693,6 +2693,10 @@ export type GlobalSettings = {
    *  - 'blank': blank terminal (no agent launched)
    *  - TuiAgent: a specific agent id */
   defaultTuiAgent: TuiAgent | 'blank' | null
+  /** When true, activating a worktree with no existing tabs launches the
+   *  `defaultTuiAgent` instead of opening a plain terminal. Only applies
+   *  when the worktree has no `createdWithAgent` (which takes precedence). */
+  openWorktreeWithAgent: boolean
   /** Agents hidden from future picker and automatic launch choices. Detection
    *  remains a raw PATH capability snapshot. */
   disabledTuiAgents: TuiAgent[]


### PR DESCRIPTION
## Summary

- Add an opt-in `openWorktreeWithAgent` global setting that launches the user's `defaultTuiAgent` when activating a worktree with no existing tabs, instead of opening a plain terminal
- New `buildDefaultAgentReopenStartup` function in `worktree-activation.ts` follows the existing `buildCreatedAgentReopenStartup` pattern
- Toggle appears in Settings > Agents, visible only when a concrete default agent is selected (not Auto or blank)

### Startup resolution order

1. **Explicit `opts.startup`** -- caller-provided (direct task launch, palette with prompt)
2. **`buildCreatedAgentReopenStartup(wt)`** -- worktree was created with a specific agent (`createdWithAgent`)
3. **`buildDefaultAgentReopenStartup(state, wt)`** -- NEW: user enabled the toggle + has `defaultTuiAgent` set
4. **None** -- plain terminal (current behavior, unchanged)

### What does NOT change

- Worktrees with existing tabs are unaffected (no new terminal created)
- Worktrees created with a specific agent still reopen that agent (takes precedence over the default)
- The setting is opt-in (default `false`) -- no behavior change for existing users
- SSH/remote worktrees work the same (launch platform is derived per-repo)

## Screenshots

Settings toggle (visible only when a concrete default agent is selected):

<img width="1864" height="1754" alt="CleanShot 2026-06-30 at 22 38 44@2x" src="https://github.com/user-attachments/assets/223ea2f7-3c2a-4cb4-8ccd-ddcccba0978d" />

## AI Review Report

### Cross-platform compatibility

- **macOS**: Verified. `buildDefaultAgentReopenStartup` uses `getAgentLaunchPlatformForRepo` which resolves the correct platform per repo. No platform-specific code paths introduced.
- **Linux**: Verified. Same platform-agnostic flow. The `launchPlatform` is derived from the repo, not hardcoded.
- **Windows**: Verified. No `metaKey` or path separator assumptions. The `buildAgentStartupPlan` call uses the resolved `launchPlatform`, which handles Windows quoting/WSL correctly (covered by existing WSL test in `worktree-activation-created-agent.test.ts`).

### SSH use case

- Verified. `getAgentLaunchPlatformForRepo` checks `repo.connectionId` to determine if the repo is remote. When remote, `getLocalProjectExecutionRuntimeContext` is not called (the `repo.connectionId ? undefined :` guard), so the launch platform correctly reflects the remote host.

### Security audit

- No new user input is processed. The setting is a boolean toggle stored in `GlobalSettings` and persisted via the existing `updateSettings` IPC.
- No secrets, credentials, or sensitive data are introduced or logged.
- The `defaultTuiAgent` value is validated via `isTuiAgent()` and `isTuiAgentEnabled()` before use, preventing injection of invalid agent IDs.

#### Test plan

- [x] `worktree-activation-default-agent.test.ts` -- 6 new tests covering: enabled + agent set, disabled, null (auto), blank, disabled agent, createdWithAgent precedence
- [x] `worktree-activation-created-agent.test.ts` -- 12 existing tests still pass
- [x] `codex-accounts` tests -- 100 tests pass (updated manual GlobalSettings constructors)
- [x] `typecheck:node` and `typecheck:web` pass
- [x] `oxlint` passes on all changed files

Generated with [Devin](https://devin.ai)

## ELI5

Optional setting opens a worktree with your default agent instead of a blank terminal when there are no existing tabs. Only shows when a concrete default agent is configured.
