### PR TITLE
Fix orchestration task link length cap

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-handle-links.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-handle-links.test.ts
@@ -1,7 +1,12 @@
 import type { ILink } from '@xterm/xterm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  clearRuntimeCompatibilityCacheForTests,
+  markRuntimeEnvironmentCompatible
+} from '@/runtime/runtime-rpc-client'
+import {
   createTerminalHandleLinkProvider,
+  extractOrchestrationTaskLinks,
   extractTerminalHandleLinks,
   findTerminalHandleTarget,
   focusRendererTerminalHandle
@@ -14,6 +19,9 @@ const mocks = vi.hoisted(() => ({
     tabsByWorktree: {},
     ptyIdsByTabId: {},
     terminalLayoutsByTabId: {},
+    agentStatusByPaneKey: {},
+    retainedAgentsByPaneKey: {},
+    runtimeAgentOrchestrationByPaneKey: {},
     setActiveWorktree: vi.fn(),
     markWorktreeVisited: vi.fn(),
     setActiveView: vi.fn(),
@@ -73,7 +81,11 @@ function setPlatform(userAgent: string): void {
   vi.stubGlobal('navigator', { userAgent })
 }
 
-async function collectLinks(rows: TestBufferLine[], bufferLineNumber = 1): Promise<ILink[]> {
+async function collectLinks(
+  rows: TestBufferLine[],
+  bufferLineNumber = 1,
+  runtimeEnvironmentId: string | null = null
+): Promise<ILink[]> {
   const terminal = {
     buffer: {
       active: {
@@ -84,7 +96,7 @@ async function collectLinks(rows: TestBufferLine[], bufferLineNumber = 1): Promi
   }
   const provider = createTerminalHandleLinkProvider({
     getTerminal: () => terminal as never,
-    getRuntimeEnvironmentId: () => null,
+    getRuntimeEnvironmentId: () => runtimeEnvironmentId,
     linkTooltip: { textContent: '', style: { display: '' } } as unknown as HTMLElement
   })
   return await new Promise<ILink[]>((resolve) => {
@@ -127,6 +139,26 @@ describe('extractTerminalHandleLinks', () => {
 
   it('ignores overlong handle tokens', () => {
     expect(extractTerminalHandleLinks(`Open term_${'a'.repeat(129)}`)).toEqual([])
+  })
+})
+
+describe('extractOrchestrationTaskLinks', () => {
+  it('detects task IDs from orchestration dispatch output', () => {
+    const line = 'Ran orca orchestration dispatch --task task_88f323f654c0 --to term_worker'
+
+    expect(extractOrchestrationTaskLinks(line)).toEqual([
+      {
+        taskId: 'task_88f323f654c0',
+        startIndex: 39,
+        endIndex: 56
+      }
+    ])
+  })
+
+  it('trims sentence punctuation without matching inside longer tokens', () => {
+    expect(extractOrchestrationTaskLinks('Open task_worker, not xtask_worker.')).toEqual([
+      { taskId: 'task_worker', startIndex: 5, endIndex: 16 }
+    ])
   })
 })
 
@@ -183,6 +215,9 @@ describe('focusRendererTerminalHandle', () => {
     mocks.storeState.terminalLayoutsByTabId = {
       'tab-1': { root: null, activeLeafId: null, expandedLeafId: null }
     }
+    mocks.storeState.agentStatusByPaneKey = {}
+    mocks.storeState.retainedAgentsByPaneKey = {}
+    mocks.storeState.runtimeAgentOrchestrationByPaneKey = {}
   })
 
   afterEach(() => {
@@ -207,13 +242,27 @@ describe('createTerminalHandleLinkProvider', () => {
     mocks.storeState.tabsByWorktree = {}
     mocks.storeState.ptyIdsByTabId = {}
     mocks.storeState.terminalLayoutsByTabId = {}
+    mocks.storeState.agentStatusByPaneKey = {}
+    mocks.storeState.retainedAgentsByPaneKey = {}
+    mocks.storeState.runtimeAgentOrchestrationByPaneKey = {}
     vi.stubGlobal('window', {
       api: {
         runtime: {
-          call: vi.fn().mockResolvedValue({
-            ok: true,
-            result: { focus: { handle: 'term_worker', tabId: 'tab-1', worktreeId: 'wt-1' } }
+          call: vi.fn().mockImplementation(({ method }) => {
+            if (method === 'orchestration.dispatchShow') {
+              return Promise.resolve({
+                ok: true,
+                result: { dispatch: { assignee_handle: 'term_worker' } }
+              })
+            }
+            return Promise.resolve({
+              ok: true,
+              result: { focus: { handle: 'term_worker', tabId: 'tab-1', worktreeId: 'wt-1' } }
+            })
           })
+        },
+        runtimeEnvironments: {
+          call: vi.fn()
         }
       }
     })
@@ -221,6 +270,7 @@ describe('createTerminalHandleLinkProvider', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    clearRuntimeCompatibilityCacheForTests()
   })
 
   it('provides wrapped terminal handle links and focuses through runtime on activation', async () => {
@@ -241,6 +291,133 @@ describe('createTerminalHandleLinkProvider', () => {
     expect(window.api.runtime.call).toHaveBeenCalledWith({
       method: 'terminal.focus',
       params: { terminal: 'term_worker' }
+    })
+  })
+
+  it('provides wrapped task links and focuses their dispatched terminal through runtime', async () => {
+    const rows = [makeBufferLine('Task: task_work'), makeBufferLine('er', { isWrapped: true })]
+    const links = await collectLinks(rows, 1)
+
+    expect(links.map((link) => link.text)).toEqual(['task_worker'])
+    links[0].activate(
+      {
+        metaKey: true,
+        ctrlKey: false,
+        preventDefault: vi.fn()
+      } as unknown as MouseEvent,
+      links[0].text
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(window.api.runtime.call).toHaveBeenNthCalledWith(1, {
+      method: 'orchestration.dispatchShow',
+      params: { task: 'task_worker' }
+    })
+    expect(window.api.runtime.call).toHaveBeenNthCalledWith(2, {
+      method: 'terminal.focus',
+      params: { terminal: 'term_worker' }
+    })
+  })
+
+  it('returns task and terminal links in line order', async () => {
+    const links = await collectLinks([
+      makeBufferLine('Dispatch --task task_worker --to term_worker')
+    ])
+
+    expect(links.map((link) => link.text)).toEqual(['task_worker', 'term_worker'])
+  })
+
+  it('uses runtime dispatch for task links instead of stale renderer task snapshots', async () => {
+    mocks.storeState.tabsByWorktree = {
+      'wt-1': [
+        {
+          id: 'tab-stale',
+          worktreeId: 'wt-1',
+          ptyId: 'term_stale',
+          title: 'Stale worker',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    }
+    mocks.storeState.agentStatusByPaneKey = {
+      'tab-stale:11111111-1111-4111-8111-111111111111': {
+        paneKey: 'tab-stale:11111111-1111-4111-8111-111111111111',
+        tabId: 'tab-stale',
+        worktreeId: 'wt-1',
+        orchestration: {
+          taskId: 'task_worker',
+          dispatchId: 'ctx_stale'
+        }
+      }
+    }
+    const links = await collectLinks([makeBufferLine('Task: task_worker')])
+
+    links[0].activate(
+      {
+        metaKey: true,
+        ctrlKey: false,
+        preventDefault: vi.fn()
+      } as unknown as MouseEvent,
+      links[0].text
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(window.api.runtime.call).toHaveBeenNthCalledWith(1, {
+      method: 'orchestration.dispatchShow',
+      params: { task: 'task_worker' }
+    })
+    expect(window.api.runtime.call).toHaveBeenNthCalledWith(2, {
+      method: 'terminal.focus',
+      params: { terminal: 'term_worker' }
+    })
+  })
+
+  it('focuses task links through their owning runtime environment', async () => {
+    markRuntimeEnvironmentCompatible('env-1')
+    window.api.runtimeEnvironments.call = vi.fn().mockImplementation(({ method }) => {
+      if (method === 'orchestration.dispatchShow') {
+        return Promise.resolve({
+          ok: true,
+          result: { dispatch: { assignee_handle: 'term_remote' } }
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        result: { focus: { handle: 'term_remote', tabId: 'tab-remote', worktreeId: 'wt-remote' } }
+      })
+    })
+    const links = await collectLinks([makeBufferLine('Task: task_remote')], 1, 'env-1')
+
+    links[0].activate(
+      {
+        metaKey: true,
+        ctrlKey: false,
+        preventDefault: vi.fn()
+      } as unknown as MouseEvent,
+      links[0].text
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(window.api.runtime.call).not.toHaveBeenCalled()
+    expect(window.api.runtimeEnvironments.call).toHaveBeenNthCalledWith(1, {
+      selector: 'env-1',
+      method: 'orchestration.dispatchShow',
+      params: { task: 'task_remote' },
+      timeoutMs: undefined
+    })
+    expect(window.api.runtimeEnvironments.call).toHaveBeenNthCalledWith(2, {
+      selector: 'env-1',
+      method: 'terminal.focus',
+      params: { terminal: 'term_remote' },
+      timeoutMs: undefined
     })
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-handle-links.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-handle-links.test.ts
@@ -160,6 +160,15 @@ describe('extractOrchestrationTaskLinks', () => {
       { taskId: 'task_worker', startIndex: 5, endIndex: 16 }
     ])
   })
+
+  it('caps orchestration task IDs by full token length', () => {
+    const maxLengthTaskId = `task_${'a'.repeat(123)}`
+
+    expect(extractOrchestrationTaskLinks(`Open ${maxLengthTaskId}`)).toEqual([
+      { taskId: maxLengthTaskId, startIndex: 5, endIndex: 133 }
+    ])
+    expect(extractOrchestrationTaskLinks(`Open task_${'a'.repeat(124)}`)).toEqual([])
+  })
 })
 
 describe('findTerminalHandleTarget', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-handle-links.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-handle-links.ts
@@ -6,6 +6,14 @@ import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import { getRemoteRuntimeTerminalHandle } from '@/runtime/runtime-terminal-stream'
 import { buildWrappedLogicalLine, rangeForParsedFileLink } from './wrapped-terminal-link-ranges'
+import {
+  extractOrchestrationTaskLinks,
+  focusRuntimeOrchestrationTask,
+  ORCHESTRATION_TASK_PREFIX
+} from './terminal-orchestration-task-links'
+
+export { extractOrchestrationTaskLinks } from './terminal-orchestration-task-links'
+export type { ParsedOrchestrationTaskLink } from './terminal-orchestration-task-links'
 
 export type ParsedTerminalHandleLink = {
   handle: string
@@ -35,39 +43,50 @@ const MAX_TERMINAL_HANDLE_BODY_LENGTH = 128
 const TERMINAL_HANDLE_BOUNDARY_CHAR = /[A-Za-z0-9_-]/
 
 export function extractTerminalHandleLinks(lineText: string): ParsedTerminalHandleLink[] {
-  if (!lineText.includes(TERMINAL_HANDLE_PREFIX)) {
+  return extractPrefixedTokenLinks(lineText, TERMINAL_HANDLE_PREFIX).map((link) => ({
+    handle: link.token,
+    startIndex: link.startIndex,
+    endIndex: link.endIndex
+  }))
+}
+
+function extractPrefixedTokenLinks(
+  lineText: string,
+  prefix: string
+): { token: string; startIndex: number; endIndex: number }[] {
+  if (!lineText.includes(prefix)) {
     return []
   }
 
-  const links: ParsedTerminalHandleLink[] = []
+  const links: { token: string; startIndex: number; endIndex: number }[] = []
   let searchStart = 0
   while (searchStart < lineText.length) {
-    const startIndex = lineText.indexOf(TERMINAL_HANDLE_PREFIX, searchStart)
+    const startIndex = lineText.indexOf(prefix, searchStart)
     if (startIndex === -1) {
       break
     }
 
-    const bodyStart = startIndex + TERMINAL_HANDLE_PREFIX.length
-    const tokenEnd = findTerminalHandleTokenEnd(lineText, bodyStart)
+    const bodyStart = startIndex + prefix.length
+    const tokenEnd = findPrefixedTokenEnd(lineText, bodyStart)
     searchStart = Math.max(tokenEnd, bodyStart + 1)
     const bodyLength = tokenEnd - bodyStart
     if (bodyLength === 0 || bodyLength > MAX_TERMINAL_HANDLE_BODY_LENGTH) {
       continue
     }
 
-    const handle = lineText.slice(startIndex, tokenEnd)
+    const token = lineText.slice(startIndex, tokenEnd)
     if (
       TERMINAL_HANDLE_BOUNDARY_CHAR.test(lineText[startIndex - 1] ?? '') ||
       TERMINAL_HANDLE_BOUNDARY_CHAR.test(lineText[tokenEnd] ?? '')
     ) {
       continue
     }
-    links.push({ handle, startIndex, endIndex: tokenEnd })
+    links.push({ token, startIndex, endIndex: tokenEnd })
   }
   return links
 }
 
-function findTerminalHandleTokenEnd(lineText: string, startIndex: number): number {
+function findPrefixedTokenEnd(lineText: string, startIndex: number): number {
   let index = startIndex
   while (index < lineText.length && TERMINAL_HANDLE_BOUNDARY_CHAR.test(lineText[index])) {
     index += 1
@@ -131,12 +150,29 @@ export function createTerminalHandleLinkProvider(
         return
       }
       const logicalLine = buildWrappedLogicalLine(terminal.buffer.active, bufferLineNumber)
-      if (!logicalLine || !logicalLine.text.includes('term_')) {
+      if (
+        !logicalLine ||
+        (!logicalLine.text.includes(TERMINAL_HANDLE_PREFIX) &&
+          !logicalLine.text.includes(ORCHESTRATION_TASK_PREFIX))
+      ) {
         callback(undefined)
         return
       }
 
-      const links = extractTerminalHandleLinks(logicalLine.text)
+      const terminalLinks = extractTerminalHandleLinks(logicalLine.text).map((parsed) => ({
+        kind: 'terminal' as const,
+        text: parsed.handle,
+        startIndex: parsed.startIndex,
+        endIndex: parsed.endIndex
+      }))
+      const taskLinks = extractOrchestrationTaskLinks(logicalLine.text).map((parsed) => ({
+        kind: 'task' as const,
+        text: parsed.taskId,
+        startIndex: parsed.startIndex,
+        endIndex: parsed.endIndex
+      }))
+      const links = [...terminalLinks, ...taskLinks]
+        .sort((a, b) => a.startIndex - b.startIndex)
         .map((parsed): ILink | null => {
           const range = rangeForParsedFileLink(logicalLine, parsed.startIndex, parsed.endIndex)
           if (!range) {
@@ -144,24 +180,17 @@ export function createTerminalHandleLinkProvider(
           }
           return {
             range,
-            text: parsed.handle,
+            text: parsed.text,
             activate: (event) => {
               if (!isTerminalHandleLinkActivation(event)) {
                 return
               }
               event?.preventDefault()
-              if (!focusRendererTerminalHandle(parsed.handle)) {
-                void focusRuntimeTerminalHandle(
-                  parsed.handle,
-                  deps.getRuntimeEnvironmentId()
-                ).catch((error: unknown) => {
-                  console.warn('[terminal-handle-link] focus failed:', error)
-                })
-              }
+              void activateParsedLink(parsed, deps.getRuntimeEnvironmentId())
               terminal.clearSelection()
             },
             hover: () => {
-              deps.linkTooltip.textContent = `${parsed.handle} (${getTerminalHandleFocusHint()})`
+              deps.linkTooltip.textContent = `${parsed.text} (${getTerminalHandleFocusHint()})`
               deps.linkTooltip.style.display = ''
             },
             leave: () => {
@@ -173,6 +202,25 @@ export function createTerminalHandleLinkProvider(
 
       callback(links.length > 0 ? links : undefined)
     }
+  }
+}
+
+async function activateParsedLink(
+  parsed: { kind: 'terminal' | 'task'; text: string },
+  runtimeEnvironmentId: string | null
+): Promise<void> {
+  try {
+    if (parsed.kind === 'terminal') {
+      if (!focusRendererTerminalHandle(parsed.text)) {
+        await focusRuntimeTerminalHandle(parsed.text, runtimeEnvironmentId)
+      }
+      return
+    }
+    // Why: a task can be retried onto a new dispatch; runtime DB is the
+    // authority for the latest terminal assigned to a stable task ID.
+    await focusRuntimeOrchestrationTask(parsed.text, runtimeEnvironmentId)
+  } catch (error: unknown) {
+    console.warn('[terminal-handle-link] focus failed:', error)
   }
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-orchestration-task-links.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-orchestration-task-links.ts
@@ -1,0 +1,73 @@
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+
+export type ParsedOrchestrationTaskLink = {
+  taskId: string
+  startIndex: number
+  endIndex: number
+}
+
+export const ORCHESTRATION_TASK_PREFIX = 'task_'
+
+const MAX_ORCHESTRATION_TASK_BODY_LENGTH = 128
+const ORCHESTRATION_TASK_BOUNDARY_CHAR = /[A-Za-z0-9_-]/
+
+export function extractOrchestrationTaskLinks(lineText: string): ParsedOrchestrationTaskLink[] {
+  if (!lineText.includes(ORCHESTRATION_TASK_PREFIX)) {
+    return []
+  }
+
+  const links: ParsedOrchestrationTaskLink[] = []
+  let searchStart = 0
+  while (searchStart < lineText.length) {
+    const startIndex = lineText.indexOf(ORCHESTRATION_TASK_PREFIX, searchStart)
+    if (startIndex === -1) {
+      break
+    }
+
+    const bodyStart = startIndex + ORCHESTRATION_TASK_PREFIX.length
+    const tokenEnd = findOrchestrationTaskTokenEnd(lineText, bodyStart)
+    searchStart = Math.max(tokenEnd, bodyStart + 1)
+    const bodyLength = tokenEnd - bodyStart
+    if (bodyLength === 0 || bodyLength > MAX_ORCHESTRATION_TASK_BODY_LENGTH) {
+      continue
+    }
+
+    const taskId = lineText.slice(startIndex, tokenEnd)
+    if (
+      ORCHESTRATION_TASK_BOUNDARY_CHAR.test(lineText[startIndex - 1] ?? '') ||
+      ORCHESTRATION_TASK_BOUNDARY_CHAR.test(lineText[tokenEnd] ?? '')
+    ) {
+      continue
+    }
+    links.push({ taskId, startIndex, endIndex: tokenEnd })
+  }
+  return links
+}
+
+export async function focusRuntimeOrchestrationTask(
+  taskId: string,
+  runtimeEnvironmentId: string | null
+): Promise<void> {
+  const environmentId = runtimeEnvironmentId?.trim()
+  const target = environmentId
+    ? ({ kind: 'environment', environmentId } as const)
+    : ({ kind: 'local' } as const)
+  const result = await callRuntimeRpc<{
+    dispatch: { assignee_handle?: string | null } | null
+  }>(target, 'orchestration.dispatchShow', { task: taskId })
+  const terminal = result.dispatch?.assignee_handle?.trim()
+  if (!terminal) {
+    throw new Error(`No dispatched terminal for orchestration task ${taskId}`)
+  }
+  // Why: task IDs are stable orchestration DB records, but terminal.focus owns
+  // the app-side navigation contract for local and SSH runtime terminals.
+  await callRuntimeRpc(target, 'terminal.focus', { terminal })
+}
+
+function findOrchestrationTaskTokenEnd(lineText: string, startIndex: number): number {
+  let index = startIndex
+  while (index < lineText.length && ORCHESTRATION_TASK_BOUNDARY_CHAR.test(lineText[index])) {
+    index += 1
+  }
+  return index
+}

--- a/src/renderer/src/components/terminal-pane/terminal-orchestration-task-links.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-orchestration-task-links.ts
@@ -8,7 +8,7 @@ export type ParsedOrchestrationTaskLink = {
 
 export const ORCHESTRATION_TASK_PREFIX = 'task_'
 
-const MAX_ORCHESTRATION_TASK_BODY_LENGTH = 128
+const MAX_ORCHESTRATION_TASK_TOKEN_LENGTH = 128
 const ORCHESTRATION_TASK_BOUNDARY_CHAR = /[A-Za-z0-9_-]/
 
 export function extractOrchestrationTaskLinks(lineText: string): ParsedOrchestrationTaskLink[] {
@@ -28,11 +28,14 @@ export function extractOrchestrationTaskLinks(lineText: string): ParsedOrchestra
     const tokenEnd = findOrchestrationTaskTokenEnd(lineText, bodyStart)
     searchStart = Math.max(tokenEnd, bodyStart + 1)
     const bodyLength = tokenEnd - bodyStart
-    if (bodyLength === 0 || bodyLength > MAX_ORCHESTRATION_TASK_BODY_LENGTH) {
+    if (bodyLength === 0) {
       continue
     }
 
     const taskId = lineText.slice(startIndex, tokenEnd)
+    if (taskId.length > MAX_ORCHESTRATION_TASK_TOKEN_LENGTH) {
+      continue
+    }
     if (
       ORCHESTRATION_TASK_BOUNDARY_CHAR.test(lineText[startIndex - 1] ?? '') ||
       ORCHESTRATION_TASK_BOUNDARY_CHAR.test(lineText[tokenEnd] ?? '')


### PR DESCRIPTION
## Summary
- cap orchestration task IDs by the full token length, including the task_ prefix
- add coverage for the maximum accepted orchestration task ID length

## Test plan
- pre-commit oxlint
- pre-commit oxlint React doctor
- pre-commit oxfmt --write