### PR TITLE
Add Project from a Devcontainer (docker exec, GUI source)

### DIFF
--- a/src/main/devcontainer/devcontainer-runtime.test.ts
+++ b/src/main/devcontainer/devcontainer-runtime.test.ts
@@ -9,6 +9,7 @@ import type { DockerClient, DockerInspect } from './docker-client'
 
 const KEY = '/Users/me/work/aprium'
 
+/** A `docker inspect` fixture for the test container in the given run state. */
 function inspect(running: boolean): DockerInspect {
   return {
     Id: 'cid-1',
@@ -19,6 +20,7 @@ function inspect(running: boolean): DockerInspect {
   }
 }
 
+/** A stub DockerClient resolving the test container, with optional overrides. */
 function client(overrides: Partial<DockerClient> = {}): DockerClient {
   return {
     listContainersByLabel: vi.fn(async () => [{ ID: 'cid-1', Names: 'aprium-dev' }]),

--- a/src/main/devcontainer/devcontainer-runtime.test.ts
+++ b/src/main/devcontainer/devcontainer-runtime.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// DevcontainerRuntime imports the PTY provider, which imports native node-pty
+// (no prebuilt binary here); stub it so the module graph loads under vitest.
+vi.mock('node-pty', () => ({ spawn: vi.fn() }))
+
+import { DevcontainerRuntime } from './devcontainer-runtime'
+import type { DockerClient, DockerInspect } from './docker-client'
+
+const KEY = '/Users/me/work/aprium'
+
+function inspect(running: boolean): DockerInspect {
+  return {
+    Id: 'cid-1',
+    Name: '/aprium-dev',
+    Config: { Labels: { 'devcontainer.local_folder': KEY } },
+    Mounts: [{ Type: 'bind', Source: KEY, Destination: '/workspaces/aprium' }],
+    State: { Running: running }
+  }
+}
+
+function client(overrides: Partial<DockerClient> = {}): DockerClient {
+  return {
+    listContainersByLabel: vi.fn(async () => [{ ID: 'cid-1', Names: 'aprium-dev' }]),
+    inspectContainer: vi.fn(async () => inspect(true)),
+    startContainer: vi.fn(async () => {}),
+    ...overrides
+  }
+}
+
+describe('DevcontainerRuntime.resolveContainerId', () => {
+  it('resolves the container id for the host key and caches mounts for translation', async () => {
+    const c = client()
+    const runtime = new DevcontainerRuntime({ containerKey: KEY, client: c })
+
+    expect(await runtime.resolveContainerId()).toBe('cid-1')
+    // includes stopped containers so a stopped devcontainer can be started
+    expect(c.listContainersByLabel).toHaveBeenCalledWith('devcontainer.local_folder', { all: true })
+    // mounts now populated → cwd translation works
+    expect(runtime.hostToContainerCwd(`${KEY}/.worktrees/feat`)).toBe(
+      '/workspaces/aprium/.worktrees/feat'
+    )
+  })
+
+  it('starts the container when it is stopped', async () => {
+    const startContainer = vi.fn(async () => {})
+    const runtime = new DevcontainerRuntime({
+      containerKey: KEY,
+      client: client({ inspectContainer: vi.fn(async () => inspect(false)), startContainer })
+    })
+    await runtime.resolveContainerId()
+    expect(startContainer).toHaveBeenCalledWith('cid-1')
+  })
+
+  it('does not start an already-running container', async () => {
+    const startContainer = vi.fn(async () => {})
+    const runtime = new DevcontainerRuntime({
+      containerKey: KEY,
+      client: client({ startContainer })
+    })
+    await runtime.resolveContainerId()
+    expect(startContainer).not.toHaveBeenCalled()
+  })
+
+  it('throws when no devcontainer matches the key', async () => {
+    const runtime = new DevcontainerRuntime({
+      containerKey: '/Users/me/work/missing',
+      client: client()
+    })
+    await expect(runtime.resolveContainerId()).rejects.toThrow(/No devcontainer found/)
+  })
+
+  it('createPtyProvider wires resolution + translation end to end', async () => {
+    const fake = {
+      pid: 1,
+      process: 'docker',
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn()
+    }
+    const ptySpawn = vi.fn(() => fake as never)
+    const runtime = new DevcontainerRuntime({
+      containerKey: KEY,
+      client: client(),
+      resolveSpawnEnv: () => ({ ANTHROPIC_API_KEY: 'secret' }),
+      ptySpawn
+    })
+    const provider = runtime.createPtyProvider()
+    await provider.spawn({ cols: 80, rows: 24, cwd: `${KEY}/.worktrees/feat` })
+
+    const [, args] = ptySpawn.mock.calls[0] as unknown as [string, string[]]
+    expect(args).toContain('cid-1')
+    expect(args).toContain('/workspaces/aprium/.worktrees/feat')
+    expect(args).toContain('ANTHROPIC_API_KEY')
+  })
+})

--- a/src/main/devcontainer/devcontainer-runtime.ts
+++ b/src/main/devcontainer/devcontainer-runtime.ts
@@ -1,0 +1,74 @@
+/**
+ * Runtime glue binding a devcontainer execution host to a {@link DockerPtyProvider}.
+ *
+ * A host is keyed by its stable `devcontainer.local_folder` (not a container id,
+ * which changes on recreate). On each spawn the runtime re-resolves the current
+ * container for that key, starts it if stopped, and remembers its mount table so
+ * worktree paths can be host→container translated for `docker exec -w`.
+ */
+import { DockerPtyProvider, type DockerPtyProviderConfig } from './docker-pty-provider'
+import { dockerCli, type DockerClient } from './docker-client'
+import { listDevcontainers } from './discovery'
+import { hostToContainer, type ContainerMount } from './path-map'
+
+/**
+ * Env var NAMES forwarded into the container (values via the spawn env, never
+ * argv) so in-container agents can authenticate with the user's keys.
+ */
+export const DEFAULT_DEVCONTAINER_FORWARD_ENV: readonly string[] = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY'
+]
+
+export type DevcontainerRuntimeConfig = {
+  /** Stable host key — the devcontainer's `devcontainer.local_folder`. */
+  containerKey: string
+  client?: DockerClient
+  shell?: string
+  forwardEnv?: readonly string[]
+  resolveSpawnEnv?: () => Record<string, string>
+  ptySpawn?: DockerPtyProviderConfig['ptySpawn']
+}
+
+export class DevcontainerRuntime {
+  private mounts: ContainerMount[] = []
+  private readonly client: DockerClient
+
+  constructor(private readonly config: DevcontainerRuntimeConfig) {
+    this.client = config.client ?? dockerCli
+  }
+
+  /**
+   * Resolve the current container id for this host (running or stopped), start
+   * it if needed, and cache its mounts. Throws if no devcontainer matches the
+   * key (e.g. the project's devcontainer was removed).
+   */
+  resolveContainerId = async (): Promise<string> => {
+    const infos = await listDevcontainers(this.client, { all: true })
+    const info = infos.find((entry) => entry.hostFolder === this.config.containerKey)
+    if (!info) {
+      throw new Error(`No devcontainer found for "${this.config.containerKey}"`)
+    }
+    this.mounts = info.mounts
+    if (!info.running) {
+      await this.client.startContainer(info.containerId)
+    }
+    return info.containerId
+  }
+
+  /** Translate a host worktree path to its in-container path using the last-resolved mounts. */
+  hostToContainerCwd = (hostPath: string): string | null => hostToContainer(hostPath, this.mounts)
+
+  /** Build a PTY provider bound to this runtime. */
+  createPtyProvider(): DockerPtyProvider {
+    return new DockerPtyProvider({
+      resolveContainerId: this.resolveContainerId,
+      hostToContainerCwd: this.hostToContainerCwd,
+      forwardEnv: this.config.forwardEnv ?? DEFAULT_DEVCONTAINER_FORWARD_ENV,
+      ...(this.config.shell ? { shell: this.config.shell } : {}),
+      ...(this.config.resolveSpawnEnv ? { resolveSpawnEnv: this.config.resolveSpawnEnv } : {}),
+      ...(this.config.ptySpawn ? { ptySpawn: this.config.ptySpawn } : {})
+    })
+  }
+}

--- a/src/main/devcontainer/discovery.test.ts
+++ b/src/main/devcontainer/discovery.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { listDevcontainers, parseDevcontainer } from './discovery'
+import type { DockerClient, DockerInspect, DockerPsEntry } from './docker-client'
+
+function inspectFixture(overrides: Partial<DockerInspect> = {}): DockerInspect {
+  return {
+    Id: 'abc123',
+    Name: '/cranky_swartz',
+    Config: {
+      Labels: {
+        'devcontainer.local_folder': '/Users/me/work/aprium',
+        'devcontainer.config_file': '/Users/me/work/aprium/.devcontainer/devcontainer.json'
+      }
+    },
+    Mounts: [
+      { Type: 'bind', Source: '/Users/me/work/aprium', Destination: '/workspaces/aprium' },
+      { Type: 'volume', Source: '/var/lib/docker/volumes/x/_data', Destination: '/cache' }
+    ],
+    State: { Running: true },
+    ...overrides
+  }
+}
+
+describe('parseDevcontainer', () => {
+  it('extracts id, name, host folder, config file, and mounts', () => {
+    expect(parseDevcontainer(inspectFixture())).toEqual({
+      containerId: 'abc123',
+      name: 'cranky_swartz',
+      hostFolder: '/Users/me/work/aprium',
+      configFile: '/Users/me/work/aprium/.devcontainer/devcontainer.json',
+      running: true,
+      mounts: [
+        { source: '/Users/me/work/aprium', destination: '/workspaces/aprium' },
+        { source: '/var/lib/docker/volumes/x/_data', destination: '/cache' }
+      ]
+    })
+  })
+
+  it('returns null when the devcontainer label is absent', () => {
+    expect(parseDevcontainer(inspectFixture({ Config: { Labels: { foo: 'bar' } } }))).toBeNull()
+    expect(parseDevcontainer(inspectFixture({ Config: { Labels: null } }))).toBeNull()
+    expect(parseDevcontainer(inspectFixture({ Config: undefined }))).toBeNull()
+  })
+
+  it('defaults configFile to null and tolerates missing/partial mounts', () => {
+    const info = parseDevcontainer(
+      inspectFixture({
+        Config: { Labels: { 'devcontainer.local_folder': '/Users/me/work/lac' } },
+        Mounts: [
+          { Type: 'bind', Source: '/Users/me/work/lac', Destination: '/workspaces/lac' },
+          { Type: 'bind', Source: '', Destination: '/skip' },
+          { Type: 'tmpfs', Destination: '/tmp' }
+        ]
+      })
+    )
+    expect(info?.configFile).toBeNull()
+    expect(info?.mounts).toEqual([{ source: '/Users/me/work/lac', destination: '/workspaces/lac' }])
+  })
+})
+
+describe('listDevcontainers', () => {
+  function stubClient(overrides: Partial<DockerClient> = {}): DockerClient {
+    return {
+      listContainersByLabel: vi.fn(async () => [] as DockerPsEntry[]),
+      inspectContainer: vi.fn(async () => null),
+      startContainer: vi.fn(async () => {}),
+      ...overrides
+    }
+  }
+
+  it('queries by the devcontainer label and returns parsed infos', async () => {
+    const listContainersByLabel = vi.fn(async () => [{ ID: 'abc123', Names: 'cranky_swartz' }])
+    const inspectContainer = vi.fn(async () => inspectFixture())
+    const result = await listDevcontainers(stubClient({ listContainersByLabel, inspectContainer }))
+
+    expect(listContainersByLabel).toHaveBeenCalledWith('devcontainer.local_folder', {})
+    expect(inspectContainer).toHaveBeenCalledWith('abc123')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.hostFolder).toBe('/Users/me/work/aprium')
+  })
+
+  it('skips containers that vanished or fail inspection', async () => {
+    const inspectContainer = vi
+      .fn()
+      .mockResolvedValueOnce(null) // removed mid-discovery
+      .mockRejectedValueOnce(new Error('inspect failed')) // transient docker error
+      .mockResolvedValueOnce(inspectFixture())
+    const result = await listDevcontainers(
+      stubClient({
+        listContainersByLabel: vi.fn(async () => [
+          { ID: 'gone', Names: 'gone' },
+          { ID: 'broken', Names: 'broken' },
+          { ID: 'abc123', Names: 'ok' }
+        ]),
+        inspectContainer
+      })
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.containerId).toBe('abc123')
+  })
+})

--- a/src/main/devcontainer/discovery.test.ts
+++ b/src/main/devcontainer/discovery.test.ts
@@ -22,6 +22,12 @@ function inspectFixture(overrides: Partial<DockerInspect> = {}): DockerInspect {
   }
 }
 
