### PR TITLE
fix: preserve live PTY identity across worktree folder rename

### DIFF
--- a/src/main/agent-hooks/first-work-folder-rename.test.ts
+++ b/src/main/agent-hooks/first-work-folder-rename.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GlobalSettings, Repo } from '../../shared/types'
+import { OrcaRuntimeService } from '../runtime/orca-runtime'
 import {
   renameWorktreeFolderOnFirstWork,
   type FirstWorkFolderRenameDeps
@@ -75,5 +76,29 @@ describe('renameWorktreeFolderOnFirstWork', () => {
     const deps = makeDeps({ getRepo: vi.fn(() => undefined) })
     expect(await renameWorktreeFolderOnFirstWork(OLD_ID, 'fix-auth', deps)).toBe(false)
     expect(deps.moveWorktree).not.toHaveBeenCalled()
+  })
+
+  // #5535 regression: the move must not drop the running session. Wiring the real
+  // runtime notify proves the orchestration -> runtime re-point seam: a live PTY
+  // record stays bound to the worktree (under the NEW id) across the folder move,
+  // instead of being orphaned to the gone old id and replaced by a fresh terminal.
+  it('keeps a live PTY bound across the move by re-pointing it to the new id', async () => {
+    const runtime = new OrcaRuntimeService()
+    const internals = runtime as unknown as {
+      recordPtyWorktree: (ptyId: string, worktreeId: string) => { worktreeId: string }
+      ptysById: Map<string, { worktreeId: string }>
+    }
+    const ptyId = `${OLD_ID}@@aaaa`
+    internals.recordPtyWorktree(ptyId, OLD_ID)
+
+    const deps = makeDeps({
+      notifyWorktreeRenamed: (repoId, oldId, newId) =>
+        runtime.notifyWorktreeFolderRenamed(repoId, oldId, newId)
+    })
+
+    const result = await renameWorktreeFolderOnFirstWork(OLD_ID, 'work-derived', deps)
+
+    expect(result).toBe(true)
+    expect(internals.ptysById.get(ptyId)?.worktreeId).toBe('repo1::/ws/work-derived')
   })
 })

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -511,6 +511,23 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(killed).toHaveLength(0)
     })
 
