### PR TITLE
Restore automatic usage tracking for default accounts

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -329,6 +329,203 @@ describe('useIpcEvents zoom routing', () => {
   })
 })
 
+describe('useIpcEvents rate-limit hydration', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not miss startup usage updates that land between get and subscription', async () => {
+    const setRateLimitsFromPush = vi.fn()
+    const staleState = {
+      claude: null,
+      codex: null,
+      gemini: null,
+      opencodeGo: null,
+      kimi: null,
+      claudeTarget: { runtime: 'host', wslDistro: null },
+      codexTarget: { runtime: 'host', wslDistro: null },
+      inactiveClaudeAccounts: [],
+      inactiveCodexAccounts: []
+    }
+    const freshState = {
+      ...staleState,
+      claude: {
+        provider: 'claude',
+        session: {
+          usedPercent: 12,
+          windowMinutes: 300,
+          resetsAt: null,
+          resetDescription: null
+        },
+        weekly: null,
+        updatedAt: 1,
+        error: null,
+        status: 'ok'
+      },
+      codex: {
+        provider: 'codex',
+        session: {
+          usedPercent: 24,
+          windowMinutes: 300,
+          resetsAt: null,
+          resetDescription: null
+        },
+        weekly: null,
+        updatedAt: 1,
+        error: null,
+        status: 'ok'
+      }
+    }
+
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return {
+        ...actual,
+        useEffect: (effect: () => void | (() => void)) => {
+          effect()
+        }
+      }
+    })
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => ({
+          setUpdateStatus: vi.fn(),
+          fetchRepos: vi.fn(),
+          fetchWorktrees: vi.fn(),
+          setActiveView: vi.fn(),
+          activeModal: null,
+          closeModal: vi.fn(),
+          openModal: vi.fn(),
+          activeWorktreeId: 'wt-1',
+          activeView: 'terminal',
+          setActiveRepo: vi.fn(),
+          setActiveWorktree: vi.fn(),
+          revealWorktreeInSidebar: vi.fn(),
+          setIsFullScreen: vi.fn(),
+          updateBrowserTabPageState: vi.fn(),
+          activeTabType: 'terminal',
+          editorFontZoomLevel: 0,
+          setEditorFontZoomLevel: vi.fn(),
+          settings: { terminalFontSize: 13 },
+          setRateLimitsFromPush,
+          updateWorktreeBaseStatus: vi.fn(),
+          updateWorktreeRemoteBranchConflict: vi.fn(),
+          setSshConnectionState: vi.fn(),
+          setSshTargetLabels: vi.fn(),
+          setPortForwards: vi.fn(),
+          clearPortForwards: vi.fn(),
+          setDetectedPorts: vi.fn(),
+          enqueueSshCredentialRequest: vi.fn(),
+          removeSshCredentialRequest: vi.fn(),
+          clearTabPtyId: vi.fn(),
+          updateTabTitle: vi.fn(),
+          runtimePaneTitlesByTabId: {},
+          terminalLayoutsByTabId: {},
+          agentStatusByPaneKey: {},
+          recentlyClosedAgentStatusTabIds: {},
+          repos: [],
+          worktreesByRepo: {},
+          tabsByWorktree: {},
+          unifiedTabsByWorktree: {},
+          workspaceSessionReady: false
+        })
+      }
+    }))
+    vi.doMock('@/lib/ui-zoom', () => ({ applyUIZoom: vi.fn() }))
+    vi.doMock('@/lib/worktree-activation', () => ({
+      activateAndRevealWorktree: vi.fn(),
+      ensureWorktreeHasInitialTerminal: vi.fn()
+    }))
+    vi.doMock('@/components/sidebar/visible-worktrees', () => ({
+      getVisibleWorktreeIds: () => []
+    }))
+    vi.doMock('@/lib/editor-font-zoom', () => ({
+      nextEditorFontZoomLevel: vi.fn(() => 0),
+      computeEditorFontSize: vi.fn(() => 13)
+    }))
+    vi.doMock('@/components/settings/SettingsConstants', () => ({
+      zoomLevelToPercent: vi.fn(() => 100),
+      ZOOM_MIN: -3,
+      ZOOM_MAX: 3
+    }))
+    vi.doMock('@/lib/zoom-events', () => ({ dispatchZoomLevelChanged: vi.fn() }))
+
+    const makeEvents = (target: Record<string, unknown> = {}): Record<string, unknown> =>
+      new Proxy(target, {
+        get: (namespace, prop) => {
+          if (prop in namespace) {
+            return Reflect.get(namespace, prop)
+          }
+          return () => () => {}
+        }
+      })
+
+    let rateLimitUpdateListener: ((state: unknown) => void) | null = null
+    const getRateLimits = vi.fn(() => {
+      if (rateLimitUpdateListener) {
+        rateLimitUpdateListener(freshState)
+      }
+      return Promise.resolve(staleState)
+    })
+
+    vi.stubGlobal('window', {
+      dispatchEvent: vi.fn(),
+      setTimeout: vi.fn(() => 1),
+      clearTimeout: vi.fn(),
+      api: {
+        repos: makeEvents(),
+        worktrees: makeEvents(),
+        keybindings: makeEvents(),
+        settings: makeEvents(),
+        updater: {
+          getStatus: () => Promise.resolve({ state: 'idle' }),
+          onStatus: () => () => {},
+          onClearDismissal: () => () => {}
+        },
+        browser: makeEvents(),
+        rateLimits: {
+          get: getRateLimits,
+          onUpdate: (listener: (state: unknown) => void) => {
+            rateLimitUpdateListener = listener
+            return () => {}
+          }
+        },
+        ssh: {
+          listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
+          getState: () => Promise.resolve(null),
+          onStateChanged: () => () => {},
+          onCredentialRequest: () => () => {},
+          onCredentialResolved: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {}
+        },
+        runtime: {
+          getTerminalFitOverrides: () => Promise.resolve([]),
+          getTerminalDrivers: () => Promise.resolve([]),
+          getBrowserDrivers: () => Promise.resolve([]),
+          onTerminalFitOverrideChanged: () => () => {},
+          onTerminalDriverChanged: () => () => {},
+          onBrowserDriverChanged: () => () => {}
+        },
+        agentStatus: { onSet: () => () => {} },
+        ui: makeEvents({
+          getZoomLevel: vi.fn(() => 0)
+        })
+      }
+    })
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    expect(setRateLimitsFromPush).toHaveBeenLastCalledWith(freshState)
+  })
+})
+
 describe('resolveBrowserSessionTabTarget', () => {
   it('resolves unified browser tabs to their browser workspace', () => {
     expect(

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2408,16 +2408,25 @@ export function useIpcEvents(): void {
       })
     )
 
-    // Hydrate initial rate limit state then subscribe to push updates
-    window.api.rateLimits.get().then((state) => {
-      useAppStore.getState().setRateLimitsFromPush(state as RateLimitState)
-    })
-
+    let initialRateLimitsSnapshotPending = true
+    let receivedRateLimitsPushBeforeInitialSnapshot = false
     unsubs.push(
       window.api.rateLimits.onUpdate((state) => {
+        if (initialRateLimitsSnapshotPending) {
+          receivedRateLimitsPushBeforeInitialSnapshot = true
+        }
         useAppStore.getState().setRateLimitsFromPush(state as RateLimitState)
       })
     )
+    // Why: the startup get is a fallback; a live push may already include
+    // system-default account snapshots that an older get result lacks.
+    window.api.rateLimits.get().then((state) => {
+      initialRateLimitsSnapshotPending = false
+      if (receivedRateLimitsPushBeforeInitialSnapshot) {
+        return
+      }
+      useAppStore.getState().setRateLimitsFromPush(state as RateLimitState)
+    })
 
     const unsubscribeWorkspaceSpaceProgress = window.api.workspaceSpace?.onProgress?.(
       (progress) => {


### PR DESCRIPTION
Fixes #5690

## Summary
- Register the renderer rate-limit push listener before the initial startup snapshot request.
- Treat the initial `rateLimits.get()` response as a fallback so a live startup push for system-default Claude/Codex accounts cannot be overwritten by an older empty snapshot.
- Add a deterministic regression test for the startup race where a fresh push lands before the stale `get()` promise resolves.

## Design and Review
- Design approach: preserve IPC/store contracts and change only renderer event ordering/guarding in `useIpcEvents`. No UI, schema, provider, SSH/runtime target, or copy changes.
- Design review: clean after adding alternatives, interaction states, architecture/data-flow coverage, and internal consistency notes to the ignored scratch design doc.
- Implementation deviations: none.
- Completeness verification: COMPLETE; implementation matches the design and edge cases.

## Perf Audit
- Result: PERF CLEAN.
- Hot paths checked: renderer startup IPC hydration, main rate-limit service polling/push path, store subscriber/render churn, startup latency, and listener cleanup.
- Evidence: no new polling, subprocesses, timers, IPC calls, or long-lived listeners; the raced path now avoids a redundant stale store write. Existing deterministic hook coverage is sufficient for this race.
- Accepted gap: the regression asserts final behavior, not explicit call count; non-blocking because perf audit found no actionable churn.

## Code Review
- Review round 1: two independent reviewers reported no issues found.
- Additional reviewer checks included focused Vitest, touched-file oxlint, and `git diff --check`.

## Validation
- Reproduction before fix: `GITHUB_TOKEN=${GITHUB_TOKEN:-dummy} pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useIpcEvents.test.ts -t "rate-limit hydration"` failed with `claude: null` / `codex: null` overwriting fresh snapshots.
- Focused test after fix: `GITHUB_TOKEN=${GITHUB_TOKEN:-dummy} pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useIpcEvents.test.ts -t "rate-limit hydration"` passed.
- Full touched hook suite: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/hooks/useIpcEvents.test.ts` passed, 64 tests.
- Static checks: `pnpm run typecheck` passed; `pnpm run lint` passed; `git diff --check` passed.
- Electron validation: launched this exact worktree on CDP port 9337, verified `window.api.app.getIdentity()` branch/root, inspected `window.api.rateLimits.get()` and `window.__store.getState().rateLimits`, and confirmed renderer console had 0 errors.
- Screenshot evidence: captured locally at `.playwright-cli/page-2026-06-24T06-17-00-350Z.png`; live Claude/Codex default accounts were unavailable in this profile, so visible usage chips could not be captured.
- `demo-project`: not exercised because the change is global renderer startup hydration with no workspace-specific user action.

## Post-PR Stabilization
- Completed initial 8-minute wait and stabilization sweep.
- CodeRabbit: no actionable comments generated.
- PR checks: `track-community-pr` passed; `verify` passed (lint, typecheck, tests, build, packaged CLI smoke).

## Risks
- Live provider-account UI could not be observed in this local profile because rate-limit providers were all null; deterministic race coverage and live API/store inspection cover the startup hydration behavior.

