### PR TITLE
Fix image paste in Remote Host terminals

### DIFF
--- a/src/main/window/clipboard-image-temp-file.ts
+++ b/src/main/window/clipboard-image-temp-file.ts
@@ -9,6 +9,7 @@ import { assertClipboardImageByteLengthWithinLimit } from '../../shared/clipboar
 
 export type SaveClipboardImageAsTempFileArgs = {
   connectionId?: string | null
+  runtimeEnvironmentId?: string | null
 }
 
 const REMOTE_CLIPBOARD_IMAGE_TEMP_DIR = '/tmp'

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -24,7 +24,8 @@ const {
   clipboardWriteBufferMock,
   nativeImageCreateFromBufferMock,
   randomUUIDMock,
-  getSshFilesystemProviderMock
+  getSshFilesystemProviderMock,
+  callRuntimeEnvironmentMock
 } = vi.hoisted(() => ({
   removeHandlerMock: vi.fn(),
   handleMock: vi.fn(),
@@ -54,7 +55,8 @@ const {
   clipboardWriteBufferMock: vi.fn(),
   nativeImageCreateFromBufferMock: vi.fn(),
   randomUUIDMock: vi.fn(() => '00000000-0000-4000-8000-000000000000'),
-  getSshFilesystemProviderMock: vi.fn()
+  getSshFilesystemProviderMock: vi.fn(),
+  callRuntimeEnvironmentMock: vi.fn()
 }))
 
 vi.mock('node:child_process', () => ({
@@ -114,6 +116,10 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
     }
     return provider
   }
+}))
+
+vi.mock('../ipc/runtime-environment-transport-routing', () => ({
+  callRuntimeEnvironment: callRuntimeEnvironmentMock
 }))
 
 import {
@@ -191,6 +197,7 @@ describe('registerClipboardHandlers', () => {
     randomUUIDMock.mockReset()
     randomUUIDMock.mockReturnValue('00000000-0000-4000-8000-000000000000')
     getSshFilesystemProviderMock.mockReset()
+    callRuntimeEnvironmentMock.mockReset()
     setTrustedClipboardRendererWebContentsId(null)
   })
 
@@ -536,6 +543,129 @@ describe('registerClipboardHandlers', () => {
     ).resolves.toBe(expectedPath)
     expect(fsWriteFileMock).toHaveBeenCalledWith(expectedPath, png)
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
+  })
+
+  it('saves clipboard images through the selected remote runtime host', async () => {
+    const png = Buffer.alloc(512 * 1024)
+    const contentBase64 = png.toString('base64')
+    clipboardReadImageMock.mockReturnValue({
+      getSize: () => ({ height: 1, width: 1 }),
+      isEmpty: () => false,
+      toPNG: () => png
+    })
+    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => {
+      if (method === 'clipboard.startImageUpload') {
+        return { ok: true, result: { uploadId: 'upload-1' }, _meta: { runtimeId: 'runtime-1' } }
+      }
+      if (method === 'clipboard.appendImageUploadChunk') {
+        return {
+          ok: true,
+          result: { receivedBase64Length: contentBase64.length },
+          _meta: { runtimeId: 'runtime-1' }
+        }
+      }
+      if (method === 'clipboard.commitImageUpload') {
+        return {
+          ok: true,
+          result: '/tmp/orca-paste-remote.png',
+          _meta: { runtimeId: 'runtime-1' }
+        }
+      }
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    registerClipboardHandlers({} as never)
+
+    const handlers = getRegisteredHandlers()
+    await expect(
+      handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), {
+        runtimeEnvironmentId: 'remote-host-1'
+      })
+    ).resolves.toBe('/tmp/orca-paste-remote.png')
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      1,
+      '/tmp',
+      'remote-host-1',
+      'clipboard.startImageUpload',
+      { expectedBase64Length: contentBase64.length, connectionId: null },
+      30_000
+    )
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      2,
+      '/tmp',
+      'remote-host-1',
+      'clipboard.appendImageUploadChunk',
+      {
+        uploadId: 'upload-1',
+        offset: 0,
+        contentBase64: contentBase64.slice(0, 512 * 1024)
+      },
+      30_000
+    )
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      3,
+      '/tmp',
+      'remote-host-1',
+      'clipboard.appendImageUploadChunk',
+      {
+        uploadId: 'upload-1',
+        offset: 512 * 1024,
+        contentBase64: contentBase64.slice(512 * 1024, 1024 * 1024)
+      },
+      30_000
+    )
+    expect(callRuntimeEnvironmentMock).toHaveBeenNthCalledWith(
+      4,
+      '/tmp',
+      'remote-host-1',
+      'clipboard.commitImageUpload',
+      { uploadId: 'upload-1' },
+      30_000
+    )
+    expect(fsWriteFileMock).not.toHaveBeenCalled()
+    expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
+  })
+
+  it('aborts remote runtime clipboard image uploads when a chunk fails', async () => {
+    const png = Buffer.alloc(512 * 1024)
+    clipboardReadImageMock.mockReturnValue({
+      getSize: () => ({ height: 1, width: 1 }),
+      isEmpty: () => false,
+      toPNG: () => png
+    })
+    callRuntimeEnvironmentMock.mockImplementation(async (_userDataPath, _runtimeId, method) => {
+      if (method === 'clipboard.startImageUpload') {
+        return { ok: true, result: { uploadId: 'upload-1' }, _meta: { runtimeId: 'runtime-1' } }
+      }
+      if (method === 'clipboard.appendImageUploadChunk') {
+        return {
+          ok: false,
+          error: { code: 'runtime_error', message: 'append failed' },
+          _meta: { runtimeId: 'runtime-1' }
+        }
+      }
+      if (method === 'clipboard.abortImageUpload') {
+        return { ok: true, result: { aborted: true }, _meta: { runtimeId: 'runtime-1' } }
+      }
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    registerClipboardHandlers({} as never)
+
+    const handlers = getRegisteredHandlers()
+    await expect(
+      handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), {
+        runtimeEnvironmentId: 'remote-host-1'
+      })
+    ).rejects.toThrow('append failed')
+    expect(callRuntimeEnvironmentMock).toHaveBeenLastCalledWith(
+      '/tmp',
+      'remote-host-1',
+      'clipboard.abortImageUpload',
+      { uploadId: 'upload-1' },
+      30_000
+    )
+    expect(fsWriteFileMock).not.toHaveBeenCalled()
   })
 
   it('uploads clipboard images to the SSH host when a connection is provided', async () => {

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -1,4 +1,5 @@
 import {
+  app,
   clipboard,
   ipcMain,
   nativeImage,
@@ -32,12 +33,25 @@ import {
   cleanupExpiredRemoteClipboardFiles,
   writeRemoteFileToClipboard
 } from './clipboard-remote-file-copy'
+import { saveClipboardImageBufferInRuntime } from './clipboard-runtime-image-upload'
 
 let trustedClipboardRendererWebContentsId: number | null = null
 
 type ClipboardWriteFileRequest = {
   filePath: string
   connectionId?: string
+}
+
+async function saveClipboardImageBufferForTarget(
+  buffer: Buffer,
+  args?: SaveClipboardImageAsTempFileArgs
+): Promise<string> {
+  assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
+  const runtimeEnvironmentId = args?.runtimeEnvironmentId?.trim()
+  if (runtimeEnvironmentId && !args?.connectionId) {
+    return saveClipboardImageBufferInRuntime(app.getPath('userData'), runtimeEnvironmentId, buffer)
+  }
+  return saveClipboardImageBufferAsTempFile(buffer, args)
 }
 
 export function setTrustedClipboardRendererWebContentsId(webContentsId: number | null): void {
@@ -91,7 +105,7 @@ export function registerClipboardHandlers(store: Store): void {
         return null
       }
       assertClipboardImageDimensionsWithinLimit(image.getSize())
-      return saveClipboardImageBufferAsTempFile(image.toPNG(), args)
+      return saveClipboardImageBufferForTarget(image.toPNG(), args)
     }
   )
   // Why: copy the actual file to the OS clipboard so pasting in Finder/Explorer

--- a/src/main/window/clipboard-runtime-image-upload.ts
+++ b/src/main/window/clipboard-runtime-image-upload.ts
@@ -1,0 +1,118 @@
+import { assertClipboardImageByteLengthWithinLimit } from '../../shared/clipboard-image'
+import { callRuntimeEnvironment } from '../ipc/runtime-environment-transport-routing'
+
+const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
+const CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS = 256 * 1024
+const CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS = 30_000
+
+async function callRuntimeClipboardMethod<TResult>(
+  userDataPath: string,
+  runtimeEnvironmentId: string,
+  method: string,
+  params: unknown
+): Promise<TResult> {
+  const response = await callRuntimeEnvironment(
+    userDataPath,
+    runtimeEnvironmentId,
+    method,
+    params,
+    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
+  )
+  if (!response.ok) {
+    throw new Error(response.error.message)
+  }
+  return response.result as TResult
+}
+
+async function saveClipboardImageBase64InRuntime(
+  userDataPath: string,
+  runtimeEnvironmentId: string,
+  contentBase64: string
+): Promise<string> {
+  const startResponse = await callRuntimeEnvironment(
+    userDataPath,
+    runtimeEnvironmentId,
+    'clipboard.startImageUpload',
+    { expectedBase64Length: contentBase64.length, connectionId: null },
+    CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
+  )
+  if (!startResponse.ok) {
+    if (
+      startResponse.error.code === 'method_not_found' &&
+      contentBase64.length <= CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS
+    ) {
+      return callRuntimeClipboardMethod<string>(
+        userDataPath,
+        runtimeEnvironmentId,
+        'clipboard.saveImageAsTempFile',
+        { contentBase64, connectionId: null }
+      )
+    }
+    throw new Error(startResponse.error.message)
+  }
+  const result = startResponse.result
+  if (
+    !result ||
+    typeof result !== 'object' ||
+    typeof (result as { uploadId?: unknown }).uploadId !== 'string'
+  ) {
+    throw new Error('Remote clipboard image upload returned an invalid id')
+  }
+  const { uploadId } = result as { uploadId: string }
+  try {
+    for (
+      let offset = 0;
+      offset < contentBase64.length;
+      offset += CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
+    ) {
+      await callRuntimeClipboardMethod(
+        userDataPath,
+        runtimeEnvironmentId,
+        'clipboard.appendImageUploadChunk',
+        {
+          uploadId,
+          offset,
+          contentBase64: contentBase64.slice(
+            offset,
+            offset + CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
+          )
+        }
+      )
+    }
+    const remotePath = await callRuntimeClipboardMethod<string>(
+      userDataPath,
+      runtimeEnvironmentId,
+      'clipboard.commitImageUpload',
+      { uploadId }
+    )
+    if (typeof remotePath !== 'string') {
+      throw new Error('Remote clipboard image save returned an invalid path')
+    }
+    return remotePath
+  } catch (error) {
+    // Why: failed chunked pastes should release the remote upload slot
+    // immediately instead of waiting for TTL cleanup.
+    await callRuntimeClipboardMethod(
+      userDataPath,
+      runtimeEnvironmentId,
+      'clipboard.abortImageUpload',
+      {
+        uploadId
+      }
+    ).catch(() => {})
+    throw error
+  }
+}
+
+export function saveClipboardImageBufferInRuntime(
+  userDataPath: string,
+  runtimeEnvironmentId: string,
+  buffer: Buffer
+): Promise<string> {
+  assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
+  return saveClipboardImageBase64InRuntime(
+    userDataPath,
+    runtimeEnvironmentId,
+    buffer.toString('base64')
+  )
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2476,6 +2476,7 @@ export type PreloadApi = {
     readSelectionClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
     saveClipboardImageAsTempFile: (args?: {
       connectionId?: string | null
+      runtimeEnvironmentId?: string | null
     }) => Promise<string | null>
     writeClipboardText: (text: string) => Promise<void>
     writeSelectionClipboardText: (text: string) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3259,6 +3259,7 @@ const api = {
       ipcRenderer.invoke('clipboard:readSelectionText', options),
     saveClipboardImageAsTempFile: (args?: {
       connectionId?: string | null
+      runtimeEnvironmentId?: string | null
     }): Promise<string | null> => ipcRenderer.invoke('clipboard:saveImageAsTempFile', args),
     writeClipboardText: (text: string): Promise<void> =>
       ipcRenderer.invoke('clipboard:writeText', text),

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -19,6 +19,7 @@ import TerminalSearch from '@/components/TerminalSearch'
 import type { PtyTransport } from './pty-transport'
 import { fitPanes, isWindowsUserAgent } from './pane-helpers'
 import { getConnectionId } from '@/lib/connection-context'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { handleInternalTerminalFileDrop } from './terminal-drop-handler'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { EMPTY_LAYOUT, serializeTerminalLayout } from './layout-serialization'
@@ -1597,11 +1598,16 @@ export default function TerminalPane({
       source: Extract<TerminalPasteSource, 'keyboard' | 'paste-event'>
     ): void => {
       const connectionId = getConnectionId(worktreeId) ?? null
+      const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
+        useAppStore.getState(),
+        worktreeId
+      )
       const activeElementAtDispatch = document.activeElement
       void pasteTerminalClipboard({
         readClipboardText: window.api.ui.readClipboardText,
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
+        runtimeEnvironmentId,
         forceBracketedMultilineTextPaste,
         pasteText: (text, options) =>
           executePanePasteText(pane, source, activeElementAtDispatch, text, options),
@@ -1722,10 +1728,15 @@ export default function TerminalPane({
         return
       }
       const connectionId = getConnectionId(worktreeId) ?? null
+      const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
+        useAppStore.getState(),
+        worktreeId
+      )
       void pasteTerminalClipboard({
         readClipboardText: window.api.ui.readClipboardText,
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
+        runtimeEnvironmentId,
         forceBracketedMultilineTextPaste,
         pasteText: (text, options) =>
           executePanePasteText(pane, 'app-menu', activeElementAtDispatch, text, options),

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -98,8 +98,34 @@ describe('terminal clipboard paste', () => {
       pasteText
     })
 
-    expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({ connectionId: 'ssh-1' })
+    expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
+      connectionId: 'ssh-1',
+      runtimeEnvironmentId: undefined
+    })
     expect(pasteText).toHaveBeenCalledWith('/var/tmp/orca-paste-1760000000000-id.png', {
+      forceBracketedPaste: true,
+      recoverImagePasteWebglAtlas: true
+    })
+  })
+
+  it('forwards remote runtime context and bracket-pastes the runtime image path', async () => {
+    const pasteText = vi.fn()
+    const saveClipboardImageAsTempFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/orca-paste-1760000000000-runtime.png')
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      saveClipboardImageAsTempFile,
+      runtimeEnvironmentId: 'remote-host-1',
+      pasteText
+    })
+
+    expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
+      connectionId: undefined,
+      runtimeEnvironmentId: 'remote-host-1'
+    })
+    expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1760000000000-runtime.png', {
       forceBracketedPaste: true,
       recoverImagePasteWebglAtlas: true
     })
@@ -134,7 +160,10 @@ describe('terminal clipboard paste', () => {
       pasteText
     })
 
-    expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({ connectionId: undefined })
+    expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
+      connectionId: undefined,
+      runtimeEnvironmentId: undefined
+    })
     expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1760000000000-id.png', {
       forceBracketedPaste: true,
       recoverImagePasteWebglAtlas: true

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -9,6 +9,7 @@ import {
 
 type SaveClipboardImageAsTempFile = (args?: {
   connectionId?: string | null
+  runtimeEnvironmentId?: string | null
 }) => Promise<string | null>
 
 type PasteTerminalClipboardDeps = {
@@ -19,6 +20,7 @@ type PasteTerminalClipboardDeps = {
     options?: TerminalPasteTextOptions
   ) => boolean | void | Promise<boolean | void>
   connectionId?: string | null
+  runtimeEnvironmentId?: string | null
   forceBracketedMultilineTextPaste?: boolean
   onTextPasteError?: (error: unknown) => void
   onImagePasteError?: (error: unknown) => void
@@ -42,6 +44,7 @@ export async function pasteTerminalClipboard({
   saveClipboardImageAsTempFile,
   pasteText,
   connectionId,
+  runtimeEnvironmentId,
   forceBracketedMultilineTextPaste = false,
   onTextPasteError,
   onImagePasteError
@@ -73,7 +76,7 @@ export async function pasteTerminalClipboard({
   }
 
   try {
-    const filePath = await saveClipboardImageAsTempFile({ connectionId })
+    const filePath = await saveClipboardImageAsTempFile({ connectionId, runtimeEnvironmentId })
     if (!filePath) {
       return { status: 'skipped', reason: 'empty' }
     }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
 import { getConnectionId } from '@/lib/connection-context'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import type { PaneCwdMap } from './resolve-split-cwd'
 import type { TerminalQuickCommand } from '../../../../shared/types'
 import { isTerminalAgentQuickCommand } from '../../../../shared/terminal-quick-commands'
@@ -286,10 +287,15 @@ export function useTerminalPaneContextMenu({
       return
     }
     const connectionId = getConnectionId(worktreeId) ?? null
+    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
+      useAppStore.getState(),
+      worktreeId
+    )
     const result = await pasteTerminalClipboard({
       readClipboardText: window.api.ui.readClipboardText,
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
       connectionId,
+      runtimeEnvironmentId,
       forceBracketedMultilineTextPaste,
       pasteText: (text, options) => executeMenuPasteText(pane, source, text, options),
       onTextPasteError: () =>

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2024,7 +2024,10 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       ),
     readSelectionClipboardText: () =>
       Promise.reject(new Error('Selection clipboard is unavailable in the web client')),
-    saveClipboardImageAsTempFile: async (args?: { connectionId?: string | null }) => {
+    saveClipboardImageAsTempFile: async (args?: {
+      connectionId?: string | null
+      runtimeEnvironmentId?: string | null
+    }) => {
       if (!requireActiveEnvironmentOrNull()) {
         return null
       }
@@ -2532,7 +2535,7 @@ async function callRuntimeResult<TResult>(
 
 async function saveClipboardImageAsTempFileInRuntime(
   contentBase64: string,
-  args?: { connectionId?: string | null }
+  args?: { connectionId?: string | null; runtimeEnvironmentId?: string | null }
 ): Promise<string> {
   if (contentBase64.length > MAX_CLIPBOARD_IMAGE_BASE64_CHARS) {
     throw new Error(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)


### PR DESCRIPTION
## Summary
- pass the owning runtime environment through terminal image paste requests
- save desktop clipboard images on Remote Host runtimes via chunked clipboard upload instead of local temp files
- add regression coverage for chunked Remote Host image paste and failed-upload abort cleanup

Addresses one image-paste failure mode from #6364 without closing the issue.

## Reproduction
- Set up a local headless Remote Host on `ws://127.0.0.1:19763` and paired the desktop dev app to it.
- Reproduced the original bad behavior where image paste in a Remote Host terminal produced a local macOS `/var/folders/.../orca-paste-*.png` path.
- After threading `runtimeEnvironmentId`, reproduced the follow-up transport failure from a one-shot image RPC: `Remote Orca runtime closed the connection (1009)`.
- Fixed by using the runtime clipboard chunk upload protocol (`clipboard.startImageUpload` / `appendImageUploadChunk` / `commitImageUpload`) for desktop Remote Host paste.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/clipboard-ipc-handlers.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm run build:cli`
- `pnpm run build:electron-vite`

Note: `build:cli` completed with the existing `/usr/local/bin/orca-dev` symlink permission warning.