### PR TITLE
Repair stale split terminal PTY focus

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -58,6 +58,7 @@ import { useTerminalPaneContextMenu } from './use-terminal-pane-context-menu'
 import type { PreparedAgentSessionFork } from './terminal-agent-session-fork'
 import { useNotificationDispatch } from './use-notification-dispatch'
 import { connectPanePty } from './pty-connection'
+import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { shouldPreserveTerminalScrollbackBuffers } from '../../../../shared/workspace-session-terminal-buffers'
 import {
   getAllOverrides,
@@ -723,6 +724,11 @@ export default function TerminalPane({
     if (Object.keys(mergedPtyIds).length > 0) {
       layout.ptyIdsByLeafId = mergedPtyIds
     }
+    layout.activeLeafId = resolveTerminalLayoutActiveLeafId({
+      root: layout.root,
+      activeLeafId: layout.activeLeafId,
+      ptyIdsByLeafId: mergedPtyIds
+    })
     // Preserve pane titles — uses the live React state (via ref) rather than
     // the stale Zustand value because React state reflects in-flight title
     // edits that haven't been persisted yet.
@@ -853,6 +859,34 @@ export default function TerminalPane({
       delete nextBindings[leafId]
       setTabLayout(tabId, {
         ...layoutWithoutPtyBindings,
+        ...(Object.keys(nextBindings).length > 0 ? { ptyIdsByLeafId: nextBindings } : {})
+      })
+    },
+    [setTabLayout, tabId]
+  )
+
+  const clearExitedPanePtyLayoutBinding = useCallback(
+    (paneId: number, exitedPtyId: string): void => {
+      const existingLayout = useAppStore.getState().terminalLayoutsByTabId[tabId] ?? EMPTY_LAYOUT
+      const { ptyIdsByLeafId: _existingPtyIdsByLeafId, ...layoutWithoutPtyBindings } =
+        existingLayout
+      const existingBindings = existingLayout.ptyIdsByLeafId ?? {}
+      const leafId = managerRef.current?.getLeafId(paneId)
+      if (!leafId || existingBindings[leafId] !== exitedPtyId) {
+        return
+      }
+
+      const nextBindings = { ...existingBindings }
+      delete nextBindings[leafId]
+      // Why: a focused pane that lost its PTY can swallow input while a live
+      // sibling still exists, so unexpected exits repair focus to a bound leaf.
+      setTabLayout(tabId, {
+        ...layoutWithoutPtyBindings,
+        activeLeafId: resolveTerminalLayoutActiveLeafId({
+          root: existingLayout.root,
+          activeLeafId: existingLayout.activeLeafId,
+          ptyIdsByLeafId: nextBindings
+        }),
         ...(Object.keys(nextBindings).length > 0 ? { ptyIdsByLeafId: nextBindings } : {})
       })
     },
@@ -1031,6 +1065,7 @@ export default function TerminalPane({
     dispatchNotification,
     setCacheTimerStartedAt,
     syncPanePtyLayoutBinding,
+    clearExitedPanePtyLayoutBinding,
     setTabPaneExpanded,
     setTabCanExpandPane,
     setExpandedPane,
@@ -1248,7 +1283,8 @@ export default function TerminalPane({
         onShowSessionRestoredBanner: showRestoredSessionBanner,
         dispatchNotification,
         setCacheTimerStartedAt,
-        syncPanePtyLayoutBinding
+        syncPanePtyLayoutBinding,
+        clearExitedPanePtyLayoutBinding
       })
       panePtyBindingsRef.current.set(paneId, newPaneBinding)
       manager.setActivePane(paneId, { focus: true })
@@ -1270,6 +1306,7 @@ export default function TerminalPane({
       setCacheTimerStartedAt,
       setRuntimePaneTitle,
       suppressPtyExit,
+      clearExitedPanePtyLayoutBinding,
       syncPanePtyLayoutBinding,
       tabId,
       updateTabPtyId,

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -65,4 +65,5 @@ export type PtyConnectionDeps = {
   }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void
   syncPanePtyLayoutBinding: (paneId: number, ptyId: string | null) => void
+  clearExitedPanePtyLayoutBinding: (paneId: number, exitedPtyId: string) => void
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -397,6 +397,7 @@ function createDeps(overrides: Record<string, unknown> = {}) {
     onShowSessionRestoredBanner: vi.fn(),
     setCacheTimerStartedAt: vi.fn(),
     syncPanePtyLayoutBinding: vi.fn(),
+    clearExitedPanePtyLayoutBinding: vi.fn(),
     ...overrides
   }
 }
@@ -830,7 +831,7 @@ describe('connectPanePty', () => {
 
     onPtyExit?.('pty-pane-2')
 
-    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, null)
+    expect(deps.clearExitedPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'pty-pane-2')
     expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'pty-pane-2')
     expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
     expect(manager.closePane).not.toHaveBeenCalled()
@@ -3230,7 +3231,7 @@ describe('connectPanePty', () => {
       2,
       expect.not.objectContaining({ sessionId: expect.any(String) })
     )
-    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, null)
+    expect(deps.clearExitedPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'stale-pty')
     expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'stale-pty')
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'fresh-pty')
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-pty')
@@ -3271,7 +3272,7 @@ describe('connectPanePty', () => {
 
     expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
     expect(transport.connect).toHaveBeenCalledTimes(2)
-    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, null)
+    expect(deps.clearExitedPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'restored-session')
     expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'restored-session')
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'fresh-ssh-pty')
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-ssh-pty')
@@ -8545,7 +8546,7 @@ describe('connectPanePty', () => {
     expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
     expect(toastInfo).not.toHaveBeenCalled()
     expect(transport.connect).toHaveBeenCalledTimes(2)
-    expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, null)
+    expect(deps.clearExitedPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'expired-session')
     expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'expired-session')
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'fresh-ssh-pty')
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-ssh-pty')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1291,7 +1291,12 @@ export function connectPanePty(
   const onExit = (ptyId: string): void => {
     agentCompletionCoordinator.dispose()
     clearPanePtyFitBinding()
-    deps.syncPanePtyLayoutBinding(pane.id, null)
+    const isSuppressedExit = deps.consumeSuppressedPtyExit(ptyId)
+    if (isSuppressedExit) {
+      deps.syncPanePtyLayoutBinding(pane.id, null)
+    } else {
+      deps.clearExitedPanePtyLayoutBinding(pane.id, ptyId)
+    }
     deps.clearRuntimePaneTitle(deps.tabId, pane.id)
     deps.clearTabPtyId(deps.tabId, ptyId)
     // Why: if the PTY exits abruptly (Ctrl-D, crash, shell termination) without
@@ -1309,7 +1314,7 @@ export function connectPanePty(
     // pane stays mounted and can reconnect in place. Without consuming the
     // suppression here, split-pane Codex restarts would still close the pane
     // because this handler runs before the tab-level close logic sees the exit.
-    if (deps.consumeSuppressedPtyExit(ptyId)) {
+    if (isSuppressedExit) {
       manager.setPaneGpuRendering(pane.id, true)
       return
     }
@@ -3428,7 +3433,11 @@ export function connectPanePty(
         })
         // Why: a stale restored daemon/SSH session can fail reattach after the
         // pane is mounted. Do not leave xterm alive without a backing PTY.
-        deps.syncPanePtyLayoutBinding(pane.id, null)
+        if (staleSessionId) {
+          deps.clearExitedPanePtyLayoutBinding(pane.id, staleSessionId)
+        } else {
+          deps.syncPanePtyLayoutBinding(pane.id, null)
+        }
         if (staleSessionId) {
           deps.clearTabPtyId(deps.tabId, staleSessionId)
         }
@@ -3440,7 +3449,11 @@ export function connectPanePty(
         ...(coldRestoreStartup ? { launchAgent: coldRestoreStartup.agent } : {})
       })
       if (connectResult?.sessionExpired) {
-        deps.syncPanePtyLayoutBinding(pane.id, null)
+        if (staleSessionId) {
+          deps.clearExitedPanePtyLayoutBinding(pane.id, staleSessionId)
+        } else {
+          deps.syncPanePtyLayoutBinding(pane.id, null)
+        }
         if (staleSessionId) {
           deps.clearTabPtyId(deps.tabId, staleSessionId)
         }
@@ -3756,7 +3769,7 @@ export function connectPanePty(
                   if (disposed) {
                     return
                   }
-                  deps.syncPanePtyLayoutBinding(pane.id, null)
+                  deps.clearExitedPanePtyLayoutBinding(pane.id, pendingSessionId)
                   deps.clearTabPtyId(deps.tabId, pendingSessionId)
                   startFreshColdRestoreAgentResume(coldRestoreStartup)
                   return
@@ -3779,7 +3792,7 @@ export function connectPanePty(
                   return
                 }
                 if (isSshSessionExpiredError(err)) {
-                  deps.syncPanePtyLayoutBinding(pane.id, null)
+                  deps.clearExitedPanePtyLayoutBinding(pane.id, pendingSessionId)
                   deps.clearTabPtyId(deps.tabId, pendingSessionId)
                   startFreshColdRestoreAgentResume(coldRestoreStartup)
                   return
@@ -3925,7 +3938,7 @@ export function connectPanePty(
             if (disposed) {
               return
             }
-            deps.syncPanePtyLayoutBinding(pane.id, null)
+            deps.clearExitedPanePtyLayoutBinding(pane.id, deferredReattachSessionId)
             deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
             startFreshColdRestoreAgentResume(coldRestoreStartup)
             return
@@ -3952,7 +3965,7 @@ export function connectPanePty(
             ptyId: deferredReattachSessionId,
             reason: message
           })
-          deps.syncPanePtyLayoutBinding(pane.id, null)
+          deps.clearExitedPanePtyLayoutBinding(pane.id, deferredReattachSessionId)
           deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
           if (connectionId && isSshSessionExpiredError(err)) {
             startFreshColdRestoreAgentResume(coldRestoreStartup)

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -18,6 +18,7 @@ import { CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS } from '../../../../shared/clip
 describe('createIpcPtyTransport', () => {
   const originalWindow = (globalThis as { window?: typeof window }).window
   let onData: ((payload: { id: string; data: string }) => void) | null = null
+  let onReplay: ((payload: { id: string; data: string }) => void) | null = null
   let onExit: ((payload: { id: string; code: number }) => void) | null = null
 
   function flushPtySideEffects(): Promise<void> {
@@ -27,6 +28,7 @@ describe('createIpcPtyTransport', () => {
   beforeEach(() => {
     vi.resetModules()
     onData = null
+    onReplay = null
     onExit = null
 
     ;(globalThis as { window: typeof window }).window = {
@@ -44,7 +46,10 @@ describe('createIpcPtyTransport', () => {
             onData = callback
             return () => {}
           }),
-          onReplay: vi.fn(() => () => {}),
+          onReplay: vi.fn((callback: (payload: { id: string; data: string }) => void) => {
+            onReplay = callback
+            return () => {}
+          }),
           onExit: vi.fn((callback: (payload: { id: string; code: number }) => void) => {
             onExit = callback
             return () => {}
@@ -75,6 +80,61 @@ describe('createIpcPtyTransport', () => {
     expect(onData).not.toBeNull()
     expect(onExit).not.toBeNull()
     transport.disconnect()
+  })
+
+  it('ignores a stale exit for a previous PTY after reconnecting the same transport', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+    const onPtyExit = vi.fn()
+    spawn.mockResolvedValueOnce({ id: 'pty-old' }).mockResolvedValueOnce({ id: 'pty-new' })
+
+    const transport = createIpcPtyTransport({ onPtyExit })
+
+    await transport.connect({ url: '', callbacks: {} })
+    await transport.connect({ url: '', callbacks: {} })
+
+    onExit?.({ id: 'pty-old', code: 0 })
+
+    expect(onPtyExit).not.toHaveBeenCalledWith('pty-old')
+    expect(transport.getPtyId()).toBe('pty-new')
+    expect(transport.isConnected()).toBe(true)
+
+    onExit?.({ id: 'pty-new', code: 0 })
+
+    expect(onPtyExit).toHaveBeenCalledWith('pty-new')
+    expect(transport.getPtyId()).toBeNull()
+    expect(transport.isConnected()).toBe(false)
+  })
+
+  it('ignores stale data and replay for a previous PTY after reconnecting the same transport', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+    const onDataCallback = vi.fn()
+    const onReplayData = vi.fn()
+    spawn.mockResolvedValueOnce({ id: 'pty-old' }).mockResolvedValueOnce({ id: 'pty-new' })
+
+    const transport = createIpcPtyTransport({})
+
+    await transport.connect({
+      url: '',
+      callbacks: { onData: vi.fn(), onReplayData: vi.fn() }
+    })
+    await transport.connect({
+      url: '',
+      callbacks: { onData: onDataCallback, onReplayData }
+    })
+
+    onData?.({ id: 'pty-old', data: 'old data' })
+    onReplay?.({ id: 'pty-old', data: 'old replay' })
+
+    expect(onDataCallback).not.toHaveBeenCalled()
+    expect(onReplayData).not.toHaveBeenCalled()
+
+    onData?.({ id: 'pty-new', data: 'new data' })
+    onReplay?.({ id: 'pty-new', data: 'new replay' })
+
+    expect(onDataCallback).toHaveBeenCalledWith('new data')
+    expect(onReplayData).toHaveBeenCalledWith('new replay')
   })
 
   it('exposes the connection identity captured at transport creation', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -506,6 +506,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     // channel. Route it through onReplayData so the renderer engages the
     // replay guard and xterm auto-replies do not leak into the shell.
     ptyReplayHandlers.set(id, (data) => {
+      if (ptyId !== id) {
+        return
+      }
       if (storedCallbacks.onReplayData) {
         storedCallbacks.onReplayData(data)
       } else {
@@ -513,6 +516,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       }
     })
     const dataHandler = (data: string, meta?: PtyDataMeta): void => {
+      if (ptyId !== id) {
+        return
+      }
       outputProcessor.processData(
         data,
         storedCallbacks,
@@ -642,6 +648,12 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
 
   function registerPtyExitHandler(id: string): void {
     const exitHandler = (code: number): void => {
+      if (ptyId !== null && ptyId !== id) {
+        // Why: a preserved sleep/reconnect session can report its old exit
+        // after this transport has already rebound to a replacement PTY.
+        unregisterPtyHandlers(id)
+        return
+      }
       clearAccumulatedState()
       connected = false
       ptyId = null

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -123,6 +123,7 @@ describe('createRemoteRuntimePtyTransport', () => {
 
   beforeEach(() => {
     vi.resetModules()
+    vi.doUnmock('../../runtime/remote-runtime-terminal-multiplexer')
     vi.clearAllMocks()
     subscriptionCallbacks = null
     subscriptionSendBinary.mockReset()
@@ -290,6 +291,163 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(onError).not.toHaveBeenCalled()
     expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-stale')
     expect(transport.getPtyId()).toBeNull()
+  })
+
+  it('ignores stale stream end after reattaching a newer remote terminal', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onPtyExit = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      onPtyExit
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-old',
+      cols: 80,
+      rows: 24,
+      callbacks: {}
+    })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    const oldStreamId = latestSubscribePayload().streamId
+
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-new',
+      cols: 80,
+      rows: 24,
+      callbacks: {}
+    })
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: { type: 'end', streamId: oldStreamId }
+    })
+
+    expect(onPtyExit).not.toHaveBeenCalled()
+    expect(transport.getPtyId()).toBe('remote:env-1@@terminal-new')
+    expect(transport.isConnected()).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(latestSubscribePayload()).toMatchObject({ terminal: 'terminal-new' })
+    })
+    const newStreamId = latestSubscribePayload().streamId
+
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: { type: 'end', streamId: newStreamId }
+    })
+
+    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-new')
+    expect(transport.getPtyId()).toBeNull()
+    expect(transport.isConnected()).toBe(false)
+  })
+
+  it('ignores stale attach subscription rejection after reattaching a newer remote terminal', async () => {
+    let rejectOldSubscription: (error: Error) => void = () => {
+      throw new Error('old subscription reject was not captured')
+    }
+    const newStream = {
+      streamId: 2,
+      sendInput: vi.fn(() => true),
+      resize: vi.fn(() => true),
+      serializeBuffer: vi.fn(async () => null),
+      close: vi.fn()
+    }
+    const subscribeTerminal = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectOldSubscription = reject
+          })
+      )
+      .mockResolvedValueOnce(newStream)
+    vi.doMock('../../runtime/remote-runtime-terminal-multiplexer', () => ({
+      getRemoteRuntimeTerminalMultiplexer: vi.fn(() => ({ subscribeTerminal }))
+    }))
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const onPtyExit = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      onPtyExit
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-old',
+      cols: 80,
+      rows: 24,
+      callbacks: { onError }
+    })
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-new',
+      cols: 80,
+      rows: 24,
+      callbacks: { onError }
+    })
+    await vi.waitFor(() => expect(subscribeTerminal).toHaveBeenCalledTimes(2))
+
+    rejectOldSubscription(new Error('terminal_handle_stale'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onPtyExit).not.toHaveBeenCalled()
+    expect(transport.getPtyId()).toBe('remote:env-1@@terminal-new')
+    expect(transport.isConnected()).toBe(true)
+  })
+
+  it('does not send queued input through a stale stream during remote handle replacement', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-old',
+      cols: 80,
+      rows: 24,
+      callbacks: {}
+    })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+
+    vi.useFakeTimers()
+    try {
+      subscriptionSendBinary.mockClear()
+      runtimeCall.mockClear()
+
+      transport.attach({
+        existingPtyId: 'remote:env-1@@terminal-new',
+        cols: 80,
+        rows: 24,
+        callbacks: {}
+      })
+      subscriptionSendBinary.mockClear()
+
+      expect(transport.sendInput('x')).toBe(true)
+      vi.advanceTimersByTime(8)
+
+      const inputFrames = subscriptionSendBinary.mock.calls
+        .map((call) => decodeTerminalStreamFrame(call[0]))
+        .filter((frame) => frame?.opcode === TerminalStreamOpcode.Input)
+      expect(inputFrames).toEqual([])
+      expect(runtimeCall).toHaveBeenCalledWith({
+        selector: 'env-1',
+        method: 'terminal.send',
+        params: {
+          terminal: 'terminal-new',
+          text: 'x',
+          client: { id: 'desktop:tab-1:pane:1', type: 'desktop' }
+        },
+        timeoutMs: 15_000
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('closes a remote terminal created after the pane was destroyed', async () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -75,6 +75,7 @@ export function createRemoteRuntimePtyTransport(
   let remotePtyId: string | null = null
   let currentRuntimeEnvironmentId = runtimeEnvironmentId
   let multiplexedStream: RemoteRuntimeMultiplexedTerminal | null = null
+  let multiplexedStreamHandle: string | null = null
   let desiredViewport: { cols: number; rows: number } | null = null
   let storedCallbacks: Parameters<PtyTransport['connect']>[0]['callbacks'] = {}
   let resubscribing = false
@@ -266,7 +267,7 @@ export function createRemoteRuntimePtyTransport(
     if (!connected || !targetHandle) {
       return
     }
-    if (multiplexedStream?.sendInput(text)) {
+    if (getCurrentMultiplexedStream(targetHandle)?.sendInput(text)) {
       return
     }
     void callRuntime('terminal.send', {
@@ -283,7 +284,7 @@ export function createRemoteRuntimePtyTransport(
     if (!connected || !targetHandle) {
       return
     }
-    if (multiplexedStream?.resize(cols, rows)) {
+    if (getCurrentMultiplexedStream(targetHandle)?.resize(cols, rows)) {
       return
     }
     void callRuntime('terminal.updateViewport', {
@@ -302,13 +303,34 @@ export function createRemoteRuntimePtyTransport(
     desiredViewport = { cols, rows }
   }
 
+  function getCurrentMultiplexedStream(
+    targetHandle: string
+  ): RemoteRuntimeMultiplexedTerminal | null {
+    return multiplexedStreamHandle === targetHandle ? multiplexedStream : null
+  }
+
+  function closeMultiplexedStream(): void {
+    multiplexedStream?.close()
+    multiplexedStream = null
+    multiplexedStreamHandle = null
+  }
+
+  function isCurrentRemoteTerminal(targetHandle: string, targetPtyId: string | null): boolean {
+    return (
+      !destroyed &&
+      connected &&
+      handle === targetHandle &&
+      remotePtyId === targetPtyId &&
+      targetPtyId !== null
+    )
+  }
+
   function retireRemoteTerminalId(): void {
     connected = false
     const stalePtyId = remotePtyId
     handle = null
     remotePtyId = null
-    multiplexedStream?.close()
-    multiplexedStream = null
+    closeMultiplexedStream()
     if (stalePtyId) {
       onPtyExit?.(stalePtyId)
     }
@@ -331,6 +353,9 @@ export function createRemoteRuntimePtyTransport(
       return
     }
     const subscribedHandle = handle
+    const subscribedPtyId = remotePtyId
+    const isCurrentSubscription = (): boolean =>
+      isCurrentRemoteTerminal(subscribedHandle, subscribedPtyId)
     const nextStream = await getRemoteRuntimeTerminalMultiplexer(
       currentRuntimeEnvironmentId
     ).subscribeTerminal({
@@ -338,9 +363,13 @@ export function createRemoteRuntimePtyTransport(
       client: { id: clientId, type: 'desktop' },
       viewport: desiredViewport ?? undefined,
       callbacks: {
-        onData: (data, meta) => outputProcessor.processData(data, storedCallbacks, undefined, meta),
+        onData: (data, meta) => {
+          if (isCurrentSubscription()) {
+            outputProcessor.processData(data, storedCallbacks, undefined, meta)
+          }
+        },
         onSnapshot: (data) => {
-          if (data) {
+          if (data && isCurrentSubscription()) {
             outputProcessor.processData(data, storedCallbacks, {
               replayingBufferedData: true,
               suppressAttentionEvents: true
@@ -348,48 +377,74 @@ export function createRemoteRuntimePtyTransport(
           }
         },
         onSubscribed: () => {
+          if (!isCurrentSubscription()) {
+            return
+          }
           storedCallbacks.onConnect?.()
           storedCallbacks.onStatus?.('shell')
         },
         onEnd: () => {
+          if (!isCurrentSubscription()) {
+            return
+          }
           outputProcessor.clearAccumulatedState()
           connected = false
+          handle = null
+          remotePtyId = null
+          multiplexedStream = null
+          multiplexedStreamHandle = null
           storedCallbacks.onExit?.(0)
           storedCallbacks.onDisconnect?.()
-          if (remotePtyId) {
-            onPtyExit?.(remotePtyId)
+          if (subscribedPtyId) {
+            onPtyExit?.(subscribedPtyId)
           }
         },
-        onError: (message) => handleRemoteTerminalError(message),
+        onError: (message) => {
+          if (isCurrentSubscription()) {
+            handleRemoteTerminalError(message)
+          }
+        },
         onFitOverrideChanged: (event) => {
-          if (remotePtyId) {
-            setFitOverride(remotePtyId, event.mode, event.cols, event.rows)
+          if (isCurrentSubscription() && subscribedPtyId) {
+            setFitOverride(subscribedPtyId, event.mode, event.cols, event.rows)
           }
         },
         onDriverChanged: (driver) => {
-          if (remotePtyId) {
-            setDriverForPty(remotePtyId, driver)
+          if (isCurrentSubscription() && subscribedPtyId) {
+            setDriverForPty(subscribedPtyId, driver)
           }
         },
         onTransportClose: () => {
+          if (!isCurrentSubscription()) {
+            return
+          }
           multiplexedStream = null
+          multiplexedStreamHandle = null
           if (destroyed || !connected || !handle || resubscribing) {
             return
           }
           resubscribing = true
+          const resubscribeHandle = handle
+          const resubscribePtyId = remotePtyId
           void subscribeToHandle()
-            .catch((error) => handleRemoteTerminalError(error))
+            .catch((error) => {
+              if (isCurrentRemoteTerminal(resubscribeHandle, resubscribePtyId)) {
+                handleRemoteTerminalError(error)
+              }
+            })
             .finally(() => {
               resubscribing = false
             })
         }
       }
     })
-    if (destroyed || !connected || handle !== subscribedHandle) {
+    if (destroyed || !connected || handle !== subscribedHandle || remotePtyId !== subscribedPtyId) {
       nextStream.close()
       return
     }
+    closeMultiplexedStream()
     multiplexedStream = nextStream
+    multiplexedStreamHandle = subscribedHandle
   }
 
   return {
@@ -456,6 +511,7 @@ export function createRemoteRuntimePtyTransport(
       if (!handle) {
         connected = false
         remotePtyId = null
+        closeMultiplexedStream()
         storedCallbacks.onError?.('Remote runtime terminal id is invalid.')
         return
       }
@@ -465,7 +521,15 @@ export function createRemoteRuntimePtyTransport(
         cols: options.cols ?? 80,
         rows: options.rows ?? 24
       }
+      const targetHandle = handle
+      const targetPtyId = remotePtyId
       void subscribeToHandle().catch((error) => {
+        if (!isCurrentRemoteTerminal(targetHandle, targetPtyId)) {
+          return
+        }
+        if (handle === targetHandle && multiplexedStreamHandle !== targetHandle) {
+          closeMultiplexedStream()
+        }
         handleRemoteTerminalError(error)
       })
     },
@@ -480,8 +544,7 @@ export function createRemoteRuntimePtyTransport(
       }
       connected = false
       const id = remotePtyId
-      multiplexedStream?.close()
-      multiplexedStream = null
+      closeMultiplexedStream()
       handle = null
       remotePtyId = null
       storedCallbacks.onDisconnect?.()
@@ -496,8 +559,7 @@ export function createRemoteRuntimePtyTransport(
       viewportBatcher.flush()
       outputProcessor.clearAccumulatedState()
       connected = false
-      multiplexedStream?.close()
-      multiplexedStream = null
+      closeMultiplexedStream()
       storedCallbacks = {}
     },
 
@@ -539,10 +601,10 @@ export function createRemoteRuntimePtyTransport(
     },
 
     async serializeBuffer(opts) {
-      if (!connected || !multiplexedStream) {
+      if (!connected || !handle) {
         return null
       }
-      return multiplexedStream.serializeBuffer(opts)
+      return getCurrentMultiplexedStream(handle)?.serializeBuffer(opts) ?? null
     },
 
     destroy() {

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalPaneLayoutNode } from '../../../../shared/types'
+import {
+  normalizeTerminalLayoutSnapshot,
+  resolveTerminalLayoutActiveLeafId
+} from './terminal-layout-leaf-ids'
+
+const LEAF_1 = '11111111-1111-4111-8111-111111111111'
+const LEAF_2 = '22222222-2222-4222-8222-222222222222'
+const LEAF_3 = '33333333-3333-4333-8333-333333333333'
+
+function split(firstLeafId: string, secondLeafId: string): TerminalPaneLayoutNode {
+  return {
+    type: 'split',
+    direction: 'vertical',
+    first: { type: 'leaf', leafId: firstLeafId },
+    second: { type: 'leaf', leafId: secondLeafId }
+  }
+}
+
+describe('resolveTerminalLayoutActiveLeafId', () => {
+  it('keeps the active leaf when it is still PTY-bound', () => {
+    expect(
+      resolveTerminalLayoutActiveLeafId({
+        root: split(LEAF_1, LEAF_2),
+        activeLeafId: LEAF_2,
+        ptyIdsByLeafId: { [LEAF_1]: 'pty-1', [LEAF_2]: 'pty-2' }
+      })
+    ).toBe(LEAF_2)
+  })
+
+  it('repairs a stale active leaf to the first PTY-bound leaf in layout order', () => {
+    expect(
+      resolveTerminalLayoutActiveLeafId({
+        root: split(LEAF_1, LEAF_2),
+        activeLeafId: LEAF_1,
+        ptyIdsByLeafId: { [LEAF_2]: 'pty-2' }
+      })
+    ).toBe(LEAF_2)
+  })
+
+  it('ignores PTY bindings for leaves outside the layout root', () => {
+    expect(
+      resolveTerminalLayoutActiveLeafId({
+        root: split(LEAF_1, LEAF_2),
+        activeLeafId: LEAF_1,
+        ptyIdsByLeafId: { [LEAF_3]: 'stale-pty' }
+      })
+    ).toBe(LEAF_1)
+  })
+
+  it('falls back to a valid visual leaf when no PTY-bound leaf remains', () => {
+    expect(
+      resolveTerminalLayoutActiveLeafId({
+        root: split(LEAF_1, LEAF_2),
+        activeLeafId: LEAF_2,
+        ptyIdsByLeafId: {}
+      })
+    ).toBe(LEAF_2)
+  })
+})
+
+describe('normalizeTerminalLayoutSnapshot active leaf repair', () => {
+  it('repairs a hydrated active leaf that has lost its PTY while a sibling is bound', () => {
+    const result = normalizeTerminalLayoutSnapshot({
+      root: split(LEAF_1, LEAF_2),
+      activeLeafId: LEAF_1,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_2]: 'pty-2' }
+    })
+
+    expect(result.changed).toBe(true)
+    expect(result.snapshot.activeLeafId).toBe(LEAF_2)
+    expect(result.snapshot.ptyIdsByLeafId).toEqual({ [LEAF_2]: 'pty-2' })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
@@ -68,11 +68,59 @@ function firstLeafId(node: TerminalPaneLayoutNode | null): string | null {
   return node.type === 'leaf' ? node.leafId : firstLeafId(node.first)
 }
 
+function hasLeafPtyBinding(
+  ptyIdsByLeafId: Record<string, string> | undefined,
+  leafId: string
+): boolean {
+  return ptyIdsByLeafId ? Object.prototype.hasOwnProperty.call(ptyIdsByLeafId, leafId) : false
+}
+
+export function resolveTerminalLayoutActiveLeafId(opts: {
+  root: TerminalPaneLayoutNode | null | undefined
+  activeLeafId: string | null | undefined
+  ptyIdsByLeafId?: Record<string, string>
+}): string | null {
+  const leafIds = collectLeafIdsInOrder(opts.root)
+  if (leafIds.length === 0) {
+    return null
+  }
+
+  const leafIdSet = new Set(leafIds)
+  const activeLeafId = opts.activeLeafId ?? null
+  const hasBoundLeaf = leafIds.some((leafId) => hasLeafPtyBinding(opts.ptyIdsByLeafId, leafId))
+
+  if (
+    activeLeafId &&
+    leafIdSet.has(activeLeafId) &&
+    (!hasBoundLeaf || hasLeafPtyBinding(opts.ptyIdsByLeafId, activeLeafId))
+  ) {
+    return activeLeafId
+  }
+
+  if (hasBoundLeaf) {
+    return leafIds.find((leafId) => hasLeafPtyBinding(opts.ptyIdsByLeafId, leafId)) ?? null
+  }
+
+  return activeLeafId && leafIdSet.has(activeLeafId) ? activeLeafId : leafIds[0]
+}
+
 export function normalizeTerminalLayoutSnapshot(
   snapshot: TerminalLayoutSnapshot | null | undefined
 ): { snapshot: TerminalLayoutSnapshot; changed: boolean } {
   if (!snapshot?.root) {
-    return { snapshot: snapshot ?? EMPTY_TERMINAL_LAYOUT, changed: false }
+    const nextSnapshot = snapshot ?? EMPTY_TERMINAL_LAYOUT
+    const activeLeafId = resolveTerminalLayoutActiveLeafId({
+      root: nextSnapshot.root,
+      activeLeafId: nextSnapshot.activeLeafId,
+      ptyIdsByLeafId: nextSnapshot.ptyIdsByLeafId
+    })
+    return {
+      snapshot:
+        activeLeafId === nextSnapshot.activeLeafId
+          ? nextSnapshot
+          : { ...nextSnapshot, activeLeafId },
+      changed: activeLeafId !== nextSnapshot.activeLeafId
+    }
   }
   const counts = collectLeafCounts(snapshot.root)
   const duplicatedInputLeafIds = new Set(
@@ -93,11 +141,19 @@ export function normalizeTerminalLayoutSnapshot(
     }
   }
   if (!changed) {
+    const activeLeafId = resolveTerminalLayoutActiveLeafId({
+      root: snapshot.root,
+      activeLeafId: snapshot.activeLeafId,
+      ptyIdsByLeafId: snapshot.ptyIdsByLeafId
+    })
+    if (activeLeafId !== snapshot.activeLeafId) {
+      return { snapshot: { ...snapshot, activeLeafId }, changed: true }
+    }
     return { snapshot, changed: false }
   }
   const rewrite: LeafIdRewrite = { nextLeafIdByInputLeafId, duplicatedInputLeafIds }
   const root = cloneLayoutWithLeafRewrite(snapshot.root, rewrite)
-  const activeLeafId =
+  const remappedActiveLeafId =
     snapshot.activeLeafId && !duplicatedInputLeafIds.has(snapshot.activeLeafId)
       ? (nextLeafIdByInputLeafId.get(snapshot.activeLeafId) ?? null)
       : firstLeafId(root)
@@ -120,7 +176,11 @@ export function normalizeTerminalLayoutSnapshot(
     snapshot: {
       ...snapshotWithoutLeafRecords,
       root,
-      activeLeafId,
+      activeLeafId: resolveTerminalLayoutActiveLeafId({
+        root,
+        activeLeafId: remappedActiveLeafId,
+        ptyIdsByLeafId
+      }),
       expandedLeafId,
       ...(ptyIdsByLeafId ? { ptyIdsByLeafId } : {}),
       ...(buffersByLeafId ? { buffersByLeafId } : {}),

--- a/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts
@@ -4,6 +4,7 @@ import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 import { getUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111' as const
+const LEAF_ID_2 = '22222222-2222-4222-8222-222222222222' as const
 
 const mocks = vi.hoisted(() => ({
   flushTerminalOutput: vi.fn()
@@ -50,6 +51,24 @@ function mockRootForPane(paneId: number, leafId: string = LEAF_ID): HTMLDivEleme
     dataset: { paneId: String(paneId), leafId }
   })
   return new MockHTMLElement({ firstElementChild: pane }) as unknown as HTMLDivElement
+}
+
+function mockRootForSplit(firstPaneId: number, secondPaneId: number): HTMLDivElement {
+  const first = new MockHTMLElement({
+    classList: ['pane'],
+    dataset: { paneId: String(firstPaneId), leafId: LEAF_ID },
+    style: { flex: '1' }
+  })
+  const second = new MockHTMLElement({
+    classList: ['pane'],
+    dataset: { paneId: String(secondPaneId), leafId: LEAF_ID_2 },
+    style: { flex: '1' }
+  })
+  const split = new MockHTMLElement({
+    classList: ['pane-split'],
+    children: [first, second]
+  })
+  return new MockHTMLElement({ firstElementChild: split }) as unknown as HTMLDivElement
 }
 
 describe('captureTerminalShutdownLayout', () => {
@@ -212,5 +231,52 @@ describe('captureTerminalShutdownLayout', () => {
     expect(layout.scrollbackRefsByLeafId).toBeUndefined()
     expect(layout.ptyIdsByLeafId).toEqual({ [LEAF_ID]: 'pty-1' })
     expect(layout.titlesByLeafId).toEqual({ [LEAF_ID]: 'local shell' })
+  })
+
+  it('does not preserve stale prior PTY bindings as shutdown focus targets', async () => {
+    const { captureTerminalShutdownLayout } = await import('./terminal-shutdown-layout-capture')
+    const deadPane = {
+      id: 1,
+      leafId: LEAF_ID,
+      stablePaneId: LEAF_ID,
+      terminal: { options: { scrollback: 1_000 } },
+      serializeAddon: {
+        serialize: vi.fn(() => 'dead scrollback')
+      }
+    }
+    const livePane = {
+      id: 2,
+      leafId: LEAF_ID_2,
+      stablePaneId: LEAF_ID_2,
+      terminal: { options: { scrollback: 1_000 } },
+      serializeAddon: {
+        serialize: vi.fn(() => 'live scrollback')
+      }
+    }
+    const manager = {
+      getPanes: vi.fn(() => [deadPane, livePane]),
+      getActivePane: vi.fn(() => deadPane)
+    }
+
+    const layout = captureTerminalShutdownLayout({
+      manager: manager as never,
+      container: mockRootForSplit(1, 2),
+      expandedPaneId: null,
+      paneTransports: new Map([[2, { getPtyId: vi.fn(() => 'pty-live') }]]),
+      paneTitlesByPaneId: {},
+      existingLayout: {
+        root: null,
+        activeLeafId: LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_ID]: 'pty-stale', [LEAF_ID_2]: 'pty-live' }
+      }
+    })
+
+    expect(layout.activeLeafId).toBe(LEAF_ID_2)
+    expect(layout.ptyIdsByLeafId).toEqual({ [LEAF_ID_2]: 'pty-live' })
+    expect(layout.buffersByLeafId).toEqual({
+      [LEAF_ID]: 'dead scrollback',
+      [LEAF_ID_2]: 'live scrollback'
+    })
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts
@@ -279,4 +279,53 @@ describe('captureTerminalShutdownLayout', () => {
       [LEAF_ID_2]: 'live scrollback'
     })
   })
+
+  it('preserves prior PTY bindings while current pane transports are still attaching', async () => {
+    const { captureTerminalShutdownLayout } = await import('./terminal-shutdown-layout-capture')
+    const firstPane = {
+      id: 1,
+      leafId: LEAF_ID,
+      stablePaneId: LEAF_ID,
+      terminal: { options: { scrollback: 1_000 } },
+      serializeAddon: {
+        serialize: vi.fn(() => 'first scrollback')
+      }
+    }
+    const secondPane = {
+      id: 2,
+      leafId: LEAF_ID_2,
+      stablePaneId: LEAF_ID_2,
+      terminal: { options: { scrollback: 1_000 } },
+      serializeAddon: {
+        serialize: vi.fn(() => 'second scrollback')
+      }
+    }
+    const manager = {
+      getPanes: vi.fn(() => [firstPane, secondPane]),
+      getActivePane: vi.fn(() => secondPane)
+    }
+
+    const layout = captureTerminalShutdownLayout({
+      manager: manager as never,
+      container: mockRootForSplit(1, 2),
+      expandedPaneId: null,
+      paneTransports: new Map([
+        [1, { getPtyId: vi.fn(() => null) }],
+        [2, { getPtyId: vi.fn(() => null) }]
+      ]),
+      paneTitlesByPaneId: {},
+      existingLayout: {
+        root: null,
+        activeLeafId: LEAF_ID_2,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_ID]: 'pty-first', [LEAF_ID_2]: 'pty-second' }
+      }
+    })
+
+    expect(layout.activeLeafId).toBe(LEAF_ID_2)
+    expect(layout.ptyIdsByLeafId).toEqual({
+      [LEAF_ID]: 'pty-first',
+      [LEAF_ID_2]: 'pty-second'
+    })
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.ts
@@ -4,6 +4,7 @@ import type { PtyTransport } from './pty-transport'
 import { flushTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { serializeTerminalLayout } from './layout-serialization'
 import { mergeCapturedLeafState } from './merge-captured-leaf-state'
+import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT } from '../../../../shared/terminal-scrollback-limits'
 import { measureUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
 
@@ -117,10 +118,13 @@ export function captureTerminalShutdownLayout({
     fresh: {},
     currentLeafIds
   })
-  const mergedPtyIds = mergeCapturedLeafState({
-    prior: existingLayout?.ptyIdsByLeafId,
-    fresh: Object.fromEntries(ptyEntries),
-    currentLeafIds
+  const livePtyIdsByLeafId = Object.fromEntries(ptyEntries)
+  // Why: PTY bindings are live ownership, unlike scrollback history; merging
+  // prior IDs can resurrect dead panes as focus/input targets after restart.
+  layout.activeLeafId = resolveTerminalLayoutActiveLeafId({
+    root: layout.root,
+    activeLeafId: layout.activeLeafId,
+    ptyIdsByLeafId: livePtyIdsByLeafId
   })
   if (Object.keys(mergedBuffers).length > 0) {
     layout.buffersByLeafId = mergedBuffers
@@ -128,8 +132,8 @@ export function captureTerminalShutdownLayout({
   if (Object.keys(mergedScrollbackRefs).length > 0) {
     layout.scrollbackRefsByLeafId = mergedScrollbackRefs
   }
-  if (Object.keys(mergedPtyIds).length > 0) {
-    layout.ptyIdsByLeafId = mergedPtyIds
+  if (Object.keys(livePtyIdsByLeafId).length > 0) {
+    layout.ptyIdsByLeafId = livePtyIdsByLeafId
   }
 
   const titleEntries = panes

--- a/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.ts
@@ -102,9 +102,22 @@ export function captureTerminalShutdownLayout({
     new Map(panes.map((pane) => [pane.id, pane.leafId]))
   )
   const currentLeafIds = new Set(panes.map((p) => p.leafId))
-  const ptyEntries = panes
-    .map((pane) => [pane.leafId, paneTransports.get(pane.id)?.getPtyId() ?? null] as const)
-    .filter((entry): entry is readonly [ShutdownPane['leafId'], string] => entry[1] !== null)
+  const livePtyIdsByLeafId: Record<string, string> = {}
+  const preservedPtyIdsByLeafId: Record<string, string> = {}
+  for (const pane of panes) {
+    const transport = paneTransports.get(pane.id)
+    const livePtyId = transport?.getPtyId() ?? null
+    if (livePtyId) {
+      livePtyIdsByLeafId[pane.leafId] = livePtyId
+      continue
+    }
+    const priorPtyId = existingLayout?.ptyIdsByLeafId?.[pane.leafId]
+    if (transport && priorPtyId) {
+      // Why: shutdown can capture during the post-remount attach gap where
+      // each pane has a transport but the deferred PTY ID is still null.
+      preservedPtyIdsByLeafId[pane.leafId] = priorPtyId
+    }
+  }
 
   const mergedBuffers = captureBuffers
     ? mergeCapturedLeafState({
@@ -118,13 +131,11 @@ export function captureTerminalShutdownLayout({
     fresh: {},
     currentLeafIds
   })
-  const livePtyIdsByLeafId = Object.fromEntries(ptyEntries)
-  // Why: PTY bindings are live ownership, unlike scrollback history; merging
-  // prior IDs can resurrect dead panes as focus/input targets after restart.
+  const ptyIdsByLeafId = { ...preservedPtyIdsByLeafId, ...livePtyIdsByLeafId }
   layout.activeLeafId = resolveTerminalLayoutActiveLeafId({
     root: layout.root,
     activeLeafId: layout.activeLeafId,
-    ptyIdsByLeafId: livePtyIdsByLeafId
+    ptyIdsByLeafId
   })
   if (Object.keys(mergedBuffers).length > 0) {
     layout.buffersByLeafId = mergedBuffers
@@ -132,8 +143,8 @@ export function captureTerminalShutdownLayout({
   if (Object.keys(mergedScrollbackRefs).length > 0) {
     layout.scrollbackRefsByLeafId = mergedScrollbackRefs
   }
-  if (Object.keys(livePtyIdsByLeafId).length > 0) {
-    layout.ptyIdsByLeafId = livePtyIdsByLeafId
+  if (Object.keys(ptyIdsByLeafId).length > 0) {
+    layout.ptyIdsByLeafId = ptyIdsByLeafId
   }
 
   const titleEntries = panes

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -42,6 +42,7 @@ import {
   replayTerminalLayout,
   restoreScrollbackBuffers
 } from './layout-serialization'
+import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
 import {
@@ -203,6 +204,7 @@ type UseTerminalPaneLifecycleDeps = {
   }) => void
   setCacheTimerStartedAt: (key: string, ts: number | null) => void
   syncPanePtyLayoutBinding: (paneId: number, ptyId: string | null) => void
+  clearExitedPanePtyLayoutBinding: (paneId: number, exitedPtyId: string) => void
   setTabPaneExpanded: (tabId: string, expanded: boolean) => void
   setTabCanExpandPane: (tabId: string, canExpand: boolean) => void
   setExpandedPane: (paneId: number | null) => void
@@ -401,6 +403,7 @@ export function useTerminalPaneLifecycle({
   dispatchNotification,
   setCacheTimerStartedAt,
   syncPanePtyLayoutBinding,
+  clearExitedPanePtyLayoutBinding,
   setTabPaneExpanded,
   setTabCanExpandPane,
   setExpandedPane,
@@ -593,6 +596,7 @@ export function useTerminalPaneLifecycle({
       dispatchNotification,
       setCacheTimerStartedAt,
       syncPanePtyLayoutBinding,
+      clearExitedPanePtyLayoutBinding,
       restoredPtyIdByLeafId: initialLayoutRef.current.ptyIdsByLeafId ?? {}
     }
 
@@ -1019,6 +1023,24 @@ export function useTerminalPaneLifecycle({
         scheduleRuntimeGraphSync()
       },
       onActivePaneChange: (pane) => {
+        const layout = useAppStore.getState().terminalLayoutsByTabId[tabId]
+        const ptyIdsByLeafId = layout?.ptyIdsByLeafId ?? {}
+        if (Object.keys(ptyIdsByLeafId).length > 0 && !ptyIdsByLeafId[pane.leafId]) {
+          const fallbackLeafId = resolveTerminalLayoutActiveLeafId({
+            root: layout?.root,
+            activeLeafId: pane.leafId,
+            ptyIdsByLeafId
+          })
+          const fallbackPaneId = fallbackLeafId
+            ? (managerRef.current?.getNumericIdForLeaf(fallbackLeafId) ?? null)
+            : null
+          if (fallbackPaneId != null && fallbackPaneId !== pane.id) {
+            // Why: a pane whose PTY exited can remain visible; do not let a
+            // click park focus on a leaf that will swallow keyboard input.
+            managerRef.current?.setActivePane(fallbackPaneId, { focus: true })
+            return
+          }
+        }
         scheduleRuntimeGraphSync()
         if (shouldPersistLayout) {
           persistLayoutSnapshot()


### PR DESCRIPTION
## Summary

- clear split-pane PTY ownership through an exit-specific cleanup path that verifies the exited PTY still matches the pane
- repair active split-terminal leaf selection to a live PTY-backed leaf when stale/dead panes remain visible
- guard local and remote PTY transports so stale data/replay/end/exit events from old sessions cannot call the current callbacks or clear replacement sessions
- preserve valid prior PTY bindings during shutdown capture only for panes whose transports are still in the deferred attach gap

## User-facing changes

- Fixes a terminal behavior bug where clicking a split pane whose PTY died could leave focus/input on a dead pane, making typed input disappear or route incorrectly.
- Fixes a stale-event race where old PTY output or exit events could corrupt a replacement PTY session in the same pane.
- No visual UI change.

## Screenshots

No visual change.

## Testing checklist

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- [x] `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json --pretty false`
- [x] `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-transport.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.ts src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts`
- [x] `git diff --check`
- [x] Fresh read-only review agent: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` passed, 5 files / 283 tests.

## AI Review Report

- review-code found the initial PR direction good but incomplete because stale PTY transport events could still hit current callbacks or clear replacement sessions.
- Follow-up fix added local IPC transport guards, remote runtime stream guards, and shutdown-capture preservation for the transient attach gap.
- Fresh read-only review-code pass on commit `7281c1e9c` found no issues.
- Cross-platform review covered macOS, Linux, and Windows concerns: this change does not add shortcuts/labels, path parsing, shell selection, or OS-specific behavior, and remote/SSH runtime paths were explicitly reviewed.
- CodeRabbit reported no actionable code comments on the latest fix-up; the remaining docstring coverage warning is non-actionable for this focused internal terminal behavior/test change.

## Security Audit

- No credential, auth, network policy, or permission model changes.
- PTY/event handling is narrowed so stale terminal events cannot affect a newer session bound to the same pane.

## Notes

- Manual repro from investigation: split terminal, kill a pane PTY, then click/type into the dead pane. The fix keeps or repairs active focus to a surviving PTY-backed leaf and prevents stale transport events from corrupting the replacement session.
- Residual risk from the fresh review: no full end-to-end SSH/split-pane Electron session was rerun after the fix-up, but local/remote stale-event unit coverage is present and passing.