### PR TITLE
Reveal automation agent logs from the sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
+import type * as ActivateTabAndFocusPaneModule from '@/lib/activate-tab-and-focus-pane'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 
 const LEAF_A = '11111111-1111-4111-8111-111111111111'
@@ -51,8 +52,12 @@ let mockAgentActivityDisplayMode: 'compact' | 'full' | undefined
 let mockTabsByWorktree: Record<string, { id: string }[]> = {}
 let mockAgentStatusByPaneKey: Record<string, { worktreeId?: string }> = {}
 let mockActiveTabId: string | null = null
+let mockActiveTabType: string = 'editor'
 const mockSetActiveTab = vi.fn((tabId: string) => {
   mockActiveTabId = tabId
+})
+const mockSetActiveTabType = vi.fn((tabType: string) => {
+  mockActiveTabType = tabType
 })
 let capturedRowActivations: {
   paneKey: string
@@ -71,7 +76,9 @@ function buildMockStoreState(): Record<string, unknown> {
     agentStatusByPaneKey: mockAgentStatusByPaneKey,
     agentStatusEpoch: 0,
     activeTabId: mockActiveTabId,
+    activeTabType: mockActiveTabType,
     setActiveTab: mockSetActiveTab,
+    setActiveTabType: mockSetActiveTabType,
     tabsByWorktree: mockTabsByWorktree,
     terminalLayoutsByTabId: {},
     ptyIdsByTabId: {},
@@ -143,11 +150,13 @@ describe('WorktreeCardAgents activation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     activationMocks.activateAndRevealWorktree.mockImplementation(() => undefined)
+    activationMocks.activateTabAndFocusPane.mockImplementation(() => undefined)
     mockAgents = []
     mockAgentActivityDisplayMode = undefined
     mockTabsByWorktree = {}
     mockAgentStatusByPaneKey = {}
     mockActiveTabId = null
+    mockActiveTabType = 'editor'
     capturedRowActivations = []
   })
 
@@ -183,6 +192,46 @@ describe('WorktreeCardAgents activation', () => {
       scrollToBottomIfOutputSinceLastView: true
     })
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).not.toHaveBeenCalled()
+  })
+
+  it('reveals the terminal surface through the helper path when activating a hydrated row', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'visible-worker-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'codex',
+        prompt: 'Show full log',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockTabsByWorktree = { 'wt-1': [{ id: tabId }] }
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    const actualActivation = await vi.importActual<typeof ActivateTabAndFocusPaneModule>(
+      '@/lib/activate-tab-and-focus-pane'
+    )
+    // Why: keep the component import mocked for call assertions, but delegate
+    // this repro to the real helper so it fails if the terminal-surface fix
+    // regresses.
+    activationMocks.activateTabAndFocusPane.mockImplementation(
+      actualActivation.activateTabAndFocusPane
+    )
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate(tabId, paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
+      ackPaneKeyOnSuccess: paneKey,
+      flashFocusedPane: true,
+      scrollToBottomIfOutputSinceLastView: true
+    })
+    expect(mockActiveTabType).toBe('terminal')
+    expect(mockActiveTabId).toBe(tabId)
   })
 
   it('keeps a live worktree-attributed row visible while its tab is hydrating', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -305,16 +305,19 @@ describe('WorktreeCardAgents activation', () => {
       })
     ]
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+    try {
+      const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
-    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
-    expect(capturedRowActivations).toHaveLength(1)
-    capturedRowActivations[0].onActivate('worker-tab', paneKey)
+      renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+      expect(capturedRowActivations).toHaveLength(1)
+      capturedRowActivations[0].onActivate('worker-tab', paneKey)
 
-    expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
-    expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
-    expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
-    warnSpy.mockRestore()
+      expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+      expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+      expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it('dismisses a pane key whose parsed tab does not match the row tab', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -50,6 +50,10 @@ let mockAgents: DashboardAgentRowData[] = []
 let mockAgentActivityDisplayMode: 'compact' | 'full' | undefined
 let mockTabsByWorktree: Record<string, { id: string }[]> = {}
 let mockAgentStatusByPaneKey: Record<string, { worktreeId?: string }> = {}
+let mockActiveTabId: string | null = null
+const mockSetActiveTab = vi.fn((tabId: string) => {
+  mockActiveTabId = tabId
+})
 let capturedRowActivations: {
   paneKey: string
   onActivate: (tabId: string, paneKey: string) => void
@@ -66,6 +70,8 @@ function buildMockStoreState(): Record<string, unknown> {
     agentSendPopoverTargetMode: null,
     agentStatusByPaneKey: mockAgentStatusByPaneKey,
     agentStatusEpoch: 0,
+    activeTabId: mockActiveTabId,
+    setActiveTab: mockSetActiveTab,
     tabsByWorktree: mockTabsByWorktree,
     terminalLayoutsByTabId: {},
     ptyIdsByTabId: {},
@@ -141,6 +147,7 @@ describe('WorktreeCardAgents activation', () => {
     mockAgentActivityDisplayMode = undefined
     mockTabsByWorktree = {}
     mockAgentStatusByPaneKey = {}
+    mockActiveTabId = null
     capturedRowActivations = []
   })
 
@@ -201,6 +208,114 @@ describe('WorktreeCardAgents activation', () => {
     expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
     expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).not.toHaveBeenCalled()
+  })
+
+  it('does not pane-focus a fallback terminal when the worker tab is still missing after reveal', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'worker-tab'
+    const fallbackTabId = 'fallback-terminal-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'codex',
+        prompt: 'Reveal the real worker',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    // Why: activation may create/select a different terminal before the
+    // automation worker hydrates; the row must only pane-focus its exact tab.
+    activationMocks.activateAndRevealWorktree.mockImplementation(() => {
+      mockTabsByWorktree = { 'wt-1': [{ id: fallbackTabId }] }
+      mockSetActiveTab(fallbackTabId)
+    })
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate(tabId, paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(mockActiveTabId).toBe(fallbackTabId)
+    expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(staleAgentRowMocks.dismissStaleAgentRowByKey).not.toHaveBeenCalled()
+  })
+
+  it('dismisses a malformed pane key instead of guessing a terminal pane', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const paneKey = 'legacy-pane-key'
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId: 'worker-tab',
+        agentType: 'codex',
+        prompt: 'Malformed worker',
+        worktreeId: 'wt-1'
+      })
+    ]
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate('worker-tab', paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
+    warnSpy.mockRestore()
+  })
+
+  it('dismisses a pane key whose parsed tab does not match the row tab', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const paneKey = makePaneKey('other-worker-tab', LEAF_B)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId: 'worker-tab',
+        agentType: 'claude',
+        prompt: 'Mismatched worker',
+        worktreeId: 'wt-1'
+      })
+    ]
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate('worker-tab', paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
+    warnSpy.mockRestore()
+  })
+
+  it('dismisses a missing tab row that is no longer attributed to this worktree', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'stale-worker-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'gemini',
+        prompt: 'Stale worker',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-2' } }
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate(tabId, paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
   })
 
   it('reveals the worktree and focuses a compact automation worker row hydrated during reveal', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -1,0 +1,249 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+
+const LEAF_A = '11111111-1111-4111-8111-111111111111'
+const LEAF_B = '22222222-2222-4222-8222-222222222222'
+
+type MockAgentOptions = {
+  paneKey: string
+  tabId: string
+  agentType: string
+  prompt: string
+  worktreeId: string
+  startedAt?: number
+}
+
+function mockAgent({
+  paneKey,
+  tabId,
+  agentType,
+  prompt,
+  worktreeId,
+  startedAt = 1000
+}: MockAgentOptions): DashboardAgentRowData {
+  return {
+    paneKey,
+    tab: { id: tabId },
+    agentType,
+    rowSource: 'live',
+    state: 'working',
+    startedAt,
+    entry: {
+      prompt,
+      state: 'working',
+      paneKey,
+      updatedAt: startedAt,
+      stateStartedAt: startedAt,
+      stateHistory: [],
+      worktreeId
+    }
+  } as unknown as DashboardAgentRowData
+}
+
+let mockAgents: DashboardAgentRowData[] = []
+let mockAgentActivityDisplayMode: 'compact' | 'full' | undefined
+let mockTabsByWorktree: Record<string, { id: string }[]> = {}
+let mockAgentStatusByPaneKey: Record<string, { worktreeId?: string }> = {}
+let capturedRowActivations: {
+  paneKey: string
+  onActivate: (tabId: string, paneKey: string) => void
+}[] = []
+
+function buildMockStoreState(): Record<string, unknown> {
+  return {
+    agentActivityDisplayMode: mockAgentActivityDisplayMode,
+    acknowledgedAgentsByPaneKey: {},
+    cacheTimerByKey: {},
+    dropAgentStatus: vi.fn(),
+    dismissRetainedAgent: vi.fn(),
+    acknowledgeAgents: vi.fn(),
+    agentSendPopoverTargetMode: null,
+    agentStatusByPaneKey: mockAgentStatusByPaneKey,
+    agentStatusEpoch: 0,
+    tabsByWorktree: mockTabsByWorktree,
+    terminalLayoutsByTabId: {},
+    ptyIdsByTabId: {},
+    runtimePaneTitlesByTabId: {},
+    sendPromptToSidebarAgentTarget: vi.fn(),
+    settings: {
+      promptCacheTimerEnabled: true,
+      promptCacheTtlMs: 60_000
+    }
+  }
+}
+
+const activationMocks = vi.hoisted(() => ({
+  activateAndRevealWorktree: vi.fn(),
+  activateTabAndFocusPane: vi.fn()
+}))
+
+const staleAgentRowMocks = vi.hoisted(() => ({
+  dismissStaleAgentRowByKey: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: unknown) => unknown) => selector(buildMockStoreState()),
+    {
+      getState: () => buildMockStoreState()
+    }
+  )
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: activationMocks.activateAndRevealWorktree
+}))
+
+vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
+  activateTabAndFocusPane: activationMocks.activateTabAndFocusPane
+}))
+
+vi.mock('../terminal-pane/stale-agent-row', () => ({
+  dismissStaleAgentRowByKey: staleAgentRowMocks.dismissStaleAgentRowByKey
+}))
+
+vi.mock('./useWorktreeAgentRows', () => ({
+  useWorktreeAgentRows: vi.fn(() => mockAgents)
+}))
+
+vi.mock('@/components/dashboard/useNow', () => ({
+  useNow: vi.fn(() => 2000)
+}))
+
+vi.mock('@/components/dashboard/DashboardAgentRow', () => ({
+  default: ({
+    agent,
+    onActivate
+  }: {
+    agent: DashboardAgentRowData
+    onActivate: (tabId: string, paneKey: string) => void
+  }) => {
+    capturedRowActivations.push({ paneKey: agent.paneKey, onActivate })
+    return <div data-testid="agent-row" data-pane-key={agent.paneKey} />
+  }
+}))
+
+vi.mock('./focused-agent-row-highlight', () => ({
+  useFocusedAgentPaneKey: vi.fn(() => null)
+}))
+
+describe('WorktreeCardAgents activation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    activationMocks.activateAndRevealWorktree.mockImplementation(() => undefined)
+    mockAgents = []
+    mockAgentActivityDisplayMode = undefined
+    mockTabsByWorktree = {}
+    mockAgentStatusByPaneKey = {}
+    capturedRowActivations = []
+  })
+
+  it('reveals the worktree and focuses an automation worker row hydrated during reveal', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'worker-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'codex',
+        prompt: 'Run automation worker',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    // Why: activation must use the post-reveal store snapshot, matching tab
+    // hydration that arrives while a background worker is being opened.
+    activationMocks.activateAndRevealWorktree.mockImplementation(() => {
+      mockTabsByWorktree = { 'wt-1': [{ id: tabId }] }
+    })
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate(tabId, paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
+      ackPaneKeyOnSuccess: paneKey,
+      flashFocusedPane: true,
+      scrollToBottomIfOutputSinceLastView: true
+    })
+    expect(staleAgentRowMocks.dismissStaleAgentRowByKey).not.toHaveBeenCalled()
+  })
+
+  it('keeps a live worktree-attributed row visible while its tab is hydrating', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'hydrating-worker-tab'
+    const paneKey = makePaneKey(tabId, LEAF_B)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'claude',
+        prompt: 'Hydrating worker',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate(tabId, paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(staleAgentRowMocks.dismissStaleAgentRowByKey).not.toHaveBeenCalled()
+  })
+
+  it('reveals the worktree and focuses a compact automation worker row hydrated during reveal', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    const tabId = 'compact-worker-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'gemini',
+        prompt: 'Compact worker',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    // Why: compact rows share the same activation contract as full rows, so
+    // this keeps the test pinned to reveal-time tab hydration.
+    activationMocks.activateAndRevealWorktree.mockImplementation(() => {
+      mockTabsByWorktree = { 'wt-1': [{ id: tabId }] }
+    })
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root: Root = createRoot(host)
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    await act(async () => {
+      root.render(<WorktreeCardAgents worktreeId="wt-1" />)
+    })
+    const row = host.querySelector('.compact-agent-row')
+    expect(row).toBeInstanceOf(HTMLElement)
+
+    await act(async () => {
+      row?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
+      ackPaneKeyOnSuccess: paneKey,
+      flashFocusedPane: true,
+      scrollToBottomIfOutputSinceLastView: true
+    })
+    act(() => root.unmount())
+    host.remove()
+  })
+})

