### PR TITLE
feat(floating-terminal): consolidate tab model — drag-to-reorder + drag-to-split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ src/**/*.d.ts
 /electron.vite.config.js
 /electron.vite.config.d.ts
 !src/main/types/hosted-git-info.d.ts
-!src/preload/api-types.d.ts
 !src/preload/index.d.ts
 !src/renderer/src/env.d.ts
 !src/renderer/src/mermaid.d.ts

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
     ORCA_FEATURE_WALL_ENABLED: 'true'
   },
   resolve: {
+    // Why: accidental tsc emits (*.js/*.d.ts) can land next to .ts sources and,
+    // because Vite resolves .js before .ts by default, silently shadow the real
+    // source in tests. Prefer TS extensions so emits can never mask sources.
+    extensions: ['.ts', '.tsx', '.mts', '.mjs', '.js', '.jsx', '.json'],
     alias: {
       '@renderer': resolve('src/renderer/src'),
       '@': resolve('src/renderer/src')

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -4,6 +4,10 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { createPlainNodeEntryGuardPlugin } from './build-plugins/plain-node-entry-guard'
 
+// Why: accidental tsc emits (*.js next to *.ts) must never shadow real source —
+// Vite resolves .js before .ts by default. Prefer TS extensions everywhere.
+const TS_FIRST_EXTENSIONS = ['.ts', '.tsx', '.mts', '.mjs', '.js', '.jsx', '.json']
+
 // Why: the telemetry transport is gated by two compile-time constants that
 // only the official CI release workflow sets. Contributor / `pnpm dev` /
 // third-party rebuilds must substitute literal `null` at these sites so
@@ -214,6 +218,7 @@ export default defineConfig({
     // prevents Vite's default resolver from finding the CJS entry. Point
     // directly at the published main file so the bundler can inline it.
     resolve: {
+      extensions: TS_FIRST_EXTENSIONS,
       alias: {
         '@xterm/headless': resolve('node_modules/@xterm/headless/lib-headless/xterm-headless.js'),
         '@xterm/addon-serialize': resolve(
@@ -223,6 +228,9 @@ export default defineConfig({
     }
   },
   preload: {
+    resolve: {
+      extensions: TS_FIRST_EXTENSIONS
+    },
     build: {
       externalizeDeps: {
         exclude: ['@electron-toolkit/preload']
@@ -231,6 +239,7 @@ export default defineConfig({
   },
   renderer: {
     resolve: {
+      extensions: TS_FIRST_EXTENSIONS,
       alias: {
         '@renderer': resolve('src/renderer/src'),
         '@': resolve('src/renderer/src')

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -400,7 +400,7 @@ export function setupGuestShortcutForwarding(args: {
       // Why: same as browser.back; the focused guest cannot call the renderer-owned webview's goForward() directly.
       renderer.send('ui:browserHistoryNavigate', 'forward')
     } else if (keybindingMatchesAction('tab.close', input, process.platform, keybindings)) {
-      renderer.send('ui:closeActiveTab')
+      renderer.send('ui:closeActiveTab', { browserTabId })
     } else if (keybindingMatchesAction('tab.nextSameType', input, process.platform, keybindings)) {
       renderer.send('ui:switchTab', 1)
     } else if (

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -2419,7 +2419,9 @@ describe('browserManager', () => {
 
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:newBrowserTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:newTerminalTab')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab', {
+      browserTabId: 'browser-1'
+    })
     expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTabAcrossAllTypes', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:switchTab', 1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:switchTerminalTab', 1)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2853,7 +2853,7 @@ export type PreloadApi = {
     onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void
     onZoomBrowserPage: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void
     onHardReloadBrowserPage: (callback: () => void) => () => void
-    onCloseActiveTab: (callback: () => void) => () => void
+    onCloseActiveTab: (callback: (payload?: { browserTabId?: string }) => void) => () => void
     onSwitchTab: (callback: (direction: 1 | -1) => void) => () => void
     onSwitchTabAcrossAllTypes: (callback: (direction: 1 | -1) => void) => () => void
     onSwitchRecentTab: (callback: () => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3395,8 +3395,9 @@ const api = {
       ipcRenderer.on('ui:hardReloadBrowserPage', listener)
       return () => ipcRenderer.removeListener('ui:hardReloadBrowserPage', listener)
     },
-    onCloseActiveTab: (callback: () => void): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent) => callback()
+    onCloseActiveTab: (callback: (payload?: { browserTabId?: string }) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload?: { browserTabId?: string }) =>
+        callback(payload)
       ipcRenderer.on('ui:closeActiveTab', listener)
       return () => ipcRenderer.removeListener('ui:closeActiveTab', listener)
     },

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -37,6 +37,7 @@ import { isIntentionalAppRestartInProgress } from '@/lib/updater-beforeunload'
 import { preventUnloadAndScheduleShutdownCheckpointReset } from '@/lib/shutdown-checkpoint-guard'
 import EditorAutosaveController from './editor/EditorAutosaveController'
 import type { Tab, TabContentType, TabGroupLayoutNode, TuiAgent } from '../../../shared/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { hasFeatureInteraction } from '../../../shared/feature-interactions'
 import BrowserPane from './browser-pane/BrowserPane'
 import BrowserPaneOverlayLayer from './browser-pane/BrowserPaneOverlayLayer'
@@ -687,7 +688,10 @@ function Terminal(): React.JSX.Element | null {
     const onRequestEditorClose = (event: Event): void => {
       const customEvent = event as CustomEvent<EditorRequestFileCloseDetail>
       const fileId = customEvent.detail?.fileId
-      if (!fileId) {
+      // Why: the floating terminal owns its own save-dialog queue; ignore its
+      // close requests so we don't pop the main-workspace dialog for a file the
+      // user is closing from the floating panel.
+      if (!fileId || customEvent.detail?.worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
         return
       }
       queueEditorCloseRequests([fileId])

--- a/src/renderer/src/components/editor/editor-autosave.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave.test.ts
@@ -148,14 +148,14 @@ describe('requestEditorFileSave', () => {
 })
 
 describe('requestEditorFileClose', () => {
-  it('dispatches a close request event with the file id', () => {
+  it('dispatches a close request event with the file id and worktree id', () => {
     const listener = vi.fn()
     window.addEventListener(ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT, listener as EventListener)
     try {
-      requestEditorFileClose('file-1')
+      requestEditorFileClose('file-1', 'wt-1')
       expect(listener).toHaveBeenCalledTimes(1)
-      const event = listener.mock.calls[0][0] as CustomEvent<{ fileId: string }>
-      expect(event.detail).toEqual({ fileId: 'file-1' })
+      const event = listener.mock.calls[0][0] as CustomEvent<{ fileId: string; worktreeId: string }>
+      expect(event.detail).toEqual({ fileId: 'file-1', worktreeId: 'wt-1' })
     } finally {
       window.removeEventListener(ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT, listener as EventListener)
     }

--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -47,6 +47,7 @@ export type EditorFileSavedDetail = {
 
 export type EditorRequestFileCloseDetail = {
   fileId: string
+  worktreeId: string
 }
 
 export function isExternalReloadableEditorTab(file: OpenFile): boolean {
@@ -183,10 +184,10 @@ export async function requestEditorFileSave(target: EditorSaveFileTarget): Promi
   })
 }
 
-export function requestEditorFileClose(fileId: string): void {
+export function requestEditorFileClose(fileId: string, worktreeId: string): void {
   window.dispatchEvent(
     new CustomEvent<EditorRequestFileCloseDetail>(ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT, {
-      detail: { fileId }
+      detail: { fileId, worktreeId }
     })
   )
 }

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -6,7 +6,7 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import type { KeybindingOverrides, TerminalShortcutPolicy } from '../../../../shared/keybindings'
 import type { BrowserTab, Tab, TabGroup, TerminalTab } from '../../../../shared/types'
 import type { OpenFile } from '@/store/slices/editor'
-import { createUntitledMarkdownFileWithTemplateSelection } from '@/lib/create-untitled-markdown'
+import { ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT } from '@/components/editor/editor-autosave'
 import {
   FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
   clampFloatingTerminalBounds,
@@ -34,6 +34,7 @@ type FloatingPanelStoreState = {
   unifiedTabsByWorktree: Record<string, Tab[]>
   openFiles: OpenFile[]
   activeGroupIdByWorktree: Record<string, string | null>
+  layoutByWorktree: Record<string, unknown>
   activeTabIdByWorktree: Record<string, string | null>
   expandedPaneByTabId: Record<string, boolean>
   renamingTabId: string | null
@@ -68,6 +69,7 @@ type FloatingPanelStoreState = {
   setTabPaneExpanded: (tabId: string, expanded: boolean) => void
   makePreviewFilePermanent: (fileId: string, tabId?: string) => void
   pinFile: (fileId: string, tabId?: string) => void
+  reconcileWorktreeTabModel: (worktreeId: string) => { renderableTabCount: number }
   openFile: (file: unknown, options?: unknown) => void
   browserDefaultUrl: string
   keybindings?: KeybindingOverrides
@@ -114,6 +116,7 @@ const mocks = vi.hoisted(() => ({
   pickFloatingMarkdownDocument: vi.fn(),
   pinFile: vi.fn(),
   setFloatingTerminalInputFocused: vi.fn(),
+  reconcileWorktreeTabModel: vi.fn(() => ({ renderableTabCount: 0 })),
   setActiveTab: vi.fn(),
   setRenamingTabId: vi.fn(),
   setTabColor: vi.fn(),
@@ -125,6 +128,33 @@ const mocks = vi.hoisted(() => ({
 const saveDialogBox = vi.hoisted(() => ({
   fileId: null as string | null
 }))
+
+const dragSplitBox = vi.hoisted(() => {
+  const setDragRootNode = vi.fn()
+  const onDragEnd = vi.fn()
+  const onDragStart = vi.fn()
+  const onDragMove = vi.fn()
+  const onDragOver = vi.fn()
+  const onDragCancel = vi.fn()
+  const collisionDetection = vi.fn()
+  const sensors = [{ sensor: vi.fn(), options: {} }]
+  const hoveredTabInsertion = { groupId: 'group-floating', index: 0 }
+  const value = {
+    activeDrag: null as unknown,
+    collisionDetection,
+    hoveredTabInsertion,
+    hoveredDropTarget: null,
+    isTabDragActiveRef: { current: false },
+    onDragCancel,
+    onDragEnd,
+    onDragMove,
+    onDragOver,
+    onDragStart,
+    sensors,
+    setDragRootNode
+  }
+  return { hook: vi.fn(() => value), value }
+})
 
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
@@ -177,6 +207,55 @@ vi.mock('@/store', () => {
 
 vi.mock('@/components/tab-bar/TabBar', () => ({
   default: function TabBar() {
+    return null
+  }
+}))
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: function DndContext(props: { children?: unknown }) {
+    return props.children
+  },
+  DragOverlay: function DragOverlay() {
+    return null
+  }
+}))
+
+vi.mock('@/components/tab-bar/TabDragPreview', () => ({
+  default: function TabDragPreview() {
+    return null
+  }
+}))
+
+vi.mock('@/components/tab-group/tab-drag-context', () => ({
+  TabDragProvider: function TabDragProvider(props: { children?: unknown }) {
+    return props.children
+  }
+}))
+
+vi.mock('@/components/tab-group/useTabDragSplit', () => ({
+  useTabDragSplit: dragSplitBox.hook
+}))
+
+vi.mock('@/components/tab-group/TabGroupSplitLayout', () => ({
+  default: function TabGroupSplitLayout() {
+    return null
+  }
+}))
+
+vi.mock('@/components/terminal-pane/TerminalPaneOverlayLayer', () => ({
+  default: function TerminalPaneOverlayLayer() {
+    return null
+  }
+}))
+
+vi.mock('@/components/browser-pane/BrowserPaneOverlayLayer', () => ({
+  default: function BrowserPaneOverlayLayer() {
+    return null
+  }
+}))
+
+vi.mock('@/components/emulator-pane/EmulatorPaneOverlayLayer', () => ({
+  default: function EmulatorPaneOverlayLayer() {
     return null
   }
 }))
@@ -397,6 +476,7 @@ function setFloatingTabs(tabs: TerminalTab[]): void {
     ]
   }
   state.activeGroupIdByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: groupId }
+  state.layoutByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: { type: 'leaf', groupId } }
   state.activeTabIdByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: tabs[0]?.id ?? null }
   state.tabBarOrderByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: tabs.map((tab) => tab.id) }
 }
@@ -430,38 +510,7 @@ function setFloatingEditorTabs(files: OpenFile[]): void {
     ]
   }
   state.activeGroupIdByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: groupId }
-}
-
-function setFloatingSimulatorTab(): Tab {
-  const state = storeBox.state as FloatingPanelStoreState
-  const groupId = 'floating-group'
-  const tab: Tab = {
-    id: 'simulator-tab',
-    entityId: 'simulator-tab',
-    groupId,
-    worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
-    contentType: 'simulator',
-    label: 'Mobile Emulator',
-    customLabel: null,
-    color: null,
-    sortOrder: 0,
-    createdAt: 0
-  }
-  state.unifiedTabsByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: [tab] }
-  state.groupsByWorktree = {
-    [FLOATING_TERMINAL_WORKTREE_ID]: [
-      {
-        id: groupId,
-        worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
-        activeTabId: tab.id,
-        tabOrder: [tab.id],
-        recentTabIds: [tab.id]
-      }
-    ]
-  }
-  state.activeGroupIdByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: groupId }
-  state.tabBarOrderByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: [tab.id] }
-  return tab
+  state.layoutByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: { type: 'leaf', groupId } }
 }
 
 function resetStore(tabs: TerminalTab[] = []): void {
@@ -473,6 +522,7 @@ function resetStore(tabs: TerminalTab[] = []): void {
     unifiedTabsByWorktree: {},
     openFiles: [],
     activeGroupIdByWorktree: {},
+    layoutByWorktree: {},
     activeTabIdByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: tabs[0]?.id ?? null },
     expandedPaneByTabId: {},
     renamingTabId: null,
@@ -487,6 +537,7 @@ function resetStore(tabs: TerminalTab[] = []): void {
     makePreviewFilePermanent: mocks.makePreviewFilePermanent,
     openFile: mocks.openFile,
     pinFile: mocks.pinFile,
+    reconcileWorktreeTabModel: mocks.reconcileWorktreeTabModel,
     setActiveTab: mocks.setActiveTab,
     setTabCustomTitle: mocks.setTabCustomTitle,
     setRenamingTabId: mocks.setRenamingTabId,
@@ -1306,111 +1357,6 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.closeBrowserTab).not.toHaveBeenCalled()
   })
 
-  it('shows the empty state when only stale unified tabs remain', async () => {
-    const state = storeBox.state as FloatingPanelStoreState
-    const staleTab = makeTab({ id: 'stale-tab' })
-    setFloatingTabs([staleTab])
-    state.tabsByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: [] }
-    state.activeTabIdByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: null }
-
-    const element = await renderPanel(true)
-    const emptyState = findByTypeName(element, 'FloatingTerminalEmptyState')
-
-    expect(emptyState).toBeTruthy()
-  })
-
-  it('creates new floating terminal tabs without globally activating createTab', async () => {
-    setFloatingTabs([makeTab({ id: 'tab-1' })])
-
-    const element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onNewTerminalTab as () => void)()
-    await flushAsyncWork()
-
-    expect(mocks.createTab).toHaveBeenCalledWith(
-      FLOATING_TERMINAL_WORKTREE_ID,
-      'floating-group',
-      undefined,
-      { activate: false }
-    )
-    expect(mocks.activateTab).toHaveBeenCalledWith('created-tab')
-    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('created-tab')
-  })
-
-  it('keeps floating browser create and duplicate local during active web runtime sessions', async () => {
-    setFloatingTabs([makeTab({ id: 'tab-1' })])
-    ;(storeBox.state as FloatingPanelStoreState).settings.activeRuntimeEnvironmentId = 'runtime-1'
-    ;(storeBox.state as FloatingPanelStoreState).browserTabsByWorktree = {
-      [FLOATING_TERMINAL_WORKTREE_ID]: [
-        {
-          id: 'browser-1',
-          worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
-          url: 'https://example.com',
-          title: 'Example',
-          loading: false,
-          faviconUrl: null,
-          canGoBack: false,
-          canGoForward: false,
-          loadError: null,
-          sessionProfileId: 'profile-1',
-          sessionPartition: 'persist:orca-browser-session-profile-1',
-          createdAt: 1
-        }
-      ]
-    }
-    mocks.isWebRuntimeSessionActive.mockReturnValue(true)
-    mocks.createWebRuntimeSessionBrowserTab.mockResolvedValue(true)
-
-    const element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onNewBrowserTab as () => void)()
-    ;(tabBar.props.onDuplicateBrowserTab as (browserTabId: string) => void)('browser-1')
-
-    expect(mocks.createWebRuntimeSessionBrowserTab).not.toHaveBeenCalled()
-    expect(mocks.createBrowserTab).toHaveBeenNthCalledWith(
-      1,
-      FLOATING_TERMINAL_WORKTREE_ID,
-      'about:blank',
-      {
-        title: 'New Browser Tab',
-        focusAddressBar: true,
-        targetGroupId: 'floating-group',
-        browserRuntimeEnvironmentId: null
-      }
-    )
-    expect(mocks.createBrowserTab).toHaveBeenNthCalledWith(
-      2,
-      FLOATING_TERMINAL_WORKTREE_ID,
-      'https://example.com',
-      {
-        title: 'Example',
-        sessionProfileId: 'profile-1',
-        sessionPartition: 'persist:orca-browser-session-profile-1',
-        targetGroupId: 'floating-group',
-        browserRuntimeEnvironmentId: null
-      }
-    )
-  })
-
-  it('hides the active terminal pane from the renderer while the panel is closed', async () => {
-    setFloatingTabs([makeTab({ id: 'tab-1' })])
-
-    // Why: the closed panel stays mounted but CSS-hidden; gating isVisible on
-    // `open` routes the terminal through the standard hidden-terminal WebGL
-    // suspend/resume path so no live glyph atlas can corrupt while hidden.
-    await renderPanel(false)
-    runEffects()
-    await Promise.resolve()
-    const closedElement = await renderPanel(false)
-    const closedPane = findByTypeName(closedElement, 'TerminalPane')
-    expect(closedPane.props.isActive).toBe(true)
-    expect(closedPane.props.isVisible).toBe(false)
-
-    const openElement = await renderPanel(true)
-    const openPane = findByTypeName(openElement, 'TerminalPane')
-    expect(openPane.props.isVisible).toBe(true)
-  })
-
   it('routes titlebar Cmd+T to the floating workspace', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' })])
     const element = await renderPanel(true)
@@ -1600,6 +1546,49 @@ describe('FloatingTerminalPanel close behavior', () => {
 
     expect(preventDefault).not.toHaveBeenCalled()
     expect(mocks.createTab).not.toHaveBeenCalled()
+  })
+
+  it('restores floating panel focus after returning from another app', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    // Why: main's blur handler probes isFloatingWorkspaceTerminalInputTarget,
+    // which walks closest(); a non-terminal element resolves to null.
+    const activeElement = { blur: vi.fn(), closest: vi.fn().mockReturnValue(null) }
+    const panelElement = {
+      contains: vi.fn((node: unknown) => node === activeElement),
+      focus: vi.fn()
+    }
+    const outsideElement = {}
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+    Object.setPrototypeOf(outsideElement, HTMLElement.prototype)
+    attachRef(panel.props.ref, panelElement)
+    const documentStub = {
+      activeElement,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+    vi.stubGlobal('document', documentStub)
+    runEffects()
+    panelElement.focus.mockClear()
+    const blurListeners = vi
+      .mocked(window.addEventListener)
+      .mock.calls.filter(([type]) => type === 'blur')
+      .map(([, listener]) => listener as () => void)
+    const focusListener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([type]) => type === 'focus')?.[1] as (() => void) | undefined
+    const blurListener = blurListeners.at(-1)
+    if (!blurListener || !focusListener) {
+      throw new Error('window focus listeners not registered')
+    }
+
+    blurListener()
+    documentStub.activeElement = outsideElement as never
+    focusListener()
+
+    expect(activeElement.blur).toHaveBeenCalledWith()
+    expect(panelElement.focus).toHaveBeenCalledWith({ preventScroll: true })
   })
 
   it('routes focused floating tab switch shortcuts to the floating workspace', async () => {
@@ -2186,6 +2175,76 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(panelElement.focus).not.toHaveBeenCalled()
   })
 
+  it('does not start a window drag from an SVG icon nested inside a tab', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebar = findByProp(element, 'data-floating-terminal-shortcut-surface')
+    const panelElement = { focus: vi.fn() }
+    attachRef(panel.props.ref, panelElement)
+    vi.stubGlobal('document', { activeElement: null })
+    const setPointerCapture = vi.fn()
+
+    // Why: model the real DOM hierarchy so the helper's Element normalization
+    // runs — an SVGElement is an Element, so closest() must resolve the
+    // [data-tab-id] tab root and the titlebar yields the pointer to dnd-kit.
+    class StubNode {}
+    class StubElement extends StubNode {
+      closest = vi.fn().mockReturnValue({})
+    }
+    class StubSVGElement extends StubElement {}
+    vi.stubGlobal('Node', StubNode)
+    vi.stubGlobal('Element', StubElement)
+    vi.stubGlobal('SVGElement', StubSVGElement)
+    const svgTarget = new StubSVGElement()
+
+    ;(titlebar.props.onPointerDown as (event: unknown) => void)({
+      button: 0,
+      clientX: 10,
+      clientY: 20,
+      currentTarget: { setPointerCapture },
+      pointerId: 1,
+      target: svgTarget
+    })
+
+    expect(svgTarget.closest).toHaveBeenCalledWith(expect.stringContaining('[data-tab-id]'))
+    expect(setPointerCapture).not.toHaveBeenCalled()
+  })
+
+  it('does not start a window drag from a text node inside a tab', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebar = findByProp(element, 'data-floating-terminal-shortcut-surface')
+    const panelElement = { focus: vi.fn() }
+    attachRef(panel.props.ref, panelElement)
+    vi.stubGlobal('document', { activeElement: null })
+    const setPointerCapture = vi.fn()
+
+    // Why: a text node is a Node but not an Element, so normalization must walk
+    // to parentElement before closest() can match the [data-tab-id] ancestor.
+    class StubNode {}
+    class StubElement extends StubNode {
+      closest = vi.fn().mockReturnValue({})
+    }
+    vi.stubGlobal('Node', StubNode)
+    vi.stubGlobal('Element', StubElement)
+    const parentElement = new StubElement()
+    const textTarget = Object.assign(new StubNode(), { parentElement })
+
+    ;(titlebar.props.onPointerDown as (event: unknown) => void)({
+      button: 0,
+      clientX: 10,
+      clientY: 20,
+      currentTarget: { setPointerCapture },
+      pointerId: 1,
+      target: textTarget
+    })
+
+    expect(parentElement.closest).toHaveBeenCalledWith(expect.stringContaining('[data-tab-id]'))
+    expect(setPointerCapture).not.toHaveBeenCalled()
+  })
+
   it('focuses the floating panel for titlebar shortcuts when focus starts outside it', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' })])
     const element = await renderPanel(true)
@@ -2233,298 +2292,110 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.closeTab).not.toHaveBeenCalled()
   })
 
-  it('creates floating markdown files in local filesystem mode', async () => {
+  it('reconciles the floating worktree tab model when the panel opens', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' })])
-    vi.mocked(createUntitledMarkdownFileWithTemplateSelection).mockResolvedValue({
-      filePath: '/tmp/orca/floating-notes/untitled.md',
-      relativePath: 'untitled.md',
-      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
-      language: 'markdown',
-      isUntitled: true,
-      mode: 'edit'
-    })
+
+    await renderPanel(true)
+    runEffects()
+
+    // Why: restored sessions can leave stale unified tabs; the panel reconciles
+    // on open so the delegated split layout never paints a stale active tab.
+    expect(mocks.reconcileWorktreeTabModel).toHaveBeenCalledWith(FLOATING_TERMINAL_WORKTREE_ID)
+  })
+
+  it('shows the empty landing when a unified tab has no backing record', async () => {
+    const state = storeBox.state as FloatingPanelStoreState
+    const staleTab = makeTab({ id: 'stale' })
+    setFloatingTabs([staleTab])
+    // Drop the backing terminal record so the tab is no longer renderable.
+    state.tabsByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: [] }
+
+    const element = await renderPanel(true)
+
+    expect(findByTypeName(element, 'FloatingTerminalEmptyState')).toBeTruthy()
+    expect(() => findByTypeName(element, 'TabGroupSplitLayout')).toThrow()
+  })
+
+  it('delegates the visible tab strip and panes to the split layout', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+
+    const element = await renderPanel(true)
+    const splitLayout = findByTypeName(element, 'TabGroupSplitLayout')
+
+    // Why: the panel owns only the floating window chrome; the tab strip, split
+    // panes, and reorder/drag wiring live in the shared split layout.
+    expect(splitLayout.props.worktreeId).toBe(FLOATING_TERMINAL_WORKTREE_ID)
+    expect(splitLayout.props.isWorktreeActive).toBe(true)
+  })
+
+  it('marks the split layout inactive while the panel is closed', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+
+    const element = await renderPanel(false)
+    const splitLayout = findByTypeName(element, 'TabGroupSplitLayout')
+
+    // Why: a closed panel stays mounted but routes its panes through the
+    // hidden-terminal suspend path by reporting the worktree inactive.
+    expect(splitLayout.props.isWorktreeActive).toBe(false)
+  })
+
+  it('mounts the terminal overlay layer scoped to the open panel', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    mocks.getFloatingTerminalCwd.mockResolvedValue('/floating/cwd')
 
     let element = await renderPanel(true)
     runEffects()
     await flushAsyncWork()
     element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onNewFileTab as () => void)()
-    await flushAsyncWork()
+    const overlay = findByTypeName(element, 'TerminalPaneOverlayLayer')
 
-    expect(createUntitledMarkdownFileWithTemplateSelection).toHaveBeenCalledWith(
-      '/tmp/orca/floating-notes',
-      FLOATING_TERMINAL_WORKTREE_ID,
-      undefined,
-      { activeRuntimeEnvironmentId: null }
-    )
-    expect(mocks.openFile).toHaveBeenCalledWith(
-      expect.objectContaining({ filePath: '/tmp/orca/floating-notes/untitled.md' }),
-      expect.objectContaining({ suppressActiveRuntimeFallback: true })
-    )
+    expect(overlay.props.worktreeId).toBe(FLOATING_TERMINAL_WORKTREE_ID)
+    expect(overlay.props.isWorktreeActive).toBe(true)
   })
 
-  it('opens existing markdown documents through the floating picker', async () => {
-    setFloatingTabs([makeTab({ id: 'tab-1' })])
-    mocks.pickFloatingMarkdownDocument.mockResolvedValue({
-      filePath: '/tmp/orca/notes.md',
-      relativePath: 'notes.md',
-      basename: 'notes.md',
-      name: 'notes'
-    })
+  it('routes dirty floating editor close requests into its own save-dialog queue', async () => {
+    setFloatingEditorTabs([makeFile({ id: 'file-a', isDirty: true })])
 
-    const element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onOpenFileTab as () => void)()
-    await flushAsyncWork()
-
-    expect(mocks.pickFloatingMarkdownDocument).toHaveBeenCalledWith()
-    expect(mocks.openFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        filePath: '/tmp/orca/notes.md',
-        relativePath: 'notes.md',
-        runtimeEnvironmentId: null,
-        worktreeId: FLOATING_TERMINAL_WORKTREE_ID
-      }),
-      expect.objectContaining({ suppressActiveRuntimeFallback: true })
-    )
-  })
-
-  it('disables markdown annotations in floating editor tabs', async () => {
-    setFloatingEditorTabs([makeFile({ id: 'notes' })])
-
-    const element = await renderPanel(true)
-    const editorPanel = findByProp(element, 'activeFileId')
-
-    expect(editorPanel.props.markdownAnnotationsEnabled).toBe(false)
-    expect(editorPanel.props.activeFileId).toBe('notes')
-  })
-
-  it('keeps the panel open when the explicit close action removes the last tab', async () => {
-    const onOpenChange = vi.fn()
-    setFloatingTabs([makeTab({ id: 'tab-1' })])
-
-    const element = await renderPanel(true, onOpenChange)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onClose as (tabId: string) => void)('tab-1')
-
-    expect(mocks.closeTab).toHaveBeenCalledWith('tab-1', { reason: 'cleanup' })
-    expect(onOpenChange).not.toHaveBeenCalled()
-  })
-
-  it('keeps the panel open when the explicit close action leaves another tab', async () => {
-    const onOpenChange = vi.fn()
-    setFloatingTabs([
-      makeTab({ id: 'tab-1', sortOrder: 0 }),
-      makeTab({ id: 'tab-2', sortOrder: 1 })
-    ])
-
-    const element = await renderPanel(true, onOpenChange)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onClose as (tabId: string) => void)('tab-2')
-
-    expect(mocks.closeTab).toHaveBeenCalledWith('tab-2', { reason: 'cleanup' })
-    expect(onOpenChange).not.toHaveBeenCalled()
-  })
-
-  it('keeps PTY exit separate from explicit terminal pane close', async () => {
-    const onOpenChange = vi.fn()
-    setFloatingTabs([makeTab({ id: 'tab-1' })])
-
-    await renderPanel(true, onOpenChange)
+    await renderPanel(true)
     runEffects()
-    await Promise.resolve()
-    const element = await renderPanel(true, onOpenChange)
-    const terminalPane = findByTypeName(element, 'TerminalPane')
 
-    ;(terminalPane.props.onPtyExit as () => void)()
-    expect(mocks.closeTab).toHaveBeenCalledWith('tab-1', { reason: 'pty-exit' })
-    expect(onOpenChange).not.toHaveBeenCalled()
+    const listener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([type]) => type === ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT)?.[1] as
+      | EventListener
+      | undefined
+    expect(listener).toBeTruthy()
 
-    mocks.closeTab.mockClear()
-    ;(terminalPane.props.onCloseTab as () => void)()
-    expect(mocks.closeTab).toHaveBeenCalledWith('tab-1', { reason: 'cleanup' })
-    expect(onOpenChange).not.toHaveBeenCalled()
-  })
-
-  it('renders and closes simulator tabs in the floating workspace', async () => {
-    const tab = setFloatingSimulatorTab()
-
-    const element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    const emulatorPane = findByTypeName(element, 'EmulatorPane')
-    ;(tabBar.props.onCloseFile as (tabId: string) => void)(tab.id)
-
-    expect(tabBar.props.activeTabType).toBe('simulator')
-    expect(tabBar.props.activeSimulatorTabId).toBe(tab.id)
-    expect(emulatorPane.props.tab).toBe(tab)
-    expect(mocks.closeUnifiedTab).toHaveBeenCalledWith(tab.id)
-    expect(mocks.closeFile).not.toHaveBeenCalledWith(tab.id)
-  })
-
-  it('keeps simulator tabs open when closing all files', async () => {
-    const state = storeBox.state as FloatingPanelStoreState
-    const groupId = 'floating-group'
-    const file = makeFile({ id: 'file-a' })
-    const editorTab: Tab = {
-      id: 'tab-file-a',
-      entityId: file.id,
-      groupId,
-      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
-      contentType: 'editor',
-      label: file.relativePath,
-      customLabel: null,
-      color: null,
-      sortOrder: 0,
-      createdAt: 0
-    }
-    const simulatorTab: Tab = {
-      id: 'simulator-tab',
-      entityId: 'simulator-tab',
-      groupId,
-      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
-      contentType: 'simulator',
-      label: 'Mobile Emulator',
-      customLabel: null,
-      color: null,
-      sortOrder: 1,
-      createdAt: 1
-    }
-    state.openFiles = [file]
-    state.unifiedTabsByWorktree = {
-      [FLOATING_TERMINAL_WORKTREE_ID]: [editorTab, simulatorTab]
-    }
-    state.groupsByWorktree = {
-      [FLOATING_TERMINAL_WORKTREE_ID]: [
-        {
-          id: groupId,
-          worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
-          activeTabId: editorTab.id,
-          tabOrder: [editorTab.id, simulatorTab.id],
-          recentTabIds: [editorTab.id, simulatorTab.id]
-        }
-      ]
-    }
-    state.activeGroupIdByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: groupId }
-    state.tabBarOrderByWorktree = {
-      [FLOATING_TERMINAL_WORKTREE_ID]: [editorTab.id, simulatorTab.id]
-    }
-
-    const element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onCloseAllFiles as () => void)()
-
-    expect(mocks.closeFile).toHaveBeenCalledWith(file.id)
-    expect(mocks.closeUnifiedTab).not.toHaveBeenCalledWith(simulatorTab.id)
-  })
-
-  it('keeps floating terminal create and close local during active web runtime sessions', async () => {
-    const onOpenChange = vi.fn()
-    setFloatingTabs([makeTab({ id: 'tab-1' })])
-    ;(storeBox.state as FloatingPanelStoreState).settings.activeRuntimeEnvironmentId = 'runtime-1'
-    mocks.isWebRuntimeSessionActive.mockReturnValue(true)
-    mocks.createWebRuntimeSessionTerminal.mockResolvedValue(true)
-
-    const element = await renderPanel(true, onOpenChange)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onNewTerminalTab as () => void)()
-    await flushAsyncWork()
-
-    expect(mocks.createWebRuntimeSessionTerminal).not.toHaveBeenCalled()
-    expect(mocks.createTab).toHaveBeenCalledWith(
-      FLOATING_TERMINAL_WORKTREE_ID,
-      'floating-group',
-      undefined,
-      { activate: false }
+    // Why: TabGroupPanel dispatches the shared request-file-close event for the
+    // floating worktree; the panel must queue it instead of dropping it.
+    listener?.(
+      new CustomEvent(ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT, {
+        detail: { fileId: 'file-a', worktreeId: FLOATING_TERMINAL_WORKTREE_ID }
+      }) as Event
     )
-    expect(mocks.activateTab).toHaveBeenCalledWith('created-tab')
-    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('created-tab')
-
-    ;(tabBar.props.onClose as (tabId: string) => void)('tab-1')
-    expect(mocks.closeWebRuntimeSessionTab).not.toHaveBeenCalled()
-    expect(mocks.closeTab).toHaveBeenCalledWith('tab-1', { reason: 'cleanup' })
-    expect(onOpenChange).not.toHaveBeenCalled()
-  })
-
-  it('queues dirty editor closes from close-all-files instead of overwriting the dialog id', async () => {
-    setFloatingEditorTabs([
-      makeFile({ id: 'file-a', isDirty: true }),
-      makeFile({ id: 'file-b', isDirty: true })
-    ])
-
-    const element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onCloseAllFiles as () => void)()
 
     expect(saveDialogBox.fileId).toBe('file-a')
     expect(mocks.closeFile).not.toHaveBeenCalledWith('file-a')
-    expect(mocks.closeFile).not.toHaveBeenCalledWith('file-b')
   })
 
