### PR TITLE
fix(file-explorer): search folder workspace roots

### DIFF
--- a/src/renderer/src/components/quick-open-file-list.react.test.tsx
+++ b/src/renderer/src/components/quick-open-file-list.react.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FolderWorkspace, ProjectGroup } from '../../../shared/types'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import { useRuntimeFileListForWorktree, type RuntimeFileListState } from './quick-open-file-list'
+
+const listRuntimeFilesMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  listRuntimeFiles: listRuntimeFilesMock
+}))
+
+const initialAppState = useAppStore.getInitialState()
+const roots: Root[] = []
+
+function makeProjectGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'Platform',
+    parentPath: '/srv/platform',
+    connectionId: null,
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'folder-workspace-1',
+    projectGroupId: 'group-1',
+    name: 'Platform workspace',
+    folderPath: '/srv/platform',
+    connectionId: null,
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function HookProbe({
+  enabled,
+  onState,
+  worktreeId
+}: {
+  enabled: boolean
+  onState: (state: RuntimeFileListState) => void
+  worktreeId: string | null
+}): null {
+  onState(useRuntimeFileListForWorktree({ enabled, worktreeId }))
+  return null
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function waitForListRuntimeFilesCall(): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await flushEffects()
+    if (listRuntimeFilesMock.mock.calls.length > 0) {
+      return
+    }
+  }
+  throw new Error('listRuntimeFiles was not called')
+}
+
+async function renderProbe(args: {
+  enabled: boolean
+  onState: (state: RuntimeFileListState) => void
+  worktreeId: string | null
+}): Promise<Root> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(createElement(HookProbe, args))
+  })
+  await flushEffects()
+  return root
+}
+
+beforeEach(() => {
+  useAppStore.setState(initialAppState, true)
+  listRuntimeFilesMock.mockReset().mockResolvedValue(['packages/app/package.json'])
+})
+
+afterEach(async () => {
+  for (const root of roots) {
+    await act(async () => {
+      root.unmount()
+    })
+  }
+  roots.length = 0
+  useAppStore.setState(initialAppState, true)
+})
+
+describe('useRuntimeFileListForWorktree', () => {
+  it('lists a repo-less SSH folder workspace after folder metadata hydrates', async () => {
+    const states: RuntimeFileListState[] = []
+    const workspaceKey = folderWorkspaceKey('folder-workspace-1')
+
+    useAppStore.setState({
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [],
+      worktreesByRepo: {}
+    } as Partial<AppState>)
+
+    await renderProbe({
+      enabled: true,
+      onState: (state) => states.push(state),
+      worktreeId: workspaceKey
+    })
+
+    expect(listRuntimeFilesMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      useAppStore.setState({
+        folderWorkspaces: [makeFolderWorkspace({ connectionId: 'ssh-1' })],
+        projectGroups: [makeProjectGroup({ connectionId: 'ssh-1' })],
+        repos: [],
+        worktreesByRepo: {}
+      } as Partial<AppState>)
+    })
+    await waitForListRuntimeFilesCall()
+
+    expect(listRuntimeFilesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: workspaceKey,
+        worktreePath: '/srv/platform',
+        connectionId: 'ssh-1',
+        settings: expect.objectContaining({ activeRuntimeEnvironmentId: null })
+      }),
+      {
+        rootPath: '/srv/platform',
+        excludePaths: undefined
+      }
+    )
+    expect(states.at(-1)?.files).toEqual(['packages/app/package.json'])
+  })
+})

