### PR TITLE
Preserve terminal scrollback when restoring a hidden alternate-screen pane

### DIFF
--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2224,6 +2224,7 @@ export function registerPtyHandlers(
       lastTitle?: string
       seq?: number
       source?: 'headless' | 'renderer'
+      alternateScreen?: boolean
     } | null> => {
       if (!runtime || typeof args?.id !== 'string' || args.id.length === 0) {
         return null

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -227,7 +227,10 @@ describe('mobile subscribe integration', () => {
       cols: 90,
       rows: 30,
       seq: 17,
-      source: 'headless'
+      source: 'headless',
+      // Non-alt-screen buffer reports alternateScreen=false so the renderer
+      // keeps its destructive scrollback clear on restore.
+      alternateScreen: false
     })
     await expect(runtime.serializeTerminalBuffer('pty-empty')).resolves.toBeNull()
   })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5267,7 +5267,10 @@ describe('OrcaRuntimeService', () => {
       cols: 90,
       rows: 30,
       seq: 17,
-      source: 'headless'
+      source: 'headless',
+      // Non-alt-screen buffer reports alternateScreen=false so the renderer
+      // keeps its destructive scrollback clear on restore.
+      alternateScreen: false
     })
     expect(serializeBuffer).not.toHaveBeenCalled()
   })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5262,6 +5262,7 @@ export class OrcaRuntimeService {
     seq?: number
     source?: 'headless' | 'renderer'
     oscLinks?: TerminalOscLinkRange[]
+    alternateScreen?: boolean
   } | null> {
     return this.serializeTerminalBufferFromAvailableState(ptyId, opts)
   }
@@ -5278,6 +5279,7 @@ export class OrcaRuntimeService {
     seq?: number
     source?: 'headless' | 'renderer'
     oscLinks?: TerminalOscLinkRange[]
+    alternateScreen?: boolean
   } | null> {
     return this.serializeHeadlessTerminalBuffer(ptyId, { ...opts, includeEmpty: true })
   }
