### PR TITLE
Refuse cross-worktree global fallback for browser text insertion (#5093)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/nwparker/orca/workspaces/orca/bug-basher/node_modules

--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -1512,6 +1512,87 @@ describe('AgentBrowserBridge', () => {
     expect(chunks).toEqual(['z'.repeat(AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES), 'qq'])
   })
 
+  // ── Cross-worktree text-injection guard ──
+
+  describe('scoped target for text-mutating commands', () => {
+    function twoWorktreeBridge(): AgentBrowserBridge {
+      const tabs = new Map([
+        ['tab-a', 1],
+        ['tab-b', 2]
+      ])
+      const worktrees = new Map([
+        ['tab-a', 'wt-1'],
+        ['tab-b', 'wt-2']
+      ])
+      const wc1 = mockWebContents(1, 'https://a.com', 'A')
+      const wc2 = mockWebContents(2, 'https://b.com', 'B')
+      webContentsFromIdMock.mockImplementation((id: number) => (id === 1 ? wc1 : wc2))
+      return new AgentBrowserBridge(mockBrowserManager(tabs, worktrees))
+    }
+
+    function sessionNamesUsed(): string[] {
+      return execFileMock.mock.calls
+        .filter((call: unknown[]) => (call[1] as string[]).includes('--session'))
+        .map((call: unknown[]) => {
+          const args = call[1] as string[]
+          return args[args.indexOf('--session') + 1]
+        })
+    }
+
+    it.each([
+      ['inserttext', (b: AgentBrowserBridge) => b.keyboardInsertText('x', undefined, undefined)],
+      ['type', (b: AgentBrowserBridge) => b.type('x', undefined, undefined)],
+      ['fill', (b: AgentBrowserBridge) => b.fill('@input', 'x', undefined, undefined)]
+    ])(
+      'refuses %s when worktrees are ambiguous instead of routing to the global active tab',
+      async (_name, run) => {
+        const b = twoWorktreeBridge()
+        // Why: simulates the user viewing worktree B's tab, which sets the global
+        // active webContents — the bug would route the agent's text there.
+        b.onTabChanged(2, 'wt-2')
+        succeedWith({ inserted: true })
+
+        await expect(run(b)).rejects.toMatchObject({
+          code: 'browser_target_ambiguous'
+        })
+        // Must not have dispatched the command to worktree B's session.
+        expect(sessionNamesUsed()).not.toContain('orca-tab-tab-b')
+      }
+    )
+
+    it('auto-scopes inserttext to the lone worktree that has a live tab', async () => {
+      const tabs = new Map([['tab-a', 1]])
+      const worktrees = new Map([['tab-a', 'wt-1']])
+      const wc1 = mockWebContents(1, 'https://a.com', 'A')
+      webContentsFromIdMock.mockReturnValue(wc1)
+      const b = new AgentBrowserBridge(mockBrowserManager(tabs, worktrees))
+      succeedWith({ inserted: true })
+
+      await b.keyboardInsertText('x', undefined, undefined)
+
+      expect(sessionNamesUsed()).toContain('orca-tab-tab-a')
+    })
+
+    it('throws browser_no_tab for inserttext when no live tab exists', async () => {
+      const b = new AgentBrowserBridge(mockBrowserManager(new Map()))
+      await expect(b.keyboardInsertText('x', undefined, undefined)).rejects.toMatchObject({
+        code: 'browser_no_tab'
+      })
+    })
+
+    it('keeps read-only snapshot on the lenient global active-tab fallback', async () => {
+      const b = twoWorktreeBridge()
+      // Why: read/navigation commands intentionally keep the global fallback so
+      // discovery still works without a worktree; only text writes are guarded.
+      b.onTabChanged(2, 'wt-2')
+      succeedWith({ snapshot: 'tree' })
+
+      await b.snapshot(undefined, undefined)
+
+      expect(sessionNamesUsed()).toContain('orca-tab-tab-b')
+    })
+  })
+
   // ── Cookie command arg building ──
 
   it('builds cookie set args with all options', async () => {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -117,6 +117,9 @@ type AgentBrowserExecOptions = {
 type EnqueueTargetedCommandOptions = {
   ensureSession?: boolean
   ensureVisible?: boolean
+  // Why: text-mutating commands must never fall back to the global active tab,
+  // which can point at a different worktree the user is currently viewing.
+  requireScopedTarget?: boolean
 }
 
 type AgentBrowserBridgeOptions = {
@@ -764,27 +767,32 @@ export class AgentBrowserBridge {
     // Agent-browser's fill and click also fail for the same reason.
     // Workaround: use agent-browser's focus to resolve the ref, then set the value
     // directly via chunked JS and dispatch input/change events for React/framework compat.
-    return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      await this.execAgentBrowser(sessionName, ['focus', element])
-      await this.execAgentBrowser(sessionName, [
-        'eval',
-        focusedValueSetExpression(JSON.stringify(''))
-      ])
-      for (const chunk of iterateBrowserTextInsertionChunks(
-        value,
-        AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
-      )) {
+    return this.enqueueTargetedCommand(
+      worktreeId,
+      browserPageId,
+      async (sessionName) => {
+        await this.execAgentBrowser(sessionName, ['focus', element])
         await this.execAgentBrowser(sessionName, [
           'eval',
-          focusedValueSetExpression(JSON.stringify(chunk), { append: true })
+          focusedValueSetExpression(JSON.stringify(''))
         ])
-      }
-      await this.execAgentBrowser(sessionName, [
-        'eval',
-        focusedValueSetExpression(JSON.stringify(''), { append: true, dispatchEvents: true })
-      ])
-      return { filled: element } as BrowserFillResult
-    })
+        for (const chunk of iterateBrowserTextInsertionChunks(
+          value,
+          AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
+        )) {
+          await this.execAgentBrowser(sessionName, [
+            'eval',
+            focusedValueSetExpression(JSON.stringify(chunk), { append: true })
+          ])
+        }
+        await this.execAgentBrowser(sessionName, [
+          'eval',
+          focusedValueSetExpression(JSON.stringify(''), { append: true, dispatchEvents: true })
+        ])
+        return { filled: element } as BrowserFillResult
+      },
+      { requireScopedTarget: true }
+    )
   }
 
   async type(
@@ -793,15 +801,20 @@ export class AgentBrowserBridge {
     browserPageId?: string
   ): Promise<BrowserTypeResult> {
     await assertClipboardTextWriteWithinLimitWithYield(input)
-    return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      for (const chunk of iterateBrowserTextInsertionChunks(
-        input,
-        AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
-      )) {
-        await this.execAgentBrowser(sessionName, ['keyboard', 'type', chunk])
-      }
-      return { typed: true } as BrowserTypeResult
-    })
+    return this.enqueueTargetedCommand(
+      worktreeId,
+      browserPageId,
+      async (sessionName) => {
+        for (const chunk of iterateBrowserTextInsertionChunks(
+          input,
+          AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
+        )) {
+          await this.execAgentBrowser(sessionName, ['keyboard', 'type', chunk])
+        }
+        return { typed: true } as BrowserTypeResult
+      },
+      { requireScopedTarget: true }
+    )
   }
 
   async select(
@@ -878,16 +891,21 @@ export class AgentBrowserBridge {
     browserPageId?: string
   ): Promise<unknown> {
     await assertClipboardTextWriteWithinLimitWithYield(text)
-    return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      let result: unknown = { inserted: true }
-      for (const chunk of iterateBrowserTextInsertionChunks(
-        text,
-        AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
-      )) {
-        result = await this.execAgentBrowser(sessionName, ['keyboard', 'inserttext', chunk])
-      }
-      return result
-    })
+    return this.enqueueTargetedCommand(
+      worktreeId,
+      browserPageId,
+      async (sessionName) => {
+        let result: unknown = { inserted: true }
+        for (const chunk of iterateBrowserTextInsertionChunks(
+          text,
+          AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
+        )) {
+          result = await this.execAgentBrowser(sessionName, ['keyboard', 'inserttext', chunk])
+        }
+        return result
+      },
+      { requireScopedTarget: true }
+    )
   }
 
   // ── Mouse commands ──
@@ -1841,7 +1859,7 @@ export class AgentBrowserBridge {
     execute: (sessionName: string, target: ResolvedBrowserCommandTarget) => Promise<T>,
     options: EnqueueTargetedCommandOptions = {}
   ): Promise<T> {
-    const target = this.resolveCommandTarget(worktreeId, browserPageId)
+    const target = this.resolveCommandTarget(worktreeId, browserPageId, options.requireScopedTarget)
     const sessionName = `orca-tab-${target.browserPageId}`
 
     if (options.ensureSession !== false) {
@@ -1962,10 +1980,13 @@ export class AgentBrowserBridge {
 
   private resolveCommandTarget(
     worktreeId?: string,
-    browserPageId?: string
+    browserPageId?: string,
+    requireScopedTarget = false
   ): ResolvedBrowserCommandTarget {
     if (!browserPageId) {
-      return this.resolveActiveTab(worktreeId)
+      return requireScopedTarget
+        ? this.resolveScopedActiveTab(worktreeId)
+        : this.resolveActiveTab(worktreeId)
     }
 
     const tabs = this.getRegisteredTabs(worktreeId)
@@ -2037,6 +2058,40 @@ export class AgentBrowserBridge {
       'browser_no_tab',
       'No live browser tab available — all registered tabs have been destroyed'
     )
+  }
+
+  // Why: text-mutating commands (inserttext/type/fill) must not silently fall
+  // back to the global active tab when no worktree was resolved — that tab can
+  // belong to a worktree the user is currently viewing, so a goal-loop agent in
+  // another worktree would inject text into the user's foreground webview and
+  // steal OS focus. A scoped (worktreeId-bearing) call is already safe because
+  // the candidate set is pre-filtered to that worktree, so defer to the lenient
+  // resolver. An unscoped call instead requires an unambiguous target: scope to
+  // the lone worktree with live tabs, or refuse rather than guess.
+  private resolveScopedActiveTab(worktreeId?: string): ResolvedBrowserCommandTarget {
+    if (worktreeId) {
+      return this.resolveActiveTab(worktreeId)
+    }
+
+    const worktreesWithLiveTabs = new Set<string | undefined>()
+    for (const [tabId, wcId] of this.getRegisteredTabs(undefined)) {
+      if (this.getWebContents(wcId)) {
+        worktreesWithLiveTabs.add(this.browserManager.getWorktreeIdForTab(tabId))
+      }
+    }
+
+    if (worktreesWithLiveTabs.size === 0) {
+      throw new BrowserError('browser_no_tab', 'No browser tab open in this worktree')
+    }
+    if (worktreesWithLiveTabs.size > 1) {
+      throw new BrowserError(
+        'browser_target_ambiguous',
+        'Multiple worktrees have browser tabs open; pass --worktree to target text insertion safely'
+      )
+    }
+
+    const [onlyWorktreeId] = worktreesWithLiveTabs
+    return this.resolveActiveTab(onlyWorktreeId)
   }
 
   private async ensureSession(

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -505,4 +505,27 @@ describe('RuntimeBrowserCommands headless offscreen routing', () => {
     })
     expect(closeTab).not.toHaveBeenCalled()
   })
+
+  it('forwards an unresolved worktree to the bridge unchanged for keyboard inserttext', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    // Why: when no --worktree is passed (or cwd is outside a managed worktree),
+    // worktreeId arrives undefined. The bridge — not the runtime — owns the
+    // cross-worktree guard, so verify the undefined scope is threaded through
+    // intact rather than silently widened here.
+    const keyboardInsertText = vi.fn().mockResolvedValue({ inserted: true })
+    const bridge = {
+      getRegisteredTabs: vi.fn(() => new Map([['page-1', 100]])),
+      keyboardInsertText
+    } as unknown as AgentBrowserBridge
+    const commands = new RuntimeBrowserCommands(
+      createHost({
+        getAgentBrowserBridge: () => bridge,
+        getAuthoritativeWindow: vi.fn(() => ({ webContents: { send: vi.fn() } }) as never)
+      })
+    )
+
+    await commands.browserKeyboardInsertText({ text: 'hello' })
+
+    expect(keyboardInsertText).toHaveBeenCalledWith('hello', undefined, undefined)
+  })
 })


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** If you run an AI agent in "goal loop" mode in one project while you're typing somewhere else, the agent can suddenly dump its text right where your cursor is — into the wrong project's files. Because it lands outside the workspace the agent is supposed to touch, it silently corrupts whatever you were editing. The reporter calls it "a huge error" that "messes up the files," and they're right: it's a data-corruption bug, not just an annoyance. It hits people who run a background agent while actively working in a second project at the same time (and is especially likely on remote/SSH setups or when the agent runs from a folder Orca doesn't recognize as a managed workspace).

**2) What this PR does (ELI5).** Think of each project as having its own mailbox for browser typing. The bug was that when the agent couldn't figure out which mailbox to use, it just shoved the text into "whatever mailbox you happened to be looking at" — which was often a different project. This fix makes the typing commands refuse to guess. If there's exactly one project with a live browser tab, it uses that one. If there are several, it stops and says "I can't tell which project you mean — tell me with --worktree" rather than risk typing into the wrong one. So it now safely refuses (or asks you to be specific) instead of blindly typing into your foreground window.

