### PR TITLE
Fix: PowerShell 7+ selection silently downgraded to Windows PowerShell on cold daemon start

### DIFF
--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -8,6 +8,7 @@
  */
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { createPtySubprocess } from './pty-subprocess'
+import { warmPwshAvailability } from '../pwsh'
 
 export function parseArgs(argv: string[]): { socketPath: string; tokenPath: string } {
   let socketPath = ''
@@ -71,6 +72,11 @@ async function main(): Promise<void> {
 
   process.on('SIGTERM', () => void shutdown())
   process.on('SIGINT', () => void shutdown())
+
+  // Why: cold pwsh.exe start exceeds the synchronous probe timeout, so warm the
+  // availability cache async at startup — before the first terminal spawn — so a
+  // PowerShell 7+ selection isn't silently downgraded to Windows PowerShell.
+  warmPwshAvailability()
 
   daemon = await startDaemon({
     socketPath,

--- a/src/main/pwsh.test.ts
+++ b/src/main/pwsh.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileSyncMock } = vi.hoisted(() => ({
-  execFileSyncMock: vi.fn()
+const { execFileSyncMock, execFileMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+  execFileMock: vi.fn()
 }))
 
 vi.mock('child_process', () => ({
-  execFileSync: execFileSyncMock
+  execFileSync: execFileSyncMock,
+  execFile: execFileMock
 }))
 
 function setPlatform(platform: NodeJS.Platform): () => void {
@@ -27,6 +29,7 @@ describe('isPwshAvailable', () => {
   beforeEach(() => {
     vi.resetModules()
     execFileSyncMock.mockReset()
+    execFileMock.mockReset()
   })
 
   it('returns false on non-Windows platforms', async () => {
@@ -78,6 +81,97 @@ describe('isPwshAvailable', () => {
     try {
       const { isPwshAvailable } = await import('./pwsh')
       expect(isPwshAvailable()).toBe(true)
+      expect(isPwshAvailable()).toBe(true)
+      expect(execFileSyncMock).toHaveBeenCalledTimes(1)
+    } finally {
+      restorePlatform()
+    }
+  })
+
+  it('re-probes after a negative result so a one-off failure does not poison the session', async () => {
+    const restorePlatform = setPlatform('win32')
+    const nowSpy = vi.spyOn(Date, 'now')
+
+    try {
+      // First probe fails (e.g. timed out during a busy startup).
+      nowSpy.mockReturnValue(0)
+      execFileSyncMock.mockImplementationOnce(() => {
+        throw new Error('timed out')
+      })
+
+      const { isPwshAvailable } = await import('./pwsh')
+      expect(isPwshAvailable()).toBe(false)
+
+      // Within the negative TTL, the cached false is reused without re-spawning.
+      nowSpy.mockReturnValue(5_000)
+      expect(isPwshAvailable()).toBe(false)
+      expect(execFileSyncMock).toHaveBeenCalledTimes(1)
+
+      // After the TTL, a recovered machine re-probes and reports pwsh available.
+      nowSpy.mockReturnValue(40_000)
+      execFileSyncMock.mockReturnValue('PowerShell 7.5.0')
+      expect(isPwshAvailable()).toBe(true)
+      expect(execFileSyncMock).toHaveBeenCalledTimes(2)
+
+      // A positive result is cached for good.
+      expect(isPwshAvailable()).toBe(true)
+      expect(execFileSyncMock).toHaveBeenCalledTimes(2)
+    } finally {
+      nowSpy.mockRestore()
+      restorePlatform()
+    }
+  })
+})
+
+describe('warmPwshAvailability', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    execFileSyncMock.mockReset()
+    execFileMock.mockReset()
+  })
+
+  it('does nothing on non-Windows platforms', async () => {
+    const restorePlatform = setPlatform('linux')
+
+    try {
+      const { warmPwshAvailability } = await import('./pwsh')
+      warmPwshAvailability()
+      expect(execFileMock).not.toHaveBeenCalled()
+    } finally {
+      restorePlatform()
+    }
+  })
+
+  it('populates the positive cache so isPwshAvailable() needs no sync probe', async () => {
+    const restorePlatform = setPlatform('win32')
+    // Async probe succeeds: invoke the callback with no error.
+    execFileMock.mockImplementation((_file, _args, _opts, cb) => {
+      cb(null, 'PowerShell 7.5.0', '')
+    })
+
+    try {
+      const { warmPwshAvailability, isPwshAvailable } = await import('./pwsh')
+      warmPwshAvailability()
+      expect(isPwshAvailable()).toBe(true)
+      // The warm result short-circuits the synchronous probe entirely.
+      expect(execFileSyncMock).not.toHaveBeenCalled()
+    } finally {
+      restorePlatform()
+    }
+  })
+
+  it('leaves the cache untouched when the warm probe fails so the TTL path still runs', async () => {
+    const restorePlatform = setPlatform('win32')
+    // Warm probe fails (e.g. cold-start timeout)…
+    execFileMock.mockImplementation((_file, _args, _opts, cb) => {
+      cb(new Error('timed out'), '', '')
+    })
+    // …but a later synchronous probe recovers.
+    execFileSyncMock.mockReturnValue('PowerShell 7.5.0')
+
+    try {
+      const { warmPwshAvailability, isPwshAvailable } = await import('./pwsh')
+      warmPwshAvailability()
       expect(isPwshAvailable()).toBe(true)
       expect(execFileSyncMock).toHaveBeenCalledTimes(1)
     } finally {

--- a/src/main/pwsh.ts
+++ b/src/main/pwsh.ts
@@ -1,15 +1,42 @@
-import { execFileSync } from 'child_process'
+import { execFileSync, execFile } from 'child_process'
 
-// Cached pwsh availability check — evaluated once per process lifetime
+const PROBE_TIMEOUT_MS = 5000
+
+// Why: a synchronous probe blocks the daemon's event loop, so it must stay
+// short. But cold-starting pwsh.exe (first .NET JIT + Defender scan) routinely
+// exceeds that, so the first terminal opened right after daemon start times out
+// and silently falls back to Windows PowerShell. The warm probe runs once at
+// startup, async (non-blocking) and with generous headroom, to populate the
+// cache before the first terminal launch.
+const WARM_PROBE_TIMEOUT_MS = 20_000
+
+// Why: only a positive result is durably true — pwsh installs don't disappear
+// mid-session, so caching `true` forever is safe and avoids re-spawning the probe
+// on every terminal launch. A `false`, however, can be a transient failure (probe
+// raced a busy startup) and, crucially, the terminal daemon is a detached process
+// that outlives app restarts (see daemon-init.ts). Caching `false` for that whole
+// lifetime keeps the PowerShell 7+ option dead for days and silently falls back to
+// Windows PowerShell. So we remember a negative result only briefly and re-probe.
+const NEGATIVE_CACHE_TTL_MS = 30_000
+
 let pwshAvailableCache: boolean | null = null
+let negativeProbedAt = 0
+
+/** @internal - tests need a clean probe cache between cases. */
+export function _resetPwshAvailableCache(): void {
+  pwshAvailableCache = null
+  negativeProbedAt = 0
+}
 
 /**
  * Check whether pwsh.exe is available on this Windows machine.
- * Result is cached for the process lifetime.
+ * A positive result is cached for the process lifetime; a negative result is
+ * cached only briefly so a one-off probe failure doesn't disable pwsh for the
+ * whole session.
  */
 export function isPwshAvailable(): boolean {
-  if (pwshAvailableCache !== null) {
-    return pwshAvailableCache
+  if (pwshAvailableCache === true) {
+    return true
   }
 
   if (process.platform !== 'win32') {
@@ -17,15 +44,36 @@ export function isPwshAvailable(): boolean {
     return false
   }
 
+  if (pwshAvailableCache === false && Date.now() - negativeProbedAt < NEGATIVE_CACHE_TTL_MS) {
+    return false
+  }
+
   try {
     execFileSync('pwsh.exe', ['-Version'], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000
+      timeout: PROBE_TIMEOUT_MS
     })
     pwshAvailableCache = true
   } catch {
     pwshAvailableCache = false
+    negativeProbedAt = Date.now()
   }
 
   return pwshAvailableCache
+}
+
+/**
+ * Warm the pwsh availability cache without blocking the caller.
+ * Only ever records a positive result — negatives are left to isPwshAvailable()
+ * and its TTL re-probe, so a slow cold start here can't poison the cache.
+ */
+export function warmPwshAvailability(): void {
+  if (process.platform !== 'win32' || pwshAvailableCache === true) {
+    return
+  }
+  execFile('pwsh.exe', ['-Version'], { timeout: WARM_PROBE_TIMEOUT_MS }, (err) => {
+    if (!err) {
+      pwshAvailableCache = true
+    }
+  })
 }


### PR DESCRIPTION
## What & why

On Windows, selecting **PowerShell 7+** (`pwsh.exe`) as the default PowerShell implementation frequently still opened **Windows PowerShell** (`powershell.exe`) for newly created terminals, only self-correcting after the app had been running a while.

**Root cause:** the terminal daemon resolves the shell via `resolveEffectiveWindowsPowerShell({ implementation, pwshAvailable: isPwshAvailable() })`. `isPwshAvailable()` probes synchronously with `execFileSync('pwsh.exe', ['-Version'], { timeout: 5000 })`. The **first** invocation of `pwsh.exe` after the daemon starts is a cold start (.NET JIT + Windows Defender first-scan) that routinely exceeds 5s → `ETIMEDOUT` → the result is cached as `false` → the resolver silently downgrades to `powershell.exe`. Since the daemon is a detached process that outlives app restarts, the bad cache could persist for its entire lifetime.

Diagnostic capture confirming the timeout (each line = one daemon terminal spawn) is in #6302. `implementation` was correctly `pwsh.exe` throughout — only `pwshAvailable` flipped, so the user setting was always threaded through correctly.

## Fix

- **Warm the availability cache asynchronously at daemon startup** (`warmPwshAvailability()` in `src/main/pwsh.ts`, called from `daemon-entry.ts`). It uses non-blocking `execFile` with generous headroom (20s) and only ever records a *positive* result, so the answer is ready and correct before the first terminal spawn without blocking the daemon's event loop.
- **Cache only positive results long-term; keep negatives short-lived** (30s TTL re-probe), so a one-off cold-start failure can't disable the PowerShell 7+ option for the daemon's session. This is the safety net if a terminal races the warm probe.
- The synchronous probe timeout stays at 5s (raising it would block the event loop on the first spawn; the async warm is the real fix).

## Tests

`src/main/pwsh.test.ts` — added coverage for the negative-cache TTL re-probe and for `warmPwshAvailability()` (no-op off-Windows, populates the positive cache so no sync probe is needed, leaves the cache untouched on warm failure so the TTL path still runs). 8/8 pass.

## Visual change

None — this is daemon/main-process behavior only.

## AI code review summary

- **Cross-platform:** All new logic is gated by `process.platform === 'win32'`; `warmPwshAvailability()` early-returns on non-Windows, and `isPwshAvailable()` retains its existing non-win32 `false` path. No behavior change on macOS/Linux.
- **SSH / remote / local:** No assumptions added about local-only execution; this only affects how the local Windows daemon picks between `powershell.exe` and `pwsh.exe`. Remote/SSH shell resolution is untouched.
- **Agent / integration / git-provider:** No agent-, integration-, or provider-specific code touched; the resolver and its inputs are unchanged.
- **Performance:** Removes a 5s synchronous-probe stall on the first terminal spawn in the common case (the warm probe pre-populates the cache). The warm probe is a single non-blocking `execFile` at startup. Positive results are cached for the process lifetime; negatives re-probe at most once per 30s.
- **UI quality:** N/A (no UI change).
- **Security:** No new inputs, network, or credential handling. `execFile` is invoked with a fixed argument array (no shell, no interpolation), same as the existing probe.

## Testing notes

Windows-specific. Verified locally: build green, lint and typecheck green, new unit tests pass. Reproduced the original cold-start `ETIMEDOUT` via daemon diagnostics, then confirmed the warm-probe path resolves `pwsh.exe` on the first spawn. The full suite has 8 pre-existing Windows-environment test-file failures (PATH-shim ordering, file-URL formatting, history snapshot) that are unrelated to this change — confirmed identical on the base commit with these changes stashed.

X: @mr_huxley

Closes #6302
