### PR TITLE
Stabilize terminal scroll restore on workspace switch

### DIFF
--- a/docs/terminal-scroll-stable-restore.md
+++ b/docs/terminal-scroll-stable-restore.md
@@ -1,0 +1,45 @@
+# Terminal Scroll Stable Restore
+
+## Problem
+
+Switching away from a workspace while a terminal TUI is scrolled near, but not at, the top or bottom can cause the viewport to jump or jitter when the workspace becomes visible again.
+
+The previous fix direction preserved more state, but it restored too aggressively: repeated frame-by-frame scroll replays and scrollbar sync jiggles can fight xterm's clamp behavior near buffer edges. That makes the viewport visibly vibrate or briefly flash at the wrong position.
+
+## Invariant
+
+The terminal leaf owns the user's scroll position.
+
+For a running terminal, Orca should prefer the live xterm viewport. When React visibility, WebGL suspend/resume, or layout fit temporarily disturbs xterm, Orca may restore the last visible viewport once after the disruptive operation settles.
+
+## Model
+
+Use a hybrid model:
+
+1. Live mounted terminals keep using the existing in-memory visibility restore path.
+2. Remounted terminals fall back to durable scroll state stored by stable layout leaf id.
+3. Layout snapshots preserve the last visible leaf scroll state while the pane is hidden.
+4. Programmatic restore does not overwrite the stored user position.
+5. Hidden/background PTY output can update terminal contents, but it must not redefine the user's visible scroll anchor unless the user is following output at the bottom.
+
+## Non-Goals
+
+- Do not replay scroll position for many animation frames during a workspace transition.
+- Do not infer durable user position from hidden xterm viewport values.
+- Do not serialize xterm marker objects into session state.
+- Do not change PTY ownership, SSH/runtime snapshot semantics, or scrollback persistence.
+
+## Implementation Plan
+
+1. Add `scrollStatesByLeafId` to `TerminalLayoutSnapshot`, schema validation, and leaf-id remapping.
+2. Capture primitive scroll state by leaf id when the terminal is visible.
+3. Preserve prior `scrollStatesByLeafId` when the terminal is hidden so hidden WebGL/layout churn cannot persist `viewportY = 0`.
+4. On visible remount/resume, restore the saved leaf state once after layout using the existing deferred layout restore helper.
+5. Avoid repeated transition restore loops and repeated scrollbar jiggles.
+6. Add focused tests for schema/remapping, hidden preservation, and single-shot leaf restore behavior.
+
+## Validation
+
+- Unit tests for scroll restore primitives and terminal layout persistence.
+- Existing visibility resume tests to ensure the live mounted path still restores after fit.
+- Real Codex TUI E2E with enough scrollback: scroll near bottom, switch workspaces, switch back, assert no top jump and final viewport remains near the saved position.

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -75,6 +75,9 @@ import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import {
   captureScrollState,
   getPendingScrollRestoreState,
+  rememberTerminalContainerScrollState,
+  rememberTerminalLeafScrollState,
+  rememberTerminalScrollState,
   restoreScrollStateAfterLayout
 } from '@/lib/pane-manager/pane-scroll'
 import {
@@ -218,10 +221,13 @@ function isTransientTerminalEdgeSnap(
   if (!previous || previous.wasAtBottom || current.bufferType !== previous.bufferType) {
     return false
   }
-  if (current.baseY !== previous.baseY || current.viewportY === previous.viewportY) {
+  if (current.viewportY === previous.viewportY) {
     return false
   }
-  return current.viewportY === 0 || current.wasAtBottom
+  return (
+    Math.abs(current.baseY - previous.baseY) <= 2 &&
+    (current.viewportY === 0 || current.wasAtBottom)
+  )
 }
 
 function arePaneTitleOverlayRectsEqual(
@@ -491,7 +497,7 @@ export default function TerminalPane({
   const savedScrollStatesByLeafIdRef = useRef(savedLayout.scrollStatesByLeafId)
   savedScrollStatesByLeafIdRef.current = savedLayout.scrollStatesByLeafId
   const lastVisibleScrollStatesByLeafIdRef = useRef(savedLayout.scrollStatesByLeafId)
-  const hasAppliedDurableScrollRestoreRef = useRef(false)
+  const wasVisibleForDurableRestoreRef = useRef(false)
   const updateTabTitle = useAppStore((store) => store.updateTabTitle)
   const setRuntimePaneTitle = useAppStore((store) => store.setRuntimePaneTitle)
   const clearRuntimePaneTitle = useAppStore((store) => store.clearRuntimePaneTitle)
@@ -740,6 +746,9 @@ export default function TerminalPane({
             const previous = lastVisibleScrollStatesByLeafIdRef.current?.[pane.leafId]
             const stable =
               previous && isTransientTerminalEdgeSnap(current, previous) ? previous : current
+            rememberTerminalScrollState(pane.terminal, stable)
+            rememberTerminalContainerScrollState(pane.container, stable)
+            rememberTerminalLeafScrollState(pane.leafId, stable)
             logTerminalScrollRestore('layout-persist', {
               baseY: stable.baseY,
               bufferType: stable.bufferType,
@@ -872,6 +881,9 @@ export default function TerminalPane({
         const previous = lastVisibleScrollStatesByLeafIdRef.current?.[pane.leafId]
         const stable =
           previous && isTransientTerminalEdgeSnap(current, previous) ? previous : current
+        rememberTerminalScrollState(pane.terminal, stable)
+        rememberTerminalContainerScrollState(pane.container, stable)
+        rememberTerminalLeafScrollState(pane.leafId, stable)
         logTerminalScrollRestore('capture-current', {
           baseY: stable.baseY,
           bufferType: stable.bufferType,
@@ -903,7 +915,9 @@ export default function TerminalPane({
   }, [captureCurrentScrollStatesByLeafId, isVisible, persistCurrentScrollStates])
 
   useLayoutEffect(() => {
-    if (!isVisible || hasAppliedDurableScrollRestoreRef.current) {
+    const shouldRestore = isVisible && !wasVisibleForDurableRestoreRef.current
+    wasVisibleForDurableRestoreRef.current = isVisible
+    if (!shouldRestore) {
       return
     }
     const scrollStatesByLeafId =
@@ -940,7 +954,6 @@ export default function TerminalPane({
         })
       }
     }
-    hasAppliedDurableScrollRestoreRef.current = true
   }, [isVisible, paneCount, tabId, worktreeId])
 
   const clearPaneScrollback = useCallback(

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -207,6 +207,19 @@ function isXtermHelperTextarea(target: EventTarget | null): target is HTMLElemen
   return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
 }
 
+function isTransientTerminalEdgeSnap(
+  current: TerminalScrollStateSnapshot,
+  previous: TerminalScrollStateSnapshot | undefined
+): boolean {
+  if (!previous || previous.wasAtBottom || current.bufferType !== previous.bufferType) {
+    return false
+  }
+  if (current.baseY !== previous.baseY || current.viewportY === previous.viewportY) {
+    return false
+  }
+  return current.viewportY === 0 || current.wasAtBottom
+}
+
 function arePaneTitleOverlayRectsEqual(
   a: Record<number, PaneTitleOverlayRect>,
   b: Record<number, PaneTitleOverlayRect>
@@ -718,19 +731,23 @@ export default function TerminalPane({
       ? Object.fromEntries(
           currentPanes.map((pane) => {
             const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+            const current = { bufferType, wasAtBottom, viewportY, baseY }
+            const previous = lastVisibleScrollStatesByLeafIdRef.current?.[pane.leafId]
+            const stable =
+              previous && isTransientTerminalEdgeSnap(current, previous) ? previous : current
             logTerminalScrollRestore('layout-persist', {
-              baseY,
-              bufferType,
+              baseY: stable.baseY,
+              bufferType: stable.bufferType,
               isVisible: isVisibleRef.current,
               leafId: pane.leafId,
               paneId: pane.id,
               source: 'persistLayoutSnapshot',
               tabId,
-              viewportY,
-              wasAtBottom,
+              viewportY: stable.viewportY,
+              wasAtBottom: stable.wasAtBottom,
               worktreeId
             })
-            return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
+            return [pane.leafId, stable]
           })
         )
       : mergeCapturedLeafState<TerminalScrollStateSnapshot>({
@@ -845,18 +862,22 @@ export default function TerminalPane({
     return Object.fromEntries(
       manager.getPanes().map((pane) => {
         const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+        const current = { bufferType, wasAtBottom, viewportY, baseY }
+        const previous = lastVisibleScrollStatesByLeafIdRef.current?.[pane.leafId]
+        const stable =
+          previous && isTransientTerminalEdgeSnap(current, previous) ? previous : current
         logTerminalScrollRestore('capture-current', {
-          baseY,
-          bufferType,
+          baseY: stable.baseY,
+          bufferType: stable.bufferType,
           leafId: pane.leafId,
           paneId: pane.id,
           source: 'visible-cleanup',
           tabId,
-          viewportY,
-          wasAtBottom,
+          viewportY: stable.viewportY,
+          wasAtBottom: stable.wasAtBottom,
           worktreeId
         })
-        return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
+        return [pane.leafId, stable]
       })
     )
   }, [tabId, worktreeId])

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -72,7 +72,11 @@ import {
 } from '@/lib/pane-manager/mobile-driver-state'
 import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
-import { captureScrollState, restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
+import {
+  captureScrollState,
+  getPendingScrollRestoreState,
+  restoreScrollStateAfterLayout
+} from '@/lib/pane-manager/pane-scroll'
 import {
   logTerminalScrollRestore,
   terminalScrollStateForDebug,
@@ -730,7 +734,8 @@ export default function TerminalPane({
     const scrollStatesByLeafId = isVisibleRef.current
       ? Object.fromEntries(
           currentPanes.map((pane) => {
-            const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+            const { bufferType, wasAtBottom, viewportY, baseY } =
+              getPendingScrollRestoreState(pane.terminal) ?? captureScrollState(pane.terminal)
             const current = { bufferType, wasAtBottom, viewportY, baseY }
             const previous = lastVisibleScrollStatesByLeafIdRef.current?.[pane.leafId]
             const stable =
@@ -861,7 +866,8 @@ export default function TerminalPane({
     }
     return Object.fromEntries(
       manager.getPanes().map((pane) => {
-        const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+        const { bufferType, wasAtBottom, viewportY, baseY } =
+          getPendingScrollRestoreState(pane.terminal) ?? captureScrollState(pane.terminal)
         const current = { bufferType, wasAtBottom, viewportY, baseY }
         const previous = lastVisibleScrollStatesByLeafIdRef.current?.[pane.leafId]
         const stable =

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -907,7 +907,10 @@ export default function TerminalPane({
           tabId,
           worktreeId
         })
-        restoreScrollStateAfterLayout(pane.terminal, scrollState, { syncScrollbar: false })
+        restoreScrollStateAfterLayout(pane.terminal, scrollState, {
+          debugSource: 'durable-remount-restore',
+          syncScrollbar: false
+        })
       }
     }
     hasAppliedDurableScrollRestoreRef.current = true

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -72,6 +72,7 @@ import {
 } from '@/lib/pane-manager/mobile-driver-state'
 import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
+import { captureScrollState, restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import { captureTerminalShutdownLayout } from './terminal-shutdown-layout-capture'
 import {
   inspectRuntimeTerminalProcess,
@@ -94,7 +95,11 @@ import {
   isHostAuthoritativeLayout,
   planTerminalLiveLayoutInsertions
 } from './terminal-live-layout-reconciliation'
-import type { TerminalQuickCommand, TerminalQuickCommandScope } from '../../../../shared/types'
+import type {
+  TerminalQuickCommand,
+  TerminalQuickCommandScope,
+  TerminalScrollStateSnapshot
+} from '../../../../shared/types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import { refitAndRefreshAllTerminalPanes } from '@/lib/pane-manager/pane-manager-registry'
@@ -461,6 +466,10 @@ export default function TerminalPane({
     [savedLayout, terminalTab]
   )
   const initialLayoutRef = useRef(restoredLayout)
+  const savedScrollStatesByLeafIdRef = useRef(savedLayout.scrollStatesByLeafId)
+  savedScrollStatesByLeafIdRef.current = savedLayout.scrollStatesByLeafId
+  const lastVisibleScrollStatesByLeafIdRef = useRef(savedLayout.scrollStatesByLeafId)
+  const hasAppliedDurableScrollRestoreRef = useRef(false)
   const updateTabTitle = useAppStore((store) => store.updateTabTitle)
   const setRuntimePaneTitle = useAppStore((store) => store.setRuntimePaneTitle)
   const clearRuntimePaneTitle = useAppStore((store) => store.clearRuntimePaneTitle)
@@ -697,6 +706,27 @@ export default function TerminalPane({
     if (Object.keys(mergedScrollbackRefs).length > 0) {
       layout.scrollbackRefsByLeafId = mergedScrollbackRefs
     }
+    // Why: xterm can report a transient top viewport while hidden or during
+    // WebGL/layout resume. Only visible captures are allowed to redefine the
+    // user's durable scroll position.
+    const scrollStatesByLeafId = isVisibleRef.current
+      ? Object.fromEntries(
+          currentPanes.map((pane) => {
+            const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+            return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
+          })
+        )
+      : mergeCapturedLeafState<TerminalScrollStateSnapshot>({
+          prior: existing?.scrollStatesByLeafId,
+          fresh: {},
+          currentLeafIds
+        })
+    if (Object.keys(scrollStatesByLeafId).length > 0) {
+      layout.scrollStatesByLeafId = scrollStatesByLeafId
+      if (isVisibleRef.current) {
+        lastVisibleScrollStatesByLeafIdRef.current = scrollStatesByLeafId
+      }
+    }
     // Why: between pane creation and the deferred rAF where PTYs actually
     // attach, all transports have getPtyId() === null. The merge below
     // preserves the *prior* snapshot's leaf→PTY mappings while still letting
@@ -762,6 +792,80 @@ export default function TerminalPane({
       clearedScrollbackLeafIds.delete(leafId)
     }
   }, [tabId, setTabLayout, worktreeId])
+
+  const persistCurrentScrollStates = useCallback(
+    (scrollStatesByLeafId: Record<string, TerminalScrollStateSnapshot>): void => {
+      if (Object.keys(scrollStatesByLeafId).length === 0) {
+        return
+      }
+      lastVisibleScrollStatesByLeafIdRef.current = scrollStatesByLeafId
+      const existingLayout = useAppStore.getState().terminalLayoutsByTabId[tabId] ?? EMPTY_LAYOUT
+      setTabLayout(tabId, {
+        ...existingLayout,
+        scrollStatesByLeafId
+      })
+    },
+    [setTabLayout, tabId]
+  )
+
+  const captureCurrentScrollStatesByLeafId = useCallback((): Record<
+    string,
+    TerminalScrollStateSnapshot
+  > | null => {
+    const manager = managerRef.current
+    if (!manager) {
+      return null
+    }
+    return Object.fromEntries(
+      manager.getPanes().map((pane) => {
+        const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+        return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
+      })
+    )
+  }, [])
+
+  useLayoutEffect(() => {
+    if (!isVisible) {
+      return
+    }
+    return () => {
+      const captured = captureCurrentScrollStatesByLeafId()
+      if (captured) {
+        // Why: workspace switches can hide terminals before the next passive
+        // effect; capture the visible viewport at the synchronous boundary.
+        persistCurrentScrollStates(captured)
+      }
+    }
+  }, [captureCurrentScrollStatesByLeafId, isVisible, persistCurrentScrollStates])
+
+  useLayoutEffect(() => {
+    if (!isVisible || hasAppliedDurableScrollRestoreRef.current) {
+      return
+    }
+    const scrollStatesByLeafId =
+      savedScrollStatesByLeafIdRef.current ?? lastVisibleScrollStatesByLeafIdRef.current
+    const manager = managerRef.current
+    if (!manager || !scrollStatesByLeafId) {
+      return
+    }
+    const panes = manager.getPanes()
+    if (panes.length === 0) {
+      return
+    }
+    const liveLeafIds = new Set<string>(panes.map((pane) => pane.leafId))
+    if (Object.keys(scrollStatesByLeafId).some((leafId) => !liveLeafIds.has(leafId))) {
+      return
+    }
+    // Why: this is a remount fallback for leaf-durable state. Live mounted
+    // visibility changes use useTerminalScrollVisibilityMemory's in-memory path.
+    for (const pane of panes) {
+      const scrollState = scrollStatesByLeafId[pane.leafId]
+      if (scrollState) {
+        restoreScrollStateAfterLayout(pane.terminal, scrollState, { syncScrollbar: false })
+      }
+    }
+    hasAppliedDurableScrollRestoreRef.current = true
+  }, [isVisible, paneCount])
 
   const clearPaneScrollback = useCallback(
     (pane: ManagedPane): void => {

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -73,6 +73,11 @@ import {
 import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { captureScrollState, restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
+import {
+  logTerminalScrollRestore,
+  terminalScrollStateForDebug,
+  terminalViewportForDebug
+} from '@/lib/pane-manager/terminal-scroll-restore-debug'
 import { captureTerminalShutdownLayout } from './terminal-shutdown-layout-capture'
 import {
   inspectRuntimeTerminalProcess,
@@ -713,6 +718,18 @@ export default function TerminalPane({
       ? Object.fromEntries(
           currentPanes.map((pane) => {
             const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+            logTerminalScrollRestore('layout-persist', {
+              baseY,
+              bufferType,
+              isVisible: isVisibleRef.current,
+              leafId: pane.leafId,
+              paneId: pane.id,
+              source: 'persistLayoutSnapshot',
+              tabId,
+              viewportY,
+              wasAtBottom,
+              worktreeId
+            })
             return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
           })
         )
@@ -725,6 +742,15 @@ export default function TerminalPane({
       layout.scrollStatesByLeafId = scrollStatesByLeafId
       if (isVisibleRef.current) {
         lastVisibleScrollStatesByLeafIdRef.current = scrollStatesByLeafId
+      }
+      if (!isVisibleRef.current) {
+        logTerminalScrollRestore('layout-persist', {
+          isVisible: false,
+          leafIds: Object.keys(scrollStatesByLeafId),
+          source: 'preserve-hidden-prior',
+          tabId,
+          worktreeId
+        })
       }
     }
     // Why: between pane creation and the deferred rAF where PTYs actually
@@ -819,10 +845,21 @@ export default function TerminalPane({
     return Object.fromEntries(
       manager.getPanes().map((pane) => {
         const { bufferType, wasAtBottom, viewportY, baseY } = captureScrollState(pane.terminal)
+        logTerminalScrollRestore('capture-current', {
+          baseY,
+          bufferType,
+          leafId: pane.leafId,
+          paneId: pane.id,
+          source: 'visible-cleanup',
+          tabId,
+          viewportY,
+          wasAtBottom,
+          worktreeId
+        })
         return [pane.leafId, { bufferType, wasAtBottom, viewportY, baseY }]
       })
     )
-  }, [])
+  }, [tabId, worktreeId])
 
   useLayoutEffect(() => {
     if (!isVisible) {
@@ -861,11 +898,20 @@ export default function TerminalPane({
     for (const pane of panes) {
       const scrollState = scrollStatesByLeafId[pane.leafId]
       if (scrollState) {
+        logTerminalScrollRestore('durable-restore', {
+          current: terminalViewportForDebug(pane.terminal),
+          leafId: pane.leafId,
+          paneId: pane.id,
+          saved: terminalScrollStateForDebug(scrollState),
+          source: 'visible-remount-fallback',
+          tabId,
+          worktreeId
+        })
         restoreScrollStateAfterLayout(pane.terminal, scrollState, { syncScrollbar: false })
       }
     }
     hasAppliedDurableScrollRestoreRef.current = true
-  }, [isVisible, paneCount])
+  }, [isVisible, paneCount, tabId, worktreeId])
 
   const clearPaneScrollback = useCallback(
     (pane: ManagedPane): void => {

--- a/src/renderer/src/components/terminal-pane/focus-terminal-pane-event.test.ts
+++ b/src/renderer/src/components/terminal-pane/focus-terminal-pane-event.test.ts
@@ -92,7 +92,7 @@ describe('handleFocusTerminalPaneDetail', () => {
     )
 
     expect(manager.setActivePane).toHaveBeenCalledWith(7, { focus: true })
-    expect(scrollToBottomIfOutputSinceLastView).toHaveBeenCalledWith(7)
+    expect(scrollToBottomIfOutputSinceLastView).toHaveBeenCalledWith(LEAF_ID)
   })
 
   it('does not focus, flash, or ack when the numeric pane no longer owns the leaf', () => {

--- a/src/renderer/src/components/terminal-pane/focus-terminal-pane-event.ts
+++ b/src/renderer/src/components/terminal-pane/focus-terminal-pane-event.ts
@@ -14,7 +14,7 @@ type FocusTerminalPaneEventDeps = {
   manager: FocusTerminalPaneManager | null
   acknowledgeAgents: (paneKeys: string[]) => void
   surfaceStaleAgentRow: (tabId: string, leafId: string) => void
-  scrollToBottomIfOutputSinceLastView?: (paneId: number) => void
+  scrollToBottomIfOutputSinceLastView?: (leafId: ManagedPane['leafId']) => void
 }
 
 export function handleFocusTerminalPaneDetail(
@@ -48,7 +48,7 @@ export function handleFocusTerminalPaneDetail(
   }
   manager.setActivePane(resolution.numericPaneId, { focus: true })
   if (detail.scrollToBottomIfOutputSinceLastView) {
-    scrollToBottomIfOutputSinceLastView?.(resolution.numericPaneId)
+    scrollToBottomIfOutputSinceLastView?.(resolution.leafId)
   }
   if (detail.flashFocusedPane) {
     const pane = manager.getPanes().find((candidate) => candidate.id === resolution.numericPaneId)

--- a/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
@@ -40,7 +40,8 @@ import {
   serializeTerminalLayout,
   EMPTY_LAYOUT,
   collectLeafIdsInOrder,
-  collectLeafIdsInReplayCreationOrder
+  collectLeafIdsInReplayCreationOrder,
+  normalizeTerminalLayoutSnapshot
 } from './layout-serialization'
 
 // ---------------------------------------------------------------------------
@@ -318,6 +319,36 @@ describe('serializeTerminalLayout', () => {
       root: { type: 'leaf', leafId: LEAF_1 },
       activeLeafId: null,
       expandedLeafId: null
+    })
+  })
+})
+
+describe('normalizeTerminalLayoutSnapshot', () => {
+  it('remaps durable scroll states with leaf ids', () => {
+    const normalized = normalizeTerminalLayoutSnapshot({
+      root: { type: 'leaf', leafId: 'legacy-pane' },
+      activeLeafId: 'legacy-pane',
+      expandedLeafId: null,
+      scrollStatesByLeafId: {
+        'legacy-pane': {
+          bufferType: 'normal',
+          wasAtBottom: false,
+          viewportY: 12,
+          baseY: 90
+        }
+      }
+    })
+
+    const nextLeafId = normalized.snapshot.activeLeafId
+    expect(normalized.changed).toBe(true)
+    expect(nextLeafId).toBeTruthy()
+    expect(normalized.snapshot.scrollStatesByLeafId).toEqual({
+      [nextLeafId as string]: {
+        bufferType: 'normal',
+        wasAtBottom: false,
+        viewportY: 12,
+        baseY: 90
+      }
     })
   })
 })

--- a/src/renderer/src/components/terminal-pane/merge-captured-leaf-state.ts
+++ b/src/renderer/src/components/terminal-pane/merge-captured-leaf-state.ts
@@ -6,14 +6,14 @@
 // This helper merges prior state with this pass's fresh state so a no-op
 // capture never erases a known-good buffer.
 
-export type LeafStringMap = Record<string, string>
+export type LeafStateMap<T> = Record<string, T>
 
-export function mergeCapturedLeafState(opts: {
-  prior: LeafStringMap | undefined
-  fresh: LeafStringMap
+export function mergeCapturedLeafState<T>(opts: {
+  prior: LeafStateMap<T> | undefined
+  fresh: LeafStateMap<T>
   currentLeafIds: ReadonlySet<string>
-}): LeafStringMap {
-  const merged: LeafStringMap = {}
+}): LeafStateMap<T> {
+  const merged: LeafStateMap<T> = {}
   if (opts.prior) {
     for (const [leafId, value] of Object.entries(opts.prior)) {
       if (opts.currentLeafIds.has(leafId)) {

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -3,6 +3,7 @@ import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 type FitPanesOptions = {
   debugSource?: string
   syncScrollbar?: boolean
+  useMarkers?: boolean
 }
 
 export function fitPanes(manager: PaneManager, options?: FitPanesOptions): void {

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -1,7 +1,9 @@
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { ManagedPane, ScrollState } from '@/lib/pane-manager/pane-manager-types'
 
 type FitPanesOptions = {
   debugSource?: string
+  scrollStatesByLeafId?: Map<ManagedPane['leafId'], ScrollState>
   syncScrollbar?: boolean
   useMarkers?: boolean
 }

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -1,7 +1,12 @@
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 
-export function fitPanes(manager: PaneManager): void {
-  manager.fitAllPanes()
+type FitPanesOptions = {
+  debugSource?: string
+  syncScrollbar?: boolean
+}
+
+export function fitPanes(manager: PaneManager, options?: FitPanesOptions): void {
+  manager.fitAllPanes(options)
 }
 
 /**
@@ -42,8 +47,8 @@ export function focusActivePane(manager: PaneManager): void {
   activePane?.terminal.focus()
 }
 
-export function fitAndFocusPanes(manager: PaneManager): void {
-  fitPanes(manager)
+export function fitAndFocusPanes(manager: PaneManager, options?: FitPanesOptions): void {
+  fitPanes(manager, options)
   focusActivePane(manager)
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
@@ -28,14 +28,14 @@ function cloneLayoutWithLeafRewrite(
   }
 }
 
-function remapLeafRecord(
-  source: Record<string, string> | undefined,
+function remapLeafRecord<T>(
+  source: Record<string, T> | undefined,
   rewrite: LeafIdRewrite
-): Record<string, string> | undefined {
+): Record<string, T> | undefined {
   if (!source) {
     return undefined
   }
-  const next: Record<string, string> = {}
+  const next: Record<string, T> = {}
   for (const [leafId, value] of Object.entries(source)) {
     if (rewrite.duplicatedInputLeafIds.has(leafId)) {
       continue
@@ -108,11 +108,13 @@ export function normalizeTerminalLayoutSnapshot(
   const ptyIdsByLeafId = remapLeafRecord(snapshot.ptyIdsByLeafId, rewrite)
   const buffersByLeafId = remapLeafRecord(snapshot.buffersByLeafId, rewrite)
   const scrollbackRefsByLeafId = remapLeafRecord(snapshot.scrollbackRefsByLeafId, rewrite)
+  const scrollStatesByLeafId = remapLeafRecord(snapshot.scrollStatesByLeafId, rewrite)
   const titlesByLeafId = remapLeafRecord(snapshot.titlesByLeafId, rewrite)
   const {
     ptyIdsByLeafId: _oldPtyIdsByLeafId,
     buffersByLeafId: _oldBuffersByLeafId,
     scrollbackRefsByLeafId: _oldScrollbackRefsByLeafId,
+    scrollStatesByLeafId: _oldScrollStatesByLeafId,
     titlesByLeafId: _oldTitlesByLeafId,
     ...snapshotWithoutLeafRecords
   } = snapshot
@@ -125,6 +127,7 @@ export function normalizeTerminalLayoutSnapshot(
       ...(ptyIdsByLeafId ? { ptyIdsByLeafId } : {}),
       ...(buffersByLeafId ? { buffersByLeafId } : {}),
       ...(scrollbackRefsByLeafId ? { scrollbackRefsByLeafId } : {}),
+      ...(scrollStatesByLeafId ? { scrollStatesByLeafId } : {}),
       ...(titlesByLeafId ? { titlesByLeafId } : {})
     },
     changed: true

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -1,5 +1,5 @@
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
-import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
+import type { ManagedPane, ScrollState } from '@/lib/pane-manager/pane-manager-types'
 import { resetAllTerminalWebglAtlases } from '@/lib/pane-manager/pane-manager-registry'
 import {
   flushTerminalOutput,
@@ -22,7 +22,9 @@ type ResumeTerminalVisibilityArgs = {
   isActive: boolean
   wasVisible: boolean
   shouldUseLightTabResume: boolean
-  captureViewportPositions: (useRememberedSnapshots: boolean) => Map<number, ScrollState>
+  captureViewportPositions: (
+    useRememberedSnapshots: boolean
+  ) => Map<ManagedPane['leafId'], ScrollState>
   withSuppressedScrollTracking: (callback: () => void) => void
 }
 
@@ -32,7 +34,9 @@ type HideTerminalVisibilityArgs = {
   wasWorktreeActive: boolean
   isWorktreeActive: boolean
   hasCompletedVisibleResume: boolean
-  captureViewportPositions: (useRememberedSnapshots: boolean) => Map<number, ScrollState>
+  captureViewportPositions: (
+    useRememberedSnapshots: boolean
+  ) => Map<ManagedPane['leafId'], ScrollState>
 }
 
 type HideTerminalVisibilityResult = {
@@ -163,13 +167,14 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
 
 function restoreTerminalViewportPositions(
   manager: PaneManager,
-  viewportPositions: Map<number, ScrollState>
+  viewportPositions: Map<ManagedPane['leafId'], ScrollState>
 ): void {
   for (const pane of manager.getPanes()) {
-    const position = viewportPositions.get(pane.id)
+    const position = viewportPositions.get(pane.leafId)
     if (position) {
       logTerminalScrollRestore('visibility-restore', {
         before: terminalViewportForDebug(pane.terminal),
+        leafId: pane.leafId,
         paneId: pane.id,
         saved: terminalScrollStateForDebug(position),
         source: 'resumeTerminalVisibility'

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -76,12 +76,13 @@ export function resumeTerminalVisibility({
     } else {
       resumeTerminalVisibilityHeavy(manager, isActive)
     }
-    restoreTerminalViewportPositions(manager, viewportPositions)
     if (!shouldUseLightTabResume) {
       // Why: this clear wipes the glyph atlas shared with other same-config
-      // terminals; the global reset rebuilds their render models too.
+      // terminals; do it before scroll restore because WebGL rebuild can
+      // disturb xterm's viewport bookkeeping during visibility resume.
       resetAllTerminalWebglAtlases()
     }
+    restoreTerminalViewportPositions(manager, viewportPositions)
   })
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -156,12 +156,14 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
   if (isActive) {
     fitAndFocusPanes(manager, {
       debugSource: 'visibility-resume-fit',
-      syncScrollbar: false
+      syncScrollbar: false,
+      useMarkers: false
     })
   } else {
     fitPanes(manager, {
       debugSource: 'visibility-resume-fit',
-      syncScrollbar: false
+      syncScrollbar: false,
+      useMarkers: false
     })
   }
 }
@@ -182,7 +184,8 @@ function restoreTerminalViewportPositions(
       })
       restoreScrollStateAfterLayout(pane.terminal, position, {
         debugSource: 'visibility-restore',
-        syncScrollbar: false
+        syncScrollbar: false,
+        useMarkers: false
       })
     }
   }

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -74,7 +74,7 @@ export function resumeTerminalVisibility({
         focusActivePane(manager)
       }
     } else {
-      resumeTerminalVisibilityHeavy(manager, isActive)
+      resumeTerminalVisibilityHeavy(manager, isActive, viewportPositions)
     }
     if (!shouldUseLightTabResume) {
       // Why: this clear wipes the glyph atlas shared with other same-config
@@ -136,7 +136,11 @@ function requestLightTabBacklogRecovery(manager: PaneManager): void {
   }
 }
 
-function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean): void {
+function resumeTerminalVisibilityHeavy(
+  manager: PaneManager,
+  isActive: boolean,
+  viewportPositions: Map<ManagedPane['leafId'], ScrollState>
+): void {
   // Why: hidden panes can accumulate large PTY bursts while Chromium is
   // occluded. Drain a bounded slice before fitting; the scheduler keeps
   // ordering and continues the rest asynchronously so return-to-app does
@@ -156,12 +160,14 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
   if (isActive) {
     fitAndFocusPanes(manager, {
       debugSource: 'visibility-resume-fit',
+      scrollStatesByLeafId: viewportPositions,
       syncScrollbar: false,
       useMarkers: false
     })
   } else {
     fitPanes(manager, {
       debugSource: 'visibility-resume-fit',
+      scrollStatesByLeafId: viewportPositions,
       syncScrollbar: false,
       useMarkers: false
     })

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -149,9 +149,15 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
   // above, so this fit only absorbs container dimension changes that
   // happened while hidden (e.g. sidebar toggle on another worktree).
   if (isActive) {
-    fitAndFocusPanes(manager)
+    fitAndFocusPanes(manager, {
+      debugSource: 'visibility-resume-fit',
+      syncScrollbar: false
+    })
   } else {
-    fitPanes(manager)
+    fitPanes(manager, {
+      debugSource: 'visibility-resume-fit',
+      syncScrollbar: false
+    })
   }
 }
 
@@ -168,7 +174,10 @@ function restoreTerminalViewportPositions(
         saved: terminalScrollStateForDebug(position),
         source: 'resumeTerminalVisibility'
       })
-      restoreScrollStateAfterLayout(pane.terminal, position, { syncScrollbar: false })
+      restoreScrollStateAfterLayout(pane.terminal, position, {
+        debugSource: 'visibility-restore',
+        syncScrollbar: false
+      })
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -144,7 +144,7 @@ function restoreTerminalViewportPositions(
   for (const pane of manager.getPanes()) {
     const position = viewportPositions.get(pane.id)
     if (position) {
-      restoreScrollStateAfterLayout(pane.terminal, position)
+      restoreScrollStateAfterLayout(pane.terminal, position, { syncScrollbar: false })
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -6,6 +6,11 @@ import {
   requestTerminalBacklogRecovery
 } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
+import {
+  logTerminalScrollRestore,
+  terminalScrollStateForDebug,
+  terminalViewportForDebug
+} from '@/lib/pane-manager/terminal-scroll-restore-debug'
 import { fitAndFocusPanes, fitPanes, focusActivePane } from './pane-helpers'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
@@ -48,6 +53,12 @@ export function resumeTerminalVisibility({
   // restore path avoids content matching so duplicate agent log lines do
   // not jump to the wrong history entry.
   const viewportPositions = captureViewportPositions(!wasVisible)
+  logTerminalScrollRestore('visibility-resume', {
+    isActive,
+    paneCount: manager.getPanes().length,
+    shouldUseLightTabResume,
+    wasVisible
+  })
   withSuppressedScrollTracking(() => {
     if (shouldUseLightTabResume) {
       // Why: intra-worktree tab switches only toggle the overlay. Keeping
@@ -83,6 +94,13 @@ export function hideTerminalVisibility({
     // Why: hidden DOM/layout churn can mutate xterm's viewport before the
     // pane becomes visible again. Preserve the last visible position.
     captureViewportPositions(false)
+    logTerminalScrollRestore('visibility-hide', {
+      hasCompletedVisibleResume,
+      isWorktreeActive,
+      paneCount: manager.getPanes().length,
+      wasVisible,
+      wasWorktreeActive
+    })
   }
   if (!isWorktreeActive && (wasVisible || surfaceBecameHidden)) {
     // Suspend WebGL when going hidden. xterm.write() continues to land in
@@ -144,6 +162,12 @@ function restoreTerminalViewportPositions(
   for (const pane of manager.getPanes()) {
     const position = viewportPositions.get(pane.id)
     if (position) {
+      logTerminalScrollRestore('visibility-restore', {
+        before: terminalViewportForDebug(pane.terminal),
+        paneId: pane.id,
+        saved: terminalScrollStateForDebug(position),
+        source: 'resumeTerminalVisibility'
+      })
       restoreScrollStateAfterLayout(pane.terminal, position, { syncScrollbar: false })
     }
   }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -20,6 +20,9 @@ const mocks = vi.hoisted(() => ({
   handleTerminalFileDrop: vi.fn(),
   pasteTerminalText: vi.fn(),
   recordTerminalUserInputForLeaf: vi.fn(),
+  rememberTerminalContainerScrollState: vi.fn(),
+  rememberTerminalLeafScrollState: vi.fn(),
+  rememberTerminalScrollState: vi.fn(),
   requestTerminalBacklogRecovery: vi.fn(),
   restoreScrollState: vi.fn(),
   restoreScrollStateAfterLayout: vi.fn()
@@ -73,6 +76,9 @@ vi.mock('@/lib/pane-manager/pane-scroll', () => ({
   captureScrollState: mocks.captureScrollState,
   getPendingScrollRestoreState: mocks.getPendingScrollRestoreState,
   getTerminalOutputEpoch: mocks.getTerminalOutputEpoch,
+  rememberTerminalContainerScrollState: mocks.rememberTerminalContainerScrollState,
+  rememberTerminalLeafScrollState: mocks.rememberTerminalLeafScrollState,
+  rememberTerminalScrollState: mocks.rememberTerminalScrollState,
   restoreScrollState: mocks.restoreScrollState,
   restoreScrollStateAfterLayout: mocks.restoreScrollStateAfterLayout
 }))
@@ -533,6 +539,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
     expect(mocks.fitAndFocusPanes).toHaveBeenCalledWith(manager, {
       debugSource: 'visibility-resume-fit',
+      scrollStatesByLeafId: expect.any(Map),
       syncScrollbar: false,
       useMarkers: false
     })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -618,7 +618,9 @@ describe('useTerminalPaneGlobalEffects', () => {
 
     expect(mocks.captureScrollState).toHaveBeenCalledTimes(2)
     expect(manager.suspendRendering).toHaveBeenCalledTimes(1)
-    expect(mocks.restoreScrollStateAfterLayout).toHaveBeenLastCalledWith(terminalA, preHideState)
+    expect(mocks.restoreScrollStateAfterLayout).toHaveBeenLastCalledWith(terminalA, preHideState, {
+      syncScrollbar: false
+    })
   })
 
   it('clears WebGL texture atlases when the active visible terminal regains focus', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -529,7 +529,10 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.requestTerminalBacklogRecovery).toHaveBeenCalledWith(terminal)
     expect(mocks.flushTerminalOutput).toHaveBeenCalledWith(terminal, { maxChars: 256 * 1024 })
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
-    expect(mocks.fitAndFocusPanes).toHaveBeenCalledWith(manager)
+    expect(mocks.fitAndFocusPanes).toHaveBeenCalledWith(manager, {
+      debugSource: 'visibility-resume-fit',
+      syncScrollbar: false
+    })
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
   })
 
@@ -619,6 +622,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.captureScrollState).toHaveBeenCalledTimes(2)
     expect(manager.suspendRendering).toHaveBeenCalledTimes(1)
     expect(mocks.restoreScrollStateAfterLayout).toHaveBeenLastCalledWith(terminalA, preHideState, {
+      debugSource: 'visibility-restore',
       syncScrollbar: false
     })
   })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -267,9 +267,9 @@ describe('useTerminalPaneGlobalEffects', () => {
       'flush:terminal-b',
       'resume',
       'fit-focus',
+      'reset-atlas',
       'restore:terminal-a',
-      'restore:terminal-b',
-      'reset-atlas'
+      'restore:terminal-b'
     ])
     expect(mocks.flushTerminalOutput).toHaveBeenNthCalledWith(1, terminalA, {
       maxChars: 256 * 1024

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -531,7 +531,8 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
     expect(mocks.fitAndFocusPanes).toHaveBeenCalledWith(manager, {
       debugSource: 'visibility-resume-fit',
-      syncScrollbar: false
+      syncScrollbar: false,
+      useMarkers: false
     })
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
   })
@@ -623,7 +624,8 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(manager.suspendRendering).toHaveBeenCalledTimes(1)
     expect(mocks.restoreScrollStateAfterLayout).toHaveBeenLastCalledWith(terminalA, preHideState, {
       debugSource: 'visibility-restore',
-      syncScrollbar: false
+      syncScrollbar: false,
+      useMarkers: false
     })
   })
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   fitPanes: vi.fn(),
   focusActivePane: vi.fn(),
   flushTerminalOutput: vi.fn(),
+  getPendingScrollRestoreState: vi.fn(() => null),
   getTerminalOutputEpoch: vi.fn(() => 0),
   handleTerminalFileDrop: vi.fn(),
   pasteTerminalText: vi.fn(),
@@ -70,6 +71,7 @@ vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
 
 vi.mock('@/lib/pane-manager/pane-scroll', () => ({
   captureScrollState: mocks.captureScrollState,
+  getPendingScrollRestoreState: mocks.getPendingScrollRestoreState,
   getTerminalOutputEpoch: mocks.getTerminalOutputEpoch,
   restoreScrollState: mocks.restoreScrollState,
   restoreScrollStateAfterLayout: mocks.restoreScrollStateAfterLayout

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
@@ -115,7 +115,7 @@ describe('useTerminalScrollVisibilityMemory', () => {
       paneCount: 1
     })
 
-    visibilityMemory.scheduleFollowOutputIfNeeded(1)
+    visibilityMemory.scheduleFollowOutputIfNeeded('leaf-1' as never)
     animationFrames.shift()?.(16)
     animationFrames.shift()?.(32)
 
@@ -145,7 +145,7 @@ describe('useTerminalScrollVisibilityMemory', () => {
       paneCount: 1
     })
 
-    visibilityMemory.scheduleFollowOutputIfNeeded(1)
+    visibilityMemory.scheduleFollowOutputIfNeeded('leaf-1' as never)
     runEffectCleanups()
 
     expect(cancelAnimationFrame).toHaveBeenCalledWith(7)
@@ -242,5 +242,85 @@ describe('useTerminalScrollVisibilityMemory', () => {
       newLeafState
     )
     expect(mocks.captureScrollState).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not apply pending follow-output to a reused pane id with a different leaf', () => {
+    const oldTerminal = {
+      onScroll: vi.fn(() => ({ dispose: vi.fn() })),
+      scrollToBottom: vi.fn()
+    }
+    const newTerminal = {
+      onScroll: vi.fn(() => ({ dispose: vi.fn() })),
+      scrollToBottom: vi.fn()
+    }
+    let panes = [{ id: 1, leafId: 'old-leaf', terminal: oldTerminal }]
+    const manager = {
+      getPanes: vi.fn(() => panes)
+    }
+    const animationFrames: FrameRequestCallback[] = []
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      animationFrames.push(callback)
+      return animationFrames.length
+    })
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+
+    visibilityMemory.scheduleFollowOutputIfNeeded('old-leaf' as never)
+    panes = [{ id: 1, leafId: 'new-leaf', terminal: newTerminal }]
+    animationFrames.shift()?.(16)
+    animationFrames.shift()?.(32)
+
+    expect(oldTerminal.scrollToBottom).not.toHaveBeenCalled()
+    expect(newTerminal.scrollToBottom).not.toHaveBeenCalled()
+    expect(mocks.flushTerminalOutput).not.toHaveBeenCalled()
+  })
+
+  it('does not follow output when the remembered visible position was not at bottom', () => {
+    const onScrollListeners: (() => void)[] = []
+    const terminal = {
+      onScroll: vi.fn((listener: () => void) => {
+        onScrollListeners.push(listener)
+        return { dispose: vi.fn() }
+      }),
+      scrollToBottom: vi.fn()
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, leafId: 'leaf-1', terminal }])
+    }
+    const animationFrames: FrameRequestCallback[] = []
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      animationFrames.push(callback)
+      return animationFrames.length
+    })
+    mocks.captureScrollState.mockReturnValue({
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100
+    })
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+    onScrollListeners[0]?.()
+
+    visibilityMemory.scheduleFollowOutputIfNeeded('leaf-1' as never)
+    animationFrames.shift()?.(16)
+    animationFrames.shift()?.(32)
+
+    expect(mocks.flushTerminalOutput).toHaveBeenCalledWith(terminal, {
+      maxChars: 256 * 1024
+    })
+    expect(terminal.scrollToBottom).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
@@ -13,7 +13,10 @@ const mocks = vi.hoisted(() => ({
   flushTerminalOutput: vi.fn(),
   getPendingScrollRestoreState: vi.fn((): unknown => null),
   getTerminalOutputEpoch: vi.fn(() => 1),
-  isTerminalScrollRestoreInProgress: vi.fn(() => false)
+  isTerminalScrollRestoreInProgress: vi.fn(() => false),
+  rememberTerminalContainerScrollState: vi.fn(),
+  rememberTerminalLeafScrollState: vi.fn(),
+  rememberTerminalScrollState: vi.fn()
 }))
 
 const reactRefState = vi.hoisted(() => ({
@@ -69,7 +72,10 @@ vi.mock('@/lib/pane-manager/pane-scroll', () => ({
   captureScrollState: mocks.captureScrollState,
   getPendingScrollRestoreState: mocks.getPendingScrollRestoreState,
   getTerminalOutputEpoch: mocks.getTerminalOutputEpoch,
-  isTerminalScrollRestoreInProgress: mocks.isTerminalScrollRestoreInProgress
+  isTerminalScrollRestoreInProgress: mocks.isTerminalScrollRestoreInProgress,
+  rememberTerminalContainerScrollState: mocks.rememberTerminalContainerScrollState,
+  rememberTerminalLeafScrollState: mocks.rememberTerminalLeafScrollState,
+  rememberTerminalScrollState: mocks.rememberTerminalScrollState
 }))
 
 describe('useTerminalScrollVisibilityMemory', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
@@ -99,7 +99,7 @@ describe('useTerminalScrollVisibilityMemory', () => {
       scrollToBottom: vi.fn()
     }
     const manager = {
-      getPanes: vi.fn(() => [{ id: 1, terminal }])
+      getPanes: vi.fn(() => [{ id: 1, leafId: 'leaf-1', terminal }])
     }
     const animationFrames: FrameRequestCallback[] = []
     globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
@@ -131,7 +131,7 @@ describe('useTerminalScrollVisibilityMemory', () => {
       scrollToBottom: vi.fn()
     }
     const manager = {
-      getPanes: vi.fn(() => [{ id: 1, terminal }])
+      getPanes: vi.fn(() => [{ id: 1, leafId: 'leaf-1', terminal }])
     }
     const cancelAnimationFrame = vi.fn()
     globalThis.requestAnimationFrame = vi.fn(() => 7)
@@ -161,7 +161,7 @@ describe('useTerminalScrollVisibilityMemory', () => {
       })
     }
     const manager = {
-      getPanes: vi.fn(() => [{ id: 1, terminal }])
+      getPanes: vi.fn(() => [{ id: 1, leafId: 'leaf-1', terminal }])
     }
     const userScrolledState = {
       bufferType: 'normal',
@@ -195,7 +195,52 @@ describe('useTerminalScrollVisibilityMemory', () => {
     mocks.isTerminalScrollRestoreInProgress.mockReturnValueOnce(true)
     listener()
 
-    expect(visibilityMemory.captureViewportPositions(true).get(1)).toBe(userScrolledState)
+    expect(visibilityMemory.captureViewportPositions(true).get('leaf-1' as never)).toBe(
+      userScrolledState
+    )
     expect(mocks.captureScrollState).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reuse a remembered snapshot when a pane id gets a new leaf', () => {
+    const terminal = {
+      onScroll: vi.fn(() => ({ dispose: vi.fn() }))
+    }
+    let panes = [{ id: 1, leafId: 'old-leaf', terminal }]
+    const manager = {
+      getPanes: vi.fn(() => panes)
+    }
+    const oldBottomState = {
+      bufferType: 'normal',
+      wasAtBottom: true,
+      viewportY: 100,
+      baseY: 100
+    }
+    const newLeafState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100
+    }
+    let currentState = oldBottomState
+    mocks.captureScrollState.mockImplementation(() => currentState)
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+
+    expect(visibilityMemory.captureViewportPositions(false).get('old-leaf' as never)).toStrictEqual(
+      oldBottomState
+    )
+    panes = [{ id: 1, leafId: 'new-leaf', terminal }]
+    currentState = newLeafState
+
+    expect(visibilityMemory.captureViewportPositions(true).get('new-leaf' as never)).toStrictEqual(
+      newLeafState
+    )
+    expect(mocks.captureScrollState).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     baseY: 0
   })),
   flushTerminalOutput: vi.fn(),
+  getPendingScrollRestoreState: vi.fn((): unknown => null),
   getTerminalOutputEpoch: vi.fn(() => 1),
   isTerminalScrollRestoreInProgress: vi.fn(() => false)
 }))
@@ -66,6 +67,7 @@ vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
 vi.mock('@/lib/pane-manager/pane-scroll', () => ({
   cancelDeferredScrollRestore: mocks.cancelDeferredScrollRestore,
   captureScrollState: mocks.captureScrollState,
+  getPendingScrollRestoreState: mocks.getPendingScrollRestoreState,
   getTerminalOutputEpoch: mocks.getTerminalOutputEpoch,
   isTerminalScrollRestoreInProgress: mocks.isTerminalScrollRestoreInProgress
 }))
@@ -78,6 +80,7 @@ describe('useTerminalScrollVisibilityMemory', () => {
     resetHookRefs()
     vi.clearAllMocks()
     mocks.captureScrollState.mockReset()
+    mocks.getPendingScrollRestoreState.mockReset()
     mocks.getTerminalOutputEpoch.mockReset()
     mocks.isTerminalScrollRestoreInProgress.mockReset()
     mocks.captureScrollState.mockImplementation(() => ({
@@ -86,6 +89,7 @@ describe('useTerminalScrollVisibilityMemory', () => {
       viewportY: 0,
       baseY: 0
     }))
+    mocks.getPendingScrollRestoreState.mockImplementation(() => null)
     mocks.getTerminalOutputEpoch.mockImplementation(() => 1)
     mocks.isTerminalScrollRestoreInProgress.mockImplementation(() => false)
   })
@@ -253,6 +257,40 @@ describe('useTerminalScrollVisibilityMemory', () => {
     )
     expect(visibilityMemory.captureViewportPositions(true).get('leaf-1' as never)).toBe(
       userScrolledState
+    )
+  })
+
+  it('captures the pending restore target while a visibility restore is settling', () => {
+    const terminal = {
+      onScroll: vi.fn(() => ({ dispose: vi.fn() }))
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, leafId: 'leaf-1', terminal }])
+    }
+    const pendingRestoreState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 150,
+      baseY: 154
+    }
+    mocks.getPendingScrollRestoreState.mockReturnValue(pendingRestoreState)
+    mocks.captureScrollState.mockReturnValue({
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 56,
+      baseY: 154
+    })
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+
+    expect(visibilityMemory.captureViewportPositions(false).get('leaf-1' as never)).toBe(
+      pendingRestoreState
     )
   })
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
@@ -77,6 +77,17 @@ describe('useTerminalScrollVisibilityMemory', () => {
   beforeEach(() => {
     resetHookRefs()
     vi.clearAllMocks()
+    mocks.captureScrollState.mockReset()
+    mocks.getTerminalOutputEpoch.mockReset()
+    mocks.isTerminalScrollRestoreInProgress.mockReset()
+    mocks.captureScrollState.mockImplementation(() => ({
+      bufferType: 'normal',
+      wasAtBottom: true,
+      viewportY: 0,
+      baseY: 0
+    }))
+    mocks.getTerminalOutputEpoch.mockImplementation(() => 1)
+    mocks.isTerminalScrollRestoreInProgress.mockImplementation(() => false)
   })
 
   afterEach(() => {
@@ -199,6 +210,50 @@ describe('useTerminalScrollVisibilityMemory', () => {
       userScrolledState
     )
     expect(mocks.captureScrollState).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the remembered non-bottom position when xterm reports a transient edge snap', () => {
+    const onScrollListeners: (() => void)[] = []
+    const terminal = {
+      onScroll: vi.fn((listener: () => void) => {
+        onScrollListeners.push(listener)
+        return { dispose: vi.fn() }
+      })
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, leafId: 'leaf-1', terminal }])
+    }
+    const userScrolledState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100
+    }
+    const transientTopState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 0,
+      baseY: 100
+    }
+    mocks.captureScrollState
+      .mockReturnValueOnce(userScrolledState)
+      .mockReturnValueOnce(transientTopState)
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+    onScrollListeners[0]?.()
+
+    expect(visibilityMemory.captureViewportPositions(false).get('leaf-1' as never)).toBe(
+      userScrolledState
+    )
+    expect(visibilityMemory.captureViewportPositions(true).get('leaf-1' as never)).toBe(
+      userScrolledState
+    )
   })
 
   it('does not reuse a remembered snapshot when a pane id gets a new leaf', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
@@ -11,7 +11,8 @@ const mocks = vi.hoisted(() => ({
     baseY: 0
   })),
   flushTerminalOutput: vi.fn(),
-  getTerminalOutputEpoch: vi.fn(() => 1)
+  getTerminalOutputEpoch: vi.fn(() => 1),
+  isTerminalScrollRestoreInProgress: vi.fn(() => false)
 }))
 
 const reactRefState = vi.hoisted(() => ({
@@ -65,7 +66,8 @@ vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
 vi.mock('@/lib/pane-manager/pane-scroll', () => ({
   cancelDeferredScrollRestore: mocks.cancelDeferredScrollRestore,
   captureScrollState: mocks.captureScrollState,
-  getTerminalOutputEpoch: mocks.getTerminalOutputEpoch
+  getTerminalOutputEpoch: mocks.getTerminalOutputEpoch,
+  isTerminalScrollRestoreInProgress: mocks.isTerminalScrollRestoreInProgress
 }))
 
 describe('useTerminalScrollVisibilityMemory', () => {
@@ -148,5 +150,52 @@ describe('useTerminalScrollVisibilityMemory', () => {
 
     expect(cancelAnimationFrame).toHaveBeenCalledWith(7)
     expect(mocks.flushTerminalOutput).not.toHaveBeenCalled()
+  })
+
+  it('does not remember scroll events caused by a deferred restore', () => {
+    const onScrollListeners: (() => void)[] = []
+    const terminal = {
+      onScroll: vi.fn((listener: () => void) => {
+        onScrollListeners.push(listener)
+        return { dispose: vi.fn() }
+      })
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, terminal }])
+    }
+    const userScrolledState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100
+    }
+    const restoreBottomState = {
+      bufferType: 'normal',
+      wasAtBottom: true,
+      viewportY: 100,
+      baseY: 100
+    }
+    mocks.captureScrollState
+      .mockReturnValueOnce(userScrolledState)
+      .mockReturnValueOnce(restoreBottomState)
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+
+    const listener = onScrollListeners[0]
+    if (!listener) {
+      throw new Error('expected onScroll listener to be registered')
+    }
+    listener()
+    mocks.isTerminalScrollRestoreInProgress.mockReturnValueOnce(true)
+    listener()
+
+    expect(visibilityMemory.captureViewportPositions(true).get(1)).toBe(userScrolledState)
+    expect(mocks.captureScrollState).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
@@ -33,6 +33,16 @@ type TerminalScrollVisibilityMemory = {
 
 const FOLLOW_OUTPUT_FLUSH_CHARS = 256 * 1024
 
+function isTransientTerminalEdgeSnap(current: ScrollState, previous: ScrollState): boolean {
+  if (previous.wasAtBottom || current.bufferType !== previous.bufferType) {
+    return false
+  }
+  if (current.baseY !== previous.baseY || current.viewportY === previous.viewportY) {
+    return false
+  }
+  return current.viewportY === 0 || current.wasAtBottom
+}
+
 export function useTerminalScrollVisibilityMemory({
   managerRef,
   isVisibleRef,
@@ -75,13 +85,17 @@ export function useTerminalScrollVisibilityMemory({
             return [pane.leafId, remembered.scrollState] as const
           }
           const state = captureScrollState(pane.terminal)
+          const stableState =
+            remembered && isTransientTerminalEdgeSnap(state, remembered.scrollState)
+              ? remembered.scrollState
+              : state
           if (!useRememberedSnapshots || !remembered) {
             visibleScrollSnapshotsRef.current.set(pane.leafId, {
-              scrollState: state,
+              scrollState: stableState,
               outputEpoch: getTerminalOutputEpoch(pane.terminal)
             })
           }
-          return [pane.leafId, state] as const
+          return [pane.leafId, stableState] as const
         })
       )
     },

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
@@ -8,7 +8,7 @@ import {
   isTerminalScrollRestoreInProgress
 } from '@/lib/pane-manager/pane-scroll'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
-import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
+import type { ManagedPane, ScrollState } from '@/lib/pane-manager/pane-manager-types'
 
 type VisibleScrollSnapshot = {
   scrollState: ScrollState
@@ -23,7 +23,9 @@ type UseTerminalScrollVisibilityMemoryArgs = {
 }
 
 type TerminalScrollVisibilityMemory = {
-  captureViewportPositions: (useRememberedSnapshots: boolean) => Map<number, ScrollState>
+  captureViewportPositions: (
+    useRememberedSnapshots: boolean
+  ) => Map<ManagedPane['leafId'], ScrollState>
   withSuppressedScrollTracking: (callback: () => void) => void
   applyPendingFollowOutputRequests: () => boolean
   scheduleFollowOutputIfNeeded: (paneId: number) => void
@@ -37,8 +39,10 @@ export function useTerminalScrollVisibilityMemory({
   visibleResumeCompleteRef,
   paneCount
 }: UseTerminalScrollVisibilityMemoryArgs): TerminalScrollVisibilityMemory {
-  const visibleScrollSnapshotsRef = useRef<Map<number, VisibleScrollSnapshot>>(new Map())
-  const scrollDisposablesRef = useRef<Map<number, IDisposable>>(new Map())
+  const visibleScrollSnapshotsRef = useRef<Map<ManagedPane['leafId'], VisibleScrollSnapshot>>(
+    new Map()
+  )
+  const scrollDisposablesRef = useRef<Map<ManagedPane['leafId'], IDisposable>>(new Map())
   const suppressScrollTrackingRef = useRef(false)
   const pendingFollowOutputPaneIdsRef = useRef<Set<number>>(new Set())
   const followOutputFrameIdsRef = useRef<number[]>([])
@@ -52,32 +56,32 @@ export function useTerminalScrollVisibilityMemory({
   )
 
   const rememberVisibleScrollSnapshot = useCallback(
-    (paneId: number, terminal: Terminal): void => {
-      visibleScrollSnapshotsRef.current.set(paneId, captureVisibleScrollSnapshot(terminal))
+    (leafId: ManagedPane['leafId'], terminal: Terminal): void => {
+      visibleScrollSnapshotsRef.current.set(leafId, captureVisibleScrollSnapshot(terminal))
     },
     [captureVisibleScrollSnapshot]
   )
 
   const captureViewportPositions = useCallback(
-    (useRememberedSnapshots: boolean): Map<number, ScrollState> => {
+    (useRememberedSnapshots: boolean): Map<ManagedPane['leafId'], ScrollState> => {
       const manager = managerRef.current
       if (!manager) {
         return new Map()
       }
       return new Map(
         manager.getPanes().map((pane) => {
-          const remembered = visibleScrollSnapshotsRef.current.get(pane.id)
+          const remembered = visibleScrollSnapshotsRef.current.get(pane.leafId)
           if (useRememberedSnapshots && remembered) {
-            return [pane.id, remembered.scrollState] as const
+            return [pane.leafId, remembered.scrollState] as const
           }
           const state = captureScrollState(pane.terminal)
           if (!useRememberedSnapshots || !remembered) {
-            visibleScrollSnapshotsRef.current.set(pane.id, {
+            visibleScrollSnapshotsRef.current.set(pane.leafId, {
               scrollState: state,
               outputEpoch: getTerminalOutputEpoch(pane.terminal)
             })
           }
-          return [pane.id, state] as const
+          return [pane.leafId, state] as const
         })
       )
     },
@@ -110,7 +114,7 @@ export function useTerminalScrollVisibilityMemory({
       if (!pending.has(pane.id)) {
         continue
       }
-      const previous = visibleScrollSnapshotsRef.current.get(pane.id)
+      const previous = visibleScrollSnapshotsRef.current.get(pane.leafId)
       // Why: focus/follow can run immediately after a hidden pane becomes
       // visible. A bounded flush is enough to observe new output without
       // putting the whole hidden PTY backlog back on the interaction path.
@@ -120,7 +124,7 @@ export function useTerminalScrollVisibilityMemory({
       if (hasNewOutput) {
         cancelDeferredScrollRestore(pane.terminal)
         pane.terminal.scrollToBottom()
-        rememberVisibleScrollSnapshot(pane.id, pane.terminal)
+        rememberVisibleScrollSnapshot(pane.leafId, pane.terminal)
         didScroll = true
       }
       pending.delete(pane.id)
@@ -167,17 +171,16 @@ export function useTerminalScrollVisibilityMemory({
     }
     const disposables = scrollDisposablesRef.current
     const panes = manager.getPanes()
-    const livePaneIds = new Set(panes.map((pane) => pane.id))
-    for (const [paneId, disposable] of disposables) {
-      if (!livePaneIds.has(paneId)) {
+    const liveLeafIds = new Set(panes.map((pane) => pane.leafId))
+    for (const [leafId, disposable] of disposables) {
+      if (!liveLeafIds.has(leafId)) {
         disposable.dispose()
-        disposables.delete(paneId)
-        visibleScrollSnapshotsRef.current.delete(paneId)
-        pendingFollowOutputPaneIdsRef.current.delete(paneId)
+        disposables.delete(leafId)
+        visibleScrollSnapshotsRef.current.delete(leafId)
       }
     }
     for (const pane of panes) {
-      if (disposables.has(pane.id)) {
+      if (disposables.has(pane.leafId)) {
         continue
       }
       const onScroll = (
@@ -189,7 +192,7 @@ export function useTerminalScrollVisibilityMemory({
         continue
       }
       disposables.set(
-        pane.id,
+        pane.leafId,
         onScroll.call(pane.terminal, () => {
           if (
             !isVisibleRef.current ||
@@ -198,7 +201,7 @@ export function useTerminalScrollVisibilityMemory({
           ) {
             return
           }
-          rememberVisibleScrollSnapshot(pane.id, pane.terminal)
+          rememberVisibleScrollSnapshot(pane.leafId, pane.terminal)
         })
       )
     }

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
@@ -4,6 +4,7 @@ import { flushTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-sch
 import {
   cancelDeferredScrollRestore,
   captureScrollState,
+  getPendingScrollRestoreState,
   getTerminalOutputEpoch,
   isTerminalScrollRestoreInProgress
 } from '@/lib/pane-manager/pane-scroll'
@@ -84,7 +85,8 @@ export function useTerminalScrollVisibilityMemory({
           if (useRememberedSnapshots && remembered) {
             return [pane.leafId, remembered.scrollState] as const
           }
-          const state = captureScrollState(pane.terminal)
+          const state =
+            getPendingScrollRestoreState(pane.terminal) ?? captureScrollState(pane.terminal)
           const stableState =
             remembered && isTransientTerminalEdgeSnap(state, remembered.scrollState)
               ? remembered.scrollState

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
@@ -28,7 +28,7 @@ type TerminalScrollVisibilityMemory = {
   ) => Map<ManagedPane['leafId'], ScrollState>
   withSuppressedScrollTracking: (callback: () => void) => void
   applyPendingFollowOutputRequests: () => boolean
-  scheduleFollowOutputIfNeeded: (paneId: number) => void
+  scheduleFollowOutputIfNeeded: (leafId: ManagedPane['leafId']) => void
 }
 
 const FOLLOW_OUTPUT_FLUSH_CHARS = 256 * 1024
@@ -44,7 +44,7 @@ export function useTerminalScrollVisibilityMemory({
   )
   const scrollDisposablesRef = useRef<Map<ManagedPane['leafId'], IDisposable>>(new Map())
   const suppressScrollTrackingRef = useRef(false)
-  const pendingFollowOutputPaneIdsRef = useRef<Set<number>>(new Set())
+  const pendingFollowOutputLeafIdsRef = useRef<Set<ManagedPane['leafId']>>(new Set())
   const followOutputFrameIdsRef = useRef<number[]>([])
 
   const captureVisibleScrollSnapshot = useCallback(
@@ -98,7 +98,7 @@ export function useTerminalScrollVisibilityMemory({
   }, [])
 
   const applyPendingFollowOutputRequests = useCallback((): boolean => {
-    const pending = pendingFollowOutputPaneIdsRef.current
+    const pending = pendingFollowOutputLeafIdsRef.current
     if (pending.size === 0) {
       return false
     }
@@ -111,7 +111,7 @@ export function useTerminalScrollVisibilityMemory({
     }
     let didScroll = false
     for (const pane of manager.getPanes()) {
-      if (!pending.has(pane.id)) {
+      if (!pending.has(pane.leafId)) {
         continue
       }
       const previous = visibleScrollSnapshotsRef.current.get(pane.leafId)
@@ -121,13 +121,13 @@ export function useTerminalScrollVisibilityMemory({
       flushTerminalOutput(pane.terminal, { maxChars: FOLLOW_OUTPUT_FLUSH_CHARS })
       const currentEpoch = getTerminalOutputEpoch(pane.terminal)
       const hasNewOutput = previous ? currentEpoch > previous.outputEpoch : currentEpoch > 0
-      if (hasNewOutput) {
+      if (hasNewOutput && (previous?.scrollState.wasAtBottom ?? true)) {
         cancelDeferredScrollRestore(pane.terminal)
         pane.terminal.scrollToBottom()
         rememberVisibleScrollSnapshot(pane.leafId, pane.terminal)
         didScroll = true
       }
-      pending.delete(pane.id)
+      pending.delete(pane.leafId)
     }
     return didScroll
   }, [isVisibleRef, managerRef, rememberVisibleScrollSnapshot, visibleResumeCompleteRef])
@@ -140,8 +140,8 @@ export function useTerminalScrollVisibilityMemory({
   }, [])
 
   const scheduleFollowOutputIfNeeded = useCallback(
-    (paneId: number): void => {
-      pendingFollowOutputPaneIdsRef.current.add(paneId)
+    (leafId: ManagedPane['leafId']): void => {
+      pendingFollowOutputLeafIdsRef.current.add(leafId)
       if (followOutputFrameIdsRef.current.length > 0) {
         return
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
@@ -6,7 +6,10 @@ import {
   captureScrollState,
   getPendingScrollRestoreState,
   getTerminalOutputEpoch,
-  isTerminalScrollRestoreInProgress
+  isTerminalScrollRestoreInProgress,
+  rememberTerminalContainerScrollState,
+  rememberTerminalLeafScrollState,
+  rememberTerminalScrollState
 } from '@/lib/pane-manager/pane-scroll'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { ManagedPane, ScrollState } from '@/lib/pane-manager/pane-manager-types'
@@ -38,10 +41,13 @@ function isTransientTerminalEdgeSnap(current: ScrollState, previous: ScrollState
   if (previous.wasAtBottom || current.bufferType !== previous.bufferType) {
     return false
   }
-  if (current.baseY !== previous.baseY || current.viewportY === previous.viewportY) {
+  if (current.viewportY === previous.viewportY) {
     return false
   }
-  return current.viewportY === 0 || current.wasAtBottom
+  return (
+    Math.abs(current.baseY - previous.baseY) <= 2 &&
+    (current.viewportY === 0 || current.wasAtBottom)
+  )
 }
 
 export function useTerminalScrollVisibilityMemory({
@@ -58,19 +64,34 @@ export function useTerminalScrollVisibilityMemory({
   const pendingFollowOutputLeafIdsRef = useRef<Set<ManagedPane['leafId']>>(new Set())
   const followOutputFrameIdsRef = useRef<number[]>([])
 
-  const captureVisibleScrollSnapshot = useCallback(
-    (terminal: Terminal): VisibleScrollSnapshot => ({
-      scrollState: captureScrollState(terminal),
+  const captureVisibleScrollSnapshot = useCallback((terminal: Terminal): VisibleScrollSnapshot => {
+    const scrollState = captureScrollState(terminal)
+    rememberTerminalScrollState(terminal, scrollState)
+    return {
+      scrollState,
       outputEpoch: getTerminalOutputEpoch(terminal)
-    }),
-    []
-  )
+    }
+  }, [])
 
   const rememberVisibleScrollSnapshot = useCallback(
     (leafId: ManagedPane['leafId'], terminal: Terminal): void => {
-      visibleScrollSnapshotsRef.current.set(leafId, captureVisibleScrollSnapshot(terminal))
+      const snapshot = captureVisibleScrollSnapshot(terminal)
+      const previous = visibleScrollSnapshotsRef.current.get(leafId)
+      const scrollState =
+        previous && isTransientTerminalEdgeSnap(snapshot.scrollState, previous.scrollState)
+          ? previous.scrollState
+          : snapshot.scrollState
+      const pane = managerRef.current?.getPanes().find((candidate) => candidate.leafId === leafId)
+      if (pane) {
+        rememberTerminalContainerScrollState(pane.container, scrollState)
+      }
+      rememberTerminalLeafScrollState(leafId, scrollState)
+      visibleScrollSnapshotsRef.current.set(leafId, {
+        outputEpoch: snapshot.outputEpoch,
+        scrollState
+      })
     },
-    [captureVisibleScrollSnapshot]
+    [captureVisibleScrollSnapshot, managerRef]
   )
 
   const captureViewportPositions = useCallback(
@@ -92,6 +113,9 @@ export function useTerminalScrollVisibilityMemory({
               ? remembered.scrollState
               : state
           if (!useRememberedSnapshots || !remembered) {
+            rememberTerminalScrollState(pane.terminal, stableState)
+            rememberTerminalContainerScrollState(pane.container, stableState)
+            rememberTerminalLeafScrollState(pane.leafId, stableState)
             visibleScrollSnapshotsRef.current.set(pane.leafId, {
               scrollState: stableState,
               outputEpoch: getTerminalOutputEpoch(pane.terminal)

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
@@ -4,7 +4,8 @@ import { flushTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-sch
 import {
   cancelDeferredScrollRestore,
   captureScrollState,
-  getTerminalOutputEpoch
+  getTerminalOutputEpoch,
+  isTerminalScrollRestoreInProgress
 } from '@/lib/pane-manager/pane-scroll'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
@@ -190,7 +191,11 @@ export function useTerminalScrollVisibilityMemory({
       disposables.set(
         pane.id,
         onScroll.call(pane.terminal, () => {
-          if (!isVisibleRef.current || suppressScrollTrackingRef.current) {
+          if (
+            !isVisibleRef.current ||
+            suppressScrollTrackingRef.current ||
+            isTerminalScrollRestoreInProgress(pane.terminal)
+          ) {
             return
           }
           rememberVisibleScrollSnapshot(pane.id, pane.terminal)

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -161,8 +161,8 @@ export class PaneManager {
     return Array.from(this.panes.values()).map(toPublicPane)
   }
 
-  fitAllPanes(): void {
-    fitAllPanesInternal(this.panes)
+  fitAllPanes(options?: { debugSource?: string; syncScrollbar?: boolean }): void {
+    fitAllPanesInternal(this.panes, options)
   }
 
   refreshAllPanes(): void {

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -161,7 +161,11 @@ export class PaneManager {
     return Array.from(this.panes.values()).map(toPublicPane)
   }
 
-  fitAllPanes(options?: { debugSource?: string; syncScrollbar?: boolean }): void {
+  fitAllPanes(options?: {
+    debugSource?: string
+    syncScrollbar?: boolean
+    useMarkers?: boolean
+  }): void {
     fitAllPanesInternal(this.panes, options)
   }
 

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -5,7 +5,8 @@ import type {
   ManagedPane,
   ManagedPaneInternal,
   PaneRenderingDiagnostics,
-  DropZone
+  DropZone,
+  ScrollState
 } from './pane-manager-types'
 import type { SplitPaneAroundLeafIdsOptions } from './pane-subtree-split'
 import {
@@ -163,6 +164,7 @@ export class PaneManager {
 
   fitAllPanes(options?: {
     debugSource?: string
+    scrollStatesByLeafId?: Map<ManagedPane['leafId'], ScrollState>
     syncScrollbar?: boolean
     useMarkers?: boolean
   }): void {

--- a/src/renderer/src/lib/pane-manager/pane-scroll-stability.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll-stability.ts
@@ -1,0 +1,62 @@
+import type { Terminal } from '@xterm/xterm'
+import type { ScrollState } from './pane-manager-types'
+
+const terminalStableScrollStates = new WeakMap<Terminal, ScrollState>()
+const terminalContainerStableScrollStates = new WeakMap<HTMLElement, ScrollState>()
+const terminalLeafStableScrollStates = new Map<string, ScrollState>()
+
+function copyScrollState(state: ScrollState): ScrollState {
+  return {
+    baseY: state.baseY,
+    bufferType: state.bufferType,
+    viewportY: state.viewportY,
+    wasAtBottom: state.wasAtBottom
+  }
+}
+
+export function rememberTerminalScrollState(terminal: Terminal, state: ScrollState): void {
+  terminalStableScrollStates.set(terminal, copyScrollState(state))
+}
+
+export function rememberTerminalLeafScrollState(leafId: string, state: ScrollState): void {
+  terminalLeafStableScrollStates.set(leafId, copyScrollState(state))
+}
+
+export function rememberTerminalContainerScrollState(
+  container: HTMLElement,
+  state: ScrollState
+): void {
+  terminalContainerStableScrollStates.set(container, copyScrollState(state))
+}
+
+export function getRememberedTerminalContainerScrollState(
+  container: HTMLElement
+): ScrollState | undefined {
+  return terminalContainerStableScrollStates.get(container)
+}
+
+export function getRememberedTerminalLeafScrollState(leafId: string): ScrollState | undefined {
+  return terminalLeafStableScrollStates.get(leafId)
+}
+
+export function selectStableLayoutScrollState(
+  terminal: Terminal,
+  current: ScrollState,
+  fallbackStableState?: ScrollState
+): ScrollState {
+  const stableState = terminalStableScrollStates.get(terminal) ?? fallbackStableState
+  return stableState && isTransientTerminalEdgeSnap(current, stableState) ? stableState : current
+}
+
+function isTransientTerminalEdgeSnap(current: ScrollState, previous: ScrollState): boolean {
+  if (previous.wasAtBottom || current.bufferType !== previous.bufferType) {
+    return false
+  }
+  if (current.viewportY === previous.viewportY) {
+    return false
+  }
+  return (
+    Math.abs(current.baseY - previous.baseY) <= 2 &&
+    (current.viewportY === 0 || current.wasAtBottom)
+  )
+}

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -210,6 +210,23 @@ describe('scroll state', () => {
     expect(marker.dispose).toHaveBeenCalledTimes(1)
   })
 
+  it('can disable marker restore for visibility resume', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 300 })
+    const marker = createMarker(71)
+    const state: ScrollState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 150,
+      baseY: 154,
+      firstVisibleLineMarker: marker
+    }
+
+    restoreScrollStateAfterLayout(terminal, state, { useMarkers: false })
+
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(150)
+    expect(terminal.buffer.active.viewportY).toBe(150)
+  })
+
   it('reapplies a layout restore after xterm settles asynchronously', () => {
     vi.useFakeTimers()
     const rafCallbacks: FrameRequestCallback[] = []

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -200,6 +200,37 @@ describe('scroll state', () => {
     expect(terminal.scrollToLine).toHaveBeenCalledWith(42)
   })
 
+  it('can restore after layout without a scrollbar sync jiggle', () => {
+    vi.useFakeTimers()
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return rafCallbacks.length
+      })
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    const terminal = createTerminal({ viewportY: 97, baseY: 100 })
+    const state: ScrollState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 98,
+      baseY: 100
+    }
+
+    restoreScrollStateAfterLayout(terminal, state, { syncScrollbar: false })
+    const activeBuffer = terminal.buffer.active as { viewportY: number }
+    activeBuffer.viewportY = 0
+    rafCallbacks.shift()?.(0)
+    activeBuffer.viewportY = 0
+    vi.advanceTimersByTime(80)
+
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(98)
+    expect(terminal.scrollLines).not.toHaveBeenCalled()
+    expect(terminal.buffer.active.viewportY).toBe(98)
+  })
+
   it('keeps the visible line marker alive across deferred layout restores', () => {
     vi.useFakeTimers()
     const rafCallbacks: FrameRequestCallback[] = []

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -2,8 +2,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { IMarker, Terminal } from '@xterm/xterm'
 import {
   captureScrollState,
+  captureScrollStateForLayout,
+  getRememberedTerminalLeafScrollState,
   getTerminalOutputEpoch,
   isTerminalScrollRestoreInProgress,
+  rememberTerminalLeafScrollState,
+  rememberTerminalScrollState,
   recordTerminalOutput,
   restoreScrollState,
   restoreScrollStateAfterLayout
@@ -88,6 +92,53 @@ describe('scroll state', () => {
 
     expect(getTerminalOutputEpoch(terminalA)).toBe(2)
     expect(getTerminalOutputEpoch(terminalB)).toBe(1)
+  })
+
+  it('rejects transient layout edge snaps against the last stable scroll state', () => {
+    const terminal = createTerminal({ viewportY: 150, baseY: 154 })
+    rememberTerminalScrollState(terminal, {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 150,
+      baseY: 154
+    })
+    ;(terminal.buffer.active as { baseY: number; viewportY: number }).viewportY = 0
+    ;(terminal.buffer.active as { baseY: number; viewportY: number }).baseY = 155
+
+    expect(captureScrollStateForLayout(terminal)).toMatchObject({
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 150,
+      baseY: 154
+    })
+
+    rememberTerminalScrollState(terminal, {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 0,
+      baseY: 154
+    })
+    expect(captureScrollStateForLayout(terminal)).toMatchObject({
+      viewportY: 0,
+      baseY: 155
+    })
+  })
+
+  it('rejects transient layout edge snaps using leaf-stable state after remount', () => {
+    const terminal = createTerminal({ viewportY: 0, baseY: 155 })
+    rememberTerminalLeafScrollState('leaf-a', {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 150,
+      baseY: 154
+    })
+
+    expect(
+      captureScrollStateForLayout(terminal, getRememberedTerminalLeafScrollState('leaf-a'))
+    ).toMatchObject({
+      viewportY: 150,
+      baseY: 154
+    })
   })
 
   it('restores the captured viewport line', () => {

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -192,6 +192,24 @@ describe('scroll state', () => {
     expect(marker.dispose).toHaveBeenCalledTimes(1)
   })
 
+  it('ignores a drifted marker when the buffer base has not changed', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 154 })
+    const marker = createMarker(28)
+    const state: ScrollState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 148,
+      baseY: 154,
+      firstVisibleLineMarker: marker
+    }
+
+    restoreScrollState(terminal, state)
+
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(148)
+    expect(terminal.buffer.active.viewportY).toBe(148)
+    expect(marker.dispose).toHaveBeenCalledTimes(1)
+  })
+
   it('reapplies a layout restore after xterm settles asynchronously', () => {
     vi.useFakeTimers()
     const rafCallbacks: FrameRequestCallback[] = []

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -3,6 +3,7 @@ import type { IMarker, Terminal } from '@xterm/xterm'
 import {
   captureScrollState,
   getTerminalOutputEpoch,
+  isTerminalScrollRestoreInProgress,
   recordTerminalOutput,
   restoreScrollState,
   restoreScrollStateAfterLayout
@@ -102,6 +103,27 @@ describe('scroll state', () => {
 
     expect(terminal.scrollToLine).toHaveBeenCalledWith(42)
     expect(terminal.buffer.active.viewportY).toBe(42)
+  })
+
+  it('marks imperative restore scrolls through the current task', () => {
+    vi.useFakeTimers()
+    const terminal = createTerminal({ viewportY: 10, baseY: 100 })
+    ;(terminal.scrollToLine as ReturnType<typeof vi.fn>).mockImplementation((line: number) => {
+      expect(isTerminalScrollRestoreInProgress(terminal)).toBe(true)
+      ;(terminal.buffer.active as { viewportY: number }).viewportY = line
+    })
+    const state: ScrollState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100
+    }
+
+    restoreScrollState(terminal, state)
+
+    expect(isTerminalScrollRestoreInProgress(terminal)).toBe(true)
+    vi.advanceTimersByTime(0)
+    expect(isTerminalScrollRestoreInProgress(terminal)).toBe(false)
   })
 
   it('skips restore when the terminal element is gone (post WebGL teardown)', () => {

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -19,6 +19,7 @@ const deferredScrollRestores = new WeakMap<
 >()
 
 type RestoreScrollStateOptions = {
+  debugSource?: string
   syncScrollbar?: boolean
 }
 
@@ -79,12 +80,14 @@ export function restoreScrollStateAfterLayout(
 ): void {
   cancelDeferredScrollRestore(terminal)
   const syncScrollbar = options.syncScrollbar ?? true
+  const debugSource = options.debugSource
   logTerminalScrollRestore('restore-scheduled', {
+    source: debugSource,
     saved: terminalScrollStateForDebug(state),
     syncScrollbar,
     viewport: terminalViewportForDebug(terminal)
   })
-  restoreScrollStateNow(terminal, state, { syncScrollbar })
+  restoreScrollStateNow(terminal, state, { debugSource, syncScrollbar })
   if (typeof requestAnimationFrame !== 'function') {
     releaseScrollStateMarker(state)
     return
@@ -99,7 +102,7 @@ export function restoreScrollStateAfterLayout(
   }
   const restore = (): void => {
     if (!pending.cancelled) {
-      restoreScrollStateNow(terminal, state, { syncScrollbar })
+      restoreScrollStateNow(terminal, state, { debugSource, syncScrollbar })
     }
   }
   const cancelPendingRafs = (): void => {
@@ -121,7 +124,7 @@ export function restoreScrollStateAfterLayout(
   })
   const timeoutId = setTimeout(() => {
     if (!pending.cancelled) {
-      restoreScrollStateNow(terminal, state, { syncScrollbar })
+      restoreScrollStateNow(terminal, state, { debugSource, syncScrollbar })
     }
     // Why: background tabs can throttle rAF past the timeout. Once the
     // authoritative timeout restore has run, stale frame callbacks must not
@@ -138,12 +141,13 @@ export function restoreScrollStateAfterLayout(
 function restoreScrollStateNow(
   terminal: Terminal,
   state: ScrollState,
-  options: Required<RestoreScrollStateOptions>
+  options: RestoreScrollStateOptions & { syncScrollbar: boolean }
 ): void {
   if (!terminal.element) {
     logTerminalScrollRestore('restore-attempt', {
       reason: 'missing-element',
       saved: terminalScrollStateForDebug(state),
+      source: options.debugSource,
       syncScrollbar: options.syncScrollbar
     })
     return
@@ -153,6 +157,7 @@ function restoreScrollStateNow(
     logTerminalScrollRestore('restore-attempt', {
       reason: 'buffer-type-mismatch',
       saved: terminalScrollStateForDebug(state),
+      source: options.debugSource,
       syncScrollbar: options.syncScrollbar,
       viewport: terminalViewportForDebug(terminal)
     })
@@ -174,6 +179,7 @@ function restoreScrollStateNow(
         before,
         branch: 'bottom',
         saved: terminalScrollStateForDebug(state),
+        source: options.debugSource,
         syncScrollbar: options.syncScrollbar
       })
     }
@@ -201,6 +207,7 @@ function restoreScrollStateNow(
       branch: 'line',
       markerLine,
       saved: terminalScrollStateForDebug(state),
+      source: options.debugSource,
       syncScrollbar: options.syncScrollbar,
       targetLine
     })

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -37,6 +37,10 @@ export function isTerminalScrollRestoreInProgress(terminal: Terminal): boolean {
   return (terminalScrollRestoreDepths.get(terminal) ?? 0) > 0
 }
 
+export function getPendingScrollRestoreState(terminal: Terminal): ScrollState | null {
+  return deferredScrollRestores.get(terminal)?.state ?? null
+}
+
 export function cancelDeferredScrollRestore(terminal: Terminal): void {
   const pending = deferredScrollRestores.get(terminal)
   if (!pending) {

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -195,7 +195,10 @@ function restoreScrollStateNow(
     state.firstVisibleLineMarker && !state.firstVisibleLineMarker.isDisposed
       ? state.firstVisibleLineMarker.line
       : -1
-  const targetLine = Math.min(markerLine >= 0 ? markerLine : state.viewportY, buf.baseY)
+  // Why: xterm markers can drift while TUIs rewrite/reflow the same scrollback
+  // base. Prefer the exact numeric viewport unless the buffer base changed.
+  const shouldUseMarkerLine = markerLine >= 0 && buf.baseY !== state.baseY
+  const targetLine = Math.min(shouldUseMarkerLine ? markerLine : state.viewportY, buf.baseY)
   // Why: deferred rAF/timeout restores re-invoke this function after xterm
   // reflow settles; keep the original viewport and marker alive so later
   // retries can recover after snapshot replay grows the buffer. Callers

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -5,6 +5,14 @@ import {
   terminalScrollStateForDebug,
   terminalViewportForDebug
 } from './terminal-scroll-restore-debug'
+import {
+  getRememberedTerminalContainerScrollState,
+  getRememberedTerminalLeafScrollState,
+  rememberTerminalContainerScrollState,
+  rememberTerminalLeafScrollState,
+  rememberTerminalScrollState,
+  selectStableLayoutScrollState
+} from './pane-scroll-stability'
 
 const terminalOutputEpochs = new WeakMap<Terminal, number>()
 const terminalScrollRestoreDepths = new WeakMap<Terminal, number>()
@@ -75,6 +83,20 @@ export function captureScrollState(terminal: Terminal): ScrollState {
         ? terminal.registerMarker?.(viewportY - (buf.baseY + buf.cursorY))
         : undefined
   }
+}
+
+export function captureScrollStateForLayout(
+  terminal: Terminal,
+  fallbackStableState?: ScrollState
+): ScrollState {
+  const state = captureScrollState(terminal)
+  const stableState = selectStableLayoutScrollState(terminal, state, fallbackStableState)
+  if (stableState !== state) {
+    releaseScrollStateMarker(state)
+    return stableState
+  }
+  rememberTerminalScrollState(terminal, state)
+  return state
 }
 
 export function restoreScrollState(terminal: Terminal, state: ScrollState): void {
@@ -182,6 +204,11 @@ function restoreScrollStateNow(
   if (state.wasAtBottom) {
     const before = terminalViewportForDebug(terminal)
     if (safeScrollRestoreCall(terminal, () => terminal.scrollToBottom())) {
+      rememberTerminalScrollState(terminal, {
+        ...state,
+        baseY: terminal.buffer.active.baseY,
+        viewportY: terminal.buffer.active.viewportY
+      })
       if (options.syncScrollbar) {
         forceViewportScrollbarSync(terminal)
       }
@@ -212,6 +239,12 @@ function restoreScrollStateNow(
   // restoreScrollStateAfterLayout, cancelDeferredScrollRestore) own disposal.
   const before = terminalViewportForDebug(terminal)
   if (safeScrollRestoreCall(terminal, () => terminal.scrollToLine(targetLine))) {
+    rememberTerminalScrollState(terminal, {
+      ...state,
+      baseY: terminal.buffer.active.baseY,
+      viewportY: terminal.buffer.active.viewportY,
+      wasAtBottom: terminal.buffer.active.viewportY >= terminal.buffer.active.baseY
+    })
     if (options.syncScrollbar) {
       forceViewportScrollbarSync(terminal)
     }
@@ -261,6 +294,14 @@ function safeScrollRestoreCall(terminal: Terminal, fn: () => void): boolean {
       }
     }, 0)
   }
+}
+
+export {
+  getRememberedTerminalContainerScrollState,
+  getRememberedTerminalLeafScrollState,
+  rememberTerminalContainerScrollState,
+  rememberTerminalLeafScrollState,
+  rememberTerminalScrollState
 }
 
 export function releaseScrollStateMarker(state: ScrollState): void {

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -22,6 +22,7 @@ const deferredScrollRestores = new WeakMap<
 type RestoreScrollStateOptions = {
   debugSource?: string
   syncScrollbar?: boolean
+  useMarkers?: boolean
 }
 
 export function recordTerminalOutput(terminal: Terminal): void {
@@ -74,7 +75,7 @@ export function captureScrollState(terminal: Terminal): ScrollState {
 
 export function restoreScrollState(terminal: Terminal, state: ScrollState): void {
   cancelDeferredScrollRestore(terminal)
-  restoreScrollStateNow(terminal, state, { syncScrollbar: true })
+  restoreScrollStateNow(terminal, state, { syncScrollbar: true, useMarkers: true })
   releaseScrollStateMarker(state)
 }
 
@@ -85,6 +86,7 @@ export function restoreScrollStateAfterLayout(
 ): void {
   cancelDeferredScrollRestore(terminal)
   const syncScrollbar = options.syncScrollbar ?? true
+  const useMarkers = options.useMarkers ?? true
   const debugSource = options.debugSource
   logTerminalScrollRestore('restore-scheduled', {
     source: debugSource,
@@ -92,7 +94,7 @@ export function restoreScrollStateAfterLayout(
     syncScrollbar,
     viewport: terminalViewportForDebug(terminal)
   })
-  restoreScrollStateNow(terminal, state, { debugSource, syncScrollbar })
+  restoreScrollStateNow(terminal, state, { debugSource, syncScrollbar, useMarkers })
   if (typeof requestAnimationFrame !== 'function') {
     releaseScrollStateMarker(state)
     return
@@ -107,7 +109,7 @@ export function restoreScrollStateAfterLayout(
   }
   const restore = (): void => {
     if (!pending.cancelled) {
-      restoreScrollStateNow(terminal, state, { debugSource, syncScrollbar })
+      restoreScrollStateNow(terminal, state, { debugSource, syncScrollbar, useMarkers })
     }
   }
   const cancelPendingRafs = (): void => {
@@ -129,7 +131,7 @@ export function restoreScrollStateAfterLayout(
   })
   const timeoutId = setTimeout(() => {
     if (!pending.cancelled) {
-      restoreScrollStateNow(terminal, state, { debugSource, syncScrollbar })
+      restoreScrollStateNow(terminal, state, { debugSource, syncScrollbar, useMarkers })
     }
     // Why: background tabs can throttle rAF past the timeout. Once the
     // authoritative timeout restore has run, stale frame callbacks must not
@@ -146,7 +148,7 @@ export function restoreScrollStateAfterLayout(
 function restoreScrollStateNow(
   terminal: Terminal,
   state: ScrollState,
-  options: RestoreScrollStateOptions & { syncScrollbar: boolean }
+  options: RestoreScrollStateOptions & { syncScrollbar: boolean; useMarkers: boolean }
 ): void {
   if (!terminal.element) {
     logTerminalScrollRestore('restore-attempt', {
@@ -197,7 +199,7 @@ function restoreScrollStateNow(
       : -1
   // Why: xterm markers can drift while TUIs rewrite/reflow the same scrollback
   // base. Prefer the exact numeric viewport unless the buffer base changed.
-  const shouldUseMarkerLine = markerLine >= 0 && buf.baseY !== state.baseY
+  const shouldUseMarkerLine = options.useMarkers && markerLine >= 0 && buf.baseY !== state.baseY
   const targetLine = Math.min(shouldUseMarkerLine ? markerLine : state.viewportY, buf.baseY)
   // Why: deferred rAF/timeout restores re-invoke this function after xterm
   // reflow settles; keep the original viewport and marker alive so later

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -7,10 +7,15 @@ const deferredScrollRestores = new WeakMap<
   {
     cancelled: boolean
     rafIds: number[]
+    syncScrollbar: boolean
     state: ScrollState
     timeoutIds: ReturnType<typeof setTimeout>[]
   }
 >()
+
+type RestoreScrollStateOptions = {
+  syncScrollbar?: boolean
+}
 
 export function recordTerminalOutput(terminal: Terminal): void {
   terminalOutputEpochs.set(terminal, getTerminalOutputEpoch(terminal) + 1)
@@ -58,13 +63,18 @@ export function captureScrollState(terminal: Terminal): ScrollState {
 
 export function restoreScrollState(terminal: Terminal, state: ScrollState): void {
   cancelDeferredScrollRestore(terminal)
-  restoreScrollStateNow(terminal, state)
+  restoreScrollStateNow(terminal, state, { syncScrollbar: true })
   releaseScrollStateMarker(state)
 }
 
-export function restoreScrollStateAfterLayout(terminal: Terminal, state: ScrollState): void {
+export function restoreScrollStateAfterLayout(
+  terminal: Terminal,
+  state: ScrollState,
+  options: RestoreScrollStateOptions = {}
+): void {
   cancelDeferredScrollRestore(terminal)
-  restoreScrollStateNow(terminal, state)
+  const syncScrollbar = options.syncScrollbar ?? true
+  restoreScrollStateNow(terminal, state, { syncScrollbar })
   if (typeof requestAnimationFrame !== 'function') {
     releaseScrollStateMarker(state)
     return
@@ -73,12 +83,13 @@ export function restoreScrollStateAfterLayout(terminal: Terminal, state: ScrollS
   const pending = {
     cancelled: false,
     rafIds: [] as number[],
+    syncScrollbar,
     state,
     timeoutIds: [] as ReturnType<typeof setTimeout>[]
   }
   const restore = (): void => {
     if (!pending.cancelled) {
-      restoreScrollStateNow(terminal, state)
+      restoreScrollStateNow(terminal, state, { syncScrollbar })
     }
   }
   const cancelPendingRafs = (): void => {
@@ -100,7 +111,7 @@ export function restoreScrollStateAfterLayout(terminal: Terminal, state: ScrollS
   })
   const timeoutId = setTimeout(() => {
     if (!pending.cancelled) {
-      restoreScrollStateNow(terminal, state)
+      restoreScrollStateNow(terminal, state, { syncScrollbar })
     }
     // Why: background tabs can throttle rAF past the timeout. Once the
     // authoritative timeout restore has run, stale frame callbacks must not
@@ -114,7 +125,11 @@ export function restoreScrollStateAfterLayout(terminal: Terminal, state: ScrollS
   deferredScrollRestores.set(terminal, pending)
 }
 
-function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
+function restoreScrollStateNow(
+  terminal: Terminal,
+  state: ScrollState,
+  options: Required<RestoreScrollStateOptions>
+): void {
   if (!terminal.element) {
     return
   }
@@ -129,7 +144,9 @@ function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
   // window quietly — the next visibility flip re-fits and re-restores.
   if (state.wasAtBottom) {
     if (safeScrollCall(() => terminal.scrollToBottom())) {
-      forceViewportScrollbarSync(terminal)
+      if (options.syncScrollbar) {
+        forceViewportScrollbarSync(terminal)
+      }
     }
     return
   }
@@ -139,13 +156,15 @@ function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
       ? state.firstVisibleLineMarker.line
       : -1
   const targetLine = Math.min(markerLine >= 0 ? markerLine : state.viewportY, buf.baseY)
-  state.viewportY = targetLine
   // Why: deferred rAF/timeout restores re-invoke this function after xterm
-  // reflow settles; keep the marker alive so each call consults the live
-  // line. Callers (restoreScrollState, the timeout in
+  // reflow settles; keep the original viewport and marker alive so later
+  // retries can recover after snapshot replay grows the buffer. Callers
+  // (restoreScrollState, the timeout in
   // restoreScrollStateAfterLayout, cancelDeferredScrollRestore) own disposal.
   if (safeScrollCall(() => terminal.scrollToLine(targetLine))) {
-    forceViewportScrollbarSync(terminal)
+    if (options.syncScrollbar) {
+      forceViewportScrollbarSync(terminal)
+    }
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -1,5 +1,10 @@
 import type { Terminal } from '@xterm/xterm'
 import type { ScrollState } from './pane-manager-types'
+import {
+  logTerminalScrollRestore,
+  terminalScrollStateForDebug,
+  terminalViewportForDebug
+} from './terminal-scroll-restore-debug'
 
 const terminalOutputEpochs = new WeakMap<Terminal, number>()
 const deferredScrollRestores = new WeakMap<
@@ -74,6 +79,11 @@ export function restoreScrollStateAfterLayout(
 ): void {
   cancelDeferredScrollRestore(terminal)
   const syncScrollbar = options.syncScrollbar ?? true
+  logTerminalScrollRestore('restore-scheduled', {
+    saved: terminalScrollStateForDebug(state),
+    syncScrollbar,
+    viewport: terminalViewportForDebug(terminal)
+  })
   restoreScrollStateNow(terminal, state, { syncScrollbar })
   if (typeof requestAnimationFrame !== 'function') {
     releaseScrollStateMarker(state)
@@ -131,10 +141,21 @@ function restoreScrollStateNow(
   options: Required<RestoreScrollStateOptions>
 ): void {
   if (!terminal.element) {
+    logTerminalScrollRestore('restore-attempt', {
+      reason: 'missing-element',
+      saved: terminalScrollStateForDebug(state),
+      syncScrollbar: options.syncScrollbar
+    })
     return
   }
   const buf = terminal.buffer.active
   if (state.bufferType === 'alternate' || buf.type !== state.bufferType) {
+    logTerminalScrollRestore('restore-attempt', {
+      reason: 'buffer-type-mismatch',
+      saved: terminalScrollStateForDebug(state),
+      syncScrollbar: options.syncScrollbar,
+      viewport: terminalViewportForDebug(terminal)
+    })
     return
   }
 
@@ -143,10 +164,18 @@ function restoreScrollStateNow(
   // throw "cannot read dimensions" until the pane re-attaches. Swallow that
   // window quietly — the next visibility flip re-fits and re-restores.
   if (state.wasAtBottom) {
+    const before = terminalViewportForDebug(terminal)
     if (safeScrollCall(() => terminal.scrollToBottom())) {
       if (options.syncScrollbar) {
         forceViewportScrollbarSync(terminal)
       }
+      logTerminalScrollRestore('restore-attempt', {
+        after: terminalViewportForDebug(terminal),
+        before,
+        branch: 'bottom',
+        saved: terminalScrollStateForDebug(state),
+        syncScrollbar: options.syncScrollbar
+      })
     }
     return
   }
@@ -161,10 +190,20 @@ function restoreScrollStateNow(
   // retries can recover after snapshot replay grows the buffer. Callers
   // (restoreScrollState, the timeout in
   // restoreScrollStateAfterLayout, cancelDeferredScrollRestore) own disposal.
+  const before = terminalViewportForDebug(terminal)
   if (safeScrollCall(() => terminal.scrollToLine(targetLine))) {
     if (options.syncScrollbar) {
       forceViewportScrollbarSync(terminal)
     }
+    logTerminalScrollRestore('restore-attempt', {
+      after: terminalViewportForDebug(terminal),
+      before,
+      branch: 'line',
+      markerLine,
+      saved: terminalScrollStateForDebug(state),
+      syncScrollbar: options.syncScrollbar,
+      targetLine
+    })
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -7,6 +7,7 @@ import {
 } from './terminal-scroll-restore-debug'
 
 const terminalOutputEpochs = new WeakMap<Terminal, number>()
+const terminalScrollRestoreDepths = new WeakMap<Terminal, number>()
 const deferredScrollRestores = new WeakMap<
   Terminal,
   {
@@ -29,6 +30,10 @@ export function recordTerminalOutput(terminal: Terminal): void {
 
 export function getTerminalOutputEpoch(terminal: Terminal): number {
   return terminalOutputEpochs.get(terminal) ?? 0
+}
+
+export function isTerminalScrollRestoreInProgress(terminal: Terminal): boolean {
+  return (terminalScrollRestoreDepths.get(terminal) ?? 0) > 0
 }
 
 export function cancelDeferredScrollRestore(terminal: Terminal): void {
@@ -170,7 +175,7 @@ function restoreScrollStateNow(
   // window quietly — the next visibility flip re-fits and re-restores.
   if (state.wasAtBottom) {
     const before = terminalViewportForDebug(terminal)
-    if (safeScrollCall(() => terminal.scrollToBottom())) {
+    if (safeScrollRestoreCall(terminal, () => terminal.scrollToBottom())) {
       if (options.syncScrollbar) {
         forceViewportScrollbarSync(terminal)
       }
@@ -197,7 +202,7 @@ function restoreScrollStateNow(
   // (restoreScrollState, the timeout in
   // restoreScrollStateAfterLayout, cancelDeferredScrollRestore) own disposal.
   const before = terminalViewportForDebug(terminal)
-  if (safeScrollCall(() => terminal.scrollToLine(targetLine))) {
+  if (safeScrollRestoreCall(terminal, () => terminal.scrollToLine(targetLine))) {
     if (options.syncScrollbar) {
       forceViewportScrollbarSync(terminal)
     }
@@ -229,6 +234,26 @@ function safeScrollCall(fn: () => void): boolean {
   }
 }
 
+function safeScrollRestoreCall(terminal: Terminal, fn: () => void): boolean {
+  const depth = terminalScrollRestoreDepths.get(terminal) ?? 0
+  terminalScrollRestoreDepths.set(terminal, depth + 1)
+  try {
+    return safeScrollCall(fn)
+  } finally {
+    // Why: xterm can notify scroll listeners just after the imperative scroll
+    // returns. Keep the restore marker through the current task so those
+    // notifications do not become remembered user scroll positions.
+    setTimeout(() => {
+      const nextDepth = (terminalScrollRestoreDepths.get(terminal) ?? 1) - 1
+      if (nextDepth > 0) {
+        terminalScrollRestoreDepths.set(terminal, nextDepth)
+      } else {
+        terminalScrollRestoreDepths.delete(terminal)
+      }
+    }, 0)
+  }
+}
+
 export function releaseScrollStateMarker(state: ScrollState): void {
   state.firstVisibleLineMarker?.dispose()
   state.firstVisibleLineMarker = undefined
@@ -244,10 +269,10 @@ function forceViewportScrollbarSync(terminal: Terminal): void {
     return
   }
   if (buf.viewportY > 0) {
-    safeScrollCall(() => terminal.scrollLines(-1))
-    safeScrollCall(() => terminal.scrollLines(1))
+    safeScrollRestoreCall(terminal, () => terminal.scrollLines(-1))
+    safeScrollRestoreCall(terminal, () => terminal.scrollLines(1))
   } else if (buf.viewportY < buf.baseY) {
-    safeScrollCall(() => terminal.scrollLines(1))
-    safeScrollCall(() => terminal.scrollLines(-1))
+    safeScrollRestoreCall(terminal, () => terminal.scrollLines(1))
+    safeScrollRestoreCall(terminal, () => terminal.scrollLines(-1))
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -199,6 +199,30 @@ describe('safeFit', () => {
     expect(activeBuffer.viewportY).toBe(42)
   })
 
+  it('prefers a preserved leaf scroll state over a transient current viewport during fit', () => {
+    const pane = createPane({
+      proposedCols: 100,
+      proposedRows: 32,
+      terminalCols: 120,
+      terminalRows: 32
+    })
+    const activeBuffer = pane.terminal.buffer.active as { viewportY: number; baseY: number }
+    activeBuffer.viewportY = 0
+    activeBuffer.baseY = 154
+    const preservedState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 150,
+      baseY: 154
+    } satisfies ScrollState
+
+    safeFit(pane, { scrollStatesByLeafId: new Map([[pane.leafId, preservedState]]) })
+
+    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.scrollToLine).toHaveBeenCalledWith(150)
+    expect(activeBuffer.viewportY).toBe(150)
+  })
+
   it('does not throw when xterm rejects scroll restoration during layout', () => {
     const pane = createPane({
       proposedCols: 100,

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -27,6 +27,11 @@ type TreeOpsCallbacks = {
   requestPaneReparentFrame?: (callback: FrameRequestCallback) => void
 }
 
+type SafeFitOptions = {
+  debugSource?: string
+  syncScrollbar?: boolean
+}
+
 const MIN_PANE_FIT_WIDTH_PX = 48
 const MIN_PANE_FIT_HEIGHT_PX = 24
 const MIN_PANE_FIT_COLS = 8
@@ -65,7 +70,7 @@ function captureScrollStateForFit(pane: ManagedPane): ScrollState | null {
     : captureScrollState(pane.terminal)
 }
 
-export function safeFit(pane: ManagedPane): void {
+export function safeFit(pane: ManagedPane, options: SafeFitOptions = {}): void {
   if (!canMeasurePaneForFit(pane)) {
     return
   }
@@ -103,7 +108,10 @@ export function safeFit(pane: ManagedPane): void {
   } finally {
     if (shouldRestoreScroll && scrollState) {
       try {
-        restoreScrollStateAfterLayout(pane.terminal, scrollState)
+        restoreScrollStateAfterLayout(pane.terminal, scrollState, {
+          debugSource: options.debugSource ?? 'safeFit',
+          syncScrollbar: options.syncScrollbar
+        })
       } catch {
         // Why: xterm can temporarily expose a terminal whose renderer has not
         // initialized dimensions yet during SSH reattach/layout. Fit is best-effort.
@@ -112,9 +120,12 @@ export function safeFit(pane: ManagedPane): void {
   }
 }
 
-export function fitAllPanesInternal(panes: Map<number, ManagedPaneInternal>): void {
+export function fitAllPanesInternal(
+  panes: Map<number, ManagedPaneInternal>,
+  options: SafeFitOptions = {}
+): void {
   for (const pane of panes.values()) {
-    safeFit(pane)
+    safeFit(pane, options)
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -30,6 +30,7 @@ type TreeOpsCallbacks = {
 type SafeFitOptions = {
   debugSource?: string
   syncScrollbar?: boolean
+  useMarkers?: boolean
 }
 
 const MIN_PANE_FIT_WIDTH_PX = 48
@@ -110,7 +111,8 @@ export function safeFit(pane: ManagedPane, options: SafeFitOptions = {}): void {
       try {
         restoreScrollStateAfterLayout(pane.terminal, scrollState, {
           debugSource: options.debugSource ?? 'safeFit',
-          syncScrollbar: options.syncScrollbar
+          syncScrollbar: options.syncScrollbar,
+          useMarkers: options.useMarkers
         })
       } catch {
         // Why: xterm can temporarily expose a terminal whose renderer has not

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -9,7 +9,14 @@ import type {
 import { createDivider, disposeDivider } from './pane-divider'
 import { getFitOverrideForPty } from './mobile-fit-overrides'
 import { disposeWebgl, attachWebgl } from './pane-webgl-renderer'
-import { captureScrollState, restoreScrollStateAfterLayout } from './pane-scroll'
+import {
+  captureScrollStateForLayout,
+  getRememberedTerminalContainerScrollState,
+  getRememberedTerminalLeafScrollState,
+  rememberTerminalContainerScrollState,
+  rememberTerminalLeafScrollState,
+  restoreScrollStateAfterLayout
+} from './pane-scroll'
 
 export { captureScrollState, restoreScrollState } from './pane-scroll'
 
@@ -29,6 +36,7 @@ type TreeOpsCallbacks = {
 
 type SafeFitOptions = {
   debugSource?: string
+  scrollStatesByLeafId?: Map<ManagedPane['leafId'], ScrollState>
   syncScrollbar?: boolean
   useMarkers?: boolean
 }
@@ -68,7 +76,11 @@ function captureScrollStateForFit(pane: ManagedPane): ScrollState | null {
   // Why: split reparent has its own delayed restore; restoring here can fight that timer.
   return 'pendingSplitScrollState' in pane && (pane as ManagedPaneInternal).pendingSplitScrollState
     ? null
-    : captureScrollState(pane.terminal)
+    : captureScrollStateForLayout(
+        pane.terminal,
+        getRememberedTerminalContainerScrollState(pane.container) ??
+          getRememberedTerminalLeafScrollState(pane.leafId)
+      )
 }
 
 export function safeFit(pane: ManagedPane, options: SafeFitOptions = {}): void {
@@ -101,7 +113,11 @@ export function safeFit(pane: ManagedPane, options: SafeFitOptions = {}): void {
       // churn, which was causing visible terminal blinking while resizing.
       return
     }
-    scrollState = captureScrollStateForFit(pane)
+    scrollState = options.scrollStatesByLeafId?.get(pane.leafId) ?? captureScrollStateForFit(pane)
+    if (scrollState) {
+      rememberTerminalContainerScrollState(pane.container, scrollState)
+      rememberTerminalLeafScrollState(pane.leafId, scrollState)
+    }
     shouldRestoreScroll = true
     pane.fitAddon.fit()
   } catch {

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-restore-debug.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-restore-debug.ts
@@ -1,0 +1,75 @@
+import type { Terminal } from '@xterm/xterm'
+import type { ScrollState } from './pane-manager-types'
+
+type TerminalScrollRestoreDebugEvent =
+  | 'capture-current'
+  | 'durable-restore'
+  | 'layout-persist'
+  | 'restore-attempt'
+  | 'restore-scheduled'
+  | 'visibility-hide'
+  | 'visibility-resume'
+  | 'visibility-restore'
+
+type TerminalScrollRestoreDetails = {
+  baseY?: number
+  bufferType?: string
+  hasMarker?: boolean
+  isActive?: boolean
+  isVisible?: boolean
+  leafId?: string
+  paneCount?: number
+  paneId?: number
+  source?: string
+  tabId?: string
+  targetLine?: number
+  viewportY?: number
+  wasAtBottom?: boolean
+  wasVisible?: boolean
+  worktreeId?: string
+  [key: string]: unknown
+}
+
+export function terminalScrollStateForDebug(state: ScrollState): TerminalScrollRestoreDetails {
+  return {
+    baseY: state.baseY,
+    bufferType: state.bufferType,
+    hasMarker: Boolean(state.firstVisibleLineMarker && !state.firstVisibleLineMarker.isDisposed),
+    viewportY: state.viewportY,
+    wasAtBottom: state.wasAtBottom
+  }
+}
+
+export function terminalViewportForDebug(
+  terminal: Terminal
+): TerminalScrollRestoreDetails & { cols?: number; rows?: number } {
+  const buffer = terminal.buffer?.active
+  if (!buffer) {
+    return {
+      cols: terminal.cols,
+      elementConnected: terminal.element?.isConnected ?? null,
+      rows: terminal.rows,
+      unavailable: true
+    }
+  }
+  return {
+    baseY: buffer.baseY,
+    bufferType: buffer.type,
+    cols: terminal.cols,
+    cursorY: buffer.cursorY,
+    elementConnected: terminal.element?.isConnected ?? null,
+    rows: terminal.rows,
+    viewportY: buffer.viewportY,
+    wasAtBottom: buffer.viewportY >= buffer.baseY
+  }
+}
+
+export function logTerminalScrollRestore(
+  event: TerminalScrollRestoreDebugEvent,
+  details: TerminalScrollRestoreDetails
+): void {
+  console.info(`[terminal-scroll-restore] ${event}`, {
+    at: Math.round(performance.now()),
+    ...details
+  })
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -960,6 +960,13 @@ export type TerminalPaneLayoutNode =
       ratio?: number
     }
 
+export type TerminalScrollStateSnapshot = {
+  bufferType: 'normal' | 'alternate'
+  wasAtBottom: boolean
+  viewportY: number
+  baseY: number
+}
+
 export type TerminalLayoutSnapshot = {
   root: TerminalPaneLayoutNode | null
   activeLeafId: string | null
@@ -971,6 +978,8 @@ export type TerminalLayoutSnapshot = {
   buffersByLeafId?: Record<string, string>
   /** Durable scrollback snapshot refs per leaf; raw bytes live outside session JSON. */
   scrollbackRefsByLeafId?: Record<string, string>
+  /** Last visible viewport per leaf for remounting without jumping scroll position. */
+  scrollStatesByLeafId?: Record<string, TerminalScrollStateSnapshot>
   /** User-assigned pane titles, keyed by stable layout leaf UUID.
    *  Persisted alongside buffers via the existing session:set flow. */
   titlesByLeafId?: Record<string, string>

--- a/src/shared/workspace-session-schema.test.ts
+++ b/src/shared/workspace-session-schema.test.ts
@@ -43,7 +43,15 @@ describe('parseWorkspaceSession', () => {
           },
           activeLeafId: 'pane:1',
           expandedLeafId: null,
-          ptyIdsByLeafId: { 'pane:1': 'daemon-session-A' }
+          ptyIdsByLeafId: { 'pane:1': 'daemon-session-A' },
+          scrollStatesByLeafId: {
+            'pane:1': {
+              bufferType: 'normal',
+              wasAtBottom: false,
+              viewportY: 42,
+              baseY: 100
+            }
+          }
         }
       },
       activeWorktreeIdsOnShutdown: ['repo1::/path/wt1']

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -52,6 +52,13 @@ const terminalPaneLayoutNodeSchema: z.ZodType<TerminalPaneLayoutNode> = z.lazy((
   ])
 )
 
+const terminalScrollStateSnapshotSchema = z.object({
+  bufferType: z.enum(['normal', 'alternate']),
+  wasAtBottom: z.boolean(),
+  viewportY: z.number(),
+  baseY: z.number()
+})
+
 const terminalLayoutSnapshotSchema = z.object({
   root: terminalPaneLayoutNodeSchema.nullable(),
   activeLeafId: z.string().nullable(),
@@ -59,6 +66,7 @@ const terminalLayoutSnapshotSchema = z.object({
   ptyIdsByLeafId: z.record(z.string(), z.string()).optional(),
   buffersByLeafId: z.record(z.string(), z.string()).optional(),
   scrollbackRefsByLeafId: z.record(z.string(), z.string()).optional(),
+  scrollStatesByLeafId: z.record(z.string(), terminalScrollStateSnapshotSchema).optional(),
   titlesByLeafId: z.record(z.string(), z.string()).optional()
 })
 


### PR DESCRIPTION
## Summary
- add a short design note for the terminal scroll restore model
- persist primitive terminal scroll state by stable pane leaf id for remount fallback
- preserve the last visible scroll state while hidden and avoid scrollbar jiggles during visibility restores

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-scroll.test.ts src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/layout-serialization.test.ts src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts src/shared/workspace-session-schema.test.ts src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts src/renderer/src/store/slices/terminals-hydration.test.ts src/renderer/src/store/slices/store-session-cascades.test.ts
- pnpm run typecheck:web
- pnpm run typecheck:node
- pnpm exec oxlint <touched files>
- ORCA_E2E_REAL_CODEX=1 pnpm exec playwright test tests/e2e/terminal-raw-emoji-table-scroll-restore.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1
- SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-hidden-tui-visual-restore.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1

Note: tests/e2e/terminal-codex-cursor-jitter-repro.spec.ts has no runnable tests for the macOS electron-headless project; it is Windows/headful gated.

Made with [Orca](https://github.com/stablyai/orca) 🐋
