### PR TITLE
fix(terminal): apply split-cursor-burst protection to remote-runtime PTYs

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -21,6 +21,7 @@ import {
 } from '@/lib/windows-terminal-capabilities'
 import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
 import { shouldProtectSplitCursorBursts } from './split-cursor-burst-protection'
+import { computeSplitCursorBurstFlags } from './split-cursor-burst-flags'
 import type { PtyConnectionDeps } from './pty-connection-types'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { getFitOverrideForPty, bindPanePtyId } from '@/lib/pane-manager/mobile-fit-overrides'
@@ -136,8 +137,6 @@ const HIDDEN_OUTPUT_RESTORE_PENDING_CHARS = 512 * 1024
 const HIDDEN_OUTPUT_RESTORE_DEFERRED_RETRY_MS = 50
 const HIDDEN_OUTPUT_RESTORE_DEFERRED_RETRY_MAX = 3
 const TERMINAL_RENDERER_RISK_SCAN_TAIL_CHARS = 256
-const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
-const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
 const REATTACH_IDLE_AGENT_CURSOR_RESET_DELAY_MS = 250
 const FOREGROUND_THROUGHPUT_IMMEDIATE_CHARS = 2048
 const FOREGROUND_INTERACTIVE_REDRAW_CHARS = 128 * 1024
