### PR TITLE
Fix WSL watcher shutdown hang

### DIFF
--- a/src/main/ipc/filesystem-watcher-wsl.test.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.test.ts
@@ -153,4 +153,23 @@ describe('createWslWatcher', () => {
 
     await expect(promise).rejects.toThrow('WSL watcher exited before first snapshot')
   })
+
+  it('does not emit a shutdown refresh after a startup error', async () => {
+    const scheduleBatchFlush = vi.fn()
+    const { child, promise } = startWatcher(makeDeps(scheduleBatchFlush))
+
+    child.emit('error', new Error('spawn failed'))
+    child.emit('close', 1, null)
+
+    await expect(promise).rejects.toThrow('spawn failed')
+    expect(scheduleBatchFlush).not.toHaveBeenCalled()
+  })
+
+  it('rejects startup when WSL exits before reading the snapshot script', async () => {
+    const { child, promise } = startWatcher()
+
+    child.stdin.emit('error', new Error('write EPIPE'))
+
+    await expect(promise).rejects.toThrow('write EPIPE')
+  })
 })

--- a/src/main/ipc/filesystem-watcher-wsl.test.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.test.ts
@@ -1,194 +1,156 @@
-import * as path from 'path'
+import { EventEmitter } from 'events'
+import { PassThrough } from 'stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { readdirMock } = vi.hoisted(() => ({
-  readdirMock: vi.fn()
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn()
 }))
 
