### PR TITLE
Keep inline-code link labels linked in rich Markdown

### DIFF
--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -20,6 +20,35 @@ function roundTripMarkdown(content: string): string {
   }
 }
 
+function markdownAfterTextReplace(content: string, search: string, replacement: string): string {
+  const editor = new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions(),
+    content: encodeRawMarkdownHtmlForRichEditor(content),
+    contentType: 'markdown'
+  })
+
+  try {
+    let from: number | null = null
+    editor.state.doc.descendants((node, pos) => {
+      if (from !== null || !node.isText || !node.text) {
+        return
+      }
+      const index = node.text.indexOf(search)
+      if (index !== -1) {
+        from = pos + index
+      }
+    })
+    if (from === null) {
+      throw new Error(`Missing text: ${search}`)
+    }
+    editor.view.dispatch(editor.state.tr.insertText(replacement, from, from + search.length))
+    return editor.getMarkdown().trimEnd()
+  } finally {
+    editor.destroy()
+  }
+}
+
 function slashCommandMarkdown(commandId: SlashCommandId): string {
   const editor = new Editor({
     element: null,
@@ -155,6 +184,36 @@ describe('rich markdown round trip', () => {
   it('preserves encoded local image paths with screenshot filenames', () => {
     expect(roundTripMarkdown('![](Screenshot%202026-06-22%20at%203.37.19%20PM%20copy.png)\n')).toBe(
       '![](Screenshot%202026-06-22%20at%203.37.19%20PM%20copy.png)'
+    )
+  })
+
+  it('preserves links whose label is inline code', () => {
+    expect(roundTripMarkdown('Link to [`foo.md`](./foo.md) here\n')).toBe(
+      'Link to [`foo.md`](./foo.md) here'
+    )
+  })
+
+  it('preserves links whose label is inline code after an editor transaction', () => {
+    expect(
+      markdownAfterTextReplace('Link to [`foo.md`](./foo.md) here\n', 'here', 'here saved')
+    ).toBe('Link to [`foo.md`](./foo.md) here saved')
+  })
+
+  it('preserves links when editing inside an inline-code label', () => {
+    expect(markdownAfterTextReplace('Link to [`foo.md`](./foo.md) here\n', 'foo', 'bar')).toBe(
+      'Link to [`bar.md`](./foo.md) here'
+    )
+  })
+
+  it('preserves titled links whose label is inline code', () => {
+    expect(roundTripMarkdown('Link to [`foo.md`](./foo.md "Foo") here\n')).toBe(
+      'Link to [`foo.md`](./foo.md "Foo") here'
+    )
+  })
+
+  it('preserves bold link labels as formatted link text', () => {
+    expect(roundTripMarkdown('Link to [**bold**](./foo.md) here\n')).toBe(
+      'Link to [**bold**](./foo.md) here'
     )
   })
 

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -1,6 +1,7 @@
 import type { AnyExtension } from '@tiptap/core'
 import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
+import { Code } from '@tiptap/extension-code'
 import Image from '@tiptap/extension-image'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -28,6 +29,18 @@ import { createRichMarkdownAnnotationHighlightExtension } from './rich-markdown-
 
 const lowlight = createLowlight(common)
 
+const RichMarkdownLink = Link.extend({
+  // Why: link's priority must stay below code's default 100 so Markdown
+  // serializes code-styled labels as [`label`](href).
+  priority: 90
+})
+
+const RichMarkdownCode = Code.extend({
+  // Why: Markdown supports linked code labels, so code cannot exclude the link
+  // mark even though it should still stay exclusive with emphasis marks.
+  excludes: 'code bold italic strike underline'
+})
+
 export function createRichMarkdownExtensions({
   includePlaceholder = false
 }: {
@@ -39,8 +52,10 @@ export function createRichMarkdownExtensions({
     // preview and then still lose syntax on save.
     StarterKit.configure({
       link: false,
+      code: false,
       codeBlock: false
     }),
+    RichMarkdownCode,
     CodeBlockLowlight.extend({
       addNodeView() {
         return safeReactNodeViewRenderer(RichMarkdownCodeBlock)
@@ -49,7 +64,7 @@ export function createRichMarkdownExtensions({
       lowlight,
       defaultLanguage: null
     }),
-    Link.configure({
+    RichMarkdownLink.configure({
       openOnClick: false,
       autolink: true,
       linkOnPaste: true


### PR DESCRIPTION
Fixes #6081

## Summary
- Preserves Markdown links whose label text is inline code when edited and saved from the rich Markdown editor.
- Replaces the rich editor's default inline-code mark with a local variant that allows `link` to coexist while staying exclusive with code/emphasis marks.
- Keeps the rich editor link mark priority below inline code so Markdown serializes as ``[`label`](href)``.

## What Changed
- `RichMarkdownCode` disables TipTap's default code-vs-link exclusion while still excluding `code bold italic strike underline`.
- `RichMarkdownLink` stays below code priority so linked code labels serialize as ``[`foo.md`](./foo.md)``.
- Regression coverage now includes the exact repro, a save-like editor transaction after the link, editing inside the inline-code label, titled inline-code links, and a nearby bold-link case.

## Code Review
- `review-code` subagent Newton: no findings. Reviewed schema/serializer correctness, mark ordering, and live editor path alignment.
- `review-code` subagent Lovelace: no findings. Reviewed product behavior and regression coverage; noted live Electron validation as the key gap, now covered below.

## Validation
- Quick `brennan-test-changes` pass launched this exact worktree via CDP: `brennanb2025/issue-6081-rich-md-code-link`, root `/Users/thebr/orca/workspaces/orca/issue-6081-rich-md-code-link`.
- Used `demo-project` and opened a markdown file containing exactly `Link to [`foo.md`](./foo.md) here` in the visible rich editor.
- Exercised the real rich editor surface with an edit plus `Cmd+S`; backing file stayed linked as `Link to [`foo.md`](./foo.md) here saved`, and the editor tab was clean.
- Screenshot evidence captured locally and intentionally left uncommitted: `.visual-evidence/issue-6081-rich-md-code-link-fixed.png`.
- Earlier pre-fix live evidence is also local/uncommitted: `.visual-evidence/issue-6081-rich-md-code-link-editor-dropped-link.png`.

## Checks
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-round-trip.test.ts` passed: 27 tests.
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-round-trip.test.ts src/renderer/src/components/editor/rich-markdown-list-continuation.test.ts src/renderer/src/components/editor/rich-markdown-tab-key-handler.test.ts src/renderer/src/components/editor/RichMarkdownLinkBubble.test.ts src/renderer/src/components/editor/markdown-preview-controls.test.ts` passed: 48 tests.
- Review subagent additional slices passed, including rich markdown commands, dirty state, normalize/cut/details keyboard, paste handler, and editor autosave coverage.
- `pnpm run typecheck` passed.
- `git diff --check` passed.
- `pnpm run lint` still reaches an unrelated existing locale parity failure: `zh.json` is missing `auto.components.NewWorkspaceComposerCard.createMultiple`.

## Risk
- The behavioral change is scoped to renderer-side rich Markdown mark compatibility and serialization.
- No new network, IPC, auth, shell, provider, or telemetry surface is introduced.