### PR TITLE
fix(terminal): re-probe stale "missing" path results so terminal links go live

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
@@ -7,7 +7,11 @@ import {
   openDetectedFilePath,
   terminalLinkWslDistro
 } from './terminal-file-open-routing'
-import { getTerminalPathExistsCacheKey } from './terminal-path-exists-cache'
+import {
+  getTerminalPathExistsCacheKey,
+  readTerminalPathExistsCache,
+  type TerminalPathExistsCache
+} from './terminal-path-exists-cache'
 import { resolveKnownWorktreeRootPathLink } from './terminal-worktree-path-link'
 import {
   buildHardWrappedPathLogicalLineCandidates,
@@ -23,7 +27,7 @@ type FileLinkHitTestDeps = {
   worktreePath: string
   runtimeEnvironmentId?: string | null
   wslDistro?: string | null
-  pathExistsCache?: Map<string, boolean>
+  pathExistsCache?: TerminalPathExistsCache
   openWithSystemDefault?: boolean
 }
 
@@ -83,7 +87,9 @@ export function openFilePathLinkAtBufferPosition(
         line: resolved.line,
         column: resolved.column,
         pathText: parsed.pathText,
-        cachedExists: deps.pathExistsCache?.get(cacheKey),
+        cachedExists: deps.pathExistsCache
+          ? readTerminalPathExistsCache(deps.pathExistsCache, cacheKey)
+          : undefined,
         isKnownWorktreeRoot
       })
     }

--- a/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
@@ -2,7 +2,11 @@ import type { IBufferLine, IBufferRange } from '@xterm/xterm'
 import { extractTerminalFileLinkCandidates, resolveTerminalFileLink } from '@/lib/terminal-links'
 import { isRemoteRuntimeFileOperation } from '@/runtime/runtime-file-client'
 import { getTerminalFileContext, openDetectedFilePath } from './terminal-file-open-routing'
-import { getTerminalPathExistsCacheKey } from './terminal-path-exists-cache'
+import {
+  getTerminalPathExistsCacheKey,
+  readTerminalPathExistsCache,
+  type TerminalPathExistsCache
+} from './terminal-path-exists-cache'
 import { resolveKnownWorktreeRootPathLink } from './terminal-worktree-path-link'
 import {
   buildHardWrappedPathLogicalLineCandidates,
@@ -17,7 +21,7 @@ type FileLinkHitTestDeps = {
   worktreeId: string
   worktreePath: string
   runtimeEnvironmentId?: string | null
-  pathExistsCache?: Map<string, boolean>
+  pathExistsCache?: TerminalPathExistsCache
   openWithSystemDefault?: boolean
 }
 
@@ -72,7 +76,9 @@ export function openFilePathLinkAtBufferPosition(
         line: resolved.line,
         column: resolved.column,
         pathText: parsed.pathText,
-        cachedExists: deps.pathExistsCache?.get(cacheKey),
+        cachedExists: deps.pathExistsCache
+          ? readTerminalPathExistsCache(deps.pathExistsCache, cacheKey)
+          : undefined,
         isKnownWorktreeRoot
       })
     }

--- a/src/renderer/src/components/terminal-pane/terminal-link-click-fallback.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-click-fallback.test.ts
@@ -274,6 +274,40 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(openFileMock).not.toHaveBeenCalled()
   })
 
