### PR TITLE
Default session history to the current workspace

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -18,8 +18,9 @@ import {
   groupAiVaultSessions
 } from './ai-vault-session-filters'
 import {
-  normalizeAiVaultScopeForContext,
-  shouldRestoreAiVaultProjectScope
+  DEFAULT_AI_VAULT_SCOPE,
+  getRestorableAiVaultScope,
+  normalizeAiVaultScopeForContext
 } from './ai-vault-scope-state'
 import { buildAiVaultProjectContext } from './ai-vault-session-projects'
 import {
@@ -47,7 +48,7 @@ export default function AiVaultPanel(): React.JSX.Element {
   const projectHostSetupProjection = useProjectHostSetupProjection()
   const agentCmdOverrides = useAppStore((s) => s.settings?.agentCmdOverrides ?? {})
   const [query, setQuery] = useState('')
-  const [scope, setScope] = useState<AiVaultScope>('project')
+  const [scope, setScope] = useState<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
   const [sort, setSort] = useState<AiVaultSort>('updated')
   const [group, setGroup] = useState<AiVaultGroup>('project')
   const [hideEmptySessions, setHideEmptySessions] = useState(true)
@@ -61,6 +62,7 @@ export default function AiVaultPanel(): React.JSX.Element {
   const refreshInFlightRef = useRef(false)
   const mountedRef = useRef(true)
   const userChangedScopeRef = useRef(false)
+  const preferredScopeRef = useRef<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
 
   const isRemoteWorktree = Boolean(activeWorktreeRepo?.connectionId)
   const activeWorktreePath = activeWorktree?.path ?? null
@@ -91,8 +93,7 @@ export default function AiVaultPanel(): React.JSX.Element {
     (group === 'project' ? 0 : 1) +
     (hideEmptySessions ? 0 : 1)
 
-  // Project scope depends on active project context, but should come back after
-  // transient context loss unless the user intentionally chose another scope.
+  // Workspace is the preferred default, but unavailable context still falls back to All.
   useEffect(() => {
     const normalizedScope = normalizeAiVaultScopeForContext({
       scope,
@@ -105,16 +106,17 @@ export default function AiVaultPanel(): React.JSX.Element {
   }, [activeProjectKey, activeWorktreePath, scope])
 
   useEffect(() => {
-    if (
-      shouldRestoreAiVaultProjectScope({
-        scope,
-        activeProjectKey,
-        userChangedScope: userChangedScopeRef.current
-      })
-    ) {
-      setScope('project')
+    const restorableScope = getRestorableAiVaultScope({
+      scope,
+      activeProjectKey,
+      activeWorktreePath,
+      preferredScope: preferredScopeRef.current,
+      userChangedScope: userChangedScopeRef.current
+    })
+    if (restorableScope) {
+      setScope(restorableScope)
     }
-  }, [activeProjectKey, scope])
+  }, [activeProjectKey, activeWorktreePath, scope])
 
   const refresh = useCallback(async (args: { force?: boolean } = {}): Promise<void> => {
     if (refreshInFlightRef.current) {
@@ -284,7 +286,8 @@ export default function AiVaultPanel(): React.JSX.Element {
   }, [])
 
   const handleScopeChange = useCallback((nextScope: AiVaultScope) => {
-    userChangedScopeRef.current = nextScope !== 'project'
+    preferredScopeRef.current = nextScope
+    userChangedScopeRef.current = nextScope !== DEFAULT_AI_VAULT_SCOPE
     setScope(nextScope)
   }, [])
 

--- a/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
@@ -36,8 +36,11 @@ import { translate } from '@/i18n/i18n'
 
 const VAULT_HEADER_CONTROL_CLASS = 'size-6 shrink-0'
 
-const VAULT_SCOPE_TOGGLE_ITEM_CLASS =
-  'h-7 min-h-7 min-w-0 flex-1 basis-0 shrink border border-transparent bg-transparent px-2.5 text-[11px] font-medium leading-none text-foreground shadow-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground aria-[checked=true]:border-foreground/20 aria-[checked=true]:bg-foreground/10 aria-[checked=true]:text-foreground aria-[checked=true]:shadow-xs aria-[checked=true]:hover:bg-foreground/15 aria-[checked=true]:hover:text-foreground data-[state=on]:border-foreground/20 data-[state=on]:bg-foreground/10 data-[state=on]:text-foreground data-[state=on]:shadow-xs data-[state=on]:hover:bg-foreground/15 data-[state=on]:hover:text-foreground @max-[300px]/ai-vault:px-1.5'
+// Why: match ToggleGroup's spacing+outline qualifiers so selected edges out-specify its border-l-0 collapse.
+const VAULT_SCOPE_SELECTED_EDGE_CLASS =
+  'data-[spacing=0]:data-[variant=outline]:aria-[checked=true]:border-l data-[spacing=0]:data-[variant=outline]:data-[state=on]:border-l'
+
+const VAULT_SCOPE_TOGGLE_ITEM_CLASS = `h-7 min-h-7 min-w-0 flex-1 basis-0 shrink border border-transparent bg-transparent px-2.5 text-[11px] font-medium leading-none text-foreground shadow-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground aria-[checked=true]:border-foreground/20 aria-[checked=true]:bg-foreground/10 aria-[checked=true]:text-foreground aria-[checked=true]:shadow-xs aria-[checked=true]:hover:bg-foreground/15 aria-[checked=true]:hover:text-foreground data-[state=on]:border-foreground/20 data-[state=on]:bg-foreground/10 data-[state=on]:text-foreground data-[state=on]:shadow-xs data-[state=on]:hover:bg-foreground/15 data-[state=on]:hover:text-foreground ${VAULT_SCOPE_SELECTED_EDGE_CLASS} @max-[300px]/ai-vault:px-1.5`
 
 export function VaultGroupHeader({
   group,

--- a/src/renderer/src/components/right-sidebar/ai-vault-scope-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-scope-state.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import {
+  DEFAULT_AI_VAULT_SCOPE,
+  getRestorableAiVaultScope,
   normalizeAiVaultScopeForContext,
-  shouldRestoreAiVaultProjectScope
+  shouldRestoreDefaultAiVaultScope
 } from './ai-vault-scope-state'
+
+describe('DEFAULT_AI_VAULT_SCOPE', () => {
+  it('defaults the session history scope to workspace', () => {
+    expect(DEFAULT_AI_VAULT_SCOPE).toBe('workspace')
+  })
+})
 
 describe('normalizeAiVaultScopeForContext', () => {
   it('falls back from project to all when no active project is available', () => {
@@ -44,24 +52,97 @@ describe('normalizeAiVaultScopeForContext', () => {
   })
 })
 
-describe('shouldRestoreAiVaultProjectScope', () => {
-  it('restores project after automatic fallback when a project becomes available', () => {
+describe('shouldRestoreDefaultAiVaultScope', () => {
+  it('restores workspace after automatic fallback when a workspace becomes available', () => {
     expect(
-      shouldRestoreAiVaultProjectScope({
+      shouldRestoreDefaultAiVaultScope({
         scope: 'all',
         activeProjectKey: 'project:orca',
+        activeWorktreePath: '/repo',
         userChangedScope: false
       })
     ).toBe(true)
   })
 
-  it('does not restore project after the user manually changed scope', () => {
+  it('does not restore workspace while the workspace is unavailable', () => {
     expect(
-      shouldRestoreAiVaultProjectScope({
+      shouldRestoreDefaultAiVaultScope({
         scope: 'all',
         activeProjectKey: 'project:orca',
+        activeWorktreePath: null,
+        userChangedScope: false
+      })
+    ).toBe(false)
+  })
+
+  it('does not restore workspace after the user manually chose project or all', () => {
+    expect(
+      shouldRestoreDefaultAiVaultScope({
+        scope: 'all',
+        activeProjectKey: 'project:orca',
+        activeWorktreePath: '/repo',
         userChangedScope: true
       })
     ).toBe(false)
+  })
+
+  it('can restore a project default only when a project becomes available', () => {
+    expect(
+      shouldRestoreDefaultAiVaultScope({
+        scope: 'all',
+        activeProjectKey: null,
+        activeWorktreePath: '/repo',
+        userChangedScope: false,
+        defaultScope: 'project'
+      })
+    ).toBe(false)
+
+    expect(
+      shouldRestoreDefaultAiVaultScope({
+        scope: 'all',
+        activeProjectKey: 'project:orca',
+        activeWorktreePath: '/repo',
+        userChangedScope: false,
+        defaultScope: 'project'
+      })
+    ).toBe(true)
+  })
+})
+
+describe('getRestorableAiVaultScope', () => {
+  it('restores the workspace preference after automatic fallback', () => {
+    expect(
+      getRestorableAiVaultScope({
+        scope: 'all',
+        activeProjectKey: 'project:orca',
+        activeWorktreePath: '/repo',
+        preferredScope: 'workspace',
+        userChangedScope: false
+      })
+    ).toBe('workspace')
+  })
+
+  it('restores a manual project preference when a project becomes available again', () => {
+    expect(
+      getRestorableAiVaultScope({
+        scope: 'all',
+        activeProjectKey: 'project:orca',
+        activeWorktreePath: '/repo',
+        preferredScope: 'project',
+        userChangedScope: true
+      })
+    ).toBe('project')
+  })
+
+  it('keeps a manual all preference sticky', () => {
+    expect(
+      getRestorableAiVaultScope({
+        scope: 'all',
+        activeProjectKey: 'project:orca',
+        activeWorktreePath: '/repo',
+        preferredScope: 'all',
+        userChangedScope: true
+      })
+    ).toBeNull()
   })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-scope-state.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-scope-state.ts
@@ -1,5 +1,7 @@
 import type { AiVaultScope } from '../../../../shared/ai-vault-types'
 
+export const DEFAULT_AI_VAULT_SCOPE: AiVaultScope = 'workspace'
+
 export function normalizeAiVaultScopeForContext(args: {
   scope: AiVaultScope
   activeProjectKey: string | null
@@ -14,10 +16,65 @@ export function normalizeAiVaultScopeForContext(args: {
   return args.scope
 }
 
-export function shouldRestoreAiVaultProjectScope(args: {
+function isAiVaultScopeAvailable(args: {
   scope: AiVaultScope
   activeProjectKey: string | null
-  userChangedScope: boolean
+  activeWorktreePath: string | null
 }): boolean {
-  return Boolean(args.activeProjectKey && args.scope === 'all' && !args.userChangedScope)
+  return normalizeAiVaultScopeForContext(args) === args.scope
+}
+
+export function shouldRestoreDefaultAiVaultScope(args: {
+  scope: AiVaultScope
+  activeProjectKey: string | null
+  activeWorktreePath: string | null
+  userChangedScope: boolean
+  defaultScope?: AiVaultScope
+}): boolean {
+  const defaultScope = args.defaultScope ?? DEFAULT_AI_VAULT_SCOPE
+
+  return (
+    args.scope === 'all' &&
+    !args.userChangedScope &&
+    isAiVaultScopeAvailable({
+      scope: defaultScope,
+      activeProjectKey: args.activeProjectKey,
+      activeWorktreePath: args.activeWorktreePath
+    })
+  )
+}
+
+export function getRestorableAiVaultScope(args: {
+  scope: AiVaultScope
+  activeProjectKey: string | null
+  activeWorktreePath: string | null
+  preferredScope: AiVaultScope
+  userChangedScope: boolean
+  defaultScope?: AiVaultScope
+}): AiVaultScope | null {
+  const defaultScope = args.defaultScope ?? DEFAULT_AI_VAULT_SCOPE
+
+  if (args.preferredScope === defaultScope) {
+    return shouldRestoreDefaultAiVaultScope({
+      scope: args.scope,
+      activeProjectKey: args.activeProjectKey,
+      activeWorktreePath: args.activeWorktreePath,
+      userChangedScope: args.userChangedScope,
+      defaultScope
+    })
+      ? defaultScope
+      : null
+  }
+
+  if (args.scope !== 'all' || args.preferredScope === 'all') {
+    return null
+  }
+
+  return isAiVaultScopeAvailable({
+    scope: args.preferredScope,
+    activeProjectKey: args.activeProjectKey,
+    activeWorktreePath: args.activeWorktreePath
+  })
+    ? args.preferredScope
+    : null
 }


### PR DESCRIPTION
## Summary
- Default Agent Session History scope to `Workspace` instead of `Project`.
- Keep scope fallback/restoration context-aware so unavailable workspace/project scope falls back to `All`, then restores the preferred scope only when its context returns.
- Restore the selected segment's left edge in the `Workspace / Project / All` selector by out-specificing the shared ToggleGroup outline border-collapse rule.

## Design Approach
Scratch design doc: `design-docs/ai-vault-scope-selector-default-workspace.md` (ignored, not included in this PR).

The change stays local to the AI Vault right-sidebar scope selector. The scope default is centralized as `DEFAULT_AI_VAULT_SCOPE`, restoration logic now checks `activeWorktreePath` as well as project context, and the selector keeps using existing sidebar tokens/shadcn primitives.

## Design Review Outcome
`auto-design-review-fix` completed 2 iterations and returned READY. It added specificity guidance for the selected border override, required the short why-comment, clarified `activeWorktreePath` restoration dependencies, and required screenshot evidence for Workspace, Project, and All selected states.

Codex design review inside that skill could not run because `CODEX_LB_API_KEY` was unavailable; Claude review completed and no P0/P1 findings remained.

## Implementation
Changed files:
- `src/renderer/src/components/right-sidebar/AiVaultPanel.tsx`
- `src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx`
- `src/renderer/src/components/right-sidebar/ai-vault-scope-state.ts`
- `src/renderer/src/components/right-sidebar/ai-vault-scope-state.test.ts`

Deviation: manual `Project` selection is also restored after transient project-context loss instead of being stranded on `All`; this preserves user intent while keeping the default path as `Workspace`.

## Completeness Verification
Read-only verifier returned complete/no issues. It confirmed default Workspace scope, `activeWorktreePath` restoration dependency, sticky manual Project/All choices, compound selected-border selectors for both Radix state forms, and no changed prompt/SSH/path/shortcut/provider surfaces.

## Code Review
Round 1 used two independent `review-code` reviewers in parallel. Both returned `No issues found.` No second round was needed.

## Brennan Test Changes
Verdict: land.

Validated in Electron on this exact worktree. `window.api.app.getIdentity()` reported:
- `devRepoRoot: /Users/thebr/orca/workspaces/orca/remora`
- branch: `brennanb2025/fix-segment-default-border`

Used a disposable `demo-project` because the registered demo-project path had no usable visible worktree. The validator registered it, activated it, exercised the visible UI, then removed the project registration and deleted the temp repo.

Covered behavior:
- Fresh visible entry into Agents / AI Vault defaulted to `Workspace`.
- Manual `Project` selection worked.
- Manual `All` selection worked.
- Selected left border computed as `1px solid` for Workspace, Project, and All.
- Renderer console had 0 errors and 1 unrelated React Grab version warning.

Screenshot evidence captured locally:
- `/tmp/orca-ai-vault-scope-selector-remora-20260623-1601/workspace-selected.png`
- `/tmp/orca-ai-vault-scope-selector-remora-20260623-1601/project-selected.png`
- `/tmp/orca-ai-vault-scope-selector-remora-20260623-1601/all-selected.png`

## Checks
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/ai-vault-scope-state.test.ts` passed: 11 tests.
- `pnpm run typecheck:web` passed.
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/AiVaultPanel.tsx src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx src/renderer/src/components/right-sidebar/ai-vault-scope-state.ts src/renderer/src/components/right-sidebar/ai-vault-scope-state.test.ts` passed.
- `git diff --check` passed.
- Commit hook/lint-staged passed `oxlint`, React Doctor oxlint, and `oxfmt --write` on staged files.
- PR checks passed: `verify` and `track-community-pr`.

Accepted gap: full `pnpm run lint` was not run; targeted lint/static checks, CI `verify`, and live UI validation covered this narrow renderer change.

## Post-PR Stabilization
Completed.

- Waited 8 minutes after opening the PR with `sleep 480`.
- CodeRabbit posted no actionable comments.
- CodeRabbit's optional docstring-coverage warning was treated as non-actionable because this repo's guidance is to add brief why-comments for non-obvious constraints, not docstrings for simple helper mechanics.
- Final PR state is `CLEAN`.
- Final PR checks passed: `verify` and `track-community-pr`.

## Risks / Notes
- No persisted state migration is needed; this scope is local component state.
- No SSH, runtime RPC, provider, shortcut, or agent-prompt behavior changed.
- `pnpm` printed the existing local `.npmrc` `${GITHUB_TOKEN}` warning during checks, but commands completed successfully.
