### PR TITLE
Fix terminal scroll restore across workspace switches

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1330,15 +1330,15 @@ function cloneLayoutWithLeafIds(
   }
 }
 
-function remapLeafRecordForPersistence(
-  source: Record<string, string> | undefined,
+function remapLeafRecordForPersistence<T>(
+  source: Record<string, T> | undefined,
   leafIdByInputLeafId: Map<string, string>,
   duplicatedInputLeafIds: Set<string>
-): Record<string, string> | undefined {
+): Record<string, T> | undefined {
   if (!source) {
     return undefined
   }
-  const next: Record<string, string> = {}
+  const next: Record<string, T> = {}
   for (const [leafId, value] of Object.entries(source)) {
     if (duplicatedInputLeafIds.has(leafId)) {
       continue
@@ -1351,9 +1351,9 @@ function remapLeafRecordForPersistence(
   return Object.keys(next).length > 0 ? next : undefined
 }
 
-function leafRecordEquivalent(
-  left: Record<string, string> | undefined,
-  right: Record<string, string> | undefined
+function leafRecordEquivalent<T>(
+  left: Record<string, T> | undefined,
+  right: Record<string, T> | undefined
 ): boolean {
   const leftEntries = Object.entries(left ?? {})
   const rightRecord = right ?? {}
@@ -1363,11 +1363,11 @@ function leafRecordEquivalent(
   return leftEntries.every(([key, value]) => rightRecord[key] === value)
 }
 
-function preserveMissingLeafRecordEntries(
-  priorRecord: Record<string, string> | undefined,
-  incomingRecord: Record<string, string> | undefined,
+function preserveMissingLeafRecordEntries<T>(
+  priorRecord: Record<string, T> | undefined,
+  incomingRecord: Record<string, T> | undefined,
   liveLeafIds: Set<string>
-): Record<string, string> | undefined {
+): Record<string, T> | undefined {
   const preserved = Object.fromEntries(
     Object.entries(priorRecord ?? {}).filter(
       ([leafId]) => liveLeafIds.has(leafId) && incomingRecord?.[leafId] === undefined
@@ -1608,6 +1608,11 @@ function normalizeTerminalLayoutSnapshotForPersistence(
     leafIdByInputLeafId,
     duplicatedInputLeafIds
   )
+  const scrollStatesByLeafId = remapLeafRecordForPersistence(
+    inputSnapshot.scrollStatesByLeafId,
+    leafIdByInputLeafId,
+    duplicatedInputLeafIds
+  )
   const titlesByLeafId = remapLeafRecordForPersistence(
     inputSnapshot.titlesByLeafId,
     leafIdByInputLeafId,
@@ -1617,6 +1622,7 @@ function normalizeTerminalLayoutSnapshotForPersistence(
     !leafRecordEquivalent(inputSnapshot.ptyIdsByLeafId, ptyIdsByLeafId) ||
     !leafRecordEquivalent(inputSnapshot.buffersByLeafId, buffersByLeafId) ||
     !leafRecordEquivalent(inputSnapshot.scrollbackRefsByLeafId, scrollbackRefsByLeafId) ||
+    !leafRecordEquivalent(inputSnapshot.scrollStatesByLeafId, scrollStatesByLeafId) ||
     !leafRecordEquivalent(inputSnapshot.titlesByLeafId, titlesByLeafId)
   const metadataChanged =
     activeLeafId !== inputSnapshot.activeLeafId || expandedLeafId !== inputSnapshot.expandedLeafId
@@ -1627,6 +1633,7 @@ function normalizeTerminalLayoutSnapshotForPersistence(
     ptyIdsByLeafId: _oldPtyIdsByLeafId,
     buffersByLeafId: _oldBuffersByLeafId,
     scrollbackRefsByLeafId: _oldScrollbackRefsByLeafId,
+    scrollStatesByLeafId: _oldScrollStatesByLeafId,
     titlesByLeafId: _oldTitlesByLeafId,
     ...snapshotWithoutLeafRecords
   } = inputSnapshot
@@ -1639,6 +1646,7 @@ function normalizeTerminalLayoutSnapshotForPersistence(
       ...(ptyIdsByLeafId ? { ptyIdsByLeafId } : {}),
       ...(buffersByLeafId ? { buffersByLeafId } : {}),
       ...(scrollbackRefsByLeafId ? { scrollbackRefsByLeafId } : {}),
+      ...(scrollStatesByLeafId ? { scrollStatesByLeafId } : {}),
       ...(titlesByLeafId ? { titlesByLeafId } : {})
     },
     changed: true,
@@ -5084,6 +5092,11 @@ export class Store {
             layout.scrollbackRefsByLeafId,
             liveLeafIds
           )
+          const scrollStatesByLeafId = preserveMissingLeafRecordEntries(
+            priorLayout.scrollStatesByLeafId,
+            layout.scrollStatesByLeafId,
+            liveLeafIds
+          )
           const titlesByLeafId = preserveMissingLeafRecordEntries(
             priorLayout.titlesByLeafId,
             layout.titlesByLeafId,
@@ -5094,6 +5107,9 @@ export class Store {
           }
           if (scrollbackRefsByLeafId) {
             layout.scrollbackRefsByLeafId = scrollbackRefsByLeafId
+          }
+          if (scrollStatesByLeafId) {
+            layout.scrollStatesByLeafId = scrollStatesByLeafId
           }
           if (titlesByLeafId) {
             layout.titlesByLeafId = titlesByLeafId

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3342,6 +3342,9 @@ export class OrcaRuntimeService {
     if (layout.scrollbackRefsByLeafId) {
       cloned.scrollbackRefsByLeafId = { ...layout.scrollbackRefsByLeafId }
     }
+    if (layout.scrollStatesByLeafId) {
+      cloned.scrollStatesByLeafId = { ...layout.scrollStatesByLeafId }
+    }
     if (layout.titlesByLeafId) {
       cloned.titlesByLeafId = { ...layout.titlesByLeafId }
     }

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -95,7 +95,11 @@ import {
   isHostAuthoritativeLayout,
   planTerminalLiveLayoutInsertions
 } from './terminal-live-layout-reconciliation'
-import type { TerminalQuickCommand, TerminalQuickCommandScope } from '../../../../shared/types'
+import type {
+  TerminalQuickCommand,
+  TerminalQuickCommandScope,
+  TerminalScrollStateSnapshot
+} from '../../../../shared/types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { refitAndRefreshAllTerminalPanes } from '@/lib/pane-manager/pane-manager-registry'
@@ -261,6 +265,13 @@ export default function TerminalPane({
   isActiveRef.current = isActive
   const isVisibleRef = useRef(isVisible)
   isVisibleRef.current = isVisible
+  const suppressScrollPersistenceRef = useRef(false)
+  const previousVisibleForScrollPersistenceRef = useRef(isVisible)
+  const lastVisibleScrollStatesByLeafIdRef = useRef<Record<
+    string,
+    TerminalScrollStateSnapshot
+  > | null>(null)
+  const transitionScrollRestoreFrameIdsRef = useRef<number[]>([])
 
   const [expandedPaneId, setExpandedPaneId] = useState<number | null>(null)
   // Why: tracked in React state (not derived from managerRef.getPanes().length)
@@ -453,6 +464,8 @@ export default function TerminalPane({
   )
   const clearCodexRestartNotice = useAppStore((store) => store.clearCodexRestartNotice)
   const savedLayout = useAppStore((store) => store.terminalLayoutsByTabId[tabId] ?? EMPTY_LAYOUT)
+  const savedScrollStatesByLeafIdRef = useRef(savedLayout.scrollStatesByLeafId)
+  savedScrollStatesByLeafIdRef.current = savedLayout.scrollStatesByLeafId
   const terminalTab = useAppStore((store) =>
     getCachedTerminalTabForWorktree(store.tabsByWorktree, worktreeId, tabId)
   )
@@ -782,21 +795,50 @@ export default function TerminalPane({
     }
   }, [tabId, setTabLayout, worktreeId])
 
-  const persistCurrentScrollStates = useCallback((): void => {
-    const manager = managerRef.current
-    if (!manager) {
-      return
-    }
-    const scrollStatesByLeafId = Object.fromEntries(
-      manager.getPanes().map((pane) => {
-        const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
-        return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
-      })
-    )
-    if (Object.keys(scrollStatesByLeafId).length > 0) {
-      updateTabScrollStates(tabId, scrollStatesByLeafId)
-    }
-  }, [tabId, updateTabScrollStates])
+  const persistCurrentScrollStates = useCallback(
+    (options?: { useLastVisible?: boolean }): void => {
+      const rememberedScrollStates = options?.useLastVisible
+        ? lastVisibleScrollStatesByLeafIdRef.current
+        : null
+      if (rememberedScrollStates && Object.keys(rememberedScrollStates).length > 0) {
+        updateTabScrollStates(tabId, rememberedScrollStates)
+        return
+      }
+      if (options?.useLastVisible) {
+        return
+      }
+      if (suppressScrollPersistenceRef.current) {
+        const manager = managerRef.current
+        const scrollStatesByLeafId = savedScrollStatesByLeafIdRef.current
+        if (manager && scrollStatesByLeafId) {
+          for (const pane of manager.getPanes()) {
+            const scrollState = scrollStatesByLeafId[pane.leafId]
+            if (scrollState) {
+              restoreScrollStateAfterLayout(pane.terminal, scrollState)
+            }
+          }
+        }
+        return
+      }
+      const manager = managerRef.current
+      if (!manager) {
+        return
+      }
+      const scrollStatesByLeafId = Object.fromEntries(
+        manager.getPanes().map((pane) => {
+          const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+          return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
+        })
+      )
+      if (Object.keys(scrollStatesByLeafId).length > 0) {
+        if (isVisibleRef.current) {
+          lastVisibleScrollStatesByLeafIdRef.current = scrollStatesByLeafId
+        }
+        updateTabScrollStates(tabId, scrollStatesByLeafId)
+      }
+    },
+    [tabId, updateTabScrollStates]
+  )
 
   useLayoutEffect(() => {
     if (!isVisible) {
@@ -805,7 +847,7 @@ export default function TerminalPane({
     return () => {
       // Why: workspace switches can hide terminals before the next scroll rAF.
       // Persist the last visible xterm viewport without serializing layout.
-      persistCurrentScrollStates()
+      persistCurrentScrollStates({ useLastVisible: true })
     }
   }, [isVisible, persistCurrentScrollStates])
 
@@ -850,23 +892,6 @@ export default function TerminalPane({
   }, [isVisible, paneCount, persistCurrentScrollStates])
 
   const wasVisibleForScrollRestoreRef = useRef(isVisible)
-  useEffect(() => {
-    const wasVisible = wasVisibleForScrollRestoreRef.current
-    wasVisibleForScrollRestoreRef.current = isVisible
-    if (!isVisible || wasVisible || !savedLayout.scrollStatesByLeafId) {
-      return
-    }
-    const manager = managerRef.current
-    if (!manager) {
-      return
-    }
-    for (const pane of manager.getPanes()) {
-      const scrollState = savedLayout.scrollStatesByLeafId[pane.leafId]
-      if (scrollState) {
-        restoreScrollStateAfterLayout(pane.terminal, scrollState)
-      }
-    }
-  }, [isVisible, savedLayout.scrollStatesByLeafId])
 
   const clearPaneScrollback = useCallback(
     (pane: ManagedPane): void => {
@@ -1324,6 +1349,7 @@ export default function TerminalPane({
         worktreeId,
         cwd,
         startup: { command: 'codex' },
+        restoredScrollStatesByLeafId: savedScrollStatesByLeafIdRef.current,
         paneTransportsRef,
         paneMode2031Ref,
         paneLastThemeModeRef,
@@ -1424,6 +1450,16 @@ export default function TerminalPane({
     terminalShortcutPolicy: settings?.terminalShortcutPolicy ?? 'orca-first'
   })
 
+  useLayoutEffect(() => {
+    const wasVisible = previousVisibleForScrollPersistenceRef.current
+    previousVisibleForScrollPersistenceRef.current = isVisible
+    if (wasVisible !== isVisible) {
+      // Why: xterm emits programmatic top-scroll events while panes suspend,
+      // resume, and refit. Those are layout mechanics, not user scrolls.
+      suppressScrollPersistenceRef.current = true
+    }
+  }, [isVisible])
+
   useTerminalPaneGlobalEffects({
     tabId,
     // Why: use the pane's own `worktreeId` prop (not global activeWorktreeId)
@@ -1447,6 +1483,59 @@ export default function TerminalPane({
     isVisibleRef,
     toggleExpandPane
   })
+
+  useLayoutEffect(() => {
+    const wasVisible = wasVisibleForScrollRestoreRef.current
+    wasVisibleForScrollRestoreRef.current = isVisible
+    if (!isVisible) {
+      return undefined
+    }
+    const manager = managerRef.current
+    const restoreSavedScrollStates = (): void => {
+      const currentManager = managerRef.current
+      const scrollStatesByLeafId = savedScrollStatesByLeafIdRef.current
+      if (!currentManager || !scrollStatesByLeafId) {
+        return
+      }
+      for (const pane of currentManager.getPanes()) {
+        const scrollState = scrollStatesByLeafId[pane.leafId]
+        if (scrollState) {
+          restoreScrollStateAfterLayout(pane.terminal, scrollState)
+        }
+      }
+    }
+    if (manager && !wasVisible && savedScrollStatesByLeafIdRef.current) {
+      restoreSavedScrollStates()
+      let remainingFrames = 24
+      const restoreDuringTransition = (): void => {
+        if (!isVisibleRef.current) {
+          suppressScrollPersistenceRef.current = false
+          return
+        }
+        restoreSavedScrollStates()
+        remainingFrames -= 1
+        if (remainingFrames <= 0) {
+          suppressScrollPersistenceRef.current = false
+          return
+        }
+        const frameId = requestAnimationFrame(restoreDuringTransition)
+        transitionScrollRestoreFrameIdsRef.current.push(frameId)
+      }
+      const frameId = requestAnimationFrame(restoreDuringTransition)
+      transitionScrollRestoreFrameIdsRef.current.push(frameId)
+      return () => {
+        for (const pendingFrameId of transitionScrollRestoreFrameIdsRef.current) {
+          cancelAnimationFrame(pendingFrameId)
+        }
+        transitionScrollRestoreFrameIdsRef.current = []
+        suppressScrollPersistenceRef.current = false
+      }
+    }
+    if (suppressScrollPersistenceRef.current) {
+      suppressScrollPersistenceRef.current = false
+    }
+    return undefined
+  }, [isVisible])
 
   useEffect(() => {
     if (

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -15,6 +15,7 @@ import {
   resolveEffectiveTerminalAppearance
 } from '@/lib/terminal-theme'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import { captureScrollState, restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import TerminalSearch from '@/components/TerminalSearch'
 import type { PtyTransport } from './pty-transport'
 import { fitPanes, isWindowsUserAgent } from './pane-helpers'
@@ -456,6 +457,7 @@ export default function TerminalPane({
     getCachedTerminalTabForWorktree(store.tabsByWorktree, worktreeId, tabId)
   )
   const setTabLayout = useAppStore((store) => store.setTabLayout)
+  const updateTabScrollStates = useAppStore((store) => store.updateTabScrollStates)
   const restoredLayout = useMemo(
     () => (terminalTab ? sanitizeTerminalLayoutPaneTitles(savedLayout, terminalTab) : savedLayout),
     [savedLayout, terminalTab]
@@ -697,6 +699,23 @@ export default function TerminalPane({
     if (Object.keys(mergedScrollbackRefs).length > 0) {
       layout.scrollbackRefsByLeafId = mergedScrollbackRefs
     }
+    // Why: hidden xterm instances can transiently report viewportY=0 during
+    // WebGL suspend/refit; keep the last visible leaf state durable instead.
+    const scrollStatesByLeafId = isVisibleRef.current
+      ? Object.fromEntries(
+          currentPanes.map((pane) => {
+            const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+            return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
+          })
+        )
+      : mergeCapturedLeafState({
+          prior: existing?.scrollStatesByLeafId,
+          fresh: {},
+          currentLeafIds
+        })
+    if (Object.keys(scrollStatesByLeafId).length > 0) {
+      layout.scrollStatesByLeafId = scrollStatesByLeafId
+    }
     // Why: between pane creation and the deferred rAF where PTYs actually
     // attach, all transports have getPtyId() === null. The merge below
     // preserves the *prior* snapshot's leaf→PTY mappings while still letting
@@ -762,6 +781,92 @@ export default function TerminalPane({
       clearedScrollbackLeafIds.delete(leafId)
     }
   }, [tabId, setTabLayout, worktreeId])
+
+  const persistCurrentScrollStates = useCallback((): void => {
+    const manager = managerRef.current
+    if (!manager) {
+      return
+    }
+    const scrollStatesByLeafId = Object.fromEntries(
+      manager.getPanes().map((pane) => {
+        const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+        return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
+      })
+    )
+    if (Object.keys(scrollStatesByLeafId).length > 0) {
+      updateTabScrollStates(tabId, scrollStatesByLeafId)
+    }
+  }, [tabId, updateTabScrollStates])
+
+  useLayoutEffect(() => {
+    if (!isVisible) {
+      return
+    }
+    return () => {
+      // Why: workspace switches can hide terminals before the next scroll rAF.
+      // Persist the last visible xterm viewport without serializing layout.
+      persistCurrentScrollStates()
+    }
+  }, [isVisible, persistCurrentScrollStates])
+
+  useEffect(() => {
+    if (!isVisible) {
+      return
+    }
+    const scrollDisposables: IDisposable[] = []
+    const persistScrolledLayout = (event: Event): void => {
+      const root = containerRef.current
+      const target = event.target
+      if (!root || !(target instanceof Node) || !root.contains(target)) {
+        return
+      }
+      persistCurrentScrollStates()
+    }
+    const persistScrolledTerminal = (): void => {
+      persistCurrentScrollStates()
+    }
+    const manager = managerRef.current
+    if (manager) {
+      for (const pane of manager.getPanes()) {
+        const onScroll = (
+          pane.terminal as typeof pane.terminal & {
+            onScroll?: (listener: (position: number) => void) => IDisposable
+          }
+        ).onScroll
+        if (typeof onScroll === 'function') {
+          scrollDisposables.push(onScroll.call(pane.terminal, persistScrolledTerminal))
+        }
+      }
+    }
+    // Why: workspace switches can remount or refit xterm before passive
+    // visibility effects run; keep the durable leaf state current as the user scrolls.
+    window.addEventListener('scroll', persistScrolledLayout, true)
+    return () => {
+      window.removeEventListener('scroll', persistScrolledLayout, true)
+      for (const disposable of scrollDisposables) {
+        disposable.dispose()
+      }
+    }
+  }, [isVisible, paneCount, persistCurrentScrollStates])
+
+  const wasVisibleForScrollRestoreRef = useRef(isVisible)
+  useEffect(() => {
+    const wasVisible = wasVisibleForScrollRestoreRef.current
+    wasVisibleForScrollRestoreRef.current = isVisible
+    if (!isVisible || wasVisible || !savedLayout.scrollStatesByLeafId) {
+      return
+    }
+    const manager = managerRef.current
+    if (!manager) {
+      return
+    }
+    for (const pane of manager.getPanes()) {
+      const scrollState = savedLayout.scrollStatesByLeafId[pane.leafId]
+      if (scrollState) {
+        restoreScrollStateAfterLayout(pane.terminal, scrollState)
+      }
+    }
+  }, [isVisible, savedLayout.scrollStatesByLeafId])
 
   const clearPaneScrollback = useCallback(
     (pane: ManagedPane): void => {

--- a/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable max-lines -- Why: this test keeps split layout replay fixtures together so
  * stable leaf-id migration regressions are visible in one focused suite. */
-import { describe, expect, it, beforeAll } from 'vitest'
+import { describe, expect, it, beforeAll, vi } from 'vitest'
 import type { TerminalPaneLayoutNode } from '../../../../shared/types'
 
 // ---------------------------------------------------------------------------
@@ -40,7 +40,8 @@ import {
   serializeTerminalLayout,
   EMPTY_LAYOUT,
   collectLeafIdsInOrder,
-  collectLeafIdsInReplayCreationOrder
+  collectLeafIdsInReplayCreationOrder,
+  replayTerminalLayout
 } from './layout-serialization'
 
 // ---------------------------------------------------------------------------
@@ -318,6 +319,42 @@ describe('serializeTerminalLayout', () => {
       root: { type: 'leaf', leafId: LEAF_1 },
       activeLeafId: null,
       expandedLeafId: null
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// replayTerminalLayout
+// ---------------------------------------------------------------------------
+describe('replayTerminalLayout', () => {
+  it('does not schedule moved-pane scroll restore while rebuilding saved splits', () => {
+    const initialPane = { id: 1, leafId: LEAF_1 }
+    const createdPane = { id: 2, leafId: LEAF_2 }
+    const manager = {
+      createInitialPane: vi.fn(() => initialPane),
+      splitPane: vi.fn(() => createdPane),
+      getActivePane: vi.fn(() => initialPane)
+    }
+
+    replayTerminalLayout(
+      manager as never,
+      {
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: LEAF_1 },
+          second: { type: 'leaf', leafId: LEAF_2 }
+        },
+        activeLeafId: LEAF_1,
+        expandedLeafId: null
+      },
+      true
+    )
+
+    expect(manager.splitPane).toHaveBeenCalledWith(1, 'vertical', {
+      ratio: undefined,
+      leafId: LEAF_2,
+      restoreMovedPaneScroll: false
     })
   })
 })

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -274,7 +274,11 @@ export function replayTerminalLayout(
 
     const createdPane = manager.splitPane(paneId, node.direction as TerminalPaneSplitDirection, {
       ratio: node.ratio,
-      leafId: getLeftmostLeafId(node.second)
+      leafId: getLeftmostLeafId(node.second),
+      // Why: replay splits an empty initial pane before scrollback restore.
+      // Restoring that pre-replay viewport later would jump the restored pane
+      // back to the top.
+      restoreMovedPaneScroll: false
     })
     if (!createdPane) {
       restoreNode(node.first, paneId)

--- a/src/renderer/src/components/terminal-pane/merge-captured-leaf-state.ts
+++ b/src/renderer/src/components/terminal-pane/merge-captured-leaf-state.ts
@@ -8,12 +8,12 @@
 
 export type LeafStringMap = Record<string, string>
 
-export function mergeCapturedLeafState(opts: {
-  prior: LeafStringMap | undefined
-  fresh: LeafStringMap
+export function mergeCapturedLeafState<T = string>(opts: {
+  prior: Record<string, T> | undefined
+  fresh: Record<string, T>
   currentLeafIds: ReadonlySet<string>
-}): LeafStringMap {
-  const merged: LeafStringMap = {}
+}): Record<string, T> {
+  const merged: Record<string, T> = {}
   if (opts.prior) {
     for (const [leafId, value] of Object.entries(opts.prior)) {
       if (opts.currentLeafIds.has(leafId)) {

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -4,7 +4,7 @@ import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinat
 import type { EventProps } from '../../../../shared/telemetry-events'
 import type { TerminalColorSchemeMode } from '../../../../shared/terminal-color-scheme-protocol'
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
-import type { TuiAgent } from '../../../../shared/types'
+import type { TerminalScrollStateSnapshot, TuiAgent } from '../../../../shared/types'
 import type { SleepingAgentLaunchConfig } from '../../../../shared/agent-session-resume'
 
 export type PtyConnectionDeps = {
@@ -31,6 +31,7 @@ export type PtyConnectionDeps = {
   } | null
   restoredLeafId?: string | null
   restoredPtyIdByLeafId?: Record<string, string>
+  restoredScrollStatesByLeafId?: Record<string, TerminalScrollStateSnapshot>
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
   paneMode2031Ref: React.RefObject<Map<number, boolean>>
   paneLastThemeModeRef: React.RefObject<Map<number, TerminalColorSchemeMode>>

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -800,6 +800,7 @@ export function connectPanePty(
   let unregisterDocumentVisibilityRecovery: (() => void) | null = null
   let cleanupHiddenOutputRestoreDeferredRetry = (): void => {}
   let unregisterE2ePtyDataInjection = (): void => {}
+  let hiddenOutputRestoreScrollDisposable: IDisposable | null = null
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
   let sshShellReadyFallbackTimer: ReturnType<typeof setTimeout> | null = null
   let agentTaskCompleteNotificationGraceTimer: ReturnType<typeof setTimeout> | null = null
@@ -3141,12 +3142,12 @@ export function connectPanePty(
       restoreScrollStateAfterLayout(pane.terminal, state)
     }
 
-    function applyMainBufferSnapshot(snapshot: {
+    async function applyMainBufferSnapshot(snapshot: {
       data: string
       cols: number
       rows: number
       seq?: number
-    }): void {
+    }): Promise<void> {
       const scrollState = captureScrollStateForSnapshotReplay()
       const colsBeforeReplay = pane.terminal.cols
       const rowsBeforeReplay = pane.terminal.rows
@@ -3170,9 +3171,9 @@ export function connectPanePty(
           suppressSnapshotReplayPtyResize = false
         }
       }
-      writeReplayData('\x1b[2J\x1b[3J\x1b[H')
-      writeReplayData(snapshot.data)
-      writeReplayData(POST_REPLAY_LIVE_SNAPSHOT_RESET)
+      await writeReplayDataAsync(
+        `\x1b[2J\x1b[3J\x1b[H${snapshot.data}${POST_REPLAY_LIVE_SNAPSHOT_RESET}`
+      )
       hiddenRendererStateDirty = false
       recordTerminalOutput(pane.terminal)
       const currentPtyId = transport.getPtyId()
@@ -3194,7 +3195,10 @@ export function connectPanePty(
       restoreScrollStateAfterSnapshotReplay(scrollState)
     }
 
-    function requestHiddenOutputRestoreIfNeeded(opts?: { bypassScheduler?: boolean }): boolean {
+    function requestHiddenOutputRestoreIfNeeded(opts?: {
+      bypassScheduler?: boolean
+      ignoreRestoredScrollState?: boolean
+    }): boolean {
       resetHiddenOutputRestoreIfPtyChanged()
       const ptyId = hiddenOutputRestorePtyId ?? transport.getPtyId()
       if (!hiddenOutputRestoreNeeded && hiddenOutputRestorePendingChunks.length === 0) {
@@ -3204,6 +3208,12 @@ export function connectPanePty(
         return false
       }
       hiddenOutputRestorePtyId = ptyId
+      if (shouldDeferHiddenOutputRestoreForScrolledViewport(opts)) {
+        // Why: snapshot replay clears and rebuilds xterm from the top. If the
+        // user is reading scrollback, wait until they return to bottom.
+        hiddenOutputRestoreRetryDeferred = true
+        return true
+      }
       if (hiddenOutputRestoreInFlight) {
         return true
       }
@@ -3298,7 +3308,7 @@ export function connectPanePty(
             return
           }
           hiddenOutputRestoreDeferredRetryAttempts = 0
-          applyMainBufferSnapshot(snapshot)
+          await applyMainBufferSnapshot(snapshot)
           const needsFreshSnapshot = hiddenOutputRestoreFreshSnapshotNeeded
           hiddenOutputRestoreFreshSnapshotNeeded = false
           if (drainPendingLiveChunksAfterSnapshot(snapshot.seq) && !needsFreshSnapshot) {
@@ -3329,6 +3339,41 @@ export function connectPanePty(
         }
       })
       return true
+    }
+
+    function shouldDeferHiddenOutputRestoreForScrolledViewport(opts?: {
+      ignoreRestoredScrollState?: boolean
+    }): boolean {
+      if (!shouldWritePtyOutputForeground(deps.isVisibleRef.current)) {
+        return false
+      }
+      const restoredScrollState = deps.restoredScrollStatesByLeafId?.[pane.leafId]
+      if (
+        !opts?.ignoreRestoredScrollState &&
+        restoredScrollState?.bufferType === 'normal' &&
+        !restoredScrollState.wasAtBottom
+      ) {
+        return true
+      }
+      const buffer = pane.terminal.buffer.active
+      return buffer.type === 'normal' && buffer.baseY > 0 && buffer.viewportY < buffer.baseY
+    }
+
+    const terminalOnScroll = (
+      pane.terminal as typeof pane.terminal & {
+        onScroll?: (listener: (position: number) => void) => IDisposable
+      }
+    ).onScroll
+    if (typeof terminalOnScroll === 'function') {
+      hiddenOutputRestoreScrollDisposable = terminalOnScroll.call(pane.terminal, () => {
+        if (
+          hiddenOutputRestoreRetryDeferred &&
+          !shouldDeferHiddenOutputRestoreForScrolledViewport({ ignoreRestoredScrollState: true })
+        ) {
+          hiddenOutputRestoreRetryDeferred = false
+          requestHiddenOutputRestoreIfNeeded({ ignoreRestoredScrollState: true })
+        }
+      })
     }
 
     unregisterBacklogRecovery = registerTerminalBacklogRecovery(
@@ -4123,6 +4168,8 @@ export function connectPanePty(
       unregisterBacklogRecovery = null
       unregisterDocumentVisibilityRecovery?.()
       unregisterDocumentVisibilityRecovery = null
+      hiddenOutputRestoreScrollDisposable?.dispose()
+      hiddenOutputRestoreScrollDisposable = null
       clearPanePtyFitBinding()
       discardTerminalOutput(pane.terminal)
       unregisterE2ePtyDataInjection()

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
@@ -28,14 +28,14 @@ function cloneLayoutWithLeafRewrite(
   }
 }
 
-function remapLeafRecord(
-  source: Record<string, string> | undefined,
+function remapLeafRecord<T>(
+  source: Record<string, T> | undefined,
   rewrite: LeafIdRewrite
-): Record<string, string> | undefined {
+): Record<string, T> | undefined {
   if (!source) {
     return undefined
   }
-  const next: Record<string, string> = {}
+  const next: Record<string, T> = {}
   for (const [leafId, value] of Object.entries(source)) {
     if (rewrite.duplicatedInputLeafIds.has(leafId)) {
       continue
@@ -108,11 +108,13 @@ export function normalizeTerminalLayoutSnapshot(
   const ptyIdsByLeafId = remapLeafRecord(snapshot.ptyIdsByLeafId, rewrite)
   const buffersByLeafId = remapLeafRecord(snapshot.buffersByLeafId, rewrite)
   const scrollbackRefsByLeafId = remapLeafRecord(snapshot.scrollbackRefsByLeafId, rewrite)
+  const scrollStatesByLeafId = remapLeafRecord(snapshot.scrollStatesByLeafId, rewrite)
   const titlesByLeafId = remapLeafRecord(snapshot.titlesByLeafId, rewrite)
   const {
     ptyIdsByLeafId: _oldPtyIdsByLeafId,
     buffersByLeafId: _oldBuffersByLeafId,
     scrollbackRefsByLeafId: _oldScrollbackRefsByLeafId,
+    scrollStatesByLeafId: _oldScrollStatesByLeafId,
     titlesByLeafId: _oldTitlesByLeafId,
     ...snapshotWithoutLeafRecords
   } = snapshot
@@ -125,6 +127,7 @@ export function normalizeTerminalLayoutSnapshot(
       ...(ptyIdsByLeafId ? { ptyIdsByLeafId } : {}),
       ...(buffersByLeafId ? { buffersByLeafId } : {}),
       ...(scrollbackRefsByLeafId ? { scrollbackRefsByLeafId } : {}),
+      ...(scrollStatesByLeafId ? { scrollStatesByLeafId } : {}),
       ...(titlesByLeafId ? { titlesByLeafId } : {})
     },
     changed: true

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -80,9 +80,10 @@ export function hideTerminalVisibility({
 }: HideTerminalVisibilityArgs): HideTerminalVisibilityResult {
   const surfaceBecameHidden = wasWorktreeActive && !isWorktreeActive
   if (wasVisible) {
-    // Why: hidden DOM/layout churn can mutate xterm's viewport before the
-    // pane becomes visible again. Preserve the last visible position.
-    captureViewportPositions(false)
+    // Why: React hides the terminal before this effect runs. Prefer the last
+    // tracked visible scroll event so hidden layout churn cannot overwrite it
+    // with xterm's transient top-of-buffer viewport.
+    captureViewportPositions(true)
   }
   if (!isWorktreeActive && (wasVisible || surfaceBecameHidden)) {
     // Suspend WebGL when going hidden. xterm.write() continues to land in

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -46,6 +46,9 @@ vi.mock('react', async (importOriginal) => {
     useEffect: (effect: () => void | (() => void)) => {
       effect()
     },
+    useLayoutEffect: (effect: () => void | (() => void)) => {
+      effect()
+    },
     useRef: <T>(value: T) => {
       const index = reactRefState.index
       reactRefState.index += 1
@@ -576,7 +579,6 @@ describe('useTerminalPaneGlobalEffects', () => {
     }
     const initialState = { marker: 'initial' }
     const preHideState = { marker: 'before-hide' }
-    const corruptedHiddenState = { marker: 'hidden-corrupted' }
     let nextCapturedState = initialState
     mocks.captureScrollState.mockImplementation(() => nextCapturedState)
 
@@ -608,7 +610,6 @@ describe('useTerminalPaneGlobalEffects', () => {
       isVisible: false
     })
 
-    nextCapturedState = corruptedHiddenState
     beginHookRender()
     useTerminalPaneGlobalEffects({
       ...baseArgs,
@@ -616,9 +617,9 @@ describe('useTerminalPaneGlobalEffects', () => {
       isVisible: true
     })
 
-    expect(mocks.captureScrollState).toHaveBeenCalledTimes(2)
+    expect(mocks.captureScrollState).toHaveBeenCalledTimes(1)
     expect(manager.suspendRendering).toHaveBeenCalledTimes(1)
-    expect(mocks.restoreScrollStateAfterLayout).toHaveBeenLastCalledWith(terminalA, preHideState)
+    expect(mocks.restoreScrollStateAfterLayout).toHaveBeenLastCalledWith(terminalA, initialState)
   })
 
   it('clears WebGL texture atlases when the active visible terminal regains focus', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import {
   FOCUS_TERMINAL_PANE_EVENT,
   PASTE_TERMINAL_TEXT_EVENT,
@@ -80,6 +80,17 @@ export function useTerminalPaneGlobalEffects({
     paneCount
   })
   useTerminalContainerFitSync({ isVisible, isSyncFitEnabled, managerRef, containerRef })
+
+  useLayoutEffect(() => {
+    if (!isVisible) {
+      return
+    }
+    return () => {
+      // Why: passive visibility effects run after React has already hidden the
+      // terminal, when xterm can transiently report viewportY=0.
+      captureViewportPositions(true)
+    }
+  }, [captureViewportPositions, isVisible])
 
   useEffect(() => {
     const manager = managerRef.current

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -92,7 +92,7 @@ export function useTerminalPaneGlobalEffects({
     }
   }, [captureViewportPositions, isVisible])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const manager = managerRef.current
     if (!manager) {
       return

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -608,7 +608,8 @@ export function useTerminalPaneLifecycle({
       dispatchNotification,
       setCacheTimerStartedAt,
       syncPanePtyLayoutBinding,
-      restoredPtyIdByLeafId: initialLayoutRef.current.ptyIdsByLeafId ?? {}
+      restoredPtyIdByLeafId: initialLayoutRef.current.ptyIdsByLeafId ?? {},
+      restoredScrollStatesByLeafId: initialLayoutRef.current.scrollStatesByLeafId
     }
 
     const unregisterRuntimeTab = registerRuntimeTerminalTab({

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -10,6 +10,7 @@ import {
   resolveTerminalCursorInactiveStyle
 } from '@/lib/pane-manager/pane-terminal-options'
 import { normalizeTerminalTuiMouseWheelMultiplier } from '@/lib/pane-manager/pane-terminal-mouse-wheel'
+import { restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import { buildWindowsPtyCompatibilityOptions } from '@/lib/pane-manager/windows-pty-compatibility'
 import { useAppStore } from '@/store'
 import {
@@ -244,6 +245,24 @@ export function mapRestoredPaneTitlesByPaneId(
     }
   }
   return restored
+}
+
+export function restoreLayoutScrollStates(
+  manager: PaneManager,
+  scrollStatesByLeafId: TerminalLayoutSnapshot['scrollStatesByLeafId'] | undefined,
+  restoredPaneByLeafId: ReadonlyMap<string, number>
+): void {
+  if (!scrollStatesByLeafId) {
+    return
+  }
+  const panesById = new Map(manager.getPanes().map((pane) => [pane.id, pane]))
+  for (const [leafId, scrollState] of Object.entries(scrollStatesByLeafId)) {
+    const paneId = restoredPaneByLeafId.get(leafId)
+    const pane = paneId != null ? panesById.get(paneId) : null
+    if (pane) {
+      restoreScrollStateAfterLayout(pane.terminal, scrollState)
+    }
+  }
 }
 
 function terminalSelectionExceedsPrimaryLimit(terminal: Terminal): boolean {
@@ -1131,6 +1150,11 @@ export function useTerminalPaneLifecycle({
 
     const restoredBuffers = initialLayoutRef.current.buffersByLeafId
     restoreScrollbackBuffers(manager, restoredBuffers, restoredPaneByLeafId, replayingPanesRef)
+    restoreLayoutScrollStates(
+      manager,
+      initialLayoutRef.current.scrollStatesByLeafId,
+      restoredPaneByLeafId
+    )
     if (restoredBuffers && initialLayoutRef.current.scrollbackRefsByLeafId) {
       const layoutWithoutRestoredBuffers = { ...initialLayoutRef.current }
       delete layoutWithoutRestoredBuffers.buffersByLeafId

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
@@ -149,4 +149,95 @@ describe('useTerminalScrollVisibilityMemory', () => {
     expect(cancelAnimationFrame).toHaveBeenCalledWith(7)
     expect(mocks.flushTerminalOutput).not.toHaveBeenCalled()
   })
+
+  it('uses remembered visible scroll snapshots when requested', () => {
+    const visibleState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 80
+    }
+    const scrollHandlers: (() => void)[] = []
+    const terminal = {
+      onScroll: vi.fn((handler: () => void) => {
+        scrollHandlers.push(handler)
+        return { dispose: vi.fn() }
+      })
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, terminal }])
+    }
+    mocks.captureScrollState.mockReturnValue(visibleState)
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+
+    const [scrollHandler] = scrollHandlers
+    if (!scrollHandler) {
+      throw new Error('expected scroll handler')
+    }
+    scrollHandler()
+    const captured = visibilityMemory.captureViewportPositions(true)
+
+    expect(captured.get(1)).toBe(visibleState)
+    expect(mocks.captureScrollState).toHaveBeenCalledTimes(1)
+  })
+
+  it('tracks xterm viewport scroll events as visible snapshots', () => {
+    const visibleState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 31,
+      baseY: 60
+    }
+    const hiddenState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 0,
+      baseY: 60
+    }
+    const container = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+    const terminal = {
+      onScroll: vi.fn(() => ({ dispose: vi.fn() }))
+    }
+    const manager = {
+      getPanes: vi.fn(() => [
+        {
+          id: 1,
+          terminal,
+          container
+        }
+      ])
+    }
+    mocks.captureScrollState.mockReturnValueOnce(visibleState).mockReturnValueOnce(hiddenState)
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+
+    const viewportScrollHandler = container.addEventListener.mock.calls[0]?.[1] as
+      | (() => void)
+      | undefined
+    if (!viewportScrollHandler) {
+      throw new Error('expected viewport scroll handler')
+    }
+    viewportScrollHandler()
+    mocks.captureScrollState.mockReturnValue(hiddenState)
+    const captured = visibilityMemory.captureViewportPositions(true)
+
+    expect(captured.get(1)).toBe(visibleState)
+    expect(mocks.captureScrollState).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
@@ -12,6 +12,7 @@ import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
 type VisibleScrollSnapshot = {
   scrollState: ScrollState
   outputEpoch: number
+  source: 'lifecycle' | 'visible'
 }
 
 type UseTerminalScrollVisibilityMemoryArgs = {
@@ -38,21 +39,26 @@ export function useTerminalScrollVisibilityMemory({
 }: UseTerminalScrollVisibilityMemoryArgs): TerminalScrollVisibilityMemory {
   const visibleScrollSnapshotsRef = useRef<Map<number, VisibleScrollSnapshot>>(new Map())
   const scrollDisposablesRef = useRef<Map<number, IDisposable>>(new Map())
+  const scrollContainerTargetsRef = useRef<Map<number, HTMLElement>>(new Map())
   const suppressScrollTrackingRef = useRef(false)
   const pendingFollowOutputPaneIdsRef = useRef<Set<number>>(new Set())
   const followOutputFrameIdsRef = useRef<number[]>([])
 
   const captureVisibleScrollSnapshot = useCallback(
-    (terminal: Terminal): VisibleScrollSnapshot => ({
+    (terminal: Terminal, source: VisibleScrollSnapshot['source']): VisibleScrollSnapshot => ({
       scrollState: captureScrollState(terminal),
-      outputEpoch: getTerminalOutputEpoch(terminal)
+      outputEpoch: getTerminalOutputEpoch(terminal),
+      source
     }),
     []
   )
 
   const rememberVisibleScrollSnapshot = useCallback(
     (paneId: number, terminal: Terminal): void => {
-      visibleScrollSnapshotsRef.current.set(paneId, captureVisibleScrollSnapshot(terminal))
+      visibleScrollSnapshotsRef.current.set(
+        paneId,
+        captureVisibleScrollSnapshot(terminal, 'visible')
+      )
     },
     [captureVisibleScrollSnapshot]
   )
@@ -64,19 +70,21 @@ export function useTerminalScrollVisibilityMemory({
         return new Map()
       }
       return new Map(
-        manager.getPanes().map((pane) => {
+        manager.getPanes().flatMap((pane) => {
           const remembered = visibleScrollSnapshotsRef.current.get(pane.id)
-          if (useRememberedSnapshots && remembered) {
-            return [pane.id, remembered.scrollState] as const
+          if (useRememberedSnapshots && remembered?.source === 'visible') {
+            return [[pane.id, remembered.scrollState] as const]
+          }
+          if (useRememberedSnapshots) {
+            return []
           }
           const state = captureScrollState(pane.terminal)
-          if (!useRememberedSnapshots || !remembered) {
-            visibleScrollSnapshotsRef.current.set(pane.id, {
-              scrollState: state,
-              outputEpoch: getTerminalOutputEpoch(pane.terminal)
-            })
-          }
-          return [pane.id, state] as const
+          visibleScrollSnapshotsRef.current.set(pane.id, {
+            scrollState: state,
+            outputEpoch: getTerminalOutputEpoch(pane.terminal),
+            source: 'lifecycle'
+          })
+          return [[pane.id, state] as const]
         })
       )
     },
@@ -160,48 +168,98 @@ export function useTerminalScrollVisibilityMemory({
   useEffect(() => cancelPendingFollowOutputFrames, [cancelPendingFollowOutputFrames])
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    const rememberScrolledPane = (event: Event): void => {
+      if (!isVisibleRef.current || suppressScrollTrackingRef.current) {
+        return
+      }
+      const target = event.target
+      if (!(target instanceof Node)) {
+        return
+      }
+      const manager = managerRef.current
+      if (!manager) {
+        return
+      }
+      const pane = manager.getPanes().find((candidate) => candidate.container.contains(target))
+      if (pane) {
+        rememberVisibleScrollSnapshot(pane.id, pane.terminal)
+      }
+    }
+    // Why: split layout can replace pane containers without changing pane ids.
+    // Delegating catches xterm viewport scrolls even while pane bindings churn.
+    window.addEventListener('scroll', rememberScrolledPane, true)
+    return () => window.removeEventListener('scroll', rememberScrolledPane, true)
+  }, [isVisibleRef, managerRef, rememberVisibleScrollSnapshot])
+
+  useEffect(() => {
     const manager = managerRef.current
     if (!manager) {
       return
     }
     const disposables = scrollDisposablesRef.current
+    const scrollContainerTargets = scrollContainerTargetsRef.current
     const panes = manager.getPanes()
-    const livePaneIds = new Set(panes.map((pane) => pane.id))
+    const paneById = new Map(panes.map((pane) => [pane.id, pane]))
     for (const [paneId, disposable] of disposables) {
-      if (!livePaneIds.has(paneId)) {
+      const pane = paneById.get(paneId)
+      if (!pane || scrollContainerTargets.get(paneId) !== pane.container) {
         disposable.dispose()
         disposables.delete(paneId)
-        visibleScrollSnapshotsRef.current.delete(paneId)
-        pendingFollowOutputPaneIdsRef.current.delete(paneId)
+        scrollContainerTargets.delete(paneId)
+        if (!pane) {
+          visibleScrollSnapshotsRef.current.delete(paneId)
+          pendingFollowOutputPaneIdsRef.current.delete(paneId)
+        }
       }
     }
     for (const pane of panes) {
       if (disposables.has(pane.id)) {
         continue
       }
+      const paneDisposables: IDisposable[] = []
+      const rememberPaneScroll = (): void => {
+        if (!isVisibleRef.current || suppressScrollTrackingRef.current) {
+          return
+        }
+        rememberVisibleScrollSnapshot(pane.id, pane.terminal)
+      }
       const onScroll = (
         pane.terminal as Terminal & {
           onScroll?: (listener: (position: number) => void) => IDisposable
         }
       ).onScroll
-      if (typeof onScroll !== 'function') {
+      if (typeof onScroll === 'function') {
+        paneDisposables.push(onScroll.call(pane.terminal, rememberPaneScroll))
+      }
+      if (pane.container) {
+        // Why: xterm's viewport element may be recreated after this effect.
+        // Capture-phase listening on the pane catches descendant scrollbar moves.
+        pane.container.addEventListener('scroll', rememberPaneScroll, true)
+        paneDisposables.push({
+          dispose: () => pane.container.removeEventListener('scroll', rememberPaneScroll, true)
+        })
+      }
+      if (paneDisposables.length === 0) {
         continue
       }
-      disposables.set(
-        pane.id,
-        onScroll.call(pane.terminal, () => {
-          if (!isVisibleRef.current || suppressScrollTrackingRef.current) {
-            return
+      disposables.set(pane.id, {
+        dispose: () => {
+          for (const disposable of paneDisposables) {
+            disposable.dispose()
           }
-          rememberVisibleScrollSnapshot(pane.id, pane.terminal)
-        })
-      )
+        }
+      })
+      scrollContainerTargets.set(pane.id, pane.container)
     }
     return () => {
       for (const disposable of disposables.values()) {
         disposable.dispose()
       }
       disposables.clear()
+      scrollContainerTargets.clear()
     }
   }, [isVisibleRef, managerRef, paneCount, rememberVisibleScrollSnapshot])
 

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -24,6 +24,14 @@ export type PaneSpawnHints = {
   ptyId?: string
 }
 
+export type PaneSplitOptions = {
+  ratio?: number
+  cwd?: string
+  leafId?: string
+  ptyId?: string
+  restoreMovedPaneScroll?: boolean
+}
+
 export type ClosedPaneInfo = {
   paneId: number
   leafId: TerminalLeafId

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -5,7 +5,8 @@ import type {
   ManagedPane,
   ManagedPaneInternal,
   PaneRenderingDiagnostics,
-  DropZone
+  DropZone,
+  PaneSplitOptions
 } from './pane-manager-types'
 import type { SplitPaneAroundLeafIdsOptions } from './pane-subtree-split'
 import {
@@ -93,7 +94,7 @@ export class PaneManager {
   splitPane(
     paneId: number,
     direction: 'vertical' | 'horizontal',
-    opts?: { ratio?: number; cwd?: string; leafId?: string; ptyId?: string }
+    opts?: PaneSplitOptions
   ): ManagedPane | null {
     return splitManagedPane({
       paneId,

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -139,10 +139,10 @@ function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
       ? state.firstVisibleLineMarker.line
       : -1
   const targetLine = Math.min(markerLine >= 0 ? markerLine : state.viewportY, buf.baseY)
-  state.viewportY = targetLine
   // Why: deferred rAF/timeout restores re-invoke this function after xterm
-  // reflow settles; keep the marker alive so each call consults the live
-  // line. Callers (restoreScrollState, the timeout in
+  // reflow settles; keep the original viewport and marker alive so later
+  // retries can recover after snapshot replay grows the buffer. Callers
+  // (restoreScrollState, the timeout in
   // restoreScrollStateAfterLayout, cancelDeferredScrollRestore) own disposal.
   if (safeScrollCall(() => terminal.scrollToLine(targetLine))) {
     forceViewportScrollbarSync(terminal)

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -2,7 +2,8 @@ import type {
   ManagedPane,
   ManagedPaneInternal,
   PaneManagerOptions,
-  PaneStyleOptions
+  PaneStyleOptions,
+  PaneSplitOptions
 } from './pane-manager-types'
 import type { DragReorderCallbacks } from './pane-drag-reorder'
 import { updateMultiPaneState } from './pane-drag-reorder'
@@ -30,7 +31,7 @@ type MovedPaneSplitState = {
 type SplitManagedPaneArgs = {
   paneId: number
   direction: 'vertical' | 'horizontal'
-  opts?: { ratio?: number; cwd?: string; leafId?: string; ptyId?: string }
+  opts?: PaneSplitOptions
   sourceContainer?: HTMLElement
   panes: Map<number, ManagedPaneInternal>
   root: HTMLElement
@@ -67,14 +68,16 @@ export function splitManagedPane(args: SplitManagedPaneArgs): ManagedPane | null
   args.setActivePaneId(newPane.id)
   openSplitPane(args, newPane, args.opts?.cwd)
 
-  for (const movedPaneState of movedPaneStates) {
-    scheduleSplitScrollRestore(
-      (id) => args.panes.get(id),
-      movedPaneState.pane.id,
-      movedPaneState.scrollState,
-      args.isDestroyed,
-      movedPaneState.hadWebgl ? reattachWebglIfNeeded : undefined
-    )
+  if (args.opts?.restoreMovedPaneScroll !== false) {
+    for (const movedPaneState of movedPaneStates) {
+      scheduleSplitScrollRestore(
+        (id) => args.panes.get(id),
+        movedPaneState.pane.id,
+        movedPaneState.scrollState,
+        args.isDestroyed,
+        movedPaneState.hadWebgl ? reattachWebglIfNeeded : undefined
+      )
+    }
   }
 
   return toPublicPane(newPane)

--- a/src/renderer/src/store/slices/terminal-scroll-state-update.test.ts
+++ b/src/renderer/src/store/slices/terminal-scroll-state-update.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createTestStore, makeLayout, seedStore } from './store-test-helpers'
+
+describe('terminal scroll state updates', () => {
+  it('does not notify store subscribers for unchanged scroll states', () => {
+    const store = createTestStore()
+    const scrollStatesByLeafId = {
+      leafA: {
+        bufferType: 'normal' as const,
+        wasAtBottom: false,
+        viewportY: 12,
+        baseY: 20
+      }
+    }
+    seedStore(store, {
+      terminalLayoutsByTabId: {
+        tabA: {
+          ...makeLayout(),
+          scrollStatesByLeafId
+        }
+      }
+    })
+    const subscriber = vi.fn()
+    const unsubscribe = store.subscribe(subscriber)
+
+    store.getState().updateTabScrollStates('tabA', { ...scrollStatesByLeafId })
+    store.getState().updateTabScrollStates('tabA', {
+      leafA: {
+        bufferType: 'normal',
+        wasAtBottom: false,
+        viewportY: 13,
+        baseY: 20
+      }
+    })
+    unsubscribe()
+
+    expect(subscriber).toHaveBeenCalledTimes(1)
+    expect(store.getState().terminalLayoutsByTabId.tabA.scrollStatesByLeafId?.leafA).toMatchObject({
+      viewportY: 13
+    })
+  })
+})

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -5,6 +5,7 @@ import type {
   SetupSplitDirection,
   Tab,
   TerminalLayoutSnapshot,
+  TerminalScrollStateSnapshot,
   TerminalTab,
   TuiAgent,
   Worktree,
@@ -78,6 +79,26 @@ function getNextTerminalOrdinal(tabs: TerminalTab[]): number {
     nextOrdinal += 1
   }
   return nextOrdinal
+}
+
+function terminalScrollStatesEqual(
+  left: Record<string, TerminalScrollStateSnapshot> | undefined,
+  right: Record<string, TerminalScrollStateSnapshot>
+): boolean {
+  const leftEntries = Object.entries(left ?? {})
+  if (leftEntries.length !== Object.keys(right).length) {
+    return false
+  }
+  return leftEntries.every(([leafId, leftState]) => {
+    const rightState = right[leafId]
+    return (
+      rightState !== undefined &&
+      leftState.bufferType === rightState.bufferType &&
+      leftState.wasAtBottom === rightState.wasAtBottom &&
+      leftState.viewportY === rightState.viewportY &&
+      leftState.baseY === rightState.baseY
+    )
+  })
 }
 
 function isRemoteRuntimePtyId(ptyId: string | null | undefined): boolean {
@@ -444,6 +465,10 @@ export type TerminalSlice = {
   setTabPaneExpanded: (tabId: string, expanded: boolean) => void
   setTabCanExpandPane: (tabId: string, canExpand: boolean) => void
   setTabLayout: (tabId: string, layout: TerminalLayoutSnapshot | null) => void
+  updateTabScrollStates: (
+    tabId: string,
+    scrollStatesByLeafId: Record<string, TerminalScrollStateSnapshot>
+  ) => void
   queueTabStartupCommand: (
     tabId: string,
     startup: {
@@ -2353,6 +2378,24 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         delete next[tabId]
       }
       return { terminalLayoutsByTabId: next }
+    })
+  },
+
+  updateTabScrollStates: (tabId, scrollStatesByLeafId) => {
+    set((s) => {
+      const existing = s.terminalLayoutsByTabId[tabId]
+      if (!existing) {
+        return s
+      }
+      if (terminalScrollStatesEqual(existing.scrollStatesByLeafId, scrollStatesByLeafId)) {
+        return s
+      }
+      return {
+        terminalLayoutsByTabId: {
+          ...s.terminalLayoutsByTabId,
+          [tabId]: { ...existing, scrollStatesByLeafId }
+        }
+      }
     })
   },
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -960,6 +960,13 @@ export type TerminalPaneLayoutNode =
       ratio?: number
     }
 
+export type TerminalScrollStateSnapshot = {
+  bufferType: 'normal' | 'alternate'
+  wasAtBottom: boolean
+  viewportY: number
+  baseY: number
+}
+
 export type TerminalLayoutSnapshot = {
   root: TerminalPaneLayoutNode | null
   activeLeafId: string | null
@@ -971,6 +978,8 @@ export type TerminalLayoutSnapshot = {
   buffersByLeafId?: Record<string, string>
   /** Durable scrollback snapshot refs per leaf; raw bytes live outside session JSON. */
   scrollbackRefsByLeafId?: Record<string, string>
+  /** Last visible xterm viewport state per leaf for in-session remounts. */
+  scrollStatesByLeafId?: Record<string, TerminalScrollStateSnapshot>
   /** User-assigned pane titles, keyed by stable layout leaf UUID.
    *  Persisted alongside buffers via the existing session:set flow. */
   titlesByLeafId?: Record<string, string>

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -59,6 +59,17 @@ const terminalLayoutSnapshotSchema = z.object({
   ptyIdsByLeafId: z.record(z.string(), z.string()).optional(),
   buffersByLeafId: z.record(z.string(), z.string()).optional(),
   scrollbackRefsByLeafId: z.record(z.string(), z.string()).optional(),
+  scrollStatesByLeafId: z
+    .record(
+      z.string(),
+      z.object({
+        bufferType: z.enum(['normal', 'alternate']),
+        wasAtBottom: z.boolean(),
+        viewportY: z.number(),
+        baseY: z.number()
+      })
+    )
+    .optional(),
   titlesByLeafId: z.record(z.string(), z.string()).optional()
 })
 

--- a/tests/e2e/terminal-codex-scroll-position-repro.spec.ts
+++ b/tests/e2e/terminal-codex-scroll-position-repro.spec.ts
@@ -134,6 +134,74 @@ async function readTerminalScrollStateForPaneIndex(
   }, paneIndex)
 }
 
+async function sampleTerminalScrollStateFramesOnActiveWorktree(
+  page: Page,
+  worktreeId: string,
+  paneIndex: number
+): Promise<
+  {
+    frame: number
+    scrollState: {
+      baseY: number
+      bufferType: string
+      leafId: string | null
+      paneId: number
+      viewportY: number
+    } | null
+  }[]
+> {
+  return page.evaluate(
+    ({ paneIndex, worktreeId }) =>
+      new Promise((resolve) => {
+        const samples: {
+          frame: number
+          scrollState: {
+            baseY: number
+            bufferType: string
+            leafId: string | null
+            paneId: number
+            viewportY: number
+          } | null
+        }[] = []
+        let started = false
+        const sample = (): void => {
+          const state = window.__store?.getState()
+          if (state?.activeWorktreeId === worktreeId) {
+            started = true
+            const tabId =
+              state.activeTabType === 'terminal'
+                ? state.activeTabId
+                : (state.activeTabIdByWorktree?.[worktreeId] ?? null)
+            const manager = tabId ? window.__paneManagers?.get(tabId) : null
+            const pane = manager?.getPanes?.()[paneIndex] ?? null
+            if (pane) {
+              const buffer = pane.terminal.buffer.active
+              samples.push({
+                frame: samples.length,
+                scrollState: {
+                  baseY: buffer.baseY,
+                  bufferType: buffer.type,
+                  leafId: pane.leafId ?? null,
+                  paneId: pane.id,
+                  viewportY: buffer.viewportY
+                }
+              })
+            } else {
+              samples.push({ frame: samples.length, scrollState: null })
+            }
+          }
+          if (started && samples.length >= 30) {
+            resolve(samples)
+            return
+          }
+          requestAnimationFrame(sample)
+        }
+        requestAnimationFrame(sample)
+      }),
+    { paneIndex, worktreeId }
+  )
+}
+
 async function scrollCodexViewportJustAboveBottom(page: Page): Promise<{
   baseY: number
   bufferType: string
@@ -141,7 +209,7 @@ async function scrollCodexViewportJustAboveBottom(page: Page): Promise<{
   paneId: number
   viewportY: number
 }> {
-  return page.evaluate(() => {
+  const target = await page.evaluate(() => {
     const state = window.__store?.getState()
     const worktreeId = state?.activeWorktreeId
     const tabId =
@@ -155,21 +223,123 @@ async function scrollCodexViewportJustAboveBottom(page: Page): Promise<{
     if (!pane) {
       throw new Error('Active terminal pane unavailable')
     }
-    const buffer = pane.terminal.buffer.active
-    pane.terminal.scrollToBottom()
-    const targetViewportY = Math.max(1, buffer.baseY - 8)
-    pane.terminal.scrollToLine(targetViewportY)
-    const viewport = pane.container.querySelector<HTMLElement>('.xterm-viewport')
-    viewport?.dispatchEvent(new Event('scroll', { bubbles: true }))
     pane.terminal.focus()
+    pane.terminal.scrollToBottom()
+    const wheelTarget =
+      pane.container.querySelector<HTMLElement>('.xterm-viewport') ??
+      pane.container.querySelector<HTMLElement>('.xterm') ??
+      pane.container.querySelector<HTMLElement>('.xterm-screen')
+    if (!wheelTarget) {
+      throw new Error('Active terminal wheel target unavailable')
+    }
+    const rect = wheelTarget.getBoundingClientRect()
     return {
-      baseY: buffer.baseY,
-      bufferType: buffer.type,
-      leafId: pane.leafId ?? null,
-      paneId: pane.id,
-      viewportY: buffer.viewportY
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2
     }
   })
+  const isAboveBottom = async (): Promise<boolean> => {
+    const state = await readActiveTerminalScrollState(page)
+    return state.bufferType === 'normal' && state.viewportY > 0 && state.viewportY < state.baseY
+  }
+  const attempts: (() => Promise<void>)[] = [
+    async () => {
+      await page.mouse.move(target.x, target.y)
+      await page.mouse.wheel(0, -1200)
+    },
+    async () => {
+      await page.evaluate(() => {
+        const state = window.__store?.getState()
+        const worktreeId = state?.activeWorktreeId
+        const tabId =
+          state?.activeTabType === 'terminal'
+            ? state.activeTabId
+            : worktreeId
+              ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+              : null
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+        if (!pane) {
+          throw new Error('Active terminal pane unavailable')
+        }
+        const wheelTargets = [
+          pane.container.querySelector<HTMLElement>('.xterm'),
+          pane.container.querySelector<HTMLElement>('.xterm-viewport'),
+          pane.container.querySelector<HTMLElement>('.xterm-screen')
+        ].filter((candidate): candidate is HTMLElement => Boolean(candidate))
+        for (const wheelTarget of wheelTargets) {
+          wheelTarget.dispatchEvent(
+            new WheelEvent('wheel', {
+              bubbles: true,
+              cancelable: true,
+              deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+              deltaY: -1200
+            })
+          )
+        }
+      })
+    },
+    async () => {
+      await page.evaluate(() => {
+        const state = window.__store?.getState()
+        const worktreeId = state?.activeWorktreeId
+        const tabId =
+          state?.activeTabType === 'terminal'
+            ? state.activeTabId
+            : worktreeId
+              ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+              : null
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+        const viewport = pane?.container.querySelector<HTMLElement>('.xterm-viewport')
+        if (!viewport) {
+          throw new Error('Active terminal viewport unavailable')
+        }
+        viewport.scrollTop = Math.max(0, viewport.scrollTop - 1200)
+        viewport.dispatchEvent(new Event('scroll', { bubbles: true }))
+      })
+    },
+    async () => {
+      await page.evaluate(() => {
+        const state = window.__store?.getState()
+        const worktreeId = state?.activeWorktreeId
+        const tabId =
+          state?.activeTabType === 'terminal'
+            ? state.activeTabId
+            : worktreeId
+              ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+              : null
+        const manager = tabId ? window.__paneManagers?.get(tabId) : null
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+        if (!pane) {
+          throw new Error('Active terminal pane unavailable')
+        }
+        const targetLine = Math.max(1, pane.terminal.buffer.active.baseY - 20)
+        pane.terminal.scrollToLine(targetLine)
+      })
+    }
+  ]
+  for (const attempt of attempts) {
+    await attempt()
+    await page.waitForTimeout(100)
+    if (await isAboveBottom()) {
+      break
+    }
+  }
+  await expect
+    .poll(
+      () =>
+        readActiveTerminalScrollState(page).then(
+          (state) =>
+            state.bufferType === 'normal' && state.viewportY > 0 && state.viewportY < state.baseY
+        ),
+      {
+        timeout: 5_000,
+        message: 'Codex viewport did not settle above bottom before switching'
+      }
+    )
+    .toBe(true)
+  return readActiveTerminalScrollState(page)
 }
 
 async function waitForCodexReady(page: Page): Promise<void> {
@@ -211,6 +381,42 @@ async function waitForTerminalScrollback(page: Page): Promise<void> {
   }
 }
 
+async function waitForCodexResponseLine(
+  page: Page,
+  marker: string,
+  lineNumber: number
+): Promise<void> {
+  await expect
+    .poll(() => getTerminalContent(page, 40_000), {
+      timeout: 180_000,
+      message: 'Codex did not finish the generated scrollback response'
+    })
+    .toContain(`${marker}_VISIBLE_LINE_${lineNumber}`)
+}
+
+async function waitForStableActiveTerminalScrollback(page: Page): Promise<void> {
+  let previousBaseY: number | null = null
+  let stableSamples = 0
+  await expect
+    .poll(
+      async () => {
+        const { baseY } = await readActiveTerminalScrollState(page)
+        if (baseY === previousBaseY) {
+          stableSamples += 1
+        } else {
+          previousBaseY = baseY
+          stableSamples = 0
+        }
+        return stableSamples >= 3
+      },
+      {
+        timeout: 15_000,
+        message: 'Codex scrollback did not settle before switching'
+      }
+    )
+    .toBe(true)
+}
+
 test.describe('Codex TUI scroll position repro', () => {
   test('keeps real Codex TUI scrollback position across worktree switches', async ({
     orcaPage
@@ -236,7 +442,7 @@ test.describe('Codex TUI scroll position repro', () => {
     const marker = `CODEX_SCROLL_REPRO_${Date.now()}`
     const prompt = [
       'Do not run commands.',
-      'Reply with exactly 140 separate short lines.',
+      'Reply with exactly 360 separate short lines.',
       `Each line must be in the form "${marker}_VISIBLE_LINE_N" where N counts up from 0.`,
       'Do not use markdown bullets or code fences.'
     ].join(' ')
@@ -253,6 +459,8 @@ test.describe('Codex TUI scroll position repro', () => {
     await dismissCodexPromptsIfPresent(orcaPage)
     await waitForCodexReady(orcaPage)
     await waitForTerminalScrollback(orcaPage)
+    await waitForCodexResponseLine(orcaPage, marker, 359)
+    await waitForStableActiveTerminalScrollback(orcaPage)
     await splitActiveTerminalPane(orcaPage, 'vertical')
     await expect
       .poll(
@@ -283,12 +491,18 @@ test.describe('Codex TUI scroll position repro', () => {
     await waitForActiveTerminalManager(orcaPage, 30_000)
     await orcaPage.waitForTimeout(500)
 
+    const returnFrameSamplesPromise = sampleTerminalScrollStateFramesOnActiveWorktree(
+      orcaPage,
+      firstWorktreeId,
+      0
+    )
     await orcaPage.getByRole('option', { name: /main/ }).first().click()
     await expect
       .poll(() => getActiveWorktreeId(orcaPage), { timeout: 10_000 })
       .toBe(firstWorktreeId)
     await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage, 30_000)
+    const returnFrameSamples = await returnFrameSamplesPromise
 
     const afterSwitch = await readTerminalScrollStateForPaneIndex(orcaPage, 0)
     testInfo.annotations.push({
@@ -301,5 +515,10 @@ test.describe('Codex TUI scroll position repro', () => {
     // xterm can reflow several rows when the split pane is hidden and refit;
     // the regression is the viewport teleporting to the top.
     expect(Math.abs(afterBottomOffset - beforeBottomOffset)).toBeLessThanOrEqual(10)
+    expect(
+      returnFrameSamples.filter(
+        (sample) => sample.scrollState?.baseY && sample.scrollState.viewportY === 0
+      )
+    ).toEqual([])
   })
 })

--- a/tests/e2e/terminal-codex-scroll-position-repro.spec.ts
+++ b/tests/e2e/terminal-codex-scroll-position-repro.spec.ts
@@ -1,0 +1,305 @@
+import type { Page } from '@stablyai/playwright-test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getActiveWorktreeId,
+  getAllWorktreeIds,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import {
+  getTerminalContent,
+  sendToTerminal,
+  splitActiveTerminalPane,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+
+const CODEX_READY_RE = /Ask Codex|OpenAI|Type your question|press enter/i
+const CODEX_TRUST_PROMPT_RE = /Do you trust|trust this folder|Trust this/i
+const CODEX_UPDATE_PROMPT_RE = /update available|install update|Skip for now/i
+const ARTIFACT_DIR = path.join(process.cwd(), '.tmp', 'codex-scroll-repro')
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+async function dismissCodexPromptsIfPresent(page: Page): Promise<void> {
+  const deadline = Date.now() + 20_000
+  while (Date.now() < deadline) {
+    const content = await getTerminalContent(page, 20_000)
+    if (CODEX_READY_RE.test(content) && !CODEX_TRUST_PROMPT_RE.test(content)) {
+      return
+    }
+    if (CODEX_TRUST_PROMPT_RE.test(content)) {
+      await page.keyboard.press('Enter')
+      await page.waitForTimeout(500)
+      continue
+    }
+    if (CODEX_UPDATE_PROMPT_RE.test(content)) {
+      await page.keyboard.type('3')
+      await page.keyboard.press('Enter')
+      await page.waitForTimeout(500)
+      continue
+    }
+    await page.waitForTimeout(250)
+  }
+}
+
+async function focusPaneByIndex(page: Page, paneIndex: number): Promise<void> {
+  await page.evaluate((paneIndex) => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getPanes?.()[paneIndex] ?? null
+    if (!manager || !pane) {
+      throw new Error(`Terminal pane ${paneIndex} is unavailable`)
+    }
+    manager.setActivePane(pane.id, { focus: true })
+  }, paneIndex)
+}
+
+async function readActiveTerminalScrollState(page: Page): Promise<{
+  baseY: number
+  bufferType: string
+  leafId: string | null
+  paneId: number
+  viewportY: number
+}> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('Active terminal pane unavailable')
+    }
+    const buffer = pane.terminal.buffer.active
+    return {
+      baseY: buffer.baseY,
+      bufferType: buffer.type,
+      leafId: pane.leafId ?? null,
+      paneId: pane.id,
+      viewportY: buffer.viewportY
+    }
+  })
+}
+
+async function readTerminalScrollStateForPaneIndex(
+  page: Page,
+  paneIndex: number
+): Promise<{
+  baseY: number
+  bufferType: string
+  leafId: string | null
+  paneId: number
+  viewportY: number
+}> {
+  return page.evaluate((paneIndex) => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getPanes?.()[paneIndex] ?? null
+    if (!pane) {
+      throw new Error(`Terminal pane ${paneIndex} unavailable`)
+    }
+    const buffer = pane.terminal.buffer.active
+    return {
+      baseY: buffer.baseY,
+      bufferType: buffer.type,
+      leafId: pane.leafId ?? null,
+      paneId: pane.id,
+      viewportY: buffer.viewportY
+    }
+  }, paneIndex)
+}
+
+async function scrollCodexViewportJustAboveBottom(page: Page): Promise<{
+  baseY: number
+  bufferType: string
+  leafId: string | null
+  paneId: number
+  viewportY: number
+}> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('Active terminal pane unavailable')
+    }
+    const buffer = pane.terminal.buffer.active
+    pane.terminal.scrollToBottom()
+    const targetViewportY = Math.max(1, buffer.baseY - 8)
+    pane.terminal.scrollToLine(targetViewportY)
+    const viewport = pane.container.querySelector<HTMLElement>('.xterm-viewport')
+    viewport?.dispatchEvent(new Event('scroll', { bubbles: true }))
+    pane.terminal.focus()
+    return {
+      baseY: buffer.baseY,
+      bufferType: buffer.type,
+      leafId: pane.leafId ?? null,
+      paneId: pane.id,
+      viewportY: buffer.viewportY
+    }
+  })
+}
+
+async function waitForCodexReady(page: Page): Promise<void> {
+  try {
+    await expect
+      .poll(
+        () => getTerminalContent(page, 20_000).then((content) => CODEX_READY_RE.test(content)),
+        {
+          timeout: 60_000,
+          message: 'Codex TUI did not render'
+        }
+      )
+      .toBe(true)
+  } catch (error) {
+    mkdirSync(ARTIFACT_DIR, { recursive: true })
+    writeFileSync(
+      path.join(ARTIFACT_DIR, 'codex-launch-terminal.txt'),
+      await getTerminalContent(page, 20_000)
+    )
+    throw error
+  }
+}
+
+async function waitForTerminalScrollback(page: Page): Promise<void> {
+  try {
+    await expect
+      .poll(() => readActiveTerminalScrollState(page).then((state) => state.baseY), {
+        timeout: 180_000,
+        message: 'Codex did not produce terminal scrollback'
+      })
+      .toBeGreaterThan(40)
+  } catch (error) {
+    mkdirSync(ARTIFACT_DIR, { recursive: true })
+    writeFileSync(
+      path.join(ARTIFACT_DIR, 'codex-no-scrollback-terminal.txt'),
+      await getTerminalContent(page, 40_000)
+    )
+    throw error
+  }
+}
+
+test.describe('Codex TUI scroll position repro', () => {
+  test('keeps real Codex TUI scrollback position across worktree switches', async ({
+    orcaPage
+  }, testInfo) => {
+    test.setTimeout(240_000)
+    test.skip(process.env.ORCA_E2E_REAL_CODEX !== '1', 'requires real local Codex CLI')
+    test.skip(process.platform === 'win32', 'local Codex command is POSIX-shell oriented')
+
+    await waitForSessionReady(orcaPage)
+    const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+    const secondWorktreeId = (await getAllWorktreeIds(orcaPage)).find(
+      (id) => id !== firstWorktreeId
+    )
+    test.skip(!secondWorktreeId, 'Codex scroll repro needs a second seeded worktree')
+    if (!secondWorktreeId) {
+      return
+    }
+
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+
+    const marker = `CODEX_SCROLL_REPRO_${Date.now()}`
+    const prompt = [
+      'Do not run commands.',
+      'Reply with exactly 140 separate short lines.',
+      `Each line must be in the form "${marker}_VISIBLE_LINE_N" where N counts up from 0.`,
+      'Do not use markdown bullets or code fences.'
+    ].join(' ')
+    const codexCommand = [
+      'codex',
+      '--no-alt-screen',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--dangerously-bypass-hook-trust',
+      '-C',
+      shellQuote(process.cwd()),
+      shellQuote(prompt)
+    ].join(' ')
+    await sendToTerminal(orcaPage, ptyId, `${codexCommand}\r`)
+    await dismissCodexPromptsIfPresent(orcaPage)
+    await waitForCodexReady(orcaPage)
+    await waitForTerminalScrollback(orcaPage)
+    await splitActiveTerminalPane(orcaPage, 'vertical')
+    await expect
+      .poll(
+        () =>
+          orcaPage.evaluate(() => {
+            const state = window.__store?.getState()
+            const tabId = state?.activeTabId
+            return tabId ? (window.__paneManagers?.get(tabId)?.getPanes?.().length ?? 0) : 0
+          }),
+        { timeout: 10_000 }
+      )
+      .toBe(2)
+    await focusPaneByIndex(orcaPage, 0)
+
+    const beforeSwitch = await scrollCodexViewportJustAboveBottom(orcaPage)
+    testInfo.annotations.push({
+      type: 'codex-scroll-before-switch',
+      description: JSON.stringify(beforeSwitch)
+    })
+    expect(beforeSwitch.baseY).toBeGreaterThan(20)
+    expect(beforeSwitch.viewportY).toBeGreaterThan(0)
+    expect(beforeSwitch.viewportY).toBeLessThan(beforeSwitch.baseY)
+
+    await orcaPage.getByRole('option', { name: /e2e-secondary/ }).click()
+    await expect
+      .poll(() => getActiveWorktreeId(orcaPage), { timeout: 10_000 })
+      .toBe(secondWorktreeId)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await orcaPage.waitForTimeout(500)
+
+    await orcaPage.getByRole('option', { name: /main/ }).first().click()
+    await expect
+      .poll(() => getActiveWorktreeId(orcaPage), { timeout: 10_000 })
+      .toBe(firstWorktreeId)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const afterSwitch = await readTerminalScrollStateForPaneIndex(orcaPage, 0)
+    testInfo.annotations.push({
+      type: 'codex-scroll-after-switch',
+      description: JSON.stringify(afterSwitch)
+    })
+    const beforeBottomOffset = beforeSwitch.baseY - beforeSwitch.viewportY
+    const afterBottomOffset = afterSwitch.baseY - afterSwitch.viewportY
+    expect(afterSwitch.viewportY).toBeGreaterThan(0)
+    // xterm can reflow several rows when the split pane is hidden and refit;
+    // the regression is the viewport teleporting to the top.
+    expect(Math.abs(afterBottomOffset - beforeBottomOffset)).toBeLessThanOrEqual(10)
+  })
+})


### PR DESCRIPTION
## Summary
- persist per-leaf terminal scroll state in layout/session snapshots and restore it after split layout replay
- avoid hidden xterm viewportY=0 overwriting the last visible scroll state
- optimize scroll persistence to update only the leaf scroll-state map, with no-op equality guarding
- add a gated real-Codex E2E repro for workspace switching with scrollback

## Verification
- pnpm run typecheck:web
- pnpm run typecheck:node
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/terminal-scroll-state-update.test.ts src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/layout-serialization.test.ts src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts src/shared/workspace-session-schema.test.ts
- ORCA_E2E_REAL_CODEX=1 pnpm exec playwright test tests/e2e/terminal-codex-scroll-position-repro.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1
- SKIP_BUILD=1 ORCA_E2E_REAL_CODEX=1 pnpm exec playwright test tests/e2e/terminal-codex-scroll-position-repro.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1

Note: local checks emitted the existing Node engine warning because this shell is on Node v26 while the repo requests Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
