### PR TITLE
feat(cli): make the CLI self-correcting and self-describing for agents

### DIFF
--- a/src/cli/agent-context.test.ts
+++ b/src/cli/agent-context.test.ts
@@ -40,6 +40,15 @@ describe('buildAgentContext', () => {
     ])
   })
 
+  it('reports effective flags including globals, not just allowedFlags', () => {
+    const schema = buildAgentContext(specs)
+    const rm = schema.commands.find((command) => command.command === 'worktree rm')
+    expect(rm?.flags).toContain('worktree')
+    expect(rm?.flags).toContain('force')
+    expect(rm?.flags).toContain('json')
+    expect(rm?.flags).toContain('help')
+  })
+
   it('orders commands deterministically', () => {
     const schema = buildAgentContext(specs)
     expect(schema.commands.map((command) => command.command)).toEqual([

--- a/src/cli/agent-context.test.ts
+++ b/src/cli/agent-context.test.ts
@@ -77,4 +77,17 @@ describe('agent-context over the live registry', () => {
     const schema = buildAgentContext(COMMAND_SPECS)
     expect(formatAgentContextSummary(schema)).toContain(`${schema.commandCount} commands`)
   })
+
+  it('does not advertise browser page targeting for local discovery', () => {
+    const schema = buildAgentContext(COMMAND_SPECS)
+    const agentContext = schema.commands.find((command) => command.command === 'agent-context')
+    expect(agentContext?.flags).not.toContain('page')
+  })
+
+  it('marks raw passthrough commands without synthesizing Orca flags', () => {
+    const schema = buildAgentContext(COMMAND_SPECS)
+    const claudeTeams = schema.commands.find((command) => command.command === 'claude-teams')
+    expect(claudeTeams?.argumentMode).toBe('passthrough')
+    expect(claudeTeams?.flags).toEqual([])
+  })
 })

--- a/src/cli/agent-context.test.ts
+++ b/src/cli/agent-context.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CommandSpec } from './args'
+import { buildAgentContext, formatAgentContextSummary } from './agent-context'
+import { COMMAND_SPECS } from './specs'
+
+describe('buildAgentContext', () => {
+  const specs: CommandSpec[] = [
+    {
+      path: ['worktree', 'rm'],
+      aliases: [
+        ['worktree', 'remove'],
+        ['worktree', 'delete']
+      ],
+      summary: 'Remove a worktree',
+      usage: 'orca worktree rm',
+      allowedFlags: ['worktree', 'force']
+    },
+    {
+      path: ['agent-context'],
+      summary: 'Print the schema',
+      usage: 'orca agent-context',
+      allowedFlags: []
+    }
+  ]
+
+  it('emits a versioned envelope with a command count', () => {
+    const schema = buildAgentContext(specs)
+    expect(schema.schemaVersion).toBe(1)
+    expect(schema.commandCount).toBe(2)
+    expect(schema.commands).toHaveLength(2)
+  })
+
+  it('includes resolved aliases for a command', () => {
+    const schema = buildAgentContext(specs)
+    const rm = schema.commands.find((command) => command.command === 'worktree rm')
+    expect(rm?.aliases).toEqual([
+      ['worktree', 'remove'],
+      ['worktree', 'delete']
+    ])
+  })
+
+  it('orders commands deterministically', () => {
+    const schema = buildAgentContext(specs)
+    expect(schema.commands.map((command) => command.command)).toEqual([
+      'agent-context',
+      'worktree rm'
+    ])
+  })
+
+  it('defaults optional fields to empty arrays', () => {
+    const schema = buildAgentContext(specs)
+    const agentContext = schema.commands.find((command) => command.command === 'agent-context')
+    expect(agentContext?.aliases).toEqual([])
+    expect(agentContext?.examples).toEqual([])
+  })
+})
+
+describe('agent-context over the live registry', () => {
+  it('exposes the worktree rm command with its remove/delete aliases', () => {
+    const schema = buildAgentContext(COMMAND_SPECS)
+    const rm = schema.commands.find((command) => command.command === 'worktree rm')
+    expect(rm).toBeDefined()
+    expect(rm?.aliases).toContainEqual(['worktree', 'remove'])
+  })
+
+  it('human summary count matches the command count', () => {
+    const schema = buildAgentContext(COMMAND_SPECS)
+    expect(formatAgentContextSummary(schema)).toContain(`${schema.commandCount} commands`)
+  })
+})

--- a/src/cli/agent-context.ts
+++ b/src/cli/agent-context.ts
@@ -1,4 +1,5 @@
 import type { CommandSpec } from './args'
+import { effectiveAllowedFlags } from './args'
 
 // Why: introspection layer 2 — a machine-readable dump of the whole command
 // surface so an agent with no skill loaded can discover the real verbs, aliases,
@@ -33,7 +34,9 @@ export function buildAgentContext(specs: CommandSpec[]): AgentContextSchema {
       aliases: spec.aliases ?? [],
       summary: spec.summary,
       usage: spec.usage,
-      flags: spec.allowedFlags,
+      // Why: the effective accepted set (globals + conditional --page), not just
+      // allowedFlags — otherwise agents treat --json/--help as unsupported.
+      flags: effectiveAllowedFlags(spec),
       positionalArgs: spec.positionalArgs ?? [],
       examples: spec.examples ?? [],
       notes: spec.notes ?? []

--- a/src/cli/agent-context.ts
+++ b/src/cli/agent-context.ts
@@ -1,0 +1,57 @@
+import type { CommandSpec } from './args'
+
+// Why: introspection layer 2 — a machine-readable dump of the whole command
+// surface so an agent with no skill loaded can discover the real verbs, aliases,
+// and flags in one call. It serializes the live spec table (the single source of
+// truth), so the schema never drifts from actual behavior.
+
+const SCHEMA_VERSION = 1
+
+export type AgentContextCommand = {
+  command: string
+  path: string[]
+  aliases: string[][]
+  summary: string
+  usage: string
+  flags: string[]
+  positionalArgs: string[]
+  examples: string[]
+  notes: string[]
+}
+
+export type AgentContextSchema = {
+  schemaVersion: number
+  commandCount: number
+  commands: AgentContextCommand[]
+}
+
+export function buildAgentContext(specs: CommandSpec[]): AgentContextSchema {
+  const commands = specs
+    .map((spec) => ({
+      command: spec.path.join(' '),
+      path: spec.path,
+      aliases: spec.aliases ?? [],
+      summary: spec.summary,
+      usage: spec.usage,
+      flags: spec.allowedFlags,
+      positionalArgs: spec.positionalArgs ?? [],
+      examples: spec.examples ?? [],
+      notes: spec.notes ?? []
+    }))
+    // Why: deterministic ordering so the JSON diffs cleanly across runs.
+    .sort((a, b) => a.command.localeCompare(b.command))
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    commandCount: commands.length,
+    commands
+  }
+}
+
+export function formatAgentContextSummary(schema: AgentContextSchema): string {
+  // Why: keep the default (human) output bounded — the full surface is large, so
+  // point the reader at --json rather than dumping every command.
+  return [
+    `${schema.commandCount} commands (schema v${schema.schemaVersion}).`,
+    'Run `orca agent-context --json` for the full machine-readable command schema.'
+  ].join('\n')
+}

--- a/src/cli/agent-context.ts
+++ b/src/cli/agent-context.ts
@@ -1,10 +1,8 @@
 import type { CommandSpec } from './args'
 import { effectiveAllowedFlags } from './args'
 
-// Why: introspection layer 2 — a machine-readable dump of the whole command
-// surface so an agent with no skill loaded can discover the real verbs, aliases,
-// and flags in one call. It serializes the live spec table (the single source of
-// truth), so the schema never drifts from actual behavior.
+// Why: serialize the live spec table so agent discovery cannot drift from the
+// command surface it describes.
 
 const SCHEMA_VERSION = 1
 
@@ -12,6 +10,7 @@ export type AgentContextCommand = {
   command: string
   path: string[]
   aliases: string[][]
+  argumentMode: 'parsed' | 'passthrough'
   summary: string
   usage: string
   flags: string[]
@@ -32,6 +31,7 @@ export function buildAgentContext(specs: CommandSpec[]): AgentContextSchema {
       command: spec.path.join(' '),
       path: spec.path,
       aliases: spec.aliases ?? [],
+      argumentMode: spec.argumentMode ?? 'parsed',
       summary: spec.summary,
       usage: spec.usage,
       // Why: the effective accepted set (globals + conditional --page), not just

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
+import type { CommandSpec } from './args'
 import {
   REPEATED_FLAG_SEPARATOR,
+  findCommandSpec,
   normalizeCommandPositionals,
   parseArgs,
   supportsBrowserPageFlag,
@@ -94,6 +96,67 @@ describe('parseArgs', () => {
   })
 })
 
+describe('command aliases', () => {
+  const specs: CommandSpec[] = [
+    {
+      path: ['worktree', 'rm'],
+      aliases: [
+        ['worktree', 'remove'],
+        ['worktree', 'delete']
+      ],
+      summary: 'Remove a worktree',
+      usage: 'orca worktree rm --worktree <selector>',
+      allowedFlags: ['worktree', 'force']
+    },
+    {
+      path: ['repo', 'show'],
+      summary: 'Show a repo',
+      usage: 'orca repo show --repo <selector>',
+      allowedFlags: ['repo'],
+      positionalArgs: ['repo']
+    }
+  ]
+
+  it('resolves an exact canonical path to its spec', () => {
+    expect(findCommandSpec(specs, ['worktree', 'rm'])?.path).toEqual(['worktree', 'rm'])
+  })
+
+  it('resolves an aliased path to the canonical spec', () => {
+    expect(findCommandSpec(specs, ['worktree', 'remove'])?.path).toEqual(['worktree', 'rm'])
+  })
+
+  it('resolves each declared alias to the canonical spec', () => {
+    expect(findCommandSpec(specs, ['worktree', 'delete'])?.path).toEqual(['worktree', 'rm'])
+  })
+
+  it('returns undefined for a path matching neither canonical nor alias', () => {
+    expect(findCommandSpec(specs, ['worktree', 'destroy'])).toBeUndefined()
+  })
+
+  it('canonicalizes an aliased command path during normalization', () => {
+    const normalized = normalizeCommandPositionals(
+      specs,
+      parseArgs(['worktree', 'remove', '--force'])
+    )
+
+    expect(normalized.commandPath).toEqual(['worktree', 'rm'])
+    expect(normalized.flags.get('force')).toBe(true)
+  })
+
+  it('leaves a canonical command path unchanged during normalization', () => {
+    const normalized = normalizeCommandPositionals(specs, parseArgs(['worktree', 'rm']))
+
+    expect(normalized.commandPath).toEqual(['worktree', 'rm'])
+  })
+
+  it('binds a trailing positional after canonicalizing the base path', () => {
+    const normalized = normalizeCommandPositionals(specs, parseArgs(['repo', 'show', 'id:abc']))
+
+    expect(normalized.commandPath).toEqual(['repo', 'show'])
+    expect(normalized.flags.get('repo')).toBe('id:abc')
+  })
+})
+
 describe('supportsBrowserPageFlag', () => {
   it('does not expose browser page targeting on orchestration commands', () => {
     expect(supportsBrowserPageFlag(['orchestration', 'send'])).toBe(false)
@@ -129,5 +192,49 @@ describe('validateCommandAndFlags', () => {
     expect(() => validateCommandAndFlags(specs, parsed)).toThrow(
       'Unknown flag --bogus for command: demo'
     )
+  })
+
+  it('enumerates valid flags and suggests a near-miss on unknown-flag errors', () => {
+    const flagSpecs: CommandSpec[] = [
+      {
+        path: ['worktree', 'rm'],
+        summary: 'Remove a worktree',
+        usage: 'orca worktree rm',
+        allowedFlags: ['worktree', 'force', 'run-hooks']
+      }
+    ]
+    const parsed = parseArgs(['worktree', 'rm', '--forcce'])
+
+    try {
+      validateCommandAndFlags(flagSpecs, parsed)
+      throw new Error('expected validateCommandAndFlags to throw')
+    } catch (error) {
+      const data = (error as { data?: { validFlags: string[]; nextSteps: string[] } }).data
+      expect(data?.validFlags).toContain('force')
+      expect(data?.validFlags).toContain('json')
+      expect(data?.nextSteps.join('\n')).toContain('--force')
+      expect(data?.nextSteps.join('\n')).toContain('Valid flags:')
+    }
+  })
+
+  it('attaches did-you-mean suggestions to unknown-command errors', () => {
+    const suggestSpecs: CommandSpec[] = [
+      {
+        path: ['worktree', 'rm'],
+        summary: 'Remove a worktree',
+        usage: 'orca worktree rm',
+        allowedFlags: []
+      }
+    ]
+    const parsed = parseArgs(['worktree', 'remov'])
+
+    try {
+      validateCommandAndFlags(suggestSpecs, parsed)
+      throw new Error('expected validateCommandAndFlags to throw')
+    } catch (error) {
+      const data = (error as { data?: { suggestions: string[]; nextSteps: string[] } }).data
+      expect(data?.suggestions).toContain('worktree rm')
+      expect(data?.nextSteps[0]).toContain('orca worktree rm')
+    }
   })
 })

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -46,6 +46,73 @@ describe('parseArgs', () => {
     expect(parsed.flags.get('url')).toBe('https://example.com')
   })
 
+  it('does not consume a command token after an unknown flag', () => {
+    const parsed = parseArgs(['--jso', 'worktree', 'list'], [['worktree', 'list']])
+
+    expect(parsed.commandPath).toEqual(['worktree', 'list'])
+    expect(parsed.flags.get('jso')).toBe(true)
+  })
+
+  it('does not consume a command token after a flag valid on another command', () => {
+    const parsed = parseArgs(['--workspace', 'worktree', 'list'], [['worktree', 'list']])
+
+    expect(parsed.commandPath).toEqual(['worktree', 'list'])
+    expect(parsed.flags.get('workspace')).toBe(true)
+  })
+
+  it('recognizes a command path with a boolean flag between its segments', () => {
+    const parsed = parseArgs(['--jso', 'worktree', '--json', 'list'], [['worktree', 'list']])
+
+    expect(parsed.commandPath).toEqual(['worktree', 'list'])
+    expect(parsed.flags.get('jso')).toBe(true)
+    expect(parsed.flags.get('json')).toBe(true)
+  })
+
+  it('recognizes a command path with a value flag between its segments', () => {
+    const parsed = parseArgs(
+      ['--jso', 'worktree', '--repo', 'id:abc', 'list'],
+      [['worktree', 'list']]
+    )
+
+    expect(parsed.commandPath).toEqual(['worktree', 'list'])
+    expect(parsed.flags.get('jso')).toBe(true)
+    expect(parsed.flags.get('repo')).toBe('id:abc')
+  })
+
+  it('still consumes a pre-command flag value before a later command path', () => {
+    const parsed = parseArgs(['--workspace', 'team-1', 'linear', 'list'], [['linear', 'list']])
+
+    expect(parsed.commandPath).toEqual(['linear', 'list'])
+    expect(parsed.flags.get('workspace')).toBe('team-1')
+  })
+
+  it('preserves existing pre-command selector values', () => {
+    const parsed = parseArgs(['--repo', 'id:abc', 'worktree', 'list'], [['worktree', 'list']])
+
+    expect(parsed.commandPath).toEqual(['worktree', 'list'])
+    expect(parsed.flags.get('repo')).toBe('id:abc')
+  })
+
+  it('preserves a selector value that is also a registered command', () => {
+    const parsed = parseArgs(
+      ['--environment', 'status', 'worktree', 'list'],
+      [['status'], ['worktree', 'list']]
+    )
+
+    expect(parsed.commandPath).toEqual(['worktree', 'list'])
+    expect(parsed.flags.get('environment')).toBe('status')
+  })
+
+  it('preserves a selector value that is also a command group', () => {
+    const parsed = parseArgs(
+      ['--environment', 'worktree', 'status'],
+      [['status'], ['worktree', 'list']]
+    )
+
+    expect(parsed.commandPath).toEqual(['status'])
+    expect(parsed.flags.get('environment')).toBe('worktree')
+  })
+
   it('parses emulator reinstall as a boolean flag', () => {
     const parsed = parseArgs(['emulator', 'install', 'app.apk', '--reinstall', '--device', 'emu'])
 
@@ -161,6 +228,10 @@ describe('supportsBrowserPageFlag', () => {
   it('does not expose browser page targeting on orchestration commands', () => {
     expect(supportsBrowserPageFlag(['orchestration', 'send'])).toBe(false)
   })
+
+  it('does not expose browser page targeting on local agent discovery', () => {
+    expect(supportsBrowserPageFlag(['agent-context'])).toBe(false)
+  })
 })
 
 describe('validateCommandAndFlags', () => {
@@ -184,6 +255,18 @@ describe('validateCommandAndFlags', () => {
     ])
 
     expect(() => validateCommandAndFlags(specs, parsed)).not.toThrow()
+  })
+
+  it.each(['environment', 'pairing-code'])('rejects --%s without a value', (flag) => {
+    const parsed = parseArgs([`--${flag}`, 'demo'], [['demo']])
+
+    expect(() => validateCommandAndFlags(specs, parsed)).toThrow(`Flag --${flag} requires a value.`)
+  })
+
+  it.each(['environment', 'pairing-code'])('rejects an empty --%s= value', (flag) => {
+    const parsed = parseArgs(['demo', `--${flag}=`])
+
+    expect(() => validateCommandAndFlags(specs, parsed)).toThrow(`Flag --${flag} requires a value.`)
   })
 
   it('still rejects unknown command-specific flags', () => {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -168,6 +168,20 @@ export function supportsBrowserPageFlag(commandPath: string[]): boolean {
   ].includes(joined)
 }
 
+// Why: the flags a command actually accepts are its own allowedFlags plus the
+// always-accepted globals and the conditional --page. validateCommandAndFlags and
+// agent-context must report the same effective set so the schema doesn't
+// under-report valid flags like --json/--help.
+export function effectiveAllowedFlags(spec: CommandSpec): string[] {
+  return [
+    ...new Set([
+      ...GLOBAL_FLAGS,
+      ...spec.allowedFlags,
+      ...(supportsBrowserPageFlag(spec.path) ? ['page'] : [])
+    ])
+  ]
+}
+
 export function isCommandGroup(commandPath: string[]): boolean {
   return (
     (commandPath.length === 1 &&
@@ -206,7 +220,10 @@ export function isCommandGroup(commandPath: string[]): boolean {
 export function normalizeCommandPositionals(specs: CommandSpec[], parsed: ParsedArgs): ParsedArgs {
   for (const spec of specs) {
     const positionalArgs = spec.positionalArgs ?? []
-    if (positionalArgs.length === 0) {
+    // Why: a spec with no positionals AND no aliases has nothing to normalize.
+    // Aliased specs still fall through so an aliased path is canonicalized even
+    // when the command takes no positionals (e.g. `worktree remove` → `rm`).
+    if (positionalArgs.length === 0 && !spec.aliases) {
       continue
     }
     // Why: match against the canonical path AND any alias so an aliased
@@ -214,8 +231,10 @@ export function normalizeCommandPositionals(specs: CommandSpec[], parsed: Parsed
     // validation run. This is the single canonicalization point — dispatch then
     // keys the handler map on `spec.path`, never the alias the user typed.
     for (const base of specPaths(spec)) {
+      // Why: `< 0` (not `<= 0`) so an exact base match with zero positionals
+      // still canonicalizes an aliased path; upper bound guards over-consumption.
       const positionalCount = parsed.commandPath.length - base.length
-      if (positionalCount <= 0 || positionalCount > positionalArgs.length) {
+      if (positionalCount < 0 || positionalCount > positionalArgs.length) {
         continue
       }
       if (!matches(parsed.commandPath.slice(0, base.length), base)) {
@@ -269,13 +288,10 @@ export function validateCommandAndFlags(specs: CommandSpec[], parsed: ParsedArgs
   for (const flag of parsed.flags.keys()) {
     const isGlobalFlag = GLOBAL_FLAGS.includes(flag)
     if (!isGlobalFlag && !spec.allowedFlags.includes(flag) && !(flag === 'page' && pageAllowed)) {
-      const validFlags = [
-        ...new Set([...GLOBAL_FLAGS, ...spec.allowedFlags, ...(pageAllowed ? ['page'] : [])])
-      ]
       throw new RuntimeClientError(
         'invalid_argument',
         `Unknown flag --${flag} for command: ${spec.path.join(' ')}`,
-        unknownFlagData(flag, validFlags)
+        unknownFlagData(flag, effectiveAllowedFlags(spec))
       )
     }
   }

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,4 +1,5 @@
 import { RuntimeClientError } from './runtime-client'
+import { unknownCommandData, unknownFlagData } from './command-suggestion'
 
 export type ParsedArgs = {
   commandPath: string[]
@@ -8,6 +9,11 @@ export type ParsedArgs = {
 
 export type CommandSpec = {
   path: string[]
+  // Why: alternate command paths that resolve to this same canonical spec, so
+  // agents reaching for a conventional verb (git's `worktree remove`) succeed
+  // instead of dead-ending. Each alias is a full command path. Additive only —
+  // dispatch always keys on the canonical `path`, never the alias.
+  aliases?: string[][]
   summary: string
   usage: string
   allowedFlags: string[]
@@ -123,6 +129,12 @@ export function matches(actual: string[], expected: string[]): boolean {
   )
 }
 
+// Why: a spec is reachable by its canonical path plus any declared aliases — one
+// definition so resolution, validation, help, and agent-context never disagree.
+export function specPaths(spec: CommandSpec): string[][] {
+  return spec.aliases ? [spec.path, ...spec.aliases] : [spec.path]
+}
+
 export function supportsBrowserPageFlag(commandPath: string[]): boolean {
   const joined = commandPath.join(' ')
   if (['open', 'status'].includes(commandPath[0])) {
@@ -197,26 +209,32 @@ export function normalizeCommandPositionals(specs: CommandSpec[], parsed: Parsed
     if (positionalArgs.length === 0) {
       continue
     }
-    const positionalCount = parsed.commandPath.length - spec.path.length
-    if (positionalCount <= 0 || positionalCount > positionalArgs.length) {
-      continue
-    }
-    if (!matches(parsed.commandPath.slice(0, spec.path.length), spec.path)) {
-      continue
-    }
-    const flags = new Map(parsed.flags)
-    const values = parsed.commandPath.slice(spec.path.length)
-    // Why: validation runs inside main's error-reporting path, so normalization
-    // records ambiguity instead of throwing before CLI errors can be formatted.
-    const providedPositionals = values.map((_, index) => positionalArgs[index])
-    const positionalFlagConflicts = providedPositionals.filter((name) => flags.has(name))
-    values.forEach((value, index) => {
-      const name = positionalArgs[index]
-      if (!flags.has(name)) {
-        flags.set(name, value)
+    // Why: match against the canonical path AND any alias so an aliased
+    // invocation is rewritten to the canonical path here, before dispatch and
+    // validation run. This is the single canonicalization point — dispatch then
+    // keys the handler map on `spec.path`, never the alias the user typed.
+    for (const base of specPaths(spec)) {
+      const positionalCount = parsed.commandPath.length - base.length
+      if (positionalCount <= 0 || positionalCount > positionalArgs.length) {
+        continue
       }
-    })
-    return { commandPath: spec.path, flags, positionalFlagConflicts }
+      if (!matches(parsed.commandPath.slice(0, base.length), base)) {
+        continue
+      }
+      const flags = new Map(parsed.flags)
+      const values = parsed.commandPath.slice(base.length)
+      // Why: validation runs inside main's error-reporting path, so normalization
+      // records ambiguity instead of throwing before CLI errors can be formatted.
+      const providedPositionals = values.map((_, index) => positionalArgs[index])
+      const positionalFlagConflicts = providedPositionals.filter((name) => flags.has(name))
+      values.forEach((value, index) => {
+        const name = positionalArgs[index]
+        if (!flags.has(name)) {
+          flags.set(name, value)
+        }
+      })
+      return { commandPath: spec.path, flags, positionalFlagConflicts }
+    }
   }
   return parsed
 }
@@ -225,7 +243,7 @@ export function findCommandSpec(
   specs: CommandSpec[],
   commandPath: string[]
 ): CommandSpec | undefined {
-  return specs.find((spec) => matches(spec.path, commandPath))
+  return specs.find((spec) => specPaths(spec).some((candidate) => matches(candidate, commandPath)))
 }
 
 export function validateCommandAndFlags(specs: CommandSpec[], parsed: ParsedArgs): void {
@@ -233,7 +251,8 @@ export function validateCommandAndFlags(specs: CommandSpec[], parsed: ParsedArgs
   if (!spec) {
     throw new RuntimeClientError(
       'invalid_argument',
-      `Unknown command: ${parsed.commandPath.join(' ')}`
+      `Unknown command: ${parsed.commandPath.join(' ')}`,
+      unknownCommandData(specs, parsed.commandPath)
     )
   }
 
@@ -246,16 +265,17 @@ export function validateCommandAndFlags(specs: CommandSpec[], parsed: ParsedArgs
     )
   }
 
+  const pageAllowed = supportsBrowserPageFlag(spec.path)
   for (const flag of parsed.flags.keys()) {
     const isGlobalFlag = GLOBAL_FLAGS.includes(flag)
-    if (
-      !isGlobalFlag &&
-      !spec.allowedFlags.includes(flag) &&
-      !(flag === 'page' && supportsBrowserPageFlag(spec.path))
-    ) {
+    if (!isGlobalFlag && !spec.allowedFlags.includes(flag) && !(flag === 'page' && pageAllowed)) {
+      const validFlags = [
+        ...new Set([...GLOBAL_FLAGS, ...spec.allowedFlags, ...(pageAllowed ? ['page'] : [])])
+      ]
       throw new RuntimeClientError(
         'invalid_argument',
-        `Unknown flag --${flag} for command: ${spec.path.join(' ')}`
+        `Unknown flag --${flag} for command: ${spec.path.join(' ')}`,
+        unknownFlagData(flag, validFlags)
       )
     }
   }

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -9,11 +9,10 @@ export type ParsedArgs = {
 
 export type CommandSpec = {
   path: string[]
-  // Why: alternate command paths that resolve to this same canonical spec, so
-  // agents reaching for a conventional verb (git's `worktree remove`) succeed
-  // instead of dead-ending. Each alias is a full command path. Additive only —
-  // dispatch always keys on the canonical `path`, never the alias.
+  // Why: conventional alternate verbs should resolve without duplicating specs
+  // or handler registrations.
   aliases?: string[][]
+  argumentMode?: 'parsed' | 'passthrough'
   summary: string
   usage: string
   allowedFlags: string[]
@@ -23,6 +22,7 @@ export type CommandSpec = {
 }
 
 export const GLOBAL_FLAGS = ['help', 'json', 'pairing-code', 'environment']
+const GLOBAL_VALUE_FLAGS = new Set(['pairing-code', 'environment'])
 export const BOOLEAN_FLAGS = new Set([
   'all',
   'attachments',
@@ -74,7 +74,23 @@ function setFlagValue(flags: Map<string, string | boolean>, name: string, value:
   flags.set(name, value)
 }
 
-export function parseArgs(argv: string[]): ParsedArgs {
+function commandPathStartsAt(argv: string[], tokenIndex: number, path: string[]): boolean {
+  let cursor = tokenIndex
+  for (const part of path) {
+    while (argv[cursor]?.startsWith('--')) {
+      const assignment = argv[cursor].slice(2)
+      const flag = assignment.split('=', 1)[0]
+      cursor += assignment.includes('=') || BOOLEAN_FLAGS.has(flag) ? 1 : 2
+    }
+    if (argv[cursor] !== part) {
+      return false
+    }
+    cursor += 1
+  }
+  return true
+}
+
+export function parseArgs(argv: string[], commandPaths?: readonly string[][]): ParsedArgs {
   const commandPath: string[] = []
   const flags = new Map<string, string | boolean>()
 
@@ -97,6 +113,13 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
     const flag = assignment
     if (BOOLEAN_FLAGS.has(flag)) {
+      flags.set(flag, true)
+      continue
+    }
+    // Why: a pre-command flag must not consume a registry-resolvable command path.
+    const startsCommandAt = (tokenIndex: number): boolean =>
+      commandPaths?.some((path) => commandPathStartsAt(argv, tokenIndex, path)) ?? false
+    if (commandPath.length === 0 && startsCommandAt(i + 1) && !startsCommandAt(i + 2)) {
       flags.set(flag, true)
       continue
     }
@@ -153,7 +176,8 @@ export function supportsBrowserPageFlag(commandPath: string[]): boolean {
       'emulator',
       'note',
       'diagnostics',
-      'linear'
+      'linear',
+      'agent-context'
     ].includes(commandPath[0])
   ) {
     return false
@@ -168,11 +192,11 @@ export function supportsBrowserPageFlag(commandPath: string[]): boolean {
   ].includes(joined)
 }
 
-// Why: the flags a command actually accepts are its own allowedFlags plus the
-// always-accepted globals and the conditional --page. validateCommandAndFlags and
-// agent-context must report the same effective set so the schema doesn't
-// under-report valid flags like --json/--help.
+// Why: validation and agent discovery must expose the same effective flag set.
 export function effectiveAllowedFlags(spec: CommandSpec): string[] {
+  if (spec.argumentMode === 'passthrough') {
+    return []
+  }
   return [
     ...new Set([
       ...GLOBAL_FLAGS,
@@ -220,16 +244,11 @@ export function isCommandGroup(commandPath: string[]): boolean {
 export function normalizeCommandPositionals(specs: CommandSpec[], parsed: ParsedArgs): ParsedArgs {
   for (const spec of specs) {
     const positionalArgs = spec.positionalArgs ?? []
-    // Why: a spec with no positionals AND no aliases has nothing to normalize.
-    // Aliased specs still fall through so an aliased path is canonicalized even
-    // when the command takes no positionals (e.g. `worktree remove` → `rm`).
+    // Why: aliased paths still need canonicalization when there are no positionals.
     if (positionalArgs.length === 0 && !spec.aliases) {
       continue
     }
-    // Why: match against the canonical path AND any alias so an aliased
-    // invocation is rewritten to the canonical path here, before dispatch and
-    // validation run. This is the single canonicalization point — dispatch then
-    // keys the handler map on `spec.path`, never the alias the user typed.
+    // Why: canonicalize aliases before validation and dispatch so both use one key.
     for (const base of specPaths(spec)) {
       // Why: `< 0` (not `<= 0`) so an exact base match with zero positionals
       // still canonicalizes an aliased path; upper bound guards over-consumption.
@@ -285,8 +304,11 @@ export function validateCommandAndFlags(specs: CommandSpec[], parsed: ParsedArgs
   }
 
   const pageAllowed = supportsBrowserPageFlag(spec.path)
-  for (const flag of parsed.flags.keys()) {
+  for (const [flag, value] of parsed.flags) {
     const isGlobalFlag = GLOBAL_FLAGS.includes(flag)
+    if (GLOBAL_VALUE_FLAGS.has(flag) && (typeof value !== 'string' || value.length === 0)) {
+      throw new RuntimeClientError('invalid_argument', `Flag --${flag} requires a value.`)
+    }
     if (!isGlobalFlag && !spec.allowedFlags.includes(flag) && !(flag === 'page' && pageAllowed)) {
       throw new RuntimeClientError(
         'invalid_argument',

--- a/src/cli/command-suggestion.test.ts
+++ b/src/cli/command-suggestion.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CommandSpec } from './args'
+import { levenshtein, suggestCommands, unknownCommandData } from './command-suggestion'
+
+const specs: CommandSpec[] = [
+  {
+    path: ['worktree', 'rm'],
+    aliases: [['worktree', 'remove']],
+    summary: 'Remove a worktree',
+    usage: 'orca worktree rm',
+    allowedFlags: []
+  },
+  {
+    path: ['worktree', 'list'],
+    summary: 'List worktrees',
+    usage: 'orca worktree list',
+    allowedFlags: []
+  },
+  {
+    path: ['terminal', 'send'],
+    summary: 'Send input',
+    usage: 'orca terminal send',
+    allowedFlags: []
+  }
+]
+
+describe('levenshtein', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshtein('rm', 'rm')).toBe(0)
+  })
+
+  it('counts single-edit distance', () => {
+    expect(levenshtein('remov', 'remove')).toBe(1)
+  })
+
+  it('handles empty operands', () => {
+    expect(levenshtein('', 'abc')).toBe(3)
+    expect(levenshtein('abc', '')).toBe(3)
+  })
+})
+
+describe('suggestCommands', () => {
+  it('suggests the closest command for a near-miss verb', () => {
+    expect(suggestCommands(specs, ['worktree', 'remov'])).toContain('worktree rm')
+  })
+
+  it('includes alias paths among suggestions', () => {
+    // `worktree remove` is the alias; a typo near it should surface it (an exact
+    // match would resolve as a real command, not trigger a suggestion).
+    expect(suggestCommands(specs, ['worktree', 'remov'])).toContain('worktree remove')
+  })
+
+  it('returns nothing for a wildly-off token', () => {
+    expect(suggestCommands(specs, ['worktree', 'zzzzz'])).toEqual([])
+  })
+
+  it('only considers commands of the same depth', () => {
+    expect(suggestCommands(specs, ['worktree'])).toEqual([])
+  })
+
+  it('ranks closer matches first', () => {
+    const result = suggestCommands(specs, ['terminal', 'sen'])
+    expect(result[0]).toBe('terminal send')
+  })
+})
+
+describe('unknownCommandData', () => {
+  it('produces a human nextSteps line when a suggestion exists', () => {
+    const data = unknownCommandData(specs, ['worktree', 'remov'])
+    expect(data.suggestions).toContain('worktree rm')
+    expect(data.nextSteps[0]).toContain('Did you mean')
+    expect(data.nextSteps[0]).toContain('orca worktree rm')
+  })
+
+  it('produces empty nextSteps when nothing is close', () => {
+    const data = unknownCommandData(specs, ['worktree', 'zzzzz'])
+    expect(data.suggestions).toEqual([])
+    expect(data.nextSteps).toEqual([])
+  })
+})

--- a/src/cli/command-suggestion.test.ts
+++ b/src/cli/command-suggestion.test.ts
@@ -56,7 +56,11 @@ describe('suggestCommands', () => {
   })
 
   it('only considers commands of the same depth', () => {
-    expect(suggestCommands(specs, ['worktree'])).toEqual([])
+    expect(suggestCommands(specs, ['worktree', 'list', 'extra'])).toEqual([])
+  })
+
+  it('suggests a top-level command group near-miss', () => {
+    expect(suggestCommands(specs, ['worktre'])).toEqual(['worktree'])
   })
 
   it('ranks closer matches first', () => {

--- a/src/cli/command-suggestion.ts
+++ b/src/cli/command-suggestion.ts
@@ -1,0 +1,106 @@
+import type { CommandSpec } from './args'
+import { specPaths } from './args'
+
+// Why: an unknown command is a dead end for an agent unless the error names the
+// real command. Suggestions are ranked by edit distance over the actual command
+// registry (canonical paths plus aliases), so they never drift from reality.
+
+const SUGGESTION_THRESHOLD = 3
+const MAX_SUGGESTIONS = 3
+
+export type CommandErrorData = {
+  suggestions: string[]
+  nextSteps: string[]
+}
+
+export function levenshtein(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  if (m === 0) {
+    return n
+  }
+  if (n === 0) {
+    return m
+  }
+  let prev = Array.from({ length: n + 1 }, (_, index) => index)
+  let curr = Array.from({ length: n + 1 }, () => 0)
+  for (let i = 1; i <= m; i += 1) {
+    curr[0] = i
+    for (let j = 1; j <= n; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+    }
+    const swap = prev
+    prev = curr
+    curr = swap
+  }
+  return prev[n]
+}
+
+// Why: keep only near matches (within the edit-distance threshold, excluding the
+// exact input), closest first, capped — the shared ranking for both command and
+// flag suggestions.
+function rankByDistance(scored: { label: string; distance: number }[]): string[] {
+  return scored
+    .filter((entry) => entry.distance > 0 && entry.distance <= SUGGESTION_THRESHOLD)
+    .sort((a, b) => a.distance - b.distance || a.label.localeCompare(b.label))
+    .slice(0, MAX_SUGGESTIONS)
+    .map((entry) => entry.label)
+}
+
+// Why: only compare against commands of the same depth (segment count). A typo is
+// almost always in one segment, not a missing/extra one, and same-depth matching
+// avoids suggesting a parent group or an unrelated longer command.
+export function suggestCommands(specs: CommandSpec[], commandPath: string[]): string[] {
+  const input = commandPath.join(' ')
+  const seen = new Set<string>()
+  const scored: { label: string; distance: number }[] = []
+  for (const spec of specs) {
+    for (const candidate of specPaths(spec)) {
+      if (candidate.length !== commandPath.length) {
+        continue
+      }
+      const joined = candidate.join(' ')
+      if (seen.has(joined)) {
+        continue
+      }
+      seen.add(joined)
+      scored.push({ label: joined, distance: levenshtein(input, joined) })
+    }
+  }
+  return rankByDistance(scored)
+}
+
+export function unknownCommandData(specs: CommandSpec[], commandPath: string[]): CommandErrorData {
+  const suggestions = suggestCommands(specs, commandPath)
+  const nextSteps = suggestions.length
+    ? [`Did you mean: ${suggestions.map((path) => `orca ${path}`).join(', ')}`]
+    : []
+  return { suggestions, nextSteps }
+}
+
+export type FlagErrorData = {
+  validFlags: string[]
+  suggestions: string[]
+  nextSteps: string[]
+}
+
+function suggestFlags(flag: string, validFlags: string[]): string[] {
+  return rankByDistance(
+    validFlags.map((candidate) => ({ label: candidate, distance: levenshtein(flag, candidate) }))
+  )
+}
+
+// Why: a rejected flag should tell the agent what the command DOES accept, so it
+// can correct without a separate `--help` round-trip. `validFlags` is the exact
+// set validation accepts (command flags, globals, and the conditional --page).
+export function unknownFlagData(flag: string, validFlags: string[]): FlagErrorData {
+  const sortedValid = [...validFlags].sort((a, b) => a.localeCompare(b))
+  const suggestions = suggestFlags(flag, sortedValid)
+  const nextSteps: string[] = []
+  if (suggestions.length > 0) {
+    nextSteps.push(`Did you mean: ${suggestions.map((name) => `--${name}`).join(', ')}`)
+  }
+  nextSteps.push(`Valid flags: ${sortedValid.map((name) => `--${name}`).join(', ')}`)
+  return { validFlags: sortedValid, suggestions, nextSteps }
+}

--- a/src/cli/command-suggestion.ts
+++ b/src/cli/command-suggestion.ts
@@ -1,9 +1,7 @@
 import type { CommandSpec } from './args'
 import { specPaths } from './args'
 
-// Why: an unknown command is a dead end for an agent unless the error names the
-// real command. Suggestions are ranked by edit distance over the actual command
-// registry (canonical paths plus aliases), so they never drift from reality.
+// Why: rank the live registry so typo recovery cannot drift from accepted paths.
 
 const SUGGESTION_THRESHOLD = 3
 const MAX_SUGGESTIONS = 3
@@ -37,9 +35,7 @@ export function levenshtein(a: string, b: string): number {
   return prev[n]
 }
 
-// Why: keep only near matches (within the edit-distance threshold, excluding the
-// exact input), closest first, capped — the shared ranking for both command and
-// flag suggestions.
+// Why: one bounded near-match ranking keeps command and flag recovery consistent.
 function rankByDistance(scored: { label: string; distance: number }[]): string[] {
   return scored
     .filter((entry) => entry.distance > 0 && entry.distance <= SUGGESTION_THRESHOLD)
@@ -48,15 +44,16 @@ function rankByDistance(scored: { label: string; distance: number }[]): string[]
     .map((entry) => entry.label)
 }
 
-// Why: only compare against commands of the same depth (segment count). A typo is
-// almost always in one segment, not a missing/extra one, and same-depth matching
-// avoids suggesting a parent group or an unrelated longer command.
+// Why: same-depth matching avoids suggesting parent groups or unrelated commands.
 export function suggestCommands(specs: CommandSpec[], commandPath: string[]): string[] {
   const input = commandPath.join(' ')
   const seen = new Set<string>()
   const scored: { label: string; distance: number }[] = []
   for (const spec of specs) {
-    for (const candidate of specPaths(spec)) {
+    const candidates = specPaths(spec).map((path) =>
+      commandPath.length === 1 ? path.slice(0, 1) : path
+    )
+    for (const candidate of candidates) {
       if (candidate.length !== commandPath.length) {
         continue
       }
@@ -91,9 +88,7 @@ function suggestFlags(flag: string, validFlags: string[]): string[] {
   )
 }
 
-// Why: a rejected flag should tell the agent what the command DOES accept, so it
-// can correct without a separate `--help` round-trip. `validFlags` is the exact
-// set validation accepts (command flags, globals, and the conditional --page).
+// Why: include the accepted set so agents can recover without another help call.
 export function unknownFlagData(flag: string, validFlags: string[]): FlagErrorData {
   const sortedValid = [...validFlags].sort((a, b) => a.localeCompare(b))
   const suggestions = suggestFlags(flag, sortedValid)

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -20,6 +20,7 @@ import { COMPUTER_HANDLERS } from './handlers/computer'
 import { ENVIRONMENT_HANDLERS } from './handlers/environment'
 import { AGENT_HOOK_HANDLERS } from './handlers/agent-hooks'
 import { DIAGNOSTICS_HANDLERS } from './handlers/diagnostics'
+import { INTROSPECTION_HANDLERS } from './handlers/introspection'
 import { EMULATOR_HANDLERS } from './handlers/emulator'
 import { LINEAR_HANDLERS } from './handlers/linear'
 import { VM_HANDLERS } from './handlers/vm'
@@ -57,6 +58,7 @@ function buildHandlers(): Map<string, CommandHandler> {
     COMPUTER_HANDLERS,
     AGENT_HOOK_HANDLERS,
     DIAGNOSTICS_HANDLERS,
+    INTROSPECTION_HANDLERS,
     ENVIRONMENT_HANDLERS,
     LINEAR_HANDLERS,
     VM_HANDLERS
@@ -73,6 +75,10 @@ function buildHandlers(): Map<string, CommandHandler> {
 }
 
 const HANDLERS = buildHandlers()
+
+// Why: exposes only the canonical command keys (not the handler internals) so the
+// registry-parity guard can check specs↔handlers without rebuilding the table.
+export const HANDLER_COMMAND_KEYS: ReadonlySet<string> = new Set(HANDLERS.keys())
 
 export async function dispatch(commandPath: string[], ctx: HandlerContext): Promise<void> {
   const handler = HANDLERS.get(commandPath.join(' '))

--- a/src/cli/format-recovery.test.ts
+++ b/src/cli/format-recovery.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatCliError } from './format'
+import { RuntimeClientError, RuntimeRpcFailureError } from './runtime-client'
+
+describe('CLI error recovery', () => {
+  it('prints did-you-mean next steps for an unknown-command error carrying data', () => {
+    const error = new RuntimeClientError('invalid_argument', 'Unknown command: worktree remov', {
+      suggestions: ['worktree rm'],
+      nextSteps: ['Did you mean: orca worktree rm']
+    })
+
+    const output = formatCliError(error)
+
+    expect(output).toContain('Unknown command: worktree remov')
+    expect(output).toContain('Next step: Did you mean: orca worktree rm')
+  })
+
+  it('prefers structured recovery over generic computer hints in text output', () => {
+    const error = new RuntimeClientError('invalid_argument', 'Unknown flag --forcce', {
+      nextSteps: ['Did you mean: --force']
+    })
+
+    const output = formatCliError(error, { commandPath: ['computer', 'click'] })
+
+    expect(output).toContain('Next step: Did you mean: --force')
+    expect(output).not.toContain('Fix the command flags or RPC params')
+  })
+
+  it('prefers RPC recovery over generic computer hints in text output', () => {
+    const error = new RuntimeRpcFailureError({
+      id: 'req_rpc_recovery',
+      ok: false,
+      error: {
+        code: 'invalid_argument',
+        message: 'Unknown runtime argument',
+        data: { nextSteps: ['Use the runtime-specific option'] }
+      },
+      _meta: { runtimeId: 'runtime_local' }
+    })
+
+    const output = formatCliError(error, { commandPath: ['computer', 'click'] })
+
+    expect(output).toContain('Next step: Use the runtime-specific option')
+    expect(output).not.toContain('Fix the command flags or RPC params')
+  })
+
+  it('keeps generic computer hints when an RPC error has no recovery data', () => {
+    const error = new RuntimeRpcFailureError({
+      id: 'req_rpc_fallback',
+      ok: false,
+      error: { code: 'invalid_argument', message: 'Invalid computer argument' },
+      _meta: { runtimeId: 'runtime_local' }
+    })
+
+    const output = formatCliError(error, { commandPath: ['computer', 'click'] })
+
+    expect(output).toContain('Fix the command flags or RPC params')
+  })
+})

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { quoteCliCommandArgument } from './shell-command-quote'
-import { RuntimeRpcFailureError } from './runtime-client'
+import { RuntimeClientError, RuntimeRpcFailureError } from './runtime-client'
 import {
   formatCliError,
   formatAutomationShow,
@@ -88,6 +88,18 @@ describe('formatCliError', () => {
     expect(output).toContain('desktop browser app/window')
     expect(output).toContain('--app <web app>')
     expect(output).not.toContain('orca goto')
+  })
+
+  it('prints did-you-mean next steps for an unknown-command error carrying data', () => {
+    const error = new RuntimeClientError('invalid_argument', 'Unknown command: worktree remov', {
+      suggestions: ['worktree rm'],
+      nextSteps: ['Did you mean: orca worktree rm']
+    })
+
+    const output = formatCliError(error)
+
+    expect(output).toContain('Unknown command: worktree remov')
+    expect(output).toContain('Next step: Did you mean: orca worktree rm')
   })
 
   it('prints runtime next steps for structured lineage errors', () => {

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { quoteCliCommandArgument } from './shell-command-quote'
-import { RuntimeClientError, RuntimeRpcFailureError } from './runtime-client'
+import { RuntimeRpcFailureError } from './runtime-client'
 import {
   formatCliError,
   formatAutomationShow,
@@ -88,18 +88,6 @@ describe('formatCliError', () => {
     expect(output).toContain('desktop browser app/window')
     expect(output).toContain('--app <web app>')
     expect(output).not.toContain('orca goto')
-  })
-
-  it('prints did-you-mean next steps for an unknown-command error carrying data', () => {
-    const error = new RuntimeClientError('invalid_argument', 'Unknown command: worktree remov', {
-      suggestions: ['worktree rm'],
-      nextSteps: ['Did you mean: orca worktree rm']
-    })
-
-    const output = formatCliError(error)
-
-    expect(output).toContain('Unknown command: worktree remov')
-    expect(output).toContain('Next step: Did you mean: orca worktree rm')
   })
 
   it('prints runtime next steps for structured lineage errors', () => {

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -90,6 +90,15 @@ export function formatCliError(error: unknown, context: CliErrorContext = {}): s
       computerUseErrorRecoveryData('invalid_argument')?.nextSteps ?? []
     )
   }
+  // Why: errors carrying a structured recovery payload (did-you-mean,
+  // valid-flag enumeration) render their nextSteps the same way computer errors
+  // do. RuntimeRpcFailureError has no `data`, so it falls through to its branch.
+  if (error instanceof RuntimeClientError) {
+    const nextSteps = nextStepsFromData(error.data)
+    if (nextSteps.length > 0) {
+      return formatMessageWithNextSteps(message, nextSteps)
+    }
+  }
   if (
     error instanceof RuntimeRpcFailureError &&
     error.response.error.code === 'runtime_unavailable'
@@ -97,14 +106,7 @@ export function formatCliError(error: unknown, context: CliErrorContext = {}): s
     return `${message}\nOrca is not running. Run 'orca open' first.`
   }
   if (error instanceof RuntimeRpcFailureError) {
-    const data = error.response.error.data
-    const nextSteps =
-      data && typeof data === 'object' && Array.isArray((data as { nextSteps?: unknown }).nextSteps)
-        ? (data as { nextSteps: unknown[] }).nextSteps.filter(
-            (step): step is string => typeof step === 'string'
-          )
-        : []
-    return formatMessageWithNextSteps(message, nextSteps)
+    return formatMessageWithNextSteps(message, nextStepsFromData(error.response.error.data))
   }
   return message
 }
@@ -140,7 +142,25 @@ function formatMessageWithNextSteps(message: string, nextSteps: readonly string[
   return `${message}\n${nextSteps.map((step) => `Next step: ${step}`).join('\n')}`
 }
 
+function nextStepsFromData(data: unknown): string[] {
+  if (
+    data &&
+    typeof data === 'object' &&
+    Array.isArray((data as { nextSteps?: unknown }).nextSteps)
+  ) {
+    return (data as { nextSteps: unknown[] }).nextSteps.filter(
+      (step): step is string => typeof step === 'string'
+    )
+  }
+  return []
+}
+
 function localCliErrorData(error: unknown, context: CliErrorContext): unknown {
+  // Why: an error's own structured payload (command/flag suggestions) wins; the
+  // computer special case stays as a fallback for errors that don't carry data.
+  if (error instanceof RuntimeClientError && error.data !== undefined) {
+    return error.data
+  }
   if (
     error instanceof RuntimeClientError &&
     error.code === 'invalid_argument' &&

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -80,23 +80,17 @@ export function formatCliError(error: unknown, context: CliErrorContext = {}): s
   if (error instanceof RuntimeClientError && error.code === 'runtime_unavailable') {
     return `${message}\nOrca is not running. Run 'orca open' first.`
   }
-  if (
-    error instanceof RuntimeClientError &&
-    error.code === 'invalid_argument' &&
-    context.commandPath?.[0] === 'computer'
-  ) {
-    return formatMessageWithNextSteps(
-      message,
-      computerUseErrorRecoveryData('invalid_argument')?.nextSteps ?? []
-    )
-  }
-  // Why: errors carrying a structured recovery payload (did-you-mean,
-  // valid-flag enumeration) render their nextSteps the same way computer errors
-  // do. RuntimeRpcFailureError has no `data`, so it falls through to its branch.
+  // Why: error-specific recovery must win over the generic computer fallback.
   if (error instanceof RuntimeClientError) {
     const nextSteps = nextStepsFromData(error.data)
     if (nextSteps.length > 0) {
       return formatMessageWithNextSteps(message, nextSteps)
+    }
+    if (error.code === 'invalid_argument' && context.commandPath?.[0] === 'computer') {
+      return formatMessageWithNextSteps(
+        message,
+        computerUseErrorRecoveryData('invalid_argument')?.nextSteps ?? []
+      )
     }
   }
   if (
@@ -156,8 +150,7 @@ function nextStepsFromData(data: unknown): string[] {
 }
 
 function localCliErrorData(error: unknown, context: CliErrorContext): unknown {
-  // Why: an error's own structured payload (command/flag suggestions) wins; the
-  // computer special case stays as a fallback for errors that don't carry data.
+  // Why: error-specific recovery must win over the generic computer fallback.
   if (error instanceof RuntimeClientError && error.data !== undefined) {
     return error.data
   }

--- a/src/cli/handlers/introspection.ts
+++ b/src/cli/handlers/introspection.ts
@@ -1,0 +1,16 @@
+import type { CommandHandler } from '../dispatch'
+import { COMMAND_SPECS } from '../specs'
+import { buildAgentContext, formatAgentContextSummary } from '../agent-context'
+
+export const INTROSPECTION_HANDLERS: Record<string, CommandHandler> = {
+  // Why: pure local command — reads the static spec registry and prints it, with
+  // no runtime RPC, so it works when the Orca app is not running (SSH/headless).
+  'agent-context': async ({ json }) => {
+    const schema = buildAgentContext(COMMAND_SPECS)
+    if (json) {
+      console.log(JSON.stringify(schema, null, 2))
+      return
+    }
+    console.log(formatAgentContextSummary(schema))
+  }
+}

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -147,9 +147,7 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
     })
     printResult(result, json, formatTerminalCreate)
   },
-  // Why: `focus` and `switch` are aliases — register the same handler under
-  // both keys so the dispatch table stays a plain command-path lookup.
-  'terminal focus': terminalFocusHandler,
+  // `focus` resolves to this canonical path via CommandSpec.aliases before dispatch.
   'terminal switch': terminalFocusHandler,
   'terminal close': async ({ flags, client, cwd, json }) => {
     const result = await client.call<{ close: RuntimeTerminalClose }>('terminal.close', {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: root and generated command help text live together so CLI discovery stays greppable. */
 import type { CommandSpec } from './args'
 import { findCommandSpec, isCommandGroup, supportsBrowserPageFlag } from './args'
+import { unknownCommandData } from './command-suggestion'
 
 const ROOT_HELP_TEXT = `orca
 
@@ -13,6 +14,9 @@ Startup:
 
 Diagnostics:
   diagnostics memory        Collect a memory snapshot for Orca and managed terminals
+
+Agent Discovery:
+  agent-context             Print the machine-readable command schema for agents
 
 Environments:
   environment add           Save a remote Orca runtime from a pairing code
@@ -192,6 +196,7 @@ Common Commands:
   orca serve [--port <port>] [--pairing-address <host>] [--mobile-pairing] [--no-pairing] [--project-root <path>] [--recipe-json] [--json]
   orca status [--json]
   orca diagnostics memory [--json]
+  orca agent-context [--json]
   orca environment add --name <name> --pairing-code <code> [--json]
   orca environment list [--json]
   orca environment show --environment <selector> [--json]
@@ -339,7 +344,9 @@ export function printHelp(specs: CommandSpec[], commandPath: string[] = []): voi
   }
 
   if (commandPath.length > 0) {
-    console.log(`Unknown command: ${commandPath.join(' ')}\n`)
+    const { nextSteps } = unknownCommandData(specs, commandPath)
+    const recovery = nextSteps.map((step) => `Next step: ${step}`).join('\n')
+    console.log(`Unknown command: ${commandPath.join(' ')}${recovery ? `\n${recovery}` : ''}\n`)
   }
 
   console.log(ROOT_HELP_TEXT)
@@ -347,9 +354,12 @@ export function printHelp(specs: CommandSpec[], commandPath: string[] = []): voi
 
 export function formatCommandHelp(spec: CommandSpec): string {
   const lines = [`orca ${spec.path.join(' ')}`, '', `Usage: ${spec.usage}`, '', spec.summary]
-  const displayedFlags = supportsBrowserPageFlag(spec.path)
-    ? [...spec.allowedFlags, 'page']
-    : spec.allowedFlags
+  const displayedFlags =
+    spec.argumentMode === 'passthrough'
+      ? []
+      : supportsBrowserPageFlag(spec.path)
+        ? [...spec.allowedFlags, 'page']
+        : spec.allowedFlags
 
   if (displayedFlags.length > 0) {
     lines.push('', 'Options:')

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   callMock,
+  runtimeClientConstructorMock,
   serveOrcaAppMock,
   getDefaultUserDataPathMock,
   addEnvironmentFromPairingCodeMock,
@@ -13,6 +14,7 @@ const {
   spawnMock
 } = vi.hoisted(() => ({
   callMock: vi.fn(),
+  runtimeClientConstructorMock: vi.fn(),
   serveOrcaAppMock: vi.fn(),
   getDefaultUserDataPathMock: vi.fn(() => '/tmp/orca-user-data'),
   addEnvironmentFromPairingCodeMock: vi.fn(),
@@ -33,6 +35,7 @@ vi.mock('./runtime-client', () => {
       remotePairingCode?: string | null,
       environmentSelector?: string | null
     ) {
+      runtimeClientConstructorMock()
       const effectivePairingCode =
         remotePairingCode === undefined
           ? (process.env.ORCA_PAIRING_CODE ?? process.env.ORCA_REMOTE_PAIRING)
@@ -120,9 +123,7 @@ import { encodePairingOffer, PAIRING_OFFER_VERSION } from '../shared/pairing'
 
 describe('COMMAND_SPECS collision check', () => {
   it('has no duplicate command or alias paths', () => {
-    // Why: resolution is first-match-wins over canonical paths AND aliases, so a
-    // duplicate alias (colliding with a canonical path or another alias) would
-    // silently shadow a real command. Fail the build if one is ever introduced.
+    // Why: first-match resolution would silently shadow duplicate aliases.
     const seen = new Set<string>()
     for (const spec of COMMAND_SPECS) {
       for (const path of specPaths(spec)) {
@@ -194,9 +195,11 @@ describe('command aliases dispatch to the canonical handler', () => {
   })
 
   it('serves `agent-context --json` without contacting the runtime', async () => {
+    runtimeClientConstructorMock.mockClear()
     await main(['agent-context', '--json'], '/tmp/repo')
 
     // Why: pure local read — proves the SSH/offline property (no RPC).
+    expect(runtimeClientConstructorMock).not.toHaveBeenCalled()
     expect(callMock).not.toHaveBeenCalled()
     const schema = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))
     expect(schema.schemaVersion).toBe(1)
@@ -204,6 +207,19 @@ describe('command aliases dispatch to the canonical handler', () => {
       (command: { command: string }) => command.command === 'worktree rm'
     )
     expect(rm.aliases).toContainEqual(['worktree', 'remove'])
+  })
+
+  it('keeps `agent-context` local when remote environment variables are set', async () => {
+    vi.stubEnv('ORCA_PAIRING_CODE', 'pairing-code')
+    vi.stubEnv('ORCA_ENVIRONMENT', 'stale-environment')
+    try {
+      await main(['agent-context', '--json'], '/tmp/repo')
+
+      expect(process.exitCode).not.toBe(1)
+      expect(callMock).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllEnvs()
+    }
   })
 })
 
@@ -228,9 +244,79 @@ describe('unknown command surfaces a suggestion', () => {
     expect(stderr).toContain('Unknown command: worktree remov')
     expect(stderr).toContain('orca worktree')
   })
+
+  it('reports a mistyped pre-command flag without swallowing the command', async () => {
+    await main(['--jso', 'worktree', 'list'], '/tmp/repo')
+
+    expect(process.exitCode).toBe(1)
+    const stderr = errorSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    expect(stderr).toContain('Unknown flag --jso for command: worktree list')
+    expect(stderr).toContain('--json')
+  })
+
+  it('reports a pre-command flag that belongs to another command', async () => {
+    await main(['--workspace', 'worktree', 'list'], '/tmp/repo')
+
+    expect(process.exitCode).toBe(1)
+    const stderr = errorSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    expect(stderr).toContain('Unknown flag --workspace for command: worktree list')
+  })
+
+  it('reports a pre-command typo when a global flag splits the command path', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['--jso', 'worktree', '--json', 'list'], '/tmp/repo')
+
+    expect(process.exitCode).toBe(1)
+    expect(logSpy.mock.calls.flat().join('\n')).toContain(
+      'Unknown flag --jso for command: worktree list'
+    )
+    expect(callMock).not.toHaveBeenCalled()
+    logSpy.mockRestore()
+  })
+
+  it.each(['environment', 'pairing-code'])(
+    'rejects --%s without a selector before runtime construction',
+    async (flag) => {
+      runtimeClientConstructorMock.mockClear()
+
+      await main([`--${flag}`, 'worktree', 'list'], '/tmp/repo')
+
+      expect(process.exitCode).toBe(1)
+      const stderr = errorSpy.mock.calls.map((call) => String(call[0])).join('\n')
+      expect(stderr).toContain(`Flag --${flag} requires a value.`)
+      expect(runtimeClientConstructorMock).not.toHaveBeenCalled()
+      expect(callMock).not.toHaveBeenCalled()
+    }
+  )
+})
+
+describe('unknown help command surfaces a suggestion', () => {
+  it.each([
+    ['help prefix', ['help', 'worktree', 'remov']],
+    ['help flag', ['worktree', 'remov', '--help']]
+  ])('prints did-you-mean for the %s form', async (_label, argv) => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(argv, '/tmp/repo')
+
+    expect(process.exitCode).toBe(1)
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('Did you mean: orca worktree')
+    logSpy.mockRestore()
+    process.exitCode = 0
+  })
 })
 
 describe('orca root help', () => {
+  it('advertises machine-readable agent discovery', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main([], '/tmp/repo')
+
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('agent-context')
+    logSpy.mockRestore()
+  })
+
   it('advertises computer-use capabilities discovery', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -51,10 +51,12 @@ vi.mock('./runtime-client', () => {
 
   class RuntimeClientError extends Error {
     readonly code: string
+    readonly data?: unknown
 
-    constructor(code: string, message: string) {
+    constructor(code: string, message: string, data?: unknown) {
       super(message)
       this.code = code
+      this.data = data
     }
   }
 
@@ -138,6 +140,88 @@ describe('COMMAND_SPECS collision check', () => {
         ).toBe(true)
       }
     }
+  })
+})
+
+describe('command aliases dispatch to the canonical handler', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    callMock.mockReset()
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    callMock.mockReset()
+    // Why: restore console.log so a downstream describe's vi.spyOn starts from a
+    // clean spy — otherwise this block's --json output leaks into its calls[0].
+    logSpy.mockRestore()
+  })
+
+  it('runs `worktree remove` as the canonical `worktree rm` (the incident)', async () => {
+    queueFixtures(callMock, okFixture('req', { removed: true }))
+
+    await main(['worktree', 'remove', '--worktree', 'id:wt-1', '--force', '--json'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith(
+      'worktree.rm',
+      expect.objectContaining({ worktree: 'id:wt-1', force: true })
+    )
+  })
+
+  it('runs `worktree delete` as the canonical `worktree rm`', async () => {
+    queueFixtures(callMock, okFixture('req', { removed: true }))
+
+    await main(['worktree', 'delete', '--worktree', 'id:wt-1', '--json'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith(
+      'worktree.rm',
+      expect.objectContaining({ worktree: 'id:wt-1' })
+    )
+  })
+
+  it('still runs `terminal focus` after the handler de-duplication', async () => {
+    queueFixtures(callMock, okFixture('req', { focus: { ok: true } }))
+
+    await main(['terminal', 'focus', '--terminal', 'term_abc', '--json'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith('terminal.focus', expect.objectContaining({}))
+  })
+
+  it('serves `agent-context --json` without contacting the runtime', async () => {
+    await main(['agent-context', '--json'], '/tmp/repo')
+
+    // Why: pure local read — proves the SSH/offline property (no RPC).
+    expect(callMock).not.toHaveBeenCalled()
+    const schema = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))
+    expect(schema.schemaVersion).toBe(1)
+    const rm = schema.commands.find(
+      (command: { command: string }) => command.command === 'worktree rm'
+    )
+    expect(rm.aliases).toContainEqual(['worktree', 'remove'])
+  })
+})
+
+describe('unknown command surfaces a suggestion', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    callMock.mockReset()
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    process.exitCode = 0
+  })
+
+  it('prints did-you-mean for a near-miss command and exits non-zero', async () => {
+    await main(['worktree', 'remov'], '/tmp/repo')
+
+    expect(process.exitCode).toBe(1)
+    const stderr = errorSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    expect(stderr).toContain('Unknown command: worktree remov')
+    expect(stderr).toContain('orca worktree')
   })
 })
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -113,18 +113,23 @@ import {
   main,
   normalizeWorktreeSelector
 } from './index'
-import { GLOBAL_FLAGS } from './args'
+import { GLOBAL_FLAGS, specPaths } from './args'
 import { RuntimeRpcFailureError } from './runtime-client'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from './test-fixtures'
 import { encodePairingOffer, PAIRING_OFFER_VERSION } from '../shared/pairing'
 
 describe('COMMAND_SPECS collision check', () => {
-  it('has no duplicate command paths', () => {
+  it('has no duplicate command or alias paths', () => {
+    // Why: resolution is first-match-wins over canonical paths AND aliases, so a
+    // duplicate alias (colliding with a canonical path or another alias) would
+    // silently shadow a real command. Fail the build if one is ever introduced.
     const seen = new Set<string>()
     for (const spec of COMMAND_SPECS) {
-      const key = spec.path.join(' ')
-      expect(seen.has(key), `Duplicate COMMAND_SPECS path: "${key}"`).toBe(false)
-      seen.add(key)
+      for (const path of specPaths(spec)) {
+        const key = path.join(' ')
+        expect(seen.has(key), `Duplicate command/alias path: "${key}"`).toBe(false)
+        seen.add(key)
+      }
     }
   })
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import {
   normalizeCommandPositionals,
   parseArgs,
   resolveHelpPath,
+  specPaths,
   validateCommandAndFlags
 } from './args'
 import { dispatch } from './dispatch'
@@ -16,12 +17,15 @@ import { COMMAND_SPECS } from './specs'
 export { COMMAND_SPECS } from './specs'
 export { buildCurrentWorktreeSelector, normalizeWorktreeSelector } from './selectors'
 
+const COMMAND_PATHS = COMMAND_SPECS.flatMap((spec) => specPaths(spec))
+
 function shouldIgnoreRemoteSelection(commandPath: string[]): boolean {
   return (
     commandPath[0] === 'environment' ||
     commandPath[0] === 'serve' ||
     commandPath[0] === 'agent' ||
-    commandPath[0] === 'vm'
+    commandPath[0] === 'vm' ||
+    commandPath[0] === 'agent-context'
   )
 }
 
@@ -46,7 +50,7 @@ export async function main(
     await runClaudeTeams(argv.slice(1), cwd)
     return
   }
-  const parsed = normalizeCommandPositionals(COMMAND_SPECS, parseArgs(argv))
+  const parsed = normalizeCommandPositionals(COMMAND_SPECS, parseArgs(argv, COMMAND_PATHS))
   const helpPath = resolveHelpPath(parsed)
   if (helpPath !== null) {
     printHelp(COMMAND_SPECS, helpPath)
@@ -77,19 +81,23 @@ export async function main(
     // so the RuntimeClient default parameter does not re-activate the
     // ORCA_PAIRING_CODE / ORCA_ENVIRONMENT env-var fallback for commands
     // that must run locally (environment / serve).
-    const client = new RuntimeClient(
-      undefined,
-      undefined,
-      typeof pairingCode === 'string' ? pairingCode : ignoreRemoteSelection ? null : undefined,
-      typeof environmentSelector === 'string'
-        ? environmentSelector
-        : ignoreRemoteSelection
-          ? null
-          : undefined
-    )
+    let client: RuntimeClient | undefined
     await dispatch(parsed.commandPath, {
       flags: parsed.flags,
-      client,
+      // Why: local-only handlers must not resolve runtime metadata just to dispatch.
+      get client() {
+        client ??= new RuntimeClient(
+          undefined,
+          undefined,
+          typeof pairingCode === 'string' ? pairingCode : ignoreRemoteSelection ? null : undefined,
+          typeof environmentSelector === 'string'
+            ? environmentSelector
+            : ignoreRemoteSelection
+              ? null
+              : undefined
+        )
+        return client
+      },
       cwd,
       json
     })

--- a/src/cli/registry-parity.test.ts
+++ b/src/cli/registry-parity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CommandSpec } from './args'
+import { HANDLER_COMMAND_KEYS } from './dispatch'
+import { findRegistryParityGaps } from './registry-parity'
+import { COMMAND_SPECS } from './specs'
+
+describe('registry parity (live tree)', () => {
+  const handlerKeys = [...HANDLER_COMMAND_KEYS]
+
+  it('has a handler for every canonical spec path', () => {
+    const { specsWithoutHandler } = findRegistryParityGaps(COMMAND_SPECS, handlerKeys)
+    expect(specsWithoutHandler).toEqual([])
+  })
+
+  it('has a spec for every handler key', () => {
+    const { handlersWithoutSpec } = findRegistryParityGaps(COMMAND_SPECS, handlerKeys)
+    expect(handlersWithoutSpec).toEqual([])
+  })
+})
+
+describe('findRegistryParityGaps (fixtures)', () => {
+  const spec = (path: string[], aliases?: string[][]): CommandSpec => ({
+    path,
+    aliases,
+    summary: 's',
+    usage: 'u',
+    allowedFlags: []
+  })
+
+  it('flags a spec with no handler', () => {
+    const gaps = findRegistryParityGaps([spec(['foo', 'bar'])], [])
+    expect(gaps.specsWithoutHandler).toEqual(['foo bar'])
+  })
+
+  it('flags a handler with no spec', () => {
+    const gaps = findRegistryParityGaps([spec(['foo', 'bar'])], ['foo bar', 'ghost cmd'])
+    expect(gaps.handlersWithoutSpec).toEqual(['ghost cmd'])
+  })
+
+  it('does not require a handler for an alias path', () => {
+    const gaps = findRegistryParityGaps([spec(['foo', 'rm'], [['foo', 'remove']])], ['foo rm'])
+    expect(gaps.specsWithoutHandler).toEqual([])
+    expect(gaps.handlersWithoutSpec).toEqual([])
+  })
+})

--- a/src/cli/registry-parity.ts
+++ b/src/cli/registry-parity.ts
@@ -1,0 +1,25 @@
+import type { CommandSpec } from './args'
+
+// Why: specs (validation/help) and handlers (dispatch) are two parallel
+// registries. Nothing structurally prevents a handler without a spec, or a spec
+// without a handler. This guard makes that drift a build failure.
+
+export type RegistryParityGaps = {
+  handlersWithoutSpec: string[]
+  specsWithoutHandler: string[]
+}
+
+export function findRegistryParityGaps(
+  specs: CommandSpec[],
+  handlerKeys: Iterable<string>
+): RegistryParityGaps {
+  // Why: alias paths are deliberately NOT canonical spec paths and never get a
+  // dedicated handler — they resolve to the canonical path before dispatch. So
+  // parity is checked against canonical paths only; aliases are naturally exempt.
+  const canonical = new Set(specs.map((spec) => spec.path.join(' ')))
+  const handlers = new Set(handlerKeys)
+  return {
+    handlersWithoutSpec: [...handlers].filter((key) => !canonical.has(key)),
+    specsWithoutHandler: [...canonical].filter((key) => !handlers.has(key))
+  }
+}

--- a/src/cli/registry-parity.ts
+++ b/src/cli/registry-parity.ts
@@ -1,8 +1,6 @@
 import type { CommandSpec } from './args'
 
-// Why: specs (validation/help) and handlers (dispatch) are two parallel
-// registries. Nothing structurally prevents a handler without a spec, or a spec
-// without a handler. This guard makes that drift a build failure.
+// Why: validation/help and dispatch use parallel registries that must not drift.
 
 export type RegistryParityGaps = {
   handlersWithoutSpec: string[]
@@ -13,9 +11,7 @@ export function findRegistryParityGaps(
   specs: CommandSpec[],
   handlerKeys: Iterable<string>
 ): RegistryParityGaps {
-  // Why: alias paths are deliberately NOT canonical spec paths and never get a
-  // dedicated handler — they resolve to the canonical path before dispatch. So
-  // parity is checked against canonical paths only; aliases are naturally exempt.
+  // Why: aliases resolve before dispatch and deliberately have no handler key.
   const canonical = new Set(specs.map((spec) => spec.path.join(' ')))
   const handlers = new Set(handlerKeys)
   return {

--- a/src/cli/runtime/types.ts
+++ b/src/cli/runtime/types.ts
@@ -23,7 +23,8 @@ export class RuntimeRpcFailureError extends RuntimeClientError {
   readonly response: RuntimeRpcFailure
 
   constructor(response: RuntimeRpcFailure) {
-    super(response.error.code, response.error.message)
+    // Why: all client errors expose recovery through the same inherited channel.
+    super(response.error.code, response.error.message, response.error.data)
     this.response = response
   }
 }

--- a/src/cli/runtime/types.ts
+++ b/src/cli/runtime/types.ts
@@ -8,10 +8,14 @@ export type {
 
 export class RuntimeClientError extends Error {
   readonly code: string
+  // Why: optional structured recovery payload (e.g. did-you-mean suggestions,
+  // valid-flag enumeration) surfaced into both the human and --json error output.
+  readonly data?: unknown
 
-  constructor(code: string, message: string) {
+  constructor(code: string, message: string, data?: unknown) {
     super(message)
     this.code = code
+    this.data = data
   }
 }
 

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -20,6 +20,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['claude-teams'],
+    argumentMode: 'passthrough',
     summary: 'Start Claude Code Agent Teams in the current Orca terminal',
     usage: 'orca claude-teams [claude args...]',
     allowedFlags: [...GLOBAL_FLAGS],

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -157,6 +157,12 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['worktree', 'rm'],
+    // Why: agents reach for git's `remove`/`delete` verbs; accept them as
+    // aliases so a conventional guess resolves instead of dead-ending.
+    aliases: [
+      ['worktree', 'remove'],
+      ['worktree', 'delete']
+    ],
     summary: 'Remove a worktree from Orca and git',
     usage: 'orca worktree rm --worktree <selector> [--force] [--run-hooks] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'force', 'run-hooks'],
@@ -235,17 +241,13 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['terminal', 'switch'],
+    // Why: `focus` is the legacy verb for this action; keep it working as an
+    // alias rather than a duplicate spec + handler registration.
+    aliases: [['terminal', 'focus']],
     summary: 'Switch to a terminal tab in the UI',
     usage: 'orca terminal switch [--terminal <handle>] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'terminal'],
     examples: ['orca terminal switch --terminal term_abc123']
-  },
-  {
-    path: ['terminal', 'focus'],
-    summary: 'Switch to a terminal tab in the UI (alias for terminal switch)',
-    usage: 'orca terminal focus [--terminal <handle>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'terminal'],
-    examples: ['orca terminal focus --terminal term_abc123']
   },
   {
     path: ['terminal', 'close'],

--- a/src/cli/specs/index.ts
+++ b/src/cli/specs/index.ts
@@ -11,6 +11,7 @@ import { ENVIRONMENT_COMMAND_SPECS } from './environment'
 import { AGENT_HOOK_COMMAND_SPECS } from './agent-hooks'
 import { DIAGNOSTICS_COMMAND_SPECS } from './diagnostics'
 import { EMULATOR_COMMAND_SPECS } from './emulator'
+import { INTROSPECTION_COMMAND_SPECS } from './introspection'
 import { LINEAR_COMMAND_SPECS } from './linear'
 import { VM_COMMAND_SPECS } from './vm'
 
@@ -25,6 +26,7 @@ export const COMMAND_SPECS: CommandSpec[] = [
   ...COMPUTER_COMMAND_SPECS,
   ...AGENT_HOOK_COMMAND_SPECS,
   ...DIAGNOSTICS_COMMAND_SPECS,
+  ...INTROSPECTION_COMMAND_SPECS,
   ...ENVIRONMENT_COMMAND_SPECS,
   ...LINEAR_COMMAND_SPECS,
   ...VM_COMMAND_SPECS,

--- a/src/cli/specs/introspection.ts
+++ b/src/cli/specs/introspection.ts
@@ -1,0 +1,15 @@
+import type { CommandSpec } from '../args'
+import { GLOBAL_FLAGS } from '../args'
+
+export const INTROSPECTION_COMMAND_SPECS: CommandSpec[] = [
+  {
+    path: ['agent-context'],
+    summary: 'Print the machine-readable command schema for agents',
+    usage: 'orca agent-context [--json]',
+    allowedFlags: [...GLOBAL_FLAGS],
+    notes: [
+      'Pure local read of the command registry — works without a running Orca app, so it is safe over SSH and in headless contexts.'
+    ],
+    examples: ['orca agent-context --json']
+  }
+]

--- a/src/cli/vocabulary-policy.test.ts
+++ b/src/cli/vocabulary-policy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CommandSpec } from './args'
+import { COMMAND_SPECS } from './specs'
+import { findVocabularyViolations } from './vocabulary-policy'
+
+const spec = (path: string[], aliases?: string[][]): CommandSpec => ({
+  path,
+  aliases,
+  summary: 's',
+  usage: 'u',
+  allowedFlags: []
+})
+
+describe('vocabulary policy (live tree)', () => {
+  it('has no off-policy verbs that are not grandfathered or alias-bridged', () => {
+    expect(findVocabularyViolations(COMMAND_SPECS)).toEqual([])
+  })
+})
+
+describe('findVocabularyViolations (fixtures)', () => {
+  it('flags a new deletion command using an off-policy verb', () => {
+    const violations = findVocabularyViolations([spec(['gadget', 'delete'])])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ command: 'gadget delete', canonical: 'rm' })
+  })
+
+  it('passes a deletion command that bridges to the canonical verb via an alias', () => {
+    const violations = findVocabularyViolations([spec(['gadget', 'delete'], [['gadget', 'rm']])])
+    expect(violations).toEqual([])
+  })
+
+  it('passes the canonical deletion verb outright', () => {
+    expect(findVocabularyViolations([spec(['gadget', 'rm'])])).toEqual([])
+  })
+
+  it('flags a new single-item read using get instead of show', () => {
+    const violations = findVocabularyViolations([spec(['gadget', 'get'])])
+    expect(violations[0]).toMatchObject({ verb: 'get', canonical: 'show' })
+  })
+})

--- a/src/cli/vocabulary-policy.test.ts
+++ b/src/cli/vocabulary-policy.test.ts
@@ -30,6 +30,18 @@ describe('findVocabularyViolations (fixtures)', () => {
     expect(violations).toEqual([])
   })
 
+  it('rejects a canonical verb alias under an unrelated command prefix', () => {
+    const violations = findVocabularyViolations([spec(['gadget', 'delete'], [['other', 'rm']])])
+    expect(violations).toHaveLength(1)
+  })
+
+  it('rejects a canonical verb alias at a different command depth', () => {
+    const violations = findVocabularyViolations([
+      spec(['gadget', 'delete'], [['gadget', 'nested', 'rm']])
+    ])
+    expect(violations).toHaveLength(1)
+  })
+
   it('passes the canonical deletion verb outright', () => {
     expect(findVocabularyViolations([spec(['gadget', 'rm'])])).toEqual([])
   })

--- a/src/cli/vocabulary-policy.ts
+++ b/src/cli/vocabulary-policy.ts
@@ -1,0 +1,72 @@
+import type { CommandSpec } from './args'
+
+// Why: agents predict verbs from a generalized CLI model. Splitting deletion
+// across rm/remove/delete or reads across show/get forces relearning and failed
+// guesses. This policy keeps NEW commands on the canonical verb (or bridged to it
+// by an alias), enforced mechanically rather than by review. Existing divergences
+// are grandfathered via allowlists; renames are out of scope.
+
+type VerbFamily = {
+  name: string
+  offPolicyVerbs: Set<string>
+  canonical: string
+  allowlist: Set<string>
+}
+
+const FAMILIES: VerbFamily[] = [
+  {
+    name: 'deletion',
+    offPolicyVerbs: new Set(['remove', 'delete', 'destroy']),
+    canonical: 'rm',
+    allowlist: new Set([
+      'cookie delete',
+      'tab profile delete',
+      'automations remove',
+      'linear label remove'
+    ])
+  },
+  {
+    name: 'single-item read',
+    offPolicyVerbs: new Set(['get']),
+    canonical: 'show',
+    allowlist: new Set(['get', 'cookie get', 'storage local get', 'storage session get'])
+  }
+]
+
+export type VocabularyViolation = {
+  command: string
+  verb: string
+  family: string
+  canonical: string
+}
+
+function terminalVerb(path: string[]): string {
+  return path.at(-1) ?? ''
+}
+
+function hasCanonicalAlias(spec: CommandSpec, canonical: string): boolean {
+  return (spec.aliases ?? []).some((alias) => terminalVerb(alias) === canonical)
+}
+
+export function findVocabularyViolations(specs: CommandSpec[]): VocabularyViolation[] {
+  const violations: VocabularyViolation[] = []
+  for (const spec of specs) {
+    const command = spec.path.join(' ')
+    const verb = terminalVerb(spec.path)
+    for (const family of FAMILIES) {
+      if (!family.offPolicyVerbs.has(verb)) {
+        continue
+      }
+      if (family.allowlist.has(command)) {
+        continue
+      }
+      // Why: an alias on the canonical verb makes the command reachable the
+      // canonical way, which satisfies the policy without a rename.
+      if (hasCanonicalAlias(spec, family.canonical)) {
+        continue
+      }
+      violations.push({ command, verb, family: family.name, canonical: family.canonical })
+    }
+  }
+  return violations
+}

--- a/src/cli/vocabulary-policy.ts
+++ b/src/cli/vocabulary-policy.ts
@@ -1,10 +1,7 @@
 import type { CommandSpec } from './args'
 
-// Why: agents predict verbs from a generalized CLI model. Splitting deletion
-// across rm/remove/delete or reads across show/get forces relearning and failed
-// guesses. This policy keeps NEW commands on the canonical verb (or bridged to it
-// by an alias), enforced mechanically rather than by review. Existing divergences
-// are grandfathered via allowlists; renames are out of scope.
+// Why: predictable verbs prevent failed agent guesses; existing divergences stay
+// grandfathered because renaming them would break compatibility.
 
 type VerbFamily = {
   name: string
@@ -45,7 +42,11 @@ function terminalVerb(path: string[]): string {
 }
 
 function hasCanonicalAlias(spec: CommandSpec, canonical: string): boolean {
-  return (spec.aliases ?? []).some((alias) => terminalVerb(alias) === canonical)
+  const expected = [...spec.path.slice(0, -1), canonical]
+  return (spec.aliases ?? []).some(
+    (alias) =>
+      alias.length === expected.length && alias.every((part, index) => part === expected[index])
+  )
 }
 
 export function findVocabularyViolations(specs: CommandSpec[]): VocabularyViolation[] {


### PR DESCRIPTION
## Summary

An agent driving the `orca` CLI used to hit a wall whenever it guessed a conventional-but-wrong verb. `orca worktree remove` (git's verb) returned a bare `Unknown command: worktree remove` with no way forward — even though the `orca-cli` skill documents `rm` correctly, because the skill wasn't loaded in context. This makes the CLI **degrade gracefully on its own**: wrong-but-conventional verbs resolve, mistakes teach instead of dead-ending, and the whole command surface is discoverable in one machine-readable call.

The principles here follow [10 Principles for Agent-Native CLIs](https://trevinsays.com/p/10-principles-for-agent-native-clis). orca already satisfied the table-stakes tier (global `--json`, stdout/stderr split, exit codes, an error-code taxonomy, an in-memory spec table); the gap was in **recovery** and **discovery**, which is what this PR closes.

## What's now possible

| Capability | Before | After |
|---|---|---|
| Conventional verbs | `orca worktree remove` → `Unknown command` | resolves to canonical `orca worktree rm` (also `delete`) |
| Typos | dead-end | `Did you mean: orca worktree remove, orca worktree rm` |
| Wrong flags | `Unknown flag --forcce` | suggests `--force` **and** enumerates every valid flag |
| Discovery | parse `--help` prose, or load the skill | `orca agent-context --json` — the whole schema, including aliases |

## Key design decisions

- **Aliases are additive data on `CommandSpec`, never renames.** A new optional `aliases?: string[][]` is resolved to the canonical path in one place before dispatch. Existing paths/flags are untouched, so SSH scripts and automations keep working. The pre-existing ad-hoc `terminal focus` duplicate (its own spec + handler) is migrated onto the mechanism.
- **Dispatch still keys on the canonical path — zero new handler registrations.** Alias resolution happens during arg normalization; the handler map never sees the alias. This kept the blast radius tiny across ~190 commands.
- **Teaching errors reuse the existing `nextSteps` channel.** The structured recovery payload that `computer` errors already used now carries did-you-mean suggestions and valid-flag enumeration, surfaced in both stderr and `--json` `error.data`. Suggestions are ranked by edit distance over the *live* registry, so they never drift from reality.
- **`agent-context` is a pure local read.** It serializes the in-memory spec table with no RPC, so it works over SSH and when the Orca app isn't running.
- **Consistency is enforced mechanically, not by review.** Two CI guards fail the build on specs↔handlers drift and on new off-policy deletion/read verbs (existing divergences are grandfathered); a new command must use the canonical verb or bridge to it with an alias.

## Validation

`pnpm test` (full repo), `pnpm typecheck`, and `pnpm lint` are green; the CLI suite is 382 tests across 30 files. Behaviors were also exercised against a local build of this branch:

```
$ orca worktree remove --help
orca worktree rm

Usage: orca worktree rm --worktree <selector> [--force] [--run-hooks] [--json]
...

$ orca worktree remov
Unknown command: worktree remov
Next step: Did you mean: orca worktree remove, orca worktree rm

$ orca worktree rm --forcce
Unknown flag --forcce for command: worktree rm
Next step: Did you mean: --force
Next step: Valid flags: --environment, --force, --help, --json, --pairing-code, --run-hooks, --worktree

$ orca agent-context --json | jq '{schemaVersion, commandCount}'
{ "schemaVersion": 1, "commandCount": 193 }
```
<img width="1280" height="820" alt="01-worktree-remove-alias" src="https://github.com/user-attachments/assets/8fc5bbd5-8b93-45b2-8738-67b820102671" />
<img width="1280" height="500" alt="02-did-you-mean" src="https://github.com/user-attachments/assets/46e0f75c-98c6-411b-9cbc-5821962fd6c1" />
<img width="1280" height="560" alt="03-flag-enumeration" src="https://github.com/user-attachments/assets/25e760b9-148b-4ac2-9d95-8f2ed5564ed0" />
<img width="1280" height="640" alt="04-agent-context" src="https://github.com/user-attachments/assets/ebea5645-db5c-4f76-b49e-33dc08fcbaee" />



---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8-D97757?logo=claude&logoColor=white)
