### PR TITLE
Reduce push target upstream polling churn

### DIFF
--- a/src/renderer/src/components/right-sidebar/git-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.ts
@@ -2,6 +2,7 @@ import { getRuntimeGitStatus, getRuntimeGitUpstreamStatus } from '@/runtime/runt
 import {
   clearAutomaticPushTargetUpstreamStatusCache,
   getCachedAutomaticPushTargetUpstreamStatus,
+  invalidateAutomaticPushTargetUpstreamStatusCache,
   storeCachedAutomaticPushTargetUpstreamStatus
 } from './push-target-upstream-refresh-cache'
 import type {
@@ -95,7 +96,21 @@ async function fetchAndApplyAutomaticUpstreamStatus({
       applyUpstreamStatus: false
     }
   )
-  if (!upstreamStatus || !shouldApplyAutomaticUpstreamRefresh(worktreeId, startGeneration)) {
+  if (!upstreamStatus) {
+    if (pushTarget) {
+      // Why: failed publish-target refreshes must not let an older automatic
+      // cache entry suppress the next recovery poll for the same target.
+      invalidateAutomaticPushTargetUpstreamStatusCache({
+        settings,
+        worktreeId,
+        worktreePath,
+        connectionId,
+        pushTarget
+      })
+    }
+    return null
+  }
+  if (!shouldApplyAutomaticUpstreamRefresh(worktreeId, startGeneration)) {
     return null
   }
   deps.setUpstreamStatus(worktreeId, upstreamStatus)

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.ts
@@ -1,4 +1,9 @@
 import { getRuntimeGitStatus, getRuntimeGitUpstreamStatus } from '@/runtime/runtime-git-client'
+import {
+  clearAutomaticPushTargetUpstreamStatusCache,
+  getCachedAutomaticPushTargetUpstreamStatus,
+  storeCachedAutomaticPushTargetUpstreamStatus
+} from './push-target-upstream-refresh-cache'
 import type {
   GitPushTarget,
   GitStatusResult,
@@ -79,7 +84,7 @@ async function fetchAndApplyAutomaticUpstreamStatus({
   pushTarget?: GitPushTarget
   deps: GitStatusRefreshDeps
   startGeneration: number
-}): Promise<void> {
+}): Promise<GitUpstreamStatus | null> {
   const upstreamStatus = await deps.fetchUpstreamStatus(
     worktreeId,
     worktreePath,
@@ -90,9 +95,11 @@ async function fetchAndApplyAutomaticUpstreamStatus({
       applyUpstreamStatus: false
     }
   )
-  if (upstreamStatus && shouldApplyAutomaticUpstreamRefresh(worktreeId, startGeneration)) {
-    deps.setUpstreamStatus(worktreeId, upstreamStatus)
+  if (!upstreamStatus || !shouldApplyAutomaticUpstreamRefresh(worktreeId, startGeneration)) {
+    return null
   }
+  deps.setUpstreamStatus(worktreeId, upstreamStatus)
+  return upstreamStatus
 }
 
 function beginStrictUpstreamRefresh(worktreeId: string): void {
@@ -106,6 +113,7 @@ function beginStrictUpstreamRefresh(worktreeId: string): void {
 export function clearGitStatusRefreshOrderingForTests(): void {
   strictUpstreamRefreshGenerationByWorktree.clear()
   automaticUpstreamRefreshInFlightByWorktree.clear()
+  clearAutomaticPushTargetUpstreamStatusCache()
 }
 
 export async function refreshGitStatusForWorktree({
@@ -149,7 +157,20 @@ export async function refreshGitStatusForWorktree({
       // Why: porcelain status reports Git's configured upstream. Source Control
       // actions for PR-created worktrees must instead reconcile with Orca's
       // explicit publish target.
-      await fetchAndApplyAutomaticUpstreamStatus({
+      const cachedUpstreamStatus = getCachedAutomaticPushTargetUpstreamStatus({
+        settings,
+        worktreeId,
+        worktreePath,
+        connectionId,
+        pushTarget,
+        status
+      })
+      if (cachedUpstreamStatus) {
+        // Why: post-push/fetch actions may have already written fresher
+        // upstream status; a poll cache hit should only skip subprocess churn.
+        return
+      }
+      const upstreamStatus = await fetchAndApplyAutomaticUpstreamStatus({
         settings,
         worktreeId,
         worktreePath,
@@ -158,6 +179,14 @@ export async function refreshGitStatusForWorktree({
         deps,
         startGeneration: upstreamStartGeneration
       })
+      if (upstreamStatus) {
+        // Why: explicit publish-target comparison can spawn several git
+        // subprocesses; unchanged automatic polls should reuse it briefly.
+        storeCachedAutomaticPushTargetUpstreamStatus(
+          { settings, worktreeId, worktreePath, connectionId, pushTarget, status },
+          upstreamStatus
+        )
+      }
       return
     }
     if (status.upstreamStatus) {
@@ -214,6 +243,7 @@ export async function refreshGitStatusForWorktreeStrict({
   }
 }): Promise<{ status: GitStatusResult; upstreamStatus: GitUpstreamStatus }> {
   beginStrictUpstreamRefresh(worktreeId)
+  clearAutomaticPushTargetUpstreamStatusCache()
   const status = (await getRuntimeGitStatus(
     {
       settings,

--- a/src/renderer/src/components/right-sidebar/push-target-upstream-refresh-cache.test.ts
+++ b/src/renderer/src/components/right-sidebar/push-target-upstream-refresh-cache.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearGitStatusRefreshOrderingForTests,
+  refreshGitStatusForWorktree,
+  refreshGitStatusForWorktreeStrict,
+  type GitStatusRefreshDeps
+} from './git-status-refresh'
+import {
+  getCachedAutomaticPushTargetUpstreamStatus,
+  storeCachedAutomaticPushTargetUpstreamStatus
+} from './push-target-upstream-refresh-cache'
+import type { GitPushTarget, GitStatusResult, GitUpstreamStatus } from '../../../../shared/types'
+
+const pushTarget: GitPushTarget = {
+  remoteName: 'fork',
+  branchName: 'feature/pr-head',
+  remoteUrl: 'https://github.com/contributor/orca.git'
+}
+
+const unchangedStatus: GitStatusResult = {
+  entries: [],
+  conflictOperation: 'unknown',
+  head: 'abc123',
+  branch: 'refs/heads/feature'
+}
+
+function makeDeps(): GitStatusRefreshDeps {
+  return {
+    setGitStatus: vi.fn(),
+    updateWorktreeGitIdentity: vi.fn(),
+    setUpstreamStatus: vi.fn(),
+    fetchUpstreamStatus: vi.fn().mockResolvedValue({
+      hasUpstream: true,
+      upstreamName: 'fork/feature/pr-head',
+      ahead: 1,
+      behind: 0
+    } satisfies GitUpstreamStatus)
+  }
+}
+
+function stubGitStatus(statuses: GitStatusResult[]): ReturnType<typeof vi.fn> {
+  const gitStatus = vi.fn()
+  for (const status of statuses) {
+    gitStatus.mockResolvedValueOnce(status)
+  }
+  gitStatus.mockResolvedValue(statuses.at(-1) ?? unchangedStatus)
+  vi.stubGlobal('window', {
+    api: {
+      git: {
+        status: gitStatus,
+        upstreamStatus: vi.fn().mockResolvedValue({
+          hasUpstream: true,
+          upstreamName: 'fork/feature/pr-head',
+          ahead: 9,
+          behind: 0
+        } satisfies GitUpstreamStatus)
+      }
+    }
+  })
+  return gitStatus
+}
+
+async function refreshAutomatically(options: {
+  deps: GitStatusRefreshDeps
+  connectionId?: string
+  runtimeEnvironmentId?: string | null
+  pushTarget?: GitPushTarget
+}): Promise<void> {
+  await refreshGitStatusForWorktree({
+    settings: { activeRuntimeEnvironmentId: options.runtimeEnvironmentId ?? null },
+    worktreeId: 'wt-1',
+    worktreePath: '/repo',
+    connectionId: options.connectionId,
+    pushTarget: options.pushTarget ?? pushTarget,
+    deps: options.deps
+  })
+}
+
+describe('push-target upstream refresh cache', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    clearGitStatusRefreshOrderingForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reuses the publish-target upstream comparison across unchanged automatic polls', async () => {
+    stubGitStatus([unchangedStatus])
+    const deps = makeDeps()
+
+    await refreshAutomatically({ deps })
+    await refreshAutomatically({ deps })
+    await refreshAutomatically({ deps })
+
+    expect(deps.fetchUpstreamStatus).toHaveBeenCalledTimes(1)
+    expect(deps.setUpstreamStatus).toHaveBeenCalledTimes(1)
+    expect(deps.setUpstreamStatus).toHaveBeenLastCalledWith('wt-1', {
+      hasUpstream: true,
+      upstreamName: 'fork/feature/pr-head',
+      ahead: 1,
+      behind: 0
+    })
+  })
+
+  it('refreshes again when HEAD changes', async () => {
+    stubGitStatus([
+      { ...unchangedStatus, head: 'abc123' },
+      { ...unchangedStatus, head: 'def456' }
+    ])
+    const deps = makeDeps()
+
+    await refreshAutomatically({ deps })
+    await refreshAutomatically({ deps })
+
+    expect(deps.fetchUpstreamStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes again when the push target changes', async () => {
+    stubGitStatus([unchangedStatus])
+    const deps = makeDeps()
+
+    await refreshAutomatically({ deps })
+    await refreshAutomatically({
+      deps,
+      pushTarget: { ...pushTarget, branchName: 'feature/retargeted-pr-head' }
+    })
+
+    expect(deps.fetchUpstreamStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes again after the automatic cache window expires', async () => {
+    stubGitStatus([unchangedStatus])
+    const deps = makeDeps()
+
+    await refreshAutomatically({ deps })
+    vi.setSystemTime(59_999)
+    await refreshAutomatically({ deps })
+    vi.setSystemTime(60_000)
+    await refreshAutomatically({ deps })
+
+    expect(deps.fetchUpstreamStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('separates automatic cache entries by SSH connection', async () => {
+    stubGitStatus([unchangedStatus])
+    const deps = makeDeps()
+
+    await refreshAutomatically({ deps, connectionId: 'ssh-1' })
+    await refreshAutomatically({ deps, connectionId: 'ssh-2' })
+
+    expect(deps.fetchUpstreamStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('separates automatic cache entries by runtime target', () => {
+    const upstreamStatus: GitUpstreamStatus = {
+      hasUpstream: true,
+      upstreamName: 'fork/feature/pr-head',
+      ahead: 1,
+      behind: 0
+    }
+
+    storeCachedAutomaticPushTargetUpstreamStatus(
+      {
+        settings: { activeRuntimeEnvironmentId: 'runtime-1' },
+        worktreeId: 'wt-1',
+        worktreePath: '/repo',
+        pushTarget,
+        status: unchangedStatus
+      },
+      upstreamStatus
+    )
+
+    expect(
+      getCachedAutomaticPushTargetUpstreamStatus({
+        settings: { activeRuntimeEnvironmentId: 'runtime-2' },
+        worktreeId: 'wt-1',
+        worktreePath: '/repo',
+        pushTarget,
+        status: unchangedStatus
+      })
+    ).toBeNull()
+  })
+
+  it('does not reuse automatic push-target cache for strict refreshes', async () => {
+    stubGitStatus([unchangedStatus])
+    const deps = makeDeps()
+
+    await refreshAutomatically({ deps })
+    await refreshGitStatusForWorktreeStrict({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      pushTarget,
+      deps
+    })
+
+    expect(deps.fetchUpstreamStatus).toHaveBeenCalledTimes(1)
+    expect(window.api.git.upstreamStatus).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      connectionId: undefined,
+      pushTarget
+    })
+    expect(deps.setUpstreamStatus).toHaveBeenLastCalledWith('wt-1', {
+      hasUpstream: true,
+      upstreamName: 'fork/feature/pr-head',
+      ahead: 9,
+      behind: 0
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/push-target-upstream-refresh-cache.test.ts
+++ b/src/renderer/src/components/right-sidebar/push-target-upstream-refresh-cache.test.ts
@@ -7,6 +7,7 @@ import {
 } from './git-status-refresh'
 import {
   getCachedAutomaticPushTargetUpstreamStatus,
+  invalidateAutomaticPushTargetUpstreamStatusCache,
   storeCachedAutomaticPushTargetUpstreamStatus
 } from './push-target-upstream-refresh-cache'
 import type { GitPushTarget, GitStatusResult, GitUpstreamStatus } from '../../../../shared/types'
@@ -103,6 +104,42 @@ describe('push-target upstream refresh cache', () => {
       hasUpstream: true,
       upstreamName: 'fork/feature/pr-head',
       ahead: 1,
+      behind: 0
+    })
+  })
+
+  it('retries after a failed push-target refresh invalidates an unchanged automatic poll cache hit', async () => {
+    stubGitStatus([unchangedStatus])
+    const deps = makeDeps()
+    vi.mocked(deps.fetchUpstreamStatus)
+      .mockResolvedValueOnce({
+        hasUpstream: true,
+        upstreamName: 'fork/feature/pr-head',
+        ahead: 1,
+        behind: 0
+      })
+      .mockResolvedValueOnce({
+        hasUpstream: true,
+        upstreamName: 'fork/feature/pr-head',
+        ahead: 0,
+        behind: 0
+      })
+
+    await refreshAutomatically({ deps })
+    invalidateAutomaticPushTargetUpstreamStatusCache({
+      settings: { activeRuntimeEnvironmentId: null },
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      pushTarget
+    })
+    await refreshAutomatically({ deps })
+    await refreshAutomatically({ deps })
+
+    expect(deps.fetchUpstreamStatus).toHaveBeenCalledTimes(2)
+    expect(deps.setUpstreamStatus).toHaveBeenLastCalledWith('wt-1', {
+      hasUpstream: true,
+      upstreamName: 'fork/feature/pr-head',
+      ahead: 0,
       behind: 0
     })
   })

--- a/src/renderer/src/components/right-sidebar/push-target-upstream-refresh-cache.ts
+++ b/src/renderer/src/components/right-sidebar/push-target-upstream-refresh-cache.ts
@@ -9,6 +9,7 @@ const AUTOMATIC_PUSH_TARGET_UPSTREAM_REFRESH_TTL_MS = 60_000
 const MAX_AUTOMATIC_PUSH_TARGET_UPSTREAM_CACHE_ENTRIES = 1024
 
 type PushTargetUpstreamRefreshCacheEntry = {
+  scopeKey: string
   status: GitUpstreamStatus
   refreshedAt: number
 }
@@ -37,6 +38,28 @@ function getStatusIdentityKey(status: GitStatusResult): readonly unknown[] {
   return [status.head ?? null, status.branch ?? null]
 }
 
+function getCacheScopeKey({
+  settings,
+  worktreeId,
+  worktreePath,
+  connectionId,
+  pushTarget
+}: {
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  worktreeId: string
+  worktreePath: string
+  connectionId?: string
+  pushTarget: GitPushTarget
+}): string {
+  return JSON.stringify([
+    worktreeId,
+    worktreePath,
+    connectionId ?? null,
+    getRuntimeEnvironmentKey(settings),
+    getPushTargetKey(pushTarget)
+  ])
+}
+
 function getCacheKey({
   settings,
   worktreeId,
@@ -53,11 +76,7 @@ function getCacheKey({
   status: GitStatusResult
 }): string {
   return JSON.stringify([
-    worktreeId,
-    worktreePath,
-    connectionId ?? null,
-    getRuntimeEnvironmentKey(settings),
-    getPushTargetKey(pushTarget),
+    getCacheScopeKey({ settings, worktreeId, worktreePath, connectionId, pushTarget }),
     getStatusIdentityKey(status)
   ])
 }
@@ -106,10 +125,26 @@ export function storeCachedAutomaticPushTargetUpstreamStatus(
   upstreamStatus: GitUpstreamStatus
 ): void {
   automaticPushTargetUpstreamRefreshCache.set(getCacheKey(input), {
+    scopeKey: getCacheScopeKey(input),
     status: upstreamStatus,
     refreshedAt: Date.now()
   })
   trimAutomaticPushTargetUpstreamRefreshCache()
+}
+
+export function invalidateAutomaticPushTargetUpstreamStatusCache(input: {
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  worktreeId: string
+  worktreePath: string
+  connectionId?: string
+  pushTarget: GitPushTarget
+}): void {
+  const scopeKey = getCacheScopeKey(input)
+  for (const [key, entry] of automaticPushTargetUpstreamRefreshCache) {
+    if (entry.scopeKey === scopeKey) {
+      automaticPushTargetUpstreamRefreshCache.delete(key)
+    }
+  }
 }
 
 export function clearAutomaticPushTargetUpstreamStatusCache(): void {

--- a/src/renderer/src/components/right-sidebar/push-target-upstream-refresh-cache.ts
+++ b/src/renderer/src/components/right-sidebar/push-target-upstream-refresh-cache.ts
@@ -1,0 +1,117 @@
+import type {
+  GitPushTarget,
+  GitStatusResult,
+  GitUpstreamStatus,
+  GlobalSettings
+} from '../../../../shared/types'
+
+const AUTOMATIC_PUSH_TARGET_UPSTREAM_REFRESH_TTL_MS = 60_000
+const MAX_AUTOMATIC_PUSH_TARGET_UPSTREAM_CACHE_ENTRIES = 1024
+
+type PushTargetUpstreamRefreshCacheEntry = {
+  status: GitUpstreamStatus
+  refreshedAt: number
+}
+
+const automaticPushTargetUpstreamRefreshCache = new Map<
+  string,
+  PushTargetUpstreamRefreshCacheEntry
+>()
+
+function getRuntimeEnvironmentKey(
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+): string | null {
+  return settings?.activeRuntimeEnvironmentId ?? null
+}
+
+function getPushTargetKey(pushTarget: GitPushTarget): readonly unknown[] {
+  return [
+    pushTarget.remoteName,
+    pushTarget.branchName,
+    pushTarget.remoteUrl ?? null,
+    pushTarget.remoteCreated ?? null
+  ]
+}
+
+function getStatusIdentityKey(status: GitStatusResult): readonly unknown[] {
+  return [status.head ?? null, status.branch ?? null]
+}
+
+function getCacheKey({
+  settings,
+  worktreeId,
+  worktreePath,
+  connectionId,
+  pushTarget,
+  status
+}: {
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  worktreeId: string
+  worktreePath: string
+  connectionId?: string
+  pushTarget: GitPushTarget
+  status: GitStatusResult
+}): string {
+  return JSON.stringify([
+    worktreeId,
+    worktreePath,
+    connectionId ?? null,
+    getRuntimeEnvironmentKey(settings),
+    getPushTargetKey(pushTarget),
+    getStatusIdentityKey(status)
+  ])
+}
+
+function trimAutomaticPushTargetUpstreamRefreshCache(): void {
+  for (const key of automaticPushTargetUpstreamRefreshCache.keys()) {
+    if (
+      automaticPushTargetUpstreamRefreshCache.size <=
+      MAX_AUTOMATIC_PUSH_TARGET_UPSTREAM_CACHE_ENTRIES
+    ) {
+      break
+    }
+    automaticPushTargetUpstreamRefreshCache.delete(key)
+  }
+}
+
+export function getCachedAutomaticPushTargetUpstreamStatus(input: {
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  worktreeId: string
+  worktreePath: string
+  connectionId?: string
+  pushTarget: GitPushTarget
+  status: GitStatusResult
+}): GitUpstreamStatus | null {
+  const key = getCacheKey(input)
+  const entry = automaticPushTargetUpstreamRefreshCache.get(key)
+  if (!entry) {
+    return null
+  }
+  if (Date.now() - entry.refreshedAt >= AUTOMATIC_PUSH_TARGET_UPSTREAM_REFRESH_TTL_MS) {
+    automaticPushTargetUpstreamRefreshCache.delete(key)
+    return null
+  }
+  return entry.status
+}
+
+export function storeCachedAutomaticPushTargetUpstreamStatus(
+  input: {
+    settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+    worktreeId: string
+    worktreePath: string
+    connectionId?: string
+    pushTarget: GitPushTarget
+    status: GitStatusResult
+  },
+  upstreamStatus: GitUpstreamStatus
+): void {
+  automaticPushTargetUpstreamRefreshCache.set(getCacheKey(input), {
+    status: upstreamStatus,
+    refreshedAt: Date.now()
+  })
+  trimAutomaticPushTargetUpstreamRefreshCache()
+}
+
+export function clearAutomaticPushTargetUpstreamStatusCache(): void {
+  automaticPushTargetUpstreamRefreshCache.clear()
+}

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -39,6 +39,7 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { clampMarkdownTocPanelWidth } from '../../../../shared/markdown-toc-panel-width'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import type { RemoteOpKind } from '@/components/right-sidebar/source-control-primary-action'
+import { invalidateAutomaticPushTargetUpstreamStatusCache } from '@/components/right-sidebar/push-target-upstream-refresh-cache'
 import {
   isNonFastForwardRemoteError,
   resolveRemoteOperationErrorMessage
@@ -3545,8 +3546,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       }
     }),
   fetchUpstreamStatus: async (worktreeId, worktreePath, connectionId, pushTarget, options) => {
+    const runtimeSettings = options?.runtimeTargetSettings ?? get().settings
     try {
-      const runtimeSettings = options?.runtimeTargetSettings ?? get().settings
       const status = await getRuntimeGitUpstreamStatus(
         {
           settings: runtimeSettings,
@@ -3567,6 +3568,17 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       // re-publish, clobbering the upstream relationship. If the branch is
       // genuinely newly unpublished, the polling effect will eventually correct
       // the status on success.
+      if (pushTarget) {
+        // Why: an old automatic poll cache entry must not suppress the next
+        // retry after a post-push/fetch refresh fails transiently.
+        invalidateAutomaticPushTargetUpstreamStatusCache({
+          settings: runtimeSettings,
+          worktreeId,
+          worktreePath,
+          connectionId,
+          pushTarget
+        })
+      }
       console.error('fetchUpstreamStatus failed', error)
       return null
     }


### PR DESCRIPTION
﻿## Summary
- cache automatic publish-target upstream comparisons for unchanged worktree identity, HEAD/branch, push target, connection, and runtime target
- leave cached poll hits as no-ops so fresher post-push/fetch upstream status is not overwritten by an older poll result
- keep strict/user-triggered refreshes uncached and clear automatic cache state before strict reconciliation

## Repro / Root Cause
Local WER/trace evidence showed AppHangB1-era git churn in `vendace`: about 15 `status`, 15 `symbolic-ref`, 15 `check-ref-format`, 15 `rev-list`, and 30 `rev-parse` spans per minute from 22:05-22:08. The renderer path matched that: automatic `refreshGitStatusForWorktree` always called `fetchUpstreamStatus` when `pushTarget` existed, causing publish-target validation/comparison on every ~3s status poll.

## Expected subprocess impact
For a PR-linked worktree with unchanged HEAD/branch and unchanged push target, automatic polling should now perform the publish-target upstream comparison once per 60s cache window instead of every 3s poll. That changes the expected publish-target comparison work from roughly 20 comparisons/minute to about 1 comparison/minute; the regular cheap `git status` poll still runs as before.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src\\renderer\\src\\components\\right-sidebar\\push-target-upstream-refresh-cache.test.ts src\\renderer\\src\\components\\right-sidebar\\git-status-refresh.test.ts`
- `pnpm exec oxlint src\\renderer\\src\\components\\right-sidebar\\git-status-refresh.ts src\\renderer\\src\\components\\right-sidebar\\push-target-upstream-refresh-cache.ts src\\renderer\\src\\components\\right-sidebar\\push-target-upstream-refresh-cache.test.ts`
- `pnpm run typecheck:web`

## Notes
- Initial `pnpm install --frozen-lockfile` completed, but `cpu-features` optional native build reported missing Visual Studio C++ tooling before postinstall skipped optional Electron rebuild modules.

## Brennan Test Changes Validation
- [x] Focused Vitest: `pnpm exec vitest run --config config/vitest.config.ts src\renderer\src\components\right-sidebar\push-target-upstream-refresh-cache.test.ts src\renderer\src\components\right-sidebar\git-status-refresh.test.ts` (15 tests passed).
- [x] Touched-file lint: `pnpm exec oxlint src\renderer\src\components\right-sidebar\git-status-refresh.ts src\renderer\src\components\right-sidebar\push-target-upstream-refresh-cache.ts src\renderer\src\components\right-sidebar\push-target-upstream-refresh-cache.test.ts`.
- [x] Typecheck: `pnpm run typecheck` and `pnpm run typecheck:web` passed.
- [x] `git diff --check` passed.
- [x] Electron validation launched from this PR worktree and verified identity: `devBranch=brennanb2025/burden-push-target-poll`, `devRepoRoot=C:\Users\neil\orca\workspaces\orca\burden-push-target-poll`.
- [x] Live local git validation used a disposable non-Orca `demo-project` repo with a local bare `origin` and explicit `pushTarget`. Three automatic `refreshGitStatusForWorktree` calls with unchanged HEAD/branch wrote git status three times but wrote upstream status once; a following strict refresh bypassed the automatic cache and wrote upstream status again.
- [x] Cleanup: disposable repo removed from the dev app, temp files deleted, PR worktree clean.
- [ ] Full `pnpm run lint`: blocked by unrelated existing localization catalog drift in `src/renderer/src/components/settings/AgentRuntimeSetting.tsx` and `src/renderer/src/components/settings/agents-search.ts`; touched files pass oxlint.

No SSH/remoting live pass was run because this PR changes renderer-side scheduling/caching before provider dispatch, not SSH transport behavior. The cache key includes `connectionId` and runtime target to keep remote/local surfaces separated.
