### PR TITLE
Show all change items in combined diff

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffFileTree.test.ts
+++ b/src/renderer/src/components/editor/CombinedDiffFileTree.test.ts
@@ -41,8 +41,23 @@ describe('CombinedDiffFileTree navigation mapping', () => {
   it('maps branch and commit entries to combined section prefixes', () => {
     const entry: GitBranchChangeEntry = { path: 'src/view.ts', status: 'renamed' }
 
+    expect(getCombinedDiffFileTreeSectionKey('all', entry)).toBe('combined-branch:src/view.ts')
     expect(getCombinedDiffFileTreeSectionKey('branch', entry)).toBe('combined-branch:src/view.ts')
     expect(getCombinedDiffFileTreeSectionKey('commit', entry)).toBe('combined-commit:src/view.ts')
+  })
+
+  it('keeps all-changes local and branch entries separate', () => {
+    const localEntry: GitStatusEntry = {
+      path: 'src/view.ts',
+      status: 'modified',
+      area: 'unstaged'
+    }
+    const branchEntry: GitBranchChangeEntry = { path: 'src/view.ts', status: 'modified' }
+
+    expect(getCombinedDiffFileTreeSectionKey('all', localEntry)).toBe('unstaged:src/view.ts')
+    expect(getCombinedDiffFileTreeSectionKey('all', branchEntry)).toBe(
+      'combined-branch:src/view.ts'
+    )
   })
 
   it('expands a collapsed target section and scrolls to its index', () => {

--- a/src/renderer/src/components/editor/CombinedDiffFileTree.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffFileTree.tsx
@@ -61,14 +61,14 @@ function buildUncommittedRows(
 }
 
 function buildBranchRows(
-  mode: Extract<CombinedDiffFileTreeMode, 'branch' | 'commit'>,
+  mode: Extract<CombinedDiffFileTreeMode, 'all' | 'branch' | 'commit'>,
   entries: readonly CombinedDiffFileTreeEntry[],
   collapsedDirectoryKeys: ReadonlySet<string>
 ): CombinedDiffTreeNode[] {
   const branchEntries = entries.filter(
     (entry): entry is GitBranchChangeEntry => !isGitStatusEntry(entry)
   )
-  const area: CombinedDiffBranchTreeArea = mode === 'branch' ? 'combined-branch' : 'combined-commit'
+  const area: CombinedDiffBranchTreeArea = mode === 'commit' ? 'combined-commit' : 'combined-branch'
   const roots = compactSourceControlTree(buildSourceControlTree(area, branchEntries))
   return flattenSourceControlTree(roots, collapsedDirectoryKeys) as CombinedDiffTreeNode[]
 }
@@ -149,12 +149,14 @@ export function CombinedDiffFileTree({
 
   const uncommittedGroups = React.useMemo(
     () =>
-      mode === 'uncommitted' ? buildUncommittedRows(filteredEntries, collapsedDirectoryKeys) : [],
+      mode === 'all' || mode === 'uncommitted'
+        ? buildUncommittedRows(filteredEntries, collapsedDirectoryKeys)
+        : [],
     [collapsedDirectoryKeys, filteredEntries, mode]
   )
   const branchRows = React.useMemo(
     () =>
-      mode === 'branch' || mode === 'commit'
+      mode === 'all' || mode === 'branch' || mode === 'commit'
         ? buildBranchRows(mode, filteredEntries, collapsedDirectoryKeys)
         : [],
     [collapsedDirectoryKeys, filteredEntries, mode]
@@ -280,27 +282,52 @@ export function CombinedDiffFileTree({
               'No files match the current filters.'
             )}
           </div>
-        ) : mode === 'uncommitted' ? (
-          uncommittedGroups.map((group) => (
-            <div key={group.area} className="py-1">
-              <div className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-                {group.label}
+        ) : mode === 'all' || mode === 'uncommitted' ? (
+          <>
+            {uncommittedGroups.map((group) => (
+              <div key={group.area} className="py-1">
+                <div className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+                  {group.label}
+                </div>
+                {group.rows.map((node) => (
+                  <CombinedDiffFileTreeRow
+                    key={node.key}
+                    node={node}
+                    mode={mode}
+                    worktreePath={worktreePath}
+                    activeSectionKey={activeSectionKey}
+                    sectionIndexByKey={sectionIndexByKey}
+                    isCollapsed={collapsedDirectoryKeys.has(node.key)}
+                    onToggleDirectory={toggleDirectory}
+                    onNavigate={onNavigate}
+                  />
+                ))}
               </div>
-              {group.rows.map((node) => (
-                <CombinedDiffFileTreeRow
-                  key={node.key}
-                  node={node}
-                  mode={mode}
-                  worktreePath={worktreePath}
-                  activeSectionKey={activeSectionKey}
-                  sectionIndexByKey={sectionIndexByKey}
-                  isCollapsed={collapsedDirectoryKeys.has(node.key)}
-                  onToggleDirectory={toggleDirectory}
-                  onNavigate={onNavigate}
-                />
-              ))}
-            </div>
-          ))
+            ))}
+            {mode === 'all' && branchRows.length > 0 ? (
+              <div className="py-1">
+                <div className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+                  {translate(
+                    'auto.components.editor.CombinedDiffFileTree.39b6b9e4e4',
+                    'Committed on Branch'
+                  )}
+                </div>
+                {branchRows.map((node) => (
+                  <CombinedDiffFileTreeRow
+                    key={node.key}
+                    node={node}
+                    mode={mode}
+                    worktreePath={worktreePath}
+                    activeSectionKey={activeSectionKey}
+                    sectionIndexByKey={sectionIndexByKey}
+                    isCollapsed={collapsedDirectoryKeys.has(node.key)}
+                    onToggleDirectory={toggleDirectory}
+                    onNavigate={onNavigate}
+                  />
+                ))}
+              </div>
+            ) : null}
+          </>
         ) : (
           branchRows.map((node) => (
             <CombinedDiffFileTreeRow

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -361,6 +361,7 @@ export default function CombinedDiffViewer({
 
   const isBranchMode = file.diffSource === 'combined-branch'
   const isCommitMode = file.diffSource === 'combined-commit'
+  const isAllMode = file.diffSource === 'combined-all'
   const branchCompare =
     file.branchCompare?.baseOid && file.branchCompare.headOid && file.branchCompare.mergeBase
       ? file.branchCompare
@@ -385,12 +386,32 @@ export default function CombinedDiffViewer({
   const branchEntries = React.useMemo<GitBranchChangeEntry[]>(() => {
     return getCombinedBranchEntries(file.branchEntriesSnapshot, liveBranchEntries)
   }, [file.branchEntriesSnapshot, liveBranchEntries])
+  const renderableBranchEntries = React.useMemo(
+    () => (branchCompare ? branchEntries : []),
+    [branchCompare, branchEntries]
+  )
   const commitEntries = React.useMemo<GitBranchChangeEntry[]>(
     () => file.commitEntriesSnapshot ?? [],
     [file.commitEntriesSnapshot]
   )
-  const entries = isBranchMode ? branchEntries : isCommitMode ? commitEntries : uncommittedEntries
-  const treeMode = isBranchMode ? 'branch' : isCommitMode ? 'commit' : 'uncommitted'
+  const allEntries = React.useMemo(
+    () => [...uncommittedEntries, ...renderableBranchEntries],
+    [renderableBranchEntries, uncommittedEntries]
+  )
+  const entries = isAllMode
+    ? allEntries
+    : isBranchMode
+      ? renderableBranchEntries
+      : isCommitMode
+        ? commitEntries
+        : uncommittedEntries
+  const treeMode = isAllMode
+    ? 'all'
+    : isBranchMode
+      ? 'branch'
+      : isCommitMode
+        ? 'commit'
+        : 'uncommitted'
   const hasUncommittedEntriesSnapshot = file.uncommittedEntriesSnapshot !== undefined
   const shouldAutoReloadFromGitStatus = shouldAutoReloadCombinedDiffFromGitStatus({
     mode: treeMode,
@@ -477,7 +498,7 @@ export default function CombinedDiffViewer({
     pendingRestoreScrollTopRef.current = combinedDiffScrollTopCache.get(viewStateKey) ?? null
     setSections(
       entries.map((entry) => ({
-        key: `${'area' in entry ? entry.area : (file.diffSource ?? 'compare')}:${entry.path}`,
+        key: getCombinedDiffFileTreeSectionKey(treeMode, entry),
         path: entry.path,
         status: entry.status,
         area: 'area' in entry ? entry.area : undefined,
@@ -500,7 +521,7 @@ export default function CombinedDiffViewer({
     loadSchedulerRef.current.reset()
     generationRef.current += 1
     setGeneration((prev) => prev + 1)
-  }, [entries, entrySignature, file.diffSource, gitStatusEntries, viewStateKey])
+  }, [entries, entrySignature, file.diffSource, gitStatusEntries, treeMode, viewStateKey])
 
   const loadSectionNow = useCallback(
     async (index: number) => {
@@ -510,11 +531,13 @@ export default function CombinedDiffViewer({
       loadingIndicesRef.current.add(index)
 
       const gen = generationRef.current
-      const entries = isBranchMode
-        ? branchEntries
-        : isCommitMode
-          ? commitEntries
-          : uncommittedEntries
+      const entries = isAllMode
+        ? allEntries
+        : isBranchMode
+          ? renderableBranchEntries
+          : isCommitMode
+            ? commitEntries
+            : uncommittedEntries
       const entry = entries[index]
       if (!entry) {
         loadingIndicesRef.current.delete(index)
@@ -527,7 +550,7 @@ export default function CombinedDiffViewer({
         const connectionId = getConnectionId(file.worktreeId) ?? undefined
         const state = useAppStore.getState()
         const fileSettings = settingsForRuntimeOwner(state.settings, file.runtimeEnvironmentId)
-        if (isBranchMode && branchCompare) {
+        if ((isBranchMode || (isAllMode && !('area' in entry))) && branchCompare) {
           result = await withDiffSectionLoadTimeout(
             getRuntimeGitBranchDiff(
               {
@@ -629,14 +652,16 @@ export default function CombinedDiffViewer({
       branchCompare?.baseOid,
       branchCompare?.headOid,
       branchCompare?.mergeBase,
-      branchEntries,
+      allEntries,
       commitCompare?.commitOid,
       commitCompare?.parentOid,
       commitEntries,
       file.filePath,
       file.runtimeEnvironmentId,
+      isAllMode,
       isBranchMode,
       isCommitMode,
+      renderableBranchEntries,
       uncommittedEntries
     ]
   )
@@ -855,7 +880,7 @@ export default function CombinedDiffViewer({
   }, [combinedGitStatusSignature, requestCombinedDiffSectionReload, shouldAutoReloadFromGitStatus])
 
   useEffect(() => {
-    if (treeMode !== 'uncommitted') {
+    if (treeMode !== 'all' && treeMode !== 'uncommitted') {
       return
     }
     const handler = (event: Event): void => {
@@ -927,7 +952,9 @@ export default function CombinedDiffViewer({
         removed: section.removed
       }
 
-      if (isBranchMode && branchCompare) {
+      const isBranchEntry = section.area === undefined
+
+      if ((isBranchMode || (isAllMode && isBranchEntry)) && branchCompare) {
         openBranchDiff(file.worktreeId, file.filePath, entry, branchCompare, language)
         return
       }
@@ -952,6 +979,7 @@ export default function CombinedDiffViewer({
       file.filePath,
       file.runtimeEnvironmentId,
       file.worktreeId,
+      isAllMode,
       isBranchMode,
       isCommitMode,
       openBranchDiff,
@@ -1145,14 +1173,14 @@ export default function CombinedDiffViewer({
       return
     }
 
-    if (file.combinedAlternate.source === 'combined-uncommitted') {
+    if (file.combinedAlternate.source === 'combined-all') {
       openAllDiffs(file.worktreeId, file.filePath)
       return
     }
 
     if (branchSummary && branchSummary.status === 'ready') {
       openBranchAllDiffs(file.worktreeId, file.filePath, branchSummary, {
-        source: 'combined-uncommitted'
+        source: 'combined-all'
       })
     }
   }, [branchSummary, file, openAllDiffs, openBranchAllDiffs])
@@ -1447,7 +1475,7 @@ export default function CombinedDiffViewer({
             <span className="truncate text-xs text-muted-foreground">
               {sections.length}{' '}
               {translate('auto.components.editor.CombinedDiffViewer.7e7ca60816', 'changed files')}
-              {isBranchMode && branchCompare
+              {(isAllMode || isBranchMode) && branchCompare
                 ? translate(
                     'auto.components.editor.CombinedDiffViewer.6094135eec',
                     ' vs {{value0}}',
@@ -1524,7 +1552,7 @@ export default function CombinedDiffViewer({
                     )
                   : translate(
                       'auto.components.editor.CombinedDiffViewer.982d14bfa5',
-                      'Open Uncommitted Diff'
+                      'Open All Changes'
                     )}
               </button>
             )}
@@ -1601,7 +1629,7 @@ export default function CombinedDiffViewer({
                         toggleSection={toggleSection}
                         openSection={openSection}
                         openSectionTitle={
-                          isBranchMode || isCommitMode ? 'Open diff' : 'Open in editor'
+                          isAllMode || isBranchMode || isCommitMode ? 'Open diff' : 'Open in editor'
                         }
                         setSectionHeights={setSectionHeights}
                         setSections={setSections}

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -199,7 +199,8 @@ export function EditorContent({
 
   const isCombinedDiff =
     activeFile.mode === 'diff' &&
-    (activeFile.diffSource === 'combined-uncommitted' ||
+    (activeFile.diffSource === 'combined-all' ||
+      activeFile.diffSource === 'combined-uncommitted' ||
       activeFile.diffSource === 'combined-branch' ||
       activeFile.diffSource === 'combined-commit')
 

--- a/src/renderer/src/components/editor/combined-diff-entries.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-entries.test.ts
@@ -35,7 +35,7 @@ describe('getCombinedUncommittedEntries', () => {
     ])
   })
 
-  it('excludes untracked entries when no area filter is set', () => {
+  it('includes every area when no area filter is set', () => {
     const liveEntries: GitStatusEntry[] = [
       { path: 'src/staged.ts', status: 'modified', area: 'staged' },
       { path: 'src/unstaged.ts', status: 'modified', area: 'unstaged' },
@@ -44,7 +44,8 @@ describe('getCombinedUncommittedEntries', () => {
 
     expect(getCombinedUncommittedEntries(liveEntries, undefined)).toEqual([
       { path: 'src/staged.ts', status: 'modified', area: 'staged' },
-      { path: 'src/unstaged.ts', status: 'modified', area: 'unstaged' }
+      { path: 'src/unstaged.ts', status: 'modified', area: 'unstaged' },
+      { path: 'src/untracked.ts', status: 'untracked', area: 'untracked' }
     ])
   })
 })

--- a/src/renderer/src/components/editor/combined-diff-entries.ts
+++ b/src/renderer/src/components/editor/combined-diff-entries.ts
@@ -15,10 +15,7 @@ export function getCombinedUncommittedEntries(
     if (entry.conflictStatus === 'unresolved') {
       return false
     }
-    if (areaFilter) {
-      return entry.area === areaFilter
-    }
-    return entry.area !== 'untracked'
+    return areaFilter === undefined || entry.area === areaFilter
   })
 }
 

--- a/src/renderer/src/components/editor/combined-diff-file-tree-model.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-model.ts
@@ -2,7 +2,7 @@ import { basename } from '@/lib/path'
 import type { GitBranchChangeEntry, GitStatusEntry } from '../../../../shared/types'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
 
-export type CombinedDiffFileTreeMode = 'uncommitted' | 'branch' | 'commit'
+export type CombinedDiffFileTreeMode = 'all' | 'uncommitted' | 'branch' | 'commit'
 export type CombinedDiffFileTreeEntry = GitStatusEntry | GitBranchChangeEntry
 export type CombinedDiffBranchTreeArea = 'combined-branch' | 'combined-commit'
 
@@ -20,10 +20,10 @@ export function getCombinedDiffFileTreeSectionKey(
   mode: CombinedDiffFileTreeMode,
   entry: CombinedDiffFileTreeEntry
 ): string {
-  if (mode === 'uncommitted' && 'area' in entry) {
+  if ((mode === 'all' || mode === 'uncommitted') && 'area' in entry) {
     return `${entry.area}:${entry.path}`
   }
-  return `${mode === 'branch' ? 'combined-branch' : 'combined-commit'}:${entry.path}`
+  return `${mode === 'commit' ? 'combined-commit' : 'combined-branch'}:${entry.path}`
 }
 
 export function createCombinedDiffSectionIndexMap(

--- a/src/renderer/src/components/editor/editor-header.test.ts
+++ b/src/renderer/src/components/editor/editor-header.test.ts
@@ -98,7 +98,7 @@ describe('getEditorHeaderCopyState', () => {
           filePath: '/repo/worktree',
           relativePath: 'All Changes',
           mode: 'diff',
-          diffSource: 'combined-uncommitted'
+          diffSource: 'combined-all'
         })
       )
     ).toEqual({

--- a/src/renderer/src/components/editor/editor-header.ts
+++ b/src/renderer/src/components/editor/editor-header.ts
@@ -35,7 +35,8 @@ export function getEditorHeaderCopyState(file: OpenFile): EditorHeaderCopyState 
 
   const isCombinedDiff =
     file.mode === 'diff' &&
-    (file.diffSource === 'combined-uncommitted' ||
+    (file.diffSource === 'combined-all' ||
+      file.diffSource === 'combined-uncommitted' ||
       file.diffSource === 'combined-branch' ||
       file.diffSource === 'combined-commit')
 
@@ -66,6 +67,7 @@ export function getEditorHeaderOpenFileState(
   const isSingleDiff =
     file.mode === 'diff' &&
     file.diffSource !== undefined &&
+    file.diffSource !== 'combined-all' &&
     file.diffSource !== 'combined-uncommitted' &&
     file.diffSource !== 'combined-branch' &&
     file.diffSource !== 'combined-commit'

--- a/src/renderer/src/components/editor/editor-labels.ts
+++ b/src/renderer/src/components/editor/editor-labels.ts
@@ -42,8 +42,11 @@ export function getEditorDisplayLabel(
   }
 
   const source = file.diffSource
-  if (source === 'combined-uncommitted') {
+  if (source === 'combined-all') {
     return 'All Changes'
+  }
+  if (source === 'combined-uncommitted') {
+    return file.combinedAreaFilter ? getBaseLabel(file, variant) : 'Uncommitted Changes'
   }
   if (source === 'combined-branch') {
     return `Branch Changes (${file.branchCompare?.baseRef ?? 'base'})`

--- a/src/renderer/src/components/editor/editor-panel-diff-reload.ts
+++ b/src/renderer/src/components/editor/editor-panel-diff-reload.ts
@@ -5,6 +5,7 @@ export function isReloadableSingleFileDiffTab(file: OpenFile): boolean {
   return (
     file.mode === 'diff' &&
     file.diffSource !== undefined &&
+    file.diffSource !== 'combined-all' &&
     file.diffSource !== 'combined-uncommitted' &&
     file.diffSource !== 'combined-branch' &&
     file.diffSource !== 'combined-commit'

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -40,12 +40,14 @@ export function getEditorPanelRenderModel({
   const isSingleDiff =
     activeFile.mode === 'diff' &&
     activeFile.diffSource !== undefined &&
+    activeFile.diffSource !== 'combined-all' &&
     activeFile.diffSource !== 'combined-uncommitted' &&
     activeFile.diffSource !== 'combined-branch' &&
     activeFile.diffSource !== 'combined-commit'
   const isCombinedDiff =
     activeFile.mode === 'diff' &&
-    (activeFile.diffSource === 'combined-uncommitted' ||
+    (activeFile.diffSource === 'combined-all' ||
+      activeFile.diffSource === 'combined-uncommitted' ||
       activeFile.diffSource === 'combined-branch' ||
       activeFile.diffSource === 'combined-commit')
   const resolvedLanguage =

--- a/src/renderer/src/components/editor/markdown-preview-controls.ts
+++ b/src/renderer/src/components/editor/markdown-preview-controls.ts
@@ -44,6 +44,7 @@ export function getMarkdownViewModes(target: MarkdownPreviewTarget): readonly Ma
     }
     if (
       target.mode === 'diff' &&
+      target.diffSource !== 'combined-all' &&
       target.diffSource !== 'combined-uncommitted' &&
       target.diffSource !== 'combined-branch' &&
       target.diffSource !== 'combined-commit'

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10423,7 +10423,7 @@
           "f786fd54e1": "Inline",
           "ea08dae15b": "Collapse All",
           "19c45cfdc0": "Expand All",
-          "982d14bfa5": "Open Uncommitted Diff",
+          "982d14bfa5": "Open All Changes",
           "3d909843bb": "Open Branch Diff",
           "8368d256ec": "combined-branch",
           "8f68ad9ca9": "Show {{value0}} AI {{value1}}",

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -11,7 +11,12 @@ import {
 } from '../../runtime/runtime-compatibility-test-fixture'
 import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
-import type { GitStatusEntry, Tab } from '../../../../shared/types'
+import type {
+  GitBranchChangeEntry,
+  GitBranchCompareSummary,
+  GitStatusEntry,
+  Tab
+} from '../../../../shared/types'
 
 const { toastErrorMock } = vi.hoisted(() => ({
   toastErrorMock: vi.fn()
@@ -2645,6 +2650,80 @@ describe('createEditorSlice combined diff exclusions', () => {
         id: 'wt-1::all-diffs::uncommitted::unstaged',
         uncommittedEntriesSnapshot: [normalEntry],
         skippedConflicts: []
+      })
+    )
+  })
+
+  it('includes untracked files in the all changes snapshot', () => {
+    const store = createEditorStore()
+    const stagedEntry: GitStatusEntry = {
+      path: 'src/staged.ts',
+      status: 'modified',
+      area: 'staged'
+    }
+    const untrackedEntry: GitStatusEntry = {
+      path: 'src/new.ts',
+      status: 'untracked',
+      area: 'untracked'
+    }
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [stagedEntry, untrackedEntry]
+    })
+    store.getState().openAllDiffs('wt-1', '/repo')
+
+    expect(store.getState().openFiles[0]).toEqual(
+      expect.objectContaining({
+        id: 'wt-1::all-diffs::uncommitted',
+        uncommittedEntriesSnapshot: [stagedEntry, untrackedEntry]
+      })
+    )
+  })
+
+  it('opens all changes with uncommitted and committed branch snapshots', () => {
+    const store = createEditorStore()
+    const localEntry: GitStatusEntry = {
+      path: 'src/local.ts',
+      status: 'modified',
+      area: 'unstaged'
+    }
+    const branchEntry: GitBranchChangeEntry = {
+      path: 'src/committed.ts',
+      status: 'modified'
+    }
+    const branchSummary: GitBranchCompareSummary = {
+      baseRef: 'origin/main',
+      baseOid: 'base-oid',
+      compareRef: 'HEAD',
+      headOid: 'head-oid',
+      mergeBase: 'merge-base-oid',
+      changedFiles: 1,
+      status: 'ready'
+    }
+
+    store.getState().setGitStatus('wt-1', {
+      conflictOperation: 'unknown',
+      entries: [localEntry]
+    })
+    store.setState({
+      gitBranchCompareSummaryByWorktree: { 'wt-1': branchSummary },
+      gitBranchChangesByWorktree: { 'wt-1': [branchEntry] }
+    })
+    store.getState().openAllDiffs('wt-1', '/repo')
+
+    expect(store.getState().openFiles[0]).toEqual(
+      expect.objectContaining({
+        id: 'wt-1::all-diffs::uncommitted',
+        diffSource: 'combined-all',
+        uncommittedEntriesSnapshot: [localEntry],
+        branchEntriesSnapshot: [branchEntry],
+        branchCompare: expect.objectContaining({
+          baseRef: 'origin/main',
+          baseOid: 'base-oid',
+          headOid: 'head-oid',
+          mergeBase: 'merge-base-oid'
+        })
       })
     )
   })

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -94,6 +94,7 @@ export type DiffSource =
   | 'staged'
   | 'branch'
   | 'commit'
+  | 'combined-all'
   | 'combined-uncommitted'
   | 'combined-branch'
   | 'combined-commit'
@@ -155,7 +156,7 @@ type CommitCompareLike = Pick<
 }
 
 type CombinedDiffAlternate = {
-  source: 'combined-uncommitted' | 'combined-branch'
+  source: 'combined-all' | 'combined-branch'
   branchCompare?: BranchCompareSnapshot
 }
 
@@ -2657,13 +2658,22 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         ] ?? 'All Changes')
       : 'All Changes'
     set((s) => {
+      const branchSummary = s.gitBranchCompareSummaryByWorktree[worktreeId]
+      const branchCompare =
+        !areaFilter &&
+        branchSummary?.status === 'ready' &&
+        branchSummary.baseOid &&
+        branchSummary.headOid &&
+        branchSummary.mergeBase
+          ? toBranchCompareSnapshot(branchSummary)
+          : undefined
+      const branchEntriesSnapshot = branchCompare
+        ? (s.gitBranchChangesByWorktree[worktreeId] ?? [])
+        : undefined
       const relevantEntries =
         entriesSnapshot ??
         (s.gitStatusByWorktree[worktreeId] ?? []).filter((entry) => {
-          if (areaFilter) {
-            return entry.area === areaFilter
-          }
-          return entry.area !== 'untracked'
+          return areaFilter === undefined || entry.area === areaFilter
         })
       const skippedConflicts = relevantEntries
         .filter((entry) => entry.conflictStatus === 'unresolved' && entry.conflictKind)
@@ -2687,6 +2697,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             f.id === id
               ? {
                   ...f,
+                  diffSource: branchCompare ? 'combined-all' : 'combined-uncommitted',
+                  branchCompare,
+                  branchEntriesSnapshot,
                   uncommittedEntriesSnapshot,
                   combinedAlternate: alternate,
                   combinedAreaFilter: areaFilter,
@@ -2710,7 +2723,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         language: 'plaintext',
         isDirty: false,
         mode: 'diff',
-        diffSource: 'combined-uncommitted',
+        diffSource: branchCompare ? 'combined-all' : 'combined-uncommitted',
+        branchCompare,
+        branchEntriesSnapshot,
         uncommittedEntriesSnapshot,
         combinedAlternate: alternate,
         combinedAreaFilter: areaFilter,


### PR DESCRIPTION
## Summary
- include untracked files and committed branch entries in the All Changes combined diff
- keep local and branch section keys distinct so duplicate paths both render/navigate
- update labels and combined-diff handling for the new combined-all source

## Tests
- pnpm exec vitest run ... (focused changed editor/store tests, via review agent)
- pnpm run typecheck:web (via review agent)
