### PR TITLE
Launch and detect Qwen Code via its qwen executable

### DIFF
--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -139,7 +139,8 @@ export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
   droid: 'droid',
   kimi: 'kimi',
   'mistral-vibe': 'mistral-vibe',
-  'qwen-code': 'qwen-code',
+  // Why: QwenLM/qwen-code installs its CLI executable as `qwen`, not `qwen-code`.
+  'qwen-code': 'qwen',
   rovo: 'rovo',
   hermes: 'hermes',
   devin: 'devin',

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -254,7 +254,9 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
   {
     id: 'qwen-code',
     label: translate('auto.lib.agent.catalog.bee242fe3d', 'Qwen Code'),
-    cmd: 'qwen-code',
+    // Why: QwenLM/qwen-code installs its CLI executable as `qwen`; the package
+    // name is not the binary users put on PATH. Keep `id` for stable identity.
+    cmd: 'qwen',
     faviconDomain: 'qwenlm.github.io',
     homepageUrl: 'https://github.com/QwenLM/qwen-code'
   },

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -135,6 +135,21 @@ describe('agent process recognition', () => {
     expect(isRecognizedAgentType('vibe')).toBe(true)
   })
 
+  it('recognizes Qwen Code by its installed qwen executable', () => {
+    expect(recognizeAgentProcess('/home/dev/.local/bin/qwen')).toEqual({
+      agent: 'qwen-code',
+      processName: 'qwen'
+    })
+    expect(
+      recognizeAgentProcess(String.raw`C:\Users\dev\AppData\Roaming\npm\qwen.cmd`)
+    ).toEqual({
+      agent: 'qwen-code',
+      processName: 'qwen'
+    })
+    expect(isExpectedAgentProcess('/usr/local/bin/qwen', 'qwen')).toBe(true)
+    expect(isRecognizedAgentType('qwen')).toBe(true)
+  })
+
   it('recognizes agent CLIs launched through interpreter wrappers', () => {
     expect(
       recognizeAgentProcessFromCommandLine('node /Users/dev/.nvm/versions/node/bin/codex')

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -277,9 +277,11 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     promptInjectionMode: 'stdin-after-start'
   },
   'qwen-code': {
-    detectCmd: 'qwen-code',
-    launchCmd: 'qwen-code',
-    expectedProcess: 'qwen-code',
+    // Why: the upstream package is QwenLM/qwen-code, but its installed CLI
+    // executable on PATH is `qwen`, so detect/launch/recognition must use that.
+    detectCmd: 'qwen',
+    launchCmd: 'qwen',
+    expectedProcess: 'qwen',
     promptInjectionMode: 'stdin-after-start'
   },
   rovo: {

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -136,6 +136,23 @@ describe('tui agent startup plans', () => {
     })
   })
 
+  it('launches Qwen Code through the installed qwen executable', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'qwen-code',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      platform: 'linux'
+    })
+
+    expect(plan).toEqual({
+      agent: 'qwen-code',
+      launchCommand: 'qwen',
+      expectedProcess: 'qwen',
+      followupPrompt: 'fix it',
+      launchConfig: { agentCommand: 'qwen', agentArgs: '', agentEnv: {} }
+    })
+  })
+
   it('leaves Claude command overrides untouched', () => {
     const plan = buildAgentStartupPlan({
       agent: 'claude',


### PR DESCRIPTION
Fixes #5350

## Root cause
Qwen Code's installed CLI executable on PATH is `qwen`, **not** `qwen-code` (the latter is only the npm package / repo name, `QwenLM/qwen-code`). Orca hardcoded `qwen-code` as the detect command, launch command, and expected process name. As a result:

- **Launching** Qwen Code ran a nonexistent `qwen-code` binary, so the agent never started.
- **Process recognition** looked for a foreground process named `qwen-code`, so a running `qwen` session was never identified as Qwen Code.

This is the same package-name-vs-executable mismatch already handled for Mistral Vibe (`mistral-vibe` package, `vibe` executable).

## Change
Point the launch/detect/recognition command at the real `qwen` executable, while keeping the agent **id** `qwen-code` for stable identity (settings keys, telemetry, picker, display name all unchanged):

- `src/shared/tui-agent-config.ts` — `detectCmd`/`launchCmd`/`expectedProcess`: `qwen-code` -> `qwen`.
- `src/renderer/src/lib/agent-catalog.tsx` — catalog `cmd`: `qwen-code` -> `qwen` (id kept).
- `mobile/src/tasks/mobile-tui-agents.ts` — `MOBILE_TUI_AGENT_LAUNCH_COMMANDS['qwen-code']`: `qwen-code` -> `qwen`.

Added regression tests asserting Qwen Code launches and is recognized via `qwen`.

## Evidence

### Before — new tests fail (reproduces the bug)
```
 FAIL  src/shared/agent-process-recognition.test.ts > agent process recognition > recognizes Qwen Code by its installed qwen executable
 FAIL  src/shared/tui-agent-startup.test.ts > tui agent startup plans > launches Qwen Code through the installed qwen executable

- Expected
+ Received
  {
    "agent": "qwen-code",
-   "expectedProcess": "qwen",
+   "expectedProcess": "qwen-code",
    "followupPrompt": "fix it",
-   "launchCommand": "qwen",
+   "launchCommand": "qwen-code",
    "launchConfig": {
      "agentArgs": "",
-     "agentCommand": "qwen",
+     "agentCommand": "qwen-code",
      "agentEnv": {},
    },
  }

 Test Files  2 failed (2)
      Tests  2 failed | 42 skipped (44)
```
(`recognizeAgentProcess('/home/dev/.local/bin/qwen')` returned `null` before the fix.)

### After — full relevant suites pass
```
$ npx vitest run --config config/vitest.config.ts \
    src/shared/agent-process-recognition.test.ts \
    src/shared/tui-agent-startup.test.ts \
    src/renderer/src/lib/agent-picker-search.test.ts

 Test Files  3 passed (3)
      Tests  55 passed (55)
```
Mobile suite (edited file):
```
$ npx vitest run --config vitest.config.ts src/tasks/   # in mobile/
 Test Files  14 passed (14)
      Tests  67 passed (67)
```

### Lint (oxlint) — clean
```
$ pnpm lint <changed files>
# oxlint: only one pre-existing unrelated warning in useGitStatusPolling.ts; no errors
# lint:switch-exhaustiveness, localization-catalog, localization-coverage all passed
```

### Typecheck — clean
```
$ pnpm typecheck
> tsgo --noEmit -p config/tsconfig.node.json && tsgo --noEmit -p config/tsconfig.tc.cli.json && tsgo --noEmit -p config/tsconfig.tc.web.json
# exit 0, no errors
```
