### PR TITLE
fix: background-mount hidden automation worktrees before launch

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -58,7 +58,7 @@ import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
 import AiVaultSessionDropLayer from './tab-group/AiVaultSessionDropLayer'
 import { shouldAutoCreateInitialTerminal } from './terminal/initial-terminal'
 import { shouldRepairActiveTerminalTab } from './terminal/active-terminal-repair'
-import { addBackgroundMountedTerminalWorktree } from './terminal/background-terminal-worktree-mount'
+import { scheduleBackgroundTerminalWorktreeMeasure } from './terminal/background-terminal-worktree-visibility'
 import {
   getEffectiveLayoutForWorktree as getEffectiveLayout,
   anyMountedWorktreeHasLayout as computeAnyMountedWorktreeHasLayout
@@ -716,27 +716,15 @@ function Terminal(): React.JSX.Element | null {
     const onBackgroundMountTerminalWorktree = (event: Event): void => {
       const customEvent = event as CustomEvent<BackgroundMountTerminalWorktreeDetail>
       const worktreeId = customEvent.detail?.worktreeId
-      addBackgroundMountedTerminalWorktree(mountedWorktreeIdsRef.current, worktreeId, () =>
-        setBackgroundMountRevision((revision) => revision + 1)
-      )
-      if (!worktreeId) {
-        return
-      }
-      measurableBackgroundWorktreeIdsRef.current.add(worktreeId)
-      const existingTimer = timers.get(worktreeId)
-      if (existingTimer !== undefined) {
-        window.clearTimeout(existingTimer)
-      }
-      // Why: background renderer-backed terminal creation must be measurable
-      // for the first xterm fit, but it must not keep hidden worktrees laid
-      // out indefinitely after the PTY has started.
-      const timer = window.setTimeout(() => {
-        measurableBackgroundWorktreeIdsRef.current.delete(worktreeId)
-        timers.delete(worktreeId)
-        setBackgroundMountRevision((revision) => revision + 1)
-      }, 3000)
-      timers.set(worktreeId, timer)
-      setBackgroundMountRevision((revision) => revision + 1)
+      scheduleBackgroundTerminalWorktreeMeasure({
+        mountedWorktreeIds: mountedWorktreeIdsRef.current,
+        measurableBackgroundWorktreeIds: measurableBackgroundWorktreeIdsRef.current,
+        timers,
+        worktreeId,
+        onRevision: () => setBackgroundMountRevision((revision) => revision + 1),
+        setTimeoutFn: window.setTimeout,
+        clearTimeoutFn: window.clearTimeout
+      })
     }
     window.addEventListener(
       BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT,

--- a/src/renderer/src/components/terminal/background-terminal-worktree-visibility.test.ts
+++ b/src/renderer/src/components/terminal/background-terminal-worktree-visibility.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  BACKGROUND_WORKTREE_MEASURE_WINDOW_MS,
+  scheduleBackgroundTerminalWorktreeMeasure
+} from './background-terminal-worktree-visibility'
+
+describe('scheduleBackgroundTerminalWorktreeMeasure', () => {
+  it('marks a hidden worktree measurable for the first mount window', () => {
+    vi.useFakeTimers()
+    try {
+      const mountedWorktreeIds = new Set<string>()
+      const measurableBackgroundWorktreeIds = new Set<string>()
+      const timers = new Map<string, number>()
+      const onRevision = vi.fn()
+
+      const added = scheduleBackgroundTerminalWorktreeMeasure({
+        mountedWorktreeIds,
+        measurableBackgroundWorktreeIds,
+        timers,
+        worktreeId: 'wt-1',
+        onRevision,
+        setTimeoutFn: setTimeout,
+        clearTimeoutFn: clearTimeout
+      })
+
+      expect(added).toBe(true)
+      expect(mountedWorktreeIds.has('wt-1')).toBe(true)
+      expect(measurableBackgroundWorktreeIds.has('wt-1')).toBe(true)
+      expect(timers.has('wt-1')).toBe(true)
+      expect(onRevision).toHaveBeenCalledTimes(2)
+
+      vi.advanceTimersByTime(BACKGROUND_WORKTREE_MEASURE_WINDOW_MS - 1)
+      expect(measurableBackgroundWorktreeIds.has('wt-1')).toBe(true)
+
+      vi.advanceTimersByTime(1)
+      expect(measurableBackgroundWorktreeIds.has('wt-1')).toBe(false)
+      expect(timers.has('wt-1')).toBe(false)
+      expect(onRevision).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('refreshes the measurable timer for repeated background-mount events', () => {
+    vi.useFakeTimers()
+    try {
+      const mountedWorktreeIds = new Set<string>()
+      const measurableBackgroundWorktreeIds = new Set<string>()
+      const timers = new Map<string, number>()
+      const onRevision = vi.fn()
+      const clearTimeoutFn = vi.fn(clearTimeout)
+
+      scheduleBackgroundTerminalWorktreeMeasure({
+        mountedWorktreeIds,
+        measurableBackgroundWorktreeIds,
+        timers,
+        worktreeId: 'wt-1',
+        onRevision,
+        setTimeoutFn: setTimeout,
+        clearTimeoutFn
+      })
+      const firstTimer = timers.get('wt-1')
+
+      scheduleBackgroundTerminalWorktreeMeasure({
+        mountedWorktreeIds,
+        measurableBackgroundWorktreeIds,
+        timers,
+        worktreeId: 'wt-1',
+        onRevision,
+        setTimeoutFn: setTimeout,
+        clearTimeoutFn
+      })
+
+      expect(firstTimer).toBeDefined()
+      expect(clearTimeoutFn).toHaveBeenCalledWith(firstTimer)
+      expect(measurableBackgroundWorktreeIds.has('wt-1')).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores missing worktree ids without creating measurable state', () => {
+    const mountedWorktreeIds = new Set<string>()
+    const measurableBackgroundWorktreeIds = new Set<string>()
+    const timers = new Map<string, number>()
+    const onRevision = vi.fn()
+
+    const added = scheduleBackgroundTerminalWorktreeMeasure({
+      mountedWorktreeIds,
+      measurableBackgroundWorktreeIds,
+      timers,
+      worktreeId: undefined,
+      onRevision,
+      setTimeoutFn: setTimeout,
+      clearTimeoutFn: clearTimeout
+    })
+
+    expect(added).toBe(false)
+    expect(mountedWorktreeIds.size).toBe(0)
+    expect(measurableBackgroundWorktreeIds.size).toBe(0)
+    expect(timers.size).toBe(0)
+    expect(onRevision).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal/background-terminal-worktree-visibility.ts
+++ b/src/renderer/src/components/terminal/background-terminal-worktree-visibility.ts
@@ -1,0 +1,44 @@
+import { addBackgroundMountedTerminalWorktree } from './background-terminal-worktree-mount'
+
+export const BACKGROUND_WORKTREE_MEASURE_WINDOW_MS = 3000
+
+type ScheduleMeasureArgs = {
+  mountedWorktreeIds: Set<string>
+  measurableBackgroundWorktreeIds: Set<string>
+  timers: Map<string, number>
+  worktreeId: string | undefined
+  onRevision: () => void
+  setTimeoutFn: typeof window.setTimeout
+  clearTimeoutFn: typeof window.clearTimeout
+}
+
+export function scheduleBackgroundTerminalWorktreeMeasure({
+  mountedWorktreeIds,
+  measurableBackgroundWorktreeIds,
+  timers,
+  worktreeId,
+  onRevision,
+  setTimeoutFn,
+  clearTimeoutFn
+}: ScheduleMeasureArgs): boolean {
+  const added = addBackgroundMountedTerminalWorktree(mountedWorktreeIds, worktreeId, onRevision)
+  if (!worktreeId) {
+    return added
+  }
+
+  measurableBackgroundWorktreeIds.add(worktreeId)
+  const existingTimer = timers.get(worktreeId)
+  if (existingTimer !== undefined) {
+    clearTimeoutFn(existingTimer)
+  }
+
+  const timer = setTimeoutFn(() => {
+    measurableBackgroundWorktreeIds.delete(worktreeId)
+    timers.delete(worktreeId)
+    onRevision()
+  }, BACKGROUND_WORKTREE_MEASURE_WINDOW_MS)
+
+  timers.set(worktreeId, timer)
+  onRevision()
+  return added
+}

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: local/runtime launch tests share a mock harness. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT } from '@/constants/terminal'
 import { createCompatibleRuntimeStatusResponseIfNeeded } from '@/runtime/runtime-compatibility-test-fixture'
 import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-client'
 
@@ -19,6 +20,7 @@ const mockSubscribeToPtyData = vi.fn()
 const mockSubscribeToPtyExit = vi.fn()
 const mockPasteDraftWhenAgentReady = vi.fn()
 const mockMarkTrusted = vi.fn()
+const mockDispatchEvent = vi.fn()
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
 function expectStablePaneSpawn(): string {
@@ -138,6 +140,7 @@ describe('launchAgentBackgroundSession', () => {
     mockSubscribeToPtyData.mockReturnValue(vi.fn())
     mockSubscribeToPtyExit.mockReturnValue(vi.fn())
     vi.stubGlobal('window', {
+      dispatchEvent: mockDispatchEvent,
       api: {
         pty: {
           spawn: mockSpawn,
@@ -171,6 +174,12 @@ describe('launchAgentBackgroundSession', () => {
       activate: false,
       recordInteraction: false
     })
+    expect(mockDispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT,
+        detail: { worktreeId: 'wt-1' }
+      })
+    )
     expect(mockSpawn).toHaveBeenCalledWith(
       expect.objectContaining({
         cwd: '/repo/worktree',

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -10,6 +10,7 @@ import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import { pasteDraftWhenAgentReady } from '@/lib/agent-paste-draft'
 import { showAutomationPromptNotSentToast } from '@/lib/agent-background-session-timeout-toast'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import { BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT } from '@/constants/terminal'
 import {
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
@@ -100,6 +101,11 @@ export async function launchAgentBackgroundSession(
 
   // Why: automation runs should start without revealing the workspace.
   // Spawn the PTY immediately, then attach an inactive tab to the live session.
+  window.dispatchEvent(
+    new CustomEvent(BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT, {
+      detail: { worktreeId }
+    })
+  )
   const tab = store.createTab(worktreeId, undefined, undefined, {
     activate: false,
     recordInteraction: false

--- a/tests/e2e/automation-hidden-terminal-first-mount.spec.ts
+++ b/tests/e2e/automation-hidden-terminal-first-mount.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getActiveWorktreeId,
+  getAllWorktreeIds,
+  switchToWorktree,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import { getTerminalContent, waitForActiveTerminalManager } from './helpers/terminal'
+import { BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT } from '../../src/renderer/src/constants/terminal'
+
+async function waitForHiddenTabPtyId(
+  page: Parameters<typeof waitForSessionReady>[0],
+  tabId: string
+): Promise<string> {
+  let ptyId: string | null = null
+  await expect
+    .poll(
+      async () => {
+        ptyId = await page.evaluate((targetTabId) => {
+          const state = window.__store?.getState()
+          if (!state) {
+            return null
+          }
+          return state.ptyIdsByTabId[targetTabId]?.[0] ?? null
+        }, tabId)
+        return ptyId
+      },
+      {
+        timeout: 20_000,
+        message: `Hidden terminal tab ${tabId} did not receive a PTY binding`
+      }
+    )
+    .not.toBeNull()
+
+  if (!ptyId) {
+    throw new Error(`waitForHiddenTabPtyId: tab ${tabId} has no PTY id`)
+  }
+  return ptyId
+}
+
+async function mainSnapshotContains(
+  page: Parameters<typeof waitForSessionReady>[0],
+  ptyId: string,
+  text: string
+): Promise<boolean> {
+  return page.evaluate(
+    async ({ targetPtyId, expectedText }) => {
+      const snapshot = await window.api.pty.getMainBufferSnapshot(targetPtyId, {
+        scrollbackRows: 200
+      })
+      return snapshot?.data.includes(expectedText) ?? false
+    },
+    { targetPtyId: ptyId, expectedText: text }
+  )
+}
+
+test.describe('Automation hidden terminal first mount', () => {
+  test('background-mounted hidden worktree replays startup output on the first visible mount', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const secondWorktreeId = (await getAllWorktreeIds(orcaPage)).find((id) => id !== firstWorktreeId)
+    test.skip(!secondWorktreeId, 'background first-mount repro needs the seeded secondary worktree')
+    if (!secondWorktreeId) {
+      return
+    }
+
+    const runId = Date.now()
+    const marker = `AUTO_FIRST_MOUNT_${runId}`
+    const hiddenTabId = await orcaPage.evaluate(
+      ({ worktreeId, marker, eventName }) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('Store unavailable')
+        }
+
+        window.dispatchEvent(
+          new CustomEvent(eventName, {
+            detail: { worktreeId }
+          })
+        )
+
+        const state = store.getState()
+        const tab = state.createTab(worktreeId, undefined, undefined, {
+          activate: false,
+          recordInteraction: false
+        })
+        state.queueTabStartupCommand(tab.id, {
+          command: `node -e "console.log('${marker}')"`,
+          telemetry: {
+            launch_source: 'automation_hidden_first_mount_e2e',
+            request_kind: 'new'
+          }
+        })
+        state.setTabCustomTitle(tab.id, 'Automation hidden shell', {
+          recordInteraction: false
+        })
+        return tab.id
+      },
+      {
+        worktreeId: secondWorktreeId,
+        marker,
+        eventName: BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT
+      }
+    )
+
+    const hiddenPtyId = await waitForHiddenTabPtyId(orcaPage, hiddenTabId)
+    await expect
+      .poll(() => mainSnapshotContains(orcaPage, hiddenPtyId, marker), {
+        timeout: 20_000,
+        message: 'Hidden automation terminal did not buffer startup output while off-screen'
+      })
+      .toBe(true)
+
+    await switchToWorktree(orcaPage, secondWorktreeId)
+    await expect
+      .poll(() => getActiveWorktreeId(orcaPage), {
+        timeout: 10_000,
+        message: 'Hidden worktree did not become active for first-mount verification'
+      })
+      .toBe(secondWorktreeId)
+
+    await orcaPage.evaluate((tabId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Store unavailable')
+      }
+      const state = store.getState()
+      state.setActiveTab(tabId)
+      state.setActiveTabType('terminal')
+    }, hiddenTabId)
+
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    await expect
+      .poll(async () => (await getTerminalContent(orcaPage)).includes(marker), {
+        timeout: 10_000,
+        message: 'First visible mount did not replay the hidden automation terminal output'
+      })
+      .toBe(true)
+  })
+})


### PR DESCRIPTION
Refs #6244

## Summary

Background-launched automation terminals now ask the renderer to background-mount the target worktree before attaching the inactive tab, so the first hidden xterm mount can measure and flush buffered PTY output instead of opening on a blank prompt.

## Screenshots

- No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused commands actually run:

```bash
/Users/openclaw/dev/AiOrchestration/Git/Contributor/work/orca-6244/node_modules/.bin/vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/launch-agent-background-session.test.ts \
  src/renderer/src/components/terminal/background-terminal-worktree-visibility.test.ts

/Users/openclaw/.nvm/versions/node/v22.22.0/bin/pnpm typecheck:web

SKIP_BUILD=1 npx playwright test tests/e2e/automation-hidden-terminal-first-mount.spec.ts \
  --config tests/playwright.config.ts \
  --project electron-headless
```

Result:

- focused vitest suite: `2 passed`, `17 passed`
- `pnpm typecheck:web`: pass
- Electron E2E: `1 passed`

Notes on broader checks:

- I did not run `pnpm lint` in this lane.
- I did not run the full `pnpm build`, but I did run `npx electron-vite build --mode e2e` successfully to exercise the Electron renderer/main bundle used by the targeted E2E proof.

## AI Review Report

I reviewed the change against the issue's first-mount blank-terminal symptom, cross-worktree mount timing, and the renderer/main handoff path.

- Main risk checked: the launch path might still create an inactive tab before the renderer had any reason to mount the hidden worktree.
- Main change: `launchAgentBackgroundSession` now dispatches `orca-background-mount-terminal-worktree` before creating the inactive tab.
- Main follow-up verification: extracted the hidden-worktree measurement window into a small helper so the timer-based behavior is directly regression-tested, then added an Electron E2E that proves a hidden background-mounted worktree replays startup output on the first visible mount.
- Cross-platform review: the change stays in renderer event dispatch and hidden mount timing only; it does not alter shortcuts, labels, path parsing, shell selection, or Electron platform branches for macOS/Linux/Windows.

## Security Audit

- Input handling: the new event carries only a `worktreeId` already owned by renderer state.
- Command execution: no new command or shell invocation path was added.
- Path handling: no filesystem path parsing changed.
- IPC/event risk: the event is renderer-local and only widens when a hidden worktree is temporarily measurable for first-fit timing; it does not expose a privileged surface or cross-origin channel.
- Follow-up: none beyond maintainer review of whether the current focused regression + E2E coverage is enough for this automation-specific path.

## Notes

- This PR keeps scope limited to the hidden automation terminal first-mount path described in `#6244`.
- The branch is isolated from the older `#5369` work so the submission diff only carries the automation-terminal fix.
- Remaining follow-up after draft PR: respond if maintainers want a more production-shaped automation-run repro than the new hidden-worktree Electron E2E.
