### PR TITLE
Fix orchestration task link length cap

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-handle-links.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-handle-links.test.ts
@@ -160,6 +160,15 @@ describe('extractOrchestrationTaskLinks', () => {
       { taskId: 'task_worker', startIndex: 5, endIndex: 16 }
     ])
   })
+
+  it('caps orchestration task IDs by full token length', () => {
+    const maxLengthTaskId = `task_${'a'.repeat(123)}`
+
+    expect(extractOrchestrationTaskLinks(`Open ${maxLengthTaskId}`)).toEqual([
+      { taskId: maxLengthTaskId, startIndex: 5, endIndex: 133 }
+    ])
+    expect(extractOrchestrationTaskLinks(`Open task_${'a'.repeat(124)}`)).toEqual([])
+  })
 })
 
 describe('findTerminalHandleTarget', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-orchestration-task-links.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-orchestration-task-links.ts
@@ -8,7 +8,7 @@ export type ParsedOrchestrationTaskLink = {
 
 export const ORCHESTRATION_TASK_PREFIX = 'task_'
 
-const MAX_ORCHESTRATION_TASK_BODY_LENGTH = 128
+const MAX_ORCHESTRATION_TASK_TOKEN_LENGTH = 128
 const ORCHESTRATION_TASK_BOUNDARY_CHAR = /[A-Za-z0-9_-]/
 
 export function extractOrchestrationTaskLinks(lineText: string): ParsedOrchestrationTaskLink[] {
@@ -28,11 +28,14 @@ export function extractOrchestrationTaskLinks(lineText: string): ParsedOrchestra
     const tokenEnd = findOrchestrationTaskTokenEnd(lineText, bodyStart)
     searchStart = Math.max(tokenEnd, bodyStart + 1)
     const bodyLength = tokenEnd - bodyStart
-    if (bodyLength === 0 || bodyLength > MAX_ORCHESTRATION_TASK_BODY_LENGTH) {
+    if (bodyLength === 0) {
       continue
     }
 
     const taskId = lineText.slice(startIndex, tokenEnd)
+    if (taskId.length > MAX_ORCHESTRATION_TASK_TOKEN_LENGTH) {
+      continue
+    }
     if (
       ORCHESTRATION_TASK_BOUNDARY_CHAR.test(lineText[startIndex - 1] ?? '') ||
       ORCHESTRATION_TASK_BOUNDARY_CHAR.test(lineText[tokenEnd] ?? '')


### PR DESCRIPTION
## Summary
- cap orchestration task IDs by the full token length, including the task_ prefix
- add coverage for the maximum accepted orchestration task ID length

## Test plan
- pre-commit oxlint
- pre-commit oxlint React doctor
- pre-commit oxfmt --write