### PR TITLE
fix(settings): defer Display Name persistence until IME composition ends

### DIFF
--- a/src/renderer/src/components/settings/RepositoryPaneDraftInput.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryPaneDraftInput.test.tsx
@@ -71,6 +71,9 @@ function compositionEnd(text: string): void {
     const input = getInput()
     setNativeValue(input, text)
     input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: text }))
+    // Why: some IMEs (e.g. Firefox) emit the final input event after
+    // compositionend; model it so the single-persist guard is exercised.
+    input.dispatchEvent(new Event('input', { bubbles: true }))
   })
 }
 

--- a/src/renderer/src/components/settings/RepositoryPaneDraftInput.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryPaneDraftInput.test.tsx
@@ -39,14 +39,38 @@ function getInput(): HTMLInputElement {
   return input
 }
 
+function setNativeValue(input: HTMLInputElement, text: string): void {
+  // Why: React reads controlled-input changes via the native value setter;
+  // assigning input.value directly is swallowed by React's value tracking.
+  const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  setValue?.call(input, text)
+}
+
 function typeText(text: string): void {
   act(() => {
     const input = getInput()
-    // Why: React reads controlled-input changes via the native value setter;
-    // assigning input.value directly is swallowed by React's value tracking.
-    const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
-    setValue?.call(input, text)
+    setNativeValue(input, text)
     input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+function compositionStart(): void {
+  act(() => {
+    getInput().dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+  })
+}
+
+// Why: an input event fired between compositionstart and compositionend models a
+// keystroke of unconfirmed IME text (e.g. Japanese kana before conversion).
+function composingInput(text: string): void {
+  typeText(text)
+}
+
+function compositionEnd(text: string): void {
+  act(() => {
+    const input = getInput()
+    setNativeValue(input, text)
+    input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: text }))
   })
 }
 
@@ -108,5 +132,48 @@ describe('RepoSettingsDraftInput', () => {
 
     expect(onTextChange).toHaveBeenNthCalledWith(1, 'a')
     expect(onTextChange).toHaveBeenNthCalledWith(2, 'ab')
+  })
+
+  it('does not persist unconfirmed IME text while composing', () => {
+    const onTextChange = vi.fn()
+    render({ repoId: 'repo-1', storeValue: '', onTextChange })
+
+    // Japanese conversion: type kana, then convert, before confirming.
+    compositionStart()
+    composingInput('にほんご')
+    composingInput('日本語')
+
+    // Why: persisting mid-composition writes the pre-confirmation value and its
+    // async store echo can cancel the IME session.
+    expect(onTextChange).not.toHaveBeenCalled()
+    // The input still shows the unconfirmed text via the local draft.
+    expect(getInput().value).toBe('日本語')
+  })
+
+  it('persists once with the confirmed value on compositionend', () => {
+    const onTextChange = vi.fn()
+    render({ repoId: 'repo-1', storeValue: '', onTextChange })
+
+    compositionStart()
+    composingInput('にほんご')
+    composingInput('日本語')
+    compositionEnd('日本語')
+
+    expect(onTextChange).toHaveBeenCalledTimes(1)
+    expect(onTextChange).toHaveBeenCalledWith('日本語')
+    expect(getInput().value).toBe('日本語')
+  })
+
+  it('resumes per-keystroke persistence after composition ends', () => {
+    const onTextChange = vi.fn()
+    render({ repoId: 'repo-1', storeValue: '', onTextChange })
+
+    compositionStart()
+    composingInput('あ')
+    compositionEnd('亜')
+    typeText('亜b')
+
+    expect(onTextChange).toHaveBeenNthCalledWith(1, '亜')
+    expect(onTextChange).toHaveBeenNthCalledWith(2, '亜b')
   })
 })

--- a/src/renderer/src/components/settings/RepositoryPaneDraftInput.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryPaneDraftInput.test.tsx
@@ -66,14 +66,16 @@ function composingInput(text: string): void {
   typeText(text)
 }
 
-function compositionEnd(text: string): void {
+function compositionEnd(text: string, options?: { trailingInput?: boolean }): void {
   act(() => {
     const input = getInput()
     setNativeValue(input, text)
     input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: text }))
     // Why: some IMEs (e.g. Firefox) emit the final input event after
     // compositionend; model it so the single-persist guard is exercised.
-    input.dispatchEvent(new Event('input', { bubbles: true }))
+    if (options?.trailingInput !== false) {
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    }
   })
 }
 
@@ -167,6 +169,21 @@ describe('RepoSettingsDraftInput', () => {
     expect(getInput().value).toBe('日本語')
   })
 
