### PR TITLE
Avoid IME punctuation listeners off macOS

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -700,12 +700,17 @@ export function useTerminalPaneLifecycle({
         // xterm's kitty CSI-u encoding for ordinary punctuation. Gate it to CJK
         // input sources so direct Japanese/Chinese punctuation works without
         // changing plain US/European terminal key handling.
-        const imePunctuationForwarder = installTerminalImePunctuationForwarder({
-          terminalElement: pane.terminal.element,
-          isComposing: () => imeCompositionTracker.isActive(),
-          sendInput: (data) => pane.terminal.input(data),
-          isEnabled: () => macCjkInputSourceTracker?.isActive() === true
-        })
+        const imePunctuationForwarder = isMac
+          ? installTerminalImePunctuationForwarder({
+              terminalElement: pane.terminal.element,
+              isComposing: () => imeCompositionTracker.isActive(),
+              sendInput: (data) => pane.terminal.input(data),
+              isEnabled: () => macCjkInputSourceTracker?.isActive() === true
+            })
+          : {
+              claimKeyEvent: () => false,
+              dispose: () => undefined
+            }
         imePunctuationForwarderDisposablesRef.current.set(pane.id, imePunctuationForwarder)
         pane.terminal.attachCustomKeyEventHandler((e) => {
           if (


### PR DESCRIPTION
Follow-up to #6417.

## Summary
- Keep the CJK IME punctuation forwarder installed only on macOS.
- Use a no-op disposable on Linux/Windows so those platforms do not register unused input/blur listeners.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts src/renderer/src/components/terminal-pane/terminal-ime-punctuation-forwarder.test.ts src/renderer/src/components/terminal-pane/terminal-ime-input-source.test.ts src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts src/renderer/src/components/terminal-pane/xterm-bypass-policy-non-mac.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes; existing unrelated hook warning in `useGitStatusPolling.ts`)