**3) Tradeoffs / regressions — honest answer.** Essentially no real regression, but one honest behavior change worth naming. Before, a typing command issued without a specific project target would always go *somewhere* (the tab you were viewing); now, in the rare case where two or more projects each have a live browser tab open, that command will fail with a clear "pass --worktree" error instead of silently typing into one of them. That's the whole point — the old "success" was the bug (it typed into the wrong place). The fix only narrows things: it can refuse or scope more tightly, never type anywhere it didn't before. Read-only and navigation commands (snapshots, screenshots, clicks) are untouched and still use the old lenient behavior, so nothing there changes. No setting is flipped, no feature is disabled, nothing slows down, and it's neutral-to-better on every platform (and a direct improvement for SSH/remote, where this misroute was most likely).

---

## Summary

Fixes #5093

Text-mutating browser commands (`keyboard inserttext`, `type`, `fill`) fell back to the **global** active browser tab when no worktree scope was resolved. Because `AgentBrowserBridge.onTabChanged()` updates the global `activeWebContentsId` every time the user views *any* browser tab in *any* worktree, a goal-loop agent running in worktree A — whenever its worktree arrived `undefined` at the runtime (cwd outside a managed worktree, `--worktree all`, or a remote/SSH runtime where cwd cannot resolve) — would insert text into whatever browser tab the user was currently viewing in worktree B. The CDP proxy's `webContents.focus()` for `Input.insertText` then pulled OS keyboard focus to that misrouted webview, which is why text appeared "at the cursor" and corrupted the user's editing.