+  it('does not suppress later edits when no final input follows compositionend', () => {
+    const onTextChange = vi.fn()
+    render({ repoId: 'repo-1', storeValue: '', onTextChange })
+
+    compositionStart()
+    composingInput('にほんご')
+    compositionEnd('日本語', { trailingInput: false })
+    render({ repoId: 'repo-1', storeValue: '日本語', onTextChange })
+
+    typeText('日本語!')
+
+    expect(onTextChange).toHaveBeenNthCalledWith(1, '日本語')
+    expect(onTextChange).toHaveBeenNthCalledWith(2, '日本語!')
+  })
+
   it('resumes per-keystroke persistence after composition ends', () => {
     const onTextChange = vi.fn()
     render({ repoId: 'repo-1', storeValue: '', onTextChange })
@@ -178,5 +195,18 @@ describe('RepoSettingsDraftInput', () => {
 
     expect(onTextChange).toHaveBeenNthCalledWith(1, '亜')
     expect(onTextChange).toHaveBeenNthCalledWith(2, '亜b')
+  })
+
+  it('resets composition state when the pane switches repos', () => {
+    const onTextChange = vi.fn()
+    render({ repoId: 'repo-1', storeValue: '', onTextChange })
+
+    compositionStart()
+    composingInput('未確定')
+    render({ repoId: 'repo-2', storeValue: 'Repo Two', onTextChange })
+    typeText('Renamed Repo Two')
+
+    expect(onTextChange).toHaveBeenCalledTimes(1)
+    expect(onTextChange).toHaveBeenCalledWith('Renamed Repo Two')
   })
 })

