### PR TITLE
Fix duplicate hibernated agent resume

### DIFF
--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -119,6 +119,30 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
   })
 
+  it('skips hibernated stable panes after their live PTY binding is cleared', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const record = makeRecord({ paneKey, origin: 'worktree-sleep', state: 'done' })
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
   it('skips legacy numeric pane-key records owned by a preserved tab wake hint', () => {
     const record = makeRecord({ paneKey: 'tab-1:0', origin: 'worktree-sleep' })
     useAppStore.setState({

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -11,7 +11,11 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
-import type { TerminalTab } from '../../../shared/types'
+import type {
+  TerminalLayoutSnapshot,
+  TerminalPaneLayoutNode,
+  TerminalTab
+} from '../../../shared/types'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { translate } from '@/i18n/i18n'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
@@ -141,13 +145,27 @@ function hasRestorableLegacyTabPty(
   return Boolean(tab.ptyId) || (ptyIdsByTabId[tab.id]?.length ?? 0) > 0
 }
 
+function layoutContainsLeaf(
+  node: TerminalPaneLayoutNode | null | undefined,
+  leafId: string
+): boolean {
+  if (!node) {
+    return false
+  }
+  if (node.type === 'leaf') {
+    return node.leafId === leafId
+  }
+  return layoutContainsLeaf(node.first, leafId) || layoutContainsLeaf(node.second, leafId)
+}
+
 function hasMatchingStablePaneLayout(
   tabId: string,
   leafId: string,
-  terminalLayoutsByTabId: ReturnType<typeof useAppStore.getState>['terminalLayoutsByTabId']
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
 ): boolean {
-  const ptyIdsByLeafId = terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId
-  return Boolean(ptyIdsByLeafId && Object.hasOwn(ptyIdsByLeafId, leafId))
+  // Why: hibernation intentionally clears the live PTY binding after the pane
+  // exits, but the preserved leaf still owns cold-restore for its session.
+  return layoutContainsLeaf(terminalLayoutsByTabId[tabId]?.root, leafId)
 }
 
 function findSameWorktreeTab(


### PR DESCRIPTION
The desired invariant is:

  - If the original terminal pane still exists, wake/resume must happen in that same pane.
  - A new tab is only acceptable when the original pane/tab is gone and there is no preserved layout owner left.

  That is what the PR fixes.

## Summary
- Treat a preserved terminal layout leaf as the owner of a sleeping agent session even after hibernation clears its live PTY binding
- Add regression coverage so waking a hibernated split pane does not launch the same provider session in a new tab

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts src/renderer/src/lib/worktree-activation-created-agent.test.ts
- pnpm exec oxlint src/renderer/src/lib/resume-sleeping-agent-session.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts

## Notes
- Web typecheck currently stops on an unrelated existing error in src/renderer/src/components/terminal-pane/useSessionRestoredBannerDismiss.test.tsx:27.

Made with [Orca](https://github.com/stablyai/orca) 🐋
