### PR TITLE
Shorten Orca Mobile toolbar labels

### DIFF
--- a/src/renderer/src/components/mobile/MobilePageToolbar.test.tsx
+++ b/src/renderer/src/components/mobile/MobilePageToolbar.test.tsx
@@ -18,10 +18,10 @@ describe('MobilePageToolbar', () => {
       <MobilePageToolbar showMobileButton onClose={vi.fn()} onToggleMobileSidebarButton={vi.fn()} />
     )
 
-    expect(html).toContain('Remove Orca Mobile from left sidebar')
+    expect(html).toContain('Hide from sidebar')
     expect(html).toContain('mp-page-toolbar-primary')
     expect(html).toContain('Configure in Settings')
-    expect(html).not.toContain('Hide from sidebar')
+    expect(html).not.toContain('Remove Orca Mobile')
   })
 
   it('labels the restore action explicitly when Orca Mobile is hidden from the sidebar', () => {
@@ -33,7 +33,6 @@ describe('MobilePageToolbar', () => {
       />
     )
 
-    expect(html).toContain('Show Orca Mobile in left sidebar')
-    expect(html).not.toContain('Show in sidebar')
+    expect(html).toContain('Show in sidebar')
   })
 })

--- a/src/renderer/src/components/mobile/MobilePageToolbar.tsx
+++ b/src/renderer/src/components/mobile/MobilePageToolbar.tsx
@@ -15,14 +15,8 @@ export function MobilePageToolbar({
   onToggleMobileSidebarButton
 }: MobilePageToolbarProps): React.JSX.Element {
   const sidebarToggleLabel = showMobileButton
-    ? translate(
-        'auto.components.mobile.MobilePageToolbar.a4f8c2d91e',
-        'Remove Orca Mobile from left sidebar'
-      )
-    : translate(
-        'auto.components.mobile.MobilePageToolbar.b7e3d1c84a',
-        'Show Orca Mobile in left sidebar'
-      )
+    ? translate('auto.components.mobile.MobilePageToolbar.c669abcf8f', 'Hide from sidebar')
+    : translate('auto.components.mobile.MobilePageToolbar.fb5f28330e', 'Show in sidebar')
   const sidebarToggleTooltip = showMobileButton
     ? translate(
         'auto.components.mobile.MobilePageToolbar.e1c7b4a92d',
@@ -30,7 +24,7 @@ export function MobilePageToolbar({
       )
     : translate(
         'auto.components.mobile.MobilePageToolbar.f3d8e5b71a',
-        'Adds the shortcut back to the left sidebar.'
+        'Adds the shortcut back to the sidebar.'
       )
 
   return (

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9756,9 +9756,9 @@
           "fb5f28330e": "Show in sidebar",
           "c669abcf8f": "Hide from sidebar",
           "e1c7b4a92d": "Configure in Settings > Mobile.",
-          "a4f8c2d91e": "Remove Orca Mobile from left sidebar",
-          "b7e3d1c84a": "Show Orca Mobile in left sidebar",
-          "f3d8e5b71a": "Adds the shortcut back to the left sidebar."
+          "a4f8c2d91e": "Hide from sidebar",
+          "b7e3d1c84a": "Show in sidebar",
+          "f3d8e5b71a": "Adds the shortcut back to the sidebar."
         },
         "PhoneCarousel": {
           "96d651cb87": "Terminal session",


### PR DESCRIPTION
## Summary

- Shorten the Orca Mobile toolbar sidebar toggle labels back to `Hide from sidebar` / `Show in sidebar`.
- Keep the Settings > Mobile tooltip guidance and update the toolbar test expectations.
- Update the English localization fallback text for the changed toolbar copy.

## Screenshots

Not captured; this is a small copy-only UI change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional focused checks:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/mobile/MobilePageToolbar.test.tsx`
- [x] `pnpm run verify:localization-catalog`

## AI Review Report

Reviewed the small follow-up diff for correctness, dead code, localization consistency, and cross-platform impact. The change is copy-only in React UI/tests and does not touch platform-specific shortcut labels, file paths, shell behavior, or Electron platform APIs.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependencies, or IPC surfaces are introduced. This PR only changes toolbar copy, matching test expectations, and English localization fallback values.

## Notes

Direct follow-up to #6551.
