### PR TITLE
Hide stale mobile agent rows after terminals close

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -14800,6 +14800,62 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('does not report stale persisted tabs or hydrated done hook rows as live mobile activity', async () => {
+    const leafId = '44444444-4444-4444-8444-444444444444'
+    const paneKey = `host-tab:${leafId}`
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        activeTabId: 'host-tab',
+        activeTabIdByWorktree: { [TEST_WORKTREE_ID]: 'host-tab' },
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId: 'persisted-pty',
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Codex Done',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [leafId]: 'persisted-pty' })
+        }
+      })
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey,
+          worktreeId: TEST_WORKTREE_ID,
+          tabId: 'host-tab',
+          state: 'done',
+          prompt: 'old prompt',
+          agentType: 'codex',
+          lastAssistantMessage: 'old done',
+          connectionId: null,
+          receivedAt: 1000,
+          stateStartedAt: 900
+        }
+      ]
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((w) => w.worktreeId === TEST_WORKTREE_ID)
+
+    expect(await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)).toMatchObject({ terminals: [] })
+    expect(summary).toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      liveTerminalCount: 0,
+      hasAttachedPty: false,
+      status: 'inactive',
+      agents: []
+    })
+  })
+
   it('falls back to the path-keyed GitHub cache entry', async () => {
     const runtimeStore = {
       ...store,
@@ -14899,6 +14955,42 @@ describe('OrcaRuntimeService', () => {
         interrupted: false,
         stateStartedAt: expect.any(Number),
         updatedAt: expect.any(Number)
+      })
+    ])
+  })
+
+  it('keeps agent rows for connected PTYs without a mounted renderer leaf', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const leafId = '55555555-5555-4555-8555-555555555555'
+    const paneKey = `headless-tab:${leafId}`
+    runtime['recordPtyWorktree']('headless-pty', TEST_WORKTREE_ID, {
+      connected: true,
+      tabId: 'headless-tab',
+      paneKey
+    })
+
+    runtime.onPtyData(
+      'headless-pty',
+      '\x1b]9999;{"state":"working","prompt":"ship it","agentType":"codex","lastAssistantMessage":"on it"}\x07',
+      321
+    )
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((w) => w.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary).toMatchObject({
+      liveTerminalCount: 1,
+      hasAttachedPty: true,
+      hasHostSidebarActivity: true,
+      status: 'active'
+    })
+    expect(summary?.agents).toEqual([
+      expect.objectContaining({
+        paneKey,
+        state: 'working',
+        agentType: 'codex',
+        prompt: 'ship it',
+        lastAssistantMessage: 'on it'
       })
     ])
   })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -8599,6 +8599,8 @@ export class OrcaRuntimeService {
     }
 
     const countedPtyIds = new Set<string>()
