### PR TITLE
fix(source-control): refresh branch compare after upstream changes

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.compare-summary.test.ts
@@ -6,6 +6,7 @@ import {
   refreshSourceControlAfterRemoteAction,
   resolveSourceControlBaseRef,
   resolveSourceControlPickerBaseRef,
+  shouldRefreshBranchCompareForRemoteStatus,
   shouldRefreshBranchCompareForStatusHead,
   shouldShowCompareSummary
 } from './SourceControl'
@@ -314,6 +315,56 @@ describe('SourceControl compare summary', () => {
         { baseRef: 'origin/main', statusHead: 'old-head', worktreeId: 'wt-1' },
         { baseRef: 'origin/release', statusHead: 'new-head', worktreeId: 'wt-1' }
       )
+    ).toBe(false)
+  })
+
+  it('refreshes branch compare when upstream status changes for the same base', () => {
+    expect(
+      shouldRefreshBranchCompareForRemoteStatus(
+        {
+          ahead: 1,
+          baseRef: 'origin/main',
+          behind: 0,
+          hasUpstream: true,
+          upstreamName: 'origin/main',
+          worktreeId: 'wt-1'
+        },
+        {
+          ahead: 0,
+          baseRef: 'origin/main',
+          behind: 0,
+          hasUpstream: true,
+          upstreamName: 'origin/main',
+          worktreeId: 'wt-1'
+        }
+      )
+    ).toBe(true)
+  })
+
+  it('does not refresh branch compare for initial or unrelated upstream status snapshots', () => {
+    const current = {
+      ahead: 0,
+      baseRef: 'origin/main',
+      behind: 0,
+      hasUpstream: true,
+      upstreamName: 'origin/main',
+      worktreeId: 'wt-1'
+    }
+
+    expect(shouldRefreshBranchCompareForRemoteStatus(null, current)).toBe(false)
+    expect(
+      shouldRefreshBranchCompareForRemoteStatus(current, {
+        ...current,
+        baseRef: 'origin/release',
+        ahead: 1
+      })
+    ).toBe(false)
+    expect(
+      shouldRefreshBranchCompareForRemoteStatus(current, {
+        ...current,
+        worktreeId: 'wt-2',
+        ahead: 1
+      })
     ).toBe(false)
   })
 

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1396,27 +1396,25 @@ function SourceControlInner(): React.JSX.Element {
     shouldResolveHostedReviewCreation &&
     hostedReviewCreationRequestMatchesCurrent &&
     hostedReviewCreationRequestState.status === 'loading' &&
-    hostedReviewCreation === null &&
     hostedReview === null
   const hostedReviewCreationForHeader = useMemo(() => {
-    if (hostedReviewCreation) {
-      return hostedReviewCreation
+    // Why: a fresh preflight must disable stale Create PR eligibility while
+    // upstream/dirty/base state is reconciling after commit or push.
+    if (isHostedReviewCreationLoading) {
+      const provider = resolveProvisionalHostedReviewProvider({
+        hostedReview,
+        hostedReviewCreationState,
+        activeRepoId: activeRepo?.id ?? null,
+        linkedGitHubPR,
+        fallbackGitHubPR: fallbackGitHubPRNumber,
+        linkedGitLabMR,
+        linkedBitbucketPR,
+        linkedAzureDevOpsPR,
+        linkedGiteaPR
+      })
+      return buildLoadingHostedReviewCreationEligibility(provider)
     }
-    if (!isHostedReviewCreationLoading) {
-      return null
-    }
-    const provider = resolveProvisionalHostedReviewProvider({
-      hostedReview,
-      hostedReviewCreationState,
-      activeRepoId: activeRepo?.id ?? null,
-      linkedGitHubPR,
-      fallbackGitHubPR: fallbackGitHubPRNumber,
-      linkedGitLabMR,
-      linkedBitbucketPR,
-      linkedAzureDevOpsPR,
-      linkedGiteaPR
-    })
-    return buildLoadingHostedReviewCreationEligibility(provider)
+    return hostedReviewCreation
   }, [
     activeRepo?.id,
     fallbackGitHubPRNumber,
@@ -2943,6 +2941,9 @@ function SourceControlInner(): React.JSX.Element {
       branch: branchName,
       status: 'loading'
     })
+    // Why: upstream/status changes can make the previous eligibility unsafe
+    // to click while the new preflight is still resolving.
+    setHostedReviewCreationState(null)
     void getHostedReviewCreationEligibility({
       repoPath: activeRepo.path,
       repoId: activeRepo.id,
@@ -4447,6 +4448,7 @@ function SourceControlInner(): React.JSX.Element {
   const branchCompareRunPromiseRef = useRef<Promise<void> | null>(null)
   const refreshBranchCompareRef = useRef<() => Promise<void>>(async () => {})
   const branchCompareStatusHeadRef = useRef<BranchCompareStatusHeadSnapshot | null>(null)
+  const branchCompareRemoteStatusRef = useRef<BranchCompareRemoteStatusSnapshot | null>(null)
 
   const runBranchCompare = useCallback(async () => {
     if (!activeWorktreeId || !worktreePath || !effectiveBaseRef || isFolder) {
@@ -4640,6 +4642,39 @@ function SourceControlInner(): React.JSX.Element {
     effectiveBaseRef,
     isBranchVisible,
     isFolder,
+    worktreePath
+  ])
+
+  useEffect(() => {
+    if (!activeWorktreeId || !worktreePath || !isBranchVisible || !effectiveBaseRef || isFolder) {
+      branchCompareRemoteStatusRef.current = null
+      return
+    }
+
+    // Why: pushing a branch can move its remote-tracking base and ahead count
+    // without changing local HEAD, so the HEAD-change effect alone misses it.
+    const current = {
+      ahead: remoteStatus?.ahead ?? null,
+      baseRef: effectiveBaseRef,
+      behind: remoteStatus?.behind ?? null,
+      hasUpstream: remoteStatus?.hasUpstream ?? null,
+      upstreamName: remoteStatus?.upstreamName ?? null,
+      worktreeId: activeWorktreeId
+    }
+    const previous = branchCompareRemoteStatusRef.current
+    branchCompareRemoteStatusRef.current = current
+    if (shouldRefreshBranchCompareForRemoteStatus(previous, current)) {
+      void refreshBranchCompareRef.current()
+    }
+  }, [
+    activeWorktreeId,
+    effectiveBaseRef,
+    isBranchVisible,
+    isFolder,
+    remoteStatus?.ahead,
+    remoteStatus?.behind,
+    remoteStatus?.hasUpstream,
+    remoteStatus?.upstreamName,
     worktreePath
   ])
 
@@ -6855,6 +6890,15 @@ type BranchCompareStatusHeadSnapshot = {
   worktreeId: string
 }
 
+type BranchCompareRemoteStatusSnapshot = {
+  ahead: number | null
+  baseRef: string
+  behind: number | null
+  hasUpstream: boolean | null
+  upstreamName: string | null
+  worktreeId: string
+}
+
 export function shouldRefreshBranchCompareForStatusHead(
   previous: BranchCompareStatusHeadSnapshot | null,
   current: BranchCompareStatusHeadSnapshot
@@ -6865,6 +6909,21 @@ export function shouldRefreshBranchCompareForStatusHead(
     previous.worktreeId === current.worktreeId &&
     previous.baseRef === current.baseRef &&
     previous.statusHead !== current.statusHead
+  )
+}
+
+export function shouldRefreshBranchCompareForRemoteStatus(
+  previous: BranchCompareRemoteStatusSnapshot | null,
+  current: BranchCompareRemoteStatusSnapshot
+): boolean {
+  return (
+    previous !== null &&
+    previous.worktreeId === current.worktreeId &&
+    previous.baseRef === current.baseRef &&
+    (previous.hasUpstream !== current.hasUpstream ||
+      previous.upstreamName !== current.upstreamName ||
+      previous.ahead !== current.ahead ||
+      previous.behind !== current.behind)
   )
 }
 

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -612,6 +612,13 @@ type HostedReviewCreationRequestState = {
   status: 'loading' | 'failed'
 }
 
+type HostedReviewCreationProviderHint = {
+  repoId: string | null
+  worktreeId: string | null
+  branch: string
+  provider: HostedReviewProvider
+}
+
 type CreatedHostedReview = {
   provider: HostedReviewProvider
   number: number
@@ -990,6 +997,12 @@ function SourceControlInner(): React.JSX.Element {
     useState<HostedReviewCreationState | null>(null)
   const [hostedReviewCreationRequestState, setHostedReviewCreationRequestState] =
     useState<HostedReviewCreationRequestState | null>(null)
+  const hostedReviewCreationProviderHintRef = useRef<HostedReviewCreationProviderHint>({
+    repoId: null,
+    worktreeId: null,
+    branch: '',
+    provider: 'github'
+  })
   const createPrInFlightRef = useRef<Record<string, boolean>>({})
   const [createPrInFlightByWorktree, setCreatePrInFlightByWorktree] = useState<
     Record<string, boolean>
@@ -1397,13 +1410,16 @@ function SourceControlInner(): React.JSX.Element {
     hostedReviewCreationRequestMatchesCurrent &&
     hostedReviewCreationRequestState.status === 'loading' &&
     hostedReview === null
-  const hostedReviewCreationForHeader = useMemo(() => {
-    // Why: a fresh preflight must disable stale Create PR eligibility while
-    // upstream/dirty/base state is reconciling after commit or push.
-    if (isHostedReviewCreationLoading) {
-      const provider = resolveProvisionalHostedReviewProvider({
+  const provisionalHostedReviewProvider = useMemo(
+    () =>
+      resolveProvisionalHostedReviewProvider({
         hostedReview,
-        hostedReviewCreationState,
+        hostedReviewCreationState: hostedReviewCreation
+          ? {
+              repoId: activeRepo?.id ?? '',
+              data: hostedReviewCreation
+            }
+          : null,
         activeRepoId: activeRepo?.id ?? null,
         linkedGitHubPR,
         fallbackGitHubPR: fallbackGitHubPRNumber,
@@ -1411,22 +1427,74 @@ function SourceControlInner(): React.JSX.Element {
         linkedBitbucketPR,
         linkedAzureDevOpsPR,
         linkedGiteaPR
-      })
+      }),
+    [
+      activeRepo?.id,
+      fallbackGitHubPRNumber,
+      hostedReview,
+      hostedReviewCreation,
+      linkedAzureDevOpsPR,
+      linkedBitbucketPR,
+      linkedGitHubPR,
+      linkedGitLabMR,
+      linkedGiteaPR
+    ]
+  )
+  useEffect(() => {
+    const hasConcreteProviderHint =
+      hostedReview !== null ||
+      hostedReviewCreation !== null ||
+      linkedGitHubPR !== null ||
+      fallbackGitHubPRNumber !== null ||
+      linkedGitLabMR !== null ||
+      linkedAzureDevOpsPR !== null ||
+      linkedGiteaPR !== null
+
+    if (!hasConcreteProviderHint) {
+      return
+    }
+
+    hostedReviewCreationProviderHintRef.current = {
+      repoId: activeRepo?.id ?? null,
+      worktreeId: activeWorktreeId ?? null,
+      branch: branchName,
+      provider: provisionalHostedReviewProvider
+    }
+  }, [
+    activeRepo?.id,
+    activeWorktreeId,
+    branchName,
+    fallbackGitHubPRNumber,
+    hostedReview,
+    hostedReviewCreation,
+    linkedAzureDevOpsPR,
+    linkedGiteaPR,
+    linkedGitHubPR,
+    linkedGitLabMR,
+    provisionalHostedReviewProvider
+  ])
+  const hostedReviewCreationForHeader = useMemo(() => {
+    // Why: a fresh preflight must disable stale Create PR eligibility while
+    // upstream/dirty/base state is reconciling after commit or push, while
+    // preserving provider copy from the previous safe snapshot.
+    if (isHostedReviewCreationLoading) {
+      const providerHint = hostedReviewCreationProviderHintRef.current
+      const provider =
+        providerHint.repoId === (activeRepo?.id ?? null) &&
+        providerHint.worktreeId === (activeWorktreeId ?? null) &&
+        providerHint.branch === branchName
+          ? providerHint.provider
+          : provisionalHostedReviewProvider
       return buildLoadingHostedReviewCreationEligibility(provider)
     }
     return hostedReviewCreation
   }, [
     activeRepo?.id,
-    fallbackGitHubPRNumber,
-    hostedReview,
+    activeWorktreeId,
+    branchName,
     hostedReviewCreation,
-    hostedReviewCreationState,
     isHostedReviewCreationLoading,
-    linkedAzureDevOpsPR,
-    linkedBitbucketPR,
-    linkedGitHubPR,
-    linkedGitLabMR,
-    linkedGiteaPR
+    provisionalHostedReviewProvider
   ])
   const hasHostedReviewLink = hasPositiveHostedReviewNumberLink({
     linkedGitHubPR,

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
@@ -416,6 +416,28 @@ describe('resolvePrimaryAction Create PR intent', () => {
     })
   })
 
+  it('keeps stale Create PR eligibility disabled while a newer preflight is loading', () => {
+    expect(
+      resolveCreatePrHeaderAction(
+        inputs({
+          hostedReviewCreation: {
+            provider: 'github',
+            review: null,
+            canCreate: true,
+            blockedReason: null,
+            nextAction: null
+          },
+          isHostedReviewCreationLoading: true
+        })
+      )
+    ).toEqual({
+      kind: 'create_pr',
+      label: 'Create PR',
+      title: 'Checking whether this branch can create a pull request…',
+      disabled: true
+    })
+  })
+
   it('returns a clickable Create PR header notice path when the branch has nothing to publish yet', () => {
     expect(
       resolveCreatePrHeaderAction(

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
@@ -438,6 +438,28 @@ describe('resolvePrimaryAction Create PR intent', () => {
     })
   })
 
+  it('keeps stale Create MR eligibility disabled with provider-aware loading copy', () => {
+    expect(
+      resolveCreatePrHeaderAction(
+        inputs({
+          hostedReviewCreation: {
+            provider: 'gitlab',
+            review: null,
+            canCreate: true,
+            blockedReason: null,
+            nextAction: null
+          },
+          isHostedReviewCreationLoading: true
+        })
+      )
+    ).toEqual({
+      kind: 'create_pr',
+      label: 'Create MR',
+      title: 'Checking whether this branch can create a merge request…',
+      disabled: true
+    })
+  })
+
   it('returns a clickable Create PR header notice path when the branch has nothing to publish yet', () => {
     expect(
       resolveCreatePrHeaderAction(


### PR DESCRIPTION
## Summary

Fixes Source Control staying stale after commit/push. The issue happened because branch compare refreshed on local `HEAD` changes, but a push can update the remote-tracking ref and ahead/behind state without changing local `HEAD`, so the tree stayed stale until tab switching triggered another refresh.

This PR refreshes branch compare when upstream status changes for the same worktree/base ref, and prevents stale Create PR eligibility from staying clickable while a newer preflight is loading.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused tests run:

- `vitest ... SourceControl.compare-summary.test.ts source-control-primary-action.create-pr-intent.test.ts`

## AI Review Report

- Reviewed the Source Control refresh flow from commit/push through upstream status, branch compare, and Create PR eligibility.
- Checked that the fix is provider-neutral and applies to GitHub/GitLab/other review providers because it keys off generic Git upstream state, not GitHub-specific behavior.
- Checked cross-platform impact for macOS, Linux, and Windows: no shortcut, shell, path separator, or platform-specific Electron behavior was changed.
- Checked SSH/remote compatibility: the refresh uses existing runtime-routed Source Control state and does not assume local-only Git execution.

## Security Audit

No new command execution, IPC channel, credential handling, dependency, or filesystem path handling was added.

The change only reacts to existing upstream-status state and existing eligibility preflight state.

No secrets, auth tokens, or user-controlled shell input are introduced.

Fixes #6516