### PR TITLE
fix(browser): keep webview guests alive across worktree switches

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -80,10 +80,19 @@ import {
 import { rememberLiveBrowserUrl } from './browser-runtime'
 import {
   destroyPersistentWebview,
+  moveFocusToRendererBeforeWebviewDetach,
   registerPersistentWebview,
   registeredWebContentsIds,
   webviewRegistry
 } from './webview-registry'
+import {
+  applyBrowserPageViewportLayout,
+  ensureBrowserPageViewport,
+  getBrowserOverlaySlotViewport,
+  parkBrowserPageViewport,
+  subscribeBrowserOverlaySlotViewport,
+  syncBrowserPageChromeInset
+} from './browser-page-viewport'
 import { useBrowserAutomationVisiblePageIds } from './browser-automation-visibility'
 import type {
   BrowserDownloadRequestedEvent,
@@ -2661,21 +2670,25 @@ function BrowserPagePane({
     isAutomationVisible,
     isMobileDriven
   })
+  const pageViewport = ensureBrowserPageViewport(browserTab.id, workspaceId)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  containerRef.current = pageViewport?.container ?? null
+  const chromeHeaderRef = useRef<HTMLDivElement | null>(null)
   const grabToastTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const annotationCopyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const browserZoomFeedbackTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-  const setContainerRef = useCallback((node: HTMLDivElement | null): void => {
-    containerRef.current = node
-    if (node !== null) {
+  const [slotViewportReady, setSlotViewportReady] = useState(
+    () => getBrowserOverlaySlotViewport(workspaceId) !== null
+  )
+  useLayoutEffect(() => {
+    if (getBrowserOverlaySlotViewport(workspaceId)) {
+      setSlotViewportReady(true)
       return
     }
-    // Why: feedback timers are scoped to this pane owner and must not fire
-    // after the DOM owner is detached.
-    clearTimeout(grabToastTimerRef.current)
-    clearTimeout(annotationCopyTimerRef.current)
-    clearTimeout(browserZoomFeedbackTimerRef.current)
-  }, [])
+    return subscribeBrowserOverlaySlotViewport(workspaceId, () => {
+      setSlotViewportReady(true)
+    })
+  }, [workspaceId])
   const addressBarInputRef = useRef<HTMLInputElement | null>(null)
   const dismissAddressBarSuggestionsRef = useRef<(() => void) | null>(null)
   const webviewRef = useRef<Electron.WebviewTag | null>(null)
@@ -2694,6 +2707,8 @@ function BrowserPagePane({
       webviewRef.current?.goForward()
     }
   }
+  const handleInternalFileDragOverRef = useRef<(event: DragEvent<HTMLDivElement>) => void>(() => {})
+  const handleInternalFileDropRef = useRef<(event: DragEvent<HTMLDivElement>) => void>(() => {})
   const keybindings = useAppStore((state) => state.keybindings)
   const browserDefaultZoomLevel = useAppStore(
     (state) => state.browserDefaultZoomLevel ?? DEFAULT_BROWSER_PAGE_ZOOM_LEVEL
@@ -3548,7 +3563,7 @@ function BrowserPagePane({
   // logic inside the effect reads from browserTabUrlRef instead.
   // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
   useEffect(() => {
-    const container = containerRef.current
+    let container = ensureBrowserPageViewport(browserTab.id, workspaceId)?.container ?? null
     if (!container) {
       return
     }
@@ -3561,6 +3576,10 @@ function BrowserPagePane({
       // guest document. Treat unexpected parent drift as stale state instead.
       destroyPersistentWebview(browserTab.id)
       webview = undefined
+      container = ensureBrowserPageViewport(browserTab.id, workspaceId)?.container ?? null
+      if (!container) {
+        return
+      }
     }
     if (webview) {
       webview.style.pointerEvents = inputLockedRef.current ? 'none' : 'auto'
@@ -3593,6 +3612,23 @@ function BrowserPagePane({
     }
 
     webviewRef.current = webview
+
+    // Why: the viewport shell is created display:none and the lifecycle cleanup
+    // parks it; the separate visibility layout effect (deps isActive/isPaintable)
+    // does NOT re-run when the viewport first appears (slotViewportReady flip) or
+    // on remount, so the shell must be un-parked here — before the initial
+    // `webview.src` is assigned — or the guest navigates while hidden and stays
+    // blank/about:blank.
+    applyBrowserPageViewportLayout(browserTab.id, { paintable: isPaintable, active: isActive })
+
+    const onContainerDragOver = (event: globalThis.DragEvent): void => {
+      handleInternalFileDragOverRef.current(event as unknown as DragEvent<HTMLDivElement>)
+    }
+    const onContainerDrop = (event: globalThis.DragEvent): void => {
+      handleInternalFileDropRef.current(event as unknown as DragEvent<HTMLDivElement>)
+    }
+    container.addEventListener('dragover', onContainerDragOver)
+    container.addEventListener('drop', onContainerDrop)
 
     const dismissAddressBarSuggestions = (): void => {
       dismissAddressBarSuggestionsRef.current?.()
@@ -3875,14 +3911,17 @@ function BrowserPagePane({
       webview.removeEventListener('page-favicon-updated', handleFaviconUpdate)
       webview.removeEventListener('did-fail-load', handleFailLoad)
       webview.removeEventListener('console-message', handleAnnotationViewportMessage)
+      container.removeEventListener('dragover', onContainerDragOver)
+      container.removeEventListener('drop', onContainerDrop)
 
       if (webviewRef.current === webview) {
         webviewRef.current = null
       }
 
-      if (webviewRegistry.get(browserTab.id) === webview) {
-        destroyPersistentWebview(browserTab.id)
-      }
+      // Why: park the viewport when chrome unmounts (worktree switch) so the
+      // guest stays alive. Destruction is reserved for explicit close paths.
+      moveFocusToRendererBeforeWebviewDetach(webview)
+      parkBrowserPageViewport(browserTab.id)
     }
     // Why: this effect mounts and wires up webview event listeners once per tab
     // identity. browserTab.url is intentionally excluded: re-running on URL
@@ -3894,8 +3933,9 @@ function BrowserPagePane({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     browserTab.id,
-    webviewPartition,
     workspaceId,
+    slotViewportReady,
+    webviewPartition,
     worktreeId,
     createBrowserTab,
     focusAddressBarNow,
@@ -3903,6 +3943,30 @@ function BrowserPagePane({
     syncNavigationState,
     syncBrowserAnnotationViewportBridge
   ])
+
+  useLayoutEffect(() => {
+    applyBrowserPageViewportLayout(browserTab.id, { paintable: isPaintable, active: isActive })
+    const syncChromeInset = (): void => {
+      const header = chromeHeaderRef.current
+      if (!header) {
+        return
+      }
+      syncBrowserPageChromeInset(browserTab.id, header.offsetHeight)
+    }
+    syncChromeInset()
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(syncChromeInset)
+    const header = chromeHeaderRef.current
+    if (header) {
+      resizeObserver?.observe(header)
+    }
+    return () => {
+      resizeObserver?.disconnect()
+    }
+    // Why: slotViewportReady gates viewport creation. Re-run once the viewport
+    // exists so visibility AND the chrome-inset measurement land on a real shell
+    // (the first render no-ops because ensureBrowserPageViewport returned null).
+  }, [browserTab.id, isActive, isPaintable, slotViewportReady])
 
   useEffect(() => {
     syncBrowserAnnotationViewportBridge()
@@ -4552,6 +4616,7 @@ function BrowserPagePane({
     event.stopPropagation()
     event.dataTransfer.dropEffect = 'copy'
   }, [])
+  handleInternalFileDragOverRef.current = handleInternalFileDragOver
 
   const handleInternalFileDrop = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
@@ -4596,6 +4661,7 @@ function BrowserPagePane({
     },
     [navigateToUrl, worktreeId]
   )
+  handleInternalFileDropRef.current = handleInternalFileDrop
 
   const dismissBrowserDownload = useCallback((downloadId: string) => {
     setDownloadStates((current) => current.filter((download) => download.downloadId !== downloadId))
@@ -4648,7 +4714,7 @@ function BrowserPagePane({
       className={cn(
         'absolute inset-0 flex min-h-0 flex-1 flex-col',
         isActive
-          ? 'z-10'
+          ? 'pointer-events-none z-10'
           : isPaintable
             ? 'pointer-events-none z-0 opacity-0'
             : 'pointer-events-none hidden'
@@ -4800,269 +4866,290 @@ function BrowserPagePane({
           )
         : null}
 
-      <div
-        className="relative z-10 flex items-center gap-2 border-b border-border/70 bg-background/95 px-3 py-1.5"
-        data-contextual-tour-target="browser-toolbar"
-      >
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7"
-          onClick={() => webviewRef.current?.goBack()}
-          disabled={!browserTab.canGoBack}
+      <div ref={chromeHeaderRef} className="pointer-events-auto shrink-0">
+        <div
+          className="relative z-10 flex items-center gap-2 border-b border-border/70 bg-background/95 px-3 py-1.5"
+          data-contextual-tour-target="browser-toolbar"
         >
-          <ArrowLeft className="size-4" />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7"
-          onClick={() => webviewRef.current?.goForward()}
-          disabled={!browserTab.canGoForward}
-        >
-          <ArrowRight className="size-4" />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7"
-          onClick={() => {
-            const webview = webviewRef.current
-            if (!webview) {
-              return
-            }
-            if (browserTab.loading) {
-              webview.stop()
-            } else if (browserTab.loadError) {
-              retryBrowserTabLoad(webview, browserTab, onUpdatePageStateRef.current)
-            } else {
-              webview.reload()
-            }
-          }}
-        >
-          {browserTab.loading ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : (
-            <RefreshCw className="size-4" />
-          )}
-        </Button>
-
-        <BrowserAddressBar
-          value={addressBarValue}
-          onChange={setAddressBarValue}
-          onSubmit={submitAddressBar}
-          onNavigate={navigateToUrl}
-          inputRef={addressBarInputRef}
-          dismissSuggestionsRef={dismissAddressBarSuggestionsRef}
-        />
-
-        <BrowserImportHintButton profileId={sessionProfileId} />
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
-              <Button
-                size="icon"
-                variant={grab.state !== 'idle' && grabIntent === 'copy' ? 'default' : 'ghost'}
-                className={cn(
-                  'h-8 w-8',
-                  grab.state !== 'idle' &&
-                    grabIntent === 'copy' &&
-                    'bg-foreground/80 text-background hover:bg-foreground/90'
-                )}
-                onClick={() => startGrabIntent('copy')}
-                disabled={isBlankTab}
-                aria-label={translate(
-                  'auto.components.browser.pane.BrowserPane.fdfc7fe0ef',
-                  'Grab page element'
-                )}
-                data-contextual-tour-target="browser-grab-control"
-              >
-                <Crosshair className="size-4" />
-              </Button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={4}>
-            {translate(
-              'auto.components.browser.pane.BrowserPane.acbe79fd01',
-              'Grab page element ({{value0}})',
-              { value0: grabElementShortcut }
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7"
+            onClick={() => webviewRef.current?.goBack()}
+            disabled={!browserTab.canGoBack}
+          >
+            <ArrowLeft className="size-4" />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7"
+            onClick={() => webviewRef.current?.goForward()}
+            disabled={!browserTab.canGoForward}
+          >
+            <ArrowRight className="size-4" />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7"
+            onClick={() => {
+              const webview = webviewRef.current
+              if (!webview) {
+                return
+              }
+              if (browserTab.loading) {
+                webview.stop()
+              } else if (browserTab.loadError) {
+                retryBrowserTabLoad(webview, browserTab, onUpdatePageStateRef.current)
+              } else {
+                webview.reload()
+              }
+            }}
+          >
+            {browserTab.loading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <RefreshCw className="size-4" />
             )}
-          </TooltipContent>
-        </Tooltip>
+          </Button>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            {/* Why: wrap the disabled button in a span so pointer events still
+          <BrowserAddressBar
+            value={addressBarValue}
+            onChange={setAddressBarValue}
+            onSubmit={submitAddressBar}
+            onNavigate={navigateToUrl}
+            inputRef={addressBarInputRef}
+            dismissSuggestionsRef={dismissAddressBarSuggestionsRef}
+          />
+
+          <BrowserImportHintButton profileId={sessionProfileId} />
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Button
+                  size="icon"
+                  variant={grab.state !== 'idle' && grabIntent === 'copy' ? 'default' : 'ghost'}
+                  className={cn(
+                    'h-8 w-8',
+                    grab.state !== 'idle' &&
+                      grabIntent === 'copy' &&
+                      'bg-foreground/80 text-background hover:bg-foreground/90'
+                  )}
+                  onClick={() => startGrabIntent('copy')}
+                  disabled={isBlankTab}
+                  aria-label={translate(
+                    'auto.components.browser.pane.BrowserPane.fdfc7fe0ef',
+                    'Grab page element'
+                  )}
+                  data-contextual-tour-target="browser-grab-control"
+                >
+                  <Crosshair className="size-4" />
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={4}>
+              {translate(
+                'auto.components.browser.pane.BrowserPane.acbe79fd01',
+                'Grab page element ({{value0}})',
+                { value0: grabElementShortcut }
+              )}
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* Why: wrap the disabled button in a span so pointer events still
                 reach the tooltip trigger — Radix (and the DOM) drop hover
                 events on disabled <button>, which is why the previous native
                 `title` attribute fired inconsistently. */}
-            <span className="inline-flex">
-              <Button
-                size="icon"
-                variant={grab.state !== 'idle' && grabIntent === 'annotate' ? 'default' : 'ghost'}
-                className={cn(
-                  'relative h-8 w-8',
-                  grab.state !== 'idle' &&
-                    grabIntent === 'annotate' &&
-                    'bg-foreground/80 text-background hover:bg-foreground/90'
-                )}
-                onClick={() => startGrabIntent('annotate')}
-                disabled={isBlankTab}
-                aria-label={translate(
-                  'auto.components.browser.pane.BrowserPane.fc9be38f6f',
-                  'Annotate page element'
-                )}
-                data-contextual-tour-target="browser-annotation-control"
-              >
-                <MessageSquarePlus className="size-4" />
-                {browserAnnotations.length > 0 ? (
-                  <span className="absolute -top-1 -right-1 flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] leading-4 text-primary-foreground">
-                    {browserAnnotations.length}
-                  </span>
-                ) : null}
-              </Button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={4}>
-            {translate(
-              'auto.components.browser.pane.BrowserPane.fc9be38f6f',
-              'Annotate page element'
-            )}
-          </TooltipContent>
-        </Tooltip>
-
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7"
-          onClick={() => void window.api.browser.openDevTools({ browserPageId: browserTab.id })}
-          title={translate(
-            'auto.components.browser.pane.BrowserPane.ec75d0c412',
-            'Open browser devtools'
-          )}
-        >
-          <SquareCode className="size-4" />
-        </Button>
-
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7"
-          onClick={() => {
-            if (!externalUrl) {
-              return
-            }
-            void window.api.shell.openUrl(externalUrl)
-          }}
-          title={translate(
-            'auto.components.browser.pane.BrowserPane.0f41bf80c7',
-            'Open in default browser'
-          )}
-          disabled={!externalUrl}
-        >
-          <ExternalLink className="size-4" />
-        </Button>
-
-        <BrowserToolbarMenu
-          currentProfileId={sessionProfileId}
-          workspaceId={workspaceId}
-          browserPageId={browserTab.id}
-          viewportPresetId={browserTab.viewportPresetId ?? null}
-          onDestroyWebview={() => destroyPersistentWebview(browserTab.id)}
-          isActive={isActive}
-        />
-      </div>
-      {visibleDownloads.length > 0 ? (
-        <div className="border-b border-border/60 bg-background px-3 py-1.5">
-          <div className="scrollbar-sleek flex max-h-36 flex-col gap-1 overflow-y-auto">
-            {visibleDownloads.map((download) => {
-              const progressLabel = formatBrowserDownloadProgress(download)
-              const statusLabel =
-                download.status === 'downloading'
-                  ? download.progressState === 'interrupted'
-                    ? translate(
-                        'auto.components.browser.pane.BrowserPane.39c04fed61',
-                        'Downloading paused'
-                      )
-                    : (progressLabel ??
-                      translate(
-                        'auto.components.browser.pane.BrowserPane.759f32af29',
-                        'Downloading'
-                      ))
-                  : download.status === 'completed'
-                    ? translate('auto.components.browser.pane.BrowserPane.5c3d530a68', 'Downloaded')
-                    : download.status === 'canceled'
-                      ? translate('auto.components.browser.pane.BrowserPane.4bb7424d6b', 'Canceled')
-                      : (download.error ??
-                        translate(
-                          'auto.components.browser.pane.BrowserPane.6e776f9ef9',
-                          'Download failed'
-                        ))
-              return (
-                <div
-                  key={download.downloadId}
-                  className="flex min-h-8 items-center gap-2 text-xs text-foreground"
-                >
-                  {download.status === 'completed' ? (
-                    <CircleCheck className="size-3.5 shrink-0 text-muted-foreground" />
-                  ) : download.status === 'failed' ? (
-                    <OctagonX className="size-3.5 shrink-0 text-muted-foreground" />
-                  ) : (
-                    <Download className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="inline-flex">
+                <Button
+                  size="icon"
+                  variant={grab.state !== 'idle' && grabIntent === 'annotate' ? 'default' : 'ghost'}
+                  className={cn(
+                    'relative h-8 w-8',
+                    grab.state !== 'idle' &&
+                      grabIntent === 'annotate' &&
+                      'bg-foreground/80 text-background hover:bg-foreground/90'
                   )}
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate font-medium">{download.filename}</div>
-                    <div className="truncate text-muted-foreground">
-                      {download.status === 'downloading'
+                  onClick={() => startGrabIntent('annotate')}
+                  disabled={isBlankTab}
+                  aria-label={translate(
+                    'auto.components.browser.pane.BrowserPane.fc9be38f6f',
+                    'Annotate page element'
+                  )}
+                  data-contextual-tour-target="browser-annotation-control"
+                >
+                  <MessageSquarePlus className="size-4" />
+                  {browserAnnotations.length > 0 ? (
+                    <span className="absolute -top-1 -right-1 flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] leading-4 text-primary-foreground">
+                      {browserAnnotations.length}
+                    </span>
+                  ) : null}
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={4}>
+              {translate(
+                'auto.components.browser.pane.BrowserPane.fc9be38f6f',
+                'Annotate page element'
+              )}
+            </TooltipContent>
+          </Tooltip>
+
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7"
+            onClick={() => void window.api.browser.openDevTools({ browserPageId: browserTab.id })}
+            title={translate(
+              'auto.components.browser.pane.BrowserPane.ec75d0c412',
+              'Open browser devtools'
+            )}
+          >
+            <SquareCode className="size-4" />
+          </Button>
+
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7"
+            onClick={() => {
+              if (!externalUrl) {
+                return
+              }
+              void window.api.shell.openUrl(externalUrl)
+            }}
+            title={translate(
+              'auto.components.browser.pane.BrowserPane.0f41bf80c7',
+              'Open in default browser'
+            )}
+            disabled={!externalUrl}
+          >
+            <ExternalLink className="size-4" />
+          </Button>
+
+          <BrowserToolbarMenu
+            currentProfileId={sessionProfileId}
+            workspaceId={workspaceId}
+            browserPageId={browserTab.id}
+            viewportPresetId={browserTab.viewportPresetId ?? null}
+            onDestroyWebview={() => destroyPersistentWebview(browserTab.id)}
+            isActive={isActive}
+          />
+        </div>
+        {visibleDownloads.length > 0 ? (
+          <div className="border-b border-border/60 bg-background px-3 py-1.5">
+            <div className="scrollbar-sleek flex max-h-36 flex-col gap-1 overflow-y-auto">
+              {visibleDownloads.map((download) => {
+                const progressLabel = formatBrowserDownloadProgress(download)
+                const statusLabel =
+                  download.status === 'downloading'
+                    ? download.progressState === 'interrupted'
+                      ? translate(
+                          'auto.components.browser.pane.BrowserPane.39c04fed61',
+                          'Downloading paused'
+                        )
+                      : (progressLabel ??
+                        translate(
+                          'auto.components.browser.pane.BrowserPane.759f32af29',
+                          'Downloading'
+                        ))
+                    : download.status === 'completed'
+                      ? translate(
+                          'auto.components.browser.pane.BrowserPane.5c3d530a68',
+                          'Downloaded'
+                        )
+                      : download.status === 'canceled'
                         ? translate(
-                            'auto.components.browser.pane.BrowserPane.4300f38145',
-                            'Downloading from {{value0}}{{value1}}',
-                            {
-                              value0: download.origin,
-                              value1: statusLabel ? ` • ${statusLabel}` : ''
-                            }
+                            'auto.components.browser.pane.BrowserPane.4bb7424d6b',
+                            'Canceled'
                           )
-                        : statusLabel}
+                        : (download.error ??
+                          translate(
+                            'auto.components.browser.pane.BrowserPane.6e776f9ef9',
+                            'Download failed'
+                          ))
+                return (
+                  <div
+                    key={download.downloadId}
+                    className="flex min-h-8 items-center gap-2 text-xs text-foreground"
+                  >
+                    {download.status === 'completed' ? (
+                      <CircleCheck className="size-3.5 shrink-0 text-muted-foreground" />
+                    ) : download.status === 'failed' ? (
+                      <OctagonX className="size-3.5 shrink-0 text-muted-foreground" />
+                    ) : (
+                      <Download className="size-3.5 shrink-0 text-muted-foreground" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate font-medium">{download.filename}</div>
+                      <div className="truncate text-muted-foreground">
+                        {download.status === 'downloading'
+                          ? translate(
+                              'auto.components.browser.pane.BrowserPane.4300f38145',
+                              'Downloading from {{value0}}{{value1}}',
+                              {
+                                value0: download.origin,
+                                value1: statusLabel ? ` • ${statusLabel}` : ''
+                              }
+                            )
+                          : statusLabel}
+                      </div>
                     </div>
-                  </div>
-                  {download.status === 'downloading' ? (
-                    <Button
-                      size="xs"
-                      variant="ghost"
-                      className="h-6 shrink-0"
-                      onClick={() => {
-                        void window.api.browser.cancelDownload({
-                          downloadId: download.downloadId
-                        })
-                      }}
-                    >
-                      {translate('auto.components.browser.pane.BrowserPane.fa6ea61de3', 'Cancel')}
-                    </Button>
-                  ) : download.status === 'completed' ? (
-                    <>
-                      <Button
-                        size="xs"
-                        variant="outline"
-                        className="h-6 shrink-0 gap-1"
-                        onClick={() => {
-                          void handleOpenDownloadedFile(download)
-                        }}
-                      >
-                        <ExternalLink className="size-3" />
-                        {translate('auto.components.browser.pane.BrowserPane.756bfc25c9', 'Open')}
-                      </Button>
+                    {download.status === 'downloading' ? (
                       <Button
                         size="xs"
                         variant="ghost"
-                        className="h-6 shrink-0 gap-1"
+                        className="h-6 shrink-0"
                         onClick={() => {
-                          void handleShowDownloadedFile(download)
+                          void window.api.browser.cancelDownload({
+                            downloadId: download.downloadId
+                          })
                         }}
                       >
-                        <FolderOpen className="size-3" />
-                        {translate('auto.components.browser.pane.BrowserPane.09a9489aa5', 'Show')}
+                        {translate('auto.components.browser.pane.BrowserPane.fa6ea61de3', 'Cancel')}
                       </Button>
+                    ) : download.status === 'completed' ? (
+                      <>
+                        <Button
+                          size="xs"
+                          variant="outline"
+                          className="h-6 shrink-0 gap-1"
+                          onClick={() => {
+                            void handleOpenDownloadedFile(download)
+                          }}
+                        >
+                          <ExternalLink className="size-3" />
+                          {translate('auto.components.browser.pane.BrowserPane.756bfc25c9', 'Open')}
+                        </Button>
+                        <Button
+                          size="xs"
+                          variant="ghost"
+                          className="h-6 shrink-0 gap-1"
+                          onClick={() => {
+                            void handleShowDownloadedFile(download)
+                          }}
+                        >
+                          <FolderOpen className="size-3" />
+                          {translate('auto.components.browser.pane.BrowserPane.09a9489aa5', 'Show')}
+                        </Button>
+                        <Button
+                          size="icon-xs"
+                          variant="ghost"
+                          className="h-6 w-6 shrink-0"
+                          onClick={() => dismissBrowserDownload(download.downloadId)}
+                          aria-label={translate(
+                            'auto.components.browser.pane.BrowserPane.2fdca7df09',
+                            'Dismiss'
+                          )}
+                        >
+                          <X className="size-3.5" />
+                        </Button>
+                      </>
+                    ) : (
                       <Button
                         size="icon-xs"
                         variant="ghost"
@@ -5075,608 +5162,522 @@ function BrowserPagePane({
                       >
                         <X className="size-3.5" />
                       </Button>
-                    </>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ) : null}
+        {resourceNotice ? (
+          <div className="flex items-center justify-between gap-2 border-b border-border/60 bg-background px-3 py-1.5 text-xs text-muted-foreground">
+            <span>{resourceNotice}</span>
+            <button
+              type="button"
+              onClick={() => setResourceNotice(null)}
+              className="shrink-0 text-muted-foreground/60 hover:text-foreground"
+              aria-label={translate(
+                'auto.components.browser.pane.BrowserPane.2fdca7df09',
+                'Dismiss'
+              )}
+            >
+              ✕
+            </button>
+          </div>
+        ) : null}
+        {grab.state !== 'idle' ? (
+          <div
+            className={cn(
+              'flex items-center gap-2 border-b border-border/60 px-3 py-1.5 text-xs text-foreground/90',
+              grab.state === 'error' ? 'bg-destructive/10' : 'bg-accent'
+            )}
+          >
+            <Crosshair
+              className={cn(
+                'size-3 shrink-0',
+                grab.state === 'error' ? 'text-destructive' : 'text-muted-foreground'
+              )}
+            />
+            <span className="min-w-0 flex-1 truncate">
+              {grab.state === 'error'
+                ? translate(
+                    'auto.components.browser.pane.BrowserPane.4328a0a062',
+                    'Grab failed: {{value0}}',
+                    { value0: grab.error ?? 'Unknown error' }
+                  )
+                : grabIntent === 'annotate'
+                  ? pendingAnnotationPayload
+                    ? translate(
+                        'auto.components.browser.pane.BrowserPane.b733a91bd9',
+                        'Add feedback for the selected element.'
+                      )
+                    : browserAnnotations.length === 1
+                      ? translate(
+                          'auto.components.browser.pane.BrowserPane.074f0ed10b',
+                          '{{value0}} annotation ready. Select another element or copy all feedback.',
+                          { value0: browserAnnotations.length }
+                        )
+                      : browserAnnotations.length > 0
+                        ? translate(
+                            'auto.components.browser.pane.BrowserPane.a2164a6e5a',
+                            '{{value0}} annotations ready. Select another element or copy all feedback.',
+                            { value0: browserAnnotations.length }
+                          )
+                        : translate(
+                            'auto.components.browser.pane.BrowserPane.777b5bc4ec',
+                            'Click an element to add feedback for the agent.'
+                          )
+                  : grab.state === 'confirming'
+                    ? translate(
+                        'auto.components.browser.pane.BrowserPane.e852e20cea',
+                        'Copied — press S to screenshot, or select another element'
+                      )
+                    : translate(
+                        'auto.components.browser.pane.BrowserPane.168350ae6a',
+                        'Click or hover an element, then press C to copy or S to screenshot.'
+                      )}
+            </span>
+            {grabIntent === 'annotate' && browserAnnotations.length > 0 ? (
+              <>
+                <DropdownMenu
+                  modal={false}
+                  open={annotationBannerSendOpen}
+                  onOpenChange={handleAnnotationBannerSendOpenChange}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <Button size="xs" variant="outline" className="h-6 gap-1.5">
+                          <Send className="size-3" />
+                          {translate('auto.components.browser.pane.BrowserPane.ac39b9366b', 'Send')}
+                        </Button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" sideOffset={6}>
+                      {translate(
+                        'auto.components.browser.pane.BrowserPane.95af781091',
+                        'Send feedback to a new agent'
+                      )}
+                    </TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent
+                    align="end"
+                    className="min-w-[180px]"
+                    onInteractOutside={preventAgentSendTargetOutsideDismiss}
+                    onPointerDownOutside={preventAgentSendTargetOutsideDismiss}
+                  >
+                    <QuickLaunchAgentMenuItems
+                      worktreeId={worktreeId}
+                      groupId={activeGroupId ?? worktreeId}
+                      onFocusTerminal={focusTerminalTabSurface}
+                      prompt={browserAnnotationsPrompt}
+                      promptDelivery="submit-after-ready"
+                      launchSource="notes_send"
+                      onPromptDelivered={handleBrowserAnnotationsSentToAgent}
+                    />
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <Button
+                  size="xs"
+                  variant="outline"
+                  className="h-6 gap-1.5"
+                  onClick={handleCopyBrowserAnnotations}
+                >
+                  {browserAnnotationsCopied ? (
+                    <CircleCheck className="size-3" />
                   ) : (
+                    <Copy className="size-3" />
+                  )}
+                  {browserAnnotationsCopied
+                    ? translate('auto.components.browser.pane.BrowserPane.6f4ab3592b', 'Copied')
+                    : translate('auto.components.browser.pane.BrowserPane.499b31b84e', 'Copy All')}
+                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
                     <Button
                       size="icon-xs"
                       variant="ghost"
-                      className="h-6 w-6 shrink-0"
-                      onClick={() => dismissBrowserDownload(download.downloadId)}
+                      className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                      onClick={handleClearBrowserAnnotations}
                       aria-label={translate(
-                        'auto.components.browser.pane.BrowserPane.2fdca7df09',
-                        'Dismiss'
+                        'auto.components.browser.pane.BrowserPane.734e4343ec',
+                        'Clear browser annotations'
                       )}
                     >
-                      <X className="size-3.5" />
+                      <Trash2 className="size-3" />
                     </Button>
-                  )}
-                </div>
-              )
-            })}
-          </div>
-        </div>
-      ) : null}
-      {resourceNotice ? (
-        <div className="flex items-center justify-between gap-2 border-b border-border/60 bg-background px-3 py-1.5 text-xs text-muted-foreground">
-          <span>{resourceNotice}</span>
-          <button
-            type="button"
-            onClick={() => setResourceNotice(null)}
-            className="shrink-0 text-muted-foreground/60 hover:text-foreground"
-            aria-label={translate('auto.components.browser.pane.BrowserPane.2fdca7df09', 'Dismiss')}
-          >
-            ✕
-          </button>
-        </div>
-      ) : null}
-      {grab.state !== 'idle' ? (
-        <div
-          className={cn(
-            'flex items-center gap-2 border-b border-border/60 px-3 py-1.5 text-xs text-foreground/90',
-            grab.state === 'error' ? 'bg-destructive/10' : 'bg-accent'
-          )}
-        >
-          <Crosshair
-            className={cn(
-              'size-3 shrink-0',
-              grab.state === 'error' ? 'text-destructive' : 'text-muted-foreground'
-            )}
-          />
-          <span className="min-w-0 flex-1 truncate">
-            {grab.state === 'error'
-              ? translate(
-                  'auto.components.browser.pane.BrowserPane.4328a0a062',
-                  'Grab failed: {{value0}}',
-                  { value0: grab.error ?? 'Unknown error' }
-                )
-              : grabIntent === 'annotate'
-                ? pendingAnnotationPayload
-                  ? translate(
-                      'auto.components.browser.pane.BrowserPane.b733a91bd9',
-                      'Add feedback for the selected element.'
-                    )
-                  : browserAnnotations.length === 1
-                    ? translate(
-                        'auto.components.browser.pane.BrowserPane.074f0ed10b',
-                        '{{value0}} annotation ready. Select another element or copy all feedback.',
-                        { value0: browserAnnotations.length }
-                      )
-                    : browserAnnotations.length > 0
-                      ? translate(
-                          'auto.components.browser.pane.BrowserPane.a2164a6e5a',
-                          '{{value0}} annotations ready. Select another element or copy all feedback.',
-                          { value0: browserAnnotations.length }
-                        )
-                      : translate(
-                          'auto.components.browser.pane.BrowserPane.777b5bc4ec',
-                          'Click an element to add feedback for the agent.'
-                        )
-                : grab.state === 'confirming'
-                  ? translate(
-                      'auto.components.browser.pane.BrowserPane.e852e20cea',
-                      'Copied — press S to screenshot, or select another element'
-                    )
-                  : translate(
-                      'auto.components.browser.pane.BrowserPane.168350ae6a',
-                      'Click or hover an element, then press C to copy or S to screenshot.'
-                    )}
-          </span>
-          {grabIntent === 'annotate' && browserAnnotations.length > 0 ? (
-            <>
-              <DropdownMenu
-                modal={false}
-                open={annotationBannerSendOpen}
-                onOpenChange={handleAnnotationBannerSendOpenChange}
-              >
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <DropdownMenuTrigger asChild>
-                      <Button size="xs" variant="outline" className="h-6 gap-1.5">
-                        <Send className="size-3" />
-                        {translate('auto.components.browser.pane.BrowserPane.ac39b9366b', 'Send')}
-                      </Button>
-                    </DropdownMenuTrigger>
                   </TooltipTrigger>
                   <TooltipContent side="bottom" sideOffset={6}>
                     {translate(
-                      'auto.components.browser.pane.BrowserPane.95af781091',
-                      'Send feedback to a new agent'
+                      'auto.components.browser.pane.BrowserPane.11c5084aa2',
+                      'Clear annotations'
                     )}
                   </TooltipContent>
                 </Tooltip>
-                <DropdownMenuContent
-                  align="end"
-                  className="min-w-[180px]"
-                  onInteractOutside={preventAgentSendTargetOutsideDismiss}
-                  onPointerDownOutside={preventAgentSendTargetOutsideDismiss}
-                >
-                  <QuickLaunchAgentMenuItems
-                    worktreeId={worktreeId}
-                    groupId={activeGroupId ?? worktreeId}
-                    onFocusTerminal={focusTerminalTabSurface}
-                    prompt={browserAnnotationsPrompt}
-                    promptDelivery="submit-after-ready"
-                    launchSource="notes_send"
-                    onPromptDelivered={handleBrowserAnnotationsSentToAgent}
-                  />
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <Button
-                size="xs"
-                variant="outline"
-                className="h-6 gap-1.5"
-                onClick={handleCopyBrowserAnnotations}
-              >
-                {browserAnnotationsCopied ? (
-                  <CircleCheck className="size-3" />
-                ) : (
-                  <Copy className="size-3" />
-                )}
-                {browserAnnotationsCopied
-                  ? translate('auto.components.browser.pane.BrowserPane.6f4ab3592b', 'Copied')
-                  : translate('auto.components.browser.pane.BrowserPane.499b31b84e', 'Copy All')}
-              </Button>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="icon-xs"
-                    variant="ghost"
-                    className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                    onClick={handleClearBrowserAnnotations}
-                    aria-label={translate(
-                      'auto.components.browser.pane.BrowserPane.734e4343ec',
-                      'Clear browser annotations'
-                    )}
-                  >
-                    <Trash2 className="size-3" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>
-                  {translate(
-                    'auto.components.browser.pane.BrowserPane.11c5084aa2',
-                    'Clear annotations'
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </>
-          ) : null}
-          <button
-            className="ml-auto shrink-0 rounded px-2 py-0.5 text-muted-foreground transition-colors hover:text-foreground"
-            onClick={() => {
-              setPendingAnnotationPayload(null)
-              grab.cancel()
-            }}
-          >
-            {translate('auto.components.browser.pane.BrowserPane.fa6ea61de3', 'Cancel')}
-          </button>
-        </div>
-      ) : null}
-      <div
-        ref={setContainerRef}
-        className="relative flex min-h-0 flex-1 overflow-hidden bg-background"
-        onDragOver={handleInternalFileDragOver}
-        onDrop={handleInternalFileDrop}
-      >
-        <div
-          role="status"
-          aria-live="polite"
-          aria-hidden={browserZoomIndicatorState.ariaHidden}
-          className={cn(
-            'pointer-events-none absolute top-3 right-3 z-30 rounded-md border border-border bg-popover/95 px-2.5 py-1 text-xs font-medium text-popover-foreground shadow-xs transition-opacity duration-300 ease-out',
-            browserZoomIndicatorState.opacityClassName
-          )}
-        >
-          {browserZoomPercent}%
-        </div>
-        <BrowserFind isOpen={findOpen} onClose={() => setFindOpen(false)} webviewRef={webviewRef} />
-        {showFailureOverlay ? (
-          <div className="absolute inset-0 z-10 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.02),transparent_58%)] px-6">
-            <div className="flex max-w-sm flex-col items-center px-8 py-8 text-center opacity-70">
-              <div className="mb-4 rounded-full border border-border/70 bg-muted/30 p-3">
-                <Globe className="size-5 text-muted-foreground" />
-              </div>
-              <h2 className="text-base font-semibold text-foreground/85">
-                {loadErrorMeta.host
-                  ? translate(
-                      'auto.components.browser.pane.BrowserPane.db325a7eeb',
-                      "Can't reach {{value0}}",
-                      { value0: loadErrorMeta.host }
-                    )
-                  : translate(
-                      'auto.components.browser.pane.BrowserPane.b2856516e2',
-                      "Can't load this page"
-                    )}
-              </h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                {formatLoadFailureDescription(browserTab.loadError, loadErrorMeta)}
-              </p>
-              {loadErrorHint ? (
-                <p className="mt-2 text-xs text-muted-foreground/80">{loadErrorHint}</p>
-              ) : null}
-              <div className="mt-5 flex items-center gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-9 gap-2 px-3"
-                  title={translate('auto.components.browser.pane.BrowserPane.781d6459ad', 'Retry')}
-                  onClick={() => {
-                    const webview = webviewRef.current
-                    if (!webview) {
-                      return
-                    }
-                    onUpdatePageStateRef.current(browserTab.id, {
-                      loading: true
-                    })
-                    retryBrowserTabLoad(webview, browserTab, onUpdatePageStateRef.current)
-                  }}
-                >
-                  <RefreshCw className="size-4" />
-                  <span>
-                    {translate('auto.components.browser.pane.BrowserPane.c6be71329e', 'Refresh')}
-                  </span>
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-9 gap-2 px-3"
-                  title={translate(
-                    'auto.components.browser.pane.BrowserPane.3c085f638d',
-                    'Copy failed page URL'
-                  )}
-                  onClick={() => {
-                    // Why: failed guests often leave users stranded on a blank
-                    // error surface. Put the current URL on the clipboard from
-                    // the recovery UI itself so they can retry elsewhere
-                    // without having to discover the toolbar overflow first.
-                    void window.api.ui.writeClipboardText(currentBrowserUrl)
-                    setResourceNotice('Copied the current page URL.')
-                  }}
-                >
-                  <Copy className="size-4" />
-                  <span>
-                    {translate(
-                      'auto.components.browser.pane.BrowserPane.93be92f8d1',
-                      'Copy Address'
-                    )}
-                  </span>
-                </Button>
-                {externalUrl ? (
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="h-9 gap-2 px-3"
-                    title={translate(
-                      'auto.components.browser.pane.BrowserPane.da68d35f7b',
-                      'Open failed page in default browser'
-                    )}
-                    onClick={() => {
-                      // Why: page failures inside Orca can still be recoverable
-                      // in the system browser, especially for OAuth, captive
-                      // portals, or enterprise auth flows that rely on a full
-                      // browser profile. Keep this action in the failed-state
-                      // overlay so recovery does not depend on toolbar affordance
-                      // discovery while the guest itself is unusable.
-                      void window.api.shell.openUrl(externalUrl)
-                    }}
-                  >
-                    <ExternalLink className="size-4" />
-                    <span>
-                      {translate(
-                        'auto.components.browser.pane.BrowserPane.1c78adc73d',
-                        'Open Externally'
-                      )}
-                    </span>
-                  </Button>
-                ) : null}
-              </div>
-            </div>
-          </div>
-        ) : null}
-        {isBlankTab ? (
-          <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.02),transparent_58%)] px-6">
-            <div className="flex flex-col items-center px-8 py-8 text-center opacity-70">
-              <div className="mb-4 rounded-full border border-border/70 bg-muted/30 p-3">
-                <Globe className="size-5 text-muted-foreground" />
-              </div>
-              <div className="text-center">
-                <p className="text-base font-semibold text-foreground/85">
-                  {translate('auto.components.browser.pane.BrowserPane.366bf5d62c', 'New Tab')}
-                </p>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {translate(
-                    'auto.components.browser.pane.BrowserPane.f796c774a4',
-                    'Type a URL above to start browsing.'
-                  )}
-                </p>
-              </div>
-            </div>
-          </div>
-        ) : null}
-        {pendingAnnotationPayload ? (
-          <PendingBrowserAnnotationCard
-            payload={pendingAnnotationPayload}
-            anchor={getBrowserOverlayAnchor(
-              pendingAnnotationPayload,
-              containerRef.current,
-              webviewRef.current,
-              browserOverlayViewport
-            )}
-            portalContainer={containerRef.current}
-            onAdd={handleAddBrowserAnnotation}
-            onCancel={handleCancelPendingBrowserAnnotation}
-          />
-        ) : null}
-        {browserAnnotations.length > 0 && browserAnnotationTrayOpen ? (
-          <div className="absolute right-3 bottom-3 z-30 flex max-h-[45%] w-[min(20rem,calc(100%-1.5rem))] flex-col overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]">
-            <div className="flex items-center gap-2 border-b border-border px-3 py-2">
-              <MessageSquarePlus className="size-4 text-muted-foreground" />
-              <div className="min-w-0 flex-1 text-sm font-medium">
-                {browserAnnotations.length === 1
-                  ? translate(
-                      'auto.components.browser.pane.BrowserPane.ea6af700da',
-                      '{{value0}} annotation',
-                      { value0: browserAnnotations.length }
-                    )
-                  : translate(
-                      'auto.components.browser.pane.BrowserPane.c13693fe27',
-                      '{{value0}} annotations',
-                      { value0: browserAnnotations.length }
-                    )}
-              </div>
-              <DropdownMenu
-                modal={false}
-                open={annotationTraySendOpen}
-                onOpenChange={handleAnnotationTraySendOpenChange}
-              >
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <DropdownMenuTrigger asChild>
-                      <Button size="xs" variant="outline" className="gap-1.5">
-                        <Send className="size-3" />
-                        {translate('auto.components.browser.pane.BrowserPane.ac39b9366b', 'Send')}
-                      </Button>
-                    </DropdownMenuTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" sideOffset={6}>
-                    {translate(
-                      'auto.components.browser.pane.BrowserPane.95af781091',
-                      'Send feedback to a new agent'
-                    )}
-                  </TooltipContent>
-                </Tooltip>
-                <DropdownMenuContent
-                  align="end"
-                  className="min-w-[180px]"
-                  onInteractOutside={preventAgentSendTargetOutsideDismiss}
-                  onPointerDownOutside={preventAgentSendTargetOutsideDismiss}
-                >
-                  <QuickLaunchAgentMenuItems
-                    worktreeId={worktreeId}
-                    groupId={activeGroupId ?? worktreeId}
-                    onFocusTerminal={focusTerminalTabSurface}
-                    prompt={browserAnnotationsPrompt}
-                    promptDelivery="submit-after-ready"
-                    launchSource="notes_send"
-                    onPromptDelivered={handleBrowserAnnotationsSentToAgent}
-                  />
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <Button
-                size="xs"
-                variant="outline"
-                className="gap-1.5"
-                onClick={handleCopyBrowserAnnotations}
-              >
-                {browserAnnotationsCopied ? (
-                  <CircleCheck className="size-3" />
-                ) : (
-                  <Copy className="size-3" />
-                )}
-                {browserAnnotationsCopied
-                  ? translate('auto.components.browser.pane.BrowserPane.6f4ab3592b', 'Copied')
-                  : translate('auto.components.browser.pane.BrowserPane.d51ef37351', 'Copy')}
-              </Button>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="icon-xs"
-                    variant="ghost"
-                    className="text-muted-foreground hover:text-foreground"
-                    onClick={handleClearBrowserAnnotations}
-                    aria-label={translate(
-                      'auto.components.browser.pane.BrowserPane.734e4343ec',
-                      'Clear browser annotations'
-                    )}
-                  >
-                    <Trash2 className="size-3" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>
-                  {translate(
-                    'auto.components.browser.pane.BrowserPane.11c5084aa2',
-                    'Clear annotations'
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </div>
-            <div className="scrollbar-sleek min-h-0 flex-1 overflow-auto p-1.5">
-              {browserAnnotations.map((annotation, index) => (
-                <div
-                  key={annotation.id}
-                  className="group flex gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent focus-within:bg-accent"
-                >
-                  <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
-                    {index + 1}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate font-medium text-foreground">
-                      {annotation.payload.target.accessibility.accessibleName ||
-                        annotation.payload.target.textSnippet ||
-                        annotation.payload.target.tagName}
-                    </div>
-                    <div className="mt-0.5 line-clamp-2 text-muted-foreground">
-                      {annotation.comment}
-                    </div>
-                    <div className="mt-1 text-[11px] text-muted-foreground">
-                      <span>{annotation.intent}</span>
-                    </div>
-                  </div>
-                  <Button
-                    size="icon-xs"
-                    variant="ghost"
-                    className="can-hover:opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
-                    onClick={() => handleDeleteBrowserAnnotation(annotation.id)}
-                    aria-label={translate(
-                      'auto.components.browser.pane.BrowserPane.f2d0c22d67',
-                      'Delete annotation {{value0}}',
-                      { value0: index + 1 }
-                    )}
-                  >
-                    <Trash2 className="size-3" />
-                  </Button>
-                </div>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        {/* Right-click context dropdown: positioned at the element's center,
-            shown when grab.contextMenu is true (user right-clicked). */}
-        <DropdownMenu
-          open={grab.state === 'confirming' && grab.contextMenu && grabIntent === 'copy'}
-          onOpenChange={(open) => {
-            if (!open && grab.state === 'confirming') {
-              // Why: skip rearm if a menu action (Copy/Screenshot) already
-              // handled the rearm — see grabMenuActionTakenRef.
-              if (grabMenuActionTakenRef.current) {
-                grabMenuActionTakenRef.current = false
-                return
-              }
-              grab.rearm()
-            }
-          }}
-        >
-          <DropdownMenuTrigger asChild>
-            <button
-              aria-hidden
-              tabIndex={-1}
-              className="pointer-events-none absolute size-px opacity-0"
-              style={(() => {
-                if (!grab.payload) {
-                  return { left: 0, top: 0 }
-                }
-                const rect = grab.payload.target.rectViewport
-                const webview = webviewRef.current
-                const webviewRect = webview?.getBoundingClientRect()
-                const cRect = containerRef.current?.getBoundingClientRect()
-                const offsetX = (webviewRect?.left ?? 0) - (cRect?.left ?? 0)
-                const offsetY = (webviewRect?.top ?? 0) - (cRect?.top ?? 0)
-                return {
-                  left: offsetX + rect.x + rect.width / 2,
-                  top: offsetY + rect.y + rect.height / 2
-                }
-              })()}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" sideOffset={4}>
-            <DropdownMenuItem onSelect={handleGrabCopy}>
-              <Copy className="size-3.5" />
-              {translate('auto.components.browser.pane.BrowserPane.c2ef0359b9', 'Copy Contents')}
-              <DropdownMenuShortcut>C</DropdownMenuShortcut>
-            </DropdownMenuItem>
-            {grab.payload?.screenshot?.dataUrl?.startsWith('data:image/png;base64,') ? (
-              <DropdownMenuItem onSelect={handleGrabCopyScreenshot}>
-                <Image className="size-3.5" />
-                {translate(
-                  'auto.components.browser.pane.BrowserPane.1ded0d3168',
-                  'Copy Screenshot'
-                )}
-                <DropdownMenuShortcut>S</DropdownMenuShortcut>
-              </DropdownMenuItem>
+              </>
             ) : null}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onSelect={() => {
-                grabMenuActionTakenRef.current = true
+            <button
+              className="ml-auto shrink-0 rounded px-2 py-0.5 text-muted-foreground transition-colors hover:text-foreground"
+              onClick={() => {
+                setPendingAnnotationPayload(null)
                 grab.cancel()
               }}
             >
               {translate('auto.components.browser.pane.BrowserPane.fa6ea61de3', 'Cancel')}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        {/* Inline toast bubble (left-click auto-copy feedback). Positioned
-            below (or above if near viewport bottom) so it doesn't occlude
-            the element. The "···" button opens the same action dropdown as
-            right-click for users who prefer clicking. */}
-        {grabToast ? (
-          <div
-            className="absolute z-30 flex items-center animate-in fade-in zoom-in-95 duration-150"
-            style={{
-              left: grabToast.x,
-              top: grabToast.y,
-              transform: grabToast.below
-                ? 'translate(-50%, 8px)'
-                : 'translate(-50%, -100%) translateY(-8px)',
-              flexDirection: grabToast.below ? 'column' : 'column-reverse'
-            }}
-          >
-            {/* Caret pointing toward the element */}
-            <div
-              className="h-2 w-4 shrink-0"
-              style={{
-                clipPath: grabToast.below
-                  ? 'polygon(50% 0%, 0% 100%, 100% 100%)'
-                  : 'polygon(0% 0%, 100% 0%, 50% 100%)',
-                background: 'white'
-              }}
-            />
-            <div
-              className={`flex items-center gap-1.5 rounded-full py-1.5 pl-3 pr-1.5 shadow-lg ${
-                grabToast.type === 'success' ? 'bg-white text-gray-900' : 'bg-white text-red-600'
-              }`}
-            >
-              {grabToast.type === 'success' ? (
-                <CircleCheck className="size-4 fill-blue-600 text-white" />
-              ) : (
-                <OctagonX className="size-4 text-red-500" />
-              )}
-              <span className="text-sm font-semibold">{grabToast.message}</span>
-              {grabToast.payload?.screenshot?.dataUrl?.startsWith('data:image/png;base64,') ? (
-                <DropdownMenu
-                  onOpenChange={(open) => {
-                    if (open) {
-                      clearTimeout(grabToastTimerRef.current)
-                    } else {
-                      grabToastTimerRef.current = setTimeout(() => dismissGrabToast(), 1200)
-                    }
-                  }}
-                >
-                  <DropdownMenuTrigger asChild>
-                    <button className="flex size-6 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-black/10 hover:text-gray-700">
-                      <span className="text-sm font-bold leading-none">···</span>
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" sideOffset={4}>
-                    <DropdownMenuItem
-                      onSelect={() => {
-                        const dataUrl = grabToast.payload?.screenshot?.dataUrl
-                        if (dataUrl?.startsWith('data:image/png;base64,')) {
-                          void window.api.ui.writeClipboardImage(dataUrl)
-                          setGrabToast((prev) =>
-                            prev
-                              ? {
-                                  ...prev,
-                                  message: translate(
-                                    'auto.components.browser.pane.BrowserPane.f30d2d35a7',
-                                    'Screenshotted'
-                                  )
-                                }
-                              : null
+            </button>
+          </div>
+        ) : null}
+      </div>
+      {pageViewport?.container
+        ? createPortal(
+            <>
+              <div
+                role="status"
+                aria-live="polite"
+                aria-hidden={browserZoomIndicatorState.ariaHidden}
+                className={cn(
+                  'pointer-events-none absolute top-3 right-3 z-30 rounded-md border border-border bg-popover/95 px-2.5 py-1 text-xs font-medium text-popover-foreground shadow-xs transition-opacity duration-300 ease-out',
+                  browserZoomIndicatorState.opacityClassName
+                )}
+              >
+                {browserZoomPercent}%
+              </div>
+              <BrowserFind
+                isOpen={findOpen}
+                onClose={() => setFindOpen(false)}
+                webviewRef={webviewRef}
+              />
+              {showFailureOverlay ? (
+                <div className="absolute inset-0 z-10 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.02),transparent_58%)] px-6">
+                  <div className="flex max-w-sm flex-col items-center px-8 py-8 text-center opacity-70">
+                    <div className="mb-4 rounded-full border border-border/70 bg-muted/30 p-3">
+                      <Globe className="size-5 text-muted-foreground" />
+                    </div>
+                    <h2 className="text-base font-semibold text-foreground/85">
+                      {loadErrorMeta.host
+                        ? translate(
+                            'auto.components.browser.pane.BrowserPane.db325a7eeb',
+                            "Can't reach {{value0}}",
+                            { value0: loadErrorMeta.host }
                           )
-                        }
-                      }}
+                        : translate(
+                            'auto.components.browser.pane.BrowserPane.b2856516e2',
+                            "Can't load this page"
+                          )}
+                    </h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {formatLoadFailureDescription(browserTab.loadError, loadErrorMeta)}
+                    </p>
+                    {loadErrorHint ? (
+                      <p className="mt-2 text-xs text-muted-foreground/80">{loadErrorHint}</p>
+                    ) : null}
+                    <div className="mt-5 flex items-center gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-9 gap-2 px-3"
+                        title={translate(
+                          'auto.components.browser.pane.BrowserPane.781d6459ad',
+                          'Retry'
+                        )}
+                        onClick={() => {
+                          const webview = webviewRef.current
+                          if (!webview) {
+                            return
+                          }
+                          onUpdatePageStateRef.current(browserTab.id, {
+                            loading: true
+                          })
+                          retryBrowserTabLoad(webview, browserTab, onUpdatePageStateRef.current)
+                        }}
+                      >
+                        <RefreshCw className="size-4" />
+                        <span>
+                          {translate(
+                            'auto.components.browser.pane.BrowserPane.c6be71329e',
+                            'Refresh'
+                          )}
+                        </span>
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-9 gap-2 px-3"
+                        title={translate(
+                          'auto.components.browser.pane.BrowserPane.3c085f638d',
+                          'Copy failed page URL'
+                        )}
+                        onClick={() => {
+                          // Why: failed guests often leave users stranded on a blank
+                          // error surface. Put the current URL on the clipboard from
+                          // the recovery UI itself so they can retry elsewhere
+                          // without having to discover the toolbar overflow first.
+                          void window.api.ui.writeClipboardText(currentBrowserUrl)
+                          setResourceNotice('Copied the current page URL.')
+                        }}
+                      >
+                        <Copy className="size-4" />
+                        <span>
+                          {translate(
+                            'auto.components.browser.pane.BrowserPane.93be92f8d1',
+                            'Copy Address'
+                          )}
+                        </span>
+                      </Button>
+                      {externalUrl ? (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-9 gap-2 px-3"
+                          title={translate(
+                            'auto.components.browser.pane.BrowserPane.da68d35f7b',
+                            'Open failed page in default browser'
+                          )}
+                          onClick={() => {
+                            // Why: page failures inside Orca can still be recoverable
+                            // in the system browser, especially for OAuth, captive
+                            // portals, or enterprise auth flows that rely on a full
+                            // browser profile. Keep this action in the failed-state
+                            // overlay so recovery does not depend on toolbar affordance
+                            // discovery while the guest itself is unusable.
+                            void window.api.shell.openUrl(externalUrl)
+                          }}
+                        >
+                          <ExternalLink className="size-4" />
+                          <span>
+                            {translate(
+                              'auto.components.browser.pane.BrowserPane.1c78adc73d',
+                              'Open Externally'
+                            )}
+                          </span>
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+              {isBlankTab ? (
+                <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.02),transparent_58%)] px-6">
+                  <div className="flex flex-col items-center px-8 py-8 text-center opacity-70">
+                    <div className="mb-4 rounded-full border border-border/70 bg-muted/30 p-3">
+                      <Globe className="size-5 text-muted-foreground" />
+                    </div>
+                    <div className="text-center">
+                      <p className="text-base font-semibold text-foreground/85">
+                        {translate(
+                          'auto.components.browser.pane.BrowserPane.366bf5d62c',
+                          'New Tab'
+                        )}
+                      </p>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {translate(
+                          'auto.components.browser.pane.BrowserPane.f796c774a4',
+                          'Type a URL above to start browsing.'
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+              {pendingAnnotationPayload ? (
+                <PendingBrowserAnnotationCard
+                  payload={pendingAnnotationPayload}
+                  anchor={getBrowserOverlayAnchor(
+                    pendingAnnotationPayload,
+                    containerRef.current,
+                    webviewRef.current,
+                    browserOverlayViewport
+                  )}
+                  portalContainer={containerRef.current}
+                  onAdd={handleAddBrowserAnnotation}
+                  onCancel={handleCancelPendingBrowserAnnotation}
+                />
+              ) : null}
+              {browserAnnotations.length > 0 && browserAnnotationTrayOpen ? (
+                <div className="absolute right-3 bottom-3 z-30 flex max-h-[45%] w-[min(20rem,calc(100%-1.5rem))] flex-col overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]">
+                  <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+                    <MessageSquarePlus className="size-4 text-muted-foreground" />
+                    <div className="min-w-0 flex-1 text-sm font-medium">
+                      {browserAnnotations.length === 1
+                        ? translate(
+                            'auto.components.browser.pane.BrowserPane.ea6af700da',
+                            '{{value0}} annotation',
+                            { value0: browserAnnotations.length }
+                          )
+                        : translate(
+                            'auto.components.browser.pane.BrowserPane.c13693fe27',
+                            '{{value0}} annotations',
+                            { value0: browserAnnotations.length }
+                          )}
+                    </div>
+                    <DropdownMenu
+                      modal={false}
+                      open={annotationTraySendOpen}
+                      onOpenChange={handleAnnotationTraySendOpenChange}
                     >
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <DropdownMenuTrigger asChild>
+                            <Button size="xs" variant="outline" className="gap-1.5">
+                              <Send className="size-3" />
+                              {translate(
+                                'auto.components.browser.pane.BrowserPane.ac39b9366b',
+                                'Send'
+                              )}
+                            </Button>
+                          </DropdownMenuTrigger>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" sideOffset={6}>
+                          {translate(
+                            'auto.components.browser.pane.BrowserPane.95af781091',
+                            'Send feedback to a new agent'
+                          )}
+                        </TooltipContent>
+                      </Tooltip>
+                      <DropdownMenuContent
+                        align="end"
+                        className="min-w-[180px]"
+                        onInteractOutside={preventAgentSendTargetOutsideDismiss}
+                        onPointerDownOutside={preventAgentSendTargetOutsideDismiss}
+                      >
+                        <QuickLaunchAgentMenuItems
+                          worktreeId={worktreeId}
+                          groupId={activeGroupId ?? worktreeId}
+                          onFocusTerminal={focusTerminalTabSurface}
+                          prompt={browserAnnotationsPrompt}
+                          promptDelivery="submit-after-ready"
+                          launchSource="notes_send"
+                          onPromptDelivered={handleBrowserAnnotationsSentToAgent}
+                        />
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      className="gap-1.5"
+                      onClick={handleCopyBrowserAnnotations}
+                    >
+                      {browserAnnotationsCopied ? (
+                        <CircleCheck className="size-3" />
+                      ) : (
+                        <Copy className="size-3" />
+                      )}
+                      {browserAnnotationsCopied
+                        ? translate('auto.components.browser.pane.BrowserPane.6f4ab3592b', 'Copied')
+                        : translate('auto.components.browser.pane.BrowserPane.d51ef37351', 'Copy')}
+                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          size="icon-xs"
+                          variant="ghost"
+                          className="text-muted-foreground hover:text-foreground"
+                          onClick={handleClearBrowserAnnotations}
+                          aria-label={translate(
+                            'auto.components.browser.pane.BrowserPane.734e4343ec',
+                            'Clear browser annotations'
+                          )}
+                        >
+                          <Trash2 className="size-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" sideOffset={6}>
+                        {translate(
+                          'auto.components.browser.pane.BrowserPane.11c5084aa2',
+                          'Clear annotations'
+                        )}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <div className="scrollbar-sleek min-h-0 flex-1 overflow-auto p-1.5">
+                    {browserAnnotations.map((annotation, index) => (
+                      <div
+                        key={annotation.id}
+                        className="group flex gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent focus-within:bg-accent"
+                      >
+                        <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
+                          {index + 1}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate font-medium text-foreground">
+                            {annotation.payload.target.accessibility.accessibleName ||
+                              annotation.payload.target.textSnippet ||
+                              annotation.payload.target.tagName}
+                          </div>
+                          <div className="mt-0.5 line-clamp-2 text-muted-foreground">
+                            {annotation.comment}
+                          </div>
+                          <div className="mt-1 text-[11px] text-muted-foreground">
+                            <span>{annotation.intent}</span>
+                          </div>
+                        </div>
+                        <Button
+                          size="icon-xs"
+                          variant="ghost"
+                          className="can-hover:opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100"
+                          onClick={() => handleDeleteBrowserAnnotation(annotation.id)}
+                          aria-label={translate(
+                            'auto.components.browser.pane.BrowserPane.f2d0c22d67',
+                            'Delete annotation {{value0}}',
+                            { value0: index + 1 }
+                          )}
+                        >
+                          <Trash2 className="size-3" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {/* Right-click context dropdown: positioned at the element's center,
+            shown when grab.contextMenu is true (user right-clicked). */}
+              <DropdownMenu
+                open={grab.state === 'confirming' && grab.contextMenu && grabIntent === 'copy'}
+                onOpenChange={(open) => {
+                  if (!open && grab.state === 'confirming') {
+                    // Why: skip rearm if a menu action (Copy/Screenshot) already
+                    // handled the rearm — see grabMenuActionTakenRef.
+                    if (grabMenuActionTakenRef.current) {
+                      grabMenuActionTakenRef.current = false
+                      return
+                    }
+                    grab.rearm()
+                  }
+                }}
+              >
+                <DropdownMenuTrigger asChild>
+                  <button
+                    aria-hidden
+                    tabIndex={-1}
+                    className="pointer-events-none absolute size-px opacity-0"
+                    style={(() => {
+                      if (!grab.payload) {
+                        return { left: 0, top: 0 }
+                      }
+                      const rect = grab.payload.target.rectViewport
+                      const webview = webviewRef.current
+                      const webviewRect = webview?.getBoundingClientRect()
+                      const cRect = containerRef.current?.getBoundingClientRect()
+                      const offsetX = (webviewRect?.left ?? 0) - (cRect?.left ?? 0)
+                      const offsetY = (webviewRect?.top ?? 0) - (cRect?.top ?? 0)
+                      return {
+                        left: offsetX + rect.x + rect.width / 2,
+                        top: offsetY + rect.y + rect.height / 2
+                      }
+                    })()}
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" sideOffset={4}>
+                  <DropdownMenuItem onSelect={handleGrabCopy}>
+                    <Copy className="size-3.5" />
+                    {translate(
+                      'auto.components.browser.pane.BrowserPane.c2ef0359b9',
+                      'Copy Contents'
+                    )}
+                    <DropdownMenuShortcut>C</DropdownMenuShortcut>
+                  </DropdownMenuItem>
+                  {grab.payload?.screenshot?.dataUrl?.startsWith('data:image/png;base64,') ? (
+                    <DropdownMenuItem onSelect={handleGrabCopyScreenshot}>
                       <Image className="size-3.5" />
                       {translate(
                         'auto.components.browser.pane.BrowserPane.1ded0d3168',
@@ -5684,13 +5685,112 @@ function BrowserPagePane({
                       )}
                       <DropdownMenuShortcut>S</DropdownMenuShortcut>
                     </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                  ) : null}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      grabMenuActionTakenRef.current = true
+                      grab.cancel()
+                    }}
+                  >
+                    {translate('auto.components.browser.pane.BrowserPane.fa6ea61de3', 'Cancel')}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              {/* Inline toast bubble (left-click auto-copy feedback). Positioned
+            below (or above if near viewport bottom) so it doesn't occlude
+            the element. The "···" button opens the same action dropdown as
+            right-click for users who prefer clicking. */}
+              {grabToast ? (
+                <div
+                  className="absolute z-30 flex items-center animate-in fade-in zoom-in-95 duration-150"
+                  style={{
+                    left: grabToast.x,
+                    top: grabToast.y,
+                    transform: grabToast.below
+                      ? 'translate(-50%, 8px)'
+                      : 'translate(-50%, -100%) translateY(-8px)',
+                    flexDirection: grabToast.below ? 'column' : 'column-reverse'
+                  }}
+                >
+                  {/* Caret pointing toward the element */}
+                  <div
+                    className="h-2 w-4 shrink-0"
+                    style={{
+                      clipPath: grabToast.below
+                        ? 'polygon(50% 0%, 0% 100%, 100% 100%)'
+                        : 'polygon(0% 0%, 100% 0%, 50% 100%)',
+                      background: 'white'
+                    }}
+                  />
+                  <div
+                    className={`flex items-center gap-1.5 rounded-full py-1.5 pl-3 pr-1.5 shadow-lg ${
+                      grabToast.type === 'success'
+                        ? 'bg-white text-gray-900'
+                        : 'bg-white text-red-600'
+                    }`}
+                  >
+                    {grabToast.type === 'success' ? (
+                      <CircleCheck className="size-4 fill-blue-600 text-white" />
+                    ) : (
+                      <OctagonX className="size-4 text-red-500" />
+                    )}
+                    <span className="text-sm font-semibold">{grabToast.message}</span>
+                    {grabToast.payload?.screenshot?.dataUrl?.startsWith(
+                      'data:image/png;base64,'
+                    ) ? (
+                      <DropdownMenu
+                        onOpenChange={(open) => {
+                          if (open) {
+                            clearTimeout(grabToastTimerRef.current)
+                          } else {
+                            grabToastTimerRef.current = setTimeout(() => dismissGrabToast(), 1200)
+                          }
+                        }}
+                      >
+                        <DropdownMenuTrigger asChild>
+                          <button className="flex size-6 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-black/10 hover:text-gray-700">
+                            <span className="text-sm font-bold leading-none">···</span>
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="start" sideOffset={4}>
+                          <DropdownMenuItem
+                            onSelect={() => {
+                              const dataUrl = grabToast.payload?.screenshot?.dataUrl
+                              if (dataUrl?.startsWith('data:image/png;base64,')) {
+                                void window.api.ui.writeClipboardImage(dataUrl)
+                                setGrabToast((prev) =>
+                                  prev
+                                    ? {
+                                        ...prev,
+                                        message: translate(
+                                          'auto.components.browser.pane.BrowserPane.f30d2d35a7',
+                                          'Screenshotted'
+                                        )
+                                      }
+                                    : null
+                                )
+                              }
+                            }}
+                          >
+                            <Image className="size-3.5" />
+                            {translate(
+                              'auto.components.browser.pane.BrowserPane.1ded0d3168',
+                              'Copy Screenshot'
+                            )}
+                            <DropdownMenuShortcut>S</DropdownMenuShortcut>
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    ) : null}
+                  </div>
+                </div>
               ) : null}
-            </div>
-          </div>
-        ) : null}
-      </div>
+            </>,
+            pageViewport.container
+          )
+        : null}
     </div>
   )
 }

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -2677,6 +2677,13 @@ function BrowserPagePane({
   const grabToastTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const annotationCopyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const browserZoomFeedbackTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  useEffect(() => {
+    return () => {
+      clearTimeout(grabToastTimerRef.current)
+      clearTimeout(annotationCopyTimerRef.current)
+      clearTimeout(browserZoomFeedbackTimerRef.current)
+    }
+  }, [])
   const [slotViewportReady, setSlotViewportReady] = useState(
     () => getBrowserOverlaySlotViewport(workspaceId) !== null
   )
@@ -3574,6 +3581,17 @@ function BrowserPagePane({
     if (webview && webview.parentElement !== container) {
       // Why: moving an Electron webview between DOM parents can recreate the
       // guest document. Treat unexpected parent drift as stale state instead.
+      destroyPersistentWebview(browserTab.id)
+      webview = undefined
+      container = ensureBrowserPageViewport(browserTab.id, workspaceId)?.container ?? null
+      if (!container) {
+        return
+      }
+    }
+    if (webview && webview.getAttribute('partition') !== webviewPartition) {
+      // Why: Electron partitions are immutable after creation. If restored state
+      // or another store path changes the profile, the persisted guest must be
+      // replaced rather than parked/reused with the stale session.
       destroyPersistentWebview(browserTab.id)
       webview = undefined
       container = ensureBrowserPageViewport(browserTab.id, workspaceId)?.container ?? null

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useMemo } from 'react'
+import { registerBrowserOverlaySlotViewport } from './browser-page-viewport'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../store'
 import type { BrowserTab as BrowserTabState, Tab, TabGroup } from '../../../../shared/types'
@@ -53,6 +54,14 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   onFocusOwningGroup,
   isWorktreeActive
 }: BrowserOverlaySlotProps): React.JSX.Element {
+  // Why: persistent page viewports (webview guests) live under this root so they
+  // survive BrowserPane chrome unmounts on worktree switch without reparenting.
+  const setSlotViewportRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      registerBrowserOverlaySlotViewport(browserTab.id, node)
+    },
+    [browserTab.id]
+  )
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
   const browserPageIds =
     browserTab.pageIds && browserTab.pageIds.length > 0
@@ -108,10 +117,16 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   return (
     <div
       style={style}
+      className="relative flex min-h-0 flex-1 flex-col"
       data-browser-overlay-tab-id={browserTab.id}
       onPointerDown={handleFocus}
       onFocusCapture={handleFocus}
     >
+      <div
+        ref={setSlotViewportRef}
+        className="absolute inset-0 flex min-h-0 flex-col"
+        aria-hidden
+      />
       {/* Why: moving an Electron webview between DOM parents destroys the guest
           document in some Electron builds. Visible worktree browsers stay in
           stable overlay slots; hidden worktrees park the heavy pane subtree. */}

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -122,11 +122,7 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
       onPointerDown={handleFocus}
       onFocusCapture={handleFocus}
     >
-      <div
-        ref={setSlotViewportRef}
-        className="absolute inset-0 flex min-h-0 flex-col"
-        aria-hidden
-      />
+      <div ref={setSlotViewportRef} className="absolute inset-0 flex min-h-0 flex-col" />
       {/* Why: moving an Electron webview between DOM parents destroys the guest
           document in some Electron builds. Visible worktree browsers stay in
           stable overlay slots; hidden worktrees park the heavy pane subtree. */}

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  applyBrowserPageViewportLayout,
+  ensureBrowserPageViewport,
+  getBrowserOverlaySlotViewport,
+  getBrowserPageViewportContainer,
+  parkBrowserPageViewport,
+  registerBrowserOverlaySlotViewport,
+  removeBrowserPageViewport,
+  syncBrowserPageChromeInset
+} from './browser-page-viewport'
+
+function mountSlotViewport(workspaceTabId: string): HTMLDivElement {
+  const root = document.createElement('div')
+  root.className = 'relative flex min-h-0 flex-1 flex-col'
+  document.body.appendChild(root)
+  registerBrowserOverlaySlotViewport(workspaceTabId, root)
+  return root
+}
+
+afterEach(() => {
+  for (const id of ['page-1', 'page-2']) {
+    removeBrowserPageViewport(id)
+  }
+  for (const id of ['workspace-1']) {
+    getBrowserOverlaySlotViewport(id)?.remove()
+    registerBrowserOverlaySlotViewport(id, null)
+  }
+})
+
+describe('ensureBrowserPageViewport', () => {
+  it('creates a flex viewport with chrome inset and container under the slot root', () => {
+    const root = mountSlotViewport('workspace-1')
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')
+
+    expect(viewport).not.toBeNull()
+    expect(viewport!.shell.parentElement).toBe(root)
+    expect(viewport!.shell.style.display).toBe('none')
+    expect(viewport!.container.className).toContain('flex-1')
+    expect(getBrowserPageViewportContainer('page-1')).toBe(viewport!.container)
+  })
+
+  it('returns null until the slot viewport root is registered', () => {
+    expect(ensureBrowserPageViewport('page-1', 'workspace-missing')).toBeNull()
+  })
+})
+
+describe('syncBrowserPageChromeInset', () => {
+  it('reserves space above the webview container for the React chrome header', () => {
+    mountSlotViewport('workspace-1')
+    ensureBrowserPageViewport('page-1', 'workspace-1')
+    syncBrowserPageChromeInset('page-1', 48)
+
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+    expect(viewport.chromeInset.style.height).toBe('48px')
+  })
+})
+
+describe('applyBrowserPageViewportLayout', () => {
+  it('shows the active page and hides parked pages', () => {
+    mountSlotViewport('workspace-1')
+    ensureBrowserPageViewport('page-1', 'workspace-1')
+    applyBrowserPageViewportLayout('page-1', { paintable: true, active: true })
+    parkBrowserPageViewport('page-1')
+
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+    expect(viewport.shell.style.display).toBe('none')
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
@@ -37,6 +37,8 @@ describe('ensureBrowserPageViewport', () => {
     expect(viewport).not.toBeNull()
     expect(viewport!.shell.parentElement).toBe(root)
     expect(viewport!.shell.style.display).toBe('none')
+    expect(viewport!.shell.inert).toBe(true)
+    expect(viewport!.shell.getAttribute('aria-hidden')).toBe('true')
     expect(viewport!.container.className).toContain('flex-1')
     expect(getBrowserPageViewportContainer('page-1')).toBe(viewport!.container)
   })
@@ -62,9 +64,18 @@ describe('applyBrowserPageViewportLayout', () => {
     mountSlotViewport('workspace-1')
     ensureBrowserPageViewport('page-1', 'workspace-1')
     applyBrowserPageViewportLayout('page-1', { paintable: true, active: true })
+    let viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+
+    expect(viewport.shell.style.display).toBe('flex')
+    expect(viewport.shell.inert).toBe(false)
+    expect(viewport.shell.getAttribute('aria-hidden')).toBeNull()
+
     parkBrowserPageViewport('page-1')
 
-    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+    viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
     expect(viewport.shell.style.display).toBe('none')
+    expect(viewport.shell.inert).toBe(true)
+    expect(viewport.shell.getAttribute('aria-hidden')).toBe('true')
+    expect(viewport.shell.style.pointerEvents).toBe('none')
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.ts
@@ -77,6 +77,8 @@ export function ensureBrowserPageViewport(
   shell.dataset.browserPageViewportId = browserPageId
   shell.className = 'absolute inset-0 flex min-h-0 flex-col'
   shell.style.display = 'none'
+  shell.inert = true
+  shell.setAttribute('aria-hidden', 'true')
 
   const chromeInset = document.createElement('div')
   chromeInset.dataset.browserPageChromeInset = ''
@@ -118,9 +120,15 @@ export function applyBrowserPageViewportLayout(
   if (!layout.paintable) {
     viewport.shell.style.display = 'none'
     viewport.shell.inert = true
+    viewport.shell.setAttribute('aria-hidden', 'true')
     return
   }
   viewport.shell.inert = !layout.active
+  if (layout.active) {
+    viewport.shell.removeAttribute('aria-hidden')
+  } else {
+    viewport.shell.setAttribute('aria-hidden', 'true')
+  }
   viewport.shell.style.display = 'flex'
   viewport.shell.style.opacity = layout.active ? '1' : '0'
   viewport.shell.style.pointerEvents = layout.active ? 'auto' : 'none'
@@ -139,5 +147,9 @@ export function parkBrowserPageViewport(browserPageId: string): void {
   const viewport = browserPageViewports.get(browserPageId)
   if (viewport) {
     viewport.shell.style.display = 'none'
+    viewport.shell.inert = true
+    viewport.shell.setAttribute('aria-hidden', 'true')
+    viewport.shell.style.pointerEvents = 'none'
+    viewport.shell.style.opacity = '0'
   }
 }

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.ts
@@ -1,0 +1,143 @@
+// Why: Electron <webview> guests are destroyed when their DOM parent is removed.
+// BrowserPane chrome unmounts on worktree switch, but the guest must stay in a
+// stable parent inside the overlay slot. Each page gets a flex-column viewport
+// (chrome inset spacer + flex-1 container) that mirrors the in-tree layout
+// without reparenting the webview or using fixed/float-over positioning.
+
+const slotViewportRoots = new Map<string, HTMLDivElement>()
+
+type BrowserPageViewport = {
+  shell: HTMLDivElement
+  chromeInset: HTMLDivElement
+  container: HTMLDivElement
+}
+
+const browserPageViewports = new Map<string, BrowserPageViewport>()
+
+const slotRootListeners = new Map<string, Set<() => void>>()
+
+function notifySlotRootListeners(workspaceTabId: string): void {
+  for (const listener of slotRootListeners.get(workspaceTabId) ?? []) {
+    listener()
+  }
+}
+
+export function registerBrowserOverlaySlotViewport(
+  workspaceTabId: string,
+  element: HTMLDivElement | null
+): void {
+  if (element) {
+    slotViewportRoots.set(workspaceTabId, element)
+    notifySlotRootListeners(workspaceTabId)
+    return
+  }
+  slotViewportRoots.delete(workspaceTabId)
+  slotRootListeners.delete(workspaceTabId)
+}
+
+export function getBrowserOverlaySlotViewport(workspaceTabId: string): HTMLDivElement | null {
+  return slotViewportRoots.get(workspaceTabId) ?? null
+}
+
+export function subscribeBrowserOverlaySlotViewport(
+  workspaceTabId: string,
+  listener: () => void
+): () => void {
+  let listeners = slotRootListeners.get(workspaceTabId)
+  if (!listeners) {
+    listeners = new Set()
+    slotRootListeners.set(workspaceTabId, listeners)
+  }
+  listeners.add(listener)
+  return () => {
+    listeners?.delete(listener)
+    if (listeners?.size === 0) {
+      slotRootListeners.delete(workspaceTabId)
+    }
+  }
+}
+
+export function getBrowserPageViewportContainer(browserPageId: string): HTMLDivElement | null {
+  return browserPageViewports.get(browserPageId)?.container ?? null
+}
+
+export function ensureBrowserPageViewport(
+  browserPageId: string,
+  workspaceTabId: string
+): BrowserPageViewport | null {
+  const existing = browserPageViewports.get(browserPageId)
+  if (existing) {
+    return existing
+  }
+  const root = slotViewportRoots.get(workspaceTabId)
+  if (!root) {
+    return null
+  }
+  const shell = document.createElement('div')
+  shell.dataset.browserPageViewportId = browserPageId
+  shell.className = 'absolute inset-0 flex min-h-0 flex-col'
+  shell.style.display = 'none'
+
+  const chromeInset = document.createElement('div')
+  chromeInset.dataset.browserPageChromeInset = ''
+  chromeInset.className = 'shrink-0'
+
+  const container = document.createElement('div')
+  container.dataset.browserPageContainer = ''
+  container.className = 'relative flex min-h-0 flex-1 overflow-hidden bg-background'
+
+  shell.append(chromeInset, container)
+  root.appendChild(shell)
+
+  const viewport = { shell, chromeInset, container }
+  browserPageViewports.set(browserPageId, viewport)
+  return viewport
+}
+
+export function removeBrowserPageViewport(browserPageId: string): void {
+  const viewport = browserPageViewports.get(browserPageId)
+  if (viewport) {
+    viewport.shell.remove()
+    browserPageViewports.delete(browserPageId)
+  }
+}
+
+export type BrowserPageViewportLayout = {
+  paintable: boolean
+  active: boolean
+}
+
+export function applyBrowserPageViewportLayout(
+  browserPageId: string,
+  layout: BrowserPageViewportLayout
+): void {
+  const viewport = browserPageViewports.get(browserPageId)
+  if (!viewport) {
+    return
+  }
+  if (!layout.paintable) {
+    viewport.shell.style.display = 'none'
+    viewport.shell.inert = true
+    return
+  }
+  viewport.shell.inert = !layout.active
+  viewport.shell.style.display = 'flex'
+  viewport.shell.style.opacity = layout.active ? '1' : '0'
+  viewport.shell.style.pointerEvents = layout.active ? 'auto' : 'none'
+  viewport.shell.style.zIndex = layout.active ? '1' : '0'
+}
+
+export function syncBrowserPageChromeInset(browserPageId: string, heightPx: number): void {
+  const viewport = browserPageViewports.get(browserPageId)
+  if (!viewport) {
+    return
+  }
+  viewport.chromeInset.style.height = `${Math.max(0, heightPx)}px`
+}
+
+export function parkBrowserPageViewport(browserPageId: string): void {
+  const viewport = browserPageViewports.get(browserPageId)
+  if (viewport) {
+    viewport.shell.style.display = 'none'
+  }
+}

--- a/src/renderer/src/components/browser-pane/webview-registry.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.ts
@@ -1,4 +1,5 @@
 import { clearLiveBrowserUrl } from './browser-runtime'
+import { removeBrowserPageViewport } from './browser-page-viewport'
 
 // Why: the webview registry is shared coordination state between BrowserPane
 // (React component) and store-layer cleanup helpers (shutdownWorktreeBrowsers,
@@ -190,6 +191,9 @@ export function moveFocusToRendererBeforeWebviewDetach(webview: Electron.Webview
 export function destroyPersistentWebview(browserTabId: string): void {
   const webview = webviewRegistry.get(browserTabId)
   if (!webview) {
+    // Why: the viewport can outlive a missing webview entry; tear it down on
+    // explicit close paths so overlay slots do not leak parked shells.
+    removeBrowserPageViewport(browserTabId)
     registeredWebContentsIds.delete(browserTabId)
     clearLiveBrowserUrl(browserTabId)
     return
@@ -198,6 +202,7 @@ export function destroyPersistentWebview(browserTabId: string): void {
   moveFocusToRendererBeforeWebviewDetach(webview)
   webview.remove()
   unregisterPersistentWebview(browserTabId)
+  removeBrowserPageViewport(browserTabId)
   registeredWebContentsIds.delete(browserTabId)
   clearLiveBrowserUrl(browserTabId)
 }


### PR DESCRIPTION
Electron `<webview>` guests are destroyed when their DOM parent is removed. When switching worktrees, `BrowserPane` chrome unmounts and previously tore down the webview, forcing a reload on return.

Introduce persistent page viewports inside overlay slots so webviews stay in a stable parent without keeping the full React chrome mounted. On worktree switch, park hidden viewports instead of destroying guests; explicit close paths still call `destroyPersistentWebview`.

Fixes stablyai/orca#6385

## Summary

- **Fix:** Browser tabs no longer reload when switching between worktrees/projects. A page you left open (e.g. a long-running QA session) keeps its loaded document, scroll position, and in-page state when you switch away and back.
- **How:** Each browser page gets a persistent viewport shell under its worktree-level overlay slot. The `<webview>` guest lives in that stable DOM parent and is registered in the existing `webviewRegistry`. When `BrowserPane` chrome unmounts on worktree switch, the viewport is **parked** (`display: none`) instead of destroyed. React chrome (toolbar, address bar, find bar, overlays) continues to mount/unmount normally via `shouldMountPane`.
- **Why not “keep everything mounted”:** We deliberately do **not** keep the full `BrowserPane` React subtree mounted for inactive worktrees. That caused performance issues (React reconciliation, event listeners, layout work for every hidden browser). Only the lightweight viewport shell + webview guest persist; the heavy chrome unmounts.
- **Performance tradeoff:** Inactive worktrees still hold live webview guests (same memory/compositor cost as an open tab in a normal browser). We avoid the extra cost of repeatedly destroying/recreating guests and re-running full page loads. Hidden guests are parked and non-interactive (`display: none`, `inert`, `pointer-events: none`).

## Screenshots

Behavior change only, same browser UI as before. Verified on macOS that pages render correctly after the fix (Google homepage and loaded sites display in the browser pane; no blank/white regression).

No visual change to layout or chrome.

<img width="1868" height="991" alt="image" src="https://github.com/user-attachments/assets/a1a15b56-b79d-4ab4-8c0c-02bc070cd0ee" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — browser-pane suite: 112 tests passed (`src/renderer/src/components/browser-pane`)
- [x] `pnpm build` — not run end-to-end in this session
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

**Manual verification (macOS, local dev):**

- Open browser tab, load a real page (google.com / custom site).
- Switch to another worktree, then switch back.
- Confirmed via Electron CDP: same `getWebContentsId()` before and after switch (no guest recreation); URL and title preserved.
- Confirmed viewport shell is visible and sized when active (`display: flex`, non-zero container rect).

**New tests:** `browser-page-viewport.test.ts` covers viewport creation under slot root, chrome inset sync, layout show/hide, and park behavior.

## AI Review Report

Reviewed the full diff with focus on Electron webview lifecycle, overlay-slot anchoring, and worktree switch paths.

**Risks checked:**

- **Webview reparenting:** Electron destroys guests on DOM parent change. Viewports are created once under the overlay slot root and never moved; `destroyPersistentWebview` only runs on explicit close.
- **Blank-page regression:** Initial navigation must happen while the viewport shell is visible. `applyBrowserPageViewportLayout` is called in the webview lifecycle effect before `webview.src` is set, and again in a `useLayoutEffect` keyed on `slotViewportReady`.
- **Focus on macOS:** `moveFocusToRendererBeforeWebviewDetach` runs before parking to avoid macOS reactivating the previous app when a focused webview is hidden.
- **Drag/drop:** File drop handlers moved to native listeners on the persistent container via refs so they survive chrome unmount.
- **Overlay stacking:** Page overlays (find bar, failure UI, annotations) portal into the persistent container; toolbar stays in React chrome with `pointer-events-auto`.

**Cross-platform (macOS, Linux, Windows):**

- No platform-specific code added. Uses standard DOM APIs (`ResizeObserver`, `inert`, `display`, `pointer-events`) available in Electron’s Chromium on all platforms.
- No keyboard shortcut, menu accelerator, or path-handling changes.
- Electron `<webview>` OOPIF behavior is the same across Orca’s desktop targets; the persistent-parent pattern applies uniformly.
- Remote/SSH browser path (`RemoteBrowserPagePane`) is untouched.

**Not flagged / verified:**

- `BrowserPaneOverlayLayer` slot viewport ref registration is keyed by workspace tab id, matching existing overlay architecture.
- `webview-registry.ts` teardown now also removes orphaned viewport shells on explicit close.

## Security Audit

- **No new IPC surface.** Existing `registerGuest` / `unregisterGuest` paths unchanged.
- **No command execution or shell invocation** added.
- **No auth/secrets handling** changed.
- **DOM/event handling:** Native drag/drop listeners on the viewport container only handle existing workspace file MIME types; same logic as before, moved to survive unmount.
- **Input isolation:** Parked/inactive viewports use `inert`, `pointer-events: none`, and `display: none` so hidden guests cannot receive input.
- **No new dependencies.**

No security follow-up identified.