### PR TITLE
Reflow the surviving terminal when a split closes

### DIFF
--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -46,6 +46,14 @@ vi.mock('./useTabDragSplit', () => ({
   })
 }))
 
+// Why: these cases invoke TabGroupSplitLayout as a plain function (not a
+// mounted component) to inspect its element tree, so any real React hook it
+// calls would throw. Stub the side-effect-only refit hook out — its behavior
+// is covered directly in use-refit-on-split-collapse.test.tsx.
+vi.mock('./use-refit-on-split-collapse', () => ({
+  useRefitOnSplitCollapse: vi.fn()
+}))
+
 import TabGroupSplitLayout from './TabGroupSplitLayout'
 
 type ReactElementLike = {

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -6,6 +6,7 @@ import TabGroupPanel from './TabGroupPanel'
 import TabDragPreview from '../tab-bar/TabDragPreview'
 import { TabDragProvider } from './tab-drag-context'
 import TabPaneColumnSplitDragOverlay from './TabPaneColumnSplitDragOverlay'
+import { useRefitOnSplitCollapse } from './use-refit-on-split-collapse'
 import { type HoveredTabInsertion, useTabDragSplit } from './useTabDragSplit'
 
 const MIN_RATIO = 0.15
@@ -222,6 +223,9 @@ export default function TabGroupSplitLayout({
 }): React.JSX.Element {
   const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
   const hasSplits = layout.type === 'split'
+
+  // Why: reflow the surviving group's terminal when a split collapses (#6154).
+  useRefitOnSplitCollapse(layout, isWorktreeActive)
 
   return (
     <TabDragProvider

--- a/src/renderer/src/components/tab-group/tab-group-layout-leaf-count.test.ts
+++ b/src/renderer/src/components/tab-group/tab-group-layout-leaf-count.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import type { TabGroupLayoutNode } from '../../../../shared/types'
+import { countLayoutLeaves } from './tab-group-layout-leaf-count'
+
+describe('countLayoutLeaves', () => {
+  it('counts a single leaf as one', () => {
+    const layout: TabGroupLayoutNode = { type: 'leaf', groupId: 'a' }
+    expect(countLayoutLeaves(layout)).toBe(1)
+  })
+
+  it('counts a two-leaf split as two', () => {
+    const layout: TabGroupLayoutNode = {
+      type: 'split',
+      direction: 'horizontal',
+      first: { type: 'leaf', groupId: 'a' },
+      second: { type: 'leaf', groupId: 'b' }
+    }
+    expect(countLayoutLeaves(layout)).toBe(2)
+  })
+
+  it('counts leaves in a nested split tree', () => {
+    const layout: TabGroupLayoutNode = {
+      type: 'split',
+      direction: 'horizontal',
+      first: { type: 'leaf', groupId: 'a' },
+      second: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', groupId: 'b' },
+        second: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', groupId: 'c' },
+          second: { type: 'leaf', groupId: 'd' }
+        }
+      }
+    }
+    expect(countLayoutLeaves(layout)).toBe(4)
+  })
+})

--- a/src/renderer/src/components/tab-group/tab-group-layout-leaf-count.ts
+++ b/src/renderer/src/components/tab-group/tab-group-layout-leaf-count.ts
@@ -1,0 +1,9 @@
+import type { TabGroupLayoutNode } from '../../../../shared/types'
+
+/** Total number of group leaves in a tab-group split tree (leaf → 1, split → sum of children). */
+export function countLayoutLeaves(node: TabGroupLayoutNode): number {
+  if (node.type === 'leaf') {
+    return 1
+  }
+  return countLayoutLeaves(node.first) + countLayoutLeaves(node.second)
+}

--- a/src/renderer/src/components/tab-group/use-refit-on-split-collapse.test.tsx
+++ b/src/renderer/src/components/tab-group/use-refit-on-split-collapse.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TabGroupLayoutNode } from '../../../../shared/types'
+import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
+import { useRefitOnSplitCollapse } from './use-refit-on-split-collapse'
+
+const LEAF: TabGroupLayoutNode = { type: 'leaf', groupId: 'a' }
+const SPLIT_2: TabGroupLayoutNode = {
+  type: 'split',
+  direction: 'horizontal',
+  first: { type: 'leaf', groupId: 'a' },
+  second: { type: 'leaf', groupId: 'b' }
+}
+const SPLIT_3: TabGroupLayoutNode = {
+  type: 'split',
+  direction: 'horizontal',
+  first: { type: 'leaf', groupId: 'a' },
+  second: {
+    type: 'split',
+    direction: 'vertical',
+    first: { type: 'leaf', groupId: 'b' },
+    second: { type: 'leaf', groupId: 'c' }
+  }
+}
+
+function Probe({
+  layout,
+  isWorktreeActive
+}: {
+  layout: TabGroupLayoutNode
+  isWorktreeActive: boolean
+}): null {
+  useRefitOnSplitCollapse(layout, isWorktreeActive)
+  return null
+}
+
+describe('useRefitOnSplitCollapse', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let dispatched: number
+  let onSyncFit: () => void
+  // Two-deep rAF callback queue so the double-rAF resolves deterministically.
+  let rafCallbacks: FrameRequestCallback[]
+
+  const flushRaf = (): void => {
+    // Drain in waves so a callback scheduled by another callback runs next tick.
+    let guard = 0
+    while (rafCallbacks.length > 0 && guard < 10) {
+      const batch = rafCallbacks
+      rafCallbacks = []
+      for (const cb of batch) {
+        cb(performance.now())
+      }
+      guard += 1
+    }
+  }
+
+  const renderLayout = (layout: TabGroupLayoutNode, isWorktreeActive = true): void => {
+    act(() => {
+      root.render(<Probe layout={layout} isWorktreeActive={isWorktreeActive} />)
+    })
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    dispatched = 0
+    rafCallbacks = []
+    onSyncFit = (): void => {
+      dispatched += 1
+    }
+    window.addEventListener(SYNC_FIT_PANES_EVENT, onSyncFit)
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    window.removeEventListener(SYNC_FIT_PANES_EVENT, onSyncFit)
+    container.remove()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('dispatches SYNC_FIT_PANES_EVENT when a split collapses to fewer leaves', () => {
+    renderLayout(SPLIT_2)
+    expect(dispatched).toBe(0)
+
+    renderLayout(LEAF)
+    flushRaf()
+    expect(dispatched).toBe(1)
+  })
+
+  it('dispatches when a nested split loses one leaf', () => {
+    renderLayout(SPLIT_3)
+    renderLayout(SPLIT_2)
+    flushRaf()
+    expect(dispatched).toBe(1)
+  })
+
+  it('does not dispatch when the leaf count increases (a split is created)', () => {
+    renderLayout(LEAF)
+    renderLayout(SPLIT_2)
+    flushRaf()
+    expect(dispatched).toBe(0)
+  })
+
+  it('does not dispatch when the leaf count is unchanged (e.g. ratio drag)', () => {
+    renderLayout(SPLIT_2)
+    renderLayout({ ...SPLIT_2, ratio: 0.3 })
+    flushRaf()
+    expect(dispatched).toBe(0)
+  })
+
+  it('does not dispatch when the worktree is not active', () => {
+    renderLayout(SPLIT_2, false)
+    renderLayout(LEAF, false)
+    flushRaf()
+    expect(dispatched).toBe(0)
+  })
+})

