### PR TITLE
feat(terminal): implement detached window terminal pop-out

### DIFF
--- a/config/localization-coverage-allowlist.json
+++ b/config/localization-coverage-allowlist.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "filePath": "src/renderer/src/web/web-preload-api.ts",
+    "kind": "object-property:error",
+    "text": "detached_terminal_tab_unavailable",
+    "dynamic": false,
+    "count": 1,
+    "reason": "Machine-readable error code in the detachedTerminal IPC result union, not user-facing copy."
+  }
+]

--- a/src/main/ipc/browser.test.ts
+++ b/src/main/ipc/browser.test.ts
@@ -66,6 +66,7 @@ import {
   waitForTabRegistration,
   waitForWorktreeTabRegistration
 } from './browser'
+import { trustedRendererRegistry } from '../window/trusted-renderer-registry'
 
 describe('registerBrowserHandlers', () => {
   beforeEach(() => {
@@ -90,6 +91,9 @@ describe('registerBrowserHandlers', () => {
     openDevToolsMock.mockResolvedValue(true)
     setAnnotationViewportBridgeMock.mockResolvedValue(true)
     setAgentBrowserBridgeRef(null)
+    trustedRendererRegistry.clearWebContents(91)
+    trustedRendererRegistry.clearWebContents(92)
+    trustedRendererRegistry.grant(91, 'browser')
   })
 
   afterEach(() => {
@@ -269,6 +273,7 @@ describe('registerBrowserHandlers', () => {
     const result = activeTabChangedHandler(
       {
         sender: {
+          id: 91,
           isDestroyed: () => false,
           getType: () => 'window',
           getURL: () => 'file:///renderer/index.html'

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -34,8 +34,8 @@ import {
   isValidBrowserAnnotationViewportBridgeToken,
   type BrowserSetAnnotationViewportBridgeArgs
 } from '../../shared/browser-annotation-viewport-bridge'
+import { trustedRendererRegistry } from '../window/trusted-renderer-registry'
 
-let trustedBrowserRendererWebContentsId: number | null = null
 let agentBrowserBridgeRef: AgentBrowserBridge | null = null
 
 // Why: CLI-driven tab creation must wait until the renderer mounts the webview
@@ -140,7 +140,10 @@ export function waitForAnyTabRegistration(timeoutMs = 8_000): Promise<void> {
 }
 
 export function setTrustedBrowserRendererWebContentsId(webContentsId: number | null): void {
-  trustedBrowserRendererWebContentsId = webContentsId
+  if (webContentsId === null) {
+    return
+  }
+  trustedRendererRegistry.grant(webContentsId, 'browser')
 }
 
 export function setAgentBrowserBridgeRef(bridge: AgentBrowserBridge | null): void {
@@ -151,20 +154,7 @@ function isTrustedBrowserRenderer(sender: Electron.WebContents): boolean {
   if (sender.isDestroyed() || sender.getType() !== 'window') {
     return false
   }
-  if (trustedBrowserRendererWebContentsId != null) {
-    return sender.id === trustedBrowserRendererWebContentsId
-  }
-
-  const senderUrl = sender.getURL()
-  if (process.env.ELECTRON_RENDERER_URL) {
-    try {
-      return new URL(senderUrl).origin === new URL(process.env.ELECTRON_RENDERER_URL).origin
-    } catch {
-      return false
-    }
-  }
-
-  return senderUrl.startsWith('file://')
+  return trustedRendererRegistry.has(sender.id, 'browser')
 }
 
 export function registerBrowserHandlers(): void {

--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -15,6 +15,7 @@ const {
   notificationCtorMock,
   notificationIsSupportedMock,
   getAllWindowsMock,
+  getPrimaryAppWindowMock,
   shellOpenExternalMock
 } = vi.hoisted(() => {
   const removeHandlerMock = vi.fn()
@@ -35,6 +36,7 @@ const {
   })
   const notificationIsSupportedMock = vi.fn(() => true)
   const getAllWindowsMock = vi.fn(() => [])
+  const getPrimaryAppWindowMock = vi.fn(() => null)
   const shellOpenExternalMock = vi.fn()
   return {
     removeHandlerMock,
@@ -47,6 +49,7 @@ const {
     notificationCtorMock,
     notificationIsSupportedMock,
     getAllWindowsMock,
+    getPrimaryAppWindowMock,
     shellOpenExternalMock
   }
 })
@@ -67,6 +70,12 @@ vi.mock('electron', () => ({
   },
   shell: {
     openExternal: shellOpenExternalMock
+  }
+}))
+
+vi.mock('../window/detached-window-registry', () => ({
+  detachedWindowRegistry: {
+    getPrimaryAppWindow: getPrimaryAppWindowMock
   }
 }))
 
@@ -121,6 +130,13 @@ describe('registerNotificationHandlers', () => {
     readAuthorizationStatusMock.mockResolvedValue(null)
     getAllWindowsMock.mockReset()
     getAllWindowsMock.mockReturnValue([])
+    getPrimaryAppWindowMock.mockReset()
+    getPrimaryAppWindowMock.mockImplementation(
+      () =>
+        getAllWindowsMock().find(
+          (window: { isDestroyed: () => boolean }) => !window.isDestroyed()
+        ) ?? null
+    )
     shellOpenExternalMock.mockClear()
     setTrayAttentionMock.mockClear()
   })
@@ -283,12 +299,10 @@ describe('registerNotificationHandlers', () => {
   })
 
   it('suppresses active-worktree notifications while Orca is focused', async () => {
-    getAllWindowsMock.mockReturnValue([
-      {
-        isDestroyed: () => false,
-        isFocused: () => true
-      } as never
-    ])
+    getPrimaryAppWindowMock.mockReturnValue({
+      isDestroyed: () => false,
+      isFocused: () => true
+    } as never)
 
     registerNotificationHandlers({
       getSettings: () => ({
@@ -307,6 +321,36 @@ describe('registerNotificationHandlers', () => {
       reason: 'suppressed-focus'
     })
     expect(notificationCtorMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the primary registered app window for focus suppression', async () => {
+    const offscreenWindow = {
+      isDestroyed: () => false,
+      isFocused: () => true
+    }
+    const appWindow = {
+      isDestroyed: () => false,
+      isFocused: () => false
+    }
+    getAllWindowsMock.mockReturnValue([offscreenWindow] as never)
+    getPrimaryAppWindowMock.mockReturnValue(appWindow as never)
+
+    registerNotificationHandlers({
+      getSettings: () => ({
+        notifications: {
+          enabled: true,
+          agentTaskComplete: true,
+          terminalBell: true,
+          suppressWhenFocused: true
+        }
+      })
+    } as never)
+
+    const handler = getDispatchHandler()
+    expect(
+      await handler({}, { source: 'agent-task-complete', isActiveWorktree: true, title: 'Done' })
+    ).toEqual({ delivered: true })
+    expect(notificationCtorMock).toHaveBeenCalledTimes(1)
   })
 
   describe('minimized tray attention dot', () => {

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: notification IPC keeps permission, dispatch, custom sound asset, and sound-loading handlers colocated so renderer/main contracts stay auditable. */
-import { app, BrowserWindow, Notification, ipcMain, shell } from 'electron'
+import { app, Notification, ipcMain, shell } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
 import { extname, isAbsolute, normalize } from 'node:path'
 import beepSoundPath from '../../../resources/notification-sounds/beep.mp3?asset'
@@ -28,6 +28,7 @@ import { readNotificationAuthorizationStatus } from './notification-authorizatio
 import { parsePaneKey } from '../../shared/stable-pane-id'
 import { setTrayAttention } from '../tray/system-tray'
 import { isMainWindowVisible } from '../window/main-window-visibility'
+import { detachedWindowRegistry } from '../window/detached-window-registry'
 
 const NOTIFICATION_COOLDOWN_MS = 5000
 const MAX_RECENT_NOTIFICATION_KEYS = 50
@@ -395,7 +396,7 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
     ): NotificationDispatchResult | Promise<NotificationDispatchResult> => {
       // Why: light the tray attention dot before the cooldown/focus/enabled gates so they can't hold it back (clears on window show/restore; see index.ts).
       if (args.source === 'agent-task-complete' || args.source === 'terminal-bell') {
-        const activeWindow = BrowserWindow.getAllWindows().find((win) => !win.isDestroyed()) ?? null
+        const activeWindow = detachedWindowRegistry.getPrimaryAppWindow()
         if (!isMainWindowVisible(activeWindow)) {
           setTrayAttention(true)
         }
@@ -430,8 +431,7 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
         }
       }
 
-      const browserWindow =
-        BrowserWindow.getAllWindows().find((window) => !window.isDestroyed()) ?? null
+      const browserWindow = detachedWindowRegistry.getPrimaryAppWindow()
       if (
         settings.suppressWhenFocused &&
         args.isActiveWorktree &&
@@ -512,7 +512,7 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
           const repoId = getRepoIdFromWorktreeId(args.worktreeId)
           clickHandler = () => {
             release()
-            const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+            const win = detachedWindowRegistry.getPrimaryAppWindow()
             if (!win) {
               return
             }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -217,6 +217,9 @@ import {
   isHiddenRendererPty
 } from './pty-hidden-delivery-gate'
 import { OrcaRuntimeService } from '../runtime/orca-runtime'
+import { detachedWindowRegistry } from '../window/detached-window-registry'
+import { paneOwnershipRegistry } from '../window/pane-ownership-registry'
+import { trustedRendererRegistry } from '../window/trusted-renderer-registry'
 import { hasLiveClaudePtys, markClaudePtySpawned } from '../claude-accounts/live-pty-gate'
 import * as livePtyGate from '../claude-accounts/live-pty-gate'
 import {
@@ -264,6 +267,8 @@ describe('registerPtyHandlers', () => {
     isVisible: () => true,
     isMinimized: () => false,
     webContents: {
+      id: 17,
+      isDestroyed: vi.fn(() => false),
       on: vi.fn(),
       send: vi.fn(),
       removeListener: vi.fn(),
@@ -274,6 +279,19 @@ describe('registerPtyHandlers', () => {
   const mainWindowIpcEvent = { sender: mainWindow.webContents }
   const foreignWindowIpcEvent = {
     sender: { on: vi.fn(), send: vi.fn(), removeListener: vi.fn() }
+  }
+  function createDetachedWindow(id: number) {
+    return {
+      isDestroyed: () => false,
+      on: vi.fn(),
+      close: vi.fn(),
+      focus: vi.fn(),
+      webContents: {
+        id,
+        isDestroyed: vi.fn(() => false),
+        send: vi.fn()
+      }
+    }
   }
 
   const savedOpenCodeConfigDir = process.env.OPENCODE_CONFIG_DIR
@@ -350,6 +368,8 @@ describe('registerPtyHandlers', () => {
     _resetHiddenRendererPtyDeliveryGateForTest()
 
     // Why: mirror real Electron — ipcMain.handle throws on a duplicate channel, catching re-registration that forgot removeHandler.
+    trustedRendererRegistry.clearWebContents(mainWindow.webContents.id)
+    paneOwnershipRegistry.clearPaneOwnerByWebContentsId(mainWindow.webContents.id)
     handleMock.mockImplementation((channel: string, handler: (...a: unknown[]) => unknown) => {
       if (handlers.has(channel)) {
         throw new Error(`Attempted to register a second handler for '${channel}'`)
@@ -4289,6 +4309,217 @@ describe('registerPtyHandlers', () => {
       }
     } finally {
       vi.useRealTimers()
+    }
+  })
+
+  it('fans PTY data and exit to the main window and owning detached window', async () => {
+    vi.useFakeTimers()
+    const detachedWindow = createDetachedWindow(88)
+    const runtime = {
+      setPtyController: vi.fn(),
+      registerPty: vi.fn(),
+      noteTerminalSpawnCommand: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn(),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'terminal-handle-detached'),
+      registerPreAllocatedHandleForPty: vi.fn()
+    }
+
+    try {
+      registerPtyHandlers(
+        mainWindow as never,
+        runtime as never,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { awaitLocalPtyStartup: () => Promise.resolve() }
+      )
+      const pendingSpawn = handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        sessionId: 'detached-fanout-session'
+      }) as Promise<{ id: string }>
+      await Promise.resolve()
+      const daemon = installObservableDaemonTestProvider()
+      rebindLocalProviderListeners()
+      const result = await pendingSpawn
+
+      detachedWindowRegistry.registerDetachedTerminalWindow(
+        { worktreeId: 'wt-1', tabId: 'tab-1' },
+        detachedWindow as never,
+        { ptyIds: [result.id] } as never
+      )
+      paneOwnershipRegistry.registerPaneOwner({
+        webContentsId: detachedWindow.webContents.id,
+        ptyId: result.id,
+        worktreeId: 'wt-1',
+        tabId: 'tab-1'
+      })
+
+      daemon.emitData(result.id, 'detached output')
+      vi.advanceTimersByTime(8)
+      daemon.emitExit(result.id, 0)
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: result.id,
+        data: 'detached output'
+      })
+      expect(detachedWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: result.id,
+        data: 'detached output'
+      })
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
+        id: result.id,
+        code: 0
+      })
+      expect(detachedWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
+        id: result.id,
+        code: 0
+      })
+    } finally {
+      detachedWindowRegistry.unregisterWindow(detachedWindow as never)
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps main-window data acknowledgements valid after a detached owner is registered', async () => {
+    vi.useFakeTimers()
+    const detachedWindow = createDetachedWindow(89)
+    const acknowledgeDataEvent = vi.fn()
+    let dataHandler: ((payload: { id: string; data: string }) => void) | null = null
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      acknowledgeDataEvent,
+      onData: vi.fn((handler: (payload: { id: string; data: string }) => void) => {
+        dataHandler = handler
+        return () => {}
+      }),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+
+    try {
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never)
+      const ackData = getPtyAckDataListener()
+      detachedWindowRegistry.registerDetachedTerminalWindow(
+        { worktreeId: 'wt-ack', tabId: 'tab-ack' },
+        detachedWindow as never,
+        { ptyIds: ['pty-ack'] } as never
+      )
+      paneOwnershipRegistry.registerPaneOwner({
+        webContentsId: detachedWindow.webContents.id,
+        ptyId: 'pty-ack',
+        worktreeId: 'wt-ack',
+        tabId: 'tab-ack'
+      })
+
+      const deliverPtyData = dataHandler as ((payload: { id: string; data: string }) => void) | null
+      if (!deliverPtyData) {
+        throw new Error('expected PTY data handler to be registered')
+      }
+      deliverPtyData({ id: 'pty-ack', data: 'ack me' })
+      vi.advanceTimersByTime(8)
+      ackData({ sender: detachedWindow.webContents }, { id: 'pty-ack', charCount: 6 })
+      ackData({ sender: mainWindow.webContents }, { id: 'pty-ack', charCount: 6 })
+
+      expect(acknowledgeDataEvent).toHaveBeenCalledTimes(1)
+      expect(acknowledgeDataEvent).toHaveBeenCalledWith('pty-ack', 6)
+    } finally {
+      detachedWindowRegistry.unregisterWindow(detachedWindow as never)
+      vi.useRealTimers()
+    }
+  })
+
+  it('limits detached PTY session listing and per-PTY controls to owned panes', async () => {
+    const detachedWindow = createDetachedWindow(91)
+    const ownedShutdown = vi.fn(async () => undefined)
+    const sendSignal = vi.fn(async () => undefined)
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: ownedShutdown,
+      sendSignal,
+      getCwd: vi.fn(async (id: string) => `/cwd/${id}`),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(async (id: string) => id === 'pty-owned'),
+      getForegroundProcess: vi.fn(async (id: string) => `fg:${id}`),
+      serialize: vi.fn(async (id: string) => ({
+        data: `buffer:${id}`,
+        cols: 80,
+        rows: 24
+      })),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => [
+        { id: 'pty-owned', cwd: '/owned', title: 'owned' },
+        { id: 'pty-foreign', cwd: '/foreign', title: 'foreign' }
+      ]),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      trustedRendererRegistry.grant(detachedWindow.webContents.id, 'pty')
+      paneOwnershipRegistry.registerPaneOwner({
+        webContentsId: detachedWindow.webContents.id,
+        ptyId: 'pty-owned',
+        worktreeId: 'wt-owned',
+        tabId: 'tab-owned'
+      })
+
+      await expect(
+        handlers.get('pty:listSessions')!({ sender: detachedWindow.webContents }, undefined)
+      ).resolves.toEqual([{ id: 'pty-owned', cwd: '/owned', title: 'owned' }])
+      await expect(
+        handlers.get('pty:getMainBufferSnapshot')!(
+          { sender: detachedWindow.webContents },
+          { id: 'pty-foreign' }
+        )
+      ).resolves.toBeNull()
+      await expect(
+        handlers.get('pty:hasChildProcesses')!(
+          { sender: detachedWindow.webContents },
+          { id: 'pty-foreign' }
+        )
+      ).resolves.toBe(false)
+      await expect(
+        handlers.get('pty:getForegroundProcess')!(
+          { sender: detachedWindow.webContents },
+          { id: 'pty-foreign' }
+        )
+      ).resolves.toBeNull()
+      await expect(
+        handlers.get('pty:getCwd')!({ sender: detachedWindow.webContents }, { id: 'pty-foreign' })
+      ).resolves.toBe('')
+      await handlers.get('pty:kill')!({ sender: detachedWindow.webContents }, { id: 'pty-foreign' })
+      const signalListener = onMock.mock.calls.find(
+        (call: unknown[]) => call[0] === 'pty:signal'
+      )?.[1] as ((event: unknown, args: { id: string; signal: string }) => void) | undefined
+      signalListener?.(
+        { sender: detachedWindow.webContents },
+        { id: 'pty-foreign', signal: 'SIGTERM' }
+      )
+
+      expect(ownedShutdown).not.toHaveBeenCalled()
+      expect(sendSignal).not.toHaveBeenCalled()
+    } finally {
+      trustedRendererRegistry.clearWebContents(detachedWindow.webContents.id)
+      paneOwnershipRegistry.clearPaneOwnerByWebContentsId(detachedWindow.webContents.id)
     }
   })
 
@@ -12058,6 +12289,60 @@ describe('registerPtyHandlers', () => {
     })
   })
 
+  it('routes clear-buffer requests to the owning detached window', async () => {
+    const detachedWindow = createDetachedWindow(90)
+    const runtime = {
+      setPtyController: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyData: vi.fn(),
+      onPtyExit: vi.fn()
+    }
+    const clearBuffer = vi.fn()
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      clearBuffer,
+      onData: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+
+    try {
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never, runtime as never)
+      detachedWindowRegistry.registerDetachedTerminalWindow(
+        { worktreeId: 'wt-clear', tabId: 'tab-clear' },
+        detachedWindow as never,
+        { ptyIds: ['pty-clear'] } as never
+      )
+      paneOwnershipRegistry.registerPaneOwner({
+        webContentsId: detachedWindow.webContents.id,
+        ptyId: 'pty-clear',
+        worktreeId: 'wt-clear',
+        tabId: 'tab-clear'
+      })
+
+      const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+        clearBuffer(ptyId: string): Promise<void>
+      }
+      await controller.clearBuffer('pty-clear')
+
+      expect(detachedWindow.webContents.send).toHaveBeenCalledWith('pty:clearBuffer:request', {
+        ptyId: 'pty-clear'
+      })
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:clearBuffer:request', {
+        ptyId: 'pty-clear'
+      })
+      expect(clearBuffer).toHaveBeenCalledWith('pty-clear')
+    } finally {
+      detachedWindowRegistry.unregisterWindow(detachedWindow as never)
+    }
+  })
+
   describe('serializeBuffer dispatch', () => {
     type SerializeListener = (
       _event: unknown,
@@ -12096,6 +12381,14 @@ describe('registerPtyHandlers', () => {
 
     function getSentRequestIds(): string[] {
       return mainWindow.webContents.send.mock.calls
+        .filter((call: unknown[]) => call[0] === 'pty:serializeBuffer:request')
+        .map((call: unknown[]) => (call[1] as { requestId: string }).requestId)
+    }
+
+    function getDetachedSentRequestIds(
+      detachedWindow: ReturnType<typeof createDetachedWindow>
+    ): string[] {
+      return detachedWindow.webContents.send.mock.calls
         .filter((call: unknown[]) => call[0] === 'pty:serializeBuffer:request')
         .map((call: unknown[]) => (call[1] as { requestId: string }).requestId)
     }
@@ -12152,6 +12445,59 @@ describe('registerPtyHandlers', () => {
         rows: 30,
         lastTitle: 'A-title'
       })
+    })
+
+    it('routes serialize requests to the owning detached window and accepts only that response', async () => {
+      const detachedWindow = createDetachedWindow(91)
+      try {
+        const { listener, controller } = setup()
+        detachedWindowRegistry.registerDetachedTerminalWindow(
+          { worktreeId: 'wt-serialize', tabId: 'tab-serialize' },
+          detachedWindow as never,
+          { ptyIds: ['pty-owned'] } as never
+        )
+        paneOwnershipRegistry.registerPaneOwner({
+          webContentsId: detachedWindow.webContents.id,
+          ptyId: 'pty-owned',
+          worktreeId: 'wt-serialize',
+          tabId: 'tab-serialize'
+        })
+
+        const pending = controller.serializeBuffer('pty-owned')
+        const requestId = getDetachedSentRequestIds(detachedWindow)[0]
+
+        expect(requestId).toBeTruthy()
+        expect(mainWindow.webContents.send).not.toHaveBeenCalledWith(
+          'pty:serializeBuffer:request',
+          expect.objectContaining({ ptyId: 'pty-owned' })
+        )
+
+        listener(
+          { sender: mainWindow.webContents },
+          {
+            requestId,
+            snapshot: { data: 'wrong', cols: 1, rows: 1 }
+          }
+        )
+
+        let resolved = false
+        void pending.then(() => {
+          resolved = true
+        })
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        expect(resolved).toBe(false)
+
+        listener(
+          { sender: detachedWindow.webContents },
+          {
+            requestId,
+            snapshot: { data: 'owned', cols: 80, rows: 24 }
+          }
+        )
+        await expect(pending).resolves.toEqual({ data: 'owned', cols: 80, rows: 24 })
+      } finally {
+        detachedWindowRegistry.unregisterWindow(detachedWindow as never)
+      }
     })
 
     it('ignores responses with unknown requestId without affecting pending requests', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -157,6 +157,9 @@ import {
 } from '../project-groups/folder-workspace-path-status'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtime-resolution'
+import { trustedRendererRegistry } from '../window/trusted-renderer-registry'
+import { paneOwnershipRegistry } from '../window/pane-ownership-registry'
+import { detachedWindowRegistry } from '../window/detached-window-registry'
 
 // ─── Provider Registry ──────────────────────────────────────────────
 // Routes PTY operations by connectionId (null = local provider).
@@ -1453,6 +1456,10 @@ export function registerPtyHandlers(
   ipcMain.removeAllListeners('pty:deliveryResyncResponse')
   ipcMain.removeAllListeners('pty:serializeBuffer:response')
 
+  if (typeof mainWindow.webContents.id === 'number') {
+    trustedRendererRegistry.grant(mainWindow.webContents.id, 'pty')
+    paneOwnershipRegistry.setPrimaryAppWebContentsId(mainWindow.webContents.id)
+  }
   // Why: only LocalPtyProvider needs main-process hook injection; daemon-backed providers spawn subprocesses internally.
   if (localProvider instanceof LocalPtyProvider) {
     localProvider.configure({
@@ -2018,6 +2025,23 @@ export function registerPtyHandlers(
     return writtenOff
   }
 
+  function getOwnerWindowForPty(ptyId: string): BrowserWindow | null {
+    const ownerWebContentsId = paneOwnershipRegistry.getOwnerForPty(ptyId)
+    if (ownerWebContentsId === null || ownerWebContentsId === mainWindow.webContents.id) {
+      return null
+    }
+    return (
+      detachedWindowRegistry
+        .getAppWindows()
+        .find((window) => window.webContents.id === ownerWebContentsId && !window.isDestroyed()) ??
+      null
+    )
+  }
+
+  function getPaneRequestTargetWindow(ptyId: string): BrowserWindow | null {
+    return getOwnerWindowForPty(ptyId) ?? (mainWindow.isDestroyed() ? null : mainWindow)
+  }
+
   function sendPtyDataToRenderer(id: string, payload: PtyDataPayload): void {
     const charCount = getPtyPayloadCharCount(payload)
     const accounting = rendererDeliveryAccountingByPty.get(id)
@@ -2035,6 +2059,7 @@ export function registerPtyHandlers(
     rendererInFlightTotalChars += charCount
     recordPtyRendererDeliveryPressure()
     mainWindow.webContents.send('pty:data', payload)
+    getOwnerWindowForPty(id)?.webContents.send('pty:data', payload)
   }
 
   function rendererPtyIsKnownHidden(id: string): boolean {
@@ -2373,6 +2398,7 @@ export function registerPtyHandlers(
     // Why: the renderer also drops its cumulative total on pty:exit, so a reused id restarts aligned at zero on both sides.
     rendererDeliveryAccountingByPty.delete(payload.id)
     recordPtyRendererDeliveryPressure()
+    getOwnerWindowForPty(payload.id)?.webContents.send('pty:exit', payload)
     mainWindow.webContents.send('pty:exit', payload)
   }
 
@@ -2558,7 +2584,11 @@ export function registerPtyHandlers(
   } | null
   const pendingSerializeRequests = new Map<
     string,
-    { resolve: (result: SerializeResult) => void; timeout: NodeJS.Timeout }
+    {
+      resolve: (result: SerializeResult) => void
+      timeout: NodeJS.Timeout
+      expectedResponderWebContentsId: number
+    }
   >()
 
   function settleSerializeRequest(requestId: string, result: SerializeResult): void {
@@ -2574,7 +2604,7 @@ export function registerPtyHandlers(
   ipcMain.on(
     'pty:serializeBuffer:response',
     (
-      _event,
+      event,
       args: {
         requestId?: string
         snapshot?: {
@@ -2587,6 +2617,13 @@ export function registerPtyHandlers(
       }
     ) => {
       if (typeof args?.requestId !== 'string') {
+        return
+      }
+      const pending = pendingSerializeRequests.get(args.requestId)
+      if (
+        !pending ||
+        (event?.sender?.id ?? mainWindow.webContents.id) !== pending.expectedResponderWebContentsId
+      ) {
         return
       }
       const snapshot = args.snapshot
@@ -2624,7 +2661,8 @@ export function registerPtyHandlers(
     ptyId: string,
     opts?: { scrollbackRows?: number; altScreenForcesZeroRows?: boolean }
   ): Promise<SerializeResult> {
-    if (mainWindow.isDestroyed()) {
+    const targetWindow = getPaneRequestTargetWindow(ptyId)
+    if (!targetWindow) {
       return Promise.resolve(null)
     }
 
@@ -2633,7 +2671,11 @@ export function registerPtyHandlers(
       const timeout = setTimeout(() => {
         settleSerializeRequest(requestId, null)
       }, 750)
-      pendingSerializeRequests.set(requestId, { resolve, timeout })
+      pendingSerializeRequests.set(requestId, {
+        resolve,
+        timeout,
+        expectedResponderWebContentsId: targetWindow.webContents.id
+      })
       const payload: {
         requestId: string
         ptyId: string
@@ -2642,7 +2684,7 @@ export function registerPtyHandlers(
       if (opts) {
         payload.opts = opts
       }
-      mainWindow.webContents.send('pty:serializeBuffer:request', payload)
+      targetWindow.webContents.send('pty:serializeBuffer:request', payload)
     })
   }
 
@@ -3383,7 +3425,7 @@ export function registerPtyHandlers(
     },
     clearBuffer: async (ptyId) => {
       // Why: desktop xterm and daemon/SSH providers hold separate buffers; clear both so mobile resubscribe can't resurrect cleared history.
-      mainWindow.webContents.send('pty:clearBuffer:request', { ptyId })
+      getPaneRequestTargetWindow(ptyId)?.webContents.send('pty:clearBuffer:request', { ptyId })
       try {
         await getProviderForPty(ptyId).clearBuffer(ptyId)
       } catch {
@@ -3450,7 +3492,7 @@ export function registerPtyHandlers(
   ipcMain.handle(
     'pty:getMainBufferSnapshot',
     async (
-      _event,
+      event,
       args: { id?: unknown; opts?: { scrollbackRows?: unknown } }
     ): Promise<{
       data: string
@@ -3465,7 +3507,12 @@ export function registerPtyHandlers(
       scrollbackAnsi?: string
       pendingEscapeTailAnsi?: string
     } | null> => {
-      if (!runtime || typeof args?.id !== 'string' || args.id.length === 0) {
+      if (
+        !runtime ||
+        typeof args?.id !== 'string' ||
+        args.id.length === 0 ||
+        !senderCanAccessPty(event, args.id)
+      ) {
         return null
       }
       const scrollbackRows = normalizeSnapshotScrollbackRows(args.opts?.scrollbackRows)
@@ -3509,8 +3556,13 @@ export function registerPtyHandlers(
   )
 
   // Why: main owns side effects, so this replay restores title state only — never historical bells/completions (no-attention-replay rule, terminal-side-effect-authority.md).
-  ipcMain.handle('pty:sideEffectSnapshot', (_event, args: { id: string }) => {
-    if (!runtime || typeof args?.id !== 'string' || args.id.length === 0) {
+  ipcMain.handle('pty:sideEffectSnapshot', (event, args: { id: string }) => {
+    if (
+      !runtime ||
+      typeof args?.id !== 'string' ||
+      args.id.length === 0 ||
+      !senderCanAccessPty(event, args.id)
+    ) {
       return null
     }
     return runtime.getTerminalSideEffectSnapshot(args.id)
@@ -4362,13 +4414,26 @@ export function registerPtyHandlers(
     (value as { cols: number }).cols > 0 &&
     (value as { rows: number }).rows > 0
 
-  const isPtyWriteEventFromMainWindow = (
-    event: IpcMainEvent | IpcMainInvokeEvent,
-    mainWebContents: WebContents
-  ): boolean =>
-    event.sender === mainWebContents &&
-    !mainWindow.isDestroyed() &&
-    !(typeof mainWebContents.isDestroyed === 'function' && mainWebContents.isDestroyed())
+  const senderCanAccessPty = (event: IpcMainEvent | IpcMainInvokeEvent, ptyId: string): boolean => {
+    const sender = event?.sender ?? mainWindow.webContents
+    return (
+      trustedRendererRegistry.has(sender.id, 'pty') &&
+      !sender.isDestroyed?.() &&
+      paneOwnershipRegistry.senderOwnsPty(sender, ptyId)
+    )
+  }
+
+  // Why: delivery accounting (ACKs, dispatcher-ready handshake) is keyed to the
+  // primary window's renderer; detached windows own per-PTY routing instead.
+  const senderIsPrimaryPtyRenderer = (event: IpcMainEvent | IpcMainInvokeEvent): boolean => {
+    const sender = event?.sender ?? mainWindow.webContents
+    return (
+      !mainWindow.isDestroyed() &&
+      sender.id === mainWindow.webContents.id &&
+      trustedRendererRegistry.has(sender.id, 'pty') &&
+      !sender.isDestroyed?.()
+    )
+  }
 
   const writePtyInput = (args: PtyWritePayload): boolean | Promise<boolean> => {
     // Why: mobile-presence-lock defense-in-depth — the renderer's onData guard can let one keystroke slip during the state-flip lag, so catch it server-side. See docs/mobile-presence-lock.md.
@@ -4420,7 +4485,7 @@ export function registerPtyHandlers(
   const hostViewportClaimTails = new Map<string, Promise<boolean>>()
 
   ipcMain.on('pty:write', (event, args: unknown) => {
-    if (!isPtyWriteEventFromMainWindow(event, mainWindow.webContents) || !isPtyWritePayload(args)) {
+    if (!isPtyWritePayload(args) || !senderCanAccessPty(event, args.id)) {
       return
     }
     const claimTail = hostViewportClaimTails.get(args.id)
@@ -4431,7 +4496,7 @@ export function registerPtyHandlers(
     writePtyInput(args)
   })
   ipcMain.handle('pty:writeAccepted', (event, args: unknown): boolean | Promise<boolean> => {
-    if (!isPtyWriteEventFromMainWindow(event, mainWindow.webContents) || !isPtyWritePayload(args)) {
+    if (!isPtyWritePayload(args) || !senderCanAccessPty(event, args.id)) {
       return false
     }
     const claimTail = hostViewportClaimTails.get(args.id)
@@ -4442,11 +4507,7 @@ export function registerPtyHandlers(
 
   ipcMain.removeAllListeners('pty:claimViewport')
   ipcMain.on('pty:claimViewport', (event, args: unknown) => {
-    if (
-      !isPtyWriteEventFromMainWindow(event, mainWindow.webContents) ||
-      !runtime ||
-      !isPtyViewportClaimPayload(args)
-    ) {
+    if (!runtime || !isPtyViewportClaimPayload(args) || !senderCanAccessPty(event, args.id)) {
       return
     }
     const prior = hostViewportClaimTails.get(args.id)
@@ -4469,7 +4530,10 @@ export function registerPtyHandlers(
 
   // Why: resize is fire-and-forget — ipcMain.on (not .handle) halves IPC traffic by skipping the empty acknowledgement reply.
   ipcMain.removeAllListeners('pty:resize')
-  ipcMain.on('pty:resize', (_event, args: { id: string; cols: number; rows: number }) => {
+  ipcMain.on('pty:resize', (event, args: { id: string; cols: number; rows: number }) => {
+    if (!args?.id || !senderCanAccessPty(event, args.id)) {
+      return
+    }
     // Why: after a desktop-fit override change the renderer's safeFit cascade re-measures ALL panes (background ones at full width), so suppress every pty:resize in this window to avoid corrupting PTY dimensions.
     if (runtime?.isResizeSuppressed()) {
       return
@@ -4510,12 +4574,18 @@ export function registerPtyHandlers(
 
   // Why: pty:reportGeometry is a measurement-only sibling of pty:resize — it refreshes the restore-target cache (never resizes) so mobile-fit hold learns real desktop dims even while resize is blocked. See docs/mobile-fit-hold.md.
   ipcMain.removeAllListeners('pty:reportGeometry')
-  ipcMain.on('pty:reportGeometry', (_event, args: { id: string; cols: number; rows: number }) => {
+  ipcMain.on('pty:reportGeometry', (event, args: { id: string; cols: number; rows: number }) => {
+    if (!args?.id || !senderCanAccessPty(event, args.id)) {
+      return
+    }
     runtime?.recordRendererGeometry(args.id, args.cols, args.rows)
   })
 
   // Why: fire-and-forget — clears the DaemonPtyAdapter's sticky cold-restore cache after the renderer consumed it; no-op for non-daemon providers.
-  ipcMain.on('pty:ackColdRestore', (_event, args: { id: string }) => {
+  ipcMain.on('pty:ackColdRestore', (event, args: { id: string }) => {
+    if (!args?.id || !senderCanAccessPty(event, args.id)) {
+      return
+    }
     const provider = tryGetProviderForPty(args.id)
     if (provider && 'ackColdRestore' in provider && typeof provider.ackColdRestore === 'function') {
       provider.ackColdRestore(args.id)
@@ -4525,7 +4595,10 @@ export function registerPtyHandlers(
   // Why: renderer ACKs bound main→renderer delivery without stopping PTY ingestion — agent/status consumers still see every chunk via the provider/runtime path.
   ipcMain.on(
     'pty:ackData',
-    (_event, args: { id: string; charCount?: number; processedChars?: number }) => {
+    (event, args: { id: string; charCount?: number; processedChars?: number }) => {
+      if (!args?.id || !senderIsPrimaryPtyRenderer(event)) {
+        return
+      }
       lastAckReceivedAtMs = Date.now()
       // Why: a live ACK channel means a future unanswered probe is a fresh diagnostic event, not a continuation of the last silent streak.
       deliveryResyncUnansweredWarnLogged = false
@@ -4548,8 +4621,9 @@ export function registerPtyHandlers(
 
   ipcMain.on(
     'pty:deliveryResyncResponse',
-    (_event, args: { requestId: number; processedCharsByPty: Record<string, number> }) => {
+    (event, args: { requestId: number; processedCharsByPty: Record<string, number> }) => {
       if (
+        !senderIsPrimaryPtyRenderer(event) ||
         deliveryResyncOutstandingRequestId === null ||
         args?.requestId !== deliveryResyncOutstandingRequestId
       ) {
@@ -4577,7 +4651,11 @@ export function registerPtyHandlers(
   // Why invoke + renderer-initiated: the field wedge (v1.4.121-rc.0) kills every main→renderer push channel while invoke survives, so the resync rides here plus a write-off lane.
   ipcMain.handle(
     'pty:reportRendererDeliveryState',
-    (_event, args: PtyRendererDeliveryStateReport): PtyRendererDeliveryHealthReply => {
+    (event, args: PtyRendererDeliveryStateReport): PtyRendererDeliveryHealthReply => {
+      // Why: delivery accounting belongs to the primary renderer; an unrelated window must not merge ACK totals or trigger write-offs.
+      if (!senderIsPrimaryPtyRenderer(event)) {
+        return { inFlightTotalChars: 0, inFlightPtyCount: 0, msSinceLastAck: null }
+      }
       // Extra repair lane for the lost-ACK variant: identical max-merge to the resync response, so a heal is only reached when merging cannot drain.
       for (const [id, processedChars] of Object.entries(args?.processedCharsByPty ?? {})) {
         if (typeof processedChars !== 'number' || !Number.isFinite(processedChars)) {
@@ -4621,7 +4699,7 @@ export function registerPtyHandlers(
   ipcMain.removeAllListeners('pty:rendererDispatcherReady')
   ipcMain.on('pty:rendererDispatcherReady', (event) => {
     // Why: the reconcile below destructively clears delivery accounting, so a straggler handshake from a dying window must not reset the new window.
-    if (!isPtyWriteEventFromMainWindow(event, mainWindow.webContents)) {
+    if (!senderIsPrimaryPtyRenderer(event)) {
       return
     }
     // Why: a handshake while the gate is already open means a page load whose lifecycle reset was missed; clear the dead page's stale accounting so it can't permanently gate survivors.
@@ -4635,8 +4713,8 @@ export function registerPtyHandlers(
   })
 
   ipcMain.removeAllListeners('pty:setActiveRendererPty')
-  ipcMain.on('pty:setActiveRendererPty', (_event, args: { id: string; active: boolean }) => {
-    if (typeof args.id !== 'string' || !args.id) {
+  ipcMain.on('pty:setActiveRendererPty', (event, args: { id: string; active: boolean }) => {
+    if (typeof args.id !== 'string' || !args.id || !senderCanAccessPty(event, args.id)) {
       return
     }
     // Why: renderer scheduling hint only — active panes just get first chance at the bounded output reserve; reads/state/notifications continue for inactive terminals.
@@ -4651,8 +4729,8 @@ export function registerPtyHandlers(
   })
 
   ipcMain.removeAllListeners('pty:setRendererPtyVisible')
-  ipcMain.on('pty:setRendererPtyVisible', (_event, args: { id: string; visible: boolean }) => {
-    if (typeof args.id !== 'string' || !args.id) {
+  ipcMain.on('pty:setRendererPtyVisible', (event, args: { id: string; visible: boolean }) => {
+    if (typeof args.id !== 'string' || !args.id || !senderCanAccessPty(event, args.id)) {
       return
     }
     // Why: data produced while no renderer can see this PTY must keep that origin through batching, even if the user switches back before the flush lands.
@@ -4667,8 +4745,8 @@ export function registerPtyHandlers(
   })
 
   ipcMain.removeAllListeners('pty:setHiddenRendererPty')
-  ipcMain.on('pty:setHiddenRendererPty', (_event, args: { id: string; hidden: boolean }) => {
-    if (typeof args.id !== 'string' || !args.id) {
+  ipcMain.on('pty:setHiddenRendererPty', (event, args: { id: string; hidden: boolean }) => {
+    if (typeof args.id !== 'string' || !args.id || !senderCanAccessPty(event, args.id)) {
       return
     }
     mainDeliveryBreadcrumbs.record(args.hidden === true ? 'gate-mark' : 'gate-unmark', {
@@ -4705,7 +4783,11 @@ export function registerPtyHandlers(
   })
 
   ipcMain.removeAllListeners('pty:terminalViewAttributes')
-  ipcMain.on('pty:terminalViewAttributes', (_event, args: unknown) => {
+  ipcMain.on('pty:terminalViewAttributes', (event, args: unknown) => {
+    // Why: the palette drives the global TUI color reply; only pty-capable app renderers may set it.
+    if (!event?.sender || !trustedRendererRegistry.has(event.sender.id, 'pty')) {
+      return
+    }
     // Why validate-or-drop: a malformed palette gives a wrong color reply that breaks TUI theme detection worse than the silent-until-first-push default.
     const attributes = validateTerminalViewAttributes(args)
     if (attributes) {
@@ -4714,8 +4796,8 @@ export function registerPtyHandlers(
   })
 
   ipcMain.removeAllListeners('pty:setPtyDeliveryInterest')
-  ipcMain.on('pty:setPtyDeliveryInterest', (_event, args: { id: string; interested: boolean }) => {
-    if (typeof args.id !== 'string' || !args.id) {
+  ipcMain.on('pty:setPtyDeliveryInterest', (event, args: { id: string; interested: boolean }) => {
+    if (typeof args.id !== 'string' || !args.id || !senderCanAccessPty(event, args.id)) {
       return
     }
     // Why: any delivery interest suppresses the hidden-delivery gate (raw-byte consumers keep receiving while hidden); not synced to the daemon pacer so interest churn can't un-pace a flood.
@@ -4723,14 +4805,20 @@ export function registerPtyHandlers(
   })
 
   ipcMain.removeAllListeners('pty:signal')
-  ipcMain.on('pty:signal', (_event, args: { id: string; signal: string }) => {
+  ipcMain.on('pty:signal', (event, args: { id: string; signal: string }) => {
+    if (!args?.id || !senderCanAccessPty(event, args.id)) {
+      return
+    }
     tryGetProviderForPty(args.id)
       ?.sendSignal(args.id, args.signal)
       .catch(() => {})
   })
 
   ipcMain.removeAllListeners('pty:clearBuffer')
-  ipcMain.on('pty:clearBuffer', (_event, args: { id: string }) => {
+  ipcMain.on('pty:clearBuffer', (event, args: { id: string }) => {
+    if (!args?.id || !senderCanAccessPty(event, args.id)) {
+      return
+    }
     // Why: clear PTY-side state (ConPTY/daemon/SSH buffer) so the next prompt repaint doesn't land at a stale cursor row.
     tryGetProviderForPty(args.id)
       ?.clearBuffer(args.id)
@@ -4738,10 +4826,13 @@ export function registerPtyHandlers(
     runtime?.clearHeadlessTerminalBuffer(args.id).catch(() => {})
   })
 
-  ipcMain.handle('pty:kill', async (_event, args: { id: string; keepHistory?: boolean }) => {
+  ipcMain.handle('pty:kill', async (event, args: { id: string; keepHistory?: boolean }) => {
     if (typeof args?.id !== 'string' || !args.id || args.id.startsWith('remote:')) {
       // Why: runtime terminal handles belong to terminal.close; unowned PTY routing could target the local provider.
       throw new Error('Invalid PTY provider id')
+    }
+    if (!senderCanAccessPty(event, args.id)) {
+      return
     }
     const ownedConnectionId = ptyOwnership.get(args.id)
     const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
@@ -4785,7 +4876,7 @@ export function registerPtyHandlers(
 
   ipcMain.handle(
     'pty:listSessions',
-    async (): Promise<{ id: string; cwd: string; title: string }[]> => {
+    async (event): Promise<{ id: string; cwd: string; title: string }[]> => {
       const providerSessions = await Promise.all([
         Promise.resolve({
           connectionId: null as string | null,
@@ -4801,7 +4892,9 @@ export function registerPtyHandlers(
         for (const session of sessions) {
           // Why: kill actions only send back the PTY id, so rebuild ownership while listing to keep reconnect-discovered remote sessions routed to their provider.
           ptyOwnership.set(session.id, connectionId)
-          deduped.set(session.id, session)
+          if (senderCanAccessPty(event, session.id)) {
+            deduped.set(session.id, session)
+          }
         }
       }
       return Array.from(deduped.values())
@@ -4824,6 +4917,11 @@ export function registerPtyHandlers(
           continue
         }
         seen.add(value)
+        // Why: unauthorized ids stay mounted-but-unknown (null) instead of leaking provider routing to unrelated renderers.
+        if (!senderCanAccessPty(event, value)) {
+          capabilities.push({ id: value, authoritative: null })
+          continue
+        }
         const provider = tryGetProviderForPty(value)
         // Why: degraded routing mixes preserved daemons with an in-process fallback; keep all panes mounted rather than guess ownership.
         capabilities.push({
@@ -4840,7 +4938,10 @@ export function registerPtyHandlers(
     }
   )
 
-  ipcMain.handle('pty:hasPty', async (_event, args: { id: string }): Promise<boolean | null> => {
+  ipcMain.handle('pty:hasPty', async (event, args: { id: string }): Promise<boolean | null> => {
+    if (!args?.id || !senderCanAccessPty(event, args.id)) {
+      return null
+    }
     const ownedConnectionId = ptyOwnership.get(args.id)
     const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
     const provider = parsedSshId
@@ -4857,20 +4958,21 @@ export function registerPtyHandlers(
     }
   })
 
-  ipcMain.handle(
-    'pty:hasChildProcesses',
-    async (_event, args: { id: string }): Promise<boolean> => {
-      if (!hasPtyProviderForInspection(args.id)) {
-        return false
-      }
-      return getProviderForPty(args.id).hasChildProcesses(args.id)
+  ipcMain.handle('pty:hasChildProcesses', async (event, args: { id: string }): Promise<boolean> => {
+    if (!args?.id || !senderCanAccessPty(event, args.id) || !hasPtyProviderForInspection(args.id)) {
+      return false
     }
-  )
+    return getProviderForPty(args.id).hasChildProcesses(args.id)
+  })
 
   ipcMain.handle(
     'pty:getForegroundProcess',
-    async (_event, args: { id: string }): Promise<string | null> => {
-      if (!hasPtyProviderForInspection(args.id)) {
+    async (event, args: { id: string }): Promise<string | null> => {
+      if (
+        !args?.id ||
+        !senderCanAccessPty(event, args.id) ||
+        !hasPtyProviderForInspection(args.id)
+      ) {
         return null
       }
       return getProviderForPty(args.id).getForegroundProcess(args.id)
@@ -4879,7 +4981,10 @@ export function registerPtyHandlers(
 
   ipcMain.handle(
     'pty:confirmForegroundProcess',
-    async (_event, args: { id: string }): Promise<string | null> => {
+    async (event, args: { id: string }): Promise<string | null> => {
+      if (!args?.id || !senderCanAccessPty(event, args.id)) {
+        return null
+      }
       if (!hasPtyProviderForInspection(args.id)) {
         return null
       }
@@ -4890,7 +4995,10 @@ export function registerPtyHandlers(
   )
 
   // Why: Cmd+D split needs the live shell cwd so the new pane inherits it (not the worktree root); '' means unknown/unresolvable (Windows) → renderer falls through.
-  ipcMain.handle('pty:getCwd', async (_event, args: { id: string }): Promise<string> => {
+  ipcMain.handle('pty:getCwd', async (event, args: { id: string }): Promise<string> => {
+    if (!args?.id || !senderCanAccessPty(event, args.id)) {
+      return ''
+    }
     try {
       return await getProviderForPty(args.id).getCwd(args.id)
     } catch {
@@ -4901,7 +5009,10 @@ export function registerPtyHandlers(
   // Why: prefer the provider's APPLIED size over the requested ptySizes so the renderer's resume drift-check can spot a dropped resize; null means "cannot confirm" → re-forward once.
   ipcMain.handle(
     'pty:getSize',
-    async (_event, args: { id: string }): Promise<{ cols: number; rows: number } | null> => {
+    async (event, args: { id: string }): Promise<{ cols: number; rows: number } | null> => {
+      if (!args?.id || !senderCanAccessPty(event, args.id)) {
+        return null
+      }
       const provider = tryGetProviderForPty(args.id)
       try {
         if (provider?.getAppliedSize) {
@@ -4930,8 +5041,13 @@ export function registerPtyHandlers(
 
   ipcMain.handle(
     'pty:settlePaneSerializer',
-    async (_event, args: { paneKey?: unknown; gen?: unknown }): Promise<void> => {
+    async (event, args: { paneKey?: unknown; gen?: unknown }): Promise<void> => {
       if (!isValidPaneKey(args.paneKey) || typeof args.gen !== 'number') {
+        return
+      }
+      // Why: the declaring renderer owns this handshake; a stale or unrelated window must not settle it.
+      const owner = pendingByPaneKey.get(args.paneKey)?.ownerWebContentsId
+      if (owner != null && event?.sender && event.sender.id !== owner) {
         return
       }
       const ptyId = pendingPtyIdBySerializerGeneration.get(args.gen)
@@ -4946,8 +5062,12 @@ export function registerPtyHandlers(
 
   ipcMain.handle(
     'pty:clearPendingPaneSerializer',
-    async (_event, args: { paneKey?: unknown; gen?: unknown }): Promise<void> => {
+    async (event, args: { paneKey?: unknown; gen?: unknown }): Promise<void> => {
       if (!isValidPaneKey(args.paneKey) || typeof args.gen !== 'number') {
+        return
+      }
+      const owner = pendingByPaneKey.get(args.paneKey)?.ownerWebContentsId
+      if (owner != null && event?.sender && event.sender.id !== owner) {
         return
       }
       settlePendingPaneSerializer(args.paneKey, args.gen)
@@ -4957,11 +5077,12 @@ export function registerPtyHandlers(
 
   ipcMain.handle(
     'pty:reportRendererSerializerReady',
-    async (_event, args: { ptyId?: unknown }): Promise<void> => {
+    async (event, args: { ptyId?: unknown }): Promise<void> => {
       if (
         typeof args.ptyId !== 'string' ||
         !args.ptyId.startsWith('remote:') ||
-        args.ptyId.length > 512
+        args.ptyId.length > 512 ||
+        !senderCanAccessPty(event, args.ptyId)
       ) {
         return
       }

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -63,7 +63,9 @@ const {
   registerLocalhostWorktreeLabelHandlersMock,
   registerNativeChatHandlersMock,
   registerEmulatorFrameStreamHandlersMock,
-  registerEmulatorVideoStreamHandlersMock
+  registerEmulatorVideoStreamHandlersMock,
+  registerDetachedTerminalHandlersMock,
+  grantManyMock
 } = vi.hoisted(() => ({
   getPathMock: vi.fn(() => '/test/user-data'),
   listEnvironmentsMock: vi.fn(() => []),
@@ -127,7 +129,9 @@ const {
   registerLocalhostWorktreeLabelHandlersMock: vi.fn(),
   registerNativeChatHandlersMock: vi.fn(),
   registerEmulatorFrameStreamHandlersMock: vi.fn(),
-  registerEmulatorVideoStreamHandlersMock: vi.fn()
+  registerEmulatorVideoStreamHandlersMock: vi.fn(),
+  registerDetachedTerminalHandlersMock: vi.fn(),
+  grantManyMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -343,6 +347,11 @@ vi.mock('./browser', () => ({
   setTrustedBrowserRendererWebContentsId: setTrustedBrowserRendererWebContentsIdMock,
   setAgentBrowserBridgeRef: setAgentBrowserBridgeRefMock
 }))
+vi.mock('../window/trusted-renderer-registry', () => ({
+  trustedRendererRegistry: {
+    grantMany: grantManyMock
+  }
+}))
 
 vi.mock('./app', () => ({
   registerAppHandlers: registerAppHandlersMock
@@ -370,6 +379,10 @@ vi.mock('./hosted-review', () => ({
 
 vi.mock('./native-chat', () => ({
   registerNativeChatHandlers: registerNativeChatHandlersMock
+}))
+
+vi.mock('../window/detached-window-coordinator', () => ({
+  registerDetachedTerminalHandlers: registerDetachedTerminalHandlersMock
 }))
 
 import { registerCoreHandlers } from './register-core-handlers'
@@ -422,6 +435,7 @@ describe('registerCoreHandlers', () => {
     registerBrowserHandlersMock.mockReset()
     setAgentBrowserBridgeRefMock.mockReset()
     setTrustedBrowserRendererWebContentsIdMock.mockReset()
+    grantManyMock.mockReset()
     registerFilesystemWatcherHandlersMock.mockReset()
     registerAppHandlersMock.mockReset()
     registerLinearHandlersMock.mockReset()
@@ -439,6 +453,7 @@ describe('registerCoreHandlers', () => {
     registerNativeChatHandlersMock.mockReset()
     registerEmulatorFrameStreamHandlersMock.mockReset()
     registerEmulatorVideoStreamHandlersMock.mockReset()
+    registerDetachedTerminalHandlersMock.mockReset()
   })
 
   it('passes the store through to handler registrars that need it', async () => {
@@ -539,9 +554,8 @@ describe('registerCoreHandlers', () => {
     expect(registerShellHandlersMock).toHaveBeenCalled()
     expect(registerClipboardHandlersMock).toHaveBeenCalledWith(store)
     expect(registerUpdaterHandlersMock).toHaveBeenCalled()
-    expect(setTrustedBrowserRendererWebContentsIdMock).toHaveBeenCalledWith(null)
-    expect(setTrustedClipboardRendererWebContentsIdMock).toHaveBeenCalledWith(null)
-    expect(setTrustedUIRendererWebContentsIdMock).toHaveBeenCalledWith(null)
+    expect(registerDetachedTerminalHandlersMock).toHaveBeenCalled()
+    expect(grantManyMock).not.toHaveBeenCalled()
     expect(registerBrowserHandlersMock).toHaveBeenCalled()
     expect(registerFilesystemWatcherHandlersMock).toHaveBeenCalled()
     expect(registerSpeechHandlersMock).toHaveBeenCalledWith(store)
@@ -628,9 +642,7 @@ describe('registerCoreHandlers', () => {
     )
 
     // Web contents ID should always be updated
-    expect(setTrustedBrowserRendererWebContentsIdMock).toHaveBeenCalledWith(42)
-    expect(setTrustedClipboardRendererWebContentsIdMock).toHaveBeenCalledWith(42)
-    expect(setTrustedUIRendererWebContentsIdMock).toHaveBeenCalledWith(42)
+    expect(grantManyMock).toHaveBeenCalledWith(42, ['ui', 'clipboard', 'pty', 'browser'])
     // IPC handlers should NOT be registered again
     expect(registerCliHandlersMock).not.toHaveBeenCalled()
     expect(registerPreflightHandlersMock).not.toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -34,7 +34,7 @@ import { registerDashboardPopoutHandlers } from './dashboard-popout'
 import { registerTerminalPreviewHandlers } from './terminal-preview'
 import { registerDeveloperPermissionHandlers } from './developer-permissions'
 import { registerComputerUsePermissionHandlers } from './computer-use-permissions'
-import { setTrustedBrowserRendererWebContentsId, setAgentBrowserBridgeRef } from './browser'
+import { setAgentBrowserBridgeRef } from './browser'
 import { registerSessionHandlers } from './session'
 import { registerSettingsHandlers } from './settings'
 import { registerDiagnosticsHandlers } from './diagnostics'
@@ -62,10 +62,9 @@ import { registerClaudeAccountHandlers } from './claude-accounts'
 import { registerMiniMaxCredentialsHandlers } from './minimax-credentials'
 import { registerGrokAccountHandlers } from './grok-accounts'
 import { registerUpdaterHandlers } from '../window/attach-main-window-services'
-import {
-  registerClipboardHandlers,
-  setTrustedClipboardRendererWebContentsId
-} from '../window/clipboard-ipc-handlers'
+import { registerClipboardHandlers } from '../window/clipboard-ipc-handlers'
+import { trustedRendererRegistry } from '../window/trusted-renderer-registry'
+import { registerDetachedTerminalHandlers } from '../window/detached-window-coordinator'
 import type { ClaudeUsageStore } from '../claude-usage/store'
 import type { CodexUsageStore } from '../codex-usage/store'
 import type { OpenCodeUsageStore } from '../opencode-usage/store'
@@ -120,9 +119,15 @@ export function registerCoreHandlers(
   // openMainWindow() is called again on 'activate'. ipcMain.handle() throws
   // if a channel is registered twice, so we guard to register only once and
   // just update the per-window web-contents ID on subsequent calls.
-  setTrustedBrowserRendererWebContentsId(mainWindowWebContentsId)
-  setTrustedClipboardRendererWebContentsId(mainWindowWebContentsId)
   setTrustedUIRendererWebContentsId(mainWindowWebContentsId)
+  if (mainWindowWebContentsId !== null) {
+    trustedRendererRegistry.grantMany(mainWindowWebContentsId, [
+      'ui',
+      'clipboard',
+      'pty',
+      'browser'
+    ])
+  }
   setAgentBrowserBridgeRef(runtime.getAgentBrowserBridge())
   if (registered) {
     return
@@ -213,5 +218,6 @@ export function registerCoreHandlers(
   registerNativeChatHandlers()
   registerClipboardHandlers(store)
   registerUpdaterHandlers(store)
+  registerDetachedTerminalHandlers()
   registerSpeechHandlers(store)
 }

--- a/src/main/ipc/ui.test.ts
+++ b/src/main/ipc/ui.test.ts
@@ -41,6 +41,7 @@ import {
   sendToTrustedUIRenderer,
   setTrustedUIRendererWebContentsId
 } from './ui'
+import { trustedRendererRegistry } from '../window/trusted-renderer-registry'
 
 function makeStore() {
   return {
@@ -83,7 +84,8 @@ describe('UI IPC', () => {
     handleMock.mockReset()
     onMock.mockReset()
     removeAllListenersMock.mockReset()
-    setTrustedUIRendererWebContentsId(null)
+    trustedRendererRegistry.clearWebContents(17)
+    trustedRendererRegistry.clearWebContents(42)
   })
 
   afterEach(() => {
@@ -165,6 +167,23 @@ describe('UI IPC', () => {
     expect(oldRendererSend).toHaveBeenCalledTimes(1)
     expect(newRendererSend).toHaveBeenCalledTimes(1)
     expect(newRendererSend).toHaveBeenCalledWith('gh:prRefreshEvent', { sequence: 2 })
+  })
+
+  it('broadcasts UI state changes to every live window, skipping destroyed ones', () => {
+    const liveSend = vi.fn()
+    const destroyedSend = vi.fn()
+    const store = makeStore()
+    getAllWindowsMock.mockReturnValue([
+      { isDestroyed: () => false, webContents: { send: liveSend } },
+      { isDestroyed: () => true, webContents: { send: destroyedSend } }
+    ] as never)
+
+    registerUIHandlers(store as never)
+    const listener = store.onUIChanged.mock.calls[0]?.[0] as (ui: unknown) => void
+    listener({ activeTabId: 'tab-1' })
+
+    expect(liveSend).toHaveBeenCalledWith('ui:stateChanged', { activeTabId: 'tab-1' })
+    expect(destroyedSend).not.toHaveBeenCalled()
   })
 
   it('routes native paste fallback to the requesting webContents only', () => {
@@ -257,7 +276,7 @@ describe('UI IPC', () => {
     expect(paste).not.toHaveBeenCalled()
   })
 
-  it('allows native paste fallback only from the configured dev renderer origin', () => {
+  it('rejects dev renderer origin senders until a capability is granted', () => {
     const paste = vi.fn()
     const pasteAndMatchStyle = vi.fn()
     const event = makeUIEvent({ getURL: () => 'http://localhost:5173/workspace' })
@@ -269,17 +288,13 @@ describe('UI IPC', () => {
     const nativePasteHandler = getNativePasteHandler()
     nativePasteHandler?.(event)
 
-    expect(fromWebContentsMock).toHaveBeenCalledWith(event.sender)
-    expect(paste).toHaveBeenCalledTimes(1)
-
-    fromWebContentsMock.mockClear()
-    paste.mockClear()
-    nativePasteHandler?.(makeUIEvent({ getURL: () => 'http://127.0.0.1:5173/workspace' }))
-    nativePasteHandler?.(makeUIEvent({ getURL: () => 'file:///orca/index.html' }))
-    nativePasteHandler?.(makeUIEvent({ getURL: () => 'not a url' }))
-
     expect(fromWebContentsMock).not.toHaveBeenCalled()
     expect(paste).not.toHaveBeenCalled()
-    expect(pasteAndMatchStyle).not.toHaveBeenCalled()
+
+    setTrustedUIRendererWebContentsId(17)
+    nativePasteHandler?.(event)
+
+    expect(fromWebContentsMock).toHaveBeenCalledWith(event.sender)
+    expect(paste).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/ipc/ui.ts
+++ b/src/main/ipc/ui.ts
@@ -2,17 +2,26 @@ import { BrowserWindow, ipcMain, webContents, type WebContents } from 'electron'
 import type { Store } from '../persistence'
 import type { PersistedUIState } from '../../shared/types'
 import { isFeatureInteractionId } from '../../shared/feature-interactions'
+import { trustedRendererRegistry } from '../window/trusted-renderer-registry'
 
+// Why: gh/dashboard events target exactly one renderer (the primary window's),
+// so keep the id mirror for targeting while the capability registry answers
+// trust checks (detached windows hold their own grants).
 let trustedUIRendererWebContentsId: number | null = null
 
 export function setTrustedUIRendererWebContentsId(webContentsId: number | null): void {
   trustedUIRendererWebContentsId = webContentsId
+  if (webContentsId === null) {
+    return
+  }
+  trustedRendererRegistry.grant(webContentsId, 'ui')
 }
 
 export function clearTrustedUIRendererWebContentsId(webContentsId: number): void {
   if (trustedUIRendererWebContentsId === webContentsId) {
     trustedUIRendererWebContentsId = null
   }
+  trustedRendererRegistry.revoke(webContentsId, 'ui')
 }
 
 export function sendToTrustedUIRenderer(
@@ -91,20 +100,5 @@ export function isTrustedUIRenderer(sender: WebContents): boolean {
   if (sender.isDestroyed() || sender.getType() !== 'window') {
     return false
   }
-  if (trustedUIRendererWebContentsId != null) {
-    return sender.id === trustedUIRendererWebContentsId
-  }
-
-  const senderUrl = sender.getURL()
-  if (process.env.ELECTRON_RENDERER_URL) {
-    try {
-      return new URL(senderUrl).origin === new URL(process.env.ELECTRON_RENDERER_URL).origin
-    } catch {
-      return false
-    }
-  }
-
-  // Why: packaged fallback must be tied to the created main window id, not any
-  // file:// document that can obtain this IPC channel.
-  return false
+  return trustedRendererRegistry.has(sender.id, 'ui')
 }

--- a/src/main/star-nag/service.test.ts
+++ b/src/main/star-nag/service.test.ts
@@ -20,7 +20,9 @@ const {
   starOrcaMock,
   trackMock,
   getCohortAtEmitMock,
-  ipcMainHandleMock
+  ipcMainHandleMock,
+  getPrimaryAppWindowMock,
+  getAppWindowsMock
 } = vi.hoisted(() => ({
   appMock: {
     getVersion: vi.fn(() => '1.2.3')
@@ -32,7 +34,9 @@ const {
   starOrcaMock: vi.fn(),
   trackMock: vi.fn(),
   getCohortAtEmitMock: vi.fn(() => ({ nth_repo_added: 3 })),
-  ipcMainHandleMock: vi.fn()
+  ipcMainHandleMock: vi.fn(),
+  getPrimaryAppWindowMock: vi.fn<() => TestWindow | null>(() => null),
+  getAppWindowsMock: vi.fn<() => TestWindow[]>(() => [])
 }))
 
 vi.mock('electron', () => ({
@@ -40,6 +44,13 @@ vi.mock('electron', () => ({
   BrowserWindow: browserWindowMock,
   ipcMain: {
     handle: ipcMainHandleMock
+  }
+}))
+
+vi.mock('../window/detached-window-registry', () => ({
+  detachedWindowRegistry: {
+    getPrimaryAppWindow: getPrimaryAppWindowMock,
+    getAppWindows: getAppWindowsMock
   }
 }))
 
@@ -149,6 +160,12 @@ describe('StarNagService', () => {
     appMock.getVersion.mockReturnValue('1.2.3')
     browserWindowMock.getAllWindows.mockReset()
     browserWindowMock.getAllWindows.mockReturnValue([])
+    getPrimaryAppWindowMock.mockReset()
+    getPrimaryAppWindowMock.mockImplementation(
+      () => browserWindowMock.getAllWindows().find((window) => !window.isDestroyed()) ?? null
+    )
+    getAppWindowsMock.mockReset()
+    getAppWindowsMock.mockImplementation(() => browserWindowMock.getAllWindows())
     checkOrcaStarredMock.mockReset()
     checkOrcaStarredMock.mockResolvedValue(false)
     starOrcaMock.mockReset()
@@ -186,6 +203,24 @@ describe('StarNagService', () => {
       threshold: STAR_NAG_INITIAL_THRESHOLD,
       agents_since_baseline: 35,
       source: 'threshold'
+    })
+  })
+
+  it('shows prompts on the primary registered app window instead of a raw offscreen window', async () => {
+    const offscreenWindow = createWindow()
+    const appWindow = createWindow()
+    browserWindowMock.getAllWindows.mockReturnValue([offscreenWindow])
+    getPrimaryAppWindowMock.mockReturnValue(appWindow)
+    const { service, emitAgentStarted } = createHarness()
+
+    service.start()
+    emitAgentStarted(45)
+    await flushAsyncWork()
+
+    expect(offscreenWindow.webContents.send).not.toHaveBeenCalled()
+    expect(appWindow.webContents.send).toHaveBeenCalledWith('star-nag:show', {
+      mode: 'gh',
+      surface: 'card'
     })
   })
 

--- a/src/main/star-nag/service.ts
+++ b/src/main/star-nag/service.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain } from 'electron'
+import { ipcMain } from 'electron'
 import { STAR_NAG_INITIAL_THRESHOLD } from '../../shared/constants'
 import { checkOrcaStarred } from '../github/client'
 import type { Store } from '../persistence'
@@ -17,6 +17,7 @@ import { deferAfterStarNagWebHandoff } from './web-handoff'
 import { runStarNagDirectStarAttempt } from './direct-star-attempt'
 import { handleStarNagOnboardingCompleted } from './onboarding-completed'
 import { ensureStarNagBaseline, shouldShowStarNagThresholdPrompt } from './threshold-trigger'
+import { detachedWindowRegistry } from '../window/detached-window-registry'
 
 const STAR_NAG_COOLDOWN_DAYS = 3
 const STAR_NAG_COOLDOWN_MS = STAR_NAG_COOLDOWN_DAYS * 24 * 60 * 60 * 1000
@@ -174,7 +175,7 @@ export class StarNagService {
     mode: StarNagPromptMode,
     surface: StarNagSurface = 'card'
   ): boolean {
-    const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
+    const win = detachedWindowRegistry.getPrimaryAppWindow()
     if (!win) {
       this.promptVisible = false
       this.promptSession = null
@@ -190,7 +191,7 @@ export class StarNagService {
   }
 
   private broadcastHide(): void {
-    for (const win of BrowserWindow.getAllWindows()) {
+    for (const win of detachedWindowRegistry.getAppWindows()) {
       if (!win.isDestroyed()) {
         win.webContents.send('star-nag:hide')
       }

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -132,6 +132,7 @@ import {
   registerClipboardHandlers,
   setTrustedClipboardRendererWebContentsId
 } from './clipboard-ipc-handlers'
+import { trustedRendererRegistry } from './trusted-renderer-registry'
 import { cleanupExpiredRemoteClipboardFiles } from './clipboard-remote-file-copy'
 
 function getRegisteredHandlers(): Map<string, (...args: unknown[]) => unknown> {
@@ -213,7 +214,9 @@ describe('registerClipboardHandlers', () => {
     randomUUIDMock.mockReturnValue('00000000-0000-4000-8000-000000000000')
     getSshFilesystemProviderMock.mockReset()
     callRuntimeEnvironmentMock.mockReset()
-    setTrustedClipboardRendererWebContentsId(null)
+    trustedRendererRegistry.clearWebContents(17)
+    trustedRendererRegistry.clearWebContents(42)
+    setTrustedClipboardRendererWebContentsId(17)
   })
 
   afterEach(() => {
@@ -421,7 +424,7 @@ describe('registerClipboardHandlers', () => {
     expect(spawnMock).not.toHaveBeenCalled()
   })
 
-  it('rejects clipboard IPC from destroyed, browser, and mismatched dev-origin senders', async () => {
+  it('rejects clipboard IPC from destroyed, browser, and ungranted dev-origin senders', async () => {
     registerClipboardHandlers({} as never)
 
     const handlers = getRegisteredHandlers()
@@ -436,11 +439,13 @@ describe('registerClipboardHandlers', () => {
 
     await expect(
       handlers.get('clipboard:readText')?.(
-        makeClipboardEvent({ getURL: () => 'http://127.0.0.1:5173/workspace' })
+        makeClipboardEvent({ id: 42, getURL: () => 'http://localhost:5173/workspace' })
       )
     ).rejects.toThrow('Unauthorized clipboard IPC sender')
     await expect(
-      handlers.get('clipboard:readText')?.(makeClipboardEvent({ getURL: () => 'not a url' }))
+      handlers.get('clipboard:readText')?.(
+        makeClipboardEvent({ id: 42, getURL: () => 'not a url' })
+      )
     ).rejects.toThrow('Unauthorized clipboard IPC sender')
 
     expect(clipboardReadTextMock).not.toHaveBeenCalled()

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -35,8 +35,7 @@ import {
 } from './clipboard-remote-file-copy'
 import { saveClipboardImageBufferInRuntime } from './clipboard-runtime-image-upload'
 import { readWindowsClipboardImageFileAsPng } from './clipboard-windows-image-file'
-
-let trustedClipboardRendererWebContentsId: number | null = null
+import { trustedRendererRegistry } from './trusted-renderer-registry'
 
 type ClipboardWriteFileRequest = {
   filePath: string
@@ -56,7 +55,10 @@ async function saveClipboardImageBufferForTarget(
 }
 
 export function setTrustedClipboardRendererWebContentsId(webContentsId: number | null): void {
-  trustedClipboardRendererWebContentsId = webContentsId
+  if (webContentsId === null) {
+    return
+  }
+  trustedRendererRegistry.grant(webContentsId, 'clipboard')
 }
 
 // Run a short-lived OS clipboard helper (PowerShell / wl-copy / xclip), feeding
@@ -243,18 +245,5 @@ function isTrustedClipboardRenderer(sender: WebContents): boolean {
   if (sender.isDestroyed() || sender.getType() !== 'window') {
     return false
   }
-  if (trustedClipboardRendererWebContentsId != null) {
-    return sender.id === trustedClipboardRendererWebContentsId
-  }
-
-  const senderUrl = sender.getURL()
-  if (process.env.ELECTRON_RENDERER_URL) {
-    try {
-      return new URL(senderUrl).origin === new URL(process.env.ELECTRON_RENDERER_URL).origin
-    } catch {
-      return false
-    }
-  }
-
-  return senderUrl.startsWith('file://')
+  return trustedRendererRegistry.has(sender.id, 'clipboard')
 }

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -48,6 +48,8 @@ import { resolveWindowCloseAction } from './window-close-decision'
 import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
 import { closeDashboardPopout } from './dashboard-popout-window'
 import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
+import { trustedRendererRegistry } from './trusted-renderer-registry'
+import { detachedWindowRegistry } from './detached-window-registry'
 
 // Why: show/restore/resume can overlap before the size nudge resets; never capture the temporary width as the next baseline.
 const activeRepaintJiggles = new WeakSet<BrowserWindow>()
@@ -252,8 +254,12 @@ export function createMainWindow(
     }
   })
   const rendererWebContentsId = mainWindow.webContents.id
-  // Why: native paste fallback is privileged IPC; only the top-level renderer may request it.
+  // Why: privileged renderer IPC is capability-scoped so detached terminal
+  // windows can receive only the subsets they need; the UI renderer id mirror
+  // keeps single-target gh/dashboard event routing on the primary window.
   setTrustedUIRendererWebContentsId(rendererWebContentsId)
+  trustedRendererRegistry.grantMany(rendererWebContentsId, ['ui', 'clipboard', 'pty', 'browser'])
+  detachedWindowRegistry.registerMainWindow(mainWindow)
 
   if (process.platform === 'darwin') {
     // Why: throttle the main window while hidden (guests self-unthrottle); toggle only while visible or Chromium blanks the surface (electron#42378).
@@ -1007,6 +1013,8 @@ export function createMainWindow(
     // Why: powerMonitor is app-global; without this the resume relay leaks and fires against a destroyed webContents.
     powerMonitor.removeListener('resume', onSystemResume)
     clearTrustedUIRendererWebContentsId(rendererWebContentsId)
+    trustedRendererRegistry.clearWebContents(rendererWebContentsId)
+    detachedWindowRegistry.unregisterWindow(mainWindow)
     // Why: on updater shutdown 'closed' can fire after webContents is destroyed, so don't touch mainWindow.webContents here.
     app.removeListener('before-quit', freezeBoundsOnQuit)
   })

--- a/src/main/window/detached-terminal-snapshot-validation.ts
+++ b/src/main/window/detached-terminal-snapshot-validation.ts
@@ -1,0 +1,125 @@
+import type {
+  DetachedTerminalOpenSnapshot,
+  DetachedTerminalSnapshot
+} from '../../shared/detached-terminal-window'
+import type { TerminalPaneLayoutNode } from '../../shared/types'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { getPtyIdForPaneKey } from '../ipc/pty'
+import { trustedRendererRegistry } from './trusted-renderer-registry'
+import { paneOwnershipRegistry } from './pane-ownership-registry'
+
+export type ValidatedDetachedSnapshot = {
+  snapshot: DetachedTerminalSnapshot
+  paneKeysByPtyId: Map<string, string>
+}
+
+export function normalizeId(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function collectLeafIds(
+  node: TerminalPaneLayoutNode | null | undefined,
+  leafIds: string[] = []
+): string[] {
+  if (!node) {
+    return leafIds
+  }
+  if (node.type === 'leaf') {
+    leafIds.push(node.leafId)
+    return leafIds
+  }
+  collectLeafIds(node.first, leafIds)
+  collectLeafIds(node.second, leafIds)
+  return leafIds
+}
+
+function layoutContainsGroup(
+  node: DetachedTerminalOpenSnapshot['groupLayout'],
+  groupId: string
+): boolean {
+  if (node.type === 'leaf') {
+    return node.groupId === groupId
+  }
+  return layoutContainsGroup(node.first, groupId) || layoutContainsGroup(node.second, groupId)
+}
+
+export function validateDetachedTerminalSnapshot(
+  worktreeId: string,
+  tabId: string,
+  snapshot: DetachedTerminalOpenSnapshot
+): ValidatedDetachedSnapshot | null {
+  if (
+    snapshot.worktree.id !== worktreeId ||
+    snapshot.terminalTab.id !== tabId ||
+    snapshot.terminalTab.worktreeId !== worktreeId ||
+    snapshot.unifiedTab.entityId !== tabId ||
+    snapshot.unifiedTab.worktreeId !== worktreeId ||
+    snapshot.unifiedTab.contentType !== 'terminal' ||
+    snapshot.unifiedTab.groupId !== snapshot.group.id ||
+    snapshot.group.worktreeId !== worktreeId ||
+    snapshot.group.activeTabId !== snapshot.unifiedTab.id ||
+    snapshot.activeGroupId !== snapshot.group.id ||
+    snapshot.activeTabId !== snapshot.unifiedTab.id ||
+    !layoutContainsGroup(snapshot.groupLayout, snapshot.group.id)
+  ) {
+    return null
+  }
+
+  const layout = snapshot.terminalLayout
+  const leafIds = collectLeafIds(layout.root)
+  const leafIdSet = new Set(leafIds)
+  const ptyIdsByLeafId = layout.ptyIdsByLeafId ?? {}
+  const validatedPtyIds: string[] = []
+  const paneKeysByPtyId = new Map<string, string>()
+
+  for (const [leafId, ptyId] of Object.entries(ptyIdsByLeafId)) {
+    if (!leafIdSet.has(leafId) || !ptyId) {
+      return null
+    }
+    const paneKey = makePaneKey(tabId, leafId)
+    if (getPtyIdForPaneKey(paneKey) !== ptyId) {
+      return null
+    }
+    if (!validatedPtyIds.includes(ptyId)) {
+      validatedPtyIds.push(ptyId)
+      paneKeysByPtyId.set(ptyId, paneKey)
+    }
+  }
+
+  if (snapshot.terminalTab.ptyId && !validatedPtyIds.includes(snapshot.terminalTab.ptyId)) {
+    if (leafIds.length !== 1) {
+      return null
+    }
+    const leafId = leafIds[0]
+    const paneKey = makePaneKey(tabId, leafId)
+    if (getPtyIdForPaneKey(paneKey) !== snapshot.terminalTab.ptyId) {
+      return null
+    }
+    validatedPtyIds.push(snapshot.terminalTab.ptyId)
+    paneKeysByPtyId.set(snapshot.terminalTab.ptyId, paneKey)
+  }
+
+  if (validatedPtyIds.length === 0) {
+    return null
+  }
+
+  return {
+    snapshot: { ...snapshot, ptyIds: validatedPtyIds },
+    paneKeysByPtyId
+  }
+}
+
+function senderCanDetachPty(sender: Electron.WebContents, ptyId: string): boolean {
+  return (
+    trustedRendererRegistry.has(sender.id, 'pty') &&
+    !sender.isDestroyed?.() &&
+    paneOwnershipRegistry.senderOwnsPty(sender, ptyId)
+  )
+}
+
+export function senderCanDetachSnapshot(
+  sender: Electron.WebContents,
+  validated: ValidatedDetachedSnapshot
+): boolean {
+  return validated.snapshot.ptyIds.every((ptyId) => senderCanDetachPty(sender, ptyId))
+}

--- a/src/main/window/detached-window-coordinator.test.ts
+++ b/src/main/window/detached-window-coordinator.test.ts
@@ -1,0 +1,385 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DetachedTerminalOpenSnapshot } from '../../shared/detached-terminal-window'
+import type { TerminalPaneLayoutNode } from '../../shared/types'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+const mocks = vi.hoisted(() => {
+  let nextWebContentsId = 100
+  class FakeBrowserWindow {
+    static instances: FakeBrowserWindow[] = []
+    webContents = {
+      id: nextWebContentsId++,
+      setWindowOpenHandler: vi.fn(),
+      on: vi.fn()
+    }
+    closed = false
+    destroyed = false
+    focused = false
+    shown = false
+    listeners = new Map<string, () => void>()
+    constructor(public readonly opts: Record<string, unknown>) {
+      FakeBrowserWindow.instances.push(this)
+    }
+    once(event: string, listener: () => void): void {
+      this.listeners.set(event, listener)
+    }
+    on(event: string, listener: () => void): void {
+      this.listeners.set(event, listener)
+    }
+    loadURL = vi.fn()
+    loadFile = vi.fn()
+    show(): void {
+      this.shown = true
+    }
+    focus(): void {
+      this.focused = true
+    }
+    close(): void {
+      this.closed = true
+      this.listeners.get('closed')?.()
+    }
+    isDestroyed(): boolean {
+      return this.destroyed
+    }
+  }
+  return {
+    FakeBrowserWindow,
+    ipcHandlers: new Map<string, (event: unknown, args: unknown) => unknown>(),
+    paneBindings: new Map<string, string>()
+  }
+})
+
+vi.mock('electron', () => ({
+  BrowserWindow: mocks.FakeBrowserWindow,
+  nativeTheme: { shouldUseDarkColors: true },
+  ipcMain: {
+    removeHandler: vi.fn((channel: string) => mocks.ipcHandlers.delete(channel)),
+    handle: vi.fn((channel: string, handler: (event: unknown, args: unknown) => unknown) => {
+      mocks.ipcHandlers.set(channel, handler)
+    })
+  }
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
+vi.mock('../app-icon', () => ({ getAppIconPath: () => 'icon.png' }))
+vi.mock('../ipc/pty', () => ({
+  getPtyIdForPaneKey: (paneKey: string) => mocks.paneBindings.get(paneKey)
+}))
+
+const leaf = '11111111-1111-4111-8111-111111111111'
+const secondLeaf = '22222222-2222-4222-8222-222222222222'
+
+function baseSnapshot(
+  root: TerminalPaneLayoutNode = { type: 'leaf', leafId: leaf }
+): DetachedTerminalOpenSnapshot {
+  return {
+    worktree: { id: 'wt-1', repoId: 'repo-1', path: '/tmp/wt' } as never,
+    terminalTab: {
+      id: 'tab-1',
+      ptyId: 'pty-1',
+      worktreeId: 'wt-1',
+      title: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 0
+    },
+    unifiedTab: {
+      id: 'unified-1',
+      entityId: 'tab-1',
+      groupId: 'group-1',
+      worktreeId: 'wt-1',
+      contentType: 'terminal',
+      label: 'Terminal',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 0
+    },
+    group: { id: 'group-1', worktreeId: 'wt-1', activeTabId: 'unified-1', tabOrder: ['unified-1'] },
+    groupLayout: { type: 'leaf', groupId: 'group-1' },
+    terminalLayout: {
+      root,
+      activeLeafId: root.type === 'leaf' ? root.leafId : leaf,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [leaf]: 'pty-1' }
+    },
+    activeGroupId: 'group-1',
+    activeTabId: 'unified-1',
+    repos: [{ id: 'repo-1', path: '/tmp/repo' } as never],
+    worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1', path: '/tmp/wt' } as never] },
+    bufferSnapshotsByLeafId: {},
+    settings: {} as never,
+    keybindings: null
+  }
+}
+
+async function importCoordinator() {
+  return import('./detached-window-coordinator')
+}
+
+describe('detached-window-coordinator', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    mocks.FakeBrowserWindow.instances.length = 0
+    mocks.ipcHandlers.clear()
+    mocks.paneBindings.clear()
+    mocks.paneBindings.set(makePaneKey('tab-1', leaf), 'pty-1')
+  })
+
+  async function allowMainSenderToOpenDetachedPty(ptyId = 'pty-1'): Promise<void> {
+    const { paneOwnershipRegistry } = await import('./pane-ownership-registry')
+    const { trustedRendererRegistry } = await import('./trusted-renderer-registry')
+    paneOwnershipRegistry.setPrimaryAppWebContentsId(1)
+    trustedRendererRegistry.grant(1, 'pty')
+    mocks.paneBindings.set(makePaneKey('tab-1', leaf), ptyId)
+  }
+
+  it('focuses an existing detached terminal window for the same worktree tab', async () => {
+    const { openDetachedTerminalWindow } = await importCoordinator()
+    const snapshot = baseSnapshot()
+
+    const first = openDetachedTerminalWindow({ worktreeId: 'wt-1', tabId: 'tab-1', snapshot })
+    const second = openDetachedTerminalWindow({ worktreeId: 'wt-1', tabId: 'tab-1', snapshot })
+
+    expect(second).toBe(first)
+    expect(mocks.FakeBrowserWindow.instances).toHaveLength(1)
+    expect((first as never as InstanceType<typeof mocks.FakeBrowserWindow>).focused).toBe(true)
+  })
+
+  it('stages a fresh renderer snapshot instead of reading debounced persisted session state', async () => {
+    const { openDetachedTerminalWindow } = await importCoordinator()
+    const { detachedWindowRegistry } = await import('./detached-window-registry')
+    const snapshot = baseSnapshot()
+    snapshot.terminalTab.title = 'Fresh renderer title'
+
+    openDetachedTerminalWindow({ worktreeId: 'wt-1', tabId: 'tab-1', snapshot })
+
+    expect(
+      detachedWindowRegistry.getDetachedTerminalSnapshot({ worktreeId: 'wt-1', tabId: 'tab-1' })
+        ?.terminalTab.title
+    ).toBe('Fresh renderer title')
+  })
+
+  it('registers every split-pane PTY in the detached tab', async () => {
+    const root: TerminalPaneLayoutNode = {
+      type: 'split',
+      direction: 'horizontal',
+      first: { type: 'leaf', leafId: leaf },
+      second: { type: 'leaf', leafId: secondLeaf }
+    }
+    const snapshot = baseSnapshot(root)
+    snapshot.terminalLayout.ptyIdsByLeafId = { [leaf]: 'pty-1', [secondLeaf]: 'pty-2' }
+    mocks.paneBindings.set(makePaneKey('tab-1', secondLeaf), 'pty-2')
+    const { openDetachedTerminalWindow } = await importCoordinator()
+    const { detachedWindowRegistry } = await import('./detached-window-registry')
+
+    openDetachedTerminalWindow({ worktreeId: 'wt-1', tabId: 'tab-1', snapshot })
+
+    expect(
+      detachedWindowRegistry.getDetachedTerminalSnapshot({ worktreeId: 'wt-1', tabId: 'tab-1' })
+        ?.ptyIds
+    ).toEqual(['pty-1', 'pty-2'])
+  })
+
+  it('rejects a split snapshot when terminalTab.ptyId is missing from the layout bindings', async () => {
+    const root: TerminalPaneLayoutNode = {
+      type: 'split',
+      direction: 'horizontal',
+      first: { type: 'leaf', leafId: leaf },
+      second: { type: 'leaf', leafId: secondLeaf }
+    }
+    const snapshot = baseSnapshot(root)
+    snapshot.terminalTab.ptyId = 'pty-orphan'
+    snapshot.terminalLayout.ptyIdsByLeafId = { [leaf]: 'pty-1', [secondLeaf]: 'pty-2' }
+    mocks.paneBindings.set(makePaneKey('tab-1', secondLeaf), 'pty-2')
+    mocks.paneBindings.set(makePaneKey('tab-1', leaf), 'pty-1')
+    await allowMainSenderToOpenDetachedPty()
+    const { registerDetachedTerminalHandlers } = await importCoordinator()
+    registerDetachedTerminalHandlers()
+
+    const result = await mocks.ipcHandlers.get('detachedTerminal:openWindow')?.(
+      { sender: { id: 1 } },
+      { worktreeId: 'wt-1', tabId: 'tab-1', snapshot }
+    )
+
+    expect(result).toEqual({ ok: false, error: 'detached_terminal_tab_unavailable' })
+  })
+
+  it('rejects a snapshot whose PTY ids do not match makePaneKey(tabId, leafId) bindings in the main PTY runtime', async () => {
+    const { registerDetachedTerminalHandlers } = await importCoordinator()
+    registerDetachedTerminalHandlers()
+    await allowMainSenderToOpenDetachedPty()
+    const result = await mocks.ipcHandlers.get('detachedTerminal:openWindow')?.(
+      { sender: { id: 1 } },
+      {
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        snapshot: {
+          ...baseSnapshot(),
+          terminalLayout: { ...baseSnapshot().terminalLayout, ptyIdsByLeafId: { [leaf]: 'wrong' } }
+        }
+      }
+    )
+
+    expect(result).toEqual({ ok: false, error: 'detached_terminal_tab_unavailable' })
+  })
+
+  it('rejects detached open requests for PTYs the sender does not own', async () => {
+    const { registerDetachedTerminalHandlers } = await importCoordinator()
+    const { trustedRendererRegistry } = await import('./trusted-renderer-registry')
+    trustedRendererRegistry.grant(1, 'pty')
+    registerDetachedTerminalHandlers()
+
+    const result = await mocks.ipcHandlers.get('detachedTerminal:openWindow')?.(
+      { sender: { id: 1, isDestroyed: () => false } },
+      { worktreeId: 'wt-1', tabId: 'tab-1', snapshot: baseSnapshot() }
+    )
+
+    expect(result).toEqual({ ok: false, error: 'detached_terminal_tab_unavailable' })
+    expect(mocks.FakeBrowserWindow.instances).toHaveLength(0)
+  })
+
+  it('closing a detached terminal window keeps the PTY owner alive in the main tab', async () => {
+    const { openDetachedTerminalWindow, registerDetachedTerminalHandlers } =
+      await importCoordinator()
+    const { paneOwnershipRegistry } = await import('./pane-ownership-registry')
+    registerDetachedTerminalHandlers()
+    const window = openDetachedTerminalWindow({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      snapshot: baseSnapshot()
+    }) as never as InstanceType<typeof mocks.FakeBrowserWindow>
+    await mocks.ipcHandlers.get('detachedTerminal:rendererPtyReady')?.(
+      { sender: { id: window.webContents.id } },
+      { worktreeId: 'wt-1', tabId: 'tab-1', ptyId: 'pty-1' }
+    )
+
+    window.close()
+
+    expect(paneOwnershipRegistry.getOwnerForPty('pty-1')).toBeNull()
+  })
+
+  it('allows the detached window to close itself', async () => {
+    const { openDetachedTerminalWindow, registerDetachedTerminalHandlers } =
+      await importCoordinator()
+    await allowMainSenderToOpenDetachedPty()
+    registerDetachedTerminalHandlers()
+    const window = openDetachedTerminalWindow({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      snapshot: baseSnapshot()
+    }) as never as InstanceType<typeof mocks.FakeBrowserWindow>
+
+    await mocks.ipcHandlers.get('detachedTerminal:closeWindow')?.(
+      { sender: { id: window.webContents.id } },
+      { worktreeId: 'wt-1', tabId: 'tab-1' }
+    )
+
+    expect(window.closed).toBe(true)
+  })
+
+  it('ignores detached close requests from unrelated renderers', async () => {
+    const { openDetachedTerminalWindow, registerDetachedTerminalHandlers } =
+      await importCoordinator()
+    registerDetachedTerminalHandlers()
+    const window = openDetachedTerminalWindow({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      snapshot: baseSnapshot()
+    }) as never as InstanceType<typeof mocks.FakeBrowserWindow>
+
+    await mocks.ipcHandlers.get('detachedTerminal:closeWindow')?.(
+      { sender: { id: 999 } },
+      { worktreeId: 'wt-1', tabId: 'tab-1' }
+    )
+
+    expect(window.closed).toBe(false)
+  })
+
+  it('closing the origin tab closes the detached terminal window', async () => {
+    const { openDetachedTerminalWindow, registerDetachedTerminalHandlers } =
+      await importCoordinator()
+    registerDetachedTerminalHandlers()
+    await allowMainSenderToOpenDetachedPty()
+    const window = openDetachedTerminalWindow({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      snapshot: baseSnapshot()
+    }) as never as InstanceType<typeof mocks.FakeBrowserWindow>
+
+    await mocks.ipcHandlers.get('detachedTerminal:closeWindow')?.(
+      { sender: { id: 1 } },
+      { worktreeId: 'wt-1', tabId: 'tab-1' }
+    )
+
+    expect(window.closed).toBe(true)
+  })
+
+  it('open -> rendererPtyReady -> main open again focuses existing', async () => {
+    const { registerDetachedTerminalHandlers } = await importCoordinator()
+    const { detachedWindowRegistry } = await import('./detached-window-registry')
+    const { paneOwnershipRegistry } = await import('./pane-ownership-registry')
+    registerDetachedTerminalHandlers()
+    await allowMainSenderToOpenDetachedPty()
+
+    // 1. Initial open from main window
+    const openResult1 = await mocks.ipcHandlers.get('detachedTerminal:openWindow')?.(
+      { sender: { id: 1, isDestroyed: () => false } },
+      { worktreeId: 'wt-1', tabId: 'tab-1', snapshot: baseSnapshot() }
+    )
+    expect(openResult1).toEqual({ ok: true })
+
+    const windowInstance = detachedWindowRegistry.getDetachedTerminalWindow({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1'
+    }) as never as InstanceType<typeof mocks.FakeBrowserWindow>
+    expect(windowInstance).toBeDefined()
+    expect(windowInstance.focused).toBe(false)
+
+    // 2. Set the detached window webContents as the owner (simulating rendererPtyReady)
+    paneOwnershipRegistry.registerTabPaneOwners({
+      webContentsId: windowInstance.webContents.id,
+      ptyIds: ['pty-1'],
+      worktreeId: 'wt-1',
+      tabId: 'tab-1'
+    })
+
+    // 3. Main open again (sender.id = 1) focuses existing window
+    const openResult2 = await mocks.ipcHandlers.get('detachedTerminal:openWindow')?.(
+      { sender: { id: 1, isDestroyed: () => false } },
+      { worktreeId: 'wt-1', tabId: 'tab-1', snapshot: baseSnapshot() }
+    )
+    expect(openResult2).toEqual({ ok: true })
+    expect(windowInstance.focused).toBe(true)
+  })
+
+  it('unrelated renderer cannot focus an already open detached window', async () => {
+    const { registerDetachedTerminalHandlers } = await importCoordinator()
+    const { detachedWindowRegistry } = await import('./detached-window-registry')
+    registerDetachedTerminalHandlers()
+    await allowMainSenderToOpenDetachedPty()
+
+    // 1. Initial open from main window
+    const openResult1 = await mocks.ipcHandlers.get('detachedTerminal:openWindow')?.(
+      { sender: { id: 1, isDestroyed: () => false } },
+      { worktreeId: 'wt-1', tabId: 'tab-1', snapshot: baseSnapshot() }
+    )
+    expect(openResult1).toEqual({ ok: true })
+
+    const windowInstance = detachedWindowRegistry.getDetachedTerminalWindow({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1'
+    }) as never as InstanceType<typeof mocks.FakeBrowserWindow>
+    expect(windowInstance).toBeDefined()
+    expect(windowInstance.focused).toBe(false)
+
+    // 2. Open request from unrelated sender (sender.id = 999) fails
+    const openResult2 = await mocks.ipcHandlers.get('detachedTerminal:openWindow')?.(
+      { sender: { id: 999, isDestroyed: () => false } },
+      { worktreeId: 'wt-1', tabId: 'tab-1', snapshot: baseSnapshot() }
+    )
+    expect(openResult2).toEqual({ ok: false, error: 'detached_terminal_tab_unavailable' })
+    expect(windowInstance.focused).toBe(false)
+  })
+})

--- a/src/main/window/detached-window-coordinator.ts
+++ b/src/main/window/detached-window-coordinator.ts
@@ -1,0 +1,218 @@
+import { BrowserWindow, ipcMain, nativeTheme } from 'electron'
+import * as path from 'node:path'
+import { is } from '@electron-toolkit/utils'
+import type {
+  DetachedTerminalOpenSnapshot,
+  DetachedTerminalSnapshot
+} from '../../shared/detached-terminal-window'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { getAppIconPath } from '../app-icon'
+import { detachedWindowRegistry, type DetachedWindowKey } from './detached-window-registry'
+import { trustedRendererRegistry } from './trusted-renderer-registry'
+import { paneOwnershipRegistry } from './pane-ownership-registry'
+import {
+  normalizeId,
+  senderCanDetachSnapshot,
+  validateDetachedTerminalSnapshot
+} from './detached-terminal-snapshot-validation'
+
+type OpenDetachedTerminalWindowArgs = {
+  worktreeId: string
+  tabId: string
+  snapshot: DetachedTerminalOpenSnapshot
+}
+
+type DetachedTerminalOpenResult =
+  | { ok: true }
+  | { ok: false; error: 'invalid_payload' | 'detached_terminal_tab_unavailable' }
+
+function loadDetachedTerminalWindow(window: BrowserWindow, key: DetachedWindowKey): void {
+  const query = {
+    mode: 'detached-terminal',
+    worktreeId: key.worktreeId,
+    tabId: key.tabId
+  }
+  if (is.dev && process.env.ELECTRON_RENDERER_URL) {
+    const url = new URL(process.env.ELECTRON_RENDERER_URL)
+    for (const [name, value] of Object.entries(query)) {
+      url.searchParams.set(name, value)
+    }
+    void window.loadURL(url.toString())
+    return
+  }
+  void window.loadFile(path.join(__dirname, '../renderer/index.html'), { query })
+}
+
+export function openDetachedTerminalWindow({
+  worktreeId,
+  tabId,
+  snapshot
+}: OpenDetachedTerminalWindowArgs): BrowserWindow {
+  const key = { worktreeId, tabId }
+  const existing = detachedWindowRegistry.getDetachedTerminalWindow(key)
+  if (existing) {
+    detachedWindowRegistry.focusDetachedTerminalWindow(key)
+    return existing
+  }
+
+  const validated = validateDetachedTerminalSnapshot(worktreeId, tabId, snapshot)
+  if (!validated) {
+    throw new Error('detached_terminal_tab_unavailable')
+  }
+
+  const window = new BrowserWindow({
+    width: 1000,
+    height: 700,
+    minWidth: 600,
+    minHeight: 400,
+    title: snapshot.terminalTab.title || 'Terminal',
+    show: false,
+    acceptFirstMouse: true,
+    autoHideMenuBar: true,
+    backgroundColor: nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff',
+    titleBarStyle:
+      process.platform === 'darwin'
+        ? 'hiddenInset'
+        : process.platform === 'win32'
+          ? 'hidden'
+          : undefined,
+    ...(process.platform === 'linux' ? { frame: false } : {}),
+    icon: getAppIconPath(snapshot.settings?.appIcon),
+    webPreferences: {
+      preload: path.join(__dirname, '../preload/index.js'),
+      sandbox: true,
+      webviewTag: false
+    }
+  })
+
+  const webContentsId = window.webContents.id
+  trustedRendererRegistry.grantMany(webContentsId, ['ui', 'clipboard', 'pty'])
+  detachedWindowRegistry.registerDetachedTerminalWindow(key, window, validated.snapshot)
+
+  window.once('ready-to-show', () => {
+    if (!window.isDestroyed()) {
+      window.show()
+    }
+  })
+  window.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+  window.webContents.on('will-navigate', (event) => event.preventDefault())
+
+  loadDetachedTerminalWindow(window, key)
+  return window
+}
+
+export function registerDetachedTerminalHandlers(): void {
+  ipcMain.removeHandler('detachedTerminal:openWindow')
+  ipcMain.removeHandler('detachedTerminal:getSnapshot')
+  ipcMain.removeHandler('detachedTerminal:closeWindow')
+  ipcMain.removeHandler('detachedTerminal:rendererPtyReady')
+
+  ipcMain.handle(
+    'detachedTerminal:openWindow',
+    (event, args: OpenDetachedTerminalWindowArgs): DetachedTerminalOpenResult => {
+      const worktreeId = normalizeId(args?.worktreeId)
+      const tabId = normalizeId(args?.tabId)
+      if (!worktreeId || !tabId || !args?.snapshot) {
+        return { ok: false, error: 'invalid_payload' }
+      }
+      const key = { worktreeId, tabId }
+      const existing = detachedWindowRegistry.getDetachedTerminalWindow(key)
+      if (existing) {
+        const senderId = event.sender.id
+        if (
+          existing.webContents.id === senderId ||
+          paneOwnershipRegistry.isPrimaryAppWebContentsId(senderId)
+        ) {
+          detachedWindowRegistry.focusDetachedTerminalWindow(key)
+          return { ok: true }
+        }
+        return { ok: false, error: 'detached_terminal_tab_unavailable' }
+      }
+      const validated = validateDetachedTerminalSnapshot(worktreeId, tabId, args.snapshot)
+      if (!validated || !senderCanDetachSnapshot(event.sender, validated)) {
+        return { ok: false, error: 'detached_terminal_tab_unavailable' }
+      }
+      try {
+        openDetachedTerminalWindow({ worktreeId, tabId, snapshot: args.snapshot })
+        return { ok: true }
+      } catch (error) {
+        if (error instanceof Error && error.message === 'detached_terminal_tab_unavailable') {
+          return { ok: false, error: 'detached_terminal_tab_unavailable' }
+        }
+        throw error
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'detachedTerminal:getSnapshot',
+    (event, args: { worktreeId?: unknown; tabId?: unknown }): DetachedTerminalSnapshot => {
+      const worktreeId = normalizeId(args?.worktreeId)
+      const tabId = normalizeId(args?.tabId)
+      if (!worktreeId || !tabId) {
+        throw new Error('invalid_payload')
+      }
+      const key = { worktreeId, tabId }
+      const window = detachedWindowRegistry.getDetachedTerminalWindow(key)
+      const snapshot = detachedWindowRegistry.getDetachedTerminalSnapshot(key)
+      if (!window || !snapshot || window.webContents.id !== event.sender.id) {
+        throw new Error('detached_terminal_tab_unavailable')
+      }
+      return snapshot
+    }
+  )
+
+  ipcMain.handle(
+    'detachedTerminal:closeWindow',
+    (event, args: { worktreeId?: unknown; tabId?: unknown }): { ok: true } => {
+      const worktreeId = normalizeId(args?.worktreeId)
+      const tabId = normalizeId(args?.tabId)
+      if (worktreeId && tabId) {
+        const key = { worktreeId, tabId }
+        const window = detachedWindowRegistry.getDetachedTerminalWindow(key)
+        const senderId = event.sender.id
+        if (
+          window &&
+          (window.webContents.id === senderId ||
+            paneOwnershipRegistry.isPrimaryAppWebContentsId(senderId))
+        ) {
+          detachedWindowRegistry.closeDetachedTerminalWindow(key)
+        }
+      }
+      return { ok: true }
+    }
+  )
+
+  ipcMain.handle(
+    'detachedTerminal:rendererPtyReady',
+    (event, args: { worktreeId?: unknown; tabId?: unknown; ptyId?: unknown }): { ok: true } => {
+      const worktreeId = normalizeId(args?.worktreeId)
+      const tabId = normalizeId(args?.tabId)
+      const ptyId = normalizeId(args?.ptyId)
+      if (!worktreeId || !tabId || !ptyId) {
+        return { ok: true }
+      }
+      const key = { worktreeId, tabId }
+      const window = detachedWindowRegistry.getDetachedTerminalWindow(key)
+      const snapshot = detachedWindowRegistry.getDetachedTerminalSnapshot(key)
+      if (!window || !snapshot || window.webContents.id !== event.sender.id) {
+        return { ok: true }
+      }
+      if (!snapshot.ptyIds.includes(ptyId)) {
+        return { ok: true }
+      }
+      const leafEntry = Object.entries(snapshot.terminalLayout.ptyIdsByLeafId ?? {}).find(
+        ([, candidatePtyId]) => candidatePtyId === ptyId
+      )
+      const paneKey = leafEntry ? makePaneKey(tabId, leafEntry[0]) : null
+      paneOwnershipRegistry.registerPaneOwner({
+        webContentsId: event.sender.id,
+        ptyId,
+        paneKey,
+        worktreeId,
+        tabId
+      })
+      return { ok: true }
+    }
+  )
+}

--- a/src/main/window/detached-window-registry.test.ts
+++ b/src/main/window/detached-window-registry.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getAllWindowsMock } = vi.hoisted(() => ({
+  getAllWindowsMock: vi.fn(() => [])
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: getAllWindowsMock
+  }
+}))
+
+import type { DetachedTerminalSnapshot } from '../../shared/detached-terminal-window'
+import { detachedWindowRegistry } from './detached-window-registry'
+
+type MockWindow = Electron.BrowserWindow & {
+  trigger: (event: string) => void
+  focus: () => void
+  close: () => void
+}
+
+function makeWindow(id: number): MockWindow {
+  const listeners = new Map<string, (() => void)[]>()
+  const win = {
+    id,
+    webContents: { id: id + 100 },
+    isDestroyed: vi.fn(() => false),
+    focus: vi.fn(),
+    close: vi.fn(() => {
+      vi.mocked(win.isDestroyed).mockReturnValue(true)
+      win.trigger('closed')
+    }),
+    on: vi.fn((event: string, handler: () => void) => {
+      listeners.set(event, [...(listeners.get(event) ?? []), handler])
+      return win
+    }),
+    trigger: (event: string) => {
+      for (const handler of listeners.get(event) ?? []) {
+        handler()
+      }
+    }
+  } as unknown as MockWindow
+  return win
+}
+
+function makeSnapshot(ptyIds: string[]): DetachedTerminalSnapshot {
+  return { ptyIds } as DetachedTerminalSnapshot
+}
+
+describe('detachedWindowRegistry', () => {
+  beforeEach(() => {
+    getAllWindowsMock.mockReset()
+    detachedWindowRegistry
+      .getAppWindows()
+      .forEach((win) => detachedWindowRegistry.unregisterWindow(win))
+  })
+
+  it('focuses an existing detached terminal window for the same worktree tab', () => {
+    const win = makeWindow(1)
+    const key = { worktreeId: 'worktree-1', tabId: 'tab-1' }
+
+    detachedWindowRegistry.registerDetachedTerminalWindow(key, win, makeSnapshot(['pty-1']))
+
+    expect(detachedWindowRegistry.focusDetachedTerminalWindow(key)).toBe(true)
+    expect(win.focus).toHaveBeenCalledTimes(1)
+    expect(detachedWindowRegistry.getDetachedTerminalWindow(key)).toBe(win)
+  })
+
+  it('unregisters only the detached window when closing it', () => {
+    const main = makeWindow(1)
+    const detached = makeWindow(2)
+    const key = { worktreeId: 'worktree-1', tabId: 'tab-1' }
+    detachedWindowRegistry.registerMainWindow(main)
+    detachedWindowRegistry.registerDetachedTerminalWindow(key, detached, makeSnapshot(['pty-1']))
+
+    detachedWindowRegistry.closeDetachedTerminalWindow(key)
+
+    expect(detached.close).toHaveBeenCalledTimes(1)
+    expect(detachedWindowRegistry.getDetachedTerminalWindow(key)).toBeNull()
+    expect(detachedWindowRegistry.getPrimaryAppWindow()).toBe(main)
+    expect(detachedWindowRegistry.getAppWindows()).toEqual([main])
+  })
+
+  it('returns only registered app windows and excludes raw offscreen BrowserWindows', () => {
+    const main = makeWindow(1)
+    const detached = makeWindow(2)
+    const offscreen = makeWindow(3)
+    getAllWindowsMock.mockReturnValue([main, detached, offscreen] as never)
+
+    detachedWindowRegistry.registerMainWindow(main)
+    detachedWindowRegistry.registerDetachedTerminalWindow(
+      { worktreeId: 'worktree-1', tabId: 'tab-1' },
+      detached,
+      makeSnapshot(['pty-1'])
+    )
+
+    expect(detachedWindowRegistry.getAppWindows()).toEqual([main, detached])
+    expect(detachedWindowRegistry.getAppWindows()).not.toContain(offscreen)
+  })
+
+  it('stores staged detached terminal snapshots by key', () => {
+    const win = makeWindow(1)
+    const key = { worktreeId: 'worktree-1', tabId: 'tab-1' }
+    const snapshot = makeSnapshot(['pty-1', 'pty-2'])
+
+    detachedWindowRegistry.registerDetachedTerminalWindow(key, win, snapshot)
+
+    expect(detachedWindowRegistry.getDetachedTerminalSnapshot(key)).toBe(snapshot)
+  })
+})

--- a/src/main/window/detached-window-registry.ts
+++ b/src/main/window/detached-window-registry.ts
@@ -1,0 +1,150 @@
+import type { BrowserWindow } from 'electron'
+import type { DetachedTerminalSnapshot } from '../../shared/detached-terminal-window'
+import { trustedRendererRegistry } from './trusted-renderer-registry'
+import { paneOwnershipRegistry } from './pane-ownership-registry'
+
+export type AppWindowKind = 'main' | 'detached-terminal'
+export type DetachedWindowKey = { worktreeId: string; tabId: string }
+
+type AppWindowRecord = {
+  kind: AppWindowKind
+  window: BrowserWindow
+  webContentsId: number
+  key?: DetachedWindowKey
+  snapshot?: DetachedTerminalSnapshot
+}
+
+class DetachedWindowRegistry {
+  private readonly recordsByWindow = new Map<BrowserWindow, AppWindowRecord>()
+  private readonly detachedByKey = new Map<string, AppWindowRecord>()
+  private primaryMainWindow: BrowserWindow | null = null
+
+  registerMainWindow(window: BrowserWindow): void {
+    this.unregisterWindow(window)
+    const webContentsId = window.webContents.id
+    this.recordsByWindow.set(window, { kind: 'main', window, webContentsId })
+    this.primaryMainWindow = window
+    paneOwnershipRegistry.setPrimaryAppWebContentsId(webContentsId)
+    this.unregisterOnClose(window)
+  }
+
+  registerDetachedTerminalWindow(
+    key: DetachedWindowKey,
+    window: BrowserWindow,
+    snapshot: DetachedTerminalSnapshot
+  ): void {
+    this.unregisterWindow(window)
+    const record: AppWindowRecord = {
+      kind: 'detached-terminal',
+      window,
+      webContentsId: window.webContents.id,
+      key,
+      snapshot
+    }
+    this.recordsByWindow.set(window, record)
+    this.detachedByKey.set(this.keyString(key), record)
+    this.unregisterOnClose(window)
+  }
+
+  unregisterWindow(window: BrowserWindow): void {
+    const record = this.recordsByWindow.get(window)
+    if (!record) {
+      return
+    }
+    this.recordsByWindow.delete(window)
+    if (record.kind === 'main' && this.primaryMainWindow === window) {
+      this.primaryMainWindow = this.findFirstMainWindow()
+      paneOwnershipRegistry.setPrimaryAppWebContentsId(
+        this.getPrimaryAppWindow()?.webContents.id ?? null
+      )
+    }
+    if (record.kind === 'detached-terminal' && record.key) {
+      this.detachedByKey.delete(this.keyString(record.key))
+    }
+    const { webContentsId } = record
+    if (typeof webContentsId === 'number') {
+      trustedRendererRegistry.clearWebContents(webContentsId)
+      paneOwnershipRegistry.clearPaneOwnerByWebContentsId(webContentsId)
+    }
+  }
+
+  getDetachedTerminalWindow(key: DetachedWindowKey): BrowserWindow | null {
+    const record = this.getLiveDetachedRecord(key)
+    return record?.window ?? null
+  }
+
+  getDetachedTerminalSnapshot(key: DetachedWindowKey): DetachedTerminalSnapshot | null {
+    const record = this.getLiveDetachedRecord(key)
+    return record?.snapshot ?? null
+  }
+
+  focusDetachedTerminalWindow(key: DetachedWindowKey): boolean {
+    const window = this.getDetachedTerminalWindow(key)
+    if (!window) {
+      return false
+    }
+    window.focus()
+    return true
+  }
+
+  closeDetachedTerminalWindow(key: DetachedWindowKey): void {
+    const window = this.getDetachedTerminalWindow(key)
+    if (!window) {
+      return
+    }
+    this.unregisterWindow(window)
+    if (!window.isDestroyed()) {
+      window.close()
+    }
+  }
+
+  getAppWindows(): BrowserWindow[] {
+    const windows: BrowserWindow[] = []
+    for (const [window] of this.recordsByWindow) {
+      if (!window.isDestroyed()) {
+        windows.push(window)
+      }
+    }
+    return windows
+  }
+
+  getPrimaryAppWindow(): BrowserWindow | null {
+    if (this.primaryMainWindow && !this.primaryMainWindow.isDestroyed()) {
+      return this.primaryMainWindow
+    }
+    this.primaryMainWindow = this.findFirstMainWindow()
+    return this.primaryMainWindow
+  }
+
+  private getLiveDetachedRecord(key: DetachedWindowKey): AppWindowRecord | null {
+    const record = this.detachedByKey.get(this.keyString(key))
+    if (!record || record.window.isDestroyed()) {
+      if (record) {
+        this.unregisterWindow(record.window)
+      }
+      return null
+    }
+    return record
+  }
+
+  private findFirstMainWindow(): BrowserWindow | null {
+    for (const record of this.recordsByWindow.values()) {
+      if (record.kind === 'main' && !record.window.isDestroyed()) {
+        return record.window
+      }
+    }
+    return null
+  }
+
+  private unregisterOnClose(window: BrowserWindow): void {
+    window.on('closed', () => {
+      this.unregisterWindow(window)
+    })
+  }
+
+  private keyString(key: DetachedWindowKey): string {
+    return `${key.worktreeId}\u0000${key.tabId}`
+  }
+}
+
+export const detachedWindowRegistry = new DetachedWindowRegistry()

--- a/src/main/window/pane-ownership-registry.test.ts
+++ b/src/main/window/pane-ownership-registry.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { paneOwnershipRegistry } from './pane-ownership-registry'
+
+describe('paneOwnershipRegistry', () => {
+  beforeEach(() => {
+    paneOwnershipRegistry.clearPaneOwnerByWebContentsId(17)
+    paneOwnershipRegistry.clearPaneOwnerByWebContentsId(18)
+    paneOwnershipRegistry.clearPaneOwnerByPtyId('pty-1')
+    paneOwnershipRegistry.clearPaneOwnerByPtyId('pty-2')
+    paneOwnershipRegistry.clearPaneOwnerByPtyId('pty-3')
+    paneOwnershipRegistry.setPrimaryAppWebContentsId(null)
+  })
+
+  it('registers ownership by PTY id and pane key', () => {
+    paneOwnershipRegistry.registerPaneOwner({
+      webContentsId: 17,
+      ptyId: 'pty-1',
+      paneKey: 'tab-1:leaf-1',
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1'
+    })
+
+    expect(paneOwnershipRegistry.getOwnerForPty('pty-1')).toBe(17)
+    expect(paneOwnershipRegistry.getPtyIdsForTab('worktree-1', 'tab-1')).toEqual(['pty-1'])
+    expect(paneOwnershipRegistry.senderOwnsPty({ id: 17 } as Electron.WebContents, 'pty-1')).toBe(
+      true
+    )
+    expect(paneOwnershipRegistry.senderOwnsPty({ id: 18 } as Electron.WebContents, 'pty-1')).toBe(
+      false
+    )
+  })
+
+  it('registers tab-level ownership for split-pane PTYs', () => {
+    paneOwnershipRegistry.registerTabPaneOwners({
+      webContentsId: 17,
+      ptyIds: ['pty-1', 'pty-2'],
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1'
+    })
+
+    expect(paneOwnershipRegistry.getOwnerForPty('pty-1')).toBe(17)
+    expect(paneOwnershipRegistry.getOwnerForPty('pty-2')).toBe(17)
+    expect(paneOwnershipRegistry.getPtyIdsForTab('worktree-1', 'tab-1')).toEqual(['pty-1', 'pty-2'])
+  })
+
+  it('lists PTY ids for an owning webContents id', () => {
+    paneOwnershipRegistry.registerTabPaneOwners({
+      webContentsId: 17,
+      ptyIds: ['pty-1', 'pty-2'],
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1'
+    })
+    paneOwnershipRegistry.registerPaneOwner({
+      webContentsId: 18,
+      ptyId: 'pty-3',
+      worktreeId: 'worktree-1',
+      tabId: 'tab-2'
+    })
+
+    expect(paneOwnershipRegistry.getPtyIdsForWebContents(17)).toEqual(['pty-1', 'pty-2'])
+  })
+
+  it('cleans up owners by webContents id and by PTY id', () => {
+    paneOwnershipRegistry.registerTabPaneOwners({
+      webContentsId: 17,
+      ptyIds: ['pty-1', 'pty-2'],
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1'
+    })
+    paneOwnershipRegistry.registerPaneOwner({
+      webContentsId: 18,
+      ptyId: 'pty-3',
+      worktreeId: 'worktree-1',
+      tabId: 'tab-2'
+    })
+
+    paneOwnershipRegistry.clearPaneOwnerByWebContentsId(17)
+    expect(paneOwnershipRegistry.getOwnerForPty('pty-1')).toBeNull()
+    expect(paneOwnershipRegistry.getOwnerForPty('pty-2')).toBeNull()
+    expect(paneOwnershipRegistry.getOwnerForPty('pty-3')).toBe(18)
+
+    paneOwnershipRegistry.clearPaneOwnerByPtyId('pty-3')
+    expect(paneOwnershipRegistry.getOwnerForPty('pty-3')).toBeNull()
+  })
+
+  it('identifies the registered primary app window', () => {
+    paneOwnershipRegistry.setPrimaryAppWebContentsId(17)
+
+    expect(paneOwnershipRegistry.isPrimaryAppWebContentsId(17)).toBe(true)
+    expect(paneOwnershipRegistry.isPrimaryAppWebContentsId(18)).toBe(false)
+  })
+
+  it('falls back to the registered primary app window when no detached owner exists', () => {
+    expect(paneOwnershipRegistry.getOwnerForPty('pty-1')).toBeNull()
+    expect(paneOwnershipRegistry.senderOwnsPty({ id: 99 } as Electron.WebContents, 'pty-1')).toBe(
+      false
+    )
+
+    paneOwnershipRegistry.setPrimaryAppWebContentsId(17)
+
+    expect(paneOwnershipRegistry.senderOwnsPty({ id: 17 } as Electron.WebContents, 'pty-1')).toBe(
+      true
+    )
+    expect(paneOwnershipRegistry.senderOwnsPty({ id: 18 } as Electron.WebContents, 'pty-1')).toBe(
+      false
+    )
+  })
+})

--- a/src/main/window/pane-ownership-registry.ts
+++ b/src/main/window/pane-ownership-registry.ts
@@ -1,0 +1,108 @@
+type PaneOwnerRecord = {
+  webContentsId: number
+  ptyId: string
+  paneKey: string | null
+  worktreeId: string
+  tabId: string
+}
+
+type RegisterPaneOwnerArgs = {
+  webContentsId: number
+  ptyId: string
+  paneKey?: string | null
+  worktreeId: string
+  tabId: string
+}
+
+type RegisterTabPaneOwnersArgs = {
+  webContentsId: number
+  ptyIds: string[]
+  worktreeId: string
+  tabId: string
+}
+
+class PaneOwnershipRegistry {
+  private readonly ownersByPtyId = new Map<string, PaneOwnerRecord>()
+  private primaryAppWebContentsId: number | null = null
+
+  setPrimaryAppWebContentsId(webContentsId: number | null): void {
+    this.primaryAppWebContentsId = webContentsId
+  }
+
+  isPrimaryAppWebContentsId(webContentsId: number): boolean {
+    return this.primaryAppWebContentsId === webContentsId
+  }
+
+  registerPaneOwner(args: RegisterPaneOwnerArgs): void {
+    if (!args.ptyId) {
+      return
+    }
+    this.ownersByPtyId.set(args.ptyId, {
+      webContentsId: args.webContentsId,
+      ptyId: args.ptyId,
+      paneKey: args.paneKey ?? null,
+      worktreeId: args.worktreeId,
+      tabId: args.tabId
+    })
+  }
+
+  registerTabPaneOwners(args: RegisterTabPaneOwnersArgs): void {
+    for (const ptyId of args.ptyIds) {
+      this.registerPaneOwner({
+        webContentsId: args.webContentsId,
+        ptyId,
+        worktreeId: args.worktreeId,
+        tabId: args.tabId
+      })
+    }
+  }
+
+  clearPaneOwnerByWebContentsId(webContentsId: number): void {
+    for (const [ptyId, owner] of this.ownersByPtyId) {
+      if (owner.webContentsId === webContentsId) {
+        this.ownersByPtyId.delete(ptyId)
+      }
+    }
+    if (this.primaryAppWebContentsId === webContentsId) {
+      this.primaryAppWebContentsId = null
+    }
+  }
+
+  clearPaneOwnerByPtyId(ptyId: string): void {
+    this.ownersByPtyId.delete(ptyId)
+  }
+
+  getOwnerForPty(ptyId: string): number | null {
+    return this.ownersByPtyId.get(ptyId)?.webContentsId ?? null
+  }
+
+  getPtyIdsForTab(worktreeId: string, tabId: string): string[] {
+    const ptyIds: string[] = []
+    for (const owner of this.ownersByPtyId.values()) {
+      if (owner.worktreeId === worktreeId && owner.tabId === tabId) {
+        ptyIds.push(owner.ptyId)
+      }
+    }
+    return ptyIds
+  }
+
+  getPtyIdsForWebContents(webContentsId: number): string[] {
+    const ptyIds: string[] = []
+    for (const owner of this.ownersByPtyId.values()) {
+      if (owner.webContentsId === webContentsId) {
+        ptyIds.push(owner.ptyId)
+      }
+    }
+    return ptyIds
+  }
+
+  senderOwnsPty(sender: Electron.WebContents, ptyId: string): boolean {
+    const owner = this.ownersByPtyId.get(ptyId)
+    if (owner) {
+      return sender.id === owner.webContentsId
+    }
+    return this.primaryAppWebContentsId !== null && sender.id === this.primaryAppWebContentsId
+  }
+}
+
+export const paneOwnershipRegistry = new PaneOwnershipRegistry()

--- a/src/main/window/trusted-renderer-registry.test.ts
+++ b/src/main/window/trusted-renderer-registry.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { trustedRendererRegistry } from './trusted-renderer-registry'
+
+describe('trustedRendererRegistry', () => {
+  beforeEach(() => {
+    trustedRendererRegistry.clearWebContents(17)
+    trustedRendererRegistry.clearWebContents(18)
+  })
+
+  it('grants, revokes, and checks capabilities independently', () => {
+    trustedRendererRegistry.grant(17, 'ui')
+
+    expect(trustedRendererRegistry.has(17, 'ui')).toBe(true)
+    expect(trustedRendererRegistry.has(17, 'clipboard')).toBe(false)
+    expect(trustedRendererRegistry.has(17, 'pty')).toBe(false)
+    expect(trustedRendererRegistry.has(17, 'browser')).toBe(false)
+
+    trustedRendererRegistry.grantMany(17, ['clipboard', 'pty'])
+    expect(trustedRendererRegistry.has(17, 'clipboard')).toBe(true)
+    expect(trustedRendererRegistry.has(17, 'pty')).toBe(true)
+    expect(trustedRendererRegistry.has(17, 'browser')).toBe(false)
+
+    trustedRendererRegistry.revoke(17, 'clipboard')
+    expect(trustedRendererRegistry.has(17, 'ui')).toBe(true)
+    expect(trustedRendererRegistry.has(17, 'clipboard')).toBe(false)
+
+    trustedRendererRegistry.revoke(17)
+    expect(trustedRendererRegistry.has(17, 'ui')).toBe(false)
+    expect(trustedRendererRegistry.has(17, 'pty')).toBe(false)
+  })
+
+  it('clears one webContents without affecting another', () => {
+    trustedRendererRegistry.grantMany(17, ['ui', 'clipboard'])
+    trustedRendererRegistry.grant(18, 'browser')
+
+    trustedRendererRegistry.clearWebContents(17)
+
+    expect(trustedRendererRegistry.has(17, 'ui')).toBe(false)
+    expect(trustedRendererRegistry.has(18, 'browser')).toBe(true)
+  })
+})

--- a/src/main/window/trusted-renderer-registry.ts
+++ b/src/main/window/trusted-renderer-registry.ts
@@ -1,0 +1,57 @@
+export type TrustedRendererCapability = 'ui' | 'clipboard' | 'pty' | 'browser'
+
+class TrustedRendererRegistry {
+  private readonly capabilitiesByWebContentsId = new Map<number, Set<TrustedRendererCapability>>()
+
+  grant(webContentsId: number, capability: TrustedRendererCapability): void {
+    if (!Number.isInteger(webContentsId)) {
+      return
+    }
+    let capabilities = this.capabilitiesByWebContentsId.get(webContentsId)
+    if (!capabilities) {
+      capabilities = new Set<TrustedRendererCapability>()
+      this.capabilitiesByWebContentsId.set(webContentsId, capabilities)
+    }
+    capabilities.add(capability)
+  }
+
+  grantMany(webContentsId: number, capabilities: TrustedRendererCapability[]): void {
+    for (const capability of capabilities) {
+      this.grant(webContentsId, capability)
+    }
+  }
+
+  revoke(webContentsId: number, capability?: TrustedRendererCapability): void {
+    if (!capability) {
+      this.capabilitiesByWebContentsId.delete(webContentsId)
+      return
+    }
+    const capabilities = this.capabilitiesByWebContentsId.get(webContentsId)
+    if (!capabilities) {
+      return
+    }
+    capabilities.delete(capability)
+    if (capabilities.size === 0) {
+      this.capabilitiesByWebContentsId.delete(webContentsId)
+    }
+  }
+
+  has(webContentsId: number, capability: TrustedRendererCapability): boolean {
+    return this.capabilitiesByWebContentsId.get(webContentsId)?.has(capability) === true
+  }
+
+  hasAny(capability: TrustedRendererCapability): boolean {
+    for (const capabilities of this.capabilitiesByWebContentsId.values()) {
+      if (capabilities.has(capability)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  clearWebContents(webContentsId: number): void {
+    this.capabilitiesByWebContentsId.delete(webContentsId)
+  }
+}
+
+export const trustedRendererRegistry = new TrustedRendererRegistry()

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -348,6 +348,10 @@ import type {
   ReactErrorBoundaryReportArgs,
   ReactErrorBoundaryReportResult
 } from '../shared/crash-reporting'
+import type {
+  DetachedTerminalOpenSnapshot,
+  DetachedTerminalSnapshot
+} from '../shared/detached-terminal-window'
 
 export type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
 
@@ -1282,6 +1286,22 @@ export type PreloadApi = {
     onAdvertisedUrlChanged: (
       callback: (event: WorkspacePortAdvertisedUrlChangedEvent) => void
     ) => () => void
+  }
+  detachedTerminal: {
+    openWindow: (args: {
+      worktreeId: string
+      tabId: string
+      snapshot: DetachedTerminalOpenSnapshot
+    }) => Promise<
+      { ok: true } | { ok: false; error: 'invalid_payload' | 'detached_terminal_tab_unavailable' }
+    >
+    getSnapshot: (args: { worktreeId: string; tabId: string }) => Promise<DetachedTerminalSnapshot>
+    closeWindow: (args: { worktreeId: string; tabId: string }) => Promise<{ ok: true }>
+    rendererPtyReady: (args: {
+      worktreeId: string
+      tabId: string
+      ptyId: string
+    }) => Promise<{ ok: true }>
   }
   pty: {
     spawn: (opts: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -233,6 +233,10 @@ import type {
   ReactErrorBoundaryReportArgs,
   ReactErrorBoundaryReportResult
 } from '../shared/crash-reporting'
+import type {
+  DetachedTerminalOpenSnapshot,
+  DetachedTerminalSnapshot
+} from '../shared/detached-terminal-window'
 import type { PreloadApi } from './api-types'
 import {
   createUpdaterQuitAbortRelay,
@@ -789,6 +793,25 @@ const api = {
       return () => ipcRenderer.removeListener('workspacePorts:advertised-url-changed', listener)
     }
   } satisfies PreloadApi['workspacePorts'],
+
+  detachedTerminal: {
+    openWindow: (args: {
+      worktreeId: string
+      tabId: string
+      snapshot: DetachedTerminalOpenSnapshot
+    }): Promise<
+      { ok: true } | { ok: false; error: 'invalid_payload' | 'detached_terminal_tab_unavailable' }
+    > => ipcRenderer.invoke('detachedTerminal:openWindow', args),
+    getSnapshot: (args: { worktreeId: string; tabId: string }): Promise<DetachedTerminalSnapshot> =>
+      ipcRenderer.invoke('detachedTerminal:getSnapshot', args),
+    closeWindow: (args: { worktreeId: string; tabId: string }): Promise<{ ok: true }> =>
+      ipcRenderer.invoke('detachedTerminal:closeWindow', args),
+    rendererPtyReady: (args: {
+      worktreeId: string
+      tabId: string
+      ptyId: string
+    }): Promise<{ ok: true }> => ipcRenderer.invoke('detachedTerminal:rendererPtyReady', args)
+  } satisfies PreloadApi['detachedTerminal'],
 
   pty: {
     spawn: (opts: {

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
@@ -10,6 +10,9 @@ import { SortableTabContextMenu } from './SortableTabContextMenu'
 
 const storeMock = vi.hoisted(() => ({
   dropUnifiedTab: vi.fn(),
+  getMainBufferSnapshot: vi.fn(),
+  openWindow: vi.fn(),
+  serializeRegisteredPtyBuffer: vi.fn(),
   state: {
     keybindings: {},
     unifiedTabsByWorktree: {},
@@ -68,6 +71,10 @@ vi.mock('lucide-react', () => ({
 
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/components/terminal-pane/pty-buffer-serializer', () => ({
+  serializeRegisteredPtyBuffer: storeMock.serializeRegisteredPtyBuffer
 }))
 
 vi.mock('../../store', () => ({
@@ -147,6 +154,26 @@ function getLastSplitEvent(spy: ReturnType<typeof vi.spyOn>): CustomEvent {
 
 beforeEach(() => {
   storeMock.dropUnifiedTab.mockReset()
+  storeMock.getMainBufferSnapshot.mockReset().mockResolvedValue({
+    data: 'main-buffer',
+    cols: 80,
+    rows: 24,
+    source: 'headless'
+  })
+  storeMock.openWindow.mockReset().mockResolvedValue({ ok: true })
+  storeMock.serializeRegisteredPtyBuffer.mockReset().mockResolvedValue({
+    data: 'renderer-buffer',
+    cols: 80,
+    rows: 24,
+    source: 'renderer'
+  })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      pty: { getMainBufferSnapshot: storeMock.getMainBufferSnapshot },
+      detachedTerminal: { openWindow: storeMock.openWindow }
+    }
+  })
   storeMock.state = {
     keybindings: {},
     dropUnifiedTab: storeMock.dropUnifiedTab,
@@ -175,7 +202,22 @@ beforeEach(() => {
           createdAt: 0
         }
       ]
-    }
+    },
+    activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+    activeTabIdByWorktree: { 'wt-1': 'tab-1' },
+    layoutByWorktree: { 'wt-1': { type: 'leaf', groupId: 'group-1' } },
+    terminalLayoutsByTabId: {
+      'term-1': {
+        root: { type: 'leaf', leafId: 'leaf-1' },
+        activeLeafId: 'leaf-1',
+        expandedLeafId: null,
+        ptyIdsByLeafId: { 'leaf-1': 'pty-1' }
+      }
+    },
+    repos: [{ id: 'repo-1', path: '/tmp/repo' }],
+    worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1', path: '/tmp/wt' }] },
+    settings: {},
+    keybindingSnapshot: null
   }
 })
 
@@ -255,5 +297,154 @@ describe('SortableTabContextMenu', () => {
 
     expect(container.textContent).not.toContain('Move Tab to Split')
     expect(container.textContent).toContain('Split terminal right')
+  })
+
+  it('selects Open in New Window with a fresh snapshot payload', async () => {
+    const { container } = renderMenu()
+
+    await act(async () => {
+      getButton(container, 'Open in New Window').click()
+    })
+
+    expect(storeMock.getMainBufferSnapshot).toHaveBeenCalledWith('pty-1', { scrollbackRows: 5000 })
+    expect(storeMock.openWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: 'wt-1',
+        tabId: 'term-1',
+        snapshot: expect.objectContaining({
+          terminalLayout: expect.objectContaining({
+            ptyIdsByLeafId: { 'leaf-1': 'pty-1' }
+          }),
+          bufferSnapshotsByLeafId: {
+            'leaf-1': expect.objectContaining({ data: 'main-buffer' })
+          }
+        })
+      })
+    )
+  })
+
+  it('targets the right-clicked inactive terminal tab when staging a detached snapshot', async () => {
+    storeMock.state = {
+      ...storeMock.state,
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'tab-1',
+            groupId: 'group-1',
+            worktreeId: 'wt-1',
+            contentType: 'terminal',
+            entityId: 'term-1',
+            label: 'bash',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 0
+          },
+          {
+            id: 'tab-2',
+            groupId: 'group-1',
+            worktreeId: 'wt-1',
+            contentType: 'terminal',
+            entityId: 'term-2',
+            label: 'zsh',
+            customLabel: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 1
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'term-1': {
+          root: { type: 'leaf', leafId: 'leaf-1' },
+          activeLeafId: 'leaf-1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-1': 'pty-1' }
+        },
+        'term-2': {
+          root: { type: 'leaf', leafId: 'leaf-2' },
+          activeLeafId: 'leaf-2',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-2': 'pty-2' }
+        }
+      },
+      activeTabIdByWorktree: { 'wt-1': 'tab-1' }
+    }
+    const { container } = renderMenu({
+      isActive: false,
+      tab: {
+        id: 'term-2',
+        ptyId: 'pty-2',
+        worktreeId: 'wt-1',
+        title: 'zsh',
+        customTitle: null,
+        color: null,
+        sortOrder: 1,
+        createdAt: 1
+      },
+      unifiedTabId: 'tab-2'
+    })
+
+    await act(async () => {
+      getButton(container, 'Open in New Window').click()
+    })
+
+    expect(storeMock.openWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          activeGroupId: 'group-1',
+          activeTabId: 'tab-2'
+        })
+      })
+    )
+  })
+
+  it('keeps Open in New Window enabled for a split tab with only layout PTYs', async () => {
+    storeMock.state = {
+      ...storeMock.state,
+      terminalLayoutsByTabId: {
+        'term-1': {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf-1' },
+            second: { type: 'leaf', leafId: 'leaf-2' }
+          },
+          activeLeafId: 'leaf-1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-1': 'pty-1', 'leaf-2': 'pty-2' }
+        }
+      }
+    }
+    const { container } = renderMenu()
+
+    await act(async () => {
+      getButton(container, 'Open in New Window').click()
+    })
+
+    expect(storeMock.openWindow).toHaveBeenCalled()
+    expect(getButton(container, 'Open in New Window').disabled).toBe(false)
+  })
+
+  it('falls back to renderer serialization when main has no buffer snapshot', async () => {
+    storeMock.getMainBufferSnapshot.mockResolvedValue(null)
+    const { container } = renderMenu()
+
+    await act(async () => {
+      getButton(container, 'Open in New Window').click()
+    })
+
+    expect(storeMock.serializeRegisteredPtyBuffer).toHaveBeenCalledWith('pty-1', {
+      scrollbackRows: 5000
+    })
+    expect(storeMock.openWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          bufferSnapshotsByLeafId: {
+            'leaf-1': expect.objectContaining({ data: 'renderer-buffer' })
+          }
+        })
+      })
+    )
   })
 })

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
@@ -17,6 +17,14 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import type { TerminalTab } from '../../../../shared/types'
+import type {
+  DetachedTerminalBufferSnapshot,
+  DetachedTerminalOpenSnapshot
+} from '../../../../shared/detached-terminal-window'
+import { collectLeafIdsInOrder } from '@/components/terminal-pane/layout-serialization'
+import { serializeRegisteredPtyBuffer } from '@/components/terminal-pane/pty-buffer-serializer'
+import { TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT } from '../../../../shared/terminal-scrollback-limits'
+import { clampUtf8TextTail, measureUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
 import { useAppStore } from '../../store'
 import { formatShortcutLabel, useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
@@ -85,6 +93,23 @@ const TAB_COLORS = [
   }
 ] as const
 
+function capBufferSnapshot(
+  snapshot: DetachedTerminalBufferSnapshot
+): DetachedTerminalBufferSnapshot {
+  if (
+    snapshot.data.length <= TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT &&
+    !measureUtf8ByteLength(snapshot.data, {
+      stopAfterBytes: TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT
+    }).exceededLimit
+  ) {
+    return snapshot
+  }
+  return {
+    ...snapshot,
+    data: clampUtf8TextTail(snapshot.data, TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT).text
+  }
+}
+
 type SortableTabContextMenuProps = {
   tab: TerminalTab
   unifiedTabId: string
@@ -139,6 +164,64 @@ export function SortableTabContextMenu({
   const splitRightShortcut = formatShortcutLabel('terminal.splitRight', keybindings)
   const splitDownShortcut = formatShortcutLabel('terminal.splitDown', keybindings)
 
+  const state = useAppStore.getState()
+  const terminalLayout = state.terminalLayoutsByTabId[tab.id]
+  const layoutPtyIds = Object.values(terminalLayout?.ptyIdsByLeafId ?? {}).filter(Boolean)
+  const canOpenInNewWindow = Boolean(tab.ptyId) || layoutPtyIds.length > 0
+  const openTerminalInNewWindow = async (): Promise<void> => {
+    const latest = useAppStore.getState()
+    const latestLayout = latest.terminalLayoutsByTabId[tab.id]
+    if (!latestLayout) {
+      return
+    }
+    const worktree = Object.values(latest.worktreesByRepo)
+      .flat()
+      .find((candidate) => candidate.id === tab.worktreeId)
+    const unifiedTab = latest.unifiedTabsByWorktree[tab.worktreeId]?.find(
+      (candidate) => candidate.id === unifiedTabId && candidate.contentType === 'terminal'
+    )
+    const group = latest.groupsByWorktree[tab.worktreeId]?.find(
+      (candidate) => candidate.id === groupId
+    )
+    const groupLayout = latest.layoutByWorktree[tab.worktreeId]
+    if (!worktree || !unifiedTab || !group || !groupLayout || !latest.settings) {
+      return
+    }
+    const leafIds = collectLeafIdsInOrder(latestLayout.root)
+    const bufferSnapshotsByLeafId: Record<string, DetachedTerminalBufferSnapshot> = {}
+    for (const leafId of leafIds) {
+      const ptyId = latestLayout.ptyIdsByLeafId?.[leafId]
+      if (!ptyId) {
+        continue
+      }
+      const snapshot =
+        (await window.api.pty.getMainBufferSnapshot(ptyId, { scrollbackRows: 5000 })) ??
+        (await serializeRegisteredPtyBuffer(ptyId, { scrollbackRows: 5000 }))
+      if (snapshot) {
+        bufferSnapshotsByLeafId[leafId] = capBufferSnapshot(snapshot)
+      }
+    }
+    const snapshot: DetachedTerminalOpenSnapshot = {
+      worktree,
+      terminalTab: tab,
+      unifiedTab,
+      group: { ...group, activeTabId: unifiedTab.id },
+      groupLayout,
+      terminalLayout: latestLayout,
+      activeGroupId: group.id,
+      activeTabId: unifiedTab.id,
+      repos: latest.repos,
+      worktreesByRepo: latest.worktreesByRepo,
+      bufferSnapshotsByLeafId,
+      settings: latest.settings,
+      keybindings: latest.keybindingSnapshot
+    }
+    await window.api.detachedTerminal.openWindow({
+      worktreeId: tab.worktreeId,
+      tabId: tab.id,
+      snapshot
+    })
+  }
   const closeShortcut = useOptionalShortcutLabel('tab.close')
   const renameShortcut = useOptionalShortcutLabel('tab.rename')
 
@@ -183,6 +266,17 @@ export function SortableTabContextMenu({
             </DropdownMenuItem>
           </>
         ) : null}
+        <DropdownMenuItem
+          onSelect={() => {
+            void openTerminalInNewWindow()
+          }}
+          disabled={!canOpenInNewWindow}
+        >
+          {translate(
+            'auto.components.tab.bar.SortableTabContextMenu.openInNewWindow',
+            'Open in New Window'
+          )}
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={onTogglePin}>
           {isPinned ? (

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -214,6 +214,7 @@ type TerminalPaneProps = {
   showSplitButton?: boolean
   onPtyExit: (ptyId: string) => void
   onCloseTab: () => void
+  onPtyDataSubscriptionReady?: (ptyId: string) => void
 }
 
 type PaneTitleOverlayRect = {
@@ -280,7 +281,8 @@ export default function TerminalPane({
   isolatedPaneKey = null,
   showSplitButton = true,
   onPtyExit,
-  onCloseTab
+  onCloseTab,
+  onPtyDataSubscriptionReady
 }: TerminalPaneProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
   const managerRef = useRef<PaneManager | null>(null)
@@ -934,6 +936,8 @@ export default function TerminalPane({
   macOptionAsAltRef.current = effectiveMacOptionAsAlt
   const onPtyExitRef = useRef(onPtyExit)
   onPtyExitRef.current = onPtyExit
+  const onPtyDataSubscriptionReadyRef = useRef(onPtyDataSubscriptionReady)
+  onPtyDataSubscriptionReadyRef.current = onPtyDataSubscriptionReady
 
   const systemPrefersDark = useSystemPrefersDark()
   const dispatchNotification = useNotificationDispatch(worktreeId)
@@ -1405,6 +1409,7 @@ export default function TerminalPane({
     isVisibleRef,
     onPtyExitRef,
     onAgentExitedRef,
+    onPtyDataSubscriptionReadyRef,
     onPtyErrorRef,
     clearTabPtyId,
     consumeSuppressedPtyExit: useAppStore((store) => store.consumeSuppressedPtyExit),
@@ -1607,6 +1612,7 @@ export default function TerminalPane({
         isVisibleRef,
         onPtyExitRef,
         onAgentExitedRef,
+        onPtyDataSubscriptionReadyRef,
         onPtyErrorRef,
         clearTabPtyId,
         consumeSuppressedPtyExit: useAppStore.getState().consumeSuppressedPtyExit,

--- a/src/renderer/src/components/terminal-pane/pty-buffer-serializer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-buffer-serializer.ts
@@ -115,6 +115,14 @@ export function hasPtySerializer(ptyId: string): boolean {
   return serializersByPtyId.has(ptyId)
 }
 
+export async function serializeRegisteredPtyBuffer(
+  ptyId: string,
+  opts?: SerializeOpts
+): Promise<SerializedBuffer | null> {
+  const entry = serializersByPtyId.get(ptyId)
+  return entry?.fn(opts) ?? null
+}
+
 function ensureSerializerListener(): void {
   if (listenerAttached) {
     return

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -54,6 +54,7 @@ export type PtyConnectionDeps = {
   isVisibleRef: React.RefObject<boolean>
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onAgentExitedRef: React.RefObject<(leafId: string) => void>
+  onPtyDataSubscriptionReadyRef?: React.RefObject<((ptyId: string) => void) | undefined>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
   clearTabPtyId: (tabId: string, ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3357,6 +3357,8 @@ export function connectPanePty(
     ...(paneStartup?.launchAgent ? { launchAgent: paneStartup.launchAgent } : {}),
     ...(paneStartup?.telemetry ? { telemetry: paneStartup.telemetry } : {}),
     onPtyExit: onExit,
+    onPtyDataSubscriptionReady: (ptyId: string) =>
+      deps.onPtyDataSubscriptionReadyRef?.current?.(ptyId),
     onPtySpawn,
     onPtyRebind,
     ...(mainSideEffectAuthority

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -162,6 +162,7 @@ export type IpcPtyTransportOptions = {
   terminalColorQueryReplies?: TerminalOscColorQueryReplyColors
   telemetry?: EventProps<'agent_started'>
   onPtyExit?: (ptyId: string) => void
+  onPtyDataSubscriptionReady?: (ptyId: string) => void
   onTitleChange?: (title: string, rawTitle: string) => void
   onPtySpawn?: (ptyId: string) => void
   /** Rebind an existing pane after its provider replaces the PTY identity. */

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -481,6 +481,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     terminalColorQueryReplies,
     telemetry,
     onPtyExit,
+    onPtyDataSubscriptionReady,
     onTitleChange,
     onPtySpawn,
     onBell,
@@ -739,6 +740,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         if (exitedBeforeAttach) {
           return { id: spawnResult.id, exitedBeforeAttach: true } satisfies PtyConnectResult
         }
+        onPtyDataSubscriptionReady?.(spawnResult.id)
         if (!connected || ptyId !== spawnResult.id) {
           return undefined
         }
@@ -818,6 +820,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       // Why: skip onPtySpawn — it would reset lastActivityAt and destroy the recency sort order reconnectPersistedTerminals preserved.
       registerPtyDataHandler(id)
       registerPtyExitHandler(id)
+      onPtyDataSubscriptionReady?.(id)
       if (!connected || ptyId !== id) {
         return
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -263,6 +263,7 @@ type UseTerminalPaneLifecycleDeps = {
   isVisibleRef: React.RefObject<boolean>
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onAgentExitedRef: React.RefObject<(leafId: string) => void>
+  onPtyDataSubscriptionReadyRef?: React.RefObject<((ptyId: string) => void) | undefined>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
   clearTabPtyId: (tabId: string, ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
@@ -518,6 +519,7 @@ export function useTerminalPaneLifecycle({
   isVisibleRef,
   onPtyExitRef,
   onAgentExitedRef,
+  onPtyDataSubscriptionReadyRef,
   onPtyErrorRef,
   clearTabPtyId,
   consumeSuppressedPtyExit,
@@ -730,6 +732,7 @@ export function useTerminalPaneLifecycle({
       isVisibleRef,
       onPtyExitRef,
       onAgentExitedRef,
+      onPtyDataSubscriptionReadyRef,
       onPtyErrorRef,
       clearTabPtyId,
       consumeSuppressedPtyExit,

--- a/src/renderer/src/components/terminal/DetachedTerminalShell.test.tsx
+++ b/src/renderer/src/components/terminal/DetachedTerminalShell.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DetachedTerminalSnapshot } from '../../../../shared/detached-terminal-window'
+
+const shellMocks = vi.hoisted(() => ({
+  terminalPaneProps: [] as Record<string, unknown>[],
+  state: {} as Record<string, unknown>,
+  getSnapshot: vi.fn(),
+  closeWindow: vi.fn(),
+  rendererPtyReady: vi.fn(),
+  openWindow: vi.fn()
+}))
+
+vi.mock('@/components/terminal-pane/TerminalPane', () => ({
+  default: (props: Record<string, unknown>) => {
+    shellMocks.terminalPaneProps.push(props)
+    return <div data-testid="detached-terminal-pane" />
+  }
+}))
+
+vi.mock('@/store/slices/detached-terminal-hydration', () => ({
+  hydrateDetachedTerminalSnapshot: (snapshot: DetachedTerminalSnapshot) => {
+    shellMocks.state = {
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ptyIdsByTabId: { [snapshot.terminalTab.id]: snapshot.ptyIds },
+      terminalLayoutsByTabId: { [snapshot.terminalTab.id]: snapshot.terminalLayout },
+      repos: snapshot.repos,
+      worktreesByRepo: snapshot.worktreesByRepo
+    }
+  }
+}))
+
+function snapshot(overrides: Partial<DetachedTerminalSnapshot> = {}): DetachedTerminalSnapshot {
+  const base: DetachedTerminalSnapshot = {
+    worktree: { id: 'wt-1', repoId: 'repo-1', path: '/tmp/wt' } as never,
+    terminalTab: {
+      id: 'tab-1',
+      ptyId: 'pty-1',
+      worktreeId: 'wt-1',
+      title: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 0
+    },
+    unifiedTab: {
+      id: 'unified-1',
+      entityId: 'tab-1',
+      groupId: 'group-1',
+      worktreeId: 'wt-1',
+      contentType: 'terminal',
+      label: 'Terminal',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 0
+    },
+    group: { id: 'group-1', worktreeId: 'wt-1', activeTabId: 'unified-1', tabOrder: ['unified-1'] },
+    groupLayout: { type: 'leaf', groupId: 'group-1' },
+    terminalLayout: {
+      root: { type: 'leaf', leafId: 'leaf-1' },
+      activeLeafId: 'leaf-1',
+      expandedLeafId: null,
+      ptyIdsByLeafId: { 'leaf-1': 'pty-1' }
+    },
+    activeGroupId: 'group-1',
+    activeTabId: 'unified-1',
+    repos: [{ id: 'repo-1', path: '/tmp/repo', connectionId: 'ssh-1' } as never],
+    worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1', path: '/tmp/wt' } as never] },
+    bufferSnapshotsByLeafId: {},
+    settings: {} as never,
+    keybindings: null,
+    ptyIds: ['pty-1']
+  }
+  return { ...base, ...overrides }
+}
+
+const mounted: { container: HTMLDivElement; root: Root }[] = []
+
+async function renderShell(
+  url = '/?mode=detached-terminal&worktreeId=wt-1&tabId=tab-1'
+): Promise<HTMLDivElement> {
+  window.history.replaceState(null, '', url)
+  const { default: DetachedTerminalShell } = await import('./DetachedTerminalShell')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(<DetachedTerminalShell />)
+  })
+  mounted.push({ container, root })
+  return container
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  shellMocks.terminalPaneProps = []
+  shellMocks.state = {}
+  shellMocks.getSnapshot.mockReset()
+  shellMocks.closeWindow.mockReset().mockResolvedValue({ ok: true })
+  shellMocks.rendererPtyReady.mockReset().mockResolvedValue({ ok: true })
+  shellMocks.openWindow.mockReset()
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      detachedTerminal: {
+        getSnapshot: shellMocks.getSnapshot,
+        closeWindow: shellMocks.closeWindow,
+        rendererPtyReady: shellMocks.rendererPtyReady,
+        openWindow: shellMocks.openWindow
+      }
+    }
+  })
+})
+
+afterEach(() => {
+  for (const { container, root } of mounted.splice(0)) {
+    act(() => root.unmount())
+    container.remove()
+  }
+  vi.restoreAllMocks()
+})
+
+describe('DetachedTerminalShell', () => {
+  it('hydrates a single-pane snapshot before mounting TerminalPane', async () => {
+    shellMocks.getSnapshot.mockResolvedValue(snapshot())
+    const container = await renderShell()
+    await act(async () => {})
+
+    expect(container.querySelector('[data-testid="detached-terminal-pane"]')).not.toBeNull()
+    expect(shellMocks.state.workspaceSessionReady).toBe(true)
+    expect(shellMocks.state.ptyIdsByTabId).toEqual({ 'tab-1': ['pty-1'] })
+    expect(shellMocks.terminalPaneProps[0]).toMatchObject({
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      cwd: '/tmp/wt',
+      isActive: true,
+      isVisible: true,
+      isWorktreeActive: true
+    })
+    expect(typeof shellMocks.terminalPaneProps[0]?.onPtyExit).toBe('function')
+    expect(typeof shellMocks.terminalPaneProps[0]?.onCloseTab).toBe('function')
+  })
+
+  it('renders a draggable title bar strip so the detached window can be moved', async () => {
+    shellMocks.getSnapshot.mockResolvedValue(snapshot())
+    const container = await renderShell()
+    await act(async () => {})
+
+    const dragStrip = container.querySelector<HTMLElement>('[data-detached-titlebar-drag]')
+    expect(dragStrip).not.toBeNull()
+    expect(dragStrip?.classList.contains('titlebar')).toBe(true)
+    // Why: the terminal surface must live outside the drag strip so xterm keeps
+    // pointer selection/focus; assert it is a sibling, not a descendant.
+    expect(
+      dragStrip?.contains(container.querySelector('[data-testid="detached-terminal-pane"]'))
+    ).toBe(false)
+  })
+
+  it('hydrates a split-pane snapshot and preserves every PTY from snapshot.ptyIds', async () => {
+    shellMocks.getSnapshot.mockResolvedValue(
+      snapshot({
+        ptyIds: ['pty-1', 'pty-2'],
+        terminalLayout: {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf-1' },
+            second: { type: 'leaf', leafId: 'leaf-2' }
+          },
+          activeLeafId: 'leaf-1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-1': 'pty-1', 'leaf-2': 'pty-2' }
+        }
+      })
+    )
+    await renderShell()
+    await act(async () => {})
+
+    expect(shellMocks.state.ptyIdsByTabId).toEqual({ 'tab-1': ['pty-1', 'pty-2'] })
+  })
+
+  it('hydrates a remote-owner snapshot with repos and worktreesByRepo for SSH ownership', async () => {
+    shellMocks.getSnapshot.mockResolvedValue(snapshot())
+    await renderShell()
+    await act(async () => {})
+
+    expect(shellMocks.state.repos).toEqual(
+      expect.arrayContaining([expect.objectContaining({ connectionId: 'ssh-1' })])
+    )
+    expect(shellMocks.state.worktreesByRepo).toHaveProperty('repo-1')
+  })
+
+  it('renders loading and unavailable states without mounting the main app shell', async () => {
+    let rejectSnapshot!: (error: Error) => void
+    shellMocks.getSnapshot.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectSnapshot = reject
+      })
+    )
+    const container = await renderShell()
+    expect(container.querySelector('[aria-label="Loading detached terminal"]')).not.toBeNull()
+    await act(async () => {
+      rejectSnapshot(new Error('detached_terminal_tab_unavailable'))
+    })
+
+    expect(container.querySelector('[aria-label="Detached terminal unavailable"]')).not.toBeNull()
+    expect(shellMocks.terminalPaneProps).toHaveLength(0)
+  })
+
+  it('reports renderer PTY readiness and closes only the detached window', async () => {
+    shellMocks.getSnapshot.mockResolvedValue(snapshot())
+    await renderShell()
+    await act(async () => {})
+
+    const props = shellMocks.terminalPaneProps[0]
+    const onReady = props?.onPtyDataSubscriptionReady as ((ptyId: string) => void) | undefined
+    const onClose = props?.onCloseTab as (() => void) | undefined
+    onReady?.('pty-1')
+    onClose?.()
+
+    expect(shellMocks.rendererPtyReady).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      ptyId: 'pty-1'
+    })
+    expect(shellMocks.closeWindow).toHaveBeenCalledWith({ worktreeId: 'wt-1', tabId: 'tab-1' })
+  })
+})

--- a/src/renderer/src/components/terminal/DetachedTerminalShell.tsx
+++ b/src/renderer/src/components/terminal/DetachedTerminalShell.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import TerminalPane from '@/components/terminal-pane/TerminalPane'
+import type { DetachedTerminalSnapshot } from '../../../../shared/detached-terminal-window'
+import { hydrateDetachedTerminalSnapshot } from '@/store/slices/detached-terminal-hydration'
+import { translate } from '@/i18n/i18n'
+
+type ShellState =
+  | { status: 'loading' }
+  | { status: 'ready'; snapshot: DetachedTerminalSnapshot }
+  | { status: 'unavailable' }
+
+function getQueryIds(): { worktreeId: string | null; tabId: string | null } {
+  const params = new URLSearchParams(window.location.search)
+  const worktreeId = params.get('worktreeId')?.trim() || null
+  const tabId = params.get('tabId')?.trim() || null
+  return { worktreeId, tabId }
+}
+
+const EMPTY_PTY_IDS: string[] = []
+
+export default function DetachedTerminalShell(): React.JSX.Element {
+  const [{ worktreeId, tabId }] = useState(getQueryIds)
+  const [state, setState] = useState<ShellState>({ status: 'loading' })
+  const [, setExitedPtyIds] = useState<Set<string>>(() => new Set())
+
+  useEffect(() => {
+    if (!worktreeId || !tabId) {
+      setState({ status: 'unavailable' })
+      return
+    }
+    let cancelled = false
+    void window.api.detachedTerminal
+      .getSnapshot({ worktreeId, tabId })
+      .then((snapshot) => {
+        if (cancelled || snapshot.ptyIds.length === 0) {
+          return
+        }
+        hydrateDetachedTerminalSnapshot(snapshot)
+        setState({ status: 'ready', snapshot })
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ status: 'unavailable' })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [tabId, worktreeId])
+
+  const readyPtyIds = state.status === 'ready' ? state.snapshot.ptyIds : EMPTY_PTY_IDS
+  const readyPtyIdSet = useMemo(() => new Set(readyPtyIds), [readyPtyIds])
+
+  const handleDetachedPtyReady = useCallback(
+    (ptyId: string) => {
+      if (!worktreeId || !tabId || !readyPtyIdSet.has(ptyId)) {
+        return
+      }
+      void window.api.detachedTerminal.rendererPtyReady({ worktreeId, tabId, ptyId })
+    },
+    [readyPtyIdSet, tabId, worktreeId]
+  )
+
+  const handleDetachedPtyExit = useCallback(
+    (ptyId: string) => {
+      setExitedPtyIds((current) => {
+        const next = new Set(current)
+        next.add(ptyId)
+        if (readyPtyIds.length > 0 && readyPtyIds.every((id) => next.has(id))) {
+          setState({ status: 'unavailable' })
+        }
+        return next
+      })
+    },
+    [readyPtyIds]
+  )
+
+  const handleDetachedCloseTab = useCallback(() => {
+    if (!worktreeId || !tabId) {
+      return
+    }
+    void window.api.detachedTerminal.closeWindow({ worktreeId, tabId })
+  }, [tabId, worktreeId])
+
+  if (state.status === 'loading') {
+    return (
+      <div
+        aria-label={translate(
+          'auto.components.terminal.DetachedTerminalShell.loading',
+          'Loading detached terminal'
+        )}
+      />
+    )
+  }
+  if (state.status === 'unavailable') {
+    return (
+      <div
+        aria-label={translate(
+          'auto.components.terminal.DetachedTerminalShell.unavailable',
+          'Detached terminal unavailable'
+        )}
+      />
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Why: detached windows hide native chrome, so they need a
+          renderer-owned drag strip while xterm stays no-drag. */}
+      <div
+        data-detached-titlebar-drag
+        className="titlebar shrink-0"
+        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      >
+        <span className="titlebar-traffic-light-pad" />
+        <span className="truncate text-xs text-muted-foreground">
+          {state.snapshot.terminalTab.title || 'Terminal'}
+        </span>
+      </div>
+      <div className="min-h-0 flex-1" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+        <TerminalPane
+          tabId={state.snapshot.terminalTab.id}
+          worktreeId={state.snapshot.worktree.id}
+          cwd={state.snapshot.worktree.path}
+          isActive={true}
+          isVisible={true}
+          isWorktreeActive={true}
+          onPtyExit={handleDetachedPtyExit}
+          onCloseTab={handleDetachedCloseTab}
+          onPtyDataSubscriptionReady={handleDetachedPtyReady}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2738,6 +2738,10 @@
             "removedBody": "The SSH host for this workspace was removed, so it can no longer connect. Remove the workspace to clear it — remote files are left untouched.",
             "removeWorkspaceButton": "Remove workspace"
           }
+        },
+        "DetachedTerminalShell": {
+          "loading": "Loading detached terminal",
+          "unavailable": "Detached terminal unavailable"
         }
       },
       "tab": {
@@ -2841,7 +2845,8 @@
             "60f958ec75": "Pin Tab",
             "417722e9c2": "Unpin Tab",
             "splitTerminalRight": "Split terminal right",
-            "splitTerminalDown": "Split terminal down"
+            "splitTerminalDown": "Split terminal down",
+            "openInNewWindow": "Open in New Window"
           },
           "TabBar": {
             "b1a132357f": "New tab",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2715,6 +2715,10 @@
             "removedBody": "El host SSH de este espacio de trabajo fue eliminado, por lo que ya no puede conectarse. Elimina el espacio de trabajo para limpiarlo — los archivos remotos permanecen intactos.",
             "removeWorkspaceButton": "Eliminar espacio de trabajo"
           }
+        },
+        "DetachedTerminalShell": {
+          "loading": "Loading detached terminal",
+          "unavailable": "Detached terminal unavailable"
         }
       },
       "tab": {
@@ -2818,7 +2822,8 @@
             "60f958ec75": "Fijar pestaña",
             "417722e9c2": "Desanclar pestaña",
             "splitTerminalRight": "Dividir terminal a la derecha",
-            "splitTerminalDown": "Dividir terminal hacia abajo"
+            "splitTerminalDown": "Dividir terminal hacia abajo",
+            "openInNewWindow": "Open in New Window"
           },
           "TabBar": {
             "b1a132357f": "Nueva pestaña",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2715,6 +2715,10 @@
             "removedBody": "このワークスペースのSSHホストが削除されたため、接続できません。ワークスペースを削除してクリアしてください — リモートファイルはそのまま残ります。",
             "removeWorkspaceButton": "ワークスペースを削除"
           }
+        },
+        "DetachedTerminalShell": {
+          "loading": "Loading detached terminal",
+          "unavailable": "Detached terminal unavailable"
         }
       },
       "tab": {
@@ -2818,7 +2822,8 @@
             "60f958ec75": "ピンタブ",
             "417722e9c2": "タブの固定を解除する",
             "splitTerminalRight": "ターミナルを右に分割",
-            "splitTerminalDown": "ターミナルを下に分割"
+            "splitTerminalDown": "ターミナルを下に分割",
+            "openInNewWindow": "Open in New Window"
           },
           "TabBar": {
             "b1a132357f": "新規タブ",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2715,6 +2715,10 @@
             "removedBody": "이 워크트리의 SSH 호스트가 제거되어 더 이상 연결할 수 없습니다. 워크트리를 제거하여 정리하세요 — 원격 파일은 그대로 남아 있습니다.",
             "removeWorkspaceButton": "워크트리 제거"
           }
+        },
+        "DetachedTerminalShell": {
+          "loading": "Loading detached terminal",
+          "unavailable": "Detached terminal unavailable"
         }
       },
       "tab": {
@@ -2818,7 +2822,8 @@
             "60f958ec75": "탭 고정",
             "417722e9c2": "탭 고정 해제",
             "splitTerminalRight": "터미널을 오른쪽으로 분할",
-            "splitTerminalDown": "터미널을 아래로 분할"
+            "splitTerminalDown": "터미널을 아래로 분할",
+            "openInNewWindow": "Open in New Window"
           },
           "TabBar": {
             "b1a132357f": "새 탭",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2715,6 +2715,10 @@
             "removedBody": "此工作区的 SSH 主机已被移除，无法再连接。请移除工作区以清理 — 远程文件不会受影响。",
             "removeWorkspaceButton": "移除工作区"
           }
+        },
+        "DetachedTerminalShell": {
+          "loading": "Loading detached terminal",
+          "unavailable": "Detached terminal unavailable"
         }
       },
       "tab": {
@@ -2818,7 +2822,8 @@
             "60f958ec75": "固定标签",
             "417722e9c2": "取消固定标签",
             "splitTerminalRight": "向右拆分终端",
-            "splitTerminalDown": "向下拆分终端"
+            "splitTerminalDown": "向下拆分终端",
+            "openInNewWindow": "Open in New Window"
           },
           "TabBar": {
             "b1a132357f": "新标签页",

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { useTranslation } from 'react-i18next'
 import App from './App'
+import DetachedTerminalShell from './components/terminal/DetachedTerminalShell'
 import { RecoverableRenderErrorBoundary } from './components/error-boundaries/RecoverableRenderErrorBoundary'
 import {
   installRendererCrashDiagnostics,
@@ -13,6 +14,10 @@ import { applyDocumentTheme } from './lib/document-theme'
 import { shouldEnableReactGrab } from './lib/react-grab-dev-gate'
 import { I18nProvider } from './i18n/I18nProvider'
 import { translate } from './i18n/i18n'
+import { TooltipProvider } from './components/ui/tooltip'
+import { Toaster } from './components/ui/sonner'
+import { ConfirmationDialogProvider } from './components/confirmation-dialog'
+import { LinkRoutingPreferenceDialogProvider } from './components/link-routing-preference-dialog'
 
 recordRendererCrashBreadcrumb('renderer_bootstrap_started', { dev: import.meta.env.DEV })
 installRendererCrashDiagnostics()
@@ -36,6 +41,9 @@ if (!rootElement) {
   throw new Error('Renderer root element not found.')
 }
 
+const isDetachedTerminalMode =
+  new URLSearchParams(window.location.search).get('mode') === 'detached-terminal'
+
 function RendererRoot(): React.JSX.Element {
   useTranslation()
   return (
@@ -48,7 +56,18 @@ function RendererRoot(): React.JSX.Element {
         'The app shell could not finish rendering. Retry to remount it, or relaunch Orca if the error persists.'
       )}
     >
-      <App />
+      {isDetachedTerminalMode ? (
+        <TooltipProvider delayDuration={400}>
+          <ConfirmationDialogProvider>
+            <LinkRoutingPreferenceDialogProvider>
+              <DetachedTerminalShell />
+            </LinkRoutingPreferenceDialogProvider>
+          </ConfirmationDialogProvider>
+          <Toaster closeButton toastOptions={{ className: 'font-sans text-sm' }} />
+        </TooltipProvider>
+      ) : (
+        <App />
+      )}
     </RecoverableRenderErrorBoundary>
   )
 }

--- a/src/renderer/src/store/slices/detached-terminal-hydration.ts
+++ b/src/renderer/src/store/slices/detached-terminal-hydration.ts
@@ -1,0 +1,43 @@
+import { useAppStore } from '..'
+import type { DetachedTerminalSnapshot } from '../../../../shared/detached-terminal-window'
+
+export function hydrateDetachedTerminalSnapshot(snapshot: DetachedTerminalSnapshot): void {
+  if (snapshot.ptyIds.length === 0) {
+    useAppStore.setState({ hydrationSucceeded: false, workspaceSessionReady: false })
+    return
+  }
+
+  const buffersByLeafId = { ...snapshot.terminalLayout.buffersByLeafId }
+  for (const [leafId, bufferSnapshot] of Object.entries(snapshot.bufferSnapshotsByLeafId)) {
+    buffersByLeafId[leafId] = bufferSnapshot.data
+  }
+  const terminalLayout = {
+    ...snapshot.terminalLayout,
+    buffersByLeafId
+  }
+
+  useAppStore.setState({
+    tabsByWorktree: { [snapshot.worktree.id]: [snapshot.terminalTab] },
+    ptyIdsByTabId: { [snapshot.terminalTab.id]: snapshot.ptyIds },
+    unifiedTabsByWorktree: { [snapshot.worktree.id]: [snapshot.unifiedTab] },
+    groupsByWorktree: { [snapshot.worktree.id]: [snapshot.group] },
+    layoutByWorktree: { [snapshot.worktree.id]: snapshot.groupLayout },
+    activeGroupIdByWorktree: { [snapshot.worktree.id]: snapshot.activeGroupId },
+    activeTabIdByWorktree: { [snapshot.worktree.id]: snapshot.activeTabId },
+    terminalLayoutsByTabId: { [snapshot.terminalTab.id]: terminalLayout },
+    settings: snapshot.settings,
+    repos: snapshot.repos,
+    worktreesByRepo: snapshot.worktreesByRepo,
+    ...(snapshot.keybindings
+      ? {
+          keybindings: snapshot.keybindings.overrides,
+          keybindingSnapshot: snapshot.keybindings
+        }
+      : {}),
+    activeWorktreeId: snapshot.worktree.id,
+    activeTabId: snapshot.terminalTab.id,
+    activeTabType: 'terminal',
+    workspaceSessionReady: true,
+    hydrationSucceeded: true
+  })
+}

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1119,6 +1119,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   closeTab: (tabId, opts) => {
+    // Why: a tab may be popped out into a detached window — close that window
+    // before retiring the session so the pop-out never outlives its tab.
+    const detachedOwnerWorktreeId = getTerminalTabOwnerWorktreeId(get().tabsByWorktree, tabId)
+    if (detachedOwnerWorktreeId) {
+      void window.api.detachedTerminal?.closeWindow({ worktreeId: detachedOwnerWorktreeId, tabId })
+    }
     const closeReason = opts?.reason ?? 'user'
     const retiresSession = closeReason === 'user' || closeReason === 'cleanup'
     const retirementPlan =

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -744,6 +744,13 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     shell: createShellApi(),
     skills: createSkillsApi(),
     pty: createPtyApi(),
+    detachedTerminal: {
+      openWindow: () => Promise.resolve({ ok: false, error: 'detached_terminal_tab_unavailable' }),
+      getSnapshot: () =>
+        Promise.reject(new Error('Detached terminal windows are unavailable in the web client.')),
+      closeWindow: () => Promise.resolve({ ok: true }),
+      rendererPtyReady: () => Promise.resolve({ ok: true })
+    },
     ssh: createSshApi(),
     wsl: {
       isAvailable: () => callRuntimeResult<boolean>('host.wsl.isAvailable').catch(() => false),

--- a/src/shared/detached-terminal-window.ts
+++ b/src/shared/detached-terminal-window.ts
@@ -1,0 +1,41 @@
+import type {
+  GlobalSettings,
+  Repo,
+  Tab,
+  TabGroup,
+  TabGroupLayoutNode,
+  TerminalLayoutSnapshot,
+  TerminalTab,
+  Worktree
+} from './types'
+import type { KeybindingFileSnapshot } from './keybindings'
+
+export type DetachedTerminalBufferSnapshot = {
+  data: string
+  cols: number
+  rows: number
+  cwd?: string | null
+  seq?: number
+  source?: 'headless' | 'renderer'
+  lastTitle?: string
+}
+
+export type DetachedTerminalOpenSnapshot = {
+  worktree: Worktree
+  terminalTab: TerminalTab
+  unifiedTab: Tab
+  group: TabGroup
+  groupLayout: TabGroupLayoutNode
+  terminalLayout: TerminalLayoutSnapshot
+  activeGroupId: string
+  activeTabId: string
+  repos: Repo[]
+  worktreesByRepo: Record<string, Worktree[]>
+  bufferSnapshotsByLeafId: Record<string, DetachedTerminalBufferSnapshot>
+  settings: GlobalSettings
+  keybindings: KeybindingFileSnapshot | null
+}
+
+export type DetachedTerminalSnapshot = DetachedTerminalOpenSnapshot & {
+  ptyIds: string[]
+}

--- a/tests/e2e/tabs-detached.spec.ts
+++ b/tests/e2e/tabs-detached.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from './helpers/orca-app'
+import {
+  getActiveTabId,
+  waitForActiveWorktree,
+  waitForSessionReady,
+  ensureTerminalVisible
+} from './helpers/store'
+import { waitForActivePanePtyId, waitForActiveTerminalManager } from './helpers/terminal'
+
+const SORTABLE_TAB = '[data-testid="sortable-tab"]'
+
+test.describe('detached terminal tabs', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await waitForActivePanePtyId(orcaPage)
+  })
+
+  test('opens, reuses, and closes a detached terminal window without closing the origin tab', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    const activeTabId = await getActiveTabId(orcaPage)
+    const activeTab = orcaPage.locator(`${SORTABLE_TAB}[data-tab-id="${activeTabId}"]`).first()
+    await expect(activeTab).toBeVisible()
+
+    await activeTab.click({ button: 'right' })
+    const firstWindowPromise = electronApp.waitForEvent('window')
+    await orcaPage.getByRole('menuitem', { name: 'Open in New Window', exact: true }).click()
+    const detachedWindow = await firstWindowPromise
+    await detachedWindow.waitForLoadState('domcontentloaded')
+    await expect(
+      detachedWindow.getByRole('textbox', { name: 'Terminal input' }).first()
+    ).toBeVisible({ timeout: 30_000 })
+
+    await activeTab.click({ button: 'right' })
+    const unexpectedWindowPromise = electronApp
+      .waitForEvent('window', { timeout: 1_000 })
+      .then(() => true)
+      .catch(() => false)
+    await orcaPage.getByRole('menuitem', { name: 'Open in New Window', exact: true }).click()
+    await expect.poll(async () => electronApp.windows().length, { timeout: 5_000 }).toBe(2)
+    expect(await unexpectedWindowPromise).toBe(false)
+
+    await detachedWindow.close()
+    await expect(activeTab).toBeVisible({ timeout: 10_000 })
+    await expect.poll(async () => electronApp.windows().length, { timeout: 5_000 }).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Implement a new feature allowing users to detach terminal tabs into standalone, platform-native secondary windows ("Open in New Window" context menu action). The main window remains the PTY lifecycle owner, while detached windows subscribe to `pty:data` and route PTY controls through a main-process capability and ownership verification layer.

## Screenshots

Pending visual proof for the window menu option and detached window display. Terminal output itself is unchanged. Keep draft until that recording or screenshot evidence is attached.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck` - not run repo-wide; targeted node and web typechecks below passed.
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

*Targeted verification:*
- `pnpm run typecheck:node` - passed.
- `pnpm run typecheck:web` - passed.
- Run targeted Vitest suite: `pnpm --filter @stablyai/terminal test`
- Run E2E: `pnpm run test:e2e -- tests/e2e/tabs-detached.spec.ts` (Passed)

## AI Review Report

The code review checked:
- **Cross-platform compatibility:** Verified modifier keys (CmdOrCtrl) and path separators are fully cross-platform.
- **PTY control security:** Verified that detached renderers are restricted from signaling, reading, or writing to PTYs they do not own.
- **Window reuse auth:** Added regression tests ensuring only the primary window or the detached window itself can call `detachedTerminal:openWindow` to focus an already open pop-out.
- **Hydration race conditions:** Ensured Zustand state hydration is synchronous and blocks rendering until PTY mappings are fully seeded to avoid duplicate spawn requests.

## Security Audit

- **IPC Gate Authorization:** Hardened PTY write/resize/ack/signal channels to check both capability (`pty`) and direct ownership of the requested PTY in the pane registry.
- **Staging Validation:** `detachedTerminal:openWindow` validates the entire tab layout and PTY bindings in the main process before creating the window or transferring ownership.
- **Close Window Gate:** Restricted `detachedTerminal:closeWindow` to prevent unrelated renderers from closing target windows.

## Notes

- Connection/SSH parameters are preserved in the snapshot structure, supporting SSH/remote environments.
- Local Node version is v25.2.1 while repo target is Node 24. The targeted typecheck and E2E commands listed above pass.
- This is a backend/shell pop-out window feature, separate from the floating-terminal tab-state model in #6469.

X handle: @wolfie_

## ELI5

You can pop a terminal tab into its own native window via “Open in New Window.” The main window still owns the PTY; the new window just displays and controls that same session.