+    it('keeps a session minted under a prior (pre-rename) worktree id when the caller seeds that alias', async () => {
+      // A folder rename changes the worktree's path-derived id, but live sessions
+      // keep the old id baked into their session id. The doc contract requires
+      // callers to union each worktree's WorktreeMeta.priorWorktreeIds into
+      // validWorktreeIds; this pins that a session minted under the old id then
+      // survives. A future change that wires reconcile into boot must honor this
+      // or it will reap renamed worktrees' live terminals (the #5535 failure mode).
+      const priorId = 'repo-a::/wt/old-creature-name'
+      const currentId = 'repo-a::/wt/work-derived-name'
+      await adapter.spawn({ cols: 80, rows: 24, worktreeId: priorId })
+
+      const { alive, killed } = await adapter.reconcileOnStartup(new Set([currentId, priorId]))
+      expect(alive).toHaveLength(1)
+      expect(alive[0]).toContain(priorId)
+      expect(killed).toHaveLength(0)
+    })
+
     it('kills sessions whose id does not match the minted format, even if id is in valid set', async () => {
       // Why: parsePtySessionId rejects bare UUIDs (no `@@`) and ids without
       // the `::` worktree shape. Such sessions can't be attributed to any

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -167,6 +167,10 @@ export class DaemonPtyRouter implements IPtyProvider {
     this.adapterFor(sessionId).clearTombstone(sessionId)
   }
 
+  /** No production caller yet. Before wiring this into boot, the caller MUST seed
+   *  `validWorktreeIds` with every live worktree's `WorktreeMeta.priorWorktreeIds`
+   *  — otherwise sessions on a renamed worktree (whose id is path-stamped with the
+   *  pre-rename path) are reaped as false orphans. See DaemonPtyAdapter.reconcileOnStartup. */
   async reconcileOnStartup(validWorktreeIds: Set<string>): Promise<{
     alive: string[]
     killed: string[]

--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -47,8 +47,9 @@ vi.mock('../repo-worktrees', () => ({
 // test schema-compliant without coupling to anything the hydrator doesn't
 // touch.
 function makeStore(
-  repos: { id: string; connectionId?: string | null }[] = []
-): Pick<Store, 'getRepos'> {
+  repos: { id: string; connectionId?: string | null }[] = [],
+  worktreeMeta: Record<string, { priorWorktreeIds?: string[] }> = {}
+): Pick<Store, 'getRepos' | 'getAllWorktreeMeta'> {
   const built: Repo[] = repos.map((r) => ({
     id: r.id,
     path: `/tmp/${r.id}`,
@@ -57,7 +58,10 @@ function makeStore(
     addedAt: 0,
     connectionId: r.connectionId ?? null
   }))
-  return { getRepos: () => built }
+  return {
+    getRepos: () => built,
+    getAllWorktreeMeta: () => worktreeMeta as unknown as ReturnType<Store['getAllWorktreeMeta']>
+  }
 }
 
 function makeProvider(sessions: SessionInfo[]): Pick<DaemonPtyAdapter, 'listSessions'> {
@@ -221,6 +225,62 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(entry).toBeDefined()
     expect(entry!.pid).toBe(4242)
     expect(entry!.worktreeId).toBe('repo-a::/local/Triton')
+  })
+
+  it('registers a renamed worktree session (minted under a prior id) under its current worktree id', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+
+    // The session id is path-stamped with the PRE-rename path; live git now only
+    // reports the current (renamed) path. Without prior-id resolution this session
+    // would be dropped (lost pid sample); with it, it attributes to the current id.
+    const priorPtyId = 'repo-a::/local/old-creature@@cafebabe'
+    const provider = makeProvider([
+      { sessionId: priorPtyId, pid: 4242, cwd: '/local/old-creature' } as unknown as SessionInfo
+    ])
+    getDaemonProviderMock.mockReturnValue(provider)
+    listRepoWorktreesMock.mockResolvedValue([
+      { path: '/local/work-derived', head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+
+    await hydrate(
+      makeStore([{ id: 'repo-a', connectionId: null }], {
+        'repo-a::/local/work-derived': {
+          priorWorktreeIds: ['repo-a::/local/old-creature']
+        }
+      })
+    )
+
+    const entry = listRegisteredPtys().find((p) => p.ptyId === priorPtyId)
+    expect(entry).toBeDefined()
+    expect(entry!.pid).toBe(4242)
+    expect(entry!.worktreeId).toBe('repo-a::/local/work-derived')
+  })
+
+  it('trusts the parsed id over a stale alias when its path was recycled by a current worktree', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+
+    // Path /local/a was renamed to /local/b (so b lists a as a prior alias), then a
+    // NEW worktree was created reusing /local/a. A live session at the current
+    // /local/a must register under /local/a — not be redirected to the b alias.
+    const sessionAtRecycledPath = 'repo-a::/local/a@@cafebabe'
+    const provider = makeProvider([
+      { sessionId: sessionAtRecycledPath, pid: 7, cwd: '/local/a' } as unknown as SessionInfo
+    ])
+    getDaemonProviderMock.mockReturnValue(provider)
+    listRepoWorktreesMock.mockResolvedValue([
+      { path: '/local/a', head: '', branch: '', isBare: false, isMainWorktree: true },
+      { path: '/local/b', head: '', branch: '', isBare: false, isMainWorktree: false }
+    ])
+
+    await hydrate(
+      makeStore([{ id: 'repo-a', connectionId: null }], {
+        'repo-a::/local/b': { priorWorktreeIds: ['repo-a::/local/a'] }
+      })
+    )
+
+    const entry = listRegisteredPtys().find((p) => p.ptyId === sessionAtRecycledPath)
+    expect(entry).toBeDefined()
+    expect(entry!.worktreeId).toBe('repo-a::/local/a')
   })
 
   it('hydrates large daemon session lists', async () => {

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -52,7 +52,9 @@ let hasHydrated = false
  * union still covers that case until the daemon comes back. Any failure
  * here is a coverage degradation, not a correctness regression.
  */
-export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos'>): Promise<void> {
+export async function hydrateLocalPtyRegistryAtBoot(
+  store: Pick<Store, 'getRepos' | 'getAllWorktreeMeta'>
+): Promise<void> {
   try {
     if (hasHydrated) {
       return
@@ -89,6 +91,17 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
       }
     }
 
+    // Why: a renamed worktree's live session keeps its pre-rename, path-stamped
+    // id; the live-git map above is keyed by the *current* id. Map each prior id
+    // to its current worktree so those sessions register under the current id
+    // instead of being dropped (a lost pid/memory sample after a folder rename).
+    const currentIdByPriorId = new Map<string, string>()
+    for (const [currentId, meta] of Object.entries(store.getAllWorktreeMeta())) {
+      for (const priorId of meta.priorWorktreeIds ?? []) {
+        currentIdByPriorId.set(priorId, currentId)
+      }
+    }
+
     // Why: SessionInfo is read through the adapter's listSessions() so we
     // get the pid alongside each id. Routing through every adapter
     // (current + legacy) keeps protocol coverage symmetric with the
@@ -105,10 +118,17 @@ export async function hydrateLocalPtyRegistryAtBoot(store: Pick<Store, 'getRepos
       if (alreadyRegistered.has(info.sessionId)) {
         continue
       }
-      const { worktreeId } = parsePtySessionId(info.sessionId)
-      if (!worktreeId) {
+      const parsedWorktreeId = parsePtySessionId(info.sessionId).worktreeId
+      if (!parsedWorktreeId) {
         continue
       }
+      // Resolve a pre-rename id to its current worktree before the local/SSH gates
+      // so a renamed worktree's session attributes to the live id, not the alias.
+      // Guard: if the parsed id is itself a current worktree (a path recycled by a
+      // worktree created after an earlier rename), trust it over the stale alias.
+      const worktreeId = repoConnectionIdByWorktreeId.has(parsedWorktreeId)
+        ? parsedWorktreeId
+        : (currentIdByPriorId.get(parsedWorktreeId) ?? parsedWorktreeId)
       // Why: SSH sessions must stay out of the registry — mirrors the
       // spawn-time `if (!args.connectionId)` gate around `registerPty` in
       // `src/main/ipc/pty.ts`. If the repo isn't in the store, skip the

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16599,9 +16599,33 @@ export class OrcaRuntimeService {
    *  (from a folder rename) as a deletion. Same channel = guaranteed ordering. */
   notifyWorktreeFolderRenamed(repoId: string, oldWorktreeId: string, newWorktreeId: string): void {
     this.invalidateResolvedWorktreeCache()
+    // Re-point live PTY records BEFORE notifying so in-process listeners and the
+    // renderer both observe the corrected ownership. A folder move changes the
+    // path-derived worktreeId; the session id is path-stamped and immutable, so
+    // ownership must be carried on the record, not re-derived from the id.
+    this.migratePtyWorktreeRecords(oldWorktreeId, newWorktreeId)
     this.notifier?.worktreesChanged(repoId, { oldWorktreeId, newWorktreeId })
     // Mirror notifyBranchRenamed so in-process onClientEvent listeners also see the rename.
     this.emitClientEvent({ type: 'worktreesChanged', repoId })
+  }
+
+  /** Carry every live PTY record (and its watcher bindings) from a renamed
+   *  worktree's old id to the new one. The session id stays path-stamped with the
+   *  old path, so this record is the authoritative source of a live session's
+   *  current owner — see {@link recordPtyWorktree}, which never reassigns an
+   *  existing record's worktreeId for the same reason. */
+  private migratePtyWorktreeRecords(oldWorktreeId: string, newWorktreeId: string): void {
+    if (oldWorktreeId === newWorktreeId) {
+      return
+    }
+    for (const pty of this.ptysById.values()) {
+      if (pty.worktreeId !== oldWorktreeId) {
+        continue
+      }
+      pty.worktreeId = newWorktreeId
+      advertisedUrlWatcher.bindPty(pty.ptyId, newWorktreeId)
+      serveSimStateWatcher.bindPty(pty.ptyId, newWorktreeId)
+    }
   }
 
   notifyFolderWorkspaceChanged(): void {
@@ -16611,7 +16635,10 @@ export class OrcaRuntimeService {
 
   private recordPtyWorktree(
     ptyId: string,
-    worktreeId: string,
+    // Only seeds a NEW record. An existing record keeps its own worktreeId — the
+    // periodic controller refresh passes the stale path-inferred id here, and
+    // honoring it would revert a folder-rename re-point (migratePtyWorktreeRecords).
+    initialWorktreeId: string,
     state: Partial<
       Pick<
         RuntimePtyWorktreeRecord,
@@ -16624,7 +16651,7 @@ export class OrcaRuntimeService {
       const titleObservedAt = state.title ? this.nextTitleObservationSequence() : null
       pty = {
         ptyId,
-        worktreeId,
+        worktreeId: initialWorktreeId,
         connectionId: state.connectionId ?? parseAppSshPtyId(ptyId)?.connectionId ?? null,
         tabId: state.tabId ?? null,
         paneKey: state.paneKey ?? null,
@@ -16657,12 +16684,13 @@ export class OrcaRuntimeService {
       this.ptysById.set(ptyId, pty)
       // Why: restored/controller-discovered PTYs learn their worktree here
       // without registerPty(), so URL enrichment must bind at this source.
-      advertisedUrlWatcher.bindPty(ptyId, worktreeId)
-      serveSimStateWatcher.bindPty(ptyId, worktreeId)
+      advertisedUrlWatcher.bindPty(ptyId, initialWorktreeId)
+      serveSimStateWatcher.bindPty(ptyId, initialWorktreeId)
       return pty
     }
 
-    pty.worktreeId = worktreeId
+    // worktreeId intentionally not reassigned on an existing record — see the
+    // initialWorktreeId param doc above.
     if (state.connectionId !== undefined) {
       pty.connectionId = state.connectionId
     }
@@ -16690,8 +16718,10 @@ export class OrcaRuntimeService {
     }
     // Why: recordPtyWorktree is the common lifecycle point for every path that
     // resolves a PTY's worktree, including renderer restore and controller list.
-    advertisedUrlWatcher.bindPty(ptyId, worktreeId)
-    serveSimStateWatcher.bindPty(ptyId, worktreeId)
+    // Bind watchers to the record's authoritative owner (not the possibly-stale
+    // `worktreeId` argument) so a post-rename refresh can't repoint them to the old id.
+    advertisedUrlWatcher.bindPty(ptyId, pty.worktreeId)
+    serveSimStateWatcher.bindPty(ptyId, pty.worktreeId)
     return pty
   }
 

--- a/src/main/runtime/worktree-folder-rename-pty-identity.test.ts
+++ b/src/main/runtime/worktree-folder-rename-pty-identity.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Live-session identity survival across a first-work worktree folder rename.
+ *
+ * A folder move changes the path-derived worktreeId, but a live PTY's session id
+ * is path-stamped and immutable — so ownership must be carried on the runtime
+ * record and re-pointed on rename, never re-derived from the id. These tests pin
+ * the two runtime guarantees that make that hold:
+ *   U1 — notifyWorktreeFolderRenamed re-points every live record old -> new.
+ *   U2 — recordPtyWorktree never reverts an existing record's worktreeId (the
+ *        periodic controller refresh infers the stale OLD id from the session id).
+ */
+import { beforeEach, describe, it, expect } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+
+type PtyRecord = { ptyId: string; worktreeId: string; connected: boolean }
+
+type RuntimeInternals = {
+  ptysById: Map<string, PtyRecord>
+  recordPtyWorktree: (
+    ptyId: string,
+    worktreeId: string,
+    state?: { connected?: boolean }
+  ) => PtyRecord
+  migratePtyWorktreeRecords: (oldWorktreeId: string, newWorktreeId: string) => void
+}
+
+function internals(runtime: OrcaRuntimeService): RuntimeInternals {
+  return runtime as unknown as RuntimeInternals
+}
+
+const OLD = 'repo1::/work/old-creature-name'
+const NEW = 'repo1::/work/work-derived-name'
+const OTHER = 'repo1::/work/unrelated'
+
+describe('worktree folder rename — live PTY identity', () => {
+  let runtime: OrcaRuntimeService
+  let i: RuntimeInternals
+
+  beforeEach(() => {
+    runtime = new OrcaRuntimeService()
+    i = internals(runtime)
+  })
+
+  it('re-points every live record from the old worktree id to the new (U1)', () => {
+    i.recordPtyWorktree(`${OLD}@@aaaa`, OLD)
+    i.recordPtyWorktree(`${OLD}@@bbbb`, OLD)
+    i.recordPtyWorktree(`${OTHER}@@cccc`, OTHER)
+
+    runtime.notifyWorktreeFolderRenamed('repo1', OLD, NEW)
+
+    expect(i.ptysById.get(`${OLD}@@aaaa`)?.worktreeId).toBe(NEW)
+    expect(i.ptysById.get(`${OLD}@@bbbb`)?.worktreeId).toBe(NEW)
+    // An unrelated worktree's record is untouched.
+    expect(i.ptysById.get(`${OTHER}@@cccc`)?.worktreeId).toBe(OTHER)
+  })
+
+  it('is a no-op when no live record owns the old id (U1)', () => {
+    i.recordPtyWorktree(`${OTHER}@@cccc`, OTHER)
+
+    expect(() => runtime.notifyWorktreeFolderRenamed('repo1', OLD, NEW)).not.toThrow()
+    expect(i.ptysById.get(`${OTHER}@@cccc`)?.worktreeId).toBe(OTHER)
+  })
+
+  it('is a no-op when old equals new (U1)', () => {
+    i.recordPtyWorktree(`${OLD}@@aaaa`, OLD)
+
+    i.migratePtyWorktreeRecords(OLD, OLD)
+
+    expect(i.ptysById.get(`${OLD}@@aaaa`)?.worktreeId).toBe(OLD)
+  })
+
+  it('does not let a controller refresh revert a re-pointed record (U2)', () => {
+    const ptyId = `${OLD}@@aaaa`
+    i.recordPtyWorktree(ptyId, OLD)
+    runtime.notifyWorktreeFolderRenamed('repo1', OLD, NEW)
+    expect(i.ptysById.get(ptyId)?.worktreeId).toBe(NEW)
+
+    // The periodic refresh re-derives the OLD id from the path-stamped session id
+    // and calls recordPtyWorktree with it — ownership must NOT revert, but other
+    // fields (connected) still update.
+    i.recordPtyWorktree(ptyId, OLD, { connected: false })
+
+    expect(i.ptysById.get(ptyId)?.worktreeId).toBe(NEW)
+    expect(i.ptysById.get(ptyId)?.connected).toBe(false)
+  })
+
+  it('sets worktreeId on first insert (U2)', () => {
+    const record = i.recordPtyWorktree(`${OLD}@@aaaa`, OLD)
+    expect(record.worktreeId).toBe(OLD)
+  })
+})

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -5279,3 +5279,48 @@ describe('pending worktree creation state', () => {
     expect(store.getState().activePendingCreationId).toBeNull()
   })
 })
+
+describe('migrateWorktreeIdentity — folder rename re-keying', () => {
+  const OLD = 'repo1::/work/old-creature-name'
+  const NEW = 'repo1::/work/work-derived-name'
+  const OTHER = 'repo1::/work/unrelated'
+
+  it('moves tabs and the default-tabs-applied marker to the new id so activation does not spawn a fresh terminal', () => {
+    const store = createTestStore()
+    store.setState({
+      tabsByWorktree: {
+        [OLD]: [{ id: 't1', worktreeId: OLD }],
+        [OTHER]: [{ id: 't2', worktreeId: OTHER }]
+      },
+      // The marker that applyDefaultTerminalTabs guards on: if it survives the
+      // rename, activation of the new id won't re-apply defaults (the #5535 symptom).
+      defaultTerminalTabsAppliedByWorktreeId: { [OLD]: true, [OTHER]: true }
+    } as unknown as Partial<AppState>)
+
+    store.getState().migrateWorktreeIdentity(OLD, NEW)
+    const s = store.getState()
+
+    // Tabs follow the rename, with their worktreeId rewritten; old id is gone.
+    expect(s.tabsByWorktree[NEW]).toEqual([{ id: 't1', worktreeId: NEW }])
+    expect(s.tabsByWorktree[OLD]).toBeUndefined()
+    // The applied marker follows too — so the worktree is treated as initialized.
+    expect(s.defaultTerminalTabsAppliedByWorktreeId[NEW]).toBe(true)
+    expect(s.defaultTerminalTabsAppliedByWorktreeId[OLD]).toBeUndefined()
+    // An unrelated worktree is untouched.
+    expect(s.tabsByWorktree[OTHER]).toEqual([{ id: 't2', worktreeId: OTHER }])
+    expect(s.defaultTerminalTabsAppliedByWorktreeId[OTHER]).toBe(true)
+  })
+
+  it('is a no-op when old equals new', () => {
+    const store = createTestStore()
+    store.setState({
+      tabsByWorktree: { [OLD]: [{ id: 't1', worktreeId: OLD }] },
+      defaultTerminalTabsAppliedByWorktreeId: { [OLD]: true }
+    } as unknown as Partial<AppState>)
+
+    store.getState().migrateWorktreeIdentity(OLD, OLD)
+
+    expect(store.getState().tabsByWorktree[OLD]).toEqual([{ id: 't1', worktreeId: OLD }])
+    expect(store.getState().defaultTerminalTabsAppliedByWorktreeId[OLD]).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

The first-work folder-rename feature (#4743) was disabled in #5535 because moving a worktree's on-disk folder dropped the running terminal and replaced it with a fresh one. This fixes the underlying identity handoff so a live terminal survives the move. **Fix-only — the feature flag stays off.**

## Why it broke

A worktree's identity is derived from its filesystem path (`${repoId}::${path}`), and the live PTY session id is path-stamped and immutable. After `git worktree move` the path — and therefore the worktree id — changes, but every live session keeps a session id that re-derives back to the **old, now-gone** worktree id. The persisted-state and renderer migrations were already complete; the gap was that the **runtime** kept re-deriving a live session's owner from that stale path-stamped id, orphaning it and spawning a fresh terminal in its place.

## What changed

- **Re-point live PTY records on rename** — `notifyWorktreeFolderRenamed` now carries every live record (and its watcher bindings) from the old worktree id to the new one, before notifying the renderer.
- **Stop the controller-refresh clobber** — `recordPtyWorktree` no longer reassigns an existing record's `worktreeId`; the periodic refresh infers the stale old id and would otherwise re-orphan the session.
- **Boot attribution** — boot-time pid/memory hydration resolves a session's pre-rename id to its current worktree (guarded against a recycled path) so samples aren't lost.
- **Harden the dead startup orphan-kill path** — `reconcileOnStartup` has no production caller, but it is built to be wired in; documented + tested that it must honor `priorWorktreeIds` so a future boot wiring can't reap a renamed worktree's live sessions.

## Scope / follow-ups

- `ENABLE_FIRST_WORK_FOLDER_RENAME` **stays `false`** — this PR does not re-enable the feature. A follow-up PR flips it after this soaks. cc @brennanb2025 (authored the #5535 disable).
- Deferred to that PR: re-keying the advertised-URL watcher's `worktreeId`-keyed cache on rename (low impact — the watcher pointer is re-bound; only its cache lags, and at first-work-rename time a URL is rarely advertised yet). `ServeSimStateWatcher` is `ptyId`-keyed and already fully handled.

## Validation

- `typecheck:node` + `typecheck:web` clean; `oxlint` clean.
- New/extended unit + seam tests: runtime re-point + no-revert, renderer re-key invariant (no fresh default tabs), daemon prior-id survival contract, boot prior-id + recycled-path attribution, and an end-to-end folder-move seam test asserting the same live PTY stays bound. **275 tests pass** across the touched suite.
- The live Electron reproduction of #5535 (a Codex terminal surviving the on-disk move) is the gate for the follow-up enable PR — it cannot be exercised here with the flag off.

## ELI5

Renaming a worktree folder used to kill the live terminal and open a new one. PTY identity survives the path change so the same session keeps running (feature flag still off).
