### PR TITLE
fix(pet): shrink overlay drag area to hug the pet content

### DIFF
--- a/src/renderer/src/components/pet/PetOverlay.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 import { usePetUrl } from './usePetUrl'
 import type { DetectedSpriteCacheEntry } from './pet-blob-cache'
@@ -113,6 +113,20 @@ function DetectedSpriteFrame({
   // intended speed; default to 8 only when the manifest didn't declare one.
   const fps = detected.fps > 0 ? detected.fps : 8
 
+  // Why: size the canvas to one fixed footprint bounding the largest scaled
+  // frame so the drag wrapper hugs the pet instead of a maxSize square. A
+  // single size across frames avoids the jitter a per-frame resize would cause.
+  const { footprintW, footprintH } = useMemo(() => {
+    let w = 0
+    let h = 0
+    for (const f of detected.frames) {
+      const s = Math.min(maxSize / f.w, maxSize / f.h)
+      w = Math.max(w, f.w * s)
+      h = Math.max(h, f.h * s)
+    }
+    return { footprintW: Math.max(1, Math.round(w)), footprintH: Math.max(1, Math.round(h)) }
+  }, [detected, maxSize])
+
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) {
@@ -122,22 +136,31 @@ function DetectedSpriteFrame({
     if (!ctx) {
       return
     }
-    canvas.width = maxSize
-    canvas.height = maxSize
+    canvas.width = footprintW
+    canvas.height = footprintH
     // Why: reset playback when the underlying sprite changes so the new
     // animation starts from frame 0 rather than wherever the prior one stopped.
     frameIndexRef.current = 0
     lastTimeRef.current = 0
+    if (detected.frames.length === 0) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      return
+    }
     let raf = 0
     const draw = (): void => {
       const f = detected.frames[frameIndexRef.current % detected.frames.length]
       const bmp = detected.bitmaps[frameIndexRef.current % detected.bitmaps.length]
+      if (!f || !bmp) {
+        return
+      }
       ctx.imageSmoothingEnabled = false
       ctx.clearRect(0, 0, canvas.width, canvas.height)
       const scale = Math.min(maxSize / f.w, maxSize / f.h)
       const w = f.w * scale
       const h = f.h * scale
-      ctx.drawImage(bmp, (maxSize - w) / 2, (maxSize - h) / 2, w, h)
+      // Why: center each frame within the fixed footprint so frames of differing
+      // sizes stay aligned without resizing the canvas per frame.
+      ctx.drawImage(bmp, (footprintW - w) / 2, (footprintH - h) / 2, w, h)
     }
     const tick = (now: number): void => {
       const dt = now - lastTimeRef.current
@@ -160,12 +183,12 @@ function DetectedSpriteFrame({
         cancelAnimationFrame(raf)
       }
     }
-  }, [detected, animate, maxSize, fps])
+  }, [detected, animate, footprintW, footprintH, maxSize, fps])
 
   return (
     <canvas
       ref={canvasRef}
-      style={{ width: maxSize, height: maxSize, imageRendering: 'pixelated' }}
+      style={{ width: footprintW, height: footprintH, imageRendering: 'pixelated' }}
     />
   )
 }
@@ -363,9 +386,9 @@ export function PetOverlay(): React.JSX.Element {
   }
 
   return (
-    // Why: the wrapper is fixed-positioned and pointer-events-none so app
-    // chrome stays interactive; only the pet itself opts back in to
-    // pointer events so the user can press and drag it around.
+    // Why: the outer box and middle layer stay pointer-events-none so app chrome
+    // stays interactive; only the innermost wrapper opts in and shrink-wraps its
+    // content, so the grab/drag hit area hugs the pet, not the full square box.
     <div
       aria-hidden
       className="pointer-events-none fixed z-40"
@@ -376,43 +399,49 @@ export function PetOverlay(): React.JSX.Element {
         height: size
       }}
     >
