### PR TITLE
fix: include legacy commit statuses in PR checks

### DIFF
--- a/src/main/github/client-pr-checks.test.ts
+++ b/src/main/github/client-pr-checks.test.ts
@@ -71,6 +71,119 @@ vi.mock('./rate-limit', () => ({
 
 import { getPRChecks, rerunPRChecks, _resetOwnerRepoCache } from './client'
 
+function graphQLChecksResponse({
+  contexts = [],
+  checkSuites = [],
+  headRefOid = 'head-oid'
+}: {
+  contexts?: unknown[]
+  checkSuites?: unknown[]
+  headRefOid?: string
+} = {}): { stdout: string } {
+  return {
+    stdout: JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            headRefOid,
+            commits: {
+              nodes: [
+                {
+                  commit: {
+                    statusCheckRollup: { contexts: { nodes: contexts } },
+                    checkSuites: { nodes: checkSuites }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    })
+  }
+}
+
+function graphQLCheckRun(
+  overrides: Partial<{
+    databaseId: number
+    name: string
+    status: string
+    conclusion: string | null
+    detailsUrl: string | null
+    url: string | null
+    checkSuiteId: number | null
+    workflowRunId: number | null
+  }> = {}
+): Record<string, unknown> {
+  const checkSuiteId = overrides.checkSuiteId ?? 1000
+  const workflowRunId = overrides.workflowRunId ?? 1
+  return {
+    __typename: 'CheckRun',
+    databaseId: overrides.databaseId ?? 88,
+    name: overrides.name ?? 'build',
+    status: overrides.status ?? 'COMPLETED',
+    conclusion: overrides.conclusion ?? 'SUCCESS',
+    detailsUrl: overrides.detailsUrl ?? 'https://github.com/acme/widgets/actions/runs/1',
+    url: overrides.url ?? 'https://github.com/acme/widgets/runs/88',
+    checkSuite: {
+      databaseId: checkSuiteId,
+      workflowRun: workflowRunId === null ? null : { databaseId: workflowRunId }
+    }
+  }
+}
+
+function graphQLStatusContext(
+  overrides: Partial<{
+    context: string
+    state: string
+    targetUrl: string | null
+  }> = {}
+): Record<string, unknown> {
+  return {
+    __typename: 'StatusContext',
+    context: overrides.context ?? 'continuous-integration/jenkins/pr-merge',
+    state: overrides.state ?? 'PENDING',
+    targetUrl: overrides.targetUrl ?? 'https://jenkins.example.com/job/merge/1'
+  }
+}
+
+function graphQLCheckSuite(
+  overrides: Partial<{
+    databaseId: number
+    status: string
+    conclusion: string | null
+    url: string | null
+    app: { name?: string | null; slug?: string | null } | null
+  }> = {}
+): Record<string, unknown> {
+  const databaseId = overrides.databaseId ?? 1001
+  return {
+    databaseId,
+    status: overrides.status ?? 'COMPLETED',
+    conclusion: overrides.conclusion ?? 'ACTION_REQUIRED',
+    url:
+      overrides.url ??
+      `https://github.com/acme/widgets/commit/head-oid/checks?check_suite_id=${databaseId}`,
+    app: overrides.app ?? { name: 'GitHub Actions', slug: 'github-actions' }
+  }
+}
+
+function expectGraphQLRollupCall(callIndex = 1, noCache = false): void {
+  const args = ghExecFileAsyncMock.mock.calls[callIndex - 1]?.[0] as string[]
+  expect(args.slice(0, 2)).toEqual(['api', 'graphql'])
+  expect(args).toEqual(
+    expect.arrayContaining(['-f', 'owner=acme', '-f', 'repo=widgets', '-F', 'pr=42'])
+  )
+  if (noCache) {
+    expect(args).not.toContain('--cache')
+  } else {
+    expect(args).toEqual(expect.arrayContaining(['--cache', '60s']))
+  }
+  const queryArg = args.find((arg) => arg.startsWith('query='))
+  expect(queryArg).toContain('statusCheckRollup')
+  expect(queryArg).toContain('checkSuites')
+}
+
 describe('getPRChecks', () => {
   beforeEach(() => {
     execFileAsyncMock.mockReset()
@@ -90,172 +203,138 @@ describe('getPRChecks', () => {
     _resetOwnerRepoCache()
   })
 
-  it('queries check-runs by PR head SHA when GitHub remote metadata is available', async () => {
+  it('queries GitHub rollup details with one cached GraphQL call', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    ghExecFileAsyncMock
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          check_runs: [
-            {
-              name: 'build',
-              status: 'completed',
-              conclusion: 'success',
-              html_url: 'https://github.com/acme/widgets/actions/runs/1',
-              details_url: null
-            }
-          ]
-        })
-      })
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_suites: [] }) })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: graphQLChecksResponse({
+        contexts: [
+          graphQLCheckRun({
+            databaseId: 88,
+            name: 'build',
+            detailsUrl: 'https://github.com/acme/widgets/actions/runs/1'
+          })
+        ]
+      }).stdout
+    })
 
     const checks = await getPRChecks('/repo-root', 42, 'head-oid')
 
-    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
-      ['api', '--cache', '60s', 'repos/acme/widgets/commits/head-oid/check-runs?per_page=100'],
-      { cwd: '/repo-root' }
-    )
+    expectGraphQLRollupCall()
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(checks).toEqual([
       {
         name: 'build',
         status: 'completed',
         conclusion: 'success',
         url: 'https://github.com/acme/widgets/actions/runs/1',
+        checkRunId: 88,
         workflowRunId: 1
+      }
+    ])
+  })
+
+  it('merges rollup check-runs with legacy commit status contexts', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce(
+      graphQLChecksResponse({
+        contexts: [
+          graphQLCheckRun({
+            databaseId: 88,
+            name: 'Summary',
+            detailsUrl: 'https://github.com/acme/widgets/actions/runs/88',
+            workflowRunId: 88
+          }),
+          graphQLStatusContext(),
+          graphQLStatusContext({
+            context: 'Summary',
+            state: 'SUCCESS',
+            targetUrl: 'https://example.com/duplicate-summary'
+          })
+        ]
+      })
+    )
+
+    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+
+    expectGraphQLRollupCall()
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(checks).toEqual([
+      {
+        name: 'Summary',
+        status: 'completed',
+        conclusion: 'success',
+        url: 'https://github.com/acme/widgets/actions/runs/88',
+        checkRunId: 88,
+        workflowRunId: 88
+      },
+      {
+        name: 'continuous-integration/jenkins/pr-merge',
+        status: 'queued',
+        conclusion: 'pending',
+        url: 'https://jenkins.example.com/job/merge/1'
       }
     ])
   })
 
   it('surfaces an action_required check suite that has no check run', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    ghExecFileAsyncMock
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          check_runs: [
-            {
-              name: 'track-community-pr',
-              status: 'completed',
-              conclusion: 'success',
-              html_url: 'https://github.com/acme/widgets/actions/runs/1',
-              details_url: null
-            }
-          ]
-        })
+    ghExecFileAsyncMock.mockResolvedValueOnce(
+      graphQLChecksResponse({
+        contexts: [
+          graphQLCheckRun({
+            name: 'track-community-pr',
+            databaseId: 66,
+            checkSuiteId: 1000,
+            detailsUrl: 'https://github.com/acme/widgets/actions/runs/1'
+          })
+        ],
+        checkSuites: [
+          graphQLCheckSuite({ databaseId: 1000, conclusion: 'SUCCESS' }),
+          graphQLCheckSuite({ databaseId: 1001 }),
+          graphQLCheckSuite({ databaseId: 1002 })
+        ]
       })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          check_suites: [
-            {
-              id: 1000,
-              status: 'completed',
-              conclusion: 'success',
-              app: { name: 'GitHub Actions' }
-            },
-            {
-              id: 1001,
-              status: 'completed',
-              conclusion: 'action_required',
-              app: { name: 'GitHub Actions' }
-            },
-            {
-              id: 1002,
-              status: 'completed',
-              conclusion: 'action_required',
-              app: { name: 'GitHub Actions' }
-            }
-          ]
-        })
-      })
+    )
 
     const checks = await getPRChecks('/repo-root', 42, 'head-oid')
 
