### PR TITLE
perf(git-status): throttle trailing refreshes and coalesce main-process reads

### DIFF
--- a/src/main/git/status-upstream-negative-cache.test.ts
+++ b/src/main/git/status-upstream-negative-cache.test.ts
@@ -92,8 +92,10 @@ describe('local upstream negative cache', () => {
   it('keeps an older automatic negative probe from overwriting a strict positive result', async () => {
     let originBranchExists = false
     let deferredOriginReject: ((error: Error) => void) | null = null
+    let statusCommandCalls = 0
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
       if (args.includes('status')) {
+        statusCommandCalls += 1
         return {
           stdout: '# branch.oid abcdef1234567890\n# branch.head feature\n'
         }
@@ -123,6 +125,7 @@ describe('local upstream negative cache', () => {
 
     originBranchExists = true
     const strict = await getStatus('/repo', { bypassEffectiveUpstreamNegativeCache: true })
+    expect(statusCommandCalls).toBe(2)
     if (!deferredOriginReject) {
       throw new Error('expected deferred origin reject')
     }

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: git status/discard/chunking behavior is verified together here to keep the command contract readable in one place. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'fs'
 import path from 'path'
 import {
   MAX_RENDERED_DIFF_COMBINED_CHARACTERS,
@@ -459,6 +460,74 @@ describe('getStatus', () => {
     // set only a `mockResolvedValueOnce` for the status output; this default
     // keeps those follow-up numstat calls from returning undefined.
     gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
+  })
+
+  it('benchmarks concurrent status burst subprocess pressure', async () => {
+    const benchPath = process.env.ORCA_GIT_STATUS_COALESCING_BENCH_JSON
+    if (!benchPath) {
+      return
+    }
+
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args.includes('status')) {
+        return Promise.resolve({ stdout: '' })
+      }
+      if (args.includes('--numstat')) {
+        return Promise.resolve({ stdout: '' })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+
+    const startedAt = performance.now()
+    await Promise.all(Array.from({ length: 10 }, () => getStatus('/repo')))
+    const durationMs = performance.now() - startedAt
+    const statusCommandCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) =>
+      (args as string[]).includes('status')
+    ).length
+    const { mkdirSync, writeFileSync } = await vi.importActual<typeof NodeFs>('fs')
+    mkdirSync(path.dirname(benchPath), { recursive: true })
+    writeFileSync(
+      benchPath,
+      JSON.stringify({
+        scenario: 'git-status-concurrent-burst',
+        concurrentCalls: 10,
+        statusCommandCalls,
+        durationMs
+      })
+    )
+  })
+
+  it('coalesces identical in-flight status reads without caching after settle', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    let statusCommandCalls = 0
+    const releaseStatusReads: (() => void)[] = []
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args.includes('status')) {
+        statusCommandCalls += 1
+        return new Promise<{ stdout: string }>((resolve) => {
+          releaseStatusReads.push(() => resolve({ stdout: '' }))
+        })
+      }
+      if (args.includes('--numstat')) {
+        return Promise.resolve({ stdout: '' })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+
+    const sharedRead = Promise.all([getStatus('/repo'), getStatus('/repo'), getStatus('/repo')])
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(1))
+    releaseStatusReads.splice(0).forEach((release) => release())
+    await sharedRead
+    expect(statusCommandCalls).toBe(1)
+
+    const settledRead = getStatus('/repo')
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(2))
+    releaseStatusReads.splice(0).forEach((release) => release())
+    await settledRead
+    expect(statusCommandCalls).toBe(2)
   })
 
   it('parses unmerged porcelain v2 entries into unresolved conflict rows', async () => {

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -64,12 +64,16 @@ const effectiveUpstreamStatusCache = new Map<string, EffectiveUpstreamStatusCach
 const effectiveUpstreamStatusInFlight = new Map<string, Promise<GitUpstreamStatus>>()
 const retiredEffectiveUpstreamStatusInFlight = new Map<string, Promise<GitUpstreamStatus>>()
 const effectiveUpstreamStatusWriteGeneration = new Map<string, number>()
+const statusReadsInFlight = new Map<string, Promise<GitStatusResult>>()
 
+// Why: status tests reuse this reset hook, so every cross-call memoization layer
+// must reset together even though the historical name mentions upstream only.
 export function clearEffectiveUpstreamStatusCacheForTests(): void {
   effectiveUpstreamStatusCache.clear()
   effectiveUpstreamStatusInFlight.clear()
   retiredEffectiveUpstreamStatusInFlight.clear()
   effectiveUpstreamStatusWriteGeneration.clear()
+  statusReadsInFlight.clear()
 }
 
 export function getEffectiveUpstreamStatusCacheCountForTests(): number {
@@ -94,6 +98,38 @@ export type GetStatusOptions = GitRuntimeOptions & {
  * Parse `git status --porcelain=v2` output into structured entries.
  */
 export async function getStatus(
+  worktreePath: string,
+  options: GetStatusOptions = {}
+): Promise<GitStatusResult> {
+  // Why: dedupe only concurrent identical reads; after settle, callers must
+  // execute a fresh status read rather than observing a cached result.
+  const cacheKey = getStatusReadKey(worktreePath, options)
+  const inFlightStatus = statusReadsInFlight.get(cacheKey)
+  if (inFlightStatus) {
+    return inFlightStatus
+  }
+
+  const statusPromise = runGetStatus(worktreePath, options)
+  statusReadsInFlight.set(cacheKey, statusPromise)
+  try {
+    return await statusPromise
+  } finally {
+    if (statusReadsInFlight.get(cacheKey) === statusPromise) {
+      statusReadsInFlight.delete(cacheKey)
+    }
+  }
+}
+
+function getStatusReadKey(worktreePath: string, options: GetStatusOptions): string {
+  // Why: each key part can change the output shape or runtime routing.
+  const limit =
+    typeof options.limit === 'number' && Number.isInteger(options.limit) && options.limit >= 0
+      ? options.limit
+      : DEFAULT_GIT_STATUS_LIMIT
+  return [worktreePath, options.wslDistro ?? '', options.includeIgnored === true, limit].join('\0')
+}
+
+async function runGetStatus(
   worktreePath: string,
   options: GetStatusOptions = {}
 ): Promise<GitStatusResult> {

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -126,7 +126,13 @@ function getStatusReadKey(worktreePath: string, options: GetStatusOptions): stri
     typeof options.limit === 'number' && Number.isInteger(options.limit) && options.limit >= 0
       ? options.limit
       : DEFAULT_GIT_STATUS_LIMIT
-  return [worktreePath, options.wslDistro ?? '', options.includeIgnored === true, limit].join('\0')
+  return [
+    worktreePath,
+    options.wslDistro ?? '',
+    options.includeIgnored === true,
+    options.bypassEffectiveUpstreamNegativeCache === true,
+    limit
+  ].join('\0')
 }
 
 async function runGetStatus(

--- a/src/renderer/src/components/right-sidebar/coalesced-poll-runner.test.ts
+++ b/src/renderer/src/components/right-sidebar/coalesced-poll-runner.test.ts
@@ -55,4 +55,59 @@ describe('createCoalescedPollRunner', () => {
 
     expect(task).toHaveBeenCalledTimes(1)
   })
+
+  it('enforces minIntervalMs delay between consecutive runs', async () => {
+    vi.useFakeTimers()
+    const calls: ReturnType<typeof deferred>[] = []
+    const task = vi.fn(() => {
+      const call = deferred()
+      calls.push(call)
+      return call.promise
+    })
+    const runner = createCoalescedPollRunner(task, { minIntervalMs: 1000 })
+
+    runner.run()
+    expect(task).toHaveBeenCalledTimes(1)
+
+    runner.run()
+    expect(task).toHaveBeenCalledTimes(1)
+
+    calls[0]?.resolve()
+    await flushMicrotasks()
+
+    expect(task).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(task).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(task).toHaveBeenCalledTimes(2)
+
+    calls[1]?.resolve()
+    await flushMicrotasks()
+    vi.useRealTimers()
+  })
+
+  it('cancels scheduled deferred run on dispose', async () => {
+    vi.useFakeTimers()
+    const calls: ReturnType<typeof deferred>[] = []
+    const task = vi.fn(() => {
+      const call = deferred()
+      calls.push(call)
+      return call.promise
+    })
+    const runner = createCoalescedPollRunner(task, { minIntervalMs: 1000 })
+
+    runner.run()
+    runner.run()
+    calls[0]?.resolve()
+    await flushMicrotasks()
+
+    runner.dispose()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(task).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
 })

--- a/src/renderer/src/components/right-sidebar/coalesced-poll-runner.ts
+++ b/src/renderer/src/components/right-sidebar/coalesced-poll-runner.ts
@@ -3,10 +3,15 @@ export type CoalescedPollRunner = {
   dispose: () => void
 }
 
-export function createCoalescedPollRunner(task: () => Promise<void>): CoalescedPollRunner {
+export function createCoalescedPollRunner(
+  task: () => Promise<void>,
+  options?: { minIntervalMs?: number }
+): CoalescedPollRunner {
   let disposed = false
   let inFlight = false
   let rerun = false
+  let lastRunEndedAt = -Infinity
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
 
   const run = (): void => {
     if (disposed) {
@@ -16,6 +21,22 @@ export function createCoalescedPollRunner(task: () => Promise<void>): CoalescedP
       rerun = true
       return
     }
+    if (timeoutId !== null) {
+      return
+    }
+
+    const now = Date.now()
+    const timeSinceLastEnd = now - lastRunEndedAt
+    const minInterval = options?.minIntervalMs ?? 0
+    if (timeSinceLastEnd < minInterval) {
+      const delay = minInterval - timeSinceLastEnd
+      timeoutId = setTimeout(() => {
+        timeoutId = null
+        run()
+      }, delay)
+      return
+    }
+
     inFlight = true
     void task()
       .catch(() => {
@@ -24,12 +45,12 @@ export function createCoalescedPollRunner(task: () => Promise<void>): CoalescedP
       })
       .finally(() => {
         inFlight = false
-        if (rerun && !disposed) {
-          rerun = false
-          run()
-          return
-        }
+        lastRunEndedAt = Date.now()
+        const shouldRerun = rerun && !disposed
         rerun = false
+        if (shouldRerun) {
+          run()
+        }
       })
   }
 
@@ -38,6 +59,10 @@ export function createCoalescedPollRunner(task: () => Promise<void>): CoalescedP
     dispose: () => {
       disposed = true
       rerun = false
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+        timeoutId = null
+      }
     }
   }
 }

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
@@ -23,8 +23,25 @@ const REPO_ID = 'repo1'
 const WORKTREE_PATH = '/repo1'
 const WORKTREE_ID = `${REPO_ID}::${WORKTREE_PATH}`
 
+const REPO_ID2 = 'repo2'
+const WORKTREE_PATH2 = '/repo2'
+const WORKTREE_ID2 = `${REPO_ID2}::${WORKTREE_PATH2}`
+
 const repo: Repo = { ...TEST_REPO, kind: 'git', connectionId: null }
 const worktree: Worktree = makeWorktree({ id: WORKTREE_ID, repoId: REPO_ID, path: WORKTREE_PATH })
+
+const repo2: Repo = {
+  ...TEST_REPO,
+  id: REPO_ID2,
+  path: WORKTREE_PATH2,
+  kind: 'git',
+  connectionId: null
+}
+const worktree2: Worktree = makeWorktree({
+  id: WORKTREE_ID2,
+  repoId: REPO_ID2,
+  path: WORKTREE_PATH2
+})
 
 const roots: Root[] = []
 
@@ -58,8 +75,11 @@ describe('useGitStatusPolling rerender stability', () => {
     useAppStore.setState(initialAppState, true)
     useAppStore.setState({
       activeWorktreeId: WORKTREE_ID,
-      worktreesByRepo: { [REPO_ID]: [worktree] },
-      repos: [repo],
+      worktreesByRepo: {
+        [REPO_ID]: [worktree],
+        [REPO_ID2]: [worktree2]
+      },
+      repos: [repo, repo2],
       rightSidebarOpen: true,
       rightSidebarTab: 'source-control',
       rightSidebarExplorerView: 'files',
@@ -135,5 +155,24 @@ describe('useGitStatusPolling rerender stability', () => {
     expect(refreshMock).toHaveBeenCalledTimes(2)
 
     addSpy.mockRestore()
+  })
+  it('triggers an immediate poll when the active worktree changes (no delay)', async () => {
+    await renderHook()
+    await flushMicrotasks()
+
+    // First poll on mount (worktree 1)
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+
+    // Switch active worktree to worktree 2
+    await act(async () => {
+      useAppStore.setState({
+        activeWorktreeId: WORKTREE_ID2
+      })
+    })
+    await flushMicrotasks()
+
+    // Should trigger an immediate poll on the new worktree (total 2 calls)
+    // without having to wait for the 3000ms timer.
+    expect(refreshMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo, Worktree } from '../../../../shared/types'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import { makeOpenFile, makeWorktree, TEST_REPO } from '@/store/slices/store-test-helpers'
+import { ORCA_WORKTREE_FILE_CHANGE_EVENT } from '@/hooks/worktree-file-change-event'
+import { useGitStatusPolling } from './useGitStatusPolling'
+
+// Mock the refresh boundary so we count invocations precisely without
+// triggering real IPC cascades (upstream probes, store mutations, etc.).
+const refreshMock = vi.hoisted(() => vi.fn())
+vi.mock('./git-status-refresh', () => ({
+  refreshGitStatusForWorktree: refreshMock
+}))
+
+const initialAppState = useAppStore.getInitialState()
+
+const REPO_ID = 'repo1'
+const WORKTREE_PATH = '/repo1'
+const WORKTREE_ID = `${REPO_ID}::${WORKTREE_PATH}`
+
+const repo: Repo = { ...TEST_REPO, kind: 'git', connectionId: null }
+const worktree: Worktree = makeWorktree({ id: WORKTREE_ID, repoId: REPO_ID, path: WORKTREE_PATH })
+
+const roots: Root[] = []
+
+function HookProbe(): null {
+  useGitStatusPolling()
+  return null
+}
+
+async function renderHook(): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(createElement(HookProbe))
+  })
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+describe('useGitStatusPolling rerender stability', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    refreshMock.mockReset().mockResolvedValue(undefined)
+
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({
+      activeWorktreeId: WORKTREE_ID,
+      worktreesByRepo: { [REPO_ID]: [worktree] },
+      repos: [repo],
+      rightSidebarOpen: true,
+      rightSidebarTab: 'source-control',
+      rightSidebarExplorerView: 'files',
+      openFiles: [],
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
+    } as Partial<AppState>)
+  })
+
+  afterEach(() => {
+    // Unmount roots WHILE fake timers are still active so effect cleanups
+    // call the faked clearInterval/clearTimeout on matching fake handles.
+    roots.splice(0).forEach((root) => {
+      act(() => root.unmount())
+    })
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+    vi.useRealTimers()
+  })
+
+  it('keeps the poll runner stable when openFiles changes mid-cooldown', async () => {
+    // Spy on addEventListener so we can guard that the file-watch listener
+    // registered before emitting — otherwise the test would prove nothing.
+    const addSpy = vi.spyOn(window, 'addEventListener')
+
+    await renderHook()
+    await flushMicrotasks()
+
+    // First poll fires immediately (installWindowVisibilityInterval calls
+    // run() once at install time).
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+
+    // Rerender: change openFiles in the store. This gives runFetchStatus a new
+    // identity (it lists openFiles in its useCallback deps). With the old
+    // useMemo([runFetchStatus]) the runner would be recreated here, resetting
+    // lastRunEndedAt to -Infinity and bypassing the cooldown.
+    await act(async () => {
+      useAppStore.setState({
+        openFiles: [makeOpenFile({ id: `${WORKTREE_PATH}/a.ts`, worktreeId: WORKTREE_ID })]
+      })
+    })
+    await flushMicrotasks()
+
+    // Guard: the file-watch listener must be registered, or the event below
+    // is a no-op and the test cannot distinguish fix from bug.
+    expect(addSpy).toHaveBeenCalledWith(ORCA_WORKTREE_FILE_CHANGE_EVENT, expect.any(Function))
+
+    // Fire a file-watch event to drive fetchStatus during the cooldown.
+    window.dispatchEvent(
+      new CustomEvent(ORCA_WORKTREE_FILE_CHANGE_EVENT, {
+        detail: {
+          payload: {
+            worktreePath: WORKTREE_PATH,
+            events: [{ kind: 'update', absolutePath: `${WORKTREE_PATH}/a.ts` }]
+          },
+          runtimeEnvironmentId: null
+        }
+      })
+    )
+
+    // Advance past the 125 ms file-watch debounce. fetchStatus is called, but
+    // the runner's cooldown (POLL_INTERVAL_MS = 3000 ms from first run end)
+    // should suppress the second refresh.
+    await vi.advanceTimersByTimeAsync(200)
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+
+    // Mid-cooldown: still no second refresh.
+    await vi.advanceTimersByTimeAsync(1300)
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+
+    // After the full 3 s cooldown the trailing refresh fires.
+    await vi.advanceTimersByTimeAsync(1500)
+    await flushMicrotasks()
+    expect(refreshMock).toHaveBeenCalledTimes(2)
+
+    addSpy.mockRestore()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
@@ -376,9 +376,9 @@ describe('useGitStatusPolling', () => {
       events: [{ kind: 'update', absolutePath: '/other/c.ts' }]
     })
 
-    await vi.advanceTimersByTimeAsync(124)
+    await vi.advanceTimersByTimeAsync(125)
     expect(gitStatus).toHaveBeenCalledTimes(1)
-    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(2875)
     await vi.waitFor(() => expect(gitStatus).toHaveBeenCalledTimes(2))
     expect(window.api.fs.watchWorktree).not.toHaveBeenCalled()
     expect(window.api.fs.unwatchWorktree).not.toHaveBeenCalled()
@@ -612,6 +612,8 @@ describe('useGitStatusPolling', () => {
     const callsBeforeDebounceFires = gitStatus.mock.calls.length
 
     await vi.advanceTimersByTimeAsync(65)
+    expect(gitStatus).toHaveBeenCalledTimes(callsBeforeDebounceFires)
+    await vi.advanceTimersByTimeAsync(2875)
     await vi.waitFor(() => expect(gitStatus).toHaveBeenCalledTimes(callsBeforeDebounceFires + 1))
 
     vi.useRealTimers()
@@ -619,6 +621,7 @@ describe('useGitStatusPolling', () => {
 
   it('does not overlap slow visible git status polls and runs one trailing refresh', async () => {
     vi.resetModules()
+    vi.useFakeTimers()
     let intervalCallback: (() => void) | null = null
     let resolveFirst!: (value: GitStatusResult) => void
     const firstStatus = new Promise<GitStatusResult>((resolve) => {
@@ -712,7 +715,10 @@ describe('useGitStatusPolling', () => {
     expect(gitStatus).toHaveBeenCalledTimes(1)
 
     resolveFirst(status)
+    await vi.waitFor(() => expect(state.setGitStatus).toHaveBeenCalledTimes(1))
+    await vi.advanceTimersByTimeAsync(3000)
     await vi.waitFor(() => expect(gitStatus).toHaveBeenCalledTimes(2))
     await vi.waitFor(() => expect(state.setGitStatus).toHaveBeenCalledTimes(2))
+    vi.useRealTimers()
   })
 })

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -158,7 +158,7 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
 
   const fetchStatus = useCallback(() => {
     statusPollRunnerRef.current?.run()
-  }, [])
+  }, [activeWorktreeId])
 
   useEffect(() => {
     if (!enabled) {

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useAppStore } from '@/store'
 import { useAllWorktrees, useRepoById, useRepoMap, useWorktreeById } from '@/store/selectors'
 import type { GitConflictOperation } from '../../../../shared/types'
@@ -6,7 +6,7 @@ import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { getConnectionId } from '@/lib/connection-context'
 import { getRuntimeGitConflictOperation } from '@/runtime/runtime-git-client'
 import { refreshGitStatusForWorktree } from './git-status-refresh'
-import { createCoalescedPollRunner } from './coalesced-poll-runner'
+import { type CoalescedPollRunner, createCoalescedPollRunner } from './coalesced-poll-runner'
 import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { shouldPollActiveGitStatus } from '@/lib/passive-macos-app-data-access'
 import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-owner'
@@ -135,22 +135,30 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
     updateWorktreeGitIdentity
   ])
 
-  // Why: sustained file-watch events can request another status while git is
-  // still running. Keep one trailing refresh, then let the previous run settle
-  // for one visible-poll interval before spawning git again.
-  const statusPollRunner = useMemo(
-    () =>
-      createCoalescedPollRunner(runFetchStatus, {
-        minIntervalMs: POLL_INTERVAL_MS
-      }),
-    [runFetchStatus]
-  )
+  // Why: the runner must survive rerenders so `lastRunEndedAt` and `inFlight`
+  // are never reset by a UI-state change mid-burst (e.g. openFiles update while
+  // git is still running). A ref keeps one runner per active-worktree lifetime;
+  // `runFetchStatusRef` lets the runner always call the latest closure without
+  // being recreated. The runner is disposed and replaced only when the active
+  // worktree changes or the hook unmounts.
+  const runFetchStatusRef = useRef(runFetchStatus)
+  runFetchStatusRef.current = runFetchStatus
 
-  useEffect(() => () => statusPollRunner.dispose(), [statusPollRunner])
+  const statusPollRunnerRef = useRef<CoalescedPollRunner | null>(null)
+  useEffect(() => {
+    const runner = createCoalescedPollRunner(() => runFetchStatusRef.current(), {
+      minIntervalMs: POLL_INTERVAL_MS
+    })
+    statusPollRunnerRef.current = runner
+    return () => {
+      runner.dispose()
+      statusPollRunnerRef.current = null
+    }
+  }, [activeWorktreeId])
 
   const fetchStatus = useCallback(() => {
-    statusPollRunner.run()
-  }, [statusPollRunner])
+    statusPollRunnerRef.current?.run()
+  }, [])
 
   useEffect(() => {
     if (!enabled) {

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useAppStore } from '@/store'
 import { useAllWorktrees, useRepoById, useRepoMap, useWorktreeById } from '@/store/selectors'
 import type { GitConflictOperation } from '../../../../shared/types'
@@ -32,9 +32,6 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
   const rightSidebarExplorerView = useAppStore((s) => s.rightSidebarExplorerView)
   const openFiles = useAppStore((s) => s.openFiles)
   const repoMap = useRepoMap()
-  const statusPollInFlightRef = useRef(false)
-  const statusPollRerunRef = useRef(false)
-  const fetchStatusRef = useRef<() => void>(() => {})
 
   const worktreePath = activeWorktree?.path ?? null
   const activePushTarget = activeWorktree?.pushTarget
@@ -138,24 +135,22 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
     updateWorktreeGitIdentity
   ])
 
+  // Why: sustained file-watch events can request another status while git is
+  // still running. Keep one trailing refresh, then let the previous run settle
+  // for one visible-poll interval before spawning git again.
+  const statusPollRunner = useMemo(
+    () =>
+      createCoalescedPollRunner(runFetchStatus, {
+        minIntervalMs: POLL_INTERVAL_MS
+      }),
+    [runFetchStatus]
+  )
+
+  useEffect(() => () => statusPollRunner.dispose(), [statusPollRunner])
+
   const fetchStatus = useCallback(() => {
-    if (statusPollInFlightRef.current) {
-      statusPollRerunRef.current = true
-      return
-    }
-    statusPollInFlightRef.current = true
-    // Why: git status can exceed the 3s poll interval on large repos. Keep at
-    // most one subprocess chain in flight, then run one trailing refresh if a
-    // tick was skipped so the UI catches up without process pileups.
-    void runFetchStatus().finally(() => {
-      statusPollInFlightRef.current = false
-      if (statusPollRerunRef.current) {
-        statusPollRerunRef.current = false
-        fetchStatusRef.current()
-      }
-    })
-  }, [runFetchStatus])
-  fetchStatusRef.current = fetchStatus
+    statusPollRunner.run()
+  }, [statusPollRunner])
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
## Summary

Consolidates the two halves of the active git-status backoff path into one change:

**Renderer-side (trailing-refresh throttle):**
- add an optional cooldown to the coalesced poll runner so trailing refreshes can be delayed after a run completes
- route active git status polling through that runner with a one-visible-poll settling interval
- update polling tests so sustained file-watch triggers still produce a trailing refresh without immediate back-to-back git status runs

**Main-process (read coalescing, folded from #6021, now closed):**
- coalesce concurrent main-process `getStatus()` reads for the same worktree/options key so overlapping renderer requests share one in-flight git invocation instead of spawning duplicates

The two layers compose: the renderer throttles how often trailing refreshes are *issued*, and the main process coalesces any that still arrive concurrently before they reach git.

Related:

- #6289 added file-watch-triggered Source Control status refresh through the existing coalesced runner. This PR follows up on that path by adding a post-completion cooldown so sustained file-watch triggers cannot immediately chain git status runs.
- #6324 reduces broader Git subprocess fanout, and its notes call active git status polling/backoff separate work. This PR targets that separate active-status backoff path.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted checks run:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/coalesced-poll-runner.test.ts src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Full lint/typecheck/test/build were not run for this narrow renderer-side follow-up. A local `pnpm test -- src/renderer/src/components/right-sidebar/coalesced-poll-runner.test.ts` attempt expanded to the broader suite and hit unrelated existing failures outside these files, so the direct Vitest command above was used for scoped verification.

### Empirical Regression Verification (Identity Churn)

We added a real-React + real-store regression test (`useGitStatusPolling.rerender.test.ts`) that simulates a rapid burst of file-watch events during a UI rerender (triggered by `openFiles` changing). Running the test against both codebases provides deterministic proof:

| Metric | Buggy Code (`useMemo([runFetchStatus])`) | Fixed Code (`useRef` + `useEffect`) |
| :--- | :---: | :---: |
| **Status calls at +200 ms** (during cooldown) | **`2`** (cooldown bypassed/reset) | **`1`** (cooldown correctly enforced) |
| **Status calls at +3000 ms** (after cooldown) | **`2`** | **`2`** (trailing call executed) |

- **Under the old code:** The runner was recreated on rerender, resetting the internal `lastRunEndedAt` timestamp. An event during cooldown immediately spawned git status (call count = 2 at 200 ms).
- **Under the fixed code:** The runner stays stable in a ref scoped to the active worktree, properly scheduling the trailing run (call count = 1 at 200 ms, 2 at 3000 ms).

### Worktree Switch Verification (No Delay)

We added a second test (`useGitStatusPolling.rerender.test.ts`) that asserts switching `activeWorktreeId` to a different repository immediately triggers `refreshGitStatusForWorktree` on the new worktree:
- **Mount:** Calls `refreshMock` 1 time.
- **Switch:** `setState({ activeWorktreeId: WORKTREE_ID2 })` immediately triggers `refreshMock` (total 2 calls) without advancing the 3000 ms cooldown.
This verifies the change handles repository switching instantly without introducing lag.

## AI Review Report

Reviewed the change for polling correctness, performance risk, and cleanup behavior. The key risk was dropping a trailing status refresh or delaying the first poll; tests now cover immediate first run, one in-flight task, delayed trailing runs, and disposing a scheduled trailing run. The cooldown is measured from the previous run's completion, so sustained file-watch events get a settling interval before spawning git again.

**Update (Reviewer Feedback):** 
1. Fixed a bug where `statusPollRunner` was memoized on `runFetchStatus`. Since `runFetchStatus` changes identity on UI updates (like `openFiles` changes), the runner was recreated mid-cooldown, bypassing the throttle. The runner now lives in a ref scoped to the active worktree and delegates to the latest closure via a ref, ensuring it is never recreated during UI updates.
2. Fixed a bug where switching `activeWorktreeId` introduced up to 3 seconds of lag before polling the new worktree. Adding `activeWorktreeId` as a dependency on `fetchStatus`'s `useCallback` causes the visibility interval effect to clean up and re-install, immediately polling the new worktree while keeping the visibility check intact.

Cross-platform review: this change is timer and React-hook based, with no OS-specific shortcuts, labels, path separators, shell behavior, Electron menu accelerators, or platform branches touched. SSH/remote/local behavior uses the existing `refreshGitStatusForWorktree` path and connection readiness checks.

## Security Audit

- Input handling: no new external input parsing.
- Command execution: no new git commands or IPC surface; existing status refreshes are rate-limited.
- Paths: no new path construction or path normalization changes.
- Auth/secrets: no new auth, token, credential, or environment handling.
- Dependencies: no new dependencies.
- Resource cleanup: `dispose()` now clears any delayed trailing run so unmount/worktree changes do not leave stale timers.

## Notes

- The visible poll interval now also acts as a post-completion cooldown for trailing active git status refreshes; it is a settling interval, not a strict fixed-rate cadence.
- Provider-neutral git behavior; no GitHub-specific source-control logic.
- Consolidates the renderer-side throttle with the main-process read coalescing from #6021 — the same active-git-status backoff story, verified together (71/71 across `status.test.ts` + the three renderer poll suites via direct vitest). Supersedes #6021.
- X handle: @wolfie_


