### PR TITLE
Disambiguate sidebar project setup groups

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -538,9 +538,6 @@ describe('buildRows with pinned worktrees', () => {
   })
 
   it('splits same-host checkouts of one project into separate per-setup groups', () => {
-    // Why: multiple local clones/worktrees of one repo share the GitHub slug, so
-    // collapsing to the project would merge them into one arbitrarily-named group.
-    // They are distinct ProjectHostSetups on the same host and must stay separate.
     const repoB: Repo = { ...repo, id: 'repo-2', path: '/tmp/orca-2', displayName: 'orca-2' }
     const worktreeB: Worktree = {
       ...worktree,
@@ -599,6 +596,146 @@ describe('buildRows with pinned worktrees', () => {
         })
       ])
     )
+  })
+
+  it('splits all project setups when one host has duplicate checkouts', () => {
+    const localRepoB: Repo = {
+      ...repo,
+      id: 'repo-local-b',
+      path: '/tmp/orca-b',
+      displayName: 'orca-b'
+    }
+    const localWorktreeB: Worktree = {
+      ...worktree,
+      id: 'wt-local-b',
+      repoId: localRepoB.id,
+      path: '/tmp/orca-b-feature',
+      displayName: 'feature-b'
+    }
+    const localSetupB: ProjectHostSetup = {
+      ...projectHostSetups[0]!,
+      id: localRepoB.id,
+      repoId: localRepoB.id,
+      path: localRepoB.path,
+      displayName: localRepoB.displayName
+    }
+    const rows = buildRows(
+      'repo',
+      [worktree, localWorktreeB, remoteWorktree],
+      new Map([
+        [repo.id, repo],
+        [localRepoB.id, localRepoB],
+        [remoteRepo.id, remoteRepo]
+      ]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([
+        [worktree.id, worktree],
+        [localWorktreeB.id, localWorktreeB],
+        [remoteWorktree.id, remoteWorktree]
+      ]),
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      [],
+      {
+        projects: [{ ...project, sourceRepoIds: [repo.id, localRepoB.id, remoteRepo.id] }],
+        projectHostSetups: [projectHostSetups[0]!, localSetupB, projectHostSetups[1]!]
+      }
+    )
+
+    const headers = rows.filter((row) => row.type === 'header')
+    expect(headers.map((row) => row.key)).toEqual([
+      'project:github:stablyai/orca::setup:repo-1',
+      'project:github:stablyai/orca::setup:repo-local-b',
+      'project:github:stablyai/orca::setup:repo-remote'
+    ])
+  })
+
+  it('groups Windows host and WSL setups on the same runtime host', () => {
+    const runtimeHostId = 'runtime:g16'
+    const windowsRepo: Repo = {
+      ...repo,
+      id: 'repo-windows',
+      path: String.raw`C:\Users\alice\git\orca`,
+      displayName: 'orca',
+      executionHostId: runtimeHostId
+    }
+    const wslRepo: Repo = {
+      ...repo,
+      id: 'repo-wsl',
+      path: String.raw`\\wsl.localhost\Ubuntu\home\alice\git\orca`,
+      displayName: 'orca',
+      executionHostId: runtimeHostId
+    }
+    const windowsWorktree: Worktree = {
+      ...worktree,
+      id: 'wt-windows',
+      repoId: windowsRepo.id,
+      path: String.raw`C:\Users\alice\git\orca\feature`
+    }
+    const wslWorktree: Worktree = {
+      ...worktree,
+      id: 'wt-wsl',
+      repoId: wslRepo.id,
+      path: String.raw`\\wsl.localhost\Ubuntu\home\alice\git\orca\feature`
+    }
+    const windowsSetup: ProjectHostSetup = {
+      ...projectHostSetups[0]!,
+      id: windowsRepo.id,
+      hostId: runtimeHostId,
+      repoId: windowsRepo.id,
+      path: windowsRepo.path,
+      displayName: windowsRepo.displayName
+    }
+    const wslSetup: ProjectHostSetup = {
+      ...windowsSetup,
+      id: wslRepo.id,
+      repoId: wslRepo.id,
+      path: wslRepo.path
+    }
+    const rows = buildRows(
+      'repo',
+      [windowsWorktree, wslWorktree],
+      new Map([
+        [windowsRepo.id, windowsRepo],
+        [wslRepo.id, wslRepo]
+      ]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([
+        [windowsWorktree.id, windowsWorktree],
+        [wslWorktree.id, wslWorktree]
+      ]),
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      [],
+      {
+        projects: [{ ...project, sourceRepoIds: [windowsRepo.id, wslRepo.id] }],
+        projectHostSetups: [windowsSetup, wslSetup]
+      }
+    )
+
+    expect(rows.filter((row) => row.type === 'header')).toMatchObject([
+      {
+        key: 'project:github:stablyai/orca',
+        label: 'Orca',
+        count: 2
+      }
+    ])
   })
 
   it('uses saved host labels for mixed-host sidebar card badges', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -35,6 +35,7 @@ import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from '../../store/slic
 import { getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
 import { translate } from '@/i18n/i18n'
 import { getExecutionHostLabel, getRepoExecutionHostId } from '../../../../shared/execution-host'
+import { parseWslUncPath } from '../../../../shared/wsl-paths'
 
 export { branchName }
 
@@ -139,16 +140,22 @@ type WorktreeGroupEntry = {
 type ProjectGroupingIndex = {
   projectById: Map<string, Project>
   setupByRepoId: Map<string, ProjectHostSetup>
-  // Why: `${projectId}::${hostId}` pairs that back more than one setup — i.e. the
-  // same project checked out multiple times on one host (independent clones or
-  // worktrees). Those setups must not collapse into a single project group.
-  multiSetupProjectHostKeys: Set<string>
+  projectIdsRequiringSetupGroups: Set<string>
 }
 
 const projectGroupingIndexCache = new WeakMap<ProjectGroupingModel, ProjectGroupingIndex | null>()
 
-function projectHostKey(projectId: string, hostId: string): string {
-  return `${projectId}::${hostId}`
+function getProjectSetupSurfaceKey(setup: ProjectHostSetup): string {
+  const wslPath = parseWslUncPath(setup.path)
+  if (wslPath) {
+    // Why: Windows host and WSL on one machine are separate execution surfaces;
+    // only duplicate checkouts within the same surface make project grouping ambiguous.
+    return `${setup.projectId}::${setup.hostId}::wsl:${wslPath.distro.toLowerCase()}`
+  }
+  if (/^[A-Za-z]:[\\/]/.test(setup.path)) {
+    return `${setup.projectId}::${setup.hostId}::windows-host`
+  }
+  return `${setup.projectId}::${setup.hostId}::default`
 }
 
 function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupingIndex | null {
@@ -165,21 +172,21 @@ function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupin
     projectGroupingIndexCache.set(model, null)
     return null
   }
-  const setupCountByProjectHost = new Map<string, number>()
+  const setupCountByProjectSurface = new Map<string, number>()
   for (const setup of projectHostSetups) {
-    const key = projectHostKey(setup.projectId, setup.hostId)
-    setupCountByProjectHost.set(key, (setupCountByProjectHost.get(key) ?? 0) + 1)
+    const key = getProjectSetupSurfaceKey(setup)
+    setupCountByProjectSurface.set(key, (setupCountByProjectSurface.get(key) ?? 0) + 1)
   }
-  const multiSetupProjectHostKeys = new Set<string>()
-  for (const [key, count] of setupCountByProjectHost) {
-    if (count > 1) {
-      multiSetupProjectHostKeys.add(key)
+  const projectIdsRequiringSetupGroups = new Set<string>()
+  for (const setup of projectHostSetups) {
+    if ((setupCountByProjectSurface.get(getProjectSetupSurfaceKey(setup)) ?? 0) > 1) {
+      projectIdsRequiringSetupGroups.add(setup.projectId)
     }
   }
   const index = {
     projectById: new Map(projects.map((project) => [project.id, project])),
     setupByRepoId: new Map(projectHostSetups.map((setup) => [setup.repoId, setup])),
-    multiSetupProjectHostKeys
+    projectIdsRequiringSetupGroups
   }
   projectGroupingIndexCache.set(model, index)
   return index
@@ -207,10 +214,9 @@ function getProjectGroupingForRepo(
       repo
     }
   }
-  if (projectIndex?.multiSetupProjectHostKeys.has(projectHostKey(setup.projectId, setup.hostId))) {
-    // Why: this project is set up more than once on this host, so each checkout
-    // keeps its own group (labelled by its folder) instead of collapsing into a
-    // single project header named after whichever folder was added first.
+  if (projectIndex?.projectIdsRequiringSetupGroups.has(setup.projectId)) {
+    // Why: once a project has duplicate checkouts on one host, other host
+    // copies cannot be safely attached to one duplicate without explicit linking.
     return {
       key: `project:${project.id}::setup:${repoId}`,
       label: repo?.displayName ?? setup.displayName,


### PR DESCRIPTION
## Summary
- preserve per-setup sidebar groups when a project has duplicate checkouts on the same execution surface
- extend that ambiguous case to all setups for the project, so a single remote copy is not implicitly attached to one of several duplicate checkouts
- keep one-project sidebar grouping when a project has only one setup per execution surface

## Behavior
- Local + SSH/runtime, one setup per surface: one project header
- Two local checkouts on the same surface: separate setup headers
- Two local checkouts plus one remote checkout: all setups render as setup headers, because Orca cannot know which duplicate checkout the remote copy belongs to without explicit linking
- Windows-host and WSL paths on the same runtime host count as different surfaces, so `C:\...\orca` plus `\\wsl.localhost\Ubuntu\...\orca` still group as one project

## Test
- pnpm test src/renderer/src/components/sidebar/worktree-list-groups.test.ts

Note: test passed with the existing Node engine warning in this shell (repo wants Node 24, shell has Node v26.0.0).