-    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
-      2,
-      ['api', '--cache', '60s', 'repos/acme/widgets/commits/head-oid/check-suites?per_page=100'],
-      { cwd: '/repo-root' }
-    )
+    expectGraphQLRollupCall()
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(checks).toEqual([
       {
         name: 'track-community-pr',
         status: 'completed',
         conclusion: 'success',
         url: 'https://github.com/acme/widgets/actions/runs/1',
+        checkRunId: 66,
         workflowRunId: 1
       },
       {
         name: 'GitHub Actions #1001',
         status: 'completed',
         conclusion: 'action_required',
-        url: 'https://github.com/acme/widgets/commits/head-oid/checks#check-suite-1001'
+        url: 'https://github.com/acme/widgets/commit/head-oid/checks?check_suite_id=1001'
       },
       {
         name: 'GitHub Actions #1002',
         status: 'completed',
         conclusion: 'action_required',
-        url: 'https://github.com/acme/widgets/commits/head-oid/checks#check-suite-1002'
-      }
-    ])
-  })
-
-  it('falls back to gh pr checks when the head SHA has no check runs or suites', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    ghExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_runs: [] }) })
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_suites: [] }) })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify([
-          { name: 'verify', state: 'PENDING', link: 'https://example.com/verify' }
-        ])
-      })
-
-    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
-
-    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
-      3,
-      ['pr', 'checks', '42', '--json', 'name,state,link', '--repo', 'acme/widgets'],
-      { cwd: '/repo-root' }
-    )
-    expect(checks).toEqual([
-      {
-        name: 'verify',
-        status: 'queued',
-        conclusion: 'pending',
-        url: 'https://example.com/verify',
-        workflowRunId: undefined
+        url: 'https://github.com/acme/widgets/commit/head-oid/checks?check_suite_id=1002'
       }
     ])
   })
 
   it('maps stale and startup_failure conclusions to failure and action_required to its own state', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    ghExecFileAsyncMock
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          check_runs: [
-            {
-              name: 'needs-approval',
-              status: 'completed',
-              conclusion: 'action_required',
-              html_url: 'https://github.com/acme/widgets/actions/runs/1',
-              details_url: null
-            },
-            {
-              name: 'old-run',
-              status: 'completed',
-              conclusion: 'stale',
-              html_url: 'https://github.com/acme/widgets/actions/runs/2',
-              details_url: null
-            },
-            {
-              name: 'boot',
-              status: 'completed',
-              conclusion: 'startup_failure',
-              html_url: 'https://github.com/acme/widgets/actions/runs/3',
-              details_url: null
-            }
-          ]
-        })
+    ghExecFileAsyncMock.mockResolvedValueOnce(
+      graphQLChecksResponse({
+        contexts: [
+          graphQLCheckRun({ name: 'needs-approval', conclusion: 'ACTION_REQUIRED' }),
+          graphQLCheckRun({ name: 'old-run', conclusion: 'STALE' }),
+          graphQLCheckRun({ name: 'boot', conclusion: 'STARTUP_FAILURE' })
+        ]
       })
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_suites: [] }) })
+    )
 
     const checks = await getPRChecks('/repo-root', 42, 'head-oid')
 
