### PR TITLE
fix(runtime): require sustained quiescence for tui-idle waits

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7471,6 +7471,61 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('does not report tui-idle while a name-only agent title keeps streaming output', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+
+      // 'Codex' is a name-only title → detectAgentStatusFromTitle defaults it to
+      // 'idle' even though the agent is actively working (the spinner and "esc to
+      // interrupt" live in the terminal body, not the OSC title). Pre-fix this
+      // made tui-idle satisfy in ~0s mid-work.
+      runtime.onPtyData('pty-bg', '\x1b]0;Codex\x07working 1\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+      let settled = false
+      void waitPromise.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+
+      // Keep streaming: each chunk refreshes lastOutputAt, so the debounce
+      // window never elapses and the wait must not resolve.
+      for (let i = 2; i <= 6; i++) {
+        runtime.onPtyData('pty-bg', `working ${i}\n`, Date.now())
+        await vi.advanceTimersByTimeAsync(2_000)
+      }
+      expect(settled).toBe(false)
+
+      // Agent finishes: output goes quiet. After >= TUI_IDLE_QUIESCENCE_MS the
+      // sustained-idle debounce elapses and the wait resolves.
+      await vi.advanceTimersByTimeAsync(4_000)
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resolves tui-idle from a Codex ready prompt preview', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7513,8 +7513,81 @@ describe('OrcaRuntimeService', () => {
       expect(settled).toBe(false)
 
       // Agent finishes: output goes quiet. After >= TUI_IDLE_QUIESCENCE_MS the
-      // sustained-idle debounce elapses and the wait resolves.
-      await vi.advanceTimersByTimeAsync(4_000)
+      // sustained-idle debounce elapses and the wait resolves without waiting
+      // for another fallback poll interval.
+      await vi.advanceTimersByTimeAsync(999)
+      expect(settled).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resolves tui-idle immediately on an explicit idle OSC title', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData('pty-bg', '\x1b]0;Codex working\x07working\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+
+      runtime.onPtyData('pty-bg', '\x1b]0;Codex done\x07done\n', Date.now())
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resolves ambiguous tui-idle at the quiet deadline instead of the next poll', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData('pty-bg', '\x1b]0;Codex\x07last chunk\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000
+      })
+      let settled = false
+      void waitPromise.then(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(2_999)
+      expect(settled).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
       await expect(waitPromise).resolves.toMatchObject({
         handle,
         condition: 'tui-idle',
@@ -9457,6 +9530,39 @@ describe('OrcaRuntimeService', () => {
       expect(unread).toHaveLength(1)
       expect(unread[0].read).toBe(0)
       expect(unread[0].delivered_at).not.toBeNull()
+      db.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('delays push-on-idle message delivery for ambiguous name-only idle titles', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      const db = new InMemoryOrchestrationMessages()
+      const write = vi.fn().mockReturnValue(true)
+      setInMemoryOrchestrationMessages(runtime, db)
+      runtime.setPtyController({
+        write,
+        kill: vi.fn(),
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime)
+
+      const [terminal] = (await runtime.listTerminals()).terminals
+      db.insertMessage({ from: 'term_sender', to: terminal.handle, subject: 'quiet hello' })
+      runtime.onPtyData('pty-1', '\x1b]0;Codex working\x07working\n', Date.now())
+      runtime.onPtyData('pty-1', '\x1b]0;Codex\x07working 1\n', Date.now())
+
+      await vi.advanceTimersByTimeAsync(2_999)
+      expect(write).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(write).toHaveBeenCalledWith('pty-1', expect.stringContaining('Subject: quiet hello'))
+
+      await vi.advanceTimersByTimeAsync(500)
       db.close()
     } finally {
       vi.useRealTimers()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1165,7 +1165,14 @@ type TerminalWaiter = {
   reject: (error: Error) => void
   timeout: NodeJS.Timeout | null
   pollInterval: NodeJS.Timeout | null
+  quietTimeout: NodeJS.Timeout | null
   abortCleanup: (() => void) | null
+}
+
+type TuiIdleStatusTarget = {
+  lastAgentStatus: AgentStatus | null
+  lastOscTitle: string | null
+  lastOutputAt: number | null
 }
 
 type MessageWaiter = {
@@ -1813,6 +1820,7 @@ export class OrcaRuntimeService {
   private detachedPreAllocatedLeaves = new Map<string, RuntimeLeafRecord>()
   private graphSyncCallbacks: (() => void)[] = []
   private waitersByHandle = new Map<string, Set<TerminalWaiter>>()
+  private tuiIdleDeliveryTimeoutsByLeafKey = new Map<string, NodeJS.Timeout>()
   private ptyController: RuntimePtyController | null = null
   private notifier: RuntimeNotifier | null = null
   private clientEventListeners = new Set<(event: RuntimeClientEvent) => void>()
@@ -5073,7 +5081,9 @@ export class OrcaRuntimeService {
         // which isn't a task-completion signal.
         if (agentStatus === 'idle' && prevStatus !== 'idle') {
           this.resolveTuiIdleWaiters(leaf)
-          this.deliverPendingMessages(leaf)
+          this.deliverPendingMessagesWhenTuiIdleSatisfied(leaf)
+        } else if (agentStatus !== 'idle') {
+          this.clearTuiIdleDeliveryTimeout(leaf)
         }
       }
     }
@@ -8447,7 +8457,7 @@ export class OrcaRuntimeService {
       if (condition === 'tui-idle' && ptyBlockedReason) {
         return buildPtyTerminalWaitBlockedResult(handle, condition, pty.pty, ptyBlockedReason)
       }
-      if (condition === 'tui-idle' && this.hasSustainedTuiIdle(pty.pty)) {
+      if (condition === 'tui-idle' && this.hasSatisfiedTuiIdle(pty.pty)) {
         return buildPtyTerminalWaitResult(handle, condition, pty.pty)
       }
       if (
@@ -8472,6 +8482,7 @@ export class OrcaRuntimeService {
           reject,
           timeout: null,
           pollInterval: null,
+          quietTimeout: null,
           abortCleanup: null
         }
         if (!this.bindTerminalWaiterAbort(waiter, options?.signal)) {
@@ -8508,7 +8519,7 @@ export class OrcaRuntimeService {
               waiter,
               buildPtyTerminalWaitBlockedResult(handle, condition, live.pty, blockedReason)
             )
-          } else if (this.hasSustainedTuiIdle(live.pty)) {
+          } else if (this.hasSatisfiedTuiIdle(live.pty)) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
           } else if (
             (this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' &&
@@ -8539,7 +8550,7 @@ export class OrcaRuntimeService {
     // detection that powers the renderer's "Task complete" notifications.
     // Why: only 'idle' satisfies tui-idle, not 'permission'. Permission means the
     // agent is blocked on user approval, not finished with its task.
-    if (condition === 'tui-idle' && this.hasSustainedTuiIdle(leaf)) {
+    if (condition === 'tui-idle' && this.hasSatisfiedTuiIdle(leaf)) {
       return buildTerminalWaitResult(handle, condition, leaf)
     }
     if (condition === 'tui-idle') {
@@ -8572,6 +8583,7 @@ export class OrcaRuntimeService {
         reject,
         timeout: null,
         pollInterval: null,
+        quietTimeout: null,
         abortCleanup: null
       }
 
@@ -8613,7 +8625,7 @@ export class OrcaRuntimeService {
               waiter,
               buildTerminalWaitBlockedResult(handle, condition, live.leaf, blockedReason)
             )
-          } else if (this.hasSustainedTuiIdle(live.leaf)) {
+          } else if (this.hasSatisfiedTuiIdle(live.leaf)) {
             // Why: don't clear lastAgentStatus here. It's a factual record of the
             // last detected OSC state, not a one-shot signal. Clearing it causes
             // subsequent tui-idle waiters to hang even though the agent is idle —
@@ -18113,7 +18125,7 @@ export class OrcaRuntimeService {
   deliverPendingMessagesForHandle(handle: string): void {
     try {
       const { leaf } = this.getLiveLeafForHandle(handle)
-      if (leaf.lastAgentStatus === 'idle') {
+      if (this.hasSatisfiedTuiIdle(leaf)) {
         this.deliverPendingMessages(leaf)
       }
     } catch {
@@ -18465,20 +18477,62 @@ export class OrcaRuntimeService {
     return Date.now() - target.lastOutputAt < TUI_IDLE_QUIESCENCE_MS
   }
 
+  // Why: explicit OSC idle markers are the agent's own completion signal. Only
+  // ambiguous default-idle titles need the output-quiescence debounce.
+  private hasExplicitOscTuiIdle(target: TuiIdleStatusTarget): boolean {
+    return (
+      target.lastAgentStatus === 'idle' &&
+      target.lastOscTitle !== null &&
+      detectExplicitIdleStatusFromTitle(target.lastOscTitle) === 'idle'
+    )
+  }
+
   // Why: treat a title-derived 'idle' status as satisfying tui-idle only after
   // output has been quiet for TUI_IDLE_QUIESCENCE_MS — i.e. require *sustained*
-  // idle (debounce). A genuinely finished agent stops emitting, so the debounce
-  // window elapses; an agent that merely flashed an idle-looking title mid-work
-  // keeps producing output and never satisfies. Body-level prompt detection
-  // (isKnownReadyPromptPreview) is a direct "cursor at input prompt" signal and
-  // stays immediate; adopted/daemon handles with no PTY output stream
-  // (lastOutputAt == null) have nothing to debounce, so their title signal
-  // also stands.
-  private hasSustainedTuiIdle(target: {
-    lastAgentStatus: AgentStatus | null
-    lastOutputAt: number | null
-  }): boolean {
+  // idle (debounce). Explicit OSC idle titles bypass this helper via
+  // hasSatisfiedTuiIdle; ambiguous name-only agent titles do not.
+  private hasSustainedTuiIdle(target: TuiIdleStatusTarget): boolean {
     return target.lastAgentStatus === 'idle' && !this.isTuiOutputActive(target)
+  }
+
+  private hasSatisfiedTuiIdle(target: TuiIdleStatusTarget): boolean {
+    return this.hasExplicitOscTuiIdle(target) || this.hasSustainedTuiIdle(target)
+  }
+
+  private isTerminalWaiterActive(waiter: TerminalWaiter): boolean {
+    return this.waitersByHandle.get(waiter.handle)?.has(waiter) ?? false
+  }
+
+  private scheduleTuiIdleQuietCheck(
+    waiter: TerminalWaiter,
+    target: TuiIdleStatusTarget,
+    resolve: () => void
+  ): void {
+    if (!this.isTerminalWaiterActive(waiter)) {
+      return
+    }
+    if (this.hasSatisfiedTuiIdle(target)) {
+      return
+    }
+    if (target.lastAgentStatus !== 'idle' || target.lastOutputAt === null) {
+      return
+    }
+    if (waiter.quietTimeout) {
+      clearTimeout(waiter.quietTimeout)
+    }
+    const elapsedMs = Date.now() - target.lastOutputAt
+    const remainingMs = Math.max(TUI_IDLE_QUIESCENCE_MS - elapsedMs, 0)
+    waiter.quietTimeout = setTimeout(() => {
+      waiter.quietTimeout = null
+      if (!this.isTerminalWaiterActive(waiter)) {
+        return
+      }
+      if (this.hasSatisfiedTuiIdle(target)) {
+        resolve()
+        return
+      }
+      this.scheduleTuiIdleQuietCheck(waiter, target, resolve)
+    }, remainingMs)
   }
 
   private resolveTuiIdleWaiters(leaf: RuntimeLeafRecord): void {
@@ -18491,11 +18545,15 @@ export class OrcaRuntimeService {
       return
     }
     for (const waiter of [...waiters]) {
-      // Why: only resolve once idle is *sustained*. The transition fires the
-      // instant an idle-looking title arrives, which is itself fresh output; the
-      // fallback poll re-checks and resolves once output goes quiet.
-      if (waiter.condition === 'tui-idle' && this.hasSustainedTuiIdle(leaf)) {
+      if (waiter.condition !== 'tui-idle') {
+        continue
+      }
+      if (this.hasSatisfiedTuiIdle(leaf)) {
         this.resolveWaiter(waiter, buildTerminalWaitResult(handle, 'tui-idle', leaf))
+      } else {
+        this.scheduleTuiIdleQuietCheck(waiter, leaf, () => {
+          this.resolveWaiter(waiter, buildTerminalWaitResult(handle, 'tui-idle', leaf))
+        })
       }
     }
   }
@@ -18529,9 +18587,15 @@ export class OrcaRuntimeService {
       return
     }
     for (const waiter of [...waiters]) {
-      // Why: only resolve once idle is *sustained* (see resolveTuiIdleWaiters).
-      if (waiter.condition === 'tui-idle' && this.hasSustainedTuiIdle(pty)) {
+      if (waiter.condition !== 'tui-idle') {
+        continue
+      }
+      if (this.hasSatisfiedTuiIdle(pty)) {
         this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, 'tui-idle', pty))
+      } else {
+        this.scheduleTuiIdleQuietCheck(waiter, pty, () => {
+          this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, 'tui-idle', pty))
+        })
       }
     }
   }
@@ -18544,13 +18608,16 @@ export class OrcaRuntimeService {
   // + output quiescence. The poll self-cancels when the primary OSC path fires.
   private startTuiIdleFallbackPoll(waiter: TerminalWaiter, leaf: RuntimeLeafRecord): void {
     let foregroundPollInFlight = false
+    this.scheduleTuiIdleQuietCheck(waiter, leaf, () => {
+      this.resolveWaiter(waiter, buildTerminalWaitResult(waiter.handle, 'tui-idle', leaf))
+    })
     waiter.pollInterval = setInterval(async () => {
       if (!waiter.pollInterval) {
         return
       }
       let startedForegroundPoll = false
       try {
-        if (this.hasSustainedTuiIdle(leaf)) {
+        if (this.hasSatisfiedTuiIdle(leaf)) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -18572,6 +18639,9 @@ export class OrcaRuntimeService {
             return
           }
         }
+        this.scheduleTuiIdleQuietCheck(waiter, leaf, () => {
+          this.resolveWaiter(waiter, buildTerminalWaitResult(waiter.handle, 'tui-idle', leaf))
+        })
         const leafWaitText = buildTerminalWaitText(
           leaf.tailBuffer,
           leaf.tailPartialLine,
@@ -18631,13 +18701,16 @@ export class OrcaRuntimeService {
 
   private startPtyTuiIdleFallbackPoll(waiter: TerminalWaiter, pty: RuntimePtyWorktreeRecord): void {
     let foregroundPollInFlight = false
+    this.scheduleTuiIdleQuietCheck(waiter, pty, () => {
+      this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
+    })
     waiter.pollInterval = setInterval(async () => {
       if (!waiter.pollInterval) {
         return
       }
       let startedForegroundPoll = false
       try {
-        if (this.hasSustainedTuiIdle(pty)) {
+        if (this.hasSatisfiedTuiIdle(pty)) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -18671,6 +18744,9 @@ export class OrcaRuntimeService {
           this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
           return
         }
+        this.scheduleTuiIdleQuietCheck(waiter, pty, () => {
+          this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
+        })
         if (pty.lastAgentStatus === null && this.ptyController && !foregroundPollInFlight) {
           foregroundPollInFlight = true
           startedForegroundPoll = true
@@ -18711,6 +18787,47 @@ export class OrcaRuntimeService {
       }
     }
     return null
+  }
+
+  private clearTuiIdleDeliveryTimeout(leaf: RuntimeLeafRecord): void {
+    const leafKey = this.getLeafKey(leaf.tabId, leaf.leafId)
+    const timeout = this.tuiIdleDeliveryTimeoutsByLeafKey.get(leafKey)
+    if (!timeout) {
+      return
+    }
+    clearTimeout(timeout)
+    this.tuiIdleDeliveryTimeoutsByLeafKey.delete(leafKey)
+  }
+
+  // Why: push-on-idle has the same correctness boundary as tui-idle waits:
+  // name-only idle must not inject text until output has actually gone quiet.
+  private deliverPendingMessagesWhenTuiIdleSatisfied(leaf: RuntimeLeafRecord): void {
+    const handle = this.handleByLeafKey.get(this.getLeafKey(leaf.tabId, leaf.leafId))
+    if (!handle || !this._orchestrationDb) {
+      return
+    }
+    if (this._orchestrationDb.getUndeliveredUnreadMessages(handle).length === 0) {
+      this.clearTuiIdleDeliveryTimeout(leaf)
+      return
+    }
+    if (this.hasSatisfiedTuiIdle(leaf)) {
+      this.clearTuiIdleDeliveryTimeout(leaf)
+      this.deliverPendingMessages(leaf)
+      return
+    }
+    if (leaf.lastAgentStatus !== 'idle' || leaf.lastOutputAt === null) {
+      this.clearTuiIdleDeliveryTimeout(leaf)
+      return
+    }
+    this.clearTuiIdleDeliveryTimeout(leaf)
+    const elapsedMs = Date.now() - leaf.lastOutputAt
+    const remainingMs = Math.max(TUI_IDLE_QUIESCENCE_MS - elapsedMs, 0)
+    const leafKey = this.getLeafKey(leaf.tabId, leaf.leafId)
+    const timeout = setTimeout(() => {
+      this.tuiIdleDeliveryTimeoutsByLeafKey.delete(leafKey)
+      this.deliverPendingMessagesWhenTuiIdleSatisfied(leaf)
+    }, remainingMs)
+    this.tuiIdleDeliveryTimeoutsByLeafKey.set(leafKey, timeout)
   }
 
   // Why: push-on-idle delivery — when an agent transitions working→idle, check
@@ -18827,6 +18944,10 @@ export class OrcaRuntimeService {
     }
     if (waiter.pollInterval) {
       clearInterval(waiter.pollInterval)
+    }
+    if (waiter.quietTimeout) {
+      clearTimeout(waiter.quietTimeout)
+      waiter.quietTimeout = null
     }
     if (waiter.abortCleanup) {
       waiter.abortCleanup()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -8447,12 +8447,13 @@ export class OrcaRuntimeService {
       if (condition === 'tui-idle' && ptyBlockedReason) {
         return buildPtyTerminalWaitBlockedResult(handle, condition, pty.pty, ptyBlockedReason)
       }
-      if (condition === 'tui-idle' && pty.pty.lastAgentStatus === 'idle') {
+      if (condition === 'tui-idle' && this.hasSustainedTuiIdle(pty.pty)) {
         return buildPtyTerminalWaitResult(handle, condition, pty.pty)
       }
       if (
         condition === 'tui-idle' &&
-        (this.getAdoptedPtyExplicitIdleStatus(pty.pty) === 'idle' ||
+        ((this.getAdoptedPtyExplicitIdleStatus(pty.pty) === 'idle' &&
+          !this.isTuiOutputActive(pty.pty)) ||
           isKnownReadyPromptPreview(ptyWaitText))
       ) {
         return buildPtyTerminalWaitResult(handle, condition, pty.pty)
@@ -8507,10 +8508,11 @@ export class OrcaRuntimeService {
               waiter,
               buildPtyTerminalWaitBlockedResult(handle, condition, live.pty, blockedReason)
             )
-          } else if (live.pty.lastAgentStatus === 'idle') {
+          } else if (this.hasSustainedTuiIdle(live.pty)) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
           } else if (
-            this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' ||
+            (this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' &&
+              !this.isTuiOutputActive(live.pty)) ||
             isKnownReadyPromptPreview(livePtyWaitText)
           ) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
@@ -8537,13 +8539,15 @@ export class OrcaRuntimeService {
     // detection that powers the renderer's "Task complete" notifications.
     // Why: only 'idle' satisfies tui-idle, not 'permission'. Permission means the
     // agent is blocked on user approval, not finished with its task.
-    if (condition === 'tui-idle' && leaf.lastAgentStatus === 'idle') {
+    if (condition === 'tui-idle' && this.hasSustainedTuiIdle(leaf)) {
       return buildTerminalWaitResult(handle, condition, leaf)
     }
     if (condition === 'tui-idle') {
       const fastPathTitle = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
       if (
-        (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
+        (fastPathTitle &&
+          detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle' &&
+          !this.isTuiOutputActive(leaf)) ||
         isKnownReadyPromptPreview(leafWaitText)
       ) {
         return buildTerminalWaitResult(handle, condition, leaf)
@@ -8609,7 +8613,7 @@ export class OrcaRuntimeService {
               waiter,
               buildTerminalWaitBlockedResult(handle, condition, live.leaf, blockedReason)
             )
-          } else if (live.leaf.lastAgentStatus === 'idle') {
+          } else if (this.hasSustainedTuiIdle(live.leaf)) {
             // Why: don't clear lastAgentStatus here. It's a factual record of the
             // last detected OSC state, not a one-shot signal. Clearing it causes
             // subsequent tui-idle waiters to hang even though the agent is idle —
@@ -8621,7 +8625,9 @@ export class OrcaRuntimeService {
             // preview/title until the waiter resolves or hits its timeout.
             const fastPathTitle = live.leaf.paneTitle ?? this.tabs.get(live.leaf.tabId)?.title
             if (
-              (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
+              (fastPathTitle &&
+                detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle' &&
+                !this.isTuiOutputActive(live.leaf)) ||
               isKnownReadyPromptPreview(liveLeafWaitText)
             ) {
               this.resolveWaiter(waiter, buildTerminalWaitResult(handle, condition, live.leaf))
@@ -18445,6 +18451,36 @@ export class OrcaRuntimeService {
     }
   }
 
+  // Why: a single OSC-title 'idle' sample is not proof an agent finished. Agents
+  // render their working spinner and "esc to interrupt" in the terminal BODY,
+  // and detectAgentStatusFromTitle() defaults a name-only agent title (e.g.
+  // "Devin", "Codex", "aider") to 'idle'. So an actively-working agent is
+  // routinely reported idle by its title alone, which made `terminal wait --for
+  // tui-idle` fire in ~0s mid-work. While output is still streaming, the
+  // terminal is by definition not idle regardless of what the title says.
+  private isTuiOutputActive(target: { lastOutputAt: number | null }): boolean {
+    if (!target.lastOutputAt) {
+      return false
+    }
+    return Date.now() - target.lastOutputAt < TUI_IDLE_QUIESCENCE_MS
+  }
+
+  // Why: treat a title-derived 'idle' status as satisfying tui-idle only after
+  // output has been quiet for TUI_IDLE_QUIESCENCE_MS — i.e. require *sustained*
+  // idle (debounce). A genuinely finished agent stops emitting, so the debounce
+  // window elapses; an agent that merely flashed an idle-looking title mid-work
+  // keeps producing output and never satisfies. Body-level prompt detection
+  // (isKnownReadyPromptPreview) is a direct "cursor at input prompt" signal and
+  // stays immediate; adopted/daemon handles with no PTY output stream
+  // (lastOutputAt == null) have nothing to debounce, so their title signal
+  // also stands.
+  private hasSustainedTuiIdle(target: {
+    lastAgentStatus: AgentStatus | null
+    lastOutputAt: number | null
+  }): boolean {
+    return target.lastAgentStatus === 'idle' && !this.isTuiOutputActive(target)
+  }
+
   private resolveTuiIdleWaiters(leaf: RuntimeLeafRecord): void {
     const handle = this.handleByLeafKey.get(this.getLeafKey(leaf.tabId, leaf.leafId))
     if (!handle) {
@@ -18455,7 +18491,10 @@ export class OrcaRuntimeService {
       return
     }
     for (const waiter of [...waiters]) {
-      if (waiter.condition === 'tui-idle') {
+      // Why: only resolve once idle is *sustained*. The transition fires the
+      // instant an idle-looking title arrives, which is itself fresh output; the
+      // fallback poll re-checks and resolves once output goes quiet.
+      if (waiter.condition === 'tui-idle' && this.hasSustainedTuiIdle(leaf)) {
         this.resolveWaiter(waiter, buildTerminalWaitResult(handle, 'tui-idle', leaf))
       }
     }
@@ -18490,7 +18529,8 @@ export class OrcaRuntimeService {
       return
     }
     for (const waiter of [...waiters]) {
-      if (waiter.condition === 'tui-idle') {
+      // Why: only resolve once idle is *sustained* (see resolveTuiIdleWaiters).
+      if (waiter.condition === 'tui-idle' && this.hasSustainedTuiIdle(pty)) {
         this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, 'tui-idle', pty))
       }
     }
@@ -18510,7 +18550,7 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
-        if (leaf.lastAgentStatus === 'idle') {
+        if (this.hasSustainedTuiIdle(leaf)) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -18523,7 +18563,7 @@ export class OrcaRuntimeService {
         const pollTitle = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
         if (pollTitle) {
           const titleStatus = detectExplicitIdleStatusFromTitle(pollTitle)
-          if (titleStatus === 'idle') {
+          if (titleStatus === 'idle' && !this.isTuiOutputActive(leaf)) {
             if (waiter.pollInterval) {
               clearInterval(waiter.pollInterval)
               waiter.pollInterval = null
@@ -18597,7 +18637,7 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
-        if (pty.lastAgentStatus === 'idle') {
+        if (this.hasSustainedTuiIdle(pty)) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -18621,7 +18661,7 @@ export class OrcaRuntimeService {
         // Why: background PTY handles can later be adopted by the renderer.
         // Use that live xterm title as the same readiness signal as leaf handles.
         if (
-          this.getAdoptedPtyExplicitIdleStatus(pty) === 'idle' ||
+          (this.getAdoptedPtyExplicitIdleStatus(pty) === 'idle' && !this.isTuiOutputActive(pty)) ||
           isKnownReadyPromptPreview(ptyWaitText)
         ) {
           if (waiter.pollInterval) {


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** Orca lets you script your AI coding agents — for example, "wait until the agent finishes working, then do the next thing." The command for that is `orca terminal wait --for tui-idle`. The bug: this "are you done yet?" check answers **"yes, done!" instantly — even while the agent is still actively typing, thinking, and streaming output.** So any automation built on top of it fires too early and steps on the agent mid-task. This hits anyone using Orca to orchestrate or chain agent steps (especially agents like Codex, Devin, or aider whose terminal title is just their name). It's not a crash, but for orchestration it's a real blocker: the one signal you'd rely on to know a task is finished is unreliable.

**2) What this PR does (ELI5).** The old check trusted the terminal's *title bar* to decide if the agent was done. But some agents keep a plain title like `Codex` while their spinner and `esc to interrupt` live in the terminal body, so a busy terminal could look idle. The fix now separates strong idle evidence from weak idle evidence: **known ready prompts and explicit done/idle OSC titles still resolve immediately**, while ambiguous name-only titles must also prove the terminal has gone quiet. So Orca still moves fast when the agent gives a real completion signal, but it no longer cuts in just because a weak title sample looked idle.

**3) Tradeoffs / regressions — honest answer.** Current status: **zero added latency for explicit completion signals**. Body-level ready prompts and explicit idle/done OSC titles (for example `Codex done`, Claude `✳ ...`, Gemini/Pi idle markers) satisfy `tui-idle` immediately. The remaining quiet wait applies only to **ambiguous, non-explicit idle evidence** — titles like plain `Codex`, `Devin`, or `aider` where Orca's shared title classifier defaults to `idle` even though the agent may still be working. For that weak signal, the `TUI_IDLE_QUIESCENCE_MS` quiet window is the necessary correctness guard: resolving immediately would reintroduce #6011. The follow-up also schedules that quiet check directly, so the ambiguous-title path resolves at the quiet deadline instead of waiting for the next 2s fallback poll. No setting, new user step, UI change, platform-specific behavior, SSH caveat, or Git-provider behavior changes.

---

## Summary

`orca terminal wait --terminal <h> --for tui-idle --timeout-ms 30000 --json` returned in ~0s with `{satisfied: true, status: running}` even while the target agent TUI was **actively working** (spinner animating, output streaming, `esc to interrupt` visible). That made `tui-idle` useless as a "task done" signal — it fired mid-work.

Fixes #6011.

This PR **supersedes community PR #6012** (I have taken over the change; the code is now maintained here). #6012 is left open for the author. Original author credited via `Co-authored-by:`.

### Root cause

Two compounding defects:

1. **`detectAgentStatusFromTitle` defaults agent titles to `idle`** (`src/shared/agent-detection.ts`, final fallthrough `return 'idle'`). A title with a recognized agent name but no explicit working marker (no braille spinner, no `working|thinking|running`, no Claude `. ` prefix, no `action required|permission|waiting`) falls through to idle. Agents render their spinner / `esc to interrupt` in the terminal **body**, not the OSC **title**, so a busy agent with a name-only title (`Devin`, `Codex`, `aider`, …) is classified `idle`.
2. **The tui-idle wait trusted a single instantaneous title sample** (`src/main/runtime/orca-runtime.ts`, `waitForTerminal`). It returned satisfied the moment `lastAgentStatus === 'idle'`, with no sustained-idle requirement. The existing `TUI_IDLE_QUIESCENCE_MS = 3000` debounce was only consulted in the foreground-process fallback (which runs only when `lastAgentStatus === null`), so a title-derived `idle` bypassed it entirely.

### Fix

Use the strongest idle evidence first:

- **Body-level ready prompts** (`isKnownReadyPromptPreview`) satisfy immediately because they directly detect the cursor at the input prompt.
- **Explicit OSC idle titles** satisfy immediately when the live OSC title itself contains a strong idle marker (for example `ready`, `idle`, `done`, Claude `✳`, Gemini/Pi idle markers).
- **Ambiguous title-derived `idle`** — especially name-only titles that reach `detectAgentStatusFromTitle`'s broad default-to-idle fallback — satisfies only after PTY output has been quiet for `TUI_IDLE_QUIESCENCE_MS`.

`hasSatisfiedTuiIdle` now centralizes that distinction across the synchronous fast paths, in-promise registration checks, fallback polls, and transition resolvers. Ambiguous idle waits use a one-shot quiet timer, so they resolve at the quiet-window deadline rather than waiting for the next fallback poll. Push-on-idle orchestration message delivery uses the same confirmed-idle boundary, so queued text is not injected into a terminal that is still streaming output behind a name-only idle-looking title.

Defect (1)'s broad default-to-idle is intentionally left in place (it's a renderer-shared classifier driving badges/indicators); `tui-idle` now neutralizes that weak signal locally without changing UI semantics. Tightening the shared classifier could be a follow-up.

## Screenshots

No visual change. This is a main-process timing fix; no renderer/UI surface is touched.

## Testing

- [x] `./node_modules/.bin/vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "tui-idle|push-on-idle|already-idle agent|Cursor Agent without auto-submitting"` — **20 passed**
- [x] `./node_modules/.bin/vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts` — **490 passed**
- [x] `./node_modules/.bin/oxfmt --check src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts` — clean
- [x] `./node_modules/.bin/oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts` — clean
- [x] `./node_modules/.bin/tsgo --noEmit -p config/tsconfig.node.json` — clean
- [ ] `pnpm build` — not run (no build-affecting change; main-process logic only)
- [x] Regression coverage now verifies: name-only agent titles do not resolve while output keeps streaming; explicit idle OSC titles resolve immediately; ambiguous name-only idle resolves exactly at the quiet deadline; push-on-idle delivery waits for the same confirmed-idle guard.

## AI Review Report

Reviewed adversarially (review-until-clean) treating the original community author as potentially malicious, since this is an adopted PR:
- **Correctness**: explicit idle only bypasses the quiet window when the latest OSC title itself passes `detectExplicitIdleStatusFromTitle`; the broad default-to-idle name-only path cannot use that fast path. Ambiguous `idle` still depends on `lastOutputAt` and `TUI_IDLE_QUIESCENCE_MS`, and the one-shot quiet timer re-checks live state before resolving.
- **Waiter coverage**: all title-derived satisfaction sites now flow through `hasSatisfiedTuiIdle` or the existing explicit renderer-title/ready-prompt checks. Waiter cleanup clears the new quiet timer alongside timeout, poll interval, and abort cleanup.
- **Message delivery**: push-on-idle orchestration delivery now uses the same confirmed-idle boundary, preventing a queued message from being injected while a name-only idle-looking title is still streaming output.
- **Edge cases**: body-level prompt detection remains immediate; explicit renderer/adopted title readiness remains immediate when there is no PTY stream to debounce; unsupported CLIs still time out predictably.
- **Cross-platform (macOS / Linux / Windows)**: pure timing/title logic in the Node main process — no keyboard shortcuts, path handling, shell invocation, or platform branches touched.
- **SSH / remote**: `lastOutputAt` is set from PTY data regardless of local vs remote runtime, so the ambiguous-title guard behaves identically over SSH.
- **Git provider**: terminal-level change; provider-agnostic, no GitHub/GitLab-specific code.

## Security Audit

No security-relevant surface changed. No new dependencies, no `eval`, no command execution, no path handling, no auth/secret access, and no network or IPC changes. The diff only adjusts in-memory title/readiness checks, timers, and the existing push-on-idle delivery gate. Re-audited the adopted community change for exfiltration / injection / traversal / suspicious deps: none found. No follow-up needed.

## Notes

- Supersedes #6012 (kept open for the original author; credited via `Co-authored-by:`).
- Follow-up suggestion (out of scope here): tighten `detectAgentStatusFromTitle`'s broad default-to-idle so name-only agent titles don't classify as idle in the first place. Left alone here because it's a renderer-shared classifier driving status badges and could shift UI semantics; the confirmed-idle guard neutralizes its `tui-idle` impact without that risk.

Made with [Orca](https://github.com/stablyai/orca) 🐋