### PR TITLE
feat(orchestration): add review, oracle, and handoff shortcuts

### DIFF
--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -8,7 +8,11 @@ description: >-
   terminal control, lightweight terminal prompts, shell commands, Orca worktree
   management, reading or waiting on terminals, and automation of the browser
   embedded inside Orca. Use Computer Use for browser windows, webviews, Orca app
-  UI, or desktop UI outside Orca's embedded browser.
+  UI, or desktop UI outside Orca's embedded browser. Also triggers on the compact
+  shortcuts `/orchestration review <agents>`, `/orchestration oracle <agents>`,
+  and `/orchestration handoff <agent>` for fanning out a code review, getting a
+  second opinion, or handing the current work to another agent (see Recognized
+  Shortcuts).
 ---
 
 # Orca Inter-Agent Orchestration
@@ -23,6 +27,7 @@ Use this skill when coordination state matters. For lightweight terminal prompts
 - Dispatch structured tasks to workers and wait for `worker_done` or `escalation`.
 - Track task DAGs with dependencies.
 - Run coordinator loops or decision gates.
+- Run a compact shortcut: `/orchestration review <agents>`, `/orchestration oracle <agents>`, or `/orchestration handoff <agent>` (see Recognized Shortcuts).
 
 ## Preconditions
 
@@ -30,6 +35,51 @@ Use this skill when coordination state matters. For lightweight terminal prompts
 - `orca` must be on PATH (`orca-ide` on Linux).
 - The orchestration experimental feature must be enabled in Settings > Experimental.
 - `orca orchestration` commands are RPC calls to the running Orca runtime.
+
+## Recognized Shortcuts
+
+These three verbs are an optional fast-path — a compact phrasing for orchestration moves you can already trigger with a full natural-language prompt. Natural-language orchestration still works exactly as before; the shortcuts add shorthand, they do not replace it. Each acts on the current task/branch in the active worktree, and each maps onto the lower-level commands documented later in this skill.
+
+Grammar: `/orchestration <verb> <agents>`, where `<verb>` is `review`, `oracle`, or `handoff`. `<agents>` is one or more agent names from the catalog, delimited by a comma or `and` (e.g. `/orchestration oracle cursor and claude`). Agents are always named explicitly — there is no `all agents` form. `review` and `oracle` accept one or more agents; `handoff` takes a single agent. If a named agent cannot be launched or never reports back within the wait window, surface it as unavailable/incomplete in the result — best-effort; do not hang indefinitely or silently drop it.
+
+### `review <agents>` and `oracle <agents>` — ephemeral children
+
+`review` fans out a code review of the current changes; `oracle` gets a second opinion on the decision/task at hand. Both spawn ephemeral children, collect their reports, synthesize, and tear the children down — you stay in the current session. For each named agent:
+
+```bash
+orca terminal create --worktree active --title <verb>-<agent> --command "<agent>" --json
+orca terminal wait --terminal <handle> --for tui-idle --timeout-ms 60000 --json
+orca orchestration task-create --spec "<review or oracle instruction for the current task>" --json
+orca orchestration dispatch --task <task_id> --to <handle> --inject --json
+```
+
+Collect each child's report, best-effort, with a bounded wait (one wait per dispatched child):
+
+```bash
+orca orchestration check --wait --types worker_done,escalation --timeout-ms 900000 --json
+```
+
+Consolidate every report into a single de-duped digest written back into this session — do not make the user open the child tabs. Then tear each child down (`orca terminal close` lives in `orca-cli`):
+
+```bash
+orca terminal close --terminal <handle> --json
+```
+
+- `review` instruction: review the current changes/diff and report findings only. Children are advisory and read-only — they must not edit the working tree, since all children share this worktree and edits would collide.
+- `oracle` instruction: give a second opinion on the current decision/task; consolidate the opinions and factor them into your next response.
+- Children appear under the current worktree (the existing child-spawn path); no new worktree handling is involved. Completion is best-effort: a child that does not report `worker_done` within the wait is noted as incomplete in the digest rather than waited on indefinitely. `--inject` reports `worker_done` only for recognized agent CLIs, so a named agent that is not injection-recognized may come back incomplete.
+
+### `handoff <agent>` — new persistent tab
+
+`handoff` moves the work to another agent in the same worktree. Open a new persistent tab running the named agent and seed it with a context brief. This is a full ownership transfer, so do NOT use `--inject` and do not create lifecycle obligations:
+
+```bash
+orca terminal create --worktree active --title handoff-<agent> --command "<agent>" --json
+orca terminal wait --terminal <handle> --for tui-idle --timeout-ms 60000 --json
+orca terminal send --terminal <handle> --text "<context brief>" --enter --json
+```
+
+The brief summarizes the current conversation so a fresh agent can continue the work. Do not duplicate content already captured in other artifacts (PRDs, plans, issues, commits) — reference them by path or URL instead. Unlike a worktree handoff (see Full Handoffs), this stays in the current worktree as a new tab; the user moves to that tab to continue.
 
 ## Ownership
 


### PR DESCRIPTION
## Summary

The orchestration skill now recognizes three compact shortcuts — `/orchestration review <agents>`, `/orchestration oracle <agents>`, and `/orchestration handoff <agent>` — so you can fan out a code review, pull a second opinion, or hand the current work to another agent in a few words. The underlying multi-agent coordination already supported all of this; what was missing was a turnkey shorthand, so each of these previously meant hand-writing a long custom prompt every time. Lowering that barrier is the point — more people can reach the capability without composing the prompt.

## What each verb does

- **`review` / `oracle`** spawn ephemeral child agents in the active worktree, collect their reports best-effort within a bounded wait, synthesize a single de-duped digest back into your current session, and tear the children down — you never leave your session. `review` children are read-only/advisory (they report findings, they don't touch the working tree they share); `oracle` folds the consulted opinions into the next response.
- **`handoff`** opens a new persistent tab running the named agent in the same worktree and seeds it with a context brief that references existing artifacts (PRDs, plans, issues, commits) by path/URL rather than duplicating them. It's a full ownership transfer — no `--inject`, no lifecycle obligations — so you move to that tab to continue.

## Design decisions

- **Additive and freeform-safe.** The recipes live in a new `## Recognized Shortcuts` section, and the skill `description` is appended to rather than rewritten, so natural-language orchestration triggers and behaves exactly as before. The shortcuts are a fast-path, not a replacement.
- **Named agents only.** There's no `all agents` form in v1 — the skill has no agent-enumeration primitive to resolve it, so requiring explicit names sidesteps that and keeps v1 shippable.
- **Best-effort completion.** `dispatch --inject` reports `worker_done` only for injection-recognized CLIs, so a named agent that can't be launched or doesn't report within the wait is surfaced as incomplete rather than hung on.

## Validation

Skill-prose change only — no code touched. `orchestration-skill-coverage.test.ts` passes (6/6); the frontmatter parses as valid YAML with the skill name unchanged; and the orchestration CLI surface the recipes rely on (`orchestration task-list`, `terminal list`) was confirmed reachable against a live runtime. The behavioral dogfood of the three shortcuts in a live Orca session (orchestration experimental feature enabled, real agent CLIs) is manual and has not yet been run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)

## ELI5

Orchestration gains short commands for review, second-opinion (“oracle”), and handoff so multi-agent workflows need less custom prompt writing. Same underlying orchestration, simpler triggers.
