### PR TITLE
Support H4 and H5 markdown headings

### DIFF
--- a/src/main/window/editable-context-menu.test.ts
+++ b/src/main/window/editable-context-menu.test.ts
@@ -116,6 +116,30 @@ describe('buildEditableContextMenuTemplate', () => {
       y: 34
     })
 
+    const paragraphMenu = template[3].submenu as Electron.MenuItemConstructorOptions[]
+    expect(paragraphMenu.map((item) => item.label ?? item.type)).toEqual([
+      'Body text',
+      'Heading 1',
+      'Heading 2',
+      'Heading 3',
+      'Heading 4',
+      'Heading 5',
+      'separator',
+      'Bullet list',
+      'Numbered list',
+      'Checklist'
+    ])
+    paragraphMenu[5].click?.(
+      {} as Electron.MenuItem,
+      {} as Electron.BrowserWindow,
+      {} as KeyboardEvent
+    )
+    expect(send).toHaveBeenLastCalledWith(richMarkdownContextMenuCommandChannel, {
+      command: 'heading-5',
+      x: 12,
+      y: 34
+    })
+
     template[8].click?.({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent)
     template[9].click?.({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent)
     expect(send).toHaveBeenCalledWith('ui:editableContextPaste', { plainTextOnly: false })

--- a/src/main/window/editable-context-menu.ts
+++ b/src/main/window/editable-context-menu.ts
@@ -67,6 +67,8 @@ function buildMarkdownMenuTemplate(
         markdownCommandItem('Heading 1', 'heading-1', webContents, point),
         markdownCommandItem('Heading 2', 'heading-2', webContents, point),
         markdownCommandItem('Heading 3', 'heading-3', webContents, point),
+        markdownCommandItem('Heading 4', 'heading-4', webContents, point),
+        markdownCommandItem('Heading 5', 'heading-5', webContents, point),
         { type: 'separator' },
         markdownCommandItem('Bullet list', 'bullet-list', webContents, point),
         markdownCommandItem('Numbered list', 'ordered-list', webContents, point),

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -500,6 +500,15 @@
   font-size: 1.15em;
 }
 
+.markdown-body h4 {
+  font-size: 1em;
+}
+
+.markdown-body h5 {
+  color: var(--muted-foreground);
+  font-size: 0.92em;
+}
+
 .markdown-body p {
   margin: 0.75em 0;
 }

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -492,6 +492,15 @@
   font-size: 1.15em;
 }
 
+.rich-markdown-editor h4 {
+  font-size: 1em;
+}
+
+.rich-markdown-editor h5 {
+  color: var(--muted-foreground);
+  font-size: 0.92em;
+}
+
 .rich-markdown-editor p,
 .rich-markdown-editor ul,
 .rich-markdown-editor ol,

--- a/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.test.tsx
+++ b/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.test.tsx
@@ -13,7 +13,28 @@ const sampleItems: MarkdownTocItem[] = [
         id: 'setup',
         level: 2,
         title: 'Setup',
-        children: []
+        children: [
+          {
+            id: 'install',
+            level: 3,
+            title: 'Install',
+            children: [
+              {
+                id: 'configure',
+                level: 4,
+                title: 'Configure',
+                children: [
+                  {
+                    id: 'options',
+                    level: 5,
+                    title: 'Options',
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }
@@ -27,7 +48,13 @@ describe('MarkdownTableOfContentsPanel', () => {
 
     expect(html).toContain('Collapse by level')
     expect(html).toContain('Collapse to heading level 1')
+    expect(html).toContain('Collapse to heading level 4')
+    expect(html).toContain('Expand all heading levels')
+    expect(html).toContain('H5')
     expect(html).toContain('Collapse Intro')
+    expect(html).toContain('Install')
+    expect(html).toContain('Configure')
+    expect(html).toContain('Options')
     expect(html).toContain('Intro')
     expect(html).toContain('Setup')
     expect(html).toContain('data-markdown-toc-resize-handle')

--- a/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.tsx
+++ b/src/renderer/src/components/editor/MarkdownTableOfContentsPanel.tsx
@@ -25,7 +25,8 @@ type MarkdownTableOfContentsPanelProps = {
   onNavigate: (id: string) => void
 }
 
-const TOC_LEVELS: MarkdownTocLevel[] = [1, 2, 3]
+const TOC_LEVELS: MarkdownTocLevel[] = [1, 2, 3, 4, 5]
+const TOC_EXPAND_ALL_LEVEL: MarkdownTocLevel = 5
 const TOC_INDENT_BASE_PX = 12
 const TOC_INDENT_STEP_PX = 12
 
@@ -194,7 +195,7 @@ export function MarkdownTableOfContentsPanel({
                 size="icon-xs"
                 className="markdown-toc-level-button"
                 aria-label={
-                  level === 3
+                  level === TOC_EXPAND_ALL_LEVEL
                     ? translate(
                         'auto.components.editor.MarkdownTableOfContentsPanel.f3de856175',
                         'Expand all heading levels'
@@ -206,7 +207,7 @@ export function MarkdownTableOfContentsPanel({
                       )
                 }
                 title={
-                  level === 3
+                  level === TOC_EXPAND_ALL_LEVEL
                     ? translate(
                         'auto.components.editor.MarkdownTableOfContentsPanel.a5daadd68b',
                         'Expand all'

--- a/src/renderer/src/components/editor/RichMarkdownToolbar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownToolbar.tsx
@@ -1,19 +1,33 @@
 import React from 'react'
 import type { Editor } from '@tiptap/react'
 import {
+  ChevronRight,
   Heading1,
   Heading2,
   Heading3,
+  Heading4,
+  Heading5,
   ImageIcon,
   Link as LinkIcon,
   List,
   ListOrdered,
   ListTodo,
+  MoreHorizontal,
   Pilcrow,
   Quote
 } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { RichMarkdownToolbarButton } from './RichMarkdownToolbarButton'
 import { translate } from '@/i18n/i18n'
+import { insertToggle } from './rich-markdown-slash-command-primitives'
 
 type RichMarkdownToolbarProps = {
   editor: Editor | null
@@ -23,6 +37,59 @@ type RichMarkdownToolbarProps = {
 
 function Separator(): React.JSX.Element {
   return <div className="rich-markdown-toolbar-separator" />
+}
+
+function RichMarkdownMoreBlocksMenu({ editor }: { editor: Editor | null }): React.JSX.Element {
+  const label = translate('auto.components.editor.RichMarkdownToolbar.91a843fb43', 'More blocks')
+
+  return (
+    <DropdownMenu>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="rich-markdown-toolbar-button"
+                aria-label={label}
+                onMouseDown={(event) => event.preventDefault()}
+              >
+                <MoreHorizontal className="size-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={4}>
+            {label}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <DropdownMenuContent align="end" side="bottom">
+        <DropdownMenuLabel>
+          {translate('auto.components.editor.RichMarkdownToolbar.2cd9e0bbb3', 'Headings')}
+        </DropdownMenuLabel>
+        <DropdownMenuItem
+          onSelect={() => editor?.chain().focus().toggleHeading({ level: 4 }).run()}
+        >
+          <Heading4 className="size-3.5" />
+          {translate('auto.components.editor.RichMarkdownToolbar.b05e14620d', 'Heading 4')}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={() => editor?.chain().focus().toggleHeading({ level: 5 }).run()}
+        >
+          <Heading5 className="size-3.5" />
+          {translate('auto.components.editor.RichMarkdownToolbar.6bbf827ef5', 'Heading 5')}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => (editor ? insertToggle(editor) : undefined)}>
+          <ChevronRight className="size-3.5" />
+          {translate(
+            'auto.components.editor.RichMarkdownToolbar.d1bbf9a835',
+            'Collapsible section'
+          )}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
 }
 
 export function RichMarkdownToolbar({
@@ -126,6 +193,7 @@ export function RichMarkdownToolbar({
       >
         <ImageIcon className="size-3.5" />
       </RichMarkdownToolbarButton>
+      <RichMarkdownMoreBlocksMenu editor={editor} />
     </div>
   )
 }

--- a/src/renderer/src/components/editor/markdown-table-of-contents.test.ts
+++ b/src/renderer/src/components/editor/markdown-table-of-contents.test.ts
@@ -9,8 +9,10 @@ afterEach(() => {
 })
 
 describe('markdown table of contents', () => {
-  it('builds a nested h1-h3 outline', () => {
-    const toc = buildMarkdownTableOfContents('# Intro\n\n## Setup\n\n### Install\n\n## Usage')
+  it('builds a nested h1-h5 outline', () => {
+    const toc = buildMarkdownTableOfContents(
+      '# Intro\n\n## Setup\n\n### Install\n\n#### Configure\n\n##### Options\n\n## Usage'
+    )
 
     expect(toc).toEqual([
       {
@@ -27,7 +29,21 @@ describe('markdown table of contents', () => {
                 id: 'install',
                 level: 3,
                 title: 'Install',
-                children: []
+                children: [
+                  {
+                    id: 'configure',
+                    level: 4,
+                    title: 'Configure',
+                    children: [
+                      {
+                        id: 'options',
+                        level: 5,
+                        title: 'Options',
+                        children: []
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -43,7 +59,7 @@ describe('markdown table of contents', () => {
   })
 
   it('skips front matter and unsupported heading depths', () => {
-    const toc = buildMarkdownTableOfContents('---\ntitle: Doc\n---\n# Visible\n#### Hidden')
+    const toc = buildMarkdownTableOfContents('---\ntitle: Doc\n---\n# Visible\n###### Hidden')
 
     expect(toc.map((item) => item.title)).toEqual(['Visible'])
   })

--- a/src/renderer/src/components/editor/markdown-table-of-contents.ts
+++ b/src/renderer/src/components/editor/markdown-table-of-contents.ts
@@ -4,7 +4,7 @@ import remarkParse from 'remark-parse'
 import { unified } from 'unified'
 import { MarkdownHeadingSlugger } from './markdown-heading-slug'
 
-export type MarkdownTocLevel = 1 | 2 | 3
+export type MarkdownTocLevel = 1 | 2 | 3 | 4 | 5
 
 export type MarkdownTocItem = {
   children: MarkdownTocItem[]
@@ -23,7 +23,7 @@ const htmlEntitiesForToc = new Map([
 ])
 
 function isMarkdownTocLevel(value: number): value is MarkdownTocLevel {
-  return value === 1 || value === 2 || value === 3
+  return value >= 1 && value <= 5
 }
 
 // Scoped local fork of the tiny entities@6.0.1 surface Orca used here.

--- a/src/renderer/src/components/editor/markdown-toc-collapse-state.test.ts
+++ b/src/renderer/src/components/editor/markdown-toc-collapse-state.test.ts
@@ -23,7 +23,21 @@ const sampleToc: MarkdownTocItem[] = [
             id: 'install',
             level: 3,
             title: 'Install',
-            children: []
+            children: [
+              {
+                id: 'configure',
+                level: 4,
+                title: 'Configure',
+                children: [
+                  {
+                    id: 'options',
+                    level: 5,
+                    title: 'Options',
+                    children: []
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -39,13 +53,28 @@ const sampleToc: MarkdownTocItem[] = [
 
 describe('markdown toc collapse state', () => {
   it('collects parent ids for nested headings', () => {
-    expect([...collectMarkdownTocParentIds(sampleToc)].sort()).toEqual(['intro', 'setup'])
+    expect([...collectMarkdownTocParentIds(sampleToc)].sort()).toEqual([
+      'configure',
+      'install',
+      'intro',
+      'setup'
+    ])
   })
 
   it('collapses parents at and below the selected level', () => {
-    expect([...collapseMarkdownTocToLevel(sampleToc, 1)].sort()).toEqual(['intro', 'setup'])
-    expect([...collapseMarkdownTocToLevel(sampleToc, 2)].sort()).toEqual(['setup'])
-    expect([...collapseMarkdownTocToLevel(sampleToc, 3)]).toEqual([])
+    expect([...collapseMarkdownTocToLevel(sampleToc, 1)].sort()).toEqual([
+      'configure',
+      'install',
+      'intro',
+      'setup'
+    ])
+    expect([...collapseMarkdownTocToLevel(sampleToc, 2)].sort()).toEqual([
+      'configure',
+      'install',
+      'setup'
+    ])
+    expect([...collapseMarkdownTocToLevel(sampleToc, 4)]).toEqual(['configure'])
+    expect([...collapseMarkdownTocToLevel(sampleToc, 5)]).toEqual([])
   })
 
   it('toggles and prunes stale collapsed ids', () => {

--- a/src/renderer/src/components/editor/rich-markdown-commands.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-commands.test.ts
@@ -42,6 +42,8 @@ describe('rich markdown slash commands', () => {
       'Headings:toggle-h1',
       'Headings:heading-2',
       'Headings:heading-3',
+      'Headings:heading-4',
+      'Headings:heading-5',
       'Basic blocks:blockquote',
       'Basic blocks:ordered-list',
       'Basic blocks:bullet-list',
@@ -57,6 +59,24 @@ describe('rich markdown slash commands', () => {
       'Media:image',
       'Others:emoji'
     ])
+  })
+
+  it('supports deep heading slash commands', () => {
+    const h4Editor = createEditor('Deep heading')
+    const h5Editor = createEditor('Nested heading')
+
+    try {
+      getCommand('heading-4').run(h4Editor)
+      getCommand('heading-5').run(h5Editor)
+
+      expect(h4Editor.getMarkdown()).toBe('#### Deep heading')
+      expect(h5Editor.getMarkdown()).toBe('##### Nested heading')
+      expect(getCommand('heading-4').aliases).toContain('h4')
+      expect(getCommand('heading-5').aliases).toContain('h5')
+    } finally {
+      h4Editor.destroy()
+      h5Editor.destroy()
+    }
   })
 
   it('inserts a durable markdown table', () => {

--- a/src/renderer/src/components/editor/rich-markdown-context-command-routing.ts
+++ b/src/renderer/src/components/editor/rich-markdown-context-command-routing.ts
@@ -49,6 +49,12 @@ export function runRichMarkdownContextCommand({
     case 'heading-3':
       editor.chain().focus().setHeading({ level: 3 }).run()
       return
+    case 'heading-4':
+      editor.chain().focus().setHeading({ level: 4 }).run()
+      return
+    case 'heading-5':
+      editor.chain().focus().setHeading({ level: 5 }).run()
+      return
     case 'bullet-list':
       editor.chain().focus().toggleBulletList().run()
       return

--- a/src/renderer/src/components/editor/rich-markdown-heading-slash-commands.tsx
+++ b/src/renderer/src/components/editor/rich-markdown-heading-slash-commands.tsx
@@ -1,0 +1,137 @@
+import { ChevronRight, Heading1, Heading2, Heading3, Heading4, Heading5 } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import { icon, insertToggle, type SlashCommand } from './rich-markdown-slash-command-primitives'
+
+export const headingSlashCommands: SlashCommand[] = [
+  {
+    id: 'heading-1',
+    get label() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.e66e7f04c6',
+        'Heading 1'
+      )
+    },
+    aliases: ['h1', 'title'],
+    icon: icon(Heading1),
+    group: 'Headings',
+    get description() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.570611864e',
+        'Large section heading.'
+      )
+    },
+    run: (editor) => {
+      // Use setHeading (not toggleHeading) so "/h1" is idempotent.
+      editor.chain().focus().setHeading({ level: 1 }).run()
+    }
+  },
+  {
+    id: 'toggle-h1',
+    get label() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.41482b15ce',
+        'Toggle Heading 1'
+      )
+    },
+    aliases: ['toggle-h1', 'toggle heading', 'details heading', 'collapse heading'],
+    icon: icon(ChevronRight),
+    group: 'Headings',
+    get description() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.3294a2c0cc',
+        'Create a collapsible section with a large heading summary.'
+      )
+    },
+    run: (editor) => {
+      insertToggle(editor, 'heading-1')
+    }
+  },
+  {
+    id: 'heading-2',
+    get label() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.c209a116b7',
+        'Heading 2'
+      )
+    },
+    aliases: ['h2'],
+    icon: icon(Heading2),
+    group: 'Headings',
+    get description() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.45cf7ceb3f',
+        'Medium section heading.'
+      )
+    },
+    run: (editor) => {
+      // Use setHeading (not toggleHeading) so "/h2" is idempotent.
+      editor.chain().focus().setHeading({ level: 2 }).run()
+    }
+  },
+  {
+    id: 'heading-3',
+    get label() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.30566ee962',
+        'Heading 3'
+      )
+    },
+    aliases: ['h3'],
+    icon: icon(Heading3),
+    group: 'Headings',
+    get description() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.4920740259',
+        'Small section heading.'
+      )
+    },
+    run: (editor) => {
+      // Use setHeading (not toggleHeading) so "/h3" is idempotent.
+      editor.chain().focus().setHeading({ level: 3 }).run()
+    }
+  },
+  {
+    id: 'heading-4',
+    get label() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.5f9a0ed7c4',
+        'Heading 4'
+      )
+    },
+    aliases: ['h4'],
+    icon: icon(Heading4),
+    group: 'Headings',
+    get description() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.01a71dbbdd',
+        'Nested section heading.'
+      )
+    },
+    run: (editor) => {
+      // Use setHeading (not toggleHeading) so "/h4" is idempotent.
+      editor.chain().focus().setHeading({ level: 4 }).run()
+    }
+  },
+  {
+    id: 'heading-5',
+    get label() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.8440fa4acf',
+        'Heading 5'
+      )
+    },
+    aliases: ['h5'],
+    icon: icon(Heading5),
+    group: 'Headings',
+    get description() {
+      return translate(
+        'auto.components.editor.rich.markdown.slash.commands.b287b93c66',
+        'Deep section heading.'
+      )
+    },
+    run: (editor) => {
+      // Use setHeading (not toggleHeading) so "/h5" is idempotent.
+      editor.chain().focus().setHeading({ level: 5 }).run()
+    }
+  }
+]

--- a/src/renderer/src/components/editor/rich-markdown-slash-command-catalog.tsx
+++ b/src/renderer/src/components/editor/rich-markdown-slash-command-catalog.tsx
@@ -1,9 +1,6 @@
 import type {} from '@tiptap/extension-mathematics'
 import {
   ChevronRight,
-  Heading1,
-  Heading2,
-  Heading3,
   ImageIcon,
   List,
   ListOrdered,
@@ -22,6 +19,7 @@ import {
   textIcon,
   type SlashCommand
 } from './rich-markdown-slash-command-primitives'
+import { headingSlashCommands } from './rich-markdown-heading-slash-commands'
 
 export type {
   SlashCommand,
@@ -32,96 +30,7 @@ export type {
 } from './rich-markdown-slash-command-primitives'
 
 export const slashCommands: SlashCommand[] = [
-  {
-    id: 'heading-1',
-    get label() {
-      return translate(
-        'auto.components.editor.rich.markdown.slash.commands.e66e7f04c6',
-        'Heading 1'
-      )
-    },
-    aliases: ['h1', 'title'],
-    icon: icon(Heading1),
-    group: 'Headings',
-    get description() {
-      return translate(
-        'auto.components.editor.rich.markdown.slash.commands.570611864e',
-        'Large section heading.'
-      )
-    },
-    run: (editor) => {
-      // Use setHeading (not toggleHeading) so the slash command is idempotent —
-      // invoking "/h1" on an existing H1 should keep it as H1, not revert to paragraph.
-      editor.chain().focus().setHeading({ level: 1 }).run()
-    }
-  },
-  {
-    id: 'toggle-h1',
-    get label() {
-      return translate(
-        'auto.components.editor.rich.markdown.slash.commands.41482b15ce',
-        'Toggle Heading 1'
-      )
-    },
-    aliases: ['toggle-h1', 'toggle heading', 'details heading', 'collapse heading'],
-    icon: icon(ChevronRight),
-    group: 'Headings',
-    get description() {
-      return translate(
-        'auto.components.editor.rich.markdown.slash.commands.3294a2c0cc',
-        'Create a collapsible section with a large heading summary.'
-      )
-    },
-    run: (editor) => {
-      insertToggle(editor, 'heading-1')
-    }
-  },
-  {
-    id: 'heading-2',
-    get label() {
-      return translate(
-        'auto.components.editor.rich.markdown.slash.commands.c209a116b7',
-        'Heading 2'
-      )
-    },
-    aliases: ['h2'],
-    icon: icon(Heading2),
-    group: 'Headings',
-    get description() {
-      return translate(
-        'auto.components.editor.rich.markdown.slash.commands.45cf7ceb3f',
-        'Medium section heading.'
-      )
-    },
-    run: (editor) => {
-      // Use setHeading (not toggleHeading) so the slash command is idempotent —
-      // invoking "/h2" on an existing H2 should keep it as H2, not revert to paragraph.
-      editor.chain().focus().setHeading({ level: 2 }).run()
-    }
-  },
-  {
-    id: 'heading-3',
-    get label() {
-      return translate(
-        'auto.components.editor.rich.markdown.slash.commands.30566ee962',
-        'Heading 3'
-      )
-    },
-    aliases: ['h3'],
-    icon: icon(Heading3),
-    group: 'Headings',
-    get description() {
-      return translate(
-        'auto.components.editor.rich.markdown.slash.commands.4920740259',
-        'Small section heading.'
-      )
-    },
-    run: (editor) => {
-      // Use setHeading (not toggleHeading) so the slash command is idempotent —
-      // invoking "/h3" on an existing H3 should keep it as H3, not revert to paragraph.
-      editor.chain().focus().setHeading({ level: 3 }).run()
-    }
-  },
+  ...headingSlashCommands,
   {
     id: 'blockquote',
     get label() {

--- a/src/renderer/src/components/editor/rich-markdown-slash-command-primitives.ts
+++ b/src/renderer/src/components/editor/rich-markdown-slash-command-primitives.ts
@@ -17,6 +17,8 @@ export type SlashCommandId =
   | 'toggle-h1'
   | 'heading-2'
   | 'heading-3'
+  | 'heading-4'
+  | 'heading-5'
   | 'task-list'
   | 'bullet-list'
   | 'ordered-list'

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10840,7 +10840,12 @@
           "cf5817d827": "Heading 3",
           "d34a2021c8": "Heading 2",
           "abb5100a3d": "Heading 1",
-          "b462641ed2": "Body text"
+          "b462641ed2": "Body text",
+          "91a843fb43": "More blocks",
+          "2cd9e0bbb3": "Headings",
+          "b05e14620d": "Heading 4",
+          "6bbf827ef5": "Heading 5",
+          "d1bbf9a835": "Collapsible section"
         },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "Save",
@@ -10918,7 +10923,11 @@
                 "3294a2c0cc": "Create a collapsible section with a large heading summary.",
                 "41482b15ce": "Toggle Heading 1",
                 "570611864e": "Large section heading.",
-                "e66e7f04c6": "Heading 1"
+                "e66e7f04c6": "Heading 1",
+                "5f9a0ed7c4": "Heading 4",
+                "01a71dbbdd": "Nested section heading.",
+                "8440fa4acf": "Heading 5",
+                "b287b93c66": "Deep section heading."
               }
             }
           }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10840,7 +10840,12 @@
           "cf5817d827": "Título 3",
           "d34a2021c8": "Título 2",
           "abb5100a3d": "Título 1",
-          "b462641ed2": "Texto del cuerpo"
+          "b462641ed2": "Texto del cuerpo",
+          "91a843fb43": "More blocks",
+          "2cd9e0bbb3": "Headings",
+          "b05e14620d": "Heading 4",
+          "6bbf827ef5": "Heading 5",
+          "d1bbf9a835": "Collapsible section"
         },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "Ahorrar",
@@ -10918,7 +10923,11 @@
                 "3294a2c0cc": "Cree una sección plegable con un resumen de encabezado grande.",
                 "41482b15ce": "Alternar título 1",
                 "570611864e": "Encabezado de sección grande.",
-                "e66e7f04c6": "Título 1"
+                "e66e7f04c6": "Título 1",
+                "5f9a0ed7c4": "Heading 4",
+                "01a71dbbdd": "Nested section heading.",
+                "8440fa4acf": "Heading 5",
+                "b287b93c66": "Deep section heading."
               }
             }
           }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10840,7 +10840,12 @@
           "cf5817d827": "見出し 3",
           "d34a2021c8": "見出し2",
           "abb5100a3d": "見出し1",
-          "b462641ed2": "本文"
+          "b462641ed2": "本文",
+          "91a843fb43": "More blocks",
+          "2cd9e0bbb3": "Headings",
+          "b05e14620d": "Heading 4",
+          "6bbf827ef5": "Heading 5",
+          "d1bbf9a835": "Collapsible section"
         },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "保存",
@@ -10918,7 +10923,11 @@
                 "3294a2c0cc": "大きな見出しの概要を含む折りたたみ可能なセクションを作成します。",
                 "41482b15ce": "見出し 1 を切り替えます",
                 "570611864e": "大きなセクション見出し。",
-                "e66e7f04c6": "見出し1"
+                "e66e7f04c6": "見出し1",
+                "5f9a0ed7c4": "Heading 4",
+                "01a71dbbdd": "Nested section heading.",
+                "8440fa4acf": "Heading 5",
+                "b287b93c66": "Deep section heading."
               }
             }
           }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10840,7 +10840,12 @@
           "cf5817d827": "제목 3",
           "d34a2021c8": "제목 2",
           "abb5100a3d": "제목 1",
-          "b462641ed2": "본문 텍스트"
+          "b462641ed2": "본문 텍스트",
+          "91a843fb43": "More blocks",
+          "2cd9e0bbb3": "Headings",
+          "b05e14620d": "Heading 4",
+          "6bbf827ef5": "Heading 5",
+          "d1bbf9a835": "Collapsible section"
         },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "저장",
@@ -10918,7 +10923,11 @@
                 "3294a2c0cc": "큰 제목 요약이 포함된 접을 수 있는 섹션을 만듭니다.",
                 "41482b15ce": "토글 제목 1",
                 "570611864e": "큰 섹션 제목.",
-                "e66e7f04c6": "제목 1"
+                "e66e7f04c6": "제목 1",
+                "5f9a0ed7c4": "Heading 4",
+                "01a71dbbdd": "Nested section heading.",
+                "8440fa4acf": "Heading 5",
+                "b287b93c66": "Deep section heading."
               }
             }
           }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10840,7 +10840,12 @@
           "cf5817d827": "标题 3",
           "d34a2021c8": "标题 2",
           "abb5100a3d": "标题 1",
-          "b462641ed2": "正文"
+          "b462641ed2": "正文",
+          "91a843fb43": "More blocks",
+          "2cd9e0bbb3": "Headings",
+          "b05e14620d": "Heading 4",
+          "6bbf827ef5": "Heading 5",
+          "d1bbf9a835": "Collapsible section"
         },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "保存",
@@ -10918,7 +10923,11 @@
                 "3294a2c0cc": "创建一个带有大标题摘要的可折叠部分。",
                 "41482b15ce": "切换标题 1",
                 "570611864e": "大节标题。",
-                "e66e7f04c6": "标题 1"
+                "e66e7f04c6": "标题 1",
+                "5f9a0ed7c4": "Heading 4",
+                "01a71dbbdd": "Nested section heading.",
+                "8440fa4acf": "Heading 5",
+                "b287b93c66": "Deep section heading."
               }
             }
           }

--- a/src/shared/rich-markdown-context-menu.ts
+++ b/src/shared/rich-markdown-context-menu.ts
@@ -10,6 +10,8 @@ export type RichMarkdownContextMenuCommand =
   | 'heading-1'
   | 'heading-2'
   | 'heading-3'
+  | 'heading-4'
+  | 'heading-5'
   | 'bullet-list'
   | 'ordered-list'
   | 'task-list'


### PR DESCRIPTION
Fixes https://github.com/stablyai/orca/issues/6345

## Summary
- add H4/H5 markdown commands across slash commands, toolbar overflow, and rich context menu routing
- include H4/H5 in table-of-contents generation, collapse controls, and editor/preview styling
- update tests and localization catalog entries for the new heading controls

## Review
- Round 1: no Critical/High/Medium issues found

## Verification
- pnpm typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/main/window/editable-context-menu.test.ts src/renderer/src/components/editor/markdown-table-of-contents.test.ts src/renderer/src/components/editor/markdown-toc-collapse-state.test.ts src/renderer/src/components/editor/MarkdownTableOfContentsPanel.test.tsx src/renderer/src/components/editor/rich-markdown-commands.test.ts