### PR TITLE
Preserve SSH pre-Codex scrollback on tab restore

### DIFF
--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -498,6 +498,27 @@ describe('HeadlessEmulator', () => {
       expect(snapshot.rehydrateSequences).toContain('\x1b[?1006h')
       expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
     })
+
+    it('preserves pre-alternate-screen content with opt-in mode', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+      await emulator.write('PRE_CODEX_START\nls | head -5\n')
+      await emulator.write('\x1b[?1049h')
+      await emulator.write('TUI_FRAME\n')
+
+      const defaultSnapshot = emulator.getSnapshot({ scrollbackRows: 10 })
+      expect(defaultSnapshot.snapshotAnsi).not.toContain('PRE_CODEX_START')
+      expect(defaultSnapshot.snapshotAnsi).toContain('TUI_FRAME')
+      expect(defaultSnapshot.rehydrateSequences).toContain('\x1b[?1049h')
+
+      const preservedSnapshot = emulator.getSnapshot({
+        scrollbackRows: 10,
+        preserveNormalBufferOnAltScreen: true
+      })
+      expect(preservedSnapshot.snapshotAnsi).toContain('PRE_CODEX_START')
+      expect(preservedSnapshot.snapshotAnsi).toContain('TUI_FRAME')
+      expect(preservedSnapshot.snapshotAnsi).toContain('\x1b[?1049h')
+      expect(preservedSnapshot.rehydrateSequences).toBe('')
+    })
   })
 
   describe('dispose', () => {

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -126,12 +126,15 @@ export class HeadlessEmulator {
     this.terminal.resize(cols, rows)
   }
 
-  getSnapshot(opts: { scrollbackRows?: number } = {}): TerminalSnapshot {
+  getSnapshot(
+    opts: { scrollbackRows?: number; preserveNormalBufferOnAltScreen?: boolean } = {}
+  ): TerminalSnapshot {
     const modes = this.getModes()
-    const snapshotAnsi = this.normalizeSnapshotAnsiForModes(
-      this.serializer.serialize({ scrollback: opts.scrollbackRows }),
-      modes
-    )
+    const rawSnapshotAnsi = this.serializer.serialize({ scrollback: opts.scrollbackRows })
+    const snapshotAnsi =
+      opts.preserveNormalBufferOnAltScreen && modes.alternateScreen
+        ? rawSnapshotAnsi
+        : this.normalizeSnapshotAnsiForModes(rawSnapshotAnsi, modes)
     return {
       snapshotAnsi,
       scrollbackAnsi: '',
@@ -140,7 +143,12 @@ export class HeadlessEmulator {
         opts.scrollbackRows,
         this.restoredOscLinks
       ),
-      rehydrateSequences: this.buildRehydrateSequences(modes),
+      // Why: opt-in alternate-screen snapshots already include the raw ?1049h
+      // marker in snapshotAnsi, so adding rehydrate sequences would duplicate it.
+      rehydrateSequences:
+        opts.preserveNormalBufferOnAltScreen && modes.alternateScreen
+          ? ''
+          : this.buildRehydrateSequences(modes),
       cwd: this.cwd,
       modes,
       cols: this.terminal.cols,

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8185,6 +8185,27 @@ describe('OrcaRuntimeService', () => {
     expect(snapshot?.data).not.toContain('line-0')
   })
 
+  it('preserves pre-alternate-screen shell output when explicitly requested for remote snapshots', async () => {
+    const runtime = createRuntime()
+    syncSinglePty(runtime, 'pty-1')
+
+    runtime.onPtyData('pty-1', 'PRE_CODEX_START\nls | head -5\n', 100)
+    runtime.onPtyData('pty-1', '\x1b[?1049hTUI_FRAME\n', 200)
+
+    const defaultSnapshot = await runtime.serializeTerminalBuffer('pty-1', { scrollbackRows: 100 })
+    const optInSnapshot = await runtime.serializeTerminalBuffer('pty-1', {
+      scrollbackRows: 100,
+      altScreenPreservesScrollback: true
+    })
+
+    expect(defaultSnapshot?.data).not.toContain('PRE_CODEX_START')
+    expect(defaultSnapshot?.data).toContain('TUI_FRAME')
+    expect(optInSnapshot?.data).toContain('PRE_CODEX_START')
+    expect(optInSnapshot?.data).toContain('TUI_FRAME')
+    expect(optInSnapshot?.data).toContain('\x1b[?1049h')
+    expect(optInSnapshot?.source).toBe('headless')
+  })
+
   it('waits for terminal exit and resolves with the exit status', async () => {
     const runtime = new OrcaRuntimeService(store)
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5190,7 +5190,7 @@ export class OrcaRuntimeService {
 
   serializeTerminalBuffer(
     ptyId: string,
-    opts: { scrollbackRows?: number } = {}
+    opts: { scrollbackRows?: number; altScreenPreservesScrollback?: boolean } = {}
   ): Promise<{
     data: string
     cols: number
@@ -5442,7 +5442,7 @@ export class OrcaRuntimeService {
 
   private async serializeTerminalBufferFromAvailableState(
     ptyId: string,
-    opts: { scrollbackRows?: number } = {}
+    opts: { scrollbackRows?: number; altScreenPreservesScrollback?: boolean } = {}
   ): Promise<{
     data: string
     cols: number
@@ -5538,7 +5538,8 @@ export class OrcaRuntimeService {
 
   private async serializeHeadlessTerminalBuffer(
     ptyId: string,
-    opts: { scrollbackRows?: number; includeEmpty?: boolean } = {}
+    opts: { scrollbackRows?: number; includeEmpty?: boolean; altScreenPreservesScrollback?: boolean } =
+      {}
   ): Promise<{
     data: string
     cols: number
@@ -5562,8 +5563,15 @@ export class OrcaRuntimeService {
     // caller can request scrollback so the user can scroll up to see prior
     // agent output.
     const requested = opts.scrollbackRows ?? 0
-    const scrollbackRows = state.emulator.isAlternateScreen ? 0 : requested
-    const snapshot = state.emulator.getSnapshot({ scrollbackRows })
+    const shouldPreserveAltScreen = opts.altScreenPreservesScrollback === true
+    const scrollbackRows = state.emulator.isAlternateScreen && !shouldPreserveAltScreen
+      ? 0
+      : requested
+    const snapshot = state.emulator.getSnapshot({
+      scrollbackRows,
+      preserveNormalBufferOnAltScreen:
+        opts.altScreenPreservesScrollback === true && state.emulator.isAlternateScreen
+    })
     const data = snapshot.rehydrateSequences + snapshot.snapshotAnsi
     return data.length > 0 || opts.includeEmpty === true
       ? {

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -389,11 +389,18 @@ function requestedSnapshotScrollbackCandidates(requestedRows: number | undefined
 async function serializeBudgetedRequestedSnapshot(
   runtime: OrcaRuntimeService,
   ptyId: string,
-  scrollbackRows: number | undefined
+  scrollbackRows: number | undefined,
+  options: { altScreenPreservesScrollback?: boolean } = {}
 ): Promise<SerializedSnapshot> {
   const requestedRows = scrollbackRows ?? 0
   for (const rows of requestedSnapshotScrollbackCandidates(scrollbackRows)) {
-    const serialized = await runtime.serializeTerminalBuffer(ptyId, { scrollbackRows: rows })
+    const requestOptions = options.altScreenPreservesScrollback === false
+      ? { scrollbackRows: rows }
+      : {
+          scrollbackRows: rows,
+          altScreenPreservesScrollback: true
+        }
+    const serialized = await runtime.serializeTerminalBuffer(ptyId, requestOptions)
     if (!serialized) {
       return null
     }
@@ -1307,7 +1314,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           let serialized = await serializeBudgetedRequestedSnapshot(
             runtime,
             stream.ptyId,
-            scrollbackRows
+            scrollbackRows,
+            { altScreenPreservesScrollback: !stream.isMobile }
           )
           if (closed || streams.get(stream.streamId) !== stream) {
             return
@@ -1323,7 +1331,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             serialized = await serializeBudgetedRequestedSnapshot(
               runtime,
               stream.ptyId,
-              scrollbackRows
+              scrollbackRows,
+              { altScreenPreservesScrollback: !stream.isMobile }
             )
             if (closed || streams.get(stream.streamId) !== stream) {
               return

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -223,7 +223,8 @@ describe('terminal multiplex RPC', () => {
         requestId: 7
       })
       expect(runtime.serializeTerminalBuffer).toHaveBeenLastCalledWith('pty-1', {
-        scrollbackRows: 5000
+        scrollbackRows: 5000,
+        altScreenPreservesScrollback: true
       })
       expect(
         requestedSnapshotFrames
@@ -237,6 +238,95 @@ describe('terminal multiplex RPC', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('does not forward alternate-screen snapshot flag for mobile snapshot requests', async () => {
+    const messages: string[] = []
+    const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+    const handlers = new Map<
+      number,
+      (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+    >()
+    const cleanups = new Map<string, () => void>()
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+      serializeTerminalBuffer: vi.fn().mockResolvedValue({
+        data: 'snapshot',
+        cols: 120,
+        rows: 40
+      }),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
+      getTerminalFitOverride: vi.fn().mockReturnValue(null),
+      getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+      handleMobileSubscribe: vi.fn().mockResolvedValue(undefined),
+      handleMobileUnsubscribe: vi.fn().mockResolvedValue(undefined),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+      sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
+      updateDesktopViewport: vi.fn().mockResolvedValue(true)
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.multiplex', {}),
+      (msg) => messages.push(msg),
+      {
+        connectionId: 'conn-mobile-request',
+        sendBinary: (bytes) => binaryFrames.push(bytes),
+        registerBinaryStreamHandler: (streamId, handler) => {
+          handlers.set(streamId, handler)
+          return () => handlers.delete(streamId)
+        }
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'ready')).toBe(true)
+    )
+    handlers.get(0)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Subscribe,
+          streamId: 0,
+          seq: 1,
+          payload: encodeTerminalStreamJson({
+            streamId: 11,
+            terminal: 'terminal-1',
+            client: { id: 'phone-1', type: 'mobile' },
+            viewport: { cols: 120, rows: 40 }
+          })
+        })
+      )!
+    )
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+    )
+    handlers.get(11)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.SnapshotRequest,
+          streamId: 11,
+          seq: 2,
+          payload: encodeTerminalStreamJson({ requestId: 9, scrollbackRows: 5000 })
+        })
+      )!
+    )
+    await vi.waitFor(() => expect(runtime.serializeTerminalBuffer).toHaveBeenCalledTimes(2))
+    expect(runtime.serializeTerminalBuffer).toHaveBeenLastCalledWith('pty-1', {
+      scrollbackRows: 5000
+    })
+
+    cleanups.get('terminal-multiplex:conn-mobile-request')?.()
+    await dispatchPromise
   })
 
   it('drops stale mobile resize re-stream completions for multiplex streams', async () => {
@@ -657,10 +747,12 @@ describe('terminal multiplex RPC', () => {
       truncatedByByteBudget: true
     })
     expect(runtime.serializeTerminalBuffer).toHaveBeenNthCalledWith(2, 'pty-1', {
-      scrollbackRows: 5000
+      scrollbackRows: 5000,
+      altScreenPreservesScrollback: true
     })
     expect(runtime.serializeTerminalBuffer).toHaveBeenNthCalledWith(3, 'pty-1', {
-      scrollbackRows: 1000
+      scrollbackRows: 1000,
+      altScreenPreservesScrollback: true
     })
     expect(
       requestedFrames


### PR DESCRIPTION
## Summary

- Preserves shell output that exists before Codex enters alternate screen when an SSH terminal tab is restored after being backgrounded.
- Keeps the live desktop `SnapshotRequest` path in `runtime.serializeTerminalBuffer` and `HeadlessEmulator.getSnapshot` opt-in to preserving that pre-alternate content while still capturing the active TUI frame.
- Leaves mobile and default alternate-screen normalization behavior intact unless the caller opts into `altScreenPreservesScrollback`.

Closes #6106.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/headless-emulator.test.ts` - passed.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts` - passed.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-multiplex.test.ts` - passed.
- [x] `pnpm run typecheck:node` - passed.
- [ ] `pnpm run typecheck` (pending).

## AI Review Report

Reviewed for targeted blast radius:
- Data-loss path: `src/main/daemon/headless-emulator.ts` now keeps raw alternate-screen snapshot when `preserveNormalBufferOnAltScreen` is true and emits `rehydrateSequences: ''`, preventing duplicate `?1049h` replay.
- Serialization path: `src/main/runtime/orca-runtime.ts` now threads `altScreenPreservesScrollback` only through live headless snapshots and only flips the alternate-screen scrollback clamp for the opt-in path.
- Routing path: `src/main/runtime/rpc/methods/terminal.ts` now passes the new flag only for desktop `SnapshotRequest` (`stream.isMobile === false`) and leaves mobile unchanged.
- Regression tests in daemon snapshot, runtime payload serialization, and multiplex forwarding cover the behavior on desktop and assert no mobile flag forwarding regression.
- Residual risk is low and isolated to remote desktop restore semantics where `?1049h` and scrollback composition changed.

## Security Audit

The change only affects terminal snapshot payload assembly and request forwarding for existing IPC/RPC paths.
- No new network endpoints, file I/O, subprocess execution, or auth flows were introduced.
- No secrets, credentials, or remote credentials are serialized by this change.
- The extra snapshot payload content is terminal-visible history already present in the session, so there is no expanded privilege boundary.
- No provider-specific logic was introduced.

## Notes

- Scope is limited to the live desktop SSH restore path. Renderer hidden-output replay policy, mobile snapshot normalization, and SSH reconnect replay remain unchanged.
- Related prior work: https://github.com/stablyai/orca/pull/5786 established the alternate-screen scrollback boundary for a different restore surface; this target keeps that boundary and applies it to the live SSH snapshot path.
- This issue remains separate from #6043.
