### PR TITLE
Keep worktree PR badges stable during refresh

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -668,4 +668,173 @@ describe('WorktreeCard linked PR display', () => {
     expect(markup).not.toContain('Branch')
     expect(markup).not.toContain('lucide-git-branch')
   })
+
+  it('keeps the detailed right-side PR badge during a transient hosted-review miss', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: false }
+    worktreeCardProperties = ['pr']
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: null,
+        fetchedAt: 100
+      }
+    }
+    prCache = {
+      'repo-1::feature/local-branch': {
+        data: makePRInfo({
+          number: 6340,
+          title: 'Remove split terminal from onboarding checklist',
+          state: 'open',
+          checksStatus: 'success'
+        }),
+        fetchedAt: 200
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedPR: null })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('Linked PR #6340')
+    expect(markup).not.toContain('Linked PR #456')
+  })
+
+  it('keeps the detailed PR badge when a transient miss still has an older review hint', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: false }
+    worktreeCardProperties = ['pr']
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: null,
+        fetchedAt: 100,
+        linkedReviewHintKey: 'github:999'
+      }
+    }
+    prCache = {
+      'repo-1::feature/local-branch': {
+        data: makePRInfo({
+          number: 6340,
+          title: 'Remove split terminal from onboarding checklist',
+          state: 'open',
+          checksStatus: 'success'
+        }),
+        fetchedAt: 200
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedPR: null })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('Linked PR #6340')
+    expect(markup).not.toContain('Linked PR #456')
+  })
+
+  it('keeps durable non-GitHub linked review metadata ahead of branch PR cache', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: false }
+    worktreeCardProperties = ['pr']
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: null,
+        fetchedAt: 100
+      }
+    }
+    prCache = {
+      'repo-1::feature/local-branch': {
+        data: makePRInfo({
+          number: 6340,
+          title: 'Remove split terminal from onboarding checklist',
+          state: 'open',
+          checksStatus: 'success'
+        }),
+        fetchedAt: 200
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedGitLabMR: 77 })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('Linked MR #77')
+    expect(markup).not.toContain('Linked PR #6340')
+  })
+
+  it('does not resurrect an older PR cache entry after a newer hosted-review miss', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: false }
+    worktreeCardProperties = ['pr']
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: null,
+        fetchedAt: 200
+      }
+    }
+    prCache = {
+      'repo-1::feature/local-branch': {
+        data: makePRInfo({
+          number: 6340,
+          title: 'Remove split terminal from onboarding checklist',
+          state: 'open',
+          checksStatus: 'success'
+        }),
+        fetchedAt: 100
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedPR: null })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).not.toContain('Linked PR #6340')
+  })
+
+  it('does not resurrect PR cache on the same millisecond as a hosted-review miss', async () => {
+    settings = { compactWorktreeCards: false, experimentalNewWorktreeCardStyle: false }
+    worktreeCardProperties = ['pr']
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: null,
+        fetchedAt: 200
+      }
+    }
+    prCache = {
+      'repo-1::feature/local-branch': {
+        data: makePRInfo({
+          number: 6340,
+          title: 'Remove split terminal from onboarding checklist',
+          state: 'open',
+          checksStatus: 'success'
+        }),
+        fetchedAt: 200
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedPR: null })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).not.toContain('Linked PR #6340')
+  })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -441,26 +441,48 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   const hostedReview: HostedReviewInfo | null | undefined =
     hostedReviewEntry !== undefined ? hostedReviewEntry.data : undefined
-  // Why: ChecksPanel can discover a branch PR before hosted-review metadata
-  // warms. The sidebar status slot should not fall back to "branch" while
-  // the branch PR cache already knows the review state.
-  const cachedBranchReview =
-    hostedReview === undefined && prCacheEntry?.data
-      ? hostedReviewInfoFromGitHubPRInfo(prCacheEntry.data)
-      : hostedReview
+  const linkedGitHubPR = worktree.linkedPR ?? null
   const linkedGitLabMR = worktree.linkedGitLabMR ?? null
   const linkedBitbucketPR = worktree.linkedBitbucketPR ?? null
   const linkedAzureDevOpsPR = worktree.linkedAzureDevOpsPR ?? null
   const linkedGiteaPR = worktree.linkedGiteaPR ?? null
+  const hasNonGitHubLinkedReview =
+    linkedGitLabMR !== null ||
+    linkedBitbucketPR !== null ||
+    linkedAzureDevOpsPR !== null ||
+    linkedGiteaPR !== null
+  const hasLinkedReview =
+    linkedGitHubPR !== null ||
+    linkedGitLabMR !== null ||
+    linkedBitbucketPR !== null ||
+    linkedAzureDevOpsPR !== null ||
+    linkedGiteaPR !== null
+  // Why: ChecksPanel can discover a branch PR before hosted-review metadata
+  // warms, and transient older hosted-review misses can race with that cache.
+  // Newer hosted-review misses still win so stale PR cache cannot resurrect.
+  const cachedBranchPR = prCacheEntry?.data
+  const cachedBranchPRFetchedAt = prCacheEntry?.fetchedAt
+  const useCachedBranchReview =
+    cachedBranchPR !== undefined &&
+    cachedBranchPR !== null &&
+    !hasNonGitHubLinkedReview &&
+    (hostedReview === undefined ||
+      (hostedReview === null &&
+        cachedBranchPRFetchedAt !== undefined &&
+        cachedBranchPRFetchedAt > (hostedReviewEntry?.fetchedAt ?? 0)))
+  const cachedBranchReview = useCachedBranchReview
+    ? hostedReviewInfoFromGitHubPRInfo(cachedBranchPR)
+    : hostedReview
   const prDisplay = getWorktreeCardPrDisplay(
     cachedBranchReview,
-    worktree.linkedPR,
+    linkedGitHubPR,
     linkedGitLabMR,
     linkedBitbucketPR,
     linkedAzureDevOpsPR,
     linkedGiteaPR,
     {
-      reviewHintKey: hostedReviewEntry?.linkedReviewHintKey ?? (prCacheEntry?.data ? '' : undefined)
+      reviewHintKey:
+        useCachedBranchReview && !hasLinkedReview ? '' : hostedReviewEntry?.linkedReviewHintKey
     }
   )
   const issue: IssueInfo | null | undefined = worktree.linkedIssue


