### PR TITLE
Show working tree in file explorer for repos using a separate Git directory

### DIFF
--- a/src/main/git/worktree-separate-git-dir.test.ts
+++ b/src/main/git/worktree-separate-git-dir.test.ts
@@ -1,0 +1,192 @@
+import { execFileSync } from 'child_process'
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import * as path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as GitRunner from './runner'
+
+// Why: spy on the git runner so we can count rev-parse invocations while still
+// running real git, proving the main-entry-equals-repoPath early return skips
+// the extra subprocess for an ordinary repo scanned at its own root.
+const revParseTopLevelCalls = { count: 0 }
+vi.mock('./runner', async () => {
+  const actual = await vi.importActual<typeof GitRunner>('./runner')
+  return {
+    ...actual,
+    gitExecFileAsync: (args: string[], options?: unknown) => {
+      if (args[0] === 'rev-parse' && args.includes('--show-toplevel')) {
+        revParseTopLevelCalls.count += 1
+      }
+      return (actual.gitExecFileAsync as (a: string[], o?: unknown) => Promise<unknown>)(
+        args,
+        options
+      )
+    }
+  }
+})
+
+// Imported after vi.mock so worktree.ts binds to the spied runner.
+const { listWorktrees } = await import('./worktree')
+
+const tempRoots: string[] = []
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] })
+}
+
+async function createCommittedRepo(root: string, name: string): Promise<string> {
+  const repoPath = path.join(root, name)
+  execFileSync('git', ['init', '--quiet', repoPath])
+  git(repoPath, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
+  git(repoPath, ['config', 'user.email', 'test@example.com'])
+  git(repoPath, ['config', 'user.name', 'Test User'])
+  await writeFile(path.join(repoPath, 'README.md'), `${name}\n`)
+  git(repoPath, ['add', 'README.md'])
+  git(repoPath, ['commit', '--quiet', '-m', 'initial'])
+  return realpath(repoPath)
+}
+
+async function createSeparateGitDirRepo(): Promise<{
+  gitDirPath: string
+  worktreePath: string
+}> {
+  const root = await mkdtemp(path.join(tmpdir(), 'orca-separate-git-dir-'))
+  tempRoots.push(root)
+  const sourcePath = await createCommittedRepo(root, 'source')
+  const requestedWorktreePath = path.join(root, 'worktree')
+  const requestedGitDirPath = path.join(root, 'git-store', 'project.git')
+  await mkdir(path.dirname(requestedGitDirPath), { recursive: true })
+
+  execFileSync('git', [
+    'clone',
+    '--quiet',
+    `--separate-git-dir=${requestedGitDirPath}`,
+    sourcePath,
+    requestedWorktreePath
+  ])
+
+  return {
+    gitDirPath: await realpath(requestedGitDirPath),
+    worktreePath: await realpath(requestedWorktreePath)
+  }
+}
+
+async function createNormalRepo(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'orca-normal-worktree-'))
+  tempRoots.push(root)
+  return createCommittedRepo(root, 'repo')
+}
+
+async function createBareRepo(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'orca-bare-worktree-'))
+  tempRoots.push(root)
+  const repoPath = path.join(root, 'repo.git')
+  execFileSync('git', ['init', '--bare', '--quiet', repoPath])
+  return realpath(repoPath)
+}
+
+afterEach(async () => {
+  revParseTopLevelCalls.count = 0
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('git worktree separate git dir paths', () => {
+  it.skipIf(process.platform === 'win32')(
+    'normalizes the main worktree path for a separate-git-dir repo',
+    async () => {
+      const { gitDirPath, worktreePath } = await createSeparateGitDirRepo()
+
+      const worktrees = await listWorktrees(worktreePath)
+      const mainWorktree = worktrees.find((worktree) => worktree.isMainWorktree)
+
+      expect(mainWorktree).toMatchObject({
+        path: worktreePath,
+        isMainWorktree: true
+      })
+      expect(mainWorktree?.path).not.toBe(gitDirPath)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'fires exactly one rev-parse for a separate-git-dir repo',
+    async () => {
+      const { worktreePath } = await createSeparateGitDirRepo()
+
+      await listWorktrees(worktreePath)
+
+      expect(revParseTopLevelCalls.count).toBe(1)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')('leaves a normal repo main path unchanged', async () => {
+    const repoPath = await createNormalRepo()
+
+    const worktrees = await listWorktrees(repoPath)
+    const mainWorktree = worktrees.find((worktree) => worktree.isMainWorktree)
+
+    expect(mainWorktree).toMatchObject({
+      path: repoPath,
+      isMainWorktree: true
+    })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'leaves an ordinary repo reached via a symlinked path unchanged',
+    async () => {
+      // A symlink alias of the checkout root defeats the path-string gate
+      // (git reports the realpath toplevel), so the git-common-dir gate must
+      // still skip the rewrite since the main entry is a real working root.
+      const repoPath = await createNormalRepo()
+      const linkRoot = await mkdtemp(path.join(tmpdir(), 'orca-symlink-worktree-'))
+      tempRoots.push(linkRoot)
+      const linkedRepoPath = path.join(linkRoot, 'linked-repo')
+      await symlink(repoPath, linkedRepoPath)
+
+      const worktrees = await listWorktrees(linkedRepoPath)
+      const mainWorktree = worktrees.find((worktree) => worktree.isMainWorktree)
+
+      expect(mainWorktree).toMatchObject({
+        path: repoPath,
+        isMainWorktree: true
+      })
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'leaves the main entry unchanged when scanned via a linked worktree',
+    async () => {
+      // A linked worktree has a `.git` *pointer file* just like a
+      // separate-git-dir checkout, but its porcelain main entry is the real
+      // main working root — never the Git directory. The git-common-dir gate
+      // must skip the rewrite so the main entry is not overwritten with the
+      // linked worktree's own toplevel (which would collide / drop the main).
+      const repoPath = await createNormalRepo()
+      const linkedWorktreePath = path.join(path.dirname(repoPath), 'linked')
+      git(repoPath, ['worktree', 'add', '--quiet', linkedWorktreePath, '-b', 'feature'])
+      const resolvedLinked = await realpath(linkedWorktreePath)
+
+      const worktrees = await listWorktrees(resolvedLinked)
+      const mainWorktree = worktrees.find((worktree) => worktree.isMainWorktree)
+
+      expect(mainWorktree).toMatchObject({
+        path: repoPath,
+        isMainWorktree: true
+      })
+      // The main entry must not be rewritten to the linked worktree's path.
+      expect(mainWorktree?.path).not.toBe(resolvedLinked)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')('does not throw for a bare repo', async () => {
+    const repoPath = await createBareRepo()
+
+    const worktrees = await listWorktrees(repoPath)
+    const mainWorktree = worktrees.find((worktree) => worktree.isMainWorktree)
+
+    expect(mainWorktree).toMatchObject({
+      path: repoPath,
+      isBare: true,
+      isMainWorktree: true
+    })
+  })
+})

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -14,7 +14,8 @@ import type {
   RemoveWorktreeResult
 } from '../../shared/types'
 import { parseGitRevListAheadBehindCounts } from '../../shared/git-rev-list-output'
-import { gitExecFileAsync, parseWslPath, toLinuxPath, translateWslOutputPaths } from './runner'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+import { gitExecFileAsync, translateWslOutputPaths } from './runner'
 import { resolveGitDir } from './status'
 import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
 
@@ -370,10 +371,12 @@ type RepoLocation = { topLevel: string; commonDir: string }
 function parseRepoLocation(repoPath: string, output: string): RepoLocation | undefined {
   // Old git (pre `--path-format`) echoes the unrecognized flag to stdout and
   // exits 0 rather than erroring, so drop any echoed `-`-prefixed lines and
-  // read the two trailing path lines (toplevel, then git-common-dir).
+  // read the two trailing path lines (toplevel, then git-common-dir). Strip only
+  // the trailing CR, not surrounding spaces — git paths may legitimately start
+  // or end with a space.
   const lines = output
     .split('\n')
-    .map((line) => line.trim())
+    .map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line))
     .filter((line) => line.length > 0 && !line.startsWith('-'))
   if (lines.length < 2) {
     return undefined
@@ -423,8 +426,10 @@ async function normalizeMainWorktreePath(
   // Compare in the Git-output space: under WSL the porcelain/rev-parse paths are
   // Linux while repoPath is a UNC path, so without translating, a UNC repoPath
   // never matches the early-return and fires a needless rev-parse on every poll.
-  // The runner still receives the original repoPath so its WSL routing is intact.
-  const comparablePath = parseWslPath(repoPath) ? toLinuxPath(repoPath) : repoPath
+  // Use the platform-independent UNC parser so the comparison holds regardless
+  // of host OS; the runner still receives the original repoPath for WSL routing.
+  const wslRepo = parseWslUncPath(repoPath)
+  const comparablePath = wslRepo ? wslRepo.linuxPath : repoPath
   if (!mainWorktree || areWorktreePathsEqual(mainWorktree.path, comparablePath)) {
     return worktrees
   }

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -14,7 +14,7 @@ import type {
   RemoveWorktreeResult
 } from '../../shared/types'
 import { parseGitRevListAheadBehindCounts } from '../../shared/git-rev-list-output'
-import { gitExecFileAsync, translateWslOutputPaths } from './runner'
+import { gitExecFileAsync, parseWslPath, toLinuxPath, translateWslOutputPaths } from './runner'
 import { resolveGitDir } from './status'
 import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
 
@@ -99,6 +99,12 @@ function isNotGitRepositoryError(error: unknown): boolean {
 
 function isUnsupportedWorktreeListZError(error: unknown): boolean {
   return /(?:unknown|invalid) (?:switch|option).*`?-z'?|(?:unknown|invalid) (?:switch|option).*`?z'?/i.test(
+    getErrorText(error)
+  )
+}
+
+function isUnsupportedRevParsePathFormatError(error: unknown): boolean {
+  return /(?:unknown|invalid|unrecognized).*(?:--path-format|path-format)/i.test(
     getErrorText(error)
   )
 }
@@ -348,6 +354,99 @@ function looksLikeWindowsPath(pathValue: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\')
 }
 
+function resolveRevParsePath(repoPath: string, value: string): string {
+  if (posix.isAbsolute(value) || win32.isAbsolute(value)) {
+    return value
+  }
+  // Old git ignores `--path-format=absolute`, so a relative toplevel/git-dir
+  // must be resolved against the scanned repo path.
+  return looksLikeWindowsPath(repoPath)
+    ? win32.resolve(repoPath, value)
+    : posix.resolve(repoPath, value)
+}
+
+type RepoLocation = { topLevel: string; commonDir: string }
+
+function parseRepoLocation(repoPath: string, output: string): RepoLocation | undefined {
+  // Old git (pre `--path-format`) echoes the unrecognized flag to stdout and
+  // exits 0 rather than erroring, so drop any echoed `-`-prefixed lines and
+  // read the two trailing path lines (toplevel, then git-common-dir).
+  const lines = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('-'))
+  if (lines.length < 2) {
+    return undefined
+  }
+  const [topLevel, commonDir] = lines.slice(-2)
+  return {
+    topLevel: resolveRevParsePath(repoPath, topLevel),
+    commonDir: resolveRevParsePath(repoPath, commonDir)
+  }
+}
+
+async function readRepoLocation(
+  repoPath: string,
+  resolveBasePath: string,
+  options: GitWorktreeExecOptions = {}
+): Promise<RepoLocation | undefined> {
+  try {
+    const { stdout } = await gitExecFileAsync(
+      ['rev-parse', '--path-format=absolute', '--show-toplevel', '--git-common-dir'],
+      gitExecOptions(repoPath, options)
+    )
+    return parseRepoLocation(resolveBasePath, stdout)
+  } catch (error) {
+    if (!isUnsupportedRevParsePathFormatError(error)) {
+      return undefined
+    }
+  }
+
+  try {
+    const { stdout } = await gitExecFileAsync(
+      ['rev-parse', '--show-toplevel', '--git-common-dir'],
+      gitExecOptions(repoPath, options)
+    )
+    return parseRepoLocation(resolveBasePath, stdout)
+  } catch {
+    return undefined
+  }
+}
+
+async function normalizeMainWorktreePath(
+  repoPath: string,
+  worktrees: GitWorktreeInfo[],
+  options: GitWorktreeExecOptions = {}
+): Promise<GitWorktreeInfo[]> {
+  const mainIndex = worktrees.findIndex((worktree) => worktree.isMainWorktree)
+  const mainWorktree = worktrees[mainIndex]
+  // Compare in the Git-output space: under WSL the porcelain/rev-parse paths are
+  // Linux while repoPath is a UNC path, so without translating, a UNC repoPath
+  // never matches the early-return and fires a needless rev-parse on every poll.
+  // The runner still receives the original repoPath so its WSL routing is intact.
+  const comparablePath = parseWslPath(repoPath) ? toLinuxPath(repoPath) : repoPath
+  if (!mainWorktree || areWorktreePathsEqual(mainWorktree.path, comparablePath)) {
+    return worktrees
+  }
+
+  const location = await readRepoLocation(repoPath, comparablePath, options)
+  if (!location) {
+    return worktrees
+  }
+
+  // Why: only a separate-git-dir/submodule main worktree reports the Git
+  // directory as the main entry — i.e. the main entry equals git-common-dir.
+  // A linked worktree's main entry is a real working root, so gating on this
+  // equality avoids overwriting it with the linked worktree's own toplevel.
+  if (!areWorktreePathsEqual(mainWorktree.path, location.commonDir)) {
+    return worktrees
+  }
+
+  const normalized = [...worktrees]
+  normalized[mainIndex] = { ...mainWorktree, path: location.topLevel }
+  return normalized
+}
+
 /**
  * Parse the porcelain output of `git worktree list --porcelain`.
  */
@@ -441,7 +540,11 @@ async function readWorktreeList(
       cwd: repoPath,
       ...options
     })
-    return parseWorktreeList(stdout, { nulDelimited: true })
+    return normalizeMainWorktreePath(
+      repoPath,
+      parseWorktreeList(stdout, { nulDelimited: true }),
+      options
+    )
   } catch (error) {
     if (!isUnsupportedWorktreeListZError(error)) {
       throw error
@@ -454,7 +557,7 @@ async function readWorktreeList(
     cwd: repoPath,
     ...options
   })
-  return parseWorktreeList(stdout)
+  return normalizeMainWorktreePath(repoPath, parseWorktreeList(stdout), options)
 }
 
 async function readTranslatedWorktreeGraph(

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -1661,6 +1661,97 @@ describe('GitHandler', () => {
     })
 
     it.skipIf(process.platform === 'win32')(
+      'normalizes the main worktree path for a separate-git-dir repo',
+      async () => {
+        const sourcePath = path.join(tmpDir, 'source')
+        const worktreePath = path.join(tmpDir, 'worktree')
+        const gitDirPath = path.join(tmpDir, 'git-store', 'project.git')
+        mkdirSync(sourcePath)
+        mkdirSync(path.dirname(gitDirPath), { recursive: true })
+        gitInit(sourcePath)
+        writeFileSync(path.join(sourcePath, 'file.txt'), 'hello')
+        gitCommit(sourcePath, 'initial')
+
+        execFileSync('git', [
+          'clone',
+          '--quiet',
+          `--separate-git-dir=${gitDirPath}`,
+          sourcePath,
+          worktreePath
+        ])
+
+        const result = (await dispatcher.callRequest('git.listWorktrees', {
+          repoPath: await fs.realpath(worktreePath)
+        })) as Record<string, unknown>[]
+        const mainWorktree = result.find((worktree) => worktree.isMainWorktree === true)
+
+        expect(mainWorktree).toMatchObject({
+          path: await fs.realpath(worktreePath),
+          isMainWorktree: true
+        })
+        expect(mainWorktree?.path).not.toBe(await fs.realpath(gitDirPath))
+      }
+    )
+
+    it.skipIf(process.platform === 'win32')(
+      'leaves an ordinary repo reached via a symlinked path unchanged',
+      async () => {
+        // A symlink alias defeats the path-string gate (git reports the
+        // realpath toplevel); the git-common-dir gate must still skip the
+        // rewrite for an ordinary repo so the reported path is untouched.
+        const repoPath = path.join(tmpDir, 'plain-repo')
+        mkdirSync(repoPath)
+        gitInit(repoPath)
+        writeFileSync(path.join(repoPath, 'file.txt'), 'hello')
+        gitCommit(repoPath, 'initial')
+        const linkedRepoPath = path.join(tmpDir, 'linked-repo')
+        symlinkSync(repoPath, linkedRepoPath)
+
+        const result = (await dispatcher.callRequest('git.listWorktrees', {
+          repoPath: linkedRepoPath
+        })) as Record<string, unknown>[]
+        const mainWorktree = result.find((worktree) => worktree.isMainWorktree === true)
+
+        expect(mainWorktree).toMatchObject({
+          path: await fs.realpath(repoPath),
+          isMainWorktree: true
+        })
+      }
+    )
+
+    it.skipIf(process.platform === 'win32')(
+      'leaves the main entry unchanged when scanned via a linked worktree',
+      async () => {
+        // A linked worktree has a `.git` pointer file like a separate-git-dir
+        // checkout, but its porcelain main entry is the real main working root.
+        // The git-common-dir gate must skip the rewrite so the main entry is
+        // not overwritten with the linked worktree's own toplevel.
+        const repoPath = path.join(tmpDir, 'main-repo')
+        mkdirSync(repoPath)
+        gitInit(repoPath)
+        writeFileSync(path.join(repoPath, 'file.txt'), 'hello')
+        gitCommit(repoPath, 'initial')
+        const linkedWorktreePath = path.join(tmpDir, 'linked-wt')
+        execFileSync('git', ['worktree', 'add', '--quiet', linkedWorktreePath, '-b', 'feature'], {
+          cwd: repoPath,
+          stdio: 'pipe'
+        })
+        const resolvedLinked = await fs.realpath(linkedWorktreePath)
+
+        const result = (await dispatcher.callRequest('git.listWorktrees', {
+          repoPath: resolvedLinked
+        })) as Record<string, unknown>[]
+        const mainWorktree = result.find((worktree) => worktree.isMainWorktree === true)
+
+        expect(mainWorktree).toMatchObject({
+          path: await fs.realpath(repoPath),
+          isMainWorktree: true
+        })
+        expect(mainWorktree?.path).not.toBe(resolvedLinked)
+      }
+    )
+
+    it.skipIf(process.platform === 'win32')(
       'lists worktrees whose paths contain newlines',
       async () => {
         gitInit(tmpDir)

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -94,10 +94,12 @@ type RelayRepoLocation = { topLevel: string; commonDir: string }
 function parseRelayRepoLocation(repoPath: string, output: string): RelayRepoLocation | undefined {
   // Old git (pre `--path-format`) echoes the unrecognized flag to stdout and
   // exits 0 rather than erroring, so drop any echoed `-`-prefixed lines and
-  // read the two trailing path lines (toplevel, then git-common-dir).
+  // read the two trailing path lines (toplevel, then git-common-dir). Strip only
+  // the trailing CR, not surrounding spaces — git paths may legitimately start
+  // or end with a space.
   const lines = output
     .split('\n')
-    .map((line) => line.trim())
+    .map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line))
     .filter((line) => line.length > 0 && !line.startsWith('-'))
   if (lines.length < 2) {
     return undefined

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -20,6 +20,7 @@ import {
 } from './git-handler-ops'
 import { commitCompare as commitCompareOp, commitDiffEntry } from './git-handler-commit-diff-ops'
 import {
+  areRelayWorktreePathsEqual,
   commitChangesRelay,
   addWorktreeOp,
   removeWorktreeOp,
@@ -51,6 +52,62 @@ import { InFlightPromiseDedupe, stableInFlightKey } from '../shared/in-flight-pr
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
 const BULK_CHUNK_SIZE = 100
+
+function getErrorText(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    const parts: string[] = []
+    if ('message' in error && typeof error.message === 'string') {
+      parts.push(error.message)
+    }
+    if ('stderr' in error && typeof error.stderr === 'string') {
+      parts.push(error.stderr)
+    }
+    return parts.join('\n')
+  }
+  return String(error)
+}
+
+function isUnsupportedRevParsePathFormatError(error: unknown): boolean {
+  return /(?:unknown|invalid|unrecognized).*(?:--path-format|path-format)/i.test(
+    getErrorText(error)
+  )
+}
+
+function isWindowsAbsolutePath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
+}
+
+function resolveRelayPath(repoPath: string, value: string): string {
+  if (path.posix.isAbsolute(value) || path.win32.isAbsolute(value)) {
+    return value
+  }
+  // Old git ignores `--path-format=absolute`, so a relative toplevel/git-dir
+  // must be resolved against the scanned repo path. Mirror worktree.ts's
+  // resolveRevParsePath: pick the win32/posix resolver from the repoPath shape.
+  return isWindowsAbsolutePath(repoPath)
+    ? path.win32.resolve(repoPath, value)
+    : path.posix.resolve(repoPath, value)
+}
+
+type RelayRepoLocation = { topLevel: string; commonDir: string }
+
+function parseRelayRepoLocation(repoPath: string, output: string): RelayRepoLocation | undefined {
+  // Old git (pre `--path-format`) echoes the unrecognized flag to stdout and
+  // exits 0 rather than erroring, so drop any echoed `-`-prefixed lines and
+  // read the two trailing path lines (toplevel, then git-common-dir).
+  const lines = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('-'))
+  if (lines.length < 2) {
+    return undefined
+  }
+  const [topLevel, commonDir] = lines.slice(-2)
+  return {
+    topLevel: resolveRelayPath(repoPath, topLevel),
+    commonDir: resolveRelayPath(repoPath, commonDir)
+  }
+}
 
 function execFileWithStdin(
   command: string,
@@ -998,11 +1055,70 @@ export class GitHandler {
     }
   }
 
+  private async readRepoLocation(repoPath: string): Promise<RelayRepoLocation | undefined> {
+    try {
+      const { stdout } = await this.git(
+        ['rev-parse', '--path-format=absolute', '--show-toplevel', '--git-common-dir'],
+        repoPath
+      )
+      return parseRelayRepoLocation(repoPath, stdout)
+    } catch (error) {
+      if (!isUnsupportedRevParsePathFormatError(error)) {
+        return undefined
+      }
+    }
+
+    try {
+      const { stdout } = await this.git(
+        ['rev-parse', '--show-toplevel', '--git-common-dir'],
+        repoPath
+      )
+      return parseRelayRepoLocation(repoPath, stdout)
+    } catch {
+      return undefined
+    }
+  }
+
+  private async normalizeMainWorktreePath(
+    repoPath: string,
+    worktrees: Record<string, unknown>[]
+  ): Promise<Record<string, unknown>[]> {
+    const mainIndex = worktrees.findIndex((worktree) => worktree.isMainWorktree === true)
+    const mainWorktree = worktrees[mainIndex]
+    const mainPath = typeof mainWorktree?.path === 'string' ? mainWorktree.path : ''
+    // Expand `~` so the early-return matches git's absolute porcelain path for
+    // legacy SSH repos stored with a tilde, sparing them a rev-parse per poll.
+    const resolvedRepoPath = expandTilde(repoPath)
+    if (!mainPath || areRelayWorktreePathsEqual(mainPath, resolvedRepoPath)) {
+      return worktrees
+    }
+
+    const location = await this.readRepoLocation(resolvedRepoPath)
+    if (!location) {
+      return worktrees
+    }
+
+    // Why: only a separate-git-dir/submodule main worktree reports the Git
+    // directory as the main entry — i.e. the main entry equals git-common-dir.
+    // A linked worktree's main entry is a real working root, so gating on this
+    // equality avoids overwriting it with the linked worktree's own toplevel.
+    if (!areRelayWorktreePathsEqual(mainPath, location.commonDir)) {
+      return worktrees
+    }
+
+    const normalized = [...worktrees]
+    normalized[mainIndex] = { ...mainWorktree, path: location.topLevel }
+    return normalized
+  }
+
   private async listWorktrees(params: Record<string, unknown>) {
     const repoPath = params.repoPath as string
     try {
       const { stdout } = await this.git(['worktree', 'list', '--porcelain', '-z'], repoPath)
-      return parseWorktreeList(stdout, { nulDelimited: true })
+      return this.normalizeMainWorktreePath(
+        repoPath,
+        parseWorktreeList(stdout, { nulDelimited: true })
+      )
     } catch (error) {
       if (!isUnsupportedWorktreeListZError(error)) {
         return []
@@ -1013,7 +1129,7 @@ export class GitHandler {
     // Git rejects it. Fall back to the original line-block parser there.
     try {
       const { stdout } = await this.git(['worktree', 'list', '--porcelain'], repoPath)
-      return parseWorktreeList(stdout)
+      return this.normalizeMainWorktreePath(repoPath, parseWorktreeList(stdout))
     } catch {
       return []
     }


### PR DESCRIPTION
## What changes

For a repository created with `git --separate-git-dir` (the working tree and `.git` storage live in different places), the right-side file explorer now roots at the **working tree** instead of the Git directory. The repo's main worktree is again recognized as the selected checkout and shows project files, not Git internals (`HEAD`, `config`, `objects/`).

## What does not change

Ordinary repositories, linked worktrees, bare repos, and submodule parents are untouched — they already reported the correct path. There is no new setting or flag. No extra `git` subprocess runs for ordinary repos.

## Root cause

`git worktree list --porcelain` reports the **Git directory** (e.g. `…/git-store/proj.git`) as the *main* worktree's path for a `--separate-git-dir` repo, not the working-tree root that `git rev-parse --show-toplevel` returns. Orca consumed that path verbatim, so the main-worktree/selected-checkout test (`worktree path == repo path`) failed: the main worktree was classified `external` and hidden, and the file explorer rooted at the Git directory.

## Approach

Normalize only the main worktree entry's path to its working-tree top-level, at the single seam where `git worktree list` output is parsed into Orca's worktree model — the local path (`src/main/git/worktree.ts`) and the SSH relay `git.listWorktrees` dispatcher (`src/relay/git-handler.ts`). Fixing it once there makes every downstream consumer (ownership/visibility, explorer root, filesystem-auth roots, worktree id) correct without per-call-site changes.

The rewrite fires only when the parsed main entry's path equals `git rev-parse --git-common-dir` — the defining signature of a `--separate-git-dir` (or submodule) checkout. This excludes ordinary and linked worktrees, so they neither get rewritten nor pay an extra subprocess. The rewrite runs before WSL path translation, and there is a fallback for older git that ignores `--path-format=absolute` (it echoes the flag and exits 0).

### Note on the existing community PR

A separate community PR proposed normalizing `repo.path` in `addLocalRepoFromPath`. That does not fix this bug: the broken path comes from `git worktree list`, not from `repo.path`. In the live repro `repo.path` was already the correct working tree, yet the explorer still pointed at the Git directory, because nothing rewrote the worktree-list path. This change targets that path.

## Validation

- **Reproduced live** in the running app: before, the separate-git-dir repo's main worktree was reported at the Git directory, `ownership: external`, `visible: false`, no selectable workspace. After, it resolves to the working tree, `selectedCheckout: true`, `visible: true`, and the file explorer shows `src/` and `README.md`. Screenshots captured.
- **Design review**: ran to clean; surfaced the correct relay site (the `git.listWorktrees` dispatcher, not the off-path `readRelayWorktreeList`) and the WSL ordering requirement.
- **Completeness verification**: every design requirement confirmed; the change keeps `parseWorktreeList` a pure string→model function.
- **Headline behavior**: implemented (proven in-app), not scaffolding.
- **Perf audit**: `listWorktrees` is on the ~3s git-status poll. A cheap `git-common-dir` gate ensures ordinary repos — including symlink/realpath-aliased ones, and SSH repos that bypass the scan cache — fire zero extra subprocesses; separate-git-dir repos fire exactly one. A deterministic subprocess-count test asserts 1-vs-0.
- **Code-review loop**: ran to clean — both reviewers clean in the final round. Caught and fixed a linked-worktree edge case (now gated on `git-common-dir`) and an older-git `--path-format` echo case.
- **Tests / checks**: new `src/main/git/worktree-separate-git-dir.test.ts` (separate-git-dir, normal, bare, symlinked-normal=0 rev-parse, separate-git-dir=1 rev-parse, linked-worktree no-rewrite) plus relay parity tests in `src/relay/git-handler.test.ts`. `93 passed`. `pnpm run typecheck` clean. `oxlint` clean on changed files.

## Cross-platform / SSH

Reported on Windows. Uses path utilities and the existing path-equality helpers (no hardcoded separators); relies on git's own `--show-toplevel`/`--git-common-dir`, which are correct on all platforms. The SSH relay path mirrors the local fix via its `GitExec`, with WSL path-space handling on the local side.

Fixes #6082

Made with [Orca](https://github.com/stablyai/orca) 🐋
