### PR TITLE
Fix duplicated/overprinted CJK glyphs in the terminal on Windows

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7153,7 +7153,11 @@ describe('connectPanePty', () => {
     }
   })
 
-  it('does not force the Windows CJK repaint path without recent terminal input', async () => {
+  // Why: #5921 — Codex/Antigravity repaint CJK blocks in place and the local
+  // Windows DOM renderer overprints the prior wide glyphs ("如" → "如如"). Agent
+  // output is not recent input, so native-ConPTY CJK output must still force a
+  // viewport refresh to clear the stale wide cells.
+  it('forces the Windows CJK repaint path for native-ConPTY agent output without recent input', async () => {
     const restoreNavigator = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     )
@@ -7168,6 +7172,48 @@ describe('connectPanePty', () => {
         }
       )
       transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      const refresh = vi.fn()
+      const terminal = pane.terminal as typeof pane.terminal & {
+        _core?: { refresh: typeof refresh }
+      }
+      terminal._core = { refresh }
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        callback?.()
+      })
+
+      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      capturedDataCallback.current?.('已经安装完成，软件已更新后重启。')
+
+      expect(refresh).toHaveBeenCalledWith(0, 39, true)
+    } finally {
+      restoreNavigator()
+    }
+  })
+
+  it('does not force the Windows CJK repaint path for remote/serve agent output without recent input', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      // Why: a serve/remote-runtime pane is not a native local ConPTY, so its
+      // bytes render through a different layer; refreshing every CJK output
+      // chunk there is wasted work. Recent-input CJK still refreshes (separate
+      // win32-client path), but plain agent output must not.
+      enableActiveRuntimeEnvironment('env-1')
 
       const pane = createPane(1)
       const refresh = vi.fn()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -26,10 +26,10 @@ import { getFitOverrideForPty, bindPanePtyId } from '@/lib/pane-manager/mobile-f
 import { isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
 import { isPaneReplaying, replayIntoTerminal, replayIntoTerminalAsync } from './replay-guard'
 import {
-  terminalOutputContainsEastAsianRendererRisk,
   terminalOutputPrefersRenderRefresh,
   terminalRewriteOutputRenderRefreshDecision,
-  terminalRewriteOutputPrefersRenderRefresh
+  terminalRewriteOutputPrefersRenderRefresh,
+  windowsEastAsianOutputPrefersRenderRefresh
 } from '@/lib/pane-manager/terminal-complex-script'
 import {
   PANE_PTY_RESIZE_HOLD_FLUSH_EVENT,
@@ -2746,15 +2746,17 @@ export function connectPanePty(
         return true
       }
       if (
-        shouldApplyWindowsRendererUnicodeRefresh &&
-        recentInput &&
-        data.length <= FOREGROUND_INTERACTIVE_REDRAW_CHARS &&
-        terminalOutputContainsEastAsianRendererRisk(data)
+        windowsEastAsianOutputPrefersRenderRefresh(data, {
+          isWindowsClient: shouldApplyWindowsRendererUnicodeRefresh,
+          isNativeWindowsConpty: shouldApplyNativeWindowsRewriteRefresh,
+          hadRecentInput: recentInput,
+          maxInteractiveRedrawChars: FOREGROUND_INTERACTIVE_REDRAW_CHARS
+        })
       ) {
-        // Why: Microsoft Pinyin commits can surface as plain CJK foreground
-        // bytes; the prompt model is correct, but the local Windows renderer
-        // can leave individual glyph cells blank until repaint. Keep this
-        // scoped to recent East Asian text input, not all Unicode output.
+        // Why: CJK/Korean from Microsoft Pinyin commits and from TUI agents
+        // (Codex/Antigravity) repainting in place both leave stale wide-glyph
+        // cells in the local Windows DOM renderer; the buffer is correct, so a
+        // viewport repaint resolves the duplicated/overprinted glyphs (#5921).
         return true
       }
       return (

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
@@ -3,7 +3,8 @@ import {
   terminalOutputContainsEastAsianRendererRisk,
   terminalOutputPrefersRenderRefresh,
   terminalRewriteOutputRenderRefreshDecision,
-  terminalRewriteOutputPrefersRenderRefresh
+  terminalRewriteOutputPrefersRenderRefresh,
+  windowsEastAsianOutputPrefersRenderRefresh
 } from './terminal-complex-script'
 
 describe('terminalOutputPrefersRenderRefresh', () => {
@@ -241,5 +242,84 @@ describe('terminalRewriteOutputRenderRefreshDecision', () => {
       nextRewriteCsiScanTail: '\x1b[',
       prefersRenderRefresh: false
     })
+  })
+})
+
+describe('windowsEastAsianOutputPrefersRenderRefresh', () => {
+  const NATIVE_CONPTY = {
+    isWindowsClient: true,
+    isNativeWindowsConpty: true,
+    hadRecentInput: false,
+    maxInteractiveRedrawChars: 128 * 1024
+  }
+
+  // Why: regression for #5921 — Codex/Antigravity repaint CJK blocks in place and
+  // the local Windows DOM renderer overprints the prior wide glyphs ("如" → "如如"),
+  // so agent *output* (no recent input) must still force a viewport refresh.
+  it('refreshes native-ConPTY agent CJK output without recent input', () => {
+    expect(windowsEastAsianOutputPrefersRenderRefresh('如果还在主 checkout', NATIVE_CONPTY)).toBe(
+      true
+    )
+  })
+
+  it('refreshes native-ConPTY Korean output without recent input', () => {
+    expect(windowsEastAsianOutputPrefersRenderRefresh('한국어 출력', NATIVE_CONPTY)).toBe(true)
+  })
+
+  it('refreshes CJK output split from its cursor-position CSI in a prior chunk', () => {
+    // Why: the main-process batch window splits the CUP move from the glyph
+    // payload, so the CJK-only chunk carries no control bytes yet still repaints.
+    expect(windowsEastAsianOutputPrefersRenderRefresh('设计专用 worktree', NATIVE_CONPTY)).toBe(true)
+  })
+
+  it('still refreshes recent-input CJK on a non-ConPTY Windows client (Pinyin commit)', () => {
+    expect(
+      windowsEastAsianOutputPrefersRenderRefresh('请创建', {
+        isWindowsClient: true,
+        isNativeWindowsConpty: false,
+        hadRecentInput: true,
+        maxInteractiveRedrawChars: 128 * 1024
+      })
+    ).toBe(true)
+  })
+
+  it('does not refresh East Asian output on non-Windows panes', () => {
+    expect(
+      windowsEastAsianOutputPrefersRenderRefresh('如果还在主', {
+        isWindowsClient: false,
+        isNativeWindowsConpty: false,
+        hadRecentInput: false,
+        maxInteractiveRedrawChars: 128 * 1024
+      })
+    ).toBe(false)
+  })
+
+  it('does not refresh East Asian output on a remote/serve Windows client without recent input', () => {
+    // Why: SSH/serve panes (win32 client, not native ConPTY) render through a
+    // different layer; refreshing every CJK chunk there is wasted work.
+    expect(
+      windowsEastAsianOutputPrefersRenderRefresh('如果还在主', {
+        isWindowsClient: true,
+        isNativeWindowsConpty: false,
+        hadRecentInput: false,
+        maxInteractiveRedrawChars: 128 * 1024
+      })
+    ).toBe(false)
+  })
+
+  it('does not refresh plain ASCII agent output', () => {
+    expect(windowsEastAsianOutputPrefersRenderRefresh('checkout worktree', NATIVE_CONPTY)).toBe(
+      false
+    )
+  })
+
+  it('skips bulk chunks larger than the interactive redraw bound', () => {
+    const bulk = '如'.repeat(200)
+    expect(
+      windowsEastAsianOutputPrefersRenderRefresh(bulk, {
+        ...NATIVE_CONPTY,
+        maxInteractiveRedrawChars: 100
+      })
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
@@ -260,3 +260,43 @@ export function terminalOutputContainsEastAsianRendererRisk(data: string): boole
   }
   return false
 }
+
+export type WindowsEastAsianRefreshState = {
+  // Why: the local Windows DOM renderer is the only one that overprints wide
+  // glyphs; a win32 *client* alone gates the recent-input (IME commit) path,
+  // while native ConPTY gates the agent-output path (SSH/serve panes render
+  // through a different layer and must not pay the per-chunk repaint).
+  isWindowsClient: boolean
+  isNativeWindowsConpty: boolean
+  hadRecentInput: boolean
+  maxInteractiveRedrawChars: number
+}
+
+/**
+ * Whether a Windows foreground chunk needs a forced viewport refresh because it
+ * carries East Asian double-width glyphs that the local DOM renderer can paint
+ * over a stale prior frame.
+ *
+ * Why: TUI agents (Codex, Antigravity) repaint blocks in place. The wide-char
+ * cells xterm parses are correct, but the local Windows DOM renderer can leave
+ * the previous frame's wide glyphs painted on top, so CJK/Korean text shows
+ * duplicated/overprinted ("如" → "如如") until the next redraw. Recent-input CJK
+ * (Microsoft Pinyin commits) already forced a refresh; agent *output* is not
+ * recent input and its East Asian glyphs are equally affected, so refresh those
+ * native-ConPTY chunks too. Bounded by the interactive-redraw chunk size so a
+ * bulk paste/scrollback dump does not pay a per-chunk repaint cost.
+ */
+export function windowsEastAsianOutputPrefersRenderRefresh(
+  data: string,
+  state: WindowsEastAsianRefreshState
+): boolean {
+  const recentInputRefresh = state.isWindowsClient && state.hadRecentInput
+  const agentOutputRefresh = state.isNativeWindowsConpty
+  if (!recentInputRefresh && !agentOutputRefresh) {
+    return false
+  }
+  if (data.length > state.maxInteractiveRedrawChars) {
+    return false
+  }
+  return terminalOutputContainsEastAsianRendererRisk(data)
+}


### PR DESCRIPTION
Fixes #5921

## Root cause

On native Windows ConPTY, TUI agents (OpenAI Codex, Antigravity) repaint blocks of output **in place**. xterm parses the wide CJK/Korean cells with the correct double width (verified: `wcwidth(如)=2`, `wcwidth(한)=2` via the Unicode 11 addon), so the buffer model is right. But the local Windows DOM renderer can leave the *previous* frame's wide glyphs painted on top of the freshly repainted cells, so the text visibly duplicates/overprints character-by-character — `如果` renders as `如如果果` — and normalizes only on the next redraw. English/ASCII is single-width and unaffected.

This matches the reporters' observation exactly: "A newly rendered line briefly flashes and appears duplicated; after the next repaint the previously duplicated block becomes normal; the latest active block then duplicates." The duplication is in the renderer's painted layer, not the buffer (a plain re-render of the same buffer fixes it), so the right tool is a forced viewport repaint.

Orca already had a forced-viewport-refresh workaround for East Asian text, but it was gated on **recent terminal input** (`recentInput`) — it only covered Microsoft Pinyin IME *commits* (PR #6488). Agent **output** is not recent input, so its East Asian glyphs were never refreshed and stayed duplicated.

(Community PR #5988 misdiagnosed this as a ConPTY wrap flag (`windowsMode: true`); that does not compile and breaks a test — not adopted.)

## Change summary

- New pure decision function `windowsEastAsianOutputPrefersRenderRefresh` in `terminal-complex-script.ts`: returns true when a Windows foreground chunk carries East Asian double-width glyphs and is within the interactive-redraw size bound, for either the recent-input path (win32 client, incl. SSH) **or** the agent-output path (native local ConPTY).
- `pty-connection.ts` `shouldForceForegroundRenderRefresh` now delegates to it, so native-ConPTY agent CJK/Korean output forces a `_core.refresh(0, rows-1, true)` viewport repaint that clears the stale wide cells.
- Scoping preserved per AGENTS.md (SSH / non-GitHub / cross-platform): remote/serve panes (not native local ConPTY) still skip the per-chunk repaint unless there was recent input; non-Windows panes are unaffected. Bounded by `FOREGROUND_INTERACTIVE_REDRAW_CHARS` so a bulk paste/scrollback dump does not pay a per-chunk repaint cost.

This is hard to e2e in CI (needs a real Windows ConPTY + a TUI agent emitting CJK), so the regression coverage is targeted unit tests on the pure decision function plus the `connectPanePty` data path. Manual verification: run Codex on Windows, ask it to reply in Chinese/Korean — the duplicated/overprinted glyphs are gone.

## Evidence

### Before (failing) — old recent-input-only behavior could not refresh agent CJK output

Temporarily forcing the agent-output branch off (`agentOutputRefresh = false`, i.e. the old behavior) fails the new regression tests:

```
 FAIL  src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts > windowsEastAsianOutputPrefersRenderRefresh > refreshes native-ConPTY agent CJK output without recent input
AssertionError: expected false to be true
 FAIL  ... > refreshes native-ConPTY Korean output without recent input
AssertionError: expected false to be true
 FAIL  ... > refreshes CJK output split from its cursor-position CSI in a prior chunk
AssertionError: expected false to be true

 Test Files  1 failed (1)
      Tests  3 failed | 29 passed (32)
```

The `connectPanePty` data-path test likewise asserted the buggy behavior before the fix (`refresh` not called for native-ConPTY CJK output without recent input); it now asserts the corrected repaint.

### After (passing) — fix in place

```
 RUN  v4.1.5

 Test Files  2 passed (2)
      Tests  230 passed (230)
```

(`terminal-complex-script.test.ts` 32 passed + `pty-connection.test.ts` 198 passed.)

Full pane-manager suite:

```
 Test Files  29 passed (29)
      Tests  262 passed (262)
```

### Lint (changed files + full)

```
> oxlint && lint:switch-exhaustiveness && check-styled-scrollbars && verify:localization-catalog && verify:localization-coverage
Verified 9153 localization key references against en.json.
Localization coverage check passed with 0 allowlisted candidates.
```

(Clean for changed files; the single pre-existing `useGitStatusPolling.ts` exhaustive-deps warning is unrelated and not a changed file.)

### Typecheck

```
> tsgo --noEmit -p config/tsconfig.node.json && tsgo --noEmit -p config/tsconfig.tc.cli.json && tsgo --noEmit -p config/tsconfig.tc.web.json
(no errors)
```