-vi.mock('fs/promises', () => ({
-  readdir: readdirMock
+vi.mock('child_process', () => ({
+  spawn: spawnMock
 }))
 
 import { createWslWatcher } from './filesystem-watcher-wsl'
-import type { WatchedRoot } from './filesystem-watcher-wsl'
+import type { WatchedRoot, WslWatcherDeps } from './filesystem-watcher-wsl'
+
+const SNAPSHOT_START = '\x1e'
+const SNAPSHOT_END = '\x1f'
+const ROOT_KEY = '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo'
+
+class FakeChildProcess extends EventEmitter {
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  kill = vi.fn(() => {
+    this.emit('close', null, 'SIGTERM')
+    return true
+  })
+}
+
+function snapshotFrame(entries: [type: string, mtime: string, path: string][]): string {
+  return `${SNAPSHOT_START}${entries
+    .map(([type, mtime, entryPath]) => `${type}\t${mtime}\t${entryPath}\0`)
+    .join('')}${SNAPSHOT_END}`
+}
+
+type ScheduleBatchFlush = (rootKey: string, root: WatchedRoot) => void
+type ScheduleBatchFlushMock = ReturnType<typeof vi.fn<ScheduleBatchFlush>>
+
+function makeDeps(
+  scheduleBatchFlush: ScheduleBatchFlushMock = vi.fn<ScheduleBatchFlush>()
+): WslWatcherDeps & {
+  scheduleBatchFlush: ScheduleBatchFlushMock
+  watchedRoots: Map<string, WatchedRoot>
+} {
+  return {
+    ignoreDirs: ['node_modules', '.git'],
+    scheduleBatchFlush,
+    watchedRoots: new Map()
+  }
+}
+
+function startWatcher(deps = makeDeps()): {
+  child: FakeChildProcess
+  promise: Promise<WatchedRoot>
+  deps: ReturnType<typeof makeDeps>
+} {
+  const child = new FakeChildProcess()
+  spawnMock.mockReturnValueOnce(child)
+  const promise = createWslWatcher(ROOT_KEY, ROOT_KEY, deps)
+  return { child, promise, deps }
+}
+
+async function resolveInitialSnapshot(
+  child: FakeChildProcess,
+  promise: Promise<WatchedRoot>
+): Promise<WatchedRoot> {
+  child.stdout.write(snapshotFrame([['f', '1.0', '/home/me/repo/README.md']]))
+  return promise
+}
 
 describe('createWslWatcher', () => {
-  const rootPath = '/mnt/wsl/repo'
-  const rootKey = rootPath
-
   beforeEach(() => {
-    vi.useFakeTimers()
-    readdirMock.mockReset()
+    spawnMock.mockReset()
   })
 
   afterEach(() => {
-    vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
-  function deps(scheduleBatchFlush: (rootKey: string, root: WatchedRoot) => void) {
-    return {
-      ignoreDirs: ['node_modules', '.git'],
-      scheduleBatchFlush,
-      watchedRoots: new Map<string, WatchedRoot>()
-    }
-  }
+  it('spawns a WSL-native snapshot process for the distro path', async () => {
+    const { child, promise } = startWatcher()
+    child.stdout.write(snapshotFrame([]))
 
-  function releasePollWith(
-    releasePoll: ((entries: ReturnType<typeof dirent>[]) => void) | null,
-    entries: ReturnType<typeof dirent>[]
-  ): void {
-    if (!releasePoll) {
-      throw new Error('expected an in-flight poll')
-    }
-    releasePoll(entries)
-  }
+    await promise
 
-  function dirent(name: string, type: 'dir' | 'file' | 'symlink' = 'file') {
-    return {
-      name,
-      isDirectory: () => type === 'dir',
-      isSymbolicLink: () => type === 'symlink'
-    }
-  }
+    expect(spawnMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      ['-d', 'Ubuntu', '--', 'sh', '-s', '--', '/home/me/repo'],
+      expect.objectContaining({
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true
+      })
+    )
+  })
 
-  it('does not overlap polling when a WSL snapshot scan is still in flight', async () => {
+  it('diffs WSL snapshots into create, update, and delete events', async () => {
     const scheduleBatchFlush = vi.fn()
-    let rootReads = 0
-    let releasePoll: ((entries: ReturnType<typeof dirent>[]) => void) | null = null
+    const { child, promise } = startWatcher(makeDeps(scheduleBatchFlush))
 
-    readdirMock.mockImplementation((dirPath: string) => {
-      if (dirPath !== rootPath) {
-        return Promise.resolve([])
-      }
-      rootReads += 1
-      if (rootReads === 1) {
-        return Promise.resolve([dirent('src', 'dir')])
-      }
-      if (rootReads === 2) {
-        return new Promise<ReturnType<typeof dirent>[]>((resolve) => {
-          releasePoll = resolve
-        })
-      }
-      return Promise.resolve([dirent('src', 'dir')])
-    })
-
-    const root = await createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
-
-    expect(rootReads).toBe(1)
-    await vi.advanceTimersByTimeAsync(2_000)
-    expect(rootReads).toBe(2)
-    await vi.advanceTimersByTimeAsync(4_000)
-    expect(rootReads).toBe(2)
-
-    releasePollWith(releasePoll, [dirent('src', 'dir'), dirent('new-file.ts')])
-    await vi.advanceTimersByTimeAsync(0)
+    child.stdout.write(
+      snapshotFrame([
+        ['f', '1.0', '/home/me/repo/README.md'],
+        ['f', '1.0', '/home/me/repo/old.txt']
+      ])
+    )
+    const root = await promise
+    child.stdout.write(
+      snapshotFrame([
+        ['f', '2.0', '/home/me/repo/README.md'],
+        ['f', '1.0', '/home/me/repo/new.txt']
+      ])
+    )
 
     expect(scheduleBatchFlush).toHaveBeenCalledOnce()
-    await root.subscription.unsubscribe()
+    expect(root.batch.events).toEqual([
+      { type: 'update', path: '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo\\README.md' },
+      { type: 'create', path: '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo\\new.txt' },
+      { type: 'delete', path: '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo\\old.txt' }
+    ])
   })
 
-  it('does not flush a poll that completes after unsubscribe', async () => {
+  it('turns watcher exit into an overflow refresh without retaining UNC paths', async () => {
     const scheduleBatchFlush = vi.fn()
-    let rootReads = 0
-    let releasePoll: ((entries: ReturnType<typeof dirent>[]) => void) | null = null
+    const deps = makeDeps(scheduleBatchFlush)
+    const { child, promise } = startWatcher(deps)
+    const root = await resolveInitialSnapshot(child, promise)
+    deps.watchedRoots.set(ROOT_KEY, root)
 
-    readdirMock.mockImplementation((dirPath: string) => {
-      if (dirPath !== rootPath) {
-        return Promise.resolve([])
-      }
-      rootReads += 1
-      if (rootReads === 1) {
-        return Promise.resolve([dirent('src', 'dir')])
-      }
-      return new Promise<ReturnType<typeof dirent>[]>((resolve) => {
-        releasePoll = resolve
-      })
-    })
+    child.emit('close', null, 'SIGTERM')
 
-    const root = await createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
-    await vi.advanceTimersByTimeAsync(2_000)
+    expect(scheduleBatchFlush).toHaveBeenCalledOnce()
+    expect(root.batch.events).toEqual([])
+    expect(root.batch.overflowed).toBe(true)
+    expect(deps.watchedRoots.has(ROOT_KEY)).toBe(false)
+  })
+
+  it('kills the WSL child on unsubscribe without emitting a shutdown refresh', async () => {
+    const scheduleBatchFlush = vi.fn()
+    const { child, promise } = startWatcher(makeDeps(scheduleBatchFlush))
+    const root = await resolveInitialSnapshot(child, promise)
+
     await root.subscription.unsubscribe()
 
-    releasePollWith(releasePoll, [dirent('src', 'dir'), dirent('late-file.ts')])
-    await vi.advanceTimersByTimeAsync(0)
-
+    expect(child.kill).toHaveBeenCalledOnce()
     expect(scheduleBatchFlush).not.toHaveBeenCalled()
   })
 
-  it('does not probe root-level files during WSL snapshots', async () => {
-    const scheduleBatchFlush = vi.fn()
+  it('rejects when the WSL process exits before the first snapshot', async () => {
+    const { child, promise } = startWatcher()
 
-    readdirMock.mockImplementation((dirPath: string) => {
-      if (dirPath === rootPath) {
-        return Promise.resolve([
-          dirent('src', 'dir'),
-          dirent('README.md'),
-          dirent('package.json'),
-          dirent('linked-dir', 'symlink')
-        ])
-      }
-      return Promise.resolve([])
-    })
+    child.stderr.write('find failed')
+    child.emit('close', 1, null)
 
-    const root = await createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
-
-    const readPaths = readdirMock.mock.calls.map(([dirPath]) => dirPath)
-    expect(readPaths).toEqual([
-      rootPath,
-      path.join(rootPath, 'src'),
-      path.join(rootPath, 'linked-dir')
-    ])
-    expect(readPaths).not.toContain(path.join(rootPath, 'README.md'))
-    expect(readPaths).not.toContain(path.join(rootPath, 'package.json'))
-    await root.subscription.unsubscribe()
-  })
-
-  it('limits concurrent child directory reads during WSL snapshots', async () => {
-    const scheduleBatchFlush = vi.fn()
-    const childDirs = Array.from({ length: 40 }, (_, index) => dirent(`dir-${index}`, 'dir'))
-    let activeChildReads = 0
-    let maxActiveChildReads = 0
-
-    readdirMock.mockImplementation((dirPath: string) => {
-      if (dirPath === rootPath) {
-        return Promise.resolve(childDirs)
-      }
-      activeChildReads += 1
-      maxActiveChildReads = Math.max(maxActiveChildReads, activeChildReads)
-      return new Promise<ReturnType<typeof dirent>[]>((resolve) => {
-        setTimeout(() => {
-          activeChildReads -= 1
-          resolve([])
-        }, 1)
-      })
-    })
-
-    const rootPromise = createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
-    await Promise.resolve()
-    await Promise.resolve()
-
-    expect(maxActiveChildReads).toBeLessThanOrEqual(8)
-    for (let i = 0; i < childDirs.length; i += 1) {
-      await vi.advanceTimersByTimeAsync(1)
-    }
-
-    const root = await rootPromise
-    expect(maxActiveChildReads).toBeLessThanOrEqual(8)
-    await root.subscription.unsubscribe()
-  })
-
-  it('marks a large WSL poll event batch for overflow without retaining every event', async () => {
-    const scheduleBatchFlush = vi.fn()
-    const initialEntries = Array.from({ length: 200_000 }, (_, index) => dirent(`file-${index}.ts`))
-
-    readdirMock.mockResolvedValueOnce(initialEntries).mockResolvedValueOnce([])
-
-    const root = await createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
-    await vi.advanceTimersByTimeAsync(2_000)
-
-    expect(scheduleBatchFlush).toHaveBeenCalledOnce()
-    expect(root.batch.events).toHaveLength(0)
-    expect(root.batch.overflowed).toBe(true)
-    await root.subscription.unsubscribe()
+    await expect(promise).rejects.toThrow('WSL watcher exited before first snapshot')
   })
 })

--- a/src/main/ipc/filesystem-watcher-wsl.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.ts
@@ -1,20 +1,16 @@
 /**
- * Polling-based file watcher for WSL paths.
+ * WSL-native file watcher for WSL paths.
  *
- * Why: @parcel/watcher uses ReadDirectoryChangesW which doesn't work across
- * the WSL network filesystem boundary (\\wsl.localhost\…).  Instead of
- * requiring the user to install extra tools inside WSL, we poll the
- * directory tree via Node's fs.readdir (which works on UNC paths) and diff
- * against a snapshot to detect changes.  A 2 s poll interval is a good
- * balance between responsiveness and CPU cost — nobody stares at the file
- * explorer waiting for instant refresh.
+ * Why: polling \\wsl.localhost from Windows keeps waking the distro after
+ * `wsl --shutdown`, which can make WSL look wedged. Keep the polling process
+ * inside the distro so shutdown kills it instead of Orca restarting WSL.
  */
-import type { Dirent } from 'fs'
-import { readdir } from 'fs/promises'
-import * as path from 'path'
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process'
+import { StringDecoder } from 'string_decoder'
 import type { WebContents } from 'electron'
 import type { Event as WatcherEvent } from '@parcel/watcher'
-import { MAX_BATCHED_WATCHER_EVENTS, queueWatcherEvents } from './filesystem-watcher-event-batch'
+import { queueWatcherEvents } from './filesystem-watcher-event-batch'
+import { parseWslUncPath } from '../../shared/wsl-paths'
 
 export type WatcherSubscription = {
   unsubscribe(): Promise<void>
@@ -40,135 +36,115 @@ export type WslWatcherDeps = {
 }
 
 const POLL_INTERVAL_MS = 2000
-const SNAPSHOT_CHILD_READ_CONCURRENCY = 8
-const DIFF_EVENT_OVERFLOW_LIMIT = MAX_BATCHED_WATCHER_EVENTS + 1
+const POLL_INTERVAL_SECONDS = Math.max(1, Math.ceil(POLL_INTERVAL_MS / 1000))
+const STARTUP_TIMEOUT_MS = 10_000
+const SNAPSHOT_START = '\x1e'
+const SNAPSHOT_END = '\x1f'
+const MAX_STREAM_BUFFER_CHARS = 10 * 1024 * 1024
 
-type DirSnapshot = Map<string, Set<string>>
+type WslSnapshotEntry = {
+  path: string
+  type: string
+  mtime: string
+}
 
-async function readDirEntriesSafe(dirPath: string): Promise<Dirent[]> {
-  try {
-    const entries = await readdir(dirPath, { withFileTypes: true })
-    return entries
-  } catch {
-    return []
+type WslSnapshot = Map<string, WslSnapshotEntry>
+
+function toWslUncPath(linuxPath: string, distro: string): string {
+  return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
+}
+
+function quoteSafeFindName(name: string): string {
+  if (!/^[A-Za-z0-9_.-]+$/.test(name)) {
+    throw new Error(`Unsupported WSL watcher ignore name: ${name}`)
   }
+  return `'${name}'`
 }
 
-function shouldIgnore(name: string, ignoreDirs: string[]): boolean {
-  return ignoreDirs.includes(name)
+function buildPruneExpression(ignoreDirs: readonly string[]): string {
+  if (ignoreDirs.length === 0) {
+    return ''
+  }
+  const names = ignoreDirs.map((name) => `-name ${quoteSafeFindName(name)}`).join(' -o ')
+  return `\\( -type d \\( ${names} \\) -prune \\) -o`
 }
 
-async function forEachWithConcurrency<T>(
-  items: readonly T[],
-  limit: number,
-  worker: (item: T) => Promise<void>
-): Promise<void> {
-  let nextIndex = 0
-  const workerCount = Math.min(limit, items.length)
-  await Promise.all(
-    Array.from({ length: workerCount }, async () => {
-      while (nextIndex < items.length) {
-        const item = items[nextIndex++]
-        await worker(item)
-      }
-    })
-  )
+function buildSnapshotScript(ignoreDirs: readonly string[]): string {
+  const prune = buildPruneExpression(ignoreDirs)
+  return [
+    'set -efu',
+    'root=$1',
+    'while :; do',
+    "  printf '\\036'",
+    '  if [ -d "$root" ]; then',
+    `    find "$root" -mindepth 1 -maxdepth 2 ${prune} -printf '%y\\t%T@\\t%p\\0' 2>/dev/null || true`,
+    '  fi',
+    "  printf '\\037'",
+    `  sleep ${POLL_INTERVAL_SECONDS} || exit 0`,
+    'done'
+  ].join('\n')
 }
 
-/**
- * Take a snapshot of the root directory and one level of subdirectories.
- * Returns a map of dirPath → set of entry names.
- */
-async function takeSnapshot(rootPath: string, ignoreDirs: string[]): Promise<DirSnapshot> {
-  const snapshot: DirSnapshot = new Map()
-
-  const rootEntries = await readDirEntriesSafe(rootPath)
-  const filtered = rootEntries.filter((entry) => !shouldIgnore(entry.name, ignoreDirs))
-  snapshot.set(rootPath, new Set(filtered.map((entry) => entry.name)))
-
-  // Why: poll one level of subdirectories so changes inside immediate
-  // children are detected, but use Dirent metadata to avoid probing every
-  // root-level file with a failing readdir on each WSL poll.
-  const childDirs = filtered.filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
-  await forEachWithConcurrency(childDirs, SNAPSHOT_CHILD_READ_CONCURRENCY, async (entry) => {
-    const childPath = path.join(rootPath, entry.name)
-    const childEntries = await readDirEntriesSafe(childPath)
-    const childFiltered = childEntries
-      .filter((childEntry) => !shouldIgnore(childEntry.name, ignoreDirs))
-      .map((childEntry) => childEntry.name)
-    snapshot.set(childPath, new Set(childFiltered))
-  })
-
+function parseSnapshotFrame(frame: string, distro: string): WslSnapshot {
+  const snapshot: WslSnapshot = new Map()
+  for (const rawEntry of frame.split('\0')) {
+    if (!rawEntry) {
+      continue
+    }
+    const firstTab = rawEntry.indexOf('\t')
+    const secondTab = firstTab === -1 ? -1 : rawEntry.indexOf('\t', firstTab + 1)
+    if (firstTab <= 0 || secondTab <= firstTab + 1) {
+      continue
+    }
+    const linuxPath = rawEntry.slice(secondTab + 1)
+    if (!linuxPath.startsWith('/')) {
+      continue
+    }
+    const entry: WslSnapshotEntry = {
+      type: rawEntry.slice(0, firstTab),
+      mtime: rawEntry.slice(firstTab + 1, secondTab),
+      path: toWslUncPath(linuxPath, distro)
+    }
+    snapshot.set(entry.path, entry)
+  }
   return snapshot
 }
 
-function appendDiffEvent(events: WatcherEvent[], event: WatcherEvent): boolean {
-  events.push(event)
-  return events.length >= DIFF_EVENT_OVERFLOW_LIMIT
-}
-
-/**
- * Diff two snapshots and return synthetic watcher events.
- */
-function diffSnapshots(prev: DirSnapshot, next: DirSnapshot): WatcherEvent[] {
+function diffSnapshots(prev: WslSnapshot, next: WslSnapshot): WatcherEvent[] {
   const events: WatcherEvent[] = []
 
-  for (const [dirPath, nextEntries] of next) {
-    const prevEntries = prev.get(dirPath)
-    if (!prevEntries) {
-      // New directory appeared — emit create for all entries
-      for (const name of nextEntries) {
-        if (
-          appendDiffEvent(events, {
-            type: 'create',
-            path: path.join(dirPath, name)
-          } as WatcherEvent)
-        ) {
-          return events
-        }
-      }
+  for (const [entryPath, nextEntry] of next) {
+    const prevEntry = prev.get(entryPath)
+    if (!prevEntry) {
+      events.push({ type: 'create', path: entryPath } as WatcherEvent)
       continue
     }
-
-    // Check for new entries (create)
-    for (const name of nextEntries) {
-      if (!prevEntries.has(name)) {
-        if (
-          appendDiffEvent(events, {
-            type: 'create',
-            path: path.join(dirPath, name)
-          } as WatcherEvent)
-        ) {
-          return events
-        }
-      }
+    if (prevEntry.type !== nextEntry.type) {
+      events.push({ type: 'delete', path: entryPath } as WatcherEvent)
+      events.push({ type: 'create', path: entryPath } as WatcherEvent)
+      continue
     }
-
-    // Check for removed entries (delete)
-    for (const name of prevEntries) {
-      if (!nextEntries.has(name)) {
-        if (
-          appendDiffEvent(events, {
-            type: 'delete',
-            path: path.join(dirPath, name)
-          } as WatcherEvent)
-        ) {
-          return events
-        }
-      }
+    if (prevEntry.mtime !== nextEntry.mtime) {
+      events.push({ type: 'update', path: entryPath } as WatcherEvent)
     }
   }
 
-  // Check for directories that disappeared entirely
-  for (const [dirPath] of prev) {
-    if (!next.has(dirPath)) {
-      if (appendDiffEvent(events, { type: 'delete', path: dirPath } as WatcherEvent)) {
-        return events
-      }
+  for (const entryPath of prev.keys()) {
+    if (!next.has(entryPath)) {
+      events.push({ type: 'delete', path: entryPath } as WatcherEvent)
     }
   }
 
   return events
+}
+
+function markOverflowWithoutUncStat(root: WatchedRoot): void {
+  if (root.batch.timer) {
+    clearTimeout(root.batch.timer)
+    root.batch.timer = null
+  }
+  root.batch.events = []
+  root.batch.overflowed = true
 }
 
 export async function createWslWatcher(
@@ -176,54 +152,156 @@ export async function createWslWatcher(
   worktreePath: string,
   deps: WslWatcherDeps
 ): Promise<WatchedRoot> {
+  const wsl = parseWslUncPath(worktreePath)
+  if (!wsl) {
+    throw new Error(`Not a WSL path: ${worktreePath}`)
+  }
+  const distro = wsl.distro
+  const linuxPath = wsl.linuxPath
+
   const root: WatchedRoot = {
     subscription: null!,
     listeners: new Map(),
     batch: { events: [], overflowed: false, timer: null, firstEventAt: 0 }
   }
 
-  // Take initial snapshot
-  let prevSnapshot = await takeSnapshot(worktreePath, deps.ignoreDirs)
-
-  let polling = false
   let disposed = false
-  const poll = async (): Promise<void> => {
-    if (polling || disposed) {
+  let prevSnapshot: WslSnapshot | null = null
+  let stopped = false
+  let streamBuffer = ''
+  const stdoutDecoder = new StringDecoder('utf8')
+  const stderrDecoder = new StringDecoder('utf8')
+  let stderrTail = ''
+
+  let resolveInitial!: () => void
+  let rejectInitial!: (error: Error) => void
+  let initialSettled = false
+  const initialSnapshotReady = new Promise<void>((resolve, reject) => {
+    resolveInitial = resolve
+    rejectInitial = reject
+  })
+
+  function settleInitial(error?: Error): void {
+    if (initialSettled) {
       return
     }
-    polling = true
-    try {
-      const nextSnapshot = await takeSnapshot(worktreePath, deps.ignoreDirs)
-      if (disposed) {
-        return
-      }
-      const events = diffSnapshots(prevSnapshot, nextSnapshot)
-      prevSnapshot = nextSnapshot
-
-      if (events.length > 0) {
-        queueWatcherEvents(root.batch, events)
-        deps.scheduleBatchFlush(rootKey, root)
-      }
-    } catch {
-      // Why: if the WSL filesystem becomes temporarily unavailable
-      // (e.g. WSL distro shuts down), skip this poll cycle rather
-      // than crashing.  The next cycle will retry.
-    } finally {
-      polling = false
+    initialSettled = true
+    if (error) {
+      rejectInitial(error)
+    } else {
+      resolveInitial()
     }
   }
 
-  const intervalId = setInterval(() => {
-    // Why: WSL UNC scans can exceed the poll interval on large repos or cold
-    // network filesystems. Run at most one tree diff at a time so a slow scan
-    // cannot stack concurrent readdir storms on the same root.
-    void poll()
-  }, POLL_INTERVAL_MS)
+  function signalWatcherStopped(): void {
+    if (stopped) {
+      return
+    }
+    stopped = true
+    markOverflowWithoutUncStat(root)
+    deps.scheduleBatchFlush(rootKey, root)
+    deps.watchedRoots.delete(rootKey)
+  }
+
+  function ingestFrame(frame: string): void {
+    const nextSnapshot = parseSnapshotFrame(frame, distro)
+    if (!prevSnapshot) {
+      prevSnapshot = nextSnapshot
+      settleInitial()
+      return
+    }
+    const events = diffSnapshots(prevSnapshot, nextSnapshot)
+    prevSnapshot = nextSnapshot
+
+    if (events.length > 0) {
+      queueWatcherEvents(root.batch, events)
+      deps.scheduleBatchFlush(rootKey, root)
+    }
+  }
+
+  function drainFrames(): void {
+    while (true) {
+      const start = streamBuffer.indexOf(SNAPSHOT_START)
+      if (start === -1) {
+        streamBuffer = streamBuffer.slice(-1)
+        return
+      }
+      if (start > 0) {
+        streamBuffer = streamBuffer.slice(start)
+      }
+      const end = streamBuffer.indexOf(SNAPSHOT_END, 1)
+      if (end === -1) {
+        if (streamBuffer.length > MAX_STREAM_BUFFER_CHARS) {
+          streamBuffer = ''
+          markOverflowWithoutUncStat(root)
+          deps.scheduleBatchFlush(rootKey, root)
+        }
+        return
+      }
+      const frame = streamBuffer.slice(1, end)
+      streamBuffer = streamBuffer.slice(end + 1)
+      ingestFrame(frame)
+    }
+  }
+
+  let child: ChildProcessWithoutNullStreams
+  try {
+    child = spawn('wsl.exe', ['-d', distro, '--', 'sh', '-s', '--', linuxPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true
+    })
+  } catch (error) {
+    throw error instanceof Error ? error : new Error(String(error))
+  }
+
+  child.stdin.end(buildSnapshotScript(deps.ignoreDirs))
+
+  const startupTimer = setTimeout(() => {
+    settleInitial(new Error(`Timed out starting WSL watcher for ${worktreePath}`))
+    child.kill()
+  }, STARTUP_TIMEOUT_MS)
+
+  child.stdout.on('data', (chunk: Buffer) => {
+    if (disposed) {
+      return
+    }
+    streamBuffer += stdoutDecoder.write(chunk)
+    drainFrames()
+  })
+
+  child.stderr.on('data', (chunk: Buffer) => {
+    stderrTail = (stderrTail + stderrDecoder.write(chunk)).slice(-4096)
+  })
+
+  child.once('error', (error) => {
+    if (!initialSettled) {
+      settleInitial(error)
+      return
+    }
+    if (!disposed) {
+      signalWatcherStopped()
+    }
+  })
+
+  child.once('close', (code, signal) => {
+    if (!initialSettled) {
+      const suffix = stderrTail.trim() ? `: ${stderrTail.trim()}` : ''
+      settleInitial(
+        new Error(`WSL watcher exited before first snapshot (${code ?? signal})${suffix}`)
+      )
+      return
+    }
+    if (!disposed) {
+      signalWatcherStopped()
+    }
+  })
+
+  await initialSnapshotReady.finally(() => clearTimeout(startupTimer))
 
   root.subscription = {
     unsubscribe: async () => {
       disposed = true
-      clearInterval(intervalId)
+      child.kill()
     }
   }
 

--- a/src/main/ipc/filesystem-watcher-wsl.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.ts
@@ -197,6 +197,9 @@ export async function createWslWatcher(
     if (stopped) {
       return
     }
+    if (!prevSnapshot) {
+      return
+    }
     stopped = true
     markOverflowWithoutUncStat(root)
     deps.scheduleBatchFlush(rootKey, root)
@@ -254,12 +257,18 @@ export async function createWslWatcher(
     throw error instanceof Error ? error : new Error(String(error))
   }
 
-  child.stdin.end(buildSnapshotScript(deps.ignoreDirs))
-
   const startupTimer = setTimeout(() => {
     settleInitial(new Error(`Timed out starting WSL watcher for ${worktreePath}`))
     child.kill()
   }, STARTUP_TIMEOUT_MS)
+
+  child.stdin.on('error', (error) => {
+    // Why: WSL can exit before reading the script; handle EPIPE here so the
+    // startup failure rejects the watcher instead of crashing on a stream error.
+    if (!initialSettled) {
+      settleInitial(error)
+    }
+  })
 
   child.stdout.on('data', (chunk: Buffer) => {
     if (disposed) {
@@ -271,6 +280,20 @@ export async function createWslWatcher(
 
   child.stderr.on('data', (chunk: Buffer) => {
     stderrTail = (stderrTail + stderrDecoder.write(chunk)).slice(-4096)
+  })
+
+  child.stdout.on('error', (error) => {
+    if (!initialSettled) {
+      settleInitial(error)
+      return
+    }
+    if (!disposed) {
+      signalWatcherStopped()
+    }
+  })
+
+  child.stderr.on('error', () => {
+    // Ignore diagnostic stream failures; stdout/close determine watcher state.
   })
 
   child.once('error', (error) => {
@@ -295,6 +318,8 @@ export async function createWslWatcher(
       signalWatcherStopped()
     }
   })
+
+  child.stdin.end(buildSnapshotScript(deps.ignoreDirs))
 
   await initialSnapshotReady.finally(() => clearTimeout(startupTimer))
 

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: filesystem-watcher centralizes native
-(@parcel/watcher), WSL (inotifywait), and SSH remote watcher lifecycles in
+(@parcel/watcher), WSL-native snapshot, and SSH remote watcher lifecycles in
 one module so subscription/cleanup invariants stay auditable from a single
 file. Splitting by transport would scatter the shared debounce/coalesce
 helpers and the common batch-flush path across three files. */
@@ -506,8 +506,8 @@ async function doInstallLocalWatcher(
   }
 
   try {
-    // Why: WSL paths use inotifywait inside the Linux distro where
-    // inotify works natively; native Windows paths use @parcel/watcher.
+    // Why: WSL paths use one snapshot subprocess inside the Linux distro so
+    // `wsl --shutdown` can kill it; native Windows paths use @parcel/watcher.
     root = isWslPath(worktreePath)
       ? await createWslWatcher(rootKey, worktreePath, {
           ignoreDirs: WATCHER_IGNORE_DIRS,


### PR DESCRIPTION
## Summary
- Replace the WSL file watcher’s Windows-side `\\wsl.localhost` polling loop with a single snapshot process that runs inside the selected WSL distro.
- Diff framed WSL `find` snapshots into create/update/delete watcher events while preserving the existing batching path.
- When the WSL watcher process exits, send one conservative overflow refresh without retaining UNC paths, so shutdown does not trigger a follow-up UNC stat that wakes WSL again.

## Repro
Report evidence in `C:\Users\neil\OneDrive\Desktop\transfer2` shows project creation under a WSL UNC path like `\\wsl.localhost\Ubuntu\home\...\orca\first`, followed by the user reporting that WSL became stuck and `wsl --shutdown` was ineffective.

I reproduced the shutdown failure mode on Windows with `Ubuntu-24.04` by polling a WSL UNC path with Node `fs.readdir`, matching the old watcher behavior:

```text
before shutdown: * Ubuntu-24.04    Running         2 { polls: 2, pollErrors: 0 }
during UNC polling after shutdown: * Ubuntu-24.04    Running         2 { polls: 2, pollErrors: 0 }
after polling stopped and shutdown: * Ubuntu-24.04    Stopped         2 { polls: 12, pollErrors: 0 }
```

That proves the old Windows-side UNC poller can make `wsl --shutdown` appear ineffective by waking the distro right back up.

## Fix proof
I reran the same shutdown proof with the new WSL-native watcher shape (`wsl.exe -d <distro> -- sh -s -- <linux-path>` fed by stdin). With the watcher active, shutdown now stops the distro and the watcher child exits:

```text
before shutdown: * Ubuntu-24.04    Running         2 { sawInitial: true, closed: false }
after shutdown with native watcher: * Ubuntu-24.04    Stopped         2 { sawInitial: true, closed: true }
```

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-watcher-wsl.test.ts src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts src/main/ipc/filesystem-watcher-large-batch.test.ts src/main/ipc/filesystem-watcher-event-batch.test.ts src/main/ipc/filesystem-watcher-real.test.ts` — 18 passed, 1 skipped
- `pnpm run typecheck` — passed
- `pnpm exec oxlint src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher-wsl.ts src/main/ipc/filesystem-watcher-wsl.test.ts` — passed

## Notes
- Native Windows watcher and SSH remote watcher paths are unchanged.
- I did not drive the full Electron create-project modal; the repro and fix proof target the underlying WSL watcher/shutdown behavior that matches the reported `wsl --shutdown` symptom.