### PR TITLE
Fix phantom/overwritten characters when typing into Claude Code on Windows

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7307,6 +7307,92 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('schedules a follow-up repaint for Claude-style in-place prompt redraws on native Windows', async () => {
+    // Why: issue #5656/#5653 — Claude Code echoes prompt keystrokes by redrawing
+    // the input line in place (CR + CHA + reprint + erase-line) without DEC 2026.
+    // On native Windows ConPTY the xterm buffer is correct but the DOM renderer
+    // paints one frame late, leaving phantom/overwritten characters until a resize.
+    // The connection layer now requests a follow-up next-frame repaint; with the
+    // synchronous rAF stub that surfaces as a SECOND _core.refresh call. Without the
+    // fix only the single synchronous settle refresh runs.
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      const refresh = vi.fn()
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        callback?.()
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      // User typed into the prompt; Claude redraws the input line in place.
+      capturedDataCallback.current?.('\r\x1b[3Gzzzx\x1b[K')
+
+      // One synchronous settle refresh + one follow-up next-frame refresh.
+      expect(refresh).toHaveBeenCalledTimes(2)
+      expect(refresh).toHaveBeenNthCalledWith(1, 0, 39, true)
+      expect(refresh).toHaveBeenNthCalledWith(2, 0, 39, true)
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('does not schedule a follow-up repaint for the Claude redraw pattern on non-Windows clients', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      const refresh = vi.fn()
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        callback?.()
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      // The CR redraw still forces one synchronous refresh (cross-platform rewrite
+      // handling), but no native-Windows follow-up next-frame repaint is scheduled.
+      capturedDataCallback.current?.('\r\x1b[3Gzzzx\x1b[K')
+
+      expect(refresh).toHaveBeenCalledTimes(1)
+      expect(refresh).toHaveBeenCalledWith(0, 39, true)
+    } finally {
+      restoreNavigator()
+    }
+  })
+
   it('keeps terminal UI drawing glyphs on the active renderer', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -26,6 +26,7 @@ import { getFitOverrideForPty, bindPanePtyId } from '@/lib/pane-manager/mobile-f
 import { isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
 import { isPaneReplaying, replayIntoTerminal, replayIntoTerminalAsync } from './replay-guard'
 import {
+  nativeWindowsRewriteNeedsFollowupRenderRefresh,
   terminalOutputContainsEastAsianRendererRisk,
   terminalOutputPrefersRenderRefresh,
   terminalRewriteOutputRenderRefreshDecision,
@@ -2731,19 +2732,22 @@ export function connectPanePty(
       return decision.prefersRenderRefresh
     }
 
-    function shouldForceForegroundRenderRefresh(data: string): boolean {
+    function shouldForceForegroundRenderRefresh(data: string): {
+      refresh: boolean
+      inPlaceRewrite: boolean
+    } {
       const rewriteOutputPrefersRenderRefresh = foregroundRewriteOutputPrefersRenderRefresh(data)
       const recentInput =
         performance.now() - lastTerminalInputAt <= FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS
       if (foregroundAnsiOutputPrefersRenderRefresh(data)) {
         // Why: Codex-style background SGR panels can paint cell fills while
         // glyphs lag behind; refresh only renderer-risk ANSI chunks, not all output.
-        return true
+        return { refresh: true, inPlaceRewrite: rewriteOutputPrefersRenderRefresh }
       }
       if (rewriteOutputPrefersRenderRefresh) {
         // Why: resize fixes these panes because xterm's buffer is right but
         // in-place redraw cells can remain stale in the renderer until repaint.
-        return true
+        return { refresh: true, inPlaceRewrite: true }
       }
       if (
         shouldApplyWindowsRendererUnicodeRefresh &&
@@ -2755,13 +2759,15 @@ export function connectPanePty(
         // bytes; the prompt model is correct, but the local Windows renderer
         // can leave individual glyph cells blank until repaint. Keep this
         // scoped to recent East Asian text input, not all Unicode output.
-        return true
+        return { refresh: true, inPlaceRewrite: false }
       }
-      return (
-        shouldApplyNativeWindowsRewriteRefresh &&
-        containsNonAsciiOutput(data) &&
-        containsWindowsRewriteControl(data)
-      )
+      return {
+        refresh:
+          shouldApplyNativeWindowsRewriteRefresh &&
+          containsNonAsciiOutput(data) &&
+          containsWindowsRewriteControl(data),
+        inPlaceRewrite: false
+      }
     }
 
     function writePtyOutputToXterm(
@@ -2798,8 +2804,18 @@ export function connectPanePty(
       const nativeWindowsCursorRestore =
         shouldProtectNativeWindowsSynchronizedOutput && foreground && containsCursorRestore(data)
       const foregroundOutput = foreground || parseHiddenStartupOutput
-      const foregroundRenderRefreshNeeded =
-        foregroundOutput && shouldForceForegroundRenderRefresh(data)
+      const renderRefreshDecision = foregroundOutput
+        ? shouldForceForegroundRenderRefresh(data)
+        : { refresh: false, inPlaceRewrite: false }
+      const foregroundRenderRefreshNeeded = renderRefreshDecision.refresh
+      // Why: see nativeWindowsRewriteNeedsFollowupRenderRefresh — Claude Code's
+      // in-place prompt redraws on Windows ConPTY can paint one frame late, so a
+      // follow-up repaint corrects the column desync without a window resize.
+      const nativeWindowsInPlaceRewriteFollowup = nativeWindowsRewriteNeedsFollowupRenderRefresh({
+        isNativeWindowsConpty: shouldApplyNativeWindowsRewriteRefresh,
+        isForeground: foreground,
+        isInPlaceRewrite: renderRefreshDecision.inPlaceRewrite
+      })
       synchronizedForegroundOutputActive = nextSynchronizedForegroundOutputActive
       if (!foreground && hiddenMode2031ScanTail) {
         respondToSkippedMode2031Subscribe(data)
@@ -2815,7 +2831,7 @@ export function connectPanePty(
           (synchronizedForegroundOutput ||
             nativeWindowsCursorRestore ||
             foregroundRenderRefreshNeeded),
-        followupForegroundRefresh: nativeWindowsCursorRestore,
+        followupForegroundRefresh: nativeWindowsCursorRestore || nativeWindowsInPlaceRewriteFollowup,
         stripTransientCursorShows: shouldProtectNativeWindowsSynchronizedOutput && foreground,
         coalesceForeground: synchronizedForegroundOutput && synchronizedOutputEnded,
         holdForeground: synchronizedForegroundOutput && nextSynchronizedForegroundOutputActive

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -144,6 +144,38 @@ describe('pane terminal output scheduler', () => {
     expect(terminal._core.refresh).toHaveBeenLastCalledWith(0, 23, true)
   })
 
+  it('schedules a follow-up repaint for a Claude-style in-place CR redraw without scroll', async () => {
+    // Why: issue #5656/#5653 — Claude Code's plain-ASCII prompt redraw (CR + CHA +
+    // reprint + erase-line, no DEC 2026, no scroll, no cursor hide/show restore)
+    // paints one frame late on Windows ConPTY. A single sync refresh races that
+    // late paint, so the connection layer requests followupForegroundRefresh.
+    // Prove the scheduler turns that into a second next-frame repaint.
+    const scheduledFrames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      scheduledFrames.push(callback)
+      return scheduledFrames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createForegroundTerminal()
+
+    writeTerminalOutput(terminal, '\r\x1b[3Gzzzx\x1b[K', {
+      foreground: true,
+      latencySensitive: true,
+      forceForegroundRefresh: true,
+      followupForegroundRefresh: true
+    })
+
+    expect(terminal._core.refresh).toHaveBeenCalledTimes(1)
+    expect(scheduledFrames).toHaveLength(1)
+
+    scheduledFrames[0]?.(16)
+
+    expect(terminal._core.refresh).toHaveBeenCalledTimes(2)
+    expect(terminal._core.refresh).toHaveBeenLastCalledWith(0, 23, true)
+  })
+
   it('skips forced viewport refresh for ordinary foreground output', async () => {
     const { writeTerminalOutput } = await loadScheduler()
     const terminal = createForegroundTerminal()

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  nativeWindowsRewriteNeedsFollowupRenderRefresh,
   terminalOutputContainsEastAsianRendererRisk,
   terminalOutputPrefersRenderRefresh,
   terminalRewriteOutputRenderRefreshDecision,
-  terminalRewriteOutputPrefersRenderRefresh
+  terminalRewriteOutputPrefersRenderRefresh,
+  type TerminalRewriteOutputRenderRefreshState
 } from './terminal-complex-script'
 
 describe('terminalOutputPrefersRenderRefresh', () => {
@@ -241,5 +243,83 @@ describe('terminalRewriteOutputRenderRefreshDecision', () => {
       nextRewriteCsiScanTail: '\x1b[',
       prefersRenderRefresh: false
     })
+  })
+})
+
+describe('nativeWindowsRewriteNeedsFollowupRenderRefresh', () => {
+  // Why: Claude Code (issue #5656/#5653) echoes prompt keystrokes by redrawing
+  // the input line in place with CR + CHA + reprint + erase-line, split across
+  // ConPTY chunks, and WITHOUT DEC 2026 synchronized output. Replay that exact
+  // pattern through the rewrite decision and assert that on native Windows it
+  // requests a follow-up next-frame repaint, which is what stops the phantom /
+  // overwritten characters without the user resizing the window.
+  function rewriteIsInPlace(chunks: string[]): boolean[] {
+    const state: TerminalRewriteOutputRenderRefreshState = {
+      previousChunkEndsWithCarriageReturn: false,
+      previousRewriteCsiScanTail: ''
+    }
+    return chunks.map((chunk) => {
+      const decision = terminalRewriteOutputRenderRefreshDecision(chunk, state)
+      state.previousChunkEndsWithCarriageReturn = decision.nextChunkEndsWithCarriageReturn
+      state.previousRewriteCsiScanTail = decision.nextRewriteCsiScanTail
+      return decision.prefersRenderRefresh
+    })
+  }
+
+  it('schedules a follow-up repaint for the split Claude prompt redraw on native Windows', () => {
+    // "> " prompt, then user types z, z, z, x — each keystroke redraws in place.
+    const claudeRedrawChunks = [
+      '\r\x1b[3G',
+      'z\x1b[K',
+      '\r\x1b[3G',
+      'zz\x1b[K',
+      '\r\x1b[3G',
+      'zzz\x1b[K',
+      '\r\x1b[3G',
+      'zzzx\x1b[K'
+    ]
+    const inPlace = rewriteIsInPlace(claudeRedrawChunks)
+    // Every redraw chunk is an in-place rewrite (CR continuation or erase-line).
+    expect(inPlace.every(Boolean)).toBe(true)
+    for (const isInPlaceRewrite of inPlace) {
+      expect(
+        nativeWindowsRewriteNeedsFollowupRenderRefresh({
+          isNativeWindowsConpty: true,
+          isForeground: true,
+          isInPlaceRewrite
+        })
+      ).toBe(true)
+    }
+  })
+
+  it('does not schedule a follow-up repaint for ordinary CRLF foreground output', () => {
+    const inPlace = rewriteIsInPlace(['line one\r\n', 'line two\r\n'])
+    expect(inPlace).toEqual([false, false])
+    for (const isInPlaceRewrite of inPlace) {
+      expect(
+        nativeWindowsRewriteNeedsFollowupRenderRefresh({
+          isNativeWindowsConpty: true,
+          isForeground: true,
+          isInPlaceRewrite
+        })
+      ).toBe(false)
+    }
+  })
+
+  it('stays off for non-Windows renderers and background writes', () => {
+    expect(
+      nativeWindowsRewriteNeedsFollowupRenderRefresh({
+        isNativeWindowsConpty: false,
+        isForeground: true,
+        isInPlaceRewrite: true
+      })
+    ).toBe(false)
+    expect(
+      nativeWindowsRewriteNeedsFollowupRenderRefresh({
+        isNativeWindowsConpty: true,
+        isForeground: false,
+        isInPlaceRewrite: true
+      })
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
@@ -209,6 +209,27 @@ export function terminalRewriteOutputRenderRefreshDecision(
   }
 }
 
+/**
+ * Whether a native-Windows ConPTY foreground chunk that forces a render refresh
+ * should ALSO schedule a follow-up next-frame repaint.
+ *
+ * Why: Claude Code echoes prompt keystrokes by redrawing the input line in place
+ * (CR + CHA/erase + reprint) without DEC 2026 synchronized output. xterm's buffer
+ * ends up correct, but its DOM renderer can paint these rapid rewrites one frame
+ * late — surfacing a phantom first char or an overwritten cell ("zzzx" rendered as
+ * "zzx") that only a window resize clears. A single synchronous refresh races that
+ * late paint; a follow-up next-frame repaint corrects the column desync the way the
+ * existing cursor-restore and scroll cases already do. Scoped to in-place rewrites
+ * on native Windows so plain shells and non-Windows renderers are unaffected.
+ */
+export function nativeWindowsRewriteNeedsFollowupRenderRefresh(args: {
+  isNativeWindowsConpty: boolean
+  isForeground: boolean
+  isInPlaceRewrite: boolean
+}): boolean {
+  return args.isNativeWindowsConpty && args.isForeground && args.isInPlaceRewrite
+}
+
 export function terminalOutputPrefersRenderRefresh(data: string): boolean {
   if (containsBackgroundSgr(data)) {
     return true


### PR DESCRIPTION
Fixes #5656
Fixes #5653

## Symptom

On Windows production builds, typing into the Claude Code prompt glitches: the first character shows as a phantom and subsequent fast keystrokes overwrite prior cells on screen (e.g. typing `zzzx` renders `zzx`). The data **sent** to the agent is correct — it is a render/cursor-column desync that the user can only clear by resizing the window. Plain shells and Codex are unaffected.

## Root cause

Claude Code echoes prompt keystrokes by redrawing the input line **in place** — carriage return, cursor-column move (CHA `ESC[<n>G`) or absolute position, reprint, erase-to-end-of-line — and crucially **without** wrapping it in DEC 2026 synchronized output. On a native Windows ConPTY these redraws also arrive split across multiple tiny PTY chunks (roughly one per fast keystroke).

I confirmed against the bundled `@xterm/xterm@6.1.0-beta.287` headless model that the xterm **buffer** ends up correct after these split writes (cursor column and row contents match), with and without the ConPTY `windowsPty` backend. So the desync is purely in xterm's **DOM renderer paint** — it paints the rapid rewrites one frame late, leaving a stale/phantom cell. A window resize "fixes" it because the reflow forces a full repaint.

Orca already carries Windows render-refresh machinery: `shouldForceForegroundRenderRefresh` + the foreground render-settle force a single **synchronous** `_core.refresh` for in-place rewrites (CR / erase). But a single synchronous refresh in the `xterm.write` completion callback races the renderer's own late paint. The only paths that scheduled a **follow-up next-frame repaint** were the DEC 2026 cursor-restore case (`nativeWindowsCursorRestore`) and the viewport-scroll case — neither of which matches Claude's plain, non-2026 ASCII CR redraw. So Claude's redraw got exactly one (racing) refresh and no follow-up, which is why it stayed corrupted until a resize.

## Change

Extend the existing follow-up-repaint behavior to cover the native-Windows in-place rewrite pattern:

- `shouldForceForegroundRenderRefresh` now returns whether the forced refresh was driven by an in-place rewrite (reusing the already-tested `terminalRewriteOutputRenderRefreshDecision` signal, including its split-chunk continuity).
- `writePtyOutputToXterm` sets `followupForegroundRefresh` for native-Windows ConPTY foreground in-place rewrites, so the scheduler schedules a second next-frame `_core.refresh` (exactly like the cursor-restore and scroll cases already do). This corrects the one-frame-late column desync without the user resizing.
- New pure, documented helper `nativeWindowsRewriteNeedsFollowupRenderRefresh` in `terminal-complex-script.ts` carries the decision so it is unit-testable.

Scoped to native Windows ConPTY (`isLocalNativeWindowsConpty`) foreground in-place rewrites, so plain shells, SSH/remote-runtime panes, and non-Windows renderers are unaffected.

## Why not an upstream xterm fix

The triage note flagged that if the underlying xterm **buffer** cursor column were wrong, only a reflow (not a refresh) could repair it — which would point upstream. The headless check above shows the buffer is correct, so this is a renderer paint-timing issue that an Orca-side follow-up repaint resolves. No xterm change is required.

## Files changed

- `src/renderer/src/lib/pane-manager/terminal-complex-script.ts` — new `nativeWindowsRewriteNeedsFollowupRenderRefresh` helper.
- `src/renderer/src/components/terminal-pane/pty-connection.ts` — surface the in-place-rewrite reason and wire the follow-up refresh.
- Tests: `terminal-complex-script.test.ts`, `pane-terminal-output-scheduler.test.ts`, `pty-connection.test.ts`.

## Evidence

### Regression test — FAILS before the fix

With the `followupForegroundRefresh` wiring reverted, the new native-Windows integration test sees only the single synchronous settle refresh:

```
 FAIL  pty-connection.test.ts > connectPanePty > schedules a follow-up repaint for Claude-style in-place prompt redraws on native Windows
AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
 ❯ src/renderer/src/components/terminal-pane/pty-connection.test.ts:7350:23
    7350|       expect(refresh).toHaveBeenCalledTimes(2)
       |                       ^

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed | 197 skipped (199)
```

### Regression test — PASSES after the fix

```
 ✓ terminal-complex-script.test.ts > nativeWindowsRewriteNeedsFollowupRenderRefresh > schedules a follow-up repaint for the split Claude prompt redraw on native Windows
 ✓ terminal-complex-script.test.ts > nativeWindowsRewriteNeedsFollowupRenderRefresh > does not schedule a follow-up repaint for ordinary CRLF foreground output
 ✓ terminal-complex-script.test.ts > nativeWindowsRewriteNeedsFollowupRenderRefresh > stays off for non-Windows renderers and background writes
 ✓ pane-terminal-output-scheduler.test.ts > schedules a follow-up repaint for a Claude-style in-place CR redraw without scroll
 ✓ pty-connection.test.ts > schedules a follow-up repaint for Claude-style in-place prompt redraws on native Windows
 ✓ pty-connection.test.ts > does not schedule a follow-up repaint for the Claude redraw pattern on non-Windows clients
```

Full affected test files:

```
 Test Files  3 passed (3)
      Tests  265 passed (265)
   (terminal-complex-script.test.ts, pane-terminal-output-scheduler.test.ts, pty-connection.test.ts)

 Test Files  29 passed (29)
      Tests  258 passed (258)
   (src/renderer/src/lib/pane-manager — full directory)
```

### Lint (changed files clean)

```
$ npx oxlint <changed files>
(no findings)

$ pnpm lint
# passes; only pre-existing warning in unrelated useGitStatusPolling.ts
```

### Typecheck

```
$ pnpm typecheck
> tsgo --noEmit -p config/tsconfig.node.json && tsgo --noEmit -p config/tsconfig.tc.cli.json && tsgo --noEmit -p config/tsconfig.tc.web.json
(no errors)
```

DO NOT MERGE — bug-bash validation PR.
