### PR TITLE
fix: focus new floating-workspace agent tab on launch

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.test.tsx
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { FloatingTerminalWindowControls } from './FloatingTerminalWindowControls'
+
+type ReactElementLike = {
+  type: unknown
+  props: Record<string, unknown>
+}
+
+const storeBox = vi.hoisted(() => ({
+  state: null as unknown
+}))
+
+const mocks = vi.hoisted(() => ({
+  activateTab: vi.fn(),
+  createTab: vi.fn(),
+  setActiveTabForWorktree: vi.fn(),
+  setTabBarOrder: vi.fn(),
+  queueTabStartupCommand: vi.fn(),
+  focusTerminalTabSurface: vi.fn(),
+  buildAgentStartupPlan: vi.fn()
+}))
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    useCallback: <T,>(callback: T) => callback,
+    useMemo: <T,>(factory: () => T) => factory()
+  }
+})
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign((selector: (state: unknown) => unknown) => selector(storeBox.state), {
+    getState: () => storeBox.state
+  })
+}))
+
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: mocks.focusTerminalTabSurface
+}))
+
+vi.mock('@/lib/tui-agent-startup', () => ({
+  buildAgentStartupPlan: mocks.buildAgentStartupPlan
+}))
+
+vi.mock('@/lib/agent-catalog', () => ({
+  getAgentCatalog: () => [{ id: 'claude', label: 'Claude' }],
+  AgentIcon: function AgentIcon() {
+    return null
+  }
+}))
+
+vi.mock('@/lib/new-workspace', () => ({
+  CLIENT_PLATFORM: 'darwin'
+}))
+
+vi.mock('@/lib/telemetry', () => ({
+  tuiAgentToAgentKind: () => 'claude'
+}))
+
+vi.mock('../../../../shared/tui-agent-selection', () => ({
+  isTuiAgentEnabled: () => true
+}))
+
+vi.mock('../../../../shared/tui-agent-launch-defaults', () => ({
+  resolveTuiAgentLaunchArgs: () => [],
+  resolveTuiAgentLaunchEnv: () => ({})
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, vars?: Record<string, string>) =>
+    vars ? fallback.replace(/\{\{(\w+)\}\}/g, (_match, name: string) => vars[name] ?? '') : fallback
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useOptionalShortcutLabel: () => null
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: function Button(props: { children?: unknown }) {
+    return props.children ?? null
+  }
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: function Tooltip(props: { children?: unknown }) {
+    return props.children
+  },
+  TooltipContent: function TooltipContent(props: { children?: unknown }) {
+    return props.children
+  },
+  TooltipTrigger: function TooltipTrigger(props: { children?: unknown }) {
+    return props.children
+  }
+}))
+
+vi.mock('lucide-react', () => ({
+  Maximize2: function Maximize2() {
+    return null
+  },
+  Minimize2: function Minimize2() {
+    return null
+  },
+  Minus: function Minus() {
+    return null
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() }
+}))
+
+function visit(node: unknown, cb: (node: ReactElementLike) => void): void {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach((entry) => visit(entry, cb))
+    return
+  }
+  const element = node as ReactElementLike
+  if (!element.props) {
+    return
+  }
+  cb(element)
+  visit(element.props.children, cb)
+}
+
+function findOnClickByAriaLabel(node: unknown, ariaLabel: string): () => void {
+  let found: (() => void) | null = null
+  visit(node, (entry) => {
+    if (entry.props['aria-label'] === ariaLabel && typeof entry.props.onClick === 'function') {
+      found = entry.props.onClick as () => void
+    }
+  })
+  if (!found) {
+    throw new Error(`onClick for aria-label "${ariaLabel}" not found`)
+  }
+  return found
+}
+
+const NEW_AGENT_TAB_ID = 'floating-agent-tab'
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) {
+    mock.mockReset()
+  }
+  mocks.createTab.mockReturnValue({ id: NEW_AGENT_TAB_ID })
+  mocks.buildAgentStartupPlan.mockReturnValue({
+    launchCommand: 'claude',
+    launchConfig: {},
+    env: undefined,
+    startupCommandDelivery: undefined
+  })
+  storeBox.state = {
+    settings: {
+      defaultTuiAgent: 'claude',
+      disabledTuiAgents: [],
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {}
+    },
+    createTab: mocks.createTab,
+    activateTab: mocks.activateTab,
+    setActiveTabForWorktree: mocks.setActiveTabForWorktree,
+    setTabBarOrder: mocks.setTabBarOrder,
+    queueTabStartupCommand: mocks.queueTabStartupCommand,
+    tabsByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: [{ id: NEW_AGENT_TAB_ID }] },
+    tabBarOrderByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: [] }
+  }
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('FloatingTerminalWindowControls default-agent launch', () => {
+  it('activates the new agent tab so the floating panel selects and focuses it', () => {
+    const element = FloatingTerminalWindowControls({
+      maximized: false,
+      onToggleMaximized: vi.fn(),
+      onMinimize: vi.fn()
+    })
+
+    const launch = findOnClickByAriaLabel(element, 'Open Claude in floating workspace')
+    launch()
+
+    expect(mocks.createTab).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      undefined,
+      undefined,
+      { activate: false }
+    )
+    // Why: the floating panel renders its visible tab from the unified group's
+    // activeTabId, which only activateTab writes. Without it the new agent tab
+    // would be appended but never selected/focused.
+    expect(mocks.activateTab).toHaveBeenCalledWith(NEW_AGENT_TAB_ID)
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith(NEW_AGENT_TAB_ID)
+  })
+})

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.test.tsx
@@ -142,12 +142,19 @@ function findOnClickByAriaLabel(node: unknown, ariaLabel: string): () => void {
 }
 
 const NEW_AGENT_TAB_ID = 'floating-agent-tab'
