### PR TITLE
Improve Windows release signing reliability

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -917,6 +917,56 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install SignPath PowerShell module
+        if: matrix.platform == 'win'
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+
+          $trimChars = [char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+          $documentsRoot = [System.IO.Path]::GetFullPath([Environment]::GetFolderPath('MyDocuments')).TrimEnd($trimChars)
+          $currentUserModuleRoot = $env:PSModulePath -split [System.IO.Path]::PathSeparator |
+            Where-Object {
+              if ([string]::IsNullOrWhiteSpace($_)) {
+                $false
+              } else {
+                $candidate = [System.IO.Path]::GetFullPath($_).TrimEnd($trimChars)
+                $candidate.StartsWith($documentsRoot, [System.StringComparison]::OrdinalIgnoreCase)
+              }
+            } |
+            Select-Object -First 1
+
+          if ([string]::IsNullOrWhiteSpace($currentUserModuleRoot)) {
+            throw 'Unable to resolve the current-user PowerShell module root from PSModulePath.'
+          }
+
+          $signPathModulePath = Join-Path -Path $currentUserModuleRoot -ChildPath 'SignPath'
+
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            if ($attempt -eq 2) {
+              Start-Sleep -Seconds 15
+            } elseif ($attempt -eq 3) {
+              Start-Sleep -Seconds 30
+            }
+
+            try {
+              Install-Module -Name SignPath -Repository PSGallery -MinimumVersion 4.0.0 -MaximumVersion 4.999.999 -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
+              Import-Module SignPath -ErrorAction Stop
+              Get-Command -Name Get-SignedArtifact -Module SignPath -ErrorAction Stop
+              break
+            } catch {
+              if ($attempt -eq 3) {
+                throw
+              }
+
+              Write-Warning "SignPath PowerShell module preflight attempt $attempt failed: $_"
+              if (Test-Path -LiteralPath $signPathModulePath) {
+                Write-Warning "Removing current-user SignPath module directory before retry: $signPathModulePath"
+                Remove-Item -LiteralPath $signPathModulePath -Recurse -Force
+              }
+            }
+          }
+
       - name: Upload unsigned Windows installer for SignPath
         if: matrix.platform == 'win'
         id: upload-unsigned-windows-installer
@@ -976,13 +1026,6 @@ jobs:
           } | ConvertTo-Json -Depth 5
 
           Invoke-RestMethod -Method Post -Uri $env:SLACK_WEBHOOK_URL -ContentType 'application/json' -Body $payload
-
-      - name: Install SignPath PowerShell module
-        if: matrix.platform == 'win'
-        shell: pwsh
-        run: |
-          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-          Install-Module -Name SignPath -MinimumVersion 4.0.0 -MaximumVersion 4.999.999 -Scope CurrentUser -Force
 
       - name: Download signed Windows installer from SignPath
         if: matrix.platform == 'win'

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -86,6 +86,62 @@ describe('Electron runtime package contract', () => {
     )
   })
 
