### PR TITLE
Fix orchestration worker done state

### DIFF
--- a/src/main/runtime/orchestration/coordinator.ts
+++ b/src/main/runtime/orchestration/coordinator.ts
@@ -2,6 +2,7 @@
 import type { OrchestrationDb } from './db'
 import type { MessageRow, TaskRow, CoordinatorStatus } from './types'
 import { buildDispatchPreamble } from './preamble'
+import { reconcileLifecycleMessage } from './lifecycle-reconciliation'
 
 export type CoordinatorRuntime = {
   sendTerminal(handle: string, action: { text?: string; enter?: boolean }): Promise<unknown>
@@ -249,7 +250,7 @@ export class Coordinator {
     for (const msg of messages) {
       switch (msg.type) {
         case 'worker_done':
-          this.handleWorkerDone(msg)
+          this.handleLifecycleMessage(msg)
           break
         case 'escalation':
           this.handleEscalation(msg)
@@ -258,7 +259,7 @@ export class Coordinator {
           this.handleDecisionGateMessage(msg)
           break
         case 'heartbeat':
-          this.handleHeartbeat(msg)
+          this.handleLifecycleMessage(msg)
           break
         case 'status':
           this.opts.onLog(`Status from ${msg.from_handle}: ${msg.subject}`)
@@ -273,108 +274,11 @@ export class Coordinator {
     this.db.markAsRead(messages.map((m) => m.id))
   }
 
-  // Why: attribute heartbeats to the specific dispatchId, not a
-  // (taskId, from_handle) lookup. A task that gets retried after a failed
-  // dispatch has multiple rows in dispatch_contexts — a late heartbeat from
-  // the previous (failed) assignee arriving while the new dispatch is active
-  // would falsely bump the new row's last_heartbeat_at if we resolved by
-  // "latest dispatch for this task" (§5.3.4). If the worker drops dispatchId
-  // from the payload, log-and-skip is the preferred failure mode: the stale
-  // detector will correctly flag the dispatch as hung because nothing
-  // refreshed last_heartbeat_at.
-  private handleHeartbeat(msg: MessageRow): void {
-    if (!msg.payload) {
-      this.opts.onLog(`Heartbeat from ${msg.from_handle} missing payload; ignored`)
-      return
+  private handleLifecycleMessage(msg: MessageRow): void {
+    const result = reconcileLifecycleMessage(this.db, msg, this.opts.onLog)
+    if (result.action === 'completed') {
+      this.state.completedTasks.push(result.taskId)
     }
-    let payload: { dispatchId?: unknown } = {}
-    try {
-      payload = JSON.parse(msg.payload)
-    } catch {
-      this.opts.onLog(`Heartbeat from ${msg.from_handle} has invalid JSON payload; ignored`)
-      return
-    }
-    const dispatchId = payload.dispatchId
-    if (typeof dispatchId !== 'string' || dispatchId.length === 0) {
-      this.opts.onLog(`Heartbeat from ${msg.from_handle} missing dispatchId; ignored`)
-      return
-    }
-    this.db.recordHeartbeat(dispatchId, msg.created_at)
-  }
-
-  private handleWorkerDone(msg: MessageRow): void {
-    this.opts.onLog(`Worker done: ${msg.from_handle} — ${msg.subject}`)
-
-    let payload: { taskId?: unknown; dispatchId?: unknown; filesModified?: unknown } = {}
-    if (msg.payload) {
-      try {
-        payload = JSON.parse(msg.payload)
-      } catch {
-        this.opts.onLog(`Warning: invalid payload in worker_done from ${msg.from_handle}`)
-      }
-    }
-
-    const taskId = payload.taskId
-    if (typeof taskId !== 'string' || taskId.length === 0) {
-      this.opts.onLog(`Warning: worker_done without taskId from ${msg.from_handle}`)
-      return
-    }
-
-    const dispatchId = payload.dispatchId
-    if (typeof dispatchId !== 'string' || dispatchId.length === 0) {
-      this.opts.onLog(`Warning: worker_done without dispatchId from ${msg.from_handle}`)
-      return
-    }
-
-    const task = this.db.getTask(taskId)
-    if (!task) {
-      this.opts.onLog(`Warning: worker_done for unknown task ${taskId}`)
-      return
-    }
-
-    // Why: taskId alone is not a completion authority; retried tasks can have
-    // stale worker_done messages racing the current active dispatch.
-    const dispatch = this.db.getDispatchContextById(dispatchId)
-    if (!dispatch) {
-      this.opts.onLog(`Warning: worker_done for unknown dispatch ${dispatchId}`)
-      return
-    }
-    if (dispatch.task_id !== taskId) {
-      this.opts.onLog(
-        `Warning: worker_done dispatch ${dispatchId} belongs to ${dispatch.task_id}, not ${taskId}`
-      )
-      return
-    }
-    if (dispatch.assignee_handle !== msg.from_handle) {
-      this.opts.onLog(
-        `Warning: worker_done for dispatch ${dispatchId} came from ${msg.from_handle}, expected ${dispatch.assignee_handle ?? '<unknown>'}`
-      )
-      return
-    }
-    if (dispatch.status !== 'dispatched') {
-      this.opts.onLog(`Warning: worker_done for inactive dispatch ${dispatchId} ignored`)
-      return
-    }
-    if (this.db.getDispatchContext(taskId)?.id !== dispatchId || task.status !== 'dispatched') {
-      this.opts.onLog(`Warning: worker_done for stale dispatch ${dispatchId} ignored`)
-      return
-    }
-
-    const filesModified =
-      Array.isArray(payload.filesModified) &&
-      payload.filesModified.every((file) => typeof file === 'string')
-        ? payload.filesModified
-        : []
-
-    const result = JSON.stringify({
-      completedBy: msg.from_handle,
-      filesModified,
-      completedAt: new Date().toISOString()
-    })
-    this.db.updateTaskStatus(taskId, 'completed', result)
-    this.state.completedTasks.push(taskId)
-
-    this.opts.onLog(`Task ${taskId} completed`)
   }
 
   private handleEscalation(msg: MessageRow): void {

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.ts
@@ -1,0 +1,144 @@
+import type { OrchestrationDb } from './db'
+import type { MessageRow } from './types'
+
+export type LifecycleReconciliationResult =
+  | { action: 'ignored' }
+  | { action: 'completed'; taskId: string; dispatchId: string }
+  | { action: 'heartbeat_recorded'; dispatchId: string }
+
+type LogFn = (msg: string) => void
+
+const noopLog: LogFn = () => {}
+
+function parseObjectPayload(msg: MessageRow, onInvalidJson: () => void): Record<string, unknown> {
+  if (!msg.payload) {
+    return {}
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(msg.payload)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    onInvalidJson()
+    return {}
+  }
+}
+
+export function reconcileLifecycleMessage(
+  db: OrchestrationDb,
+  msg: MessageRow,
+  onLog: LogFn = noopLog
+): LifecycleReconciliationResult {
+  switch (msg.type) {
+    case 'worker_done':
+      return reconcileWorkerDoneMessage(db, msg, onLog)
+    case 'heartbeat':
+      return reconcileHeartbeatMessage(db, msg, onLog)
+    case 'status':
+    case 'dispatch':
+    case 'merge_ready':
+    case 'escalation':
+    case 'handoff':
+    case 'decision_gate':
+      return { action: 'ignored' }
+  }
+}
+
+function reconcileHeartbeatMessage(
+  db: OrchestrationDb,
+  msg: MessageRow,
+  onLog: LogFn
+): LifecycleReconciliationResult {
+  if (!msg.payload) {
+    onLog(`Heartbeat from ${msg.from_handle} missing payload; ignored`)
+    return { action: 'ignored' }
+  }
+
+  const payload = parseObjectPayload(msg, () => {
+    onLog(`Heartbeat from ${msg.from_handle} has invalid JSON payload; ignored`)
+  })
+  const dispatchId = payload.dispatchId
+  if (typeof dispatchId !== 'string' || dispatchId.length === 0) {
+    onLog(`Heartbeat from ${msg.from_handle} missing dispatchId; ignored`)
+    return { action: 'ignored' }
+  }
+
+  // Why: dispatchId-specific writes let the DB ignore late heartbeats for
+  // completed/failed retries without masking a newer hung dispatch.
+  db.recordHeartbeat(dispatchId, msg.created_at)
+  return { action: 'heartbeat_recorded', dispatchId }
+}
+
+function reconcileWorkerDoneMessage(
+  db: OrchestrationDb,
+  msg: MessageRow,
+  onLog: LogFn
+): LifecycleReconciliationResult {
+  onLog(`Worker done: ${msg.from_handle} — ${msg.subject}`)
+
+  const payload = parseObjectPayload(msg, () => {
+    onLog(`Warning: invalid payload in worker_done from ${msg.from_handle}`)
+  })
+
+  const taskId = payload.taskId
+  if (typeof taskId !== 'string' || taskId.length === 0) {
+    onLog(`Warning: worker_done without taskId from ${msg.from_handle}`)
+    return { action: 'ignored' }
+  }
+
+  const dispatchId = payload.dispatchId
+  if (typeof dispatchId !== 'string' || dispatchId.length === 0) {
+    onLog(`Warning: worker_done without dispatchId from ${msg.from_handle}`)
+    return { action: 'ignored' }
+  }
+
+  const task = db.getTask(taskId)
+  if (!task) {
+    onLog(`Warning: worker_done for unknown task ${taskId}`)
+    return { action: 'ignored' }
+  }
+
+  // Why: taskId alone is not a completion authority; retried tasks can have
+  // stale worker_done messages racing the current active dispatch.
+  const dispatch = db.getDispatchContextById(dispatchId)
+  if (!dispatch) {
+    onLog(`Warning: worker_done for unknown dispatch ${dispatchId}`)
+    return { action: 'ignored' }
+  }
+  if (dispatch.task_id !== taskId) {
+    onLog(
+      `Warning: worker_done dispatch ${dispatchId} belongs to ${dispatch.task_id}, not ${taskId}`
+    )
+    return { action: 'ignored' }
+  }
+  if (dispatch.assignee_handle !== msg.from_handle) {
+    onLog(
+      `Warning: worker_done for dispatch ${dispatchId} came from ${msg.from_handle}, expected ${dispatch.assignee_handle ?? '<unknown>'}`
+    )
+    return { action: 'ignored' }
+  }
+  if (dispatch.status !== 'dispatched') {
+    onLog(`Warning: worker_done for inactive dispatch ${dispatchId} ignored`)
+    return { action: 'ignored' }
+  }
+  if (db.getDispatchContext(taskId)?.id !== dispatchId || task.status !== 'dispatched') {
+    onLog(`Warning: worker_done for stale dispatch ${dispatchId} ignored`)
+    return { action: 'ignored' }
+  }
+
+  const filesModified =
+    Array.isArray(payload.filesModified) &&
+    payload.filesModified.every((file) => typeof file === 'string')
+      ? payload.filesModified
+      : []
+
+  const result = JSON.stringify({
+    completedBy: msg.from_handle,
+    filesModified,
+    completedAt: new Date().toISOString()
+  })
+  db.updateTaskStatus(taskId, 'completed', result)
+
+  onLog(`Task ${taskId} completed`)
+  return { action: 'completed', taskId, dispatchId }
+}

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -377,6 +377,39 @@ describe('orchestration RPC methods', () => {
   })
 
   describe('orchestration.check', () => {
+    function createDispatchedTask(assigneeHandle = 'term_worker') {
+      const task = db.createTask({ spec: 'manual check work' })
+      const dispatch = db.createDispatchContext(task.id, assigneeHandle)
+      return { task, dispatch }
+    }
+
+    function insertWorkerDone(params: {
+      from?: string
+      to?: string
+      taskId?: string
+      dispatchId?: string
+      filesModified?: string[]
+    }): void {
+      const payload: Record<string, unknown> = {}
+      if (params.taskId !== undefined) {
+        payload.taskId = params.taskId
+      }
+      if (params.dispatchId !== undefined) {
+        payload.dispatchId = params.dispatchId
+      }
+      if (params.filesModified !== undefined) {
+        payload.filesModified = params.filesModified
+      }
+
+      db.insertMessage({
+        from: params.from ?? 'term_worker',
+        to: params.to ?? 'term_coord',
+        subject: 'Done',
+        type: 'worker_done',
+        payload: JSON.stringify(payload)
+      })
+    }
+
     it('returns unread messages for a terminal', async () => {
       setup()
       db.insertMessage({ from: 'a', to: 'b', subject: 'one' })
@@ -414,6 +447,152 @@ describe('orchestration RPC methods', () => {
       })) as { count: number }
 
       expect(result.count).toBe(1)
+    })
+
+    it('reconciles worker_done returned by a waiting manual check', async () => {
+      setup()
+      const { task, dispatch } = createDispatchedTask()
+      vi.spyOn(runtime, 'waitForMessage').mockImplementation(async () => {
+        insertWorkerDone({
+          taskId: task.id,
+          dispatchId: dispatch.id,
+          filesModified: ['src/file.ts']
+        })
+      })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        wait: true,
+        timeoutMs: 100,
+        types: 'worker_done,escalation,decision_gate'
+      })) as { count: number; messages: { type: string }[] }
+
+      expect(result.count).toBe(1)
+      expect(result.messages[0].type).toBe('worker_done')
+      expect(db.getTask(task.id)?.status).toBe('completed')
+      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+      expect(db.getUnreadMessages('term_coord')).toHaveLength(0)
+      const taskList = (await call('orchestration.taskList', {})) as {
+        tasks: {
+          id: string
+          status: string
+          assignee_handle?: string | null
+          dispatch_id?: string | null
+        }[]
+      }
+      const listedTask = taskList.tasks.find((t) => t.id === task.id)
+      expect(listedTask?.status).toBe('completed')
+      expect(listedTask).not.toHaveProperty('assignee_handle')
+      expect(listedTask).not.toHaveProperty('dispatch_id')
+      const shownDispatch = (await call('orchestration.dispatchShow', {
+        task: task.id
+      })) as { dispatch: { status: string } | null }
+      expect(shownDispatch.dispatch?.status).toBe('completed')
+
+      const completedAt = db.getTask(task.id)?.completed_at
+      const taskResult = db.getTask(task.id)?.result
+      const repeated = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        types: 'worker_done'
+      })) as { count: number }
+      expect(repeated.count).toBe(0)
+      expect(db.getTask(task.id)?.completed_at).toBe(completedAt)
+      expect(db.getTask(task.id)?.result).toBe(taskResult)
+    })
+
+    it('keeps check --all read-only for lifecycle messages', async () => {
+      setup()
+      const { task, dispatch } = createDispatchedTask()
+      insertWorkerDone({ taskId: task.id, dispatchId: dispatch.id })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        all: true,
+        types: 'worker_done'
+      })) as { count: number }
+
+      expect(result.count).toBe(1)
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('dispatched')
+      expect(db.getUnreadMessages('term_coord', ['worker_done'])).toHaveLength(1)
+    })
+
+    it('does not complete worker_done missing taskId or dispatchId', async () => {
+      setup()
+      const { task, dispatch } = createDispatchedTask()
+      insertWorkerDone({ dispatchId: dispatch.id })
+      insertWorkerDone({ taskId: task.id })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        types: 'worker_done'
+      })) as { count: number }
+
+      expect(result.count).toBe(2)
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('dispatched')
+    })
+
+    it('does not complete worker_done from a terminal that does not own the dispatch', async () => {
+      setup()
+      const { task, dispatch } = createDispatchedTask('term_owner')
+      insertWorkerDone({
+        from: 'term_intruder',
+        taskId: task.id,
+        dispatchId: dispatch.id
+      })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        types: 'worker_done'
+      })) as { count: number }
+
+      expect(result.count).toBe(1)
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('dispatched')
+    })
+
+    it('does not complete worker_done for a stale inactive dispatch', async () => {
+      setup()
+      const task = db.createTask({ spec: 'retry-sensitive work' })
+      const staleDispatch = db.createDispatchContext(task.id, 'term_old')
+      db.failDispatch(staleDispatch.id, 'retry elsewhere')
+      const activeDispatch = db.createDispatchContext(task.id, 'term_current')
+      insertWorkerDone({
+        from: 'term_old',
+        taskId: task.id,
+        dispatchId: staleDispatch.id
+      })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        types: 'worker_done'
+      })) as { count: number }
+
+      expect(result.count).toBe(1)
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContextById(staleDispatch.id)?.status).toBe('failed')
+      expect(db.getDispatchContextById(activeDispatch.id)?.status).toBe('dispatched')
+    })
+
+    it('records heartbeat returned by unread manual check', async () => {
+      setup()
+      const { task, dispatch } = createDispatchedTask()
+      const msg = db.insertMessage({
+        from: 'term_worker',
+        to: 'term_coord',
+        subject: 'alive',
+        type: 'heartbeat',
+        payload: JSON.stringify({ taskId: task.id, dispatchId: dispatch.id })
+      })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        types: 'heartbeat'
+      })) as { count: number }
+
+      expect(result.count).toBe(1)
+      expect(db.getDispatchContextById(dispatch.id)?.last_heartbeat_at).toBe(msg.created_at)
     })
 
     it('rejects invalid type filters', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -6,6 +6,7 @@ import type { MessageType, MessagePriority, TaskStatus } from '../../orchestrati
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { formatMessageBanner } from '../../orchestration/formatter'
 import { isGroupAddress, resolveGroupAddress } from '../../orchestration/groups'
+import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
 import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
 
 const MESSAGE_TYPES: MessageType[] = [
@@ -265,6 +266,12 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           : db.getAllMessagesForHandle(handle, undefined, typeFilter)
 
         if (showUnread && messages.length > 0) {
+          // Why: manual coordinators can consume lifecycle messages before
+          // the coordinator loop sees them, but unread `check` is still an
+          // authoritative read path for worker_done/heartbeat.
+          for (const message of messages) {
+            reconcileLifecycleMessage(db, message)
+          }
           db.markAsRead(messages.map((m) => m.id))
         }
 


### PR DESCRIPTION
## Summary

Extracts lifecycle message reconciliation (`worker_done`, `heartbeat`) from the coordinator class into a standalone, reusable `lifecycle-reconciliation` module. This allows both the background coordinator and the manual RPC check endpoint (`orchestration.check`) to authoritatively process lifecycle messages when they are fetched. This fixes a race condition where manual coordinators could consume lifecycle messages before the coordinator loop processed them, preventing tasks from being marked as completed.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

### Testing Notes
- Added comprehensive unit tests in `src/main/runtime/rpc/methods/orchestration.test.ts` to verify worker_done/heartbeat reconciliation on the check endpoint, read-only checks, missing parameter handling, terminal authority verification, and stale dispatch prevention.

## AI Review Report

- **Refactoring & Scope**: Refactored the core lifecycle reconciliation logic from `coordinator.ts` into a standalone module `lifecycle-reconciliation.ts`.
- **Risks Checked**:
  - Idempotency & Safety: Verified that executing reconciliation from both the coordinator and the check RPC endpoint is safe and idempotent.
  - Authorization & Stale States: Verified that messages from older/failed dispatches or unauthorized terminals are safely ignored.
- **Cross-Platform Compatibility**: Checked macOS, Linux, and Windows compatibility. There are no OS-specific operations, paths, shortcuts, or shell commands involved in this change.

## Security Audit

- **Input Validation**: Safe `JSON.parse` is used to parse the payload within try-catch blocks to prevent crashes on invalid payloads. Field types and non-emptiness for `taskId` and `dispatchId` are explicitly verified.
- **Authorization**: The database-level check guarantees that only messages coming from the authorized `assignee_handle` of the active dispatch can complete a task, preventing terminal spoofing.
- **IPC/RPC Security**: No command execution, file-system writing, or dependency-risk changes.

## Notes

No platform-specific behavior or known risks.