### PR TITLE
Keep restored terminal panes typeable after sleep

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -22,7 +22,11 @@ import { getConnectionId } from '@/lib/connection-context'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { handleInternalTerminalFileDrop } from './terminal-drop-handler'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
-import { EMPTY_LAYOUT, serializeTerminalLayout } from './layout-serialization'
+import {
+  collectLeafIdsInOrder,
+  EMPTY_LAYOUT,
+  serializeTerminalLayout
+} from './layout-serialization'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import {
   applyExpandedLayoutTo,
@@ -468,6 +472,12 @@ export default function TerminalPane({
     () => (terminalTab ? sanitizeTerminalLayoutPaneTitles(savedLayout, terminalTab) : savedLayout),
     [savedLayout, terminalTab]
   )
+  const expectedLayoutLeafIds = useMemo(
+    () => collectLeafIdsInOrder(restoredLayout.root),
+    [restoredLayout.root]
+  )
+  const expectedLayoutLeafIdsAttr =
+    expectedLayoutLeafIds.length > 0 ? expectedLayoutLeafIds.join(' ') : undefined
   const initialLayoutRef = useRef(restoredLayout)
   const updateTabTitle = useAppStore((store) => store.updateTabTitle)
   const setRuntimePaneTitle = useAppStore((store) => store.setRuntimePaneTitle)
@@ -2492,6 +2502,7 @@ export default function TerminalPane({
         className="absolute inset-0 min-h-0 min-w-0"
         data-native-file-drop-target="terminal"
         data-terminal-tab-id={tabId}
+        data-terminal-layout-leaf-ids={expectedLayoutLeafIdsAttr}
         data-pane-title-surface={titleUsesLightSurface ? 'light' : 'dark'}
         style={terminalContainerStyle}
         onContextMenuCapture={contextMenu.onContextMenuCapture}

--- a/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable max-lines -- Why: this test keeps split layout replay fixtures together so
  * stable leaf-id migration regressions are visible in one focused suite. */
-import { describe, expect, it, beforeAll } from 'vitest'
+import { describe, expect, it, beforeAll, vi } from 'vitest'
 import type { TerminalPaneLayoutNode } from '../../../../shared/types'
 
 // ---------------------------------------------------------------------------
@@ -38,6 +38,7 @@ import {
   buildFontFamily,
   serializePaneTree,
   serializeTerminalLayout,
+  replayTerminalLayout,
   EMPTY_LAYOUT,
   collectLeafIdsInOrder,
   collectLeafIdsInReplayCreationOrder
@@ -319,6 +320,98 @@ describe('serializeTerminalLayout', () => {
       activeLeafId: null,
       expandedLeafId: null
     })
+  })
+})
+
+describe('replayTerminalLayout', () => {
+  function createReplayManager() {
+    const createInitialPane = vi.fn((opts?: { leafId?: string }) => ({
+      id: 1,
+      leafId: opts?.leafId ?? LEAF_4
+    }))
+    return {
+      createInitialPane,
+      splitPane: vi.fn()
+    }
+  }
+
+  it('preserves the active leaf when replaying a single-pane snapshot without a root', () => {
+    const manager = createReplayManager()
+
+    const restored = replayTerminalLayout(
+      manager as unknown as Parameters<typeof replayTerminalLayout>[0],
+      {
+        root: null,
+        activeLeafId: LEAF_1,
+        expandedLeafId: null
+      },
+      true
+    )
+
+    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: true, leafId: LEAF_1 })
+    expect(restored.get(LEAF_1)).toBe(1)
+  })
+
+  it('prefers the active leaf over multiple retained PTY bindings in a rootless snapshot', () => {
+    const manager = createReplayManager()
+
+    const restored = replayTerminalLayout(
+      manager as unknown as Parameters<typeof replayTerminalLayout>[0],
+      {
+        root: null,
+        activeLeafId: LEAF_3,
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          [LEAF_1]: 'pty-1',
+          [LEAF_2]: 'pty-2'
+        }
+      },
+      false
+    )
+
+    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: false, leafId: LEAF_3 })
+    expect(restored.get(LEAF_3)).toBe(1)
+  })
+
+  it('preserves a bound PTY leaf when the rootless snapshot has no active leaf', () => {
+    const manager = createReplayManager()
+
+    const restored = replayTerminalLayout(
+      manager as unknown as Parameters<typeof replayTerminalLayout>[0],
+      {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          [LEAF_2]: 'pty-2'
+        }
+      },
+      false
+    )
+
+    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: false, leafId: LEAF_2 })
+    expect(restored.get(LEAF_2)).toBe(1)
+  })
+
+  it('does not pick an arbitrary PTY leaf when a rootless snapshot has multiple bindings', () => {
+    const manager = createReplayManager()
+
+    const restored = replayTerminalLayout(
+      manager as unknown as Parameters<typeof replayTerminalLayout>[0],
+      {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          [LEAF_1]: 'pty-1',
+          [LEAF_2]: 'pty-2'
+        }
+      },
+      false
+    )
+
+    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: false, leafId: undefined })
+    expect(restored.get(LEAF_4)).toBe(1)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -6,7 +6,11 @@ import type {
 import { isTerminalLeafId } from '../../../../shared/stable-pane-id'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { replayIntoTerminal, type ReplayingPanesRef } from './replay-guard'
-import { getLeftmostLeafId, normalizeTerminalLayoutSnapshot } from './terminal-layout-leaf-ids'
+import {
+  getLeftmostLeafId,
+  normalizeTerminalLayoutSnapshot,
+  resolveRootlessTerminalLayoutLeafId
+} from './terminal-layout-leaf-ids'
 
 export {
   collectLeafIdsInOrder,
@@ -257,9 +261,12 @@ export function replayTerminalLayout(
 ): Map<string, number> {
   const paneByLeafId = new Map<string, number>()
 
+  const inputSnapshot = snapshot
   const normalized = normalizeTerminalLayoutSnapshot(snapshot)
   snapshot = normalized.snapshot
-  const initialLeafId = snapshot.root ? getLeftmostLeafId(snapshot.root) : undefined
+  const initialLeafId = snapshot.root
+    ? getLeftmostLeafId(snapshot.root)
+    : (resolveRootlessTerminalLayoutLeafId(inputSnapshot ?? snapshot) ?? undefined)
   const initialPane = manager.createInitialPane({ focus: focusInitialPane, leafId: initialLeafId })
   if (!snapshot?.root) {
     paneByLeafId.set(initialPane.leafId, initialPane.id)

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.test.ts
@@ -61,6 +61,61 @@ describe('resolveTerminalLayoutActiveLeafId', () => {
 })
 
 describe('normalizeTerminalLayoutSnapshot active leaf repair', () => {
+  it('preserves a rootless active leaf before terminal replay', () => {
+    const result = normalizeTerminalLayoutSnapshot({
+      root: null,
+      activeLeafId: LEAF_1,
+      expandedLeafId: null
+    })
+
+    expect(result.changed).toBe(false)
+    expect(result.snapshot.activeLeafId).toBe(LEAF_1)
+  })
+
+  it('prefers a rootless active leaf over multiple retained PTY bindings', () => {
+    const result = normalizeTerminalLayoutSnapshot({
+      root: null,
+      activeLeafId: LEAF_3,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-1',
+        [LEAF_2]: 'pty-2'
+      }
+    })
+
+    expect(result.changed).toBe(false)
+    expect(result.snapshot.activeLeafId).toBe(LEAF_3)
+  })
+
+  it('uses a sole rootless PTY binding when no active leaf remains', () => {
+    const result = normalizeTerminalLayoutSnapshot({
+      root: null,
+      activeLeafId: null,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_2]: 'pty-2'
+      }
+    })
+
+    expect(result.changed).toBe(true)
+    expect(result.snapshot.activeLeafId).toBe(LEAF_2)
+  })
+
+  it('does not pick an arbitrary rootless PTY binding when multiple remain', () => {
+    const result = normalizeTerminalLayoutSnapshot({
+      root: null,
+      activeLeafId: null,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-1',
+        [LEAF_2]: 'pty-2'
+      }
+    })
+
+    expect(result.changed).toBe(false)
+    expect(result.snapshot.activeLeafId).toBeNull()
+  })
+
   it('repairs a hydrated active leaf that has lost its PTY while a sibling is bound', () => {
     const result = normalizeTerminalLayoutSnapshot({
       root: split(LEAF_1, LEAF_2),

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
@@ -75,6 +75,16 @@ function hasLeafPtyBinding(
   return ptyIdsByLeafId ? Object.prototype.hasOwnProperty.call(ptyIdsByLeafId, leafId) : false
 }
 
+export function resolveRootlessTerminalLayoutLeafId(
+  snapshot: Pick<TerminalLayoutSnapshot, 'activeLeafId' | 'ptyIdsByLeafId'>
+): string | null {
+  if (snapshot.activeLeafId && isTerminalLeafId(snapshot.activeLeafId)) {
+    return snapshot.activeLeafId
+  }
+  const boundLeafIds = Object.keys(snapshot.ptyIdsByLeafId ?? {}).filter(isTerminalLeafId)
+  return boundLeafIds.length === 1 ? boundLeafIds[0] : null
+}
+
 export function resolveTerminalLayoutActiveLeafId(opts: {
   root: TerminalPaneLayoutNode | null | undefined
   activeLeafId: string | null | undefined
@@ -109,11 +119,7 @@ export function normalizeTerminalLayoutSnapshot(
 ): { snapshot: TerminalLayoutSnapshot; changed: boolean } {
   if (!snapshot?.root) {
     const nextSnapshot = snapshot ?? EMPTY_TERMINAL_LAYOUT
-    const activeLeafId = resolveTerminalLayoutActiveLeafId({
-      root: nextSnapshot.root,
-      activeLeafId: nextSnapshot.activeLeafId,
-      ptyIdsByLeafId: nextSnapshot.ptyIdsByLeafId
-    })
+    const activeLeafId = resolveRootlessTerminalLayoutLeafId(nextSnapshot)
     return {
       snapshot:
         activeLeafId === nextSnapshot.activeLeafId

--- a/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
@@ -47,6 +47,90 @@ describe('focusTerminalTabSurface', () => {
     expect(textarea.focus).not.toHaveBeenCalled()
   })
 
+  it('falls back to the single tab helper when an old leaf id was reminted', () => {
+    flushAnimationFrames()
+    const textarea = { focus: vi.fn() }
+    vi.stubGlobal('document', {
+      querySelector: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"]' ? { getAttribute: () => 'new-leaf' } : null
+      ),
+      querySelectorAll: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"] .xterm-helper-textarea'
+          ? { length: 1, item: () => textarea }
+          : { length: 0, item: () => null }
+      )
+    })
+
+    focusTerminalTabSurface('tab-1', 'stale-leaf')
+
+    expect(textarea.focus).toHaveBeenCalled()
+  })
+
+  it('does not focus a mounted sibling while a requested split leaf is still expected', () => {
+    flushAnimationFrames()
+    const textarea = { focus: vi.fn() }
+    vi.stubGlobal('document', {
+      querySelector: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"]'
+          ? { getAttribute: () => 'mounted-leaf pending-leaf' }
+          : null
+      ),
+      querySelectorAll: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"] .xterm-helper-textarea'
+          ? { length: 1, item: () => textarea }
+          : { length: 0, item: () => null }
+      )
+    })
+
+    focusTerminalTabSurface('tab-1', 'pending-leaf')
+
+    expect(textarea.focus).not.toHaveBeenCalled()
+  })
+
+  it('does not use stale-leaf fallback while the expected layout still has multiple leaves', () => {
+    flushAnimationFrames()
+    const textarea = { focus: vi.fn() }
+    vi.stubGlobal('document', {
+      querySelector: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"]'
+          ? { getAttribute: () => 'mounted-leaf pending-leaf' }
+          : null
+      ),
+      querySelectorAll: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"] .xterm-helper-textarea'
+          ? { length: 1, item: () => textarea }
+          : { length: 0, item: () => null }
+      )
+    })
+
+    focusTerminalTabSurface('tab-1', 'stale-leaf')
+
+    expect(textarea.focus).not.toHaveBeenCalled()
+  })
+
+  it('does not focus a sibling when a stale leaf id has multiple helpers in the tab', () => {
+    flushAnimationFrames()
+    const first = { focus: vi.fn() }
+    const second = { focus: vi.fn() }
+    vi.stubGlobal('document', {
+      querySelector: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"]'
+          ? { getAttribute: () => 'new-left new-right' }
+          : null
+      ),
+      querySelectorAll: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"] .xterm-helper-textarea'
+          ? { length: 2, item: (index: number) => (index === 0 ? first : second) }
+          : { length: 0, item: () => null }
+      )
+    })
+
+    focusTerminalTabSurface('tab-1', 'stale-leaf')
+
+    expect(first.focus).not.toHaveBeenCalled()
+    expect(second.focus).not.toHaveBeenCalled()
+  })
+
   it('cancels a pending focus frame when a newer focus request starts', () => {
     const cancelAnimationFrame = vi.fn()
     vi.stubGlobal(

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -20,6 +20,15 @@ function cancelPendingFocusFrames(): void {
   pendingFocusFrameIds = []
 }
 
+function canUseSinglePaneStaleLeafFallback(tabId: string, leafId: string): boolean {
+  const tabElement = document.querySelector(`[data-terminal-tab-id="${cssAttributeString(tabId)}"]`)
+  const expectedLeafIds = tabElement
+    ?.getAttribute('data-terminal-layout-leaf-ids')
+    ?.split(' ')
+    .filter(Boolean)
+  return expectedLeafIds?.length === 1 && !expectedLeafIds.includes(leafId)
+}
+
 export function focusTerminalTabSurface(tabId: string, leafId?: string | null): void {
   cancelPendingFocusFrames()
   const firstFrameId = requestAnimationFrame(() => {
@@ -41,8 +50,21 @@ export function focusTerminalTabSurface(tabId: string, leafId?: string | null): 
         return
       }
       if (leafId) {
-        // Why: exact mobile split-pane focus must not silently focus a sibling
-        // pane when the requested UUID leaf has not mounted yet.
+        if (!canUseSinglePaneStaleLeafFallback(tabId, leafId)) {
+          // Why: exact mobile split-pane focus must not silently focus a sibling
+          // pane when the requested UUID leaf has not mounted yet.
+          return
+        }
+        // Why: old single-pane remounts could remint the leaf id. Only recover
+        // after the tab layout no longer expects the requested leaf.
+        const tabScopedHelpers = document.querySelectorAll(
+          `[data-terminal-tab-id="${escapedTabId}"] .xterm-helper-textarea`
+        )
+        if (tabScopedHelpers.length === 1) {
+          const fallback = tabScopedHelpers.item(0) as HTMLElement | null
+          fallback?.focus()
+          return
+        }
         return
       }
       const fallback = document.querySelector('.xterm-helper-textarea') as HTMLElement | null


### PR DESCRIPTION
## Summary
- preserve valid rootless terminal layout leaf ids during restore/replay so single-pane terminals do not remint their focus identity
- add a guarded stale-leaf focus fallback only when the tab layout is definitely single-pane and exactly one xterm helper is mounted
- cover the restore and focus edge cases with regression tests

## Process
- Followed the brennan-yolo-lite shape: wrote the design, ran design/completeness/code-review passes, then tightened the implementation around ambiguous split and multi-helper cases.
- Checked prior attempts (#6411 / af52e418e, #6379 / 101608736, and 7936e466f). Those fixed adjacent stale PTY/sleep/resume paths but did not cover the rootless restore leaf-remint plus exact focus miss chain.

## Regression reasoning
- The primary path preserves an already-valid active leaf id, or infers a leaf only when exactly one PTY binding exists.
- Ambiguous rootless snapshots still fail closed rather than picking an arbitrary PTY leaf.
- The focus fallback is tab-scoped and only runs when the expected layout has exactly one leaf, the requested leaf is no longer expected, and exactly one helper textarea exists. Split panes, pending split mounts, and multiple helpers remain exact-focus only.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/layout-serialization.test.ts src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.test.ts src/renderer/src/lib/focus-terminal-tab-surface.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
