### PR TITLE
Preserve local runtime preference on remote project refresh

### DIFF
--- a/src/renderer/src/store/slices/repos-all-hosts.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTestStore } from './store-test-helpers'
 import type {
@@ -191,6 +192,7 @@ beforeEach(() => {
 function configureSharedProjectCompatibilityMocks(
   options: {
     localRepoHasProviderIdentity?: boolean
+    localProjectRuntimePreference?: Project['localWindowsRuntimePreference'] | null
     remoteProjectRuntimePreference?: Project['localWindowsRuntimePreference']
   } = {}
 ): {
@@ -214,7 +216,13 @@ function configureSharedProjectCompatibilityMocks(
     displayName: 'Orca',
     badgeColor: '#000',
     sourceRepoIds: ['local-repo'],
-    localWindowsRuntimePreference: { kind: 'windows-host' },
+    ...(options.localProjectRuntimePreference === null
+      ? {}
+      : {
+          localWindowsRuntimePreference: options.localProjectRuntimePreference ?? {
+            kind: 'windows-host'
+          }
+        }),
     createdAt: 1,
     updatedAt: 1
   }
@@ -238,7 +246,7 @@ function configureSharedProjectCompatibilityMocks(
     id: 'remote-setup',
     projectId: sharedProjectId,
     repoId: 'remote-repo',
-    path: '/srv/repo',
+    path: path.join('/', 'srv', 'repo'),
     displayName: 'Remote setup'
   }
   reposList.mockResolvedValue([localRepoForSharedProject])
@@ -427,6 +435,22 @@ describe('fetchReposForAllHosts', () => {
       store.getState().projects.find((project) => project.id === sharedProjectId)
         ?.localWindowsRuntimePreference
     ).toEqual({ kind: 'windows-host' })
+  })
+
+  it('does not adopt a remote runtime preference when the local shared project inherits the default', async () => {
+    const { sharedProjectId } = configureSharedProjectCompatibilityMocks({
+      localProjectRuntimePreference: null,
+      remoteProjectRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+
+    expect(
+      store.getState().projects.find((project) => project.id === sharedProjectId)
+        ?.localWindowsRuntimePreference
+    ).toBeUndefined()
   })
 
   it('preserves shared project metadata after a runtime-only repo refresh', async () => {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -499,7 +499,8 @@ function mergePreviousProjectMetadata(
   previous: Project,
   current: Project,
   reposById: ReadonlyMap<string, Repo>,
-  hostId: string
+  hostId: string,
+  preserveLocalWindowsRuntimePreference: boolean
 ): Project {
   const project = mergeProjectCompatibilityProject(previous, current)
   if (hostId === LOCAL_EXECUTION_HOST_ID) {
@@ -514,10 +515,14 @@ function mergePreviousProjectMetadata(
     } else {
       delete project.localWindowsRuntimePreference
     }
-  } else if (previous.localWindowsRuntimePreference !== undefined) {
+  } else if (preserveLocalWindowsRuntimePreference) {
     // Why: remote runtimes can have their own local Windows preference; they must
-    // not overwrite the client-local project runtime setting.
-    project.localWindowsRuntimePreference = previous.localWindowsRuntimePreference
+    // not overwrite the client-local project runtime setting, even when unset.
+    if (previous.localWindowsRuntimePreference === undefined) {
+      delete project.localWindowsRuntimePreference
+    } else {
+      project.localWindowsRuntimePreference = previous.localWindowsRuntimePreference
+    }
   }
   return {
     ...project,
@@ -606,6 +611,8 @@ function mergeFetchedProjectCompatibilityForHost({
     [...getExplicitProjectHostIds(project, projectHostSetups, repos)].some(
       (ownerHostId) => ownerHostId !== hostId
     )
+  const projectHasLocalOwner = (project: Project): boolean =>
+    getExplicitProjectHostIds(project, projectHostSetups, repos).has(LOCAL_EXECUTION_HOST_ID)
   const fetchedProjects = fetched.projects
     .filter((project) => {
       const previousProject = previousProjectById.get(project.id)
@@ -619,7 +626,13 @@ function mergeFetchedProjectCompatibilityForHost({
     .map((project) => {
       const previousProject = previousProjectById.get(project.id)
       return previousProject
-        ? mergePreviousProjectMetadata(previousProject, project, reposById, hostId)
+        ? mergePreviousProjectMetadata(
+            previousProject,
+            project,
+            reposById,
+            hostId,
+            hostId !== LOCAL_EXECUTION_HOST_ID && projectHasLocalOwner(previousProject)
+          )
         : projectWithCurrentSourceRepoIds(project, currentRepoIds)
     })
   const fetchedProjectIds = new Set(fetchedProjects.map((project) => project.id))


### PR DESCRIPTION
## Summary
- preserve the client-local project runtime preference when merging remote project metadata for a shared project
- keep the inherited-default case unset instead of adopting a remote WSL preference
- add regression coverage for shared local/remote project metadata

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/repos-all-hosts.test.ts src/renderer/src/store/slices/repos-project-runtime.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- pnpm exec oxlint src/renderer/src/store/slices/repos.ts src/renderer/src/store/slices/repos-all-hosts.test.ts src/renderer/src/store/slices/repos-project-runtime.test.ts src/renderer/src/components/sidebar/worktree-list-groups.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- pnpm exec oxfmt --check src/renderer/src/store/slices/repos.ts src/renderer/src/store/slices/repos-all-hosts.test.ts src/renderer/src/store/slices/repos-project-runtime.test.ts src/renderer/src/components/sidebar/worktree-list-groups.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- pnpm run typecheck:web
- git diff --check