### PR TITLE
Reduce duplicate worktree refresh scans

### DIFF
--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -683,6 +683,110 @@ describe('fetchWorktrees', () => {
     expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(2)
   })
 
+  it('preserves SSH host identity when detected and visible refreshes overlap', async () => {
+    const store = createTestStore()
+    const sshWorktree = makeWorktree({
+      id: 'repo-ssh::/home/orca/wt1',
+      repoId: 'repo-ssh',
+      path: '/home/orca/wt1'
+    })
+    let releaseScan!: () => void
+    const scanStarted = new Promise<void>((resolve) => {
+      mockApi.worktrees.listDetected.mockImplementationOnce(
+        async ({ repoId }: { repoId: string }) => {
+          resolve()
+          await new Promise<void>((release) => {
+            releaseScan = release
+          })
+          return makeDetectedResult(repoId, [sshWorktree])
+        }
+      )
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [
+        {
+          id: 'repo-ssh',
+          path: '/home/orca/repo',
+          displayName: 'SSH Repo',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-1'
+        }
+      ]
+    } as Partial<AppState>)
+
+    const detectedRequest = store.getState().fetchDetectedWorktrees('repo-ssh')
+    const visibleRequest = store.getState().fetchWorktrees('repo-ssh')
+    await scanStarted
+
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1)
+
+    releaseScan()
+    const [, visibleResult] = await Promise.all([detectedRequest, visibleRequest])
+
+    expect(visibleResult).toBe(true)
+    expect(store.getState().worktreesByRepo['repo-ssh']).toEqual([
+      { ...sshWorktree, hostId: 'ssh:ssh-1' }
+    ])
+    expect(store.getState().detectedWorktreesByRepo['repo-ssh']?.worktrees).toEqual([
+      expect.objectContaining({ id: sshWorktree.id, hostId: 'ssh:ssh-1' })
+    ])
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves SSH host identity when visible refresh starts before detected refresh', async () => {
+    const store = createTestStore()
+    const sshWorktree = makeWorktree({
+      id: 'repo-ssh::/home/orca/wt1',
+      repoId: 'repo-ssh',
+      path: '/home/orca/wt1'
+    })
+    let releaseScan!: () => void
+    const scanStarted = new Promise<void>((resolve) => {
+      mockApi.worktrees.listDetected.mockImplementationOnce(
+        async ({ repoId }: { repoId: string }) => {
+          resolve()
+          await new Promise<void>((release) => {
+            releaseScan = release
+          })
+          return makeDetectedResult(repoId, [sshWorktree])
+        }
+      )
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [
+        {
+          id: 'repo-ssh',
+          path: '/home/orca/repo',
+          displayName: 'SSH Repo',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-1'
+        }
+      ]
+    } as Partial<AppState>)
+
+    const visibleRequest = store.getState().fetchWorktrees('repo-ssh')
+    const detectedRequest = store.getState().fetchDetectedWorktrees('repo-ssh')
+    await scanStarted
+
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1)
+
+    releaseScan()
+    const [visibleResult] = await Promise.all([visibleRequest, detectedRequest])
+
+    expect(visibleResult).toBe(true)
+    expect(store.getState().worktreesByRepo['repo-ssh']).toEqual([
+      { ...sshWorktree, hostId: 'ssh:ssh-1' }
+    ])
+    expect(store.getState().detectedWorktreesByRepo['repo-ssh']?.worktrees).toEqual([
+      expect.objectContaining({ id: sshWorktree.id, hostId: 'ssh:ssh-1' })
+    ])
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1)
+  })
+
   it('purges remembered right sidebar tabs for worktrees removed by a committed refresh', async () => {
     const store = createTestStore()
     const removed = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -485,6 +485,204 @@ describe('fetchWorktrees', () => {
     expect(result).toBe(false)
   })
 
+  it('coalesces concurrent duplicate refreshes for the same repo and host', async () => {
+    const store = createTestStore()
+    const refreshed = makeWorktree({
+      id: 'repo1::/path/refreshed',
+      repoId: 'repo1',
+      path: '/path/refreshed'
+    })
+    let releaseScan!: () => void
+    const scanStarted = new Promise<void>((resolve) => {
+      mockApi.worktrees.listDetected.mockImplementationOnce(
+        async ({ repoId }: { repoId: string }) => {
+          resolve()
+          await new Promise<void>((release) => {
+            releaseScan = release
+          })
+          return makeDetectedResult(repoId, [refreshed])
+        }
+      )
+    })
+
+    const requests = Array.from({ length: 8 }, () => store.getState().fetchWorktrees('repo1'))
+    await scanStarted
+
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1)
+
+    releaseScan()
+    await expect(Promise.all(requests)).resolves.toEqual(Array(8).fill(true))
+    expect(store.getState().worktreesByRepo.repo1).toEqual([refreshed])
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces fetchDetectedWorktrees with a matching fetchWorktrees refresh', async () => {
+    const store = createTestStore()
+    const refreshed = makeWorktree({
+      id: 'repo1::/path/refreshed',
+      repoId: 'repo1',
+      path: '/path/refreshed'
+    })
+    let releaseScan!: () => void
+    const scanStarted = new Promise<void>((resolve) => {
+      mockApi.worktrees.listDetected.mockImplementationOnce(
+        async ({ repoId }: { repoId: string }) => {
+          resolve()
+          await new Promise<void>((release) => {
+            releaseScan = release
+          })
+          return makeDetectedResult(repoId, [refreshed])
+        }
+      )
+    })
+
+    const detectedRequest = store.getState().fetchDetectedWorktrees('repo1')
+    const visibleRequest = store.getState().fetchWorktrees('repo1')
+    await scanStarted
+
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1)
+
+    releaseScan()
+    await expect(Promise.all([detectedRequest, visibleRequest])).resolves.toEqual([
+      makeDetectedResult('repo1', [refreshed]),
+      true
+    ])
+    expect(store.getState().worktreesByRepo.repo1).toEqual([refreshed])
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps authoritative refreshes separate from non-authoritative in-flight results', async () => {
+    const store = createTestStore()
+    const fallback = makeWorktree({
+      id: 'repo1::/path/fallback',
+      repoId: 'repo1',
+      path: '/path/fallback'
+    })
+    const authoritative = makeWorktree({
+      id: 'repo1::/path/authoritative',
+      repoId: 'repo1',
+      path: '/path/authoritative'
+    })
+    let releaseFallback!: () => void
+    let releaseAuthoritative!: () => void
+    const fallbackStarted = new Promise<void>((resolve) => {
+      mockApi.worktrees.listDetected.mockImplementationOnce(
+        async ({ repoId }: { repoId: string }) => {
+          resolve()
+          await new Promise<void>((release) => {
+            releaseFallback = release
+          })
+          return makeDetectedResult(repoId, [fallback], {
+            authoritative: false,
+            source: 'metadata-fallback'
+          })
+        }
+      )
+    })
+    const authoritativeStarted = new Promise<void>((resolve) => {
+      mockApi.worktrees.listDetected.mockImplementationOnce(
+        async ({ repoId }: { repoId: string }) => {
+          resolve()
+          await new Promise<void>((release) => {
+            releaseAuthoritative = release
+          })
+          return makeDetectedResult(repoId, [authoritative])
+        }
+      )
+    })
+
+    const bestEffortRequest = store.getState().fetchWorktrees('repo1')
+    await fallbackStarted
+    const authoritativeRequest = store
+      .getState()
+      .fetchWorktrees('repo1', { requireAuthoritative: true })
+    await authoritativeStarted
+
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(2)
+
+    releaseFallback()
+    await expect(bestEffortRequest).resolves.toBe(false)
+    releaseAuthoritative()
+    await expect(authoritativeRequest).resolves.toBe(true)
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([authoritative])
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps same-repo refreshes separate for different execution hosts', async () => {
+    const store = createTestStore()
+    const localWorktree = makeWorktree({
+      id: 'repo1::/local/wt1',
+      repoId: 'repo1',
+      path: '/local/wt1'
+    })
+    const sshWorktree = makeWorktree({
+      id: 'repo1::/ssh/wt1',
+      repoId: 'repo1',
+      path: '/home/orca/wt1'
+    })
+    let releaseLocal!: () => void
+    let releaseSsh!: () => void
+    const localStarted = new Promise<void>((resolve) => {
+      mockApi.worktrees.listDetected.mockImplementationOnce(
+        async ({ repoId }: { repoId: string }) => {
+          resolve()
+          await new Promise<void>((release) => {
+            releaseLocal = release
+          })
+          return makeDetectedResult(repoId, [localWorktree])
+        }
+      )
+    })
+    const sshStarted = new Promise<void>((resolve) => {
+      mockApi.worktrees.listDetected.mockImplementationOnce(
+        async ({ repoId }: { repoId: string }) => {
+          resolve()
+          await new Promise<void>((release) => {
+            releaseSsh = release
+          })
+          return makeDetectedResult(repoId, [sshWorktree])
+        }
+      )
+    })
+    store.setState({
+      hasHydratedWorktreePurge: true,
+      repos: [
+        {
+          id: 'repo1',
+          path: '/local/repo1',
+          displayName: 'Repo One',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'local'
+        },
+        {
+          id: 'repo1',
+          path: '/home/orca/repo1',
+          displayName: 'Repo One SSH',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-1'
+        }
+      ]
+    } as Partial<AppState>)
+
+    const refresh = store.getState().fetchAllWorktrees()
+    await Promise.all([localStarted, sshStarted])
+
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(2)
+
+    releaseLocal()
+    releaseSsh()
+    await refresh
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([
+      localWorktree,
+      { ...sshWorktree, hostId: 'ssh:ssh-1' }
+    ])
+    expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(2)
+  })
+
   it('purges remembered right sidebar tabs for worktrees removed by a committed refresh', async () => {
     const store = createTestStore()
     const removed = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -72,6 +72,7 @@ const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
 const hostedReviewPushTargetLookupsInFlight = new Set<string>()
+const detectedWorktreeRefreshesInFlight = new Map<string, Promise<DetectedWorktreeListResult>>()
 
 async function mapReposForWorktreeRefresh<TRepo extends { id: string }, TResult>(
   repos: readonly TRepo[],
@@ -822,6 +823,44 @@ async function listDetectedWorktreesForRepo(
       { timeoutMs: 15_000 }
     )
     return toLegacyDetectedWorktreeResult(repoId, legacy)
+  }
+}
+
+function detectedWorktreeRefreshKey(
+  settings: AppState['settings'],
+  repoId: string,
+  options: { executionHostId: ExecutionHostId; requireAuthoritative?: boolean }
+): string {
+  const target = getActiveRuntimeTarget(settings)
+  const targetKey = target.kind === 'local' ? 'local' : `runtime:${target.environmentId}`
+  return [
+    repoId,
+    options.executionHostId,
+    targetKey,
+    options.requireAuthoritative === true ? 'authoritative' : 'best-effort'
+  ].join('\n')
+}
+
+async function listDetectedWorktreesForRepoCoalesced(
+  settings: AppState['settings'],
+  repoId: string,
+  options: { executionHostId: ExecutionHostId; requireAuthoritative?: boolean }
+): Promise<DetectedWorktreeListResult> {
+  const key = detectedWorktreeRefreshKey(settings, repoId, options)
+  const existing = detectedWorktreeRefreshesInFlight.get(key)
+  if (existing) {
+    return existing
+  }
+  // Why: startup/event fan-out can ask for the same repo/host refresh many
+  // times at once; share only the scan promise so state merge semantics stay local.
+  const refresh = listDetectedWorktreesForRepo(settings, repoId)
+  detectedWorktreeRefreshesInFlight.set(key, refresh)
+  try {
+    return await refresh
+  } finally {
+    if (detectedWorktreeRefreshesInFlight.get(key) === refresh) {
+      detectedWorktreeRefreshesInFlight.delete(key)
+    }
   }
 }
 
@@ -1691,7 +1730,13 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
   fetchDetectedWorktrees: async (repoId) => {
     try {
-      const result = await listDetectedWorktreesForRepo(settingsForRepoOwner(get(), repoId), repoId)
+      const ownerState = get()
+      const hostId = repoHostId(ownerState, repoId)
+      const result = await listDetectedWorktreesForRepoCoalesced(
+        settingsForRepoOwner(ownerState, repoId, hostId),
+        repoId,
+        { executionHostId: hostId }
+      )
       set((s) =>
         areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[repoId], result)
           ? s
@@ -1709,7 +1754,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const ownerState = get()
       const hostId = repoHostId(ownerState, repoId)
       const settings = settingsForRepoOwner(ownerState, repoId, hostId)
-      const detected = await listDetectedWorktreesForRepo(settings, repoId)
+      const detected = await listDetectedWorktreesForRepoCoalesced(settings, repoId, {
+        executionHostId: hostId,
+        requireAuthoritative: options?.requireAuthoritative
+      })
       if (options?.requireAuthoritative && !detected.authoritative) {
         return false
       }
@@ -1834,7 +1882,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       await mapReposForWorktreeRefresh(repos, async (r) => {
         const hostId = getRepoExecutionHostId(r)
         const settings = settingsForKnownRepoOwner(get().settings, r)
-        const detected = await listDetectedWorktreesForRepo(settings, r.id)
+        const detected = await listDetectedWorktreesForRepoCoalesced(settings, r.id, {
+          executionHostId: hostId
+        })
         const worktrees = toVisibleWorktrees(detected, hostId)
         set((s) => {
           const matchOptions = worktreeHostMatchOptions(s, r.id, hostId)
@@ -1890,9 +1940,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       > => {
         try {
           const hostId = getRepoExecutionHostId(r)
-          const detected = await listDetectedWorktreesForRepo(
+          const detected = await listDetectedWorktreesForRepoCoalesced(
             settingsForKnownRepoOwner(get().settings, r),
-            r.id
+            r.id,
+            { executionHostId: hostId }
           )
           const list = toVisibleWorktrees(detected, hostId)
           const current = get().worktreesByRepo[r.id]

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1737,11 +1737,19 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         repoId,
         { executionHostId: hostId }
       )
-      set((s) =>
-        areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[repoId], result)
+      set((s) => {
+        // Why: detected-only refreshes can overlap host-scoped visible refreshes;
+        // keep detected state stamped/merged so SSH/runtime rows are not clobbered.
+        const mergedDetected = mergeDetectedWorktreesForHost(
+          s.detectedWorktreesByRepo[repoId],
+          result,
+          hostId,
+          worktreeHostMatchOptions(s, repoId, hostId)
+        )
+        return areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[repoId], mergedDetected)
           ? s
-          : { detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [repoId]: result } }
-      )
+          : { detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [repoId]: mergedDetected } }
+      })
       return result
     } catch (err) {
       console.error(`Failed to fetch detected worktrees for repo ${repoId}:`, err)


### PR DESCRIPTION
﻿## Summary

Reduces duplicate worktree refresh scans by coalescing concurrent detected-worktree refreshes for the same repo, execution host, runtime target, and refresh mode. Each caller still performs its own state merge after the shared scan resolves, so existing visible/detected worktree semantics remain local to the caller.

A follow-up verification pass found and fixed an SSH overlap edge: `fetchDetectedWorktrees` now uses the same host-scoped merge/stamp path as visible refreshes so a detected-only refresh cannot clobber SSH/runtime host identity when it overlaps `fetchWorktrees`.

## Design and Review

- Design approach: add a module-local in-flight promise map keyed by repo id, execution host id, local/runtime target, and best-effort vs authoritative mode.
- Design review outcome: reviewed against the requested duplicate-scan fix, retry behavior, state merge semantics, SSH/runtime separation, and cross-platform constraints; no product-scope drift found.
- Implementation notes: routed `fetchDetectedWorktrees`, `fetchWorktrees`, and both `fetchAllWorktrees` paths through the coalesced scanner. Added focused regression coverage for same-host coalescing, detected/visible overlap, authoritative separation, same-repo/different-host separation, and SSH host identity preservation in both detected/visible overlap orders.
- Completeness verification: implementation matches the design doc requirements and edge cases after the SSH overlap follow-up.
- Code review loop: two orchestration review subagents completed clean after the follow-up fix; both reported no actionable findings. Residual risk noted by both: duplicate repo IDs that share the same lower-level list API key remain a pre-existing sharp edge, not introduced by this patch.
- Brennan test result: land. Store-level behavior is covered by focused unit tests plus static gates; no visible UI/layout changed.
- Post-PR stabilization: CodeRabbit code review reported no actionable code comments; PR-body template warning addressed below. Follow-up PR checks are running.

## Screenshots

Not applicable; this is renderer store/runtime refresh behavior and does not change visible UI or layout.

## Security Audit

- Input handling: no new user-provided input is parsed; the coalescing key uses existing repo id, execution host id, runtime target, and refresh mode values.
- Paths: no path parsing or path separator assumptions were added.
- IPC/RPC: no new IPC/RPC methods or permissions were added; existing local/runtime detected worktree calls are only de-duplicated while in flight.
- Auth/SSH: SSH-owned repos stay routed through local desktop/SSH settings, and tests cover host identity preservation during overlapping refreshes.
- Dependencies: no new dependencies.
- Failure behavior: in-flight entries are removed in `finally`, so failed refreshes are not cached or reused after settlement.

## Tests

- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts` (160 tests)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (passes; emits an existing warning in `src/renderer/src/components/right-sidebar/useGitStatusPolling.ts`)
- [x] `git diff --check`
- [x] Post-PR checks after initial PR: `track-community-pr` and `verify` passed.

## Notes

- Initial install required `pnpm install --frozen-lockfile`; optional `cpu-features` native build could not find a Visual Studio toolchain, but repo postinstall skipped/recovered optional native modules and install exited successfully.
- Live SSH/Electron validation was not run because the changed behavior is covered at the store refresh boundary and does not add UI controls or new SSH transport behavior. A manual SSH smoke of overlapping refreshes would still be useful final confidence evidence if available.
