### PR TITLE
Fix delete workspace confirmation spacing

### DIFF
--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
@@ -115,6 +115,10 @@ function buttonText(props: Record<string, unknown>): string {
   return renderToStaticMarkup(<>{props.children as ReactNode}</>)
 }
 
+function visibleMarkupText(markup: string): string {
+  return markup.replace(/<[^>]*>/g, '')
+}
+
 describe('DeleteWorktreeDialog lineage copy', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -210,6 +214,20 @@ describe('DeleteWorktreeDialog lineage copy', () => {
 
     expect(markup).toContain('from Orca. The project folder on disk will not be deleted.')
     expect(markup).not.toContain('including uncommitted or untracked files')
+  })
+
+  it('keeps a space between remove copy and the workspace name', async () => {
+    const workspace = makeWorktree('Hide working dot', '/workspaces/hide-working-dot')
+    mocks.state.modalData = { worktreeId: workspace.id }
+    mocks.state.allWorktrees.mockReturnValue([workspace])
+
+    const { default: DeleteWorktreeDialog } = await import('./DeleteWorktreeDialog')
+    const markup = renderToStaticMarkup(<DeleteWorktreeDialog />)
+
+    expect(visibleMarkupText(markup)).toContain(
+      'Remove Hide working dot from git and delete its workspace folder.'
+    )
+    expect(markup).not.toContain('RemoveHide working dot')
   })
 
   it('shows an inline warning when the workspace has uncommitted or untracked changes', async () => {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialogDescription.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialogDescription.tsx
@@ -16,7 +16,7 @@ export function DeleteWorktreeDialogDescription({
 }): React.JSX.Element {
   return (
     <DialogDescription className="text-xs">
-      {translate('auto.components.sidebar.DeleteWorktreeDialog.91492c9ad6', 'Remove')}
+      {translate('auto.components.sidebar.DeleteWorktreeDialog.91492c9ad6', 'Remove')}{' '}
       <span className={targetClassName}>{targetLabel}</span>
       {canDeleteAllLineage ? (
         <>


### PR DESCRIPTION
## Summary
- Fixed the delete workspace confirmation sentence so the translated `Remove` label is separated from the emphasized workspace name.
- Kept the existing delete suffix copy unchanged for single, batch, folder-workspace, and child-workspace flows.
- Added a regression test for `Remove Hide working dot from git and delete its workspace folder.` and the absence of `RemoveHide working dot`.

## Design and Review
- Design approach: narrow UI rendering fix in the modal description component, with coverage at the rendered sentence boundary. Scratch design doc: `design-docs/delete-workspace-modal-spacing.md` (ignored, not included in the product diff).
- Design review: clean after the reviewer corrected the diagnosis to the boundary between `Remove` and the workspace name.
- Implementation: changed `DeleteWorktreeDialogDescription.tsx` and `DeleteWorktreeDialog.test.tsx`; no deviations from the reviewed design.
- Completeness verification: clean; every design requirement and edge case was accounted for.
- Perf audit: clean. Touched path is a user-opened modal render plus a test-only helper; no new polling, subprocess work, store subscribers, effects, startup work, leaks, or cache invalidation. Existing deterministic coverage is sufficient.
- Code review: one round with two independent reviewers; both returned clean.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- Electron validation via the real sidebar delete menu on a disposable workspace confirmed the modal showed `Remove Hide working dot spacing 1782343516954 from git and delete its workspace folder.` and did not contain `RemoveHide...`.

## Screenshots
- Screenshot evidence captured locally at `tmp-validation-evidence/delete-workspace-modal-spacing.png`; not committed.

## Security Audit
- No security-sensitive behavior changed. This is renderer copy/spacing only and does not alter deletion logic, filesystem access, SSH behavior, authentication, or git provider integration.

## Post-PR Stabilization
- Waited 8 minutes after opening the PR before the first sweep.
- CodeRabbit posted no actionable comments. Its docstring coverage warning is a non-actionable false positive for this TypeScript UI/test diff.
- PR checks are passing: `track-community-pr` and `verify`.
- Merge state is clean; PR remains open and unmerged.

## Notes
- Existing local pnpm warning observed: `/Users/thebr/.npmrc` references `${GITHUB_TOKEN}`; it did not affect validation.
- No SSH, path handling, keyboard shortcut, or git provider behavior changed.