### PR TITLE
Fix Orca CLI path resolution and improve registration UI

### DIFF
--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -624,6 +624,249 @@ describe('CliInstaller', () => {
     }
   )
 
+  // Why: users can have a managed Orca command in ~/.local/bin even when
+  // /usr/local/bin exists; Settings must follow the shell-visible command.
+  it.skipIf(process.platform === 'win32')(
+    'uses an existing managed macOS orca command from the shell PATH before /usr/local/bin',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const resourcesPath = await createPackagedMacLauncher(fixture.root)
+      const usrLocalBin = join(fixture.root, 'usr', 'local', 'bin')
+      const userLocalBin = join(homePath, '.local', 'bin')
+      const defaultInstallPath = join(usrLocalBin, 'orca')
+      const userInstallPath = join(userLocalBin, 'orca')
+      const launcherPath = join(resourcesPath, 'bin', 'orca')
+      await mkdir(usrLocalBin, { recursive: true })
+      await mkdir(userLocalBin, { recursive: true })
+      await symlink(launcherPath, userInstallPath)
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        resourcesPath,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        homePath,
+        defaultMacCommandPath: defaultInstallPath,
+        processPathEnv: `${userLocalBin}:${usrLocalBin}`
+      })
+
+      const status = await installer.getStatus()
+      expect(status.state).toBe('installed')
+      expect(status.commandPath).toBe(userInstallPath)
+      expect(status.pathConfigured).toBe(true)
+
+      const installed = await installer.install()
+      expect(installed.commandPath).toBe(userInstallPath)
+      await expect(readlink(userInstallPath)).resolves.toBe(launcherPath)
+      await expect(lstat(defaultInstallPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    }
+  )
+
+  // Why: POSIX command lookup skips broken symlinks and keeps searching PATH,
+  // so a stale earlier artifact must not steal status from the install path.
+  it.skipIf(process.platform === 'win32')(
+    'skips a broken managed macOS orca symlink before /usr/local/bin',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const resourcesPath = await createPackagedMacLauncher(fixture.root)
+      const usrLocalBin = join(fixture.root, 'usr', 'local', 'bin')
+      const userLocalBin = join(homePath, '.local', 'bin')
+      const defaultInstallPath = join(usrLocalBin, 'orca')
+      const userInstallPath = join(userLocalBin, 'orca')
+      const launcherPath = join(resourcesPath, 'bin', 'orca')
+      const oldLauncherPath = join(fixture.root, 'Old.app', 'Contents', 'Resources', 'bin', 'orca')
+      await mkdir(usrLocalBin, { recursive: true })
+      await mkdir(userLocalBin, { recursive: true })
+      await symlink(oldLauncherPath, userInstallPath)
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        resourcesPath,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        homePath,
+        defaultMacCommandPath: defaultInstallPath,
+        processPathEnv: `${userLocalBin}:${usrLocalBin}`
+      })
+
+      const status = await installer.getStatus()
+      expect(status).toMatchObject({
+        commandPath: defaultInstallPath,
+        state: 'not_installed',
+        currentTarget: null
+      })
+
+      const installed = await installer.install()
+      expect(installed.commandPath).toBe(defaultInstallPath)
+      expect(installed.state).toBe('installed')
+      await expect(readlink(defaultInstallPath)).resolves.toBe(launcherPath)
+      await expect(readlink(userInstallPath)).resolves.toBe(oldLauncherPath)
+    }
+  )
+
+  // Why: PATH lookup stops at the first existing command; a later managed
+  // ~/.local/bin/orca must not steal status from /usr/local/bin/orca.
+  it.skipIf(process.platform === 'win32')(
+    'keeps the default macOS command when a managed orca appears later on PATH',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const resourcesPath = await createPackagedMacLauncher(fixture.root)
+      const usrLocalBin = join(fixture.root, 'usr', 'local', 'bin')
+      const userLocalBin = join(homePath, '.local', 'bin')
+      const defaultInstallPath = join(usrLocalBin, 'orca')
+      const userInstallPath = join(userLocalBin, 'orca')
+      const launcherPath = join(resourcesPath, 'bin', 'orca')
+      await mkdir(usrLocalBin, { recursive: true })
+      await mkdir(userLocalBin, { recursive: true })
+      await symlink(launcherPath, defaultInstallPath)
+      await symlink(launcherPath, userInstallPath)
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        resourcesPath,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        homePath,
+        defaultMacCommandPath: defaultInstallPath,
+        processPathEnv: `${usrLocalBin}:${userLocalBin}`
+      })
+
+      const status = await installer.getStatus()
+      expect(status.commandPath).toBe(defaultInstallPath)
+      expect(status.state).toBe('installed')
+    }
+  )
+
+  // Why: an off-PATH ~/.local/bin/orca must not hijack CLI registration and
+  // leave the shell-visible /usr/local/bin command missing.
+  it.skipIf(process.platform === 'win32')(
+    'ignores managed macOS orca commands that are not visible on the shell PATH',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const resourcesPath = await createPackagedMacLauncher(fixture.root)
+      const usrLocalBin = join(fixture.root, 'usr', 'local', 'bin')
+      const userLocalBin = join(homePath, '.local', 'bin')
+      const defaultInstallPath = join(usrLocalBin, 'orca')
+      const userInstallPath = join(userLocalBin, 'orca')
+      const launcherPath = join(resourcesPath, 'bin', 'orca')
+      await mkdir(usrLocalBin, { recursive: true })
+      await mkdir(userLocalBin, { recursive: true })
+      await symlink(launcherPath, userInstallPath)
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        resourcesPath,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        homePath,
+        defaultMacCommandPath: defaultInstallPath,
+        processPathEnv: usrLocalBin
+      })
+
+      const status = await installer.getStatus()
+      expect(status.commandPath).toBe(defaultInstallPath)
+      expect(status.pathConfigured).toBe(true)
+      expect(status.state).toBe('not_installed')
+
+      const installed = await installer.install()
+      expect(installed.commandPath).toBe(defaultInstallPath)
+      expect(installed.state).toBe('installed')
+      await expect(readlink(defaultInstallPath)).resolves.toBe(launcherPath)
+      await expect(readlink(userInstallPath)).resolves.toBe(launcherPath)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'reports a conflict for an unmanaged macOS orca that shadows the install path',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const resourcesPath = await createPackagedMacLauncher(fixture.root)
+      const usrLocalBin = join(fixture.root, 'usr', 'local', 'bin')
+      const userLocalBin = join(homePath, '.local', 'bin')
+      const defaultInstallPath = join(usrLocalBin, 'orca')
+      const userInstallPath = join(userLocalBin, 'orca')
+      await mkdir(usrLocalBin, { recursive: true })
+      await mkdir(userLocalBin, { recursive: true })
+      await writeFile(userInstallPath, '#!/usr/bin/env bash\necho other-orca\n', {
+        encoding: 'utf8',
+        mode: 0o755
+      })
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        resourcesPath,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        homePath,
+        defaultMacCommandPath: defaultInstallPath,
+        processPathEnv: `${userLocalBin}:${usrLocalBin}`
+      })
+
+      const status = await installer.getStatus()
+      expect(status.commandPath).toBe(userInstallPath)
+      expect(status.state).toBe('conflict')
+      await expect(installer.install()).rejects.toThrow('Refusing to replace non-Orca command')
+      await expect(lstat(defaultInstallPath)).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(readFile(userInstallPath, 'utf8')).resolves.toContain('other-orca')
+    }
+  )
+
+  // Why: bash/zsh skip non-executable PATH entries, so reporting them as a
+  // conflict would block a valid later install path the shell would use.
+  it.skipIf(process.platform === 'win32')(
+    'skips a non-executable unmanaged macOS orca before the install path',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const resourcesPath = await createPackagedMacLauncher(fixture.root)
+      const usrLocalBin = join(fixture.root, 'usr', 'local', 'bin')
+      const userLocalBin = join(homePath, '.local', 'bin')
+      const defaultInstallPath = join(usrLocalBin, 'orca')
+      const userInstallPath = join(userLocalBin, 'orca')
+      const launcherPath = join(resourcesPath, 'bin', 'orca')
+      await mkdir(usrLocalBin, { recursive: true })
+      await mkdir(userLocalBin, { recursive: true })
+      await writeFile(userInstallPath, '#!/usr/bin/env bash\necho other-orca\n', 'utf8')
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        resourcesPath,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        homePath,
+        defaultMacCommandPath: defaultInstallPath,
+        processPathEnv: `${userLocalBin}:${usrLocalBin}`
+      })
+
+      const status = await installer.getStatus()
+      expect(status.commandPath).toBe(defaultInstallPath)
+      expect(status.state).toBe('not_installed')
+
+      const installed = await installer.install()
+      expect(installed.commandPath).toBe(defaultInstallPath)
+      expect(installed.state).toBe('installed')
+      await expect(readlink(defaultInstallPath)).resolves.toBe(launcherPath)
+      await expect(readFile(userInstallPath, 'utf8')).resolves.toContain('other-orca')
+    }
+  )
+
   // Why: when macCommandPath falls back to ~/.local/bin/orca on arm64, commandName
   // must still be 'orca' (not 'orca-ide' which is Linux-only).
   it.skipIf(process.platform === 'win32')(

--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -746,6 +746,129 @@ describe('CliInstaller', () => {
     }
   )
 
+  // Why: shells skip missing PATH entries, so a managed command later in PATH
+  // is still the shell-visible Orca command until the default path is installed.
+  it.skipIf(process.platform === 'win32')(
+    'uses a later managed macOS orca command when the default command is missing',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const resourcesPath = await createPackagedMacLauncher(fixture.root)
+      const usrLocalBin = join(fixture.root, 'usr', 'local', 'bin')
+      const userLocalBin = join(homePath, '.local', 'bin')
+      const defaultInstallPath = join(usrLocalBin, 'orca')
+      const userInstallPath = join(userLocalBin, 'orca')
+      const launcherPath = join(resourcesPath, 'bin', 'orca')
+      await mkdir(usrLocalBin, { recursive: true })
+      await mkdir(userLocalBin, { recursive: true })
+      await symlink(launcherPath, userInstallPath)
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        resourcesPath,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        homePath,
+        defaultMacCommandPath: defaultInstallPath,
+        processPathEnv: `${usrLocalBin}:${userLocalBin}`
+      })
+
+      const status = await installer.getStatus()
+      expect(status.commandPath).toBe(userInstallPath)
+      expect(status.state).toBe('installed')
+
+      const installed = await installer.install()
+      expect(installed.commandPath).toBe(userInstallPath)
+      await expect(lstat(defaultInstallPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    }
+  )
+
+  // Why: bash/zsh skip non-executable PATH entries even at Orca's configured
+  // install slot, then keep looking for a runnable command later in PATH.
+  it.skipIf(process.platform === 'win32')(
+    'uses a later managed macOS orca command when the default command is not executable',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const resourcesPath = await createPackagedMacLauncher(fixture.root)
+      const usrLocalBin = join(fixture.root, 'usr', 'local', 'bin')
+      const userLocalBin = join(homePath, '.local', 'bin')
+      const defaultInstallPath = join(usrLocalBin, 'orca')
+      const userInstallPath = join(userLocalBin, 'orca')
+      const launcherPath = join(resourcesPath, 'bin', 'orca')
+      await mkdir(usrLocalBin, { recursive: true })
+      await mkdir(userLocalBin, { recursive: true })
+      await writeFile(defaultInstallPath, '#!/usr/bin/env bash\necho other-orca\n', 'utf8')
+      await symlink(launcherPath, userInstallPath)
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        resourcesPath,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        homePath,
+        defaultMacCommandPath: defaultInstallPath,
+        processPathEnv: `${usrLocalBin}:${userLocalBin}`
+      })
+
+      const status = await installer.getStatus()
+      expect(status.commandPath).toBe(userInstallPath)
+      expect(status.state).toBe('installed')
+
+      const installed = await installer.install()
+      expect(installed.commandPath).toBe(userInstallPath)
+      await expect(readFile(defaultInstallPath, 'utf8')).resolves.toContain('other-orca')
+    }
+  )
+
+  // Why: a non-Orca command after an empty default install slot can be shadowed
+  // by installing the default path without replacing the user's command.
+  it.skipIf(process.platform === 'win32')(
+    'installs the default macOS command instead of replacing an unmanaged later command',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const resourcesPath = await createPackagedMacLauncher(fixture.root)
+      const usrLocalBin = join(fixture.root, 'usr', 'local', 'bin')
+      const userLocalBin = join(homePath, '.local', 'bin')
+      const defaultInstallPath = join(usrLocalBin, 'orca')
+      const userInstallPath = join(userLocalBin, 'orca')
+      const launcherPath = join(resourcesPath, 'bin', 'orca')
+      await mkdir(usrLocalBin, { recursive: true })
+      await mkdir(userLocalBin, { recursive: true })
+      await writeFile(userInstallPath, '#!/usr/bin/env bash\necho other-orca\n', {
+        encoding: 'utf8',
+        mode: 0o755
+      })
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        resourcesPath,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        homePath,
+        defaultMacCommandPath: defaultInstallPath,
+        processPathEnv: `${usrLocalBin}:${userLocalBin}`
+      })
+
+      const status = await installer.getStatus()
+      expect(status.commandPath).toBe(defaultInstallPath)
+      expect(status.state).toBe('not_installed')
+
+      const installed = await installer.install()
+      expect(installed.commandPath).toBe(defaultInstallPath)
+      expect(installed.state).toBe('installed')
+      await expect(readlink(defaultInstallPath)).resolves.toBe(launcherPath)
+      await expect(readFile(userInstallPath, 'utf8')).resolves.toContain('other-orca')
+    }
+  )
+
   // Why: an off-PATH ~/.local/bin/orca must not hijack CLI registration and
   // leave the shell-visible /usr/local/bin command missing.
   it.skipIf(process.platform === 'win32')(

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -290,12 +290,10 @@ export class CliInstaller {
     launcherPath: string,
     defaultCommandPath: string
   ): Promise<string | null> {
+    let reachedDefaultCommandPath = false
     for (const commandPath of this.getPathCommandCandidates(defaultCommandPath)) {
-      if (samePathEntry(this.platform, commandPath, defaultCommandPath)) {
-        // Why: once PATH reaches Orca's configured install location, installing
-        // there will shadow any later same-name command.
-        return defaultCommandPath
-      }
+      const isDefaultCommandPath = samePathEntry(this.platform, commandPath, defaultCommandPath)
+      reachedDefaultCommandPath ||= isDefaultCommandPath
 
       if (!(await isExecutableFile(commandPath))) {
         continue
@@ -303,8 +301,13 @@ export class CliInstaller {
 
       const status = await this.inspectSymlink(commandPath, launcherPath)
       if (status.state !== 'not_installed') {
-        // Why: PATH lookup is first-match-wins; an earlier unmanaged command
-        // must surface as a conflict instead of letting Orca install a shadowed path.
+        if (reachedDefaultCommandPath && !isDefaultCommandPath && status.state === 'conflict') {
+          // Why: a non-Orca command after an empty/default install slot can be
+          // shadowed safely by installing there; no user file needs replacing.
+          continue
+        }
+        // Why: PATH lookup is first-match-wins; use the executable command the
+        // shell will actually run, while preserving conflicts that shadow Orca.
         return commandPath
       }
     }

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -1,8 +1,18 @@
 /* eslint-disable max-lines -- Why: this file centralizes cross-platform CLI install state, launcher resolution, and PATH registration so the public shell command stays consistent across packaged and development builds. */
 import { app } from 'electron'
 import { execFile } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { lstat, mkdir, readFile, readlink, symlink, unlink, writeFile } from 'node:fs/promises'
+import { constants, existsSync } from 'node:fs'
+import {
+  access,
+  lstat,
+  mkdir,
+  readFile,
+  readlink,
+  stat,
+  symlink,
+  unlink,
+  writeFile
+} from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { promisify } from 'node:util'
@@ -104,8 +114,8 @@ export class CliInstaller {
   }
 
   async getStatus(): Promise<CliInstallStatus> {
-    const spec = this.resolveInstallSpec()
-    if (!spec) {
+    const defaultSpec = this.resolveInstallSpec()
+    if (!defaultSpec) {
       return {
         platform: this.platform,
         commandName: this.commandName,
@@ -133,11 +143,11 @@ export class CliInstaller {
       return {
         platform: this.platform,
         commandName: this.commandName,
-        commandPath: spec.commandPath,
-        pathDirectory: dirname(spec.commandPath),
+        commandPath: defaultSpec.commandPath,
+        pathDirectory: dirname(defaultSpec.commandPath),
         pathConfigured: false,
         launcherPath: null,
-        installMethod: spec.installMethod,
+        installMethod: defaultSpec.installMethod,
         supported: false,
         state: 'unsupported',
         currentTarget: null,
@@ -146,6 +156,7 @@ export class CliInstaller {
       }
     }
 
+    const spec = await this.resolveActiveInstallSpec(defaultSpec, launcherPath)
     const baseStatus =
       spec.installMethod === 'symlink'
         ? await this.inspectSymlink(spec.commandPath, launcherPath)
@@ -249,6 +260,63 @@ export class CliInstaller {
     }
 
     return null
+  }
+
+  private async resolveActiveInstallSpec(
+    defaultSpec: InstallSpec,
+    launcherPath: string
+  ): Promise<InstallSpec> {
+    if (
+      this.commandPathOverride ||
+      this.platform !== 'darwin' ||
+      defaultSpec.installMethod !== 'symlink'
+    ) {
+      return defaultSpec
+    }
+
+    const activeCommandPath = await this.findActivePathCommand(
+      launcherPath,
+      defaultSpec.commandPath
+    )
+    return activeCommandPath
+      ? {
+          commandPath: activeCommandPath,
+          installMethod: defaultSpec.installMethod
+        }
+      : defaultSpec
+  }
+
+  private async findActivePathCommand(
+    launcherPath: string,
+    defaultCommandPath: string
+  ): Promise<string | null> {
+    for (const commandPath of this.getPathCommandCandidates(defaultCommandPath)) {
+      if (samePathEntry(this.platform, commandPath, defaultCommandPath)) {
+        // Why: once PATH reaches Orca's configured install location, installing
+        // there will shadow any later same-name command.
+        return defaultCommandPath
+      }
+
+      if (!(await isExecutableFile(commandPath))) {
+        continue
+      }
+
+      const status = await this.inspectSymlink(commandPath, launcherPath)
+      if (status.state !== 'not_installed') {
+        // Why: PATH lookup is first-match-wins; an earlier unmanaged command
+        // must surface as a conflict instead of letting Orca install a shadowed path.
+        return commandPath
+      }
+    }
+    return null
+  }
+
+  private getPathCommandCandidates(defaultCommandPath: string): string[] {
+    const commandName = basename(defaultCommandPath)
+    const pathCandidates = splitPathEntries(this.platform, this.processPathEnv ?? '').map((entry) =>
+      join(entry, commandName)
+    )
+    return uniquePathEntries(this.platform, pathCandidates)
   }
 
   private resolveCommandPath(): string | null {
@@ -906,6 +974,20 @@ function splitPathEntries(platform: NodeJS.Platform, value: string | null): stri
     .filter(Boolean)
 }
 
+function uniquePathEntries(platform: NodeJS.Platform, entries: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const entry of entries) {
+    const key = platform === 'win32' ? normalizeWindowsPath(entry) : entry
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    result.push(entry)
+  }
+  return result
+}
+
 function samePathEntry(platform: NodeJS.Platform, left: string, right: string): boolean {
   return platform === 'win32'
     ? normalizeWindowsPath(left) === normalizeWindowsPath(right)
@@ -915,6 +997,19 @@ function samePathEntry(platform: NodeJS.Platform, left: string, right: string): 
 function isPathInsideOrEqual(parentPath: string, childPath: string): boolean {
   const childRelative = relative(parentPath, childPath)
   return childRelative === '' || (!childRelative.startsWith('..') && !isAbsolute(childRelative))
+}
+
+async function isExecutableFile(commandPath: string): Promise<boolean> {
+  try {
+    const stats = await stat(commandPath)
+    if (!stats.isFile()) {
+      return false
+    }
+    await access(commandPath, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
 }
 
 function normalizeWindowsPath(value: string): string {

--- a/src/main/ipc/cli.ts
+++ b/src/main/ipc/cli.ts
@@ -2,21 +2,37 @@ import { ipcMain } from 'electron'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
 import { CliInstaller } from '../cli/cli-installer'
 import { WslCliInstaller } from '../cli/wsl-cli-installer'
+import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 
 function normalizeWslCliDistro(args?: { distro?: string | null }): string | undefined {
   return args?.distro?.trim() || undefined
 }
 
+async function hydrateLocalShellPathForCli(force = false): Promise<void> {
+  if (process.platform === 'win32') {
+    return
+  }
+  // Why: CLI registration must match `which orca` in the user's terminal, not
+  // the sparse PATH a GUI-launched Electron process inherited from launchd.
+  const hydration = await hydrateShellPath(force ? { force: true } : undefined)
+  if (hydration.ok) {
+    mergePathSegments(hydration.segments)
+  }
+}
+
 export function registerCliHandlers(): void {
   ipcMain.handle('cli:getInstallStatus', async (): Promise<CliInstallStatus> => {
+    await hydrateLocalShellPathForCli()
     return new CliInstaller().getStatus()
   })
 
   ipcMain.handle('cli:install', async (): Promise<CliInstallStatus> => {
+    await hydrateLocalShellPathForCli(true)
     return new CliInstaller().install()
   })
 
   ipcMain.handle('cli:remove', async (): Promise<CliInstallStatus> => {
+    await hydrateLocalShellPathForCli()
     return new CliInstaller().remove()
   })
 

--- a/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
@@ -73,6 +73,23 @@ export function MobileEmulatorAgentSetupGuideSteps({
               {setup.cliInstallStatus.detail}
             </p>
           ) : null}
+          {setup.cliBusy ? (
+            <p className="text-[11px] leading-snug text-muted-foreground">
+              {translate(
+                'auto.components.emulator.pane.MobileEmulatorAgentSetupGuideSteps.3d34423e88',
+                'Registering the Orca CLI'
+              )}{' '}
+              {setup.cliInstallStatus?.commandPath ? (
+                <code className="rounded bg-muted px-1 py-0.5">
+                  {setup.cliInstallStatus.commandPath}
+                </code>
+              ) : null}{' '}
+              {translate(
+                'auto.components.emulator.pane.MobileEmulatorAgentSetupGuideSteps.3be27641c9',
+                'so emulator commands can run from agent shells.'
+              )}
+            </p>
+          ) : null}
           {!setup.cliEnabled && !setup.cliPathNeedsAttention && setup.cliInstallStatus?.detail ? (
             <p className="text-[11px] text-muted-foreground">{setup.cliInstallStatus.detail}</p>
           ) : null}
@@ -93,7 +110,9 @@ export function MobileEmulatorAgentSetupGuideSteps({
                     void setup.handleEnableCli()
                   }}
                 >
-                  {setup.cliLoading ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                  {setup.cliLoading || setup.cliBusy ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : null}
                   {setup.cliActionLabel}
                 </Button>
               </span>
@@ -149,6 +168,10 @@ export function MobileEmulatorAgentSetupGuideSteps({
             preInstallNotice={
               showSkillPreInstallNotice ? AGENT_SKILL_CLI_PREREQUISITE_NOTICE : undefined
             }
+            openingHint={translate(
+              'auto.components.emulator.pane.MobileEmulatorAgentSetupGuideSteps.3941719a56',
+              'Checking Orca CLI before opening skill setup.'
+            )}
             onBeforeOpenTerminal={async () => {
               recordFeatureInteraction('mobile-emulator-agent-setup')
               await ensureOrcaCliAvailableForAgentSkillTerminal()

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
@@ -238,6 +238,32 @@ describe('AgentSkillSetupPanel', () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith('Copied command.')
   })
 
+  it('shows a visible pending state while CLI setup preflight is running', async () => {
+    let resolvePreflight: (() => void) | null = null
+    const preflight = new Promise<void>((resolve) => {
+      resolvePreflight = resolve
+    })
+
+    await renderInteractivePanel({
+      onBeforeOpenTerminal: () => preflight
+    })
+
+    await clickButton('Install')
+
+    expect(findButton('Preparing...').disabled).toBe(true)
+    expect(container?.textContent).toContain('Preparing setup terminal.')
+    expect(container?.textContent).not.toContain(INSTALL_COMMAND)
+
+    await act(async () => {
+      resolvePreflight?.()
+      await preflight
+    })
+    await act(async () => {})
+
+    expect(container?.textContent).toContain(INSTALL_COMMAND)
+    expect(mocks.terminalProps.at(-1)).toMatchObject({ command: INSTALL_COMMAND })
+  })
+
   it('opens installed setup with the installed command for preview, copy, and terminal', async () => {
     await renderInteractivePanel({ installed: true, installedCommand: UPDATE_COMMAND })
 

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -173,14 +173,20 @@ export function AgentSkillSetupPanel({
             const nextCommand = activeCommand
             setTerminalOpening(true)
             void (async () => {
+              let shouldOpenTerminal = false
               try {
                 await onBeforeOpenTerminal?.()
                 await refreshPreInstallNotice()
+                shouldOpenTerminal = true
+              } catch {
+                shouldOpenTerminal = false
               } finally {
                 if (mountedRef.current) {
                   setTerminalOpening(false)
-                  setTerminalCommand(nextCommand)
-                  setTerminalOpen(true)
+                  if (shouldOpenTerminal) {
+                    setTerminalCommand(nextCommand)
+                    setTerminalOpen(true)
+                  }
                 }
               }
             })()

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react'
-import { Copy, RefreshCw, Terminal } from 'lucide-react'
+import { Copy, Loader2, RefreshCw, Terminal } from 'lucide-react'
 import { toast } from 'sonner'
 import { IntegrationStatusPill } from '../integration-status-pill'
 import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
@@ -44,6 +44,7 @@ type AgentSkillSetupPanelProps = {
   installLabel?: string
   installedInstallLabel?: string
   actionHint?: ReactNode
+  openingHint?: ReactNode
   footer?: ReactNode
   onRecheck: () => void | Promise<unknown>
 }
@@ -76,11 +77,13 @@ export function AgentSkillSetupPanel({
   installLabel = 'Install',
   installedInstallLabel = 'Update',
   actionHint,
+  openingHint,
   footer,
   onRecheck
 }: AgentSkillSetupPanelProps): React.JSX.Element {
   const [terminalOpen, setTerminalOpen] = useState(false)
   const [terminalCommand, setTerminalCommand] = useState<string | null>(null)
+  const [terminalOpening, setTerminalOpening] = useState(false)
   const [preInstallNoticeVisible, setPreInstallNoticeVisible] = useState(
     Boolean(preInstallNotice && !installed)
   )
@@ -164,23 +167,36 @@ export function AgentSkillSetupPanel({
           variant="outline"
           size="sm"
           onClick={() => {
+            if (terminalOpening) {
+              return
+            }
             const nextCommand = activeCommand
+            setTerminalOpening(true)
             void (async () => {
               try {
                 await onBeforeOpenTerminal?.()
                 await refreshPreInstallNotice()
               } finally {
                 if (mountedRef.current) {
+                  setTerminalOpening(false)
                   setTerminalCommand(nextCommand)
                   setTerminalOpen(true)
                 }
               }
             })()
           }}
-          disabled={terminalOpen || installDisabled}
+          disabled={terminalOpen || installDisabled || terminalOpening}
         >
-          <Terminal className="size-3.5" />
-          {installed ? installedInstallLabel : installLabel}
+          {terminalOpening ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Terminal className="size-3.5" />
+          )}
+          {terminalOpening
+            ? translate('auto.components.settings.AgentSkillSetupPanel.5f818f12ab', 'Preparing...')
+            : installed
+              ? installedInstallLabel
+              : installLabel}
         </Button>
       ) : null}
       {!installed || showRecheckWhenInstalled ? (
@@ -195,6 +211,15 @@ export function AgentSkillSetupPanel({
           <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
           {translate('auto.components.settings.AgentSkillSetupPanel.c689392435', 'Re-check')}
         </Button>
+      ) : null}
+      {terminalOpening ? (
+        <p className="basis-full text-[12px] leading-snug text-muted-foreground">
+          {openingHint ??
+            translate(
+              'auto.components.settings.AgentSkillSetupPanel.4c05b9d7cb',
+              'Preparing setup terminal.'
+            )}
+        </p>
       ) : null}
     </div>
   )

--- a/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
@@ -94,6 +94,23 @@ export function MobileEmulatorAgentControlRow(): React.JSX.Element {
             {!setup.cliEnabled && setup.cliInstallStatus?.detail ? (
               <p className="text-[11px] text-muted-foreground">{setup.cliInstallStatus.detail}</p>
             ) : null}
+            {setup.cliBusy ? (
+              <p className="text-[11px] leading-snug text-muted-foreground">
+                {translate(
+                  'auto.components.settings.MobileEmulatorAgentControlRow.3d34423e88',
+                  'Registering the Orca CLI'
+                )}{' '}
+                {setup.cliInstallStatus?.commandPath ? (
+                  <code className="rounded bg-muted px-1 py-0.5">
+                    {setup.cliInstallStatus.commandPath}
+                  </code>
+                ) : null}{' '}
+                {translate(
+                  'auto.components.settings.MobileEmulatorAgentControlRow.3be27641c9',
+                  'so emulator commands can run from agent shells.'
+                )}
+              </p>
+            ) : null}
           </div>
           <TooltipProvider delayDuration={250}>
             <Tooltip>
@@ -108,7 +125,9 @@ export function MobileEmulatorAgentControlRow(): React.JSX.Element {
                     }
                     onClick={() => void handleEnableCli()}
                   >
-                    {setup.cliLoading ? <Loader2 className="size-3.5 animate-spin" /> : null}
+                    {setup.cliLoading || setup.cliBusy ? (
+                      <Loader2 className="size-3.5 animate-spin" />
+                    ) : null}
                     {setup.cliActionLabel}
                   </Button>
                 </span>
@@ -144,6 +163,10 @@ export function MobileEmulatorAgentControlRow(): React.JSX.Element {
             installDisabled={setup.step2Blocked}
             leading={<StepBadge index={2} state={setup.cliSkillInstalled ? 'done' : 'pending'} />}
             preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
+            openingHint={translate(
+              'auto.components.settings.MobileEmulatorAgentControlRow.3941719a56',
+              'Checking Orca CLI before opening skill setup.'
+            )}
             onBeforeOpenTerminal={async () => {
               await ensureOrcaCliAvailableForAgentSkillTerminal()
             }}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4495,7 +4495,9 @@
           "copiedCommand": "Copied command.",
           "failedToCopyCommand": "Failed to copy command.",
           "copyCommandAria": "Copy command",
-          "runCommandDescription": "Press Enter to run the command."
+          "runCommandDescription": "Press Enter to run the command.",
+          "5f818f12ab": "Preparing...",
+          "4c05b9d7cb": "Preparing setup terminal."
         },
         "AgentsPane": {
           "d83834f5e6": "Detecting installed agents…",
@@ -5315,7 +5317,10 @@
           "4f2205f3b6": "Enable Orca CLI",
           "ff4b7e65d6": "Let coding agents control the active mobile emulator with Orca CLI commands.",
           "2a674aa810": "Agent Mobile Emulator Control",
-          "cdeaed9e37": "Registered the Orca CLI in PATH."
+          "cdeaed9e37": "Registered the Orca CLI in PATH.",
+          "3d34423e88": "Registering the Orca CLI",
+          "3be27641c9": "so emulator commands can run from agent shells.",
+          "3941719a56": "Checking Orca CLI before opening skill setup."
         },
         "MobileEmulatorExamples": {
           "edf13dd03b": "Copy",
@@ -10459,7 +10464,10 @@
             "21f5687c07": "Orca CLI skill",
             "64fb057667": "Teaches agents the orca emulator commands for this worktree.",
             "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
-            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal"
+            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal",
+            "3d34423e88": "Registering the Orca CLI",
+            "3be27641c9": "so emulator commands can run from agent shells.",
+            "3941719a56": "Checking Orca CLI before opening skill setup."
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "Dismiss",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4495,7 +4495,9 @@
           "copiedCommand": "Comando copiado.",
           "failedToCopyCommand": "No se pudo copiar el comando.",
           "copyCommandAria": "Copiar comando",
-          "runCommandDescription": "Presiona Enter para ejecutar el comando."
+          "runCommandDescription": "Presiona Enter para ejecutar el comando.",
+          "5f818f12ab": "Preparing...",
+          "4c05b9d7cb": "Preparing setup terminal."
         },
         "AgentsPane": {
           "d83834f5e6": "Detectando agents instalados…",
@@ -5278,7 +5280,10 @@
           "4f2205f3b6": "Habilitar CLI de Orca",
           "ff4b7e65d6": "Deje que los agents de codificación controlen el emulador móvil activo con los comandos CLI de Orca.",
           "2a674aa810": "Control del emulador móvil del Agent",
-          "cdeaed9e37": "Registré Orca CLI en PATH."
+          "cdeaed9e37": "Registré Orca CLI en PATH.",
+          "3d34423e88": "Registering the Orca CLI",
+          "3be27641c9": "so emulator commands can run from agent shells.",
+          "3941719a56": "Checking Orca CLI before opening skill setup."
         },
         "MobileEmulatorExamples": {
           "edf13dd03b": "Copiar",
@@ -10459,7 +10464,10 @@
             "21f5687c07": "Skill del CLI de Orca",
             "64fb057667": "Enseña a los agents los comandos del emulador orca para este worktree.",
             "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
-            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal"
+            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal",
+            "3d34423e88": "Registering the Orca CLI",
+            "3be27641c9": "so emulator commands can run from agent shells.",
+            "3941719a56": "Checking Orca CLI before opening skill setup."
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "Descartar",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4496,8 +4496,8 @@
           "failedToCopyCommand": "No se pudo copiar el comando.",
           "copyCommandAria": "Copiar comando",
           "runCommandDescription": "Presiona Enter para ejecutar el comando.",
-          "5f818f12ab": "Preparing...",
-          "4c05b9d7cb": "Preparing setup terminal."
+          "5f818f12ab": "Preparando...",
+          "4c05b9d7cb": "Preparando el terminal de configuración."
         },
         "AgentsPane": {
           "d83834f5e6": "Detectando agents instalados…",
@@ -5281,9 +5281,9 @@
           "ff4b7e65d6": "Deje que los agents de codificación controlen el emulador móvil activo con los comandos CLI de Orca.",
           "2a674aa810": "Control del emulador móvil del Agent",
           "cdeaed9e37": "Registré Orca CLI en PATH.",
-          "3d34423e88": "Registering the Orca CLI",
-          "3be27641c9": "so emulator commands can run from agent shells.",
-          "3941719a56": "Checking Orca CLI before opening skill setup."
+          "3d34423e88": "Registrando la CLI de Orca",
+          "3be27641c9": "para que los comandos del emulador se puedan ejecutar desde shells de agents.",
+          "3941719a56": "Comprobando la CLI de Orca antes de abrir la configuración de la skill."
         },
         "MobileEmulatorExamples": {
           "edf13dd03b": "Copiar",
@@ -10465,9 +10465,9 @@
             "64fb057667": "Enseña a los agents los comandos del emulador orca para este worktree.",
             "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
             "bff5341ac3": "Mobile emulator Orca CLI skill install terminal",
-            "3d34423e88": "Registering the Orca CLI",
-            "3be27641c9": "so emulator commands can run from agent shells.",
-            "3941719a56": "Checking Orca CLI before opening skill setup."
+            "3d34423e88": "Registrando la CLI de Orca",
+            "3be27641c9": "para que los comandos del emulador se puedan ejecutar desde shells de agents.",
+            "3941719a56": "Comprobando la CLI de Orca antes de abrir la configuración de la skill."
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "Descartar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4480,7 +4480,9 @@
           "copiedCommand": "コマンドをコピーしました。",
           "failedToCopyCommand": "コマンドのコピーに失敗しました。",
           "copyCommandAria": "コマンドをコピー",
-          "runCommandDescription": "Enter を押してコマンドを実行します。"
+          "runCommandDescription": "Enter を押してコマンドを実行します。",
+          "5f818f12ab": "Preparing...",
+          "4c05b9d7cb": "Preparing setup terminal."
         },
         "AgentsPane": {
           "d83834f5e6": "インストールされている agents を検出しています…",
@@ -5300,7 +5302,10 @@
           "4f2205f3b6": "Orca CLI を有効にする",
           "ff4b7e65d6": "コーディング agents が Orca CLI コマンドを使用してアクティブなモバイル エミュレータを制御できるようにします。",
           "2a674aa810": "Agent モバイル エミュレータ制御",
-          "cdeaed9e37": "Orca CLIをPATHに登録しました。"
+          "cdeaed9e37": "Orca CLIをPATHに登録しました。",
+          "3d34423e88": "Registering the Orca CLI",
+          "3be27641c9": "so emulator commands can run from agent shells.",
+          "3941719a56": "Checking Orca CLI before opening skill setup."
         },
         "MobileEmulatorExamples": {
           "edf13dd03b": "コピー",
@@ -10459,7 +10464,10 @@
             "21f5687c07": "Orca CLI スキル",
             "64fb057667": "このワークツリーの orca エミュレーターコマンドを agents に教えます。",
             "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
-            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal"
+            "bff5341ac3": "Mobile emulator Orca CLI skill install terminal",
+            "3d34423e88": "Registering the Orca CLI",
+            "3be27641c9": "so emulator commands can run from agent shells.",
+            "3941719a56": "Checking Orca CLI before opening skill setup."
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "閉じる",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4481,8 +4481,8 @@
           "failedToCopyCommand": "コマンドのコピーに失敗しました。",
           "copyCommandAria": "コマンドをコピー",
           "runCommandDescription": "Enter を押してコマンドを実行します。",
-          "5f818f12ab": "Preparing...",
-          "4c05b9d7cb": "Preparing setup terminal."
+          "5f818f12ab": "準備中...",
+          "4c05b9d7cb": "セットアップ用ターミナルを準備しています。"
         },
         "AgentsPane": {
           "d83834f5e6": "インストールされている agents を検出しています…",
@@ -5303,9 +5303,9 @@
           "ff4b7e65d6": "コーディング agents が Orca CLI コマンドを使用してアクティブなモバイル エミュレータを制御できるようにします。",
           "2a674aa810": "Agent モバイル エミュレータ制御",
           "cdeaed9e37": "Orca CLIをPATHに登録しました。",
-          "3d34423e88": "Registering the Orca CLI",
-          "3be27641c9": "so emulator commands can run from agent shells.",
-          "3941719a56": "Checking Orca CLI before opening skill setup."
+          "3d34423e88": "Orca CLI を登録しています",
+          "3be27641c9": "agent のシェルからエミュレーターコマンドを実行できるようにします。",
+          "3941719a56": "スキル設定を開く前に Orca CLI を確認しています。"
         },
         "MobileEmulatorExamples": {
           "edf13dd03b": "コピー",
@@ -10465,9 +10465,9 @@
             "64fb057667": "このワークツリーの orca エミュレーターコマンドを agents に教えます。",
             "5c59ea96ca": "Mobile emulator Orca CLI skill setup",
             "bff5341ac3": "Mobile emulator Orca CLI skill install terminal",
-            "3d34423e88": "Registering the Orca CLI",
-            "3be27641c9": "so emulator commands can run from agent shells.",
-            "3941719a56": "Checking Orca CLI before opening skill setup."
+            "3d34423e88": "Orca CLI を登録しています",
+            "3be27641c9": "agent のシェルからエミュレーターコマンドを実行できるようにします。",
+            "3941719a56": "スキル設定を開く前に Orca CLI を確認しています。"
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "閉じる",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4481,8 +4481,8 @@
           "failedToCopyCommand": "명령 복사 실패.",
           "copyCommandAria": "명령 복사",
           "runCommandDescription": "Enter를 눌러 명령을 실행하세요.",
-          "5f818f12ab": "Preparing...",
-          "4c05b9d7cb": "Preparing setup terminal."
+          "5f818f12ab": "준비 중...",
+          "4c05b9d7cb": "설정 터미널을 준비하고 있습니다."
         },
         "AgentsPane": {
           "d83834f5e6": "설치된 agents 감지 중…",
@@ -5266,9 +5266,9 @@
           "ff4b7e65d6": "코딩 agents가 Orca CLI 명령을 사용하여 활성 모바일 에뮬레이터를 제어하도록 합니다.",
           "2a674aa810": "Agent 모바일 에뮬레이터 제어",
           "cdeaed9e37": "PATH에 Orca CLI를 등록했습니다.",
-          "3d34423e88": "Registering the Orca CLI",
-          "3be27641c9": "so emulator commands can run from agent shells.",
-          "3941719a56": "Checking Orca CLI before opening skill setup."
+          "3d34423e88": "Orca CLI를 등록하는 중",
+          "3be27641c9": "agent 셸에서 에뮬레이터 명령을 실행할 수 있도록 합니다.",
+          "3941719a56": "스킬 설정을 열기 전에 Orca CLI를 확인하고 있습니다."
         },
         "MobileEmulatorExamples": {
           "edf13dd03b": "복사",
@@ -10465,9 +10465,9 @@
             "64fb057667": "이 워크트리의 orca 에뮬레이터 명령을 agents에게 알려줍니다.",
             "5c59ea96ca": "모바일 에뮬레이터 Orca CLI 스킬 설정",
             "bff5341ac3": "모바일 에뮬레이터 Orca CLI 스킬 설치 terminal",
-            "3d34423e88": "Registering the Orca CLI",
-            "3be27641c9": "so emulator commands can run from agent shells.",
-            "3941719a56": "Checking Orca CLI before opening skill setup."
+            "3d34423e88": "Orca CLI를 등록하는 중",
+            "3be27641c9": "agent 셸에서 에뮬레이터 명령을 실행할 수 있도록 합니다.",
+            "3941719a56": "스킬 설정을 열기 전에 Orca CLI를 확인하고 있습니다."
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "닫기",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4480,7 +4480,9 @@
           "copiedCommand": "명령 복사됨.",
           "failedToCopyCommand": "명령 복사 실패.",
           "copyCommandAria": "명령 복사",
-          "runCommandDescription": "Enter를 눌러 명령을 실행하세요."
+          "runCommandDescription": "Enter를 눌러 명령을 실행하세요.",
+          "5f818f12ab": "Preparing...",
+          "4c05b9d7cb": "Preparing setup terminal."
         },
         "AgentsPane": {
           "d83834f5e6": "설치된 agents 감지 중…",
@@ -5263,7 +5265,10 @@
           "4f2205f3b6": "Orca CLI 활성화",
           "ff4b7e65d6": "코딩 agents가 Orca CLI 명령을 사용하여 활성 모바일 에뮬레이터를 제어하도록 합니다.",
           "2a674aa810": "Agent 모바일 에뮬레이터 제어",
-          "cdeaed9e37": "PATH에 Orca CLI를 등록했습니다."
+          "cdeaed9e37": "PATH에 Orca CLI를 등록했습니다.",
+          "3d34423e88": "Registering the Orca CLI",
+          "3be27641c9": "so emulator commands can run from agent shells.",
+          "3941719a56": "Checking Orca CLI before opening skill setup."
         },
         "MobileEmulatorExamples": {
           "edf13dd03b": "복사",
@@ -10459,7 +10464,10 @@
             "21f5687c07": "Orca CLI 스킬",
             "64fb057667": "이 워크트리의 orca 에뮬레이터 명령을 agents에게 알려줍니다.",
             "5c59ea96ca": "모바일 에뮬레이터 Orca CLI 스킬 설정",
-            "bff5341ac3": "모바일 에뮬레이터 Orca CLI 스킬 설치 terminal"
+            "bff5341ac3": "모바일 에뮬레이터 Orca CLI 스킬 설치 terminal",
+            "3d34423e88": "Registering the Orca CLI",
+            "3be27641c9": "so emulator commands can run from agent shells.",
+            "3941719a56": "Checking Orca CLI before opening skill setup."
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "닫기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4481,8 +4481,8 @@
           "failedToCopyCommand": "复制命令失败。",
           "copyCommandAria": "复制命令",
           "runCommandDescription": "按 Enter 运行命令。",
-          "5f818f12ab": "Preparing...",
-          "4c05b9d7cb": "Preparing setup terminal."
+          "5f818f12ab": "正在准备...",
+          "4c05b9d7cb": "正在准备设置终端。"
         },
         "AgentsPane": {
           "d83834f5e6": "检测已安装的智能体...",
@@ -5266,9 +5266,9 @@
           "ff4b7e65d6": "让编码智能体使用 Orca CLI 命令控制活动手机模拟器。",
           "2a674aa810": "智能体手机模拟器控制",
           "cdeaed9e37": "在 PATH 中注册 Orca CLI。",
-          "3d34423e88": "Registering the Orca CLI",
-          "3be27641c9": "so emulator commands can run from agent shells.",
-          "3941719a56": "Checking Orca CLI before opening skill setup."
+          "3d34423e88": "正在注册 Orca CLI",
+          "3be27641c9": "以便智能体 shell 可以运行模拟器命令。",
+          "3941719a56": "打开技能设置前正在检查 Orca CLI。"
         },
         "MobileEmulatorExamples": {
           "edf13dd03b": "复制",
@@ -10465,9 +10465,9 @@
             "64fb057667": "教授智能体此工作区的 orca 模拟器命令。",
             "5c59ea96ca": "移动端模拟器 Orca CLI 技能设置",
             "bff5341ac3": "移动端模拟器 Orca CLI 技能安装终端",
-            "3d34423e88": "Registering the Orca CLI",
-            "3be27641c9": "so emulator commands can run from agent shells.",
-            "3941719a56": "Checking Orca CLI before opening skill setup."
+            "3d34423e88": "正在注册 Orca CLI",
+            "3be27641c9": "以便智能体 shell 可以运行模拟器命令。",
+            "3941719a56": "打开技能设置前正在检查 Orca CLI。"
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "关闭",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4480,7 +4480,9 @@
           "copiedCommand": "已复制命令。",
           "failedToCopyCommand": "复制命令失败。",
           "copyCommandAria": "复制命令",
-          "runCommandDescription": "按 Enter 运行命令。"
+          "runCommandDescription": "按 Enter 运行命令。",
+          "5f818f12ab": "Preparing...",
+          "4c05b9d7cb": "Preparing setup terminal."
         },
         "AgentsPane": {
           "d83834f5e6": "检测已安装的智能体...",
@@ -5263,7 +5265,10 @@
           "4f2205f3b6": "启用 Orca CLI",
           "ff4b7e65d6": "让编码智能体使用 Orca CLI 命令控制活动手机模拟器。",
           "2a674aa810": "智能体手机模拟器控制",
-          "cdeaed9e37": "在 PATH 中注册 Orca CLI。"
+          "cdeaed9e37": "在 PATH 中注册 Orca CLI。",
+          "3d34423e88": "Registering the Orca CLI",
+          "3be27641c9": "so emulator commands can run from agent shells.",
+          "3941719a56": "Checking Orca CLI before opening skill setup."
         },
         "MobileEmulatorExamples": {
           "edf13dd03b": "复制",
@@ -10459,7 +10464,10 @@
             "21f5687c07": "Orca CLI 技能",
             "64fb057667": "教授智能体此工作区的 orca 模拟器命令。",
             "5c59ea96ca": "移动端模拟器 Orca CLI 技能设置",
-            "bff5341ac3": "移动端模拟器 Orca CLI 技能安装终端"
+            "bff5341ac3": "移动端模拟器 Orca CLI 技能安装终端",
+            "3d34423e88": "Registering the Orca CLI",
+            "3be27641c9": "so emulator commands can run from agent shells.",
+            "3941719a56": "Checking Orca CLI before opening skill setup."
           },
           "MobileEmulatorTabIntroCallout": {
             "1924982130": "关闭",


### PR DESCRIPTION
## Summary

Fixes macOS Orca CLI path resolution by ensuring the app discovers and uses the correct shell-visible `orca` command. It handles conflicts and broken symlinks along the user's `PATH` environment, prioritizing user-managed commands. Also ensures Electron main process hydrates its `PATH` environment from the terminal prior to CLI operations. Improved UI responsiveness with loading spinners and status indicators when registering the CLI or opening the setup terminal.

## Screenshots

- Added loading states, a "Preparing..." button, and registration progress texts ("Registering the Orca CLI...") in settings and emulator setup. No major layout changes.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

**Testing Notes**:
- Added 6 detailed test cases in `cli-installer.test.ts` to cover macOS path command candidate resolution, skipping broken or non-executable symlinks, and conflict reporting.
- Added a new unit test in `AgentSkillSetupPanel.test.tsx` to verify the pending state while the CLI preflight is running.

## AI Review Report

Reviewed cross-platform compatibility for macOS, Linux, and Windows:
- **macOS/Linux**: Solved the discrepancy between shell and Electron's GUI environment by calling `hydrateShellPath` before running CLI status and install/remove checks. Skipping non-executable files ensures compatibility with POSIX standards.
- **Windows**: Ensured win32 environment skips symlink inspection and uses native normalizations. Windows tests are marked with `it.skipIf(process.platform === 'win32')`.

## Security Audit

- **IPC & Execution**: Safe IPC handlers call helper processes without raw execution of unsanitized arguments.
- **Symlinks**: Only replacing symlinks that actually point to Orca's packaged launcher, preventing arbitrary overwrites of user binaries.
- **Environment**: Safely queries variables from hydrated shell environment.

## Notes

Requires terminal shell environment hydration on macOS to function reliably when the app is launched via GUI.