+    const liveAgentPaneKeys = new Set<string>()
+    const liveAgentPtyIds = new Set<string>()
     for (const leaf of this.leaves.values()) {
       const summary = this.getSummaryForRuntimeWorktreeId(
         summaries,
@@ -8608,8 +8610,10 @@ export class OrcaRuntimeService {
       if (!summary) {
         continue
       }
+      liveAgentPaneKeys.add(this.makeRuntimePaneKey(leaf))
       if (leaf.ptyId) {
         countedPtyIds.add(leaf.ptyId)
+        liveAgentPtyIds.add(leaf.ptyId)
       }
       if (leaf.ptyId && leaf.connected) {
         summary.hasHostSidebarActivity = true
@@ -8642,9 +8646,14 @@ export class OrcaRuntimeService {
       if (!summary) {
         continue
       }
+      if (pty.paneKey) {
+        liveAgentPaneKeys.add(pty.paneKey)
+      }
+      liveAgentPtyIds.add(pty.ptyId)
       const previousLastOutputAt = summary.lastOutputAt
       summary.liveTerminalCount += 1
       summary.hasAttachedPty = true
+      summary.hasHostSidebarActivity = true
       summary.lastOutputAt = maxTimestamp(summary.lastOutputAt, pty.lastOutputAt)
       summary.status = mergeWorktreeStatus(summary.status, 'active')
       if (
@@ -8655,30 +8664,9 @@ export class OrcaRuntimeService {
       }
     }
 
+    // Why: tabsByWorktree is restore state, not proof of a live terminal. Mobile
+    // activity must come from runtime leaves or connected PTY records only.
     const session = this.store?.getWorkspaceSession?.()
-    for (const [worktreeId, tabs] of Object.entries(session?.tabsByWorktree ?? {})) {
-      if (tabs.length === 0) {
-        continue
-      }
-      const summary = this.getSummaryForRuntimeWorktreeId(summaries, resolvedWorktrees, worktreeId)
-      if (!summary) {
-        continue
-      }
-      // Why: desktop can show terminal tabs that are not mounted as renderer
-      // leaves and are not currently visible in the PTY provider list. Mobile
-      // still needs those worktrees to show as terminal-bearing entries.
-      summary.liveTerminalCount = Math.max(summary.liveTerminalCount, tabs.length)
-      summary.hasAttachedPty = summary.hasAttachedPty || tabs.some((tab) => tab.ptyId !== null)
-      if (tabs.some((tab) => tab.ptyId !== null && this.ptysById.get(tab.ptyId)?.connected)) {
-        summary.hasHostSidebarActivity = true
-      }
-      for (const tab of tabs) {
-        summary.status = mergeWorktreeStatus(
-          summary.status,
-          getSavedTabWorktreeStatus(tab.title, tab.ptyId !== null)
-        )
-      }
-    }
 
     // Why: surface the desktop's focused worktree so mobile can scroll it into
     // view and highlight it. Resolve through getSummaryForRuntimeWorktreeId so
@@ -8694,7 +8682,10 @@ export class OrcaRuntimeService {
       }
     }
 
-    this.attachAgentRowsToSummaries(summaries)
+    this.attachAgentRowsToSummaries(summaries, {
+      livePaneKeys: liveAgentPaneKeys,
+      livePtyIds: liveAgentPtyIds
+    })
 
     const sorted = [...summaries.values()].sort(compareWorktreePs)
     return {
@@ -8708,7 +8699,10 @@ export class OrcaRuntimeService {
   // agent list, mirroring the desktop sidebar. Lineage parent is resolved from
   // the orchestration db (paneKey-keyed), not the OSC payload, since spawn
   // hierarchy is pane-level state tracked separately from terminal output.
-  private attachAgentRowsToSummaries(summaries: Map<string, RuntimeWorktreePsSummary>): void {
+  private attachAgentRowsToSummaries(
+    summaries: Map<string, RuntimeWorktreePsSummary>,
+    liveEvidence: { livePaneKeys: ReadonlySet<string>; livePtyIds: ReadonlySet<string> }
+  ): void {
     // Why: most agents report via hooks (agent-hooks/server), not OSC, so the
     // hook snapshot is the primary source — same one the desktop sidebar reads.
     // OSC-only entries (no hook) are merged in as a fallback, keyed by paneKey.
@@ -8716,6 +8710,7 @@ export class OrcaRuntimeService {
       string,
       {
         paneKey: string
+        ptyId?: string
         worktreeId?: string
         state: ParsedAgentStatusPayload['state']
         agentType: string | null
@@ -8732,6 +8727,7 @@ export class OrcaRuntimeService {
       const { payload } = snapshot
       rowSources.set(snapshot.paneKey, {
         paneKey: snapshot.paneKey,
+        ptyId: snapshot.ptyId,
         worktreeId: snapshot.worktreeId,
         state: payload.state,
         agentType: payload.agentType ?? null,
@@ -8767,6 +8763,12 @@ export class OrcaRuntimeService {
     for (const src of rowSources.values()) {
       const worktreeId = src.worktreeId
       if (!worktreeId || !summaries.has(worktreeId)) {
+        continue
+      }
+      if (
+        !liveEvidence.livePaneKeys.has(src.paneKey) &&
+        (!src.ptyId || !liveEvidence.livePtyIds.has(src.ptyId))
+      ) {
         continue
       }
       const taskTitle = orchestrationByPaneKey?.[src.paneKey]?.taskTitle ?? null
@@ -22398,10 +22400,6 @@ function getLatestAgentCandidateTitleInfo(
     }
   }
   return latest
-}
-
-function getSavedTabWorktreeStatus(title: string, hasPty: boolean): RuntimeWorktreeStatus {
-  return getDetectedWorktreeStatus(detectAgentStatusFromTitle(title), hasPty)
 }
 
 function getDetectedWorktreeStatus(

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1102,7 +1102,8 @@
         "importHostSetup": "导入",
         "notePasteTooLarge": "笔记字段的粘贴内容过大。",
         "reuseExistingBranch": "复用分支",
-        "reuseExistingBranchHint": "检出已有分支，而不是基于它创建新分支。"
+        "reuseExistingBranchHint": "检出已有分支，而不是基于它创建新分支。",
+        "createMultiple": "Create more"
       },
       "NewWorkspaceComposerModal": {
         "fa90f739a5": "创建工作区之前选择项目、工作区名称和 Agent。"


### PR DESCRIPTION
Fixes #6072

## Summary

Fixes mobile/worktree activity projection so stale persisted terminal tabs and hydrated hook snapshots no longer make a worktree look active after its matching live terminal is gone.

Design approach:
- Treat live renderer leaves and connected PTYs as the only evidence for `liveTerminalCount`, attached PTY state, active status, previews, and agent rows in `getWorktreePs()`.
- Preserve persisted session tabs for restoration/opening surfaces, but stop promoting those saved rows into current activity.
- Filter hook/OSC agent rows by the current live pane key or connected PTY id instead of attaching every row with the same worktree id.
- Keep connected PTY evidence for headless/daemon/mobile terminals so real live agents without a mounted renderer leaf still appear.

## Review And Implementation

Design review:
- A read-only design reviewer returned ready after checking stale persisted tabs, live PTY preservation, SSH/cross-platform assumptions, and cache invalidation behavior.
- Earlier reviewer attempts using other local agent providers failed or stalled because of local agent credential/runtime issues; the reviewed design was checked manually before implementation.

Implementation:
- Updated `src/main/runtime/orca-runtime.ts` to build per-call live evidence from current leaves and connected PTYs.
- Updated agent-row attachment to require a live pane key or live PTY id match.
- Removed dead persisted-tab status promotion code.
- Added deterministic runtime tests covering the stale-row repro and the positive connected-PTY/no-renderer-leaf case.
- Added missing zh localization parity generated by `pnpm run sync:localization-catalog` so full lint can pass.

Completeness verification:
- A read-only verifier reported `COMPLETE` against the design.

Performance audit:
- Touched hot path: `getWorktreePs()`, used by mobile/worktree polling and CLI projection.
- Audit result: `PERF PASS`.
- No polling, subprocesses, disk reads, or long-lived caches were added.
- Live evidence is built per call from already-held in-memory maps, which avoids stale cache invalidation failure modes.
- Deterministic tests cover the stale persisted-tab/hydrated-hook invalidation behavior without timers.

Code review loop:
- Round 1 found one real comment-placement issue, fixed before commit. Other findings were checked and confirmed false positives by code inspection and typecheck.
- Round 2 returned one clean review and one false-positive concern about hook snapshot shape; existing types and tests covered the path.
- No unresolved actionable review findings remain.

Merge-confidence validation:
- The dedicated test subagent stalled locally; I completed local validation instead and treated that as a process deviation.
- Electron identity validation confirmed the app was running from this branch/worktree:
  - Branch: `brennanb2025/issue-6072-mobile-stale-agent-rows`
  - Worktree: `/Users/thebr/orca/workspaces/orca/issue-6072-mobile-stale-agent-rows`
- Contextual screenshot evidence was captured locally at `.tmp/evidence/issue-6072-electron-identity.png` and was not committed.

## Repro Evidence

Before the fix, the deterministic runtime test reproduced the issue:
- `runtime.listTerminals("id:repo-1::/tmp/worktree-a")` returned `[]`.
- `runtime.getWorktreePs()` incorrectly returned `liveTerminalCount: 1`, `hasAttachedPty: true`, `status: "active"`, and a stale `done` agent row.

After the fix, that same seeded persisted-tab plus hydrated-hook scenario reports inactive/zero-live/no-agent projection.

## Validation

Ran locally:
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "stale persisted tabs|connected PTYs without a mounted renderer leaf|hook-reported status|saved session tabs with live PTYs"`
- `git diff --check`
- `pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck`
- `pnpm run lint`

Post-PR stabilization:
- Required 8-minute wait completed after opening the PR.
- CodeRabbit reported no actionable comments.
- PR checks passed: `verify` and `track-community-pr`.
- No stabilization fixes were needed after PR creation.

## Residual Risks

- No full mobile emulator product-surface repro was captured; deterministic runtime projection tests are the primary behavior proof.
- The merge-confidence validation subagent stalled locally, so validation was completed manually with local checks and Electron identity evidence.