### PR TITLE
docs: document localization workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Orca targets macOS, Linux, and Windows. Keep all platform-dependent behavior beh
 
 ## Localization (i18n)
 
-All user-facing copy is localized. `src/renderer/src/i18n/locales/en.json` is the source of truth; the `zh`, `ja`, `ko`, and `es` catalogs mirror its keys. Strings reach the UI through `translate('auto.<key>', 'English fallback')` (also `t` / `translateMain`) — never hardcode display text.
+All user-facing copy is localized. `src/renderer/src/i18n/locales/en.json` is the source of truth; the `zh`, `ja`, `ko`, and `es` catalogs mirror its keys. Strings reach the UI through `translate('auto.<key>', 'English fallback')` — never hardcode display text.
 
 When you touch user-facing copy, keep all five catalogs in sync:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,18 @@ Orca targets macOS, Linux, and Windows. Keep all platform-dependent behavior beh
 - **Shortcut labels in UI**: Display `⌘` / `⇧` on Mac and `Ctrl+` / `Shift+` on other platforms.
 - **File paths**: Use `path.join` or Electron/Node path utilities — never assume `/` or `\`.
 
+## Localization (i18n)
+
+All user-facing copy is localized. `src/renderer/src/i18n/locales/en.json` is the source of truth; the `zh`, `ja`, `ko`, and `es` catalogs mirror its keys. Strings reach the UI through `translate('auto.<key>', 'English fallback')` (also `t` / `translateMain`) — never hardcode display text.
+
+When you touch user-facing copy, keep all five catalogs in sync:
+
+- **New strings** — wrap them in `translate(...)` with an English fallback, run `pnpm sync:localization-catalog` to register the keys in `en.json` and add placeholders to every other locale, then `pnpm bootstrap:<locale>-catalog` (e.g. `bootstrap:ja-catalog`) to translate the placeholders.
+- **Reworded strings** — changing the value of an existing key updates only `en.json`. The other locales keep the key with its old translation, and **the lint checks will not catch this**: `verify:localization-catalog` enforces key _parity_, not translation _freshness_. Update the same key in `zh/ja/ko/es` by hand, or re-translate it via `bootstrap:<locale>-catalog`.
+- **Removed strings** — delete the key from _every_ locale; the parity check rejects a key that exists in one catalog but not another.
+
+Before pushing copy changes, run `pnpm verify:localization-catalog` and `pnpm verify:localization-coverage` (both also run in `pnpm lint`).
+
 ## SSH Use Case
 
 All changes must consider the SSH use case. Don't assume local-only execution.


### PR DESCRIPTION
## Summary

Documents the localization workflow in `AGENTS.md`, which currently has **zero** i18n guidance. The entire workflow lives only in `package.json` scripts (`sync:localization-catalog`, `bootstrap:*-catalog`), so an agent or contributor changing UI copy has no instruction telling them to update the locale catalogs.

This gap caused a concrete miss: in #6199 a dialog's English copy was reworded, but the `zh`/`ja`/`ko`/`es` catalogs kept the old translation — and nothing flagged it.

## Why the lint checks don't catch it

`pnpm lint` runs `verify:localization-catalog`, but that check enforces key **parity** (every locale has the same keys), not translation **freshness**. Rewording an _existing_ key changes only `en.json`; the other locales still have the key, so parity stays green and CI passes with stale translations. The new section calls this out explicitly so the next person knows it's a manual responsibility.

## What's added

A `## Localization (i18n)` section covering:
- `en.json` as source of truth; `zh/ja/ko/es` mirror its keys; copy reaches the UI via `translate(...)`.
- The workflow for **new** strings (`sync` → `bootstrap:<locale>-catalog`), **reworded** strings (update locales by hand or re-bootstrap — lint won't catch staleness), and **removed** strings (delete from every locale or parity fails).
- The pre-push checks (`verify:localization-catalog`, `verify:localization-coverage`).

## Validation

Docs-only change. Verified the referenced script names exist in `package.json` and that `verify:localization-catalog` / `verify:localization-coverage` pass on the current tree.

## ELI5

Documents how to keep locale catalogs in sync when UI copy changes. Helps contributors and agents avoid shipping English-only updates that leave other languages stale.