-  it('queues dirty editor closes from close-others and close-to-right one file at a time', async () => {
-    setFloatingEditorTabs([
-      makeFile({ id: 'file-a', isDirty: true }),
-      makeFile({ id: 'file-b', isDirty: true }),
-      makeFile({ id: 'file-c', isDirty: true })
-    ])
+  it('ignores request-file-close events for other worktrees', async () => {
+    setFloatingEditorTabs([makeFile({ id: 'file-a', isDirty: true })])
 
-    const element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onCloseOthers as (tabId: string) => void)('tab-file-b')
-    expect(saveDialogBox.fileId).toBe('file-a')
+    await renderPanel(true)
+    runEffects()
 
-    saveDialogBox.fileId = null
-    mocks.closeFile.mockClear()
-    hookRuntime.values = []
-    const nextElement = await renderPanel(true)
-    const nextTabBar = findByTypeName(nextElement, 'TabBar')
-    ;(nextTabBar.props.onCloseToRight as (tabId: string) => void)('tab-file-a')
-    expect(saveDialogBox.fileId).toBe('file-b')
-    expect(mocks.closeFile).not.toHaveBeenCalledWith('file-c')
-  })
+    const listener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([type]) => type === ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT)?.[1] as
+      | EventListener
+      | undefined
 