@@ -268,41 +347,102 @@ describe('getPRChecks', () => {
 
   it('surfaces an action_required suite even when there are zero check runs', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
-    ghExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_runs: [] }) })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          check_suites: [
-            {
-              id: 1001,
-              status: 'completed',
-              conclusion: 'action_required',
-              app: { name: 'GitHub Actions' }
-            }
-          ]
-        })
+    ghExecFileAsyncMock.mockResolvedValueOnce(
+      graphQLChecksResponse({
+        checkSuites: [graphQLCheckSuite({ databaseId: 1001 })]
       })
+    )
 
     const checks = await getPRChecks('/repo-root', 42, 'head-oid')
 
-    // Why: must not fall through to `gh pr checks` — the suite is the only signal.
-    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(checks).toEqual([
       {
         name: 'GitHub Actions #1001',
         status: 'completed',
         conclusion: 'action_required',
-        url: 'https://github.com/acme/widgets/commits/head-oid/checks#check-suite-1001'
+        url: 'https://github.com/acme/widgets/commit/head-oid/checks?check_suite_id=1001'
       }
     ])
   })
 
-  it('treats gh pr checks "no checks reported" as an empty check list', async () => {
+  it('returns an empty list when the rollup has no checks or pending suites', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce(graphQLChecksResponse())
+
+    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(checks).toEqual([])
+  })
+
+  it('uses REST fallback when the GraphQL rollup is unavailable', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('GraphQL rollup failed'))
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          check_runs: [
+            {
+              id: 88,
+              name: 'Summary',
+              status: 'completed',
+              conclusion: 'success',
+              html_url: 'https://github.com/acme/widgets/actions/runs/88',
+              details_url: null
+            }
+          ]
+        })
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          statuses: [
+            {
+              context: 'continuous-integration/jenkins/pr-merge',
+              state: 'pending',
+              target_url: 'https://jenkins.example.com/job/merge/1'
+            }
+          ]
+        })
+      })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_suites: [] }) })
+
+    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+
+    expectGraphQLRollupCall()
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      ['api', '--cache', '60s', 'repos/acme/widgets/commits/head-oid/check-runs?per_page=100'],
+      { cwd: '/repo-root' }
+    )
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      3,
+      ['api', '--cache', '60s', 'repos/acme/widgets/commits/head-oid/status?per_page=100'],
+      { cwd: '/repo-root' }
+    )
+    expect(checks).toEqual([
+      {
+        name: 'Summary',
+        status: 'completed',
+        conclusion: 'success',
+        url: 'https://github.com/acme/widgets/actions/runs/88',
+        checkRunId: 88,
+        workflowRunId: 88
+      },
+      {
+        name: 'continuous-integration/jenkins/pr-merge',
+        status: 'queued',
+        conclusion: 'pending',
+        url: 'https://jenkins.example.com/job/merge/1'
+      }
+    ])
+  })
+
+  it('treats gh pr checks "no checks reported" as an empty fallback list', async () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_runs: [] }) })
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_suites: [] }) })
+      .mockRejectedValueOnce(new Error('GraphQL rollup failed'))
       .mockRejectedValueOnce(
         Object.assign(new Error('Command failed: gh pr checks 42'), {
           stderr: "no checks reported on the 'codex/keybindings-toml' branch\n",
@@ -310,10 +450,13 @@ describe('getPRChecks', () => {
         })
       )
 
-    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+    const checks = await getPRChecks('/repo-root', 42)
 
     expect(checks).toEqual([])
-    expect(consoleWarnSpy).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'getPRChecks via GraphQL rollup failed, falling back to gh pr checks:',
+      expect.any(Error)
+    )
     consoleWarnSpy.mockRestore()
   })
 
@@ -321,8 +464,7 @@ describe('getPRChecks', () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_runs: [] }) })
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_suites: [] }) })
+      .mockRejectedValueOnce(new Error('GraphQL rollup failed'))
       .mockRejectedValueOnce(
         Object.assign(new Error('Command failed: gh pr checks 42'), {
           stderr: 'GraphQL: Could not resolve to a PullRequest',
@@ -330,25 +472,29 @@ describe('getPRChecks', () => {
         })
       )
 
-    await expect(getPRChecks('/repo-root', 42, 'head-oid')).rejects.toThrow(
-      'Command failed: gh pr checks 42'
+    await expect(getPRChecks('/repo-root', 42)).rejects.toThrow('Command failed: gh pr checks 42')
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'getPRChecks via GraphQL rollup failed, falling back to gh pr checks:',
+      expect.any(Error)
     )
     expect(consoleWarnSpy).toHaveBeenCalledWith('getPRChecks failed:', expect.any(Error))
     consoleWarnSpy.mockRestore()
   })
 
