### PR TITLE
Prevent active PR refresh storms from overwhelming worktrees

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -209,14 +209,236 @@ describe('pr-refresh-coordinator', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(3)
+    expect(
+      getPRForBranchOutcomeMock.mock.calls.map(([repoPath, branch]) => [repoPath, branch])
+    ).toEqual([
+      ['/repo', 'feature/9'],
+      ['/repo', 'feature/8'],
+      ['/repo', 'feature/7']
+    ])
 
     await vi.advanceTimersByTimeAsync(29_999)
 
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(3)
+    expect(
+      sendMock.mock.calls
+        .map(([, event]) => event)
+        .some((event) => event.reason === 'active' && event.status === 'queued')
+    ).toBe(true)
 
     await vi.advanceTimersByTimeAsync(1)
 
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(6)
+  })
+
+  it('treats a same-key active reactivation as the latest active signal', async () => {
+    const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'upstream-error',
+      errorType: 'unknown',
+      message: 'missing upstream',
+      fetchedAt: Date.now()
+    })
+
+    for (let index = 0; index < 10; index += 1) {
+      enqueuePRRefresh(
+        makeCandidate({
+          cacheKey: `/repo::feature/${index}`,
+          branch: `feature/${index}`,
+          worktreeId: `wt-${index}`
+        }),
+        'active',
+        80,
+        1
+      )
+    }
+    await vi.advanceTimersByTimeAsync(0)
+
+    enqueuePRRefresh(
+      makeCandidate({
+        cacheKey: '/repo::feature/0',
+        branch: 'feature/0',
+        worktreeId: 'wt-0'
+      }),
+      'active',
+      80,
+      1
+    )
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(getPRForBranchOutcomeMock.mock.calls[3]?.[1]).toBe('feature/0')
+  })
+
+  it('does not let one capped active window block another window', async () => {
+    const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'upstream-error',
+      errorType: 'unknown',
+      message: 'missing upstream',
+      fetchedAt: Date.now()
+    })
+
+    for (let index = 0; index < 10; index += 1) {
+      enqueuePRRefresh(
+        makeCandidate({
+          cacheKey: `/repo::feature/${index}`,
+          branch: `feature/${index}`,
+          worktreeId: `wt-${index}`
+        }),
+        'active',
+        80,
+        1
+      )
+    }
+    enqueuePRRefresh(
+      makeCandidate({
+        cacheKey: '/repo::feature/other-window',
+        branch: 'feature/other-window',
+        worktreeId: 'wt-other-window'
+      }),
+      'active',
+      80,
+      2
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getPRForBranchOutcomeMock.mock.calls.map((call) => call[1])).toContain(
+      'feature/other-window'
+    )
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not let capped host active work block WSL or SSH active scopes', async () => {
+    const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'upstream-error',
+      errorType: 'unknown',
+      message: 'missing upstream',
+      fetchedAt: Date.now()
+    })
+
+    for (let index = 0; index < 10; index += 1) {
+      enqueuePRRefresh(
+        makeCandidate({
+          cacheKey: `/repo::feature/${index}`,
+          branch: `feature/${index}`,
+          worktreeId: `wt-${index}`
+        }),
+        'active',
+        80,
+        1
+      )
+    }
+    enqueuePRRefresh(
+      makeCandidate({
+        cacheKey: 'wsl::repo-1::feature/wsl',
+        branch: 'feature/wsl',
+        localGitOptions: { wslDistro: 'Ubuntu' },
+        worktreeId: 'wt-wsl'
+      }),
+      'active',
+      80,
+      1
+    )
+    enqueuePRRefresh(
+      makeCandidate({
+        cacheKey: 'ssh:ssh-1::repo-1::feature/ssh',
+        branch: 'feature/ssh',
+        connectionId: 'ssh-1',
+        worktreeId: 'wt-ssh'
+      }),
+      'active',
+      80,
+      1
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    const startedBranches = getPRForBranchOutcomeMock.mock.calls.map((call) => call[1])
+    expect(startedBranches).toContain('feature/wsl')
+    expect(startedBranches).toContain('feature/ssh')
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(5)
+  })
+
+  it('does not let a capped active scope block ready visible work', async () => {
+    const { enqueuePRRefresh, reportVisiblePRRefreshCandidates } =
+      await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'upstream-error',
+      errorType: 'unknown',
+      message: 'missing upstream',
+      fetchedAt: Date.now()
+    })
+
+    for (let index = 0; index < 10; index += 1) {
+      enqueuePRRefresh(
+        makeCandidate({
+          cacheKey: `/repo::feature/${index}`,
+          branch: `feature/${index}`,
+          worktreeId: `wt-${index}`
+        }),
+        'active',
+        80,
+        1
+      )
+    }
+    reportVisiblePRRefreshCandidates(
+      [
+        makeCandidate({
+          cacheKey: '/repo::feature/visible',
+          branch: 'feature/visible',
+          worktreeId: 'wt-visible'
+        })
+      ],
+      1,
+      1
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getPRForBranchOutcomeMock.mock.calls.map((call) => call[1])).toContain('feature/visible')
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not consume active burst slots for rate-limit pauses', async () => {
+    const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
+    getRateLimitMock
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValue({ ok: true })
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'upstream-error',
+      errorType: 'unknown',
+      message: 'missing upstream',
+      fetchedAt: Date.now()
+    })
+
+    for (let index = 0; index < 6; index += 1) {
+      enqueuePRRefresh(
+        makeCandidate({
+          cacheKey: `/repo::feature/${index}`,
+          branch: `feature/${index}`,
+          worktreeId: `wt-${index}`
+        }),
+        'active',
+        80,
+        1
+      )
+    }
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    const pausedEvents = sendMock.mock.calls
+      .map(([, event]) => event)
+      .filter((event) => event.status === 'paused' && event.skippedReason === 'rate-limit')
+    expect(pausedEvents).toHaveLength(3)
+    expect(getPRForBranchOutcomeMock.mock.calls.map((call) => call[1])).toEqual([
+      'feature/2',
+      'feature/1',
+      'feature/0'
+    ])
   })
 
   it('preserves an active refresh queued while a visible refresh is in flight', async () => {

--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -401,6 +401,69 @@ describe('pr-refresh-coordinator', () => {
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(4)
   })
 
+  it('wakes for visible budget spacing before a capped active burst opens', async () => {
+    const { enqueuePRRefresh, reportVisiblePRRefreshCandidates } =
+      await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'upstream-error',
+      errorType: 'unknown',
+      message: 'missing upstream',
+      fetchedAt: Date.now()
+    })
+
+    reportVisiblePRRefreshCandidates(
+      [
+        makeCandidate({
+          cacheKey: '/repo::feature/visible-first',
+          branch: 'feature/visible-first',
+          worktreeId: 'wt-visible-first'
+        })
+      ],
+      1,
+      1
+    )
+    await vi.advanceTimersByTimeAsync(0)
+
+    for (let index = 0; index < 10; index += 1) {
+      enqueuePRRefresh(
+        makeCandidate({
+          cacheKey: `/repo::feature/${index}`,
+          branch: `feature/${index}`,
+          worktreeId: `wt-${index}`
+        }),
+        'active',
+        80,
+        1
+      )
+    }
+    reportVisiblePRRefreshCandidates(
+      [
+        makeCandidate({
+          cacheKey: '/repo::feature/visible-second',
+          branch: 'feature/visible-second',
+          worktreeId: 'wt-visible-second'
+        })
+      ],
+      2,
+      1
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(4)
+
+    await vi.advanceTimersByTimeAsync(9_999)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(4)
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(getPRForBranchOutcomeMock.mock.calls.map((call) => call[1])).toContain(
+      'feature/visible-second'
+    )
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(5)
+  })
+
   it('does not consume active burst slots for rate-limit pauses', async () => {
     const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
     getRateLimitMock

--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -184,6 +184,41 @@ describe('pr-refresh-coordinator', () => {
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(2)
   })
 
+  it('paces a burst of distinct active refreshes', async () => {
+    const { enqueuePRRefresh } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'upstream-error',
+      errorType: 'unknown',
+      message: 'missing upstream',
+      fetchedAt: Date.now()
+    })
+
+    for (let index = 0; index < 10; index += 1) {
+      enqueuePRRefresh(
+        makeCandidate({
+          cacheKey: `/repo::feature/${index}`,
+          branch: `feature/${index}`,
+          worktreeId: `wt-${index}`
+        }),
+        'active',
+        80,
+        1
+      )
+    }
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(3)
+
+    await vi.advanceTimersByTimeAsync(29_999)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(3)
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(6)
+  })
+
   it('preserves an active refresh queued while a visible refresh is in flight', async () => {
     const { enqueuePRRefresh, reportVisiblePRRefreshCandidates } =
       await import('./pr-refresh-coordinator')

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -100,13 +100,23 @@ function removeInvisibleVisibleRefreshes(): void {
   }
 }
 
-export function clearVisiblePRRefreshWindow(windowId: number): void {
-  if (!visibleByWindow.delete(windowId)) {
-    return
+function clearActiveBurstWindow(windowId: number): void {
+  const windowPrefix = `${windowId}::`
+  for (const scope of Array.from(activeStartsByScope.keys())) {
+    if (scope.startsWith(windowPrefix)) {
+      activeStartsByScope.delete(scope)
+    }
   }
-  // Why: visible follow-ups are owned by the renderer that reported them.
-  // If that WebContents is destroyed, no later visibility report may arrive.
-  removeInvisibleVisibleRefreshes()
+}
+
+export function clearVisiblePRRefreshWindow(windowId: number): void {
+  const hadVisibleRefreshes = visibleByWindow.delete(windowId)
+  clearActiveBurstWindow(windowId)
+  if (hadVisibleRefreshes) {
+    // Why: visible follow-ups are owned by the renderer that reported them.
+    // If that WebContents is destroyed, no later visibility report may arrive.
+    removeInvisibleVisibleRefreshes()
+  }
 }
 
 function nextSequence(): number {
@@ -513,6 +523,19 @@ function isActiveBurstDelayed(entry: QueueEntry): boolean {
   return entry.reason === 'active' && nextActiveBurstDelay(entry) > 0
 }
 
+function nextQueuedWakeDelay(excludedKey: string): number | null {
+  const now = Date.now()
+  let nextDelay = Number.POSITIVE_INFINITY
+  for (const entry of queue.values()) {
+    if (entry.key === excludedKey) {
+      continue
+    }
+    const delay = entry.dueAt > now ? entry.dueAt - now : entryDelay(entry)
+    nextDelay = Math.min(nextDelay, delay)
+  }
+  return Number.isFinite(nextDelay) ? Math.max(0, nextDelay) : null
+}
+
 function scheduleDrain(delay = 0): void {
   if (drainTimer) {
     clearTimeout(drainTimer)
@@ -569,7 +592,7 @@ async function drainQueue(): Promise<void> {
               status: 'queued'
             })
           }
-          scheduleDrain(delay)
+          scheduleDrain(Math.min(delay, nextQueuedWakeDelay(next.key) ?? delay))
           return
         }
       }

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -20,7 +20,9 @@ type QueueEntry = {
   reason: GitHubPRRefreshReason
   priority: number
   dueAt: number
+  queuedAt: number
   bypassBackgroundBudget?: boolean
+  activeDelayNotified?: boolean
   windowId?: number
 }
 
@@ -68,11 +70,12 @@ const ACTIVE_BURST_WINDOW_MS = 30_000
 const ACTIVE_BURST_MAX = 3
 
 let sequence = 0
+let queueOrder = 0
 let draining = false
 let drainTimer: ReturnType<typeof setTimeout> | null = null
 const queue = new Map<string, QueueEntry>()
 const backgroundStarts: number[] = []
-const activeStarts: number[] = []
+const activeStartsByScope = new Map<string, number[]>()
 const errorBackoff = new Map<string, { failures: number; retryAt: number }>()
 let lastBackgroundStartAt = 0
 const visibleByWindow = new Map<number, { generation: number; keys: Set<string> }>()
@@ -109,6 +112,11 @@ export function clearVisiblePRRefreshWindow(windowId: number): void {
 function nextSequence(): number {
   sequence += 1
   return sequence
+}
+
+function nextQueueOrder(): number {
+  queueOrder += 1
+  return queueOrder
 }
 
 function broadcast(event: Omit<GitHubPRRefreshEvent, 'sequence'>, sequenceOverride?: number): void {
@@ -332,6 +340,7 @@ function scheduleVisibleFollowUp(
       reason: 'visible',
       priority,
       dueAt: retryAt,
+      queuedAt: nextQueueOrder(),
       windowId
     })
     // Why: this is a delayed retry, not active work; showing it as a spinner
@@ -360,6 +369,7 @@ function scheduleVisibleFollowUp(
     reason: 'visible',
     priority,
     dueAt,
+    queuedAt: nextQueueOrder(),
     // Why: this manual one-shot fixes GitHub's transient UNKNOWN state; visible
     // spacing would otherwise delay it past the intended prompt retry window.
     bypassBackgroundBudget: pendingMergeabilityDueAt !== null,
@@ -442,25 +452,65 @@ function nextBudgetDelay(): number {
   return Math.max(spacingDelay, windowDelay)
 }
 
-function pruneActiveStarts(now: number): void {
+function activeBurstScope(entry: QueueEntry): string {
+  const runtimeScope = entry.candidate.connectionId
+    ? `ssh:${entry.candidate.connectionId}`
+    : `local:${entry.candidate.localGitOptions?.wslDistro ?? 'host'}`
+  return `${entry.windowId ?? 'global'}::${runtimeScope}`
+}
+
+function pruneActiveStarts(scope: string, now: number): number[] {
+  const activeStarts = activeStartsByScope.get(scope) ?? []
   while (activeStarts.length > 0 && now - activeStarts[0] >= ACTIVE_BURST_WINDOW_MS) {
     activeStarts.shift()
   }
+  if (activeStarts.length === 0) {
+    activeStartsByScope.delete(scope)
+  } else {
+    activeStartsByScope.set(scope, activeStarts)
+  }
+  return activeStarts
 }
 
-function nextActiveBurstDelay(): number {
+function nextActiveBurstDelay(entry: QueueEntry): number {
   const now = Date.now()
-  pruneActiveStarts(now)
+  const activeStarts = pruneActiveStarts(activeBurstScope(entry), now)
   if (activeStarts.length < ACTIVE_BURST_MAX) {
     return 0
   }
   return Math.max(1, ACTIVE_BURST_WINDOW_MS - (now - activeStarts[0]))
 }
 
-function noteActiveStart(): void {
+function noteActiveStart(entry: QueueEntry): void {
   const now = Date.now()
-  pruneActiveStarts(now)
+  const scope = activeBurstScope(entry)
+  const activeStarts = pruneActiveStarts(scope, now)
   activeStarts.push(now)
+  activeStartsByScope.set(scope, activeStarts)
+}
+
+function activeOrder(a: QueueEntry, b: QueueEntry): number {
+  if (a.reason !== 'active' || b.reason !== 'active') {
+    return 0
+  }
+  if (activeBurstScope(a) !== activeBurstScope(b)) {
+    return 0
+  }
+  // Why: activation churn should refresh the worktree the user lands on before
+  // stale transient selections from the same window/runtime scope.
+  return b.queuedAt - a.queuedAt
+}
+
+function entryDelay(entry: QueueEntry): number {
+  const activeBurstDelay = entry.reason === 'active' ? nextActiveBurstDelay(entry) : 0
+  if (activeBurstDelay > 0) {
+    return activeBurstDelay
+  }
+  return isBudgetedQueueEntry(entry) ? nextBudgetDelay() : 0
+}
+
+function isActiveBurstDelayed(entry: QueueEntry): boolean {
+  return entry.reason === 'active' && nextActiveBurstDelay(entry) > 0
 }
 
 function scheduleDrain(delay = 0): void {
@@ -479,7 +529,7 @@ function queuedEntriesByPriority(): QueueEntry[] {
     const aReady = a.dueAt <= now
     const bReady = b.dueAt <= now
     if (aReady && bReady) {
-      return b.priority - a.priority || a.dueAt - b.dueAt
+      return b.priority - a.priority || activeOrder(a, b) || a.dueAt - b.dueAt
     }
     if (aReady !== bReady) {
       return aReady ? -1 : 1
@@ -495,23 +545,33 @@ async function drainQueue(): Promise<void> {
   draining = true
   try {
     while (queue.size > 0) {
-      const next = queuedEntriesByPriority()[0]
+      let next = queuedEntriesByPriority()[0]
       const waitMs = next.dueAt - Date.now()
       if (waitMs > 0) {
         scheduleDrain(waitMs)
         return
       }
 
-      const activeBurstDelay = next.reason === 'active' ? nextActiveBurstDelay() : 0
-      if (activeBurstDelay > 0) {
-        scheduleDrain(activeBurstDelay)
-        return
-      }
-
-      const budgetDelay = isBudgetedQueueEntry(next) ? nextBudgetDelay() : 0
-      if (budgetDelay > 0) {
-        scheduleDrain(budgetDelay)
-        return
+      let delay = entryDelay(next)
+      if (delay > 0) {
+        const runnable = queuedEntriesByPriority().find(
+          (entry) => entry.dueAt <= Date.now() && entryDelay(entry) === 0
+        )
+        if (runnable && runnable.key !== next.key) {
+          next = runnable
+          delay = 0
+        } else {
+          if (isActiveBurstDelayed(next) && !next.activeDelayNotified) {
+            next.activeDelayNotified = true
+            broadcast({
+              aliases: Array.from(next.aliases.values()),
+              reason: next.reason,
+              status: 'queued'
+            })
+          }
+          scheduleDrain(delay)
+          return
+        }
       }
 
       queue.delete(next.key)
@@ -571,7 +631,7 @@ async function drainQueue(): Promise<void> {
         if (next.reason === 'active') {
           // Why: activation is high priority, but tab/worktree churn can enqueue
           // many distinct active refreshes that each probe local Git.
-          noteActiveStart()
+          noteActiveStart(next)
         }
         for (const bucket of buckets) {
           noteRateLimitSpend(bucket)
@@ -630,11 +690,14 @@ export function enqueuePRRefresh(
     const shouldPromoteExisting =
       priority > existing.priority ||
       isManual(reason) ||
+      (reason === 'active' && existing.reason === 'active') ||
       (priority >= existing.priority && dueAt < existing.dueAt && bypassesFreshnessDelay(reason))
     if (shouldPromoteExisting) {
       existing.priority = priority
       existing.reason = reason
       existing.dueAt = Math.min(existing.dueAt, dueAt)
+      existing.queuedAt = nextQueueOrder()
+      existing.activeDelayNotified = false
       existing.candidate = candidate
       existing.windowId = windowId ?? existing.windowId
     }
@@ -646,6 +709,7 @@ export function enqueuePRRefresh(
       reason,
       priority,
       dueAt,
+      queuedAt: nextQueueOrder(),
       windowId
     })
   }

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -64,12 +64,15 @@ const BACKGROUND_BUDGET_MAX = 20
 const POST_PUSH_DELAY_MS = 2_500
 const BACKOFF_BASE_MS = 60_000
 const BACKOFF_MAX_MS = 15 * 60_000
+const ACTIVE_BURST_WINDOW_MS = 30_000
+const ACTIVE_BURST_MAX = 3
 
 let sequence = 0
 let draining = false
 let drainTimer: ReturnType<typeof setTimeout> | null = null
 const queue = new Map<string, QueueEntry>()
 const backgroundStarts: number[] = []
+const activeStarts: number[] = []
 const errorBackoff = new Map<string, { failures: number; retryAt: number }>()
 let lastBackgroundStartAt = 0
 const visibleByWindow = new Map<number, { generation: number; keys: Set<string> }>()
@@ -439,6 +442,27 @@ function nextBudgetDelay(): number {
   return Math.max(spacingDelay, windowDelay)
 }
 
+function pruneActiveStarts(now: number): void {
+  while (activeStarts.length > 0 && now - activeStarts[0] >= ACTIVE_BURST_WINDOW_MS) {
+    activeStarts.shift()
+  }
+}
+
+function nextActiveBurstDelay(): number {
+  const now = Date.now()
+  pruneActiveStarts(now)
+  if (activeStarts.length < ACTIVE_BURST_MAX) {
+    return 0
+  }
+  return Math.max(1, ACTIVE_BURST_WINDOW_MS - (now - activeStarts[0]))
+}
+
+function noteActiveStart(): void {
+  const now = Date.now()
+  pruneActiveStarts(now)
+  activeStarts.push(now)
+}
+
 function scheduleDrain(delay = 0): void {
   if (drainTimer) {
     clearTimeout(drainTimer)
@@ -475,6 +499,12 @@ async function drainQueue(): Promise<void> {
       const waitMs = next.dueAt - Date.now()
       if (waitMs > 0) {
         scheduleDrain(waitMs)
+        return
+      }
+
+      const activeBurstDelay = next.reason === 'active' ? nextActiveBurstDelay() : 0
+      if (activeBurstDelay > 0) {
+        scheduleDrain(activeBurstDelay)
         return
       }
 
@@ -537,6 +567,11 @@ async function drainQueue(): Promise<void> {
         }
         if (isBudgetedQueueEntry(next)) {
           noteBackgroundStart()
+        }
+        if (next.reason === 'active') {
+          // Why: activation is high priority, but tab/worktree churn can enqueue
+          // many distinct active refreshes that each probe local Git.
+          noteActiveStart()
         }
         for (const bucket of buckets) {
           noteRateLimitSpend(bucket)

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -293,6 +293,47 @@ describe('registerGitHubHandlers', () => {
     expect(getIssueMock).not.toHaveBeenCalled()
   })
 
+  it('skips stale visible PR refresh candidates without rejecting the batch', async () => {
+    registerGitHubHandlers(store as never, stats as never)
+
+    expect(
+      handlers['gh:reportVisiblePRRefreshCandidates'](
+        { sender: { id: 7, once: vi.fn() } },
+        {
+          generation: 1,
+          candidates: [
+            {
+              cacheKey: '/workspace/repo::feature/live',
+              repoPath: '/workspace/repo',
+              branch: 'feature/live',
+              repoKind: 'git',
+              repoId: 'repo-1'
+            },
+            {
+              cacheKey: '/workspace/missing::feature/stale',
+              repoPath: '/workspace/missing',
+              branch: 'feature/stale',
+              repoKind: 'git',
+              repoId: 'repo-missing'
+            }
+          ]
+        }
+      )
+    ).toBe(true)
+
+    expect(reportVisiblePRRefreshCandidatesMock).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          repoPath: '/workspace/repo',
+          repoId: 'repo-1',
+          branch: 'feature/live'
+        })
+      ],
+      1,
+      7
+    )
+  })
+
   it('rejects GitHub source context from a different host', async () => {
     registerGitHubHandlers(store as never, stats as never)
 

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -277,7 +277,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
   ipcMain.handle(
     'gh:enqueuePRRefresh',
     (
-      _event,
+      event,
       args: {
         candidate: GitHubPRRefreshCandidate
         reason: GitHubPRRefreshReason
@@ -296,7 +296,8 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
           connectionState: repo.connectionId ? 'connected' : args.candidate.connectionState
         },
         args.reason,
-        args.priority ?? 0
+        args.priority ?? 0,
+        event.sender.id
       )
       return true
     }

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -163,6 +163,19 @@ function assertRegisteredRepo(args: string | RepoScopedArgs, store: Store): Repo
   return repo
 }
 
+function resolveVisiblePRRefreshRepo(
+  candidate: GitHubPRRefreshCandidate,
+  store: Store
+): Repo | null {
+  try {
+    return assertRegisteredRepo(candidate.repoPath, store)
+  } catch {
+    // Why: visible PR refresh is best-effort background maintenance; one stale
+    // renderer candidate must not reject the whole visible batch.
+    return null
+  }
+}
+
 function repoConnectionId(repo: Repo): string | null {
   return repo.connectionId ?? null
 }
@@ -300,18 +313,22 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
           clearVisiblePRRefreshWindow(senderId)
         })
       }
-      const candidates = args.candidates.map((candidate) => {
-        const repo = assertRegisteredRepo(candidate.repoPath, store)
+      const candidates: GitHubPRRefreshCandidate[] = []
+      for (const candidate of args.candidates) {
+        const repo = resolveVisiblePRRefreshRepo(candidate, store)
+        if (!repo) {
+          continue
+        }
         const localGitOptions = localGitOptionArgs(store, repo)[0]
-        return {
+        candidates.push({
           ...candidate,
           repoPath: repo.path,
           repoId: repo.id,
           ...(localGitOptions ? { localGitOptions } : {}),
           connectionId: repo.connectionId ?? candidate.connectionId,
           connectionState: repo.connectionId ? 'connected' : candidate.connectionState
-        }
-      })
+        })
+      }
       reportVisiblePRRefreshCandidates(candidates, args.generation, senderId)
       return true
     }


### PR DESCRIPTION
## Summary- Adds a main-process active PR refresh burst governor so rapid worktree activation churn starts at most three active refreshes per 30-second window for each renderer window/runtime scope.- Keeps the newest active selection first within the same window/runtime while allowing other windows, host/WSL/SSH scopes, and eligible visible/SWR refreshes to keep draining.- Cleans up active burst accounting when a renderer window is destroyed and passes the IPC sender id into active refresh enqueues so the governor is window-aware.## Design / Review- Design scratch: `.tmp/pr-refresh-active-burst-design-2026-06-23.md` (not included in the PR).- Design review found the initial FIFO burst plan could delay the final active worktree; resolved with latest-active-wins ordering plus burst pacing.- Completeness verification found the implementation matched the design.- Code review round 1 found two issues: window-scoped burst cleanup and timer oversleep behind a capped active entry. Both were fixed.- Code review round 2: both independent reviewers returned `No issues found.`## Validation- [x] `pnpm vitest run --config config/vitest.config.ts src/main/github/pr-refresh-coordinator.test.ts src/main/github/client.test.ts src/main/github/gh-utils.test.ts src/main/ipc/github.test.ts` - 137 tests passed.- [x] `pnpm oxlint src/main/github/pr-refresh-coordinator.ts src/main/github/pr-refresh-coordinator.test.ts src/main/ipc/github.ts src/main/ipc/github.test.ts`.- [x] `pnpm run typecheck:node`.- [x] `git diff --check origin/main...HEAD`.- [x] Post-commit smoke: `pnpm vitest run --config config/vitest.config.ts src/main/github/pr-refresh-coordinator.test.ts src/main/ipc/github.test.ts` - 42 tests passed.- [x] `brennan-test-changes` focused validation: scoped behavior and tests pass.## Accepted Gaps- Electron/demo-project was not run because this is a deterministic main-process queue/timer governor with no intentional renderer UI change; reproducing the crash shape live would require artificial instrumentation or a synthetic refresh storm.- Live SSH validation was not run; the transport path is unchanged, and focused tests cover separate SSH/WSL/host scopes.- Full `pnpm run lint` currently fails on an unrelated renderer exhaustive-switch issue in `src/renderer/src/components/task-page-github-work-item-status.ts`, which is outside this scoped PR-refresh change.
## Post-PR Stabilization
- Waited 8 minutes after opening the PR before checking automation.
- CI checks are passing: `verify` and `track-community-pr`.
- CodeRabbit initially hit a review rate limit; manually triggered `@coderabbitai review` after the retry window. CodeRabbit acknowledged the trigger and posted no actionable code findings.