### PR TITLE
Fix remote File Explorer opening files via local fs:readFile

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -479,6 +479,7 @@ function FileExplorerFiles(): React.JSX.Element {
   }, [])
   const { handleClick, handleDoubleClick, handleWheelCapture } = useFileExplorerHandlers({
     activeWorktreeId,
+    runtimeEnvironmentId: activeRuntimeEnvironmentId,
     openFile,
     makePreviewFilePermanent,
     toggleDir: hasNameFilter ? handleToggleNameFilterDir : toggleDir,

--- a/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
@@ -112,6 +112,7 @@ let capturedHandlers: ReturnType<typeof useFileExplorerHandlers> | null = null
 function HandlersProbe({ scrollRef }: { scrollRef: React.RefObject<HTMLDivElement | null> }): null {
   capturedHandlers = useFileExplorerHandlers({
     activeWorktreeId: 'wt-1',
+    runtimeEnvironmentId: null,
     openFile: vi.fn(),
     makePreviewFilePermanent: vi.fn(),
     toggleDir: vi.fn(),

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
@@ -72,6 +72,7 @@ describe('activateFileExplorerNode', () => {
     await activateFileExplorerNode({
       node: symlinkNode,
       activeWorktreeId: 'wt-1',
+      runtimeEnvironmentId: 'runtime-env-1',
       openFile,
       toggleDir: vi.fn(),
       loadDir: vi.fn(),
@@ -85,10 +86,42 @@ describe('activateFileExplorerNode', () => {
         filePath: '/repo/linked-docs',
         relativePath: 'linked-docs',
         worktreeId: 'wt-1',
+        runtimeEnvironmentId: 'runtime-env-1',
         language: expect.any(String),
         mode: 'edit'
       },
-      { preview: true }
+      { preview: true, suppressActiveRuntimeFallback: false }
+    )
+  })
+
+  it('opens local files without runtime fallback when no runtime owner is set', async () => {
+    const fileNode: TreeNode = {
+      name: 'README.md',
+      path: '/repo/README.md',
+      relativePath: 'README.md',
+      isDirectory: false,
+      depth: 0
+    }
+    const openFile = vi.fn()
+
+    await activateFileExplorerNode({
+      node: fileNode,
+      activeWorktreeId: 'wt-1',
+      runtimeEnvironmentId: null,
+      openFile,
+      toggleDir: vi.fn(),
+      loadDir: vi.fn(),
+      statPath: vi.fn(),
+      markPathAsDirectory: vi.fn(),
+      setSelectedPath: vi.fn()
+    })
+
+    expect(openFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/repo/README.md',
+        runtimeEnvironmentId: undefined
+      }),
+      { preview: true, suppressActiveRuntimeFallback: true }
     )
   })
 })

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -126,6 +126,8 @@ export async function activateFileExplorerNode(args: {
     },
     {
       preview: true,
+      // Why: explicit local opens must not inherit the active runtime, so we
+      // encode "no runtime owner" via the fallback-suppression option.
       suppressActiveRuntimeFallback: runtimeEnvironmentId === null
     }
   )

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -9,6 +9,7 @@ import { translate } from '@/i18n/i18n'
 
 type UseFileExplorerHandlersParams = {
   activeWorktreeId: string | null
+  runtimeEnvironmentId?: string | null
   openFile: (
     params: {
       filePath: string
@@ -16,8 +17,9 @@ type UseFileExplorerHandlersParams = {
       worktreeId: string
       language: string
       mode: 'edit'
+      runtimeEnvironmentId?: string | null
     },
-    options?: { preview?: boolean }
+    options?: { preview?: boolean; suppressActiveRuntimeFallback?: boolean }
   ) => void
   makePreviewFilePermanent: (filePath: string) => void
   toggleDir: (worktreeId: string, dirPath: string) => void
@@ -45,6 +47,7 @@ type OpenFileOptions = Parameters<UseFileExplorerHandlersParams['openFile']>[1]
 export async function activateFileExplorerNode(args: {
   node: TreeNode
   activeWorktreeId: string | null
+  runtimeEnvironmentId?: string | null
   openFile: (params: OpenFileParams, options?: OpenFileOptions) => void
   toggleDir: (worktreeId: string, dirPath: string) => void
   canToggleDirectories?: boolean
@@ -56,6 +59,7 @@ export async function activateFileExplorerNode(args: {
   const {
     node,
     activeWorktreeId,
+    runtimeEnvironmentId,
     openFile,
     toggleDir,
     canToggleDirectories = true,
@@ -116,15 +120,20 @@ export async function activateFileExplorerNode(args: {
       filePath: node.path,
       relativePath: node.relativePath,
       worktreeId: activeWorktreeId,
+      runtimeEnvironmentId: runtimeEnvironmentId ?? undefined,
       language: detectLanguage(node.name),
       mode: 'edit'
     },
-    { preview: true }
+    {
+      preview: true,
+      suppressActiveRuntimeFallback: runtimeEnvironmentId === null
+    }
   )
 }
 
 export function useFileExplorerHandlers({
   activeWorktreeId,
+  runtimeEnvironmentId,
   openFile,
   makePreviewFilePermanent,
   toggleDir,
@@ -140,6 +149,7 @@ export function useFileExplorerHandlers({
       void activateFileExplorerNode({
         node,
         activeWorktreeId,
+        runtimeEnvironmentId,
         openFile,
         toggleDir,
         canToggleDirectories,
@@ -151,6 +161,7 @@ export function useFileExplorerHandlers({
     },
     [
       activeWorktreeId,
+      runtimeEnvironmentId,
       canToggleDirectories,
       loadDir,
       markPathAsDirectory,

--- a/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
@@ -158,13 +158,19 @@ export function useFileExplorerInlineInput({
             }
             await refreshDir(inlineInput.parentPath)
             if (inlineInput.type === 'file') {
-              openFile({
-                filePath: fullPath,
-                relativePath: worktreePath ? fullPath.slice(worktreePath.length + 1) : name,
-                worktreeId: activeWorktreeId,
-                language: detectLanguage(name),
-                mode: 'edit'
-              })
+              const runtimeEnvironmentId =
+                fileContext.settings.activeRuntimeEnvironmentId?.trim() ?? null
+              openFile(
+                {
+                  filePath: fullPath,
+                  relativePath: worktreePath ? fullPath.slice(worktreePath.length + 1) : name,
+                  worktreeId: activeWorktreeId,
+                  runtimeEnvironmentId: runtimeEnvironmentId ?? undefined,
+                  language: detectLanguage(name),
+                  mode: 'edit'
+                },
+                { suppressActiveRuntimeFallback: runtimeEnvironmentId === null }
+              )
             }
           } catch (err) {
             // Refresh the directory even on failure so the tree stays consistent

--- a/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
@@ -159,7 +159,7 @@ export function useFileExplorerInlineInput({
             await refreshDir(inlineInput.parentPath)
             if (inlineInput.type === 'file') {
               const runtimeEnvironmentId =
-                fileContext.settings.activeRuntimeEnvironmentId?.trim() ?? null
+                fileContext.settings.activeRuntimeEnvironmentId?.trim() || null
               openFile(
                 {
                   filePath: fullPath,


### PR DESCRIPTION
Pass the worktree runtime owner when opening files from File Explorer so editor tabs use runtime RPC instead of falling back to local file reads.

Fixes #6440

## Summary

When opening a file from a paired remote runtime's File Explorer, the editor tab was created without `runtimeEnvironmentId`. Reads then fell back to local `fs:readFile`, which failed with "Access denied: path resolves outside allowed directories." Retry hit the same path.

This change passes the worktree's runtime owner when opening files from File Explorer (click and inline create), matching existing patterns in drag-and-drop and mobile file open. Editor tabs now route through runtime file RPC, and Retry uses the same owner.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — targeted tests for changed files pass (`useFileExplorerHandlers.test.ts`, `file-explorer-drag-scroll-marker.test.tsx`, 9 tests). Full suite not re-run locally on Node 26.
- [x] `pnpm build` — not run locally yet; CI will verify.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

**Manual repro (from #6440):**
1. Pair a remote runtime into the desktop app.
2. Select a runtime worktree and open File Explorer.
3. Click a file (e.g. `large.bin` or `README.md`).
4. **Expected:** Editor loads via runtime RPC (or a runtime-aware error for unsupported files).
5. **Before fix:** `Unable to load file` with local `fs:readFile` access denied; Retry repeated the failure.

## AI Review Report

Reviewed with Cursor agent against `CONTRIBUTING.md` and `AGENTS.md`.

**Risks checked:**
- **Cross-platform (macOS / Linux / Windows):** Change is renderer-only TypeScript in File Explorer open paths. No keyboard shortcuts, menu accelerators, shell spawning, or path-separator assumptions added. Behavior is platform-neutral.
- **SSH / remote / local:** Fix is specifically for remote-runtime-owned worktrees. Local worktrees pass `runtimeEnvironmentId: null` with `suppressActiveRuntimeFallback: true`, preserving explicit local reads.
- **Agent / integration compatibility:** No agent or git-provider logic touched.
- **Performance:** One extra argument on existing `openFile` calls; no new watchers or polling.
- **UI quality:** No layout, color, or interaction changes.

**Flags / verification:**
- Mirrored existing `useGlobalFileDrop` / mobile `onOpenFileFromMobile` pattern for runtime owner propagation.
- Also fixed inline file creation in `useFileExplorerInlineInput.ts` (same missing owner).
- Did not change search-result open path (`search-match-open.ts`) — separate code path, out of scope for #6440.

## Security Audit

**Reviewed areas:**
- **Path handling:** No new path construction; uses existing File Explorer node paths and worktree-relative paths already shown in the tree.
- **IPC / auth:** Fix routes reads through existing runtime file RPC when `runtimeEnvironmentId` is set, instead of incorrectly hitting local `fs:readFile`. Reduces risk of confusing cross-boundary reads rather than expanding access.
- **Command execution / secrets:** Not touched.
- **Dependencies:** None added.

**Follow-up:** None identified for this change.

## Notes

- Branch targets unassigned issue #6440 with a scoped fix (5 files).
- Local dev used Node 26; project engines specify Node 24. Recommend CI as source of truth for full test/build.
- Search panel file open (`search-match-open.ts`) may have the same class of bug; can follow up separately if desired.