### PR TITLE
feat(jujutsu): spawn sessions as jj workspaces for pure-jj repos

### DIFF
--- a/src/main/git/worktree-jujutsu.test.ts
+++ b/src/main/git/worktree-jujutsu.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  translateWslOutputPaths: (value: string) => value
+}))
+
+import { addWorktree } from './worktree'
+
+describe('addWorktree jj delegation', () => {
+  it('routes a detected pure-jj repo to `jj workspace add` and skips git', async () => {
+    const runJujutsuWorkspaceAdd = vi.fn().mockResolvedValue(undefined)
+    gitExecFileAsyncMock.mockReset()
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo/.worktrees/feature',
+      'feature',
+      'origin/main',
+      false,
+      false,
+      {
+        detectJujutsuWorkspace: () => true,
+        runJujutsuWorkspaceAdd
+      }
+    )
+
+    expect(result).toEqual({})
+    expect(runJujutsuWorkspaceAdd).toHaveBeenCalledWith({
+      repoPath: '/repo',
+      worktreePath: '/repo/.worktrees/feature',
+      name: 'feature',
+      baseRef: 'origin/main'
+    })
+    // The git worktree path must not run for a jj repo.
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps using git when the repo is not a pure-jj repo', async () => {
+    const runJujutsuWorkspaceAdd = vi.fn().mockResolvedValue(undefined)
+    gitExecFileAsyncMock.mockReset()
+    // worktree add, then push.autoSetupRemote read (unset) + write.
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 }))
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await addWorktree('/repo', '/repo/.worktrees/feature', 'feature', undefined, false, false, {
+      detectJujutsuWorkspace: () => false,
+      runJujutsuWorkspaceAdd
+    })
+
+    expect(runJujutsuWorkspaceAdd).not.toHaveBeenCalled()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['worktree', 'add', '--no-track', '-b', 'feature', '/repo/.worktrees/feature'],
+      expect.objectContaining({ cwd: '/repo' })
+    )
+  })
+})

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -14,6 +14,11 @@ import type {
   RemoveWorktreeResult
 } from '../../shared/types'
 import { parseGitRevListAheadBehindCounts } from '../../shared/git-rev-list-output'
+import {
+  addJujutsuWorkspace,
+  shouldUseJujutsuWorkspace,
+  type AddJujutsuWorkspaceInput
+} from '../jujutsu/workspace'
 import { gitExecFileAsync, translateWslOutputPaths } from './runner'
 import { resolveGitDir } from './status'
 import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
@@ -39,6 +44,11 @@ export type AddWorktreeOptions = GitWorktreeExecOptions & {
     branch: string
     ref: string
   }