+const EXISTING_TAB_ID = 'floating-existing-tab'
 
 beforeEach(() => {
   for (const mock of Object.values(mocks)) {
     mock.mockReset()
   }
-  mocks.createTab.mockReturnValue({ id: NEW_AGENT_TAB_ID })
+  mocks.createTab.mockImplementation(() => {
+    const tab = { id: NEW_AGENT_TAB_ID }
+    const state = storeBox.state as { tabsByWorktree: Record<string, { id: string }[]> }
+    const existing = state.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []
+    state.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] = [...existing, tab]
+    return tab
+  })
   mocks.buildAgentStartupPlan.mockReturnValue({
     launchCommand: 'claude',
     launchConfig: {},
@@ -167,8 +174,8 @@ beforeEach(() => {
     setActiveTabForWorktree: mocks.setActiveTabForWorktree,
     setTabBarOrder: mocks.setTabBarOrder,
     queueTabStartupCommand: mocks.queueTabStartupCommand,
-    tabsByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: [{ id: NEW_AGENT_TAB_ID }] },
-    tabBarOrderByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: [] }
+    tabsByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: [{ id: EXISTING_TAB_ID }] },
+    tabBarOrderByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: [EXISTING_TAB_ID] }
   }
 })
 
@@ -193,10 +200,34 @@ describe('FloatingTerminalWindowControls default-agent launch', () => {
       undefined,
       { activate: false }
     )
+    // Why: TerminalPane consumes any pending startup command on first render, so
+    // the launch command must be queued before activation can mount the surface -
+    // otherwise the new tab can come up as a bare shell.
+    expect(mocks.queueTabStartupCommand).toHaveBeenCalledWith(
+      NEW_AGENT_TAB_ID,
+      expect.objectContaining({
+        command: 'claude',
+        launchAgent: 'claude'
+      })
+    )
+    expect(mocks.queueTabStartupCommand.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.activateTab.mock.invocationCallOrder[0]
+    )
     // Why: the floating panel renders its visible tab from the unified group's
-    // activeTabId, which only activateTab writes. Without it the new agent tab
-    // would be appended but never selected/focused.
+    // activeTabId, which only activateTab writes. setActiveTabForWorktree updates
+    // the complementary legacy per-worktree map. Without activateTab the new agent
+    // tab would be appended but never selected/focused.
+    expect(mocks.setActiveTabForWorktree).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      NEW_AGENT_TAB_ID
+    )
     expect(mocks.activateTab).toHaveBeenCalledWith(NEW_AGENT_TAB_ID)
     expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith(NEW_AGENT_TAB_ID)
+    // Why: createTab appends the new tab to the worktree; the order reconciliation
+    // must keep the pre-existing tab and place the new agent tab last.
+    expect(mocks.setTabBarOrder).toHaveBeenCalledWith(FLOATING_TERMINAL_WORKTREE_ID, [
+      EXISTING_TAB_ID,
+      NEW_AGENT_TAB_ID
+    ])
   })
 })

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReactModule from 'react'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { FloatingTerminalWindowControls } from './FloatingTerminalWindowControls'
 
