### PR TITLE
Show Source Control for Folder Workspaces

### DIFF
--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import type * as RepoModule from '../git/repo'
 import { DEFAULT_REPO_BADGE_COLOR } from '../../shared/constants'
-import { isGitRepo } from '../git/repo'
+import { getBaseRefDefault, isGitRepo } from '../git/repo'
 
 const {
   handleMock,
@@ -2226,6 +2226,30 @@ describe('repos:getBaseRefDefault envelope', () => {
     expect(result.remoteCount).toBe(1)
   })
 
+  it('uses repoPath to disambiguate duplicate repo ids for local defaults', async () => {
+    const selectedRepo = {
+      id: 'r1',
+      path: '/selected/repo',
+      kind: 'git'
+    }
+    mockStore.getRepo.mockReturnValue({
+      id: 'r1',
+      path: '/wrong/repo',
+      kind: 'git'
+    })
+    mockStore.getRepos.mockReturnValue([
+      { id: 'r1', path: '/wrong/repo', kind: 'git' },
+      selectedRepo
+    ])
+
+    await handlers.get('repos:getBaseRefDefault')!(null, {
+      repoId: 'r1',
+      repoPath: selectedRepo.path
+    })
+
+    expect(getBaseRefDefault).toHaveBeenLastCalledWith(selectedRepo.path)
+  })
+
   // Why: the SSH handler resolves default-ref and remote-count in parallel
   // (Promise.all) so the order of calls into provider.exec is not stable.
   // Dispatch on argv instead of `mockResolvedValueOnce` chains so tests remain
@@ -2281,6 +2305,39 @@ describe('repos:getBaseRefDefault envelope', () => {
 
     expect(result.defaultBaseRef).toBe('origin/main')
     expect(result.remoteCount).toBe(2)
+  })
+
+  it('uses repoPath to disambiguate duplicate repo ids for SSH defaults', async () => {
+    mockGitProvider.exec = vi.fn().mockImplementation(
+      dispatchExec([
+        {
+          match: isSymbolicRef,
+          respond: () => Promise.resolve({ stdout: 'refs/remotes/origin/main\n', stderr: '' })
+        },
+        {
+          match: isRemoteList,
+          respond: () => Promise.resolve({ stdout: 'origin\n', stderr: '' })
+        }
+      ])
+    )
+    mockStore.getRepo.mockReturnValue({
+      id: 'r1',
+      path: '/wrong/repo',
+      kind: 'git'
+    })
+    mockStore.getRepos.mockReturnValue([
+      { id: 'r1', path: '/wrong/repo', kind: 'git' },
+      { id: 'r1', path: '/remote/selected', connectionId: 'wrong-conn', kind: 'git' },
+      { id: 'r1', path: '/remote/selected', connectionId: 'conn-1', kind: 'git' }
+    ])
+
+    await handlers.get('repos:getBaseRefDefault')!(null, {
+      repoId: 'r1',
+      repoPath: '/remote/selected',
+      executionHostId: 'ssh:conn-1'
+    })
+
+    expect(mockGitProvider.exec).toHaveBeenCalledWith(expect.any(Array), '/remote/selected')
   })
 
   it('returns defaultBaseRef even when remote-count lookup fails', async () => {
@@ -2425,6 +2482,39 @@ describe('repos:searchBaseRefs SSH relay', () => {
     expect(argv).toContain('refs/heads/**/**/**')
     expect(argv).toContain('refs/remotes/**/**')
     expect(argv).toContain('refs/remotes/**/**/**')
+  })
+
+  it('uses repoPath to disambiguate duplicate repo ids for SSH searches', async () => {
+    mockGitProvider.exec = vi.fn().mockImplementation((argv: string[]) => {
+      if (argv[0] === 'remote') {
+        return Promise.resolve({ stdout: 'origin\n', stderr: '' })
+      }
+      return Promise.resolve({
+        stdout: 'refs/remotes/origin/main\0origin/main',
+        stderr: ''
+      })
+    })
+    mockStore.getRepo.mockReturnValue({
+      id: 'r1',
+      path: '/wrong/repo',
+      kind: 'git'
+    })
+    mockStore.getRepos.mockReturnValue([
+      { id: 'r1', path: '/wrong/repo', kind: 'git' },
+      { id: 'r1', path: '/remote/selected', connectionId: 'wrong-conn', kind: 'git' },
+      { id: 'r1', path: '/remote/selected', connectionId: 'conn-1', kind: 'git' }
+    ])
+
+    const result = await handlers.get('repos:searchBaseRefs')!(null, {
+      repoId: 'r1',
+      repoPath: '/remote/selected',
+      executionHostId: 'ssh:conn-1',
+      query: 'main'
+    })
+
+    expect(result).toEqual(['origin/main'])
+    expect(mockGitProvider.exec).toHaveBeenCalledWith(['remote'], '/remote/selected')
+    expect(mockGitProvider.exec).toHaveBeenCalledWith(expect.any(Array), '/remote/selected')
   })
 
   it('sanitizes glob metacharacter-only queries into the empty-query branch list', async () => {

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -83,7 +83,11 @@ import type { RepoMethod } from '../../shared/telemetry-events'
 import { detectRepoIconAndUpstream } from '../repo-icon-autodetect'
 import { enrichMissingRepoGitRemoteIdentities } from '../repo-git-remote-identity-enrichment'
 import { getProjectHostSetupForRepo } from '../../shared/project-host-setup-projection'
-import { normalizeExecutionHostId, parseExecutionHostId } from '../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  normalizeExecutionHostId,
+  parseExecutionHostId
+} from '../../shared/execution-host'
 import { joinRemotePath } from '../ssh/ssh-remote-platform'
 import {
   assertFolderWorkspacePathUsable,
@@ -2325,8 +2329,8 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
 
   ipcMain.handle(
     'repos:getBaseRefDefault',
-    async (_event, args: { repoId: string }): Promise<BaseRefDefaultResult> => {
-      const repo = store.getRepo(args.repoId)
+    async (_event, args: BaseRefRepoLookupArgs): Promise<BaseRefDefaultResult> => {
+      const repo = resolveBaseRefRepo(store, args)
       if (!repo || isFolderRepo(repo)) {
         // Why: folder-mode repos have no git state to resolve a base ref from.
         // Return null + 0 so the renderer can decline to use a fabricated default
@@ -2417,9 +2421,9 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
 
 async function searchBaseRefDetailsForRepo(
   store: Store,
-  args: { repoId: string; query: string; limit?: number }
+  args: BaseRefSearchArgs
 ): Promise<BaseRefSearchResult[]> {
-  const repo = store.getRepo(args.repoId)
+  const repo = resolveBaseRefRepo(store, args)
   if (!repo || isFolderRepo(repo)) {
     return []
   }
@@ -2494,6 +2498,36 @@ async function searchBaseRefDetailsForRepo(
     }
   }
   return searchBaseRefDetails(repo.path, args.query, limit)
+}
+
+type BaseRefRepoLookupArgs = {
+  repoId: string
+  repoPath?: string
+  executionHostId?: string | null
+}
+
+type BaseRefSearchArgs = BaseRefRepoLookupArgs & {
+  query: string
+  limit?: number
+}
+
+function resolveBaseRefRepo(store: Store, args: BaseRefRepoLookupArgs): Repo | undefined {
+  const repoPath = args.repoPath?.trim()
+  const executionHostId = args.executionHostId?.trim()
+  if (!repoPath && !executionHostId) {
+    return store.getRepo(args.repoId)
+  }
+  // Why: folder-workspace Source Control can render duplicate repo ids across
+  // hosts, sometimes with identical checkout paths. Match every supplied
+  // discriminator so local/SSH IPC base-ref lookups stay on the embedded child.
+  return store
+    .getRepos()
+    .find(
+      (repo) =>
+        repo.id === args.repoId &&
+        (!repoPath || repo.path === repoPath) &&
+        (!executionHostId || getRepoExecutionHostId(repo) === executionHostId)
+    )
 }
 
 function notifyReposChanged(mainWindow: BrowserWindow): void {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -823,10 +823,22 @@ export type PreloadApi = {
     getDefaultCreateProjectParent: () => Promise<string>
     onCloneProgress: (callback: (data: { phase: string; percent: number }) => void) => () => void
     getGitUsername: (args: { repoId: string }) => Promise<string>
-    getBaseRefDefault: (args: { repoId: string }) => Promise<BaseRefDefaultResult>
-    searchBaseRefs: (args: { repoId: string; query: string; limit?: number }) => Promise<string[]>
+    getBaseRefDefault: (args: {
+      repoId: string
+      repoPath?: string
+      executionHostId?: string | null
+    }) => Promise<BaseRefDefaultResult>
+    searchBaseRefs: (args: {
+      repoId: string
+      repoPath?: string
+      executionHostId?: string | null
+      query: string
+      limit?: number
+    }) => Promise<string[]>
     searchBaseRefDetails: (args: {
       repoId: string
+      repoPath?: string
+      executionHostId?: string | null
       query: string
       limit?: number
     }) => Promise<BaseRefSearchResult[]>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -517,14 +517,24 @@ const api = {
     getGitUsername: (args: { repoId: string }): Promise<string> =>
       ipcRenderer.invoke('repos:getGitUsername', args),
 
-    getBaseRefDefault: (args: { repoId: string }): Promise<BaseRefDefaultResult> =>
-      ipcRenderer.invoke('repos:getBaseRefDefault', args),
+    getBaseRefDefault: (args: {
+      repoId: string
+      repoPath?: string
+      executionHostId?: string | null
+    }): Promise<BaseRefDefaultResult> => ipcRenderer.invoke('repos:getBaseRefDefault', args),
 
-    searchBaseRefs: (args: { repoId: string; query: string; limit?: number }): Promise<string[]> =>
-      ipcRenderer.invoke('repos:searchBaseRefs', args),
+    searchBaseRefs: (args: {
+      repoId: string
+      repoPath?: string
+      executionHostId?: string | null
+      query: string
+      limit?: number
+    }): Promise<string[]> => ipcRenderer.invoke('repos:searchBaseRefs', args),
 
     searchBaseRefDetails: (args: {
       repoId: string
+      repoPath?: string
+      executionHostId?: string | null
       query: string
       limit?: number
     }): Promise<BaseRefSearchResult[]> => ipcRenderer.invoke('repos:searchBaseRefDetails', args),

--- a/src/renderer/src/components/right-sidebar/FolderWorkspaceSourceControlPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspaceSourceControlPanel.test.tsx
@@ -1,0 +1,317 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo, Worktree, WorkspaceLineage } from '../../../../shared/types'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import FolderWorkspaceSourceControlPanel from './FolderWorkspaceSourceControlPanel'
+
+type MockStoreState = {
+  activeWorktreeId: string | null
+  activeWorkspaceKey: string | null
+  folderWorkspaces: { id: string; name: string; folderPath: string }[]
+  workspaceLineageByChildKey: Record<string, WorkspaceLineage>
+  worktreeLineageById: Record<string, never>
+  worktreesByRepo: Record<string, Worktree[]>
+  repos: Repo[]
+  gitStatusByWorktree: Record<string, unknown[]>
+  sshConnectionStates: Map<string, { status?: string }>
+  setGitStatus: () => void
+  updateWorktreeGitIdentity: () => void
+  setUpstreamStatus: () => void
+  fetchUpstreamStatus: () => Promise<null>
+}
+
+const panelMocks = vi.hoisted(() => ({
+  store: {} as MockStoreState,
+  sourceControlProps: [] as { worktreeId?: string; embedded?: boolean }[],
+  refreshCalls: [] as unknown[],
+  invalidatedWorktreeIds: [] as string[],
+  keepRefreshPending: false
+}))
+
+vi.mock('@/store', () => {
+  const useAppStore = Object.assign(
+    <T,>(selector: (state: MockStoreState) => T): T => selector(panelMocks.store),
+    { getState: () => panelMocks.store }
+  )
+  return { useAppStore }
+})
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, values?: Record<string, unknown>) =>
+    values ? fallback.replace('{{value0}}', String(values.value0)) : fallback
+}))
+
+vi.mock('./SourceControl', () => ({
+  default: (props: { worktreeId?: string; embedded?: boolean }) => {
+    panelMocks.sourceControlProps.push(props)
+    return (
+      <div data-testid="scoped-source-control" data-worktree-id={props.worktreeId}>
+        SourceControl {props.worktreeId}
+      </div>
+    )
+  }
+}))
+
+vi.mock('./folder-workspace-source-control-refresh', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    invalidateFolderSourceControlRefreshGeneration: (
+      generationMap: Map<string, number>,
+      worktreeIds: Iterable<string>
+    ) => {
+      const ids = [...worktreeIds]
+      panelMocks.invalidatedWorktreeIds.push(...ids)
+      const invalidate = actual.invalidateFolderSourceControlRefreshGeneration as (
+        generationMap: Map<string, number>,
+        worktreeIds: Iterable<string>
+      ) => void
+      invalidate(generationMap, ids)
+    },
+    runLimitedFolderSourceControlRefreshes: (args: unknown) => {
+      panelMocks.refreshCalls.push(args)
+      if (panelMocks.keepRefreshPending) {
+        const refreshArgs = args as {
+          candidates: { worktree: Worktree }[]
+          inFlightWorktreeIds?: Map<string, number>
+        }
+        for (const candidate of refreshArgs.candidates) {
+          refreshArgs.inFlightWorktreeIds?.set(candidate.worktree.id, 1)
+        }
+        return new Promise<void>(() => undefined)
+      }
+      return Promise.resolve()
+    }
+  }
+})
+
+let container: HTMLDivElement
+let root: Root
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    badgeColor: '#fff',
+    addedAt: 1,
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> & { id: string }): Worktree {
+  return {
+    path: `/worktrees/${overrides.id}`,
+    head: 'abc',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    repoId: 'repo-1',
+    displayName: overrides.id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+function makeWorkspaceLineage(child: Worktree, parentFolderId = 'folder-1'): WorkspaceLineage {
+  return {
+    childWorkspaceKey: worktreeWorkspaceKey(child.id),
+    childInstanceId: child.instanceId ?? null,
+    parentWorkspaceKey: folderWorkspaceKey(parentFolderId),
+    parentInstanceId: null,
+    origin: 'cli',
+    capture: { source: 'env-workspace', confidence: 'inferred' },
+    createdAt: 1
+  }
+}
+
+function renderPanel(children?: ReactNode): void {
+  act(() => {
+    root.render(
+      <TooltipProvider>{children ?? <FolderWorkspaceSourceControlPanel />}</TooltipProvider>
+    )
+  })
+}
+
+describe('FolderWorkspaceSourceControlPanel', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    panelMocks.sourceControlProps = []
+    panelMocks.refreshCalls = []
+    panelMocks.invalidatedWorktreeIds = []
+    panelMocks.keepRefreshPending = false
+    panelMocks.store = {
+      activeWorktreeId: folderWorkspaceKey('folder-1'),
+      activeWorkspaceKey: folderWorkspaceKey('folder-1'),
+      folderWorkspaces: [{ id: 'folder-1', name: 'Platform folder', folderPath: '/platform' }],
+      workspaceLineageByChildKey: {},
+      worktreeLineageById: {},
+      worktreesByRepo: {},
+      repos: [makeRepo()],
+      gitStatusByWorktree: {},
+      sshConnectionStates: new Map(),
+      setGitStatus: vi.fn(),
+      updateWorktreeGitIdentity: vi.fn(),
+      setUpstreamStatus: vi.fn(),
+      fetchUpstreamStatus: vi.fn().mockResolvedValue(null)
+    }
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('shows unavailable copy outside folder workspaces', () => {
+    panelMocks.store.activeWorktreeId = 'repo-1::/current'
+    panelMocks.store.activeWorkspaceKey = 'repo-1::/current'
+
+    renderPanel()
+
+    expect(container.textContent).toContain(
+      'Source Control is only shown for folder workspaces with attached worktrees.'
+    )
+    expect(panelMocks.sourceControlProps).toEqual([])
+  })
+
+  it('shows an empty state for a folder workspace with no attached worktrees', () => {
+    renderPanel()
+
+    expect(container.textContent).toContain('Platform folder')
+    expect(container.textContent).toContain('No attached worktrees yet')
+    expect(panelMocks.sourceControlProps).toEqual([])
+  })
+
+  it('mounts SourceControl only for expanded sections and scopes it to the child worktree', () => {
+    const first = makeWorktree({
+      id: 'repo-1::/first',
+      displayName: 'First child',
+      instanceId: 'first',
+      lastActivityAt: 20
+    })
+    const second = makeWorktree({
+      id: 'repo-1::/second',
+      displayName: 'Second child',
+      instanceId: 'second',
+      lastActivityAt: 10
+    })
+    panelMocks.store.worktreesByRepo = { 'repo-1': [first, second] }
+    panelMocks.store.workspaceLineageByChildKey = {
+      [first.id]: makeWorkspaceLineage(first),
+      [second.id]: makeWorkspaceLineage(second)
+    }
+    panelMocks.store.gitStatusByWorktree = {
+      [first.id]: [{ path: 'a.ts' }],
+      [second.id]: [{ path: 'b.ts' }, { path: 'c.ts' }]
+    }
+
+    renderPanel()
+
+    expect(container.textContent).toContain('2 attached worktrees')
+    expect(container.textContent).toContain('First child')
+    expect(container.textContent).toContain('Second child')
+    expect(container.textContent).toContain('1 cached')
+    expect(container.textContent).toContain('2 cached')
+    expect(panelMocks.sourceControlProps).toEqual([{ worktreeId: first.id, embedded: true }])
+
+    const secondButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.includes('Second child')
+    )
+    expect(secondButton).not.toBeNull()
+    act(() => {
+      secondButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(panelMocks.sourceControlProps).toContainEqual({
+      worktreeId: second.id,
+      embedded: true
+    })
+    expect(container.querySelectorAll('[data-testid="scoped-source-control"]')).toHaveLength(2)
+  })
+
+  it('invalidates pending refresh generations when the panel unmounts', () => {
+    const child = makeWorktree({
+      id: 'repo-1::/first',
+      displayName: 'First child',
+      instanceId: 'first',
+      lastActivityAt: 20
+    })
+    panelMocks.store.worktreesByRepo = { 'repo-1': [child] }
+    panelMocks.store.workspaceLineageByChildKey = {
+      [child.id]: makeWorkspaceLineage(child)
+    }
+
+    renderPanel()
+    expect(panelMocks.refreshCalls.length).toBeGreaterThan(0)
+
+    renderPanel(<div />)
+
+    expect(panelMocks.invalidatedWorktreeIds).toContain(child.id)
+  })
+
+  it('releases cancelled refresh reservations so dependency reruns can retry', () => {
+    const child = makeWorktree({
+      id: 'repo-1::/first',
+      displayName: 'First child',
+      instanceId: 'first',
+      lastActivityAt: 20
+    })
+    panelMocks.keepRefreshPending = true
+    panelMocks.store.worktreesByRepo = { 'repo-1': [child] }
+    panelMocks.store.workspaceLineageByChildKey = {
+      [child.id]: makeWorkspaceLineage(child)
+    }
+
+    renderPanel()
+    const initialCallCount = panelMocks.refreshCalls.length
+
+    panelMocks.store.sshConnectionStates = new Map([['ssh-target', { status: 'connected' }]])
+    renderPanel()
+
+    expect(panelMocks.invalidatedWorktreeIds).toContain(child.id)
+    expect(panelMocks.refreshCalls.length).toBeGreaterThan(initialCallCount)
+  })
+
+  it('uses the host-matching repo name for duplicate repo ids', () => {
+    const child = makeWorktree({
+      id: 'repo-1::/ssh-child',
+      displayName: 'SSH child',
+      hostId: 'ssh:ssh-target',
+      instanceId: 'ssh-child',
+      lastActivityAt: 20
+    })
+    panelMocks.store.repos = [
+      makeRepo({ displayName: 'Local Repo', executionHostId: 'local' }),
+      makeRepo({
+        displayName: 'SSH Repo',
+        connectionId: 'ssh-target',
+        executionHostId: 'ssh:ssh-target'
+      })
+    ]
+    panelMocks.store.worktreesByRepo = { 'repo-1': [child] }
+    panelMocks.store.workspaceLineageByChildKey = {
+      [child.id]: makeWorkspaceLineage(child)
+    }
+
+    renderPanel()
+
+    expect(container.textContent).toContain('SSH Repo')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/FolderWorkspaceSourceControlPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspaceSourceControlPanel.test.tsx
@@ -29,6 +29,7 @@ const panelMocks = vi.hoisted(() => ({
   sourceControlProps: [] as { worktreeId?: string; embedded?: boolean }[],
   refreshCalls: [] as unknown[],
   invalidatedWorktreeIds: [] as string[],
+  jumpToWorktreeCalls: [] as string[],
   keepRefreshPending: false
 }))
 
@@ -43,6 +44,12 @@ vi.mock('@/store', () => {
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string, values?: Record<string, unknown>) =>
     values ? fallback.replace('{{value0}}', String(values.value0)) : fallback
+}))
+
+vi.mock('@/lib/sidebar-worktree-activation', () => ({
+  activateWorktreeFromSidebar: (worktreeId: string) => {
+    panelMocks.jumpToWorktreeCalls.push(worktreeId)
+  }
 }))
 
 vi.mock('./SourceControl', () => ({
@@ -156,6 +163,7 @@ describe('FolderWorkspaceSourceControlPanel', () => {
     panelMocks.sourceControlProps = []
     panelMocks.refreshCalls = []
     panelMocks.invalidatedWorktreeIds = []
+    panelMocks.jumpToWorktreeCalls = []
     panelMocks.keepRefreshPending = false
     panelMocks.store = {
       activeWorktreeId: folderWorkspaceKey('folder-1'),
@@ -313,5 +321,32 @@ describe('FolderWorkspaceSourceControlPanel', () => {
     renderPanel()
 
     expect(container.textContent).toContain('SSH Repo')
+  })
+
+  it('jumps to a child worktree from the section header without collapsing it', () => {
+    const child = makeWorktree({
+      id: 'repo-1::/first',
+      displayName: 'First child',
+      instanceId: 'first',
+      lastActivityAt: 20
+    })
+    panelMocks.store.worktreesByRepo = { 'repo-1': [child] }
+    panelMocks.store.workspaceLineageByChildKey = {
+      [child.id]: makeWorkspaceLineage(child)
+    }
+
+    renderPanel()
+
+    const jumpButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Jump to worktree"]'
+    )
+    expect(jumpButton).not.toBeNull()
+
+    act(() => {
+      jumpButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(panelMocks.jumpToWorktreeCalls).toEqual([child.id])
+    expect(container.querySelectorAll('[data-testid="scoped-source-control"]')).toHaveLength(1)
   })
 })

--- a/src/renderer/src/components/right-sidebar/FolderWorkspaceSourceControlPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspaceSourceControlPanel.tsx
@@ -1,0 +1,408 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, RefreshCw } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { Button } from '@/components/ui/button'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { Worktree } from '../../../../shared/types'
+import { getAttachedWorktreesForFolderWorkspace } from './folder-workspace-attached-worktrees'
+import SourceControl from './SourceControl'
+import {
+  getFolderSourceControlRefreshCandidates,
+  invalidateFolderSourceControlRefreshGeneration,
+  resolveFolderSourceControlRepo,
+  runLimitedFolderSourceControlRefreshes,
+  type FolderSourceControlRefreshReservations,
+  type FolderSourceControlRefreshOutcome
+} from './folder-workspace-source-control-refresh'
+
+export default function FolderWorkspaceSourceControlPanel(): React.JSX.Element {
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const activeWorkspaceKey = useAppStore((s) => s.activeWorkspaceKey)
+  const folderWorkspaces = useAppStore((s) => s.folderWorkspaces)
+  const workspaceLineageByChildKey = useAppStore((s) => s.workspaceLineageByChildKey)
+  const worktreeLineageById = useAppStore((s) => s.worktreeLineageById)
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const repos = useAppStore((s) => s.repos)
+  const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
+  const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
+  const setGitStatus = useAppStore((s) => s.setGitStatus)
+  const updateWorktreeGitIdentity = useAppStore((s) => s.updateWorktreeGitIdentity)
+  const setUpstreamStatus = useAppStore((s) => s.setUpstreamStatus)
+  const fetchUpstreamStatus = useAppStore((s) => s.fetchUpstreamStatus)
+  const [expandedWorktreeIds, setExpandedWorktreeIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  )
+  const [refreshOutcomes, setRefreshOutcomes] = useState<
+    ReadonlyMap<string, FolderSourceControlRefreshOutcome>
+  >(() => new Map())
+  const [manualRefreshGeneration, setManualRefreshGeneration] = useState(0)
+  const lastManualGenerationRef = useRef(0)
+  const inFlightRefreshWorktreeIdsRef = useRef<FolderSourceControlRefreshReservations>(new Map())
+  const refreshGenerationByWorktreeRef = useRef<Map<string, number>>(new Map())
+
+  const { folderWorkspace, childWorktrees } = useMemo(
+    () =>
+      getAttachedWorktreesForFolderWorkspace({
+        activeWorkspaceKey,
+        activeWorktreeId,
+        folderWorkspaces,
+        workspaceLineageByChildKey,
+        worktreeLineageById,
+        worktreesByRepo
+      }),
+    [
+      activeWorkspaceKey,
+      activeWorktreeId,
+      folderWorkspaces,
+      workspaceLineageByChildKey,
+      worktreeLineageById,
+      worktreesByRepo
+    ]
+  )
+
+  useEffect(() => {
+    setExpandedWorktreeIds((current) => {
+      const validIds = new Set(childWorktrees.map((worktree) => worktree.id))
+      const next = new Set([...current].filter((id) => validIds.has(id)))
+      if (next.size === 0 && childWorktrees[0]) {
+        next.add(childWorktrees[0].id)
+      }
+      return setsEqual(current, next) ? current : next
+    })
+  }, [childWorktrees])
+
+  const manualWorktreeIds = useMemo(() => {
+    if (manualRefreshGeneration <= lastManualGenerationRef.current) {
+      return new Set<string>()
+    }
+    return new Set(childWorktrees.map((worktree) => worktree.id))
+  }, [childWorktrees, manualRefreshGeneration])
+
+  const refreshCandidates = useMemo(
+    () =>
+      getFolderSourceControlRefreshCandidates({
+        worktrees: childWorktrees,
+        repos,
+        expandedWorktreeIds,
+        manualWorktreeIds
+      }),
+    [childWorktrees, expandedWorktreeIds, manualWorktreeIds, repos]
+  )
+  const refreshCandidateSignature = useMemo(
+    () =>
+      refreshCandidates
+        .map((candidate) =>
+          [
+            candidate.worktree.id,
+            candidate.worktree.path,
+            candidate.repo.connectionId ?? '',
+            candidate.repo.executionHostId ?? '',
+            candidate.expanded ? 'expanded' : 'collapsed',
+            candidate.manual ? 'manual' : 'auto'
+          ].join('|')
+        )
+        .join(';;'),
+    [refreshCandidates]
+  )
+
+  useEffect(() => {
+    if (!folderWorkspace || childWorktrees.length === 0 || refreshCandidates.length === 0) {
+      return
+    }
+    const refreshWorktreeIds = refreshCandidates.map((candidate) => candidate.worktree.id)
+    const refreshGenerations = refreshGenerationByWorktreeRef.current
+    const inFlightRefreshes = inFlightRefreshWorktreeIdsRef.current
+    if (manualRefreshGeneration > lastManualGenerationRef.current) {
+      lastManualGenerationRef.current = manualRefreshGeneration
+    }
+    let cancelled = false
+    void runLimitedFolderSourceControlRefreshes({
+      candidates: refreshCandidates,
+      concurrency: 3,
+      deps: {
+        setGitStatus,
+        updateWorktreeGitIdentity,
+        setUpstreamStatus,
+        fetchUpstreamStatus
+      },
+      sshConnectionStates,
+      inFlightWorktreeIds: inFlightRefreshes,
+      refreshGenerationByWorktree: refreshGenerations,
+      onOutcome: (worktreeId, outcome) => {
+        if (cancelled) {
+          return
+        }
+        setRefreshOutcomes((current) => new Map(current).set(worktreeId, outcome))
+      }
+    })
+    return () => {
+      cancelled = true
+      invalidateFolderSourceControlRefreshGeneration(refreshGenerations, refreshWorktreeIds)
+      for (const worktreeId of refreshWorktreeIds) {
+        inFlightRefreshes.delete(worktreeId)
+      }
+    }
+  }, [
+    childWorktrees.length,
+    fetchUpstreamStatus,
+    folderWorkspace,
+    manualRefreshGeneration,
+    refreshCandidateSignature,
+    refreshCandidates,
+    setGitStatus,
+    setUpstreamStatus,
+    sshConnectionStates,
+    updateWorktreeGitIdentity
+  ])
+
+  const currentChildWorktreeIds = useMemo(
+    () => new Set(childWorktrees.map((worktree) => worktree.id)),
+    [childWorktrees]
+  )
+  const isRefreshing = [...refreshOutcomes.entries()].some(
+    ([worktreeId, outcome]) => currentChildWorktreeIds.has(worktreeId) && outcome.kind === 'loading'
+  )
+  const repoNameByWorktreeId = useMemo(
+    () =>
+      new Map(
+        childWorktrees.map((worktree) => [
+          worktree.id,
+          resolveFolderSourceControlRepo(worktree, repos)?.displayName ?? null
+        ])
+      ),
+    [childWorktrees, repos]
+  )
+
+  const toggleWorktree = useCallback((worktreeId: string): void => {
+    setExpandedWorktreeIds((current) => {
+      const next = new Set(current)
+      if (next.has(worktreeId)) {
+        next.delete(worktreeId)
+      } else {
+        next.add(worktreeId)
+      }
+      return next
+    })
+  }, [])
+
+  if (!folderWorkspace) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        {translate(
+          'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.unavailable',
+          'Source Control is only shown for folder workspaces with attached worktrees.'
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium text-foreground">
+              {folderWorkspace.name}
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              {formatAttachedWorktreeCount(childWorktrees.length)}
+            </div>
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => setManualRefreshGeneration((generation) => generation + 1)}
+                disabled={childWorktrees.length === 0 || isRefreshing}
+                aria-label={translate(
+                  'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.refresh',
+                  'Refresh source control'
+                )}
+              >
+                <RefreshCw className={cn('size-3.5', isRefreshing && 'animate-spin')} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {translate(
+                'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.refresh',
+                'Refresh source control'
+              )}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {childWorktrees.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center px-6 text-center">
+          <div className="text-sm font-medium text-foreground">
+            {translate(
+              'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.emptyTitle',
+              'No attached worktrees yet'
+            )}
+          </div>
+          <div className="mt-2 max-w-[16rem] text-xs leading-5 text-muted-foreground">
+            {translate(
+              'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.emptyCopy',
+              'Source Control sections will appear here after worktrees are attached to this folder workspace.'
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto px-2 py-2">
+          <div className="space-y-1">
+            {childWorktrees.map((worktree) => {
+              const expanded = expandedWorktreeIds.has(worktree.id)
+              return (
+                <FolderWorkspaceSourceControlSection
+                  key={worktree.id}
+                  worktree={worktree}
+                  repoName={repoNameByWorktreeId.get(worktree.id) ?? null}
+                  expanded={expanded}
+                  statusEntries={gitStatusByWorktree[worktree.id]}
+                  refreshOutcome={refreshOutcomes.get(worktree.id) ?? null}
+                  onToggle={() => toggleWorktree(worktree.id)}
+                />
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function FolderWorkspaceSourceControlSection({
+  worktree,
+  repoName,
+  expanded,
+  statusEntries,
+  refreshOutcome,
+  onToggle
+}: {
+  worktree: Worktree
+  repoName: string | null
+  expanded: boolean
+  statusEntries: ReturnType<typeof useAppStore.getState>['gitStatusByWorktree'][string] | undefined
+  refreshOutcome: FolderSourceControlRefreshOutcome | null
+  onToggle: () => void
+}): React.JSX.Element {
+  return (
+    <Collapsible open={expanded} onOpenChange={onToggle}>
+      <div className="overflow-hidden rounded-md border border-border bg-background">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-accent"
+          >
+            <ChevronDown
+              className={cn('size-3.5 shrink-0 transition-transform', !expanded && '-rotate-90')}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-xs font-medium text-foreground">
+                {worktree.displayName}
+              </div>
+              {repoName ? (
+                <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{repoName}</div>
+              ) : null}
+            </div>
+            <div className="shrink-0 text-right text-[11px] text-muted-foreground">
+              {formatStatusSummary(statusEntries, refreshOutcome)}
+            </div>
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="border-t border-border">
+            {expanded ? <SourceControl worktreeId={worktree.id} embedded /> : null}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  )
+}
+
+function formatAttachedWorktreeCount(count: number): string {
+  return count === 1
+    ? translate(
+        'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.countOne',
+        '1 attached worktree'
+      )
+    : translate(
+        'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.countMany',
+        '{{value0}} attached worktrees',
+        { value0: count }
+      )
+}
+
+function formatStatusSummary(
+  entries: readonly unknown[] | undefined,
+  refreshOutcome: FolderSourceControlRefreshOutcome | null
+): string {
+  if (refreshOutcome?.kind === 'loading') {
+    return translate(
+      'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.loading',
+      'Refreshing'
+    )
+  }
+  if (refreshOutcome?.kind === 'unavailable') {
+    return translate(
+      'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.unavailableStatus',
+      'Unavailable'
+    )
+  }
+  if (refreshOutcome?.kind === 'failed') {
+    return entries
+      ? translate(
+          'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.staleAfterFailed',
+          '{{value0}} stale',
+          { value0: entries.length }
+        )
+      : translate(
+          'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.failed',
+          'Refresh failed'
+        )
+  }
+  if (refreshOutcome?.kind === 'fresh') {
+    return formatFreshChangeCount(entries?.length ?? 0)
+  }
+  if (entries) {
+    return translate(
+      'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.cached',
+      '{{value0}} cached',
+      { value0: entries.length }
+    )
+  }
+  return translate(
+    'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.pending',
+    'Status pending'
+  )
+}
+
+function formatFreshChangeCount(count: number): string {
+  return count === 1
+    ? translate(
+        'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.changeOne',
+        '1 change'
+      )
+    : translate(
+        'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.changeMany',
+        '{{value0}} changes',
+        { value0: count }
+      )
+}
+
+function setsEqual(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  if (left.size !== right.size) {
+    return false
+  }
+  for (const value of left) {
+    if (!right.has(value)) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/renderer/src/components/right-sidebar/FolderWorkspaceSourceControlPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspaceSourceControlPanel.tsx
@@ -1,14 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronDown, RefreshCw } from 'lucide-react'
+import { RefreshCw } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
-import type { Worktree } from '../../../../shared/types'
 import { getAttachedWorktreesForFolderWorkspace } from './folder-workspace-attached-worktrees'
-import SourceControl from './SourceControl'
+import { FolderWorkspaceSourceControlSection } from './folder-workspace-source-control-section'
 import {
   getFolderSourceControlRefreshCandidates,
   invalidateFolderSourceControlRefreshGeneration,
@@ -276,55 +274,6 @@ export default function FolderWorkspaceSourceControlPanel(): React.JSX.Element {
   )
 }
 
-function FolderWorkspaceSourceControlSection({
-  worktree,
-  repoName,
-  expanded,
-  statusEntries,
-  refreshOutcome,
-  onToggle
-}: {
-  worktree: Worktree
-  repoName: string | null
-  expanded: boolean
-  statusEntries: ReturnType<typeof useAppStore.getState>['gitStatusByWorktree'][string] | undefined
-  refreshOutcome: FolderSourceControlRefreshOutcome | null
-  onToggle: () => void
-}): React.JSX.Element {
-  return (
-    <Collapsible open={expanded} onOpenChange={onToggle}>
-      <div className="overflow-hidden rounded-md border border-border bg-background">
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-accent"
-          >
-            <ChevronDown
-              className={cn('size-3.5 shrink-0 transition-transform', !expanded && '-rotate-90')}
-            />
-            <div className="min-w-0 flex-1">
-              <div className="truncate text-xs font-medium text-foreground">
-                {worktree.displayName}
-              </div>
-              {repoName ? (
-                <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{repoName}</div>
-              ) : null}
-            </div>
-            <div className="shrink-0 text-right text-[11px] text-muted-foreground">
-              {formatStatusSummary(statusEntries, refreshOutcome)}
-            </div>
-          </button>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="border-t border-border">
-            {expanded ? <SourceControl worktreeId={worktree.id} embedded /> : null}
-          </div>
-        </CollapsibleContent>
-      </div>
-    </Collapsible>
-  )
-}
-
 function formatAttachedWorktreeCount(count: number): string {
   return count === 1
     ? translate(
@@ -334,63 +283,6 @@ function formatAttachedWorktreeCount(count: number): string {
     : translate(
         'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.countMany',
         '{{value0}} attached worktrees',
-        { value0: count }
-      )
-}
-
-function formatStatusSummary(
-  entries: readonly unknown[] | undefined,
-  refreshOutcome: FolderSourceControlRefreshOutcome | null
-): string {
-  if (refreshOutcome?.kind === 'loading') {
-    return translate(
-      'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.loading',
-      'Refreshing'
-    )
-  }
-  if (refreshOutcome?.kind === 'unavailable') {
-    return translate(
-      'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.unavailableStatus',
-      'Unavailable'
-    )
-  }
-  if (refreshOutcome?.kind === 'failed') {
-    return entries
-      ? translate(
-          'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.staleAfterFailed',
-          '{{value0}} stale',
-          { value0: entries.length }
-        )
-      : translate(
-          'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.failed',
-          'Refresh failed'
-        )
-  }
-  if (refreshOutcome?.kind === 'fresh') {
-    return formatFreshChangeCount(entries?.length ?? 0)
-  }
-  if (entries) {
-    return translate(
-      'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.cached',
-      '{{value0}} cached',
-      { value0: entries.length }
-    )
-  }
-  return translate(
-    'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.pending',
-    'Status pending'
-  )
-}
-
-function formatFreshChangeCount(count: number): string {
-  return count === 1
-    ? translate(
-        'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.changeOne',
-        '1 change'
-      )
-    : translate(
-        'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.changeMany',
-        '{{value0}} changes',
         { value0: count }
       )
 }

--- a/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
@@ -616,7 +616,7 @@ describe('SourceControl preview row opens', () => {
     )
   })
 
-  it('activates the scoped child worktree before embedded uncommitted View all opens', () => {
+  it('opens embedded uncommitted View all in the parent folder workspace', () => {
     resetState({
       activeWorktreeId: 'folder:folder-1',
       gitStatusByWorktree: {
@@ -628,20 +628,18 @@ describe('SourceControl preview row opens', () => {
 
     clickViewAllButton()
 
-    expect(mocks.calls.activateAndRevealWorktree).toHaveBeenCalledWith(mocks.activeWorktree.id, {
-      revealInSidebar: false,
-      notifyHostRuntime: false
-    })
+    expect(mocks.calls.activateAndRevealWorktree).not.toHaveBeenCalled()
     expect(mocks.calls.openAllDiffs).toHaveBeenCalledWith(
       mocks.activeWorktree.id,
       '/repo/wt',
       undefined,
       'unstaged',
-      [expect.objectContaining({ path: 'src/file.ts' })]
+      [expect.objectContaining({ path: 'src/file.ts' })],
+      { displayWorktreeId: 'folder:folder-1' }
     )
   })
 
-  it('activates the scoped child worktree before embedded branch View all opens', () => {
+  it('opens embedded branch View all in the parent folder workspace', () => {
     resetState({
       activeWorktreeId: 'folder:folder-1',
       gitBranchChangesByWorktree: { [mocks.activeWorktree.id]: [branchEntry()] },
@@ -651,18 +649,17 @@ describe('SourceControl preview row opens', () => {
 
     clickViewAllButton()
 
-    expect(mocks.calls.activateAndRevealWorktree).toHaveBeenCalledWith(mocks.activeWorktree.id, {
-      revealInSidebar: false,
-      notifyHostRuntime: false
-    })
+    expect(mocks.calls.activateAndRevealWorktree).not.toHaveBeenCalled()
     expect(mocks.calls.openBranchAllDiffs).toHaveBeenCalledWith(
       mocks.activeWorktree.id,
       '/repo/wt',
-      expect.objectContaining({ status: 'ready' })
+      expect.objectContaining({ status: 'ready' }),
+      undefined,
+      { displayWorktreeId: 'folder:folder-1' }
     )
   })
 
-  it('activates the scoped child worktree before embedded row opens', () => {
+  it('opens embedded rows in the parent folder workspace', () => {
     resetState({
       activeWorktreeId: 'folder:folder-1',
       gitStatusByWorktree: {
@@ -674,10 +671,7 @@ describe('SourceControl preview row opens', () => {
 
     clickUncommitted('src/file.ts', { ctrlKey: true })
 
-    expect(mocks.calls.activateAndRevealWorktree).toHaveBeenCalledWith(mocks.activeWorktree.id, {
-      revealInSidebar: false,
-      notifyHostRuntime: false
-    })
+    expect(mocks.calls.activateAndRevealWorktree).not.toHaveBeenCalled()
     expect(mocks.calls.createEmptySplitGroup).not.toHaveBeenCalled()
     expect(mocks.calls.openDiff).toHaveBeenCalledWith(
       mocks.activeWorktree.id,
@@ -685,7 +679,7 @@ describe('SourceControl preview row opens', () => {
       'src/file.ts',
       'typescript',
       false,
-      { targetGroupId: undefined, preview: true }
+      { targetGroupId: undefined, preview: true, displayWorktreeId: 'folder:folder-1' }
     )
   })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
@@ -291,7 +291,53 @@ function clickViewAllButton(): void {
   })
 }
 
+async function waitForCondition(assertion: () => void): Promise<void> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+    }
+  }
+  throw lastError
+}
+
 describe('SourceControl preview row opens', () => {
+  it('shows Create PR chrome in embedded scoped worktree source control', async () => {
+    resetState({
+      rightSidebarOpen: true,
+      getHostedReviewCreationEligibility: vi.fn().mockResolvedValue({
+        provider: 'github',
+        review: null,
+        canCreate: true,
+        blockedReason: null,
+        nextAction: null
+      }),
+      remoteStatusesByWorktree: {
+        [mocks.activeWorktree.id]: {
+          hasUpstream: true,
+          upstreamName: 'origin/feature/source-control-preview',
+          ahead: 0,
+          behind: 0
+        }
+      },
+      gitBranchCompareSummaryByWorktree: {
+        [mocks.activeWorktree.id]: branchSummary()
+      }
+    })
+
+    renderSourceControl({ worktreeId: mocks.activeWorktree.id, embedded: true })
+
+    await waitForCondition(() => {
+      expect(container.textContent).toContain('Create PR')
+    })
+  })
+
   it('passes preview=true when plain uncommitted row clicks open diff tabs', () => {
     resetState({
       gitStatusByWorktree: {

--- a/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
@@ -44,8 +44,12 @@ const mocks = vi.hoisted(() => {
     openDiff: vi.fn(),
     openFile: vi.fn(),
     openConflictFile: vi.fn(),
+    openConflictReview: vi.fn(),
     openBranchDiff: vi.fn(),
+    openAllDiffs: vi.fn(),
+    openBranchAllDiffs: vi.fn(),
     createEmptySplitGroup: vi.fn(),
+    activateAndRevealWorktree: vi.fn(),
     discardRuntimeGitPath: vi.fn(),
     refreshGitStatusForWorktree: vi.fn(),
     requestEditorSaveQuiesce: vi.fn(),
@@ -92,6 +96,10 @@ vi.mock('@/runtime/runtime-git-client', async (importOriginal) => {
 vi.mock('@/components/editor/editor-autosave', () => ({
   requestEditorSaveQuiesce: mocks.calls.requestEditorSaveQuiesce,
   notifyEditorExternalFileChange: mocks.calls.notifyEditorExternalFileChange
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: mocks.calls.activateAndRevealWorktree
 }))
 
 vi.mock('./git-status-refresh', () => ({
@@ -144,6 +152,9 @@ function resetState(overrides: Partial<Record<string, unknown>> = {}): void {
   mocks.calls.requestEditorSaveQuiesce.mockResolvedValue(undefined)
   mocks.state = {
     activeWorktreeId: mocks.activeWorktree.id,
+    getKnownWorktreeById: vi.fn((worktreeId: string) =>
+      worktreeId === mocks.activeWorktree.id ? mocks.activeWorktree : null
+    ),
     activeGroupIdByWorktree: { [mocks.activeWorktree.id]: 'group-1' },
     groupsByWorktree: { [mocks.activeWorktree.id]: [{ id: 'group-1', activeTabId: null }] },
     repos: [mocks.activeRepo],
@@ -193,11 +204,11 @@ function resetState(overrides: Partial<Record<string, unknown>> = {}): void {
     setMarkdownViewMode: vi.fn(),
     setPendingEditorReveal: vi.fn(),
     openConflictFile: mocks.calls.openConflictFile,
-    openConflictReview: vi.fn(),
+    openConflictReview: mocks.calls.openConflictReview,
     openBranchDiff: mocks.calls.openBranchDiff,
     createEmptySplitGroup: mocks.calls.createEmptySplitGroup,
-    openAllDiffs: vi.fn(),
-    openBranchAllDiffs: vi.fn(),
+    openAllDiffs: mocks.calls.openAllDiffs,
+    openBranchAllDiffs: mocks.calls.openBranchAllDiffs,
     openCommitAllDiffs: vi.fn(),
     deleteDiffComment: noopAsync(true),
     clearDiffComments: noopAsync(true),
@@ -233,11 +244,11 @@ afterEach(() => {
   container.remove()
 })
 
-function renderSourceControl(): void {
+function renderSourceControl(props: React.ComponentProps<typeof SourceControl> = {}): void {
   act(() => {
     root.render(
       <TooltipProvider>
-        <SourceControl />
+        <SourceControl {...props} />
       </TooltipProvider>
     )
   })
@@ -267,6 +278,16 @@ function clickBranchRow(init: MouseEventInit = {}): void {
   expect(row).not.toBeNull()
   act(() => {
     row?.dispatchEvent(new MouseEvent('click', { bubbles: true, ...init }))
+  })
+}
+
+function clickViewAllButton(): void {
+  const button = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+    (candidate) => candidate.textContent?.trim() === 'View all'
+  )
+  expect(button).not.toBeNull()
+  act(() => {
+    button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
   })
 }
 
@@ -420,6 +441,91 @@ describe('SourceControl preview row opens', () => {
     })
   })
 
+  it('routes embedded git mutations through the scoped worktree host owner', async () => {
+    const hostedWorktree = { ...mocks.activeWorktree, hostId: 'runtime:worktree-env' }
+    resetState({
+      activeWorktreeId: 'folder:folder-1',
+      settings: { activeRuntimeEnvironmentId: 'focused-env' },
+      getKnownWorktreeById: vi.fn((worktreeId: string) =>
+        worktreeId === hostedWorktree.id ? hostedWorktree : null
+      ),
+      worktreesByRepo: { [mocks.activeRepo.id]: [hostedWorktree] },
+      gitStatusByWorktree: { [hostedWorktree.id]: [gitEntry({ path: 'src/file.ts' })] }
+    })
+    renderSourceControl({ worktreeId: hostedWorktree.id, embedded: true })
+
+    const row = container.querySelector<HTMLDivElement>('[data-source-control-path="src/file.ts"]')
+    const discardButton = row?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Discard changes"]'
+    )
+    expect(discardButton).not.toBeNull()
+    act(() => {
+      discardButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const confirmButton = [...document.body.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Discard'
+    )
+    expect(confirmButton).not.toBeNull()
+    await act(async () => {
+      confirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(mocks.calls.discardRuntimeGitPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: expect.objectContaining({ activeRuntimeEnvironmentId: 'worktree-env' }),
+        worktreeId: hostedWorktree.id
+      }),
+      'src/file.ts'
+    )
+  })
+
+  it('does not inherit an SSH connection from a duplicate repo on another host', async () => {
+    const sshRepo = {
+      ...mocks.activeRepo,
+      connectionId: 'ssh-target',
+      executionHostId: 'ssh:ssh-target'
+    }
+    const localRepo = { ...mocks.activeRepo, connectionId: null, executionHostId: 'local' }
+    const localWorktree = { ...mocks.activeWorktree, hostId: 'local' }
+    resetState({
+      repos: [sshRepo, localRepo],
+      worktreesByRepo: { [mocks.activeRepo.id]: [localWorktree] },
+      getKnownWorktreeById: vi.fn((worktreeId: string) =>
+        worktreeId === localWorktree.id ? localWorktree : null
+      ),
+      gitStatusByWorktree: { [localWorktree.id]: [gitEntry({ path: 'src/file.ts' })] }
+    })
+    renderSourceControl({ worktreeId: localWorktree.id, embedded: true })
+
+    const row = container.querySelector<HTMLDivElement>('[data-source-control-path="src/file.ts"]')
+    const discardButton = row?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Discard changes"]'
+    )
+    expect(discardButton).not.toBeNull()
+    act(() => {
+      discardButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    const confirmButton = [...document.body.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Discard'
+    )
+    expect(confirmButton).not.toBeNull()
+    await act(async () => {
+      confirmButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    expect(mocks.calls.discardRuntimeGitPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: undefined,
+        worktreeId: localWorktree.id
+      }),
+      'src/file.ts'
+    )
+  })
+
   it('keeps nested-only submodule rows non-stageable from the parent repo', () => {
     resetState({
       gitStatusByWorktree: {
@@ -460,6 +566,79 @@ describe('SourceControl preview row opens', () => {
       expect.objectContaining({ path: 'src/branch.ts' }),
       expect.objectContaining({ status: 'ready' }),
       'typescript',
+      { targetGroupId: undefined, preview: true }
+    )
+  })
+
+  it('activates the scoped child worktree before embedded uncommitted View all opens', () => {
+    resetState({
+      activeWorktreeId: 'folder:folder-1',
+      gitStatusByWorktree: {
+        [mocks.activeWorktree.id]: [gitEntry({ path: 'src/file.ts' })],
+        'folder:folder-1': [gitEntry({ path: 'wrong.ts' })]
+      }
+    })
+    renderSourceControl({ worktreeId: mocks.activeWorktree.id, embedded: true })
+
+    clickViewAllButton()
+
+    expect(mocks.calls.activateAndRevealWorktree).toHaveBeenCalledWith(mocks.activeWorktree.id, {
+      revealInSidebar: false,
+      notifyHostRuntime: false
+    })
+    expect(mocks.calls.openAllDiffs).toHaveBeenCalledWith(
+      mocks.activeWorktree.id,
+      '/repo/wt',
+      undefined,
+      'unstaged',
+      [expect.objectContaining({ path: 'src/file.ts' })]
+    )
+  })
+
+  it('activates the scoped child worktree before embedded branch View all opens', () => {
+    resetState({
+      activeWorktreeId: 'folder:folder-1',
+      gitBranchChangesByWorktree: { [mocks.activeWorktree.id]: [branchEntry()] },
+      gitBranchCompareSummaryByWorktree: { [mocks.activeWorktree.id]: branchSummary() }
+    })
+    renderSourceControl({ worktreeId: mocks.activeWorktree.id, embedded: true })
+
+    clickViewAllButton()
+
+    expect(mocks.calls.activateAndRevealWorktree).toHaveBeenCalledWith(mocks.activeWorktree.id, {
+      revealInSidebar: false,
+      notifyHostRuntime: false
+    })
+    expect(mocks.calls.openBranchAllDiffs).toHaveBeenCalledWith(
+      mocks.activeWorktree.id,
+      '/repo/wt',
+      expect.objectContaining({ status: 'ready' })
+    )
+  })
+
+  it('activates the scoped child worktree before embedded row opens', () => {
+    resetState({
+      activeWorktreeId: 'folder:folder-1',
+      gitStatusByWorktree: {
+        [mocks.activeWorktree.id]: [gitEntry({ path: 'src/file.ts' })],
+        'folder:folder-1': [gitEntry({ path: 'wrong.ts' })]
+      }
+    })
+    renderSourceControl({ worktreeId: mocks.activeWorktree.id, embedded: true })
+
+    clickUncommitted('src/file.ts', { ctrlKey: true })
+
+    expect(mocks.calls.activateAndRevealWorktree).toHaveBeenCalledWith(mocks.activeWorktree.id, {
+      revealInSidebar: false,
+      notifyHostRuntime: false
+    })
+    expect(mocks.calls.createEmptySplitGroup).not.toHaveBeenCalled()
+    expect(mocks.calls.openDiff).toHaveBeenCalledWith(
+      mocks.activeWorktree.id,
+      '/repo/wt/src/file.ts',
+      'src/file.ts',
+      'typescript',
+      false,
       { targetGroupId: undefined, preview: true }
     )
   })

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -199,7 +199,6 @@ import type { SourceControlAiWriteTarget } from '../../../../shared/source-contr
 import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { resolveSourceControlLaunchPlatform } from '@/lib/source-control-launch-platform'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
-import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import {
   loadSessionCommitDrafts,
   saveSessionCommitDrafts
@@ -765,6 +764,9 @@ function SourceControlInner({
   const activeGroupId = useAppStore((s) =>
     !embedded && activeWorktreeId ? s.activeGroupIdByWorktree[activeWorktreeId] : undefined
   )
+  const editorDisplayWorktreeId = embedded
+    ? (globalActiveWorktreeId ?? activeWorktreeId)
+    : undefined
   const worktreeMap = useWorktreeMap()
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const activeRepo = useAppStore((s) => {
@@ -886,19 +888,17 @@ function SourceControlInner({
   const setScrollToDiffCommentId = useAppStore((s) => s.setScrollToDiffCommentId)
   const setRightSidebarOpen = useAppStore((s) => s.setRightSidebarOpen)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
-  const activateEmbeddedWorktreeForEditorOpen = useCallback((): boolean => {
-    if (!embedded || !activeWorktreeId) {
-      return true
-    }
-    // Why: editor groups are worktree-scoped today; embedded folder sections
-    // must activate the child before opening files/diffs so tabs land visibly.
-    return (
-      activateAndRevealWorktree(activeWorktreeId, {
-        revealInSidebar: false,
-        notifyHostRuntime: false
-      }) !== false
-    )
-  }, [activeWorktreeId, embedded])
+  const getEmbeddedEditorOpenOptions = useCallback(
+    <T extends Record<string, unknown>>(options?: T): T & { displayWorktreeId?: string } => {
+      if (!embedded || !editorDisplayWorktreeId) {
+        return (options ?? {}) as T & { displayWorktreeId?: string }
+      }
+      // Why: embedded child Source Control opens child-owned files in the
+      // parent folder workspace instead of switching the visible workspace.
+      return { ...(options ?? ({} as T)), displayWorktreeId: editorDisplayWorktreeId }
+    },
+    [editorDisplayWorktreeId, embedded]
+  )
   // Why: pass activeWorktreeId directly (even when null/undefined) so the
   // slice's getDiffComments returns its stable EMPTY_COMMENTS sentinel. An
   // inline `[]` fallback would allocate a new array each store update, break
@@ -4241,9 +4241,6 @@ function SourceControlInner({
       if (!activeWorktreeId || !worktreePath) {
         return
       }
-      if (!activateEmbeddedWorktreeForEditorOpen()) {
-        return
-      }
       const targetGroupId = resolveSplitTargetGroupId(event)
       const openAsPreview = shouldOpenSourceControlRowAsPreview(event, targetGroupId)
       if (entry.conflictKind && entry.conflictStatus) {
@@ -4252,7 +4249,8 @@ function SourceControlInner({
         }
         openConflictFile(activeWorktreeId, worktreePath, entry, detectLanguage(entry.path), {
           targetGroupId,
-          preview: openAsPreview
+          preview: openAsPreview,
+          ...getEmbeddedEditorOpenOptions()
         })
         return
       }
@@ -4275,14 +4273,15 @@ function SourceControlInner({
             language,
             mode: 'edit'
           },
-          { targetGroupId, preview: openAsPreview }
+          getEmbeddedEditorOpenOptions({ targetGroupId, preview: openAsPreview })
         )
         setEditorViewMode(filePath, 'changes')
         return
       }
       openDiff(activeWorktreeId, filePath, entry.path, language, entry.area === 'staged', {
         targetGroupId,
-        preview: openAsPreview
+        preview: openAsPreview,
+        ...getEmbeddedEditorOpenOptions()
       })
     },
     [
@@ -4294,7 +4293,7 @@ function SourceControlInner({
       openDiff,
       openFile,
       setEditorViewMode,
-      activateEmbeddedWorktreeForEditorOpen
+      getEmbeddedEditorOpenOptions
     ]
   )
 
@@ -4864,9 +4863,6 @@ function SourceControlInner({
       ) {
         return
       }
-      if (!activateEmbeddedWorktreeForEditorOpen()) {
-        return
-      }
       const targetGroupId = resolveSplitTargetGroupId(event)
       openBranchDiff(
         activeWorktreeId,
@@ -4874,7 +4870,10 @@ function SourceControlInner({
         entry,
         branchSummary,
         detectLanguage(entry.path),
-        { targetGroupId, preview: shouldOpenSourceControlRowAsPreview(event, targetGroupId) }
+        getEmbeddedEditorOpenOptions({
+          targetGroupId,
+          preview: shouldOpenSourceControlRowAsPreview(event, targetGroupId)
+        })
       )
     },
     [
@@ -4883,7 +4882,7 @@ function SourceControlInner({
       openBranchDiff,
       resolveSplitTargetGroupId,
       worktreePath,
-      activateEmbeddedWorktreeForEditorOpen
+      getEmbeddedEditorOpenOptions
     ]
   )
 
@@ -4894,7 +4893,7 @@ function SourceControlInner({
       activeRepoSettings,
       resolveSplitTargetGroupId,
       getConnectionIdForWorktree: getScopedConnectionId,
-      activateWorktreeForEditorOpen: activateEmbeddedWorktreeForEditorOpen
+      getEditorOpenOptions: getEmbeddedEditorOpenOptions
     })
 
   // Why: a note's filePath is the same relative path used by GitStatusEntry /
@@ -4913,9 +4912,6 @@ function SourceControlInner({
       if (!activeWorktreeId || !worktreePath) {
         return
       }
-      if (!activateEmbeddedWorktreeForEditorOpen()) {
-        return
-      }
       const filePath = comment.filePath
       const commentId = comment.id
       // Defensively clear any dangling prior scroll request before routing
@@ -4927,13 +4923,16 @@ function SourceControlInner({
         const language = detectLanguage(filePath)
         setEditorViewMode(absPath, 'edit')
         setMarkdownViewMode(absPath, 'source')
-        openFile({
-          filePath: absPath,
-          relativePath: filePath,
-          worktreeId: activeWorktreeId,
-          language,
-          mode: 'edit'
-        })
+        openFile(
+          {
+            filePath: absPath,
+            relativePath: filePath,
+            worktreeId: activeWorktreeId,
+            language,
+            mode: 'edit'
+          },
+          getEmbeddedEditorOpenOptions()
+        )
         setPendingEditorReveal(null)
         requestSourceControlEditorRevealFrame(pendingCommentEditorRevealFrameIdsRef, () => {
           requestSourceControlEditorRevealFrame(pendingCommentEditorRevealFrameIdsRef, () => {
@@ -4977,13 +4976,16 @@ function SourceControlInner({
       // via the editor's Edit/Changes toggle.
       const absPath = joinPath(worktreePath, filePath)
       const language = detectLanguage(filePath)
-      openFile({
-        filePath: absPath,
-        relativePath: filePath,
-        worktreeId: activeWorktreeId,
-        language,
-        mode: 'edit'
-      })
+      openFile(
+        {
+          filePath: absPath,
+          relativePath: filePath,
+          worktreeId: activeWorktreeId,
+          language,
+          mode: 'edit'
+        },
+        getEmbeddedEditorOpenOptions()
+      )
       if (commentId) {
         setEditorViewMode(absPath, 'changes')
         setScrollToDiffCommentId(commentId)
@@ -5002,7 +5004,7 @@ function SourceControlInner({
       setMarkdownViewMode,
       setPendingEditorReveal,
       worktreePath,
-      activateEmbeddedWorktreeForEditorOpen
+      getEmbeddedEditorOpenOptions
     ]
   )
 
@@ -5535,14 +5537,12 @@ function SourceControlInner({
                   if (!activeWorktreeId || !worktreePath) {
                     return
                   }
-                  if (!activateEmbeddedWorktreeForEditorOpen()) {
-                    return
-                  }
                   openConflictReview(
                     activeWorktreeId,
                     worktreePath,
                     unresolvedConflictReviewEntries,
-                    'live-summary'
+                    'live-summary',
+                    getEmbeddedEditorOpenOptions()
                   )
                 }}
               />
@@ -5823,15 +5823,13 @@ function SourceControlInner({
                                 if (!activeWorktreeId || !worktreePath) {
                                   return
                                 }
-                                if (!activateEmbeddedWorktreeForEditorOpen()) {
-                                  return
-                                }
                                 if (sectionViewAction.kind === 'conflict-review') {
                                   openConflictReview(
                                     activeWorktreeId,
                                     worktreePath,
                                     sectionViewAction.entries,
-                                    'live-summary'
+                                    'live-summary',
+                                    getEmbeddedEditorOpenOptions()
                                   )
                                 } else {
                                   openAllDiffs(
@@ -5839,7 +5837,8 @@ function SourceControlInner({
                                     worktreePath,
                                     undefined,
                                     sectionViewAction.area,
-                                    sectionViewAction.entries
+                                    sectionViewAction.entries,
+                                    getEmbeddedEditorOpenOptions()
                                   )
                                 }
                               }}
@@ -5962,10 +5961,13 @@ function SourceControlInner({
                     onClick={(e) => {
                       e.stopPropagation()
                       if (activeWorktreeId && worktreePath && branchSummary) {
-                        if (!activateEmbeddedWorktreeForEditorOpen()) {
-                          return
-                        }
-                        openBranchAllDiffs(activeWorktreeId, worktreePath, branchSummary)
+                        openBranchAllDiffs(
+                          activeWorktreeId,
+                          worktreePath,
+                          branchSummary,
+                          undefined,
+                          getEmbeddedEditorOpenOptions()
+                        )
                       }
                     }}
                   >

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1380,7 +1380,9 @@ function SourceControlInner({
   const baseRefOwnedByWorktree = normalizedWorktreeBaseRef !== null
   const pinnedBaseRef = normalizedWorktreeBaseRef ?? normalizedRepoBaseRef
   const hasUncommittedEntries = entries.length > 0
-  const hostedReviewSurfaceEnabled = !embedded
+  // Why: embedded folder sections are scoped to one child worktree, so hosted
+  // review actions can target that repo/host with the same identity as diffs.
+  const hostedReviewSurfaceEnabled = Boolean(activeWorktreeId && activeRepo && !isFolder)
 
   const hostedReviewCreation =
     hostedReviewCreationState &&

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -33,7 +33,7 @@ import {
 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { resolveRemoteOperationErrorMessage } from '@/lib/source-control-remote-error'
-import { useActiveWorktree, useRepoById, useWorktreeMap } from '@/store/selectors'
+import { useWorktreeMap } from '@/store/selectors'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review'
 import { getGitHubPRCacheKey } from '@/store/slices/github-cache-key'
 import { detectLanguage } from '@/lib/language-detect'
@@ -144,7 +144,6 @@ import {
   requestEditorSaveQuiesce
 } from '@/components/editor/editor-autosave'
 import { getConnectionId } from '@/lib/connection-context'
-import { getRepoOwnerRoutedSettings } from '@/lib/repo-runtime-owner'
 import {
   abortRuntimeGitMerge,
   abortRuntimeGitRebase,
@@ -200,6 +199,7 @@ import type { SourceControlAiWriteTarget } from '../../../../shared/source-contr
 import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { resolveSourceControlLaunchPlatform } from '@/lib/source-control-launch-platform'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import {
   loadSessionCommitDrafts,
   saveSessionCommitDrafts
@@ -234,6 +234,11 @@ import {
   localizedHostedReviewCopy,
   resolveSupportedHostedReviewCopyProvider
 } from '@/i18n/hosted-review-localized-copy'
+import {
+  getExecutionHostIdForWorktree,
+  getSettingsForWorktreeRuntimeOwner
+} from '@/lib/worktree-runtime-owner'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import {
   createCreatePrIntentRunToken,
   createPrIntentCurrentTargetConflictsWithToken,
@@ -726,7 +731,15 @@ export function clearRemoteActionErrorsForCompletedConflictOperations({
   return next ?? remoteActionErrors
 }
 
-function SourceControlInner(): React.JSX.Element {
+export type SourceControlProps = {
+  worktreeId?: string
+  embedded?: boolean
+}
+
+function SourceControlInner({
+  worktreeId: scopedWorktreeId,
+  embedded = false
+}: SourceControlProps): React.JSX.Element {
   const sourceControlRef = useRef<HTMLDivElement | null>(null)
   const isMac = useMemo(() => navigator.userAgent.includes('Mac'), [])
   const pendingCommentEditorRevealFrameIdsRef = useRef<number[]>([])
@@ -735,14 +748,40 @@ function SourceControlInner(): React.JSX.Element {
   // state re-renders. A ref flipped synchronously at the start of
   // handleCommit gives us a true single-flight lock.
   const commitInFlightRef = useRef<Record<string, boolean>>({})
-  const activeWorktree = useActiveWorktree()
-  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const globalActiveWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const activeWorktreeId = scopedWorktreeId ?? globalActiveWorktreeId
+  const activeWorktree = useAppStore((s) => {
+    if (!activeWorktreeId) {
+      return null
+    }
+    return (
+      s.getKnownWorktreeById?.(activeWorktreeId) ??
+      Object.values(s.worktreesByRepo)
+        .flat()
+        .find((worktree) => worktree.id === activeWorktreeId) ??
+      null
+    )
+  })
   const activeGroupId = useAppStore((s) =>
-    activeWorktreeId ? s.activeGroupIdByWorktree[activeWorktreeId] : undefined
+    !embedded && activeWorktreeId ? s.activeGroupIdByWorktree[activeWorktreeId] : undefined
   )
   const worktreeMap = useWorktreeMap()
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
-  const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
+  const activeRepo = useAppStore((s) => {
+    if (!activeWorktree?.repoId) {
+      return null
+    }
+    const matchingRepos = s.repos.filter((repo) => repo.id === activeWorktree.repoId)
+    if (matchingRepos.length <= 1 || !activeWorktreeId) {
+      return matchingRepos[0] ?? null
+    }
+    const worktreeHostId = getExecutionHostIdForWorktree(s, activeWorktreeId)
+    return (
+      matchingRepos.find((repo) => getRepoExecutionHostId(repo) === worktreeHostId) ??
+      matchingRepos[0] ??
+      null
+    )
+  })
   const entries = useAppStore((s) =>
     activeWorktreeId
       ? (s.gitStatusByWorktree[activeWorktreeId] ?? EMPTY_GIT_STATUS_ENTRIES)
@@ -774,11 +813,30 @@ function SourceControlInner(): React.JSX.Element {
   const isRemoteOperationActive = useAppStore((s) => s.isRemoteOperationActive)
   const inFlightRemoteOpKind = useAppStore((s) => s.inFlightRemoteOpKind)
   const settings = useAppStore((s) => s.settings)
-  // Why: git/file mutations and repo metadata requests belong to the repo
-  // OWNER host, not the currently focused host in the sidebar.
-  const activeRepoSettings = useMemo(
-    () => getRepoOwnerRoutedSettings(settings, activeRepo ?? null),
-    [activeRepo, settings]
+  const activeRepoSettings = useMemo(() => {
+    if (!settings) {
+      return settings
+    }
+    const ownerSettings = activeWorktreeId
+      ? getSettingsForWorktreeRuntimeOwner(useAppStore.getState(), activeWorktreeId)
+      : { activeRuntimeEnvironmentId: null }
+    return { ...settings, activeRuntimeEnvironmentId: ownerSettings.activeRuntimeEnvironmentId }
+  }, [activeWorktreeId, settings])
+  const getScopedConnectionId = useCallback(
+    (worktreeId: string | null | undefined): string | undefined => {
+      if (!worktreeId) {
+        return undefined
+      }
+      if (worktreeId === activeWorktreeId && activeRepo) {
+        const hostId = getExecutionHostIdForWorktree(useAppStore.getState(), worktreeId)
+        const repoHostId = getRepoExecutionHostId(activeRepo)
+        if (hostId === repoHostId) {
+          return activeRepo.connectionId ?? undefined
+        }
+      }
+      return getConnectionId(worktreeId) ?? undefined
+    },
+    [activeRepo, activeWorktreeId]
   )
   const updateSettings = useAppStore((s) => s.updateSettings)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
@@ -828,6 +886,19 @@ function SourceControlInner(): React.JSX.Element {
   const setScrollToDiffCommentId = useAppStore((s) => s.setScrollToDiffCommentId)
   const setRightSidebarOpen = useAppStore((s) => s.setRightSidebarOpen)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
+  const activateEmbeddedWorktreeForEditorOpen = useCallback((): boolean => {
+    if (!embedded || !activeWorktreeId) {
+      return true
+    }
+    // Why: editor groups are worktree-scoped today; embedded folder sections
+    // must activate the child before opening files/diffs so tabs land visibly.
+    return (
+      activateAndRevealWorktree(activeWorktreeId, {
+        revealInSidebar: false,
+        notifyHostRuntime: false
+      }) !== false
+    )
+  }, [activeWorktreeId, embedded])
   // Why: pass activeWorktreeId directly (even when null/undefined) so the
   // slice's getDiffComments returns its stable EMPTY_COMMENTS sentinel. An
   // inline `[]` fallback would allocate a new array each store update, break
@@ -1035,10 +1106,10 @@ function SourceControlInner(): React.JSX.Element {
       settings: activeRepoSettings,
       worktreeId: token.worktreeId,
       worktreePath: token.worktreePath,
-      connectionId: getConnectionId(token.worktreeId) ?? undefined,
+      connectionId: getScopedConnectionId(token.worktreeId),
       pushTarget: worktreeMap.get(token.worktreeId)?.pushTarget
     }),
-    [activeRepoSettings, worktreeMap]
+    [activeRepoSettings, getScopedConnectionId, worktreeMap]
   )
   const prGenerationRecords = useAppStore((s) => s.pullRequestGenerationRecords)
   const allocatePullRequestGenerationRequestId = useAppStore(
@@ -1099,9 +1170,7 @@ function SourceControlInner(): React.JSX.Element {
     (generateInFlightByWorktree[activeWorktreeId ?? ''] ?? false)
   const generateError =
     activeCommitMessageGenerationRecord?.error ?? generateErrors[activeWorktreeId ?? ''] ?? null
-  const activeConnectionId = activeWorktreeId
-    ? (getConnectionId(activeWorktreeId) ?? activeRepo?.connectionId ?? null)
-    : null
+  const activeConnectionId = getScopedConnectionId(activeWorktreeId) ?? null
   const activeSourceControlLaunchPlatform = resolveSourceControlLaunchPlatform({
     connectionId: activeConnectionId,
     worktreePath,
@@ -1136,13 +1205,16 @@ function SourceControlInner(): React.JSX.Element {
   // The sidebar now stays mounted when closed (for performance), so without
   // this guard the branchCompare interval and PR fetch would keep running
   // with no visible consumer, wasting git process spawns and API calls.
-  const isBranchVisible = rightSidebarTab === 'source-control' && rightSidebarOpen
+  const isBranchVisible =
+    rightSidebarTab === 'source-control' &&
+    rightSidebarOpen &&
+    (!embedded || Boolean(activeWorktreeId))
 
   const refreshActiveGitStatus = useCallback(async (): Promise<void> => {
     if (!activeWorktreeId || !worktreePath || isFolder) {
       return
     }
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+    const connectionId = activeConnectionId ?? undefined
     await refreshGitStatusForWorktree({
       // Why: route git status by the repo OWNER host, not the focused runtime.
       settings: activeRepoSettings,
@@ -1159,6 +1231,7 @@ function SourceControlInner(): React.JSX.Element {
     })
   }, [
     activeRepoSettings,
+    activeConnectionId,
     activeWorktreeId,
     activeWorktree?.pushTarget,
     fetchUpstreamStatus,
@@ -1275,7 +1348,10 @@ function SourceControlInner(): React.JSX.Element {
     setDefaultBaseRef(null)
 
     let stale = false
-    void getRuntimeRepoBaseRefDefault(activeRepoSettings, activeRepo.id)
+    void getRuntimeRepoBaseRefDefault(activeRepoSettings, activeRepo.id, {
+      repoPath: activeRepo.path,
+      executionHostId: getRepoExecutionHostId(activeRepo)
+    })
       .then((result) => {
         if (!stale) {
           // Why: IPC now returns a `{ defaultBaseRef, remoteCount }` envelope;
@@ -1304,9 +1380,11 @@ function SourceControlInner(): React.JSX.Element {
   const baseRefOwnedByWorktree = normalizedWorktreeBaseRef !== null
   const pinnedBaseRef = normalizedWorktreeBaseRef ?? normalizedRepoBaseRef
   const hasUncommittedEntries = entries.length > 0
+  const hostedReviewSurfaceEnabled = !embedded
 
   const hostedReviewCreation =
     hostedReviewCreationState &&
+    hostedReviewSurfaceEnabled &&
     activeRepo?.id === hostedReviewCreationState.repoId &&
     activeWorktreeId === hostedReviewCreationState.worktreeId &&
     branchName === hostedReviewCreationState.branch
@@ -1317,7 +1395,7 @@ function SourceControlInner(): React.JSX.Element {
   )
   const hostedReviewCreateCopy = localizedHostedReviewCopy(hostedReviewCreateProvider)
   const hostedReviewCacheKey =
-    activeRepo && branchName
+    hostedReviewSurfaceEnabled && activeRepo && branchName
       ? getHostedReviewCacheKey(
           activeRepo.path,
           branchName,
@@ -1331,7 +1409,7 @@ function SourceControlInner(): React.JSX.Element {
     ? hostedReviewCache[hostedReviewCacheKey]
     : undefined
   const activePrCacheKey =
-    activeRepo && branchName
+    hostedReviewSurfaceEnabled && activeRepo && branchName
       ? getGitHubPRCacheKey(
           activeRepo.path,
           activeRepo.id,
@@ -1379,6 +1457,7 @@ function SourceControlInner(): React.JSX.Element {
   const linkedAzureDevOpsPR = activeWorktree?.linkedAzureDevOpsPR ?? null
   const linkedGiteaPR = activeWorktree?.linkedGiteaPR ?? null
   const shouldResolveHostedReviewCreation =
+    hostedReviewSurfaceEnabled &&
     isBranchVisible &&
     Boolean(activeRepo) &&
     !isFolder &&
@@ -1501,6 +1580,7 @@ function SourceControlInner(): React.JSX.Element {
       !isBranchVisible ||
       !activeRepo ||
       isFolder ||
+      !hostedReviewSurfaceEnabled ||
       !branchName ||
       branchName === 'HEAD' ||
       !activeWorktreeId
@@ -1530,6 +1610,7 @@ function SourceControlInner(): React.JSX.Element {
     branchName,
     enqueueGitHubPRRefresh,
     fetchHostedReviewForBranch,
+    hostedReviewSurfaceEnabled,
     isBranchVisible,
     isFolder,
     linkedGitHubPR,
@@ -1719,9 +1800,10 @@ function SourceControlInner(): React.JSX.Element {
     openSettingsTarget,
     openSettingsPage
   })
+  const scopedSourceControlAiActionsVisible = !embedded && sourceControlAiActionsVisible
 
   useEffect(() => {
-    if (sourceControlAiActionsVisible) {
+    if (scopedSourceControlAiActionsVisible) {
       return
     }
     setResolveConflictsComposerOpen(false)
@@ -1731,7 +1813,7 @@ function SourceControlInner(): React.JSX.Element {
     setCommitGenerationDialogOpen,
     setPullRequestGenerationDialogOpen,
     setResolveConflictsComposerOpen,
-    sourceControlAiActionsVisible
+    scopedSourceControlAiActionsVisible
   ])
 
   // Why: orphaned draft/error/in-flight entries accumulate when worktrees are
@@ -1851,7 +1933,7 @@ function SourceControlInner(): React.JSX.Element {
               settings: activeRepoSettings,
               worktreeId: activeWorktreeId,
               worktreePath,
-              connectionId: getConnectionId(activeWorktreeId) ?? undefined,
+              connectionId: activeConnectionId ?? undefined,
               pushTarget: activeWorktree?.pushTarget
             }
           : null)
@@ -1951,6 +2033,7 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activeRepoSettings,
+      activeConnectionId,
       activeWorktree?.pushTarget,
       activeWorktreeId,
       beginGitBranchCompareRequest,
@@ -1994,7 +2077,7 @@ function SourceControlInner(): React.JSX.Element {
 
       generateInFlightRef.current[activeWorktreeId] = true
       const requestId = allocateCommitMessageGenerationRequestId()
-      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      const connectionId = activeConnectionId ?? undefined
       setCommitMessageGenerationRecord(
         activeCommitMessageGenerationKey,
         createRunningCommitMessageGenerationRecord({
@@ -2087,6 +2170,7 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activeCommitMessageGenerationKey,
+      activeConnectionId,
       activeRepoSettings,
       activeWorktreeId,
       allocateCommitMessageGenerationRequestId,
@@ -2099,7 +2183,7 @@ function SourceControlInner(): React.JSX.Element {
   )
 
   const handleGenerateCommitMessageClick = useCallback((): void => {
-    if (!sourceControlAiActionsVisible) {
+    if (!scopedSourceControlAiActionsVisible) {
       return
     }
     if (
@@ -2116,7 +2200,7 @@ function SourceControlInner(): React.JSX.Element {
     openCommitGenerationDialog,
     resolvedCommitMessageAi,
     settings,
-    sourceControlAiActionsVisible
+    scopedSourceControlAiActionsVisible
   ])
 
   const generateCommitMessageForCreatePrIntent = useCallback(
@@ -2185,7 +2269,7 @@ function SourceControlInner(): React.JSX.Element {
     updateCommitMessageGenerationRecord(activeCommitMessageGenerationKey, (record) =>
       resolveCommitMessageGenerationCancel(record)
     )
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+    const connectionId = activeConnectionId ?? undefined
     // Why: fire-and-forget — the in-flight generateCommitMessage promise
     // resolves with `{canceled: true}` once the kill propagates, which is
     // where the spinner is cleared. Awaiting here would just delay UI feedback.
@@ -2198,6 +2282,7 @@ function SourceControlInner(): React.JSX.Element {
     })
   }, [
     activeCommitMessageGenerationKey,
+    activeConnectionId,
     activeRepoSettings,
     activeWorktreeId,
     updateCommitMessageGenerationRecord,
@@ -2232,7 +2317,7 @@ function SourceControlInner(): React.JSX.Element {
               settings: activeRepoSettings,
               worktreeId: activeWorktreeId,
               worktreePath,
-              connectionId: getConnectionId(activeWorktreeId) ?? undefined,
+              connectionId: activeConnectionId ?? undefined,
               pushTarget: activeWorktree?.pushTarget
             }
           : null)
@@ -2364,6 +2449,7 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activeRepoSettings,
+      activeConnectionId,
       activeWorktree?.pushTarget,
       activeWorktreeId,
       fetchBranch,
@@ -2406,7 +2492,7 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
 
-      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      const connectionId = activeConnectionId ?? undefined
       setAbortOperationInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: true }))
       setRemoteActionErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
       try {
@@ -2444,6 +2530,7 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activeRepoSettings,
+      activeConnectionId,
       activeWorktreeId,
       confirmAction,
       conflictOperation,
@@ -2628,7 +2715,7 @@ function SourceControlInner(): React.JSX.Element {
       const context: PullRequestGenerationContext = {
         worktreeId: activeWorktreeId,
         worktreePath,
-        connectionId: getConnectionId(activeWorktreeId) ?? undefined,
+        connectionId: activeConnectionId ?? undefined,
         requestId,
         repoId: activeRepo.id,
         branch: branchName,
@@ -2703,6 +2790,7 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activePullRequestGenerationKey,
+      activeConnectionId,
       activeRepo,
       activeRepoSettings,
       activeWorktreeId,
@@ -2805,7 +2893,7 @@ function SourceControlInner(): React.JSX.Element {
     settings: activeRepoSettings,
     submitting: isCreatingPr,
     prCreationDefaults: resolvedPrCreationDefaults,
-    sourceControlAiActionsVisible,
+    sourceControlAiActionsVisible: scopedSourceControlAiActionsVisible,
     onBranchChangedByGeneration: handleBranchChangedByPullRequestGeneration,
     generation: {
       generating: activePullRequestGenerationRecord?.status === 'running',
@@ -2822,7 +2910,7 @@ function SourceControlInner(): React.JSX.Element {
   })
 
   const handleGeneratePullRequestFieldsClick = useCallback((): void => {
-    if (!sourceControlAiActionsVisible) {
+    if (!scopedSourceControlAiActionsVisible) {
       return
     }
     if (
@@ -2841,7 +2929,7 @@ function SourceControlInner(): React.JSX.Element {
     handleGeneratePullRequestFields,
     openPullRequestGenerationDialog,
     settings,
-    sourceControlAiActionsVisible
+    scopedSourceControlAiActionsVisible
   ])
 
   useEffect(() => {
@@ -2921,7 +3009,14 @@ function SourceControlInner(): React.JSX.Element {
   ])
 
   useEffect(() => {
-    if (!isBranchVisible || !activeRepo || isFolder || !branchName || !activeWorktreeId) {
+    if (
+      !isBranchVisible ||
+      !activeRepo ||
+      isFolder ||
+      !hostedReviewSurfaceEnabled ||
+      !branchName ||
+      !activeWorktreeId
+    ) {
       setHostedReviewCreationState(null)
       setHostedReviewCreationRequestState(null)
       return
@@ -2990,6 +3085,7 @@ function SourceControlInner(): React.JSX.Element {
     effectiveBaseRef,
     getHostedReviewCreationEligibility,
     hasUncommittedEntries,
+    hostedReviewSurfaceEnabled,
     setHostedReviewCreationRequestState,
     isBranchVisible,
     isCreatingPr,
@@ -3015,6 +3111,7 @@ function SourceControlInner(): React.JSX.Element {
       !activeWorktreeId ||
       !worktreePath ||
       !hostedReviewCreation ||
+      !hostedReviewSurfaceEnabled ||
       prGenerating ||
       createPrInFlightRef.current[activeWorktreeId]
     ) {
@@ -3157,6 +3254,7 @@ function SourceControlInner(): React.JSX.Element {
     hostedReviewCreateCopy.reviewLabel,
     hostedReviewCreateCopy.titleLabel,
     hostedReviewCreateProvider,
+    hostedReviewSurfaceEnabled,
     prBase,
     prBody,
     prDraft,
@@ -3173,7 +3271,7 @@ function SourceControlInner(): React.JSX.Element {
       token: CreatePrIntentRunToken,
       eligibility: HostedReviewCreationEligibility
     ): Promise<boolean> => {
-      if (!activeRepo || !token.branch || !eligibility.canCreate) {
+      if (!activeRepo || !token.branch || !eligibility.canCreate || !hostedReviewSurfaceEnabled) {
         return false
       }
 
@@ -3369,6 +3467,7 @@ function SourceControlInner(): React.JSX.Element {
       getCreatePrIntentOperationTarget,
       handlePullRequestCreated,
       hostedReviewCreateCopy.reviewLabel,
+      hostedReviewSurfaceEnabled,
       prBase,
       prBody,
       resolvedPrCreationDefaults.draft,
@@ -3394,14 +3493,19 @@ function SourceControlInner(): React.JSX.Element {
           settings: activeRepoSettings,
           worktreeId: token.worktreeId,
           worktreePath: token.worktreePath,
-          connectionId: getConnectionId(token.worktreeId) ?? undefined
+          connectionId: getScopedConnectionId(token.worktreeId)
         },
         baseRef
       )
       setGitBranchCompareResult(token.worktreeId, requestKey, result)
       return result.summary.status === 'ready' ? (result.summary.commitsAhead ?? 0) : undefined
     },
-    [activeRepoSettings, beginGitBranchCompareRequest, setGitBranchCompareResult]
+    [
+      activeRepoSettings,
+      beginGitBranchCompareRequest,
+      getScopedConnectionId,
+      setGitBranchCompareResult
+    ]
   )
 
   const readHostedReviewCreationEligibilityForIntent = useCallback(
@@ -3414,7 +3518,7 @@ function SourceControlInner(): React.JSX.Element {
       hasUncommittedChanges: boolean
       upstreamStatus?: NonNullable<typeof remoteStatus>
     }): Promise<HostedReviewCreationEligibility | null> => {
-      if (!activeRepo || !token.branch) {
+      if (!activeRepo || !token.branch || !hostedReviewSurfaceEnabled) {
         return null
       }
       const result = await getHostedReviewCreationEligibility({
@@ -3446,6 +3550,7 @@ function SourceControlInner(): React.JSX.Element {
       activeRepo,
       fallbackGitHubPRNumber,
       getHostedReviewCreationEligibility,
+      hostedReviewSurfaceEnabled,
       linkedAzureDevOpsPR,
       linkedBitbucketPR,
       linkedGiteaPR,
@@ -3489,6 +3594,7 @@ function SourceControlInner(): React.JSX.Element {
       !activeRepo ||
       !activeWorktreeId ||
       !worktreePath ||
+      !hostedReviewSurfaceEnabled ||
       !branchName ||
       isExecutingBulk ||
       isCommitting ||
@@ -3812,6 +3918,7 @@ function SourceControlInner(): React.JSX.Element {
     generateCommitMessageForCreatePrIntent,
     getCreatePrIntentOperationTarget,
     handleCommit,
+    hostedReviewSurfaceEnabled,
     isCommitting,
     isCreatingPr,
     isExecutingBulk,
@@ -4065,7 +4172,12 @@ function SourceControlInner(): React.JSX.Element {
   // selected Source Control file in a fresh split to the right.
   const resolveSplitTargetGroupId = useCallback(
     (event?: SourceControlRowOpenEvent): string | undefined => {
-      if (!event || !activeWorktreeId || !isSourceControlSplitOpenModifier(event, isMac)) {
+      if (
+        embedded ||
+        !event ||
+        !activeWorktreeId ||
+        !isSourceControlSplitOpenModifier(event, isMac)
+      ) {
         return undefined
       }
       const sourceGroupId =
@@ -4075,7 +4187,14 @@ function SourceControlInner(): React.JSX.Element {
       }
       return createEmptySplitGroup(activeWorktreeId, sourceGroupId, 'right') ?? undefined
     },
-    [activeGroupIdByWorktree, activeWorktreeId, createEmptySplitGroup, groupsByWorktree, isMac]
+    [
+      activeGroupIdByWorktree,
+      activeWorktreeId,
+      createEmptySplitGroup,
+      embedded,
+      groupsByWorktree,
+      isMac
+    ]
   )
 
   // Why: a stable string signature keeps this selector referentially stable so
@@ -4118,6 +4237,9 @@ function SourceControlInner(): React.JSX.Element {
   const handleOpenDiff = useCallback(
     (entry: GitStatusEntry, event?: SourceControlRowOpenEvent) => {
       if (!activeWorktreeId || !worktreePath) {
+        return
+      }
+      if (!activateEmbeddedWorktreeForEditorOpen()) {
         return
       }
       const targetGroupId = resolveSplitTargetGroupId(event)
@@ -4169,7 +4291,8 @@ function SourceControlInner(): React.JSX.Element {
       openConflictFile,
       openDiff,
       openFile,
-      setEditorViewMode
+      setEditorViewMode,
+      activateEmbeddedWorktreeForEditorOpen
     ]
   )
 
@@ -4235,7 +4358,7 @@ function SourceControlInner(): React.JSX.Element {
     }
     setIsExecutingBulk(true)
     try {
-      const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+      const connectionId = activeConnectionId ?? undefined
       await bulkStageRuntimeGitPaths(
         {
           // Why: route staging by the repo OWNER host, not the focused runtime.
@@ -4253,6 +4376,7 @@ function SourceControlInner(): React.JSX.Element {
     }
   }, [
     activeRepoSettings,
+    activeConnectionId,
     worktreePath,
     bulkStagePaths,
     clearSelection,
@@ -4266,7 +4390,7 @@ function SourceControlInner(): React.JSX.Element {
     }
     setIsExecutingBulk(true)
     try {
-      const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+      const connectionId = activeConnectionId ?? undefined
       await bulkUnstageRuntimeGitPaths(
         {
           // Why: route unstaging by the repo OWNER host, not the focused runtime.
@@ -4284,6 +4408,7 @@ function SourceControlInner(): React.JSX.Element {
     }
   }, [
     activeRepoSettings,
+    activeConnectionId,
     worktreePath,
     bulkUnstagePaths,
     clearSelection,
@@ -4298,7 +4423,7 @@ function SourceControlInner(): React.JSX.Element {
       }
       setIsExecutingBulk(true)
       try {
-        const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+        const connectionId = activeConnectionId ?? undefined
         await bulkStageRuntimeGitPaths(
           {
             // Why: route staging by the repo OWNER host, not the focused runtime.
@@ -4317,6 +4442,7 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activeRepoSettings,
+      activeConnectionId,
       activeWorktreeId,
       clearSelection,
       isExecutingBulk,
@@ -4332,7 +4458,7 @@ function SourceControlInner(): React.JSX.Element {
       }
       setIsExecutingBulk(true)
       try {
-        const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+        const connectionId = activeConnectionId ?? undefined
         await bulkUnstageRuntimeGitPaths(
           {
             // Why: route unstaging by the repo OWNER host, not the focused runtime.
@@ -4351,6 +4477,7 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activeRepoSettings,
+      activeConnectionId,
       activeWorktreeId,
       clearSelection,
       isExecutingBulk,
@@ -4376,7 +4503,7 @@ function SourceControlInner(): React.JSX.Element {
     }
     setIsExecutingBulk(true)
     try {
-      const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+      const connectionId = activeConnectionId ?? undefined
       await bulkStageRuntimeGitPaths(
         {
           // Why: route staging by the repo OWNER host, not the focused runtime.
@@ -4394,6 +4521,7 @@ function SourceControlInner(): React.JSX.Element {
     }
   }, [
     activeRepoSettings,
+    activeConnectionId,
     worktreePath,
     isExecutingBulk,
     grouped,
@@ -4473,7 +4601,7 @@ function SourceControlInner(): React.JSX.Element {
     }
 
     try {
-      const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+      const connectionId = activeConnectionId ?? undefined
       const result = await getRuntimeGitBranchCompare(
         {
           // Why: route the branch compare by the repo OWNER host, not the focused runtime.
@@ -4502,6 +4630,7 @@ function SourceControlInner(): React.JSX.Element {
     }
   }, [
     activeRepoSettings,
+    activeConnectionId,
     activeWorktreeId,
     beginGitBranchCompareRequest,
     branchName,
@@ -4572,7 +4701,7 @@ function SourceControlInner(): React.JSX.Element {
     })
 
     try {
-      const connectionId = getConnectionId(worktreeId) ?? undefined
+      const connectionId = getScopedConnectionId(worktreeId)
       const result = await getRuntimeGitHistory(
         {
           // Why: route the history read by the repo OWNER host, not the focused runtime.
@@ -4606,6 +4735,7 @@ function SourceControlInner(): React.JSX.Element {
     activeRepoSettings,
     activeWorktreeId,
     effectiveBaseRef,
+    getScopedConnectionId,
     isBranchVisible,
     isFolder,
     isGitHistoryExpanded,
@@ -4679,7 +4809,7 @@ function SourceControlInner(): React.JSX.Element {
     if (!activeWorktreeId || !worktreePath || isFolder || !isBranchVisible) {
       return
     }
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+    const connectionId = activeConnectionId ?? undefined
     void fetchUpstreamStatus(
       activeWorktreeId,
       worktreePath,
@@ -4689,6 +4819,7 @@ function SourceControlInner(): React.JSX.Element {
     )
   }, [
     activeRepoSettings,
+    activeConnectionId,
     activeWorktree?.pushTarget,
     activeWorktreeId,
     fetchUpstreamStatus,
@@ -4731,6 +4862,9 @@ function SourceControlInner(): React.JSX.Element {
       ) {
         return
       }
+      if (!activateEmbeddedWorktreeForEditorOpen()) {
+        return
+      }
       const targetGroupId = resolveSplitTargetGroupId(event)
       openBranchDiff(
         activeWorktreeId,
@@ -4741,7 +4875,14 @@ function SourceControlInner(): React.JSX.Element {
         { targetGroupId, preview: shouldOpenSourceControlRowAsPreview(event, targetGroupId) }
       )
     },
-    [activeWorktreeId, branchSummary, openBranchDiff, resolveSplitTargetGroupId, worktreePath]
+    [
+      activeWorktreeId,
+      branchSummary,
+      openBranchDiff,
+      resolveSplitTargetGroupId,
+      worktreePath,
+      activateEmbeddedWorktreeForEditorOpen
+    ]
   )
 
   const { loadCommitFiles, openHistoryCommitDiff, openCommitFile, handleCommitAction } =
@@ -4749,7 +4890,9 @@ function SourceControlInner(): React.JSX.Element {
       activeWorktreeId,
       worktreePath,
       activeRepoSettings,
-      resolveSplitTargetGroupId
+      resolveSplitTargetGroupId,
+      getConnectionIdForWorktree: getScopedConnectionId,
+      activateWorktreeForEditorOpen: activateEmbeddedWorktreeForEditorOpen
     })
 
   // Why: a note's filePath is the same relative path used by GitStatusEntry /
@@ -4766,6 +4909,9 @@ function SourceControlInner(): React.JSX.Element {
   const handleOpenComment = useCallback(
     (comment: DiffComment) => {
       if (!activeWorktreeId || !worktreePath) {
+        return
+      }
+      if (!activateEmbeddedWorktreeForEditorOpen()) {
         return
       }
       const filePath = comment.filePath
@@ -4853,7 +4999,8 @@ function SourceControlInner(): React.JSX.Element {
       setScrollToDiffCommentId,
       setMarkdownViewMode,
       setPendingEditorReveal,
-      worktreePath
+      worktreePath,
+      activateEmbeddedWorktreeForEditorOpen
     ]
   )
 
@@ -4863,7 +5010,7 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
       try {
-        const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+        const connectionId = activeConnectionId ?? undefined
         await stageRuntimeGitPath(
           {
             // Why: route staging by the repo OWNER host, not the focused runtime.
@@ -4879,7 +5026,13 @@ function SourceControlInner(): React.JSX.Element {
         // git operation failed silently
       }
     },
-    [activeRepoSettings, worktreePath, activeWorktreeId, refreshActiveGitStatusAfterMutation]
+    [
+      activeRepoSettings,
+      activeConnectionId,
+      worktreePath,
+      activeWorktreeId,
+      refreshActiveGitStatusAfterMutation
+    ]
   )
 
   const handleUnstage = useCallback(
@@ -4888,7 +5041,7 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
       try {
-        const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+        const connectionId = activeConnectionId ?? undefined
         await unstageRuntimeGitPath(
           {
             // Why: route unstaging by the repo OWNER host, not the focused runtime.
@@ -4904,7 +5057,13 @@ function SourceControlInner(): React.JSX.Element {
         // git operation failed silently
       }
     },
-    [activeRepoSettings, worktreePath, activeWorktreeId, refreshActiveGitStatusAfterMutation]
+    [
+      activeRepoSettings,
+      activeConnectionId,
+      worktreePath,
+      activeWorktreeId,
+      refreshActiveGitStatusAfterMutation
+    ]
   )
 
   // Why: split into two variants — `discardSingle` throws so bulk callers can
@@ -4916,8 +5075,7 @@ function SourceControlInner(): React.JSX.Element {
       if (!worktreePath || !activeWorktreeId) {
         return
       }
-      const runtimeEnvironmentId =
-        useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() || null
+      const runtimeEnvironmentId = activeRepoSettings?.activeRuntimeEnvironmentId?.trim() || null
       // Why: git discard replaces the working tree version of this file. Any
       // pending editor autosave must be quiesced first so it cannot recreate
       // the discarded edits after git restores the file.
@@ -4927,7 +5085,7 @@ function SourceControlInner(): React.JSX.Element {
         relativePath: filePath,
         runtimeEnvironmentId
       })
-      const connectionId = getConnectionId(activeWorktreeId ?? null) ?? undefined
+      const connectionId = activeConnectionId ?? undefined
       await discardRuntimeGitPath(
         {
           // Why: route the discard by the repo OWNER host, not the focused runtime.
@@ -4945,7 +5103,7 @@ function SourceControlInner(): React.JSX.Element {
         runtimeEnvironmentId
       })
     },
-    [activeRepoSettings, activeWorktreeId, worktreePath]
+    [activeRepoSettings, activeConnectionId, activeWorktreeId, worktreePath]
   )
 
   const discardMany = useCallback(
@@ -4953,8 +5111,7 @@ function SourceControlInner(): React.JSX.Element {
       if (!worktreePath || !activeWorktreeId) {
         return
       }
-      const runtimeEnvironmentId =
-        useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() || null
+      const runtimeEnvironmentId = activeRepoSettings?.activeRuntimeEnvironmentId?.trim() || null
       // Why: bulk discard replaces many working-tree files at once. Quiesce
       // any matching editor autosaves before git mutates the files so a delayed
       // save cannot recreate edits after the restore.
@@ -4968,7 +5125,7 @@ function SourceControlInner(): React.JSX.Element {
           })
         )
       )
-      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      const connectionId = activeConnectionId ?? undefined
       await bulkDiscardRuntimeGitPaths(
         {
           // Why: route the discard by the repo OWNER host, not the focused runtime.
@@ -4988,7 +5145,7 @@ function SourceControlInner(): React.JSX.Element {
         })
       }
     },
-    [activeRepoSettings, activeWorktreeId, worktreePath]
+    [activeRepoSettings, activeConnectionId, activeWorktreeId, worktreePath]
   )
 
   const handleDiscard = useCallback(
@@ -5024,7 +5181,7 @@ function SourceControlInner(): React.JSX.Element {
       }
       setIsExecutingBulk(true)
       try {
-        const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+        const connectionId = activeConnectionId ?? undefined
         // Why: `onError` fires once per failure — both for the bulk-unstage
         // pre-step and for each per-file discard failure. Aggregate into one
         // toast after the sequence completes so a partial failure across N
@@ -5093,6 +5250,7 @@ function SourceControlInner(): React.JSX.Element {
     },
     [
       activeRepoSettings,
+      activeConnectionId,
       worktreePath,
       activeWorktreeId,
       grouped,
@@ -5249,12 +5407,14 @@ function SourceControlInner(): React.JSX.Element {
                 )}
               </button>
               <div className="ml-1 flex shrink-0 items-center gap-1.5">
-                <DiffNotesSendMenu
-                  worktreeId={activeWorktreeId}
-                  groupId={activeGroupId ?? activeWorktreeId}
-                  comments={diffCommentsForActive}
-                  triggerClassName="size-6"
-                />
+                {!embedded && (
+                  <DiffNotesSendMenu
+                    worktreeId={activeWorktreeId}
+                    groupId={activeGroupId ?? activeWorktreeId}
+                    comments={diffCommentsForActive}
+                    triggerClassName="size-6"
+                  />
+                )}
                 {diffCommentCount > 0 && (
                   <TooltipProvider delayDuration={400}>
                     <Tooltip>
@@ -5356,7 +5516,7 @@ function SourceControlInner(): React.JSX.Element {
               <ConflictSummaryCard
                 conflictOperation={conflictOperation}
                 unresolvedCount={unresolvedConflictReviewEntries.length}
-                sourceControlAiActionsVisible={sourceControlAiActionsVisible}
+                sourceControlAiActionsVisible={scopedSourceControlAiActionsVisible}
                 isResolvingWithAI={false}
                 isAbortingOperation={isAbortingOperation}
                 onAbortOperation={handleAbortOperationForConflict}
@@ -5365,6 +5525,9 @@ function SourceControlInner(): React.JSX.Element {
                 }}
                 onReview={() => {
                   if (!activeWorktreeId || !worktreePath) {
+                    return
+                  }
+                  if (!activateEmbeddedWorktreeForEditorOpen()) {
                     return
                   }
                   openConflictReview(
@@ -5466,7 +5629,7 @@ function SourceControlInner(): React.JSX.Element {
                 baseResults={prBaseResults}
                 setBaseResults={setPrBaseResults}
                 baseSearchError={prBaseSearchError}
-                aiGenerationEnabled={sourceControlAiActionsVisible && prAiGenerationEnabled}
+                aiGenerationEnabled={scopedSourceControlAiActionsVisible && prAiGenerationEnabled}
                 generating={prGenerating}
                 generateDisabled={prGenerateDisabled}
                 generateDisabledReason={prGenerateDisabledReason}
@@ -5501,8 +5664,10 @@ function SourceControlInner(): React.JSX.Element {
                 isCreatePrIntentInFlight={isCreatePrIntentInFlight}
                 groupId={activeGroupId ?? activeWorktreeId}
                 showComposer={!showGenericEmptyState}
-                sourceControlAiActionsVisible={sourceControlAiActionsVisible}
-                aiEnabled={sourceControlAiActionsVisible && resolvedCommitMessageAi?.ok === true}
+                sourceControlAiActionsVisible={scopedSourceControlAiActionsVisible}
+                aiEnabled={
+                  scopedSourceControlAiActionsVisible && resolvedCommitMessageAi?.ok === true
+                }
                 aiAgentConfigured={resolvedCommitMessageAi?.ok === true}
                 isGenerating={isGenerating}
                 generateError={generateError}
@@ -5650,6 +5815,9 @@ function SourceControlInner(): React.JSX.Element {
                                 if (!activeWorktreeId || !worktreePath) {
                                   return
                                 }
+                                if (!activateEmbeddedWorktreeForEditorOpen()) {
+                                  return
+                                }
                                 if (sectionViewAction.kind === 'conflict-review') {
                                   openConflictReview(
                                     activeWorktreeId,
@@ -5786,6 +5954,9 @@ function SourceControlInner(): React.JSX.Element {
                     onClick={(e) => {
                       e.stopPropagation()
                       if (activeWorktreeId && worktreePath && branchSummary) {
+                        if (!activateEmbeddedWorktreeForEditorOpen()) {
+                          return
+                        }
                         openBranchAllDiffs(activeWorktreeId, worktreePath, branchSummary)
                       }
                     }}
@@ -5936,9 +6107,14 @@ function SourceControlInner(): React.JSX.Element {
           <div className="min-h-0 overflow-y-auto scrollbar-sleek">
             <BaseRefPicker
               repoId={activeRepo.id}
+              repoPath={activeRepo.path}
+              executionHostId={getRepoExecutionHostId(activeRepo)}
               currentBaseRef={pickerBaseRef}
+              runtimeSettings={activeRepoSettings}
               onSelect={(ref) => {
-                if (baseRefOwnedByWorktree && activeWorktreeId) {
+                // Why: embedded folder sections can share repo ids across hosts;
+                // worktree-scoped refs avoid updating the wrong host's repo row.
+                if ((embedded || baseRefOwnedByWorktree) && activeWorktreeId) {
                   void updateWorktreeMeta(activeWorktreeId, { baseRef: ref })
                 } else {
                   void updateRepo(activeRepo.id, { worktreeBaseRef: ref })
@@ -5947,7 +6123,9 @@ function SourceControlInner(): React.JSX.Element {
                 window.setTimeout(() => void refreshBranchCompare(), 0)
               }}
               onUsePrimary={() => {
-                if (baseRefOwnedByWorktree && activeWorktreeId) {
+                // Why: embedded folder sections can share repo ids across hosts;
+                // worktree-scoped refs avoid updating the wrong host's repo row.
+                if ((embedded || baseRefOwnedByWorktree) && activeWorktreeId) {
                   void updateWorktreeMeta(activeWorktreeId, { baseRef: undefined })
                 } else {
                   void updateRepo(activeRepo.id, { worktreeBaseRef: undefined })
@@ -5960,7 +6138,7 @@ function SourceControlInner(): React.JSX.Element {
         </DialogContent>
       </Dialog>
       <SourceControlAgentActionDialog
-        open={sourceControlAiActionsVisible && resolveConflictsComposerOpen}
+        open={scopedSourceControlAiActionsVisible && resolveConflictsComposerOpen}
         onOpenChange={setResolveConflictsComposerOpen}
         actionId="resolveConflicts"
         title={translate(
@@ -5998,7 +6176,7 @@ function SourceControlInner(): React.JSX.Element {
         }
       />
       <SourceControlTextGenerationDialog
-        open={sourceControlAiActionsVisible && commitGenerationDialogOpen}
+        open={scopedSourceControlAiActionsVisible && commitGenerationDialogOpen}
         onOpenChange={setCommitGenerationDialogOpen}
         actionId="commitMessage"
         title={translate(
@@ -6019,7 +6197,7 @@ function SourceControlInner(): React.JSX.Element {
         onSaveDefaults={handleSaveCommitMessageGenerationDefaults}
       />
       <SourceControlTextGenerationDialog
-        open={sourceControlAiActionsVisible && pullRequestGenerationDialogOpen}
+        open={scopedSourceControlAiActionsVisible && pullRequestGenerationDialogOpen}
         onOpenChange={setPullRequestGenerationDialogOpen}
         actionId="pullRequest"
         title={translate(

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -5331,7 +5331,10 @@ function SourceControlInner({
 
   return (
     <>
-      <div ref={setSourceControlRoot} className="relative flex h-full flex-col overflow-hidden">
+      <div
+        ref={setSourceControlRoot}
+        className={cn('relative flex flex-col overflow-hidden', embedded ? 'min-h-0' : 'h-full')}
+      >
         <SourceControlHeaderToolbar
           filterQuery={filterQuery}
           filterExpanded={filterExpanded}
@@ -5508,7 +5511,10 @@ function SourceControlInner({
         )}
 
         <div
-          className="relative flex flex-1 flex-col overflow-auto scrollbar-sleek pt-1"
+          className={cn(
+            'relative flex flex-1 flex-col overflow-auto scrollbar-sleek',
+            embedded ? 'pt-0.5 pb-3' : 'pt-1'
+          )}
           style={{ paddingBottom: selectedKeys.size > 0 ? 50 : undefined }}
         >
           {unresolvedConflictReviewEntries.length > 0 && (

--- a/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
+++ b/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
@@ -21,6 +21,8 @@ export type ActivityBarItem = {
   shortcut: string
   /** When true, hidden for non-git (folder-mode) repos. */
   gitOnly?: boolean
+  /** When true, git-only items remain visible for folder workspaces. */
+  folderWorkspaceAllowed?: boolean
   /** When true, shown only for folder workspaces. */
   folderOnly?: boolean
   /** When true, shown only for worktrees that belong to an SSH repo. */

--- a/src/renderer/src/components/right-sidebar/folder-workspace-source-control-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/folder-workspace-source-control-refresh.test.ts
@@ -1,0 +1,412 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo, Worktree } from '../../../../shared/types'
+import {
+  getFolderSourceControlRefreshCandidates,
+  invalidateFolderSourceControlRefreshGeneration,
+  runLimitedFolderSourceControlRefreshes,
+  type FolderSourceControlRefreshCandidate
+} from './folder-workspace-source-control-refresh'
+
+const refreshMocks = vi.hoisted(() => ({
+  getConnectionId: vi.fn(),
+  getRightSidebarWorktreeRuntimeSettings: vi.fn(() => ({ activeRuntimeEnvironmentId: null })),
+  isWebRuntimeSessionActive: vi.fn(() => true),
+  refreshGitStatusForWorktree: vi.fn()
+}))
+
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: refreshMocks.getConnectionId
+}))
+
+vi.mock('./file-explorer-runtime-owner', () => ({
+  getRightSidebarWorktreeRuntimeSettings: refreshMocks.getRightSidebarWorktreeRuntimeSettings
+}))
+
+vi.mock('./git-status-refresh', () => ({
+  refreshGitStatusForWorktree: refreshMocks.refreshGitStatusForWorktree
+}))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  isWebRuntimeSessionActive: refreshMocks.isWebRuntimeSessionActive
+}))
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    badgeColor: '#fff',
+    addedAt: 1,
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> & { id: string }): Worktree {
+  return {
+    path: `/worktrees/${overrides.id}`,
+    head: 'abc',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    repoId: 'repo-1',
+    displayName: overrides.id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+function makeCandidate(
+  overrides: Partial<FolderSourceControlRefreshCandidate> = {}
+): FolderSourceControlRefreshCandidate {
+  return {
+    worktree: makeWorktree({ id: 'repo-1::/child' }),
+    repo: makeRepo(),
+    expanded: true,
+    manual: false,
+    ...overrides
+  }
+}
+
+function makeDeps() {
+  return {
+    setGitStatus: vi.fn(),
+    updateWorktreeGitIdentity: vi.fn(),
+    setUpstreamStatus: vi.fn(),
+    fetchUpstreamStatus: vi.fn()
+  }
+}
+
+describe('folder workspace Source Control refresh scheduling', () => {
+  beforeEach(() => {
+    refreshMocks.getConnectionId.mockReset()
+    refreshMocks.getRightSidebarWorktreeRuntimeSettings.mockReset()
+    refreshMocks.getRightSidebarWorktreeRuntimeSettings.mockReturnValue({
+      activeRuntimeEnvironmentId: null
+    })
+    refreshMocks.isWebRuntimeSessionActive.mockReset()
+    refreshMocks.isWebRuntimeSessionActive.mockReturnValue(true)
+    refreshMocks.refreshGitStatusForWorktree.mockReset()
+    refreshMocks.refreshGitStatusForWorktree.mockResolvedValue(undefined)
+  })
+
+  it('deduplicates a child worktree across overlapping refresh batches', async () => {
+    let resolveRefresh: (() => void) | undefined
+    refreshMocks.refreshGitStatusForWorktree.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve
+        })
+    )
+    const inFlightWorktreeIds = new Map<string, number>()
+    const candidate = makeCandidate()
+
+    const firstRun = runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps: makeDeps(),
+      sshConnectionStates: new Map(),
+      inFlightWorktreeIds
+    })
+    await Promise.resolve()
+
+    await runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps: makeDeps(),
+      sshConnectionStates: new Map(),
+      inFlightWorktreeIds
+    })
+
+    expect(refreshMocks.refreshGitStatusForWorktree).toHaveBeenCalledTimes(1)
+    const finishRefresh = resolveRefresh
+    if (!finishRefresh) {
+      throw new Error('Expected refresh promise to be pending')
+    }
+    finishRefresh()
+    await firstRun
+    expect(inFlightWorktreeIds.has(candidate.worktree.id)).toBe(false)
+  })
+
+  it('deduplicates queued children across overlapping refresh batches', async () => {
+    const pendingRefreshResolves: (() => void)[] = []
+    refreshMocks.refreshGitStatusForWorktree.mockImplementation(() => {
+      if (pendingRefreshResolves.length >= 3) {
+        return Promise.resolve()
+      }
+      return new Promise<void>((resolve) => {
+        pendingRefreshResolves.push(resolve)
+      })
+    })
+    const inFlightWorktreeIds = new Map<string, number>()
+    const candidates = ['one', 'two', 'three', 'four'].map((name) =>
+      makeCandidate({ worktree: makeWorktree({ id: `repo-1::/${name}`, displayName: name }) })
+    )
+
+    const firstRun = runLimitedFolderSourceControlRefreshes({
+      candidates,
+      deps: makeDeps(),
+      sshConnectionStates: new Map(),
+      inFlightWorktreeIds
+    })
+    await Promise.resolve()
+
+    await runLimitedFolderSourceControlRefreshes({
+      candidates: [candidates[3]],
+      deps: makeDeps(),
+      sshConnectionStates: new Map(),
+      inFlightWorktreeIds
+    })
+
+    expect(refreshMocks.refreshGitStatusForWorktree).toHaveBeenCalledTimes(3)
+    if (pendingRefreshResolves.length !== 3) {
+      throw new Error('Expected three refresh promises to be pending')
+    }
+    pendingRefreshResolves.forEach((resolve) => resolve())
+    await firstRun
+    expect(inFlightWorktreeIds.size).toBe(0)
+  })
+
+  it('does not let an older refresh clear a newer reservation', async () => {
+    const pendingRefreshResolves: (() => void)[] = []
+    refreshMocks.refreshGitStatusForWorktree.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pendingRefreshResolves.push(resolve)
+        })
+    )
+    const inFlightWorktreeIds = new Map<string, number>()
+    const refreshGenerationByWorktree = new Map<string, number>()
+    const candidate = makeCandidate()
+
+    const firstRun = runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps: makeDeps(),
+      sshConnectionStates: new Map(),
+      inFlightWorktreeIds,
+      refreshGenerationByWorktree
+    })
+    await Promise.resolve()
+    invalidateFolderSourceControlRefreshGeneration(refreshGenerationByWorktree, [
+      candidate.worktree.id
+    ])
+    inFlightWorktreeIds.delete(candidate.worktree.id)
+
+    const secondRun = runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps: makeDeps(),
+      sshConnectionStates: new Map(),
+      inFlightWorktreeIds,
+      refreshGenerationByWorktree
+    })
+    await Promise.resolve()
+    expect(pendingRefreshResolves).toHaveLength(2)
+    expect(inFlightWorktreeIds.has(candidate.worktree.id)).toBe(true)
+
+    pendingRefreshResolves[0]()
+    await firstRun
+
+    expect(inFlightWorktreeIds.has(candidate.worktree.id)).toBe(true)
+    pendingRefreshResolves[1]()
+    await secondRun
+    expect(inFlightWorktreeIds.has(candidate.worktree.id)).toBe(false)
+  })
+
+  it('ignores queued refresh side effects after cleanup invalidates the batch', async () => {
+    const pendingRefreshResolves: (() => void)[] = []
+    let queuedRefreshArgs: { deps: ReturnType<typeof makeDeps> } | undefined
+    refreshMocks.refreshGitStatusForWorktree.mockImplementation(
+      (args: { deps: ReturnType<typeof makeDeps> }) => {
+        if (pendingRefreshResolves.length < 3) {
+          return new Promise<void>((resolve) => {
+            pendingRefreshResolves.push(resolve)
+          })
+        }
+        queuedRefreshArgs = args
+        return Promise.resolve()
+      }
+    )
+    const inFlightWorktreeIds = new Map<string, number>()
+    const refreshGenerationByWorktree = new Map<string, number>()
+    const deps = makeDeps()
+    const candidates = ['one', 'two', 'three', 'four'].map((name) =>
+      makeCandidate({ worktree: makeWorktree({ id: `repo-1::/${name}`, displayName: name }) })
+    )
+
+    const run = runLimitedFolderSourceControlRefreshes({
+      candidates,
+      deps,
+      sshConnectionStates: new Map(),
+      inFlightWorktreeIds,
+      refreshGenerationByWorktree,
+      concurrency: 3
+    })
+    await Promise.resolve()
+    invalidateFolderSourceControlRefreshGeneration(
+      refreshGenerationByWorktree,
+      candidates.map((candidate) => candidate.worktree.id)
+    )
+    for (const candidate of candidates) {
+      inFlightWorktreeIds.delete(candidate.worktree.id)
+    }
+
+    pendingRefreshResolves[0]()
+    await Promise.resolve()
+    queuedRefreshArgs?.deps.setGitStatus(candidates[3].worktree.id, { entries: [] } as never)
+    expect(deps.setGitStatus).not.toHaveBeenCalled()
+
+    pendingRefreshResolves.slice(1).forEach((resolve) => resolve())
+    await run
+  })
+
+  it('allows retry after timeout while ignoring late older refresh side effects', async () => {
+    let firstRefreshArgs: { deps: ReturnType<typeof makeDeps> } | undefined
+    let firstRefresh = true
+    refreshMocks.refreshGitStatusForWorktree.mockImplementation(
+      (args: { deps: ReturnType<typeof makeDeps> }) => {
+        if (firstRefresh) {
+          firstRefresh = false
+          firstRefreshArgs = args
+          return new Promise<void>(() => undefined)
+        }
+        return Promise.resolve()
+      }
+    )
+    const inFlightWorktreeIds = new Map<string, number>()
+    const refreshGenerationByWorktree = new Map<string, number>()
+    const candidate = makeCandidate()
+    const deps = makeDeps()
+
+    await runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps,
+      sshConnectionStates: new Map(),
+      inFlightWorktreeIds,
+      refreshGenerationByWorktree,
+      timeoutMs: 1
+    })
+
+    expect(inFlightWorktreeIds.has(candidate.worktree.id)).toBe(false)
+    firstRefreshArgs?.deps.setGitStatus(candidate.worktree.id, { entries: [] } as never)
+    expect(deps.setGitStatus).not.toHaveBeenCalled()
+
+    await runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps,
+      sshConnectionStates: new Map(),
+      inFlightWorktreeIds,
+      refreshGenerationByWorktree
+    })
+
+    expect(refreshMocks.refreshGitStatusForWorktree).toHaveBeenCalledTimes(2)
+    firstRefreshArgs?.deps.setGitStatus(candidate.worktree.id, { entries: [] } as never)
+    expect(deps.setGitStatus).not.toHaveBeenCalled()
+  })
+
+  it('skips inactive runtime-owned repos without consuming a git refresh', async () => {
+    refreshMocks.isWebRuntimeSessionActive.mockReturnValue(false)
+    const outcomes = new Map<string, unknown>()
+    const candidate = makeCandidate({
+      repo: makeRepo({ executionHostId: 'runtime:owner-env' })
+    })
+
+    await runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps: makeDeps(),
+      sshConnectionStates: new Map(),
+      onOutcome: (worktreeId, outcome) => outcomes.set(worktreeId, outcome)
+    })
+
+    expect(refreshMocks.isWebRuntimeSessionActive).toHaveBeenCalledWith('owner-env')
+    expect(refreshMocks.refreshGitStatusForWorktree).not.toHaveBeenCalled()
+    expect(outcomes.get(candidate.worktree.id)).toEqual({
+      kind: 'unavailable',
+      reason: 'runtime'
+    })
+  })
+
+  it('skips disconnected SSH repos declared through executionHostId', async () => {
+    const outcomes = new Map<string, unknown>()
+    const candidate = makeCandidate({
+      repo: makeRepo({ connectionId: null, executionHostId: 'ssh:ssh-target' })
+    })
+
+    await runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps: makeDeps(),
+      sshConnectionStates: new Map([['ssh-target', { status: 'disconnected' }]]),
+      onOutcome: (worktreeId, outcome) => outcomes.set(worktreeId, outcome)
+    })
+
+    expect(refreshMocks.refreshGitStatusForWorktree).not.toHaveBeenCalled()
+    expect(outcomes.get(candidate.worktree.id)).toEqual({
+      kind: 'unavailable',
+      reason: 'ssh'
+    })
+  })
+
+  it('skips disconnected SSH worktrees declared through hostId', async () => {
+    const outcomes = new Map<string, unknown>()
+    const candidate = makeCandidate({
+      repo: makeRepo({ connectionId: null, executionHostId: 'local' }),
+      worktree: makeWorktree({ id: 'repo-1::/ssh-child', hostId: 'ssh:ssh-target' })
+    })
+
+    await runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps: makeDeps(),
+      sshConnectionStates: new Map([['ssh-target', { status: 'disconnected' }]]),
+      onOutcome: (worktreeId, outcome) => outcomes.set(worktreeId, outcome)
+    })
+
+    expect(refreshMocks.refreshGitStatusForWorktree).not.toHaveBeenCalled()
+    expect(outcomes.get(candidate.worktree.id)).toEqual({
+      kind: 'unavailable',
+      reason: 'ssh'
+    })
+  })
+
+  it('does not inherit repo SSH connection when a worktree host is local', async () => {
+    const candidate = makeCandidate({
+      repo: makeRepo({ connectionId: 'ssh-target', executionHostId: 'ssh:ssh-target' }),
+      worktree: makeWorktree({ id: 'repo-1::/local-child', hostId: 'local' })
+    })
+
+    await runLimitedFolderSourceControlRefreshes({
+      candidates: [candidate],
+      deps: makeDeps(),
+      sshConnectionStates: new Map([['ssh-target', { status: 'disconnected' }]])
+    })
+
+    expect(refreshMocks.refreshGitStatusForWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: undefined })
+    )
+  })
+
+  it('selects the repo matching a worktree host when repo ids are duplicated', () => {
+    const worktree = makeWorktree({ id: 'repo-1::/ssh-child', hostId: 'ssh:ssh-target' })
+    const candidates = getFolderSourceControlRefreshCandidates({
+      worktrees: [worktree],
+      repos: [
+        makeRepo({ connectionId: null, executionHostId: 'local', displayName: 'Local Repo' }),
+        makeRepo({
+          connectionId: 'ssh-target',
+          executionHostId: 'ssh:ssh-target',
+          displayName: 'SSH Repo'
+        })
+      ],
+      expandedWorktreeIds: new Set([worktree.id])
+    })
+
+    expect(candidates[0]?.repo.displayName).toBe('SSH Repo')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/folder-workspace-source-control-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/folder-workspace-source-control-refresh.ts
@@ -1,0 +1,298 @@
+import { getConnectionId } from '@/lib/connection-context'
+import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-owner'
+import { refreshGitStatusForWorktree } from './git-status-refresh'
+import type { GitStatusRefreshDeps } from './git-status-refresh'
+import type { Repo, Worktree } from '../../../../shared/types'
+import { isFolderRepo } from '../../../../shared/repo-kind'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../../../shared/execution-host'
+import { isWebRuntimeSessionActive } from '@/runtime/web-runtime-session'
+
+const REFRESH_TIMEOUT_ERROR_NAME = 'FolderSourceControlRefreshTimeout'
+let nextRefreshReservationToken = 1
+
+export type FolderSourceControlRefreshCandidate = {
+  worktree: Worktree
+  repo: Repo
+  expanded: boolean
+  manual: boolean
+}
+
+export type FolderSourceControlRefreshOutcome =
+  | { kind: 'loading' }
+  | { kind: 'fresh' }
+  | { kind: 'unavailable'; reason: 'ssh' | 'runtime' | 'folder' }
+  | { kind: 'failed'; error: unknown }
+
+export type FolderSourceControlRefreshReservations = Map<string, number>
+
+type QueuedFolderSourceControlRefresh = {
+  candidate: FolderSourceControlRefreshCandidate
+  generation: number
+  reservationToken: number
+}
+
+export function getFolderSourceControlRefreshCandidates({
+  worktrees,
+  repos,
+  expandedWorktreeIds,
+  manualWorktreeIds = new Set()
+}: {
+  worktrees: readonly Worktree[]
+  repos: readonly Repo[]
+  expandedWorktreeIds: ReadonlySet<string>
+  manualWorktreeIds?: ReadonlySet<string>
+}): FolderSourceControlRefreshCandidate[] {
+  return worktrees
+    .map((worktree) => {
+      const repo = resolveFolderSourceControlRepo(worktree, repos)
+      if (!repo) {
+        return null
+      }
+      return {
+        worktree,
+        repo,
+        expanded: expandedWorktreeIds.has(worktree.id),
+        manual: manualWorktreeIds.has(worktree.id)
+      }
+    })
+    .filter((candidate): candidate is FolderSourceControlRefreshCandidate => candidate !== null)
+    .sort(compareFolderSourceControlRefreshCandidates)
+}
+
+export function resolveFolderSourceControlRepo(
+  worktree: Worktree,
+  repos: readonly Repo[]
+): Repo | null {
+  const matchingRepos = repos.filter((repo) => repo.id === worktree.repoId)
+  if (matchingRepos.length <= 1) {
+    return matchingRepos[0] ?? null
+  }
+  const worktreeHost = parseExecutionHostId(worktree.hostId)
+  if (worktreeHost) {
+    return (
+      matchingRepos.find((repo) => getRepoExecutionHostId(repo) === worktreeHost.id) ??
+      matchingRepos[0] ??
+      null
+    )
+  }
+  return matchingRepos[0] ?? null
+}
+
+export async function runLimitedFolderSourceControlRefreshes({
+  candidates,
+  deps,
+  sshConnectionStates,
+  inFlightWorktreeIds,
+  refreshGenerationByWorktree,
+  concurrency = 3,
+  timeoutMs = 15_000,
+  onOutcome
+}: {
+  candidates: readonly FolderSourceControlRefreshCandidate[]
+  deps: GitStatusRefreshDeps
+  sshConnectionStates: Map<string, { status?: string }>
+  inFlightWorktreeIds?: FolderSourceControlRefreshReservations
+  refreshGenerationByWorktree?: Map<string, number>
+  concurrency?: number
+  timeoutMs?: number
+  onOutcome?: (worktreeId: string, outcome: FolderSourceControlRefreshOutcome) => void
+}): Promise<void> {
+  const queuedWorktreeIds = new Set<string>()
+  const generationMap = refreshGenerationByWorktree ?? new Map<string, number>()
+  const reservedWorktreeIds = inFlightWorktreeIds ?? new Map<string, number>()
+  const queue: QueuedFolderSourceControlRefresh[] = []
+  for (const candidate of candidates) {
+    if (
+      queuedWorktreeIds.has(candidate.worktree.id) ||
+      reservedWorktreeIds.has(candidate.worktree.id)
+    ) {
+      continue
+    }
+    queuedWorktreeIds.add(candidate.worktree.id)
+    const generation = (generationMap.get(candidate.worktree.id) ?? 0) + 1
+    const reservationToken = nextRefreshReservationToken++
+    generationMap.set(candidate.worktree.id, generation)
+    reservedWorktreeIds.set(candidate.worktree.id, reservationToken)
+    queue.push({ candidate, generation, reservationToken })
+  }
+  let cursor = 0
+  const workerCount = Math.max(1, Math.min(concurrency, queue.length || 1))
+
+  const runWorker = async (): Promise<void> => {
+    while (cursor < queue.length) {
+      const { candidate, generation, reservationToken } = queue[cursor]
+      cursor += 1
+      try {
+        const outcome = await refreshFolderSourceControlCandidate({
+          candidate,
+          deps: createGenerationScopedRefreshDeps({
+            deps,
+            generation,
+            generationMap,
+            worktreeId: candidate.worktree.id
+          }),
+          sshConnectionStates,
+          timeoutMs,
+          onOutcome
+        })
+        if (outcome.kind === 'failed') {
+          invalidateFolderSourceControlRefreshGeneration(generationMap, [candidate.worktree.id])
+        }
+        onOutcome?.(candidate.worktree.id, outcome)
+      } finally {
+        if (reservedWorktreeIds.get(candidate.worktree.id) === reservationToken) {
+          reservedWorktreeIds.delete(candidate.worktree.id)
+        }
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, runWorker))
+}
+
+export function invalidateFolderSourceControlRefreshGeneration(
+  generationMap: Map<string, number>,
+  worktreeIds: Iterable<string>
+): void {
+  for (const worktreeId of worktreeIds) {
+    generationMap.set(worktreeId, (generationMap.get(worktreeId) ?? 0) + 1)
+  }
+}
+
+function createGenerationScopedRefreshDeps({
+  deps,
+  generation,
+  generationMap,
+  worktreeId
+}: {
+  deps: GitStatusRefreshDeps
+  generation: number
+  generationMap: Map<string, number>
+  worktreeId: string
+}): GitStatusRefreshDeps {
+  const isCurrent = () => generationMap.get(worktreeId) === generation
+  return {
+    setGitStatus: (targetWorktreeId, status) => {
+      if (isCurrent()) {
+        deps.setGitStatus(targetWorktreeId, status)
+      }
+    },
+    updateWorktreeGitIdentity: (targetWorktreeId, identity) => {
+      if (isCurrent()) {
+        deps.updateWorktreeGitIdentity(targetWorktreeId, identity)
+      }
+    },
+    setUpstreamStatus: (targetWorktreeId, status) => {
+      if (isCurrent()) {
+        deps.setUpstreamStatus(targetWorktreeId, status)
+      }
+    },
+    fetchUpstreamStatus: (...args) => deps.fetchUpstreamStatus(...args)
+  }
+}
+
+async function refreshFolderSourceControlCandidate({
+  candidate,
+  deps,
+  sshConnectionStates,
+  timeoutMs,
+  onOutcome
+}: {
+  candidate: FolderSourceControlRefreshCandidate
+  deps: GitStatusRefreshDeps
+  sshConnectionStates: Map<string, { status?: string }>
+  timeoutMs: number
+  onOutcome?: (worktreeId: string, outcome: FolderSourceControlRefreshOutcome) => void
+}): Promise<FolderSourceControlRefreshOutcome> {
+  const { worktree, repo } = candidate
+  if (isFolderRepo(repo)) {
+    return { kind: 'unavailable', reason: 'folder' }
+  }
+  const parsedHost =
+    parseExecutionHostId(worktree.hostId) ?? parseExecutionHostId(repo.executionHostId)
+  if (parsedHost?.kind === 'runtime' && !isWebRuntimeSessionActive(parsedHost.environmentId)) {
+    return { kind: 'unavailable', reason: 'runtime' }
+  }
+  const connectionId = resolveFolderSourceControlConnectionId(worktree, repo)
+  if (connectionId && sshConnectionStates.get(connectionId)?.status !== 'connected') {
+    return { kind: 'unavailable', reason: 'ssh' }
+  }
+
+  onOutcome?.(worktree.id, { kind: 'loading' })
+  const refreshPromise = refreshGitStatusForWorktree({
+    settings: getRightSidebarWorktreeRuntimeSettings(worktree.id),
+    worktreeId: worktree.id,
+    worktreePath: worktree.path,
+    connectionId,
+    pushTarget: worktree.pushTarget,
+    deps
+  })
+  try {
+    await withTimeout(refreshPromise, timeoutMs)
+    return { kind: 'fresh' }
+  } catch (error) {
+    return { kind: 'failed', error }
+  }
+}
+
+function resolveFolderSourceControlConnectionId(
+  worktree: Worktree,
+  repo: Repo
+): string | undefined {
+  const worktreeHost = parseExecutionHostId(worktree.hostId)
+  if (worktreeHost?.kind === 'ssh') {
+    return worktreeHost.targetId
+  }
+  if (worktreeHost) {
+    return undefined
+  }
+  const repoHost = parseExecutionHostId(getRepoExecutionHostId(repo))
+  if (repoHost?.kind === 'ssh') {
+    return repoHost.targetId
+  }
+  if (repoHost) {
+    return undefined
+  }
+  return getConnectionId(worktree.id) ?? undefined
+}
+
+function compareFolderSourceControlRefreshCandidates(
+  left: FolderSourceControlRefreshCandidate,
+  right: FolderSourceControlRefreshCandidate
+): number {
+  return (
+    getRefreshPriority(left) - getRefreshPriority(right) ||
+    (right.worktree.lastActivityAt ?? 0) - (left.worktree.lastActivityAt ?? 0) ||
+    left.worktree.displayName.localeCompare(right.worktree.displayName)
+  )
+}
+
+function getRefreshPriority(candidate: FolderSourceControlRefreshCandidate): number {
+  if (candidate.manual) {
+    return 0
+  }
+  if (candidate.expanded) {
+    return 1
+  }
+  return 2
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      const error = new Error('Timed out refreshing source control status')
+      error.name = REFRESH_TIMEOUT_ERROR_NAME
+      reject(error)
+    }, timeoutMs)
+    promise.then(
+      (value) => {
+        window.clearTimeout(timeoutId)
+        resolve(value)
+      },
+      (error) => {
+        window.clearTimeout(timeoutId)
+        reject(error)
+      }
+    )
+  })
+}

--- a/src/renderer/src/components/right-sidebar/folder-workspace-source-control-section.tsx
+++ b/src/renderer/src/components/right-sidebar/folder-workspace-source-control-section.tsx
@@ -1,0 +1,149 @@
+import { ChevronDown, PanelTopOpen } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import { activateWorktreeFromSidebar } from '@/lib/sidebar-worktree-activation'
+import { cn } from '@/lib/utils'
+import type { useAppStore } from '@/store'
+import type { Worktree } from '../../../../shared/types'
+import type { FolderSourceControlRefreshOutcome } from './folder-workspace-source-control-refresh'
+import SourceControl from './SourceControl'
+
+export function FolderWorkspaceSourceControlSection({
+  worktree,
+  repoName,
+  expanded,
+  statusEntries,
+  refreshOutcome,
+  onToggle
+}: {
+  worktree: Worktree
+  repoName: string | null
+  expanded: boolean
+  statusEntries: ReturnType<typeof useAppStore.getState>['gitStatusByWorktree'][string] | undefined
+  refreshOutcome: FolderSourceControlRefreshOutcome | null
+  onToggle: () => void
+}): React.JSX.Element {
+  return (
+    <Collapsible open={expanded} onOpenChange={onToggle}>
+      <div className="overflow-hidden rounded-md border border-border bg-background">
+        <div className="flex items-center transition-colors hover:bg-accent">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2 text-left"
+            >
+              <ChevronDown
+                className={cn('size-3.5 shrink-0 transition-transform', !expanded && '-rotate-90')}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-xs font-medium text-foreground">
+                  {worktree.displayName}
+                </div>
+                {repoName ? (
+                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                    {repoName}
+                  </div>
+                ) : null}
+              </div>
+              <div className="shrink-0 text-right text-[11px] text-muted-foreground">
+                {formatStatusSummary(statusEntries, refreshOutcome)}
+              </div>
+            </button>
+          </CollapsibleTrigger>
+          <div className="pr-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="-mr-1 shrink-0 text-muted-foreground hover:text-foreground"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    activateWorktreeFromSidebar(worktree.id)
+                  }}
+                  aria-label={translate(
+                    'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.jumpToWorktree',
+                    'Jump to worktree'
+                  )}
+                >
+                  <PanelTopOpen className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4}>
+                {translate(
+                  'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.jumpToWorktree',
+                  'Jump to worktree'
+                )}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+        <CollapsibleContent>
+          <div className="border-t border-border">
+            {expanded ? <SourceControl worktreeId={worktree.id} embedded /> : null}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  )
+}
+
+function formatStatusSummary(
+  entries: readonly unknown[] | undefined,
+  refreshOutcome: FolderSourceControlRefreshOutcome | null
+): string {
+  if (refreshOutcome?.kind === 'loading') {
+    return translate(
+      'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.loading',
+      'Refreshing'
+    )
+  }
+  if (refreshOutcome?.kind === 'unavailable') {
+    return translate(
+      'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.unavailableStatus',
+      'Unavailable'
+    )
+  }
+  if (refreshOutcome?.kind === 'failed') {
+    return entries
+      ? translate(
+          'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.staleAfterFailed',
+          '{{value0}} stale',
+          { value0: entries.length }
+        )
+      : translate(
+          'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.failed',
+          'Refresh failed'
+        )
+  }
+  if (refreshOutcome?.kind === 'fresh') {
+    return formatFreshChangeCount(entries?.length ?? 0)
+  }
+  if (entries) {
+    return translate(
+      'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.cached',
+      '{{value0}} cached',
+      { value0: entries.length }
+    )
+  }
+  return translate(
+    'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.pending',
+    'Status pending'
+  )
+}
+
+function formatFreshChangeCount(count: number): string {
+  return count === 1
+    ? translate(
+        'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.changeOne',
+        '1 change'
+      )
+    : translate(
+        'auto.components.rightSidebar.FolderWorkspaceSourceControlPanel.changeMany',
+        '{{value0}} changes',
+        { value0: count }
+      )
+}

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -121,7 +121,8 @@ function RightSidebarInner(): React.JSX.Element {
         icon: GitBranch,
         title: translate('auto.components.right.sidebar.index.0314901467', 'Source Control'),
         shortcut: sourceControlShortcut === 'Unassigned' ? '' : sourceControlShortcut,
-        gitOnly: true
+        gitOnly: true,
+        folderWorkspaceAllowed: true
       },
       {
         id: 'checks',

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
@@ -24,6 +24,14 @@ const items: ActivityBarItem[] = [
     icon: Files,
     title: 'Source Control',
     shortcut: '',
+    gitOnly: true,
+    folderWorkspaceAllowed: true
+  },
+  {
+    id: 'checks',
+    icon: Files,
+    title: 'Checks',
+    shortcut: '',
     gitOnly: true
   },
   { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true }
@@ -37,7 +45,7 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: false,
         isSshRepo: false
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'source-control'])
+    ).toEqual(['explorer', 'source-control', 'checks'])
 
     expect(
       getVisibleRightSidebarActivityItems(items, {
@@ -45,18 +53,20 @@ describe('getVisibleRightSidebarActivityItems', () => {
         isFolderWorkspace: false,
         isSshRepo: true
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'source-control', 'ports'])
+    ).toEqual(['explorer', 'source-control', 'checks', 'ports'])
   })
 
-  it('shows Workspaces only for folder workspaces and hides git tabs for all folder scopes', () => {
+  it('shows folder-workspace-safe Source Control for folder workspaces', () => {
     expect(
       getVisibleRightSidebarActivityItems(items, {
         isFolder: true,
         isFolderWorkspace: true,
         isSshRepo: true
       }).map((item) => item.id)
-    ).toEqual(['explorer', 'workspaces', 'pr-checks', 'ports'])
+    ).toEqual(['explorer', 'workspaces', 'pr-checks', 'source-control', 'ports'])
+  })
 
+  it('hides git tabs for plain non-git folders', () => {
     expect(
       getVisibleRightSidebarActivityItems(items, {
         isFolder: true,

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
@@ -12,7 +12,7 @@ export function getVisibleRightSidebarActivityItems(
 ): ActivityBarItem[] {
   return items.filter((item) => {
     if (item.gitOnly && isFolder) {
-      return false
+      return item.folderWorkspaceAllowed === true && isFolderWorkspace
     }
     if (item.folderOnly && !isFolderWorkspace) {
       return false

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
+import { useAppStore } from '@/store'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 
 const FileExplorer = lazy(() => import('./FileExplorer'))
 const SourceControl = lazy(() => import('./SourceControl'))
@@ -9,6 +11,7 @@ const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
 const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
+const FolderWorkspaceSourceControlPanel = lazy(() => import('./FolderWorkspaceSourceControlPanel'))
 
 type RightSidebarPanelContentProps = {
   effectiveTab: ActiveRightSidebarTab
@@ -19,11 +22,17 @@ export function RightSidebarPanelContent({
   effectiveTab,
   rightSidebarOpen
 }: RightSidebarPanelContentProps): React.JSX.Element {
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const activeWorkspaceKey = useAppStore((s) => s.activeWorkspaceKey)
+  const activeWorkspaceScope = parseWorkspaceKey(activeWorkspaceKey ?? activeWorktreeId ?? '')
+  const isFolderWorkspace = activeWorkspaceScope?.type === 'folder'
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <Suspense fallback={null}>
         {effectiveTab === 'explorer' && <FileExplorer />}
-        {effectiveTab === 'source-control' && <SourceControl />}
+        {effectiveTab === 'source-control' &&
+          (isFolderWorkspace ? <FolderWorkspaceSourceControlPanel /> : <SourceControl />)}
         {effectiveTab === 'checks' && <ChecksPanel />}
         {/* Why: SSH port forwarding still depends on the raw ports.detect data,
             which the workspace-scoped status bar popover intentionally does not

--- a/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
@@ -311,7 +311,7 @@ describe('rendered right sidebar titlebar drag regions', () => {
     expect(buttonOpeningTag(markup, 'Toggle right sidebar')).toContain('sidebar-toggle')
   })
 
-  it('hides git-only activity buttons for folder workspace ids without a backing repo', () => {
+  it('shows folder workspace activity buttons without a backing repo', () => {
     mockAppState.activeWorktreeId = 'folder:folder-1'
     mockAppState.activeRepo = null
 
@@ -322,7 +322,7 @@ describe('rendered right sidebar titlebar drag regions', () => {
     expect(markup).not.toContain('aria-label="Search')
     expect(markup).toContain('aria-label="Attached worktrees')
     expect(markup).toContain('aria-label="PR Checks')
-    expect(markup).not.toContain('aria-label="Source Control')
+    expect(markup).toContain('aria-label="Source Control')
     expect(markup).not.toContain('aria-label="Checks')
   })
 

--- a/src/renderer/src/components/right-sidebar/useGitHistoryCommitActions.ts
+++ b/src/renderer/src/components/right-sidebar/useGitHistoryCommitActions.ts
@@ -40,14 +40,16 @@ export function useGitHistoryCommitActions({
   activeRepoSettings,
   resolveSplitTargetGroupId,
   getConnectionIdForWorktree,
-  activateWorktreeForEditorOpen
+  getEditorOpenOptions
 }: {
   activeWorktreeId: string | null | undefined
   worktreePath: string | null
   activeRepoSettings: RuntimeGitContext['settings']
   resolveSplitTargetGroupId: (event?: SourceControlRowOpenEvent) => string | undefined
   getConnectionIdForWorktree?: (worktreeId: string | null | undefined) => string | undefined
-  activateWorktreeForEditorOpen?: () => boolean
+  getEditorOpenOptions?: <T extends Record<string, unknown>>(
+    options?: T
+  ) => T & { displayWorktreeId?: string }
 }): GitHistoryCommitActions {
   const openCommitAllDiffs = useAppStore((s) => s.openCommitAllDiffs)
   const openCommitDiff = useAppStore((s) => s.openCommitDiff)
@@ -115,16 +117,14 @@ export function useGitHistoryCommitActions({
         if (!cached) {
           return
         }
-        if (activateWorktreeForEditorOpen && !activateWorktreeForEditorOpen()) {
-          return
-        }
         openCommitAllDiffs(
           activeWorktreeId,
           worktreePath,
           cached.summary,
           cached.entries,
           item.subject,
-          item.message
+          item.message,
+          getEditorOpenOptions?.()
         )
       } catch (error) {
         toast.error(
@@ -137,13 +137,7 @@ export function useGitHistoryCommitActions({
         )
       }
     },
-    [
-      activateWorktreeForEditorOpen,
-      activeWorktreeId,
-      loadCommitFiles,
-      openCommitAllDiffs,
-      worktreePath
-    ]
+    [getEditorOpenOptions, activeWorktreeId, loadCommitFiles, openCommitAllDiffs, worktreePath]
   )
 
   const openCommitFile = useCallback(
@@ -161,10 +155,8 @@ export function useGitHistoryCommitActions({
       if (!cached) {
         return
       }
-      if (activateWorktreeForEditorOpen && !activateWorktreeForEditorOpen()) {
-        return
-      }
       const targetGroupId = resolveSplitTargetGroupId(event)
+      const preview = shouldOpenSourceControlRowAsPreview(event, targetGroupId)
       openCommitDiff(
         activeWorktreeId,
         worktreePath,
@@ -178,11 +170,11 @@ export function useGitHistoryCommitActions({
           message: item.message
         },
         detectLanguage(entry.path),
-        { targetGroupId, preview: shouldOpenSourceControlRowAsPreview(event, targetGroupId) }
+        getEditorOpenOptions?.({ targetGroupId, preview }) ?? { targetGroupId, preview }
       )
     },
     [
-      activateWorktreeForEditorOpen,
+      getEditorOpenOptions,
       activeWorktreeId,
       openCommitDiff,
       resolveSplitTargetGroupId,

--- a/src/renderer/src/components/right-sidebar/useGitHistoryCommitActions.ts
+++ b/src/renderer/src/components/right-sidebar/useGitHistoryCommitActions.ts
@@ -38,12 +38,16 @@ export function useGitHistoryCommitActions({
   activeWorktreeId,
   worktreePath,
   activeRepoSettings,
-  resolveSplitTargetGroupId
+  resolveSplitTargetGroupId,
+  getConnectionIdForWorktree,
+  activateWorktreeForEditorOpen
 }: {
   activeWorktreeId: string | null | undefined
   worktreePath: string | null
   activeRepoSettings: RuntimeGitContext['settings']
   resolveSplitTargetGroupId: (event?: SourceControlRowOpenEvent) => string | undefined
+  getConnectionIdForWorktree?: (worktreeId: string | null | undefined) => string | undefined
+  activateWorktreeForEditorOpen?: () => boolean
 }): GitHistoryCommitActions {
   const openCommitAllDiffs = useAppStore((s) => s.openCommitAllDiffs)
   const openCommitDiff = useAppStore((s) => s.openCommitDiff)
@@ -69,7 +73,10 @@ export function useGitHistoryCommitActions({
       if (cached) {
         return cached.entries
       }
-      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      const connectionId =
+        getConnectionIdForWorktree?.(activeWorktreeId) ??
+        getConnectionId(activeWorktreeId) ??
+        undefined
       const result = await getRuntimeGitCommitCompare(
         {
           // Why: route the commit compare by the repo OWNER host, not the focused runtime.
@@ -92,7 +99,7 @@ export function useGitHistoryCommitActions({
       commitCompareCacheRef.current.set(item.id, result)
       return result.entries
     },
-    [activeRepoSettings, activeWorktreeId, worktreePath]
+    [activeRepoSettings, activeWorktreeId, getConnectionIdForWorktree, worktreePath]
   )
 
   const openHistoryCommitDiff = useCallback(
@@ -106,6 +113,9 @@ export function useGitHistoryCommitActions({
         await loadCommitFiles(item)
         const cached = commitCompareCacheRef.current.get(item.id)
         if (!cached) {
+          return
+        }
+        if (activateWorktreeForEditorOpen && !activateWorktreeForEditorOpen()) {
           return
         }
         openCommitAllDiffs(
@@ -127,7 +137,13 @@ export function useGitHistoryCommitActions({
         )
       }
     },
-    [activeWorktreeId, loadCommitFiles, openCommitAllDiffs, worktreePath]
+    [
+      activateWorktreeForEditorOpen,
+      activeWorktreeId,
+      loadCommitFiles,
+      openCommitAllDiffs,
+      worktreePath
+    ]
   )
 
   const openCommitFile = useCallback(
@@ -143,6 +159,9 @@ export function useGitHistoryCommitActions({
       // missing entry means the files never loaded — nothing to open.
       const cached = commitCompareCacheRef.current.get(item.id)
       if (!cached) {
+        return
+      }
+      if (activateWorktreeForEditorOpen && !activateWorktreeForEditorOpen()) {
         return
       }
       const targetGroupId = resolveSplitTargetGroupId(event)
@@ -162,7 +181,13 @@ export function useGitHistoryCommitActions({
         { targetGroupId, preview: shouldOpenSourceControlRowAsPreview(event, targetGroupId) }
       )
     },
-    [activeWorktreeId, openCommitDiff, resolveSplitTargetGroupId, worktreePath]
+    [
+      activateWorktreeForEditorOpen,
+      activeWorktreeId,
+      openCommitDiff,
+      resolveSplitTargetGroupId,
+      worktreePath
+    ]
   )
 
   const copyCommitText = useCallback(async (text: string, label: string): Promise<void> => {
@@ -197,7 +222,10 @@ export function useGitHistoryCommitActions({
             settings: activeRepoSettings,
             worktreeId: activeWorktreeId,
             worktreePath,
-            connectionId: getConnectionId(activeWorktreeId) ?? undefined
+            connectionId:
+              getConnectionIdForWorktree?.(activeWorktreeId) ??
+              getConnectionId(activeWorktreeId) ??
+              undefined
           },
           { sha: item.id }
         )
@@ -246,7 +274,8 @@ export function useGitHistoryCommitActions({
         return
       }
       const state = useAppStore.getState()
-      const connectionId = getConnectionId(activeWorktreeId)
+      const connectionId =
+        getConnectionIdForWorktree?.(activeWorktreeId) ?? getConnectionId(activeWorktreeId)
       const agent = resolveDefaultAgentForNewTab({
         defaultTuiAgent: state.settings?.defaultTuiAgent,
         detectedAgentIds:
@@ -279,7 +308,14 @@ export function useGitHistoryCommitActions({
         promptDelivery: 'submit-after-ready'
       })
     },
-    [activeRepoSettings, activeWorktreeId, copyCommitText, createBrowserTab, worktreePath]
+    [
+      activeRepoSettings,
+      activeWorktreeId,
+      copyCommitText,
+      createBrowserTab,
+      getConnectionIdForWorktree,
+      worktreePath
+    ]
   )
 
   return { loadCommitFiles, openHistoryCommitDiff, openCommitFile, handleCommitAction }

--- a/src/renderer/src/components/settings/BaseRefPicker.tsx
+++ b/src/renderer/src/components/settings/BaseRefPicker.tsx
@@ -1,5 +1,5 @@
 /* oxlint-disable react-doctor/no-adjust-state-on-prop-change -- Why: base-ref defaults and search results come from runtime repo IPC and must clear stale repo results before new requests resolve. */
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { useAppStore } from '@/store'
@@ -10,22 +10,33 @@ import {
 } from '@/runtime/runtime-repo-client'
 import { isRuntimeRepoRefSearchQueryWithinLimit } from '@/runtime/runtime-repo-search-bounds'
 import { translate } from '@/i18n/i18n'
+import type { GlobalSettings } from '../../../../shared/types'
 
 type BaseRefPickerProps = {
   repoId: string
+  repoPath?: string | null
+  executionHostId?: string | null
   currentBaseRef?: string
+  runtimeSettings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
   onSelect: (ref: string) => void
   onUsePrimary?: () => void
 }
 
 export function BaseRefPicker({
   repoId,
+  repoPath,
+  executionHostId,
   currentBaseRef,
+  runtimeSettings,
   onSelect,
   onUsePrimary
 }: BaseRefPickerProps): React.JSX.Element {
   const activeRuntimeEnvironmentId = useAppStore((state) =>
     getRuntimeEnvironmentIdForRepo(state, repoId)
+  )
+  const scopedRuntimeSettings = useMemo(
+    () => runtimeSettings ?? { activeRuntimeEnvironmentId },
+    [activeRuntimeEnvironmentId, runtimeSettings]
   )
   // Why: null until the IPC resolves (or when the repo has no default base ref
   // available). We avoid seeding with 'origin/main' because that would display
@@ -64,7 +75,10 @@ export function BaseRefPicker({
 
     const loadDefaultBaseRef = async (): Promise<void> => {
       try {
-        const result = await getRuntimeRepoBaseRefDefault({ activeRuntimeEnvironmentId }, repoId)
+        const result = await getRuntimeRepoBaseRefDefault(scopedRuntimeSettings, repoId, {
+          repoPath,
+          executionHostId
+        })
         if (!stale) {
           setDefaultBaseRef(result.defaultBaseRef)
           setRemoteCount(result.remoteCount)
@@ -90,7 +104,7 @@ export function BaseRefPicker({
     return () => {
       stale = true
     }
-  }, [activeRuntimeEnvironmentId, repoId])
+  }, [executionHostId, repoId, repoPath, scopedRuntimeSettings])
 
   useEffect(() => {
     if (!isRuntimeRepoRefSearchQueryWithinLimit(baseRefQuery)) {
@@ -109,7 +123,10 @@ export function BaseRefPicker({
     setIsSearchingBaseRefs(true)
 
     const timer = window.setTimeout(() => {
-      void searchRuntimeRepoBaseRefs({ activeRuntimeEnvironmentId }, repoId, trimmedQuery, 20)
+      void searchRuntimeRepoBaseRefs(scopedRuntimeSettings, repoId, trimmedQuery, 20, {
+        repoPath,
+        executionHostId
+      })
         .then((results) => {
           if (!stale) {
             setBaseRefResults(results)
@@ -132,7 +149,7 @@ export function BaseRefPicker({
       stale = true
       window.clearTimeout(timer)
     }
-  }, [activeRuntimeEnvironmentId, baseRefQuery, repoId])
+  }, [baseRefQuery, executionHostId, repoId, repoPath, scopedRuntimeSettings])
 
   const effectiveBaseRef = currentBaseRef ?? defaultBaseRef
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11760,6 +11760,22 @@
             "noPr": "No PR",
             "unavailable": "Unavailable"
           }
+        },
+        "FolderWorkspaceSourceControlPanel": {
+          "unavailable": "Source Control is only shown for folder workspaces with attached worktrees.",
+          "refresh": "Refresh source control",
+          "emptyTitle": "No attached worktrees yet",
+          "emptyCopy": "Source Control sections will appear here after worktrees are attached to this folder workspace.",
+          "countOne": "1 attached worktree",
+          "countMany": "{{value0}} attached worktrees",
+          "loading": "Refreshing",
+          "unavailableStatus": "Unavailable",
+          "staleAfterFailed": "{{value0}} stale",
+          "failed": "Refresh failed",
+          "cached": "{{value0}} cached",
+          "pending": "Status pending",
+          "changeOne": "1 change",
+          "changeMany": "{{value0}} changes"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11775,7 +11775,8 @@
           "cached": "{{value0}} cached",
           "pending": "Status pending",
           "changeOne": "1 change",
-          "changeMany": "{{value0}} changes"
+          "changeMany": "{{value0}} changes",
+          "jumpToWorktree": "Jump to worktree"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11760,6 +11760,22 @@
             "noPr": "Sin PR",
             "unavailable": "No disponible"
           }
+        },
+        "FolderWorkspaceSourceControlPanel": {
+          "unavailable": "Source Control is only shown for folder workspaces with attached worktrees.",
+          "refresh": "Refresh source control",
+          "emptyTitle": "No attached worktrees yet",
+          "emptyCopy": "Source Control sections will appear here after worktrees are attached to this folder workspace.",
+          "countOne": "1 attached worktree",
+          "countMany": "{{value0}} attached worktrees",
+          "loading": "Refreshing",
+          "unavailableStatus": "Unavailable",
+          "staleAfterFailed": "{{value0}} stale",
+          "failed": "Refresh failed",
+          "cached": "{{value0}} cached",
+          "pending": "Status pending",
+          "changeOne": "1 change",
+          "changeMany": "{{value0}} changes"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11775,7 +11775,8 @@
           "cached": "{{value0}} cached",
           "pending": "Status pending",
           "changeOne": "1 change",
-          "changeMany": "{{value0}} changes"
+          "changeMany": "{{value0}} changes",
+          "jumpToWorktree": "Jump to worktree"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11760,6 +11760,22 @@
             "noPr": "PR なし",
             "unavailable": "利用不可"
           }
+        },
+        "FolderWorkspaceSourceControlPanel": {
+          "unavailable": "Source Control is only shown for folder workspaces with attached worktrees.",
+          "refresh": "Refresh source control",
+          "emptyTitle": "No attached worktrees yet",
+          "emptyCopy": "Source Control sections will appear here after worktrees are attached to this folder workspace.",
+          "countOne": "1 attached worktree",
+          "countMany": "{{value0}} attached worktrees",
+          "loading": "Refreshing",
+          "unavailableStatus": "Unavailable",
+          "staleAfterFailed": "{{value0}} stale",
+          "failed": "Refresh failed",
+          "cached": "{{value0}} cached",
+          "pending": "Status pending",
+          "changeOne": "1 change",
+          "changeMany": "{{value0}} changes"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11775,7 +11775,8 @@
           "cached": "{{value0}} cached",
           "pending": "Status pending",
           "changeOne": "1 change",
-          "changeMany": "{{value0}} changes"
+          "changeMany": "{{value0}} changes",
+          "jumpToWorktree": "Jump to worktree"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11760,6 +11760,22 @@
             "noPr": "PR 없음",
             "unavailable": "사용 불가"
           }
+        },
+        "FolderWorkspaceSourceControlPanel": {
+          "unavailable": "Source Control is only shown for folder workspaces with attached worktrees.",
+          "refresh": "Refresh source control",
+          "emptyTitle": "No attached worktrees yet",
+          "emptyCopy": "Source Control sections will appear here after worktrees are attached to this folder workspace.",
+          "countOne": "1 attached worktree",
+          "countMany": "{{value0}} attached worktrees",
+          "loading": "Refreshing",
+          "unavailableStatus": "Unavailable",
+          "staleAfterFailed": "{{value0}} stale",
+          "failed": "Refresh failed",
+          "cached": "{{value0}} cached",
+          "pending": "Status pending",
+          "changeOne": "1 change",
+          "changeMany": "{{value0}} changes"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11775,7 +11775,8 @@
           "cached": "{{value0}} cached",
           "pending": "Status pending",
           "changeOne": "1 change",
-          "changeMany": "{{value0}} changes"
+          "changeMany": "{{value0}} changes",
+          "jumpToWorktree": "Jump to worktree"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11760,6 +11760,22 @@
             "noPr": "无 PR",
             "unavailable": "不可用"
           }
+        },
+        "FolderWorkspaceSourceControlPanel": {
+          "unavailable": "Source Control is only shown for folder workspaces with attached worktrees.",
+          "refresh": "Refresh source control",
+          "emptyTitle": "No attached worktrees yet",
+          "emptyCopy": "Source Control sections will appear here after worktrees are attached to this folder workspace.",
+          "countOne": "1 attached worktree",
+          "countMany": "{{value0}} attached worktrees",
+          "loading": "Refreshing",
+          "unavailableStatus": "Unavailable",
+          "staleAfterFailed": "{{value0}} stale",
+          "failed": "Refresh failed",
+          "cached": "{{value0}} cached",
+          "pending": "Status pending",
+          "changeOne": "1 change",
+          "changeMany": "{{value0}} changes"
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11775,7 +11775,8 @@
           "cached": "{{value0}} cached",
           "pending": "Status pending",
           "changeOne": "1 change",
-          "changeMany": "{{value0}} changes"
+          "changeMany": "{{value0}} changes",
+          "jumpToWorktree": "Jump to worktree"
         }
       },
       "link": {

--- a/src/renderer/src/runtime/runtime-repo-client.ts
+++ b/src/renderer/src/runtime/runtime-repo-client.ts
@@ -8,13 +8,23 @@ export type RuntimeRepoBaseRefDefault = {
   remoteCount: number
 }
 
+type RuntimeRepoLookupOptions = {
+  repoPath?: string | null
+  executionHostId?: string | null
+}
+
 export async function getRuntimeRepoBaseRefDefault(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
-  repoId: string
+  repoId: string,
+  options: RuntimeRepoLookupOptions = {}
 ): Promise<RuntimeRepoBaseRefDefault> {
   const target = getActiveRuntimeTarget(settings)
   if (target.kind !== 'environment') {
-    return window.api.repos.getBaseRefDefault({ repoId })
+    return window.api.repos.getBaseRefDefault({
+      repoId,
+      ...(options.repoPath ? { repoPath: options.repoPath } : {}),
+      ...(options.executionHostId ? { executionHostId: options.executionHostId } : {})
+    })
   }
   return callRuntimeRpc<RuntimeRepoBaseRefDefault>(
     target,
@@ -28,14 +38,21 @@ export async function searchRuntimeRepoBaseRefs(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   repoId: string,
   query: string,
-  limit: number
+  limit: number,
+  options: RuntimeRepoLookupOptions = {}
 ): Promise<string[]> {
   if (!isRuntimeRepoRefSearchQueryWithinLimit(query)) {
     return []
   }
   const target = getActiveRuntimeTarget(settings)
   if (target.kind !== 'environment') {
-    return window.api.repos.searchBaseRefs({ repoId, query, limit })
+    return window.api.repos.searchBaseRefs({
+      repoId,
+      ...(options.repoPath ? { repoPath: options.repoPath } : {}),
+      ...(options.executionHostId ? { executionHostId: options.executionHostId } : {}),
+      query,
+      limit
+    })
   }
   const result = await callRuntimeRpc<{ refs: string[]; truncated: boolean }>(
     target,
@@ -50,14 +67,21 @@ export async function searchRuntimeRepoBaseRefDetails(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   repoId: string,
   query: string,
-  limit: number
+  limit: number,
+  options: RuntimeRepoLookupOptions = {}
 ): Promise<BaseRefSearchResult[]> {
   if (!isRuntimeRepoRefSearchQueryWithinLimit(query)) {
     return []
   }
   const target = getActiveRuntimeTarget(settings)
   if (target.kind !== 'environment') {
-    return window.api.repos.searchBaseRefDetails({ repoId, query, limit })
+    return window.api.repos.searchBaseRefDetails({
+      repoId,
+      ...(options.repoPath ? { repoPath: options.repoPath } : {}),
+      ...(options.executionHostId ? { executionHostId: options.executionHostId } : {}),
+      query,
+      limit
+    })
   }
   const result = await callRuntimeRpc<{
     refs: string[]

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -288,6 +288,7 @@ const MAX_RECENT_CLOSED_EDITOR_TABS = 10
 
 type EditorOpenTargetOptions = {
   targetGroupId?: string
+  displayWorktreeId?: string
   preview?: boolean
   runtimeEnvironmentId?: string | null
   forceContentReload?: boolean
@@ -437,6 +438,7 @@ export type EditorSlice = {
     options?: {
       preview?: boolean
       targetGroupId?: string
+      displayWorktreeId?: string
       recordReplacedPreview?: boolean
       suppressActiveRuntimeFallback?: boolean
       forceContentReload?: boolean
@@ -504,7 +506,8 @@ export type EditorSlice = {
     worktreePath: string,
     alternate?: CombinedDiffAlternate,
     areaFilter?: string,
-    entriesSnapshot?: GitStatusEntry[]
+    entriesSnapshot?: GitStatusEntry[],
+    options?: Pick<EditorOpenTargetOptions, 'displayWorktreeId' | 'targetGroupId'>
   ) => void
   openConflictFile: (
     worktreeId: string,
@@ -524,7 +527,8 @@ export type EditorSlice = {
     worktreeId: string,
     worktreePath: string,
     entries: ConflictReviewEntry[],
-    source: ConflictReviewState['source']
+    source: ConflictReviewState['source'],
+    options?: Pick<EditorOpenTargetOptions, 'displayWorktreeId' | 'targetGroupId'>
   ) => void
   openCheckRunDetails: (
     worktreeId: string,
@@ -543,7 +547,8 @@ export type EditorSlice = {
     worktreeId: string,
     worktreePath: string,
     compare: GitBranchCompareSummary,
-    alternate?: CombinedDiffAlternate
+    alternate?: CombinedDiffAlternate,
+    options?: Pick<EditorOpenTargetOptions, 'displayWorktreeId' | 'targetGroupId'>
   ) => void
   openCommitAllDiffs: (
     worktreeId: string,
@@ -551,7 +556,8 @@ export type EditorSlice = {
     compare: GitCommitCompareSummary,
     entries: GitBranchChangeEntry[],
     subject?: string,
-    message?: string
+    message?: string,
+    options?: Pick<EditorOpenTargetOptions, 'displayWorktreeId' | 'targetGroupId'>
   ) => void
 
   // Cursor line tracking per file
@@ -875,6 +881,13 @@ function resolveEditorOpenTargetGroupId(
     (group) => group.id !== activeGroup.id && getMostRecentEditorTabForGroup(group, tabsById)
   )
   return recentEditorGroup?.id ?? activeGroup.id
+}
+
+function resolveEditorDisplayWorktreeId(
+  sourceWorktreeId: string,
+  options: Pick<EditorOpenTargetOptions, 'displayWorktreeId'> | undefined
+): string {
+  return options?.displayWorktreeId ?? sourceWorktreeId
 }
 
 function buildEditorActiveResult(
@@ -1492,7 +1505,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     }),
 
   openFile: (file, options) => {
-    let editorItemWorktreeId = file.worktreeId
+    let editorItemWorktreeId = resolveEditorDisplayWorktreeId(file.worktreeId, options)
     let editorItemFileId = file.filePath
     let editorItemLabel = file.relativePath
     let editorItemContentType: 'editor' | 'diff' | 'conflict-review' | 'check-details' =
@@ -1506,6 +1519,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     let editorItemTargetGroupId = options?.targetGroupId
     set((s) => {
       const worktreeId = file.worktreeId
+      const displayWorktreeId = resolveEditorDisplayWorktreeId(worktreeId, options)
       const runtimeEnvironmentId =
         file.runtimeEnvironmentId === null
           ? null
@@ -1534,9 +1548,9 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       // scoped to that group. Opening as preview in group B must not evict a
       // preview tab belonging to group A (split tab groups).
       const targetGroupId =
-        resolveEditorOpenTargetGroupId(s, worktreeId, options?.targetGroupId) ?? undefined
+        resolveEditorOpenTargetGroupId(s, displayWorktreeId, options?.targetGroupId) ?? undefined
       editorItemTargetGroupId = targetGroupId
-      const activeResult = buildEditorActiveResult(s, worktreeId, id)
+      const activeResult = buildEditorActiveResult(s, displayWorktreeId, id)
 
       if (existing) {
         // If opening as non-preview, also pin the existing tab
@@ -1603,7 +1617,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       // prior behavior.
       let newFiles = s.openFiles
       if (isPreview) {
-        const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
+        const replaceablePreviewId = getReplaceablePreviewFileId(
+          s,
+          displayWorktreeId,
+          targetGroupId
+        )
         const existingPreviewIdx = s.openFiles.findIndex((f) => f.id === replaceablePreviewId)
         if (existingPreviewIdx !== -1) {
           const replacedPreview = s.openFiles[existingPreviewIdx]
@@ -1667,12 +1685,14 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
               : f
           )
           // Swap the old preview ID for the new one in the stored tab bar order
-          const prevOrder = s.tabBarOrderByWorktree?.[worktreeId]
+          const prevOrder = s.tabBarOrderByWorktree?.[displayWorktreeId]
           const previewTabBarUpdate = prevOrder
             ? {
                 tabBarOrderByWorktree: {
                   ...s.tabBarOrderByWorktree,
-                  [worktreeId]: prevOrder.map((eid) => (eid === replacedPreview.id ? id : eid))
+                  [displayWorktreeId]: prevOrder.map((eid) =>
+                    eid === replacedPreview.id ? id : eid
+                  )
                 }
               }
             : {}
@@ -1689,10 +1709,10 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
               mirroredFromRuntimeSession: _rmirrored,
               ...snap
             } = replacedPreview
-            const stack = s.recentlyClosedEditorTabsByWorktree[worktreeId] ?? []
+            const stack = s.recentlyClosedEditorTabsByWorktree[displayWorktreeId] ?? []
             nextRecentlyClosed = {
               ...s.recentlyClosedEditorTabsByWorktree,
-              [worktreeId]: [snap as ClosedEditorTabSnapshot, ...stack].slice(
+              [displayWorktreeId]: [snap as ClosedEditorTabSnapshot, ...stack].slice(
                 0,
                 MAX_RECENT_CLOSED_EDITOR_TABS
               )
@@ -1718,12 +1738,12 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       // order doesn't contain the new file.
       const tabBarUpdate: Record<string, unknown> = {}
       if (s.tabBarOrderByWorktree) {
-        const currentOrder = s.tabBarOrderByWorktree[worktreeId] ?? []
-        const terminalIds = (s.tabsByWorktree?.[worktreeId] ?? []).map((t) => t.id)
+        const currentOrder = s.tabBarOrderByWorktree[displayWorktreeId] ?? []
+        const terminalIds = (s.tabsByWorktree?.[displayWorktreeId] ?? []).map((t) => t.id)
         const editorFileIds = s.openFiles
           .filter((f) => f.worktreeId === worktreeId)
           .map((f) => f.id)
-        const browserIds = (s.browserTabsByWorktree?.[worktreeId] ?? []).map((t) => t.id)
+        const browserIds = (s.browserTabsByWorktree?.[displayWorktreeId] ?? []).map((t) => t.id)
         const allExisting = new Set([...terminalIds, ...editorFileIds, ...browserIds])
         const base = currentOrder.filter((eid) => allExisting.has(eid))
         const inBase = new Set(base)
@@ -1734,7 +1754,10 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           }
         }
         base.push(id)
-        tabBarUpdate.tabBarOrderByWorktree = { ...s.tabBarOrderByWorktree, [worktreeId]: base }
+        tabBarUpdate.tabBarOrderByWorktree = {
+          ...s.tabBarOrderByWorktree,
+          [displayWorktreeId]: base
+        }
       }
 
       return {
@@ -2414,6 +2437,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   openDiff: (worktreeId, filePath, relativePath, language, staged, options) => {
     const isPreview = options?.preview ?? false
     const runtimeEnvironmentId = options?.runtimeEnvironmentId
+    const displayWorktreeId = resolveEditorDisplayWorktreeId(worktreeId, options)
     let editorItemTargetGroupId = options?.targetGroupId
     let editorItemFileId = ''
     set((s) => {
@@ -2421,7 +2445,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const id = buildDiffEditorFileId(worktreeId, diffSource, relativePath, runtimeEnvironmentId)
       editorItemFileId = id
       const targetGroupId =
-        resolveEditorOpenTargetGroupId(s, worktreeId, options?.targetGroupId) ?? undefined
+        resolveEditorOpenTargetGroupId(s, displayWorktreeId, options?.targetGroupId) ?? undefined
       editorItemTargetGroupId = targetGroupId
       const existing = s.openFiles.find((f) => f.id === id)
       if (existing) {
@@ -2440,8 +2464,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           openFiles: s.openFiles.map((f) => (f.id === id ? reopenedDiff : f)),
           activeFileId: id,
           activeTabType: 'editor',
-          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-          activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+          activeTabTypeByWorktree: {
+            ...s.activeTabTypeByWorktree,
+            [displayWorktreeId]: 'editor'
+          }
         }
       }
       const newFile: OpenFile = {
@@ -2460,7 +2487,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         runtimeEnvironmentId: options?.runtimeEnvironmentId
       }
       if (isPreview) {
-        const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
+        const replaceablePreviewId = getReplaceablePreviewFileId(
+          s,
+          displayWorktreeId,
+          targetGroupId
+        )
         const replaceablePreviewIndex = s.openFiles.findIndex(
           (file) => file.id === replaceablePreviewId
         )
@@ -2472,8 +2503,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             ...removeEditorStateForReplacedPreview(s, s.openFiles[replaceablePreviewIndex].id, id),
             activeFileId: id,
             activeTabType: 'editor',
-            activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-            activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+            activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+            activeTabTypeByWorktree: {
+              ...s.activeTabTypeByWorktree,
+              [displayWorktreeId]: 'editor'
+            }
           }
         }
       }
@@ -2481,14 +2515,14 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFiles: [...s.openFiles, newFile],
         activeFileId: id,
         activeTabType: 'editor',
-        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [displayWorktreeId]: 'editor' }
       }
     })
     void openWorkspaceEditorItem(
       get(),
       editorItemFileId,
-      worktreeId,
+      displayWorktreeId,
       relativePath,
       'diff',
       isPreview,
@@ -2500,10 +2534,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     const branchCompare = toBranchCompareSnapshot(compare)
     const id = `${worktreeId}::diff::branch::${compare.baseRef}::${branchCompare.compareVersion}::${entry.path}`
     const isPreview = options?.preview ?? false
+    const displayWorktreeId = resolveEditorDisplayWorktreeId(worktreeId, options)
     let editorItemTargetGroupId = options?.targetGroupId
     set((s) => {
       const targetGroupId =
-        resolveEditorOpenTargetGroupId(s, worktreeId, options?.targetGroupId) ?? undefined
+        resolveEditorOpenTargetGroupId(s, displayWorktreeId, options?.targetGroupId) ?? undefined
       editorItemTargetGroupId = targetGroupId
       const existing = s.openFiles.find((f) => f.id === id)
       if (existing) {
@@ -2523,8 +2558,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           openFiles: s.openFiles.map((f) => (f.id === id ? reopenedDiff : f)),
           activeFileId: id,
           activeTabType: 'editor',
-          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-          activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+          activeTabTypeByWorktree: {
+            ...s.activeTabTypeByWorktree,
+            [displayWorktreeId]: 'editor'
+          }
         }
       }
       const newFile: OpenFile = {
@@ -2544,7 +2582,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         isPreview: isPreview || undefined
       }
       if (isPreview) {
-        const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
+        const replaceablePreviewId = getReplaceablePreviewFileId(
+          s,
+          displayWorktreeId,
+          targetGroupId
+        )
         const replaceablePreviewIndex = s.openFiles.findIndex(
           (file) => file.id === replaceablePreviewId
         )
@@ -2556,8 +2598,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             ...removeEditorStateForReplacedPreview(s, s.openFiles[replaceablePreviewIndex].id, id),
             activeFileId: id,
             activeTabType: 'editor',
-            activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-            activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+            activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+            activeTabTypeByWorktree: {
+              ...s.activeTabTypeByWorktree,
+              [displayWorktreeId]: 'editor'
+            }
           }
         }
       }
@@ -2565,14 +2610,14 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFiles: [...s.openFiles, newFile],
         activeFileId: id,
         activeTabType: 'editor',
-        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [displayWorktreeId]: 'editor' }
       }
     })
     void openWorkspaceEditorItem(
       get(),
       id,
-      worktreeId,
+      displayWorktreeId,
       entry.path,
       'diff',
       isPreview,
@@ -2584,10 +2629,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     const commitCompare = toCommitCompareSnapshot(compare)
     const id = `${worktreeId}::diff::commit::${commitCompare.compareVersion}::${entry.path}`
     const isPreview = options?.preview ?? false
+    const displayWorktreeId = resolveEditorDisplayWorktreeId(worktreeId, options)
     let editorItemTargetGroupId = options?.targetGroupId
     set((s) => {
       const targetGroupId =
-        resolveEditorOpenTargetGroupId(s, worktreeId, options?.targetGroupId) ?? undefined
+        resolveEditorOpenTargetGroupId(s, displayWorktreeId, options?.targetGroupId) ?? undefined
       editorItemTargetGroupId = targetGroupId
       const existing = s.openFiles.find((f) => f.id === id)
       if (existing) {
@@ -2607,8 +2653,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           openFiles: s.openFiles.map((f) => (f.id === id ? reopenedDiff : f)),
           activeFileId: id,
           activeTabType: 'editor',
-          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-          activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+          activeTabTypeByWorktree: {
+            ...s.activeTabTypeByWorktree,
+            [displayWorktreeId]: 'editor'
+          }
         }
       }
       const newFile: OpenFile = {
@@ -2628,7 +2677,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         isPreview: isPreview || undefined
       }
       if (isPreview) {
-        const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
+        const replaceablePreviewId = getReplaceablePreviewFileId(
+          s,
+          displayWorktreeId,
+          targetGroupId
+        )
         const replaceablePreviewIndex = s.openFiles.findIndex(
           (file) => file.id === replaceablePreviewId
         )
@@ -2640,8 +2693,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             ...removeEditorStateForReplacedPreview(s, s.openFiles[replaceablePreviewIndex].id, id),
             activeFileId: id,
             activeTabType: 'editor',
-            activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-            activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+            activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+            activeTabTypeByWorktree: {
+              ...s.activeTabTypeByWorktree,
+              [displayWorktreeId]: 'editor'
+            }
           }
         }
       }
@@ -2649,14 +2705,14 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFiles: [...s.openFiles, newFile],
         activeFileId: id,
         activeTabType: 'editor',
-        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [displayWorktreeId]: 'editor' }
       }
     })
     void openWorkspaceEditorItem(
       get(),
       id,
-      worktreeId,
+      displayWorktreeId,
       entry.path,
       'diff',
       isPreview,
@@ -2664,7 +2720,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     )
   },
 
-  openAllDiffs: (worktreeId, worktreePath, alternate, areaFilter, entriesSnapshot) => {
+  openAllDiffs: (worktreeId, worktreePath, alternate, areaFilter, entriesSnapshot, options) => {
     const id = areaFilter
       ? `${worktreeId}::all-diffs::uncommitted::${areaFilter}`
       : `${worktreeId}::all-diffs::uncommitted`
@@ -2673,7 +2729,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           areaFilter
         ] ?? 'All Changes')
       : 'All Changes'
+    const displayWorktreeId = resolveEditorDisplayWorktreeId(worktreeId, options)
+    let editorItemTargetGroupId = options?.targetGroupId
     set((s) => {
+      editorItemTargetGroupId =
+        resolveEditorOpenTargetGroupId(s, displayWorktreeId, options?.targetGroupId) ?? undefined
       const branchSummary = s.gitBranchCompareSummaryByWorktree[worktreeId]
       const branchCompare =
         !areaFilter &&
@@ -2727,8 +2787,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           ),
           activeFileId: id,
           activeTabType: 'editor',
-          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-          activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+          activeTabTypeByWorktree: {
+            ...s.activeTabTypeByWorktree,
+            [displayWorktreeId]: 'editor'
+          }
         }
       }
       const newFile: OpenFile = {
@@ -2753,22 +2816,31 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFiles: [...s.openFiles, newFile],
         activeFileId: id,
         activeTabType: 'editor',
-        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [displayWorktreeId]: 'editor' }
       }
     })
-    void openWorkspaceEditorItem(get(), id, worktreeId, label, 'diff')
+    void openWorkspaceEditorItem(
+      get(),
+      id,
+      displayWorktreeId,
+      label,
+      'diff',
+      undefined,
+      editorItemTargetGroupId
+    )
   },
 
   openConflictFile: (worktreeId, worktreePath, entry, language, options) => {
     const absolutePath = joinPath(worktreePath, entry.path)
     const isPreview = options?.preview ?? false
+    const displayWorktreeId = resolveEditorDisplayWorktreeId(worktreeId, options)
     let editorItemTargetGroupId = options?.targetGroupId
     set((s) => {
       const id = absolutePath
       const conflict = toOpenConflictMetadata(entry)
       const targetGroupId =
-        resolveEditorOpenTargetGroupId(s, worktreeId, options?.targetGroupId) ?? undefined
+        resolveEditorOpenTargetGroupId(s, displayWorktreeId, options?.targetGroupId) ?? undefined
       editorItemTargetGroupId = targetGroupId
       const existing = s.openFiles.find((f) => f.id === id)
       const nextTracked =
@@ -2804,8 +2876,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           ),
           activeFileId: id,
           activeTabType: 'editor',
-          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-          activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' },
+          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+          activeTabTypeByWorktree: {
+            ...s.activeTabTypeByWorktree,
+            [displayWorktreeId]: 'editor'
+          },
           trackedConflictPathsByWorktree:
             nextTracked === s.trackedConflictPathsByWorktree[worktreeId]
               ? s.trackedConflictPathsByWorktree
@@ -2826,7 +2901,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       }
 
       if (isPreview) {
-        const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
+        const replaceablePreviewId = getReplaceablePreviewFileId(
+          s,
+          displayWorktreeId,
+          targetGroupId
+        )
         const replaceablePreviewIndex = s.openFiles.findIndex(
           (file) => file.id === replaceablePreviewId
         )
@@ -2838,8 +2917,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             ...removeEditorStateForReplacedPreview(s, s.openFiles[replaceablePreviewIndex].id, id),
             activeFileId: id,
             activeTabType: 'editor',
-            activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-            activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' },
+            activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+            activeTabTypeByWorktree: {
+              ...s.activeTabTypeByWorktree,
+              [displayWorktreeId]: 'editor'
+            },
             trackedConflictPathsByWorktree:
               nextTracked === s.trackedConflictPathsByWorktree[worktreeId]
                 ? s.trackedConflictPathsByWorktree
@@ -2852,8 +2934,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFiles: [...s.openFiles, newFile],
         activeFileId: id,
         activeTabType: 'editor',
-        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' },
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [displayWorktreeId]: 'editor' },
         trackedConflictPathsByWorktree:
           nextTracked === s.trackedConflictPathsByWorktree[worktreeId]
             ? s.trackedConflictPathsByWorktree
@@ -2863,7 +2945,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     void openWorkspaceEditorItem(
       get(),
       absolutePath,
-      worktreeId,
+      displayWorktreeId,
       entry.path,
       'editor',
       isPreview,
@@ -2974,9 +3056,13 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   // status. The tab renders from a stored snapshot (entries + timestamp), not
   // from live status on every paint, so the list is stable even if the live
   // unresolved set changes between polls.
-  openConflictReview: (worktreeId, worktreePath, entries, source) => {
+  openConflictReview: (worktreeId, worktreePath, entries, source, options) => {
     const id = `${worktreeId}::conflict-review`
+    const displayWorktreeId = resolveEditorDisplayWorktreeId(worktreeId, options)
+    let editorItemTargetGroupId = options?.targetGroupId
     set((s) => {
+      editorItemTargetGroupId =
+        resolveEditorOpenTargetGroupId(s, displayWorktreeId, options?.targetGroupId) ?? undefined
       const conflictReview: ConflictReviewState = {
         source,
         snapshotTimestamp: Date.now(),
@@ -3002,8 +3088,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           ),
           activeFileId: id,
           activeTabType: 'editor',
-          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-          activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+          activeTabTypeByWorktree: {
+            ...s.activeTabTypeByWorktree,
+            [displayWorktreeId]: 'editor'
+          }
         }
       }
 
@@ -3022,11 +3111,19 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFiles: [...s.openFiles, newFile],
         activeFileId: id,
         activeTabType: 'editor',
-        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [displayWorktreeId]: 'editor' }
       }
     })
-    void openWorkspaceEditorItem(get(), id, worktreeId, 'Conflict Review', 'conflict-review')
+    void openWorkspaceEditorItem(
+      get(),
+      id,
+      displayWorktreeId,
+      'Conflict Review',
+      'conflict-review',
+      undefined,
+      editorItemTargetGroupId
+    )
   },
 
   // Why: the checks sidebar only has room for inline summaries; full logs and
@@ -3175,10 +3272,14 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     }
   },
 
-  openBranchAllDiffs: (worktreeId, worktreePath, compare, alternate) => {
+  openBranchAllDiffs: (worktreeId, worktreePath, compare, alternate, options) => {
     const branchCompare = toBranchCompareSnapshot(compare)
     const id = `${worktreeId}::all-diffs::branch::${compare.baseRef}::${branchCompare.compareVersion}`
+    const displayWorktreeId = resolveEditorDisplayWorktreeId(worktreeId, options)
+    let editorItemTargetGroupId = options?.targetGroupId
     set((s) => {
+      editorItemTargetGroupId =
+        resolveEditorOpenTargetGroupId(s, displayWorktreeId, options?.targetGroupId) ?? undefined
       const branchEntriesSnapshot = s.gitBranchChangesByWorktree[worktreeId] ?? []
       const existing = s.openFiles.find((f) => f.id === id)
       if (existing) {
@@ -3198,8 +3299,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           ),
           activeFileId: id,
           activeTabType: 'editor',
-          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-          activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+          activeTabTypeByWorktree: {
+            ...s.activeTabTypeByWorktree,
+            [displayWorktreeId]: 'editor'
+          }
         }
       }
       const newFile: OpenFile = {
@@ -3222,26 +3326,32 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFiles: [...s.openFiles, newFile],
         activeFileId: id,
         activeTabType: 'editor',
-        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [displayWorktreeId]: 'editor' }
       }
     })
     void openWorkspaceEditorItem(
       get(),
       id,
-      worktreeId,
+      displayWorktreeId,
       `Branch Changes (${compare.baseRef})`,
-      'diff'
+      'diff',
+      undefined,
+      editorItemTargetGroupId
     )
   },
 
-  openCommitAllDiffs: (worktreeId, worktreePath, compare, entries, subject, message) => {
+  openCommitAllDiffs: (worktreeId, worktreePath, compare, entries, subject, message, options) => {
     const commitCompare = toCommitCompareSnapshot(compare, subject, message)
     const id = `${worktreeId}::all-diffs::commit::${commitCompare.commitOid}`
     const label = subject
       ? `Commit ${commitCompare.compareRef}: ${subject}`
       : `Commit ${commitCompare.compareRef}`
+    const displayWorktreeId = resolveEditorDisplayWorktreeId(worktreeId, options)
+    let editorItemTargetGroupId = options?.targetGroupId
     set((s) => {
+      editorItemTargetGroupId =
+        resolveEditorOpenTargetGroupId(s, displayWorktreeId, options?.targetGroupId) ?? undefined
       const existing = s.openFiles.find((f) => f.id === id)
       if (existing) {
         return {
@@ -3260,8 +3370,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           ),
           activeFileId: id,
           activeTabType: 'editor',
-          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-          activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+          activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+          activeTabTypeByWorktree: {
+            ...s.activeTabTypeByWorktree,
+            [displayWorktreeId]: 'editor'
+          }
         }
       }
 
@@ -3284,11 +3397,19 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         openFiles: [...s.openFiles, newFile],
         activeFileId: id,
         activeTabType: 'editor',
-        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
-        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [displayWorktreeId]: id },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [displayWorktreeId]: 'editor' }
       }
     })
-    void openWorkspaceEditorItem(get(), id, worktreeId, label, 'diff')
+    void openWorkspaceEditorItem(
+      get(),
+      id,
+      displayWorktreeId,
+      label,
+      'diff',
+      undefined,
+      editorItemTargetGroupId
+    )
   },
 
   // Cursor line tracking


### PR DESCRIPTION
## Summary

Adds a Source Control activity to folder workspaces so a top-folder import can show one collapsible Source Control section per attached child worktree. Embedded child sections reuse the regular Source Control UI while scoping git status, file opens, history actions, and base-ref lookup/search to the child worktree and its repo host.

The implementation keeps hosted-review/create-review surfaces disabled in embedded child sections until those APIs can be safely host-scoped end to end. Base-ref changes from embedded sections are saved on the worktree, not the repo, to avoid duplicate repo-id ambiguity.

## Design and implementation

- Design doc scratch path: `design-docs/multi-repo-folder-source-control.md`.
- Design review: delegated `auto-design-review-fix` completed READY.
- Completeness verification: delegated pass completed; follow-up review findings were addressed.
- Implementation adds `FolderWorkspaceSourceControlPanel`, bounded/tokenized child refresh scheduling, folder-workspace Source Control visibility, embedded `SourceControl` scoping, and host-aware base-ref IPC via `repoPath + executionHostId`.
- Localization catalog entries were synced for the new folder Source Control strings.

## Review

- Iterative subagent code-review loop completed.
- Final same-round reviewers: Lagrange and Planck both reported no actionable issues.
- Earlier findings fixed included hosted-review host ambiguity, repo base-ref writes from embedded sections, stale refresh generations, queued refresh cleanup races, tokenized refresh reservations, duplicate repo labels, hook deps, and base-ref routing across duplicate repo ids/hosts/paths.

## Validation

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts src/renderer/src/components/right-sidebar/FolderWorkspaceSourceControlPanel.test.tsx src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx src/renderer/src/components/right-sidebar/folder-workspace-source-control-refresh.test.ts src/main/ipc/repos-remote.test.ts` - 6 files / 138 tests passed after the CI expectation fix.
- [x] `pnpm run typecheck`.
- [x] `pnpm run lint`.
- [x] `git diff --check` - clean aside from Windows CRLF warnings.
- [x] `pnpm build:relay` during Brennan validation.
- [x] Electron validation launched this exact worktree and verified identity: branch `brennanb2025/kahawai`, root `C:\Users\neil\orca\workspaces\orca\kahawai`.
- [x] Reproduced top-folder multi-repo import with disposable `alpha-repo` and `beta-repo` under a folder workspace.
- [x] Verified right-sidebar Source Control showed `2 attached worktrees`, collapsible child sections, and each embedded Source Control section showed its own changed/untracked files.
- [x] Verified local base-ref IPC with `repoPath + executionHostId` returned the scoped child repo default.
- [ ] Live SSH validation: intentionally not completed in this run. The validation environment had no Docker/Podman, WSL command execution failed with `Wsl/Service/E_UNEXPECTED`, and no disposable SSH target was configured. Brennan will run SSH validation separately before merge.

Screenshot evidence:

- `.context/multi-repo-source-control-validation-20260626/folder-source-control-initial.png`
- `.context/multi-repo-source-control-validation-20260626/folder-source-control-both-expanded.png`
- `.context/multi-repo-source-control-validation-20260626/folder-source-control-base-ref-picker.png`

## Cleanup

Validation cleanup removed the disposable child worktrees, folder workspace, project group, imported repos, temp repos/profile/worktree directories, and stopped the Electron process tree started for validation.

## Post-PR stabilization

- [x] Waited 8 minutes after opening the PR, inspected CI and CodeRabbit.
- [x] Fixed the initial `verify` failure by updating the folder-workspace sidebar titlebar test expectation for the newly visible Source Control activity.
- [x] Pushed the fix, waited another 8 minutes, and verified `verify` passes.
- [x] Triggered CodeRabbit manually after its rate-limit notice with `@coderabbitai review`; CodeRabbit replied `Review finished` and did not leave actionable review comments.
- [x] Final PR checks are passing: `verify` and `track-community-pr`.