--- a/src/renderer/src/components/tab-group/use-refit-on-split-collapse.ts
+++ b/src/renderer/src/components/tab-group/use-refit-on-split-collapse.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react'
+import type { TabGroupLayoutNode } from '../../../../shared/types'
+import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
+import { countLayoutLeaves } from './tab-group-layout-leaf-count'
+
+/**
+ * Forces a synchronous fit of all visible terminal panes when a tab-group split
+ * collapses (the layout tree loses a leaf), so the surviving group's xterm grid
+ * reflows to the new, wider container.
+ *
+ * Why: a collapsing split widens the surviving group via flexbox alone. The
+ * within-tab pane close has a deterministic rAF refit (onLayoutChanged →
+ * queueResizeAll → fitPanes); the group path otherwise relies only on a
+ * 150ms-debounced ResizeObserver that can miss the flex-only resize, leaving an
+ * idle agent's xterm pinned at the old narrow width with a blank survivor half
+ * (#6154). Double-rAF: the first frame commits React/flex styles, the second
+ * runs after layout reflow so proposeDimensions reads the new width. Only fires
+ * on a leaf-count *decrease* so splits/ratio drags (which have their own fit
+ * paths) don't trigger it, and only while the worktree is visible (the
+ * SYNC_FIT_PANES_EVENT listener and safeFit skip unmeasurable hidden panes).
+ */
+export function useRefitOnSplitCollapse(
+  layout: TabGroupLayoutNode,
+  isWorktreeActive: boolean
+): void {
+  const prevLeafCountRef = useRef(countLayoutLeaves(layout))
+  useEffect(() => {
+    const leafCount = countLayoutLeaves(layout)
+    const collapsed = leafCount < prevLeafCountRef.current
+    prevLeafCountRef.current = leafCount
+    if (!isWorktreeActive || !collapsed) {
+      return
+    }
+    const handles = { raf1: 0, raf2: 0 }
+    handles.raf1 = requestAnimationFrame(() => {
+      handles.raf2 = requestAnimationFrame(() => {
+        window.dispatchEvent(new Event(SYNC_FIT_PANES_EVENT))
+      })
+    })
+    return () => {
+      cancelAnimationFrame(handles.raf1)
+      if (handles.raf2) {
+        cancelAnimationFrame(handles.raf2)
+      }
+    }
+  }, [layout, isWorktreeActive])
+}


