### PR TITLE
feat(floating-terminal): tab drag-reorder + popup close-shortcut routing

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -415,7 +415,7 @@ export function setupGuestShortcutForwarding(args: {
       // renderer-owned parked webview's goForward() path directly.
       renderer.send('ui:browserHistoryNavigate', 'forward')
     } else if (keybindingMatchesAction('tab.close', input, process.platform, keybindings)) {
-      renderer.send('ui:closeActiveTab')
+      renderer.send('ui:closeActiveTab', { browserTabId })
     } else if (keybindingMatchesAction('tab.nextSameType', input, process.platform, keybindings)) {
       renderer.send('ui:switchTab', 1)
     } else if (

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1628,7 +1628,9 @@ describe('browserManager', () => {
 
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:newBrowserTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:newTerminalTab')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab', {
+      browserTabId: 'browser-1'
+    })
     expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTab', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:switchTerminalTab', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:openQuickOpen')

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2353,7 +2353,7 @@ export type PreloadApi = {
     onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void
     onZoomBrowserPage: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void
     onHardReloadBrowserPage: (callback: () => void) => () => void
-    onCloseActiveTab: (callback: () => void) => () => void
+    onCloseActiveTab: (callback: (payload?: { browserTabId?: string }) => void) => () => void
     onSwitchTab: (callback: (direction: 1 | -1) => void) => () => void
     onSwitchTabAcrossAllTypes: (callback: (direction: 1 | -1) => void) => () => void
     onSwitchRecentTab: (callback: () => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2918,8 +2918,9 @@ const api = {
       ipcRenderer.on('ui:hardReloadBrowserPage', listener)
       return () => ipcRenderer.removeListener('ui:hardReloadBrowserPage', listener)
     },
-    onCloseActiveTab: (callback: () => void): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent) => callback()
+    onCloseActiveTab: (callback: (payload?: { browserTabId?: string }) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload?: { browserTabId?: string }) =>
+        callback(payload)
       ipcRenderer.on('ui:closeActiveTab', listener)
       return () => ipcRenderer.removeListener('ui:closeActiveTab', listener)
     },

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -178,6 +178,44 @@ vi.mock('@/components/tab-bar/TabBar', () => ({
   }
 }))
 
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: function DndContext(props: { children?: unknown }) {
+    return props.children
+  },
+  DragOverlay: function DragOverlay() {
+    return null
+  }
+}))
+
+vi.mock('@/components/tab-bar/TabDragPreview', () => ({
+  default: function TabDragPreview() {
+    return null
+  }
+}))
+
+vi.mock('@/components/tab-group/tab-drag-context', () => ({
+  TabDragProvider: function TabDragProvider(props: { children?: unknown }) {
+    return props.children
+  }
+}))
+
+vi.mock('@/components/tab-group/useTabDragSplit', () => ({
+  useTabDragSplit: () => ({
+    activeDrag: null,
+    collisionDetection: vi.fn(),
+    hoveredTabInsertion: null,
+    hoveredDropTarget: null,
+    isTabDragActiveRef: { current: false },
+    onDragCancel: vi.fn(),
+    onDragEnd: vi.fn(),
+    onDragMove: vi.fn(),
+    onDragOver: vi.fn(),
+    onDragStart: vi.fn(),
+    sensors: [],
+    setDragRootNode: vi.fn()
+  })
+}))
+
 vi.mock('@/components/terminal-pane/TerminalPane', () => ({
   default: function TerminalPane() {
     return null
@@ -2362,5 +2400,23 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.closeTab).toHaveBeenCalledWith('tab-a')
     expect(mocks.closeTab).toHaveBeenCalledWith('tab-b')
     expect(mocks.closeTab).not.toHaveBeenCalledWith('tab-c')
+  })
+
+  it('wraps the tab strip in a drag context wired to the reorder engine', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-a' }), makeTab({ id: 'tab-b' })])
+
+    const element = await renderPanel(true)
+    const dndContext = findByTypeName(element, 'DndContext')
+
+    // Why: reordering is driven entirely by the shared useTabDragSplit
+    // handlers, so the context must receive real onDragEnd/sensors, and the
+    // TabBar must receive the live insertion indicator for the drop bar.
+    expect(typeof dndContext.props.onDragEnd).toBe('function')
+    expect(typeof dndContext.props.onDragStart).toBe('function')
+    expect(dndContext.props.sensors).toBeDefined()
+    expect(dndContext.props.autoScroll).toBe(false)
+
+    const tabBar = findByTypeName(element, 'TabBar')
+    expect('hoveredTabInsertion' in tabBar.props).toBe(true)
   })
 })

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -123,6 +123,33 @@ const saveDialogBox = vi.hoisted(() => ({
   fileId: null as string | null
 }))
 
