### PR TITLE
Sweep stale Codex marketplace staging clones on startup

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -11,6 +11,7 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  utimesSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -4536,5 +4537,160 @@ describe('CodexRuntimeHomeService', () => {
       .split('\n')
     expect(diagnostics).toHaveLength(2)
     expect(diagnostics[0]).toContain('"type":"session-conflict"')
+  })
+
+  describe('stale marketplace staging sweep', () => {
+    function getMarketplacesRoot(): string {
+      return join(getRuntimeCodexHomePath(), '.tmp', 'marketplaces')
+    }
+
+    function getStagingRoot(): string {
+      return join(getMarketplacesRoot(), '.staging')
+    }
+
+    function makeDir(path: string, ageMs: number): void {
+      mkdirSync(path, { recursive: true })
+      const markerPath = join(path, 'clone.txt')
+      writeFileSync(markerPath, 'x', 'utf-8')
+      setMtime(markerPath, ageMs)
+      setMtime(path, ageMs)
+    }
+
+    function setMtime(path: string, ageMs: number): void {
+      const time = (Date.now() - ageMs) / 1000
+      utimesSync(path, time, time)
+    }
+
+    async function construct(): Promise<void> {
+      const store = createStore(createSettings())
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      new CodexRuntimeHomeService(store as never)
+    }
+
+    it('removes aged marketplace-upgrade and marketplace-add staging dirs on startup', async () => {
+      const stagingRoot = getStagingRoot()
+      const staleUpgrade = join(stagingRoot, 'marketplace-upgrade-abc123')
+      const staleAdd = join(stagingRoot, 'marketplace-add-def456')
+      makeDir(staleUpgrade, 2 * 60 * 60 * 1000)
+      makeDir(staleAdd, 2 * 60 * 60 * 1000)
+
+      await construct()
+
+      expect(existsSync(staleUpgrade)).toBe(false)
+      expect(existsSync(staleAdd)).toBe(false)
+    })
+
+    it('removes aged marketplace-backup dirs at the marketplaces root', async () => {
+      const staleBackup = join(getMarketplacesRoot(), 'marketplace-backup-ghi789')
+      makeDir(staleBackup, 2 * 60 * 60 * 1000)
+
+      await construct()
+
+      expect(existsSync(staleBackup)).toBe(false)
+    })
+
+    it('preserves staging dirs just under the stale threshold', async () => {
+      const almostStale = join(getStagingRoot(), 'marketplace-add-almost-stale')
+      makeDir(almostStale, 60 * 60 * 1000 - 1_000)
+
+      await construct()
+
+      expect(existsSync(almostStale)).toBe(true)
+    })
+
+    it('preserves recent staging dirs that may belong to an in-flight sync', async () => {
+      const freshUpgrade = join(getStagingRoot(), 'marketplace-upgrade-fresh')
+      makeDir(freshUpgrade, 5 * 60 * 1000)
+
+      await construct()
+
+      expect(existsSync(freshUpgrade)).toBe(true)
+    })
+
+    it('preserves old staging dirs when nested clone activity is recent', async () => {
+      const activeUpgrade = join(getStagingRoot(), 'marketplace-upgrade-active')
+      const activePackDir = join(activeUpgrade, '.git', 'objects', 'pack')
+      mkdirSync(activePackDir, { recursive: true })
+      writeFileSync(join(activePackDir, 'tmp_pack_active'), 'x', 'utf-8')
+      setMtime(activeUpgrade, 2 * 60 * 60 * 1000)
+      setMtime(join(activeUpgrade, '.git'), 2 * 60 * 60 * 1000)
+      setMtime(join(activeUpgrade, '.git', 'objects'), 2 * 60 * 60 * 1000)
+      setMtime(activePackDir, 5 * 60 * 1000)
+
+      await construct()
+
+      expect(existsSync(activeUpgrade)).toBe(true)
+    })
+
+    it('removes staging dirs whose newest nested activity is stale', async () => {
+      const staleUpgrade = join(getStagingRoot(), 'marketplace-upgrade-nested-stale')
+      const stalePackDir = join(staleUpgrade, '.git', 'objects', 'pack')
+      mkdirSync(stalePackDir, { recursive: true })
+      const stalePackFile = join(stalePackDir, 'pack-stale.pack')
+      writeFileSync(stalePackFile, 'x', 'utf-8')
+      setMtime(stalePackFile, 2 * 60 * 60 * 1000)
+      setMtime(stalePackDir, 2 * 60 * 60 * 1000)
+      setMtime(join(staleUpgrade, '.git', 'objects'), 2 * 60 * 60 * 1000)
+      setMtime(join(staleUpgrade, '.git'), 2 * 60 * 60 * 1000)
+      setMtime(staleUpgrade, 2 * 60 * 60 * 1000)
+
+      await construct()
+
+      expect(existsSync(staleUpgrade)).toBe(false)
+    })
+
+    it('preserves unrelated dirs regardless of age', async () => {
+      const unrelated = join(getStagingRoot(), 'some-other-dir')
+      const promoted = join(getMarketplacesRoot(), 'claude-mem')
+      makeDir(unrelated, 2 * 60 * 60 * 1000)
+      makeDir(promoted, 2 * 60 * 60 * 1000)
+
+      await construct()
+
+      expect(existsSync(unrelated)).toBe(true)
+      expect(existsSync(promoted)).toBe(true)
+    })
+
+    it('does not throw when the marketplaces tree does not exist', async () => {
+      await expect(construct()).resolves.toBeUndefined()
+    })
+
+    it('sweeps the WSL runtime home staging dirs on selection sync', async () => {
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const wslHome = join(testState.userDataDir, 'wsl-home')
+      vi.doMock('../wsl', () => ({
+        getDefaultWslDistro: () => 'Ubuntu',
+        getWslHome: () => wslHome
+      }))
+      const wslRuntimeHomePath = join(
+        wslHome,
+        '.local',
+        'share',
+        'orca',
+        'codex-runtime-home',
+        'home'
+      )
+      const staleWslUpgrade = join(
+        wslRuntimeHomePath,
+        '.tmp',
+        'marketplaces',
+        '.staging',
+        'marketplace-upgrade-wsl'
+      )
+      makeDir(staleWslUpgrade, 2 * 60 * 60 * 1000)
+      try {
+        const store = createStore(createSettings())
+        const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+        const service = new CodexRuntimeHomeService(store as never)
+        service.syncForCurrentSelection({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+
+        expect(existsSync(staleWslUpgrade)).toBe(false)
+      } finally {
+        if (originalPlatform) {
+          Object.defineProperty(process, 'platform', originalPlatform)
+        }
+      }
+    })
   })
 })

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -107,6 +107,22 @@ function getEffectiveCodexHomeEnv(launchEnv: NodeJS.ProcessEnv): NodeJS.ProcessE
     ORCA_CODEX_HOME: readLaunchEnvValue(launchEnv, 'ORCA_CODEX_HOME')
   }
 }
