### PR TITLE
Quiet-window Pi/OMP intermediate done so resumed work cancels notification (#6361)

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -983,8 +983,6 @@ describe('agent completion coordinator', () => {
     'gemini',
     'opencode',
     'cursor',
-    'pi',
-    'omp',
     'droid',
     'grok',
     'devin',
@@ -1008,6 +1006,132 @@ describe('agent completion coordinator', () => {
     })
 
     expect(dispatchCompletion).toHaveBeenCalledWith(agentType)
+  })
+
+  it.each(['pi', 'omp'])(
+    'defers a %s milestone done without prior working through the quiet window',
+    (agentType) => {
+      const dispatchCompletion = vi.fn()
+      const coordinator = createAgentCompletionCoordinator({
+        paneKey: 'tab-1:leaf-1',
+        getPtyId: () => 'pty-1',
+        getSettings: () => null,
+        inspectProcess: vi.fn(),
+        dispatchCompletion,
+        isLive: () => true
+      })
+
+      // Pi/OMP emit agent_end ('done') between milestones with no prior 'working';
+      // the done must wait out the quiet window instead of firing immediately.
+      coordinator.observeHookStatus({
+        state: 'done',
+        prompt: 'run the mission',
+        agentType
+      })
+      expect(coordinator.hasPendingHookDoneCompletion()).toBe(true)
+      vi.advanceTimersByTime(HOOK_DONE_QUIET_MS - 1)
+      expect(dispatchCompletion).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+      expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+      expect(dispatchCompletion).toHaveBeenCalledWith(
+        agentType,
+        expect.objectContaining({ source: 'hook', quietedHookDone: true })
+      )
+    }
+  )
+
+  it('suppresses a Pi milestone done when work resumes before the quiet window', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'run the mission',
+      agentType: 'pi'
+    })
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(true)
+
+    // Pi resumes (a tool_call mapped to 'working') before the window elapses,
+    // which must cancel the premature "finished".
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'run the mission',
+      agentType: 'pi'
+    })
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(false)
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('still dispatches a Codex done-without-prior-working immediately', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    // Codex only emits 'done' at turn end, so it must keep its immediate dispatch.
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'fix the bug',
+      agentType: 'codex'
+    })
+
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(false)
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+  })
+
+  it('still fires a pending Pi done when process inspection sees the agent exit first', async () => {
+    // Why: a process-exit probe landing inside the quiet window must not tear
+    // down agent evidence, or the pending hook 'done' would be silently dropped.
+    let foregroundProcess: string | null = 'pi'
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(async () => processResult(foregroundProcess)),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.startProcessTracking()
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'run the mission',
+      agentType: 'pi'
+    })
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(true)
+
+    // The agent process disappears mid-window; the cadence poll must not drop
+    // the pending completion.
+    foregroundProcess = null
+    vi.advanceTimersByTime(750)
+    await flushAsyncTicks()
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    expect(dispatchCompletion).toHaveBeenCalledWith(
+      'pi',
+      expect.objectContaining({ source: 'hook' })
+    )
   })
 
   it('notifies once after a Cursor tool-heavy turn, not on each shell hook', () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -16,6 +16,7 @@ import type {
   AgentCompletionStatusSnapshot
 } from './agent-completion-coordinator-types'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
+import { isPiCompatibleAgentType } from '../../../../shared/pi-agent-kind'
 import {
   titleHasExplicitAgentIdentity,
   titleIsInconclusiveNativeDroidTitle
@@ -155,6 +156,12 @@ export function createAgentCompletionCoordinator(
 
   function hookCompletionAgentIdentity(payload: AgentCompletionStatusSnapshot): string | null {
     return payload.agentType?.trim().toLowerCase() || null
+  }
+
+  function doneShouldUseQuietWindow(payload: AgentCompletionStatusSnapshot): boolean {
+    // Why: Pi/OMP emit milestone 'done' while still working, so route their done
+    // through the quiet window (like a resumed turn) so later work can cancel it.
+    return workingStatusObserved || isPiCompatibleAgentType(hookCompletionAgentIdentity(payload))
   }
 
   function hookAttentionToken(payload: AgentCompletionStatusSnapshot): string {
@@ -415,6 +422,12 @@ export function createAgentCompletionCoordinator(
     if (recognized) {
       handleRecognizedProcess(recognized)
       return true
+    }
+    if (pendingHookDoneTimer !== null) {
+      // Why: a pending quiet-window 'done' is the authoritative completion;
+      // tearing down agent evidence here would make the timer drop it.
+      scheduleNextPoll()
+      return false
     }
     if (lastForegroundAgent && hasAgentRunEvidence) {
       if (result.hasChildProcesses) {
@@ -708,7 +721,7 @@ export function createAgentCompletionCoordinator(
         // backstops duplicate the same completion.
         currentTurn += 1
       }
-      if (payload.state === 'done' && workingStatusObserved) {
+      if (payload.state === 'done' && doneShouldUseQuietWindow(payload)) {
         lastCompletionIdentity = hookIdentity
           ? {
               source: 'hook',

--- a/src/shared/pi-agent-kind.ts
+++ b/src/shared/pi-agent-kind.ts
@@ -13,6 +13,17 @@ import { getCommandTokenPathBasename, getFirstCommandToken } from './command-tok
  */
 export type PiAgentKind = 'pi' | 'omp'
 
+/**
+ * True when `agentType` names a Pi-compatible (goal/mission) kind. These agents
+ * emit milestone `agent_end` events between steps while still working, so they
+ * are treated differently from agents that only signal completion at turn end.
+ */
+export function isPiCompatibleAgentType(
+  agentType: string | null | undefined
+): agentType is PiAgentKind {
+  return agentType === 'pi' || agentType === 'omp'
+}
+
 const OMP_LAUNCH_CMD = TUI_AGENT_CONFIG.omp.launchCmd
 
 // Why: regex carved to avoid matching `pi` inside `pip`, `mpi`, `api`,


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** People running Orca with goal/mission-style agents (Pi from pi.dev, and OMP) get a false "your agent is finished!" notification while the agent is actually still working. The agent then looks frozen — it sits there "thinking" and won't reliably wrap up its turn, so the user has to poke it ("are you still working?") to nudge it back to life. This only happens inside Orca (the reporter never saw it using Pi directly), and only for these mission-style agents — but for the people it hits it's a real blocker, because the tool is lying to them about whether their work is done.

**2) What this PR does (ELI5).** Pi and OMP announce small milestones as they go ("done with step 1!") even though they're still chugging along. Orca was treating the very first "done!" as the whole job being finished and immediately pinging you. The fix makes Orca wait a brief, quiet moment after any "done!" from these specific agents before sounding the alarm — and if the agent starts working again during that pause, the premature "finished" alert is quietly cancelled. So it now says "finished" only when the agent truly stops.

**3) Tradeoffs / regressions — honest answer.** No regressions. The change is surgical and scoped by agent kind: only Pi and OMP now route their "done" signal through the short quiet-window delay that already existed in the codebase. Agents that only say "done" once at the real end of their turn (like Codex) are explicitly preserved and still notify instantly — a dedicated test guards that. The one honest cost: for Pi/OMP, even the legitimate "really finished" notification is delayed by that quiet-window interval (a brief pause, not a behavior loss) — and that pause is exactly what lets a resumed agent cancel a false alarm. It behaves identically on macOS, Linux, and Windows, and applies to both local and SSH/remote panes since they share the same notification logic.

---

## Summary

Fixes #6361

Pi (pi.dev) and OMP are goal/mission agents whose `normalizePiCompatibleEvent` maps milestone `agent_end` (and `session_shutdown`) to hook state `done` while they are *still working*. Orca fired an "agent finished" OS notification at one of these intermediate `done` events while Pi's TUI was still spinning, and a follow-up working/tool event could not cancel it.

Root cause is in `observeHookStatus` (`agent-completion-coordinator.ts`). The quiet-window path (`scheduleHookDoneCompletion`) — which exists precisely so resumed work can CANCEL an intermediate `done` — was gated on `payload.state === 'done' && workingStatusObserved`. Pi's intermediate `done` events have `workingStatusObserved === false`, so control fell through to the IMMEDIATE `dispatchCompletion('hook', …)` with no quiet window.

### What changed

1. **Route Pi/OMP `done` through the quiet window.** A new `doneShouldUseQuietWindow(payload)` predicate widens the gate to `workingStatusObserved || isPiCompatibleAgentType(agentType)`. When Pi resumes (emits a tool_call/message mapped to `working`), the working branch calls `clearPendingHookDone()` and the premature notification is suppressed — exactly the milestone-suppression behavior the quiet window was built for. Codex and other turn-end-only producers keep their immediate dispatch.

2. **Shared, typed agent-kind predicate.** Rather than hardcoding `agent === 'pi' || agent === 'omp'` inline (a fourth drift site), the check delegates to a new `isPiCompatibleAgentType()` exported from `src/shared/pi-agent-kind.ts`, co-located with the canonical `PiAgentKind = 'pi' | 'omp'` type. One source of truth; the compiler keeps it in sync if a third Pi-compatible kind is ever added.

3. **Hardened the process-exit backstop (prevents a *lost* notification).** Routing Pi/OMP through the quiet window newly exposed them to a race: a process-inspection poll landing inside the 1.5 s window could find the agent process gone and run `clearAgentRunEvidence()`, wiping `hasAgentRunEvidence` — so when the quiet-window timer fired, `dispatchCompletion('hook', …)` was blocked by the `!hasAgentRunEvidence` guard and the *real* completion was silently dropped. `handleProcessInspectionResult` now skips the agent-evidence teardown while a quiet-window `done` is pending and reschedules a poll, so the pending hook completion remains authoritative (and process-exit detection resumes after the window). This also closes the same latent silent-drop for Codex `working`→`done`.

The change is renderer-side and provider/transport agnostic, so it applies equally to local and SSH/remote panes (both PTY-connection and hook-completion coordinators funnel through `observeHookStatus`).

## Screenshots

No visual change. This affects OS notification timing only; verified at the unit level.

## Testing

- [x] `pnpm test` (scoped: `agent-completion-coordinator.test.ts` — 55 passed; `agent-completion-coordinator-dispose-leak.test.ts` — 3 passed)
- [x] `tsgo --noEmit` across the node, cli, and web tc configs — clean (exit 0)
- [x] `oxlint` + `lint:switch-exhaustiveness` on the changed/shared files — clean
- [x] Full `src/shared/` vitest suite — 1583 passed (no regression from the `pi-agent-kind.ts` export)
- [x] Added or updated high-quality tests that would catch regressions

New/updated tests:
- `defers a %s milestone done without prior working through the quiet window` (pi, omp) — asserts `hasPendingHookDoneCompletion()` is true and `dispatchCompletion` is NOT called before `HOOK_DONE_QUIET_MS`, then is called once after with `quietedHookDone: true`.
- `suppresses a Pi milestone done when work resumes before the quiet window` — a `working` event before the window cancels the premature "finished".
- `still dispatches a Codex done-without-prior-working immediately` — regression guard for Codex's immediate dispatch.
- `still fires a pending Pi done when process inspection sees the agent exit first` — regression guard for the lost-notification race fixed in (3).
- Removed `pi`/`omp` from the immediate-dispatch `recognizes %s hook agent ids` it.each (they now defer); the Codex done-only tests are unchanged and still pass.

## AI Review Report

Reviewed for correctness, edge cases, and cross-platform behavior; adversarially verified against current `main`.
- **Design:** agent-scoped quiet window is the right scope (not always-quiet) — the root cause is provider-specific to `normalizePiCompatibleEvent`, and several existing tests assert immediate dispatch for Codex/others. Making every provider quiet would add a 1.5 s delay to every completion and break the Codex done-only contract.
- **Regression sweep (all clear):** Codex done-only still immediate; the done-only-producer turn bump does not pre-empt the new branch on a fresh coordinator; replay-guard/identity dedup correctly suppress duplicates without suppressing-forever; `waiting`/`blocked` and `shouldSuppressHookCompletion` still cancel a provisional done; resumed turns re-fire; the new process-exit guard delays (never drops) process-exit completions and has no path that pauses polling forever.
- **Cross-platform / SSH:** no platform-dependent code touched; transport-agnostic renderer state-machine logic; applies to remote panes.
- **Git providers:** not applicable — no source-control/review code involved.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The diff reads an already-parsed `agentType` string from an existing hook payload and branches on it, and adds a pure `string → boolean` predicate. No new external input is trusted, no new surface introduced.

## Notes

- If other goal/mission agents adopt the same milestone `agent_end` contract in the future, add them to `PiAgentKind` / `isPiCompatibleAgentType` (or generalize to a capability flag on the agent identity).

Made with [Orca](https://github.com/stablyai/orca) 🐋