@@ -748,61 +747,6 @@ function shouldWritePtyOutputForeground(isPaneVisible: boolean): boolean {
   // backgrounded. Treat hidden documents like background tabs so Chromium
   // timer throttling cannot pin terminal writes on the renderer foreground path.
   return document.visibilityState === 'visible'
-}
-
-function containsSynchronizedOutputStart(data: string): boolean {
-  return data.includes('\x1b[?2026h')
-}
-
-function containsSynchronizedOutputEnd(data: string): boolean {
-  return data.includes('\x1b[?2026l')
-}
-
-function shouldSynchronizedOutputRemainActive(data: string, wasActive: boolean): boolean {
-  const lastStartIndex = data.lastIndexOf('\x1b[?2026h')
-  const lastEndIndex = data.lastIndexOf('\x1b[?2026l')
-  if (lastStartIndex === -1 && lastEndIndex === -1) {
-    return wasActive
-  }
-  return lastStartIndex > lastEndIndex
-}
-
-function containsCursorPositionSequence(data: string): boolean {
-  let offset = data.indexOf('\x1b[')
-  while (offset !== -1) {
-    let index = offset + 2
-    while (index < data.length) {
-      const char = data[index]
-      if (char === 'G' || char === 'H' || char === 'f') {
-        return true
-      }
-      if ((char < '0' || char > '9') && char !== ';') {
-        break
-      }
-      index += 1
-    }
-    offset = data.indexOf('\x1b[', offset + 2)
-  }
-  return false
-}
-
-function containsCursorRestore(data: string): boolean {
-  const hideIndex = data.indexOf(CURSOR_HIDE_SEQUENCE)
-  const showIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE)
-  return hideIndex !== -1 && showIndex > hideIndex && containsCursorPositionSequence(data)
-}
-
-// Why: TUIs like claude/vim/htop hide the cursor with a bare `?25l` and a split
-// transport can end a chunk on the unmatched hide, painting a cursor-hidden gap
-// until the later `?25h`. Known limitation: a chunk that splits inside the 6-byte
-// `?25l` itself is not caught (xterm reassembles for display; rare write-ordering).
-function endsWithDanglingCursorHide(data: string): boolean {
-  const hideIndex = data.lastIndexOf(CURSOR_HIDE_SEQUENCE)
-  if (hideIndex === -1) {
-    return false
-  }
-  const showIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE)
-  return hideIndex > showIndex
 }
 
 export function connectPanePty(
@@ -2776,37 +2720,19 @@ export function connectPanePty(
         canUseHiddenOutputSnapshot(transport.getPtyId()) &&
         shouldSnapshotHiddenCodexOutput &&
         (opts?.hiddenStartupRendererQuery === true || containsHiddenStartupRendererQuery(data))
-      const synchronizedOutputStarted =
-        protectSplitCursorBursts && foreground && containsSynchronizedOutputStart(data)
-      const synchronizedOutputEnded =
-        protectSplitCursorBursts && foreground && containsSynchronizedOutputEnd(data)
-      const synchronizedForegroundOutput =
-        protectSplitCursorBursts &&
-        foreground &&
-        (synchronizedForegroundOutputActive || synchronizedOutputStarted || synchronizedOutputEnded)
-      const nextSynchronizedForegroundOutputActive =
-        protectSplitCursorBursts &&
-        foreground &&
-        shouldSynchronizedOutputRemainActive(data, synchronizedForegroundOutputActive)
-      // Why: xterm's DOM renderer draws the cursor as row content, so a
-      // cursor-only restore needs row invalidation even outside DEC 2026 — on
-      // both native-Windows ConPTY and remote-runtime split transports.
-      const cursorRestoreNeedsRowInvalidation =
-        protectSplitCursorBursts && foreground && containsCursorRestore(data)
+      const {
+        synchronizedForegroundOutput,
+        cursorRestoreNeedsRowInvalidation,
+        synchronizedOutputEnded,
+        bareCursorHideShow,
+        bareCursorHideEnding,
+        nextSynchronizedForegroundOutputActive
+      } = computeSplitCursorBurstFlags(data, {
+        protectSplitCursorBursts,
+        foreground,
+        state: { synchronizedForegroundOutputActive, bareCursorHideForegroundActive }
+      })
       synchronizedForegroundOutputActive = nextSynchronizedForegroundOutputActive
-      // Why: hold a foreground chunk that ends on an unmatched bare `?25l`;
-      // release once the matching `?25h` arrives. Skipped while the DEC-2026 hold
-      // is already engaged so the two paths don't contend.
-      const bareCursorSplitProtection = protectSplitCursorBursts && foreground
-      const bareCursorHideEnding =
-        bareCursorSplitProtection &&
-        !synchronizedForegroundOutput &&
-        endsWithDanglingCursorHide(data)
-      const bareCursorHideShow =
-        bareCursorSplitProtection &&
-        bareCursorHideForegroundActive &&
-        !bareCursorHideEnding &&
-        data.includes(CURSOR_SHOW_SEQUENCE)
       bareCursorHideForegroundActive = bareCursorHideEnding
       if (hiddenMode2031ScanTail) {
         respondToSkippedMode2031Subscribe(data)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -20,6 +20,7 @@ import {
   hasCachedWindowsTerminalCapabilities
 } from '@/lib/windows-terminal-capabilities'
 import { shouldSeedCacheTimerOnInitialTitle } from './cache-timer-seeding'
+import { shouldProtectSplitCursorBursts } from './split-cursor-burst-protection'
 import type { PtyConnectionDeps } from './pty-connection-types'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { getFitOverrideForPty, bindPanePtyId } from '@/lib/pane-manager/mobile-fit-overrides'
@@ -791,6 +792,19 @@ function containsCursorRestore(data: string): boolean {
   return hideIndex !== -1 && showIndex > hideIndex && containsCursorPositionSequence(data)
 }
 
+// Why: TUIs like claude/vim/htop hide the cursor with a bare `?25l` and a split
+// transport can end a chunk on the unmatched hide, painting a cursor-hidden gap
+// until the later `?25h`. Known limitation: a chunk that splits inside the 6-byte
+// `?25l` itself is not caught (xterm reassembles for display; rare write-ordering).
+function endsWithDanglingCursorHide(data: string): boolean {
+  const hideIndex = data.lastIndexOf(CURSOR_HIDE_SEQUENCE)
+  if (hideIndex === -1) {
+    return false
+  }
+  const showIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE)
+  return hideIndex > showIndex
+}
+
 export function connectPanePty(
   pane: ManagedPane,
   manager: PaneManager,
@@ -817,6 +831,9 @@ export function connectPanePty(
   let reattachIdleAgentCursorResetTimer: ReturnType<typeof setTimeout> | null = null
   let synchronizedForegroundOutputActive = false
   let suppressSnapshotReplayPtyResize = false
+  // Why: true once a foreground chunk ended on an unmatched bare `?25l`, so the
+  // next chunk holds (or releases on its `?25h`) the cursor.
+  let bareCursorHideForegroundActive = false
   // Why: idle callbacks are registered before the deferred PTY output plumbing
   // exists. Start with the shared scheduler, then switch to the PTY writer
   // below so hidden-tab resets keep backlog-recovery callbacks and byte order.
@@ -1760,7 +1777,6 @@ export function connectPanePty(
     executionHostId
   })
   const shouldApplyNativeWindowsRewriteRefresh = isNativeWindowsConpty
-  const shouldProtectNativeWindowsSynchronizedOutput = isNativeWindowsConpty
 
   const restoredPtyIdForTransport =
     deps.restoredLeafId && deps.restoredPtyIdByLeafId
@@ -1772,6 +1788,12 @@ export function connectPanePty(
       : null) ?? (tab?.ptyId ? getRemoteRuntimePtyEnvironmentId(tab.ptyId) : null)
   const runtimeEnvironmentId =
     remoteRuntimeOwnerForTransport ?? getRuntimeEnvironmentIdForWorktree(state, deps.worktreeId)
+  // Why: defined after runtimeEnvironmentId so the remote signal is in scope.
+  // Genuinely Windows-only behavior stays keyed to isNativeWindowsConpty.
+  const protectSplitCursorBursts = shouldProtectSplitCursorBursts({
+    isNativeWindowsConpty,
+    runtimeEnvironmentId
+  })
   const localWindowsTerminalCapabilities = hasCachedWindowsTerminalCapabilities()
     ? getCachedWindowsTerminalCapabilities()
     : null
@@ -2755,26 +2777,37 @@ export function connectPanePty(
         shouldSnapshotHiddenCodexOutput &&
         (opts?.hiddenStartupRendererQuery === true || containsHiddenStartupRendererQuery(data))
       const synchronizedOutputStarted =
-        shouldProtectNativeWindowsSynchronizedOutput &&
-        foreground &&
-        containsSynchronizedOutputStart(data)
+        protectSplitCursorBursts && foreground && containsSynchronizedOutputStart(data)
       const synchronizedOutputEnded =
-        shouldProtectNativeWindowsSynchronizedOutput &&
-        foreground &&
-        containsSynchronizedOutputEnd(data)
+        protectSplitCursorBursts && foreground && containsSynchronizedOutputEnd(data)
       const synchronizedForegroundOutput =
-        shouldProtectNativeWindowsSynchronizedOutput &&
+        protectSplitCursorBursts &&
         foreground &&
         (synchronizedForegroundOutputActive || synchronizedOutputStarted || synchronizedOutputEnded)
       const nextSynchronizedForegroundOutputActive =
-        shouldProtectNativeWindowsSynchronizedOutput &&
+        protectSplitCursorBursts &&
         foreground &&
         shouldSynchronizedOutputRemainActive(data, synchronizedForegroundOutputActive)
-      // Why: xterm's DOM renderer draws the cursor as row content; Windows
-      // cursor-only restores need row invalidation even outside DEC 2026.
-      const nativeWindowsCursorRestore =
-        shouldProtectNativeWindowsSynchronizedOutput && foreground && containsCursorRestore(data)
+      // Why: xterm's DOM renderer draws the cursor as row content, so a
+      // cursor-only restore needs row invalidation even outside DEC 2026 — on
+      // both native-Windows ConPTY and remote-runtime split transports.
+      const cursorRestoreNeedsRowInvalidation =
+        protectSplitCursorBursts && foreground && containsCursorRestore(data)
       synchronizedForegroundOutputActive = nextSynchronizedForegroundOutputActive
+      // Why: hold a foreground chunk that ends on an unmatched bare `?25l`;
+      // release once the matching `?25h` arrives. Skipped while the DEC-2026 hold
+      // is already engaged so the two paths don't contend.
+      const bareCursorSplitProtection = protectSplitCursorBursts && foreground
+      const bareCursorHideEnding =
+        bareCursorSplitProtection &&
+        !synchronizedForegroundOutput &&
+        endsWithDanglingCursorHide(data)
+      const bareCursorHideShow =
+        bareCursorSplitProtection &&
+        bareCursorHideForegroundActive &&
+        !bareCursorHideEnding &&
+        data.includes(CURSOR_SHOW_SEQUENCE)
+      bareCursorHideForegroundActive = bareCursorHideEnding
       if (hiddenMode2031ScanTail) {
         respondToSkippedMode2031Subscribe(data)
       }
@@ -2787,12 +2820,16 @@ export function connectPanePty(
         forceForegroundRefresh:
           (foreground || parseHiddenStartupOutput) &&
           (synchronizedForegroundOutput ||
-            nativeWindowsCursorRestore ||
+            cursorRestoreNeedsRowInvalidation ||
             shouldForceForegroundRenderRefresh(data)),
-        followupForegroundRefresh: nativeWindowsCursorRestore,
-        stripTransientCursorShows: shouldProtectNativeWindowsSynchronizedOutput && foreground,
-        coalesceForeground: synchronizedForegroundOutput && synchronizedOutputEnded,
-        holdForeground: synchronizedForegroundOutput && nextSynchronizedForegroundOutputActive
+        followupForegroundRefresh: cursorRestoreNeedsRowInvalidation,
+        stripTransientCursorShows: protectSplitCursorBursts && foreground,
+        coalesceForeground:
+          (synchronizedForegroundOutput && synchronizedOutputEnded) || bareCursorHideShow,
+        holdForeground:
+          (synchronizedForegroundOutput && nextSynchronizedForegroundOutputActive) ||
+          bareCursorHideEnding,
+        holdForegroundUntilCursorShow: bareCursorHideEnding
       })
     }
 

--- a/src/renderer/src/components/terminal-pane/split-cursor-burst-flags.test.ts
+++ b/src/renderer/src/components/terminal-pane/split-cursor-burst-flags.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the pure split-cursor-burst flag decision. This is the SAME
+ * logic `writePtyOutputToXterm` runs in production (pty-connection.ts), extracted
+ * so a future edit that re-narrows protection to native-Windows-only is caught
+ * here instead of silently passing CI.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  computeSplitCursorBurstFlags,
+  type SplitCursorBurstState
+} from './split-cursor-burst-flags'
+
+const CURSOR_HIDE = '\x1b[?25l'
+const CURSOR_SHOW = '\x1b[?25h'
+
+function freshState(): SplitCursorBurstState {
+  return { synchronizedForegroundOutputActive: false, bareCursorHideForegroundActive: false }
+}
+
+describe('computeSplitCursorBurstFlags', () => {
+  it('engages the hold when a chunk ends on a dangling bare ?25l', () => {
+    const flags = computeSplitCursorBurstFlags(`${CURSOR_HIDE}REDRAW`, {
+      protectSplitCursorBursts: true,
+      foreground: true,
+      state: freshState()
+    })
+    expect(flags.bareCursorHideEnding).toBe(true)
+    expect(flags.bareCursorHideShow).toBe(false)
+  })
+
+  it('releases (coalesces) when the matching ?25h arrives after a held hide', () => {
+    const flags = computeSplitCursorBurstFlags(CURSOR_SHOW, {
+      protectSplitCursorBursts: true,
+      foreground: true,
+      // Prior chunk ended on a dangling hide, so the hold is active.
+      state: { synchronizedForegroundOutputActive: false, bareCursorHideForegroundActive: true }
+    })
+    expect(flags.bareCursorHideShow).toBe(true)
+    expect(flags.bareCursorHideEnding).toBe(false)
+  })
+
+  it('applies no protection when the transport opts out (local non-Windows)', () => {
+    const flags = computeSplitCursorBurstFlags(`${CURSOR_HIDE}REDRAW`, {
+      protectSplitCursorBursts: false,
+      foreground: true,
+      state: freshState()
+    })
+    expect(flags.bareCursorHideEnding).toBe(false)
+    expect(flags.bareCursorHideShow).toBe(false)
+    expect(flags.synchronizedForegroundOutput).toBe(false)
+    expect(flags.cursorRestoreNeedsRowInvalidation).toBe(false)
+  })
+
+  it('applies no protection on a background (non-foreground) chunk', () => {
+    const flags = computeSplitCursorBurstFlags(`${CURSOR_HIDE}REDRAW`, {
+      protectSplitCursorBursts: true,
+      foreground: false,
+      state: freshState()
+    })
+    expect(flags.bareCursorHideEnding).toBe(false)
+  })
+
+  it('gate-narrowing regression guard: protection stays ON for a protected remote-runtime chunk', () => {
+    // A future edit that re-narrows the gate to native-Windows-only would flip
+    // this off for a remote-runtime PTY (which sets protectSplitCursorBursts via
+    // shouldProtectSplitCursorBursts) — this asserts the bare-cursor hold engages.
+    const flags = computeSplitCursorBurstFlags(`${CURSOR_HIDE}REDRAW`, {
+      protectSplitCursorBursts: true,
+      foreground: true,
+      state: freshState()
+    })
+    expect(flags.bareCursorHideEnding).toBe(true)
+  })
+
+  it('does not engage the bare-cursor hold while a DEC-2026 synchronized hold is active', () => {
+    // Why: the two protection paths must not contend — the bare path is gated on
+    // !synchronizedForegroundOutput.
+    const flags = computeSplitCursorBurstFlags(`\x1b[?2026h${CURSOR_HIDE}`, {
+      protectSplitCursorBursts: true,
+      foreground: true,
+      state: freshState()
+    })
+    expect(flags.synchronizedForegroundOutput).toBe(true)
+    expect(flags.bareCursorHideEnding).toBe(false)
+  })
+
+  it('flags a cursor restore (hide -> reposition -> show) for row invalidation', () => {
+    const flags = computeSplitCursorBurstFlags(`${CURSOR_HIDE}\x1b[5;1HX${CURSOR_SHOW}`, {
+      protectSplitCursorBursts: true,
+      foreground: true,
+      state: freshState()
+    })
+    expect(flags.cursorRestoreNeedsRowInvalidation).toBe(true)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/split-cursor-burst-flags.ts
+++ b/src/renderer/src/components/terminal-pane/split-cursor-burst-flags.ts
@@ -1,0 +1,146 @@
+// Why: TUIs like claude/vim/htop hide the cursor with bare `?25l`/`?25h` and a
+// split transport (native-Windows ConPTY, remote-runtime) can end a chunk on the
+// unmatched hide, painting a cursor-hidden gap until the later `?25h`. This pure
+// module decides the foreground hold / coalesce flags that close that gap; the
+// caller owns the mutable session state and threads it through each call.
+
+const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
+const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
+
+function containsSynchronizedOutputStart(data: string): boolean {
+  return data.includes('\x1b[?2026h')
+}
+
+function containsSynchronizedOutputEnd(data: string): boolean {
+  return data.includes('\x1b[?2026l')
+}
+
+function shouldSynchronizedOutputRemainActive(data: string, wasActive: boolean): boolean {
+  const lastStartIndex = data.lastIndexOf('\x1b[?2026h')
+  const lastEndIndex = data.lastIndexOf('\x1b[?2026l')
+  if (lastStartIndex === -1 && lastEndIndex === -1) {
+    return wasActive
+  }
+  return lastStartIndex > lastEndIndex
+}
+
+function containsCursorPositionSequence(data: string): boolean {
+  let offset = data.indexOf('\x1b[')
+  while (offset !== -1) {
+    let index = offset + 2
+    while (index < data.length) {
+      const char = data[index]
+      if (char === 'G' || char === 'H' || char === 'f') {
+        return true
+      }
+      if ((char < '0' || char > '9') && char !== ';') {
+        break
+      }
+      index += 1
+    }
+    offset = data.indexOf('\x1b[', offset + 2)
+  }
+  return false
+}
+
+function containsCursorRestore(data: string): boolean {
+  const hideIndex = data.indexOf(CURSOR_HIDE_SEQUENCE)
+  const showIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE)
+  return hideIndex !== -1 && showIndex > hideIndex && containsCursorPositionSequence(data)
+}
+
+// Why: TUIs like claude/vim/htop hide the cursor with a bare `?25l` and a split
+// transport can end a chunk on the unmatched hide, painting a cursor-hidden gap
+// until the later `?25h`. Known limitation: a chunk that splits inside the 6-byte
+// `?25l` itself is not caught (xterm reassembles for display; rare write-ordering).
+function endsWithDanglingCursorHide(data: string): boolean {
+  const hideIndex = data.lastIndexOf(CURSOR_HIDE_SEQUENCE)
+  if (hideIndex === -1) {
+    return false
+  }
+  const showIndex = data.lastIndexOf(CURSOR_SHOW_SEQUENCE)
+  return hideIndex > showIndex
+}
+
+/**
+ * Mutable session state the flag decision reads and advances across chunks. The
+ * caller owns these fields; this module never mutates them — it returns the next
+ * values in {@link SplitCursorBurstFlags}.
+ */
+export type SplitCursorBurstState = {
+  synchronizedForegroundOutputActive: boolean
+  bareCursorHideForegroundActive: boolean
+}
+
+export type SplitCursorBurstContext = {
+  /** Whether this transport opts into split-cursor-burst protection at all. */
+  protectSplitCursorBursts: boolean
+  /** Whether this chunk is being written to the foreground (visible) pane. */
+  foreground: boolean
+  /** Current session state (not mutated; advanced via the returned next-state). */
+  state: SplitCursorBurstState
+}
+
+export type SplitCursorBurstFlags = {
+  synchronizedForegroundOutput: boolean
+  cursorRestoreNeedsRowInvalidation: boolean
+  synchronizedOutputEnded: boolean
+  bareCursorHideShow: boolean
+  bareCursorHideEnding: boolean
+  /** Next value for {@link SplitCursorBurstState.synchronizedForegroundOutputActive}. */
+  nextSynchronizedForegroundOutputActive: boolean
+}
+
+/**
+ * Pure decision for the split-cursor-burst foreground hold/coalesce flags. Moved
+ * verbatim out of `writePtyOutputToXterm` so the same logic the renderer runs is
+ * the logic the tests exercise. The caller applies the returned flags to the
+ * write and persists the next-state fields back onto its own session state.
+ */
+export function computeSplitCursorBurstFlags(
+  data: string,
+  ctx: SplitCursorBurstContext
+): SplitCursorBurstFlags {
+  const { protectSplitCursorBursts, foreground, state } = ctx
+  const synchronizedOutputStarted =
+    protectSplitCursorBursts && foreground && containsSynchronizedOutputStart(data)
+  const synchronizedOutputEnded =
+    protectSplitCursorBursts && foreground && containsSynchronizedOutputEnd(data)
+  const synchronizedForegroundOutput =
+    protectSplitCursorBursts &&
+    foreground &&
+    (state.synchronizedForegroundOutputActive ||
+      synchronizedOutputStarted ||
+      synchronizedOutputEnded)
+  const nextSynchronizedForegroundOutputActive =
+    protectSplitCursorBursts &&
+    foreground &&
+    shouldSynchronizedOutputRemainActive(data, state.synchronizedForegroundOutputActive)
+  // Why: xterm's DOM renderer draws the cursor as row content, so a
+  // cursor-only restore needs row invalidation even outside DEC 2026 — on
+  // both native-Windows ConPTY and remote-runtime split transports.
+  const cursorRestoreNeedsRowInvalidation =
+    protectSplitCursorBursts && foreground && containsCursorRestore(data)
+  // Why: hold a foreground chunk that ends on an unmatched bare `?25l`;
+  // release once the matching `?25h` arrives. Skipped while the DEC-2026 hold
+  // is already engaged so the two paths don't contend.
+  const bareCursorSplitProtection = protectSplitCursorBursts && foreground
+  const bareCursorHideEnding =
+    bareCursorSplitProtection &&
+    !synchronizedForegroundOutput &&
+    endsWithDanglingCursorHide(data)
+  const bareCursorHideShow =
+    bareCursorSplitProtection &&
+    state.bareCursorHideForegroundActive &&
+    !bareCursorHideEnding &&
+    data.includes(CURSOR_SHOW_SEQUENCE)
+
+  return {
+    synchronizedForegroundOutput,
+    cursorRestoreNeedsRowInvalidation,
+    synchronizedOutputEnded,
+    bareCursorHideShow,
+    bareCursorHideEnding,
+    nextSynchronizedForegroundOutputActive
+  }
+}

--- a/src/renderer/src/components/terminal-pane/split-cursor-burst-protection.test.ts
+++ b/src/renderer/src/components/terminal-pane/split-cursor-burst-protection.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { shouldProtectSplitCursorBursts } from './split-cursor-burst-protection'
+
+describe('shouldProtectSplitCursorBursts gate', () => {
+  it('fires for a remote-runtime PTY (runtimeEnvironmentId set)', () => {
+    expect(
+      shouldProtectSplitCursorBursts({
+        isNativeWindowsConpty: false,
+        runtimeEnvironmentId: 'env-1'
+      })
+    ).toBe(true)
+  })
+
+  it('fires for a native-Windows ConPTY even with no remote runtime', () => {
+    expect(
+      shouldProtectSplitCursorBursts({
+        isNativeWindowsConpty: true,
+        runtimeEnvironmentId: null
+      })
+    ).toBe(true)
+  })
+
+  it('stays off for a local non-Windows PTY (no remote runtime, not ConPTY)', () => {
+    expect(
+      shouldProtectSplitCursorBursts({
+        isNativeWindowsConpty: false,
+        runtimeEnvironmentId: null
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/split-cursor-burst-protection.ts
+++ b/src/renderer/src/components/terminal-pane/split-cursor-burst-protection.ts
@@ -1,0 +1,10 @@
+// Why: native-Windows ConPTY and remote-runtime (serve) PTYs both split a
+// `?25l`...`?25h` cursor burst across separate output frames, so cursor
+// protection must cover both transports. Local non-Windows PTYs deliver each
+// burst in one frame and need no protection.
+export function shouldProtectSplitCursorBursts(args: {
+  isNativeWindowsConpty: boolean
+  runtimeEnvironmentId: string | null
+}): boolean {
+  return args.isNativeWindowsConpty || args.runtimeEnvironmentId !== null
+}

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -442,6 +442,145 @@ describe('pane terminal output scheduler', () => {
     ])
   })
 
+  it('holds a bare ?25l split across frames so a remote terminal never paints the hidden cursor', async () => {
+    // Bare-cursor-split regression: claude/vim/htop emit bare `?25l`/`?25h` with NO
+    // DEC-2026 wrapper (byte capture 2026-06-20). When a remote-runtime chunk
+    // ends on an unmatched `?25l`, pty-connection sets holdForeground so the
+    // cursor-hidden frame is not painted alone; the matching `?25h` releases it
+    // via coalesceForeground. This proves the hidden frame never paints first.
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    // Frame 1: repaint that ends with the cursor hidden (dangling `?25l`).
+    writeTerminalOutput(terminal, '\x1b[?25h\x1b[?25l\x1b[5;1Hrepaint', {
+      foreground: true,
+      latencySensitive: true,
+      holdForeground: true
+    })
+
+    // The hidden-cursor frame must not paint on its own.
+    vi.advanceTimersByTime(0)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    // Frame 2: the matching `?25h` arrives; release the hold.
+    writeTerminalOutput(terminal, '\x1b[?25h', {
+      foreground: true,
+      latencySensitive: true,
+      coalesceForeground: true
+    })
+
+    vi.advanceTimersByTime(16)
+    vi.runOnlyPendingTimers()
+
+    expect(terminal.write).toHaveBeenCalledTimes(1)
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[?25h\x1b[?25l\x1b[5;1Hrepaint\x1b[?25h',
+      expect.any(Function)
+    )
+  })
+
+  it('preserves the real cursor show when a held bare ?25l split is stripped (remote prod path)', async () => {
+    // Remote-runtime terminals also pass stripTransientCursorShows: true. The
+    // leading transient `?25h` (immediately cancelled by `?25l`) is stripped,
+    // but the final `?25h` that actually restores the cursor must survive so the
+    // joined frame ends with the cursor visible, never hidden.
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[?25h\x1b[?25l\x1b[5;1Hrepaint', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true,
+      holdForeground: true
+    })
+    writeTerminalOutput(terminal, '\x1b[?25h', {
+      foreground: true,
+      latencySensitive: true,
+      stripTransientCursorShows: true,
+      coalesceForeground: true
+    })
+
+    vi.advanceTimersByTime(16)
+    vi.runOnlyPendingTimers()
+
+    expect(terminal.write).toHaveBeenCalledTimes(1)
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[?25l\x1b[5;1Hrepaint\x1b[?25h',
+      expect.any(Function)
+    )
+  })
+
+  it('releases a held bare ?25l on the safety timer so a hide-only TUI cannot stall', async () => {
+    // The matching `?25h` may never come (cursor legitimately stays hidden); the
+    // bounded hold-safety timer must still paint so input is never stranded.
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[?25l\x1b[5;1Hredraw', {
+      foreground: true,
+      latencySensitive: true,
+      holdForeground: true
+    })
+
+    vi.advanceTimersByTime(0)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    // Latency-sensitive hold-safety fallback (32ms) fires with no `?25h`.
+    vi.advanceTimersByTime(32)
+    vi.runOnlyPendingTimers()
+
+    expect(terminal.write).toHaveBeenCalledWith('\x1b[?25l\x1b[5;1Hredraw', expect.any(Function))
+  })
+
+  it('extends a held bare ?25l across an intermediate cursor-free redraw frame (3-frame split)', async () => {
+    // A >=2-frame gap re-opens the bug: frame 1 ends on a dangling `?25l`, frame
+    // 2 is a pure redraw with NO cursor codes, frame 3 carries the matching
+    // `?25h`. holdForegroundUntilCursorShow must keep the hold across frame 2 so
+    // the held data never drains cursor-hidden before the show arrives.
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal, '\x1b[?25l\x1b[5;1Hrepaint', {
+      foreground: true,
+      latencySensitive: true,
+      holdForeground: true,
+      holdForegroundUntilCursorShow: true
+    })
+
+    vi.advanceTimersByTime(0)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    // Frame 2: an intermediate redraw with neither `?25l` nor `?25h`. Pre-fix
+    // this released the hold and drained cursor-hidden; it must now extend it.
+    writeTerminalOutput(terminal, '\x1b[6;1Hmore output', {
+      foreground: true,
+      latencySensitive: true
+    })
+
+    vi.advanceTimersByTime(0)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    // Frame 3: the matching `?25h` finally arrives and releases the hold.
+    writeTerminalOutput(terminal, '\x1b[?25h', {
+      foreground: true,
+      latencySensitive: true,
+      coalesceForeground: true
+    })
+
+    vi.advanceTimersByTime(16)
+    vi.runOnlyPendingTimers()
+
+    expect(terminal.write).toHaveBeenCalledTimes(1)
+    expect(terminal.write).toHaveBeenCalledWith(
+      '\x1b[?25l\x1b[5;1Hrepaint\x1b[6;1Hmore output\x1b[?25h',
+      expect.any(Function)
+    )
+  })
+
   it('keeps transient cursor shows unless the caller opts into stripping', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -27,6 +27,7 @@ type WriteTerminalOutputOptions = {
   stripTransientCursorShows?: boolean
   coalesceForeground?: boolean
   holdForeground?: boolean
+  holdForegroundUntilCursorShow?: boolean
 }
 
 type QueueChunk = {
@@ -55,6 +56,7 @@ type QueueEntry = {
   backgroundBacklogDropped: boolean
   highPriority: boolean
   foregroundHold: boolean
+  bareCursorHideHeldUntilShow: boolean
   foregroundHoldSafetyDelayMs: number
   foregroundCoalesce: boolean
   foregroundCoalesceDelayMs: number
@@ -246,6 +248,7 @@ function createQueueEntry(
     backgroundBacklogDropped: false,
     highPriority: true,
     foregroundHold: false,
+    bareCursorHideHeldUntilShow: false,
     foregroundHoldSafetyDelayMs: FOREGROUND_HOLD_SAFETY_DELAY_MS,
     foregroundCoalesce: false,
     foregroundCoalesceDelayMs: FOREGROUND_COALESCE_DELAY_MS,
@@ -277,6 +280,7 @@ function scheduleForegroundHoldSafety(entry: QueueEntry): void {
   entry.foregroundHoldSafetyTimer = setTimeout(() => {
     entry.foregroundHoldSafetyTimer = null
     entry.foregroundHold = false
+    entry.bareCursorHideHeldUntilShow = false
     clearForegroundCoalesce(entry)
     if (queuedByTerminal.has(entry.terminal)) {
       scheduleDrain(0)
@@ -569,6 +573,7 @@ function replaceBacklogWithWarning(entry: QueueEntry): void {
   entry.backgroundBacklogDropped = true
   entry.highPriority = true
   entry.foregroundHold = false
+  entry.bareCursorHideHeldUntilShow = false
   if (debugEnabled && shouldNotify) {
     debugState.droppedBacklogCount++
   }
@@ -712,6 +717,7 @@ function drainQueuedOutput(): void {
       queuedByTerminal.set(entry.terminal, entry)
     } else {
       entry.highPriority = false
+      entry.bareCursorHideHeldUntilShow = false
       clearForegroundCoalesce(entry)
       clearForegroundHoldSafety(entry)
     }
@@ -771,12 +777,19 @@ export function writeTerminalOutput(
           queued.foregroundHoldSafetyDelayMs = FOREGROUND_HOLD_SAFETY_DELAY_MS
         }
         queued.foregroundHold = true
+        // Why: a bare `?25l` can be split from its `?25h` by intermediate redraw
+        // frames; persist the intent so those cursor-free frames extend the hold
+        // instead of draining the entry cursor-hidden.
+        if (options.holdForegroundUntilCursorShow === true) {
+          queued.bareCursorHideHeldUntilShow = true
+        }
         clearForegroundCoalesce(queued)
         scheduleForegroundHoldSafety(queued)
         return
       }
       if (options.coalesceForeground || queued.foregroundCoalesce) {
         queued.foregroundHold = false
+        queued.bareCursorHideHeldUntilShow = false
         clearForegroundHoldSafety(queued)
         const shouldShortenCoalesceForLatencySensitiveForeground = options.latencySensitive === true
         if (shouldShortenCoalesceForLatencySensitiveForeground) {
@@ -801,6 +814,15 @@ export function writeTerminalOutput(
         scheduleForegroundCoalesceRelease(queued, {
           rescheduleEarlier: shouldShortenCoalesceForLatencySensitiveForeground
         })
+        return
+      }
+      if (queued.bareCursorHideHeldUntilShow) {
+        // Why: a cursor-free redraw between the dangling `?25l` and its `?25h`
+        // must keep the hold so the entry never drains cursor-hidden; the matching
+        // `?25h` (coalesceForeground) or the safety timer releases it.
+        queued.foregroundHold = true
+        clearForegroundCoalesce(queued)
+        scheduleForegroundHoldSafety(queued)
         return
       }
       queued.foregroundHold = false
@@ -965,6 +987,7 @@ export function flushTerminalOutput(
     scheduleDrain(0)
   } else {
     entry.highPriority = false
+    entry.bareCursorHideHeldUntilShow = false
     clearForegroundCoalesce(entry)
     clearForegroundHoldSafety(entry)
   }

--- a/src/renderer/src/runtime/remote-runtime-cursor-burst.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-cursor-burst.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Mechanism-level repro for the remote-runtime invisible-cursor bug (v1.4.88).
+ *
+ * WHY this exists: in the remote serve topology a repainting TUI (claude/vim)
+ * hides the cursor with a bare `\e[?25l` and shows it again with `\e[?25h` a
+ * moment later. The serve output batcher coalesces on a 5ms timer, so under
+ * fast input the flush can land BETWEEN the hide and the show — emitting them in
+ * two separate binary frames. The client multiplexer forwards one frame at a
+ * time with no cross-frame buffering, so the renderer paints the gap with the
+ * cursor hidden. The native-Windows path already protects against this split;
+ * remote-runtime PTYs were never included in that gate.
+ *
+ * This test wires the REAL transport modules end-to-end and asserts the cursor
+ * is not left hidden after both frames are processed.
+ *
+ * --- REAL vs FAKED (RULE #1: no silent over-mocking) ---
+ * REAL:
+ *  - The serve output batcher `createTerminalOutputBatcher`, driven through the
+ *    REAL RPC path (`TERMINAL_METHODS` + `RpcDispatcher.dispatchStreaming` with
+ *    `terminalBinaryStream` capability), exactly as it runs in production. Fake
+ *    timers make the 5ms flush land between the hide and show, producing two
+ *    real binary `Output` frames.
+ *  - The real terminal-stream wire codec: `encodeTerminalStreamFrame` /
+ *    `encodeTerminalStreamText` on the serve side; `decodeTerminalStreamFrame` /
+ *    `decodeTerminalStreamText` on the client side.
+ *  - The real renderer write scheduler `writeTerminalOutput`
+ *    (pane-terminal-output-scheduler.ts) and its foreground hold / coalesce /
+ *    strip-transient-cursor-show state machine, against a faithful xterm sink
+ *    that records the exact byte stream written (same fake-terminal shape the
+ *    scheduler's own tests use).
+ * FAKED / REPLICATED (and why):
+ *  - The client multiplexer's Output-case forwarding. The real
+ *    `RemoteRuntimeTerminalMultiplexer` class is not exported and only receives
+ *    frames via `window.api.runtimeEnvironments.subscribe` (Electron preload),
+ *    so it is not headlessly constructible without deep Electron mocks. We
+ *    replicate its Output case verbatim (decode frame -> decode text -> call
+ *    onData once per frame, NO cross-frame buffering — multiplexer
+ *    handleBinary, lines 330-336) so the no-buffering behavior under test is the
+ *    real one.
+ *  - The gate flag-decision from `writePtyOutputToXterm` (pty-connection.ts,
+ *    lines ~2473-2511) is an un-exported closure inside `connectPanePty`, which
+ *    needs the full pane/manager/store graph to build. We replicate that exact
+ *    flag expression in `computeRemoteProtectionFlags`, parameterized by whether
+ *    the bare-`?25l` cross-frame hold is wired. The DEC-2026 branches are kept
+ *    identical to the source; the captured claude/vim/htop byte streams contain
+ *    ZERO DEC-2026 markers (only bare `?25l`/`?25h`), so the bare path is the one
+ *    that decides the bug — see CAPTURE-FINDINGS.md.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TerminalStreamOpcode,
+  decodeTerminalStreamFrame,
+  decodeTerminalStreamText
+} from '../../../shared/terminal-stream-protocol'
+import { RpcDispatcher } from '../../../main/runtime/rpc/dispatcher'
+import { TERMINAL_METHODS } from '../../../main/runtime/rpc/methods/terminal'
+import type { OrcaRuntimeService } from '../../../main/runtime/orca-runtime'
+import type { RpcRequest } from '../../../main/runtime/rpc/core'
+import type { RuntimeTerminalWait } from '../../../shared/runtime-types'
+
+// Why: the scheduler imports @/lib/e2e-config at module load; the alias is not
+// resolved in this test context, so stub it like the scheduler's own tests do.
+vi.mock('@/lib/e2e-config', () => ({
+  e2eConfig: { exposeStore: true }
+}))
+
+const CURSOR_HIDE = '\x1b[?25l'
+const CURSOR_SHOW = '\x1b[?25h'
+
+function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeService {
+  return {
+    getRuntimeId: () => 'test-runtime',
+    ...overrides
+  } as OrcaRuntimeService
+}
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+/**
+ * Drive the REAL serve batcher through the REAL RPC streaming path and collect
+ * the binary frames it emits. `emit` lets the caller push PTY output, then
+ * advance fake timers to control where the 5ms flush boundary falls.
+ */
+async function startServeBatcherStream(): Promise<{
+  emit: (data: string) => void
+  binaryFrames: Uint8Array<ArrayBufferLike>[]
+  flushTimers: () => Promise<void>
+  stop: () => Promise<void>
+}> {
+  const messages: string[] = []
+  const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+  const cleanups = new Map<string, () => void>()
+  const dataListenerRef: { current?: (data: string) => void } = {}
+  const runtime = stubRuntime({
+    resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+    readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+    serializeTerminalBuffer: vi.fn().mockResolvedValue({ data: 'snapshot', cols: 80, rows: 24 }),
+    getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+    getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+    getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+    subscribeToTerminalData: vi.fn((_: string, listener: (data: string) => void) => {
+      dataListenerRef.current = listener
+      return vi.fn()
+    }),
+    subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+    subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+    registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+      cleanups.set(id, cleanup)
+    }),
+    cleanupSubscription: vi.fn((id: string) => {
+      const cleanup = cleanups.get(id)
+      cleanups.delete(id)
+      cleanup?.()
+    }),
+    waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+    sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
+    updateMobileViewport: vi.fn().mockResolvedValue(false)
+  })
+  const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+  const dispatchPromise = dispatcher.dispatchStreaming(
+    makeRequest('terminal.subscribe', {
+      terminal: 'terminal-1',
+      client: { id: 'desktop-1', type: 'desktop' },
+      capabilities: { terminalBinaryStream: 1 }
+    }),
+    (msg) => messages.push(msg),
+    {
+      connectionId: 'conn-1',
+      sendBinary: (bytes) => binaryFrames.push(bytes)
+    }
+  )
+
+  await vi.waitFor(() =>
+    expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+  )
+  const emitData = dataListenerRef.current
+  if (!emitData) {
+    throw new Error('serve batcher data listener was never registered')
+  }
+
+  return {
+    emit: emitData,
+    binaryFrames,
+    flushTimers: () => vi.runOnlyPendingTimersAsync(),
+    stop: async () => {
+      runtime.cleanupSubscription?.('terminal-1:desktop-1')
+      await dispatchPromise
+    }
+  }
+}
+
+/**
+ * Replicates the client multiplexer Output case (handleBinary lines 330-336):
+ * decode each binary frame and deliver its text to onData ONCE per frame, with
+ * NO cross-frame buffering. This is the no-buffering behavior the bug depends on.
+ */
+function deliverFramesAsMultiplexerWould(
+  frames: Uint8Array<ArrayBufferLike>[],
+  onData: (data: string) => void
+): void {
+  for (const bytes of frames) {
+    const frame = decodeTerminalStreamFrame(bytes)
+    if (!frame || frame.opcode !== TerminalStreamOpcode.Output) {
+      continue
+    }
+    onData(decodeTerminalStreamText(frame.payload))
+  }
+}
+
+/**
+ * Replicates the protection flag-decision from pty-connection.ts
+ * `writePtyOutputToXterm` for a REMOTE-RUNTIME foreground chunk
+ * (`shouldProtectSplitCursorBursts === true`). It mirrors the real source's two
+ * protection paths:
+ *  - The DEC-2026 synchronized-output hold (unchanged from the native-Windows
+ *    path). The captured TUIs emit NO DEC-2026, so it stays inert here.
+ *  - The bare-cursor split protection — hold a chunk that ends on an unmatched
+ *    `\e[?25l` (`bareCursorHideEnding` -> holdForeground) and release it when the
+ *    matching `\e[?25h` arrives (`bareCursorHideShow` -> coalesceForeground).
+ * `bareCursorSplitFixWired` selects the repo state under test:
+ *  - false = pre-fix v1.4.88 (protection absent): a bare dangling hide never
+ *            holds -> frame A is shown cursor-hidden (the bug).
+ *  - true  = with the bare-cursor split fix wired: the hide holds until the show.
+ */
+function computeRemoteProtectionFlags(
+  data: string,
+  state: { synchronizedForegroundOutputActive: boolean; bareCursorHideForegroundActive: boolean },
+  bareCursorSplitFixWired: boolean
+): {
+  forceForegroundRefresh: boolean
+  followupForegroundRefresh: boolean
+  stripTransientCursorShows: boolean
+  coalesceForeground: boolean
+  holdForeground: boolean
+} {
+  // DEC-2026 synchronized output (unchanged from the source).
+  const synchronizedOutputStarted = data.includes('\x1b[?2026h')
+  const synchronizedOutputEnded = data.includes('\x1b[?2026l')
+  const synchronizedForegroundOutput =
+    state.synchronizedForegroundOutputActive || synchronizedOutputStarted || synchronizedOutputEnded
+  const lastStart = data.lastIndexOf('\x1b[?2026h')
+  const lastEnd = data.lastIndexOf('\x1b[?2026l')
+  const nextSynchronizedForegroundOutputActive =
+    lastStart === -1 && lastEnd === -1
+      ? state.synchronizedForegroundOutputActive
+      : lastStart > lastEnd
+
+  const hideIndex = data.indexOf(CURSOR_HIDE)
+  const lastShowIndex = data.lastIndexOf(CURSOR_SHOW)
+  const containsCursorRestore = hideIndex !== -1 && lastShowIndex > hideIndex
+
+  // Bare cursor split (mirrors pty-connection.ts bareCursorHide* flags).
+  const endsWithDanglingCursorHide = data.lastIndexOf(CURSOR_HIDE) > data.lastIndexOf(CURSOR_SHOW)
+  const bareCursorHideEnding =
+    bareCursorSplitFixWired && !synchronizedForegroundOutput && endsWithDanglingCursorHide
+  const bareCursorHideShow =
+    bareCursorSplitFixWired &&
+    state.bareCursorHideForegroundActive &&
+    !bareCursorHideEnding &&
+    data.includes(CURSOR_SHOW)
+
+  state.synchronizedForegroundOutputActive = nextSynchronizedForegroundOutputActive
+  state.bareCursorHideForegroundActive = bareCursorHideEnding
+
+  return {
+    forceForegroundRefresh: synchronizedForegroundOutput || containsCursorRestore,
+    followupForegroundRefresh: containsCursorRestore,
+    stripTransientCursorShows: true,
+    coalesceForeground:
+      (synchronizedForegroundOutput && synchronizedOutputEnded) || bareCursorHideShow,
+    holdForeground:
+      (synchronizedForegroundOutput && nextSynchronizedForegroundOutputActive) || bareCursorHideEnding
+  }
+}
+
+/**
+ * Faithful xterm sink. Tracks the exact byte stream written AND captures the
+ * cursor-visibility state AFTER EACH WRITE — every `terminal.write` is a chunk
+ * xterm parses and shows on the next frame, so the cursor state left by a write
+ * is a state the user can actually see. A write that leaves the cursor hidden,
+ * followed by a SEPARATE later write that restores it, is the visible flicker:
+ * the cursor vanished and only reappeared a frame later. (The scheduler's hold
+ * coalesces the two into one write, so the hidden state is never displayed.)
+ */
+function createFakeXterm(): {
+  written: string[]
+  cursorHiddenAfterEachWrite: boolean[]
+  buffer: { active: { cursorY: number; baseY: number; viewportY: number } }
+  rows: number
+  refresh: ReturnType<typeof vi.fn>
+  _core: { refresh: ReturnType<typeof vi.fn> }
+  write: (data: string, callback?: () => void) => void
+} {
+  const written: string[] = []
+  const cursorHiddenAfterEachWrite: boolean[] = []
+  const cursorHiddenNow = (): boolean => {
+    const all = written.join('')
+    const lastHide = all.lastIndexOf(CURSOR_HIDE)
+    const lastShow = all.lastIndexOf(CURSOR_SHOW)
+    return lastHide !== -1 && lastHide > lastShow
+  }
+  return {
+    written,
+    cursorHiddenAfterEachWrite,
+    buffer: { active: { cursorY: 0, baseY: 0, viewportY: 0 } },
+    rows: 24,
+    refresh: vi.fn(),
+    _core: { refresh: vi.fn() },
+    write: (data: string, callback?: () => void) => {
+      written.push(data)
+      cursorHiddenAfterEachWrite.push(cursorHiddenNow())
+      callback?.()
+    }
+  }
+}
+
+/**
+ * True iff the cursor was left hidden by some write and only restored by a LATER
+ * separate write — i.e. the hidden state was displayed for at least one frame.
+ * (If the final write also leaves it hidden it still counts; either way the user
+ * saw the cursor disappear.)
+ */
+function paintedWhileCursorHidden(cursorHiddenAfterEachWrite: boolean[]): boolean {
+  return cursorHiddenAfterEachWrite.some((hidden) => hidden)
+}
+
+/**
+ * Derive the cursor's final resting visibility from the exact bytes xterm
+ * received. The cursor is hidden iff the last cursor toggle written was a hide.
+ */
+function cursorEndsHidden(written: string[]): boolean {
+  const all = written.join('')
+  const lastHide = all.lastIndexOf(CURSOR_HIDE)
+  const lastShow = all.lastIndexOf(CURSOR_SHOW)
+  return lastHide !== -1 && lastHide > lastShow
+}
+
+describe('remote-runtime cursor burst (mechanism-level repro)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', globalThis)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete (globalThis as { __terminalOutputSchedulerDebug?: unknown })
+      .__terminalOutputSchedulerDebug
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  async function loadScheduler() {
+    vi.resetModules()
+    return import('../lib/pane-manager/pane-terminal-output-scheduler')
+  }
+
+  /**
+   * Run the full pipeline: serve batcher -> binary frames -> multiplexer
+   * forward -> renderer scheduler -> fake xterm. `bareCursorSplitFixWired` selects
+   * the unpatched (false) vs fixed (true) protection decision. `singleFrame`
+   * lets the positive control deliver the whole burst atomically.
+   */
+  async function runPipeline(opts: {
+    bareCursorSplitFixWired: boolean
+    singleFrame: boolean
+  }): Promise<{ written: string[]; cursorHiddenAfterEachWrite: boolean[]; frameCount: number }> {
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createFakeXterm()
+    const protectionState = {
+      synchronizedForegroundOutputActive: false,
+      bareCursorHideForegroundActive: false
+    }
+
+    const stream = await startServeBatcherStream()
+
+    if (opts.singleFrame) {
+      // Positive control: hide+redraw+show arrive together, one flush.
+      stream.emit(`${CURSOR_HIDE}REDRAW${CURSOR_SHOW}`)
+      await stream.flushTimers()
+    } else {
+      // Bug repro: the 5ms flush lands between the hide and the show, so the
+      // batcher emits two separate Output frames (frame A ends cursor-hidden).
+      stream.emit(`${CURSOR_HIDE}REDRAW`)
+      await stream.flushTimers()
+      stream.emit(CURSOR_SHOW)
+      await stream.flushTimers()
+    }
+
+    deliverFramesAsMultiplexerWould(stream.binaryFrames, (data) => {
+      const flags = computeRemoteProtectionFlags(data, protectionState, opts.bareCursorSplitFixWired)
+      writeTerminalOutput(terminal, data, {
+        foreground: true,
+        latencySensitive: true,
+        ...flags
+      })
+    })
+
+    // Drain every pending scheduler timer (hold-safety / coalesce release) so
+    // any held chunk is flushed to xterm before we inspect cursor state.
+    await vi.runAllTimersAsync()
+
+    const frameCount = stream.binaryFrames.filter((bytes) => {
+      const frame = decodeTerminalStreamFrame(bytes)
+      return frame?.opcode === TerminalStreamOpcode.Output
+    }).length
+
+    await stream.stop()
+    return {
+      written: terminal.written,
+      cursorHiddenAfterEachWrite: terminal.cursorHiddenAfterEachWrite,
+      frameCount
+    }
+  }
+
+  it('positive control: a single-frame burst is never painted with the cursor hidden (no false green)', async () => {
+    const { written, cursorHiddenAfterEachWrite, frameCount } = await runPipeline({
+      bareCursorSplitFixWired: false,
+      singleFrame: true
+    })
+    // The whole burst rode one frame, so the transport never split it.
+    expect(frameCount).toBe(1)
+    // The cursor is shown by the end, and no write ever left it hidden — proving
+    // the harness does not report a phantom flicker when there is none.
+    expect(written.join('')).toContain(CURSOR_SHOW)
+    expect(cursorEndsHidden(written)).toBe(false)
+    expect(paintedWhileCursorHidden(cursorHiddenAfterEachWrite)).toBe(false)
+  })
+
+  it('repro: a split bare ?25l/?25h burst over remote-runtime paints the cursor hidden (UNPATCHED)', async () => {
+    const { cursorHiddenAfterEachWrite, frameCount } = await runPipeline({
+      bareCursorSplitFixWired: false,
+      singleFrame: false
+    })
+    // The serve batcher really split the burst into two separate Output frames.
+    expect(frameCount).toBe(2)
+    // With the bare-cursor cross-frame hold NOT wired, the hide-ending frame is
+    // written on its own before the show arrives — the user sees the cursor
+    // vanish for a frame. THIS is the bug. On unpatched v1.4.88 this is true.
+    expect(paintedWhileCursorHidden(cursorHiddenAfterEachWrite)).toBe(true)
+  })
+
+  it('fix: wiring the dangling-?25l cross-frame hold never paints the cursor hidden (PATCHED)', async () => {
+    const { written, cursorHiddenAfterEachWrite, frameCount } = await runPipeline({
+      bareCursorSplitFixWired: true,
+      singleFrame: false
+    })
+    // The transport still splits the burst...
+    expect(frameCount).toBe(2)
+    // ...but the dangling-hide hold defers the hide-ending frame until the
+    // matching show arrives, so no write ever leaves the cursor hidden, and the
+    // cursor is visible at rest.
+    expect(paintedWhileCursorHidden(cursorHiddenAfterEachWrite)).toBe(false)
+    expect(cursorEndsHidden(written)).toBe(false)
+  })
+})

--- a/src/renderer/src/runtime/remote-runtime-cursor-burst.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-cursor-burst.test.ts
@@ -37,14 +37,14 @@
  *    onData once per frame, NO cross-frame buffering — multiplexer
  *    handleBinary, lines 330-336) so the no-buffering behavior under test is the
  *    real one.
- *  - The gate flag-decision from `writePtyOutputToXterm` (pty-connection.ts,
- *    lines ~2473-2511) is an un-exported closure inside `connectPanePty`, which
- *    needs the full pane/manager/store graph to build. We replicate that exact
- *    flag expression in `computeRemoteProtectionFlags`, parameterized by whether
- *    the bare-`?25l` cross-frame hold is wired. The DEC-2026 branches are kept
- *    identical to the source; the captured claude/vim/htop byte streams contain
- *    ZERO DEC-2026 markers (only bare `?25l`/`?25h`), so the bare path is the one
- *    that decides the bug — see CAPTURE-FINDINGS.md.
+ * REAL (was replicated, now wired to production):
+ *  - The gate flag-decision from `writePtyOutputToXterm`. It is now the exported
+ *    pure `computeSplitCursorBurstFlags` (split-cursor-burst-flags.ts), so this
+ *    test drives the SAME logic the renderer runs. `protectSplitCursorBursts`
+ *    selects the repo state under test (false = pre-fix, remote-runtime PTYs
+ *    outside the gate; true = the fix that adds them). The captured claude/vim/htop
+ *    byte streams contain ZERO DEC-2026 markers (only bare `?25l`/`?25h`), so the
+ *    bare path is the one that decides the bug — see CAPTURE-FINDINGS.md.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -52,6 +52,7 @@ import {
   decodeTerminalStreamFrame,
   decodeTerminalStreamText
 } from '../../../shared/terminal-stream-protocol'
+import { computeSplitCursorBurstFlags } from '../components/terminal-pane/split-cursor-burst-flags'
 import { RpcDispatcher } from '../../../main/runtime/rpc/dispatcher'
 import { TERMINAL_METHODS } from '../../../main/runtime/rpc/methods/terminal'
 import type { OrcaRuntimeService } from '../../../main/runtime/orca-runtime'
@@ -171,19 +172,17 @@ function deliverFramesAsMultiplexerWould(
 }
 
 /**
- * Replicates the protection flag-decision from pty-connection.ts
- * `writePtyOutputToXterm` for a REMOTE-RUNTIME foreground chunk
- * (`shouldProtectSplitCursorBursts === true`). It mirrors the real source's two
- * protection paths:
- *  - The DEC-2026 synchronized-output hold (unchanged from the native-Windows
- *    path). The captured TUIs emit NO DEC-2026, so it stays inert here.
- *  - The bare-cursor split protection — hold a chunk that ends on an unmatched
- *    `\e[?25l` (`bareCursorHideEnding` -> holdForeground) and release it when the
- *    matching `\e[?25h` arrives (`bareCursorHideShow` -> coalesceForeground).
- * `bareCursorSplitFixWired` selects the repo state under test:
- *  - false = pre-fix v1.4.88 (protection absent): a bare dangling hide never
- *            holds -> frame A is shown cursor-hidden (the bug).
- *  - true  = with the bare-cursor split fix wired: the hide holds until the show.
+ * Drives the REAL production flag-decision (`computeSplitCursorBurstFlags`) for a
+ * REMOTE-RUNTIME foreground chunk and maps its outputs onto the scheduler write
+ * opts exactly as `writePtyOutputToXterm` (pty-connection.ts) does. This is the
+ * same logic the renderer runs — no replica.
+ * `bareCursorSplitFixWired` selects the repo state under test via the production
+ * `protectSplitCursorBursts` gate:
+ *  - false = pre-fix v1.4.88: remote-runtime PTYs sit OUTSIDE the protect gate,
+ *            so a bare dangling hide never holds -> frame A is shown cursor-hidden.
+ *  - true  = the fix that adds remote-runtime PTYs to the gate: the hide holds
+ *            until the matching show.
+ * Advances the caller-owned `state` the same way the production caller does.
  */
 function computeRemoteProtectionFlags(
   data: string,
@@ -195,44 +194,34 @@ function computeRemoteProtectionFlags(
   stripTransientCursorShows: boolean
   coalesceForeground: boolean
   holdForeground: boolean
+  holdForegroundUntilCursorShow: boolean
 } {
-  // DEC-2026 synchronized output (unchanged from the source).
-  const synchronizedOutputStarted = data.includes('\x1b[?2026h')
-  const synchronizedOutputEnded = data.includes('\x1b[?2026l')
-  const synchronizedForegroundOutput =
-    state.synchronizedForegroundOutputActive || synchronizedOutputStarted || synchronizedOutputEnded
-  const lastStart = data.lastIndexOf('\x1b[?2026h')
-  const lastEnd = data.lastIndexOf('\x1b[?2026l')
-  const nextSynchronizedForegroundOutputActive =
-    lastStart === -1 && lastEnd === -1
-      ? state.synchronizedForegroundOutputActive
-      : lastStart > lastEnd
+  const flags = computeSplitCursorBurstFlags(data, {
+    protectSplitCursorBursts: bareCursorSplitFixWired,
+    foreground: true,
+    state: {
+      synchronizedForegroundOutputActive: state.synchronizedForegroundOutputActive,
+      bareCursorHideForegroundActive: state.bareCursorHideForegroundActive
+    }
+  })
 
-  const hideIndex = data.indexOf(CURSOR_HIDE)
-  const lastShowIndex = data.lastIndexOf(CURSOR_SHOW)
-  const containsCursorRestore = hideIndex !== -1 && lastShowIndex > hideIndex
+  // Advance the caller-owned state exactly as writePtyOutputToXterm does.
+  state.synchronizedForegroundOutputActive = flags.nextSynchronizedForegroundOutputActive
+  state.bareCursorHideForegroundActive = flags.bareCursorHideEnding
 
-  // Bare cursor split (mirrors pty-connection.ts bareCursorHide* flags).
-  const endsWithDanglingCursorHide = data.lastIndexOf(CURSOR_HIDE) > data.lastIndexOf(CURSOR_SHOW)
-  const bareCursorHideEnding =
-    bareCursorSplitFixWired && !synchronizedForegroundOutput && endsWithDanglingCursorHide
-  const bareCursorHideShow =
-    bareCursorSplitFixWired &&
-    state.bareCursorHideForegroundActive &&
-    !bareCursorHideEnding &&
-    data.includes(CURSOR_SHOW)
-
-  state.synchronizedForegroundOutputActive = nextSynchronizedForegroundOutputActive
-  state.bareCursorHideForegroundActive = bareCursorHideEnding
-
+  // Map the pure flags onto scheduler opts, mirroring the production caller.
   return {
-    forceForegroundRefresh: synchronizedForegroundOutput || containsCursorRestore,
-    followupForegroundRefresh: containsCursorRestore,
-    stripTransientCursorShows: true,
+    forceForegroundRefresh:
+      flags.synchronizedForegroundOutput || flags.cursorRestoreNeedsRowInvalidation,
+    followupForegroundRefresh: flags.cursorRestoreNeedsRowInvalidation,
+    stripTransientCursorShows: bareCursorSplitFixWired,
     coalesceForeground:
-      (synchronizedForegroundOutput && synchronizedOutputEnded) || bareCursorHideShow,
+      (flags.synchronizedForegroundOutput && flags.synchronizedOutputEnded) ||
+      flags.bareCursorHideShow,
     holdForeground:
-      (synchronizedForegroundOutput && nextSynchronizedForegroundOutputActive) || bareCursorHideEnding
+      (flags.synchronizedForegroundOutput && flags.nextSynchronizedForegroundOutputActive) ||
+      flags.bareCursorHideEnding,
+    holdForegroundUntilCursorShow: flags.bareCursorHideEnding
   }
 }
 


### PR DESCRIPTION
## Summary

The text cursor disappears while typing in repainting TUIs (claude, vim, htop) in **serve-hosted (remote-runtime)** terminals. Local terminals are unaffected.

**Root cause:** The serve-side 5 ms output batcher (`TERMINAL_OUTPUT_FLUSH_MS`) can split a TUI's `ESC[?25l … ESC[?25h` repaint burst across separate Output frames. The renderer's cursor-restore protection added for native-Windows ConPTY (#4669/#4907) is gated to `isNativeWindowsConpty` and is never applied to remote-runtime PTYs, which split the burst identically. Local PTYs deliver the burst atomically, so they never hit it.

**Fix** (renderer-only — `src/renderer/src/components/terminal-pane/`, `src/renderer/src/lib/pane-manager/`):
- Extract the protection gate into a pure, unit-testable predicate `shouldProtectSplitCursorBursts()` and **broaden it to remote-runtime PTYs**. Native-Windows ConPTY behaviour is unchanged (it still matches).
- Add a **persistent hold-until-show**: a dangling `ESC[?25l` holds foreground output, and an intermediate cursor-free redraw frame **extends** the hold (instead of releasing it) until the matching `ESC[?25h` arrives or a safety timeout fires — fixing the ≥3-frame split case.
- Extract the per-chunk flag decision into a pure, exported `computeSplitCursorBurstFlags()` so the test drives the exact production logic rather than a hand-copied replica.

No serve-side, main-process, or native-module changes — so it does not collide with the in-flight output-batcher/ACK work (`terminal.ts` / multiplexer).

## Screenshots

No visual change in the static UI. The fix is a runtime rendering behavior (cursor visibility during fast TUI repaints over a remote PTY); there is no layout or component change to screenshot.

## Testing

- [x] `pnpm lint`
- [ ] `pnpm typecheck` — the new/changed files are type-clean; the only failure is a **pre-existing** error on `main` in an unrelated file (`src/main/github/work-item-details.test.ts`, `TS18048`), reproduced on a pristine `upstream/main` checkout with none of this PR's changes present.
- [x] `pnpm test` — the four test files in this PR pass (55 tests). The full suite's only failures are environment-specific and unrelated to this change (WSL `HISTFILE` path assertions in `local-pty-provider.test.ts`; filesystem permission-mode assertions in `runtime-metadata.test.ts`).
- [ ] `pnpm build` — gates on the full `pnpm typecheck`, so it stops on the same pre-existing unrelated error above.
- [x] Added high-quality regression tests that would catch this exact regression (see below).

New/updated tests:
- `split-cursor-burst-protection.test.ts` — the gate fires for remote-runtime and native-Windows ConPTY, and stays **off** for local non-Windows.
- `split-cursor-burst-flags.test.ts` — drives the real `computeSplitCursorBurstFlags()`; guards against a future edit silently re-narrowing protection to native-Windows-only.
- `pane-terminal-output-scheduler.test.ts` — 3-frame split test that extends the hold across a cursor-free redraw frame (RED before the hold-persistence change, GREEN after).
- `remote-runtime-cursor-burst.test.ts` — integration over the real batcher + codec + scheduler (unpatched vs patched contrast).

## AI Review Report

Reviewed with an AI coding agent across the dimensions below.

- **Cross-platform (macOS / Linux / Windows):** No new platform branching, no hardcoded `metaKey`, no path/shell assumptions. Native-Windows ConPTY keeps the identical gate value (`isNativeWindowsConpty` still matches `shouldProtectSplitCursorBursts`), so Windows behaviour is unchanged; the only new path is broadening the *same* protection to remote-runtime PTYs.
- **SSH / remote / local:** This is the core of the change — protection now also covers remote-runtime (`orca serve`) PTYs, which were the unprotected case. Local non-Windows PTYs are deliberately excluded (the burst arrives atomically there, so protection isn't needed and stays off).
- **Agent / integration:** The hold/coalesce logic was extracted verbatim into a pure function; the DEC-2026 synchronized-output path is preserved and the bare-`?25l` hold is skipped while a DEC-2026 hold is already engaged, so the two paths don't contend.
- **Performance:** Per-chunk work is a handful of `indexOf`/`lastIndexOf` scans plus a bounded foreground-hold timer that already existed; no added allocations on the hot path and no new timers beyond the existing safety fallback.
- **UI quality:** No layout/component/token changes; fixes a visible rendering glitch (vanishing cursor).
- **Security:** No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes.

The review explicitly checked cross-platform compatibility for macOS, Linux, and Windows (shortcuts, labels, paths, shell behavior, Electron specifics): this PR touches none of those — it is renderer-side terminal-output scheduling only.

## Security Audit

No new attack surface. The change only decides whether to hold/coalesce already-trusted PTY output frames in the renderer before writing them to xterm. No new IPC, no command execution, no path or secret handling, no dependency changes.

## Notes

- Native-Windows ConPTY path is untouched (same gate value), and local non-Windows PTYs are excluded.
- Known limitation (documented in source): a 5 ms flush that bisects the 6-byte `ESC[?25l` itself is not specifically handled (ambiguous tail; xterm reassembles for display).
- Platform/remote note: the bug only manifests on the split transport (remote-runtime or native-Windows ConPTY); validate on a thin-client → `orca serve` setup running a repainting TUI.