-      <div
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={endDrag}
-        onPointerCancel={endDrag}
-        className="pointer-events-auto flex size-full select-none items-center justify-end"
-        style={{
-          cursor: dragging ? 'grabbing' : 'grab',
-          animation: 'pet-bob 1.2s ease-in-out infinite',
-          animationPlayState: animate ? 'running' : 'paused',
-          touchAction: 'none'
-        }}
-      >
-        <style>
-          {translate(
-            'auto.components.pet.PetOverlay.de932b0e8f',
-            '@keyframes pet-bob { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-4px); } }'
+      <div className="pointer-events-none flex size-full items-center justify-end">
+        <div
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+          className="pointer-events-auto flex h-fit w-fit select-none"
+          style={{
+            cursor: dragging ? 'grabbing' : 'grab',
+            animation: 'pet-bob 1.2s ease-in-out infinite',
+            animationPlayState: animate ? 'running' : 'paused',
+            touchAction: 'none',
+            // Why: floor so the wrapper stays grabbable while w-fit/h-fit would
+            // otherwise collapse to 0×0 during the image-load window.
+            minWidth: 24,
+            minHeight: 24
+          }}
+        >
+          <style>
+            {translate(
+              'auto.components.pet.PetOverlay.de932b0e8f',
+              '@keyframes pet-bob { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-4px); } }'
+            )}
+          </style>
+          {sprite ? (
+            <SpriteFrame
+              url={url}
+              sprite={sprite}
+              animate={animate}
+              maxSize={size}
+              animationName={animationName}
+            />
+          ) : detected ? (
+            <DetectedSpriteFrame detected={detected} animate={animate} maxSize={size} />
+          ) : (
+            <img
+              src={url}
+              alt=""
+              className="max-h-full max-w-full object-contain"
+              draggable={false}
+            />
           )}
-        </style>
-        {sprite ? (
-          <SpriteFrame
-            url={url}
-            sprite={sprite}
-            animate={animate}
-            maxSize={size}
-            animationName={animationName}
-          />
-        ) : detected ? (
-          <DetectedSpriteFrame detected={detected} animate={animate} maxSize={size} />
-        ) : (
-          <img
-            src={url}
-            alt=""
-            className="max-h-full max-w-full object-contain"
-            draggable={false}
-          />
-        )}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/src/components/pet/PetOverlay.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.tsx
@@ -434,10 +434,15 @@ export function PetOverlay(): React.JSX.Element {
           ) : detected ? (
             <DetectedSpriteFrame detected={detected} animate={animate} maxSize={size} />
           ) : (
+            // Why: cap explicitly at the pet size — the w-fit/h-fit wrapper is
+            // fit-content, so max-w/h-full has no fixed box to resolve against
+            // and the image would otherwise render at its intrinsic size and
+            // overflow the persisted size box that clamping still assumes.
             <img
               src={url}
               alt=""
               className="max-h-full max-w-full object-contain"
+              style={{ maxWidth: size, maxHeight: size }}
               draggable={false}
             />
           )}

--- a/src/renderer/src/components/pet/pet-overlay-hit-area.test.tsx
+++ b/src/renderer/src/components/pet/pet-overlay-hit-area.test.tsx
@@ -3,6 +3,34 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DetectedSpriteCacheEntry } from './pet-blob-cache'
+import type { CustomPet } from '../../../../shared/types'
+
+type PetUrlState =
+  | { url: string; ready: boolean; sprite: null; detected: null }
+  | {
+      url: string
+      ready: boolean
+      sprite: NonNullable<CustomPet['sprite']>
+      detected: null
+    }
+  | { url: string; ready: boolean; sprite: null; detected: DetectedSpriteCacheEntry }
+
+const defaultPetUrlState: PetUrlState = {
+  url: 'data:image/png;base64,',
+  ready: true,
+  sprite: null,
+  detected: null
+}
+
+const petUrlMock = vi.hoisted(() => ({
+  current: {
+    url: 'data:image/png;base64,',
+    ready: true,
+    sprite: null,
+    detected: null
+  } as PetUrlState
+}))
 
 // Why: keep the render focused on the overlay's layout structure — the real
 // store + pet-url resolution pull in IPC/asset loading we don't need to assert
