### PR TITLE
Prevent Codex hook trust prompts on Windows upgrades

### DIFF
--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -245,13 +245,12 @@ describe('computeTrustKey', () => {
         handlerIndex: 0,
         command: 'irrelevant'
       })
-    ).toBe(`${realpathSync.native(hooksPath).replace(/\\/g, '/')}:user_prompt_submit:0:0`)
+    ).toBe(`${realpathSync.native(hooksPath)}:user_prompt_submit:0:0`)
   })
 
-  it('normalizes Windows backslashes to forward slashes in the trust key', () => {
-    // Why: getCodexCanonicalTrustPath must return a forward-slash key even when
-    // the path uses native Windows separators, preventing separator mismatch
-    // against Codex-written literal-string keys.
+  it('uses native Windows backslashes in the trust key Codex looks up', () => {
+    // Why: Codex 0.140 writes approved Windows hook trust keys as raw native
+    // paths under [hooks.state].
     const winPath = 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json'
     const key = computeTrustKey({
       sourcePath: winPath,
@@ -260,8 +259,8 @@ describe('computeTrustKey', () => {
       handlerIndex: 0,
       command: 'echo'
     })
-    expect(key).not.toContain('\\')
-    expect(key.startsWith('C:/Users/Rod/AppData/Roaming/orca/hooks.json:')).toBe(true)
+    expect(key).toContain('\\')
+    expect(key.startsWith('C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json:')).toBe(true)
   })
 
   it('preserves literal backslashes in non-Windows-style fallback paths', () => {
@@ -399,12 +398,9 @@ describe('upsertHookTrustEntries', () => {
     }
     upsertHookTrustEntries(configPath, [entry])
 
-    // Why: after normalization Orca writes the forward-slash form; the fixture's
-    // backslash form is matched via normalizeHookTrustKeyForLookup and collapsed.
-    const normalizedKey = key.replace(/\\/g, '/')
     const written = readFileSync(configPath, 'utf-8')
     const duplicateKeyOccurrences = written.match(
-      new RegExp(`\\[hooks\\.state\\."${escapeRegex(normalizedKey)}"\\]`, 'g')
+      new RegExp(`\\[hooks\\.state\\.'${escapeRegex(key)}'\\]`, 'g')
     )
     expect(duplicateKeyOccurrences).toHaveLength(1)
     // The unrelated key was not upserted and stays in its original escaped form.
@@ -416,7 +412,7 @@ describe('upsertHookTrustEntries', () => {
     expect(written).toContain(`trusted_hash = "${computeTrustedHash(entry)}"`)
   })
 
-  it('collapses a literal-string hook table before writing the canonical basic-string table', () => {
+  it('collapses a literal-string hook table before writing the canonical Codex literal table', () => {
     const sourcePath = 'C:\\Users\\me\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json'
     const key = `${sourcePath}:session_start:0:0`
     const original = [
@@ -436,12 +432,10 @@ describe('upsertHookTrustEntries', () => {
     }
     upsertHookTrustEntries(configPath, [entry])
 
-    // Why: Orca writes the normalized forward-slash key form after replacement.
-    const normalizedKey = key.replace(/\\/g, '/')
     const written = readFileSync(configPath, 'utf-8')
-    expect(written).not.toContain(`[hooks.state.'${key}']`)
-    expect(written.match(/\[hooks\.state\./g)).toHaveLength(1)
-    expect(written).toContain(`[hooks.state."${normalizedKey}"]`)
+    expect(written.match(/\[hooks\.state\./g)).toHaveLength(2)
+    expect(written).toContain(`[hooks.state.'${key}']`)
+    expect(written).toContain(`[hooks.state.'${key.replace(/\\/g, '/')}']`)
     expect(written).toContain('enabled = false')
     expect(written).toContain(`trusted_hash = "${computeTrustedHash(entry)}"`)
   })
@@ -856,15 +850,13 @@ describe('upsertHookTrustEntries', () => {
     expect(written).not.toContain('sha256:OLD')
   })
 
-  it('finds and replaces a Codex literal-string backslash block when Orca upserts with forward-slash key', () => {
-    // Why: Codex writes literal-string keys with raw backslashes; Orca builds
-    // keys with forward slashes after getCodexCanonicalTrustPath normalization.
-    // normalizeHookTrustKeyForLookup must bridge that separator gap so upsert replaces
-    // rather than appends.
+  it('finds and replaces a legacy forward-slash block when Orca upserts with native backslash key', () => {
+    // Why: Codex 0.140 can expose Windows trust keys with either separator
+    // shape depending on startup cwd, so Orca replaces stale blocks with both.
     const backslashPath = 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json'
-    const literalKey = `${backslashPath}:session_start:0:0`
+    const legacyKey = `${backslashPath.replace(/\\/g, '/')}:session_start:0:0`
     const original = [
-      `[hooks.state.'${literalKey}']`,
+      `[hooks.state."${legacyKey}"]`,
       'enabled = true',
       'trusted_hash = "sha256:CODEX-WRITTEN"',
       ''
@@ -881,12 +873,14 @@ describe('upsertHookTrustEntries', () => {
     upsertHookTrustEntries(configPath, [entry])
 
     const written = readFileSync(configPath, 'utf-8')
-    expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(1)
+    expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(2)
+    expect(written).toContain(`[hooks.state.'${backslashPath}:session_start:0:0']`)
+    expect(written).toContain(`[hooks.state.'${legacyKey}']`)
     expect(written).not.toContain('sha256:CODEX-WRITTEN')
     expect(written).toContain(`trusted_hash = "${computeTrustedHash(entry)}"`)
   })
 
-  it('produces exactly one [hooks.state.*] header after two consecutive upserts on Windows path', () => {
+  it('produces exactly one Windows separator pair after two consecutive upserts', () => {
     // Why: idempotency guard — repeated auto-install on app start must not
     // accumulate duplicate trust blocks and produce invalid TOML.
     const entry: CodexTrustEntry = {
@@ -900,7 +894,31 @@ describe('upsertHookTrustEntries', () => {
     upsertHookTrustEntries(configPath, [entry])
 
     const written = readFileSync(configPath, 'utf-8')
-    expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(1)
+    expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(2)
+    expect((written.match(/session_start:0:0/g) ?? []).length).toBe(2)
+  })
+
+  it('falls back to TOML basic-string headers when a Windows path contains an apostrophe', () => {
+    // Why: TOML literal-string table keys cannot contain apostrophes, but
+    // Windows user/profile paths can.
+    const entry: CodexTrustEntry = {
+      sourcePath: "C:\\Users\\O'Connor\\AppData\\Roaming\\orca\\hooks.json",
+      eventLabel: 'session_start',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'echo session'
+    }
+    upsertHookTrustEntries(configPath, [entry])
+
+    const written = readFileSync(configPath, 'utf-8')
+    expect((written.match(/\[hooks\.state\."/g) ?? []).length).toBe(2)
+    expect(written).toContain(
+      `[hooks.state."C:\\\\Users\\\\O'Connor\\\\AppData\\\\Roaming\\\\orca\\\\hooks.json:session_start:0:0"]`
+    )
+    expect(written).toContain(
+      `[hooks.state."C:/Users/O'Connor/AppData/Roaming/orca/hooks.json:session_start:0:0"]`
+    )
+    expect(written).not.toContain(`[hooks.state.'C:\\Users\\O'Connor`)
   })
 
   it.skipIf(process.platform !== 'win32')(
@@ -931,7 +949,7 @@ describe('upsertHookTrustEntries', () => {
       upsertHookTrustEntries(configPath, [entry])
 
       const written = readFileSync(configPath, 'utf-8')
-      expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(1)
+      expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(2)
       expect(written).not.toContain('sha256:LOWERCASE')
       expect(written).toContain(`trusted_hash = "${computeTrustedHash(entry)}"`)
     }
@@ -951,9 +969,8 @@ describe('upsertProjectTrustLevel', () => {
     mkdirSync(nestedDir)
     mkdirSync(projectDir)
     const aliasedProjectPath = join(nestedDir, '..', 'project')
-    // Why: getCodexCanonicalTrustPath normalizes separators to forward slashes.
-    const trustedPath = realpathSync.native(aliasedProjectPath).replace(/\\/g, '/')
-    const trustedTomlPath = trustedPath.replaceAll('"', '\\"')
+    const trustedPath = realpathSync.native(aliasedProjectPath)
+    const trustedTomlPath = escapeTomlString(trustedPath)
 
     expect(upsertProjectTrustLevelInContent('', aliasedProjectPath, 'trusted')).toBe(
       [`[projects."${trustedTomlPath}"]`, 'trust_level = "trusted"', ''].join('\n')
@@ -1000,22 +1017,22 @@ describe('upsertProjectTrustLevel', () => {
     expect(updated).toContain('[other]\nvalue = 1')
   })
 
-  it('preserves CRLF endings and normalizes Windows path separators in the header', () => {
-    // Why: getCodexCanonicalTrustPath normalizes backslashes to forward slashes;
-    // the project path header uses forward slashes even on Windows input.
+  it('preserves CRLF endings and writes native Windows path separators in the header', () => {
+    // Why: local project trust still follows Codex's realpath display, while
+    // remote project trust preserves the SSH provider's canonical path string.
     const original = ['[profiles.default]', 'model = "gpt-5"', ''].join('\r\n')
 
     const updated = upsertProjectTrustLevelInContent(original, 'C:\\Users\\nw\\repo', 'trusted')
 
     expect(updated).toContain(
-      ['[projects."C:/Users/nw/repo"]', 'trust_level = "trusted"', ''].join('\r\n')
+      ['[projects."C:\\\\Users\\\\nw\\\\repo"]', 'trust_level = "trusted"', ''].join('\r\n')
     )
     expect(updated).toContain('[profiles.default]\r\nmodel = "gpt-5"')
   })
 
   it('updates an existing Windows backslash project block after separator normalization', () => {
-    // Why: forward-slash writes must not strand an older backslash-form
-    // project table and append a duplicate project trust block.
+    // Why: hook trust now writes paired Windows variants, but project trust
+    // must still repair an existing single project table in place.
     const original = [
       '[projects."C:\\\\Users\\\\nw\\\\repo"]',
       'notes = "keep"',
@@ -1030,6 +1047,37 @@ describe('upsertProjectTrustLevel', () => {
     expect(updated).toContain('notes = "keep"')
     expect(updated).toContain('trust_level = "trusted"')
     expect(updated).not.toContain('trust_level = "untrusted"')
+  })
+
+  it('updates an existing legacy Windows forward-slash project block', () => {
+    // Why: older Orca builds normalized Windows project paths to forward
+    // slashes; native-backslash hook fixes must not duplicate those blocks.
+    const original = [
+      '[projects."C:/Users/nw/repo"]',
+      'notes = "keep"',
+      'trust_level = "untrusted"',
+      ''
+    ].join('\n')
+
+    const updated = upsertProjectTrustLevelInContent(original, 'C:\\Users\\nw\\repo', 'trusted')
+
+    expect(updated.match(/\[projects\./g)).toHaveLength(1)
+    expect(updated).toContain('[projects."C:/Users/nw/repo"]')
+    expect(updated).toContain('notes = "keep"')
+    expect(updated).toContain('trust_level = "trusted"')
+    expect(updated).not.toContain('trust_level = "untrusted"')
+  })
+
+  it('preserves an already-canonical remote Windows project path', () => {
+    // Why: SSH project paths are resolved on the remote; local realpath would
+    // canonicalize the wrong machine if the same path happens to exist locally.
+    const updated = upsertProjectTrustLevelInContent('', 'C:/Users/nw/repo', 'trusted', {
+      alreadyCanonical: true
+    })
+
+    expect(updated).toBe(
+      ['[projects."C:/Users/nw/repo"]', 'trust_level = "trusted"', ''].join('\n')
+    )
   })
 
   it('writes config.toml and avoids rewriting an already-trusted project', () => {

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -122,12 +122,29 @@ export function getCodexCanonicalTrustPath(sourcePath: string): string {
   try {
     // Why: Codex canonicalizes trust paths before building config keys. On
     // macOS, /var is a symlink to /private/var; trusting the raw path still
-    // leaves the TUI in review/trust prompts. Forward-slash normalization
-    // prevents separator mismatch against Codex-written literal-string keys on Windows.
-    return normalizeWindowsPathSeparators(realpathSync.native(sourcePath))
+    // leaves the TUI in review/trust prompts. On Windows, Codex 0.140 writes
+    // hook state keys with native raw backslashes under an explicit parent table.
+    return realpathSync.native(sourcePath)
   } catch {
-    return normalizeWindowsPathSeparators(sourcePath)
+    return normalizeWindowsPathForCodexLookup(sourcePath)
   }
+}
+
+function getCodexCanonicalProjectPath(projectPath: string): string {
+  try {
+    // Why: local project trust still needs Codex's realpath shape, but remote
+    // SSH callers pass an already-canonical remote path string.
+    return realpathSync.native(projectPath)
+  } catch {
+    return projectPath
+  }
+}
+
+function normalizeWindowsPathForCodexLookup(sourcePath: string): string {
+  if (!usesWindowsPathSeparators(sourcePath)) {
+    return sourcePath
+  }
+  return sourcePath.replace(/\//g, '\\')
 }
 
 function normalizeWindowsPathSeparators(sourcePath: string): string {
@@ -242,9 +259,17 @@ export function upsertHookTrustEntriesInContent(
 ): string {
   const existing =
     existingContent.charCodeAt(0) === 0xfeff ? existingContent.slice(1) : existingContent
-  let updated = existing
+  let updated = entries.some((entry) =>
+    usesWindowsPathSeparators(getCodexCanonicalTrustPath(entry.sourcePath))
+  )
+    ? ensureHooksStateParentTable(existing)
+    : existing
   for (const entry of entries) {
-    updated = upsertTrustBlock(updated, computeTrustKey(entry), computeTrustedHash(entry))
+    updated = upsertTrustBlocks(
+      updated,
+      getTrustKeyWriteVariants(computeTrustKey(entry)),
+      computeTrustedHash(entry)
+    )
   }
   return updated
 }
@@ -265,11 +290,14 @@ export function upsertProjectTrustLevel(
 export function upsertProjectTrustLevelInContent(
   existingContent: string,
   projectPath: string,
-  trustLevel: CodexProjectTrustLevel
+  trustLevel: CodexProjectTrustLevel,
+  options?: { alreadyCanonical?: boolean }
 ): string {
   const existing =
     existingContent.charCodeAt(0) === 0xfeff ? existingContent.slice(1) : existingContent
-  const trustedProjectPath = getCodexCanonicalTrustPath(projectPath)
+  const trustedProjectPath = options?.alreadyCanonical
+    ? projectPath
+    : getCodexCanonicalProjectPath(projectPath)
   const headerPattern = buildProjectHeaderPattern(trustedProjectPath)
   const match = headerPattern.exec(existing)
   const eol = existing.includes('\r\n') ? '\r\n' : '\n'
@@ -311,10 +339,32 @@ export function upsertProjectTrustLevelInContent(
 // `enabled = false` survives reinstall.
 function buildTrustBlock(key: string, hash: string, enabled: boolean): string {
   return [
-    `[hooks.state."${escapeTomlString(key)}"]`,
+    `[hooks.state.${formatHookStateTableKey(key)}]`,
     `enabled = ${enabled}`,
     `trusted_hash = "${escapeTomlString(hash)}"`
   ].join('\n')
+}
+
+function formatHookStateTableKey(key: string): string {
+  const parsed = parseTrustKey(key)
+  if (parsed && usesWindowsPathSeparators(parsed.sourcePath) && !key.includes("'")) {
+    // Why: Codex 0.140 trusts Windows hooks only when the state table keys
+    // match the raw native path shape it writes after /hooks approval.
+    return `'${key}'`
+  }
+  return `"${escapeTomlString(key)}"`
+}
+
+function getTrustKeyWriteVariants(key: string): string[] {
+  const parsed = parseTrustKey(key)
+  if (!parsed || !usesWindowsPathSeparators(parsed.sourcePath)) {
+    return [key]
+  }
+  const suffix = `:${parsed.eventLabel}:${parsed.groupIndex}:${parsed.handlerIndex}`
+  return [
+    `${parsed.sourcePath.replace(/\//g, '\\')}${suffix}`,
+    `${parsed.sourcePath.replace(/\\/g, '/')}${suffix}`
+  ].filter((variant, index, variants) => variants.indexOf(variant) === index)
 }
 
 // Why: TOML basic strings forbid raw control chars; escape backslash first so
@@ -330,10 +380,18 @@ export function escapeTomlString(value: string): string {
     .replaceAll('\t', '\\t')
 }
 
-function upsertTrustBlock(content: string, key: string, hash: string): string {
-  const ranges = findTrustBlockRanges(content, key)
+function upsertTrustBlocks(content: string, keys: readonly string[], hash: string): string {
+  const ranges = keys
+    .flatMap((key) => findTrustBlockRanges(content, key))
+    .filter(
+      (range, index, ranges) =>
+        ranges.findIndex(
+          (candidate) => candidate.start === range.start && candidate.end === range.end
+        ) === index
+    )
+    .sort((a, b) => a.start - b.start)
   if (ranges.length === 0) {
-    const block = buildTrustBlock(key, hash, true)
+    const block = buildTrustBlocks(keys, hash, true)
     if (content.length === 0) {
       return `${block}\n`
     }
@@ -355,7 +413,7 @@ function upsertTrustBlock(content: string, key: string, hash: string): string {
     )
     return enabledMatch?.[1] === 'false'
   })
-  const block = buildTrustBlock(key, hash, enabled)
+  const block = buildTrustBlocks(keys, hash, enabled)
   let cursor = 0
   let deduped = ''
   ranges.forEach((range, index) => {
@@ -366,6 +424,29 @@ function upsertTrustBlock(content: string, key: string, hash: string): string {
     cursor = range.end
   })
   return deduped + content.slice(cursor)
+}
+
+function buildTrustBlocks(keys: readonly string[], hash: string, enabled: boolean): string {
+  // Why: Codex 0.140 can expose Windows hook-state keys with either native
+  // backslashes or forward slashes depending on the cwd string used at startup.
+  return keys.map((key) => buildTrustBlock(key, hash, enabled)).join('\n\n')
+}
+
+function ensureHooksStateParentTable(content: string): string {
+  if (/^[ \t]*\[hooks\.state\][ \t]*(?:#[^\r\n]*)?$/m.test(content)) {
+    return content
+  }
+  const eol = content.includes('\r\n') ? '\r\n' : '\n'
+  const parent = `[hooks.state]${eol}`
+  const hookHeader = /^[ \t]*\[hooks\.state\.(?:"|')/m.exec(content)
+  if (hookHeader) {
+    return `${content.slice(0, hookHeader.index)}${parent}${eol}${content.slice(hookHeader.index)}`
+  }
+  if (content.length === 0) {
+    return parent
+  }
+  const separator = content.endsWith(`${eol}${eol}`) ? '' : content.endsWith(eol) ? eol : eol + eol
+  return `${content}${separator}${parent}`
 }
 
 type TrustBlockRange = {
@@ -417,10 +498,13 @@ function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
 }
 
 function buildProjectHeaderPattern(projectPath: string): RegExp {
-  const headerPaths = [escapeRegex(escapeTomlString(projectPath))]
+  const headerPathValues = [projectPath]
   if (usesWindowsPathSeparators(projectPath)) {
-    headerPaths.push(escapeRegex(escapeTomlString(projectPath.replace(/\//g, '\\'))))
+    headerPathValues.push(projectPath.replace(/\//g, '\\'), projectPath.replace(/\\/g, '/'))
   }
+  const headerPaths = [...new Set(headerPathValues)].map((path) =>
+    escapeRegex(escapeTomlString(path))
+  )
   return new RegExp(
     `(^|\\r?\\n)[ \\t]*\\[projects\\."(?:${headerPaths.join('|')})"\\][ \\t]*(?:#[^\\r\\n]*)?(?=\\r?\\n|$)`,
     process.platform === 'win32' ? 'i' : undefined
@@ -757,9 +841,17 @@ export function readHookTrustEntries(configPath: string): Map<string, CodexHookT
       // a line scan beats pulling in a full TOML value parser.
       const hashMatch = /^[ \t]*trusted_hash[ \t]*=[ \t]*"((?:[^"\\]|\\.)*)"/m.exec(block)
       const enabledMatch = /^[ \t]*enabled[ \t]*=[ \t]*(true|false)[ \t\r]*(?:#.*)?$/m.exec(block)
-      result.set(normalizeHookTrustKeyForLookup(key), {
-        trustedHash: hashMatch ? unescapeTomlString(hashMatch[1]) : undefined,
-        enabled: enabledMatch ? enabledMatch[1] === 'true' : undefined
+      const normalizedKey = normalizeHookTrustKeyForLookup(key)
+      const existingState = result.get(normalizedKey)
+      const enabled = enabledMatch ? enabledMatch[1] === 'true' : undefined
+      result.set(normalizedKey, {
+        trustedHash: hashMatch ? unescapeTomlString(hashMatch[1]) : existingState?.trustedHash,
+        // Why: Windows writes both slash variants for one hook; a disabled copy
+        // must remain authoritative regardless of which variant appears last.
+        enabled:
+          existingState?.enabled === false || enabled === false
+            ? false
+            : (enabled ?? existingState?.enabled)
       })
       cursor = nextCursor
       continue

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -76,7 +76,10 @@ function escapeTomlBasicString(value: string): string {
 }
 
 function hookTrustHeader(key: string): string {
-  return `[hooks.state."${escapeTomlBasicString(canonicalizeHookTrustKeyForTest(key))}"]`
+  const canonicalKey = canonicalizeHookTrustKeyForTest(key)
+  return /^[A-Za-z]:[\\/]|^\\\\/.test(canonicalKey) && !canonicalKey.includes("'")
+    ? `[hooks.state.'${canonicalKey}']`
+    : `[hooks.state."${escapeTomlBasicString(canonicalKey)}"]`
 }
 
 function canonicalizeHookTrustKeyForTest(key: string): string {
@@ -88,12 +91,24 @@ function canonicalizeHookTrustKeyForTest(key: string): string {
   }
   const sourcePath = key.slice(0, thirdLast)
   try {
-    // Why: mirrors getCodexCanonicalTrustPath separator normalization so test
-    // expectations match the forward-slash keys Orca writes on Windows.
-    return `${realpathSync.native(sourcePath).replace(/\\/g, '/')}${key.slice(thirdLast)}`
+    // Why: mirrors getCodexCanonicalTrustPath so test expectations match the
+    // native raw-backslash keys Codex writes after hook approval on Windows.
+    return `${realpathSync.native(sourcePath)}${key.slice(thirdLast)}`
   } catch {
-    return key.replace(/\\/g, '/')
+    return /^[A-Za-z]:[\\/]|^\\\\/.test(sourcePath)
+      ? `${sourcePath.replace(/\//g, '\\')}${key.slice(thirdLast)}`
+      : key
   }
+}
+
+function markHookTrustDisabled(toml: string, header: string): string {
+  const headerIndex = toml.indexOf(header)
+  expect(headerIndex).not.toBe(-1)
+  const nextHeaderIndex = toml.indexOf('\n[', headerIndex + header.length)
+  const blockEnd = nextHeaderIndex === -1 ? toml.length : nextHeaderIndex
+  const block = toml.slice(headerIndex, blockEnd)
+  expect(block).toContain('enabled = true')
+  return `${toml.slice(0, headerIndex)}${block.replace('enabled = true', 'enabled = false')}${toml.slice(blockEnd)}`
 }
 
 describe('CodexHookService', () => {
@@ -533,27 +548,25 @@ describe('CodexHookService', () => {
       'utf-8'
     )
     const disabledPostCompactHeader = hookTrustHeader(`${systemHooksPath}:post_compact:0:0`)
+    const systemToml = upsertHookTrustEntriesInContent('model = "system-model"\n', [
+      {
+        sourcePath: systemHooksPath,
+        eventLabel: 'pre_compact',
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: 'pre-compact-user'
+      },
+      {
+        sourcePath: systemHooksPath,
+        eventLabel: 'post_compact',
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: 'post-compact-disabled'
+      }
+    ])
     writeFileSync(
       join(systemCodexHome, 'config.toml'),
-      upsertHookTrustEntriesInContent('model = "system-model"\n', [
-        {
-          sourcePath: systemHooksPath,
-          eventLabel: 'pre_compact',
-          groupIndex: 0,
-          handlerIndex: 0,
-          command: 'pre-compact-user'
-        },
-        {
-          sourcePath: systemHooksPath,
-          eventLabel: 'post_compact',
-          groupIndex: 0,
-          handlerIndex: 0,
-          command: 'post-compact-disabled'
-        }
-      ]).replace(
-        `${disabledPostCompactHeader}\nenabled = true`,
-        `${disabledPostCompactHeader}\nenabled = false`
-      ),
+      markHookTrustDisabled(systemToml, disabledPostCompactHeader),
       'utf-8'
     )
 
@@ -669,17 +682,18 @@ describe('CodexHookService', () => {
       'utf-8'
     )
     const disabledStopHeader = hookTrustHeader(`${systemHooksPath}:stop:0:0`)
+    const systemToml = upsertHookTrustEntriesInContent('model = "system-model"\n', [
+      {
+        sourcePath: systemHooksPath,
+        eventLabel: 'stop',
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: 'user-stop-hook'
+      }
+    ])
     writeFileSync(
       join(systemCodexHome, 'config.toml'),
-      upsertHookTrustEntriesInContent('model = "system-model"\n', [
-        {
-          sourcePath: systemHooksPath,
-          eventLabel: 'stop',
-          groupIndex: 0,
-          handlerIndex: 0,
-          command: 'user-stop-hook'
-        }
-      ]).replace(`${disabledStopHeader}\nenabled = true`, `${disabledStopHeader}\nenabled = false`),
+      markHookTrustDisabled(systemToml, disabledStopHeader),
       'utf-8'
     )
 
@@ -1176,6 +1190,41 @@ describe('CodexHookService', () => {
     expect(trustConfig).toContain(':permission_request:0:0')
     expect(trustConfig).not.toContain('model = "runtime-model"')
   })
+
+  it.skipIf(process.platform !== 'win32')(
+    'treats legacy forward-slash runtime trust keys as installed before canonicalizing on reinstall',
+    () => {
+      const service = new CodexHookService()
+      expect(service.install().state).toBe('installed')
+
+      const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
+      const managedHooksPath = join(managedCodexHome, 'hooks.json')
+      const runtimeTomlPath = join(managedCodexHome, 'config.toml')
+      const canonicalSessionStartHeader = hookTrustHeader(`${managedHooksPath}:session_start:0:0`)
+      const legacySessionStartHeader = `[hooks.state."${escapeTomlBasicString(
+        `${realpathSync.native(managedHooksPath).replace(/\\/g, '/')}:session_start:0:0`
+      )}"]`
+      const installedToml = readFileSync(runtimeTomlPath, 'utf-8')
+      expect(installedToml).toContain(canonicalSessionStartHeader)
+
+      writeFileSync(
+        runtimeTomlPath,
+        installedToml.replace(canonicalSessionStartHeader, legacySessionStartHeader),
+        'utf-8'
+      )
+
+      const legacyToml = readFileSync(runtimeTomlPath, 'utf-8')
+      expect(legacyToml).toContain(legacySessionStartHeader)
+      expect(service.getStatus().state).toBe('installed')
+
+      expect(service.install().state).toBe('installed')
+
+      const repairedToml = readFileSync(runtimeTomlPath, 'utf-8')
+      expect(repairedToml).not.toContain(legacySessionStartHeader)
+      expect(repairedToml).toContain(canonicalSessionStartHeader)
+      expect(service.getStatus().state).toBe('installed')
+    }
+  )
 
   it('repairs duplicate managed SessionStart trust tables on restart install', () => {
     const systemCodexHome = join(tmpHome, '.codex')

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -464,6 +464,28 @@ function escapeRegex(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+function buildHookTrustHeaderKeyPattern(key: string): string {
+  const keyVariants = [key]
+  const parsed = parseTrustKey(key)
+  if (parsed && /^[A-Za-z]:[\\/]|^\\\\/.test(parsed.sourcePath)) {
+    const suffix = `:${parsed.eventLabel}:${parsed.groupIndex}:${parsed.handlerIndex}`
+    keyVariants.push(
+      `${parsed.sourcePath.replace(/\\/g, '/')}${suffix}`,
+      `${parsed.sourcePath.replace(/\//g, '\\')}${suffix}`
+    )
+  }
+  const alternatives = [...new Set(keyVariants)].flatMap((variant) => {
+    const quoted = [`"${escapeRegex(escapeTomlString(variant))}"`]
+    if (!variant.includes("'")) {
+      // Why: tolerate raw-backslash literal keys left by Codex/manual approval
+      // while Orca repairs mirrored runtime trust across both Windows variants.
+      quoted.push(`'${escapeRegex(variant)}'`)
+    }
+    return quoted
+  })
+  return `(?:${alternatives.join('|')})`
+}
+
 function applyMirroredRuntimeUserHookTrustStates(
   tomlPath: string,
   entries: readonly MirroredRuntimeUserHookTrustEntry[]
@@ -475,9 +497,10 @@ function applyMirroredRuntimeUserHookTrustStates(
   const existing = readFileSync(tomlPath, 'utf-8')
   let updated = existing
   for (const { entry, enabled } of entries) {
-    const escapedKey = escapeRegex(escapeTomlString(computeTrustKey(entry)))
+    const headerKeyPattern = buildHookTrustHeaderKeyPattern(computeTrustKey(entry))
     const pattern = new RegExp(
-      `(\\[hooks\\.state\\."${escapedKey}"\\]\\r?\\n[ \\t]*enabled[ \\t]*=[ \\t]*)(true|false)`
+      `(\\[hooks\\.state\\.${headerKeyPattern}\\]\\r?\\n[ \\t]*enabled[ \\t]*=[ \\t]*)(true|false)`,
+      'g'
     )
     updated = updated.replace(pattern, `$1${enabled}`)
   }

--- a/src/main/remote-agent-trust-presets.ts
+++ b/src/main/remote-agent-trust-presets.ts
@@ -83,7 +83,11 @@ async function markRemoteCodexProjectTrusted(
   const codexDir = `${remoteHome}/.codex`
   const configPath = `${codexDir}/config.toml`
   const existing = await readRemoteTextFile(fsProvider, configPath)
-  const updated = upsertProjectTrustLevelInContent(existing, workspacePath, 'trusted')
+  const updated = upsertProjectTrustLevelInContent(existing, workspacePath, 'trusted', {
+    // Why: workspacePath was resolved by the remote filesystem provider; local
+    // realpath would canonicalize the wrong machine on SSH.
+    alreadyCanonical: true
+  })
   if (updated === existing) {
     return
   }


### PR DESCRIPTION
## Summary
- Writes paired Windows Codex hook trust entries for each managed hook: native backslash and forward-slash key variants.
- Treats those variants as one logical trust state so stale variants are deduped and `enabled = false` remains authoritative.
- Keeps project trust compatible with legacy Windows separators and prevents SSH remote project trust from local-realpathing remote paths.

## Brennan YOLO Lite Evidence

### Design approach
Created scratch design doc `design-docs/codex-windows-hook-trust-regression.md` (ignored, not shipped). The design targets the Codex 0.140 Windows path-shape mismatch between hook discovery and startup cwd normalization.

### Design review outcome
`auto-design-review-fix` completed clean. It clarified that the invariant is writing both Windows key spellings; TOML literal keys are preferred when valid, with basic-string fallback for apostrophes.

### Implementation and deviations
Implemented the reviewed design in `config-toml-trust.ts` and `hook-service.ts`, plus regression coverage. Review also found and fixed an SSH project-trust edge case by adding an `alreadyCanonical` path option for remote trust writes.

### Completeness verification
Read-only verification reported complete against the design. It identified apostrophe-path and UNC coverage gaps; apostrophe-path fallback coverage was added. UNC remains covered by pattern support/static review, not a dedicated test.

### Code review loop
Round 1: Reviewer A clean; Reviewer B found remote Windows project trust could be rewritten to local backslashes. Fixed.
Round 2: Reviewer A found local `realpathSync.native` could still affect an already-resolved remote path if it exists locally. Fixed with explicit `alreadyCanonical` remote mode. Reviewer B clean.
Round 3: Both reviewers returned clean.

### Brennan test changes
Verdict from delegated validation: local Windows Codex hook-trust path is good; do not claim full land until SSH Docker gate is accepted or rerun in an environment with Docker.

Product evidence:
- Real Orca-spawned interactive Codex CLI through `orca terminal create` using branch live-install harness.
- Terminal `term_29952b80-5a83-4d66-84d2-e395c9a202ba` reached normal Codex prompt with no hook review prompt.
- Runtime config retained 12 hook-state headers for 6 hooks, 1 `[hooks.state]` parent, 6 native-backslash keys, and 6 forward-slash keys.
- Both Codex `hooks/list` probes, backslash cwd and forward-slash cwd, reported all 6 managed hooks as `trustStatus: trusted`.

No screenshots required: this is terminal/runtime behavior, not renderer UI.

### Validation
- `pnpm vitest run --config config/vitest.config.ts src/main/codex/config-toml-trust.test.ts src/main/codex/hook-service.test.ts src/main/remote-agent-trust-presets.test.ts` passed: 114 tests.
- `pnpm vitest run --config config/vitest.config.ts src/main/codex/codex-config-mirror.test.ts src/main/codex-accounts/runtime-home-service.test.ts` passed: 85 tests.
- `pnpm vitest run --config config/vitest.config.ts src/main/agent-trust-presets.test.ts src/main/remote-agent-trust-presets.test.ts` passed: 12 tests.
- `pnpm run typecheck` passed.
- `pnpm run lint` passed with one unrelated existing warning in `src/renderer/src/components/right-sidebar/useGitStatusPolling.ts:161`.
- `pnpm run build:relay` passed.
- `git diff --check` passed with only CRLF normalization warnings.

### SSH Gate
Attempted `pnpm run test:e2e:ssh-docker-perf`, but the local environment cannot run it because `docker` and `podman` are unavailable on Windows and inside WSL Ubuntu. The runbook also notes Windows-as-target SSH is not supported by the Docker rig; the changed remote Windows project-trust behavior is covered by unit tests and review, while supported Linux SSH relay coverage remains blocked by missing Docker.

### Post-PR stabilization
Pending after latest push. Will wait 8 minutes, then review CodeRabbit and PR checks.

### Assumptions / accepted gaps
- The live Codex validation used a branch live-install harness because the currently installed Orca can rewrite runtime config back to the old 6-entry shape before launch.
- Full SSH Docker e2e is blocked by missing Docker/Podman in this environment.