### PR TITLE
Dim and transition Create More label on hover

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -1066,7 +1066,7 @@ export default function NewWorkspaceComposerCard({
             role="switch"
             aria-checked={createMultiple}
             onClick={() => onCreateMultipleChange?.(!createMultiple)}
-            className="group flex w-fit cursor-pointer items-center gap-2 rounded-md text-xs text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            className="group flex w-fit cursor-pointer items-center gap-2 rounded-md text-xs outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >
             <span
               aria-hidden
@@ -1082,7 +1082,7 @@ export default function NewWorkspaceComposerCard({
                 )}
               />
             </span>
-            <span>
+            <span className="text-muted-foreground transition-colors group-hover:text-foreground">
               {translate('auto.components.NewWorkspaceComposerCard.createMultiple', 'Create more')}
             </span>
           </button>


### PR DESCRIPTION
## Summary

Dims the "Create more" label (changing from `text-foreground` to `text-muted-foreground`) and transitions the color to `text-foreground` when the button is hovered.

## Screenshots

- TODO: Add screen recording of hover transition.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

The change is a CSS class replacement within a React component. We checked style correctness and verified that it is cross-platform compatible as it uses standard utility classes. No Electron-specific platform differences, shortcuts, paths, or shell behaviors are affected.

## Security Audit

No security risks were found. The modified code is entirely layout and styling-centric (Tailwind CSS classes) with no data handling, secrets, IPC, or external inputs.

## Notes

No platform-specific risks or behavior.