### PR TITLE
Add devcontainer runtime setup helper

### DIFF
--- a/docs/reference/devcontainer-runtime.md
+++ b/docs/reference/devcontainer-runtime.md
@@ -12,7 +12,7 @@ Install the Linux Orca build in the devcontainer, then start a headless runtime:
 orca serve --json --port 6768 --pairing-address 127.0.0.1:31682
 ```
 
-Expose the container port to the host so desktop Orca can reach it. The pairing address must be the host-reachable address, not the container-local address.
+Expose the container port to the host so desktop Orca can reach it. The `127.0.0.1:31682` example assumes the devcontainer port is forwarded or bridged to host loopback at that fixed port. If your container is reached through a different host address, pass that host-reachable address instead; do not use a container-only loopback address that the desktop cannot reach.
 
 Copy the `pairing.url` from the JSON output and save it on the desktop:
 

--- a/docs/reference/devcontainer-runtime.md
+++ b/docs/reference/devcontainer-runtime.md
@@ -1,0 +1,79 @@
+# Devcontainer runtime setup
+
+Orca can manage worktrees and terminals inside a devcontainer by pairing the desktop app with an `orca serve` runtime that runs in the container.
+
+This is useful when project tooling, credentials, or dependencies only exist inside the devcontainer.
+
+## 1. Start Orca inside the devcontainer
+
+Install the Linux Orca build in the devcontainer, then start a headless runtime:
+
+```sh
+orca serve --json --port 6768 --pairing-address 127.0.0.1:31682
+```
+
+Expose the container port to the host so desktop Orca can reach it. The pairing address must be the host-reachable address, not the container-local address.
+
+Copy the `pairing.url` from the JSON output and save it on the desktop:
+
+```sh
+orca environment add --name lac-devcontainer --pairing-code 'orca://pair?code=...'
+orca status --environment lac-devcontainer --json
+```
+
+## 2. Configure a persistent worktree base
+
+Do not leave worktrees under the container home directory, such as:
+
+```text
+/home/vscode/orca/workspaces/...
+```
+
+That location may be lost when the container is rebuilt or deleted.
+
+Choose a bind-mounted workspace path instead, for example:
+
+```text
+/workspaces/lac/projects/.worktrees/orca
+```
+
+Then configure the project in one command:
+
+```sh
+orca project setup-devcontainer \
+  --environment lac-devcontainer \
+  --project git:bitbucket.org/acme/app \
+  --host local \
+  --path /workspaces/lac/projects/app \
+  --worktree-base-path /workspaces/lac/projects/.worktrees/orca \
+  --kind git
+```
+
+Both `--path` and `--worktree-base-path` are paths inside the devcontainer runtime. When using `--environment` or `--pairing-code`, they must be absolute server paths because the desktop CLI current directory is unrelated to the container filesystem.
+
+`setup-devcontainer` intentionally requires a paired runtime selector (`--environment`, `--pairing-code`, `ORCA_ENVIRONMENT`, or `ORCA_PAIRING_CODE`) so it cannot accidentally configure the desktop-local Orca runtime.
+
+New worktrees will be created under the persistent base, grouped by repo name:
+
+```text
+/workspaces/lac/projects/.worktrees/orca/app/<worktree-name>
+```
+
+## 3. Add multiple repos from a parent folder
+
+The desktop UI can scan a runtime path for nested git repositories and import them. Use the add-project/add-repo flow for the paired runtime and enter the parent path inside the container, such as:
+
+```text
+/workspaces/lac/projects
+```
+
+Runtime scans are bounded and do not currently have the same streaming progress or cancel support as local scans.
+
+## Notes and limitations
+
+- The devcontainer runtime must keep `orca serve` running.
+- Use normal runtime pairing, not mobile pairing.
+- If the devcontainer does not include the libraries required by Electron, install the Linux desktop runtime dependencies before starting `orca serve`.
+- Some container environments require disabling Electron's sandbox or running under a virtual display, depending on the base image.
+- The CLI helper assumes the runtime environment already exists; it does not install Orca, start the container, or create the pairing.
+- The helper imports the checkout first, then updates the worktree base path. If the second step fails, rerun `setup-devcontainer` or run `project setup-update --setup <setup-id> --worktree-base-path <path>`.

--- a/docs/reference/devcontainer-runtime.md
+++ b/docs/reference/devcontainer-runtime.md
@@ -6,20 +6,20 @@ This is useful when project tooling, credentials, or dependencies only exist ins
 
 ## 1. Start Orca inside the devcontainer
 
-Install the Linux Orca build in the devcontainer, then start a headless runtime:
+Install the Linux Orca build in the devcontainer, then start a headless runtime with the helper:
 
 ```sh