@@ -22,12 +50,7 @@ vi.mock('../../store', () => {
 })
 
 vi.mock('./usePetUrl', () => ({
-  usePetUrl: () => ({
-    url: 'data:image/png;base64,',
-    ready: true,
-    sprite: null,
-    detected: null
-  })
+  usePetUrl: () => petUrlMock.current
 }))
 
 import { PetOverlay } from './PetOverlay'
@@ -42,6 +65,41 @@ function renderOverlay(): { root: Root; container: HTMLDivElement } {
   return { root, container }
 }
 
+function setPetUrlState(state: PetUrlState): void {
+  petUrlMock.current = state
+}
+
+function getDragHandle(container: HTMLElement): HTMLElement {
+  const fixedEl = container.querySelector('.fixed')
+  const sizeFullEl = container.querySelector('.size-full')
+  const grabEls = container.querySelectorAll('.pointer-events-auto')
+
+  expect(fixedEl).not.toBeNull()
+  expect(sizeFullEl).not.toBeNull()
+  // Exactly one element opts into pointer events: the content-fit grab handle.
+  expect(grabEls.length).toBe(1)
+  const grabEl = grabEls[0] as HTMLElement
+
+  // The outer box and the size-full middle layer must stay pointer-events-none
+  // so they never become a grab surface around the rendered pet.
+  expect(fixedEl?.className).toContain('pointer-events-none')
+  expect(sizeFullEl?.className).toContain('pointer-events-none')
+  expect(sizeFullEl?.className).not.toContain('pointer-events-auto')
+
+  // The grab handle (the element carrying the pointer handlers) is NOT the
+  // full-size box: it does not carry size-full and sits nested inside it.
+  expect(grabEl.className).not.toContain('size-full')
+  expect(grabEl).not.toBe(sizeFullEl)
+  expect(sizeFullEl?.contains(grabEl)).toBe(true)
+
+  // The drag affordances (cursor + touch-action) live on that same handle,
+  // confirming it is the pointer-handler element rather than the box.
+  expect(grabEl.style.cursor).toBe('grab')
+  expect(grabEl.style.touchAction).toBe('none')
+
+  return grabEl
+}
+
 describe('PetOverlay drag hit area', () => {
   let root: Root | null = null
   let container: HTMLDivElement | null = null
@@ -53,36 +111,67 @@ describe('PetOverlay drag hit area', () => {
     container?.remove()
     root = null
     container = null
+    setPetUrlState(defaultPetUrlState)
   })
 
   it('keeps the grab/drag region off the full-size square box', () => {
     ;({ root, container } = renderOverlay())
 
-    const fixedEl = container.querySelector('.fixed')
-    const sizeFullEl = container.querySelector('.size-full')
-    const grabEls = container.querySelectorAll('.pointer-events-auto')
+    const grabEl = getDragHandle(container)
+    const img = grabEl.querySelector('img') as HTMLImageElement | null
+    expect(img).not.toBeNull()
+    expect(img?.style.maxWidth).toBe('180px')
+    expect(img?.style.maxHeight).toBe('180px')
+  })
 
-    expect(fixedEl).not.toBeNull()
-    expect(sizeFullEl).not.toBeNull()
-    // Exactly one element opts into pointer events: the content-fit grab handle.
-    expect(grabEls.length).toBe(1)
-    const grabEl = grabEls[0] as HTMLElement
+  it('renders manifest sprites with a content-sized drag handle child', () => {
+    setPetUrlState({
+      url: 'data:image/png;base64,',
+      ready: true,
+      sprite: {
+        frameWidth: 252,
+        frameHeight: 320,
+        columns: 4,
+        rows: 1,
+        sheetWidth: 1008,
+        sheetHeight: 320,
+        fps: 8,
+        defaultAnimation: 'idle',
+        animations: { idle: { row: 0, frames: 4 } }
+      },
+      detected: null
+    })
 
-    // The outer box and the size-full middle layer must stay pointer-events-none
-    // so they never become a grab surface around the rendered pet.
-    expect(fixedEl?.className).toContain('pointer-events-none')
-    expect(sizeFullEl?.className).toContain('pointer-events-none')
-    expect(sizeFullEl?.className).not.toContain('pointer-events-auto')
+    ;({ root, container } = renderOverlay())
 
-    // The grab handle (the element carrying the pointer handlers) is NOT the
-    // full-size box: it does not carry size-full and sits nested inside it.
-    expect(grabEl.className).not.toContain('size-full')
-    expect(grabEl).not.toBe(sizeFullEl)
-    expect(sizeFullEl?.contains(grabEl)).toBe(true)
+    const grabEl = getDragHandle(container)
+    const spriteEl = grabEl.querySelector('div[style*="background-image"]') as HTMLElement | null
+    expect(spriteEl).not.toBeNull()
+    expect(spriteEl?.style.width).toBe('141.75px')
+    expect(spriteEl?.style.height).toBe('180px')
+  })
 
-    // The drag affordances (cursor + touch-action) live on that same handle,
-    // confirming it is the pointer-handler element rather than the box.
-    expect(grabEl.style.cursor).toBe('grab')
-    expect(grabEl.style.touchAction).toBe('none')
+  it('renders detected sprites with a fixed content footprint smaller than the square box', () => {
+    setPetUrlState({
+      url: 'data:image/png;base64,',
+      ready: true,
+      sprite: null,
+      detected: {
+        frames: [
+          { x: 0, y: 0, w: 252, h: 320 },
+          { x: 0, y: 0, w: 126, h: 320 }
+        ],
+        bitmaps: [] as ImageBitmap[],
+        fps: 8
+      }
+    })
+
+    ;({ root, container } = renderOverlay())
+
+    const grabEl = getDragHandle(container)
+    const canvas = grabEl.querySelector('canvas') as HTMLCanvasElement | null
+    expect(canvas).not.toBeNull()
+    expect(canvas?.style.width).toBe('142px')
+    expect(canvas?.style.height).toBe('180px')
   })
 })

