### PR TITLE
Fix remote File Explorer opening files via local fs:readFile (#6440)

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -479,6 +479,7 @@ function FileExplorerFiles(): React.JSX.Element {
   }, [])
   const { handleClick, handleDoubleClick, handleWheelCapture } = useFileExplorerHandlers({
     activeWorktreeId,
+    runtimeEnvironmentId: activeRuntimeEnvironmentId,
     openFile,
     makePreviewFilePermanent,
     toggleDir: hasNameFilter ? handleToggleNameFilterDir : toggleDir,

--- a/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
@@ -112,6 +112,7 @@ let capturedHandlers: ReturnType<typeof useFileExplorerHandlers> | null = null
 function HandlersProbe({ scrollRef }: { scrollRef: React.RefObject<HTMLDivElement | null> }): null {
   capturedHandlers = useFileExplorerHandlers({
     activeWorktreeId: 'wt-1',
+    runtimeEnvironmentId: null,
     openFile: vi.fn(),
     makePreviewFilePermanent: vi.fn(),
     toggleDir: vi.fn(),

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
@@ -72,6 +72,7 @@ describe('activateFileExplorerNode', () => {
     await activateFileExplorerNode({
       node: symlinkNode,
       activeWorktreeId: 'wt-1',
+      runtimeEnvironmentId: 'runtime-env-1',
       openFile,
       toggleDir: vi.fn(),
       loadDir: vi.fn(),
@@ -85,10 +86,42 @@ describe('activateFileExplorerNode', () => {
         filePath: '/repo/linked-docs',
         relativePath: 'linked-docs',
         worktreeId: 'wt-1',
+        runtimeEnvironmentId: 'runtime-env-1',
         language: expect.any(String),
         mode: 'edit'
       },
-      { preview: true }
+      { preview: true, suppressActiveRuntimeFallback: false }
+    )
+  })
+
+  it('opens local files without runtime fallback when no runtime owner is set', async () => {
+    const fileNode: TreeNode = {
+      name: 'README.md',
+      path: '/repo/README.md',
+      relativePath: 'README.md',
+      isDirectory: false,
+      depth: 0
+    }
+    const openFile = vi.fn()
+
+    await activateFileExplorerNode({
+      node: fileNode,
+      activeWorktreeId: 'wt-1',
+      runtimeEnvironmentId: null,
+      openFile,
+      toggleDir: vi.fn(),
+      loadDir: vi.fn(),
+      statPath: vi.fn(),
+      markPathAsDirectory: vi.fn(),
+      setSelectedPath: vi.fn()
+    })
+
+    expect(openFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/repo/README.md',
+        runtimeEnvironmentId: undefined
+      }),
+      { preview: true, suppressActiveRuntimeFallback: true }
     )
   })
 })

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -9,6 +9,7 @@ import { translate } from '@/i18n/i18n'
 
 type UseFileExplorerHandlersParams = {
   activeWorktreeId: string | null
+  runtimeEnvironmentId?: string | null
   openFile: (
     params: {
       filePath: string
@@ -16,8 +17,9 @@ type UseFileExplorerHandlersParams = {
       worktreeId: string
       language: string
       mode: 'edit'
+      runtimeEnvironmentId?: string | null
     },
-    options?: { preview?: boolean }
+    options?: { preview?: boolean; suppressActiveRuntimeFallback?: boolean }
   ) => void
   makePreviewFilePermanent: (filePath: string) => void
   toggleDir: (worktreeId: string, dirPath: string) => void
@@ -45,6 +47,7 @@ type OpenFileOptions = Parameters<UseFileExplorerHandlersParams['openFile']>[1]
 export async function activateFileExplorerNode(args: {
   node: TreeNode
   activeWorktreeId: string | null
+  runtimeEnvironmentId?: string | null
   openFile: (params: OpenFileParams, options?: OpenFileOptions) => void
   toggleDir: (worktreeId: string, dirPath: string) => void
   canToggleDirectories?: boolean
@@ -56,6 +59,7 @@ export async function activateFileExplorerNode(args: {
   const {
     node,
     activeWorktreeId,
+    runtimeEnvironmentId,
     openFile,
     toggleDir,
     canToggleDirectories = true,
@@ -116,15 +120,22 @@ export async function activateFileExplorerNode(args: {
       filePath: node.path,
       relativePath: node.relativePath,
       worktreeId: activeWorktreeId,
+      runtimeEnvironmentId: runtimeEnvironmentId ?? undefined,
       language: detectLanguage(node.name),
       mode: 'edit'
     },
-    { preview: true }
+    {
+      preview: true,
+      // Why: explicit local opens must not inherit the active runtime, so we
+      // encode "no runtime owner" via the fallback-suppression option.
+      suppressActiveRuntimeFallback: runtimeEnvironmentId === null
+    }
   )
 }
 
 export function useFileExplorerHandlers({
   activeWorktreeId,
+  runtimeEnvironmentId,
   openFile,
   makePreviewFilePermanent,
   toggleDir,
@@ -140,6 +151,7 @@ export function useFileExplorerHandlers({
       void activateFileExplorerNode({
         node,
         activeWorktreeId,
+        runtimeEnvironmentId,
         openFile,
         toggleDir,
         canToggleDirectories,
@@ -151,6 +163,7 @@ export function useFileExplorerHandlers({
     },
     [
       activeWorktreeId,
+      runtimeEnvironmentId,
       canToggleDirectories,
       loadDir,
       markPathAsDirectory,

--- a/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
@@ -158,13 +158,19 @@ export function useFileExplorerInlineInput({
             }
             await refreshDir(inlineInput.parentPath)
             if (inlineInput.type === 'file') {
-              openFile({
-                filePath: fullPath,
-                relativePath: worktreePath ? fullPath.slice(worktreePath.length + 1) : name,
-                worktreeId: activeWorktreeId,
-                language: detectLanguage(name),
-                mode: 'edit'
-              })
+              const runtimeEnvironmentId =
+                fileContext.settings.activeRuntimeEnvironmentId?.trim() || null
+              openFile(
+                {
+                  filePath: fullPath,
+                  relativePath: worktreePath ? fullPath.slice(worktreePath.length + 1) : name,
+                  worktreeId: activeWorktreeId,
+                  runtimeEnvironmentId: runtimeEnvironmentId ?? undefined,
+                  language: detectLanguage(name),
+                  mode: 'edit'
+                },
+                { suppressActiveRuntimeFallback: runtimeEnvironmentId === null }
+              )
             }
           } catch (err) {
             // Refresh the directory even on failure so the tree stays consistent


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** If you connect Orca to a remote machine (a "paired runtime" — for example a server you SSH into) and then click a file in that remote project's File Explorer, the editor often just shows "Unable to load file." Clicking "Retry" does nothing — it keeps failing the same way. Orca is mistakenly trying to read the file from your own laptop's disk instead of from the remote machine where the file actually lives, so it hits a permission wall ("Access denied: path resolves outside allowed directories"). This affects people working against remote/headless runtimes; it doesn't hit purely-local users. For those who do use remote runtimes, it's a hard blocker on a basic action — opening a file to look at it.

**2) What this PR does (ELI5).** Think of every open file as a package that needs a "return address" saying which machine it came from. The File Explorer was sending files off with the address left blank, so Orca guessed — and often guessed "the laptop," which was wrong for remote files. This PR makes the File Explorer write the correct return address (the remote runtime that owns the file) right on the package when you click it. Now the editor knows to fetch the file over the remote connection instead of the local disk. For files that really are local, it stamps an explicit "this one is genuinely local" flag so Orca won't accidentally re-route it to whatever remote machine happens to be focused. Oh, so it now reads remote files from the remote machine instead of silently looking on your laptop and failing.

**3) Tradeoffs / regressions — honest answer.** No regressions — nothing is disabled, no new setup, no behavior is lost. The change is one extra piece of information ("which machine owns this file") passed along an existing call; no GPU flag, fast path, or feature is turned off, and there are no new network calls, watchers, or polling. There is one subtle behavior *correction* worth naming honestly: for a local worktree, the old code would fall back to "whatever runtime is currently focused" when the owner was blank, which could route a local file's read to a focused remote runtime. This PR now marks local opens as explicitly local so they stay local. That is strictly the intended behavior (the old fallback was the bug), and it mirrors the already-shipped drag-and-drop and mobile file-open paths, so it's consistent rather than a new special case. Net: remote-runtime users gain a working file open/retry; local users are unaffected.

---

## Summary

Fixes #6440.

Opening a file from the File Explorer of a remote-runtime-owned worktree created the editor tab without a `runtimeEnvironmentId`. In `store.openFile`, an absent owner falls back to the ambient `settings.activeRuntimeEnvironmentId`, which is fragile: a tab for a remote worktree could be created with no/incorrect owner. The editor read path (`useEditorPanelContentState` -> `settingsForRuntimeOwner` -> `readRuntimeFileContent`) then routed through local `fs:readFile` and failed with `Access denied: path resolves outside allowed directories`. Retry reloaded the same tab and repeated the identical local read.

This change passes the worktree-owned runtime owner (`getRuntimeEnvironmentIdForWorktree`) when opening files from File Explorer (row click/keyboard activation and inline file creation), mirroring the existing `useGlobalFileDrop` and mobile file-open patterns. Explicit local opens pass `suppressActiveRuntimeFallback: true` so they stay local and are not retargeted to a focused runtime. Editor tabs now route through runtime file RPC, and Retry reuses the same owner.

This PR supersedes community PR #6506 (the original author is credited via `Co-authored-by`). #6506 is left open for the maintainers to close.

## Screenshots

No visual change. This is a renderer-only logic fix to file-open owner routing.

## Testing

- [x] `pnpm lint` (oxlint on changed files — clean)
- [x] `pnpm typecheck` (`tsgo -p config/tsconfig.tc.web.json` — exit 0)
- [x] `pnpm test` — targeted suites pass: `useFileExplorerHandlers.test.ts`, `file-explorer-drag-scroll-marker.test.tsx` (9 tests), plus `editor.test.ts` + `useEditorPanelContentState.test.tsx` (166 tests) as regression coverage for the read path
- [ ] `pnpm build` — not run locally; CI will verify
- [x] Added/updated high-quality tests: new `useFileExplorerHandlers` case asserts a local file open emits `runtimeEnvironmentId: undefined` with `suppressActiveRuntimeFallback: true`; the symlink case now asserts the owner is stamped and `suppressActiveRuntimeFallback: false`

**Electron verification:** A full UI repro requires pairing a real remote/headless runtime (`orca://pair`), which was infeasible in this environment (no runtime environments present; all repos are `local`). Instead I verified the exact `store.openFile` owner-stamping contract over CDP against the running app, proving the three cases the fix depends on (see PR comment for output): a stamped remote owner is preserved on the tab; an explicit local open with `suppressActiveRuntimeFallback` stays local; and the old no-owner path inherits the ambient focused runtime (the buggy behavior this fix avoids).

## AI Review Report

Reviewed adversarially as an adopted community contribution (assumed the original author could be malicious) and against `AGENTS.md`.

- **Cross-platform (macOS / Linux / Windows):** Renderer-only TypeScript in File Explorer open paths. No keyboard shortcuts, menu accelerators, shell spawning, or path-separator assumptions added or changed. Platform-neutral.
- **SSH / remote / local:** This is the core of the fix. Remote-runtime-owned worktrees now propagate their owner; local worktrees pass `runtimeEnvironmentId: null` with `suppressActiveRuntimeFallback: true`, preserving explicit local reads and avoiding retarget to a merely focused runtime.
- **Git provider compatibility:** No source-control/provider logic touched.
- **Performance:** One extra argument on existing `openFile` calls; no new watchers, polling, or IPC.
- **Consistency:** Mirrors the established `useGlobalFileDrop` runtime-owner propagation pattern (`runtimeEnvironmentId ?? undefined` + `suppressActiveRuntimeFallback: runtimeEnvironmentId === null`).

## Security Audit

- **Dependencies:** None added.
- **Path handling:** No new path construction; uses existing tree node paths and the already-computed inline-create `fullPath`. No path-traversal surface introduced.
- **IPC / auth:** Routes reads through the existing runtime file RPC when an owner is set instead of incorrectly hitting local `fs:readFile`. This narrows cross-boundary reads rather than widening access.
- **Input / execution / secrets:** No `eval`, no shell, no secret access, no network. The `runtimeEnvironmentId` originates from trusted store-derived owner functions, not user input.

No follow-up security work identified.

## Notes

- Out of scope for #6440: the search-result open path (`src/renderer/src/lib/search-match-open.ts`) likely has the same class of missing-owner bug and can be fixed in a separate issue/PR.

Made with [Orca](https://github.com/stablyai/orca) 🐋