### PR TITLE
Fix fork PR detection for same-name upstreams

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -1736,6 +1736,97 @@ describe('getPRForBranch', () => {
     })
   })
 
+  it('uses the tracked upstream remote owner when the fork branch name matches locally', async () => {
+    resolvePRRepositoryCandidatesMock.mockResolvedValueOnce({
+      candidates: [
+        { owner: 'stablyai', repo: 'orca' },
+        { owner: 'origin-owner', repo: 'orca' }
+      ],
+      headRepo: { owner: 'origin-owner', repo: 'orca' }
+    })
+    getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'brennanb2025', repo: 'orca' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 6433,
+            title: 'Recover Windows worktree deletes from long paths',
+            state: 'open',
+            html_url: 'https://github.com/stablyai/orca/pull/6433',
+            updated_at: '2026-06-26T00:00:00Z',
+            draft: false,
+            mergeable: true,
+            base: { ref: 'main', sha: 'base-oid' },
+            head: {
+              ref: 'brennanb2025/worktree-remove-fix',
+              sha: 'same-name-fork-head-oid'
+            }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 6433,
+          title: 'Recover Windows worktree deletes from long paths',
+          state: 'OPEN',
+          url: 'https://github.com/stablyai/orca/pull/6433',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-26T00:00:00Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'brennanb2025/worktree-remove-fix',
+          baseRefOid: 'base-oid',
+          headRefOid: 'same-name-fork-head-oid'
+        })
+      })
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'brennanb2025/worktree-remove-fix\0brennan/brennanb2025/worktree-remove-fix\n',
+      stderr: ''
+    })
+
+    const pr = await getPRForBranch('/repo-root', 'brennanb2025/worktree-remove-fix')
+
+    expect(getOwnerRepoForRemoteMock).toHaveBeenCalledWith('/repo-root', 'brennan', undefined)
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      3,
+      [
+        'api',
+        'repos/stablyai/orca/pulls?head=brennanb2025%3Abrennanb2025%2Fworktree-remove-fix&state=all&per_page=1'
+      ],
+      { cwd: '/repo-root' }
+    )
+    expect(pr).toMatchObject({
+      number: 6433,
+      prRepo: { owner: 'stablyai', repo: 'orca' },
+      headRepo: { owner: 'brennanb2025', repo: 'orca' }
+    })
+  })
+
+  it('does not retry same-name tracked upstream lookup for the same head repo', async () => {
+    resolvePRRepositoryCandidatesMock.mockResolvedValueOnce({
+      candidates: [{ owner: 'acme', repo: 'widgets' }],
+      headRepo: { owner: 'acme', repo: 'widgets' }
+    })
+    getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'feature/no-pr\0origin/feature/no-pr\n',
+      stderr: ''
+    })
+
+    await expect(getPRForBranch('/repo-root', 'feature/no-pr')).resolves.toBeNull()
+
+    expect(getOwnerRepoForRemoteMock).toHaveBeenCalledWith('/repo-root', 'origin', undefined)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      ['api', 'repos/acme/widgets/pulls?head=acme%3Afeature%2Fno-pr&state=all&per_page=1'],
+      { cwd: '/repo-root' }
+    )
+  })
+
   it('checks the tracked upstream branch through the SSH git provider', async () => {
     const sshGitProvider = {
       exec: vi.fn().mockResolvedValue({
@@ -1782,6 +1873,57 @@ describe('getPRForBranch', () => {
       {}
     )
     expect(pr).toMatchObject({ number: 78, title: 'SSH upstream branch PR' })
+  })
+
+  it('uses the same-name tracked upstream fork owner through the SSH git provider', async () => {
+    const sshGitProvider = {
+      exec: vi.fn().mockResolvedValue({
+        stdout: 'contributor/fix\0fork/contributor/fix\n',
+        stderr: ''
+      })
+    }
+    getSshGitProviderMock.mockReturnValue(sshGitProvider)
+    resolvePRRepositoryCandidatesMock.mockResolvedValueOnce({
+      candidates: [
+        { owner: 'stablyai', repo: 'orca' },
+        { owner: 'origin-owner', repo: 'orca' }
+      ],
+      headRepo: { owner: 'origin-owner', repo: 'orca' }
+    })
+    getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'fork-owner', repo: 'orca' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 79,
+            title: 'SSH same-name fork PR',
+            state: 'open',
+            html_url: 'https://github.com/stablyai/orca/pull/79',
+            updated_at: '2026-03-28T00:00:00Z',
+            draft: false,
+            mergeable: true,
+            base: { ref: 'main', sha: 'base-oid' },
+            head: { ref: 'contributor/fix', sha: 'same-name-ssh-head-oid' }
+          }
+        ])
+      })
+
+    const pr = await getPRForBranch('/remote/repo-root', 'contributor/fix', undefined, 'ssh-1')
+
+    expect(getOwnerRepoForRemoteMock).toHaveBeenCalledWith('/remote/repo-root', 'fork', 'ssh-1')
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      3,
+      ['api', 'repos/stablyai/orca/pulls?head=fork-owner%3Acontributor%2Ffix&state=all&per_page=1'],
+      {}
+    )
+    expect(pr).toMatchObject({
+      number: 79,
+      title: 'SSH same-name fork PR',
+      prRepo: { owner: 'stablyai', repo: 'orca' },
+      headRepo: { owner: 'fork-owner', repo: 'orca' }
+    })
   })
 
   it('caches positive tracked-upstream entries for unsigned SSH runtimes during PR refresh polling', async () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2314,15 +2314,31 @@ export function __resetTrackedUpstreamBranchCacheForTests(): void {
   trackedUpstreamSnapshotGenerations.clear()
 }
 
-function parseTrackedUpstreamBranch(
-  upstreamRef: string,
-  branchName: string
-): TrackedUpstreamBranch | null {
+function parseTrackedUpstreamBranch(upstreamRef: string): TrackedUpstreamBranch | null {
   const parsed = splitRemoteBranchName(upstreamRef.trim())
-  if (!parsed || parsed.branchName === branchName) {
+  if (!parsed) {
     return null
   }
   return parsed
+}
+
+function prOwnerRepoKey(ownerRepo: OwnerRepo): string {
+  return `${ownerRepo.owner.toLowerCase()}/${ownerRepo.repo.toLowerCase()}`
+}
+
+function shouldRetryTrackedUpstreamBranch(
+  upstreamBranch: TrackedUpstreamBranch,
+  branchName: string,
+  upstreamHeadRepo: OwnerRepo,
+  headRepo: OwnerRepo | null
+): boolean {
+  if (upstreamBranch.branchName !== branchName) {
+    return true
+  }
+  if (!headRepo) {
+    return true
+  }
+  return prOwnerRepoKey(upstreamHeadRepo) !== prOwnerRepoKey(headRepo)
 }
 
 async function getTrackedUpstreamBranch(
@@ -2513,27 +2529,21 @@ function parseTrackedUpstreamBranches(stdout: string): Map<string, TrackedUpstre
     if (!localBranchName) {
       continue
     }
-    upstreamsByBranchName.set(
-      localBranchName,
-      parseTrackedUpstreamRef(upstreamRef ?? '', localBranchName)
-    )
+    upstreamsByBranchName.set(localBranchName, parseTrackedUpstreamRef(upstreamRef ?? ''))
   }
   return upstreamsByBranchName
 }
 
-function parseTrackedUpstreamRef(
-  upstreamRef: string,
-  branchName: string
-): TrackedUpstreamBranch | null {
+function parseTrackedUpstreamRef(upstreamRef: string): TrackedUpstreamBranch | null {
   const remoteRefPrefix = 'refs/remotes/'
   const normalizedRef = upstreamRef.trim()
   if (normalizedRef.startsWith(remoteRefPrefix)) {
-    return parseTrackedUpstreamBranch(normalizedRef.slice(remoteRefPrefix.length), branchName)
+    return parseTrackedUpstreamBranch(normalizedRef.slice(remoteRefPrefix.length))
   }
   if (normalizedRef.startsWith('refs/heads/')) {
     return null
   }
-  return parseTrackedUpstreamBranch(normalizedRef, branchName)
+  return parseTrackedUpstreamBranch(normalizedRef)
 }
 
 async function lookupPRByBranchName(args: {
@@ -2799,8 +2809,8 @@ export async function getPRForBranchOutcome(
       data = branchLookup.data
       dataRepo = branchLookup.dataRepo
       if (!data) {
-        // Why: worktrees can have a short local branch tracking a differently
-        // named remote PR head; after the local miss, try that configured head.
+        // Why: the tracked upstream can identify the real PR head by branch
+        // name or by fork owner even when branch names match locally.
         const upstreamBranch = await getTrackedUpstreamBranch(
           repoPath,
           branchName,
@@ -2815,16 +2825,21 @@ export async function getPRForBranchOutcome(
               connectionId,
               ...localGitArgs
             )) ?? headRepo
-          const upstreamLookup = await lookupPRByBranchName({
-            candidates,
-            headRepo: upstreamHeadRepo,
-            branchName: upstreamBranch.branchName,
-            ghOptions
-          })
-          data = upstreamLookup.data
-          dataRepo = upstreamLookup.dataRepo
-          if (data) {
-            dataHeadRepo = upstreamHeadRepo
+          if (
+            upstreamHeadRepo &&
+            shouldRetryTrackedUpstreamBranch(upstreamBranch, branchName, upstreamHeadRepo, headRepo)
+          ) {
+            const upstreamLookup = await lookupPRByBranchName({
+              candidates,
+              headRepo: upstreamHeadRepo,
+              branchName: upstreamBranch.branchName,
+              ghOptions
+            })
+            data = upstreamLookup.data
+            dataRepo = upstreamLookup.dataRepo
+            if (data) {
+              dataHeadRepo = upstreamHeadRepo
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- Keep tracked upstream metadata when the remote branch name matches the local branch name.
- Retry GitHub PR discovery with the tracked upstream remote owner when the initial origin-head lookup misses.
- Avoid duplicate same-name retries when the tracked upstream resolves to the same head repo.
- Add local and SSH regression coverage for same-name fork upstream branches.

## Screenshots

Not applicable; GitHub PR lookup behavior only.

## AI Review Report

CodeRabbit reviewed the PR and left one maintainability nit about the adjacent `Why` comment. Addressed in the latest commit.

## Security Audit

No new inputs, permissions, credential handling, or shell command surfaces. The change reuses existing git/gh execution paths and only changes which already-configured Git remote owner is used for a GitHub PR lookup retry.

## Validation

- `pnpm test -- src/main/github/client.test.ts` - 89 passed
- `pnpm test -- src/main/github/gh-utils.test.ts` - 35 passed
- `pnpm run lint` - passed; existing `useGitStatusPolling.ts` exhaustive-deps warning remains
- `pnpm run typecheck` - passed
- `git diff --check HEAD~1..HEAD` - clean

## Electron validation

Launched the PR Electron app from `C:/Users/neil/orca/workspaces/orca/fix-fork-pr-detection` via Orca CLI terminal. Verified identity over CDP:

- `name`: `Orca: brennanb2025/fix-fork-pr-detection`
- `devRepoRoot`: `C:\Users\neil\orca\workspaces\orca\fix-fork-pr-detection`
- renderer: `http://localhost:5173/`

Imported `C:/Users/neil/source/orca` into that dev app and invoked the same `gh.prForBranch` path for `brennanb2025/worktree-remove-fix`. Temporary trace showed Electron resolved the tracked upstream as `brennan/brennanb2025/worktree-remove-fix`, retried with `headRepo: brennanb2025/orca`, and found PR #6433 in `stablyai/orca`. The public result is now `null` only because #6433 is already `MERGED` and Orca intentionally hides implicit merged branch matches without a linked PR hint.

## Notes

This is intentionally GitHub-only. Other hosted review providers continue through their existing provider-specific lookup paths.