### PR TITLE
Validate entry metadata when matching cached combined diff sections

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -55,10 +55,7 @@ import {
   createCombinedDiffSectionIndexMap,
   handleCombinedDiffFileTreeNavigation
 } from './CombinedDiffFileTree'
-import {
-  getCombinedDiffFileTreeSectionKey,
-  type CombinedDiffFileTreeMode
-} from './combined-diff-file-tree-model'
+import { getCombinedDiffFileTreeSectionKey } from './combined-diff-file-tree-model'
 import {
   ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
   type EditorPathMutationTarget
@@ -77,6 +74,7 @@ import type { DiffSection } from './diff-section-types'
 import { getInitialCombinedDiffSectionLoadIndices } from './combined-diff-initial-section-load'
 import { removeDiffSectionMeasuredHeight } from './diff-section-height-cache'
 import { createCombinedDiffLoadScheduler } from './combined-diff-load-scheduler'
+import { combinedDiffSectionsMatchEntryMetadata } from './combined-diff-section-cache-match'
 import {
   beginCombinedDiffScrollbarDrag,
   type CombinedDiffScrollbarDragCleanup
@@ -208,26 +206,6 @@ function getInitialCombinedDiffFileTreeCollapsed(
   // Why: the tree is opt-in for new sessions; only an explicit saved setting
   // should make it the opening surface while settings are still loading.
   return combinedDiffFileTreeCollapsedPreference ?? combinedDiffFileTreeVisibleByDefault !== true
-}
-
-function cachedCombinedDiffSectionsMatchEntries({
-  entries,
-  sections,
-  treeMode
-}: {
-  entries: readonly (GitStatusEntry | GitBranchChangeEntry)[]
-  sections: readonly DiffSection[]
-  treeMode: CombinedDiffFileTreeMode
-}): boolean {
-  return (
-    sections.length === entries.length &&
-    sections.every((section, index) => {
-      const entry = entries[index]
-      return (
-        entry !== undefined && section.key === getCombinedDiffFileTreeSectionKey(treeMode, entry)
-      )
-    })
-  )
 }
 
 export default function CombinedDiffViewer({
@@ -541,7 +519,7 @@ export default function CombinedDiffViewer({
     const canRestoreSnapshotSectionsByKey =
       hasUncommittedEntriesSnapshot &&
       cached !== undefined &&
-      cachedCombinedDiffSectionsMatchEntries({
+      combinedDiffSectionsMatchEntryMetadata({
         entries,
         sections: cached.sections,
         treeMode

--- a/src/renderer/src/components/editor/combined-diff-section-cache-match.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-section-cache-match.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import type { GitBranchChangeEntry, GitStatusEntry } from '../../../../shared/types'
+import type { DiffSection } from './diff-section-types'
+import { combinedDiffSectionsMatchEntryMetadata } from './combined-diff-section-cache-match'
+
+function section(overrides: Partial<DiffSection>): DiffSection {
+  return {
+    key: 'unstaged:src/file.ts',
+    path: 'src/file.ts',
+    status: 'modified',
+    area: 'unstaged',
+    originalContent: '',
+    modifiedContent: '',
+    collapsed: false,
+    loading: false,
+    dirty: false,
+    diffResult: null,
+    largeDiffRenderLimit: null,
+    ...overrides
+  }
+}
+
+describe('combinedDiffSectionsMatchEntryMetadata', () => {
+  it('matches sections when keys and entry metadata still match', () => {
+    const entry: GitStatusEntry = {
+      path: 'src/file.ts',
+      status: 'modified',
+      area: 'unstaged',
+      added: 2,
+      removed: 1
+    }
+
+    expect(
+      combinedDiffSectionsMatchEntryMetadata({
+        entries: [entry],
+        sections: [section({ added: 2, removed: 1 })],
+        treeMode: 'uncommitted'
+      })
+    ).toBe(true)
+  })
+
+  it('rejects cached sections when a same-path entry has new line counts', () => {
+    const entry: GitStatusEntry = {
+      path: 'src/file.ts',
+      status: 'modified',
+      area: 'unstaged',
+      added: 177,
+      removed: 175
+    }
+
+    expect(
+      combinedDiffSectionsMatchEntryMetadata({
+        entries: [entry],
+        sections: [section({ added: 2, removed: 1 })],
+        treeMode: 'uncommitted'
+      })
+    ).toBe(false)
+  })
+
+  it('keeps branch sections separate when old paths change for the same new path', () => {
+    const entry: GitBranchChangeEntry = {
+      path: 'src/new.ts',
+      oldPath: 'src/old.ts',
+      status: 'renamed',
+      added: 4,
+      removed: 3
+    }
+
+    expect(
+      combinedDiffSectionsMatchEntryMetadata({
+        entries: [entry],
+        sections: [
+          section({
+            key: 'combined-branch:src/new.ts',
+            path: 'src/new.ts',
+            status: 'renamed',
+            area: undefined,
+            oldPath: 'src/older.ts',
+            added: 4,
+            removed: 3
+          })
+        ],
+        treeMode: 'branch'
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-section-cache-match.ts
+++ b/src/renderer/src/components/editor/combined-diff-section-cache-match.ts
@@ -1,0 +1,37 @@
+import type { GitBranchChangeEntry, GitStatusEntry } from '../../../../shared/types'
+import type { CombinedDiffFileTreeMode } from './combined-diff-file-tree-model'
+import { getCombinedDiffFileTreeSectionKey } from './combined-diff-file-tree-model'
+import type { DiffSection } from './diff-section-types'
+
+export function combinedDiffSectionsMatchEntryMetadata({
+  entries,
+  sections,
+  treeMode
+}: {
+  entries: readonly (GitStatusEntry | GitBranchChangeEntry)[]
+  sections: readonly DiffSection[]
+  treeMode: CombinedDiffFileTreeMode
+}): boolean {
+  // Why: same-path combined sections can survive status refreshes; metadata
+  // drift means restoring cached content would replay stale, partial diffs.
+  return (
+    sections.length === entries.length &&
+    sections.every((section, index) => {
+      const entry = entries[index]
+      if (!entry) {
+        return false
+      }
+      const entryArea = 'area' in entry ? entry.area : undefined
+      const entryAdded = 'added' in entry ? entry.added : undefined
+      const entryRemoved = 'removed' in entry ? entry.removed : undefined
+      return (
+        section.key === getCombinedDiffFileTreeSectionKey(treeMode, entry) &&
+        section.status === entry.status &&
+        section.area === entryArea &&
+        section.oldPath === entry.oldPath &&
+        section.added === entryAdded &&
+        section.removed === entryRemoved
+      )
+    })
+  )
+}


### PR DESCRIPTION
## Summary

This PR improves cached combined diff matching by validating entry metadata in addition to the path keys.

We extract the cached section comparison logic from `CombinedDiffViewer.tsx` into a standalone helper `combinedDiffSectionsMatchEntryMetadata` in `combined-diff-section-cache-match.ts`. It ensures same-path combined sections do not restore stale, partial cached diffs when git statuses refresh, validating line count changes (`added`/`removed`), statuses, area, and old paths.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

We have added comprehensive unit tests in `combined-diff-section-cache-match.test.ts` to verify the cache matching behavior:
- Matches sections when keys and entry metadata still match
- Rejects cached sections when a same-path entry has new line counts
- Keeps branch sections separate when old paths change for the same new path

## AI Review Report

The code changes were reviewed using our AI coding agent:
- **Risks Checked:** Correct comparison of cached diff sections with updated entries after refreshes. Verified that any metadata drift (e.g., modified line additions/removals, rename oldPaths) correctly triggers a cache mismatch to prevent rendering incorrect or partial diffs.
- **Cross-Platform Compatibility:** The changes are restricted to standard React/TypeScript business logic and file metadata comparisons. No system/platform-specific paths, commands, shortcuts, or IPC endpoints are touched, ensuring seamless compatibility across macOS, Linux, and Windows.

## Security Audit

- **Input Handling/Command Execution:** None. All data is handled in-memory within the UI renderer.
- **IPC/Secrets:** No IPC, authentication, or secret exposure risks.
- **Dependency/Path Risks:** Standard relative imports are used. No unsanitized paths or dynamic command executions.

## Notes

No platform-specific behaviors or external follow-up work needed.