### PR TITLE
Fix Create PR visibility when upstream status is unknown

### DIFF
--- a/src/main/source-control/hosted-review-creation.test.ts
+++ b/src/main/source-control/hosted-review-creation.test.ts
@@ -594,6 +594,28 @@ describe('getHostedReviewCreationEligibility', () => {
     })
   })
 
+  it('keeps dirty feature branches eligible for PR preparation when review lookup fails', async () => {
+    getHostedReviewForBranchMock.mockRejectedValueOnce(new Error('gh lookup failed'))
+
+    await expect(
+      getHostedReviewCreationEligibility({
+        repoPath: '/repo',
+        branch: 'feature/create-pr',
+        base: 'main',
+        hasUncommittedChanges: true,
+        hasUpstream: false,
+        ahead: 0,
+        behind: 0
+      })
+    ).resolves.toMatchObject({
+      provider: 'github',
+      canCreate: false,
+      blockedReason: 'dirty',
+      nextAction: 'commit',
+      head: 'feature/create-pr'
+    })
+  })
+
   it('enables creation for clean, in-sync, authenticated GitHub feature branches', async () => {
     await expect(
       getHostedReviewCreationEligibility({

--- a/src/main/source-control/hosted-review-creation.test.ts
+++ b/src/main/source-control/hosted-review-creation.test.ts
@@ -616,6 +616,21 @@ describe('getHostedReviewCreationEligibility', () => {
     })
   })
 
+  it('rethrows review lookup failures when upstream status is unknown', async () => {
+    getHostedReviewForBranchMock.mockRejectedValueOnce(new Error('gh lookup failed'))
+
+    await expect(
+      getHostedReviewCreationEligibility({
+        repoPath: '/repo',
+        branch: 'feature/create-pr',
+        base: 'main',
+        hasUncommittedChanges: false,
+        ahead: 0,
+        behind: 0
+      })
+    ).rejects.toThrow('gh lookup failed')
+  })
+
   it('enables creation for clean, in-sync, authenticated GitHub feature branches', async () => {
     await expect(
       getHostedReviewCreationEligibility({

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -385,18 +385,34 @@ export async function getHostedReviewCreationEligibility(
   const defaultBaseRef =
     args.base?.trim() || (await getDefaultBaseRef(args.repoPath, args.connectionId, args))
   const baseBranch = defaultBaseRef ? normalizeHostedReviewBaseRef(defaultBaseRef) : null
-  const review = await getHostedReviewForBranch({
-    repoPath: args.repoPath,
-    branch,
-    linkedGitHubPR: args.linkedGitHubPR ?? null,
-    fallbackGitHubPR: args.linkedGitHubPR == null ? (args.fallbackGitHubPR ?? null) : null,
-    linkedGitLabMR: args.linkedGitLabMR ?? null,
-    linkedBitbucketPR: args.linkedBitbucketPR ?? null,
-    linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
-    linkedGiteaPR: args.linkedGiteaPR ?? null,
-    connectionId: args.connectionId ?? null,
-    ...hostedReviewExecutionContext(args)
-  })
+  let review: Awaited<ReturnType<typeof getHostedReviewForBranch>> = null
+  try {
+    review = await getHostedReviewForBranch({
+      repoPath: args.repoPath,
+      branch,
+      linkedGitHubPR: args.linkedGitHubPR ?? null,
+      fallbackGitHubPR: args.linkedGitHubPR == null ? (args.fallbackGitHubPR ?? null) : null,
+      linkedGitLabMR: args.linkedGitLabMR ?? null,
+      linkedBitbucketPR: args.linkedBitbucketPR ?? null,
+      linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
+      linkedGiteaPR: args.linkedGiteaPR ?? null,
+      connectionId: args.connectionId ?? null,
+      ...hostedReviewExecutionContext(args)
+    })
+  } catch (error) {
+    const canReturnLocalBlocker =
+      branch &&
+      branch !== 'HEAD' &&
+      supportsHostedReviewCreation(provider) &&
+      (!baseBranch || branch.toLowerCase() !== baseBranch.toLowerCase()) &&
+      (args.hasUncommittedChanges || args.hasUpstream !== true || (args.behind ?? 0) > 0)
+    if (!canReturnLocalBlocker) {
+      throw error
+    }
+    // Why: local blockers still let the UI offer Create PR preparation; a
+    // flaky existing-review lookup should not hide the affordance entirely.
+    console.warn('Hosted review lookup failed while resolving local review blocker:', error)
+  }
 
   const baseResult = {
     provider,

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -405,7 +405,7 @@ export async function getHostedReviewCreationEligibility(
       branch !== 'HEAD' &&
       supportsHostedReviewCreation(provider) &&
       (!baseBranch || branch.toLowerCase() !== baseBranch.toLowerCase()) &&
-      (args.hasUncommittedChanges || args.hasUpstream !== true || (args.behind ?? 0) > 0)
+      (args.hasUncommittedChanges || args.hasUpstream === false || (args.behind ?? 0) > 0)
     if (!canReturnLocalBlocker) {
       throw error
     }


### PR DESCRIPTION
## Summary
- rethrow hosted review lookup failures when upstream status is unknown
- keep local blocker fallback limited to dirty, explicitly unpushed, or behind branches
- add regression coverage for the unknown-upstream lookup failure case

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/source-control/hosted-review-creation.test.ts