### PR TITLE
Keep Orca visible when Windows startup stalls

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -2546,10 +2546,12 @@ describe('createMainWindow', () => {
     consoleError.mockRestore()
   })
 
-  it('ignores duplicate ready-to-show events after startup maximize has already run', () => {
+  function createStartupRevealWindowFixture() {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
-      on: vi.fn(),
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
       setZoomLevel: vi.fn(),
       setBackgroundThrottling: vi.fn(),
       invalidate: vi.fn(),
@@ -2576,6 +2578,23 @@ describe('createMainWindow', () => {
       return browserWindowInstance
     })
 
+    return { browserWindowInstance, windowHandlers }
+  }
+
+  function createStartupRevealStore(savedMaximized: boolean) {
+    return {
+      getUI: () =>
+        ({
+          windowMaximized: savedMaximized
+        }) as never,
+      getSettings: () => ({ windowBackgroundBlur: false }) as never,
+      updateUI: vi.fn()
+    }
+  }
+
+  it('ignores duplicate ready-to-show events after startup maximize has already run', () => {
+    const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
+
     createMainWindow({
       getUI: () =>
         ({
@@ -2590,6 +2609,98 @@ describe('createMainWindow', () => {
 
     expect(browserWindowInstance.maximize).toHaveBeenCalledTimes(1)
     expect(browserWindowInstance.show).toHaveBeenCalledTimes(1)
+  })
+
+  it('reveals the startup window on Windows when ready-to-show never fires', () => {
+    vi.useFakeTimers()
+    const { browserWindowInstance } = createStartupRevealWindowFixture()
+
+    withPlatform('win32', () => {
+      createMainWindow(null)
+      vi.advanceTimersByTime(9_999)
+      expect(browserWindowInstance.show).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+
+      expect(browserWindowInstance.show).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('cancels the Windows startup reveal fallback after ready-to-show', () => {
+    vi.useFakeTimers()
+    const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
+
+    withPlatform('win32', () => {
+      createMainWindow(null)
+      windowHandlers['ready-to-show']()
+      vi.advanceTimersByTime(10_000)
+
+      expect(browserWindowInstance.show).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not install the startup reveal fallback off Windows', () => {
+    vi.useFakeTimers()
+    const { browserWindowInstance } = createStartupRevealWindowFixture()
+
+    withPlatform('linux', () => {
+      createMainWindow(null)
+      vi.advanceTimersByTime(10_000)
+
+      expect(browserWindowInstance.show).not.toHaveBeenCalled()
+      expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
+    })
+  })
+
+  it('keeps the headless E2E window hidden when the Windows fallback fires', () => {
+    vi.useFakeTimers()
+    const previousHeadless = process.env.ORCA_E2E_HEADLESS
+    process.env.ORCA_E2E_HEADLESS = '1'
+    const { browserWindowInstance } = createStartupRevealWindowFixture()
+
+    try {
+      withPlatform('win32', () => {
+        createMainWindow(createStartupRevealStore(true) as never)
+        vi.advanceTimersByTime(10_000)
+
+        expect(browserWindowInstance.show).not.toHaveBeenCalled()
+        expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
+      })
+    } finally {
+      if (previousHeadless === undefined) {
+        delete process.env.ORCA_E2E_HEADLESS
+      } else {
+        process.env.ORCA_E2E_HEADLESS = previousHeadless
+      }
+    }
+  })
+
+  it('clears the Windows startup reveal fallback when the window is closed', () => {
+    vi.useFakeTimers()
+    const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
+
+    withPlatform('win32', () => {
+      createMainWindow(createStartupRevealStore(true) as never)
+      windowHandlers.closed()
+      vi.advanceTimersByTime(10_000)
+
+      expect(browserWindowInstance.show).not.toHaveBeenCalled()
+      expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
+    })
+  })
+
+  it('does not show or maximize a destroyed window when the Windows fallback fires', () => {
+    vi.useFakeTimers()
+    const { browserWindowInstance } = createStartupRevealWindowFixture()
+
+    withPlatform('win32', () => {
+      createMainWindow(createStartupRevealStore(true) as never)
+      browserWindowInstance.isDestroyed.mockReturnValue(true)
+      vi.advanceTimersByTime(10_000)
+
+      expect(browserWindowInstance.show).not.toHaveBeenCalled()
+      expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
+    })
   })
 
   describe('minimize to tray on close (win32)', () => {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -329,11 +329,34 @@ export function createMainWindow(
   // handler re-runs maximize() from the persisted savedMaximized flag, snapping
   // the window back to full-screen after the user already resized it (#591).
   let handledInitialReadyToShow = false
-  mainWindow.on('ready-to-show', () => {
+  let initialRevealFallbackTimer: ReturnType<typeof setTimeout> | null =
+    process.platform === 'win32'
+      ? setTimeout(() => {
+          // Why: GPU/driver failures on Windows can prevent ready-to-show forever,
+          // leaving the only app window hidden while the main process stays alive.
+          initialRevealFallbackTimer = null
+          revealInitialWindow()
+        }, 10_000)
+      : null
+  initialRevealFallbackTimer?.unref?.()
+
+  const clearInitialRevealFallbackTimer = (): void => {
+    if (initialRevealFallbackTimer) {
+      clearTimeout(initialRevealFallbackTimer)
+      initialRevealFallbackTimer = null
+    }
+  }
+
+  const revealInitialWindow = (): void => {
+    if (mainWindow.isDestroyed()) {
+      clearInitialRevealFallbackTimer()
+      return
+    }
     if (handledInitialReadyToShow) {
       return
     }
     handledInitialReadyToShow = true
+    clearInitialRevealFallbackTimer()
 
     // Why: in E2E headless mode, the window stays hidden to avoid stealing
     // focus and screen real estate during test runs. Playwright interacts
@@ -346,7 +369,8 @@ export function createMainWindow(
       mainWindow.maximize()
     }
     mainWindow.show()
-  })
+  }
+  mainWindow.on('ready-to-show', revealInitialWindow)
 
   // Why: persist window bounds so the app restores to the user's last
   // position/size instead of maximizing on every launch. Debounce to avoid
@@ -1113,6 +1137,7 @@ export function createMainWindow(
 
   ipcMain.on(confirmCloseChannel, onConfirmClose)
   mainWindow.on('closed', () => {
+    clearInitialRevealFallbackTimer()
     // Why: default-deny the Cmd+B carve-out after the window is gone so a
     // stale-true flag can't leak past subsequent state transitions. Paired
     // with the webContents lifecycle resets above.


### PR DESCRIPTION
## Summary

- Adds a Windows-only 10s fallback that reveals Orca's main window if Electron never emits the initial `ready-to-show` event.
- Reuses the existing one-shot startup reveal path so saved maximized state, headless E2E behavior, and duplicate `ready-to-show` handling stay consistent.
- Clears the fallback on normal reveal and window teardown, and guards destroyed windows before showing/maximizing.

Fixes #6233.

## Design / Review

- Scratch design doc: `design-docs/issue-6233-window-reveal-fallback.md` (ignored; not committed).
- Design-review subagent: clean after adding teardown/destroyed-window requirements and expanded validation coverage.
- Completeness verification subagent: complete against the reviewed design.
- Code-review loop: two independent reviewers returned clean in the same round.
- `brennan-test-changes` pass: Land.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/createMainWindow.test.ts` - 59 tests passed.
- `pnpm exec oxlint src/main/window/createMainWindow.ts src/main/window/createMainWindow.test.ts` - passed.
- `pnpm run typecheck:node` - passed.
- `git diff --check` - no whitespace errors; only Windows LF/CRLF warnings.

## Product Surface Evidence

- Launched Orca dev from this worktree with a raw CDP attach after `playwright-cli` was unavailable on PATH.
- Verified target: `http://127.0.0.1:5176/`.
- Verified app identity: `devRepoRoot = C:\Users\neil\orca\workspaces\orca\6233`.
- Screenshot evidence captured locally at `validation-screenshots/issue-6233-electron-visible-9341.png` (not committed).

## Accepted Gaps

- The actual Windows GPU/driver `ready-to-show` stall is hardware/driver dependent and was not reproduced directly. The fallback behavior is covered by unit simulation, while the visible Orca product surface was validated via CDP.
- PR checks and CodeRabbit have not been stabilized yet in this fast pass.