### PR TITLE
Style commit text area to match input tokens and fix disabled state

### DIFF
--- a/src/main/github/work-item-details.test.ts
+++ b/src/main/github/work-item-details.test.ts
@@ -283,9 +283,13 @@ describe('getWorkItemDetails', () => {
         call[0].includes('repos/acme/widgets/issues/923/timeline?per_page=100&page=7')
       )
     ).toBe(false)
-    expect(details?.timelineItems).toHaveLength(300)
-    expect(details?.timelineItems.at(0)).toMatchObject({ assignee: 'assignee-3-0' })
-    expect(details?.timelineItems.at(-1)).toMatchObject({ assignee: 'assignee-6-89' })
+    const timelineItems = details?.timelineItems
+    expect(timelineItems).toHaveLength(300)
+    if (!timelineItems) {
+      throw new Error('Expected timeline items to be present')
+    }
+    expect(timelineItems.at(0)).toMatchObject({ assignee: 'assignee-3-0' })
+    expect(timelineItems.at(-1)).toMatchObject({ assignee: 'assignee-6-89' })
   })
 
   it('falls back to REST + GraphQL when the collapsed issue query fails', async () => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -6501,7 +6501,9 @@ export function CommitArea({
             aria-describedby={describedBy || undefined}
             // Why: reserve right padding so typed text does not slide under the
             // absolute-positioned Generate icon in the top-right corner.
-            className={`mt-0.5 min-h-14 w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ${
+            // Why: match Input surface tokens and pin disabled:border-input so
+            // Chromium's UA disabled styles don't wash out the field outline.
+            className={`mt-0.5 min-h-14 w-full resize-none appearance-none rounded-md border border-input bg-background shadow-xs px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:border-input disabled:bg-background disabled:text-foreground disabled:shadow-xs dark:bg-input/30 dark:disabled:bg-input/30 ${
               showGenerate ? 'pr-8' : ''
             }`}
           />


### PR DESCRIPTION
## Summary

Styles the commit text area in `SourceControl.tsx` to match standard Input surface tokens (`border-input`, `shadow-xs`) and explicitly styles its disabled state. This ensures Chromium's User Agent (UA) disabled styles do not wash out the field outline.

## Screenshots

- TODO: Add screenshots of the updated commit area visual states.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

The styling changes for `CommitArea` were reviewed to ensure visual parity with other inputs and correct disabled behavior under Chromium:
- Verified CSS and Tailwind classes (`border-input`, `shadow-xs`, etc.).
- Cross-platform compatibility was explicitly checked: Since this runs in Chromium/Electron, standard CSS classes behave identically across macOS, Linux, and Windows. No system paths, OS shortcuts, or IPC layers are impacted.

## Security Audit

- Purely styling change: Reviewed the `className` updates on the text area. No input handling logic, IPC, secrets, or shell commands are touched by this change.

## Notes

- Explicitly overriding `disabled:border-input` and `disabled:bg-background` prevents default Chromium styles from obscuring the boundary of the field.