-  it('reads the current tab list for bulk close actions', async () => {
-    setFloatingTabs([makeTab({ id: 'old-left' }), makeTab({ id: 'old-keep' })])
+    listener?.(
+      new CustomEvent(ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT, {
+        detail: { fileId: 'file-a', worktreeId: 'some-other-worktree' }
+      }) as Event
+    )
 
-    const element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    setFloatingTabs([
-      makeTab({ id: 'new-left', sortOrder: 0 }),
-      makeTab({ id: 'new-keep', sortOrder: 1 }),
-      makeTab({ id: 'new-right', sortOrder: 2 })
-    ])
-
-    ;(tabBar.props.onCloseOthers as (tabId: string) => void)('new-keep')
-    expect(mocks.closeTab).toHaveBeenCalledWith('new-left', { reason: 'cleanup' })
-    expect(mocks.closeTab).toHaveBeenCalledWith('new-right', { reason: 'cleanup' })
-    expect(mocks.closeTab).not.toHaveBeenCalledWith('old-left')
-
-    mocks.closeTab.mockClear()
-    ;(tabBar.props.onCloseToRight as (tabId: string) => void)('new-left')
-    expect(mocks.closeTab).toHaveBeenCalledWith('new-keep', { reason: 'cleanup' })
-    expect(mocks.closeTab).toHaveBeenCalledWith('new-right', { reason: 'cleanup' })
-    expect(mocks.closeTab).not.toHaveBeenCalledWith('old-keep')
-  })
-
-  it('closes tabs to the right using visible tab order', async () => {
-    setFloatingTabs([
-      makeTab({ id: 'tab-a', sortOrder: 0 }),
-      makeTab({ id: 'tab-b', sortOrder: 1 }),
-      makeTab({ id: 'tab-c', sortOrder: 2 })
-    ])
-    ;(storeBox.state as FloatingPanelStoreState).tabBarOrderByWorktree = {
-      [FLOATING_TERMINAL_WORKTREE_ID]: ['tab-c', 'tab-a', 'tab-b']
-    }
-    ;(storeBox.state as FloatingPanelStoreState).groupsByWorktree[
-      FLOATING_TERMINAL_WORKTREE_ID
-    ][0].tabOrder = ['tab-c', 'tab-a', 'tab-b']
-
-    const element = await renderPanel(true)
-    const tabBar = findByTypeName(element, 'TabBar')
-    ;(tabBar.props.onCloseToRight as (tabId: string) => void)('tab-c')
-
-    expect(mocks.closeTab).toHaveBeenCalledWith('tab-a', { reason: 'cleanup' })
-    expect(mocks.closeTab).toHaveBeenCalledWith('tab-b', { reason: 'cleanup' })
-    expect(mocks.closeTab).not.toHaveBeenCalledWith('tab-c')
+    expect(saveDialogBox.fileId).toBeNull()
   })
 })

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -2,16 +2,15 @@
  * resizing, orchestration setup, and mixed terminal/browser/editor tab
  * handling in one surface so the floating worktree does not drift from the
  * main tab model while still keeping the DOM-mounted panes local. */
