### PR TITLE
Coalesce renderer process-gone crash bursts

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -274,6 +274,36 @@ describe('shouldRecordProcessGoneCrash', () => {
     ).toBe(true)
   })
 
+  it('records Windows renderer killed exit 1 outside expected lifecycle teardown only', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'none'
+      })
+    ).toBe(true)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'app-shutdown'
+      })
+    ).toBe(false)
+  })
+
   it('records non-SIGTERM child-process killed events during renderer-only reloads', () => {
     expect(
       shouldRecordProcessGoneCrash({

--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -201,6 +201,16 @@ describe('shouldRecordProcessGoneCrash', () => {
         expectedTeardown: 'none'
       })
     ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'Utility',
+        serviceName: 'video_capture.mojom.VideoCaptureService',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
   })
 
   it('still records unknown child process crashes', () => {
@@ -231,6 +241,16 @@ describe('shouldRecordProcessGoneCrash', () => {
         source: 'child',
         processType: 'Utility',
         serviceName: 'network.mojom.NetworkService',
+        reason: 'launch-failed',
+        exitCode: -1,
+        expectedTeardown: 'none'
+      })
+    ).toBe(true)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'Utility',
+        serviceName: 'video_capture.mojom.VideoCaptureService',
         reason: 'launch-failed',
         exitCode: -1,
         expectedTeardown: 'none'

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -5,7 +5,10 @@ const WINDOWS_CONTROL_TERMINATION_EXIT_CODES = new Set([0xc000013a, 0x40010004])
 const RECOVERABLE_CHILD_PROCESS_TYPES = new Set(['gpu'])
 const RECOVERABLE_UTILITY_SERVICE_NAMES = new Set([
   'audio.mojom.AudioService',
-  'network.mojom.NetworkService'
+  'network.mojom.NetworkService',
+  // Why: Windows media/screen capture can churn this Chromium utility without
+  // taking down Orca; prompting users for those child exits is noise.
+  'video_capture.mojom.VideoCaptureService'
 ])
 const RECOVERABLE_CHILD_PROCESS_REASONS = new Set(['abnormal-exit', 'crashed', 'killed'])
 const NON_RECOVERABLE_RENDERER_REASONS = new Set(['integrity-failure', 'launch-failed'])

--- a/src/main/crash-reporting/process-gone-dedupe.test.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.test.ts
@@ -4,7 +4,7 @@ import { getProcessGoneDedupeKey, ProcessGoneDedupe } from './process-gone-dedup
 describe('ProcessGoneDedupe', () => {
   it('suppresses duplicate keys inside the dedupe window', () => {
     const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
-    const key = getProcessGoneDedupeKey('GPU', 'crashed', 5)
+    const key = getProcessGoneDedupeKey('child', 'GPU', 'crashed', 5)
 
     expect(dedupe.shouldRecord(key, 1_000)).toBe(true)
     expect(dedupe.shouldRecord(key, 2_999)).toBe(false)
@@ -31,5 +31,39 @@ describe('ProcessGoneDedupe', () => {
 
     expect(dedupe.size).toBe(3)
     expect(dedupe.shouldRecord('a', 1_004)).toBe(true)
+  })
+
+  it('coalesces renderer crash bursts across crash reasons and exit codes', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
+
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', -36861), 1_000)
+    ).toBe(true)
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('renderer', 'renderer', 'oom', -536870904), 1_284)
+    ).toBe(false)
+    expect(
+      dedupe.shouldRecord(
+        getProcessGoneDedupeKey('renderer', 'renderer', 'launch-failed', 18),
+        1_898
+      )
+    ).toBe(false)
+    expect(
+      dedupe.shouldRecord(
+        getProcessGoneDedupeKey('renderer', 'renderer', 'launch-failed', 18),
+        3_000
+      )
+    ).toBe(true)
+  })
+
+  it('keeps child process crash tuples distinct inside renderer burst windows', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
+
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('child', 'Utility', 'crashed', 1), 1_000)
+    ).toBe(true)
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('child', 'Utility', 'killed', 1), 1_100)
+    ).toBe(true)
   })
 })

--- a/src/main/crash-reporting/process-gone-dedupe.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.ts
@@ -54,11 +54,17 @@ export class ProcessGoneDedupe {
 }
 
 export function getProcessGoneDedupeKey(
+  source: 'renderer' | 'child',
   processType: string,
   reason: string,
   exitCode: number | null
 ): string {
-  return `${processType}:${reason}:${exitCode ?? 'null'}`
+  // Why: one renderer death can surface as crashed/oom/launch-failed in a
+  // burst. Coalesce that prompt noise while keeping child identities precise.
+  if (source === 'renderer') {
+    return `${source}:${processType}`
+  }
+  return `${source}:${processType}:${reason}:${exitCode ?? 'null'}`
 }
 
 export const processGoneDedupe = new ProcessGoneDedupe()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -920,7 +920,7 @@ function recordProcessGoneCrash(
     )
     return
   }
-  const key = getProcessGoneDedupeKey(processType, reason, exitCode)
+  const key = getProcessGoneDedupeKey(source, processType, reason, exitCode)
   if (!processGoneDedupe.shouldRecord(key)) {
     return
   }


### PR DESCRIPTION
## Summary
- Coalesce renderer process-gone dedupe keys by renderer process instead of reason/exit code so a single Windows renderer death reported as crashed/oom/launch-failed only records once in the short burst window.
- Suppress recoverable Chromium Video Capture utility child exits (`video_capture.mojom.VideoCaptureService`) alongside GPU, Network Service, and Audio Service churn so Windows child-process noise does not prompt as an Orca crash.
- Preserve reason/exit-code-specific dedupe and severe failure reporting for unknown child services and launch failures.
- Add regression coverage for the `5fbcee83` renderer burst shape, Windows renderer killed exit 1 classification during expected vs unexpected teardown, and the `444808e0` Video Capture child-process shape.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/crash-reporting/process-gone-dedupe.test.ts`
- Earlier #6202 validation: `pnpm exec vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/crash-reporting/process-gone-dedupe.test.ts src/main/crash-reporting/process-gone-diagnostics.test.ts src/main/window/createMainWindow.test.ts`
- Earlier #6202 validation: `pnpm run typecheck:node`
- Earlier #6202 validation: targeted `oxlint`
- Orca child-worktree Electron validation reproduced the process-gone scenario and passed `tests/e2e/process-gone-crash-reporting.spec.ts` locally with `2` tests.
- PR CI is rerunning for `c31b35650`.

## Screenshots
- Not applicable; crash-reporting logic only.

## AI Review Report
- Cross-platform: keeps process-gone classification runtime-only and preserves child diagnostic precision for unknown/severe failures.
- SSH/runtime: no local-only path assumptions added.
- CodeRabbit: no actionable comments were generated before the latest Video Capture follow-up.

## Security Audit
- No new secrets, auth flows, network permissions, telemetry, or external inputs.

## Notes
- #6203 is stacked on this PR for the separate PR-refresh crash storm cluster.