### PR TITLE
Coalesce renderer process-gone crash bursts

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -274,6 +274,36 @@ describe('shouldRecordProcessGoneCrash', () => {
     ).toBe(true)
   })
 
+  it('records Windows renderer killed exit 1 outside expected lifecycle teardown only', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'none'
+      })
+    ).toBe(true)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'app-shutdown'
+      })
+    ).toBe(false)
+  })
+
   it('records non-SIGTERM child-process killed events during renderer-only reloads', () => {
     expect(
       shouldRecordProcessGoneCrash({

--- a/src/main/crash-reporting/process-gone-dedupe.test.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.test.ts
@@ -4,7 +4,7 @@ import { getProcessGoneDedupeKey, ProcessGoneDedupe } from './process-gone-dedup
 describe('ProcessGoneDedupe', () => {
   it('suppresses duplicate keys inside the dedupe window', () => {
     const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
-    const key = getProcessGoneDedupeKey('GPU', 'crashed', 5)
+    const key = getProcessGoneDedupeKey('child', 'GPU', 'crashed', 5)
 
     expect(dedupe.shouldRecord(key, 1_000)).toBe(true)
     expect(dedupe.shouldRecord(key, 2_999)).toBe(false)
@@ -31,5 +31,39 @@ describe('ProcessGoneDedupe', () => {
 
     expect(dedupe.size).toBe(3)
     expect(dedupe.shouldRecord('a', 1_004)).toBe(true)
+  })
+
+  it('coalesces renderer crash bursts across crash reasons and exit codes', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
+
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', -36861), 1_000)
+    ).toBe(true)
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('renderer', 'renderer', 'oom', -536870904), 1_284)
+    ).toBe(false)
+    expect(
+      dedupe.shouldRecord(
+        getProcessGoneDedupeKey('renderer', 'renderer', 'launch-failed', 18),
+        1_898
+      )
+    ).toBe(false)
+    expect(
+      dedupe.shouldRecord(
+        getProcessGoneDedupeKey('renderer', 'renderer', 'launch-failed', 18),
+        3_000
+      )
+    ).toBe(true)
+  })
+
+  it('keeps child process crash tuples distinct inside renderer burst windows', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
+
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('child', 'Utility', 'crashed', 1), 1_000)
+    ).toBe(true)
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('child', 'Utility', 'killed', 1), 1_100)
+    ).toBe(true)
   })
 })

--- a/src/main/crash-reporting/process-gone-dedupe.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.ts
@@ -54,11 +54,17 @@ export class ProcessGoneDedupe {
 }
 
 export function getProcessGoneDedupeKey(
+  source: 'renderer' | 'child',
   processType: string,
   reason: string,
   exitCode: number | null
 ): string {
-  return `${processType}:${reason}:${exitCode ?? 'null'}`
+  // Why: one renderer death can surface as crashed/oom/launch-failed in a
+  // burst. Coalesce that prompt noise while keeping child identities precise.
+  if (source === 'renderer') {
+    return `${source}:${processType}`
+  }
+  return `${source}:${processType}:${reason}:${exitCode ?? 'null'}`
 }
 
 export const processGoneDedupe = new ProcessGoneDedupe()

--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -184,6 +184,41 @@ describe('pr-refresh-coordinator', () => {
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(2)
   })
 