-  it('falls back to gh pr checks when the cached head SHA no longer resolves', async () => {
+  it('falls back to gh pr checks when GraphQL and REST details are unavailable', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('gh: No commit found for SHA: stale-head (HTTP 422)'))
+      .mockRejectedValueOnce(new Error('GraphQL rollup failed'))
+      .mockRejectedValueOnce(new Error('REST details failed'))
       .mockResolvedValueOnce({
         stdout: JSON.stringify([{ name: 'lint', state: 'PASS', link: 'https://example.com/lint' }])
       })
 
     const checks = await getPRChecks('/repo-root', 42, 'stale-head')
 
+    expectGraphQLRollupCall()
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
-      2,
+      3,
       ['pr', 'checks', '42', '--json', 'name,state,link', '--repo', 'acme/widgets'],
       { cwd: '/repo-root' }
     )
@@ -366,20 +512,24 @@ describe('getPRChecks', () => {
   it('reruns GitHub Actions checks for a PR', async () => {
     getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify([
-          {
-            name: 'lint',
-            state: 'FAIL',
-            link: 'https://github.com/acme/widgets/actions/runs/77/job/88'
-          }
-        ])
-      })
+      .mockResolvedValueOnce(
+        graphQLChecksResponse({
+          contexts: [
+            graphQLCheckRun({
+              name: 'lint',
+              conclusion: 'FAILURE',
+              detailsUrl: 'https://github.com/acme/widgets/actions/runs/77/job/88',
+              workflowRunId: 77
+            })
+          ]
+        })
+      )
       .mockResolvedValueOnce({ stdout: '' })
 
     const result = await rerunPRChecks('/repo-root', 42, { failedOnly: true })
 
     expect(result).toEqual({ ok: true, count: 1 })
+    expectGraphQLRollupCall(1, true)
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
       ['api', '-X', 'POST', 'repos/acme/widgets/actions/runs/77/rerun-failed-jobs'],
@@ -391,29 +541,29 @@ describe('getPRChecks', () => {
     const localGitOptions = { wslDistro: 'Ubuntu' }
     getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify({
-          check_runs: [
-            {
+      .mockResolvedValueOnce(
+        graphQLChecksResponse({
+          contexts: [
+            graphQLCheckRun({
               name: 'build',
-              status: 'completed',
-              conclusion: 'success',
-              html_url: 'https://github.com/acme/widgets/actions/runs/66',
-              details_url: null
-            }
+              detailsUrl: 'https://github.com/acme/widgets/actions/runs/66',
+              workflowRunId: 66
+            })
           ]
         })
-      })
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_suites: [] }) })
-      .mockResolvedValueOnce({
-        stdout: JSON.stringify([
-          {
-            name: 'lint',
-            state: 'FAIL',
-            link: 'https://github.com/acme/widgets/actions/runs/77/job/88'
-          }
-        ])
-      })
+      )
+      .mockResolvedValueOnce(
+        graphQLChecksResponse({
+          contexts: [
+            graphQLCheckRun({
+              name: 'lint',
+              conclusion: 'FAILURE',
+              detailsUrl: 'https://github.com/acme/widgets/actions/runs/77/job/88',
+              workflowRunId: 77
+            })
+          ]
+        })
+      )
       .mockResolvedValueOnce({ stdout: '' })
 
     await getPRChecks('/repo-root', 42, 'head-oid', undefined, undefined, null, localGitOptions)
@@ -433,22 +583,18 @@ describe('getPRChecks', () => {
     )
   })
 
-  it('uses explicit PR repo for check-runs and gh pr checks fallback', async () => {
+  it('uses explicit PR repo for rollup and gh pr checks fallback', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'widgets' })
     ghExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('gh: No commit found for SHA: stale-head (HTTP 422)'))
+      .mockRejectedValueOnce(new Error('GraphQL rollup failed'))
       .mockResolvedValueOnce({
         stdout: JSON.stringify([{ name: 'lint', state: 'PASS', link: 'https://example.com/lint' }])
       })
 
-    await getPRChecks('/repo-root', 42, 'stale-head', { owner: 'acme', repo: 'widgets' })
+    await getPRChecks('/repo-root', 42, undefined, { owner: 'acme', repo: 'widgets' })
 
     expect(getOwnerRepoMock).not.toHaveBeenCalled()
-    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
-      1,
-      ['api', '--cache', '60s', 'repos/acme/widgets/commits/stale-head/check-runs?per_page=100'],
-      { cwd: '/repo-root' }
-    )
+    expectGraphQLRollupCall()
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
       ['pr', 'checks', '42', '--json', 'name,state,link', '--repo', 'acme/widgets'],
@@ -456,12 +602,12 @@ describe('getPRChecks', () => {
     )
   })
 
