### PR TITLE
fix: clear stale Codex branding when a pane is reused by another agent

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -471,6 +471,32 @@ describe('dispatchTerminalNotification', () => {
     expect(dispatchArgs?.agentLastAssistantMessage).toBeUndefined()
   })
 
+  it('does not reuse an untyped fresh agent snapshot when the terminal title names an agent', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      agentType: undefined,
+      terminalTitle: 'unknown',
+      lastAssistantMessage: 'Previous agent done.'
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'Claude Code',
+      paneKey
+    })
+
+    const dispatchArgs = window.api.notifications.dispatch.mock.calls.at(-1)?.[0]
+    expect(dispatchArgs).toEqual(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        terminalTitle: 'Claude Code'
+      })
+    )
+    expect(dispatchArgs?.agentType).toBeUndefined()
+    expect(dispatchArgs?.agentLastAssistantMessage).toBeUndefined()
+  })
+
   it('drops a delayed completion snapshot when the pane has already started a newer turn', () => {
     const previousDoneStartedAt = Date.now() - 10_000
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -445,6 +445,32 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
+  it('does not reuse a fresh stale agent snapshot when the terminal title names another agent', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      agentType: 'codex',
+      terminalTitle: 'Codex',
+      lastAssistantMessage: 'Codex done.'
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: '✳ Claude Code',
+      paneKey
+    })
+
+    const dispatchArgs = window.api.notifications.dispatch.mock.calls.at(-1)?.[0]
+    expect(dispatchArgs).toEqual(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey,
+        terminalTitle: '✳ Claude Code'
+      })
+    )
+    expect(dispatchArgs?.agentType).toBeUndefined()
+    expect(dispatchArgs?.agentLastAssistantMessage).toBeUndefined()
+  })
+
   it('drops a delayed completion snapshot when the pane has already started a newer turn', () => {
     const previousDoneStartedAt = Date.now() - 10_000
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -84,6 +84,11 @@ function stubDocumentFocus({
   })
 }
 
+function getLastNotificationDispatchArg(): Record<string, unknown> | undefined {
+  const dispatch = window.api.notifications.dispatch as unknown as ReturnType<typeof vi.fn>
+  return dispatch.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
+}
+
 describe('dispatchTerminalNotification', () => {
   const liveLeafId = '11111111-1111-4111-8111-111111111111'
   const staleLeafId = '22222222-2222-4222-8222-222222222222'
@@ -458,7 +463,7 @@ describe('dispatchTerminalNotification', () => {
       paneKey
     })
 
-    const dispatchArgs = window.api.notifications.dispatch.mock.calls.at(-1)?.[0]
+    const dispatchArgs = getLastNotificationDispatchArg()
     expect(dispatchArgs).toEqual(
       expect.objectContaining({
         source: 'agent-task-complete',
@@ -484,7 +489,7 @@ describe('dispatchTerminalNotification', () => {
       paneKey
     })
 
-    const dispatchArgs = window.api.notifications.dispatch.mock.calls.at(-1)?.[0]
+    const dispatchArgs = getLastNotificationDispatchArg()
     expect(dispatchArgs).toEqual(
       expect.objectContaining({
         source: 'agent-task-complete',

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useAppStore } from '@/store'
+import { resolveExplicitTerminalTitleAgentType } from '@/lib/terminal-title-agent-type'
 import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
@@ -39,13 +40,20 @@ export function dispatchTerminalNotification(
   event: TerminalNotificationEvent
 ): void {
   const state = useAppStore.getState()
+  const explicitTitleAgentType =
+    event.source === 'agent-task-complete' && event.terminalTitle
+      ? resolveExplicitTerminalTitleAgentType(event.terminalTitle)
+      : null
   const storedAgentStatus =
     event.source === 'agent-task-complete' && event.paneKey
       ? state.agentStatusByPaneKey[event.paneKey]
       : undefined
   const freshStoredAgentStatus =
     storedAgentStatus &&
-    Date.now() - storedAgentStatus.updatedAt <= AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS
+    Date.now() - storedAgentStatus.updatedAt <= AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS &&
+    (!explicitTitleAgentType ||
+      !storedAgentStatus.agentType ||
+      storedAgentStatus.agentType === explicitTitleAgentType)
       ? storedAgentStatus
       : undefined
   const agentStatus =

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -51,9 +51,7 @@ export function dispatchTerminalNotification(
   const freshStoredAgentStatus =
     storedAgentStatus &&
     Date.now() - storedAgentStatus.updatedAt <= AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS &&
-    (!explicitTitleAgentType ||
-      !storedAgentStatus.agentType ||
-      storedAgentStatus.agentType === explicitTitleAgentType)
+    (!explicitTitleAgentType || storedAgentStatus.agentType === explicitTitleAgentType)
       ? storedAgentStatus
       : undefined
   const agentStatus =

--- a/src/renderer/src/lib/terminal-title-agent-type.ts
+++ b/src/renderer/src/lib/terminal-title-agent-type.ts
@@ -11,6 +11,7 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   Devin: 'devin',
   Antigravity: 'antigravity',
   OpenCode: 'opencode',
+  'MiMo Code': 'mimo-code',
   Aider: 'aider',
   Cursor: 'cursor',
   Droid: 'droid',

--- a/src/renderer/src/lib/terminal-title-agent-type.ts
+++ b/src/renderer/src/lib/terminal-title-agent-type.ts
@@ -1,0 +1,62 @@
+import { getAgentLabel, titleHasAgentName } from '../../../shared/agent-detection'
+import type { TuiAgent } from '../../../shared/types'
+
+const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
+  'Claude Code': 'claude',
+  OpenClaude: 'openclaude',
+  Codex: 'codex',
+  'Gemini CLI': 'gemini',
+  'GitHub Copilot': 'copilot',
+  Grok: 'grok',
+  Devin: 'devin',
+  Antigravity: 'antigravity',
+  OpenCode: 'opencode',
+  Aider: 'aider',
+  Cursor: 'cursor',
+  Droid: 'droid',
+  Hermes: 'hermes',
+  Pi: 'pi'
+}
+
+function containsBrailleSpinner(title: string): boolean {
+  for (const char of title) {
+    const codePoint = char.codePointAt(0)
+    if (codePoint !== undefined && codePoint >= 0x2800 && codePoint <= 0x28ff) {
+      return true
+    }
+  }
+  return false
+}
+
+function hasGenericClaudeStatusPrefix(title: string): boolean {
+  return (
+    containsBrailleSpinner(title) ||
+    title.startsWith('\u2733 ') ||
+    title === '\u2733' ||
+    title.startsWith('. ') ||
+    title.startsWith('* ')
+  )
+}
+
+function isGenericClaudeStatusClaim(title: string, titleAgent: TuiAgent | null): boolean {
+  return (
+    titleAgent === 'claude' &&
+    hasGenericClaudeStatusPrefix(title) &&
+    !titleHasAgentName(title, 'claude')
+  )
+}
+
+export function resolveTerminalTitleAgentType(title: string): TuiAgent | null {
+  const label = getAgentLabel(title)
+  return label ? (TITLE_LABEL_TO_AGENT[label] ?? null) : null
+}
+
+export function resolveExplicitTerminalTitleAgentType(title: string): TuiAgent | null {
+  const titleAgent = resolveTerminalTitleAgentType(title)
+  if (isGenericClaudeStatusClaim(title, titleAgent)) {
+    // Why: Claude's task-title spinner can describe arbitrary work. Treat it
+    // as activity-only unless the title explicitly names Claude.
+    return null
+  }
+  return titleAgent
+}

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -290,6 +290,21 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('openclaude')
   })
 
+  it('lets an explicit title override stale launch identity after the pane shows newer activity', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        foreground: undefined,
+        hasObservedAgentSignal: true,
+        shellForegroundAfterAgentSignal: false,
+        isRemote: false,
+        title: '✳ Claude Code',
+        hookAgent: null,
+        hasCompletedHook: false,
+        launchAgent: 'codex'
+      })
+    ).toBe('claude')
+  })
+
   it('lets shell foreground clear the icon after an agent was observed running', () => {
     expect(
       resolveTabAgentFromSignals({

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -139,7 +139,7 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('openclaude')
   })
 
-  it('keeps title fallback for real Gemini and Pi titles', () => {
+  it('keeps title fallback for real Gemini, MiMo, and Pi titles', () => {
     expect(
       resolveTabAgentFromSignals({
         foreground: undefined,
@@ -152,6 +152,19 @@ describe('resolveTabAgentFromSignals', () => {
         launchAgent: undefined
       })
     ).toBe('gemini')
+
+    expect(
+      resolveTabAgentFromSignals({
+        foreground: undefined,
+        hasObservedAgentSignal: false,
+        shellForegroundAfterAgentSignal: false,
+        isRemote: false,
+        title: 'MiMo Code',
+        hookAgent: null,
+        hasCompletedHook: false,
+        launchAgent: undefined
+      })
+    ).toBe('mimo-code')
 
     expect(
       resolveTabAgentFromSignals({

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -2,7 +2,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { recognizeAgentProcess } from '../../../shared/agent-process-recognition'
-import { isShellProcess, getAgentLabel, titleHasAgentName } from '../../../shared/agent-detection'
+import { isShellProcess } from '../../../shared/agent-detection'
+import type { TerminalTab, TuiAgent } from '../../../shared/types'
 import { worktreeUsesRemoteConnection } from '@/store/slices/terminals'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 import {
@@ -11,77 +12,14 @@ import {
   resolveSiblingCompletedTabAgent,
   resolveSiblingTabAgent
 } from './tab-agent'
-import type { TerminalTab, TuiAgent } from '../../../shared/types'
-
-// Maps getAgentLabel()'s product labels to TuiAgent ids — the fallback for
-// agents whose foreground PROCESS name isn't self-identifying (Claude Code runs
-// as `node`, but its "✳ Claude Code" title resolves here). Agents whose process
-// name already matches (codex, etc.) never reach this path.
-const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
-  'Claude Code': 'claude',
-  OpenClaude: 'openclaude',
-  Codex: 'codex',
-  'Gemini CLI': 'gemini',
-  'GitHub Copilot': 'copilot',
-  Grok: 'grok',
-  Devin: 'devin',
-  Antigravity: 'antigravity',
-  OpenCode: 'opencode',
-  Aider: 'aider',
-  Cursor: 'cursor',
-  Droid: 'droid',
-  Hermes: 'hermes',
-  Pi: 'pi'
-}
+import {
+  resolveExplicitTerminalTitleAgentType
+} from './terminal-title-agent-type'
 
 const HELPER_FOREGROUND_RETRY_DELAYS_MS = [250, 1250, 3500, 750] as const
 
-function agentFromTitle(title: string): TuiAgent | null {
-  const label = getAgentLabel(title)
-  return label ? (TITLE_LABEL_TO_AGENT[label] ?? null) : null
-}
-
-function containsBrailleSpinner(title: string): boolean {
-  for (const char of title) {
-    const codePoint = char.codePointAt(0)
-    if (codePoint !== undefined && codePoint >= 0x2800 && codePoint <= 0x28ff) {
-      return true
-    }
-  }
-  return false
-}
-
-function hasGenericClaudeStatusPrefix(title: string): boolean {
-  return (
-    containsBrailleSpinner(title) ||
-    title.startsWith('✳ ') ||
-    title === '✳' ||
-    title.startsWith('. ') ||
-    title.startsWith('* ')
-  )
-}
-
-function isGenericClaudeStatusClaim(title: string, titleAgent: TuiAgent | null): boolean {
-  return (
-    titleAgent === 'claude' &&
-    hasGenericClaudeStatusPrefix(title) &&
-    !titleHasAgentName(title, 'claude')
-  )
-}
-
-function agentFromTabTitle(title: string): TuiAgent | null {
-  const titleAgent = agentFromTitle(title)
-  if (isGenericClaudeStatusClaim(title, titleAgent)) {
-    // Why: bare Claude status prefixes are activity evidence, not identity.
-    // Keep them out of tab icons so task/worktree titles cannot become Claude
-    // without a hook, launch intent, foreground process, or explicit name.
-    return null
-  }
-  return titleAgent
-}
-
 function getTitleForegroundKey(title: string, launchAgent?: TuiAgent): string {
-  const titleAgent = launchAgent ? null : agentFromTabTitle(title)
+  const titleAgent = launchAgent ? null : resolveExplicitTerminalTitleAgentType(title)
   if (titleAgent) {
     return `agent:${titleAgent}`
   }
@@ -94,7 +32,7 @@ function getTitleForegroundKey(title: string, launchAgent?: TuiAgent): string {
     // Why: unknown agents may still animate leading status glyphs. Include the
     // stable title body so first launch from "Terminal 1" triggers one poll,
     // without polling on every spinner frame.
-    .replace(/^(?:[✳✦⏲◇✋⠀-⣿]+|[.*]\s)\s*/, '')
+    .replace(/^(?:[\u2733\u2726\u23f2\u25c7\u270b\u2800-\u28ff]+|[.*]\s)\s*/, '')
     .slice(0, 48)
   return `unknown:${stableTitle}`
 }
@@ -112,7 +50,15 @@ export function resolveTabAgentFromSignals(args: {
   launchAgent?: TuiAgent
 }): TuiAgent | null {
   const launchAgent = args.launchAgent ?? null
-  const titleAgent = launchAgent ? null : agentFromTabTitle(args.title)
+  const explicitTitleAgent = resolveExplicitTerminalTitleAgentType(args.title)
+  const titleOverridesLaunch =
+    launchAgent !== null &&
+    explicitTitleAgent !== null &&
+    explicitTitleAgent !== launchAgent &&
+    args.hasObservedAgentSignal
+  const titleAgent = titleOverridesLaunch
+    ? explicitTitleAgent
+    : (launchAgent ? null : explicitTitleAgent)
   const titleLooksShell = isShellProcess(args.title)
   // Why: remote panes cannot cheaply prove shell foreground after hook exit,
   // so keep the last completed hook identity instead of flashing unknown.
@@ -126,7 +72,7 @@ export function resolveTabAgentFromSignals(args: {
   const activeLaunchAgent =
     localShellForegroundClearedLaunch || remoteCompletedHookAtShellTitle ? null : launchAgent
   if (args.isRemote || args.foreground === undefined) {
-    return focusedHookAgent ?? activeLaunchAgent ?? fallbackHookAgent ?? titleAgent
+    return focusedHookAgent ?? titleAgent ?? activeLaunchAgent ?? fallbackHookAgent
   }
   if (args.foreground) {
     return args.foreground
@@ -136,25 +82,25 @@ export function resolveTabAgentFromSignals(args: {
   if (args.shellForegroundAfterAgentSignal) {
     return null
   }
-  return focusedHookAgent ?? activeLaunchAgent ?? fallbackHookAgent ?? titleAgent
+  return focusedHookAgent ?? titleAgent ?? activeLaunchAgent ?? fallbackHookAgent
 }
 
 /**
  * Resolve which coding-harness agent a terminal tab is running, for its tab-bar
  * icon. Layered signals, most-authoritative first:
  *
- * 1. Live foreground process — the ground truth for what's running *now*: the
+ * 1. Live foreground process - the ground truth for what's running now: the
  *    only signal that reverts to the terminal glyph when the agent exits to a
  *    shell, or flips when a different agent starts in the same pane. Checked
- *    event-driven (only when the tab's title changes — exactly when an agent
+ *    event-driven (only when the tab's title changes - exactly when an agent
  *    starts/exits/takes a turn), never on an interval, and only for local panes
  *    (SSH foreground inspection is a 15s-timeout RPC). A recognized agent wins;
  *    a recognized shell authoritatively means "no agent".
- * 2. Hook status — accurate provider identity from native integrations, and
+ * 2. Hook status - accurate provider identity from native integrations, and
  *    available for SSH/remote panes where foreground polling is too costly.
- * 3. launchAgent — what Orca launched here; instant bootstrap before hooks or
+ * 3. launchAgent - what Orca launched here; instant bootstrap before hooks or
  *    foreground polling arrive, and the owned identity for startup windows.
- * 4. Title — legacy/unknown-session fallback only. It is ignored while
+ * 4. Title - legacy/unknown-session fallback only. It is ignored while
  *    launchAgent exists, and generic spinner-only titles do not identify an agent.
  */
 export function useTabAgent(tab: TerminalTab): TuiAgent | null {
@@ -223,7 +169,7 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
 
   useEffect(() => {
     const fallbackAgentSignal =
-      !tab.launchAgent && (agentFromTabTitle(tab.title) || siblingHookAgent)
+      !tab.launchAgent && (resolveExplicitTerminalTitleAgentType(tab.title) || siblingHookAgent)
     // Why: a completed structured hook proves a launched agent existed, but
     // local launch cleanup still waits for current foreground-shell evidence.
     if (focusedHookAgent || hasCompletedHook || fallbackAgentSignal) {
@@ -239,7 +185,7 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     const localPtyId = ptyId
     let cancelled = false
     const helperForegroundRetryTimers: number[] = []
-    // Why: re-runs when ptyId or tab.title changes — a title change is the event
+    // Why: re-runs when ptyId or tab.title changes - a title change is the event
     // signalling a possible foreground transition (agent start, exit, or turn).
     // One RPC per transition, not a timer; cancellation coalesces rapid churn.
     function readForeground(retryIndex = 0): void {


### PR DESCRIPTION
## Summary

Fixes #6355 by preventing stale Codex branding from sticking to a pane after it is reused by another agent.

  - allow explicit terminal identity to override stale `launchAgent` metadata after newer activity is observed
  - avoid reusing stale stored agent snapshots for completion notifications when the current title names a different agent
  - share terminal-title agent parsing between tab branding and notifications

  ## Screenshots

  - No visual change

  ## Testing

  - [ ] `pnpm lint`
  - [ ] `pnpm typecheck`
  - [ ] `pnpm test`
  - [ ] `pnpm build`
  - [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

  Ran:
  - `node config/scripts/ensure-native-runtime.mjs --runtime=node`
  - `.\node_modules\.bin\vitest.cmd run --config config/vitest.config.ts src/renderer/src/lib/use-tab-agent.test.ts src/renderer/src/
  components/terminal-pane/use-notification-dispatch.test.ts`

  ## AI Review Report

Reviewed stale agent identity reuse across tab icons and completion notifications. Main risk was Codex metadata outliving the original session and being shown for Claude. Added shared title parsing and regressions for Codex -> Claude pane reuse. Cross-platform impact checked; no platform-specific shortcut, path, shell, or Electron behavior was changed.

  ## Security Audit

Low risk. Reviewed terminal-title parsing, stored agent snapshot selection, and notification dispatch. No new command execution, path handling, auth, secrets, or IPC surface was added.

  ## Notes

  - No visual change; this is a state-consistency fix.
  - Focused regression tests were run for the touched paths.