The fix adds a strict target resolution (`requireScopedTarget`) used only by the three text-writing entry points:

- worktree-scoped calls are unchanged (already safe — the candidate tab set is pre-filtered to that worktree);
- an **unscoped** call now scopes to the lone worktree that has live browser tabs;
- throws `browser_no_tab` when no live tab exists;
- throws a new `browser_target_ambiguous` error ("Multiple worktrees have browser tabs open; pass --worktree to target text insertion safely") when more than one worktree has tabs, instead of guessing the global tab.

Read-only / navigation commands (`snapshot`, `screenshot`, `get`, `click`, etc.) keep the existing lenient global fallback to avoid behavior churn.

## Screenshots

No visual change. This is an internal command-routing fix (which webview receives an `Input.insertText`), not a renderer/UI change. See the Testing section and the PR comment for unit-test evidence demonstrating the misroute is prevented.

## Testing

- [x] `pnpm lint` (oxlint on changed files — clean)
- [x] `pnpm typecheck` (`tsgo --noEmit -p config/tsconfig.node.json` — clean)
- [x] `pnpm test` (touched suites — see below)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New/updated tests:
- `src/main/browser/agent-browser-bridge.test.ts`: with two worktrees (each one live tab) and the global active tab pointed at worktree B, `inserttext`/`type`/`fill` now reject with `browser_target_ambiguous` and never dispatch to worktree B's session; single-worktree auto-scopes; no-tab throws `browser_no_tab`; read-only `snapshot` keeps the lenient global fallback (still routes to B).
- `src/main/runtime/orca-runtime-browser.test.ts`: `browserKeyboardInsertText({ text })` with no `--worktree` forwards `worktreeId: undefined` to the bridge unchanged (confirming the guard belongs in the bridge, the single chokepoint).