### PR DESCRIPTION
## What changes

When two terminals are arranged in a left/right split and you close one side, the surviving terminal now reliably reflows to fill the new full width. Previously it could stay rendered at the old narrow (half) width, leaving the rest of the now full-width pane permanently blank — visible whenever the surviving session was an idle agent that doesn't repaint on its own (finished Codex/Claude run, static scrollback). Fixes issue `#6154`.

**What does not change:** this only affects the resize/reflow of the *surviving* terminal on collapse. It does not change how splits are created, how panes close, or the within-tab pane-close path (which already reflowed correctly).

## Root cause

Orca has two left/right split mechanisms with asymmetric refit behavior:

- **Within-tab pane split** (two PTYs in one tab): `closeManagedPane` → `onLayoutChanged` → `queueResizeAll` → `requestAnimationFrame` → `fitPanes`. A deterministic post-collapse refit. Robust.
- **Tab-group split** (two side-by-side groups, each its own `TerminalPane`/`PaneManager`): `collapseGroupLayout` mutates the layout tree and the survivor widens via flexbox alone. The only thing that re-fit it was the per-container, 150ms-debounced `ResizeObserver` — which can measure stale geometry or miss a purely flex-ratio width change. When it misses, the survivor's xterm stays pinned at the narrow column count, so an idle agent never reflows and the right half stays blank.