--- a/src/renderer/src/components/pet/pet-overlay-hit-area.test.tsx
+++ b/src/renderer/src/components/pet/pet-overlay-hit-area.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Why: keep the render focused on the overlay's layout structure — the real
+// store + pet-url resolution pull in IPC/asset loading we don't need to assert
+// the hit-area invariant.
+vi.mock('../../store', () => {
+  const storeState = {
+    petSize: 180,
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
+    retainedAgentsByPaneKey: {}
+  }
+  const useAppStore = Object.assign(
+    (selector: (state: unknown) => unknown) => selector(storeState),
+    { getState: () => storeState }
+  )
+  return { useAppStore }
+})
+
+vi.mock('./usePetUrl', () => ({
+  usePetUrl: () => ({
+    url: 'data:image/png;base64,',
+    ready: true,
+    sprite: null,
+    detected: null
+  })
+}))
+
+import { PetOverlay } from './PetOverlay'
+
+function renderOverlay(): { root: Root; container: HTMLDivElement } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(<PetOverlay />)
+  })
+  return { root, container }
+}
+
+describe('PetOverlay drag hit area', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+    }
+    container?.remove()
+    root = null
+    container = null
+  })
+
+  it('keeps the grab/drag region off the full-size square box', () => {
+    ;({ root, container } = renderOverlay())
+
+    const fixedEl = container.querySelector('.fixed')
+    const sizeFullEl = container.querySelector('.size-full')
+    const grabEls = container.querySelectorAll('.pointer-events-auto')
+
+    expect(fixedEl).not.toBeNull()
+    expect(sizeFullEl).not.toBeNull()
+    // Exactly one element opts into pointer events: the content-fit grab handle.
+    expect(grabEls.length).toBe(1)
+    const grabEl = grabEls[0] as HTMLElement
+
+    // The outer box and the size-full middle layer must stay pointer-events-none
+    // so they never become a grab surface around the rendered pet.
+    expect(fixedEl?.className).toContain('pointer-events-none')
+    expect(sizeFullEl?.className).toContain('pointer-events-none')
+    expect(sizeFullEl?.className).not.toContain('pointer-events-auto')
+
+    // The grab handle (the element carrying the pointer handlers) is NOT the
+    // full-size box: it does not carry size-full and sits nested inside it.
+    expect(grabEl.className).not.toContain('size-full')
+    expect(grabEl).not.toBe(sizeFullEl)
+    expect(sizeFullEl?.contains(grabEl)).toBe(true)
+
+    // The drag affordances (cursor + touch-action) live on that same handle,
+    // confirming it is the pointer-handler element rather than the box.
+    expect(grabEl.style.cursor).toBe('grab')
+    expect(grabEl.style.touchAction).toBe('none')
+  })
+})


