### PR TITLE
Make permission attention indicators consistent

### DIFF
--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -39,14 +39,17 @@ describe('AgentStateDot', () => {
     expect(markup).toContain('text-emerald-500')
   })
 
-  it('renders permission as an amber attention dot', () => {
-    const classNames = renderDotClassNames('permission')
+  it.each(['permission', 'waiting'] satisfies AgentDotState[])(
+    'renders %s as an amber attention dot',
+    (state) => {
+      const classNames = renderDotClassNames(state)
 
-    expect(classNames).toContain('bg-amber-500')
-    expect(classNames).not.toContain('bg-red-500')
-  })
+      expect(classNames).toContain('bg-amber-500')
+      expect(classNames).not.toContain('bg-red-500')
+    }
+  )
 
-  it.each(['blocked', 'waiting', 'interrupted'] satisfies AgentDotState[])(
+  it.each(['blocked', 'interrupted'] satisfies AgentDotState[])(
     'renders %s as a red attention dot',
     (state) => {
       const classNames = renderDotClassNames(state)

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -103,9 +103,9 @@ export const AgentStateDot = React.memo(function AgentStateDot({
         className={cn(
           'block rounded-full',
           inner,
-          state === 'permission'
+          state === 'permission' || state === 'waiting'
             ? 'bg-amber-500'
-            : state === 'blocked' || state === 'waiting' || state === 'interrupted'
+            : state === 'blocked' || state === 'interrupted'
               ? 'bg-red-500'
               : 'bg-neutral-500/40'
         )}

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -239,6 +239,24 @@ describe('DashboardAgentRow', () => {
     expect(classes.every((className) => !/\bgroup-hover:/.test(className))).toBe(true)
   })
 
+  it('renders waiting rows with the amber permission color', () => {
+    const markup = renderRow(makeAgent({}, { state: 'waiting' }))
+    const tokens = classTokens(markup)
+
+    expect(markup).toContain('aria-label="Waiting for input"')
+    expect(tokens).toContain('bg-amber-500')
+    expect(tokens).not.toContain('bg-red-500')
+  })
+
+  it('keeps blocked rows red', () => {
+    const markup = renderRow(makeAgent({}, { state: 'blocked' }))
+    const tokens = classTokens(markup)
+
+    expect(markup).toContain('aria-label="Blocked"')
+    expect(tokens).toContain('bg-red-500')
+    expect(tokens).not.toContain('bg-amber-500')
+  })
+
   it('keeps each row hover boundary inside an anonymous ancestor group', () => {
     const markup = renderToStaticMarkup(
       <TooltipProvider>

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -109,6 +109,30 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('text-amber-500')
   })
 
+  it('suppresses the new-card unread badge while unread status is permission', () => {
+    mocks.status = 'permission'
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction
+        isUnread
+        unreadTooltip="Mark as read"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        newCardStyle
+        hasBranchIdentity={false}
+      />
+    )
+
+    expect(markup).toContain('Needs permission · Unread')
+    expect(markup).toContain('bg-amber-500')
+    expect(markup).not.toContain('data-worktree-status-lane-unread=""')
+    expect(markup).not.toContain('data-worktree-unread-alert=""')
+    expect(markup).not.toContain('aria-label="Mark as read"')
+    expect(markup).not.toContain('lucide-bell')
+  })
+
   it('keeps legacy unread working cards on the unread bell control', () => {
     mocks.status = 'working'
     const markup = renderToStaticMarkup(

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -121,9 +121,10 @@ export function WorktreeCardStatusSlot({
         : statusLabel
   const passiveStatusTooltip =
     newCardStyle && isUnread ? `${passiveStatusLabel} · Unread` : passiveStatusLabel
-  // Why: the working spinner owns the new-card status lane, but unread state
-  // should still surface in tooltip/sr-only copy and reappear afterward.
-  const showNewCardUnreadAlert = newCardStyle && isUnread && showStatus && status !== 'working'
+  // Why: working and permission already own the new-card status lane, but
+  // unread state should still surface in tooltip/sr-only copy and reappear afterward.
+  const showNewCardUnreadAlert =
+    newCardStyle && isUnread && showStatus && status !== 'working' && status !== 'permission'
   const reviewStatusIconClassName = compactReviewAndBranchStatusIconClassName
   const branchStatusIcon = <GitBranch className={branchStatusIconClassName} aria-hidden="true" />
   const passiveStatus =


### PR DESCRIPTION
## Summary

- Makes agent rows use the same amber attention color for `waiting` and `permission` states.
- Keeps harder stop states (`blocked`, `interrupted`) red at the inline agent-row level.
- Suppresses the extra unread overlay on new-style worktree cards when the visible status is already `permission`, while preserving unread tooltip/screen-reader copy.

## Screenshots

Manual validation screenshots were captured locally and not committed:

- `.playwright-cli/page-2026-06-25T20-07-17-640Z.png` - permission/unread suppression plus waiting/blocked/interrupted rows.
- `.playwright-cli/page-2026-06-25T20-07-44-821Z.png` - non-permission unread overlay present.

## Design Approach

The design keeps worktree `permission` as the broad amber "needs you" rollup and keeps inline agent rows more specific: waiting/input prompts are amber, while blocked/interrupted rows remain red. The unread state is not mutated; only the extra visual overlay is hidden when permission already owns the status lane.

Design review completed with no P0/P1 findings remaining. One direction issue was resolved by explicitly documenting that a worktree-level amber permission rollup may contain a red blocked inline row because the two surfaces answer different questions.

## Implementation Notes

- Updated `AgentStateDot` color mapping so `waiting` joins `permission` on `bg-amber-500`.
- Updated `WorktreeCardStatusSlot` so new-card unread overlay is skipped for `permission` status, matching existing `working` suppression.
- Added focused static-render tests for primitive state colors, dashboard row state colors, and permission/unread overlay suppression.
- No deviations from the reviewed design.

Completeness verification confirmed every design requirement was implemented, no worktree promotion/sorting behavior changed, and SSH/cross-platform assumptions remain valid because this is renderer-only presentation logic.

## Performance

Perf audit found no actionable performance issues.

- Hot paths touched: inline agent-row dot rendering and sidebar worktree-card status-lane rendering.
- No new effects, polling, subprocesses, store subscriptions, cache invalidation, startup work, or leak surfaces.
- Existing deterministic render tests are sufficient; the permission+unread case renders slightly less DOM by suppressing the overlay.

## Review

- Code review round 1: both reviewers found the same stale `AgentStateDot` unit test expecting `waiting` to be red.
- Fix: updated the primitive test to assert `permission` and `waiting` are amber, while `blocked` and `interrupted` remain red.
- Code review round 2: both fresh reviewers returned clean.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/AgentStateDot.test.ts src/renderer/src/components/sidebar/StatusIndicator.test.ts src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx` - 6 files, 91 tests passed.
- [x] `pnpm run typecheck` - passed.
- [x] `pnpm run lint` - passed.
- [x] `git diff --check` - passed.
- [x] Electron product validation against `demo-project`.

## AI Review Report

- Design review: completed with no P0/P1 findings remaining.
- Completeness verification: confirmed every design requirement was implemented and no worktree promotion/sorting behavior changed.
- Perf audit: no actionable performance issues; the diff adds no effects, polling, subprocesses, subscriptions, startup work, or cache invalidation.
- Code review loop: first round found a stale primitive unit test; after fixing it, both fresh reviewers returned clean.
- Cross-platform/SSH coverage: renderer-only presentation logic; no path, process, keyboard, local-only, or provider-specific behavior changed.

## Product Validation

Product validation result: land.

- Validated in Electron against `demo-project` on this branch.
- Verified waiting rows render amber.
- Verified blocked and interrupted rows render red.
- Verified unread permission status keeps `Needs permission · Unread` sr-only/tooltip copy with no extra unread overlay/action.
- Verified unread non-permission status still renders the unread overlay.

Accepted validation gaps:

- No SSH/remoting validation; this is renderer-only presentation logic with no path/process/keyboard behavior.
- No live provider/agent run; validation seeded real app/store state through normal status paths.

## Security Audit

- No new data access, IPC, filesystem, network, shell execution, secrets handling, or authorization behavior.
- No agent-facing prompt text or external side-effect instruction was added.

## Notes

- Headline behavior status: implemented.
- The local screenshot paths are evidence from the validation machine and are intentionally not committed.

## Post-PR Stabilization

CodeRabbit posted no actionable review comments. GitHub checks are still being monitored until completion.
