### PR TITLE
Verify the inner Orca.exe is Authenticode-signed in the Windows release pipeline

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1094,6 +1094,51 @@ jobs:
           }
           $signature.SignerCertificate | Format-List Subject,Issuer,NotBefore,NotAfter,Thumbprint
 
+      # Why: Smart App Control (issue #6487) evaluates the inner Orca.exe, not
+      # just the outer installer. SignPath must be configured to RECURSIVELY
+      # sign nested PE files — its "github-actions-windows-installer" artifact
+      # configuration has to declare the inner Orca.exe (inside app-64.7z) as a
+      # signable element. That config lives in the SignPath dashboard, not this
+      # repo. This step is the release gate that fails if recursive signing did
+      # not actually land on Orca.exe, so an unsigned inner binary cannot ship.
+      - name: Verify signed inner Orca.exe (Smart App Control prerequisite)
+        if: matrix.platform == 'win'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $extractRoot = Join-Path $env:RUNNER_TEMP 'inner-exe-verify'
+          if (Test-Path -LiteralPath $extractRoot) {
+            Remove-Item -LiteralPath $extractRoot -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $extractRoot -Force | Out-Null
+
+          # Why: electron-builder NSIS installers embed the packaged app in a
+          # nested app-64.7z; 7-Zip (preinstalled on windows runners) unpacks the
+          # NSIS shell first, then the inner 7z, exposing Orca.exe on disk.
+          # Why: native commands do not honor $ErrorActionPreference, so check
+          # $LASTEXITCODE explicitly to surface a failed extraction clearly.
+          & 7z x 'dist/orca-windows-setup.exe' "-o$extractRoot" -y | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            throw "7z failed to extract the NSIS installer (exit $LASTEXITCODE)."
+          }
+          $innerArchive = Get-ChildItem -Path $extractRoot -Recurse -File -Filter 'app-64.7z' | Select-Object -First 1
+          if ($null -ne $innerArchive) {
+            $appRoot = Join-Path $extractRoot 'app'
+            & 7z x $innerArchive.FullName "-o$appRoot" -y | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+              throw "7z failed to extract the inner app-64.7z payload (exit $LASTEXITCODE)."
+            }
+          }
+
+          $innerExe = Get-ChildItem -Path $extractRoot -Recurse -File -Filter 'Orca.exe' | Select-Object -First 1
+          if ($null -eq $innerExe) {
+            throw 'Could not locate inner Orca.exe inside the NSIS installer payload.'
+          }
+
+          node config/scripts/verify-windows-inner-signature.mjs $innerExe.FullName
+        env:
+          ORCA_WINDOWS_EXPECTED_SIGNER: SignPath Foundation
+
       - name: Publish signed Windows release artifacts
         if: matrix.platform == 'win'
         uses: nick-fields/retry@v4

