### PR TITLE
Prevent visible agent terminals from sleeping

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -111,6 +111,7 @@ import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
 import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-paste-recovery'
 import { restoreTerminalFitToDesktop, restoreTerminalFitsToDesktop } from './terminal-fit-restore'
+import { useVisibleTerminalWorktreeClaim } from './use-visible-terminal-worktree-claim'
 
 // Why: registry lives in a leaf module so the store slice can import it
 // without re-entering the `slice → TerminalPane → store → slice` cycle
@@ -260,6 +261,8 @@ export default function TerminalPane({
   isActiveRef.current = isActive
   const isVisibleRef = useRef(isVisible)
   isVisibleRef.current = isVisible
+
+  useVisibleTerminalWorktreeClaim({ isVisible, worktreeId })
 
   const [expandedPaneId, setExpandedPaneId] = useState<number | null>(null)
   // Why: tracked in React state (not derived from managerRef.getPanes().length)

--- a/src/renderer/src/components/terminal-pane/use-visible-terminal-worktree-claim.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-visible-terminal-worktree-claim.test.ts
@@ -1,0 +1,54 @@
+import type * as ReactModule from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getForegroundTerminalWorktreeIds,
+  resetForegroundTerminalWorktreeIdsForTests
+} from '@/lib/foreground-terminal-worktrees'
+import { useVisibleTerminalWorktreeClaim } from './use-visible-terminal-worktree-claim'
+
+const reactEffects = vi.hoisted(() => ({
+  layoutEffects: [] as (() => void | (() => void))[],
+  passiveEffects: [] as (() => void | (() => void))[]
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactModule>()
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => {
+      reactEffects.passiveEffects.push(effect)
+    },
+    useLayoutEffect: (effect: () => void | (() => void)) => {
+      reactEffects.layoutEffects.push(effect)
+    }
+  }
+})
+
+afterEach(() => {
+  resetForegroundTerminalWorktreeIdsForTests()
+  reactEffects.layoutEffects = []
+  reactEffects.passiveEffects = []
+})
+
+describe('useVisibleTerminalWorktreeClaim', () => {
+  it('registers visible panes through a layout effect', () => {
+    useVisibleTerminalWorktreeClaim({ isVisible: true, worktreeId: 'wt-visible' })
+
+    expect(reactEffects.passiveEffects).toHaveLength(0)
+    expect(reactEffects.layoutEffects).toHaveLength(1)
+
+    const cleanup = reactEffects.layoutEffects[0]()
+    expect(getForegroundTerminalWorktreeIds()).toEqual(['wt-visible'])
+
+    cleanup?.()
+    expect(getForegroundTerminalWorktreeIds()).toEqual([])
+  })
+
+  it('does not claim hidden panes', () => {
+    useVisibleTerminalWorktreeClaim({ isVisible: false, worktreeId: 'wt-hidden' })
+
+    reactEffects.layoutEffects[0]()
+
+    expect(getForegroundTerminalWorktreeIds()).toEqual([])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-visible-terminal-worktree-claim.ts
+++ b/src/renderer/src/components/terminal-pane/use-visible-terminal-worktree-claim.ts
@@ -1,0 +1,21 @@
+import { useLayoutEffect } from 'react'
+import { registerVisibleTerminalWorktree } from '@/lib/foreground-terminal-worktrees'
+
+type VisibleTerminalWorktreeClaimOptions = {
+  isVisible: boolean
+  worktreeId: string
+}
+
+export function useVisibleTerminalWorktreeClaim({
+  isVisible,
+  worktreeId
+}: VisibleTerminalWorktreeClaimOptions): void {
+  useLayoutEffect(() => {
+    if (!isVisible) {
+      return
+    }
+    // Why: agent sleep must fail closed before paint for any pane the user can
+    // see, even when global active-worktree state is between views.
+    return registerVisibleTerminalWorktree(worktreeId)
+  }, [isVisible, worktreeId])
+}

--- a/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
@@ -9,6 +9,7 @@ import {
 } from './agent-hibernation-coordinator'
 import { hydrateDrivers, setDriverForPty } from './pane-manager/mobile-driver-state'
 import {
+  registerVisibleTerminalWorktree,
   resetForegroundTerminalWorktreeIdsForTests,
   setForegroundTerminalWorktreeIds
 } from './foreground-terminal-worktrees'
@@ -237,6 +238,27 @@ describe('agent sleep coordinator', () => {
     await vi.advanceTimersByTimeAsync(3000)
 
     expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('does not hibernate a worktree with a visible mounted terminal pane', async () => {
+    vi.useFakeTimers()
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined))
+    const unregister = registerVisibleTerminalWorktree('wt-bg')
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(shutdown).not.toHaveBeenCalled()
+
+    unregister()
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(shutdown).toHaveBeenCalledWith('wt-bg', {
+      paneKey: `tab-1:${LEAF}`,
+      tabId: 'tab-1',
+      leafId: LEAF,
+      ptyId: 'pty-1'
+    })
   })
 
   it('requires the same candidate signature during final revalidation', async () => {

--- a/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
@@ -250,6 +250,8 @@ describe('agent sleep coordinator', () => {
     expect(shutdown).not.toHaveBeenCalled()
 
     unregister()
+    // Why: the coordinator requires one tick to confirm a stable candidate
+    // and a second tick to revalidate before shutdown.
     await vi.advanceTimersByTimeAsync(1000)
     await vi.advanceTimersByTimeAsync(1000)
 

--- a/src/renderer/src/lib/foreground-terminal-worktrees.test.ts
+++ b/src/renderer/src/lib/foreground-terminal-worktrees.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  getForegroundTerminalWorktreeIds,
+  registerVisibleTerminalWorktree,
+  resetForegroundTerminalWorktreeIdsForTests,
+  setForegroundTerminalWorktreeIds
+} from './foreground-terminal-worktrees'
+
+afterEach(() => {
+  resetForegroundTerminalWorktreeIdsForTests()
+})
+
+describe('foreground terminal worktrees', () => {
+  it('returns the union of explicit foreground ids and visible terminal claims', () => {
+    setForegroundTerminalWorktreeIds(['wt-explicit', null, '', undefined])
+    const unregister = registerVisibleTerminalWorktree('wt-visible')
+
+    expect(getForegroundTerminalWorktreeIds().sort()).toEqual(['wt-explicit', 'wt-visible'])
+
+    unregister()
+    expect(getForegroundTerminalWorktreeIds()).toEqual(['wt-explicit'])
+  })
+
+  it('keeps duplicate visible worktree claims until every token unregisters', () => {
+    const unregisterFirst = registerVisibleTerminalWorktree('wt-visible')
+    const unregisterSecond = registerVisibleTerminalWorktree('wt-visible')
+
+    expect(getForegroundTerminalWorktreeIds()).toEqual(['wt-visible'])
+
+    unregisterFirst()
+    expect(getForegroundTerminalWorktreeIds()).toEqual(['wt-visible'])
+
+    unregisterSecond()
+    expect(getForegroundTerminalWorktreeIds()).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/foreground-terminal-worktrees.ts
+++ b/src/renderer/src/lib/foreground-terminal-worktrees.ts
@@ -1,19 +1,41 @@
-let foregroundWorktreeIds = new Set<string>()
+let explicitForegroundWorktreeIds = new Set<string>()
+const visibleTerminalClaimsByToken = new Map<symbol, string>()
 
-export function setForegroundTerminalWorktreeIds(
-  worktreeIds: Iterable<string | null | undefined>
-): void {
-  foregroundWorktreeIds = new Set(
+function normalizeWorktreeIds(worktreeIds: Iterable<string | null | undefined>): Set<string> {
+  return new Set(
     Array.from(worktreeIds).filter(
       (worktreeId): worktreeId is string => typeof worktreeId === 'string' && worktreeId.length > 0
     )
   )
 }
 
+export function setForegroundTerminalWorktreeIds(
+  worktreeIds: Iterable<string | null | undefined>
+): void {
+  explicitForegroundWorktreeIds = normalizeWorktreeIds(worktreeIds)
+}
+
+export function registerVisibleTerminalWorktree(worktreeId: string | null | undefined): () => void {
+  const normalized = normalizeWorktreeIds([worktreeId])
+  const id = Array.from(normalized)[0]
+  if (!id) {
+    return () => {}
+  }
+
+  const token = Symbol(id)
+  visibleTerminalClaimsByToken.set(token, id)
+  return () => {
+    visibleTerminalClaimsByToken.delete(token)
+  }
+}
+
 export function getForegroundTerminalWorktreeIds(): string[] {
-  return Array.from(foregroundWorktreeIds)
+  return Array.from(
+    new Set([...explicitForegroundWorktreeIds, ...visibleTerminalClaimsByToken.values()])
+  )
 }
 
 export function resetForegroundTerminalWorktreeIdsForTests(): void {
-  foregroundWorktreeIds = new Set()
+  explicitForegroundWorktreeIds = new Set()
+  visibleTerminalClaimsByToken.clear()
 }

--- a/src/renderer/src/lib/foreground-terminal-worktrees.ts
+++ b/src/renderer/src/lib/foreground-terminal-worktrees.ts
@@ -22,6 +22,8 @@ export function registerVisibleTerminalWorktree(worktreeId: string | null | unde
     return () => {}
   }
 
+  // Why: multiple visible panes can belong to one worktree; tokenized claims
+  // let each pane clean up without dropping sibling foreground protection.
   const token = Symbol(id)
   visibleTerminalClaimsByToken.set(token, id)
   return () => {
@@ -30,6 +32,8 @@ export function registerVisibleTerminalWorktree(worktreeId: string | null | unde
 }
 
 export function getForegroundTerminalWorktreeIds(): string[] {
+  // Why: hibernation already gates by foreground worktree, so visible pane
+  // claims join the page-level foreground set instead of adding pane rules.
   return Array.from(
     new Set([...explicitForegroundWorktreeIds, ...visibleTerminalClaimsByToken.values()])
   )


### PR DESCRIPTION
## Summary

Visible agent terminals now keep a foreground claim while their `TerminalPane` is actually visible. Agent sleep already skips foreground worktrees, so the hibernation planner now fails closed for panes the user can see instead of killing the backing PTY and leaving xterm unable to accept typing.

This prevents visible agent terminals from being slept; it does not make an already-slept terminal responsive.

## Design Approach

- Kept the existing hibernation planner semantics: it still skips active/foreground worktrees and sleeps eligible completed agents in genuinely background worktrees.
- Extended the foreground worktree source with tokenized visible-pane claims, then unions those claims with the existing page-level foreground set.
- Registered visible claims from `TerminalPane` through a small `useLayoutEffect` hook so the claim is installed before a visible pane paints.
- Kept the claim worktree-scoped intentionally. If any terminal in a worktree is visible, the safer behavior is to skip automatic agent sleep for that worktree during that tick.

## Review And Implementation

- Design review outcome: clean after tightening the implementation requirement from passive effect to pre-paint `useLayoutEffect`.
- Implementation: added the visible-claim registry, wired `TerminalPane`, and added focused registry/hook/coordinator tests.
- Deviations from design: none.
- Completeness verification: complete enough to proceed; noted a non-blocking hardening gap that hook wiring is covered by hook tests plus code review rather than a full `TerminalPane` mount test.

## Perf Audit

- Touched hot paths: `TerminalPane` visibility lifecycle and the once-per-minute hibernation foreground collection.
- Result: clean. No new polling, subprocesses, store subscriptions, terminal output work, or typing-path work.
- Measurement/test rationale: deterministic registry cleanup and coordinator tests cover the only meaningful count/leak risks for this tiny lifecycle registry.

## Code Review

- Round 1 reviewer A: clean.
- Round 1 reviewer B: clean.
- No agent-facing prompt text or product-authored agent workflow instructions were added.

## Validation

- Focused reproduction/fix:
  - Eligible completed agent sleeps without a visible claim.
  - Same eligible agent is not slept while the terminal worktree has a visible pane claim.
  - It sleeps again after unregistering the visible claim.
- Electron/product validation:
  - Launched this worktree's app.
  - Verified a visible terminal pane was mounted and focused.
  - Typed through the real xterm helper textarea.
  - Confirmed terminal input state updated and the textarea stayed focused.
- Screenshot evidence: not attached. Capture attempts were blocked by the dev app/native keychain prompt and a hung Playwright screenshot; the invalid screenshot was deleted rather than used as misleading evidence.
- Accepted validation gap: did not run a full live provider-agent sleep window in Electron because the running app had hibernation disabled and no completed resumable provider session available. The deterministic coordinator reproduction covers the PTY-kill cause directly.

## Checks

- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/agent-hibernation-coordinator.test.ts src/renderer/src/lib/agent-hibernation-planner.test.ts src/renderer/src/lib/foreground-terminal-worktrees.test.ts src/renderer/src/components/terminal-pane/use-visible-terminal-worktree-claim.test.ts`
- `git diff --check`
- `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json`
- `pnpm exec oxlint src/renderer/src/lib/foreground-terminal-worktrees.ts src/renderer/src/lib/foreground-terminal-worktrees.test.ts src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/components/terminal-pane/use-visible-terminal-worktree-claim.ts src/renderer/src/components/terminal-pane/use-visible-terminal-worktree-claim.test.ts src/renderer/src/lib/agent-hibernation-coordinator.test.ts`
- Brennan's test-changes pass also reported `pnpm run typecheck` and `pnpm run lint` passing.
- Commit hook ran staged-file `oxlint`, React doctor lint, and `oxfmt`.

## Post-PR Stabilization

- Initial 8-minute wait completed after PR open.
- CodeRabbit found two actionable maintainability nitpicks requesting short rationale comments. Fixed in `Document visible terminal sleep guard`, pushed, and waited another 8 minutes.
- CodeRabbit's follow-up reported no actionable comments.
- PR checks: `verify` passed.

## Risks

- The visible claim is intentionally conservative at worktree granularity, so a visible terminal can delay sleep for hidden completed siblings in the same worktree. That is preferred over sleeping a pane the user is looking at.
