### PR TITLE
Fix wobbling session-history loading spinner

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanelControls.tsx
@@ -76,7 +76,7 @@ export function SessionLoadingState(): React.JSX.Element {
   return (
     <div className="px-3 py-3" aria-busy="true">
       <div className="mb-3 flex items-center gap-2 text-[11px] text-muted-foreground">
-        <LoaderCircle className="size-3.5 animate-spin" />
+        <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
         <span>
           {translate(
             'auto.components.right.sidebar.AiVaultPanelControls.scanningSessions',


### PR DESCRIPTION
## Summary

The "Scanning sessions" loading spinner in the AI Vault / agent session history panel didn't just rotate on first load — the whole icon drifted slightly as it spun.

The loader sits in a `flex items-center gap-2` row next to a plain text span, with no `flex-1`/`min-w-0` sibling to absorb slack. Both items default to `flex-shrink: 1`, so the SVG could be compressed below its 14px width while keeping its 14px height. A non-square box shifts the rotation pivot off center, producing the wobble.

## Fix

Add `shrink-0` to the `LoaderCircle`, matching every other text-adjacent spinner in the app (e.g. `WorktreeCreationPanel`, `LinearIssueWorkspace`, `AddRepoStartSteps`). The two header spinners that omit `shrink-0` don't wobble because their rows have a `flex-1` sibling (the input) that absorbs the slack instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)