### PR TITLE
fix: forward Ctrl+Enter as kitty CSI-u so TUIs can cue instead of send

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -107,6 +107,43 @@ describe('resolveTerminalShortcutAction', () => {
     })
   })
 
+  it('forwards Ctrl+Enter as the kitty CSI-u chord so TUIs can cue instead of send', () => {
+    // Why: xterm.js collapses Ctrl+Enter to a bare CR; intercept upstream and
+    // emit the kitty sequence (modifier code 5 = Ctrl) so probing TUIs (e.g.
+    // Factory Droid CLI) receive the distinct chord on every platform.
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', ctrlKey: true }), true)
+    ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', ctrlKey: true }), false)
+    ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
+    // Windows uses the same kitty sequence for now: no TUI is known to treat the
+    // CSI-u Ctrl+Enter form as inert (cf. the Shift+Enter Codex-on-PowerShell case).
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', ctrlKey: true }),
+        false,
+        'false',
+        0,
+        true
+      )
+    ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
+
+    // Modifier combos that are NOT plain Ctrl+Enter must keep falling through.
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', ctrlKey: true, shiftKey: true }),
+        true
+      )
+    ).toBeNull()
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', ctrlKey: true, metaKey: true }),
+        true
+      )
+    ).toBeNull()
+  })
+
   it('translates Cmd+←/→ on macOS to readline start/end-of-line (Ctrl+A/E)', () => {
     expect(
       resolveTerminalShortcutAction(

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -109,8 +109,8 @@ describe('resolveTerminalShortcutAction', () => {
 
   it('forwards Ctrl+Enter as the kitty CSI-u chord so TUIs can cue instead of send', () => {
     // Why: xterm.js collapses Ctrl+Enter to a bare CR; intercept upstream and
-    // emit the kitty sequence (modifier code 5 = Ctrl) so probing TUIs (e.g.
-    // Factory Droid CLI) receive the distinct chord on every platform.
+    // emit the kitty sequence (modifier code 5 = Ctrl) so probing TUIs receive
+    // the distinct chord on every platform.
     expect(
       resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', ctrlKey: true }), true)
     ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -110,14 +110,13 @@ export function resolveTerminalShortcutAction(
     !event.shiftKey &&
     event.key === 'Enter'
   ) {
-    // Why: xterm.js collapses Ctrl+Enter to a bare CR, so TUIs that probe the
-    // kitty keyboard handshake (CSI ? u) — e.g. the Factory Droid CLI — never
-    // receive the distinct chord and treat it as a plain Enter. Forward the
-    // kitty CSI-u sequence directly (modifier code 5 = Ctrl; cf. 2 = Shift
-    // above) so the cue/queue behavior reaches the TUI. Sibling of the
-    // Shift+Enter case; a Windows fallback is not added yet because, unlike
-    // #2418's Codex-on-PowerShell inertness, no Windows TUI is known to drop
-    // the CSI-u form for Ctrl+Enter.
+    // Why: xterm.js collapses Ctrl+Enter to a bare CR, so TUIs that expect
+    // modified Enter chords never receive the distinct input and treat it as
+    // plain Enter. Forward the kitty CSI-u sequence directly (modifier code
+    // 5 = Ctrl; cf. 2 = Shift above) so cue/queue behavior reaches the TUI.
+    // Sibling of the Shift+Enter case; a Windows fallback is not added yet
+    // because, unlike #2418's Codex-on-PowerShell inertness, no Windows TUI is
+    // known to drop the CSI-u form for Ctrl+Enter.
     return { type: 'sendInput', data: '\x1b[13;5u' }
   }
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -108,6 +108,24 @@ export function resolveTerminalShortcutAction(
     !event.metaKey &&
     !event.altKey &&
     !event.shiftKey &&
+    event.key === 'Enter'
+  ) {
+    // Why: xterm.js collapses Ctrl+Enter to a bare CR, so TUIs that probe the
+    // kitty keyboard handshake (CSI ? u) — e.g. the Factory Droid CLI — never
+    // receive the distinct chord and treat it as a plain Enter. Forward the
+    // kitty CSI-u sequence directly (modifier code 5 = Ctrl; cf. 2 = Shift
+    // above) so the cue/queue behavior reaches the TUI. Sibling of the
+    // Shift+Enter case; a Windows fallback is not added yet because, unlike
+    // #2418's Codex-on-PowerShell inertness, no Windows TUI is known to drop
+    // the CSI-u form for Ctrl+Enter.
+    return { type: 'sendInput', data: '\x1b[13;5u' }
+  }
+
+  if (
+    event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.shiftKey &&
     event.key === 'Backspace'
   ) {
     return { type: 'sendInput', data: '\x17' }

--- a/tests/e2e/terminal-shortcuts.spec.ts
+++ b/tests/e2e/terminal-shortcuts.spec.ts
@@ -495,6 +495,16 @@ test.describe('Terminal Shortcuts', () => {
     )
   })
 
+  test('Ctrl+Enter writes the kitty modified-enter chord for terminal TUIs', async ({
+    orcaPage,
+    electronApp
+  }) => {
+    await installMainProcessPtyWriteSpy(electronApp)
+    await waitForActivePanePtyId(orcaPage)
+
+    await pressAndExpectWrite(orcaPage, electronApp, 'Control+Enter', '\x1b[13;5u')
+  })
+
   test('plain Ctrl+C sends ETX under kitty keyboard reporting', async ({
     orcaPage,
     electronApp


### PR DESCRIPTION
Fixes #5966.

## Summary
Inside an Orca embedded terminal, **Control+Enter** was delivered to TUIs as a bare `\r` (plain Enter) instead of the distinct Ctrl+Enter chord. Programs that probe the kitty keyboard handshake (`CSI ? u`) — e.g. the Factory Droid CLI, which uses Ctrl+Enter to cue/queue a message rather than send it — therefore behaved as if the user pressed Enter. The same Droid build works in macOS Terminal / iTerm2.

## Root cause
Orca advertises kitty keyboard support and the renderer's capture-phase listener (`keyboard-handlers.ts`) already forwards **Shift+Enter** as `\x1b[13;2u` via `sendInput`. **Ctrl+Enter** had no sibling branch, so it fell through to xterm, which collapses it to bare CR.

## Change
`terminal-shortcut-policy.ts` — added a sibling branch that intercepts Ctrl+Enter (no other modifiers) and forwards the kitty CSI-u `\x1b[13;5u` (modifier code 5 = Ctrl) directly to the PTY. No Windows fallback yet; unlike #2418's Codex-on-PowerShell inertness for Shift+Enter, no Windows TUI is known to drop the CSI-u form for Ctrl+Enter.

## Tests
`terminal-shortcut-policy.test.ts` — covers macOS/Linux/Windows all emitting `\x1b[13;5u`, plus regression guards for Ctrl+Shift+Enter and Ctrl+Cmd+Enter.

## Verification
- vitest terminal-shortcut-policy.test.ts -> 17/17
- vitest terminal-pane/ -> 1096/1096
- oxlint + tsgo web typecheck -> clean
- Manually verified in `pnpm dev` against the Droid CLI: Ctrl+Enter cues instead of sending.