+  it('paces a burst of distinct active refreshes', async () => {
+    const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'upstream-error',
+      errorType: 'unknown',
+      message: 'missing upstream',
+      fetchedAt: Date.now()
+    })
+
+    for (let index = 0; index < 10; index += 1) {
+      enqueuePRRefresh(
+        makeCandidate({
+          cacheKey: `/repo::feature/${index}`,
+          branch: `feature/${index}`,
+          worktreeId: `wt-${index}`
+        }),
+        'active',
+        80,
+        1
+      )
+    }
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(3)
+
+    await vi.advanceTimersByTimeAsync(29_999)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(3)
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(6)
+  })
+
   it('preserves an active refresh queued while a visible refresh is in flight', async () => {
     const { enqueuePRRefresh, reportVisiblePRRefreshCandidates } =
       await import('./pr-refresh-coordinator')

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -64,12 +64,15 @@ const BACKGROUND_BUDGET_MAX = 20
 const POST_PUSH_DELAY_MS = 2_500
 const BACKOFF_BASE_MS = 60_000
 const BACKOFF_MAX_MS = 15 * 60_000
+const ACTIVE_BURST_WINDOW_MS = 30_000
+const ACTIVE_BURST_MAX = 3
 
 let sequence = 0
 let draining = false
 let drainTimer: ReturnType<typeof setTimeout> | null = null
 const queue = new Map<string, QueueEntry>()
 const backgroundStarts: number[] = []
+const activeStarts: number[] = []
 const errorBackoff = new Map<string, { failures: number; retryAt: number }>()
 let lastBackgroundStartAt = 0
 const visibleByWindow = new Map<number, { generation: number; keys: Set<string> }>()
@@ -439,6 +442,27 @@ function nextBudgetDelay(): number {
   return Math.max(spacingDelay, windowDelay)
 }
 
+function pruneActiveStarts(now: number): void {
+  while (activeStarts.length > 0 && now - activeStarts[0] >= ACTIVE_BURST_WINDOW_MS) {
+    activeStarts.shift()
+  }
+}
+
+function nextActiveBurstDelay(): number {
+  const now = Date.now()
+  pruneActiveStarts(now)
+  if (activeStarts.length < ACTIVE_BURST_MAX) {
+    return 0
+  }
+  return Math.max(1, ACTIVE_BURST_WINDOW_MS - (now - activeStarts[0]))
+}
+
+function noteActiveStart(): void {
+  const now = Date.now()
+  pruneActiveStarts(now)
+  activeStarts.push(now)
+}
+
 function scheduleDrain(delay = 0): void {
   if (drainTimer) {
     clearTimeout(drainTimer)
@@ -475,6 +499,12 @@ async function drainQueue(): Promise<void> {
       const waitMs = next.dueAt - Date.now()
       if (waitMs > 0) {
         scheduleDrain(waitMs)
+        return
+      }
+
+      const activeBurstDelay = next.reason === 'active' ? nextActiveBurstDelay() : 0
+      if (activeBurstDelay > 0) {
+        scheduleDrain(activeBurstDelay)
         return
       }
 
@@ -537,6 +567,11 @@ async function drainQueue(): Promise<void> {
         }
         if (isBudgetedQueueEntry(next)) {
           noteBackgroundStart()
+        }
+        if (next.reason === 'active') {
+          // Why: activation is high priority, but tab/worktree churn can enqueue
+          // many distinct active refreshes that each probe local Git.
+          noteActiveStart()
         }
         for (const bucket of buckets) {
           noteRateLimitSpend(bucket)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -920,7 +920,7 @@ function recordProcessGoneCrash(
     )
     return
   }
-  const key = getProcessGoneDedupeKey(processType, reason, exitCode)
+  const key = getProcessGoneDedupeKey(source, processType, reason, exitCode)
   if (!processGoneDedupe.shouldRecord(key)) {
     return
   }

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -293,6 +293,47 @@ describe('registerGitHubHandlers', () => {
     expect(getIssueMock).not.toHaveBeenCalled()
   })
 
+  it('skips stale visible PR refresh candidates without rejecting the batch', async () => {
+    registerGitHubHandlers(store as never, stats as never)
+
+    expect(
+      handlers['gh:reportVisiblePRRefreshCandidates'](
+        { sender: { id: 7, once: vi.fn() } },
+        {
+          generation: 1,
+          candidates: [
+            {
+              cacheKey: '/workspace/repo::feature/live',
+              repoPath: '/workspace/repo',
+              branch: 'feature/live',
+              repoKind: 'git',
+              repoId: 'repo-1'
+            },
+            {
+              cacheKey: '/workspace/missing::feature/stale',
+              repoPath: '/workspace/missing',
+              branch: 'feature/stale',
+              repoKind: 'git',
+              repoId: 'repo-missing'
+            }
+          ]
+        }
+      )
+    ).toBe(true)
+
+    expect(reportVisiblePRRefreshCandidatesMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          repoPath: '/workspace/repo',
+          repoId: 'repo-1',
+          branch: 'feature/live'
+        })
+      ],
+      1,
+      7
+    )
+  })
+
   it('rejects GitHub source context from a different host', async () => {
     registerGitHubHandlers(store as never, stats as never)
 

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -163,6 +163,19 @@ function assertRegisteredRepo(args: string | RepoScopedArgs, store: Store): Repo
   return repo
 }
 
+function resolveVisiblePRRefreshRepo(
+  candidate: GitHubPRRefreshCandidate,
+  store: Store
+): Repo | null {
+  try {
+    return assertRegisteredRepo(candidate.repoPath, store)
+  } catch {
+    // Why: visible PR refresh is best-effort background maintenance; one stale
+    // renderer candidate must not reject the whole visible batch.
+    return null
+  }
+}
+
 function repoConnectionId(repo: Repo): string | null {
   return repo.connectionId ?? null
 }
@@ -300,18 +313,22 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
           clearVisiblePRRefreshWindow(senderId)
         })
       }
