### PR TITLE
Fix deleting a worktree's preserved branch over SSH

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -6168,6 +6168,62 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('force-deletes an SSH branch that was preserved by safe worktree removal', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: null
+    }
+    const worktreeId = 'repo-ssh::/remote/feature-wt'
+    const provider = {
+      exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      forceDeletePreservedBranch: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: repo.path,
+          head: 'main',
+          branch: 'main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: '/remote/feature-wt',
+          head: 'def456',
+          branch: 'feature/test',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      removeWorktree: vi.fn().mockResolvedValue({
+        preservedBranch: { branchName: 'feature/test', head: 'def456' }
+      }),
+      worktreeIsClean: vi.fn().mockResolvedValue({ clean: true })
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue({ request: vi.fn(), notify: vi.fn() })
+
+    await handlers['worktrees:remove'](null, { worktreeId })
+    const result = await handlers['worktrees:forceDeletePreservedBranch'](null, {
+      worktreeId,
+      branchName: 'feature/test',
+      expectedHead: 'def456'
+    })
+
+    expect(result).toMatchObject({ deleted: true })
+    expect(provider.forceDeletePreservedBranch).toHaveBeenCalledWith(
+      '/remote/repo',
+      'feature/test',
+      'def456'
+    )
+    expect(forceDeleteLocalBranchMock).not.toHaveBeenCalled()
+  })
+
   it('rejects stale preserved-branch cleanup actions with an old head', async () => {
     mockKnownFeatureWorktree()
     removeWorktreeMock.mockResolvedValue({

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1755,11 +1755,10 @@ export function registerWorktreeHandlers(
 
       if (repo.connectionId) {
         const provider = requireSshGitProvider(repo.connectionId)
-        await forceDeleteLocalBranch(
+        await provider.forceDeletePreservedBranch(
           repo.path,
           cleanupTarget.branchName,
-          cleanupTarget.head,
-          (argv, cwd) => provider.exec(argv, cwd)
+          cleanupTarget.head
         )
         await cleanupUnusedWorktreePushTargetRemoteSsh(
           provider,

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1755,6 +1755,9 @@ export function registerWorktreeHandlers(
 
       if (repo.connectionId) {
         const provider = requireSshGitProvider(repo.connectionId)
+        // Why: SSH must use the write-capable relay RPC; the shared exec-based
+        // helper routes through the read-only git.exec allowlist, which rejects
+        // the worktree/update-ref/config writes this delete needs.
         await provider.forceDeletePreservedBranch(
           repo.path,
           cleanupTarget.branchName,

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1258,6 +1258,38 @@ describe('SshGitProvider', () => {
     })
   })
 
+  it('forceDeletePreservedBranch sends the preserved-branch delete request', async () => {
+    await provider.forceDeletePreservedBranch('/home/user/repo', 'you/fix-auth', 'abc123')
+    expect(mux.request).toHaveBeenCalledWith('git.forceDeletePreservedBranch', {
+      repoPath: '/home/user/repo',
+      branchName: 'you/fix-auth',
+      expectedHead: 'abc123'
+    })
+  })
+
+  it('forceDeletePreservedBranch maps old relays to the reconnect message', async () => {
+    const methodNotFound = Object.assign(
+      new Error('Method not found: git.forceDeletePreservedBranch'),
+      { code: -32601 }
+    )
+    mux.request.mockRejectedValueOnce(methodNotFound)
+
+    await expect(
+      provider.forceDeletePreservedBranch('/home/user/repo', 'you/fix-auth', 'abc123')
+    ).rejects.toThrow(
+      'This SSH host is running an older Orca relay that cannot delete preserved branches. Reconnect to deploy the latest relay, then try again.'
+    )
+  })
+
+  it('forceDeletePreservedBranch rethrows non-method-not-found errors', async () => {
+    const error = new Error('remote update-ref failed')
+    mux.request.mockRejectedValueOnce(error)
+
+    await expect(
+      provider.forceDeletePreservedBranch('/home/user/repo', 'you/fix-auth', 'abc123')
+    ).rejects.toBe(error)
+  })
+
   it('isGitRepo always returns true for remote paths', () => {
     expect(provider.isGitRepo('/any/path')).toBe(true)
   })

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -697,6 +697,29 @@ export class SshGitProvider implements IGitProvider {
     })
   }
 
+  async forceDeletePreservedBranch(
+    repoPath: string,
+    branchName: string,
+    expectedHead: string
+  ): Promise<void> {
+    try {
+      await this.runWithDiffDedupeClear(async () => {
+        await this.mux.request('git.forceDeletePreservedBranch', {
+          repoPath,
+          branchName,
+          expectedHead
+        })
+      })
+    } catch (error) {
+      if (isJsonRpcMethodNotFoundError(error)) {
+        throw new Error(
+          'This SSH host is running an older Orca relay that cannot delete preserved branches. Reconnect to deploy the latest relay, then try again.'
+        )
+      }
+      throw error
+    }
+  }
+
   async exec(
     args: string[],
     cwd: string,

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -712,6 +712,8 @@ export class SshGitProvider implements IGitProvider {
       })
     } catch (error) {
       if (isJsonRpcMethodNotFoundError(error)) {
+        // Why: older SSH relays predate git.forceDeletePreservedBranch; surface
+        // a reconnect prompt instead of a raw JSON-RPC method-not-found error.
         throw new Error(
           'This SSH host is running an older Orca relay that cannot delete preserved branches. Reconnect to deploy the latest relay, then try again.'
         )

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -232,6 +232,11 @@ export type IGitProvider = {
     options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
   ): Promise<RemoveWorktreeResult>
   renameCurrentBranch?(worktreePath: string, newBranch: string): Promise<void>
+  forceDeletePreservedBranch?(
+    repoPath: string,
+    branchName: string,
+    expectedHead: string
+  ): Promise<void>
   isGitRepo(path: string): boolean
   isGitRepoAsync(dirPath: string): Promise<{ isRepo: boolean; rootPath: string | null }>
   exec(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -21190,6 +21190,77 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('force-deletes an SSH branch that was preserved by runtime worktree removal', async () => {
+    const remoteRepo = {
+      ...store.getRepo(TEST_REPO_ID)!,
+      path: '/remote/repo',
+      connectionId: 'ssh-1'
+    }
+    const remoteWorktree = {
+      path: '/remote/feature-wt',
+      head: 'def456',
+      branch: 'feature/test',
+      isBare: false,
+      isMainWorktree: false
+    }
+    const remoteWorktreeId = `${remoteRepo.id}::${remoteWorktree.path}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [remoteWorktreeId]: makeWorktreeMeta()
+    }
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [remoteRepo],
+      getRepo: (id: string) => (id === remoteRepo.id ? remoteRepo : undefined),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      },
+      removeWorktreeMeta: (worktreeId: string) => {
+        delete metaById[worktreeId]
+      }
+    }
+    const provider = {
+      exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      forceDeletePreservedBranch: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: remoteRepo.path,
+          head: 'main',
+          branch: 'main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        remoteWorktree
+      ]),
+      removeWorktree: vi.fn().mockResolvedValue({
+        preservedBranch: { branchName: 'feature/test', head: 'def456' }
+      })
+    }
+    registerSshGitProvider('ssh-1', provider as never)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    try {
+      await runtime.removeManagedWorktree(remoteWorktreeId)
+      const result = await runtime.forceDeletePreservedBranch(
+        remoteWorktreeId,
+        'feature/test',
+        'def456'
+      )
+
+      expect(result).toEqual({ deleted: true })
+      expect(provider.forceDeletePreservedBranch).toHaveBeenCalledWith(
+        '/remote/repo',
+        'feature/test',
+        'def456'
+      )
+      expect(forceDeleteLocalBranchMock).not.toHaveBeenCalled()
+    } finally {
+      unregisterSshGitProvider('ssh-1')
+    }
+  })
+
   it('routes runtime preserved-branch force-delete through the selected WSL project runtime', async () => {
     setPlatform('win32')
     const runtimeStore = {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -14099,6 +14099,9 @@ export class OrcaRuntimeService {
 
     if (repo.connectionId) {
       const provider = requireSshGitProvider(repo.connectionId)
+      // Why: SSH must use the write-capable relay RPC; the shared exec-based
+      // helper routes through the read-only git.exec allowlist, which rejects
+      // the worktree/update-ref/config writes this delete needs.
       await provider.forceDeletePreservedBranch(
         repo.path,
         cleanupTarget.branchName,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -14099,11 +14099,10 @@ export class OrcaRuntimeService {
 
     if (repo.connectionId) {
       const provider = requireSshGitProvider(repo.connectionId)
-      await forceDeleteLocalBranch(
+      await provider.forceDeletePreservedBranch(
         repo.path,
         cleanupTarget.branchName,
-        cleanupTarget.head,
-        (argv, cwd) => provider.exec(argv, cwd)
+        cleanupTarget.head
       )
       await cleanupUnusedWorktreePushTargetRemoteSsh(
         provider,

--- a/src/relay/git-handler-branch-cleanup.test.ts
+++ b/src/relay/git-handler-branch-cleanup.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import * as path from 'path'
 import type { GitExec } from './git-handler-ops'
 import { removeWorktreeOp } from './git-handler-worktree-ops'
+import { forceDeletePreservedRelayBranch } from './git-handler-branch-cleanup'
 
 function worktreeList(...entries: { path: string; branch?: string }[]): string {
   return entries
@@ -18,6 +19,137 @@ function worktreeList(...entries: { path: string; branch?: string }[]): string {
 function resolvedRepoPath(): string {
   return path.posix.resolve('/repo-feature', '/repo/.git', '..')
 }
+
+describe('forceDeletePreservedRelayBranch', () => {
+  it('deletes a preserved branch at the expected head', async () => {
+    const calls: string[][] = []
+    const git = vi.fn<GitExec>(async (args) => {
+      calls.push(args)
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      forceDeletePreservedRelayBranch(git, '/repo', 'feature/test', 'abc123')
+    ).resolves.toBeUndefined()
+
+    expect(calls).toEqual([
+      ['worktree', 'list', '--porcelain'],
+      ['update-ref', '-d', 'refs/heads/feature/test', 'abc123'],
+      ['worktree', 'list', '--porcelain'],
+      ['config', '--remove-section', 'branch.feature/test']
+    ])
+  })
+
+  it('maps only ref-moved update-ref delete failures to the preserved-branch message', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
+      }
+      if (args[0] === 'update-ref' && args[1] === '-d') {
+        throw new Error('cannot lock ref')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      forceDeletePreservedRelayBranch(git, '/repo', 'feature/test', 'abc123')
+    ).rejects.toThrow(
+      'Local branch "feature/test" changed after the workspace was deleted. Review it before deleting it.'
+    )
+    expect(git).not.toHaveBeenCalledWith(
+      ['config', '--remove-section', 'branch.feature/test'],
+      '/repo'
+    )
+  })
+
+  it('keeps the checked-out message when the branch is checked out before delete', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      forceDeletePreservedRelayBranch(git, '/repo', 'feature/test', 'abc123')
+    ).rejects.toThrow('Local branch "feature/test" is checked out in another worktree.')
+    expect(git).not.toHaveBeenCalledWith(
+      ['update-ref', '-d', 'refs/heads/feature/test', 'abc123'],
+      '/repo'
+    )
+  })
+
+  it('restores the ref and keeps the checked-out message after a concurrent checkout', async () => {
+    let listCount = 0
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCount += 1
+        return {
+          stdout:
+            listCount === 1
+              ? worktreeList({ path: '/repo', branch: 'main' })
+              : worktreeList(
+                  { path: '/repo', branch: 'main' },
+                  { path: '/repo-feature', branch: 'feature/test' }
+                ),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      forceDeletePreservedRelayBranch(git, '/repo', 'feature/test', 'abc123')
+    ).rejects.toThrow('Local branch "feature/test" is checked out in another worktree.')
+    expect(git).toHaveBeenCalledWith(
+      ['update-ref', '-d', 'refs/heads/feature/test', 'abc123'],
+      '/repo'
+    )
+    expect(git).toHaveBeenCalledWith(
+      ['update-ref', 'refs/heads/feature/test', 'abc123', ''],
+      '/repo'
+    )
+  })
+
+  it('swallows branch config removal failures after deleting the ref', async () => {
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
+      }
+      if (args[0] === 'config' && args[1] === '--remove-section') {
+        throw new Error('missing section')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      forceDeletePreservedRelayBranch(git, '/repo', 'feature/test', 'abc123')
+    ).resolves.toBeUndefined()
+  })
+
+  it.each([
+    ['empty branch name', '', 'abc123'],
+    ['empty expected head', 'feature/test', ''],
+    ['leading dash branch name', '-feature', 'abc123'],
+    ['NUL branch name', 'feature\0test', 'abc123']
+  ])('rejects invalid input: %s', async (_label, branchName, expectedHead) => {
+    const git = vi.fn<GitExec>()
+
+    await expect(
+      forceDeletePreservedRelayBranch(git, '/repo', branchName, expectedHead)
+    ).rejects.toThrow()
+    expect(git).not.toHaveBeenCalled()
+  })
+})
 
 describe('removeWorktreeOp branch cleanup', () => {
   it('deletes a squash-merged SSH branch when merging it into the base is a no-op', async () => {
@@ -278,7 +410,7 @@ describe('removeWorktreeOp branch cleanup', () => {
 
     expect(warnSpy).toHaveBeenCalledWith(
       'relay removeWorktree: failed to delete already-merged local branch "feature/test" after removing worktree',
-      expect.any(Error)
+      expect.objectContaining({ message: 'cannot lock ref' })
     )
     expect(warnSpy).toHaveBeenCalledWith(
       'relay removeWorktree: preserved local branch "feature/test" after removing worktree (not fully merged)',

--- a/src/relay/git-handler-branch-cleanup.ts
+++ b/src/relay/git-handler-branch-cleanup.ts
@@ -26,16 +26,42 @@ export async function deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure(
   return true
 }
 
-async function deleteRelayBranchAtExpectedHead(
+export async function forceDeletePreservedRelayBranch(
   git: GitExec,
   repoPath: string,
   branchName: string,
   expectedHead: string
 ): Promise<void> {
+  if (!branchName || branchName.includes('\0') || branchName.startsWith('-')) {
+    throw new Error('Invalid branch name for preserved branch delete.')
+  }
+  if (!expectedHead) {
+    throw new Error('Expected branch head is required for preserved branch delete.')
+  }
+  await deleteRelayBranchAtExpectedHead(git, repoPath, branchName, expectedHead, () => {
+    return new Error(
+      `Local branch "${branchName}" changed after the workspace was deleted. Review it before deleting it.`
+    )
+  })
+}
+
+async function deleteRelayBranchAtExpectedHead(
+  git: GitExec,
+  repoPath: string,
+  branchName: string,
+  expectedHead: string,
+  mapUpdateRefError?: (error: unknown) => Error
+): Promise<void> {
   if (await isRelayBranchCheckedOut(git, repoPath, branchName)) {
     throw new Error(`Local branch "${branchName}" is checked out in another worktree.`)
   }
-  await git(['update-ref', '-d', `refs/heads/${branchName}`, expectedHead], repoPath)
+  try {
+    await git(['update-ref', '-d', `refs/heads/${branchName}`, expectedHead], repoPath)
+  } catch (error) {
+    // Why: only stale ref writes get the force-delete message; checkout guards
+    // and removeWorktree cleanup still rely on their distinct/raw failures.
+    throw mapUpdateRefError?.(error) ?? error
+  }
   if (await isRelayBranchCheckedOut(git, repoPath, branchName)) {
     try {
       await git(['update-ref', `refs/heads/${branchName}`, expectedHead, ''], repoPath)

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -129,6 +129,7 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.worktreeIsClean')
     expect(methods).toContain('git.refreshLocalBaseRefForWorktreeCreate')
     expect(methods).toContain('git.renameCurrentBranch')
+    expect(methods).toContain('git.forceDeletePreservedBranch')
     expect(methods).toContain('git.exec')
     expect(methods).toContain('git.clone')
     expect(methods).toContain('git.isGitRepo')
@@ -262,6 +263,66 @@ describe('GitHandler', () => {
           newBranch: '-bad'
         })
       ).rejects.toThrow('Branch name must not start with "-"')
+    })
+  })
+
+  describe('forceDeletePreservedBranch', () => {
+    function headOf(cwd: string, ref: string): string {
+      return execFileSync('git', ['rev-parse', ref], { cwd, encoding: 'utf-8' }).trim()
+    }
+
+    it('deletes a preserved branch at its expected head through the narrow RPC', async () => {
+      gitInit(tmpDir)
+      writeFileSync(path.join(tmpDir, 'file.txt'), 'hello')
+      gitCommit(tmpDir, 'initial')
+      execFileSync('git', ['branch', 'feature/preserved'], { cwd: tmpDir, stdio: 'pipe' })
+      const head = headOf(tmpDir, 'refs/heads/feature/preserved')
+
+      await dispatcher.callRequest('git.forceDeletePreservedBranch', {
+        repoPath: tmpDir,
+        branchName: 'feature/preserved',
+        expectedHead: head
+      })
+
+      const refs = execFileSync('git', ['branch', '--list', 'feature/preserved'], {
+        cwd: tmpDir,
+        encoding: 'utf-8'
+      }).trim()
+      expect(refs).toBe('')
+    })
+
+    it('refuses to delete when the branch moved past the expected head', async () => {
+      gitInit(tmpDir)
+      writeFileSync(path.join(tmpDir, 'file.txt'), 'hello')
+      gitCommit(tmpDir, 'initial')
+      const staleHead = headOf(tmpDir, 'HEAD')
+      execFileSync('git', ['checkout', '-b', 'feature/preserved'], { cwd: tmpDir, stdio: 'pipe' })
+      // Advance the branch so the saved (stale) head no longer matches its tip.
+      gitCommit(tmpDir, 'second')
+      execFileSync('git', ['checkout', '-'], { cwd: tmpDir, stdio: 'pipe' })
+
+      await expect(
+        dispatcher.callRequest('git.forceDeletePreservedBranch', {
+          repoPath: tmpDir,
+          branchName: 'feature/preserved',
+          expectedHead: staleHead
+        })
+      ).rejects.toThrow('changed after the workspace was deleted')
+      const refs = execFileSync('git', ['branch', '--list', 'feature/preserved'], {
+        cwd: tmpDir,
+        encoding: 'utf-8'
+      }).trim()
+      expect(refs).toContain('feature/preserved')
+    })
+
+    it('rejects an empty repoPath at the RPC boundary', async () => {
+      await expect(
+        dispatcher.callRequest('git.forceDeletePreservedBranch', {
+          repoPath: '',
+          branchName: 'feature/preserved',
+          expectedHead: 'abc123'
+        })
+      ).rejects.toThrow('Invalid preserved branch force-delete request.')
     })
   })
 

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -25,6 +25,7 @@ import {
   removeWorktreeOp,
   worktreeIsCleanOp
 } from './git-handler-worktree-ops'
+import { forceDeletePreservedRelayBranch } from './git-handler-branch-cleanup'
 import { refreshLocalBaseRefForWorktreeCreateOp } from './git-handler-local-base-ref-refresh'
 import { checkIgnoredPathsOp, detectConflictOperation, getStatusOp } from './git-handler-status-ops'
 import { resolveRelayPushTarget } from './git-handler-push-target'
@@ -138,6 +139,9 @@ export class GitHandler {
       this.refreshLocalBaseRefForWorktreeCreate(p)
     )
     this.dispatcher.onRequest('git.renameCurrentBranch', (p) => this.renameCurrentBranch(p))
+    this.dispatcher.onRequest('git.forceDeletePreservedBranch', (p) =>
+      this.forceDeletePreservedBranch(p)
+    )
     this.dispatcher.onRequest('git.exec', (p, context) => this.exec(p, context))
     this.dispatcher.onRequest('git.clone', (p, context) => this.clone(p, context))
     this.dispatcher.onRequest('git.isGitRepo', (p) => this.isGitRepo(p))
@@ -986,6 +990,28 @@ export class GitHandler {
         throw new Error(normalizeGitErrorMessage(error))
       }
     })
+  }
+
+  private async forceDeletePreservedBranch(params: Record<string, unknown>) {
+    const repoPath = params.repoPath
+    const branchName = params.branchName
+    const expectedHead = params.expectedHead
+    if (
+      typeof repoPath !== 'string' ||
+      typeof branchName !== 'string' ||
+      typeof expectedHead !== 'string'
+    ) {
+      throw new Error('Invalid preserved branch force-delete request.')
+    }
+    // Why: an empty repoPath would resolve `cwd` to the relay's own process
+    // directory, running the destructive update-ref against the wrong repo. NUL
+    // bytes cannot reach git safely either; reject both at the boundary.
+    if (!repoPath || repoPath.includes('\0') || expectedHead.includes('\0')) {
+      throw new Error('Invalid preserved branch force-delete request.')
+    }
+    return this.runWithDiffDedupeClear(() =>
+      forceDeletePreservedRelayBranch(this.git.bind(this), repoPath, branchName, expectedHead)
+    )
   }
 
   private async isGitRepo(params: Record<string, unknown>) {


### PR DESCRIPTION
## What changes

Force-deleting a worktree's **preserved branch over SSH** now succeeds. Previously it failed with `Error: git subcommand not allowed: worktree` and left the branch behind on the remote host.

**What does not change:** the local (non-SSH) preserved-branch delete path is untouched, and this does not widen the relay's read-only `git.exec` allowlist — it adds one narrow, purpose-built RPC instead.

## Root cause

When a dirty worktree with an unmerged branch is force-deleted, Orca removes the worktree but preserves the branch and offers a "force delete branch" action. Over SSH that action called `forceDeleteLocalBranch`, which runs `git worktree list`, `git update-ref -d`, and `git config --remove-section` through the relay's generic `git.exec` handler. That handler validates every call against a read-only allowlist, which rejects `worktree`/`update-ref`/`config` writes — so the first command (`git worktree list`) threw `git subcommand not allowed: worktree`. The normal worktree-removal path never hit this because it uses a dedicated relay RPC (`git.removeWorktree`) that runs git through the relay's internal executor.

## Design approach

Add a dedicated relay RPC `git.forceDeletePreservedBranch` that performs the delete sequence relay-side (checked-out guard → `update-ref -d` at the expected head → restore-on-race → best-effort `config --remove-section`), exactly mirroring how `git.removeWorktree` already bypasses the allowlist. The SSH runtime and IPC handlers now call `SshGitProvider.forceDeletePreservedBranch`, which issues that RPC. The relay reuses the existing branch-cleanup body shared with `removeWorktreeOp`; an optional error-mapper is applied to **only** the `update-ref -d` step so the actionable "branch changed after the workspace was deleted" message is produced for the force-delete path without remapping the checked-out-guard message or regressing `removeWorktreeOp`'s "branch preserved (not fully merged)" outcome.

Alternatives considered and rejected during design review: widening the `git.exec` allowlist (weakens the deliberately read-only SSH boundary — `update-ref` is a general ref-write primitive), and a generic privileged-op RPC (over-abstraction vs the codebase's one-RPC-per-op pattern).

## Implementation notes / deviations from design

- `forceDeletePreservedRelayBranch` validates the branch name (empty/NUL/leading-`-`) and expected head before any git call.
- Relay handler rejects empty/NUL `repoPath` and NUL `expectedHead` at the RPC boundary (defense-in-depth: an empty `repoPath` would resolve `cwd` to the relay's process directory).
- `SshGitProvider.forceDeletePreservedBranch` maps a JSON-RPC "method not found" (older relay binary) to an actionable reconnect message rather than silently failing; it does not fall back to `provider.exec` (that is the path that fails).
- Added `forceDeletePreservedBranch?` to the `IGitProvider` contract (optional, mirroring `renameCurrentBranch?`).
- No deviations from the reviewed design.

## Headline behavior status

**Implemented** in production code on both the runtime RPC (`OrcaRuntimeService.forceDeletePreservedBranch`) and the IPC (`worktrees:forceDeletePreservedBranch`) SSH branches. Not fixture-only or dormant.

## Validation

**Design review:** ran to clean (no P0/P1; direction confirmed).

**Completeness verification:** confirmed every requirement and edge case implemented; flagged a missing runtime/IPC unit-test for the SSH path, which was then added.

**Perf audit:** no actionable findings. Net improvement — over SSH the old path issued one `git.exec` round-trip per git command; the new path issues a single RPC that runs all commands relay-side. No new polling, render, subscriber, or startup work. Rare one-shot user action; deterministic command/RPC-count tests are sufficient (added), no runtime measurement warranted.

**Code-review loop:** two independent reviewers per round. Round 1 surfaced two actionable items (validate empty/NUL `repoPath`+`expectedHead` at the RPC boundary; add relay dispatch-contract coverage for the new RPC) plus a contract nit (`IGitProvider`); a flagged test-file-length item was a false positive (test files allow 800 lines). All fixed. Round 2: both reviewers returned clean.

**brennan-test-changes (SSH end-to-end): verdict LAND.** Exercised the real flow against a throwaway Dockerized Linux SSH target (debian-slim + openssh + git, SSH on 127.0.0.1:2222; repo seeded via local git-bundle fallback since the container had no GitHub auth; Electron launched from this worktree with an isolated user-data dir and CDP port, identity verified before acting). Created a worktree over SSH on branch `test-6418-run2-...`, made it dirty with an unmerged commit, force-deleted the worktree (branch preserved at HEAD `45cc64e2…`), then invoked `worktrees:forceDeletePreservedBranch` (the exact IPC the force-delete button calls), which returned `{ deleted: true }`. Remote proof on `/work/demo-project`:

- before: `git show-ref` had `refs/heads/test-6418-run2-...` at `45cc64e2…`
- after: `git branch --list 'test-6418-*'` → **empty**; `git show-ref | grep test-6418` → **empty**; `git worktree list` → only `/work/demo-project [main]`
- **zero** `git subcommand not allowed` matches in the Playwright console, Electron main log, or remote relay log; the relay log confirms the preserved-branch path ran and completed without falling back through `git.exec`.

Relay-level real-git tests additionally prove the same deterministically (ref deleted at the expected head; refused when the head moved).

**Static checks / focused tests:** `pnpm run typecheck` passes; `oxlint` clean on all touched files; 809 tests pass across `git-handler.test.ts`, `git-handler-branch-cleanup.test.ts`, `ssh-git-provider.test.ts`, `orca-runtime.test.ts`, `worktrees.test.ts`. New tests cover: relay delete-at-expected-head success / ref-moved rejection / checked-out guard / concurrent-checkout restore / config-failure swallow / invalid input; that `removeWorktreeOp` still propagates the raw error (unchanged); provider RPC params + old-relay mapping + rethrow; runtime and IPC SSH branches route to the new provider method; and dispatcher-level real-git happy-path/ref-moved/empty-repoPath cases.

## Out of scope

The post-delete fork-remote cleanup (`cleanupUnusedWorktreePushTargetRemoteSsh`) also routes a `git remote remove` through the allowlist, but it is best-effort (try/catch that only warns), affects only fork-PR worktrees, is identical in the normal removal path, and is not part of the reported dirty-delete failure. Noted for a possible follow-up.

## Remaining risks / accepted gaps

During SSH validation the renderer's force-delete-preserved-branch **button** did not surface for this particular force-remove flow (the toast/panel hosting it is gated on a code path that doesn't fire for `force=true` removal of a dirty unmerged worktree on this baseline). Validation drove the exact IPC that button calls (`worktrees:forceDeletePreservedBranch`) with the same args, exercising the entire fixed relay/RPC path; surfacing the button is a separate concern, out of scope for this PR. No other accepted gaps.

Fixes #6418

Made with [Orca](https://github.com/stablyai/orca) 🐋