--- a/src/renderer/src/components/quick-open-file-list.test.ts
+++ b/src/renderer/src/components/quick-open-file-list.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { Worktree } from '../../../shared/types'
 import { buildExcludePathPrefixes } from '../../../shared/quick-open-filter'
 import {
+  getRuntimeFileListTarget,
   getNestedWorktreeExcludePaths,
   getNestedWorktreeExcludeRequest,
   isNestedWorktreePath
@@ -56,5 +57,16 @@ describe('quick-open nested worktree excludes', () => {
     expect(request.paths).toEqual(['/tmp/repo/linked\nworktree'])
     expect(request.key).toBe('["/tmp/repo/linked\\nworktree"]')
     expect(buildExcludePathPrefixes('/tmp/repo', request.paths)).toEqual(['linked\nworktree'])
+  })
+
+  it('can list files for folder workspaces resolved outside registered repo worktrees', () => {
+    const folderWorkspace = makeWorktree('folder:workspace-1', '/Users/jenkei/test')
+    const target = getRuntimeFileListTarget(folderWorkspace.id, folderWorkspace.path, [])
+
+    expect(target).toEqual({
+      canList: true,
+      excludeRequest: { paths: [], key: '[]' },
+      worktreePath: '/Users/jenkei/test'
+    })
   })
 })

--- a/src/renderer/src/components/quick-open-file-list.ts
+++ b/src/renderer/src/components/quick-open-file-list.ts
@@ -2,11 +2,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Worktree } from '../../../shared/types'
 import { isWindowsAbsolutePathLike } from '../../../shared/cross-platform-path'
-import { getConnectionId } from '@/lib/connection-context'
+import { getConnectionIdFromState } from '@/lib/connection-context'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
 import { listRuntimeFiles } from '@/runtime/runtime-file-client'
 import { useAppStore } from '@/store'