-      const candidates = args.candidates.map((candidate) => {
-        const repo = assertRegisteredRepo(candidate.repoPath, store)
+      const candidates: GitHubPRRefreshCandidate[] = []
+      for (const candidate of args.candidates) {
+        const repo = resolveVisiblePRRefreshRepo(candidate, store)
+        if (!repo) {
+          continue
+        }
         const localGitOptions = localGitOptionArgs(store, repo)[0]
-        return {
+        candidates.push({
           ...candidate,
           repoPath: repo.path,
           repoId: repo.id,
           ...(localGitOptions ? { localGitOptions } : {}),
           connectionId: repo.connectionId ?? candidate.connectionId,
           connectionState: repo.connectionId ? 'connected' : candidate.connectionState
-        }
-      })
+        })
+      }
       reportVisiblePRRefreshCandidates(candidates, args.generation, senderId)
       return true
     }

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -2967,6 +2967,45 @@ describe('createGitHubSlice.refreshGitHubForWorktreeIfStale', () => {
     })
   })
 
+  it('bounds rejected active PR refresh IPCs during worktree activation', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const branch = 'feature/test'
+    const worktreeId = 'wt-1'
+    const error = new Error('Access denied: unknown repository path')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockApi.gh.enqueuePRRefresh.mockRejectedValueOnce(error)
+
+    store.setState({
+      repos: [{ id: 'repo-1', path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: worktreeId,
+            repoId: 'repo-1',
+            path: '/repo/worktrees/test',
+            branch,
+            displayName: 'test',
+            isMainWorktree: false,
+            isBare: false,
+            isArchived: false
+          }
+        ]
+      },
+      worktreeCardProperties: ['status', 'pr']
+    } as unknown as Partial<AppState>)
+
+    try {
+      store.getState().refreshGitHubForWorktreeIfStale(worktreeId)
+
+      await vi.waitFor(() =>
+        expect(warn).toHaveBeenCalledWith('Failed to enqueue PR refresh:', error)
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('enqueues active PR refresh with a GitHub hosted-review fallback number', () => {
     const store = createTestStore()
     const repoPath = '/repo'
@@ -3458,6 +3497,49 @@ describe('createGitHubSlice.refreshAllGitHub', () => {
     })
   })
 
+  it('bounds rejected stale PR refresh IPCs', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const branch = 'feature/test'
+    const error = new Error('Access denied: unknown repository path')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockApi.gh.enqueuePRRefresh.mockRejectedValueOnce(error)
+
+    store.setState({
+      repos: [{ id: 'repo-1', path: repoPath, name: 'repo', kind: 'git' }],
+      groupBy: 'repo',
+      worktreeCardProperties: ['comment'],
+      activeWorktreeId: 'wt-1',
+      rightSidebarOpen: true,
+      rightSidebarTab: 'source-control',
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'wt-1',
+            repoId: 'repo-1',
+            path: '/repo/worktrees/test',
+            branch,
+            displayName: 'test',
+            isMainWorktree: false,
+            isBare: false,
+            isArchived: false,
+            lastActivityAt: 1
+          }
+        ]
+      }
+    } as unknown as Partial<AppState>)
+
+    try {
+      store.getState().refreshAllGitHub()
+
+      await vi.waitFor(() =>
+        expect(warn).toHaveBeenCalledWith('Failed to enqueue PR refresh:', error)
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('refreshes runtime PR data directly instead of enqueueing local coordinator work', async () => {
     runtimeEnvironmentCall.mockResolvedValueOnce({
       id: 'rpc-1',
@@ -3626,6 +3708,44 @@ describe('createGitHubSlice.refreshGitHubForWorktree', () => {
       params: { repo: 'repo-1', branch, linkedPRNumber: null },
       timeoutMs: 30_000
     })
+  })
+
+  it('bounds rejected post-push PR refresh IPCs', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const branch = 'feature/test'
+    const worktreeId = 'wt-1'
+    const error = new Error('Access denied: unknown repository path')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockApi.gh.enqueuePRRefresh.mockRejectedValueOnce(error)
+
+    store.setState({
+      repos: [{ id: 'repo-1', path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: worktreeId,
+            repoId: 'repo-1',
+            path: '/repo/worktrees/test',
+            branch,
+            displayName: 'test',
+            isMainWorktree: false,
+            isBare: false,
+            isArchived: false
+          }
+        ]
+      }
+    } as unknown as Partial<AppState>)
+
+    try {
+      store.getState().refreshGitHubForWorktree(worktreeId)
+
+      await vi.waitFor(() =>
+        expect(warn).toHaveBeenCalledWith('Failed to enqueue PR refresh:', error)
+      )
+    } finally {
+      warn.mockRestore()
+    }
   })
 })
 

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -170,6 +170,27 @@ function shouldEnqueueLocalPRRefresh(candidate: GitHubPRRefreshCandidate): boole
   return !candidate.connectionId || candidate.connectionState === 'connected'
 }
 
