### PR TITLE
fix(renderer): answer OSC color queries from active terminal theme

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
@@ -87,6 +87,66 @@ describe('installTerminalCapabilityReplyHandlers', () => {
     }
   })
 
+  it('answers OSC color queries for active rgba and modern rgb theme colors', async () => {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    term.options.theme = {
+      foreground: 'rgb(245 245 244 / 92%)',
+      background: 'rgba(17, 34, 51, 0.5)'
+    }
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+    const disposable = installTerminalCapabilityReplyHandlers({
+      terminal: term as never,
+      parser: term.parser,
+      sendInput,
+      isReplaying: () => false
+    })
+
+    try {
+      await writeTerminal(term, '\x1b]10;?\x1b\\\x1b]11;?\x1b\\')
+
+      expect(sendInput).toHaveBeenCalledWith('\x1b]10;rgb:f5f5/f5f5/f4f4\x1b\\')
+      expect(sendInput).toHaveBeenCalledWith('\x1b]11;rgb:1111/2222/3333\x1b\\')
+    } finally {
+      disposable.dispose()
+      term.dispose()
+    }
+  })
+
+  it('leaves non-query OSC color commands to other handlers', async () => {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    term.options.theme = {
+      foreground: '#2e3434',
+      background: '#ffffff'
+    }
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+    const returnValues: boolean[] = []
+    const disposable = installTerminalCapabilityReplyHandlers({
+      terminal: term as never,
+      parser: {
+        registerCsiHandler: (id, cb) =>
+          term.parser.registerCsiHandler(id, (params) => cb(params) === true),
+        registerOscHandler: (id, cb) =>
+          term.parser.registerOscHandler(id, (data) => {
+            const value = cb(data) === true
+            returnValues.push(value)
+            return value
+          })
+      },
+      sendInput,
+      isReplaying: () => false
+    })
+
+    try {
+      await writeTerminal(term, '\x1b]10;#123456\x1b\\')
+
+      expect(sendInput).not.toHaveBeenCalled()
+      expect(returnValues).toEqual([false])
+    } finally {
+      disposable.dispose()
+      term.dispose()
+    }
+  })
+
   it('consumes replayed OSC color queries without sending input to the shell', async () => {
     const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
     term.options.theme = {
@@ -174,11 +234,12 @@ describe('installTerminalCapabilityReplyHandlers', () => {
       parser: {
         registerCsiHandler: (id, cb) =>
           term.parser.registerCsiHandler(id, (params) => {
-            const value = cb(params) as boolean
+            const value = cb(params) === true
             returnValues.push(value)
             return value
           }),
-        registerOscHandler: (id, cb) => term.parser.registerOscHandler(id, cb)
+        registerOscHandler: (id, cb) =>
+          term.parser.registerOscHandler(id, (data) => cb(data) === true)
       },
       sendInput,
       isReplaying: () => false

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts
@@ -62,6 +62,55 @@ describe('installTerminalCapabilityReplyHandlers', () => {
     }
   })
 
+  it('answers OSC foreground and background color queries from the active theme', async () => {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    term.options.theme = {
+      foreground: '#2e3434',
+      background: '#ffffff'
+    }
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+    const disposable = installTerminalCapabilityReplyHandlers({
+      terminal: term as never,
+      parser: term.parser,
+      sendInput,
+      isReplaying: () => false
+    })
+
+    try {
+      await writeTerminal(term, '\x1b]10;?\x1b\\\x1b]11;?\x1b\\')
+
+      expect(sendInput).toHaveBeenCalledWith('\x1b]10;rgb:2e2e/3434/3434\x1b\\')
+      expect(sendInput).toHaveBeenCalledWith('\x1b]11;rgb:ffff/ffff/ffff\x1b\\')
+    } finally {
+      disposable.dispose()
+      term.dispose()
+    }
+  })
+
+  it('consumes replayed OSC color queries without sending input to the shell', async () => {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    term.options.theme = {
+      foreground: '#2e3434',
+      background: '#ffffff'
+    }
+    const sendInput = vi.fn<(data: string) => boolean>(() => true)
+    const disposable = installTerminalCapabilityReplyHandlers({
+      terminal: term as never,
+      parser: term.parser,
+      sendInput,
+      isReplaying: () => true
+    })
+
+    try {
+      await writeTerminal(term, '\x1b]11;?\x1b\\')
+
+      expect(sendInput).not.toHaveBeenCalled()
+    } finally {
+      disposable.dispose()
+      term.dispose()
+    }
+  })
+
   it('answers window and cell pixel-size reports from renderer geometry', () => {
     const sendInput = vi.fn<(data: string) => boolean>(() => true)
     const observe = createTerminalPixelSizeQueryResponder(
@@ -128,7 +177,8 @@ describe('installTerminalCapabilityReplyHandlers', () => {
             const value = cb(params) as boolean
             returnValues.push(value)
             return value
-          })
+          }),
+        registerOscHandler: (id, cb) => term.parser.registerOscHandler(id, cb)
       },
       sendInput,
       isReplaying: () => false

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
@@ -64,21 +64,53 @@ function cssColorToOscRgb(value: string | undefined): string | null {
       expanded.slice(2, 4)
     )}/${byteHexToWord(expanded.slice(4, 6))}`
   }
-  const rgb = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,[^)]+)?\)$/i.exec(
-    trimmed
-  )
+  const rgb = /^rgba?\(\s*([^)]+)\)$/i.exec(trimmed)
   if (!rgb) {
     return null
   }
-  const [red, green, blue] = rgb.slice(1, 4).map((component) => {
-    const byte = Math.min(255, Math.max(0, Number(component)))
-    return byte.toString(16).padStart(2, '0').repeat(2)
-  })
+  const channels = parseCssRgbChannels(rgb[1])
+  if (!channels) {
+    return null
+  }
+  const [red, green, blue] = channels.map((byte) => byte.toString(16).padStart(2, '0').repeat(2))
   return `rgb:${red}/${green}/${blue}`
 }
 
 function byteHexToWord(byte: string): string {
   return byte.repeat(2)
+}
+
+function parseCssRgbChannels(body: string): [number, number, number] | null {
+  const colorPart = body.split('/')[0]?.trim()
+  if (!colorPart) {
+    return null
+  }
+  const components = colorPart.includes(',')
+    ? colorPart.split(',').slice(0, 3)
+    : colorPart.split(/\s+/).slice(0, 3)
+  if (components.length !== 3) {
+    return null
+  }
+  const channels = components.map((component) => parseCssRgbChannel(component.trim()))
+  if (channels.some((channel) => channel === null)) {
+    return null
+  }
+  return channels as [number, number, number]
+}
+
+function parseCssRgbChannel(component: string): number | null {
+  const percent = /^(\d+(?:\.\d+)?)%$/.exec(component)?.[1]
+  if (percent !== undefined) {
+    return clampByte((Number(percent) / 100) * 255)
+  }
+  if (!/^\d+(?:\.\d+)?$/.test(component)) {
+    return null
+  }
+  return clampByte(Number(component))
+}
+
+function clampByte(value: number): number {
+  return Math.min(255, Math.max(0, Math.round(value)))
 }
 
 function isOscColorQuery(data: string): boolean {

--- a/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-capability-replies.ts
@@ -4,8 +4,8 @@ export const DEFAULT_DA1_RESPONSE = '\x1b[?1;2c'
 export const CONPTY_DA1_RESPONSE = '\x1b[?61;4c'
 
 type TerminalCapabilityRepliesDeps = {
-  terminal: Pick<Terminal, 'cols' | 'rows' | 'element'>
-  parser: Pick<IParser, 'registerCsiHandler'>
+  terminal: Pick<Terminal, 'cols' | 'rows' | 'element' | 'options'>
+  parser: Pick<IParser, 'registerCsiHandler' | 'registerOscHandler'>
   sendInput: (data: string) => boolean | void
   isReplaying: () => boolean
   da1Response?: string
@@ -44,6 +44,45 @@ function disposeAll(disposables: IDisposable[]): void {
   for (const disposable of disposables) {
     disposable.dispose()
   }
+}
+
+function cssColorToOscRgb(value: string | undefined): string | null {
+  if (!value) {
+    return null
+  }
+  const trimmed = value.trim()
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(trimmed)?.[1]
+  if (hex) {
+    const expanded =
+      hex.length === 3
+        ? hex
+            .split('')
+            .map((char) => `${char}${char}`)
+            .join('')
+        : hex
+    return `rgb:${byteHexToWord(expanded.slice(0, 2))}/${byteHexToWord(
+      expanded.slice(2, 4)
+    )}/${byteHexToWord(expanded.slice(4, 6))}`
+  }
+  const rgb = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,[^)]+)?\)$/i.exec(
+    trimmed
+  )
+  if (!rgb) {
+    return null
+  }
+  const [red, green, blue] = rgb.slice(1, 4).map((component) => {
+    const byte = Math.min(255, Math.max(0, Number(component)))
+    return byte.toString(16).padStart(2, '0').repeat(2)
+  })
+  return `rgb:${red}/${green}/${blue}`
+}
+
+function byteHexToWord(byte: string): string {
+  return byte.repeat(2)
+}
+
+function isOscColorQuery(data: string): boolean {
+  return data.trim() === '?'
 }
 
 export function createTerminalPixelSizeQueryResponder(
@@ -98,6 +137,34 @@ export function installTerminalCapabilityReplyHandlers(
       if (!deps.isReplaying()) {
         deps.sendInput(deps.da1Response ?? DEFAULT_DA1_RESPONSE)
       }
+      return true
+    }),
+    deps.parser.registerOscHandler(10, (data) => {
+      if (!isOscColorQuery(data)) {
+        return false
+      }
+      if (deps.isReplaying()) {
+        return true
+      }
+      const foreground = cssColorToOscRgb(deps.terminal.options.theme?.foreground)
+      if (!foreground) {
+        return false
+      }
+      deps.sendInput(`\x1b]10;${foreground}\x1b\\`)
+      return true
+    }),
+    deps.parser.registerOscHandler(11, (data) => {
+      if (!isOscColorQuery(data)) {
+        return false
+      }
+      if (deps.isReplaying()) {
+        return true
+      }
+      const background = cssColorToOscRgb(deps.terminal.options.theme?.background)
+      if (!background) {
+        return false
+      }
+      deps.sendInput(`\x1b]11;${background}\x1b\\`)
       return true
     })
   ]

--- a/tests/e2e/terminal-osc-color-queries.spec.ts
+++ b/tests/e2e/terminal-osc-color-queries.spec.ts
@@ -1,0 +1,91 @@
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  waitForActivePaneHookDescriptor,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForTerminalPtyDataInjector } from './helpers/terminal-pty-injection'
+import {
+  clearTerminalPtyWriteLog,
+  installTerminalPtyWriteSpy,
+  readTerminalPtyWriteEntries
+} from './helpers/terminal-pty-write-spy'
+
+type TerminalTheme = {
+  foreground: string
+  background: string
+}
+
+type TerminalPtyDataInjectionWindow = Window & {
+  __terminalPtyDataInjection?: {
+    inject: (paneKey: string, data: string) => boolean
+  }
+}
+
+async function setActiveTerminalTheme(page: Page, theme: TerminalTheme): Promise<void> {
+  await page.evaluate((nextTheme) => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('No active terminal pane to theme')
+    }
+    pane.terminal.options.theme = nextTheme
+  }, theme)
+}
+
+async function injectPtyOutput(page: Page, paneKey: string, data: string): Promise<boolean> {
+  return page.evaluate(
+    ({ targetPaneKey, output }) =>
+      (window as TerminalPtyDataInjectionWindow).__terminalPtyDataInjection?.inject(
+        targetPaneKey,
+        output
+      ) ?? false,
+    { targetPaneKey: paneKey, output: data }
+  )
+}
+
+test('answers OSC foreground and background color queries from the active terminal theme', async ({
+  electronApp,
+  orcaPage
+}) => {
+  await installTerminalPtyWriteSpy(electronApp)
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+
+  const ptyId = await waitForActivePanePtyId(orcaPage)
+  const { paneKey } = await waitForActivePaneHookDescriptor(orcaPage)
+  await waitForTerminalPtyDataInjector(orcaPage, paneKey)
+  await setActiveTerminalTheme(orcaPage, {
+    foreground: '#2e3434',
+    background: 'rgba(255, 255, 255, 1)'
+  })
+  await clearTerminalPtyWriteLog(electronApp)
+
+  const injected = await injectPtyOutput(orcaPage, paneKey, '\x1b]10;?\x1b\\\x1b]11;?\x1b\\')
+
+  expect(injected).toBe(true)
+  await expect
+    .poll(
+      async () =>
+        (await readTerminalPtyWriteEntries(electronApp))
+          .filter((entry) => entry.id === ptyId)
+          .map((entry) => entry.data),
+      {
+        timeout: 5_000,
+        message: 'OSC color query replies were not written to the active PTY'
+      }
+    )
+    .toEqual(['\x1b]10;rgb:2e2e/3434/3434\x1b\\', '\x1b]11;rgb:ffff/ffff/ffff\x1b\\'])
+})


### PR DESCRIPTION
## Summary

Codex TUI color detection now receives Orca's active terminal foreground/background colors for OSC 10/11 queries. This prevents Codex from falling back to an incorrect/default dark background for the input area when Orca is using a light terminal theme on Windows.

## Screenshots

No visual change.

## Testing

* [ ] `pnpm lint`
* [ ] `pnpm typecheck`
* [ ] `pnpm test`
* [ ] `pnpm build`
* [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Ran:

* `.\node_modules\.bin\vitest.cmd run src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts`
* `.\node_modules\.bin\oxlint.cmd src/renderer/src/components/terminal-pane/terminal-capability-replies.ts src/renderer/src/components/terminal-pane/terminal-capability-replies.test.ts`

## AI Review Report

Reviewed the terminal color-query path used by TUIs such as Codex. The fix keeps the change scoped to Orca's existing terminal capability reply handler, answers only OSC 10/11 foreground/background queries, and preserves replay suppression so restored scrollback cannot leak terminal replies into a fresh shell.

Cross-platform review: this does not add platform-specific shortcuts, labels, paths, shell assumptions, or Electron platform branches. The behavior is renderer/xterm based and applies consistently across macOS, Linux, Windows, local terminals, and SSH/remote panes.

## Security Audit

Reviewed input handling around terminal escape sequences. The handler only responds to exact OSC color queries (`?`) and only sends theme-derived color replies back through the existing PTY input path. It does not introduce command execution, filesystem/path handling, dependency changes, auth/secrets handling, or new IPC surfaces.

## Notes

This is targeted at the Codex input background issue reported on Windows light theme, but the fix is provider-neutral for TUIs that query terminal foreground/background colors through OSC 10/11. Fixes #6091.