-  it('throws when both check-runs and gh pr checks fail', async () => {
+  it('throws when both GraphQL rollup and gh pr checks fail', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('gh: No commit found for SHA: stale-head (HTTP 422)'))
+      .mockRejectedValueOnce(new Error('GraphQL rollup failed'))
       .mockRejectedValueOnce(new Error('rate limited'))
 
-    await expect(getPRChecks('/repo-root', 42, 'stale-head')).rejects.toThrow('rate limited')
+    await expect(getPRChecks('/repo-root', 42)).rejects.toThrow('rate limited')
   })
 })

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -82,6 +82,8 @@ export {
 import {
   mapCheckRunRESTStatus,
   mapCheckRunRESTConclusion,
+  mapCommitStatusRESTStatus,
+  mapCommitStatusRESTConclusion,
   mapCheckStatus,
   mapCheckConclusion,
   mapPRState,
@@ -2973,10 +2975,373 @@ export async function getPRForBranchOutcome(
   }
 }
 
+const PR_CHECKS_ROLLUP_QUERY = `
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      headRefOid
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              contexts(first: 100) {
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    databaseId
+                    name
+                    status
+                    conclusion
+                    detailsUrl
+                    url
+                    checkSuite {
+                      databaseId
+                      workflowRun {
+                        databaseId
+                      }
+                    }
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                    targetUrl
+                  }
+                }
+              }
+            }
+            checkSuites(first: 100) {
+              nodes {
+                databaseId
+                status
+                conclusion
+                url
+                app {
+                  name
+                  slug
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+type GraphQLPRChecksResponse = {
+  data?: {
+    repository?: {
+      pullRequest?: {
+        headRefOid?: string | null
+        commits?: {
+          nodes?: { commit?: GraphQLPRChecksCommit | null }[] | null
+        } | null
+      } | null
+    } | null
+  } | null
+}
+
+type GraphQLPRChecksCommit = {
+  statusCheckRollup?: {
+    contexts?: {
+      nodes?: GraphQLStatusCheckContext[] | null
+    } | null
+  } | null
+  checkSuites?: {
+    nodes?: GraphQLCheckSuite[] | null
+  } | null
+}
+
+type GraphQLCheckRunContext = {
+  __typename: 'CheckRun'
+  databaseId?: number | null
+  name?: string | null
+  status?: string | null
+  conclusion?: string | null
+  detailsUrl?: string | null
+  url?: string | null
+  checkSuite?: {
+    databaseId?: number | null
+    workflowRun?: { databaseId?: number | null } | null
+  } | null
+}
+
+type GraphQLStatusContext = {
+  __typename: 'StatusContext'
+  context?: string | null
+  state?: string | null
+  targetUrl?: string | null
+}
+
+type GraphQLStatusCheckContext =
+  | GraphQLCheckRunContext
+  | GraphQLStatusContext
+  | { __typename?: string | null }
+
+type GraphQLCheckSuite = {
+  databaseId?: number | null
+  status?: string | null
+  conclusion?: string | null
+  url?: string | null
+  app?: { name?: string | null; slug?: string | null } | null
+}
+
+type RestCheckRun = {
+  id?: number
+  name: string
+  status: string
+  conclusion: string | null
+  html_url: string
+  details_url: string | null
+}
+
+type RestCommitStatus = {
+  context?: string
+  state?: string
+  target_url?: string | null
+}
+
+type RestCheckSuite = {
+  id?: number | null
+  status: string | null
+  conclusion: string | null
+  app?: { name?: string | null; slug?: string | null } | null
+}
+
+function isGraphQLCheckRunContext(
+  context: GraphQLStatusCheckContext
+): context is GraphQLCheckRunContext {
+  return context.__typename === 'CheckRun'
+}
+
+function isGraphQLStatusContext(
+  context: GraphQLStatusCheckContext
+): context is GraphQLStatusContext {
+  return context.__typename === 'StatusContext'
+}
+
+function mapGraphQLCheckRunContext(context: GraphQLCheckRunContext): PRCheckDetail | null {
+  const name = nullableString(context.name)
+  if (!name) {
+    return null
+  }
+  const url = nullableString(context.detailsUrl) ?? nullableString(context.url)
+  const checkRunId = nullableNumber(context.databaseId)
+  const workflowRunId =
+    nullableNumber(context.checkSuite?.workflowRun?.databaseId) ?? parseActionsRunId(url)
+  return {
+    name,
+    status: mapCheckRunRESTStatus(context.status ?? ''),
+    conclusion: mapCheckRunRESTConclusion(context.status ?? '', context.conclusion ?? null),
+    url,
+    ...(checkRunId !== null ? { checkRunId } : {}),
+    ...(typeof workflowRunId === 'number' ? { workflowRunId } : {})
+  }
+}
+
+function mapGraphQLStatusContext(context: GraphQLStatusContext): PRCheckDetail | null {
+  const name = nullableString(context.context)
+  if (!name) {
+    return null
+  }
+  const url = nullableString(context.targetUrl)
+  const workflowRunId = parseActionsRunId(url)
+  return {
+    name,
+    status: mapCommitStatusRESTStatus(context.state ?? ''),
+    conclusion: mapCommitStatusRESTConclusion(context.state ?? ''),
+    url,
+    ...(workflowRunId !== undefined ? { workflowRunId } : {})
+  }
+}
+
+function mapRestCheckRun(checkRun: RestCheckRun): PRCheckDetail {
+  return {
+    name: checkRun.name,
+    status: mapCheckRunRESTStatus(checkRun.status),
+    conclusion: mapCheckRunRESTConclusion(checkRun.status, checkRun.conclusion),
+    url: checkRun.details_url || checkRun.html_url || null,
+    ...(typeof checkRun.id === 'number' ? { checkRunId: checkRun.id } : {}),
+    workflowRunId: parseActionsRunId(checkRun.details_url || checkRun.html_url || null)
+  }
+}
+
+function mapRestCommitStatus(status: RestCommitStatus): PRCheckDetail | null {
+  const name = nullableString(status.context)
+  if (!name) {
+    return null
+  }
+  const url = nullableString(status.target_url)
+  const workflowRunId = parseActionsRunId(url)
+  return {
+    name,
+    status: mapCommitStatusRESTStatus(status.state ?? ''),
+    conclusion: mapCommitStatusRESTConclusion(status.state ?? ''),
+    url,
+    ...(workflowRunId !== undefined ? { workflowRunId } : {})
+  }
+}
+
+function mapGraphQLPendingApprovalCheckSuite(
+  ownerRepo: OwnerRepo,
+  suite: GraphQLCheckSuite,
+  headSha: string | null | undefined,
+  index: number
+): PRCheckDetail {
+  return {
+    name: getPendingApprovalCheckSuiteName(suite, headSha, index),
+    status: 'completed',
+    conclusion: 'action_required',
+    // Why: suite-only approval blockers have no check run; use the suite page
+    // as the actionable destination when GraphQL exposes one.
+    url:
+      nullableString(suite.url) ??
+      (headSha ? getPendingApprovalCheckSuiteUrl(ownerRepo, headSha, suite.databaseId) : null)
+  }
+}
+
+function mapGraphQLPRChecksResponse(
+  ownerRepo: OwnerRepo,
+  response: GraphQLPRChecksResponse
+): PRCheckDetail[] | null {
+  const pullRequest = response.data?.repository?.pullRequest
+  if (!pullRequest) {
+    return null
+  }
+  const commit = pullRequest.commits?.nodes?.[0]?.commit
+  if (!commit) {
+    return []
+  }
+
+  const contexts = commit.statusCheckRollup?.contexts?.nodes ?? []
+  const checkRunContexts = contexts.filter(isGraphQLCheckRunContext)
+  const checkRuns = checkRunContexts
+    .map(mapGraphQLCheckRunContext)
+    .filter((check): check is PRCheckDetail => check !== null)
+  const checkRunNames = new Set(checkRuns.map((check) => check.name))
+  const checkSuiteIdsWithRuns = new Set(
+    checkRunContexts
+      .map((context) => nullableNumber(context.checkSuite?.databaseId))
+      .filter((id): id is number => id !== null)
+  )
+  // Why: mixed-CI repos expose Jenkins/Prow/Tide as legacy status contexts
+  // inside the same rollup as check runs. Keep check-run metadata on collisions.
+  const legacyStatuses = contexts
+    .filter(isGraphQLStatusContext)
+    .map(mapGraphQLStatusContext)
+    .filter((check): check is PRCheckDetail => check !== null && !checkRunNames.has(check.name))
+  const pendingApprovalChecks = (commit.checkSuites?.nodes ?? [])
+    .filter((suite) => suite.conclusion?.toLowerCase() === 'action_required')
+    .filter((suite) => {
+      const suiteId = nullableNumber(suite.databaseId)
+      return suiteId === null || !checkSuiteIdsWithRuns.has(suiteId)
+    })
+    .map((suite, index) =>
+      mapGraphQLPendingApprovalCheckSuite(ownerRepo, suite, pullRequest.headRefOid, index)
+    )
+
+  return [...checkRuns, ...legacyStatuses, ...pendingApprovalChecks]
+}
+
+async function getPRChecksViaRestFallback(
+  ownerRepo: OwnerRepo,
+  headSha: string | undefined,
+  ghOptions: GhExecOptions,
+  noCache?: boolean
+): Promise<PRCheckDetail[] | null> {
+  if (!headSha) {
+    return null
+  }
+  try {
+    await assertRateLimitBudget('core')
+  } catch (err) {
+    console.warn('getPRChecks skipped REST fallback, falling back to gh pr checks:', err)
+    return null
+  }
+
+  await acquire()
+  try {
+    const cacheArgs = noCache ? [] : ['--cache', '60s']
+    const encodedHeadSha = encodeURIComponent(headSha)
+    const { stdout } = await ghExecFileAsync(
+      [
+        'api',
+        ...cacheArgs,
+        `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/check-runs?per_page=100`
+      ],
+      ghOptions
+    )
+    noteRateLimitSpend('core')
+    const checkRunData = JSON.parse(stdout) as {
+      check_runs?: RestCheckRun[]
+    }
+    const checkRuns = (checkRunData.check_runs ?? []).map(mapRestCheckRun)
+    const checkRunNames = new Set(checkRuns.map((check) => check.name))
+
+    let legacyStatuses: PRCheckDetail[] = []
+    try {
+      const statusResult = await ghExecFileAsync(
+        [
+          'api',
+          ...cacheArgs,
+          `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/status?per_page=100`
+        ],
+        ghOptions
+      )
+      noteRateLimitSpend('core')
+      const statusData = JSON.parse(statusResult.stdout) as {
+        statuses?: RestCommitStatus[]
+      }
+      legacyStatuses = (statusData.statuses ?? [])
+        .map(mapRestCommitStatus)
+        .filter((check): check is PRCheckDetail => check !== null && !checkRunNames.has(check.name))
+    } catch (err) {
+      // Why: the REST fallback is already degraded; keep richer check-run rows
+      // if the legacy-status enrichment fails.
+      console.warn('getPRChecks REST status fallback failed:', err)
+    }
+
+    let pendingApprovalChecks: PRCheckDetail[] = []
+    try {
+      const suitesResult = await ghExecFileAsync(
+        [
+          'api',
+          ...cacheArgs,
+          `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/check-suites?per_page=100`
+        ],
+        ghOptions
+      )
+      noteRateLimitSpend('core')
+      const suitesData = JSON.parse(suitesResult.stdout) as {
+        check_suites?: RestCheckSuite[]
+      }
+      pendingApprovalChecks = (suitesData.check_suites ?? [])
+        .filter((suite) => suite.conclusion?.toLowerCase() === 'action_required')
+        .map((suite, index) => ({
+          name: getPendingApprovalCheckSuiteName(suite, headSha, index),
+          status: 'completed' as const,
+          conclusion: 'action_required' as const,
+          url: getPendingApprovalCheckSuiteUrl(ownerRepo, headSha, suite.id)
+        }))
+    } catch (err) {
+      console.warn('getPRChecks REST check-suite fallback failed:', err)
+    }
+
+    const checks = [...checkRuns, ...legacyStatuses, ...pendingApprovalChecks]
+    return checks.length > 0 ? checks : null
+  } catch (err) {
+    console.warn('getPRChecks via REST fallback failed, falling back to gh pr checks:', err)
+    return null
+  } finally {
+    release()
+  }
+}
+
 /**
  * Get detailed check statuses for a PR.
- * When branch is provided, uses gh api --cache with the check-runs REST endpoint
- * so 304 Not Modified responses don't count against the rate limit.
+ * Uses GitHub's combined GraphQL rollup so check runs and legacy commit statuses
+ * arrive in one cached request; suite-only approval blockers are included too.
  */
 export async function getPRChecks(
   repoPath: string,
@@ -2987,13 +3352,10 @@ export async function getPRChecks(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<PRCheckDetail[]> {
+  void headSha
   const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
   const ownerRepo = prRepo ?? (await getOwnerRepo(repoPath, connectionId, localGitOptions))
   const fallbackToPRChecks = async (): Promise<PRCheckDetail[]> => {
-    // Why: the REST check-runs path spends core only. Guard GraphQL only when
-    // we actually fall back to `gh pr checks`, so a low GraphQL bucket does not
-    // block fresh REST check data. Keep this outside the gh lock because the
-    // guard may need its own `gh api rate_limit` call.
     await assertRateLimitBudget('graphql')
     await acquire()
     try {
@@ -3024,15 +3386,15 @@ export async function getPRChecks(
     }
   }
 
-  if (ownerRepo && headSha) {
-    let canUseRestChecks = true
+  if (ownerRepo) {
+    let canUseGraphQLRollup = true
     try {
-      await assertRateLimitBudget('core')
+      await assertRateLimitBudget('graphql')
     } catch (err) {
-      canUseRestChecks = false
-      console.warn('getPRChecks skipped REST check-runs, falling back to gh pr checks:', err)
+      canUseGraphQLRollup = false
+      console.warn('getPRChecks skipped GraphQL rollup, falling back to gh pr checks:', err)
     }
-    if (canUseRestChecks) {
+    if (canUseGraphQLRollup) {
       await acquire()
       try {
         // Why: --cache 60s saves rate-limit budget during polling, but when the
@@ -3041,53 +3403,43 @@ export async function getPRChecks(
         const { stdout } = await ghExecFileAsync(
           [
             'api',
+            'graphql',
             ...cacheArgs,
-            `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodeURIComponent(headSha)}/check-runs?per_page=100`
+            '-f',
+            `owner=${ownerRepo.owner}`,
+            '-f',
+            `repo=${ownerRepo.repo}`,
+            '-F',
+            `pr=${prNumber}`,
+            '-f',
+            `query=${PR_CHECKS_ROLLUP_QUERY}`
           ],
           ghOptions
         )
-        noteRateLimitSpend('core')
-        const data = JSON.parse(stdout) as {
-          check_runs: {
-            id?: number
-            name: string
-            status: string
-            conclusion: string | null
-            html_url: string
-            details_url: string | null
-          }[]
-        }
-        const checkRuns: PRCheckDetail[] = data.check_runs.map((d) => ({
-          name: d.name,
-          status: mapCheckRunRESTStatus(d.status),
-          conclusion: mapCheckRunRESTConclusion(d.status, d.conclusion),
-          url: d.details_url || d.html_url || null,
-          ...(typeof d.id === 'number' ? { checkRunId: d.id } : {}),
-          workflowRunId: parseActionsRunId(d.details_url || d.html_url || null)
-        }))
-        // Why: a workflow awaiting "Approve and run" produces a check SUITE with
-        // no check run, and is absent from statusCheckRollup — so without this
-        // the panel shows "no checks"/"all passing" while auto-merge fails with
-        // "unstable status". Surface them as their own check rows. Fetch even
-        // when there are zero check runs, since that is the exact case GitHub
-        // leaves the PR unstable with nothing to show.
-        const pendingApprovalChecks = await getPendingApprovalCheckSuites(
+        noteRateLimitSpend('graphql')
+        const checks = mapGraphQLPRChecksResponse(
           ownerRepo,
-          headSha,
-          ghOptions,
-          options?.noCache
+          JSON.parse(stdout) as GraphQLPRChecksResponse
         )
-        if (checkRuns.length > 0 || pendingApprovalChecks.length > 0) {
-          return [...checkRuns, ...pendingApprovalChecks]
+        if (checks !== null) {
+          return checks
         }
       } catch (err) {
-        // Why: a PR can outlive the cached head SHA after force-pushes or remote
-        // rewrites. Falling back to `gh pr checks` keeps the panel populated
-        // instead of rendering a false "no checks" state from a stale commit.
-        console.warn('getPRChecks via head SHA failed, falling back to gh pr checks:', err)
+        // Why: if GitHub's richer rollup query is unavailable, the older gh
+        // command still returns the combined check/status list for display.
+        console.warn('getPRChecks via GraphQL rollup failed, falling back to gh pr checks:', err)
       } finally {
         release()
       }
+    }
+    const restChecks = await getPRChecksViaRestFallback(
+      ownerRepo,
+      headSha,
+      ghOptions,
+      options?.noCache
+    )
+    if (restChecks !== null) {
+      return restChecks
     }
   }
 
@@ -3099,65 +3451,19 @@ export async function getPRChecks(
   }
 }
 
-/**
- * Fetch check SUITES that need manual action (e.g. a workflow awaiting approval).
- * These have no check run and are absent from statusCheckRollup, yet they keep a
- * PR in "unstable status" and block auto-merge. We surface one synthetic check
- * row per such suite so both check panels show it.
- */
-async function getPendingApprovalCheckSuites(
-  ownerRepo: OwnerRepo,
-  headSha: string,
-  ghOptions: GhExecOptions,
-  noCache?: boolean
-): Promise<PRCheckDetail[]> {
-  const cacheArgs = noCache ? [] : ['--cache', '60s']
-  try {
-    const { stdout } = await ghExecFileAsync(
-      [
-        'api',
-        ...cacheArgs,
-        `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodeURIComponent(headSha)}/check-suites?per_page=100`
-      ],
-      ghOptions
-    )
-    noteRateLimitSpend('core')
-    const data = JSON.parse(stdout) as {
-      check_suites?: {
-        id?: number | null
-        status: string | null
-        conclusion: string | null
-        app?: { name?: string | null; slug?: string | null } | null
-      }[]
-    }
-    return (data.check_suites ?? [])
-      .filter((suite) => suite.conclusion?.toLowerCase() === 'action_required')
-      .map((suite, index) => ({
-        name: getPendingApprovalCheckSuiteName(suite, headSha, index),
-        status: 'completed' as const,
-        conclusion: 'action_required' as const,
-        // Why: check suites expose no per-PR details URL; the checks tab is the
-        // closest actionable destination for approving the run.
-        url: getPendingApprovalCheckSuiteUrl(ownerRepo, headSha, suite.id)
-      }))
-  } catch (err) {
-    // Why: this is a best-effort enrichment; a failed suites lookup must not
-    // blank out the check runs we already fetched successfully.
-    console.warn('getPendingApprovalCheckSuites failed:', err)
-    return []
-  }
-}
-
 function getPendingApprovalCheckSuiteName(
   suite: {
     id?: number | null
+    databaseId?: number | null
     app?: { name?: string | null; slug?: string | null } | null
   },
-  headSha: string,
+  headSha: string | null | undefined,
   index: number
 ): string {
   const appName = suite.app?.name ?? suite.app?.slug ?? null
-  const suiteId = typeof suite.id === 'number' && Number.isFinite(suite.id) ? `#${suite.id}` : null
+  const rawSuiteId = suite.databaseId ?? suite.id
+  const suiteId =
+    typeof rawSuiteId === 'number' && Number.isFinite(rawSuiteId) ? `#${rawSuiteId}` : null
   if (appName && suiteId) {
     return `${appName} ${suiteId}`
   }
