### PR TITLE
fix: group multi-host projects by git remote identity

### DIFF
--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -81,6 +81,7 @@ import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 import type { RepoMethod } from '../../shared/telemetry-events'
 import { detectRepoIconAndUpstream } from '../repo-icon-autodetect'
+import { enrichMissingRepoGitRemoteIdentities } from '../repo-git-remote-identity-enrichment'
 import { getProjectHostSetupForRepo } from '../../shared/project-host-setup-projection'
 import { normalizeExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
 import { joinRemotePath } from '../ssh/ssh-remote-platform'
@@ -1136,11 +1137,21 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   ipcMain.removeHandler('sparsePresets:save')
   ipcMain.removeHandler('sparsePresets:remove')
 
-  ipcMain.handle('repos:list', () => {
+  ipcMain.handle('repos:list', async () => {
+    const changed = await enrichMissingRepoGitRemoteIdentities(store)
+    if (changed) {
+      notifyReposChanged(mainWindow)
+    }
     return store.getRepos()
   })
 
-  ipcMain.handle('projects:list', () => store.getProjects())
+  ipcMain.handle('projects:list', async () => {
+    const changed = await enrichMissingRepoGitRemoteIdentities(store)
+    if (changed) {
+      notifyReposChanged(mainWindow)
+    }
+    return store.getProjects()
+  })
 
   ipcMain.handle('projects:update', (_event, rawArgs: ProjectUpdateArgs): Project | null => {
     const args = parseProjectGroupIpcArgs(
@@ -1151,7 +1162,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     return store.updateProject(args.projectId, args.updates)
   })
 
-  ipcMain.handle('projectHostSetups:list', () => store.getProjectHostSetups())
+  ipcMain.handle('projectHostSetups:list', async () => {
+    const changed = await enrichMissingRepoGitRemoteIdentities(store)
+    if (changed) {
+      notifyReposChanged(mainWindow)
+    }
+    return store.getProjectHostSetups()
+  })
 
   ipcMain.handle(
     'projectHostSetups:create',

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -1137,19 +1137,17 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   ipcMain.removeHandler('sparsePresets:save')
   ipcMain.removeHandler('sparsePresets:remove')
 
-  ipcMain.handle('repos:list', async () => {
-    const changed = await enrichMissingRepoGitRemoteIdentities(store)
-    if (changed) {
-      notifyReposChanged(mainWindow)
-    }
+  ipcMain.handle('repos:list', () => {
+    enrichMissingRepoGitRemoteIdentities(store, {
+      onChanged: () => notifyReposChanged(mainWindow)
+    })
     return store.getRepos()
   })
 
-  ipcMain.handle('projects:list', async () => {
-    const changed = await enrichMissingRepoGitRemoteIdentities(store)
-    if (changed) {
-      notifyReposChanged(mainWindow)
-    }
+  ipcMain.handle('projects:list', () => {
+    enrichMissingRepoGitRemoteIdentities(store, {
+      onChanged: () => notifyReposChanged(mainWindow)
+    })
     return store.getProjects()
   })
 
@@ -1162,11 +1160,10 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     return store.updateProject(args.projectId, args.updates)
   })
 
-  ipcMain.handle('projectHostSetups:list', async () => {
-    const changed = await enrichMissingRepoGitRemoteIdentities(store)
-    if (changed) {
-      notifyReposChanged(mainWindow)
-    }
+  ipcMain.handle('projectHostSetups:list', () => {
+    enrichMissingRepoGitRemoteIdentities(store, {
+      onChanged: () => notifyReposChanged(mainWindow)
+    })
     return store.getProjectHostSetups()
   })
 

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -72,6 +72,7 @@ import {
   normalizeProjectRuntimePreference
 } from '../shared/project-execution-runtime'
 import { projectHostSetupProjectionFromRepos } from '../shared/project-host-setup-projection'
+import type { GitRemoteIdentity } from '../shared/git-remote-identity'
 import {
   buildTaskSourceContextFromRepo,
   buildWorkspaceRunContext
@@ -1081,6 +1082,24 @@ function sanitizeRepoUpstream(value: unknown): Repo['upstream'] | undefined {
   return owner && repo ? { owner, repo } : undefined
 }
 
+function sanitizeGitRemoteIdentity(value: unknown): GitRemoteIdentity | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+  const candidate = value as {
+    canonicalKey?: unknown
+    remoteName?: unknown
+    remoteUrl?: unknown
+  }
+  const canonicalKey =
+    typeof candidate.canonicalKey === 'string' ? candidate.canonicalKey.trim().toLowerCase() : ''
+  const remoteName = typeof candidate.remoteName === 'string' ? candidate.remoteName.trim() : ''
+  const remoteUrl = typeof candidate.remoteUrl === 'string' ? candidate.remoteUrl.trim() : ''
+  return canonicalKey && remoteName && remoteUrl
+    ? { canonicalKey, remoteName, remoteUrl }
+    : undefined
+}
+
 function sanitizeRepoProjectHostSetupMethod(
   value: unknown
 ): RepoProjectHostSetupMethod | undefined {
@@ -1098,6 +1117,7 @@ function sanitizeRepoUpdatesForPersistence<
       | 'badgeColor'
       | 'repoIcon'
       | 'upstream'
+      | 'gitRemoteIdentity'
       | 'worktreeBasePath'
       | 'projectHostSetupMethod'
       | 'forkSyncMode'
@@ -1128,6 +1148,14 @@ function sanitizeRepoUpdatesForPersistence<
       delete sanitized.upstream
     } else {
       sanitized.upstream = upstream
+    }
+  }
+  if ('gitRemoteIdentity' in sanitized) {
+    const gitRemoteIdentity = sanitizeGitRemoteIdentity(sanitized.gitRemoteIdentity)
+    if (gitRemoteIdentity === undefined) {
+      delete sanitized.gitRemoteIdentity
+    } else {
+      sanitized.gitRemoteIdentity = gitRemoteIdentity
     }
   }
   if ('worktreeBasePath' in sanitized && sanitized.worktreeBasePath !== undefined) {
@@ -3720,6 +3748,7 @@ export class Store {
         | 'badgeColor'
         | 'repoIcon'
         | 'upstream'
+        | 'gitRemoteIdentity'
         | 'hookSettings'
         | 'worktreeBaseRef'
         | 'worktreeBasePath'
@@ -3895,6 +3924,7 @@ export class Store {
     const {
       repoIcon: rawRepoIcon,
       upstream: rawUpstream,
+      gitRemoteIdentity: rawGitRemoteIdentity,
       sourceControlAi: rawSourceControlAi,
       projectHostSetupMethod: rawProjectHostSetupMethod,
       forkSyncMode: rawForkSyncMode,
@@ -3902,6 +3932,7 @@ export class Store {
     } = repo
     const repoIcon = sanitizeRepoIcon(rawRepoIcon)
     const upstream = sanitizeRepoUpstream(rawUpstream)
+    const gitRemoteIdentity = sanitizeGitRemoteIdentity(rawGitRemoteIdentity)
     const sourceControlAi = normalizeRepoSourceControlAiOverrides(rawSourceControlAi)
     const projectHostSetupMethod = sanitizeRepoProjectHostSetupMethod(rawProjectHostSetupMethod)
     const forkSyncMode = sanitizeForkSyncMode(rawForkSyncMode)
@@ -3918,6 +3949,7 @@ export class Store {
       ...repoWithoutIcon,
       ...(repoIcon !== undefined ? { repoIcon } : {}),
       ...(upstream !== undefined ? { upstream } : {}),
+      ...(gitRemoteIdentity !== undefined ? { gitRemoteIdentity } : {}),
       ...(sourceControlAi !== undefined ? { sourceControlAi } : {}),
       ...(projectHostSetupMethod !== undefined ? { projectHostSetupMethod } : {}),
       ...(forkSyncMode !== undefined ? { forkSyncMode } : {}),

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1092,7 +1092,7 @@ function sanitizeGitRemoteIdentity(value: unknown): GitRemoteIdentity | undefine
     remoteUrl?: unknown
   }
   const canonicalKey =
-    typeof candidate.canonicalKey === 'string' ? candidate.canonicalKey.trim().toLowerCase() : ''
+    typeof candidate.canonicalKey === 'string' ? candidate.canonicalKey.trim() : ''
   const remoteName = typeof candidate.remoteName === 'string' ? candidate.remoteName.trim() : ''
   const remoteUrl = typeof candidate.remoteUrl === 'string' ? candidate.remoteUrl.trim() : ''
   return canonicalKey && remoteName && remoteUrl

--- a/src/main/repo-git-remote-identity-enrichment.test.ts
+++ b/src/main/repo-git-remote-identity-enrichment.test.ts
@@ -1,64 +1,137 @@
-import { mkdtemp, rm } from 'fs/promises'
-import { tmpdir } from 'os'
-import { join } from 'path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GitRemoteIdentity } from '../shared/git-remote-identity'
 import type { Repo } from '../shared/types'
-import { gitExecFileAsync } from './git/runner'
-import { enrichMissingRepoGitRemoteIdentities } from './repo-git-remote-identity-enrichment'
+import { detectGitRemoteIdentity } from './repo-git-remote-identity'
+import {
+  enrichMissingRepoGitRemoteIdentities,
+  flushRepoGitRemoteIdentityEnrichmentForTests,
+  resetRepoGitRemoteIdentityEnrichmentForTests
+} from './repo-git-remote-identity-enrichment'
 
-const tempDirs: string[] = []
+vi.mock('./repo-git-remote-identity', () => ({
+  detectGitRemoteIdentity: vi.fn()
+}))
 
-async function makeTempRepoDir(): Promise<string> {
-  const dir = await mkdtemp(join(tmpdir(), 'orca-repo-identity-'))
-  tempDirs.push(dir)
-  return dir
+type RepoIdentityStore = {
+  getRepos: () => Repo[]
+  getRepo: (id: string) => Repo | undefined
+  updateRepo: (id: string, updates: Pick<Partial<Repo>, 'gitRemoteIdentity'>) => Repo | null
 }
 
-function makeStore(repo: Repo): {
-  getRepos: () => Repo[]
-  updateRepo: (id: string, updates: Pick<Partial<Repo>, 'gitRemoteIdentity'>) => Repo | null
-} {
+const remoteIdentity: GitRemoteIdentity = {
+  canonicalKey: 'git.company.test/team/sample-app',
+  remoteName: 'origin',
+  remoteUrl: 'git@git.company.test:team/sample-app.git'
+}
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/workspace/sample-app',
+    displayName: 'sample-app',
+    badgeColor: '#737373',
+    addedAt: 1,
+    kind: 'git',
+    ...overrides
+  }
+}
+
+function makeStore(repo: Repo): RepoIdentityStore & { updateRepo: ReturnType<typeof vi.fn> } {
   const repos = [repo]
   return {
     getRepos: () => repos,
-    updateRepo: (id, updates) => {
+    getRepo: (id) => repos.find((candidate) => candidate.id === id),
+    updateRepo: vi.fn((id, updates) => {
       const target = repos.find((candidate) => candidate.id === id)
       if (!target) {
         return null
       }
       Object.assign(target, updates)
       return target
-    }
+    })
   }
 }
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  resetRepoGitRemoteIdentityEnrichmentForTests()
 })
 
 describe('enrichMissingRepoGitRemoteIdentities', () => {
-  it('backfills a missing git remote identity from local git metadata', async () => {
-    const repoPath = await makeTempRepoDir()
-    await gitExecFileAsync(['init'], { cwd: repoPath })
-    await gitExecFileAsync(
-      ['remote', 'add', 'origin', 'git@git.company.test:team/sample-app.git'],
-      { cwd: repoPath }
-    )
-    const repo: Repo = {
-      id: 'repo-1',
-      path: repoPath,
-      displayName: 'sample-app',
-      badgeColor: '#737373',
-      addedAt: 1,
-      kind: 'git'
-    }
+  it('schedules remote identity enrichment without blocking the caller', async () => {
+    vi.mocked(detectGitRemoteIdentity).mockResolvedValue(remoteIdentity)
+    const repo = makeRepo()
+    const store = makeStore(repo)
+    const onChanged = vi.fn()
+
+    enrichMissingRepoGitRemoteIdentities(store, { onChanged })
+
+    expect(repo.gitRemoteIdentity).toBeUndefined()
+    expect(detectGitRemoteIdentity).toHaveBeenCalledWith('/workspace/sample-app', undefined)
+
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+
+    expect(repo.gitRemoteIdentity).toEqual(remoteIdentity)
+    expect(onChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces concurrent probes for the same repo location', async () => {
+    const probe = deferred<GitRemoteIdentity | null>()
+    vi.mocked(detectGitRemoteIdentity).mockReturnValue(probe.promise)
+    const repo = makeRepo()
     const store = makeStore(repo)
 
-    await expect(enrichMissingRepoGitRemoteIdentities(store)).resolves.toBe(true)
-    expect(repo.gitRemoteIdentity).toEqual({
-      canonicalKey: 'git.company.test/team/sample-app',
-      remoteName: 'origin',
-      remoteUrl: 'git@git.company.test:team/sample-app.git'
-    })
+    enrichMissingRepoGitRemoteIdentities(store)
+    enrichMissingRepoGitRemoteIdentities(store)
+
+    expect(detectGitRemoteIdentity).toHaveBeenCalledTimes(1)
+
+    probe.resolve(remoteIdentity)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+
+    expect(store.updateRepo).toHaveBeenCalledTimes(1)
+    expect(repo.gitRemoteIdentity).toEqual(remoteIdentity)
+  })
+
+  it('caches no-identity probes briefly so list calls do not retry every time', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(detectGitRemoteIdentity).mockResolvedValue(null)
+    const repo = makeRepo()
+    const store = makeStore(repo)
+
+    enrichMissingRepoGitRemoteIdentities(store)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+    enrichMissingRepoGitRemoteIdentities(store)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+
+    expect(detectGitRemoteIdentity).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not write stale identity data after the repo path changes', async () => {
+    const probe = deferred<GitRemoteIdentity | null>()
+    vi.mocked(detectGitRemoteIdentity).mockReturnValue(probe.promise)
+    const repo = makeRepo()
+    const store = makeStore(repo)
+
+    enrichMissingRepoGitRemoteIdentities(store)
+    repo.path = '/workspace/renamed-sample-app'
+    probe.resolve(remoteIdentity)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+
+    expect(store.updateRepo).not.toHaveBeenCalled()
+    expect(repo.gitRemoteIdentity).toBeUndefined()
   })
 })

--- a/src/main/repo-git-remote-identity-enrichment.test.ts
+++ b/src/main/repo-git-remote-identity-enrichment.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Repo } from '../shared/types'
+import { gitExecFileAsync } from './git/runner'
+import { enrichMissingRepoGitRemoteIdentities } from './repo-git-remote-identity-enrichment'
+
+const tempDirs: string[] = []
+
+async function makeTempRepoDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'orca-repo-identity-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function makeStore(repo: Repo): {
+  getRepos: () => Repo[]
+  updateRepo: (id: string, updates: Pick<Partial<Repo>, 'gitRemoteIdentity'>) => Repo | null
+} {
+  const repos = [repo]
+  return {
+    getRepos: () => repos,
+    updateRepo: (id, updates) => {
+      const target = repos.find((candidate) => candidate.id === id)
+      if (!target) {
+        return null
+      }
+      Object.assign(target, updates)
+      return target
+    }
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('enrichMissingRepoGitRemoteIdentities', () => {
+  it('backfills a missing git remote identity from local git metadata', async () => {
+    const repoPath = await makeTempRepoDir()
+    await gitExecFileAsync(['init'], { cwd: repoPath })
+    await gitExecFileAsync(
+      ['remote', 'add', 'origin', 'git@git.company.test:team/sample-app.git'],
+      { cwd: repoPath }
+    )
+    const repo: Repo = {
+      id: 'repo-1',
+      path: repoPath,
+      displayName: 'sample-app',
+      badgeColor: '#737373',
+      addedAt: 1,
+      kind: 'git'
+    }
+    const store = makeStore(repo)
+
+    await expect(enrichMissingRepoGitRemoteIdentities(store)).resolves.toBe(true)
+    expect(repo.gitRemoteIdentity).toEqual({
+      canonicalKey: 'git.company.test/team/sample-app',
+      remoteName: 'origin',
+      remoteUrl: 'git@git.company.test:team/sample-app.git'
+    })
+  })
+})

--- a/src/main/repo-git-remote-identity-enrichment.ts
+++ b/src/main/repo-git-remote-identity-enrichment.ts
@@ -1,27 +1,107 @@
 import type { Repo } from '../shared/types'
 import { detectGitRemoteIdentity } from './repo-git-remote-identity'
 
+const NO_IDENTITY_RETRY_TTL_MS = 5 * 60 * 1000
+
 type RepoIdentityStore = {
   getRepos(): Repo[]
+  getRepo?(id: string): Repo | undefined
   updateRepo(id: string, updates: Pick<Partial<Repo>, 'gitRemoteIdentity'>): Repo | null
 }
 
-export async function enrichMissingRepoGitRemoteIdentities(
-  store: RepoIdentityStore
-): Promise<boolean> {
-  let changed = false
+type EnrichmentOptions = {
+  onChanged?: () => void
+}
+
+const inFlightProbesByLocation = new Map<string, Promise<boolean>>()
+const noIdentityRetryAfterByLocation = new Map<string, number>()
+
+function getRepoLocationKey(repo: Pick<Repo, 'path' | 'connectionId'>): string {
+  return `${repo.connectionId ?? 'local'}\0${repo.path}`
+}
+
+function getCurrentRepo(store: RepoIdentityStore, id: string): Repo | undefined {
+  return store.getRepo?.(id) ?? store.getRepos().find((repo) => repo.id === id)
+}
+
+function isSameUnenrichedRepo(snapshot: Repo, current: Repo | undefined): boolean {
+  return (
+    !!current &&
+    current.kind !== 'folder' &&
+    !current.gitRemoteIdentity &&
+    current.path === snapshot.path &&
+    (current.connectionId ?? null) === (snapshot.connectionId ?? null)
+  )
+}
+
+async function enrichRepoGitRemoteIdentity(store: RepoIdentityStore, repo: Repo): Promise<boolean> {
+  const locationKey = getRepoLocationKey(repo)
+  const retryAfter = noIdentityRetryAfterByLocation.get(locationKey) ?? 0
+  if (retryAfter > Date.now()) {
+    return false
+  }
+  const inFlight = inFlightProbesByLocation.get(locationKey)
+  if (inFlight) {
+    return inFlight
+  }
+  const probe = (async () => {
+    const identity = await detectGitRemoteIdentity(repo.path, repo.connectionId)
+    if (!identity) {
+      // Why: repos without a parseable remote are common; cache misses briefly so
+      // list calls stay cheap while still allowing recent remote changes to land.
+      noIdentityRetryAfterByLocation.set(locationKey, Date.now() + NO_IDENTITY_RETRY_TTL_MS)
+      return false
+    }
+
+    noIdentityRetryAfterByLocation.delete(locationKey)
+    const current = getCurrentRepo(store, repo.id)
+    if (!isSameUnenrichedRepo(repo, current)) {
+      return false
+    }
+    return !!store.updateRepo(repo.id, { gitRemoteIdentity: identity })
+  })().finally(() => {
+    if (inFlightProbesByLocation.get(locationKey) === probe) {
+      inFlightProbesByLocation.delete(locationKey)
+    }
+  })
+  inFlightProbesByLocation.set(locationKey, probe)
+  return probe
+}
+
+async function enrichMissingRepoGitRemoteIdentitiesInBackground(
+  store: RepoIdentityStore,
+  options: EnrichmentOptions
+): Promise<void> {
   const candidates = store
     .getRepos()
     .filter((repo) => repo.kind !== 'folder' && !repo.gitRemoteIdentity)
-
+  let changed = false
   for (const repo of candidates) {
-    const identity = await detectGitRemoteIdentity(repo.path, repo.connectionId)
-    if (!identity) {
-      continue
-    }
-    if (store.updateRepo(repo.id, { gitRemoteIdentity: identity })) {
+    // Why: enrichment runs later; capture the location we probed so a mutable
+    // store cannot make the stale-write guard compare against changed fields.
+    if (await enrichRepoGitRemoteIdentity(store, { ...repo })) {
       changed = true
     }
   }
-  return changed
+  if (changed) {
+    options.onChanged?.()
+  }
+}
+
+export function enrichMissingRepoGitRemoteIdentities(
+  store: RepoIdentityStore,
+  options: EnrichmentOptions = {}
+): void {
+  void enrichMissingRepoGitRemoteIdentitiesInBackground(store, options).catch((error: unknown) => {
+    console.error('[repo-identity] Failed to enrich git remote identities:', error)
+  })
+}
+
+export async function flushRepoGitRemoteIdentityEnrichmentForTests(): Promise<void> {
+  await Promise.all(inFlightProbesByLocation.values())
+}
+
+export function resetRepoGitRemoteIdentityEnrichmentForTests(): void {
+  inFlightProbesByLocation.clear()
+  noIdentityRetryAfterByLocation.clear()
 }

--- a/src/main/repo-git-remote-identity-enrichment.ts
+++ b/src/main/repo-git-remote-identity-enrichment.ts
@@ -1,0 +1,27 @@
+import type { Repo } from '../shared/types'
+import { detectGitRemoteIdentity } from './repo-git-remote-identity'
+
+type RepoIdentityStore = {
+  getRepos(): Repo[]
+  updateRepo(id: string, updates: Pick<Partial<Repo>, 'gitRemoteIdentity'>): Repo | null
+}
+
+export async function enrichMissingRepoGitRemoteIdentities(
+  store: RepoIdentityStore
+): Promise<boolean> {
+  let changed = false
+  const candidates = store
+    .getRepos()
+    .filter((repo) => repo.kind !== 'folder' && !repo.gitRemoteIdentity)
+
+  for (const repo of candidates) {
+    const identity = await detectGitRemoteIdentity(repo.path, repo.connectionId)
+    if (!identity) {
+      continue
+    }
+    if (store.updateRepo(repo.id, { gitRemoteIdentity: identity })) {
+      changed = true
+    }
+  }
+  return changed
+}

--- a/src/main/repo-git-remote-identity.ts
+++ b/src/main/repo-git-remote-identity.ts
@@ -1,0 +1,18 @@
+import { deriveGitRemoteIdentity, type GitRemoteIdentity } from '../shared/git-remote-identity'
+import { gitExecFileAsync } from './git/runner'
+import { getSshGitProvider } from './providers/ssh-git-dispatch'
+
+export async function detectGitRemoteIdentity(
+  repoPath: string,
+  connectionId?: string | null
+): Promise<GitRemoteIdentity | null> {
+  try {
+    const result = connectionId
+      ? await getSshGitProvider(connectionId)?.exec(['remote', '-v'], repoPath)
+      : await gitExecFileAsync(['remote', '-v'], { cwd: repoPath })
+    return result ? deriveGitRemoteIdentity(result.stdout) : null
+  } catch {
+    // Repo creation must not fail because a best-effort remote probe failed.
+    return null
+  }
+}

--- a/src/main/repo-icon-autodetect.test.ts
+++ b/src/main/repo-icon-autodetect.test.ts
@@ -168,6 +168,11 @@ describe('detectRepoIcon', () => {
     })
 
     await expect(detectRepoIconAndUpstream({ repoPath, kind: 'git' })).resolves.toEqual({
+      gitRemoteIdentity: {
+        canonicalKey: 'github.com/stablyai/orca',
+        remoteName: 'upstream',
+        remoteUrl: 'git@github.com:stablyai/orca.git'
+      },
       repoIcon: {
         type: 'image',
         src: 'https://github.com/stablyai.png?size=64',
@@ -175,6 +180,24 @@ describe('detectRepoIcon', () => {
         label: 'stablyai/orca'
       },
       upstream: { owner: 'stablyai', repo: 'orca' }
+    })
+  })
+
+  it('detects a provider-neutral git remote identity for non-GitHub remotes', async () => {
+    const repoPath = await makeTempRepoDir()
+    await gitExecFileAsync(['init'], { cwd: repoPath })
+    await gitExecFileAsync(
+      ['remote', 'add', 'origin', 'git@git.company.test:platform/tools/sample-app.git'],
+      { cwd: repoPath }
+    )
+
+    await expect(detectRepoIconAndUpstream({ repoPath, kind: 'git' })).resolves.toMatchObject({
+      gitRemoteIdentity: {
+        canonicalKey: 'git.company.test/platform/tools/sample-app',
+        remoteName: 'origin',
+        remoteUrl: 'git@git.company.test:platform/tools/sample-app.git'
+      },
+      upstream: null
     })
   })
 })

--- a/src/main/repo-icon-autodetect.ts
+++ b/src/main/repo-icon-autodetect.ts
@@ -9,6 +9,7 @@ import {
 import { getRepoSlug, getRepoUpstream } from './github/client'
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import type { IFilesystemProvider } from './providers/types'
+import { detectGitRemoteIdentity } from './repo-git-remote-identity'
 import { iconHrefCandidates } from './repo-icon-href-candidates'
 import { joinWorktreeRelativePath } from './runtime/runtime-relative-paths'
 
@@ -306,12 +307,8 @@ export async function detectRepoIcon({
   return undefined
 }
 
-/**
- * Detect a repo's icon and its fork upstream together. The upstream is resolved
- * once and reused for the avatar so a fork shows the upstream owner's avatar.
- * Returns a spread-ready slice of `Repo`. For git repos, `upstream: null`
- * is a resolved "not a fork" marker and prevents repeated best-effort probes.
- */
+// Why: `upstream: null` is a resolved "not a fork" marker and prevents
+// repeated best-effort probes.
 export async function detectRepoIconAndUpstream({
   repoPath,
   kind,
@@ -320,11 +317,14 @@ export async function detectRepoIconAndUpstream({
   repoPath: string
   kind: RepoKind
   connectionId?: string | null
-}): Promise<{ repoIcon?: RepoIcon; upstream?: GitHubRepositoryIdentity | null }> {
+}) {
   const upstream = kind === 'git' ? await getRepoUpstream(repoPath, connectionId) : null
+  const gitRemoteIdentity =
+    kind === 'git' ? await detectGitRemoteIdentity(repoPath, connectionId) : null
   const repoIcon = await detectRepoIcon({ repoPath, kind, connectionId, upstream })
   return {
     ...(repoIcon ? { repoIcon } : {}),
+    ...(gitRemoteIdentity ? { gitRemoteIdentity } : {}),
     ...(kind === 'git' ? { upstream: upstream ?? null } : {})
   }
 }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -8808,14 +8808,16 @@ export class OrcaRuntimeService {
     return this.store?.getRepos() ?? []
   }
 
-  async enrichMissingRepoGitRemoteIdentities(): Promise<void> {
+  enrichMissingRepoGitRemoteIdentities(): void {
     if (!this.store) {
       return
     }
-    if (await enrichMissingRepoGitRemoteIdentities(this.store)) {
-      this.invalidateResolvedWorktreeCache()
-      this.notifyReposChanged()
-    }
+    enrichMissingRepoGitRemoteIdentities(this.store, {
+      onChanged: () => {
+        this.invalidateResolvedWorktreeCache()
+        this.notifyReposChanged()
+      }
+    })
   }
 
   listProjects(): Project[] {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -643,6 +643,7 @@ import {
 } from '../project-groups/folder-workspace-path-status'
 import { getSshGitProvider, requireSshGitProvider } from '../providers/ssh-git-dispatch'
 import { detectRepoIconAndUpstream } from '../repo-icon-autodetect'
+import { enrichMissingRepoGitRemoteIdentities } from '../repo-git-remote-identity-enrichment'
 import { githubAvatarIcon } from '../../shared/repo-icon'
 import type { ClaudeAccountService } from '../claude-accounts/service'
 import type { CodexAccountService } from '../codex-accounts/service'
@@ -8805,6 +8806,16 @@ export class OrcaRuntimeService {
 
   listRepos(): Repo[] {
     return this.store?.getRepos() ?? []
+  }
+
+  async enrichMissingRepoGitRemoteIdentities(): Promise<void> {
+    if (!this.store) {
+      return
+    }
+    if (await enrichMissingRepoGitRemoteIdentities(this.store)) {
+      this.invalidateResolvedWorktreeCache()
+      this.notifyReposChanged()
+    }
   }
 
   listProjects(): Project[] {

--- a/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
+++ b/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
@@ -90,7 +90,10 @@ export const PROJECT_RUNTIME_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'project.list',
     params: null,
-    handler: (_params, { runtime }) => ({ projects: runtime.listProjects() })
+    handler: async (_params, { runtime }) => {
+      await runtime.enrichMissingRepoGitRemoteIdentities()
+      return { projects: runtime.listProjects() }
+    }
   }),
   defineMethod({
     name: 'project.update',
@@ -102,7 +105,10 @@ export const PROJECT_RUNTIME_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'projectHostSetup.list',
     params: null,
-    handler: (_params, { runtime }) => ({ setups: runtime.listProjectHostSetups() })
+    handler: async (_params, { runtime }) => {
+      await runtime.enrichMissingRepoGitRemoteIdentities()
+      return { setups: runtime.listProjectHostSetups() }
+    }
   }),
   defineMethod({
     name: 'projectHostSetup.create',

--- a/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
+++ b/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
@@ -90,8 +90,8 @@ export const PROJECT_RUNTIME_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'project.list',
     params: null,
-    handler: async (_params, { runtime }) => {
-      await runtime.enrichMissingRepoGitRemoteIdentities?.()
+    handler: (_params, { runtime }) => {
+      runtime.enrichMissingRepoGitRemoteIdentities?.()
       return { projects: runtime.listProjects() }
     }
   }),
@@ -105,8 +105,8 @@ export const PROJECT_RUNTIME_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'projectHostSetup.list',
     params: null,
-    handler: async (_params, { runtime }) => {
-      await runtime.enrichMissingRepoGitRemoteIdentities?.()
+    handler: (_params, { runtime }) => {
+      runtime.enrichMissingRepoGitRemoteIdentities?.()
       return { setups: runtime.listProjectHostSetups() }
     }
   }),

--- a/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
+++ b/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
@@ -91,7 +91,7 @@ export const PROJECT_RUNTIME_METHODS: RpcMethod[] = [
     name: 'project.list',
     params: null,
     handler: async (_params, { runtime }) => {
-      await runtime.enrichMissingRepoGitRemoteIdentities()
+      await runtime.enrichMissingRepoGitRemoteIdentities?.()
       return { projects: runtime.listProjects() }
     }
   }),
@@ -106,7 +106,7 @@ export const PROJECT_RUNTIME_METHODS: RpcMethod[] = [
     name: 'projectHostSetup.list',
     params: null,
     handler: async (_params, { runtime }) => {
-      await runtime.enrichMissingRepoGitRemoteIdentities()
+      await runtime.enrichMissingRepoGitRemoteIdentities?.()
       return { setups: runtime.listProjectHostSetups() }
     }
   }),

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -158,8 +158,8 @@ export const REPO_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'repo.list',
     params: null,
-    handler: async (_params, { runtime }) => {
-      await runtime.enrichMissingRepoGitRemoteIdentities?.()
+    handler: (_params, { runtime }) => {
+      runtime.enrichMissingRepoGitRemoteIdentities?.()
       return { repos: runtime.listRepos() }
     }
   }),

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -158,7 +158,10 @@ export const REPO_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'repo.list',
     params: null,
-    handler: (_params, { runtime }) => ({ repos: runtime.listRepos() })
+    handler: async (_params, { runtime }) => {
+      await runtime.enrichMissingRepoGitRemoteIdentities()
+      return { repos: runtime.listRepos() }
+    }
   }),
   ...PROJECT_RUNTIME_METHODS,
   defineMethod({

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -159,7 +159,7 @@ export const REPO_METHODS: RpcMethod[] = [
     name: 'repo.list',
     params: null,
     handler: async (_params, { runtime }) => {
-      await runtime.enrichMissingRepoGitRemoteIdentities()
+      await runtime.enrichMissingRepoGitRemoteIdentities?.()
       return { repos: runtime.listRepos() }
     }
   }),

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -29,6 +29,7 @@ import type { AppState } from '@/store/types'
 import {
   getAllWorktreesFromState,
   useAllWorktrees,
+  useProjectHostSetupProjection,
   useRepoMap,
   useWorktreeMap
 } from '@/store/selectors'
@@ -5332,11 +5333,13 @@ const WorktreeList = React.memo(function WorktreeList({
   // Why: manual repo header order is bound to state.repos. Recent/Smart derive
   // header order from the sorted visible worktree stream instead.
   const repos = useAppStore((s) => s.repos)
-  const projects = useAppStore((s) => s.projects)
-  const projectHostSetups = useAppStore((s) => s.projectHostSetups)
+  const projectHostSetupProjection = useProjectHostSetupProjection()
   const projectGrouping = useMemo(
-    () => ({ projects, projectHostSetups }),
-    [projectHostSetups, projects]
+    () => ({
+      projects: projectHostSetupProjection.projects,
+      projectHostSetups: projectHostSetupProjection.setups
+    }),
+    [projectHostSetupProjection]
   )
   const projectGroups = useAppStore((s) => s.projectGroups ?? EMPTY_PROJECT_GROUPS)
   const folderWorkspaces = useAppStore((s) => s.folderWorkspaces)

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -2606,6 +2606,13 @@ describe('WorktreeList header styles', () => {
     expect(source).toContain('headerKey: row.key')
     expect(source).toContain('color={repoHeaderColor}')
   })
+
+  it('adapts projected setup rows for sidebar project grouping', () => {
+    const source = readWorktreeListSource()
+
+    expect(source).toContain('const projectHostSetupProjection = useProjectHostSetupProjection()')
+    expect(source).toContain('projectHostSetups: projectHostSetupProjection.setups')
+  })
 })
 
 describe('buildRows pending creations', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -362,26 +362,41 @@ describe('buildRows with pinned worktrees', () => {
     ])
   })
 
-  it('reproduces legacy same-project records rendering as separate host-local project headers', () => {
+  it('renders same-project records with git remote identity as one mixed-host project header', () => {
     const localRepo: Repo = {
       ...repo,
       id: 'local-sample-app',
       path: '/Users/alice/work/sample-app',
-      displayName: 'sample-app'
+      displayName: 'sample-app',
+      gitRemoteIdentity: {
+        canonicalKey: 'git.company.test/team/sample-app',
+        remoteName: 'origin',
+        remoteUrl: 'git@git.company.test:team/sample-app.git'
+      }
     }
     const sshRepo: Repo = {
       ...repo,
       id: 'ssh-sample-app',
       path: '/home/alice/src/sample-app',
       displayName: 'sample-app',
-      connectionId: 'build server'
+      connectionId: 'build server',
+      gitRemoteIdentity: {
+        canonicalKey: 'git.company.test/team/sample-app',
+        remoteName: 'origin',
+        remoteUrl: 'https://git.company.test/team/sample-app.git'
+      }
     }
     const runtimeRepo: Repo = {
       ...repo,
       id: 'runtime-sample-app',
       path: '/workspace/sample-app',
       displayName: 'sample-app',
-      executionHostId: 'runtime:dev-container'
+      executionHostId: 'runtime:dev-container',
+      gitRemoteIdentity: {
+        canonicalKey: 'git.company.test/team/sample-app',
+        remoteName: 'origin',
+        remoteUrl: 'ssh://git@git.company.test/team/sample-app.git'
+      }
     }
     const localWorktree: Worktree = {
       ...worktree,
@@ -433,16 +448,17 @@ describe('buildRows with pinned worktrees', () => {
       }
     )
 
-    expect(rows.filter((row) => row.type === 'header')).toMatchObject([
-      { key: 'project:repo:local-sample-app', label: 'work/sample-app', count: 1 },
-      { key: 'project:repo:ssh-sample-app', label: 'src/sample-app', count: 1 },
-      { key: 'project:repo:runtime-sample-app', label: 'workspace/sample-app', count: 1 }
+    expect(rows).toMatchObject([
+      {
+        type: 'header',
+        key: 'project:git:git.company.test/team/sample-app',
+        label: 'sample-app',
+        count: 3
+      },
+      { type: 'item', worktree: { id: localWorktree.id }, hostContextLabel: LOCAL_HOST_LABEL },
+      { type: 'item', worktree: { id: sshWorktree.id }, hostContextLabel: 'build server' },
+      { type: 'item', worktree: { id: runtimeWorktree.id }, hostContextLabel: 'dev-container' }
     ])
-    for (const row of rows) {
-      if (row.type === 'item') {
-        expect(row.hostContextLabel).toBeUndefined()
-      }
-    }
   })
 
   it('orders project identity headers by the manual repo order anchor', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { getExecutionHostLabel } from '../../../../shared/execution-host'
+import { projectHostSetupProjectionFromRepos } from '../../../../shared/project-host-setup-projection'
 import {
   ALL_GROUP_META,
   buildRows,
@@ -359,6 +360,89 @@ describe('buildRows with pinned worktrees', () => {
       { type: 'item', worktree: { id: worktree.id }, hostContextLabel: LOCAL_HOST_LABEL },
       { type: 'item', worktree: { id: remoteWorktree.id }, hostContextLabel: 'gpu-vm' }
     ])
+  })
+
+  it('reproduces legacy same-project records rendering as separate host-local project headers', () => {
+    const localRepo: Repo = {
+      ...repo,
+      id: 'local-sample-app',
+      path: '/Users/alice/work/sample-app',
+      displayName: 'sample-app'
+    }
+    const sshRepo: Repo = {
+      ...repo,
+      id: 'ssh-sample-app',
+      path: '/home/alice/src/sample-app',
+      displayName: 'sample-app',
+      connectionId: 'build server'
+    }
+    const runtimeRepo: Repo = {
+      ...repo,
+      id: 'runtime-sample-app',
+      path: '/workspace/sample-app',
+      displayName: 'sample-app',
+      executionHostId: 'runtime:dev-container'
+    }
+    const localWorktree: Worktree = {
+      ...worktree,
+      id: 'wt-local-sample-app',
+      repoId: localRepo.id,
+      path: '/Users/alice/work/sample-app-feature'
+    }
+    const sshWorktree: Worktree = {
+      ...worktree,
+      id: 'wt-ssh-sample-app',
+      repoId: sshRepo.id,
+      path: '/home/alice/src/sample-app-feature'
+    }
+    const runtimeWorktree: Worktree = {
+      ...worktree,
+      id: 'wt-runtime-sample-app',
+      repoId: runtimeRepo.id,
+      path: '/workspace/sample-app-feature'
+    }
+    const projection = projectHostSetupProjectionFromRepos([localRepo, sshRepo, runtimeRepo])
+    const rows = buildRows(
+      'repo',
+      [localWorktree, sshWorktree, runtimeWorktree],
+      new Map([
+        [localRepo.id, localRepo],
+        [sshRepo.id, sshRepo],
+        [runtimeRepo.id, runtimeRepo]
+      ]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([
+        [localWorktree.id, localWorktree],
+        [sshWorktree.id, sshWorktree],
+        [runtimeWorktree.id, runtimeWorktree]
+      ]),
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      [],
+      {
+        projects: projection.projects,
+        projectHostSetups: projection.setups
+      }
+    )
+
+    expect(rows.filter((row) => row.type === 'header')).toMatchObject([
+      { key: 'project:repo:local-sample-app', label: 'work/sample-app', count: 1 },
+      { key: 'project:repo:ssh-sample-app', label: 'src/sample-app', count: 1 },
+      { key: 'project:repo:runtime-sample-app', label: 'workspace/sample-app', count: 1 }
+    ])
+    for (const row of rows) {
+      if (row.type === 'item') {
+        expect(row.hostContextLabel).toBeUndefined()
+      }
+    }
   })
 
   it('orders project identity headers by the manual repo order anchor', () => {

--- a/src/shared/git-remote-identity.test.ts
+++ b/src/shared/git-remote-identity.test.ts
@@ -12,6 +12,9 @@ describe('normalizeGitRemoteUrl', () => {
     expect(normalizeGitRemoteUrl('ssh://git@github.com/example/sample-app.git')).toBe(
       'github.com/example/sample-app'
     )
+    expect(normalizeGitRemoteUrl('https://GitHub.com/example/sample-app.git')).toBe(
+      'github.com/example/sample-app'
+    )
   })
 
   it('preserves nested GitLab/self-hosted paths', () => {
@@ -24,6 +27,20 @@ describe('normalizeGitRemoteUrl', () => {
     expect(normalizeGitRemoteUrl('ssh://git@git.company.test:2222/team/sample-app.git')).toBe(
       'git.company.test/team/sample-app'
     )
+  })
+
+  it('preserves path case for case-sensitive hosted remotes', () => {
+    expect(normalizeGitRemoteUrl('git@Git.Company.Test:Team/Sample-App.git')).toBe(
+      'git.company.test/Team/Sample-App'
+    )
+    expect(normalizeGitRemoteUrl('https://git.company.test/Team/Sample-App.git')).toBe(
+      'git.company.test/Team/Sample-App'
+    )
+  })
+
+  it('rejects Windows local filesystem remotes', () => {
+    expect(normalizeGitRemoteUrl('C:\\Repos\\sample-app.git')).toBeNull()
+    expect(normalizeGitRemoteUrl('C:/Repos/sample-app.git')).toBeNull()
   })
 })
 

--- a/src/shared/git-remote-identity.test.ts
+++ b/src/shared/git-remote-identity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { deriveGitRemoteIdentity, normalizeGitRemoteUrl } from './git-remote-identity'
+
+describe('normalizeGitRemoteUrl', () => {
+  it('normalizes HTTPS and SSH GitHub remotes to the same canonical key', () => {
+    expect(normalizeGitRemoteUrl('https://github.com/example/sample-app.git')).toBe(
+      'github.com/example/sample-app'
+    )
+    expect(normalizeGitRemoteUrl('git@github.com:example/sample-app.git')).toBe(
+      'github.com/example/sample-app'
+    )
+    expect(normalizeGitRemoteUrl('ssh://git@github.com/example/sample-app.git')).toBe(
+      'github.com/example/sample-app'
+    )
+  })
+
+  it('preserves nested GitLab/self-hosted paths', () => {
+    expect(normalizeGitRemoteUrl('git@gitlab.company.test:platform/tools/sample-app.git')).toBe(
+      'gitlab.company.test/platform/tools/sample-app'
+    )
+  })
+
+  it('ignores explicit URL ports in canonical keys', () => {
+    expect(normalizeGitRemoteUrl('ssh://git@git.company.test:2222/team/sample-app.git')).toBe(
+      'git.company.test/team/sample-app'
+    )
+  })
+})
+
+describe('deriveGitRemoteIdentity', () => {
+  it('prefers upstream, then origin, then the first named remote', () => {
+    expect(
+      deriveGitRemoteIdentity(
+        [
+          'origin\tgit@git.company.test:forks/sample-app.git (fetch)',
+          'origin\tgit@git.company.test:forks/sample-app.git (push)',
+          'upstream\thttps://git.company.test/team/sample-app.git (fetch)',
+          'upstream\thttps://git.company.test/team/sample-app.git (push)'
+        ].join('\n')
+      )
+    ).toEqual({
+      canonicalKey: 'git.company.test/team/sample-app',
+      remoteName: 'upstream',
+      remoteUrl: 'https://git.company.test/team/sample-app.git'
+    })
+
+    expect(
+      deriveGitRemoteIdentity('origin\tgit@git.company.test:team/sample-app.git (fetch)')
+    ).toMatchObject({
+      canonicalKey: 'git.company.test/team/sample-app',
+      remoteName: 'origin'
+    })
+
+    expect(
+      deriveGitRemoteIdentity('mirror\tgit@git.company.test:team/sample-app.git (fetch)')
+    ).toMatchObject({
+      canonicalKey: 'git.company.test/team/sample-app',
+      remoteName: 'mirror'
+    })
+  })
+})

--- a/src/shared/git-remote-identity.ts
+++ b/src/shared/git-remote-identity.ts
@@ -1,0 +1,96 @@
+export type GitRemoteIdentity = {
+  canonicalKey: string
+  remoteName: string
+  remoteUrl: string
+}
+
+type GitRemoteEntry = {
+  name: string
+  url: string
+}
+
+function stripGitSuffix(path: string): string {
+  return path.endsWith('.git') ? path.slice(0, -4) : path
+}
+
+function normalizeRemotePath(path: string): string {
+  return stripGitSuffix(path.replace(/^\/+/, '').replace(/\/+$/, '')).toLowerCase()
+}
+
+function normalizeRemoteHost(host: string): string {
+  return host.trim().toLowerCase()
+}
+
+export function normalizeGitRemoteUrl(remoteUrl: string): string | null {
+  const trimmed = remoteUrl.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const scpMatch = trimmed.includes('://') ? null : /^([^@\s:]+@)?([^:\s]+):(.+)$/.exec(trimmed)
+  if (scpMatch) {
+    const host = normalizeRemoteHost(scpMatch[2] ?? '')
+    const path = normalizeRemotePath(scpMatch[3] ?? '')
+    return host && path ? `${host}/${path}` : null
+  }
+
+  try {
+    const parsed = new URL(trimmed)
+    const host = normalizeRemoteHost(parsed.hostname)
+    const path = normalizeRemotePath(parsed.pathname)
+    return host && path ? `${host}/${path}` : null
+  } catch {
+    return null
+  }
+}
+
+export function parseGitRemoteVerboseOutput(stdout: string): GitRemoteEntry[] {
+  const entries: GitRemoteEntry[] = []
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line.endsWith('(fetch)')) {
+      continue
+    }
+    const match = /^(\S+)\s+(.+?)\s+\(fetch\)$/.exec(line)
+    if (!match) {
+      continue
+    }
+    const name = match[1]?.trim()
+    const url = match[2]?.trim()
+    if (name && url) {
+      entries.push({ name, url })
+    }
+  }
+  return entries
+}
+
+function primaryRemoteSortKey(entry: GitRemoteEntry): number {
+  if (entry.name === 'upstream') {
+    return 0
+  }
+  if (entry.name === 'origin') {
+    return 1
+  }
+  return 2
+}
+
+export function deriveGitRemoteIdentity(stdout: string): GitRemoteIdentity | null {
+  const entries = parseGitRemoteVerboseOutput(stdout)
+    .map((entry) => ({
+      ...entry,
+      canonicalKey: normalizeGitRemoteUrl(entry.url)
+    }))
+    .filter((entry): entry is GitRemoteEntry & { canonicalKey: string } => !!entry.canonicalKey)
+    .sort((left, right) => {
+      const priority = primaryRemoteSortKey(left) - primaryRemoteSortKey(right)
+      return priority === 0 ? left.name.localeCompare(right.name) : priority
+    })
+  const selected = entries[0]
+  return selected
+    ? {
+        canonicalKey: selected.canonicalKey,
+        remoteName: selected.name,
+        remoteUrl: selected.url
+      }
+    : null
+}

--- a/src/shared/git-remote-identity.ts
+++ b/src/shared/git-remote-identity.ts
@@ -14,16 +14,23 @@ function stripGitSuffix(path: string): string {
 }
 
 function normalizeRemotePath(path: string): string {
-  return stripGitSuffix(path.replace(/^\/+/, '').replace(/\/+$/, '')).toLowerCase()
+  return stripGitSuffix(path.replace(/^\/+/, '').replace(/\/+$/, ''))
 }
 
 function normalizeRemoteHost(host: string): string {
   return host.trim().toLowerCase()
 }
 
+function isLocalFilesystemRemote(remoteUrl: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(remoteUrl)
+}
+
 export function normalizeGitRemoteUrl(remoteUrl: string): string | null {
   const trimmed = remoteUrl.trim()
   if (!trimmed) {
+    return null
+  }
+  if (isLocalFilesystemRemote(trimmed)) {
     return null
   }
 

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -168,6 +168,65 @@ describe('project host setup projection', () => {
     ])
   })
 
+  it('reproduces legacy same-project records splitting across local, SSH, and runtime hosts', () => {
+    const projection = projectHostSetupProjectionFromRepos([
+      repo({
+        id: 'local-sample-app',
+        path: '/Users/alice/work/sample-app',
+        displayName: 'sample-app'
+      }),
+      repo({
+        id: 'ssh-sample-app',
+        path: '/home/alice/src/sample-app',
+        displayName: 'sample-app',
+        connectionId: 'build server'
+      }),
+      repo({
+        id: 'runtime-sample-app',
+        path: '/workspace/sample-app',
+        displayName: 'sample-app',
+        executionHostId: 'runtime:dev-container'
+      })
+    ])
+
+    expect(projection.projects.map((project) => project.id)).toEqual([
+      'repo:local-sample-app',
+      'repo:ssh-sample-app',
+      'repo:runtime-sample-app'
+    ])
+    expect(projection.setups.map((setup) => setup.hostId)).toEqual([
+      'local',
+      'ssh:build%20server',
+      'runtime:dev-container'
+    ])
+  })
+
+  it('keeps same-named cross-host records separate when there is no shared repo identity', () => {
+    const projection = projectHostSetupProjectionFromRepos([
+      repo({
+        id: 'local-sample-app',
+        path: '/Users/alice/work/sample-app',
+        displayName: 'sample-app'
+      }),
+      repo({
+        id: 'ssh-sample-app',
+        path: '/srv/unrelated/sample-app',
+        displayName: 'sample-app',
+        connectionId: 'staging server'
+      }),
+      repo({
+        id: 'runtime-sample-app',
+        path: '/workspace/sample-app',
+        displayName: 'sample-app',
+        executionHostId: 'runtime:preview'
+      })
+    ])
+
+    // Why: display names are labels, not identity. A future fix needs a
+    // normalized git remote identity or an explicit user link before merging.
+    expect(projection.projects).toHaveLength(3)
+  })
+
   it('ignores malformed provider identity values', () => {
     const projection = projectHostSetupProjectionFromRepos([
       repo({

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -168,37 +168,60 @@ describe('project host setup projection', () => {
     ])
   })
 
-  it('reproduces legacy same-project records splitting across local, SSH, and runtime hosts', () => {
+  it('groups same-project records across local, SSH, and runtime hosts by git remote identity', () => {
     const projection = projectHostSetupProjectionFromRepos([
       repo({
         id: 'local-sample-app',
         path: '/Users/alice/work/sample-app',
-        displayName: 'sample-app'
+        displayName: 'sample-app',
+        gitRemoteIdentity: {
+          canonicalKey: 'git.company.test/team/sample-app',
+          remoteName: 'origin',
+          remoteUrl: 'git@git.company.test:team/sample-app.git'
+        }
       }),
       repo({
         id: 'ssh-sample-app',
         path: '/home/alice/src/sample-app',
         displayName: 'sample-app',
-        connectionId: 'build server'
+        connectionId: 'build server',
+        gitRemoteIdentity: {
+          canonicalKey: 'git.company.test/team/sample-app',
+          remoteName: 'origin',
+          remoteUrl: 'https://git.company.test/team/sample-app.git'
+        }
       }),
       repo({
         id: 'runtime-sample-app',
         path: '/workspace/sample-app',
         displayName: 'sample-app',
-        executionHostId: 'runtime:dev-container'
+        executionHostId: 'runtime:dev-container',
+        gitRemoteIdentity: {
+          canonicalKey: 'git.company.test/team/sample-app',
+          remoteName: 'origin',
+          remoteUrl: 'ssh://git@git.company.test/team/sample-app.git'
+        }
       })
     ])
 
-    expect(projection.projects.map((project) => project.id)).toEqual([
-      'repo:local-sample-app',
-      'repo:ssh-sample-app',
-      'repo:runtime-sample-app'
-    ])
+    expect(projection.projects).toHaveLength(1)
+    expect(projection.projects[0]).toMatchObject({
+      id: 'git:git.company.test/team/sample-app',
+      displayName: 'sample-app',
+      sourceRepoIds: ['local-sample-app', 'ssh-sample-app', 'runtime-sample-app'],
+      gitRemoteIdentity: {
+        canonicalKey: 'git.company.test/team/sample-app',
+        remoteName: 'origin'
+      }
+    })
     expect(projection.setups.map((setup) => setup.hostId)).toEqual([
       'local',
       'ssh:build%20server',
       'runtime:dev-container'
     ])
+    expect(
+      getProjectHostSetupsForProject(projection.setups, 'git:git.company.test/team/sample-app')
+    ).toHaveLength(3)
   })
 
   it('keeps same-named cross-host records separate when there is no shared repo identity', () => {

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -250,6 +250,37 @@ describe('project host setup projection', () => {
     expect(projection.projects).toHaveLength(3)
   })
 
+  it('does not collapse case-distinct remote paths for self-hosted git remotes', () => {
+    const projection = projectHostSetupProjectionFromRepos([
+      repo({
+        id: 'uppercase-repo',
+        path: '/Users/alice/work/sample-app',
+        displayName: 'sample-app',
+        gitRemoteIdentity: {
+          canonicalKey: 'git.company.test/Team/Sample-App',
+          remoteName: 'origin',
+          remoteUrl: 'git@git.company.test:Team/Sample-App.git'
+        }
+      }),
+      repo({
+        id: 'lowercase-repo',
+        path: '/home/alice/src/sample-app',
+        displayName: 'sample-app',
+        connectionId: 'build server',
+        gitRemoteIdentity: {
+          canonicalKey: 'git.company.test/team/sample-app',
+          remoteName: 'origin',
+          remoteUrl: 'git@git.company.test:team/sample-app.git'
+        }
+      })
+    ])
+
+    expect(projection.projects.map((project) => project.id)).toEqual([
+      'git:git.company.test/Team/Sample-App',
+      'git:git.company.test/team/sample-app'
+    ])
+  })
+
   it('ignores malformed provider identity values', () => {
     const projection = projectHostSetupProjectionFromRepos([
       repo({

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -46,7 +46,7 @@ function getProjectGitRemoteIdentity(
 ): NonNullable<Repo['gitRemoteIdentity']> | null {
   const identity = repo.gitRemoteIdentity
   const canonicalKey =
-    typeof identity?.canonicalKey === 'string' ? identity.canonicalKey.trim().toLowerCase() : ''
+    typeof identity?.canonicalKey === 'string' ? identity.canonicalKey.trim() : ''
   const remoteName = typeof identity?.remoteName === 'string' ? identity.remoteName.trim() : ''
   const remoteUrl = typeof identity?.remoteUrl === 'string' ? identity.remoteUrl.trim() : ''
   return canonicalKey && remoteName && remoteUrl ? { canonicalKey, remoteName, remoteUrl } : null

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -41,6 +41,17 @@ function getProjectProviderIdentity(
     : null
 }
 
+function getProjectGitRemoteIdentity(
+  repo: Pick<Repo, 'gitRemoteIdentity'>
+): NonNullable<Repo['gitRemoteIdentity']> | null {
+  const identity = repo.gitRemoteIdentity
+  const canonicalKey =
+    typeof identity?.canonicalKey === 'string' ? identity.canonicalKey.trim().toLowerCase() : ''
+  const remoteName = typeof identity?.remoteName === 'string' ? identity.remoteName.trim() : ''
+  const remoteUrl = typeof identity?.remoteUrl === 'string' ? identity.remoteUrl.trim() : ''
+  return canonicalKey && remoteName && remoteUrl ? { canonicalKey, remoteName, remoteUrl } : null
+}
+
 /** True when the repo resolves to a GitHub provider identity (via explicit
  *  upstream or a GitHub-sourced avatar icon). Used to scope GitHub-CLI setup
  *  prompts to users who actually have GitHub-backed projects. */
@@ -48,20 +59,29 @@ export function isGitHubBackedRepo(repo: Pick<Repo, 'upstream' | 'repoIcon'>): b
   return getProjectProviderIdentity(repo) !== null
 }
 
-export function getProjectIdentityKey(repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon'>): string {
+export function getProjectIdentityKey(
+  repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon' | 'gitRemoteIdentity'>
+): string {
   const identity = getProjectProviderIdentity(repo)
-  if (!identity) {
-    return `repo:${repo.id}`
+  if (identity) {
+    return `github:${normalizeIdentityPart(identity.owner)}/${normalizeIdentityPart(identity.repo)}`
   }
-  return `github:${normalizeIdentityPart(identity.owner)}/${normalizeIdentityPart(identity.repo)}`
+  const gitRemoteIdentity = getProjectGitRemoteIdentity(repo)
+  if (gitRemoteIdentity) {
+    return `git:${gitRemoteIdentity.canonicalKey}`
+  }
+  return `repo:${repo.id}`
 }
 
-function getProjectId(repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon'>): string {
+function getProjectId(
+  repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon' | 'gitRemoteIdentity'>
+): string {
   return getProjectIdentityKey(repo)
 }
 
 function createProjectFromRepo(repo: Repo, now: number): Project {
   const identity = getProjectProviderIdentity(repo)
+  const gitRemoteIdentity = getProjectGitRemoteIdentity(repo)
   return {
     id: getProjectId(repo),
     displayName: repo.displayName,
@@ -69,6 +89,7 @@ function createProjectFromRepo(repo: Repo, now: number): Project {
     ...(repo.repoIcon !== undefined ? { repoIcon: repo.repoIcon } : {}),
     ...(repo.kind ? { kind: repo.kind } : {}),
     ...(identity ? { providerIdentity: identity } : {}),
+    ...(gitRemoteIdentity ? { gitRemoteIdentity } : {}),
     sourceRepoIds: [repo.id],
     createdAt: repo.addedAt || now,
     updatedAt: repo.addedAt || now

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -35,6 +35,7 @@ import type { ClaudeAgentTeamsMode } from './claude-agent-teams-tmux-compat'
 import type { TerminalCustomTheme } from './terminal-custom-themes'
 import type { UiLanguage } from './ui-language'
 import type { ForkSyncMode } from './git-fork-sync'
+import type { GitRemoteIdentity } from './git-remote-identity'
 import type {
   GlobalWindowsRuntimeDefault,
   LocalWindowsRuntimePreference
@@ -109,6 +110,7 @@ export type Project = {
   repoIcon?: RepoIcon | null
   kind?: RepoKind
   providerIdentity?: ProjectProviderIdentity
+  gitRemoteIdentity?: GitRemoteIdentity
   /** Local Windows projects inherit the global runtime default unless this override is set. */
   localWindowsRuntimePreference?: LocalWindowsRuntimePreference
   sourceRepoIds: string[]
@@ -235,6 +237,7 @@ export type Repo = {
    *  default avatar (upstream owner, not the personal fork) and the fork
    *  indicator. Absent = not a fork, or fork status not yet resolved. */
   upstream?: GitHubRepositoryIdentity | null
+  gitRemoteIdentity?: GitRemoteIdentity | null
   addedAt: number
   kind?: RepoKind
   gitUsername?: string


### PR DESCRIPTION
## Summary
- Add provider-neutral git remote identity normalization for SSH/HTTPS remotes, including nested GitLab/self-hosted paths
- Persist `gitRemoteIdentity` on repos/projects and use it in compatibility projection when GitHub provider identity is unavailable
- Backfill missing identities for legacy local, SSH, and runtime repos without blocking list APIs
- Coalesce enrichment probes, cache no-identity misses briefly, and guard against stale identity writes
- Reject Windows local filesystem remotes and preserve remote path case for case-sensitive self-hosted providers
- Update sidebar/projection regression coverage so same canonical remotes merge across hosts, while same-name/no-identity repos stay separate
- Wire the sidebar to the merged project/setup projection so partial persisted setup rows do not split a same-identity project back into separate headers

Refs #6259

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm build:relay`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/git-remote-identity.test.ts src/shared/project-host-setup-projection.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/main/repo-icon-autodetect.test.ts src/main/repo-git-remote-identity-enrichment.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/remote-runtime-request-connection.integration.test.ts -t "fetches repos|multiplexes shared-control"`
- [x] Brennan live SSH/Electron validation: launched this PR worktree in an isolated Electron profile, verified `window.api.app.getIdentity()` for branch `Jinwoo-H/bug-multi-machine-same-project-sidebar-view`, connected a disposable Ubuntu 24.04 Docker SSH target through Orca's real SSH relay, registered local and SSH-hosted `demo-project` checkouts with the same `github.com/stablyai/demo-project` identity, and verified the sidebar renders one project header with the SSH workspace nested under it and labeled by host.

## Brennan notes
- The first live pass exposed a real UI wiring gap: backing projection collapsed both repos, but `WorktreeList` used raw partial `projectHostSetups`, so the sidebar still rendered two headers.
- Fixed in `ed63b57a9` by adapting `useProjectHostSetupProjection()` into the sidebar grouping model and adding a regression guard.