### PR TITLE
Fix runtime GitHub work item details

### DIFF
--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -282,6 +282,62 @@ describe('registerGitHubHandlers', () => {
     )
   })
 
+  it('broadcasts mutation notifications by repo id even when the payload path is remote', async () => {
+    const sendMock = vi.fn()
+    getAllWebContentsMock.mockReturnValue([
+      { id: 1, isDestroyed: () => false, send: vi.fn() },
+      { id: 2, isDestroyed: () => false, send: sendMock }
+    ])
+    registerGitHubHandlers(store as never, stats as never)
+
+    const result = await handlers['gh:notifyWorkItemMutated'](
+      { sender: { id: 1 } },
+      {
+        repoPath: '/home/runtime/repo',
+        repoId: 'repo-1',
+        type: 'pr',
+        number: 42
+      }
+    )
+
+    expect(result).toBe(true)
+    expect(sendMock).toHaveBeenCalledWith('gh:workItemMutated', {
+      repoPath: '/workspace/repo',
+      repoId: 'repo-1',
+      type: 'pr',
+      number: 42
+    })
+  })
+
+  it('broadcasts PR file viewed mutations with repo id for sibling cache invalidation', async () => {
+    const sendMock = vi.fn()
+    getAllWebContentsMock.mockReturnValue([
+      { id: 1, isDestroyed: () => false, send: vi.fn() },
+      { id: 2, isDestroyed: () => false, send: sendMock }
+    ])
+    setPRFileViewedMock.mockResolvedValue(true)
+    registerGitHubHandlers(store as never, stats as never)
+
+    const result = await handlers['gh:setPRFileViewed'](
+      { sender: { id: 1 } },
+      {
+        repoPath: '/workspace/repo',
+        prNumber: 42,
+        pullRequestId: 'PR_kw',
+        path: 'src/app.ts',
+        viewed: true
+      }
+    )
+
+    expect(result).toBe(true)
+    expect(sendMock).toHaveBeenCalledWith('gh:workItemMutated', {
+      repoPath: '/workspace/repo',
+      repoId: 'repo-1',
+      type: 'pr',
+      number: 42
+    })
+  })
+
   it('rejects unknown repository paths', async () => {
     registerGitHubHandlers(store as never, stats as never)
 

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -309,6 +309,32 @@ describe('registerGitHubHandlers', () => {
     })
   })
 
