### PR TITLE
Remove active-worktree gating from restored session visibility

### DIFF
--- a/src/renderer/src/lib/worktree-runtime-owner.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.test.ts
@@ -3,6 +3,7 @@ import {
   getExplicitRuntimeEnvironmentIdForWorktree,
   getExecutionHostIdForWorktree,
   getRuntimeEnvironmentIdForWorktree,
+  getRuntimeSessionMirrorEnvironmentIds,
   getSettingsForWorktreeRuntimeOwner,
   type WorktreeRuntimeOwnerState
 } from './worktree-runtime-owner'
@@ -116,5 +117,47 @@ describe('getExplicitRuntimeEnvironmentIdForWorktree', () => {
     expect(
       getExecutionHostIdForWorktree(hostOverrideState, 'runtime-repo::wt-runtime-override')
     ).toBe('runtime:worktree-env')
+  })
+})
+
+describe('getRuntimeSessionMirrorEnvironmentIds', () => {
+  it('includes focused runtime plus explicit repo, worktree, and folder owners', () => {
+    const multiRuntimeState: WorktreeRuntimeOwnerState = {
+      ...state,
+      worktreesByRepo: {
+        ...state.worktreesByRepo,
+        'runtime-repo': [
+          ...(state.worktreesByRepo?.['runtime-repo'] ?? []),
+          {
+            id: 'runtime-repo::wt-runtime-override',
+            repoId: 'runtime-repo',
+            hostId: 'runtime:worktree-env'
+          }
+        ]
+      }
+    }
+
+    expect(getRuntimeSessionMirrorEnvironmentIds(multiRuntimeState)).toEqual([
+      'focused-env',
+      'folder-env',
+      'owner-env',
+      'worktree-env'
+    ])
+  })
+
+  it('does not include local or SSH owners', () => {
+    const localOnlyState: WorktreeRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: null },
+      repos: [
+        { id: 'local-repo', connectionId: null, executionHostId: 'local' },
+        { id: 'ssh-repo', connectionId: 'remote', executionHostId: 'ssh:remote' }
+      ],
+      worktreesByRepo: {
+        'local-repo': [{ id: 'local-repo::wt-local', repoId: 'local-repo', hostId: 'local' }],
+        'ssh-repo': [{ id: 'ssh-repo::wt-ssh', repoId: 'ssh-repo', hostId: 'ssh:remote' }]
+      }
+    }
+
+    expect(getRuntimeSessionMirrorEnvironmentIds(localOnlyState)).toEqual([])
   })
 })

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -162,6 +162,35 @@ export function getExplicitRuntimeEnvironmentIdForWorktree(
   return getExplicitRuntimeEnvironmentIdFromHost(getRepoExecutionHostId(repo))
 }
 
+export function getRuntimeSessionMirrorEnvironmentIds(state: WorktreeRuntimeOwnerState): string[] {
+  const ids = new Set<string>()
+  const activeRuntimeEnvironmentId = state.settings?.activeRuntimeEnvironmentId?.trim()
+  if (activeRuntimeEnvironmentId) {
+    ids.add(activeRuntimeEnvironmentId)
+  }
+  for (const repo of state.repos ?? []) {
+    const environmentId = getExplicitRuntimeEnvironmentIdFromHost(getRepoExecutionHostId(repo))
+    if (environmentId) {
+      ids.add(environmentId)
+    }
+  }
+  for (const worktrees of Object.values(state.worktreesByRepo ?? {})) {
+    for (const worktree of worktrees) {
+      const environmentId = getRuntimeEnvironmentIdFromWorktreeHost(worktree.hostId)
+      if (environmentId) {
+        ids.add(environmentId)
+      }
+    }
+  }
+  for (const group of state.projectGroups ?? []) {
+    const environmentId = getExplicitRuntimeEnvironmentIdFromHost(group.executionHostId)
+    if (environmentId) {
+      ids.add(environmentId)
+    }
+  }
+  return [...ids].sort()
+}
+
 export function getExecutionHostIdForWorktree(
   state: WorktreeRuntimeOwnerState,
   worktreeId: string | null | undefined

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -306,19 +306,17 @@ describe('applyWebSessionTabsSnapshot', () => {
     ).toBe(false)
   })
 