The defect was introduced by the tab-split redesign (#5927, landed two days before the report); the collapse/refit paths are otherwise unchanged since.

## The fix

`useRefitOnSplitCollapse` (called from `TabGroupSplitLayout`): when the layout tree loses a leaf (a group was closed) while the worktree is visible, dispatch the **existing** `SYNC_FIT_PANES_EVENT` across a double `requestAnimationFrame` (first frame commits React/flex styles, second runs after layout reflow). Every visible pane then runs `fitAllPanes()`; the resulting `terminal.onResize` forwards `transport.resize` (SIGWINCH) so a live agent repaints. Panes already at the right size no-op via `safeFit`'s early return. This gives the tab-group collapse the same deterministic refit the within-tab path already had, reusing the same primitive sidebar toggles use.

Fires only on a leaf-count **decrease** (splits / ratio drags don't trigger it) and only while the worktree is visible (hidden worktrees re-fit on visibility resume, as before).

## Design approach & review

- **Design review:** clean (READY) after the auto design-review loop; direction confirmed, scope kept proportional. Considered and rejected lowering the ResizeObserver debounce (would cause reflow storms during drags/window-resize) and dispatching from the store slice (must stay DOM-free and runs before React commits).
- **Implementation deviations from the doc:** extracted the logic into a dedicated hook (`useRefitOnSplitCollapse`) instead of an inline effect, and reordered the rAF-handle declaration to avoid a TDZ hazard the doc's illustrative snippet had. Both are improvements; behavior is identical.
- **Completeness verification:** COMPLETE — every requirement, edge case, and validation item implemented.
- **Headline behavior:** **implemented** and verified live (see below) — not scaffolding or fixture-only.

## Performance

`perf` audit: all clear, no fix needed. Idle cost is a bounded (<~50-node) sub-microsecond `countLayoutLeaves` tree walk per layout change. Active cost is one fit-all on collapse where unchanged panes self-skip via `safeFit` — strictly no worse than the already-shipped sidebar-toggle dispatch. No reflow storm, no per-instance multiplier (hidden worktrees early-return before scheduling), no rAF/listener leak, no startup/polling impact.

## Code review

`review-code` two-reviewer loop: 1 round, **both reviewers clean**, no actionable findings. Verified hook deps/cleanup/TDZ, no spurious mount-time dispatch, correct hidden→visible handoff, and that tests aren't false-greens.

## Validation

**Static:** `oxlint` clean, `tsgo` typecheck clean, 8/8 unit + behavioral tests pass.

**Tests added:**
- `tab-group-layout-leaf-count.test.ts` — leaf / 2-leaf / nested counts.
- `use-refit-on-split-collapse.test.tsx` — dispatches on collapse, dispatches on nested collapse, **no** dispatch on leaf-count increase, **no** dispatch on equal count (ratio drag), **no** dispatch when worktree inactive (renders via `createRoot`/`act` and drains the double-rAF queue, so a single-rAF regression would fail).

**Manual (Electron, real agent) — merge-confidence pass: LAND.**
1. Tab-group split with a real idle **Codex** agent in the left group → close the right group: survivor reflows to full width (663px), Codex TUI repaints full-width, exactly **1** fit event, no blank region, no React error dialog.
2. Within-tab pane split → close one pane: survivor reflows full-width; the new hook stays out of it (0 events — that path uses its own refit). No regression.
3. Split creation (leaf-count increase): no spurious fit event from the new hook.
4. No recoverable-UI/React render-error dialog at any step.

## SSH / cross-platform

Platform-agnostic (rAF + a DOM event). Remote/web-runtime PTYs that shouldn't resize remain protected by the existing `isRendererPtyResizeAuthoritative()` / mobile-fit-override gates in the resize path; this change adds no SSH-specific resize.

## Assumptions / residual risk

- Double-rAF is post-paint, so the survivor may paint ~1 frame at the old width before reflow (the sidebar path uses `useLayoutEffect` for zero-flash). Acceptable for a discrete user-initiated collapse and far better than a permanent blank.
- The original report was not reproducible on current `main` on fast local hardware (the debounced observer usually does fire in time); the fix makes the refit deterministic so the gap is closed regardless of timing/hardware. Validation therefore confirms the fix path fires correctly and the survivor reflows, rather than reproducing the original failure.

Made with [Orca](https://github.com/stablyai/orca) 🐋
