### PR TITLE
Remove textContentType none from iOS terminal input to restore IME switching

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -4915,12 +4915,14 @@ export default function SessionScreen() {
                       autoCorrect={false}
                       spellCheck={false}
                       smartInsertDelete={false}
+                      // Why: iOS textContentType wins over autoComplete and can
+                      // narrow the keyboard surface; keep IME switching available.
+                      autoComplete="off"
                       keyboardType={getTerminalLiveInputKeyboardType(Platform.OS)}
                       returnKeyType="default"
                       blurOnSubmit={false}
                       editable={canSend}
                       importantForAutofill="no"
-                      textContentType="none"
                     />
                   </Pressable>
                 ) : (
@@ -4946,6 +4948,9 @@ export default function SessionScreen() {
                       autoCorrect={autocompleteEnabled}
                       spellCheck={autocompleteEnabled}
                       smartInsertDelete={false}
+                      // Why: terminal commands are not autofill content, but the
+                      // keyboard must stay default so non-Latin IMEs remain selectable.
+                      autoComplete="off"
                       keyboardType={getTerminalCommandKeyboardType(
                         Platform.OS,
                         autocompleteEnabled

--- a/mobile/src/terminal/terminal-ios-ime-keyboard.test.ts
+++ b/mobile/src/terminal/terminal-ios-ime-keyboard.test.ts
@@ -11,4 +11,9 @@ describe('terminal iOS IME keyboard', () => {
     expect(sessionRouteSource).not.toContain("'ascii-capable'")
     expect(sessionRouteSource).not.toContain('"ascii-capable"')
   })
+
+  it('does not put terminal keyboard capture behind iOS textContentType semantics', () => {
+    expect(sessionRouteSource).not.toContain('textContentType="none"')
+    expect(sessionRouteSource).toContain('autoComplete="off"')
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/stablyai/orca/issues/6149

## Summary

Removes `textContentType="none"` and adds `autoComplete="off"` to iOS terminal inputs. This resolves an issue where iOS `textContentType` narrows the keyboard layout, preventing users from switching to non-Latin IMEs.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Verified the impact of `textContentType` on iOS keyboard behavior. Removing it and ensuring `autoComplete="off"` maintains the default keyboard surface so all non-Latin keyboard layouts are selectable. Explicitly checked cross-platform compatibility; these changes are limited to the React Native mobile directory and do not touch or affect macOS, Linux, or Windows.

## Security Audit

No security risks or input handling vulnerabilities. This is a purely presentation/keyboard-configuration adjustment.

## Notes

Platform-specific fix targeting iOS IME capture behavior.