+const dragSplitBox = vi.hoisted(() => {
+  const setDragRootNode = vi.fn()
+  const onDragEnd = vi.fn()
+  const onDragStart = vi.fn()
+  const onDragMove = vi.fn()
+  const onDragOver = vi.fn()
+  const onDragCancel = vi.fn()
+  const collisionDetection = vi.fn()
+  const sensors = [{ sensor: vi.fn(), options: {} }]
+  const hoveredTabInsertion = { groupId: 'group-floating', index: 0 }
+  const value = {
+    activeDrag: null as unknown,
+    collisionDetection,
+    hoveredTabInsertion,
+    hoveredDropTarget: null,
+    isTabDragActiveRef: { current: false },
+    onDragCancel,
+    onDragEnd,
+    onDragMove,
+    onDragOver,
+    onDragStart,
+    sensors,
+    setDragRootNode
+  }
+  return { hook: vi.fn(() => value), value }
+})
+
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
   return {
@@ -200,20 +227,7 @@ vi.mock('@/components/tab-group/tab-drag-context', () => ({
 }))
 
 vi.mock('@/components/tab-group/useTabDragSplit', () => ({
-  useTabDragSplit: () => ({
-    activeDrag: null,
-    collisionDetection: vi.fn(),
-    hoveredTabInsertion: null,
-    hoveredDropTarget: null,
-    isTabDragActiveRef: { current: false },
-    onDragCancel: vi.fn(),
-    onDragEnd: vi.fn(),
-    onDragMove: vi.fn(),
-    onDragOver: vi.fn(),
-    onDragStart: vi.fn(),
-    sensors: [],
-    setDragRootNode: vi.fn()
-  })
+  useTabDragSplit: dragSplitBox.hook
 }))
 
 vi.mock('@/components/terminal-pane/TerminalPane', () => ({
@@ -2057,6 +2071,76 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(panelElement.focus).not.toHaveBeenCalled()
   })
 
+  it('does not start a window drag from an SVG icon nested inside a tab', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebar = findByProp(element, 'data-floating-terminal-shortcut-surface')
+    const panelElement = { focus: vi.fn() }
+    attachRef(panel.props.ref, panelElement)
+    vi.stubGlobal('document', { activeElement: null })
+    const setPointerCapture = vi.fn()
+
+    // Why: model the real DOM hierarchy so the helper's Element normalization
+    // runs — an SVGElement is an Element, so closest() must resolve the
+    // [data-tab-id] tab root and the titlebar yields the pointer to dnd-kit.
+    class StubNode {}
+    class StubElement extends StubNode {
+      closest = vi.fn().mockReturnValue({})
+    }
+    class StubSVGElement extends StubElement {}
+    vi.stubGlobal('Node', StubNode)
+    vi.stubGlobal('Element', StubElement)
+    vi.stubGlobal('SVGElement', StubSVGElement)
+    const svgTarget = new StubSVGElement()
+
+    ;(titlebar.props.onPointerDown as (event: unknown) => void)({
+      button: 0,
+      clientX: 10,
+      clientY: 20,
+      currentTarget: { setPointerCapture },
+      pointerId: 1,
+      target: svgTarget
+    })
+
+    expect(svgTarget.closest).toHaveBeenCalledWith(expect.stringContaining('[data-tab-id]'))
+    expect(setPointerCapture).not.toHaveBeenCalled()
+  })
+
+  it('does not start a window drag from a text node inside a tab', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebar = findByProp(element, 'data-floating-terminal-shortcut-surface')
+    const panelElement = { focus: vi.fn() }
+    attachRef(panel.props.ref, panelElement)
+    vi.stubGlobal('document', { activeElement: null })
+    const setPointerCapture = vi.fn()
+
+    // Why: a text node is a Node but not an Element, so normalization must walk
+    // to parentElement before closest() can match the [data-tab-id] ancestor.
+    class StubNode {}
+    class StubElement extends StubNode {
+      closest = vi.fn().mockReturnValue({})
+    }
+    vi.stubGlobal('Node', StubNode)
+    vi.stubGlobal('Element', StubElement)
+    const parentElement = new StubElement()
+    const textTarget = Object.assign(new StubNode(), { parentElement })
+
+    ;(titlebar.props.onPointerDown as (event: unknown) => void)({
+      button: 0,
+      clientX: 10,
+      clientY: 20,
+      currentTarget: { setPointerCapture },
+      pointerId: 1,
+      target: textTarget
+    })
+
+    expect(parentElement.closest).toHaveBeenCalledWith(expect.stringContaining('[data-tab-id]'))
+    expect(setPointerCapture).not.toHaveBeenCalled()
+  })
+
   it('focuses the floating panel for titlebar shortcuts when focus starts outside it', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' })])
     const element = await renderPanel(true)
@@ -2406,17 +2490,51 @@ describe('FloatingTerminalPanel close behavior', () => {
     setFloatingTabs([makeTab({ id: 'tab-a' }), makeTab({ id: 'tab-b' })])
 
     const element = await renderPanel(true)
-    const dndContext = findByTypeName(element, 'DndContext')
+
+    // Why: the panel must key the shared reorder engine to the floating
+    // worktree and enable it while the panel is open.
+    expect(dragSplitBox.hook).toHaveBeenCalledWith({
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      enabled: true
+    })
 
     // Why: reordering is driven entirely by the shared useTabDragSplit
-    // handlers, so the context must receive real onDragEnd/sensors, and the
-    // TabBar must receive the live insertion indicator for the drop bar.
-    expect(typeof dndContext.props.onDragEnd).toBe('function')
-    expect(typeof dndContext.props.onDragStart).toBe('function')
-    expect(dndContext.props.sensors).toBeDefined()
+    // handlers, so DndContext must receive the exact references the hook
+    // returned — not re-wrapped copies that could drop drag events.
+    const dndContext = findByTypeName(element, 'DndContext')
+    expect(dndContext.props.sensors).toBe(dragSplitBox.value.sensors)
+    expect(dndContext.props.collisionDetection).toBe(dragSplitBox.value.collisionDetection)
+    expect(dndContext.props.onDragStart).toBe(dragSplitBox.value.onDragStart)
+    expect(dndContext.props.onDragMove).toBe(dragSplitBox.value.onDragMove)
+    expect(dndContext.props.onDragOver).toBe(dragSplitBox.value.onDragOver)
+    expect(dndContext.props.onDragEnd).toBe(dragSplitBox.value.onDragEnd)
+    expect(dndContext.props.onDragCancel).toBe(dragSplitBox.value.onDragCancel)
     expect(dndContext.props.autoScroll).toBe(false)
 
+    // Why: the drag root must register with the hook so webview passthrough
+    // teardown fires on unmount.
+    let dragRootRef: unknown = null
+    visit(element, (entry) => {
+      if (entry.props.ref === dragSplitBox.value.setDragRootNode) {
+        dragRootRef = entry.props.ref
+      }
+    })
+    expect(dragRootRef).toBe(dragSplitBox.value.setDragRootNode)
+
+    // Why: the drop indicator bar is driven by the hook's live insertion state,
+    // so TabBar must receive that exact object.
     const tabBar = findByTypeName(element, 'TabBar')
-    expect('hoveredTabInsertion' in tabBar.props).toBe(true)
+    expect(tabBar.props.hoveredTabInsertion).toBe(dragSplitBox.value.hoveredTabInsertion)
+  })
+
+  it('disables drag activation when the panel is closed', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-a' })])
+
+    await renderPanel(false)
+
+    expect(dragSplitBox.hook).toHaveBeenCalledWith({
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      enabled: false
+    })
   })
 })

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -1487,6 +1487,47 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.createTab).not.toHaveBeenCalled()
   })
 