### PR DESCRIPTION
## Summary

Keep legacy detailed worktree cards from briefly losing their right-side PR badge when hosted-review metadata writes an older transient miss while the branch PR cache already has a newer PR.

The card now uses the GitHub PR cache only when hosted-review data is still warming, or when the PR cache is strictly newer than a hosted-review `null` miss. Equal or older PR cache entries do not resurrect a stale badge. When the PR cache supplies an unlinked branch review, the display path also gets the neutral review hint needed to render branch-discovered GitHub PR metadata.

The GitHub-only PR cache is blocked from masking durable linked metadata for GitLab, Bitbucket, Azure DevOps, and Gitea worktrees.

## Design And Review

- Design approach: scoped renderer-side cache selection in `WorktreeCard`, no provider calls, polling changes, cache-key changes, or visual styling changes.
- Design review outcome: the design was revised to avoid stale PR resurrection by using a strict `fetchedAt` comparison, and later tightened so the neutral hint follows the same fallback decision.
- Implementation deviations: added a provider guard so GitHub `prCache` cannot override durable non-GitHub linked review metadata.
- Completeness verification: final read-only verification found no blockers after the provider and hint-key fixes.
- Performance audit: no actionable perf issues. The render path keeps exact-entry Zustand subscriptions and adds only constant-time scalar checks plus an existing PR-to-review projection when eligible.

## Code Review

- Review round 1 found that a broad hosted-review `null` fallback could resurrect stale PR cache data. Fixed with strict timestamp ordering and negative tests.
- Review round 2 found that an older hosted-review hint could still suppress the PR-cache fallback. Fixed by tying the neutral hint to the PR-cache fallback decision.
- Review round 3 found GitHub PR cache could mask durable non-GitHub linked metadata. Fixed with a provider guard and regression test.
- Final round: WorktreeCard changes were clean. One reviewer surfaced an unrelated base-code concern outside this PR diff, so it was treated as non-actionable for this PR.

## Tests

- [x] `git diff --check`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (exited 0; existing warning in `useGitStatusPolling.ts`)
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx` (24 tests)
- [x] Electron validation from exact worktree:
  - verified `window.api.app.getIdentity()` root `/Users/thebr/orca/workspaces/orca/velvetfish`
  - verified branch `brennanb2025/continue-task`
  - used real demo-project PR `stablyai/demo-project#21`
  - real branch/worktree: `brennanb2025/pr-badge-real-pr-20260626`
  - configured legacy detailed cards with PR metadata enabled
  - fetched real GitHub PR data through the app provider path
  - clicked the real worktree card and verified the right-side PR badge remained visible as `Linked PR #21`

## Screenshots

Manual validation evidence was captured from the exact PR worktree:

- `.playwright-cli/page-2026-06-26T02-21-34-854Z.png`
- `.playwright-cli/page-2026-06-26T02-20-51-705Z.png`
- `.playwright-cli/page-2026-06-26T02-00-03-688Z.png`
- `.playwright-cli/page-2026-06-26T01-59-37-287Z.png`

The latest clean screenshot shows the real demo-project PR `#21` in the Checks panel after clicking the legacy detailed worktree card. DOM inspection after the click showed the selected card's metadata node contained `Linked PR #21`.

Accepted validation notes:

- A synthetic cache-race pass was run first to deterministically cover older hosted-review `null` plus newer PR cache.
- A follow-up real-PR pass used `stablyai/demo-project#21` for reproduction/manual validation through the actual provider data path.
- Demo-project PR `#21` intentionally remains open as a throwaway validation PR.

## Security Audit

- No new network calls, filesystem writes, subprocesses, IPC handlers, shell commands, permissions, or secrets handling.
- The change is renderer-only cache selection over already-loaded store entries.
- SSH/runtime boundaries are preserved by the existing hosted-review and PR-cache key construction; no cache-key construction changed.

## AI Review Report

- Design review: completed and incorporated strict timestamp ordering plus neutral-hint coupling.
- Completeness verification: completed after each review fix; final pass found no blockers.
- Performance audit: completed; no actionable performance issues.
- Code review: multiple independent review rounds completed. Actionable findings were fixed. Final WorktreeCard review was clean; one unrelated base-code finding outside this PR diff was treated as non-actionable for this PR.
- Platform coverage: no platform-specific behavior changed. The code path uses existing cache keys for local, SSH, and runtime-owned repos and avoids path, shell, shortcut, or OS assumptions.

## Notes

- This PR is intentionally scoped to keeping the existing PR badge stable during hosted-review cache races. It does not change provider refresh semantics globally.
- The validation used deterministic synthetic demo-project PR cache data because the original click race is transient.

## Post-PR Stabilization

- First sweep after the required 8-minute wait: CodeRabbit generated no actionable code comments or review threads.
- CodeRabbit description warning requested explicit Screenshots, Security Audit, Notes, and AI Review Report sections; this PR body update addresses that warning.
- Final check sweep: `verify` passed and `track-community-pr` passed.
