### PR TITLE
Add per-agent resume command override for Agent Session History

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -46,6 +46,7 @@ export default function AiVaultPanel(): React.JSX.Element {
   const allWorktrees = useAllWorktrees()
   const projectHostSetupProjection = useProjectHostSetupProjection()
   const agentCmdOverrides = useAppStore((s) => s.settings?.agentCmdOverrides ?? {})
+  const agentResumeArgsOverrides = useAppStore((s) => s.settings?.agentResumeArgsOverrides ?? {})
   const [query, setQuery] = useState('')
   const [scope, setScope] = useState<AiVaultScope>('project')
   const [sort, setSort] = useState<AiVaultSort>('updated')
@@ -203,9 +204,10 @@ export default function AiVaultPanel(): React.JSX.Element {
         state: useAppStore.getState(),
         worktreeId: activeWorktree?.id ?? null,
         session,
-        commandOverride: agentCmdOverrides[session.agent]
+        commandOverride: agentCmdOverrides[session.agent],
+        resumeArgsOverride: agentResumeArgsOverrides[session.agent]
       }),
-    [activeWorktree?.id, agentCmdOverrides]
+    [activeWorktree?.id, agentCmdOverrides, agentResumeArgsOverrides]
   )
 
   const copyResumeCommand = useCallback(

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -38,6 +38,11 @@ import {
   resolveAgentPermissionModeSummary,
   type AgentPermissionMode
 } from '../../../../shared/tui-agent-permissions'
+import {
+  AI_VAULT_AGENTS,
+  defaultAiVaultResumeArgsTemplate,
+  type AiVaultAgent
+} from '../../../../shared/ai-vault-types'
 import { getSettingOwnershipSummary } from './setting-ownership'
 import { translate } from '@/i18n/i18n'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
@@ -81,6 +86,10 @@ type AgentRowProps = {
   onSaveOverride: (value: string) => void
   onSaveArgs: (value: string) => void
   onSaveEnv: (value: Record<string, string>) => void
+  /** Resume-flag override props are only supplied for agents with vault sessions. */
+  resumeArgsOverride?: string
+  defaultResumeArgs?: string
+  onSaveResumeArgs?: (value: string) => void
 }
 
 type AgentCommandOverrideInputProps = {
@@ -93,6 +102,12 @@ type AgentDefaultArgsInputProps = {
   defaultArgs: string
   argsOverride: string
   onSaveArgs: (value: string) => void
+}
+
+type AgentResumeArgsInputProps = {
+  defaultResumeArgs: string
+  resumeArgsOverride: string | undefined
+  onSaveResumeArgs: (value: string) => void
 }
 
 type AgentDefaultEnvInputProps = {
@@ -373,6 +388,58 @@ function AgentDefaultArgsInput({
   )
 }
 
+function AgentResumeArgsInput({
+  defaultResumeArgs,
+  resumeArgsOverride,
+  onSaveResumeArgs
+}: AgentResumeArgsInputProps): React.JSX.Element {
+  const [draft, setDraft] = useState(resumeArgsOverride ?? '')
+
+  const commit = (): void => {
+    onSaveResumeArgs(draft.trim())
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {translate('auto.components.settings.AgentsPane.resumeArgsLabel', 'Resume')}
+      </span>
+      <Input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            commit()
+            e.currentTarget.blur()
+          }
+          if (e.key === 'Escape') {
+            setDraft(resumeArgsOverride ?? '')
+            e.currentTarget.blur()
+          }
+        }}
+        placeholder={defaultResumeArgs}
+        spellCheck={false}
+        className="h-7 flex-1 font-mono text-xs"
+      />
+      {resumeArgsOverride && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={() => {
+            onSaveResumeArgs('')
+            setDraft('')
+          }}
+          className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+        >
+          {translate('auto.components.settings.AgentsPane.5200dac9da', 'Reset')}
+        </Button>
+      )}
+    </div>
+  )
+}
+
 function AgentDefaultEnvInput({
   defaultEnv,
   envOverride,
@@ -476,12 +543,18 @@ function AgentRow({
   onSetEnabled,
   onSaveOverride,
   onSaveArgs,
-  onSaveEnv
+  onSaveEnv,
+  resumeArgsOverride,
+  defaultResumeArgs,
+  onSaveResumeArgs
 }: AgentRowProps): React.JSX.Element {
   const envSummary = stringifyAgentDefaultEnvDraft(envOverride)
   const defaultEnvSummary = stringifyAgentDefaultEnvDraft(defaultEnv)
   const [cmdOpen, setCmdOpen] = useState(
-    Boolean(cmdOverride) || argsOverride !== defaultArgs || envSummary !== defaultEnvSummary
+    Boolean(cmdOverride) ||
+      Boolean(resumeArgsOverride) ||
+      argsOverride !== defaultArgs ||
+      envSummary !== defaultEnvSummary
   )
 
   return (
@@ -634,6 +707,16 @@ function AgentRow({
               onSaveArgs={onSaveArgs}
             />
           </div>
+          {defaultResumeArgs !== undefined && onSaveResumeArgs && (
+            <div className="mt-2">
+              <AgentResumeArgsInput
+                key={`${agentId}:resume:${resumeArgsOverride ?? ''}`}
+                defaultResumeArgs={defaultResumeArgs}
+                resumeArgsOverride={resumeArgsOverride}
+                onSaveResumeArgs={onSaveResumeArgs}
+              />
+            </div>
+          )}
           {(defaultEnvSummary || envSummary) && (
             <div className="mt-2">
               <AgentDefaultEnvInput
@@ -647,7 +730,7 @@ function AgentRow({
           <p className="mt-1.5 text-[11px] text-muted-foreground">
             {translate(
               'auto.components.settings.AgentsPane.f9f127d664',
-              'Override the binary path or name, and edit the default launch arguments or environment for this agent.'
+              'Override the binary path or name, edit the default launch arguments or environment, and customize the resume command ({{id}} = session id) for this agent.'
             )}
           </p>
         </div>
@@ -696,6 +779,7 @@ export function AgentsPane({ settings, updateSettings }: AgentsPaneProps): React
   const defaultAgent = settings.defaultTuiAgent
   const agentOwnership = getSettingOwnershipSummary('agentLaunchDefaults')
   const cmdOverrides = settings.agentCmdOverrides ?? {}
+  const resumeArgsOverrides = settings.agentResumeArgsOverrides ?? {}
   const agentDefaultArgs = settings.agentDefaultArgs ?? {}
   const agentDefaultEnv = settings.agentDefaultEnv ?? {}
   const agentPermissionMode = resolveAgentPermissionModeSummary({
@@ -726,6 +810,21 @@ export function AgentsPane({ settings, updateSettings }: AgentsPaneProps): React
       delete next[id]
     }
     updateSettings({ agentCmdOverrides: next })
+  }
+
+  // Why: empty value clears the per-agent key so the built-in resume flags
+  // (from buildAiVaultResumeCommand) take over again.
+  const isAiVaultAgent = (id: TuiAgent): id is AiVaultAgent =>
+    (AI_VAULT_AGENTS as readonly TuiAgent[]).includes(id)
+
+  const saveResumeArgs = (id: TuiAgent, value: string): void => {
+    const next = { ...resumeArgsOverrides }
+    if (value) {
+      next[id] = value
+    } else {
+      delete next[id]
+    }
+    updateSettings({ agentResumeArgsOverrides: next })
   }
 
   const saveAgentArgs = (id: TuiAgent, value: string): void => {
@@ -880,6 +979,15 @@ export function AgentsPane({ settings, updateSettings }: AgentsPaneProps): React
                 cmdOverride={cmdOverrides[agent.id]}
                 argsOverride={resolveTuiAgentLaunchArgs(agent.id, agentDefaultArgs)}
                 envOverride={resolveTuiAgentLaunchEnv(agent.id, agentDefaultEnv)}
+                resumeArgsOverride={
+                  isAiVaultAgent(agent.id) ? resumeArgsOverrides[agent.id] : undefined
+                }
+                defaultResumeArgs={
+                  isAiVaultAgent(agent.id) ? defaultAiVaultResumeArgsTemplate(agent.id) : undefined
+                }
+                onSaveResumeArgs={
+                  isAiVaultAgent(agent.id) ? (v) => saveResumeArgs(agent.id, v) : undefined
+                }
                 onSetDefault={() => setDefault(agent.id)}
                 onSetEnabled={(enabled) => setAgentEnabled(agent.id, enabled)}
                 onSaveOverride={(v) => saveOverride(agent.id, v)}
@@ -924,6 +1032,15 @@ export function AgentsPane({ settings, updateSettings }: AgentsPaneProps): React
                 cmdOverride={undefined}
                 argsOverride={resolveTuiAgentLaunchArgs(agent.id, agentDefaultArgs)}
                 envOverride={resolveTuiAgentLaunchEnv(agent.id, agentDefaultEnv)}
+                resumeArgsOverride={
+                  isAiVaultAgent(agent.id) ? resumeArgsOverrides[agent.id] : undefined
+                }
+                defaultResumeArgs={
+                  isAiVaultAgent(agent.id) ? defaultAiVaultResumeArgsTemplate(agent.id) : undefined
+                }
+                onSaveResumeArgs={
+                  isAiVaultAgent(agent.id) ? (v) => saveResumeArgs(agent.id, v) : undefined
+                }
                 onSetDefault={() => {}}
                 onSetEnabled={(enabled) => setAgentEnabled(agent.id, enabled)}
                 onSaveOverride={() => {}}

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -14,6 +14,7 @@ export function buildAiVaultResumeCommandForWorktree(args: {
   worktreeId?: string | null
   session: AiVaultResumeCommandSession
   commandOverride?: string | null
+  resumeArgsOverride?: string | null
 }): string {
   const platform = getAiVaultResumePlatform(args.state, args.worktreeId)
   const codexHome = getAiVaultResumeCodexHome(args.session.codexHome, platform)
@@ -23,6 +24,7 @@ export function buildAiVaultResumeCommandForWorktree(args: {
     cwd: args.session.cwd,
     platform,
     commandOverride: args.commandOverride,
+    resumeArgsOverride: args.resumeArgsOverride,
     codexHome
   })
 }

--- a/src/shared/ai-vault-types.test.ts
+++ b/src/shared/ai-vault-types.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { buildAiVaultResumeCommand, defaultAiVaultResumeArgsTemplate } from './ai-vault-types'
+
+const base = {
+  sessionId: 'sess-123',
+  cwd: '/work/repo',
+  platform: 'darwin' as NodeJS.Platform
+}
+
+describe('buildAiVaultResumeCommand', () => {
+  it('uses built-in resume flags when no override is set', () => {
+    expect(buildAiVaultResumeCommand({ ...base, agent: 'claude' })).toBe(
+      "cd '/work/repo' && claude --resume 'sess-123'"
+    )
+    expect(buildAiVaultResumeCommand({ ...base, agent: 'copilot' })).toBe(
+      "cd '/work/repo' && copilot --resume='sess-123'"
+    )
+  })
+
+  it('keeps the CODEX_HOME prefix and base override together', () => {
+    expect(
+      buildAiVaultResumeCommand({
+        ...base,
+        agent: 'codex',
+        commandOverride: 'npx codex',
+        codexHome: '/home/.codex'
+      })
+    ).toBe("cd '/work/repo' && CODEX_HOME='/home/.codex' npx codex resume 'sess-123'")
+  })
+
+  it('substitutes {{id}} in a resume-args override with the quoted session id', () => {
+    expect(
+      buildAiVaultResumeCommand({ ...base, agent: 'claude', resumeArgsOverride: '--resume {{id}} --yolo' })
+    ).toBe("cd '/work/repo' && claude --resume 'sess-123' --yolo")
+  })
+
+  it('appends the session id when the override omits {{id}}', () => {
+    expect(
+      buildAiVaultResumeCommand({ ...base, agent: 'claude', resumeArgsOverride: 'resume --pick' })
+    ).toBe("cd '/work/repo' && claude resume --pick 'sess-123'")
+  })
+
+  it('preserves the CODEX_HOME prefix when codex resume flags are overridden', () => {
+    expect(
+      buildAiVaultResumeCommand({
+        ...base,
+        agent: 'codex',
+        resumeArgsOverride: 'resume {{id}}',
+        codexHome: '/home/.codex'
+      })
+    ).toBe("cd '/work/repo' && CODEX_HOME='/home/.codex' codex resume 'sess-123'")
+  })
+
+  it('omits the cd prefix when there is no cwd', () => {
+    expect(buildAiVaultResumeCommand({ ...base, cwd: null, agent: 'claude' })).toBe(
+      "claude --resume 'sess-123'"
+    )
+  })
+})
+
+describe('defaultAiVaultResumeArgsTemplate', () => {
+  it('returns editable flag templates with an {{id}} placeholder', () => {
+    expect(defaultAiVaultResumeArgsTemplate('claude')).toBe('--resume {{id}}')
+    expect(defaultAiVaultResumeArgsTemplate('codex')).toBe('resume {{id}}')
+    expect(defaultAiVaultResumeArgsTemplate('copilot')).toBe('--resume={{id}}')
+    expect(defaultAiVaultResumeArgsTemplate('kimi')).toBe('--session {{id}}')
+  })
+})

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -88,14 +88,16 @@ export function buildAiVaultResumeCommand(args: {
   cwd: string | null
   platform: NodeJS.Platform
   commandOverride?: string | null
+  resumeArgsOverride?: string | null
   codexHome?: string | null
 }): string {
-  const { agent, sessionId, cwd, platform, commandOverride, codexHome } = args
+  const { agent, sessionId, cwd, platform, commandOverride, resumeArgsOverride, codexHome } = args
   const baseCommand = commandOverride?.trim() || defaultAiVaultResumeCommandBase(agent)
   const sessionArg = quoteShellArg(sessionId, platform)
   const resumeCommand = buildAgentResumeInvocation(agent, baseCommand, sessionArg, {
     codexHome: codexHome?.trim() || null,
-    platform
+    platform,
+    resumeArgsOverride: resumeArgsOverride?.trim() || null
   })
 
   if (!cwd) {
@@ -131,22 +133,42 @@ function buildAgentResumeInvocation(
   agent: AiVaultAgent,
   baseCommand: string,
   sessionArg: string,
-  options: { codexHome: string | null; platform: NodeJS.Platform }
+  options: { codexHome: string | null; platform: NodeJS.Platform; resumeArgsOverride: string | null }
 ): string {
+  // Why: codex needs CODEX_HOME exported before the binary; keep that prefix
+  // even when the user overrides the resume flags.
+  const envPrefix = agent === 'codex' ? codexHomeEnvPrefix(options.codexHome, options.platform) : ''
+  const flags = options.resumeArgsOverride
+    ? expandResumeArgsOverride(options.resumeArgsOverride, sessionArg)
+    : defaultAgentResumeFlags(agent, sessionArg)
+  return `${envPrefix}${baseCommand} ${flags}`
+}
+
+// Why: {{id}} marks where the shell-quoted session id goes; if the override
+// omits it, append the id so a flags-only value still resumes the session.
+// The replacement uses a function so a session id with `$` is treated literally.
+function expandResumeArgsOverride(override: string, sessionArg: string): string {
+  if (override.includes('{{id}}')) {
+    return override.replace(/\{\{id\}\}/g, () => sessionArg)
+  }
+  return `${override} ${sessionArg}`
+}
+
+function defaultAgentResumeFlags(agent: AiVaultAgent, sessionArg: string): string {
   switch (agent) {
     case 'codex':
-      return `${codexHomeEnvPrefix(options.codexHome, options.platform)}${baseCommand} resume ${sessionArg}`
+      return `resume ${sessionArg}`
     case 'rovo':
-      return `${baseCommand} rovodev run --restore ${sessionArg}`
+      return `rovodev run --restore ${sessionArg}`
     case 'opencode':
     case 'pi':
     // Why: Kimi Code resumes with `kimi --session <id>` (alias `-S`). Sessions
     // are work-dir-scoped, so the cwd prefix from buildAiVaultResumeCommand is
     // required — resuming from another directory is rejected by the CLI.
     case 'kimi':
-      return `${baseCommand} --session ${sessionArg}`
+      return `--session ${sessionArg}`
     case 'copilot':
-      return `${baseCommand} --resume=${sessionArg}`
+      return `--resume=${sessionArg}`
     case 'claude':
     case 'cursor':
     case 'gemini':
@@ -155,8 +177,13 @@ function buildAgentResumeInvocation(
     case 'devin':
     case 'openclaw':
     case 'droid':
-      return `${baseCommand} --resume ${sessionArg}`
+      return `--resume ${sessionArg}`
   }
+}
+
+/** Default resume flags for an agent as an editable template ({{id}} = session id). */
+export function defaultAiVaultResumeArgsTemplate(agent: AiVaultAgent): string {
+  return defaultAgentResumeFlags(agent, '{{id}}')
 }
 
 function codexHomeEnvPrefix(codexHome: string | null, platform: NodeJS.Platform): string {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -312,6 +312,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     opencodeWorkspaceId: '',
     geminiCliOAuthEnabled: false,
     agentCmdOverrides: {},
+    agentResumeArgsOverrides: {},
     agentDefaultArgs: { ...DEFAULT_TUI_AGENT_ARGS },
     agentDefaultEnv: { ...DEFAULT_TUI_AGENT_ENV },
     agentYoloDefaultsMigrated: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2639,6 +2639,9 @@ export type GlobalSettings = {
   geminiCliOAuthEnabled: boolean
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */
   agentCmdOverrides: Partial<Record<TuiAgent, string>>
+  /** Per-agent resume flag overrides for the Agent Session History resume button.
+   *  Use {{id}} for the session id (omit it to append). Missing key = built-in flags. */
+  agentResumeArgsOverrides?: Partial<Record<TuiAgent, string>>
   /** Per-agent default CLI arguments appended after the binary/path and before prompts. */
   agentDefaultArgs?: Partial<Record<TuiAgent, string>>
   /** Per-agent launch environment defaults used when yolo mode is exposed as env. */


### PR DESCRIPTION
## Summary
Makes the Resume in New Tab command in the Agent Session History panel configurable per agent via Settings → Agents → Resume.

- New optional setting agentResumeArgsOverrides (mirrors agentCmdOverrides).
- The override replaces the resume flags after the binary; {{id}} = shell-quoted session id (omit it to append).
- Base binary, cd prefix, CODEX_HOME prefix, and win32 wrapping are preserved.
- Default output is byte-for-byte unchanged when no override is set, so the scanner-precomputed resumeCommand and existing tests are unaffected.

## Test plan
- tsc --noEmit -p tsconfig.web.json: clean
- New unit test src/shared/ai-vault-types.test.ts (run: pnpm test src/shared/ai-vault-types.test.ts)
- Manual: set a Resume override in Settings → Agents, click Resume in New Tab, confirm the launched command reflects it