### PR TITLE
Fix Windows ConPTY scrollback corruption

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -159,6 +159,31 @@ describe('createPtySubprocess', () => {
     )
   })
 
+  it('uses bundled ConPTY for native Windows daemon terminals', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        env: { COMSPEC: 'C:\\Windows\\System32\\cmd.exe' }
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock.mock.calls.at(-1)?.[2]).toEqual(
+      expect.objectContaining({ useConptyDll: true })
+    )
+  })
+
   it('suppresses the first-run Powerlevel10k wizard for daemon terminals', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -636,7 +636,10 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       cols: size.cols,
       rows: size.rows,
       cwd: spawnCwd,
-      env
+      env,
+      // Why: bundled ConPTY has the modern wrap-marker behavior xterm expects;
+      // legacy system ConPTY can corrupt full-width TUI rows in scrollback.
+      ...(process.platform === 'win32' ? { useConptyDll: true } : {})
     })
   } catch (err) {
     if (process.platform === 'win32') {

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest'
+import { Terminal } from '@xterm/headless'
 import {
   buildWindowsPtyCompatibilityOptions,
   isLocalNativeWindowsConpty,
   isLocalNativeWindowsPty
 } from './windows-pty-compatibility'
+
+function writeTerminal(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve))
+}
 
 describe('buildWindowsPtyCompatibilityOptions', () => {
   it('returns ConPTY compatibility options for local Windows terminals', () => {
@@ -34,6 +39,40 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
     ).toEqual({
       windowsPty: { backend: 'conpty' }
     })
+  })
+
+  it('omits old Windows build numbers so xterm does not enable lossy wrap heuristics', () => {
+    expect(
+      buildWindowsPtyCompatibilityOptions({
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        osRelease: '10.0.19045',
+        connectionId: null,
+        cwd: 'C:\\repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      })
+    ).toEqual({
+      windowsPty: { backend: 'conpty' }
+    })
+  })
+
+  it('keeps full-width status rows from being falsely joined to following scrollback', async () => {
+    const cols = 20
+    const windowsPty = buildWindowsPtyCompatibilityOptions({
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      osRelease: '10.0.19045',
+      connectionId: null,
+      cwd: 'C:\\repo',
+      shellOverride: null,
+      executionHostId: 'local'
+    }).windowsPty
+    const terminal = new Terminal({ cols, rows: 5, windowsPty })
+
+    await writeTerminal(terminal, `${'S'.repeat(cols)}\r\nNEXT\r\n`)
+
+    expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('S'.repeat(cols))
+    expect(terminal.buffer.active.getLine(1)?.translateToString(true)).toBe('NEXT')
+    expect(terminal.buffer.active.getLine(1)?.isWrapped).toBe(false)
   })
 
   it('skips compatibility options for SSH-backed Windows terminals', () => {

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
@@ -31,6 +31,17 @@ function parseWindowsBuildNumber(osRelease: string | null | undefined): number |
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
 }
 
+function buildXtermWindowsPtyOptions(
+  buildNumber: number | undefined
+): NonNullable<ITerminalOptions['windowsPty']> {
+  // Why: old system ConPTY does not provide reliable wrap markers; passing the
+  // low build number makes xterm mark full-width status rows as wrapped.
+  if (buildNumber === undefined || buildNumber < 21376) {
+    return { backend: 'conpty' }
+  }
+  return { backend: 'conpty', buildNumber }
+}
+
 /**
  * xterm options that select the native-Windows ConPTY backend, returned only for
  * a genuine local Windows pane and `{}` otherwise.
@@ -47,10 +58,7 @@ export function buildWindowsPtyCompatibilityOptions(
   }
   const buildNumber = parseWindowsBuildNumber(context.osRelease)
   return {
-    // Why: native Windows shells are backed by ConPTY, and xterm's dedicated
-    // compatibility heuristics need the OS build to choose the right wrap path.
-    windowsPty:
-      buildNumber === undefined ? { backend: 'conpty' } : { backend: 'conpty', buildNumber }
+    windowsPty: buildXtermWindowsPtyOptions(buildNumber)
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid passing legacy Windows build numbers into the terminal renderer's ConPTY compatibility options, preventing the old full-width-row wrap heuristic from corrupting scrollback
- spawn native Windows daemon PTYs with node-pty's bundled ConPTY implementation
- add a deterministic reproduction for the false wrap marker after a full-width TUI/status row, plus a spawn-option regression test

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts src/main/daemon/pty-subprocess.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts src/main/daemon/pty-subprocess.ts src/main/daemon/pty-subprocess.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts src/main/daemon/pty-subprocess.ts src/main/daemon/pty-subprocess.test.ts`

Fixes #5345