### PR TITLE
Increase Quick Command agent prompt limit

### DIFF
--- a/src/shared/terminal-quick-commands.test.ts
+++ b/src/shared/terminal-quick-commands.test.ts
@@ -159,6 +159,61 @@ describe('terminal quick commands', () => {
     ])
   })
 
+  it('keeps larger reusable agent prompts while bounding shell commands separately', () => {
+    const largePrompt = 'Review this diff.\n'.repeat(320)
+    const overLimitPrompt = 'x'.repeat(6001)
+    const overLimitCommand = 'y'.repeat(4001)
+
+    expect(
+      normalizeTerminalQuickCommands([
+        {
+          id: 'large-review',
+          label: 'Review',
+          action: 'agent-prompt',
+          agent: 'codex',
+          prompt: largePrompt
+        },
+        {
+          id: 'over-limit-review',
+          label: 'Review with cap',
+          action: 'agent-prompt',
+          agent: 'codex',
+          prompt: overLimitPrompt
+        },
+        {
+          id: 'over-limit-command',
+          label: 'Run long command',
+          command: overLimitCommand
+        }
+      ])
+    ).toEqual([
+      {
+        id: 'large-review',
+        label: 'Review',
+        action: 'agent-prompt',
+        agent: 'codex',
+        prompt: largePrompt.trimEnd(),
+        scope: { type: 'global' }
+      },
+      {
+        id: 'over-limit-review',
+        label: 'Review with cap',
+        action: 'agent-prompt',
+        agent: 'codex',
+        prompt: 'x'.repeat(6000),
+        scope: { type: 'global' }
+      },
+      {
+        id: 'over-limit-command',
+        label: 'Run long command',
+        action: 'terminal-command',
+        command: 'y'.repeat(4000),
+        appendEnter: true,
+        scope: { type: 'global' }
+      }
+    ])
+  })
+
   it('matches global commands everywhere and repo commands only in their repo', () => {
     expect(
       terminalQuickCommandMatchesRepo(

--- a/src/shared/terminal-quick-commands.ts
+++ b/src/shared/terminal-quick-commands.ts
@@ -10,7 +10,10 @@ import type {
 const MAX_QUICK_COMMANDS = 40
 const MAX_QUICK_COMMAND_LABEL_LENGTH = 80
 const MAX_QUICK_COMMAND_REPO_ID_LENGTH = 200
-const MAX_QUICK_COMMAND_TEXT_LENGTH = 4000
+const MAX_QUICK_COMMAND_TERMINAL_TEXT_LENGTH = 4000
+// Why: agent prompt quick commands still launch through startup commands for
+// argv/flag agents, so this must stay within Orca's Windows shell safety cap.
+const MAX_QUICK_COMMAND_AGENT_PROMPT_LENGTH = 6000
 const REMOVED_PRESET_IDS = new Set(['default-pwd', 'default-git-status'])
 
 const DEFAULT_TERMINAL_QUICK_COMMANDS: TerminalQuickCommand[] = []
@@ -133,7 +136,7 @@ export function normalizeTerminalQuickCommands(input: unknown): TerminalQuickCom
         agent: agentId,
         prompt: (hasPrompt ? String(record.prompt).trimEnd() : '').slice(
           0,
-          MAX_QUICK_COMMAND_TEXT_LENGTH
+          MAX_QUICK_COMMAND_AGENT_PROMPT_LENGTH
         )
       })
     } else {
@@ -141,7 +144,7 @@ export function normalizeTerminalQuickCommands(input: unknown): TerminalQuickCom
       normalized.push({
         ...base,
         action: 'terminal-command',
-        command: command.slice(0, MAX_QUICK_COMMAND_TEXT_LENGTH),
+        command: command.slice(0, MAX_QUICK_COMMAND_TERMINAL_TEXT_LENGTH),
         appendEnter: record.appendEnter !== false
       })
     }


### PR DESCRIPTION
## Summary
- increase saved agent Quick Command prompts from 4,000 to 6,000 characters
- keep terminal command Quick Commands capped at 4,000 characters
- add regression coverage for separate agent prompt and terminal command caps

## Rationale
6,000 is not a general prompt-size standard. It matches Orca’s existing Windows shell startup safety cap, which matters because agent Quick Command prompts can still launch through startup command text for argv/flag-style agents. Larger reusable review rubrics should move into skills or a future non-argv prompt transport instead of pushing this storage cap higher.

## Validation
- pnpm vitest run src/shared/terminal-quick-commands.test.ts
- pnpm exec oxlint src/shared/terminal-quick-commands.ts src/shared/terminal-quick-commands.test.ts
- pnpm run typecheck:node
- git diff --check

## Review
- Spawned review-code subagent; addressed its Windows/shell limit finding by splitting terminal and agent caps and using a 6,000-character agent prompt cap.