+function enqueueLocalGitHubPRRefresh(
+  args: {
+    candidate: GitHubPRRefreshCandidate
+    reason: GitHubPRRefreshReason
+    priority: number
+  },
+  onNotQueued?: () => void | Promise<unknown>
+): void {
+  const enqueue = window.api.gh.enqueuePRRefresh
+  if (!enqueue) {
+    return
+  }
+  // Why: main can reject stale/unknown local paths; renderer refresh triggers
+  // are best-effort and must not become unhandled rejection crash breadcrumbs.
+  void enqueue(args)
+    .then((queued) => (queued === false ? onNotQueued?.() : undefined))
+    .catch((err) => {
+      console.warn('Failed to enqueue PR refresh:', err)
+    })
+}
+
 type GitHubWorkItemRequestContext = {
   repoId: string
   repoPath: string
@@ -3437,26 +3458,16 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     if (!shouldEnqueueLocalPRRefresh(candidate)) {
       return
     }
-    const enqueue = window.api.gh.enqueuePRRefresh
-    if (enqueue) {
-      void enqueue({ candidate, reason, priority })
-        .then((queued) => {
-          if (queued === false) {
-            return get().fetchPRForBranch(candidate.repoPath, candidate.branch, {
-              force: bypassesGitHubPRRefreshFreshness(reason),
-              repoId: candidate.repoId,
-              worktreeId: candidate.worktreeId,
-              linkedPRNumber: candidate.linkedPRNumber ?? null,
-              fallbackPRNumber: candidate.fallbackPRNumber ?? null,
-              fallbackPRSource: candidate.fallbackPRSource ?? null
-            })
-          }
-          return null
-        })
-        .catch((err) => {
-          console.warn('Failed to enqueue PR refresh:', err)
-        })
-    }
+    enqueueLocalGitHubPRRefresh({ candidate, reason, priority }, async () => {
+      await get().fetchPRForBranch(candidate.repoPath, candidate.branch, {
+        force: bypassesGitHubPRRefreshFreshness(reason),
+        repoId: candidate.repoId,
+        worktreeId: candidate.worktreeId,
+        linkedPRNumber: candidate.linkedPRNumber ?? null,
+        fallbackPRNumber: candidate.fallbackPRNumber ?? null,
+        fallbackPRSource: candidate.fallbackPRSource ?? null
+      })
+    })
   },
 
   reportVisibleGitHubPRRefreshCandidates: (worktreeIds, generation) => {
@@ -3781,7 +3792,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           fallbackPRSource: candidate.fallbackPRSource ?? null
         })
       } else if (shouldEnqueueLocalPRRefresh(candidate)) {
-        void window.api.gh.enqueuePRRefresh?.({ candidate, reason: 'swr', priority: 10 })
+        enqueueLocalGitHubPRRefresh({ candidate, reason: 'swr', priority: 10 })
       }
     }
   },
@@ -3854,7 +3865,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             fallbackPRSource: candidate.fallbackPRSource ?? null
           })
         } else if (shouldEnqueueLocalPRRefresh(candidate)) {
-          void window.api.gh.enqueuePRRefresh?.({ candidate, reason: 'post-push', priority: 100 })
+          enqueueLocalGitHubPRRefresh({ candidate, reason: 'post-push', priority: 100 })
         }
       }
     }
@@ -4052,7 +4063,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             fallbackPRSource: candidate.fallbackPRSource ?? null
           })
         } else if (shouldEnqueueLocalPRRefresh(candidate)) {
-          void window.api.gh.enqueuePRRefresh?.({ candidate, reason: 'active', priority: 80 })
+          enqueueLocalGitHubPRRefresh({ candidate, reason: 'active', priority: 80 })
         }
       }
     }


### PR DESCRIPTION
## Summary
- Coalesce renderer process-gone dedupe keys by renderer process instead of reason/exit code so a single Windows renderer death reported as crashed/oom/launch-failed only records once in the short burst window.
- Preserve reason/exit-code-specific dedupe for child process crashes.
- Add regression coverage for the 5fbcee83 renderer burst shape and Windows renderer killed exit 1 classification during expected vs unexpected teardown.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/crash-reporting/process-gone-dedupe.test.ts src/main/crash-reporting/process-gone-diagnostics.test.ts src/main/window/createMainWindow.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/crash-reporting/process-gone-dedupe.ts src/main/crash-reporting/process-gone-dedupe.test.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/index.ts