+  // Injectable jj hooks (default to the real filesystem probe and runner) so a
+  // pure-jj repo spawns sessions via `jj workspace add` instead of
+  // `git worktree add`. Overridable in tests; see src/main/jujutsu/workspace.ts.
+  detectJujutsuWorkspace?: (repoPath: string) => boolean | Promise<boolean>
+  runJujutsuWorkspaceAdd?: (input: AddJujutsuWorkspaceInput) => Promise<void>
 }
 
 export type RemoveWorktreeOptions = GitWorktreeExecOptions & {
@@ -651,6 +661,17 @@ export async function addWorktree(
   noCheckout = false,
   options: AddWorktreeOptions = {}
 ): Promise<AddWorktreeResult> {
+  // Pure-jj repos manage parallel working copies with `jj workspace`, not git
+  // worktrees, so delegate before any git-specific command runs. Colocated
+  // repos return false here and keep the git path so their status/diff/history
+  // stay intact (jj workspaces are invisible to git — jj-vcs/jj#8052).
+  const detectJujutsu = options.detectJujutsuWorkspace ?? shouldUseJujutsuWorkspace
+  if (await detectJujutsu(repoPath)) {
+    const runJujutsuAdd = options.runJujutsuWorkspaceAdd ?? addJujutsuWorkspace
+    await runJujutsuAdd({ repoPath, worktreePath, name: branch, baseRef: baseBranch })
+    return {}
+  }
+
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
   const args = ['worktree', 'add']

--- a/src/main/jujutsu/workspace.test.ts
+++ b/src/main/jujutsu/workspace.test.ts
@@ -64,15 +64,23 @@ describe('jj repo detection', () => {
 })
 
 describe('addJujutsuWorkspace', () => {
-  it('runs `jj workspace add` with a derived name and translated base revision', async () => {
+  it('rewrites a remote-tracking base ref after confirming the remote exists', async () => {
+    // baseRef contains a slash -> remote lookup runs first, then workspace add.
+    commandExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'origin https://example.com/repo.git\n',
+      stderr: ''
+    })
     commandExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
     await addJujutsuWorkspace({
       repoPath: '/repo',
       worktreePath: '/repo/.worktrees/feature',
       baseRef: 'origin/main'
     })
-    expect(commandExecFileAsyncMock).toHaveBeenCalledTimes(1)
-    expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
+    expect(commandExecFileAsyncMock).toHaveBeenNthCalledWith(1, 'jj', ['git', 'remote', 'list'], {
+      cwd: '/repo'
+    })
+    expect(commandExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
       'jj',
       [
         'workspace',
@@ -87,13 +95,30 @@ describe('addJujutsuWorkspace', () => {
     )
   })
 
-  it('honours an explicit name and omits the revision when no base is given', async () => {
+  it('keeps a slash-containing local bookmark intact when no matching remote exists', async () => {
+    commandExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'origin https://x\n', stderr: '' })
+    commandExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    await addJujutsuWorkspace({
+      repoPath: '/repo',
+      worktreePath: '/repo/.worktrees/foo',
+      baseRef: 'feature/foo'
+    })
+    expect(commandExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      'jj',
+      ['workspace', 'add', '--name', 'foo', '--revision', 'feature/foo', '/repo/.worktrees/foo'],
+      { cwd: '/repo' }
+    )
+  })
+
+  it('skips the remote lookup and omits the revision when no base is given', async () => {
     commandExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
     await addJujutsuWorkspace({
       repoPath: '/repo',
       worktreePath: '/repo/.worktrees/feature',
       name: 'custom'
     })
+    expect(commandExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
       'jj',
       ['workspace', 'add', '--name', 'custom', '/repo/.worktrees/feature'],
@@ -117,6 +142,31 @@ describe('listJujutsuWorkspaces', () => {
       ['workspace', 'list', '--template', expect.any(String)],
       { cwd: '/repo' }
     )
+  })
+
+  it('falls back to the template-less listing when jj rejects --template', async () => {
+    commandExecFileAsyncMock.mockRejectedValueOnce(
+      Object.assign(new Error('error: unexpected argument --template found'), {
+        stderr: 'unexpected argument'
+      })
+    )
+    commandExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'default: qpv abc main | msg\nfeature: rly def | msg\n',
+      stderr: ''
+    })
+    expect(await listJujutsuWorkspaces('/repo')).toEqual([
+      { name: 'default', path: '' },
+      { name: 'feature', path: '' }
+    ])
+    expect(commandExecFileAsyncMock).toHaveBeenNthCalledWith(2, 'jj', ['workspace', 'list'], {
+      cwd: '/repo'
+    })
+  })
+
+  it('rethrows unrelated listing failures instead of falling back', async () => {
+    commandExecFileAsyncMock.mockRejectedValueOnce(new Error('repo is locked'))
+    await expect(listJujutsuWorkspaces('/repo')).rejects.toThrow('repo is locked')
+    expect(commandExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/main/jujutsu/workspace.test.ts
+++ b/src/main/jujutsu/workspace.test.ts
@@ -1,0 +1,147 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { commandExecFileAsyncMock } = vi.hoisted(() => ({
+  commandExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  commandExecFileAsync: commandExecFileAsyncMock
+}))
+
+import {
+  addJujutsuWorkspace,
+  forgetJujutsuWorkspace,
+  isColocatedJujutsuRepo,
+  isJujutsuRepo,
+  jujutsuWorkspaceRoot,
+  listJujutsuWorkspaces,
+  shouldUseJujutsuWorkspace
+} from './workspace'
+
+let tmp: string
+
+beforeEach(async () => {
+  commandExecFileAsyncMock.mockReset()
+  tmp = await mkdtemp(join(tmpdir(), 'orca-jj-'))
+})
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true })
+})
+
+describe('jj repo detection', () => {
+  it('detects a pure jj repo by its .jj directory', async () => {
+    await mkdir(join(tmp, '.jj'))
+    expect(await isJujutsuRepo(tmp)).toBe(true)
+    expect(await isColocatedJujutsuRepo(tmp)).toBe(false)
+    expect(await shouldUseJujutsuWorkspace(tmp)).toBe(true)
+  })
+
+  it('treats a colocated repo as git-managed, not a jj-workspace target', async () => {
+    await mkdir(join(tmp, '.jj'))
+    await mkdir(join(tmp, '.git'))
+    expect(await isJujutsuRepo(tmp)).toBe(true)
+    expect(await isColocatedJujutsuRepo(tmp)).toBe(true)
+    // Colocated repos must keep using git worktrees to preserve status/diff.
+    expect(await shouldUseJujutsuWorkspace(tmp)).toBe(false)
+  })
+
+  it('recognises a colocated repo whose .git is a gitfile, not a directory', async () => {
+    await mkdir(join(tmp, '.jj'))
+    await writeFile(join(tmp, '.git'), 'gitdir: /elsewhere/.git/worktrees/x\n')
+    expect(await isColocatedJujutsuRepo(tmp)).toBe(true)
+    expect(await shouldUseJujutsuWorkspace(tmp)).toBe(false)
+  })
+
+  it('reports a plain git repo as neither jj nor a jj-workspace target', async () => {
+    await mkdir(join(tmp, '.git'))
+    expect(await isJujutsuRepo(tmp)).toBe(false)
+    expect(await shouldUseJujutsuWorkspace(tmp)).toBe(false)
+  })
+})
+
+describe('addJujutsuWorkspace', () => {
+  it('runs `jj workspace add` with a derived name and translated base revision', async () => {
+    commandExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    await addJujutsuWorkspace({
+      repoPath: '/repo',
+      worktreePath: '/repo/.worktrees/feature',
+      baseRef: 'origin/main'
+    })
+    expect(commandExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
+      'jj',
+      [
+        'workspace',
+        'add',
+        '--name',
+        'feature',
+        '--revision',
+        'main@origin',
+        '/repo/.worktrees/feature'
+      ],
+      { cwd: '/repo' }
+    )
+  })
+
+  it('honours an explicit name and omits the revision when no base is given', async () => {
+    commandExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    await addJujutsuWorkspace({
+      repoPath: '/repo',
+      worktreePath: '/repo/.worktrees/feature',
+      name: 'custom'
+    })
+    expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
+      'jj',
+      ['workspace', 'add', '--name', 'custom', '/repo/.worktrees/feature'],
+      { cwd: '/repo' }
+    )
+  })
+})
+
+describe('listJujutsuWorkspaces', () => {
+  it('parses tab-separated workspace output', async () => {
+    commandExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'default\t/repo\nfeature\t/repo/.worktrees/feature\n',
+      stderr: ''
+    })
+    expect(await listJujutsuWorkspaces('/repo')).toEqual([
+      { name: 'default', path: '/repo' },
+      { name: 'feature', path: '/repo/.worktrees/feature' }
+    ])
+    expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
+      'jj',
+      ['workspace', 'list', '--template', expect.any(String)],
+      { cwd: '/repo' }
+    )
+  })
+})
+
+describe('forgetJujutsuWorkspace', () => {
+  it('runs `jj workspace forget <name>`', async () => {
+    commandExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    await forgetJujutsuWorkspace('/repo', 'feature')
+    expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
+      'jj',
+      ['workspace', 'forget', 'feature'],
+      {
+        cwd: '/repo'
+      }
+    )
+  })
+})
+
+describe('jujutsuWorkspaceRoot', () => {
+  it('returns the trimmed root path', async () => {
+    commandExecFileAsyncMock.mockResolvedValueOnce({ stdout: '/repo\n', stderr: '' })
+    expect(await jujutsuWorkspaceRoot('/repo/sub')).toBe('/repo')
+  })
+
+  it('returns null when jj is unavailable or the path is not a jj repo', async () => {
+    commandExecFileAsyncMock.mockRejectedValueOnce(new Error('command not found: jj'))
+    expect(await jujutsuWorkspaceRoot('/repo')).toBeNull()
+  })
+})

--- a/src/main/jujutsu/workspace.ts
+++ b/src/main/jujutsu/workspace.ts
@@ -1,0 +1,132 @@
+import { stat } from 'fs/promises'
+import { join } from 'path'
+import {
+  JUJUTSU_BIN,
+  buildJjWorkspaceAddArgs,
+  buildJjWorkspaceForgetArgs,
+  buildJjWorkspaceListArgs,
+  buildJjWorkspaceRootArgs,
+  jujutsuWorkspaceNameForPath,
+  parseJujutsuWorkspaceList,
+  resolveJujutsuBaseRevision,
+  type JujutsuWorkspaceInfo
+} from '../../shared/jujutsu-workspace-command'
+import { commandExecFileAsync } from '../git/runner'
+
+export type JujutsuExecOptions = {
+  env?: NodeJS.ProcessEnv
+  timeout?: number
+  signal?: AbortSignal
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// A jj repo is identified by a `.jj` directory at the workspace root — the same
+// ancestor-marker scheme jj uses internally. No `jj` binary required, so
+// detection works even when jj is not installed.
+export async function isJujutsuRepo(repoPath: string): Promise<boolean> {
+  return isDirectory(join(repoPath, '.jj'))
+}
+
+// Colocated repos carry both `.jj` and `.git`. Orca already drives those
+// through its git machinery (status, diff, history, worktrees), so they must
+// stay on git to avoid regressions.
+export async function isColocatedJujutsuRepo(repoPath: string): Promise<boolean> {
+  const [jj, git] = await Promise.all([
+    isDirectory(join(repoPath, '.jj')),
+    pathExists(join(repoPath, '.git'))
+  ])
+  return jj && git
+}
+
+// Sessions should spawn as `jj workspace` only for a pure-jj repo (a `.jj`
+// marker with no colocated `.git`). Colocated repos keep using git worktrees so
+// their existing status/diff/history flows stay intact — jj workspaces are not
+// git worktrees and git tooling cannot see them (jj-vcs/jj#8052).
+export async function shouldUseJujutsuWorkspace(repoPath: string): Promise<boolean> {
+  const [jj, git] = await Promise.all([
+    isDirectory(join(repoPath, '.jj')),
+    pathExists(join(repoPath, '.git'))
+  ])
+  return jj && !git
+}
+
+// Resolve the workspace root from any subdirectory. Returns null when jj is not
+// installed or the path is not a jj repo, so callers can fall back to git.
+export async function jujutsuWorkspaceRoot(
+  repoPath: string,
+  options: JujutsuExecOptions = {}
+): Promise<string | null> {
+  try {
+    const { stdout } = await commandExecFileAsync(JUJUTSU_BIN, buildJjWorkspaceRootArgs(), {
+      cwd: repoPath,
+      ...options
+    })
+    const root = stdout.trim()
+    return root.length > 0 ? root : null
+  } catch {
+    return null
+  }
+}
+
+export type AddJujutsuWorkspaceInput = {
+  repoPath: string
+  worktreePath: string
+  name?: string
+  baseRef?: string
+}
+
+// Create a new jj workspace at `worktreePath` — the jj analogue of
+// `git worktree add`. The name defaults to the leaf directory (matching jj's
+// own default) and the git base ref is translated to a jj revset.
+export async function addJujutsuWorkspace(
+  input: AddJujutsuWorkspaceInput,
+  options: JujutsuExecOptions = {}
+): Promise<void> {
+  const args = buildJjWorkspaceAddArgs({
+    worktreePath: input.worktreePath,
+    name: input.name ?? jujutsuWorkspaceNameForPath(input.worktreePath),
+    baseRevision: resolveJujutsuBaseRevision(input.baseRef)
+  })
+  await commandExecFileAsync(JUJUTSU_BIN, args, { cwd: input.repoPath, ...options })
+}
+
+export async function listJujutsuWorkspaces(
+  repoPath: string,
+  options: JujutsuExecOptions = {}
+): Promise<JujutsuWorkspaceInfo[]> {
+  const { stdout } = await commandExecFileAsync(JUJUTSU_BIN, buildJjWorkspaceListArgs(), {
+    cwd: repoPath,
+    ...options
+  })
+  return parseJujutsuWorkspaceList(stdout)
+}
+
+// Detach a workspace from the repo. jj leaves the directory on disk, so callers
+// remove it separately — the same two-step contract as forgetting plus
+// deleting a git worktree.
+export async function forgetJujutsuWorkspace(
+  repoPath: string,
+  name: string,
+  options: JujutsuExecOptions = {}
+): Promise<void> {
+  await commandExecFileAsync(JUJUTSU_BIN, buildJjWorkspaceForgetArgs(name), {
+    cwd: repoPath,
+    ...options
+  })
+}

--- a/src/main/jujutsu/workspace.ts
+++ b/src/main/jujutsu/workspace.ts
@@ -2,12 +2,16 @@ import { stat } from 'fs/promises'
 import { join } from 'path'
 import {
   JUJUTSU_BIN,
+  buildJjRemoteListArgs,
   buildJjWorkspaceAddArgs,
   buildJjWorkspaceForgetArgs,
   buildJjWorkspaceListArgs,
+  buildJjWorkspaceListDefaultArgs,
   buildJjWorkspaceRootArgs,
   jujutsuWorkspaceNameForPath,
+  parseJujutsuRemoteNames,
   parseJujutsuWorkspaceList,
+  parseJujutsuWorkspaceListDefault,
   resolveJujutsuBaseRevision,
   type JujutsuWorkspaceInfo
 } from '../../shared/jujutsu-workspace-command'
@@ -84,6 +88,24 @@ export async function jujutsuWorkspaceRoot(
   }
 }
 
+// List the repo's jj remote names. Best-effort: returns [] when jj is
+// unavailable or the repo has no git backend, so base-ref resolution simply
+// declines to rewrite slash-containing refs.
+export async function listJujutsuRemotes(
+  repoPath: string,
+  options: JujutsuExecOptions = {}
+): Promise<string[]> {
+  try {
+    const { stdout } = await commandExecFileAsync(JUJUTSU_BIN, buildJjRemoteListArgs(), {
+      cwd: repoPath,
+      ...options
+    })
+    return parseJujutsuRemoteNames(stdout)
+  } catch {
+    return []
+  }
+}
+
 export type AddJujutsuWorkspaceInput = {
   repoPath: string
   worktreePath: string
@@ -93,28 +115,59 @@ export type AddJujutsuWorkspaceInput = {
 
 // Create a new jj workspace at `worktreePath` — the jj analogue of
 // `git worktree add`. The name defaults to the leaf directory (matching jj's
-// own default) and the git base ref is translated to a jj revset.
+// own default) and the git base ref is translated to a jj revset, but only a
+// `<remote>/<branch>` ref whose prefix is a real jj remote is rewritten — local
+// bookmarks like `feature/foo` are passed through untouched.
 export async function addJujutsuWorkspace(
   input: AddJujutsuWorkspaceInput,
   options: JujutsuExecOptions = {}
 ): Promise<void> {
+  // Only pay for the remote lookup when the ref could be remote-tracking.
+  const knownRemotes = input.baseRef?.includes('/')
+    ? await listJujutsuRemotes(input.repoPath, options)
+    : []
   const args = buildJjWorkspaceAddArgs({
     worktreePath: input.worktreePath,
     name: input.name ?? jujutsuWorkspaceNameForPath(input.worktreePath),
-    baseRevision: resolveJujutsuBaseRevision(input.baseRef)
+    baseRevision: resolveJujutsuBaseRevision(input.baseRef, knownRemotes)
   })
   await commandExecFileAsync(JUJUTSU_BIN, args, { cwd: input.repoPath, ...options })
 }
 
+// List workspaces with their paths, falling back to the template-less format on
+// jj < 0.32 (which rejects `--template`); the fallback yields names with empty
+// paths.
 export async function listJujutsuWorkspaces(
   repoPath: string,
   options: JujutsuExecOptions = {}
 ): Promise<JujutsuWorkspaceInfo[]> {
-  const { stdout } = await commandExecFileAsync(JUJUTSU_BIN, buildJjWorkspaceListArgs(), {
-    cwd: repoPath,
-    ...options
-  })
-  return parseJujutsuWorkspaceList(stdout)
+  try {
+    const { stdout } = await commandExecFileAsync(JUJUTSU_BIN, buildJjWorkspaceListArgs(), {
+      cwd: repoPath,
+      ...options
+    })
+    return parseJujutsuWorkspaceList(stdout)
+  } catch (error) {
+    if (!isUnsupportedTemplateError(error)) {
+      throw error
+    }
+    const { stdout } = await commandExecFileAsync(JUJUTSU_BIN, buildJjWorkspaceListDefaultArgs(), {
+      cwd: repoPath,
+      ...options
+    })
+    return parseJujutsuWorkspaceListDefault(stdout)
+  }
+}
+
+// jj < 0.32 rejects `--template` on `workspace list`; detect that (and a stale
+// `root()` method on in-between versions) to trigger the name-only fallback
+// without masking unrelated failures.
+function isUnsupportedTemplateError(error: unknown): boolean {
+  const text =
+    error instanceof Error
+      ? `${error.message} ${(error as { stderr?: string }).stderr ?? ''}`
+      : String(error)
+  return /unexpected argument|--template|unrecognized|no method named `root`|root\(\)/i.test(text)
 }
 
 // Detach a workspace from the repo. jj leaves the directory on disk, so callers

--- a/src/shared/jujutsu-workspace-command.test.ts
+++ b/src/shared/jujutsu-workspace-command.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import {
   JJ_WORKSPACE_LIST_TEMPLATE,
+  buildJjRemoteListArgs,
   buildJjWorkspaceAddArgs,
   buildJjWorkspaceForgetArgs,
   buildJjWorkspaceListArgs,
+  buildJjWorkspaceListDefaultArgs,
   buildJjWorkspaceRootArgs,
   jujutsuWorkspaceNameForPath,
+  parseJujutsuRemoteNames,
   parseJujutsuWorkspaceList,
+  parseJujutsuWorkspaceListDefault,
   resolveJujutsuBaseRevision
 } from './jujutsu-workspace-command'
 
@@ -58,12 +62,47 @@ describe('buildJjWorkspace* arg builders', () => {
     ])
   })
 
+  it('builds the template-less list args for the older-jj fallback', () => {
+    expect(buildJjWorkspaceListDefaultArgs()).toEqual(['workspace', 'list'])
+  })
+
   it('builds forget args from a workspace name', () => {
     expect(buildJjWorkspaceForgetArgs('feature')).toEqual(['workspace', 'forget', 'feature'])
   })
 
   it('builds workspace root args', () => {
     expect(buildJjWorkspaceRootArgs()).toEqual(['workspace', 'root'])
+  })
+
+  it('builds git remote list args', () => {
+    expect(buildJjRemoteListArgs()).toEqual(['git', 'remote', 'list'])
+  })
+})
+
+describe('parseJujutsuWorkspaceListDefault', () => {
+  it('parses names from `name: summary` lines with empty paths', () => {
+    const stdout = 'default: qpv abc main | msg\nfeature: rly def | (no description set)\n'
+    expect(parseJujutsuWorkspaceListDefault(stdout)).toEqual([
+      { name: 'default', path: '' },
+      { name: 'feature', path: '' }
+    ])
+  })
+
+  it('skips blank lines', () => {
+    expect(parseJujutsuWorkspaceListDefault('\ndefault: x\n\n')).toEqual([
+      { name: 'default', path: '' }
+    ])
+  })
+})
+
+describe('parseJujutsuRemoteNames', () => {
+  it('takes the first whitespace-delimited token per line', () => {
+    const stdout = 'origin https://example.com/a.git\nupstream git@example.com:b.git\n'
+    expect(parseJujutsuRemoteNames(stdout)).toEqual(['origin', 'upstream'])
+  })
+
+  it('returns an empty array for empty output', () => {
+    expect(parseJujutsuRemoteNames('')).toEqual([])
   })
 })
 
