### PR TITLE
Only create worktree root directory on blur, not per keystroke

### DIFF
--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
@@ -108,6 +108,17 @@ describe('RepositoryWorktreeDefaultsSection — worktree path', () => {
     expect(updateRepo).toHaveBeenCalledWith('repo-1', { worktreeBasePath: './worktree' })
   })
 
+  it('does not call updateRepo when the normalized value is unchanged on blur', () => {
+    const updateRepo = vi.fn()
+    render({ ...BASE_REPO, worktreeBasePath: './worktree' }, updateRepo)
+
+    const input = getWorktreePathInput()
+    typeText(input, '  ./worktree  ')
+    blurInput(input)
+
+    expect(updateRepo).not.toHaveBeenCalled()
+  })
+
   it('calls updateRepo with undefined when the field is cleared', () => {
     const updateRepo = vi.fn()
     render({ ...BASE_REPO, worktreeBasePath: '../worktrees' }, updateRepo)
@@ -121,7 +132,7 @@ describe('RepositoryWorktreeDefaultsSection — worktree path', () => {
 
   it('calls updateRepo with undefined when the value is whitespace-only', () => {
     const updateRepo = vi.fn()
-    render(BASE_REPO, updateRepo)
+    render({ ...BASE_REPO, worktreeBasePath: '../worktrees' }, updateRepo)
 
     const input = getWorktreePathInput()
     typeText(input, '   ')

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
@@ -101,7 +101,7 @@ describe('RepositoryWorktreeDefaultsSection — worktree path', () => {
     render(BASE_REPO, updateRepo)
 
     const input = getWorktreePathInput()
-    typeText(input, './worktree')
+    typeText(input, '  ./worktree  ')
     blurInput(input)
 
     expect(updateRepo).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import { RepositoryWorktreeDefaultsSection } from './RepositoryWorktreeDefaultsSection'
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: { settingsSearchQuery: string }) => unknown) =>
+    selector({ settingsSearchQuery: '' })
+}))
+
+vi.mock('./BaseRefPicker', () => ({
+  BaseRefPicker: () => null
+}))
+
+const BASE_REPO: Repo = {
+  id: 'repo-1',
+  path: '/home/user/project',
+  displayName: 'My Project',
+  badgeColor: '#000000',
+  addedAt: 0
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function render(repo: Repo, updateRepo: (repoId: string, updates: object) => void): void {
+  act(() => {
+    root.render(
+      React.createElement(RepositoryWorktreeDefaultsSection, {
+        repo,
+        settings: null,
+        updateRepo,
+        forceVisible: true
+      })
+    )
+  })
+}
+
+function getWorktreePathInput(): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>('input')
+  if (!input) {
+    throw new Error('worktree path input not found')
+  }
+  return input
+}
+
+function setNativeValue(input: HTMLInputElement, text: string): void {
+  // Why: React reads controlled-input changes via the native value setter;
+  // assigning input.value directly is swallowed by React's value tracking.
+  const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  setValue?.call(input, text)
+}
+
+function typeText(input: HTMLInputElement, text: string): void {
+  act(() => {
+    setNativeValue(input, text)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+function blurInput(input: HTMLInputElement): void {
+  act(() => {
+    input.dispatchEvent(new FocusEvent('blur', { bubbles: true }))
+  })
+}
+
+describe('RepositoryWorktreeDefaultsSection — worktree path', () => {
+  it('does not call updateRepo while the user is typing', () => {
+    const updateRepo = vi.fn()
+    render(BASE_REPO, updateRepo)
+
+    const input = getWorktreePathInput()
+    typeText(input, './w')
+    typeText(input, './wo')
+    typeText(input, './wor')
+    typeText(input, './worktree')
+
+    expect(updateRepo).not.toHaveBeenCalled()
+  })
+
+  it('calls updateRepo with the final value on blur', () => {
+    const updateRepo = vi.fn()
+    render(BASE_REPO, updateRepo)
+
+    const input = getWorktreePathInput()
+    typeText(input, './worktree')
+    blurInput(input)
+
+    expect(updateRepo).toHaveBeenCalledTimes(1)
+    expect(updateRepo).toHaveBeenCalledWith('repo-1', { worktreeBasePath: './worktree' })
+  })
+
+  it('calls updateRepo with undefined when the field is cleared', () => {
+    const updateRepo = vi.fn()
+    render({ ...BASE_REPO, worktreeBasePath: '../worktrees' }, updateRepo)
+
+    const input = getWorktreePathInput()
+    typeText(input, '')
+    blurInput(input)
+
+    expect(updateRepo).toHaveBeenCalledWith('repo-1', { worktreeBasePath: undefined })
+  })
+
+  it('calls updateRepo with undefined when the value is whitespace-only', () => {
+    const updateRepo = vi.fn()
+    render(BASE_REPO, updateRepo)
+
+    const input = getWorktreePathInput()
+    typeText(input, '   ')
+    blurInput(input)
+
+    expect(updateRepo).toHaveBeenCalledWith('repo-1', { worktreeBasePath: undefined })
+  })
+})

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
@@ -75,8 +75,10 @@ function typeText(input: HTMLInputElement, text: string): void {
 }
 
 function blurInput(input: HTMLInputElement): void {
+  // Why: React delegates onBlur via focusout (which bubbles) not blur (which
+  // doesn't), so dispatching focusout is required to trigger the React handler.
   act(() => {
-    input.dispatchEvent(new FocusEvent('blur', { bubbles: true }))
+    input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
   })
 }
 

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
@@ -86,6 +86,11 @@ export function RepositoryWorktreeDefaultsSection({
           onTextChange={() => {}}
           onBlur={(e) => {
             const worktreeBasePath = e.currentTarget.value.trim() || undefined
+            // Why: even an unchanged worktreeBasePath update asks main to
+            // prepare the root, which can touch the filesystem.
+            if (worktreeBasePath === (repo.worktreeBasePath?.trim() || undefined)) {
+              return
+            }
             updateRepo(repo.id, { worktreeBasePath })
           }}
           className="h-9 text-sm"

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
@@ -83,9 +83,11 @@ export function RepositoryWorktreeDefaultsSection({
           repoId={repo.id}
           storeValue={repo.worktreeBasePath ?? ''}
           placeholder={settings?.workspaceDir ?? ''}
-          onTextChange={(text) =>
+          onTextChange={() => {}}
+          onBlur={(e) => {
+            const text = e.currentTarget.value
             updateRepo(repo.id, { worktreeBasePath: text.trim() ? text : undefined })
-          }
+          }}
           className="h-9 text-sm"
         />
         <p className="text-xs text-muted-foreground">

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
@@ -85,8 +85,8 @@ export function RepositoryWorktreeDefaultsSection({
           placeholder={settings?.workspaceDir ?? ''}
           onTextChange={() => {}}
           onBlur={(e) => {
-            const text = e.currentTarget.value
-            updateRepo(repo.id, { worktreeBasePath: text.trim() ? text : undefined })
+            const worktreeBasePath = e.currentTarget.value.trim() || undefined
+            updateRepo(repo.id, { worktreeBasePath })
           }}
           className="h-9 text-sm"
         />


### PR DESCRIPTION
   ## Summary

   - Typing in the **Worktree Location** field in project settings was creating a new directory on every keystroke. Writing `./worktree` would produce `./w`, `./wo`, `./wor`, … before the user finished typing.
   - Root cause: `onTextChange` called `updateRepo` on each character, which triggered `prepareLocalWorktreeRootForRepo` → `mkdir(root, { recursive: true })` via IPC on every update.
   - Fix: `onTextChange` is now a no-op (the input's local draft still updates immediately for smooth typing); `updateRepo` — and therefore the `mkdir` — only fires on `onBlur`, once the user leaves the field.

   ## Screenshots

<img width="303" height="234" alt="image" src="https://github.com/user-attachments/assets/9d7970a0-b1f5-4a42-a17e-1d0368d7f58d" />

   ## Testing

   - [x] `pnpm lint`
   - [x] `pnpm typecheck`
   - [x] `pnpm test`
   - [x] `pnpm build`
   - [x] Added tests in `RepositoryWorktreeDefaultsSection.test.tsx` covering: no `updateRepo` calls during typing, correct call on blur, `undefined` on empty/whitespace blur.

   **Manual repro (before fix):** Open Settings → any project → Worktree Location, type `./worktree` character by character — verify no intermediate directories are created while typing, and exactly one directory is created after tabbing away.

   ## AI Review Report

   Reviewed the change for correctness, cross-platform compatibility, and side-effects:

   - **Correctness:** The `RepoSettingsDraftInput` component maintains a local draft on every keystroke so the input feels instant. The internal `pendingStoreEchoesRef` still accumulates typed values, so when the store eft is correctly preserved ratherthan reset. IME composition (Japanese/Korean) is unaffected — composition completes naturally before blur.                                                                                   - **Cross-platform (macOS/Linux/Win React event handling(`onBlur`) — no platform-specific paths, shortcuts, or shell behavior involved. The `mkdir` call in `worktree-root-preparation.ts` that was the source of the bug uses `fs/promises` with  `{ recursive: true }`, which is c
   - **SSH/remote:** `prepareLocalWorktreeRootForRepo` already returns early for non-local repos, so SSH worktrees are unaffected.                                                               - **No regressions flagged** for  which still calls `updateRepo`directly on click (correct — that is an intentional immediate action, not a text input).
                                                                                                  ## Security Audit

   - **Path handling:** The `worktreeBasePath` value goes through `text.trim()` before being      passed to `updateRepo`, consisten No change to how the path isvalidated or resolved in the main process (`sanitizeRepoUpdatesForPersistence` still applies).
   - **IPC:** No new IPC channels or payloads introduced. The fix reduces IPC call frequency (one call on blur vs. one per keystrok
   - **No input injection risk:** The value is stored as a string setting and resolved through `path.resolve`/`path.join` in the main process before any filesystem operation.

   ## Notes

   No platform-specific behavior. No

