### PR TITLE
Zoom the app after leaving terminal focus

### DIFF
--- a/src/main/browser/browser-guest-ui.test.ts
+++ b/src/main/browser/browser-guest-ui.test.ts
@@ -469,7 +469,7 @@ describe('setupGuestShortcutForwarding', () => {
     }
   })
 
-  it('forwards browser page zoom shortcuts from focused guest pages', () => {
+  it('forwards app zoom shortcuts from focused guest pages', () => {
     setupGuestShortcutForwarding({
       browserTabId,
       guest: makeGuest(),
@@ -497,12 +497,12 @@ describe('setupGuestShortcutForwarding', () => {
     expect(numpadSubtractPreventDefault).toHaveBeenCalledTimes(1)
     expect(resetPreventDefault).toHaveBeenCalledTimes(1)
     expect(repeatPreventDefault).toHaveBeenCalledTimes(1)
-    expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:zoomBrowserPage', 'in')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:zoomBrowserPage', 'in')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:zoomBrowserPage', 'out')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:zoomBrowserPage', 'out')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:zoomBrowserPage', 'reset')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:zoomBrowserPage', 'in')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'terminal:zoom', 'in')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'terminal:zoom', 'in')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'terminal:zoom', 'out')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'terminal:zoom', 'out')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'terminal:zoom', 'reset')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'terminal:zoom', 'in')
   })
 
   it('forwards browser history shortcuts from focused guest pages', () => {
@@ -558,7 +558,7 @@ describe('setupGuestShortcutForwarding', () => {
 
     expect(defaultPreventDefault).not.toHaveBeenCalled()
     expect(customPreventDefault).toHaveBeenCalledTimes(1)
-    expect(rendererSendMock).toHaveBeenCalledWith('ui:zoomBrowserPage', 'in')
+    expect(rendererSendMock).toHaveBeenCalledWith('terminal:zoom', 'in')
   })
 
   it('forwards double-tap window shortcuts from focused guest pages', () => {

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -279,11 +279,11 @@ export function setupGuestShortcutForwarding(args: {
   ): boolean => {
     const keybindings = getKeybindings?.()
     if (action?.type === 'zoom') {
-      // Why: browser page zoom must consume repeats and teardown races before
-      // Chromium or the guest page can apply its own shortcut behavior.
+      // Why: keyboard zoom is Orca chrome zoom. Focused guests bypass the
+      // main-window shortcut path, so forward to the shared renderer zoom router.
       event.preventDefault()
       const renderer = resolveRenderer(browserTabId)
-      renderer?.send('ui:zoomBrowserPage', action.direction)
+      renderer?.send('terminal:zoom', action.direction)
       return true
     }
     if (input.isAutoRepeat) {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -696,6 +696,21 @@
   user-select: none;
 }
 
+[data-terminal-focus-release-surface='true'] {
+  -webkit-app-region: drag;
+}
+
+/* Why: Electron drag regions swallow renderer pointer events. While regular
+   xterm owns focus, make the next top-chrome click observable so it can release
+   terminal zoom ownership; after release these surfaces become draggable again. */
+:root[data-regular-terminal-input-focused] .titlebar,
+:root[data-regular-terminal-input-focused] .titlebar-left,
+:root[data-regular-terminal-input-focused] .window-controls-titlebar-spacer,
+:root[data-regular-terminal-input-focused] .right-sidebar-header-drag,
+:root[data-regular-terminal-input-focused] [data-terminal-focus-release-surface='true'] {
+  -webkit-app-region: no-drag;
+}
+
 .right-sidebar-header-no-drag {
   -webkit-app-region: no-drag;
 }

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -230,7 +230,7 @@ export default function TabGroupPanel({
           user can only drag from the tiny left-sidebar header strip. */}
       <div
         className="h-[32px] shrink-0 border-b border-border bg-card"
-        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+        data-terminal-focus-release-surface="true"
       >
         <div className="flex h-full items-stretch pr-1.5">
           {/* Why: Electron's native drag hit-test only respects no-drag on DOM

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -263,10 +263,7 @@ export default function TabGroupSplitLayout({
           ref={dragSplit.setDragRootNode}
           className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-l border-border"
         >
-          <div
-            className="h-[4px] shrink-0 bg-card"
-            style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-          />
+          <div className="h-[4px] shrink-0 bg-card" data-terminal-focus-release-surface="true" />
           <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
             <SplitNode
               node={layout}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1416,7 +1416,9 @@ export default function TerminalPane({
     if (!container) {
       return
     }
+    let ownsRegularTerminalFocus = false
     const syncFocused = (focused: boolean): void => {
+      ownsRegularTerminalFocus = focused
       setRegularTerminalInputFocusAttribute(focused)
       window.api.ui.setTerminalInputFocused?.(focused)
     }
@@ -1478,10 +1480,9 @@ export default function TerminalPane({
       document.removeEventListener('pointerdown', onPointerDown, true)
       window.removeEventListener('blur', onWindowBlur)
       window.removeEventListener('focus', onWindowFocus)
-      if (
-        isXtermHelperTextarea(document.activeElement) &&
-        container.contains(document.activeElement)
-      ) {
+      // Why: the helper textarea may be removed before cleanup observes
+      // document.activeElement, so clear by this pane's mirrored ownership.
+      if (ownsRegularTerminalFocus) {
         syncFocused(false)
       }
     }

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -140,6 +140,13 @@ import {
 import { getCachedTerminalTabForWorktree } from './terminal-tab-lookup'
 import { getCachedTerminalGroupIdForWorktree } from './terminal-unified-tab-lookup'
 import { useRepoById } from '@/store/selectors'
+import {
+  isXtermHelperTextarea,
+  releaseTerminalFocusForOutsidePointerDown,
+  releaseTerminalFocusForWindowBlur,
+  resyncTerminalFocusForWindowFocus,
+  setRegularTerminalInputFocusAttribute
+} from './regular-terminal-focus-ownership'
 
 type TerminalPaneProps = {
   tabId: string
@@ -192,10 +199,6 @@ function TerminalQuickCommandEditorDialog({
 function formatClipboardImagePasteError(error: unknown): string {
   const detail = error instanceof Error ? error.message : String(error)
   return `Image paste failed: ${detail}`
-}
-
-function isXtermHelperTextarea(target: EventTarget | null): target is HTMLElement {
-  return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
 }
 
 function arePaneTitleOverlayRectsEqual(
@@ -1295,7 +1298,7 @@ export default function TerminalPane({
     }
   }, [consumePendingCodexPaneRestart, handleRestartCodexPane, pendingCodexPaneRestartIds])
 
-  useTerminalFontZoom({ isActive, managerRef, paneFontSizesRef, settingsRef })
+  useTerminalFontZoom({ isActive, containerRef, managerRef, paneFontSizesRef, settingsRef })
 
   useTerminalKeyboardShortcuts({
     tabId,
@@ -1414,6 +1417,7 @@ export default function TerminalPane({
       return
     }
     const syncFocused = (focused: boolean): void => {
+      setRegularTerminalInputFocusAttribute(focused)
       window.api.ui.setTerminalInputFocused?.(focused)
     }
     const onFocusIn = (event: FocusEvent): void => {
@@ -1430,6 +1434,32 @@ export default function TerminalPane({
       }
       syncFocused(false)
     }
+    const onPointerDown = (event: PointerEvent): void => {
+      releaseTerminalFocusForOutsidePointerDown({
+        container,
+        activeElement: document.activeElement,
+        pointerTarget: event.target,
+        syncFocused
+      })
+    }
+    const onWindowBlur = (): void => {
+      // Why: webview/browser handoff leaves the helper textarea as DOM focus,
+      // so clear only the main-process mirror and let guest focus proceed.
+      releaseTerminalFocusForWindowBlur({
+        container,
+        activeElement: document.activeElement,
+        syncFocused
+      })
+    }
+    const onWindowFocus = (): void => {
+      // Why: app reactivation can preserve DOM focus on xterm after blur
+      // cleared the process-wide shortcut mirror.
+      resyncTerminalFocusForWindowFocus({
+        container,
+        activeElement: document.activeElement,
+        syncFocused
+      })
+    }
 
     if (
       isXtermHelperTextarea(document.activeElement) &&
@@ -1439,9 +1469,15 @@ export default function TerminalPane({
     }
     container.addEventListener('focusin', onFocusIn)
     container.addEventListener('focusout', onFocusOut)
+    document.addEventListener('pointerdown', onPointerDown, true)
+    window.addEventListener('blur', onWindowBlur)
+    window.addEventListener('focus', onWindowFocus)
     return () => {
       container.removeEventListener('focusin', onFocusIn)
       container.removeEventListener('focusout', onFocusOut)
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      window.removeEventListener('blur', onWindowBlur)
+      window.removeEventListener('focus', onWindowFocus)
       if (
         isXtermHelperTextarea(document.activeElement) &&
         container.contains(document.activeElement)

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  REGULAR_TERMINAL_INPUT_FOCUSED_ATTRIBUTE,
+  getPaneOwnedActiveHelperTextarea,
+  releaseTerminalFocusForOutsidePointerDown,
+  releaseTerminalFocusForWindowBlur,
+  resyncTerminalFocusForWindowFocus,
+  setRegularTerminalInputFocusAttribute
+} from './regular-terminal-focus-ownership'
+
+function appendPane(): HTMLDivElement {
+  const pane = document.createElement('div')
+  document.body.appendChild(pane)
+  return pane
+}
+
+function appendHelper(pane: HTMLElement): HTMLTextAreaElement {
+  const helper = document.createElement('textarea')
+  helper.className = 'xterm-helper-textarea'
+  pane.appendChild(helper)
+  return helper
+}
+
+describe('regular terminal focus ownership', () => {
+  beforeEach(() => {
+    document.body.replaceChildren()
+    document.documentElement.removeAttribute(REGULAR_TERMINAL_INPUT_FOCUSED_ATTRIBUTE)
+  })
+
+  it('releases and blurs the owning helper textarea on outside pointerdown', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const outside = document.createElement('button')
+    const syncFocused = vi.fn()
+    const blur = vi.spyOn(helper, 'blur')
+    document.body.appendChild(outside)
+    helper.focus()
+
+    const released = releaseTerminalFocusForOutsidePointerDown({
+      container: pane,
+      activeElement: document.activeElement,
+      pointerTarget: outside,
+      syncFocused
+    })
+
+    expect(released).toBe(true)
+    expect(syncFocused).toHaveBeenCalledWith(false)
+    expect(blur).toHaveBeenCalledOnce()
+  })
+
+  it('keeps ownership for pointerdowns inside the same terminal pane', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const innerTarget = document.createElement('div')
+    const syncFocused = vi.fn()
+    const blur = vi.spyOn(helper, 'blur')
+    pane.appendChild(innerTarget)
+    helper.focus()
+
+    const released = releaseTerminalFocusForOutsidePointerDown({
+      container: pane,
+      activeElement: document.activeElement,
+      pointerTarget: innerTarget,
+      syncFocused
+    })
+
+    expect(released).toBe(false)
+    expect(syncFocused).not.toHaveBeenCalled()
+    expect(blur).not.toHaveBeenCalled()
+  })
+
+  it("does not clear another pane's active helper ownership", () => {
+    const pane = appendPane()
+    const otherPane = appendPane()
+    const otherHelper = appendHelper(otherPane)
+    const outside = document.createElement('button')
+    const syncFocused = vi.fn()
+    document.body.appendChild(outside)
+    otherHelper.focus()
+
+    const released = releaseTerminalFocusForOutsidePointerDown({
+      container: pane,
+      activeElement: document.activeElement,
+      pointerTarget: outside,
+      syncFocused
+    })
+
+    expect(released).toBe(false)
+    expect(syncFocused).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(otherHelper)
+  })
+
+  it('releases the main-process mirror on renderer blur without blurring DOM focus', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const syncFocused = vi.fn()
+    const blur = vi.spyOn(helper, 'blur')
+    helper.focus()
+
+    const released = releaseTerminalFocusForWindowBlur({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused
+    })
+
+    expect(released).toBe(true)
+    expect(syncFocused).toHaveBeenCalledWith(false)
+    expect(blur).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(helper)
+  })
+
+  it('resyncs terminal ownership on renderer focus when the same helper remains active', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const syncFocused = vi.fn()
+    helper.focus()
+
+    const synced = resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused
+    })
+
+    expect(synced).toBe(true)
+    expect(syncFocused).toHaveBeenCalledWith(true)
+  })
+
+  it('resolves an owned active xterm helper textarea', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const otherPane = appendPane()
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+
+    expect(getPaneOwnedActiveHelperTextarea(pane, helper)).toBe(helper)
+    expect(getPaneOwnedActiveHelperTextarea(pane, button)).toBeNull()
+    expect(getPaneOwnedActiveHelperTextarea(otherPane, helper)).toBeNull()
+    expect(getPaneOwnedActiveHelperTextarea(pane, null)).toBeNull()
+  })
+
+  it('tracks regular terminal focus on the document element for titlebar click release', () => {
+    setRegularTerminalInputFocusAttribute(true)
+    expect(document.documentElement.hasAttribute(REGULAR_TERMINAL_INPUT_FOCUSED_ATTRIBUTE)).toBe(
+      true
+    )
+
+    setRegularTerminalInputFocusAttribute(false)
+    expect(document.documentElement.hasAttribute(REGULAR_TERMINAL_INPUT_FOCUSED_ATTRIBUTE)).toBe(
+      false
+    )
+  })
+})

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
@@ -1,0 +1,73 @@
+export type TerminalInputFocusSync = (focused: boolean) => void
+export const REGULAR_TERMINAL_INPUT_FOCUSED_ATTRIBUTE = 'data-regular-terminal-input-focused'
+
+export function isXtermHelperTextarea(target: EventTarget | null): target is HTMLElement {
+  return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
+}
+
+export function setRegularTerminalInputFocusAttribute(focused: boolean): void {
+  if (typeof document === 'undefined') {
+    return
+  }
+  document.documentElement.toggleAttribute(REGULAR_TERMINAL_INPUT_FOCUSED_ATTRIBUTE, focused)
+}
+
+export function getPaneOwnedActiveHelperTextarea(
+  container: HTMLElement,
+  activeElement: Element | null
+): HTMLElement | null {
+  if (!isXtermHelperTextarea(activeElement) || !container.contains(activeElement)) {
+    return null
+  }
+  return activeElement
+}
+
+export function releaseTerminalFocusForOutsidePointerDown(args: {
+  container: HTMLElement
+  activeElement: Element | null
+  pointerTarget: EventTarget | null
+  syncFocused: TerminalInputFocusSync
+}): boolean {
+  const activeHelper = getPaneOwnedActiveHelperTextarea(args.container, args.activeElement)
+  if (!activeHelper) {
+    return false
+  }
+
+  if (isNode(args.pointerTarget) && args.container.contains(args.pointerTarget)) {
+    return false
+  }
+
+  args.syncFocused(false)
+  activeHelper.blur()
+  return true
+}
+
+export function releaseTerminalFocusForWindowBlur(args: {
+  container: HTMLElement
+  activeElement: Element | null
+  syncFocused: TerminalInputFocusSync
+}): boolean {
+  if (!getPaneOwnedActiveHelperTextarea(args.container, args.activeElement)) {
+    return false
+  }
+
+  args.syncFocused(false)
+  return true
+}
+
+export function resyncTerminalFocusForWindowFocus(args: {
+  container: HTMLElement
+  activeElement: Element | null
+  syncFocused: TerminalInputFocusSync
+}): boolean {
+  if (!getPaneOwnedActiveHelperTextarea(args.container, args.activeElement)) {
+    return false
+  }
+
+  args.syncFocused(true)
+  return true
+}
+
+function isNode(value: EventTarget | null): value is Node {
+  return typeof Node !== 'undefined' && value instanceof Node
+}

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+import type * as ReactModule from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTerminalFontZoom } from './useTerminalFontZoom'
+
+const mocks = vi.hoisted(() => ({
+  captureScrollState: vi.fn(() => ({ wasAtBottom: true })),
+  restoreScrollState: vi.fn(),
+  safeFit: vi.fn(),
+  dispatchZoomLevelChanged: vi.fn()
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactModule>()
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => effect()
+  }
+})
+
+vi.mock('@/lib/pane-manager/pane-tree-ops', () => ({
+  captureScrollState: mocks.captureScrollState,
+  restoreScrollState: mocks.restoreScrollState,
+  safeFit: mocks.safeFit
+}))
+
+vi.mock('@/lib/zoom-events', () => ({
+  dispatchZoomLevelChanged: mocks.dispatchZoomLevelChanged
+}))
+
+describe('useTerminalFontZoom', () => {
+  let terminalZoomListeners: ((direction: 'in' | 'out' | 'reset') => void)[]
+
+  beforeEach(() => {
+    terminalZoomListeners = []
+    document.body.replaceChildren()
+    vi.clearAllMocks()
+    vi.stubGlobal('window', {
+      api: {
+        ui: {
+          onTerminalZoom: vi.fn((listener: (direction: 'in' | 'out' | 'reset') => void) => {
+            terminalZoomListeners.push(listener)
+            return () => {}
+          })
+        }
+      }
+    })
+  })
+
+  function useMountedTerminalFontZoom(activeElement: HTMLElement): {
+    terminal: { options: { fontSize?: number } }
+    listener: (direction: 'in' | 'out' | 'reset') => void
+  } {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    container.appendChild(activeElement)
+    activeElement.focus()
+    const terminal = { options: { fontSize: 14 } }
+    useTerminalFontZoom({
+      isActive: true,
+      containerRef: { current: container },
+      managerRef: {
+        current: {
+          getActivePane: () => ({ id: 1, terminal })
+        }
+      } as never,
+      paneFontSizesRef: { current: new Map() },
+      settingsRef: { current: { terminalFontSize: 14 } }
+    })
+    const listener = terminalZoomListeners.at(-1)
+    expect(listener).toBeTypeOf('function')
+    return { terminal, listener: listener as (direction: 'in' | 'out' | 'reset') => void }
+  }
+
+  it('ignores zoom events when terminal input no longer owns focus', () => {
+    const button = document.createElement('button')
+    const { listener, terminal } = useMountedTerminalFontZoom(button)
+
+    listener('in')
+
+    expect(terminal.options.fontSize).toBe(14)
+    expect(mocks.safeFit).not.toHaveBeenCalled()
+    expect(mocks.dispatchZoomLevelChanged).not.toHaveBeenCalled()
+  })
+
+  it('applies terminal font zoom while the xterm helper textarea owns focus', () => {
+    const helper = document.createElement('textarea')
+    helper.className = 'xterm-helper-textarea'
+    const { listener, terminal } = useMountedTerminalFontZoom(helper)
+
+    listener('in')
+
+    expect(terminal.options.fontSize).toBe(15)
+    expect(mocks.safeFit).toHaveBeenCalledTimes(1)
+    expect(mocks.dispatchZoomLevelChanged).toHaveBeenCalledWith('terminal', 107)
+  })
+
+  it('only lets the pane owning the focused helper apply terminal font zoom', () => {
+    const inactiveContainer = document.createElement('div')
+    const activeContainer = document.createElement('div')
+    const focusedHelper = document.createElement('textarea')
+    focusedHelper.className = 'xterm-helper-textarea'
+    document.body.append(inactiveContainer, activeContainer)
+    activeContainer.appendChild(focusedHelper)
+    focusedHelper.focus()
+
+    const inactiveTerminal = { options: { fontSize: 14 } }
+    const activeTerminal = { options: { fontSize: 14 } }
+    useTerminalFontZoom({
+      isActive: true,
+      containerRef: { current: inactiveContainer },
+      managerRef: {
+        current: {
+          getActivePane: () => ({ id: 1, terminal: inactiveTerminal })
+        }
+      } as never,
+      paneFontSizesRef: { current: new Map() },
+      settingsRef: { current: { terminalFontSize: 14 } }
+    })
+    useTerminalFontZoom({
+      isActive: true,
+      containerRef: { current: activeContainer },
+      managerRef: {
+        current: {
+          getActivePane: () => ({ id: 2, terminal: activeTerminal })
+        }
+      } as never,
+      paneFontSizesRef: { current: new Map() },
+      settingsRef: { current: { terminalFontSize: 14 } }
+    })
+
+    for (const listener of terminalZoomListeners) {
+      listener('in')
+    }
+
+    expect(inactiveTerminal.options.fontSize).toBe(14)
+    expect(activeTerminal.options.fontSize).toBe(15)
+    expect(mocks.safeFit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
@@ -2,9 +2,11 @@ import { useEffect } from 'react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
 import { captureScrollState, restoreScrollState, safeFit } from '@/lib/pane-manager/pane-tree-ops'
+import { getPaneOwnedActiveHelperTextarea } from './regular-terminal-focus-ownership'
 
 type FontZoomDeps = {
   isActive: boolean
+  containerRef: React.RefObject<HTMLElement | null>
   managerRef: React.RefObject<PaneManager | null>
   paneFontSizesRef: React.RefObject<Map<number, number>>
   settingsRef: React.RefObject<{ terminalFontSize?: number } | null>
@@ -12,6 +14,7 @@ type FontZoomDeps = {
 
 export function useTerminalFontZoom({
   isActive,
+  containerRef,
   managerRef,
   paneFontSizesRef,
   settingsRef
@@ -25,6 +28,10 @@ export function useTerminalFontZoom({
     const FONT_SIZE_STEP = 1
 
     return window.api.ui.onTerminalZoom((direction) => {
+      const container = containerRef.current
+      if (!container || !getPaneOwnedActiveHelperTextarea(container, document.activeElement)) {
+        return
+      }
       const manager = managerRef.current
       if (!manager) {
         return
@@ -61,5 +68,5 @@ export function useTerminalFontZoom({
       const percent = Math.round((nextSize / globalSize) * 100)
       dispatchZoomLevelChanged('terminal', percent)
     })
-  }, [isActive, managerRef, paneFontSizesRef, settingsRef])
+  }, [containerRef, isActive, managerRef, paneFontSizesRef, settingsRef])
 }

--- a/src/renderer/src/hooks/resolve-zoom-target.ts
+++ b/src/renderer/src/hooks/resolve-zoom-target.ts
@@ -55,11 +55,10 @@ export function resolveZoomTarget(args: {
   if (activeTabType === 'editor' || editorFocused) {
     return 'editor'
   }
-  // Why: terminal tabs should keep using per-pane terminal font zoom even when
-  // focus leaves the xterm textarea (e.g. clicking tab bar/sidebar controls).
-  // Falling back to UI zoom here would resize the whole app for a terminal-only
-  // action and break parity with terminal zoom behavior.
-  if (activeTabType === 'terminal' || terminalInputFocused) {
+  // Why: terminal zoom is focus-owned. After the user clicks app chrome or
+  // whitespace, the active terminal tab remains visible but app zoom should own
+  // Cmd/Ctrl +/- until xterm focus returns.
+  if (terminalInputFocused) {
     return 'terminal'
   }
   return 'ui'

--- a/src/renderer/src/hooks/resolve-zoom-target.ts
+++ b/src/renderer/src/hooks/resolve-zoom-target.ts
@@ -1,5 +1,5 @@
 /**
- * Determine which zoom domain (terminal, editor, or UI) should be adjusted
+ * Determine which zoom domain (terminal, editor, simulator, or UI) should be adjusted
  * based on current view, tab type, and focused element.
  */
 export function resolveZoomTarget(args: {
@@ -13,10 +13,9 @@ export function resolveZoomTarget(args: {
     | 'skills'
     | 'mobile'
   activeTabType: 'terminal' | 'editor' | 'browser' | 'simulator'
-  activeBrowserPageId?: string | null
   activeElement: unknown
-}): 'terminal' | 'editor' | 'browser' | 'simulator' | 'ui' {
-  const { activeView, activeTabType, activeBrowserPageId, activeElement } = args
+}): 'terminal' | 'editor' | 'simulator' | 'ui' {
+  const { activeView, activeTabType, activeElement } = args
   const terminalInputFocused =
     typeof activeElement === 'object' &&
     activeElement !== null &&
@@ -44,13 +43,13 @@ export function resolveZoomTarget(args: {
   if (activeView !== 'terminal') {
     return 'ui'
   }
-  // Why: a browser tab owns zoom shortcuts even if DOM focus still points at a
-  // just-deactivated editor or terminal during tab switches.
-  if (activeTabType === 'browser' && activeBrowserPageId) {
-    return 'browser'
-  }
   if (activeTabType === 'simulator') {
     return 'simulator'
+  }
+  // Why: keyboard/menu zoom in an active browser tab belongs to Orca chrome.
+  // Browser page zoom has a dedicated route for wheel and page-specific IPC.
+  if (activeTabType === 'browser') {
+    return 'ui'
   }
   if (activeTabType === 'editor' || editorFocused) {
     return 'editor'

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -98,7 +98,7 @@ function makeTarget(args: { hasXtermClass?: boolean; editorClosest?: boolean }):
 }
 
 describe('resolveZoomTarget', () => {
-  it('routes to terminal zoom when terminal tab is active', () => {
+  it('routes to terminal zoom when terminal input is focused', () => {
     expect(
       resolveZoomTarget({
         activeView: 'terminal',
@@ -106,6 +106,16 @@ describe('resolveZoomTarget', () => {
         activeElement: makeTarget({ hasXtermClass: true })
       })
     ).toBe('terminal')
+  })
+
+  it('routes to ui zoom for an active terminal tab after terminal focus is released', () => {
+    expect(
+      resolveZoomTarget({
+        activeView: 'terminal',
+        activeTabType: 'terminal',
+        activeElement: makeTarget({})
+      })
+    ).toBe('ui')
   })
 
   it('routes to editor zoom for editor tabs', () => {
@@ -326,6 +336,149 @@ describe('useIpcEvents zoom routing', () => {
     expect(setUI).not.toHaveBeenCalledWith(
       expect.objectContaining({ uiZoomLevel: expect.anything() })
     )
+  })
+
+  it('applies app zoom for an active terminal tab after terminal focus is released', async () => {
+    const terminalZoomListenerRef: {
+      current: ((direction: 'in' | 'out' | 'reset') => void) | null
+    } = { current: null }
+    const setUI = vi.fn()
+
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return {
+        ...actual,
+        useEffect: (effect: () => void | (() => void)) => {
+          effect()
+        }
+      }
+    })
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => ({
+          activeView: 'terminal',
+          activeTabType: 'terminal',
+          activeWorktreeId: 'wt-1',
+          activeBrowserTabId: null,
+          activeBrowserTabIdByWorktree: {},
+          browserTabsByWorktree: {},
+          browserPagesByWorkspace: {},
+          editorFontZoomLevel: 0,
+          setEditorFontZoomLevel: vi.fn(),
+          settings: { terminalFontSize: 13 },
+          setUpdateStatus: vi.fn(),
+          fetchRepos: vi.fn(),
+          fetchWorktrees: vi.fn(),
+          setActiveView: vi.fn(),
+          activeModal: null,
+          closeModal: vi.fn(),
+          openModal: vi.fn(),
+          setActiveRepo: vi.fn(),
+          setActiveWorktree: vi.fn(),
+          revealWorktreeInSidebar: vi.fn(),
+          setIsFullScreen: vi.fn(),
+          setRateLimitsFromPush: vi.fn()
+        })
+      }
+    }))
+    vi.doMock('@/lib/ui-zoom', () => ({ applyUIZoom: vi.fn() }))
+    vi.doMock('@/lib/worktree-activation', () => ({
+      activateAndRevealWorktree: vi.fn(),
+      ensureWorktreeHasInitialTerminal: vi.fn()
+    }))
+    vi.doMock('@/components/sidebar/visible-worktrees', () => ({
+      getVisibleWorktreeIds: () => []
+    }))
+    vi.doMock('@/lib/editor-font-zoom', () => ({
+      nextEditorFontZoomLevel: vi.fn(() => 0),
+      computeEditorFontSize: vi.fn(() => 13)
+    }))
+    vi.doMock('@/components/settings/SettingsConstants', () => ({
+      zoomLevelToPercent: vi.fn(() => 120),
+      ZOOM_STEP: 0.5,
+      ZOOM_MIN: -3,
+      ZOOM_MAX: 3
+    }))
+    vi.doMock('@/lib/zoom-events', () => ({ dispatchZoomLevelChanged: vi.fn() }))
+
+    const makeEvents = (target: Record<string, unknown> = {}): Record<string, unknown> =>
+      new Proxy(target, {
+        get: (namespace, prop) => {
+          if (prop in namespace) {
+            return Reflect.get(namespace, prop)
+          }
+          return () => () => {}
+        }
+      })
+    vi.stubGlobal('document', {
+      activeElement: makeTarget({})
+    })
+
+    vi.stubGlobal('window', {
+      dispatchEvent: vi.fn(),
+      setTimeout: vi.fn(() => 1),
+      clearTimeout: vi.fn(),
+      api: {
+        repos: makeEvents(),
+        worktrees: makeEvents(),
+        keybindings: makeEvents(),
+        settings: makeEvents(),
+        updater: {
+          getStatus: () => Promise.resolve({ state: 'idle' }),
+          onStatus: () => () => {},
+          onClearDismissal: () => () => {}
+        },
+        browser: makeEvents(),
+        rateLimits: {
+          get: () => Promise.resolve({ limits: {}, lastUpdatedAt: Date.now() }),
+          onUpdate: () => () => {}
+        },
+        ssh: {
+          listTargets: () => Promise.resolve([]),
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
+          getState: () => Promise.resolve(null),
+          onStateChanged: () => () => {},
+          onCredentialRequest: () => () => {},
+          onCredentialResolved: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {}
+        },
+        runtime: {
+          getTerminalFitOverrides: () => Promise.resolve([]),
+          getTerminalDrivers: () => Promise.resolve([]),
+          getBrowserDrivers: () => Promise.resolve([]),
+          onTerminalFitOverrideChanged: () => () => {},
+          onTerminalDriverChanged: () => () => {},
+          onBrowserDriverChanged: () => () => {}
+        },
+        agentStatus: { onSet: () => () => {} },
+        ui: makeEvents({
+          onTerminalZoom: (listener: (direction: 'in' | 'out' | 'reset') => void) => {
+            terminalZoomListenerRef.current = listener
+            return () => {}
+          },
+          getZoomLevel: vi.fn(() => 0),
+          set: setUI
+        })
+      }
+    })
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    const { applyUIZoom } = await import('@/lib/ui-zoom')
+    const { dispatchZoomLevelChanged } = await import('@/lib/zoom-events')
+
+    useIpcEvents()
+    const listener = terminalZoomListenerRef.current
+    if (!listener) {
+      throw new Error('Expected terminal zoom listener to be registered')
+    }
+    listener('in')
+
+    expect(applyUIZoom).toHaveBeenCalledWith(0.5)
+    expect(setUI).toHaveBeenCalledWith({ uiZoomLevel: 0.5 })
+    expect(dispatchZoomLevelChanged).toHaveBeenCalledWith('ui', 120)
   })
 })
 

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -148,23 +148,21 @@ describe('resolveZoomTarget', () => {
     ).toBe('ui')
   })
 
-  it('routes to browser zoom for active browser tabs before stale DOM focus', () => {
+  it('routes to ui zoom for active browser tabs before stale DOM focus', () => {
     expect(
       resolveZoomTarget({
         activeView: 'terminal',
         activeTabType: 'browser',
-        activeBrowserPageId: 'page-1',
         activeElement: makeTarget({ editorClosest: true, hasXtermClass: true })
       })
-    ).toBe('browser')
+    ).toBe('ui')
   })
 
-  it('does not route to browser zoom without an active browser page', () => {
+  it('routes to ui zoom for browser tabs without an active browser page', () => {
     expect(
       resolveZoomTarget({
         activeView: 'terminal',
         activeTabType: 'browser',
-        activeBrowserPageId: null,
         activeElement: makeTarget({})
       })
     ).toBe('ui')
@@ -177,11 +175,10 @@ describe('useIpcEvents zoom routing', () => {
     vi.unstubAllGlobals()
   })
 
-  it('dispatches browser page zoom without applying or persisting UI zoom', async () => {
+  it('applies app zoom for an active browser tab', async () => {
     const terminalZoomListenerRef: {
       current: ((direction: 'in' | 'out' | 'reset') => void) | null
     } = { current: null }
-    const dispatchEvent = vi.fn()
     const setUI = vi.fn()
 
     vi.doMock('react', async () => {
@@ -245,7 +242,8 @@ describe('useIpcEvents zoom routing', () => {
       computeEditorFontSize: vi.fn(() => 13)
     }))
     vi.doMock('@/components/settings/SettingsConstants', () => ({
-      zoomLevelToPercent: vi.fn(() => 100),
+      zoomLevelToPercent: vi.fn(() => 120),
+      ZOOM_STEP: 0.5,
       ZOOM_MIN: -3,
       ZOOM_MAX: 3
     }))
@@ -265,7 +263,7 @@ describe('useIpcEvents zoom routing', () => {
     })
 
     vi.stubGlobal('window', {
-      dispatchEvent,
+      dispatchEvent: vi.fn(),
       setTimeout: vi.fn(() => 1),
       clearTimeout: vi.fn(),
       api: {
@@ -323,19 +321,10 @@ describe('useIpcEvents zoom routing', () => {
     if (!listener) {
       throw new Error('Expected terminal zoom listener to be registered')
     }
-    listener('reset')
+    listener('in')
 
-    expect(dispatchEvent).toHaveBeenCalledTimes(1)
-    const event = dispatchEvent.mock.calls[0]?.[0] as CustomEvent<{
-      browserPageId: string
-      direction: string
-    }>
-    expect(event.type).toBe('orca:browser-page-zoom')
-    expect(event.detail).toEqual({ browserPageId: 'page-1', direction: 'reset' })
-    expect(applyUIZoom).not.toHaveBeenCalled()
-    expect(setUI).not.toHaveBeenCalledWith(
-      expect.objectContaining({ uiZoomLevel: expect.anything() })
-    )
+    expect(applyUIZoom).toHaveBeenCalledWith(0.5)
+    expect(setUI).toHaveBeenCalledWith({ uiZoomLevel: 0.5 })
   })
 
   it('applies app zoom for an active terminal tab after terminal focus is released', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -72,7 +72,6 @@ import {
   setDriverForBrowserPage
 } from '@/lib/pane-manager/browser-mobile-driver-state'
 import { destroyPersistentWebview } from '@/components/browser-pane/webview-registry'
-import { dispatchBrowserPageZoomEvent } from '@/components/browser-pane/browser-page-zoom'
 import {
   acquireBrowserAutomationVisibility,
   releaseBrowserAutomationVisibility
@@ -251,23 +250,6 @@ function getAuthoritativeDetectedWorktreeIds(state: AppState, repoId: string): S
 
 function getVisibleWorktreeIdsForRepo(state: AppState, repoId: string): Set<string> {
   return new Set((state.worktreesByRepo[repoId] ?? []).map((worktree) => worktree.id))
-}
-
-function resolveActiveBrowserPageId(state: AppState): string | null {
-  const worktreeId = state.activeWorktreeId
-  if (!worktreeId) {
-    return null
-  }
-  const activeWorkspaceId =
-    state.activeBrowserTabIdByWorktree[worktreeId] ?? state.activeBrowserTabId ?? null
-  const browserWorkspaces = state.browserTabsByWorktree[worktreeId] ?? []
-  const workspace =
-    browserWorkspaces.find((candidate) => candidate.id === activeWorkspaceId) ?? null
-  if (!workspace) {
-    return null
-  }
-  const pages = state.browserPagesByWorkspace[workspace.id] ?? []
-  return workspace.activePageId ?? workspace.pageIds?.[0] ?? pages[0]?.id ?? null
 }
 
 function activateTerminalInitiatedWorktree(store: AppState, worktreeId: string): void {
@@ -2661,21 +2643,12 @@ export function useIpcEvents(): void {
         const store = useAppStore.getState()
         const { activeView, activeTabType, editorFontZoomLevel, setEditorFontZoomLevel, settings } =
           store
-        const activeBrowserPageId = resolveActiveBrowserPageId(store)
         const target = resolveZoomTarget({
           activeView,
           activeTabType,
-          activeBrowserPageId,
           activeElement: document.activeElement
         })
         if (target === 'terminal') {
-          return
-        }
-        if (target === 'browser') {
-          if (!activeBrowserPageId) {
-            return
-          }
-          dispatchBrowserPageZoomEvent({ browserPageId: activeBrowserPageId, direction })
           return
         }
         if (target === 'editor') {


### PR DESCRIPTION
## Summary

- Tracks regular terminal input focus as the owner of terminal font zoom.
- Releases that ownership when the user clicks app chrome, empty tab-group space, the right sidebar header, or other outside surfaces, so the next Cmd/Ctrl +/- zoom event adjusts the app UI.
- Keeps terminal font zoom scoped to the pane that owns the focused xterm helper textarea.

## Design And Review

- Design approach: make terminal zoom focus-owned instead of tab-owned, mirror regular terminal focus to the main-process shortcut context and a root DOM attribute, and temporarily make drag-region chrome observable while xterm owns focus so the first click can release ownership.
- Design review: completed clean after the doc was tightened around focus ownership, drag-region behavior, cross-platform shortcut handling, SSH/runtime implications, and validation.
- Implementation deviations: the top chrome drag styles moved from inline `WebkitAppRegion` to a CSS data attribute so the focused-terminal `no-drag` override can win.

## Verification

- Completeness verification: clean after gating terminal font zoom to the pane that owns the focused xterm helper and after adding release behavior for chrome/sidebar/tab-row clicks.
- Performance audit: clean. Touched hot paths are pointer/focus listeners on mounted terminal panes and zoom event handling; deterministic tests cover listener cleanup/ownership behavior. Accepted residual risk is bounded listener fanout across mounted panes.
- Code review: two review rounds. Latest round had one staging-hygiene note about untracked new files and one clean review; the files are included in this commit.

## Product Validation

- Merge-confidence validation verdict: land.
- Live Electron validation attached to the dev app on branch `brennanb2025/reset-terminal-zoom` with `demo-project` active.
- Verified terminal focus sets `data-regular-terminal-input-focused` and focuses `TEXTAREA.xterm-helper-textarea`.
- Verified clicks on right sidebar/header, tab-row release surface, and 4px top drag strip clear terminal ownership; refocusing the terminal restores ownership.
- Console check: 0 errors, 1 unrelated dev warning.
- Screenshot evidence captured locally: `.playwright-cli/page-2026-06-24T22-23-16-741Z.png`.

## Checks

- `git diff --check`
- `pnpm exec oxlint` on touched files
- `pnpm run typecheck`
- `pnpm run lint`
- Focused Vitest:
  - Browser guest zoom forwarding: `browser-guest-ui.test.ts`, `browser-manager.test.ts`, and `useIpcEvents.test.ts` `regular-terminal-focus-ownership.test.ts`, `useTerminalFontZoom.test.ts`, `useIpcEvents.test.ts`, `createMainWindow.test.ts`, `window-shortcut-policy.test.ts`, `TabGroupSplitLayout.test.ts`, `TabGroupPanel.context-menu.test.ts`, `right-sidebar-titlebar-drag-regions.render.test.tsx` (8 files, 176 tests passed)
- Additional merge-confidence focused suites: 4 zoom/focus files (128 tests) and neighboring focus/chrome suites (72 tests)

## Assumptions And Gaps

- Native shortcut injection could not be completed in this environment: CDP key events did not trigger app zoom and macOS System Events was blocked with `Not authorized to send Apple events to System Events. (-1743)`.
- This is not considered blocking because deterministic tests cover native shortcut dispatch to `terminal:zoom` and renderer routing from released terminal focus to app UI zoom, while live Electron validation proves the focus-release state transition in the running app.
- Post-PR stabilization: waited 8 minutes after opening the PR, fixed CodeRabbit's actionable cleanup finding in `7d56c278a`, and later added `2974f7703` so focused browser guests forward keyboard zoom to app zoom instead of browser page zoom. Waited 8 minutes after each push; refreshed CodeRabbit reported no actionable comments, and final `gh pr checks` reports `verify` passing.

Made with [Orca](https://github.com/stablyai/orca) 🐋