-orca serve --json --port 6768 --pairing-address 127.0.0.1:31682
+orca environment devcontainer-up \
+  --name lac-devcontainer \
+  --container lac-devcontainer \
+  --host-port 31682 \
+  --container-port 6768 \
+  --orca-bin orca
 ```
 
-Expose the container port to the host so desktop Orca can reach it. The `127.0.0.1:31682` example assumes the devcontainer port is forwarded or bridged to host loopback at that fixed port. If your container is reached through a different host address, pass that host-reachable address instead; do not use a container-only loopback address that the desktop cannot reach.
+The helper starts a temporary Docker/socat bridge, runs `orca serve --json --port 6768 --pairing-address 127.0.0.1:31682` inside the container, and saves the environment automatically from the readiness payload.
 
-Copy the `pairing.url` from the JSON output and save it on the desktop:
-
-```sh
-orca environment add --name lac-devcontainer --pairing-code 'orca://pair?code=...'
-orca status --environment lac-devcontainer --json
-```
+If you need to script the flow manually, keep the host loopback address reachable from the desktop and save the pairing URL from the readiness JSON with `orca environment add`.
 
 ## 2. Configure a persistent worktree base
 
@@ -76,4 +76,5 @@ Runtime scans are bounded and do not currently have the same streaming progress 
 - If the devcontainer does not include the libraries required by Electron, install the Linux desktop runtime dependencies before starting `orca serve`.
 - Some container environments require disabling Electron's sandbox or running under a virtual display, depending on the base image.
 - The CLI helper assumes the runtime environment already exists; it does not install Orca, start the container, or create the pairing.
+- `orca environment devcontainer-up` is the preferred way to seed the runtime record before running `project setup-devcontainer`.
 - The helper imports the checkout first, then updates the worktree base path. If the second step fails, rerun `setup-devcontainer` or run `project setup-update --setup <setup-id> --worktree-base-path <path>`.

--- a/src/cli/handlers/environment.ts
+++ b/src/cli/handlers/environment.ts
@@ -12,6 +12,7 @@ import {
   type EnvironmentAddResult,
   type EnvironmentRemoveResult
 } from '../runtime/environments'
+import { startDevcontainerUp } from '../runtime/devcontainer-up'
 
 export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
   'environment add': async ({ flags, json }) => {
@@ -29,6 +30,33 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
       (result: EnvironmentAddResult) =>
         `Saved environment ${result.environment.name} (${result.environment.id}).`
     )
+  },
+  'environment devcontainer-up': async ({ flags, json }) => {
+    const name = getRequiredStringFlag(flags, 'name')
+    const container = getRequiredStringFlag(flags, 'container')
+    const hostPort = getRequiredPortFlag(flags, 'host-port')
+    const containerPort = getOptionalPortFlag(flags, 'container-port') ?? 6768
+    const orcaBin = getOptionalStringFlag(flags, 'orca-bin') ?? 'orca'
+    const bridgeName = getOptionalStringFlag(flags, 'bridge-name') ?? defaultBridgeName(name)
+
+    const session = startDevcontainerUp({
+      userDataPath: getDefaultUserDataPath(),
+      name,
+      container,
+      hostPort,
+      containerPort,
+      orcaBin,
+      bridgeName
+    })
+    const environment = redactRuntimeEnvironment(await session.ready)
+    printResult(
+      localSuccess({ environment }),
+      json,
+      (result: { environment: typeof environment }) => formatEnvironment(result.environment)
+    )
+    // Why: the devcontainer bridge and `orca serve` must keep running after
+    // readiness so the paired desktop runtime remains reachable.
+    await session.done
   },
   'environment list': async ({ json }) => {
     const environments = listEnvironments(getDefaultUserDataPath()).map(redactRuntimeEnvironment)
@@ -61,6 +89,46 @@ function getRequiredStringFlag(flags: Map<string, string | boolean>, name: strin
     throw new RuntimeClientError('invalid_argument', `Missing required --${name}`)
   }
   return value
+}
+
+function getOptionalStringFlag(
+  flags: Map<string, string | boolean>,
+  name: string
+): string | undefined {
+  const value = flags.get(name)
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function getRequiredPortFlag(flags: Map<string, string | boolean>, name: string): number {
+  const value = getOptionalStringFlag(flags, name)
+  if (value === undefined) {
+    throw new RuntimeClientError('invalid_argument', `Missing required --${name}`)
+  }
+  return parsePortValue(name, value)
+}
+
+function getOptionalPortFlag(
+  flags: Map<string, string | boolean>,
+  name: string
+): number | undefined {
+  const value = getOptionalStringFlag(flags, name)
+  return value === undefined ? undefined : parsePortValue(name, value)
+}
+
+function parsePortValue(name: string, raw: string): number {
+  const port = Number(raw)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new RuntimeClientError('invalid_argument', `Invalid --${name} value: ${raw}`)
+  }
+  return port
+}
+
+function defaultBridgeName(name: string): string {
+  const suffix = name
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return `orca-devcontainer-${suffix.length > 0 ? suffix : 'bridge'}`
 }
 
 function localSuccess<TResult>(result: TResult): RuntimeRpcSuccess<TResult> {

--- a/src/cli/handlers/project.ts
+++ b/src/cli/handlers/project.ts
@@ -24,6 +24,7 @@ import {
 import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
 import { resolveRepoPathArgument } from '../repo-path-arguments'
 import { RuntimeClientError } from '../runtime-client'
+import type { RuntimeRpcSuccess } from '../runtime-client'
 
 function getOptionalRepoKind(flags: Map<string, string | boolean>): RepoKind | undefined {
   const kind = getOptionalStringFlag(flags, 'kind')
@@ -101,16 +102,28 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
         kind: getOptionalRepoKind(flags)
       } satisfies ProjectHostSetupExistingFolderArgs
     )
+    // setupExistingFolder does not accept worktreeBasePath, so apply the
+    // persistent worktree base in a follow-up update against the new setup id.
     const setupId = setupResult.result.result.setup.id
-    const updateResult = await client.call<{ result: ProjectHostSetupUpdateResult }>(
-      'projectHostSetup.update',
-      {
-        setupId,
-        updates: {
-          worktreeBasePath
-        }
-      } satisfies ProjectHostSetupUpdateArgs
-    )
+    let updateResult: RuntimeRpcSuccess<{ result: ProjectHostSetupUpdateResult }>
+    try {
+      updateResult = await client.call<{ result: ProjectHostSetupUpdateResult }>(
+        'projectHostSetup.update',
+        {
+          setupId,
+          updates: {
+            worktreeBasePath
+          }
+        } satisfies ProjectHostSetupUpdateArgs
+      )
+    } catch (error) {
+      const detail =
+        error instanceof Error && error.message ? ` Runtime error: ${error.message}` : ''
+      throw new RuntimeClientError(
+        'runtime_error',
+        `Imported folder but failed to set the worktree base. Rerun this command or use: orca project setup-update --setup ${setupId} --worktree-base-path ${worktreeBasePath}.${detail}`
+      )
+    }
     printResult(updateResult, json, formatProjectHostSetupUpdateResult)
   },
   'project setup-clone': async ({ flags, client, cwd, json }) => {

--- a/src/cli/handlers/project.ts
+++ b/src/cli/handlers/project.ts
@@ -67,6 +67,52 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
     )
     printResult(result, json, formatProjectHostSetupResult)
   },
+  'project setup-devcontainer': async ({ flags, client, cwd, json }) => {
+    if (!client.isRemote) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        'Devcontainer setup requires a paired remote runtime. Use --environment, --pairing-code, ORCA_ENVIRONMENT, or ORCA_PAIRING_CODE.'
+      )
+    }
+    const rawPath = getRequiredStringFlag(flags, 'path')
+    const rawWorktreeBasePath = getRequiredStringFlag(flags, 'worktree-base-path')
+    const projectPath = resolveRepoPathArgument(
+      rawPath,
+      cwd,
+      client.isRemote,
+      'Devcontainer project setup'
+    )
+    const worktreeBasePath = resolveRepoPathArgument(
+      rawWorktreeBasePath,
+      cwd,
+      client.isRemote,
+      'Devcontainer worktree base path',
+      '--worktree-base-path'
+    )
+    const setupResult = await client.call<{ result: ProjectHostSetupResult }>(
+      'projectHostSetup.setupExistingFolder',
+      {
+        projectId: getRequiredStringFlag(flags, 'project'),
+        hostId: getRequiredStringFlag(
+          flags,
+          'host'
+        ) as ProjectHostSetupExistingFolderArgs['hostId'],
+        path: projectPath,
+        kind: getOptionalRepoKind(flags)
+      } satisfies ProjectHostSetupExistingFolderArgs
+    )
+    const setupId = setupResult.result.result.setup.id
+    const updateResult = await client.call<{ result: ProjectHostSetupUpdateResult }>(
+      'projectHostSetup.update',
+      {
+        setupId,
+        updates: {
+          worktreeBasePath
+        }
+      } satisfies ProjectHostSetupUpdateArgs
+    )
+    printResult(updateResult, json, formatProjectHostSetupUpdateResult)
+  },
   'project setup-clone': async ({ flags, client, cwd, json }) => {
     const rawDestination = getRequiredStringFlag(flags, 'destination')
     const args: ProjectHostSetupCloneArgs = {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -33,6 +33,7 @@ Projects:
   project list              List durable projects known to Orca
   project setups            List project host setups
   project setup-existing-folder Make a project available on a host by importing an existing folder
+  project setup-devcontainer Configure a paired devcontainer runtime checkout with persistent worktrees
   project setup-clone       Make a project available on a host by cloning a repository
   project setup-create      Create independent project host setup metadata
   project setup-update      Update project host setup metadata
@@ -216,6 +217,7 @@ Common Commands:
   orca project list [--json]
   orca project setups [--project <id>] [--host <host-id>] [--json]
   orca project setup-existing-folder --project <id> --host <host-id> --path <path> [--kind git|folder] [--display-name <name>] [--json]
+  orca project setup-devcontainer --project <id> --host <host-id> --path <absolute-repo-path> --worktree-base-path <absolute-worktrees-path> [--kind git|folder] [--json]
   orca project setup-clone --project <id> --host <host-id> --url <clone-url> --destination <path> [--display-name <name>] [--json]
   orca project setup-create --project <id> --host <host-id> [--setup-id <id>] [--path <path>] [--kind git|folder] [--display-name <name>] [--worktree-base-path <path>] [--git-username <name>] [--state ready|not-set-up|setting-up|error|unsupported] [--method imported-existing-folder|cloned|provisioned] [--json]
   orca project setup-update --setup <setup-id> [--display-name <name>] [--path <path>] [--worktree-base-path <path>] [--git-username <name>] [--kind git|folder] [--state ready|not-set-up|setting-up|error|unsupported] [--method legacy-repo|imported-existing-folder|cloned|provisioned] [--json]

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -16,6 +16,7 @@ Diagnostics:
 
 Environments:
   environment add           Save a remote Orca runtime from a pairing code
+  environment devcontainer-up Start Orca in a devcontainer and save the paired environment
   environment list          List saved remote Orca runtimes
   environment show          Show one saved remote Orca runtime
   environment rm            Remove a saved remote Orca runtime
@@ -191,6 +192,7 @@ Common Commands:
   orca status [--json]
   orca diagnostics memory [--json]
   orca environment add --name <name> --pairing-code <code> [--json]
+  orca environment devcontainer-up --name <env-name> --container <container> --host-port <port> [--container-port <port>] [--orca-bin <path>] [--bridge-name <name>] [--json]
   orca environment list [--json]
   orca environment show --environment <selector> [--json]
   orca environment rm --environment <selector> [--json]

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -2193,6 +2193,79 @@ describe('orca cli worktree awareness', () => {
     })
   })
 
+  it('reports the imported setup id when devcontainer worktree base update fails', async () => {
+    callMock
+      .mockResolvedValueOnce(
+        okFixture('req_project_setup', {
+          result: {
+            project: {
+              id: 'git:bitbucket.org/acme/app',
+              displayName: 'app',
+              badgeColor: '#7c3aed',
+              sourceRepoIds: ['repo-1'],
+              createdAt: 1,
+              updatedAt: 1
+            },
+            setup: {
+              id: 'setup-devcontainer',
+              projectId: 'git:bitbucket.org/acme/app',
+              hostId: 'local',
+              repoId: 'repo-1',
+              path: '/workspaces/lac/projects/app',
+              displayName: 'app',
+              setupState: 'ready',
+              setupMethod: 'imported-existing-folder',
+              createdAt: 1,
+              updatedAt: 1
+            },
+            repo: {
+              id: 'repo-1',
+              path: '/workspaces/lac/projects/app',
+              displayName: 'app',
+              badgeColor: '#7c3aed',
+              addedAt: 1
+            }
+          }
+        })
+      )
+      .mockRejectedValueOnce(new Error('update failed'))
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      [
+        'project',
+        'setup-devcontainer',
+        '--project',
+        'git:bitbucket.org/acme/app',
+        '--host',
+        'local',
+        '--path',
+        '/workspaces/lac/projects/app',
+        '--worktree-base-path',
+        '/workspaces/lac/projects/.worktrees/orca',
+        '--pairing-code',
+        'remote-runtime',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(2, 'projectHostSetup.update', {
+      setupId: 'setup-devcontainer',
+      updates: {
+        worktreeBasePath: '/workspaces/lac/projects/.worktrees/orca'
+      }
+    })
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'orca project setup-update --setup setup-devcontainer --worktree-base-path /workspaces/lac/projects/.worktrees/orca'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it('rejects devcontainer setup without a paired remote runtime', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -146,6 +146,9 @@ describe('orca root help', () => {
       'project setup-existing-folder Make a project available on a host by importing an existing folder'
     )
     expect(logSpy.mock.calls[0][0]).toContain(
+      'project setup-devcontainer Configure a paired devcontainer runtime checkout with persistent worktrees'
+    )
+    expect(logSpy.mock.calls[0][0]).toContain(
       'project setup-create      Create independent project host setup metadata'
     )
     expect(logSpy.mock.calls[0][0]).toContain(
@@ -2079,6 +2082,208 @@ describe('orca cli worktree awareness', () => {
     expect(callMock).not.toHaveBeenCalled()
     expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
       'Remote project setup requires --path to be an absolute path on the remote server.'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('sets up a devcontainer project with a persistent remote worktree base', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_project_setup', {
+        result: {
+          project: {
+            id: 'git:bitbucket.org/acme/app',
+            displayName: 'app',
+            badgeColor: '#7c3aed',
+            sourceRepoIds: ['repo-1'],
+            createdAt: 1,
+            updatedAt: 1
+          },
+          setup: {
+            id: 'setup-devcontainer',
+            projectId: 'git:bitbucket.org/acme/app',
+            hostId: 'local',
+            repoId: 'repo-1',
+            path: '/workspaces/lac/projects/app',
+            displayName: 'app',
+            setupState: 'ready',
+            setupMethod: 'imported-existing-folder',
+            createdAt: 1,
+            updatedAt: 1
+          },
+          repo: {
+            id: 'repo-1',
+            path: '/workspaces/lac/projects/app',
+            displayName: 'app',
+            badgeColor: '#7c3aed',
+            addedAt: 1
+          }
+        }
+      }),
+      okFixture('req_project_setup_update', {
+        result: {
+          project: {
+            id: 'git:bitbucket.org/acme/app',
+            displayName: 'app',
+            badgeColor: '#7c3aed',
+            sourceRepoIds: ['repo-1'],
+            createdAt: 1,
+            updatedAt: 1
+          },
+          setup: {
+            id: 'setup-devcontainer',
+            projectId: 'git:bitbucket.org/acme/app',
+            hostId: 'local',
+            repoId: 'repo-1',
+            path: '/workspaces/lac/projects/app',
+            worktreeBasePath: '/workspaces/lac/projects/.worktrees/orca',
+            displayName: 'app',
+            setupState: 'ready',
+            setupMethod: 'legacy-repo',
+            createdAt: 1,
+            updatedAt: 1
+          },
+          repo: {
+            id: 'repo-1',
+            path: '/workspaces/lac/projects/app',
+            worktreeBasePath: '/workspaces/lac/projects/.worktrees/orca',
+            displayName: 'app',
+            badgeColor: '#7c3aed',
+            addedAt: 1
+          }
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'project',
+        'setup-devcontainer',
+        '--project',
+        'git:bitbucket.org/acme/app',
+        '--host',
+        'local',
+        '--path',
+        '/workspaces/lac/projects/app',
+        '--worktree-base-path',
+        '/workspaces/lac/projects/.worktrees/orca',
+        '--kind',
+        'git',
+        '--pairing-code',
+        'remote-runtime',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'projectHostSetup.setupExistingFolder', {
+      projectId: 'git:bitbucket.org/acme/app',
+      hostId: 'local',
+      path: '/workspaces/lac/projects/app',
+      kind: 'git'
+    })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'projectHostSetup.update', {
+      setupId: 'setup-devcontainer',
+      updates: {
+        worktreeBasePath: '/workspaces/lac/projects/.worktrees/orca'
+      }
+    })
+  })
+
+  it('rejects devcontainer setup without a paired remote runtime', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      [
+        'project',
+        'setup-devcontainer',
+        '--project',
+        'git:bitbucket.org/acme/app',
+        '--host',
+        'local',
+        '--path',
+        '/workspaces/lac/projects/app',
+        '--worktree-base-path',
+        '/workspaces/lac/projects/.worktrees/orca',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'Devcontainer setup requires a paired remote runtime.'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('rejects remote devcontainer project relative paths before setup calls', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      [
+        'project',
+        'setup-devcontainer',
+        '--project',
+        'git:bitbucket.org/acme/app',
+        '--host',
+        'local',
+        '--path',
+        './app',
+        '--worktree-base-path',
+        '/workspaces/lac/projects/.worktrees/orca',
+        '--pairing-code',
+        'remote-runtime',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'Devcontainer project setup requires --path to be an absolute path on the remote server.'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('rejects remote devcontainer relative worktree base paths before setup calls', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      [
+        'project',
+        'setup-devcontainer',
+        '--project',
+        'git:bitbucket.org/acme/app',
+        '--host',
+        'local',
+        '--path',
+        '/workspaces/lac/projects/app',
+        '--worktree-base-path',
+        './.worktrees/orca',
+        '--pairing-code',
+        'remote-runtime',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'Devcontainer worktree base path requires --worktree-base-path to be an absolute path on the remote server.'
     )
     expect(process.exitCode).toBe(1)
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -7,6 +7,7 @@ const {
   serveOrcaAppMock,
   getDefaultUserDataPathMock,
   addEnvironmentFromPairingCodeMock,
+  upsertEnvironmentFromPairingCodeMock,
   listEnvironmentsMock,
   spawnMock
 } = vi.hoisted(() => ({
@@ -14,6 +15,7 @@ const {
   serveOrcaAppMock: vi.fn(),
   getDefaultUserDataPathMock: vi.fn(() => '/tmp/orca-user-data'),
   addEnvironmentFromPairingCodeMock: vi.fn(),
+  upsertEnvironmentFromPairingCodeMock: vi.fn(),
   listEnvironmentsMock: vi.fn(),
   spawnMock: vi.fn()
 }))
@@ -76,6 +78,7 @@ vi.mock('./runtime-client', () => {
 
 vi.mock('./runtime/environments', () => ({
   addEnvironmentFromPairingCode: addEnvironmentFromPairingCodeMock,
+  upsertEnvironmentFromPairingCode: upsertEnvironmentFromPairingCodeMock,
   listEnvironments: listEnvironmentsMock,
   removeEnvironment: vi.fn(),
   resolveEnvironment: vi.fn()
@@ -156,6 +159,9 @@ describe('orca root help', () => {
     )
     expect(logSpy.mock.calls[0][0]).toContain(
       'project setup-delete      Remove a project host setup'
+    )
+    expect(logSpy.mock.calls[0][0]).toContain(
+      'environment devcontainer-up Start Orca in a devcontainer and save the paired environment'
     )
     expect(logSpy.mock.calls[0][0]).toContain('Agent Sessions And Worktrees:')
     expect(logSpy.mock.calls[0][0]).toContain(
@@ -316,6 +322,7 @@ describe('orca cli worktree awareness', () => {
     serveOrcaAppMock.mockReset()
     getDefaultUserDataPathMock.mockClear()
     addEnvironmentFromPairingCodeMock.mockReset()
+    upsertEnvironmentFromPairingCodeMock.mockReset()
     listEnvironmentsMock.mockReset()
     spawnMock.mockClear()
     addEnvironmentFromPairingCodeMock.mockReturnValue({
@@ -1900,6 +1907,50 @@ describe('orca cli worktree awareness', () => {
     expect(logSpy.mock.calls[0]?.[0]).not.toContain('publicKeyB64')
   })
 
+  it('advertises the devcontainer environment helper', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['environment', 'devcontainer-up', '--help'], '/tmp/repo')
+
+    const help = String(logSpy.mock.calls[0][0])
+    expect(help).toContain('orca environment devcontainer-up')
+    expect(help).toContain('--host-port <port>')
+    expect(help).toContain('--bridge-name <name>')
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects host port 0 for environment devcontainer-up', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      [
+        'environment',
+        'devcontainer-up',
+        '--name',
+        'lac-devcontainer',
+        '--container',
+        'lac-devcontainer',
+        '--host-port',
+        '0',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+      ok: false,
+      error: {
+        code: 'invalid_argument',
+        message: 'Invalid --host-port value: 0'
+      }
+    })
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it('resolves repo.add paths against the invoking cli cwd', async () => {
     queueFixtures(
       callMock,
@@ -2233,37 +2284,41 @@ describe('orca cli worktree awareness', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const priorExitCode = process.exitCode
 
-    await main(
-      [
-        'project',
-        'setup-devcontainer',
-        '--project',
-        'git:bitbucket.org/acme/app',
-        '--host',
-        'local',
-        '--path',
-        '/workspaces/lac/projects/app',
-        '--worktree-base-path',
-        '/workspaces/lac/projects/.worktrees/orca',
-        '--pairing-code',
-        'remote-runtime',
-        '--json'
-      ],
-      '/tmp/repo'
-    )
+    try {
+      await main(
+        [
+          'project',
+          'setup-devcontainer',
+          '--project',
+          'git:bitbucket.org/acme/app',
+          '--host',
+          'local',
+          '--path',
+          '/workspaces/lac/projects/app',
+          '--worktree-base-path',
+          '/workspaces/lac/projects/.worktrees/orca',
+          '--pairing-code',
+          'remote-runtime',
+          '--json'
+        ],
+        '/tmp/repo'
+      )
 
-    expect(callMock).toHaveBeenNthCalledWith(2, 'projectHostSetup.update', {
-      setupId: 'setup-devcontainer',
-      updates: {
-        worktreeBasePath: '/workspaces/lac/projects/.worktrees/orca'
-      }
-    })
-    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
-      'orca project setup-update --setup setup-devcontainer --worktree-base-path /workspaces/lac/projects/.worktrees/orca'
-    )
-    expect(process.exitCode).toBe(1)
-
-    process.exitCode = priorExitCode
+      expect(callMock).toHaveBeenNthCalledWith(2, 'projectHostSetup.update', {
+        setupId: 'setup-devcontainer',
+        updates: {
+          worktreeBasePath: '/workspaces/lac/projects/.worktrees/orca'
+        }
+      })
+      expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+        'orca project setup-update --setup setup-devcontainer --worktree-base-path /workspaces/lac/projects/.worktrees/orca'
+      )
+      expect(process.exitCode).toBe(1)
+    } finally {
+      process.exitCode = priorExitCode
+      logSpy.mockRestore()
+      errSpy.mockRestore()
+    }
   })
 
   it('rejects devcontainer setup without a paired remote runtime', async () => {

--- a/src/cli/repo-path-arguments.ts
+++ b/src/cli/repo-path-arguments.ts
@@ -14,7 +14,8 @@ export function resolveRepoPathArgument(
   inputPath: string,
   cwd: string,
   isRemote: boolean,
-  remotePathSubject = 'Remote repo path'
+  remotePathSubject = 'Remote repo path',
+  remoteFlagName = '--path'
 ): string {
   if (!isRemote) {
     return resolvePath(cwd, inputPath)
@@ -24,7 +25,7 @@ export function resolveRepoPathArgument(
   if (!isAbsoluteServerPath(inputPath)) {
     throw new RuntimeClientError(
       'invalid_argument',
-      `${remotePathSubject} requires --path to be an absolute path on the remote server.`
+      `${remotePathSubject} requires ${remoteFlagName} to be an absolute path on the remote server.`
     )
   }
   return inputPath

--- a/src/cli/runtime/devcontainer-docker-launch.ts
+++ b/src/cli/runtime/devcontainer-docker-launch.ts
@@ -1,0 +1,262 @@
+import { spawn } from 'child_process'
+import { connect } from 'net'
+import { setTimeout as delay } from 'timers/promises'
+import { quoteCliCommandArgument } from '../shell-command-quote'
+import { RuntimeClientError } from './types'
+
+type ContainerNetworkInfo = {
+  networkName: string
+  containerIp: string
+}
+
+export function spawnBridgeContainer(args: {
+  bridgeName: string
+  networkName: string
+  containerIp: string
+  hostPort: number
+  containerPort: number
+}): ReturnType<typeof spawn> {
+  // Why: the bridge container must join the devcontainer's Docker network so
+  // the published host port can still reach the container IP that serves Orca.
+  return spawn(
+    'docker',
+    [
+      'run',
+      '--rm',
+      '--name',
+      args.bridgeName,
+      '--network',
+      args.networkName,
+      '-p',
+      `127.0.0.1:${args.hostPort}:${args.hostPort}`,
+      'alpine',
+      'sh',
+      '-lc',
+      `apk add --no-cache socat >/dev/null 2>&1 && exec socat -d -d TCP-LISTEN:${args.hostPort},fork,reuseaddr TCP:${args.containerIp}:${args.containerPort}`
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  )
+}
+
+export function spawnDevcontainerServe(args: {
+  container: string
+  containerPort: number
+  hostPort: number
+  orcaBin: string
+}): ReturnType<typeof spawn> {
+  return spawn(
+    'docker',
+    [
+      'exec',
+      args.container,
+      'sh',
+      '-lc',
+      `${quoteCliCommandArgument(args.orcaBin)} serve --json --port ${args.containerPort} --pairing-address 127.0.0.1:${args.hostPort}`
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] }
+  )
+}
+
+export function waitForBridgeReady(
+  child: ReturnType<typeof spawn>,
+  bridgeName: string,
+  hostPort: number
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + 30_000
+    let stderr = ''
+    let settled = false
+    const cleanup = (): void => {
+      child.stderr?.off('data', onStderrData)
+      child.off('exit', onExit)
+      child.off('error', onError)
+    }
+    const settleResolve = (): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      resolve()
+    }
+    const settleReject = (error: unknown): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      reject(error)
+    }
+    const onStderrData = (chunk: Buffer | string): void => {
+      stderr += chunk.toString()
+    }
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      settleReject(createBridgeStartupError(bridgeName, stderr, code, signal))
+    }
+    const onError = (error: Error): void => {
+      settleReject(error)
+    }
+
+    child.stderr?.on('data', onStderrData)
+    child.once('exit', onExit)
+    child.once('error', onError)
+
+    void (async () => {
+      while (!settled) {
+        if (Date.now() > deadline) {
+          settleReject(
+            new RuntimeClientError(
+              'runtime_error',
+              `Docker bridge ${bridgeName} did not become reachable on 127.0.0.1:${hostPort} within 30 seconds.`
+            )
+          )
+          return
+        }
+        if (child.exitCode !== null || child.signalCode !== null) {
+          settleReject(
+            createBridgeStartupError(bridgeName, stderr, child.exitCode, child.signalCode)
+          )
+          return
+        }
+        if (await canConnectToHostPort(hostPort)) {
+          await delay(100)
+          if (child.exitCode !== null || child.signalCode !== null) {
+            settleReject(
+              createBridgeStartupError(bridgeName, stderr, child.exitCode, child.signalCode)
+            )
+            return
+          }
+          settleResolve()
+          return
+        }
+        await delay(50)
+      }
+    })().catch(settleReject)
+  })
+}
+
+export function readContainerNetworkAndIp(container: string): Promise<ContainerNetworkInfo> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'docker',
+      [
+        'inspect',
+        '-f',
+        '{{range $name, $network := .NetworkSettings.Networks}}{{$name}}\t{{$network.IPAddress}}{{"\n"}}{{end}}',
+        container
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    )
+    let stdout = ''
+    let stderr = ''
+
+    const onStdoutData = (chunk: Buffer | string): void => {
+      stdout += chunk.toString()
+    }
+    const onStderrData = (chunk: Buffer | string): void => {
+      stderr += chunk.toString()
+    }
+    const onExit = (code: number | null): void => {
+      cleanup()
+      if (code !== 0) {
+        reject(
+          new RuntimeClientError(
+            'runtime_error',
+            stderr.trim().length > 0
+              ? stderr.trim()
+              : `Could not inspect Docker container ${container}.`
+          )
+        )
+        return
+      }
+      const line = stdout
+        .trim()
+        .split(/\r?\n/)
+        .map((value) => value.trim())
+        .find((value) => value.length > 0)
+      if (!line) {
+        reject(
+          new RuntimeClientError(
+            'runtime_error',
+            `Could not read a Docker network for ${container}.`
+          )
+        )
+        return
+      }
+      const [networkName, containerIp] = line.split('\t')
+      if (!networkName || !containerIp) {
+        reject(
+          new RuntimeClientError(
+            'runtime_error',
+            `Could not parse Docker network data for ${container}.`
+          )
+        )
+        return
+      }
+      resolve({ networkName, containerIp })
+    }
+    const onError = (error: Error): void => {
+      cleanup()
+      reject(error)
+    }
+    const cleanup = (): void => {
+      child.stdout?.off('data', onStdoutData)
+      child.stderr?.off('data', onStderrData)
+      child.off('exit', onExit)
+      child.off('error', onError)
+    }
+
+    child.stdout?.on('data', onStdoutData)
+    child.stderr?.on('data', onStderrData)
+    child.once('exit', onExit)
+    child.once('error', onError)
+  })
+}
+
+export function stopServeContainer(child: ReturnType<typeof spawn> | null): void {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+  child.kill('SIGTERM')
+}
+
+export function stopBridgeContainer(child: ReturnType<typeof spawn> | null): void {
+  if (!child) {
+    return
+  }
+  child.kill('SIGTERM')
+}
+
+function canConnectToHostPort(hostPort: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ host: '127.0.0.1', port: hostPort })
+    let settled = false
+    const finish = (ready: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      socket.removeAllListeners()
+      socket.destroy()
+      resolve(ready)
+    }
+    socket.setTimeout(250, () => finish(false))
+    socket.once('connect', () => finish(true))
+    socket.once('error', () => finish(false))
+  })
+}
+
+function createBridgeStartupError(
+  bridgeName: string,
+  stderr: string,
+  code: number | null,
+  signal: NodeJS.Signals | null
+): RuntimeClientError {
+  const trimmedStderr = stderr.trim()
+  return new RuntimeClientError(
+    'runtime_error',
+    trimmedStderr.length > 0
+      ? trimmedStderr
+      : `Docker bridge ${bridgeName} exited before readiness${code !== null ? ` with code ${code}` : ''}${signal ? ` via ${signal}` : ''}.`
+  )
+}

--- a/src/cli/runtime/devcontainer-server-readiness.ts
+++ b/src/cli/runtime/devcontainer-server-readiness.ts
@@ -1,0 +1,137 @@
+import type { spawn } from 'child_process'
+import { RuntimeClientError } from './types'
+
+export type DevcontainerServerReady = {
+  type: 'orca_server_ready'
+  runtimeId: string
+  pairing: { url: string }
+}
+
+export function waitForOrcaServerReady(
+  child: ReturnType<typeof spawn>
+): Promise<DevcontainerServerReady> {
+  return new Promise((resolve, reject) => {
+    let buffer = ''
+    const cleanup = (): void => {
+      child.stdout?.off('data', onStdoutData)
+      child.stderr?.off('data', onStderrData)
+      child.off('exit', onExit)
+      child.off('error', onError)
+    }
+    const onStdoutData = (chunk: Buffer | string): void => {
+      buffer += chunk.toString()
+      const ready = consumeReadyLine(buffer)
+      buffer = ready.remaining
+      if (ready.payload) {
+        cleanup()
+        resolve(ready.payload)
+      }
+    }
+    const onStderrData = (chunk: Buffer | string): void => {
+      process.stderr.write(chunk)
+    }
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      cleanup()
+      if (code === 0) {
+        reject(
+          new RuntimeClientError(
+            'runtime_error',
+            'orca serve exited before printing the orca_server_ready JSON line.'
+          )
+        )
+        return
+      }
+      reject(
+        new RuntimeClientError(
+          'runtime_error',
+          `orca serve exited before readiness${code !== null ? ` with code ${code}` : ''}${signal ? ` via ${signal}` : ''}.`
+        )
+      )
+    }
+    const onError = (error: Error): void => {
+      cleanup()
+      reject(error)
+    }
+
+    child.stdout?.on('data', onStdoutData)
+    child.stderr?.on('data', onStderrData)
+    child.once('exit', onExit)
+    child.once('error', onError)
+  })
+}
+
+export function waitForChildExit(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    if (child.exitCode === 0) {
+      return Promise.resolve()
+    }
+    return Promise.reject(
+      new RuntimeClientError(
+        'runtime_error',
+        `orca serve exited after readiness${child.exitCode !== null ? ` with code ${child.exitCode}` : ''}${child.signalCode ? ` via ${child.signalCode}` : ''}.`
+      )
+    )
+  }
+  return new Promise((resolve, reject) => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+      reject(
+        new RuntimeClientError(
+          'runtime_error',
+          `orca serve exited after readiness${code !== null ? ` with code ${code}` : ''}${signal ? ` via ${signal}` : ''}.`
+        )
+      )
+    }
+    child.once('exit', onExit)
+    child.once('error', reject)
+  })
+}
+
+function consumeReadyLine(buffer: string): {
+  payload: DevcontainerServerReady | null
+  remaining: string
+} {
+  let remaining = buffer
+  while (true) {
+    const newlineIndex = remaining.indexOf('\n')
+    if (newlineIndex === -1) {
+      return { payload: null, remaining }
+    }
+    const line = remaining.slice(0, newlineIndex).trim()
+    remaining = remaining.slice(newlineIndex + 1)
+    const payload = parseReadyPayload(line)
+    if (payload) {
+      return { payload, remaining }
+    }
+  }
+}
+
+function parseReadyPayload(line: string): DevcontainerServerReady | null {
+  if (line.trim().length === 0) {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(line) as Partial<DevcontainerServerReady> & {
+      pairing?: { url?: unknown } | null
+    }
+    if (
+      parsed.type === 'orca_server_ready' &&
+      typeof parsed.runtimeId === 'string' &&
+      parsed.pairing != null &&
+      typeof parsed.pairing.url === 'string' &&
+      parsed.pairing.url.length > 0
+    ) {
+      return {
+        type: 'orca_server_ready',
+        runtimeId: parsed.runtimeId,
+        pairing: { url: parsed.pairing.url }
+      }
+    }
+    return null
+  } catch {
+    return null
+  }
+}

--- a/src/cli/runtime/devcontainer-up.test.ts
+++ b/src/cli/runtime/devcontainer-up.test.ts
@@ -1,0 +1,306 @@
+import { EventEmitter } from 'events'
+import { createServer } from 'net'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock, upsertEnvironmentFromPairingCodeMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  upsertEnvironmentFromPairingCodeMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('./environments', () => ({
+  upsertEnvironmentFromPairingCode: upsertEnvironmentFromPairingCodeMock
+}))
+
+import { startDevcontainerUp } from './devcontainer-up'
+
+function createChild(): EventEmitter & {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  kill: ReturnType<typeof vi.fn>
+  unref: ReturnType<typeof vi.fn>
+  exitCode: number | null
+  signalCode: NodeJS.Signals | null
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+    unref: ReturnType<typeof vi.fn>
+    exitCode: number | null
+    signalCode: NodeJS.Signals | null
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  child.unref = vi.fn()
+  child.exitCode = null
+  child.signalCode = null
+  return child
+}
+
+function emitExit(
+  child: EventEmitter & { exitCode: number | null; signalCode: NodeJS.Signals | null },
+  code: number | null,
+  signal: NodeJS.Signals | null
+): void {
+  child.exitCode = code
+  child.signalCode = signal
+  child.emit('exit', code, signal)
+}
+
+async function listenOnLoopbackPort(): Promise<{ close: () => Promise<void>; port: number }> {
+  const server = createServer()
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+  const address = server.address()
+  if (address == null || typeof address === 'string') {
+    throw new Error('Expected an IPv4 address info')
+  }
+  return {
+    port: address.port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+      })
+  }
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('startDevcontainerUp', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    upsertEnvironmentFromPairingCodeMock.mockReset()
+  })
+
+  it('spawns the Docker bridge, waits for readiness, and upserts the saved environment', async () => {
+    const inspectChild = createChild()
+    const bridgeChild = createChild()
+    const serveChild = createChild()
+    const listener = await listenOnLoopbackPort()
+    const savedEnvironment = {
+      id: 'env-1',
+      name: 'lac-devcontainer',
+      createdAt: 100,
+      updatedAt: 200,
+      lastUsedAt: null,
+      runtimeId: 'runtime-123',
+      endpoints: [
+        {
+          id: 'ws-env-1',
+          kind: 'websocket',
+          label: 'WebSocket',
+          endpoint: 'orca://pair?code=ready',
+          deviceToken: 'token',
+          publicKeyB64: 'pk'
+        }
+      ],
+      preferredEndpointId: 'ws-env-1'
+    }
+
+    spawnMock
+      .mockReturnValueOnce(inspectChild)
+      .mockReturnValueOnce(bridgeChild)
+      .mockReturnValueOnce(serveChild)
+    upsertEnvironmentFromPairingCodeMock.mockReturnValue(savedEnvironment)
+
+    const session = startDevcontainerUp({
+      userDataPath: '/tmp/orca-user-data',
+      name: 'lac-devcontainer',
+      container: 'lac-devcontainer',
+      hostPort: listener.port,
+      containerPort: 6_768,
+      orcaBin: 'orca',
+      bridgeName: 'orca-devcontainer-lac'
+    })
+
+    inspectChild.stdout.emit('data', 'dev-net\t172.18.0.22\n')
+    inspectChild.emit('exit', 0, null)
+    await flush()
+
+    expect(spawnMock).toHaveBeenCalledTimes(3)
+    expect(spawnMock.mock.calls[1]).toEqual([
+      'docker',
+      [
+        'run',
+        '--rm',
+        '--name',
+        'orca-devcontainer-lac',
+        '--network',
+        'dev-net',
+        '-p',
+        `127.0.0.1:${listener.port}:${listener.port}`,
+        'alpine',
+        'sh',
+        '-lc',
+        `apk add --no-cache socat >/dev/null 2>&1 && exec socat -d -d TCP-LISTEN:${listener.port},fork,reuseaddr TCP:172.18.0.22:6768`
+      ],
+      { stdio: ['ignore', 'ignore', 'pipe'] }
+    ])
+    expect(spawnMock.mock.calls[2]).toEqual([
+      'docker',
+      [
+        'exec',
+        'lac-devcontainer',
+        'sh',
+        '-lc',
+        `orca serve --json --port 6768 --pairing-address 127.0.0.1:${listener.port}`
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    ])
+
+    serveChild.stdout.emit(
+      'data',
+      '{"type":"orca_server_ready","runtimeId":"runtime-123","endpoint":"ws://127.0.0.1:6768","pairing":{"url":"orca://pair?code=ready"}}\n'
+    )
+
+    await expect(session.ready).resolves.toEqual(savedEnvironment)
+    expect(upsertEnvironmentFromPairingCodeMock).toHaveBeenCalledWith('/tmp/orca-user-data', {
+      name: 'lac-devcontainer',
+      pairingCode: 'orca://pair?code=ready',
+      runtimeId: 'runtime-123',
+      now: undefined
+    })
+
+    emitExit(serveChild, 0, null)
+    await expect(session.done).resolves.toBeUndefined()
+    expect(bridgeChild.kill).toHaveBeenCalledWith('SIGTERM')
+    await listener.close()
+  })
+
+  it('rejects when the bridge fails or collides before saving the environment', async () => {
+    const inspectChild = createChild()
+    const bridgeChild = createChild()
+    const serveChild = createChild()
+    const listener = await listenOnLoopbackPort()
+
+    spawnMock
+      .mockReturnValueOnce(inspectChild)
+      .mockReturnValueOnce(bridgeChild)
+      .mockReturnValueOnce(serveChild)
+
+    const session = startDevcontainerUp({
+      userDataPath: '/tmp/orca-user-data',
+      name: 'lac-devcontainer',
+      container: 'lac-devcontainer',
+      hostPort: listener.port,
+      containerPort: 6_768,
+      orcaBin: 'orca',
+      bridgeName: 'orca-devcontainer-lac'
+    })
+
+    inspectChild.stdout.emit('data', 'dev-net\t172.18.0.22\n')
+    emitExit(inspectChild, 0, null)
+    await flush()
+    bridgeChild.stderr.emit(
+      'data',
+      'docker: Error response from daemon: driver failed programming external connectivity on endpoint bridge (port is already allocated)\n'
+    )
+    emitExit(bridgeChild, 1, null)
+
+    await expect(session.ready).rejects.toThrow('port is already allocated')
+    await expect(session.done).rejects.toThrow('port is already allocated')
+    expect(upsertEnvironmentFromPairingCodeMock).not.toHaveBeenCalled()
+    expect(serveChild.kill).toHaveBeenCalledWith('SIGTERM')
+    await listener.close()
+  })
+
+  it('resolves done when serve exits immediately after readiness', async () => {
+    const inspectChild = createChild()
+    const bridgeChild = createChild()
+    const serveChild = createChild()
+    const listener = await listenOnLoopbackPort()
+
+    spawnMock
+      .mockReturnValueOnce(inspectChild)
+      .mockReturnValueOnce(bridgeChild)
+      .mockReturnValueOnce(serveChild)
+    upsertEnvironmentFromPairingCodeMock.mockReturnValue({
+      id: 'env-1',
+      name: 'lac-devcontainer',
+      createdAt: 100,
+      updatedAt: 200,
+      lastUsedAt: null,
+      runtimeId: 'runtime-123',
+      endpoints: [],
+      preferredEndpointId: null
+    })
+
+    const session = startDevcontainerUp({
+      userDataPath: '/tmp/orca-user-data',
+      name: 'lac-devcontainer',
+      container: 'lac-devcontainer',
+      hostPort: listener.port,
+      containerPort: 6_768,
+      orcaBin: 'orca',
+      bridgeName: 'orca-devcontainer-lac'
+    })
+
+    inspectChild.stdout.emit('data', 'dev-net\t172.18.0.22\n')
+    emitExit(inspectChild, 0, null)
+    await flush()
+
+    serveChild.stdout.emit(
+      'data',
+      '{"type":"orca_server_ready","runtimeId":"runtime-123","pairing":{"url":"orca://pair?code=ready"}}\n'
+    )
+    emitExit(serveChild, 0, null)
+
+    await expect(session.ready).resolves.toMatchObject({ runtimeId: 'runtime-123' })
+    await expect(session.done).resolves.toBeUndefined()
+    await listener.close()
+  })
+
+  it('kills the serve child when upserting the environment fails', async () => {
+    const inspectChild = createChild()
+    const bridgeChild = createChild()
+    const serveChild = createChild()
+    const listener = await listenOnLoopbackPort()
+
+    spawnMock
+      .mockReturnValueOnce(inspectChild)
+      .mockReturnValueOnce(bridgeChild)
+      .mockReturnValueOnce(serveChild)
+    upsertEnvironmentFromPairingCodeMock.mockImplementation(() => {
+      throw new Error('write failed')
+    })
+
+    const session = startDevcontainerUp({
+      userDataPath: '/tmp/orca-user-data',
+      name: 'lac-devcontainer',
+      container: 'lac-devcontainer',
+      hostPort: listener.port,
+      containerPort: 6_768,
+      orcaBin: 'orca',
+      bridgeName: 'orca-devcontainer-lac'
+    })
+
+    inspectChild.stdout.emit('data', 'dev-net\t172.18.0.22\n')
+    emitExit(inspectChild, 0, null)
+    await flush()
+
+    serveChild.stdout.emit(
+      'data',
+      '{"type":"orca_server_ready","runtimeId":"runtime-123","pairing":{"url":"orca://pair?code=ready"}}\n'
+    )
+
+    await expect(session.ready).rejects.toThrow('write failed')
+    await expect(session.done).rejects.toThrow('write failed')
+    expect(serveChild.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(bridgeChild.kill).toHaveBeenCalledWith('SIGTERM')
+    await listener.close()
+  })
+})

--- a/src/cli/runtime/devcontainer-up.ts
+++ b/src/cli/runtime/devcontainer-up.ts
@@ -1,0 +1,92 @@
+import type { KnownRuntimeEnvironment } from '../../shared/runtime-environments'
+import { upsertEnvironmentFromPairingCode } from './environments'
+import {
+  readContainerNetworkAndIp,
+  spawnBridgeContainer,
+  spawnDevcontainerServe,
+  stopBridgeContainer,
+  stopServeContainer,
+  waitForBridgeReady
+} from './devcontainer-docker-launch'
+import { waitForChildExit, waitForOrcaServerReady } from './devcontainer-server-readiness'
+
+export type DevcontainerUpOptions = {
+  userDataPath: string
+  name: string
+  container: string
+  hostPort: number
+  containerPort: number
+  orcaBin: string
+  bridgeName: string
+  now?: number
+}
+
+export type DevcontainerUpSession = {
+  ready: Promise<KnownRuntimeEnvironment>
+  done: Promise<void>
+}
+
+export function startDevcontainerUp(options: DevcontainerUpOptions): DevcontainerUpSession {
+  const readyState = createDeferred<KnownRuntimeEnvironment>()
+  const doneState = createDeferred<void>()
+  let readySettled = false
+  let bridgeChild: ReturnType<typeof spawnBridgeContainer> | null = null
+  let serveChild: ReturnType<typeof spawnDevcontainerServe> | null = null
+
+  void (async () => {
+    try {
+      const { networkName, containerIp } = await readContainerNetworkAndIp(options.container)
+      bridgeChild = spawnBridgeContainer({
+        bridgeName: options.bridgeName,
+        networkName,
+        containerIp,
+        hostPort: options.hostPort,
+        containerPort: options.containerPort
+      })
+      serveChild = spawnDevcontainerServe({
+        container: options.container,
+        containerPort: options.containerPort,
+        hostPort: options.hostPort,
+        orcaBin: options.orcaBin
+      })
+      const [readyPayload] = await Promise.all([
+        waitForOrcaServerReady(serveChild),
+        waitForBridgeReady(bridgeChild, options.bridgeName, options.hostPort)
+      ])
+      const readyEnvironment = upsertEnvironmentFromPairingCode(options.userDataPath, {
+        name: options.name,
+        pairingCode: readyPayload.pairing.url,
+        runtimeId: readyPayload.runtimeId,
+        now: options.now
+      })
+      readySettled = true
+      readyState.resolve(readyEnvironment)
+      await waitForChildExit(serveChild)
+      doneState.resolve()
+    } catch (error) {
+      stopServeContainer(serveChild)
+      if (!readySettled) {
+        readyState.reject(error)
+      }
+      doneState.reject(error)
+    } finally {
+      stopBridgeContainer(bridgeChild)
+    }
+  })()
+
+  return { ready: readyState.promise, done: doneState.promise }
+}
+
+function createDeferred<TResult>(): {
+  promise: Promise<TResult>
+  resolve: (value: TResult | PromiseLike<TResult>) => void
+  reject: (reason?: unknown) => void
+} {
+  let resolve!: (value: TResult | PromiseLike<TResult>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<TResult>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}

--- a/src/cli/runtime/environments.ts
+++ b/src/cli/runtime/environments.ts
@@ -6,6 +6,7 @@ import {
   removeEnvironment as removeEnvironmentFromStore,
   resolveEnvironment as resolveEnvironmentFromStore,
   resolveEnvironmentPairingOffer as resolveEnvironmentPairingOfferFromStore,
+  upsertEnvironmentFromPairingCode as upsertEnvironmentFromPairingCodeInStore,
   RuntimeEnvironmentStoreError,
   type RuntimeEnvironmentStoreErrorCode
 } from '../../shared/runtime-environment-store'
@@ -32,9 +33,16 @@ export { getEnvironmentStorePath, listEnvironments }
 
 export function addEnvironmentFromPairingCode(
   userDataPath: string,
-  args: { name: string; pairingCode: string; now?: number }
+  args: { name: string; pairingCode: string; runtimeId?: string | null; now?: number }
 ): KnownRuntimeEnvironment {
   return translateStoreError(() => addEnvironmentFromPairingCodeInStore(userDataPath, args))
+}
+
+export function upsertEnvironmentFromPairingCode(
+  userDataPath: string,
+  args: { name: string; pairingCode: string; runtimeId?: string | null; now?: number }
+): KnownRuntimeEnvironment {
+  return translateStoreError(() => upsertEnvironmentFromPairingCodeInStore(userDataPath, args))
 }
 
 export function removeEnvironment(userDataPath: string, selector: string): KnownRuntimeEnvironment {

--- a/src/cli/specs/environment.ts
+++ b/src/cli/specs/environment.ts
@@ -10,6 +10,30 @@ export const ENVIRONMENT_COMMAND_SPECS: CommandSpec[] = [
     examples: ['orca environment add --name work-laptop --pairing-code orca://pair?code=...']
   },
   {
+    path: ['environment', 'devcontainer-up'],
+    summary: 'Start Orca inside a devcontainer and save the paired environment',
+    usage:
+      'orca environment devcontainer-up --name <env-name> --container <container> --host-port <port> [--container-port <port>] [--orca-bin <path>] [--bridge-name <name>] [--json]',
+    allowedFlags: [
+      ...GLOBAL_FLAGS,
+      'name',
+      'container',
+      'host-port',
+      'container-port',
+      'orca-bin',
+      'bridge-name'
+    ],
+    notes: [
+      'Starts a temporary Docker/socat bridge that forwards the host port to the devcontainer network.',
+      'The helper runs `orca serve --json` inside the container and saves the environment from the readiness payload.',
+      '--container-port defaults to 6768 when omitted.',
+      '--bridge-name defaults to a sanitized `orca-devcontainer-<name>` value.'
+    ],
+    examples: [
+      'orca environment devcontainer-up --name lac-devcontainer --container lac-devcontainer --host-port 31682 --container-port 6768 --orca-bin orca --json'
+    ]
+  },
+  {
     path: ['environment', 'list'],
     summary: 'List saved Orca runtime environments',
     usage: 'orca environment list [--json]',

--- a/src/cli/specs/project.ts
+++ b/src/cli/specs/project.ts
@@ -34,6 +34,24 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     ]
   },
   {
+    path: ['project', 'setup-devcontainer'],
+    summary: 'Configure a paired devcontainer runtime checkout with persistent worktrees',
+    usage:
+      'orca project setup-devcontainer --project <id> --host <host-id> --path <absolute-repo-path> --worktree-base-path <absolute-worktrees-path> [--kind git|folder] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'project', 'host', 'path', 'worktree-base-path', 'kind'],
+    notes: [
+      'Use after pairing an `orca serve` runtime running inside a devcontainer.',
+      'Requires --environment, --pairing-code, ORCA_ENVIRONMENT, or ORCA_PAIRING_CODE.',
+      'For a paired devcontainer runtime, --host is usually local because it is evaluated inside that runtime.',
+      '--path and --worktree-base-path must be absolute paths inside that devcontainer.',
+      'Choose a worktree base under a bind-mounted workspace path so worktrees survive container rebuilds.',
+      'If the worktree-base update fails after import, rerun the command or use project setup-update with the reported setup id.'
+    ],
+    examples: [
+      'orca project setup-devcontainer --environment lac --project git:bitbucket.org/acme/app --host local --path /workspaces/lac/projects/app --worktree-base-path /workspaces/lac/projects/.worktrees/orca --kind git --json'
+    ]
+  },
+  {
     path: ['project', 'setup-clone'],
     summary: 'Make a project available on a host by cloning a repository',
     usage:

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -118,7 +118,11 @@ import {
 
 const SSH_WORKTREE_CREATE_FETCH_FRESHNESS_MS = 30_000
 const SSH_WORKTREE_CREATE_FETCH_CACHE_MAX = 512
-const WORKTREE_SOURCE_CONFIG_FILES = ['orca.yaml', '.envrc'] as const
+// Why: `orca.yaml` must be available in the created worktree before setup so
+// Orca can read the worktree's own hooks/default tabs. `.envrc` is now owned by
+// the setup hook so it can deterministically compose workspace and repo-local
+// direnv sources without a pre-created file blocking the rewrite path.
+const WORKTREE_SOURCE_CONFIG_FILES = ['orca.yaml'] as const
 const sshWorktreeCreateFetchInflight = new Map<string, Promise<void>>()
 const sshWorktreeCreateFetchCompletedAt = new Map<string, number>()
 const sshWorktreeCreateFetchQueueTail = new Map<string, Promise<void>>()

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -10,6 +10,7 @@
 import type { BrowserWindow } from 'electron'
 import { posix, win32 } from 'node:path'
 import { existsSync } from 'node:fs'
+import { copyFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
 import type {
@@ -117,6 +118,7 @@ import {
 
 const SSH_WORKTREE_CREATE_FETCH_FRESHNESS_MS = 30_000
 const SSH_WORKTREE_CREATE_FETCH_CACHE_MAX = 512
+const WORKTREE_SOURCE_CONFIG_FILES = ['orca.yaml', '.envrc'] as const
 const sshWorktreeCreateFetchInflight = new Map<string, Promise<void>>()
 const sshWorktreeCreateFetchCompletedAt = new Map<string, number>()
 const sshWorktreeCreateFetchQueueTail = new Map<string, Promise<void>>()
@@ -128,6 +130,48 @@ const sshWorktreeCreateBasePlanInflight = new Map<
 type RemoteWorktreeCreateBasePlan = {
   baseBranch: string
   remoteTrackingBase: RemoteTrackingBase | null
+}
+
+async function copyMissingWorktreeSourceFiles(
+  sourceRoot: string,
+  destinationRoot: string,
+  fsProvider?: IFilesystemProvider | null
+): Promise<void> {
+  await Promise.all(
+    WORKTREE_SOURCE_CONFIG_FILES.map(async (filename) => {
+      const sourcePath = joinWorktreeRelativePath(sourceRoot, filename)
+      const destinationPath = joinWorktreeRelativePath(destinationRoot, filename)
+
+      if (fsProvider) {
+        try {
+          await fsProvider.stat(destinationPath)
+          return
+        } catch (error) {
+          if (!isENOENT(error)) {
+            throw error
+          }
+        }
+
+        try {
+          await fsProvider.stat(sourcePath)
+        } catch (error) {
+          if (isENOENT(error)) {
+            return
+          }
+          throw error
+        }
+
+        await fsProvider.copy(sourcePath, destinationPath)
+        return
+      }
+
+      if (existsSync(destinationPath) || !existsSync(sourcePath)) {
+        return
+      }
+
+      await copyFile(sourcePath, destinationPath)
+    })
+  )
 }
 
 type StagedStartupResult = {
@@ -1800,14 +1844,16 @@ export async function createRemoteWorktree(
   let setup: CreateWorktreeResult['setup']
   let defaultTabs: CreateWorktreeResult['defaultTabs']
   if (fsProvider) {
+    await copyMissingWorktreeSourceFiles(repo.path, created.path, fsProvider)
     await timing.time('prepare_setup', async () => {
       const yamlHooks = await readRemoteOrcaYaml(fsProvider, created.path)
       const hooks = getEffectiveHooksFromConfig(repo, yamlHooks)
       try {
         defaultTabs = getDefaultTabsLaunch(yamlHooks, repo, args.setupDecision)
       } catch (error) {
-        // Why: default tab commands share setup's run policy. If the target branch
-        // adds commands without a renderer decision, create the tabs but don't run them.
+        // Why: default tab commands share setup's run policy. If the created
+        // worktree adds commands without a renderer decision,
+        // create the tabs but don't run them.
         console.warn(`[hooks] default tab commands skipped for ${created.path}:`, error)
         defaultTabs = yamlHooks?.defaultTabs
           ? { tabs: yamlHooks.defaultTabs, runCommands: false }
@@ -2387,31 +2433,25 @@ export async function createLocalWorktree(
     })
   }
 
-  // Why: the worktree's own `orca.yaml` (at the tip of the base branch) is
-  // authoritative for what runs post-creation. The repo-level trust already
-  // granted by the user in the pre-create flow covers execution of that
-  // script; we intentionally do not re-gate on content equality with the
-  // primary checkout's preview, because benign divergence (whitespace,
-  // comments, or any setup-script edit that has landed on the base branch
-  // but not yet been pulled into the primary checkout) was silently
-  // disabling setup with no UI signal. See #1280 for the original gate and
-  // the regression this replaced.
+  await copyMissingWorktreeSourceFiles(repo.path, created.path)
+
   let setup: CreateWorktreeResult['setup']
   let defaultTabs: CreateWorktreeResult['defaultTabs']
   await timing.time('prepare_setup', async () => {
     const createdYamlHooks = loadHooks(worktreePath)
-    const createdEffectiveHooks = getEffectiveHooksFromConfig(repo, createdYamlHooks)
+    const createdHooks = getEffectiveHooksFromConfig(repo, createdYamlHooks)
     try {
       defaultTabs = getDefaultTabsLaunch(createdYamlHooks, repo, args.setupDecision)
     } catch (error) {
-      // Why: default tab commands share setup's run policy. If the target branch
-      // adds commands without a renderer decision, create the tabs but don't run them.
+      // Why: default tab commands share setup's run policy. If the created
+      // worktree adds commands without a renderer decision,
+      // create the tabs but don't run them.
       console.warn(`[hooks] default tab commands skipped for ${worktreePath}:`, error)
       defaultTabs = createdYamlHooks?.defaultTabs
         ? { tabs: createdYamlHooks.defaultTabs, runCommands: false }
         : undefined
     }
-    const setupScript = createdEffectiveHooks?.scripts.setup
+    const setupScript = createdHooks?.scripts.setup
     let shouldLaunchSetup = false
     if (setupScript) {
       try {

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1848,7 +1848,11 @@ export async function createRemoteWorktree(
   let setup: CreateWorktreeResult['setup']
   let defaultTabs: CreateWorktreeResult['defaultTabs']
   if (fsProvider) {
-    await copyMissingWorktreeSourceFiles(repo.path, created.path, fsProvider)
+    try {
+      await copyMissingWorktreeSourceFiles(repo.path, created.path, fsProvider)
+    } catch (error) {
+      console.warn(`[hooks] Failed to copy source config files into ${created.path}:`, error)
+    }
     await timing.time('prepare_setup', async () => {
       const yamlHooks = await readRemoteOrcaYaml(fsProvider, created.path)
       const hooks = getEffectiveHooksFromConfig(repo, yamlHooks)
@@ -2437,7 +2441,11 @@ export async function createLocalWorktree(
     })
   }
 
-  await copyMissingWorktreeSourceFiles(repo.path, created.path)
+  try {
+    await copyMissingWorktreeSourceFiles(repo.path, created.path)
+  } catch (error) {
+    console.warn(`[hooks] Failed to copy source config files into ${created.path}:`, error)
+  }
 
   let setup: CreateWorktreeResult['setup']
   let defaultTabs: CreateWorktreeResult['defaultTabs']

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1039,7 +1039,7 @@ describe('registerWorktreeHandlers', () => {
     expect(result.setup?.command).toContain('printf')
   })
 
-  it('copies source orca.yaml and .envrc into a new worktree before hook discovery', async () => {
+  it('copies source orca.yaml into a new worktree before hook discovery', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-worktree-copy-'))
     const repoPath = join(root, 'repo')
     const worktreePath = join(root, 'improve-dashboard')
@@ -1048,7 +1048,6 @@ describe('registerWorktreeHandlers', () => {
       await mkdir(repoPath, { recursive: true })
       await mkdir(worktreePath, { recursive: true })
       await writeFile(join(repoPath, 'orca.yaml'), 'scripts:\n  setup: copied-setup\n')
-      await writeFile(join(repoPath, '.envrc'), 'export ORCA_SOURCE=1\n')
 
       const repo = {
         id: 'repo-1',
@@ -1108,9 +1107,7 @@ describe('registerWorktreeHandlers', () => {
       expect(readFileSync(join(createdPath ?? worktreePath, 'orca.yaml'), 'utf-8')).toBe(
         'scripts:\n  setup: copied-setup\n'
       )
-      expect(readFileSync(join(createdPath ?? worktreePath, '.envrc'), 'utf-8')).toBe(
-        'export ORCA_SOURCE=1\n'
-      )
+      expect(() => readFileSync(join(createdPath ?? worktreePath, '.envrc'), 'utf-8')).toThrow()
       expect(loadHooksMock).toHaveBeenCalledWith(createdPath ?? worktreePath)
       expect(loadHooksMock).not.toHaveBeenCalledWith(repoPath)
     } finally {
@@ -1127,7 +1124,6 @@ describe('registerWorktreeHandlers', () => {
       await mkdir(repoPath, { recursive: true })
       await mkdir(worktreePath, { recursive: true })
       await writeFile(join(repoPath, 'orca.yaml'), 'scripts:\n  setup: copied-setup\n')
-      await writeFile(join(repoPath, '.envrc'), 'export ORCA_SOURCE=1\n')
 
       const repo = {
         id: 'repo-1',

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
 import { lstat, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -903,7 +904,7 @@ describe('registerWorktreeHandlers', () => {
 
   it('spawns a startup terminal and setup terminal after local worktree registration', async () => {
     addWorktreeMock.mockResolvedValue({})
-    listWorktreesMock.mockResolvedValueOnce([
+    listWorktreesMock.mockResolvedValue([
       {
         path: '/workspace/improve-dashboard',
         head: 'def',
@@ -1036,6 +1037,169 @@ describe('registerWorktreeHandlers', () => {
       })
     )
     expect(result.setup?.command).toContain('printf')
+  })
+
+  it('copies source orca.yaml and .envrc into a new worktree before hook discovery', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-worktree-copy-'))
+    const repoPath = join(root, 'repo')
+    const worktreePath = join(root, 'improve-dashboard')
+
+    try {
+      await mkdir(repoPath, { recursive: true })
+      await mkdir(worktreePath, { recursive: true })
+      await writeFile(join(repoPath, 'orca.yaml'), 'scripts:\n  setup: copied-setup\n')
+      await writeFile(join(repoPath, '.envrc'), 'export ORCA_SOURCE=1\n')
+
+      const repo = {
+        id: 'repo-1',
+        path: repoPath,
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        worktreeBaseRef: null
+      }
+
+      store.getRepos.mockReturnValue([repo])
+      store.getRepo.mockReturnValue(repo)
+      store.getProjectHostSetups.mockReturnValue([])
+      store.getSettings.mockReturnValue({
+        branchPrefix: 'none',
+        nestWorkspaces: false,
+        refreshLocalBaseRefOnWorktreeCreate: false,
+        workspaceDir: root
+      })
+
+      let createdPath: string | undefined
+      addWorktreeMock.mockImplementation(async (_repoPath: string, path: string) => {
+        createdPath = path
+        await mkdir(path, { recursive: true })
+        return {}
+      })
+      listWorktreesMock.mockImplementation(async () =>
+        createdPath
+          ? [
+              {
+                path: createdPath,
+                head: 'def',
+                branch: 'improve-dashboard',
+                isBare: false,
+                isMainWorktree: false
+              }
+            ]
+          : []
+      )
+      loadHooksMock.mockImplementation((path: string) => {
+        if (path === (createdPath ?? worktreePath)) {
+          expect(readFileSync(join(createdPath ?? worktreePath, 'orca.yaml'), 'utf-8')).toBe(
+            'scripts:\n  setup: copied-setup\n'
+          )
+        }
+        return null
+      })
+      getEffectiveHooksMock.mockReturnValue(null)
+      getEffectiveHooksFromConfigMock.mockReturnValue(null)
+      getDefaultTabsLaunchMock.mockReturnValue(undefined)
+
+      await handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'improve-dashboard'
+      })
+
+      expect(readFileSync(join(createdPath ?? worktreePath, 'orca.yaml'), 'utf-8')).toBe(
+        'scripts:\n  setup: copied-setup\n'
+      )
+      expect(readFileSync(join(createdPath ?? worktreePath, '.envrc'), 'utf-8')).toBe(
+        'export ORCA_SOURCE=1\n'
+      )
+      expect(loadHooksMock).toHaveBeenCalledWith(createdPath ?? worktreePath)
+      expect(loadHooksMock).not.toHaveBeenCalledWith(repoPath)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not overwrite existing orca.yaml or .envrc in a new worktree', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-worktree-preserve-'))
+    const repoPath = join(root, 'repo')
+    const worktreePath = join(root, 'improve-dashboard')
+
+    try {
+      await mkdir(repoPath, { recursive: true })
+      await mkdir(worktreePath, { recursive: true })
+      await writeFile(join(repoPath, 'orca.yaml'), 'scripts:\n  setup: copied-setup\n')
+      await writeFile(join(repoPath, '.envrc'), 'export ORCA_SOURCE=1\n')
+
+      const repo = {
+        id: 'repo-1',
+        path: repoPath,
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        worktreeBaseRef: null
+      }
+
+      store.getRepos.mockReturnValue([repo])
+      store.getRepo.mockReturnValue(repo)
+      store.getProjectHostSetups.mockReturnValue([])
+      store.getSettings.mockReturnValue({
+        branchPrefix: 'none',
+        nestWorkspaces: false,
+        refreshLocalBaseRefOnWorktreeCreate: false,
+        workspaceDir: root
+      })
+
+      let createdPath: string | undefined
+      addWorktreeMock.mockImplementation(async (_repoPath: string, path: string) => {
+        createdPath = path
+        await mkdir(path, { recursive: true })
+        await writeFile(join(path, 'orca.yaml'), 'scripts:\n  setup: keep-existing\n')
+        await writeFile(join(path, '.envrc'), 'export ORCA_DEST=1\n')
+        return {}
+      })
+      listWorktreesMock.mockImplementation(async () =>
+        createdPath
+          ? [
+              {
+                path: createdPath,
+                head: 'def',
+                branch: 'improve-dashboard',
+                isBare: false,
+                isMainWorktree: false
+              }
+            ]
+          : []
+      )
+      loadHooksMock.mockImplementation((path: string) => {
+        if (path === (createdPath ?? worktreePath)) {
+          expect(readFileSync(join(createdPath ?? worktreePath, 'orca.yaml'), 'utf-8')).toBe(
+            'scripts:\n  setup: keep-existing\n'
+          )
+          expect(readFileSync(join(createdPath ?? worktreePath, '.envrc'), 'utf-8')).toBe(
+            'export ORCA_DEST=1\n'
+          )
+        }
+        return null
+      })
+      getEffectiveHooksMock.mockReturnValue(null)
+      getEffectiveHooksFromConfigMock.mockReturnValue(null)
+      getDefaultTabsLaunchMock.mockReturnValue(undefined)
+
+      await handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'improve-dashboard'
+      })
+
+      expect(readFileSync(join(createdPath ?? worktreePath, 'orca.yaml'), 'utf-8')).toBe(
+        'scripts:\n  setup: keep-existing\n'
+      )
+      expect(readFileSync(join(createdPath ?? worktreePath, '.envrc'), 'utf-8')).toBe(
+        'export ORCA_DEST=1\n'
+      )
+      expect(loadHooksMock).toHaveBeenCalledWith(createdPath ?? worktreePath)
+      expect(loadHooksMock).not.toHaveBeenCalledWith(repoPath)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it('checks out a selected existing local branch exactly', async () => {
@@ -3159,7 +3323,7 @@ describe('registerWorktreeHandlers', () => {
     expect(result.localBaseRefUpdateSuggestion).toBeUndefined()
   })
 
-  it('reads remote orca.yaml and returns a setup launch payload during SSH create', async () => {
+  it('uses the created remote orca.yaml for setup launch during SSH create', async () => {
     const repo = {
       id: 'repo-ssh',
       path: '/remote/repo',
@@ -3198,12 +3362,27 @@ describe('registerWorktreeHandlers', () => {
       ])
     }
     const fsProvider = {
-      readFile: vi.fn().mockResolvedValue({
-        content: 'scripts:\n  setup: pnpm install\n',
-        isBinary: false
+      stat: vi.fn().mockImplementation(async (path: string) => {
+        if (path === '/remote/repo/orca.yaml') {
+          return { size: 31, type: 'file', mtime: 0 }
+        }
+        if (path === '/remote/improve-dashboard/orca.yaml') {
+          return { size: 34, type: 'file', mtime: 0 }
+        }
+        const error = new Error('missing') as Error & { code: string }
+        error.code = 'ENOENT'
+        throw error
       }),
+      readFile: vi.fn().mockImplementation(async (path: string) => ({
+        content:
+          path === '/remote/repo/orca.yaml'
+            ? 'scripts:\n  setup: source-setup\n'
+            : 'scripts:\n  setup: copied-setup\n',
+        isBinary: false
+      })),
       createDir: vi.fn().mockResolvedValue(undefined),
-      writeFile: vi.fn().mockResolvedValue(undefined)
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      copy: vi.fn().mockResolvedValue(undefined)
     }
     const mux = {
       request: vi.fn().mockResolvedValue(undefined),
@@ -3215,8 +3394,12 @@ describe('registerWorktreeHandlers', () => {
     getSshFilesystemProviderMock.mockReturnValue(fsProvider)
     getActiveMultiplexerMock.mockReturnValue(mux)
     store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
-    parseOrcaYamlMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
-    getEffectiveHooksFromConfigMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    parseOrcaYamlMock.mockImplementation((content: string) => ({
+      scripts: {
+        setup: content.includes('copied-setup') ? 'copied-setup' : 'source-setup'
+      }
+    }))
+    getEffectiveHooksFromConfigMock.mockImplementation((_repo, yamlHooks) => yamlHooks)
     shouldRunSetupForCreateMock.mockReturnValue(true)
 
     const result = await handlers['worktrees:create'](null, {
@@ -3227,6 +3410,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(fsProvider.readFile).toHaveBeenCalledWith('/remote/repo/orca.yaml')
     expect(fsProvider.readFile).toHaveBeenCalledWith('/remote/improve-dashboard/orca.yaml')
+    expect(fsProvider.copy).not.toHaveBeenCalled()
     expect(provider.exec).toHaveBeenCalledWith(
       ['rev-parse', '--git-path', 'orca/setup-runner.sh'],
       '/remote/improve-dashboard'
@@ -3236,7 +3420,7 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(fsProvider.writeFile).toHaveBeenCalledWith(
       '/remote/repo/.git/worktrees/improve-dashboard/orca/setup-runner.sh',
-      '#!/usr/bin/env bash\nset -e\npnpm install\n'
+      '#!/usr/bin/env bash\nset -e\ncopied-setup\n'
     )
     expect(result).toEqual(
       expect.objectContaining({
@@ -5272,6 +5456,11 @@ describe('registerWorktreeHandlers', () => {
         setup: 'pnpm worktree:setup'
       }
     })
+    loadHooksMock.mockReturnValue({
+      scripts: {
+        setup: 'pnpm worktree:setup'
+      }
+    })
     shouldRunSetupForCreateMock.mockReturnValue(true)
 
     const result = await handlers['worktrees:create'](null, {
@@ -5285,6 +5474,7 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/improve-dashboard',
       'pnpm worktree:setup'
     )
+    expect(loadHooksMock).toHaveBeenCalledWith('/workspace/improve-dashboard')
     expect(result).toMatchObject({
       worktree: expect.objectContaining({
         repoId: 'repo-1',
@@ -5327,6 +5517,11 @@ describe('registerWorktreeHandlers', () => {
         setup: 'pnpm worktree:setup'
       }
     })
+    loadHooksMock.mockReturnValue({
+      scripts: {
+        setup: 'pnpm worktree:setup'
+      }
+    })
     getEffectiveHooksFromConfigMock.mockReturnValue({
       scripts: {
         setup: 'pnpm worktree:setup'
@@ -5346,6 +5541,7 @@ describe('registerWorktreeHandlers', () => {
       'pnpm worktree:setup',
       { wslDistro: 'Ubuntu' }
     )
+    expect(loadHooksMock).toHaveBeenCalledWith('/workspace/improve-dashboard')
     expect(addWorktreeMock).toHaveBeenCalledWith(
       '/workspace/repo',
       '/workspace/improve-dashboard',
@@ -5373,6 +5569,11 @@ describe('registerWorktreeHandlers', () => {
         setup: 'pnpm worktree:setup # worktree'
       }
     })
+    loadHooksMock.mockReturnValue({
+      scripts: {
+        setup: 'pnpm worktree:setup # worktree'
+      }
+    })
     shouldRunSetupForCreateMock.mockReturnValue(true)
 
     const result = await handlers['worktrees:create'](null, {
@@ -5386,6 +5587,7 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/improve-dashboard',
       'pnpm worktree:setup # worktree'
     )
+    expect(loadHooksMock).toHaveBeenCalledWith('/workspace/improve-dashboard')
     expect(result).toEqual(
       expect.objectContaining({
         setup: expect.objectContaining({
@@ -5565,6 +5767,11 @@ describe('registerWorktreeHandlers', () => {
   it('still returns the created worktree when setup runner generation fails', async () => {
     listWorktreesMock.mockResolvedValue(createdWorktreeList)
     getEffectiveHooksMock.mockReturnValue({
+      scripts: {
+        setup: 'pnpm worktree:setup'
+      }
+    })
+    loadHooksMock.mockReturnValue({
       scripts: {
         setup: 'pnpm worktree:setup'
       }

--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -7,7 +7,8 @@ import {
   RuntimeEnvironmentStoreError,
   addEnvironmentFromPairingCode,
   listEnvironments,
-  markEnvironmentUsed
+  markEnvironmentUsed,
+  upsertEnvironmentFromPairingCode
 } from './runtime-environment-store'
 
 function pairingCode(endpoint = 'ws://127.0.0.1:6768'): string {
@@ -53,6 +54,32 @@ describe('runtime environment store', () => {
       })
     ).toThrow(RuntimeEnvironmentStoreError)
     expect(listEnvironments(userDataPath)).toEqual([first])
+  })
+
+  it('upserts duplicate names by replacing the saved pairing fields in place', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+
+    const first = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'dev box',
+      pairingCode: pairingCode('ws://127.0.0.1:6768'),
+      now: 100,
+      runtimeId: 'runtime-1'
+    })
+
+    const updated = upsertEnvironmentFromPairingCode(userDataPath, {
+      name: 'dev box',
+      pairingCode: pairingCode('ws://192.0.2.10:6768'),
+      now: 200,
+      runtimeId: 'runtime-2'
+    })
+
+    expect(updated.id).toBe(first.id)
+    expect(updated.createdAt).toBe(first.createdAt)
+    expect(updated.updatedAt).toBe(200)
+    expect(updated.runtimeId).toBe('runtime-2')
+    expect(updated.endpoints[0]?.endpoint).toBe('ws://192.0.2.10:6768')
+    expect(listEnvironments(userDataPath)).toEqual([updated])
   })
 
   it('throttles lastUsedAt writes so it does not rewrite the store on every runtime call', () => {

--- a/src/shared/runtime-environment-store.ts
+++ b/src/shared/runtime-environment-store.ts
@@ -36,7 +36,7 @@ export function listEnvironments(userDataPath: string): KnownRuntimeEnvironment[
 
 export function addEnvironmentFromPairingCode(
   userDataPath: string,
-  args: { name: string; pairingCode: string; now?: number }
+  args: { name: string; pairingCode: string; runtimeId?: string | null; now?: number }
 ): KnownRuntimeEnvironment {
   const offer = parsePairingCode(args.pairingCode)
   if (!offer) {
@@ -59,12 +59,59 @@ export function addEnvironmentFromPairingCode(
     name: args.name,
     now,
     offer,
-    runtimeId: null
+    runtimeId: args.runtimeId ?? null
   })
   const next = {
     version: 1 as const,
     environments: [
       ...store.environments.filter((entry) => entry.id !== environment.id),
+      environment
+    ].sort((a, b) => a.name.localeCompare(b.name))
+  }
+  writeEnvironmentStore(userDataPath, next)
+  return environment
+}
+
+export function upsertEnvironmentFromPairingCode(
+  userDataPath: string,
+  args: { name: string; pairingCode: string; runtimeId?: string | null; now?: number }
+): KnownRuntimeEnvironment {
+  const offer = parsePairingCode(args.pairingCode)
+  if (!offer) {
+    throw new RuntimeEnvironmentStoreError(
+      'invalid_argument',
+      'Invalid pairing code. Expected an orca://pair?... URL or bare pairing payload.'
+    )
+  }
+  const store = readEnvironmentStore(userDataPath)
+  const now = args.now ?? Date.now()
+  const existing = store.environments.find((entry) => entry.name === args.name)
+  const environment = existing
+    ? {
+        ...createEnvironmentFromPairingOffer({
+          id: existing.id,
+          name: args.name,
+          now,
+          offer,
+          runtimeId: args.runtimeId ?? existing.runtimeId ?? null
+        }),
+        createdAt: existing.createdAt,
+        lastUsedAt: existing.lastUsedAt,
+        runtimeId: args.runtimeId ?? existing.runtimeId ?? null
+      }
+    : createEnvironmentFromPairingOffer({
+        id: randomUUID(),
+        name: args.name,
+        now,
+        offer,
+        runtimeId: args.runtimeId ?? null
+      })
+  const next = {
+    version: 1 as const,
+    environments: [
+      ...store.environments.filter(
+        (entry) => entry.id !== environment.id && entry.name !== args.name
+      ),
       environment
     ].sort((a, b) => a.name.localeCompare(b.name))
   }


### PR DESCRIPTION
## What this PR does
This PR adds `orca project setup-devcontainer`, a CLI command for configuring an existing checkout that lives inside a paired devcontainer runtime.

The command:
- refuses to run against the desktop-local runtime, so users must pass `--environment`, `--pairing-code`, `ORCA_ENVIRONMENT`, or `ORCA_PAIRING_CODE`
- imports the repo path inside the devcontainer using the existing `projectHostSetup.setupExistingFolder` RPC
- immediately updates that setup with a persistent `worktreeBasePath`
- requires both `--path` and `--worktree-base-path` to be absolute paths on the remote/devcontainer filesystem
- reports the imported setup id if the follow-up worktree-base update fails, so users can recover with `project setup-update`
- documents how to choose a bind-mounted worktree base such as `/workspaces/lac/projects/.worktrees/orca`

## Why
Devcontainer users need Orca worktrees and terminals to run inside the container, but worktrees should survive rebuilds/container deletion. This helper avoids accidentally storing worktrees under ephemeral container-home paths like `/home/vscode/orca/workspaces/...`.

## Related issue
Closes #6420

## Screenshots
No screenshots. This is a CLI and documentation change with no visual UI changes.

## Testing checklist
- [x] Added/updated CLI tests for the new command
- [x] Added test coverage for the partial-failure recovery message
- [x] Ran focused CLI test file
- [x] Ran broader CLI test suite
- [x] Ran CLI typecheck
- [x] Verified docs clarify the devcontainer pairing address assumption

## Validation
- `npx --yes pnpm@10.24.0 vitest src/cli/index.test.ts`
- `npx --yes pnpm@10.24.0 vitest src/cli`
- `npx --yes pnpm@10.24.0 run tc:cli`

Note: local shell has Node v26, while the repo requests Node 24; commands passed with the repo engine warning.

## AI Review Report
CodeRabbit reviewed the PR. Follow-up changes addressed the actionable feedback:
- clarified the devcontainer pairing address documentation
- added a why-comment for the two-step setup/update flow
- surfaced the setup id when the worktree-base update fails
- added focused test coverage for that recovery path

Docstring coverage was reported by CodeRabbit as a warning, but this TypeScript CLI codebase does not use Python-style docstring coverage and the repository checks exposed on GitHub are passing. No separate failing GitHub Actions docstring job was found.

## Security Audit
Security impact is low. The command requires an explicit paired remote runtime selector and rejects relative remote paths, which reduces accidental desktop-local or wrong-filesystem configuration. It does not add new credential handling, network listeners, persistence formats, or authentication flows.

## Notes
- `setup-devcontainer` intentionally composes existing runtime RPCs instead of adding a new backend API.
- The helper is non-atomic because `setupExistingFolder` does not accept `worktreeBasePath`; the PR now documents and reports the recovery command if the second step fails.
- Maintainer merge is still required because this branch is pushed from a fork.

## ELI5

New CLI `orca project setup-devcontainer` wires an existing checkout inside a paired devcontainer into Orca. It refuses pure local desktop runs so setup stays tied to the container environment.
