### PR TITLE
Retry branch auto-rename when metadata is pending

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -45,6 +45,7 @@ import {
   FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT,
   maybeAutoRenameBranchOnFirstWork,
   resetFirstWorkBranchRenameState,
+  type AutoRenameBranchEligibility,
   type FirstWorkBranchRenameDeps
 } from './first-work-branch-rename'
 import {
@@ -376,6 +377,22 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
     expect(generateBranchNameMock).not.toHaveBeenCalled()
     expect(onRenamed).not.toHaveBeenCalled()
+  })
+
+  it('retries when Orca-created eligibility is not available on the first working event', async () => {
+    let eligibility: AutoRenameBranchEligibility = 'transient-unknown'
+    const { deps, onRenamed } = makeDeps({
+      getAutoRenameBranchEligibility: () => eligibility
+    })
+
+    await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+    expect(generateBranchNameMock).not.toHaveBeenCalled()
+
+    eligibility = 'eligible'
+    await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+
+    expect(generateBranchNameMock).toHaveBeenCalled()
+    expect(onRenamed).toHaveBeenCalledWith(REPO_ID)
   })
 
   it('suffixes the branch, display name, and folder together on collision', async () => {

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -42,6 +42,8 @@ export type FirstWorkBranchRenameEvent = {
   isReplay: boolean | undefined
 }
 
+export type AutoRenameBranchEligibility = 'eligible' | 'transient-unknown' | 'permanent-ineligible'
+
 export type FirstWorkBranchRenameDeps = {
   getSettings: () => GlobalSettings
   getRepo: (repoId: string) => Repo | undefined
@@ -54,6 +56,11 @@ export type FirstWorkBranchRenameDeps = {
   isPendingFirstAgentMessageRename?: (worktreeId: string) => boolean
   /** True only for Orca-created worktrees whose branch Orca is allowed to rename. */
   canRenameOrcaCreatedBranch: (worktreeId: string) => boolean
+  /**
+   * Classifies Orca-created branch metadata. Missing metadata can be transient
+   * during worktree creation, so it must not permanently settle auto-rename.
+   */
+  getAutoRenameBranchEligibility?: (worktreeId: string) => AutoRenameBranchEligibility
   /** Persist a new sidebar display name for the worktree. */
   setDisplayName: (worktreeId: string, displayName: string) => void
   /** Align the on-disk folder with the new branch leaf (best-effort, local-only). */
@@ -199,7 +206,14 @@ async function runAutoRename(
   if (!currentBranch || currentBranch === 'HEAD') {
     return retry(`no checked-out branch (${currentBranch || 'empty'})`)
   }
-  if (!deps.canRenameOrcaCreatedBranch(worktreeId)) {
+
+  const eligibility =
+    deps.getAutoRenameBranchEligibility?.(worktreeId) ??
+    (deps.canRenameOrcaCreatedBranch(worktreeId) ? 'eligible' : 'permanent-ineligible')
+  if (eligibility === 'transient-unknown') {
+    return retry('worktree auto-rename eligibility is not available yet')
+  }
+  if (eligibility === 'permanent-ineligible') {
     return stop(`worktree is not eligible for auto-rename`, true)
   }
   // Only rename a branch Orca auto-named — never one the user chose.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -255,6 +255,16 @@ function maybeAutoRenameBranchOnFirstWorkFromHook(event: {
         // Only worktrees Orca stamped at creation are safe to auto-rename.
         return !!meta?.orcaCreationSource && meta.preserveBranchOnDelete !== true
       },
+      getAutoRenameBranchEligibility: (worktreeId) => {
+        const meta = currentStore.getWorktreeMeta(worktreeId)
+        if (!meta) {
+          return 'transient-unknown'
+        }
+        if (!meta.orcaCreationSource || meta.preserveBranchOnDelete === true) {
+          return 'permanent-ineligible'
+        }
+        return 'eligible'
+      },
       setDisplayName: (worktreeId, displayName) => {
         const scope = parseWorkspaceKey(worktreeId)
         if (scope?.type === 'folder') {


### PR DESCRIPTION
## Background

First-work branch auto-rename intentionally dedupes each worktree after it reaches a terminal verdict. That is important because agent hook `working` events can fire repeatedly, and branch-name generation is comparatively expensive.

The bug is that the existing eligibility check used a boolean:

```ts
canRenameOrcaCreatedBranch(worktreeId) => boolean
```

In production that boolean is derived from worktree metadata:

- `orcaCreationSource` means Orca created the worktree and may rename the initial creature branch.
- `preserveBranchOnDelete` means the worktree came from an existing/user branch and must not be auto-renamed.

A missing metadata read was therefore indistinguishable from a true permanent ineligible case. If an early hook event arrived before the worktree metadata was available through the store, auto-rename returned “not eligible” and the worktree was added to `settledWorktreeIds`. Later valid `working` events for the same worktree were ignored before any retry could happen.

That explains the observed failure mode: the branch remains a creature name, no user-facing rename error is recorded, and manual replaying a valid hook event still does nothing because the process-level settled cache has already poisoned the worktree.

## Change

This PR splits auto-rename eligibility into three states:

- `eligible`: Orca-created worktree, safe to rename.
- `transient-unknown`: metadata is not available yet, so retry on a later hook event.
- `permanent-ineligible`: user/imported/preserved worktree, so settle and stop retrying.

The production caller now treats missing metadata as `transient-unknown`, while preserving the permanent skip for missing `orcaCreationSource` or `preserveBranchOnDelete === true`.

## Regression Coverage

Adds a test for the failure pattern directly:

1. First `working` event sees transient unknown eligibility and does not generate a branch name.
2. Second `working` event sees eligibility become available.
3. Auto-rename proceeds instead of being blocked by `settledWorktreeIds`.

## Tests

- `pnpm test src/main/agent-hooks/first-work-branch-rename.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/agent-hooks/first-work-branch-rename.ts src/main/agent-hooks/first-work-branch-rename.test.ts src/main/index.ts`

## ELI5

Branch auto-rename could permanently skip a worktree if metadata was not ready yet. It now retries when creation metadata is still pending instead of giving up forever.