@@ -119,19 +158,28 @@ describe('resolveJujutsuBaseRevision', () => {
     expect(resolveJujutsuBaseRevision('   ')).toBeUndefined()
   })
 
-  it('rewrites a single remote/branch ref into a jj remote-bookmark revset', () => {
-    expect(resolveJujutsuBaseRevision('origin/main')).toBe('main@origin')
+  it('rewrites a remote/branch ref to a jj remote-bookmark revset when the prefix is a known remote', () => {
+    expect(resolveJujutsuBaseRevision('origin/main', ['origin'])).toBe('main@origin')
+  })
+
+  it('does NOT rewrite a slash ref when the prefix is not a known remote (local bookmark safety)', () => {
+    // `feature/foo` is a valid local jj bookmark — must not become `foo@feature`.
+    expect(resolveJujutsuBaseRevision('feature/foo', ['origin'])).toBe('feature/foo')
+  })
+
+  it('passes a slash ref through verbatim when no remotes are known', () => {
+    expect(resolveJujutsuBaseRevision('origin/main')).toBe('origin/main')
   })
 
   it('passes through a bare local branch name', () => {
-    expect(resolveJujutsuBaseRevision('main')).toBe('main')
+    expect(resolveJujutsuBaseRevision('main', ['origin'])).toBe('main')
   })
 
   it('passes through an explicit jj remote-bookmark revset unchanged', () => {
-    expect(resolveJujutsuBaseRevision('main@origin')).toBe('main@origin')
+    expect(resolveJujutsuBaseRevision('main@origin', ['origin'])).toBe('main@origin')
   })
 
   it('passes through refs with multiple slashes verbatim', () => {
-    expect(resolveJujutsuBaseRevision('refs/heads/feature')).toBe('refs/heads/feature')
+    expect(resolveJujutsuBaseRevision('refs/heads/feature', ['refs'])).toBe('refs/heads/feature')
   })
 })