--- a/config/scripts/verify-windows-inner-signature.mjs
+++ b/config/scripts/verify-windows-inner-signature.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+// Why: Windows Smart App Control (issue #6487) evaluates the inner application
+// executable (Orca.exe), not just the outer NSIS installer. The release pipeline
+// signs and verifies orca-windows-setup.exe, but nothing asserted that the
+// Orca.exe extracted from that installer carries a valid Authenticode signature.
+// SignPath must be configured server-side to recursively sign nested PE files
+// (its artifact configuration must declare the inner exe / app-64.7z payload as
+// signable; that lives in the SignPath dashboard, not this repo). This script is
+// the CI gate that fails the release if recursive signing did not actually land
+// on Orca.exe, so an unsigned inner binary can never reach users.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+// Why: signtool ships a localized "Successfully verified" line, but the
+// structured, scriptable signal is the per-file "Number of ... errors: N"
+// summary, which is emitted in the invariant (English) form regardless of UI
+// language. We treat zero signing-cert errors as the success condition.
+const SIGNTOOL_SUCCESS_PATTERN = /Successfully verified:/i
+const SIGNTOOL_ERROR_COUNT_PATTERN = /Number of errors:\s*(\d+)/i
+
+/**
+ * Parse `signtool verify /pa /v <file>` output into a normalized result.
+ * `signtool` exits non-zero on failure, so callers should also honor the exit
+ * code; this parser exists so the verdict + signer can be asserted in tests and
+ * surfaced in logs without depending on a live signed binary.
+ *
+ * @param {string} output combined stdout/stderr from signtool
+ * @returns {{ valid: boolean, signerSubject: string | null }}
+ */
+export function parseSigntoolOutput(output) {
+  const text = String(output ?? '')
+  const errorCountMatch = text.match(SIGNTOOL_ERROR_COUNT_PATTERN)
+  const errorCount = errorCountMatch ? Number.parseInt(errorCountMatch[1], 10) : null
+  // Why: prefer the explicit error count when signtool prints it; otherwise fall
+  // back to the success line so non-verbose invocations still parse.
+  const valid =
+    errorCount === 0 || (errorCount === null && SIGNTOOL_SUCCESS_PATTERN.test(text))
+  return {
+    valid,
+    signerSubject: extractSigntoolSignerSubject(text)
+  }
+}
+
+function extractSigntoolSignerSubject(text) {
+  // signtool /v prints "Issued to: <subject>" for the leaf signing cert.
+  const issuedTo = text.match(/Issued to:\s*(.+?)\s*$/im)
+  if (issuedTo) {
+    return issuedTo[1].trim()
+  }
+  return null
+}
+
+/**
+ * Parse a JSON object emitted by PowerShell's Get-AuthenticodeSignature
+ * (`... | Select-Object Status,@{...SignerCertificate.Subject...} | ConvertTo-Json`).
+ * PowerShell's Authenticode Status enum is `Valid` (0) when the signature chains
+ * to a trusted root and matches the file hash.
+ *
+ * @param {unknown} parsed already-JSON-parsed Get-AuthenticodeSignature object
+ * @returns {{ valid: boolean, signerSubject: string | null, status: string | null }}
+ */
+export function parseAuthenticodeSignature(parsed) {
+  if (parsed === null || typeof parsed !== 'object') {
+    return { valid: false, signerSubject: null, status: null }
+  }
+  const record = /** @type {Record<string, unknown>} */ (parsed)
+  const status = typeof record.Status === 'string' ? record.Status : null
+  const signerSubject =
+    typeof record.SignerSubject === 'string' && record.SignerSubject.length > 0
+      ? record.SignerSubject
+      : null
+  return {
+    valid: status === 'Valid',
+    signerSubject,
+    status
+  }
+}
+
+/**
+ * Assert that a parsed inner-signature result is acceptable for release.
+ * `expectedSignerSubstring` guards against a valid-but-wrong-signer regression
+ * (e.g. an ad-hoc or developer cert), mirroring the outer-installer gate that
+ * pins `CN=SignPath Foundation`.
+ *
+ * @param {{ valid: boolean, signerSubject: string | null }} result
+ * @param {{ expectedSignerSubstring?: string | null }} [options]
+ * @returns {{ ok: boolean, reason: string | null }}
+ */
+export function evaluateInnerSignature(result, options = {}) {
+  const expected = options.expectedSignerSubstring ?? null
+  if (!result.valid) {
+    return {
+      ok: false,
+      reason: 'Inner Orca.exe does not carry a valid Authenticode signature.'
+    }
+  }
+  if (expected) {
+    const subject = result.signerSubject ?? ''
+    if (!subject.toLowerCase().includes(expected.toLowerCase())) {
+      return {
+        ok: false,
+        reason: `Inner Orca.exe signer "${result.signerSubject ?? '<unknown>'}" does not contain expected "${expected}".`
+      }
+    }
+  }
+  return { ok: true, reason: null }
+}
+
+function verifyWithSigntool(filePath) {
+  // Why: /pa uses the "Default Authentication Verification Policy" (the same
+  // chain SAC evaluates); /v gives the verbose "Issued to" signer line.
+  const output = execFileSync('signtool', ['verify', '/pa', '/v', filePath], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+  return parseSigntoolOutput(output)
+}
+
+function verifyWithPowerShell(filePath) {
+  const script = [
+    '$ErrorActionPreference = "Stop"',
+    `$sig = Get-AuthenticodeSignature -LiteralPath "${filePath.replace(/"/g, '`"')}"`,
+    '$obj = [PSCustomObject]@{',
+    '  Status = $sig.Status.ToString()',
+    '  SignerSubject = if ($sig.SignerCertificate) { $sig.SignerCertificate.Subject } else { $null }',
+    '}',
+    '$obj | ConvertTo-Json -Compress'
+  ].join('\n')
+  const output = execFileSync(
+    'powershell',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+  )
+  return parseAuthenticodeSignature(JSON.parse(output))
+}
+
+/**
+ * Run the available platform verifier against a PE file. Prefers signtool (the
+ * tool SignPath/electron-builder use), falling back to PowerShell's
+ * Get-AuthenticodeSignature. Only meaningful on Windows runners.
+ *
+ * @param {string} filePath
+ * @returns {{ valid: boolean, signerSubject: string | null }}
+ */
+export function verifyInnerExecutableSignature(filePath) {
+  if (!existsSync(filePath)) {
+    throw new Error(`Inner executable not found at ${filePath}`)
+  }
+  if (process.platform !== 'win32') {
+    throw new Error(
+      'verifyInnerExecutableSignature must run on a Windows runner (signtool/PowerShell required).'
+    )
+  }
+  try {
+    return verifyWithSigntool(filePath)
+  } catch (signtoolError) {
+    try {
+      return verifyWithPowerShell(filePath)
+    } catch (powershellError) {
+      throw new Error(
+        `Unable to verify Authenticode signature for ${filePath}. signtool: ${
+          signtoolError instanceof Error ? signtoolError.message : signtoolError
+        }; powershell: ${
+          powershellError instanceof Error ? powershellError.message : powershellError
+        }`
+      )
+    }
+  }
+}
+
+function main() {
+  const filePath = process.argv[2]
+  if (!filePath) {
+    throw new Error('Usage: node config/scripts/verify-windows-inner-signature.mjs <orca-exe-path>')
+  }
+  const expectedSignerSubstring =
+    process.env.ORCA_WINDOWS_EXPECTED_SIGNER || 'SignPath Foundation'
+  const result = verifyInnerExecutableSignature(filePath)
+  const verdict = evaluateInnerSignature(result, { expectedSignerSubstring })
+  if (!verdict.ok) {
+    throw new Error(
+      `${verdict.reason}\nSigner subject: ${result.signerSubject ?? '<none>'}\n` +
+        'SignPath must be configured to recursively sign nested PE files ' +
+        '(the inner Orca.exe / app-64.7z payload) in its artifact configuration.'
+    )
+  }
+  console.log(
+    `Verified inner Orca.exe Authenticode signature (signer: ${result.signerSubject ?? '<unknown>'}).`
+  )
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  }
+}

--- a/config/scripts/verify-windows-inner-signature.test.mjs
+++ b/config/scripts/verify-windows-inner-signature.test.mjs
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluateInnerSignature,
+  parseAuthenticodeSignature,
+  parseSigntoolOutput
+} from './verify-windows-inner-signature.mjs'
+
+describe('parseSigntoolOutput', () => {
+  it('treats zero errors with a signer line as valid', () => {
+    const output = [
+      'Verifying: Orca.exe',
+      '',
+      'Signature Index: 0 (Primary Signature)',
+      'Hash of file (sha256): ABC123',
+      '',
+      'Signing Certificate Chain:',
+      '    Issued to: SignPath Foundation',
+      '    Issued by: SSL.com Code Signing Intermediate CA RSA R1',
+      '',
+      'Successfully verified: Orca.exe',
+      '',
+      'Number of files successfully Verified: 1',
+      'Number of warnings: 0',
+      'Number of errors: 0'
+    ].join('\r\n')
+
+    expect(parseSigntoolOutput(output)).toEqual({
+      valid: true,
+      signerSubject: 'SignPath Foundation'
+    })
+  })
+
+  it('treats a nonzero error count as invalid', () => {
+    const output = [
+      'Verifying: Orca.exe',
+      'SignTool Error: No signature found.',
+      '',
+      'Number of errors: 1'
+    ].join('\r\n')
+
+    expect(parseSigntoolOutput(output)).toEqual({
+      valid: false,
+      signerSubject: null
+    })
+  })
+
+  it('falls back to the success line when no error count is printed', () => {
+    const output = ['Successfully verified: Orca.exe'].join('\n')
+    expect(parseSigntoolOutput(output)).toEqual({
+      valid: true,
+      signerSubject: null
+    })
+  })
+
+  it('reports invalid for empty or missing output', () => {
+    expect(parseSigntoolOutput('')).toEqual({ valid: false, signerSubject: null })
+    expect(parseSigntoolOutput(undefined)).toEqual({ valid: false, signerSubject: null })
+  })
+})
+
+describe('parseAuthenticodeSignature', () => {
+  it('maps a Valid status to a valid result and extracts the signer subject', () => {
+    expect(
+      parseAuthenticodeSignature({
+        Status: 'Valid',
+        SignerSubject: 'CN=SignPath Foundation, O=SignPath Foundation, C=US'
+      })
+    ).toEqual({
+      valid: true,
+      signerSubject: 'CN=SignPath Foundation, O=SignPath Foundation, C=US',
+      status: 'Valid'
+    })
+  })
+
+  it('maps a NotSigned status to invalid', () => {
+    expect(parseAuthenticodeSignature({ Status: 'NotSigned', SignerSubject: null })).toEqual({
+      valid: false,
+      signerSubject: null,
+      status: 'NotSigned'
+    })
+  })
+
+  it('handles HashMismatch (tampered binary) as invalid', () => {
+    expect(
+      parseAuthenticodeSignature({ Status: 'HashMismatch', SignerSubject: 'CN=Whoever' })
+    ).toEqual({
+      valid: false,
+      signerSubject: 'CN=Whoever',
+      status: 'HashMismatch'
+    })
+  })
+
+  it('tolerates non-object input', () => {
+    expect(parseAuthenticodeSignature(null)).toEqual({
+      valid: false,
+      signerSubject: null,
+      status: null
+    })
+    expect(parseAuthenticodeSignature('not-an-object')).toEqual({
+      valid: false,
+      signerSubject: null,
+      status: null
+    })
+  })
+})
+
+describe('evaluateInnerSignature', () => {
+  it('passes when valid and the signer matches the expected substring', () => {
+    expect(
+      evaluateInnerSignature(
+        { valid: true, signerSubject: 'CN=SignPath Foundation, O=SignPath Foundation' },
+        { expectedSignerSubstring: 'SignPath Foundation' }
+      )
+    ).toEqual({ ok: true, reason: null })
+  })
+
+  it('matches the expected signer case-insensitively', () => {
+    expect(
+      evaluateInnerSignature(
+        { valid: true, signerSubject: 'CN=signpath foundation' },
+        { expectedSignerSubstring: 'SignPath Foundation' }
+      ).ok
+    ).toBe(true)
+  })
+
+  it('fails when the signature is invalid even if a subject is present', () => {
+    const verdict = evaluateInnerSignature(
+      { valid: false, signerSubject: 'CN=SignPath Foundation' },
+      { expectedSignerSubstring: 'SignPath Foundation' }
+    )
+    expect(verdict.ok).toBe(false)
+    expect(verdict.reason).toMatch(/valid Authenticode signature/)
+  })
+
+  it('fails a valid signature signed by an unexpected identity', () => {
+    const verdict = evaluateInnerSignature(
+      { valid: true, signerSubject: 'CN=Some Dev Cert' },
+      { expectedSignerSubstring: 'SignPath Foundation' }
+    )
+    expect(verdict.ok).toBe(false)
+    expect(verdict.reason).toMatch(/does not contain expected/)
+  })
+
+  it('passes a valid signature when no expected signer is configured', () => {
+    expect(
+      evaluateInnerSignature({ valid: true, signerSubject: null }).ok
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

This is a **CI hardening PREREQUISITE** for issue #6487 (Windows Smart App Control blocks `orca.exe`). It is **not** a full fix for the SAC block.

**Important — what this does NOT do:** The actual SAC block is resolved only by signing with a SAC-trusted identity (Azure Trusted Signing, or an EV cert with Microsoft/ISG trust). That requires infrastructure, cost, and server-side SignPath dashboard configuration — it is **not** a code change in this repo, and this PR does not claim to fix the SAC block in code.

**What this PR does fix (a real, mergeable gap):** Today the release pipeline only signs and verifies the **outer** NSIS installer (`orca-windows-setup.exe`). Nothing ever asserted that the **inner** extracted `Orca.exe` carries a valid Authenticode signature. SAC evaluates that inner executable, so an unsigned `Orca.exe` could ship inside a signed installer and still be blocked. This PR adds the missing CI gate.

Fixes #6487 to the extent it is fixable in this repository (the CI prerequisite); the SAC-trusted signing identity itself is tracked as human/infra work (see "Remaining work" below).

## ELI5

This PR adds the missing CI check for the Windows app executable inside the installer. It unpacks the signed NSIS installer, pulls out the nested `Orca.exe`, and fails the release if that inner executable is unsigned or signed by the wrong identity.

We need to land it because Windows Smart App Control evaluates the app people run, not just the installer wrapper. The old release check could prove `orca-windows-setup.exe` was signed while saying nothing about the `Orca.exe` inside it. This PR closes that release-time blind spot and gives us a hard signal that the required SignPath recursive signing setup is actually working.

## Root cause

`.github/workflows/release-cut.yml` "Verify signed Windows installer" only ran `Get-AuthenticodeSignature` against `dist/orca-windows-setup.exe` (the outer installer). The SignPath signing request (`artifact-configuration-slug: github-actions-windows-installer`) signs the installer, but unless its artifact configuration declares the nested PE payload (the inner `Orca.exe` inside `app-64.7z`) as signable, the inner exe ships **unsigned** — which is exactly what SAC rejects. There was no gate to catch that.

## Change summary

- **`config/scripts/verify-windows-inner-signature.mjs`** — cross-platform-safe module that parses `signtool verify /pa /v` output and `Get-AuthenticodeSignature` JSON into a normalized `{ valid, signerSubject }` verdict, and `evaluateInnerSignature()` which pins the expected signer (`SignPath Foundation`) the same way the outer-installer gate pins `CN=SignPath Foundation`. Prefers `signtool`, falls back to PowerShell; guards against running off-Windows.
- **`config/scripts/verify-windows-inner-signature.test.mjs`** — unit tests for the parsing/evaluation logic (the genuinely testable portion; no signed binary is available in CI for this PR).
- **`.github/workflows/release-cut.yml`** — new step **"Verify signed inner Orca.exe (Smart App Control prerequisite)"** after the signed installer is staged. It extracts the inner `Orca.exe` from the NSIS payload (7-Zip, preinstalled on Windows runners; unpacks the NSIS shell then the nested `app-64.7z`) and runs the verifier, **failing the release if `Orca.exe` is unsigned or signed by an unexpected identity.**

## Remaining work (human / infra — NOT this PR)

Enable **recursive PE signing** in SignPath's server-side artifact configuration for the `orca` project's `github-actions-windows-installer` artifact configuration: declare the inner `Orca.exe` (inside `app-64.7z`) as a signable element so SignPath signs it during the same request. That config lives in the SignPath dashboard, not this repo, and is documented in a code comment next to the new gate and in the script header. Separately, the SAC block itself requires a SAC-trusted signing identity (Azure Trusted Signing or an EV cert with MS/ISG trust). This PR's gate ensures the inner exe is verifiably signed once that server-side config + identity land.

## Evidence

### Regression test — FAILING before (parser logic deliberately broken)

```
- Expected
+ Received

  {
    "signerSubject": null,
-   "valid": false,
+   "valid": true,
  }

 ❯ config/scripts/verify-windows-inner-signature.test.mjs:56:37
 Test Files  1 failed (1)
      Tests  2 failed | 11 passed (13)
```

### Regression test — PASSING after (correct logic)

```
 RUN  v4.1.5

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Duration  449ms
```

### Affected test files (new + closest neighbor)

```
 Test Files  2 passed (2)
      Tests  29 passed | 1 skipped (30)
   Duration  1.26s
  (verify-windows-inner-signature.test.mjs + electron-builder-config.test.mjs)
```

### Lint (changed files)

```
$ oxlint config/scripts/verify-windows-inner-signature.mjs config/scripts/verify-windows-inner-signature.test.mjs
exit=0
```

### Typecheck

```
$ pnpm typecheck
> tsgo --noEmit -p config/tsconfig.node.json && tsgo --noEmit -p config/tsconfig.tc.cli.json && tsgo --noEmit -p config/tsconfig.tc.web.json
typecheck-exit=0
```

## Testing notes / honesty

This is genuinely hard to fully test here: CI in this PR has no signed Windows binary, so the end-to-end signtool path cannot be exercised offline. I tested the parsing + evaluation logic (the part with real branching) and validated the workflow YAML parses. The extraction + signtool invocation only runs on the Windows release runner against the real signed installer.
