### PR TITLE
fix(terminal): launch prior/default agent when a woken terminal can't resume

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -81,7 +81,7 @@ type StoreState = {
       | { kind: 'windows-host' }
       | { kind: 'wsl'; distro: string }
   }[]
-  sshConnectionStates: Map<string, { status: string }>
+  sshConnectionStates: Map<string, { status: string; remotePlatform?: NodeJS.Platform }>
   cacheTimerByKey: Record<string, number | null>
   settings: {
     theme?: 'system' | 'dark' | 'light'
@@ -3817,11 +3817,23 @@ describe('connectPanePty', () => {
       (args) => (args[0] as { sessionId?: string })?.sessionId === 'lost-pty'
     )
     return call?.[0] as
-      | { command?: string; launchAgent?: string; env?: Record<string, string> }
+      | {
+          command?: string
+          launchAgent?: string
+          launchConfig?: {
+            agentCommand?: string
+            agentArgs?: string
+            agentEnv?: Record<string, string>
+          }
+          env?: Record<string, string>
+        }
       | undefined
   }
 
-  const mountColdRestore = async (transport: ReturnType<typeof createMockTransport>) => {
+  const mountColdRestore = async (
+    transport: ReturnType<typeof createMockTransport>,
+    depsOverrides: Record<string, unknown> = {}
+  ) => {
     const { connectPanePty } = await import('./pty-connection')
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
       if (sessionId) {
@@ -3834,7 +3846,8 @@ describe('connectPanePty', () => {
     const manager = createManager(1)
     const deps = createDeps({
       restoredLeafId: LEAF_1,
-      restoredPtyIdByLeafId: { [LEAF_1]: 'lost-pty' }
+      restoredPtyIdByLeafId: { [LEAF_1]: 'lost-pty' },
+      ...depsOverrides
     })
     connectPanePty(pane as never, manager as never, deps as never)
     await flushAsyncTicks(20)
@@ -3872,6 +3885,75 @@ describe('connectPanePty', () => {
     expect(reattach?.command).not.toContain('resume')
     expect(reattach?.launchAgent).toBe('codex')
     expect(reattach?.env?.ORCA_AGENT_LAUNCH_TOKEN).toMatch(new RegExp(`^${UUID_RE}$`))
+  })
+
+  it('cold-restores a fresh agent with the sleeping record launch config when resume is unavailable', async () => {
+    const transport = createMockTransport('fresh-pty')
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty' }] },
+      settings: {
+        ...mockStoreState.settings,
+        agentCmdOverrides: { codex: 'current-codex' },
+        agentDefaultArgs: { codex: '--current-args' }
+      },
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {
+        [paneKey]: {
+          paneKey,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agent: 'codex',
+          prompt: 'finish the task',
+          state: 'working',
+          capturedAt: 1,
+          updatedAt: 1,
+          launchConfig: {
+            agentCommand: 'sleeping-codex --stored-args',
+            agentArgs: '--stored-args',
+            agentEnv: { CODEX_HOME: '/tmp/orca-stored-codex' }
+          }
+        }
+      }
+    } as StoreState
+
+    await mountColdRestore(transport)
+
+    const reattach = findReattachConnect(transport)
+    expect(reattach?.command).toBe('sleeping-codex --stored-args')
+    expect(reattach?.launchAgent).toBe('codex')
+    expect(reattach?.launchConfig).toMatchObject({
+      agentCommand: 'sleeping-codex --stored-args',
+      agentArgs: '--stored-args',
+      agentEnv: { CODEX_HOME: '/tmp/orca-stored-codex' }
+    })
+    expect(reattach?.env).toMatchObject({
+      CODEX_HOME: '/tmp/orca-stored-codex',
+      ORCA_AGENT_LAUNCH_TOKEN: expect.stringMatching(new RegExp(`^${UUID_RE}$`))
+    })
+  })
+
+  it('uses the known SSH remote platform when fresh-launching an unresumable agent', async () => {
+    const transport = createMockTransport('fresh-pty')
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty', launchAgent: 'claude-agent-teams' }]
+      },
+      repos: [{ id: 'repo1', connectionId: 'ssh-win' }],
+      sshConnectionStates: new Map([['ssh-win', { status: 'connected', remotePlatform: 'win32' }]]),
+      settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {}
+    } as StoreState
+
+    await mountColdRestore(transport)
+
+    const reattach = findReattachConnect(transport)
+    expect(reattach?.command).toMatch(/^orca\.cmd claude-teams/)
+    expect(reattach?.command).not.toContain('orca-ide')
+    expect(reattach?.launchAgent).toBe('claude-agent-teams')
   })
 
   it('cold-restores the prior agent from the persisted tab launchAgent after a restart', async () => {
@@ -3913,6 +3995,80 @@ describe('connectPanePty', () => {
     const reattach = findReattachConnect(transport)
     expect(reattach?.command).toMatch(/^codex /)
     expect(reattach?.command).not.toContain('resume')
+    expect(reattach?.launchAgent).toBe('codex')
+  })
+
+  it('does not cold-restore a fresh agent from only a completed live status row', async () => {
+    const transport = createMockTransport('fresh-pty')
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty' }] },
+      settings: { ...mockStoreState.settings, agentCmdOverrides: {}, defaultTuiAgent: 'codex' },
+      agentStatusByPaneKey: {
+        [paneKey]: {
+          agentType: 'codex',
+          paneKey,
+          prompt: 'done task',
+          state: 'done',
+          stateHistory: [],
+          stateStartedAt: 1,
+          updatedAt: 1
+        }
+      },
+      sleepingAgentSessionsByPaneKey: {}
+    } as StoreState
+
+    await mountColdRestore(transport)
+
+    const reattach = findReattachConnect(transport)
+    expect(reattach?.command).toBeUndefined()
+    expect(reattach?.launchAgent).toBeUndefined()
+  })
+
+  it('ignores malformed sleeping launch config when a live resumable status exists', async () => {
+    const transport = createMockTransport('fresh-pty')
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty' }] },
+      settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
+      agentStatusByPaneKey: {
+        [paneKey]: {
+          agentType: 'codex',
+          paneKey,
+          prompt: 'live task',
+          providerSession: { key: 'session_id', id: 'live-session' },
+          state: 'working',
+          stateHistory: [],
+          stateStartedAt: 1,
+          updatedAt: 1
+        }
+      },
+      sleepingAgentSessionsByPaneKey: {
+        [paneKey]: {
+          paneKey,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agent: 'codex',
+          prompt: 'malformed sleeping task',
+          state: 'working',
+          capturedAt: 1,
+          updatedAt: 1,
+          launchConfig: {
+            agentCommand: 'malformed-sleeping-codex',
+            agentArgs: '',
+            agentEnv: {}
+          }
+        }
+      }
+    } as StoreState
+
+    await mountColdRestore(transport)
+
+    const reattach = findReattachConnect(transport)
+    expect(reattach?.command).toContain("'resume' 'live-session'")
+    expect(reattach?.command).not.toBe('malformed-sleeping-codex')
     expect(reattach?.launchAgent).toBe('codex')
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3912,6 +3912,7 @@ describe('connectPanePty', () => {
 
     const reattach = findReattachConnect(transport)
     expect(reattach?.command).toMatch(/^codex /)
+    expect(reattach?.command).not.toContain('resume')
     expect(reattach?.launchAgent).toBe('codex')
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -50,7 +50,10 @@ function leafIdForPane(paneId: number): string {
 
 type StoreState = {
   activeWorktreeId: string | null
-  tabsByWorktree: Record<string, { id: string; ptyId: string | null; title?: string }[]>
+  tabsByWorktree: Record<
+    string,
+    { id: string; ptyId: string | null; title?: string; launchAgent?: string }[]
+  >
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
   unreadTerminalTabs?: Record<string, true>
@@ -3805,6 +3808,128 @@ describe('connectPanePty', () => {
     // Why: consuming the record prevents a later worktree activation from
     // launching a duplicate resume tab for the same session.
     expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+  })
+
+  // #4557: an agent terminal that can't be resumed should come back as a fresh
+  // agent (prior agent, else default) instead of a blank shell.
+  const findReattachConnect = (transport: ReturnType<typeof createMockTransport>) => {
+    const call = transport.connect.mock.calls.find(
+      (args) => (args[0] as { sessionId?: string })?.sessionId === 'lost-pty'
+    )
+    return call?.[0] as
+      | { command?: string; launchAgent?: string; env?: Record<string, string> }
+      | undefined
+  }
+
+  const mountColdRestore = async (transport: ReturnType<typeof createMockTransport>) => {
+    const { connectPanePty } = await import('./pty-connection')
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return { id: 'fresh-pty', coldRestore: { scrollback: 'cold-payload', cwd: '/tmp/wt-1' } }
+      }
+      return 'fresh-pty'
+    })
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'lost-pty' }
+    })
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(20)
+    await new Promise((resolve) => setTimeout(resolve, 70))
+    return deps
+  }
+
+  it('cold-restores a fresh agent from the sleeping record when its session is unresumable', async () => {
+    const transport = createMockTransport('fresh-pty')
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty' }] },
+      settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {
+        // Agent known, but no resumable provider session id.
+        [paneKey]: {
+          paneKey,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agent: 'codex',
+          prompt: 'finish the task',
+          state: 'working',
+          capturedAt: 1,
+          updatedAt: 1
+        }
+      }
+    } as StoreState
+
+    await mountColdRestore(transport)
+
+    const reattach = findReattachConnect(transport)
+    expect(reattach?.command).toMatch(/^codex /)
+    expect(reattach?.command).not.toContain('resume')
+    expect(reattach?.launchAgent).toBe('codex')
+    expect(reattach?.env?.ORCA_AGENT_LAUNCH_TOKEN).toMatch(new RegExp(`^${UUID_RE}$`))
+  })
+
+  it('cold-restores the prior agent from the persisted tab launchAgent after a restart', async () => {
+    const transport = createMockTransport('fresh-pty')
+    mockStoreState = {
+      ...mockStoreState,
+      // After a restart there is no live status nor sleeping record — only the
+      // persisted tab.launchAgent tells us this terminal ran an agent.
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty', launchAgent: 'claude' }] },
+      settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {}
+    } as StoreState
+
+    await mountColdRestore(transport)
+
+    const reattach = findReattachConnect(transport)
+    expect(reattach?.command).toContain('claude')
+    expect(reattach?.command).not.toContain('resume')
+    expect(reattach?.launchAgent).toBe('claude')
+  })
+
+  it('cold-restores the default agent when an agent terminal has no recoverable agent', async () => {
+    const transport = createMockTransport('fresh-pty')
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty' }] },
+      settings: { ...mockStoreState.settings, agentCmdOverrides: {}, defaultTuiAgent: 'codex' },
+      agentStatusByPaneKey: {},
+      // A record exists (it was an agent terminal) but carries no usable agent id.
+      sleepingAgentSessionsByPaneKey: {
+        [paneKey]: { paneKey, tabId: 'tab-1', worktreeId: 'wt-1', capturedAt: 1, updatedAt: 1 }
+      }
+    } as StoreState
+
+    await mountColdRestore(transport)
+
+    const reattach = findReattachConnect(transport)
+    expect(reattach?.command).toMatch(/^codex /)
+    expect(reattach?.launchAgent).toBe('codex')
+  })
+
+  it('leaves a plain shell blank on cold restore (no prior agent, no default)', async () => {
+    const transport = createMockTransport('fresh-pty')
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty' }] },
+      settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {}
+    } as StoreState
+
+    await mountColdRestore(transport)
+
+    const reattach = findReattachConnect(transport)
+    expect(reattach?.command).toBeUndefined()
+    expect(reattach?.launchAgent).toBeUndefined()
   })
 
   it('resumes from an unambiguous legacy sleeping record when cold-restoring a preserved pane', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -103,16 +103,17 @@ import {
   getRuntimeEnvironmentIdForWorktree
 } from '@/lib/worktree-runtime-owner'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
-import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
+import { buildAgentResumeStartupPlan, buildAgentStartupPlan } from '@/lib/tui-agent-startup'
 import { resolveAgentStatusTerminalTitle } from '@/lib/agent-status-terminal-title'
 import {
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
 } from '../../../../shared/tui-agent-launch-defaults'
+import { isTuiAgent } from '../../../../shared/tui-agent-config'
+import { isTuiAgentEnabled } from '../../../../shared/tui-agent-selection'
 import {
   isResumableTuiAgent,
   normalizeAgentProviderSession,
-  type ResumableTuiAgent,
   type SleepingAgentSessionRecord
 } from '../../../../shared/agent-session-resume'
 import type { TuiAgent } from '../../../../shared/types'
@@ -193,7 +194,9 @@ type PendingStartupCommand = {
 }
 
 type ColdRestoreAgentResumeStartup = PendingStartupCommand & {
-  agent: ResumableTuiAgent
+  // TuiAgent (not just ResumableTuiAgent): the fresh-launch fallback can spawn any
+  // agent the terminal previously ran, including ones without resume support.
+  agent: TuiAgent
   launchConfig: NonNullable<ReturnType<typeof buildAgentResumeStartupPlan>>['launchConfig']
   launchToken: string
   useLiveEntry: boolean
@@ -897,13 +900,19 @@ export function connectPanePty(
     consumed: { paneKey: string; record: SleepingAgentSessionRecord }
   ): void => {
     state.clearSleepingAgentSession(consumed.paneKey)
+    const consumedSession = consumed.record.providerSession
+    // No provider session (e.g. a fresh-launch fallback record) means there is no
+    // shared session to alias, so there is nothing else to clear.
+    if (!consumedSession) {
+      return
+    }
     for (const [paneKey, record] of Object.entries(state.sleepingAgentSessionsByPaneKey)) {
       if (
         paneKey !== consumed.paneKey &&
         record.worktreeId === consumed.record.worktreeId &&
         record.agent === consumed.record.agent &&
-        record.providerSession.key === consumed.record.providerSession.key &&
-        record.providerSession.id === consumed.record.providerSession.id
+        record.providerSession?.key === consumedSession.key &&
+        record.providerSession?.id === consumedSession.id
       ) {
         // Why: legacy pane aliases can leave multiple sleeping rows for one
         // provider session; once this pane resumes it, every alias is stale.
@@ -2207,15 +2216,69 @@ export function connectPanePty(
       const sleepingRecordEntry = getSleepingRecordForPane(state)
       const sleepingRecord = sleepingRecordEntry?.record
       const useLiveEntry = entry && entry.state !== 'done'
+
+      // When the provider session can't be resumed, an agent terminal should still
+      // come back as its agent (or the default), not a blank shell (#4557). A plain
+      // shell — no agent ever ran here — stays blank (buildFreshFallback returns null).
+      const buildFreshFallback = (): ColdRestoreAgentResumeStartup | null => {
+        const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find(
+          (candidate) => candidate.id === deps.tabId
+        )
+        const liveAgent = isTuiAgent(entry?.agentType) ? entry.agentType : undefined
+        const priorAgent =
+          liveAgent ?? sleepingRecord?.agent ?? tab?.launchAgent ?? paneStartup?.launchAgent
+        const defaultPref = state.settings?.defaultTuiAgent
+        const defaultAgent =
+          defaultPref &&
+          defaultPref !== 'blank' &&
+          isTuiAgentEnabled(defaultPref, state.settings?.disabledTuiAgents)
+            ? defaultPref
+            : undefined
+        // Fall back to the default agent only when this was an agent terminal whose
+        // specific agent is unrecoverable — never for a genuine plain shell.
+        const fallbackAgent = priorAgent ?? (entry || sleepingRecord ? defaultAgent : undefined)
+        if (!fallbackAgent) {
+          return null
+        }
+        const freshPlan = buildAgentStartupPlan({
+          agent: fallbackAgent,
+          prompt: '',
+          cmdOverrides: state.settings?.agentCmdOverrides ?? {},
+          agentArgs: resolveTuiAgentLaunchArgs(fallbackAgent, state.settings?.agentDefaultArgs),
+          agentEnv: resolveTuiAgentLaunchEnv(fallbackAgent, state.settings?.agentDefaultEnv),
+          platform: getColdRestoreAgentResumePlatform(),
+          allowEmptyPromptLaunch: true
+        })
+        if (!freshPlan) {
+          return null
+        }
+        const freshLaunchToken = createBrowserUuid()
+        return {
+          agent: fallbackAgent,
+          command: freshPlan.launchCommand,
+          env: {
+            ...freshPlan.env,
+            ORCA_AGENT_LAUNCH_TOKEN: freshLaunchToken
+          },
+          launchConfig: freshPlan.launchConfig,
+          launchToken: freshLaunchToken,
+          useLiveEntry: Boolean(useLiveEntry),
+          // A fresh launch is a new session, not a restored one, so no "restored"
+          // banner; the stale sleeping record is still cleared after the spawn.
+          hasSleepingRecord: false,
+          sleepingRecordEntry
+        }
+      }
+
       const agent = useLiveEntry ? entry.agentType : sleepingRecord?.agent
       if (!agent || !isResumableTuiAgent(agent)) {
-        return null
+        return buildFreshFallback()
       }
       const providerSession = normalizeAgentProviderSession(
         useLiveEntry ? entry.providerSession : sleepingRecord?.providerSession
       )
       if (!providerSession) {
-        return null
+        return buildFreshFallback()
       }
       const matchingSleepingLaunchConfig =
         sleepingRecord?.launchConfig &&
@@ -2245,7 +2308,7 @@ export function connectPanePty(
         platform: resumePlatform
       })
       if (!startupPlan) {
-        return null
+        return buildFreshFallback()
       }
       const coldRestoreLaunchToken = createBrowserUuid()
       // Why: cold restore means the PTY process is gone but the agent provider

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -863,32 +863,34 @@ export function connectPanePty(
         )
       }
     )
+    const legacyProviderSessionKeys = legacyMatches.map(([, record]) => {
+      const providerSession = normalizeAgentProviderSession(record.providerSession)
+      return providerSession
+        ? [record.worktreeId, record.agent, providerSession.key, providerSession.id].join('\0')
+        : null
+    })
     const exactLegacyMatch = legacyMatches.find(([paneKey]) => {
       const legacy = parseLegacyNumericPaneKey(paneKey)
       return legacy?.numericPaneId === String(pane.id)
     })
     const providerSessionKeys = new Set(
-      legacyMatches.map(([, record]) =>
-        [
-          record.worktreeId,
-          record.agent,
-          record.providerSession.key,
-          record.providerSession.id
-        ].join('\0')
-      )
+      legacyProviderSessionKeys.filter((key): key is string => key !== null)
     )
     const oldestLegacyMatch = legacyMatches
       .slice()
       .sort(([, a], [, b]) => a.capturedAt - b.capturedAt || a.updatedAt - b.updatedAt)[0]
     // Why: duplicate legacy aliases can point at one provider session; consume
     // the oldest capture as canonical and clear its aliases after resume.
+    const allLegacyMatchesHaveProviderSession = legacyProviderSessionKeys.every(
+      (key) => key !== null
+    )
     const selectedLegacyMatch =
       exactLegacyMatch ??
-      (providerSessionKeys.size === 1
-        ? legacyMatches.length === 1
-          ? legacyMatches[0]
-          : oldestLegacyMatch
-        : null)
+      (legacyMatches.length === 1
+        ? legacyMatches[0]
+        : allLegacyMatchesHaveProviderSession && providerSessionKeys.size === 1
+          ? oldestLegacyMatch
+          : null)
     if (!selectedLegacyMatch) {
       return null
     }
@@ -900,7 +902,7 @@ export function connectPanePty(
     consumed: { paneKey: string; record: SleepingAgentSessionRecord }
   ): void => {
     state.clearSleepingAgentSession(consumed.paneKey)
-    const consumedSession = consumed.record.providerSession
+    const consumedSession = normalizeAgentProviderSession(consumed.record.providerSession)
     // No provider session (e.g. a fresh-launch fallback record) means there is no
     // shared session to alias, so there is nothing else to clear.
     if (!consumedSession) {
@@ -2202,6 +2204,10 @@ export function connectPanePty(
       if (projectRuntime?.status === 'resolved' && projectRuntime.runtime.kind === 'wsl') {
         return 'linux'
       }
+      const sshRemotePlatform = getTerminalPasteSshRemotePlatform(connectionId)
+      if (sshRemotePlatform) {
+        return sshRemotePlatform
+      }
       if (connectionId || (worktree?.path && isWslUncPath(worktree.path))) {
         return 'linux'
       }
@@ -2215,16 +2221,18 @@ export function connectPanePty(
       const entry = state.agentStatusByPaneKey[cacheKey]
       const sleepingRecordEntry = getSleepingRecordForPane(state)
       const sleepingRecord = sleepingRecordEntry?.record
-      const useLiveEntry = entry && entry.state !== 'done'
+      const liveEntry = entry && entry.state !== 'done' ? entry : null
+      const useLiveEntry = Boolean(liveEntry)
 
       // When the provider session can't be resumed, an agent terminal should still
       // come back as its agent (or the default), not a blank shell (#4557). A plain
-      // shell — no agent ever ran here — stays blank (buildFreshFallback returns null).
+      // shell - no agent ever ran here - stays blank (buildFreshFallback returns null).
       const buildFreshFallback = (): ColdRestoreAgentResumeStartup | null => {
         const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find(
           (candidate) => candidate.id === deps.tabId
         )
-        const liveAgent = isTuiAgent(entry?.agentType) ? entry.agentType : undefined
+        const liveAgent =
+          liveEntry && isTuiAgent(liveEntry.agentType) ? liveEntry.agentType : undefined
         const priorAgent =
           liveAgent ?? sleepingRecord?.agent ?? tab?.launchAgent ?? paneStartup?.launchAgent
         const defaultPref = state.settings?.defaultTuiAgent
@@ -2234,18 +2242,56 @@ export function connectPanePty(
           isTuiAgentEnabled(defaultPref, state.settings?.disabledTuiAgents)
             ? defaultPref
             : undefined
-        // Fall back to the default agent only when this was an agent terminal whose
-        // specific agent is unrecoverable — never for a genuine plain shell.
-        const fallbackAgent = priorAgent ?? (entry || sleepingRecord ? defaultAgent : undefined)
+        // Fall back to the default agent only when this was an active/sleeping
+        // agent terminal whose specific agent is unrecoverable - never for a
+        // genuine plain shell or a stale completed live row.
+        const fallbackAgent = priorAgent ?? (liveEntry || sleepingRecord ? defaultAgent : undefined)
         if (!fallbackAgent) {
           return null
+        }
+        const liveLaunchConfig =
+          liveEntry && liveAgent === fallbackAgent
+            ? state.getAgentLaunchConfigForStatusEntry(liveEntry)
+            : undefined
+        const fallbackLaunchConfig =
+          liveLaunchConfig ??
+          (sleepingRecord?.agent === fallbackAgent ? sleepingRecord.launchConfig : undefined) ??
+          (paneStartup?.launchAgent === fallbackAgent ? paneStartup.launchConfig : undefined)
+        if (fallbackLaunchConfig?.agentCommand?.trim()) {
+          const freshLaunchToken = createBrowserUuid()
+          return {
+            agent: fallbackAgent,
+            command: fallbackLaunchConfig.agentCommand.trim(),
+            env: {
+              ...fallbackLaunchConfig.agentEnv,
+              ORCA_AGENT_LAUNCH_TOKEN: freshLaunchToken
+            },
+            launchConfig: {
+              agentCommand: fallbackLaunchConfig.agentCommand.trim(),
+              agentArgs: fallbackLaunchConfig.agentArgs,
+              agentEnv: { ...fallbackLaunchConfig.agentEnv }
+            },
+            launchToken: freshLaunchToken,
+            useLiveEntry,
+            // A fresh launch is a new session, not a restored one, so no
+            // "restored" banner; the stale sleeping record is still cleared
+            // after the spawn.
+            hasSleepingRecord: false,
+            sleepingRecordEntry
+          }
         }
         const freshPlan = buildAgentStartupPlan({
           agent: fallbackAgent,
           prompt: '',
           cmdOverrides: state.settings?.agentCmdOverrides ?? {},
-          agentArgs: resolveTuiAgentLaunchArgs(fallbackAgent, state.settings?.agentDefaultArgs),
-          agentEnv: resolveTuiAgentLaunchEnv(fallbackAgent, state.settings?.agentDefaultEnv),
+          agentArgs:
+            fallbackLaunchConfig !== undefined
+              ? fallbackLaunchConfig.agentArgs
+              : resolveTuiAgentLaunchArgs(fallbackAgent, state.settings?.agentDefaultArgs),
+          agentEnv:
+            fallbackLaunchConfig !== undefined
+              ? fallbackLaunchConfig.agentEnv
+              : resolveTuiAgentLaunchEnv(fallbackAgent, state.settings?.agentDefaultEnv),
           platform: getColdRestoreAgentResumePlatform(),
           allowEmptyPromptLaunch: true
         })
@@ -2262,34 +2308,36 @@ export function connectPanePty(
           },
           launchConfig: freshPlan.launchConfig,
           launchToken: freshLaunchToken,
-          useLiveEntry: Boolean(useLiveEntry),
-          // A fresh launch is a new session, not a restored one, so no "restored"
-          // banner; the stale sleeping record is still cleared after the spawn.
+          useLiveEntry,
+          // A fresh launch is a new session, not a restored one, so no
+          // "restored" banner; the stale sleeping record is still cleared after
+          // the spawn.
           hasSleepingRecord: false,
           sleepingRecordEntry
         }
       }
 
-      const agent = useLiveEntry ? entry.agentType : sleepingRecord?.agent
+      const agent = liveEntry ? liveEntry.agentType : sleepingRecord?.agent
       if (!agent || !isResumableTuiAgent(agent)) {
         return buildFreshFallback()
       }
       const providerSession = normalizeAgentProviderSession(
-        useLiveEntry ? entry.providerSession : sleepingRecord?.providerSession
+        liveEntry ? liveEntry.providerSession : sleepingRecord?.providerSession
       )
       if (!providerSession) {
         return buildFreshFallback()
       }
+      const sleepingProviderSession = normalizeAgentProviderSession(sleepingRecord?.providerSession)
       const matchingSleepingLaunchConfig =
         sleepingRecord?.launchConfig &&
         (!useLiveEntry ||
           (sleepingRecord.agent === agent &&
-            sleepingRecord.providerSession.key === providerSession.key &&
-            sleepingRecord.providerSession.id === providerSession.id))
+            sleepingProviderSession?.key === providerSession.key &&
+            sleepingProviderSession?.id === providerSession.id))
           ? sleepingRecord.launchConfig
           : undefined
       const launchConfig =
-        (useLiveEntry && entry ? state.getAgentLaunchConfigForStatusEntry(entry) : undefined) ??
+        (liveEntry ? state.getAgentLaunchConfigForStatusEntry(liveEntry) : undefined) ??
         matchingSleepingLaunchConfig
       const resumePlatform = getColdRestoreAgentResumePlatform()
       const startupPlan = buildAgentResumeStartupPlan({


### PR DESCRIPTION
## Summary

Waking a sleeping worktree — or restoring terminals after an app restart — left a terminal that previously ran an agent as a **blank shell** while the tab still showed the agent's icon/title. You had to manually re-run `claude`/`codex` to get going.

Root cause: in `pty-connection.ts`, `buildColdRestoreAgentResumeStartup()` returns `null` whenever the agent's provider session can't be resumed (no provider session, or the resume plan can't be built). The caller then spawns a bare shell, and nothing clears the tab's `launchAgent`, so the stale agent icon remains.

This change adds a fresh-launch fallback at exactly those `null` points. When resume isn't possible, an **agent terminal** now comes back as a **fresh session** (no `--resume`) of the agent it previously ran, resolved in priority order:

1. live agent status (`agentType`), else
2. the sleeping record's agent, else
3. the terminal's persisted `tab.launchAgent` (the durable signal across restarts), else
4. the pane's startup `launchAgent`.

If the prior agent is unknown **but there's evidence the terminal was an agent terminal** (a live status entry or sleeping record exists), the configured **default agent** is used — exactly like opening a new terminal. A **genuine plain shell** (no agent ever ran there, no default trigger) stays blank. No context is carried over (a clean session), and the correct agent icon is restored because the fresh startup flows through the existing cold-restore path that sets `launchAgent`.

Fixes #4557

## Screenshots

Waking a slept agent terminal — before vs after (PII redacted):

https://github.com/user-attachments/assets/56e7a654-6699-48dc-a68b-cdab23e9864e

- **Before**: the woken terminal comes up as a blank shell (with a stale agent icon).
- **After**: it relaunches the agent it previously ran; a plain shell still wakes blank.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — `pty-connection.test.ts` passes (193 incl. 4 new cases). The only full-suite failures are pre-existing, environment-only flakes unrelated to this change (`src/relay/git-handler.test.ts`, `src/relay/subprocess.test.ts` — they pass in isolation and flake under parallel load; they also fail on a clean `upstream/main`).
- [x] `pnpm build`
- [x] Added regression tests: unresumable sleeping record → fresh agent; persisted `tab.launchAgent` → fresh prior agent after restart; agent terminal with unrecoverable agent → default agent; plain shell stays blank.

## AI Review Report

Ran an adversarial review of the diff. Risks checked and outcomes:

- **Forcing an agent into a plain shell / new terminal** — verified safe: the `pendingStartupCommand` guard returns null for any launch that already carries a startup command; the default-agent fallback only fires when a live entry or sleeping record exists; a brand-new blank terminal has none of those (even with a default agent configured), so it stays blank. New-terminal creation does not route through this builder.
- **Resume behavior unchanged** — the fallback is only reached at the three sites that previously returned `null`; the successful-resume branch is untouched (existing resume tests pass).
- **Cross-platform (macOS/Linux/Windows + WSL)** — the fresh launch uses the same `getColdRestoreAgentResumePlatform()` and `buildAgentStartupPlan` (same shell resolution/quoting) as the resume path; empty prompt avoids quoting risk; WSL→`linux` mapping is identical. No shortcuts/labels/paths touched.
- **SSH/remote** — parity confirmed: the fresh startup object has the same shape as the resume object and is delivered through the existing SSH cold-restore mechanism; no SSH-specific code change.
- **Type widening** — `ColdRestoreAgentResumeStartup.agent` widened from `ResumableTuiAgent` to `TuiAgent` (a fresh launch can target a non-resumable agent). All consumers accept `TuiAgent` (`registerAgentLaunchConfig` metadata is `AgentType`; `launchAgent` fields are `TuiAgent`).
- Hardened `clearSleepingRecordProviderDuplicates` to tolerate a record without a `providerSession` (now reachable via the fresh-launch path).

## Security Audit

- **Command execution** — the fresh launch command is built by the same `buildAgentStartupPlan` used for new terminals; no user-derived strings are interpolated unquoted (empty prompt), and args/env come from the existing settings-resolution helpers.
- **No** new IPC surface, secrets, auth, path handling, or dependency changes.

## Notes

- Behavior is gated so plain shells and blank new terminals are never converted into agents.
- The fresh launch starts a clean session (no transcript continuation), matching the agreed behavior.