--- a/src/shared/jujutsu-workspace-command.test.ts
+++ b/src/shared/jujutsu-workspace-command.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  JJ_WORKSPACE_LIST_TEMPLATE,
+  buildJjWorkspaceAddArgs,
+  buildJjWorkspaceForgetArgs,
+  buildJjWorkspaceListArgs,
+  buildJjWorkspaceRootArgs,
+  jujutsuWorkspaceNameForPath,
+  parseJujutsuWorkspaceList,
+  resolveJujutsuBaseRevision
+} from './jujutsu-workspace-command'
+
+describe('buildJjWorkspaceAddArgs', () => {
+  it('emits a bare add with only the path when no name or base is given', () => {
+    expect(buildJjWorkspaceAddArgs({ worktreePath: '/repo/.worktrees/feature' })).toEqual([
+      'workspace',
+      'add',
+      '/repo/.worktrees/feature'
+    ])
+  })
+
+  it('includes --name and --revision in jj flag order before the path', () => {
+    expect(
+      buildJjWorkspaceAddArgs({
+        worktreePath: '/repo/.worktrees/feature',
+        name: 'feature',
+        baseRevision: 'main@origin'
+      })
+    ).toEqual([
+      'workspace',
+      'add',
+      '--name',
+      'feature',
+      '--revision',
+      'main@origin',
+      '/repo/.worktrees/feature'
+    ])
+  })
+
+  it('ignores blank name and base values', () => {
+    expect(
+      buildJjWorkspaceAddArgs({
+        worktreePath: '/repo/ws',
+        name: '   ',
+        baseRevision: '  '
+      })
+    ).toEqual(['workspace', 'add', '/repo/ws'])
+  })
+})
+
+describe('buildJjWorkspace* arg builders', () => {
+  it('builds list args with the path-bearing template', () => {
+    expect(buildJjWorkspaceListArgs()).toEqual([
+      'workspace',
+      'list',
+      '--template',
+      JJ_WORKSPACE_LIST_TEMPLATE
+    ])
+  })
+
+  it('builds forget args from a workspace name', () => {
+    expect(buildJjWorkspaceForgetArgs('feature')).toEqual(['workspace', 'forget', 'feature'])
+  })
+
+  it('builds workspace root args', () => {
+    expect(buildJjWorkspaceRootArgs()).toEqual(['workspace', 'root'])
+  })
+})
+
+describe('parseJujutsuWorkspaceList', () => {
+  it('parses tab-separated name/path lines', () => {
+    const stdout = 'default\t/repo\nfeature\t/repo/.worktrees/feature\n'
+    expect(parseJujutsuWorkspaceList(stdout)).toEqual([
+      { name: 'default', path: '/repo' },
+      { name: 'feature', path: '/repo/.worktrees/feature' }
+    ])
+  })
+
+  it('tolerates CRLF line endings and trailing whitespace', () => {
+    const stdout = 'default\t/repo  \r\nfeature\t/repo/ws\r\n'
+    expect(parseJujutsuWorkspaceList(stdout)).toEqual([
+      { name: 'default', path: '/repo' },
+      { name: 'feature', path: '/repo/ws' }
+    ])
+  })
+
+  it('keeps paths that contain spaces or further tabs intact after the first tab', () => {
+    const stdout = 'ws\t/repo/my work/ws\n'
+    expect(parseJujutsuWorkspaceList(stdout)).toEqual([{ name: 'ws', path: '/repo/my work/ws' }])
+  })
+
+  it('skips blank and tab-less lines', () => {
+    const stdout = '\ndefault\t/repo\nname-only-no-path\n\n'
+    expect(parseJujutsuWorkspaceList(stdout)).toEqual([{ name: 'default', path: '/repo' }])
+  })
+
+  it('returns an empty array for empty output', () => {
+    expect(parseJujutsuWorkspaceList('')).toEqual([])
+  })
+})
+
+describe('jujutsuWorkspaceNameForPath', () => {
+  it('returns the leaf directory for a posix path', () => {
+    expect(jujutsuWorkspaceNameForPath('/repo/.worktrees/feature')).toBe('feature')
+  })
+
+  it('returns the leaf directory for a windows path', () => {
+    expect(jujutsuWorkspaceNameForPath('C:\\repo\\.worktrees\\feature')).toBe('feature')
+  })
+
+  it('ignores trailing separators', () => {
+    expect(jujutsuWorkspaceNameForPath('/repo/.worktrees/feature/')).toBe('feature')
+  })
+})
+
+describe('resolveJujutsuBaseRevision', () => {
+  it('returns undefined for empty input', () => {
+    expect(resolveJujutsuBaseRevision(undefined)).toBeUndefined()
+    expect(resolveJujutsuBaseRevision('   ')).toBeUndefined()
+  })
+
+  it('rewrites a single remote/branch ref into a jj remote-bookmark revset', () => {
+    expect(resolveJujutsuBaseRevision('origin/main')).toBe('main@origin')
+  })
+
+  it('passes through a bare local branch name', () => {
+    expect(resolveJujutsuBaseRevision('main')).toBe('main')
+  })
+
+  it('passes through an explicit jj remote-bookmark revset unchanged', () => {
+    expect(resolveJujutsuBaseRevision('main@origin')).toBe('main@origin')
+  })
+
+  it('passes through refs with multiple slashes verbatim', () => {
+    expect(resolveJujutsuBaseRevision('refs/heads/feature')).toBe('refs/heads/feature')
+  })
+})

