### PR TITLE
Improve PR comment sidebar readability

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -145,6 +145,7 @@ import { localizedHostedReviewCopy } from '@/i18n/hosted-review-localized-copy'
 import { translate } from '@/i18n/i18n'
 import { groupPRComments, type PRCommentGroup } from '@/lib/pr-comment-groups'
 import { openChecksPanelHostedReviewUrl } from './checks-panel-hosted-review-click-routing'
+import { ChecksPanelUpdatedAtMetadata } from './checks-panel-updated-at-metadata'
 import {
   clearPullRequestGenerationRequiresPushBeforeCreate,
   createRunningPullRequestGenerationRecord,
@@ -3469,11 +3470,10 @@ export default function ChecksPanel(): React.JSX.Element {
 
         {/* Updated at */}
         {activeReview.updatedAt && (
-          <div className="text-[10px] text-muted-foreground/60">
-            {reviewShortLabel}{' '}
-            {translate('auto.components.right.sidebar.ChecksPanel.34464d00b9', 'updated')}
-            {new Date(activeReview.updatedAt).toLocaleString()}
-          </div>
+          <ChecksPanelUpdatedAtMetadata
+            reviewShortLabel={reviewShortLabel}
+            updatedAt={activeReview.updatedAt}
+          />
         )}
         {/* Merge / Delete Workspace actions */}
         {activeReview && activeWorktree && repo && (

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.updated-at-metadata.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.updated-at-metadata.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment happy-dom
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ChecksPanelUpdatedAtMetadata } from './checks-panel-updated-at-metadata'
+
+function renderMetadataText(reviewShortLabel: string): string {
+  const container = document.createElement('div')
+  container.innerHTML = renderToStaticMarkup(
+    <ChecksPanelUpdatedAtMetadata
+      reviewShortLabel={reviewShortLabel}
+      updatedAt="2026-06-24T17:30:00.000Z"
+    />
+  )
+  return container.textContent ?? ''
+}
+
+describe('ChecksPanel updated-at metadata', () => {
+  it.each(['PR', 'MR'])(
+    'renders a whitespace boundary between the %s updated label and timestamp',
+    (reviewShortLabel) => {
+      const text = renderMetadataText(reviewShortLabel)
+
+      expect(text).toMatch(new RegExp(`${reviewShortLabel} updated\\s+\\S`))
+      expect(text).not.toMatch(new RegExp(`${reviewShortLabel} updated\\S`))
+    }
+  )
+})

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
@@ -273,6 +273,9 @@ describe('PRCommentsList', () => {
     expect(markup.indexOf('aria-label="Add comment"')).toBeLessThan(
       markup.indexOf('Existing review context')
     )
+    expect(markup.indexOf('aria-label="Comment display options"')).toBeLessThan(
+      markup.indexOf('aria-label="Add comment"')
+    )
     expect(markup).toContain('lucide-plus')
     expect(markup).not.toContain('Add a comment...')
     expect(markup).not.toContain('Add a PR comment')

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -2461,6 +2461,42 @@ export function PRCommentsList({
                 )}
               </>
             )}
+            {comments.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground hover:text-foreground"
+                    aria-label={translate(
+                      'auto.components.right.sidebar.checks.panel.content.f5cf324efa',
+                      'Comment display options'
+                    )}
+                  >
+                    <SlidersHorizontal className="size-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
+                  <DropdownMenuLabel>
+                    {translate(
+                      'auto.components.right.sidebar.checks.panel.content.5e6e5a13fa',
+                      'View'
+                    )}
+                  </DropdownMenuLabel>
+                  <DropdownMenuRadioGroup
+                    value={displayMode}
+                    onValueChange={(value) => setDisplayMode(value as PRCommentsListDisplayMode)}
+                  >
+                    {PR_COMMENT_LIST_DISPLAY_MODES.map((mode) => (
+                      <DropdownMenuRadioItem key={mode} value={mode}>
+                        {getPRCommentsListDisplayModeLabel(mode)}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
             {onAddComment && !isAddingComment && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -2501,42 +2537,6 @@ export function PRCommentsList({
                         )}
                 </TooltipContent>
               </Tooltip>
-            )}
-            {comments.length > 0 && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground hover:text-foreground"
-                    aria-label={translate(
-                      'auto.components.right.sidebar.checks.panel.content.f5cf324efa',
-                      'Comment display options'
-                    )}
-                  >
-                    <SlidersHorizontal className="size-3" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
-                  <DropdownMenuLabel>
-                    {translate(
-                      'auto.components.right.sidebar.checks.panel.content.5e6e5a13fa',
-                      'View'
-                    )}
-                  </DropdownMenuLabel>
-                  <DropdownMenuRadioGroup
-                    value={displayMode}
-                    onValueChange={(value) => setDisplayMode(value as PRCommentsListDisplayMode)}
-                  >
-                    {PR_COMMENT_LIST_DISPLAY_MODES.map((mode) => (
-                      <DropdownMenuRadioItem key={mode} value={mode}>
-                        {getPRCommentsListDisplayModeLabel(mode)}
-                      </DropdownMenuRadioItem>
-                    ))}
-                  </DropdownMenuRadioGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
             )}
           </div>
         </div>

--- a/src/renderer/src/components/right-sidebar/checks-panel-updated-at-metadata.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-updated-at-metadata.tsx
@@ -1,0 +1,20 @@
+import type React from 'react'
+import { translate } from '@/i18n/i18n'
+
+type ChecksPanelUpdatedAtMetadataProps = {
+  reviewShortLabel: string
+  updatedAt: string
+}
+
+export function ChecksPanelUpdatedAtMetadata({
+  reviewShortLabel,
+  updatedAt
+}: ChecksPanelUpdatedAtMetadataProps): React.JSX.Element {
+  return (
+    <div className="text-[10px] text-muted-foreground/60">
+      {reviewShortLabel}{' '}
+      {translate('auto.components.right.sidebar.ChecksPanel.34464d00b9', 'updated')}{' '}
+      {new Date(updatedAt).toLocaleString()}
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
@@ -22,8 +22,12 @@ describe('pr-comment-presentation', () => {
     expect(cards.avatar).toContain('border-border')
     expect(cards.avatar).toContain('bg-background')
 
-    expect(getPRCommentPresentationClasses('focus').useCardLayout).toBe(true)
-    expect(getPRCommentPresentationClasses('focus').commentBody).toContain('text-[14px]')
+    const focus = getPRCommentPresentationClasses('focus')
+    expect(focus.useCardLayout).toBe(true)
+    expect(focus.commentBody).toContain('text-[13px]')
+    expect(focus.commentBodyReply).toContain('text-[13px]')
+    expect(focus.author).toContain('text-[13px]')
+    expect(focus.list).toContain('gap-3')
   })
 
   it('preserves the legacy flat layout tokens', () => {

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
@@ -15,7 +15,8 @@ describe('pr-comment-presentation', () => {
   it('returns card layout tokens for cards and focus variants', () => {
     const cards = getPRCommentPresentationClasses('cards')
     expect(cards.useCardLayout).toBe(true)
-    expect(cards.commentBody).toContain('text-[13px]')
+    expect(cards.commentBody).toContain('text-xs')
+    expect(cards.commentBody).toContain('leading-5')
     expect(cards.commentBody).toContain('text-foreground')
     expect(cards.group).toContain('bg-secondary')
     expect(cards.group).toContain('shadow-xs')
@@ -24,8 +25,10 @@ describe('pr-comment-presentation', () => {
 
     const focus = getPRCommentPresentationClasses('focus')
     expect(focus.useCardLayout).toBe(true)
-    expect(focus.commentBody).toContain('text-[13px]')
-    expect(focus.commentBodyReply).toContain('text-[13px]')
+    expect(focus.commentBody).toContain('text-xs')
+    expect(focus.commentBody).toContain('leading-5')
+    expect(focus.commentBodyReply).toContain('text-xs')
+    expect(focus.commentBodyReply).toContain('leading-5')
     expect(focus.author).toContain('text-[13px]')
     expect(focus.list).toContain('gap-2')
     expect(focus.commentBody).toContain('px-4 py-2.5')

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
@@ -27,7 +27,13 @@ describe('pr-comment-presentation', () => {
     expect(focus.commentBody).toContain('text-[13px]')
     expect(focus.commentBodyReply).toContain('text-[13px]')
     expect(focus.author).toContain('text-[13px]')
-    expect(focus.list).toContain('gap-3')
+    expect(focus.list).toContain('gap-2')
+    expect(focus.commentBody).toContain('px-4 py-2.5')
+    expect(focus.commentBodyReply).toContain('px-4 py-2.5')
+    expect(focus.commentHeader).toContain('px-3 py-2')
+    expect(focus.commentHeaderReply).toContain('px-3 py-2')
+    expect(focus.commentHeaderMeta).toContain('pl-7')
+    expect(focus.commentHeaderMetaWithSelection).toContain('pl-[3.25rem]')
   })
 
   it('preserves the legacy flat layout tokens', () => {

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
@@ -96,6 +96,7 @@ const COMMENT_AVATAR =
 const RESOLVED_SECTION_LABEL =
   'text-[11px] font-semibold uppercase tracking-wider text-muted-foreground'
 
+// Why: cards and focus vary spacing only; PR comment text stays at dense sidebar scale.
 const CARD_COMMENT_BODY_SIZE = 'text-[13px] leading-relaxed'
 const CARD_COMMENT_AUTHOR_SIZE = 'text-[13px]'
 

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
@@ -96,9 +96,14 @@ const COMMENT_AVATAR =
 const RESOLVED_SECTION_LABEL =
   'text-[11px] font-semibold uppercase tracking-wider text-muted-foreground'
 
-// Why: cards and focus vary spacing only; PR comment text stays at dense sidebar scale.
+// Why: cards and focus share dense sidebar scale so PR comments do not read oversized.
 const CARD_COMMENT_BODY_SIZE = 'text-[13px] leading-relaxed'
 const CARD_COMMENT_AUTHOR_SIZE = 'text-[13px]'
+const CARD_COMMENT_LIST_GAP = 'gap-2'
+const CARD_COMMENT_BODY_PADDING = 'px-4 py-2.5'
+const CARD_COMMENT_HEADER_PADDING = 'px-3 py-2'
+const CARD_COMMENT_META_INDENT = 'pl-7'
+const CARD_COMMENT_META_SELECTION_INDENT = 'pl-[3.25rem]'
 
 const RESOLVED_SECTION_TRIGGER = cn(
   RESOLVED_SECTION_LABEL,
@@ -176,25 +181,19 @@ export function getPRCommentPresentationClasses(
     }
   }
 
-  const isFocus = variant === 'focus'
-  const listGap = isFocus ? 'gap-3' : 'gap-2'
-  const bodyPadding = isFocus ? 'px-4 py-3' : 'px-4 py-2.5'
-  const headerPadding = isFocus ? 'px-3.5 py-2.5' : 'px-3 py-2'
-  const metaIndent = isFocus ? 'pl-8' : 'pl-7'
-
   return {
     variant,
     useCardLayout: true,
-    list: `flex flex-col ${listGap} px-3 py-2`,
+    list: `flex flex-col ${CARD_COMMENT_LIST_GAP} px-3 py-2`,
     group: COMMENT_CARD_SURFACE,
     groupStandalone: '',
     groupThread: '',
     commentRow: 'group/comment',
     commentRowReply: `border-t ${COMMENT_CARD_DIVIDER} bg-muted/25 dark:bg-muted/10`,
-    commentHeader: `flex flex-col gap-1 border-b ${COMMENT_CARD_DIVIDER} ${headerPadding}`,
-    commentHeaderReply: `flex min-w-0 items-center gap-2 ${headerPadding}`,
-    commentBody: `${bodyPadding} ${CARD_COMMENT_BODY_SIZE} text-foreground`,
-    commentBodyReply: `${bodyPadding} ${CARD_COMMENT_BODY_SIZE} text-foreground`,
+    commentHeader: `flex flex-col gap-1 border-b ${COMMENT_CARD_DIVIDER} ${CARD_COMMENT_HEADER_PADDING}`,
+    commentHeaderReply: `flex min-w-0 items-center gap-2 ${CARD_COMMENT_HEADER_PADDING}`,
+    commentBody: `${CARD_COMMENT_BODY_PADDING} ${CARD_COMMENT_BODY_SIZE} text-foreground`,
+    commentBodyReply: `${CARD_COMMENT_BODY_PADDING} ${CARD_COMMENT_BODY_SIZE} text-foreground`,
     commentBodyMarkdown: MARKDOWN_BASE,
     author: `min-w-0 flex-1 truncate ${CARD_COMMENT_AUTHOR_SIZE} font-semibold text-foreground`,
     authorResolved: 'text-muted-foreground',
@@ -226,12 +225,12 @@ export function getPRCommentPresentationClasses(
       'shrink-0 rounded border border-ring/40 bg-accent px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-foreground',
     commentHeaderPrimary: 'flex min-w-0 items-center gap-2',
     commentHeaderMeta: cn(
-      metaIndent,
+      CARD_COMMENT_META_INDENT,
       'flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground'
     ),
     // Why: checkbox (16px) + gap-2 sits before the avatar row the meta row already indents past.
     commentHeaderMetaWithSelection: cn(
-      isFocus ? 'pl-[3.5rem]' : 'pl-[3.25rem]',
+      CARD_COMMENT_META_SELECTION_INDENT,
       'flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground'
     ),
     // Why: open state is conveyed by the status badge; a green card rail reads noisy in the sidebar.

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
@@ -96,8 +96,8 @@ const COMMENT_AVATAR =
 const RESOLVED_SECTION_LABEL =
   'text-[11px] font-semibold uppercase tracking-wider text-muted-foreground'
 
-// Why: cards and focus share dense sidebar scale so PR comments do not read oversized.
-const CARD_COMMENT_BODY_SIZE = 'text-[13px] leading-relaxed'
+// Why: markdown bodies need the secondary sidebar scale; 13px relaxed copy reads oversized in narrow comment cards.
+const CARD_COMMENT_BODY_SIZE = 'text-xs leading-5'
 const CARD_COMMENT_AUTHOR_SIZE = 'text-[13px]'
 const CARD_COMMENT_LIST_GAP = 'gap-2'
 const CARD_COMMENT_BODY_PADDING = 'px-4 py-2.5'

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
@@ -96,6 +96,9 @@ const COMMENT_AVATAR =
 const RESOLVED_SECTION_LABEL =
   'text-[11px] font-semibold uppercase tracking-wider text-muted-foreground'
 
+const CARD_COMMENT_BODY_SIZE = 'text-[13px] leading-relaxed'
+const CARD_COMMENT_AUTHOR_SIZE = 'text-[13px]'
+
 const RESOLVED_SECTION_TRIGGER = cn(
   RESOLVED_SECTION_LABEL,
   'rounded-none border-0 bg-transparent px-3 py-2 shadow-none hover:bg-accent/40 hover:text-foreground hover:no-underline'
@@ -173,8 +176,6 @@ export function getPRCommentPresentationClasses(
   }
 
   const isFocus = variant === 'focus'
-  const bodySize = isFocus ? 'text-[14px] leading-relaxed' : 'text-[13px] leading-relaxed'
-  const authorSize = isFocus ? 'text-[14px]' : 'text-[13px]'
   const listGap = isFocus ? 'gap-3' : 'gap-2'
   const bodyPadding = isFocus ? 'px-4 py-3' : 'px-4 py-2.5'
   const headerPadding = isFocus ? 'px-3.5 py-2.5' : 'px-3 py-2'
@@ -191,10 +192,10 @@ export function getPRCommentPresentationClasses(
     commentRowReply: `border-t ${COMMENT_CARD_DIVIDER} bg-muted/25 dark:bg-muted/10`,
     commentHeader: `flex flex-col gap-1 border-b ${COMMENT_CARD_DIVIDER} ${headerPadding}`,
     commentHeaderReply: `flex min-w-0 items-center gap-2 ${headerPadding}`,
-    commentBody: `${bodyPadding} ${bodySize} text-foreground`,
-    commentBodyReply: `${bodyPadding} ${bodySize} text-foreground`,
+    commentBody: `${bodyPadding} ${CARD_COMMENT_BODY_SIZE} text-foreground`,
+    commentBodyReply: `${bodyPadding} ${CARD_COMMENT_BODY_SIZE} text-foreground`,
     commentBodyMarkdown: MARKDOWN_BASE,
-    author: `min-w-0 flex-1 truncate ${authorSize} font-semibold text-foreground`,
+    author: `min-w-0 flex-1 truncate ${CARD_COMMENT_AUTHOR_SIZE} font-semibold text-foreground`,
     authorResolved: 'text-muted-foreground',
     avatar: `size-5 ${COMMENT_AVATAR}`,
     avatarReply: `size-4 ${COMMENT_AVATAR}`,


### PR DESCRIPTION
## Summary
- Sets right-sidebar PR comment markdown bodies and replies to the documented secondary sidebar scale (`text-xs` / 12px with `leading-5`) so CodeRabbit-style long markdown no longer reads larger than nearby sidebar text.
- Keeps PR comment author/header chrome at 13px for scanability while the markdown body recedes to the dense content tier.
- Tightens the focus presentation padding so PR comment cards no longer have extra list gaps, body padding, header padding, or metadata indentation compared with the compact card layout.
- Moves the comment display options icon to the left of the add-comment plus in the comments header.
- Fixes the hosted review updated-at metadata so it renders `PR updated <timestamp>` / `MR updated <timestamp>` with a real whitespace boundary after `updated`.
- Extracts the updated-at metadata into a focused component so its regression test does not import the full Checks panel.

## AI Review Report
- Design review completed clean after tightening the timestamp test surface, locale-stable assertion guidance, the focus-padding target, and the 12px markdown-body follow-up.
- Completeness verification found no omissions for the typography/timestamp work and the compact focus spacing.
- Perf audit found no production hot-path concerns. Earlier test import churn was fixed by moving the metadata renderer out of `ChecksPanel.tsx`; the spacing and typography follow-ups only share static class constants.
- Code-review loop: first round returned clean for the original change, then the follow-up round found one stale why-comment, which was fixed. The fresh follow-up reviewer pair returned clean.
- CodeRabbit initially requested a short why-comment for the typography invariant; fixed in `2f5306289`. Latest CodeRabbit review reports no actionable comments.
- Cross-platform compatibility: the diff is renderer-only Tailwind class composition and static text/button ordering. It adds no macOS/Linux/Windows-specific shortcuts, paths, filesystem access, process spawning, or runtime checks, so platform behavior is unchanged.

## Security Audit
- Renderer-only presentation/copy/button-order changes.
- No filesystem, shell, IPC/RPC, SSH, auth, external provider mutation, telemetry, persistence, or agent prompt/workflow changes.
- GitHub/GitLab provider behavior remains neutral: timestamp spacing is covered for both `PR` and `MR` labels.

## Screenshots
Captured during validation and not committed:
- `tmp/validation-evidence/right-sidebar-pr-comments-2026-06-24.png`
- `tmp/validation-evidence/right-sidebar-mr-metadata-2026-06-24.png`
- `/Users/thebr/orca/workspaces/.validation-screenshots/right-sidebar-pr-comments/checks-sidebar-focus-comments-context.png`
- `/Users/thebr/orca/workspaces/.validation-screenshots/right-sidebar-pr-comments/checks-comments-focus-compact-padding.png`
- `/Users/thebr/orca/workspaces/.validation-screenshots/right-sidebar-pr-comments/comment-options-left-of-plus.png`
- `/Users/thebr/orca/workspaces/.validation-screenshots/right-sidebar-pr-comments/comment-markdown-body-12px-context-clean.png`

## Brennan's PR Process Evidence
- Design approach: scoped the change to PR/MR checks sidebar presentation classes, comments-header button order, and updated-at metadata rendering; no data model, runtime, SSH, provider API, or prompt behavior changes.
- Implementation: changed right-sidebar presentation tokens, moved the display options button before the add-comment button, added provider-neutral metadata component, and added regression tests; no deviations from the reviewed design.
- Merge-confidence validation: `land`. Electron launched from this exact worktree, identity was verified, right-sidebar Checks was opened, PR/MR metadata spacing was verified, focus/card comment spacing was verified, the display-options icon order was verified, and CodeRabbit markdown body text computed to 12px / 20px while the reference worktree title computed to 13px / 20px.

## Tests
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts src/renderer/src/components/right-sidebar/ChecksPanel.updated-at-metadata.test.tsx`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts`
- [x] `pnpm exec oxlint src/renderer/src/components/right-sidebar/checks-panel-content.tsx src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx`
- [x] `pnpm exec oxlint src/renderer/src/components/right-sidebar/pr-comment-presentation.ts src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts src/renderer/src/components/right-sidebar/ChecksPanel.tsx src/renderer/src/components/right-sidebar/ChecksPanel.updated-at-metadata.test.tsx src/renderer/src/components/right-sidebar/checks-panel-updated-at-metadata.tsx`
- [x] `pnpm exec oxlint src/renderer/src/components/right-sidebar/pr-comment-presentation.ts src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts`
- [x] `git diff --check`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] Electron validation with contextual screenshot evidence

## Post-PR Stabilization
- First sweep after the required wait found one actionable CodeRabbit nit: add a short why-comment for the fixed PR comment typography invariant.
- Fixed in commit `2f5306289` and validated with focused Vitest plus oxlint on the touched file.
- Waited another required 8 minutes after pushing the fix.
- Refreshed CodeRabbit review reported no actionable comments and GitHub Actions `verify` passed.
- Follow-up padding fix pushed in `2b2aa7c26`; waited the required 8 minutes.
- Options-icon reorder pushed in `dc295f315`; waited the required 8 minutes.
- Markdown body scale follow-up pushed in `64070f7f3`; waited the required 8 minutes.
- GitHub Actions `verify` passed on `64070f7f3`.
- CodeRabbit initially hit its review rate limit for the latest commit; after availability returned, a manual `@coderabbitai review` was requested and completed. Latest CodeRabbit text says no actionable comments were generated. Remaining CodeRabbit docstring-coverage item is a pre-merge warning/false positive for this TS UI diff, not an actionable code finding.

## Notes
- macOS Dock Accessibility identity check was blocked locally by permission `-1743`; Orca API identity and launch logs verified the exact worktree instead.
- PR/MR validation used synthetic demo-project data and this PR's live sidebar state in isolated/local state to avoid mutating real Orca PRs/issues beyond the requested CodeRabbit review trigger.