+  it('retries a direct file click when a cached missing path expires', async () => {
+    setPlatform('Macintosh')
+    const now = vi.spyOn(Date, 'now').mockReturnValue(10_999)
+    const pathExistsCache = new Map([
+      ['active\0/tmp/eventually-created.ts', { exists: false, checkedAt: 1_000 }]
+    ])
+    const openAtCurrentTime = (): boolean =>
+      openFilePathLinkAtBufferPosition(
+        makeBuffer([makeBufferLine('eventually-created.ts')]),
+        { x: 4, y: 1 },
+        80,
+        {
+          startupCwd: '/tmp',
+          worktreeId: 'wt-1',
+          worktreePath: '/tmp',
+          runtimeEnvironmentId: null,
+          pathExistsCache
+        }
+      )
+
+    expect(openAtCurrentTime()).toBe(false)
+    expect(openFileMock).not.toHaveBeenCalled()
+
+    now.mockReturnValue(11_000)
+    expect(openAtCurrentTime()).toBe(true)
+    await flushAsyncWork()
+
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/tmp/eventually-created.ts' }),
+      { forceContentReload: true }
+    )
+    now.mockRestore()
+  })
+
   it('retries a wrapped file click even when xterm already marked the link active', async () => {
     setPlatform('Macintosh')
     const rows = [

--- a/src/renderer/src/components/terminal-pane/terminal-link-click-fallback.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-click-fallback.test.ts
@@ -11,6 +11,7 @@ import {
   getRegisteredMouseUpHandler,
   makeBuffer,
   makeBufferLine,
+  makeExistsCache,
   makeFallbackTerminal
 } from './terminal-link-provider-buffer-fixtures'
 import {
@@ -95,7 +96,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\repo',
         runtimeEnvironmentId: null,
         wslDistro: 'Ubuntu',
-        pathExistsCache: new Map([
+        pathExistsCache: makeExistsCache([
           ['active\0\\\\wsl.localhost\\Ubuntu\\root\\workspace\\myrepo\\README.md', true]
         ])
       }
@@ -235,7 +236,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreeId: 'wt-1',
         worktreePath: '/repo',
         runtimeEnvironmentId: null,
-        pathExistsCache: new Map<string, boolean>([
+        pathExistsCache: makeExistsCache([
           ['active\0/repo/My Folder now', false],
           ['active\0/repo/My Folder', true]
         ])
@@ -263,7 +264,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreeId: 'wt-1',
         worktreePath: '/repo',
         runtimeEnvironmentId: null,
-        pathExistsCache: new Map([['active\0/repo/unknown-dir', true]])
+        pathExistsCache: makeExistsCache([['active\0/repo/unknown-dir', true]])
       }
     )
     await flushAsyncWork()
@@ -288,7 +289,7 @@ describe('createFilePathLinkProvider range bounds', () => {
       runtimeEnvironmentId: null,
       managerRef: { current: null },
       linkProviderDisposablesRef: { current: new Map<number, IDisposable>() },
-      pathExistsCache: new Map<string, boolean>()
+      pathExistsCache: makeExistsCache()
     })
     const mouseUp = getRegisteredMouseUpHandler(element)
     const preventDefault = vi.fn()
@@ -330,7 +331,7 @@ describe('createFilePathLinkProvider range bounds', () => {
       runtimeEnvironmentId: null,
       managerRef: { current: null },
       linkProviderDisposablesRef: { current: new Map<number, IDisposable>() },
-      pathExistsCache: new Map<string, boolean>()
+      pathExistsCache: makeExistsCache()
     })
     const mouseUp = getRegisteredMouseUpHandler(element)
     const preventDefault = vi.fn()
@@ -567,7 +568,7 @@ describe('createFilePathLinkProvider range bounds', () => {
       makeBufferLine(`${firstPath} · ${middleStart}`),
       makeBufferLine(`${middleEnd} · ${thirdPath}`)
     ]
-    const pathExistsCache = new Map([[`active\0/repo/${middlePath}`, true]])
+    const pathExistsCache = makeExistsCache([[`active\0/repo/${middlePath}`, true]])
     const positions = [
       { x: firstPath.length + ' · '.length + 2, y: 1 },
       { x: 2, y: 2 }

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -13,7 +13,10 @@ import {
   openFilePathLinkAtBufferPosition,
   openDetectedFilePath
 } from './terminal-link-handlers'
-import { TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES } from './terminal-path-exists-cache'
+import {
+  TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES,
+  type TerminalPathExistsCache
+} from './terminal-path-exists-cache'
 import { handleOscLink } from './terminal-osc-link-routing'
 import { installHttpLinkClickFallback } from './terminal-url-link-hit-testing'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
@@ -24,6 +27,13 @@ import {
   type RuntimeEnvironmentCallRequest
 } from '@/runtime/runtime-compatibility-test-fixture'
 import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-client'
+
+// Why: the path-exists cache now stores { exists, checkedAt } entries with a
+// TTL on negatives; build fixtures with a fresh timestamp so cached results
+// (including "missing") are honored within the test.
+function makeExistsCache(pairs: [string, boolean][] = []): TerminalPathExistsCache {
+  return new Map(pairs.map(([key, exists]) => [key, { exists, checkedAt: Date.now() }]))
+}
 
 const openUrlMock = vi.fn()
 const openFileUriMock = vi.fn()
@@ -1047,7 +1057,7 @@ describe('createFilePathLinkProvider range bounds', () => {
 
   function createProviderSetup(
     rows: TestBufferLine[],
-    pathExistsCache = new Map<string, boolean>([
+    pathExistsCache = makeExistsCache([
       ['/repo', true],
       ['/repo/CLAUDE.md', true],
       ['/repo/package.json', true],
@@ -1242,7 +1252,7 @@ describe('createFilePathLinkProvider range bounds', () => {
     }
     const { provider, linkTooltip } = createProviderSetup(
       [makeBufferLine('/repo')],
-      new Map([['active\0/repo', false]])
+      makeExistsCache([['active\0/repo', false]])
     )
 
     const links = await new Promise<ILink[]>((resolve) => {
@@ -1261,7 +1271,7 @@ describe('createFilePathLinkProvider range bounds', () => {
     setPlatform('Macintosh')
     const { provider } = createProviderSetup(
       [makeBufferLine('/repo/unknown-dir/')],
-      new Map([['active\0/repo/unknown-dir', true]])
+      makeExistsCache([['active\0/repo/unknown-dir', true]])
     )
 
     const links = await new Promise<ILink[]>((resolve) => {
@@ -1322,9 +1332,9 @@ describe('createFilePathLinkProvider range bounds', () => {
   })
 
   it('bounds the terminal path-exists cache while preserving recent probes', async () => {
-    const pathExistsCache = new Map<string, boolean>()
+    const pathExistsCache = makeExistsCache()
     for (let index = 0; index < TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES; index += 1) {
-      pathExistsCache.set(`active\0/repo/old-${index}.ts`, true)
+      pathExistsCache.set(`active\0/repo/old-${index}.ts`, { exists: true, checkedAt: Date.now() })
     }
     const pane = makePane([makeBufferLine('fresh.ts')])
     const managerRef = {
@@ -1351,12 +1361,12 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(links.map((link) => link.text)).toEqual(['fresh.ts'])
     expect(pathExistsCache.size).toBe(TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES)
     expect(pathExistsCache.has('active\0/repo/old-0.ts')).toBe(false)
-    expect(pathExistsCache.get('active\0/repo/fresh.ts')).toBe(true)
+    expect(pathExistsCache.get('active\0/repo/fresh.ts')?.exists).toBe(true)
   })
 
   it('does not reuse SSH path-exists cache entries across connections', async () => {
     setPlatform('Macintosh')
-    const pathExistsCache = new Map<string, boolean>()
+    const pathExistsCache = makeExistsCache()
     const rows = [makeBufferLine('shared.ts')]
     const pane = makePane(rows)
     const managerRef = {
@@ -1450,7 +1460,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreeId: 'wt-1',
         worktreePath: '/tmp',
         runtimeEnvironmentId: null,
-        pathExistsCache: new Map([['active\0/tmp/other-worktree', false]])
+        pathExistsCache: makeExistsCache([['active\0/tmp/other-worktree', false]])
       }
     )
     await flushAsyncWork()
@@ -1625,7 +1635,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreeId: 'wt-1',
         worktreePath: '/repo',
         runtimeEnvironmentId: null,
-        pathExistsCache: new Map<string, boolean>([
+        pathExistsCache: makeExistsCache([
           ['active\0/repo/My Folder now', false],
           ['active\0/repo/My Folder', true]
         ])
@@ -1653,7 +1663,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreeId: 'wt-1',
         worktreePath: '/repo',
         runtimeEnvironmentId: null,
-        pathExistsCache: new Map([['active\0/repo/unknown-dir', true]])
+        pathExistsCache: makeExistsCache([['active\0/repo/unknown-dir', true]])
       }
     )
     await flushAsyncWork()
@@ -1678,7 +1688,7 @@ describe('createFilePathLinkProvider range bounds', () => {
       runtimeEnvironmentId: null,
       managerRef: { current: null },
       linkProviderDisposablesRef: { current: new Map<number, IDisposable>() },
-      pathExistsCache: new Map<string, boolean>()
+      pathExistsCache: makeExistsCache()
     })
     const mouseUp = getRegisteredMouseUpHandler(element)
     const preventDefault = vi.fn()
@@ -1720,7 +1730,7 @@ describe('createFilePathLinkProvider range bounds', () => {
       runtimeEnvironmentId: null,
       managerRef: { current: null },
       linkProviderDisposablesRef: { current: new Map<number, IDisposable>() },
-      pathExistsCache: new Map<string, boolean>()
+      pathExistsCache: makeExistsCache()
     })
     const mouseUp = getRegisteredMouseUpHandler(element)
     const preventDefault = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -1364,6 +1364,35 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(pathExistsCache.get('active\0/repo/fresh.ts')?.exists).toBe(true)
   })
 
+  it('expires a cached missing path even when the provider scans it repeatedly', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(5_000)
+    const cacheKey = 'active\0/repo/eventually-created.ts'
+    const pathExistsCache: TerminalPathExistsCache = new Map([
+      [cacheKey, { exists: false, checkedAt: 1_000 }]
+    ])
+    const { provider } = createProviderSetup(
+      [makeBufferLine('eventually-created.ts')],
+      pathExistsCache
+    )
+
+    const firstLinks = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+    expect(firstLinks).toEqual([])
+    expect(window.api.shell.pathExists).not.toHaveBeenCalled()
+    expect(pathExistsCache.get(cacheKey)?.checkedAt).toBe(1_000)
+
+    now.mockReturnValue(11_000)
+    const refreshedLinks = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(refreshedLinks.map((link) => link.text)).toEqual(['eventually-created.ts'])
+    expect(window.api.shell.pathExists).toHaveBeenCalledOnce()
+    expect(pathExistsCache.get(cacheKey)).toEqual({ exists: true, checkedAt: 11_000 })
+    now.mockRestore()
+  })
+
   it('does not reuse SSH path-exists cache entries across connections', async () => {
     setPlatform('Macintosh')
     const pathExistsCache = makeExistsCache()
@@ -1443,6 +1472,40 @@ describe('createFilePathLinkProvider range bounds', () => {
       { forceContentReload: true }
     )
     expect(openFilePathMock).not.toHaveBeenCalled()
+  })
+
+  it('retries a direct file click when a cached missing path expires', async () => {
+    setPlatform('Macintosh')
+    const now = vi.spyOn(Date, 'now').mockReturnValue(10_999)
+    const pathExistsCache: TerminalPathExistsCache = new Map([
+      ['active\0/tmp/eventually-created.ts', { exists: false, checkedAt: 1_000 }]
+    ])
+    const openAtCurrentTime = (): boolean =>
+      openFilePathLinkAtBufferPosition(
+        makeBuffer([makeBufferLine('eventually-created.ts')]),
+        { x: 4, y: 1 },
+        80,
+        {
+          startupCwd: '/tmp',
+          worktreeId: 'wt-1',
+          worktreePath: '/tmp',
+          runtimeEnvironmentId: null,
+          pathExistsCache
+        }
+      )
+
+    expect(openAtCurrentTime()).toBe(false)
+    expect(openFileMock).not.toHaveBeenCalled()
+
+    now.mockReturnValue(11_000)
+    expect(openAtCurrentTime()).toBe(true)
+    await flushAsyncWork()
+
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/tmp/eventually-created.ts' }),
+      { forceContentReload: true }
+    )
+    now.mockRestore()
   })
 
   it('switches to a known worktree root from direct fallback even when cache says missing', async () => {
@@ -2050,7 +2113,7 @@ describe('createFilePathLinkProvider range bounds', () => {
       makeBufferLine(`${firstPath} · ${middleStart}`),
       makeBufferLine(`${middleEnd} · ${thirdPath}`)
     ]
-    const pathExistsCache = new Map([[`active\0/repo/${middlePath}`, true]])
+    const pathExistsCache = makeExistsCache([[`active\0/repo/${middlePath}`, true]])
     const positions = [
       { x: firstPath.length + ' · '.length + 2, y: 1 },
       { x: 2, y: 2 }

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -177,7 +177,11 @@ export function createFilePathLinkProvider(
                   (fileContext.connectionId || isRemoteRuntimePath
                     ? await runtimePathExists(fileContext, mappedPath)
                     : await window.api.shell.pathExists(mappedPath))
-                writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
+                // Why: refreshing a cached negative's timestamp on every hover
+                // would keep frequently scanned missing paths stale forever.
+                if (cachedExists === undefined) {
+                  writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
+                }
                 if (!exists) {
                   return null
                 }

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -27,7 +27,8 @@ import {
 import {
   getTerminalPathExistsCacheKey,
   readTerminalPathExistsCache,
-  writeTerminalPathExistsCache
+  writeTerminalPathExistsCache,
+  type TerminalPathExistsCache
 } from './terminal-path-exists-cache'
 import {
   getTerminalHtmlFileOpenHint,
@@ -55,7 +56,7 @@ export type LinkHandlerDeps = {
   getPaneLinkCwd?: (paneId: number) => string | null
   managerRef: React.RefObject<PaneManager | null>
   linkProviderDisposablesRef: React.RefObject<Map<number, IDisposable>>
-  pathExistsCache: Map<string, boolean>
+  pathExistsCache: TerminalPathExistsCache
   runtimeEnvironmentId?: string | null
   terminalHomePath?: string | null
   wslDistro?: string | null

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -26,7 +26,8 @@ import {
 import {
   getTerminalPathExistsCacheKey,
   readTerminalPathExistsCache,
-  writeTerminalPathExistsCache
+  writeTerminalPathExistsCache,
+  type TerminalPathExistsCache
 } from './terminal-path-exists-cache'
 import {
   getTerminalHtmlFileOpenHint,
@@ -50,7 +51,7 @@ export type LinkHandlerDeps = {
   getPaneLinkCwd?: (paneId: number) => string | null
   managerRef: React.RefObject<PaneManager | null>
   linkProviderDisposablesRef: React.RefObject<Map<number, IDisposable>>
-  pathExistsCache: Map<string, boolean>
+  pathExistsCache: TerminalPathExistsCache
   runtimeEnvironmentId?: string | null
   terminalHomePath?: string | null
   getRuntimeEnvironmentIdForPane?: (paneId: number) => string | null

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -168,7 +168,11 @@ export function createFilePathLinkProvider(
                   (fileContext.connectionId || isRemoteRuntimePath
                     ? await runtimePathExists(fileContext, resolved.absolutePath)
                     : await window.api.shell.pathExists(resolved.absolutePath))
-                writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
+                // Why: refreshing a cached negative's timestamp on every hover
+                // would keep frequently scanned missing paths stale forever.
+                if (cachedExists === undefined) {
+                  writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
+                }
                 if (!exists) {
                   return null
                 }

--- a/src/renderer/src/components/terminal-pane/terminal-link-provider-buffer-fixtures.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-provider-buffer-fixtures.ts
@@ -2,6 +2,15 @@ import { expect, vi } from 'vitest'
 import type { IDisposable, ILink } from '@xterm/xterm'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { createFilePathLinkProvider, getTerminalFileOpenHint } from './terminal-link-handlers'
+import type { TerminalPathExistsCache } from './terminal-path-exists-cache'
+
+export function makeExistsCache(
+  entries: Iterable<[string, boolean]> = []
+): TerminalPathExistsCache {
+  return new Map(
+    [...entries].map(([key, exists]) => [key, { exists, checkedAt: Date.now() }])
+  )
+}
 import type {
   installFilePathLinkClickFallback,
   openFilePathLinkAtBufferPosition
@@ -63,7 +72,7 @@ export function makePane(rows: TestBufferLine[]): { id: number; terminal: unknow
 
 export function createProviderSetup(
   rows: TestBufferLine[],
-  pathExistsCache = new Map<string, boolean>([
+  pathExistsCache = makeExistsCache([
     ['/repo', true],
     ['/repo/CLAUDE.md', true],
     ['/repo/package.json', true],

--- a/src/renderer/src/components/terminal-pane/terminal-link-provider-link-detection.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-provider-link-detection.test.ts
@@ -11,6 +11,7 @@ import {
   createProvider,
   createProviderSetup,
   makeBufferLine,
+  makeExistsCache,
   makePane
 } from './terminal-link-provider-buffer-fixtures'
 import {
@@ -111,7 +112,7 @@ describe('createFilePathLinkProvider range bounds', () => {
     setPlatform('Macintosh')
     const { provider } = createProviderSetup(
       [makeBufferLine('/repo/unknown-dir/')],
-      new Map([['active\0/repo/unknown-dir', true]])
+      makeExistsCache([['active\0/repo/unknown-dir', true]])
     )
 
     const links = await new Promise<ILink[]>((resolve) => {
@@ -139,9 +140,9 @@ describe('createFilePathLinkProvider range bounds', () => {
   })
 
   it('bounds the terminal path-exists cache while preserving recent probes', async () => {
-    const pathExistsCache = new Map<string, boolean>()
+    const pathExistsCache = makeExistsCache()
     for (let index = 0; index < TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES; index += 1) {
-      pathExistsCache.set(`active\0/repo/old-${index}.ts`, true)
+      pathExistsCache.set(`active\0/repo/old-${index}.ts`, { exists: true, checkedAt: Date.now() })
     }
     const pane = makePane([makeBufferLine('fresh.ts')])
     const managerRef = {
@@ -168,12 +169,12 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(links.map((link) => link.text)).toEqual(['fresh.ts'])
     expect(pathExistsCache.size).toBe(TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES)
     expect(pathExistsCache.has('active\0/repo/old-0.ts')).toBe(false)
-    expect(pathExistsCache.get('active\0/repo/fresh.ts')).toBe(true)
+    expect(pathExistsCache.get('active\0/repo/fresh.ts')?.exists).toBe(true)
   })
 
   it('does not reuse SSH path-exists cache entries across connections', async () => {
     setPlatform('Macintosh')
-    const pathExistsCache = new Map<string, boolean>()
+    const pathExistsCache = makeExistsCache()
     const rows = [makeBufferLine('shared.ts')]
     const pane = makePane(rows)
     const managerRef = {

--- a/src/renderer/src/components/terminal-pane/terminal-link-provider-link-detection.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-provider-link-detection.test.ts
@@ -2,7 +2,10 @@ import type { IDisposable, ILink } from '@xterm/xterm'
 import { describe, expect, it, vi } from 'vitest'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { createFilePathLinkProvider, getTerminalFileOpenHint } from './terminal-link-handlers'
-import { TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES } from './terminal-path-exists-cache'
+import {
+  TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES,
+  type TerminalPathExistsCache
+} from './terminal-path-exists-cache'
 import { getConnectionId } from '@/lib/connection-context'
 import { createTerminalLinkTestDoubles } from './terminal-link-handlers-test-fixtures'
 import {
@@ -170,6 +173,35 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(pathExistsCache.size).toBe(TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES)
     expect(pathExistsCache.has('active\0/repo/old-0.ts')).toBe(false)
     expect(pathExistsCache.get('active\0/repo/fresh.ts')?.exists).toBe(true)
+  })
+
+  it('expires a cached missing path even when the provider scans it repeatedly', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(5_000)
+    const cacheKey = 'active\0/repo/eventually-created.ts'
+    const pathExistsCache: TerminalPathExistsCache = new Map([
+      [cacheKey, { exists: false, checkedAt: 1_000 }]
+    ])
+    const { provider } = createProviderSetup(
+      [makeBufferLine('eventually-created.ts')],
+      pathExistsCache
+    )
+
+    const firstLinks = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+    expect(firstLinks).toEqual([])
+    expect(window.api.shell.pathExists).not.toHaveBeenCalled()
+    expect(pathExistsCache.get(cacheKey)?.checkedAt).toBe(1_000)
+
+    now.mockReturnValue(11_000)
+    const refreshedLinks = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(refreshedLinks.map((link) => link.text)).toEqual(['eventually-created.ts'])
+    expect(window.api.shell.pathExists).toHaveBeenCalledOnce()
+    expect(pathExistsCache.get(cacheKey)).toEqual({ exists: true, checkedAt: 11_000 })
+    now.mockRestore()
   })
 
   it('does not reuse SSH path-exists cache entries across connections', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-worktree-root-activation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-worktree-root-activation.test.ts
@@ -246,7 +246,7 @@ describe('createFilePathLinkProvider range bounds', () => {
         worktreeId: 'wt-1',
         worktreePath: '/tmp',
         runtimeEnvironmentId: null,
-        pathExistsCache: new Map([['active\0/tmp/other-worktree', false]])
+        pathExistsCache: new Map([['active\0/tmp/other-worktree', { exists: false, checkedAt: Date.now() }]])
       }
     )
     await flushAsyncWork()

--- a/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.test.ts
@@ -26,7 +26,7 @@ describe('terminal path-exists cache', () => {
     writeTerminalPathExistsCache(cache, 'k', false, 1000)
     // Past the negative TTL: treated as a miss so the caller re-checks the
     // filesystem (the file may have since been created).
-    expect(readTerminalPathExistsCache(cache, 'k', 1000 + 11_000)).toBeUndefined()
+    expect(readTerminalPathExistsCache(cache, 'k', 1000 + 10_000)).toBeUndefined()
     expect(cache.has('k')).toBe(false)
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES,
+  getTerminalPathExistsCacheKey,
+  readTerminalPathExistsCache,
+  writeTerminalPathExistsCache,
+  type TerminalPathExistsCache
+} from './terminal-path-exists-cache'
+
+describe('terminal path-exists cache', () => {
+  it('caches a positive result, and positives are not subject to the TTL', () => {
+    const cache: TerminalPathExistsCache = new Map()
+    writeTerminalPathExistsCache(cache, 'k', true, 1000)
+    expect(readTerminalPathExistsCache(cache, 'k', 1000)).toBe(true)
+    expect(readTerminalPathExistsCache(cache, 'k', 1000 + 60_000)).toBe(true)
+  })
+
+  it('honors a negative result within the TTL window', () => {
+    const cache: TerminalPathExistsCache = new Map()
+    writeTerminalPathExistsCache(cache, 'k', false, 1000)
+    expect(readTerminalPathExistsCache(cache, 'k', 1000 + 5_000)).toBe(false)
+  })
+
+  it('re-probes (cache miss) once a negative result expires — issue #5024', () => {
+    const cache: TerminalPathExistsCache = new Map()
+    writeTerminalPathExistsCache(cache, 'k', false, 1000)
+    // Past the negative TTL: treated as a miss so the caller re-checks the
+    // filesystem (the file may have since been created).
+    expect(readTerminalPathExistsCache(cache, 'k', 1000 + 11_000)).toBeUndefined()
+    expect(cache.has('k')).toBe(false)
+  })
+
+  it('returns undefined for an unknown key', () => {
+    expect(readTerminalPathExistsCache(new Map(), 'missing')).toBeUndefined()
+  })
+
+  it('bounds the cache to the max entry count, evicting the oldest', () => {
+    const cache: TerminalPathExistsCache = new Map()
+    for (let i = 0; i < TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES; i++) {
+      writeTerminalPathExistsCache(cache, `k-${i}`, true, 1)
+    }
+    expect(cache.size).toBe(TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES)
+    writeTerminalPathExistsCache(cache, 'k-fresh', true, 2)
+    expect(cache.size).toBe(TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES)
+    expect(cache.has('k-0')).toBe(false)
+    expect(cache.has('k-fresh')).toBe(true)
+  })
+
+  it('scopes keys by SSH connection and runtime environment', () => {
+    const abs = '/repo/file.ts'
+    expect(getTerminalPathExistsCacheKey({ absolutePath: abs })).toBe(`active\0${abs}`)
+    expect(getTerminalPathExistsCacheKey({ absolutePath: abs, connectionId: 'ssh-1' })).toBe(
+      `ssh:ssh-1\0${abs}`
+    )
+    expect(
+      getTerminalPathExistsCacheKey({
+        absolutePath: abs,
+        isRemoteRuntimePath: true,
+        runtimeEnvironmentId: 'env-1'
+      })
+    ).toBe(`env-1\0${abs}`)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts
@@ -45,7 +45,7 @@ export function readTerminalPathExistsCache(
   }
   // Why: an expired "missing" entry is treated as a cache miss so the caller
   // re-probes the filesystem (the file may have since been created).
-  if (!entry.exists && now - entry.checkedAt > NEGATIVE_PATH_EXISTS_TTL_MS) {
+  if (!entry.exists && now - entry.checkedAt >= NEGATIVE_PATH_EXISTS_TTL_MS) {
     cache.delete(key)
     return undefined
   }

--- a/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-path-exists-cache.ts
@@ -1,5 +1,15 @@
 export const TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES = 1024
 
+// Why (issue #5024): a path can be printed in the terminal a moment before the
+// file it names actually exists. Caching that "missing" result forever leaves
+// the link permanently dead even after the file appears. Re-probe negatives
+// after a short window; positive results stay cached (files rarely vanish
+// mid-session, and a stale positive fails gracefully on open).
+const NEGATIVE_PATH_EXISTS_TTL_MS = 10_000
+
+type TerminalPathExistsCacheEntry = { exists: boolean; checkedAt: number }
+export type TerminalPathExistsCache = Map<string, TerminalPathExistsCacheEntry>
+
 // Why: POSIX-looking SSH paths are only meaningful inside their connection;
 // local/runtime keys keep the legacy scope so existing hover probes stay hot.
 export function getTerminalPathExistsCacheKey({
@@ -25,21 +35,30 @@ export function getTerminalPathExistsCacheKey({
 }
 
 export function readTerminalPathExistsCache(
-  cache: Map<string, boolean>,
-  key: string
+  cache: TerminalPathExistsCache,
+  key: string,
+  now: number = Date.now()
 ): boolean | undefined {
-  const value = cache.get(key)
-  if (value !== undefined) {
-    cache.delete(key)
-    cache.set(key, value)
+  const entry = cache.get(key)
+  if (entry === undefined) {
+    return undefined
   }
-  return value
+  // Why: an expired "missing" entry is treated as a cache miss so the caller
+  // re-probes the filesystem (the file may have since been created).
+  if (!entry.exists && now - entry.checkedAt > NEGATIVE_PATH_EXISTS_TTL_MS) {
+    cache.delete(key)
+    return undefined
+  }
+  cache.delete(key)
+  cache.set(key, entry)
+  return entry.exists
 }
 
 export function writeTerminalPathExistsCache(
-  cache: Map<string, boolean>,
+  cache: TerminalPathExistsCache,
   key: string,
-  exists: boolean
+  exists: boolean,
+  now: number = Date.now()
 ): void {
   if (cache.has(key)) {
     cache.delete(key)
@@ -54,5 +73,5 @@ export function writeTerminalPathExistsCache(
       cache.delete(oldestKey)
     }
   }
-  cache.set(key, exists)
+  cache.set(key, { exists, checkedAt: now })
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -38,6 +38,7 @@ import {
 } from './terminal-link-open-hints'
 import { createTerminalHandleLinkProvider } from './terminal-handle-links'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
+import type { TerminalPathExistsCache } from './terminal-path-exists-cache'
 import { handleOscLink } from './terminal-osc-link-routing'
 import { handleTerminalWebLinkClick } from './terminal-web-link-click'
 import {
@@ -801,8 +802,10 @@ export function useTerminalPaneLifecycle({
         focusTerminal: () => pane.terminal.focus()
       }
     }
-    // Why: lifecycle-scoped cache for cross-SSH/runtime existence probes; may hold temporarily stale entries.
-    const pathExistsCache = new Map<string, boolean>()
+    // Why: existence probes can cross SSH/runtime boundaries. This cache is
+    // lifecycle-scoped, so external mutations and the initial 'active' runtime
+    // fallback can temporarily leave stale entries.
+    const pathExistsCache: TerminalPathExistsCache = new Map()
     const linkDeps: LinkHandlerDeps = {
       worktreeId,
       worktreePath,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -30,6 +30,7 @@ import {
 } from './terminal-link-handlers'
 import { createTerminalHandleLinkProvider } from './terminal-handle-links'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
+import type { TerminalPathExistsCache } from './terminal-path-exists-cache'
 import { handleOscLink } from './terminal-osc-link-routing'
 import {
   installHttpLinkClickFallback,
@@ -664,7 +665,7 @@ export function useTerminalPaneLifecycle({
     // Why: existence probes can cross SSH/runtime boundaries. This cache is
     // lifecycle-scoped, so external mutations and the initial 'active' runtime
     // fallback can temporarily leave stale entries.
-    const pathExistsCache = new Map<string, boolean>()
+    const pathExistsCache: TerminalPathExistsCache = new Map()
     const linkDeps: LinkHandlerDeps = {
       worktreeId,
       worktreePath,


### PR DESCRIPTION
## Summary

Refs #5024.

A terminal file path printed **a moment before its file exists** stays permanently un-clickable, even after the file lands. The link provider caches filesystem-existence per pane, but **negatives were cached forever** with no expiry — so a path checked while the file was still missing got stuck as "missing."

Concrete repro from this session: the *same* path (`~/Desktop/…mp4`) was **not** clickable where it was first printed (checked an instant before the file was written → cached missing), but **was** clickable in a later mention (re-checked after the file existed). This is exactly the case Jinwoo-H flagged on #5024 ("tried before the file existed, and the build cached the missing result").

This gives **negative** results a short **TTL** (~10s): a cached "missing" older than the window is treated as a cache miss, so the next hover re-probes the filesystem and the link goes live. Positives stay cached (files rarely vanish mid-session, and a stale positive fails gracefully on open). Cache entries become `{ exists, checkedAt }`, and both readers — the hover link provider and the click-fallback — go through the shared read helper so the TTL applies uniformly.

This is **independent** of #6269 (that one is bare-name → workspace resolution; this is existence-caching).

## Screenshots

No visual change — behavioral only (a previously-stuck path becomes clickable on the next hover once its file exists).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (full `terminal-pane` suite — 1087 tests; new `terminal-path-exists-cache.test.ts`)
- [x] `pnpm build`
- [x] Added tests: positive cached (no TTL); negative honored within TTL; negative re-probes (miss) after expiry; unknown-key miss; LRU eviction at the max-entry bound; SSH/runtime key scoping. Existing `terminal-link-handlers.test.ts` migrated to the `{ exists, checkedAt }` entry shape and still passes.

## AI Review Report

Reviewed for:
- **Cross-platform (macOS/Linux/Windows):** pure timestamp arithmetic and a Map; no path/shell/shortcut behavior touched. `Date.now()` is injectable for deterministic tests.
- **SSH / remote:** cache keys remain scoped by SSH `connectionId` / runtime environment (unchanged); the TTL applies per key, so remote negatives re-probe the same way.
- **Agent/integration:** no IPC/store/data-model changes; the existence probe itself (`window.api.shell.pathExists` / `runtimePathExists`) is unchanged — only how long a "missing" answer is trusted.
- **Performance:** positives still cached indefinitely; only negatives re-probe, and only after the TTL and only when that line is re-scanned — so steady-state hover cost is unchanged. LRU bound (1024 entries) preserved.

What changed as a result: routed the click-fallback's direct `.get()` through the shared read helper so it also respects the TTL (it previously read raw booleans).

## Security Audit

- **Path handling:** no new path construction or input; the resolved absolute path and existence check are unchanged. The fix only affects cache *retention* of a boolean existence result.
- **Command execution / IPC / secrets / deps:** none touched; no new dependencies.

## Notes

- TTL is negatives-only and set to ~10s — long enough to avoid re-stat churn, short enough that a just-created file becomes clickable on the next hover. Positives are intentionally not expired.
- A fuller approach (invalidate on `fs:changed`) was considered but the TTL alone resolves the reported case with far less surface area.
- cc @Jinwoo-H — this implements the stale-"missing"-cache piece you diagnosed on #5024.

## ELI5

Terminal file links that were checked before the file existed stayed permanently unclickable. Missing-path cache entries expire so links become live after the file appears.
