### PR TITLE
Add source control shortcut actions

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -128,6 +128,8 @@ import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import { formatDiffComment, formatDiffComments } from '@/lib/diff-comments-format'
 import { getDiffCommentLineLabel, getDiffCommentSource } from '@/lib/diff-comment-compat'
 import { DiffNotesSendMenu } from '@/components/editor/DiffNotesSendMenu'
+import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import {
   countPendingDiffCommentsClear,
   formatPendingDiffCommentsClearDescription,
@@ -774,6 +776,7 @@ function SourceControlInner(): React.JSX.Element {
   const isRemoteOperationActive = useAppStore((s) => s.isRemoteOperationActive)
   const inFlightRemoteOpKind = useAppStore((s) => s.inFlightRemoteOpKind)
   const settings = useAppStore((s) => s.settings)
+  const keybindings = useAppStore((s) => s.keybindings)
   // Why: git/file mutations and repo metadata requests belong to the repo
   // OWNER host, not the currently focused host in the sidebar.
   const activeRepoSettings = useMemo(
@@ -4426,6 +4429,77 @@ function SourceControlInner(): React.JSX.Element {
         void runCreatePrIntent()
     }
   }, [handleActionInvoke, handleStageAllPrimary, primaryAction.kind, runCreatePrIntent])
+
+  useEffect(() => {
+    if (!rightSidebarOpen || rightSidebarTab !== 'source-control') {
+      return
+    }
+
+    const handleSourceControlShortcut = (event: KeyboardEvent): void => {
+      if (event.repeat || event.isComposing) {
+        return
+      }
+
+      const input = {
+        key: event.key,
+        code: event.code,
+        control: event.ctrlKey,
+        meta: event.metaKey,
+        alt: event.altKey,
+        shift: event.shiftKey
+      }
+      const platform = getShortcutPlatform()
+      const matches = (actionId: Parameters<typeof keybindingMatchesAction>[0]): boolean =>
+        keybindingMatchesAction(actionId, input, platform, keybindings)
+
+      if (matches('sourceControl.stageAll')) {
+        event.preventDefault()
+        void handleStageAllPrimary()
+        return
+      }
+      if (matches('sourceControl.generateCommitMessage')) {
+        event.preventDefault()
+        handleGenerateCommitMessageClick()
+        return
+      }
+      if (matches('sourceControl.commit')) {
+        event.preventDefault()
+        void handleCommit()
+        return
+      }
+      if (matches('sourceControl.commitPush')) {
+        event.preventDefault()
+        void runCompoundCommitAction('push')
+        return
+      }
+      if (matches('sourceControl.commitSync')) {
+        event.preventDefault()
+        void runCompoundCommitAction('sync')
+        return
+      }
+      if (matches('sourceControl.push')) {
+        event.preventDefault()
+        void runRemoteAction('push')
+        return
+      }
+      if (matches('sourceControl.sync')) {
+        event.preventDefault()
+        void runRemoteAction('sync')
+      }
+    }
+
+    window.addEventListener('keydown', handleSourceControlShortcut)
+    return () => window.removeEventListener('keydown', handleSourceControlShortcut)
+  }, [
+    handleCommit,
+    handleGenerateCommitMessageClick,
+    handleStageAllPrimary,
+    keybindings,
+    rightSidebarOpen,
+    rightSidebarTab,
+    runCompoundCommitAction,
+    runRemoteAction
+  ])
 
   const handleCreatePrHeaderClick = useCallback((): void => {
     if (!createPrHeaderAction || createPrHeaderAction.disabled) {

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -223,6 +223,7 @@ describe('keybindings', () => {
     expect(getEffectiveKeybindingsForAction('workspace.rename', 'darwin')).toEqual(['Mod+Alt+R'])
     expect(getEffectiveKeybindingsForAction('workspace.rename', 'linux')).toEqual([])
     expect(formatKeybindingList(['Mod+Alt+R'], 'darwin')).toBe('⌘⌥R')
+    expect(getKeybindingDefinition('tab.rename')?.searchKeywords).toContain('set title')
     expect(
       keybindingMatchesAction(
         'tab.rename',
@@ -286,6 +287,41 @@ describe('keybindings', () => {
         actionIds: ['workspace.rename', 'tab.rename']
       }
     ])
+  })
+
+  it('defines configurable source control shortcuts without default chords', () => {
+    const sourceControlActions: KeybindingActionId[] = [
+      'sourceControl.stageAll',
+      'sourceControl.generateCommitMessage',
+      'sourceControl.commit',
+      'sourceControl.commitPush',
+      'sourceControl.commitSync',
+      'sourceControl.push',
+      'sourceControl.sync'
+    ]
+
+    for (const actionId of sourceControlActions) {
+      expect(getKeybindingDefinition(actionId)?.group).toBe('Source Control')
+      expect(getEffectiveKeybindingsForAction(actionId, 'darwin')).toEqual([])
+      expect(getEffectiveKeybindingsForAction(actionId, 'linux')).toEqual([])
+      expect(getEffectiveKeybindingsForAction(actionId, 'win32')).toEqual([])
+    }
+
+    expect(
+      keybindingMatchesAction(
+        'sourceControl.commitSync',
+        {
+          key: 'p',
+          code: 'KeyP',
+          meta: true,
+          control: true,
+          alt: false,
+          shift: false
+        },
+        'darwin',
+        { 'sourceControl.commitSync': ['Ctrl+Cmd+P'] }
+      )
+    ).toBe(true)
   })
 
   it('defines browser history shortcuts for Logitech side-button remaps', () => {

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -11,6 +11,7 @@ export type KeybindingScope =
   | 'browser'
   | 'editor'
   | 'fileExplorer'
+  | 'sourceControl'
   | 'composer'
   | 'settings'
 
@@ -93,6 +94,13 @@ export type KeybindingActionId =
   | 'fileExplorer.copyPath'
   | 'fileExplorer.copyRelativePath'
   | 'fileExplorer.delete'
+  | 'sourceControl.stageAll'
+  | 'sourceControl.generateCommitMessage'
+  | 'sourceControl.commit'
+  | 'sourceControl.commitPush'
+  | 'sourceControl.commitSync'
+  | 'sourceControl.push'
+  | 'sourceControl.sync'
   | 'settings.search'
   | 'terminal.copySelection'
   | 'terminal.paste'
@@ -605,7 +613,7 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Tabs',
     scope: 'tabs',
     conflictGroup: 'workspace-shell',
-    searchKeywords: ['shortcut', 'tab', 'rename', 'title', 'label'],
+    searchKeywords: ['shortcut', 'tab', 'rename', 'title', 'set title', 'label'],
     // Why: macOS only. Cmd+R is free in the app/terminal focus zone (the
     // browser pane owns its own Cmd+R reload). On Windows/Linux Ctrl+R is the
     // shell reverse-search, so it is left unbound for explicit user binding.
@@ -849,6 +857,70 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
       win32: ['Delete']
     },
     allowBareKeybindings: true
+  },
+  {
+    id: 'sourceControl.stageAll',
+    title: 'Stage all changes',
+    group: 'Source Control',
+    scope: 'sourceControl',
+    searchKeywords: ['shortcut', 'source control', 'git', 'stage', 'stage all', 'changes'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'sourceControl.generateCommitMessage',
+    title: 'Generate commit message',
+    group: 'Source Control',
+    scope: 'sourceControl',
+    searchKeywords: [
+      'shortcut',
+      'source control',
+      'git',
+      'commit',
+      'message',
+      'generate',
+      'ai'
+    ],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'sourceControl.commit',
+    title: 'Commit staged changes',
+    group: 'Source Control',
+    scope: 'sourceControl',
+    searchKeywords: ['shortcut', 'source control', 'git', 'commit', 'staged', 'changes'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'sourceControl.commitPush',
+    title: 'Commit and push',
+    group: 'Source Control',
+    scope: 'sourceControl',
+    searchKeywords: ['shortcut', 'source control', 'git', 'commit', 'push', 'publish'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'sourceControl.commitSync',
+    title: 'Commit and sync',
+    group: 'Source Control',
+    scope: 'sourceControl',
+    searchKeywords: ['shortcut', 'source control', 'git', 'commit', 'sync', 'pull', 'push'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'sourceControl.push',
+    title: 'Push branch',
+    group: 'Source Control',
+    scope: 'sourceControl',
+    searchKeywords: ['shortcut', 'source control', 'git', 'push', 'branch'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'sourceControl.sync',
+    title: 'Sync branch',
+    group: 'Source Control',
+    scope: 'sourceControl',
+    searchKeywords: ['shortcut', 'source control', 'git', 'sync', 'pull', 'push', 'branch'],
+    defaultBindings: platformBindings([])
   },
   {
     id: 'settings.search',


### PR DESCRIPTION
## Summary
- Add configurable Source Control shortcut actions for stage all, generate commit message, commit, commit & push, commit & sync, push, and sync
- Wire those shortcuts to the existing Source Control handlers when the Source Control sidebar tab is active
- Make Rename active tab discoverable by searching for "set title"

## Validation
- corepack pnpm vitest run src/shared/keybindings.test.ts
- corepack pnpm run typecheck:web
- corepack pnpm run typecheck:node
- corepack pnpm exec oxlint src/shared/keybindings.ts src/shared/keybindings.test.ts src/renderer/src/components/right-sidebar/SourceControl.tsx