### PR TITLE
Fix Windows agent hook regressions

### DIFF
--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -346,9 +346,12 @@ describe('wrapWindowsHookCommand', () => {
     return Buffer.from(encodedCommand!, 'base64').toString('utf16le')
   }
 
-  it('uses the script path directly when no cmd escaping is needed', () => {
+  it('invokes the .cmd through an encoded PowerShell command', () => {
     const command = wrapWindowsHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd')
-    expect(command).toBe('C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd')
+    expect(command).toMatch(/^powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/)
+    expect(decodeWindowsHookCommand(command)).toBe(
+      "& 'C:\\Users\\alice\\.orca\\agent-hooks\\codex-hook.cmd'; exit $LASTEXITCODE"
+    )
   })
 
   // Why: a user profile path like `C:\Users\Jane Doe` is the regression from
@@ -408,7 +411,7 @@ describe('buildWindowsAgentHookCurlPostCommand', () => {
   it('posts form fields via curl.exe and reads the payload from stdin', () => {
     const command = buildWindowsAgentHookCurlPostCommand('codex')
 
-    // Why: the fast path must not spawn a second PowerShell — that startup cost
+    // Why: the fast path must not spawn a second PowerShell; that startup cost
     // is the regression this replaces.
     expect(command).not.toMatch(/powershell/i)
     expect(command).toContain('%SystemRoot%\\System32\\curl.exe')

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -148,11 +148,9 @@ function quotePowerShellString(value: string): string {
 }
 
 export function wrapWindowsHookCommand(scriptPath: string): string {
-  if (!/[ \t&()^|<>%!"]/u.test(scriptPath)) {
-    return scriptPath
-  }
-  // Why: Windows splits raw hook commands on whitespace, and cmd.exe expands
-  // `%`/`^`; use PowerShell only for paths that need that compatibility shim.
+  // Why: most Windows agents run hooks through Git Bash or another shell that
+  // mangles a raw backslash path. Codex has its own cmd.exe-safe fast path; the
+  // shared wrapper keeps the encoded launcher for every other agent.
   const command = `& ${quotePowerShellString(scriptPath)}; exit $LASTEXITCODE`
   const encodedCommand = Buffer.from(command, 'utf16le').toString('base64')
   return `powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`
@@ -181,7 +179,7 @@ export function buildWindowsAgentHookPostCommand(source: AgentHookSource): strin
 // <event> hook" rows make visible. curl.exe (Windows 10 1803+) posts the same
 // form fields as the POSIX hook and reads the raw payload from stdin via
 // `--data-urlencode payload@-`, so UTF-8 (e.g. CJK prompts) survives byte-for-
-// byte without the code-page translation that forced the PowerShell post.
+// byte without the code-page translation that previously forced PowerShell.
 export function buildWindowsAgentHookCurlPostCommand(source: AgentHookSource): string {
   return [
     '"%SystemRoot%\\System32\\curl.exe" -sS -X POST',

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -115,13 +115,14 @@ function markHookTrustDisabled(toml: string, header: string): string {
 }
 
 function localManagedCodexEvents(): string[] {
-  return process.platform === 'win32'
-    ? ['PermissionRequest', 'PostToolUse', 'PreToolUse']
-    : ['PermissionRequest', 'PostToolUse', 'PreToolUse', 'SessionStart', 'Stop', 'UserPromptSubmit']
-}
-
-function localHasManagedCodexLifecycleHooks(): boolean {
-  return process.platform !== 'win32'
+  return [
+    'PermissionRequest',
+    'PostToolUse',
+    'PreToolUse',
+    'SessionStart',
+    'Stop',
+    'UserPromptSubmit'
+  ]
 }
 
 describe('CodexHookService', () => {
@@ -434,18 +435,13 @@ describe('CodexHookService', () => {
         { matcher?: string; hooks?: { command?: string; statusMessage?: string }[] }[]
       >
     }
-    const userStopIndex = localHasManagedCodexLifecycleHooks() ? 1 : 0
-    expect(runtimeHooks.hooks.Stop?.[userStopIndex]?.matcher).toBe('*')
-    expect(runtimeHooks.hooks.Stop?.[userStopIndex]?.hooks?.[0]?.command).toBe('user-hook')
-    expect(runtimeHooks.hooks.Stop?.[userStopIndex]?.hooks?.[0]?.statusMessage).toBe(
-      'Running user hook'
-    )
+    expect(runtimeHooks.hooks.Stop?.[1]?.matcher).toBe('*')
+    expect(runtimeHooks.hooks.Stop?.[1]?.hooks?.[0]?.command).toBe('user-hook')
+    expect(runtimeHooks.hooks.Stop?.[1]?.hooks?.[0]?.statusMessage).toBe('Running user hook')
 
     const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
-    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:${userStopIndex}:0`))
-    if (localHasManagedCodexLifecycleHooks()) {
-      expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
-    }
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
     expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:0:0`))
   })
 
@@ -545,9 +541,7 @@ describe('CodexHookService', () => {
     const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
     expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
     expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
-    if (localHasManagedCodexLifecycleHooks()) {
-      expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:2:0`))
-    }
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:2:0`))
     expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:0:0`))
     expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:1:0`))
   })
@@ -622,9 +616,7 @@ describe('CodexHookService', () => {
       ) ?? []
 
     expect(stopCommands).toContain(userCommand)
-    expect(stopCommands.some((command) => isCodexManagedCommand(command))).toBe(
-      localHasManagedCodexLifecycleHooks()
-    )
+    expect(stopCommands.some((command) => isCodexManagedCommand(command))).toBe(true)
     expect(runtimeHooks.hooks.PreCompact).toBeUndefined()
     for (const command of pluginCommands) {
       expect(runtimeHooksText).not.toContain(command)
@@ -632,9 +624,7 @@ describe('CodexHookService', () => {
 
     const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
     expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
-    if (localHasManagedCodexLifecycleHooks()) {
-      expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
-    }
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
     for (const command of pluginCommands) {
       expect(runtimeToml).not.toContain(command)
     }
@@ -732,10 +722,7 @@ describe('CodexHookService', () => {
 
     const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
     const managedHooksPath = join(managedCodexHome, 'hooks.json')
-    const runtimeUserStopIndex = localHasManagedCodexLifecycleHooks() ? 1 : 0
-    const runtimeUserTrustHeader = hookTrustHeader(
-      `${managedHooksPath}:stop:${runtimeUserStopIndex}:0`
-    )
+    const runtimeUserTrustHeader = hookTrustHeader(`${managedHooksPath}:stop:1:0`)
     expect(readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')).toContain(
       runtimeUserTrustHeader
     )
@@ -745,11 +732,7 @@ describe('CodexHookService', () => {
 
     const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
     expect(runtimeToml).not.toContain(runtimeUserTrustHeader)
-    if (localHasManagedCodexLifecycleHooks()) {
-      expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
-    } else {
-      expect(runtimeToml).not.toContain(':stop:0:0')
-    }
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
   })
 
   it('refreshes mirrored system user hooks when the system hooks file changes', () => {
@@ -1197,9 +1180,7 @@ describe('CodexHookService', () => {
         (definition) => definition.hooks?.map((hook) => hook.command ?? '') ?? []
       ) ?? []
     expect(stopCommands).toContain(userCommand)
-    expect(stopCommands.some((command) => isCodexManagedCommand(command))).toBe(
-      localHasManagedCodexLifecycleHooks()
-    )
+    expect(stopCommands.some((command) => isCodexManagedCommand(command))).toBe(true)
     expect(
       isCodexManagedCommand(runtimeHooks.hooks.PermissionRequest?.[0]?.hooks?.[0]?.command)
     ).toBe(true)

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -59,16 +59,6 @@ const CODEX_EVENTS = [
   'Stop'
 ] as const
 
-const CODEX_WINDOWS_LOCAL_EVENTS = ['PreToolUse', 'PermissionRequest', 'PostToolUse'] as const
-
-function getLocalCodexManagedEvents(): readonly (typeof CODEX_EVENTS)[number][] {
-  // Why: Codex renders synchronous lifecycle hooks as prominent TUI progress
-  // rows on Windows, where even fast hook processes leave multi-second stale
-  // screen fragments. Keep the tool/permission hooks Orca needs for live
-  // status and approvals, but avoid chat lifecycle hooks in local Windows PTYs.
-  return process.platform === 'win32' ? CODEX_WINDOWS_LOCAL_EVENTS : CODEX_EVENTS
-}
-
 function getConfigPath(): string {
   return join(getOrcaManagedCodexHomePath(), 'hooks.json')
 }
@@ -96,9 +86,9 @@ const CODEX_EVENT_LABEL: Record<(typeof CODEX_EVENTS)[number], CodexEventLabel> 
   Stop: 'stop'
 }
 
-function getLocalCodexManagedEventLabels(): Set<CodexEventLabel> {
-  return new Set(getLocalCodexManagedEvents().map((eventName) => CODEX_EVENT_LABEL[eventName]))
-}
+const CODEX_MANAGED_EVENT_LABELS = new Set<CodexEventLabel>(
+  CODEX_EVENTS.map((eventName) => CODEX_EVENT_LABEL[eventName])
+)
 
 const CODEX_HOOK_EVENT_LABEL: Record<string, CodexEventLabel> = {
   ...CODEX_EVENT_LABEL,
@@ -470,7 +460,7 @@ function moveMirroredRuntimeUserTrustAfterManagedStatusHook(
   entries: readonly MirroredRuntimeUserHookTrustEntry[]
 ): MirroredRuntimeUserHookTrustEntry[] {
   return entries.map(({ entry, enabled }) => {
-    if (!getLocalCodexManagedEventLabels().has(entry.eventLabel)) {
+    if (!CODEX_MANAGED_EVENT_LABELS.has(entry.eventLabel)) {
       return { entry, enabled }
     }
     return {
@@ -785,7 +775,7 @@ export class CodexHookService {
     const trustMissing: string[] = []
     const disabled: string[] = []
     let presentCount = 0
-    for (const eventName of getLocalCodexManagedEvents()) {
+    for (const eventName of CODEX_EVENTS) {
       const definitions = Array.isArray(config.hooks?.[eventName]) ? config.hooks![eventName]! : []
       // Why: older installs appended this command, while current installs
       // prepend it. Picking the last match keeps status repair conservative
@@ -889,8 +879,7 @@ export class CodexHookService {
     const command = getManagedCommand(scriptPath)
     const hookPlan = getRuntimeHooksWithSystemUserHooks(config.hooks, isManagedCommand)
     const nextHooks = hookPlan.hooks
-    const localManagedEvents = getLocalCodexManagedEvents()
-    const managedEvents = new Set<string>(localManagedEvents)
+    const managedEvents = new Set<string>(CODEX_EVENTS)
 
     // Why: sweep managed entries out of events we no longer subscribe to
     // (e.g., PreToolUse from a prior install). Without this, users who
@@ -923,7 +912,7 @@ export class CodexHookService {
       hookPlan.trustEntries
     )
     const trustEntries: CodexTrustEntry[] = mirroredUserTrustEntries.map(({ entry }) => entry)
-    for (const eventName of localManagedEvents) {
+    for (const eventName of CODEX_EVENTS) {
       const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
       const cleaned = removeManagedCommands(current, isManagedCommand)
       const definition: HookDefinition = {


### PR DESCRIPTION
## Summary
- restore all six managed Codex events on local Windows instead of limiting installs/status to only PreToolUse/PermissionRequest/PostToolUse
- restore the shared Windows hook launcher to always use the encoded PowerShell wrapper so Claude/Git-Bash-style agents do not receive bare backslash paths
- keep Codex's private cmd-safe fast path and the curl-based Windows post path from #6402, so common Codex hooks stay fast without dropping lifecycle events

## Regression history checked
- #6078 fixed spaced Windows profile paths by wrapping hook launchers, but made Codex pay an extra PowerShell startup per hook
- #6388 repaired Codex hook trust prompts on Windows upgrades; this PR keeps those trust-key/status behaviors intact
- #6398 avoided Codex TUI hook slowness by dropping SessionStart/UserPromptSubmit/Stop on local Windows; this PR removes that behavior and restores the normal all-event surface
- #6402 added the fast Codex cmd-safe path and curl poster, but its shared bare-path launcher was too broad for Git Bash agents; this PR scopes bare paths back to Codex only

## Validation
- `pnpm test -- src/main/codex/hook-service.test.ts src/main/agent-hooks/installer-utils.test.ts src/main/claude/hook-service.test.ts` -> 65 passed / 3 skipped
- `pnpm test -- src/main/agent-hooks/server.test.ts` -> 220 passed
- `pnpm run typecheck:node`
- targeted `oxlint` on touched hook files
- `git diff --check`
- direct Windows shell probes:
  - Codex-style `cmd.exe /C <bare .cmd>` posted UTF-8 CJK payload and metadata through curl
  - Claude-style real Git Bash executed the encoded PowerShell launcher for a spaced path and posted UTF-8 CJK payload through curl

## Notes
- I attempted a real isolated Codex 0.140 `CODEX_HOME` run, but the temp profile had no auth and exited 401 before hooks could fire; I did not point the repro at a real user profile.