### PR TITLE
Prevent review lookup failures from blocking PR preparation

### DIFF
--- a/src/main/source-control/hosted-review-creation.test.ts
+++ b/src/main/source-control/hosted-review-creation.test.ts
@@ -594,6 +594,28 @@ describe('getHostedReviewCreationEligibility', () => {
     })
   })
 
+  it('keeps dirty feature branches eligible for PR preparation when review lookup fails', async () => {
+    getHostedReviewForBranchMock.mockRejectedValueOnce(new Error('gh lookup failed'))
+
+    await expect(
+      getHostedReviewCreationEligibility({
+        repoPath: '/repo',
+        branch: 'feature/create-pr',
+        base: 'main',
+        hasUncommittedChanges: true,
+        hasUpstream: false,
+        ahead: 0,
+        behind: 0
+      })
+    ).resolves.toMatchObject({
+      provider: 'github',
+      canCreate: false,
+      blockedReason: 'dirty',
+      nextAction: 'commit',
+      head: 'feature/create-pr'
+    })
+  })
+
   it('enables creation for clean, in-sync, authenticated GitHub feature branches', async () => {
     await expect(
       getHostedReviewCreationEligibility({

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -385,18 +385,34 @@ export async function getHostedReviewCreationEligibility(
   const defaultBaseRef =
     args.base?.trim() || (await getDefaultBaseRef(args.repoPath, args.connectionId, args))
   const baseBranch = defaultBaseRef ? normalizeHostedReviewBaseRef(defaultBaseRef) : null
-  const review = await getHostedReviewForBranch({
-    repoPath: args.repoPath,
-    branch,
-    linkedGitHubPR: args.linkedGitHubPR ?? null,
-    fallbackGitHubPR: args.linkedGitHubPR == null ? (args.fallbackGitHubPR ?? null) : null,
-    linkedGitLabMR: args.linkedGitLabMR ?? null,
-    linkedBitbucketPR: args.linkedBitbucketPR ?? null,
-    linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
-    linkedGiteaPR: args.linkedGiteaPR ?? null,
-    connectionId: args.connectionId ?? null,
-    ...hostedReviewExecutionContext(args)
-  })
+  let review: Awaited<ReturnType<typeof getHostedReviewForBranch>> = null
+  try {
+    review = await getHostedReviewForBranch({
+      repoPath: args.repoPath,
+      branch,
+      linkedGitHubPR: args.linkedGitHubPR ?? null,
+      fallbackGitHubPR: args.linkedGitHubPR == null ? (args.fallbackGitHubPR ?? null) : null,
+      linkedGitLabMR: args.linkedGitLabMR ?? null,
+      linkedBitbucketPR: args.linkedBitbucketPR ?? null,
+      linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
+      linkedGiteaPR: args.linkedGiteaPR ?? null,
+      connectionId: args.connectionId ?? null,
+      ...hostedReviewExecutionContext(args)
+    })
+  } catch (error) {
+    const canReturnLocalBlocker =
+      branch &&
+      branch !== 'HEAD' &&
+      supportsHostedReviewCreation(provider) &&
+      (!baseBranch || branch.toLowerCase() !== baseBranch.toLowerCase()) &&
+      (args.hasUncommittedChanges || args.hasUpstream !== true || (args.behind ?? 0) > 0)
+    if (!canReturnLocalBlocker) {
+      throw error
+    }
+    // Why: local blockers still let the UI offer Create PR preparation; a
+    // flaky existing-review lookup should not hide the affordance entirely.
+    console.warn('Hosted review lookup failed while resolving local review blocker:', error)
+  }
 
   const baseResult = {
     provider,


### PR DESCRIPTION
## Summary

Prevents flaky or failing hosted review lookups from completely blocking or hiding the "Create PR" button/affordance. When a lookup fails, if there are already local blockers (e.g., uncommitted changes, lack of upstream, or being behind the base branch), the system will safely catch the error and still report eligibility using the local blocker, allowing the user to see the preparation options.

## Screenshots

- No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

The code review verified that errors thrown by `getHostedReviewForBranch` are gracefully caught only under conditions where a local blocker can be returned instead. It confirmed that the error is rethrown if no local blocker is applicable, preventing silent failure of legitimate lookup issues when clean.
No platform-specific (macOS, Linux, Windows) behavior or shortcuts are impacted, as this logic resides purely in the source control service layer.

## Security Audit

No input handling, IPC, secrets, command execution, or path-traversal risks were introduced. The error handling safely catches lookup exceptions and logs them with `console.warn` without exposing secrets or disrupting critical execution.

## Notes

None.