### PR TITLE
Restore pre-culprit workspace liveness boundary

### DIFF
--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -1498,7 +1498,7 @@ describe('reconnectPersistedTerminals', () => {
     expect(store.getState().workspaceSessionReady).toBe(false)
     expect(store.getState().tabsByWorktree[wt1][0].ptyId).toBeNull()
     expect(store.getState().tabsByWorktree[wt2][0].ptyId).toBeNull()
-    expect(store.getState().pendingReconnectWorktreeIds).toEqual([wt1, wt2])
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([wt1])
 
     await store.getState().reconnectPersistedTerminals()
 
@@ -1508,9 +1508,9 @@ describe('reconnectPersistedTerminals', () => {
     // records daemon session IDs as tab-level ptyIds so connectPanePty
     // can pass them as sessionId to the daemon's createOrAttach.
     expect(s.tabsByWorktree[wt1][0].ptyId).toBe('old-pty-1')
-    expect(s.tabsByWorktree[wt2][0].ptyId).toBe('old-pty-2')
+    expect(s.tabsByWorktree[wt2][0].ptyId).toBeNull()
     expect(s.ptyIdsByTabId.tab1).toEqual(['old-pty-1'])
-    expect(s.ptyIdsByTabId.tab2).toEqual(['old-pty-2'])
+    expect(s.ptyIdsByTabId.tab2).toEqual([])
     expect(
       computeVisibleWorktreeIds(s.worktreesByRepo, [wt1, wt2], {
         filterRepoIds: [],
@@ -1525,7 +1525,7 @@ describe('reconnectPersistedTerminals', () => {
         defaultHostId: LOCAL_EXECUTION_HOST_ID,
         worktreeLineageById: {}
       })
-    ).toEqual([wt1, wt2])
+    ).toEqual([wt1])
     expect(s.pendingReconnectWorktreeIds).toEqual([])
     // No eager spawn — PTY creation deferred to pane mount
     expect((mockApi.pty as Record<string, unknown>).spawn).not.toHaveBeenCalled()
@@ -1817,7 +1817,7 @@ describe('reconnectPersistedTerminals', () => {
     expect(s.workspaceSessionReady).toBe(true)
   })
 
-  it('advertises split-pane-only restored sessions for hide-sleeping visibility', async () => {
+  it('does not advertise split-pane-only wake hints as hide-sleeping activity', async () => {
     const store = createDaemonEnabledStore()
     const wt1 = 'repo1::/path/wt1'
 
@@ -1852,12 +1852,13 @@ describe('reconnectPersistedTerminals', () => {
       activeWorktreeIdsOnShutdown: []
     })
 
-    expect(store.getState().pendingReconnectWorktreeIds).toEqual([wt1])
+    expect(store.getState().pendingReconnectWorktreeIds).toEqual([])
 
     await store.getState().reconnectPersistedTerminals()
 
     const s = store.getState()
-    expect(s.ptyIdsByTabId.tab1?.sort()).toEqual(['daemon-session-A', 'daemon-session-B'])
+    expect(s.terminalLayoutsByTabId.tab1?.ptyIdsByLeafId).toBeDefined()
+    expect(s.ptyIdsByTabId.tab1).toEqual([])
     expect(
       computeVisibleWorktreeIds(s.worktreesByRepo, [wt1], {
         filterRepoIds: [],
@@ -1872,7 +1873,7 @@ describe('reconnectPersistedTerminals', () => {
         defaultHostId: LOCAL_EXECUTION_HOST_ID,
         worktreeLineageById: {}
       })
-    ).toEqual([wt1])
+    ).toEqual([])
   })
 })
 

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2595,22 +2595,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // reconnectPersistedTerminals() after all eager PTY spawns complete.
       // This prevents TerminalPane from mounting and spawning duplicate PTYs
       // before the reconnect phase has set ptyId on each tab.
-      const remoteSessionIds = session.remoteSessionIdsByTabId ?? {}
-      // Why: activeWorktreeIdsOnShutdown is only the eager-remount hint. Any
-      // tab with a persisted PTY or relay session can still reattach when
-      // opened, so it must also advertise liveness to Hide sleeping.
-      const tabHasRestorableSession = (tab: TerminalTab): boolean => {
-        const leafPtyIds = Object.values(
-          session.terminalLayoutsByTabId?.[tab.id]?.ptyIdsByLeafId ?? {}
-        ).filter(Boolean)
-        return Boolean(tab.ptyId || remoteSessionIds[tab.id] || leafPtyIds.length > 0)
-      }
-      const sessionBackedWorktreeIds = Object.entries(session.tabsByWorktree)
-        .filter(([, tabs]) => tabs.some(tabHasRestorableSession))
-        .map(([wId]) => wId)
-      const shutdownIds = Array.from(
-        new Set([...(session.activeWorktreeIdsOnShutdown ?? []), ...sessionBackedWorktreeIds])
-      )
+      // Why: match the pre-idle-runtime-optimization startup contract.
+      // activeWorktreeIdsOnShutdown is authoritative when present; persisted
+      // tab/layout PTY IDs are wake hints, not a broader active-workspace list.
+      const shutdownIds =
+        session.activeWorktreeIdsOnShutdown ??
+        Object.entries(session.tabsByWorktree)
+          .filter(([, tabs]) => tabs.some((t) => t.ptyId))
+          .map(([wId]) => wId)
       const pendingReconnectWorktreeIds = shutdownIds.filter((id) => validWorktreeIds.has(id))
 
       // Why: capture which specific tabs had live PTYs per worktree from the
@@ -2620,11 +2612,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // Also include tabs whose relay session IDs were preserved in
       // remoteSessionIdsByTabId — those tabs were disconnected before shutdown
       // (ptyId was null) but the relay still has their PTY alive.
+      const remoteSessionIds = session.remoteSessionIdsByTabId ?? {}
       const pendingReconnectTabByWorktree: Record<string, string[]> = {}
       for (const worktreeId of pendingReconnectWorktreeIds) {
         const rawTabs = session.tabsByWorktree[worktreeId] ?? []
         const liveTabIds = rawTabs
-          .filter((t) => tabHasRestorableSession(t) && validTabIds.has(t.id))
+          .filter((t) => (t.ptyId || remoteSessionIds[t.id]) && validTabIds.has(t.id))
           .map((t) => t.id)
         if (liveTabIds.length > 0) {
           pendingReconnectTabByWorktree[worktreeId] = liveTabIds
@@ -2873,16 +2866,11 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         console.debug(
           `[reconnect-terminals] tab=${tabId} tabLevelPtyId=${tabLevelPtyId} supportsDeferredReattach=${supportsDeferredReattach} hasLeafMappings=${hasLeafMappings}`
         )
-        if (tabLevelPtyId || hasLeafMappings) {
+        if (tabLevelPtyId) {
           set((s) => {
             const next = { ...s.tabsByWorktree }
             if (!next[worktreeId]) {
               return {}
-            }
-            if (tabLevelPtyId) {
-              next[worktreeId] = next[worktreeId].map((t) =>
-                t.id === tabId ? { ...t, ptyId: tabLevelPtyId } : t
-              )
             }
 
             // Why: populate ptyIdsByTabId so the sessions status segment
@@ -2892,6 +2880,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
             const allPtyIds = hasLeafMappings
               ? (Object.values(leafPtyMap).filter(Boolean) as string[])
               : [tabLevelPtyId!]
+            next[worktreeId] = next[worktreeId].map((t) =>
+              t.id === tabId ? { ...t, ptyId: tabLevelPtyId } : t
+            )
             return {
               tabsByWorktree: next,
               // Why: hide-sleeping uses ptyIdsByTabId as the liveness source.


### PR DESCRIPTION
## Summary
- restore the pre-culprit startup boundary for Hide sleeping: `activeWorktreeIdsOnShutdown` is authoritative when present
- stop expanding restored-active worktrees from all persisted/restorable tab, relay, or split-pane leaf session metadata
- keep split-pane leaf PTY IDs as wake/reattach metadata, but do not let leaf-only saved IDs advertise a workspace as active

## What this intentionally does not do
- no `window.api.pty.listSessions()` call
- no daemon live-session validation
- no persisted-data repair/migration

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/store-session-cascades.test.ts --testNamePattern "reconnectPersistedTerminals"`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/lib/worktree-activity-state.test.ts src/renderer/src/lib/worktree-status.test.ts src/renderer/src/store/slices/store-session-cascades.test.ts --testNamePattern "reconnectPersistedTerminals|worktree activity state|worktree status|visible"`
- `pnpm exec oxlint src/renderer/src/store/slices/terminals.ts src/renderer/src/store/slices/store-session-cascades.test.ts`

Node warning observed locally: repo wants Node 24; shell is Node 26.