@@ -22,7 +23,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('react', async () => {
-  const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  const actual = await vi.importActual<typeof ReactModule>('react')
   return {
     ...actual,
     useCallback: <T,>(callback: T) => callback,

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.tsx
@@ -43,6 +43,7 @@ export function FloatingTerminalWindowControls({
   const defaultTuiAgent = useAppStore((s) => s.settings?.defaultTuiAgent ?? null)
   const createTab = useAppStore((s) => s.createTab)
   const setActiveTabForWorktree = useAppStore((s) => s.setActiveTabForWorktree)
+  const activateTab = useAppStore((s) => s.activateTab)
   const maximizeShortcutLabel = useOptionalShortcutLabel('floatingWorkspace.maximize')
   const minimizeShortcutLabel = useOptionalShortcutLabel('floatingWorkspace.minimize')
 
@@ -100,7 +101,12 @@ export function FloatingTerminalWindowControls({
         request_kind: 'new'
       }
     })
+    // Why: the floating panel renders its visible tab from the unified group's
+    // activeTabId. setActiveTabForWorktree only writes activeTabIdByWorktree, so
+    // the new agent tab would be appended but never selected/focused. activateTab
+    // selects it within the group, matching the empty-state tab creators.
     setActiveTabForWorktree(FLOATING_TERMINAL_WORKTREE_ID, tab.id)
+    activateTab(tab.id)
     const fresh = useAppStore.getState()
     const currentTabs = fresh.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []
     const stored = fresh.tabBarOrderByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []
@@ -114,7 +120,7 @@ export function FloatingTerminalWindowControls({
     order.push(tab.id)
     fresh.setTabBarOrder(FLOATING_TERMINAL_WORKTREE_ID, order)
     focusTerminalTabSurface(tab.id)
-  }, [createTab, defaultAgent, defaultAgentLabel, setActiveTabForWorktree])
+  }, [activateTab, createTab, defaultAgent, defaultAgentLabel, setActiveTabForWorktree])
 
   return (
     <div className="flex items-center gap-1 px-2" data-floating-terminal-no-drag>


### PR DESCRIPTION
## Summary

Clicking the default-agent button in the floating workspace titlebar (the icon that launches a new default coding-agent tab) created the tab but did not switch to or focus it — the floating panel stayed on the previously active tab.

Root cause: `launchDefaultAgent` created the tab with `{ activate: false }` and then only called `setActiveTabForWorktree`, which writes `activeTabIdByWorktree`. The floating panel selects its visible tab from the unified group's `activeTabId` (via `activateTab`), so the new agent tab was appended to the group but never selected or focused.

Fix: call `activateTab(tab.id)` after creating the tab, matching the floating empty-state tab creators (`createFloatingTerminalTab`). Now launching a new agent switches to and focuses its tab.

## Screenshots

Before this fix, clicking the default-agent button created the tab but the floating workspace stayed on the previously active tab. After the fix, launching a new agent switches to and focuses its tab:

![Floating workspace focuses the new agent tab on launch](https://hooks.wolfie.gg/share/floating-agent-focus-redacted.gif)

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck` (web project)
- [x] `pnpm test` (floating-terminal suite)
- [ ] `pnpm build`
- [x] Added a focused regression test (`FloatingTerminalWindowControls.test.tsx`) asserting `activateTab(tab.id)` and `focusTerminalTabSurface(tab.id)` fire on launch

Ran:
- `pnpm typecheck:web` — passes
- `oxlint` on both changed files — OK
- `vitest run src/renderer/src/components/floating-terminal/` — 92 passed

## AI Review Report

Reviewed the floating workspace tab-activation path. Confirmed the panel derives its active/visible tab from the unified group's `activeTabId` (`FloatingTerminalPanel.tsx`), set only by `activateTab`/`createTab({activate:true})`, while `setActiveTabForWorktree` updates only the per-worktree map — explaining the missing focus. Aligned the agent button with the existing empty-state creators rather than adding new focus plumbing. No cross-platform surface touched: change is renderer store/state only, no shortcuts, labels, paths, or shell behavior; macOS/Linux/Windows behave identically. The pre-existing `setTabBarOrder` block was left as-is (out of scope; the panel orders tabs from group `tabOrder`, which `createTab` already maintains).

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The diff adds a single store selector and one `activateTab` call in the renderer. No new attack surface.

## Notes

No platform-specific behavior. Follow-up (optional, not done here): the legacy `setTabBarOrder` reconciliation in `launchDefaultAgent` rebuilds order from terminal IDs only and is redundant with the group `tabOrder`; could be removed in a separate cleanup.