--- a/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
+++ b/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
@@ -1,17 +1,24 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { activateTabAndFocusPane } from './activate-tab-and-focus-pane'
 
 const setActiveTab = vi.hoisted(() => vi.fn())
+const setActiveTabType = vi.hoisted(() => vi.fn())
 
 vi.mock('@/store', () => ({
   useAppStore: {
     getState: () => ({
-      setActiveTab
+      setActiveTab,
+      setActiveTabType
     })
   }
 }))
 
 describe('activateTabAndFocusPane', () => {
+  beforeEach(() => {
+    setActiveTab.mockImplementation(() => undefined)
+    setActiveTabType.mockImplementation(() => undefined)
+  })
+
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.clearAllMocks()
@@ -34,5 +41,44 @@ describe('activateTabAndFocusPane', () => {
     expect(setActiveTab).toHaveBeenNthCalledWith(1, 'tab-1')
     expect(setActiveTab).toHaveBeenNthCalledWith(2, 'tab-2')
     expect(cancelAnimationFrame).toHaveBeenCalledWith(12)
+  })
+
+  it('reveals the terminal surface before selecting the terminal tab', () => {
+    const callOrder: string[] = []
+    setActiveTabType.mockImplementation((tabType: string) => {
+      callOrder.push(`type:${tabType}`)
+    })
+    setActiveTab.mockImplementation((tabId: string) => {
+      callOrder.push(`tab:${tabId}`)
+    })
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 12)
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('window', {
+      dispatchEvent: vi.fn()
+    })
+
+    activateTabAndFocusPane('tab-1', 'leaf-1')
+
+    expect(callOrder).toEqual(['type:terminal', 'tab:tab-1'])
+  })
+
+  it('reveals the terminal surface for tab-only activation without dispatching pane focus', () => {
+    const requestAnimationFrame = vi.fn()
+    const dispatchEvent = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('window', {
+      dispatchEvent
+    })
+
+    activateTabAndFocusPane('tab-1', null)
+
+    expect(setActiveTabType).toHaveBeenCalledWith('terminal')
+    expect(setActiveTab).toHaveBeenCalledWith('tab-1')
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+    expect(dispatchEvent).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/activate-tab-and-focus-pane.ts
+++ b/src/renderer/src/lib/activate-tab-and-focus-pane.ts
@@ -19,7 +19,11 @@ export function activateTabAndFocusPane(
     scrollToBottomIfOutputSinceLastView?: boolean
   }
 ): void {
-  useAppStore.getState().setActiveTab(tabId)
+  const { setActiveTab, setActiveTabType } = useAppStore.getState()
+  // Why: selecting a terminal tab is independent from the visible surface;
+  // force Terminal first so tab-only activation reveals the full log.
+  setActiveTabType('terminal')
+  setActiveTab(tabId)
   cancelPendingFocusPaneFrame()
   if (leafId === null) {
     return

--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -8,6 +8,7 @@ import {
   waitForPaneIdentitySnapshot,
   type PaneIdentitySnapshot
 } from './helpers/terminal'
+import { clickFileInExplorer } from './helpers/file-explorer'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
 type SeededActivityThread = {
@@ -26,6 +27,7 @@ type ActivePaneSelection = {
   activeWorktreeId: string | null
   activeGroupId: string | null
   activeTabId: string | null
+  activeTabType: string | null
   activeLeafId: string | null
   activePaneId: number | null
 }
@@ -189,6 +191,7 @@ async function readActivePaneSelection(page: Page): Promise<ActivePaneSelection>
         activeWorktreeId: null,
         activeGroupId: null,
         activeTabId: null,
+        activeTabType: null,
         activeLeafId: null,
         activePaneId: null
       }
@@ -208,10 +211,15 @@ async function readActivePaneSelection(page: Page): Promise<ActivePaneSelection>
       activeWorktreeId,
       activeGroupId,
       activeTabId,
+      activeTabType: state.activeTabType ?? null,
       activeLeafId: activePane?.leafId ?? null,
       activePaneId: activePane?.id ?? null
     }
   })
+}
+
+function terminalPaneForLeaf(page: Page, leafId: string) {
+  return page.locator(`.pane[data-leaf-id="${leafId}"]`).first()
 }
 
 async function createTerminalInNewSplitGroup(page: Page): Promise<SplitGroupTerminal> {
@@ -373,6 +381,42 @@ test.describe('Activity Agent Pane Isolation', () => {
         activeTabId: snapshot.tabId,
         activeLeafId: second.leafId
       })
+  })
+
+  test('workspace card agent rows reveal terminal logs from a non-terminal surface', async ({
+    orcaPage
+  }) => {
+    await splitActiveTerminalPane(orcaPage, 'vertical')
+    await waitForPaneCount(orcaPage, 2)
+    const snapshot = await waitForPaneIdentitySnapshot(orcaPage, 2)
+    const [first] = await seedActivityThreadsForSplitPanes(orcaPage, snapshot)
+
+    await enableInlineAgentCards(orcaPage)
+    await expect(terminalPaneForLeaf(orcaPage, first.leafId)).toBeVisible()
+    // Why: this reproduces the user-visible failure mode: the agent row is
+    // visible in the sidebar while the main workspace surface is not Terminal.
+    await expect(await clickFileInExplorer(orcaPage, ['README.md'])).toBe('README.md')
+    await expect
+      .poll(() => readActivePaneSelection(orcaPage))
+      .toMatchObject({
+        activeTabType: 'editor',
+        activeTabId: snapshot.tabId
+      })
+    await expect(terminalPaneForLeaf(orcaPage, first.leafId)).toBeHidden()
+
+    await clickWorkspaceCardAgentRow(orcaPage, first.prompt)
+
+    await expect
+      .poll(async () => readActivePaneSelection(orcaPage), {
+        timeout: 10_000,
+        message: 'Workspace-card row did not reveal the terminal log surface'
+      })
+      .toMatchObject({
+        activeTabType: 'terminal',
+        activeTabId: snapshot.tabId,
+        activeLeafId: first.leafId
+      })
+    await expect(terminalPaneForLeaf(orcaPage, first.leafId)).toBeVisible()
   })
 
   test('workspace card agent rows focus the matching split-group terminal pane', async ({


### PR DESCRIPTION
## Summary

Fixes #6261.

Fixes a real sidebar activation bug where an automation-launched agent could be visible in the worktree sidebar, but clicking it did not reveal the full terminal log when the main workspace was currently showing a non-terminal surface such as an editor.

The row activation path already selected the correct terminal tab and pane. The missing piece was switching the visible workspace surface back to Terminal. `activateTabAndFocusPane` now forces the Terminal surface before selecting/focusing the terminal tab, so sidebar automation-agent rows reveal the full log instead of leaving the user on the editor surface.

## What Changed

- Updated `activateTabAndFocusPane` to call `setActiveTabType('terminal')` before `setActiveTab(tabId)`.
- Added helper-level coverage for ordering and tab-only activation with no leaf id.
- Added sidebar activation coverage that delegates through the real helper and verifies the terminal surface is revealed.
- Added a focused Electron e2e repro: open an editor so the target terminal pane is hidden, click the workspace-card agent row, then assert the Terminal surface and matching pane become visible.

## Brennan YOLO Lite Evidence

- Scratch design doc: `design-docs/automation-agent-terminal-surface-repro.md` (ignored, not part of the product diff).
- Design review: `auto-design-review-fix` completed clean before implementation.
- Implementation: production renderer fix plus focused unit/component/e2e regression coverage.
- Completeness verification: initial pass found the sidebar test needed to exercise the real helper path; fixed before final review.
- Code review loop: reviewers found a mock-leak risk in the sidebar test after the e2e was strengthened; fixed and revalidated. Final review was clean.
- `brennan-test-changes`: verdict `land`. It confirmed the e2e reproduces the user bug shape and validates the actual sidebar row click path.

## Validation

- [x] `git diff --check` passed, with only Git CRLF conversion warnings on Windows.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx src/renderer/src/lib/activate-tab-and-focus-pane.test.ts` passed: 2 files, 11 tests.
- [x] `pnpm exec oxlint tests/e2e/activity-agent-pane-isolation.spec.ts src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx src/renderer/src/lib/activate-tab-and-focus-pane.ts src/renderer/src/lib/activate-tab-and-focus-pane.test.ts` passed.
- [x] `pnpm run typecheck` passed.
- [x] `pnpm run lint` passed, with existing unrelated hook-dependency warnings in `src/renderer/src/components/right-sidebar/AiVaultPanel.tsx`.
- [x] `pnpm exec playwright test tests/e2e/activity-agent-pane-isolation.spec.ts --config tests/playwright.config.ts --project electron-headless --grep "workspace card agent rows reveal terminal logs" --workers=1` passed.

## Product Validation

Focused Electron e2e validation exercised the reported workflow:

- Created split terminal panes and seeded inline/workspace-card agent rows.
- Verified the target terminal pane was initially visible.
- Opened `README.md` through the file explorer so `activeTabType` became `editor` and the target terminal pane was hidden.
- Clicked the visible workspace-card agent row.
- Verified `activeTabType` became `terminal`, the same terminal tab stayed active, the matching leaf became focused, and the pane was visible again.

Evidence: Playwright passing status is recorded in `test-results/.last-run.json`. No screenshot artifact was produced by the passing automated run.

## SSH / Cross-Platform

No SSH/remoting/runtime RPC/provider code changed. The fix is renderer state selection only: it switches the active surface to Terminal before selecting the existing terminal tab. No platform-specific paths, shortcuts, shell behavior, or provider execution paths were introduced. `brennan-test-ssh` was not run because the changed behavior is local renderer tab/surface selection.

## Post-PR Stabilization

- [x] Waited the required 8 minutes after pushing the latest commit.
- [x] CodeRabbit latest summary reported no actionable comments after commit `148a776`; the earlier `console.warn` restoration comment is marked addressed in commit `148a776`.
- [x] Inline CodeRabbit review comments were checked directly; none are present on the PR.
- [x] GitHub PR check `verify` passed on the latest commit in 10m12s.