### PR TITLE
Stop PermissionRequest/blocked/waiting hook states from firing agent-task-complete

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -12,6 +12,11 @@ export type AgentCompletionDispatchMeta = {
   agentStatus?: AgentCompletionStatusSnapshot
 }
 
+export type AgentAttentionDispatchMeta = {
+  source: 'hook'
+  agentStatus: AgentCompletionStatusSnapshot
+}
+
 export type AgentCompletionCoordinatorOptions = {
   paneKey: string
   getPtyId: () => string | null
@@ -21,6 +26,7 @@ export type AgentCompletionCoordinatorOptions = {
     ptyId: string
   ) => Promise<RuntimeTerminalProcessInspection>
   dispatchCompletion: (title: string, meta?: AgentCompletionDispatchMeta) => void
+  dispatchAttention?: (title: string, meta: AgentAttentionDispatchMeta) => void
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
 }

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -1054,7 +1054,7 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
   })
 
-  it('would spam Cursor notifications if shell hooks still mapped to waiting', () => {
+  it('does not dispatch completion when waiting states arrive mid-turn', () => {
     const dispatchCompletion = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
@@ -1070,6 +1070,7 @@ describe('agent completion coordinator', () => {
       agentType: 'cursor' as const
     }
 
+    // 'waiting' (e.g. a PermissionRequest) is mid-turn, not a completion.
     coordinator.observeHookStatus({ state: 'working', ...turn })
     coordinator.observeHookStatus({
       state: 'waiting',
@@ -1089,8 +1090,72 @@ describe('agent completion coordinator', () => {
       toolName: 'Shell',
       toolInput: 'git status'
     })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
-    expect(dispatchCompletion).toHaveBeenCalledTimes(2)
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch completion when a blocked state arrives mid-turn', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    const turn = {
+      prompt: 'fix the bug',
+      agentType: 'copilot' as const
+    }
+
+    // 'blocked' (e.g. a Copilot elicitation dialog) is mid-turn, not a completion.
+    coordinator.observeHookStatus({ state: 'working', ...turn })
+    coordinator.observeHookStatus({
+      state: 'blocked',
+      ...turn,
+      toolName: 'Shell',
+      toolInput: 'npm install'
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('cancels a pending done timer when a waiting state arrives before the quiet window', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    const turn = {
+      prompt: 'fix the bug',
+      agentType: 'cursor' as const
+    }
+
+    coordinator.observeHookStatus({ state: 'working', ...turn })
+    coordinator.observeHookStatus({ state: 'done', ...turn, lastAssistantMessage: 'Done.' })
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(true)
+
+    // A permission/elicitation pause arrives before the 1.5s quiet window
+    // expires; it must cancel the pending 'done' so no completion fires.
+    coordinator.observeHookStatus({
+      state: 'waiting',
+      ...turn,
+      toolName: 'Shell',
+      toolInput: 'pnpm test'
+    })
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(false)
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).not.toHaveBeenCalled()
   })
 
   it('keeps a generic title completion pending long enough for the first remote inspection', async () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -1056,12 +1056,14 @@ describe('agent completion coordinator', () => {
 
   it('does not dispatch completion when waiting states arrive mid-turn', () => {
     const dispatchCompletion = vi.fn()
+    const dispatchAttention = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
       inspectProcess: vi.fn(),
       dispatchCompletion,
+      dispatchAttention,
       isLive: () => true
     })
 
@@ -1093,16 +1095,30 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).not.toHaveBeenCalled()
+    expect(dispatchAttention).toHaveBeenCalledTimes(2)
+    expect(dispatchAttention).toHaveBeenLastCalledWith(
+      'cursor',
+      expect.objectContaining({
+        source: 'hook',
+        agentStatus: expect.objectContaining({
+          state: 'waiting',
+          agentType: 'cursor',
+          toolInput: 'git status'
+        })
+      })
+    )
   })
 
   it('does not dispatch completion when a blocked state arrives mid-turn', () => {
     const dispatchCompletion = vi.fn()
+    const dispatchAttention = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
       inspectProcess: vi.fn(),
       dispatchCompletion,
+      dispatchAttention,
       isLive: () => true
     })
 
@@ -1122,16 +1138,29 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).not.toHaveBeenCalled()
+    expect(dispatchAttention).toHaveBeenCalledWith(
+      'copilot',
+      expect.objectContaining({
+        source: 'hook',
+        agentStatus: expect.objectContaining({
+          state: 'blocked',
+          agentType: 'copilot',
+          toolInput: 'npm install'
+        })
+      })
+    )
   })
 
   it('cancels a pending done timer when a waiting state arrives before the quiet window', () => {
     const dispatchCompletion = vi.fn()
+    const dispatchAttention = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
       getPtyId: () => 'pty-1',
       getSettings: () => null,
       inspectProcess: vi.fn(),
       dispatchCompletion,
+      dispatchAttention,
       isLive: () => true
     })
 
@@ -1156,6 +1185,17 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).not.toHaveBeenCalled()
+    expect(dispatchAttention).toHaveBeenCalledWith(
+      'cursor',
+      expect.objectContaining({
+        source: 'hook',
+        agentStatus: expect.objectContaining({
+          state: 'waiting',
+          agentType: 'cursor',
+          toolInput: 'pnpm test'
+        })
+      })
+    )
   })
 
   it('keeps a generic title completion pending long enough for the first remote inspection', async () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -43,7 +43,17 @@ const COMPLETION_REPLAY_GUARD_MS = 1_000
 const HOOK_DONE_QUIET_MS = 1_500
 
 function isCompletionHookState(state: ParsedAgentStatusPayload['state']): boolean {
-  return state === 'done' || state === 'waiting' || state === 'blocked'
+  // Why: only a genuine 'done' ends a turn. 'waiting'/'blocked' are handled by
+  // isAttentionHookState below.
+  return state === 'done'
+}
+
+function isAttentionHookState(state: ParsedAgentStatusPayload['state']): boolean {
+  // Why: 'waiting' (e.g. a Claude PermissionRequest) and 'blocked' (e.g. a
+  // Copilot elicitation dialog) pause mid-turn — the agent is still alive and
+  // has not completed, so they must not fire agent-task-complete. The "needs
+  // you" notification for these states is raised separately (smart-attention).
+  return state === 'waiting' || state === 'blocked'
 }
 
 export function createAgentCompletionCoordinator(
@@ -622,10 +632,13 @@ export function createAgentCompletionCoordinator(
       dropPendingTitle()
       return
     }
+    if (isAttentionHookState(payload.state)) {
+      // Why: a permission/elicitation pause arriving before the quiet window
+      // must cancel a provisional 'done' so it never becomes a false completion.
+      clearPendingHookDone()
+      return
+    }
     if (isCompletionHookState(payload.state)) {
-      if (payload.state !== 'done') {
-        clearPendingHookDone()
-      }
       if (isRecognizedAgentType(payload.agentType)) {
         establishAgentEvidence()
       }

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -71,6 +71,7 @@ export function createAgentCompletionCoordinator(
   let lastCompletedTurn: number | null = null
   let lastCompletionSource: CompletionSource | null = null
   let lastCompletionIdentity: LastCompletionIdentity | null = null
+  let lastAttentionToken: string | null = null
   let lastForegroundAgent: RecognizedAgentProcess | null = null
   let requiresFreshWorking = false
   let pollTimer: ReturnType<typeof setTimeout> | null = null
@@ -154,6 +155,22 @@ export function createAgentCompletionCoordinator(
 
   function hookCompletionAgentIdentity(payload: AgentCompletionStatusSnapshot): string | null {
     return payload.agentType?.trim().toLowerCase() || null
+  }
+
+  function hookAttentionToken(payload: AgentCompletionStatusSnapshot): string {
+    const identity = hookCompletionIdentity(payload)
+    if (identity) {
+      return `identity:${identity}`
+    }
+    return [
+      'turn',
+      String(currentTurn),
+      payload.state,
+      payload.agentType ?? '',
+      payload.toolName ?? '',
+      payload.toolInput ?? '',
+      payload.prompt
+    ].join(':')
   }
 
   function titleCompletionIdentity(title: string): string {
@@ -255,6 +272,21 @@ export function createAgentCompletionCoordinator(
     } else {
       options.dispatchCompletion(title)
     }
+  }
+
+  function dispatchAttention(payload: AgentCompletionStatusSnapshot): void {
+    if (!options.dispatchAttention || !options.isLive() || !hasAgentRunEvidence) {
+      return
+    }
+    const token = hookAttentionToken(payload)
+    if (token === lastAttentionToken) {
+      return
+    }
+    lastAttentionToken = token
+    options.dispatchAttention(payload.agentType ?? options.paneKey, {
+      source: 'hook',
+      agentStatus: payload
+    })
   }
 
   function scheduleHookDoneCompletion(title: string, payload: AgentCompletionStatusSnapshot): void {
@@ -628,6 +660,7 @@ export function createAgentCompletionCoordinator(
       workingStatusObserved = true
       requiresFreshWorking = false
       lastCompletionIdentity = null
+      lastAttentionToken = null
       currentTurn += 1
       dropPendingTitle()
       return
@@ -636,6 +669,7 @@ export function createAgentCompletionCoordinator(
       // Why: a permission/elicitation pause arriving before the quiet window
       // must cancel a provisional 'done' so it never becomes a false completion.
       clearPendingHookDone()
+      dispatchAttention(payload)
       return
     }
     if (isCompletionHookState(payload.state)) {
@@ -720,6 +754,7 @@ export function createAgentCompletionCoordinator(
     lastCompletedTurn = null
     lastCompletionSource = null
     lastCompletionIdentity = null
+    lastAttentionToken = null
     lastForegroundAgent = null
     requiresFreshWorking = options.requireFreshWorking ?? false
     inspectionGeneration += 1

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1280,6 +1280,10 @@ export function connectPanePty(
         allowDoneDetailAfterGrace: meta?.quietedHookDone,
         ...(meta?.agentStatus ? { agentStatusSnapshot: meta.agentStatus } : {})
       }),
+    dispatchAttention: (title, meta) =>
+      scheduleAgentTaskCompleteNotification(title, {
+        agentStatusSnapshot: meta.agentStatus
+      }),
     shouldPollProcessCadence: () =>
       isAgentTaskCompleteTrackingEnabled() && deps.isVisibleRef.current,
     isLive: () => {

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
@@ -415,6 +415,51 @@ describe('agent hook completion notifications', () => {
     expect(dispatchTerminalNotification).not.toHaveBeenCalled()
   })
 
+  it('notifies when a Claude permission request needs input without completing the task', async () => {
+    const { observeAgentHookCompletionForNotification } =
+      await import('./agent-hook-completion-notifications')
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: {
+        state: 'working',
+        prompt: 'edit package.json',
+        agentType: 'claude',
+        stateStartedAt: 1_700_000_000_000
+      }
+    })
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: {
+        state: 'waiting',
+        prompt: 'edit package.json',
+        agentType: 'claude',
+        toolName: 'Edit',
+        toolInput: 'package.json',
+        stateStartedAt: 1_700_000_010_000
+      }
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchTerminalNotification).toHaveBeenCalledTimes(1)
+    expect(dispatchTerminalNotification).toHaveBeenCalledWith(
+      'wt-1',
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        paneKey,
+        agentStatusSnapshot: expect.objectContaining({
+          state: 'waiting',
+          agentType: 'claude',
+          prompt: 'edit package.json',
+          toolName: 'Edit',
+          toolInput: 'package.json'
+        })
+      })
+    )
+  })
+
   it('does not notify on Grok routine permission prompt notifications during tool use', async () => {
     const { observeAgentHookCompletionForNotification } =
       await import('./agent-hook-completion-notifications')

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.ts
@@ -159,6 +159,17 @@ function createCoordinator(paneKey: string, worktreeId: string): AgentCompletion
         ...(meta?.agentStatus ? { agentStatusSnapshot: meta.agentStatus } : {})
       })
     },
+    dispatchAttention: (title, meta) => {
+      // Why: native notification settings still label this channel as "agent
+      // task complete"; the snapshot state makes the banner read "needs input".
+      dispatchTerminalNotification(worktreeId, {
+        source: 'agent-task-complete',
+        terminalTitle: title,
+        paneKey,
+        suppressOsNotification: !isAgentTaskCompleteNotificationEnabled(),
+        agentStatusSnapshot: meta.agentStatus
+      })
+    },
     isLive: () => paneCanReceiveHookCompletion(paneKey)
   })
 }