@@ -3167,7 +3473,7 @@ function getPendingApprovalCheckSuiteName(
   if (suiteId) {
     return suiteId
   }
-  return `${headSha.slice(0, 12)}:${index + 1}`
+  return `${headSha?.slice(0, 12) ?? 'check-suite'}:${index + 1}`
 }
 
 function getPendingApprovalCheckSuiteUrl(

--- a/src/main/github/mappers.ts
+++ b/src/main/github/mappers.ts
@@ -40,6 +40,28 @@ export function mapCheckRunRESTConclusion(
   return conclusionMap[conclusion.toLowerCase()] ?? null
 }
 
+// ── REST API commit status mapping ──────────────────────────────────────
+// Legacy Jenkins/Prow integrations report commit statuses, not check runs.
+
+export function mapCommitStatusRESTStatus(state: string): PRCheckDetail['status'] {
+  const s = state?.toLowerCase()
+  return s === 'pending' ? 'queued' : 'completed'
+}
+
+export function mapCommitStatusRESTConclusion(state: string): PRCheckDetail['conclusion'] {
+  const s = state?.toLowerCase()
+  if (s === 'success') {
+    return 'success'
+  }
+  if (s === 'failure' || s === 'error') {
+    return 'failure'
+  }
+  if (s === 'pending') {
+    return 'pending'
+  }
+  return null
+}
+
 // ── gh pr checks mapping (single "state" string) ─────────────────────
 
 export function mapCheckStatus(state: string): PRCheckDetail['status'] {


### PR DESCRIPTION
## Summary

Fixes #5393

`getPRChecks()` used GitHub's REST check-runs endpoint as its detailed fast path. That endpoint does not include legacy commit Status contexts, so mixed-CI PRs could show fewer rows in Orca than GitHub's combined PR checks rollup. In the reported Milvus example, Orca showed the 3 Check Runs but omitted 5 Jenkins/Prow/Tide status contexts.

This PR now reads GitHub's combined GraphQL `statusCheckRollup` for the PR commit and maps both source types from the same response:

- `CheckRun` contexts keep rich metadata (`checkRunId`, `workflowRunId`, details URL) for details and rerun flows.
- `StatusContext` rows add legacy-only Jenkins/Prow/Tide statuses.
- If a legacy status has the same name as a check run, the check-run row wins.
- `checkSuites` are included in the same GraphQL request so suite-only `action_required` approval blockers remain visible without a second happy-path request.
- If the GraphQL rollup is unavailable, Orca falls back to REST check-runs + combined status (`per_page=100`) + check-suites before using the existing `gh pr checks` fallback.

## Tradeoffs / regressions

Happy-path tradeoff is now **zero** for the reported caveat. Legacy statuses no longer require an extra GitHub API call; the normal detailed-check fetch is one cached GitHub request that includes check runs, legacy status contexts, and suite-only approval blockers.

No feature is disabled. GitLab and other providers are untouched. The REST path remains only as a degraded fallback so unavailable GraphQL does not lose richer check-run metadata when a head SHA is available.

## Screenshots

No visual change; this is a data-layer fix for the existing PR checks UI.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/github/client-pr-checks.test.ts` — 14/14 pass
- [x] `pnpm exec oxlint src/main/github/client.ts src/main/github/mappers.ts src/main/github/client-pr-checks.test.ts` — clean
- [x] `pnpm run tc:node` — pass
- [x] GitHub `verify` — pass on `107bc06f937b27e45194171201d8723e51775d04`
- [ ] `pnpm build` — not run (main-process data-layer change only)

## Review notes

- The normal path is GitHub-only and uses the existing `ghOptions`, so local, WSL, SSH/remote-host execution keep the same routing behavior.
- The fallback status endpoint uses `per_page=100`, addressing the review concern about missing paginated legacy contexts in degraded mode.
- Provider compatibility is preserved: GitLab and other non-GitHub providers do not route through this client path.

Supersedes community PR #5650. Credit retained via `Co-authored-by` trailer.

Made with [Orca](https://github.com/stablyai/orca)
