### PR TITLE
Show the correct agent icon for terminal helpers

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -352,6 +352,42 @@ describe('createPtySubprocess', () => {
     }
   })
 
+  it('serves Unix agent foreground when node-pty reports an agent child process', async () => {
+    const proc = mockPtyProcess()
+    proc.process = 'uv'
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    let resolveForeground!: (processName: string) => void
+    resolveAgentForegroundProcessMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveForeground = resolve
+      })
+    )
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24
+      })
+
+      expect(handle.getForegroundProcess()).toBe('uv')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        proc.pid,
+        'uv',
+        expect.any(Object)
+      )
+
+      resolveForeground('claude')
+      await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('claude'))
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
   it('does not let stale shell enrichment clear a newer direct agent foreground cache', async () => {
     const proc = mockPtyProcess()
     proc.process = 'powershell.exe'

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -732,7 +732,11 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   }
   const shouldInspectFallbackForegroundProcess = (fallbackProcess: string | null): boolean =>
     fallbackProcess !== null &&
-    (isShellProcess(fallbackProcess) || isAgentForegroundWrapperProcess(fallbackProcess))
+    (isShellProcess(fallbackProcess) ||
+      isAgentForegroundWrapperProcess(fallbackProcess) ||
+      // Why: agent-spawned helper processes can become the PTY foreground
+      // child; the Unix process tree can still identify the parent agent.
+      process.platform !== 'win32')
   const scheduleAgentForegroundRefresh = (fallbackProcess: string | null): void => {
     if (dead || !proc.pid) {
       return
@@ -756,7 +760,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     foregroundRefreshInFlight = true
     lastForegroundRefreshStartedAt = now
     // Why: daemon foreground reads are sync and run on the IPC hot path.
-    // Refresh shell/wrapper-derived identities (powershell/node -> codex/etc.)
+    // Refresh derived identities (shell/wrapper/helper -> codex/claude/etc.)
     // in the background and serve them from a short cache on later reads.
     void resolveAgentForegroundProcess(proc.pid, fallbackProcess, {
       contextPaths: agentForegroundContextPaths

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -591,6 +591,85 @@ describe('useTabAgent', () => {
     expect(getForegroundProcess).toHaveBeenCalledTimes(2)
   })
 
+  it('retries helper foreground so daemon-derived agent beats stale launch identity', async () => {
+    vi.useFakeTimers()
+    getForegroundProcess.mockResolvedValueOnce('uv').mockResolvedValueOnce('claude')
+
+    try {
+      await renderHookProbe({ ...baseTab, launchAgent: 'opencode' })
+
+      expect(latestHookAgent).toBe('opencode')
+      expect(getForegroundProcess).toHaveBeenCalledExactlyOnceWith('pty-1')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250)
+      })
+      await flushHookEffects()
+
+      expect(getForegroundProcess).toHaveBeenCalledTimes(2)
+      expect(latestHookAgent).toBe('claude')
+    } finally {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not retry unknown helper foreground without launch intent', async () => {
+    vi.useFakeTimers()
+    getForegroundProcess.mockResolvedValue('uv')
+
+    try {
+      await renderHookProbe({ ...baseTab, launchAgent: undefined })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000)
+      })
+      await flushHookEffects()
+
+      expect(getForegroundProcess).toHaveBeenCalledExactlyOnceWith('pty-1')
+      expect(latestHookAgent).toBeNull()
+    } finally {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps one post-throttle shell retry to observe daemon-derived launch identity', async () => {
+    vi.useFakeTimers()
+    getForegroundProcess
+      .mockResolvedValueOnce('zsh')
+      .mockResolvedValueOnce('zsh')
+      .mockResolvedValueOnce('zsh')
+      .mockResolvedValueOnce('zsh')
+      .mockResolvedValueOnce('claude')
+
+    try {
+      await renderHookProbe({ ...baseTab, launchAgent: 'opencode' })
+
+      expect(latestHookAgent).toBe('opencode')
+      expect(getForegroundProcess).toHaveBeenCalledExactlyOnceWith('pty-1')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250 + 1250 + 3500)
+      })
+      await flushHookEffects()
+
+      expect(getForegroundProcess).toHaveBeenCalledTimes(4)
+      expect(latestHookAgent).toBe('opencode')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(750)
+      })
+      await flushHookEffects()
+
+      expect(getForegroundProcess).toHaveBeenCalledTimes(5)
+      expect(latestHookAgent).toBe('claude')
+    } finally {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
   it('uses completed local hook status as launch lifecycle evidence after remount', async () => {
     const paneKey = makePaneKey('tab-1', LEAF_ID)
     getForegroundProcess.mockResolvedValueOnce('zsh')

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -34,6 +34,8 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   Pi: 'pi'
 }
 
+const HELPER_FOREGROUND_RETRY_DELAYS_MS = [250, 1250, 3500, 750] as const
+
 function agentFromTitle(title: string): TuiAgent | null {
   const label = getAgentLabel(title)
   return label ? (TITLE_LABEL_TO_AGENT[label] ?? null) : null
@@ -234,42 +236,69 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     if (!ptyId || isRemoteLike) {
       return
     }
+    const localPtyId = ptyId
     let cancelled = false
+    const helperForegroundRetryTimers: number[] = []
     // Why: re-runs when ptyId or tab.title changes — a title change is the event
     // signalling a possible foreground transition (agent start, exit, or turn).
     // One RPC per transition, not a timer; cancellation coalesces rapid churn.
-    window.api.pty
-      .getForegroundProcess(ptyId)
-      .then((process) => {
-        if (cancelled) {
-          return
+    function readForeground(retryIndex = 0): void {
+      window.api.pty
+        .getForegroundProcess(localPtyId)
+        .then((process) => {
+          applyForegroundProcess(process, retryIndex)
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setForeground(undefined)
+          }
+        })
+    }
+    function scheduleHelperForegroundRetry(retryIndex: number): void {
+      const delay = HELPER_FOREGROUND_RETRY_DELAYS_MS[retryIndex]
+      if (delay === undefined) {
+        return
+      }
+      // Why: the daemon resolves shell/helper -> agent ancestry asynchronously
+      // after the first foreground read, so give its short cache a bounded re-read.
+      const timer = window.setTimeout(() => {
+        readForeground(retryIndex + 1)
+      }, delay)
+      helperForegroundRetryTimers.push(timer)
+    }
+    function applyForegroundProcess(process: string | null, retryIndex: number): void {
+      if (cancelled) {
+        return
+      }
+      const recognized = recognizeAgentProcess(process)
+      if (recognized) {
+        hasObservedAgentSignalRef.current = true
+        setHasObservedAgentSignal(true)
+        setForeground(recognized.agent)
+      } else if (process && isShellProcess(process)) {
+        setShellForegroundAfterAgentSignal(hasObservedAgentSignalRef.current)
+        setForeground(null)
+        if (tab.launchAgent && !hasObservedAgentSignalRef.current) {
+          scheduleHelperForegroundRetry(retryIndex)
         }
-        const recognized = recognizeAgentProcess(process)
-        if (recognized) {
+      } else {
+        if (process && tab.launchAgent) {
+          // Why: for Orca-owned launches, an unrecognized non-shell process
+          // is enough lifecycle evidence to clear launch intent when the pane
+          // later returns to a shell, without using title text as identity.
           hasObservedAgentSignalRef.current = true
           setHasObservedAgentSignal(true)
-          setForeground(recognized.agent)
-        } else if (process && isShellProcess(process)) {
-          setShellForegroundAfterAgentSignal(hasObservedAgentSignalRef.current)
-          setForeground(null)
-        } else {
-          if (process && tab.launchAgent) {
-            // Why: for Orca-owned launches, an unrecognized non-shell process
-            // is enough lifecycle evidence to clear launch intent when the pane
-            // later returns to a shell, without using title text as identity.
-            hasObservedAgentSignalRef.current = true
-            setHasObservedAgentSignal(true)
-          }
-          setForeground(undefined)
         }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setForeground(undefined)
+        setForeground(undefined)
+        if (process && tab.launchAgent) {
+          scheduleHelperForegroundRetry(retryIndex)
         }
-      })
+      }
+    }
+    readForeground()
     return () => {
       cancelled = true
+      helperForegroundRetryTimers.forEach((timer) => window.clearTimeout(timer))
     }
   }, [ptyId, isRemoteLike, tab.launchAgent, titleForegroundKey])
 


### PR DESCRIPTION
## Summary

This fixes terminal tab agent icons when node-pty reports an agent helper child instead of the actual agent parent. On Unix, the daemon now enriches unknown foreground process names through the existing process-tree resolver, so helper processes like `uv` can resolve back to `claude`.

The renderer tab-agent hook also performs a small bounded follow-up sequence for local launch-intent tabs when the first foreground read sees a helper or pre-start shell wrapper. That gives the daemon's async cache enough time to surface the live agent before stale `launchAgent` metadata wins.

## Design Review

- Scratch design doc: `.tmp/terminal-agent-icon-foreground-child-design.md`
- Design review tightened the daemon scope, corrected the provider path, and later added the renderer retry/cache timing requirement.
- Follow-up design review called out the daemon's shell refresh throttle; the implementation now includes a final cache-observation retry and a regression test for that timing.

## Implementation

- `src/main/daemon/pty-subprocess.ts`: inspect unknown Unix fallback foregrounds, while preserving the narrower Windows behavior.
- `src/renderer/src/lib/use-tab-agent.ts`: add bounded local retry reads only for launch-intent helper/wrapper foregrounds; cleanup clears timers on effect teardown.
- No deviations from the reviewed design after the final timing/perf fixes.

## Completeness And Perf

- Completeness verification found no blockers against the updated design.
- Perf audit initially found retries for unknown helper foregrounds without launch intent; fixed by gating retries on `tab.launchAgent`.
- Perf rerun passed: retries are fixed-count, remote-like panes still skip local foreground reads, and daemon enrichment remains async and throttled.

## Code Review

- Final two-reviewer loop returned clean after the validation pass's timer type fix.
- No agent-facing text or prompt behavior was added.

## Validation

- `git diff --check`
- `pnpm vitest run --config config/vitest.config.ts src/main/daemon/pty-subprocess.test.ts src/main/providers/agent-foreground-process.test.ts src/renderer/src/lib/use-tab-agent.test.ts`
  - 3 files, 131 tests passed
- `pnpm run typecheck`
- `pnpm run lint`
  - Passed with an unrelated existing warning in `src/renderer/src/components/right-sidebar/useGitStatusPolling.ts:161`

## Electron Evidence

- Validated against the dev Electron app for `seadragon @ brennanb2025/fix-terminal-agent-icon`.
- Created a fresh terminal tab with stale `launchAgent: "opencode"`.
- Ran a fake `claude -> uv` helper chain.
- Confirmed backing IPC returned `claude`.
- Confirmed the rendered tab DOM used `data-agent-icon="claude"` while tab state still had stale `launchAgent: "opencode"`.
- Screenshot evidence captured locally at `.tmp/electron-terminal-agent-icon-validation-live-20260626.png`.

## Post-PR Stabilization

- Waited 8 minutes after opening the PR before the first automated-review/check sweep.
- CodeRabbit posted no actionable comments. Its docstring-coverage note did not include concrete file/line feedback and did not block CI.
- GitHub checks passed:
  - `track-community-pr`
  - `verify`

## Assumptions And Gaps

- No live SSH or Windows manual pass. This is accepted because the new enrichment is local Unix-only, remote-like PTYs still skip renderer foreground reads, and Windows remains on the previous narrower shell/wrapper path.