-import { Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { FileText, Globe, Minus, TerminalSquare } from 'lucide-react'
 import { toast } from 'sonner'
-import EmulatorPane from '@/components/emulator-pane/EmulatorPane'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { useContextualTour } from '@/components/contextual-tours/use-contextual-tour'
-import TabBar from '@/components/tab-bar/TabBar'
-import { resolveGroupTabFromVisibleId } from '@/components/tab-group/tab-group-visible-id'
-import TerminalPane from '@/components/terminal-pane/TerminalPane'
+import TabGroupSplitLayout from '@/components/tab-group/TabGroupSplitLayout'
+import TerminalPaneOverlayLayer from '@/components/terminal-pane/TerminalPaneOverlayLayer'
+import BrowserPaneOverlayLayer from '@/components/browser-pane/BrowserPaneOverlayLayer'
+import EmulatorPaneOverlayLayer from '@/components/emulator-pane/EmulatorPaneOverlayLayer'
 import { isTerminalImeInputContextRefreshing } from '@/components/terminal-pane/terminal-ime-input-context-refresh'
 import { Button } from '@/components/ui/button'
 import { useMountedRef } from '@/hooks/useMountedRef'
@@ -29,7 +28,6 @@ import { appendUniqueOpenFileIds } from '@/components/terminal/unsaved-close-que
 import { getConnectionId } from '@/lib/connection-context'
 import { createUntitledMarkdownFileWithTemplateSelection } from '@/lib/create-untitled-markdown'
 import { detectLanguage } from '@/lib/language-detect'
-import { buildDuplicatedBrowserTabOptions } from '@/lib/duplicate-browser-tab-options'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
 import {
@@ -47,7 +45,10 @@ import {
   notifyOrchestrationSetupStateChanged
 } from '@/lib/orchestration-setup-state'
 import { useAppStore } from '@/store'
-import type { OpenFile } from '@/store/slices/editor'
+import {
+  ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT,
+  type EditorRequestFileCloseDetail
+} from '@/components/editor/editor-autosave'
 import { destroyWorkspaceWebviews } from '@/store/slices/browser-webview-cleanup'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import {
@@ -62,9 +63,7 @@ import {
   ModifierDoubleTapDetector,
   toModifierDoubleTapEvent
 } from '../../../../shared/modifier-double-tap-detector'
-import type { BrowserTab as BrowserTabState, Tab, TerminalTab } from '../../../../shared/types'
-import { resolveUnifiedTabLabel } from '../../../../shared/tab-title-resolution'
-import { FloatingBrowserSlot } from './FloatingBrowserSlot'
+import type { Tab } from '../../../../shared/types'
 import { FloatingTerminalOrchestrationDialog } from './FloatingTerminalOrchestrationDialog'
 import { FloatingTerminalResizeHandles } from './FloatingTerminalResizeHandles'
 import { FloatingTerminalWindowControls } from './FloatingTerminalWindowControls'
@@ -89,8 +88,6 @@ import { consumeFloatingTerminalOpenMaximizedIntent } from '@/lib/floating-termi
 import { selectFloatingTerminalPanelInputs } from './floating-terminal-panel-inputs'
 const LOCAL_RUNTIME_SETTINGS = { activeRuntimeEnvironmentId: null } as const
 
-const EditorPanel = lazy(() => import('@/components/editor/EditorPanel'))
-
 type FloatingTerminalPanelProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -108,8 +105,11 @@ type FloatingPanelShortcutInput = Partial<
 > &
   Pick<KeyboardEvent, 'target'> & { doubleTapModifier?: PhysicalModifierToken }
 
+// Why: every tab strip root (terminal/browser/markdown) carries data-tab-id.
+// Excluding it from the titlebar drag region lets dnd-kit own the pointer for
+// tab reordering instead of starting a floating-window move.
 const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
-  'button,input,textarea,select,[role="menuitem"],[data-testid="sortable-tab"],[data-floating-terminal-no-drag]'
+  'button,input,textarea,select,[role="menuitem"],[data-tab-id],[data-testid="sortable-tab"],[data-floating-terminal-no-drag]'
 const FLOATING_TERMINAL_SHORTCUT_SURFACE_SELECTOR = '[data-floating-terminal-shortcut-surface]'
 
 type FloatingTerminalPanelBoundsState = {
@@ -118,8 +118,27 @@ type FloatingTerminalPanelBoundsState = {
   source: FloatingTerminalPanelBoundsSource
 }
 
+function resolveDragTargetElement(target: EventTarget): Element | null {
+  // Why: pointer targets can be SVG icons or text nodes nested inside a tab
+  // root, neither of which is an HTMLElement. Normalize any Node to its nearest
+  // Element (text nodes via parentElement) so closest() can match a
+  // [data-tab-id] ancestor. typeof guards keep this safe in non-DOM contexts.
+  if (typeof Element !== 'undefined' && target instanceof Element) {
+    return target
+  }
+  if (typeof Node !== 'undefined' && target instanceof Node) {
+    return target.parentElement
+  }
+  // Fallback for hosts/targets that duck-type the DOM (e.g. test doubles).
+  const candidate = target as { closest?: unknown; parentElement?: Element | null }
+  if (typeof candidate.closest === 'function') {
+    return candidate as unknown as Element
+  }
+  return candidate.parentElement ?? null
+}
+
 function isFloatingTerminalDragTarget(target: EventTarget): boolean {
-  return !(target instanceof HTMLElement && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
+  return !resolveDragTargetElement(target)?.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR)
 }
 
 function readInitialPanelBounds(): FloatingTerminalPanelBoundsState {
@@ -163,8 +182,10 @@ export function FloatingTerminalPanel({
   onOpenChange,
   tourInteractionSnapshot
 }: FloatingTerminalPanelProps): React.JSX.Element | null {
-  const { tabs, browserTabs, groups, unifiedTabs, floatingFiles, expandedPaneByTabId } =
-    useAppStore(selectFloatingTerminalPanelInputs)
+  const { tabs, browserTabs, groups, unifiedTabs, floatingFiles } = useAppStore(
+    selectFloatingTerminalPanelInputs
+  )
+  const reconcileWorktreeTabModel = useAppStore((s) => s.reconcileWorktreeTabModel)
   const createTab = useAppStore((s) => s.createTab)
   const createBrowserTab = useAppStore((s) => s.createBrowserTab)
   const closeTab = useAppStore((s) => s.closeTab)
@@ -174,15 +195,9 @@ export function FloatingTerminalPanel({
   const markFileDirty = useAppStore((s) => s.markFileDirty)
   const activateTab = useAppStore((s) => s.activateTab)
   const setActiveTab = useAppStore((s) => s.setActiveTab)
-  const setTabCustomTitle = useAppStore((s) => s.setTabCustomTitle)
-  const setTabColor = useAppStore((s) => s.setTabColor)
-  const setTabPaneExpanded = useAppStore((s) => s.setTabPaneExpanded)
-  const makePreviewFilePermanent = useAppStore((s) => s.makePreviewFilePermanent)
-  const pinFile = useAppStore((s) => s.pinFile)
   const openFile = useAppStore((s) => s.openFile)
   const browserDefaultUrl = useAppStore((s) => s.browserDefaultUrl)
   const floatingTerminalCwd = useAppStore((s) => s.settings?.floatingTerminalCwd ?? '')
-  const generatedTabTitlesEnabled = useAppStore((s) => s.settings?.tabAutoGenerateTitle === true)
   const newTerminalShortcut = useShortcutKeyDetails('tab.newTerminal')
   const newBrowserShortcut = useShortcutKeyDetails('tab.newBrowser')
   const newMarkdownShortcut = useShortcutKeyDetails('tab.newMarkdown')
@@ -217,6 +232,7 @@ export function FloatingTerminalPanel({
   const pendingEditorCloseQueueRef = useRef<string[]>([])
   const saveDialogFileIdRef = useRef<string | null>(null)
   const panelRef = useRef<HTMLDivElement | null>(null)
+  const shouldRestorePanelFocusAfterWindowFocusRef = useRef(false)
   const doubleTapDetectorRef = useRef<ModifierDoubleTapDetector | null>(null)
   if (!doubleTapDetectorRef.current) {
     doubleTapDetectorRef.current = new ModifierDoubleTapDetector()
@@ -236,161 +252,77 @@ export function FloatingTerminalPanel({
     moved: boolean
   } | null>(null)
 
-  const activeGroup = useMemo(
-    () =>
-      groups.find((group) => group.activeTabId != null) ??
-      (unifiedTabs[0]
-        ? (groups.find((group) => group.id === unifiedTabs[0].groupId) ?? null)
-        : null),
-    [groups, unifiedTabs]
+  const layout = useAppStore((s) => s.layoutByWorktree[FLOATING_TERMINAL_WORKTREE_ID])
+  const focusedGroupId = useAppStore(
+    (s) => s.activeGroupIdByWorktree[FLOATING_TERMINAL_WORKTREE_ID]
   )
-  const groupTabs = useMemo(
-    () => (activeGroup ? unifiedTabs.filter((tab) => tab.groupId === activeGroup.id) : unifiedTabs),
-    [activeGroup, unifiedTabs]
-  )
-  const activeTab = useMemo(
-    () =>
-      (activeGroup?.activeTabId
-        ? groupTabs.find((tab) => tab.id === activeGroup.activeTabId)
-        : null) ??
-      groupTabs[0] ??
-      null,
-    [activeGroup, groupTabs]
-  )
-  const activeTerminalId = activeTab?.contentType === 'terminal' ? activeTab.entityId : null
-  const activeBrowserId = activeTab?.contentType === 'browser' ? activeTab.entityId : null
-  const activeEditorUnifiedId =
-    activeTab &&
-    activeTab.contentType !== 'terminal' &&
-    activeTab.contentType !== 'browser' &&
-    activeTab.contentType !== 'simulator'
-      ? activeTab.id
-      : null
-  const activeEditorFileId =
-    activeTab &&
-    activeTab.contentType !== 'terminal' &&
-    activeTab.contentType !== 'browser' &&
-    activeTab.contentType !== 'simulator'
-      ? activeTab.entityId
-      : null
-  const terminalTabById = useMemo(() => new Map(tabs.map((tab) => [tab.id, tab])), [tabs])
-  const terminalItems = useMemo<(TerminalTab & { unifiedTabId: string })[]>(
-    () =>
-      groupTabs
-        .filter((tab) => tab.contentType === 'terminal')
-        .flatMap((tab): (TerminalTab & { unifiedTabId: string })[] => {
-          const terminalTab = terminalTabById.get(tab.entityId)
-          if (!terminalTab) {
-            return []
-          }
 
-          return [
-            {
-              ...terminalTab,
-              unifiedTabId: tab.id,
-              title: resolveUnifiedTabLabel(
-                {
-                  ...tab,
-                  quickCommandLabel: tab.quickCommandLabel ?? terminalTab.quickCommandLabel,
-                  generatedLabel: tab.generatedLabel ?? terminalTab.generatedTitle
-                },
-                generatedTabTitlesEnabled,
-                tab.label
-              ),
-              generatedTitle: terminalTab.generatedTitle ?? tab.generatedLabel ?? null,
-              quickCommandLabel: terminalTab.quickCommandLabel ?? tab.quickCommandLabel ?? null,
-              customTitle: tab.customLabel ?? terminalTab.customTitle,
-              color: tab.color ?? terminalTab.color
-            }
-          ]
-        }),
-    [generatedTabTitlesEnabled, groupTabs, terminalTabById]
+  const activeGroup = useMemo(
+    () => groups.find((group) => group.id === focusedGroupId) ?? groups[0] ?? null,
+    [groups, focusedGroupId]
   )
-  const browserItems = useMemo(
+  const activeTab = useMemo(() => {
+    if (!activeGroup) {
+      return null
+    }
+    return unifiedTabs.find((tab) => tab.id === activeGroup.activeTabId) ?? null
+  }, [activeGroup, unifiedTabs])
+
+  // Why: restored sessions can retain unified tabs whose backing terminal,
+  // browser, or editor record is gone. Basing visibility on the raw unified
+  // tab count would keep the empty landing hidden and paint a blank surface,
+  // so derive the renderable set from tabs that still have a backing record.
+  const floatingTerminalTabs = tabs
+  const floatingBrowserTabs = browserTabs
+  const renderableUnifiedTabs = useMemo(
     () =>
-      groupTabs
-        .filter((tab) => tab.contentType === 'browser')
-        .map((tab) => {
-          const browserTab = browserTabs.find((candidate) => candidate.id === tab.entityId)
-          return browserTab ? { ...browserTab, tabId: tab.id } : null
-        })
-        .filter((tab): tab is BrowserTabState & { tabId: string } => tab !== null),
-    [browserTabs, groupTabs]
-  )
-  const editorItems = useMemo(
-    () =>
-      groupTabs
-        .filter(
-          (tab) =>
-            tab.contentType !== 'terminal' &&
-            tab.contentType !== 'browser' &&
-            tab.contentType !== 'simulator'
-        )
-        .map((tab) => {
-          const file = floatingFiles.find((candidate) => candidate.id === tab.entityId)
-          return file ? { ...file, tabId: tab.id } : null
-        })
-        .filter((file): file is OpenFile & { tabId: string } => file !== null),
-    [floatingFiles, groupTabs]
-  )
-  const simulatorItems = useMemo(
-    () => groupTabs.filter((tab) => tab.contentType === 'simulator'),
-    [groupTabs]
-  )
-  // Why: restored sessions can retain unified tabs whose backing records are
-  // gone; the empty landing should follow what the user can see.
-  const hasVisibleFloatingTabs =
-    terminalItems.length > 0 ||
-    browserItems.length > 0 ||
-    editorItems.length > 0 ||
-    simulatorItems.length > 0
-  const visibleFloatingItemCount =
-    terminalItems.length + browserItems.length + editorItems.length + simulatorItems.length
-  const activeClosableTab = hasVisibleFloatingTabs ? activeTab : null
-  const tabBarOrder = useMemo(
-    () =>
-      (activeGroup?.tabOrder ?? []).map((tabId) => {
-        const tab = groupTabs.find((candidate) => candidate.id === tabId)
-        return tab?.contentType === 'terminal' || tab?.contentType === 'browser'
-          ? tab.entityId
-          : tabId
-      }),
-    [activeGroup, groupTabs]
-  )
-  const visibleFloatingTabOrder = useMemo(
-    () =>
-      tabBarOrder.filter((visibleId) => {
-        const tab = resolveGroupTabFromVisibleId(groupTabs, visibleId)
-        if (!tab) {
-          return false
-        }
+      unifiedTabs.filter((tab) => {
         if (tab.contentType === 'terminal') {
-          return terminalItems.some((item) => item.unifiedTabId === tab.id)
+          return floatingTerminalTabs.some((candidate) => candidate.id === tab.entityId)
         }
         if (tab.contentType === 'browser') {
-          return browserItems.some((item) => item.tabId === tab.id)
+          return floatingBrowserTabs.some((candidate) => candidate.id === tab.entityId)
         }
         if (tab.contentType === 'simulator') {
-          return simulatorItems.some((item) => item.id === tab.id)
+          return true
         }
-        return editorItems.some((item) => item.tabId === tab.id)
+        // Why: mirror reconcileWorktreeTabModel — an open file with the same id
+        // in another worktree must not make a stale floating editor tab look
+        // renderable, so scope the match to the floating worktree.
+        return floatingFiles.some((file) => file.id === tab.entityId)
       }),
-    [browserItems, editorItems, groupTabs, simulatorItems, tabBarOrder, terminalItems]
+    [unifiedTabs, floatingTerminalTabs, floatingBrowserTabs, floatingFiles]
   )
-  const activeBrowserTab = activeBrowserId
-    ? (browserTabs.find((tab) => tab.id === activeBrowserId) ?? null)
-    : null
-  const activeEditorFile = activeEditorFileId
-    ? (floatingFiles.find((file) => file.id === activeEditorFileId) ?? null)
-    : null
+  const renderableTabIds = useMemo(
+    () => new Set(renderableUnifiedTabs.map((tab) => tab.id)),
+    [renderableUnifiedTabs]
+  )
+  const hasVisibleFloatingTabs = renderableUnifiedTabs.length > 0
+  const visibleFloatingItemCount = renderableUnifiedTabs.length
+  // Why: the active/group tab order can still reference a stale tab whose
+  // backing record is gone. Resolve the active tab and selection order against
+  // the renderable set so close/rename/select-by-index never target a tab the
+  // surface does not paint.
+  const renderableActiveTab =
+    activeTab && renderableTabIds.has(activeTab.id) ? activeTab : (renderableUnifiedTabs[0] ?? null)
+  const activeClosableTab = renderableActiveTab
+
+  const visibleFloatingTabOrder = useMemo(
+    () => (activeGroup?.tabOrder ?? []).filter((tabId) => renderableTabIds.has(tabId)),
+    [activeGroup, renderableTabIds]
+  )
+
   const activeTabType =
-    activeTab?.contentType === 'browser'
+    renderableActiveTab?.contentType === 'browser'
       ? 'browser'
-      : activeTab?.contentType === 'terminal'
+      : renderableActiveTab?.contentType === 'terminal'
         ? 'terminal'
-        : activeTab?.contentType === 'simulator'
+        : renderableActiveTab?.contentType === 'simulator'
           ? 'simulator'
           : 'editor'
+
+  const activeTerminalId =
+    renderableActiveTab?.contentType === 'terminal' ? renderableActiveTab.entityId : null
 
   useContextualTour('floating-workspace', open, 'floating_workspace_visible', {
     recordFeatureInteraction: tourInteractionSnapshot?.recordFeatureInteractionForTour ?? false,
@@ -453,6 +385,49 @@ export function FloatingTerminalPanel({
     },
     [advanceEditorCloseQueue]
   )
+
+  // Why: dirty editor closes triggered from the floating panel's split-group
+  // tab strip (TabGroupPanel -> useTabGroupWorkspaceModel) dispatch the shared
+  // request-file-close event. Terminal.tsx ignores floating-worktree events, so
+  // the floating panel must route them through its own local save-dialog queue.
+  useEffect(() => {
+    const onRequestEditorClose = (event: Event): void => {
+      const detail = (event as CustomEvent<EditorRequestFileCloseDetail>).detail
+      if (!detail?.fileId || detail.worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
+        return
+      }
+      queueEditorCloseRequests([detail.fileId])
+    }
+    window.addEventListener(
+      ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT,
+      onRequestEditorClose as EventListener
+    )
+    return () =>
+      window.removeEventListener(
+        ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT,
+        onRequestEditorClose as EventListener
+      )
+  }, [queueEditorCloseRequests])
+
+  // Why: restored sessions can leave the floating worktree with unified tabs
+  // whose backing terminal/editor/browser record is gone. The delegated
+  // TabGroupPanel renders straight from the unified-tab model, so prune the
+  // stale tabs (and repair the active tab/group/layout) when the panel opens or
+  // its backing collections change — otherwise a mixed stale+valid state hands
+  // a stale active tab and tab order to the split layout.
+  useLayoutEffect(() => {
+    if (!open) {
+      return
+    }
+    reconcileWorktreeTabModel(FLOATING_TERMINAL_WORKTREE_ID)
+  }, [
+    open,
+    reconcileWorktreeTabModel,
+    unifiedTabs,
+    floatingTerminalTabs,
+    floatingBrowserTabs,
+    floatingFiles
+  ])
 
   useEffect(() => {
     saveDialogFileIdRef.current = saveDialogFileId
@@ -637,8 +612,8 @@ export function FloatingTerminalPanel({
   }, [refreshOrchestrationSetupVisibility])
 
   const activateFloatingItem = useCallback(
-    (visibleId: string) => {
-      const item = resolveGroupTabFromVisibleId(groupTabs, visibleId)
+    (tabId: string) => {
+      const item = unifiedTabs.find((t) => t.id === tabId)
       if (!item) {
         return
       }
@@ -657,7 +632,7 @@ export function FloatingTerminalPanel({
         }
       }
     },
-    [activateTab, groupTabs, setActiveTab]
+    [activateTab, unifiedTabs, setActiveTab]
   )
 
   const createFloatingTerminalTab = useCallback(
@@ -741,16 +716,11 @@ export function FloatingTerminalPanel({
   }, [activeGroup, openFile])
 
   const closeFloatingItems = useCallback(
-    (visibleIds: string[]) => {
+    (tabIds: string[]) => {
       const state = useAppStore.getState()
-      const currentGroupTabs = activeGroup
-        ? (state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).filter(
-            (tab) => tab.groupId === activeGroup.id
-          )
-        : (state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? [])
-      const items = visibleIds
-        .map((visibleId) => resolveGroupTabFromVisibleId(currentGroupTabs, visibleId))
-        .filter((item): item is Tab => item !== null && !item.isPinned)
+      const items = tabIds
+        .map((tabId) => unifiedTabs.find((t) => t.id === tabId))
+        .filter((item): item is Tab => item !== undefined && item !== null && !item.isPinned)
       if (items.length === 0) {
         return
       }
@@ -761,6 +731,7 @@ export function FloatingTerminalPanel({
         } else if (item.contentType === 'browser') {
           destroyWorkspaceWebviews(state.browserPagesByWorkspace, item.entityId)
           closeBrowserTab(item.entityId)
+          closeUnifiedTab(item.id)
         } else if (item.contentType === 'simulator') {
           closeUnifiedTab(item.id)
         } else {
@@ -776,88 +747,15 @@ export function FloatingTerminalPanel({
         queueEditorCloseRequests(dirtyEditorFileIds)
       }
     },
-    [activeGroup, closeBrowserTab, closeFile, closeTab, closeUnifiedTab, queueEditorCloseRequests]
+    [closeBrowserTab, closeFile, closeTab, closeUnifiedTab, queueEditorCloseRequests, unifiedTabs]
   )
 
   const closeFloatingItem = useCallback(
-    (visibleId: string) => {
-      closeFloatingItems([visibleId])
+    (tabId: string) => {
+      closeFloatingItems([tabId])
     },
     [closeFloatingItems]
   )
-
-  const closeOthers = useCallback(
-    (visibleId: string) => {
-      const state = useAppStore.getState()
-      const currentGroupTabs = activeGroup
-        ? (state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).filter(
-            (tab) => tab.groupId === activeGroup.id
-          )
-        : (state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? [])
-      const item = resolveGroupTabFromVisibleId(currentGroupTabs, visibleId)
-      if (!item) {
-        return
-      }
-      closeFloatingItems(
-        currentGroupTabs.filter((tab) => tab.id !== item.id && !tab.isPinned).map((tab) => tab.id)
-      )
-    },
-    [activeGroup, closeFloatingItems]
-  )
-
-  const closeToRight = useCallback(
-    (visibleId: string) => {
-      const state = useAppStore.getState()
-      const currentGroup = activeGroup
-        ? state.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID]?.find(
-            (group) => group.id === activeGroup.id
-          )
-        : null
-      const currentGroupTabs = currentGroup
-        ? (state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).filter(
-            (tab) => tab.groupId === currentGroup.id
-          )
-        : (state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? [])
-      const item = resolveGroupTabFromVisibleId(currentGroupTabs, visibleId)
-      if (!item || !currentGroup) {
-        return
-      }
-      const index = currentGroup.tabOrder.indexOf(item.id)
-      if (index === -1) {
-        return
-      }
-      const tabById = new Map(currentGroupTabs.map((tab) => [tab.id, tab]))
-      closeFloatingItems(
-        currentGroup.tabOrder.slice(index + 1).filter((tabId) => {
-          const tab = tabById.get(tabId)
-          return tab ? !tab.isPinned : false
-        })
-      )
-    },
-    [activeGroup, closeFloatingItems]
-  )
-
-  const closeAllFiles = useCallback(() => {
-    const state = useAppStore.getState()
-    const currentGroupTabs = activeGroup
-      ? (state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).filter(
-          (tab) => tab.groupId === activeGroup.id
-        )
-      : (state.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? [])
-    closeFloatingItems(
-      currentGroupTabs
-        .filter(
-          (tab) =>
-            tab.contentType !== 'terminal' &&
-            tab.contentType !== 'browser' &&
-            // Why: simulator tabs are not files; "Close All Files" must leave
-            // the Mobile Emulator open like terminal/browser tabs do.
-            tab.contentType !== 'simulator' &&
-            !tab.isPinned
-        )
-        .map((tab) => tab.id)
-    )
-  }, [activeGroup, closeFloatingItems])
 
   const focusPanelForShortcuts = useCallback((preserveExistingPanelFocus = true) => {
     const active = document.activeElement
@@ -1037,9 +935,9 @@ export function FloatingTerminalPanel({
         }
         return true
       }
-      if (matchesFloatingChrome('tab.rename') && activeTab) {
+      if (matchesFloatingChrome('tab.rename') && renderableActiveTab) {
         consume()
-        state.setRenamingTabId(activeTab.id)
+        state.setRenamingTabId(renderableActiveTab.id)
         return true
       }
       const selectedTabIndex = matchKeybindingDigitIndex(
@@ -1072,7 +970,7 @@ export function FloatingTerminalPanel({
     },
     [
       activeClosableTab,
-      activeTab,
+      renderableActiveTab,
       activateFloatingItem,
       closeFloatingItem,
       createFloatingBrowserTab,
@@ -1303,6 +1201,7 @@ export function FloatingTerminalPanel({
 
   useEffect(() => {
     if (!open || typeof document === 'undefined') {
+      shouldRestorePanelFocusAfterWindowFocusRef.current = false
       return
     }
 
@@ -1324,8 +1223,10 @@ export function FloatingTerminalPanel({
       const active = document.activeElement
       reclaimTerminalInputOnWindowFocusRef.current = null
       if (!panel || !(active instanceof HTMLElement) || !panel.contains(active)) {
+        shouldRestorePanelFocusAfterWindowFocusRef.current = false
         return
       }
+      shouldRestorePanelFocusAfterWindowFocusRef.current = true
       // Why: browser webviews focus out-of-process and do not emit renderer
       // pointerdown events, so release floating ownership on renderer blur too.
       setFloatingTerminalInputFocusedInMain(false)
@@ -1340,12 +1241,10 @@ export function FloatingTerminalPanel({
       }
       active.blur()
     }
-
     const handleWindowFocus = (): void => {
+      const shouldRestorePanelFocus = shouldRestorePanelFocusAfterWindowFocusRef.current
+      shouldRestorePanelFocusAfterWindowFocusRef.current = false
       const reclaim = reclaimTerminalInputOnWindowFocusRef.current
-      if (!reclaim) {
-        return
-      }
       reclaimTerminalInputOnWindowFocusRef.current = null
       const panel = panelRef.current
       const active = document.activeElement
@@ -1358,7 +1257,7 @@ export function FloatingTerminalPanel({
         setFloatingTerminalInputFocusedInMain(true)
         return
       }
-      if ((active === null || active === document.body) && activeTerminalId) {
+      if (reclaim && (active === null || active === document.body) && activeTerminalId) {
         if (reclaim.helper.isConnected && panel?.contains(reclaim.helper)) {
           // Why: TerminalPane owns exact-helper reclaim and IME refresh. Avoid
           // racing it with a second floating-layer blur/refocus cycle.
@@ -1372,7 +1271,17 @@ export function FloatingTerminalPanel({
             setFloatingTerminalInputFocusedInMain(isFloatingWorkspaceTerminalInputTarget(active)),
           refreshImeContext: true
         })
+        return
       }
+      if (!shouldRestorePanelFocus) {
+        return
+      }
+      if (!panel || (active instanceof HTMLElement && panel.contains(active))) {
+        return
+      }
+      // Why: macOS app switching can blur the floating panel without a click.
+      // Restore panel ownership so Cmd/Ctrl+W cannot fall through to main tabs.
+      focusPanelForShortcuts(false)
     }
 
     document.addEventListener('pointerdown', handleOutsidePointerDown, true)
@@ -1380,11 +1289,12 @@ export function FloatingTerminalPanel({
     window.addEventListener('focus', handleWindowFocus)
     return () => {
       reclaimTerminalInputOnWindowFocusRef.current = null
+      shouldRestorePanelFocusAfterWindowFocusRef.current = false
       document.removeEventListener('pointerdown', handleOutsidePointerDown, true)
       window.removeEventListener('blur', handleWindowBlur)
       window.removeEventListener('focus', handleWindowFocus)
     }
-  }, [activeTerminalId, open])
+  }, [activeTerminalId, focusPanelForShortcuts, open])
   const handleDragStart = (event: React.PointerEvent<HTMLDivElement>): void => {
     if (maximized) {
       return
@@ -1491,7 +1401,7 @@ export function FloatingTerminalPanel({
     >
       <div className="relative flex h-full w-full min-h-0 flex-col overflow-hidden rounded-lg border border-black/14 bg-card dark:border-white/14">
         <div
-          className="flex h-9 shrink-0 cursor-grab items-center border-b border-border bg-[var(--bg-titlebar,var(--card))] active:cursor-grabbing"
+          className="flex h-9 shrink-0 cursor-grab items-center border-b border-border bg-[var(--bg-titlebar,var(--card))] active:cursor-grabbing px-3 justify-between"
           data-floating-terminal-shortcut-surface
           onPointerDown={handleDragStart}
           onPointerMove={handleDragMove}
@@ -1499,55 +1409,9 @@ export function FloatingTerminalPanel({
           onPointerCancel={handleDragEnd}
           onDoubleClick={handleTitlebarDoubleClick}
         >
-          <div className="flex h-full min-w-0 flex-1">
-            <TabBar
-              tabs={terminalItems}
-              activeTabId={activeTerminalId}
-              worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
-              expandedPaneByTabId={expandedPaneByTabId}
-              onActivate={activateFloatingItem}
-              onClose={closeFloatingItem}
-              onCloseOthers={closeOthers}
-              onCloseToRight={closeToRight}
-              onNewTerminalTab={() => createFloatingTerminalTab()}
-              onNewTerminalWithShell={createFloatingTerminalTab}
-              onNewBrowserTab={createFloatingBrowserTab}
-              onNewFileTab={createFloatingMarkdownTab}
-              onOpenFileTab={openFloatingMarkdownTab}
-              newTabMenuOrder="markdown-first"
-              onSetCustomTitle={setTabCustomTitle}
-              onSetTabColor={setTabColor}
-              onTogglePaneExpand={(tabId) =>
-                setTabPaneExpanded(tabId, expandedPaneByTabId[tabId] !== true)
-              }
-              editorFiles={editorItems}
-              browserTabs={browserItems}
-              activeFileId={activeEditorUnifiedId}
-              activeBrowserTabId={activeBrowserId}
-              activeSimulatorTabId={activeTab?.contentType === 'simulator' ? activeTab.id : null}
-              activeTabType={activeTabType}
-              onActivateFile={activateFloatingItem}
-              onCloseFile={closeFloatingItem}
-              onActivateBrowserTab={activateFloatingItem}
-              onCloseBrowserTab={closeFloatingItem}
-              onDuplicateBrowserTab={(browserTabId) => {
-                const source = browserTabs.find((tab) => tab.id === browserTabId)
-                if (!source) {
-                  return
-                }
-                createBrowserTab(FLOATING_TERMINAL_WORKTREE_ID, source.url, {
-                  ...buildDuplicatedBrowserTabOptions(source),
-                  targetGroupId: activeGroup?.id,
-                  browserRuntimeEnvironmentId: null
-                })
-              }}
-              onCloseAllFiles={closeAllFiles}
-              onMakePreviewFilePermanent={makePreviewFilePermanent}
-              onPinFile={pinFile}
-              tabBarOrder={tabBarOrder}
-              tabStripChrome="floating-panel"
-            />
-          </div>
+          <span className="text-xs font-medium text-muted-foreground select-none">
+            {translate('auto.components.floating.terminal.FloatingTerminalPanel.title', 'Terminal')}
+          </span>
           <FloatingTerminalWindowControls
             maximized={maximized}
             onToggleMaximized={toggleMaximized}
@@ -1561,79 +1425,32 @@ export function FloatingTerminalPanel({
             hasVisibleFloatingTabs ? 'floating-workspace-surface' : undefined
           }
         >
-          {cwd
-            ? tabs.map((tab) => {
-                const isActive = tab.id === activeTerminalId
-                return (
-                  <div
-                    key={`${tab.id}-${tab.generation ?? 0}`}
-                    className={isActive ? 'absolute inset-0' : 'absolute inset-0 hidden'}
-                    aria-hidden={!isActive}
-                  >
-                    <TerminalPane
-                      tabId={tab.id}
-                      worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
-                      cwd={cwd}
-                      isActive={isActive}
-                      // Why: the closed panel is only CSS-hidden, so gate
-                      // visibility on `open` too. This routes the floating
-                      // terminal through the standard hidden-terminal
-                      // suspend/resume path: no live WebGL context (or glyph
-                      // atlas to corrupt) while hidden, and the resume on
-                      // reopen rebuilds the renderer from scratch.
-                      isVisible={isActive && open}
-                      onPtyExit={() => closeTab(tab.id, { reason: 'pty-exit' })}
-                      onCloseTab={() => closeFloatingItem(tab.id)}
-                    />
-                  </div>
-                )
-              })
-            : null}
-          {browserTabs.map((tab) => {
-            const isActive = tab.id === activeBrowserTab?.id
-            return (
-              <div
-                key={tab.id}
-                className={isActive ? 'absolute inset-0 flex' : 'absolute inset-0 hidden'}
-                aria-hidden={!isActive}
-              >
-                <FloatingBrowserSlot browserTab={tab} isActive={open && isActive} />
-              </div>
-            )
-          })}
-          {simulatorItems.map((tab) => {
-            const isActive = tab.id === activeTab?.id
-            return (
-              <div
-                key={tab.id}
-                className={isActive ? 'absolute inset-0 flex' : 'absolute inset-0 hidden'}
-                aria-hidden={!isActive}
-              >
-                <EmulatorPane tab={tab} worktreeId={tab.worktreeId} isActive={open && isActive} />
-              </div>
-            )
-          })}
-          {activeEditorFile ? (
-            <div className="absolute inset-0 flex min-h-0 min-w-0">
-              <Suspense
-                fallback={
-                  <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-                    {translate(
-                      'auto.components.floating.terminal.FloatingTerminalPanel.d6b563ae24',
-                      'Loading editor...'
-                    )}
-                  </div>
-                }
-              >
-                {/* Why: floating workspace markdown is scratch/local context,
-                    not a repo review surface that should expose agent notes. */}
-                <EditorPanel
-                  activeFileId={activeEditorFile.id}
-                  activeViewStateId={activeEditorUnifiedId}
-                  markdownAnnotationsEnabled={false}
-                />
-              </Suspense>
-            </div>
+          {hasVisibleFloatingTabs && layout ? (
+            <TabGroupSplitLayout
+              layout={layout}
+              worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
+              focusedGroupId={focusedGroupId}
+              isWorktreeActive={open}
+            />
+          ) : null}
+          {hasVisibleFloatingTabs && cwd ? (
+            <TerminalPaneOverlayLayer
+              worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
+              worktreePath={cwd}
+              isWorktreeActive={open}
+            />
+          ) : null}
+          {hasVisibleFloatingTabs ? (
+            <>
+              <BrowserPaneOverlayLayer
+                worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
+                isWorktreeActive={open}
+              />
+              <EmulatorPaneOverlayLayer
+                worktreeId={FLOATING_TERMINAL_WORKTREE_ID}
+                isWorktreeActive={open}
+              />
+            </>
           ) : null}
           {!hasVisibleFloatingTabs ? (
             <FloatingTerminalEmptyState

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '../../store'
 import type { Tab } from '../../../../shared/types'
 import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 
 const WT = 'wt-1'
 
@@ -114,5 +115,70 @@ describe('tab-move-to-pane-column', () => {
       moveTabToNewPaneColumn({ unifiedTabId: 'tab-b', groupId: 'group-1', direction: 'right' })
     ).toBe(false)
     expect(mocks.mirrorWebRuntimeTabMove).not.toHaveBeenCalled()
+  })
+
+  it('allows moving a floating-terminal tab into a sibling split pane', () => {
+    const dropUnifiedTab = vi.fn(() => true)
+    useAppStore.setState({
+      groupsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [
+          {
+            id: 'floating-group',
+            worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+            activeTabId: 'float-a',
+            tabOrder: ['float-a', 'float-b']
+          }
+        ]
+      },
+      unifiedTabsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [
+          {
+            id: 'float-a',
+            groupId: 'floating-group',
+            worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+            contentType: 'terminal',
+            entityId: 'term-fa',
+            label: 'A',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 0
+          } satisfies Tab,
+          {
+            id: 'float-b',
+            groupId: 'floating-group',
+            worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+            contentType: 'terminal',
+            entityId: 'term-fb',
+            label: 'B',
+            customLabel: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 1
+          } satisfies Tab
+        ]
+      },
+      dropUnifiedTab
+    } as Partial<ReturnType<typeof useAppStore.getState>>)
+
+    expect(canMoveTabToNewPaneColumn('float-b', 'floating-group')).toBe(true)
+    expect(
+      moveTabToNewPaneColumn({
+        unifiedTabId: 'float-b',
+        groupId: 'floating-group',
+        direction: 'right'
+      })
+    ).toBe(true)
+    expect(dropUnifiedTab).toHaveBeenCalledWith('float-b', {
+      groupId: 'floating-group',
+      splitDirection: 'right'
+    })
+    expect(mocks.mirrorWebRuntimeTabMove).toHaveBeenCalledWith({
+      kind: 'split',
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      tabId: 'float-b',
+      targetGroupId: 'floating-group',
+      splitDirection: 'right'
+    })
   })
 })

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -111,6 +111,7 @@ export default function TabGroupPanel({
       onNewSimulatorTab={commands.newSimulatorTab}
       onOpenEntry={commands.openEntry}
       onNewFileTab={commands.newFileTab}
+      onOpenFileTab={commands.openFileTab}
       onSetCustomTitle={commands.setTabCustomTitle}
       onSetTabColor={commands.setTabColor}
       onTogglePaneExpand={commands.toggleTerminalPaneExpand}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -29,21 +29,25 @@ vi.mock('./TabGroupPanel', () => ({
   default: (props: unknown) => ({ __mock: 'TabGroupPanel', props })
 }))
 
+const dragSplitValue = {
+  activeDrag: null,
+  collisionDetection: vi.fn(),
+  hoveredDropTarget: null,
+  hoveredTabInsertion: null,
+  isTabDragActiveRef: { current: false },
+  onDragCancel: vi.fn(),
+  onDragEnd: vi.fn(),
+  onDragMove: vi.fn(),
+  onDragOver: vi.fn(),
+  onDragStart: vi.fn(),
+  sensors: [],
+  setDragRootNode: setDragRootNodeMock
+}
+const useTabDragSplitMock = vi.fn(
+  (_args: { worktreeId: string; enabled: boolean }) => dragSplitValue
+)
 vi.mock('./useTabDragSplit', () => ({
-  useTabDragSplit: () => ({
-    activeDrag: null,
-    collisionDetection: vi.fn(),
-    hoveredDropTarget: null,
-    hoveredTabInsertion: null,
-    isTabDragActiveRef: { current: false },
-    onDragCancel: vi.fn(),
-    onDragEnd: vi.fn(),
-    onDragMove: vi.fn(),
-    onDragOver: vi.fn(),
-    onDragStart: vi.fn(),
-    sensors: [],
-    setDragRootNode: setDragRootNodeMock
-  })
+  useTabDragSplit: (args: { worktreeId: string; enabled: boolean }) => useTabDragSplitMock(args)
 }))
 
 import TabGroupSplitLayout from './TabGroupSplitLayout'
@@ -70,6 +74,7 @@ describe('TabGroupSplitLayout', () => {
     recordFeatureInteractionMock.mockClear()
     setDragRootNodeMock.mockClear()
     useAppStoreMock.mockClear()
+    useTabDragSplitMock.mockClear()
   })
 
   function getLayoutWrapper(element: ReturnType<typeof TabGroupSplitLayout>) {
@@ -205,5 +210,49 @@ describe('TabGroupSplitLayout', () => {
     ;(resizeHandle.props.onResizeStart as () => void)()
 
     expect(recordFeatureInteractionMock).toHaveBeenCalledWith('terminal-panes')
+  })
+
+  it('keys the shared drag/reorder engine to the worktree and active state', () => {
+    TabGroupSplitLayout({
+      layout: { type: 'leaf', groupId: 'group-1' },
+      worktreeId: 'wt-1',
+      focusedGroupId: 'group-1',
+      isWorktreeActive: true
+    })
+
+    expect(useTabDragSplitMock).toHaveBeenCalledWith({ worktreeId: 'wt-1', enabled: true })
+  })
+
+  it('disables drag activation when the worktree is offscreen', () => {
+    TabGroupSplitLayout({
+      layout: { type: 'leaf', groupId: 'group-1' },
+      worktreeId: 'wt-1',
+      focusedGroupId: 'group-1',
+      isWorktreeActive: false
+    })
+
+    expect(useTabDragSplitMock).toHaveBeenCalledWith({ worktreeId: 'wt-1', enabled: false })
+  })
+
+  it('passes the exact hook handlers to DndContext without rewrapping', () => {
+    const element = TabGroupSplitLayout({
+      layout: { type: 'leaf', groupId: 'group-1' },
+      worktreeId: 'wt-1',
+      focusedGroupId: 'group-1',
+      isWorktreeActive: true
+    })
+
+    // Why: reordering/splitting is driven entirely by the hook's handlers, so
+    // DndContext must receive the exact references — not rewrapped copies that
+    // could drop drag events.
+    const dndContext = asElement(element.props.children)
+    expect(dndContext.props.sensors).toBe(dragSplitValue.sensors)
+    expect(dndContext.props.collisionDetection).toBe(dragSplitValue.collisionDetection)
+    expect(dndContext.props.onDragStart).toBe(dragSplitValue.onDragStart)
+    expect(dndContext.props.onDragMove).toBe(dragSplitValue.onDragMove)
+    expect(dndContext.props.onDragOver).toBe(dragSplitValue.onDragOver)
+    expect(dndContext.props.onDragEnd).toBe(dragSplitValue.onDragEnd)
+    expect(dndContext.props.onDragCancel).toBe(dragSplitValue.onDragCancel)
+    expect(dndContext.props.autoScroll).toBe(false)
   })
 })

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -158,9 +158,9 @@ export function useTabDragSplit({
   enabled = true
 }: {
   worktreeId: string
-  /** When false (e.g. for hidden worktrees), returns empty sensors so no
-   *  DndContext pointer listeners are registered on the document. Multiple
-   *  simultaneous DndContext instances with active sensors can interfere. */
+  /** When false (e.g. for hidden worktrees), the pointer sensor uses an
+   *  impossible activation distance so drags never activate while the surface
+   *  is hidden, without changing the sensors array length between renders. */
   enabled?: boolean
 }): {
   activeDrag: TabDragItemData | null

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 
 const mocks = vi.hoisted(() => ({
   activateTab: vi.fn(),
@@ -13,6 +14,11 @@ const mocks = vi.hoisted(() => ({
   createBrowserTab: vi.fn(),
   createEmptySplitGroup: vi.fn(),
   createTab: vi.fn(),
+  createWebRuntimeSessionBrowserTab: vi.fn(() => Promise.resolve(false)),
+  createWebRuntimeSessionTerminal: vi.fn(() => Promise.resolve(false)),
+  createUntitledMarkdownFile: vi.fn(),
+  getFloatingMarkdownDirectory: vi.fn(),
+  pickFloatingMarkdownDocument: vi.fn(),
   destroyWorkspaceWebviews: vi.fn(),
   dispatchEvent: vi.fn(),
   dropUnifiedTab: vi.fn(),
@@ -23,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   openFile: vi.fn(),
   pinFile: vi.fn(),
   recordFeatureInteraction: vi.fn(),
+  requestEditorFileClose: vi.fn(),
   setActiveBrowserTab: vi.fn(),
   setActiveFile: vi.fn(),
   setActiveTab: vi.fn(),
@@ -70,8 +77,8 @@ vi.mock('../../lib/focus-terminal-tab-surface', () => ({
 vi.mock('../../runtime/web-runtime-session', () => ({
   activateWebRuntimeSessionTab: mocks.activateWebRuntimeSessionTab,
   closeWebRuntimeSessionTab: mocks.closeWebRuntimeSessionTab,
-  createWebRuntimeSessionBrowserTab: vi.fn(),
-  createWebRuntimeSessionTerminal: vi.fn(),
+  createWebRuntimeSessionBrowserTab: mocks.createWebRuntimeSessionBrowserTab,
+  createWebRuntimeSessionTerminal: mocks.createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive: mocks.isWebRuntimeSessionActive,
   toHostSessionTabId: (tabId: string) => tabId
 }))
@@ -81,7 +88,15 @@ vi.mock('../../store/slices/browser-webview-cleanup', () => ({
 }))
 
 vi.mock('../../lib/create-untitled-markdown', () => ({
-  createUntitledMarkdownFileWithTemplateSelection: vi.fn()
+  createUntitledMarkdownFileWithTemplateSelection: mocks.createUntitledMarkdownFile
+}))
+
+vi.mock('../../lib/connection-context', () => ({
+  getConnectionId: () => null
+}))
+
+vi.mock('../editor/editor-autosave', () => ({
+  requestEditorFileClose: mocks.requestEditorFileClose
 }))
 
 vi.mock('../../lib/ipc-error', () => ({
@@ -187,7 +202,7 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
     expect(mocks.focusGroup).toHaveBeenCalledWith('wt-1', 'group-1')
     expect(mocks.activateTab).toHaveBeenCalledWith('unified-terminal-1')
     expect(mocks.setActiveTab).toHaveBeenCalledWith('terminal-1')
-    expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal')
+    expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal', 'wt-1')
     expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1', null)
   })
 
@@ -216,6 +231,7 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
 
     model.commands.activateTerminal('terminal-1')
 
+    expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal', 'wt-1')
     expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1', 'right-leaf')
   })
 
@@ -228,7 +244,7 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
     expect(mocks.focusGroup).toHaveBeenCalledWith('wt-1', 'group-1')
     expect(mocks.activateTab).toHaveBeenCalledWith('unified-terminal-1')
     expect(mocks.setActiveTab).toHaveBeenCalledWith('terminal-1')
-    expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal')
+    expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal', 'wt-1')
     const event = mocks.dispatchEvent.mock.calls[0]?.[0] as CustomEvent<{ tabId: string }>
     expect(event.type).toBe(TOGGLE_TERMINAL_PANE_EXPAND_EVENT)
     expect(event.detail).toEqual({ tabId: 'terminal-1' })
@@ -527,5 +543,307 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
       expect.objectContaining({ worktreeId: 'wt-1', tabId: 'browser-unified-1' })
     )
     expect(mocks.closeUnifiedTab).toHaveBeenCalledWith('browser-unified-1')
+  })
+})
+
+describe('useTabGroupWorkspaceModel dirty editor bulk closes', () => {
+  function makeEditorTab(id: string, sortOrder: number) {
+    return {
+      id: `tab-${id}`,
+      entityId: id,
+      groupId: 'group-1',
+      worktreeId: 'wt-1',
+      contentType: 'editor' as const,
+      label: id,
+      customLabel: null,
+      color: null,
+      sortOrder,
+      createdAt: sortOrder
+    }
+  }
+
+  function seedDirtyEditors(): void {
+    const tabs = [
+      makeEditorTab('file-a', 0),
+      makeEditorTab('file-b', 1),
+      makeEditorTab('file-c', 2)
+    ]
+    const state = storeBox.state as Record<string, unknown>
+    ;(state.groupsByWorktree as Record<string, unknown>)['wt-1'] = [
+      {
+        id: 'group-1',
+        worktreeId: 'wt-1',
+        activeTabId: 'tab-file-b',
+        tabOrder: ['tab-file-a', 'tab-file-b', 'tab-file-c']
+      }
+    ]
+    ;(state.unifiedTabsByWorktree as Record<string, unknown>)['wt-1'] = tabs
+    state.openFiles = [
+      { id: 'file-a', isDirty: true },
+      { id: 'file-b', isDirty: true },
+      { id: 'file-c', isDirty: true }
+    ]
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetStore()
+    seedDirtyEditors()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal('window', { dispatchEvent: mocks.dispatchEvent })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('routes close-others dirty editors through the centralized save queue', async () => {
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    model.commands.closeOthers('tab-file-b')
+
+    // Why: dirty siblings must defer to the save dialog (requestEditorFileClose)
+    // instead of being force-closed, so the unified tab is not removed yet.
+    expect(mocks.requestEditorFileClose).toHaveBeenCalledWith('file-a', 'wt-1')
+    expect(mocks.requestEditorFileClose).toHaveBeenCalledWith('file-c', 'wt-1')
+    expect(mocks.requestEditorFileClose).not.toHaveBeenCalledWith('file-b', 'wt-1')
+    expect(mocks.closeUnifiedTab).not.toHaveBeenCalled()
+  })
+
+  it('routes close-to-right dirty editors through the centralized save queue', async () => {
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    model.commands.closeToRight('tab-file-a')
+
+    expect(mocks.requestEditorFileClose).toHaveBeenCalledWith('file-b', 'wt-1')
+    expect(mocks.requestEditorFileClose).toHaveBeenCalledWith('file-c', 'wt-1')
+    expect(mocks.requestEditorFileClose).not.toHaveBeenCalledWith('file-a', 'wt-1')
+    expect(mocks.closeUnifiedTab).not.toHaveBeenCalled()
+  })
+
+  it('routes close-all dirty editors through the centralized save queue', async () => {
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    model.commands.closeAllEditorTabsInGroup()
+
+    expect(mocks.requestEditorFileClose).toHaveBeenCalledWith('file-a', 'wt-1')
+    expect(mocks.requestEditorFileClose).toHaveBeenCalledWith('file-b', 'wt-1')
+    expect(mocks.requestEditorFileClose).toHaveBeenCalledWith('file-c', 'wt-1')
+    expect(mocks.closeUnifiedTab).not.toHaveBeenCalled()
+  })
+})
+
+describe('useTabGroupWorkspaceModel floating worktree commands', () => {
+  const FLOATING_GROUP_ID = 'floating-group'
+
+  function seedFloatingWorktree(): void {
+    const state = storeBox.state as Record<string, unknown>
+    ;(state.groupsByWorktree as Record<string, unknown>)[FLOATING_TERMINAL_WORKTREE_ID] = [
+      {
+        id: FLOATING_GROUP_ID,
+        worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+        activeTabId: null,
+        tabOrder: []
+      }
+    ]
+    ;(state.unifiedTabsByWorktree as Record<string, unknown>)[FLOATING_TERMINAL_WORKTREE_ID] = []
+    ;(state.tabsByWorktree as Record<string, unknown>)[FLOATING_TERMINAL_WORKTREE_ID] = []
+    state.openFile = mocks.openFile
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetStore()
+    seedFloatingWorktree()
+    // Why: vi.clearAllMocks() wipes implementations too, so re-seed the async
+    // gates to their default "no remote owner" resolution for each test.
+    mocks.createWebRuntimeSessionTerminal.mockResolvedValue(false)
+    mocks.createWebRuntimeSessionBrowserTab.mockResolvedValue(false)
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal('window', {
+      dispatchEvent: mocks.dispatchEvent,
+      api: {
+        app: {
+          getFloatingMarkdownDirectory: mocks.getFloatingMarkdownDirectory,
+          pickFloatingMarkdownDocument: mocks.pickFloatingMarkdownDocument
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  async function flushMicrotasks(): Promise<void> {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+
+  // Why: floating commands fire async IIFEs without returning the promise, so
+  // tests flush microtasks instead of awaiting the command result directly.
+  it('creates a local floating terminal without consulting the web runtime session', async () => {
+    mocks.createTab.mockReturnValue({ id: 'floating-terminal-1' })
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({
+      groupId: FLOATING_GROUP_ID,
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID
+    })
+
+    model.commands.newTerminalTab()
+    await flushMicrotasks()
+
+    expect(mocks.createTab).toHaveBeenCalledWith(FLOATING_TERMINAL_WORKTREE_ID, FLOATING_GROUP_ID)
+    expect(mocks.setActiveTab).toHaveBeenCalledWith('floating-terminal-1')
+    expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal', FLOATING_TERMINAL_WORKTREE_ID)
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('floating-terminal-1')
+  })
+
+  it('keeps floating terminal creates local while a web runtime session is active', async () => {
+    // Why: the floating workspace is a local scratchpad; a focused remote
+    // runtime must never own its tabs even when it would accept the create.
+    mocks.isWebRuntimeSessionActive.mockReturnValue(true)
+    mocks.createWebRuntimeSessionTerminal.mockResolvedValue(true)
+    mocks.createTab.mockReturnValue({ id: 'floating-terminal-1' })
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({
+      groupId: FLOATING_GROUP_ID,
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID
+    })
+
+    model.commands.newTerminalTab()
+    await flushMicrotasks()
+
+    expect(mocks.createWebRuntimeSessionTerminal).not.toHaveBeenCalled()
+    expect(mocks.createTab).toHaveBeenCalledWith(FLOATING_TERMINAL_WORKTREE_ID, FLOATING_GROUP_ID)
+  })
+
+  it('creates a floating markdown file in the floating markdown directory', async () => {
+    mocks.getFloatingMarkdownDirectory.mockResolvedValue('/tmp/orca/floating-notes')
+    mocks.createUntitledMarkdownFile.mockResolvedValue({
+      filePath: '/tmp/orca/floating-notes/untitled.md',
+      relativePath: 'untitled.md',
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      language: 'markdown',
+      isUntitled: true,
+      mode: 'edit'
+    })
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({
+      groupId: FLOATING_GROUP_ID,
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID
+    })
+
+    await model.commands.newFileTab()
+    await flushMicrotasks()
+
+    expect(mocks.createUntitledMarkdownFile).toHaveBeenCalledWith(
+      '/tmp/orca/floating-notes',
+      FLOATING_TERMINAL_WORKTREE_ID,
+      undefined,
+      { activeRuntimeEnvironmentId: null }
+    )
+    expect(mocks.openFile).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/tmp/orca/floating-notes/untitled.md' }),
+      expect.objectContaining({
+        preview: false,
+        targetGroupId: FLOATING_GROUP_ID,
+        suppressActiveRuntimeFallback: true
+      })
+    )
+  })
+
+  it('skips markdown creation when no floating markdown directory is available', async () => {
+    mocks.getFloatingMarkdownDirectory.mockResolvedValue(null)
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({
+      groupId: FLOATING_GROUP_ID,
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID
+    })
+
+    await model.commands.newFileTab()
+    await flushMicrotasks()
+
+    expect(mocks.createUntitledMarkdownFile).not.toHaveBeenCalled()
+    expect(mocks.openFile).not.toHaveBeenCalled()
+  })
+
+  it('opens an existing markdown document through the floating picker', async () => {
+    mocks.pickFloatingMarkdownDocument.mockResolvedValue({
+      filePath: '/tmp/orca/floating-notes/readme.md',
+      relativePath: 'readme.md'
+    })
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({
+      groupId: FLOATING_GROUP_ID,
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID
+    })
+
+    await model.commands.openFileTab?.()
+    await flushMicrotasks()
+
+    expect(mocks.openFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/tmp/orca/floating-notes/readme.md',
+        relativePath: 'readme.md',
+        worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+        mode: 'edit'
+      }),
+      expect.objectContaining({
+        preview: false,
+        targetGroupId: FLOATING_GROUP_ID,
+        suppressActiveRuntimeFallback: true
+      })
+    )
+  })
+
+  it('does nothing when the floating markdown picker is dismissed', async () => {
+    mocks.pickFloatingMarkdownDocument.mockResolvedValue(null)
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({
+      groupId: FLOATING_GROUP_ID,
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID
+    })
+
+    await model.commands.openFileTab?.()
+    await flushMicrotasks()
+
+    expect(mocks.openFile).not.toHaveBeenCalled()
+  })
+
+  it('keeps floating browser creates local while a web runtime session is active', async () => {
+    mocks.isWebRuntimeSessionActive.mockReturnValue(true)
+    mocks.createWebRuntimeSessionBrowserTab.mockResolvedValue(true)
+    const state = storeBox.state as Record<string, unknown>
+    state.browserDefaultUrl = 'https://example.com'
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({
+      groupId: FLOATING_GROUP_ID,
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID
+    })
+
+    model.commands.newBrowserTab()
+    await flushMicrotasks()
+
+    expect(mocks.createWebRuntimeSessionBrowserTab).not.toHaveBeenCalled()
+    expect(mocks.createBrowserTab).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      'https://example.com',
+      expect.objectContaining({
+        focusAddressBar: true,
+        targetGroupId: FLOATING_GROUP_ID,
+        browserRuntimeEnvironmentId: null
+      })
+    )
   })
 })

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -28,6 +28,13 @@ import { ensureSimulatorTab, getSimulatorTabForWorktree } from '@/lib/ensure-sim
 import { buildDuplicatedBrowserTabOptions } from '@/lib/duplicate-browser-tab-options'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { browserWorkspaceHasRemoteOwner } from '@/runtime/remote-browser-tab-ownership'
+import { toast } from 'sonner'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
+import { detectLanguage } from '@/lib/language-detect'
+import { createUntitledMarkdownFileWithTemplateSelection } from '@/lib/create-untitled-markdown'
+import { getConnectionId } from '@/lib/connection-context'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { translate } from '@/i18n/i18n'
 
 export function recordTerminalTabGroupSplit(createdTerminal: TerminalTab | null | undefined): void {
   if (!createdTerminal) {
@@ -199,7 +206,7 @@ export function useTabGroupWorkspaceModel({
         const file = useAppStore.getState().openFiles.find((candidate) => candidate.id === entityId)
         if (file?.isDirty) {
           // Why: route through Terminal.tsx so the unsaved-confirmation save/discard queue stays centralized across all close paths.
-          requestEditorFileClose(entityId)
+          requestEditorFileClose(entityId, worktreeId)
           return false
         }
         closeFile(entityId)
@@ -354,7 +361,7 @@ export function useTabGroupWorkspaceModel({
         })
       }
       setActiveTab(terminalId)
-      setActiveTabType('terminal')
+      setActiveTabType('terminal', worktreeId)
       const activeLeafId = worktreeState.terminalLayoutsByTabId[terminalId]?.activeLeafId ?? null
       // Why: restore xterm focus to the store-active leaf so keyboard input can't drift to a sibling pane.
       focusTerminalTabSurface(terminalId, activeLeafId)
@@ -401,11 +408,11 @@ export function useTabGroupWorkspaceModel({
       focusGroup(worktreeId, groupId)
       activateTab(item.id)
       if (item.contentType === 'simulator') {
-        setActiveTabType('simulator')
+        setActiveTabType('simulator', worktreeId)
         // simulator has no editor file entity
       } else {
         setActiveFile(item.entityId)
-        setActiveTabType('editor')
+        setActiveTabType('editor', worktreeId)
       }
     },
     [activateTab, focusGroup, groupId, groupTabs, setActiveFile, setActiveTabType, worktreeId]
@@ -436,7 +443,7 @@ export function useTabGroupWorkspaceModel({
         })
       }
       setActiveBrowserTab(browserTabId)
-      setActiveTabType('browser')
+      setActiveTabType('browser', worktreeId)
     },
     [activateTab, focusGroup, groupId, groupTabs, setActiveBrowserTab, setActiveTabType, worktreeId]
   )
@@ -560,7 +567,23 @@ export function useTabGroupWorkspaceModel({
       closeToRight,
       createSplitGroup,
       newBrowserTab: () => {
-        void openNewBrowserTabInActiveWorkspace(groupId)
+        if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+          // Why: the floating workspace is a local scratchpad; a focused remote
+          // runtime must not own tabs users keep there for manual SSH/tmux work.
+          const state = useAppStore.getState()
+          const url = state.browserDefaultUrl ?? 'about:blank'
+          state.createBrowserTab(worktreeId, url, {
+            title: translate(
+              'auto.components.floating.terminal.FloatingTerminalPanel.8b14ba6c17',
+              'New Browser Tab'
+            ),
+            focusAddressBar: true,
+            targetGroupId: groupId,
+            browserRuntimeEnvironmentId: null
+          })
+        } else {
+          void openNewBrowserTabInActiveWorkspace(groupId, worktreeId)
+        }
       },
       newSimulatorTab: worktreeState.mobileEmulatorEnabled
         ? () => {
@@ -578,6 +601,34 @@ export function useTabGroupWorkspaceModel({
       openEntry: async (args: TabCreateEntryArgs) => {
         await openTabBarEntry(args)
       },
+      openFileTab:
+        worktreeId === FLOATING_TERMINAL_WORKTREE_ID
+          ? async () => {
+              try {
+                const document = await window.api.app.pickFloatingMarkdownDocument()
+                if (!document) {
+                  return
+                }
+                useAppStore.getState().openFile(
+                  {
+                    filePath: document.filePath,
+                    relativePath: document.relativePath,
+                    worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+                    language: detectLanguage(document.relativePath),
+                    mode: 'edit',
+                    runtimeEnvironmentId: null
+                  },
+                  {
+                    preview: false,
+                    targetGroupId: groupId,
+                    suppressActiveRuntimeFallback: true
+                  }
+                )
+              } catch (err) {
+                toast.error(extractIpcErrorMessage(err, 'Failed to open markdown file.'))
+              }
+            }
+          : undefined,
       duplicateBrowserTab: (browserTabId: string) => {
         void (async () => {
           const state = useAppStore.getState()
@@ -607,27 +658,65 @@ export function useTabGroupWorkspaceModel({
       },
       // Why: target the owning group explicitly; the "+" menu can fire from an unfocused panel without updating global group focus.
       newFileTab: async () => {
-        await openNewMarkdownInActiveWorkspace(groupId)
+        if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+          try {
+            const markdownCwd = await window.api.app.getFloatingMarkdownDirectory()
+            if (!markdownCwd) {
+              return
+            }
+            const fileInfo = await createUntitledMarkdownFileWithTemplateSelection(
+              markdownCwd,
+              worktreeId,
+              getConnectionId(worktreeId) ?? undefined,
+              { activeRuntimeEnvironmentId: null }
+            )
+            if (!fileInfo) {
+              return
+            }
+            useAppStore.getState().openFile(fileInfo, {
+              preview: false,
+              targetGroupId: groupId,
+              suppressActiveRuntimeFallback: true
+            })
+          } catch (err) {
+            toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))
+          }
+        } else {
+          await openNewMarkdownInActiveWorkspace(groupId, worktreeId)
+        }
       },
       newTerminalTab: () => {
-        void openNewTerminalTabInActiveWorkspace(groupId)
+        if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+          // Why: the floating workspace is a local scratchpad; a focused remote
+          // runtime must not own tabs users keep there for manual SSH/tmux work.
+          const state = useAppStore.getState()
+          const tab = state.createTab(worktreeId, groupId)
+          state.setActiveTab(tab.id)
+          state.setActiveTabType('terminal', worktreeId)
+          focusTerminalTabSurface(tab.id)
+        } else {
+          void openNewTerminalTabInActiveWorkspace(groupId, worktreeId)
+        }
       },
       newTerminalWithShell: (shellOverride: string) => {
         void (async () => {
           if (
-            await createWebRuntimeSessionTerminal({
+            // Why: keep floating-scratchpad terminals local even when a remote
+            // runtime session is active; it must not own floating tabs.
+            worktreeId !== FLOATING_TERMINAL_WORKTREE_ID &&
+            (await createWebRuntimeSessionTerminal({
               worktreeId,
               environmentId: getRuntimeEnvironmentIdForWorktree(useAppStore.getState(), worktreeId),
               targetGroupId: groupId,
               command: shellOverride,
               activate: true
-            })
+            }))
           ) {
             return
           }
           const terminal = createTab(worktreeId, groupId, shellOverride)
           setActiveTab(terminal.id)
-          setActiveTabType('terminal')
+          setActiveTabType('terminal', worktreeId)
           focusTerminalTabSurface(terminal.id)
         })()
       },

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.test.tsx
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Tab, TabGroup, TerminalTab } from '../../../../shared/types'
+
+const mocks = vi.hoisted(() => ({
+  closeTab: vi.fn(),
+  closeTerminalTab: vi.fn(),
+  consumeSuppressedPtyExit: vi.fn(() => false),
+  focusGroup: vi.fn(),
+  reconcileWorktreeTabModel: vi.fn(() => ({ renderableTabCount: 0 })),
+  setActiveWorktree: vi.fn()
+}))
+
+type OverlayStoreState = {
+  tabsByWorktree: Record<string, TerminalTab[]>
+  unifiedTabsByWorktree: Record<string, Tab[]>
+  groupsByWorktree: Record<string, TabGroup[]>
+  activeGroupIdByWorktree: Record<string, string | null | undefined>
+  activeWorktreeId: string | null
+  pendingStartupByTabId: Record<string, boolean>
+  focusGroup: typeof mocks.focusGroup
+  consumeSuppressedPtyExit: typeof mocks.consumeSuppressedPtyExit
+  closeTab: typeof mocks.closeTab
+  setActiveWorktree: typeof mocks.setActiveWorktree
+  reconcileWorktreeTabModel: typeof mocks.reconcileWorktreeTabModel
+}
+
+const storeBox = vi.hoisted(() => ({
+  state: null as OverlayStoreState | null
+}))
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    useCallback: <T,>(callback: T) => callback,
+    useMemo: <T,>(factory: () => T) => factory(),
+    useRef: <T,>(initial: T) => ({ current: initial }),
+    // Why: main's cold-parking hook seeds state lazily (`useState(() => new Set())`),
+    // so the stub must invoke function initializers like real React.
+    useState: <T,>(initial: T | (() => T)) =>
+      [typeof initial === 'function' ? (initial as () => T)() : initial, vi.fn()] as const,
+    useLayoutEffect: () => undefined,
+    useEffect: () => undefined,
+    memo: <T,>(component: T) => component
+  }
+})
+
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: <T,>(selector: T) => selector
+}))
+
+vi.mock('../../store', () => {
+  const useAppStore = Object.assign(
+    (selector: (state: OverlayStoreState) => unknown) =>
+      selector(storeBox.state as OverlayStoreState),
+    {
+      getState: () => storeBox.state as OverlayStoreState
+    }
+  )
+  return { useAppStore }
+})
+
+vi.mock('react-dom', () => ({
+  createPortal: (node: unknown) => node
+}))
+
+vi.mock('./TerminalPane', () => ({
+  default: (props: Record<string, unknown>) => ({ __mock: 'TerminalPane', props })
+}))
+
+vi.mock('../terminal/terminal-tab-actions', () => ({
+  closeTerminalTab: mocks.closeTerminalTab
+}))
+
+import TerminalPaneOverlayLayer from './TerminalPaneOverlayLayer'
+
+type ReactElementLike = {
+  type: string | ((props: Record<string, unknown>) => unknown)
+  props: Record<string, unknown>
+}
+
+function collectTerminalPaneProps(node: unknown): Record<string, unknown>[] {
+  const found: Record<string, unknown>[] = []
+  const visit = (current: unknown): void => {
+    if (current == null || typeof current !== 'object') {
+      return
+    }
+    if (Array.isArray(current)) {
+      current.forEach(visit)
+      return
+    }
+    const mockNode = current as { __mock?: string; props?: Record<string, unknown> }
+    if (mockNode.__mock === 'TerminalPane' && mockNode.props) {
+      found.push(mockNode.props)
+      return
+    }
+    const element = current as ReactElementLike
+    if (typeof element.type === 'function') {
+      visit(element.type(element.props ?? {}))
+      return
+    }
+    if (element.props) {
+      visit(element.props.children)
+    }
+  }
+  visit(node)
+  return found
+}
+
+function makeTerminalTab(id: string): TerminalTab {
+  return {
+    id,
+    ptyId: `pty-${id}`,
+    worktreeId: 'wt-1',
+    title: id,
+    defaultTitle: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  } as TerminalTab
+}
+
+function makeUnifiedTerminalTab(entityId: string, groupId: string): Tab {
+  return {
+    id: `unified-${entityId}`,
+    entityId,
+    groupId,
+    worktreeId: 'wt-1',
+    contentType: 'terminal',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  } as Tab
+}
+
+function seedStore(activeTabId: string): void {
+  storeBox.state = {
+    tabsByWorktree: { 'wt-1': [makeTerminalTab('term-1'), makeTerminalTab('term-2')] },
+    unifiedTabsByWorktree: {
+      'wt-1': [
+        makeUnifiedTerminalTab('term-1', 'group-1'),
+        makeUnifiedTerminalTab('term-2', 'group-1')
+      ]
+    },
+    groupsByWorktree: {
+      'wt-1': [
+        {
+          id: 'group-1',
+          worktreeId: 'wt-1',
+          activeTabId,
+          tabOrder: ['unified-term-1', 'unified-term-2']
+        } as TabGroup
+      ]
+    },
+    activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+    activeWorktreeId: 'wt-1',
+    // Why: main's overlay slot seeds hidden-startup measuring from
+    // pendingStartupByTabId at first render; an empty record means no
+    // pending startups, matching the default store shape.
+    pendingStartupByTabId: {},
+    focusGroup: mocks.focusGroup,
+    consumeSuppressedPtyExit: mocks.consumeSuppressedPtyExit,
+    closeTab: mocks.closeTab,
+    setActiveWorktree: mocks.setActiveWorktree,
+    reconcileWorktreeTabModel: mocks.reconcileWorktreeTabModel
+  }
+}
+
+function renderOverlay(isWorktreeActive: boolean): Record<string, unknown>[] {
+  const element = TerminalPaneOverlayLayer({
+    worktreeId: 'wt-1',
+    worktreePath: '/worktree',
+    isWorktreeActive
+  })
+  return collectTerminalPaneProps(element)
+}
+
+function paneFor(panes: Record<string, unknown>[], tabId: string): Record<string, unknown> {
+  const pane = panes.find((props) => props.tabId === tabId)
+  if (!pane) {
+    throw new Error(`expected an overlay pane for ${tabId}`)
+  }
+  return pane
+}
+
+describe('TerminalPaneOverlayLayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.consumeSuppressedPtyExit.mockReturnValue(false)
+    mocks.reconcileWorktreeTabModel.mockReturnValue({ renderableTabCount: 0 })
+    seedStore('unified-term-1')
+  })
+
+  it('shows only the active-in-group terminal while the worktree is active', () => {
+    const panes = renderOverlay(true)
+    const first = panes.find((props) => props.tabId === 'term-1')
+    const second = panes.find((props) => props.tabId === 'term-2')
+
+    expect(first?.isVisible).toBe(true)
+    expect(first?.isActive).toBe(true)
+    expect(second?.isVisible).toBe(false)
+    expect(second?.isActive).toBe(false)
+  })
+
+  it('hides every terminal pane while the worktree is inactive', () => {
+    const panes = renderOverlay(false)
+
+    for (const props of panes) {
+      expect(props.isVisible).toBe(false)
+      expect(props.isActive).toBe(false)
+    }
+  })
+
+  it('closes the tab and re-checks the worktree on a genuine PTY exit', () => {
+    const panes = renderOverlay(true)
+    const first = paneFor(panes, 'term-1')
+
+    ;(first.onPtyExit as (ptyId: string) => void)('pty-term-1')
+
+    // Why: PTY exits route through the pinned-aware helper, never the raw
+    // store closeTab; the worktree re-check runs in the onClosed continuation.
+    expect(mocks.closeTab).not.toHaveBeenCalled()
+    expect(mocks.closeTerminalTab).toHaveBeenCalledWith('term-1', {
+      reason: 'pty-exit',
+      onClosed: expect.any(Function)
+    })
+    const { onClosed } = mocks.closeTerminalTab.mock.calls[0][1] as { onClosed: () => void }
+    onClosed()
+    expect(mocks.reconcileWorktreeTabModel).toHaveBeenCalledWith('wt-1')
+    expect(mocks.setActiveWorktree).toHaveBeenCalledWith(null)
+  })
+
+  it('keeps the tab open when a PTY exit is suppressed', () => {
+    mocks.consumeSuppressedPtyExit.mockReturnValue(true)
+    const panes = renderOverlay(true)
+    const first = paneFor(panes, 'term-1')
+
+    ;(first.onPtyExit as (ptyId: string) => void)('pty-term-1')
+
+    expect(mocks.closeTerminalTab).not.toHaveBeenCalled()
+    expect(mocks.closeTab).not.toHaveBeenCalled()
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+  })
+
+  it('routes an explicit pane close through the pinned-aware close helper', () => {
+    const panes = renderOverlay(true)
+    const first = paneFor(panes, 'term-1')
+
+    ;(first.onCloseTab as () => void)()
+
+    expect(mocks.closeTerminalTab).toHaveBeenCalledWith('term-1', {
+      onClosed: expect.any(Function)
+    })
+    expect(mocks.closeTab).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2817,7 +2817,7 @@ describe('useIpcEvents browser tab close routing', () => {
     tabId: string | null
     worktreeId?: string
   }) => void
-  type CloseActiveTabListener = () => void
+  type CloseActiveTabListener = (payload?: { browserTabId?: string }) => void
   type CloseTerminalListener = (data: { tabId: string; paneRuntimeId?: number | null }) => void
   type CloseSessionTabListener = (data: { tabId: string; worktreeId: string }) => void
   type TerminalTabCloseRequestListener = (data: { requestId: string; tabId: string }) => void
@@ -3226,6 +3226,29 @@ describe('useIpcEvents browser tab close routing', () => {
     onConfirm()
 
     expect(closeBrowserTab).toHaveBeenCalledWith('workspace-1')
+  })
+
+  it('closes the browser tab that emitted a guest Cmd+W event', async () => {
+    const closeActiveTabListenerRef: { current: CloseActiveTabListener | null } = { current: null }
+    const closeBrowserTab = vi.fn()
+
+    await useIpcEventsForCloseRouting({
+      closeActiveTabListenerRef,
+      getState: () => ({
+        activeBrowserTabId: 'main-browser',
+        browserTabsByWorktree: {
+          'wt-1': [{ id: 'main-browser' }],
+          floating: [{ id: 'floating-browser' }]
+        },
+        closeBrowserTab,
+        unifiedTabsByWorktree: {}
+      })
+    })
+
+    closeActiveTabListenerRef.current?.({ browserTabId: 'floating-browser' })
+
+    expect(closeBrowserTab).toHaveBeenCalledWith('floating-browser')
+    expect(closeBrowserTab).not.toHaveBeenCalledWith('main-browser')
   })
 
   it('confirms CLI workspace browser closes and replies after confirmation', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -201,6 +201,16 @@ function findBrowserPageWorktreeId(store: AppState, browserPageId: string): stri
   return null
 }
 
+function findBrowserTabWorktreeId(store: AppState, browserTabId: string): string | null {
+  for (const [worktreeId, browserTabs] of Object.entries(store.browserTabsByWorktree)) {
+    if (browserTabs.some((tab) => tab.id === browserTabId)) {
+      return worktreeId
+    }
+  }
+
+  return null
+}
+
 function acquireBrowserAutomationBootstrapLease(
   worktreeId: string | null | undefined,
   browserPageId?: string | null
@@ -2467,42 +2477,71 @@ export function useIpcEvents(): void {
     )
 
     unsubs.push(
-      window.api.ui.onCloseActiveTab(() => {
+      window.api.ui.onCloseActiveTab((payload) => {
         if (isEmptyFloatingWorkspacePanelVisible()) {
           window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
           return
         }
         const store = useAppStore.getState()
-        if (store.activeTabType === 'browser' && store.activeBrowserTabId) {
-          const tabId = store.activeBrowserTabId
-          const worktreeId = store.activeWorktreeId
-          const closeActiveBrowserTab = (): void => {
-            const currentStore = useAppStore.getState()
-            const environmentId = getWorktreeRuntimeEnvironmentId(worktreeId)
-            if (environmentId && worktreeId) {
-              if (!isWebRuntimeSessionActive(environmentId)) {
-                currentStore.closeBrowserTab(tabId)
-                return
-              }
-              void closeWebRuntimeSessionTab({
-                worktreeId,
-                tabId,
-                environmentId
-              })
+        const payloadBrowserTabId =
+          payload && typeof payload.browserTabId === 'string' ? payload.browserTabId : null
+        let tabId =
+          payloadBrowserTabId ??
+          (store.activeTabType === 'browser' && store.activeBrowserTabId
+            ? store.activeBrowserTabId
+            : null)
+        if (!tabId) {
+          return
+        }
+        let worktreeId = payloadBrowserTabId
+          ? findBrowserTabWorktreeId(store, payloadBrowserTabId)
+          : store.activeWorktreeId
+        // Why: the incoming browserTabId may be a browser page id rather than a
+        // workspace tab id. Mirror onRequestTabClose by resolving the page id to
+        // its owning workspace tab via browserPagesByWorkspace before closing,
+        // otherwise findBrowserTabWorktreeId yields no match and we silently no-op.
+        if (payloadBrowserTabId && !worktreeId) {
+          const owningWorkspaceId =
+            Object.entries(store.browserPagesByWorkspace).find(([, pages]) =>
+              pages.some((p) => p.id === payloadBrowserTabId)
+            )?.[0] ?? null
+          if (owningWorkspaceId) {
+            const owningWorktreeId = findBrowserTabWorktreeId(store, owningWorkspaceId)
+            if (owningWorktreeId) {
+              tabId = owningWorkspaceId
+              worktreeId = owningWorktreeId
+            }
+          }
+        }
+        if (!worktreeId) {
+          return
+        }
+        const closeBrowserTab = (): void => {
+          const currentStore = useAppStore.getState()
+          const environmentId = getWorktreeRuntimeEnvironmentId(worktreeId)
+          if (environmentId) {
+            if (!isWebRuntimeSessionActive(environmentId)) {
+              currentStore.closeBrowserTab(tabId)
               return
             }
-            currentStore.closeBrowserTab(tabId)
-          }
-          if (worktreeId && isPinnedSessionTab(store, worktreeId, tabId)) {
-            guardPinnedTabClose({
-              isPinned: true,
-              tabLabel: resolvePinnedTabLabel(store, worktreeId, tabId),
-              onClose: closeActiveBrowserTab
+            void closeWebRuntimeSessionTab({
+              worktreeId,
+              tabId,
+              environmentId
             })
             return
           }
-          closeActiveBrowserTab()
+          currentStore.closeBrowserTab(tabId)
         }
+        if (isPinnedSessionTab(store, worktreeId, tabId)) {
+          guardPinnedTabClose({
+            isPinned: true,
+            tabLabel: resolvePinnedTabLabel(store, worktreeId, tabId),
+            onClose: closeBrowserTab
+          })
+          return
+        }
+        closeBrowserTab()
       })
     )
 

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -125,7 +125,7 @@ export type BrowserSlice = {
     url: string,
     options?: CreateBrowserTabOptions
   ) => BrowserWorkspace
-  openNewBrowserTabInActiveWorkspace: (groupId: string) => Promise<void>
+  openNewBrowserTabInActiveWorkspace: (groupId: string, worktreeId?: string) => Promise<void>
   closeBrowserTab: (tabId: string) => void
   shutdownWorktreeBrowsers: (worktreeId: string) => Promise<void>
   reopenClosedBrowserTab: (worktreeId: string) => BrowserWorkspace | null
@@ -593,19 +593,19 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     return browserTab
   },
 
-  openNewBrowserTabInActiveWorkspace: async (groupId) => {
+  openNewBrowserTabInActiveWorkspace: async (groupId, worktreeId) => {
     const state = get()
-    const worktreeId = state.activeWorktreeId
-    if (!worktreeId) {
+    const targetWorktreeId = worktreeId ?? state.activeWorktreeId
+    if (!targetWorktreeId) {
       return
     }
     const defaultUrl = state.browserDefaultUrl ?? 'about:blank'
-    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, targetWorktreeId)
     if (runtimeEnvironmentId) {
       const { createWebRuntimeSessionBrowserTab } = await import('@/runtime/web-runtime-session')
       try {
         const created = await createWebRuntimeSessionBrowserTab({
-          worktreeId,
+          worktreeId: targetWorktreeId,
           environmentId: runtimeEnvironmentId,
           url: defaultUrl,
           targetGroupId: groupId
@@ -623,7 +623,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       }
       return
     }
-    get().createBrowserTab(worktreeId, defaultUrl, {
+    get().createBrowserTab(targetWorktreeId, defaultUrl, {
       title: translate('auto.store.slices.browser.d175274b6d', 'New Browser Tab'),
       focusAddressBar: true,
       targetGroupId: groupId
@@ -869,13 +869,14 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       if (!browserTab) {
         return s
       }
+      const isActiveWorktree = browserTab.worktreeId === s.activeWorktreeId
       return {
-        activeBrowserTabId: tabId,
+        activeBrowserTabId: isActiveWorktree ? tabId : s.activeBrowserTabId,
         activeBrowserTabIdByWorktree: {
           ...s.activeBrowserTabIdByWorktree,
           [browserTab.worktreeId]: tabId
         },
-        activeTabType: 'browser',
+        activeTabType: isActiveWorktree ? 'browser' : s.activeTabType,
         activeTabTypeByWorktree: {
           ...s.activeTabTypeByWorktree,
           [browserTab.worktreeId]: 'browser'

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -419,7 +419,7 @@ export type EditorSlice = {
   activeFileIdByWorktree: Record<string, string | null> // worktreeId -> last active file
   activeTabTypeByWorktree: Record<string, WorkspaceVisibleTabType> // worktreeId -> last active tab type
   activeTabType: WorkspaceVisibleTabType
-  setActiveTabType: (type: WorkspaceVisibleTabType) => void
+  setActiveTabType: (type: WorkspaceVisibleTabType, worktreeId?: string) => void
   openFile: (
     file: Omit<OpenFile, 'id' | 'isDirty'>,
     options?: {
@@ -430,7 +430,7 @@ export type EditorSlice = {
       forceContentReload?: boolean
     }
   ) => void
-  openNewMarkdownInActiveWorkspace: (groupId: string) => Promise<void>
+  openNewMarkdownInActiveWorkspace: (groupId: string, worktreeId?: string) => Promise<void>
   // Why: sequences openFile/setMarkdownViewMode/reveal around an async Monaco remount. See docs/markdown-internal-link-opening-design.md.
   activateMarkdownLink: (
     rawHref: string | undefined,
@@ -1515,13 +1515,14 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   activeTabTypeByWorktree: {},
   activeTabType: 'terminal',
   recentlyClosedEditorTabsByWorktree: {},
-  setActiveTabType: (type) =>
+  setActiveTabType: (type, worktreeId) =>
     set((s) => {
-      const worktreeId = s.activeWorktreeId
+      const wId = worktreeId ?? s.activeWorktreeId
+      const isActiveWorktree = wId === s.activeWorktreeId
       return {
-        activeTabType: type,
-        activeTabTypeByWorktree: worktreeId
-          ? { ...s.activeTabTypeByWorktree, [worktreeId]: type }
+        activeTabType: isActiveWorktree ? type : s.activeTabType,
+        activeTabTypeByWorktree: wId
+          ? { ...s.activeTabTypeByWorktree, [wId]: type }
           : s.activeTabTypeByWorktree
       }
     }),
@@ -1749,13 +1750,13 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     )
   },
 
-  openNewMarkdownInActiveWorkspace: async (groupId) => {
+  openNewMarkdownInActiveWorkspace: async (groupId, worktreeId) => {
     const state = get()
-    const worktreeId = state.activeWorktreeId
-    if (!worktreeId) {
+    const targetWorktreeId = worktreeId ?? state.activeWorktreeId
+    if (!targetWorktreeId) {
       return
     }
-    const worktree = state.getKnownWorktreeById(worktreeId)
+    const worktree = state.getKnownWorktreeById(targetWorktreeId)
     if (!worktree) {
       return
     }
@@ -1764,7 +1765,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         state.repos.find((entry) => entry.id === worktree.repoId)?.connectionId ?? undefined
       const fileInfo = await createUntitledMarkdownFileWithTemplateSelection(
         worktree.path,
-        worktreeId,
+        targetWorktreeId,
         connectionId,
         get().settings
       )
@@ -2268,18 +2269,23 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   },
 
   setActiveFile: (fileId) => {
+    let fileOwnerWorktreeId: string | null = null
     set((s) => {
       const file = s.openFiles.find((f) => f.id === fileId)
       const worktreeId = file?.worktreeId
+      if (worktreeId) {
+        fileOwnerWorktreeId = worktreeId
+      }
+      const isActiveWorktree = worktreeId === s.activeWorktreeId
       return {
-        activeFileId: fileId,
+        activeFileId: isActiveWorktree ? fileId : s.activeFileId,
         activeFileIdByWorktree: worktreeId
           ? { ...s.activeFileIdByWorktree, [worktreeId]: fileId }
           : s.activeFileIdByWorktree
       }
     })
     const state = get()
-    const worktreeId = state.activeWorktreeId
+    const worktreeId = fileOwnerWorktreeId ?? state.activeWorktreeId
     if (!worktreeId) {
       return
     }

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -1217,6 +1217,42 @@ describe('TabsSlice', () => {
         store.getState().unifiedTabsByWorktree[WT].find((tab) => tab.id === right.id)?.groupId
       ).toBe(rightGroupId)
     })
+
+    it('allows a split drop for the floating worktree, creating a new group and split layout', () => {
+      const first = store.getState().createUnifiedTab(FLOATING_TERMINAL_WORKTREE_ID, 'terminal', {
+        id: 'floating-a',
+        label: 'A'
+      })
+      const second = store.getState().createUnifiedTab(FLOATING_TERMINAL_WORKTREE_ID, 'terminal', {
+        id: 'floating-b',
+        label: 'B'
+      })
+      const groupId = store.getState().groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID][0].id
+
+      const moved = store.getState().dropUnifiedTab(second.id, {
+        groupId,
+        splitDirection: 'right'
+      })
+
+      expect(moved).toBe(true)
+      const state = store.getState()
+      expect(state.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID]).toHaveLength(2)
+      const newGroupId = state.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID].find(
+        (g) => g.id !== groupId
+      )?.id
+      expect(newGroupId).toBeTruthy()
+      const sourceGroup = state.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID].find(
+        (g) => g.id === groupId
+      )
+      expect(sourceGroup?.tabOrder).toEqual([first.id])
+      expect(state.layoutByWorktree[FLOATING_TERMINAL_WORKTREE_ID]).toEqual({
+        type: 'split',
+        direction: 'horizontal',
+        ratio: 0.5,
+        first: { type: 'leaf', groupId },
+        second: { type: 'leaf', groupId: newGroupId }
+      })
+    })
   })
 
   // ─── setTabLabel / setTabCustomLabel / setUnifiedTabColor ─────────

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -553,7 +553,7 @@ export type TerminalSlice = {
       startupCwd?: string
     }
   ) => TerminalTab
-  openNewTerminalTabInActiveWorkspace: (groupId: string) => Promise<void>
+  openNewTerminalTabInActiveWorkspace: (groupId: string, worktreeId?: string) => Promise<void>
   closeTab: (
     tabId: string,
     opts?: {
@@ -1076,31 +1076,31 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     return tab
   },
 
-  openNewTerminalTabInActiveWorkspace: async (groupId) => {
+  openNewTerminalTabInActiveWorkspace: async (groupId, worktreeId) => {
     const state = get()
-    const worktreeId = state.activeWorktreeId
-    if (!worktreeId) {
+    const targetWorktreeId = worktreeId ?? state.activeWorktreeId
+    if (!targetWorktreeId) {
       return
     }
-    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, targetWorktreeId)
     if (runtimeEnvironmentId) {
       const { createWebRuntimeSessionTerminal } = await import('@/runtime/web-runtime-session')
       await createWebRuntimeSessionTerminal({
-        worktreeId,
+        worktreeId: targetWorktreeId,
         environmentId: runtimeEnvironmentId,
         targetGroupId: groupId,
         activate: true
       })
       return
     }
-    const terminal = get().createTab(worktreeId, groupId)
+    const terminal = get().createTab(targetWorktreeId, groupId)
     get().setActiveTab(terminal.id)
-    get().setActiveTabType('terminal')
+    get().setActiveTabType('terminal', targetWorktreeId)
     const latest = get()
-    const currentTerminals = latest.tabsByWorktree[worktreeId] ?? []
-    const currentEditors = latest.openFiles.filter((file) => file.worktreeId === worktreeId)
-    const currentBrowsers = latest.browserTabsByWorktree[worktreeId] ?? []
-    const stored = latest.tabBarOrderByWorktree[worktreeId]
+    const currentTerminals = latest.tabsByWorktree[targetWorktreeId] ?? []
+    const currentEditors = latest.openFiles.filter((file) => file.worktreeId === targetWorktreeId)
+    const currentBrowsers = latest.browserTabsByWorktree[targetWorktreeId] ?? []
+    const stored = latest.tabBarOrderByWorktree[targetWorktreeId]
     const validIds = new Set([
       ...currentTerminals.map((tab) => tab.id),
       ...currentEditors.map((file) => file.id),
@@ -1114,7 +1114,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
     }
     // Why: Cmd+J shares the titlebar-button creation path, so append the new terminal after mixed editor/browser tabs, not first.
-    get().setTabBarOrder(worktreeId, [...base.filter((id) => id !== terminal.id), terminal.id])
+    get().setTabBarOrder(targetWorktreeId, [
+      ...base.filter((id) => id !== terminal.id),
+      terminal.id
+    ])
     focusTerminalTabSurface(terminal.id)
   },
 

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
     ORCA_FEATURE_WALL_ENABLED: 'true'
   },
   resolve: {
+    // Why: accidental tsc emits (*.js next to *.ts) must never shadow the real
+    // source — Vite resolves .js before .ts by default. Prefer TS extensions.
+    extensions: ['.ts', '.tsx', '.mts', '.mjs', '.js', '.jsx', '.json'],
     alias: {
       '@renderer': resolve('src/renderer/src'),
       '@': resolve('src/renderer/src')


### PR DESCRIPTION
## Summary

Brings the floating terminal's tab handling to parity with the main workspace by consolidating it onto the shared unified-tab model:

- **Drag-to-reorder** tabs within the floating terminal tab strip.
- **Drag-to-split with live hover preview** — drag a tab onto a pane edge to split the floating workspace into a side-by-side / stacked layout, using the same preview overlay as the main workspace.
- Floating editor close requests route into the panel's own save-dialog queue; floating popup/close shortcuts route correctly.

The floating panel now renders the shared `TabGroupSplitLayout` (tab strip, panes, reorder/drag wiring) instead of owning a bespoke single-group surface. The earlier no-split invariant was removed from both the `tab-move-to-pane-column` UI guard and the `dropUnifiedTab` store boundary, and the floating worktree seeds `layoutByWorktree`.

## Screenshots

Pending visual recording of drag-to-reorder and drag-to-split behavior. Keep draft until the recording is attached or maintainers accept the written behavior evidence.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` - not run repo-wide.
- [x] Affected suite: 7 files, 173 tests green.
- [ ] `pnpm build`
- [x] Added/updated tests: floating panel tests now assert delegation to `TabGroupSplitLayout` rather than TabBar internals; PTY-exit / hidden-visibility coverage moved to `TerminalPaneOverlayLayer.test.tsx`; dnd-wiring (enabled/disabled, exact sensor/handler passthrough) covered in `TabGroupSplitLayout.test.ts`

Targeted gates run locally: `typecheck:web` clean, `oxlint` clean on all changed files, full affected suite 173/173.

## AI Review Report

Reviewed the drag-split consolidation for: (1) correctness of removing the no-split invariant at both the UI guard and store boundary — confirmed the floating worktree now seeds `layoutByWorktree` so the split layout has a tree to paint and tabs aren't orphaned; (2) test quality — confirmed panel tests assert delegation (component boundary) rather than reaching into TabBar internals, reducing brittleness; (3) the untracked `src/preload/api-types.d.ts` was identified as an accidental tsc emit of the type-checked `api-types.ts` (source-of-truth since #1197) and is **not** committed — the stale `!src/preload/api-types.d.ts` allow-list entry was removed from `.gitignore` to prevent recurrence.

Cross-platform: changes are renderer-only (React/zustand/dnd-kit) with no shell, path, or Electron-main behavior touched; no OS-specific code paths introduced. Drag activation uses pointer sensors already in use across platforms.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or IPC surfaces. Changes are confined to renderer tab-model state and drag wiring. The `.gitignore` change keeps a generated `.d.ts` emit out of source control (no secret exposure). No dependency changes.

## Notes

- Built on top of the prior floating-terminal drag-to-reorder and close-routing commits in this branch.
- `.gitignore`: dropped the stale `!src/preload/api-types.d.ts` whitelist (leftover from #1197's `.d.ts` -> `.ts` migration) so the accidental tsc emit stays ignored.
- This consolidated tab model functionally supersedes the narrow drag-reorder implementation in #6254.

X: @wolfie_

## ELI5

Floating terminal tabs match the main workspace: drag to reorder and drag to split with a live preview. Closing floating editors goes through the floating panel’s own save flow.
