### PR TITLE
Hide unread dot while worktrees are working

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -84,6 +84,53 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('text-amber-500')
   })
 
+  it('suppresses the new-card unread badge while unread status is working', () => {
+    mocks.status = 'working'
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction
+        isUnread
+        unreadTooltip="Mark as read"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        newCardStyle
+        hasBranchIdentity={false}
+      />
+    )
+
+    expect(markup).toContain('Working · Unread')
+    expect(markup).toContain('border-yellow-500')
+    expect(markup).not.toContain('data-worktree-status-lane-unread=""')
+    expect(markup).not.toContain('data-worktree-unread-alert=""')
+    expect(markup).not.toContain('aria-label="Mark as read"')
+    expect(markup).not.toContain('lucide-bell')
+    expect(markup).not.toContain('text-amber-500')
+  })
+
+  it('keeps legacy unread working cards on the unread bell control', () => {
+    mocks.status = 'working'
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction
+        isUnread
+        unreadTooltip="Mark as read"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('aria-label="Mark as read"')
+    expect(markup).toContain('Mark as read')
+    expect(markup).toContain('Working')
+    expect(markup).toContain('text-amber-500')
+    expect(markup).not.toContain('border-yellow-500')
+    expect(markup).not.toContain('data-worktree-unread-alert=""')
+  })
+
   it('shows status in the unread toggle affordance', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCardStatusSlot

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -121,6 +121,9 @@ export function WorktreeCardStatusSlot({
         : statusLabel
   const passiveStatusTooltip =
     newCardStyle && isUnread ? `${passiveStatusLabel} · Unread` : passiveStatusLabel
+  // Why: the working spinner owns the new-card status lane, but unread state
+  // should still surface in tooltip/sr-only copy and reappear afterward.
+  const showNewCardUnreadAlert = newCardStyle && isUnread && showStatus && status !== 'working'
   const reviewStatusIconClassName = compactReviewAndBranchStatusIconClassName
   const branchStatusIcon = <GitBranch className={branchStatusIconClassName} aria-hidden="true" />
   const passiveStatus =
@@ -173,7 +176,7 @@ export function WorktreeCardStatusSlot({
   }
 
   if (!unreadActionEnabled) {
-    return overlayNewCardUnreadStatus(passiveStatus, newCardStyle && isUnread && showStatus)
+    return overlayNewCardUnreadStatus(passiveStatus, showNewCardUnreadAlert)
   }
 
   const actionLabel = isUnread ? 'Mark as read' : 'Mark as unread'


### PR DESCRIPTION
## Summary

Suppress the new worktree-card unread overlay dot while a worktree is resolved as `working`, so the yellow working indicator owns the left status lane. The underlying unread state and accessible copy remain intact, and the unread overlay returns when the worktree leaves `working`.

## Screenshots

Manual Electron validation screenshot evidence was captured locally and not committed per repo policy:

- `.tmp/validation/hide-working-dot-demo-project-full-app.png`

The screenshot shows the relevant app surface around the worktree list while an unread demo card is resolved as `working`: the yellow working spinner remains visible and the left unread lane dot is absent.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` full suite was not run; focused regression coverage was run instead for this narrow sidebar conditional.
- [ ] `pnpm build` was not run; CI `verify` passed on the pushed branch.
- [x] Added or updated high-quality tests that would catch regressions.

Focused and supporting validation:

- `git diff --check` passed.
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx` passed, 18 tests.
- Perf audit additionally ran `npm test -- --run src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx` and `npm test -- --run src/renderer/src/components/sidebar/worktree-card-status-inputs.test.ts`, both passed.
- PR checks passed: `verify` and `track-community-pr`.

Manual product validation:

- Electron validation launched this exact worktree on CDP port `9336`.
- Verified an unread demo card with resolved status `working` kept the yellow working spinner visible and rendered no `data-worktree-unread-alert` lane dot.
- Verified unread state/copy was preserved (`Working · Unread`, title prefix, store `isUnread: true`).
- Verified the unread alert wrapper reappeared after leaving `working`.
- Verified legacy card mode still rendered the amber `Mark as read` bell control.

## Design Approach

The change keeps the existing status resolution and status-lane rendering model. `WorktreeCardStatusSlot` now derives a focused `showNewCardUnreadAlert` boolean that preserves the existing unread overlay for new-card quiet states, PR/branch identity states, and permission states, but skips the overlay when the resolved status is `working`. Legacy card unread behavior remains unchanged.

## Design Review

Design review completed cleanly for Brennan's PR process. The review added an interaction priority matrix and data-flow notes to the scratch design doc. Remaining caveat: the review subagent could not use an external Codex reviewer because `CODEX_LB_API_KEY` was unavailable, so it completed the loop with in-process review.

## Implementation

- Updated `src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx` to suppress only the new-card unread overlay while `status === 'working'`.
- Added focused coverage in `src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx` for new-card working suppression and unchanged legacy unread behavior.
- No deviations from the reviewed design.

## Completeness Verification

Read-only verification found the implementation complete against the design: unread state/copy is preserved, legacy behavior is unchanged, PR/branch priority remains limited to quiet statuses, and no new styling primitives or tokens were introduced.

## Performance Audit

Perf audit passed. Touched hot path: per-worktree sidebar status rendering inside `WorktreeCardStatusSlot`. No new store subscriptions, effects, timers, polling, subprocesses, cache invalidation, or startup work were introduced. The change removes the unread overlay subtree while working, so existing deterministic coverage is sufficient.

## AI Review Report

Two independent review subagents reviewed the current branch diff in one round and both returned clean. They checked correctness, missing tests, accessibility, styleguide fit, performance, provider compatibility, SSH behavior, and cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and Electron-specific platform differences touched by this PR.

No product-authored agent workflow direction, external side-effect instruction, or agent-visible prompt text was introduced.

## Security Audit

Security review found no new input handling, auth, secrets, dependency, IPC, command execution, or path-handling risk. This is renderer-only conditional rendering based on the existing resolved worktree status. The change does not touch filesystem access, runtime connections, provider APIs, shell invocation, clipboard data, remote/SSH path translation, or privileged Electron surfaces.

## Post-PR Stabilization

Completed.

- Required initial `sleep 480` was run before the first automated-feedback sweep.
- Initial sweep found `verify` pending and CodeRabbit temporarily rate-limited.
- Triggered CodeRabbit with `@coderabbitai review`, then ran another `sleep 480` before the next sweep.
- Final sweep: CodeRabbit reported no actionable comments. PR checks passed: `verify` and `track-community-pr`.
- CodeRabbit pre-merge warnings: PR description template warning addressed by this body update; docstring coverage warning treated as non-actionable because this PR adds no new documented public API and the behavior is covered by focused regression tests.

## Notes

This is renderer-only conditional rendering. It does not add keyboard shortcuts, path handling, provider-specific behavior, subprocesses, or filesystem assumptions. SSH/runtime worktrees use the same resolved `useWorktreeActivityStatus` value, so no SSH-specific branch was needed.