--- a/src/shared/jujutsu-workspace-command.ts
+++ b/src/shared/jujutsu-workspace-command.ts
@@ -1,0 +1,107 @@
+// Command construction and output parsing for Jujutsu (`jj`) workspaces — the
+// jj equivalent of git worktrees, used to spawn parallel agent sessions in a
+// jj repo (see issue stablyai/orca#1082). Kept pure and binary-free so it can
+// be unit tested without `jj` installed; the runtime wrapper in
+// src/main/jujutsu/workspace.ts executes these args via commandExecFileAsync.
+
+export const JUJUTSU_BIN = 'jj'
+
+export type JujutsuWorkspaceInfo = {
+  name: string
+  path: string
+}
+
+// Tab-separated `name<TAB>absolute-root` per workspace. `root()` is a
+// WorkspaceRef template method (jj >= 0.40); older clients reject it, so the
+// runtime wrapper degrades to a name-only listing on failure.
+export const JJ_WORKSPACE_LIST_TEMPLATE = 'name ++ "\\t" ++ root() ++ "\\n"'
+
+export function buildJjWorkspaceListArgs(): string[] {
+  return ['workspace', 'list', '--template', JJ_WORKSPACE_LIST_TEMPLATE]
+}
+
+export function parseJujutsuWorkspaceList(stdout: string): JujutsuWorkspaceInfo[] {
+  const result: JujutsuWorkspaceInfo[] = []
+  for (const rawLine of stdout.split('\n')) {
+    const line = rawLine.replace(/\r$/, '')
+    if (!line) {
+      continue
+    }
+    const tab = line.indexOf('\t')
+    if (tab === -1) {
+      continue
+    }
+    const name = line.slice(0, tab).trim()
+    const path = line.slice(tab + 1).trim()
+    if (name && path) {
+      result.push({ name, path })
+    }
+  }
+  return result
+}
+
+export type JujutsuWorkspaceAddInput = {
+  // Absolute, empty-or-missing leaf path. jj refuses to populate a non-empty
+  // directory and only creates a single trailing component, matching the
+  // contract Orca already uses for git worktree paths.
+  worktreePath: string
+  name?: string
+  baseRevision?: string
+}
+
+export function buildJjWorkspaceAddArgs(input: JujutsuWorkspaceAddInput): string[] {
+  const args = ['workspace', 'add']
+  const name = input.name?.trim()
+  if (name) {
+    args.push('--name', name)
+  }
+  const base = input.baseRevision?.trim()
+  if (base) {
+    args.push('--revision', base)
+  }
+  args.push(input.worktreePath)
+  return args
+}
+
+export function buildJjWorkspaceForgetArgs(name: string): string[] {
+  return ['workspace', 'forget', name]
+}
+
+export function buildJjWorkspaceRootArgs(): string[] {
+  return ['workspace', 'root']
+}
+
+// Mirror the name jj infers from the leaf directory so Orca's chosen name lines
+// up with `jj workspace list`. Separator-agnostic to stay correct on Windows.
+export function jujutsuWorkspaceNameForPath(worktreePath: string): string {
+  const trimmed = worktreePath.replace(/[\\/]+$/, '')
+  const segments = trimmed.split(/[\\/]/)
+  return segments.at(-1) ?? ''
+}
+
+// Best-effort translation of a git base ref into a jj revset. Orca's base
+// picker yields remote-tracking names like `origin/main` or local names like
+// `main`; jj addresses a remote bookmark as `main@origin`, while a bare name
+// resolves as a local bookmark or revision. Anything carrying an explicit `@`
+// or extra path segments is passed through for jj to resolve (or reject).
+export function resolveJujutsuBaseRevision(baseRef: string | undefined): string | undefined {
+  if (!baseRef) {
+    return undefined
+  }
+  const trimmed = baseRef.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  if (trimmed.includes('@')) {
+    return trimmed
+  }
+  const slash = trimmed.indexOf('/')
+  if (slash > 0 && !trimmed.includes('/', slash + 1)) {
+    const remote = trimmed.slice(0, slash)
+    const bookmark = trimmed.slice(slash + 1)
+    if (remote && bookmark) {
+      return `${bookmark}@${remote}`
+    }
+  }
+  return trimmed
+}