-import { useWorktreeById, useWorktreesForRepo } from '@/store/selectors'
+import { useWorktreesForRepo } from '@/store/selectors'
 
 export type RuntimeFileListState = {
   files: string[]
@@ -49,6 +49,32 @@ export type NestedWorktreeExcludeRequest = {
   key: string
 }
 
+export type RuntimeFileListTarget = {
+  canList: boolean
+  excludeRequest: NestedWorktreeExcludeRequest
+  worktreePath: string | null
+}
+
+export function getRuntimeFileListTarget(
+  worktreeId: string | null,
+  worktreePath: string | null | undefined,
+  repoWorktrees: readonly Worktree[]
+): RuntimeFileListTarget {
+  const resolvedWorktreePath = worktreePath ?? null
+  if (!worktreeId || !resolvedWorktreePath) {
+    return { canList: false, excludeRequest: { paths: [], key: '[]' }, worktreePath: null }
+  }
+  return {
+    canList: true,
+    excludeRequest: getNestedWorktreeExcludeRequest(
+      worktreeId,
+      resolvedWorktreePath,
+      repoWorktrees
+    ),
+    worktreePath: resolvedWorktreePath
+  }
+}
+
 export function getNestedWorktreeExcludeRequest(
   worktreeId: string | null,
   worktreePath: string | null,
@@ -70,20 +96,26 @@ export function useRuntimeFileListForWorktree({
   enabled: boolean
   worktreeId: string | null
 }): RuntimeFileListState {
-  const worktree = useWorktreeById(worktreeId)
+  const worktree = useAppStore((state) =>
+    // Why: folder workspaces live behind getKnownWorktreeById, not worktreesByRepo.
+    worktreeId ? (state.getKnownWorktreeById(worktreeId) ?? null) : null
+  )
+  const worktreePath = worktree?.path ?? null
   const repoWorktrees = useWorktreesForRepo(worktree?.repoId ?? null)
   const [files, setFiles] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
   const lastRequestKeyRef = useRef('')
 
-  const worktreePath = worktree?.path ?? null
-  const excludeRequest = useMemo(
-    () => getNestedWorktreeExcludeRequest(worktreeId, worktreePath, repoWorktrees),
+  const target = useMemo(
+    () => getRuntimeFileListTarget(worktreeId, worktreePath, repoWorktrees),
     [repoWorktrees, worktreeId, worktreePath]
   )
+  const { excludeRequest } = target
 
-  const connectionId = useMemo(() => getConnectionId(worktreeId) ?? undefined, [worktreeId])
+  const connectionId = useAppStore(
+    (state) => getConnectionIdFromState(state, worktreeId) ?? undefined
+  )
   const activeTargetStatus = useAppStore((state) =>
     connectionId ? state.sshConnectionStates.get(connectionId)?.status : undefined
   )
@@ -103,7 +135,7 @@ export function useRuntimeFileListForWorktree({
       return
     }
 
-    if (!worktreeId || !worktreePath) {
+    if (!target.canList || !worktreeId || !worktreePath) {
       setFiles([])
       setLoadError(null)
       setLoading(false)
@@ -155,7 +187,7 @@ export function useRuntimeFileListForWorktree({
     return () => {
       cancelled = true
     }
-  }, [connectionId, enabled, excludeRequest, requestKey, worktreeId, worktreePath])
+  }, [connectionId, enabled, excludeRequest, requestKey, target.canList, worktreeId, worktreePath])
 
   return { files, loading: loading || connectionPending, loadError }
 }

--- a/src/renderer/src/lib/connection-context.ts
+++ b/src/renderer/src/lib/connection-context.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import {
@@ -16,17 +17,20 @@ import {
  * cannot be found (e.g., store not yet hydrated).
  */
 export function getConnectionId(worktreeId: string | null): string | null | undefined {
+  return getConnectionIdFromState(useAppStore.getState(), worktreeId)
+}
+
+export function getConnectionIdFromState(
+  state: Pick<AppState, 'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'>,
+  worktreeId: string | null
+): string | null | undefined {
   if (!worktreeId) {
     return null
   }
   const parsedWorkspaceKey = parseWorkspaceKey(worktreeId)
   if (parsedWorkspaceKey?.type === 'folder') {
-    return getFolderWorkspaceConnectionId(
-      useAppStore.getState(),
-      parsedWorkspaceKey.folderWorkspaceId
-    )
+    return getFolderWorkspaceConnectionId(state, parsedWorkspaceKey.folderWorkspaceId)
   }
-  const state = useAppStore.getState()
   const allWorktrees = Object.values(state.worktreesByRepo ?? {}).flat()
   const worktree = allWorktrees.find((w) => w.id === worktreeId)
   // Why: SSH worktrees can be restored from session IDs before relay discovery


### PR DESCRIPTION
## Summary
- Resolve Quick Open file-list targets through known worktrees so folder workspaces can provide their root path even when they are not in `worktreesByRepo`.
- Recompute folder workspace `connectionId` from subscribed store state so hydration does not leave SSH folder roots stale.
- Add a hook-level regression for repo-less folder workspaces plus the existing helper coverage.

Fixes #5939.

## Screenshots
N/A - no visual UI change. This affects Quick Open file-list loading for folder workspace roots.

## Testing Checklist
- [x] Focused Quick Open folder workspace regression tests.
- [x] Nearby File Explorer projection and component tests.
- [x] Targeted lint for touched TypeScript files.
- [x] Full TypeScript typecheck.
- [x] Diff whitespace check.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/quick-open-file-list.test.ts src/renderer/src/components/quick-open-file-list.react.test.tsx src/renderer/src/lib/connection-context.test.ts src/renderer/src/lib/worktree-runtime-owner.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts --environment happy-dom src/renderer/src/components/right-sidebar/FileExplorer.test.tsx`
- `pnpm exec oxlint src/renderer/src/components/quick-open-file-list.ts src/renderer/src/components/quick-open-file-list.test.ts src/renderer/src/components/quick-open-file-list.react.test.tsx src/renderer/src/lib/connection-context.ts`
- `pnpm run typecheck`
- `git diff --check origin/main..HEAD`

## Review Report
- CodeRabbit reported no actionable review comments.
- GitHub review threads are empty as of this update.
- Copilot review did not run because the requesting user hit quota.

## Security Audit
- No auth, permissions, secrets, payments, uploads, or external vendor configuration changed.
- The change passes an existing workspace root and resolved connection id through the existing runtime file-list path.
- Focused diff scan found no new secret, token, eval, HTML injection, process-spawn, or network-call patterns.