+  it('preflights SignPath module install before Windows signing side effects', () => {
+    const releaseWorkflow = readFileSync(
+      join(projectDir, '.github/workflows/release-cut.yml'),
+      'utf8'
+    )
+    const parsedWorkflow = parse(releaseWorkflow)
+    const steps = parsedWorkflow.jobs.build.steps
+    const stepNames = steps.map((step) => step.name)
+    const installStepIndexes = stepNames.flatMap((name, index) =>
+      name === 'Install SignPath PowerShell module' ? [index] : []
+    )
+    const buildIndex = stepNames.indexOf('Build Windows release artifacts')
+    const uploadIndex = stepNames.indexOf('Upload unsigned Windows installer for SignPath')
+    const downloadIndex = stepNames.indexOf('Download signed Windows installer from SignPath')
+
+    expect(installStepIndexes).toEqual([buildIndex + 1])
+    expect(installStepIndexes[0]).toBeLessThan(uploadIndex)
+
+    const uploadThroughDownloadScript = steps
+      .slice(uploadIndex, downloadIndex + 1)
+      .map((step) => step.run ?? '')
+      .join('\n')
+
+    expect(uploadThroughDownloadScript).not.toContain('Install-Module -Name SignPath')
+
+    const installStep = steps[installStepIndexes[0]]
+    const installRun = installStep.run
+    const sleepSeconds = [...installRun.matchAll(/Start-Sleep -Seconds (\d+)/g)].map(
+      ([, seconds]) => seconds
+    )
+
+    expect(installStep.if).toBe("matrix.platform == 'win'")
+    expect(installStep.shell).toBe('pwsh')
+    expect(installRun).toContain('Set-PSRepository -Name PSGallery -InstallationPolicy Trusted')
+    expect(installRun).toMatch(/\$env:PSModulePath -split \[System\.IO\.Path\]::PathSeparator/)
+    expect(installRun).toContain(
+      "$signPathModulePath = Join-Path -Path $currentUserModuleRoot -ChildPath 'SignPath'"
+    )
+    expect(installRun).toMatch(/for \(\$attempt = 1; \$attempt -le 3; \$attempt\+\+\)/)
+    expect(sleepSeconds).toEqual(['15', '30'])
+    expect(installRun).toContain(
+      'Install-Module -Name SignPath -Repository PSGallery -MinimumVersion 4.0.0 -MaximumVersion 4.999.999 -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop'
+    )
+    expect(installRun).toContain('Import-Module SignPath')
+    expect(installRun).toContain(
+      'Get-Command -Name Get-SignedArtifact -Module SignPath -ErrorAction Stop'
+    )
+    expect(installRun).toContain('Remove-Item -LiteralPath $signPathModulePath -Recurse -Force')
+    expect(installRun).not.toContain('SignPath*')
+    expect(installRun.indexOf('if ($attempt -eq 3)')).toBeLessThan(
+      installRun.indexOf('Remove-Item -LiteralPath $signPathModulePath')
+    )
+    expect(installRun).toMatch(/if \(\$attempt -eq 3\) {\s+throw\s+}/)
+    expect(installRun).not.toMatch(/throw\s+\$_/)
+  })
+
   it('publishes both Linux release matrix entries', () => {
     const releaseWorkflow = readFileSync(
       join(projectDir, '.github/workflows/release-cut.yml'),


### PR DESCRIPTION
## Summary

This hardens the Windows release signing path by moving the SignPath PowerShell module install into a preflight immediately after the Windows installer build and before upload, signing-request, or Slack approval side effects. The preflight now retries bounded PSGallery/module-install failures, verifies the module imports, and asserts `Get-SignedArtifact` is exported before the workflow creates an approver-facing signing request.

## Design Approach

The design keeps the existing SignPath request, manual approval, signed artifact download, staging, signature verification, and release publication semantics intact. It only changes when and how the SignPath PowerShell module dependency is proven usable.

Design review outcome: reviewed and marked ready after tightening the plan to preflight before side effects, require exact current-user `SignPath` cleanup only on retry, preserve final exception rethrow, and add parsed workflow contract coverage.

## Implementation

- Moved `Install SignPath PowerShell module` before `Upload unsigned Windows installer for SignPath`.
- Replaced the single install attempt with 3 bounded attempts and 15s/30s waits.
- Added exact current-user `SignPath` module directory cleanup before retrying failed attempts.
- Added `Import-Module SignPath` and `Get-Command -Name Get-SignedArtifact -Module SignPath -ErrorAction Stop` assertions.
- Added a workflow contract test for ordering, retry shape, cleanup scope, command assertion, and final rethrow behavior.

Deviations from the reviewed design: none.

## Verification

Completeness verification: complete; no omissions found against the reviewed design.

Perf audit: clean. The only touched hot path is the Windows release CI path. Worst-case added delay is bounded to 45 seconds plus two additional install attempts only when PSGallery/module install fails. No app runtime, render, store, terminal, SSH, or cache hot paths are touched.

Code review: one round with two independent reviewers; both returned clean. Residual risk is that the Windows-only PowerShell/SignPath path must ultimately be exercised by GitHub's Windows runner.

Brennan test validation: land. Screenshot evidence is not applicable because this is a GitHub Actions workflow/test change with no visible Electron UI surface.

## Checks Run

- `pnpm vitest run config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`

## Post-PR Stabilization

Completed. After the required wait, `verify` was initially pending and CodeRabbit was rate-limited. I waited for the review window, requested a manual CodeRabbit review, waited again, then rechecked all PR surfaces. Final state:

- `verify`: passed.
- `track-community-pr`: passed.
- CodeRabbit: manual review finished; no actionable inline comments or review findings were present.
- Merge state: clean.

## Why This Was Not Already Preflighted

The previous flow installed the SignPath PowerShell module immediately before the step that used it, which was a reasonable first implementation. The release failure showed the hidden cost of that ordering: a transient PSGallery/module install failure could happen after the workflow had already uploaded the unsigned installer, submitted the SignPath request, and notified approvers.

This PR keeps the same signing and download semantics, but moves the dependency proof earlier. We still use the same SignPath module version bounds, request parameters, Slack notification, signed artifact download command, installer staging, signature verification, and release publication path. The behavior change is timing: prove `Get-SignedArtifact` can be installed, imported, and resolved before creating SignPath or human-approval side effects.

The main residual risk is GitHub's Windows runner PowerShell environment. Local validation could not execute the actual `pwsh`/SignPath path because `pwsh` is not installed here, so the next Windows release job remains the end-to-end proof. The PR contract test and reviews cover the workflow ordering, bounded retry shape, cleanup scope, and command assertion to reduce that risk.

## Risks and Assumptions

- `pwsh` and `actionlint` were not available locally, so PowerShell syntax and workflow execution will be validated by GitHub Actions.
- The original release run also had unrelated E2E/test-evidence failures; this PR intentionally fixes the deterministic Windows SignPath module-install release blocker only.
