### PR TITLE
Prevent accidental tab drags when clicking

### DIFF
--- a/src/renderer/src/components/tab-group/useTabDragSplit.test.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.test.ts
@@ -10,6 +10,8 @@ import type { TabDragItemData } from './useTabDragSplit'
 import {
   canDropTabForPaneColumnSplit,
   canDropTabIntoPaneBody,
+  getTabDragActivationDistance,
+  TAB_DRAG_ACTIVATION_DISTANCE_PX,
   useTabDragSplit
 } from './useTabDragSplit'
 
@@ -175,6 +177,21 @@ afterEach(() => {
   }
   document.body.replaceChildren()
   vi.clearAllMocks()
+})
+
+describe('tab drag activation distance', () => {
+  it('uses the named threshold for enabled tab drags', () => {
+    expect(TAB_DRAG_ACTIVATION_DISTANCE_PX).toBe(12)
+    expect(getTabDragActivationDistance(true)).toBe(TAB_DRAG_ACTIVATION_DISTANCE_PX)
+  })
+
+  it('keeps enabled tab drags above the old overly-sensitive distance', () => {
+    expect(TAB_DRAG_ACTIVATION_DISTANCE_PX).toBeGreaterThan(5)
+  })
+
+  it('uses an impossible activation distance when tab dragging is disabled', () => {
+    expect(getTabDragActivationDistance(false)).toBe(Number.MAX_SAFE_INTEGER)
+  })
 })
 
 describe('canDropTabIntoPaneBody', () => {

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -45,6 +45,10 @@ export type { HoveredTabInsertion }
 
 export type TabDropZone = 'center' | TabSplitDirection
 
+// Why: tab activation waits for pointerup, so dnd-kit needs enough movement
+// tolerance to avoid treating ordinary click jitter as an intentional drag.
+export const TAB_DRAG_ACTIVATION_DISTANCE_PX = 12
+
 export type TabDragItemData = {
   kind: 'tab'
   worktreeId: string
@@ -145,6 +149,10 @@ export function getTabPaneBodyDroppableId(groupId: string): UniqueIdentifier {
   return `tab-group-pane-body:${groupId}`
 }
 
+export function getTabDragActivationDistance(enabled: boolean): number {
+  return enabled ? TAB_DRAG_ACTIVATION_DISTANCE_PX : Number.MAX_SAFE_INTEGER
+}
+
 export function useTabDragSplit({
   worktreeId,
   enabled = true
@@ -187,7 +195,7 @@ export function useTabDragSplit({
   // the sensors array into a useEffect dependency list — changing its
   // length between renders violates React's rules of hooks.
   const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: enabled ? 5 : Number.MAX_SAFE_INTEGER }
+    activationConstraint: { distance: getTabDragActivationDistance(enabled) }
   })
   const sensors = useSensors(pointerSensor)
 


### PR DESCRIPTION
## Summary
- Raises the tab drag activation distance from 5px to a named 12px policy so small trackpad drift during a click still switches tabs instead of starting a drag.
- Keeps the existing pointerup activation model, dnd-kit drag lifecycle, split/drop logic, webview passthrough, SSH behavior, and cross-platform pointer-event behavior unchanged.
- Adds focused regression coverage for the enabled threshold, the old 5px sensitivity guard, and the disabled hidden-worktree sentinel.

## Design / Review Pipeline
- Design approach documented in ignored scratch doc: design-docs/tab-click-drag-threshold.md.
- Design review: auto-design-review-fix completed clean for P0/P1 after adding ownership/data-flow detail, less brittle test guidance, and rollback criteria.
- Implementation: matched the reviewed design with no deviations.
- Completeness verification: read-only verifier marked implementation complete against every requirement; one verifier-local test-resolution hiccup was superseded by passing local/subagent runs.

## Code Review
- Round 1: two independent reviewers found no correctness issues. One noted the threshold test did not pin the exact 12px value.
- Fix from review: pinned TAB_DRAG_ACTIVATION_DISTANCE_PX to 12 in the test.
- Round 2: two fresh reviewers returned clean; only residual gap was real-device/manual trackpad feel, covered by product validation below.

## Validation
- brennan-test-changes verdict: land.
- Product surface: launched Electron from this worktree on branch brennanb2025/tab-click-gesture-bug; verified plain tab click switched without drag state, 8px sub-threshold drift switched without reorder, and intentional drag beyond threshold still showed drag affordance and reordered.
- SSH/cross-platform: no live SSH pass; accepted because this is renderer-local pointer classification with no runtime IPC/path/provider changes and no platform branch.

## Screenshots
- /tmp/orca-tab-drag-evidence/click-target-active.png
- /tmp/orca-tab-drag-evidence/subthreshold-click-terminal1-active.png
- /tmp/orca-tab-drag-evidence/intentional-drag-active.png

## Checks Run
- pnpm run typecheck
- pnpm run lint
- git diff --check
- pnpm vitest run src/renderer/src/components/tab-group/useTabDragSplit.test.ts src/renderer/src/components/tab-bar/tab-strip-pointer-activation.test.tsx --config config/vitest.config.ts
- brennan-test-changes also ran the focused tests individually.

## Post-PR Stabilization
- Completed required sleep 480 after opening the PR.
- CodeRabbit posted no actionable comments.
- PR checks passed: track-community-pr and verify.
- No follow-up fix commits were needed after PR creation.