### PR TITLE
fix: handle native Windows skill update flow for Orca setup

### DIFF
--- a/src/renderer/src/components/feature-wall/BrowserUseSkillSetupCard.tsx
+++ b/src/renderer/src/components/feature-wall/BrowserUseSkillSetupCard.tsx
@@ -26,14 +26,12 @@ export function BrowserUseSkillSetupCard(props: {
 }): JSX.Element {
   const { compact, terminalHeightPx, skill } = props
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  const installCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND, activeSkillRuntime.agentRuntime)
-      : ORCA_CLI_SKILL_INSTALL_COMMAND
-  const updateCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND, activeSkillRuntime.agentRuntime)
-      : ORCA_CLI_SKILL_UPDATE_COMMAND
+  const installCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND, activeSkillRuntime.agentRuntime)
+    : ORCA_CLI_SKILL_INSTALL_COMMAND
+  const updateCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND, activeSkillRuntime.agentRuntime)
+    : ORCA_CLI_SKILL_UPDATE_COMMAND
 
   const handleBeforeOpenTerminal = async (): Promise<void> => {
     useAppStore.getState().recordFeatureInteraction('agent-browser-setup')

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
@@ -42,20 +42,18 @@ export function FloatingTerminalOrchestrationDialog({
   onSetupStateChange
 }: FloatingTerminalOrchestrationDialogProps): React.JSX.Element {
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  const installCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          ORCHESTRATION_SKILL_INSTALL_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : ORCHESTRATION_SKILL_INSTALL_COMMAND
-  const updateCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          ORCHESTRATION_SKILL_UPDATE_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : ORCHESTRATION_SKILL_UPDATE_COMMAND
+  const installCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(
+        ORCHESTRATION_SKILL_INSTALL_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
+    : ORCHESTRATION_SKILL_INSTALL_COMMAND
+  const updateCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(
+        ORCHESTRATION_SKILL_UPDATE_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
+    : ORCHESTRATION_SKILL_UPDATE_COMMAND
   const {
     installed: orchestrationSkillDetected,
     loading: orchestrationSkillLoading,

--- a/src/renderer/src/components/settings/BrowserUsePane.tsx
+++ b/src/renderer/src/components/settings/BrowserUsePane.tsx
@@ -56,14 +56,12 @@ export function BrowserUseSetup({
   const [cliBusy, setCliBusy] = useState(false)
   const mountedRef = useMountedRef()
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  const browserUseInstallCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND, activeSkillRuntime.agentRuntime)
-      : ORCA_CLI_SKILL_INSTALL_COMMAND
-  const browserUseUpdateCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND, activeSkillRuntime.agentRuntime)
-      : ORCA_CLI_SKILL_UPDATE_COMMAND
+  const browserUseInstallCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND, activeSkillRuntime.agentRuntime)
+    : ORCA_CLI_SKILL_INSTALL_COMMAND
+  const browserUseUpdateCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND, activeSkillRuntime.agentRuntime)
+    : ORCA_CLI_SKILL_UPDATE_COMMAND
 
   const handleCliStatusChange = useCallback(
     (nextStatus: CliInstallStatus | null): void => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -34,16 +34,35 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
   })
 
   it('reinstalls Windows-host skill updates through the add path', () => {
-    const command = buildSkillCommandForRuntime('npx skills update orchestration --global', {
-      runtime: 'host',
-      label: 'Windows'
-    })
-    const expectedCommand =
-      process.platform === 'win32'
-        ? buildAgentFeatureSkillInstallCommand(['orchestration'])
-        : 'npx skills update orchestration --global'
+    expect(
+      buildSkillCommandForRuntime(
+        'npx skills update orchestration --global',
+        {
+          runtime: 'host',
+          label: 'Windows'
+        },
+        'win32'
+      )
+    ).toBe(buildAgentFeatureSkillInstallCommand(['orchestration']))
+  })
 
-    expect(command).toBe(expectedCommand)
+  it('treats missing runtime as a Windows host fallback for skill updates', () => {
+    expect(
+      buildSkillCommandForRuntime('npx skills update orca-cli --global', undefined, 'win32')
+    ).toBe(buildAgentFeatureSkillInstallCommand(['orca-cli']))
+  })
+
+  it('keeps non-Windows host skill updates on the update path', () => {
+    expect(
+      buildSkillCommandForRuntime(
+        'npx skills update orchestration --global',
+        {
+          runtime: 'host',
+          label: 'This device'
+        },
+        'linux'
+      )
+    ).toBe('npx skills update orchestration --global')
   })
 
   it('preserves the selected WSL distro for skill discovery', () => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
+import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import {
   buildSkillCommandForRuntime,
   buildSkillInstallCommandForRuntime,
@@ -30,6 +31,19 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     expect(command).toContain("wsl.exe -d 'Fedora Remix' -- sh -c")
     expect(command).toContain('getent passwd')
     expect(command).toContain('npx skills update orchestration --global')
+  })
+
+  it('reinstalls Windows-host skill updates through the add path', () => {
+    const command = buildSkillCommandForRuntime('npx skills update orchestration --global', {
+      runtime: 'host',
+      label: 'Windows'
+    })
+    const expectedCommand =
+      process.platform === 'win32'
+        ? buildAgentFeatureSkillInstallCommand(['orchestration'])
+        : 'npx skills update orchestration --global'
+
+    expect(command).toBe(expectedCommand)
   })
 
   it('preserves the selected WSL distro for skill discovery', () => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -22,6 +22,11 @@ export type LocalAgentRuntime = {
   label: string
 }
 
+const LOCAL_HOST_AGENT_RUNTIME: LocalAgentRuntime = {
+  runtime: 'host',
+  label: ''
+}
+
 export function getHostRuntimeLabel(): string {
   return navigator.userAgent.includes('Windows') ? 'Windows' : 'This device'
 }
@@ -63,21 +68,34 @@ export function getWslCliDistroRequest(
     : undefined
 }
 
-export function buildSkillCommandForRuntime(command: string, runtime: LocalAgentRuntime): string {
-  const normalizedCommand = normalizeWindowsSkillUpdateCommand(command, runtime)
-  if (runtime.runtime !== 'wsl') {
+export function buildSkillCommandForRuntime(
+  command: string,
+  runtime?: LocalAgentRuntime,
+  currentPlatform = getSkillCommandPlatform()
+): string {
+  const resolvedRuntime = runtime ?? LOCAL_HOST_AGENT_RUNTIME
+  const normalizedCommand = normalizeWindowsSkillUpdateCommand(
+    command,
+    resolvedRuntime,
+    currentPlatform
+  )
+  if (resolvedRuntime.runtime !== 'wsl') {
     return normalizedCommand
   }
 
-  const distroArg = runtime.wslDistro?.trim()
-    ? ` -d ${quotePowerShellSingle(runtime.wslDistro.trim())}`
+  const distroArg = resolvedRuntime.wslDistro?.trim()
+    ? ` -d ${quotePowerShellSingle(resolvedRuntime.wslDistro.trim())}`
     : ''
   const wslCommand = escapeWslShCommandForWindows(buildWslLoginShellCommand(normalizedCommand))
   return `wsl.exe${distroArg} -- sh -c ${quotePowerShellSingle(wslCommand)}`
 }
 
-function normalizeWindowsSkillUpdateCommand(command: string, runtime: LocalAgentRuntime): string {
-  if (runtime.runtime === 'wsl' || process.platform !== 'win32') {
+function normalizeWindowsSkillUpdateCommand(
+  command: string,
+  runtime: LocalAgentRuntime,
+  currentPlatform: NodeJS.Platform
+): string {
+  if (runtime.runtime === 'wsl' || currentPlatform !== 'win32') {
     return command
   }
 
@@ -91,6 +109,23 @@ function normalizeWindowsSkillUpdateCommand(command: string, runtime: LocalAgent
   // Windows, while reinstalling from the same repo source is idempotent and
   // keeps the setup affordance working.
   return buildAgentFeatureSkillInstallCommand([updateMatch[1]])
+}
+
+function getSkillCommandPlatform(): NodeJS.Platform {
+  const platform =
+    typeof window === 'undefined' ? undefined : window.api?.platform?.get?.()?.platform
+  if (platform) {
+    return platform
+  }
+
+  const userAgent = typeof navigator === 'undefined' ? '' : navigator.userAgent
+  if (userAgent.includes('Windows')) {
+    return 'win32'
+  }
+  if (userAgent.includes('Mac')) {
+    return 'darwin'
+  }
+  return 'linux'
 }
 
 export function buildSkillInstallCommandForRuntime(

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -7,6 +7,7 @@ import {
   buildWslLoginShellCommand,
   escapeWslShCommandForWindows
 } from '../../../../shared/wsl-login-shell-command'
+import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
 import {
@@ -63,14 +64,33 @@ export function getWslCliDistroRequest(
 }
 
 export function buildSkillCommandForRuntime(command: string, runtime: LocalAgentRuntime): string {
+  const normalizedCommand = normalizeWindowsSkillUpdateCommand(command, runtime)
   if (runtime.runtime !== 'wsl') {
-    return command
+    return normalizedCommand
   }
+
   const distroArg = runtime.wslDistro?.trim()
     ? ` -d ${quotePowerShellSingle(runtime.wslDistro.trim())}`
     : ''
-  const wslCommand = escapeWslShCommandForWindows(buildWslLoginShellCommand(command))
+  const wslCommand = escapeWslShCommandForWindows(buildWslLoginShellCommand(normalizedCommand))
   return `wsl.exe${distroArg} -- sh -c ${quotePowerShellSingle(wslCommand)}`
+}
+
+function normalizeWindowsSkillUpdateCommand(command: string, runtime: LocalAgentRuntime): string {
+  if (runtime.runtime === 'wsl' || process.platform !== 'win32') {
+    return command
+  }
+
+  const trimmedCommand = command.trim()
+  const updateMatch = /^npx\s+skills\s+update\s+([A-Za-z0-9_-]+)\s+--global$/i.exec(trimmedCommand)
+  if (!updateMatch) {
+    return command
+  }
+
+  // Why: the `skills update` subcommand is currently unreliable on native
+  // Windows, while reinstalling from the same repo source is idempotent and
+  // keeps the setup affordance working.
+  return buildAgentFeatureSkillInstallCommand([updateMatch[1]])
 }
 
 export function buildSkillInstallCommandForRuntime(

--- a/src/renderer/src/components/settings/ComputerUseSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/ComputerUseSkillSetupPanel.tsx
@@ -24,20 +24,18 @@ import { translate } from '@/i18n/i18n'
 
 export function ComputerUseSkillSetupPanel(): React.JSX.Element {
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  const installCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          COMPUTER_USE_SKILL_INSTALL_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : COMPUTER_USE_SKILL_INSTALL_COMMAND
-  const updateCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          COMPUTER_USE_SKILL_UPDATE_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : COMPUTER_USE_SKILL_UPDATE_COMMAND
+  const installCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(
+        COMPUTER_USE_SKILL_INSTALL_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
+    : COMPUTER_USE_SKILL_INSTALL_COMMAND
+  const updateCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(
+        COMPUTER_USE_SKILL_UPDATE_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
+    : COMPUTER_USE_SKILL_UPDATE_COMMAND
   const {
     installed: computerUseSkillDetected,
     loading: computerUseSkillLoading,

--- a/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
@@ -10,6 +10,7 @@ import {
 import { cn } from '@/lib/utils'
 import { useMobileEmulatorAgentSetupState } from '../emulator-pane/use-mobile-emulator-agent-setup-state'
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
+import { buildSkillCommandForRuntime } from './CliSkillRuntimeSetup'
 import { StepBadge } from './BrowserUseStepBadge'
 import { MobileEmulatorExamples } from './MobileEmulatorExamples'
 import { Button } from '../ui/button'
@@ -25,6 +26,8 @@ const EMULATOR_CLI_COMMANDS = [
 
 export function MobileEmulatorAgentControlRow(): React.JSX.Element {
   const setup = useMobileEmulatorAgentSetupState(true)
+  const cliSkillInstallCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)
+  const cliSkillUpdateCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND)
 
   const handleEnableCli = async (): Promise<void> => {
     await setup.handleEnableCli()
@@ -130,8 +133,8 @@ export function MobileEmulatorAgentControlRow(): React.JSX.Element {
               'auto.components.settings.MobileEmulatorAgentControlRow.d94ca6a623',
               'Enables agents to use Orca CLI commands, including mobile emulator control.'
             )}
-            command={ORCA_CLI_SKILL_INSTALL_COMMAND}
-            installedCommand={ORCA_CLI_SKILL_UPDATE_COMMAND}
+            command={cliSkillInstallCommand}
+            installedCommand={cliSkillUpdateCommand}
             terminalTitle="Orca CLI skill setup"
             terminalAriaLabel="Orca CLI skill install terminal"
             terminalWorktreeId="settings-mobile-emulator-orca-cli-skill-terminal"

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -9,7 +9,10 @@ import { OrchestrationPane } from './OrchestrationPane'
 
 const INSTALL_COMMAND =
   'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
-const UPDATE_COMMAND = 'npx skills update orchestration --global'
+const UPDATE_COMMAND =
+  process.platform === 'win32'
+    ? INSTALL_COMMAND
+    : 'npx skills update orchestration --global'
 
 const mocks = vi.hoisted(() => ({
   dialogProps: [] as Record<string, unknown>[],

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -3,16 +3,13 @@
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getOrchestrationUsageExamples } from '@/lib/orchestration-usage-examples'
 import { OrchestrationPane } from './OrchestrationPane'
 
 const INSTALL_COMMAND =
   'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
-const UPDATE_COMMAND =
-  process.platform === 'win32'
-    ? INSTALL_COMMAND
-    : 'npx skills update orchestration --global'
+const UPDATE_COMMAND = INSTALL_COMMAND
 
 const mocks = vi.hoisted(() => ({
   dialogProps: [] as Record<string, unknown>[],
@@ -100,6 +97,31 @@ async function renderPane(): Promise<HTMLDivElement> {
 }
 
 describe('OrchestrationPane', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        ...window.api,
+        platform: {
+          get: () => ({ platform: 'win32', osRelease: 'test' })
+        },
+        wsl: {
+          isAvailable: vi.fn().mockResolvedValue(false),
+          listDistros: vi.fn().mockResolvedValue([])
+        },
+        pwsh: {
+          isAvailable: vi.fn().mockResolvedValue(false)
+        },
+        gitBash: {
+          isAvailable: vi.fn().mockResolvedValue(false)
+        },
+        runtime: {
+          getStatus: vi.fn().mockResolvedValue({ hostPlatform: 'win32' })
+        }
+      }
+    })
+  })
+
   afterEach(async () => {
     if (root) {
       await act(async () => {

--- a/src/renderer/src/components/settings/OrchestrationPane.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.tsx
@@ -44,20 +44,18 @@ export function OrchestrationPane(): React.JSX.Element {
   const [selectedExampleId, setSelectedExampleId] = useState<string | null>(null)
   const [skillPromptOpen, setSkillPromptOpen] = useState(false)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  const orchestrationInstallCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          ORCHESTRATION_SKILL_INSTALL_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : ORCHESTRATION_SKILL_INSTALL_COMMAND
-  const orchestrationUpdateCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          ORCHESTRATION_SKILL_UPDATE_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : ORCHESTRATION_SKILL_UPDATE_COMMAND
+  const orchestrationInstallCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(
+        ORCHESTRATION_SKILL_INSTALL_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
+    : ORCHESTRATION_SKILL_INSTALL_COMMAND
+  const orchestrationUpdateCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(
+        ORCHESTRATION_SKILL_UPDATE_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
+    : ORCHESTRATION_SKILL_UPDATE_COMMAND
 
   const {
     installed: orchestrationSkillDetected,

--- a/src/renderer/src/components/settings/OrchestrationSetupCard.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSetupCard.tsx
@@ -25,20 +25,18 @@ export function OrchestrationSetupCard(props: {
 }): JSX.Element {
   const { compact, terminalHeightPx, skill } = props
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  const installCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          ORCHESTRATION_SKILL_INSTALL_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : ORCHESTRATION_SKILL_INSTALL_COMMAND
-  const updateCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          ORCHESTRATION_SKILL_UPDATE_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : ORCHESTRATION_SKILL_UPDATE_COMMAND
+  const installCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(
+        ORCHESTRATION_SKILL_INSTALL_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
+    : ORCHESTRATION_SKILL_INSTALL_COMMAND
+  const updateCommand = !activeSkillRuntime.installDisabledReason
+    ? buildSkillCommandForRuntime(
+        ORCHESTRATION_SKILL_UPDATE_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
+    : ORCHESTRATION_SKILL_UPDATE_COMMAND
 
   const setupPanel = (
     <AgentSkillSetupPanel

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -53,7 +53,7 @@ const updateCapableCallers = new Map<string, readonly string[]>([
   ],
   [
     'src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx',
-    ['ORCA_CLI_SKILL_UPDATE_COMMAND', 'installedCommand={ORCA_CLI_SKILL_UPDATE_COMMAND}']
+    ['ORCA_CLI_SKILL_UPDATE_COMMAND', 'installedCommand={cliSkillUpdateCommand}']
   ]
 ])
 


### PR DESCRIPTION
## Summary

Fixed #6162 the native Windows skill update flow by rewriting npx skills update <skill> --global to the Orca reinstall path on Windows hosts.

This issue was marked as Windows-specific, so WSL behavior is intentionally left unchanged.

  ## Screenshots

  No visual change.

  ## Testing

  - [ ] pnpm lint
  - [ ] pnpm typecheck
  - [ ] pnpm test
  - [ ] pnpm build
  - [x] Added or updated tests covering the Windows fallback

  ## AI Review Report

  Reviewed the change for command construction, runtime branching, and regression risk in the skill setup flow.

  Checked cross-platform behavior for macOS, Linux, and Windows, including shell handling and platform-specific runtime
  differences.

  Verified the fix stays narrow and only affects the Windows-host update path.

  ## Security Audit

  Reviewed shell command handling and input narrowing in the rewrite path.

  No new auth, secrets, IPC, or path-handling risks were introduced.

  The fallback uses a fixed repository URL and only matches the exact update command shape.

  ## Notes

  - Windows host skill updates now use the reinstall path.
  - WSL is unchanged because the issue is Windows-specific.
  - The shared skill command constants were left intact to avoid unrelated side effects.