+// Why: Codex CLI stages git-sourced marketplace upgrades/adds by cloning the
+// full repo (~100-230MB each) into `<CODEX_HOME>/.tmp/marketplaces/.staging/`
+// before atomically swapping it into place. When the CLI is killed or a clone
+// times out mid-sync, the staging clone is orphaned and never reclaimed, so it
+// accumulates indefinitely under the runtime home Orca manages (openai/codex
+// #21005, #29994). Orca cannot fix the upstream lifecycle, but it owns the
+// runtime home, so it sweeps aged orphans on startup. Mirror the upstream
+// staging-dir prefixes exactly, but use a deliberately conservative 1h age
+// threshold (upstream's own cleanup uses ~10m): Orca's managed home can be
+// shared with externally-launched Codex processes whose long git clones must
+// never be razed mid-flight. The sweep compares the newest mtime anywhere in
+// the candidate subtree, not just the staging root, because git clone activity
+// may update deep `.git/objects` files without touching the root dir.
+const CODEX_MARKETPLACE_STAGING_PREFIXES = ['marketplace-upgrade-', 'marketplace-add-'] as const
+const CODEX_MARKETPLACE_BACKUP_PREFIX = 'marketplace-backup-'
+const CODEX_MARKETPLACE_STALE_AGE_MS = 60 * 60 * 1000
 
 export class CodexRuntimeHomeService {
   // Which managed account runtime auth.json mirrors; null means it follows system-default ~/.codex instead of a managed account.
@@ -127,6 +143,7 @@ export class CodexRuntimeHomeService {
     this.safeMigrateLegacyManagedState()
     this.safeMigrateLegacyActiveHomePointer()
     this.initializeLastSyncedState()
+    this.safeSweepStaleMarketplaceStagingDirs(this.getRuntimeHomePath())
     this.safeSyncForCurrentSelection()
   }
 
@@ -839,6 +856,7 @@ export class CodexRuntimeHomeService {
     this.wslRuntimeHomePathByDistro.set(distro, runtimeHomePath)
 
     mkdirSync(runtimeHomePath, { recursive: true })
+    this.safeSweepStaleMarketplaceStagingDirs(runtimeHomePath)
     this.safeMigrateLegacyWslActiveHomePointer(distro, runtimeHomePath)
     this.seedWslRuntimeHome(runtimeHomePath, activeAccount, distro)
 
@@ -1427,6 +1445,89 @@ export class CodexRuntimeHomeService {
     } catch (error) {
       // Why: diagnostics must not fail the one-shot migration after the session file is already preserved.
       console.warn('[codex-runtime-home] Failed to append migration diagnostic:', error)
+    }
+  }
+
+  private safeSweepStaleMarketplaceStagingDirs(runtimeHomePath: string): void {
+    try {
+      this.sweepStaleMarketplaceStagingDirs(runtimeHomePath)
+    } catch (error) {
+      // Why: the sweep is a best-effort disk-reclamation pass. A transient fs
+      // error (permissions, races with a live Codex sync) must never block
+      // runtime-home setup or launch.
+      console.warn('[codex-runtime-home] Failed to sweep stale marketplace staging dirs:', error)
+    }
+  }
+
+  private sweepStaleMarketplaceStagingDirs(runtimeHomePath: string): void {
+    const marketplacesRoot = join(runtimeHomePath, '.tmp', 'marketplaces')
+    const stagingRoot = join(marketplacesRoot, '.staging')
+    const now = Date.now()
+    this.removeStaleMarketplaceDirs(stagingRoot, CODEX_MARKETPLACE_STAGING_PREFIXES, now)
+    this.removeStaleMarketplaceDirs(marketplacesRoot, [CODEX_MARKETPLACE_BACKUP_PREFIX], now)
+  }
+
+  private getNewestMarketplaceDirMtimeMs(dirPath: string): number | null {
+    let newestMtimeMs: number
+    try {
+      newestMtimeMs = statSync(dirPath).mtimeMs
+    } catch {
+      return null
+    }
+
+    try {
+      for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+        const childPath = join(dirPath, entry.name)
+        let childMtimeMs: number | null = null
+        if (entry.isDirectory()) {
+          childMtimeMs = this.getNewestMarketplaceDirMtimeMs(childPath)
+          if (childMtimeMs === null) {
+            return null
+          }
+        } else if (entry.isFile()) {
+          childMtimeMs = statSync(childPath).mtimeMs
+        }
+        if (childMtimeMs !== null && childMtimeMs > newestMtimeMs) {
+          newestMtimeMs = childMtimeMs
+        }
+      }
+    } catch {
+      return null
+    }
+
+    return newestMtimeMs
+  }
+
+  private removeStaleMarketplaceDirs(
+    parentDir: string,
+    prefixes: readonly string[],
+    now: number
+  ): void {
+    if (!existsSync(parentDir)) {
+      return
+    }
+    for (const entry of readdirSync(parentDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !prefixes.some((prefix) => entry.name.startsWith(prefix))) {
+        continue
+      }
+      const dirPath = join(parentDir, entry.name)
+      const newestMtimeMs = this.getNewestMarketplaceDirMtimeMs(dirPath)
+      if (newestMtimeMs === null) {
+        // Why: the dir vanished between readdir and stat (a live Codex sync
+        // promoted/removed it). Nothing to reclaim — skip it.
+        continue
+      }
+      if (now - newestMtimeMs < CODEX_MARKETPLACE_STALE_AGE_MS) {
+        continue
+      }
+      try {
+        rmSync(dirPath, { recursive: true, force: true })
+      } catch (error) {
+        console.warn(
+          `[codex-runtime-home] Failed to remove stale marketplace staging dir ${dirPath}:`,
+          error
+        )
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Codex CLI stages git-sourced marketplace upgrades/adds by cloning the full repo (~100-230 MB each, mostly `.git` history) into `<CODEX_HOME>/.tmp/marketplaces/.staging/marketplace-upgrade-*` (and `marketplace-add-*`) before atomically swapping it into place. If the CLI is killed, crashes, or a clone times out mid-sync, the staging clone is orphaned and can accumulate indefinitely under Orca's managed Codex runtime home.

This is an upstream Codex bug ([openai/codex#21005](https://github.com/openai/codex/issues/21005), [openai/codex#29994](https://github.com/openai/codex/issues/29994)). Orca does not pin the user's Codex CLI version, but it owns the runtime home the leak lands in, so this PR bounds the disk growth for Orca-launched Codex sessions.

The sweep removes only aged orphan dirs matching these exact upstream temp prefixes:

- `.tmp/marketplaces/.staging/marketplace-upgrade-*`
- `.tmp/marketplaces/.staging/marketplace-add-*`
- `.tmp/marketplaces/marketplace-backup-*`

It runs for the host runtime home on startup and for WSL runtime homes when the WSL selection is synced.

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec vitest run src/main/codex-accounts/runtime-home-service.test.ts`
- [x] `pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
- [x] `pnpm exec oxlint src/main/codex-accounts/runtime-home-service.ts src/main/codex-accounts/runtime-home-service.test.ts`
- [x] `pnpm exec oxfmt --write src/main/codex-accounts/runtime-home-service.ts src/main/codex-accounts/runtime-home-service.test.ts`
- [x] Added regression tests for stale cleanup, fresh/in-flight preservation, recursive nested clone activity, unrelated dir preservation, missing-tree no-op, backup-root cleanup, and WSL runtime-home cleanup.

## AI Review Report

Reviewed the cleanup for race safety, cross-platform behavior, and repo-fit. The review flagged that checking only the staging root directory `mtime` could delete a long-running clone whose recent writes happen deeper under `.git/objects`; the implementation now compares the newest mtime anywhere in the candidate subtree before deleting. The review also checked macOS/Linux/Windows path handling, including WSL UNC runtime homes; the code keeps `path.join`/Node fs handling already used by `CodexRuntimeHomeService` for WSL runtime-home files and leaves shell-specific WSL symlink migration unchanged.

## Security Audit

This change does not add IPC, network calls, command execution, dependencies, or auth handling. Path deletion is constrained to Orca's managed Codex runtime home, exact known Codex marketplace temp prefixes, and dirs whose newest subtree activity is older than one hour. The sweep is best-effort and fail-open: filesystem errors are logged and never block runtime-home setup or Codex launch.

## Notes

The upstream Codex issues remain open and no upstream cleanup PR is currently merged. This Orca-side sweep is defensive and can be removed later if Orca starts pinning a Codex version that includes upstream marketplace temp cleanup.

X: @wolfie_

## ELI5

Installing or updating a plugin can leave temporary copies behind. This PR tries to clean them up, but it still needs a way to prove a copy is unused and avoid making Orca pause while scanning it.

<!-- oss-readiness-review -->
## Readiness review — 2026-09-08

**Held — redesign required.** The original cleanup still conflicts with the current runtime-home split. Extracted fixture probe: 10,001 synchronous stats, three listings, 53.24ms blocked for 10,000 fresh files. Cleanup needs bounded asynchronous work outside launch and established ownership/orphan proof before deletion. Age alone does not establish ownership; no data loss was proven. Three counsel seats classify measured performance finding P2. No branch changes or cleanup against user homes performed.

<!-- oss-visual-proof -->
## Visual proof

Not applicable as rendered UI proof. Needs bounded async cleanup and ownership proof. No data loss proven. The functional evidence is the tests or probe recorded in the readiness review; an illustrative screenshot would not establish correctness.
