### PR TITLE
feat(compare): cross-worktree side-by-side review (terminals + per-worktree diff)

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -35,6 +35,8 @@ import {
 } from './editor/editor-autosave'
 import { isIntentionalAppRestartInProgress } from '@/lib/updater-beforeunload'
 import EditorAutosaveController from './editor/EditorAutosaveController'
+import CompareStrip from './compare/CompareStrip'
+import { getWorktreeActiveTerminalPane } from './compare/worktree-active-pane'
 import type { Tab, TabContentType, TabGroupLayoutNode, TuiAgent } from '../../../shared/types'
 import { hasFeatureInteraction } from '../../../shared/feature-interactions'
 import BrowserPane from './browser-pane/BrowserPane'
@@ -276,8 +278,10 @@ function Terminal(): React.JSX.Element | null {
   // activeTabId here used to flash the wrong terminal — selectThread updates
   // the store in multiple steps and intermediate renders briefly pointed the
   // portal at the new worktree's stale last-active tab.
+  const compareWorktreeIds = useAppStore((s) => s.compareWorktreeIds)
+  const compareOn = compareWorktreeIds != null && compareWorktreeIds.length > 0
   const activityTerminalPortals: ActivityTerminalPortalTarget[] = useActivityTerminalPortals(
-    activeView === 'activity'
+    activeView === 'activity' || compareOn
   )
   const foregroundTerminalWorktreeIds = useMemo(() => {
     const ids = new Set<string>()
@@ -296,6 +300,55 @@ function Terminal(): React.JSX.Element | null {
     setForegroundTerminalWorktreeIds(foregroundTerminalWorktreeIds)
     return () => setForegroundTerminalWorktreeIds([])
   }, [foregroundTerminalWorktreeIds])
+
+  // Side-by-side trigger. Hotkey ⌘/Ctrl+Shift+\ toggles compare on the active
+  // worktree + the first other mounted worktree with a live terminal. Also
+  // exposed as window.__orcaCompare([ids]) for explicit selection / scripting.
+  useEffect(() => {
+    const w = window as unknown as { __orcaCompare?: (ids?: string[] | null) => void }
+    const enterCompareAuto = (): void => {
+      const state = useAppStore.getState()
+      const active = state.activeWorktreeId
+      const others = Array.from(mountedWorktreeIdsRef.current).filter(
+        (id) => id !== active && getWorktreeActiveTerminalPane(state, id)
+      )
+      const picked = [active, others[0]].filter((id): id is string => typeof id === 'string')
+      if (picked.length < 2) {
+        console.warn('[compare] need 2 worktrees with live terminals; got', picked)
+        return
+      }
+      state.setCompareWorktreeIds(picked)
+    }
+    w.__orcaCompare = (ids) => {
+      const state = useAppStore.getState()
+      if (ids === null) {
+        state.setCompareWorktreeIds(null)
+      } else if (ids && ids.length > 0) {
+        state.setCompareWorktreeIds(ids)
+      } else {
+        enterCompareAuto()
+      }
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      // Why: platform-correct modifier per AGENTS.md (metaKey mac, ctrlKey else).
+      // e.code (not e.key) because Shift+\ yields '|' on US layouts.
+      const mod = navigator.userAgent.includes('Mac') ? event.metaKey : event.ctrlKey
+      if (mod && event.shiftKey && event.code === 'Backslash') {
+        event.preventDefault()
+        const state = useAppStore.getState()
+        if (state.compareWorktreeIds) {
+          state.setCompareWorktreeIds(null)
+        } else {
+          enterCompareAuto()
+        }
+      }
+    }
+    window.addEventListener('keydown', onKeyDown, { capture: true })
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, { capture: true })
+      delete w.__orcaCompare
+    }
+  }, [])
 
   const tabs = useMemo(
     () => (renderedActiveWorktreeId ? (tabsByWorktree[renderedActiveWorktreeId] ?? []) : []),
@@ -1723,10 +1776,11 @@ function Terminal(): React.JSX.Element | null {
 
   return (
     <div
-      className={`flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${renderedActiveWorktreeId ? '' : ' hidden'}`}
+      className={`relative flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${renderedActiveWorktreeId ? '' : ' hidden'}`}
       data-rendered-active-worktree-id={renderedActiveWorktreeId ?? undefined}
     >
       <EditorAutosaveController />
+      {compareOn && compareWorktreeIds ? <CompareStrip worktreeIds={compareWorktreeIds} /> : null}
 
       {/* Why: once split groups are enabled, each group owns its own tab strip
           inline. The old titlebar portal stays only as a fallback
@@ -1809,7 +1863,7 @@ function Terminal(): React.JSX.Element | null {
               // Why: use strict equality with 'terminal' instead of !== 'settings'
               // so the terminal/browser surface hides on the tasks page too.
               const isVisible =
-                activeView === 'terminal' && workspace.id === renderedActiveWorktreeId
+                activeView === 'terminal' && !compareOn && workspace.id === renderedActiveWorktreeId
               const shouldMeasureHiddenWorktree =
                 !isVisible && measurableBackgroundWorktreeIdsRef.current.has(workspace.id)
               return (
@@ -1869,7 +1923,9 @@ function Terminal(): React.JSX.Element | null {
                 // Why: use strict equality with 'terminal' instead of !== 'settings'
                 // so the terminal/browser surface hides on the tasks page too.
                 const isVisible =
-                  activeView === 'terminal' && workspace.id === renderedActiveWorktreeId
+                  activeView === 'terminal' &&
+                  !compareOn &&
+                  workspace.id === renderedActiveWorktreeId
                 const shouldMeasureHiddenWorktree =
                   !isVisible && measurableBackgroundWorktreeIdsRef.current.has(workspace.id)
                 return (
@@ -1944,7 +2000,7 @@ function Terminal(): React.JSX.Element | null {
               // Why: use strict equality with 'terminal' instead of !== 'settings'
               // so browser panes also hide on the tasks page.
               const isVisibleWorktree =
-                activeView === 'terminal' && workspace.id === renderedActiveWorktreeId
+                activeView === 'terminal' && !compareOn && workspace.id === renderedActiveWorktreeId
               if (browserTabs.length === 0) {
                 return null
               }

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -308,11 +308,17 @@ function Terminal(): React.JSX.Element | null {
     const w = window as unknown as { __orcaCompare?: (ids?: string[] | null) => void }
     const enterCompareAuto = (): void => {
       const state = useAppStore.getState()
-      const active = state.activeWorktreeId
-      const others = Array.from(mountedWorktreeIdsRef.current).filter(
-        (id) => id !== active && getWorktreeActiveTerminalPane(state, id)
+      // Only worktrees with a resolvable terminal pane are eligible — including
+      // the active one, so its Agent column never portals nothing and blanks.
+      const withTerminal = Array.from(mountedWorktreeIdsRef.current).filter((id) =>
+        getWorktreeActiveTerminalPane(state, id)
       )
-      const picked = [active, others[0]].filter((id): id is string => typeof id === 'string')
+      const active = state.activeWorktreeId
+      const ordered =
+        active && withTerminal.includes(active)
+          ? [active, ...withTerminal.filter((id) => id !== active)]
+          : withTerminal
+      const picked = ordered.slice(0, 2)
       if (picked.length < 2) {
         console.warn('[compare] need 2 worktrees with live terminals; got', picked)
         return

--- a/src/renderer/src/components/compare/CompareStrip.tsx
+++ b/src/renderer/src/components/compare/CompareStrip.tsx
@@ -7,6 +7,7 @@ import {
 } from '../activity/activity-terminal-portal'
 import { getWorktreeActiveTerminalPane } from './worktree-active-pane'
 import CombinedDiffViewer from '../editor/CombinedDiffViewer'
+import { translate } from '@/i18n/i18n'
 
 type ColumnMode = 'agent' | 'changes'
 
@@ -16,7 +17,8 @@ function worktreePathFromId(id: string): string {
   return i === -1 ? id : id.slice(i + 2)
 }
 function shortName(path: string): string {
-  const parts = path.split('/').filter(Boolean)
+  // Why: split on both separators so Windows (backslash) paths segment too.
+  const parts = path.split(/[/\\]/).filter(Boolean)
   return parts.at(-1) ?? path
 }
 
@@ -39,7 +41,7 @@ function ChangesPane({
   if (!file) {
     return (
       <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
-        Loading changes…
+        {translate('compare.loadingChanges', 'Loading changes…')}
       </div>
     )
   }
@@ -133,10 +135,10 @@ export default function CompareStrip({
           >
             <div className="relative z-20 flex items-center gap-2 h-9 px-2 border-b border-border bg-card/60 text-xs shrink-0">
               <span
-                className={`w-1.5 h-1.5 rounded-full shrink-0 ${id === activeWorktreeId ? 'bg-green-500' : 'bg-muted-foreground/40'}`}
+                className={`w-1.5 h-1.5 rounded-full shrink-0 ${id === activeWorktreeId ? 'bg-status-success' : 'bg-muted-foreground/40'}`}
               />
               <span
-                className="font-mono text-[11px] text-muted-foreground truncate flex-1"
+                className="font-mono text-xs text-muted-foreground truncate flex-1"
                 title={path}
               >
                 {shortName(path)}
@@ -145,17 +147,17 @@ export default function CompareStrip({
                 <button
                   type="button"
                   onClick={() => setMode('agent')}
-                  className={`px-2 py-0.5 rounded text-[11px] ${mode === 'agent' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50'}`}
+                  className={`px-2 py-0.5 rounded text-xs ${mode === 'agent' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50'}`}
                 >
-                  Agent
+                  {translate('compare.agentTab', 'Agent')}
                 </button>
                 <button
                   type="button"
                   onClick={() => setMode('changes')}
-                  className={`px-2 py-0.5 rounded text-[11px] flex items-center gap-1 ${mode === 'changes' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50'}`}
+                  className={`px-2 py-0.5 rounded text-xs flex items-center gap-1 ${mode === 'changes' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50'}`}
                 >
-                  Changes
-                  <span className="font-mono text-[10px] rounded-full bg-background px-1.5">
+                  {translate('compare.changesTab', 'Changes')}
+                  <span className="font-mono text-xs rounded-full bg-background px-1.5">
                     {count}
                   </span>
                 </button>

--- a/src/renderer/src/components/compare/CompareStrip.tsx
+++ b/src/renderer/src/components/compare/CompareStrip.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '@/store'
+import {
+  setActivityTerminalPortals,
+  type ActivityTerminalPortalTarget
+} from '../activity/activity-terminal-portal'
+import { getWorktreeActiveTerminalPane } from './worktree-active-pane'
+import CombinedDiffViewer from '../editor/CombinedDiffViewer'
+
+type ColumnMode = 'agent' | 'changes'
+
+// The worktree id is `${repoUuid}::${absolutePath}`; openAllDiffs needs the path.
+function worktreePathFromId(id: string): string {
+  const i = id.indexOf('::')
+  return i === -1 ? id : id.slice(i + 2)
+}
+function shortName(path: string): string {
+  const parts = path.split('/').filter(Boolean)
+  return parts.at(-1) ?? path
+}
+
+// Renders one worktree's combined uncommitted diff (collapsible per-file
+// sections) by reusing Orca's own openAllDiffs action + CombinedDiffViewer.
+function ChangesPane({
+  worktreeId,
+  worktreePath
+}: {
+  worktreeId: string
+  worktreePath: string
+}): React.JSX.Element {
+  const openAllDiffs = useAppStore((s) => s.openAllDiffs)
+  const file = useAppStore((s) =>
+    s.openFiles.find((f) => f.id === `${worktreeId}::all-diffs::uncommitted`)
+  )
+  useEffect(() => {
+    openAllDiffs(worktreeId, worktreePath)
+  }, [worktreeId, worktreePath, openAllDiffs])
+  if (!file) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+        Loading changes…
+      </div>
+    )
+  }
+  return <CombinedDiffViewer file={file} viewStateKey={`compare:${worktreeId}`} />
+}
+
+// Side-by-side compare columns. Each column shows either its worktree's agent
+// terminal (portaled in — the agent keeps running) or its combined diff. Only
+// one worktree is ever "active", so there's no single-foreground collision.
+export default function CompareStrip({
+  worktreeIds
+}: {
+  worktreeIds: string[]
+}): React.JSX.Element {
+  const columnRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+  const [modes, setModes] = useState<Record<string, ColumnMode>>({})
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const changeCounts = useAppStore(
+    useShallow((s) => worktreeIds.map((id) => (s.gitStatusByWorktree[id] ?? []).length))
+  )
+  // Primitive change-detection key (avoids the getSnapshot infinite-loop).
+  const panesKey = useAppStore((s) =>
+    worktreeIds
+      .map((id) => {
+        const pane = getWorktreeActiveTerminalPane(s, id)
+        return `${id}=${pane?.paneKey ?? ''}`
+      })
+      .join('|')
+  )
+
+  const setColumnRef = useCallback((node: HTMLDivElement | null): void => {
+    if (node) {
+      columnRefs.current.set(node.dataset.compareWorktreeId ?? '', node)
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    const state = useAppStore.getState()
+    const active = state.activeWorktreeId
+    // Fail-safe: exit compare to the normal view if a compared worktree is gone
+    // or the active worktree fell outside the set (e.g. last terminal closed →
+    // setActiveWorktree(null)). Don't require a terminal — a column may be
+    // reviewing (its active tab is the diff, not the terminal).
+    const stillValid =
+      worktreeIds.length >= 2 &&
+      active != null &&
+      worktreeIds.includes(active) &&
+      worktreeIds.every((id) => state.tabsByWorktree[id] !== undefined)
+    if (!stillValid) {
+      state.setCompareWorktreeIds(null)
+      return
+    }
+    const descriptors: ActivityTerminalPortalTarget[] = []
+    worktreeIds.forEach((id, index) => {
+      // Reviewing columns don't portal a terminal; the agent stays alive in its
+      // (hidden) worktree surface and re-appears when you switch back to Agent.
+      if ((modes[id] ?? 'agent') !== 'agent') {
+        return
+      }
+      const pane = getWorktreeActiveTerminalPane(state, id)
+      const target = columnRefs.current.get(id)
+      if (!pane || !target) {
+        return
+      }
+      descriptors.push({
+        slotId: `compare-${index}`,
+        requestToken: pane.paneKey,
+        target,
+        worktreeId: id,
+        tabId: pane.tabId,
+        paneKey: pane.paneKey,
+        active: id === state.activeWorktreeId
+      })
+    })
+    setActivityTerminalPortals(descriptors)
+  }, [panesKey, worktreeIds, activeWorktreeId, modes])
+
+  useEffect(() => () => setActivityTerminalPortals([]), [])
+
+  return (
+    <div className="absolute inset-0 z-10 flex bg-background">
+      {worktreeIds.map((id, index) => {
+        const mode = modes[id] ?? 'agent'
+        const path = worktreePathFromId(id)
+        const count = changeCounts[index] ?? 0
+        const setMode = (m: ColumnMode): void => setModes((prev) => ({ ...prev, [id]: m }))
+        return (
+          <div
+            key={id}
+            className="relative flex-1 min-w-0 min-h-0 flex flex-col border-l border-border/40 first:border-l-0"
+          >
+            <div className="relative z-20 flex items-center gap-2 h-9 px-2 border-b border-border bg-card/60 text-xs shrink-0">
+              <span
+                className={`w-1.5 h-1.5 rounded-full shrink-0 ${id === activeWorktreeId ? 'bg-green-500' : 'bg-muted-foreground/40'}`}
+              />
+              <span
+                className="font-mono text-[11px] text-muted-foreground truncate flex-1"
+                title={path}
+              >
+                {shortName(path)}
+              </span>
+              <div className="flex gap-0.5 shrink-0">
+                <button
+                  type="button"
+                  onClick={() => setMode('agent')}
+                  className={`px-2 py-0.5 rounded text-[11px] ${mode === 'agent' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50'}`}
+                >
+                  Agent
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMode('changes')}
+                  className={`px-2 py-0.5 rounded text-[11px] flex items-center gap-1 ${mode === 'changes' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50'}`}
+                >
+                  Changes
+                  <span className="font-mono text-[10px] rounded-full bg-background px-1.5">
+                    {count}
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div className="relative flex-1 min-h-0 flex flex-col">
+              {mode === 'agent' ? (
+                <div
+                  ref={setColumnRef}
+                  data-compare-worktree-id={id}
+                  className="absolute inset-0"
+                />
+              ) : (
+                <ChangesPane worktreeId={id} worktreePath={path} />
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/compare/worktree-active-pane.ts
+++ b/src/renderer/src/components/compare/worktree-active-pane.ts
@@ -1,0 +1,39 @@
+import type { AppState } from '@/store/types'
+import { isTerminalLeafId, makePaneKey } from '../../../../shared/stable-pane-id'
+
+export type WorktreeActivePane = { tabId: string; paneKey: string }
+
+type ResolverState = Pick<
+  AppState,
+  'groupsByWorktree' | 'activeGroupIdByWorktree' | 'tabsByWorktree' | 'terminalLayoutsByTabId'
+>
+
+// Resolves a worktree's currently-focused terminal pane (tab + durable paneKey)
+// WITHOUT the active-worktree gate getFocusedAgentPaneKeyForWorktree applies, so a
+// backgrounded worktree's terminal can be portaled into a side-by-side column.
+// Returns null when the worktree's active tab isn't a terminal.
+export function getWorktreeActiveTerminalPane(
+  state: ResolverState,
+  worktreeId: string
+): WorktreeActivePane | null {
+  // tabsByWorktree holds the worktree's terminal tabs.
+  const terminalTabs = state.tabsByWorktree[worktreeId] ?? []
+  if (terminalTabs.length === 0) {
+    return null
+  }
+  // Prefer the active group's active tab when it's a terminal; otherwise fall
+  // back to the first terminal tab. Why: this must NOT require the worktree's
+  // active tab to currently BE a terminal — a compare column flips the worktree
+  // to its diff (editor) when reviewing, and we still need to portal its agent
+  // terminal back when switching to Agent. (Otherwise: black screen.)
+  const groups = state.groupsByWorktree[worktreeId] ?? []
+  const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
+  const group = groups.find((candidate) => candidate.id === activeGroupId) ?? groups[0]
+  const preferredTabId = group?.activeTabId
+  const tab = terminalTabs.find((candidate) => candidate.id === preferredTabId) ?? terminalTabs[0]
+  const activeLeafId = state.terminalLayoutsByTabId[tab.id]?.activeLeafId
+  if (!activeLeafId || !isTerminalLeafId(activeLeafId)) {
+    return null
+  }
+  return { tabId: tab.id, paneKey: makePaneKey(tab.id, activeLeafId) }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11883,5 +11883,10 @@
         }
       }
     }
+  },
+  "compare": {
+    "loadingChanges": "Loading changes…",
+    "agentTab": "Agent",
+    "changesTab": "Changes"
   }
 }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11883,5 +11883,10 @@
         }
       }
     }
+  },
+  "compare": {
+    "loadingChanges": "Loading changes…",
+    "agentTab": "Agent",
+    "changesTab": "Changes"
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11883,5 +11883,10 @@
         }
       }
     }
+  },
+  "compare": {
+    "loadingChanges": "Loading changes…",
+    "agentTab": "Agent",
+    "changesTab": "Changes"
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11883,5 +11883,10 @@
         }
       }
     }
+  },
+  "compare": {
+    "loadingChanges": "Loading changes…",
+    "agentTab": "Agent",
+    "changesTab": "Changes"
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11883,5 +11883,10 @@
         }
       }
     }
+  },
+  "compare": {
+    "loadingChanges": "Loading changes…",
+    "agentTab": "Agent",
+    "changesTab": "Changes"
   }
 }

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -544,6 +544,10 @@ export type UISlice = {
   acknowledgedAgentsByPaneKey: Record<string, number>
   acknowledgeAgents: (paneKeys: string[]) => void
   unacknowledgeAgents: (paneKeys: string[]) => void
+  // Side-by-side: when non-null, render these worktrees' terminals as columns
+  // (via the activity terminal-portal store) instead of the single active one.
+  compareWorktreeIds: string[] | null
+  setCompareWorktreeIds: (ids: string[] | null) => void
   activeView:
     | 'terminal'
     | 'settings'
@@ -1137,6 +1141,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   previousViewBeforeSkills: 'terminal',
   previousViewBeforeMobile: 'terminal',
   setActiveView: (view) => set({ activeView: view }),
+  compareWorktreeIds: null,
+  setCompareWorktreeIds: (ids) => set({ compareWorktreeIds: ids }),
   taskPageData: {},
   taskResumeState: undefined,
   githubTaskDrawerWorkItem: null,


### PR DESCRIPTION
## What this adds

A **side-by-side compare view**: two worktrees rendered as columns, each independently switchable between its **live Agent terminal** and a **Changes (diff) review** — so you can watch/drive two agents at once *and* review either one's diff, without losing the other.

## The problem it solves

Today Orca shows **one worktree at a time** — switching worktrees swaps the whole view. That's by design: the terminal stack assumes a single "foreground" worktree (terminals are mounted once and positioned via a global anchor; hibernation, the foreground set, and overlay visibility all key off the single active worktree).

The naive fix — rendering two worktree surfaces visible at once — **breaks that invariant**: both worktrees become "active", their terminals collide over the shared foreground/anchor machinery, and one PTY ends up mirrored into every column. So a real side-by-side needs to respect the single-active model, not fight it.

## The approach (reuse, not rewrite)

- **Terminals:** relocate each worktree's *already-mounted* terminal into a column using the existing **Activity terminal-portal** primitive (`setActivityTerminalPortals` + `createPortal`). The terminal stays mounted once in its own surface; only one worktree is ever `active`, so there's no foreground collision. A reviewing column simply stops publishing its terminal portal — the agent keeps running in the background and re-appears on switch-back.
- **Diffs:** rendered per-worktree via the existing `openAllDiffs` + `CombinedDiffViewer`. The git data is already worktree-keyed (`gitStatusByWorktree`), so no portal trick is needed — the diff viewer just renders for the column's `worktreeId`.
- **Layout:** the underlying worktree surfaces are hidden while compare is on, so nothing renders behind the columns to compete for the Monaco/diff models.

## UX

- Two columns; each header has **Agent | Changes (N)** tabs (N = that worktree's change count).
- **Agent** = the live terminal. **Changes** = that worktree's combined uncommitted diff (collapsible per-file sections). The *other* column keeps running its agent throughout.
- **Fail-safe:** compare exits cleanly to the normal single-worktree view if a compared worktree is closed or removed (e.g. its last terminal closes → `setActiveWorktree(null)`), so closing never strands a half-portaled layout.

## Entry points (intentionally minimal — feedback welcome)

- **Hotkey:** `Cmd/Ctrl+Shift+\` toggles compare on the active worktree + the first other mounted worktree with a live terminal.
- **Scripting:** `window.__orcaCompare([idA, idB])` for explicit selection.

These are deliberately small; happy to wire a proper toolbar control / command-palette entry + worktree picker if the team wants this to land.

## Files

- **New:** `src/renderer/src/components/compare/{CompareStrip.tsx, worktree-active-pane.ts}`
- **Touched:** `src/renderer/src/components/Terminal.tsx`, `src/renderer/src/store/slices/ui.ts` (`compareWorktreeIds`)

## Testing

- Manual in a local production build: two agents (Claude Code + Codex) side-by-side; per-column **Agent ⇄ Changes**; both agents stay live; close/exit fail-safe; per-worktree diffs render correctly.
- `tsgo` typecheck + `oxlint` clean. Rebased on current `main`.

## Open questions for maintainers

1. Direction on the entry UI (toolbar button + worktree picker vs. hotkey/scripting only).
2. Should >2 columns be supported, or cap at 2?
3. On closing one compared worktree, prefer **exit compare** (current) or **collapse to the surviving column full-screen**?

Screenshots / short demo to follow in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

A side-by-side compare view shows two worktrees at once. Each column can show a live agent terminal or that worktree’s diff so you can watch two agents or review both without swapping.