--- a/src/renderer/src/components/settings/RepositorySettingsDraftInput.tsx
+++ b/src/renderer/src/components/settings/RepositorySettingsDraftInput.tsx
@@ -42,10 +42,13 @@ export function RepoSettingsDraftInput({
     setDraft((current) => {
       if (current.repoId !== repoId) {
         pendingStoreEchoesRef.current = []
+        composingRef.current = false
+        skipNextChangeRef.current = null
         return { repoId, text: storeValue }
       }
       if (storeValue === current.text) {
         pendingStoreEchoesRef.current = []
+        skipNextChangeRef.current = null
         return current
       }
       const pendingEchoIndex = pendingStoreEchoesRef.current.indexOf(storeValue)
@@ -56,6 +59,7 @@ export function RepoSettingsDraftInput({
         return current
       }
       pendingStoreEchoesRef.current = []
+      skipNextChangeRef.current = null
       return { repoId, text: storeValue }
     })
   }, [repoId, storeValue])

--- a/src/renderer/src/components/settings/RepositorySettingsDraftInput.tsx
+++ b/src/renderer/src/components/settings/RepositorySettingsDraftInput.tsx
@@ -6,11 +6,14 @@ type RepoTextDraft = { repoId: string; text: string }
 
 // Why: updateRepo persists via async IPC before the store value updates, so a
 // store-controlled input resets mid-IME-composition (Hangul decomposes into
-// jamo). Keep keystrokes in local draft state; persist stays per-keystroke.
+// jamo). Keep keystrokes in local draft state; persist per-keystroke except
+// while an IME composition is active (see composingRef below).
 export function RepoSettingsDraftInput({
   repoId,
   storeValue,
   onTextChange,
+  onCompositionStart,
+  onCompositionEnd,
   ...inputProps
 }: {
   repoId: string
@@ -19,6 +22,17 @@ export function RepoSettingsDraftInput({
 } & Omit<React.ComponentProps<typeof Input>, 'value' | 'onChange'>): React.JSX.Element {
   const [draft, setDraft] = useState<RepoTextDraft>({ repoId, text: storeValue })
   const pendingStoreEchoesRef = useRef<string[]>([])
+  // Why: IME composition (e.g. Japanese kana→kanji conversion) fires input
+  // events for unconfirmed text. Persisting those mid-composition writes the
+  // pre-confirmation value to the store and its async echo can cancel the
+  // composition. Hold persistence until compositionend so only confirmed text
+  // reaches updateRepo.
+  const composingRef = useRef(false)
+
+  const persist = (text: string): void => {
+    pendingStoreEchoesRef.current.push(text)
+    onTextChange(text)
+  }
 
   useEffect(() => {
     setDraft((current) => {
@@ -49,9 +63,23 @@ export function RepoSettingsDraftInput({
       value={text}
       onChange={(e) => {
         const nextText = e.target.value
-        pendingStoreEchoesRef.current.push(nextText)
         setDraft({ repoId, text: nextText })
-        onTextChange(nextText)
+        // Why: during composition the input stays live via draft, but the
+        // unconfirmed text is not persisted until compositionend.
+        if (!composingRef.current) {
+          persist(nextText)
+        }
+      }}
+      onCompositionStart={(e) => {
+        composingRef.current = true
+        onCompositionStart?.(e)
+      }}
+      onCompositionEnd={(e) => {
+        composingRef.current = false
+        const nextText = e.currentTarget.value
+        setDraft({ repoId, text: nextText })
+        persist(nextText)
+        onCompositionEnd?.(e)
       }}
     />
   )

--- a/src/renderer/src/components/settings/RepositorySettingsDraftInput.tsx
+++ b/src/renderer/src/components/settings/RepositorySettingsDraftInput.tsx
@@ -28,6 +28,10 @@ export function RepoSettingsDraftInput({
   // composition. Hold persistence until compositionend so only confirmed text
   // reaches updateRepo.
   const composingRef = useRef(false)
+  // Why: some IMEs emit a trailing change event after compositionend that
+  // repeats the already-persisted confirmed value; consume that one change so
+  // the value is not persisted twice.
+  const skipNextChangeRef = useRef<string | null>(null)
 
   const persist = (text: string): void => {
     pendingStoreEchoesRef.current.push(text)
@@ -66,12 +70,19 @@ export function RepoSettingsDraftInput({
         setDraft({ repoId, text: nextText })
         // Why: during composition the input stays live via draft, but the
         // unconfirmed text is not persisted until compositionend.
-        if (!composingRef.current) {
-          persist(nextText)
+        if (composingRef.current) {
+          return
         }
+        if (skipNextChangeRef.current === nextText) {
+          skipNextChangeRef.current = null
+          return
+        }
+        skipNextChangeRef.current = null
+        persist(nextText)
       }}
       onCompositionStart={(e) => {
         composingRef.current = true
+        skipNextChangeRef.current = null
         onCompositionStart?.(e)
       }}
       onCompositionEnd={(e) => {
@@ -79,6 +90,8 @@ export function RepoSettingsDraftInput({
         const nextText = e.currentTarget.value
         setDraft({ repoId, text: nextText })
         persist(nextText)
+        // Why: cover IMEs that fire the final change after compositionend.
+        skipNextChangeRef.current = nextText
         onCompositionEnd?.(e)
       }}
     />


### PR DESCRIPTION
## Summary

In **Settings → Repository**, the **Display Name** input persisted every keystroke through the async `updateRepo` IPC — including unconfirmed IME text. For Japanese (and other CJK) input methods this committed pre-confirmation text to the store, and the async store echo could cancel the active composition, so the field could not be edited correctly with an IME.

`#4632` fixed the Korean jamo-decomposition variant for the same input via a local draft, but it deliberately kept per-keystroke persistence ("persist stays per-keystroke"), so unconfirmed IME text was still written mid-composition. This was still reproducible on **v1.4.94**.

**Fix:** track IME composition state in `RepoSettingsDraftInput` and hold persistence until `compositionend`, so only confirmed text reaches `updateRepo`. The input stays live during composition via the local draft, and non-IME typing still persists per keystroke (sidebar/tabs stay live). During composition there are no async `updateRepo` calls, so the echo race that cancels the IME session cannot occur.

## Screenshots

No visual change — the fix is entirely behavioral (correct IME composition for the repository Display Name).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — added unit tests pass; the only failures were 3 pre-existing, environment-dependent file-permission tests (`secure-file.test.ts`, `runtime-metadata.test.ts`) that also fail on `main` without this change.
- [x] `pnpm build`

**Unit tests** (`RepositoryPaneDraftInput.test.tsx`, happy-dom) — added 3 Japanese composition cases:
- No persist while composing (unconfirmed kana/kanji is not written to the store).
- A single persist with the confirmed value on `compositionend`.
- Per-keystroke persistence resumes after composition ends.

The existing Korean jamo regression cases stay green.

## Code Review Summary

- **Cross-platform:** pure renderer logic using standard DOM composition events; no platform-specific assumptions. macOS/Linux/Windows behave identically.
- **SSH/remote/local:** only changes *when* the local draft persists to the store. The `updateRepo` path (local IPC vs runtime RPC) is untouched, so local repos, remote hosts, and SSH worktrees all behave the same.
- **Agents / integrations / git providers:** no agent-, integration-, or provider-specific behavior is touched.
- **Performance:** removes redundant per-keystroke async `updateRepo` calls during composition — strictly fewer IPC writes, no hot-path impact.
- **UI quality:** no visual change; the input stays responsive during composition via draft state.
- **Security:** no new trusted inputs or IO; the persisted value still flows through the existing `trim`/sanitize path in main.

## Notes

- **IME/locale-specific:** primarily affects CJK IME users (Japanese verified; Korean regression preserved).
- No platform-, remote/SSH-, agent-, integration-, or git-provider-specific divergence.

X (Twitter): @_mantaroh_
