### PR TITLE
Show merged PR status from merge commits

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -1219,6 +1219,21 @@ describe('getPRForBranch', () => {
     })
   })
 
+  it('treats stale fallback PR misses as accessible before merge-commit 404s', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('HTTP 404: PR not found'))
+      .mockRejectedValueOnce(new Error('HTTP 404: REST PR not found'))
+      .mockRejectedValueOnce(new Error('HTTP 404: Commit association not found'))
+
+    const outcome = await getPRForBranchOutcome('/repo-root', '', null, null, 123, {
+      currentHeadOid: 'dddddddd'
+    })
+
+    expect(outcome).toMatchObject({ kind: 'no-pr' })
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
   it('treats a merged branch lookup as a miss before using a fallback PR number', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -840,9 +840,7 @@ describe('getPRForBranch', () => {
 
   it('returns a merged PR by exact merge commit when branch lookup misses', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    gitExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: 'feature/test\0\n', stderr: '' })
-      .mockResolvedValueOnce({ stdout: 'aaaaaaaa\n', stderr: '' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'feature/test\0\n', stderr: '' })
     ghExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({
@@ -890,7 +888,9 @@ describe('getPRForBranch', () => {
         })
       })
 
-    const pr = await getPRForBranch('/repo-root', 'feature/test')
+    const pr = await getPRForBranch('/repo-root', 'feature/test', null, null, null, {
+      currentHeadOid: 'aaaaaaaa'
+    })
 
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
@@ -920,9 +920,7 @@ describe('getPRForBranch', () => {
 
   it('rejects open and merge-commit mismatched associated PRs', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    gitExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: 'feature/test\0\n', stderr: '' })
-      .mockResolvedValueOnce({ stdout: 'aaaaaaaa\n', stderr: '' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'feature/test\0\n', stderr: '' })
     ghExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({
@@ -953,8 +951,43 @@ describe('getPRForBranch', () => {
         ])
       })
 
-    await expect(getPRForBranch('/repo-root', 'feature/test')).resolves.toBeNull()
+    await expect(
+      getPRForBranch('/repo-root', 'feature/test', null, null, null, {
+        currentHeadOid: 'aaaaaaaa'
+      })
+    ).resolves.toBeNull()
     expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats a missing GitHub commit association as no PR for local-only commits', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'feature/test\0\n', stderr: '' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockRejectedValueOnce(new Error('gh: No commit found for SHA: aaaaaaaa (HTTP 422)'))
+
+    await expect(
+      getPRForBranchOutcome('/repo-root', 'feature/test', null, null, null, {
+        currentHeadOid: 'aaaaaaaa'
+      })
+    ).resolves.toMatchObject({ kind: 'no-pr' })
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not discover merge-commit PRs from repo-root HEAD without an explicit head hint', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'feature/test\0\n', stderr: '' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+
+    await expect(getPRForBranchOutcome('/repo-root', 'feature/test')).resolves.toMatchObject({
+      kind: 'no-pr'
+    })
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      ['api', 'repos/acme/widgets/pulls?head=acme%3Afeature%2Ftest&state=all&per_page=1'],
+      { cwd: '/repo-root' }
+    )
   })
 
   it('reuses an unavailable HEAD lookup after hiding a stale merged branch PR', async () => {
@@ -1002,7 +1035,6 @@ describe('getPRForBranch', () => {
 
   it('runs the merge-commit fallback for detached HEAD', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'dddddddd\n', stderr: '' })
     ghExecFileAsyncMock
       .mockResolvedValueOnce({
         stdout: JSON.stringify([
@@ -1037,7 +1069,9 @@ describe('getPRForBranch', () => {
         })
       })
 
-    const pr = await getPRForBranch('/repo-root', '')
+    const pr = await getPRForBranch('/repo-root', '', null, null, null, {
+      currentHeadOid: 'dddddddd'
+    })
 
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       1,
@@ -1160,7 +1194,6 @@ describe('getPRForBranch', () => {
 
   it('does not use invalid current HEAD hints for merge-commit lookup', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
 
     await expect(
       getPRForBranch('/repo-root', '', null, null, null, {
@@ -1168,16 +1201,17 @@ describe('getPRForBranch', () => {
       })
     ).resolves.toBeNull()
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['rev-parse', 'HEAD'], { cwd: '/repo-root' })
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
     expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
   it('keeps unproven merge-commit 404s distinct from no-pr misses', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'dddddddd\n', stderr: '' })
     ghExecFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 404: Not Found'))
 
-    const outcome = await getPRForBranchOutcome('/repo-root', '')
+    const outcome = await getPRForBranchOutcome('/repo-root', '', null, null, null, {
+      currentHeadOid: 'dddddddd'
+    })
 
     expect(outcome).toMatchObject({
       kind: 'upstream-error',
@@ -1568,13 +1602,11 @@ describe('getPRForBranch', () => {
     getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'existing\0\n', stderr: '' })
-      .mockResolvedValueOnce({ stdout: '1111111\n', stderr: '' })
       .mockResolvedValueOnce({
         stdout: 'existing\0\nnew-feature\0origin/contributor/original\n',
         stderr: ''
       })
     ghExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({
@@ -1750,10 +1782,8 @@ describe('getPRForBranch', () => {
       .mockResolvedValueOnce('/repo-root/.git/config\u0000mtime-b\u0000120')
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'feature\0\n', stderr: '' })
-      .mockResolvedValueOnce({ stdout: '2222222\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: 'feature\0origin/contributor/original\n', stderr: '' })
     ghExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({
@@ -1814,10 +1844,8 @@ describe('getPRForBranch', () => {
       .mockResolvedValueOnce('/repo-root/.git/config\u0000mtime-b\u0000120')
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'feature\0origin/old-upstream\n', stderr: '' })
-      .mockResolvedValueOnce({ stdout: '2222222\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: 'feature\0origin/contributor/original\n', stderr: '' })
     ghExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
@@ -1863,10 +1891,8 @@ describe('getPRForBranch', () => {
       .mockResolvedValueOnce('/repo-root/.git/config\u0000mtime-b\u0000120')
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'feature\0\n', stderr: '' })
-      .mockResolvedValueOnce({ stdout: '2222222\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: 'feature\0origin/contributor/original\n', stderr: '' })
     ghExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({
@@ -2327,7 +2353,6 @@ describe('getPRForBranch', () => {
       getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
       getOwnerRepoForRemoteMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
       ghExecFileAsyncMock
-        .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
         .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
         .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
         .mockResolvedValueOnce({ stdout: JSON.stringify([]) })

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -114,9 +114,11 @@ import {
   setPRAutoMerge,
   updatePRState,
   updatePRTitle,
+  getPRForBranchOutcome,
   _getMergeQueueCacheSizeForTests,
   _resetOwnerRepoCache,
   _resetMergeQueueCacheForTests,
+  __resetCommitAssociatedPRCacheForTests,
   __resetTrackedUpstreamBranchCacheForTests
 } from './client'
 import { __resetPRConflictSummaryGitCapabilityCacheForTests } from './conflict-summary'
@@ -189,6 +191,7 @@ describe('getPRForBranch', () => {
     acquireMock.mockResolvedValue(undefined)
     _resetOwnerRepoCache()
     _resetMergeQueueCacheForTests()
+    __resetCommitAssociatedPRCacheForTests()
     __resetTrackedUpstreamBranchCacheForTests()
     __resetPRConflictSummaryGitCapabilityCacheForTests()
   })
@@ -835,6 +838,353 @@ describe('getPRForBranch', () => {
     expect(pr).toMatchObject({ number: 42, title: 'Fallback PR lookup' })
   })
 
+  it('returns a merged PR by exact merge commit when branch lookup misses', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'feature/test\0\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'aaaaaaaa\n', stderr: '' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 87,
+            title: 'Wrong associated PR',
+            state: 'closed',
+            merged_at: '2026-06-20T04:53:05Z',
+            merge_commit_sha: 'bbbbbbbb',
+            html_url: 'https://github.com/acme/widgets/pull/87',
+            updated_at: '2026-06-20T04:53:05Z',
+            draft: false,
+            head: { ref: 'feature/old', sha: 'old-head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          },
+          {
+            number: 88,
+            title: 'Merged by commit association',
+            state: 'closed',
+            merged_at: '2026-06-21T04:53:05Z',
+            merge_commit_sha: 'aaaaaaaa',
+            html_url: 'https://github.com/acme/widgets/pull/88',
+            updated_at: '2026-06-21T04:53:05Z',
+            draft: false,
+            head: { ref: 'feature/test', sha: 'pr-head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 88,
+          title: 'Hydrated merge commit PR',
+          state: 'MERGED',
+          url: 'https://github.com/acme/widgets/pull/88',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-21T04:53:05Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'feature/test',
+          baseRefOid: 'base-oid',
+          headRefOid: 'pr-head-oid'
+        })
+      })
+
+    const pr = await getPRForBranch('/repo-root', 'feature/test')
+
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      ['api', 'repos/acme/widgets/commits/aaaaaaaa/pulls?per_page=100'],
+      { cwd: '/repo-root' }
+    )
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      3,
+      [
+        'pr',
+        'view',
+        '88',
+        '--repo',
+        'acme/widgets',
+        '--json',
+        'number,title,state,url,statusCheckRollup,updatedAt,isDraft,mergeable,reviewDecision,mergeStateStatus,autoMergeRequest,baseRefName,headRefName,baseRefOid,headRefOid'
+      ],
+      { cwd: '/repo-root' }
+    )
+    expect(pr).toMatchObject({
+      number: 88,
+      title: 'Hydrated merge commit PR',
+      state: 'merged',
+      headSha: 'pr-head-oid'
+    })
+  })
+
+  it('rejects open and merge-commit mismatched associated PRs', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'feature/test\0\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'aaaaaaaa\n', stderr: '' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 90,
+            title: 'Open associated PR',
+            state: 'open',
+            merge_commit_sha: 'aaaaaaaa',
+            html_url: 'https://github.com/acme/widgets/pull/90',
+            updated_at: '2026-06-21T04:53:05Z',
+            draft: false,
+            head: { ref: 'feature/test', sha: 'open-head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          },
+          {
+            number: 91,
+            title: 'Different merge commit PR',
+            state: 'closed',
+            merged_at: '2026-06-21T04:53:05Z',
+            merge_commit_sha: 'bbbbbbbb',
+            html_url: 'https://github.com/acme/widgets/pull/91',
+            updated_at: '2026-06-21T04:53:05Z',
+            draft: false,
+            head: { ref: 'feature/test', sha: 'closed-head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+
+    await expect(getPRForBranch('/repo-root', 'feature/test')).resolves.toBeNull()
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('reuses an unavailable HEAD lookup after hiding a stale merged branch PR', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 93,
+            title: 'Historical merged branch PR',
+            state: 'closed',
+            merged_at: '2026-06-22T04:53:05Z',
+            html_url: 'https://github.com/acme/widgets/pull/93',
+            updated_at: '2026-06-22T04:53:05Z',
+            draft: false,
+            head: { ref: 'feature/test', sha: 'old-pr-head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 93,
+          title: 'Hydrated historical merged branch PR',
+          state: 'MERGED',
+          url: 'https://github.com/acme/widgets/pull/93',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-22T04:53:05Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'feature/test',
+          baseRefOid: 'base-oid',
+          headRefOid: 'old-pr-head-oid'
+        })
+      })
+
+    await expect(getPRForBranch('/repo-root', 'feature/test')).resolves.toBeNull()
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['rev-parse', 'HEAD'], { cwd: '/repo-root' })
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs the merge-commit fallback for detached HEAD', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'dddddddd\n', stderr: '' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 92,
+            title: 'Detached merge commit PR',
+            state: 'closed',
+            merged_at: '2026-06-22T04:53:05Z',
+            merge_commit_sha: 'dddddddd',
+            html_url: 'https://github.com/acme/widgets/pull/92',
+            updated_at: '2026-06-22T04:53:05Z',
+            draft: false,
+            head: { ref: 'feature/detached', sha: 'detached-pr-head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 92,
+          title: 'Hydrated detached merge commit PR',
+          state: 'MERGED',
+          url: 'https://github.com/acme/widgets/pull/92',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-22T04:53:05Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'feature/detached',
+          baseRefOid: 'base-oid',
+          headRefOid: 'detached-pr-head-oid'
+        })
+      })
+
+    const pr = await getPRForBranch('/repo-root', '')
+
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      ['api', 'repos/acme/widgets/commits/dddddddd/pulls?per_page=100'],
+      { cwd: '/repo-root' }
+    )
+    expect(pr).toMatchObject({
+      number: 92,
+      title: 'Hydrated detached merge commit PR',
+      state: 'merged'
+    })
+  })
+
+  it('does not run the merge-commit fallback for linked PR lookups', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        number: 77,
+        title: 'Linked PR lookup',
+        state: 'OPEN',
+        url: 'https://github.com/acme/widgets/pull/77',
+        statusCheckRollup: [],
+        updatedAt: '2026-03-28T00:00:00Z',
+        isDraft: false,
+        mergeable: 'MERGEABLE',
+        baseRefName: 'main',
+        headRefName: 'feature/test',
+        baseRefOid: 'base-oid',
+        headRefOid: 'linked-head-oid'
+      })
+    })
+
+    const pr = await getPRForBranch('/repo-root', 'feature/test', 77)
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(pr).toMatchObject({ number: 77, title: 'Linked PR lookup' })
+  })
+
+  it('coalesces and caches empty merge-commit association lookups across worktree paths', async () => {
+    let resolveAssociatedPRs: (value: { stdout: string }) => void
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAssociatedPRs = resolve
+        })
+    )
+
+    const firstLookup = getPRForBranch('/repo-root-a', '', null, null, null, {
+      currentHeadOid: 'eeeeeeee'
+    })
+    const secondLookup = getPRForBranch('/repo-root-b', '', null, null, null, {
+      currentHeadOid: 'eeeeeeee'
+    })
+    await vi.waitFor(() => expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1))
+    resolveAssociatedPRs!({ stdout: JSON.stringify([]) })
+
+    await expect(Promise.all([firstLookup, secondLookup])).resolves.toEqual([null, null])
+    await expect(
+      getPRForBranch('/repo-root-c', '', null, null, null, {
+        currentHeadOid: 'eeeeeeee'
+      })
+    ).resolves.toBeNull()
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('coalesces positive merge-commit association hydration across worktree paths', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 94,
+            title: 'Merged by shared commit association',
+            state: 'closed',
+            merged_at: '2026-06-22T04:53:05Z',
+            merge_commit_sha: 'eeeeeeee',
+            html_url: 'https://github.com/acme/widgets/pull/94',
+            updated_at: '2026-06-22T04:53:05Z',
+            draft: false,
+            head: { ref: 'feature/shared', sha: 'shared-pr-head-oid' },
+            base: { ref: 'main', sha: 'base-oid' }
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 94,
+          title: 'Hydrated shared merge commit PR',
+          state: 'MERGED',
+          url: 'https://github.com/acme/widgets/pull/94',
+          statusCheckRollup: [],
+          updatedAt: '2026-06-22T04:53:05Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'feature/shared',
+          baseRefOid: 'base-oid',
+          headRefOid: 'shared-pr-head-oid'
+        })
+      })
+
+    const firstLookup = getPRForBranch('/repo-root-a', '', null, null, null, {
+      currentHeadOid: 'eeeeeeee'
+    })
+    const secondLookup = getPRForBranch('/repo-root-b', '', null, null, null, {
+      currentHeadOid: 'eeeeeeee'
+    })
+
+    await expect(Promise.all([firstLookup, secondLookup])).resolves.toEqual([
+      expect.objectContaining({ number: 94, title: 'Hydrated shared merge commit PR' }),
+      expect.objectContaining({ number: 94, title: 'Hydrated shared merge commit PR' })
+    ])
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('does not use invalid current HEAD hints for merge-commit lookup', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await expect(
+      getPRForBranch('/repo-root', '', null, null, null, {
+        currentHeadOid: '(initial)'
+      })
+    ).resolves.toBeNull()
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['rev-parse', 'HEAD'], { cwd: '/repo-root' })
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps unproven merge-commit 404s distinct from no-pr misses', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'dddddddd\n', stderr: '' })
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 404: Not Found'))
+
+    const outcome = await getPRForBranchOutcome('/repo-root', '')
+
+    expect(outcome).toMatchObject({
+      kind: 'upstream-error',
+      errorType: 'repo_unavailable'
+    })
+  })
+
   it('treats a merged branch lookup as a miss before using a fallback PR number', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
@@ -1218,11 +1568,13 @@ describe('getPRForBranch', () => {
     getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'existing\0\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '1111111\n', stderr: '' })
       .mockResolvedValueOnce({
         stdout: 'existing\0\nnew-feature\0origin/contributor/original\n',
         stderr: ''
       })
     ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({
@@ -1398,8 +1750,10 @@ describe('getPRForBranch', () => {
       .mockResolvedValueOnce('/repo-root/.git/config\u0000mtime-b\u0000120')
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'feature\0\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '2222222\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: 'feature\0origin/contributor/original\n', stderr: '' })
     ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({
@@ -1460,8 +1814,10 @@ describe('getPRForBranch', () => {
       .mockResolvedValueOnce('/repo-root/.git/config\u0000mtime-b\u0000120')
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'feature\0origin/old-upstream\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '2222222\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: 'feature\0origin/contributor/original\n', stderr: '' })
     ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
@@ -1507,8 +1863,10 @@ describe('getPRForBranch', () => {
       .mockResolvedValueOnce('/repo-root/.git/config\u0000mtime-b\u0000120')
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'feature\0\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '2222222\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: 'feature\0origin/contributor/original\n', stderr: '' })
     ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
       .mockResolvedValueOnce({
@@ -1942,28 +2300,34 @@ describe('getPRForBranch', () => {
     await getPRForBranch('/remote/repo-root', 'feature', undefined, 'ssh-1')
     await getPRForBranch('/remote/repo-root', 'feature', undefined, 'ssh-1')
 
-    expect(sshGitProvider.exec).toHaveBeenCalledTimes(1)
+    const trackedUpstreamCalls = sshGitProvider.exec.mock.calls.filter(([args]) =>
+      (args as string[]).includes('refs/heads')
+    )
+    expect(trackedUpstreamCalls).toHaveLength(1)
   })
 
   it('refreshes positive tracked-upstream entries for unsigned SSH runtimes after the TTL', async () => {
     vi.useFakeTimers()
     try {
+      let trackedProbeCount = 0
       const sshGitProvider = {
-        exec: vi
-          .fn()
-          .mockResolvedValueOnce({
-            stdout: 'refs/heads/feature\0origin/old-upstream\n',
-            stderr: ''
-          })
-          .mockResolvedValueOnce({
-            stdout: 'refs/heads/feature\0origin/contributor/original\n',
-            stderr: ''
-          })
+        exec: vi.fn(async (args: string[]) => {
+          if (args.includes('refs/heads')) {
+            trackedProbeCount += 1
+            const stdout =
+              trackedProbeCount === 1
+                ? 'refs/heads/feature\0origin/old-upstream\n'
+                : 'refs/heads/feature\0origin/contributor/original\n'
+            return { stdout, stderr: '' }
+          }
+          return { stdout: '3333333\n', stderr: '' }
+        })
       }
       getSshGitProviderMock.mockReturnValue(sshGitProvider)
       getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
       getOwnerRepoForRemoteMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
       ghExecFileAsyncMock
+        .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
         .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
         .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
         .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
@@ -1987,7 +2351,10 @@ describe('getPRForBranch', () => {
       await vi.advanceTimersByTimeAsync(30_001)
       const pr = await getPRForBranch('/remote/repo-root', 'feature', undefined, 'ssh-1')
 
-      expect(sshGitProvider.exec).toHaveBeenCalledTimes(2)
+      const trackedUpstreamCalls = sshGitProvider.exec.mock.calls.filter(([args]) =>
+        (args as string[]).includes('refs/heads')
+      )
+      expect(trackedUpstreamCalls).toHaveLength(2)
       expect(pr).toMatchObject({
         number: 81,
         title: 'Fresh SSH upstream PR'

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2460,6 +2460,13 @@ async function probeCommitAssociatedPRForRepo(args: {
     cacheCommitAssociatedPRResult(args.cacheKey, result)
     return result
   } catch (err) {
+    if (isMissingCommitAssociatedPRError(err)) {
+      // Why: local/unpushed commits commonly do not exist in GitHub yet; that is
+      // an empty association, not a PR refresh failure.
+      const result: Extract<CommitAssociatedPRProbeResult, { kind: 'empty' }> = { kind: 'empty' }
+      cacheCommitAssociatedPRResult(args.cacheKey, result)
+      return result
+    }
     if (!isNotFoundGhError(err)) {
       throw err
     }
@@ -2932,6 +2939,11 @@ function isNotFoundGhError(err: unknown): boolean {
   return classifyGhError(stderr).type === 'not_found'
 }
 
+function isMissingCommitAssociatedPRError(err: unknown): boolean {
+  const stderr = err instanceof Error ? err.message : String(err)
+  return /no commit found for sha/i.test(stderr) && /http 422/i.test(stderr)
+}
+
 function shouldStopAfterExactLookupError(err: unknown): boolean {
   const stderr = err instanceof Error ? err.message : String(err)
   const type = classifyGhError(stderr).type
@@ -2997,12 +3009,15 @@ export async function getPRForBranchOutcome(
     let currentHeadOidResolved = false
     let acceptedByExactMergeCommit = false
     const accessibleRepos = new Set<string>()
+    const explicitCurrentHeadOid = isUsableHeadOid(options.currentHeadOid ?? null)
+      ? (options.currentHeadOid ?? null)
+      : null
 
     const getCurrentHeadOidForLookup = async (): Promise<string | null> => {
       if (!currentHeadOidResolved) {
-        currentHeadOidForMergedImplicit = isUsableHeadOid(options.currentHeadOid ?? null)
-          ? (options.currentHeadOid ?? null)
-          : await getCurrentHeadOid(repoPath, connectionId, localGitOptions)
+        currentHeadOidForMergedImplicit =
+          explicitCurrentHeadOid ??
+          (await getCurrentHeadOid(repoPath, connectionId, localGitOptions))
         currentHeadOidResolved = true
       }
       return currentHeadOidForMergedImplicit ?? null
@@ -3106,11 +3121,10 @@ export async function getPRForBranchOutcome(
       dataHeadRepo = headRepo
     }
     if (!data && typeof linkedPRNumber !== 'number') {
-      currentHeadOidForMergedImplicit = await getCurrentHeadOidForLookup()
-      if (isUsableHeadOid(currentHeadOidForMergedImplicit) && candidates.length > 0) {
+      if (explicitCurrentHeadOid && candidates.length > 0) {
         const mergeCommitLookup = await lookupPRByMergeCommit({
           candidates,
-          headOid: currentHeadOidForMergedImplicit,
+          headOid: explicitCurrentHeadOid,
           ghOptions,
           repoPath,
           connectionId,

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1979,6 +1979,7 @@ type RestPullRequest = {
   updated_at?: string
   draft?: boolean
   merged_at?: string | null
+  merge_commit_sha?: string | null
   mergeable?: boolean | null
   mergeable_state?: string | null
   base?: { ref?: string; sha?: string }
@@ -1995,9 +1996,31 @@ const GITHUB_AUTO_MERGE_METHODS: Record<GitHubPRMergeMethod, 'MERGE' | 'SQUASH' 
   squash: 'SQUASH',
   rebase: 'REBASE'
 }
+const COMMIT_ASSOCIATED_PR_POSITIVE_CACHE_TTL_MS = 30_000
+const COMMIT_ASSOCIATED_PR_EMPTY_CACHE_TTL_MS = 5_000
+const COMMIT_ASSOCIATED_PR_CACHE_MAX_ENTRIES = 256
+
+type CommitAssociatedPRProbeResult =
+  | { kind: 'match'; pr: RestPullRequest }
+  | { kind: 'empty' }
+  | { kind: 'inconclusive' }
+
+const commitAssociatedPRCache = new Map<
+  string,
+  { value: Extract<CommitAssociatedPRProbeResult, { kind: 'match' | 'empty' }>; expiresAt: number }
+>()
+const commitAssociatedPRInFlight = new Map<string, Promise<CommitAssociatedPRProbeResult>>()
+const commitAssociatedPRHydrationInFlight = new Map<string, Promise<PullRequestLookupData>>()
+
+export function __resetCommitAssociatedPRCacheForTests(): void {
+  commitAssociatedPRCache.clear()
+  commitAssociatedPRInFlight.clear()
+  commitAssociatedPRHydrationInFlight.clear()
+}
 
 export type GitHubPRBranchLookupOptions = HostedReviewExecutionOptions & {
   acceptMergedFallbackPR?: boolean
+  currentHeadOid?: string | null
 }
 
 function mapRestPRMergeable(pr: RestPullRequest): PRMergeableState {
@@ -2326,6 +2349,201 @@ function prOwnerRepoKey(ownerRepo: OwnerRepo): string {
   return `${ownerRepo.owner.toLowerCase()}/${ownerRepo.repo.toLowerCase()}`
 }
 
+function pruneCommitAssociatedPRCache(now = Date.now()): void {
+  for (const [cacheKey, cached] of commitAssociatedPRCache) {
+    if (cached.expiresAt <= now) {
+      commitAssociatedPRCache.delete(cacheKey)
+    }
+  }
+  while (commitAssociatedPRCache.size > COMMIT_ASSOCIATED_PR_CACHE_MAX_ENTRIES) {
+    const oldestKey = commitAssociatedPRCache.keys().next().value
+    if (oldestKey === undefined) {
+      break
+    }
+    commitAssociatedPRCache.delete(oldestKey)
+  }
+}
+
+function commitAssociatedPRCacheKey(args: {
+  connectionId?: string | null
+  localGitOptions: { wslDistro?: string }
+  ownerRepo: OwnerRepo
+  headOid: string
+}): string {
+  const runtimeKey = args.connectionId
+    ? `ssh:${args.connectionId}`
+    : `local:${args.localGitOptions.wslDistro ?? 'host'}`
+  return [runtimeKey, prOwnerRepoKey(args.ownerRepo), args.headOid].join('\0')
+}
+
+function cacheCommitAssociatedPRResult(
+  cacheKey: string,
+  value: Extract<CommitAssociatedPRProbeResult, { kind: 'match' | 'empty' }>
+): void {
+  const now = Date.now()
+  const ttl =
+    value.kind === 'match'
+      ? COMMIT_ASSOCIATED_PR_POSITIVE_CACHE_TTL_MS
+      : COMMIT_ASSOCIATED_PR_EMPTY_CACHE_TTL_MS
+  pruneCommitAssociatedPRCache(now)
+  commitAssociatedPRCache.delete(cacheKey)
+  commitAssociatedPRCache.set(cacheKey, { value, expiresAt: now + ttl })
+  pruneCommitAssociatedPRCache(now)
+}
+
+function isUsableHeadOid(headOid: string | null): headOid is string {
+  return Boolean(headOid && /^[0-9a-f]{7,64}$/i.test(headOid) && !/^0+$/.test(headOid))
+}
+
+function isExactMergedCommitPR(pr: RestPullRequest, headOid: string): boolean {
+  if (pr.merge_commit_sha !== headOid) {
+    return false
+  }
+  return Boolean(pr.merged_at) || mapPRState(pr.state, pr.draft) === 'merged'
+}
+
+async function lookupCommitAssociatedPRForRepo(args: {
+  ownerRepo: OwnerRepo
+  headOid: string
+  ghOptions: GhExecOptions
+  repoAccessProven: boolean
+  cacheKey: string
+}): Promise<CommitAssociatedPRProbeResult> {
+  const now = Date.now()
+  pruneCommitAssociatedPRCache(now)
+  const cached = commitAssociatedPRCache.get(args.cacheKey)
+  if (cached && cached.expiresAt > now) {
+    return cached.value
+  }
+  if (cached) {
+    commitAssociatedPRCache.delete(args.cacheKey)
+  }
+
+  const inFlight = commitAssociatedPRInFlight.get(args.cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  // Why: many worktrees can sit on the same merge commit during polling; share
+  // GitHub's commit-association probe without extending stale "no PR" states.
+  const probe = probeCommitAssociatedPRForRepo(args)
+  commitAssociatedPRInFlight.set(args.cacheKey, probe)
+  try {
+    return await probe
+  } finally {
+    if (commitAssociatedPRInFlight.get(args.cacheKey) === probe) {
+      commitAssociatedPRInFlight.delete(args.cacheKey)
+    }
+  }
+}
+
+async function probeCommitAssociatedPRForRepo(args: {
+  ownerRepo: OwnerRepo
+  headOid: string
+  ghOptions: GhExecOptions
+  repoAccessProven: boolean
+  cacheKey: string
+}): Promise<CommitAssociatedPRProbeResult> {
+  try {
+    const { stdout } = await ghExecFileAsync(
+      [
+        'api',
+        `repos/${args.ownerRepo.owner}/${args.ownerRepo.repo}/commits/${args.headOid}/pulls?per_page=100`
+      ],
+      args.ghOptions
+    )
+    const list = JSON.parse(stdout) as RestPullRequest[]
+    const match = list.find((pr) => isExactMergedCommitPR(pr, args.headOid))
+    const result: Extract<CommitAssociatedPRProbeResult, { kind: 'match' | 'empty' }> = match
+      ? { kind: 'match', pr: match }
+      : { kind: 'empty' }
+    cacheCommitAssociatedPRResult(args.cacheKey, result)
+    return result
+  } catch (err) {
+    if (!isNotFoundGhError(err)) {
+      throw err
+    }
+    if (!args.repoAccessProven) {
+      return { kind: 'inconclusive' }
+    }
+    const result: Extract<CommitAssociatedPRProbeResult, { kind: 'empty' }> = { kind: 'empty' }
+    cacheCommitAssociatedPRResult(args.cacheKey, result)
+    return result
+  }
+}
+
+async function lookupPRByMergeCommit(args: {
+  candidates: OwnerRepo[]
+  headOid: string
+  ghOptions: GhExecOptions
+  repoPath: string
+  connectionId?: string | null
+  localGitOptions: { wslDistro?: string }
+  accessibleRepos: Set<string>
+}): Promise<{ data: PullRequestLookupData | null; dataRepo: OwnerRepo | null }> {
+  let sawInconclusiveCandidate = false
+  for (const candidate of args.candidates) {
+    const cacheKey = commitAssociatedPRCacheKey({
+      connectionId: args.connectionId,
+      localGitOptions: args.localGitOptions,
+      ownerRepo: candidate,
+      headOid: args.headOid
+    })
+    const probe = await lookupCommitAssociatedPRForRepo({
+      ownerRepo: candidate,
+      headOid: args.headOid,
+      ghOptions: args.ghOptions,
+      repoAccessProven: args.accessibleRepos.has(prOwnerRepoKey(candidate)),
+      cacheKey
+    })
+    if (probe.kind === 'inconclusive') {
+      sawInconclusiveCandidate = true
+      continue
+    }
+    if (probe.kind === 'empty') {
+      continue
+    }
+
+    const restData = mapRestPullRequest(probe.pr)
+    const data = await hydrateCommitAssociatedPR({
+      ownerRepo: candidate,
+      restData,
+      ghOptions: args.ghOptions,
+      cacheKey
+    })
+    return { data, dataRepo: candidate }
+  }
+  if (sawInconclusiveCandidate) {
+    throw new Error('HTTP 404: GitHub commit-associated pull request lookup was inconclusive')
+  }
+  return { data: null, dataRepo: null }
+}
+
+async function hydrateCommitAssociatedPR(args: {
+  ownerRepo: OwnerRepo
+  restData: PullRequestLookupData
+  ghOptions: GhExecOptions
+  cacheKey: string
+}): Promise<PullRequestLookupData> {
+  const hydrationKey = `${args.cacheKey}\0pr:${args.restData.number}`
+  const inFlight = commitAssociatedPRHydrationInFlight.get(hydrationKey)
+  if (inFlight) {
+    return inFlight
+  }
+  const hydrate = (async () => {
+    const hydratedData = await getPRByNumber(args.ownerRepo, args.restData.number, args.ghOptions)
+    return hydratedData ?? args.restData
+  })()
+  commitAssociatedPRHydrationInFlight.set(hydrationKey, hydrate)
+  try {
+    return await hydrate
+  } finally {
+    if (commitAssociatedPRHydrationInFlight.get(hydrationKey) === hydrate) {
+      commitAssociatedPRHydrationInFlight.delete(hydrationKey)
+    }
+  }
+}
+
 function shouldRetryTrackedUpstreamBranch(
   upstreamBranch: TrackedUpstreamBranch,
   branchName: string,
@@ -2551,6 +2769,7 @@ async function lookupPRByBranchName(args: {
   headRepo: OwnerRepo | null
   branchName: string
   ghOptions: GhExecOptions
+  accessibleRepos?: Set<string>
 }): Promise<{ data: PullRequestLookupData | null; dataRepo: OwnerRepo | null }> {
   if (args.candidates.length > 0) {
     for (const candidate of args.candidates) {
@@ -2563,6 +2782,7 @@ async function lookupPRByBranchName(args: {
               args.ghOptions
             )
           : await getFallbackPRListForBranch(candidate, args.branchName, args.ghOptions)
+        args.accessibleRepos?.add(prOwnerRepoKey(candidate))
         // Why: REST/list branch lookup identifies the PR cheaply; exact
         // `gh pr view` carries review, merge queue, and auto-merge state.
         const data = await hydrateBranchLookupWithExactPR(candidate, branchData, args.ghOptions)
@@ -2579,6 +2799,7 @@ async function lookupPRByBranchName(args: {
           args.branchName,
           args.ghOptions
         )
+        args.accessibleRepos?.add(prOwnerRepoKey(candidate))
         const data = await hydrateBranchLookupWithExactPR(candidate, branchData, args.ghOptions)
         if (data) {
           return { data, dataRepo: candidate }
@@ -2665,6 +2886,7 @@ async function lookupPRByNumber(args: {
   candidates: OwnerRepo[]
   number: number
   ghOptions: ReturnType<typeof ghRepoExecOptions>
+  accessibleRepos?: Set<string>
 }): Promise<{ data: PullRequestLookupData | null; dataRepo: OwnerRepo | null }> {
   for (const candidate of args.candidates) {
     try {
@@ -2672,6 +2894,7 @@ async function lookupPRByNumber(args: {
       if (!linkedData) {
         continue
       }
+      args.accessibleRepos?.add(prOwnerRepoKey(candidate))
       return { data: linkedData, dataRepo: candidate }
     } catch (err) {
       if (shouldStopAfterExactLookupError(err)) {
@@ -2755,11 +2978,6 @@ export async function getPRForBranchOutcome(
 ): Promise<PRRefreshOutcome> {
   // Strip refs/heads/ prefix if present
   const branchName = branch.replace(/^refs\/heads\//, '')
-  // Why: detached HEAD cannot use branch lookup, but an exact linked/fallback
-  // PR number remains safe to query and keeps review state visible.
-  if (!branchName && typeof linkedPRNumber !== 'number' && typeof fallbackPRNumber !== 'number') {
-    return { kind: 'no-pr', fetchedAt: Date.now() }
-  }
   const localGitArgs = hostedReviewLocalGitOptionArgs(options)
   const localGitOptions = localGitArgs[0] ?? {}
   const context = githubRepoContext(repoPath, connectionId, localGitOptions)
@@ -2776,16 +2994,25 @@ export async function getPRForBranchOutcome(
     let dataRepo: OwnerRepo | null = null
     let dataHeadRepo: OwnerRepo | null = headRepo
     let currentHeadOidForMergedImplicit: string | null | undefined
+    let currentHeadOidResolved = false
+    let acceptedByExactMergeCommit = false
+    const accessibleRepos = new Set<string>()
+
+    const getCurrentHeadOidForLookup = async (): Promise<string | null> => {
+      if (!currentHeadOidResolved) {
+        currentHeadOidForMergedImplicit = isUsableHeadOid(options.currentHeadOid ?? null)
+          ? (options.currentHeadOid ?? null)
+          : await getCurrentHeadOid(repoPath, connectionId, localGitOptions)
+        currentHeadOidResolved = true
+      }
+      return currentHeadOidForMergedImplicit ?? null
+    }
 
     const hideMergedImplicitPR = async (candidate: PullRequestLookupData | null) => {
       if (!candidate || !isMergedImplicitPR(candidate, linkedPRNumber)) {
         return false
       }
-      currentHeadOidForMergedImplicit ??= await getCurrentHeadOid(
-        repoPath,
-        connectionId,
-        localGitOptions
-      )
+      currentHeadOidForMergedImplicit = await getCurrentHeadOidForLookup()
       return shouldHideMergedImplicitPR(candidate, linkedPRNumber, currentHeadOidForMergedImplicit)
     }
 
@@ -2793,7 +3020,8 @@ export async function getPRForBranchOutcome(
       const exactLookup = await lookupPRByNumber({
         candidates,
         number: linkedPRNumber,
-        ghOptions
+        ghOptions,
+        accessibleRepos
       })
       data = exactLookup.data
       dataRepo = exactLookup.dataRepo
@@ -2804,7 +3032,8 @@ export async function getPRForBranchOutcome(
         candidates,
         headRepo,
         branchName,
-        ghOptions
+        ghOptions,
+        accessibleRepos
       })
       data = branchLookup.data
       dataRepo = branchLookup.dataRepo
@@ -2833,7 +3062,8 @@ export async function getPRForBranchOutcome(
               candidates,
               headRepo: upstreamHeadRepo,
               branchName: upstreamBranch.branchName,
-              ghOptions
+              ghOptions,
+              accessibleRepos
             })
             data = upstreamLookup.data
             dataRepo = upstreamLookup.dataRepo
@@ -2855,15 +3085,47 @@ export async function getPRForBranchOutcome(
       const fallbackLookup = await lookupPRByNumber({
         candidates,
         number: fallbackPRNumber,
-        ghOptions
+        ghOptions,
+        accessibleRepos
       })
       data = fallbackLookup.data
       dataRepo = fallbackLookup.dataRepo
     }
+    let fallbackConfirmedMergedBranch =
+      typeof fallbackPRNumber === 'number' &&
+      mergedBranchLookupNumber === fallbackPRNumber &&
+      data?.number === fallbackPRNumber
+    if (
+      data &&
+      (await hideMergedImplicitPR(data)) &&
+      !fallbackConfirmedMergedBranch &&
+      options.acceptMergedFallbackPR !== true
+    ) {
+      data = null
+      dataRepo = null
+      dataHeadRepo = headRepo
+    }
+    if (!data && typeof linkedPRNumber !== 'number') {
+      currentHeadOidForMergedImplicit = await getCurrentHeadOidForLookup()
+      if (isUsableHeadOid(currentHeadOidForMergedImplicit) && candidates.length > 0) {
+        const mergeCommitLookup = await lookupPRByMergeCommit({
+          candidates,
+          headOid: currentHeadOidForMergedImplicit,
+          ghOptions,
+          repoPath,
+          connectionId,
+          localGitOptions,
+          accessibleRepos
+        })
+        data = mergeCommitLookup.data
+        dataRepo = mergeCommitLookup.dataRepo
+        acceptedByExactMergeCommit = Boolean(data)
+      }
+    }
     if (!data) {
       return { kind: 'no-pr', fetchedAt: Date.now() }
     }
-    const fallbackConfirmedMergedBranch =
+    fallbackConfirmedMergedBranch =
       typeof fallbackPRNumber === 'number' &&
       mergedBranchLookupNumber === fallbackPRNumber &&
       data.number === fallbackPRNumber
@@ -2873,6 +3135,7 @@ export async function getPRForBranchOutcome(
     if (
       (await hideMergedImplicitPR(data)) &&
       !fallbackConfirmedMergedBranch &&
+      !acceptedByExactMergeCommit &&
       options.acceptMergedFallbackPR !== true
     ) {
       return { kind: 'no-pr', fetchedAt: Date.now() }

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2898,10 +2898,10 @@ async function lookupPRByNumber(args: {
   for (const candidate of args.candidates) {
     try {
       const linkedData = await getPRByNumber(candidate, args.number, args.ghOptions)
+      args.accessibleRepos?.add(prOwnerRepoKey(candidate))
       if (!linkedData) {
         continue
       }
-      args.accessibleRepos?.add(prOwnerRepoKey(candidate))
       return { data: linkedData, dataRepo: candidate }
     } catch (err) {
       if (shouldStopAfterExactLookupError(err)) {

--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -747,6 +747,29 @@ describe('pr-refresh-coordinator', () => {
     )
   })
 
+  it('uses the latest coalesced worktree HEAD hint for queued refreshes', async () => {
+    const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValueOnce({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    reportVisiblePRRefreshCandidates([makeCandidate({ worktreeHead: '1111111' })], 1, 1)
+    reportVisiblePRRefreshCandidates([makeCandidate({ worktreeHead: '2222222' })], 2, 1)
+    await vi.runOnlyPendingTimersAsync()
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith(
+      '/repo',
+      'feature/test',
+      null,
+      null,
+      null,
+      { currentHeadOid: '2222222' }
+    )
+  })
+
   it('preserves coalesced aliases across visible follow-up refreshes', async () => {
     const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
     getPRForBranchOutcomeMock

--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -790,6 +790,32 @@ describe('pr-refresh-coordinator', () => {
     })
   })
 
+  it('does not coalesce detached refreshes for different worktree HEADs', async () => {
+    const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock
+      .mockResolvedValueOnce({ kind: 'no-pr', fetchedAt: Date.now() })
+      .mockResolvedValueOnce({ kind: 'no-pr', fetchedAt: Date.now() })
+
+    reportVisiblePRRefreshCandidates(
+      [
+        makeCandidate({ branch: '', worktreeHead: '1111111', cacheKey: '/repo::head::1111111' }),
+        makeCandidate({ branch: '', worktreeHead: '2222222', cacheKey: '/repo::head::2222222' })
+      ],
+      1,
+      1
+    )
+    await vi.runOnlyPendingTimersAsync()
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(2)
+    expect(getPRForBranchOutcomeMock).toHaveBeenNthCalledWith(1, '/repo', '', null, null, null, {
+      currentHeadOid: '1111111'
+    })
+    expect(getPRForBranchOutcomeMock).toHaveBeenNthCalledWith(2, '/repo', '', null, null, null, {
+      currentHeadOid: '2222222'
+    })
+  })
+
   it('accounts for the extra core probe on background PR refreshes', async () => {
     const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
     getPRForBranchOutcomeMock.mockResolvedValueOnce({

--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -790,6 +790,34 @@ describe('pr-refresh-coordinator', () => {
     })
   })
 
+  it('normalizes worktree HEAD hints before lookup and alias emission', async () => {
+    const { refreshPRNow } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValueOnce({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    await refreshPRNow(
+      makeCandidate({
+        branch: '',
+        worktreeHead: '  abcdef1  ',
+        cacheKey: '/repo::__detached_head__:abcdef1'
+      })
+    )
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', '', null, null, null, {
+      currentHeadOid: 'abcdef1'
+    })
+    expect(
+      sendMock.mock.calls.map(([, event]) => event).find((event) => event.outcome)?.aliases
+    ).toEqual([
+      expect.objectContaining({
+        cacheKey: '/repo::__detached_head__:abcdef1',
+        worktreeHead: 'abcdef1'
+      })
+    ])
+  })
+
   it('does not coalesce detached refreshes for different worktree HEADs', async () => {
     const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
     getPRForBranchOutcomeMock

--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -3,14 +3,19 @@ request timestamps, and follow-up scheduling against shared module state. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GitHubPRRefreshCandidate, PRInfo } from '../../shared/types'
 
-const { sendMock, getAllWebContentsMock, getPRForBranchOutcomeMock, getRateLimitMock } = vi.hoisted(
-  () => ({
-    sendMock: vi.fn(),
-    getAllWebContentsMock: vi.fn(),
-    getPRForBranchOutcomeMock: vi.fn(),
-    getRateLimitMock: vi.fn()
-  })
-)
+const {
+  sendMock,
+  getAllWebContentsMock,
+  getPRForBranchOutcomeMock,
+  getRateLimitMock,
+  noteRateLimitSpendMock
+} = vi.hoisted(() => ({
+  sendMock: vi.fn(),
+  getAllWebContentsMock: vi.fn(),
+  getPRForBranchOutcomeMock: vi.fn(),
+  getRateLimitMock: vi.fn(),
+  noteRateLimitSpendMock: vi.fn()
+}))
 
 vi.mock('electron', () => ({
   webContents: {
@@ -24,7 +29,7 @@ vi.mock('./client', () => ({
 
 vi.mock('./rate-limit', () => ({
   getRateLimit: getRateLimitMock,
-  noteRateLimitSpend: vi.fn(),
+  noteRateLimitSpend: noteRateLimitSpendMock,
   rateLimitGuard: vi.fn(() => ({ blocked: false }))
 }))
 
@@ -80,6 +85,7 @@ describe('pr-refresh-coordinator', () => {
     getAllWebContentsMock.mockReset()
     getPRForBranchOutcomeMock.mockReset()
     getRateLimitMock.mockReset()
+    noteRateLimitSpendMock.mockReset()
     getAllWebContentsMock.mockReturnValue([
       {
         id: 1,
@@ -768,6 +774,38 @@ describe('pr-refresh-coordinator', () => {
       null,
       { currentHeadOid: '2222222' }
     )
+  })
+
+  it('refreshes empty-branch candidates when a worktree HEAD hint exists', async () => {
+    const { refreshPRNow } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValueOnce({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    await refreshPRNow(makeCandidate({ branch: '', worktreeHead: 'abcdef1' }))
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', '', null, null, null, {
+      currentHeadOid: 'abcdef1'
+    })
+  })
+
+  it('accounts for the extra core probe on background PR refreshes', async () => {
+    const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValueOnce({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    reportVisiblePRRefreshCandidates([makeCandidate({ worktreeHead: 'abcdef1' })], 1, 1)
+    await vi.runOnlyPendingTimersAsync()
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(noteRateLimitSpendMock.mock.calls.map(([bucket]) => bucket)).toEqual([
+      'core',
+      'core',
+      'graphql'
+    ])
   })
 
   it('preserves coalesced aliases across visible follow-up refreshes', async () => {

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -34,7 +34,7 @@ type PRRefreshOutcomeObserver = (
 
 type PRBranchLookupCandidate = Pick<
   GitHubPRRefreshCandidate,
-  'localGitOptions' | 'linkedPRNumber' | 'fallbackPRNumber' | 'fallbackPRSource'
+  'localGitOptions' | 'linkedPRNumber' | 'fallbackPRNumber' | 'fallbackPRSource' | 'worktreeHead'
 >
 
 function shouldAcceptMergedFallbackPR(candidate: PRBranchLookupCandidate): boolean {
@@ -51,6 +51,9 @@ function hostedReviewOptionArgs(
   const options: GitHubPRBranchLookupOptions = {}
   if (candidate.localGitOptions?.wslDistro) {
     options.localGitExecOptions = { wslDistro: candidate.localGitOptions.wslDistro }
+  }
+  if (candidate.worktreeHead) {
+    options.currentHeadOid = candidate.worktreeHead
   }
   if (shouldAcceptMergedFallbackPR(candidate)) {
     options.acceptMergedFallbackPR = true
@@ -747,6 +750,9 @@ export function enqueuePRRefresh(
   const dueAt = freshDueAt ?? Date.now() + (reason === 'post-push' ? POST_PUSH_DELAY_MS : 0)
   if (existing) {
     existing.aliases.set(alias.cacheKey, alias)
+    // Why: visible refreshes can sit in the queue while git status advances.
+    // Keep the latest HEAD/cache hints without changing priority or timing.
+    existing.candidate = candidate
     diagnosticsCounters.coalesced += 1
     recordPRRefreshQueueDiagnostic('coalesced', reason)
     const shouldPromoteExisting =
@@ -760,7 +766,6 @@ export function enqueuePRRefresh(
       existing.dueAt = Math.min(existing.dueAt, dueAt)
       existing.queuedAt = nextQueueOrder()
       existing.activeDelayNotified = false
-      existing.candidate = candidate
       existing.windowId = windowId ?? existing.windowId
     }
   } else {

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -236,7 +236,12 @@ function validateCandidate(
   if (candidate.connectionId && candidate.connectionState === 'disconnected') {
     return 'disconnected'
   }
-  if (!candidate.branch && typeof candidate.linkedPRNumber !== 'number') {
+  if (
+    !candidate.branch &&
+    typeof candidate.linkedPRNumber !== 'number' &&
+    typeof candidate.fallbackPRNumber !== 'number' &&
+    !candidate.worktreeHead
+  ) {
     return 'fresh'
   }
   return null
@@ -463,10 +468,9 @@ function isMergeabilityPendingOutcome(outcome: PRRefreshOutcome): boolean {
 }
 
 function backgroundRefreshBuckets(): ('core' | 'graphql')[] {
-  // Why: branch refreshes prefer REST but can still fall back to `gh pr list`
-  // when local head-owner metadata is unavailable. Guard both buckets until the
-  // client exposes an exact per-lookup cost plan.
-  return ['core', 'graphql']
+  // Why: branch misses can now spend core on both branch and merge-commit REST
+  // probes; keep the coarse queue budget conservative until lookup cost is exact.
+  return ['core', 'core', 'graphql']
 }
 
 function noteBackgroundStart(): void {

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -178,6 +178,10 @@ function refreshKey(candidate: GitHubPRRefreshCandidate): string {
   if (typeof candidate.linkedPRNumber === 'number') {
     return `${connectionScope}::${runtimeScope}::${candidate.repoPath}::pr::${candidate.linkedPRNumber}`
   }
+  const detachedHead = candidate.branch ? null : candidate.worktreeHead?.trim()
+  if (detachedHead) {
+    return `${connectionScope}::${runtimeScope}::${candidate.repoPath}::head::${detachedHead}`
+  }
   return `${connectionScope}::${runtimeScope}::${candidate.repoPath}::branch::${candidate.branch}`
 }
 
@@ -236,6 +240,7 @@ function validateCandidate(
   if (candidate.connectionId && candidate.connectionState === 'disconnected') {
     return 'disconnected'
   }
+  // Why: detached worktrees can still resolve a PR from the checked-out merge commit.
   if (
     !candidate.branch &&
     typeof candidate.linkedPRNumber !== 'number' &&
@@ -281,6 +286,7 @@ function aliasFromCandidate(candidate: GitHubPRRefreshCandidate): GitHubPRRefres
     repoPath: candidate.repoPath,
     branch: candidate.branch,
     worktreeId: candidate.worktreeId,
+    worktreeHead: candidate.worktreeHead ?? null,
     connectionId: candidate.connectionId ?? null,
     linkedPRNumber: candidate.linkedPRNumber ?? null,
     fallbackPRNumber:

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -52,8 +52,9 @@ function hostedReviewOptionArgs(
   if (candidate.localGitOptions?.wslDistro) {
     options.localGitExecOptions = { wslDistro: candidate.localGitOptions.wslDistro }
   }
-  if (candidate.worktreeHead) {
-    options.currentHeadOid = candidate.worktreeHead
+  const worktreeHead = normalizedWorktreeHead(candidate.worktreeHead)
+  if (worktreeHead) {
+    options.currentHeadOid = worktreeHead
   }
   if (shouldAcceptMergedFallbackPR(candidate)) {
     options.acceptMergedFallbackPR = true
@@ -178,11 +179,16 @@ function refreshKey(candidate: GitHubPRRefreshCandidate): string {
   if (typeof candidate.linkedPRNumber === 'number') {
     return `${connectionScope}::${runtimeScope}::${candidate.repoPath}::pr::${candidate.linkedPRNumber}`
   }
-  const detachedHead = candidate.branch ? null : candidate.worktreeHead?.trim()
+  const detachedHead = candidate.branch ? null : normalizedWorktreeHead(candidate.worktreeHead)
   if (detachedHead) {
     return `${connectionScope}::${runtimeScope}::${candidate.repoPath}::head::${detachedHead}`
   }
   return `${connectionScope}::${runtimeScope}::${candidate.repoPath}::branch::${candidate.branch}`
+}
+
+function normalizedWorktreeHead(head: string | null | undefined): string | null {
+  const trimmed = head?.trim()
+  return trimmed ? trimmed : null
 }
 
 function isVisibleKey(key: string): boolean {
@@ -245,7 +251,7 @@ function validateCandidate(
     !candidate.branch &&
     typeof candidate.linkedPRNumber !== 'number' &&
     typeof candidate.fallbackPRNumber !== 'number' &&
-    !candidate.worktreeHead
+    !normalizedWorktreeHead(candidate.worktreeHead)
   ) {
     return 'fresh'
   }
@@ -286,7 +292,7 @@ function aliasFromCandidate(candidate: GitHubPRRefreshCandidate): GitHubPRRefres
     repoPath: candidate.repoPath,
     branch: candidate.branch,
     worktreeId: candidate.worktreeId,
-    worktreeHead: candidate.worktreeHead ?? null,
+    worktreeHead: normalizedWorktreeHead(candidate.worktreeHead),
     connectionId: candidate.connectionId ?? null,
     linkedPRNumber: candidate.linkedPRNumber ?? null,
     fallbackPRNumber:

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -282,6 +282,22 @@ describe('registerGitHubHandlers', () => {
     )
   })
 
+  it('trims current HEAD hints before invoking github clients', async () => {
+    getPRForBranchMock.mockResolvedValue(null)
+
+    registerGitHubHandlers(store as never, stats as never)
+
+    await handlers['gh:prForBranch'](null, {
+      repoPath: '/workspace/repo',
+      branch: '',
+      currentHeadOid: '  abcdef1  '
+    })
+
+    expect(getPRForBranchMock).toHaveBeenCalledWith('/workspace/repo', '', null, null, null, {
+      currentHeadOid: 'abcdef1'
+    })
+  })
+
   it('rejects unknown repository paths', async () => {
     registerGitHubHandlers(store as never, stats as never)
 

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -278,23 +278,24 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         linkedPRNumber?: number | null
         fallbackPRNumber?: number | null
         acceptMergedFallbackPR?: boolean
+        currentHeadOid?: string | null
       }
     ) => {
       const repo = assertRegisteredRepo(args, store)
       const localGitOptions = localGitOptionArgs(store, repo)[0]
       const hostedReviewOptionArgs: [] | [{ localGitExecOptions: { wslDistro?: string } }] =
         localGitOptions ? [{ localGitExecOptions: localGitOptions }] : []
-      const lookupOptions: GitHubPRBranchLookupOptions | undefined = hostedReviewOptionArgs[0]
+      const lookupOptions: GitHubPRBranchLookupOptions = hostedReviewOptionArgs[0]
         ? { ...hostedReviewOptionArgs[0] }
-        : args.acceptMergedFallbackPR === true
-          ? {}
-          : undefined
-      if (lookupOptions && args.acceptMergedFallbackPR === true) {
+        : {}
+      if (args.acceptMergedFallbackPR === true) {
         lookupOptions.acceptMergedFallbackPR = true
       }
-      const lookupOptionArgs: [] | [GitHubPRBranchLookupOptions] = lookupOptions
-        ? [lookupOptions]
-        : []
+      if (typeof args.currentHeadOid === 'string') {
+        lookupOptions.currentHeadOid = args.currentHeadOid
+      }
+      const lookupOptionArgs: [] | [GitHubPRBranchLookupOptions] =
+        Object.keys(lookupOptions).length > 0 ? [lookupOptions] : []
       const pr = await getPRForBranch(
         repo.path,
         args.branch,

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -291,8 +291,10 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
       if (args.acceptMergedFallbackPR === true) {
         lookupOptions.acceptMergedFallbackPR = true
       }
-      if (typeof args.currentHeadOid === 'string') {
-        lookupOptions.currentHeadOid = args.currentHeadOid
+      const currentHeadOid =
+        typeof args.currentHeadOid === 'string' ? args.currentHeadOid.trim() : ''
+      if (currentHeadOid) {
+        lookupOptions.currentHeadOid = currentHeadOid
       }
       const lookupOptionArgs: [] | [GitHubPRBranchLookupOptions] =
         Object.keys(lookupOptions).length > 0 ? [lookupOptions] : []

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -4244,6 +4244,16 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('passes runtime PR branch current HEAD hints through to GitHub lookup', async () => {
+    const runtime = new OrcaRuntimeService(store as never)
+
+    await runtime.getRepoPRForBranch('id:repo-1', '', null, null, false, 'abc1234')
+
+    expect(getPRForBranchMock).toHaveBeenCalledWith(TEST_REPO_PATH, '', null, null, null, {
+      currentHeadOid: 'abc1234'
+    })
+  })
+
   it('rejects hosted review worktree selectors outside the selected repo', async () => {
     vi.mocked(listWorktrees).mockImplementation(async (repoPath: string) => {
       if (repoPath === '/tmp/repo-b') {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10239,13 +10239,17 @@ export class OrcaRuntimeService {
     branch: string,
     linkedPRNumber?: number | null,
     fallbackPRNumber?: number | null,
-    acceptMergedFallbackPR?: boolean
+    acceptMergedFallbackPR?: boolean,
+    currentHeadOid?: string | null
   ): Promise<Awaited<ReturnType<typeof getPRForBranch>>> {
     const repo = await this.resolveRepoSelector(repoSelector)
     const options: GitHubPRBranchLookupOptions = this.getHostedReviewExecutionOptions(repo) ?? {}
     const lookupOptions = { ...options }
     if (acceptMergedFallbackPR === true) {
       lookupOptions.acceptMergedFallbackPR = true
+    }
+    if (typeof currentHeadOid === 'string') {
+      lookupOptions.currentHeadOid = currentHeadOid
     }
     const lookupOptionArgs: [] | [GitHubPRBranchLookupOptions] =
       Object.keys(lookupOptions).length > 0 ? [lookupOptions] : []

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -1,7 +1,12 @@
 /* eslint-disable max-lines -- Why: GitHub runtime RPC keeps related repo, project, and mutation schemas beside their handlers so the method contract stays reviewable in one place. */
 import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
-import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
+import {
+  OptionalFiniteNumber,
+  OptionalString,
+  requiredString,
+  requiredStringAllowingEmpty
+} from '../schemas'
 
 const RepoSelector = z.object({
   repo: requiredString('Missing repo selector')
@@ -50,10 +55,11 @@ const SlugAssignableUsers = SlugRepo.extend({
 })
 
 const PrForBranch = RepoSelector.extend({
-  branch: requiredString('Missing branch'),
+  branch: requiredStringAllowingEmpty('Missing branch'),
   linkedPRNumber: z.number().int().positive().nullable().optional(),
   fallbackPRNumber: z.number().int().positive().nullable().optional(),
-  acceptMergedFallbackPR: z.boolean().optional()
+  acceptMergedFallbackPR: z.boolean().optional(),
+  currentHeadOid: z.string().nullable().optional()
 })
 
 const Issue = RepoSelector.extend({
@@ -361,7 +367,8 @@ export const GITHUB_METHODS: RpcMethod[] = [
         params.branch,
         params.linkedPRNumber,
         params.fallbackPRNumber,
-        params.acceptMergedFallbackPR
+        params.acceptMergedFallbackPR,
+        params.currentHeadOid
       )
   }),
   defineMethod({

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -55,6 +55,7 @@ const SlugAssignableUsers = SlugRepo.extend({
 })
 
 const PrForBranch = RepoSelector.extend({
+  // Why: detached/merge-commit worktrees have no branch; currentHeadOid can still resolve PR context.
   branch: requiredStringAllowingEmpty('Missing branch'),
   linkedPRNumber: z.number().int().positive().nullable().optional(),
   fallbackPRNumber: z.number().int().positive().nullable().optional(),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1151,6 +1151,7 @@ export type PreloadApi = {
       linkedPRNumber?: number | null
       fallbackPRNumber?: number | null
       acceptMergedFallbackPR?: boolean
+      currentHeadOid?: string | null
     }) => Promise<PRInfo | null>
     refreshPRNow: (args: { candidate: GitHubPRRefreshCandidate }) => Promise<PRRefreshOutcome>
     enqueuePRRefresh: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -950,6 +950,7 @@ const api = {
       linkedPRNumber?: number | null
       fallbackPRNumber?: number | null
       acceptMergedFallbackPR?: boolean
+      currentHeadOid?: string | null
     }): Promise<unknown> => ipcRenderer.invoke('gh:prForBranch', args),
 
     refreshPRNow: (args: { candidate: GitHubPRRefreshCandidate }): Promise<unknown> =>

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ChecksPanelReviewHeader } from './ChecksPanel'
+import { ChecksPanelReviewHeader, shouldRunChecksPanelEntryRefresh } from './ChecksPanel'
 
 vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -111,5 +111,61 @@ describe('ChecksPanelReviewHeader', () => {
     expect(markup).not.toContain('More PR actions')
     expect(markup).not.toContain('unlink PR')
     expect(markup).not.toContain('Link another PR')
+  })
+})
+
+describe('shouldRunChecksPanelEntryRefresh', () => {
+  it('allows detached GitHub refreshes when the worktree has head identity', () => {
+    expect(
+      shouldRunChecksPanelEntryRefresh({
+        hasRepo: true,
+        hasReviewLookupIdentity: true,
+        activeWorktreeId: 'repo-1::C:/Users/neil/orca/workspaces/demo-project-6470-detached-24',
+        isGitLabReviewContext: false,
+        branch: ''
+      })
+    ).toBe(true)
+  })
+
+  it('keeps GitLab entry refreshes branch-scoped', () => {
+    expect(
+      shouldRunChecksPanelEntryRefresh({
+        hasRepo: true,
+        hasReviewLookupIdentity: true,
+        activeWorktreeId: 'wt-1',
+        isGitLabReviewContext: true,
+        branch: ''
+      })
+    ).toBe(false)
+  })
+
+  it('requires repo, active worktree, and review lookup identity', () => {
+    expect(
+      shouldRunChecksPanelEntryRefresh({
+        hasRepo: false,
+        hasReviewLookupIdentity: true,
+        activeWorktreeId: 'wt-1',
+        isGitLabReviewContext: false,
+        branch: ''
+      })
+    ).toBe(false)
+    expect(
+      shouldRunChecksPanelEntryRefresh({
+        hasRepo: true,
+        hasReviewLookupIdentity: false,
+        activeWorktreeId: 'wt-1',
+        isGitLabReviewContext: false,
+        branch: ''
+      })
+    ).toBe(false)
+    expect(
+      shouldRunChecksPanelEntryRefresh({
+        hasRepo: true,
+        hasReviewLookupIdentity: true,
+        activeWorktreeId: null,
+        isGitLabReviewContext: false,
+        branch: ''
+      })
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1164,7 +1164,7 @@ export default function ChecksPanel(): React.JSX.Element {
     [setPrTitle]
   )
   const stateRequestKey =
-    repo && branch
+    repo && hasReviewLookupIdentity
       ? activeGitLabReview
         ? checksPanelHostedReviewAsyncResultKey(
             hostedReviewCacheKey,
@@ -2141,7 +2141,7 @@ export default function ChecksPanel(): React.JSX.Element {
   // duplicate fetches from rapid show/hide toggles. See
   // docs/refresh-on-checks-tab.md.
   const entryKey =
-    isPanelVisible && repo && !isFolder && branch
+    isPanelVisible && repo && !isFolder && hasReviewLookupIdentity
       ? `${activeWorktreeId ?? ''}::${activeGitLabReview ? hostedReviewCacheKey : prCacheKey}`
       : ''
   const lastEntryKeyRef = useRef<string>('')

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -20,7 +20,11 @@ import {
   prChecksCacheSuffix,
   prCommentsCacheSuffix
 } from '@/store/slices/github'
-import { getGitHubPRCacheKey, getGitHubRepoCacheKey } from '@/store/slices/github-cache-key'
+import {
+  getGitHubPRCacheBranch,
+  getGitHubPRCacheKey,
+  getGitHubRepoCacheKey
+} from '@/store/slices/github-cache-key'
 import { useActiveWorktree, useRepoById } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import { openHttpLink } from '@/lib/http-link-routing'
@@ -599,12 +603,14 @@ export default function ChecksPanel(): React.JSX.Element {
 
   // Find active worktree and repo
   const isFolder = repo ? isFolderRepo(repo) : false
+  const prCacheBranch = getGitHubPRCacheBranch(branch, activeWorktree?.head)
+  const hasReviewLookupIdentity = Boolean(branch || activeWorktree?.head)
   const prCacheKey =
-    repo && branch
+    repo && hasReviewLookupIdentity
       ? getGitHubPRCacheKey(
           repo.path,
           repo.id,
-          branch,
+          prCacheBranch,
           settings,
           repo.connectionId,
           repo.executionHostId,
@@ -612,10 +618,10 @@ export default function ChecksPanel(): React.JSX.Element {
         )
       : ''
   const hostedReviewCacheKey =
-    repo && branch
+    repo && hasReviewLookupIdentity
       ? getHostedReviewCacheKey(
           repo.path,
-          branch,
+          prCacheBranch,
           settings,
           repo.id,
           repo.connectionId,
@@ -1186,17 +1192,19 @@ export default function ChecksPanel(): React.JSX.Element {
   }, [agentComposerState?.commentResolution, stateRequestKey])
 
   useEffect(() => {
-    if (isPanelVisible && repo && !isFolder && branch) {
-      void fetchHostedReviewForBranch(repo.path, branch, {
-        repoId: repo.id,
-        linkedGitHubPR: linkedPR,
-        fallbackGitHubPR: fallbackGitHubPRNumber,
-        linkedGitLabMR,
-        linkedBitbucketPR,
-        linkedAzureDevOpsPR,
-        linkedGiteaPR,
-        staleWhileRevalidate: true
-      })
+    if (isPanelVisible && repo && !isFolder && hasReviewLookupIdentity) {
+      if (branch) {
+        void fetchHostedReviewForBranch(repo.path, branch, {
+          repoId: repo.id,
+          linkedGitHubPR: linkedPR,
+          fallbackGitHubPR: fallbackGitHubPRNumber,
+          linkedGitLabMR,
+          linkedBitbucketPR,
+          linkedAzureDevOpsPR,
+          linkedGiteaPR,
+          staleWhileRevalidate: true
+        })
+      }
       if (activeWorktreeId && !isGitLabReviewContext) {
         enqueueGitHubPRRefresh(activeWorktreeId, 'swr', 30)
       }
@@ -1207,6 +1215,7 @@ export default function ChecksPanel(): React.JSX.Element {
     enqueueGitHubPRRefresh,
     fallbackGitHubPRNumber,
     fetchHostedReviewForBranch,
+    hasReviewLookupIdentity,
     isFolder,
     isGitLabReviewContext,
     isPanelVisible,
@@ -1834,7 +1843,7 @@ export default function ChecksPanel(): React.JSX.Element {
   }, [activeGitLabReview, fetchComments, isPanelVisible, prNumber, repo])
 
   const handleRefresh = useCallback(async () => {
-    if (!repo || !branch) {
+    if (!repo || !hasReviewLookupIdentity || (isGitLabReviewContext && !branch)) {
       return
     }
     const initialRequestKey = checksPanelAsyncResultKey(
@@ -1920,17 +1929,19 @@ export default function ChecksPanel(): React.JSX.Element {
       if (!isCurrentRequest()) {
         return
       }
-      await refreshHostedReviewCard(fetchHostedReviewForBranch, {
-        repoPath: repo.path,
-        repoId: repo.id,
-        branch,
-        linkedGitHubPR: linkedPR,
-        fallbackGitHubPR: refreshedPR?.number ?? fallbackGitHubPRNumber,
-        linkedGitLabMR,
-        linkedBitbucketPR,
-        linkedAzureDevOpsPR,
-        linkedGiteaPR
-      })
+      if (branch) {
+        await refreshHostedReviewCard(fetchHostedReviewForBranch, {
+          repoPath: repo.path,
+          repoId: repo.id,
+          branch,
+          linkedGitHubPR: linkedPR,
+          fallbackGitHubPR: refreshedPR?.number ?? fallbackGitHubPRNumber,
+          linkedGitLabMR,
+          linkedBitbucketPR,
+          linkedAzureDevOpsPR,
+          linkedGiteaPR
+        })
+      }
       if (!isCurrentRequest()) {
         return
       }
@@ -2057,6 +2068,7 @@ export default function ChecksPanel(): React.JSX.Element {
     linkedPR,
     fallbackGitHubPRNumber,
     fetchGitLabDetails,
+    hasReviewLookupIdentity,
     linkedAzureDevOpsPR,
     linkedBitbucketPR,
     linkedGiteaPR,

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -205,6 +205,25 @@ type ChecksPanelReviewHeaderProps = {
   onLinkAnotherPullRequest: () => void
 }
 
+export function shouldRunChecksPanelEntryRefresh({
+  hasRepo,
+  hasReviewLookupIdentity,
+  activeWorktreeId,
+  isGitLabReviewContext,
+  branch
+}: {
+  hasRepo: boolean
+  hasReviewLookupIdentity: boolean
+  activeWorktreeId: string | null | undefined
+  isGitLabReviewContext: boolean
+  branch: string
+}): boolean {
+  if (!hasRepo || !hasReviewLookupIdentity || !activeWorktreeId) {
+    return false
+  }
+  return !isGitLabReviewContext || branch.length > 0
+}
+
 export function ChecksPanelReviewHeader({
   review,
   isRefreshing,
@@ -502,7 +521,7 @@ export default function ChecksPanel(): React.JSX.Element {
   const gitStatusSnapshotRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const gitIdentityDisplay = activeWorktree ? getWorktreeGitIdentityDisplay(activeWorktree) : null
   const detachedHeadDisplay = gitIdentityDisplay?.kind === 'detached' ? gitIdentityDisplay : null
-  const branch = gitIdentityDisplay?.kind === 'branch' ? gitIdentityDisplay.branchName : ''
+  const branch = gitIdentityDisplay?.kind === 'branch' ? (gitIdentityDisplay.branchName ?? '') : ''
   const activeWorktreePath = activeWorktree?.path ?? null
   const activeWorktreePushTarget = activeWorktree?.pushTarget ?? null
   const activeSourceControlLaunchPlatform = resolveSourceControlLaunchPlatform({
@@ -2084,7 +2103,20 @@ export default function ChecksPanel(): React.JSX.Element {
 
   const handleEntryRefresh = useCallback(
     (options: { refreshChecks: boolean; refreshComments: boolean }) => {
-      if (!repo || !branch || !activeWorktreeId) {
+      const refreshRepo = repo
+      const refreshWorktreeId = activeWorktreeId
+      if (
+        !shouldRunChecksPanelEntryRefresh({
+          hasRepo: Boolean(refreshRepo),
+          hasReviewLookupIdentity,
+          activeWorktreeId: refreshWorktreeId,
+          isGitLabReviewContext,
+          branch
+        })
+      ) {
+        return
+      }
+      if (!refreshRepo || !refreshWorktreeId) {
         return
       }
       // Why: entering the Checks tab is automatic UI behavior, not an explicit
@@ -2092,9 +2124,12 @@ export default function ChecksPanel(): React.JSX.Element {
       // guards still apply; only force detail panes that the entry freshness rule
       // already proved stale, so tab entry stays fresh without broad fan-out.
       if (isGitLabReviewContext) {
-        void fetchHostedReviewForBranch(repo.path, branch, {
+        if (!branch) {
+          return
+        }
+        void fetchHostedReviewForBranch(refreshRepo.path, branch, {
           force: true,
-          repoId: repo.id,
+          repoId: refreshRepo.id,
           linkedGitHubPR: linkedPR,
           fallbackGitHubPR: fallbackGitHubPRNumber,
           linkedGitLabMR,
@@ -2107,7 +2142,7 @@ export default function ChecksPanel(): React.JSX.Element {
         }
         return
       }
-      enqueueGitHubPRRefresh(activeWorktreeId, 'active', 80)
+      enqueueGitHubPRRefresh(refreshWorktreeId, 'active', 80)
       if (options.refreshChecks) {
         void fetchChecks({ force: true })
       }
@@ -2125,6 +2160,7 @@ export default function ChecksPanel(): React.JSX.Element {
       fetchComments,
       fetchGitLabDetails,
       fetchHostedReviewForBranch,
+      hasReviewLookupIdentity,
       isGitLabReviewContext,
       linkedAzureDevOpsPR,
       linkedBitbucketPR,

--- a/src/renderer/src/components/right-sidebar/active-checks-status.test.ts
+++ b/src/renderer/src/components/right-sidebar/active-checks-status.test.ts
@@ -38,6 +38,29 @@ describe('getActiveChecksStatus', () => {
     expect(getActiveChecksStatus(state)).toBe('success')
   })
 
+  it('uses detached-head PR cache entries for active checks status', () => {
+    const state = {
+      activeWorktreeId: 'wt-1',
+      repos: [{ id: 'repo-1', path: '/repo' }],
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'wt-1',
+            repoId: 'repo-1',
+            branch: '',
+            head: 'abc1234'
+          }
+        ]
+      },
+      prCache: {
+        'repo-1::__detached_head__:abc1234': { data: makePR('failure'), fetchedAt: 2 },
+        'repo-1::': { data: makePR('success'), fetchedAt: 999 }
+      }
+    } as unknown as Pick<AppState, 'activeWorktreeId' | 'repos' | 'worktreesByRepo' | 'prCache'>
+
+    expect(getActiveChecksStatus(state)).toBe('failure')
+  })
+
   it('uses GitLab MR pipeline status when the active branch has no GitHub PR cache entry', () => {
     const state = {
       activeWorktreeId: 'wt-1',

--- a/src/renderer/src/components/right-sidebar/active-checks-status.ts
+++ b/src/renderer/src/components/right-sidebar/active-checks-status.ts
@@ -1,7 +1,7 @@
 import type { AppState } from '../../store/types'
 import { getRepoMapFromState, getWorktreeMapFromState } from '../../store/selectors'
 import type { CheckStatus } from '../../../../shared/types'
-import { getGitHubPRCacheKey } from '../../store/slices/github-cache-key'
+import { getGitHubPRCacheBranch, getGitHubPRCacheKey } from '../../store/slices/github-cache-key'
 import { getHostedReviewCacheKey } from '../../store/slices/hosted-review-cache-identity'
 
 type ActiveChecksStatusState = Pick<
@@ -28,16 +28,17 @@ export function getActiveChecksStatus(state: ActiveChecksStatusState): CheckStat
   }
 
   const branch = branchDisplayName(activeWorktree.branch)
-  if (!branch) {
+  if (!branch && !activeWorktree.head) {
     return null
   }
+  const prCacheBranch = getGitHubPRCacheBranch(branch, activeWorktree.head)
 
   // Why: PR refreshes are written under repo-id scoped keys so repo path
   // changes and legacy duplicates cannot leave the activity indicator stale.
   const prCacheKey = getGitHubPRCacheKey(
     activeRepo.path,
     activeRepo.id,
-    branch,
+    prCacheBranch,
     state.settings,
     activeRepo.connectionId,
     activeRepo.executionHostId,
@@ -45,7 +46,7 @@ export function getActiveChecksStatus(state: ActiveChecksStatusState): CheckStat
   )
   const hostedReviewCacheKey = getHostedReviewCacheKey(
     activeRepo.path,
-    branch,
+    prCacheBranch,
     state.settings,
     activeRepo.id,
     activeRepo.connectionId,

--- a/src/renderer/src/components/sidebar/WorktreeCard.branch-review-pending.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.branch-review-pending.test.tsx
@@ -155,4 +155,16 @@ describe('WorktreeCard branch review lookup pending state', () => {
     expect(markup).toContain('Branch')
     expect(markup).toContain('lucide-git-branch')
   })
+
+  it('keeps branch status on pathname-detected paired web clients', async () => {
+    vi.stubGlobal('window', { location: { pathname: '/web-index.html' } })
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).toContain('Branch')
+    expect(markup).toContain('lucide-git-branch')
+  })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.branch-review-pending.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.branch-review-pending.test.tsx
@@ -1,0 +1,158 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings, Repo, Worktree, WorktreeCardProperty } from '../../../../shared/types'
+
+const fetchHostedReviewForBranch = vi.fn()
+const fetchIssue = vi.fn()
+const fetchLinearIssue = vi.fn()
+const openModal = vi.fn()
+const updateWorktreeMeta = vi.fn()
+
+let hostedReviewCache: Record<string, unknown> = {}
+let settings: Partial<GlobalSettings> | null = null
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      deleteStateByWorktreeId: {},
+      fetchHostedReviewForBranch,
+      fetchIssue,
+      fetchLinearIssue,
+      gitConflictOperationByWorktree: {},
+      hostedReviewCache,
+      issueCache: {},
+      linearIssueCache: {},
+      openModal,
+      prCache: {},
+      projectGroups: [],
+      remoteBranchConflictByWorktreeId: {},
+      settings,
+      sshConnectionStates: new Map(),
+      sshTargetLabels: new Map(),
+      updateWorktreeMeta,
+      workspacePortScan: null,
+      worktreeCardProperties: ['status'] satisfies WorktreeCardProperty[]
+    })
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('./use-worktree-activity-status', () => ({
+  useWorktreeActivityStatus: () => 'active'
+}))
+
+vi.mock('./CacheTimer', () => ({
+  default: () => null,
+  usePromptCacheCountdownStartedAt: () => null
+}))
+
+vi.mock('./WorktreeCardAgents', () => ({
+  default: () => null
+}))
+
+vi.mock('./SshDisconnectedDialog', () => ({
+  SshDisconnectedDialog: () => null
+}))
+
+vi.mock('./WorktreeContextMenu', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+  CLOSE_ALL_CONTEXT_MENUS_EVENT: 'orca:test-close-context-menus',
+  WORKTREE_NATIVE_CONTEXT_MENU_ATTR: 'data-worktree-native-context-menu',
+  WORKTREE_CONTEXT_MENU_SCOPE_ATTR: 'data-orca-context-menu-scope'
+}))
+
+function makeRepo(): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'orca',
+    badgeColor: '#999999',
+    addedAt: 1
+  }
+}
+
+function makeWorktree(): Worktree {
+  return {
+    id: 'repo-1::/repo/worktrees/pr-456',
+    repoId: 'repo-1',
+    path: '/repo/worktrees/pr-456',
+    displayName: 'feature/local-branch',
+    branch: 'feature/local-branch',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1
+  }
+}
+
+function renderWorktreeCardMarkup(element: ReactNode): string {
+  return renderToStaticMarkup(<>{element}</>)
+}
+
+describe('WorktreeCard branch review lookup pending state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    hostedReviewCache = {}
+    settings = { experimentalNewWorktreeCardStyle: true }
+  })
+
+  it('does not show branch status before branch-discovered PR lookup resolves', async () => {
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).toContain('Active')
+    expect(markup).not.toContain('Branch')
+    expect(markup).not.toContain('lucide-git-branch')
+  })
+
+  it('restores branch status after branch-discovered PR lookup resolves with no PR', async () => {
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: null,
+        fetchedAt: Date.now(),
+        linkedReviewHintKey: ''
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).toContain('Branch')
+    expect(markup).toContain('lucide-git-branch')
+  })
+
+  it('keeps branch status on paired web where passive review lookup is disabled', async () => {
+    vi.stubGlobal('window', { __ORCA_WEB_CLIENT__: true })
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).toContain('Branch')
+    expect(markup).toContain('lucide-git-branch')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type {
   GlobalSettings,
   PRInfo,
@@ -118,6 +119,21 @@ function makePRInfo(overrides: Partial<PRInfo> = {}): PRInfo {
     state: 'merged',
     url: 'https://github.com/acme/orca/pull/6340',
     checksStatus: 'success',
+    updatedAt: '2026-05-17T00:00:00.000Z',
+    mergeable: 'MERGEABLE',
+    headSha: 'abc123',
+    ...overrides
+  }
+}
+
+function makeHostedReview(overrides: Partial<HostedReviewInfo> = {}): HostedReviewInfo {
+  return {
+    provider: 'github',
+    number: 6340,
+    title: 'Merged PR still checked out',
+    state: 'merged',
+    url: 'https://github.com/acme/orca/pull/6340',
+    status: 'success',
     updatedAt: '2026-05-17T00:00:00.000Z',
     mergeable: 'MERGEABLE',
     headSha: 'abc123',
@@ -249,6 +265,70 @@ describe('WorktreeCard merged PR fallback display', () => {
 
     expect(markup).toContain('Linked PR #6340')
     expect(markup).not.toContain('Detached HEAD @ merge-c')
+  })
+
+  it('shows detached hosted PRs even when the cache entry was warmed from a linked hint', async () => {
+    hostedReviewCache = {
+      'local::repo-1::__detached_head__:merge-commit': {
+        data: makeHostedReview({
+          number: 24,
+          title: 'Validate Orca PR status fallback',
+          headSha: 'pr-head-before-merge',
+          status: 'failure'
+        }),
+        fetchedAt: 200,
+        linkedReviewHintKey: 'github:24'
+      }
+    }
+    prCache = {
+      'repo-1::__detached_head__:merge-commit': {
+        data: makePRInfo({
+          number: 24,
+          title: 'Validate Orca PR status fallback',
+          headSha: 'pr-head-before-merge',
+          checksStatus: 'failure'
+        }),
+        fetchedAt: 100
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ branch: '', linkedPR: null, head: 'merge-commit' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('Linked PR #24')
+    expect(markup).not.toContain('Detached HEAD @ merge-c')
+  })
+
+  it('keeps linked-hint detached hosted PRs hidden without HEAD-scoped PR proof', async () => {
+    hostedReviewCache = {
+      'local::repo-1::__detached_head__:merge-commit': {
+        data: makeHostedReview({
+          number: 24,
+          title: 'Stale manually linked PR',
+          headSha: 'pr-head-before-merge'
+        }),
+        fetchedAt: 200,
+        linkedReviewHintKey: 'github:24'
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ branch: '', linkedPR: null, head: 'merge-commit' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).not.toContain('Linked PR #24')
+    expect(markup).toContain('Detached HEAD @ merge-c')
   })
 
   it('hides detached HEAD badge when the parent list supplies PR status', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
@@ -164,6 +164,35 @@ describe('WorktreeCard merged PR fallback display', () => {
     expect(markup).not.toContain('Branch')
   })
 
+  it('shows cached merged PR for detached HEAD-scoped cache entries', async () => {
+    hostedReviewCache = {
+      'local::repo-1::__detached_head__:merge-commit': {
+        data: null,
+        fetchedAt: 200
+      }
+    }
+    prCache = {
+      'repo-1::__detached_head__:merge-commit': {
+        data: makePRInfo({
+          headSha: 'pr-head-before-merge'
+        }),
+        fetchedAt: 100
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ branch: '', linkedPR: null, head: 'merge-commit' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('Linked PR #6340')
+    expect(markup).not.toContain('Detached HEAD @ merge-c')
+  })
+
   it('suppresses cached merged PR after a newer hosted-review miss when the worktree head moved', async () => {
     prCache = {
       'repo-1::feature/local-branch': {

--- a/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
@@ -222,6 +222,35 @@ describe('WorktreeCard merged PR fallback display', () => {
     expect(markup).not.toContain('Detached HEAD @ merge-c')
   })
 
+  it('shows detached PRs when cache owner prefix differs', async () => {
+    hostedReviewCache = {
+      'local::repo-1::__detached_head__:merge-commit': {
+        data: null,
+        fetchedAt: 200
+      }
+    }
+    prCache = {
+      'runtime:windows::other-repo-id::__detached_head__:merge-commit': {
+        data: makePRInfo({
+          headSha: 'pr-head-before-merge'
+        }),
+        fetchedAt: 100
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ branch: '', linkedPR: null, head: 'merge-commit' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('Linked PR #6340')
+    expect(markup).not.toContain('Detached HEAD @ merge-c')
+  })
+
   it('hides detached HEAD badge when the parent list supplies PR status', async () => {
     const { default: WorktreeCard } = await import('./WorktreeCard')
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
@@ -193,6 +193,57 @@ describe('WorktreeCard merged PR fallback display', () => {
     expect(markup).not.toContain('Detached HEAD @ merge-c')
   })
 
+  it('shows detached PRs from legacy path-scoped cache entries', async () => {
+    hostedReviewCache = {
+      'local::repo-1::__detached_head__:merge-commit': {
+        data: null,
+        fetchedAt: 200
+      }
+    }
+    prCache = {
+      '/repo::__detached_head__:merge-commit': {
+        data: makePRInfo({
+          headSha: 'pr-head-before-merge'
+        }),
+        fetchedAt: 100
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ branch: '', linkedPR: null, head: 'merge-commit' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('Linked PR #6340')
+    expect(markup).not.toContain('Detached HEAD @ merge-c')
+  })
+
+  it('hides detached HEAD badge when the parent list supplies PR status', async () => {
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ branch: '', linkedPR: null, head: 'merge-commit' })}
+        repo={makeRepo()}
+        isActive={false}
+        statusPrDisplay={{
+          provider: 'github',
+          number: 24,
+          title: 'Detached PR from parent status',
+          state: 'merged',
+          status: 'failure',
+          url: 'https://github.com/acme/orca/pull/24'
+        }}
+      />
+    )
+
+    expect(markup).not.toContain('Detached HEAD @ merge-c')
+  })
+
   it('suppresses cached merged PR after a newer hosted-review miss when the worktree head moved', async () => {
     prCache = {
       'repo-1::feature/local-branch': {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -3,7 +3,11 @@ import React, { useEffect, useCallback, useState } from 'react'
 import { useAppStore } from '@/store'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review'
 import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
-import { getGitHubPRCacheBranch, getGitHubPRCacheKey } from '@/store/slices/github-cache-key'
+import {
+  getGitHubPRCacheBranch,
+  getGitHubPRCacheKey,
+  getLegacyGitHubPRCacheKey
+} from '@/store/slices/github-cache-key'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -435,6 +439,15 @@ const WorktreeCard = React.memo(function WorktreeCard({
           true
         )
       : ''
+  const canUseLegacyPRCache = repo !== undefined && !repo.connectionId && !repo.executionHostId
+  const legacyRepoScopedPRCacheKey =
+    canUseLegacyPRCache && prCacheBranch
+      ? getLegacyGitHubPRCacheKey(repo.path, repo.id, prCacheBranch)
+      : ''
+  const legacyPathScopedPRCacheKey =
+    canUseLegacyPRCache && prCacheBranch
+      ? getLegacyGitHubPRCacheKey(repo.path, undefined, prCacheBranch)
+      : ''
   const issueCacheKey =
     repo && worktree.linkedIssue
       ? getIssueCacheKey(
@@ -455,7 +468,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const hostedReviewEntry = useAppStore((s) =>
     hostedReviewCacheKey ? s.hostedReviewCache[hostedReviewCacheKey] : undefined
   )
-  const prCacheEntry = useAppStore((s) => (prCacheKey ? s.prCache?.[prCacheKey] : undefined))
+  const prCacheEntry = useAppStore(
+    (s) =>
+      (prCacheKey ? s.prCache?.[prCacheKey] : undefined) ??
+      (legacyRepoScopedPRCacheKey ? s.prCache?.[legacyRepoScopedPRCacheKey] : undefined) ??
+      (legacyPathScopedPRCacheKey ? s.prCache?.[legacyPathScopedPRCacheKey] : undefined)
+  )
   const issueEntry = useAppStore((s) => (issueCacheKey ? s.issueCache[issueCacheKey] : undefined))
   const linearIssueEntry = useAppStore((s) =>
     linearIssueCacheKey ? s.linearIssueCache[linearIssueCacheKey] : undefined
@@ -1171,7 +1189,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // Why: a detached merge commit can still have PR context; once shown, the PR
   // status is the higher-signal sidebar identity than the raw commit badge.
   const showDetachedHeadInMetaRow =
-    !compactCards && !isFolder && detachedHeadDisplay !== null && hoverReview === null
+    !compactCards && !isFolder && detachedHeadDisplay !== null && statusLaneReview === null
   const showBranch =
     !isFolder &&
     branch.length > 0 &&

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -136,6 +136,11 @@ type WorktreeCardProps = {
 
 const EMPTY_WORKSPACE_PORTS = []
 const HOSTED_REVIEW_CARD_REFRESH_INTERVAL_MS = 60_000
+type WorktreeCardHostedReviewCacheEntry = {
+  data?: HostedReviewInfo | null
+  fetchedAt?: number
+  linkedReviewHintKey?: string
+}
 type WorktreeCardPRCacheEntry = { data?: PRInfo | null; fetchedAt?: number }
 
 export function shouldBeginWorktreeRename(
@@ -178,11 +183,30 @@ function isCachedMergedBranchPRCurrentForWorktree(
   )
 }
 
+function isDetachedHeadCacheBranch(cacheBranch: string): boolean {
+  return cacheBranch.startsWith('__detached_head__:')
+}
+
+function findDetachedHostedReviewCacheEntry(
+  hostedReviewCache: Record<string, WorktreeCardHostedReviewCacheEntry> | undefined,
+  cacheBranch: string
+): WorktreeCardHostedReviewCacheEntry | undefined {
+  if (!hostedReviewCache || !isDetachedHeadCacheBranch(cacheBranch)) {
+    return undefined
+  }
+  // Why: imported/folder workspaces can observe the same detached review under a
+  // different repo owner key; the HEAD-scoped suffix is still exact.
+  const suffix = `::${cacheBranch}`
+  return Object.entries(hostedReviewCache).find(
+    ([key, entry]) => key.endsWith(suffix) && entry?.data
+  )?.[1]
+}
+
 function findDetachedPRCacheEntry(
   prCache: Record<string, WorktreeCardPRCacheEntry> | undefined,
   cacheBranch: string
 ): WorktreeCardPRCacheEntry | undefined {
-  if (!prCache || !cacheBranch.startsWith('__detached_head__:')) {
+  if (!prCache || !isDetachedHeadCacheBranch(cacheBranch)) {
     return undefined
   }
   // Why: imported/folder workspaces can observe the same detached PR under a
@@ -479,8 +503,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const linearIssueCacheKey = worktree.linkedLinearIssue ? `all::${worktree.linkedLinearIssue}` : ''
 
   // Subscribe to ONLY the specific cache entry, not entire review/issue caches.
-  const hostedReviewEntry = useAppStore((s) =>
-    hostedReviewCacheKey ? s.hostedReviewCache[hostedReviewCacheKey] : undefined
+  const hostedReviewEntry = useAppStore(
+    (s) =>
+      (hostedReviewCacheKey ? s.hostedReviewCache[hostedReviewCacheKey] : undefined) ??
+      findDetachedHostedReviewCacheEntry(s.hostedReviewCache, prCacheBranch)
   )
   const prCacheEntry = useAppStore(
     (s) =>
@@ -522,7 +548,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // cache entries are already scoped by the checked-out HEAD merge commit.
   const cachedBranchPR = prCacheEntry?.data
   const cachedBranchPRFetchedAt = prCacheEntry?.fetchedAt
-  const cachedBranchPRIsHeadScoped = branch.length === 0 && prCacheBranch.length > 0
+  const cachedBranchPRIsHeadScoped = branch.length === 0 && isDetachedHeadCacheBranch(prCacheBranch)
   const cachedMergedBranchPRMatchesCurrentHead = isCachedMergedBranchPRCurrentForWorktree(
     cachedBranchPR,
     worktree
@@ -540,6 +566,17 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const cachedBranchReview = useCachedBranchReview
     ? hostedReviewInfoFromGitHubPRInfo(cachedBranchPR)
     : hostedReview
+  const detachedHostedReviewMatchesCachedHeadPR =
+    cachedBranchPRIsHeadScoped &&
+    cachedBranchPR !== undefined &&
+    cachedBranchPR !== null &&
+    hostedReview?.provider === 'github' &&
+    hostedReview.number === cachedBranchPR.number &&
+    !hasNonGitHubLinkedReview
+  const reviewHintKey =
+    (useCachedBranchReview || detachedHostedReviewMatchesCachedHeadPR) && !hasLinkedReview
+      ? ''
+      : hostedReviewEntry?.linkedReviewHintKey
   const prDisplay = getWorktreeCardPrDisplay(
     cachedBranchReview,
     linkedGitHubPR,
@@ -548,8 +585,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     linkedAzureDevOpsPR,
     linkedGiteaPR,
     {
-      reviewHintKey:
-        useCachedBranchReview && !hasLinkedReview ? '' : hostedReviewEntry?.linkedReviewHintKey
+      reviewHintKey
     }
   )
   const issue: IssueInfo | null | undefined = worktree.linkedIssue

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -150,6 +150,9 @@ function formatSparseDirectoryPreview(directories: string[]): string {
 }
 
 function isWebClient(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
   return Boolean((window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__)
 }
 
@@ -608,6 +611,17 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const showComment = cardProps.includes('comment')
   const showPorts = cardProps.includes('ports')
   const shouldRefreshHostedReview = newCardStyle ? showStatus : showPR
+  const canPassivelyRefreshHostedReview =
+    !isWebClient() && repo !== undefined && !isMacAppDataPath(repo.path)
+  const hostedReviewLookupPending =
+    newCardStyle &&
+    shouldRefreshHostedReview &&
+    canPassivelyRefreshHostedReview &&
+    repo !== undefined &&
+    !isFolder &&
+    !worktree.isBare &&
+    hostedReviewCacheKey.length > 0 &&
+    hostedReviewEntry === undefined
   const detailsHoverControl = useWorktreeCardDetailsHoverControl()
   const hoverDetailsOpen = detailsHoverControl.hoverOpen
 
@@ -1357,7 +1371,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
             onToggleUnread={handleToggleUnreadQuick}
             prDisplay={statusLaneReview}
             newCardStyle={newCardStyle}
-            hasBranchIdentity={Boolean(branchIdentityDisplay)}
+            // Why: an unresolved branch-review lookup means "unknown", not
+            // "no PR"; showing the branch glyph here causes visible PR flicker.
+            hasBranchIdentity={Boolean(branchIdentityDisplay) && !hostedReviewLookupPending}
           />
         </div>
       ) : null}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -485,9 +485,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
   // Why: ChecksPanel can discover a branch PR before hosted-review metadata
   // warms, and transient older hosted-review misses can race with that cache.
   // A newer miss only yields to merged PR cache when the stored worktree head
-  // proves the cached PR still describes the checked-out commit.
+  // proves the cached PR still describes the checked-out commit. Detached
+  // cache entries are already scoped by the checked-out HEAD merge commit.
   const cachedBranchPR = prCacheEntry?.data
   const cachedBranchPRFetchedAt = prCacheEntry?.fetchedAt
+  const cachedBranchPRIsHeadScoped = branch.length === 0 && prCacheBranch.length > 0
   const cachedMergedBranchPRMatchesCurrentHead = isCachedMergedBranchPRCurrentForWorktree(
     cachedBranchPR,
     worktree
@@ -500,6 +502,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       (hostedReview === null &&
         ((cachedBranchPRFetchedAt !== undefined &&
           cachedBranchPRFetchedAt > (hostedReviewEntry?.fetchedAt ?? 0)) ||
+          cachedBranchPRIsHeadScoped ||
           cachedMergedBranchPRMatchesCurrentHead)))
   const cachedBranchReview = useCachedBranchReview
     ? hostedReviewInfoFromGitHubPRInfo(cachedBranchPR)
@@ -1165,7 +1168,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const showRepoBadgeInMetaRow =
     !showRepoIdentityInTitle && !!repo && !hideRepoBadge && !showPinnedRepoIcon
   const showHostContextBadge = !compactCards && !!hostContextLabel
-  const showDetachedHeadInMetaRow = !compactCards && !isFolder && detachedHeadDisplay !== null
+  // Why: a detached merge commit can still have PR context; once shown, the PR
+  // status is the higher-signal sidebar identity than the raw commit badge.
+  const showDetachedHeadInMetaRow =
+    !compactCards && !isFolder && detachedHeadDisplay !== null && hoverReview === null
   const showBranch =
     !isFolder &&
     branch.length > 0 &&

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -136,6 +136,7 @@ type WorktreeCardProps = {
 
 const EMPTY_WORKSPACE_PORTS = []
 const HOSTED_REVIEW_CARD_REFRESH_INTERVAL_MS = 60_000
+type WorktreeCardPRCacheEntry = { data?: PRInfo | null; fetchedAt?: number }
 
 export function shouldBeginWorktreeRename(
   request: WorktreeRenameRequest | null,
@@ -175,6 +176,19 @@ function isCachedMergedBranchPRCurrentForWorktree(
     worktree.head.length > 0 &&
     cachedPR.headSha === worktree.head
   )
+}
+
+function findDetachedPRCacheEntry(
+  prCache: Record<string, WorktreeCardPRCacheEntry> | undefined,
+  cacheBranch: string
+): WorktreeCardPRCacheEntry | undefined {
+  if (!prCache || !cacheBranch.startsWith('__detached_head__:')) {
+    return undefined
+  }
+  // Why: imported/folder workspaces can observe the same detached PR under a
+  // different repo owner key; the HEAD-scoped suffix is still exact.
+  const suffix = `::${cacheBranch}`
+  return Object.entries(prCache).find(([key, entry]) => key.endsWith(suffix) && entry?.data)?.[1]
 }
 
 function getDirectoryName(folderPath: string): string {
@@ -472,7 +486,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
     (s) =>
       (prCacheKey ? s.prCache?.[prCacheKey] : undefined) ??
       (legacyRepoScopedPRCacheKey ? s.prCache?.[legacyRepoScopedPRCacheKey] : undefined) ??
-      (legacyPathScopedPRCacheKey ? s.prCache?.[legacyPathScopedPRCacheKey] : undefined)
+      (legacyPathScopedPRCacheKey ? s.prCache?.[legacyPathScopedPRCacheKey] : undefined) ??
+      findDetachedPRCacheEntry(s.prCache, prCacheBranch)
   )
   const issueEntry = useAppStore((s) => (issueCacheKey ? s.issueCache[issueCacheKey] : undefined))
   const linearIssueEntry = useAppStore((s) =>

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useCallback, useState } from 'react'
 import { useAppStore } from '@/store'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review'
 import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
-import { getGitHubPRCacheKey } from '@/store/slices/github-cache-key'
+import { getGitHubPRCacheBranch, getGitHubPRCacheKey } from '@/store/slices/github-cache-key'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -153,7 +153,10 @@ function isWebClient(): boolean {
   if (typeof window === 'undefined') {
     return false
   }
-  return Boolean((window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__)
+  return (
+    Boolean((window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__) ||
+    window.location.pathname.endsWith('/web-index.html')
+  )
 }
 
 function isCachedMergedBranchPRCurrentForWorktree(
@@ -407,11 +410,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const folderMetaRowContent = newCardStyle
     ? hasPathIdentityEnabled && Boolean(folderPathIdentityDisplay)
     : isFolder
+  const prCacheBranch = getGitHubPRCacheBranch(branch, worktree.head)
   const hostedReviewCacheKey =
-    repo && branch
+    repo && prCacheBranch
       ? getHostedReviewCacheKey(
           repo.path,
-          branch,
+          prCacheBranch,
           settings,
           repo.id,
           repo.connectionId,
@@ -420,11 +424,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
         )
       : ''
   const prCacheKey =
-    repo && branch
+    repo && prCacheBranch
       ? getGitHubPRCacheKey(
           repo.path,
           repo.id,
-          branch,
+          prCacheBranch,
           settings,
           repo.connectionId,
           repo.executionHostId,

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -136,11 +136,6 @@ type WorktreeCardProps = {
 
 const EMPTY_WORKSPACE_PORTS = []
 const HOSTED_REVIEW_CARD_REFRESH_INTERVAL_MS = 60_000
-type WorktreeCardHostedReviewCacheEntry = {
-  data?: HostedReviewInfo | null
-  fetchedAt?: number
-  linkedReviewHintKey?: string
-}
 type WorktreeCardPRCacheEntry = { data?: PRInfo | null; fetchedAt?: number }
 
 export function shouldBeginWorktreeRename(
@@ -185,21 +180,6 @@ function isCachedMergedBranchPRCurrentForWorktree(
 
 function isDetachedHeadCacheBranch(cacheBranch: string): boolean {
   return cacheBranch.startsWith('__detached_head__:')
-}
-
-function findDetachedHostedReviewCacheEntry(
-  hostedReviewCache: Record<string, WorktreeCardHostedReviewCacheEntry> | undefined,
-  cacheBranch: string
-): WorktreeCardHostedReviewCacheEntry | undefined {
-  if (!hostedReviewCache || !isDetachedHeadCacheBranch(cacheBranch)) {
-    return undefined
-  }
-  // Why: imported/folder workspaces can observe the same detached review under a
-  // different repo owner key; the HEAD-scoped suffix is still exact.
-  const suffix = `::${cacheBranch}`
-  return Object.entries(hostedReviewCache).find(
-    ([key, entry]) => key.endsWith(suffix) && entry?.data
-  )?.[1]
 }
 
 function findDetachedPRCacheEntry(
@@ -503,10 +483,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const linearIssueCacheKey = worktree.linkedLinearIssue ? `all::${worktree.linkedLinearIssue}` : ''
 
   // Subscribe to ONLY the specific cache entry, not entire review/issue caches.
-  const hostedReviewEntry = useAppStore(
-    (s) =>
-      (hostedReviewCacheKey ? s.hostedReviewCache[hostedReviewCacheKey] : undefined) ??
-      findDetachedHostedReviewCacheEntry(s.hostedReviewCache, prCacheBranch)
+  const hostedReviewEntry = useAppStore((s) =>
+    hostedReviewCacheKey ? s.hostedReviewCache[hostedReviewCacheKey] : undefined
   )
   const prCacheEntry = useAppStore(
     (s) =>

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -3521,22 +3521,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       .filter((item) => item.start < viewportBottom && item.end > viewportTop)
       .map((item) => renderRows[item.index])
       .filter((row): row is WorktreeItemRow => row?.type === 'item')
-      .filter((row) => row.repo?.kind === 'git' && !row.worktree.isBare && row.worktree.branch)
+      .filter((row) => row.repo?.kind === 'git' && hasGitHubPRRefreshIdentity(row.worktree))
     const visibleWorktreeIds = new Set(visibleRows.map((row) => row.worktree.id))
     if (
       shouldTrackSidebarWorktree &&
       currentWorktree &&
-      !currentWorktree.isBare &&
-      currentWorktree.branch
+      hasGitHubPRRefreshIdentity(currentWorktree)
     ) {
       visibleWorktreeIds.add(currentWorktree.id)
     }
     const visibleIdentity = visibleRows
-      .map((row) => `${row.worktree.id}:${row.worktree.branch}:${row.worktree.linkedPR ?? ''}`)
+      .map((row) => getGitHubPRRefreshIdentity(row.worktree))
       .join('|')
     const sidebarIdentity =
       shouldTrackSidebarWorktree && currentWorktree
-        ? `${currentWorktree.id}:${currentWorktree.branch}:${currentWorktree.linkedPR ?? ''}`
+        ? getGitHubPRRefreshIdentity(currentWorktree)
         : ''
     const key = `${visibleIdentity}:${sidebarIdentity}:${sshConnectedGeneration}:${prVisibleRefreshGeneration}:${cardProps.join(',')}`
     if (!key || key === lastVisibleRefreshKeyRef.current) {
@@ -4897,6 +4896,19 @@ type WorktreeListProps = {
 export function installWorktreeVisibleRefreshVisibilityListener(onChange: () => void): () => void {
   document.addEventListener('visibilitychange', onChange)
   return () => document.removeEventListener('visibilitychange', onChange)
+}
+
+export function hasGitHubPRRefreshIdentity(
+  worktree: Pick<Worktree, 'isBare' | 'branch' | 'head'>
+): boolean {
+  return !worktree.isBare && Boolean(worktree.branch || worktree.head)
+}
+
+export function getGitHubPRRefreshIdentity(
+  worktree: Pick<Worktree, 'id' | 'branch' | 'head' | 'linkedPR'>
+): string {
+  const gitIdentity = worktree.branch || worktree.head || ''
+  return `${worktree.id}:${gitIdentity}:${worktree.linkedPR ?? ''}`
 }
 
 const WorktreeList = React.memo(function WorktreeList({

--- a/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
@@ -176,6 +176,35 @@ describe('getFolderWorkspaceCardPrDisplay', () => {
       status: 'failure'
     })
   })
+
+  it('uses detached HEAD PR cache when the owner prefix differs', () => {
+    const detached = makeWorktree({
+      id: 'detached',
+      branch: '',
+      head: 'merge-commit',
+      linkedPR: null
+    })
+
+    const display = getFolderWorkspaceCardPrDisplay({
+      folderWorkspaceId: 'folder-1',
+      workspaceLineageByChildKey: { [detached.id]: makeWorkspaceLineage(detached) },
+      worktreeLineageById: {},
+      worktreeMap: new Map([[detached.id, detached]]),
+      repoMap: new Map([[repo.id, repo]]),
+      hostedReviewCache: null,
+      prCache: {
+        'runtime:windows::other-repo-id::__detached_head__:merge-commit': {
+          data: makePr(24, 'failure')
+        }
+      }
+    })
+
+    expect(display).toMatchObject({
+      provider: 'github',
+      number: 24,
+      status: 'failure'
+    })
+  })
 })
 
 function makePr(number: number, checksStatus: CheckStatus) {

--- a/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
@@ -145,6 +145,37 @@ describe('getFolderWorkspaceCardPrDisplay', () => {
 
     expect(display).toMatchObject({ number: 4, status: 'success' })
   })
+
+  it('uses detached HEAD-scoped PR cache for attached worktrees', () => {
+    const detached = makeWorktree({
+      id: 'detached',
+      branch: '',
+      head: 'merge-commit',
+      linkedPR: null
+    })
+
+    const display = getFolderWorkspaceCardPrDisplay({
+      folderWorkspaceId: 'folder-1',
+      workspaceLineageByChildKey: { [detached.id]: makeWorkspaceLineage(detached) },
+      worktreeLineageById: {},
+      worktreeMap: new Map([[detached.id, detached]]),
+      repoMap: new Map([[repo.id, repo]]),
+      hostedReviewCache: {
+        'local::repo-1::__detached_head__:merge-commit': { data: null }
+      },
+      prCache: {
+        'repo-1::__detached_head__:merge-commit': {
+          data: makePr(24, 'failure')
+        }
+      }
+    })
+
+    expect(display).toMatchObject({
+      provider: 'github',
+      number: 24,
+      status: 'failure'
+    })
+  })
 })
 
 function makePr(number: number, checksStatus: CheckStatus) {

--- a/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.ts
@@ -264,7 +264,8 @@ function getCachedGitHubPr({
       : undefined) ??
     (legacyPathScopedCacheKey
       ? (prCache[legacyPathScopedCacheKey] as PrCacheEntry | undefined)
-      : undefined)
+      : undefined) ??
+    findDetachedPRCacheEntry(prCache, cacheBranch)
   const pr = entry?.data ?? null
   if (!pr) {
     return null
@@ -273,6 +274,22 @@ function getCachedGitHubPr({
     return pr
   }
   return pr.number === worktree.linkedPR ? pr : null
+}
+
+function findDetachedPRCacheEntry(
+  prCache: Record<string, unknown>,
+  cacheBranch: string
+): PrCacheEntry | undefined {
+  if (!cacheBranch.startsWith('__detached_head__:')) {
+    return undefined
+  }
+  // Why: folder/import aggregate rows may represent a different repo identity
+  // than the active worktree, but a detached HEAD cache suffix is unambiguous.
+  const suffix = `::${cacheBranch}`
+  return Object.entries(prCache).find(([key, entry]) => {
+    const data = (entry as PrCacheEntry | undefined)?.data
+    return key.endsWith(suffix) && data
+  })?.[1] as PrCacheEntry | undefined
 }
 
 function compareReviewDisplays(left: WorktreeCardPrDisplay, right: WorktreeCardPrDisplay): number {

--- a/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.ts
@@ -1,6 +1,10 @@
 import type { AppState } from '@/store/types'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review'
-import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from '@/store/slices/github-cache-key'
+import {
+  getGitHubPRCacheBranch,
+  getGitHubPRCacheKey,
+  getLegacyGitHubPRCacheKey
+} from '@/store/slices/github-cache-key'
 import { branchName } from '@/lib/git-utils'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type {
@@ -162,13 +166,14 @@ function getAttachedWorktreePrDisplay({
   }
 
   const branch = branchName(worktree.branch).trim()
-  if (!branch) {
+  const cacheBranch = getGitHubPRCacheBranch(branch, worktree.head)
+  if (!cacheBranch) {
     return getLinkedReviewDisplay(worktree)
   }
 
   const hostedReviewCacheKey = getHostedReviewCacheKey(
     repo.path,
-    branch,
+    cacheBranch,
     settings,
     repo.id,
     repo.connectionId,
@@ -193,7 +198,7 @@ function getAttachedWorktreePrDisplay({
     return hostedReviewDisplay
   }
 
-  const cachedGitHubPr = getCachedGitHubPr({ worktree, repo, branch, prCache, settings })
+  const cachedGitHubPr = getCachedGitHubPr({ worktree, repo, cacheBranch, prCache, settings })
   if (cachedGitHubPr) {
     return {
       provider: 'github',
@@ -222,24 +227,24 @@ function getLinkedReviewDisplay(worktree: Worktree): WorktreeCardPrDisplay | nul
 function getCachedGitHubPr({
   worktree,
   repo,
-  branch,
+  cacheBranch,
   prCache,
   settings
 }: {
   worktree: Worktree
   repo: Repo
-  branch: string
+  cacheBranch: string
   prCache: Record<string, unknown> | null
   settings?: AppState['settings']
 }): PRInfo | null {
-  if (!prCache || worktree.linkedPR === null) {
+  if (!prCache || (worktree.linkedPR === null && !cacheBranch.startsWith('__detached_head__:'))) {
     return null
   }
 
   const cacheKey = getGitHubPRCacheKey(
     repo.path,
     repo.id,
-    branch,
+    cacheBranch,
     settings,
     repo.connectionId,
     repo.executionHostId,
@@ -247,10 +252,10 @@ function getCachedGitHubPr({
   )
   const canUseLegacyPRCache = !repo.connectionId && !repo.executionHostId
   const legacyRepoScopedCacheKey = canUseLegacyPRCache
-    ? getLegacyGitHubPRCacheKey(repo.path, repo.id, branch)
+    ? getLegacyGitHubPRCacheKey(repo.path, repo.id, cacheBranch)
     : ''
   const legacyPathScopedCacheKey = canUseLegacyPRCache
-    ? getLegacyGitHubPRCacheKey(repo.path, undefined, branch)
+    ? getLegacyGitHubPRCacheKey(repo.path, undefined, cacheBranch)
     : ''
   const entry =
     (prCache[cacheKey] as PrCacheEntry | undefined) ??
@@ -261,7 +266,13 @@ function getCachedGitHubPr({
       ? (prCache[legacyPathScopedCacheKey] as PrCacheEntry | undefined)
       : undefined)
   const pr = entry?.data ?? null
-  return pr?.number === worktree.linkedPR ? pr : null
+  if (!pr) {
+    return null
+  }
+  if (cacheBranch.startsWith('__detached_head__:')) {
+    return pr
+  }
+  return pr.number === worktree.linkedPR ? pr : null
 }
 
 function compareReviewDisplays(left: WorktreeCardPrDisplay, right: WorktreeCardPrDisplay): number {

--- a/src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { installWorktreeVisibleRefreshVisibilityListener } from './WorktreeList'
+import {
+  getGitHubPRRefreshIdentity,
+  hasGitHubPRRefreshIdentity,
+  installWorktreeVisibleRefreshVisibilityListener
+} from './WorktreeList'
 
 describe('installWorktreeVisibleRefreshVisibilityListener', () => {
   beforeEach(() => {
@@ -28,5 +32,41 @@ describe('installWorktreeVisibleRefreshVisibilityListener', () => {
 
     cleanup()
     expect(removeEventListener).toHaveBeenCalledWith('visibilitychange', onChange)
+  })
+
+  it('tracks detached worktrees by head for visible PR refreshes', () => {
+    expect(
+      hasGitHubPRRefreshIdentity({
+        isBare: false,
+        branch: '',
+        head: '67c9b9565d1596f40afbb5d4acb1ee71e56e1c4e'
+      })
+    ).toBe(true)
+    expect(
+      getGitHubPRRefreshIdentity({
+        id: 'repo-1::C:/Users/neil/orca/workspaces/demo-project-6470-detached-24',
+        branch: '',
+        head: '67c9b9565d1596f40afbb5d4acb1ee71e56e1c4e',
+        linkedPR: null
+      })
+    ).toBe(
+      'repo-1::C:/Users/neil/orca/workspaces/demo-project-6470-detached-24:67c9b9565d1596f40afbb5d4acb1ee71e56e1c4e:'
+    )
+  })
+
+  it('keeps branch worktree refresh identity branch-scoped', () => {
+    expect(
+      getGitHubPRRefreshIdentity({
+        id: 'repo-1::/repo/worktrees/feature',
+        branch: 'feature/local-branch',
+        head: 'abc123',
+        linkedPR: 42
+      })
+    ).toBe('repo-1::/repo/worktrees/feature:feature/local-branch:42')
+  })
+
+  it('does not track worktrees without branch or head identity', () => {
+    expect(hasGitHubPRRefreshIdentity({ isBare: false, branch: '', head: '' })).toBe(false)
+    expect(hasGitHubPRRefreshIdentity({ isBare: true, branch: 'main', head: 'abc123' })).toBe(false)
   })
 })

--- a/src/renderer/src/store/slices/github-cache-key.ts
+++ b/src/renderer/src/store/slices/github-cache-key.ts
@@ -80,6 +80,16 @@ export function getGitHubPRCacheKey(
   )
 }
 
+export function getGitHubPRCacheBranch(branch: string, worktreeHead?: string | null): string {
+  const trimmedHead = worktreeHead?.trim()
+  if (branch || !trimmedHead) {
+    return branch
+  }
+  // Why: detached worktrees have no branch, so PR lookup results are keyed by
+  // the commit whose GitHub merge association was probed.
+  return `__detached_head__:${trimmedHead}`
+}
+
 export function getLegacyGitHubPRCacheKey(
   repoPath: string,
   repoId: string | undefined,

--- a/src/renderer/src/store/slices/github-pr-refresh-owner-routing.test.ts
+++ b/src/renderer/src/store/slices/github-pr-refresh-owner-routing.test.ts
@@ -155,7 +155,7 @@ describe('GitHub PR refresh owner-host routing', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-runtime', branch, linkedPRNumber: null },
+      params: { repo: 'repo-runtime', branch, linkedPRNumber: null, currentHeadOid: 'head-oid' },
       timeoutMs: 30_000
     })
   })
@@ -228,7 +228,45 @@ describe('GitHub PR refresh owner-host routing', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-runtime', branch, linkedPRNumber: null },
+      params: { repo: 'repo-runtime', branch, linkedPRNumber: null, currentHeadOid: 'head-oid' },
+      timeoutMs: 30_000
+    })
+  })
+
+  it('routes detached post-push refreshes with the current HEAD hint', async () => {
+    runtimeEnvironmentCall.mockResolvedValueOnce({
+      id: 'rpc-1',
+      ok: true,
+      result: makePR({ number: 27 }),
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+    const store = createTestStore()
+    seed(store, {
+      repos: [
+        makeRepo({
+          id: 'repo-runtime',
+          path: '/runtime/repo',
+          executionHostId: 'runtime:env-1'
+        })
+      ],
+      worktreesByRepo: {
+        'repo-runtime': [makeWorktree('repo-runtime', '', 'wt-runtime-detached')]
+      }
+    })
+
+    store.getState().refreshGitHubForWorktree('wt-runtime-detached')
+
+    await vi.waitFor(() => expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(1))
+    expect(enqueuePRRefresh).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'github.prForBranch',
+      params: {
+        repo: 'repo-runtime',
+        branch: '',
+        linkedPRNumber: null,
+        currentHeadOid: 'head-oid'
+      },
       timeoutMs: 30_000
     })
   })
@@ -272,7 +310,52 @@ describe('GitHub PR refresh owner-host routing', () => {
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-runtime', branch: 'feature/runtime', linkedPRNumber: null },
+      params: {
+        repo: 'repo-runtime',
+        branch: 'feature/runtime',
+        linkedPRNumber: null,
+        currentHeadOid: 'head-oid'
+      },
+      timeoutMs: 30_000
+    })
+  })
+
+  it('routes detached runtime PR refreshes with the current HEAD hint', async () => {
+    runtimeEnvironmentCall.mockResolvedValueOnce({
+      id: 'rpc-1',
+      ok: true,
+      result: makePR({ number: 26 }),
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+    const store = createTestStore()
+    seed(store, {
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings'],
+      repos: [
+        makeRepo({
+          id: 'repo-runtime',
+          path: '/runtime/repo',
+          executionHostId: 'runtime:env-1'
+        })
+      ],
+      worktreesByRepo: {
+        'repo-runtime': [makeWorktree('repo-runtime', '', 'wt-runtime-detached')]
+      },
+      groupBy: 'pr-status'
+    })
+
+    store.getState().refreshGitHubForWorktreeIfStale('wt-runtime-detached')
+
+    await vi.waitFor(() => expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(1))
+    expect(enqueuePRRefresh).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'github.prForBranch',
+      params: {
+        repo: 'repo-runtime',
+        branch: '',
+        linkedPRNumber: null,
+        currentHeadOid: 'head-oid'
+      },
       timeoutMs: 30_000
     })
   })

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -1712,6 +1712,17 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
           connectionId: 'ssh-1'
         }
       ],
+      worktreesByRepo: {
+        'repo-1': [
+          makePRRefreshWorktree({
+            id: 'wt-direct-refresh-head',
+            repoId: 'repo-1',
+            path: `${repoPath}/worktrees/direct-refresh`,
+            branch,
+            head: 'direct-head-oid'
+          })
+        ]
+      },
       prCache: {
         [`repo-1::${branch}`]: {
           data: pr,
@@ -1726,7 +1737,10 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     })
 
     await expect(
-      store.getState().fetchPRForBranch(repoPath, branch, { force: true })
+      store.getState().fetchPRForBranch(repoPath, branch, {
+        force: true,
+        worktreeId: 'wt-direct-refresh-head'
+      })
     ).resolves.toMatchObject({ number: 44 })
     expect(mockApi.gh.prForBranch).not.toHaveBeenCalled()
     expect(mockApi.gh.refreshPRNow).toHaveBeenCalledWith({
@@ -1735,6 +1749,7 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
         repoPath,
         branch,
         cacheKey: `ssh:ssh-1::repo-1::${branch}`,
+        worktreeHead: 'direct-head-oid',
         connectionId: 'ssh-1'
       })
     })

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -1755,6 +1755,149 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     })
   })
 
+  it('keys detached-head PR refresh cache entries by worktree head', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const firstPR = makePR({ number: 101, title: 'Detached first' })
+
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: {
+        [repoId]: [
+          makePRRefreshWorktree({
+            id: 'wt-detached-one',
+            repoId,
+            branch: '',
+            head: 'detached-head-one'
+          }),
+          makePRRefreshWorktree({
+            id: 'wt-detached-two',
+            repoId,
+            branch: '',
+            head: 'detached-head-two'
+          })
+        ]
+      }
+    } as unknown as Partial<AppState>)
+    mockApi.gh.refreshPRNow
+      .mockResolvedValueOnce({ kind: 'found', pr: firstPR, fetchedAt: 10 })
+      .mockResolvedValueOnce({ kind: 'no-pr', fetchedAt: 20 })
+
+    await expect(
+      store.getState().fetchPRForBranch(repoPath, '', {
+        force: true,
+        repoId,
+        worktreeId: 'wt-detached-one'
+      })
+    ).resolves.toMatchObject({ number: 101 })
+    await expect(
+      store.getState().fetchPRForBranch(repoPath, '', {
+        force: true,
+        repoId,
+        worktreeId: 'wt-detached-two'
+      })
+    ).resolves.toBeNull()
+
+    expect(mockApi.gh.refreshPRNow).toHaveBeenNthCalledWith(1, {
+      candidate: expect.objectContaining({
+        branch: '',
+        cacheKey: `${repoId}::__detached_head__:detached-head-one`,
+        worktreeHead: 'detached-head-one'
+      })
+    })
+    expect(mockApi.gh.refreshPRNow).toHaveBeenNthCalledWith(2, {
+      candidate: expect.objectContaining({
+        branch: '',
+        cacheKey: `${repoId}::__detached_head__:detached-head-two`,
+        worktreeHead: 'detached-head-two'
+      })
+    })
+    expect(
+      store.getState().prCache[`${repoId}::__detached_head__:detached-head-one`]
+    ).toMatchObject({
+      data: expect.objectContaining({ number: 101 }),
+      fetchedAt: 10
+    })
+    expect(store.getState().prCache[`${repoId}::__detached_head__:detached-head-two`]).toEqual({
+      data: null,
+      fetchedAt: 20
+    })
+  })
+
+  it('does not reuse empty-branch hosted-review fallback across detached HEADs', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const staleEmptyBranchHostedKey = getHostedReviewCacheKey(repoPath, '', null, repoId)
+    const detachedHostedKey = getHostedReviewCacheKey(
+      repoPath,
+      '__detached_head__:detached-head-two',
+      null,
+      repoId
+    )
+    const freshPR = makePR({ number: 202, title: 'Detached second' })
+
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      hostedReviewCache: {
+        [staleEmptyBranchHostedKey]: {
+          data: {
+            provider: 'github',
+            number: 101,
+            title: 'Detached first',
+            state: 'merged',
+            url: 'https://github.com/acme/repo/pull/101',
+            status: 'success',
+            updatedAt: '2026-05-20T00:00:00Z',
+            mergeable: 'UNKNOWN'
+          },
+          fetchedAt: Date.now(),
+          linkedReviewHintKey: 'github:101'
+        }
+      },
+      worktreesByRepo: {
+        [repoId]: [
+          makePRRefreshWorktree({
+            id: 'wt-detached-two',
+            repoId,
+            branch: '',
+            head: 'detached-head-two'
+          })
+        ]
+      }
+    } as unknown as Partial<AppState>)
+    mockApi.gh.refreshPRNow.mockResolvedValueOnce({
+      kind: 'found',
+      pr: freshPR,
+      fetchedAt: 30
+    })
+
+    await expect(
+      store.getState().fetchPRForBranch(repoPath, '', {
+        force: true,
+        repoId,
+        worktreeId: 'wt-detached-two'
+      })
+    ).resolves.toMatchObject({ number: 202 })
+
+    expect(mockApi.gh.refreshPRNow).toHaveBeenCalledWith({
+      candidate: expect.objectContaining({
+        branch: '',
+        cacheKey: `${repoId}::__detached_head__:detached-head-two`,
+        fallbackPRNumber: null,
+        fallbackPRSource: null,
+        worktreeHead: 'detached-head-two'
+      })
+    })
+    expect(store.getState().hostedReviewCache[staleEmptyBranchHostedKey]?.data).toMatchObject({
+      number: 101
+    })
+    expect(store.getState().hostedReviewCache[detachedHostedKey]?.data).toMatchObject({
+      number: 202
+    })
+  })
+
   it('does not reuse local fresh PR cache for SSH-backed repos', async () => {
     const store = createTestStore()
     const repoPath = '/repo'
@@ -3917,18 +4060,38 @@ describe('createGitHubSlice.refreshGitHubForWorktreeIfStale', () => {
           connectionId: null,
           executionHostId: 'runtime:env-1'
         }
-      ]
+      ],
+      worktreesByRepo: {
+        'repo-runtime': [
+          makePRRefreshWorktree({
+            id: 'wt-runtime-owner',
+            repoId: 'repo-runtime',
+            branch,
+            head: 'runtime-head-oid'
+          })
+        ]
+      }
     } as unknown as Partial<AppState>)
 
     await expect(
-      store.getState().fetchPRForBranch(repoPath, branch, { repoId: 'repo-runtime' })
+      store
+        .getState()
+        .fetchPRForBranch(repoPath, branch, {
+          repoId: 'repo-runtime',
+          worktreeId: 'wt-runtime-owner'
+        })
     ).resolves.toMatchObject({ number: 23 })
 
     expect(mockApi.gh.refreshPRNow).not.toHaveBeenCalled()
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'github.prForBranch',
-      params: { repo: 'repo-runtime', branch, linkedPRNumber: null },
+      params: {
+        repo: 'repo-runtime',
+        branch,
+        linkedPRNumber: null,
+        currentHeadOid: 'runtime-head-oid'
+      },
       timeoutMs: 30_000
     })
     expect(store.getState().prCache[`runtime:env-1::repo-runtime::${branch}`]?.data).toMatchObject({

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -2957,6 +2957,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                 : ({ kind: 'no-pr', fetchedAt: Date.now() } as const)
             )
           : await (async () => {
+              const requestWorktree = options?.worktreeId
+                ? findWorktreeById(get(), options.worktreeId)
+                : null
               const candidate: GitHubPRRefreshCandidate = {
                 repoId: repoId ?? '',
                 repoPath,
@@ -2964,6 +2967,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                 branch,
                 cacheKey,
                 worktreeId: options?.worktreeId,
+                worktreeHead: requestWorktree?.head ?? null,
                 linkedPRNumber,
                 fallbackPRNumber,
                 fallbackPRSource,

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -44,7 +44,11 @@ import { settingsForProjectRowOwner } from './github-project-row-owner'
 import { rightSidebarShowsPullRequestData } from '@/lib/right-sidebar-visibility'
 import { hostedReviewInfoFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
 import { getHostedReviewCacheKey, linkedReviewHintKey } from './hosted-review-cache-identity'
-import { getGitHubPRCacheKey, getGitHubRepoCacheKey } from './github-cache-key'
+import {
+  getGitHubPRCacheBranch,
+  getGitHubPRCacheKey,
+  getGitHubRepoCacheKey
+} from './github-cache-key'
 import { isGitHubWorkItemsQueryTooLarge } from './github-work-items-query-bounds'
 import { isMacAppDataPath } from '@/lib/passive-macos-app-data-access'
 import { translate } from '@/i18n/i18n'
@@ -1018,10 +1022,11 @@ function buildPRRefreshCandidate(
     return null
   }
   const branch = worktree.branch.replace(/^refs\/heads\//, '')
+  const cacheBranch = getGitHubPRCacheBranch(branch, worktree.head)
   const cacheKey = prCacheKey(
     repoPath ?? repo.path,
     repo.id,
-    branch,
+    cacheBranch,
     settingsForGitHubRepoOwner(state.settings, repo),
     repo.connectionId,
     repo.executionHostId,
@@ -1032,7 +1037,7 @@ function buildPRRefreshCandidate(
     state,
     repoPath ?? repo.path,
     repo.id,
-    branch,
+    cacheBranch,
     repo.connectionId,
     repo.executionHostId,
     true
@@ -1156,6 +1161,7 @@ function syncHostedReviewCacheFromGitHubPRResult(args: {
   cache: AppState['hostedReviewCache']
   repoPath: string
   branch: string
+  hostedReviewBranch?: string
   settings: AppState['settings']
   repoId?: string
   connectionId?: string | null
@@ -1171,7 +1177,7 @@ function syncHostedReviewCacheFromGitHubPRResult(args: {
 }): { cache: AppState['hostedReviewCache']; accepted: boolean } {
   const hostedReviewCacheKey = getHostedReviewCacheKey(
     args.repoPath,
-    args.branch,
+    args.hostedReviewBranch ?? args.branch,
     args.settings,
     args.repoId,
     args.connectionId,
@@ -1343,6 +1349,7 @@ function setGitHubPRResultCaches(
     prCacheKey: string
     repoPath: string
     branch: string
+    hostedReviewBranch?: string
     settings: AppState['settings']
     repoId?: string
     connectionId?: string | null
@@ -1362,6 +1369,7 @@ function setGitHubPRResultCaches(
     cache: state.hostedReviewCache,
     repoPath: args.repoPath,
     branch: args.branch,
+    hostedReviewBranch: args.hostedReviewBranch,
     settings: args.settings,
     repoId: args.repoId,
     connectionId: args.connectionId,
@@ -1377,7 +1385,7 @@ function setGitHubPRResultCaches(
   })
   const hostedReviewCacheKey = getHostedReviewCacheKey(
     args.repoPath,
-    args.branch,
+    args.hostedReviewBranch ?? args.branch,
     args.settings,
     args.repoId,
     args.connectionId,
@@ -1420,6 +1428,7 @@ function applyGitHubPRResultToCaches(args: {
   prCacheKey: string
   repoPath: string
   branch: string
+  hostedReviewBranch?: string
   settings: AppState['settings']
   repoId?: string
   connectionId?: string | null
@@ -1442,6 +1451,7 @@ function applyGitHubPRResultToCaches(args: {
     cache: args.hostedReviewCache,
     repoPath: args.repoPath,
     branch: args.branch,
+    hostedReviewBranch: args.hostedReviewBranch,
     settings: args.settings,
     repoId: args.repoId,
     connectionId: args.connectionId,
@@ -1457,7 +1467,7 @@ function applyGitHubPRResultToCaches(args: {
   })
   const hostedReviewCacheKey = getHostedReviewCacheKey(
     args.repoPath,
-    args.branch,
+    args.hostedReviewBranch ?? args.branch,
     args.settings,
     args.repoId,
     args.connectionId,
@@ -2865,11 +2875,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       options?.repoId ? candidate.id === options.repoId : candidate.path === repoPath
     )
     const repoId = options?.repoId ?? repo?.id
+    const requestWorktree = options?.worktreeId ? findWorktreeById(get(), options.worktreeId) : null
     const requestSettings = settingsForGitHubRepoOwner(get().settings, repo)
+    const cacheBranch = getGitHubPRCacheBranch(branch, requestWorktree?.head)
     const cacheKey = prCacheKey(
       repoPath,
       repoId,
-      branch,
+      cacheBranch,
       requestSettings,
       repo?.connectionId,
       repo?.executionHostId,
@@ -2878,7 +2890,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const cached = get().prCache[cacheKey]
     const hostedReviewCacheKey = getHostedReviewCacheKey(
       repoPath,
-      branch,
+      cacheBranch,
       requestSettings,
       repoId,
       repo?.connectionId,
@@ -2895,7 +2907,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       get(),
       repoPath,
       repoId,
-      branch,
+      cacheBranch,
       repo?.connectionId,
       repo?.executionHostId,
       repo !== undefined
@@ -2946,6 +2958,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                 repo: runtimeRepo.repo.id,
                 branch,
                 linkedPRNumber,
+                ...(requestWorktree?.head ? { currentHeadOid: requestWorktree.head } : {}),
                 ...(fallbackPRNumber !== null
                   ? { fallbackPRNumber, acceptMergedFallbackPR: fallbackPRSource !== null }
                   : {})
@@ -2957,9 +2970,6 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                 : ({ kind: 'no-pr', fetchedAt: Date.now() } as const)
             )
           : await (async () => {
-              const requestWorktree = options?.worktreeId
-                ? findWorktreeById(get(), options.worktreeId)
-                : null
               const candidate: GitHubPRRefreshCandidate = {
                 repoId: repoId ?? '',
                 repoPath,
@@ -2989,6 +2999,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                       branch,
                       linkedPRNumber,
                       fallbackPRNumber,
+                      currentHeadOid: requestWorktree?.head ?? null,
                       acceptMergedFallbackPR: fallbackPRNumber !== null && fallbackPRSource !== null
                     })
                     .then((pr) =>
@@ -3016,6 +3027,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               prCacheKey: cacheKey,
               repoPath,
               branch,
+              hostedReviewBranch: cacheBranch,
               settings: requestSettings,
               repoId,
               connectionId: repo?.connectionId,
@@ -3877,12 +3889,14 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           if (isStaleExactLinkedPRLookup(s, alias.worktreeId, alias.linkedPRNumber)) {
             continue
           }
+          const hostedReviewBranch = getGitHubPRCacheBranch(alias.branch, alias.worktreeHead)
           const nextCaches = applyGitHubPRResultToCaches({
             prCache: nextPRCache,
             hostedReviewCache: nextHostedReviewCache,
             prCacheKey: alias.cacheKey,
             repoPath: alias.repoPath,
             branch: alias.branch,
+            hostedReviewBranch,
             settings: s.settings,
             repoId: alias.repoId,
             connectionId: alias.connectionId,
@@ -3909,9 +3923,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             deletePRRefreshStartedEntry(previousSequence, alias.cacheKey)
           }
           if (event.status === 'in-flight' && event.requestStartedAt !== undefined) {
+            const hostedReviewBranch = getGitHubPRCacheBranch(alias.branch, alias.worktreeHead)
             const hostedReviewCacheKey = getHostedReviewCacheKey(
               alias.repoPath,
-              alias.branch,
+              hostedReviewBranch,
               s.settings,
               alias.repoId,
               alias.connectionId,
@@ -3998,12 +4013,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         }
 
         const branch = wt.branch.replace(/^refs\/heads\//, '')
-        if (shouldRefreshPRs && !wt.isBare && branch) {
+        if (shouldRefreshPRs && !wt.isBare && (branch || wt.head)) {
           const ownerSettings = settingsForGitHubRepoOwner(state.settings, repo)
+          const cacheBranch = getGitHubPRCacheBranch(branch, wt.head)
           const prKey = prCacheKey(
             repo.path,
             repo.id,
-            branch,
+            cacheBranch,
             ownerSettings,
             repo.connectionId,
             repo.executionHostId
@@ -4081,11 +4097,12 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
     // Invalidate this worktree's cache entries
     const branch = worktree.branch.replace(/^refs\/heads\//, '')
+    const cacheBranch = getGitHubPRCacheBranch(branch, worktree.head)
     const ownerSettings = settingsForGitHubRepoOwner(state.settings, repo)
     const prKey = prCacheKey(
       repo.path,
       repo.id,
-      branch,
+      cacheBranch,
       ownerSettings,
       repo.connectionId,
       repo.executionHostId
@@ -4116,8 +4133,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       return updates
     })
 
-    // Re-fetch (skip when branch is empty — detached HEAD during rebase)
-    if (!worktree.isBare && branch) {
+    // Re-fetch; detached merged worktrees resolve PRs from the checked-out HEAD.
+    if (!worktree.isBare && (branch || worktree.head)) {
       const candidate = buildPRRefreshCandidate(get(), worktree)
       if (candidate) {
         if (getPRRefreshRuntimeRepoTarget(get(), candidate)) {
@@ -4315,7 +4332,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         : cardProps.includes('pr') || rawCardProps.includes('ci')) ||
       rightSidebarShowsPullRequestData(state)
 
-    if (shouldRefreshPR && !worktree.isBare && branch) {
+    if (shouldRefreshPR && !worktree.isBare && (branch || worktree.head)) {
       const candidate = buildPRRefreshCandidate(state, worktree)
       if (candidate) {
         if (getPRRefreshRuntimeRepoTarget(state, candidate)) {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1056,6 +1056,7 @@ function buildPRRefreshCandidate(
     branch,
     cacheKey,
     worktreeId: worktree.id,
+    worktreeHead: worktree.head ?? null,
     // Why: persisted linked PR metadata is exact, while PR cache numbers are
     // only fallback hints after branch lookup misses.
     linkedPRNumber: worktree.linkedPR ?? null,

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1718,6 +1718,7 @@ function createGitHubApi(): WebGitHubApi {
         branch: candidate.branch,
         linkedPRNumber: candidate.linkedPRNumber ?? null,
         fallbackPRNumber: candidate.fallbackPRNumber ?? null,
+        ...(candidate.worktreeHead ? { currentHeadOid: candidate.worktreeHead } : {}),
         ...(acceptMergedFallbackPR ? { acceptMergedFallbackPR: true } : {})
       })
       return pr

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1139,6 +1139,7 @@ export type GitHubPRRefreshAlias = {
   repoPath: string
   branch: string
   worktreeId?: string
+  worktreeHead?: string | null
   connectionId?: string | null
   executionHostId?: string | null
   linkedPRNumber?: number | null


### PR DESCRIPTION
## Summary
- Resolve GitHub PRs from the checked-out merge commit when branch/upstream/fallback PR lookup misses, so merged detached worktrees keep PR context in the left sidebar and Checks tab.
- Scope branchless/detached PR and hosted-review cache entries by the checked-out HEAD instead of the empty branch string, preventing stale PRs from leaking between detached worktrees.
- Thread `currentHeadOid` / `worktreeHead` through renderer, IPC, runtime RPC, refresh coordinator aliases, queued/manual refreshes, right-sidebar refreshes, entry refreshes, and async cache keys so detached merged worktrees refresh under the same identity everywhere.
- Update the left sidebar card, folder/import aggregate card, and Checks panel to read/use detached-HEAD PR/hosted-review cache keys, including imported/folder and legacy local cache-key shapes.
- Add detached-only suffix fallback for PR cache owner-prefix mismatches observed on Windows, while keeping normal branch cards and hosted-review lookups on exact-key subscriptions.
- Fix the latest Windows repro shape: when a detached card has no `linkedPR`, a hosted review entry with `linkedReviewHintKey: github:<n>`, and a matching detached PR-cache entry, the card now shows the PR instead of the raw detached badge.
- Keep the stale linked-review guard: linked-hint detached hosted reviews are only shown unlinked when corroborated by the HEAD-scoped PR cache.
- Include detached worktrees in visible PR refresh reporting when `head` is present; branch worktrees remain branch-scoped so ordinary HEAD movement does not trigger extra visible PR refresh churn.
- Add short-lived commit-associated PR caching, in-flight dedupe, hydration dedupe, and bounded perf accounting for the extra merge-commit probe.

## Manual validation
- Created a throwaway PR in `stablyai/demo-project`, merged it, then opened a detached worktree at the resulting merged commit.
- Verified the app saw the detached worktree with empty branch and the merge commit HEAD.
- Verified the right sidebar Checks panel rendered the merged PR instead of “No pull request found”.
- Verified PR/hosted-review cache entries were written under the detached HEAD key, not the empty branch key.
- Windows validation through commit `1b3961128` confirmed no crash and correct right-sidebar/cache behavior, but the active left sidebar detached card still rendered raw detached status.
- Windows retest on `9a2d8b6a7fb0190c8890894d7c0bdb30e4285962` passed for both repro shapes:
  - direct imported detached folder showed `Linked PR #24` in the active left sidebar card, not `Detached HEAD @ 67c9b95`;
  - parent repo with external worktrees visible also showed `Linked PR #24` on the active detached child row;
  - right Checks panel stayed on `stablyai/demo-project#24`, title `Validate Orca PR status fallback 20260626214121`, merged state, and check status;
  - switching away/back and closing/reopening Checks stayed stable with no “No PR”, stale detached PR, or raw detached status after refresh settled;
  - logs showed no git/worktree/HEAD/path stack traces, crashes, fatal errors, or unhandled exceptions; only Chromium cache warnings.
- Local repro test for the Windows store shape failed before the display fix and now passes.
- Review-code loop on the latest diff found and fixed two issues before push:
  - normal branch visible-refresh identity briefly included `head`, which could cause extra refresh churn; now branch rows use branch identity and detached rows use head identity;
  - detached hosted-review hints were briefly neutralized too broadly; now they require HEAD-scoped PR-cache proof or the PR-cache display path.
- CodeRabbit follow-up found that Checks-panel tab-entry refresh still had a `!branch` guard; `9a2d8b6a7` changes GitHub entry refresh to use detached `head` identity while keeping GitLab branch-scoped.
- Internal `perf` skill review found the hosted-review suffix fallback could scan the whole cache per detached card on unrelated store updates; `9a2d8b6a7` removes that scan and relies on exact hosted-review keys plus the detached PR-cache fallback.

## Performance notes
- The merge-commit lookup only runs after cheaper branch/upstream/fallback paths miss and only when a usable explicit HEAD hint is present.
- Commit-associated PR probes use short TTLs, a bounded cache, and in-flight coalescing so multiple visible worktrees on the same commit share the same request.
- Background refresh accounting charges the extra core probe, and tests assert coalescing keeps the latest HEAD hint without merging distinct detached HEADs.
- Sidebar cache fallback first checks exact keys; suffix fallback is detached-only and only for PR cache after exact detached keys miss. Hosted-review cache lookup stays exact-key only to avoid O(visible detached cards × hosted cache size) selector work.
- Visible refresh reporting includes branchless worktrees only when `head` is present; normal branch cards remain branch-scoped.

## Automated validation
- Focused sidebar/status run after the latest fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx src/renderer/src/components/right-sidebar/active-checks-status.test.ts src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx src/renderer/src/components/sidebar/WorktreeCard.branch-review-pending.test.tsx src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx` — 7 files / 58 tests passed
- Broader PR-status run after the latest fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx src/renderer/src/components/right-sidebar/active-checks-status.test.ts src/renderer/src/store/slices/github.test.ts src/renderer/src/store/slices/github-pr-refresh-owner-routing.test.ts src/renderer/src/components/sidebar/WorktreeCard.branch-review-pending.test.tsx src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts src/main/github/client.test.ts src/main/github/pr-refresh-coordinator.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/github.test.ts src/main/ipc/github.test.ts src/renderer/src/web/web-preload-api.test.ts` — 14 files / 894 tests passed
- Windows focused test command — 7 files / 62 tests passed
- Windows `pnpm run typecheck` — passed
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed with the existing `useGitStatusPolling.ts` warning
- `git diff --check` — passed
- Local macOS isolated Electron E2E fresh-start smoke with a temporary spec (removed after run) — direct detached import and parent repo with external worktrees visible both showed `Linked PR #24` and the Checks panel stayed on demo-project PR #24; 2 tests passed.
- Fresh-start Windows smoke at `9a2d8b6a7fb0190c8890894d7c0bdb30e4285962` passed both sidebar shapes: direct imported detached folder and parent repo with external worktrees visible both rendered PR-aware left sidebar rows (`PR: Merged...` in the fresh default UI), not `Detached HEAD @ 67c9b95`; backing cache and Checks panel identified demo-project PR #24, Checks showed `#24`, `MERGED`, title `Validate Orca PR status fallback 20260626214121`, and 1 failing check; closing/reopening Checks and switching away/back stayed stable; stdout/stderr scans found no crash, stack traces, fatal errors, unhandled exceptions, or git/worktree/HEAD/path errors. Focused tests/typecheck were not rerun in this final smoke. Screenshots were left untracked under `.visual-evidence/` on the Windows machine.
- Windows `$git-crash-perf` audit at `9a2d8b6a7fb0190c8890894d7c0bdb30e4285962`: no new spawn/exec/`shell: true`/`git status`/`git worktree` scan path in the PR diff; detached refresh carries `worktreeHead` through the existing PR refresh coordinator; refresh remains bounded by coordinator concurrency (`MAX_CONCURRENT = 4`), Orca `ghExecFileAsync` timeout/retry behavior, commit-associated PR TTL caches capped at 256 entries, and in-flight coalescing; detached renderer suffix fallback scans only bounded `prCache` after exact detached-key misses and does not scan `hostedReviewCache`; no lingering `git.exe`/`gh.exe` after tests/typecheck; focused regression/perf-ish suite passed (8 files / 163 tests) and Windows `pnpm run typecheck` passed. Caveats: inactive-workspace cleanup/delete smoke and live SSH/WSL smoke were not rerun because PR #6470 does not touch those paths; the fallback `git rev-parse HEAD` helper uses the safe `gitExecFileAsync` wrapper but lacks an explicit timeout, and the detached repro path should not hit it because renderer provides `currentHeadOid`.