### PR DESCRIPTION
## Problem

The Pet overlay's draggable/hit area was the full `size × size` box, not the pet. The element carrying `pointer-events-auto` + the pointer handlers + `cursor: grab` + the bob animation used Tailwind `size-full`, so the whole square (default 180px) was grabbable — including the transparent margin around the pet, which is pinned center-right via `items-center justify-end`.

This dead-zone is large for the **default** pets (all non-square):

| Pet | Asset | Rendered at 180px | Empty but draggable |
| --- | --- | --- | --- |
| Claudino | 320×180 | 180×101 | ~79px vertical band |
| OpenCode | 252×320 | 142×180 | ~38px on the left |
| Gremlin | 252×320 | 142×180 | ~38px on the left |

You could grab and drag the pet from clearly empty space above/below/beside it.

## Fix

Restructure `PetOverlay` into three nested layers:

- **Outer box** — unchanged: `pointer-events-none fixed`, sized `size × size`, positioned at the persisted `left/top`.
- **Middle centering layer** — new, `pointer-events-none flex size-full items-center justify-end`, preserving the exact bottom-right placement.
- **Innermost content-fit wrapper** — the *only* `pointer-events-auto` element. `w-fit`/`h-fit` so it shrink-wraps the rendered pet, and it carries all four pointer handlers, `cursor`, the `pet-bob` animation (`animationPlayState` still bound to `animate`), and `touch-action: none`. A `min-w`/`min-h` floor keeps it grabbable during the image-load window when `w-fit` would otherwise collapse to 0×0.

`DetectedSpriteFrame` previously forced its canvas to the full box and centered frames inside, so the wrapper couldn't tighten that path. It now sizes the canvas to one fixed footprint bounding the largest scaled frame (computed once, stable across frames to avoid jitter) and re-centers each frame within it.

The `<img>` and `SpriteFrame` paths tighten purely from the wrapper change.

### What is intentionally unchanged

Drag math, `clampPositionToViewport`, and localStorage persistence are all keyed to the **outer box** top-left and size — they are untouched, so dragging, edge-clamping, size-change re-clamping, and saved positions behave exactly as before. No platform-specific code is involved.

## Verification

- `pnpm typecheck:web` — clean
- `pnpm lint` (incl. localization catalog + coverage) — clean; no new user-facing strings
- Full unit suite — 21,052 passed (one unrelated `ssh-system-transport.integration` test was flaky under full-suite load and passes in isolation)
- Added `pet-overlay-hit-area.test.tsx`: a structural regression test (happy-dom + `react-dom/client` + `act`) asserting exactly one `pointer-events-auto` element, that it is **not** the `size-full` layer, and that it carries the drag affordances — so the grab region can never silently revert to the full box.

## Residual (out of scope)

Element-tightening hugs the rendered element box, not opaque pixels. Transparent padding baked into the bundled `.webp` assets still travels inside the element; trimming that would require re-cropping the source art, which is a separate task.

## Note for reviewers

This touches the same JSX block in `PetOverlay.tsx` as open PR #6360 (i18n keyframe handling). The existing `translate(...)` keyframe calls are preserved here, so the overlap is mechanical — whichever lands second needs a trivial rebase.
