### PR TITLE
Clear worktree session state when its metadata is removed

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -7794,6 +7794,44 @@ describe('Store', () => {
     expect(store.getWorktreeMeta('b')).toBeDefined()
   })
 
+  it('removeWorktreeMeta clears the removed worktree session state across host partitions', async () => {
+    const store = await createStore()
+    const removedId = 'r1::/path/gone'
+    const keptId = 'r1::/path/kept'
+    store.setWorktreeMeta(removedId, { displayName: 'Gone' })
+    // Worktree activation stores the canonical workspace key in activeWorkspaceKey
+    // but the raw worktree id everywhere else (store/slices/worktrees.ts) — the
+    // mix a prefixed-key-only cleanup would miss.
+    const removedTab = makeTerminalTab({ id: 'gone-tab', worktreeId: removedId })
+    const keptTab = makeTerminalTab({ id: 'kept-tab', worktreeId: keptId })
+    const makeSession = (): WorkspaceSessionState => ({
+      ...getDefaultWorkspaceSession(),
+      activeWorkspaceKey: worktreeWorkspaceKey(removedId),
+      activeWorktreeId: removedId,
+      activeTabId: removedTab.id,
+      tabsByWorktree: { [removedId]: [removedTab], [keptId]: [keptTab] },
+      activeWorktreeIdsOnShutdown: [removedId, keptId]
+    })
+    store.setWorkspaceSession(makeSession())
+    // Runtime-host worktrees persist in a per-host partition, not the local one.
+    store.setWorkspaceSession(makeSession(), 'runtime:env-a')
+
+    store.removeWorktreeMeta(removedId)
+
+    for (const hostId of [undefined, 'runtime:env-a']) {
+      const session = store.getWorkspaceSession(hostId)
+      // Why: any of these left dangling makes startup restore reopen a deleted
+      // worktree and spawn a terminal at a path that no longer exists.
+      expect(session.activeWorkspaceKey).toBeNull()
+      expect(session.activeWorktreeId).toBeNull()
+      expect(session.activeTabId).toBeNull()
+      expect(session.tabsByWorktree[removedId]).toBeUndefined()
+      expect(session.activeWorktreeIdsOnShutdown).toEqual([keptId])
+      // Scoped only: an unrelated worktree's session state must survive.
+      expect(session.tabsByWorktree[keptId]).toHaveLength(1)
+    }
+  })
+
   it('stores and removes worktree lineage independently from metadata', async () => {
     const store = await createStore()
     const lineage = makeWorktreeLineage()

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -4248,6 +4248,26 @@ export class Store {
     delete this.state.worktreeMeta[worktreeId]
     delete this.state.worktreeLineageById[worktreeId]
     delete this.state.workspaceLineageByChildKey[worktreeWorkspaceKey(worktreeId)]
+    // Why: drop the removed worktree's scoped session state, or startup restore
+    // re-spawns a terminal in the deleted worktree's gone directory. Worktree
+    // session state is split across two key forms — the canonical workspace key
+    // (activeWorkspaceKey) and the raw worktree id (activeWorktreeId,
+    // tabsByWorktree, shutdown ids) — and lives in every host partition, so clear
+    // both keys across the local and per-host sessions (cf. migrateWorktreeIdentity).
+    const dropWorktreeOwners = (
+      session: WorkspaceSessionState | undefined
+    ): WorkspaceSessionState =>
+      removeWorkspaceSessionOwner(
+        removeWorkspaceSessionOwner(session, worktreeWorkspaceKey(worktreeId)),
+        worktreeId
+      )!
+    this.state.workspaceSession = dropWorktreeOwners(this.state.workspaceSession)
+    const sessionsByHost = this.state.workspaceSessionsByHostId
+    if (sessionsByHost) {
+      for (const hostId of Object.keys(sessionsByHost)) {
+        sessionsByHost[hostId] = dropWorktreeOwners(sessionsByHost[hostId])
+      }
+    }
     this.scheduleSave()
   }
 


### PR DESCRIPTION
## Summary

Deleting a worktree left dangling session state behind, so the next app launch tried to restore a workspace that no longer existed and spawned a terminal in the deleted worktree's directory — surfacing:

> Working directory "<path>" does not exist. It may have been deleted or is on an unmounted volume.

Root cause: every worktree/repo removal routes through `Store.removeWorktreeMeta()`, which deleted `worktreeMeta` / `worktreeLineageById` / `workspaceLineageByChildKey` but never touched `workspaceSession`. The only function that clears session ownership — `removeWorkspaceSessionOwner()` — was wired into folder-workspace and project-group deletion, but never into worktree removal. The leftover `activeWorkspaceKey` (and the worktree's tabs/layouts/shutdown PTY ids) then drove session restore on next launch.

The fix calls `removeWorkspaceSessionOwner()` from `removeWorktreeMeta()`. Two details matter:

- **Two key forms.** Worktree session state is split: `activeWorkspaceKey` uses the canonical `worktree:<id>` key, while `activeWorktreeId`, `tabsByWorktree` keys, and `activeWorktreeIdsOnShutdown` use the **raw** worktree id. The cleanup clears both forms.
- **Per-host partitions.** Runtime-host worktrees persist in `workspaceSessionsByHostId[hostId]`, not the local session. The cleanup is applied across the local session and every host partition, mirroring `migrateWorktreeIdentity`.

Cleanup is scoped to the removed worktree only — unrelated worktrees keep their session state.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — oxlint + oxfmt clean on the changed files via husky pre-commit; full-repo lint not run (pre-existing unrelated drift)
- [x] `pnpm typecheck` — 3 tsgo passes, clean
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence.test.ts` — 310 passed, including a new regression test
- [ ] `pnpm build` — not run locally; relying on CI
- [x] Added a regression test that fails without the fix and passes with it

Regression-guard proof: with the fix reverted, the new test fails with `expected 'r1::/path/gone' to be null` (the raw `activeWorktreeId` that a prefixed-key-only cleanup would miss); with the fix it passes. The test exercises both the local session and a `runtime:env-a` host partition, and asserts an unrelated worktree's state survives.

## AI Review Report

Reviewed with Codex (GPT-5.5) in an adversarial pass. It initially returned **CHANGES-NEEDED**, flagging a blocker: an earlier version of the fix cleared only the canonical `activeWorkspaceKey`, leaving the raw-keyed `activeWorktreeId` / `tabsByWorktree` / `activeWorktreeIdsOnShutdown` / sleeping-agent records dangling — which would still drive a startup re-spawn. The fix was upgraded to clear both key forms across local + per-host partitions, and the test was rewritten to use realistic raw keys (the earlier test used prefixed keys and gave false confidence). Re-review returned **SHIP** with no outstanding findings.

Explicit checks:
- **Cross-platform (macOS/Linux/Windows):** no path/OS/shortcut assumptions — pure in-memory map cleanup.
- **SSH / remote / local:** local lives in `workspaceSession`, remote/runtime-host in `workspaceSessionsByHostId`; both are cleaned. SSH (local-session) behavior unchanged.
- **Agent / integration / git-provider neutrality:** no provider-specific logic touched.
- **Performance:** cleanup runs only on worktree removal (not a hot refresh/reconcile path); the extra `structuredClone` is negligible there.
- **Caller intent:** every `removeWorktreeMeta` caller (`removeWorktreeMetadataAndTransientState` in `ipc/worktrees.ts`, `removeWorktreeMetadataAndHistory` in `runtime/orca-runtime.ts`) is a genuine deletion path — none is a refresh/reconcile that could wrongly clear the active workspace.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change only removes entries from in-memory persisted-state maps that are already owned by the store. The trailing non-null assertion on `removeWorkspaceSessionOwner(...)` matches the existing folder-deletion callers; `workspaceSession` is a required, defaulted field and host partitions only hold parsed/validated `WorkspaceSessionState` values. No follow-up required.

## Notes

- Known pre-existing gap (not a regression, out of scope here): folder-workspace deletion also does not clean `workspaceSessionsByHostId`. This PR adds per-host cleanup for the worktree path because runtime-host worktrees are partitioned there; the folder path can be aligned separately.

## ELI5

Deleting a worktree left session restore data behind, so relaunch tried to open a missing folder. Removing worktree metadata also clears that session state.
