### PR TITLE
Keep interrupted Claude turns from appearing active

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -434,6 +434,74 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('does not let late Claude tool hooks with explicit prompt resurrect an inferred interrupt', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          hookEventName: 'UserPromptSubmit',
+          payload: {
+            state: 'working',
+            prompt: 'Do I have gpu acceleration on on my terminal?',
+            agentType: 'claude'
+          }
+        },
+        'conn-1'
+      )
+      const baseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(1_500)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'Do I have gpu acceleration on on my terminal?',
+          baselineAgentType: 'claude',
+          intent: 'ctrl-c'
+        })
+      ).toBe(true)
+
+      vi.setSystemTime(2_000)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          hookEventName: 'PostToolUse',
+          payload: {
+            state: 'working',
+            prompt: 'Do I have gpu acceleration on on my terminal?',
+            agentType: 'claude',
+            toolName: 'Read',
+            toolInput: 'src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts'
+          }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'done',
+          prompt: 'Do I have gpu acceleration on on my terminal?',
+          agentType: 'claude',
+          interrupted: true,
+          receivedAt: 1_500,
+          stateStartedAt: 1_500
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('allows a new prompt after an inferred interrupt', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
@@ -478,6 +546,64 @@ describe('AgentHookServer listener replay', () => {
           state: 'working',
           prompt: 'second task',
           agentType: 'pi',
+          receivedAt: 2_000,
+          stateStartedAt: 2_000
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows a Claude follow-up prompt after an inferred interrupt to keep working', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          hookEventName: 'UserPromptSubmit',
+          payload: { state: 'working', prompt: 'first Claude turn', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      const baseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(1_500)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'first Claude turn',
+          baselineAgentType: 'claude',
+          intent: 'ctrl-c'
+        })
+      ).toBe(true)
+
+      vi.setSystemTime(2_000)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          hookEventName: 'UserPromptSubmit',
+          payload: { state: 'working', prompt: 'second queued Claude turn', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'second queued Claude turn',
+          agentType: 'claude',
+          interrupted: undefined,
           receivedAt: 2_000,
           stateStartedAt: 2_000
         })
