### PR TITLE
Prevent redundant SIGWINCH signals on terminal tab restoration

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -487,10 +487,12 @@ export default function TerminalPane({
   // xterm may not know multi-line text needs bracketed-paste protection.
   const forceBracketedMultilineTextPaste = isWindowsUserAgent()
   const [startup] = useState(() => useAppStore.getState().pendingStartupByTabId[tabId])
+  const [shouldMeasureHiddenStartup, setShouldMeasureHiddenStartup] = useState(
+    () => startup !== undefined && !isVisible
+  )
   const [sessionRestoredBannerPaneIds, setSessionRestoredBannerPaneIds] = useState<Set<number>>(
     () => new Set()
   )
-  const shouldMeasureHiddenStartup = startup !== undefined && !isVisible
   const consumeTabStartupCommand = useAppStore((store) => store.consumeTabStartupCommand)
   const [setupSplit] = useState(() => useAppStore.getState().pendingSetupSplitByTabId[tabId])
   const consumeTabSetupSplit = useAppStore((store) => store.consumeTabSetupSplit)
@@ -503,6 +505,14 @@ export default function TerminalPane({
       consumeTabStartupCommand(tabId)
     }
   }, [startup, tabId, consumeTabStartupCommand])
+
+  useLayoutEffect(() => {
+    if (isVisible && shouldMeasureHiddenStartup) {
+      // Why: hidden startup measurement is only for first launch. Keeping it
+      // after first visibility lets inactive agent tabs refit and SIGWINCH.
+      setShouldMeasureHiddenStartup(false)
+    }
+  }, [isVisible, shouldMeasureHiddenStartup])
 
   const clearSessionRestoredBannerForPane = useCallback((paneId: number): void => {
     setSessionRestoredBannerPaneIds((prev) => {
@@ -1768,7 +1778,10 @@ export default function TerminalPane({
       sessionRestoredBannerPaneIds,
       reservePaneHeaderSpace: isActive && (isVisible || shouldMeasureHiddenStartup)
     })
-    if (needsFit) {
+    if (needsFit && (isVisible || shouldMeasureHiddenStartup)) {
+      // Why: inactive terminal tabs can drop active-only header reservation.
+      // Fitting that hidden geometry changes PTY rows and wakes TUIs with
+      // SIGWINCH; the visible resume path owns any real layout correction.
       fitPanes(manager)
     }
   }, [

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -79,9 +79,14 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   const [measuredFallbackRect, setMeasuredFallbackRect] = useState<MeasuredFallbackRect | null>(
     null
   )
-  const [shouldMeasureHiddenStartup] = useState(
+  const [shouldMeasureHiddenStartup, setShouldMeasureHiddenStartup] = useState(
     () => useAppStore.getState().pendingStartupByTabId[terminalTabId] !== undefined
   )
+  useLayoutEffect(() => {
+    if (isVisible && shouldMeasureHiddenStartup) {
+      setShouldMeasureHiddenStartup(false)
+    }
+  }, [isVisible, shouldMeasureHiddenStartup])
   useLayoutEffect(() => {
     if (!anchorName || shouldUseCssAnchorPositioning() || !groupId) {
       return

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6156,6 +6156,7 @@ describe('connectPanePty', () => {
     const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
       typeof vi.fn
     >
+    const signalPty = window.api.pty.signal as unknown as ReturnType<typeof vi.fn>
     const firstSnapshot = createDeferred<{
       data: string
       cols: number
@@ -6196,10 +6197,12 @@ describe('connectPanePty', () => {
       seq: hidden.length + visibleLive.length + hiddenAgain.length,
       rawLength: hiddenAgain.length
     })
+    transport.resize.mockClear()
+    signalPty.mockClear()
     firstSnapshot.resolve({
       data: 'snapshot-before-hidden-again\r\n',
-      cols: 120,
-      rows: 40,
+      cols: 100,
+      rows: 30,
       seq: hidden.length + visibleLive.length
     })
     await flushAsyncTicks(20)
@@ -6210,6 +6213,8 @@ describe('connectPanePty', () => {
       expect.any(Function)
     )
     expect(pane.terminal.write).not.toHaveBeenCalledWith(hiddenAgain, expect.any(Function))
+    expect(transport.resize).not.toHaveBeenCalled()
+    expect(signalPty).not.toHaveBeenCalledWith('pty-id', 'SIGWINCH')
 
     ;(deps.isVisibleRef as { current: boolean }).current = true
     visibilityState = 'visible'
@@ -6267,6 +6272,84 @@ describe('connectPanePty', () => {
 
     expect(pane.terminal.write).toHaveBeenCalledWith('snapshot-state\r\n', expect.any(Function))
     expect(pane.terminal.scrollToLine).toHaveBeenCalledWith(42)
+    disposable.dispose()
+  })
+
+  it('does not signal SIGWINCH after hidden-backlog snapshot replay when dimensions are unchanged', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const signalPty = window.api.pty.signal as unknown as ReturnType<typeof vi.fn>
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const live = 'visible-after\r\n'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: 'snapshot-state\r\n',
+      cols: 120,
+      rows: 40,
+      seq: hidden.length + live.length
+    })
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false }
+    })
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+    transport.resize.mockClear()
+    signalPty.mockClear()
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    expect(pane.terminal.write).toHaveBeenCalledWith('snapshot-state\r\n', expect.any(Function))
+    expect(transport.resize).not.toHaveBeenCalledWith(120, 40)
+    expect(signalPty).not.toHaveBeenCalledWith('pty-id', 'SIGWINCH')
+    disposable.dispose()
+  })
+
+  it('does not forward terminal resizes while the pane is hidden', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const isVisibleRef = { current: false }
+    const deps = createDeps({ isVisibleRef })
+
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    const onResizeMock = pane.terminal.onResize as unknown as {
+      mock: { calls: [[(event: { cols: number; rows: number }) => void] | []] }
+    }
+    const resizeHandler = onResizeMock.mock.calls[0]?.[0]
+    if (!resizeHandler) {
+      throw new Error('Expected terminal resize handler to be registered')
+    }
+
+    transport.resize.mockClear()
+    resizeHandler({ cols: 121, rows: 41 })
+
+    expect(transport.resize).not.toHaveBeenCalled()
+
+    isVisibleRef.current = true
+    resizeHandler({ cols: 122, rows: 42 })
+
+    expect(transport.resize).toHaveBeenCalledWith(122, 42)
     disposable.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -813,6 +813,7 @@ export function connectPanePty(
   let pendingTerminalBellNotification = false
   let reattachIdleAgentCursorResetTimer: ReturnType<typeof setTimeout> | null = null
   let synchronizedForegroundOutputActive = false
+  let suppressSnapshotReplayPtyResize = false
   // Why: idle callbacks are registered before the deferred PTY output plumbing
   // exists. Start with the shared scheduler, then switch to the PTY writer
   // below so hidden-tab resets keep backlog-recovery callbacks and byte order.
@@ -1959,7 +1960,19 @@ export function connectPanePty(
     )
   }
 
+  const isRendererPtyResizeAuthoritative = (): boolean => {
+    if (deps.isVisibleRef.current) {
+      return true
+    }
+    // Why: hidden-tab layout churn is not authoritative; visible resume
+    // owns correction, and hidden SIGWINCH can reset full-screen TUIs.
+    return false
+  }
+
   const forwardPtyResize = (cols: number, rows: number): void => {
+    if (!isRendererPtyResizeAuthoritative()) {
+      return
+    }
     // Why: when a mobile-fit override is active OR mobile is currently the
     // driver of this PTY, the PTY is already at phone dims and any desktop
     // resize is wrong. Suppress resize forwarding to avoid spurious SIGWINCH
@@ -1985,6 +1998,12 @@ export function connectPanePty(
   pane.container.addEventListener(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT, onHeldPtyResizeFlush)
 
   const onResizeDisposable = pane.terminal.onResize(({ cols, rows }) => {
+    if (suppressSnapshotReplayPtyResize) {
+      return
+    }
+    if (!isRendererPtyResizeAuthoritative()) {
+      return
+    }
     if (shouldSuppressDesktopPtyResize()) {
       return
     }
@@ -3129,17 +3148,27 @@ export function connectPanePty(
       seq?: number
     }): void {
       const scrollState = captureScrollStateForSnapshotReplay()
-      discardTerminalOutput(pane.terminal)
-      if (
+      const colsBeforeReplay = pane.terminal.cols
+      const rowsBeforeReplay = pane.terminal.rows
+      const hasSnapshotDimensions =
         Number.isFinite(snapshot.cols) &&
         Number.isFinite(snapshot.rows) &&
         snapshot.cols > 0 &&
-        snapshot.rows > 0 &&
+        snapshot.rows > 0
+      discardTerminalOutput(pane.terminal)
+      if (
+        hasSnapshotDimensions &&
         (pane.terminal.cols !== snapshot.cols || pane.terminal.rows !== snapshot.rows)
       ) {
         // Why: serialized terminal snapshots encode layout at their source
         // dimensions. Replay at those dimensions first, then fit back below.
-        pane.terminal.resize(snapshot.cols, snapshot.rows)
+        // This xterm-only resize must not SIGWINCH the live TUI.
+        suppressSnapshotReplayPtyResize = true
+        try {
+          pane.terminal.resize(snapshot.cols, snapshot.rows)
+        } finally {
+          suppressSnapshotReplayPtyResize = false
+        }
       }
       writeReplayData('\x1b[2J\x1b[3J\x1b[H')
       writeReplayData(snapshot.data)
@@ -3149,9 +3178,16 @@ export function connectPanePty(
       const currentPtyId = transport.getPtyId()
       if (currentPtyId && !getFitOverrideForPty(currentPtyId)) {
         safeFit(pane)
-        transport.resize(pane.terminal.cols, pane.terminal.rows)
-        if (!isRemoteRuntimePtyId(currentPtyId)) {
-          window.api.pty.signal(currentPtyId, 'SIGWINCH')
+        const replayChangedDimensions = hasSnapshotDimensions
+          ? pane.terminal.cols !== snapshot.cols || pane.terminal.rows !== snapshot.rows
+          : pane.terminal.cols !== colsBeforeReplay || pane.terminal.rows !== rowsBeforeReplay
+        if (replayChangedDimensions && isRendererPtyResizeAuthoritative()) {
+          transport.resize(pane.terminal.cols, pane.terminal.rows)
+          if (!isRemoteRuntimePtyId(currentPtyId)) {
+            // Why: redundant SIGWINCH can make alternate-screen TUIs rebuild
+            // their internal scroll viewport to the top on tab return.
+            window.api.pty.signal(currentPtyId, 'SIGWINCH')
+          }
         }
         scheduleReattachIdleAgentCursorReset()
       }

--- a/tests/e2e/terminal-tab-switch-sigwinch-restore.spec.ts
+++ b/tests/e2e/terminal-tab-switch-sigwinch-restore.spec.ts
@@ -1,0 +1,294 @@
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getActiveTabId,
+  getActiveWorktreeId,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import {
+  getTerminalContent,
+  sendToTerminal,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+
+const SIGWINCH_PROBE_PAGE = 100
+const SIGWINCH_PROBE_ROWS = 12
+
+type HiddenOutputDebugSnapshot = {
+  hiddenRendererSkipCount: number
+}
+
+type HiddenOutputRecoveryWindow = Window & {
+  __terminalPtyDataInjection?: {
+    inject: (paneKey: string, data: string, meta?: { seq?: number; rawLength?: number }) => boolean
+  }
+  __terminalPtyOutputDebug?: {
+    reset: () => void
+    snapshot: () => HiddenOutputDebugSnapshot
+  }
+  __terminalHiddenSnapshotOverride?: {
+    setPending: (
+      ptyId: string,
+      snapshot: { data: string; cols: number; rows: number; seq?: number }
+    ) => void
+    resolve: (ptyId: string) => void
+  }
+}
+
+function buildSigwinchProbeRows(page: number): string {
+  return Array.from(
+    { length: SIGWINCH_PROBE_ROWS },
+    (_, index) => `row ${String(page + index).padStart(3, '0')}`
+  ).join('\r\n')
+}
+
+function buildSigwinchResetProbeCommand(): string {
+  const script = [
+    'let armed=false',
+    `let page=${SIGWINCH_PROBE_PAGE}`,
+    "const topLabel=['TOP','AFTER','SIGWINCH'].join('_')",
+    `function paint(label){process.stdout.write('\\x1b[?1049h\\x1b[2J\\x1b[H'+label+' page='+page+'\\r\\n'+Array.from({length:${SIGWINCH_PROBE_ROWS}},(_,i)=>'row '+String(page+i).padStart(3,'0')).join('\\r\\n'))}`,
+    "paint('VISIBLE_BEFORE_SWITCH')",
+    "process.stdin.setEncoding('utf8')",
+    "process.stdin.on('data',data=>{if(data.includes('ARM_SIGWINCH_PROBE')){armed=true;paint('ARMED_BEFORE_SWITCH')}})",
+    "process.on('SIGWINCH',()=>{if(armed===false)return;page=0;paint(topLabel)})",
+    'setInterval(()=>{},1000)'
+  ].join(';')
+  return `node -e ${JSON.stringify(script)}`
+}
+
+function buildSigwinchResetProbeSnapshot(label: string): string {
+  return `\x1b[?1049h\x1b[2J\x1b[H${label} page=${SIGWINCH_PROBE_PAGE}\r\n${buildSigwinchProbeRows(SIGWINCH_PROBE_PAGE)}`
+}
+
+async function createAgentMarkedTerminalTab(
+  page: Page,
+  agent: 'codex',
+  command: string
+): Promise<string> {
+  const worktreeId = (await getActiveWorktreeId(page))!
+  return page.evaluate(
+    ({ worktreeId, agent, command }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Store unavailable')
+      }
+      const state = store.getState()
+      const tab = state.createTab(worktreeId, undefined, undefined, {
+        launchAgent: agent
+      })
+      state.queueTabStartupCommand(tab.id, {
+        command,
+        launchAgent: agent,
+        telemetry: {
+          agent_kind: agent,
+          launch_source: 'tab_bar_quick_launch',
+          request_kind: 'new'
+        }
+      })
+      state.setActiveTab(tab.id)
+      state.setActiveTabType('terminal')
+      return tab.id
+    },
+    { worktreeId, agent, command }
+  )
+}
+
+async function activateTerminalTab(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    store.getState().setActiveTab(id)
+    store.getState().setActiveTabType('terminal')
+  }, tabId)
+  await expect
+    .poll(
+      () =>
+        page
+          .locator(`[data-testid="sortable-tab"][data-active="true"]`)
+          .getAttribute('data-tab-id'),
+      {
+        timeout: 3_000
+      }
+    )
+    .toBe(tabId)
+}
+
+async function waitForPanePtyIdOnTab(page: Page, tabId: string): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate((id) => {
+          const manager = window.__paneManagers?.get(id)
+          const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+          return pane?.container?.dataset?.ptyId ?? null
+        }, tabId),
+      { timeout: 15_000, message: `Pane for tab ${tabId} did not receive a PTY binding` }
+    )
+    .not.toBeNull()
+}
+
+async function readPaneIdentityOnTab(
+  page: Page,
+  tabId: string
+): Promise<{ leafId: string; ptyId: string; cols: number; rows: number }> {
+  const identity = await page.evaluate((tabId) => {
+    const manager = window.__paneManagers?.get(tabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      return null
+    }
+    return {
+      leafId: pane.container.dataset.leafId ?? null,
+      ptyId: pane.container.dataset.ptyId ?? null,
+      cols: pane.terminal.cols,
+      rows: pane.terminal.rows
+    }
+  }, tabId)
+  if (!identity?.leafId || !identity.ptyId) {
+    throw new Error(`Pane identity for tab ${tabId} is incomplete`)
+  }
+  return {
+    leafId: identity.leafId,
+    ptyId: identity.ptyId,
+    cols: identity.cols,
+    rows: identity.rows
+  }
+}
+
+async function resetHiddenOutputDebug(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    ;(window as HiddenOutputRecoveryWindow).__terminalPtyOutputDebug?.reset()
+  })
+}
+
+async function readHiddenOutputDebug(page: Page): Promise<HiddenOutputDebugSnapshot | null> {
+  return page.evaluate(() => {
+    return (window as HiddenOutputRecoveryWindow).__terminalPtyOutputDebug?.snapshot() ?? null
+  })
+}
+
+async function injectPaneData(
+  page: Page,
+  paneKey: string,
+  data: string,
+  meta?: { seq?: number; rawLength?: number }
+): Promise<void> {
+  const injected = await page.evaluate(
+    ({ paneKey, data, meta }) =>
+      (window as HiddenOutputRecoveryWindow).__terminalPtyDataInjection?.inject(
+        paneKey,
+        data,
+        meta
+      ) ?? false,
+    { paneKey, data, meta }
+  )
+  if (!injected) {
+    throw new Error(`No terminal PTY data injector registered for ${paneKey}`)
+  }
+}
+
+async function setHiddenSnapshotOverride(
+  page: Page,
+  ptyId: string,
+  snapshot: { data: string; cols: number; rows: number; seq?: number }
+): Promise<void> {
+  await page.evaluate(
+    ({ ptyId, snapshot }) => {
+      const api = (window as HiddenOutputRecoveryWindow).__terminalHiddenSnapshotOverride
+      if (!api) {
+        throw new Error('Hidden snapshot override API unavailable')
+      }
+      api.setPending(ptyId, snapshot)
+      api.resolve(ptyId)
+    },
+    { ptyId, snapshot }
+  )
+}
+
+test.describe('Terminal tab switch SIGWINCH restore', () => {
+  test('keeps an alternate-screen Codex viewport after hidden snapshot replay', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const shellTabId = (await getActiveTabId(orcaPage))!
+    const agentTabId = await createAgentMarkedTerminalTab(
+      orcaPage,
+      'codex',
+      buildSigwinchResetProbeCommand()
+    )
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await waitForPanePtyIdOnTab(orcaPage, agentTabId)
+    await expect
+      .poll(() => getTerminalContent(orcaPage, 8_000), {
+        timeout: 10_000,
+        message: 'SIGWINCH probe TUI did not paint its initial scrolled page'
+      })
+      .toContain(`VISIBLE_BEFORE_SWITCH page=${SIGWINCH_PROBE_PAGE}`)
+    const paneIdentity = await readPaneIdentityOnTab(orcaPage, agentTabId)
+    await sendToTerminal(orcaPage, paneIdentity.ptyId, 'ARM_SIGWINCH_PROBE\n')
+    await expect
+      .poll(() => getTerminalContent(orcaPage, 8_000), {
+        timeout: 10_000,
+        message: 'SIGWINCH probe TUI did not arm after startup settled'
+      })
+      .toContain(`ARMED_BEFORE_SWITCH page=${SIGWINCH_PROBE_PAGE}`)
+    await orcaPage.waitForTimeout(1_200)
+    const armedContentAfterSettle = await getTerminalContent(orcaPage, 8_000)
+    expect(armedContentAfterSettle).not.toContain('TOP_AFTER_SIGWINCH page=0')
+    const paneKey = `${agentTabId}:${paneIdentity.leafId}`
+
+    await activateTerminalTab(orcaPage, shellTabId)
+    const hiddenFrame = ['\x1b[?2026h', 'hidden probe frame', '\x1b[?2026l'].join('\r\n')
+    await resetHiddenOutputDebug(orcaPage)
+    await injectPaneData(orcaPage, paneKey, hiddenFrame, {
+      seq: hiddenFrame.length,
+      rawLength: hiddenFrame.length
+    })
+
+    await expect
+      .poll(async () => (await readHiddenOutputDebug(orcaPage))?.hiddenRendererSkipCount ?? 0, {
+        timeout: 5_000,
+        message: 'Codex probe hidden output did not take the skipped renderer path'
+      })
+      .toBeGreaterThan(0)
+    await setHiddenSnapshotOverride(orcaPage, paneIdentity.ptyId, {
+      data: buildSigwinchResetProbeSnapshot('RESTORED_SNAPSHOT'),
+      cols: paneIdentity.cols,
+      rows: paneIdentity.rows,
+      seq: hiddenFrame.length
+    })
+
+    await activateTerminalTab(orcaPage, agentTabId)
+
+    await expect
+      .poll(
+        async () => {
+          const content = await getTerminalContent(orcaPage, 8_000)
+          if (content.includes('TOP_AFTER_SIGWINCH page=0')) {
+            return 'top'
+          }
+          return content.includes(`RESTORED_SNAPSHOT page=${SIGWINCH_PROBE_PAGE}`)
+            ? 'snapshot'
+            : 'pending'
+        },
+        {
+          timeout: 10_000,
+          message: 'hidden snapshot replay did not restore the probe TUI page'
+        }
+      )
+      .toBe('snapshot')
+    await orcaPage.waitForTimeout(1_200)
+    const contentAfterSettle = await getTerminalContent(orcaPage, 8_000)
+    expect(contentAfterSettle).toContain(`RESTORED_SNAPSHOT page=${SIGWINCH_PROBE_PAGE}`)
+    expect(contentAfterSettle).not.toContain('TOP_AFTER_SIGWINCH page=0')
+  })
+})


### PR DESCRIPTION
## Summary

Prevents alternate-screen terminal applications (such as TUIs like `less`, `vim`, etc.) from scrolling or resetting their viewport to the top when switching tabs. 

This bug was caused by redundant `SIGWINCH` signals triggered on terminal tab restoration. Specifically, when a hidden terminal tab is restored, hidden layout fitting and snapshot replays forced terminal resizing and sent unnecessary `SIGWINCH` signals to the PTY, waking/disrupting inactive TUIs.

This change fixes the issue by:
- Restricting hidden-tab layout fitting to the initial first-launch measurement.
- Making renderer PTY resizes non-authoritative when the tab is hidden or during snapshot replay.
- Suppressing PTY resizing and `SIGWINCH` signals during snapshot replay when dimensions are unchanged.

## Screenshots

No visual change (fixes viewport reset glitch on tab switch).

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

### Testing Notes
- Added a new comprehensive Playwright E2E test: `tests/e2e/terminal-tab-switch-sigwinch-restore.spec.ts` which verifies that alternate-screen terminal alternate viewports are preserved after tab switching and snapshot replay.
- Added new unit tests in `src/renderer/src/components/terminal-pane/pty-connection.test.ts` to assert that terminal resizes are not forwarded when hidden, and that `SIGWINCH` is not signaled after hidden snapshot replay when dimensions are unchanged.

## AI Review Report

The code changes were reviewed to ensure correct handling of terminal pane state and PTY signals:
- **Viewport/Signal Risks**: Verified that suppressing resizing during snapshot replay (`suppressSnapshotReplayPtyResize`) does not cause desync of dimensions when the tab is actually focused. Visible tabs still trigger authoritative resizing on active tab switch.
- **Cross-Platform Compatibility**: Checked for compatibility across macOS, Linux, and Windows. No OS-specific paths or commands were introduced in the application code. Keyboard shortcuts and labels were not touched. The PTY signal API is cross-platform. E2E tests are designed to run in a standard environment.

## Security Audit

- **Input/Command Risks**: No new commands are executed on the host except via existing authenticated terminal APIs.
- **IPC Risks**: No new IPC handlers or channels were registered or modified. Existing `window.api.pty.signal` and `transport.resize` are used safely with pre-existing sanitized PTY IDs.
- **Path/Dependency Risks**: No paths are handled, and no new dependencies have been added.

## Notes

No platform-specific risks are introduced by this PR. Alternate screen TUI behaviors are handled identically across Linux/macOS, and the dimensions suppression is safely bypassed on active renderer windows.