### PR TITLE
Support port forwarding for system SSH

### DIFF
--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'events'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { SshPortForwardManager } from './ssh-port-forward'
+
+const { spawnSystemSshPortForwardMock } = vi.hoisted(() => ({
+  spawnSystemSshPortForwardMock: vi.fn()
+}))
+
+vi.mock('./ssh-system-fallback', () => ({
+  spawnSystemSshPortForward: spawnSystemSshPortForwardMock
+}))
 
 function createMockConn(forwardOutErr?: Error) {
   const mockChannel = {
@@ -18,9 +27,34 @@ function createMockConn(forwardOutErr?: Error) {
   }
   return {
     getClient: vi.fn().mockReturnValue(mockClient),
+    usesSystemSshTransport: vi.fn().mockReturnValue(false),
     mockClient,
     mockChannel
   }
+}
+
+function createSystemSshConn() {
+  return {
+    getClient: vi.fn().mockReturnValue(null),
+    usesSystemSshTransport: vi.fn().mockReturnValue(true),
+    getTarget: vi.fn().mockReturnValue({
+      id: 'target-1',
+      label: 'container',
+      host: 'container',
+      port: 22,
+      username: 'vscode'
+    })
+  }
+}
+
+function createFakeSystemSshProcess() {
+  const process = new EventEmitter() as EventEmitter & {
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+  }
+  process.stderr = new EventEmitter()
+  process.kill = vi.fn()
+  return process
 }
 
 // Mock the net module to avoid real TCP listeners
@@ -48,6 +82,11 @@ describe('SshPortForwardManager', () => {
 
   beforeEach(() => {
     manager = new SshPortForwardManager()
+    spawnSystemSshPortForwardMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('adds a port forward and returns entry', async () => {
@@ -64,10 +103,67 @@ describe('SshPortForwardManager', () => {
   })
 
   it('throws when SSH client is not connected', async () => {
-    const conn = { getClient: vi.fn().mockReturnValue(null) }
+    const conn = {
+      getClient: vi.fn().mockReturnValue(null),
+      usesSystemSshTransport: vi.fn().mockReturnValue(false)
+    }
     await expect(
       manager.addForward('conn-1', conn as never, 3000, 'localhost', 8080)
     ).rejects.toThrow('SSH connection is not established')
+  })
+
+  it('adds a system SSH port forward when no ssh2 client is available', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    await vi.advanceTimersByTimeAsync(250)
+    const entry = await pending
+
+    expect(spawnSystemSshPortForwardMock).toHaveBeenCalledWith(
+      conn.getTarget(),
+      3000,
+      '127.0.0.1',
+      8080
+    )
+    expect(entry).toMatchObject({
+      connectionId: 'conn-1',
+      localPort: 3000,
+      remoteHost: '127.0.0.1',
+      remotePort: 8080
+    })
+    expect(manager.listForwards('conn-1')).toHaveLength(1)
+  })
+
+  it('surfaces early system SSH port forward failures', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    process.stderr.emit('data', Buffer.from('bind: Address already in use'))
+    process.emit('exit', 255)
+
+    await expect(pending).rejects.toThrow('bind: Address already in use')
+    expect(manager.listForwards('conn-1')).toHaveLength(0)
+  })
+
+  it('kills a system SSH tunnel when removing the forward', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    await vi.advanceTimersByTimeAsync(250)
+    const entry = await pending
+
+    expect(manager.removeForward(entry.id)).toMatchObject({ id: entry.id })
+    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(manager.listForwards('conn-1')).toHaveLength(0)
   })
 
   it('lists forwards filtered by connectionId', async () => {

--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -51,9 +51,13 @@ function createFakeSystemSshProcess() {
   const process = new EventEmitter() as EventEmitter & {
     stderr: EventEmitter
     kill: ReturnType<typeof vi.fn>
+    exitCode: number | null
+    signalCode: NodeJS.Signals | null
   }
   process.stderr = new EventEmitter()
   process.kill = vi.fn()
+  process.exitCode = null
+  process.signalCode = null
   return process
 }
 
@@ -164,6 +168,55 @@ describe('SshPortForwardManager', () => {
     expect(manager.removeForward(entry.id)).toMatchObject({ id: entry.id })
     expect(process.kill).toHaveBeenCalledWith('SIGTERM')
     expect(manager.listForwards('conn-1')).toHaveLength(0)
+  })
+
+  it('waits for system SSH tunnels to exit before async removal resolves', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    await vi.advanceTimersByTimeAsync(250)
+    await pending
+
+    let resolved = false
+    const removal = manager.removeAllForwards('conn-1').then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(resolved).toBe(false)
+
+    process.emit('exit', null)
+    await removal
+    expect(resolved).toBe(true)
+  })
+
+  it('escalates stuck system SSH tunnels to SIGKILL before async removal resolves', async () => {
+    vi.useFakeTimers()
+    const process = createFakeSystemSshProcess()
+    spawnSystemSshPortForwardMock.mockReturnValue(process)
+    const conn = createSystemSshConn()
+
+    const pending = manager.addForward('conn-1', conn as never, 3000, '127.0.0.1', 8080)
+    await vi.advanceTimersByTimeAsync(250)
+    await pending
+
+    let resolved = false
+    const removal = manager.removeAllForwards('conn-1').then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(process.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(resolved).toBe(false)
+
+    process.emit('exit', null)
+    await removal
+    expect(resolved).toBe(true)
   })
 
   it('lists forwards filtered by connectionId', async () => {

--- a/src/main/ssh/ssh-port-forward.test.ts
+++ b/src/main/ssh/ssh-port-forward.test.ts
@@ -210,8 +210,8 @@ describe('SshPortForwardManager', () => {
     })
 
     await vi.advanceTimersByTimeAsync(2_000)
-    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
-    expect(process.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(process.kill).toHaveBeenNthCalledWith(1, 'SIGTERM')
+    expect(process.kill).toHaveBeenNthCalledWith(2, 'SIGKILL')
     expect(resolved).toBe(false)
 
     process.emit('exit', null)

--- a/src/main/ssh/ssh-port-forward.ts
+++ b/src/main/ssh/ssh-port-forward.ts
@@ -1,14 +1,27 @@
+import type { ChildProcess } from 'child_process'
 import { createServer, type Server, type Socket } from 'net'
 import type { SshConnection } from './ssh-connection'
+import { spawnSystemSshPortForward } from './ssh-system-fallback'
 import type { PortForwardEntry } from '../../shared/ssh-types'
 
 export type { PortForwardEntry }
 
 type ActiveForward = {
   entry: PortForwardEntry
-  server: Server
-  activeSockets: Set<Socket>
-}
+} & (
+  | {
+      kind: 'ssh2'
+      server: Server
+      activeSockets: Set<Socket>
+    }
+  | {
+      kind: 'system-ssh'
+      process: ChildProcess
+    }
+)
+
+const SYSTEM_SSH_FORWARD_STARTUP_SETTLE_MS = 250
+const SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS = 2_000
 
 export class SshPortForwardManager {
   private forwards = new Map<string, ActiveForward>()
@@ -52,6 +65,20 @@ export class SshPortForwardManager {
     }
 
     const client = conn.getClient()
+    if (!client && conn.usesSystemSshTransport()) {
+      const target = conn.getTarget()
+      const process = spawnSystemSshPortForward(target, localPort, remoteHost, remotePort)
+      await this.waitForSystemSshForwardStartup(process)
+      const forward: ActiveForward = { kind: 'system-ssh', entry, process }
+      process.once('exit', () => {
+        const active = this.forwards.get(id)
+        if (active === forward) {
+          this.forwards.delete(id)
+        }
+      })
+      this.forwards.set(id, forward)
+      return entry
+    }
     if (!client) {
       throw new Error('SSH connection is not established')
     }
@@ -82,8 +109,54 @@ export class SshPortForwardManager {
       })
     })
 
-    this.forwards.set(id, { entry, server, activeSockets })
+    this.forwards.set(id, { kind: 'ssh2', entry, server, activeSockets })
     return entry
+  }
+
+  private waitForSystemSshForwardStartup(process: ChildProcess): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let stderr = ''
+      let settled = false
+      const cleanup = (): void => {
+        clearTimeout(timer)
+        process.off('error', onError)
+        process.off('exit', onExit)
+        process.stderr?.off('data', onStderr)
+      }
+      const finish = (callback: () => void): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanup()
+        callback()
+      }
+      const onStderr = (chunk: Buffer): void => {
+        stderr += chunk.toString('utf-8')
+      }
+      const onError = (error: Error): void => {
+        finish(() => reject(error))
+      }
+      const onExit = (code: number | null): void => {
+        const detail = stderr.trim()
+        finish(() =>
+          reject(
+            new Error(
+              `System SSH port forward failed${code !== null ? ` (exit ${code})` : ''}${
+                detail ? `: ${detail}` : ''
+              }`
+            )
+          )
+        )
+      }
+      const timer = setTimeout(() => {
+        finish(resolve)
+      }, SYSTEM_SSH_FORWARD_STARTUP_SETTLE_MS)
+
+      process.stderr?.on('data', onStderr)
+      process.once('error', onError)
+      process.once('exit', onExit)
+    })
   }
 
   async updateForward(
@@ -152,16 +225,42 @@ export class SshPortForwardManager {
     if (!forward) {
       return Promise.resolve(null)
     }
+    this.forwards.delete(id)
+    if (forward.kind === 'system-ssh') {
+      return this.waitForSystemSshForwardStop(forward.process).then(() => forward.entry)
+    }
     for (const socket of forward.activeSockets) {
       socket.destroy()
     }
-    this.forwards.delete(id)
     return new Promise((resolve) => {
       forward.server.close(() => resolve(forward.entry))
     })
   }
 
+  private waitForSystemSshForwardStop(process: ChildProcess): Promise<void> {
+    process.kill('SIGTERM')
+    return new Promise((resolve) => {
+      const cleanup = (): void => {
+        clearTimeout(timer)
+        process.off('exit', onExit)
+      }
+      const onExit = (): void => {
+        cleanup()
+        resolve()
+      }
+      const timer = setTimeout(() => {
+        cleanup()
+        resolve()
+      }, SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS)
+      process.once('exit', onExit)
+    })
+  }
+
   private teardownForward(forward: ActiveForward): void {
+    if (forward.kind === 'system-ssh') {
+      forward.process.kill('SIGTERM')
+      return
+    }
     for (const socket of forward.activeSockets) {
       socket.destroy()
     }

--- a/src/main/ssh/ssh-port-forward.ts
+++ b/src/main/ssh/ssh-port-forward.ts
@@ -238,21 +238,44 @@ export class SshPortForwardManager {
   }
 
   private waitForSystemSshForwardStop(process: ChildProcess): Promise<void> {
-    process.kill('SIGTERM')
     return new Promise((resolve) => {
+      let settled = false
       const cleanup = (): void => {
-        clearTimeout(timer)
+        clearTimeout(escalationTimer)
         process.off('exit', onExit)
       }
-      const onExit = (): void => {
+      const finish = (): void => {
+        if (settled) {
+          return
+        }
+        settled = true
         cleanup()
         resolve()
       }
-      const timer = setTimeout(() => {
-        cleanup()
-        resolve()
+      const onExit = (): void => {
+        finish()
+      }
+      const hasExited = (): boolean => process.exitCode !== null || process.signalCode !== null
+      const kill = (signal: NodeJS.Signals): void => {
+        try {
+          const sent = process.kill(signal)
+          if (!sent && hasExited()) {
+            finish()
+          }
+        } catch {
+          if (hasExited()) {
+            finish()
+          }
+        }
+      }
+      const escalationTimer = setTimeout(() => {
+        // Why: update/reconnect callers must not rebind while a stubborn ssh -L
+        // process still owns the local port.
+        kill('SIGKILL')
       }, SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS)
+
       process.once('exit', onExit)
+      kill('SIGTERM')
     })
   }
 

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -27,6 +27,7 @@ import {
   findSystemSsh,
   spawnSystemSsh,
   spawnSystemSshCommand,
+  spawnSystemSshPortForward,
   uploadDirectoryViaSystemSsh,
   writeFileViaSystemSsh
 } from './ssh-system-fallback'
@@ -249,6 +250,27 @@ describe('spawnSystemSsh', () => {
       SYSTEM_SSH_PATH,
       expect.arrayContaining(['--', 'deploy@fdpass-host', "exec /bin/sh -c 'echo hello'"]),
       expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    )
+  })
+
+  it('spawns port forwards before the ssh destination terminator', () => {
+    spawnSystemSshPortForward(createTarget({ configHost: 'fdpass-host' }), 5173, '127.0.0.1', 3000)
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      SYSTEM_SSH_PATH,
+      [
+        '-o',
+        'BatchMode=no',
+        '-T',
+        '-N',
+        '-o',
+        'ExitOnForwardFailure=yes',
+        '-L',
+        '127.0.0.1:5173:127.0.0.1:3000',
+        '--',
+        'deploy@fdpass-host'
+      ],
+      expect.objectContaining({ stdio: ['ignore', 'ignore', 'pipe'] })
     )
   })
 

--- a/src/main/ssh/ssh-system-fallback.ts
+++ b/src/main/ssh/ssh-system-fallback.ts
@@ -121,9 +121,13 @@ export function spawnSystemSshPortForward(
   if (destinationIndex === -1) {
     args.unshift(...forwardArgs)
   } else {
+    // Why: OpenSSH parses options only before `--`; after it, args are the
+    // destination and optional remote command.
     args.splice(destinationIndex, 0, ...forwardArgs)
   }
 
+  // Why: port-forward ssh processes are not wired to Orca credential prompts;
+  // system SSH forwards must authenticate via OpenSSH config, agent, or control socket.
   return spawn(sshPath, args, {
     stdio: ['ignore', 'ignore', 'pipe'],
     windowsHide: true

--- a/src/main/ssh/ssh-system-fallback.ts
+++ b/src/main/ssh/ssh-system-fallback.ts
@@ -96,6 +96,40 @@ export function spawnSystemSshCommand(
   return wrapCommandProcess(proc)
 }
 
+export function spawnSystemSshPortForward(
+  target: SshTarget,
+  localPort: number,
+  remoteHost: string,
+  remotePort: number
+): ChildProcess {
+  const sshPath = findSystemSsh()
+  if (!sshPath) {
+    throw new Error(
+      'No system ssh binary found. Install OpenSSH to use system SSH port forwarding.'
+    )
+  }
+
+  const args = buildSshArgs(target)
+  const destinationIndex = args.lastIndexOf('--')
+  const forwardArgs = [
+    '-N',
+    '-o',
+    'ExitOnForwardFailure=yes',
+    '-L',
+    `127.0.0.1:${localPort}:${remoteHost}:${remotePort}`
+  ]
+  if (destinationIndex === -1) {
+    args.unshift(...forwardArgs)
+  } else {
+    args.splice(destinationIndex, 0, ...forwardArgs)
+  }
+
+  return spawn(sshPath, args, {
+    stdio: ['ignore', 'ignore', 'pipe'],
+    windowsHide: true
+  })
+}
+
 export async function uploadDirectoryViaSystemSsh(
   target: SshTarget,
   localDir: string,


### PR DESCRIPTION
## Summary

This is a proof-of-concept fix for port forwarding when an SSH target uses system SSH transport.

The issue is posted here: https://github.com/stablyai/orca/issues/6498

The motivating setup is:

- Orca runs on a local Mac.
- SSH connects to a remote Linux machine.
- `ProxyCommand` runs `docker exec` on that remote machine.
- The command enters a Docker container running `sshd`.
- A dev server runs inside that container, for example on `127.0.0.1:3000`.

Before this change, Orca could connect to the container and open terminals, but port forwarding failed because the port-forwarding path expected an `ssh2` client instance. System SSH transport connections do not have one.

This PR keeps the existing `ssh2.forwardOut()` path unchanged, and adds a system SSH fallback that starts a managed OpenSSH local-forward process:

```bash
ssh -N -o ExitOnForwardFailure=yes -L 127.0.0.1:<localPort>:<remoteHost>:<remotePort> <target>
```

This proved out locally: Orca successfully connected through the remote host into the container, started a port forward, and made the container dev server reachable from the local Mac browser without Docker port publishing.

Happy to discuss whether this is the right long-term direction. The goal here was to prove the approach works in a real local setup.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
  - Ran: `pnpm run typecheck:node`
- [x] `pnpm test`
  - Ran focused tests: `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-port-forward.test.ts src/main/ssh/ssh-system-fallback.test.ts`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - Added coverage for system SSH port-forward creation, early failure handling, teardown, and command construction.

Additional validation:

```bash
pnpm exec oxlint src/main/ssh/ssh-port-forward.ts src/main/ssh/ssh-system-fallback.ts src/main/ssh/ssh-port-forward.test.ts src/main/ssh/ssh-system-fallback.test.ts
git diff --check
```

Note: `pnpm run test -- ...` was blocked locally by the repo’s native runtime wrapper requiring the patched `node-pty` build path, so I ran the focused Vitest command directly.

## AI Review Report

I reviewed the change with an AI coding agent for:

- Correct transport branching:
  - Existing `ssh2.forwardOut()` behavior remains unchanged when an `ssh2` client exists.
  - System SSH forwarding is only used when the connection reports system SSH transport.
- Process lifecycle:
  - System SSH forwards track the spawned child process.
  - Removing a forward terminates the process.
  - Unexpected process exit removes the stale active-forward entry.
- Failure behavior:
  - Early `ssh -N -L` failures are surfaced instead of registering a broken forward.
  - `stderr` is captured for more useful diagnostics.
- Regression coverage:
  - Unit tests cover the system SSH fallback path and preserve existing ssh2 behavior.
- Cross-platform compatibility:
  - The review explicitly considered macOS, Linux, and Windows.
  - The code uses the existing system SSH discovery path rather than hardcoding one platform path.
  - Path handling is not changed.
  - No keyboard shortcuts, shortcut labels, renderer UI, or Electron platform UI behavior were touched.
  - Shell behavior is delegated to OpenSSH-compatible system `ssh`, matching the existing system SSH transport model.

Main risk identified:

- This proof of concept depends on an OpenSSH-compatible system `ssh` binary for system-transport port forwarding. That matches the existing system SSH transport direction, but it is worth confirming whether maintainers want this process-based forwarding model as the long-term abstraction.

## Security Audit

Reviewed security-relevant areas:

- Command execution:
  - The new path spawns the discovered system `ssh` binary with an argument array, not a shell string.
  - This avoids shell interpolation for local command construction.
- SSH config behavior:
  - Existing system SSH target configuration is reused, including `ProxyCommand`, `ProxyJump`, and related OpenSSH behavior.
  - This PR does not add new parsing or evaluation of user SSH config beyond what the existing system SSH path already relies on.
- Local bind address:
  - The local listener is bound to `127.0.0.1`, not `0.0.0.0`, so forwarded dev servers are not exposed on the LAN by default.
- Secrets/auth:
  - No credentials, tokens, or key material are logged or persisted.
  - Authentication remains delegated to the existing SSH mechanism.
- IPC:
  - No new IPC surface was added.
  - Existing port-forward IPC behavior now works for system SSH-backed connections.
- Path handling:
  - No filesystem path expansion or deletion behavior was added.
- Dependencies:
  - No new dependencies were added.

Follow-up worth discussing:

- Whether to add stronger readiness detection than a short startup settle window.
- Whether to expose richer diagnostics in the Ports UI when system SSH forwarding fails.
- Whether system SSH tunnel processes need additional cleanup on app shutdown/reconnect beyond the existing manager lifecycle.

## Notes

This is intentionally a proof-of-concept coded solution.

Manual validation succeeded on my local setup:

- Local Mac running Orca.
- Remote Linux host.
- Docker container on that host running `sshd`.
- SSH target reached through `ProxyCommand` and `docker exec`.
- Dev server running inside the container.
- Orca port forward made the dev server reachable from the Mac browser.

No Docker port publishing was required.

Platform note:

- This path depends on an OpenSSH-compatible `ssh` command for system SSH transport forwarding. That should be normal on macOS and Linux, and modern Windows includes OpenSSH-compatible `ssh.exe`, but maintainers may want to confirm the desired support boundary.