+  it('restores floating panel focus after returning from another app', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const activeElement = { blur: vi.fn() }
+    const panelElement = {
+      contains: vi.fn((node: unknown) => node === activeElement),
+      focus: vi.fn()
+    }
+    const outsideElement = {}
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+    Object.setPrototypeOf(outsideElement, HTMLElement.prototype)
+    attachRef(panel.props.ref, panelElement)
+    const documentStub = {
+      activeElement,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+    vi.stubGlobal('document', documentStub)
+    runEffects()
+    panelElement.focus.mockClear()
+    const blurListeners = vi
+      .mocked(window.addEventListener)
+      .mock.calls.filter(([type]) => type === 'blur')
+      .map(([, listener]) => listener as () => void)
+    const focusListener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([type]) => type === 'focus')?.[1] as (() => void) | undefined
+    const blurListener = blurListeners.at(-1)
+    if (!blurListener || !focusListener) {
+      throw new Error('window focus listeners not registered')
+    }
+
+    blurListener()
+    documentStub.activeElement = outsideElement as never
+    focusListener()
+
+    expect(activeElement.blur).toHaveBeenCalledWith()
+    expect(panelElement.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
   it('routes focused floating tab switch shortcuts to the floating workspace', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' }), makeTab({ id: 'tab-2' })])
     const element = await renderPanel(true)

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -260,6 +260,7 @@ export function FloatingTerminalPanel({
   const pendingEditorCloseQueueRef = useRef<string[]>([])
   const saveDialogFileIdRef = useRef<string | null>(null)
   const panelRef = useRef<HTMLDivElement | null>(null)
+  const shouldRestorePanelFocusAfterWindowFocusRef = useRef(false)
   const doubleTapDetectorRef = useRef<ModifierDoubleTapDetector | null>(null)
   if (!doubleTapDetectorRef.current) {
     doubleTapDetectorRef.current = new ModifierDoubleTapDetector()
@@ -1404,6 +1405,7 @@ export function FloatingTerminalPanel({
 
   useEffect(() => {
     if (!open || typeof document === 'undefined') {
+      shouldRestorePanelFocusAfterWindowFocusRef.current = false
       return
     }
 
@@ -1424,21 +1426,41 @@ export function FloatingTerminalPanel({
       const panel = panelRef.current
       const active = document.activeElement
       if (!panel || !(active instanceof HTMLElement) || !panel.contains(active)) {
+        shouldRestorePanelFocusAfterWindowFocusRef.current = false
         return
       }
+      shouldRestorePanelFocusAfterWindowFocusRef.current = true
       // Why: browser webviews focus out-of-process and do not emit renderer
       // pointerdown events, so release floating ownership on renderer blur too.
       setFloatingTerminalInputFocusedInMain(false)
       active.blur()
     }
+    const handleWindowFocus = (): void => {
+      if (!shouldRestorePanelFocusAfterWindowFocusRef.current) {
+        return
+      }
+      shouldRestorePanelFocusAfterWindowFocusRef.current = false
+      const panel = panelRef.current
+      const active = document.activeElement
+      if (!panel || (active instanceof HTMLElement && panel.contains(active))) {
+        return
+      }
+      // Why: macOS app switching can blur the floating panel without a click.
+      // Restore panel ownership so Cmd/Ctrl+W cannot fall through to main tabs.
+      focusPanelForShortcuts(false)
+    }
 
     document.addEventListener('pointerdown', handleOutsidePointerDown, true)
     window.addEventListener('blur', handleWindowBlur)
+    window.addEventListener('focus', handleWindowFocus)
     return () => {
+      shouldRestorePanelFocusAfterWindowFocusRef.current = false
       document.removeEventListener('pointerdown', handleOutsidePointerDown, true)
       window.removeEventListener('blur', handleWindowBlur)
+      window.removeEventListener('focus', handleWindowFocus)
     }
-  }, [open])
+  }, [focusPanelForShortcuts, open])
+
   const handleDragStart = (event: React.PointerEvent<HTMLDivElement>): void => {
     if (maximized) {
       return

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -138,8 +138,27 @@ type FloatingTerminalPanelBoundsState = {
   source: FloatingTerminalPanelBoundsSource
 }
 
+function resolveDragTargetElement(target: EventTarget): Element | null {
+  // Why: pointer targets can be SVG icons or text nodes nested inside a tab
+  // root, neither of which is an HTMLElement. Normalize any Node to its nearest
+  // Element (text nodes via parentElement) so closest() can match a
+  // [data-tab-id] ancestor. typeof guards keep this safe in non-DOM contexts.
+  if (typeof Element !== 'undefined' && target instanceof Element) {
+    return target
+  }
+  if (typeof Node !== 'undefined' && target instanceof Node) {
+    return target.parentElement
+  }
+  // Fallback for hosts/targets that duck-type the DOM (e.g. test doubles).
+  const candidate = target as { closest?: unknown; parentElement?: Element | null }
+  if (typeof candidate.closest === 'function') {
+    return candidate as unknown as Element
+  }
+  return candidate.parentElement ?? null
+}
+
 function isFloatingTerminalDragTarget(target: EventTarget): boolean {
-  return !(target instanceof HTMLElement && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
+  return !resolveDragTargetElement(target)?.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR)
 }
 
 function readInitialPanelBounds(): FloatingTerminalPanelBoundsState {
@@ -275,8 +294,9 @@ export function FloatingTerminalPanel({
   // Why: reuse the workspace tab drag/reorder engine so floating tabs reorder
   // identically. The floating worktree renders no split-pane layout, so the
   // hook's split-target resolution naturally returns null (no panel geometry)
-  // and only the same-group reorder path runs. enabled is gated on `open` so
-  // the hidden panel registers no document-level pointer sensors.
+  // and only the same-group reorder path runs. enabled is gated on `open` so a
+  // hidden panel's pointer sensor uses an impossible activation distance,
+  // preventing drag activation while hidden.
   const dragSplit = useTabDragSplit({ worktreeId: FLOATING_TERMINAL_WORKTREE_ID, enabled: open })
   const groupTabs = useMemo(
     () => (activeGroup ? unifiedTabs.filter((tab) => tab.groupId === activeGroup.id) : unifiedTabs),

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -10,7 +10,11 @@ import BrowserPane from '@/components/browser-pane/BrowserPane'
 import EmulatorPane from '@/components/emulator-pane/EmulatorPane'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { useContextualTour } from '@/components/contextual-tours/use-contextual-tour'
+import { DndContext, DragOverlay } from '@dnd-kit/core'
 import TabBar from '@/components/tab-bar/TabBar'
+import TabDragPreview from '@/components/tab-bar/TabDragPreview'
+import { TabDragProvider } from '@/components/tab-group/tab-drag-context'
+import { useTabDragSplit } from '@/components/tab-group/useTabDragSplit'
 import { resolveGroupTabFromVisibleId } from '@/components/tab-group/tab-group-visible-id'
 import TerminalPane from '@/components/terminal-pane/TerminalPane'
 import { Button } from '@/components/ui/button'
@@ -121,8 +125,11 @@ type FloatingPanelShortcutInput = Partial<
 > &
   Pick<KeyboardEvent, 'target'> & { doubleTapModifier?: PhysicalModifierToken }
 
+// Why: every tab strip root (terminal/browser/markdown) carries data-tab-id.
+// Excluding it from the titlebar drag region lets dnd-kit own the pointer for
+// tab reordering instead of starting a floating-window move.
 const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
-  'button,input,textarea,select,[role="menuitem"],[data-testid="sortable-tab"],[data-floating-terminal-no-drag]'
+  'button,input,textarea,select,[role="menuitem"],[data-tab-id],[data-testid="sortable-tab"],[data-floating-terminal-no-drag]'
 const FLOATING_TERMINAL_SHORTCUT_SURFACE_SELECTOR = '[data-floating-terminal-shortcut-surface]'
 
 type FloatingTerminalPanelBoundsState = {
@@ -265,6 +272,12 @@ export function FloatingTerminalPanel({
         : null),
     [groups, unifiedTabs]
   )
+  // Why: reuse the workspace tab drag/reorder engine so floating tabs reorder
+  // identically. The floating worktree renders no split-pane layout, so the
+  // hook's split-target resolution naturally returns null (no panel geometry)
+  // and only the same-group reorder path runs. enabled is gated on `open` so
+  // the hidden panel registers no document-level pointer sensors.
+  const dragSplit = useTabDragSplit({ worktreeId: FLOATING_TERMINAL_WORKTREE_ID, enabled: open })
   const groupTabs = useMemo(
     () => (activeGroup ? unifiedTabs.filter((tab) => tab.groupId === activeGroup.id) : unifiedTabs),
     [activeGroup, unifiedTabs]
@@ -1513,68 +1526,95 @@ export function FloatingTerminalPanel({
           onPointerCancel={handleDragEnd}
           onDoubleClick={handleTitlebarDoubleClick}
         >
-          <div className="flex h-full min-w-0 flex-1">
-            <TabBar
-              tabs={terminalItems}
-              activeTabId={activeTerminalId}
-              worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
-              expandedPaneByTabId={expandedPaneByTabId}
-              onActivate={activateFloatingItem}
-              onClose={closeFloatingItem}
-              onCloseOthers={closeOthers}
-              onCloseToRight={closeToRight}
-              onNewTerminalTab={() => createFloatingTerminalTab()}
-              onNewTerminalWithShell={createFloatingTerminalTab}
-              onNewBrowserTab={createFloatingBrowserTab}
-              onNewFileTab={createFloatingMarkdownTab}
-              onOpenFileTab={openFloatingMarkdownTab}
-              newTabMenuOrder="markdown-first"
-              onSetCustomTitle={setTabCustomTitle}
-              onSetTabColor={setTabColor}
-              onTogglePaneExpand={(tabId) =>
-                setTabPaneExpanded(tabId, expandedPaneByTabId[tabId] !== true)
-              }
-              editorFiles={editorItems}
-              browserTabs={browserItems}
-              activeFileId={activeEditorUnifiedId}
-              activeBrowserTabId={activeBrowserId}
-              activeSimulatorTabId={activeTab?.contentType === 'simulator' ? activeTab.id : null}
-              activeTabType={activeTabType}
-              onActivateFile={activateFloatingItem}
-              onCloseFile={closeFloatingItem}
-              onActivateBrowserTab={activateFloatingItem}
-              onCloseBrowserTab={closeFloatingItem}
-              onDuplicateBrowserTab={(browserTabId) => {
-                void (async () => {
-                  const source = browserTabs.find((tab) => tab.id === browserTabId)
-                  if (!source) {
-                    return
+          <TabDragProvider
+            isTabDragActive={dragSplit.activeDrag !== null}
+            isTabDragActiveRef={dragSplit.isTabDragActiveRef}
+          >
+            <DndContext
+              sensors={dragSplit.sensors}
+              collisionDetection={dragSplit.collisionDetection}
+              onDragStart={dragSplit.onDragStart}
+              onDragMove={dragSplit.onDragMove}
+              onDragOver={dragSplit.onDragOver}
+              onDragEnd={dragSplit.onDragEnd}
+              onDragCancel={dragSplit.onDragCancel}
+              // Why: the strip fits the panel width, so dnd-kit edge autoscroll
+              // is unnecessary and would fight the reorder. Matches the main
+              // workspace layout (see TabGroupSplitLayout).
+              autoScroll={false}
+            >
+              <div ref={dragSplit.setDragRootNode} className="flex h-full min-w-0 flex-1">
+                <TabBar
+                  tabs={terminalItems}
+                  activeTabId={activeTerminalId}
+                  worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
+                  expandedPaneByTabId={expandedPaneByTabId}
+                  onActivate={activateFloatingItem}
+                  onClose={closeFloatingItem}
+                  onCloseOthers={closeOthers}
+                  onCloseToRight={closeToRight}
+                  onNewTerminalTab={() => createFloatingTerminalTab()}
+                  onNewTerminalWithShell={createFloatingTerminalTab}
+                  onNewBrowserTab={createFloatingBrowserTab}
+                  onNewFileTab={createFloatingMarkdownTab}
+                  onOpenFileTab={openFloatingMarkdownTab}
+                  newTabMenuOrder="markdown-first"
+                  onSetCustomTitle={setTabCustomTitle}
+                  onSetTabColor={setTabColor}
+                  onTogglePaneExpand={(tabId) =>
+                    setTabPaneExpanded(tabId, expandedPaneByTabId[tabId] !== true)
                   }
-                  if (
-                    await createWebRuntimeSessionBrowserTab({
-                      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
-                      url: source.url,
-                      profileId: source.sessionProfileId,
-                      targetGroupId: activeGroup?.id,
-                      selectWorktree: false
-                    })
-                  ) {
-                    return
+                  editorFiles={editorItems}
+                  browserTabs={browserItems}
+                  activeFileId={activeEditorUnifiedId}
+                  activeBrowserTabId={activeBrowserId}
+                  activeSimulatorTabId={
+                    activeTab?.contentType === 'simulator' ? activeTab.id : null
                   }
-                  createBrowserTab(FLOATING_TERMINAL_WORKTREE_ID, source.url, {
-                    title: source.title,
-                    sessionProfileId: source.sessionProfileId,
-                    targetGroupId: activeGroup?.id
-                  })
-                })()
-              }}
-              onCloseAllFiles={closeAllFiles}
-              onMakePreviewFilePermanent={makePreviewFilePermanent}
-              onPinFile={pinFile}
-              tabBarOrder={tabBarOrder}
-              tabStripChrome="floating-panel"
-            />
-          </div>
+                  activeTabType={activeTabType}
+                  onActivateFile={activateFloatingItem}
+                  onCloseFile={closeFloatingItem}
+                  onActivateBrowserTab={activateFloatingItem}
+                  onCloseBrowserTab={closeFloatingItem}
+                  onDuplicateBrowserTab={(browserTabId) => {
+                    void (async () => {
+                      const source = browserTabs.find((tab) => tab.id === browserTabId)
+                      if (!source) {
+                        return
+                      }
+                      if (
+                        await createWebRuntimeSessionBrowserTab({
+                          worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+                          url: source.url,
+                          profileId: source.sessionProfileId,
+                          targetGroupId: activeGroup?.id,
+                          selectWorktree: false
+                        })
+                      ) {
+                        return
+                      }
+                      createBrowserTab(FLOATING_TERMINAL_WORKTREE_ID, source.url, {
+                        title: source.title,
+                        sessionProfileId: source.sessionProfileId,
+                        targetGroupId: activeGroup?.id
+                      })
+                    })()
+                  }}
+                  onCloseAllFiles={closeAllFiles}
+                  onMakePreviewFilePermanent={makePreviewFilePermanent}
+                  onPinFile={pinFile}
+                  tabBarOrder={tabBarOrder}
+                  tabStripChrome="floating-panel"
+                  hoveredTabInsertion={dragSplit.hoveredTabInsertion}
+                />
+              </div>
+              {/* Why: ghost that tracks the cursor across the panel while the
+                  source tab stays anchored in the strip (overflow-hidden). */}
+              <DragOverlay dropAnimation={null}>
+                {dragSplit.activeDrag ? <TabDragPreview drag={dragSplit.activeDrag} /> : null}
+              </DragOverlay>
+            </DndContext>
+          </TabDragProvider>
           <FloatingTerminalWindowControls
             maximized={maximized}
             onToggleMaximized={toggleMaximized}

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '../../store'
 import type { Tab } from '../../../../shared/types'
 import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 
 const WT = 'wt-1'
 
@@ -113,6 +114,62 @@ describe('tab-move-to-pane-column', () => {
     expect(
       moveTabToNewPaneColumn({ unifiedTabId: 'tab-b', groupId: 'group-1', direction: 'right' })
     ).toBe(false)
+    expect(mocks.mirrorWebRuntimeTabMove).not.toHaveBeenCalled()
+  })
+
+  it('blocks moving a floating-terminal tab to a split it never renders', () => {
+    const dropUnifiedTab = vi.fn(() => true)
+    useAppStore.setState({
+      groupsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [
+          {
+            id: 'floating-group',
+            worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+            activeTabId: 'float-a',
+            tabOrder: ['float-a', 'float-b']
+          }
+        ]
+      },
+      unifiedTabsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [
+          {
+            id: 'float-a',
+            groupId: 'floating-group',
+            worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+            contentType: 'terminal',
+            entityId: 'term-fa',
+            label: 'A',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 0
+          } satisfies Tab,
+          {
+            id: 'float-b',
+            groupId: 'floating-group',
+            worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+            contentType: 'terminal',
+            entityId: 'term-fb',
+            label: 'B',
+            customLabel: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 1
+          } satisfies Tab
+        ]
+      },
+      dropUnifiedTab
+    } as Partial<ReturnType<typeof useAppStore.getState>>)
+
+    expect(canMoveTabToNewPaneColumn('float-b', 'floating-group')).toBe(false)
+    expect(
+      moveTabToNewPaneColumn({
+        unifiedTabId: 'float-b',
+        groupId: 'floating-group',
+        direction: 'right'
+      })
+    ).toBe(false)
+    expect(dropUnifiedTab).not.toHaveBeenCalled()
     expect(mocks.mirrorWebRuntimeTabMove).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from '../../store'
 import type { TabSplitDirection } from '../../store/slices/tabs'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { mirrorWebRuntimeTabMove } from './web-runtime-tab-move-mirror'
 
 type TabMovePaneColumnState = Pick<
@@ -16,6 +17,12 @@ export function canMoveTabToNewPaneColumnFromState(
     const tab = tabs.find((candidate) => candidate.id === unifiedTabId)
     if (!tab || tab.groupId !== groupId) {
       continue
+    }
+    // Why: the floating panel renders a single group with no split layout, so
+    // moving a tab into a new pane column would orphan it into a group the
+    // surface never paints. Block the affordance for that worktree.
+    if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+      return false
     }
     const group = (state.groupsByWorktree[worktreeId] ?? []).find(
       (candidate) => candidate.id === groupId

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -158,9 +158,9 @@ export function useTabDragSplit({
   enabled = true
 }: {
   worktreeId: string
-  /** When false (e.g. for hidden worktrees), returns empty sensors so no
-   *  DndContext pointer listeners are registered on the document. Multiple
-   *  simultaneous DndContext instances with active sensors can interfere. */
+  /** When false (e.g. for hidden worktrees), the pointer sensor uses an
+   *  impossible activation distance so drags never activate while the surface
+   *  is hidden, without changing the sensors array length between renders. */
   enabled?: boolean
 }): {
   activeDrag: TabDragItemData | null

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2202,7 +2202,7 @@ describe('useIpcEvents browser tab close routing', () => {
     tabId: string | null
     worktreeId?: string
   }) => void
-  type CloseActiveTabListener = () => void
+  type CloseActiveTabListener = (payload?: { browserTabId?: string }) => void
   type CloseTerminalListener = (data: { tabId: string; paneRuntimeId?: number | null }) => void
   type CloseSessionTabListener = (data: { tabId: string; worktreeId: string }) => void
 
@@ -2528,6 +2528,29 @@ describe('useIpcEvents browser tab close routing', () => {
     onConfirm()
 
     expect(closeBrowserTab).toHaveBeenCalledWith('workspace-1')
+  })
+
+  it('closes the browser tab that emitted a guest Cmd+W event', async () => {
+    const closeActiveTabListenerRef: { current: CloseActiveTabListener | null } = { current: null }
+    const closeBrowserTab = vi.fn()
+
+    await useIpcEventsForCloseRouting({
+      closeActiveTabListenerRef,
+      getState: () => ({
+        activeBrowserTabId: 'main-browser',
+        browserTabsByWorktree: {
+          'wt-1': [{ id: 'main-browser' }],
+          floating: [{ id: 'floating-browser' }]
+        },
+        closeBrowserTab,
+        unifiedTabsByWorktree: {}
+      })
+    })
+
+    closeActiveTabListenerRef.current?.({ browserTabId: 'floating-browser' })
+
+    expect(closeBrowserTab).toHaveBeenCalledWith('floating-browser')
+    expect(closeBrowserTab).not.toHaveBeenCalledWith('main-browser')
   })
 
   it('confirms CLI workspace browser closes and replies after confirmation', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2340,7 +2340,7 @@ export function useIpcEvents(): void {
         const store = useAppStore.getState()
         const payloadBrowserTabId =
           payload && typeof payload.browserTabId === 'string' ? payload.browserTabId : null
-        const tabId =
+        let tabId =
           payloadBrowserTabId ??
           (store.activeTabType === 'browser' && store.activeBrowserTabId
             ? store.activeBrowserTabId
@@ -2348,9 +2348,26 @@ export function useIpcEvents(): void {
         if (!tabId) {
           return
         }
-        const worktreeId = payloadBrowserTabId
+        let worktreeId = payloadBrowserTabId
           ? findBrowserTabWorktreeId(store, payloadBrowserTabId)
           : store.activeWorktreeId
+        // Why: the incoming browserTabId may be a browser page id rather than a
+        // workspace tab id. Mirror onRequestTabClose by resolving the page id to
+        // its owning workspace tab via browserPagesByWorkspace before closing,
+        // otherwise findBrowserTabWorktreeId yields no match and we silently no-op.
+        if (payloadBrowserTabId && !worktreeId) {
+          const owningWorkspaceId =
+            Object.entries(store.browserPagesByWorkspace).find(([, pages]) =>
+              pages.some((p) => p.id === payloadBrowserTabId)
+            )?.[0] ?? null
+          if (owningWorkspaceId) {
+            const owningWorktreeId = findBrowserTabWorktreeId(store, owningWorkspaceId)
+            if (owningWorktreeId) {
+              tabId = owningWorkspaceId
+              worktreeId = owningWorktreeId
+            }
+          }
+        }
         if (!worktreeId) {
           return
         }

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -171,6 +171,16 @@ function findBrowserPageWorktreeId(store: AppState, browserPageId: string): stri
   return null
 }
 
+function findBrowserTabWorktreeId(store: AppState, browserTabId: string): string | null {
+  for (const [worktreeId, browserTabs] of Object.entries(store.browserTabsByWorktree)) {
+    if (browserTabs.some((tab) => tab.id === browserTabId)) {
+      return worktreeId
+    }
+  }
+
+  return null
+}
+
 function acquireBrowserAutomationBootstrapLease(
   worktreeId: string | null | undefined,
   browserPageId?: string | null
@@ -2322,42 +2332,54 @@ export function useIpcEvents(): void {
     )
 
     unsubs.push(
-      window.api.ui.onCloseActiveTab(() => {
+      window.api.ui.onCloseActiveTab((payload) => {
         if (isEmptyFloatingWorkspacePanelVisible()) {
           window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
           return
         }
         const store = useAppStore.getState()
-        if (store.activeTabType === 'browser' && store.activeBrowserTabId) {
-          const tabId = store.activeBrowserTabId
-          const worktreeId = store.activeWorktreeId
-          const closeActiveBrowserTab = (): void => {
-            const currentStore = useAppStore.getState()
-            const environmentId = getWorktreeRuntimeEnvironmentId(worktreeId)
-            if (environmentId && worktreeId) {
-              if (!isWebRuntimeSessionActive(environmentId)) {
-                currentStore.closeBrowserTab(tabId)
-                return
-              }
-              void closeWebRuntimeSessionTab({
-                worktreeId,
-                tabId,
-                environmentId
-              })
+        const payloadBrowserTabId =
+          payload && typeof payload.browserTabId === 'string' ? payload.browserTabId : null
+        const tabId =
+          payloadBrowserTabId ??
+          (store.activeTabType === 'browser' && store.activeBrowserTabId
+            ? store.activeBrowserTabId
+            : null)
+        if (!tabId) {
+          return
+        }
+        const worktreeId = payloadBrowserTabId
+          ? findBrowserTabWorktreeId(store, payloadBrowserTabId)
+          : store.activeWorktreeId
+        if (!worktreeId) {
+          return
+        }
+        const closeBrowserTab = (): void => {
+          const currentStore = useAppStore.getState()
+          const environmentId = getWorktreeRuntimeEnvironmentId(worktreeId)
+          if (environmentId) {
+            if (!isWebRuntimeSessionActive(environmentId)) {
+              currentStore.closeBrowserTab(tabId)
               return
             }
-            currentStore.closeBrowserTab(tabId)
-          }
-          if (worktreeId && isPinnedSessionTab(store, worktreeId, tabId)) {
-            guardPinnedTabClose({
-              isPinned: true,
-              tabLabel: resolvePinnedTabLabel(store, worktreeId, tabId),
-              onClose: closeActiveBrowserTab
+            void closeWebRuntimeSessionTab({
+              worktreeId,
+              tabId,
+              environmentId
             })
             return
           }
-          closeActiveBrowserTab()
+          currentStore.closeBrowserTab(tabId)
         }
+        if (isPinnedSessionTab(store, worktreeId, tabId)) {
+          guardPinnedTabClose({
+            isPinned: true,
+            tabLabel: resolvePinnedTabLabel(store, worktreeId, tabId),
+            onClose: closeBrowserTab
+          })
+          return
+        }
+        closeBrowserTab()
       })
     )
 

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -1274,6 +1274,41 @@ describe('TabsSlice', () => {
         store.getState().unifiedTabsByWorktree[WT].find((tab) => tab.id === right.id)?.groupId
       ).toBe(rightGroupId)
     })
+
+    it('rejects a split drop for the floating worktree without mutating groups or layout', () => {
+      const first = store.getState().createUnifiedTab(FLOATING_TERMINAL_WORKTREE_ID, 'terminal', {
+        id: 'floating-a',
+        label: 'A'
+      })
+      const second = store.getState().createUnifiedTab(FLOATING_TERMINAL_WORKTREE_ID, 'terminal', {
+        id: 'floating-b',
+        label: 'B'
+      })
+      const groupId = store.getState().groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID][0].id
+      const layoutBefore = store.getState().layoutByWorktree[FLOATING_TERMINAL_WORKTREE_ID]
+
+      const moved = store.getState().dropUnifiedTab(second.id, {
+        groupId,
+        splitDirection: 'right'
+      })
+
+      expect(moved).toBe(false)
+      const state = store.getState()
+      // Why: the floating surface paints a single group, so no new group or
+      // split layout may be created and the tab must stay where it was.
+      expect(state.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID]).toHaveLength(1)
+      expect(state.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID][0].id).toBe(groupId)
+      expect(state.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID][0].tabOrder).toEqual([
+        first.id,
+        second.id
+      ])
+      expect(
+        state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID].find(
+          (tab) => tab.id === second.id
+        )?.groupId
+      ).toBe(groupId)
+      expect(state.layoutByWorktree[FLOATING_TERMINAL_WORKTREE_ID]).toEqual(layoutBefore)
+    })
   })
 
   // ─── setTabLabel / setTabCustomLabel / setUnifiedTabColor ─────────

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -1499,6 +1499,12 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       }
 
       const isSplitDrop = Boolean(target.splitDirection)
+      // Why: the floating panel renders a single group with no split layout, so
+      // a split drop would create a group/layout the surface never paints,
+      // orphaning the tab. Reject it at the store boundary before any mutation.
+      if (isSplitDrop && worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+        return {}
+      }
       if (!isSplitDrop && tab.groupId === target.groupId) {
         return {}
       }


### PR DESCRIPTION
## Summary

Adds floating-terminal tab drag reorder and routes popup close shortcuts back to the originating tab.

- Wraps the floating tab strip in the shared tab drag provider so reordering uses the existing tab-order model.
- Broadens titlebar no-drag handling so tab drags reorder tabs instead of moving the floating window.
- Blocks tab-to-pane-column moves for the floating worktree to avoid orphaning a tab into a split group the floating panel does not render.
- Routes popup close shortcuts back to the owning tab so close accelerators close the correct tab.

## Screenshots

Pending visual recording. This PR changes floating-terminal tab drag behavior and popup close routing, so it should stay draft unless maintainers decide the consolidated #6469 path supersedes it.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test -- FloatingTerminalPanel`
- [x] `pnpm test -- tab-bar tab-group store`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the scope for cross-platform shortcut routing, floating-window drag behavior, tab-state reuse, and remote/local terminal consistency. Main risks checked: close accelerators firing in popup guests, drag gestures moving the window instead of tabs, and split-target actions creating state the floating panel cannot render. The implementation keeps reorder state in the existing tab model and gates unsupported pane-column moves for the floating worktree.

## Security Audit

No new command execution, auth, secret, or dependency surface. IPC changes carry the originating browser tab id for close routing and do not grant additional renderer privileges. Path handling is limited to existing tab/worktree identifiers.

## Notes

- Functionally superseded by the consolidated tab model in #6469. If maintainers prefer #6469, this PR can be closed.
- The popup close-shortcut routing was folded from #6322, which is closed.