Regression confirmed: temporarily reverting the `requireScopedTarget` on `keyboardInsertText` makes the ambiguity test fail ("promise resolved instead of rejecting"), proving the test catches the bug.

Electron repro: the end-to-end visual repro requires two managed worktrees each with a live Agent Browser tab plus a running goal-loop agent issuing CLI `browser keyboard inserttext` from a non-managed cwd — an integration-level, multi-process scenario not reliably reproducible via CDP automation here, and the defect is internal routing state rather than a screenshot-able element. The unit tests directly exercise the exact misroute (global `activeWebContentsId` → worktree B) and are the authoritative evidence.

## AI Review Report

Reviewed with an adversarial self-review pass:
- **Correctness / edge cases**: only *live* tabs (`getWebContents` truthy) count toward worktree ambiguity, so ghost/destroyed tabs from other worktrees don't trigger false ambiguity. Single live tab with no worktree mapping (common case) still resolves via the lenient path — no behavior change. No TOCTOU: the count scan and `resolveActiveTab` run synchronously in the same call stack (no `await` between), so the tab set cannot mutate between them. `refreshTargetAfterAutomationVisibility` passes a concrete `browserPageId`, so it takes the explicit-page branch and never hits the strict resolver.
- **Cross-platform (macOS/Linux/Windows)**: no keyboard shortcuts, no `metaKey`/`ctrlKey`, no path separators, no shell behavior touched. The `--worktree` guidance in the error is platform- and git-provider-agnostic.
- **SSH/remote**: directly improves the remote path — when cwd cannot resolve server-side, `worktreeId` is intentionally `undefined`, and the strict guard now yields the safe ambiguity error instead of a global misroute.

## Security Audit

The change only **narrows** command routing: text-mutating commands can now reject or scope more tightly, never widen access. No new input handling, command execution, path handling, auth, secrets, dependencies, or IPC surface. The new error message is a fixed string with no interpolation of untrusted input. `cdp-ws-proxy.ts` `focus()` is intentionally left in place (required for `Input.insertText` delivery to Electron webview guests); it is only dangerous when a command is misrouted, which this fix prevents. No follow-up security work needed.

## Notes

- Scope kept minimal per the validation plan: the runtime-side strict guard in `AgentBrowserBridge` is the single chokepoint for all callers (CLI, RPC, remote), so `src/cli/selectors.ts` is left unchanged.
- **Future suggestion (out of scope)**: optionally add a `strict` flag to the `inserttext`/`type`/`fill` CLI handlers so they surface a CLI-local message ("run inside a managed worktree or pass --worktree") before the round-trip, instead of relaying the runtime's `browser_target_ambiguous`. Purely an error-locale nicety; the current behavior already fails loudly and clearly.

Made with [Orca](https://github.com/stablyai/orca) 🐋