### PR TITLE
fix(tabs): activate clicks when pointer release has no button

### DIFF
--- a/src/renderer/src/components/tab-bar/tab-strip-pointer-activation.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-strip-pointer-activation.test.tsx
@@ -65,8 +65,8 @@ function renderProbe(onActivate = vi.fn()): {
   }
 }
 
-function dispatchPointer(target: EventTarget, type: string): void {
-  target.dispatchEvent(new MouseEvent(type, { bubbles: true, button: 0 }))
+function dispatchPointer(target: EventTarget, type: string, button = 0): void {
+  target.dispatchEvent(new MouseEvent(type, { bubbles: true, button }))
 }
 
 afterEach(() => {
@@ -85,6 +85,16 @@ describe('useTabStripPointerActivation', () => {
     expect(onActivate).not.toHaveBeenCalled()
 
     act(() => dispatchPointer(window, 'pointerup'))
+    expect(tabButton.dataset.pressed).toBe('false')
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('activates when the release event reports no changed button', () => {
+    const { onActivate, tabButton } = renderProbe()
+
+    act(() => dispatchPointer(tabButton, 'pointerdown'))
+    act(() => dispatchPointer(window, 'pointerup', -1))
+
     expect(tabButton.dataset.pressed).toBe('false')
     expect(onActivate).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/src/components/tab-bar/tab-strip-pointer-activation.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-pointer-activation.ts
@@ -33,10 +33,9 @@ export function useTabStripPointerActivation({
     if (!isPressed) {
       return
     }
-    const finishPointerPress = (event: PointerEvent): void => {
-      if (event.button !== 0) {
-        return
-      }
+    const finishPointerPress = (): void => {
+      // Why: pointerup often reports button -1/no changed button; the left-button
+      // gate is on pointerdown, so release must always clear the pending click.
       const shouldActivate = pendingActivationRef.current && !isTabDragActiveRef.current
       pendingActivationRef.current = false
       setIsPressed(false)


### PR DESCRIPTION
## Summary
- Fix terminal/editor/browser tab click activation when `pointerup` reports no changed button (`button === -1`)
- Keep the left-button gate on `pointerdown`, but always clear/complete the pending activation on release unless a real tab drag became active
- Add a focused regression harness for the release-event shape that previously left tabs pressed and inactive

## Why
PR #5927 moved tab activation from pointer down to pointer up so click-vs-drag could be distinguished. Some real pointer release events report `button: -1`, so the old release handler ignored them and left pending tab activation stuck. That made ordinary terminal tab clicks feel like they were being swallowed by drag handling.

## Test plan
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/tab-strip-pointer-activation.test.tsx`
- `pnpm exec oxlint src/renderer/src/components/tab-bar/tab-strip-pointer-activation.ts src/renderer/src/components/tab-bar/tab-strip-pointer-activation.test.tsx`
- `pnpm exec oxfmt --check src/renderer/src/components/tab-bar/tab-strip-pointer-activation.ts src/renderer/src/components/tab-bar/tab-strip-pointer-activation.test.tsx`
- Electron dev validation: created two terminal tabs and clicked Terminal 1 / Terminal 2 through the rendered tab strip; active tab switched both directions and `data-pressed` cleared to `false`

Made with [Orca](https://github.com/stablyai/orca) 🐋