@@ -5294,6 +5296,7 @@ export class OrcaRuntimeService {
     seq?: number
     source?: 'headless' | 'renderer'
     oscLinks?: TerminalOscLinkRange[]
+    alternateScreen?: boolean
   } | null> {
     const headlessSnapshot = await this.serializeHeadlessTerminalBuffer(ptyId, {
       ...opts,
@@ -5540,6 +5543,7 @@ export class OrcaRuntimeService {
     seq?: number
     source?: 'headless' | 'renderer'
     oscLinks?: TerminalOscLinkRange[]
+    alternateScreen?: boolean
   } | null> {
     const headlessSnapshot = await this.serializeHeadlessTerminalBuffer(ptyId, opts)
     if (headlessSnapshot) {
@@ -5650,6 +5654,7 @@ export class OrcaRuntimeService {
     seq?: number
     source?: 'headless'
     oscLinks?: TerminalOscLinkRange[]
+    alternateScreen?: boolean
   } | null> {
     const state = this.headlessTerminals.get(ptyId)
     if (!state) {
@@ -5664,7 +5669,8 @@ export class OrcaRuntimeService {
     // caller can request scrollback so the user can scroll up to see prior
     // agent output.
     const requested = opts.scrollbackRows ?? 0
-    const scrollbackRows = state.emulator.isAlternateScreen ? 0 : requested
+    const isAlternateScreen = state.emulator.isAlternateScreen
+    const scrollbackRows = isAlternateScreen ? 0 : requested
     const snapshot = state.emulator.getSnapshot({ scrollbackRows })
     const data = snapshot.rehydrateSequences + snapshot.snapshotAnsi
     return data.length > 0 || opts.includeEmpty === true
@@ -5676,7 +5682,11 @@ export class OrcaRuntimeService {
           lastTitle: snapshot.lastTitle,
           seq: state.outputSequence,
           source: 'headless',
-          oscLinks: snapshot.oscLinks
+          oscLinks: snapshot.oscLinks,
+          // Why: lets the renderer skip the destructive scrollback clear when
+          // restoring an alt-screen snapshot — clearing wipes xterm's own
+          // history that the TUI relies on for scroll-up after a tab return.
+          alternateScreen: isAlternateScreen
         }
       : null
   }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1072,6 +1072,7 @@ export type PreloadApi = {
       cwd?: string | null
       seq?: number
       source?: 'headless' | 'renderer'
+      alternateScreen?: boolean
     } | null>
     getRendererDeliveryDebugSnapshot: () => Promise<{
       pendingPtyCount: number

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -785,6 +785,7 @@ const api = {
       cwd?: string | null
       seq?: number
       source?: 'headless' | 'renderer'
+      alternateScreen?: boolean
     } | null> => ipcRenderer.invoke('pty:getMainBufferSnapshot', { id, opts }),
 
     getRendererDeliveryDebugSnapshot: (): Promise<{

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6112,6 +6112,59 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('preserves scrollback by skipping the destructive clear when restoring an alternate-screen snapshot', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const live = 'visible-after-altscreen\r\n'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: 'altscreen-snapshot\r\n',
+      cols: 100,
+      rows: 30,
+      seq: hidden.length + live.length,
+      alternateScreen: true
+    })
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false }
+    })
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    expect(pane.terminal.write).not.toHaveBeenCalled()
+
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+    // Why: the destructive clear wipes xterm's scrollback. Alt-screen TUIs keep
+    // their history in xterm, so restoring one must NOT emit the clear.
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+      '\x1b[2J\x1b[3J\x1b[H',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).toHaveBeenCalledWith('altscreen-snapshot\r\n', expect.any(Function))
+    disposable.dispose()
+  })
+
   it('drains foreground output after a renderer-sourced hidden-backlog snapshot without seq', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3174,6 +3174,7 @@ export function connectPanePty(
       cols: number
       rows: number
       seq?: number
+      alternateScreen?: boolean
     }): void {
       const scrollIntent = captureTerminalWriteScrollIntent(pane.terminal)
       const colsBeforeReplay = pane.terminal.cols
@@ -3198,7 +3199,13 @@ export function connectPanePty(
           suppressSnapshotReplayPtyResize = false
         }
       }
-      writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+      if (!snapshot.alternateScreen) {
+        // Why: this clear (incl. \x1b[3J) wipes xterm's scrollback. Alt-screen
+        // TUIs (Claude Code, vim) keep their scroll history in xterm, so
+        // clearing on restore loses scroll-up after a hidden->visible return.
+        // Mirrors the attach-time guard in pty-transport.ts.
+        writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+      }
       writeReplayData(snapshot.data)
       writeReplayData(POST_REPLAY_LIVE_SNAPSHOT_RESET)
       hiddenRendererStateDirty = false

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -36,6 +36,11 @@ export type PtyBufferSnapshot = {
   rows: number
   seq?: number
   source?: 'headless' | 'renderer'
+  /** True when the snapshot captures an alternate-screen TUI (Claude Code,
+   *  vim). Restore must NOT clear xterm's buffer in that case — the TUI's
+   *  scrollback lives in xterm and a clear destroys scroll-up after a tab
+   *  return. Mirrors the attach-time guard in pty-transport.ts. */
+  alternateScreen?: boolean
 }
 
 export type LocalPtySessionMetadata = { cwd?: string; shellOverride?: string }


### PR DESCRIPTION
Fixes #5723

## Root cause

On Windows, a terminal pane running an alternate-screen TUI (Claude Code) could lose the ability to scroll above the viewport after the pane was hidden (tab/worktree switch or app backgrounded) and then shown again — even though the backend still held full scrollback (`orca terminal read` returned it).

On a hidden->visible restore, the renderer calls `applyMainBufferSnapshot` (`src/renderer/src/components/terminal-pane/pty-connection.ts`), which **unconditionally** wrote a destructive clear `ESC[2J ESC[3J ESC[H` before replaying the snapshot. The `ESC[3J` clears xterm's scrollback buffer. For an alternate-screen TUI the scroll history lives in xterm itself, so this clear destroyed scroll-up.

There was already a precedent guard for exactly this on the attach/reattach path: `pty-transport.ts` skips the same clear behind `if (!options.isAlternateScreen)`. The snapshot restore path lacked that guard.

## Change summary

Thread an `alternateScreen` boolean from the backend snapshot to the renderer and skip the destructive clear when restoring an alternate-screen buffer:

- `src/main/runtime/orca-runtime.ts` — `serializeHeadlessTerminalBuffer` now returns `alternateScreen` (sourced from the same `state.emulator.isAlternateScreen` it already reads to force `scrollbackRows=0`); the four wrapper serialize methods propagate the field in their return types.
- `src/main/ipc/pty.ts` — `pty:getMainBufferSnapshot` return type includes `alternateScreen`.
- `src/preload/api-types.ts` + `src/preload/index.ts` — `getMainBufferSnapshot` preload type includes `alternateScreen`.
- `src/renderer/src/components/terminal-pane/pty-dispatcher.ts` — `PtyBufferSnapshot` type gains `alternateScreen`.
- `src/renderer/src/components/terminal-pane/pty-connection.ts` — `applyMainBufferSnapshot` skips the destructive clear when `snapshot.alternateScreen`, mirroring the existing `pty-transport.ts` guard.

Note: alt-screen serialization already forces `scrollbackRows=0`, so the snapshot only contains the current alt-screen frame; replaying it without the preceding clear simply repaints over the preserved xterm buffer (same as the attach path).

This re-implements the diagnosis/design from the closed community PR #5786 cleanly against the current code shape.

## Evidence

### Regression test — BEFORE fix (fails)

New test `preserves scrollback by skipping the destructive clear when restoring an alternate-screen snapshot` in `pty-connection.test.ts`:

```
AssertionError: expected "vi.fn()" to not be called with arguments: [ '[2J[3J[H', ... ]
Received:
  1st vi.fn() call:
  [ "<ESC>[2J<ESC>[3J<ESC>[H", [Function anonymous] ]
  ...
 fail src/renderer/src/components/terminal-pane/pty-connection.test.ts:6160:37
    6160|     expect(pane.terminal.write).not.toHaveBeenCalledWith(

 Test Files  1 failed (1)
      Tests  1 failed | 197 skipped (198)
```

### Regression test — AFTER fix (passes)

```
$ vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "snapshot"
 Test Files  1 passed (1)
      Tests  23 passed | 175 skipped (198)
```

(includes the new alt-screen test AND the pre-existing normal-buffer test which still asserts the clear IS emitted)

### Affected test files

```
$ vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/pty-connection.test.ts \
    src/main/ipc/pty.test.ts \
    src/renderer/src/components/terminal-pane/pty-transport.test.ts

 Test Files  1 failed | 2 passed (3)
      Tests  5 failed | 410 passed | 11 skipped (426)
```

The 5 failures are all in `pty.test.ts`, are about git/gh attribution-shim PATH ordering (`win32` vs `posix` delimiters), and are unrelated to this change. Verified pre-existing on the clean baseline (`git stash` -> same 5 failures: `5 failed | 168 passed | 11 skipped`).

### Lint

```
$ pnpm lint
oxlint              -> clean (only warning is in useGitStatusPolling.ts — untouched, pre-existing)
lint:switch-exhaustiveness -> clean
check-styled-scrollbars    -> clean
verify:localization-catalog -> clean
verify:localization-coverage -> clean
```

### Typecheck

```
$ pnpm typecheck
> tsgo --noEmit -p config/tsconfig.node.json && tsgo --noEmit -p config/tsconfig.tc.cli.json && tsgo --noEmit -p config/tsconfig.tc.web.json
(clean — no errors)
```
