### PR TITLE
Fix Ctrl+C copy in Markdown Source (Monaco) mode

### DIFF
--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -833,6 +833,71 @@ describe('keybindings', () => {
     })
   })
 
+  it('matches letter shortcuts on non-Latin layouts via the physical code (issue #6274)', () => {
+    // Cyrillic ЙЦУКЕН: physical C produces the logical key 'с' (Cyrillic es,
+    // U+0441) while code stays 'KeyC'. The produced character is not a Latin
+    // shortcut letter, so the chord must still match through the physical code.
+    const cyrillicCtrlC = {
+      key: 'с',
+      code: 'KeyC',
+      control: true,
+      meta: false,
+      alt: false,
+      shift: false
+    }
+    expect(keybindingMatchesAction('browser.grabElement', cyrillicCtrlC, 'win32')).toBe(true)
+    expect(keybindingMatchesAction('browser.grabElement', cyrillicCtrlC, 'linux')).toBe(true)
+
+    // Ctrl+Shift+C on the same layout (terminal copy) must match too.
+    expect(
+      keybindingMatchesAction(
+        'terminal.copySelection',
+        { ...cyrillicCtrlC, shift: true },
+        'win32'
+      )
+    ).toBe(true)
+
+    // Greek layout: physical P produces 'π' (U+03C0); Ctrl+P must still match.
+    expect(
+      keybindingMatchesAction(
+        'worktree.quickOpen',
+        { key: 'π', code: 'KeyP', control: true, meta: false, alt: false, shift: false },
+        'win32'
+      )
+    ).toBe(true)
+
+    // The fallback must not steal a different physical key: Ctrl+V (physical V,
+    // Cyrillic 'м') is not Ctrl+C, so grabElement must stay unmatched.
+    expect(
+      keybindingMatchesAction(
+        'browser.grabElement',
+        { key: 'м', code: 'KeyV', control: true, meta: false, alt: false, shift: false },
+        'win32'
+      )
+    ).toBe(false)
+  })
+
+  it('does not let non-Latin physical fallback hijack AltGr text input (issue #6274)', () => {
+    // Windows/Linux AltGr arrives as Ctrl+Alt. A composed character typed via
+    // AltGr (e.g. AltGr+C) must remain text input, never an app shortcut.
+    // editor.copyContext is Mod+Alt+C, so the modifier state otherwise matches —
+    // only the AltGr key gating may keep this from firing.
+    expect(
+      keybindingMatchesAction(
+        'editor.copyContext',
+        {
+          key: '¢',
+          code: 'KeyC',
+          control: true,
+          meta: false,
+          alt: true,
+          shift: false
+        },
+        'win32'
+      )
+    ).toBe(false)
+  })
+
   it('uses shifted punctuation aliases only while Shift is pressed', () => {
     const shiftedComma = {
       key: '<',

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1483,6 +1483,51 @@ function canUsePhysicalCodeFallback(input: KeybindingInput): boolean {
   return PHYSICAL_CODE_FALLBACK_KEYS.has(input.key ?? '')
 }
 
+function isLatinShortcutKey(key: string): boolean {
+  // Why: A-Z / 0-9 are the only single chars a Latin shortcut token names; any
+  // other produced character (Cyrillic с, Greek π, ...) cannot be a deliberate
+  // remap of a Latin chord, so it is safe to fall back to the physical code.
+  if (key.length !== 1) {
+    return false
+  }
+  const upper = key.toUpperCase()
+  return (upper >= 'A' && upper <= 'Z') || (key >= '0' && key <= '9')
+}
+
+function shouldUseNonLatinShortcutPhysicalFallback(
+  input: KeybindingInput,
+  platform: NodeJS.Platform
+): boolean {
+  // Why: non-Latin layouts (Cyrillic, Greek, ...) report a non-Latin logical key
+  // for physical letter keys (issue #6274), so Ctrl/Meta shortcuts never match.
+  // Fall back to the physical code, but only when no logical shortcut token
+  // exists, a real primary modifier (Ctrl or Meta) is held, and this is not an
+  // AltGr (Ctrl+Alt) text-composition event. macOS is excluded — it already has
+  // dedicated Option-composed fallbacks and Cmd shortcuts are layout-stable.
+  if (getKeybindingPlatform(platform) === 'darwin') {
+    return false
+  }
+  const hasPrimaryModifier = hasModifier(input, 'control') || hasModifier(input, 'meta')
+  if (!hasPrimaryModifier) {
+    return false
+  }
+  // AltGr surfaces as Ctrl+Alt on Windows/Linux; treat it as text, not a chord.
+  if (hasModifier(input, 'control') && hasModifier(input, 'alt')) {
+    return false
+  }
+  if (logicalKeyTokenFromInput(input) !== null) {
+    return false
+  }
+  const key = input.key ?? ''
+  return key !== '' && !MODIFIER_KEYS.has(key) && !isLatinShortcutKey(key)
+}
+
+function canFallBackToPhysicalCode(input: KeybindingInput, platform: NodeJS.Platform): boolean {
+  return (
+    canUsePhysicalCodeFallback(input) || shouldUseNonLatinShortcutPhysicalFallback(input, platform)
+  )
+}
+
 function physicalCodeKeyTokenFromInput(input: KeybindingInput): string | null {
   const code = input.code ?? ''
   if (code.startsWith('Key') && code.length === 4) {
@@ -1534,7 +1579,8 @@ function keyTokenFromInput(input: KeybindingInput, platform: NodeJS.Platform): s
   }
   if (
     !canUsePhysicalCodeFallback(input) &&
-    !shouldUseMacOptionComposedCaptureFallback(input, platform)
+    !shouldUseMacOptionComposedCaptureFallback(input, platform) &&
+    !shouldUseNonLatinShortcutPhysicalFallback(input, platform)
   ) {
     return null
   }
@@ -1764,18 +1810,22 @@ function letterKeyMatches(
     return logicalKey === letter.toUpperCase()
   }
   return (
-    (canUsePhysicalCodeFallback(input) ||
+    (canFallBackToPhysicalCode(input, platform) ||
       shouldUseMacOptionLetterPhysicalFallback(parsed, input, platform)) &&
     input.code === `Key${letter.toUpperCase()}`
   )
 }
 
-function digitKeyMatches(input: KeybindingInput, digit: string): boolean {
+function digitKeyMatches(
+  input: KeybindingInput,
+  digit: string,
+  platform: NodeJS.Platform
+): boolean {
   const logicalKey = logicalKeyTokenFromInput(input)
   if (logicalKey && logicalKey.length === 1 && logicalKey >= '0' && logicalKey <= '9') {
     return logicalKey === digit
   }
-  return canUsePhysicalCodeFallback(input) && input.code === `Digit${digit}`
+  return canFallBackToPhysicalCode(input, platform) && input.code === `Digit${digit}`
 }
 
 function isPunctuationKeyToken(token: string | null): token is string {
@@ -1823,7 +1873,7 @@ function keyMatches(
     return letterKeyMatches(input, parsedKey, parsed, platform)
   }
   if (parsedKey.length === 1 && parsedKey >= '0' && parsedKey <= '9') {
-    return digitKeyMatches(input, parsedKey)
+    return digitKeyMatches(input, parsedKey, platform)
   }
 
   if (parsedKey === 'NumpadAdd' || parsedKey === 'NumpadSubtract') {
@@ -1844,7 +1894,7 @@ function keyMatches(
       return semanticKey === parsedKey
     }
     return (
-      (canUsePhysicalCodeFallback(input) ||
+      (canFallBackToPhysicalCode(input, platform) ||
         shouldUseMacOptionPunctuationPhysicalFallback(parsed, input, platform)) &&
       physicalPunctuationKey(input) === parsedKey
     )
@@ -1854,7 +1904,9 @@ function keyMatches(
   if (logicalKey !== null) {
     return logicalKey === parsedKey
   }
-  return canUsePhysicalCodeFallback(input) && physicalCodeKeyTokenFromInput(input) === parsedKey
+  return (
+    canFallBackToPhysicalCode(input, platform) && physicalCodeKeyTokenFromInput(input) === parsedKey
+  )
 }
 
 function resolveModifierToken(
@@ -1928,10 +1980,10 @@ export function keybindingMatchesAction(
   )
 }
 
-function digitFromInput(input: KeybindingInput): string | null {
+function digitFromInput(input: KeybindingInput, platform: NodeJS.Platform): string | null {
   for (let value = 1; value <= 9; value++) {
     const digit = String(value)
-    if (digitKeyMatches(input, digit)) {
+    if (digitKeyMatches(input, digit, platform)) {
       return digit
     }
   }
@@ -1954,7 +2006,7 @@ export function matchKeybindingDigitIndex(
   if (!definition || !keybindingIsActiveInContext(definition, options)) {
     return null
   }
-  const digit = digitFromInput(input)
+  const digit = digitFromInput(input, platform)
   if (!digit) {
     return null
   }


### PR DESCRIPTION
## Summary

Fixes #6274.

In a Markdown file's **Source** mode (Monaco), pressing **Ctrl+C** copied nothing to the clipboard; only right-click → Copy worked. The same press worked fine in **Rich Editor** (TipTap) mode. The bug was also reported on ABNT2 (Windows) and Cyrillic (Linux) layouts, and users noted the copy shortcut could not even be re-bound in Settings.

### Root cause

Orca's central shortcut matcher (`src/shared/keybindings.ts`) resolves letter/digit/punctuation chords from the **produced logical key** (`KeyboardEvent.key`). That is correct for text-aware layouts (e.g. Dvorak, where the user sees the produced Latin character on the cap). A physical-code (`KeyboardEvent.code`) fallback existed, but it was gated to only fire when `event.key` was empty / `Dead` / `Unidentified`.

On a **non-Latin layout** the physical letter keys report a non-Latin character — e.g. physical `C` produces `event.key = 'с'` (Cyrillic es) while `event.code = 'KeyC'`. `'с'` normalizes to no shortcut token, and the old fallback gate did not consider `'с'` "unavailable", so:

- `Ctrl+C` / `Ctrl+Shift+C` / `Ctrl+P` / `Ctrl+F` etc. never matched their actions, and
- the Settings recorder produced no key token, so the chord could not be re-bound.

This is layout-dependence in the matcher, not a Monaco- or copy-specific handler — copy is just the most visible casualty.

### The change

Add a narrowly-scoped physical-code fallback (`shouldUseNonLatinShortcutPhysicalFallback`) that activates **only** when **all** of these hold:

- platform is **not** macOS (macOS already has dedicated Option-composed fallbacks and layout-stable Cmd chords);
- a real **primary** modifier is held (`Ctrl` or `Meta`);
- the event is **not** AltGr — on Windows/Linux AltGr surfaces as `Ctrl+Alt`, which is text composition, not a chord;
- the produced `event.key` yields **no** logical shortcut token and is **not** a single Latin `A–Z` / `0–9` char (so deliberate Latin remaps like Dvorak keep matching by logical key, unchanged).

The same predicate is threaded into the Settings capture path so non-Latin users can also re-bind shortcuts. Latin / Dvorak / IME-composed behavior is unchanged.

### Files changed

- `src/shared/keybindings.ts` — fallback predicate + wiring into letter/digit/punctuation/default matching and the capture path.
- `src/shared/keybindings.test.ts` — regression tests.

## Evidence

### Regression test — BEFORE fix (fails)

Test added, source fix reverted:

```
 ❯ src/shared/keybindings.test.ts (55 tests | 1 failed | 53 skipped)
     × matches letter shortcuts on non-Latin layouts via the physical code (issue #6274)

 FAIL  src/shared/keybindings.test.ts > keybindings > matches letter shortcuts on non-Latin layouts via the physical code (issue #6274)
 AssertionError: expected false to be true // Object.is equality
 - Expected  + Received
 - true
 + false
   ❯ src/shared/keybindings.test.ts:848  expect(keybindingMatchesAction('browser.grabElement', cyrillicCtrlC, 'win32')).toBe(true)
      Tests  1 failed | 1 passed | 53 skipped (55)
```

### Regression test — AFTER fix (passes)

```
 RUN  v4.1.5

 ✓ src/shared/keybindings.test.ts (55 tests)
   ✓ matches letter shortcuts on non-Latin layouts via the physical code (issue #6274)
   ✓ does not let non-Latin physical fallback hijack AltGr text input (issue #6274)

 Test Files  1 passed (1)
      Tests  55 passed (55)
```

Related matcher suites (no regressions):

```
 Test Files  5 passed (5)
      Tests  125 passed (125)
  (keybindings, window-shortcut-policy, terminal-shortcut-policy, xterm-bypass-policy, main/ipc keybindings)
```

### Lint (changed files clean)

```
$ pnpm lint
> oxlint && lint:switch-exhaustiveness && check-styled-scrollbars && verify:localization-catalog && verify:localization-coverage
(oxlint: no findings in src/shared/keybindings.ts or keybindings.test.ts)
Verified 9153 localization key references against en.json.
Localization coverage check passed with 0 allowlisted candidates.
```

### Typecheck (clean)

```
$ pnpm typecheck
> tsgo --noEmit -p config/tsconfig.node.json && tsgo --noEmit -p config/tsconfig.tc.cli.json && tsgo --noEmit -p config/tsconfig.tc.web.json
(no errors)
```

### Manual verification

`keybindingMatchesAction` is the single matcher used by the Monaco editor copy path, the App/terminal global handlers, and the main-process `before-input-event` resolver. On a Cyrillic layout, physical `Ctrl+C` (`{ key: 'с', code: 'KeyC' }`) now resolves the copy chord (verified via the new unit tests across `win32` and `linux`); AltGr composition (`{ key: '¢', code: 'KeyC', control: true, alt: true }`) stays text input. The pre-existing `remote-runtime-shared-control-connection` keepalive-timeout test is flaky on a clean checkout independent of this change.

> Note: triage rejected community PR #6365 as not credibly fixing this; this PR was root-caused and implemented independently.