+  it('broadcasts mutation notifications with resolved repo id when called by repo path', async () => {
+    const sendMock = vi.fn()
+    getAllWebContentsMock.mockReturnValue([
+      { id: 1, isDestroyed: () => false, send: vi.fn() },
+      { id: 2, isDestroyed: () => false, send: sendMock }
+    ])
+    registerGitHubHandlers(store as never, stats as never)
+
+    const result = await handlers['gh:notifyWorkItemMutated'](
+      { sender: { id: 1 } },
+      {
+        repoPath: '/workspace/repo',
+        type: 'issue',
+        number: 7
+      }
+    )
+
+    expect(result).toBe(true)
+    expect(sendMock).toHaveBeenCalledWith('gh:workItemMutated', {
+      repoPath: '/workspace/repo',
+      repoId: 'repo-1',
+      type: 'issue',
+      number: 7
+    })
+  })
+
   it('broadcasts PR file viewed mutations with repo id for sibling cache invalidation', async () => {
     const sendMock = vi.fn()
     getAllWebContentsMock.mockReturnValue([

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -525,7 +525,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
       broadcastWorkItemMutated(
         {
           repoPath: repo.path,
-          repoId: args.repoId,
+          repoId: repo.id,
           type: args.type,
           number: args.number
         },

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -498,6 +498,44 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
   })
 
   ipcMain.handle(
+    'gh:notifyWorkItemMutated',
+    (
+      event,
+      args: {
+        repoPath: string
+        repoId?: string
+        type: 'issue' | 'pr'
+        number: number
+      }
+    ) => {
+      const repo = args.repoId
+        ? store.getRepos().find((candidate) => candidate.id === args.repoId)
+        : assertRegisteredRepo(args, store)
+      if (!repo) {
+        return false
+      }
+      if (
+        (args.type !== 'issue' && args.type !== 'pr') ||
+        typeof args.number !== 'number' ||
+        !Number.isInteger(args.number) ||
+        args.number < 1
+      ) {
+        return false
+      }
+      broadcastWorkItemMutated(
+        {
+          repoPath: repo.path,
+          repoId: args.repoId,
+          type: args.type,
+          number: args.number
+        },
+        event.sender.id
+      )
+      return true
+    }
+  )
+
+  ipcMain.handle(
     'gh:prFileContents',
     (
       _event,
@@ -688,7 +726,7 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
       })
       if (ok) {
         broadcastWorkItemMutated(
-          { repoPath: repo.path, type: 'pr', number: args.prNumber },
+          { repoPath: repo.path, repoId: repo.id, type: 'pr', number: args.prNumber },
           event.sender.id
         )
       }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1190,6 +1190,12 @@ export type PreloadApi = {
         type?: 'issue' | 'pr'
       }
     ) => Promise<GitHubWorkItemDetails | null>
+    notifyWorkItemMutated: (args: {
+      repoPath: string
+      repoId?: string
+      type: 'issue' | 'pr'
+      number: number
+    }) => Promise<boolean>
     prFileContents: (
       args: GitHubRepoSelectorArgs & {
         prNumber: number

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1005,6 +1005,13 @@ const api = {
       type?: 'issue' | 'pr'
     }): Promise<unknown> => ipcRenderer.invoke('gh:workItemDetails', args),
 
+    notifyWorkItemMutated: (args: {
+      repoPath: string
+      repoId?: string
+      type: 'issue' | 'pr'
+      number: number
+    }): Promise<boolean> => ipcRenderer.invoke('gh:notifyWorkItemMutated', args),
+
     prFileContents: (args: {
       repoPath: string
       repoId?: string

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -7038,7 +7038,7 @@ export default function GitHubItemDialog({
       .then((result) => {
         const invalidatedMidFlight = workItemDetailsCacheGeneration !== launchedAtGeneration
         const prev = workItemDetailsCache.get(detailsCacheKey)
-        if (invalidatedMidFlight) {
+        if (invalidatedMidFlight && prev?.pending !== inflight) {
           // Why: entry was deliberately dropped; do not recreate it. If the
           // entry still exists (later open repopulated it) leave it alone too.
           return
@@ -7067,10 +7067,10 @@ export default function GitHubItemDialog({
       .catch((err) => {
         const message = err instanceof Error ? err.message : 'Failed to load details'
         const invalidatedMidFlight = workItemDetailsCacheGeneration !== launchedAtGeneration
-        if (invalidatedMidFlight) {
+        const prev = workItemDetailsCache.get(detailsCacheKey)
+        if (invalidatedMidFlight && prev?.pending !== inflight) {
           return
         }
-        const prev = workItemDetailsCache.get(detailsCacheKey)
         // Why: stale-on-error — keep cached data if we have it, drop the
         // pending promise so the next open can retry. Only surface the
         // blocking error when nothing is cached.
@@ -7206,6 +7206,26 @@ export default function GitHubItemDialog({
     },
     [detailsCacheKey]
   )
+
+  const invalidateCurrentDetailsCache = useCallback((): void => {
+    if (!workItem) {
+      return
+    }
+    // Why: local repos can invalidate every source-preference variant; runtime-only
+    // entries need their exact source-scoped key because there is no local path.
+    if (repoPath) {
+      invalidateWorkItemDetailsCacheByMatch({
+        repoPath,
+        repoId: effectiveRepoId ?? undefined,
+        type: workItem.type,
+        number: workItem.number
+      })
+      return
+    }
+    if (detailsCacheKey) {
+      invalidateWorkItemDetailsCacheForKey(detailsCacheKey)
+    }
+  }, [detailsCacheKey, effectiveRepoId, repoPath, workItem])
 
   const handlePRFileViewedChange = useCallback(
     async (path: string, viewed: boolean): Promise<boolean> => {
@@ -7610,21 +7630,7 @@ export default function GitHubItemDialog({
           localLabels={localLabels}
           onStateChange={setLocalState}
           onLabelsChange={setLocalLabels}
-          onMutated={() => {
-            // Why: drop the cached details for this item so the next
-            // open issues a fresh fetch instead of painting pre-edit
-            // state. We invalidate by (repoPath, type, number) match
-            // because a single mutation can affect entries across all
-            // issueSourcePreference values for the same number.
-            if (repoPath) {
-              invalidateWorkItemDetailsCacheByMatch({
-                repoPath,
-                repoId: effectiveRepoId ?? undefined,
-                type: workItem.type,
-                number: workItem.number
-              })
-            }
-          }}
+          onMutated={invalidateCurrentDetailsCache}
           assignees={details?.assignees ?? []}
           onUse={onUse}
           onOpenOrUse={handleOpenOrUseIssueWorkspace}
@@ -7656,16 +7662,7 @@ export default function GitHubItemDialog({
                   localState={localState}
                   onStateChange={setLocalState}
                   projectOrigin={projectOrigin}
-                  onMutated={() => {
-                    if (repoPath) {
-                      invalidateWorkItemDetailsCacheByMatch({
-                        repoPath,
-                        repoId: effectiveRepoId ?? undefined,
-                        type: workItem.type,
-                        number: workItem.number
-                      })
-                    }
-                  }}
+                  onMutated={invalidateCurrentDetailsCache}
                   onChecksUpdated={(nextChecks) => {
                     if (detailsCacheKey) {
                       patchCachedPRChecks(detailsCacheKey, nextChecks)
@@ -7701,16 +7698,7 @@ export default function GitHubItemDialog({
                       localLabels={localLabels}
                       onStateChange={setLocalState}
                       onLabelsChange={setLocalLabels}
-                      onMutated={() => {
-                        if (repoPath) {
-                          invalidateWorkItemDetailsCacheByMatch({
-                            repoPath,
-                            repoId: effectiveRepoId ?? undefined,
-                            type: workItem.type,
-                            number: workItem.number
-                          })
-                        }
-                      }}
+                      onMutated={invalidateCurrentDetailsCache}
                       assignees={details?.assignees ?? []}
                       onUse={onUse}
                       onOpenOrUse={handleOpenOrUseIssueWorkspace}
@@ -7777,16 +7765,7 @@ export default function GitHubItemDialog({
                   localState={localState}
                   onStateChange={setLocalState}
                   projectOrigin={projectOrigin}
-                  onMutated={() => {
-                    if (repoPath) {
-                      invalidateWorkItemDetailsCacheByMatch({
-                        repoPath,
-                        repoId: effectiveRepoId ?? undefined,
-                        type: workItem.type,
-                        number: workItem.number
-                      })
-                    }
-                  }}
+                  onMutated={invalidateCurrentDetailsCache}
                   onChecksUpdated={(nextChecks) => {
                     if (detailsCacheKey) {
                       patchCachedPRChecks(detailsCacheKey, nextChecks)

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -3133,6 +3133,9 @@ function ConversationTab({
   const [bodyDraft, setBodyDraft] = useState(body)
   const [bodyEditing, setBodyEditing] = useState(false)
   const [bodySaving, setBodySaving] = useState(false)
+  const parsedSourceHost =
+    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
+  const canUseRepoMutationContext = !!repoPath || parsedSourceHost?.kind === 'runtime'
   const commentCounts = useMemo(() => getPRCommentAudienceCounts(comments), [comments])
   const visibleComments = useMemo(
     () => filterPRCommentsByAudience(comments, commentFilter),
@@ -3166,7 +3169,9 @@ function ConversationTab({
     [bodySlug, projectOrigin]
   )
   const canEditBody =
-    item.type === 'pr' ? Boolean(projectOrigin || bodySlug) : Boolean(projectOrigin || repoPath)
+    item.type === 'pr'
+      ? Boolean(projectOrigin || bodySlug)
+      : Boolean(projectOrigin || canUseRepoMutationContext)
   const bodyChanged = resolvedBodyDraft !== body
 
   const handleSaveBody = useCallback(async (): Promise<void> => {
@@ -3216,7 +3221,7 @@ function ConversationTab({
 
   const handleReply = useCallback(
     async (comment: PRComment, replyBody: string): Promise<boolean> => {
-      if (!repoPath) {
+      if (!canUseRepoMutationContext) {
         toast.error(
           translate(
             'auto.components.GitHubItemDialog.745c9089ec',
@@ -3228,7 +3233,7 @@ function ConversationTab({
       const result =
         comment.path && item.type === 'pr'
           ? await addPRReviewCommentReplyForRepo({
-              repoPath,
+              repoPath: repoPath ?? '',
               repoId: item.repoId,
               sourceContext,
               prNumber: item.number,
@@ -3239,7 +3244,7 @@ function ConversationTab({
               line: comment.line
             })
           : await addIssueCommentForRepo({
-              repoPath,
+              repoPath: repoPath ?? '',
               repoId: item.repoId,
               sourceContext,
               number: item.number,
@@ -3259,7 +3264,15 @@ function ConversationTab({
       toast.success(translate('auto.components.GitHubItemDialog.10f4ff5be8', 'Reply posted.'))
       return true
     },
-    [item.number, item.repoId, item.type, onCommentAdded, repoPath, sourceContext]
+    [
+      canUseRepoMutationContext,
+      item.number,
+      item.repoId,
+      item.type,
+      onCommentAdded,
+      repoPath,
+      sourceContext
+    ]
   )
 
   const rightPanel =
@@ -3803,10 +3816,10 @@ function ConversationTab({
           </>
         ) : null}
 
-        {detailsLoaded && repoPath && (
+        {detailsLoaded && canUseRepoMutationContext && (
           <GHCommentComposer
             className="mt-1"
-            repoPath={repoPath}
+            repoPath={repoPath ?? ''}
             repoId={item.repoId}
             sourceContext={sourceContext}
             issueNumber={item.number}
@@ -3850,7 +3863,9 @@ function PRActionsPanel({
   const mergeMethods = resolveGitHubPRMergeMethods(actionItem.mergeMethodSettings)
   const sourceSettings = getTaskSourceRuntimeSettings(sourceContext)
   const mergeTarget = getActiveRuntimeTarget(sourceSettings)
-  const canMutateState = localState !== 'merged' && (!!repoPath || !!projectOrigin)
+  const canMutateWithRepoContext =
+    !!repoPath || !!projectOrigin || mergeTarget.kind === 'environment'
+  const canMutateState = localState !== 'merged' && canMutateWithRepoContext
   const nextState: 'open' | 'closed' = localState === 'closed' ? 'open' : 'closed'
   const canMergeWithRepoContext = !!repoPath || mergeTarget.kind === 'environment'
   const mergeDisabled =
@@ -4110,7 +4125,7 @@ function PRActionsPanel({
               </DropdownMenuTrigger>
             </TooltipTrigger>
             <TooltipContent side="bottom" sideOffset={6}>
-              {!repoPath
+              {!canMergeWithRepoContext
                 ? translate(
                     'auto.components.GitHubItemDialog.5932578f51',
                     'Merge requires a registered local repo'
@@ -4121,7 +4136,7 @@ function PRActionsPanel({
           <DropdownMenuContent align="start" className="w-52">
             {mergePresentation.autoMergeAction && (
               <DropdownMenuItem
-                disabled={!repoPath || mergePending}
+                disabled={!canMergeWithRepoContext || mergePending}
                 onSelect={() => void handleAutoMerge()}
               >
                 <GitMerge className="size-4" />
@@ -4423,6 +4438,7 @@ function ChecksTab({
   const prRepo = useMemo(() => parseOwnerRepoFromItemUrl(item.url), [item.url])
   const parsedSourceHost =
     sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
+  const canUseChecksRepoContext = !!repoPath || parsedSourceHost?.kind === 'runtime'
   const sorted = [...list].sort(
     (a, b) =>
       (CHECK_SORT_ORDER[getCheckConclusion(a)] ?? 3) -
@@ -4450,7 +4466,7 @@ function ChecksTab({
   const canFixBrokenChecks = Boolean((repoId ?? item.repoId) && failedChecks.length > 0)
 
   const handleRefresh = useCallback(async (): Promise<PRCheckDetail[] | null> => {
-    if (!repoPath) {
+    if (!canUseChecksRepoContext) {
       toast.error(
         translate(
           'auto.components.GitHubItemDialog.e7007aa1d8',
@@ -4475,7 +4491,7 @@ function ChecksTab({
             { timeoutMs: 30_000 }
           )
         : window.api.gh.prChecks({
-            repoPath,
+            repoPath: repoPath ?? '',
             repoId: repoId ?? undefined,
             sourceContext,
             prNumber: item.number,
@@ -4496,6 +4512,7 @@ function ChecksTab({
       setRefreshing(false)
     }
   }, [
+    canUseChecksRepoContext,
     headSha,
     item.number,
     item.repoId,
@@ -4509,7 +4526,7 @@ function ChecksTab({
 
   const handleRerun = useCallback(
     async (failedOnly: boolean): Promise<void> => {
-      if (!repoPath || rerunning) {
+      if (!canUseChecksRepoContext || rerunning) {
         return
       }
       setRerunning(true)
@@ -4528,7 +4545,7 @@ function ChecksTab({
                 { timeoutMs: 30_000 }
               )
             : await window.api.gh.rerunPRChecks({
-                repoPath,
+                repoPath: repoPath ?? '',
                 repoId: repoId ?? undefined,
                 sourceContext,
                 prNumber: item.number,
@@ -4556,6 +4573,7 @@ function ChecksTab({
       }
     },
     [
+      canUseChecksRepoContext,
       handleRefresh,
       headSha,
       item.number,
@@ -4632,7 +4650,7 @@ function ChecksTab({
       const key = getCheckDetailsKey(check)
       setChecksState((current) => toggleGitHubChecksTabExpandedKey(current, key))
       if (
-        !repoPath ||
+        !canUseChecksRepoContext ||
         detailsByCheckKey[key] ||
         (!check.checkRunId && !check.workflowRunId && !check.url)
       ) {
@@ -4661,7 +4679,7 @@ function ChecksTab({
               { timeoutMs: 30_000 }
             )
           : window.api.gh.prCheckDetails({
-              repoPath,
+              repoPath: repoPath ?? '',
               repoId: repoId ?? undefined,
               sourceContext,
               checkRunId: check.checkRunId,
@@ -4697,6 +4715,7 @@ function ChecksTab({
         })
     },
     [
+      canUseChecksRepoContext,
       detailsByCheckKey,
       item.repoId,
       mountedRef,
@@ -4716,7 +4735,7 @@ function ChecksTab({
           variant="ghost"
           size="icon-xs"
           className="size-7 shrink-0"
-          disabled={!repoPath || refreshing}
+          disabled={!canUseChecksRepoContext || refreshing}
           onClick={() => void handleRefresh()}
           aria-label={translate('auto.components.GitHubItemDialog.9a1004fc76', 'Refresh checks')}
         >
@@ -4767,7 +4786,7 @@ function ChecksTab({
             variant="outline"
             size="xs"
             className="h-7 gap-1 px-2 text-[11px]"
-            disabled={!repoPath || rerunning || list.length === 0}
+            disabled={!canUseChecksRepoContext || rerunning || list.length === 0}
           >
             {rerunning ? (
               <LoaderCircle className="size-3 animate-spin" />
@@ -5263,13 +5282,13 @@ async function runIssueUpdate(args: {
     }
     return
   }
-  if (!args.repoPath) {
-    throw new Error('No repo context available for this edit.')
-  }
   const parsedHost =
     args.sourceContext?.provider === 'github'
       ? parseExecutionHostId(args.sourceContext.hostId)
       : null
+  if (!args.repoPath && parsedHost?.kind !== 'runtime') {
+    throw new Error('No repo context available for this edit.')
+  }
   const res =
     parsedHost?.kind === 'runtime'
       ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssue>>>(
@@ -5283,7 +5302,7 @@ async function runIssueUpdate(args: {
           { timeoutMs: 30_000 }
         )
       : await window.api.gh.updateIssue({
-          repoPath: args.repoPath,
+          repoPath: args.repoPath ?? '',
           repoId: args.repoId ?? undefined,
           sourceContext: args.sourceContext,
           number: args.number,
@@ -5295,7 +5314,7 @@ async function runIssueUpdate(args: {
   if (parsedHost?.kind === 'runtime') {
     notifyWorkItemDetailsMutation(
       {
-        repoPath: args.repoPath,
+        repoPath: args.repoPath ?? '',
         repoId: args.repoId ?? undefined,
         sourceContext: args.sourceContext,
         type: 'issue',
@@ -5419,13 +5438,13 @@ async function runPullRequestStateUpdate(args: {
     }
     return
   }
-  if (!args.repoPath) {
-    throw new Error('No repo context available for this pull request.')
-  }
   const parsedHost =
     args.sourceContext?.provider === 'github'
       ? parseExecutionHostId(args.sourceContext.hostId)
       : null
+  if (!args.repoPath && parsedHost?.kind !== 'runtime') {
+    throw new Error('No repo context available for this pull request.')
+  }
   const res =
     parsedHost?.kind === 'runtime'
       ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
@@ -5439,7 +5458,7 @@ async function runPullRequestStateUpdate(args: {
           { timeoutMs: 30_000 }
         )
       : await window.api.gh.updatePRState({
-          repoPath: args.repoPath,
+          repoPath: args.repoPath ?? '',
           repoId: args.repoId ?? undefined,
           sourceContext: args.sourceContext,
           prNumber: args.number,
@@ -5451,7 +5470,7 @@ async function runPullRequestStateUpdate(args: {
   if (parsedHost?.kind === 'runtime') {
     notifyWorkItemDetailsMutation(
       {
-        repoPath: args.repoPath,
+        repoPath: args.repoPath ?? '',
         repoId: args.repoId ?? undefined,
         sourceContext: args.sourceContext,
         type: 'pr',
@@ -6815,12 +6834,15 @@ export default function GitHubItemDialog({
     return s.repos.find((r) => (effectiveRepoId ? r.id === effectiveRepoId : r.path === repoPath))
       ?.issueSourcePreference
   })
+  const detailsSourceHost =
+    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
+  const canUseDetailsRepoContext = !!repoPath || detailsSourceHost?.kind === 'runtime'
   const detailsCacheKey = useMemo(() => {
-    if (!workItem || !repoPath || !effectiveRepoId) {
+    if (!workItem || !effectiveRepoId || !canUseDetailsRepoContext) {
       return null
     }
     return getWorkItemDetailsCacheKey({
-      repoPath,
+      repoPath: repoPath ?? '',
       repoId: effectiveRepoId,
       issueSourcePreference,
       sourceCacheScope:
@@ -6828,7 +6850,14 @@ export default function GitHubItemDialog({
       type: workItem.type,
       number: workItem.number
     })
-  }, [repoPath, effectiveRepoId, sourceContext, workItem, issueSourcePreference])
+  }, [
+    canUseDetailsRepoContext,
+    repoPath,
+    effectiveRepoId,
+    sourceContext,
+    workItem,
+    issueSourcePreference
+  ])
 
   // Why: track comments added optimistically before the detail fetch resolves
   // so they can be merged into the fetch result instead of being overwritten.
@@ -6956,7 +6985,7 @@ export default function GitHubItemDialog({
   }, [workItem, detailsCacheKey, cachedEntry])
 
   useEffect(() => {
-    if (!workItem || !repoPath || !effectiveRepoId || !detailsCacheKey) {
+    if (!workItem || !effectiveRepoId || !detailsCacheKey || !canUseDetailsRepoContext) {
       return
     }
     // Why: only clear optimistic comments when switching to a genuinely
@@ -6984,7 +7013,7 @@ export default function GitHubItemDialog({
     const inflight: Promise<GitHubWorkItemDetails | null> =
       cached?.pending ??
       lookupGitHubWorkItemDetailsForSource({
-        repoPath,
+        repoPath: repoPath ?? '',
         repoId: effectiveRepoId,
         sourceContext,
         number: workItem.number,
@@ -7051,7 +7080,16 @@ export default function GitHubItemDialog({
           error: message
         })
       })
-  }, [repoPath, effectiveRepoId, sourceContext, workItem, detailsCacheKey, initialTab, refetchTick])
+  }, [
+    canUseDetailsRepoContext,
+    repoPath,
+    effectiveRepoId,
+    sourceContext,
+    workItem,
+    detailsCacheKey,
+    initialTab,
+    refetchTick
+  ])
 
   const Icon = workItem?.type === 'pr' ? GitPullRequest : CircleDot
   const displayWorkItem = useMemo<GitHubWorkItem | null>(() => {
@@ -7171,7 +7209,12 @@ export default function GitHubItemDialog({
 
   const handlePRFileViewedChange = useCallback(
     async (path: string, viewed: boolean): Promise<boolean> => {
-      if (!repoPath || !details?.pullRequestId || !workItem || workItem.type !== 'pr') {
+      if (
+        !canUseDetailsRepoContext ||
+        !details?.pullRequestId ||
+        !workItem ||
+        workItem.type !== 'pr'
+      ) {
         toast.error(
           translate(
             'auto.components.GitHubItemDialog.c0253318d6',
@@ -7188,7 +7231,7 @@ export default function GitHubItemDialog({
       try {
         const ok = await setPRFileViewedForRepo({
           repoId: workItem.repoId,
-          repoPath,
+          repoPath: repoPath ?? '',
           sourceContext,
           prNumber: workItem.number,
           pullRequestId: details.pullRequestId,
@@ -7216,7 +7259,14 @@ export default function GitHubItemDialog({
         })
       }
     },
-    [details?.pullRequestId, detailsCacheKey, repoPath, sourceContext, workItem]
+    [
+      canUseDetailsRepoContext,
+      details?.pullRequestId,
+      detailsCacheKey,
+      repoPath,
+      sourceContext,
+      workItem
+    ]
   )
 
   const isIssuePage = workItem?.type === 'issue'
@@ -7549,7 +7599,7 @@ export default function GitHubItemDialog({
         </div>
       )}
 
-      {!isIssuePage && (repoPath || projectOrigin) && (
+      {!isIssuePage && (canUseDetailsRepoContext || projectOrigin) && (
         <GHEditSection
           item={workItem}
           repoPath={repoPath}
@@ -7638,7 +7688,7 @@ export default function GitHubItemDialog({
                   }}
                 />
               </div>
-              {(repoPath || projectOrigin) && (
+              {(canUseDetailsRepoContext || projectOrigin) && (
                 <div className="min-w-0">
                   <div className="lg:sticky lg:top-4">
                     <GHEditSection

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -159,6 +159,11 @@ import {
   getCommentBodySubmitState,
   hasBoundedCommentBodyText
 } from '@/lib/comment-body-submit-state'
+import {
+  emitGitHubWorkItemDetailsCacheMutation,
+  onGitHubWorkItemDetailsCacheMutation
+} from '@/lib/github-work-item-details-cache-events'
+import { lookupGitHubWorkItemDetailsForSource } from '@/lib/github-work-item-source-lookup'
 import IssueSourceIndicator, { sameGitHubOwnerRepo } from '@/components/github/IssueSourceIndicator'
 import {
   getGitHubPRReviewerRows,
@@ -175,6 +180,7 @@ import {
   GITHUB_PR_MERGE_METHOD_LABELS,
   resolveGitHubPRMergeMethods
 } from '../../../shared/github-pr-merge-methods'
+import { parseExecutionHostId } from '../../../shared/execution-host'
 import {
   findGithubIssueWorkspaceAttachment,
   getGithubWorkItemWorkspaceAttachmentLabel
@@ -200,6 +206,7 @@ import type {
   PRComment
 } from '../../../shared/types'
 import {
+  getTaskSourceCacheScope,
   getTaskSourceRuntimeSettings,
   type TaskSourceContext
 } from '../../../shared/task-source-context'
@@ -939,12 +946,13 @@ function PRReviewersPanel({
     }
     setSubmitting(true)
     try {
+      const runtimeRepo = sourceContext?.repoId ?? item.repoId
       const result =
         target.kind === 'environment'
           ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
               target,
               'github.requestPRReviewers',
-              { repo: item.repoId, prNumber: item.number, reviewers: logins },
+              { repo: runtimeRepo, prNumber: item.number, reviewers: logins },
               { timeoutMs: 30_000 }
             )
           : await window.api.gh.requestPRReviewers({
@@ -974,6 +982,18 @@ function PRReviewersPanel({
         sourceContext
       })
       onReviewersRequested(nextReviewRequests)
+      if (target.kind === 'environment') {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: repoPath ?? '',
+            repoId: item.repoId,
+            sourceContext,
+            type: 'pr',
+            number: item.number
+          },
+          { local: false }
+        )
+      }
       setReviewerInput('')
       useAppStore.getState().recordFeatureInteraction('github-tasks')
       toast.success(
@@ -1017,12 +1037,13 @@ function PRReviewersPanel({
     }
     setSubmitting(true)
     try {
+      const runtimeRepo = sourceContext?.repoId ?? item.repoId
       const result =
         target.kind === 'environment'
           ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
               target,
               'github.removePRReviewers',
-              { repo: item.repoId, prNumber: item.number, reviewers: logins },
+              { repo: runtimeRepo, prNumber: item.number, reviewers: logins },
               { timeoutMs: 30_000 }
             )
           : await window.api.gh.removePRReviewers({
@@ -1051,6 +1072,18 @@ function PRReviewersPanel({
         sourceContext
       })
       onReviewersRequested(nextReviewRequests)
+      if (target.kind === 'environment') {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: repoPath ?? '',
+            repoId: item.repoId,
+            sourceContext,
+            type: 'pr',
+            number: item.number
+          },
+          { local: false }
+        )
+      }
       setReviewerInput('')
       useAppStore.getState().recordFeatureInteraction('github-tasks')
       toast.success(
@@ -1365,6 +1398,7 @@ function isPRFileViewed(file: GitHubPRFile): boolean {
 // background refetch on open. See docs/gh-work-item-drawer-cache.md.
 const WORK_ITEM_DETAILS_CACHE_MAX = 50
 const WORK_ITEM_DETAILS_FRESH_MS = 30_000
+const WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE = 'Unable to load details for this GitHub item.'
 type WorkItemDetailsCacheEntry = {
   details: GitHubWorkItemDetails | null
   fetchedAt: number
@@ -1394,12 +1428,16 @@ function getWorkItemDetailsCacheKey(args: {
   repoPath: string
   repoId: string
   issueSourcePreference: string | undefined
+  sourceCacheScope?: string | null
   type: 'issue' | 'pr'
   number: number
 }): string {
   // Why: include all axes that change which (repo, item) the IPC resolves to.
   // `\0` separator avoids ambiguity between fields that may contain `:` or `/`.
-  return [args.repoId, args.issueSourcePreference ?? 'auto', args.type, args.number].join('\0')
+  const keyParts = args.sourceCacheScope
+    ? [args.repoId, args.sourceCacheScope, args.issueSourcePreference ?? 'auto', args.type]
+    : [args.repoId, args.issueSourcePreference ?? 'auto', args.type]
+  return [...keyParts, args.number].join('\0')
 }
 
 function touchWorkItemDetailsCache(key: string, entry: WorkItemDetailsCacheEntry): void {
@@ -1446,7 +1484,6 @@ function invalidateWorkItemDetailsCacheByMatch(args: {
   type: 'issue' | 'pr'
   number: number
 }): void {
-  workItemDetailsCacheGeneration += 1
   const suffix = `\0${args.type}\0${args.number}`
   const prefix = `${args.repoId ?? args.repoPath}\0`
   let removed = false
@@ -1457,6 +1494,7 @@ function invalidateWorkItemDetailsCacheByMatch(args: {
     }
   }
   if (removed) {
+    workItemDetailsCacheGeneration += 1
     notifyWorkItemDetailsCache()
   }
 }
@@ -1541,6 +1579,7 @@ function patchCachedWorkItemBody(cacheKey: string, body: string): void {
 // own cache when any window's mutation lands. We track the unsubscribe so
 // Vite HMR doesn't accumulate listeners across module reloads in dev.
 let workItemMutatedUnsub: (() => void) | undefined
+let workItemDetailsCacheEventUnsub: (() => void) | undefined
 if (typeof window !== 'undefined' && window.api?.gh?.onWorkItemMutated) {
   workItemMutatedUnsub = window.api.gh.onWorkItemMutated((payload) => {
     invalidateWorkItemDetailsCacheByMatch({
@@ -1550,10 +1589,14 @@ if (typeof window !== 'undefined' && window.api?.gh?.onWorkItemMutated) {
       number: payload.number
     })
   })
+  workItemDetailsCacheEventUnsub = onGitHubWorkItemDetailsCacheMutation((payload) => {
+    invalidateWorkItemDetailsCacheByMatch(payload)
+  })
 }
 if (typeof import.meta !== 'undefined' && import.meta.hot) {
   import.meta.hot.dispose(() => {
     workItemMutatedUnsub?.()
+    workItemDetailsCacheEventUnsub?.()
   })
 }
 
@@ -1650,14 +1693,20 @@ function touchPRFileContentCache(
 function getPRFileContentCacheKey(args: {
   repoPath: string
   repoId: string
+  sourceContext?: TaskSourceContext | null
   prNumber: number
   file: GitHubPRFile
   headSha: string
   baseSha: string
 }): string {
   const repositoryKey = args.repoId ? `repo:${args.repoId}` : `path:${args.repoPath}`
+  const sourceKey =
+    args.sourceContext?.provider === 'github'
+      ? `source:${getTaskSourceCacheScope(args.sourceContext)}`
+      : 'source:local'
   return [
     repositoryKey,
+    sourceKey,
     args.prNumber,
     args.file.path,
     args.file.oldPath ?? '',
@@ -1683,18 +1732,38 @@ function loadPRFileContents(args: {
     return Promise.resolve(cached.value)
   }
   let request: Promise<GitHubPRFileContents>
-  request = window.api.gh
-    .prFileContents({
-      repoPath: args.repoPath,
-      repoId: args.repoId,
-      sourceContext: args.sourceContext,
-      prNumber: args.prNumber,
-      path: args.file.path,
-      oldPath: args.file.oldPath,
-      status: args.file.status,
-      headSha: args.headSha,
-      baseSha: args.baseSha
-    })
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  request = (
+    parsedHost?.kind === 'runtime'
+      ? callRuntimeRpc<GitHubPRFileContents>(
+          { kind: 'environment', environmentId: parsedHost.environmentId },
+          'github.prFileContents',
+          {
+            repo: args.sourceContext?.repoId ?? args.repoId,
+            prNumber: args.prNumber,
+            path: args.file.path,
+            oldPath: args.file.oldPath,
+            status: args.file.status,
+            headSha: args.headSha,
+            baseSha: args.baseSha
+          },
+          { timeoutMs: 30_000 }
+        )
+      : window.api.gh.prFileContents({
+          repoPath: args.repoPath,
+          repoId: args.repoId,
+          sourceContext: args.sourceContext,
+          prNumber: args.prNumber,
+          path: args.file.path,
+          oldPath: args.file.oldPath,
+          status: args.file.status,
+          headSha: args.headSha,
+          baseSha: args.baseSha
+        })
+  )
     .then((contents) => {
       if (prFileContentCache.get(cacheKey)?.value === request) {
         touchPRFileContentCache(cacheKey, contents)
@@ -1721,6 +1790,36 @@ function addIssueCommentForRepo(args: {
   body: string
   type?: 'issue' | 'pr'
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>> {
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  if (parsedHost?.kind === 'runtime') {
+    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.addIssueComment',
+      {
+        repo: args.sourceContext?.repoId ?? args.repoId,
+        number: args.number,
+        body: args.body
+      },
+      { timeoutMs: 30_000 }
+    ).then((result) => {
+      if (result.ok) {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: args.repoPath,
+            repoId: args.repoId,
+            sourceContext: args.sourceContext,
+            type: args.type ?? 'issue',
+            number: args.number
+          },
+          { local: false }
+        )
+      }
+      return result
+    })
+  }
   return window.api.gh.addIssueComment({
     repoPath: args.repoPath,
     repoId: args.repoId,
@@ -1742,6 +1841,40 @@ function addPRReviewCommentForRepo(args: {
   startLine?: number
   body: string
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>> {
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  if (parsedHost?.kind === 'runtime') {
+    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.addPRReviewComment',
+      {
+        repo: args.sourceContext?.repoId ?? args.repoId,
+        prNumber: args.prNumber,
+        commitId: args.commitId,
+        path: args.path,
+        line: args.line,
+        startLine: args.startLine,
+        body: args.body
+      },
+      { timeoutMs: 30_000 }
+    ).then((result) => {
+      if (result.ok) {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: args.repoPath,
+            repoId: args.repoId,
+            sourceContext: args.sourceContext,
+            type: 'pr',
+            number: args.prNumber
+          },
+          { local: false }
+        )
+      }
+      return result
+    })
+  }
   return window.api.gh.addPRReviewComment({
     repoPath: args.repoPath,
     repoId: args.repoId,
@@ -1766,6 +1899,40 @@ function addPRReviewCommentReplyForRepo(args: {
   path?: string
   line?: number
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>> {
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  if (parsedHost?.kind === 'runtime') {
+    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.addPRReviewCommentReply',
+      {
+        repo: args.sourceContext?.repoId ?? args.repoId,
+        prNumber: args.prNumber,
+        commentId: args.commentId,
+        body: args.body,
+        threadId: args.threadId,
+        path: args.path,
+        line: args.line
+      },
+      { timeoutMs: 30_000 }
+    ).then((result) => {
+      if (result.ok) {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: args.repoPath,
+            repoId: args.repoId,
+            sourceContext: args.sourceContext,
+            type: 'pr',
+            number: args.prNumber
+          },
+          { local: false }
+        )
+      }
+      return result
+    })
+  }
   return window.api.gh.addPRReviewCommentReply({
     repoPath: args.repoPath,
     repoId: args.repoId,
@@ -1779,8 +1946,31 @@ function addPRReviewCommentReplyForRepo(args: {
   })
 }
 
+function notifyWorkItemDetailsMutation(
+  args: {
+    repoPath: string
+    repoId?: string
+    sourceContext?: TaskSourceContext | null
+    type: 'issue' | 'pr'
+    number: number
+  },
+  options: { local?: boolean } = {}
+): void {
+  if (options.local !== false) {
+    emitGitHubWorkItemDetailsCacheMutation(args)
+  }
+  void window.api.gh
+    .notifyWorkItemMutated({
+      repoPath: args.repoPath,
+      repoId: args.repoId,
+      type: args.type,
+      number: args.number
+    })
+    .catch(() => undefined)
+}
+
 function setPRFileViewedForRepo(args: {
-  repoId?: string
+  repoId: string
   repoPath: string
   sourceContext?: TaskSourceContext | null
   prNumber: number
@@ -1788,6 +1978,37 @@ function setPRFileViewedForRepo(args: {
   path: string
   viewed: boolean
 }): Promise<boolean> {
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  if (parsedHost?.kind === 'runtime') {
+    return callRuntimeRpc<boolean>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.setPRFileViewed',
+      {
+        repo: args.sourceContext?.repoId ?? args.repoId,
+        pullRequestId: args.pullRequestId,
+        path: args.path,
+        viewed: args.viewed
+      },
+      { timeoutMs: 30_000 }
+    ).then((ok) => {
+      if (ok) {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: args.repoPath,
+            repoId: args.repoId,
+            sourceContext: args.sourceContext,
+            type: 'pr',
+            number: args.prNumber
+          },
+          { local: false }
+        )
+      }
+      return ok
+    })
+  }
   return window.api.gh.setPRFileViewed({
     repoPath: args.repoPath,
     repoId: args.repoId,
@@ -1796,22 +2017,6 @@ function setPRFileViewedForRepo(args: {
     pullRequestId: args.pullRequestId,
     path: args.path,
     viewed: args.viewed
-  })
-}
-
-function getWorkItemDetailsForRepo(args: {
-  repoId?: string
-  repoPath: string
-  sourceContext?: TaskSourceContext | null
-  number: number
-  type: 'issue' | 'pr'
-}): Promise<GitHubWorkItemDetails | null> {
-  return window.api.gh.workItemDetails({
-    repoPath: args.repoPath,
-    repoId: args.repoId,
-    sourceContext: args.sourceContext,
-    number: args.number,
-    type: args.type
   })
 }
 
@@ -3643,9 +3848,13 @@ function PRActionsPanel({
   const actionItem = { ...item, state: localState }
   const mergePresentation = presentGitHubPRMergeState(actionItem)
   const mergeMethods = resolveGitHubPRMergeMethods(actionItem.mergeMethodSettings)
+  const sourceSettings = getTaskSourceRuntimeSettings(sourceContext)
+  const mergeTarget = getActiveRuntimeTarget(sourceSettings)
   const canMutateState = localState !== 'merged' && (!!repoPath || !!projectOrigin)
   const nextState: 'open' | 'closed' = localState === 'closed' ? 'open' : 'closed'
-  const mergeDisabled = !repoPath || mergePending || !mergePresentation.directMergeAvailable
+  const canMergeWithRepoContext = !!repoPath || mergeTarget.kind === 'environment'
+  const mergeDisabled =
+    !canMergeWithRepoContext || mergePending || !mergePresentation.directMergeAvailable
 
   const patchProjectRowIfNeeded = useCallback(
     (state: GitHubWorkItem['state']) => {
@@ -3727,7 +3936,7 @@ function PRActionsPanel({
   }
 
   const handleMerge = async (method: GitHubPRMergeMethod): Promise<void> => {
-    if (!repoPath || mergeDisabled) {
+    if (mergeDisabled) {
       return
     }
     const label = GITHUB_PR_MERGE_METHOD_LABELS[method]
@@ -3748,19 +3957,44 @@ function PRActionsPanel({
     }
     setMergePending(true)
     try {
-      const result = await window.api.gh.mergePR({
-        repoPath,
-        repoId: repoId ?? undefined,
-        sourceContext,
-        prNumber: item.number,
-        method,
-        prRepo: item.prRepo ?? null
-      })
+      const result =
+        mergeTarget.kind === 'environment'
+          ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.mergePR>>>(
+              mergeTarget,
+              'github.mergePR',
+              {
+                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                prNumber: item.number,
+                method,
+                prRepo: item.prRepo ?? null
+              },
+              { timeoutMs: 30_000 }
+            )
+          : await window.api.gh.mergePR({
+              repoPath: repoPath ?? '',
+              repoId: repoId ?? undefined,
+              sourceContext,
+              prNumber: item.number,
+              method,
+              prRepo: item.prRepo ?? null
+            })
       if (!result.ok) {
         toast.error(result.error)
         return
       }
       applyStatePatch('merged')
+      if (mergeTarget.kind === 'environment') {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: repoPath ?? '',
+            repoId: item.repoId,
+            sourceContext,
+            type: 'pr',
+            number: item.number
+          },
+          { local: false }
+        )
+      }
       useAppStore.getState().recordFeatureInteraction('github-tasks')
       toast.success(translate('auto.components.GitHubItemDialog.dbe5e2448e', 'Pull request merged'))
       onMutated()
@@ -3774,24 +4008,50 @@ function PRActionsPanel({
   }
 
   const handleAutoMerge = async (): Promise<void> => {
-    if (!repoPath || !mergePresentation.autoMergeAction) {
+    if (!canMergeWithRepoContext || !mergePresentation.autoMergeAction) {
       return
     }
     const enabled = mergePresentation.autoMergeAction.kind === 'enable'
     setMergePending(true)
     try {
-      const result = await window.api.gh.setPRAutoMerge({
-        repoPath,
-        repoId: repoId ?? undefined,
-        sourceContext,
-        prNumber: item.number,
-        enabled,
-        method: enabled ? mergeMethods.defaultMethod : undefined,
-        prRepo: item.prRepo ?? null
-      })
+      const result =
+        mergeTarget.kind === 'environment'
+          ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.setPRAutoMerge>>>(
+              mergeTarget,
+              'github.setPRAutoMerge',
+              {
+                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                prNumber: item.number,
+                enabled,
+                method: enabled ? mergeMethods.defaultMethod : undefined,
+                prRepo: item.prRepo ?? null
+              },
+              { timeoutMs: 30_000 }
+            )
+          : await window.api.gh.setPRAutoMerge({
+              repoPath: repoPath ?? '',
+              repoId: repoId ?? undefined,
+              sourceContext,
+              prNumber: item.number,
+              enabled,
+              method: enabled ? mergeMethods.defaultMethod : undefined,
+              prRepo: item.prRepo ?? null
+            })
       if (!result.ok) {
         toast.error(result.error)
         return
+      }
+      if (mergeTarget.kind === 'environment') {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: repoPath ?? '',
+            repoId: item.repoId,
+            sourceContext,
+            type: 'pr',
+            number: item.number
+          },
+          { local: false }
+        )
       }
       useAppStore.getState().recordFeatureInteraction('github-tasks')
       toast.success(
@@ -4161,6 +4421,8 @@ function ChecksTab({
   const { localChecks, expandedCheckKey, detailsByCheckKey } = resolvedChecksState
   const list = useMemo(() => localChecks ?? checks ?? [], [checks, localChecks])
   const prRepo = useMemo(() => parseOwnerRepoFromItemUrl(item.url), [item.url])
+  const parsedSourceHost =
+    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
   const sorted = [...list].sort(
     (a, b) =>
       (CHECK_SORT_ORDER[getCheckConclusion(a)] ?? 3) -
@@ -4199,14 +4461,27 @@ function ChecksTab({
     }
     setRefreshing(true)
     try {
-      const nextChecks = (await window.api.gh.prChecks({
-        repoPath,
-        repoId: repoId ?? undefined,
-        sourceContext,
-        prNumber: item.number,
-        headSha,
-        noCache: true
-      })) as PRCheckDetail[]
+      const nextChecks = (await (parsedSourceHost?.kind === 'runtime'
+        ? callRuntimeRpc<PRCheckDetail[]>(
+            { kind: 'environment', environmentId: parsedSourceHost.environmentId },
+            'github.prChecks',
+            {
+              repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+              prNumber: item.number,
+              headSha,
+              prRepo,
+              noCache: true
+            },
+            { timeoutMs: 30_000 }
+          )
+        : window.api.gh.prChecks({
+            repoPath,
+            repoId: repoId ?? undefined,
+            sourceContext,
+            prNumber: item.number,
+            headSha,
+            noCache: true
+          }))) as PRCheckDetail[]
       setChecksState((current) => updateGitHubChecksTabLocalChecks(current, nextChecks))
       onChecksUpdated(nextChecks)
       return nextChecks
@@ -4220,7 +4495,17 @@ function ChecksTab({
     } finally {
       setRefreshing(false)
     }
-  }, [headSha, item.number, onChecksUpdated, repoId, repoPath, sourceContext])
+  }, [
+    headSha,
+    item.number,
+    item.repoId,
+    onChecksUpdated,
+    parsedSourceHost,
+    prRepo,
+    repoId,
+    repoPath,
+    sourceContext
+  ])
 
   const handleRerun = useCallback(
     async (failedOnly: boolean): Promise<void> => {
@@ -4229,14 +4514,27 @@ function ChecksTab({
       }
       setRerunning(true)
       try {
-        const result = await window.api.gh.rerunPRChecks({
-          repoPath,
-          repoId: repoId ?? undefined,
-          sourceContext,
-          prNumber: item.number,
-          headSha,
-          failedOnly
-        })
+        const result =
+          parsedSourceHost?.kind === 'runtime'
+            ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.rerunPRChecks>>>(
+                { kind: 'environment', environmentId: parsedSourceHost.environmentId },
+                'github.rerunPRChecks',
+                {
+                  repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                  prNumber: item.number,
+                  headSha,
+                  failedOnly
+                },
+                { timeoutMs: 30_000 }
+              )
+            : await window.api.gh.rerunPRChecks({
+                repoPath,
+                repoId: repoId ?? undefined,
+                sourceContext,
+                prNumber: item.number,
+                headSha,
+                failedOnly
+              })
         if (!result.ok) {
           toast.error(result.error)
           return
@@ -4257,7 +4555,17 @@ function ChecksTab({
         setRerunning(false)
       }
     },
-    [handleRefresh, headSha, item.number, rerunning, repoId, repoPath, sourceContext]
+    [
+      handleRefresh,
+      headSha,
+      item.number,
+      item.repoId,
+      parsedSourceHost,
+      rerunning,
+      repoId,
+      repoPath,
+      sourceContext
+    ]
   )
 
   const handleFixBrokenChecks = useCallback(async (): Promise<void> => {
@@ -4337,16 +4645,32 @@ function ChecksTab({
           error: null
         })
       )
-      void window.api.gh
-        .prCheckDetails({
-          repoPath,
-          repoId: repoId ?? undefined,
-          checkRunId: check.checkRunId,
-          workflowRunId: check.workflowRunId,
-          checkName: check.name,
-          url: check.url,
-          prRepo
-        })
+      const detailsRequest =
+        parsedSourceHost?.kind === 'runtime'
+          ? callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.prCheckDetails>>>(
+              { kind: 'environment', environmentId: parsedSourceHost.environmentId },
+              'github.prCheckDetails',
+              {
+                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                checkRunId: check.checkRunId,
+                workflowRunId: check.workflowRunId,
+                checkName: check.name,
+                url: check.url,
+                prRepo
+              },
+              { timeoutMs: 30_000 }
+            )
+          : window.api.gh.prCheckDetails({
+              repoPath,
+              repoId: repoId ?? undefined,
+              sourceContext,
+              checkRunId: check.checkRunId,
+              workflowRunId: check.workflowRunId,
+              checkName: check.name,
+              url: check.url,
+              prRepo
+            })
+      void detailsRequest
         .then((details) => {
           if (!mountedRef.current) {
             return
@@ -4372,7 +4696,16 @@ function ChecksTab({
           )
         })
     },
-    [detailsByCheckKey, mountedRef, prRepo, repoId, repoPath]
+    [
+      detailsByCheckKey,
+      item.repoId,
+      mountedRef,
+      parsedSourceHost,
+      prRepo,
+      repoId,
+      repoPath,
+      sourceContext
+    ]
   )
 
   const refreshAction = (
@@ -4891,7 +5224,11 @@ async function runIssueUpdate(args: {
   updates: Parameters<typeof window.api.gh.updateIssue>[0]['updates']
 }): Promise<void> {
   if (args.projectOrigin) {
-    const target = getActiveRuntimeTarget(getGitHubMutationSettings(args.repoId))
+    const targetSettings =
+      args.sourceContext?.provider === 'github'
+        ? getTaskSourceRuntimeSettings(args.sourceContext)
+        : getGitHubMutationSettings(args.repoId)
+    const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: args.projectOrigin.owner,
       repo: args.projectOrigin.repo,
@@ -4912,20 +5249,60 @@ async function runIssueUpdate(args: {
     if (!res.ok) {
       throw new Error(res.error.message)
     }
+    if (target.kind === 'environment') {
+      notifyWorkItemDetailsMutation(
+        {
+          repoPath: args.repoPath ?? '',
+          repoId: args.repoId ?? undefined,
+          sourceContext: args.sourceContext,
+          type: 'issue',
+          number: args.number
+        },
+        { local: false }
+      )
+    }
     return
   }
   if (!args.repoPath) {
     throw new Error('No repo context available for this edit.')
   }
-  const res = await window.api.gh.updateIssue({
-    repoPath: args.repoPath,
-    repoId: args.repoId ?? undefined,
-    sourceContext: args.sourceContext,
-    number: args.number,
-    updates: args.updates
-  })
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  const res =
+    parsedHost?.kind === 'runtime'
+      ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssue>>>(
+          { kind: 'environment', environmentId: parsedHost.environmentId },
+          'github.updateIssue',
+          {
+            repo: args.sourceContext?.repoId ?? args.repoId,
+            number: args.number,
+            updates: args.updates
+          },
+          { timeoutMs: 30_000 }
+        )
+      : await window.api.gh.updateIssue({
+          repoPath: args.repoPath,
+          repoId: args.repoId ?? undefined,
+          sourceContext: args.sourceContext,
+          number: args.number,
+          updates: args.updates
+        })
   if (!res.ok) {
     throw new Error(res.error)
+  }
+  if (parsedHost?.kind === 'runtime') {
+    notifyWorkItemDetailsMutation(
+      {
+        repoPath: args.repoPath,
+        repoId: args.repoId ?? undefined,
+        sourceContext: args.sourceContext,
+        type: 'issue',
+        number: args.number
+      },
+      { local: false }
+    )
   }
 }
 
@@ -4944,7 +5321,11 @@ async function runWorkItemBodyUpdate(args: {
     if (!targetSlug) {
       throw new Error('No GitHub repository context available for this pull request.')
     }
-    const target = getActiveRuntimeTarget(getGitHubMutationSettings(args.item.repoId))
+    const targetSettings =
+      args.sourceContext?.provider === 'github'
+        ? getTaskSourceRuntimeSettings(args.sourceContext)
+        : getGitHubMutationSettings(args.item.repoId)
+    const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: targetSlug.owner,
       repo: targetSlug.repo,
@@ -4964,6 +5345,18 @@ async function runWorkItemBodyUpdate(args: {
         : await window.api.gh.updatePullRequestBySlug(updateArgs)
     if (!res.ok) {
       throw new Error(res.error.message)
+    }
+    if (target.kind === 'environment') {
+      notifyWorkItemDetailsMutation(
+        {
+          repoPath: args.repoPath ?? '',
+          repoId: args.item.repoId,
+          sourceContext: args.sourceContext,
+          type: 'pr',
+          number: args.item.number
+        },
+        { local: false }
+      )
     }
     return
   }
@@ -4987,7 +5380,11 @@ async function runPullRequestStateUpdate(args: {
   updates: { state: 'open' | 'closed' }
 }): Promise<void> {
   if (args.projectOrigin) {
-    const target = getActiveRuntimeTarget(getGitHubMutationSettings(args.repoId))
+    const targetSettings =
+      args.sourceContext?.provider === 'github'
+        ? getTaskSourceRuntimeSettings(args.sourceContext)
+        : getGitHubMutationSettings(args.repoId)
+    const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: args.projectOrigin.owner,
       repo: args.projectOrigin.repo,
@@ -5008,20 +5405,60 @@ async function runPullRequestStateUpdate(args: {
     if (!res.ok) {
       throw new Error(res.error.message)
     }
+    if (target.kind === 'environment') {
+      notifyWorkItemDetailsMutation(
+        {
+          repoPath: args.repoPath ?? '',
+          repoId: args.repoId ?? undefined,
+          sourceContext: args.sourceContext,
+          type: 'pr',
+          number: args.number
+        },
+        { local: false }
+      )
+    }
     return
   }
   if (!args.repoPath) {
     throw new Error('No repo context available for this pull request.')
   }
-  const res = await window.api.gh.updatePRState({
-    repoPath: args.repoPath,
-    repoId: args.repoId ?? undefined,
-    sourceContext: args.sourceContext,
-    prNumber: args.number,
-    updates: args.updates
-  })
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  const res =
+    parsedHost?.kind === 'runtime'
+      ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
+          { kind: 'environment', environmentId: parsedHost.environmentId },
+          'github.updatePRState',
+          {
+            repo: args.sourceContext?.repoId ?? args.repoId,
+            prNumber: args.number,
+            updates: args.updates
+          },
+          { timeoutMs: 30_000 }
+        )
+      : await window.api.gh.updatePRState({
+          repoPath: args.repoPath,
+          repoId: args.repoId ?? undefined,
+          sourceContext: args.sourceContext,
+          prNumber: args.number,
+          updates: args.updates
+        })
   if (!res.ok) {
     throw new Error(res.error)
+  }
+  if (parsedHost?.kind === 'runtime') {
+    notifyWorkItemDetailsMutation(
+      {
+        repoPath: args.repoPath,
+        repoId: args.repoId ?? undefined,
+        sourceContext: args.sourceContext,
+        type: 'pr',
+        number: args.number
+      },
+      { local: false }
+    )
   }
 }
 
@@ -6386,10 +6823,12 @@ export default function GitHubItemDialog({
       repoPath,
       repoId: effectiveRepoId,
       issueSourcePreference,
+      sourceCacheScope:
+        sourceContext?.provider === 'github' ? getTaskSourceCacheScope(sourceContext) : null,
       type: workItem.type,
       number: workItem.number
     })
-  }, [repoPath, effectiveRepoId, workItem, issueSourcePreference])
+  }, [repoPath, effectiveRepoId, sourceContext, workItem, issueSourcePreference])
 
   // Why: track comments added optimistically before the detail fetch resolves
   // so they can be merged into the fetch result instead of being overwritten.
@@ -6503,9 +6942,7 @@ export default function GitHubItemDialog({
 
   const loading = !!cachedEntry?.pending && !cachedEntry?.details
   const error = cachedEntry?.error && !cachedEntry?.details ? cachedEntry.error : null
-  const detailsLoaded =
-    Boolean(cachedEntry?.details) ||
-    Boolean(cachedEntry && !cachedEntry.pending && !cachedEntry.error && cachedEntry.fetchedAt > 0)
+  const detailsLoaded = Boolean(cachedEntry?.details)
 
   // Why: if a cross-window mutation invalidates the open drawer's entry
   // (cachedEntry becomes undefined while workItem is still set), the main
@@ -6519,7 +6956,7 @@ export default function GitHubItemDialog({
   }, [workItem, detailsCacheKey, cachedEntry])
 
   useEffect(() => {
-    if (!workItem || !repoPath || !detailsCacheKey) {
+    if (!workItem || !repoPath || !effectiveRepoId || !detailsCacheKey) {
       return
     }
     // Why: only clear optimistic comments when switching to a genuinely
@@ -6546,9 +6983,9 @@ export default function GitHubItemDialog({
     // racing two `gh` subprocesses against each other.
     const inflight: Promise<GitHubWorkItemDetails | null> =
       cached?.pending ??
-      getWorkItemDetailsForRepo({
+      lookupGitHubWorkItemDetailsForSource({
         repoPath,
-        repoId: effectiveRepoId ?? undefined,
+        repoId: effectiveRepoId,
         sourceContext,
         number: workItem.number,
         type: workItem.type
@@ -6577,14 +7014,18 @@ export default function GitHubItemDialog({
           // entry still exists (later open repopulated it) leave it alone too.
           return
         }
-        // Why: 404/unauthorized must not overwrite valid cached data. When the
-        // IPC resolves to null and we already have cached details, keep the
-        // stale data — only blank entries get the null payload.
+        // Why: null means unavailable/not found, not loaded empty content.
         if (result === null && prev?.details) {
           touchWorkItemDetailsCache(detailsCacheKey, {
             details: prev.details,
             fetchedAt: prev.fetchedAt,
             error: undefined
+          })
+        } else if (result === null) {
+          touchWorkItemDetailsCache(detailsCacheKey, {
+            details: null,
+            fetchedAt: 0,
+            error: WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE
           })
         } else {
           touchWorkItemDetailsCache(detailsCacheKey, {

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -164,6 +164,11 @@ import {
   onGitHubWorkItemDetailsCacheMutation
 } from '@/lib/github-work-item-details-cache-events'
 import { lookupGitHubWorkItemDetailsForSource } from '@/lib/github-work-item-source-lookup'
+import {
+  canUseGitHubRepoContext,
+  getGitHubRuntimeRepoId,
+  getGitHubSourceRuntimeHost
+} from '@/lib/github-source-runtime-context'
 import IssueSourceIndicator, { sameGitHubOwnerRepo } from '@/components/github/IssueSourceIndicator'
 import {
   getGitHubPRReviewerRows,
@@ -180,7 +185,6 @@ import {
   GITHUB_PR_MERGE_METHOD_LABELS,
   resolveGitHubPRMergeMethods
 } from '../../../shared/github-pr-merge-methods'
-import { parseExecutionHostId } from '../../../shared/execution-host'
 import {
   findGithubIssueWorkspaceAttachment,
   getGithubWorkItemWorkspaceAttachmentLabel
@@ -946,7 +950,7 @@ function PRReviewersPanel({
     }
     setSubmitting(true)
     try {
-      const runtimeRepo = sourceContext?.repoId ?? item.repoId
+      const runtimeRepo = getGitHubRuntimeRepoId(sourceContext, item.repoId)
       const result =
         target.kind === 'environment'
           ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
@@ -1037,7 +1041,7 @@ function PRReviewersPanel({
     }
     setSubmitting(true)
     try {
-      const runtimeRepo = sourceContext?.repoId ?? item.repoId
+      const runtimeRepo = getGitHubRuntimeRepoId(sourceContext, item.repoId)
       const result =
         target.kind === 'environment'
           ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
@@ -1732,17 +1736,14 @@ function loadPRFileContents(args: {
     return Promise.resolve(cached.value)
   }
   let request: Promise<GitHubPRFileContents>
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
   request = (
-    parsedHost?.kind === 'runtime'
+    runtimeHost
       ? callRuntimeRpc<GitHubPRFileContents>(
-          { kind: 'environment', environmentId: parsedHost.environmentId },
+          { kind: 'environment', environmentId: runtimeHost.environmentId },
           'github.prFileContents',
           {
-            repo: args.sourceContext?.repoId ?? args.repoId,
+            repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
             prNumber: args.prNumber,
             path: args.file.path,
             oldPath: args.file.oldPath,
@@ -1790,16 +1791,13 @@ function addIssueCommentForRepo(args: {
   body: string
   type?: 'issue' | 'pr'
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>> {
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (parsedHost?.kind === 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (runtimeHost) {
     return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>>(
-      { kind: 'environment', environmentId: parsedHost.environmentId },
+      { kind: 'environment', environmentId: runtimeHost.environmentId },
       'github.addIssueComment',
       {
-        repo: args.sourceContext?.repoId ?? args.repoId,
+        repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
         number: args.number,
         body: args.body
       },
@@ -1841,16 +1839,13 @@ function addPRReviewCommentForRepo(args: {
   startLine?: number
   body: string
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>> {
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (parsedHost?.kind === 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (runtimeHost) {
     return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>>(
-      { kind: 'environment', environmentId: parsedHost.environmentId },
+      { kind: 'environment', environmentId: runtimeHost.environmentId },
       'github.addPRReviewComment',
       {
-        repo: args.sourceContext?.repoId ?? args.repoId,
+        repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
         prNumber: args.prNumber,
         commitId: args.commitId,
         path: args.path,
@@ -1899,16 +1894,13 @@ function addPRReviewCommentReplyForRepo(args: {
   path?: string
   line?: number
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>> {
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (parsedHost?.kind === 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (runtimeHost) {
     return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>>(
-      { kind: 'environment', environmentId: parsedHost.environmentId },
+      { kind: 'environment', environmentId: runtimeHost.environmentId },
       'github.addPRReviewCommentReply',
       {
-        repo: args.sourceContext?.repoId ?? args.repoId,
+        repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
         prNumber: args.prNumber,
         commentId: args.commentId,
         body: args.body,
@@ -1978,16 +1970,13 @@ function setPRFileViewedForRepo(args: {
   path: string
   viewed: boolean
 }): Promise<boolean> {
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (parsedHost?.kind === 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (runtimeHost) {
     return callRuntimeRpc<boolean>(
-      { kind: 'environment', environmentId: parsedHost.environmentId },
+      { kind: 'environment', environmentId: runtimeHost.environmentId },
       'github.setPRFileViewed',
       {
-        repo: args.sourceContext?.repoId ?? args.repoId,
+        repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
         pullRequestId: args.pullRequestId,
         path: args.path,
         viewed: args.viewed
@@ -3133,9 +3122,7 @@ function ConversationTab({
   const [bodyDraft, setBodyDraft] = useState(body)
   const [bodyEditing, setBodyEditing] = useState(false)
   const [bodySaving, setBodySaving] = useState(false)
-  const parsedSourceHost =
-    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
-  const canUseRepoMutationContext = !!repoPath || parsedSourceHost?.kind === 'runtime'
+  const canUseRepoMutationContext = canUseGitHubRepoContext(repoPath, sourceContext)
   const commentCounts = useMemo(() => getPRCommentAudienceCounts(comments), [comments])
   const visibleComments = useMemo(
     () => filterPRCommentsByAudience(comments, commentFilter),
@@ -3978,7 +3965,7 @@ function PRActionsPanel({
               mergeTarget,
               'github.mergePR',
               {
-                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
                 prNumber: item.number,
                 method,
                 prRepo: item.prRepo ?? null
@@ -4035,7 +4022,7 @@ function PRActionsPanel({
               mergeTarget,
               'github.setPRAutoMerge',
               {
-                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
                 prNumber: item.number,
                 enabled,
                 method: enabled ? mergeMethods.defaultMethod : undefined,
@@ -4436,9 +4423,8 @@ function ChecksTab({
   const { localChecks, expandedCheckKey, detailsByCheckKey } = resolvedChecksState
   const list = useMemo(() => localChecks ?? checks ?? [], [checks, localChecks])
   const prRepo = useMemo(() => parseOwnerRepoFromItemUrl(item.url), [item.url])
-  const parsedSourceHost =
-    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
-  const canUseChecksRepoContext = !!repoPath || parsedSourceHost?.kind === 'runtime'
+  const runtimeHost = getGitHubSourceRuntimeHost(sourceContext)
+  const canUseChecksRepoContext = canUseGitHubRepoContext(repoPath, sourceContext)
   const sorted = [...list].sort(
     (a, b) =>
       (CHECK_SORT_ORDER[getCheckConclusion(a)] ?? 3) -
@@ -4477,12 +4463,12 @@ function ChecksTab({
     }
     setRefreshing(true)
     try {
-      const nextChecks = (await (parsedSourceHost?.kind === 'runtime'
+      const nextChecks = (await (runtimeHost
         ? callRuntimeRpc<PRCheckDetail[]>(
-            { kind: 'environment', environmentId: parsedSourceHost.environmentId },
+            { kind: 'environment', environmentId: runtimeHost.environmentId },
             'github.prChecks',
             {
-              repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+              repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
               prNumber: item.number,
               headSha,
               prRepo,
@@ -4517,7 +4503,7 @@ function ChecksTab({
     item.number,
     item.repoId,
     onChecksUpdated,
-    parsedSourceHost,
+    runtimeHost,
     prRepo,
     repoId,
     repoPath,
@@ -4531,27 +4517,26 @@ function ChecksTab({
       }
       setRerunning(true)
       try {
-        const result =
-          parsedSourceHost?.kind === 'runtime'
-            ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.rerunPRChecks>>>(
-                { kind: 'environment', environmentId: parsedSourceHost.environmentId },
-                'github.rerunPRChecks',
-                {
-                  repo: sourceContext?.repoId ?? repoId ?? item.repoId,
-                  prNumber: item.number,
-                  headSha,
-                  failedOnly
-                },
-                { timeoutMs: 30_000 }
-              )
-            : await window.api.gh.rerunPRChecks({
-                repoPath: repoPath ?? '',
-                repoId: repoId ?? undefined,
-                sourceContext,
+        const result = runtimeHost
+          ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.rerunPRChecks>>>(
+              { kind: 'environment', environmentId: runtimeHost.environmentId },
+              'github.rerunPRChecks',
+              {
+                repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
                 prNumber: item.number,
                 headSha,
                 failedOnly
-              })
+              },
+              { timeoutMs: 30_000 }
+            )
+          : await window.api.gh.rerunPRChecks({
+              repoPath: repoPath ?? '',
+              repoId: repoId ?? undefined,
+              sourceContext,
+              prNumber: item.number,
+              headSha,
+              failedOnly
+            })
         if (!result.ok) {
           toast.error(result.error)
           return
@@ -4578,7 +4563,7 @@ function ChecksTab({
       headSha,
       item.number,
       item.repoId,
-      parsedSourceHost,
+      runtimeHost,
       rerunning,
       repoId,
       repoPath,
@@ -4663,31 +4648,30 @@ function ChecksTab({
           error: null
         })
       )
-      const detailsRequest =
-        parsedSourceHost?.kind === 'runtime'
-          ? callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.prCheckDetails>>>(
-              { kind: 'environment', environmentId: parsedSourceHost.environmentId },
-              'github.prCheckDetails',
-              {
-                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
-                checkRunId: check.checkRunId,
-                workflowRunId: check.workflowRunId,
-                checkName: check.name,
-                url: check.url,
-                prRepo
-              },
-              { timeoutMs: 30_000 }
-            )
-          : window.api.gh.prCheckDetails({
-              repoPath: repoPath ?? '',
-              repoId: repoId ?? undefined,
-              sourceContext,
+      const detailsRequest = runtimeHost
+        ? callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.prCheckDetails>>>(
+            { kind: 'environment', environmentId: runtimeHost.environmentId },
+            'github.prCheckDetails',
+            {
+              repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
               checkRunId: check.checkRunId,
               workflowRunId: check.workflowRunId,
               checkName: check.name,
               url: check.url,
               prRepo
-            })
+            },
+            { timeoutMs: 30_000 }
+          )
+        : window.api.gh.prCheckDetails({
+            repoPath: repoPath ?? '',
+            repoId: repoId ?? undefined,
+            sourceContext,
+            checkRunId: check.checkRunId,
+            workflowRunId: check.workflowRunId,
+            checkName: check.name,
+            url: check.url,
+            prRepo
+          })
       void detailsRequest
         .then((details) => {
           if (!mountedRef.current) {
@@ -4719,7 +4703,7 @@ function ChecksTab({
       detailsByCheckKey,
       item.repoId,
       mountedRef,
-      parsedSourceHost,
+      runtimeHost,
       prRepo,
       repoId,
       repoPath,
@@ -5282,36 +5266,32 @@ async function runIssueUpdate(args: {
     }
     return
   }
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (!args.repoPath && parsedHost?.kind !== 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (!args.repoPath && !runtimeHost) {
     throw new Error('No repo context available for this edit.')
   }
-  const res =
-    parsedHost?.kind === 'runtime'
-      ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssue>>>(
-          { kind: 'environment', environmentId: parsedHost.environmentId },
-          'github.updateIssue',
-          {
-            repo: args.sourceContext?.repoId ?? args.repoId,
-            number: args.number,
-            updates: args.updates
-          },
-          { timeoutMs: 30_000 }
-        )
-      : await window.api.gh.updateIssue({
-          repoPath: args.repoPath ?? '',
-          repoId: args.repoId ?? undefined,
-          sourceContext: args.sourceContext,
+  const res = runtimeHost
+    ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssue>>>(
+        { kind: 'environment', environmentId: runtimeHost.environmentId },
+        'github.updateIssue',
+        {
+          repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? ''),
           number: args.number,
           updates: args.updates
-        })
+        },
+        { timeoutMs: 30_000 }
+      )
+    : await window.api.gh.updateIssue({
+        repoPath: args.repoPath ?? '',
+        repoId: args.repoId ?? undefined,
+        sourceContext: args.sourceContext,
+        number: args.number,
+        updates: args.updates
+      })
   if (!res.ok) {
     throw new Error(res.error)
   }
-  if (parsedHost?.kind === 'runtime') {
+  if (runtimeHost) {
     notifyWorkItemDetailsMutation(
       {
         repoPath: args.repoPath ?? '',
@@ -5438,36 +5418,32 @@ async function runPullRequestStateUpdate(args: {
     }
     return
   }
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (!args.repoPath && parsedHost?.kind !== 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (!args.repoPath && !runtimeHost) {
     throw new Error('No repo context available for this pull request.')
   }
-  const res =
-    parsedHost?.kind === 'runtime'
-      ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
-          { kind: 'environment', environmentId: parsedHost.environmentId },
-          'github.updatePRState',
-          {
-            repo: args.sourceContext?.repoId ?? args.repoId,
-            prNumber: args.number,
-            updates: args.updates
-          },
-          { timeoutMs: 30_000 }
-        )
-      : await window.api.gh.updatePRState({
-          repoPath: args.repoPath ?? '',
-          repoId: args.repoId ?? undefined,
-          sourceContext: args.sourceContext,
+  const res = runtimeHost
+    ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
+        { kind: 'environment', environmentId: runtimeHost.environmentId },
+        'github.updatePRState',
+        {
+          repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? ''),
           prNumber: args.number,
           updates: args.updates
-        })
+        },
+        { timeoutMs: 30_000 }
+      )
+    : await window.api.gh.updatePRState({
+        repoPath: args.repoPath ?? '',
+        repoId: args.repoId ?? undefined,
+        sourceContext: args.sourceContext,
+        prNumber: args.number,
+        updates: args.updates
+      })
   if (!res.ok) {
     throw new Error(res.error)
   }
-  if (parsedHost?.kind === 'runtime') {
+  if (runtimeHost) {
     notifyWorkItemDetailsMutation(
       {
         repoPath: args.repoPath ?? '',
@@ -6834,9 +6810,7 @@ export default function GitHubItemDialog({
     return s.repos.find((r) => (effectiveRepoId ? r.id === effectiveRepoId : r.path === repoPath))
       ?.issueSourcePreference
   })
-  const detailsSourceHost =
-    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
-  const canUseDetailsRepoContext = !!repoPath || detailsSourceHost?.kind === 'runtime'
+  const canUseDetailsRepoContext = canUseGitHubRepoContext(repoPath, sourceContext)
   const detailsCacheKey = useMemo(() => {
     if (!workItem || !effectiveRepoId || !canUseDetailsRepoContext) {
       return null

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -6700,7 +6700,7 @@ export default function PullRequestPage({
       .then((result) => {
         const invalidatedMidFlight = workItemDetailsCacheGeneration !== launchedAtGeneration
         const prev = workItemDetailsCache.get(detailsCacheKey)
-        if (invalidatedMidFlight) {
+        if (invalidatedMidFlight && prev?.pending !== inflight) {
           // Why: entry was deliberately dropped; do not recreate it. If the
           // entry still exists (later open repopulated it) leave it alone too.
           return
@@ -6729,10 +6729,10 @@ export default function PullRequestPage({
       .catch((err) => {
         const message = err instanceof Error ? err.message : 'Failed to load details'
         const invalidatedMidFlight = workItemDetailsCacheGeneration !== launchedAtGeneration
-        if (invalidatedMidFlight) {
+        const prev = workItemDetailsCache.get(detailsCacheKey)
+        if (invalidatedMidFlight && prev?.pending !== inflight) {
           return
         }
-        const prev = workItemDetailsCache.get(detailsCacheKey)
         // Why: stale-on-error — keep cached data if we have it, drop the
         // pending promise so the next open can retry. Only surface the
         // blocking error when nothing is cached.
@@ -6865,6 +6865,26 @@ export default function PullRequestPage({
     },
     [detailsCacheKey]
   )
+
+  const invalidateCurrentDetailsCache = useCallback((): void => {
+    if (!workItem) {
+      return
+    }
+    // Why: local repos can invalidate every source-preference variant; runtime-only
+    // entries need their exact source-scoped key because there is no local path.
+    if (repoPath) {
+      invalidateWorkItemDetailsCacheByMatch({
+        repoPath,
+        repoId: effectiveRepoId ?? undefined,
+        type: workItem.type,
+        number: workItem.number
+      })
+      return
+    }
+    if (detailsCacheKey) {
+      invalidateWorkItemDetailsCacheForKey(detailsCacheKey)
+    }
+  }, [detailsCacheKey, effectiveRepoId, repoPath, workItem])
 
   const handlePRFileViewedChange = useCallback(
     async (path: string, viewed: boolean): Promise<boolean> => {
@@ -7145,21 +7165,7 @@ export default function PullRequestPage({
           localLabels={localLabels}
           onStateChange={setLocalState}
           onLabelsChange={setLocalLabels}
-          onMutated={() => {
-            // Why: drop the cached details for this item so the next
-            // open issues a fresh fetch instead of painting pre-edit
-            // state. We invalidate by (repoPath, type, number) match
-            // because a single mutation can affect entries across all
-            // issueSourcePreference values for the same number.
-            if (repoPath) {
-              invalidateWorkItemDetailsCacheByMatch({
-                repoPath,
-                repoId: effectiveRepoId ?? undefined,
-                type: workItem.type,
-                number: workItem.number
-              })
-            }
-          }}
+          onMutated={invalidateCurrentDetailsCache}
           assignees={details?.assignees ?? []}
           onUse={onUse}
         />
@@ -7224,16 +7230,7 @@ export default function PullRequestPage({
                   localState={localState}
                   onStateChange={setLocalState}
                   projectOrigin={projectOrigin}
-                  onMutated={() => {
-                    if (repoPath) {
-                      invalidateWorkItemDetailsCacheByMatch({
-                        repoPath,
-                        repoId: effectiveRepoId ?? undefined,
-                        type: workItem.type,
-                        number: workItem.number
-                      })
-                    }
-                  }}
+                  onMutated={invalidateCurrentDetailsCache}
                   onChecksUpdated={(nextChecks) => {
                     if (detailsCacheKey) {
                       patchCachedPRChecks(detailsCacheKey, nextChecks)

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -3240,6 +3240,9 @@ function ConversationTab({
   const [bodySaving, setBodySaving] = useState(false)
   const bodyTextareaRef = useRef<HTMLTextAreaElement>(null)
   const bodyTextareaFocusFrameRef = useRef<number | null>(null)
+  const parsedSourceHost =
+    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
+  const canUseRepoMutationContext = !!repoPath || parsedSourceHost?.kind === 'runtime'
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
   )
@@ -3311,7 +3314,9 @@ function ConversationTab({
     [bodySlug, projectOrigin]
   )
   const canEditBody =
-    item.type === 'pr' ? Boolean(projectOrigin || bodySlug) : Boolean(projectOrigin || repoPath)
+    item.type === 'pr'
+      ? Boolean(projectOrigin || bodySlug)
+      : Boolean(projectOrigin || canUseRepoMutationContext)
   const bodyChanged = resolvedBodyDraft !== body
 
   const handleSaveBody = useCallback(async (): Promise<void> => {
@@ -3355,7 +3360,7 @@ function ConversationTab({
 
   const handleReply = useCallback(
     async (comment: PRComment, replyBody: string): Promise<boolean> => {
-      if (!repoPath) {
+      if (!canUseRepoMutationContext) {
         toast.error(
           translate(
             'auto.components.PullRequestPage.6885c619e7',
@@ -3367,7 +3372,7 @@ function ConversationTab({
       const result =
         comment.path && item.type === 'pr'
           ? await addPRReviewCommentReplyForRepo({
-              repoPath,
+              repoPath: repoPath ?? '',
               repoId: item.repoId,
               sourceContext,
               prNumber: item.number,
@@ -3378,7 +3383,7 @@ function ConversationTab({
               line: comment.line
             })
           : await addIssueCommentForRepo({
-              repoPath,
+              repoPath: repoPath ?? '',
               repoId: item.repoId,
               sourceContext,
               number: item.number,
@@ -3398,7 +3403,15 @@ function ConversationTab({
       toast.success(translate('auto.components.PullRequestPage.11505c7a71', 'Reply posted.'))
       return true
     },
-    [item.number, item.repoId, item.type, onCommentAdded, repoPath, sourceContext]
+    [
+      canUseRepoMutationContext,
+      item.number,
+      item.repoId,
+      item.type,
+      onCommentAdded,
+      repoPath,
+      sourceContext
+    ]
   )
 
   const rightPanel =
@@ -3793,10 +3806,10 @@ function ConversationTab({
           </>
         ) : null}
 
-        {detailsLoaded && repoPath && (
+        {detailsLoaded && canUseRepoMutationContext && (
           <GHCommentComposer
             className="mt-1"
-            repoPath={repoPath}
+            repoPath={repoPath ?? ''}
             repoId={item.repoId}
             sourceContext={sourceContext}
             issueNumber={item.number}
@@ -3841,7 +3854,9 @@ function PRActionsPanel({
   const mergeMethods = resolveGitHubPRMergeMethods(actionItem.mergeMethodSettings)
   const sourceSettings = getTaskSourceRuntimeSettings(sourceContext)
   const mergeTarget = getActiveRuntimeTarget(sourceSettings)
-  const canMutateState = localState !== 'merged' && (!!repoPath || !!projectOrigin)
+  const canMutateWithRepoContext =
+    !!repoPath || !!projectOrigin || mergeTarget.kind === 'environment'
+  const canMutateState = localState !== 'merged' && canMutateWithRepoContext
   const nextState: 'open' | 'closed' = localState === 'closed' ? 'open' : 'closed'
   const canMergeWithRepoContext = !!repoPath || mergeTarget.kind === 'environment'
   const mergeDisabled =
@@ -4096,7 +4111,7 @@ function PRActionsPanel({
               </DropdownMenuTrigger>
             </TooltipTrigger>
             <TooltipContent side="bottom" sideOffset={6}>
-              {!repoPath
+              {!canMergeWithRepoContext
                 ? translate(
                     'auto.components.PullRequestPage.eca289e593',
                     'Merge requires a registered local repo'
@@ -4107,7 +4122,7 @@ function PRActionsPanel({
           <DropdownMenuContent align="start" className="w-52">
             {mergePresentation.autoMergeAction && (
               <DropdownMenuItem
-                disabled={!repoPath || mergePending}
+                disabled={!canMergeWithRepoContext || mergePending}
                 onSelect={() => void handleAutoMerge()}
               >
                 <GitMerge className="size-4" />
@@ -4522,6 +4537,7 @@ function ChecksTab({
   const prRepo = useMemo(() => parseOwnerRepoFromItemUrl(item.url), [item.url])
   const parsedSourceHost =
     sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
+  const canUseChecksRepoContext = !!repoPath || parsedSourceHost?.kind === 'runtime'
   const sorted = [...list].sort(
     (a, b) =>
       (CHECK_SORT_ORDER[getCheckConclusion(a)] ?? 3) -
@@ -4549,7 +4565,7 @@ function ChecksTab({
   const canFixBrokenChecks = Boolean((repoId ?? item.repoId) && failedChecks.length > 0)
 
   const handleRefresh = useCallback(async (): Promise<PRCheckDetail[] | null> => {
-    if (!repoPath) {
+    if (!canUseChecksRepoContext) {
       toast.error(
         translate(
           'auto.components.PullRequestPage.c057f2fcb0',
@@ -4574,7 +4590,7 @@ function ChecksTab({
             { timeoutMs: 30_000 }
           )
         : window.api.gh.prChecks({
-            repoPath,
+            repoPath: repoPath ?? '',
             repoId: repoId ?? undefined,
             sourceContext,
             prNumber: item.number,
@@ -4595,6 +4611,7 @@ function ChecksTab({
       setRefreshing(false)
     }
   }, [
+    canUseChecksRepoContext,
     headSha,
     item.number,
     item.repoId,
@@ -4608,7 +4625,7 @@ function ChecksTab({
 
   const handleRerun = useCallback(
     async (failedOnly: boolean): Promise<void> => {
-      if (!repoPath || rerunning) {
+      if (!canUseChecksRepoContext || rerunning) {
         return
       }
       setRerunning(true)
@@ -4627,7 +4644,7 @@ function ChecksTab({
                 { timeoutMs: 30_000 }
               )
             : await window.api.gh.rerunPRChecks({
-                repoPath,
+                repoPath: repoPath ?? '',
                 repoId: repoId ?? undefined,
                 sourceContext,
                 prNumber: item.number,
@@ -4655,6 +4672,7 @@ function ChecksTab({
       }
     },
     [
+      canUseChecksRepoContext,
       handleRefresh,
       headSha,
       item.number,
@@ -4725,7 +4743,7 @@ function ChecksTab({
       const key = getCheckDetailsKey(check)
       setChecksState((current) => toggleGitHubChecksTabExpandedKey(current, key))
       if (
-        !repoPath ||
+        !canUseChecksRepoContext ||
         detailsByCheckKey[key] ||
         (!check.checkRunId && !check.workflowRunId && !check.url)
       ) {
@@ -4754,7 +4772,7 @@ function ChecksTab({
               { timeoutMs: 30_000 }
             )
           : window.api.gh.prCheckDetails({
-              repoPath,
+              repoPath: repoPath ?? '',
               repoId: repoId ?? undefined,
               sourceContext,
               checkRunId: check.checkRunId,
@@ -4790,6 +4808,7 @@ function ChecksTab({
         })
     },
     [
+      canUseChecksRepoContext,
       detailsByCheckKey,
       item.repoId,
       mountedRef,
@@ -4809,7 +4828,7 @@ function ChecksTab({
           variant="ghost"
           size="icon-xs"
           className="size-7 shrink-0"
-          disabled={!repoPath || refreshing}
+          disabled={!canUseChecksRepoContext || refreshing}
           onClick={() => void handleRefresh()}
           aria-label={translate('auto.components.PullRequestPage.5d0f42766d', 'Refresh checks')}
         >
@@ -4860,7 +4879,7 @@ function ChecksTab({
             variant="outline"
             size="xs"
             className="h-7 gap-1 px-2 text-[11px]"
-            disabled={!repoPath || rerunning || list.length === 0}
+            disabled={!canUseChecksRepoContext || rerunning || list.length === 0}
           >
             {rerunning ? (
               <LoaderCircle className="size-3 animate-spin" />
@@ -5541,13 +5560,13 @@ async function runIssueUpdate(args: {
     }
     return
   }
-  if (!args.repoPath) {
-    throw new Error('No repo context available for this edit.')
-  }
   const parsedHost =
     args.sourceContext?.provider === 'github'
       ? parseExecutionHostId(args.sourceContext.hostId)
       : null
+  if (!args.repoPath && parsedHost?.kind !== 'runtime') {
+    throw new Error('No repo context available for this edit.')
+  }
   const res =
     parsedHost?.kind === 'runtime'
       ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssue>>>(
@@ -5561,7 +5580,7 @@ async function runIssueUpdate(args: {
           { timeoutMs: 30_000 }
         )
       : await window.api.gh.updateIssue({
-          repoPath: args.repoPath,
+          repoPath: args.repoPath ?? '',
           repoId: args.repoId ?? undefined,
           sourceContext: args.sourceContext,
           number: args.number,
@@ -5573,7 +5592,7 @@ async function runIssueUpdate(args: {
   if (parsedHost?.kind === 'runtime') {
     notifyWorkItemDetailsMutation(
       {
-        repoPath: args.repoPath,
+        repoPath: args.repoPath ?? '',
         repoId: args.repoId ?? undefined,
         sourceContext: args.sourceContext,
         type: 'issue',
@@ -5697,13 +5716,13 @@ async function runPullRequestStateUpdate(args: {
     }
     return
   }
-  if (!args.repoPath) {
-    throw new Error('No repo context available for this pull request.')
-  }
   const parsedHost =
     args.sourceContext?.provider === 'github'
       ? parseExecutionHostId(args.sourceContext.hostId)
       : null
+  if (!args.repoPath && parsedHost?.kind !== 'runtime') {
+    throw new Error('No repo context available for this pull request.')
+  }
   const res =
     parsedHost?.kind === 'runtime'
       ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
@@ -5717,7 +5736,7 @@ async function runPullRequestStateUpdate(args: {
           { timeoutMs: 30_000 }
         )
       : await window.api.gh.updatePRState({
-          repoPath: args.repoPath,
+          repoPath: args.repoPath ?? '',
           repoId: args.repoId ?? undefined,
           sourceContext: args.sourceContext,
           prNumber: args.number,
@@ -5729,7 +5748,7 @@ async function runPullRequestStateUpdate(args: {
   if (parsedHost?.kind === 'runtime') {
     notifyWorkItemDetailsMutation(
       {
-        repoPath: args.repoPath,
+        repoPath: args.repoPath ?? '',
         repoId: args.repoId ?? undefined,
         sourceContext: args.sourceContext,
         type: 'pr',
@@ -6439,12 +6458,15 @@ export default function PullRequestPage({
     return s.repos.find((r) => (effectiveRepoId ? r.id === effectiveRepoId : r.path === repoPath))
       ?.issueSourcePreference
   })
+  const detailsSourceHost =
+    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
+  const canUseDetailsRepoContext = !!repoPath || detailsSourceHost?.kind === 'runtime'
   const detailsCacheKey = useMemo(() => {
-    if (!workItem || !repoPath || !effectiveRepoId) {
+    if (!workItem || !effectiveRepoId || !canUseDetailsRepoContext) {
       return null
     }
     return getWorkItemDetailsCacheKey({
-      repoPath,
+      repoPath: repoPath ?? '',
       repoId: effectiveRepoId,
       issueSourcePreference,
       sourceCacheScope:
@@ -6452,7 +6474,14 @@ export default function PullRequestPage({
       type: workItem.type,
       number: workItem.number
     })
-  }, [repoPath, effectiveRepoId, sourceContext, workItem, issueSourcePreference])
+  }, [
+    canUseDetailsRepoContext,
+    repoPath,
+    effectiveRepoId,
+    sourceContext,
+    workItem,
+    issueSourcePreference
+  ])
 
   // Why: reset lifted edit state when the dialog switches items or when the
   // same item receives an optimistic cache patch from the surrounding table.
@@ -6619,7 +6648,7 @@ export default function PullRequestPage({
   }, [workItem, detailsCacheKey, cachedEntry])
 
   useEffect(() => {
-    if (!workItem || !repoPath || !effectiveRepoId || !detailsCacheKey) {
+    if (!workItem || !effectiveRepoId || !detailsCacheKey || !canUseDetailsRepoContext) {
       return
     }
     // Why: only clear optimistic comments when switching to a genuinely
@@ -6646,7 +6675,7 @@ export default function PullRequestPage({
     const inflight: Promise<GitHubWorkItemDetails | null> =
       cached?.pending ??
       lookupGitHubWorkItemDetailsForSource({
-        repoPath,
+        repoPath: repoPath ?? '',
         repoId: effectiveRepoId,
         sourceContext,
         number: workItem.number,
@@ -6713,7 +6742,15 @@ export default function PullRequestPage({
           error: message
         })
       })
-  }, [repoPath, effectiveRepoId, sourceContext, workItem, detailsCacheKey, refetchTick])
+  }, [
+    canUseDetailsRepoContext,
+    repoPath,
+    effectiveRepoId,
+    sourceContext,
+    workItem,
+    detailsCacheKey,
+    refetchTick
+  ])
 
   const Icon = workItem?.type === 'pr' ? GitPullRequest : CircleDot
   const displayWorkItem = useMemo<GitHubWorkItem | null>(() => {
@@ -6831,7 +6868,12 @@ export default function PullRequestPage({
 
   const handlePRFileViewedChange = useCallback(
     async (path: string, viewed: boolean): Promise<boolean> => {
-      if (!repoPath || !details?.pullRequestId || !workItem || workItem.type !== 'pr') {
+      if (
+        !canUseDetailsRepoContext ||
+        !details?.pullRequestId ||
+        !workItem ||
+        workItem.type !== 'pr'
+      ) {
         toast.error(
           translate(
             'auto.components.PullRequestPage.996a1897d2',
@@ -6848,7 +6890,7 @@ export default function PullRequestPage({
       try {
         const ok = await setPRFileViewedForRepo({
           repoId: workItem.repoId,
-          repoPath,
+          repoPath: repoPath ?? '',
           sourceContext,
           prNumber: workItem.number,
           pullRequestId: details.pullRequestId,
@@ -6876,7 +6918,14 @@ export default function PullRequestPage({
         })
       }
     },
-    [details?.pullRequestId, detailsCacheKey, repoPath, sourceContext, workItem]
+    [
+      canUseDetailsRepoContext,
+      details?.pullRequestId,
+      detailsCacheKey,
+      repoPath,
+      sourceContext,
+      workItem
+    ]
   )
 
   const ownerRepo = parseOwnerRepoFromItemUrl(workItem?.url ?? '')
@@ -7085,7 +7134,7 @@ export default function PullRequestPage({
         </div>
       </div>
 
-      {(repoPath || projectOrigin) && (
+      {(canUseDetailsRepoContext || projectOrigin) && (
         <GHEditSection
           item={workItem}
           repoPath={repoPath}

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -160,11 +160,17 @@ import {
   getCommentBodySubmitState,
   hasBoundedCommentBodyText
 } from '@/lib/comment-body-submit-state'
+import {
+  emitGitHubWorkItemDetailsCacheMutation,
+  onGitHubWorkItemDetailsCacheMutation
+} from '@/lib/github-work-item-details-cache-events'
+import { lookupGitHubWorkItemDetailsForSource } from '@/lib/github-work-item-source-lookup'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
 import {
   GITHUB_PR_MERGE_METHOD_LABELS,
   resolveGitHubPRMergeMethods
 } from '../../../shared/github-pr-merge-methods'
+import { parseExecutionHostId } from '../../../shared/execution-host'
 import {
   findGithubPrWorkspaceAttachment,
   getGithubPrWorkspaceAttachmentLabel
@@ -201,6 +207,11 @@ import type {
   PRCheckDetail,
   PRComment
 } from '../../../shared/types'
+import {
+  getTaskSourceCacheScope,
+  getTaskSourceRuntimeSettings,
+  type TaskSourceContext
+} from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
 
@@ -288,6 +299,7 @@ type PullRequestPageProps = {
   workItem: GitHubWorkItem | null
   repoPath: string | null
   repoId?: string | null
+  sourceContext?: TaskSourceContext | null
   initialTab?: ItemDialogTab
   backLabel?: string
   /** Called when the user clicks the primary CTA to start work from this item. */
@@ -503,11 +515,13 @@ function PRAssigneesPanel({
   item,
   repoPath,
   projectOrigin,
+  sourceContext,
   onMutated
 }: {
   item: GitHubWorkItem
   repoPath: string | null
   projectOrigin: PullRequestPageProjectOrigin | undefined
+  sourceContext?: TaskSourceContext | null
   onMutated: () => void
 }): React.JSX.Element {
   const [assigneePopoverOpen, setAssigneePopoverOpen] = useState(false)
@@ -523,6 +537,16 @@ function PRAssigneesPanel({
   const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
+  )
+  const sourceSettings = useMemo(
+    () =>
+      sourceContext?.provider === 'github'
+        ? ({
+            ...repoOwnerSettings,
+            ...getTaskSourceRuntimeSettings(sourceContext)
+          } as typeof repoOwnerSettings)
+        : repoOwnerSettings,
+    [repoOwnerSettings, sourceContext]
   )
   const { isPending, run } = useImmediateMutation()
 
@@ -554,9 +578,9 @@ function PRAssigneesPanel({
     slugOwner,
     slugRepo,
     assigneeLogins,
-    repoOwnerSettings
+    sourceSettings
   )
-  const repoAssigneesByPath = useRepoAssignees(repoPath, item.repoId, repoOwnerSettings)
+  const repoAssigneesByPath = useRepoAssignees(repoPath, item.repoId, sourceSettings)
   const repoAssignees = slugOwner && slugRepo ? repoAssigneesBySlug : repoAssigneesByPath
   const canEditAssignees = Boolean(projectOrigin || repoPath)
   const assigneesByLogin = useMemo(
@@ -581,18 +605,19 @@ function PRAssigneesPanel({
           runIssueUpdate({
             repoId: item.repoId,
             repoPath,
+            sourceContext,
             projectOrigin,
             number: item.number,
             updates: isAssigned ? { removeAssignees: [login] } : { addAssignees: [login] }
           }),
         onOptimistic: () => {
           setLocalAssignees(nextAssignees)
-          patchWorkItem(item.id, { assignees: nextAssignees }, item.repoId)
+          patchWorkItem(item.id, { assignees: nextAssignees }, item.repoId, { sourceContext })
           patchProjectRowIfNeeded(nextLogins)
         },
         onRevert: () => {
           setLocalAssignees(prevAssignees)
-          patchWorkItem(item.id, { assignees: prevAssignees }, item.repoId)
+          patchWorkItem(item.id, { assignees: prevAssignees }, item.repoId, { sourceContext })
           patchProjectRowIfNeeded(prevLogins)
         },
         onSuccess: () => {
@@ -613,7 +638,8 @@ function PRAssigneesPanel({
       patchWorkItem,
       projectOrigin,
       repoPath,
-      run
+      run,
+      sourceContext
     ]
   )
 
@@ -719,11 +745,13 @@ function PRReviewersPanel({
   item,
   loading,
   repoPath,
+  sourceContext,
   onReviewersRequested
 }: {
   item: GitHubWorkItem
   loading: boolean
   repoPath: string | null
+  sourceContext?: TaskSourceContext | null
   onReviewersRequested: (reviewRequests: GitHubAssignableUser[]) => void
 }): React.JSX.Element {
   const [open, setOpen] = useState(false)
@@ -744,6 +772,16 @@ function PRReviewersPanel({
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
+  )
+  const sourceSettings = useMemo(
+    () =>
+      sourceContext?.provider === 'github'
+        ? ({
+            ...repoOwnerSettings,
+            ...getTaskSourceRuntimeSettings(sourceContext)
+          } as typeof repoOwnerSettings)
+        : repoOwnerSettings,
+    [repoOwnerSettings, sourceContext]
   )
   const reviewerInputRef = useRef<HTMLInputElement | null>(null)
   const reviewerInputFocusFrameRef = useRef<number | null>(null)
@@ -819,12 +857,12 @@ function PRReviewersPanel({
     open && reviewSlug ? reviewSlug.owner : null,
     open && reviewSlug ? reviewSlug.repo : null,
     reviewerSeedUsers.map((user) => user.login),
-    repoOwnerSettings
+    sourceSettings
   )
   const reviewerMetadataByPath = useRepoAssignees(
     open && !reviewSlug ? repoPath : null,
     open && !reviewSlug ? item.repoId : null,
-    repoOwnerSettings
+    sourceSettings
   )
   const reviewerMetadata = reviewSlug ? reviewerMetadataBySlug : reviewerMetadataByPath
   const displayItem = { ...item, reviewRequests: localReviewRequests }
@@ -915,7 +953,7 @@ function PRReviewersPanel({
     item.reviewRequests !== undefined ||
     item.latestReviews !== undefined
   const canRequestReview =
-    !!repoPath || getActiveRuntimeTarget(repoOwnerSettings).kind === 'environment'
+    !!repoPath || getActiveRuntimeTarget(sourceSettings).kind === 'environment'
 
   const handleRequestReview = async (requestedLogins?: string[]): Promise<void> => {
     if (submitting) {
@@ -938,7 +976,7 @@ function PRReviewersPanel({
       )
       return
     }
-    const target = getActiveRuntimeTarget(repoOwnerSettings)
+    const target = getActiveRuntimeTarget(sourceSettings)
     if (target.kind !== 'environment' && !repoPath) {
       toast.error(
         translate(
@@ -950,17 +988,19 @@ function PRReviewersPanel({
     }
     setSubmitting(true)
     try {
+      const runtimeRepo = sourceContext?.repoId ?? item.repoId
       const result =
         target.kind === 'environment'
           ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
               target,
               'github.requestPRReviewers',
-              { repo: item.repoId, prNumber: item.number, reviewers: logins },
+              { repo: runtimeRepo, prNumber: item.number, reviewers: logins },
               { timeoutMs: 30_000 }
             )
           : await window.api.gh.requestPRReviewers({
               repoPath: repoPath ?? '',
               repoId: item.repoId,
+              sourceContext,
               prNumber: item.number,
               reviewers: logins
             })
@@ -980,8 +1020,22 @@ function PRReviewersPanel({
         localReviewRequests
       )
       setLocalReviewRequests(nextReviewRequests)
-      patchWorkItem(item.id, { reviewRequests: nextReviewRequests }, item.repoId)
+      patchWorkItem(item.id, { reviewRequests: nextReviewRequests }, item.repoId, {
+        sourceContext
+      })
       onReviewersRequested(nextReviewRequests)
+      if (target.kind === 'environment') {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: repoPath ?? '',
+            repoId: item.repoId,
+            sourceContext,
+            type: 'pr',
+            number: item.number
+          },
+          { local: false }
+        )
+      }
       setReviewerInput('')
       toast.success(
         logins.length === 1
@@ -1012,7 +1066,7 @@ function PRReviewersPanel({
     if (logins.length === 0) {
       return
     }
-    const target = getActiveRuntimeTarget(repoOwnerSettings)
+    const target = getActiveRuntimeTarget(sourceSettings)
     if (target.kind !== 'environment' && !repoPath) {
       toast.error(
         translate(
@@ -1024,17 +1078,19 @@ function PRReviewersPanel({
     }
     setSubmitting(true)
     try {
+      const runtimeRepo = sourceContext?.repoId ?? item.repoId
       const result =
         target.kind === 'environment'
           ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
               target,
               'github.removePRReviewers',
-              { repo: item.repoId, prNumber: item.number, reviewers: logins },
+              { repo: runtimeRepo, prNumber: item.number, reviewers: logins },
               { timeoutMs: 30_000 }
             )
           : await window.api.gh.removePRReviewers({
               repoPath: repoPath ?? '',
               repoId: item.repoId,
+              sourceContext,
               prNumber: item.number,
               reviewers: logins
             })
@@ -1053,8 +1109,22 @@ function PRReviewersPanel({
         (reviewer) => !removed.has(reviewer.login.toLowerCase())
       )
       setLocalReviewRequests(nextReviewRequests)
-      patchWorkItem(item.id, { reviewRequests: nextReviewRequests }, item.repoId)
+      patchWorkItem(item.id, { reviewRequests: nextReviewRequests }, item.repoId, {
+        sourceContext
+      })
       onReviewersRequested(nextReviewRequests)
+      if (target.kind === 'environment') {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: repoPath ?? '',
+            repoId: item.repoId,
+            sourceContext,
+            type: 'pr',
+            number: item.number
+          },
+          { local: false }
+        )
+      }
       setReviewerInput('')
       toast.success(
         logins.length === 1
@@ -1368,6 +1438,7 @@ function isPRFileViewed(file: GitHubPRFile): boolean {
 // background refetch on open. See docs/gh-work-item-drawer-cache.md.
 const WORK_ITEM_DETAILS_CACHE_MAX = 50
 const WORK_ITEM_DETAILS_FRESH_MS = 30_000
+const WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE = 'Unable to load details for this GitHub item.'
 type WorkItemDetailsCacheEntry = {
   details: GitHubWorkItemDetails | null
   fetchedAt: number
@@ -1397,12 +1468,16 @@ function getWorkItemDetailsCacheKey(args: {
   repoPath: string
   repoId: string
   issueSourcePreference: string | undefined
+  sourceCacheScope?: string | null
   type: 'issue' | 'pr'
   number: number
 }): string {
   // Why: include all axes that change which (repo, item) the IPC resolves to.
   // `\0` separator avoids ambiguity between fields that may contain `:` or `/`.
-  return [args.repoId, args.issueSourcePreference ?? 'auto', args.type, args.number].join('\0')
+  const keyParts = args.sourceCacheScope
+    ? [args.repoId, args.sourceCacheScope, args.issueSourcePreference ?? 'auto', args.type]
+    : [args.repoId, args.issueSourcePreference ?? 'auto', args.type]
+  return [...keyParts, args.number].join('\0')
 }
 
 function touchWorkItemDetailsCache(key: string, entry: WorkItemDetailsCacheEntry): void {
@@ -1449,7 +1524,6 @@ function invalidateWorkItemDetailsCacheByMatch(args: {
   type: 'issue' | 'pr'
   number: number
 }): void {
-  workItemDetailsCacheGeneration += 1
   const suffix = `\0${args.type}\0${args.number}`
   const prefix = `${args.repoId ?? args.repoPath}\0`
   let removed = false
@@ -1460,6 +1534,7 @@ function invalidateWorkItemDetailsCacheByMatch(args: {
     }
   }
   if (removed) {
+    workItemDetailsCacheGeneration += 1
     notifyWorkItemDetailsCache()
   }
 }
@@ -1544,6 +1619,7 @@ function patchCachedWorkItemBody(cacheKey: string, body: string): void {
 // own cache when any window's mutation lands. We track the unsubscribe so
 // Vite HMR doesn't accumulate listeners across module reloads in dev.
 let workItemMutatedUnsub: (() => void) | undefined
+let workItemDetailsCacheEventUnsub: (() => void) | undefined
 if (typeof window !== 'undefined' && window.api?.gh?.onWorkItemMutated) {
   workItemMutatedUnsub = window.api.gh.onWorkItemMutated((payload) => {
     invalidateWorkItemDetailsCacheByMatch({
@@ -1553,10 +1629,14 @@ if (typeof window !== 'undefined' && window.api?.gh?.onWorkItemMutated) {
       number: payload.number
     })
   })
+  workItemDetailsCacheEventUnsub = onGitHubWorkItemDetailsCacheMutation((payload) => {
+    invalidateWorkItemDetailsCacheByMatch(payload)
+  })
 }
 if (typeof import.meta !== 'undefined' && import.meta.hot) {
   import.meta.hot.dispose(() => {
     workItemMutatedUnsub?.()
+    workItemDetailsCacheEventUnsub?.()
   })
 }
 
@@ -1653,14 +1733,20 @@ function touchPRFileContentCache(
 function getPRFileContentCacheKey(args: {
   repoPath: string
   repoId: string
+  sourceContext?: TaskSourceContext | null
   prNumber: number
   file: GitHubPRFile
   headSha: string
   baseSha: string
 }): string {
   const repositoryKey = args.repoId ? `repo:${args.repoId}` : `path:${args.repoPath}`
+  const sourceKey =
+    args.sourceContext?.provider === 'github'
+      ? `source:${getTaskSourceCacheScope(args.sourceContext)}`
+      : 'source:local'
   return [
     repositoryKey,
+    sourceKey,
     args.prNumber,
     args.file.path,
     args.file.oldPath ?? '',
@@ -1673,6 +1759,7 @@ function getPRFileContentCacheKey(args: {
 function loadPRFileContents(args: {
   repoPath: string
   repoId: string
+  sourceContext?: TaskSourceContext | null
   prNumber: number
   file: GitHubPRFile
   headSha: string
@@ -1685,17 +1772,38 @@ function loadPRFileContents(args: {
     return Promise.resolve(cached.value)
   }
   let request: Promise<GitHubPRFileContents>
-  request = window.api.gh
-    .prFileContents({
-      repoPath: args.repoPath,
-      repoId: args.repoId,
-      prNumber: args.prNumber,
-      path: args.file.path,
-      oldPath: args.file.oldPath,
-      status: args.file.status,
-      headSha: args.headSha,
-      baseSha: args.baseSha
-    })
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  request = (
+    parsedHost?.kind === 'runtime'
+      ? callRuntimeRpc<GitHubPRFileContents>(
+          { kind: 'environment', environmentId: parsedHost.environmentId },
+          'github.prFileContents',
+          {
+            repo: args.sourceContext?.repoId ?? args.repoId,
+            prNumber: args.prNumber,
+            path: args.file.path,
+            oldPath: args.file.oldPath,
+            status: args.file.status,
+            headSha: args.headSha,
+            baseSha: args.baseSha
+          },
+          { timeoutMs: 30_000 }
+        )
+      : window.api.gh.prFileContents({
+          repoPath: args.repoPath,
+          repoId: args.repoId,
+          sourceContext: args.sourceContext,
+          prNumber: args.prNumber,
+          path: args.file.path,
+          oldPath: args.file.oldPath,
+          status: args.file.status,
+          headSha: args.headSha,
+          baseSha: args.baseSha
+        })
+  )
     .then((contents) => {
       if (prFileContentCache.get(cacheKey)?.value === request) {
         touchPRFileContentCache(cacheKey, contents)
@@ -1717,13 +1825,45 @@ function loadPRFileContents(args: {
 function addIssueCommentForRepo(args: {
   repoId?: string
   repoPath: string
+  sourceContext?: TaskSourceContext | null
   number: number
   body: string
   type?: 'issue' | 'pr'
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>> {
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  if (parsedHost?.kind === 'runtime') {
+    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.addIssueComment',
+      {
+        repo: args.sourceContext?.repoId ?? args.repoId,
+        number: args.number,
+        body: args.body
+      },
+      { timeoutMs: 30_000 }
+    ).then((result) => {
+      if (result.ok) {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: args.repoPath,
+            repoId: args.repoId,
+            sourceContext: args.sourceContext,
+            type: args.type ?? 'issue',
+            number: args.number
+          },
+          { local: false }
+        )
+      }
+      return result
+    })
+  }
   return window.api.gh.addIssueComment({
     repoPath: args.repoPath,
     repoId: args.repoId,
+    sourceContext: args.sourceContext,
     number: args.number,
     body: args.body,
     type: args.type
@@ -1733,6 +1873,7 @@ function addIssueCommentForRepo(args: {
 function addPRReviewCommentForRepo(args: {
   repoId?: string
   repoPath: string
+  sourceContext?: TaskSourceContext | null
   prNumber: number
   commitId: string
   path: string
@@ -1740,9 +1881,44 @@ function addPRReviewCommentForRepo(args: {
   startLine?: number
   body: string
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>> {
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  if (parsedHost?.kind === 'runtime') {
+    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.addPRReviewComment',
+      {
+        repo: args.sourceContext?.repoId ?? args.repoId,
+        prNumber: args.prNumber,
+        commitId: args.commitId,
+        path: args.path,
+        line: args.line,
+        startLine: args.startLine,
+        body: args.body
+      },
+      { timeoutMs: 30_000 }
+    ).then((result) => {
+      if (result.ok) {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: args.repoPath,
+            repoId: args.repoId,
+            sourceContext: args.sourceContext,
+            type: 'pr',
+            number: args.prNumber
+          },
+          { local: false }
+        )
+      }
+      return result
+    })
+  }
   return window.api.gh.addPRReviewComment({
     repoPath: args.repoPath,
     repoId: args.repoId,
+    sourceContext: args.sourceContext,
     prNumber: args.prNumber,
     commitId: args.commitId,
     path: args.path,
@@ -1755,6 +1931,7 @@ function addPRReviewCommentForRepo(args: {
 function addPRReviewCommentReplyForRepo(args: {
   repoId?: string
   repoPath: string
+  sourceContext?: TaskSourceContext | null
   prNumber: number
   commentId: number
   body: string
@@ -1762,9 +1939,44 @@ function addPRReviewCommentReplyForRepo(args: {
   path?: string
   line?: number
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>> {
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  if (parsedHost?.kind === 'runtime') {
+    return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.addPRReviewCommentReply',
+      {
+        repo: args.sourceContext?.repoId ?? args.repoId,
+        prNumber: args.prNumber,
+        commentId: args.commentId,
+        body: args.body,
+        threadId: args.threadId,
+        path: args.path,
+        line: args.line
+      },
+      { timeoutMs: 30_000 }
+    ).then((result) => {
+      if (result.ok) {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: args.repoPath,
+            repoId: args.repoId,
+            sourceContext: args.sourceContext,
+            type: 'pr',
+            number: args.prNumber
+          },
+          { local: false }
+        )
+      }
+      return result
+    })
+  }
   return window.api.gh.addPRReviewCommentReply({
     repoPath: args.repoPath,
     repoId: args.repoId,
+    sourceContext: args.sourceContext,
     prNumber: args.prNumber,
     commentId: args.commentId,
     body: args.body,
@@ -1774,35 +1986,77 @@ function addPRReviewCommentReplyForRepo(args: {
   })
 }
 
+function notifyWorkItemDetailsMutation(
+  args: {
+    repoPath: string
+    repoId?: string
+    sourceContext?: TaskSourceContext | null
+    type: 'issue' | 'pr'
+    number: number
+  },
+  options: { local?: boolean } = {}
+): void {
+  if (options.local !== false) {
+    emitGitHubWorkItemDetailsCacheMutation(args)
+  }
+  void window.api.gh
+    .notifyWorkItemMutated({
+      repoPath: args.repoPath,
+      repoId: args.repoId,
+      type: args.type,
+      number: args.number
+    })
+    .catch(() => undefined)
+}
+
 function setPRFileViewedForRepo(args: {
-  repoId?: string
+  repoId: string
   repoPath: string
+  sourceContext?: TaskSourceContext | null
   prNumber: number
   pullRequestId: string
   path: string
   viewed: boolean
 }): Promise<boolean> {
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  if (parsedHost?.kind === 'runtime') {
+    return callRuntimeRpc<boolean>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.setPRFileViewed',
+      {
+        repo: args.sourceContext?.repoId ?? args.repoId,
+        pullRequestId: args.pullRequestId,
+        path: args.path,
+        viewed: args.viewed
+      },
+      { timeoutMs: 30_000 }
+    ).then((ok) => {
+      if (ok) {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: args.repoPath,
+            repoId: args.repoId,
+            sourceContext: args.sourceContext,
+            type: 'pr',
+            number: args.prNumber
+          },
+          { local: false }
+        )
+      }
+      return ok
+    })
+  }
   return window.api.gh.setPRFileViewed({
     repoPath: args.repoPath,
     repoId: args.repoId,
+    sourceContext: args.sourceContext,
     prNumber: args.prNumber,
     pullRequestId: args.pullRequestId,
     path: args.path,
     viewed: args.viewed
-  })
-}
-
-function getWorkItemDetailsForRepo(args: {
-  repoId?: string
-  repoPath: string
-  number: number
-  type: 'issue' | 'pr'
-}): Promise<GitHubWorkItemDetails | null> {
-  return window.api.gh.workItemDetails({
-    repoPath: args.repoPath,
-    repoId: args.repoId,
-    number: args.number,
-    type: args.type
   })
 }
 
@@ -1971,6 +2225,7 @@ type PRFilesCombinedDiffViewerProps = {
   comments: PRComment[]
   repoPath: string
   repoId: string
+  sourceContext?: TaskSourceContext | null
   prNumber: number
   prUrl: string
   headSha: string | undefined
@@ -1985,6 +2240,7 @@ function PRFilesCombinedDiffViewer({
   comments,
   repoPath,
   repoId,
+  sourceContext,
   prNumber,
   prUrl,
   headSha,
@@ -2184,6 +2440,7 @@ function PRFilesCombinedDiffViewer({
         const contents = await loadPRFileContents({
           repoPath,
           repoId,
+          sourceContext,
           prNumber,
           file,
           headSha,
@@ -2233,7 +2490,7 @@ function PRFilesCombinedDiffViewer({
           )
         })
     },
-    [baseSha, fileByPath, headSha, prNumber, repoId, repoPath]
+    [baseSha, fileByPath, headSha, prNumber, repoId, repoPath, sourceContext]
   )
 
   const retrySection = useCallback(
@@ -2466,6 +2723,7 @@ function PRFilesCombinedDiffViewer({
       const result = await addPRReviewCommentForRepo({
         repoPath,
         repoId,
+        sourceContext,
         prNumber,
         commitId: headSha,
         path: section.path,
@@ -2486,7 +2744,7 @@ function PRFilesCombinedDiffViewer({
       )
       return true
     },
-    [headSha, onCommentAdded, prNumber, repoId, repoPath]
+    [headSha, onCommentAdded, prNumber, repoId, repoPath, sourceContext]
   )
 
   const renderViewedCheckbox = useCallback(
@@ -2632,6 +2890,7 @@ function CommentCodeContext({
   comment,
   repoPath,
   repoId,
+  sourceContext,
   prNumber,
   files,
   headSha,
@@ -2640,6 +2899,7 @@ function CommentCodeContext({
   comment: PRComment
   repoPath: string | null
   repoId: string
+  sourceContext?: TaskSourceContext | null
   prNumber: number
   files: GitHubPRFile[]
   headSha: string | undefined
@@ -2664,7 +2924,7 @@ function CommentCodeContext({
       return
     }
     let cancelled = false
-    loadPRFileContents({ repoPath, repoId, prNumber, file, headSha, baseSha })
+    loadPRFileContents({ repoPath, repoId, sourceContext, prNumber, file, headSha, baseSha })
       .then((result) => {
         if (!cancelled) {
           setContents(result)
@@ -2678,7 +2938,7 @@ function CommentCodeContext({
     return () => {
       cancelled = true
     }
-  }, [baseSha, file, headSha, line, prNumber, repoId, repoPath])
+  }, [baseSha, file, headSha, line, prNumber, repoId, repoPath, sourceContext])
 
   const resolvedContextExpansionState = resolveCommentCodeContextExpansionState(
     contextExpansionState,
@@ -2931,6 +3191,7 @@ function ConversationTab({
   item,
   repoPath,
   repoId,
+  sourceContext,
   body,
   comments,
   files,
@@ -2952,6 +3213,7 @@ function ConversationTab({
   item: GitHubWorkItem
   repoPath: string | null
   repoId: string | null
+  sourceContext?: TaskSourceContext | null
   body: string
   comments: PRComment[]
   files: GitHubPRFile[]
@@ -2981,7 +3243,17 @@ function ConversationTab({
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
   )
-  const repoAssignees = useRepoAssignees(repoPath, item.repoId, repoOwnerSettings)
+  const sourceSettings = useMemo(
+    () =>
+      sourceContext?.provider === 'github'
+        ? ({
+            ...repoOwnerSettings,
+            ...getTaskSourceRuntimeSettings(sourceContext)
+          } as typeof repoOwnerSettings)
+        : repoOwnerSettings,
+    [repoOwnerSettings, sourceContext]
+  )
+  const repoAssignees = useRepoAssignees(repoPath, item.repoId, sourceSettings)
   const commentCounts = useMemo(() => getPRCommentAudienceCounts(comments), [comments])
   const visibleComments = useMemo(
     () => filterPRCommentsByAudience(comments, commentFilter),
@@ -3052,6 +3324,7 @@ function ConversationTab({
       await runWorkItemBodyUpdate({
         item,
         repoPath,
+        sourceContext,
         projectOrigin,
         body: resolvedBodyDraft,
         parsedSlug: bodySlug
@@ -3076,7 +3349,8 @@ function ConversationTab({
     item,
     onBodyUpdated,
     projectOrigin,
-    repoPath
+    repoPath,
+    sourceContext
   ])
 
   const handleReply = useCallback(
@@ -3095,6 +3369,7 @@ function ConversationTab({
           ? await addPRReviewCommentReplyForRepo({
               repoPath,
               repoId: item.repoId,
+              sourceContext,
               prNumber: item.number,
               commentId: comment.id,
               body: replyBody,
@@ -3105,6 +3380,7 @@ function ConversationTab({
           : await addIssueCommentForRepo({
               repoPath,
               repoId: item.repoId,
+              sourceContext,
               number: item.number,
               body: `@${comment.author} ${replyBody}`,
               type: item.type
@@ -3122,7 +3398,7 @@ function ConversationTab({
       toast.success(translate('auto.components.PullRequestPage.11505c7a71', 'Reply posted.'))
       return true
     },
-    [item.number, item.repoId, item.type, onCommentAdded, repoPath]
+    [item.number, item.repoId, item.type, onCommentAdded, repoPath, sourceContext]
   )
 
   const rightPanel =
@@ -3132,6 +3408,7 @@ function ConversationTab({
           item={item}
           repoPath={repoPath}
           repoId={item.repoId}
+          sourceContext={sourceContext}
           projectOrigin={projectOrigin}
           localState={localState}
           onStateChange={onStateChange}
@@ -3141,12 +3418,14 @@ function ConversationTab({
           item={item}
           repoPath={repoPath}
           projectOrigin={projectOrigin}
+          sourceContext={sourceContext}
           onMutated={onMutated}
         />
         <PRReviewersPanel
           item={item}
           loading={loading}
           repoPath={repoPath}
+          sourceContext={sourceContext}
           onReviewersRequested={onReviewersRequested}
         />
         <aside className="overflow-hidden rounded-lg border border-border/50 bg-card shadow-xs">
@@ -3154,6 +3433,7 @@ function ConversationTab({
             item={item}
             repoPath={repoPath}
             repoId={item.repoId}
+            sourceContext={sourceContext}
             headSha={headSha}
             checks={checks}
             loading={loading || !detailsLoaded}
@@ -3259,6 +3539,7 @@ function ConversationTab({
           comment={comment}
           repoPath={repoPath}
           repoId={item.repoId}
+          sourceContext={sourceContext}
           prNumber={item.number}
           files={files}
           headSha={headSha}
@@ -3517,6 +3798,7 @@ function ConversationTab({
             className="mt-1"
             repoPath={repoPath}
             repoId={item.repoId}
+            sourceContext={sourceContext}
             issueNumber={item.number}
             itemType={item.type}
             mentionOptions={mentionOptions}
@@ -3534,6 +3816,7 @@ function PRActionsPanel({
   item,
   repoPath,
   repoId,
+  sourceContext,
   projectOrigin,
   localState,
   onStateChange,
@@ -3542,6 +3825,7 @@ function PRActionsPanel({
   item: GitHubWorkItem
   repoPath: string | null
   repoId: string | null
+  sourceContext?: TaskSourceContext | null
   projectOrigin: PullRequestPageProjectOrigin | undefined
   localState: GitHubWorkItem['state']
   onStateChange: (state: GitHubWorkItem['state']) => void
@@ -3555,9 +3839,13 @@ function PRActionsPanel({
   const actionItem = { ...item, state: localState }
   const mergePresentation = presentGitHubPRMergeState(actionItem)
   const mergeMethods = resolveGitHubPRMergeMethods(actionItem.mergeMethodSettings)
+  const sourceSettings = getTaskSourceRuntimeSettings(sourceContext)
+  const mergeTarget = getActiveRuntimeTarget(sourceSettings)
   const canMutateState = localState !== 'merged' && (!!repoPath || !!projectOrigin)
   const nextState: 'open' | 'closed' = localState === 'closed' ? 'open' : 'closed'
-  const mergeDisabled = !repoPath || mergePending || !mergePresentation.directMergeAvailable
+  const canMergeWithRepoContext = !!repoPath || mergeTarget.kind === 'environment'
+  const mergeDisabled =
+    !canMergeWithRepoContext || mergePending || !mergePresentation.directMergeAvailable
 
   const patchProjectRowIfNeeded = useCallback(
     (state: GitHubWorkItem['state']) => {
@@ -3572,10 +3860,10 @@ function PRActionsPanel({
   const applyStatePatch = useCallback(
     (state: GitHubWorkItem['state']) => {
       onStateChange(state)
-      patchWorkItem(item.id, { state }, item.repoId)
+      patchWorkItem(item.id, { state }, item.repoId, { sourceContext })
       patchProjectRowIfNeeded(state)
     },
-    [item.id, item.repoId, onStateChange, patchProjectRowIfNeeded, patchWorkItem]
+    [item.id, item.repoId, onStateChange, patchProjectRowIfNeeded, patchWorkItem, sourceContext]
   )
 
   const handleStateChange = async (): Promise<void> => {
@@ -3611,6 +3899,7 @@ function PRActionsPanel({
       await runPullRequestStateUpdate({
         repoPath,
         repoId,
+        sourceContext,
         projectOrigin,
         number: item.number,
         updates: { state: nextState }
@@ -3636,7 +3925,7 @@ function PRActionsPanel({
   }
 
   const handleMerge = async (method: GitHubPRMergeMethod): Promise<void> => {
-    if (!repoPath || mergeDisabled) {
+    if (mergeDisabled) {
       return
     }
     const label = GITHUB_PR_MERGE_METHOD_LABELS[method]
@@ -3656,18 +3945,44 @@ function PRActionsPanel({
     }
     setMergePending(true)
     try {
-      const result = await window.api.gh.mergePR({
-        repoPath,
-        repoId: repoId ?? undefined,
-        prNumber: item.number,
-        method,
-        prRepo: item.prRepo ?? null
-      })
+      const result =
+        mergeTarget.kind === 'environment'
+          ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.mergePR>>>(
+              mergeTarget,
+              'github.mergePR',
+              {
+                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                prNumber: item.number,
+                method,
+                prRepo: item.prRepo ?? null
+              },
+              { timeoutMs: 30_000 }
+            )
+          : await window.api.gh.mergePR({
+              repoPath: repoPath ?? '',
+              repoId: repoId ?? undefined,
+              sourceContext,
+              prNumber: item.number,
+              method,
+              prRepo: item.prRepo ?? null
+            })
       if (!result.ok) {
         toast.error(result.error)
         return
       }
       applyStatePatch('merged')
+      if (mergeTarget.kind === 'environment') {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: repoPath ?? '',
+            repoId: item.repoId,
+            sourceContext,
+            type: 'pr',
+            number: item.number
+          },
+          { local: false }
+        )
+      }
       toast.success(translate('auto.components.PullRequestPage.c57873d721', 'Pull request merged'))
       onMutated()
     } catch {
@@ -3680,23 +3995,50 @@ function PRActionsPanel({
   }
 
   const handleAutoMerge = async (): Promise<void> => {
-    if (!repoPath || !mergePresentation.autoMergeAction) {
+    if (!canMergeWithRepoContext || !mergePresentation.autoMergeAction) {
       return
     }
     const enabled = mergePresentation.autoMergeAction.kind === 'enable'
     setMergePending(true)
     try {
-      const result = await window.api.gh.setPRAutoMerge({
-        repoPath,
-        repoId: repoId ?? undefined,
-        prNumber: item.number,
-        enabled,
-        method: enabled ? mergeMethods.defaultMethod : undefined,
-        prRepo: item.prRepo ?? null
-      })
+      const result =
+        mergeTarget.kind === 'environment'
+          ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.setPRAutoMerge>>>(
+              mergeTarget,
+              'github.setPRAutoMerge',
+              {
+                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                prNumber: item.number,
+                enabled,
+                method: enabled ? mergeMethods.defaultMethod : undefined,
+                prRepo: item.prRepo ?? null
+              },
+              { timeoutMs: 30_000 }
+            )
+          : await window.api.gh.setPRAutoMerge({
+              repoPath: repoPath ?? '',
+              repoId: repoId ?? undefined,
+              sourceContext,
+              prNumber: item.number,
+              enabled,
+              method: enabled ? mergeMethods.defaultMethod : undefined,
+              prRepo: item.prRepo ?? null
+            })
       if (!result.ok) {
         toast.error(result.error)
         return
+      }
+      if (mergeTarget.kind === 'environment') {
+        notifyWorkItemDetailsMutation(
+          {
+            repoPath: repoPath ?? '',
+            repoId: item.repoId,
+            sourceContext,
+            type: 'pr',
+            number: item.number
+          },
+          { local: false }
+        )
       }
       toast.success(
         enabled
@@ -4052,6 +4394,7 @@ function ChecksTab({
   item,
   repoPath,
   repoId,
+  sourceContext,
   headSha,
   checks,
   loading,
@@ -4061,6 +4404,7 @@ function ChecksTab({
   item: GitHubWorkItem
   repoPath: string | null
   repoId: string | null
+  sourceContext?: TaskSourceContext | null
   headSha: string | undefined
   checks: GitHubWorkItemDetails['checks']
   loading: boolean
@@ -4176,6 +4520,8 @@ function ChecksTab({
     [item, targetRepoId]
   )
   const prRepo = useMemo(() => parseOwnerRepoFromItemUrl(item.url), [item.url])
+  const parsedSourceHost =
+    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
   const sorted = [...list].sort(
     (a, b) =>
       (CHECK_SORT_ORDER[getCheckConclusion(a)] ?? 3) -
@@ -4214,13 +4560,27 @@ function ChecksTab({
     }
     setRefreshing(true)
     try {
-      const nextChecks = (await window.api.gh.prChecks({
-        repoPath,
-        repoId: repoId ?? undefined,
-        prNumber: item.number,
-        headSha,
-        noCache: true
-      })) as PRCheckDetail[]
+      const nextChecks = (await (parsedSourceHost?.kind === 'runtime'
+        ? callRuntimeRpc<PRCheckDetail[]>(
+            { kind: 'environment', environmentId: parsedSourceHost.environmentId },
+            'github.prChecks',
+            {
+              repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+              prNumber: item.number,
+              headSha,
+              prRepo,
+              noCache: true
+            },
+            { timeoutMs: 30_000 }
+          )
+        : window.api.gh.prChecks({
+            repoPath,
+            repoId: repoId ?? undefined,
+            sourceContext,
+            prNumber: item.number,
+            headSha,
+            noCache: true
+          }))) as PRCheckDetail[]
       setChecksState((current) => updateGitHubChecksTabLocalChecks(current, nextChecks))
       onChecksUpdated(nextChecks)
       return nextChecks
@@ -4234,7 +4594,17 @@ function ChecksTab({
     } finally {
       setRefreshing(false)
     }
-  }, [headSha, item.number, onChecksUpdated, repoId, repoPath])
+  }, [
+    headSha,
+    item.number,
+    item.repoId,
+    onChecksUpdated,
+    parsedSourceHost,
+    prRepo,
+    repoId,
+    repoPath,
+    sourceContext
+  ])
 
   const handleRerun = useCallback(
     async (failedOnly: boolean): Promise<void> => {
@@ -4243,13 +4613,27 @@ function ChecksTab({
       }
       setRerunning(true)
       try {
-        const result = await window.api.gh.rerunPRChecks({
-          repoPath,
-          repoId: repoId ?? undefined,
-          prNumber: item.number,
-          headSha,
-          failedOnly
-        })
+        const result =
+          parsedSourceHost?.kind === 'runtime'
+            ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.rerunPRChecks>>>(
+                { kind: 'environment', environmentId: parsedSourceHost.environmentId },
+                'github.rerunPRChecks',
+                {
+                  repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                  prNumber: item.number,
+                  headSha,
+                  failedOnly
+                },
+                { timeoutMs: 30_000 }
+              )
+            : await window.api.gh.rerunPRChecks({
+                repoPath,
+                repoId: repoId ?? undefined,
+                sourceContext,
+                prNumber: item.number,
+                headSha,
+                failedOnly
+              })
         if (!result.ok) {
           toast.error(result.error)
           return
@@ -4270,7 +4654,17 @@ function ChecksTab({
         setRerunning(false)
       }
     },
-    [handleRefresh, headSha, item.number, rerunning, repoId, repoPath]
+    [
+      handleRefresh,
+      headSha,
+      item.number,
+      item.repoId,
+      parsedSourceHost,
+      rerunning,
+      repoId,
+      repoPath,
+      sourceContext
+    ]
   )
 
   const handleFixBrokenChecks = useCallback(async (): Promise<void> => {
@@ -4344,16 +4738,32 @@ function ChecksTab({
           error: null
         })
       )
-      void window.api.gh
-        .prCheckDetails({
-          repoPath,
-          repoId: repoId ?? undefined,
-          checkRunId: check.checkRunId,
-          workflowRunId: check.workflowRunId,
-          checkName: check.name,
-          url: check.url,
-          prRepo
-        })
+      const detailsRequest =
+        parsedSourceHost?.kind === 'runtime'
+          ? callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.prCheckDetails>>>(
+              { kind: 'environment', environmentId: parsedSourceHost.environmentId },
+              'github.prCheckDetails',
+              {
+                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                checkRunId: check.checkRunId,
+                workflowRunId: check.workflowRunId,
+                checkName: check.name,
+                url: check.url,
+                prRepo
+              },
+              { timeoutMs: 30_000 }
+            )
+          : window.api.gh.prCheckDetails({
+              repoPath,
+              repoId: repoId ?? undefined,
+              sourceContext,
+              checkRunId: check.checkRunId,
+              workflowRunId: check.workflowRunId,
+              checkName: check.name,
+              url: check.url,
+              prRepo
+            })
+      void detailsRequest
         .then((details) => {
           if (!mountedRef.current) {
             return
@@ -4379,7 +4789,16 @@ function ChecksTab({
           )
         })
     },
-    [detailsByCheckKey, mountedRef, prRepo, repoId, repoPath]
+    [
+      detailsByCheckKey,
+      item.repoId,
+      mountedRef,
+      parsedSourceHost,
+      prRepo,
+      repoId,
+      repoPath,
+      sourceContext
+    ]
   )
 
   const refreshAction = (
@@ -5077,12 +5496,17 @@ function getGitHubMutationSettings(repoId: string | null | undefined) {
 async function runIssueUpdate(args: {
   repoPath: string | null
   repoId?: string | null
+  sourceContext?: TaskSourceContext | null
   projectOrigin: PullRequestPageProjectOrigin | undefined
   number: number
   updates: Parameters<typeof window.api.gh.updateIssue>[0]['updates']
 }): Promise<void> {
   if (args.projectOrigin) {
-    const target = getActiveRuntimeTarget(getGitHubMutationSettings(args.repoId))
+    const targetSettings =
+      args.sourceContext?.provider === 'github'
+        ? getTaskSourceRuntimeSettings(args.sourceContext)
+        : getGitHubMutationSettings(args.repoId)
+    const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: args.projectOrigin.owner,
       repo: args.projectOrigin.repo,
@@ -5103,25 +5527,67 @@ async function runIssueUpdate(args: {
     if (!res.ok) {
       throw new Error(res.error.message)
     }
+    if (target.kind === 'environment') {
+      notifyWorkItemDetailsMutation(
+        {
+          repoPath: args.repoPath ?? '',
+          repoId: args.repoId ?? undefined,
+          sourceContext: args.sourceContext,
+          type: 'issue',
+          number: args.number
+        },
+        { local: false }
+      )
+    }
     return
   }
   if (!args.repoPath) {
     throw new Error('No repo context available for this edit.')
   }
-  const res = await window.api.gh.updateIssue({
-    repoPath: args.repoPath,
-    repoId: args.repoId ?? undefined,
-    number: args.number,
-    updates: args.updates
-  })
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  const res =
+    parsedHost?.kind === 'runtime'
+      ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssue>>>(
+          { kind: 'environment', environmentId: parsedHost.environmentId },
+          'github.updateIssue',
+          {
+            repo: args.sourceContext?.repoId ?? args.repoId,
+            number: args.number,
+            updates: args.updates
+          },
+          { timeoutMs: 30_000 }
+        )
+      : await window.api.gh.updateIssue({
+          repoPath: args.repoPath,
+          repoId: args.repoId ?? undefined,
+          sourceContext: args.sourceContext,
+          number: args.number,
+          updates: args.updates
+        })
   if (!res.ok) {
     throw new Error(res.error)
+  }
+  if (parsedHost?.kind === 'runtime') {
+    notifyWorkItemDetailsMutation(
+      {
+        repoPath: args.repoPath,
+        repoId: args.repoId ?? undefined,
+        sourceContext: args.sourceContext,
+        type: 'issue',
+        number: args.number
+      },
+      { local: false }
+    )
   }
 }
 
 async function runWorkItemBodyUpdate(args: {
   item: GitHubWorkItem
   repoPath: string | null
+  sourceContext?: TaskSourceContext | null
   projectOrigin: PullRequestPageProjectOrigin | undefined
   body: string
   parsedSlug: GitHubOwnerRepo | null
@@ -5133,7 +5599,11 @@ async function runWorkItemBodyUpdate(args: {
     if (!targetSlug) {
       throw new Error('No GitHub repository context available for this pull request.')
     }
-    const target = getActiveRuntimeTarget(getGitHubMutationSettings(args.item.repoId))
+    const targetSettings =
+      args.sourceContext?.provider === 'github'
+        ? getTaskSourceRuntimeSettings(args.sourceContext)
+        : getGitHubMutationSettings(args.item.repoId)
+    const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: targetSlug.owner,
       repo: targetSlug.repo,
@@ -5154,12 +5624,25 @@ async function runWorkItemBodyUpdate(args: {
     if (!res.ok) {
       throw new Error(res.error.message)
     }
+    if (target.kind === 'environment') {
+      notifyWorkItemDetailsMutation(
+        {
+          repoPath: args.repoPath ?? '',
+          repoId: args.item.repoId,
+          sourceContext: args.sourceContext,
+          type: 'pr',
+          number: args.item.number
+        },
+        { local: false }
+      )
+    }
     return
   }
 
   await runIssueUpdate({
     repoPath: args.repoPath,
     repoId: args.item.repoId,
+    sourceContext: args.sourceContext,
     projectOrigin: args.projectOrigin,
     number: args.item.number,
     updates: { body: args.body }
@@ -5169,12 +5652,17 @@ async function runWorkItemBodyUpdate(args: {
 async function runPullRequestStateUpdate(args: {
   repoPath: string | null
   repoId?: string | null
+  sourceContext?: TaskSourceContext | null
   projectOrigin: PullRequestPageProjectOrigin | undefined
   number: number
   updates: { state: 'open' | 'closed' }
 }): Promise<void> {
   if (args.projectOrigin) {
-    const target = getActiveRuntimeTarget(getGitHubMutationSettings(args.repoId))
+    const targetSettings =
+      args.sourceContext?.provider === 'github'
+        ? getTaskSourceRuntimeSettings(args.sourceContext)
+        : getGitHubMutationSettings(args.repoId)
+    const target = getActiveRuntimeTarget(targetSettings)
     const updateArgs = {
       owner: args.projectOrigin.owner,
       repo: args.projectOrigin.repo,
@@ -5195,19 +5683,60 @@ async function runPullRequestStateUpdate(args: {
     if (!res.ok) {
       throw new Error(res.error.message)
     }
+    if (target.kind === 'environment') {
+      notifyWorkItemDetailsMutation(
+        {
+          repoPath: args.repoPath ?? '',
+          repoId: args.repoId ?? undefined,
+          sourceContext: args.sourceContext,
+          type: 'pr',
+          number: args.number
+        },
+        { local: false }
+      )
+    }
     return
   }
   if (!args.repoPath) {
     throw new Error('No repo context available for this pull request.')
   }
-  const res = await window.api.gh.updatePRState({
-    repoPath: args.repoPath,
-    repoId: args.repoId ?? undefined,
-    prNumber: args.number,
-    updates: args.updates
-  })
+  const parsedHost =
+    args.sourceContext?.provider === 'github'
+      ? parseExecutionHostId(args.sourceContext.hostId)
+      : null
+  const res =
+    parsedHost?.kind === 'runtime'
+      ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
+          { kind: 'environment', environmentId: parsedHost.environmentId },
+          'github.updatePRState',
+          {
+            repo: args.sourceContext?.repoId ?? args.repoId,
+            prNumber: args.number,
+            updates: args.updates
+          },
+          { timeoutMs: 30_000 }
+        )
+      : await window.api.gh.updatePRState({
+          repoPath: args.repoPath,
+          repoId: args.repoId ?? undefined,
+          sourceContext: args.sourceContext,
+          prNumber: args.number,
+          updates: args.updates
+        })
   if (!res.ok) {
     throw new Error(res.error)
+  }
+  if (parsedHost?.kind === 'runtime') {
+    notifyWorkItemDetailsMutation(
+      {
+        repoPath: args.repoPath,
+        repoId: args.repoId ?? undefined,
+        sourceContext: args.sourceContext,
+        type: 'pr',
+        number: args.number
+      },
+      { local: false }
+    )
   }
 }
 
@@ -5215,6 +5744,7 @@ function GHEditSection({
   item,
   repoPath,
   repoId,
+  sourceContext,
   projectOrigin,
   localState,
   localLabels,
@@ -5227,6 +5757,7 @@ function GHEditSection({
   item: GitHubWorkItem
   repoPath: string | null
   repoId: string | null
+  sourceContext?: TaskSourceContext | null
   projectOrigin: PullRequestPageProjectOrigin | undefined
   localState: GitHubWorkItem['state']
   localLabels: string[]
@@ -5248,6 +5779,16 @@ function GHEditSection({
   const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
+  )
+  const sourceSettings = useMemo(
+    () =>
+      sourceContext?.provider === 'github'
+        ? ({
+            ...repoOwnerSettings,
+            ...getTaskSourceRuntimeSettings(sourceContext)
+          } as typeof repoOwnerSettings)
+        : repoOwnerSettings,
+    [repoOwnerSettings, sourceContext]
   )
   const { isPending, run } = useImmediateMutation()
   // Why: when the dialog opens from a Project view, mutations route through
@@ -5273,21 +5814,16 @@ function GHEditSection({
   const repoLabelsByPath = useRepoLabels(
     projectOrigin ? null : repoPath,
     projectOrigin ? null : repoId,
-    repoOwnerSettings
+    sourceSettings
   )
-  const repoLabelsBySlug = useRepoLabelsBySlug(slugOwner, slugRepo, repoOwnerSettings)
+  const repoLabelsBySlug = useRepoLabelsBySlug(slugOwner, slugRepo, sourceSettings)
   const repoLabels = projectOrigin ? repoLabelsBySlug : repoLabelsByPath
   const repoAssigneesByPath = useRepoAssignees(
     projectOrigin ? null : repoPath,
     projectOrigin ? null : repoId,
-    repoOwnerSettings
+    sourceSettings
   )
-  const repoAssigneesBySlug = useRepoAssigneesBySlug(
-    slugOwner,
-    slugRepo,
-    assignees,
-    repoOwnerSettings
-  )
+  const repoAssigneesBySlug = useRepoAssigneesBySlug(slugOwner, slugRepo, assignees, sourceSettings)
   const repoAssignees = projectOrigin ? repoAssigneesBySlug : repoAssigneesByPath
 
   // Why: sync local assignees when item changes or when the detail fetch
@@ -5311,22 +5847,23 @@ function GHEditSection({
           runIssueUpdate({
             repoId: item.repoId,
             repoPath,
+            sourceContext,
             projectOrigin,
             number: item.number,
             updates: { state: newState }
           }),
         onOptimistic: () => {
           onStateChange(newState)
-          patchWorkItem(item.id, { state: newState }, item.repoId)
+          patchWorkItem(item.id, { state: newState }, item.repoId, { sourceContext })
           patchProjectRowIfNeeded({ state: newState })
         },
         onRevert: () => {
           onStateChange(prevState)
-          patchWorkItem(item.id, { state: prevState }, item.repoId)
+          patchWorkItem(item.id, { state: prevState }, item.repoId, { sourceContext })
           patchProjectRowIfNeeded({ state: prevState })
         },
         onSuccess: () => {
-          patchWorkItem(item.id, { state: newState }, item.repoId)
+          patchWorkItem(item.id, { state: newState }, item.repoId, { sourceContext })
           patchProjectRowIfNeeded({ state: newState })
           onMutated()
         },
@@ -5339,6 +5876,7 @@ function GHEditSection({
       item.repoId,
       localState,
       repoPath,
+      sourceContext,
       projectOrigin,
       patchWorkItem,
       patchProjectRowIfNeeded,
@@ -5360,13 +5898,14 @@ function GHEditSection({
             runIssueUpdate({
               repoId: item.repoId,
               repoPath,
+              sourceContext,
               projectOrigin,
               number: item.number,
               updates: { addLabels: [label] }
             }),
           onOptimistic: () => {
             onLabelsChange(newLabels)
-            patchWorkItem(item.id, { labels: newLabels }, item.repoId)
+            patchWorkItem(item.id, { labels: newLabels }, item.repoId, { sourceContext })
             patchProjectRowIfNeeded({ labels: newLabels })
           },
           onSuccess: () => {
@@ -5374,7 +5913,7 @@ function GHEditSection({
           },
           onRevert: () => {
             onLabelsChange(prevLabels)
-            patchWorkItem(item.id, { labels: prevLabels }, item.repoId)
+            patchWorkItem(item.id, { labels: prevLabels }, item.repoId, { sourceContext })
             patchProjectRowIfNeeded({ labels: prevLabels })
           },
           onError: (err) => toast.error(err)
@@ -5385,18 +5924,19 @@ function GHEditSection({
             runIssueUpdate({
               repoId: item.repoId,
               repoPath,
+              sourceContext,
               projectOrigin,
               number: item.number,
               updates: { removeLabels: [label] }
             }),
           onOptimistic: () => {
             onLabelsChange(newLabels)
-            patchWorkItem(item.id, { labels: newLabels }, item.repoId)
+            patchWorkItem(item.id, { labels: newLabels }, item.repoId, { sourceContext })
             patchProjectRowIfNeeded({ labels: newLabels })
           },
           onRevert: () => {
             onLabelsChange(prevLabels)
-            patchWorkItem(item.id, { labels: prevLabels }, item.repoId)
+            patchWorkItem(item.id, { labels: prevLabels }, item.repoId, { sourceContext })
             patchProjectRowIfNeeded({ labels: prevLabels })
           },
           onSuccess: () => {
@@ -5412,6 +5952,7 @@ function GHEditSection({
       item.repoId,
       localLabels,
       repoPath,
+      sourceContext,
       projectOrigin,
       patchWorkItem,
       patchProjectRowIfNeeded,
@@ -5438,6 +5979,7 @@ function GHEditSection({
             runIssueUpdate({
               repoId: item.repoId,
               repoPath,
+              sourceContext,
               projectOrigin,
               number: item.number,
               updates: { removeAssignees: [login] }
@@ -5461,6 +6003,7 @@ function GHEditSection({
             runIssueUpdate({
               repoId: item.repoId,
               repoPath,
+              sourceContext,
               projectOrigin,
               number: item.number,
               updates: { addAssignees: [login] }
@@ -5485,6 +6028,7 @@ function GHEditSection({
       item.repoId,
       assigneesItemKey,
       repoPath,
+      sourceContext,
       projectOrigin,
       localAssignees,
       patchProjectRowIfNeeded,
@@ -5694,6 +6238,7 @@ function GHCommentComposer({
   className,
   repoPath,
   repoId,
+  sourceContext,
   issueNumber,
   itemType,
   mentionOptions,
@@ -5702,6 +6247,7 @@ function GHCommentComposer({
   className?: string
   repoPath: string
   repoId?: string | null
+  sourceContext?: TaskSourceContext | null
   issueNumber: number
   itemType: 'issue' | 'pr'
   mentionOptions: MentionOption[]
@@ -5740,6 +6286,7 @@ function GHCommentComposer({
       const result = await addIssueCommentForRepo({
         repoPath,
         repoId: repoId ?? undefined,
+        sourceContext,
         number: issueNumber,
         body: bodyState.body,
         type: itemType
@@ -5772,7 +6319,17 @@ function GHCommentComposer({
         setSubmitting(false)
       }
     }
-  }, [autoGrow, body, mountedRef, repoPath, repoId, issueNumber, itemType, onCommentAdded])
+  }, [
+    autoGrow,
+    body,
+    mountedRef,
+    repoPath,
+    repoId,
+    sourceContext,
+    issueNumber,
+    itemType,
+    onCommentAdded
+  ])
   const canSubmitComment = hasBoundedCommentBodyText(body)
 
   const handleKeyDown = useCallback(
@@ -5833,6 +6390,7 @@ export default function PullRequestPage({
   workItem,
   repoPath,
   repoId,
+  sourceContext,
   initialTab,
   backLabel = 'Pull requests',
   projectOrigin,
@@ -5889,10 +6447,12 @@ export default function PullRequestPage({
       repoPath,
       repoId: effectiveRepoId,
       issueSourcePreference,
+      sourceCacheScope:
+        sourceContext?.provider === 'github' ? getTaskSourceCacheScope(sourceContext) : null,
       type: workItem.type,
       number: workItem.number
     })
-  }, [repoPath, effectiveRepoId, workItem, issueSourcePreference])
+  }, [repoPath, effectiveRepoId, sourceContext, workItem, issueSourcePreference])
 
   // Why: reset lifted edit state when the dialog switches items or when the
   // same item receives an optimistic cache patch from the surrounding table.
@@ -6045,9 +6605,7 @@ export default function PullRequestPage({
 
   const loading = !!cachedEntry?.pending && !cachedEntry?.details
   const error = cachedEntry?.error && !cachedEntry?.details ? cachedEntry.error : null
-  const detailsLoaded =
-    Boolean(cachedEntry?.details) ||
-    Boolean(cachedEntry && !cachedEntry.pending && !cachedEntry.error && cachedEntry.fetchedAt > 0)
+  const detailsLoaded = Boolean(cachedEntry?.details)
 
   // Why: if a cross-window mutation invalidates the open drawer's entry
   // (cachedEntry becomes undefined while workItem is still set), the main
@@ -6061,7 +6619,7 @@ export default function PullRequestPage({
   }, [workItem, detailsCacheKey, cachedEntry])
 
   useEffect(() => {
-    if (!workItem || !repoPath || !detailsCacheKey) {
+    if (!workItem || !repoPath || !effectiveRepoId || !detailsCacheKey) {
       return
     }
     // Why: only clear optimistic comments when switching to a genuinely
@@ -6087,9 +6645,10 @@ export default function PullRequestPage({
     // racing two `gh` subprocesses against each other.
     const inflight: Promise<GitHubWorkItemDetails | null> =
       cached?.pending ??
-      getWorkItemDetailsForRepo({
+      lookupGitHubWorkItemDetailsForSource({
         repoPath,
-        repoId: effectiveRepoId ?? undefined,
+        repoId: effectiveRepoId,
+        sourceContext,
         number: workItem.number,
         type: workItem.type
       })
@@ -6117,14 +6676,18 @@ export default function PullRequestPage({
           // entry still exists (later open repopulated it) leave it alone too.
           return
         }
-        // Why: 404/unauthorized must not overwrite valid cached data. When the
-        // IPC resolves to null and we already have cached details, keep the
-        // stale data — only blank entries get the null payload.
+        // Why: null means unavailable/not found, not loaded empty content.
         if (result === null && prev?.details) {
           touchWorkItemDetailsCache(detailsCacheKey, {
             details: prev.details,
             fetchedAt: prev.fetchedAt,
             error: undefined
+          })
+        } else if (result === null) {
+          touchWorkItemDetailsCache(detailsCacheKey, {
+            details: null,
+            fetchedAt: 0,
+            error: WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE
           })
         } else {
           touchWorkItemDetailsCache(detailsCacheKey, {
@@ -6150,7 +6713,7 @@ export default function PullRequestPage({
           error: message
         })
       })
-  }, [repoPath, effectiveRepoId, workItem, detailsCacheKey, refetchTick])
+  }, [repoPath, effectiveRepoId, sourceContext, workItem, detailsCacheKey, refetchTick])
 
   const Icon = workItem?.type === 'pr' ? GitPullRequest : CircleDot
   const displayWorkItem = useMemo<GitHubWorkItem | null>(() => {
@@ -6286,6 +6849,7 @@ export default function PullRequestPage({
         const ok = await setPRFileViewedForRepo({
           repoId: workItem.repoId,
           repoPath,
+          sourceContext,
           prNumber: workItem.number,
           pullRequestId: details.pullRequestId,
           path,
@@ -6312,7 +6876,7 @@ export default function PullRequestPage({
         })
       }
     },
-    [details?.pullRequestId, detailsCacheKey, repoPath, workItem]
+    [details?.pullRequestId, detailsCacheKey, repoPath, sourceContext, workItem]
   )
 
   const ownerRepo = parseOwnerRepoFromItemUrl(workItem?.url ?? '')
@@ -6526,6 +7090,7 @@ export default function PullRequestPage({
           item={workItem}
           repoPath={repoPath}
           repoId={effectiveRepoId}
+          sourceContext={sourceContext}
           projectOrigin={projectOrigin}
           localState={localState}
           localLabels={localLabels}
@@ -6597,6 +7162,7 @@ export default function PullRequestPage({
                   item={displayWorkItem ?? workItem}
                   repoPath={repoPath}
                   repoId={effectiveRepoId}
+                  sourceContext={sourceContext}
                   body={body}
                   comments={comments}
                   files={files}
@@ -6647,6 +7213,7 @@ export default function PullRequestPage({
                   item={workItem}
                   repoPath={repoPath}
                   repoId={effectiveRepoId}
+                  sourceContext={sourceContext}
                   headSha={details?.headSha}
                   checks={checks}
                   loading={loading || !detailsLoaded}
@@ -6674,6 +7241,7 @@ export default function PullRequestPage({
                     comments={comments}
                     repoPath={repoPath ?? ''}
                     repoId={effectiveRepoId ?? ''}
+                    sourceContext={sourceContext}
                     prNumber={workItem.number}
                     prUrl={workItem.url}
                     headSha={details?.headSha}

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -165,12 +165,16 @@ import {
   onGitHubWorkItemDetailsCacheMutation
 } from '@/lib/github-work-item-details-cache-events'
 import { lookupGitHubWorkItemDetailsForSource } from '@/lib/github-work-item-source-lookup'
+import {
+  canUseGitHubRepoContext,
+  getGitHubRuntimeRepoId,
+  getGitHubSourceRuntimeHost
+} from '@/lib/github-source-runtime-context'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
 import {
   GITHUB_PR_MERGE_METHOD_LABELS,
   resolveGitHubPRMergeMethods
 } from '../../../shared/github-pr-merge-methods'
-import { parseExecutionHostId } from '../../../shared/execution-host'
 import {
   findGithubPrWorkspaceAttachment,
   getGithubPrWorkspaceAttachmentLabel
@@ -988,7 +992,7 @@ function PRReviewersPanel({
     }
     setSubmitting(true)
     try {
-      const runtimeRepo = sourceContext?.repoId ?? item.repoId
+      const runtimeRepo = getGitHubRuntimeRepoId(sourceContext, item.repoId)
       const result =
         target.kind === 'environment'
           ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
@@ -1078,7 +1082,7 @@ function PRReviewersPanel({
     }
     setSubmitting(true)
     try {
-      const runtimeRepo = sourceContext?.repoId ?? item.repoId
+      const runtimeRepo = getGitHubRuntimeRepoId(sourceContext, item.repoId)
       const result =
         target.kind === 'environment'
           ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
@@ -1772,17 +1776,14 @@ function loadPRFileContents(args: {
     return Promise.resolve(cached.value)
   }
   let request: Promise<GitHubPRFileContents>
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
   request = (
-    parsedHost?.kind === 'runtime'
+    runtimeHost
       ? callRuntimeRpc<GitHubPRFileContents>(
-          { kind: 'environment', environmentId: parsedHost.environmentId },
+          { kind: 'environment', environmentId: runtimeHost.environmentId },
           'github.prFileContents',
           {
-            repo: args.sourceContext?.repoId ?? args.repoId,
+            repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
             prNumber: args.prNumber,
             path: args.file.path,
             oldPath: args.file.oldPath,
@@ -1830,16 +1831,13 @@ function addIssueCommentForRepo(args: {
   body: string
   type?: 'issue' | 'pr'
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>> {
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (parsedHost?.kind === 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (runtimeHost) {
     return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addIssueComment>>>(
-      { kind: 'environment', environmentId: parsedHost.environmentId },
+      { kind: 'environment', environmentId: runtimeHost.environmentId },
       'github.addIssueComment',
       {
-        repo: args.sourceContext?.repoId ?? args.repoId,
+        repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
         number: args.number,
         body: args.body
       },
@@ -1881,16 +1879,13 @@ function addPRReviewCommentForRepo(args: {
   startLine?: number
   body: string
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>> {
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (parsedHost?.kind === 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (runtimeHost) {
     return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewComment>>>(
-      { kind: 'environment', environmentId: parsedHost.environmentId },
+      { kind: 'environment', environmentId: runtimeHost.environmentId },
       'github.addPRReviewComment',
       {
-        repo: args.sourceContext?.repoId ?? args.repoId,
+        repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
         prNumber: args.prNumber,
         commitId: args.commitId,
         path: args.path,
@@ -1939,16 +1934,13 @@ function addPRReviewCommentReplyForRepo(args: {
   path?: string
   line?: number
 }): Promise<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>> {
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (parsedHost?.kind === 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (runtimeHost) {
     return callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.addPRReviewCommentReply>>>(
-      { kind: 'environment', environmentId: parsedHost.environmentId },
+      { kind: 'environment', environmentId: runtimeHost.environmentId },
       'github.addPRReviewCommentReply',
       {
-        repo: args.sourceContext?.repoId ?? args.repoId,
+        repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
         prNumber: args.prNumber,
         commentId: args.commentId,
         body: args.body,
@@ -2018,16 +2010,13 @@ function setPRFileViewedForRepo(args: {
   path: string
   viewed: boolean
 }): Promise<boolean> {
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (parsedHost?.kind === 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (runtimeHost) {
     return callRuntimeRpc<boolean>(
-      { kind: 'environment', environmentId: parsedHost.environmentId },
+      { kind: 'environment', environmentId: runtimeHost.environmentId },
       'github.setPRFileViewed',
       {
-        repo: args.sourceContext?.repoId ?? args.repoId,
+        repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId),
         pullRequestId: args.pullRequestId,
         path: args.path,
         viewed: args.viewed
@@ -3240,9 +3229,7 @@ function ConversationTab({
   const [bodySaving, setBodySaving] = useState(false)
   const bodyTextareaRef = useRef<HTMLTextAreaElement>(null)
   const bodyTextareaFocusFrameRef = useRef<number | null>(null)
-  const parsedSourceHost =
-    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
-  const canUseRepoMutationContext = !!repoPath || parsedSourceHost?.kind === 'runtime'
+  const canUseRepoMutationContext = canUseGitHubRepoContext(repoPath, sourceContext)
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null))
   )
@@ -3966,7 +3953,7 @@ function PRActionsPanel({
               mergeTarget,
               'github.mergePR',
               {
-                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
                 prNumber: item.number,
                 method,
                 prRepo: item.prRepo ?? null
@@ -4022,7 +4009,7 @@ function PRActionsPanel({
               mergeTarget,
               'github.setPRAutoMerge',
               {
-                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+                repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
                 prNumber: item.number,
                 enabled,
                 method: enabled ? mergeMethods.defaultMethod : undefined,
@@ -4535,9 +4522,8 @@ function ChecksTab({
     [item, targetRepoId]
   )
   const prRepo = useMemo(() => parseOwnerRepoFromItemUrl(item.url), [item.url])
-  const parsedSourceHost =
-    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
-  const canUseChecksRepoContext = !!repoPath || parsedSourceHost?.kind === 'runtime'
+  const runtimeHost = getGitHubSourceRuntimeHost(sourceContext)
+  const canUseChecksRepoContext = canUseGitHubRepoContext(repoPath, sourceContext)
   const sorted = [...list].sort(
     (a, b) =>
       (CHECK_SORT_ORDER[getCheckConclusion(a)] ?? 3) -
@@ -4576,12 +4562,12 @@ function ChecksTab({
     }
     setRefreshing(true)
     try {
-      const nextChecks = (await (parsedSourceHost?.kind === 'runtime'
+      const nextChecks = (await (runtimeHost
         ? callRuntimeRpc<PRCheckDetail[]>(
-            { kind: 'environment', environmentId: parsedSourceHost.environmentId },
+            { kind: 'environment', environmentId: runtimeHost.environmentId },
             'github.prChecks',
             {
-              repo: sourceContext?.repoId ?? repoId ?? item.repoId,
+              repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
               prNumber: item.number,
               headSha,
               prRepo,
@@ -4616,7 +4602,7 @@ function ChecksTab({
     item.number,
     item.repoId,
     onChecksUpdated,
-    parsedSourceHost,
+    runtimeHost,
     prRepo,
     repoId,
     repoPath,
@@ -4630,27 +4616,26 @@ function ChecksTab({
       }
       setRerunning(true)
       try {
-        const result =
-          parsedSourceHost?.kind === 'runtime'
-            ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.rerunPRChecks>>>(
-                { kind: 'environment', environmentId: parsedSourceHost.environmentId },
-                'github.rerunPRChecks',
-                {
-                  repo: sourceContext?.repoId ?? repoId ?? item.repoId,
-                  prNumber: item.number,
-                  headSha,
-                  failedOnly
-                },
-                { timeoutMs: 30_000 }
-              )
-            : await window.api.gh.rerunPRChecks({
-                repoPath: repoPath ?? '',
-                repoId: repoId ?? undefined,
-                sourceContext,
+        const result = runtimeHost
+          ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.rerunPRChecks>>>(
+              { kind: 'environment', environmentId: runtimeHost.environmentId },
+              'github.rerunPRChecks',
+              {
+                repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
                 prNumber: item.number,
                 headSha,
                 failedOnly
-              })
+              },
+              { timeoutMs: 30_000 }
+            )
+          : await window.api.gh.rerunPRChecks({
+              repoPath: repoPath ?? '',
+              repoId: repoId ?? undefined,
+              sourceContext,
+              prNumber: item.number,
+              headSha,
+              failedOnly
+            })
         if (!result.ok) {
           toast.error(result.error)
           return
@@ -4677,7 +4662,7 @@ function ChecksTab({
       headSha,
       item.number,
       item.repoId,
-      parsedSourceHost,
+      runtimeHost,
       rerunning,
       repoId,
       repoPath,
@@ -4756,31 +4741,30 @@ function ChecksTab({
           error: null
         })
       )
-      const detailsRequest =
-        parsedSourceHost?.kind === 'runtime'
-          ? callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.prCheckDetails>>>(
-              { kind: 'environment', environmentId: parsedSourceHost.environmentId },
-              'github.prCheckDetails',
-              {
-                repo: sourceContext?.repoId ?? repoId ?? item.repoId,
-                checkRunId: check.checkRunId,
-                workflowRunId: check.workflowRunId,
-                checkName: check.name,
-                url: check.url,
-                prRepo
-              },
-              { timeoutMs: 30_000 }
-            )
-          : window.api.gh.prCheckDetails({
-              repoPath: repoPath ?? '',
-              repoId: repoId ?? undefined,
-              sourceContext,
+      const detailsRequest = runtimeHost
+        ? callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.prCheckDetails>>>(
+            { kind: 'environment', environmentId: runtimeHost.environmentId },
+            'github.prCheckDetails',
+            {
+              repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId),
               checkRunId: check.checkRunId,
               workflowRunId: check.workflowRunId,
               checkName: check.name,
               url: check.url,
               prRepo
-            })
+            },
+            { timeoutMs: 30_000 }
+          )
+        : window.api.gh.prCheckDetails({
+            repoPath: repoPath ?? '',
+            repoId: repoId ?? undefined,
+            sourceContext,
+            checkRunId: check.checkRunId,
+            workflowRunId: check.workflowRunId,
+            checkName: check.name,
+            url: check.url,
+            prRepo
+          })
       void detailsRequest
         .then((details) => {
           if (!mountedRef.current) {
@@ -4812,7 +4796,7 @@ function ChecksTab({
       detailsByCheckKey,
       item.repoId,
       mountedRef,
-      parsedSourceHost,
+      runtimeHost,
       prRepo,
       repoId,
       repoPath,
@@ -5560,36 +5544,32 @@ async function runIssueUpdate(args: {
     }
     return
   }
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (!args.repoPath && parsedHost?.kind !== 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (!args.repoPath && !runtimeHost) {
     throw new Error('No repo context available for this edit.')
   }
-  const res =
-    parsedHost?.kind === 'runtime'
-      ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssue>>>(
-          { kind: 'environment', environmentId: parsedHost.environmentId },
-          'github.updateIssue',
-          {
-            repo: args.sourceContext?.repoId ?? args.repoId,
-            number: args.number,
-            updates: args.updates
-          },
-          { timeoutMs: 30_000 }
-        )
-      : await window.api.gh.updateIssue({
-          repoPath: args.repoPath ?? '',
-          repoId: args.repoId ?? undefined,
-          sourceContext: args.sourceContext,
+  const res = runtimeHost
+    ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssue>>>(
+        { kind: 'environment', environmentId: runtimeHost.environmentId },
+        'github.updateIssue',
+        {
+          repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? ''),
           number: args.number,
           updates: args.updates
-        })
+        },
+        { timeoutMs: 30_000 }
+      )
+    : await window.api.gh.updateIssue({
+        repoPath: args.repoPath ?? '',
+        repoId: args.repoId ?? undefined,
+        sourceContext: args.sourceContext,
+        number: args.number,
+        updates: args.updates
+      })
   if (!res.ok) {
     throw new Error(res.error)
   }
-  if (parsedHost?.kind === 'runtime') {
+  if (runtimeHost) {
     notifyWorkItemDetailsMutation(
       {
         repoPath: args.repoPath ?? '',
@@ -5716,36 +5696,32 @@ async function runPullRequestStateUpdate(args: {
     }
     return
   }
-  const parsedHost =
-    args.sourceContext?.provider === 'github'
-      ? parseExecutionHostId(args.sourceContext.hostId)
-      : null
-  if (!args.repoPath && parsedHost?.kind !== 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(args.sourceContext)
+  if (!args.repoPath && !runtimeHost) {
     throw new Error('No repo context available for this pull request.')
   }
-  const res =
-    parsedHost?.kind === 'runtime'
-      ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
-          { kind: 'environment', environmentId: parsedHost.environmentId },
-          'github.updatePRState',
-          {
-            repo: args.sourceContext?.repoId ?? args.repoId,
-            prNumber: args.number,
-            updates: args.updates
-          },
-          { timeoutMs: 30_000 }
-        )
-      : await window.api.gh.updatePRState({
-          repoPath: args.repoPath ?? '',
-          repoId: args.repoId ?? undefined,
-          sourceContext: args.sourceContext,
+  const res = runtimeHost
+    ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updatePRState>>>(
+        { kind: 'environment', environmentId: runtimeHost.environmentId },
+        'github.updatePRState',
+        {
+          repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? ''),
           prNumber: args.number,
           updates: args.updates
-        })
+        },
+        { timeoutMs: 30_000 }
+      )
+    : await window.api.gh.updatePRState({
+        repoPath: args.repoPath ?? '',
+        repoId: args.repoId ?? undefined,
+        sourceContext: args.sourceContext,
+        prNumber: args.number,
+        updates: args.updates
+      })
   if (!res.ok) {
     throw new Error(res.error)
   }
-  if (parsedHost?.kind === 'runtime') {
+  if (runtimeHost) {
     notifyWorkItemDetailsMutation(
       {
         repoPath: args.repoPath ?? '',
@@ -6458,9 +6434,7 @@ export default function PullRequestPage({
     return s.repos.find((r) => (effectiveRepoId ? r.id === effectiveRepoId : r.path === repoPath))
       ?.issueSourcePreference
   })
-  const detailsSourceHost =
-    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
-  const canUseDetailsRepoContext = !!repoPath || detailsSourceHost?.kind === 'runtime'
+  const canUseDetailsRepoContext = canUseGitHubRepoContext(repoPath, sourceContext)
   const detailsCacheKey = useMemo(() => {
     if (!workItem || !effectiveRepoId || !canUseDetailsRepoContext) {
       return null

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -8899,6 +8899,7 @@ export default function TaskPage(): React.JSX.Element {
                 initialTab={dialogInitialTab}
                 repoPath={dialogRepoPath}
                 repoId={dialogWorkItem.repoId}
+                sourceContext={dialogSourceContext}
                 backLabel="Pull requests"
                 onUse={(item) => {
                   setDialogWorkItem(null)

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -36,11 +36,22 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(section).toContain('useRepoAssignees(')
     expect(section).toContain('sourceSettings')
     expect(section).toContain('getActiveRuntimeTarget(sourceSettings)')
+    expect(section).toContain('const runtimeRepo = sourceContext?.repoId ?? item.repoId')
+    expect(section).toContain("'github.requestPRReviewers'")
+    expect(section).toContain("'github.removePRReviewers'")
+    expect(section).toContain('{ repo: runtimeRepo, prNumber: item.number, reviewers: logins }')
+    expect(section).toContain('notifyWorkItemDetailsMutation(')
+    expect(section).toContain('{ local: false }')
   })
 
   it('routes edit metadata through the same task source as issue mutations', () => {
     const source = componentSource('GitHubItemDialog.tsx')
     const section = sourceBetween(source, 'function GHEditSection', 'const hasAttachedWorkspace')
+    const helperSection = sourceBetween(
+      source,
+      'function getGitHubMutationSettings',
+      'function GitHubLabelsSettingsLink'
+    )
 
     expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
     expect(section).toContain('useRepoLabels(')
@@ -48,5 +59,161 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(section).toContain('useRepoAssignees(')
     expect(section).toContain('useRepoAssigneesBySlug(')
     expect(section).toContain('sourceSettings')
+    expect(helperSection).toContain("'github.updateIssue'")
+    expect(helperSection).toContain("'github.updatePRState'")
+    expect(helperSection).toContain("'github.project.updateIssueBySlug'")
+    expect(helperSection).toContain("'github.project.updatePullRequestBySlug'")
+    expect(helperSection).toContain("args.sourceContext?.provider === 'github'")
+    expect(helperSection).toContain('getTaskSourceRuntimeSettings(args.sourceContext)')
+    expect(helperSection).toContain('notifyWorkItemDetailsMutation(')
+    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain('{ local: false }')
+  })
+
+  it('uses source-aware details routing and cache identity', () => {
+    const source = componentSource('GitHubItemDialog.tsx')
+    const cacheKeySection = sourceBetween(
+      source,
+      'function getWorkItemDetailsCacheKey',
+      'function touchWorkItemDetailsCache'
+    )
+    const matchInvalidationSection = sourceBetween(
+      source,
+      'function invalidateWorkItemDetailsCacheByMatch',
+      'function patchCachedPRFileViewedState'
+    )
+
+    expect(source).toContain('lookupGitHubWorkItemDetailsForSource({')
+    expect(source).toContain('sourceContext,')
+    expect(cacheKeySection).toContain('sourceCacheScope')
+    expect(source).toContain('getTaskSourceCacheScope(sourceContext)')
+    expect(matchInvalidationSection).toContain(
+      'if (removed) {\n    workItemDetailsCacheGeneration += 1'
+    )
+  })
+
+  it('treats null details as unavailable while preserving empty detail payloads', () => {
+    const source = componentSource('GitHubItemDialog.tsx')
+    const loadedSection = sourceBetween(
+      source,
+      'const loading = !!cachedEntry?.pending && !cachedEntry?.details',
+      '// Why: if a cross-window mutation invalidates'
+    )
+    const resultSection = sourceBetween(source, 'inflight', '.catch((err) => {')
+
+    expect(loadedSection).toContain('const detailsLoaded = Boolean(cachedEntry?.details)')
+    expect(loadedSection).not.toContain('fetchedAt > 0')
+    expect(resultSection).toContain('} else if (result === null) {')
+    expect(resultSection).toContain('error: WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE')
+    expect(resultSection).toContain('details: result')
+  })
+
+  it('routes PR file viewed mutations through the task source context', () => {
+    const source = componentSource('GitHubItemDialog.tsx')
+    const helperSection = sourceBetween(
+      source,
+      'function setPRFileViewedForRepo',
+      'function PRViewedCheckbox'
+    )
+    const changeSection = sourceBetween(
+      source,
+      'const handlePRFileViewedChange = useCallback',
+      'const isIssuePage = workItem?.type ==='
+    )
+
+    expect(helperSection).toContain('parseExecutionHostId(args.sourceContext.hostId)')
+    expect(helperSection).toContain("'github.setPRFileViewed'")
+    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain('sourceContext: args.sourceContext')
+    expect(helperSection).toContain('{ local: false }')
+    expect(changeSection).toContain('sourceContext,')
+    expect(changeSection).toContain(
+      '[details?.pullRequestId, detailsCacheKey, repoPath, sourceContext, workItem]'
+    )
+  })
+
+  it('routes comment mutations through runtime source context when needed', () => {
+    const source = componentSource('GitHubItemDialog.tsx')
+    const helperSection = sourceBetween(
+      source,
+      'function addIssueCommentForRepo',
+      'function setPRFileViewedForRepo'
+    )
+
+    expect(helperSection).toContain('parseExecutionHostId(args.sourceContext.hostId)')
+    expect(helperSection).toContain("'github.addIssueComment'")
+    expect(helperSection).toContain("'github.addPRReviewComment'")
+    expect(helperSection).toContain("'github.addPRReviewCommentReply'")
+    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain('sourceContext: args.sourceContext')
+    expect(helperSection).toContain('notifyWorkItemDetailsMutation(')
+    expect(helperSection).toContain('{ local: false }')
+  })
+
+  it('routes PR file contents and runtime viewed invalidations through the task source context', () => {
+    const source = componentSource('GitHubItemDialog.tsx')
+    const fileContentsSection = sourceBetween(
+      source,
+      'function loadPRFileContents',
+      'function setPRFileViewedForRepo'
+    )
+    const fileContentsCacheKeySection = sourceBetween(
+      source,
+      'function getPRFileContentCacheKey',
+      'function loadPRFileContents'
+    )
+    const listenerSection = sourceBetween(source, 'let workItemMutatedUnsub', '// Why: bounded LRU')
+
+    expect(fileContentsCacheKeySection).toContain(
+      'source:${getTaskSourceCacheScope(args.sourceContext)}'
+    )
+    expect(fileContentsSection).toContain("'github.prFileContents'")
+    expect(fileContentsSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(fileContentsSection).toContain('sourceContext: args.sourceContext')
+    expect(fileContentsSection).toContain('sourceContext,')
+    expect(listenerSection).toContain('onGitHubWorkItemDetailsCacheMutation')
+    expect(source).toContain('emitGitHubWorkItemDetailsCacheMutation(args)')
+    expect(source).toContain('options.local !== false')
+    expect(source).toContain('notifyWorkItemMutated({')
+  })
+
+  it('routes merge actions through the task source context', () => {
+    const source = componentSource('GitHubItemDialog.tsx')
+    const actionsSection = sourceBetween(
+      source,
+      'function PRActionsPanel',
+      'function CommentReactions'
+    )
+
+    expect(actionsSection).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(actionsSection).toContain('getActiveRuntimeTarget(sourceSettings)')
+    expect(actionsSection).toContain(
+      'const canMergeWithRepoContext = !!repoPath || mergeTarget.kind ==='
+    )
+    expect(actionsSection).toContain("'github.mergePR'")
+    expect(actionsSection).toContain("'github.setPRAutoMerge'")
+    expect(actionsSection).toContain('repo: sourceContext?.repoId ?? repoId ?? item.repoId')
+    expect(actionsSection).toContain('sourceContext,')
+    expect(actionsSection).toContain('notifyWorkItemDetailsMutation(')
+    expect(actionsSection).toContain('{ local: false }')
+  })
+
+  it('routes check actions through the task source context', () => {
+    const source = componentSource('GitHubItemDialog.tsx')
+    const checksSection = sourceBetween(
+      source,
+      'function ChecksTab',
+      'function getGitHubMutationSettings'
+    )
+
+    expect(checksSection).toContain('sourceContext?: TaskSourceContext | null')
+    expect(checksSection).toContain('sourceContext,')
+    expect(checksSection).toContain("'github.prChecks'")
+    expect(checksSection).toContain("'github.rerunPRChecks'")
+    expect(checksSection).toContain("'github.prCheckDetails'")
+    expect(checksSection).toContain('repo: sourceContext?.repoId ?? repoId ?? item.repoId')
+    expect(checksSection).toContain('window.api.gh.prChecks({')
+    expect(checksSection).toContain('window.api.gh.rerunPRChecks({')
+    expect(checksSection).toContain('prCheckDetails({')
   })
 })

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -36,7 +36,9 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(section).toContain('useRepoAssignees(')
     expect(section).toContain('sourceSettings')
     expect(section).toContain('getActiveRuntimeTarget(sourceSettings)')
-    expect(section).toContain('const runtimeRepo = sourceContext?.repoId ?? item.repoId')
+    expect(section).toContain(
+      'const runtimeRepo = getGitHubRuntimeRepoId(sourceContext, item.repoId)'
+    )
     expect(section).toContain("'github.requestPRReviewers'")
     expect(section).toContain("'github.removePRReviewers'")
     expect(section).toContain('{ repo: runtimeRepo, prNumber: item.number, reviewers: logins }')
@@ -66,7 +68,9 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(helperSection).toContain("args.sourceContext?.provider === 'github'")
     expect(helperSection).toContain('getTaskSourceRuntimeSettings(args.sourceContext)')
     expect(helperSection).toContain('notifyWorkItemDetailsMutation(')
-    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain(
+      "repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? '')"
+    )
     expect(helperSection).toContain('{ local: false }')
   })
 
@@ -121,9 +125,9 @@ describe('GitHubItemDialog source host boundaries', () => {
       'const isIssuePage = workItem?.type ==='
     )
 
-    expect(helperSection).toContain('parseExecutionHostId(args.sourceContext.hostId)')
+    expect(helperSection).toContain('getGitHubSourceRuntimeHost(args.sourceContext)')
     expect(helperSection).toContain("'github.setPRFileViewed'")
-    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain('repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId)')
     expect(helperSection).toContain('sourceContext: args.sourceContext')
     expect(helperSection).toContain('{ local: false }')
     expect(changeSection).toContain('canUseDetailsRepoContext')
@@ -139,11 +143,11 @@ describe('GitHubItemDialog source host boundaries', () => {
       'function setPRFileViewedForRepo'
     )
 
-    expect(helperSection).toContain('parseExecutionHostId(args.sourceContext.hostId)')
+    expect(helperSection).toContain('getGitHubSourceRuntimeHost(args.sourceContext)')
     expect(helperSection).toContain("'github.addIssueComment'")
     expect(helperSection).toContain("'github.addPRReviewComment'")
     expect(helperSection).toContain("'github.addPRReviewCommentReply'")
-    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain('repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId)')
     expect(helperSection).toContain('sourceContext: args.sourceContext')
     expect(helperSection).toContain('notifyWorkItemDetailsMutation(')
     expect(helperSection).toContain('{ local: false }')
@@ -167,7 +171,9 @@ describe('GitHubItemDialog source host boundaries', () => {
       'source:${getTaskSourceCacheScope(args.sourceContext)}'
     )
     expect(fileContentsSection).toContain("'github.prFileContents'")
-    expect(fileContentsSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(fileContentsSection).toContain(
+      'repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId)'
+    )
     expect(fileContentsSection).toContain('sourceContext: args.sourceContext')
     expect(fileContentsSection).toContain('sourceContext,')
     expect(listenerSection).toContain('onGitHubWorkItemDetailsCacheMutation')
@@ -191,7 +197,9 @@ describe('GitHubItemDialog source host boundaries', () => {
     )
     expect(actionsSection).toContain("'github.mergePR'")
     expect(actionsSection).toContain("'github.setPRAutoMerge'")
-    expect(actionsSection).toContain('repo: sourceContext?.repoId ?? repoId ?? item.repoId')
+    expect(actionsSection).toContain(
+      'repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId)'
+    )
     expect(actionsSection).toContain('sourceContext,')
     expect(actionsSection).toContain('notifyWorkItemDetailsMutation(')
     expect(actionsSection).toContain('{ local: false }')
@@ -210,7 +218,9 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(checksSection).toContain("'github.prChecks'")
     expect(checksSection).toContain("'github.rerunPRChecks'")
     expect(checksSection).toContain("'github.prCheckDetails'")
-    expect(checksSection).toContain('repo: sourceContext?.repoId ?? repoId ?? item.repoId')
+    expect(checksSection).toContain(
+      'repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId)'
+    )
     expect(checksSection).toContain('window.api.gh.prChecks({')
     expect(checksSection).toContain('window.api.gh.rerunPRChecks({')
     expect(checksSection).toContain('prCheckDetails({')

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -126,10 +126,9 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
     expect(helperSection).toContain('sourceContext: args.sourceContext')
     expect(helperSection).toContain('{ local: false }')
+    expect(changeSection).toContain('canUseDetailsRepoContext')
+    expect(changeSection).toContain('repoPath: repoPath ??')
     expect(changeSection).toContain('sourceContext,')
-    expect(changeSection).toContain(
-      '[details?.pullRequestId, detailsCacheKey, repoPath, sourceContext, workItem]'
-    )
   })
 
   it('routes comment mutations through runtime source context when needed', () => {

--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -62,6 +62,7 @@ import {
   type CachedVisibleProjectTable
 } from './project-visible-table-cache'
 import { translate } from '@/i18n/i18n'
+import { buildTaskSourceContextFromRepo } from '../../../../shared/task-source-context'
 
 type Props = {
   selectedRepoIds: ReadonlySet<string>
@@ -426,6 +427,16 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
     // Orca; clear them before the modal tree receives stale repo ids.
     setDialogRepoItem(resolvedDialogRepoItem)
   }
+  const resolvedDialogRepo = resolvedDialogRepoItem
+    ? (repos.find((repo) => repo.id === resolvedDialogRepoItem.repoId) ?? null)
+    : null
+  const resolvedDialogSourceContext = resolvedDialogRepo
+    ? buildTaskSourceContextFromRepo({
+        provider: 'github',
+        projectId: resolvedDialogRepo.id,
+        repo: resolvedDialogRepo
+      })
+    : null
 
   const resolvedMissingRepoDialogs = resolveMissingRepoProjectDialogState({
     slugIndexReady,
@@ -923,6 +934,7 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
           workItem={resolvedDialogRepoItem.workItem}
           repoPath={resolvedDialogRepoItem.repoPath}
           repoId={resolvedDialogRepoItem.repoId}
+          sourceContext={resolvedDialogSourceContext}
           projectOrigin={resolvedDialogRepoItem.origin}
           backLabel={translate(
             'auto.components.github.project.ProjectViewWrapper.1aa7c952b9',

--- a/src/renderer/src/components/github-project/project-view-wrapper-source-context-boundary.test.ts
+++ b/src/renderer/src/components/github-project/project-view-wrapper-source-context-boundary.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const COMPONENT_ROOT = __dirname
+
+function componentSource(relativePath: string): string {
+  return readFileSync(join(COMPONENT_ROOT, relativePath), 'utf8')
+}
+
+function sourceBetween(source: string, startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('ProjectViewWrapper GitHub source context boundary', () => {
+  it('passes the matched repo source context into the repo-backed GitHub dialog', () => {
+    const source = componentSource('ProjectViewWrapper.tsx')
+    const contextSection = sourceBetween(
+      source,
+      'const resolvedDialogRepo = resolvedDialogRepoItem',
+      'const resolvedMissingRepoDialogs'
+    )
+    const dialogSection = sourceBetween(source, '<GitHubItemDialog', 'onUse={(item) => {')
+
+    expect(source).toContain('buildTaskSourceContextFromRepo')
+    expect(contextSection).toContain("provider: 'github'")
+    expect(contextSection).toContain('repo: resolvedDialogRepo')
+    expect(dialogSection).toContain('sourceContext={resolvedDialogSourceContext}')
+  })
+})

--- a/src/renderer/src/components/pull-request-page-host-boundary.test.ts
+++ b/src/renderer/src/components/pull-request-page-host-boundary.test.ts
@@ -21,12 +21,22 @@ describe('PullRequestPage host boundaries', () => {
     const source = componentSource('PullRequestPage.tsx')
     const section = sourceBetween(source, 'function PRReviewersPanel', 'function isPRFileViewed')
 
-    expect(section).toContain('getSettingsForRepoRuntimeOwner(s, item.repoId ?? null)')
+    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
     expect(section).toContain('useRepoAssigneesBySlug(')
-    expect(section).toContain('repoOwnerSettings')
+    expect(section).toContain('sourceSettings')
     expect(section).toContain('useRepoAssignees(')
-    expect(section).toContain('repoOwnerSettings')
-    expect(section).toContain('getActiveRuntimeTarget(repoOwnerSettings)')
+    expect(section).toContain('sourceSettings')
+    expect(section).toContain('getActiveRuntimeTarget(sourceSettings)')
+    expect(section).toContain('sourceContext,')
+    expect(section).toContain(
+      'patchWorkItem(item.id, { reviewRequests: nextReviewRequests }, item.repoId, {'
+    )
+    expect(section).toContain('const runtimeRepo = sourceContext?.repoId ?? item.repoId')
+    expect(section).toContain("'github.requestPRReviewers'")
+    expect(section).toContain("'github.removePRReviewers'")
+    expect(section).toContain('{ repo: runtimeRepo, prNumber: item.number, reviewers: logins }')
+    expect(section).toContain('notifyWorkItemDetailsMutation(')
+    expect(section).toContain('{ local: false }')
   })
 
   it('routes PR edit metadata through the same repo owner host as mutations', () => {
@@ -34,11 +44,44 @@ describe('PullRequestPage host boundaries', () => {
     const section = sourceBetween(source, 'function GHEditSection', 'function GHCommentComposer')
 
     expect(section).toContain('getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null)')
+    expect(section).toContain('getTaskSourceRuntimeSettings(sourceContext)')
     expect(section).toContain('useRepoLabels(')
-    expect(section).toContain('useRepoLabelsBySlug(slugOwner, slugRepo, repoOwnerSettings)')
+    expect(section).toContain('useRepoLabelsBySlug(slugOwner, slugRepo, sourceSettings)')
     expect(section).toContain('useRepoAssignees(')
     expect(section).toContain('useRepoAssigneesBySlug(')
-    expect(section).toContain('repoOwnerSettings')
+    expect(section).toContain('sourceSettings')
+  })
+
+  it('source-scopes full-page optimistic work item patches', () => {
+    const source = componentSource('PullRequestPage.tsx')
+    const prAssigneesSection = sourceBetween(
+      source,
+      'function PRAssigneesPanel',
+      'function PRReviewersPanel'
+    )
+    const prActionsSection = sourceBetween(
+      source,
+      'function PRActionsPanel',
+      'function CommentReactions'
+    )
+    const issueEditSection = sourceBetween(
+      source,
+      'function GHEditSection',
+      'function GHCommentComposer'
+    )
+
+    expect(prAssigneesSection).toContain(
+      'patchWorkItem(item.id, { assignees: nextAssignees }, item.repoId, { sourceContext })'
+    )
+    expect(prActionsSection).toContain(
+      'patchWorkItem(item.id, { state }, item.repoId, { sourceContext })'
+    )
+    expect(issueEditSection).toContain(
+      'patchWorkItem(item.id, { state: newState }, item.repoId, { sourceContext })'
+    )
+    expect(issueEditSection).toContain(
+      'patchWorkItem(item.id, { labels: newLabels }, item.repoId, { sourceContext })'
+    )
   })
 
   it('routes PR mention metadata through the PR repo owner host', () => {
@@ -46,6 +89,206 @@ describe('PullRequestPage host boundaries', () => {
     const section = sourceBetween(source, 'function ConversationTab', 'const mentionOptions')
 
     expect(section).toContain('getSettingsForRepoRuntimeOwner(s, item.repoId ?? repoId ?? null)')
-    expect(section).toContain('useRepoAssignees(repoPath, item.repoId, repoOwnerSettings)')
+    expect(section).toContain('useRepoAssignees(repoPath, item.repoId, sourceSettings)')
+  })
+
+  it('uses source-aware initial details routing and cache identity', () => {
+    const source = componentSource('PullRequestPage.tsx')
+    const propsSection = sourceBetween(
+      source,
+      'type PullRequestPageProps',
+      'function formatRelativeTime'
+    )
+    const cacheKeySection = sourceBetween(
+      source,
+      'function getWorkItemDetailsCacheKey',
+      'function touchWorkItemDetailsCache'
+    )
+    const matchInvalidationSection = sourceBetween(
+      source,
+      'function invalidateWorkItemDetailsCacheByMatch',
+      'function patchCachedPRFileViewedState'
+    )
+
+    expect(propsSection).toContain('sourceContext?: TaskSourceContext | null')
+    expect(source).toContain('lookupGitHubWorkItemDetailsForSource({')
+    expect(source).toContain('sourceContext,')
+    expect(cacheKeySection).toContain('sourceCacheScope')
+    expect(source).toContain('getTaskSourceCacheScope(sourceContext)')
+    expect(matchInvalidationSection).toContain(
+      'if (removed) {\n    workItemDetailsCacheGeneration += 1'
+    )
+  })
+
+  it('treats null details as unavailable while preserving empty detail payloads', () => {
+    const source = componentSource('PullRequestPage.tsx')
+    const loadedSection = sourceBetween(
+      source,
+      'const loading = !!cachedEntry?.pending && !cachedEntry?.details',
+      '// Why: if a cross-window mutation invalidates'
+    )
+    const resultSection = sourceBetween(source, 'inflight', '.catch((err) => {')
+
+    expect(loadedSection).toContain('const detailsLoaded = Boolean(cachedEntry?.details)')
+    expect(loadedSection).not.toContain('fetchedAt > 0')
+    expect(resultSection).toContain('} else if (result === null) {')
+    expect(resultSection).toContain('error: WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE')
+    expect(resultSection).toContain('details: result')
+  })
+
+  it('routes file viewed mutations through the PR source context', () => {
+    const source = componentSource('PullRequestPage.tsx')
+    const helperSection = sourceBetween(
+      source,
+      'function setPRFileViewedForRepo',
+      'function PRViewedCheckbox'
+    )
+    const changeSection = sourceBetween(
+      source,
+      'const handlePRFileViewedChange = useCallback',
+      'const ownerRepo = parseOwnerRepoFromItemUrl'
+    )
+
+    expect(helperSection).toContain('parseExecutionHostId(args.sourceContext.hostId)')
+    expect(helperSection).toContain("'github.setPRFileViewed'")
+    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain('sourceContext: args.sourceContext')
+    expect(helperSection).toContain('{ local: false }')
+    expect(changeSection).toContain('sourceContext,')
+    expect(changeSection).toContain(
+      '[details?.pullRequestId, detailsCacheKey, repoPath, sourceContext, workItem]'
+    )
+  })
+
+  it('routes comment mutations through runtime source context when needed', () => {
+    const source = componentSource('PullRequestPage.tsx')
+    const helperSection = sourceBetween(
+      source,
+      'function addIssueCommentForRepo',
+      'function setPRFileViewedForRepo'
+    )
+    const fileCommentSection = sourceBetween(
+      source,
+      'const handleAddLineComment = useCallback',
+      'const renderViewedCheckbox = useCallback'
+    )
+    const conversationSection = sourceBetween(
+      source,
+      'const handleReply = useCallback',
+      'const rightPanel ='
+    )
+    const composerSection = sourceBetween(
+      source,
+      'const handleSubmit = useCallback',
+      'const canSubmitComment ='
+    )
+
+    expect(helperSection).toContain('parseExecutionHostId(args.sourceContext.hostId)')
+    expect(helperSection).toContain("'github.addIssueComment'")
+    expect(helperSection).toContain("'github.addPRReviewComment'")
+    expect(helperSection).toContain("'github.addPRReviewCommentReply'")
+    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain('sourceContext: args.sourceContext')
+    expect(helperSection).toContain('notifyWorkItemDetailsMutation(')
+    expect(helperSection).toContain('{ local: false }')
+    expect(fileCommentSection).toContain('sourceContext,')
+    expect(conversationSection).toContain('sourceContext,')
+    expect(composerSection).toContain('sourceContext,')
+  })
+
+  it('routes PR file contents and runtime viewed invalidations through the PR source context', () => {
+    const source = componentSource('PullRequestPage.tsx')
+    const fileContentsSection = sourceBetween(
+      source,
+      'function loadPRFileContents',
+      'function setPRFileViewedForRepo'
+    )
+    const fileContentsCacheKeySection = sourceBetween(
+      source,
+      'function getPRFileContentCacheKey',
+      'function loadPRFileContents'
+    )
+    const listenerSection = sourceBetween(source, 'let workItemMutatedUnsub', '// Why: bounded LRU')
+    const commentContextSection = sourceBetween(
+      source,
+      'function CommentCodeContext',
+      'const resolvedContextExpansionState'
+    )
+
+    expect(fileContentsCacheKeySection).toContain(
+      'source:${getTaskSourceCacheScope(args.sourceContext)}'
+    )
+    expect(fileContentsSection).toContain("'github.prFileContents'")
+    expect(fileContentsSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(fileContentsSection).toContain('sourceContext: args.sourceContext')
+    expect(fileContentsSection).toContain('sourceContext,')
+    expect(listenerSection).toContain('onGitHubWorkItemDetailsCacheMutation')
+    expect(source).toContain('emitGitHubWorkItemDetailsCacheMutation(args)')
+    expect(source).toContain('options.local !== false')
+    expect(source).toContain('notifyWorkItemMutated({')
+    expect(commentContextSection).toContain('sourceContext?: TaskSourceContext | null')
+    expect(commentContextSection).toContain('sourceContext, prNumber')
+  })
+
+  it('routes check actions through the PR source context', () => {
+    const source = componentSource('PullRequestPage.tsx')
+    const checksSection = sourceBetween(source, 'function ChecksTab', 'function MentionTextarea')
+
+    expect(checksSection).toContain('sourceContext?: TaskSourceContext | null')
+    expect(checksSection).toContain('sourceContext,')
+    expect(checksSection).toContain("'github.prChecks'")
+    expect(checksSection).toContain("'github.rerunPRChecks'")
+    expect(checksSection).toContain("'github.prCheckDetails'")
+    expect(checksSection).toContain('repo: sourceContext?.repoId ?? repoId ?? item.repoId')
+    expect(checksSection).toContain('window.api.gh.prChecks({')
+    expect(checksSection).toContain('window.api.gh.rerunPRChecks({')
+    expect(checksSection).toContain('prCheckDetails({')
+  })
+
+  it('routes edit metadata and mutations through the PR source context', () => {
+    const source = componentSource('PullRequestPage.tsx')
+    const editHelperSection = sourceBetween(
+      source,
+      'function getGitHubMutationSettings',
+      'function GHCommentComposer'
+    )
+    const editSection = sourceBetween(
+      source,
+      'function GHEditSection',
+      'function GHCommentComposer'
+    )
+
+    expect(editHelperSection).toContain("'github.updateIssue'")
+    expect(editHelperSection).toContain("'github.updatePRState'")
+    expect(editHelperSection).toContain("'github.project.updateIssueBySlug'")
+    expect(editHelperSection).toContain("'github.project.updatePullRequestBySlug'")
+    expect(editHelperSection).toContain('sourceContext?: TaskSourceContext | null')
+    expect(editHelperSection).toContain("args.sourceContext?.provider === 'github'")
+    expect(editHelperSection).toContain('getTaskSourceRuntimeSettings(args.sourceContext)')
+    expect(editHelperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(editHelperSection).toContain('{ local: false }')
+    expect(editSection).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(editSection).toContain('sourceContext,')
+  })
+
+  it('routes merge actions through the PR source context', () => {
+    const source = componentSource('PullRequestPage.tsx')
+    const actionsSection = sourceBetween(
+      source,
+      'function PRActionsPanel',
+      'function CommentReactions'
+    )
+
+    expect(actionsSection).toContain('getTaskSourceRuntimeSettings(sourceContext)')
+    expect(actionsSection).toContain('getActiveRuntimeTarget(sourceSettings)')
+    expect(actionsSection).toContain(
+      'const canMergeWithRepoContext = !!repoPath || mergeTarget.kind ==='
+    )
+    expect(actionsSection).toContain("'github.mergePR'")
+    expect(actionsSection).toContain("'github.setPRAutoMerge'")
+    expect(actionsSection).toContain('repo: sourceContext?.repoId ?? repoId ?? item.repoId')
+    expect(actionsSection).toContain('sourceContext,')
+    expect(actionsSection).toContain('notifyWorkItemDetailsMutation(')
+    expect(actionsSection).toContain('{ local: false }')
   })
 })

--- a/src/renderer/src/components/pull-request-page-host-boundary.test.ts
+++ b/src/renderer/src/components/pull-request-page-host-boundary.test.ts
@@ -31,7 +31,9 @@ describe('PullRequestPage host boundaries', () => {
     expect(section).toContain(
       'patchWorkItem(item.id, { reviewRequests: nextReviewRequests }, item.repoId, {'
     )
-    expect(section).toContain('const runtimeRepo = sourceContext?.repoId ?? item.repoId')
+    expect(section).toContain(
+      'const runtimeRepo = getGitHubRuntimeRepoId(sourceContext, item.repoId)'
+    )
     expect(section).toContain("'github.requestPRReviewers'")
     expect(section).toContain("'github.removePRReviewers'")
     expect(section).toContain('{ repo: runtimeRepo, prNumber: item.number, reviewers: logins }')
@@ -149,9 +151,9 @@ describe('PullRequestPage host boundaries', () => {
       'const ownerRepo = parseOwnerRepoFromItemUrl'
     )
 
-    expect(helperSection).toContain('parseExecutionHostId(args.sourceContext.hostId)')
+    expect(helperSection).toContain('getGitHubSourceRuntimeHost(args.sourceContext)')
     expect(helperSection).toContain("'github.setPRFileViewed'")
-    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain('repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId)')
     expect(helperSection).toContain('sourceContext: args.sourceContext')
     expect(helperSection).toContain('{ local: false }')
     expect(changeSection).toContain('canUseDetailsRepoContext')
@@ -182,11 +184,11 @@ describe('PullRequestPage host boundaries', () => {
       'const canSubmitComment ='
     )
 
-    expect(helperSection).toContain('parseExecutionHostId(args.sourceContext.hostId)')
+    expect(helperSection).toContain('getGitHubSourceRuntimeHost(args.sourceContext)')
     expect(helperSection).toContain("'github.addIssueComment'")
     expect(helperSection).toContain("'github.addPRReviewComment'")
     expect(helperSection).toContain("'github.addPRReviewCommentReply'")
-    expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(helperSection).toContain('repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId)')
     expect(helperSection).toContain('sourceContext: args.sourceContext')
     expect(helperSection).toContain('notifyWorkItemDetailsMutation(')
     expect(helperSection).toContain('{ local: false }')
@@ -218,7 +220,9 @@ describe('PullRequestPage host boundaries', () => {
       'source:${getTaskSourceCacheScope(args.sourceContext)}'
     )
     expect(fileContentsSection).toContain("'github.prFileContents'")
-    expect(fileContentsSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(fileContentsSection).toContain(
+      'repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId)'
+    )
     expect(fileContentsSection).toContain('sourceContext: args.sourceContext')
     expect(fileContentsSection).toContain('sourceContext,')
     expect(listenerSection).toContain('onGitHubWorkItemDetailsCacheMutation')
@@ -238,7 +242,9 @@ describe('PullRequestPage host boundaries', () => {
     expect(checksSection).toContain("'github.prChecks'")
     expect(checksSection).toContain("'github.rerunPRChecks'")
     expect(checksSection).toContain("'github.prCheckDetails'")
-    expect(checksSection).toContain('repo: sourceContext?.repoId ?? repoId ?? item.repoId')
+    expect(checksSection).toContain(
+      'repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId)'
+    )
     expect(checksSection).toContain('window.api.gh.prChecks({')
     expect(checksSection).toContain('window.api.gh.rerunPRChecks({')
     expect(checksSection).toContain('prCheckDetails({')
@@ -264,7 +270,9 @@ describe('PullRequestPage host boundaries', () => {
     expect(editHelperSection).toContain('sourceContext?: TaskSourceContext | null')
     expect(editHelperSection).toContain("args.sourceContext?.provider === 'github'")
     expect(editHelperSection).toContain('getTaskSourceRuntimeSettings(args.sourceContext)')
-    expect(editHelperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
+    expect(editHelperSection).toContain(
+      "repo: getGitHubRuntimeRepoId(args.sourceContext, args.repoId ?? '')"
+    )
     expect(editHelperSection).toContain('{ local: false }')
     expect(editSection).toContain('getTaskSourceRuntimeSettings(sourceContext)')
     expect(editSection).toContain('sourceContext,')
@@ -285,7 +293,9 @@ describe('PullRequestPage host boundaries', () => {
     )
     expect(actionsSection).toContain("'github.mergePR'")
     expect(actionsSection).toContain("'github.setPRAutoMerge'")
-    expect(actionsSection).toContain('repo: sourceContext?.repoId ?? repoId ?? item.repoId')
+    expect(actionsSection).toContain(
+      'repo: getGitHubRuntimeRepoId(sourceContext, repoId ?? item.repoId)'
+    )
     expect(actionsSection).toContain('sourceContext,')
     expect(actionsSection).toContain('notifyWorkItemDetailsMutation(')
     expect(actionsSection).toContain('{ local: false }')

--- a/src/renderer/src/components/pull-request-page-host-boundary.test.ts
+++ b/src/renderer/src/components/pull-request-page-host-boundary.test.ts
@@ -154,10 +154,9 @@ describe('PullRequestPage host boundaries', () => {
     expect(helperSection).toContain('repo: args.sourceContext?.repoId ?? args.repoId')
     expect(helperSection).toContain('sourceContext: args.sourceContext')
     expect(helperSection).toContain('{ local: false }')
+    expect(changeSection).toContain('canUseDetailsRepoContext')
+    expect(changeSection).toContain('repoPath: repoPath ??')
     expect(changeSection).toContain('sourceContext,')
-    expect(changeSection).toContain(
-      '[details?.pullRequestId, detailsCacheKey, repoPath, sourceContext, workItem]'
-    )
   })
 
   it('routes comment mutations through runtime source context when needed', () => {

--- a/src/renderer/src/components/task-page-source-switch-boundary.test.ts
+++ b/src/renderer/src/components/task-page-source-switch-boundary.test.ts
@@ -27,6 +27,8 @@ describe('TaskPage source switching host boundary', () => {
 
     expect(modalSection).toContain('selectedRepoIds={repoSelection}')
     expect(detailSection).toContain('workItem={dialogWorkItem}')
+    expect(detailSection).toContain('<PullRequestPage')
+    expect(detailSection).toContain('sourceContext={dialogSourceContext}')
     expect(detailSection).toContain('<GitHubItemDialog')
     expect(detailSection).toContain('sourceContext={dialogSourceContext}')
     expect(modalSection).not.toContain('<GitHubItemDialog')

--- a/src/renderer/src/lib/github-source-runtime-context.test.ts
+++ b/src/renderer/src/lib/github-source-runtime-context.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import {
+  canUseGitHubRepoContext,
+  getGitHubRuntimeRepoId,
+  getGitHubSourceRuntimeHost,
+  getGitHubSourceRuntimeTarget
+} from './github-source-runtime-context'
+
+const runtimeSourceContext: TaskSourceContext = {
+  kind: 'task-source',
+  provider: 'github',
+  projectId: 'project-1',
+  hostId: 'runtime:env-1',
+  repoId: 'runtime-repo'
+}
+
+describe('GitHub source runtime context', () => {
+  it('detects runtime-owned GitHub sources', () => {
+    expect(getGitHubSourceRuntimeHost(runtimeSourceContext)).toEqual({
+      kind: 'runtime',
+      id: 'runtime:env-1',
+      environmentId: 'env-1'
+    })
+    expect(getGitHubSourceRuntimeTarget(runtimeSourceContext)).toEqual({
+      kind: 'environment',
+      environmentId: 'env-1'
+    })
+  })
+
+  it('does not treat non-runtime or non-GitHub sources as runtime GitHub sources', () => {
+    expect(getGitHubSourceRuntimeHost({ ...runtimeSourceContext, hostId: 'local' })).toBeNull()
+    expect(getGitHubSourceRuntimeHost({ ...runtimeSourceContext, provider: 'gitlab' })).toBeNull()
+    expect(getGitHubSourceRuntimeTarget({ ...runtimeSourceContext, provider: 'gitlab' })).toEqual({
+      kind: 'local'
+    })
+  })
+
+  it('allows a repo context from either a local path or runtime source', () => {
+    expect(canUseGitHubRepoContext('', runtimeSourceContext)).toBe(true)
+    expect(canUseGitHubRepoContext('C:\\workspace\\repo', null)).toBe(true)
+    expect(canUseGitHubRepoContext('', { ...runtimeSourceContext, hostId: 'local' })).toBe(false)
+  })
+
+  it('uses the source repo id for GitHub runtime calls when available', () => {
+    expect(getGitHubRuntimeRepoId(runtimeSourceContext, 'fallback-repo')).toBe('runtime-repo')
+    expect(getGitHubRuntimeRepoId({ ...runtimeSourceContext, repoId: null }, 'fallback-repo')).toBe(
+      'fallback-repo'
+    )
+    expect(
+      getGitHubRuntimeRepoId({ ...runtimeSourceContext, provider: 'gitlab' }, 'fallback')
+    ).toBe('fallback')
+  })
+})

--- a/src/renderer/src/lib/github-source-runtime-context.ts
+++ b/src/renderer/src/lib/github-source-runtime-context.ts
@@ -1,0 +1,49 @@
+import type { ParsedExecutionHost } from '../../../shared/execution-host'
+import { parseExecutionHostId } from '../../../shared/execution-host'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import { getTaskSourceRuntimeSettings } from '../../../shared/task-source-context'
+import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+
+export type GitHubRuntimeHost = Extract<ParsedExecutionHost, { kind: 'runtime' }>
+
+export function getGitHubSourceRuntimeHost(
+  sourceContext: TaskSourceContext | null | undefined
+): GitHubRuntimeHost | null {
+  if (sourceContext?.provider !== 'github') {
+    return null
+  }
+  const parsedHost = parseExecutionHostId(sourceContext.hostId)
+  return parsedHost?.kind === 'runtime' ? parsedHost : null
+}
+
+export function getGitHubSourceRuntimeTarget(
+  sourceContext: TaskSourceContext | null | undefined
+): RuntimeClientTarget {
+  return getActiveRuntimeTarget(
+    getTaskSourceRuntimeSettings(sourceContext?.provider === 'github' ? sourceContext : null)
+  )
+}
+
+export function canUseGitHubRepoContext(
+  repoPath: string | null | undefined,
+  sourceContext: TaskSourceContext | null | undefined
+): boolean {
+  return Boolean(repoPath) || getGitHubSourceRuntimeHost(sourceContext) !== null
+}
+
+export function getGitHubRuntimeRepoId(
+  sourceContext: TaskSourceContext | null | undefined,
+  fallbackRepoId: string
+): string
+export function getGitHubRuntimeRepoId(
+  sourceContext: TaskSourceContext | null | undefined,
+  fallbackRepoId: string | null | undefined
+): string | undefined
+export function getGitHubRuntimeRepoId(
+  sourceContext: TaskSourceContext | null | undefined,
+  fallbackRepoId: string | null | undefined
+): string | undefined {
+  const fallback = fallbackRepoId ?? undefined
+  return sourceContext?.provider === 'github' ? (sourceContext.repoId ?? fallback) : fallback
+}

--- a/src/renderer/src/lib/github-work-item-details-cache-events.ts
+++ b/src/renderer/src/lib/github-work-item-details-cache-events.ts
@@ -1,0 +1,32 @@
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+
+export type GitHubWorkItemDetailsCacheMutation = {
+  repoPath: string
+  repoId?: string
+  sourceContext?: TaskSourceContext | null
+  type: 'issue' | 'pr'
+  number: number
+}
+
+const GITHUB_WORK_ITEM_DETAILS_CACHE_MUTATED_EVENT = 'orca:github-work-item-details-cache-mutated'
+
+export function emitGitHubWorkItemDetailsCacheMutation(
+  payload: GitHubWorkItemDetailsCacheMutation
+): void {
+  window.dispatchEvent(
+    new CustomEvent<GitHubWorkItemDetailsCacheMutation>(
+      GITHUB_WORK_ITEM_DETAILS_CACHE_MUTATED_EVENT,
+      { detail: payload }
+    )
+  )
+}
+
+export function onGitHubWorkItemDetailsCacheMutation(
+  listener: (payload: GitHubWorkItemDetailsCacheMutation) => void
+): () => void {
+  const handler = (event: Event): void => {
+    listener((event as CustomEvent<GitHubWorkItemDetailsCacheMutation>).detail)
+  }
+  window.addEventListener(GITHUB_WORK_ITEM_DETAILS_CACHE_MUTATED_EVENT, handler)
+  return () => window.removeEventListener(GITHUB_WORK_ITEM_DETAILS_CACHE_MUTATED_EVENT, handler)
+}

--- a/src/renderer/src/lib/github-work-item-source-lookup.test.ts
+++ b/src/renderer/src/lib/github-work-item-source-lookup.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import type * as RuntimeRpcClient from '@/runtime/runtime-rpc-client'
+import { lookupGitHubWorkItemDetailsForSource } from './github-work-item-source-lookup'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+
+vi.mock('@/runtime/runtime-rpc-client', async () => {
+  const actual = await vi.importActual<typeof RuntimeRpcClient>('@/runtime/runtime-rpc-client')
+  return {
+    ...actual,
+    callRuntimeRpc: vi.fn()
+  }
+})
+
+const runtimeSourceContext: TaskSourceContext = {
+  kind: 'task-source',
+  provider: 'github',
+  projectId: 'project-1',
+  hostId: 'runtime:env-1',
+  repoId: 'runtime-repo'
+}
+
+describe('GitHub source lookup routing', () => {
+  beforeEach(() => {
+    vi.mocked(callRuntimeRpc).mockReset()
+    vi.stubGlobal('window', {
+      api: {
+        gh: {
+          workItemDetails: vi.fn()
+        }
+      }
+    })
+  })
+
+  it('routes runtime-owned GitHub details through runtime RPC', async () => {
+    vi.mocked(callRuntimeRpc).mockResolvedValue(null)
+
+    await expect(
+      lookupGitHubWorkItemDetailsForSource({
+        repoPath: '/home/runtime/app',
+        repoId: 'renderer-repo',
+        sourceContext: runtimeSourceContext,
+        number: 42,
+        type: 'issue'
+      })
+    ).resolves.toBeNull()
+
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'github.workItemDetails',
+      { repo: 'runtime-repo', number: 42, type: 'issue' },
+      { timeoutMs: 30_000 }
+    )
+    expect(window.api.gh.workItemDetails).not.toHaveBeenCalled()
+  })
+
+  it('uses the renderer repo id for runtime details when the source has no repo id', async () => {
+    vi.mocked(callRuntimeRpc).mockResolvedValue(null)
+
+    await lookupGitHubWorkItemDetailsForSource({
+      repoPath: '/home/runtime/app',
+      repoId: 'renderer-repo',
+      sourceContext: { ...runtimeSourceContext, repoId: null },
+      number: 42,
+      type: 'pr'
+    })
+
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'github.workItemDetails',
+      { repo: 'renderer-repo', number: 42, type: 'pr' },
+      { timeoutMs: 30_000 }
+    )
+  })
+
+  it('keeps local GitHub details on Electron IPC with source context', async () => {
+    vi.mocked(window.api.gh.workItemDetails).mockResolvedValue(null)
+    const sourceContext: TaskSourceContext = {
+      ...runtimeSourceContext,
+      hostId: 'local',
+      repoId: 'local-repo'
+    }
+
+    await expect(
+      lookupGitHubWorkItemDetailsForSource({
+        repoPath: 'C:\\workspace\\app',
+        repoId: 'local-repo',
+        sourceContext,
+        number: 42,
+        type: 'issue'
+      })
+    ).resolves.toBeNull()
+
+    expect(window.api.gh.workItemDetails).toHaveBeenCalledWith({
+      repoPath: 'C:\\workspace\\app',
+      repoId: 'local-repo',
+      sourceContext,
+      number: 42,
+      type: 'issue'
+    })
+    expect(callRuntimeRpc).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/github-work-item-source-lookup.test.ts
+++ b/src/renderer/src/lib/github-work-item-source-lookup.test.ts
@@ -54,6 +54,29 @@ describe('GitHub source lookup routing', () => {
     expect(window.api.gh.workItemDetails).not.toHaveBeenCalled()
   })
 
+  // Regression for #6429: a runtime-sourced details lookup must never reach the
+  // local Electron IPC, which rejects unregistered remote repos with
+  // "Access denied: unknown repository path". On main this routed through
+  // window.api.gh.workItemDetails and surfaced that error.
+  it('does not invoke the local IPC (which throws access-denied) for runtime sources', async () => {
+    vi.mocked(callRuntimeRpc).mockResolvedValue(null)
+    vi.mocked(window.api.gh.workItemDetails).mockRejectedValue(
+      new Error('Access denied: unknown repository path')
+    )
+
+    await expect(
+      lookupGitHubWorkItemDetailsForSource({
+        repoPath: '/home/runtime/app',
+        repoId: 'renderer-repo',
+        sourceContext: runtimeSourceContext,
+        number: 42,
+        type: 'issue'
+      })
+    ).resolves.toBeNull()
+
+    expect(window.api.gh.workItemDetails).not.toHaveBeenCalled()
+  })
+
   it('uses the renderer repo id for runtime details when the source has no repo id', async () => {
     vi.mocked(callRuntimeRpc).mockResolvedValue(null)
 

--- a/src/renderer/src/lib/github-work-item-source-lookup.ts
+++ b/src/renderer/src/lib/github-work-item-source-lookup.ts
@@ -1,6 +1,7 @@
-import type { GitHubWorkItem } from '../../../shared/types'
+import type { GitHubWorkItem, GitHubWorkItemDetails } from '../../../shared/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { getTaskSourceRuntimeSettings } from '../../../shared/task-source-context'
+import { parseExecutionHostId } from '../../../shared/execution-host'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 
 type GitHubWorkItemLookupArgs = {
@@ -14,6 +15,14 @@ type GitHubWorkItemLookupArgs = {
 type GitHubWorkItemByOwnerRepoLookupArgs = GitHubWorkItemLookupArgs & {
   owner: string
   repo: string
+  type: 'issue' | 'pr'
+}
+
+type GitHubWorkItemDetailsLookupArgs = {
+  repoPath: string
+  repoId: string
+  sourceContext?: TaskSourceContext | null
+  number: number
   type: 'issue' | 'pr'
 }
 
@@ -73,4 +82,31 @@ export async function lookupGitHubWorkItemByOwnerRepoForSource(
           type: args.type
         })
   return item ? ({ ...item, repoId: args.repoId } as GitHubWorkItem) : null
+}
+
+export function lookupGitHubWorkItemDetailsForSource(
+  args: GitHubWorkItemDetailsLookupArgs
+): Promise<GitHubWorkItemDetails | null> {
+  const sourceContext = args.sourceContext
+  const parsedHost =
+    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
+  if (parsedHost?.kind === 'runtime') {
+    return callRuntimeRpc<GitHubWorkItemDetails | null>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.workItemDetails',
+      {
+        repo: sourceContext?.repoId ?? args.repoId,
+        number: args.number,
+        type: args.type
+      },
+      { timeoutMs: 30_000 }
+    )
+  }
+  return window.api.gh.workItemDetails({
+    repoPath: args.repoPath,
+    repoId: args.repoId,
+    sourceContext,
+    number: args.number,
+    type: args.type
+  })
 }

--- a/src/renderer/src/lib/github-work-item-source-lookup.ts
+++ b/src/renderer/src/lib/github-work-item-source-lookup.ts
@@ -1,8 +1,11 @@
 import type { GitHubWorkItem, GitHubWorkItemDetails } from '../../../shared/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
-import { getTaskSourceRuntimeSettings } from '../../../shared/task-source-context'
-import { parseExecutionHostId } from '../../../shared/execution-host'
-import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import {
+  getGitHubRuntimeRepoId,
+  getGitHubSourceRuntimeHost,
+  getGitHubSourceRuntimeTarget
+} from './github-source-runtime-context'
 
 type GitHubWorkItemLookupArgs = {
   repoPath: string
@@ -27,13 +30,13 @@ type GitHubWorkItemDetailsLookupArgs = {
 }
 
 function runtimeRepoId(args: Pick<GitHubWorkItemLookupArgs, 'repoId' | 'sourceContext'>): string {
-  return args.sourceContext?.repoId ?? args.repoId
+  return getGitHubRuntimeRepoId(args.sourceContext, args.repoId)
 }
 
 export async function lookupGitHubWorkItemForSource(
   args: GitHubWorkItemLookupArgs
 ): Promise<GitHubWorkItem | null> {
-  const target = getActiveRuntimeTarget(getTaskSourceRuntimeSettings(args.sourceContext))
+  const target = getGitHubSourceRuntimeTarget(args.sourceContext)
   const item =
     target.kind === 'environment'
       ? await callRuntimeRpc<Omit<GitHubWorkItem, 'repoId'> | null>(
@@ -58,7 +61,7 @@ export async function lookupGitHubWorkItemForSource(
 export async function lookupGitHubWorkItemByOwnerRepoForSource(
   args: GitHubWorkItemByOwnerRepoLookupArgs
 ): Promise<GitHubWorkItem | null> {
-  const target = getActiveRuntimeTarget(getTaskSourceRuntimeSettings(args.sourceContext))
+  const target = getGitHubSourceRuntimeTarget(args.sourceContext)
   const item =
     target.kind === 'environment'
       ? await callRuntimeRpc<Omit<GitHubWorkItem, 'repoId'> | null>(
@@ -88,14 +91,13 @@ export function lookupGitHubWorkItemDetailsForSource(
   args: GitHubWorkItemDetailsLookupArgs
 ): Promise<GitHubWorkItemDetails | null> {
   const sourceContext = args.sourceContext
-  const parsedHost =
-    sourceContext?.provider === 'github' ? parseExecutionHostId(sourceContext.hostId) : null
-  if (parsedHost?.kind === 'runtime') {
+  const runtimeHost = getGitHubSourceRuntimeHost(sourceContext)
+  if (runtimeHost) {
     return callRuntimeRpc<GitHubWorkItemDetails | null>(
-      { kind: 'environment', environmentId: parsedHost.environmentId },
+      { kind: 'environment', environmentId: runtimeHost.environmentId },
       'github.workItemDetails',
       {
-        repo: sourceContext?.repoId ?? args.repoId,
+        repo: getGitHubRuntimeRepoId(sourceContext, args.repoId),
         number: args.number,
         type: args.type
       },

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -1952,6 +1952,7 @@ describe('web GitHub preload API', () => {
         'listProjectViews',
         'listWorkItems',
         'mergePR',
+        'notifyWorkItemMutated',
         'onPRRefreshEvent',
         'onWorkItemMutated',
         'prCheckDetails',

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1736,6 +1736,7 @@ function createGitHubApi(): WebGitHubApi {
       }),
     workItemDetails: (args) =>
       route<WebGitHubResult<'workItemDetails'>>(GITHUB_WEB_RPC_METHODS.workItemDetails, args),
+    notifyWorkItemMutated: () => Promise.resolve(false),
     prFileContents: (args) =>
       route<WebGitHubResult<'prFileContents'>>(GITHUB_WEB_RPC_METHODS.prFileContents, args),
     listIssues: (args) =>


### PR DESCRIPTION
## Summary

Fixes #6429: on Windows in Orca `1.4.102.0`, opening a GitHub work item from a runtime/remote source could fail with `Error invoking remote method 'gh:workItemDetails': Error: Access denied: unknown repository path`.

Runtime/source-scoped GitHub work item details now route through runtime RPC instead of failing local registered-repo path checks. Follow-up PR/issue actions also preserve the source context across comments, reviewers, checks, file viewed state, body/state edits, merge/auto-merge, and project-origin item flows.

## Original Report

- Issue: https://github.com/stablyai/orca/issues/6429
- OS: Windows
- Orca version: `1.4.102.0`
- Symptom: GitHub work item details failed to load with `gh:workItemDetails` access denied because the remote/runtime repo path was checked as if it were a locally registered repository path.

## Why this PR is large

The original failure was in details loading, but the same local-only `repoPath` assumption existed across the neighboring GitHub work item surfaces. `GitHubItemDialog` and `PullRequestPage` currently duplicate much of that details/action logic, so runtime-safe routing had to be applied in both places.

To keep this as a bug fix rather than a broad refactor, this PR does not merge those UI surfaces. It only extracts the repeated runtime/source decision helpers into `github-source-runtime-context.ts` so future edits are less likely to fix one surface and miss the other.

## Design Approach

- Added source-aware lookup for GitHub work item details.
- Added narrow helpers for GitHub runtime host detection, runtime repo id selection, and repo-context availability.
- Source-scoped details caches now include the task source scope and receive cross-window invalidations.
- Runtime-owned mutations use the runtime repo identity (`sourceContext.repoId`) and sibling-only cache invalidation when the current renderer already applies optimistic state.
- Local IPC mutation broadcasts include repo ids so renderer cache keys can be matched reliably.

## Risk Notes

- Medium risk because this touches many GitHub work item controls in two duplicated renderer surfaces.
- Main risk is cache invalidation/source-context drift, which is now covered by focused boundary tests plus the helper extraction.
- Local GitHub flows still use the existing Electron IPC path; runtime flows bypass local repo-path authorization.
- This does not touch worktree cleanup, destructive deletion, git subprocess scans, WSL/SSH git providers, or cleanup modal progress.

## Brennan Pipeline

- Design doc: `.tmp/issue-6429-runtime-gh-work-item-details-design.md` (scratch/ignored, not committed).
- Design review: completed before implementation.
- Implementation: completed with focused source-routing and cache invalidation changes; no intentional deviations from the design.
- Completeness verification: completed before code review.
- Code review loop: multiple two-reviewer rounds; final round returned clean from both reviewers.
- `brennan-test-changes`: verdict was land, with the live runtime/SSH mutation gap explicitly accepted.

## Validation

- Focused Vitest: `8 files, 114 tests passed`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- Changed-file `oxlint`
- `git diff --check`
- Git crash/perf audit: no git/worktree cleanup crash surface touched

## Electron Evidence

- Original repro screenshot: `C:\Users\neil\AppData\Local\Temp\orca-6429-electron-api-repro.png`
- After-fix screenshot: `C:\Users\neil\AppData\Local\Temp\orca-6429-electron-after-fix.png`
- Brennan validation screenshot: `C:\Users\neil\AppData\Local\Temp\orca-6429-brennan-validation.png`

Validated in this worktree via Electron/CDP that source-aware lookup with runtime path `/home/aixz/data/hxf/bigmodel/ai_code/test` bypasses local repo path matching and reaches runtime dispatch (`Unknown environment: repro-env`), while the direct old IPC path still reproduces `Access denied: unknown repository path`.

## Accepted Gaps

- Did not mutate a real disposable GitHub issue/PR through a live runtime environment.
- Did not run a live `brennan-test-ssh` pass.
- Boundary tests are mostly source-routing assertions and do not replace a full end-to-end runtime GitHub integration test.
