### PR TITLE
feat(activity): add agent row status moves

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -53,7 +53,13 @@ import {
   setActivityTerminalPortals,
   type ActivityTerminalPortalTarget
 } from './activity-terminal-portal'
-import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
+import type {
+  Repo,
+  TerminalTab,
+  WorkspaceStatus,
+  WorkspaceStatusDefinition,
+  Worktree
+} from '../../../../shared/types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
@@ -70,6 +76,7 @@ import { translate } from '@/i18n/i18n'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { ActivityThreadRowContextMenu } from './ActivityThreadRowContextMenu'
+import { getWorkspaceStatus } from '../sidebar/workspace-status'
 
 type ThreadReadFilter = 'all' | 'unread'
 type ActivityGroupBy = 'status' | 'project' | 'worktree' | 'agent'
@@ -1155,9 +1162,13 @@ function ThreadRow({
   canJump,
   compactMode,
   liveTab,
+  canMoveWorkspaceStatus,
+  workspaceStatuses,
+  currentWorkspaceStatus,
   onCloseTab,
   onRenameCommit,
   onSetTabColor,
+  onMoveToStatus,
   onMarkRead
 }: {
   thread: AgentPaneThread
@@ -1168,9 +1179,13 @@ function ThreadRow({
   canJump: boolean
   compactMode: boolean
   liveTab: boolean
+  canMoveWorkspaceStatus: boolean
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  currentWorkspaceStatus: WorkspaceStatus | ''
   onCloseTab: (tabId: string) => void
   onRenameCommit: (tabId: string, value: string) => void
   onSetTabColor: (tabId: string, color: string | null) => void
+  onMoveToStatus: (worktreeId: string, status: WorkspaceStatus) => void
   onMarkRead: () => void
 }): React.JSX.Element {
   const renderedResponsePreview = activityThreadResponseRenderPreview({
@@ -1442,11 +1457,16 @@ function ThreadRow({
   return (
     <ActivityThreadRowContextMenu
       tab={thread.tab}
+      worktree={thread.worktree}
       unread={thread.unread}
       liveTab={liveTab}
+      canMoveWorkspaceStatus={canMoveWorkspaceStatus}
+      workspaceStatuses={workspaceStatuses}
+      currentWorkspaceStatus={currentWorkspaceStatus}
       onCloseTab={onCloseTab}
       onRenameOpen={openRename}
       onSetTabColor={onSetTabColor}
+      onMoveToStatus={onMoveToStatus}
       onMarkRead={onMarkRead}
       onMarkUnread={onMarkUnread}
     >
@@ -1505,6 +1525,8 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
   const setTabCustomTitle = useAppStore((s) => s.setTabCustomTitle)
   const setTabColor = useAppStore((s) => s.setTabColor)
+  const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
+  const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
 
   const { events: allEvents, liveAgentByPaneKey } = useMemo(
     () =>
@@ -1759,7 +1781,19 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   const isThreadTabLive = (thread: AgentPaneThread): boolean =>
     (storeData.tabsByWorktree[thread.worktree.id] ?? []).some((tab) => tab.id === thread.tab.id)
 
-  // Status helpers removed for Commit 1; will be added in Commit 2
+  const getThreadWorkspaceStatus = (thread: AgentPaneThread): WorkspaceStatus | '' => {
+    const worktree = storeData.worktreeMap.get(thread.worktree.id)
+    return worktree ? getWorkspaceStatus(worktree, workspaceStatuses) : ''
+  }
+
+  const moveThreadWorkspaceToStatus = (worktreeId: string, status: WorkspaceStatus): void => {
+    const worktree = storeData.worktreeMap.get(worktreeId)
+    if (!worktree || getWorkspaceStatus(worktree, workspaceStatuses) === status) {
+      return
+    }
+    useAppStore.getState().recordFeatureInteraction('workspace-board-actions')
+    void updateWorktreeMeta(worktreeId, { workspaceStatus: status })
+  }
 
   const commitThreadRename = (tabId: string, value: string): void => {
     const trimmed = value.trim()
@@ -2019,9 +2053,13 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                     canJump={storeData.worktreeMap.has(thread.worktree.id)}
                     compactMode={compactMode}
                     liveTab={isThreadTabLive(thread)}
+                    canMoveWorkspaceStatus={storeData.worktreeMap.has(thread.worktree.id)}
+                    workspaceStatuses={workspaceStatuses}
+                    currentWorkspaceStatus={getThreadWorkspaceStatus(thread)}
                     onCloseTab={(tabId) => closeTerminalTab(tabId)}
                     onRenameCommit={commitThreadRename}
                     onSetTabColor={setTabColor}
+                    onMoveToStatus={moveThreadWorkspaceToStatus}
                     onMarkRead={() => markThreadRead(thread)}
                   />
                 ))}

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -68,6 +68,8 @@ import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { translate } from '@/i18n/i18n'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
+import { closeTerminalTab } from '../terminal/terminal-tab-actions'
+import { ActivityThreadRowContextMenu } from './ActivityThreadRowContextMenu'
 
 type ThreadReadFilter = 'all' | 'unread'
 type ActivityGroupBy = 'status' | 'project' | 'worktree' | 'agent'
@@ -1151,7 +1153,12 @@ function ThreadRow({
   onJump,
   onMarkUnread,
   canJump,
-  compactMode
+  compactMode,
+  liveTab,
+  onCloseTab,
+  onRenameCommit,
+  onSetTabColor,
+  onMarkRead
 }: {
   thread: AgentPaneThread
   selected: boolean
@@ -1160,11 +1167,56 @@ function ThreadRow({
   onMarkUnread: () => void
   canJump: boolean
   compactMode: boolean
+  liveTab: boolean
+  onCloseTab: (tabId: string) => void
+  onRenameCommit: (tabId: string, value: string) => void
+  onSetTabColor: (tabId: string, color: string | null) => void
+  onMarkRead: () => void
 }): React.JSX.Element {
   const renderedResponsePreview = activityThreadResponseRenderPreview({
     responsePreview: thread.responsePreview
   })
-  return (
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [renameValue, setRenameValue] = useState('')
+  // Why: React's onBlur fires during the input's unmount when isRenaming flips
+  // to false. Without this guard, Enter/Escape would run commit a second time
+  // and overwrite the title the user just discarded. Mirrors SortableTab.tsx.
+  const committedOrCancelledRef = useRef(false)
+  const renameFocusFrameRef = useRef<number | null>(null)
+  const openRename = (): void => {
+    committedOrCancelledRef.current = false
+    setRenameValue(thread.tab.customTitle ?? thread.tab.title)
+    setIsRenaming(true)
+  }
+  const commitRename = (): void => {
+    if (committedOrCancelledRef.current) {
+      return
+    }
+    committedOrCancelledRef.current = true
+    onRenameCommit(thread.tab.id, renameValue)
+    setIsRenaming(false)
+  }
+  const cancelRename = (): void => {
+    committedOrCancelledRef.current = true
+    setIsRenaming(false)
+  }
+  const setRenameInputElement = useCallback((input: HTMLInputElement | null): void => {
+    if (renameFocusFrameRef.current !== null) {
+      cancelAnimationFrame(renameFocusFrameRef.current)
+      renameFocusFrameRef.current = null
+    }
+    if (!input) {
+      return
+    }
+    // Why: defer past Radix menu teardown/focus restore while still keying off
+    // input mount only; terminal title updates must not re-select in-progress text.
+    renameFocusFrameRef.current = requestAnimationFrame(() => {
+      renameFocusFrameRef.current = null
+      input.focus()
+      input.select()
+    })
+  }, [])
+  const row = (
     <div
       data-current={selected ? 'true' : undefined}
       onClick={onSelect}
@@ -1195,7 +1247,7 @@ function ThreadRow({
         // ~3px of internal space above the cap-height that isn't present
         // below the secondary badge row. Symmetric py made the top read
         // heavier; the smaller top pad visually evens the row.
-        'group relative flex w-full cursor-pointer flex-col gap-1 border-b border-border px-3 pt-2.5 pb-3 text-left transition-colors',
+        'group/thread-row relative flex w-full cursor-pointer flex-col gap-1 border-b border-border px-3 pt-2.5 pb-3 text-left transition-colors',
         selected
           ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
           : 'hover:bg-accent/40'
@@ -1216,16 +1268,62 @@ function ThreadRow({
           </span>
         </span>
         <div className="min-w-0 flex-1">
-          <span
-            className={cn(
-              'min-w-0 text-xs leading-snug',
-              compactMode ? 'block truncate' : 'line-clamp-3 break-words',
-              thread.unread ? 'font-semibold text-foreground' : 'font-medium text-foreground'
+          <div className="flex min-w-0 items-start gap-1.5">
+            {isRenaming ? (
+              <Input
+                ref={setRenameInputElement}
+                data-activity-thread-rename-input="true"
+                value={renameValue}
+                aria-label={translate(
+                  'auto.components.activity.ActivityPrototypePage.renameThreadTab',
+                  'Rename agent tab {{value0}}',
+                  { value0: thread.paneTitle }
+                )}
+                onChange={(event) => setRenameValue(event.target.value)}
+                onBlur={commitRename}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    commitRename()
+                  } else if (event.key === 'Escape') {
+                    event.preventDefault()
+                    cancelRename()
+                  }
+                }}
+                onPointerDown={(event) => event.stopPropagation()}
+                onMouseDown={(event) => {
+                  event.stopPropagation()
+                  if (event.button === 1) {
+                    event.preventDefault()
+                  }
+                }}
+                onClick={(event) => event.stopPropagation()}
+                onDoubleClick={(event) => event.stopPropagation()}
+                onAuxClick={(event) => event.stopPropagation()}
+                className="h-5 min-w-0 flex-1 px-1 py-0 text-xs"
+                spellCheck={false}
+              />
+            ) : (
+              <span
+                className={cn(
+                  'min-w-0 text-xs leading-snug',
+                  compactMode ? 'block truncate' : 'line-clamp-3 break-words',
+                  thread.unread ? 'font-semibold text-foreground' : 'font-medium text-foreground'
+                )}
+                title={compactMode ? thread.paneTitle : undefined}
+              >
+                {thread.paneTitle}
+              </span>
             )}
-            title={compactMode ? thread.paneTitle : undefined}
-          >
-            {thread.paneTitle}
-          </span>
+            {thread.tab.color && !isRenaming ? (
+              <span
+                data-activity-thread-color-dot="true"
+                className="mt-[5px] size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: thread.tab.color }}
+                aria-hidden
+              />
+            ) : null}
+          </div>
           {!compactMode && renderedResponsePreview ? (
             <CommentMarkdown
               content={renderedResponsePreview}
@@ -1245,8 +1343,8 @@ function ThreadRow({
           {/* Why (bell matches WorktreeCard pattern): unread → amber filled
               bell as a static, non-interactive cue (selecting the thread
               auto-marks it read, so a Mark-read button would be redundant);
-              read → outline Bell that fades in on row hover and acts as
-              Mark-unread. Bare button (no shadcn outline) so it reads as
+              read → outline Bell that fades in on row hover/focus and acts
+              as Mark-unread. Bare button (no shadcn outline) so it reads as
               an inline cue rather than a discrete control square. */}
           <span className="inline-flex size-4 shrink-0 items-center justify-center">
             {thread.unread ? (
@@ -1277,7 +1375,7 @@ function ThreadRow({
                       'Mark thread unread'
                     )}
                   >
-                    <Bell className="size-3 text-muted-foreground/40 can-hover:opacity-0 transition-opacity group-hover:opacity-100 group-hover/unread:opacity-100" />
+                    <Bell className="size-3 text-muted-foreground/40 can-hover:opacity-0 transition-opacity group-hover/thread-row:opacity-100 group-focus-within/thread-row:opacity-100 group-hover/unread:opacity-100" />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="left">
@@ -1301,13 +1399,13 @@ function ThreadRow({
             on the title row already holds the unread/Mark-unread state, so
             the navigation action gets its own slot down here aligned with
             the worktree name. On hover-capable pointers, the hidden state
-            keeps the worktree-name's flex-1 width stable across hover. */}
+            keeps the worktree-name's flex-1 width stable until hover or keyboard focus. */}
         {canJump ? (
           <span
             className={cn(
               'ml-auto inline-flex shrink-0 items-center transition-opacity',
               'can-hover:pointer-events-none can-hover:invisible can-hover:opacity-0',
-              'group-hover:pointer-events-auto group-hover:visible group-hover:opacity-100'
+              'group-hover/thread-row:pointer-events-auto group-hover/thread-row:visible group-hover/thread-row:opacity-100 group-focus-within/thread-row:pointer-events-auto group-focus-within/thread-row:visible group-focus-within/thread-row:opacity-100'
             )}
           >
             <Tooltip>
@@ -1340,6 +1438,20 @@ function ThreadRow({
         ) : null}
       </div>
     </div>
+  )
+  return (
+    <ActivityThreadRowContextMenu
+      tab={thread.tab}
+      unread={thread.unread}
+      liveTab={liveTab}
+      onCloseTab={onCloseTab}
+      onRenameOpen={openRename}
+      onSetTabColor={onSetTabColor}
+      onMarkRead={onMarkRead}
+      onMarkUnread={onMarkUnread}
+    >
+      {row}
+    </ActivityThreadRowContextMenu>
   )
 }
 
@@ -1391,6 +1503,8 @@ export default function ActivityPrototypePage(): React.JSX.Element {
   // computation itself) so the memo recomputes when freshness boundaries expire,
   // even if no new PTY data arrives.
   const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
+  const setTabCustomTitle = useAppStore((s) => s.setTabCustomTitle)
+  const setTabColor = useAppStore((s) => s.setTabColor)
 
   const { events: allEvents, liveAgentByPaneKey } = useMemo(
     () =>
@@ -1640,6 +1754,16 @@ export default function ActivityPrototypePage(): React.JSX.Element {
 
   const markThreadUnread = (thread: AgentPaneThread): void => {
     storeData.unacknowledgeAgents([thread.paneKey])
+  }
+
+  const isThreadTabLive = (thread: AgentPaneThread): boolean =>
+    (storeData.tabsByWorktree[thread.worktree.id] ?? []).some((tab) => tab.id === thread.tab.id)
+
+  // Status helpers removed for Commit 1; will be added in Commit 2
+
+  const commitThreadRename = (tabId: string, value: string): void => {
+    const trimmed = value.trim()
+    setTabCustomTitle(tabId, trimmed.length > 0 ? trimmed : null)
   }
 
   const activateThreadTerminal = (thread: AgentPaneThread): void => {
@@ -1894,6 +2018,11 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                     onMarkUnread={() => markThreadUnread(thread)}
                     canJump={storeData.worktreeMap.has(thread.worktree.id)}
                     compactMode={compactMode}
+                    liveTab={isThreadTabLive(thread)}
+                    onCloseTab={(tabId) => closeTerminalTab(tabId)}
+                    onRenameCommit={commitThreadRename}
+                    onSetTabColor={setTabColor}
+                    onMarkRead={() => markThreadRead(thread)}
                   />
                 ))}
               </section>
@@ -1953,6 +2082,13 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                     <h2 className="line-clamp-3 break-words text-sm font-semibold leading-snug">
                       {selectedThread.paneTitle}
                     </h2>
+                    {selectedThread.tab.color ? (
+                      <span
+                        className="mt-[7px] size-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: selectedThread.tab.color }}
+                        aria-hidden
+                      />
+                    ) : null}
                   </div>
                   <div className="mt-1 flex min-w-0 items-center gap-1.5 pl-11">
                     <EventRepoBadge repo={selectedThread.repo} />

--- a/src/renderer/src/components/activity/ActivityThreadRowContextMenu.test.tsx
+++ b/src/renderer/src/components/activity/ActivityThreadRowContextMenu.test.tsx
@@ -8,7 +8,7 @@ import {
   ActivityThreadRowContextMenu,
   type ActivityThreadRowContextMenuProps
 } from './ActivityThreadRowContextMenu'
-import type { TerminalTab } from '../../../../shared/types'
+import type { TerminalTab, Worktree, WorkspaceStatusDefinition } from '../../../../shared/types'
 
 vi.mock('@/components/ui/context-menu', () => ({
   ContextMenu: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
@@ -77,6 +77,19 @@ const mockTab = {
   isPinned: false
 } as unknown as TerminalTab // Why: mock tab only exercises context menu fields
 
+const mockWorktree = {
+  id: 'wt-1',
+  repoId: 'repo-1',
+  displayName: 'Workspace 1',
+  comment: '',
+  linkedIssue: null,
+  linkedPR: null,
+  linkedLinearIssue: null,
+  path: '/path/to/wt-1',
+  head: 'main',
+  branch: 'main'
+} as unknown as Worktree // Why: mock worktree only exercises context menu fields
+
 const mounted: { container: HTMLDivElement; root: Root }[] = []
 
 function renderMenu(overrides: Partial<ActivityThreadRowContextMenuProps> = {}): {
@@ -85,6 +98,7 @@ function renderMenu(overrides: Partial<ActivityThreadRowContextMenuProps> = {}):
   onCloseTab: Mock<(tabId: string) => void>
   onRenameOpen: Mock<() => void>
   onSetTabColor: Mock<(tabId: string, color: string | null) => void>
+  onMoveToStatus: Mock<(worktreeId: string, status: string) => void>
   onMarkRead: Mock<() => void>
   onMarkUnread: Mock<() => void>
 } {
@@ -95,17 +109,26 @@ function renderMenu(overrides: Partial<ActivityThreadRowContextMenuProps> = {}):
   const onCloseTab = vi.fn()
   const onRenameOpen = vi.fn()
   const onSetTabColor = vi.fn()
+  const onMoveToStatus = vi.fn()
   const onMarkRead = vi.fn()
   const onMarkUnread = vi.fn()
 
   const defaultProps: ActivityThreadRowContextMenuProps = {
     children: <div>Row Child</div>,
     tab: mockTab,
+    worktree: mockWorktree,
     unread: false,
     liveTab: true,
+    canMoveWorkspaceStatus: true,
+    workspaceStatuses: [
+      { id: 'todo', label: 'Todo' },
+      { id: 'completed', label: 'Done' }
+    ] as WorkspaceStatusDefinition[],
+    currentWorkspaceStatus: 'todo',
     onCloseTab,
     onRenameOpen,
     onSetTabColor,
+    onMoveToStatus,
     onMarkRead,
     onMarkUnread
   }
@@ -121,6 +144,7 @@ function renderMenu(overrides: Partial<ActivityThreadRowContextMenuProps> = {}):
     onCloseTab,
     onRenameOpen,
     onSetTabColor,
+    onMoveToStatus,
     onMarkRead,
     onMarkUnread
   }
@@ -203,6 +227,21 @@ describe('ActivityThreadRowContextMenu', () => {
       orangeSwatch.click()
     })
     expect(onSetTabColor).toHaveBeenCalledWith('tab-1', '#f97316')
+  })
+
+  it('calls onMoveToStatus when a status is clicked', () => {
+    const { container, onMoveToStatus } = renderMenu()
+    const todoBtn = getButton(container, 'Todo')
+    act(() => {
+      todoBtn.click()
+    })
+    expect(onMoveToStatus).toHaveBeenCalledWith('wt-1', 'todo')
+  })
+
+  it('disables status submenu when canMoveWorkspaceStatus is false', () => {
+    const { container } = renderMenu({ canMoveWorkspaceStatus: false })
+    const subTrigger = getButton(container, 'Move to Status')
+    expect(subTrigger.disabled).toBe(true)
   })
 
   it('calls onMarkRead when unread and Mark Read is clicked', () => {

--- a/src/renderer/src/components/activity/ActivityThreadRowContextMenu.test.tsx
+++ b/src/renderer/src/components/activity/ActivityThreadRowContextMenu.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
+import {
+  ActivityThreadRowContextMenu,
+  type ActivityThreadRowContextMenuProps
+} from './ActivityThreadRowContextMenu'
+import type { TerminalTab } from '../../../../shared/types'
+
+vi.mock('@/components/ui/context-menu', () => ({
+  ContextMenu: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+    ...props
+  }: {
+    children?: React.ReactNode
+    disabled?: boolean
+    onSelect?: () => void
+  } & React.ComponentPropsWithoutRef<'button'>) => (
+    <button type="button" disabled={disabled} onClick={() => onSelect?.()} {...props}>
+      {children}
+    </button>
+  ),
+  ContextMenuLabel: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSeparator: () => null,
+  ContextMenuSub: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuSubTrigger: ({
+    children,
+    disabled
+  }: {
+    children?: React.ReactNode
+    disabled?: boolean
+  }) => (
+    <button type="button" disabled={disabled}>
+      {children}
+    </button>
+  ),
+  ContextMenuSubContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ContextMenuRadioItem: ({
+    children,
+    onSelect,
+    ...props
+  }: {
+    children?: React.ReactNode
+    onSelect?: () => void
+  } & React.ComponentPropsWithoutRef<'button'>) => (
+    <button type="button" onClick={() => onSelect?.()} {...props}>
+      {children}
+    </button>
+  )
+}))
+
+vi.mock('../sidebar/workspace-status', () => ({
+  getWorkspaceStatusVisualMeta: () => ({
+    tone: 'text-muted-foreground',
+    icon: () => null
+  })
+}))
+
+const mockTab = {
+  id: 'tab-1',
+  ptyId: 'pty-1',
+  worktreeId: 'wt-1',
+  title: 'Agent',
+  customTitle: null,
+  color: null,
+  sortOrder: 0,
+  createdAt: 0,
+  isPinned: false
+} as unknown as TerminalTab // Why: mock tab only exercises context menu fields
+
+const mounted: { container: HTMLDivElement; root: Root }[] = []
+
+function renderMenu(overrides: Partial<ActivityThreadRowContextMenuProps> = {}): {
+  container: HTMLDivElement
+  root: Root
+  onCloseTab: Mock<(tabId: string) => void>
+  onRenameOpen: Mock<() => void>
+  onSetTabColor: Mock<(tabId: string, color: string | null) => void>
+  onMarkRead: Mock<() => void>
+  onMarkUnread: Mock<() => void>
+} {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  const onCloseTab = vi.fn()
+  const onRenameOpen = vi.fn()
+  const onSetTabColor = vi.fn()
+  const onMarkRead = vi.fn()
+  const onMarkUnread = vi.fn()
+
+  const defaultProps: ActivityThreadRowContextMenuProps = {
+    children: <div>Row Child</div>,
+    tab: mockTab,
+    unread: false,
+    liveTab: true,
+    onCloseTab,
+    onRenameOpen,
+    onSetTabColor,
+    onMarkRead,
+    onMarkUnread
+  }
+
+  act(() => {
+    root.render(<ActivityThreadRowContextMenu {...defaultProps} {...overrides} />)
+  })
+
+  mounted.push({ container, root })
+  return {
+    container,
+    root,
+    onCloseTab,
+    onRenameOpen,
+    onSetTabColor,
+    onMarkRead,
+    onMarkUnread
+  }
+}
+
+function getButton(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find((btn) =>
+    btn.textContent?.includes(text)
+  )
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${text}`)
+  }
+  return button
+}
+
+afterEach(() => {
+  while (mounted.length > 0) {
+    const item = mounted.pop()
+    if (item) {
+      act(() => {
+        item.root.unmount()
+      })
+      item.container.remove()
+    }
+  }
+})
+
+describe('ActivityThreadRowContextMenu', () => {
+  it('calls onCloseTab when Close is clicked and tab is live and not pinned', () => {
+    const { container, onCloseTab } = renderMenu()
+    const btn = getButton(container, 'Close')
+    expect(btn.disabled).toBe(false)
+    act(() => {
+      btn.click()
+    })
+    expect(onCloseTab).toHaveBeenCalledWith('tab-1')
+  })
+
+  it('disables Close when tab is pinned', () => {
+    const { container } = renderMenu({
+      tab: { ...mockTab, isPinned: true }
+    })
+    const btn = getButton(container, 'Close')
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('disables Close when tab is not live', () => {
+    const { container } = renderMenu({ liveTab: false })
+    const btn = getButton(container, 'Close')
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('calls onRenameOpen when Change Title is clicked and live', () => {
+    const { container, onRenameOpen } = renderMenu()
+    const btn = getButton(container, 'Change Title')
+    expect(btn.disabled).toBe(false)
+    act(() => {
+      btn.click()
+    })
+    expect(onRenameOpen).toHaveBeenCalled()
+  })
+
+  it('disables Change Title when tab is not live', () => {
+    const { container } = renderMenu({ liveTab: false })
+    const btn = getButton(container, 'Change Title')
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('calls onSetTabColor when a color is clicked', () => {
+    const { container, onSetTabColor } = renderMenu()
+    const swatches = Array.from(container.querySelectorAll('button')).filter(
+      (btn) => btn.getAttribute('aria-label') !== null
+    )
+    expect(swatches.length).toBeGreaterThan(0)
+    const orangeSwatch = swatches.find((btn) => btn.getAttribute('aria-label')?.includes('Orange'))
+    if (!orangeSwatch) {
+      throw new Error('Orange swatch not found')
+    }
+    act(() => {
+      orangeSwatch.click()
+    })
+    expect(onSetTabColor).toHaveBeenCalledWith('tab-1', '#f97316')
+  })
+
+  it('calls onMarkRead when unread and Mark Read is clicked', () => {
+    const { container, onMarkRead } = renderMenu({ unread: true })
+    const btn = getButton(container, 'Mark Read')
+    act(() => {
+      btn.click()
+    })
+    expect(onMarkRead).toHaveBeenCalled()
+  })
+
+  it('calls onMarkUnread when read and Mark Unread is clicked', () => {
+    const { container, onMarkUnread } = renderMenu({ unread: false })
+    const btn = getButton(container, 'Mark Unread')
+    act(() => {
+      btn.click()
+    })
+    expect(onMarkUnread).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/activity/ActivityThreadRowContextMenu.tsx
+++ b/src/renderer/src/components/activity/ActivityThreadRowContextMenu.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import { translate } from '@/i18n/i18n'
+import { TabColorSwatchGrid } from '../tab-bar/tab-color-swatch'
+import type { TerminalTab } from '../../../../shared/types'
+
+export type ActivityThreadRowContextMenuProps = {
+  children: React.ReactNode
+  tab: TerminalTab
+  // worktree removed for Commit 1
+  unread: boolean
+  liveTab: boolean
+  // workspaceStatuses removed for Commit 1
+  onCloseTab: (tabId: string) => void
+  onRenameOpen: () => void
+  onSetTabColor: (tabId: string, color: string | null) => void
+  onMarkRead: () => void
+  onMarkUnread: () => void
+}
+
+export function ActivityThreadRowContextMenu({
+  children,
+  tab,
+  // worktree parameter removed for Commit 1
+  unread,
+  liveTab,
+  // workspaceStatuses parameter removed for Commit 1
+  onCloseTab,
+  onRenameOpen,
+  onSetTabColor,
+  onMarkRead,
+  onMarkUnread
+}: ActivityThreadRowContextMenuProps): React.JSX.Element {
+  const closeDisabled = !liveTab || tab.isPinned === true
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        <ContextMenuItem onSelect={() => onCloseTab(tab.id)} disabled={closeDisabled}>
+          {translate('auto.components.tab.bar.SortableTabContextMenu.89359a36f7', 'Close')}
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => onRenameOpen()} disabled={!liveTab}>
+          {translate('auto.components.tab.bar.SortableTabContextMenu.2f697b3c31', 'Change Title')}
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuLabel>
+          {translate('auto.components.tab.bar.SortableTabContextMenu.35e8892fd0', 'Tab Color')}
+        </ContextMenuLabel>
+        <TabColorSwatchGrid
+          selectedColor={tab.color}
+          className="px-2 pt-1 pb-1.5"
+          renderSwatch={({ color, className, style, ariaLabel, children }) => (
+            <ContextMenuItem
+              key={color.label}
+              disabled={!liveTab}
+              aria-label={ariaLabel}
+              className={className}
+              style={style}
+              onSelect={() => onSetTabColor(tab.id, color.value)}
+            >
+              {children}
+            </ContextMenuItem>
+          )}
+        />
+        <ContextMenuSeparator />
+        {unread ? (
+          <ContextMenuItem onSelect={() => onMarkRead()}>
+            {translate('auto.components.sidebar.WorktreeContextMenu.8dacff1fe0', 'Mark Read')}
+          </ContextMenuItem>
+        ) : (
+          <ContextMenuItem onSelect={() => onMarkUnread()}>
+            {translate('auto.components.sidebar.WorktreeContextMenu.f50603c6b2', 'Mark Unread')}
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/src/renderer/src/components/activity/ActivityThreadRowContextMenu.tsx
+++ b/src/renderer/src/components/activity/ActivityThreadRowContextMenu.tsx
@@ -4,23 +4,38 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuLabel,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
 import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
 import { TabColorSwatchGrid } from '../tab-bar/tab-color-swatch'
-import type { TerminalTab } from '../../../../shared/types'
+import { getWorkspaceStatusVisualMeta } from '../sidebar/workspace-status'
+import type {
+  TerminalTab,
+  WorkspaceStatus,
+  WorkspaceStatusDefinition,
+  Worktree
+} from '../../../../shared/types'
 
 export type ActivityThreadRowContextMenuProps = {
   children: React.ReactNode
   tab: TerminalTab
-  // worktree removed for Commit 1
+  worktree: Worktree
   unread: boolean
   liveTab: boolean
-  // workspaceStatuses removed for Commit 1
+  canMoveWorkspaceStatus: boolean
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  currentWorkspaceStatus: WorkspaceStatus | ''
   onCloseTab: (tabId: string) => void
   onRenameOpen: () => void
   onSetTabColor: (tabId: string, color: string | null) => void
+  onMoveToStatus: (worktreeId: string, status: WorkspaceStatus) => void
   onMarkRead: () => void
   onMarkUnread: () => void
 }
@@ -28,17 +43,21 @@ export type ActivityThreadRowContextMenuProps = {
 export function ActivityThreadRowContextMenu({
   children,
   tab,
-  // worktree parameter removed for Commit 1
+  worktree,
   unread,
   liveTab,
-  // workspaceStatuses parameter removed for Commit 1
+  canMoveWorkspaceStatus,
+  workspaceStatuses,
+  currentWorkspaceStatus,
   onCloseTab,
   onRenameOpen,
   onSetTabColor,
+  onMoveToStatus,
   onMarkRead,
   onMarkUnread
 }: ActivityThreadRowContextMenuProps): React.JSX.Element {
   const closeDisabled = !liveTab || tab.isPinned === true
+  const statusDisabled = !canMoveWorkspaceStatus || workspaceStatuses.length === 0
 
   return (
     <ContextMenu>
@@ -70,6 +89,29 @@ export function ActivityThreadRowContextMenu({
             </ContextMenuItem>
           )}
         />
+        <ContextMenuSeparator />
+        <ContextMenuSub>
+          <ContextMenuSubTrigger disabled={statusDisabled}>
+            {translate('auto.components.sidebar.WorktreeContextMenu.84cdbb7e30', 'Move to Status')}
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent className="w-44">
+            <ContextMenuRadioGroup value={currentWorkspaceStatus}>
+              {workspaceStatuses.map((status) => {
+                const meta = getWorkspaceStatusVisualMeta(status)
+                return (
+                  <ContextMenuRadioItem
+                    key={status.id}
+                    value={status.id}
+                    onSelect={() => onMoveToStatus(worktree.id, status.id)}
+                  >
+                    <meta.icon className={cn('size-3.5', meta.tone)} />
+                    {status.label}
+                  </ContextMenuRadioItem>
+                )
+              })}
+            </ContextMenuRadioGroup>
+          </ContextMenuSubContent>
+        </ContextMenuSub>
         <ContextMenuSeparator />
         {unread ? (
           <ContextMenuItem onSelect={() => onMarkRead()}>

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
@@ -57,7 +57,8 @@ vi.mock('lucide-react', () => ({
 }))
 
 vi.mock('@/i18n/i18n', () => ({
-  translate: (_key: string, fallback: string) => fallback
+  translate: (_key: string, fallback: string) => fallback,
+  i18n: { language: 'en' }
 }))
 
 vi.mock('../../store', () => ({

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
@@ -13,69 +13,7 @@ import { formatShortcutLabel, useOptionalShortcutLabel } from '@/hooks/useShortc
 import { translate } from '@/i18n/i18n'
 import { TabWorkspaceLayoutMenuSection } from './TabWorkspaceLayoutMenuSection'
 import { requestActiveTerminalPaneSplit } from './request-active-terminal-pane-split'
-
-const TAB_COLORS = [
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.20baa43c05', 'None')
-    },
-    value: null
-  },
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.cb3eadefd2', 'Blue')
-    },
-    value: '#3b82f6'
-  },
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.c2d8b0991f', 'Purple')
-    },
-    value: '#a855f7'
-  },
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.03cf6dab1a', 'Pink')
-    },
-    value: '#ec4899'
-  },
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.620aec6729', 'Red')
-    },
-    value: '#ef4444'
-  },
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.a47629b3cf', 'Orange')
-    },
-    value: '#f97316'
-  },
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.69682e2ce4', 'Yellow')
-    },
-    value: '#eab308'
-  },
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.be905e9b0a', 'Green')
-    },
-    value: '#22c55e'
-  },
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.845576bed1', 'Teal')
-    },
-    value: '#14b8a6'
-  },
-  {
-    get label() {
-      return translate('auto.components.tab.bar.SortableTabContextMenu.7703990447', 'Gray')
-    },
-    value: '#9ca3af'
-  }
-] as const
+import { TabColorSwatchGrid } from './tab-color-swatch'
 
 type SortableTabContextMenuProps = {
   tab: TerminalTab
@@ -187,29 +125,22 @@ export function SortableTabContextMenu({
           <div className="text-xs font-medium text-muted-foreground mb-1.5">
             {translate('auto.components.tab.bar.SortableTabContextMenu.35e8892fd0', 'Tab Color')}
           </div>
-          <div className="flex flex-wrap gap-2">
-            {TAB_COLORS.map((color) => {
-              const isSelected = tab.color === color.value
-              return (
-                <DropdownMenuItem
-                  key={color.label}
-                  className={`relative h-4 w-4 min-w-4 p-0 rounded-full border ${
-                    isSelected ? 'ring-1 ring-foreground/70 ring-offset-1 ring-offset-popover' : ''
-                  } ${
-                    color.value ? 'border-transparent' : 'border-muted-foreground/50 bg-transparent'
-                  }`}
-                  style={color.value ? { backgroundColor: color.value } : undefined}
-                  onSelect={() => {
-                    onSetTabColor(tab.id, color.value)
-                  }}
-                >
-                  {color.value === null && (
-                    <span className="absolute block h-px w-3 rotate-45 bg-muted-foreground/80" />
-                  )}
-                </DropdownMenuItem>
-              )
-            })}
-          </div>
+          <TabColorSwatchGrid
+            selectedColor={tab.color}
+            renderSwatch={({ color, className, style, ariaLabel, children }) => (
+              <DropdownMenuItem
+                key={color.label}
+                className={className}
+                style={style}
+                aria-label={ariaLabel}
+                onSelect={() => {
+                  onSetTabColor(tab.id, color.value)
+                }}
+              >
+                {children}
+              </DropdownMenuItem>
+            )}
+          />
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/renderer/src/components/tab-bar/tab-color-options.ts
+++ b/src/renderer/src/components/tab-bar/tab-color-options.ts
@@ -1,0 +1,50 @@
+import { translate } from '@/i18n/i18n'
+import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+
+export type TabColorOption = {
+  readonly label: string
+  readonly value: string | null
+}
+
+export const getTabColorOptions = createLocalizedCatalog((): readonly TabColorOption[] => [
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.20baa43c05', 'None'),
+    value: null
+  },
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.cb3eadefd2', 'Blue'),
+    value: '#3b82f6'
+  },
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.c2d8b0991f', 'Purple'),
+    value: '#a855f7'
+  },
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.03cf6dab1a', 'Pink'),
+    value: '#ec4899'
+  },
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.620aec6729', 'Red'),
+    value: '#ef4444'
+  },
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.a47629b3cf', 'Orange'),
+    value: '#f97316'
+  },
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.69682e2ce4', 'Yellow'),
+    value: '#eab308'
+  },
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.be905e9b0a', 'Green'),
+    value: '#22c55e'
+  },
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.845576bed1', 'Teal'),
+    value: '#14b8a6'
+  },
+  {
+    label: translate('auto.components.tab.bar.SortableTabContextMenu.7703990447', 'Gray'),
+    value: '#9ca3af'
+  }
+])

--- a/src/renderer/src/components/tab-bar/tab-color-swatch.tsx
+++ b/src/renderer/src/components/tab-bar/tab-color-swatch.tsx
@@ -1,0 +1,65 @@
+import React, { type CSSProperties } from 'react'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { getTabColorOptions, type TabColorOption } from './tab-color-options'
+
+export type TabColorSwatchRenderProps = {
+  color: TabColorOption
+  isSelected: boolean
+  className: string
+  style: CSSProperties | undefined
+  ariaLabel: string
+  children: React.ReactNode
+}
+
+// Why: both the terminal tab context menu and the Activity row context menu
+// render the same swatch grid. Sharing the class names, selected-ring styling,
+// inline color, and the "none" diagonal strike here keeps the two menus from
+// drifting apart while each still owns its own menu-item wrapper primitive.
+export function getTabColorSwatchClassName(isSelected: boolean, value: string | null): string {
+  return cn(
+    'relative h-4 w-4 min-w-4 rounded-full border p-0',
+    isSelected ? 'ring-1 ring-foreground/70 ring-offset-1 ring-offset-popover' : '',
+    value ? 'border-transparent' : 'border-muted-foreground/50 bg-transparent'
+  )
+}
+
+export function TabColorSwatchGrid({
+  selectedColor,
+  className,
+  renderSwatch
+}: {
+  selectedColor: string | null | undefined
+  className?: string
+  renderSwatch: (props: TabColorSwatchRenderProps) => React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div className={cn('flex flex-wrap gap-2', className)}>
+      {getTabColorOptions().map((color) => {
+        const isSelected = selectedColor === color.value
+        // Why: shared aria-label so both the terminal tab menu and the Activity
+        // row menu expose the same accessible name to screen readers without
+        // each call site re-deriving the translate keys.
+        const ariaLabel =
+          color.value === null
+            ? translate('auto.components.tab.bar.tab-color-swatch.clearTabColor', 'Clear tab color')
+            : translate(
+                'auto.components.tab.bar.tab-color-swatch.setTabColor',
+                'Set tab color {{value0}}',
+                { value0: color.label }
+              )
+        return renderSwatch({
+          color,
+          isSelected,
+          className: getTabColorSwatchClassName(isSelected, color.value),
+          style: color.value ? { backgroundColor: color.value } : undefined,
+          ariaLabel,
+          children:
+            color.value === null ? (
+              <span className="absolute block h-px w-3 rotate-45 bg-muted-foreground/80" />
+            ) : null
+        })
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2673,6 +2673,10 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "Close tab",
             "a768f428f1": "Close tab"
+          },
+          "tab-color-swatch": {
+            "clearTabColor": "Clear tab color",
+            "setTabColor": "Set tab color {{value0}}"
           }
         }
       },
@@ -11667,12 +11671,17 @@
           "beb2c19173": "Unread",
           "5651b216c6": "Unknown project",
           "22b22034bc": "Standalone terminal unavailable in Activity.",
-          "afdc2139a8": "Agent terminal closed. Open a new terminal in this workspace to continue."
+          "afdc2139a8": "Agent terminal closed. Open a new terminal in this workspace to continue.",
+          "renameThreadTab": "Rename agent tab {{value0}}"
         },
         "ActivityTitlebarControls": {
           "f915168c8e": "unread",
           "d6a8de3934": "agents",
           "dc708f3eff": "Close agents"
+        },
+        "ActivityThreadRowContextMenu": {
+          "clearTabColor": "Clear tab color",
+          "setTabColor": "Set tab color {{value0}}"
         }
       },
       "confirmation": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2673,6 +2673,10 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "Cerrar pestaña",
             "a768f428f1": "Cerrar pestaña"
+          },
+          "tab-color-swatch": {
+            "clearTabColor": "Clear tab color",
+            "setTabColor": "Set tab color {{value0}}"
           }
         }
       },
@@ -11667,12 +11671,17 @@
           "beb2c19173": "No leído",
           "5651b216c6": "Proyecto desconocido",
           "22b22034bc": "Terminal independiente no disponible en Actividad.",
-          "afdc2139a8": "Terminal de Agent cerrada. Abra una nueva terminal en este espacio de trabajo para continuar."
+          "afdc2139a8": "Terminal de Agent cerrada. Abra una nueva terminal en este espacio de trabajo para continuar.",
+          "renameThreadTab": "Rename agent tab {{value0}}"
         },
         "ActivityTitlebarControls": {
           "f915168c8e": "no leído",
           "d6a8de3934": "agentes",
           "dc708f3eff": "Agentes cercanos"
+        },
+        "ActivityThreadRowContextMenu": {
+          "clearTabColor": "Clear tab color",
+          "setTabColor": "Set tab color {{value0}}"
         }
       },
       "confirmation": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2673,6 +2673,10 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "タブを閉じる",
             "a768f428f1": "タブを閉じる"
+          },
+          "tab-color-swatch": {
+            "clearTabColor": "Clear tab color",
+            "setTabColor": "Set tab color {{value0}}"
           }
         }
       },
@@ -11667,12 +11671,17 @@
           "beb2c19173": "未読",
           "5651b216c6": "不明なプロジェクト",
           "22b22034bc": "スタンドアロン terminal はアクティビティでは使用できません。",
-          "afdc2139a8": "Agent terminal が閉じられました。続行するには、このワークスペースで新規 terminal を開いてください。"
+          "afdc2139a8": "Agent terminal が閉じられました。続行するには、このワークスペースで新規 terminal を開いてください。",
+          "renameThreadTab": "Rename agent tab {{value0}}"
         },
         "ActivityTitlebarControls": {
           "f915168c8e": "未読",
           "d6a8de3934": "エージェント",
           "dc708f3eff": "agents を閉じる"
+        },
+        "ActivityThreadRowContextMenu": {
+          "clearTabColor": "Clear tab color",
+          "setTabColor": "Set tab color {{value0}}"
         }
       },
       "confirmation": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2673,6 +2673,10 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "탭 닫기",
             "a768f428f1": "탭 닫기"
+          },
+          "tab-color-swatch": {
+            "clearTabColor": "Clear tab color",
+            "setTabColor": "Set tab color {{value0}}"
           }
         }
       },
@@ -11667,12 +11671,17 @@
           "beb2c19173": "읽지 않음",
           "5651b216c6": "알 수 없는 프로젝트",
           "22b22034bc": "활동에서는 독립형 terminal을 사용할 수 없습니다.",
-          "afdc2139a8": "Agent terminal이 닫혔습니다. 계속하려면 이 워크스페이스에서 새 terminal을 여세요."
+          "afdc2139a8": "Agent terminal이 닫혔습니다. 계속하려면 이 워크스페이스에서 새 terminal을 여세요.",
+          "renameThreadTab": "Rename agent tab {{value0}}"
         },
         "ActivityTitlebarControls": {
           "f915168c8e": "읽지 않음",
           "d6a8de3934": "에이전트",
           "dc708f3eff": "agents 닫기"
+        },
+        "ActivityThreadRowContextMenu": {
+          "clearTabColor": "Clear tab color",
+          "setTabColor": "Set tab color {{value0}}"
         }
       },
       "confirmation": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2673,6 +2673,10 @@
           "EditorFileTabCloseButton": {
             "4655cf570e": "关闭选项卡",
             "a768f428f1": "关闭选项卡"
+          },
+          "tab-color-swatch": {
+            "clearTabColor": "Clear tab color",
+            "setTabColor": "Set tab color {{value0}}"
           }
         }
       },
@@ -11667,12 +11671,17 @@
           "beb2c19173": "未读",
           "5651b216c6": "未知项目",
           "22b22034bc": "独立终端在活动中不可用。",
-          "afdc2139a8": "智能体终端关闭。在此工作区中打开一个新终端以继续。"
+          "afdc2139a8": "智能体终端关闭。在此工作区中打开一个新终端以继续。",
+          "renameThreadTab": "Rename agent tab {{value0}}"
         },
         "ActivityTitlebarControls": {
           "f915168c8e": "未读",
           "d6a8de3934": "智能体",
           "dc708f3eff": "紧密智能体"
+        },
+        "ActivityThreadRowContextMenu": {
+          "clearTabColor": "Clear tab color",
+          "setTabColor": "Set tab color {{value0}}"
         }
       },
       "confirmation": {

--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -445,9 +445,9 @@ test.describe('Activity Agent Pane Isolation', () => {
       })
   })
 
-  test('agent row context menu updates tab title, color, and close state', async ({
+  test('agent row context menu updates tab title, color, workspace status, and close state', async ({
     orcaPage
-  }): Promise<void> => {
+  }) => {
     await splitActiveTerminalPane(orcaPage, 'vertical')
     await waitForPaneCount(orcaPage, 2)
     const snapshot = await waitForPaneIdentitySnapshot(orcaPage, 2)
@@ -515,7 +515,20 @@ test.describe('Activity Agent Pane Isolation', () => {
     const colorDot = selectedRow.locator('[data-activity-thread-color-dot="true"]')
     await expect(colorDot).toBeVisible()
 
-    // 4. Close Tab
+    // 4. Move Workspace status
+    await selectedRow.click({ button: 'right' })
+    await orcaPage.getByRole('menuitem', { name: 'Move to Status' }).hover()
+    await orcaPage.getByRole('menuitemradio', { name: 'Done' }).click()
+    await expect
+      .poll(async () => {
+        return orcaPage.evaluate((wId) => {
+          const wt = window.__store.getState().getKnownWorktreeById(wId)
+          return wt?.workspaceStatus
+        }, worktreeId)
+      })
+      .toBe('completed')
+
+    // 5. Close Tab
     await selectedRow.click({ button: 'right' })
     await orcaPage.getByRole('menuitem', { name: 'Close' }).click()
     await expect

--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -444,4 +444,89 @@ test.describe('Activity Agent Pane Isolation', () => {
         activeLeafId: second.leafId
       })
   })
+
+  test('agent row context menu updates tab title, color, and close state', async ({
+    orcaPage
+  }): Promise<void> => {
+    await splitActiveTerminalPane(orcaPage, 'vertical')
+    await waitForPaneCount(orcaPage, 2)
+    const snapshot = await waitForPaneIdentitySnapshot(orcaPage, 2)
+    const [first] = await seedActivityThreadsForSplitPanes(orcaPage, snapshot)
+
+    await agentsSidebarButton(orcaPage).click()
+    await expect(orcaPage.getByText(first.prompt)).toBeVisible()
+
+    // 1. Select the row so we can target it stably via data-current="true"
+    await orcaPage.getByRole('button').filter({ hasText: first.prompt }).first().click()
+    const selectedRow = orcaPage.locator('[data-current="true"]').first()
+
+    // Extract tabId and worktreeId for assertions
+    const [tabId] = first.paneKey.split(':')
+    const worktreeId = await orcaPage.evaluate((tid) => {
+      const state = window.__store.getState()
+      for (const [wId, tabs] of Object.entries(state.tabsByWorktree)) {
+        if (tabs.some((t) => t.id === tid)) {
+          return wId
+        }
+      }
+      return null
+    }, tabId)
+    if (!worktreeId) {
+      throw new Error('Could not resolve worktreeId for E2E test')
+    }
+
+    // 2. Change Title
+    await selectedRow.click({ button: 'right' })
+    await orcaPage.getByRole('menuitem', { name: 'Change Title' }).click()
+    const renameInput = orcaPage.locator('[data-activity-thread-rename-input="true"]')
+    await expect(renameInput).toBeVisible()
+    await renameInput.fill('Renamed activity agent')
+    await renameInput.press('Enter')
+
+    await expect
+      .poll(async () => {
+        return orcaPage.evaluate(
+          ({ wId, tId }) => {
+            const tab = window.__store.getState().tabsByWorktree[wId]?.find((t) => t.id === tId)
+            return tab?.customTitle
+          },
+          { wId: worktreeId, tId: tabId }
+        )
+      })
+      .toBe('Renamed activity agent')
+    await expect(selectedRow).toContainText('Renamed activity agent')
+
+    // 3. Set tab color
+    await selectedRow.click({ button: 'right' })
+    await orcaPage.getByLabel('Set tab color Orange').click()
+    await expect
+      .poll(async () => {
+        return orcaPage.evaluate(
+          ({ wId, tId }) => {
+            const tab = window.__store.getState().tabsByWorktree[wId]?.find((t) => t.id === tId)
+            return tab?.color
+          },
+          { wId: worktreeId, tId: tabId }
+        )
+      })
+      .toBe('#f97316')
+
+    // Confirm color dot is visible
+    const colorDot = selectedRow.locator('[data-activity-thread-color-dot="true"]')
+    await expect(colorDot).toBeVisible()
+
+    // 4. Close Tab
+    await selectedRow.click({ button: 'right' })
+    await orcaPage.getByRole('menuitem', { name: 'Close' }).click()
+    await expect
+      .poll(async () => {
+        return orcaPage.evaluate(
+          ({ wId, tId }) => {
+            return window.__store.getState().tabsByWorktree[wId]?.some((t) => t.id === tId) ?? false
+          },
+          { wId: worktreeId, tId: tabId }
+        )
+      })
+      .toBe(false)
+  })
 })


### PR DESCRIPTION
*(Note: This PR is based on PR #6343 and includes its changes. Once #6343 is merged, this diff will show only the status move changes.)*

## Summary

Adds workspace status management to the Activity agent row right-click context menu. Right-clicking an agent row now includes a "Move to Status" submenu that lists all configured board columns (e.g. Done, In progress, In review, Todo) with their custom icons, allowing the user to transition the backing workspace direct from the Agents page.

## Screenshots

- Move to Status submenu:
  <img src="https://github.com/user-attachments/assets/52b9dd97-c66f-4479-969a-770a2e27b23c" width="400" alt="Move to Status Submenu" />

## Testing

- [x] `pnpm lint` — passed.
- [x] `pnpm typecheck` — passed.
- [x] `pnpm test` — passed.
- [x] `pnpm build` — passed.
- [x] Component unit tests for the submenu items and action routing added to `ActivityThreadRowContextMenu.test.tsx` (10/10 passed).
- [x] E2E integration verified in `activity-agent-pane-isolation.spec.ts` under headless Electron (5/5 passed).

## AI Review Report

Reviewed the submenu structure, transition guards, and icon rendering. Checked that workspace status moves are skipped if the workspace is already in the target status or is not present in the workspace mapping (e.g., floating/unbound rows).
Cross-platform: UI component matches existing design system and works across macOS, Windows, and Linux. No custom shell command execution or native platform APIs.

## Security Audit

Status changes validate that the target status is a valid option and update the metadata via the standard store actions. No file reads/writes, command execution, or network calls are initiated directly by the context menu.

## Notes

- X handle: @wolfie_

