### PR TITLE
Fix split terminal tab focus target

### DIFF
--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -133,6 +133,7 @@ function resetStore(): void {
     reconcileWorktreeTabModel: vi.fn(() => ({ renderableTabCount: 0 })),
     settings: { activeRuntimeEnvironmentId: null },
     tabsByWorktree: { 'wt-1': [terminalTab] },
+    terminalLayoutsByTabId: {},
     unifiedTabsByWorktree: { 'wt-1': [unifiedTab] },
     activateTab: mocks.activateTab,
     closeBrowserTab: mocks.closeBrowserTab,
@@ -186,7 +187,36 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
     expect(mocks.activateTab).toHaveBeenCalledWith('unified-terminal-1')
     expect(mocks.setActiveTab).toHaveBeenCalledWith('terminal-1')
     expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal')
-    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1')
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1', null)
+  })
+
+  it('returns keyboard focus to the active split pane leaf when a terminal tab is activated', async () => {
+    storeBox.state = {
+      ...storeBox.state,
+      terminalLayoutsByTabId: {
+        'terminal-1': {
+          activeLeafId: 'right-leaf',
+          ptyIdsByLeafId: {
+            'left-leaf': 'pty-left',
+            'right-leaf': 'pty-right'
+          },
+          root: {
+            id: 'root-split',
+            direction: 'horizontal',
+            children: [
+              { id: 'left-leaf', type: 'pane' },
+              { id: 'right-leaf', type: 'pane' }
+            ]
+          }
+        }
+      }
+    }
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    model.commands.activateTerminal('terminal-1')
+
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1', 'right-leaf')
   })
 
   it('toggles pane expansion from the split-group tab bar collapse button', async () => {

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -201,13 +201,12 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
             'right-leaf': 'pty-right'
           },
           root: {
-            id: 'root-split',
+            type: 'split',
             direction: 'horizontal',
-            children: [
-              { id: 'left-leaf', type: 'pane' },
-              { id: 'right-leaf', type: 'pane' }
-            ]
-          }
+            first: { type: 'leaf', leafId: 'left-leaf' },
+            second: { type: 'leaf', leafId: 'right-leaf' }
+          },
+          expandedLeafId: null
         }
       }
     }

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -44,6 +44,9 @@ const EMPTY_GROUPS: readonly TabGroup[] = []
 const EMPTY_UNIFIED_TABS: readonly Tab[] = []
 const EMPTY_BROWSER_TABS: readonly BrowserTabState[] = []
 const EMPTY_TERMINAL_TABS: readonly TerminalTab[] = []
+const EMPTY_TERMINAL_LAYOUTS_BY_TAB_ID: NonNullable<
+  ReturnType<typeof useAppStore.getState>['terminalLayoutsByTabId']
+> = {}
 
 type TerminalTabItem = TerminalTab & { unifiedTabId: string }
 
@@ -67,6 +70,7 @@ export function useTabGroupWorkspaceModel({
       openFiles: state.openFiles,
       browserTabs: state.browserTabsByWorktree[worktreeId] ?? EMPTY_BROWSER_TABS,
       expandedPaneByTabId: state.expandedPaneByTabId,
+      terminalLayoutsByTabId: state.terminalLayoutsByTabId ?? EMPTY_TERMINAL_LAYOUTS_BY_TAB_ID,
       generatedTabTitlesEnabled: state.settings?.tabAutoGenerateTitle === true,
       mobileEmulatorEnabled: state.settings?.mobileEmulatorEnabled !== false
     }))
@@ -376,11 +380,21 @@ export function useTabGroupWorkspaceModel({
       }
       setActiveTab(terminalId)
       setActiveTabType('terminal')
-      // Why: clicking the tab button gives the browser focus to the tab strip
-      // after pointerdown; explicitly return it to xterm on the next frames.
-      focusTerminalTabSurface(terminalId)
+      const activeLeafId = worktreeState.terminalLayoutsByTabId[terminalId]?.activeLeafId ?? null
+      // Why: split terminal tab activation must restore xterm focus to the
+      // store-active leaf so keyboard input cannot drift to a sibling pane.
+      focusTerminalTabSurface(terminalId, activeLeafId)
     },
-    [activateTab, focusGroup, groupId, groupTabs, setActiveTab, setActiveTabType, worktreeId]
+    [
+      activateTab,
+      focusGroup,
+      groupId,
+      groupTabs,
+      setActiveTab,
+      setActiveTabType,
+      worktreeState.terminalLayoutsByTabId,
+      worktreeId
+    ]
   )
 
   const toggleTerminalPaneExpand = useCallback(


### PR DESCRIPTION
## Summary

- Restore terminal tab activation focus to the active split-pane leaf instead of the first xterm textarea in the tab.
- Add regression coverage for split terminal tabs whose store-active leaf is the right pane.
- Align the regression fixture with the real `TerminalLayoutSnapshot` split/leaf shape.

## User-facing changes

- Fixes terminal input routing after switching away from and back to a split terminal tab: typing returns to the active split pane instead of drifting into a sibling pane.
- No visual UI change.

## Screenshots

- Full-page Electron validation screenshot: `.orca-p0-terminal-repro-artifacts/cross-pane-focus-after-tab-return.png` (not committed).
- The screenshot shows Terminal 2 split into left/right panes after switching away and back, with the typed marker landing in the right pane.

## Testing checklist

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts`
- [x] `pnpm exec oxlint src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts`
- [x] `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json --pretty false`
- [x] Electron repro validation via temporary Playwright spec: split Terminal 2, focus right pane, switch to Terminal 1 and back, assert DOM-focused leaf equals store-active right leaf, type marker, verify PTY write goes to right pane only.
- [x] PR check `verify` passed on the latest pushed branch.

## AI Review Report

- CodeRabbit reported no actionable code comments on the latest review.
- CodeRabbit docstring coverage warning is non-actionable for this focused TypeScript behavior/test change; no public API or new exported function was introduced.
- Compatibility checked for macOS, Linux, and Windows: the change does not add platform-specific shortcuts, paths, shell behavior, or OS conditionals.

## Security Audit

- No authentication, authorization, secret handling, filesystem access, shell execution, network, IPC permission, or provider integration behavior changes.
- The change only passes existing client-side terminal layout state into the existing xterm focus helper.
- SSH/remote runtime behavior remains unchanged; remote tab activation still follows the existing runtime path before local DOM focus is restored.

## Notes

- Earlier `pnpm test -- src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts` unexpectedly ran the broader suite and was interrupted; the direct Vitest file filter above passed.