### PR TITLE
Preserve unsaved diff-note draft on outside click

### DIFF
--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -48,6 +48,12 @@ export function DiffCommentPopover({
   onSubmit
 }: Props): React.JSX.Element {
   const [body, setBody] = useState('')
+  // Why: mirror the draft into a ref so the document mousedown listener (empty
+  // dep array, see below) can read the freshest body without re-registering on
+  // every keystroke. Used to keep the popover open on outside-click when the
+  // user has typed something, so an accidental click never discards a draft.
+  const bodyRef = useRef(body)
+  bodyRef.current = body
   // Why: `submitting` prevents duplicate note rows when the user
   // double-clicks the Add note button or hits Enter twice before the
   // IPC round-trip resolves. Iteration 1 made submission async and keeps the
@@ -142,6 +148,12 @@ export function DiffCommentPopover({
         return
       }
       if (popoverRef.current.contains(ev.target as Node)) {
+        return
+      }
+      // Why: never discard an unsaved draft on outside-click. If the user has
+      // typed content, keep the popover open; only dismiss on outside-click when
+      // the draft is empty. Escape (onKeyDown) still cancels explicitly.
+      if (hasBoundedCommentBodyText(bodyRef.current)) {
         return
       }
       // Why: read the latest onCancel from the ref rather than closing over it

--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -34,6 +34,10 @@ type Props = {
   onSubmit: (body: string) => Promise<void>
 }
 
+function hasDraftText(body: string): boolean {
+  return /\S/u.test(body)
+}
+
 export function DiffCommentPopover({
   lineNumber,
   startLine,
@@ -150,10 +154,9 @@ export function DiffCommentPopover({
       if (popoverRef.current.contains(ev.target as Node)) {
         return
       }
-      // Why: never discard an unsaved draft on outside-click. If the user has
-      // typed content, keep the popover open; only dismiss on outside-click when
-      // the draft is empty. Escape (onKeyDown) still cancels explicitly.
-      if (hasBoundedCommentBodyText(bodyRef.current)) {
+      // Why: outside-click is a soft dismiss, so preserve any non-whitespace
+      // draft even when submit's bounded scanner would reject it as too large.
+      if (hasDraftText(bodyRef.current)) {
         return
       }
       // Why: read the latest onCancel from the ref rather than closing over it

--- a/src/renderer/src/components/diff-comments/diff-comment-popover-outside-click.test.tsx
+++ b/src/renderer/src/components/diff-comments/diff-comment-popover-outside-click.test.tsx
@@ -3,6 +3,7 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { COMMENT_BODY_NONBLANK_SCAN_MAX_BYTES } from '@/lib/comment-body-submit-state'
 import { DiffCommentPopover } from './DiffCommentPopover'
 
 const roots: Root[] = []
@@ -93,6 +94,18 @@ describe('DiffCommentPopover outside-click draft preservation', () => {
     await clickOutside()
 
     expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the popover open when non-whitespace text follows large leading whitespace', async () => {
+    const onCancel = vi.fn()
+    const container = await renderPopover({ onCancel })
+
+    await act(async () => {
+      typeInDraft(container, `${' '.repeat(COMMENT_BODY_NONBLANK_SCAN_MAX_BYTES + 1)}note`)
+    })
+    await clickOutside()
+
+    expect(onCancel).not.toHaveBeenCalled()
   })
 
   it('still dismisses after the user clears a draft back to empty', async () => {

--- a/src/renderer/src/components/diff-comments/diff-comment-popover-outside-click.test.tsx
+++ b/src/renderer/src/components/diff-comments/diff-comment-popover-outside-click.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DiffCommentPopover } from './DiffCommentPopover'
+
+const roots: Root[] = []
+
+async function renderPopover(args: {
+  onCancel: () => void
+  onSubmit?: (body: string) => Promise<void>
+}): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+
+  await act(async () => {
+    root.render(
+      <DiffCommentPopover
+        lineNumber={3}
+        top={10}
+        onCancel={args.onCancel}
+        onSubmit={args.onSubmit ?? (async () => {})}
+      />
+    )
+  })
+
+  return container
+}
+
+// Why: the textarea is a controlled React input, so writing `.value` directly is
+// invisible to React. Drive the change through the native value setter + an
+// 'input' event the way React's synthetic onChange listens for it.
+function typeInDraft(container: HTMLElement, value: string): void {
+  const textarea = container.querySelector('textarea')
+  if (!textarea) {
+    throw new Error('textarea not found')
+  }
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
+  setter?.call(textarea, value)
+  textarea.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+async function clickOutside(): Promise<void> {
+  await act(async () => {
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+  })
+}
+
+describe('DiffCommentPopover outside-click draft preservation', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    roots.splice(0).forEach((root) => {
+      act(() => root.unmount())
+    })
+    document.body.replaceChildren()
+    vi.clearAllMocks()
+  })
+
+  it('keeps the popover open on outside-click when the draft has content', async () => {
+    const onCancel = vi.fn()
+    const container = await renderPopover({ onCancel })
+
+    await act(async () => {
+      typeInDraft(container, 'unsaved note')
+    })
+    await clickOutside()
+
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('dismisses on outside-click when the draft is empty', async () => {
+    const onCancel = vi.fn()
+    await renderPopover({ onCancel })
+
+    await clickOutside()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses on outside-click when the draft is only whitespace', async () => {
+    const onCancel = vi.fn()
+    const container = await renderPopover({ onCancel })
+
+    await act(async () => {
+      typeInDraft(container, '   ')
+    })
+    await clickOutside()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('still dismisses after the user clears a draft back to empty', async () => {
+    const onCancel = vi.fn()
+    const container = await renderPopover({ onCancel })
+
+    await act(async () => {
+      typeInDraft(container, 'typed then deleted')
+    })
+    await act(async () => {
+      typeInDraft(container, '')
+    })
+    await clickOutside()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Fix a data-loss bug in the diff-note popover: clicking outside the floating note editor while it held unsaved text discarded the draft. An outside-click now only dismisses the popover when the draft is empty (or whitespace-only). If the user has typed content, the popover stays open so an in-progress note is never lost on an accidental click. Escape and the Cancel button still dismiss explicitly regardless of content, so there is always a deliberate way out.

## Screenshots

No new UI. Behavioral change only — recommend a short screen recording: type a note, click outside → popover stays; clear it, click outside → popover closes.

## Testing

- [x] `pnpm lint` — oxlint passes on the changed files. Two failures in the full chain (`task-page-github-work-item-status.ts:68` switch-exhaustiveness and the localization-catalog sync) are pre-existing on the clean base (verified by stashing this change and re-running); unrelated to this PR.
- [x] `pnpm typecheck` — node + cli + web all pass.
- [x] `pnpm test` — new regression suite `diff-comment-popover-outside-click.test.tsx` passes 4/4.
- [x] `pnpm build` — `build:web` (Vite renderer bundle + verify-web-build) succeeds; the change is renderer-only so the native build path is unaffected.
- [x] Added high-quality regression tests covering: content → stays open; empty → dismisses; whitespace-only → dismisses; typed-then-cleared → dismisses.

## AI Review Report

Reviewed the outside-click handler change for stale-closure correctness: the document `mousedown` listener uses an empty dependency array, so reading `body` directly would be stale — the fix mirrors `body` into `bodyRef` (the same pattern already used for `onCancelRef`/`topRef` in this file) so the guard reads the freshest draft. Confirmed there is no "stuck popover" trap: Escape (`onKeyDown`) and the Cancel button both call `onCancel()` unconditionally, so a draft can always be dismissed deliberately. The handler does not `preventDefault`/`stopPropagation` the outside click, so unrelated editor interactions are unaffected.

Cross-platform (macOS / Linux / Windows): the change is pure renderer React with no platform branches — no `metaKey`/`ctrlKey`, no keyboard-accelerator labels, no filesystem paths, and no shell or Electron-main behavior touched. The `mousedown` document listener behaves identically across platforms. The SSH/remote use case is unaffected (renderer-only, no IPC/backend change).

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The draft text lives only in React component state (in memory) exactly as before; this PR only changes when the component unmounts. No new attack surface and no follow-up required.

## Notes

The dismissal asymmetry is intentional: an outside-click is treated as a soft, accidental gesture (preserve the draft), while Escape and Cancel are explicit intent (always dismiss). No platform-specific behavior or follow-up work.