+function unmountedInspectFixture(): DockerInspect {
+  return inspectFixture({
+    Mounts: [{ Type: 'bind', Source: '/Users/me/work/other', Destination: '/workspaces/other' }]
+  })
+}
+
 describe('parseDevcontainer', () => {
   it('extracts id, name, host folder, config file, and mounts', () => {
     expect(parseDevcontainer(inspectFixture())).toEqual({
@@ -41,6 +47,10 @@ describe('parseDevcontainer', () => {
     expect(parseDevcontainer(inspectFixture({ Config: { Labels: { foo: 'bar' } } }))).toBeNull()
     expect(parseDevcontainer(inspectFixture({ Config: { Labels: null } }))).toBeNull()
     expect(parseDevcontainer(inspectFixture({ Config: undefined }))).toBeNull()
+  })
+
+  it('returns null when the labeled host folder is not covered by a mount', () => {
+    expect(parseDevcontainer(unmountedInspectFixture())).toBeNull()
   })
 
   it('defaults configFile to null and tolerates missing/partial mounts', () => {
@@ -70,11 +80,17 @@ describe('listDevcontainers', () => {
   }
 
   it('queries by the devcontainer label and returns parsed infos', async () => {
-    const listContainersByLabel = vi.fn(async () => [{ ID: 'abc123', Names: 'cranky_swartz' }])
-    const inspectContainer = vi.fn(async () => inspectFixture())
+    const listContainersByLabel = vi.fn(async () => [
+      { ID: 'unsupported', Names: 'unsupported' },
+      { ID: 'abc123', Names: 'cranky_swartz' }
+    ])
+    const inspectContainer = vi.fn(async (id: string) =>
+      id === 'unsupported' ? unmountedInspectFixture() : inspectFixture()
+    )
     const result = await listDevcontainers(stubClient({ listContainersByLabel, inspectContainer }))
 
     expect(listContainersByLabel).toHaveBeenCalledWith('devcontainer.local_folder', {})
+    expect(inspectContainer).toHaveBeenCalledWith('unsupported')
     expect(inspectContainer).toHaveBeenCalledWith('abc123')
     expect(result).toHaveLength(1)
     expect(result[0]?.hostFolder).toBe('/Users/me/work/aprium')

--- a/src/main/devcontainer/discovery.test.ts
+++ b/src/main/devcontainer/discovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { listDevcontainers, parseDevcontainer } from './discovery'
 import type { DockerClient, DockerInspect, DockerPsEntry } from './docker-client'
 
+/** Build a `docker inspect` fixture for a devcontainer, with optional overrides. */
 function inspectFixture(overrides: Partial<DockerInspect> = {}): DockerInspect {
   return {
     Id: 'abc123',

--- a/src/main/devcontainer/discovery.ts
+++ b/src/main/devcontainer/discovery.ts
@@ -1,0 +1,74 @@
+/**
+ * Devcontainer discovery.
+ *
+ * Finds running devcontainers and extracts the data the devcontainer execution
+ * host needs: a stable key, display name, the host workspace folder (the bind
+ * mount Orca manages git/files on), and the full mount table (for host↔container
+ * path translation). A devcontainer is any container carrying the standard
+ * `devcontainer.local_folder` label set by the Dev Containers tooling.
+ */
+import { dockerCli, type DockerClient, type DockerInspect } from './docker-client'
+import type { ContainerMount, DevcontainerInfo } from '../../shared/devcontainer-types'
+
+export type { DevcontainerInfo }
+
+/** Label the Dev Containers spec/tooling sets to the host workspace folder. */
+export const DEVCONTAINER_LOCAL_FOLDER_LABEL = 'devcontainer.local_folder'
+/** Label pointing at the devcontainer.json used (optional, informational). */
+export const DEVCONTAINER_CONFIG_FILE_LABEL = 'devcontainer.config_file'
+
+/**
+ * Build a {@link DevcontainerInfo} from a `docker inspect` result, or null when
+ * the container is not a devcontainer (missing `devcontainer.local_folder`).
+ * Pure — unit-tested without Docker.
+ */
+export function parseDevcontainer(inspect: DockerInspect): DevcontainerInfo | null {
+  const labels = inspect.Config?.Labels ?? {}
+  const hostFolder = labels[DEVCONTAINER_LOCAL_FOLDER_LABEL]
+  if (!hostFolder) {
+    return null
+  }
+  const mounts: ContainerMount[] = (inspect.Mounts ?? [])
+    .filter(
+      (mount): mount is { Source: string; Destination: string } =>
+        typeof mount.Source === 'string' &&
+        mount.Source.length > 0 &&
+        typeof mount.Destination === 'string' &&
+        mount.Destination.length > 0
+    )
+    .map((mount) => ({ source: mount.Source, destination: mount.Destination }))
+
+  return {
+    containerId: inspect.Id,
+    // Why strip the slash: docker reports `/cranky_swartz`; the leading slash is
+    // a docker artifact, not part of the name users or `docker exec` need.
+    name: (inspect.Name ?? '').replace(/^\//, ''),
+    hostFolder,
+    configFile: labels[DEVCONTAINER_CONFIG_FILE_LABEL] ?? null,
+    running: inspect.State?.Running ?? false,
+    mounts
+  }
+}
+
+/**
+ * List running devcontainers. Resolves each candidate via `docker inspect`
+ * (labels alone don't carry the mount table). Containers that disappear between
+ * listing and inspecting, or that fail to parse, are skipped rather than fatal.
+ */
+export async function listDevcontainers(
+  client: DockerClient = dockerCli,
+  opts: { all?: boolean } = {}
+): Promise<DevcontainerInfo[]> {
+  const entries = await client.listContainersByLabel(DEVCONTAINER_LOCAL_FOLDER_LABEL, opts)
+  const inspected = await Promise.all(
+    entries.map(async (entry) => {
+      try {
+        const inspect = await client.inspectContainer(entry.ID)
+        return inspect ? parseDevcontainer(inspect) : null
+      } catch {
+        return null
+      }
+    })
+  )
+  return inspected.filter((info): info is DevcontainerInfo => info !== null)
+}

--- a/src/main/devcontainer/discovery.ts
+++ b/src/main/devcontainer/discovery.ts
@@ -8,6 +8,7 @@
  * `devcontainer.local_folder` label set by the Dev Containers tooling.
  */
 import { dockerCli, type DockerClient, type DockerInspect } from './docker-client'
+import { hostToContainer } from './path-map'
 import type { ContainerMount, DevcontainerInfo } from '../../shared/devcontainer-types'
 
 export type { DevcontainerInfo }
@@ -37,6 +38,14 @@ export function parseDevcontainer(inspect: DockerInspect): DevcontainerInfo | nu
         mount.Destination.length > 0
     )
     .map((mount) => ({ source: mount.Source, destination: mount.Destination }))
+
+  // Why: PTY cwd translation needs a host mount that docker can actually route
+  // into the container. If the labeled host folder is not covered by any mount,
+  // skip this container instead of letting the devcontainer PTY fall back to a
+  // misleading repo-root cwd.
+  if (!hostToContainer(hostFolder, mounts)) {
+    return null
+  }
 
   return {
     containerId: inspect.Id,

--- a/src/main/devcontainer/docker-client.ts
+++ b/src/main/devcontainer/docker-client.ts
@@ -1,0 +1,97 @@
+/**
+ * Minimal Docker CLI client for devcontainer discovery.
+ *
+ * Talks to the local Docker daemon (OrbStack provides the standard `docker`
+ * binary + socket) by shelling out to the CLI via the repo's cross-platform
+ * `commandExecFileAsync` runner — no new dependency, same pattern Orca uses for
+ * git. Only the read-only operations discovery needs are exposed.
+ */
+import { commandExecFileAsync } from '../git/runner'
+
+/** Default wall-clock budget for a single docker invocation. */
+const DOCKER_TIMEOUT_MS = 10_000
+/** `docker inspect` of a large container can exceed Node's 1 MB exec default. */
+const DOCKER_MAX_BUFFER = 16 * 1024 * 1024
+
+/** One row of `docker ps --format '{{json .}}'` (subset of fields we use). */
+export type DockerPsEntry = {
+  ID: string
+  Names: string
+  Image?: string
+  State?: string
+  Status?: string
+  Labels?: string
+}
+
+/** One mount from `docker inspect` `.Mounts[]` (subset). */
+export type DockerInspectMount = {
+  Type?: string
+  Source?: string
+  Destination?: string
+}
+
+/** Subset of a single `docker inspect <id>` array element. */
+export type DockerInspect = {
+  Id: string
+  Name?: string
+  Config?: { Labels?: Record<string, string> | null }
+  Mounts?: DockerInspectMount[]
+  State?: { Running?: boolean }
+}
+
+/** Docker surface discovery + runtime depend on. Injectable so callers/tests can stub it. */
+export type DockerClient = {
+  /** List containers carrying `label`. By default running only; `all` includes stopped. */
+  listContainersByLabel(label: string, opts?: { all?: boolean }): Promise<DockerPsEntry[]>
+  inspectContainer(id: string): Promise<DockerInspect | null>
+  /** Start a stopped container (no-op if already running). */
+  startContainer(id: string): Promise<void>
+}
+
+async function runDocker(args: string[]): Promise<string> {
+  const { stdout } = await commandExecFileAsync('docker', args, {
+    timeout: DOCKER_TIMEOUT_MS,
+    maxBuffer: DOCKER_MAX_BUFFER
+  })
+  return stdout
+}
+
+/**
+ * List running containers carrying `label`. `docker ps --format '{{json .}}'`
+ * emits one JSON object per line (NDJSON), not a JSON array, so parse per line.
+ */
+async function listContainersByLabel(
+  label: string,
+  opts: { all?: boolean } = {}
+): Promise<DockerPsEntry[]> {
+  const args = ['ps']
+  if (opts.all) {
+    args.push('-a')
+  }
+  args.push('--filter', `label=${label}`, '--format', '{{json .}}')
+  const stdout = await runDocker(args)
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as DockerPsEntry)
+}
+
+async function inspectContainer(id: string): Promise<DockerInspect | null> {
+  const stdout = await runDocker(['inspect', id])
+  const parsed = JSON.parse(stdout) as DockerInspect[]
+  // Why nullable: `docker inspect` returns `[]` for an id that vanished between
+  // listing and inspecting (container removed mid-discovery).
+  return parsed[0] ?? null
+}
+
+async function startContainer(id: string): Promise<void> {
+  await runDocker(['start', id])
+}
+
+/** Default client backed by the local `docker` CLI. */
+export const dockerCli: DockerClient = {
+  listContainersByLabel,
+  inspectContainer,
+  startContainer
+}

--- a/src/main/devcontainer/docker-client.ts
+++ b/src/main/devcontainer/docker-client.ts
@@ -48,6 +48,7 @@ export type DockerClient = {
   startContainer(id: string): Promise<void>
 }
 
+/** Run a `docker` CLI subcommand and return its stdout. */
 async function runDocker(args: string[]): Promise<string> {
   const { stdout } = await commandExecFileAsync('docker', args, {
     timeout: DOCKER_TIMEOUT_MS,
@@ -77,6 +78,7 @@ async function listContainersByLabel(
     .map((line) => JSON.parse(line) as DockerPsEntry)
 }
 
+/** Inspect a single container by id; null if it no longer exists. */
 async function inspectContainer(id: string): Promise<DockerInspect | null> {
   const stdout = await runDocker(['inspect', id])
   const parsed = JSON.parse(stdout) as DockerInspect[]
@@ -85,6 +87,7 @@ async function inspectContainer(id: string): Promise<DockerInspect | null> {
   return parsed[0] ?? null
 }
 
+/** Start a (possibly stopped) container by id. */
 async function startContainer(id: string): Promise<void> {
   await runDocker(['start', id])
 }

--- a/src/main/devcontainer/docker-exec-command.test.ts
+++ b/src/main/devcontainer/docker-exec-command.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { buildDockerExecArgs } from './docker-exec-command'
+
+describe('buildDockerExecArgs', () => {
+  it('builds an interactive exec with cwd and shell by default', () => {
+    expect(
+      buildDockerExecArgs({
+        containerId: 'abc123',
+        shell: '/bin/bash',
+        containerCwd: '/workspaces/aprium/.worktrees/feat'
+      })
+    ).toEqual([
+      'exec',
+      '-i',
+      '-t',
+      '-w',
+      '/workspaces/aprium/.worktrees/feat',
+      'abc123',
+      '/bin/bash'
+    ])
+  })
+
+  it('omits the -w flag when no cwd is given', () => {
+    expect(buildDockerExecArgs({ containerId: 'c', shell: 'sh', containerCwd: null })).toEqual([
+      'exec',
+      '-i',
+      '-t',
+      'c',
+      'sh'
+    ])
+  })
+
+  it('can disable the interactive TTY', () => {
+    expect(buildDockerExecArgs({ containerId: 'c', shell: 'sh', interactive: false })).toEqual([
+      'exec',
+      'c',
+      'sh'
+    ])
+  })
+
+  it('forwards env by NAME only (never leaks secret values into argv)', () => {
+    const args = buildDockerExecArgs({
+      containerId: 'c',
+      shell: 'bash',
+      forwardEnv: ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY']
+    })
+    expect(args).toEqual([
+      'exec',
+      '-i',
+      '-t',
+      '-e',
+      'ANTHROPIC_API_KEY',
+      '-e',
+      'OPENAI_API_KEY',
+      'c',
+      'bash'
+    ])
+    // The secret value must not appear anywhere in argv.
+    expect(args.join(' ')).not.toContain('=')
+  })
+
+  it('emits literal env as NAME=VALUE for non-secret values', () => {
+    expect(
+      buildDockerExecArgs({
+        containerId: 'c',
+        shell: 'bash',
+        interactive: false,
+        literalEnv: { TERM: 'xterm-256color' }
+      })
+    ).toEqual(['exec', '-e', 'TERM=xterm-256color', 'c', 'bash'])
+  })
+
+  it('orders flags before the container id and shell', () => {
+    const args = buildDockerExecArgs({
+      containerId: 'mycontainer',
+      shell: '/bin/zsh',
+      containerCwd: '/workspaces/x',
+      forwardEnv: ['PATH_EXTRA'],
+      literalEnv: { TERM: 'xterm' }
+    })
+    expect(args.at(-2)).toBe('mycontainer')
+    expect(args.at(-1)).toBe('/bin/zsh')
+    expect(args.indexOf('mycontainer')).toBeGreaterThan(args.indexOf('-w'))
+  })
+})

--- a/src/main/devcontainer/docker-exec-command.ts
+++ b/src/main/devcontainer/docker-exec-command.ts
@@ -1,0 +1,49 @@
+/**
+ * Builds the `docker exec` argv used to run a shell/agent inside a devcontainer.
+ *
+ * Security note on env: secret values (API keys, tokens) must NOT appear in the
+ * argv — process arguments are world-readable via `ps`. So this builder emits
+ * `-e NAME` (no value); docker forwards each NAME from the *docker client's own
+ * environment*, which the PTY provider sets on the spawned process. Values that
+ * genuinely need a literal (rare, non-secret) can go through `literalEnv`.
+ */
+
+export type BuildDockerExecArgsParams = {
+  /** Target container id or name. */
+  containerId: string
+  /** Shell to launch (absolute path or bare name resolvable in the container). */
+  shell: string
+  /** Working directory *inside the container* (already host→container translated). */
+  containerCwd?: string | null
+  /** Allocate an interactive TTY (`-i -t`). Default true. */
+  interactive?: boolean
+  /** Variable NAMES to forward from the docker client env via `-e NAME` (no value in argv). */
+  forwardEnv?: readonly string[]
+  /** Literal, non-secret env entries emitted as `-e NAME=VALUE`. */
+  literalEnv?: Readonly<Record<string, string>>
+}
+
+/** Construct the argv (after the `docker` binary) for `docker exec`. */
+export function buildDockerExecArgs(params: BuildDockerExecArgsParams): string[] {
+  const { containerId, shell, containerCwd, forwardEnv = [], literalEnv = {} } = params
+  const interactive = params.interactive ?? true
+
+  const args = ['exec']
+  if (interactive) {
+    args.push('-i', '-t')
+  }
+  if (containerCwd) {
+    args.push('-w', containerCwd)
+  }
+  // `-e NAME` forwards the value from the client env without exposing it in argv.
+  for (const name of forwardEnv) {
+    args.push('-e', name)
+  }
+  for (const [name, value] of Object.entries(literalEnv)) {
+    args.push('-e', `${name}=${value}`)
+  }
+  // `--` would be ideal before the command, but `docker exec` treats the first
+  // non-flag token as the container id, so options must end here naturally.
+  args.push(containerId, shell)
+  return args
+}

--- a/src/main/devcontainer/docker-pty-provider.test.ts
+++ b/src/main/devcontainer/docker-pty-provider.test.ts
@@ -62,7 +62,7 @@ describe('DockerPtyProvider.spawn', () => {
       cols: 120,
       rows: 30,
       cwd: '/Users/me/work/aprium/.worktrees/feat',
-      env: { TERM: 'xterm-kitty' }
+      env: { TERM: 'xterm-kitty', ANTHROPIC_API_KEY: 'from-spawn-env', PATH: '/opt/bin' }
     })
 
     expect(result.pid).toBe(4242)
@@ -88,8 +88,9 @@ describe('DockerPtyProvider.spawn', () => {
       'bash'
     ])
     // Secret value travels via the spawn env, not the argv.
-    expect(options.env.ANTHROPIC_API_KEY).toBe('secret')
-    expect(args.join(' ')).not.toContain('secret')
+    expect(options.env.ANTHROPIC_API_KEY).toBe('from-spawn-env')
+    expect(options.env.PATH).toBe('/opt/bin')
+    expect(args.join(' ')).not.toContain('from-spawn-env')
   })
 
   it('routes onData and cleans up on exit', async () => {

--- a/src/main/devcontainer/docker-pty-provider.test.ts
+++ b/src/main/devcontainer/docker-pty-provider.test.ts
@@ -58,39 +58,65 @@ function setup(overrides: Partial<DockerPtyProviderConfig> = {}) {
 describe('DockerPtyProvider.spawn', () => {
   it('spawns docker exec with translated cwd, forwarded env, and TERM', async () => {
     const { provider, ptySpawn } = setup()
-    const result = await provider.spawn({
-      cols: 120,
-      rows: 30,
-      cwd: '/Users/me/work/aprium/.worktrees/feat',
-      env: { TERM: 'xterm-kitty', ANTHROPIC_API_KEY: 'from-spawn-env', PATH: '/opt/bin' }
+    const originalAnthropic = process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY = 'ambient-secret'
+    try {
+      const result = await provider.spawn({
+        cols: 120,
+        rows: 30,
+        cwd: '/Users/me/work/aprium/.worktrees/feat',
+        env: { TERM: 'xterm-kitty', ANTHROPIC_API_KEY: 'from-spawn-env', PATH: '/opt/bin' }
+      })
+
+      expect(result.pid).toBe(4242)
+      expect(result.id).toMatch(/^dpty-\d+$/)
+
+      const [file, args, options] = ptySpawn.mock.calls[0] as unknown as [
+        string,
+        string[],
+        { env: Record<string, string>; cols: number }
+      ]
+      expect(file).toBe('docker')
+      expect(args).toEqual([
+        'exec',
+        '-i',
+        '-t',
+        '-w',
+        '/workspaces/aprium/.worktrees/feat',
+        '-e',
+        'ANTHROPIC_API_KEY',
+        '-e',
+        'TERM=xterm-kitty',
+        'container-xyz',
+        'bash'
+      ])
+      // Secret value travels via the spawn env, not the argv.
+      expect(options.env.ANTHROPIC_API_KEY).toBe('from-spawn-env')
+      expect(options.env.PATH).toBe('/opt/bin')
+      expect(args.join(' ')).not.toContain('from-spawn-env')
+      expect(args.join(' ')).not.toContain('ambient-secret')
+    } finally {
+      if (originalAnthropic !== undefined) {
+        process.env.ANTHROPIC_API_KEY = originalAnthropic
+      } else {
+        delete process.env.ANTHROPIC_API_KEY
+      }
+    }
+  })
+
+  it('uses the configured spawn env resolver when opts.env is omitted', async () => {
+    const { provider, ptySpawn } = setup({
+      resolveSpawnEnv: () => ({ TERM: 'xterm-256color', ANTHROPIC_API_KEY: 'resolved-secret' })
     })
 
-    expect(result.pid).toBe(4242)
-    expect(result.id).toMatch(/^dpty-\d+$/)
+    await provider.spawn({ cols: 80, rows: 24, cwd: '/Users/me/work/aprium' })
 
-    const [file, args, options] = ptySpawn.mock.calls[0] as unknown as [
+    const [, , options] = ptySpawn.mock.calls[0] as unknown as [
       string,
       string[],
-      { env: Record<string, string>; cols: number }
+      { env: Record<string, string> }
     ]
-    expect(file).toBe('docker')
-    expect(args).toEqual([
-      'exec',
-      '-i',
-      '-t',
-      '-w',
-      '/workspaces/aprium/.worktrees/feat',
-      '-e',
-      'ANTHROPIC_API_KEY',
-      '-e',
-      'TERM=xterm-kitty',
-      'container-xyz',
-      'bash'
-    ])
-    // Secret value travels via the spawn env, not the argv.
-    expect(options.env.ANTHROPIC_API_KEY).toBe('from-spawn-env')
-    expect(options.env.PATH).toBe('/opt/bin')
-    expect(args.join(' ')).not.toContain('from-spawn-env')
+    expect(options.env.ANTHROPIC_API_KEY).toBe('resolved-secret')
   })
 
   it('routes onData and cleans up on exit', async () => {

--- a/src/main/devcontainer/docker-pty-provider.test.ts
+++ b/src/main/devcontainer/docker-pty-provider.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// node-pty ships a native binary that isn't built in this environment; the
+// provider only needs the type at runtime via an injected spawn, so stub it.
+vi.mock('node-pty', () => ({ spawn: vi.fn() }))
+
+import { DockerPtyProvider, type DockerPtyProviderConfig } from './docker-pty-provider'
+
+type FakePty = {
+  pid: number
+  process: string
+  write: ReturnType<typeof vi.fn>
+  resize: ReturnType<typeof vi.fn>
+  kill: ReturnType<typeof vi.fn>
+  onData: (cb: (data: string) => void) => void
+  onExit: (cb: (e: { exitCode: number }) => void) => void
+  emitData: (data: string) => void
+  emitExit: (code: number) => void
+}
+
+function makeFakePty(): FakePty {
+  let dataCb: ((data: string) => void) | null = null
+  let exitCb: ((e: { exitCode: number }) => void) | null = null
+  return {
+    pid: 4242,
+    process: 'docker',
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData: (cb) => {
+      dataCb = cb
+    },
+    onExit: (cb) => {
+      exitCb = cb
+    },
+    emitData: (data) => dataCb?.(data),
+    emitExit: (code) => exitCb?.({ exitCode: code })
+  }
+}
+
+function setup(overrides: Partial<DockerPtyProviderConfig> = {}) {
+  const fake = makeFakePty()
+  const ptySpawn = vi.fn(() => fake as never)
+  const provider = new DockerPtyProvider({
+    resolveContainerId: async () => 'container-xyz',
+    hostToContainerCwd: (hostPath) =>
+      hostPath.replace('/Users/me/work/aprium', '/workspaces/aprium'),
+    forwardEnv: ['ANTHROPIC_API_KEY'],
+    resolveSpawnEnv: () => ({ ANTHROPIC_API_KEY: 'secret', PATH: '/usr/bin' }),
+    ptySpawn,
+    ...overrides
+  })
+  return { provider, ptySpawn, fake }
+}
+
+describe('DockerPtyProvider.spawn', () => {
+  it('spawns docker exec with translated cwd, forwarded env, and TERM', async () => {
+    const { provider, ptySpawn } = setup()
+    const result = await provider.spawn({
+      cols: 120,
+      rows: 30,
+      cwd: '/Users/me/work/aprium/.worktrees/feat',
+      env: { TERM: 'xterm-kitty' }
+    })
+
+    expect(result.pid).toBe(4242)
+    expect(result.id).toMatch(/^dpty-\d+$/)
+
+    const [file, args, options] = ptySpawn.mock.calls[0] as unknown as [
+      string,
+      string[],
+      { env: Record<string, string>; cols: number }
+    ]
+    expect(file).toBe('docker')
+    expect(args).toEqual([
+      'exec',
+      '-i',
+      '-t',
+      '-w',
+      '/workspaces/aprium/.worktrees/feat',
+      '-e',
+      'ANTHROPIC_API_KEY',
+      '-e',
+      'TERM=xterm-kitty',
+      'container-xyz',
+      'bash'
+    ])
+    // Secret value travels via the spawn env, not the argv.
+    expect(options.env.ANTHROPIC_API_KEY).toBe('secret')
+    expect(args.join(' ')).not.toContain('secret')
+  })
+
+  it('routes onData and cleans up on exit', async () => {
+    const { provider, fake } = setup()
+    const data = vi.fn()
+    const exit = vi.fn()
+    provider.onData(data)
+    provider.onExit(exit)
+
+    const { id } = await provider.spawn({ cols: 80, rows: 24, cwd: '/Users/me/work/aprium' })
+    expect(provider.hasPty(id)).toBe(true)
+
+    fake.emitData('hello')
+    expect(data).toHaveBeenCalledWith({ id, data: 'hello' })
+
+    fake.emitExit(0)
+    expect(exit).toHaveBeenCalledWith({ id, code: 0 })
+    expect(provider.hasPty(id)).toBe(false)
+  })
+
+  it('forwards write/resize/kill to the underlying pty', async () => {
+    const { provider, fake } = setup()
+    const { id } = await provider.spawn({ cols: 80, rows: 24 })
+    provider.write(id, 'ls\n')
+    provider.resize(id, 100, 40)
+    await provider.shutdown(id, {})
+    expect(fake.write).toHaveBeenCalledWith('ls\n')
+    expect(fake.resize).toHaveBeenCalledWith(100, 40)
+    expect(fake.kill).toHaveBeenCalled()
+  })
+})

--- a/src/main/devcontainer/docker-pty-provider.test.ts
+++ b/src/main/devcontainer/docker-pty-provider.test.ts
@@ -18,6 +18,7 @@ type FakePty = {
   emitExit: (code: number) => void
 }
 
+/** A fake node-pty handle whose data/exit events can be driven from tests. */
 function makeFakePty(): FakePty {
   let dataCb: ((data: string) => void) | null = null
   let exitCb: ((e: { exitCode: number }) => void) | null = null
@@ -38,6 +39,7 @@ function makeFakePty(): FakePty {
   }
 }
 
+/** Construct a provider wired to a fake spawn + stub config for assertions. */
 function setup(overrides: Partial<DockerPtyProviderConfig> = {}) {
   const fake = makeFakePty()
   const ptySpawn = vi.fn(() => fake as never)

--- a/src/main/devcontainer/docker-pty-provider.ts
+++ b/src/main/devcontainer/docker-pty-provider.ts
@@ -77,8 +77,10 @@ export class DockerPtyProvider implements IPtyProvider {
     // Why: pty.ts already assembles the canonical host spawn env (including
     // deletions and provider shims). Prefer the IPC-passed env so docker exec
     // inherits the same values instead of ambient process.env.
-    const env =
-      opts.env ?? this.config.resolveSpawnEnv?.() ?? (process.env as Record<string, string>)
+    const env = opts.env ?? this.config.resolveSpawnEnv?.()
+    if (!env) {
+      throw new Error('Missing spawn environment for devcontainer PTY')
+    }
     const proc = spawnFn('docker', args, {
       name: term,
       cols: opts.cols,

--- a/src/main/devcontainer/docker-pty-provider.ts
+++ b/src/main/devcontainer/docker-pty-provider.ts
@@ -56,6 +56,7 @@ export class DockerPtyProvider implements IPtyProvider {
 
   constructor(private readonly config: DockerPtyProviderConfig) {}
 
+  /** Start a shell inside the container via `docker exec` and stream its IO. */
   async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
     const containerId = await this.config.resolveContainerId()
     const shell = this.config.shell ?? 'bash'
@@ -103,17 +104,20 @@ export class DockerPtyProvider implements IPtyProvider {
     return { id, pid: proc.pid }
   }
 
-  // No cross-restart reattach in v1; a fresh terminal always spawns anew.
+  /** No cross-restart reattach in v1; a fresh terminal always spawns anew. */
   async attach(): Promise<void> {}
 
+  /** Whether a live PTY session exists for `id`. */
   hasPty(id: string): boolean {
     return this.sessions.has(id)
   }
 
+  /** Write input to the container shell's stdin. */
   write(id: string, data: string): void {
     this.sessions.get(id)?.proc.write(data)
   }
 
+  /** Resize the PTY; ignored if the process is already tearing down. */
   resize(id: string, cols: number, rows: number): void {
     try {
       this.sessions.get(id)?.proc.resize(cols, rows)
@@ -122,6 +126,7 @@ export class DockerPtyProvider implements IPtyProvider {
     }
   }
 
+  /** Kill the `docker exec` process and drop its session. */
   async shutdown(id: string, _opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
     const session = this.sessions.get(id)
     if (!session) {
@@ -135,6 +140,7 @@ export class DockerPtyProvider implements IPtyProvider {
     }
   }
 
+  /** Send a signal to the container shell process. */
   async sendSignal(id: string, signal: string): Promise<void> {
     try {
       this.sessions.get(id)?.proc.kill(signal)
@@ -143,33 +149,41 @@ export class DockerPtyProvider implements IPtyProvider {
     }
   }
 
+  /** Best-effort cwd: the live in-container cwd isn't readable from the host. */
   async getCwd(id: string): Promise<string> {
-    // Live in-container cwd isn't readable from the host; report the spawn cwd.
     return this.sessions.get(id)?.initialCwd ?? ''
   }
 
+  /** The in-container cwd the session was spawned in. */
   async getInitialCwd(id: string): Promise<string> {
     return this.sessions.get(id)?.initialCwd ?? ''
   }
 
+  /** No-op: scrollback clearing is handled client-side for docker sessions. */
   async clearBuffer(): Promise<void> {}
 
+  /** No-op: flow-control acks are not implemented for docker sessions. */
   acknowledgeDataEvent(): void {}
 
+  /** Child-process inspection isn't available across `docker exec`; report none. */
   async hasChildProcesses(): Promise<boolean> {
     return false
   }
 
+  /** Foreground-process inspection isn't available across `docker exec`. */
   async getForegroundProcess(): Promise<string | null> {
     return null
   }
 
+  /** No-op: devcontainer sessions are not serialized across app restarts in v1. */
   async serialize(): Promise<string> {
     return ''
   }
 
+  /** No-op counterpart to {@link serialize}. */
   async revive(): Promise<void> {}
 
+  /** List live sessions as `{ id, cwd, title }` triples. */
   async listProcesses(): Promise<{ id: string; cwd: string; title: string }[]> {
     return Array.from(this.sessions.entries()).map(([id, session]) => ({
       id,
@@ -178,24 +192,28 @@ export class DockerPtyProvider implements IPtyProvider {
     }))
   }
 
+  /** The shell launched inside the container (defaults to `bash`). */
   async getDefaultShell(): Promise<string> {
     return this.config.shell ?? 'bash'
   }
 
+  /** No selectable shell profiles for docker sessions. */
   async getProfiles(): Promise<{ name: string; path: string }[]> {
     return []
   }
 
+  /** Subscribe to terminal output; returns an unsubscribe function. */
   onData(callback: (payload: DataPayload) => void): () => void {
     this.dataListeners.add(callback)
     return () => this.dataListeners.delete(callback)
   }
 
-  // Replay only applies to relay/daemon reattach; devcontainer sessions never replay.
+  /** Replay only applies to relay/daemon reattach; devcontainer sessions never replay. */
   onReplay(): () => void {
     return () => {}
   }
 
+  /** Subscribe to PTY exit; returns an unsubscribe function. */
   onExit(callback: (payload: ExitPayload) => void): () => void {
     this.exitListeners.add(callback)
     return () => this.exitListeners.delete(callback)

--- a/src/main/devcontainer/docker-pty-provider.ts
+++ b/src/main/devcontainer/docker-pty-provider.ts
@@ -74,7 +74,11 @@ export class DockerPtyProvider implements IPtyProvider {
     })
 
     const spawnFn = this.config.ptySpawn ?? pty.spawn
-    const env = this.config.resolveSpawnEnv?.() ?? (process.env as Record<string, string>)
+    // Why: pty.ts already assembles the canonical host spawn env (including
+    // deletions and provider shims). Prefer the IPC-passed env so docker exec
+    // inherits the same values instead of ambient process.env.
+    const env =
+      opts.env ?? this.config.resolveSpawnEnv?.() ?? (process.env as Record<string, string>)
     const proc = spawnFn('docker', args, {
       name: term,
       cols: opts.cols,

--- a/src/main/devcontainer/docker-pty-provider.ts
+++ b/src/main/devcontainer/docker-pty-provider.ts
@@ -1,0 +1,203 @@
+/**
+ * PTY provider that runs the shell/agent *inside* a devcontainer via
+ * `docker exec`, implementing the same {@link IPtyProvider} contract as the
+ * local and SSH providers so the dispatch layer routes to it transparently.
+ *
+ * Design (hybrid model): Orca manages git/files host-side on the bind mount;
+ * only the terminal runs in the container. So this provider is a thin node-pty
+ * wrapper around `docker exec` — the host process is the docker client, and its
+ * child (the in-container shell) is what the user interacts with.
+ *
+ * Container id is resolved lazily per spawn (`resolveContainerId`) because a
+ * recreated devcontainer gets a new id; the host is keyed by something stable
+ * upstream. The worktree cwd is host→container translated before `-w`.
+ *
+ * Not yet implemented (v1): session serialize/revive (no reattach across app
+ * restart), in-container live cwd/foreground reporting, and flow-control acks.
+ * These degrade gracefully rather than block a working terminal.
+ */
+import * as pty from 'node-pty'
+import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+import { buildDockerExecArgs } from './docker-exec-command'
+
+type PtySpawnFn = (file: string, args: string[], options: pty.IPtyForkOptions) => pty.IPty
+
+export type DockerPtyProviderConfig = {
+  /** Resolve the current container id for this host (recreate-safe). */
+  resolveContainerId: () => Promise<string>
+  /** Translate a host worktree path to its in-container path (null if unmapped). */
+  hostToContainerCwd: (hostPath: string) => string | null
+  /** Shell to launch inside the container. Defaults to `bash`. */
+  shell?: string
+  /** Env var NAMES forwarded into the container via `-e NAME` (values from spawn env). */
+  forwardEnv?: readonly string[]
+  /** Full environment for the spawned docker client process (incl. forwarded secret values). */
+  resolveSpawnEnv?: () => Record<string, string>
+  /** Injectable spawn for tests; defaults to node-pty. */
+  ptySpawn?: PtySpawnFn
+}
+
+type DataPayload = { id: string; data: string }
+type ExitPayload = { id: string; code: number }
+
+type Session = {
+  proc: pty.IPty
+  /** In-container cwd at spawn; best-effort answer for getCwd/getInitialCwd. */
+  initialCwd: string
+}
+
+let ptyCounter = 0
+const DEFAULT_TERM = 'xterm-256color'
+
+export class DockerPtyProvider implements IPtyProvider {
+  private readonly sessions = new Map<string, Session>()
+  private readonly dataListeners = new Set<(payload: DataPayload) => void>()
+  private readonly exitListeners = new Set<(payload: ExitPayload) => void>()
+
+  constructor(private readonly config: DockerPtyProviderConfig) {}
+
+  async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
+    const containerId = await this.config.resolveContainerId()
+    const shell = this.config.shell ?? 'bash'
+    const containerCwd = opts.cwd ? this.config.hostToContainerCwd(opts.cwd) : null
+    const term = opts.env?.TERM ?? DEFAULT_TERM
+
+    const args = buildDockerExecArgs({
+      containerId,
+      shell,
+      containerCwd,
+      interactive: true,
+      forwardEnv: this.config.forwardEnv,
+      // TERM is non-secret and must reach the container for correct rendering.
+      literalEnv: { TERM: term }
+    })
+
+    const spawnFn = this.config.ptySpawn ?? pty.spawn
+    const env = this.config.resolveSpawnEnv?.() ?? (process.env as Record<string, string>)
+    const proc = spawnFn('docker', args, {
+      name: term,
+      cols: opts.cols,
+      rows: opts.rows,
+      // The docker *client* runs on the host; its own cwd is irrelevant to the
+      // in-container shell, so leave it at the process default.
+      cwd: process.cwd(),
+      env
+    })
+
+    const id = `dpty-${(ptyCounter += 1)}`
+    const session: Session = { proc, initialCwd: containerCwd ?? '' }
+    this.sessions.set(id, session)
+
+    proc.onData((data) => {
+      for (const listener of this.dataListeners) {
+        listener({ id, data })
+      }
+    })
+    proc.onExit(({ exitCode }) => {
+      this.sessions.delete(id)
+      for (const listener of this.exitListeners) {
+        listener({ id, code: exitCode })
+      }
+    })
+
+    return { id, pid: proc.pid }
+  }
+
+  // No cross-restart reattach in v1; a fresh terminal always spawns anew.
+  async attach(): Promise<void> {}
+
+  hasPty(id: string): boolean {
+    return this.sessions.has(id)
+  }
+
+  write(id: string, data: string): void {
+    this.sessions.get(id)?.proc.write(data)
+  }
+
+  resize(id: string, cols: number, rows: number): void {
+    try {
+      this.sessions.get(id)?.proc.resize(cols, rows)
+    } catch {
+      // node-pty rejects resize during teardown; ignore — the PTY is going away.
+    }
+  }
+
+  async shutdown(id: string, _opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
+    const session = this.sessions.get(id)
+    if (!session) {
+      return
+    }
+    this.sessions.delete(id)
+    try {
+      session.proc.kill()
+    } catch {
+      // Already dead.
+    }
+  }
+
+  async sendSignal(id: string, signal: string): Promise<void> {
+    try {
+      this.sessions.get(id)?.proc.kill(signal)
+    } catch {
+      // Process may already be gone.
+    }
+  }
+
+  async getCwd(id: string): Promise<string> {
+    // Live in-container cwd isn't readable from the host; report the spawn cwd.
+    return this.sessions.get(id)?.initialCwd ?? ''
+  }
+
+  async getInitialCwd(id: string): Promise<string> {
+    return this.sessions.get(id)?.initialCwd ?? ''
+  }
+
+  async clearBuffer(): Promise<void> {}
+
+  acknowledgeDataEvent(): void {}
+
+  async hasChildProcesses(): Promise<boolean> {
+    return false
+  }
+
+  async getForegroundProcess(): Promise<string | null> {
+    return null
+  }
+
+  async serialize(): Promise<string> {
+    return ''
+  }
+
+  async revive(): Promise<void> {}
+
+  async listProcesses(): Promise<{ id: string; cwd: string; title: string }[]> {
+    return Array.from(this.sessions.entries()).map(([id, session]) => ({
+      id,
+      cwd: session.initialCwd,
+      title: session.proc.process
+    }))
+  }
+
+  async getDefaultShell(): Promise<string> {
+    return this.config.shell ?? 'bash'
+  }
+
+  async getProfiles(): Promise<{ name: string; path: string }[]> {
+    return []
+  }
+
+  onData(callback: (payload: DataPayload) => void): () => void {
+    this.dataListeners.add(callback)
+    return () => this.dataListeners.delete(callback)
+  }
+
+  // Replay only applies to relay/daemon reattach; devcontainer sessions never replay.
+  onReplay(): () => void {
+    return () => {}
+  }
+
+  onExit(callback: (payload: ExitPayload) => void): () => void {
+    this.exitListeners.add(callback)
+    return () => this.exitListeners.delete(callback)
+  }
+}

--- a/src/main/devcontainer/path-map.test.ts
+++ b/src/main/devcontainer/path-map.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { containerToHost, hostToContainer, type ContainerMount } from './path-map'
+
+const REPO_MOUNT: ContainerMount = {
+  source: '/Users/me/work/aprium',
+  destination: '/workspaces/aprium'
+}
+
+describe('hostToContainer', () => {
+  it('maps the mount root itself', () => {
+    expect(hostToContainer('/Users/me/work/aprium', [REPO_MOUNT])).toBe('/workspaces/aprium')
+  })
+
+  it('maps a worktree path beneath the mount root', () => {
+    expect(hostToContainer('/Users/me/work/aprium/.worktrees/feature-x', [REPO_MOUNT])).toBe(
+      '/workspaces/aprium/.worktrees/feature-x'
+    )
+  })
+
+  it('tolerates trailing slashes on input and mount', () => {
+    const mount: ContainerMount = {
+      source: '/Users/me/work/aprium/',
+      destination: '/workspaces/aprium/'
+    }
+    expect(hostToContainer('/Users/me/work/aprium/src/', [mount])).toBe('/workspaces/aprium/src')
+  })
+
+  it('normalizes . and .. segments', () => {
+    expect(hostToContainer('/Users/me/work/aprium/src/../lib', [REPO_MOUNT])).toBe(
+      '/workspaces/aprium/lib'
+    )
+  })
+
+  it('respects path boundaries (no sibling-prefix false match)', () => {
+    expect(hostToContainer('/Users/me/work/aprium-staging', [REPO_MOUNT])).toBeNull()
+  })
+
+  it('returns null when the path is under no mount', () => {
+    expect(hostToContainer('/Users/me/other/repo', [REPO_MOUNT])).toBeNull()
+  })
+
+  it('returns null for non-absolute input', () => {
+    expect(hostToContainer('relative/path', [REPO_MOUNT])).toBeNull()
+  })
+
+  it('picks the most specific (longest) matching mount when mounts nest', () => {
+    const mounts: ContainerMount[] = [
+      REPO_MOUNT,
+      { source: '/Users/me/work/aprium/node_modules', destination: '/opt/deps' }
+    ]
+    expect(hostToContainer('/Users/me/work/aprium/node_modules/pkg/index.js', mounts)).toBe(
+      '/opt/deps/pkg/index.js'
+    )
+    // A sibling path still resolves through the outer mount.
+    expect(hostToContainer('/Users/me/work/aprium/src/index.ts', mounts)).toBe(
+      '/workspaces/aprium/src/index.ts'
+    )
+  })
+})
+
+describe('containerToHost', () => {
+  it('maps the destination root itself', () => {
+    expect(containerToHost('/workspaces/aprium', [REPO_MOUNT])).toBe('/Users/me/work/aprium')
+  })
+
+  it('maps a path beneath the destination', () => {
+    expect(containerToHost('/workspaces/aprium/.worktrees/feat', [REPO_MOUNT])).toBe(
+      '/Users/me/work/aprium/.worktrees/feat'
+    )
+  })
+
+  it('returns null when the container path is under no mount', () => {
+    expect(containerToHost('/tmp/scratch', [REPO_MOUNT])).toBeNull()
+  })
+
+  it('round-trips host -> container -> host', () => {
+    const hostPath = '/Users/me/work/aprium/.worktrees/feature-x'
+    const containerPath = hostToContainer(hostPath, [REPO_MOUNT])
+    expect(containerPath).not.toBeNull()
+    expect(containerToHost(containerPath as string, [REPO_MOUNT])).toBe(hostPath)
+  })
+})

--- a/src/main/devcontainer/path-map.ts
+++ b/src/main/devcontainer/path-map.ts
@@ -42,6 +42,7 @@ function relativeTail(base: string, full: string): string {
   return full.slice(base === '/' ? 1 : base.length + 1)
 }
 
+/** Translate `path` from one mount side to the other via longest-prefix match. */
 function translate(
   path: string,
   mounts: readonly ContainerMount[],

--- a/src/main/devcontainer/path-map.ts
+++ b/src/main/devcontainer/path-map.ts
@@ -1,0 +1,92 @@
+/**
+ * Host ↔ container path translation for devcontainer execution hosts.
+ *
+ * A devcontainer bind-mounts the project from the host (e.g. macOS
+ * `/Users/me/work/app`) into the container (e.g. `/workspaces/app`). Orca
+ * manages git/files host-side on the bind-mounted path, but the agent's PTY
+ * runs *inside* the container, so a worktree's host path must be translated to
+ * its in-container path before `docker exec -w`, and container paths reported by
+ * in-container tooling must be mapped back to the host.
+ *
+ * Both ends are POSIX (macOS host, Linux container), so translation is pure
+ * POSIX-path arithmetic over the container's mount table (`docker inspect`
+ * `.Mounts[]`). No filesystem access — keep this deterministic and unit-tested.
+ */
+import { posix } from 'path'
+import type { ContainerMount } from '../../shared/devcontainer-types'
+
+export type { ContainerMount }
+
+type MountSide = keyof ContainerMount
+
+/** Normalize a POSIX path: collapse `.`/`..`, drop any trailing slash (except root). */
+function normalize(input: string): string {
+  const normalized = posix.normalize(input)
+  return normalized.length > 1 && normalized.endsWith('/') ? normalized.slice(0, -1) : normalized
+}
+
+/** True when `candidate` equals `base` or sits beneath it on a path boundary.
+ *  The boundary check stops `/a/app` from matching `/a/app2`. */
+function isWithin(base: string, candidate: string): boolean {
+  if (base === candidate) {
+    return true
+  }
+  return candidate.startsWith(base === '/' ? '/' : `${base}/`)
+}
+
+/** Remainder of `full` relative to ancestor `base` (no leading slash). '' when equal. */
+function relativeTail(base: string, full: string): string {
+  if (base === full) {
+    return ''
+  }
+  return full.slice(base === '/' ? 1 : base.length + 1)
+}
+
+function translate(
+  path: string,
+  mounts: readonly ContainerMount[],
+  from: MountSide
+): string | null {
+  // Only absolute paths are meaningful here; a relative path has no host/container identity.
+  if (!path.startsWith('/')) {
+    return null
+  }
+  const to: MountSide = from === 'source' ? 'destination' : 'source'
+  const target = normalize(path)
+
+  // Why longest-prefix: nested mounts (e.g. the repo and a mount inside it) can
+  // both be ancestors; the most specific one owns the path.
+  let best: ContainerMount | null = null
+  let bestBaseLength = -1
+  for (const mount of mounts) {
+    const base = normalize(mount[from])
+    if (base.startsWith('/') && isWithin(base, target) && base.length > bestBaseLength) {
+      best = mount
+      bestBaseLength = base.length
+    }
+  }
+  if (!best) {
+    return null
+  }
+
+  const base = normalize(best[from])
+  const dest = normalize(best[to])
+  const tail = relativeTail(base, target)
+  return tail ? posix.join(dest, tail) : dest
+}
+
+/** Translate a host path to its in-container path, or null if not under any mount. */
+export function hostToContainer(
+  hostPath: string,
+  mounts: readonly ContainerMount[]
+): string | null {
+  return translate(hostPath, mounts, 'source')
+}
+
+/** Translate an in-container path back to its host path, or null if not under any mount. */
+export function containerToHost(
+  containerPath: string,
+  mounts: readonly ContainerMount[]
+): string | null {
+  return translate(containerPath, mounts, 'destination')
+}

--- a/src/main/devcontainer/project-fields.test.ts
+++ b/src/main/devcontainer/project-fields.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { buildDevcontainerProjectFields } from './project-fields'
+
+describe('buildDevcontainerProjectFields', () => {
+  it('maps a devcontainer to host-mounted repo fields with a relative worktree base', () => {
+    expect(buildDevcontainerProjectFields({ hostFolder: '/Users/me/work/aprium' })).toEqual({
+      path: '/Users/me/work/aprium',
+      displayName: 'aprium',
+      executionHostId: 'devcontainer:%2FUsers%2Fme%2Fwork%2Faprium',
+      connectionId: 'devcontainer:%2FUsers%2Fme%2Fwork%2Faprium',
+      worktreeBasePath: '.worktrees',
+      relativePaths: true
+    })
+  })
+
+  it('keeps connectionId equal to executionHostId so PTY routing resolves the docker provider', () => {
+    const fields = buildDevcontainerProjectFields({ hostFolder: '/srv/lac' })
+    expect(fields.connectionId).toBe(fields.executionHostId)
+  })
+})

--- a/src/main/devcontainer/project-fields.test.ts
+++ b/src/main/devcontainer/project-fields.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { toDevcontainerExecutionHostId } from '../../shared/execution-host'
 import { buildDevcontainerProjectFields } from './project-fields'
 
 describe('buildDevcontainerProjectFields', () => {
@@ -16,5 +17,18 @@ describe('buildDevcontainerProjectFields', () => {
   it('keeps connectionId equal to executionHostId so PTY routing resolves the docker provider', () => {
     const fields = buildDevcontainerProjectFields({ hostFolder: '/srv/lac' })
     expect(fields.connectionId).toBe(fields.executionHostId)
+  })
+
+  it('derives the repo display name from a Windows host path', () => {
+    const hostFolder = 'C:\\Users\\me\\work\\repo'
+
+    expect(buildDevcontainerProjectFields({ hostFolder })).toEqual({
+      path: hostFolder,
+      displayName: 'repo',
+      executionHostId: toDevcontainerExecutionHostId(hostFolder),
+      connectionId: toDevcontainerExecutionHostId(hostFolder),
+      worktreeBasePath: '.worktrees',
+      relativePaths: true
+    })
   })
 })

--- a/src/main/devcontainer/project-fields.ts
+++ b/src/main/devcontainer/project-fields.ts
@@ -9,6 +9,7 @@
  *    with relative gitdir pointers, so they're valid from both host and
  *    container paths (see Phase 3).
  */
+import { posix, win32 } from 'path'
 import { toDevcontainerExecutionHostId } from '../../shared/execution-host'
 import { DEVCONTAINER_WORKTREE_BASE_PATH } from '../../shared/devcontainer-types'
 import type { DevcontainerInfo } from './discovery'
@@ -24,6 +25,10 @@ export type DevcontainerProjectFields = {
   relativePaths: true
 }
 
+function hostPathBasename(hostPath: string): string {
+  return hostPath.includes('\\') ? win32.basename(hostPath) : posix.basename(hostPath)
+}
+
 /** Map a discovered devcontainer to the repo/project fields Add-Project persists. */
 export function buildDevcontainerProjectFields(
   info: Pick<DevcontainerInfo, 'hostFolder'>
@@ -31,7 +36,9 @@ export function buildDevcontainerProjectFields(
   const hostId = toDevcontainerExecutionHostId(info.hostFolder)
   return {
     path: info.hostFolder,
-    displayName: info.hostFolder.split('/').filter(Boolean).pop() ?? info.hostFolder,
+    // Why: this may run on a non-Windows host while inspecting a Windows
+    // devcontainer path, so select the parser from the path string itself.
+    displayName: hostPathBasename(info.hostFolder) || info.hostFolder,
     executionHostId: hostId,
     // Route the PTY by the same id the provider is registered under.
     connectionId: hostId,

--- a/src/main/devcontainer/project-fields.ts
+++ b/src/main/devcontainer/project-fields.ts
@@ -24,6 +24,7 @@ export type DevcontainerProjectFields = {
   relativePaths: true
 }
 
+/** Map a discovered devcontainer to the repo/project fields Add-Project persists. */
 export function buildDevcontainerProjectFields(
   info: Pick<DevcontainerInfo, 'hostFolder'>
 ): DevcontainerProjectFields {

--- a/src/main/devcontainer/project-fields.ts
+++ b/src/main/devcontainer/project-fields.ts
@@ -1,0 +1,40 @@
+/**
+ * Maps a discovered devcontainer to the repo/project fields Add-Project must
+ * persist. This is the single place the hybrid model is encoded:
+ *  - `path` is the HOST bind-mount folder, so Orca's local filesystem/git
+ *    providers operate on the same inodes the container sees.
+ *  - `executionHostId`/`connectionId` are the devcontainer host id, so the PTY
+ *    routes to the docker provider (terminal runs in the container).
+ *  - `worktreeBasePath` is relative (inside the mount) and worktrees are created
+ *    with relative gitdir pointers, so they're valid from both host and
+ *    container paths (see Phase 3).
+ */
+import { toDevcontainerExecutionHostId } from '../../shared/execution-host'
+import { DEVCONTAINER_WORKTREE_BASE_PATH } from '../../shared/devcontainer-types'
+import type { DevcontainerInfo } from './discovery'
+
+export { DEVCONTAINER_WORKTREE_BASE_PATH }
+
+export type DevcontainerProjectFields = {
+  path: string
+  displayName: string
+  executionHostId: `devcontainer:${string}`
+  connectionId: string
+  worktreeBasePath: string
+  relativePaths: true
+}
+
+export function buildDevcontainerProjectFields(
+  info: Pick<DevcontainerInfo, 'hostFolder'>
+): DevcontainerProjectFields {
+  const hostId = toDevcontainerExecutionHostId(info.hostFolder)
+  return {
+    path: info.hostFolder,
+    displayName: info.hostFolder.split('/').filter(Boolean).pop() ?? info.hostFolder,
+    executionHostId: hostId,
+    // Route the PTY by the same id the provider is registered under.
+    connectionId: hostId,
+    worktreeBasePath: DEVCONTAINER_WORKTREE_BASE_PATH,
+    relativePaths: true
+  }
+}

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -332,6 +332,39 @@ describe('addWorktree', () => {
     ])
   })
 
+  it('fails fast with a clear error when git is too old for relative-path worktrees', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'git version 2.47.3\n' })
+
+    await expect(
+      addWorktree('/repo', '/repo-feature', 'feature/test', undefined, false, false, {
+        relativePaths: true
+      })
+    ).rejects.toThrow(/Git 2\.48 or newer is required for devcontainer worktrees/)
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([[['version'], { cwd: '/repo' }]])
+  })
+
+  it('verifies git version before using --relative-paths', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'git version 2.48.1\n' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote already set
+
+    await addWorktree('/repo', '/repo-feature', 'feature/test', undefined, false, false, {
+      relativePaths: true
+    })
+
+    expect(gitExecFileAsyncMock.mock.calls[0]?.[0]).toEqual(['version'])
+    expect(gitExecFileAsyncMock.mock.calls[1]?.[0]).toEqual([
+      'worktree',
+      'add',
+      '--relative-paths',
+      '--no-track',
+      '-b',
+      'feature/test',
+      '/repo-feature'
+    ])
+  })
+
   it('checks out a selected existing local branch without creating a new branch', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
 

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -126,6 +126,38 @@ function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
   )
 }
 
+const MIN_RELATIVE_WORKTREE_PATHS_GIT_VERSION = { major: 2, minor: 48 }
+
+function parseGitVersion(stdout: string): { major: number; minor: number } | null {
+  const match = stdout.match(/git version (\d+)\.(\d+)/i)
+  if (!match) {
+    return null
+  }
+  return { major: Number(match[1]), minor: Number(match[2]) }
+}
+
+async function assertGitSupportsRelativeWorktreePaths(
+  repoPath: string,
+  options: GitWorktreeExecOptions = {}
+): Promise<void> {
+  const { stdout } = await gitExecFileAsync(['version'], gitExecOptions(repoPath, options))
+  const version = parseGitVersion(stdout)
+  if (!version) {
+    throw new Error(
+      `Git ${MIN_RELATIVE_WORKTREE_PATHS_GIT_VERSION.major}.${MIN_RELATIVE_WORKTREE_PATHS_GIT_VERSION.minor} or newer is required for devcontainer worktrees with relative paths, but git version output could not be parsed: ${stdout.trim() || 'unknown'}`
+    )
+  }
+  if (
+    version.major < MIN_RELATIVE_WORKTREE_PATHS_GIT_VERSION.major ||
+    (version.major === MIN_RELATIVE_WORKTREE_PATHS_GIT_VERSION.major &&
+      version.minor < MIN_RELATIVE_WORKTREE_PATHS_GIT_VERSION.minor)
+  ) {
+    throw new Error(
+      `Git ${MIN_RELATIVE_WORKTREE_PATHS_GIT_VERSION.major}.${MIN_RELATIVE_WORKTREE_PATHS_GIT_VERSION.minor} or newer is required for devcontainer worktrees with relative paths (found ${stdout.trim() || 'unknown'}).`
+    )
+  }
+}
+
 function normalizeLocalBranchRef(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
@@ -774,6 +806,7 @@ export async function addWorktree(
   const args = ['worktree', 'add']
   let effectiveBase: string | undefined
   if (options.relativePaths) {
+    await assertGitSupportsRelativeWorktreePaths(repoPath, options)
     // Why first: `--relative-paths` is an option to `worktree add` itself; it
     // makes both the worktree `.git` file and the `.git/worktrees/<n>/gitdir`
     // back-pointer relative, so they resolve from any absolute prefix (host vs

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -41,6 +41,11 @@ export type AddWorktreeOptions = GitWorktreeExecOptions & {
     branch: string
     ref: string
   }
+  /** Create the worktree with relative gitdir pointers (`--relative-paths`,
+   *  git >= 2.48). Set for devcontainer repos so a worktree created host-side
+   *  stays valid when the same bind-mounted files are accessed at a different
+   *  absolute path inside the container. */
+  relativePaths?: boolean
 }
 
 export type RemoveWorktreeOptions = GitWorktreeExecOptions & {
@@ -768,6 +773,14 @@ export async function addWorktree(
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
   const args = ['worktree', 'add']
   let effectiveBase: string | undefined
+  if (options.relativePaths) {
+    // Why first: `--relative-paths` is an option to `worktree add` itself; it
+    // makes both the worktree `.git` file and the `.git/worktrees/<n>/gitdir`
+    // back-pointer relative, so they resolve from any absolute prefix (host vs
+    // in-container). Verified: an absolute-pointer worktree breaks when the
+    // host path is absent inside the container; a relative one stays valid.
+    args.push('--relative-paths')
+  }
   if (noCheckout) {
     args.push('--no-checkout')
   }

--- a/src/main/ipc/devcontainer.ts
+++ b/src/main/ipc/devcontainer.ts
@@ -7,6 +7,7 @@
 import { ipcMain } from 'electron'
 import { listDevcontainers, type DevcontainerInfo } from '../devcontainer/discovery'
 
+/** Register the `devcontainer:*` IPC handlers (Add-Project devcontainer source). */
 export function registerDevcontainerHandlers(): void {
   ipcMain.handle('devcontainer:list', async (): Promise<DevcontainerInfo[]> => {
     try {

--- a/src/main/ipc/devcontainer.ts
+++ b/src/main/ipc/devcontainer.ts
@@ -1,0 +1,19 @@
+/**
+ * IPC for the Add-Project "Devcontainer" source: lists running/known
+ * devcontainers the renderer can offer as projects. Docker being unavailable
+ * (not installed / daemon down) is not an error here — it just means there are
+ * no devcontainers to offer, so the source stays empty rather than throwing.
+ */
+import { ipcMain } from 'electron'
+import { listDevcontainers, type DevcontainerInfo } from '../devcontainer/discovery'
+
+export function registerDevcontainerHandlers(): void {
+  ipcMain.handle('devcontainer:list', async (): Promise<DevcontainerInfo[]> => {
+    try {
+      return await listDevcontainers(undefined, { all: true })
+    } catch (error) {
+      console.warn('[devcontainer] list failed (docker unavailable?):', error)
+      return []
+    }
+  })
+}

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -185,7 +185,9 @@ import {
   setPtyOwnership,
   setLocalPtyProvider,
   rebindLocalProviderListeners,
-  unregisterSshPtyProvider
+  unregisterSshPtyProvider,
+  registerDockerPtyProvider,
+  unregisterDockerPtyProvider
 } from './pty'
 import { hasLiveClaudePtys, markClaudePtySpawned } from '../claude-accounts/live-pty-gate'
 import {
@@ -363,6 +365,7 @@ describe('registerPtyHandlers', () => {
     _resetWslCachesForTests()
     vi.useRealTimers()
     unregisterSshPtyProvider('ssh-1')
+    unregisterDockerPtyProvider('devcontainer:%2FUsers%2Fme%2Fwork%2Faprium')
     setLocalPtyProvider(new LocalPtyProvider())
     if (savedProcessPlatform) {
       Object.defineProperty(process, 'platform', savedProcessPlatform)
@@ -3055,8 +3058,11 @@ describe('registerPtyHandlers', () => {
     expect(sshSpawn).toHaveBeenCalledTimes(1)
   })
 
-  it('lists sessions from both local and SSH providers', async () => {
+  it('lists sessions from local, SSH, and devcontainer providers', async () => {
     registerPtyHandlers(mainWindow as never)
+    const dockerListProcesses = vi.fn(async () => [
+      { id: 'docker-pty', cwd: '/workspaces/aprium', title: 'docker-shell' }
+    ])
     const sshListProcesses = vi.fn(async () => [
       { id: 'remote-pty', cwd: '/remote', title: 'ssh-shell' }
     ])
@@ -3080,6 +3086,25 @@ describe('registerPtyHandlers', () => {
       getDefaultShell: vi.fn(),
       getProfiles: vi.fn()
     } as never)
+    registerDockerPtyProvider('devcontainer:%2FUsers%2Fme%2Fwork%2Faprium', {
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(async () => undefined),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: dockerListProcesses,
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
 
     await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
     const sessions = (await handlers.get('pty:listSessions')!(null, undefined)) as {
@@ -3089,9 +3114,15 @@ describe('registerPtyHandlers', () => {
     }[]
 
     expect(sshListProcesses).toHaveBeenCalled()
+    expect(dockerListProcesses).toHaveBeenCalled()
     expect(sessions).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ cwd: '/remote', id: 'remote-pty', title: 'ssh-shell' })
+        expect.objectContaining({ cwd: '/remote', id: 'remote-pty', title: 'ssh-shell' }),
+        expect.objectContaining({
+          cwd: '/workspaces/aprium',
+          id: 'docker-pty',
+          title: 'docker-shell'
+        })
       ])
     )
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -39,6 +39,8 @@ import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import { SSH_SESSION_EXPIRED_ERROR, isSshPtyNotFoundError } from '../providers/ssh-pty-provider'
 import { parseAppSshPtyId, toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
+import { parseExecutionHostId } from '../../shared/execution-host'
+import { DevcontainerRuntime } from '../devcontainer/devcontainer-runtime'
 import { mintPtySessionId, isSafePtySessionId } from '../daemon/pty-session-id'
 import { addNodePtyRecoveryHint } from '../daemon/node-pty-error-hints'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
@@ -111,6 +113,22 @@ type FreshLocalFallbackProvider = IPtyProvider & {
   routesFreshSpawnsToLocalProvider?: true
 }
 const sshProviders = new Map<string, IPtyProvider>()
+// Devcontainer PTY providers (`docker exec`), keyed by the devcontainer
+// execution-host id used as the connectionId. Kept separate from sshProviders
+// because devcontainers carry none of the SSH relay machinery (no id wrapping,
+// no remote leases) — the guards below branch on `isDockerConnection`.
+const dockerProviders = new Map<string, IPtyProvider>()
+
+function isDockerConnection(connectionId: string | null | undefined): boolean {
+  if (!connectionId) {
+    return false
+  }
+  // Registration may be lazy, so also recognize the id format itself — the
+  // SSH-coupled id wrapping/lease guards must hold even before first spawn.
+  return (
+    dockerProviders.has(connectionId) || parseExecutionHostId(connectionId)?.kind === 'devcontainer'
+  )
+}
 // Why: PTY IDs are assigned at spawn time with a connectionId, but subsequent
 // write/resize/kill calls only carry the PTY ID. This map lets us route
 // post-spawn operations to the correct provider without the renderer needing
@@ -314,11 +332,32 @@ export function hasPendingRendererSerializerForPaneKey(paneKey: string): boolean
   return isValidPaneKey(paneKey) && pendingByPaneKey.has(paneKey)
 }
 
+/**
+ * Lazily create + register a devcontainer PTY provider the first time one of
+ * its terminals spawns. The host id (`devcontainer:<key>`) is self-describing,
+ * so no separate connect step is needed — unlike SSH, a devcontainer has no
+ * relay session to stand up. The runtime resolves/starts the container per spawn.
+ */
+function ensureDevcontainerProvider(connectionId: string): IPtyProvider | undefined {
+  const parsed = parseExecutionHostId(connectionId)
+  if (parsed?.kind !== 'devcontainer') {
+    return undefined
+  }
+  const provider = new DevcontainerRuntime({
+    containerKey: parsed.containerKey
+  }).createPtyProvider()
+  dockerProviders.set(connectionId, provider)
+  return provider
+}
+
 function getProvider(connectionId: string | null | undefined): IPtyProvider {
   if (!connectionId) {
     return localProvider
   }
-  const provider = sshProviders.get(connectionId)
+  const provider =
+    dockerProviders.get(connectionId) ??
+    sshProviders.get(connectionId) ??
+    ensureDevcontainerProvider(connectionId)
   if (!provider) {
     throw new Error(`No PTY provider for connection "${connectionId}"`)
   }
@@ -337,15 +376,23 @@ function hasPtyProviderForInspection(ptyId: string): boolean {
   // Why: process inspection is background polling; disconnected SSH hosts should
   // read as idle instead of surfacing repeated IPC errors.
   const connectionId = ptyOwnership.get(ptyId)
-  return connectionId == null || sshProviders.has(connectionId)
+  return connectionId == null || sshProviders.has(connectionId) || dockerProviders.has(connectionId)
 }
 
 function getAppPtyId(connectionId: string | null | undefined, ptyId: string): string {
-  return connectionId ? toAppSshPtyId(connectionId, ptyId) : ptyId
+  // Devcontainer providers return globally-unique ids and have no relay, so the
+  // SSH id wrapping must be skipped — the raw id is the app-facing id.
+  if (!connectionId || isDockerConnection(connectionId)) {
+    return ptyId
+  }
+  return toAppSshPtyId(connectionId, ptyId)
 }
 
 function getRelayPtyId(connectionId: string | null | undefined, ptyId: string): string {
-  return connectionId ? toRelaySshPtyId(connectionId, ptyId) : ptyId
+  if (!connectionId || isDockerConnection(connectionId)) {
+    return ptyId
+  }
+  return toRelaySshPtyId(connectionId, ptyId)
 }
 
 function stripRemotePaneEnvWhenHooksDisabled(
@@ -456,7 +503,7 @@ function finishPtyShutdown(
   store: Store | undefined
 ): void {
   clearProviderPtyState(id)
-  if (connectionId) {
+  if (connectionId && !isDockerConnection(connectionId)) {
     store?.markSshRemotePtyLease(connectionId, getRelayPtyId(connectionId, id), 'terminated')
   }
   ptyOwnership.delete(id)
@@ -966,6 +1013,22 @@ export function unregisterSshPtyProvider(connectionId: string): void {
 /** Get the SSH PTY provider for a connection (for dispose on cleanup). */
 export function getSshPtyProvider(connectionId: string): IPtyProvider | undefined {
   return sshProviders.get(connectionId)
+}
+
+/** Register a devcontainer (`docker exec`) PTY provider, keyed by its
+ *  devcontainer execution-host id (used as the connectionId on spawn). */
+export function registerDockerPtyProvider(connectionId: string, provider: IPtyProvider): void {
+  dockerProviders.set(connectionId, provider)
+}
+
+/** Remove a devcontainer PTY provider when its project/host is closed. */
+export function unregisterDockerPtyProvider(connectionId: string): void {
+  dockerProviders.delete(connectionId)
+}
+
+/** Get the devcontainer PTY provider for a connection (for dispose on cleanup). */
+export function getDockerPtyProvider(connectionId: string): IPtyProvider | undefined {
+  return dockerProviders.get(connectionId)
 }
 
 /** Get the installed PTY provider (for direct access in tests/runtime).
@@ -1983,7 +2046,9 @@ export function registerPtyHandlers(
               clearProviderPtyState(effectiveSessionAppId)
               deletePtyOwnership(effectiveSessionAppId)
             }
-            store?.markSshRemotePtyLease(args.connectionId, effectiveSessionRelayId, 'expired')
+            if (!isDockerConnection(args.connectionId)) {
+              store?.markSshRemotePtyLease(args.connectionId, effectiveSessionRelayId, 'expired')
+            }
           }
           if (isMintedSessionId && sessionId !== undefined) {
             clearProviderPtyState(sessionId)
@@ -1997,7 +2062,7 @@ export function registerPtyHandlers(
         ptyOwnership.set(result.id, args.connectionId ?? null)
         const relayResultId = getRelayPtyId(args.connectionId, result.id)
         const persistSshLease = (): void => {
-          if (!store || !args.connectionId) {
+          if (!store || !args.connectionId || isDockerConnection(args.connectionId)) {
             return
           }
           // Why: workspace-session bindings keep app-facing PTY ids for hydration,
@@ -2708,7 +2773,9 @@ export function registerPtyHandlers(
               clearProviderPtyState(effectiveSessionAppId)
               deletePtyOwnership(effectiveSessionAppId)
             }
-            store?.markSshRemotePtyLease(args.connectionId, effectiveSessionRelayId, 'expired')
+            if (!isDockerConnection(args.connectionId)) {
+              store?.markSshRemotePtyLease(args.connectionId, effectiveSessionRelayId, 'expired')
+            }
           }
           // Why: if buildPtyHostEnv materialized provider state for this minted
           // id but provider.spawn failed, that state would otherwise leak.
@@ -3231,7 +3298,9 @@ export function registerPtyHandlers(
     const ownedConnectionId = ptyOwnership.get(args.id)
     const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
     const connectionId = ownedConnectionId ?? parsedSshId?.connectionId
-    const provider = connectionId ? sshProviders.get(connectionId) : tryGetProviderForPty(args.id)
+    const provider = connectionId
+      ? (dockerProviders.get(connectionId) ?? sshProviders.get(connectionId))
+      : tryGetProviderForPty(args.id)
     if (!provider && connectionId) {
       // Why: detached SSH PTYs intentionally keep ownership after their
       // provider is unregistered; hydrated app-scoped ids can also arrive

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2287,7 +2287,8 @@ export function registerPtyHandlers(
     listProcesses: async () => {
       const providerSessions = await Promise.all([
         localProvider.listProcesses(),
-        ...Array.from(sshProviders.values(), (provider) => provider.listProcesses())
+        ...Array.from(sshProviders.values(), (provider) => provider.listProcesses()),
+        ...Array.from(dockerProviders.values(), (provider) => provider.listProcesses())
       ])
       return providerSessions.flat()
     },
@@ -3339,6 +3340,10 @@ export function registerPtyHandlers(
           sessions: await localProvider.listProcesses()
         }),
         ...Array.from(sshProviders.entries(), async ([connectionId, provider]) => ({
+          connectionId,
+          sessions: await provider.listProcesses().catch(() => [])
+        })),
+        ...Array.from(dockerProviders.entries(), async ([connectionId, provider]) => ({
           connectionId,
           sessions: await provider.listProcesses().catch(() => [])
         }))

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -344,7 +344,10 @@ function ensureDevcontainerProvider(connectionId: string): IPtyProvider | undefi
     return undefined
   }
   const provider = new DevcontainerRuntime({
-    containerKey: parsed.containerKey
+    containerKey: parsed.containerKey,
+    // Why: devcontainer PTYs must receive an explicit spawn env from pty.ts or
+    // this resolver; never let DockerPtyProvider fall back to ambient process.env.
+    resolveSpawnEnv: () => ({})
   }).createPtyProvider()
   dockerProviders.set(connectionId, provider)
   return provider

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -51,6 +51,7 @@ import { registerSpeechHandlers } from './speech'
 import { registerCodexAccountHandlers } from './codex-accounts'
 import { registerAgentHookHandlers } from './agent-hooks'
 import { registerAgentTrustHandlers } from './agent-trust'
+import { registerDevcontainerHandlers } from './devcontainer'
 import { registerClaudeAccountHandlers } from './claude-accounts'
 import { registerUpdaterHandlers } from '../window/attach-main-window-services'
 import {
@@ -115,6 +116,7 @@ export function registerCoreHandlers(
   registerCodexAccountHandlers(codexAccounts)
   registerAgentHookHandlers(runtime)
   registerAgentTrustHandlers()
+  registerDevcontainerHandlers()
   registerClaudeAccountHandlers(claudeAccounts)
   registerRateLimitHandlers(rateLimits)
   registerGitHubHandlers(store, stats)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -8,6 +8,7 @@ import {
   isShellProcess
 } from '../../shared/agent-detection'
 import { extractOscTitleScanTail } from '../../shared/osc-title-scan-tail'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
 import type { AgentStatus } from '../../shared/agent-detection'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
 import {
@@ -12591,11 +12592,19 @@ export class OrcaRuntimeService {
     const localWorktreeGitOptionArgs: [] | [{ wslDistro?: string }] = hasLocalWorktreeGitOptions
       ? [localWorktreeGitOptions]
       : []
+    // Devcontainer repos create worktrees with relative gitdir pointers so they
+    // stay valid when the same bind-mounted files are seen at the container's
+    // path (see Phase 3 / git --relative-paths).
+    const useRelativeWorktreePaths =
+      parseExecutionHostId(getRepoExecutionHostId(repo))?.kind === 'devcontainer'
     const addProjectGitOptions = (options?: AddWorktreeOptions): AddWorktreeOptions | undefined => {
+      const withRelative: AddWorktreeOptions | undefined = useRelativeWorktreePaths
+        ? { ...options, relativePaths: true }
+        : options
       if (!hasLocalWorktreeGitOptions) {
-        return options
+        return withRelative
       }
-      return { ...options, ...localWorktreeGitOptions }
+      return { ...withRelative, ...localWorktreeGitOptions }
     }
     const hostedReviewExecutionContext = this.getHostedReviewExecutionOptions(repo)
     let effectiveRequestedName = args.name

--- a/src/main/worktree-root-preparation.ts
+++ b/src/main/worktree-root-preparation.ts
@@ -1,6 +1,6 @@
 import { mkdir } from 'node:fs/promises'
 import type { GlobalSettings, Repo } from '../shared/types'
-import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
+import { getRepoExecutionHostId, isLocalFilesystemHost } from '../shared/execution-host'
 import { isFolderRepo } from '../shared/repo-kind'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
 
@@ -14,7 +14,10 @@ export async function prepareLocalWorktreeRootForRepo(
   store: Pick<WorktreeRootPreparationStore, 'getSettings'>,
   repo: Repo
 ): Promise<void> {
-  if (getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID || isFolderRepo(repo)) {
+  // Devcontainer repos prepare their worktree root locally too: the project is
+  // bind-mounted, so worktrees live on host disk (under the mount) and only the
+  // terminal runs in the container.
+  if (!isLocalFilesystemHost(getRepoExecutionHostId(repo)) || isFolderRepo(repo)) {
     return
   }
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -9,6 +9,7 @@ import type {
   HostedReviewProvider
 } from '../shared/hosted-review'
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
+import type { DevcontainerInfo } from '../shared/devcontainer-types'
 import type { ReadClipboardTextOptions } from '../shared/clipboard-text'
 import type { AppIdentity } from '../shared/app-identity'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
@@ -1518,6 +1519,10 @@ export type PreloadApi = {
       args: HostedReviewCreationEligibilityArgs
     ) => Promise<HostedReviewCreationEligibility>
     create: (args: CreateHostedReviewArgs) => Promise<CreateHostedReviewResult>
+  }
+  // ── Devcontainers — Add-Project source listing running devcontainers ──
+  devcontainer: {
+    list: () => Promise<DevcontainerInfo[]>
   }
   // ── GitLab — parallel to gh, MR/issue surface only in v1 ────────
   // Shapes mirror gh.* one-to-one where the data matches; diverge

--- a/src/preload/devcontainer.ts
+++ b/src/preload/devcontainer.ts
@@ -1,0 +1,12 @@
+/* Devcontainer preload bindings — split out of `src/preload/index.ts` for the
+   same reason as the GitLab bindings (smaller merge surface on upstream sync).
+   Composed back into `api.devcontainer` from `index.ts`. */
+import { ipcRenderer } from 'electron'
+import type { DevcontainerInfo } from '../shared/devcontainer-types'
+
+export type { DevcontainerInfo }
+
+export const devcontainerApi = {
+  /** List devcontainers to offer in the Add-Project "Devcontainer" source. */
+  list: (): Promise<DevcontainerInfo[]> => ipcRenderer.invoke('devcontainer:list')
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,6 +5,7 @@ import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
+import { devcontainerApi } from './devcontainer'
 import type { AppIdentity } from '../shared/app-identity'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
@@ -1378,6 +1379,7 @@ const api = {
   // `gl.*` channel doesn't surface as a merge conflict on every
   // upstream sync of this central preload file.
   gl: glApi,
+  devcontainer: devcontainerApi,
 
   linear: {
     connect: (args: {

--- a/src/renderer/src/components/sidebar/AddRepoDevcontainerStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDevcontainerStep.tsx
@@ -8,6 +8,7 @@ type DevcontainerStepProps = {
   onSelect: (info: DevcontainerInfo) => void
 }
 
+/** Derive a short client label (the last path segment) from the host folder. */
 function clientName(hostFolder: string): string {
   return hostFolder.split('/').filter(Boolean).at(-1) ?? hostFolder
 }

--- a/src/renderer/src/components/sidebar/AddRepoDevcontainerStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDevcontainerStep.tsx
@@ -1,16 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { Container } from 'lucide-react'
 import { DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { basename } from '@/lib/path'
 import { translate } from '@/i18n/i18n'
 import type { DevcontainerInfo } from '../../../../shared/devcontainer-types'
 
 type DevcontainerStepProps = {
   onSelect: (info: DevcontainerInfo) => void
-}
-
-/** Derive a short client label (the last path segment) from the host folder. */
-function clientName(hostFolder: string): string {
-  return hostFolder.split('/').filter(Boolean).at(-1) ?? hostFolder
 }
 
 /**
@@ -55,7 +51,7 @@ export function AddRepoDevcontainerStep({ onSelect }: DevcontainerStepProps): Re
         <DialogDescription>
           {translate(
             'auto.components.sidebar.AddRepoDevcontainerStep.description',
-            'Pick a running devcontainer to manage as a project. Files and git stay on your machine; the agent runs inside the container.'
+            'Pick a devcontainer to manage as a project. Files and git stay on your machine; the agent runs inside the container.'
           )}
         </DialogDescription>
       </DialogHeader>
@@ -95,7 +91,7 @@ export function AddRepoDevcontainerStep({ onSelect }: DevcontainerStepProps): Re
                 <Container className="size-4 shrink-0 text-muted-foreground" />
                 <span className="min-w-0">
                   <span className="block truncate text-sm font-medium">
-                    {clientName(info.hostFolder)}
+                    {basename(info.hostFolder) || info.hostFolder}
                   </span>
                   <span className="block truncate text-xs text-muted-foreground">
                     {info.hostFolder}

--- a/src/renderer/src/components/sidebar/AddRepoDevcontainerStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDevcontainerStep.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react'
+import { Container } from 'lucide-react'
+import { DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { translate } from '@/i18n/i18n'
+import type { DevcontainerInfo } from '../../../../shared/devcontainer-types'
+
+type DevcontainerStepProps = {
+  onSelect: (info: DevcontainerInfo) => void
+}
+
+function clientName(hostFolder: string): string {
+  return hostFolder.split('/').filter(Boolean).at(-1) ?? hostFolder
+}
+
+/**
+ * Add-Project "Devcontainer" source: lists running/known devcontainers (via the
+ * `devcontainer:list` IPC) and lets the user open one as a project. Selecting a
+ * container hands the {@link DevcontainerInfo} back to the dialog, which creates
+ * a repo bound to the host folder + devcontainer execution host.
+ */
+export function AddRepoDevcontainerStep({ onSelect }: DevcontainerStepProps): React.JSX.Element {
+  const [items, setItems] = useState<DevcontainerInfo[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    window.api.devcontainer
+      .list()
+      .then((list) => {
+        if (!cancelled) {
+          setItems(list)
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(String(err))
+          setItems([])
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {translate(
+            'auto.components.sidebar.AddRepoDevcontainerStep.title',
+            'Open a devcontainer'
+          )}
+        </DialogTitle>
+        <DialogDescription>
+          {translate(
+            'auto.components.sidebar.AddRepoDevcontainerStep.description',
+            'Pick a running devcontainer to manage as a project. Files and git stay on your machine; the agent runs inside the container.'
+          )}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-3 pt-2" data-testid="devcontainer-list">
+        {items === null ? (
+          <p className="text-sm text-muted-foreground">
+            {translate(
+              'auto.components.sidebar.AddRepoDevcontainerStep.loading',
+              'Loading devcontainers…'
+            )}
+          </p>
+        ) : items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {error
+              ? translate(
+                  'auto.components.sidebar.AddRepoDevcontainerStep.error',
+                  'Could not reach Docker. Make sure Docker/OrbStack is running.'
+                )
+              : translate(
+                  'auto.components.sidebar.AddRepoDevcontainerStep.empty',
+                  'No devcontainers found. Start one (e.g. “Reopen in Container”) and try again.'
+                )}
+          </p>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-input bg-background">
+            {items.map((info, index) => (
+              <button
+                key={info.containerId}
+                type="button"
+                data-testid="devcontainer-item"
+                onClick={() => onSelect(info)}
+                className={`flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-accent ${
+                  index > 0 ? 'border-t border-border/70' : ''
+                }`}
+              >
+                <Container className="size-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0">
+                  <span className="block truncate text-sm font-medium">
+                    {clientName(info.hostFolder)}
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {info.hostFolder}
+                    {info.running ? '' : ' · stopped'}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/renderer/src/components/sidebar/AddRepoDialog.default-checkout.test.ts
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.default-checkout.test.ts
@@ -32,6 +32,9 @@ describe('AddRepoDialog default-checkout handoff', () => {
     expect(source).toContain("onGitRepoReady(repo.id, 'clone_url')")
     expect(source).toContain("onGitRepoReady(repo.id, 'runtime_server_path')")
     expect(source).toContain('onGitRepoReady(repo.id, source)')
+    expect(source).toContain(
+      "onRepoReady: (repoId) => completeGitRepoAdd(repoId, 'local_folder_picker')"
+    )
   })
 
   it('does not fail nested import completion on non-authoritative refresh', () => {

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -282,6 +282,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
 
   const { handleSelectDevcontainer } = useAddRepoDevcontainerFlow({
     setIsAdding,
+    onRepoReady: (repoId) => completeGitRepoAdd(repoId, 'local_folder_picker'),
     onDone: resetState
   })
 

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -15,6 +15,7 @@ import { useCreateProjectDefaults } from './useCreateProjectDefaults'
 import { useAddRepoHostChangeReset } from './use-add-repo-host-change-reset'
 import { AddRepoDialogChrome } from './AddRepoDialogChrome'
 import { AddRepoHostSelectorSlot } from './AddRepoHostSelectorSlot'
+import { useAddRepoDevcontainerFlow } from './useAddRepoDevcontainerFlow'
 import { useAddRepoRemoteNestedScan } from './use-add-repo-remote-nested-scan'
 
 const AddRepoDialog = React.memo(function AddRepoDialog() {
@@ -279,6 +280,11 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     [closeModal, isAdding, resetState, step, trackNestedBackAction]
   )
 
+  const { handleSelectDevcontainer } = useAddRepoDevcontainerFlow({
+    setIsAdding,
+    onDone: resetState
+  })
+
   return (
     <AddRepoDialogChrome
       isOpen={isOpen}
@@ -328,6 +334,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
         browseHostKind={
           selectedHostKind === 'ssh' || selectedHostKind === 'runtime' ? selectedHostKind : 'local'
         }
+        onOpenDevcontainerStep={() => setStep('devcontainer')}
+        onSelectDevcontainer={handleSelectDevcontainer}
         createDefaultParent={createDefaultParent}
         createGitAvailability={createGitAvailability}
         createRuntimeParentStatus={createRuntimeParentStatus}

--- a/src/renderer/src/components/sidebar/AddRepoDialogStepContent.test.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogStepContent.test.tsx
@@ -63,6 +63,8 @@ function renderStepContent(overrides: Partial<StepContentProps>): string {
     onOpenCloneStep: vi.fn(),
     onOpenCreateStep: vi.fn(),
     onOpenRemoteStep: vi.fn(),
+    onOpenDevcontainerStep: vi.fn(),
+    onSelectDevcontainer: vi.fn(),
     onStopNestedScan: vi.fn(),
     onServerPathChange: vi.fn(),
     onAddServerPath: vi.fn(),

--- a/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
@@ -5,6 +5,8 @@ import { CreateStep } from './AddRepoCreateStep'
 import { AddRepoLocalStartStep } from './AddRepoStartSteps'
 import { AddRepoServerPathStartStep } from './AddRepoServerStartStep'
 import { AddRepoNestedImportStep } from './AddRepoNestedImportStep'
+import { AddRepoDevcontainerStep } from './AddRepoDevcontainerStep'
+import type { DevcontainerInfo } from '../../../../shared/devcontainer-types'
 import type { AddRepoDialogStep } from './add-repo-dialog-types'
 import type { NestedRepoScanResult } from '../../../../shared/types'
 import type { SshConnectionState, SshTarget } from '../../../../shared/ssh-types'
@@ -56,6 +58,8 @@ type AddRepoDialogStepContentProps = {
   onOpenCloneStep: () => void
   onOpenCreateStep: () => void
   onOpenRemoteStep: (targetId?: string | null) => void
+  onOpenDevcontainerStep: () => void
+  onSelectDevcontainer: (info: DevcontainerInfo) => void
   onStopNestedScan: () => void
   onServerPathChange: (path: string) => void
   onAddServerPath: (kind: 'git' | 'folder') => void
@@ -124,6 +128,8 @@ export function AddRepoDialogStepContent({
   onOpenCloneStep,
   onOpenCreateStep,
   onOpenRemoteStep,
+  onOpenDevcontainerStep,
+  onSelectDevcontainer,
   onStopNestedScan,
   onServerPathChange,
   onAddServerPath,
@@ -162,9 +168,14 @@ export function AddRepoDialogStepContent({
         onOpenCloneStep={onOpenCloneStep}
         onOpenRemoteStep={onOpenRemoteStep}
         onOpenCreateStep={onOpenCreateStep}
+        onOpenDevcontainerStep={onOpenDevcontainerStep}
         onStopNestedScan={onStopNestedScan}
       />
     )
+  }
+
+  if (step === 'devcontainer') {
+    return <AddRepoDevcontainerStep onSelect={onSelectDevcontainer} />
   }
 
   if (step === 'server-path') {

--- a/src/renderer/src/components/sidebar/AddRepoStartSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoStartSteps.tsx
@@ -74,6 +74,7 @@ type AddRepoLocalStartStepProps = {
   onOpenCloneStep: () => void
   onOpenRemoteStep: () => void
   onOpenCreateStep: () => void
+  onOpenDevcontainerStep?: () => void
   onStopNestedScan: () => void
 }
 
@@ -92,6 +93,7 @@ export function AddRepoLocalStartStep({
   onOpenCloneStep,
   onOpenRemoteStep,
   onOpenCreateStep,
+  onOpenDevcontainerStep,
   onStopNestedScan
 }: AddRepoLocalStartStepProps): React.JSX.Element {
   const browseActionRef = useRef<HTMLButtonElement | null>(null)
@@ -102,6 +104,7 @@ export function AddRepoLocalStartStep({
     onOpenCloneStep,
     onOpenRemoteStep,
     onOpenCreateStep,
+    onOpenDevcontainerStep,
     showRemoteAction,
     canCreateProject,
     browseHostKind

--- a/src/renderer/src/components/sidebar/AddRepoStepIndicator.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoStepIndicator.tsx
@@ -18,7 +18,8 @@ export function AddRepoStepIndicator({
     step === 'remote' ||
     step === 'server-path' ||
     step === 'create' ||
-    step === 'nested'
+    step === 'nested' ||
+    step === 'devcontainer'
 
   if (!showBack) {
     return null

--- a/src/renderer/src/components/sidebar/add-repo-dialog-types.ts
+++ b/src/renderer/src/components/sidebar/add-repo-dialog-types.ts
@@ -1,4 +1,11 @@
-export type AddRepoDialogStep = 'add' | 'clone' | 'remote' | 'server-path' | 'create' | 'nested'
+export type AddRepoDialogStep =
+  | 'add'
+  | 'clone'
+  | 'remote'
+  | 'server-path'
+  | 'create'
+  | 'nested'
+  | 'devcontainer'
 
 export function defaultProjectGroupNameForPath(path: string): string {
   return (

--- a/src/renderer/src/components/sidebar/add-repo-local-start-actions.ts
+++ b/src/renderer/src/components/sidebar/add-repo-local-start-actions.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from 'react'
-import { FolderOpen, Globe, Monitor, Plus } from 'lucide-react'
+import { Container, FolderOpen, Globe, Monitor, Plus } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 
 export type AddRepoLocalStartActionHandlers = {
@@ -7,13 +7,15 @@ export type AddRepoLocalStartActionHandlers = {
   onOpenCloneStep: () => void
   onOpenRemoteStep: () => void
   onOpenCreateStep: () => void
+  /** Optional — when provided, a "Devcontainer" entry is offered. */
+  onOpenDevcontainerStep?: () => void
   showRemoteAction?: boolean
   canCreateProject?: boolean
   browseHostKind?: 'local' | 'ssh' | 'runtime'
 }
 
 export type AddRepoLocalStartAction = {
-  kind: 'browse' | 'clone' | 'remote' | 'create'
+  kind: 'browse' | 'clone' | 'remote' | 'create' | 'devcontainer'
   icon: ComponentType<{ className?: string }>
   title: string
   description: string
@@ -27,6 +29,7 @@ export function getAddRepoLocalStartActions({
   onOpenCloneStep,
   onOpenRemoteStep,
   onOpenCreateStep,
+  onOpenDevcontainerStep,
   showRemoteAction = true,
   canCreateProject = true,
   browseHostKind = 'local'
@@ -111,11 +114,28 @@ export function getAddRepoLocalStartActions({
     onClick: onOpenCreateStep
   }
 
-  const secondaryActions = showRemoteAction
+  const devcontainer = onOpenDevcontainerStep
+    ? {
+        kind: 'devcontainer' as const,
+        icon: Container,
+        title: translate(
+          'auto.components.sidebar.add.repo.local.start.actions.devcontainerTitle',
+          'Devcontainer'
+        ),
+        description: translate(
+          'auto.components.sidebar.add.repo.local.start.actions.devcontainerDescription',
+          'Open a running devcontainer as a project'
+        ),
+        onClick: onOpenDevcontainerStep
+      }
+    : null
+
+  const baseSecondary = showRemoteAction
     ? isSshLikely
       ? [remote, clone, create]
       : [clone, remote, create]
     : [clone, create]
+  const secondaryActions = devcontainer ? [...baseSecondary, devcontainer] : baseSecondary
 
   return { primaryAction, secondaryActions }
 }

--- a/src/renderer/src/components/sidebar/add-repo-local-start-actions.ts
+++ b/src/renderer/src/components/sidebar/add-repo-local-start-actions.ts
@@ -125,7 +125,7 @@ export function getAddRepoLocalStartActions({
         ),
         description: translate(
           'auto.components.sidebar.add.repo.local.start.actions.devcontainerDescription',
-          'Open a running devcontainer as a project'
+          'Open a devcontainer as a project'
         ),
         onClick: onOpenDevcontainerStep
       }

--- a/src/renderer/src/components/sidebar/add-repo-local-start-actions.ts
+++ b/src/renderer/src/components/sidebar/add-repo-local-start-actions.ts
@@ -23,6 +23,7 @@ export type AddRepoLocalStartAction = {
   onClick: () => void
 }
 
+/** Build the Add-Project start-step actions (primary Browse + secondary entries). */
 export function getAddRepoLocalStartActions({
   isSshLikely,
   onBrowse,

--- a/src/renderer/src/components/sidebar/host-header-menu-items.ts
+++ b/src/renderer/src/components/sidebar/host-header-menu-items.ts
@@ -53,6 +53,10 @@ export function buildHostHeaderMenuModel(input: HostHeaderMenuInput): HostHeader
       break
     case 'local':
       break
+    case 'devcontainer':
+      // Why no host-level actions yet: devcontainer attach/lifecycle is
+      // resolved per-project at runtime; only rename/manage apply for now.
+      break
   }
 
   // Manage host… always closes out the list as the catch-all deep link.

--- a/src/renderer/src/components/sidebar/sidebar-host-options.ts
+++ b/src/renderer/src/components/sidebar/sidebar-host-options.ts
@@ -2,7 +2,8 @@ import type { GlobalSettings, Repo, WorkspaceHostScope } from '../../../../share
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
   LOCAL_EXECUTION_HOST_ID,
-  type ExecutionHostId
+  type ExecutionHostId,
+  type ExecutionHostKind
 } from '../../../../shared/execution-host'
 import {
   buildExecutionHostRegistry,
@@ -18,7 +19,7 @@ export type SidebarHostOption = {
   id: ExecutionHostId
   label: string
   detail: string
-  kind: 'local' | 'ssh' | 'runtime'
+  kind: ExecutionHostKind
   health: ExecutionHostHealth
   presence: 'local' | 'configured' | 'project' | 'active'
   // Why: surfaced to the sidebar host-header menu so it can warn on version skew.

--- a/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReactModule from 'react'
+import type { DevcontainerInfo } from '../../../../shared/devcontainer-types'
+import type { Repo } from '../../../../shared/types'
+
+const mocks = vi.hoisted(() => ({
+  storeState: {
+    addRepoPath: vi.fn(),
+    updateRepo: vi.fn(),
+    removeProject: vi.fn()
+  },
+  onRepoReady: vi.fn(),
+  onDone: vi.fn(),
+  setIsAdding: vi.fn()
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactModule>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: never[]) => unknown>(fn: T) => fn
+  }
+})
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: typeof mocks.storeState) => unknown) => selector(mocks.storeState)
+}))
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-devcontainer',
+    path: '/Users/me/work/aprium',
+    displayName: 'aprium',
+    badgeColor: '#999999',
+    addedAt: 1,
+    kind: 'folder',
+    ...overrides
+  }
+}
+
+function makeInfo(hostFolder = '/Users/me/work/aprium'): DevcontainerInfo {
+  return {
+    containerId: 'cid-1',
+    name: 'aprium-dev',
+    hostFolder,
+    configFile: `${hostFolder}/.devcontainer/devcontainer.json`,
+    running: true,
+    mounts: [{ source: hostFolder, destination: '/workspaces/aprium' }]
+  }
+}
+
+describe('useAddRepoDevcontainerFlow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes a successful devcontainer selection through the normal completion path', async () => {
+    const repo = makeRepo()
+    mocks.storeState.addRepoPath.mockResolvedValue(repo)
+    mocks.storeState.updateRepo.mockResolvedValue(true)
+    mocks.onRepoReady.mockResolvedValue(undefined)
+    const { useAddRepoDevcontainerFlow } = await import('./useAddRepoDevcontainerFlow')
+
+    const result = useAddRepoDevcontainerFlow({
+      setIsAdding: mocks.setIsAdding,
+      onRepoReady: mocks.onRepoReady,
+      onDone: mocks.onDone
+    })
+    await result.handleSelectDevcontainer(makeInfo())
+
+    expect(mocks.storeState.addRepoPath).toHaveBeenCalledWith('/Users/me/work/aprium', 'folder')
+    expect(mocks.storeState.updateRepo).toHaveBeenCalledWith(repo.id, {
+      executionHostId: 'devcontainer:%2FUsers%2Fme%2Fwork%2Faprium',
+      connectionId: 'devcontainer:%2FUsers%2Fme%2Fwork%2Faprium',
+      worktreeBasePath: '.worktrees'
+    })
+    expect(mocks.storeState.removeProject).not.toHaveBeenCalled()
+    expect(mocks.onRepoReady).toHaveBeenCalledWith(repo.id)
+    expect(mocks.onDone).toHaveBeenCalled()
+    expect(mocks.setIsAdding).toHaveBeenNthCalledWith(1, true)
+    expect(mocks.setIsAdding).toHaveBeenLastCalledWith(false)
+  })
+
+  it('rolls back a transient repo when routing updateRepo fails', async () => {
+    const repo = makeRepo()
+    mocks.storeState.addRepoPath.mockResolvedValue(repo)
+    mocks.storeState.updateRepo.mockResolvedValue(false)
+    const { useAddRepoDevcontainerFlow } = await import('./useAddRepoDevcontainerFlow')
+
+    const result = useAddRepoDevcontainerFlow({
+      setIsAdding: mocks.setIsAdding,
+      onRepoReady: mocks.onRepoReady,
+      onDone: mocks.onDone
+    })
+    await result.handleSelectDevcontainer(makeInfo())
+
+    expect(mocks.storeState.removeProject).toHaveBeenCalledWith(repo.id)
+    expect(mocks.onRepoReady).not.toHaveBeenCalled()
+    expect(mocks.onDone).not.toHaveBeenCalled()
+  })
+
+  it('rolls back a transient repo when routing updateRepo rejects', async () => {
+    const repo = makeRepo()
+    mocks.storeState.addRepoPath.mockResolvedValue(repo)
+    mocks.storeState.updateRepo.mockRejectedValue(new Error('disk full'))
+    const { useAddRepoDevcontainerFlow } = await import('./useAddRepoDevcontainerFlow')
+
+    const result = useAddRepoDevcontainerFlow({
+      setIsAdding: mocks.setIsAdding,
+      onRepoReady: mocks.onRepoReady,
+      onDone: mocks.onDone
+    })
+    await result.handleSelectDevcontainer(makeInfo())
+
+    expect(mocks.storeState.removeProject).toHaveBeenCalledWith(repo.id)
+    expect(mocks.onRepoReady).not.toHaveBeenCalled()
+    expect(mocks.onDone).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.test.ts
@@ -33,7 +33,7 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
     displayName: 'aprium',
     badgeColor: '#999999',
     addedAt: 1,
-    kind: 'folder',
+    kind: 'git',
     ...overrides
   }
 }
@@ -68,7 +68,7 @@ describe('useAddRepoDevcontainerFlow', () => {
     })
     await result.handleSelectDevcontainer(makeInfo())
 
-    expect(mocks.storeState.addRepoPath).toHaveBeenCalledWith('/Users/me/work/aprium', 'folder')
+    expect(mocks.storeState.addRepoPath).toHaveBeenCalledWith('/Users/me/work/aprium', 'git')
     expect(mocks.storeState.updateRepo).toHaveBeenCalledWith(repo.id, {
       executionHostId: 'devcontainer:%2FUsers%2Fme%2Fwork%2Faprium',
       connectionId: 'devcontainer:%2FUsers%2Fme%2Fwork%2Faprium',

--- a/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.ts
@@ -30,7 +30,10 @@ export function useAddRepoDevcontainerFlow({
       setIsAdding(true)
       let repo: Repo | null = null
       try {
-        repo = await addRepoPath(info.hostFolder, 'folder')
+        // Why: devcontainer projects should preserve git capabilities when the
+        // mounted host folder is a repo. `addRepoPath(..., 'git')` keeps SCM and
+        // worktree wiring intact instead of downgrading to folder mode.
+        repo = await addRepoPath(info.hostFolder, 'git')
         if (!repo) {
           return
         }

--- a/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.ts
@@ -5,6 +5,7 @@ import {
   DEVCONTAINER_WORKTREE_BASE_PATH,
   type DevcontainerInfo
 } from '../../../../shared/devcontainer-types'
+import type { Repo } from '../../../../shared/types'
 
 /**
  * Add-Project "Devcontainer" flow: create a repo on the devcontainer's host
@@ -13,33 +14,45 @@ import {
  */
 export function useAddRepoDevcontainerFlow({
   setIsAdding,
+  onRepoReady,
   onDone
 }: {
   setIsAdding: (busy: boolean) => void
+  onRepoReady: (repoId: string) => Promise<void>
   onDone: () => void
 }): { handleSelectDevcontainer: (info: DevcontainerInfo) => Promise<void> } {
   const addRepoPath = useAppStore((s) => s.addRepoPath)
   const updateRepo = useAppStore((s) => s.updateRepo)
+  const removeProject = useAppStore((s) => s.removeProject)
 
   const handleSelectDevcontainer = useCallback(
     async (info: DevcontainerInfo) => {
       setIsAdding(true)
+      let repo: Repo | null = null
       try {
-        const repo = await addRepoPath(info.hostFolder, 'folder')
-        if (repo) {
-          const hostId = toDevcontainerExecutionHostId(info.hostFolder)
-          await updateRepo(repo.id, {
-            executionHostId: hostId,
-            connectionId: hostId,
-            worktreeBasePath: DEVCONTAINER_WORKTREE_BASE_PATH
-          })
+        repo = await addRepoPath(info.hostFolder, 'folder')
+        if (!repo) {
+          return
         }
+        const hostId = toDevcontainerExecutionHostId(info.hostFolder)
+        const updated = await updateRepo(repo.id, {
+          executionHostId: hostId,
+          connectionId: hostId,
+          worktreeBasePath: DEVCONTAINER_WORKTREE_BASE_PATH
+        }).catch(() => false)
+        if (!updated) {
+          // Why: if the devcontainer routing update fails, remove the transient
+          // repo row so the Add-Project flow does not leave a half-configured entry.
+          await removeProject(repo.id)
+          return
+        }
+        await onRepoReady(repo.id)
+        onDone()
       } finally {
         setIsAdding(false)
-        onDone()
       }
     },
-    [addRepoPath, updateRepo, setIsAdding, onDone]
+    [addRepoPath, onDone, onRepoReady, removeProject, setIsAdding, updateRepo]
   )
 
   return { handleSelectDevcontainer }

--- a/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoDevcontainerFlow.ts
@@ -1,0 +1,46 @@
+import { useCallback } from 'react'
+import { useAppStore } from '@/store'
+import { toDevcontainerExecutionHostId } from '../../../../shared/execution-host'
+import {
+  DEVCONTAINER_WORKTREE_BASE_PATH,
+  type DevcontainerInfo
+} from '../../../../shared/devcontainer-types'
+
+/**
+ * Add-Project "Devcontainer" flow: create a repo on the devcontainer's host
+ * bind-mount folder, then bind it to the devcontainer execution host so the
+ * terminal runs via `docker exec` and worktrees live inside the mount.
+ */
+export function useAddRepoDevcontainerFlow({
+  setIsAdding,
+  onDone
+}: {
+  setIsAdding: (busy: boolean) => void
+  onDone: () => void
+}): { handleSelectDevcontainer: (info: DevcontainerInfo) => Promise<void> } {
+  const addRepoPath = useAppStore((s) => s.addRepoPath)
+  const updateRepo = useAppStore((s) => s.updateRepo)
+
+  const handleSelectDevcontainer = useCallback(
+    async (info: DevcontainerInfo) => {
+      setIsAdding(true)
+      try {
+        const repo = await addRepoPath(info.hostFolder, 'folder')
+        if (repo) {
+          const hostId = toDevcontainerExecutionHostId(info.hostFolder)
+          await updateRepo(repo.id, {
+            executionHostId: hostId,
+            connectionId: hostId,
+            worktreeBasePath: DEVCONTAINER_WORKTREE_BASE_PATH
+          })
+        }
+      } finally {
+        setIsAdding(false)
+        onDone()
+      }
+    },
+    [addRepoPath, updateRepo, setIsAdding, onDone]
+  )
+
+  return { handleSelectDevcontainer }
+}

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -90,6 +90,8 @@ export type RepoUpdate = Partial<
     | 'hookSettings'
     | 'worktreeBaseRef'
     | 'worktreeBasePath'
+    | 'executionHostId'
+    | 'connectionId'
     | 'kind'
     | 'symlinkPaths'
     | 'issueSourcePreference'

--- a/src/shared/devcontainer-types.ts
+++ b/src/shared/devcontainer-types.ts
@@ -1,0 +1,34 @@
+/**
+ * Devcontainer DTO types shared across main, preload, and renderer.
+ *
+ * These live in `shared` (not `main`) so the preload `api` surface and the
+ * renderer Add-Project UI can reference them without importing main-only modules
+ * (which would break the renderer/preload project boundary).
+ */
+
+/** Worktrees live inside the bind mount so the in-container agent can see them. */
+export const DEVCONTAINER_WORKTREE_BASE_PATH = '.worktrees'
+
+/** One bind/volume mount from `docker inspect` `.Mounts[]`. */
+export type ContainerMount = {
+  /** Absolute host path (`.Mounts[].Source`). */
+  source: string
+  /** Absolute in-container path (`.Mounts[].Destination`). */
+  destination: string
+}
+
+/** A discovered devcontainer the Add-Project flow can offer as a project. */
+export type DevcontainerInfo = {
+  /** Current container id (changes when the container is recreated). */
+  containerId: string
+  /** Container name without the leading slash docker reports. */
+  name: string
+  /** Host workspace folder (`devcontainer.local_folder`) — the bind-mount root. */
+  hostFolder: string
+  /** Path to the devcontainer.json, when the label is present. */
+  configFile: string | null
+  /** Whether the container is currently running. */
+  running: boolean
+  /** Bind/volume mounts, for host↔container path translation. */
+  mounts: ContainerMount[]
+}

--- a/src/shared/execution-host.test.ts
+++ b/src/shared/execution-host.test.ts
@@ -9,6 +9,9 @@ import {
   normalizeExecutionHostScope,
   normalizeVisibleExecutionHostIds,
   parseExecutionHostId,
+  getExecutionHostLabel,
+  isLocalFilesystemHost,
+  toDevcontainerExecutionHostId,
   toRuntimeExecutionHostId,
   toSshExecutionHostId
 } from './execution-host'
@@ -32,6 +35,27 @@ describe('execution host identity', () => {
       id: 'runtime:prod%2Fserver',
       environmentId: 'prod/server'
     })
+  })
+
+  it('round-trips devcontainer host ids and labels by folder basename', () => {
+    const id = toDevcontainerExecutionHostId('/Users/me/work/aprium')
+    expect(id).toBe('devcontainer:%2FUsers%2Fme%2Fwork%2Faprium')
+    expect(parseExecutionHostId(id)).toEqual({
+      kind: 'devcontainer',
+      id: 'devcontainer:%2FUsers%2Fme%2Fwork%2Faprium',
+      containerKey: '/Users/me/work/aprium'
+    })
+    expect(getExecutionHostLabel(id)).toBe('aprium')
+    // An empty/invalid devcontainer id is rejected like the other kinds.
+    expect(parseExecutionHostId('devcontainer:')).toBeNull()
+  })
+
+  it('treats local and devcontainer as local-filesystem hosts, but not ssh/runtime', () => {
+    expect(isLocalFilesystemHost(LOCAL_EXECUTION_HOST_ID)).toBe(true)
+    expect(isLocalFilesystemHost(toDevcontainerExecutionHostId('/Users/me/work/aprium'))).toBe(true)
+    expect(isLocalFilesystemHost(toSshExecutionHostId('vm'))).toBe(false)
+    expect(isLocalFilesystemHost(toRuntimeExecutionHostId('prod'))).toBe(false)
+    expect(isLocalFilesystemHost(null)).toBe(false)
   })
 
   it('labels the local host by platform and by navigator detection', () => {

--- a/src/shared/execution-host.ts
+++ b/src/shared/execution-host.ts
@@ -3,8 +3,12 @@ import type { GlobalSettings, Repo } from './types'
 export const LOCAL_EXECUTION_HOST_ID = 'local'
 export const ALL_EXECUTION_HOSTS_SCOPE = 'all'
 
-export type ExecutionHostKind = 'local' | 'ssh' | 'runtime'
-export type ExecutionHostId = typeof LOCAL_EXECUTION_HOST_ID | `ssh:${string}` | `runtime:${string}`
+export type ExecutionHostKind = 'local' | 'ssh' | 'runtime' | 'devcontainer'
+export type ExecutionHostId =
+  | typeof LOCAL_EXECUTION_HOST_ID
+  | `ssh:${string}`
+  | `runtime:${string}`
+  | `devcontainer:${string}`
 
 export type ExecutionHostScope = typeof ALL_EXECUTION_HOSTS_SCOPE | ExecutionHostId
 
@@ -12,6 +16,10 @@ export type ParsedExecutionHost =
   | { kind: 'local'; id: typeof LOCAL_EXECUTION_HOST_ID }
   | { kind: 'ssh'; id: `ssh:${string}`; targetId: string }
   | { kind: 'runtime'; id: `runtime:${string}`; environmentId: string }
+  // Why containerKey (not a live container id): containers are recreated with a
+  // new id, so the host is keyed by something stable (the devcontainer's host
+  // folder) and re-resolved to the current container at attach time.
+  | { kind: 'devcontainer'; id: `devcontainer:${string}`; containerKey: string }
 
 function getCurrentLocalPlatform(): NodeJS.Platform | null {
   const globalNavigator = (globalThis as { navigator?: { userAgent?: string; platform?: string } })
@@ -56,6 +64,10 @@ export function toRuntimeExecutionHostId(environmentId: string): `runtime:${stri
   return `runtime:${encodeURIComponent(environmentId)}`
 }
 
+export function toDevcontainerExecutionHostId(containerKey: string): `devcontainer:${string}` {
+  return `devcontainer:${encodeURIComponent(containerKey)}`
+}
+
 export function parseExecutionHostId(value: string | null | undefined): ParsedExecutionHost | null {
   const normalized = normalizeHostPart(value)
   if (!normalized) {
@@ -88,11 +100,37 @@ export function parseExecutionHostId(value: string | null | undefined): ParsedEx
       return null
     }
   }
+  if (normalized.startsWith('devcontainer:')) {
+    const encoded = normalized.slice('devcontainer:'.length)
+    if (!encoded) {
+      return null
+    }
+    try {
+      const containerKey = decodeURIComponent(encoded)
+      return containerKey
+        ? { kind: 'devcontainer', id: `devcontainer:${encoded}`, containerKey }
+        : null
+    } catch {
+      return null
+    }
+  }
   return null
 }
 
 export function normalizeExecutionHostId(value: string | null | undefined): ExecutionHostId | null {
   return parseExecutionHostId(value)?.id ?? null
+}
+
+/**
+ * True when the host's filesystem, git, and worktrees live on THIS machine's
+ * disk: a local host, or a devcontainer whose project is bind-mounted from the
+ * host. Devcontainers run only the *terminal* inside the container (via
+ * `docker exec`); files and git are managed host-side on the same inodes, so
+ * they reuse the local providers and local worktree machinery.
+ */
+export function isLocalFilesystemHost(value: string | null | undefined): boolean {
+  const kind = parseExecutionHostId(value)?.kind
+  return kind === 'local' || kind === 'devcontainer'
 }
 
 export function normalizeExecutionHostScope(value: string | null | undefined): ExecutionHostScope {
@@ -164,5 +202,9 @@ export function getExecutionHostLabel(id: ExecutionHostScope): string {
       return parsed.targetId
     case 'runtime':
       return parsed.environmentId
+    case 'devcontainer':
+      // Why basename: the key is the devcontainer's host folder; its last
+      // segment ("aprium") is the recognizable client/project name.
+      return parsed.containerKey.split('/').filter(Boolean).pop() ?? parsed.containerKey
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -251,7 +251,7 @@ export type Repo = {
    * Explicit execution owner for this repo. Runtime-host repos need this
    * because they otherwise look identical to local repos (`connectionId: null`).
    */
-  executionHostId?: 'local' | `ssh:${string}` | `runtime:${string}` | null
+  executionHostId?: ExecutionHostId | null
   /** Per-repo override for issue-source resolution. `undefined` is treated
    *  identically to `'auto'`; writers leave it undefined on creation so
    *  existing persisted records stay forward-compatible. */
@@ -3105,7 +3105,12 @@ export type ActiveRightSidebarTab = Exclude<RightSidebarTab, 'search'>
 export type RightSidebarExplorerView = 'files' | 'search'
 
 export type ProjectOrderBy = 'manual' | 'recent'
-export type WorkspaceHostScope = 'all' | 'local' | `ssh:${string}` | `runtime:${string}`
+export type WorkspaceHostScope =
+  | 'all'
+  | 'local'
+  | `ssh:${string}`
+  | `runtime:${string}`
+  | `devcontainer:${string}`
 export type VisibleWorkspaceHostIds = Exclude<WorkspaceHostScope, 'all'>[] | null
 export type WorkspaceHostOrder = Exclude<WorkspaceHostScope, 'all'>[]
 

--- a/tests/e2e/add-project-devcontainer.spec.ts
+++ b/tests/e2e/add-project-devcontainer.spec.ts
@@ -1,4 +1,5 @@
 import type { ElectronApplication } from 'playwright'
+import { posix } from 'node:path'
 import { test, expect } from './helpers/orca-app'
 
 /**
@@ -7,27 +8,36 @@ import { test, expect } from './helpers/orca-app'
  * renders their client/folder info.
  */
 async function stubDevcontainerList(app: ElectronApplication): Promise<void> {
-  await app.evaluate(({ ipcMain }) => {
-    ipcMain.removeHandler('devcontainer:list')
-    ipcMain.handle('devcontainer:list', () => [
-      {
-        containerId: 'c-aprium',
-        name: 'aprium-dev',
-        hostFolder: '/Users/me/work/aprium',
-        configFile: '/Users/me/work/aprium/.devcontainer/devcontainer.json',
-        running: true,
-        mounts: [{ source: '/Users/me/work/aprium', destination: '/workspaces/aprium' }]
-      },
-      {
-        containerId: 'c-lac',
-        name: 'lac-dev',
-        hostFolder: '/Users/me/work/lac',
-        configFile: null,
-        running: false,
-        mounts: [{ source: '/Users/me/work/lac', destination: '/workspaces/lac' }]
-      }
-    ])
-  })
+  const apriumHostFolder = posix.join('/Users', 'me', 'work', 'aprium')
+  const lacHostFolder = posix.join('/Users', 'me', 'work', 'lac')
+  const apriumConfigFile = posix.join(apriumHostFolder, '.devcontainer', 'devcontainer.json')
+  await app.evaluate(
+    (
+      { ipcMain },
+      paths: { apriumHostFolder: string; lacHostFolder: string; apriumConfigFile: string }
+    ) => {
+      ipcMain.removeHandler('devcontainer:list')
+      ipcMain.handle('devcontainer:list', () => [
+        {
+          containerId: 'c-aprium',
+          name: 'aprium-dev',
+          hostFolder: paths.apriumHostFolder,
+          configFile: paths.apriumConfigFile,
+          running: true,
+          mounts: [{ source: paths.apriumHostFolder, destination: '/workspaces/aprium' }]
+        },
+        {
+          containerId: 'c-lac',
+          name: 'lac-dev',
+          hostFolder: paths.lacHostFolder,
+          configFile: null,
+          running: false,
+          mounts: [{ source: paths.lacHostFolder, destination: '/workspaces/lac' }]
+        }
+      ])
+    },
+    { apriumHostFolder, lacHostFolder, apriumConfigFile }
+  )
 }
 
 test.describe('Add project from devcontainer', () => {
@@ -37,7 +47,10 @@ test.describe('Add project from devcontainer', () => {
   }, testInfo) => {
     await stubDevcontainerList(electronApp)
 
-    await orcaPage.getByRole('button', { name: /Add Project/i }).first().click()
+    await orcaPage
+      .getByRole('button', { name: /Add Project/i })
+      .first()
+      .click()
     const addDialog = orcaPage.getByRole('dialog', { name: /Add a project/i })
     await expect(addDialog).toBeVisible()
 

--- a/tests/e2e/add-project-devcontainer.spec.ts
+++ b/tests/e2e/add-project-devcontainer.spec.ts
@@ -1,0 +1,61 @@
+import type { ElectronApplication } from 'playwright'
+import { test, expect } from './helpers/orca-app'
+
+/**
+ * Verifies the Add-Project "Devcontainer" source: with `devcontainer:list`
+ * stubbed (no Docker needed), opening the source lists the devcontainers and
+ * renders their client/folder info.
+ */
+async function stubDevcontainerList(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ ipcMain }) => {
+    ipcMain.removeHandler('devcontainer:list')
+    ipcMain.handle('devcontainer:list', () => [
+      {
+        containerId: 'c-aprium',
+        name: 'aprium-dev',
+        hostFolder: '/Users/me/work/aprium',
+        configFile: '/Users/me/work/aprium/.devcontainer/devcontainer.json',
+        running: true,
+        mounts: [{ source: '/Users/me/work/aprium', destination: '/workspaces/aprium' }]
+      },
+      {
+        containerId: 'c-lac',
+        name: 'lac-dev',
+        hostFolder: '/Users/me/work/lac',
+        configFile: null,
+        running: false,
+        mounts: [{ source: '/Users/me/work/lac', destination: '/workspaces/lac' }]
+      }
+    ])
+  })
+}
+
+test.describe('Add project from devcontainer', () => {
+  test('lists devcontainers in the Add-Project Devcontainer source', async ({
+    orcaPage,
+    electronApp
+  }, testInfo) => {
+    await stubDevcontainerList(electronApp)
+
+    await orcaPage.getByRole('button', { name: /Add Project/i }).first().click()
+    const addDialog = orcaPage.getByRole('dialog', { name: /Add a project/i })
+    await expect(addDialog).toBeVisible()
+
+    await addDialog.getByRole('button', { name: /Devcontainer/i }).click()
+
+    // The stubbed devcontainers render as selectable items.
+    const items = orcaPage.getByTestId('devcontainer-item')
+    await expect(items).toHaveCount(2)
+    await expect(items.first()).toContainText('aprium')
+    await expect(items.first()).toContainText('/Users/me/work/aprium')
+    await expect(items.nth(1)).toContainText('stopped')
+
+    await orcaPage.screenshot({
+      path: testInfo.outputPath('devcontainer-source.png')
+    })
+    await testInfo.attach('devcontainer-source', {
+      path: testInfo.outputPath('devcontainer-source.png'),
+      contentType: 'image/png'
+    })
+  })
+})

--- a/tests/e2e/helpers/electron-launch-args.ts
+++ b/tests/e2e/helpers/electron-launch-args.ts
@@ -11,6 +11,10 @@ export function getOrcaElectronLaunchArgs(mainPath: string, headful: boolean): s
     '--disable-gpu-sandbox',
     '--disable-dev-shm-usage',
     '--in-process-gpu',
+    // Why: unprivileged containers (no user-namespace / non-suid sandbox) can't
+    // start Chromium's sandbox; opt out so headless E2E runs there. Gated on an
+    // env var so CI keeps its sandboxed default.
+    ...(process.env.ORCA_E2E_NO_SANDBOX === '1' ? ['--no-sandbox'] : []),
     mainPath
   ]
 }


### PR DESCRIPTION
## Add Project from a Devcontainer

Adds a new **Add Project → Devcontainer** source: open a running devcontainer as an Orca project and run agents inside it.

### Why
Orca can already target local folders, git repos, and SSH remote hosts — but not the devcontainers many of us already run (e.g. one per client). This lets you point Orca at a running devcontainer and have agents execute in that container's toolchain, the way "Reopen in Container" works in VS Code.

### How it works — the hybrid model
A devcontainer's project folder is **bind-mounted** from the host, so:
- **Files + git stay host-side** — Orca reuses the existing local filesystem/git providers on the bind-mounted path (native speed, no in-container bridge).
- **Only the terminal/agent runs inside** the container, via a new PTY provider over `docker exec`.

A devcontainer is therefore "local for files/git, container for execution."

### Relation to #6419
#6419 ("Add devcontainer runtime setup helper") and this PR are **two different approaches to devcontainer support**, and they touch disjoint files (no conflict):

- **#6419 — devcontainer as a paired *runtime*.** Orca's daemon/relay runs **inside** the container; you pair to it (`--environment`/`--pairing-code`) and a new **CLI** command imports a checkout + sets a persistent (absolute, in-container) `worktreeBasePath`.
- **This PR — devcontainer via `docker exec`.** **No daemon in the container, no pairing.** Orca stays on the host, discovers containers by label, and drives them with `docker exec` via a new `devcontainer:` execution-host kind, surfaced as a **GUI** Add-Project source.

They serve slightly different users (already-running-Orca-in-container vs. plain devcontainers with zero extra setup) and could coexist as a CLI path and a GUI path. The one shared concept is **worktrees must persist in a bind-mounted path**: #6419 sets an absolute in-container path manually; this PR uses a relative `.worktrees` base + `git worktree add --relative-paths` automatically. If both land, it's worth reconciling the two `worktreeBasePath` conventions. Happy to align on a single direction if maintainers prefer one model.

### Key pieces
- **New `devcontainer` execution-host kind** (`shared/execution-host.ts`) — id `devcontainer:<host-folder>`, parse/label helpers, and `isLocalFilesystemHost`.
- **`main/devcontainer/`** — docker CLI client, label-based discovery (`devcontainer.local_folder`), host↔container **path translation**, a **secure `docker exec` arg builder** (secret env forwarded via `-e NAME`, never placed in argv), the **`DockerPtyProvider`** (`IPtyProvider` over `docker exec`), and a **`DevcontainerRuntime`** that resolves the container by a stable key, starts it if stopped, and forwards agent env.
- **PTY routing** (`ipc/pty.ts`) — devcontainer hosts route to the docker provider (lazily registered on first spawn); all SSH-only id-wrapping / lease paths are guarded so the SSH path is untouched.
- **Worktrees** — devcontainer repos root worktrees **inside** the bind mount and create them with `git worktree add --relative-paths`, so gitdir pointers resolve from **both** the host path and the in-container path. (Verified empirically; an absolute-pointer worktree breaks inside the container, a relative one doesn't.)
- **IPC + UI** — `devcontainer:list` IPC + typed `api.devcontainer.list()`, and the Add-Project picker + create flow that binds the new repo to the devcontainer execution host (`executionHostId`/`connectionId` + `.worktrees` base path).

### Screenshot
The Add-Project "Devcontainer" picker (from the e2e run):

<!-- attach test-results/.../devcontainer-source.png -->

### Testing
- **Unit:** path-map, discovery, docker-exec-command, docker-pty-provider, devcontainer-runtime, project-fields, and the execution-host kind.
- **E2E** (`add-project-from-devcontainer.spec.ts`): stubs `devcontainer:list` and verifies the picker renders the devcontainers.
- `typecheck` (node/web/cli), `oxlint`, and `oxlint --type-aware` (switch exhaustiveness) all pass.

### Notes / requirements
- Requires **git ≥ 2.48** on host **and** in the container (for `--relative-paths`).
- The **live agent-in-container path** (an agent actually running via `docker exec`) is exercised manually against a real Docker/OrbStack — CI/e2e stubs `devcontainer:list` since there's no daemon there.
- `tests/e2e/helpers/electron-launch-args.ts` gains an **opt-in** `--no-sandbox` (gated on `ORCA_E2E_NO_SANDBOX=1`) so the headless e2e can run in unprivileged containers; CI's sandboxed default is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

You can add a running Docker devcontainer as an Orca project and run agents inside its toolchain. Bridges the gap when you already work in VS Code-style containers.
