### PR TITLE
Disable Kitty enhanced keyboard protocol for local Windows ConPTY terminals

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/pane-manager/pane-terminal-options'
 import { normalizeTerminalTuiMouseWheelMultiplier } from '@/lib/pane-manager/pane-terminal-mouse-wheel'
 import { buildWindowsPtyCompatibilityOptions } from '@/lib/pane-manager/windows-pty-compatibility'
+import { buildTerminalKeyboardProtocolOptions } from '@/lib/pane-manager/terminal-keyboard-protocol'
 import { useAppStore } from '@/store'
 import {
   createFilePathLinkProvider,
@@ -1136,16 +1137,23 @@ export function useTerminalPaneLifecycle({
           (candidate) => candidate.id === tabId
         )
         const platformInfo = window.api.platform?.get?.()
-        const windowsPtyCompatibilityOptions = buildWindowsPtyCompatibilityOptions({
+        const ptyBackendContext = {
           userAgent: navigator.userAgent,
           osRelease: platformInfo?.osRelease,
           connectionId: getConnectionId(worktreeId),
           cwd: startupCwd,
           shellOverride: currentTab?.shellOverride,
           executionHostId: getExecutionHostIdForWorktree(storeState, worktreeId)
-        })
+        }
+        const windowsPtyCompatibilityOptions =
+          buildWindowsPtyCompatibilityOptions(ptyBackendContext)
+        // Why: local Windows ConPTY CLIs read the Kitty keyboard advertisement but
+        // do not decode CSI-u, so withhold it there to restore Enter/Up/Down nav
+        // (issue #2434); SSH and macOS/Linux panes keep enhanced reporting.
+        const keyboardProtocolOptions = buildTerminalKeyboardProtocolOptions(ptyBackendContext)
         return {
           ...windowsPtyCompatibilityOptions,
+          ...keyboardProtocolOptions,
           fontSize: currentSettings?.terminalFontSize ?? 14,
           fontFamily: buildFontFamily(currentSettings?.terminalFontFamily ?? ''),
           fontWeight: terminalFontWeights.fontWeight,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -15,6 +15,7 @@ import {
   normalizeTerminalScrollSensitivity,
   resolveTerminalCursorInactiveStyle
 } from './pane-terminal-options'
+import { buildTerminalKeyboardProtocolOptions } from './terminal-keyboard-protocol'
 
 const webglMock = vi.hoisted(() => ({
   contextLossHandler: null as (() => void) | null,
@@ -123,6 +124,51 @@ describe('buildDefaultTerminalOptions', () => {
     // bytes once the terminal advertises support. Regressing this flag
     // silently breaks enhanced chords, especially inside tmux.
     expect(buildDefaultTerminalOptions().vtExtensions?.kittyKeyboard).toBe(true)
+  })
+
+  it('lets a local Windows ConPTY pane override the default and withhold kitty keyboard', () => {
+    // Regression for #2434: per-pane options merge over the default the same way
+    // createPaneDOM merges them, so a local Windows ConPTY override must win and
+    // turn the advertised kittyKeyboard off (CSI-u-blind local CLIs ignore nav keys).
+    const merged = {
+      ...buildDefaultTerminalOptions(),
+      ...buildTerminalKeyboardProtocolOptions({
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        osRelease: '10.0.26100',
+        connectionId: null,
+        cwd: 'C:\\repo',
+        shellOverride: 'powershell.exe',
+        executionHostId: 'local'
+      })
+    }
+
+    expect(merged.vtExtensions?.kittyKeyboard).toBe(false)
+  })
+
+  it('keeps the advertised kitty keyboard default for SSH and macOS/Linux panes', () => {
+    for (const context of [
+      {
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        connectionId: 'ssh-1',
+        cwd: 'C:\\repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      },
+      {
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)',
+        connectionId: null,
+        cwd: '/repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      }
+    ] as const) {
+      const merged = {
+        ...buildDefaultTerminalOptions(),
+        ...buildTerminalKeyboardProtocolOptions(context)
+      }
+
+      expect(merged.vtExtensions?.kittyKeyboard).toBe(true)
+    }
   })
 })
 

--- a/src/renderer/src/lib/pane-manager/terminal-keyboard-protocol.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-keyboard-protocol.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTerminalKeyboardProtocolOptions,
+  shouldDisableKittyKeyboardForTerminal
+} from './terminal-keyboard-protocol'
+
+const WINDOWS_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+const MAC_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)'
+const LINUX_UA = 'Mozilla/5.0 (X11; Linux x86_64)'
+
+describe('shouldDisableKittyKeyboardForTerminal', () => {
+  it('disables Kitty keyboard for a local native Windows ConPTY pane', () => {
+    // Regression for #2434: local Windows CLIs (e.g. Antigravity agy) read the
+    // advertisement but do not decode CSI-u, so enhanced reporting swallows
+    // Enter/Up/Down navigation. The advertisement must be withheld here.
+    expect(
+      shouldDisableKittyKeyboardForTerminal({
+        userAgent: WINDOWS_UA,
+        osRelease: '10.0.26100',
+        connectionId: null,
+        cwd: 'C:\\repo',
+        shellOverride: 'powershell.exe',
+        executionHostId: 'local'
+      })
+    ).toBe(true)
+  })
+
+  it('keeps Kitty keyboard for an SSH-backed Windows-client pane', () => {
+    expect(
+      shouldDisableKittyKeyboardForTerminal({
+        userAgent: WINDOWS_UA,
+        osRelease: '10.0.26100',
+        connectionId: 'ssh-1',
+        cwd: 'C:\\repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      })
+    ).toBe(false)
+  })
+
+  it('keeps Kitty keyboard for an SSH-runtime pane on a Windows client', () => {
+    expect(
+      shouldDisableKittyKeyboardForTerminal({
+        userAgent: WINDOWS_UA,
+        osRelease: '10.0.26100',
+        connectionId: null,
+        cwd: 'C:\\repo',
+        shellOverride: null,
+        executionHostId: 'ssh:my-host'
+      })
+    ).toBe(false)
+  })
+
+  it('keeps Kitty keyboard for a serve/remote-runtime pane on a Windows client', () => {
+    // A serve pane has no SSH connectionId and a Linux cwd, so the raw Windows
+    // heuristic matches; the execution-host gate must still preserve enhanced
+    // reporting for the remote Linux PTY that decodes CSI-u correctly.
+    expect(
+      shouldDisableKittyKeyboardForTerminal({
+        userAgent: WINDOWS_UA,
+        osRelease: '10.0.26100',
+        connectionId: null,
+        cwd: '/home/me/workspaces/repo',
+        shellOverride: null,
+        executionHostId: 'runtime:my-serve'
+      })
+    ).toBe(false)
+  })
+
+  it('keeps Kitty keyboard for a WSL pane on a Windows client', () => {
+    expect(
+      shouldDisableKittyKeyboardForTerminal({
+        userAgent: WINDOWS_UA,
+        osRelease: '10.0.26100',
+        connectionId: null,
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      })
+    ).toBe(false)
+  })
+
+  it('keeps Kitty keyboard on macOS', () => {
+    expect(
+      shouldDisableKittyKeyboardForTerminal({
+        userAgent: MAC_UA,
+        osRelease: '23.0.0',
+        connectionId: null,
+        cwd: '/repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      })
+    ).toBe(false)
+  })
+
+  it('keeps Kitty keyboard on Linux', () => {
+    expect(
+      shouldDisableKittyKeyboardForTerminal({
+        userAgent: LINUX_UA,
+        osRelease: '6.5.0',
+        connectionId: null,
+        cwd: '/repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      })
+    ).toBe(false)
+  })
+})
+
+describe('buildTerminalKeyboardProtocolOptions', () => {
+  it('withholds the Kitty keyboard advertisement for a local Windows ConPTY pane', () => {
+    expect(
+      buildTerminalKeyboardProtocolOptions({
+        userAgent: WINDOWS_UA,
+        osRelease: '10.0.26100',
+        connectionId: null,
+        cwd: 'C:\\repo',
+        shellOverride: 'powershell.exe',
+        executionHostId: 'local'
+      })
+    ).toEqual({ vtExtensions: { kittyKeyboard: false } })
+  })
+
+  it('returns no override for SSH panes so enhanced reporting stays advertised', () => {
+    expect(
+      buildTerminalKeyboardProtocolOptions({
+        userAgent: WINDOWS_UA,
+        osRelease: '10.0.26100',
+        connectionId: 'ssh-1',
+        cwd: 'C:\\repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      })
+    ).toEqual({})
+  })
+
+  it('returns no override on macOS/Linux', () => {
+    for (const userAgent of [MAC_UA, LINUX_UA]) {
+      expect(
+        buildTerminalKeyboardProtocolOptions({
+          userAgent,
+          osRelease: '23.0.0',
+          connectionId: null,
+          cwd: '/repo',
+          shellOverride: null,
+          executionHostId: 'local'
+        })
+      ).toEqual({})
+    }
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-keyboard-protocol.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-keyboard-protocol.ts
@@ -1,0 +1,43 @@
+import type { ITerminalOptions } from '@xterm/xterm'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import {
+  isLocalNativeWindowsConpty,
+  type WindowsPtyCompatibilityContext
+} from './windows-pty-compatibility'
+
+export type TerminalKeyboardProtocolContext = WindowsPtyCompatibilityContext & {
+  executionHostId: ExecutionHostId
+}
+
+/**
+ * Whether the Kitty enhanced keyboard protocol (CSI-u) must be withheld from a
+ * pane's xterm advertisement.
+ *
+ * Why: Orca's default options advertise `vtExtensions.kittyKeyboard` so probing
+ * CLIs enable enhanced key reporting. But local native Windows shells are backed
+ * by ConPTY, and several local Windows CLIs (e.g. the Antigravity `agy` CLI) read
+ * the advertisement yet do not decode CSI-u, so once it is on they ignore
+ * Enter/Up/Down and other navigation keys. Disabling the advertisement only for
+ * a genuine local Windows ConPTY pane restores standard navigation there while
+ * preserving enhanced keyboard reporting for SSH and macOS/Linux panes (which
+ * decode CSI-u correctly, including inside tmux).
+ */
+export function shouldDisableKittyKeyboardForTerminal(
+  context: TerminalKeyboardProtocolContext
+): boolean {
+  return isLocalNativeWindowsConpty(context)
+}
+
+/**
+ * xterm option overrides that withhold the Kitty enhanced keyboard protocol for
+ * local Windows ConPTY panes and leave every other pane untouched. Merged after
+ * `buildDefaultTerminalOptions()`, so `{}` keeps the advertised default on.
+ */
+export function buildTerminalKeyboardProtocolOptions(
+  context: TerminalKeyboardProtocolContext
+): Partial<ITerminalOptions> {
+  if (!shouldDisableKittyKeyboardForTerminal(context)) {
+    return {}
+  }
+  return { vtExtensions: { kittyKeyboard: false } }
+}


### PR DESCRIPTION
Fixes #2434

## Root cause

Orca builds every pane's xterm with `buildDefaultTerminalOptions()`, which advertises the Kitty enhanced keyboard protocol unconditionally:

```ts
vtExtensions: { kittyKeyboard: true }
```

That advertisement is correct for terminals that decode CSI-u (macOS, Linux, and SSH-backed panes, including inside tmux). But local **native Windows** shells are backed by ConPTY, and several local Windows CLIs — notably the Antigravity `agy` CLI — read the `CSI ? u` handshake and switch into enhanced reporting, yet do **not** decode the resulting CSI-u byte sequences. Once enhanced reporting is on, those CLIs ignore Enter / Up / Down and other navigation keys, which is the reported symptom.

## Change summary

- New module `terminal-keyboard-protocol.ts`:
  - `shouldDisableKittyKeyboardForTerminal(context)` returns `true` only for a genuine **local Windows ConPTY** pane, reusing the existing `isLocalNativeWindowsConpty` predicate from `windows-pty-compatibility.ts` (so SSH `connectionId`, serve/runtime execution hosts, and WSL cwd/shell are all correctly excluded).
  - `buildTerminalKeyboardProtocolOptions(context)` returns `{ vtExtensions: { kittyKeyboard: false } }` for those panes and `{}` otherwise.
- `use-terminal-pane-lifecycle.ts` builds the PTY-backend context once and merges the keyboard-protocol override into the per-pane `terminalOptions()`, right alongside the existing `buildWindowsPtyCompatibilityOptions`. Per-pane options are merged after `buildDefaultTerminalOptions()` in `createPaneDOM`, so the override (`kittyKeyboard: false`) wins for local Windows and the advertised default stays on everywhere else.

No SSH / macOS / Linux behavior changes: those panes still advertise `kittyKeyboard: true`.

### Scope note

This PR fixes the **Orca-side** enhanced-keyboard advertisement, which restores Enter / Up / Down and standard navigation for local Windows CLIs that don't decode CSI-u. The residual ESC / Ctrl+C non-response specific to the Antigravity CLI is an **upstream Antigravity CLI defect** (it does not decode CSI-u sequences it opted into) and is out of scope for the Orca repo.

## Evidence

### Before (failing) — pre-fix baseline (gate stubbed to the old unconditional behavior)

```
 FAIL  src/renderer/src/lib/pane-manager/terminal-keyboard-protocol.test.ts > shouldDisableKittyKeyboardForTerminal > disables Kitty keyboard for a local native Windows ConPTY pane
- Expected
+ Received
- true
+ false

 FAIL  src/renderer/src/lib/pane-manager/terminal-keyboard-protocol.test.ts > buildTerminalKeyboardProtocolOptions > withholds the Kitty keyboard advertisement for a local Windows ConPTY pane
AssertionError: expected {} to deeply equal { vtExtensions: { …(1) } }
- { "vtExtensions": { "kittyKeyboard": false } }
+ {}

 FAIL  src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts > buildDefaultTerminalOptions > lets a local Windows ConPTY pane override the default and withhold kitty keyboard

 Test Files  2 failed (2)
      Tests  3 failed | 32 passed (35)
```

### After (passing)

```
 RUN  v4.1.5

 Test Files  3 passed (3)
      Tests  49 passed (49)
```

(`terminal-keyboard-protocol.test.ts`, `pane-lifecycle.test.ts`, `windows-pty-compatibility.test.ts`)

### Lint (changed files clean)

```
> oxlint && pnpm run lint:switch-exhaustiveness && node config/scripts/check-styled-scrollbars.mjs && pnpm run verify:localization-catalog && pnpm run verify:localization-coverage

Verified 9153 localization key references against en.json.
Localization coverage check passed with 0 allowlisted candidates.
```

(The only oxlint warning is a pre-existing `exhaustive-deps` warning in `useGitStatusPolling.ts`, which this PR does not touch.)

### Typecheck

```
> tsgo --noEmit -p config/tsconfig.node.json && tsgo --noEmit -p config/tsconfig.tc.cli.json && tsgo --noEmit -p config/tsconfig.tc.web.json
(clean — no errors)
```
