### PR TITLE
Prepare mobile iOS 0.0.16

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- Bump Orca Mobile marketing version to 0.0.16 for the next TestFlight upload

## Verification
- `node -e "const app=require('./mobile/app.json'); console.log(app.expo.version, app.expo.ios?.buildNumber, app.expo.android?.versionCode)"` -> `0.0.16 1 2`
- Previous TestFlight upload failed because Apple closed the 0.0.15 train: https://github.com/stablyai/orca/actions/runs/28081704599