@@ -542,7 +668,125 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
-  it('allows a same-prompt working hook after the stale suppression window', () => {
+  it('suppresses same-turn Claude tool progress after the stale suppression window', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          hookEventName: 'UserPromptSubmit',
+          payload: { state: 'working', prompt: 'repeat task', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      const baseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(1_500)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'repeat task',
+          baselineAgentType: 'claude',
+          intent: 'ctrl-c'
+        })
+      ).toBe(true)
+
+      vi.setSystemTime(16_501)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          hookEventName: 'PostToolUse',
+          payload: {
+            state: 'working',
+            prompt: 'repeat task',
+            agentType: 'claude',
+            toolName: 'bash',
+            toolInput: '/bin/sleep 90'
+          }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'done',
+          prompt: 'repeat task',
+          agentType: 'claude',
+          interrupted: true,
+          receivedAt: 1_500,
+          stateStartedAt: 1_500
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows generic non-explicit same-prompt working after the stale suppression window', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'repeat task', agentType: 'pi' }
+        },
+        'conn-1'
+      )
+      const baseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(1_500)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'repeat task',
+          baselineAgentType: 'pi',
+          intent: 'ctrl-c'
+        })
+      ).toBe(true)
+
+      vi.setSystemTime(16_501)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'repeat task', agentType: 'pi' }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'repeat task',
+          agentType: 'pi',
+          interrupted: undefined,
+          receivedAt: 16_501,
+          stateStartedAt: 16_501
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows non-Claude tool-context working after the stale suppression window', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
     try {
@@ -592,6 +836,9 @@ describe('AgentHookServer listener replay', () => {
           state: 'working',
           prompt: 'repeat task',
           agentType: 'pi',
+          interrupted: undefined,
+          toolName: 'bash',
+          toolInput: '/bin/sleep 90',
           receivedAt: 16_501,
           stateStartedAt: 16_501
         })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -108,6 +108,7 @@ const LAST_STATUS_FILE_VERSION = 2
 // hook-server batching; quit-time uses flushStatusPersistSync() for the
 // guaranteed final flush.
 const STATUS_PERSIST_DEBOUNCE_MS = 250
+const TOOL_PROGRESS_HOOK_EVENTS = new Set(['PreToolUse', 'PostToolUse', 'PostToolUseFailure'])
 const AGENT_PROMPT_SENT_AGENT_KINDS = new Set<AgentKind>(AGENT_KIND_VALUES)
 
 // Why: bound the on-disk file's growth across many sessions. PTY-teardown
@@ -269,6 +270,18 @@ function trackEmptyPaneKeyHook(body: unknown): void {
     return
   }
   track('agent_hook_unattributed', { reason: 'empty_pane_key' })
+}
+
+function isToolProgressWorkingAfterInterrupt(next: AgentHookEventPayload): boolean {
+  if (next.payload.state !== 'working') {
+    return false
+  }
+  if (next.payload.agentType !== 'claude') {
+    return false
+  }
+  // Why: a same-prompt retry is another UserPromptSubmit, while late Claude
+  // progress after Ctrl+C arrives as tool lifecycle work for the old turn.
+  return next.hookEventName !== undefined && TOOL_PROGRESS_HOOK_EVENTS.has(next.hookEventName)
 }
 
 function paneCacheKeyTabId(key: string): string | null {
@@ -737,6 +750,7 @@ export class AgentHookServer {
       previous.payload.agentType === effectivePayload.payload.agentType &&
       previous.payload.prompt === effectivePayload.payload.prompt &&
       (effectivePayload.isReplay === true ||
+        isToolProgressWorkingAfterInterrupt(effectivePayload) ||
         (effectivePayload.hasExplicitPrompt !== true &&
           Date.now() - previous.receivedAt <= INTERRUPTED_DONE_LATE_WORKING_SUPPRESSION_MS))
     ) {

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -903,6 +903,62 @@ describe('agent status retention + prefix sweep', () => {
     expect(map['tab-10:0']).toBeDefined()
   })
 
+  it('setAgentStatus clears a retained snapshot for the same paneKey', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const oldEntry: AgentStatusEntry = {
+      state: 'done',
+      prompt: 'old turn',
+      updatedAt: 1_000,
+      stateStartedAt: 1_000,
+      paneKey: 'tab-a:0',
+      stateHistory: [],
+      agentType: 'claude'
+    }
+    const siblingEntry: AgentStatusEntry = {
+      state: 'done',
+      prompt: 'sibling turn',
+      updatedAt: 1_000,
+      stateStartedAt: 1_000,
+      paneKey: 'tab-a:1',
+      stateHistory: [],
+      agentType: 'claude'
+    }
+    const retainedA: RetainedAgentEntry = {
+      entry: oldEntry,
+      worktreeId: 'wt-a',
+      tab: makeTab({ id: 'tab-a', worktreeId: 'wt-a', title: 'claude' }),
+      agentType: 'claude',
+      startedAt: 1_000
+    }
+    const retainedSibling: RetainedAgentEntry = {
+      entry: siblingEntry,
+      worktreeId: 'wt-a',
+      tab: makeTab({ id: 'tab-a', worktreeId: 'wt-a', title: 'claude' }),
+      agentType: 'claude',
+      startedAt: 1_000
+    }
+
+    store.getState().retainAgents([retainedA, retainedSibling])
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-a:0',
+        { state: 'done', prompt: 'interrupted turn', agentType: 'claude', interrupted: true },
+        'claude',
+        { updatedAt: 2_000, stateStartedAt: 2_000 }
+      )
+
+    const state = store.getState()
+    expect(state.agentStatusByPaneKey['tab-a:0']).toMatchObject({
+      state: 'done',
+      prompt: 'interrupted turn',
+      interrupted: true
+    })
+    expect(state.retainedAgentsByPaneKey['tab-a:0']).toBeUndefined()
+    expect(state.retainedAgentsByPaneKey['tab-a:1']).toBe(retainedSibling)
+  })
+
   it('dismissRetainedAgentsByWorktree removes only entries for the given worktreeId', () => {
     const store = createTestStore()
     const now = Date.now()

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1167,6 +1167,16 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           nextRetentionSuppressedPaneKeys = { ...s.retentionSuppressedPaneKeys }
           delete nextRetentionSuppressedPaneKeys[paneKey]
         }
+        // Why: pane keys are reused by the same terminal pane across turns.
+        // Once a fresh live hook row arrives, any retained snapshot for that
+        // pane is stale and must not render beside the live row in the sidebar.
+        const hasRetainedSnapshot = paneKey in s.retainedAgentsByPaneKey
+        const nextRetainedAgents = hasRetainedSnapshot
+          ? { ...s.retainedAgentsByPaneKey }
+          : s.retainedAgentsByPaneKey
+        if (hasRetainedSnapshot) {
+          delete nextRetainedAgents[paneKey]
+        }
         const migrationUnsupported = pruneMigrationUnsupportedEntries(
           s.migrationUnsupportedByPtyId,
           (entry) => entry.paneKey === paneKey
@@ -1226,6 +1236,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
         return {
           agentStatusByPaneKey: { ...s.agentStatusByPaneKey, [paneKey]: entry },
+          retainedAgentsByPaneKey: nextRetainedAgents,
           sleepingAgentSessionsByPaneKey: nextSleepingAgentSessions,
           agentLaunchConfigByPaneKey: nextLaunchConfigs,
           migrationUnsupportedByPtyId: migrationUnsupported.next,


### PR DESCRIPTION
## Summary

Keeps interrupted Claude Code turns from resurfacing as active/running in the sidebar when late same-turn tool hooks arrive after Ctrl+C.

Design approach:
- Preserve Orca's existing Ctrl+C interrupt inference (`done` with `interrupted: true`).
- Add a main-process guard so replayed same-prompt working events and known Claude tool-lifecycle working events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`) do not resurrect an interrupted row.
- Preserve real continued work: fresh/follow-up Claude `UserPromptSubmit` events, explicit same-prompt retries, and generic/non-Claude later working events can still become `working`.
- Clear a same-pane retained snapshot when a fresh live status arrives, while preserving sibling retained rows.

## Brennan's PR Process Evidence

Design review:
- Reviewed scratch design doc passed after tightening stale-hook classification.
- Residual design notes were handled during code review: indefinite stale suppression is now Claude tool-lifecycle specific; generic/non-Claude recovery remains bounded by the existing stale window.

Implementation:
- Updated `AgentHookServer.applyNormalizedStatus` transition handling for interrupted rows.
- Added hook-server regressions for late Claude tool hooks, after-window Claude tool progress, Claude follow-up prompts, same-prompt retry, generic non-explicit after-window working, non-Claude tool-context after-window working, and replay suppression.
- Updated renderer store status handling so fresh live rows clear stale retained snapshots for the same pane key only.
- No deviations from the final design contract.

Completeness verification:
- Read-only verifier found the implementation complete against the design, with SSH/cross-platform/perf considerations satisfied.

Perf audit:
- Clean. Touched hot paths are main hook ingestion and renderer `setAgentStatus`.
- New work is constant-time field checks plus a small `Set.has`; retained-map cloning happens only when the pane key actually has a retained snapshot.
- No polling, subprocess churn, render churn, startup latency, leaks, or cache invalidation issues found.

Code review:
- Round 1: one reviewer found overbroad indefinite suppression for generic non-explicit same-prompt working; fixed with bounded fallback and added regression coverage.
- Round 2: both reviewers found overbroad indefinite suppression for non-Claude tool-context working; fixed by narrowing indefinite suppression to Claude tool lifecycle events and added regression coverage.
- Round 3: both reviewers returned clean.

Merge-confidence validation:
- Verdict: land.
- Product validation used the real Electron app, an actual terminal pane, real hook endpoint, and app interrupt inference API.
- Before interrupt: backing state was `working`; retained rows empty.
- After inferred Ctrl+C: backing state and renderer store were `done`, `interrupted: true`; retained rows empty; sidebar showed `Interrupted by user`.
- After waiting past the 15s stale window and posting a late same-turn Claude `PostToolUse`, state stayed `done + interrupted` and the sidebar did not resurrect `working`.
- Fresh Claude follow-up `UserPromptSubmit` correctly became `working`.
- Renderer retained-status check confirmed same-pane retained cleanup while preserving sibling retained rows.

Manual validation screenshot evidence:
- `/tmp/orca-stage8-evidence/ctrlc-interrupted-sidebar.png`
- `/tmp/orca-stage8-evidence/ctrlc-interrupted-after-late-tool-hook.png`

Accepted validation gaps:
- Product validation used a faithful hook-endpoint/Electron equivalent rather than a live network/provider Claude TUI session.
- No SSH integration run; the changed path is shared through `ingestRemote(...)` into `applyNormalizedStatus(...)` and does not alter relay transport.

## Checks

Local/static checks run:
- `pnpm run typecheck`
- `pnpm run lint` (passed with one existing warning in `src/renderer/src/components/right-sidebar/useGitStatusPolling.ts`)
- `git diff --check`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts src/renderer/src/store/slices/agent-status.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts`
- `pnpm exec oxlint src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts src/renderer/src/store/slices/agent-status.ts src/renderer/src/store/slices/agent-status.test.ts`

Post-PR stabilization:
- Initial PR checks: `verify` passed; `track-community-pr` passed.
- CodeRabbit initially hit a review rate limit. After the cooldown, `@coderabbitai review` was triggered manually.
- CodeRabbit completed with “No actionable comments were generated in the recent review.”
- Final PR checks are passing.
