### PR TITLE
Move Orca Mobile shortcut control into Mobile settings

### DIFF
--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -6,10 +6,28 @@
   position: absolute;
   top: 12px;
   left: 12px;
+  right: 12px;
   z-index: 3;
   display: flex;
-  align-items: center;
-  gap: 4px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mobile-page-root .mp-page-toolbar-primary {
+  max-width: min(100%, 22rem);
+}
+
+.mobile-page-root .mp-sidebar-toggle-btn {
+  max-width: 100%;
+  justify-content: flex-start;
+  font-weight: 600;
+  text-align: left;
+  white-space: normal;
+}
+
+.mobile-page-root .mp-page-toolbar-close {
+  margin-top: 1px;
 }
 
 .mobile-page-root {

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -354,7 +354,16 @@ export default function MobilePage(): React.JSX.Element {
   }
 
   const toggleMobileSidebarButton = useCallback(() => {
-    void updateSettings({ showMobileButton: !showMobileButton })
+    const nextShowMobileButton = !showMobileButton
+    void updateSettings({ showMobileButton: nextShowMobileButton })
+    if (!nextShowMobileButton) {
+      toast.message(
+        translate(
+          'auto.components.mobile.MobilePageToolbar.e1c7b4a92d',
+          'Configure in Settings > Mobile.'
+        )
+      )
+    }
   }, [showMobileButton, updateSettings])
 
   useMobilePageEscape(closeMobilePage)

--- a/src/renderer/src/components/mobile/MobilePageToolbar.test.tsx
+++ b/src/renderer/src/components/mobile/MobilePageToolbar.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+import { MobilePageToolbar } from './MobilePageToolbar'
+
+describe('MobilePageToolbar', () => {
+  it('labels the sidebar toggle explicitly when Orca Mobile is visible in the sidebar', () => {
+    const html = renderToStaticMarkup(
+      <MobilePageToolbar showMobileButton onClose={vi.fn()} onToggleMobileSidebarButton={vi.fn()} />
+    )
+
+    expect(html).toContain('Remove Orca Mobile from left sidebar')
+    expect(html).toContain('mp-page-toolbar-primary')
+    expect(html).toContain('Configure in Settings')
+    expect(html).not.toContain('Hide from sidebar')
+  })
+
+  it('labels the restore action explicitly when Orca Mobile is hidden from the sidebar', () => {
+    const html = renderToStaticMarkup(
+      <MobilePageToolbar
+        showMobileButton={false}
+        onClose={vi.fn()}
+        onToggleMobileSidebarButton={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('Show Orca Mobile in left sidebar')
+    expect(html).not.toContain('Show in sidebar')
+  })
+})

--- a/src/renderer/src/components/mobile/MobilePageToolbar.tsx
+++ b/src/renderer/src/components/mobile/MobilePageToolbar.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff, X } from 'lucide-react'
+import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
@@ -14,14 +14,52 @@ export function MobilePageToolbar({
   onClose,
   onToggleMobileSidebarButton
 }: MobilePageToolbarProps): React.JSX.Element {
+  const sidebarToggleLabel = showMobileButton
+    ? translate(
+        'auto.components.mobile.MobilePageToolbar.a4f8c2d91e',
+        'Remove Orca Mobile from left sidebar'
+      )
+    : translate(
+        'auto.components.mobile.MobilePageToolbar.b7e3d1c84a',
+        'Show Orca Mobile in left sidebar'
+      )
+  const sidebarToggleTooltip = showMobileButton
+    ? translate(
+        'auto.components.mobile.MobilePageToolbar.e1c7b4a92d',
+        'Configure in Settings > Mobile.'
+      )
+    : translate(
+        'auto.components.mobile.MobilePageToolbar.f3d8e5b71a',
+        'Adds the shortcut back to the left sidebar.'
+      )
+
   return (
     <div className="mp-page-toolbar">
+      <div className="mp-page-toolbar-primary">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={showMobileButton ? 'default' : 'secondary'}
+              size="sm"
+              className="mp-sidebar-toggle-btn"
+              onClick={onToggleMobileSidebarButton}
+              aria-label={sidebarToggleLabel}
+            >
+              {sidebarToggleLabel}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {sidebarToggleTooltip}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
             variant="ghost"
             size="icon"
-            className="size-7 rounded-full"
+            className="mp-page-toolbar-close size-7 shrink-0 rounded-full"
             onClick={onClose}
             aria-label={translate(
               'auto.components.mobile.MobilePageToolbar.9883b58693',
@@ -35,17 +73,6 @@ export function MobilePageToolbar({
           {translate('auto.components.mobile.MobilePageToolbar.ad2284a9e2', 'Close · Esc')}
         </TooltipContent>
       </Tooltip>
-      <Button
-        variant="outline"
-        size="sm"
-        className="h-8 gap-2 rounded-md bg-card px-3 text-xs font-medium shadow-xs"
-        onClick={onToggleMobileSidebarButton}
-      >
-        {showMobileButton ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
-        {showMobileButton
-          ? translate('auto.components.mobile.MobilePageToolbar.c669abcf8f', 'Hide from sidebar')
-          : translate('auto.components.mobile.MobilePageToolbar.fb5f28330e', 'Show in sidebar')}
-      </Button>
     </div>
   )
 }

--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -1,10 +1,13 @@
 import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
 import { MobilePane } from './MobilePane'
 import {
   getMobileOverviewSearchEntry,
+  getMobileSidebarShortcutSearchEntry,
   getMobileSettingsPaneSearchEntries
 } from './mobile-settings-search'
 import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
 export { getMobileSettingsPaneSearchEntries }
 
 const ORCA_IOS_APP_STORE_URL = 'https://apps.apple.com/app/orca-ide/id6766130217'
@@ -12,6 +15,9 @@ const ORCA_ANDROID_APK_URL =
   'https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.16/app-release.apk'
 
 export function MobileSettingsPane(): React.JSX.Element {
+  const showMobileButton = useAppStore((s) => s.settings?.showMobileButton !== false)
+  const updateSettings = useAppStore((s) => s.updateSettings)
+
   return (
     <div className="space-y-4">
       <SearchableSetting
@@ -50,6 +56,32 @@ export function MobileSettingsPane(): React.JSX.Element {
           </button>
           .
         </p>
+      </SearchableSetting>
+
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.MobileSettingsPane.1de96ec8a6',
+          'Show Orca Mobile Button'
+        )}
+        description={translate(
+          'auto.components.settings.MobileSettingsPane.682293cadf',
+          'Show the Orca Mobile button at the top of the left sidebar.'
+        )}
+        keywords={getMobileSidebarShortcutSearchEntry().keywords}
+      >
+        {/* Why: the in-page removal toast points users to Settings > Mobile. */}
+        <SettingsSwitchRow
+          label={translate(
+            'auto.components.settings.MobileSettingsPane.1de96ec8a6',
+            'Show Orca Mobile Button'
+          )}
+          description={translate(
+            'auto.components.settings.MobileSettingsPane.d4f2b65f30',
+            'Show the Orca Mobile shortcut in the sidebar.'
+          )}
+          checked={showMobileButton}
+          onChange={() => updateSettings({ showMobileButton: !showMobileButton })}
+        />
       </SearchableSetting>
 
       <div className="rounded-xl border border-border/60 bg-card/50 p-4">

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -114,11 +114,6 @@ const SETTINGS_NAV_GROUPS = [
     titleDefault: 'Remote Hosts'
   },
   {
-    id: 'mobile',
-    titleKey: 'auto.components.settings.Settings.mobile_group',
-    titleDefault: 'Mobile'
-  },
-  {
     id: 'security',
     titleKey: 'auto.components.settings.Settings.084d8fac5b',
     titleDefault: 'Privacy & Security'
@@ -1213,6 +1208,21 @@ function Settings(): React.JSX.Element {
                   {isSectionMounted('integrations') ? <IntegrationsPane /> : null}
                 </SettingsSection>
 
+                {showDesktopOnlySettings ? (
+                  <SettingsSection
+                    id="mobile"
+                    title={translate('auto.components.settings.Settings.c40dadaac8', 'Mobile')}
+                    badge="Beta"
+                    description={translate(
+                      'auto.components.settings.Settings.c6c01ac209',
+                      'Control terminals and agents from your phone.'
+                    )}
+                    searchEntries={getSectionSearchEntries('mobile')}
+                  >
+                    {isSectionMounted('mobile') ? <MobileSettingsPane /> : null}
+                  </SettingsSection>
+                ) : null}
+
                 <SettingsSection
                   id="git"
                   title={translate(
@@ -1490,32 +1500,17 @@ function Settings(): React.JSX.Element {
                 </SettingsSection>
 
                 {showDesktopOnlySettings ? (
-                  <>
-                    <SettingsSection
-                      id="ssh"
-                      title={translate('auto.components.settings.Settings.9b02492d1f', 'SSH Hosts')}
-                      description={translate(
-                        'auto.components.settings.Settings.c2ee313198',
-                        'Use existing machines over SSH for files, terminals, Git, and workspaces.'
-                      )}
-                      searchEntries={getSectionSearchEntries('ssh')}
-                    >
-                      {isSectionMounted('ssh') ? <SshPane /> : null}
-                    </SettingsSection>
-
-                    <SettingsSection
-                      id="mobile"
-                      title={translate('auto.components.settings.Settings.c40dadaac8', 'Mobile')}
-                      badge="Beta"
-                      description={translate(
-                        'auto.components.settings.Settings.c6c01ac209',
-                        'Control terminals and agents from your phone.'
-                      )}
-                      searchEntries={getSectionSearchEntries('mobile')}
-                    >
-                      {isSectionMounted('mobile') ? <MobileSettingsPane /> : null}
-                    </SettingsSection>
-                  </>
+                  <SettingsSection
+                    id="ssh"
+                    title={translate('auto.components.settings.Settings.9b02492d1f', 'SSH Hosts')}
+                    description={translate(
+                      'auto.components.settings.Settings.c2ee313198',
+                      'Use existing machines over SSH for files, terminals, Git, and workspaces.'
+                    )}
+                    searchEntries={getSectionSearchEntries('ssh')}
+                  >
+                    {isSectionMounted('ssh') ? <SshPane /> : null}
+                  </SettingsSection>
                 ) : null}
 
                 {showDesktopOnlySettings && isMac ? (

--- a/src/renderer/src/components/settings/mobile-settings-search.ts
+++ b/src/renderer/src/components/settings/mobile-settings-search.ts
@@ -54,6 +54,49 @@ export const getMobileOverviewSearchEntry = createLocalizedCatalog(
   })
 )
 
+export const getMobileSidebarShortcutSearchEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry => ({
+    title: translate(
+      'auto.components.settings.mobile.settings.search.1de96ec8a6',
+      'Show Orca Mobile Button'
+    ),
+    description: translate(
+      'auto.components.settings.mobile.settings.search.682293cadf',
+      'Show the Orca Mobile button at the top of the left sidebar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.mobile.settings.search.74618577c7',
+        'mobile'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.mobile.settings.search.5e5b8878bf',
+        'phone'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.mobile.settings.search.5bff6a2ef0',
+        'sidebar'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.mobile.settings.search.6cf5f54ce1',
+        'button'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.mobile.settings.search.648eeada79',
+        'hide'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.mobile.settings.search.ac79fe4a04',
+        'show'
+      )
+    ]
+  })
+)
+
 export const getMobileSettingsPaneSearchEntries = createLocalizedCatalog(
-  (): SettingsSearchEntry[] => [getMobileOverviewSearchEntry(), ...getMobilePaneSearchEntries()]
+  (): SettingsSearchEntry[] => [
+    getMobileOverviewSearchEntry(),
+    getMobileSidebarShortcutSearchEntry(),
+    ...getMobilePaneSearchEntries()
+  ]
 )

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -43,7 +43,6 @@ const SidebarNav = React.memo(function SidebarNav() {
   const showAgentsButton = useAppStore((s) => shouldShowAgentsButton(s.settings))
   const showAutomationsButton = useAppStore((s) => shouldShowAutomationsButton(s.settings))
   const showMobileButton = useAppStore((s) => shouldShowMobileButton(s.settings))
-
   const automationsActive = activeView === 'automations'
   const activityActive = activeView === 'activity'
   const mobileActive = activeView === 'mobile'

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -24,7 +24,7 @@ function ids(args: { isMac?: boolean; isWindows?: boolean; isWebClient?: boolean
 
 describe('settings navigation metadata', () => {
   it('puts AI capability panes at the top on desktop', () => {
-    expect(ids().slice(0, 9)).toEqual([
+    expect(ids().slice(0, 10)).toEqual([
       'agents',
       'accounts',
       'orchestration',
@@ -33,8 +33,20 @@ describe('settings navigation metadata', () => {
       'setup-guide',
       'general',
       'integrations',
+      'mobile',
       'git'
     ])
+  })
+
+  it('places Mobile under Set Up instead of its own sidebar group', () => {
+    const sections = buildSettingsNavigationMetadata({
+      isMac: false,
+      isWindows: false,
+      isWebClient: false,
+      repos: [repo]
+    })
+
+    expect(sections.find((section) => section.id === 'mobile')?.group).toBe('setup')
   })
 
   it('puts web-safe AI capability panes at the top while hiding desktop-only panes', () => {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -225,6 +225,21 @@ export function buildSettingsNavigationMetadata({
       searchEntries: getIntegrationsPaneSearchEntries(),
       group: 'setup'
     },
+    ...(showDesktopOnlySettings
+      ? [
+          {
+            id: 'mobile',
+            title: translate('auto.hooks.useSettingsNavigationMetadata.1cd25673df', 'Mobile'),
+            description: translate(
+              'auto.hooks.useSettingsNavigationMetadata.95a1886d94',
+              'Control terminals and agents from your phone.'
+            ),
+            icon: Smartphone,
+            searchEntries: getMobileSettingsPaneSearchEntries(),
+            group: 'setup'
+          }
+        ]
+      : []),
     {
       id: 'git',
       title: translate(
@@ -413,17 +428,6 @@ export function buildSettingsNavigationMetadata({
             icon: Cable,
             searchEntries: getSshPaneSearchEntries(),
             group: 'remote'
-          },
-          {
-            id: 'mobile',
-            title: translate('auto.hooks.useSettingsNavigationMetadata.1cd25673df', 'Mobile'),
-            description: translate(
-              'auto.hooks.useSettingsNavigationMetadata.95a1886d94',
-              'Control terminals and agents from your phone.'
-            ),
-            icon: Smartphone,
-            searchEntries: getMobileSettingsPaneSearchEntries(),
-            group: 'mobile'
           }
         ]
       : []),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5392,7 +5392,10 @@
           "b5a2ed83ff": "App Store",
           "c8491c17ef": "Control Orca from your phone by scanning a QR code. Beta / early preview - expect bugs and breaking changes. Get the iOS app from the",
           "e7a3ae8c4e": "Mobile",
-          "174f4a3c6d": "Control terminals and agents from your phone."
+          "174f4a3c6d": "Control terminals and agents from your phone.",
+          "1de96ec8a6": "Show Orca Mobile Button",
+          "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
+          "d4f2b65f30": "Show the Orca Mobile shortcut in the sidebar."
         },
         "NotificationsPane": {
           "906b4afebf": "Send Test Notification",
@@ -7459,7 +7462,9 @@
               "f4ed142753": "phone",
               "f213400800": "mobile",
               "671eb4173c": "Control terminals and agents from your phone.",
-              "ffd52a96e4": "Mobile"
+              "ffd52a96e4": "Mobile",
+              "1de96ec8a6": "Show Orca Mobile Button",
+              "682293cadf": "Show the Orca Mobile button at the top of the left sidebar."
             }
           }
         },
@@ -9749,7 +9754,11 @@
           "ad2284a9e2": "Close · Esc",
           "9883b58693": "Close Orca Mobile",
           "fb5f28330e": "Show in sidebar",
-          "c669abcf8f": "Hide from sidebar"
+          "c669abcf8f": "Hide from sidebar",
+          "e1c7b4a92d": "Configure in Settings > Mobile.",
+          "a4f8c2d91e": "Remove Orca Mobile from left sidebar",
+          "b7e3d1c84a": "Show Orca Mobile in left sidebar",
+          "f3d8e5b71a": "Adds the shortcut back to the left sidebar."
         },
         "PhoneCarousel": {
           "96d651cb87": "Terminal session",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5355,7 +5355,10 @@
           "b5a2ed83ff": "Tienda de aplicaciones",
           "c8491c17ef": "Controla Orca desde tu teléfono escaneando un código QR. Beta/vista previa anticipada: espere errores y cambios importantes. Obtenga la aplicación para iOS desde",
           "e7a3ae8c4e": "Móvil",
-          "174f4a3c6d": "Controla terminales y agents desde tu teléfono."
+          "174f4a3c6d": "Controla terminales y agents desde tu teléfono.",
+          "1de96ec8a6": "Show Orca Mobile Button",
+          "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
+          "d4f2b65f30": "Show the Orca Mobile shortcut in the sidebar."
         },
         "NotificationsPane": {
           "906b4afebf": "Enviar notificación de prueba",
@@ -7422,7 +7425,9 @@
               "f4ed142753": "teléfono",
               "f213400800": "móvil",
               "671eb4173c": "Controla terminales y agents desde tu teléfono.",
-              "ffd52a96e4": "Móvil"
+              "ffd52a96e4": "Móvil",
+              "1de96ec8a6": "Show Orca Mobile Button",
+              "682293cadf": "Show the Orca Mobile button at the top of the left sidebar."
             }
           }
         },
@@ -9749,7 +9754,11 @@
           "ad2284a9e2": "Cerrar · Esc",
           "9883b58693": "Cerrar Orca Móvil",
           "fb5f28330e": "Mostrar en la barra lateral",
-          "c669abcf8f": "Ocultar de la barra lateral"
+          "c669abcf8f": "Ocultar de la barra lateral",
+          "e1c7b4a92d": "Configure in Settings > Mobile.",
+          "a4f8c2d91e": "Remove Orca Mobile from left sidebar",
+          "b7e3d1c84a": "Show Orca Mobile in left sidebar",
+          "f3d8e5b71a": "Adds the shortcut back to the left sidebar."
         },
         "PhoneCarousel": {
           "96d651cb87": "Sesión terminal",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5377,7 +5377,10 @@
           "b5a2ed83ff": "アプリストア",
           "c8491c17ef": "QR コードをスキャンしてスマートフォンから Orca を制御します。ベータ/早期プレビュー - バグや重大な変更が予想されます。 iOS アプリを次の場所から入手します。",
           "e7a3ae8c4e": "モバイル",
-          "174f4a3c6d": "スマートフォンから terminals と agents を操作"
+          "174f4a3c6d": "スマートフォンから terminals と agents を操作",
+          "1de96ec8a6": "Show Orca Mobile Button",
+          "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
+          "d4f2b65f30": "Show the Orca Mobile shortcut in the sidebar."
         },
         "NotificationsPane": {
           "906b4afebf": "テスト通知を送信する",
@@ -7444,7 +7447,9 @@
               "f4ed142753": "スマートフォン",
               "f213400800": "モバイル",
               "671eb4173c": "スマートフォンから terminals と agents を操作",
-              "ffd52a96e4": "モバイル"
+              "ffd52a96e4": "モバイル",
+              "1de96ec8a6": "Show Orca Mobile Button",
+              "682293cadf": "Show the Orca Mobile button at the top of the left sidebar."
             }
           }
         },
@@ -9749,7 +9754,11 @@
           "ad2284a9e2": "閉じる・Esc",
           "9883b58693": "Orca モバイルを閉じる",
           "fb5f28330e": "サイドバーに表示",
-          "c669abcf8f": "サイドバーから隠す"
+          "c669abcf8f": "サイドバーから隠す",
+          "e1c7b4a92d": "Configure in Settings > Mobile.",
+          "a4f8c2d91e": "Remove Orca Mobile from left sidebar",
+          "b7e3d1c84a": "Show Orca Mobile in left sidebar",
+          "f3d8e5b71a": "Adds the shortcut back to the left sidebar."
         },
         "PhoneCarousel": {
           "96d651cb87": "Terminal セッション",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5340,7 +5340,10 @@
           "b5a2ed83ff": "앱스토어",
           "c8491c17ef": "QR 코드를 스캔하여 휴대폰에서 Orca를 제어하세요. 베타/초기 미리보기 - 버그 및 주요 변경 사항이 예상됩니다. 다음에서 iOS 앱을 받으세요.",
           "e7a3ae8c4e": "모바일",
-          "174f4a3c6d": "휴대폰에서 terminals과 agents를 제어하세요."
+          "174f4a3c6d": "휴대폰에서 terminals과 agents를 제어하세요.",
+          "1de96ec8a6": "Show Orca Mobile Button",
+          "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
+          "d4f2b65f30": "Show the Orca Mobile shortcut in the sidebar."
         },
         "NotificationsPane": {
           "906b4afebf": "테스트 알림 보내기",
@@ -7407,7 +7410,9 @@
               "f4ed142753": "핸드폰",
               "f213400800": "모바일",
               "671eb4173c": "휴대폰에서 terminals과 agents를 제어하세요.",
-              "ffd52a96e4": "모바일"
+              "ffd52a96e4": "모바일",
+              "1de96ec8a6": "Show Orca Mobile Button",
+              "682293cadf": "Show the Orca Mobile button at the top of the left sidebar."
             }
           }
         },
@@ -9749,7 +9754,11 @@
           "ad2284a9e2": "닫기 · Esc",
           "9883b58693": "Orca 모바일 닫기",
           "fb5f28330e": "사이드바에 표시",
-          "c669abcf8f": "사이드바에서 숨기기"
+          "c669abcf8f": "사이드바에서 숨기기",
+          "e1c7b4a92d": "Configure in Settings > Mobile.",
+          "a4f8c2d91e": "Remove Orca Mobile from left sidebar",
+          "b7e3d1c84a": "Show Orca Mobile in left sidebar",
+          "f3d8e5b71a": "Adds the shortcut back to the left sidebar."
         },
         "PhoneCarousel": {
           "96d651cb87": "Terminal 세션",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5340,7 +5340,10 @@
           "b5a2ed83ff": "应用商店",
           "c8491c17ef": "通过扫描二维码从手机控制 Orca。 Beta/早期预览 - 预计会出现错误和重大更改。从以下位置获取 iOS 应用程序",
           "e7a3ae8c4e": "移动端",
-          "174f4a3c6d": "通过手机控制终端和智能体。"
+          "174f4a3c6d": "通过手机控制终端和智能体。",
+          "1de96ec8a6": "Show Orca Mobile Button",
+          "682293cadf": "Show the Orca Mobile button at the top of the left sidebar.",
+          "d4f2b65f30": "Show the Orca Mobile shortcut in the sidebar."
         },
         "NotificationsPane": {
           "906b4afebf": "发送测试通知",
@@ -7407,7 +7410,9 @@
               "f4ed142753": "手机",
               "f213400800": "移动端",
               "671eb4173c": "通过手机控制终端和智能体。",
-              "ffd52a96e4": "移动端"
+              "ffd52a96e4": "移动端",
+              "1de96ec8a6": "Show Orca Mobile Button",
+              "682293cadf": "Show the Orca Mobile button at the top of the left sidebar."
             }
           }
         },
@@ -9749,7 +9754,11 @@
           "ad2284a9e2": "关闭 · Esc",
           "9883b58693": "关闭 Orca 手机",
           "fb5f28330e": "在侧边栏中显示",
-          "c669abcf8f": "从侧边栏隐藏"
+          "c669abcf8f": "从侧边栏隐藏",
+          "e1c7b4a92d": "Configure in Settings > Mobile.",
+          "a4f8c2d91e": "Remove Orca Mobile from left sidebar",
+          "b7e3d1c84a": "Show Orca Mobile in left sidebar",
+          "f3d8e5b71a": "Adds the shortcut back to the left sidebar."
         },
         "PhoneCarousel": {
           "96d651cb87": "终端会话",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2561,7 +2561,7 @@ export type GlobalSettings = {
   /** Why: Automations can be restored from Settings or the View menu, so this
    *  only controls whether the top-level sidebar shortcut is shown. */
   showAutomationsButton?: boolean
-  /** Why: Orca Mobile remains reachable from the toolbox; this only controls
+  /** Why: Orca Mobile remains reachable from Settings; this only controls
    *  whether the top-level sidebar shortcut is shown. */
   showMobileButton?: boolean
   /** Controls how Ctrl+Tab chooses the next visible tab. Optional for


### PR DESCRIPTION
## Summary

- Move Orca Mobile into the Set Up settings group and remove its separate sidebar group.
- Make the in-page Mobile toolbar action explicit for removing/restoring the left-sidebar shortcut.
- Add the same sidebar shortcut switch to Settings > Mobile so the removal toast points to a real restore path.
- Sync localization catalog entries and add focused toolbar/navigation coverage.

## Screenshots

Not captured; this is a small toolbar/settings placement change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional focused checks:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/mobile/MobilePageToolbar.test.tsx src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts src/renderer/src/components/sidebar/SidebarNav.test.tsx`
- [x] `pnpm run verify:localization-catalog`

## AI Review Report

Ran a two-round AI review against the branch diff and current worktree. The review checked correctness, security, type safety, error handling, performance, dead code, unused imports, and cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and Electron-specific platform differences touched by this PR.

Round 1 flagged missing localization catalog entries and a brittle static-markup assertion around escaped `>` text. I synced the localization catalog, verified the test assertion, and added the Settings > Mobile restore switch so the new toast copy has a matching destination. Round 2 found no issues.

## Security Audit

Reviewed the changed UI/settings code for input handling, command execution, path handling, auth, secrets, dependency, and IPC risk. This PR does not add command execution, file/path handling, auth, secrets, dependencies, or new IPC surfaces. Existing external links in Mobile settings remain routed through the existing `window.api.shell.openUrl` path.

## Notes

No platform-specific behavior changes are expected. Orca Mobile remains desktop-only in settings metadata and hidden from web-client settings.