-  it('only starts the all-session mirror for paired web clients', () => {
+  it('starts the all-session mirror for desktop and paired web clients', () => {
     expect(
       shouldSyncAllRuntimeSessionTabs({
         activeRuntimeEnvironmentId: ENV,
-        workspaceSessionReady: true,
-        isWebClient: true
+        workspaceSessionReady: true
       })
     ).toBe(true)
     expect(
       shouldSyncAllRuntimeSessionTabs({
         activeRuntimeEnvironmentId: ENV,
-        workspaceSessionReady: true,
-        isWebClient: false
+        workspaceSessionReady: false
       })
     ).toBe(false)
   })

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -32,7 +32,10 @@ import type { OpenFile } from '../store/slices/editor'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { getRemoteRuntimePtyEnvironmentId, toRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { sanitizeTerminalLayoutPaneTitlesForLabels } from '@/lib/terminal-pane-title-sanitization'
-import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  getExplicitRuntimeEnvironmentIdForWorktree,
+  getRuntimeSessionMirrorEnvironmentIds
+} from '@/lib/worktree-runtime-owner'
 import {
   createWebRuntimeSessionTerminal,
   HOST_TERMINAL_SURFACE_SEPARATOR,
@@ -2327,8 +2330,8 @@ export function applyFreshWebSessionTabsSnapshots(
 
 export function useWebSessionTabsSync(): void {
   const activeWorktreeId = useAppStore((state) => state.activeWorktreeId)
-  const activeRuntimeEnvironmentId = useAppStore(
-    (state) => state.settings?.activeRuntimeEnvironmentId ?? null
+  const runtimeSessionMirrorEnvironmentKey = useAppStore((state) =>
+    getRuntimeSessionMirrorEnvironmentIds(state).join('\u0000')
   )
   const activeWorktreeRuntimeEnvironmentId = useAppStore((state) =>
     getExplicitRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId)
@@ -2336,123 +2339,133 @@ export function useWebSessionTabsSync(): void {
   const workspaceSessionReady = useAppStore((state) => state.workspaceSessionReady)
 
   useEffect(() => {
-    const environmentId = activeRuntimeEnvironmentId?.trim()
+    const environmentIds = runtimeSessionMirrorEnvironmentKey
+      ? runtimeSessionMirrorEnvironmentKey.split('\u0000').filter((id) => id.trim())
+      : []
     // Why: startup hydration writes browser-local session state; applying the
     // host snapshot before that point gets clobbered and leaves the sidebar stale.
     // Selectedness is not liveness: desktop and web clients both mirror the
     // runtime's session bindings so background worktrees do not look asleep.
-    if (
-      !shouldSyncAllRuntimeSessionTabs({
-        activeRuntimeEnvironmentId,
-        workspaceSessionReady
-      }) ||
-      !environmentId
-    ) {
+    if (!workspaceSessionReady || environmentIds.length === 0) {
       return
     }
 
     let disposed = false
-    let unsubscribe: (() => void) | null = null
+    const unsubscribes: (() => void)[] = []
     // Why: the streaming RPC emits an initial snapshots event, but startup can
     // render a paired web session before that event is applied. A one-shot
     // fetch makes initial parity deterministic; the stream remains the live
     // update path afterward.
-    void window.api.runtimeEnvironments
-      .call({
-        selector: environmentId,
-        method: 'session.tabs.listAll',
-        params: {},
-        timeoutMs: 15_000
-      })
-      .then((response: RuntimeRpcResponse<unknown>) => {
-        if (disposed) {
-          return
-        }
-        if (response.ok === false) {
-          console.warn('[web-session-tabs-sync] initial listAll failed:', response.error.message)
-          return
-        }
-        const result = response.result
-        if (!isSessionTabsListAllResult(result)) {
-          console.warn('[web-session-tabs-sync] initial listAll returned an invalid payload')
-          return
-        }
-        useAppStore.setState((state) =>
-          applyFreshWebSessionTabsSnapshots(state, result.snapshots, environmentId)
-        )
-      })
-      .catch((error) => {
-        if (!disposed) {
-          console.warn(
-            '[web-session-tabs-sync] failed to load initial session tabs:',
-            error instanceof Error ? error.message : String(error)
-          )
-        }
-      })
-
-    void window.api.runtimeEnvironments
-      .subscribe(
-        {
+    for (const environmentId of environmentIds) {
+      if (
+        !shouldSyncAllRuntimeSessionTabs({
+          activeRuntimeEnvironmentId: environmentId,
+          workspaceSessionReady
+        })
+      ) {
+        continue
+      }
+      void window.api.runtimeEnvironments
+        .call({
           selector: environmentId,
-          method: 'session.tabs.subscribeAll',
+          method: 'session.tabs.listAll',
           params: {},
           timeoutMs: 15_000
-        },
-        {
-          onResponse: (response: RuntimeRpcResponse<unknown>) => {
-            if (disposed) {
-              return
-            }
-            if (response.ok === false) {
-              console.warn(
-                '[web-session-tabs-sync] global subscription failed:',
-                response.error.message
-              )
-              return
-            }
-            const event = response.result as SessionTabsStreamEvent
-            if (event.type === 'snapshots') {
-              useAppStore.setState((state) =>
-                applyFreshWebSessionTabsSnapshots(state, event.snapshots, environmentId)
-              )
-              return
-            }
-            if (event.type !== 'snapshot' && event.type !== 'updated') {
-              return
-            }
-            useAppStore.setState((state) =>
-              applyFreshWebSessionTabsSnapshot(state, event, environmentId)
-            )
-          },
-          onError: (error) => {
-            console.warn('[web-session-tabs-sync] global subscription error:', error.message)
+        })
+        .then((response: RuntimeRpcResponse<unknown>) => {
+          if (disposed) {
+            return
           }
-        }
-      )
-      .then((handle) => {
-        if (disposed) {
-          handle.unsubscribe()
-          return
-        }
-        unsubscribe = handle.unsubscribe
-      })
-      .catch((error) => {
-        if (!disposed) {
-          console.warn(
-            '[web-session-tabs-sync] failed to subscribe globally:',
-            error instanceof Error ? error.message : String(error)
+          if (response.ok === false) {
+            console.warn('[web-session-tabs-sync] initial listAll failed:', response.error.message)
+            return
+          }
+          const result = response.result
+          if (!isSessionTabsListAllResult(result)) {
+            console.warn('[web-session-tabs-sync] initial listAll returned an invalid payload')
+            return
+          }
+          useAppStore.setState((state) =>
+            applyFreshWebSessionTabsSnapshots(state, result.snapshots, environmentId)
           )
-        }
-      })
+        })
+        .catch((error) => {
+          if (!disposed) {
+            console.warn(
+              '[web-session-tabs-sync] failed to load initial session tabs:',
+              error instanceof Error ? error.message : String(error)
+            )
+          }
+        })
+
+      void window.api.runtimeEnvironments
+        .subscribe(
+          {
+            selector: environmentId,
+            method: 'session.tabs.subscribeAll',
+            params: {},
+            timeoutMs: 15_000
+          },
+          {
+            onResponse: (response: RuntimeRpcResponse<unknown>) => {
+              if (disposed) {
+                return
+              }
+              if (response.ok === false) {
+                console.warn(
+                  '[web-session-tabs-sync] global subscription failed:',
+                  response.error.message
+                )
+                return
+              }
+              const event = response.result as SessionTabsStreamEvent
+              if (event.type === 'snapshots') {
+                useAppStore.setState((state) =>
+                  applyFreshWebSessionTabsSnapshots(state, event.snapshots, environmentId)
+                )
+                return
+              }
+              if (event.type !== 'snapshot' && event.type !== 'updated') {
+                return
+              }
+              useAppStore.setState((state) =>
+                applyFreshWebSessionTabsSnapshot(state, event, environmentId)
+              )
+            },
+            onError: (error) => {
+              console.warn('[web-session-tabs-sync] global subscription error:', error.message)
+            }
+          }
+        )
+        .then((handle) => {
+          if (disposed) {
+            handle.unsubscribe()
+            return
+          }
+          unsubscribes.push(handle.unsubscribe)
+        })
+        .catch((error) => {
+          if (!disposed) {
+            console.warn(
+              '[web-session-tabs-sync] failed to subscribe globally:',
+              error instanceof Error ? error.message : String(error)
+            )
+          }
+        })
+    }
 
     return () => {
       disposed = true
-      unsubscribe?.()
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe()
+      }
       // Why: environment ids can churn as paired runtimes reconnect or switch;
       // stale freshness/mapping entries should not live for the renderer lifetime.
-      clearWebSessionTabsTrackingForEnvironment(environmentId)
+      for (const environmentId of environmentIds) {
+        clearWebSessionTabsTrackingForEnvironment(environmentId)
+      }
     }
-  }, [activeRuntimeEnvironmentId, workspaceSessionReady])
+  }, [runtimeSessionMirrorEnvironmentKey, workspaceSessionReady])
 
   useEffect(() => {
     const environmentId = activeWorktreeRuntimeEnvironmentId?.trim()

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -255,10 +255,9 @@ export function shouldSyncRuntimeSessionTabs(args: {
 export function shouldSyncAllRuntimeSessionTabs(args: {
   activeRuntimeEnvironmentId: string | null | undefined
   workspaceSessionReady: boolean
-  isWebClient: boolean
 }): boolean {
   const environmentId = args.activeRuntimeEnvironmentId?.trim()
-  return Boolean(environmentId && args.workspaceSessionReady && args.isWebClient)
+  return Boolean(environmentId && args.workspaceSessionReady)
 }
 
 export function resetWebSessionTabsSnapshotFreshnessForTests(): void {
@@ -2335,19 +2334,17 @@ export function useWebSessionTabsSync(): void {
     getExplicitRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId)
   )
   const workspaceSessionReady = useAppStore((state) => state.workspaceSessionReady)
-  const isWebClient = (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ === true
 
   useEffect(() => {
     const environmentId = activeRuntimeEnvironmentId?.trim()
     // Why: startup hydration writes browser-local session state; applying the
     // host snapshot before that point gets clobbered and leaves the sidebar stale.
-    // Desktop clients should not mirror every remote session just because a
-    // remote is connected; project discovery runs through separate repo APIs.
+    // Selectedness is not liveness: desktop and web clients both mirror the
+    // runtime's session bindings so background worktrees do not look asleep.
     if (
       !shouldSyncAllRuntimeSessionTabs({
         activeRuntimeEnvironmentId,
-        workspaceSessionReady,
-        isWebClient
+        workspaceSessionReady
       }) ||
       !environmentId
     ) {
@@ -2455,7 +2452,7 @@ export function useWebSessionTabsSync(): void {
       // stale freshness/mapping entries should not live for the renderer lifetime.
       clearWebSessionTabsTrackingForEnvironment(environmentId)
     }
-  }, [activeRuntimeEnvironmentId, isWebClient, workspaceSessionReady])
+  }, [activeRuntimeEnvironmentId, workspaceSessionReady])
 
   useEffect(() => {
     const environmentId = activeWorktreeRuntimeEnvironmentId?.trim()

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -101,6 +101,8 @@ const mockApi = {
 globalThis.window = { api: mockApi }
 
 import { createTestStore, makeWorktree, makeTab, makeLayout } from './store-test-helpers'
+import { computeVisibleWorktreeIds } from '@/components/sidebar/visible-worktrees'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 
 // ─── Helpers ──────────────────────────────────────────────────────────
 
@@ -1508,9 +1510,22 @@ describe('reconnectPersistedTerminals', () => {
     expect(s.tabsByWorktree[wt1][0].ptyId).toBe('old-pty-1')
     expect(s.tabsByWorktree[wt2][0].ptyId).toBe('old-pty-2')
     expect(s.ptyIdsByTabId.tab1).toEqual(['old-pty-1'])
-    // Why: inactive worktrees keep a wake hint but must not advertise live PTYs
-    // until the user opens them and connectPanePty performs the actual reattach.
-    expect(s.ptyIdsByTabId.tab2).toEqual([])
+    expect(s.ptyIdsByTabId.tab2).toEqual(['old-pty-2'])
+    expect(
+      computeVisibleWorktreeIds(s.worktreesByRepo, [wt1, wt2], {
+        filterRepoIds: [],
+        showSleepingWorkspaces: false,
+        tabsByWorktree: s.tabsByWorktree,
+        ptyIdsByTabId: s.ptyIdsByTabId,
+        browserTabsByWorktree: s.browserTabsByWorktree,
+        hideDefaultBranchWorkspace: false,
+        hideAutomationGeneratedWorkspaces: false,
+        repoMap: new Map(s.repos.map((repo) => [repo.id, repo])),
+        workspaceHostScope: 'all',
+        defaultHostId: LOCAL_EXECUTION_HOST_ID,
+        worktreeLineageById: {}
+      })
+    ).toEqual([wt1, wt2])
     expect(s.pendingReconnectWorktreeIds).toEqual([])
     // No eager spawn — PTY creation deferred to pane mount
     expect((mockApi.pty as Record<string, unknown>).spawn).not.toHaveBeenCalled()

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -1492,7 +1492,7 @@ describe('reconnectPersistedTerminals', () => {
         [wt2]: [makeTab({ id: 'tab2', worktreeId: wt2, ptyId: 'old-pty-2' })]
       },
       terminalLayoutsByTabId: { tab1: makeLayout(), tab2: makeLayout() },
-      activeWorktreeIdsOnShutdown: [wt1, wt2]
+      activeWorktreeIdsOnShutdown: [wt1]
     })
 
     expect(store.getState().workspaceSessionReady).toBe(false)

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -1816,6 +1816,64 @@ describe('reconnectPersistedTerminals', () => {
     expect(Object.values(bindings).sort()).toEqual(['daemon-session-A', 'daemon-session-B'])
     expect(s.workspaceSessionReady).toBe(true)
   })
+
+  it('advertises split-pane-only restored sessions for hide-sleeping visibility', async () => {
+    const store = createDaemonEnabledStore()
+    const wt1 = 'repo1::/path/wt1'
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt1, repoId: 'repo1', path: '/path/wt1' })]
+      }
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: wt1,
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        [wt1]: [makeTab({ id: 'tab1', worktreeId: wt1, ptyId: null })]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          ...makeLayout(),
+          root: {
+            type: 'split',
+            direction: 'vertical',
+            first: { type: 'leaf', leafId: 'pane:1' },
+            second: { type: 'leaf', leafId: 'pane:3' }
+          },
+          ptyIdsByLeafId: { 'pane:1': 'daemon-session-A', 'pane:3': 'daemon-session-B' }
+        }
+      },
+      activeWorktreeIdsOnShutdown: []
+    })
+
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([wt1])
+
+    await store.getState().reconnectPersistedTerminals()
+
+    const s = store.getState()
+    expect(s.ptyIdsByTabId.tab1?.sort()).toEqual(['daemon-session-A', 'daemon-session-B'])
+    expect(
+      computeVisibleWorktreeIds(s.worktreesByRepo, [wt1], {
+        filterRepoIds: [],
+        showSleepingWorkspaces: false,
+        tabsByWorktree: s.tabsByWorktree,
+        ptyIdsByTabId: s.ptyIdsByTabId,
+        browserTabsByWorktree: s.browserTabsByWorktree,
+        hideDefaultBranchWorkspace: false,
+        hideAutomationGeneratedWorkspaces: false,
+        repoMap: new Map(s.repos.map((repo) => [repo.id, repo])),
+        workspaceHostScope: 'all',
+        defaultHostId: LOCAL_EXECUTION_HOST_ID,
+        worktreeLineageById: {}
+      })
+    ).toEqual([wt1])
+  })
 })
 
 describe('hydrateEditorSession', () => {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2595,15 +2595,16 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // reconnectPersistedTerminals() after all eager PTY spawns complete.
       // This prevents TerminalPane from mounting and spawning duplicate PTYs
       // before the reconnect phase has set ptyId on each tab.
-      // Why: fall back to deriving the list from tabsByWorktree ptyIds when
-      // activeWorktreeIdsOnShutdown is absent (upgrade from older build).
-      // The raw tabs still carry ptyId values before clearTransientTerminalState
-      // nulls them, so we can infer which worktrees had active terminals.
-      const shutdownIds =
-        session.activeWorktreeIdsOnShutdown ??
-        Object.entries(session.tabsByWorktree)
-          .filter(([, tabs]) => tabs.some((t) => t.ptyId))
-          .map(([wId]) => wId)
+      const remoteSessionIds = session.remoteSessionIdsByTabId ?? {}
+      // Why: activeWorktreeIdsOnShutdown is only the eager-remount hint. Any
+      // tab with a persisted PTY or relay session can still reattach when
+      // opened, so it must also advertise liveness to Hide sleeping.
+      const sessionBackedWorktreeIds = Object.entries(session.tabsByWorktree)
+        .filter(([, tabs]) => tabs.some((t) => t.ptyId || remoteSessionIds[t.id]))
+        .map(([wId]) => wId)
+      const shutdownIds = Array.from(
+        new Set([...(session.activeWorktreeIdsOnShutdown ?? []), ...sessionBackedWorktreeIds])
+      )
       const pendingReconnectWorktreeIds = shutdownIds.filter((id) => validWorktreeIds.has(id))
 
       // Why: capture which specific tabs had live PTYs per worktree from the
@@ -2613,7 +2614,6 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // Also include tabs whose relay session IDs were preserved in
       // remoteSessionIdsByTabId — those tabs were disconnected before shutdown
       // (ptyId was null) but the relay still has their PTY alive.
-      const remoteSessionIds = session.remoteSessionIdsByTabId ?? {}
       const pendingReconnectTabByWorktree: Record<string, string[]> = {}
       for (const worktreeId of pendingReconnectWorktreeIds) {
         const rawTabs = session.tabsByWorktree[worktreeId] ?? []

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2599,8 +2599,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // Why: activeWorktreeIdsOnShutdown is only the eager-remount hint. Any
       // tab with a persisted PTY or relay session can still reattach when
       // opened, so it must also advertise liveness to Hide sleeping.
+      const tabHasRestorableSession = (tab: TerminalTab): boolean => {
+        const leafPtyIds = Object.values(
+          session.terminalLayoutsByTabId?.[tab.id]?.ptyIdsByLeafId ?? {}
+        ).filter(Boolean)
+        return Boolean(tab.ptyId || remoteSessionIds[tab.id] || leafPtyIds.length > 0)
+      }
       const sessionBackedWorktreeIds = Object.entries(session.tabsByWorktree)
-        .filter(([, tabs]) => tabs.some((t) => t.ptyId || remoteSessionIds[t.id]))
+        .filter(([, tabs]) => tabs.some(tabHasRestorableSession))
         .map(([wId]) => wId)
       const shutdownIds = Array.from(
         new Set([...(session.activeWorktreeIdsOnShutdown ?? []), ...sessionBackedWorktreeIds])
@@ -2618,7 +2624,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       for (const worktreeId of pendingReconnectWorktreeIds) {
         const rawTabs = session.tabsByWorktree[worktreeId] ?? []
         const liveTabIds = rawTabs
-          .filter((t) => (t.ptyId || remoteSessionIds[t.id]) && validTabIds.has(t.id))
+          .filter((t) => tabHasRestorableSession(t) && validTabIds.has(t.id))
           .map((t) => t.id)
         if (liveTabIds.length > 0) {
           pendingReconnectTabByWorktree[worktreeId] = liveTabIds
@@ -2867,15 +2873,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         console.debug(
           `[reconnect-terminals] tab=${tabId} tabLevelPtyId=${tabLevelPtyId} supportsDeferredReattach=${supportsDeferredReattach} hasLeafMappings=${hasLeafMappings}`
         )
-        if (tabLevelPtyId) {
+        if (tabLevelPtyId || hasLeafMappings) {
           set((s) => {
             const next = { ...s.tabsByWorktree }
             if (!next[worktreeId]) {
               return {}
             }
-            next[worktreeId] = next[worktreeId].map((t) =>
-              t.id === tabId ? { ...t, ptyId: tabLevelPtyId } : t
-            )
+            if (tabLevelPtyId) {
+              next[worktreeId] = next[worktreeId].map((t) =>
+                t.id === tabId ? { ...t, ptyId: tabLevelPtyId } : t
+              )
+            }
 
             // Why: populate ptyIdsByTabId so the sessions status segment
             // can map daemon session IDs back to tabs (for bound/orphan
@@ -2883,7 +2891,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
             // appear as orphans until the terminal pane mounts.
             const allPtyIds = hasLeafMappings
               ? (Object.values(leafPtyMap).filter(Boolean) as string[])
-              : [tabLevelPtyId]
+              : [tabLevelPtyId!]
             return {
               tabsByWorktree: next,
               // Why: hide-sleeping uses ptyIdsByTabId as the liveness source.

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2794,8 +2794,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       pendingReconnectTabByWorktree,
       pendingReconnectPtyIdByTabId,
       terminalLayoutsByTabId,
-      tabsByWorktree,
-      activeWorktreeId
+      tabsByWorktree
     } = get()
     const ids = pendingReconnectWorktreeIds ?? []
 
@@ -2869,7 +2868,6 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           `[reconnect-terminals] tab=${tabId} tabLevelPtyId=${tabLevelPtyId} supportsDeferredReattach=${supportsDeferredReattach} hasLeafMappings=${hasLeafMappings}`
         )
         if (tabLevelPtyId) {
-          const shouldAdvertiseLivePtys = worktreeId === activeWorktreeId
           set((s) => {
             const next = { ...s.tabsByWorktree }
             if (!next[worktreeId]) {
@@ -2888,17 +2886,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
               : [tabLevelPtyId]
             return {
               tabsByWorktree: next,
-              ...(shouldAdvertiseLivePtys
-                ? {
-                    // Why: inactive worktrees only need wake hints. Publishing
-                    // their PTYs as live at startup starts global session/status
-                    // machinery before the user opens that workspace.
-                    ptyIdsByTabId: {
-                      ...s.ptyIdsByTabId,
-                      [tabId]: allPtyIds
-                    }
-                  }
-                : {})
+              // Why: hide-sleeping uses ptyIdsByTabId as the liveness source.
+              // Restored daemon sessions are still running even before their
+              // pane remounts, so background workspaces must advertise them.
+              ptyIdsByTabId: {
+                ...s.ptyIdsByTabId,
+                [tabId]: allPtyIds
+              }
             }
           })
         }


### PR DESCRIPTION
## Summary
- Removes the active-worktree-only restored PTY advertisement behavior introduced by #5895.
- Restored background terminal sessions now populate the tab-to-session binding used by Hide sleeping, so reattachable/running workspaces are not hidden just because they are not selected.
- Covers tab-level restored PTYs, remote relay session IDs, and split-pane-only restored PTYs stored in terminalLayoutsByTabId[*].ptyIdsByLeafId.
- Removes selected-worktree-only assumptions from runtime session mirroring: desktop now mirrors session tabs for every relevant runtime owner, including focused runtime, explicit repo owners, per-worktree runtime host overrides, and folder project-group runtime owners.

## Why
#5895 optimized idle startup work by treating the selected worktree as the only workspace that should advertise restored/live session state. That made selectedness stand in for liveness. Background workspaces could still reattach when clicked, but Hide sleeping, status, and remote session mirroring could treat them as inactive/sleeping.

Selectedness is not liveness. This PR removes that assumption while keeping the unrelated #5895 runtime project refresh and host ownership fixes.

## Verification
- Reproduced the regression with a persisted background workspace PTY missing from activeWorktreeIdsOnShutdown.
- Verified against the user's real Orca profile in a dev app: 354 tab-level restored sessions + 2 split-pane-only restored sessions, hiddenRestorableCount=0.
- Independent subagent audit found the multi-runtime-owner mirroring gap; fixed it and re-audit confirmed no remaining selectedness-as-liveness issue in the #5895 areas.
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/store-session-cascades.test.ts --testNamePattern reconnectPersistedTerminals
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/lib/worktree-runtime-owner.test.ts
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/lib/worktree-activity-state.test.ts
- pnpm exec oxlint src/renderer/src/lib/worktree-runtime-owner.ts src/renderer/src/lib/worktree-runtime-owner.test.ts src/renderer/src/runtime/web-session-tabs-sync.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/store/slices/terminals.ts src/renderer/src/store/slices/store-session-cascades.test.ts

Note: local shell is on Node v26 while the repo wants Node v24, so pnpm prints the existing engine warning.