### PR TITLE
Show Agent activity for mobile smart sort

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -765,6 +765,8 @@ export function HostScreen({
     count += filters.filterRepoIds.size
     return count
   }, [filters])
+  const selectedSortLabel =
+    SORT_OPTIONS.find((option) => option.value === sortMode)?.label ?? 'Recent'
 
   const handleGroupChange = useCallback(
     (value: MobileGroupMode) => {
@@ -937,19 +939,19 @@ export function HostScreen({
               </Pressable>
 
               <Pressable
-                style={[styles.sortButton, styles.embeddedModeButton]}
+                style={[styles.modeButton, styles.embeddedModeButton]}
                 onPress={() => setShowSortPicker(true)}
                 accessibilityRole="button"
-                accessibilityLabel={`Sort by ${SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? 'Recent'}`}
+                accessibilityLabel={`Sort by ${selectedSortLabel}`}
               >
                 <SlidersHorizontal size={14} color={colors.textSecondary} />
                 <Text style={styles.sortLabel} numberOfLines={1}>
-                  {SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? 'Recent'}
+                  {selectedSortLabel}
                 </Text>
               </Pressable>
 
               <Pressable
-                style={[styles.groupButton, styles.embeddedModeButton]}
+                style={[styles.modeButton, styles.embeddedModeButton]}
                 onPress={() => setShowGroupPicker(true)}
                 accessibilityRole="button"
                 accessibilityLabel="Group workspaces"
@@ -1050,16 +1052,16 @@ export function HostScreen({
               </Text>
             </Pressable>
 
-            <Pressable style={styles.sortButton} onPress={() => setShowSortPicker(true)}>
+            <Pressable style={styles.modeButton} onPress={() => setShowSortPicker(true)}>
               <SlidersHorizontal size={14} color={colors.textSecondary} />
-              <Text style={styles.sortLabel}>
-                {SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? 'Recent'}
+              <Text style={styles.sortLabel} numberOfLines={1}>
+                {selectedSortLabel}
               </Text>
             </Pressable>
 
-            <Pressable style={styles.groupButton} onPress={() => setShowGroupPicker(true)}>
+            <Pressable style={styles.modeButton} onPress={() => setShowGroupPicker(true)}>
               <Layers size={14} color={colors.textSecondary} />
-              <Text style={styles.sortLabel}>
+              <Text style={styles.sortLabel} numberOfLines={1}>
                 {groupMode === 'none'
                   ? 'Group'
                   : groupMode === 'workspaceStatus'
@@ -1570,21 +1572,18 @@ const styles = StyleSheet.create({
   filterChipTextActive: {
     color: colors.textPrimary
   },
-  sortButton: {
+  modeButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs
-  },
-  groupButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexShrink: 1,
+    minWidth: 0,
     gap: 4,
     paddingHorizontal: spacing.sm,
     paddingVertical: spacing.xs
   },
   sortLabel: {
+    flexShrink: 1,
+    minWidth: 0,
     fontSize: 12,
     color: colors.textSecondary
   },

--- a/mobile/src/worktree/workspace-list-picker-options.test.ts
+++ b/mobile/src/worktree/workspace-list-picker-options.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { WORKSPACE_SORT_OPTIONS } from './workspace-list-picker-options'
+
+describe('WORKSPACE_SORT_OPTIONS', () => {
+  it('keeps the smart sort value while showing the agent activity label', () => {
+    expect(WORKSPACE_SORT_OPTIONS.find((option) => option.value === 'smart')).toEqual({
+      value: 'smart',
+      label: 'Agent activity',
+      subtitle: 'Agents that need attention, then recent activity'
+    })
+  })
+})

--- a/mobile/src/worktree/workspace-list-picker-options.test.ts
+++ b/mobile/src/worktree/workspace-list-picker-options.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from 'vitest'
 import { WORKSPACE_SORT_OPTIONS } from './workspace-list-picker-options'
 
 describe('WORKSPACE_SORT_OPTIONS', () => {
+  it('keeps the persisted sort values stable for desktop compatibility', () => {
+    expect(WORKSPACE_SORT_OPTIONS.map((option) => option.value)).toEqual([
+      'smart',
+      'name',
+      'recent',
+      'repo',
+      'manual'
+    ])
+  })
+
   it('keeps the smart sort value while showing the agent activity label', () => {
     expect(WORKSPACE_SORT_OPTIONS.find((option) => option.value === 'smart')).toEqual({
       value: 'smart',

--- a/mobile/src/worktree/workspace-list-picker-options.ts
+++ b/mobile/src/worktree/workspace-list-picker-options.ts
@@ -2,7 +2,12 @@ import type { PickerOption } from '../components/PickerModal'
 import type { MobileGroupMode, MobileSortMode } from './workspace-view-settings'
 
 export const WORKSPACE_SORT_OPTIONS: PickerOption<MobileSortMode>[] = [
-  { value: 'smart', label: 'Smart', subtitle: 'Unread and active first' },
+  // Why: desktop and persisted state keep the `smart` key, while mobile shows the product label.
+  {
+    value: 'smart',
+    label: 'Agent activity',
+    subtitle: 'Agents that need attention, then recent activity'
+  },
   { value: 'name', label: 'Name', subtitle: 'Alphabetical by name' },
   { value: 'recent', label: 'Recent', subtitle: 'Most recent output first' },
   { value: 'repo', label: 'Repo', subtitle: 'Repository, then workspace name' },


### PR DESCRIPTION
## Summary

- Rename the mobile workspace `smart` sort option from `Smart` to `Agent activity`, matching the desktop product concept.
- Preserve the persisted `smart` value and existing mobile sort comparator semantics for backwards compatibility.
- Keep the mobile toolbar sort/group controls constrained so the longer display label truncates cleanly without overlapping neighboring controls.

## Design Approach

- The change is frontend/display-name-only: mobile continues to model and sync the same `sortBy: 'smart'` value over existing UI RPC state.
- The visible mobile sort label and subtitle now align with desktop naming while leaving storage, RPC fields, IPC/API payloads, and comparator behavior untouched.
- Semantic drift documented in the scratch design: desktop uses the richer attention-class comparator, while mobile keeps its existing unread/status/last-output/name comparator.

## Backwards Compatibility

- Persisted sort enum value remains `smart`.
- No storage keys, RPC fields, database fields, IPC contracts, API payload values, or shared type unions were renamed.
- Existing users with `sortBy: 'smart'` continue to hydrate and sort with the same behavior; only the visible mobile label changes to `Agent activity`.
- Added a focused compatibility test that locks the mobile sort option values to `smart`, `name`, `recent`, `repo`, and `manual`.

## Design And Reviews

- Design-review outcome: delegated design review returned clean after clarifying toolbar, semantic-drift, validation, and mobile style-token boundaries.
- Completeness verification: clean on the final diff.
- Performance audit: clean; no new polling, subscriptions, subprocesses, cache invalidation, startup work, leaks, or meaningful render churn.
- Code-review loop: three two-reviewer rounds. Earlier rounds found toolbar truncation constraints; final round returned clean from both reviewers.
- Agent prompt autonomy boundary: not applicable; this changes user-facing UI copy only, not agent prompt text.

## Implementation

- Updated `WORKSPACE_SORT_OPTIONS` so `value: 'smart'` now displays `Agent activity` with the aligned subtitle.
- Reused the selected sort option label for toolbar display and the existing explicit sort accessibility label.
- Consolidated identical sort/group toolbar button styles into `modeButton` with shrink/min-width constraints for one-line truncation.
- Added focused tests for the stable sort value contract and the new visible label/subtitle.

## Checks Run

- `git diff --check`
- `pnpm --dir mobile exec vitest run src/worktree/workspace-view-settings.test.ts src/worktree/workspace-list-picker-options.test.ts` (12 tests)
- `pnpm --dir mobile test -- workspace-view-settings workspace-list-picker-options` (133 files, 835 passed, 2 skipped)
- `pnpm --dir mobile lint`
- `pnpm --dir mobile exec tsc --noEmit -p tsconfig.json`
- `pnpm run typecheck`
- `pnpm run lint`
- Contract audit for `sortBy`, `MobileSortMode`, `WorkspaceViewSettings`, `SORT_VALUES`, `ui.get`, `ui.set`, `normalizeSortBy`, and RPC enum changes.

## Screenshots

- `/tmp/orca-mobile-agent-activity-sort-evidence/03-sort-picker-agent-activity.png`
- `/tmp/orca-mobile-agent-activity-sort-evidence/04-toolbar-after-agent-activity-selection.png`
- `/tmp/orca-mobile-agent-activity-sort-evidence/summary.json`

## Manual Validation

- Brennan's PR process validation result: land.
- Android emulator attempt: blocked because `Orca_Pixel_7_API_36` did not attach through ADB; `adb devices -l` stayed empty during direct launch attempts.
- Fallback mobile product-surface validation passed via Expo web at a Pixel-sized mobile viewport using a mobile mock WebSocket host.
- Exercised actual UI: paired mock host, opened sort picker, selected `Agent activity`, observed mock `ui.set`, verified toolbar shows `Agent activity`, and verified no exact `Smart` text remained.

## AI Review Report

- CodeRabbit generated no actionable code comments after the latest commit.
- CodeRabbit's docstring-coverage warning is non-actionable for this UI-label/test-only diff because no exported runtime API or new function needing docs was introduced.

## Security Audit

- No auth, transport, storage, prompt, file-system, shell, or provider-specific behavior changed.
- The shared persisted/RPC sort key remains `smart`, so existing local, SSH, and mobile-host state contracts stay unchanged across macOS, Linux, and Windows.

## Notes

- Native Android screenshot evidence remains the accepted gap due emulator/ADB attachment failure in this environment.
- At a narrow phone width, the toolbar label may truncate; this is intentional to avoid overlap, and the picker shows the full label/subtitle.
- Latest post-push stabilization completed after the backwards-compatibility guard commit: Mobile Checks and PR Checks are passing, and CodeRabbit has no actionable code comments.