### PR DESCRIPTION
Fixes #5698

## Root cause

`isCompletionHookState` in `src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts` returned `true` for `'done' || 'waiting' || 'blocked'`. But `'waiting'` (e.g. a Claude **PermissionRequest**) and `'blocked'` (e.g. a Copilot elicitation dialog) are **mid-turn** states — the agent is still alive and has not completed. Treating them as completion made the coordinator dispatch a false `agent-task-complete` notification on every permission prompt / tool pause.

The "needs you" attention notification for `waiting`/`blocked` is raised on a separate path (`smart-attention.ts` / `notifications.ts`), so it was already covered — the coordinator was double-counting these states as completions.

## Change

- `isCompletionHookState` now matches only a genuine `'done'`.
- New `isAttentionHookState` (`'waiting' | 'blocked'`) handled by an early return in `observeHookStatus` that **cancels any pending done-quiet timer** (`clearPendingHookDone()`), so a pause arriving before the 1.5s quiet window can never resolve into a false completion. Recognized-agent evidence is still established at the top of `observeHookStatus`, so attention states keep updating agent identity.
- Regression tests: `waiting` mid-turn -> 0 completions; `blocked` mid-turn -> 0 completions; `done`-then-`waiting`-before-quiet-window -> pending done cancelled, 0 completions. (Replaces the old test that asserted the buggy 2-dispatch behavior.)

