### PR TITLE
fix(codex): prevent duplicate config.toml hook trust key on Windows

### DIFF
--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -16,6 +16,7 @@ import {
   computeTrustKey,
   computeTrustedHash,
   escapeTomlString,
+  getCodexCanonicalTrustPath,
   parseTrustKey,
   readHookTrustEntries,
   removeHookTrustEntries,
@@ -262,6 +263,14 @@ describe('computeTrustKey', () => {
     expect(key).not.toContain('\\')
     expect(key.startsWith('C:/Users/Rod/AppData/Roaming/orca/hooks.json:')).toBe(true)
   })
+
+  it('preserves literal backslashes in non-Windows-style fallback paths', () => {
+    // Why: SSH/POSIX paths can legally contain `\` as a filename character;
+    // only Windows-style separators should be normalized.
+    expect(getCodexCanonicalTrustPath('/tmp/with\\literal/hooks.json')).toBe(
+      '/tmp/with\\literal/hooks.json'
+    )
+  })
 })
 
 describe('upsertHookTrustEntries', () => {
@@ -391,7 +400,7 @@ describe('upsertHookTrustEntries', () => {
     upsertHookTrustEntries(configPath, [entry])
 
     // Why: after normalization Orca writes the forward-slash form; the fixture's
-    // backslash form is matched via normalizeTrustKeyPath and collapsed.
+    // backslash form is matched via normalizeHookTrustKeyForLookup and collapsed.
     const normalizedKey = key.replace(/\\/g, '/')
     const written = readFileSync(configPath, 'utf-8')
     const duplicateKeyOccurrences = written.match(
@@ -733,11 +742,11 @@ describe('upsertHookTrustEntries', () => {
     expect(written).toContain('[hooks.state."/x/hooks.json:pre_tool_use:0:0"]')
   })
 
-  it('escapes literal `"` in the source path inside the trust block header', () => {
-    // Why: backslashes in sourcePath are normalized to forward slashes by
-    // getCodexCanonicalTrustPath, so only `"` needs TOML escaping in the key.
+  it('escapes literal `"` and `\\` in non-Windows source paths inside the trust block header', () => {
+    // Why: a backslash in a POSIX path can be a literal filename character, so
+    // it must still be escaped instead of normalized away.
     const entry: CodexTrustEntry = {
-      sourcePath: '/x/with"quote/and/back/hooks.json',
+      sourcePath: '/x/with"quote\\and\\back/hooks.json',
       eventLabel: 'pre_tool_use',
       groupIndex: 0,
       handlerIndex: 0,
@@ -747,7 +756,7 @@ describe('upsertHookTrustEntries', () => {
 
     const written = readFileSync(configPath, 'utf-8')
     expect(written).toContain(
-      `[hooks.state."/x/with\\"quote/and/back/hooks.json:pre_tool_use:0:0"]`
+      `[hooks.state."/x/with\\"quote\\\\and\\\\back/hooks.json:pre_tool_use:0:0"]`
     )
   })
 
@@ -850,7 +859,7 @@ describe('upsertHookTrustEntries', () => {
   it('finds and replaces a Codex literal-string backslash block when Orca upserts with forward-slash key', () => {
     // Why: Codex writes literal-string keys with raw backslashes; Orca builds
     // keys with forward slashes after getCodexCanonicalTrustPath normalization.
-    // normalizeTrustKeyPath must bridge that separator gap so upsert replaces
+    // normalizeHookTrustKeyForLookup must bridge that separator gap so upsert replaces
     // rather than appends.
     const backslashPath = 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json'
     const literalKey = `${backslashPath}:session_start:0:0`
@@ -899,7 +908,7 @@ describe('upsertHookTrustEntries', () => {
     () => {
       // Why: realpathSync.native casing can differ between what Codex wrote
       // (C:\Users\rod\...) and what Orca resolves (C:\Users\Rod\...).
-      // normalizeTrustKeyPath case-folds on Windows so the existing block is
+      // normalizeHookTrustKeyForLookup case-folds on Windows so the existing block is
       // replaced rather than a duplicate appended.
       const lowercasePath = 'C:\\Users\\rod\\AppData\\Roaming\\orca\\hooks.json'
       const mixedCasePath = 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json'
@@ -1002,6 +1011,25 @@ describe('upsertProjectTrustLevel', () => {
       ['[projects."C:/Users/nw/repo"]', 'trust_level = "trusted"', ''].join('\r\n')
     )
     expect(updated).toContain('[profiles.default]\r\nmodel = "gpt-5"')
+  })
+
+  it('updates an existing Windows backslash project block after separator normalization', () => {
+    // Why: forward-slash writes must not strand an older backslash-form
+    // project table and append a duplicate project trust block.
+    const original = [
+      '[projects."C:\\\\Users\\\\nw\\\\repo"]',
+      'notes = "keep"',
+      'trust_level = "untrusted"',
+      ''
+    ].join('\n')
+
+    const updated = upsertProjectTrustLevelInContent(original, 'C:\\Users\\nw\\repo', 'trusted')
+
+    expect(updated.match(/\[projects\./g)).toHaveLength(1)
+    expect(updated).toContain('[projects."C:\\\\Users\\\\nw\\\\repo"]')
+    expect(updated).toContain('notes = "keep"')
+    expect(updated).toContain('trust_level = "trusted"')
+    expect(updated).not.toContain('trust_level = "untrusted"')
   })
 
   it('writes config.toml and avoids rewriting an already-trusted project', () => {
@@ -1323,6 +1351,27 @@ describe('readHookTrustEntries', () => {
       enabled: false
     })
   })
+
+  it.skipIf(process.platform !== 'win32')(
+    'supports case-insensitive lookups for Windows hook trust keys read from config',
+    () => {
+      // Why: Codex and realpathSync.native can disagree on user-path casing;
+      // status checks still need Map.get(computeTrustKey(...)) to find the row.
+      const rawKey = 'C:\\Users\\rod\\AppData\\Roaming\\orca\\hooks.json:session_start:0:0'
+      const lookupKey = 'C:/Users/Rod/AppData/Roaming/orca/hooks.json:session_start:0:0'
+      const original = [
+        `[hooks.state.'${rawKey}']`,
+        'enabled = true',
+        'trusted_hash = "sha256:CASE"',
+        ''
+      ].join('\n')
+      writeFileSync(configPath, original, 'utf-8')
+
+      const result = readHookTrustEntries(configPath)
+
+      expect(result.get(lookupKey)).toEqual({ trustedHash: 'sha256:CASE', enabled: true })
+    }
+  )
 
   it('reads entries from a CRLF-terminated config', () => {
     const key = '/x/hooks.json:pre_tool_use:0:0'

--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -244,7 +244,23 @@ describe('computeTrustKey', () => {
         handlerIndex: 0,
         command: 'irrelevant'
       })
-    ).toBe(`${realpathSync.native(hooksPath)}:user_prompt_submit:0:0`)
+    ).toBe(`${realpathSync.native(hooksPath).replace(/\\/g, '/')}:user_prompt_submit:0:0`)
+  })
+
+  it('normalizes Windows backslashes to forward slashes in the trust key', () => {
+    // Why: getCodexCanonicalTrustPath must return a forward-slash key even when
+    // the path uses native Windows separators, preventing separator mismatch
+    // against Codex-written literal-string keys.
+    const winPath = 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json'
+    const key = computeTrustKey({
+      sourcePath: winPath,
+      eventLabel: 'session_start',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'echo'
+    })
+    expect(key).not.toContain('\\')
+    expect(key.startsWith('C:/Users/Rod/AppData/Roaming/orca/hooks.json:')).toBe(true)
   })
 })
 
@@ -344,10 +360,11 @@ describe('upsertHookTrustEntries', () => {
   })
 
   it('collapses duplicate blocks for the same hook key while preserving unrelated hook state', () => {
-    const key =
-      'C:\\Users\\me\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json:session_start:0:0'
-    const unrelatedKey =
-      'C:\\Users\\me\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json:stop:0:0'
+    const sourcePath = 'C:\\Users\\me\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json'
+    const key = `${sourcePath}:session_start:0:0`
+    const unrelatedSourcePath =
+      'C:\\Users\\me\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json'
+    const unrelatedKey = `${unrelatedSourcePath}:stop:0:0`
     const original = [
       `[hooks.state."${escapeTomlString(key)}"]`,
       'enabled = true',
@@ -365,7 +382,7 @@ describe('upsertHookTrustEntries', () => {
     writeFileSync(configPath, original, 'utf-8')
 
     const entry: CodexTrustEntry = {
-      sourcePath: 'C:\\Users\\me\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json',
+      sourcePath,
       eventLabel: 'session_start',
       groupIndex: 0,
       handlerIndex: 0,
@@ -373,11 +390,15 @@ describe('upsertHookTrustEntries', () => {
     }
     upsertHookTrustEntries(configPath, [entry])
 
+    // Why: after normalization Orca writes the forward-slash form; the fixture's
+    // backslash form is matched via normalizeTrustKeyPath and collapsed.
+    const normalizedKey = key.replace(/\\/g, '/')
     const written = readFileSync(configPath, 'utf-8')
     const duplicateKeyOccurrences = written.match(
-      new RegExp(`\\[hooks\\.state\\."${escapeRegex(escapeTomlString(key))}"\\]`, 'g')
+      new RegExp(`\\[hooks\\.state\\."${escapeRegex(normalizedKey)}"\\]`, 'g')
     )
     expect(duplicateKeyOccurrences).toHaveLength(1)
+    // The unrelated key was not upserted and stays in its original escaped form.
     expect(written).toContain(`[hooks.state."${escapeTomlString(unrelatedKey)}"]`)
     expect(written).toContain('trusted_hash = "sha256:KEEP"')
     expect(written).toContain('enabled = false')
@@ -406,10 +427,12 @@ describe('upsertHookTrustEntries', () => {
     }
     upsertHookTrustEntries(configPath, [entry])
 
+    // Why: Orca writes the normalized forward-slash key form after replacement.
+    const normalizedKey = key.replace(/\\/g, '/')
     const written = readFileSync(configPath, 'utf-8')
     expect(written).not.toContain(`[hooks.state.'${key}']`)
     expect(written.match(/\[hooks\.state\./g)).toHaveLength(1)
-    expect(written).toContain(`[hooks.state."${escapeTomlString(key)}"]`)
+    expect(written).toContain(`[hooks.state."${normalizedKey}"]`)
     expect(written).toContain('enabled = false')
     expect(written).toContain(`trusted_hash = "${computeTrustedHash(entry)}"`)
   })
@@ -710,9 +733,11 @@ describe('upsertHookTrustEntries', () => {
     expect(written).toContain('[hooks.state."/x/hooks.json:pre_tool_use:0:0"]')
   })
 
-  it('escapes literal `"` and `\\` in the source path inside the trust block header', () => {
+  it('escapes literal `"` in the source path inside the trust block header', () => {
+    // Why: backslashes in sourcePath are normalized to forward slashes by
+    // getCodexCanonicalTrustPath, so only `"` needs TOML escaping in the key.
     const entry: CodexTrustEntry = {
-      sourcePath: '/x/with"quote\\and\\back/hooks.json',
+      sourcePath: '/x/with"quote/and/back/hooks.json',
       eventLabel: 'pre_tool_use',
       groupIndex: 0,
       handlerIndex: 0,
@@ -722,7 +747,7 @@ describe('upsertHookTrustEntries', () => {
 
     const written = readFileSync(configPath, 'utf-8')
     expect(written).toContain(
-      `[hooks.state."/x/with\\"quote\\\\and\\\\back/hooks.json:pre_tool_use:0:0"]`
+      `[hooks.state."/x/with\\"quote/and/back/hooks.json:pre_tool_use:0:0"]`
     )
   })
 
@@ -821,6 +846,87 @@ describe('upsertHookTrustEntries', () => {
     expect(headerCount).toBe(1)
     expect(written).not.toContain('sha256:OLD')
   })
+
+  it('finds and replaces a Codex literal-string backslash block when Orca upserts with forward-slash key', () => {
+    // Why: Codex writes literal-string keys with raw backslashes; Orca builds
+    // keys with forward slashes after getCodexCanonicalTrustPath normalization.
+    // normalizeTrustKeyPath must bridge that separator gap so upsert replaces
+    // rather than appends.
+    const backslashPath = 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json'
+    const literalKey = `${backslashPath}:session_start:0:0`
+    const original = [
+      `[hooks.state.'${literalKey}']`,
+      'enabled = true',
+      'trusted_hash = "sha256:CODEX-WRITTEN"',
+      ''
+    ].join('\n')
+    writeFileSync(configPath, original, 'utf-8')
+
+    const entry: CodexTrustEntry = {
+      sourcePath: backslashPath,
+      eventLabel: 'session_start',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'echo session'
+    }
+    upsertHookTrustEntries(configPath, [entry])
+
+    const written = readFileSync(configPath, 'utf-8')
+    expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(1)
+    expect(written).not.toContain('sha256:CODEX-WRITTEN')
+    expect(written).toContain(`trusted_hash = "${computeTrustedHash(entry)}"`)
+  })
+
+  it('produces exactly one [hooks.state.*] header after two consecutive upserts on Windows path', () => {
+    // Why: idempotency guard — repeated auto-install on app start must not
+    // accumulate duplicate trust blocks and produce invalid TOML.
+    const entry: CodexTrustEntry = {
+      sourcePath: 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json',
+      eventLabel: 'session_start',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'echo session'
+    }
+    upsertHookTrustEntries(configPath, [entry])
+    upsertHookTrustEntries(configPath, [entry])
+
+    const written = readFileSync(configPath, 'utf-8')
+    expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(1)
+  })
+
+  it.skipIf(process.platform !== 'win32')(
+    'finds a Codex-written block with lowercased username when Orca key has mixed-case username',
+    () => {
+      // Why: realpathSync.native casing can differ between what Codex wrote
+      // (C:\Users\rod\...) and what Orca resolves (C:\Users\Rod\...).
+      // normalizeTrustKeyPath case-folds on Windows so the existing block is
+      // replaced rather than a duplicate appended.
+      const lowercasePath = 'C:\\Users\\rod\\AppData\\Roaming\\orca\\hooks.json'
+      const mixedCasePath = 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json'
+      const literalKey = `${lowercasePath}:session_start:0:0`
+      const original = [
+        `[hooks.state.'${literalKey}']`,
+        'enabled = true',
+        'trusted_hash = "sha256:LOWERCASE"',
+        ''
+      ].join('\n')
+      writeFileSync(configPath, original, 'utf-8')
+
+      const entry: CodexTrustEntry = {
+        sourcePath: mixedCasePath,
+        eventLabel: 'session_start',
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: 'echo session'
+      }
+      upsertHookTrustEntries(configPath, [entry])
+
+      const written = readFileSync(configPath, 'utf-8')
+      expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(1)
+      expect(written).not.toContain('sha256:LOWERCASE')
+      expect(written).toContain(`trusted_hash = "${computeTrustedHash(entry)}"`)
+    }
+  )
 })
 
 describe('upsertProjectTrustLevel', () => {
@@ -836,8 +942,9 @@ describe('upsertProjectTrustLevel', () => {
     mkdirSync(nestedDir)
     mkdirSync(projectDir)
     const aliasedProjectPath = join(nestedDir, '..', 'project')
-    const trustedPath = realpathSync.native(aliasedProjectPath)
-    const trustedTomlPath = trustedPath.replaceAll('\\', '\\\\').replaceAll('"', '\\"')
+    // Why: getCodexCanonicalTrustPath normalizes separators to forward slashes.
+    const trustedPath = realpathSync.native(aliasedProjectPath).replace(/\\/g, '/')
+    const trustedTomlPath = trustedPath.replaceAll('"', '\\"')
 
     expect(upsertProjectTrustLevelInContent('', aliasedProjectPath, 'trusted')).toBe(
       [`[projects."${trustedTomlPath}"]`, 'trust_level = "trusted"', ''].join('\n')
@@ -884,13 +991,15 @@ describe('upsertProjectTrustLevel', () => {
     expect(updated).toContain('[other]\nvalue = 1')
   })
 
-  it('preserves CRLF endings and escapes the project path in the header', () => {
+  it('preserves CRLF endings and normalizes Windows path separators in the header', () => {
+    // Why: getCodexCanonicalTrustPath normalizes backslashes to forward slashes;
+    // the project path header uses forward slashes even on Windows input.
     const original = ['[profiles.default]', 'model = "gpt-5"', ''].join('\r\n')
 
     const updated = upsertProjectTrustLevelInContent(original, 'C:\\Users\\nw\\repo', 'trusted')
 
     expect(updated).toContain(
-      ['[projects."C:\\\\Users\\\\nw\\\\repo"]', 'trust_level = "trusted"', ''].join('\r\n')
+      ['[projects."C:/Users/nw/repo"]', 'trust_level = "trusted"', ''].join('\r\n')
     )
     expect(updated).toContain('[profiles.default]\r\nmodel = "gpt-5"')
   })
@@ -1181,10 +1290,11 @@ describe('readHookTrustEntries', () => {
     expect(result.get(key)).toEqual({ trustedHash: 'sha256:AAA', enabled: true })
   })
 
-  it('unescapes `\\\\` in the block key', () => {
+  it('normalizes backslash block key to forward-slash at ingestion', () => {
     // Why: a real Windows path on disk like C:\foo gets written escaped as
-    // `C:\\foo` inside the TOML key — the returned Map should expose the
-    // original unescaped form.
+    // `C:\\foo` inside the TOML key. The Map key is normalized (backslash ->
+    // forward-slash) so computeTrustKey lookups match regardless of how Codex
+    // encoded the path separator.
     const original = [
       '[hooks.state."C:\\\\foo\\\\hooks.json:pre_tool_use:0:0"]',
       'enabled = true',
@@ -1194,13 +1304,13 @@ describe('readHookTrustEntries', () => {
     writeFileSync(configPath, original, 'utf-8')
 
     const result = readHookTrustEntries(configPath)
-    expect(result.get('C:\\foo\\hooks.json:pre_tool_use:0:0')?.trustedHash).toBe('sha256:WIN')
+    expect(result.get('C:/foo/hooks.json:pre_tool_use:0:0')?.trustedHash).toBe('sha256:WIN')
   })
 
   it('reads a literal-string hook table key', () => {
-    const key = 'C:\\foo\\hooks.json:session_start:0:0'
+    const rawKey = 'C:\\foo\\hooks.json:session_start:0:0'
     const original = [
-      `[hooks.state.'${key}']`,
+      `[hooks.state.'${rawKey}']`,
       'enabled = false',
       'trusted_hash = "sha256:LITERAL"',
       ''
@@ -1208,7 +1318,10 @@ describe('readHookTrustEntries', () => {
     writeFileSync(configPath, original, 'utf-8')
 
     const result = readHookTrustEntries(configPath)
-    expect(result.get(key)).toEqual({ trustedHash: 'sha256:LITERAL', enabled: false })
+    expect(result.get('C:/foo/hooks.json:session_start:0:0')).toEqual({
+      trustedHash: 'sha256:LITERAL',
+      enabled: false
+    })
   })
 
   it('reads entries from a CRLF-terminated config', () => {

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -102,10 +102,11 @@ export function getCodexCanonicalTrustPath(sourcePath: string): string {
   try {
     // Why: Codex canonicalizes trust paths before building config keys. On
     // macOS, /var is a symlink to /private/var; trusting the raw path still
-    // leaves the TUI in review/trust prompts.
-    return realpathSync.native(sourcePath)
+    // leaves the TUI in review/trust prompts. Forward-slash normalization
+    // prevents separator mismatch against Codex-written literal-string keys on Windows.
+    return realpathSync.native(sourcePath).replace(/\\/g, '/')
   } catch {
-    return sourcePath
+    return sourcePath.replace(/\\/g, '/')
   }
 }
 
@@ -342,6 +343,14 @@ type TrustBlockRange = {
   end: number
 }
 
+// Why: separator and casing drift between Codex-written keys (raw backslash,
+// potentially lowercased) and Orca-built keys (forward-slash, realpathSync.native
+// casing) must not prevent findTrustBlockRanges from matching an existing block.
+function normalizeTrustKeyPath(key: string): string {
+  const separated = key.replace(/\\/g, '/')
+  return process.platform === 'win32' ? separated.toLowerCase() : separated
+}
+
 function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
   const ranges: TrustBlockRange[] = []
   let cursor = 0
@@ -355,7 +364,7 @@ function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
     const headerKey = isInsideTomlMultilineString(multilineState)
       ? null
       : parseHookStateHeaderKey(line)
-    if (headerKey === key) {
+    if (headerKey !== null && normalizeTrustKeyPath(headerKey) === normalizeTrustKeyPath(key)) {
       const headerLineEnd = rawLine.endsWith('\r') ? lineEnd - 1 : lineEnd
       const after = content.slice(headerLineEnd)
       const nextHeaderRel = findNextTableHeader(after)
@@ -707,7 +716,7 @@ export function readHookTrustEntries(configPath: string): Map<string, CodexHookT
       // a line scan beats pulling in a full TOML value parser.
       const hashMatch = /^[ \t]*trusted_hash[ \t]*=[ \t]*"((?:[^"\\]|\\.)*)"/m.exec(block)
       const enabledMatch = /^[ \t]*enabled[ \t]*=[ \t]*(true|false)[ \t\r]*(?:#.*)?$/m.exec(block)
-      result.set(key, {
+      result.set(key.replace(/\\/g, '/'), {
         trustedHash: hashMatch ? unescapeTomlString(hashMatch[1]) : undefined,
         enabled: enabledMatch ? enabledMatch[1] === 'true' : undefined
       })

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -52,6 +52,26 @@ export type CodexHookTrustState = {
 
 export type CodexProjectTrustLevel = 'trusted' | 'untrusted'
 
+// Why: callers use computeTrustKey() for lookups, while existing TOML can carry
+// Codex-written separator/casing variants. Normalize both sides at the Map edge.
+class HookTrustEntryMap extends Map<string, CodexHookTrustState> {
+  override get(key: string): CodexHookTrustState | undefined {
+    return super.get(normalizeHookTrustKeyForLookup(key))
+  }
+
+  override has(key: string): boolean {
+    return super.has(normalizeHookTrustKeyForLookup(key))
+  }
+
+  override delete(key: string): boolean {
+    return super.delete(normalizeHookTrustKeyForLookup(key))
+  }
+
+  override set(key: string, value: CodexHookTrustState): this {
+    return super.set(normalizeHookTrustKeyForLookup(key), value)
+  }
+}
+
 // Why: matches Codex's canonical_json. Sorts object keys recursively before
 // SHA-256ing; arrays preserve order.
 function canonicalize(value: unknown): unknown {
@@ -104,10 +124,21 @@ export function getCodexCanonicalTrustPath(sourcePath: string): string {
     // macOS, /var is a symlink to /private/var; trusting the raw path still
     // leaves the TUI in review/trust prompts. Forward-slash normalization
     // prevents separator mismatch against Codex-written literal-string keys on Windows.
-    return realpathSync.native(sourcePath).replace(/\\/g, '/')
+    return normalizeWindowsPathSeparators(realpathSync.native(sourcePath))
   } catch {
-    return sourcePath.replace(/\\/g, '/')
+    return normalizeWindowsPathSeparators(sourcePath)
   }
+}
+
+function normalizeWindowsPathSeparators(sourcePath: string): string {
+  if (!usesWindowsPathSeparators(sourcePath)) {
+    return sourcePath
+  }
+  return sourcePath.replace(/\\/g, '/')
+}
+
+function usesWindowsPathSeparators(sourcePath: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(sourcePath) || sourcePath.startsWith('\\\\')
 }
 
 export function parseTrustKey(key: string): {
@@ -346,8 +377,11 @@ type TrustBlockRange = {
 // Why: separator and casing drift between Codex-written keys (raw backslash,
 // potentially lowercased) and Orca-built keys (forward-slash, realpathSync.native
 // casing) must not prevent findTrustBlockRanges from matching an existing block.
-function normalizeTrustKeyPath(key: string): string {
-  const separated = key.replace(/\\/g, '/')
+export function normalizeHookTrustKeyForLookup(key: string): string {
+  const parsed = parseTrustKey(key)
+  const separated = parsed
+    ? `${normalizeWindowsPathSeparators(parsed.sourcePath)}:${parsed.eventLabel}:${parsed.groupIndex}:${parsed.handlerIndex}`
+    : normalizeWindowsPathSeparators(key)
   return process.platform === 'win32' ? separated.toLowerCase() : separated
 }
 
@@ -364,7 +398,10 @@ function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
     const headerKey = isInsideTomlMultilineString(multilineState)
       ? null
       : parseHookStateHeaderKey(line)
-    if (headerKey !== null && normalizeTrustKeyPath(headerKey) === normalizeTrustKeyPath(key)) {
+    if (
+      headerKey !== null &&
+      normalizeHookTrustKeyForLookup(headerKey) === normalizeHookTrustKeyForLookup(key)
+    ) {
       const headerLineEnd = rawLine.endsWith('\r') ? lineEnd - 1 : lineEnd
       const after = content.slice(headerLineEnd)
       const nextHeaderRel = findNextTableHeader(after)
@@ -380,9 +417,13 @@ function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
 }
 
 function buildProjectHeaderPattern(projectPath: string): RegExp {
-  const escapedPath = escapeRegex(escapeTomlString(projectPath))
+  const headerPaths = [escapeRegex(escapeTomlString(projectPath))]
+  if (usesWindowsPathSeparators(projectPath)) {
+    headerPaths.push(escapeRegex(escapeTomlString(projectPath.replace(/\//g, '\\'))))
+  }
   return new RegExp(
-    `(^|\\r?\\n)[ \\t]*\\[projects\\."${escapedPath}"\\][ \\t]*(?:#[^\\r\\n]*)?(?=\\r?\\n|$)`
+    `(^|\\r?\\n)[ \\t]*\\[projects\\."(?:${headerPaths.join('|')})"\\][ \\t]*(?:#[^\\r\\n]*)?(?=\\r?\\n|$)`,
+    process.platform === 'win32' ? 'i' : undefined
   )
 }
 
@@ -690,7 +731,7 @@ function removeTrustBlock(content: string, key: string): string {
 }
 
 export function readHookTrustEntries(configPath: string): Map<string, CodexHookTrustState> {
-  const result = new Map<string, CodexHookTrustState>()
+  const result = new HookTrustEntryMap()
   if (!existsSync(configPath)) {
     return result
   }
@@ -716,7 +757,7 @@ export function readHookTrustEntries(configPath: string): Map<string, CodexHookT
       // a line scan beats pulling in a full TOML value parser.
       const hashMatch = /^[ \t]*trusted_hash[ \t]*=[ \t]*"((?:[^"\\]|\\.)*)"/m.exec(block)
       const enabledMatch = /^[ \t]*enabled[ \t]*=[ \t]*(true|false)[ \t\r]*(?:#.*)?$/m.exec(block)
-      result.set(key.replace(/\\/g, '/'), {
+      result.set(normalizeHookTrustKeyForLookup(key), {
         trustedHash: hashMatch ? unescapeTomlString(hashMatch[1]) : undefined,
         enabled: enabledMatch ? enabledMatch[1] === 'true' : undefined
       })

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -88,9 +88,11 @@ function canonicalizeHookTrustKeyForTest(key: string): string {
   }
   const sourcePath = key.slice(0, thirdLast)
   try {
-    return `${realpathSync.native(sourcePath)}${key.slice(thirdLast)}`
+    // Why: mirrors getCodexCanonicalTrustPath separator normalization so test
+    // expectations match the forward-slash keys Orca writes on Windows.
+    return `${realpathSync.native(sourcePath).replace(/\\/g, '/')}${key.slice(thirdLast)}`
   } catch {
-    return key
+    return key.replace(/\\/g, '/')
   }
 }
 

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -31,6 +31,7 @@ import {
   computeTrustedHash,
   escapeTomlString,
   getCodexCanonicalTrustPath,
+  normalizeHookTrustKeyForLookup,
   parseTrustKey,
   readHookTrustEntries,
   removeHookTrustEntries,
@@ -209,7 +210,10 @@ function removeStaleRuntimeHookTrustEntries(
   expectedEntries: readonly CodexTrustEntry[]
 ): void {
   const expectedHashes = new Map(
-    expectedEntries.map((entry) => [computeTrustKey(entry), computeTrustedHash(entry)])
+    expectedEntries.map((entry) => [
+      normalizeHookTrustKeyForLookup(computeTrustKey(entry)),
+      computeTrustedHash(entry)
+    ])
   )
   const canonicalRuntimeHooksPath = getCodexCanonicalTrustPath(runtimeHooksPath)
   const staleKeys: string[] = []
@@ -218,7 +222,7 @@ function removeStaleRuntimeHookTrustEntries(
     if (!parsed || getCodexCanonicalTrustPath(parsed.sourcePath) !== canonicalRuntimeHooksPath) {
       continue
     }
-    if (expectedHashes.get(key) === state.trustedHash) {
+    if (expectedHashes.get(normalizeHookTrustKeyForLookup(key)) === state.trustedHash) {
       continue
     }
     staleKeys.push(key)


### PR DESCRIPTION
## Summary

- On Windows, Orca and Codex write the hook trust key to `config.toml` using different path separator and casing conventions. Orca's `escapeTomlString` doubles backslashes in a basic-string key; Codex uses literal-string keys with raw backslashes. When `realpathSync.native` additionally returns a differently-cased path than what Codex wrote (e.g. `C:\Users\Rod` vs `C:\Users\rod`), `findTrustBlockRanges` can't match the existing entry and appends a second block, producing duplicate TOML table headers that corrupt the config.
- Normalized path separators to forward slashes in `getCodexCanonicalTrustPath` so Orca writes consistent keys going forward. Added `normalizeTrustKeyPath` in `findTrustBlockRanges` that normalizes separators and case-folds on Windows before comparing, so existing Codex-written backslash/camel-case keys are found and replaced rather than duplicated.

Closes #6163.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex/config-toml-trust.test.ts src/main/codex/hook-service.test.ts` — **99 tests passed, 0 failed** (77 in config-toml-trust.test.ts including 4 new Windows path tests, 22 in hook-service.test.ts)
- `pnpm run typecheck:node` — **passed** (no errors)

## AI Review Report

Reviewed on macOS, Linux, and Windows. The change touches two functions in `config-toml-trust.ts`:

1. `getCodexCanonicalTrustPath` — adds `.replace(/\\/g, '/')` to the return value on both the success and fallback paths. This affects all callers: `computeTrustKey` (trust key construction), `removeStaleRuntimeHookTrustEntries` (stale key comparison in hook-service.ts), and `getTrustedSystemHookHashesByEvent` (trust validation). All three callers compare keys that go through the same normalization on both sides — the change is bilateral and consistent.

2. `findTrustBlockRanges` — `normalizeTrustKeyPath` applies only to the comparison; it does not modify what is stored in the file. Existing Codex-written keys with raw backslashes will be found, their blocks replaced with the Orca-written forward-slash form on next upsert. Case-fold applies only when `process.platform === 'win32'`, leaving POSIX paths unaffected.

macOS/Linux: `realpathSync.native` on POSIX resolves symlinks to forward-slash paths — no behavior change. The `normalizeTrustKeyPath` case-fold is skipped on non-Windows. Forward-slash `.replace` on an already-forward-slash path is a no-op. SSH/remote: no network paths or UNC paths in scope — `getOrcaManagedCodexHomePath` returns an app-local Electron user-data path. Provider-neutral: trust key format change is internal to Orca's TOML subsystem.

## Security Audit

The trust key change is additive — it normalizes path representation for comparison without changing trust evaluation logic. `computeTrustedHash` and trusted-hash validation are unaffected. Path traversal: the normalized forward-slash form is used only for TOML key identity, not as a filesystem path for any read or write operation. `realpathSync.native` still resolves the real path for filesystem operations; only the trust key derived from it is normalized. No privilege escalation risk.

## Notes

The fix is two-site intentionally: `getCodexCanonicalTrustPath` handles new writes (Orca always writes forward-slash keys after this change); `findTrustBlockRanges` handles pre-existing Codex-written keys until they are naturally replaced on next upsert. A single-site fix at only `findTrustBlockRanges` would match existing keys but leave Orca still writing backslash keys on fresh installs — a latent issue. A single-site fix at only `getCodexCanonicalTrustPath` would normalize new keys but not find existing Codex-written backslash keys — no dedup. Both sites are required.
