### PR TITLE
Update mobile 0.0.16 Android links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 Monitor and steer your agents from your phone — get notified when an agent finishes and send follow-ups from anywhere.
 
-[iOS App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) · [Android APK](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.15/app-release.apk) · [Docs →](https://www.onorca.dev/docs/mobile)
+[iOS App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) · [Android APK](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.16/app-release.apk) · [Docs →](https://www.onorca.dev/docs/mobile)
 
 </td>
 <td width="50%">
@@ -228,7 +228,7 @@ yay -S stably-orca-bin
 Pair with your desktop app to monitor and steer your agents from your phone.
 
 - **iOS:** [Download on the App Store](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [Download the APK](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.15/app-release.apk)
+- **Android:** [Download the APK](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.16/app-release.apk)
 
 ---
 

--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -9,7 +9,7 @@ export { getMobileSettingsPaneSearchEntries }
 
 const ORCA_IOS_APP_STORE_URL = 'https://apps.apple.com/app/orca-ide/id6766130217'
 const ORCA_ANDROID_APK_URL =
-  'https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.15/app-release.apk'
+  'https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.16/app-release.apk'
 
 export function MobileSettingsPane(): React.JSX.Element {
   return (


### PR DESCRIPTION
## Summary
- Point README Android APK links at mobile-android-v0.0.16
- Point the Mobile settings Android APK link at mobile-android-v0.0.16

Release: https://github.com/stablyai/orca/releases/tag/mobile-android-v0.0.16

## Verification
- gh release view mobile-android-v0.0.16 --repo stablyai/orca --json tagName,name,url,isDraft,isPrerelease,publishedAt,assets,targetCommitish
- rg -n "mobile-android-v0\.0\.(14|15)|releases/download/mobile-android-v0\.0\.16/app-release\.apk" README.md src/renderer/src/components/settings/MobileSettingsPane.tsx
- git diff --check
- pre-commit staged hooks: oxlint, oxlint react-doctor config, oxfmt

Made with [Orca](https://github.com/stablyai/orca) 🐋