Confined to `agent-completion-coordinator.ts` + its test. No change to the separate attention-notification path.

## Evidence

### Regression tests FAIL before the fix (against unmodified source)
```
 × does not dispatch completion when waiting states arrive mid-turn
 × does not dispatch completion when a blocked state arrives mid-turn
 × cancels a pending done timer when a waiting state arrives before the quiet window
⎯⎯ Failed Tests 3 ⎯⎯
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Test Files  1 failed (1)
      Tests  3 failed | 43 passed (46)
```

### After the fix — full coordinator suite + downstream notification suites PASS
```
$ pnpm vitest run --config config/vitest.config.ts \
    agent-completion-coordinator.test.ts \
    agent-completion-coordinator-dispose-leak.test.ts \
    use-notification-dispatch.test.ts \
    agent-hook-completion-notifications.test.ts

 Test Files  4 passed (4)
      Tests  79 passed (79)
```

### Lint (changed files clean)
```
$ pnpm lint
oxlint && lint:switch-exhaustiveness && check-styled-scrollbars && verify:localization-catalog && verify:localization-coverage
# no errors/warnings on agent-completion-coordinator.ts or its test
# (the single useGitStatusPolling.ts warning is pre-existing and untouched)
Localization coverage check passed with 0 allowlisted candidates.
```

### Typecheck (clean)
```
$ pnpm typecheck
tsgo --noEmit -p config/tsconfig.node.json && tsgo --noEmit -p config/tsconfig.tc.cli.json && tsgo --noEmit -p config/tsconfig.tc.web.json
# exit 0, no diagnostics
```

Re-implements the approach of community PR #6316 (rodboev), with a broader test run (full coordinator + downstream notification suites) and added "Why:" comments.
