### PR TITLE
Make mobile pairing QR codes larger

### DIFF
--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -557,6 +557,15 @@
   height: 116px;
 }
 
+.mobile-page-root .mp-qr-large {
+  padding: 10px;
+}
+
+.mobile-page-root .mp-qr-large img {
+  width: 164px;
+  height: 164px;
+}
+
 .mobile-page-root .mp-qr-stack {
   display: flex;
   flex-direction: column;
@@ -704,8 +713,9 @@
 }
 
 .mobile-page-root .mp-network-select {
-  min-width: 220px;
-  max-width: 280px;
+  flex: 1 1 180px;
+  min-width: 0;
+  max-width: 240px;
 }
 
 .mobile-page-root .mp-network-refresh {

--- a/src/renderer/src/components/mobile/MobileHero.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.tsx
@@ -121,7 +121,7 @@ export function HeroFlow({
               </div>
             </div>
             <div
-              className="mp-qr"
+              className="mp-qr mp-qr-large"
               aria-label={translate(
                 'auto.components.mobile.MobileHero.7af266b80d',
                 'Install QR code'
@@ -225,7 +225,7 @@ export function HeroFlow({
             </div>
             <div className="mp-qr-stack">
               <div
-                className="mp-qr"
+                className="mp-qr mp-qr-large"
                 aria-label={translate(
                   'auto.components.mobile.MobileHero.bb0074ce11',
                   'Pairing QR code'

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10399,7 +10399,8 @@
           "4cc7b83ffe": "Filter files...",
           "21783df79f": "Collapse file tree",
           "481e63ca52": "Files",
-          "d5ac717d65": "uncommitted"
+          "d5ac717d65": "uncommitted",
+          "39b6b9e4e4": "Committed on Branch"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "in Source Control",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10399,7 +10399,8 @@
           "4cc7b83ffe": "Filtrar archivos...",
           "21783df79f": "Contraer árbol de archivos",
           "481e63ca52": "Archivos",
-          "d5ac717d65": "no comprometido"
+          "d5ac717d65": "no comprometido",
+          "39b6b9e4e4": "Committed on Branch"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "en control de fuente",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10399,7 +10399,8 @@
           "4cc7b83ffe": "ファイルをフィルタリング...",
           "21783df79f": "ファイルツリーを折りたたむ",
           "481e63ca52": "ファイル",
-          "d5ac717d65": "commit されていない"
+          "d5ac717d65": "commit されていない",
+          "39b6b9e4e4": "Committed on Branch"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "ソース管理内",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10399,7 +10399,8 @@
           "4cc7b83ffe": "파일 필터링...",
           "21783df79f": "파일 트리 축소",
           "481e63ca52": "파일",
-          "d5ac717d65": "commit 안 됨"
+          "d5ac717d65": "commit 안 됨",
+          "39b6b9e4e4": "Committed on Branch"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "소스 제어에서",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10399,7 +10399,8 @@
           "4cc7b83ffe": "搜索文件...",
           "21783df79f": "折叠文件树",
           "481e63ca52": "文件",
-          "d5ac717d65": "未提交"
+          "d5ac717d65": "未提交",
+          "39b6b9e4e4": "Committed on Branch"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "在源代码控制中",


### PR DESCRIPTION
## Summary
- Increase QR size for both Orca Mobile install and desktop pairing steps
- Share one large QR class for both codes
- Keep the network picker row aligned beside the larger pairing QR

## Verification
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/mobile/MobileHero.tsx src/renderer/src/assets/mobile-page.css
- pnpm run verify:localization-catalog
- pnpm run verify:localization-coverage

Made with [Orca](https://github.com/stablyai/orca) 🐋
