### PR TITLE
Open terminal file taps in mobile preview

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -3177,7 +3177,7 @@ export default function SessionScreen() {
           // Why: HTML opens in a browser pane (streamed from the desktop),
           // matching desktop's terminal-click behavior, instead of a file view.
           if (target.kind === 'browser') {
-            void handleCreateBrowser(target.url)
+            void handleCreateBrowserRef.current?.(target.url)
             return
           }
           navigateToMobileFilePreview(router, target.params)

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -164,7 +164,9 @@ import {
 } from '../../../../src/session/mobile-clipboard-image'
 import { useMobileImageAttachment } from '../../../../src/session/use-mobile-image-attachment'
 import { classifyMobileArtifact } from '../../../../src/session/mobile-artifact-kind'
+import { getMobileTerminalFileTapTarget } from '../../../../src/session/mobile-terminal-file-tap-target'
 import { useLiveWorktreeName } from '../../../../src/session/use-live-worktree-name'
+import { navigateToMobileFilePreview } from '../../../../src/files/mobile-file-preview-navigation'
 import {
   acceptSessionSnapshot,
   applyClosedTabTombstones,
@@ -3142,8 +3144,8 @@ export default function SessionScreen() {
   )
 
   // Tap on a file path in terminal output → resolve it on the host and open it
-  // as a file tab (mirrors desktop Cmd/Ctrl-click). Silent on a miss; the
-  // WebView only emits this when the tap landed on a detected path.
+  // in the phone previewer. Silent on a miss; the WebView only emits this when
+  // the tap landed on a detected path.
   const handleFileTap = useCallback(
     (handle: string, pathText: string) => {
       if (handle !== activeHandleRef.current || !client) {
@@ -3161,65 +3163,30 @@ export default function SessionScreen() {
             return
           }
           const resolved = (response as RpcSuccess).result as RuntimeTerminalPathResolution
-          if (!resolved.exists || resolved.isDirectory || !resolved.relativePath) {
+          const target = getMobileTerminalFileTapTarget({
+            hostId,
+            worktreeId,
+            worktreeName: worktreeName || undefined,
+            resolved
+          })
+          if (target.kind === 'ignore') {
             return
           }
           // Confirm the tap landed on something openable before giving feedback.
           triggerSelection()
           // Why: HTML opens in a browser pane (streamed from the desktop),
           // matching desktop's terminal-click behavior, instead of a file view.
-          if (classifyMobileArtifact(resolved.relativePath) === 'html' && resolved.absolutePath) {
-            void handleCreateBrowser('file://' + resolved.absolutePath)
+          if (target.kind === 'browser') {
+            void handleCreateBrowser(target.url)
             return
           }
-          const openResponse = await client.sendRequest(
-            'files.open',
-            { worktree, relativePath: resolved.relativePath },
-            { timeoutMs: 15_000 }
-          )
-          if (!openResponse.ok) {
-            return
-          }
-          // Why: the host opens the file as a markdown/file/image tab (the type
-          // depends on the file — .md opens as a 'markdown' tab), and from a terminal
-          // the active tab stays on the terminal. Once the new tab syncs in, switch to
-          // it by relativePath across ANY openable type. Poll since it arrives async.
-          const openedPath = resolved.relativePath
-          // Why: retries poll for the async-arriving tab, but once activation lands
-          // a later retry would steal focus back from the user — short-circuit the
-          // remaining ones once the opened tab is (or becomes) the active tab.
-          let activated = false
-          const activateOpenedTab = async (): Promise<void> => {
-            if (activated) {
-              return
-            }
-            await fetchSessionTabs()
-            if (activated) {
-              return
-            }
-            const opened = sessionTabsRef.current.find(
-              (tab): tab is Extract<MobileSessionTab, { relativePath?: string }> =>
-                'relativePath' in tab && tab.relativePath === openedPath
-            )
-            if (!opened) {
-              return
-            }
-            if (activeSessionTabIdRef.current === opened.id) {
-              activated = true
-              return
-            }
-            switchSessionTabRef.current?.(opened)
-            activated = true
-          }
-          scheduleDelayedAction(() => void activateOpenedTab(), 300)
-          scheduleDelayedAction(() => void activateOpenedTab(), 900)
-          scheduleDelayedAction(() => void activateOpenedTab(), 1800)
+          navigateToMobileFilePreview(router, target.params)
         } catch {
           // Resolution/open is best-effort; a failed tap silently no-ops.
         }
       })()
     },
-    [client, worktreeId, scheduleDelayedAction, fetchSessionTabs]
+    [client, hostId, router, worktreeId, worktreeName]
   )
 
   const handleTerminalOpenUrl = useCallback(

--- a/mobile/scripts/mock-server-file-preview-data.ts
+++ b/mobile/scripts/mock-server-file-preview-data.ts
@@ -7,6 +7,8 @@ type ErrorResponse = (id: string, code: string, message: string) => RpcResponse
 const MOCK_IMAGE_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l8sm7wAAAABJRU5ErkJggg=='
 
+const MOCK_ROOT_PATH = '/tmp/orca-mobile-repro/orca'
+
 const MOCK_FILE_CONTENT: Record<string, string> = {
   'README.md': '# Mobile preview\n\nThis markdown file is served by the mock desktop.',
   'src/app.ts': "export const mobilePreview = 'ready'\n",
@@ -17,9 +19,28 @@ const MOCK_FILE_LIST = [
   { relativePath: 'README.md', basename: 'README.md', kind: 'text' },
   { relativePath: 'src/app.ts', basename: 'app.ts', kind: 'text' },
   { relativePath: 'public/index.html', basename: 'index.html', kind: 'text' },
+  { relativePath: 'artifacts/screenshot.png', basename: 'screenshot.png', kind: 'binary' },
   { relativePath: 'assets/logo.png', basename: 'logo.png', kind: 'binary' },
   { relativePath: 'dist/archive.zip', basename: 'archive.zip', kind: 'binary' }
 ]
+
+const MOCK_FILE_PATHS = new Set([
+  ...Object.keys(MOCK_FILE_CONTENT),
+  ...MOCK_FILE_LIST.map((entry) => entry.relativePath)
+])
+
+function resolveMockTerminalPath(pathText: string): string | null {
+  const normalized = pathText.replace(/\\/g, '/').replace(/^\.\//, '')
+  const rootPrefix = `${MOCK_ROOT_PATH}/`
+  const relativePath = normalized.startsWith(rootPrefix)
+    ? normalized.slice(rootPrefix.length)
+    : normalized
+
+  if (relativePath.startsWith('/') || relativePath.includes('../') || relativePath === '..') {
+    return null
+  }
+  return MOCK_FILE_PATHS.has(relativePath) ? relativePath : null
+}
 
 export function handleMockFilePreviewRequest(
   request: RpcRequest,
@@ -59,9 +80,24 @@ export function handleMockFilePreviewRequest(
       return true
     }
 
+    case 'files.resolveTerminalPath': {
+      const pathText = String(request.params?.pathText ?? '')
+      const relativePath = resolveMockTerminalPath(pathText)
+      respond(
+        success(request.id, {
+          worktree: request.params?.worktree ?? 'id:mock',
+          relativePath,
+          absolutePath: relativePath ? `${MOCK_ROOT_PATH}/${relativePath}` : null,
+          exists: relativePath !== null,
+          isDirectory: false
+        })
+      )
+      return true
+    }
+
     case 'files.readPreview': {
       const relativePath = String(request.params?.relativePath ?? '')
-      if (relativePath !== 'assets/logo.png') {
+      if (relativePath !== 'assets/logo.png' && relativePath !== 'artifacts/screenshot.png') {
         respond(error(request.id, 'binary_file', 'binary_file'))
         return true
       }

--- a/mobile/scripts/mock-server-file-preview-data.ts
+++ b/mobile/scripts/mock-server-file-preview-data.ts
@@ -29,6 +29,10 @@ const MOCK_FILE_PATHS = new Set([
   ...MOCK_FILE_LIST.map((entry) => entry.relativePath)
 ])
 
+/**
+ * Mirrors the host terminal-path resolver just enough for mock sessions: only
+ * known worktree-relative files, or their absolute mock-root form, are openable.
+ */
 function resolveMockTerminalPath(pathText: string): string | null {
   const normalized = pathText.replace(/\\/g, '/').replace(/^\.\//, '')
   const rootPrefix = `${MOCK_ROOT_PATH}/`
@@ -42,6 +46,10 @@ function resolveMockTerminalPath(pathText: string): string | null {
   return MOCK_FILE_PATHS.has(relativePath) ? relativePath : null
 }
 
+/**
+ * Serves the file RPC subset that the mobile Files panel and terminal path-tap
+ * flow need, keeping mock development close to the real desktop contract.
+ */
 export function handleMockFilePreviewRequest(
   request: RpcRequest,
   respond: Respond,

--- a/mobile/scripts/mock-server-terminal-fixtures.ts
+++ b/mobile/scripts/mock-server-terminal-fixtures.ts
@@ -17,5 +17,6 @@ export const STREAMING_CHUNKS = [
   'Reading src/auth/session.ts...\n',
   '\nI see the current implementation uses express-session.\n',
   "I'll replace it with jsonwebtoken.\n",
-  '\nUpdating src/auth/middleware.ts...\n'
+  '\nUpdating src/auth/middleware.ts...\n',
+  '\nGenerated visual artifact: artifacts/screenshot.png\n'
 ]

--- a/mobile/src/session/mobile-mock-file-preview-data.test.ts
+++ b/mobile/src/session/mobile-mock-file-preview-data.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import { handleMockFilePreviewRequest } from '../../scripts/mock-server-file-preview-data'
+import { error, success, type RpcResponse } from '../../scripts/mock-server-rpc-handlers'
+
+function request(method: string, params: Record<string, unknown>) {
+  return { id: 'req-1', method, params }
+}
+
+function capture(method: string, params: Record<string, unknown>): RpcResponse {
+  const respond = vi.fn()
+  const handled = handleMockFilePreviewRequest(request(method, params), respond, success, error)
+  expect(handled).toBe(true)
+  expect(respond).toHaveBeenCalledTimes(1)
+  return respond.mock.calls[0]?.[0] as RpcResponse
+}
+
+describe('mock file preview data', () => {
+  it('resolves terminal screenshot paths into worktree-relative files', () => {
+    expect(
+      capture('files.resolveTerminalPath', {
+        worktree: 'id:wt-1',
+        pathText: 'artifacts/screenshot.png'
+      })
+    ).toMatchObject({
+      ok: true,
+      result: {
+        relativePath: 'artifacts/screenshot.png',
+        absolutePath: '/tmp/orca-mobile-repro/orca/artifacts/screenshot.png',
+        exists: true,
+        isDirectory: false
+      }
+    })
+
+    expect(
+      capture('files.resolveTerminalPath', {
+        worktree: 'id:wt-1',
+        pathText: '/tmp/orca-mobile-repro/orca/artifacts/screenshot.png'
+      })
+    ).toMatchObject({
+      ok: true,
+      result: {
+        relativePath: 'artifacts/screenshot.png',
+        exists: true
+      }
+    })
+  })
+
+  it('serves screenshot image previews through files.readPreview', () => {
+    expect(
+      capture('files.readPreview', {
+        worktree: 'id:wt-1',
+        relativePath: 'artifacts/screenshot.png'
+      })
+    ).toMatchObject({
+      ok: true,
+      result: {
+        isBinary: true,
+        isImage: true,
+        mimeType: 'image/png'
+      }
+    })
+  })
+})

--- a/mobile/src/session/mobile-terminal-file-tap-target.test.ts
+++ b/mobile/src/session/mobile-terminal-file-tap-target.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import type { RuntimeTerminalPathResolution } from '../../../src/shared/runtime-types'
+import { getMobileTerminalFileTapTarget } from './mobile-terminal-file-tap-target'
+
+function resolved(
+  overrides: Partial<RuntimeTerminalPathResolution>
+): RuntimeTerminalPathResolution {
+  return {
+    worktree: 'wt-1',
+    relativePath: 'src/app.ts',
+    absolutePath: '/repo/src/app.ts',
+    exists: true,
+    isDirectory: false,
+    ...overrides
+  }
+}
+
+describe('getMobileTerminalFileTapTarget', () => {
+  it('opens ordinary files in the mobile preview route', () => {
+    expect(
+      getMobileTerminalFileTapTarget({
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        worktreeName: 'Orca',
+        resolved: resolved({ relativePath: 'src/app.ts', absolutePath: '/repo/src/app.ts' })
+      })
+    ).toEqual({
+      kind: 'preview',
+      params: {
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        relativePath: 'src/app.ts',
+        name: 'app.ts',
+        worktreeName: 'Orca'
+      }
+    })
+  })
+
+  it('opens images in the same mobile preview route', () => {
+    expect(
+      getMobileTerminalFileTapTarget({
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        resolved: resolved({
+          relativePath: 'artifacts/screenshot.png',
+          absolutePath: '/repo/artifacts/screenshot.png'
+        })
+      })
+    ).toEqual({
+      kind: 'preview',
+      params: {
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        relativePath: 'artifacts/screenshot.png',
+        name: 'screenshot.png',
+        worktreeName: undefined
+      }
+    })
+  })
+
+  it('keeps HTML on the browser path when an absolute file URL is available', () => {
+    expect(
+      getMobileTerminalFileTapTarget({
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        resolved: resolved({ relativePath: 'report.html', absolutePath: '/repo/report.html' })
+      })
+    ).toEqual({ kind: 'browser', url: 'file:///repo/report.html' })
+  })
+
+  it('ignores missing files, directories, and paths outside the worktree', () => {
+    expect(
+      getMobileTerminalFileTapTarget({
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        resolved: resolved({ exists: false })
+      })
+    ).toEqual({ kind: 'ignore' })
+    expect(
+      getMobileTerminalFileTapTarget({
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        resolved: resolved({ isDirectory: true })
+      })
+    ).toEqual({ kind: 'ignore' })
+    expect(
+      getMobileTerminalFileTapTarget({
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        resolved: resolved({ relativePath: null })
+      })
+    ).toEqual({ kind: 'ignore' })
+  })
+})

--- a/mobile/src/session/mobile-terminal-file-tap-target.test.ts
+++ b/mobile/src/session/mobile-terminal-file-tap-target.test.ts
@@ -63,9 +63,36 @@ describe('getMobileTerminalFileTapTarget', () => {
       getMobileTerminalFileTapTarget({
         hostId: 'host-1',
         worktreeId: 'wt-1',
-        resolved: resolved({ relativePath: 'report.html', absolutePath: '/repo/report.html' })
+        resolved: resolved({
+          relativePath: 'report.html',
+          absolutePath: '/repo/my report.html'
+        })
       })
-    ).toEqual({ kind: 'browser', url: 'file:///repo/report.html' })
+    ).toEqual({ kind: 'browser', url: 'file:///repo/my%20report.html' })
+  })
+
+  it('formats Windows and UNC HTML file URLs', () => {
+    expect(
+      getMobileTerminalFileTapTarget({
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        resolved: resolved({
+          relativePath: 'report.html',
+          absolutePath: 'C:\\repo\\my report.html'
+        })
+      })
+    ).toEqual({ kind: 'browser', url: 'file:///C:/repo/my%20report.html' })
+
+    expect(
+      getMobileTerminalFileTapTarget({
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        resolved: resolved({
+          relativePath: 'report.html',
+          absolutePath: '\\\\server\\share\\repo\\report.html'
+        })
+      })
+    ).toEqual({ kind: 'browser', url: 'file://server/share/repo/report.html' })
   })
 
   it('ignores missing files, directories, and paths outside the worktree', () => {

--- a/mobile/src/session/mobile-terminal-file-tap-target.ts
+++ b/mobile/src/session/mobile-terminal-file-tap-target.ts
@@ -1,4 +1,5 @@
 import type { RuntimeTerminalPathResolution } from '../../../src/shared/runtime-types'
+import { filesystemPathToFileUri } from '../../../src/shared/file-uri-path'
 import {
   displayNameFromPreviewPath,
   type MobileFilePreviewRouteParams
@@ -10,6 +11,11 @@ export type MobileTerminalFileTapTarget =
   | { kind: 'browser'; url: string }
   | { kind: 'preview'; params: MobileFilePreviewRouteParams }
 
+/**
+ * Classifies a host-resolved terminal path into the mobile surface that should
+ * open it. The host already enforces the worktree boundary; this helper keeps
+ * UI routing and cross-platform file URL normalization in one tested place.
+ */
 export function getMobileTerminalFileTapTarget(args: {
   hostId: string
   worktreeId: string
@@ -24,7 +30,7 @@ export function getMobileTerminalFileTapTarget(args: {
   // HTML keeps the desktop-like browser path when the host can provide an
   // absolute file URL; all other artifacts open directly in the phone previewer.
   if (classifyMobileArtifact(resolved.relativePath) === 'html' && resolved.absolutePath) {
-    return { kind: 'browser', url: `file://${resolved.absolutePath}` }
+    return { kind: 'browser', url: filesystemPathToFileUri(resolved.absolutePath) }
   }
 
   return {

--- a/mobile/src/session/mobile-terminal-file-tap-target.ts
+++ b/mobile/src/session/mobile-terminal-file-tap-target.ts
@@ -1,0 +1,40 @@
+import type { RuntimeTerminalPathResolution } from '../../../src/shared/runtime-types'
+import {
+  displayNameFromPreviewPath,
+  type MobileFilePreviewRouteParams
+} from '../files/mobile-file-preview-route'
+import { classifyMobileArtifact } from './mobile-artifact-kind'
+
+export type MobileTerminalFileTapTarget =
+  | { kind: 'ignore' }
+  | { kind: 'browser'; url: string }
+  | { kind: 'preview'; params: MobileFilePreviewRouteParams }
+
+export function getMobileTerminalFileTapTarget(args: {
+  hostId: string
+  worktreeId: string
+  worktreeName?: string
+  resolved: RuntimeTerminalPathResolution
+}): MobileTerminalFileTapTarget {
+  const { hostId, worktreeId, worktreeName, resolved } = args
+  if (!resolved.exists || resolved.isDirectory || !resolved.relativePath) {
+    return { kind: 'ignore' }
+  }
+
+  // HTML keeps the desktop-like browser path when the host can provide an
+  // absolute file URL; all other artifacts open directly in the phone previewer.
+  if (classifyMobileArtifact(resolved.relativePath) === 'html' && resolved.absolutePath) {
+    return { kind: 'browser', url: `file://${resolved.absolutePath}` }
+  }
+
+  return {
+    kind: 'preview',
+    params: {
+      hostId,
+      worktreeId,
+      relativePath: resolved.relativePath,
+      name: displayNameFromPreviewPath(resolved.relativePath),
+      worktreeName
+    }
+  }
+}


### PR DESCRIPTION
Closes #6539

## Summary
- Open resolved terminal file taps directly in the mobile file preview screen.
- Preserve the existing HTML browser behavior when the host returns an absolute file URL.
- Add a pure target-selection helper with coverage for source files, images, HTML, ignored paths, and Windows/UNC HTML paths.
- Extend the mobile mock desktop fixture so terminal output includes `artifacts/screenshot.png`, and the mock server resolves/serves that image through `files.resolveTerminalPath` + `files.readPreview`.

## Screenshots
No screenshot attached: this is a mobile routing change and local iOS/Android simulator tooling is unavailable on this machine. Manual-ish protocol validation is listed below.

## AI Review Report
Addressed CodeRabbit inline feedback by:
- Routing HTML terminal taps through `handleCreateBrowserRef.current?.(...)` to avoid stale browser opener closures.
- Replacing manual `file://${absolutePath}` construction with the shared `filesystemPathToFileUri` helper.
- Adding Windows drive and UNC path fixtures around HTML file URL formatting.

## Security Audit
- The mobile app still asks the host to resolve terminal paths before opening anything.
- Host-side `files.resolveTerminalPath` remains the worktree-boundary gate; this PR does not expand file read permissions.
- Image/text previews continue to use existing `files.readPreview` / `files.read` RPCs.
- HTML paths are normalized as file URLs through the shared path helper instead of string concatenation.

## Test plan
- `cd mobile && pnpm test -- src/session/mobile-terminal-file-tap-target.test.ts src/session/mobile-mock-file-preview-data.test.ts src/files/mobile-file-preview-request.test.ts src/files/mobile-file-preview-navigation.test.ts src/terminal/terminal-path-tap.test.ts`
- `cd mobile && pnpm format:check`
- `cd mobile && pnpm lint`
- `cd mobile && pnpm exec tsc --noEmit`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/files.test.ts`
- `git diff --check`

## Manual-ish validation
- Started the mock desktop server on `PORT=7678 pnpm mock-server`.
- Connected with a real encrypted WebSocket handshake using the mock server public key and `mock-device-token`.
- Sent `files.resolveTerminalPath` for `artifacts/screenshot.png` and verified it resolved to a worktree-relative file.
- Sent `files.readPreview` for the resolved path and verified it returned a PNG image preview payload.

## Notes
- Local iOS Simulator testing was not possible on this machine because only Xcode Command Line Tools are installed (`xcrun simctl` is unavailable). Android emulator tooling is also not installed.
- I also tried `pnpm test -- src/main/runtime/rpc/methods/files.test.ts`, but the root script expanded to the full suite and timed out in unrelated `src/shared/feature-interactions.test.ts`; the narrower file RPC command above passed.

## ELI5

On mobile, tapping a file path in the terminal opens it in the mobile file preview (images, source, etc.) instead of only handling special HTML cases.
