### PR TITLE
Fix diff tab reselect after opening file tab

### DIFF
--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -579,6 +579,46 @@ describe('createEditorSlice openDiff', () => {
     expect(store.getState().activeGroupIdByWorktree['wt-1']).toBe(targetGroupId)
   })
 
+  it('keeps a diff tab selectable after opening its target file tab', () => {
+    const store = createEditorTabsStore()
+
+    store.getState().openDiff('wt-1', '/repo/file.ts', 'file.ts', 'typescript', false)
+    const diffFileId = 'wt-1::diff::unstaged::file.ts'
+    const diffTab = store
+      .getState()
+      .unifiedTabsByWorktree['wt-1']?.find((tab) => tab.contentType === 'diff')
+    if (!diffTab) {
+      throw new Error('expected diff tab')
+    }
+
+    store.getState().openFile({
+      filePath: '/repo/file.ts',
+      relativePath: 'file.ts',
+      worktreeId: 'wt-1',
+      language: 'typescript',
+      mode: 'edit'
+    })
+
+    const stateAfterOpen = store.getState()
+    const editFile = stateAfterOpen.openFiles.find((file) => file.mode === 'edit')
+    expect(stateAfterOpen.openFiles.find((file) => file.id === diffFileId)).toEqual(
+      expect.objectContaining({ mode: 'diff' })
+    )
+    expect(editFile).toEqual(expect.objectContaining({ id: '/repo/file.ts', mode: 'edit' }))
+    expect(
+      stateAfterOpen.unifiedTabsByWorktree['wt-1']?.find((tab) => tab.contentType === 'editor')
+        ?.entityId
+    ).toBe('/repo/file.ts')
+
+    store.getState().activateTab(diffTab.id)
+    store.getState().setActiveFile(diffFileId)
+
+    const stateAfterReselect = store.getState()
+    expect(stateAfterReselect.groupsByWorktree['wt-1']?.[0]?.activeTabId).toBe(diffTab.id)
+    expect(stateAfterReselect.activeFileId).toBe(diffFileId)
+    expect(stateAfterReselect.openFiles.find((file) => file.id === diffFileId)?.mode).toBe('diff')
+  })
+
   it('reuses a preview editor tab when opening a preview diff', () => {
     const store = createEditorTabsStore()
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -978,6 +978,12 @@ function matchesEditorMode(
   return !modes || modes.includes(file.mode)
 }
 
+function getReusableOpenFileModes(mode: OpenFile['mode']): readonly OpenFile['mode'][] {
+  // Why: the same path can be open as both a diff and an editable file; matching
+  // by path alone collapses those distinct visible tabs onto one OpenFile.
+  return [mode]
+}
+
 function resolveEditorFileIdForOwner(
   state: Pick<EditorSlice, 'openFiles'>,
   filePath: string,
@@ -1507,11 +1513,20 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             (options?.suppressActiveRuntimeFallback
               ? null
               : (s.settings?.activeRuntimeEnvironmentId?.trim() ?? undefined)))
+      const reusableOpenFileModes = getReusableOpenFileModes(file.mode)
       const existing = s.openFiles.find(
         (f) =>
-          f.filePath === file.filePath && isSameEditorOwner(f, worktreeId, runtimeEnvironmentId)
+          f.filePath === file.filePath &&
+          matchesEditorMode(f, reusableOpenFileModes) &&
+          isSameEditorOwner(f, worktreeId, runtimeEnvironmentId)
       )
-      const id = resolveEditorFileIdForOwner(s, file.filePath, worktreeId, runtimeEnvironmentId)
+      const id = resolveEditorFileIdForOwner(
+        s,
+        file.filePath,
+        worktreeId,
+        runtimeEnvironmentId,
+        reusableOpenFileModes
+      )
       editorItemFileId = id
       const isPreview = options?.preview ?? false
       const recordReplacedPreview = options?.recordReplacedPreview ?? false


### PR DESCRIPTION
## Summary
- keep diff and editable file tabs backed by separate OpenFile records when they share the same path
- add a regression covering opening a file tab from a diff tab and then reselecting the diff

## Review loop
- Ran one review-until-clean round against the branch diff; no in-scope issues remained after the fix.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/editor.test.ts
- pnpm exec oxlint src/renderer/src/store/slices/editor.ts src/renderer/src/store/slices/editor.test.ts
- pnpm run typecheck:web
- Manual Electron/CDP validation: opened an unstaged diff, opened the matching file tab, reselected the diff tab, and confirmed the rendered diff tab stayed active.