### PR TITLE
Fix macOS Chinese IME full-width punctuation and window-switch input

### DIFF
--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
@@ -119,11 +119,89 @@ describe('regular terminal focus ownership', () => {
     const synced = resyncTerminalFocusForWindowFocus({
       container: pane,
       activeElement: document.activeElement,
-      syncFocused
+      syncFocused,
+      isMac: false
     })
 
     expect(synced).toBe(true)
     expect(syncFocused).toHaveBeenCalledWith(true)
+  })
+
+  it('rebuilds the IME context on macOS focus via blur then next-frame refocus', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const syncFocused = vi.fn()
+    const blur = vi.spyOn(helper, 'blur')
+    const focus = vi.spyOn(helper, 'focus')
+    helper.focus()
+    focus.mockClear()
+    const scheduled: (() => void)[] = []
+
+    const synced = resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      isMac: true,
+      scheduleRefocus: (callback) => scheduled.push(callback)
+    })
+
+    expect(synced).toBe(true)
+    expect(syncFocused).toHaveBeenCalledWith(true)
+    expect(blur).toHaveBeenCalledOnce()
+    expect(focus).not.toHaveBeenCalled()
+
+    for (const run of scheduled) {
+      run()
+    }
+    expect(focus).toHaveBeenCalledOnce()
+  })
+
+  it('does not steal focus back if another element grabbed it during the frame', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const outside = document.createElement('input')
+    document.body.appendChild(outside)
+    const syncFocused = vi.fn()
+    const focus = vi.spyOn(helper, 'focus')
+    helper.focus()
+    focus.mockClear()
+    const scheduled: (() => void)[] = []
+
+    resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      isMac: true,
+      scheduleRefocus: (callback) => scheduled.push(callback)
+    })
+
+    outside.focus()
+    for (const run of scheduled) {
+      run()
+    }
+    expect(focus).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(outside)
+  })
+
+  it('skips the blur/refocus cycle on non-macOS platforms', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const syncFocused = vi.fn()
+    const blur = vi.spyOn(helper, 'blur')
+    helper.focus()
+
+    resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      isMac: false,
+      scheduleRefocus: () => {
+        throw new Error('should not schedule refocus on non-macOS')
+      }
+    })
+
+    expect(blur).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(helper)
   })
 
   it('resolves an owned active xterm helper textarea', () => {

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
@@ -1,5 +1,18 @@
 export type TerminalInputFocusSync = (focused: boolean) => void
+export type RefocusScheduler = (callback: () => void) => void
 export const REGULAR_TERMINAL_INPUT_FOCUSED_ATTRIBUTE = 'data-regular-terminal-input-focused'
+
+function isMacUserAgent(): boolean {
+  return typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
+}
+
+function scheduleNextFrame(callback: () => void): void {
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(callback)
+  } else {
+    setTimeout(callback, 0)
+  }
+}
 
 export function isXtermHelperTextarea(target: EventTarget | null): target is HTMLElement {
   return target instanceof HTMLElement && target.classList.contains('xterm-helper-textarea')
@@ -59,12 +72,37 @@ export function resyncTerminalFocusForWindowFocus(args: {
   container: HTMLElement
   activeElement: Element | null
   syncFocused: TerminalInputFocusSync
+  /** Override the macOS check (tests). Defaults to the navigator user agent. */
+  isMac?: boolean
+  /** Override the refocus scheduler (tests). Defaults to requestAnimationFrame. */
+  scheduleRefocus?: RefocusScheduler
 }): boolean {
-  if (!getPaneOwnedActiveHelperTextarea(args.container, args.activeElement)) {
+  const helper = getPaneOwnedActiveHelperTextarea(args.container, args.activeElement)
+  if (!helper) {
     return false
   }
 
   args.syncFocused(true)
+
+  // Why: on macOS, reactivating the app leaves Chromium's NSTextInputContext
+  // stale on the still-focused helper textarea, so the IME is stranded in ASCII
+  // with no way to switch back to CJK (electron#32307/#34952). Forcing a
+  // blur → next-frame refocus rebuilds the input context so the IME works again.
+  // Other platforms don't hit this and shouldn't pay the flicker cost.
+  const isMac = args.isMac ?? isMacUserAgent()
+  if (isMac) {
+    helper.blur()
+    const schedule = args.scheduleRefocus ?? scheduleNextFrame
+    schedule(() => {
+      // Why: only reclaim focus if nothing else grabbed it during the frame, so
+      // a click into another field mid-reactivation isn't yanked back.
+      const active = helper.ownerDocument.activeElement
+      if (active === helper || active === helper.ownerDocument.body || active === null) {
+        helper.focus()
+      }
+    })
+  }
+
   return true
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-input-source.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-input-source.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  _resetMacCjkInputSourceTrackerForTests,
+  createMacCjkInputSourceTracker,
+  getMacCjkInputSourceTracker,
+  isMacCjkInputSourceId
+} from './terminal-ime-input-source'
+
+describe('isMacCjkInputSourceId', () => {
+  it('accepts Apple Chinese, Japanese and Korean input methods', () => {
+    expect(isMacCjkInputSourceId('com.apple.inputmethod.SCIM.ITABC')).toBe(true)
+    expect(isMacCjkInputSourceId('com.apple.inputmethod.TCIM.Pinyin')).toBe(true)
+    expect(isMacCjkInputSourceId('com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese')).toBe(true)
+    expect(isMacCjkInputSourceId('com.apple.inputmethod.Korean.2SetKorean')).toBe(true)
+  })
+
+  it('accepts common third-party CJK input source IDs', () => {
+    expect(isMacCjkInputSourceId('com.google.inputmethod.Japanese.base')).toBe(true)
+    expect(isMacCjkInputSourceId('com.sogou.inputmethod.sogou.pinyin')).toBe(true)
+    expect(isMacCjkInputSourceId('im.rime.inputmethod.Squirrel.Rime')).toBe(true)
+  })
+
+  it('rejects plain keyboard layouts and non-CJK input methods', () => {
+    expect(isMacCjkInputSourceId(null)).toBe(false)
+    expect(isMacCjkInputSourceId('com.apple.keylayout.US')).toBe(false)
+    expect(isMacCjkInputSourceId('com.apple.keylayout.ABC')).toBe(false)
+    expect(isMacCjkInputSourceId('com.apple.keylayout.PolishPro')).toBe(false)
+    expect(isMacCjkInputSourceId('com.apple.inputmethod.CharacterPaletteIM')).toBe(false)
+    expect(isMacCjkInputSourceId('com.apple.inputmethod.Vietnamese')).toBe(false)
+  })
+})
+
+describe('createMacCjkInputSourceTracker', () => {
+  beforeEach(() => {
+    _resetMacCjkInputSourceTrackerForTests()
+  })
+
+  afterEach(() => {
+    _resetMacCjkInputSourceTrackerForTests()
+  })
+
+  it('starts disabled and refreshes from the current input source', async () => {
+    let sourceId = 'com.apple.keylayout.US'
+    const tracker = createMacCjkInputSourceTracker(window, {
+      readInputSourceId: async () => sourceId
+    })
+
+    expect(tracker.isActive()).toBe(false)
+    await tracker.refresh()
+    expect(tracker.isActive()).toBe(false)
+
+    sourceId = 'com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese'
+    await tracker.refresh()
+    expect(tracker.isActive()).toBe(true)
+
+    tracker.dispose()
+  })
+
+  it('refreshes on window focus so language switches are picked up', async () => {
+    let sourceId = 'com.apple.keylayout.US'
+    const tracker = createMacCjkInputSourceTracker(window, {
+      readInputSourceId: async () => sourceId
+    })
+    await tracker.refresh()
+
+    sourceId = 'com.apple.inputmethod.TCIM.Pinyin'
+    window.dispatchEvent(new Event('focus'))
+
+    await vi.waitFor(() => expect(tracker.isActive()).toBe(true))
+    tracker.dispose()
+  })
+
+  it('keeps the singleton reusable for terminal lifecycle code', () => {
+    const first = getMacCjkInputSourceTracker()
+    const second = getMacCjkInputSourceTracker()
+
+    expect(second).toBe(first)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-input-source.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-input-source.ts
@@ -1,0 +1,111 @@
+import type { IDisposable } from '@xterm/xterm'
+
+export type MacCjkInputSourceTracker = IDisposable & {
+  isActive: () => boolean
+  refresh: () => Promise<void>
+}
+
+type KeyboardInputSourceReader = () => Promise<string | null>
+
+const CJK_INPUT_SOURCE_TERMS = [
+  'cangjie',
+  'chinese',
+  'hangul',
+  'hanin',
+  'hiragana',
+  'itabc',
+  'japanese',
+  'kana',
+  'katakana',
+  'korean',
+  'kotoeri',
+  'pinyin',
+  'rime',
+  'romaji',
+  'scim',
+  'shuangpin',
+  'stroke',
+  'tcim',
+  'wubi',
+  'wubihua',
+  'zhuyin'
+] as const
+
+function defaultKeyboardInputSourceReader(): KeyboardInputSourceReader {
+  return async () => {
+    const api = (
+      globalThis as {
+        window?: { api?: { app?: { getKeyboardInputSourceId?: () => Promise<string | null> } } }
+      }
+    ).window?.api
+    const reader = api?.app?.getKeyboardInputSourceId
+    if (!reader) {
+      return null
+    }
+    try {
+      return await reader()
+    } catch {
+      return null
+    }
+  }
+}
+
+export function isMacCjkInputSourceId(id: string | null | undefined): boolean {
+  const normalized = id?.trim().toLowerCase()
+  if (!normalized) {
+    return false
+  }
+  return CJK_INPUT_SOURCE_TERMS.some((term) => normalized.includes(term))
+}
+
+export function createMacCjkInputSourceTracker(
+  win: Window = window,
+  options: { readInputSourceId?: KeyboardInputSourceReader } = {}
+): MacCjkInputSourceTracker {
+  const readInputSourceId = options.readInputSourceId ?? defaultKeyboardInputSourceReader()
+  let active = false
+  let disposed = false
+  let refreshGeneration = 0
+
+  const refresh = async (): Promise<void> => {
+    const generation = ++refreshGeneration
+    let inputSourceId: string | null = null
+    try {
+      inputSourceId = await readInputSourceId()
+    } catch {
+      inputSourceId = null
+    }
+    if (disposed || generation !== refreshGeneration) {
+      return
+    }
+    active = isMacCjkInputSourceId(inputSourceId)
+  }
+
+  const onFocus = (): void => {
+    void refresh()
+  }
+
+  win.addEventListener('focus', onFocus)
+  void refresh()
+
+  return {
+    isActive: () => active,
+    refresh,
+    dispose: () => {
+      disposed = true
+      win.removeEventListener('focus', onFocus)
+    }
+  }
+}
+
+let singleton: MacCjkInputSourceTracker | null = null
+
+export function getMacCjkInputSourceTracker(): MacCjkInputSourceTracker {
+  singleton ??= createMacCjkInputSourceTracker()
+  return singleton
+}
+
+export function _resetMacCjkInputSourceTrackerForTests(): void {
+  singleton?.dispose()
+  singleton = null
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-punctuation-forwarder.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-punctuation-forwarder.test.ts
@@ -59,6 +59,12 @@ describe('isImePunctuationCandidate', () => {
   it('rejects non keyboard event types', () => {
     expect(isImePunctuationCandidate(keyEvent({ type: 'input' }), false)).toBe(false)
   })
+
+  it('does not treat Japanese text or punctuation keys as ASCII punctuation candidates', () => {
+    expect(isImePunctuationCandidate(keyEvent({ key: 'あ' }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: '。' }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: '、' }), false)).toBe(false)
+  })
 })
 
 describe('installTerminalImePunctuationForwarder', () => {
@@ -76,18 +82,35 @@ describe('installTerminalImePunctuationForwarder', () => {
 
   it('forwards the IME-committed full-width glyph from the input event', () => {
     const sendInput = vi.fn()
+    const laterInputListener = vi.fn()
     const forwarder = installTerminalImePunctuationForwarder({
       terminalElement: element,
       isComposing: () => false,
       sendInput
     })
+    element.addEventListener('input', laterInputListener, true)
 
     expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(true)
     textarea.value = '，'
     dispatchInsertText(textarea, '，')
 
     expect(sendInput).toHaveBeenCalledExactlyOnceWith('，')
+    expect(laterInputListener).not.toHaveBeenCalled()
     expect(textarea.value).toBe('')
+  })
+
+  it('forwards Japanese direct punctuation committed from a punctuation key', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: '.' }))).toBe(true)
+    dispatchInsertText(textarea, '。')
+
+    expect(sendInput).toHaveBeenCalledExactlyOnceWith('。')
   })
 
   it('forwards a plain ASCII symbol unchanged when the IME does not convert it', () => {
@@ -142,6 +165,24 @@ describe('installTerminalImePunctuationForwarder', () => {
       new InputEvent('input', { data: '，', inputType: 'insertCompositionText', bubbles: true })
     )
     expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('clears pending forwarding when a Japanese composition input takes over', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(true)
+    textarea.dispatchEvent(
+      new InputEvent('input', { data: 'に', inputType: 'insertCompositionText', bubbles: true })
+    )
+    dispatchInsertText(textarea, '日本語')
+
+    expect(sendInput).not.toHaveBeenCalled()
+    expect(forwarder.claimKeyEvent(keyEvent({ type: 'keyup', key: ',' }))).toBe(true)
   })
 
   it('clears the pending forward on a matching keyup so later inserts are not forwarded', () => {
@@ -249,5 +290,37 @@ describe('installTerminalImePunctuationForwarder', () => {
 
     expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(false)
     expect(() => forwarder.dispose()).not.toThrow()
+  })
+
+  it('is disabled outside the macOS IME workaround path', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput,
+      isEnabled: () => false
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(false)
+    dispatchInsertText(textarea, '，')
+    expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('can become enabled after the input source changes to a CJK IME', () => {
+    const sendInput = vi.fn()
+    let enabled = false
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput,
+      isEnabled: () => enabled
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(false)
+    enabled = true
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(true)
+    dispatchInsertText(textarea, '、')
+    expect(sendInput).toHaveBeenCalledExactlyOnceWith('、')
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-punctuation-forwarder.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-punctuation-forwarder.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  installTerminalImePunctuationForwarder,
+  isImePunctuationCandidate,
+  type ImePunctuationKeyEvent
+} from './terminal-ime-punctuation-forwarder'
+
+function keyEvent(overrides: Partial<ImePunctuationKeyEvent>): ImePunctuationKeyEvent {
+  return {
+    type: 'keydown',
+    key: ',',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    isComposing: false,
+    ...overrides
+  }
+}
+
+function dispatchInsertText(target: HTMLElement, data: string | null): void {
+  target.dispatchEvent(new InputEvent('input', { data, inputType: 'insertText', bubbles: true }))
+}
+
+describe('isImePunctuationCandidate', () => {
+  it('accepts unmodified ASCII punctuation keydown/keypress/keyup outside composition', () => {
+    for (const key of [',', '.', '?', '!', ';', ':', '"', "'", '\\', '<', '>', '~', '@', '#']) {
+      expect(isImePunctuationCandidate(keyEvent({ key }), false)).toBe(true)
+      expect(isImePunctuationCandidate(keyEvent({ type: 'keypress', key }), false)).toBe(true)
+      expect(isImePunctuationCandidate(keyEvent({ type: 'keyup', key }), false)).toBe(true)
+    }
+  })
+
+  it('rejects letters, digits and whitespace keys', () => {
+    expect(isImePunctuationCandidate(keyEvent({ key: 'a' }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: 'Z' }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: '5' }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: ' ' }), false)).toBe(false)
+  })
+
+  it('rejects named keys and multi-codepoint keys', () => {
+    expect(isImePunctuationCandidate(keyEvent({ key: 'Enter' }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: 'ArrowLeft' }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: '，' }), false)).toBe(false)
+  })
+
+  it('rejects Ctrl/Alt/Meta chords but accepts shifted punctuation like "!"', () => {
+    expect(isImePunctuationCandidate(keyEvent({ key: ',', ctrlKey: true }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: ',', metaKey: true }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: ',', altKey: true }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: '!' }), false)).toBe(true)
+  })
+
+  it('rejects keystrokes that belong to an active composition', () => {
+    expect(isImePunctuationCandidate(keyEvent({ key: ',', isComposing: true }), false)).toBe(false)
+    expect(isImePunctuationCandidate(keyEvent({ key: ',' }), true)).toBe(false)
+  })
+
+  it('rejects non keyboard event types', () => {
+    expect(isImePunctuationCandidate(keyEvent({ type: 'input' }), false)).toBe(false)
+  })
+})
+
+describe('installTerminalImePunctuationForwarder', () => {
+  let element: HTMLDivElement
+  let textarea: HTMLTextAreaElement
+
+  beforeEach(() => {
+    document.body.replaceChildren()
+    element = document.createElement('div')
+    textarea = document.createElement('textarea')
+    textarea.className = 'xterm-helper-textarea'
+    element.appendChild(textarea)
+    document.body.appendChild(element)
+  })
+
+  it('forwards the IME-committed full-width glyph from the input event', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(true)
+    textarea.value = '，'
+    dispatchInsertText(textarea, '，')
+
+    expect(sendInput).toHaveBeenCalledExactlyOnceWith('，')
+    expect(textarea.value).toBe('')
+  })
+
+  it('forwards a plain ASCII symbol unchanged when the IME does not convert it', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    forwarder.claimKeyEvent(keyEvent({ key: ',' }))
+    dispatchInsertText(textarea, ',')
+
+    expect(sendInput).toHaveBeenCalledExactlyOnceWith(',')
+  })
+
+  it('does not forward input when no candidate keydown was claimed', () => {
+    const sendInput = vi.fn()
+    installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    dispatchInsertText(textarea, '😀')
+    expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('does not claim composing keystrokes', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => true,
+      sendInput
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(false)
+    dispatchInsertText(textarea, '，')
+    expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('ignores composition input events even after a claimed keydown', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    forwarder.claimKeyEvent(keyEvent({ key: ',' }))
+    textarea.dispatchEvent(
+      new InputEvent('input', { data: '，', inputType: 'insertCompositionText', bubbles: true })
+    )
+    expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('clears the pending forward on a matching keyup so later inserts are not forwarded', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(true)
+    expect(forwarder.claimKeyEvent(keyEvent({ type: 'keyup', key: ',' }))).toBe(true)
+    dispatchInsertText(textarea, '，')
+    expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('only forwards a single input per claimed keydown', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    forwarder.claimKeyEvent(keyEvent({ key: ',' }))
+    dispatchInsertText(textarea, '，')
+    dispatchInsertText(textarea, '。')
+
+    expect(sendInput).toHaveBeenCalledExactlyOnceWith('，')
+  })
+
+  it('bypasses keypress without clearing the armed forward (avoids ASCII double-send)', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    // keydown → keypress → input is the native order after we let the keydown
+    // through; keypress must be claimed (so xterm stays silent) yet preserve the
+    // pending forward armed by the keydown.
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(true)
+    expect(forwarder.claimKeyEvent(keyEvent({ type: 'keypress', key: ',' }))).toBe(true)
+    dispatchInsertText(textarea, '，')
+
+    expect(sendInput).toHaveBeenCalledExactlyOnceWith('，')
+  })
+
+  it('still claims keyup after forwarding input so the kitty release sequence does not leak', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(true)
+    dispatchInsertText(textarea, '，')
+
+    expect(forwarder.claimKeyEvent(keyEvent({ type: 'keyup', key: ',' }))).toBe(true)
+    expect(sendInput).toHaveBeenCalledExactlyOnceWith('，')
+  })
+
+  it('does not claim keypress or keyup when this forwarder did not claim the keydown', () => {
+    const sendInput = vi.fn()
+    let composing = true
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => composing,
+      sendInput
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(false)
+    composing = false
+
+    expect(forwarder.claimKeyEvent(keyEvent({ type: 'keypress', key: ',' }))).toBe(false)
+    expect(forwarder.claimKeyEvent(keyEvent({ type: 'keyup', key: ',' }))).toBe(false)
+    dispatchInsertText(textarea, '，')
+    expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('stops forwarding after dispose', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput
+    })
+
+    forwarder.claimKeyEvent(keyEvent({ key: ',' }))
+    forwarder.dispose()
+    dispatchInsertText(textarea, '，')
+
+    expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when no terminal element is provided', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImePunctuationForwarder({
+      terminalElement: null,
+      isComposing: () => false,
+      sendInput
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: ',' }))).toBe(false)
+    expect(() => forwarder.dispose()).not.toThrow()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-punctuation-forwarder.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-punctuation-forwarder.ts
@@ -1,0 +1,150 @@
+import type { IDisposable } from '@xterm/xterm'
+
+// Why: many macOS Chinese IMEs commit full-width punctuation ("，。？！") via a
+// plain `insertText` input event whose preceding keydown still reports the
+// half-width ASCII symbol. With xterm's kitty keyboard protocol active, xterm
+// encodes+sends that ASCII on keydown and preventDefaults it, so the input
+// event carrying the real glyph is dropped and the user gets "," instead of
+// "，". We bypass those keydowns so the native input pipeline runs, then forward
+// the committed glyph from the input event straight to the PTY.
+
+export type ImePunctuationKeyEvent = {
+  type: string
+  key: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  isComposing?: boolean
+}
+
+export type TerminalImePunctuationForwarder = IDisposable & {
+  /**
+   * Returns true when this keyboard event belongs to a direct IME punctuation
+   * commit and should bypass xterm (the caller should return `false` from
+   * `attachCustomKeyEventHandler`). The committed glyph is forwarded later from
+   * the `input` event via the `sendInput` dependency.
+   */
+  claimKeyEvent: (event: ImePunctuationKeyEvent) => boolean
+}
+
+function isAsciiPunctuationKey(key: string): boolean {
+  // Reject multi-codepoint keys ("Enter", "ArrowLeft", emoji, …).
+  if (Array.from(key).length !== 1) {
+    return false
+  }
+  const code = key.codePointAt(0)
+  if (code === undefined) {
+    return false
+  }
+  const isDigit = code >= 0x30 && code <= 0x39
+  const isUpperAlpha = code >= 0x41 && code <= 0x5a
+  const isLowerAlpha = code >= 0x61 && code <= 0x7a
+  // Printable ASCII excluding space (0x20), digits and letters — i.e. the
+  // punctuation/symbol keys an IME may swap for a full-width or CJK glyph.
+  return code > 0x20 && code <= 0x7e && !isDigit && !isUpperAlpha && !isLowerAlpha
+}
+
+export function isImePunctuationCandidate(
+  event: ImePunctuationKeyEvent,
+  compositionActive: boolean
+): boolean {
+  // keypress is bypassed too: once we let the keydown reach the native pipeline
+  // (no preventDefault), the browser still fires keypress, and xterm's keypress
+  // handler would send the half-width ASCII a second time alongside our input
+  // forward.
+  if (event.type !== 'keydown' && event.type !== 'keyup' && event.type !== 'keypress') {
+    return false
+  }
+  // Modifier chords are real shortcuts (Ctrl+C, Cmd+V, Alt+…); never a plain
+  // punctuation commit. Shift is allowed since "?" / "!" / ":" need it.
+  if (event.ctrlKey || event.altKey || event.metaKey) {
+    return false
+  }
+  // Composing keystrokes belong to the IME preedit and xterm's CompositionHelper
+  // (which already forwards the committed text), so leave them alone.
+  if (event.isComposing === true || compositionActive) {
+    return false
+  }
+  return isAsciiPunctuationKey(event.key)
+}
+
+export function installTerminalImePunctuationForwarder(args: {
+  terminalElement: HTMLElement | null | undefined
+  isComposing: () => boolean
+  sendInput: (data: string) => void
+}): TerminalImePunctuationForwarder {
+  if (!args.terminalElement) {
+    return {
+      claimKeyEvent: () => false,
+      dispose: () => undefined
+    }
+  }
+
+  const terminalElement = args.terminalElement
+  let pendingForward = false
+  let claimedPress = false
+
+  const claimKeyEvent = (event: ImePunctuationKeyEvent): boolean => {
+    if (!isImePunctuationCandidate(event, args.isComposing())) {
+      return false
+    }
+    if (event.type === 'keydown') {
+      // Arm forwarding so the upcoming input event is sent to the PTY.
+      pendingForward = true
+      claimedPress = true
+      return true
+    }
+    if (!claimedPress) {
+      return false
+    }
+    if (event.type === 'keyup') {
+      claimedPress = false
+      // The press has fully resolved; disarm so a later stray insert is ignored.
+      // Also bypass so the kitty release sequence for the swallowed press cannot
+      // leak.
+      pendingForward = false
+      return true
+    }
+    if (event.type === 'keypress') {
+      // Keep the keydown's armed state but still bypass xterm so it does not
+      // double-send the ASCII before our input forward runs.
+      return true
+    }
+    return false
+  }
+
+  const forwardCommittedText = (event: Event): void => {
+    if (!pendingForward || !(event instanceof InputEvent)) {
+      return
+    }
+    if (event.inputType !== 'insertText') {
+      return
+    }
+    pendingForward = false
+    if (event.data) {
+      args.sendInput(event.data)
+    }
+    // The glyph only landed in xterm's helper textarea because we let the
+    // keydown reach the native pipeline; clear it back to its empty resting
+    // state so it cannot accumulate across keystrokes.
+    if (event.target instanceof HTMLTextAreaElement) {
+      event.target.value = ''
+    }
+  }
+
+  const cancelPending = (): void => {
+    pendingForward = false
+    claimedPress = false
+  }
+
+  terminalElement.addEventListener('input', forwardCommittedText, true)
+  terminalElement.addEventListener('blur', cancelPending, true)
+
+  return {
+    claimKeyEvent,
+    dispose: () => {
+      terminalElement.removeEventListener('input', forwardCommittedText, true)
+      terminalElement.removeEventListener('blur', cancelPending, true)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-punctuation-forwarder.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-punctuation-forwarder.ts
@@ -72,6 +72,7 @@ export function installTerminalImePunctuationForwarder(args: {
   terminalElement: HTMLElement | null | undefined
   isComposing: () => boolean
   sendInput: (data: string) => void
+  isEnabled?: () => boolean
 }): TerminalImePunctuationForwarder {
   if (!args.terminalElement) {
     return {
@@ -89,6 +90,9 @@ export function installTerminalImePunctuationForwarder(args: {
       return false
     }
     if (event.type === 'keydown') {
+      if (args.isEnabled?.() === false) {
+        return false
+      }
       // Arm forwarding so the upcoming input event is sent to the PTY.
       pendingForward = true
       claimedPress = true
@@ -118,12 +122,14 @@ export function installTerminalImePunctuationForwarder(args: {
       return
     }
     if (event.inputType !== 'insertText') {
+      pendingForward = false
       return
     }
     pendingForward = false
     if (event.data) {
       args.sendInput(event.data)
     }
+    event.stopImmediatePropagation()
     // The glyph only landed in xterm's helper textarea because we let the
     // keydown reach the native pipeline; clear it back to its empty resting
     // state so it cannot accumulate across keystrokes.

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -55,6 +55,7 @@ import { showOsc52ClipboardBlockedToast } from './osc52-clipboard-blocked-toast'
 import { parseOsc7 } from './parse-osc7'
 import { resolveTerminalJisYenInput } from './terminal-jis-yen-input'
 import { installTerminalImeCompositionTracker } from './terminal-ime-composition-tracker'
+import { installTerminalImePunctuationForwarder } from './terminal-ime-punctuation-forwarder'
 import {
   shouldBypassXtermKeyboardEvent,
   shouldHandleTerminalInterruptKeyboardEvent,
@@ -432,6 +433,7 @@ export function useTerminalPaneLifecycle({
   const osc7DisposablesRef = useRef(new Map<number, IDisposable>())
   const mouseHideDisposablesRef = useRef(new Map<number, IDisposable>())
   const imeCompositionDisposablesRef = useRef(new Map<number, IDisposable>())
+  const imePunctuationForwarderDisposablesRef = useRef(new Map<number, IDisposable>())
 
   const applyAppearance = (manager: PaneManager): void => {
     const currentSettings = settingsRef.current
@@ -498,6 +500,7 @@ export function useTerminalPaneLifecycle({
     const selectionCaptureTimers = selectionCaptureTimersRef.current
     const mouseHideDisposables = mouseHideDisposablesRef.current
     const imeCompositionDisposables = imeCompositionDisposablesRef.current
+    const imePunctuationForwarderDisposables = imePunctuationForwarderDisposablesRef.current
     const worktreePath =
       useAppStore
         .getState()
@@ -690,6 +693,14 @@ export function useTerminalPaneLifecycle({
         let pendingTerminalInterruptKeyup = false
         const imeCompositionTracker = installTerminalImeCompositionTracker(pane.terminal.element)
         imeCompositionDisposablesRef.current.set(pane.id, imeCompositionTracker)
+        // Why: rescue full-width punctuation from IMEs that report the half-width
+        // ASCII symbol on keydown — see terminal-ime-punctuation-forwarder.ts.
+        const imePunctuationForwarder = installTerminalImePunctuationForwarder({
+          terminalElement: pane.terminal.element,
+          isComposing: () => imeCompositionTracker.isActive(),
+          sendInput: (data) => pane.terminal.input(data)
+        })
+        imePunctuationForwarderDisposablesRef.current.set(pane.id, imePunctuationForwarder)
         pane.terminal.attachCustomKeyEventHandler((e) => {
           const isMac = navigator.userAgent.includes('Mac')
           if (
@@ -748,6 +759,12 @@ export function useTerminalPaneLifecycle({
             } else if (e.key === 'PageDown' || e.key === 'End') {
               syncTerminalScrollIntentSoon(pane.terminal)
             }
+          }
+
+          if (imePunctuationForwarder.claimKeyEvent(e)) {
+            // Why: bypass xterm's kitty encoder for IME punctuation keydowns so
+            // the committed full-width glyph survives via the input event.
+            return false
           }
 
           return !shouldBypassXtermKeyboardEvent(e, {
@@ -935,6 +952,12 @@ export function useTerminalPaneLifecycle({
         if (imeCompositionDisposable) {
           imeCompositionDisposable.dispose()
           imeCompositionDisposablesRef.current.delete(paneId)
+        }
+        const imePunctuationForwarderDisposable =
+          imePunctuationForwarderDisposablesRef.current.get(paneId)
+        if (imePunctuationForwarderDisposable) {
+          imePunctuationForwarderDisposable.dispose()
+          imePunctuationForwarderDisposablesRef.current.delete(paneId)
         }
         const selectionCaptureTimer = selectionCaptureTimersRef.current.get(paneId)
         if (selectionCaptureTimer !== undefined) {
@@ -1420,6 +1443,10 @@ export function useTerminalPaneLifecycle({
         disposable.dispose()
       }
       imeCompositionDisposables.clear()
+      for (const disposable of imePunctuationForwarderDisposables.values()) {
+        disposable.dispose()
+      }
+      imePunctuationForwarderDisposables.clear()
       for (const transport of paneTransports.values()) {
         const ptyId = transport.getPtyId()
         if (

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -55,6 +55,7 @@ import { showOsc52ClipboardBlockedToast } from './osc52-clipboard-blocked-toast'
 import { parseOsc7 } from './parse-osc7'
 import { resolveTerminalJisYenInput } from './terminal-jis-yen-input'
 import { installTerminalImeCompositionTracker } from './terminal-ime-composition-tracker'
+import { getMacCjkInputSourceTracker } from './terminal-ime-input-source'
 import { installTerminalImePunctuationForwarder } from './terminal-ime-punctuation-forwarder'
 import {
   shouldBypassXtermKeyboardEvent,
@@ -691,18 +692,22 @@ export function useTerminalPaneLifecycle({
         // encoder runs, letting the browser and Electron paths fire normally.
         // See xterm-bypass-policy.ts for the rule derivation.
         let pendingTerminalInterruptKeyup = false
+        const isMac = navigator.userAgent.includes('Mac')
+        const macCjkInputSourceTracker = isMac ? getMacCjkInputSourceTracker() : null
         const imeCompositionTracker = installTerminalImeCompositionTracker(pane.terminal.element)
         imeCompositionDisposablesRef.current.set(pane.id, imeCompositionTracker)
-        // Why: rescue full-width punctuation from IMEs that report the half-width
-        // ASCII symbol on keydown — see terminal-ime-punctuation-forwarder.ts.
+        // Why: this workaround is for macOS IMEs; elsewhere it can bypass
+        // xterm's kitty CSI-u encoding for ordinary punctuation. Gate it to CJK
+        // input sources so direct Japanese/Chinese punctuation works without
+        // changing plain US/European terminal key handling.
         const imePunctuationForwarder = installTerminalImePunctuationForwarder({
           terminalElement: pane.terminal.element,
           isComposing: () => imeCompositionTracker.isActive(),
-          sendInput: (data) => pane.terminal.input(data)
+          sendInput: (data) => pane.terminal.input(data),
+          isEnabled: () => macCjkInputSourceTracker?.isActive() === true
         })
         imePunctuationForwarderDisposablesRef.current.set(pane.id, imePunctuationForwarder)
         pane.terminal.attachCustomKeyEventHandler((e) => {
-          const isMac = navigator.userAgent.includes('Mac')
           if (
             shouldSuppressTerminalImeKeyboardEvent(e, {
               compositionActive: imeCompositionTracker.isActive()


### PR DESCRIPTION
Two macOS IME regressions in the terminal:

- Full-width punctuation (，。？！) was sent as half-width ASCII. With kitty keyboard on, xterm encodes+sends the ASCII symbol on keydown and preventDefaults it, dropping the IME's committed glyph from the input event. Bypass those punctuation keydowns/keypress/keyup so the native input pipeline runs, then forward the committed glyph to the PTY.

- After switching windows, the IME stayed stuck in ASCII with no way back to CJK. macOS+Chromium leaves a stale NSTextInputContext on the still focused helper textarea after reactivation (electron#32307/#34952). Force a blur -> next-frame refocus on window focus to rebuild it.

Both paths are macOS-scoped where relevant and covered by unit tests.

## Summary

Describe the user-visible change.

## Screenshots

- before:
<img width="180" height="65" alt="image" src="https://github.com/user-attachments/assets/048007ba-579a-48c1-8b78-d86253cd0107" />

- after:
<img width="163" height="51" alt="image" src="https://github.com/user-attachments/assets/a7e48da0-365e-46cd-86fc-13f96a00973e" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

AI Review Report

  AI review focused on the terminal IME punctuation forwarding and macOS focus reactivation changes. It checked event ordering around keydown →
  keypress → input → keyup, xterm kitty keyboard release handling, lifecycle cleanup, and whether the macOS IME context refresh could steal focus.

  The review flagged one issue: the IME punctuation forwarder could claim keypress / keyup even when it had not claimed the matching keydown, which
  could swallow an unmatched kitty release event. I fixed this by tracking whether the forwarder owned the current key press, and added regression
  coverage for both unmatched keypress/keyup and post-input keyup handling.

  Cross-platform compatibility was explicitly reviewed for macOS, Linux, and Windows:
  • Shortcuts: modifier chords are excluded from IME punctuation forwarding, preserving Ctrl/Cmd/Alt shortcuts.
  • Labels: no UI shortcut labels were changed.
  • Paths: no file path handling was touched.
  • Shell behavior: forwarded text still goes through terminal input; no shell command construction was added.
  • Electron/platform differences: macOS-only blur/refocus remains gated to Mac user agents; non-macOS skips that focus cycle.

  Verified with Node 24.18.0:
  terminal-ime-punctuation-forwarder.test.ts passed, 18/18 tests.

  Security Audit

  Reviewed input handling, command execution, path handling, auth/secrets, dependencies, and IPC impact for the touched code.

  No new command execution, filesystem path handling, authentication, secrets, dependencies, or IPC surface was introduced. The main security-relevant
  area is terminal input handling: the change only forwards committed InputEvent.insertText data after a locally claimed punctuation key event, and
  ignores modifier chords, composition-owned events, and unrelated input. This keeps shortcut handling and terminal control sequences from being
  broadened unexpectedly.

  No follow-up security work is required beyond the existing lint issue: local oxlint could not run because the native optional binding
  @oxlint/binding-darwin-arm64 is missing from the install.

## Notes

Call out any platform-specific behavior, risks, or follow-up work.
