### PR TITLE
fix: route floating popup close shortcuts to the originating tab

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -415,7 +415,7 @@ export function setupGuestShortcutForwarding(args: {
       // renderer-owned parked webview's goForward() path directly.
       renderer.send('ui:browserHistoryNavigate', 'forward')
     } else if (keybindingMatchesAction('tab.close', input, process.platform, keybindings)) {
-      renderer.send('ui:closeActiveTab')
+      renderer.send('ui:closeActiveTab', { browserTabId })
     } else if (keybindingMatchesAction('tab.nextSameType', input, process.platform, keybindings)) {
       renderer.send('ui:switchTab', 1)
     } else if (

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -1628,7 +1628,9 @@ describe('browserManager', () => {
 
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:newBrowserTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:newTerminalTab')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab', {
+      browserTabId: 'browser-1'
+    })
     expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTab', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:switchTerminalTab', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:openQuickOpen')

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2353,7 +2353,7 @@ export type PreloadApi = {
     onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void
     onZoomBrowserPage: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void
     onHardReloadBrowserPage: (callback: () => void) => () => void
-    onCloseActiveTab: (callback: () => void) => () => void
+    onCloseActiveTab: (callback: (payload?: { browserTabId?: string }) => void) => () => void
     onSwitchTab: (callback: (direction: 1 | -1) => void) => () => void
     onSwitchTabAcrossAllTypes: (callback: (direction: 1 | -1) => void) => () => void
     onSwitchRecentTab: (callback: () => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2918,8 +2918,9 @@ const api = {
       ipcRenderer.on('ui:hardReloadBrowserPage', listener)
       return () => ipcRenderer.removeListener('ui:hardReloadBrowserPage', listener)
     },
-    onCloseActiveTab: (callback: () => void): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent) => callback()
+    onCloseActiveTab: (callback: (payload?: { browserTabId?: string }) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload?: { browserTabId?: string }) =>
+        callback(payload)
       ipcRenderer.on('ui:closeActiveTab', listener)
       return () => ipcRenderer.removeListener('ui:closeActiveTab', listener)
     },

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -1435,6 +1435,47 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.createTab).not.toHaveBeenCalled()
   })
 