--- a/src/shared/jujutsu-workspace-command.ts
+++ b/src/shared/jujutsu-workspace-command.ts
@@ -8,18 +8,27 @@ export const JUJUTSU_BIN = 'jj'
 
 export type JujutsuWorkspaceInfo = {
   name: string
+  // Absolute workspace root. Empty only when listing fell back to the
+  // template-less format on jj < 0.32, which cannot print paths.
   path: string
 }
 
 // Tab-separated `name<TAB>absolute-root` per workspace. `root()` is a
-// WorkspaceRef template method (jj >= 0.40); older clients reject it, so the
-// runtime wrapper degrades to a name-only listing on failure.
+// WorkspaceRef template method (jj >= 0.32); older clients reject `--template`
+// entirely, so the runtime wrapper falls back to buildJjWorkspaceListDefaultArgs.
 export const JJ_WORKSPACE_LIST_TEMPLATE = 'name ++ "\\t" ++ root() ++ "\\n"'
 
+/** Args for the path-bearing workspace listing (requires jj >= 0.32). */
 export function buildJjWorkspaceListArgs(): string[] {
   return ['workspace', 'list', '--template', JJ_WORKSPACE_LIST_TEMPLATE]
 }
 
+/** Args for the template-less workspace listing used as the older-jj fallback. */
+export function buildJjWorkspaceListDefaultArgs(): string[] {
+  return ['workspace', 'list']
+}
+
+/** Parse `name<TAB>path` output from {@link buildJjWorkspaceListArgs}. */
 export function parseJujutsuWorkspaceList(stdout: string): JujutsuWorkspaceInfo[] {
   const result: JujutsuWorkspaceInfo[] = []
   for (const rawLine of stdout.split('\n')) {
@@ -40,6 +49,25 @@ export function parseJujutsuWorkspaceList(stdout: string): JujutsuWorkspaceInfo[
   return result
 }
 
+// Default `jj workspace list` prints `name: <commit summary>` per line and has
+// no path. Parse names only so older clients still get a usable listing; paths
+// come back empty and callers fall back to `jj workspace root` when needed.
+export function parseJujutsuWorkspaceListDefault(stdout: string): JujutsuWorkspaceInfo[] {
+  const result: JujutsuWorkspaceInfo[] = []
+  for (const rawLine of stdout.split('\n')) {
+    const line = rawLine.replace(/\r$/, '')
+    if (!line) {
+      continue
+    }
+    const colon = line.indexOf(':')
+    const name = (colon === -1 ? line : line.slice(0, colon)).trim()
+    if (name) {
+      result.push({ name, path: '' })
+    }
+  }
+  return result
+}
+
 export type JujutsuWorkspaceAddInput = {
   // Absolute, empty-or-missing leaf path. jj refuses to populate a non-empty
   // directory and only creates a single trailing component, matching the
@@ -49,6 +77,7 @@ export type JujutsuWorkspaceAddInput = {
   baseRevision?: string
 }
 
+/** Build `jj workspace add [--name N] [--revision R] <path>`. */
 export function buildJjWorkspaceAddArgs(input: JujutsuWorkspaceAddInput): string[] {
   const args = ['workspace', 'add']
   const name = input.name?.trim()
@@ -63,28 +92,57 @@ export function buildJjWorkspaceAddArgs(input: JujutsuWorkspaceAddInput): string
   return args
 }
 
+/** Build `jj workspace forget <name>`. */
 export function buildJjWorkspaceForgetArgs(name: string): string[] {
   return ['workspace', 'forget', name]
 }
 
+/** Build `jj workspace root`. */
 export function buildJjWorkspaceRootArgs(): string[] {
   return ['workspace', 'root']
 }
 
-// Mirror the name jj infers from the leaf directory so Orca's chosen name lines
-// up with `jj workspace list`. Separator-agnostic to stay correct on Windows.
+/** Build `jj git remote list`, whose output feeds {@link parseJujutsuRemoteNames}. */
+export function buildJjRemoteListArgs(): string[] {
+  return ['git', 'remote', 'list']
+}
+
+// `jj git remote list` prints `<name> <url>` per line; take the first token so
+// callers can tell a real remote (`origin`) from a slash in a local bookmark.
+export function parseJujutsuRemoteNames(stdout: string): string[] {
+  const names: string[] = []
+  for (const rawLine of stdout.split('\n')) {
+    const name = rawLine.trim().split(/\s+/)[0]
+    if (name) {
+      names.push(name)
+    }
+  }
+  return names
+}
+
+/**
+ * Mirror the name jj infers from the leaf directory so Orca's chosen name lines
+ * up with `jj workspace list`. Separator-agnostic to stay correct on Windows.
+ */
 export function jujutsuWorkspaceNameForPath(worktreePath: string): string {
   const trimmed = worktreePath.replace(/[\\/]+$/, '')
   const segments = trimmed.split(/[\\/]/)
   return segments.at(-1) ?? ''
 }
 
-// Best-effort translation of a git base ref into a jj revset. Orca's base
-// picker yields remote-tracking names like `origin/main` or local names like
-// `main`; jj addresses a remote bookmark as `main@origin`, while a bare name
-// resolves as a local bookmark or revision. Anything carrying an explicit `@`
-// or extra path segments is passed through for jj to resolve (or reject).
-export function resolveJujutsuBaseRevision(baseRef: string | undefined): string | undefined {
+/**
+ * Translate a git base ref into a jj revset. Orca's base picker yields
+ * remote-tracking names like `origin/main` or local names like `main` or even
+ * `feature/foo`. jj addresses a remote bookmark as `main@origin`, but local
+ * bookmarks may legitimately contain slashes — so a `<prefix>/<rest>` ref is
+ * rewritten to `<rest>@<prefix>` ONLY when `<prefix>` is a known jj remote.
+ * Everything else (including slash-containing local bookmarks) is passed
+ * through verbatim for jj to resolve, avoiding a wrong-revision rewrite.
+ */
+export function resolveJujutsuBaseRevision(
+  baseRef: string | undefined,
+  knownRemotes: readonly string[] = []
+): string | undefined {
   if (!baseRef) {
     return undefined
   }
@@ -99,7 +157,7 @@ export function resolveJujutsuBaseRevision(baseRef: string | undefined): string 
   if (slash > 0 && !trimmed.includes('/', slash + 1)) {
     const remote = trimmed.slice(0, slash)
     const bookmark = trimmed.slice(slash + 1)
-    if (remote && bookmark) {
+    if (remote && bookmark && knownRemotes.includes(remote)) {
       return `${bookmark}@${remote}`
     }
   }


### PR DESCRIPTION
Refs #1082.

## Summary

Adds a Jujutsu (`jj`) workspace foundation so jj users can spawn parallel agent sessions — the jj analogue of git worktrees that #1082 asks for. The change is strictly additive and gated to **pure-jj repos** (`.jj` present, `.git` absent); plain-git and colocated repos keep the existing git path unchanged.

- `src/shared/jujutsu-workspace-command.ts` — pure, jj-binary-free builders/parsers for `jj workspace add/list/forget/root` and `jj git remote list`, workspace-name derivation, and remote-aware git-ref → jj-revset translation.
- `src/main/jujutsu/workspace.ts` — runtime detection (`.jj` marker; colocated-vs-pure-jj) plus add/list/forget/root over the existing WSL/SSH-aware `commandExecFileAsync` runner.
- `src/main/git/worktree.ts` — `addWorktree` delegates to `jj workspace add` only for pure-jj repos, via an injectable detector.

**Why pure-jj only:** jj workspaces are not git worktrees and are invisible to `git status`/`git worktree list`, even in colocated repos ([jj-vcs/jj#8052](https://github.com/jj-vcs/jj/issues/8052)). Orca's status/diff/history shell out to git inside the worktree, so routing a colocated repo through jj would break those panels. Making status/diff/history jj-aware inside a jj workspace is the intended follow-up; the `list`/`forget` primitives are already provided for that wiring.

## Screenshots

No visual change. This is a main-process/VCS-backend change with no UI surface yet.

## Testing

- [x] `pnpm lint` — `oxlint` clean on all new/changed files
- [x] `pnpm typecheck` — clean for all new/changed files across node/cli/web configs
- [x] `pnpm test` — 42 new unit tests pass; existing `worktree`/`repo`/`remove-worktree` suites (116 tests) still pass (no regressions). Full-suite/`pnpm build` not run end-to-end in this environment (pre-existing missing i18n dev deps unrelated to this change).
- [ ] `pnpm build`
- [x] Added high-quality tests covering command building, list parsing (incl. older-jj fallback), remote-aware ref translation, repo detection, and the `addWorktree` delegation switch.

## AI Review Report

CodeRabbit reviewed the PR and flagged two functional-correctness items, both addressed in `906c8de`:

1. **(Major) Unsafe base-ref rewrite** — the ref translator rewrote any single-slash ref to `<branch>@<remote>`, which would mis-retarget a valid slash-containing local bookmark like `feature/foo` → `foo@feature`. Fixed: translation now happens only when the prefix is a confirmed jj remote (`jj git remote list`); everything else passes through verbatim.
2. **(Minor) No older-jj listing fallback** — `jj workspace list --template`/`root()` requires jj ≥ 0.32. Fixed: listing falls back to the template-less format (names only) on unsupported-template errors, and rethrows unrelated failures.

Cross-platform: command execution goes through the existing WSL/SSH-aware `commandExecFileAsync`; path handling uses `path.join` and a separator-agnostic basename for Windows; no keyboard shortcuts or UI labels are touched. Detection is a filesystem probe that works without `jj` installed.

## Security Audit

- **Command execution:** all `jj` invocations use `commandExecFileAsync` (argv array, no shell string interpolation), so base refs / names / paths cannot inject shell commands.
- **Path handling:** detection only `stat`s `.jj`/`.git` under the repo path; no path is constructed from untrusted remote data.
- **Input handling:** the git-ref → jj-revset translation is conservative and never executes the ref; an unexpected value at worst makes `jj` reject the revision.
- **Auth/secrets/IPC:** none touched. No new dependencies.

## Notes

- Activation is gated to pure-jj repos, so there is zero behavior change for existing git and colocated users.
- Follow-up: jj-aware status/diff/history inside a jj workspace (depends on / tracks jj-vcs/jj#8052); the list/forget primitives land here to support it.

## ELI5

Pure Jujutsu (jj) repos can spawn parallel agent sessions as jj workspaces, like git worktrees for jj users. Plain git and colocated repos keep the existing path.
