### PR TITLE
fix: defer hook task-complete when PTY still has children

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -41,6 +41,14 @@ function createRejectableDeferred<T>(): {
 
 const HOOK_DONE_QUIET_MS = 1_500
 
+async function elapseHookDoneQuiet(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(HOOK_DONE_QUIET_MS)
+}
+
+function inspectNoChildProcesses(): ReturnType<typeof vi.fn> {
+  return vi.fn(async () => processResult(null, false))
+}
+
 describe('agent completion coordinator', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -372,13 +380,13 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledWith('Fix flaky e2e tests')
   })
 
-  it('suppresses same-turn title completion after a hook completion already notified', () => {
+  it('suppresses same-turn title completion after a hook completion already notified', async () => {
     const dispatchCompletion = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
-      inspectProcess: vi.fn(),
+      inspectProcess: inspectNoChildProcesses(),
       dispatchCompletion,
       isLive: () => true
     })
@@ -394,7 +402,7 @@ describe('agent completion coordinator', () => {
       agentType: 'codex'
     })
     coordinator.observeClassifiedTitleCompletion('codex done')
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
     expect(dispatchCompletion).toHaveBeenCalledWith(
@@ -509,7 +517,7 @@ describe('agent completion coordinator', () => {
       agentType: 'codex',
       stateStartedAt: 1_700_000_000_000
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
 
@@ -567,13 +575,13 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
   })
 
-  it('can require a fresh working signal after completion state reset', () => {
+  it('can require a fresh working signal after completion state reset', async () => {
     const dispatchCompletion = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
-      inspectProcess: vi.fn(),
+      inspectProcess: inspectNoChildProcesses(),
       dispatchCompletion,
       isLive: () => true
     })
@@ -602,7 +610,7 @@ describe('agent completion coordinator', () => {
       prompt: '',
       agentType: 'codex'
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(2)
   })
@@ -724,13 +732,13 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
   })
 
-  it('suppresses the same hook completion replay after fresh work starts', () => {
+  it('suppresses the same hook completion replay after fresh work starts', async () => {
     const dispatchCompletion = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
-      inspectProcess: vi.fn(),
+      inspectProcess: inspectNoChildProcesses(),
       dispatchCompletion,
       isLive: () => true
     })
@@ -752,7 +760,7 @@ describe('agent completion coordinator', () => {
     })
     vi.advanceTimersByTime(5_000)
     coordinator.observeHookStatus(completedTurn)
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
 
@@ -762,18 +770,18 @@ describe('agent completion coordinator', () => {
       agentType: 'codex',
       stateStartedAt: 1_700_000_020_000
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(2)
   })
 
-  it('suppresses same-agent title replay after hook-backed fresh work starts', () => {
+  it('suppresses same-agent title replay after hook-backed fresh work starts', async () => {
     const dispatchCompletion = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
-      inspectProcess: vi.fn(),
+      inspectProcess: inspectNoChildProcesses(),
       dispatchCompletion,
       isLive: () => true
     })
@@ -790,7 +798,7 @@ describe('agent completion coordinator', () => {
       agentType: 'codex',
       stateStartedAt: 1_700_000_010_000
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
 
     coordinator.observeHookStatus({
@@ -809,7 +817,7 @@ describe('agent completion coordinator', () => {
       agentType: 'codex',
       stateStartedAt: 1_700_000_030_000
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(2)
   })
@@ -847,13 +855,13 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledTimes(2)
   })
 
-  it('suppresses stale title completion replay after a hook completion remount', () => {
+  it('suppresses stale title completion replay after a hook completion remount', async () => {
     const dispatchCompletion = vi.fn()
     const firstCoordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
-      inspectProcess: vi.fn(),
+      inspectProcess: inspectNoChildProcesses(),
       dispatchCompletion,
       isLive: () => true
     })
@@ -871,6 +879,7 @@ describe('agent completion coordinator', () => {
       stateStartedAt: 1_700_000_010_000
     })
     vi.advanceTimersByTime(5_000)
+    await flushAsyncTicks()
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
     firstCoordinator.dispose()
 
@@ -878,7 +887,7 @@ describe('agent completion coordinator', () => {
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
-      inspectProcess: vi.fn(),
+      inspectProcess: inspectNoChildProcesses(),
       dispatchCompletion,
       isLive: () => true
     })
@@ -891,13 +900,13 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledTimes(2)
   })
 
-  it('cancels a hook completion when the same turn resumes work before the quiet window', () => {
+  it('cancels a hook completion when the same turn resumes work before the quiet window', async () => {
     const dispatchCompletion = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
-      inspectProcess: vi.fn(),
+      inspectProcess: inspectNoChildProcesses(),
       dispatchCompletion,
       isLive: () => true
     })
@@ -913,7 +922,7 @@ describe('agent completion coordinator', () => {
       agentType: 'codex'
     })
     expect(coordinator.hasPendingHookDoneCompletion()).toBe(true)
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS - 1)
+    await vi.advanceTimersByTimeAsync(HOOK_DONE_QUIET_MS - 1)
     expect(dispatchCompletion).not.toHaveBeenCalled()
 
     coordinator.observeHookStatus({
@@ -922,7 +931,7 @@ describe('agent completion coordinator', () => {
       agentType: 'codex'
     })
     expect(coordinator.hasPendingHookDoneCompletion()).toBe(false)
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await vi.advanceTimersByTimeAsync(HOOK_DONE_QUIET_MS)
     expect(dispatchCompletion).not.toHaveBeenCalled()
 
     coordinator.observeHookStatus({
@@ -930,7 +939,7 @@ describe('agent completion coordinator', () => {
       prompt: 'run the goal',
       agentType: 'codex'
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
     expect(dispatchCompletion).toHaveBeenCalledWith(
@@ -1010,13 +1019,13 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledWith(agentType)
   })
 
-  it('notifies once after a Cursor tool-heavy turn, not on each shell hook', () => {
+  it('notifies once after a Cursor tool-heavy turn, not on each shell hook', async () => {
     const dispatchCompletion = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
-      inspectProcess: vi.fn(),
+      inspectProcess: inspectNoChildProcesses(),
       dispatchCompletion,
       isLive: () => true
     })
@@ -1049,7 +1058,7 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).not.toHaveBeenCalled()
 
     coordinator.observeHookStatus({ state: 'done', ...turn, lastAssistantMessage: 'Fixed.' })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -68,6 +68,8 @@ export function createAgentCompletionCoordinator(
   let pendingHookDoneTimer: ReturnType<typeof setTimeout> | null = null
   let pendingHookDoneTitle: string | null = null
   let pendingHookDonePayload: AgentCompletionStatusSnapshot | null = null
+  let pendingHookDoneGeneration = 0
+  let hookDoneInspectionInFlight = false
   let pendingProcessExitAgent: RecognizedAgentProcess | null = null
   let pendingTitleSequence = 0
   let pendingTitle: {
@@ -99,6 +101,7 @@ export function createAgentCompletionCoordinator(
   }
 
   function clearPendingHookDone(): void {
+    pendingHookDoneGeneration += 1
     if (pendingHookDoneTimer !== null) {
       clearTimeout(pendingHookDoneTimer)
       pendingHookDoneTimer = null
@@ -258,6 +261,8 @@ export function createAgentCompletionCoordinator(
     if (pendingHookDoneTimer !== null) {
       return
     }
+    const generationAtSchedule = pendingHookDoneGeneration
+    const turnAtSchedule = currentTurn
     // Why: goal/mission agents can report a temporary done state between
     // milestones. Wait for a short quiet window so resumed work can cancel it.
     pendingHookDoneTimer = setTimeout(() => {
@@ -271,14 +276,28 @@ export function createAgentCompletionCoordinator(
           return
         }
         const ptyId = options.getPtyId()
+        let hasChildProcesses = false
         if (ptyId) {
+          hookDoneInspectionInFlight = true
           try {
             const inspection = await options.inspectProcess(options.getSettings(), ptyId)
-            if (inspection.hasChildProcesses && pendingPayload) {
-              scheduleHookDoneCompletion(pendingTitle, pendingPayload)
-              return
-            }
-          } catch {}
+            hasChildProcesses = inspection.hasChildProcesses
+          } catch {
+          } finally {
+            hookDoneInspectionInFlight = false
+          }
+        }
+        if (
+          disposed ||
+          !options.isLive() ||
+          generationAtSchedule !== pendingHookDoneGeneration ||
+          turnAtSchedule !== currentTurn
+        ) {
+          return
+        }
+        if (hasChildProcesses && pendingPayload) {
+          scheduleHookDoneCompletion(pendingTitle, pendingPayload)
+          return
         }
         const hookIdentity = pendingPayload ? hookCompletionIdentity(pendingPayload) : null
         dispatchCompletion('hook', pendingTitle, {
@@ -498,7 +517,7 @@ export function createAgentCompletionCoordinator(
   }
 
   function shouldRunCadenceInspection(): boolean {
-    if (pendingHookDoneTimer !== null) {
+    if (pendingHookDoneTimer !== null || hookDoneInspectionInFlight) {
       return false
     }
     // Why: hidden idle terminals should not join the global process-inspection

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -217,7 +217,12 @@ export function createAgentCompletionCoordinator(
     if (requiresFreshWorking || lastCompletedTurn === currentTurn) {
       return
     }
-    if (!options.isLive() || !hasAgentRunEvidence) {
+    if (!options.isLive()) {
+      return
+    }
+    const hookQuietHasRunEvidence =
+      optionsOverride.quietedHookDone === true && optionsOverride.agentStatus !== undefined
+    if (!hasAgentRunEvidence && !hookQuietHasRunEvidence) {
       return
     }
     const now = Date.now()
@@ -256,12 +261,25 @@ export function createAgentCompletionCoordinator(
     // Why: goal/mission agents can report a temporary done state between
     // milestones. Wait for a short quiet window so resumed work can cancel it.
     pendingHookDoneTimer = setTimeout(() => {
-      pendingHookDoneTimer = null
-      const pendingTitle = pendingHookDoneTitle
-      const pendingPayload = pendingHookDonePayload
-      pendingHookDoneTitle = null
-      pendingHookDonePayload = null
-      if (pendingTitle) {
+      void (async () => {
+        pendingHookDoneTimer = null
+        const pendingTitle = pendingHookDoneTitle
+        const pendingPayload = pendingHookDonePayload
+        pendingHookDoneTitle = null
+        pendingHookDonePayload = null
+        if (!pendingTitle) {
+          return
+        }
+        const ptyId = options.getPtyId()
+        if (ptyId) {
+          try {
+            const inspection = await options.inspectProcess(options.getSettings(), ptyId)
+            if (inspection.hasChildProcesses && pendingPayload) {
+              scheduleHookDoneCompletion(pendingTitle, pendingPayload)
+              return
+            }
+          } catch {}
+        }
         const hookIdentity = pendingPayload ? hookCompletionIdentity(pendingPayload) : null
         dispatchCompletion('hook', pendingTitle, {
           quietedHookDone: true,
@@ -276,7 +294,7 @@ export function createAgentCompletionCoordinator(
               }
             : {})
         })
-      }
+      })()
     }, HOOK_DONE_QUIET_MS)
   }
 
@@ -406,7 +424,10 @@ export function createAgentCompletionCoordinator(
       clearAgentRunEvidence()
     } else {
       lastForegroundAgent = null
-      clearAgentRunEvidence()
+      agentIdentityEstablished = false
+      hasAgentRunEvidence = false
+      pendingProcessExitAgent = null
+      dropPendingTitle()
     }
     return false
   }
@@ -477,6 +498,9 @@ export function createAgentCompletionCoordinator(
   }
 
   function shouldRunCadenceInspection(): boolean {
+    if (pendingHookDoneTimer !== null) {
+      return false
+    }
     // Why: hidden idle terminals should not join the global process-inspection
     // cadence. Once a pane has agent evidence, keep the backstop alive so an
     // unannounced process exit can still produce/clear completion state.

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
@@ -3,6 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 
 const dispatchTerminalNotification = vi.fn()
+const inspectRuntimeTerminalProcess = vi.fn(async () => ({
+  foregroundProcess: null,
+  hasChildProcesses: false
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  inspectRuntimeTerminalProcess
+}))
 
 type MockStoreState = {
   settings: {
@@ -28,6 +36,10 @@ type MockStoreState = {
 
 let mockStoreState: MockStoreState
 const HOOK_DONE_QUIET_MS = 1_500
+
+async function elapseHookDoneQuiet(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(HOOK_DONE_QUIET_MS)
+}
 
 vi.mock('@/store', () => ({
   useAppStore: {
@@ -55,6 +67,11 @@ describe('agent hook completion notifications', () => {
     vi.resetModules()
     vi.useFakeTimers()
     dispatchTerminalNotification.mockClear()
+    inspectRuntimeTerminalProcess.mockClear()
+    inspectRuntimeTerminalProcess.mockResolvedValue({
+      foregroundProcess: null,
+      hasChildProcesses: false
+    })
     mockStoreState = {
       settings: {
         experimentalTerminalAttention: false,
@@ -106,7 +123,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(
       'wt-1',
@@ -134,7 +151,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(
       'wt-1',
@@ -168,7 +185,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(
       'wt-1',
@@ -207,7 +224,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(
       'wt-1',
@@ -249,7 +266,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(
       'wt-1',
@@ -280,7 +297,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: { ...hookStatus('done'), stateStartedAt: 1_700_000_010_000 }
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(
       'wt-1',
@@ -309,7 +326,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: { ...hookStatus('done'), stateStartedAt: 1_700_000_010_000 }
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchTerminalNotification).toHaveBeenCalledTimes(1)
 
@@ -318,7 +335,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: { ...hookStatus('done'), stateStartedAt: 1_700_000_010_000 }
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchTerminalNotification).toHaveBeenCalledTimes(1)
   })
@@ -369,7 +386,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(_getAgentHookCompletionNotificationCoordinatorCountForTest()).toBe(0)
     expect(dispatchTerminalNotification).not.toHaveBeenCalled()
@@ -436,7 +453,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('working')
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await vi.advanceTimersByTimeAsync(HOOK_DONE_QUIET_MS)
     expect(dispatchTerminalNotification).not.toHaveBeenCalled()
 
     observeAgentHookCompletionForNotification({
@@ -444,7 +461,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
-    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    await elapseHookDoneQuiet()
 
     expect(dispatchTerminalNotification).toHaveBeenCalledTimes(1)
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.ts
@@ -5,7 +5,7 @@ import type {
   AgentCompletionCoordinator,
   AgentCompletionStatusSnapshot
 } from '@/components/terminal-pane/agent-completion-coordinator-types'
-import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
+import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
 import { dispatchTerminalNotification } from '@/components/terminal-pane/use-notification-dispatch'
 import { collectLeafIdsInOrder } from '@/components/terminal-pane/layout-serialization'
 
@@ -146,10 +146,7 @@ function createCoordinator(paneKey: string, worktreeId: string): AgentCompletion
     paneKey,
     getPtyId: () => getPtyIdForPaneKey(paneKey),
     getSettings: () => useAppStore.getState().settings,
-    inspectProcess: async (): Promise<RuntimeTerminalProcessInspection> => ({
-      foregroundProcess: null,
-      hasChildProcesses: false
-    }),
+    inspectProcess: inspectRuntimeTerminalProcess,
     dispatchCompletion: (title, meta) => {
       dispatchTerminalNotification(worktreeId, {
         source: 'agent-task-complete',


### PR DESCRIPTION
## Summary
- Use real `inspectRuntimeTerminalProcess` on the hook completion notification path (replacing a stub that always reported no PTY children).
- After the hook `done` quiet window, inspect the pane PTY; if child processes remain, reschedule the same quiet window before dispatching `agent-task-complete`.
- Prevent cadence process inspection from clearing hook turn/evidence state while the async hook-done probe runs.

## Issue
Fixes #6100

## Test plan
- [x] `pnpm exec vitest run src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts --config config/vitest.config.ts`

## ELI5

Task-complete notifications could fire while the terminal still had child processes running. Orca re-checks the PTY after the quiet window and waits again if children remain.