+  it('restores floating panel focus after returning from another app', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const activeElement = { blur: vi.fn() }
+    const panelElement = {
+      contains: vi.fn((node: unknown) => node === activeElement),
+      focus: vi.fn()
+    }
+    const outsideElement = {}
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+    Object.setPrototypeOf(outsideElement, HTMLElement.prototype)
+    attachRef(panel.props.ref, panelElement)
+    const documentStub = {
+      activeElement,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+    vi.stubGlobal('document', documentStub)
+    runEffects()
+    panelElement.focus.mockClear()
+    const blurListeners = vi
+      .mocked(window.addEventListener)
+      .mock.calls.filter(([type]) => type === 'blur')
+      .map(([, listener]) => listener as () => void)
+    const focusListener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([type]) => type === 'focus')?.[1] as (() => void) | undefined
+    const blurListener = blurListeners.at(-1)
+    if (!blurListener || !focusListener) {
+      throw new Error('window focus listeners not registered')
+    }
+
+    blurListener()
+    documentStub.activeElement = outsideElement as never
+    focusListener()
+
+    expect(activeElement.blur).toHaveBeenCalledWith()
+    expect(panelElement.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
   it('routes focused floating tab switch shortcuts to the floating workspace', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' }), makeTab({ id: 'tab-2' })])
     const element = await renderPanel(true)

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -234,6 +234,7 @@ export function FloatingTerminalPanel({
   const pendingEditorCloseQueueRef = useRef<string[]>([])
   const saveDialogFileIdRef = useRef<string | null>(null)
   const panelRef = useRef<HTMLDivElement | null>(null)
+  const shouldRestorePanelFocusAfterWindowFocusRef = useRef(false)
   const doubleTapDetectorRef = useRef<ModifierDoubleTapDetector | null>(null)
   if (!doubleTapDetectorRef.current) {
     doubleTapDetectorRef.current = new ModifierDoubleTapDetector()
@@ -1371,6 +1372,7 @@ export function FloatingTerminalPanel({
 
   useEffect(() => {
     if (!open || typeof document === 'undefined') {
+      shouldRestorePanelFocusAfterWindowFocusRef.current = false
       return
     }
 
@@ -1391,21 +1393,41 @@ export function FloatingTerminalPanel({
       const panel = panelRef.current
       const active = document.activeElement
       if (!panel || !(active instanceof HTMLElement) || !panel.contains(active)) {
+        shouldRestorePanelFocusAfterWindowFocusRef.current = false
         return
       }
+      shouldRestorePanelFocusAfterWindowFocusRef.current = true
       // Why: browser webviews focus out-of-process and do not emit renderer
       // pointerdown events, so release floating ownership on renderer blur too.
       setFloatingTerminalInputFocusedInMain(false)
       active.blur()
     }
+    const handleWindowFocus = (): void => {
+      if (!shouldRestorePanelFocusAfterWindowFocusRef.current) {
+        return
+      }
+      shouldRestorePanelFocusAfterWindowFocusRef.current = false
+      const panel = panelRef.current
+      const active = document.activeElement
+      if (!panel || (active instanceof HTMLElement && panel.contains(active))) {
+        return
+      }
+      // Why: macOS app switching can blur the floating panel without a click.
+      // Restore panel ownership so Cmd/Ctrl+W cannot fall through to main tabs.
+      focusPanelForShortcuts(false)
+    }
 
     document.addEventListener('pointerdown', handleOutsidePointerDown, true)
     window.addEventListener('blur', handleWindowBlur)
+    window.addEventListener('focus', handleWindowFocus)
     return () => {
+      shouldRestorePanelFocusAfterWindowFocusRef.current = false
       document.removeEventListener('pointerdown', handleOutsidePointerDown, true)
       window.removeEventListener('blur', handleWindowBlur)
+      window.removeEventListener('focus', handleWindowFocus)
     }
-  }, [open])
+  }, [focusPanelForShortcuts, open])
+
   const handleDragStart = (event: React.PointerEvent<HTMLDivElement>): void => {
     if (maximized) {
       return

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2202,7 +2202,7 @@ describe('useIpcEvents browser tab close routing', () => {
     tabId: string | null
     worktreeId?: string
   }) => void
-  type CloseActiveTabListener = () => void
+  type CloseActiveTabListener = (payload?: { browserTabId?: string }) => void
   type CloseTerminalListener = (data: { tabId: string; paneRuntimeId?: number | null }) => void
   type CloseSessionTabListener = (data: { tabId: string; worktreeId: string }) => void
 
@@ -2528,6 +2528,29 @@ describe('useIpcEvents browser tab close routing', () => {
     onConfirm()
 
     expect(closeBrowserTab).toHaveBeenCalledWith('workspace-1')
+  })
+
+  it('closes the browser tab that emitted a guest Cmd+W event', async () => {
+    const closeActiveTabListenerRef: { current: CloseActiveTabListener | null } = { current: null }
+    const closeBrowserTab = vi.fn()
+
+    await useIpcEventsForCloseRouting({
+      closeActiveTabListenerRef,
+      getState: () => ({
+        activeBrowserTabId: 'main-browser',
+        browserTabsByWorktree: {
+          'wt-1': [{ id: 'main-browser' }],
+          floating: [{ id: 'floating-browser' }]
+        },
+        closeBrowserTab,
+        unifiedTabsByWorktree: {}
+      })
+    })
+
+    closeActiveTabListenerRef.current?.({ browserTabId: 'floating-browser' })
+
+    expect(closeBrowserTab).toHaveBeenCalledWith('floating-browser')
+    expect(closeBrowserTab).not.toHaveBeenCalledWith('main-browser')
   })
 
   it('confirms CLI workspace browser closes and replies after confirmation', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -171,6 +171,16 @@ function findBrowserPageWorktreeId(store: AppState, browserPageId: string): stri
   return null
 }
 
+function findBrowserTabWorktreeId(store: AppState, browserTabId: string): string | null {
+  for (const [worktreeId, browserTabs] of Object.entries(store.browserTabsByWorktree)) {
+    if (browserTabs.some((tab) => tab.id === browserTabId)) {
+      return worktreeId
+    }
+  }
+
+  return null
+}
+
 function acquireBrowserAutomationBootstrapLease(
   worktreeId: string | null | undefined,
   browserPageId?: string | null
@@ -2322,42 +2332,54 @@ export function useIpcEvents(): void {
     )
 
     unsubs.push(
-      window.api.ui.onCloseActiveTab(() => {
+      window.api.ui.onCloseActiveTab((payload) => {
         if (isEmptyFloatingWorkspacePanelVisible()) {
           window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
           return
         }
         const store = useAppStore.getState()
-        if (store.activeTabType === 'browser' && store.activeBrowserTabId) {
-          const tabId = store.activeBrowserTabId
-          const worktreeId = store.activeWorktreeId
-          const closeActiveBrowserTab = (): void => {
-            const currentStore = useAppStore.getState()
-            const environmentId = getWorktreeRuntimeEnvironmentId(worktreeId)
-            if (environmentId && worktreeId) {
-              if (!isWebRuntimeSessionActive(environmentId)) {
-                currentStore.closeBrowserTab(tabId)
-                return
-              }
-              void closeWebRuntimeSessionTab({
-                worktreeId,
-                tabId,
-                environmentId
-              })
+        const payloadBrowserTabId =
+          payload && typeof payload.browserTabId === 'string' ? payload.browserTabId : null
+        const tabId =
+          payloadBrowserTabId ??
+          (store.activeTabType === 'browser' && store.activeBrowserTabId
+            ? store.activeBrowserTabId
+            : null)
+        if (!tabId) {
+          return
+        }
+        const worktreeId = payloadBrowserTabId
+          ? findBrowserTabWorktreeId(store, payloadBrowserTabId)
+          : store.activeWorktreeId
+        if (!worktreeId) {
+          return
+        }
+        const closeBrowserTab = (): void => {
+          const currentStore = useAppStore.getState()
+          const environmentId = getWorktreeRuntimeEnvironmentId(worktreeId)
+          if (environmentId) {
+            if (!isWebRuntimeSessionActive(environmentId)) {
+              currentStore.closeBrowserTab(tabId)
               return
             }
-            currentStore.closeBrowserTab(tabId)
-          }
-          if (worktreeId && isPinnedSessionTab(store, worktreeId, tabId)) {
-            guardPinnedTabClose({
-              isPinned: true,
-              tabLabel: resolvePinnedTabLabel(store, worktreeId, tabId),
-              onClose: closeActiveBrowserTab
+            void closeWebRuntimeSessionTab({
+              worktreeId,
+              tabId,
+              environmentId
             })
             return
           }
-          closeActiveBrowserTab()
+          currentStore.closeBrowserTab(tabId)
         }
+        if (isPinnedSessionTab(store, worktreeId, tabId)) {
+          guardPinnedTabClose({
+            isPinned: true,
+            tabLabel: resolvePinnedTabLabel(store, worktreeId, tabId),
+            onClose: closeBrowserTab
+          })
+          return
+        }
+        closeBrowserTab()
       })
     )
 


### PR DESCRIPTION
## Problem

Pressing `Cmd/Ctrl+W` while a floating/popup browser window had focus closed the **active tab in the main window behind it**, instead of the tab in the focused popup. In some states `Cmd+W` appeared not to work on the popup at all.

## Root cause

- Browser-guest shortcut forwarding sent a generic `ui:closeActiveTab` with no tab identity.
- The renderer then closed `store.activeBrowserTabId` (the globally active browser tab), which is the main-window tab, not the one that owned focus.
- The floating workspace panel also dropped focus on macOS app switching, so after returning to the app `Cmd+W` could fall through to the main window's handler.

## Fix

- `browser-guest-ui.ts`: forward `ui:closeActiveTab` with a `{ browserTabId }` payload identifying the originating guest tab.
- `preload` (`api-types.ts`, `index.ts`): thread the optional close payload through the IPC bridge.
- `useIpcEvents.ts`: close the tab identified by the payload (resolving its worktree via a new `findBrowserTabWorktreeId` helper) instead of the global active tab; falls back to prior behavior when no payload is present.
- `FloatingTerminalPanel.tsx`: restore floating-panel focus when the window regains focus, if the panel owned focus before blur — so `Cmd/Ctrl+W` no longer leaks to the main tab after an app switch.

## Tests

- `browser-manager.test.ts` — asserts the new `{ browserTabId }` payload is forwarded.
- `useIpcEvents.test.ts` — closes the originating browser tab from a guest `Cmd+W` event.
- `FloatingTerminalPanel.test.tsx` — restores floating panel focus after returning from another app.
- `pnpm run typecheck` passes.