### PR TITLE
fix: run new worktree setup before launching scheduled automation agents

### DIFF
--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockLaunchAgentBackgroundSession = vi.fn()
 const mockLaunchWorktreeBackgroundTerminals = vi.fn()
-const mockSubmitPromptToAgentTab = vi.fn()
+const mockSubmitPromptToAgentPty = vi.fn()
 const mockFindReusableAutomationSession = vi.fn()
 const mockObserveExistingAutomationSession = vi.fn()
 const mockCreateWorktree = vi.fn()
@@ -101,7 +101,7 @@ vi.mock('@/lib/launch-worktree-background-terminals', () => ({
 }))
 
 vi.mock('@/lib/agent-paste-draft', () => ({
-  submitPromptToAgentTab: mockSubmitPromptToAgentTab
+  submitPromptToAgentPty: mockSubmitPromptToAgentPty
 }))
 
 vi.mock('@/lib/automation-session-reuse', () => ({
@@ -174,46 +174,24 @@ describe('useAutomationDispatchEvents setup launch', () => {
     })
   })
 
-  it('starts setup terminal launch without waiting before launching the automation agent', async () => {
-    const order: string[] = []
-    let finishSetupLaunch: (() => void) | null = null
-    mockLaunchWorktreeBackgroundTerminals.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          finishSetupLaunch = () => {
-            order.push('setup')
-            resolve()
-          }
-        })
-    )
-    mockLaunchAgentBackgroundSession.mockImplementation(async () => {
-      order.push('agent')
-      return { tabId: 'agent-tab', ptyId: 'agent-pty', startupPlan: {} }
-    })
-
+  it('passes new-run setup into the agent launcher so startup is gated', async () => {
     await registerAndDispatch()
 
     expect(mockCreateWorktree).toHaveBeenCalled()
     expect(mockCreateWorktree.mock.calls[0][3]).toBe('run')
-    expect(mockLaunchWorktreeBackgroundTerminals).toHaveBeenCalledWith({
-      worktreeId: 'wt-created',
-      setup: setupLaunch,
-      defaultTabs: undefined
-    })
+    expect(mockLaunchWorktreeBackgroundTerminals).not.toHaveBeenCalled()
     expect(state.setActiveView).not.toHaveBeenCalled()
     expect(state.setActiveWorktree).not.toHaveBeenCalled()
     expect(mockLaunchAgentBackgroundSession).toHaveBeenCalledWith(
       expect.objectContaining({
         worktreeId: 'wt-created',
-        prompt: 'run this'
+        prompt: 'run this',
+        preAgentWorktreeSetup: {
+          setup: setupLaunch,
+          defaultTabs: undefined
+        }
       })
     )
-    expect(order).toEqual(['agent'])
-    expect(finishSetupLaunch).not.toBeNull()
-    const completeSetupLaunch = finishSetupLaunch as unknown as () => void
-    completeSetupLaunch()
-    await Promise.resolve()
-    expect(order).toEqual(['agent', 'setup'])
     expect(mockMarkDispatchResult).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: 'run-1',
@@ -224,7 +202,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     )
   })
 
-  it('launches setup and default tabs without activating the created worktree', async () => {
+  it('passes setup and default tabs into the setup-gated agent launcher', async () => {
     const defaultTabs = {
       tabs: [{ title: 'Dev', command: 'pnpm dev' }],
       runCommands: true
@@ -237,17 +215,37 @@ describe('useAutomationDispatchEvents setup launch', () => {
 
     await registerAndDispatch()
 
-    expect(mockLaunchWorktreeBackgroundTerminals).toHaveBeenCalledWith({
-      worktreeId: 'wt-created',
-      setup: setupLaunch,
-      defaultTabs
-    })
+    expect(mockLaunchWorktreeBackgroundTerminals).not.toHaveBeenCalled()
     expect(state.setActiveView).not.toHaveBeenCalled()
     expect(state.setActiveWorktree).not.toHaveBeenCalled()
     expect(mockLaunchAgentBackgroundSession).toHaveBeenCalledWith(
       expect.objectContaining({
         worktreeId: 'wt-created',
-        prompt: 'run this'
+        prompt: 'run this',
+        preAgentWorktreeSetup: { setup: setupLaunch, defaultTabs }
+      })
+    )
+  })
+
+  it('launches default tabs best-effort when there is no setup to gate the agent', async () => {
+    const defaultTabs = {
+      tabs: [{ title: 'Dev', command: 'pnpm dev' }],
+      runCommands: true
+    }
+    mockCreateWorktree.mockResolvedValue({
+      worktree: createdWorktree,
+      defaultTabs
+    })
+
+    await registerAndDispatch()
+
+    expect(mockLaunchWorktreeBackgroundTerminals).toHaveBeenCalledWith({
+      worktreeId: 'wt-created',
+      defaultTabs
+    })
+    expect(mockLaunchAgentBackgroundSession).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        preAgentWorktreeSetup: expect.anything()
       })
     )
   })
@@ -259,28 +257,27 @@ describe('useAutomationDispatchEvents setup launch', () => {
     expect(mockLaunchAgentBackgroundSession).toHaveBeenCalled()
   })
 
-  it('keeps launching the agent when background setup terminal launch fails', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    mockLaunchWorktreeBackgroundTerminals.mockRejectedValue(new Error('tab launch failed'))
+  it('marks the dispatch failed when setup-gated agent launch fails', async () => {
+    mockLaunchAgentBackgroundSession.mockRejectedValue(new Error('setup spawn failed'))
 
-    try {
-      await registerAndDispatch()
-    } finally {
-      warnSpy.mockRestore()
-    }
+    await registerAndDispatch()
 
     expect(mockLaunchAgentBackgroundSession).toHaveBeenCalledWith(
       expect.objectContaining({
         worktreeId: 'wt-created',
-        prompt: 'run this'
+        prompt: 'run this',
+        preAgentWorktreeSetup: {
+          setup: setupLaunch,
+          defaultTabs: undefined
+        }
       })
     )
     expect(mockMarkDispatchResult).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: 'run-1',
-        status: 'dispatched',
+        status: 'dispatch_failed',
         workspaceId: 'wt-created',
-        terminalSessionId: 'agent-tab'
+        error: 'setup spawn failed'
       })
     )
   })

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -235,15 +235,14 @@ export function useAutomationDispatchEvents(): void {
           }
           dispatchWorkspaceId = worktree.id
           dispatchWorkspaceDisplayName = worktree.displayName
-          if (createResult?.setup || createResult?.defaultTabs) {
+          if (!createResult?.setup && createResult?.defaultTabs) {
             void launchWorktreeBackgroundTerminals({
               worktreeId: worktree.id,
-              setup: createResult.setup,
               defaultTabs: createResult.defaultTabs
             }).catch((error) => {
-              // Why: setup/defaultTabs match normal worktree creation: they are
-              // best-effort terminal work and must not block the automation agent.
-              console.warn('[automations] Failed to launch workspace setup/default tabs:', error)
+              // Why: default tabs match normal worktree creation, but are not
+              // prerequisites for starting the automation agent.
+              console.warn('[automations] Failed to launch workspace default tabs:', error)
             })
           }
 
@@ -430,6 +429,14 @@ export function useAutomationDispatchEvents(): void {
             prompt: automation.prompt,
             launchSource: 'unknown',
             title: run.title,
+            ...(createResult?.setup
+              ? {
+                  preAgentWorktreeSetup: {
+                    setup: createResult.setup,
+                    defaultTabs: createResult.defaultTabs
+                  }
+                }
+              : {}),
             onData: (chunk) => {
               outputSnapshotBuffer.append(chunk)
             },

--- a/src/renderer/src/lib/agent-background-session-contract.ts
+++ b/src/renderer/src/lib/agent-background-session-contract.ts
@@ -2,6 +2,7 @@ import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-type
 import type { LaunchSource } from '../../../shared/telemetry-events'
 import type { TuiAgent } from '../../../shared/types'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+import type { PreAgentWorktreeSetup } from '@/lib/background-agent-setup-sequence'
 
 export type LaunchAgentBackgroundSessionArgs = {
   agent: TuiAgent
@@ -9,6 +10,7 @@ export type LaunchAgentBackgroundSessionArgs = {
   prompt?: string
   launchSource?: LaunchSource
   title?: string
+  preAgentWorktreeSetup?: PreAgentWorktreeSetup
   onData?: (chunk: string) => void
   onExit?: (ptyId: string, code: number) => void
   onAgentStatus?: (payload: ParsedAgentStatusPayload) => void

--- a/src/renderer/src/lib/background-agent-setup-sequence.ts
+++ b/src/renderer/src/lib/background-agent-setup-sequence.ts
@@ -1,0 +1,46 @@
+import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+import { launchWorktreeBackgroundTerminals } from '@/lib/launch-worktree-background-terminals'
+import {
+  createSequencedSetupAgentCommands,
+  DEFAULT_SETUP_AGENT_SEQUENCE_WAIT_TIMEOUT_SECONDS
+} from '../../../shared/setup-agent-sequencing'
+import { getSetupRunnerCommandPlatformForPath } from '../../../shared/setup-runner-command'
+import type { WorktreeDefaultTabsLaunch, WorktreeSetupLaunch } from '../../../shared/types'
+
+export const SETUP_GATED_AGENT_READY_TIMEOUT_MS =
+  (DEFAULT_SETUP_AGENT_SEQUENCE_WAIT_TIMEOUT_SECONDS + 10) * 1000
+
+export type PreAgentWorktreeSetup = {
+  setup: WorktreeSetupLaunch
+  defaultTabs?: WorktreeDefaultTabsLaunch
+}
+
+export async function sequenceBackgroundAgentStartupAfterSetup(args: {
+  worktreeId: string
+  startupPlan: AgentStartupPlan
+  launchPlatform: NodeJS.Platform
+  preAgentWorktreeSetup: PreAgentWorktreeSetup
+}): Promise<AgentStartupPlan> {
+  const { setup } = args.preAgentWorktreeSetup
+  const sequenced = createSequencedSetupAgentCommands({
+    runnerScriptPath: setup.runnerScriptPath,
+    startupCommand: args.startupPlan.launchCommand,
+    platform: getSetupRunnerCommandPlatformForPath(
+      setup.runnerScriptPath,
+      args.launchPlatform === 'win32' ? 'windows' : 'posix'
+    )
+  })
+  const startupPlan = {
+    ...args.startupPlan,
+    launchCommand: sequenced.startupCommand,
+    env: { ...args.startupPlan.env, ...sequenced.startupEnv }
+  }
+  // Why: scheduled new-run automations need setup-created config/skills
+  // before the agent starts, while the hidden agent tab still appears promptly.
+  await launchWorktreeBackgroundTerminals({
+    worktreeId: args.worktreeId,
+    setup: { ...setup, command: sequenced.setupCommand },
+    defaultTabs: args.preAgentWorktreeSetup.defaultTabs
+  })
+  return startupPlan
+}

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -21,6 +21,7 @@ const mockSubscribeToPtyExit = vi.fn()
 const mockPasteDraftWhenAgentReady = vi.fn()
 const mockMarkTrusted = vi.fn()
 const mockDispatchEvent = vi.fn()
+const mockLaunchWorktreeBackgroundTerminals = vi.fn()
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
 function expectStablePaneSpawn(): string {
@@ -89,6 +90,10 @@ vi.mock('@/lib/agent-paste-draft', () => ({
   pasteDraftWhenAgentReady: mockPasteDraftWhenAgentReady
 }))
 
+vi.mock('@/lib/launch-worktree-background-terminals', () => ({
+  launchWorktreeBackgroundTerminals: mockLaunchWorktreeBackgroundTerminals
+}))
+
 vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
   registerEagerPtyBuffer: mockRegisterEagerPtyBuffer,
   subscribeToPtyExit: mockSubscribeToPtyExit
@@ -129,6 +134,7 @@ describe('launchAgentBackgroundSession', () => {
     }
     mockCreateTab.mockReturnValue({ id: 'tab-1', title: 'Terminal 1' })
     mockSpawn.mockResolvedValue({ id: 'pty-1' })
+    mockLaunchWorktreeBackgroundTerminals.mockResolvedValue(undefined)
     mockRuntimeEnvironmentCall.mockResolvedValue({
       ok: true,
       result: { terminal: { handle: 'terminal-1', worktreeId: 'wt-1', title: null } }
@@ -224,6 +230,83 @@ describe('launchAgentBackgroundSession', () => {
     expect(mockSubscribeToPtyData).toHaveBeenCalledWith('pty-1', expect.any(Function))
     expect(mockSubscribeToPtyExit).toHaveBeenCalledWith('pty-1', expect.any(Function))
     expect(result).toMatchObject({ tabId: 'tab-1', paneKey, ptyId: 'pty-1' })
+  })
+
+  it('launches setup terminals before spawning a setup-gated automation agent', async () => {
+    const order: string[] = []
+    const defaultTabs = {
+      runCommands: true,
+      tabs: [{ title: 'Dev', command: 'pnpm dev' }]
+    }
+    const setup = {
+      runnerScriptPath: '/tmp/setup.sh',
+      envVars: { ORCA_WORKTREE_PATH: '/repo/worktree' }
+    }
+    mockLaunchWorktreeBackgroundTerminals.mockImplementation(async () => {
+      order.push('setup')
+    })
+    mockSpawn.mockImplementation(async () => {
+      order.push('agent')
+      return { id: 'pty-1' }
+    })
+    const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+
+    await launchAgentBackgroundSession({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      prompt: 'run the automation',
+      preAgentWorktreeSetup: { setup, defaultTabs }
+    })
+
+    expect(order).toEqual(['setup', 'agent'])
+    const setupLaunch = mockLaunchWorktreeBackgroundTerminals.mock.calls[0]?.[0]
+    expect(setupLaunch).toMatchObject({
+      worktreeId: 'wt-1',
+      defaultTabs,
+      setup: expect.objectContaining({
+        runnerScriptPath: '/tmp/setup.sh',
+        envVars: { ORCA_WORKTREE_PATH: '/repo/worktree' }
+      })
+    })
+    expect(setupLaunch.setup.command).toContain('bash /tmp/setup.sh')
+    expect(setupLaunch.setup.command).toContain('/tmp/setup.sh.')
+    expect(setupLaunch.setup.command).toContain('.done')
+    const spawnArgs = mockSpawn.mock.calls[0]?.[0]
+    expect(spawnArgs.command).toContain('Waiting for setup to finish before starting agent')
+    expect(spawnArgs.command).toContain('/tmp/setup.sh.')
+    expect(spawnArgs.env).toEqual(
+      expect.objectContaining({
+        ORCA_SEQUENCED_STARTUP_COMMAND:
+          "claude '--dangerously-skip-permissions' 'run the automation'"
+      })
+    )
+    expect(spawnArgs.launchConfig).toEqual({
+      agentCommand: "claude '--dangerously-skip-permissions'",
+      agentArgs: '--dangerously-skip-permissions',
+      agentEnv: {}
+    })
+  })
+
+  it('does not launch the agent when setup terminal creation fails', async () => {
+    mockLaunchWorktreeBackgroundTerminals.mockRejectedValueOnce(new Error('setup spawn failed'))
+    const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+
+    await expect(
+      launchAgentBackgroundSession({
+        agent: 'claude',
+        worktreeId: 'wt-1',
+        prompt: 'run the automation',
+        preAgentWorktreeSetup: {
+          setup: {
+            runnerScriptPath: '/tmp/setup.sh',
+            envVars: { ORCA_WORKTREE_PATH: '/repo/worktree' }
+          }
+        }
+      })
+    ).rejects.toThrow('setup spawn failed')
+
+    expect(mockSpawn).not.toHaveBeenCalled()
+    expect(mockCreateTab).not.toHaveBeenCalled()
   })
 
   it('records effective launch config returned by local PTY spawn', async () => {
@@ -627,5 +710,27 @@ describe('launchAgentBackgroundSession', () => {
       paneKey: `tab-1:${leafId}`,
       ptyId: 'remote:env-1@@terminal-1'
     })
+  })
+
+  it('does not add renderer-side setup gates for runtime-owned worktrees', async () => {
+    state.settings = { agentCmdOverrides: {}, activeRuntimeEnvironmentId: 'env-1' }
+    const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+
+    await launchAgentBackgroundSession({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      prompt: 'run the automation',
+      preAgentWorktreeSetup: {
+        setup: {
+          runnerScriptPath: '/tmp/setup.sh',
+          envVars: { ORCA_WORKTREE_PATH: '/repo/worktree' }
+        }
+      }
+    })
+
+    expect(mockLaunchWorktreeBackgroundTerminals).not.toHaveBeenCalled()
+    expect(mockRuntimeEnvironmentCall.mock.calls[0]?.[0]?.params.command).toBe(
+      "claude '--dangerously-skip-permissions' 'run the automation'"
+    )
   })
 })

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -37,6 +37,10 @@ import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
 import type { RuntimeTerminalCreate } from '../../../shared/runtime-types'
 import { createSshBackgroundStartupDelivery } from '@/lib/ssh-background-startup-delivery'
 import { shouldUseShellReadyStartupDelivery } from '../../../shared/codex-startup-delivery'
+import {
+  sequenceBackgroundAgentStartupAfterSetup,
+  SETUP_GATED_AGENT_READY_TIMEOUT_MS
+} from '@/lib/background-agent-setup-sequence'
 
 export async function launchAgentBackgroundSession(
   args: LaunchAgentBackgroundSessionArgs
@@ -104,6 +108,21 @@ export async function launchAgentBackgroundSession(
   if (!startupPlan) {
     return null
   }
+  // Route by the worktree's owner host, not the focused runtime.
+  const runtimeTarget = getActiveRuntimeTarget(
+    getSettingsForWorktreeRuntimeOwner(store, worktreeId)
+  )
+
+  let didSequencePreAgentSetup = false
+  if (args.preAgentWorktreeSetup && runtimeTarget.kind !== 'environment') {
+    startupPlan = await sequenceBackgroundAgentStartupAfterSetup({
+      worktreeId,
+      startupPlan,
+      launchPlatform,
+      preAgentWorktreeSetup: args.preAgentWorktreeSetup
+    })
+    didSequencePreAgentSetup = true
+  }
 
   // Why: automation runs should start without revealing the workspace.
   // Spawn the PTY immediately, then attach an inactive tab to the live session.
@@ -156,10 +175,6 @@ export async function launchAgentBackgroundSession(
       }),
     write: (ptyId, data) => window.api.pty.write(ptyId, data)
   })
-  // Route by the worktree's owner host, not the focused runtime.
-  const runtimeTarget = getActiveRuntimeTarget(
-    getSettingsForWorktreeRuntimeOwner(store, worktreeId)
-  )
   let ptyId = ''
   try {
     if (runtimeTarget.kind === 'environment') {
@@ -304,6 +319,7 @@ export async function launchAgentBackgroundSession(
       content: pasteDraftAfterLaunch,
       agent,
       submit: true,
+      ...(didSequencePreAgentSetup ? { timeoutMs: SETUP_GATED_AGENT_READY_TIMEOUT_MS } : {}),
       onTimeout: () => showAutomationPromptNotSentToast(agent)
     })
   }

--- a/src/renderer/src/lib/launch-worktree-background-terminals.test.ts
+++ b/src/renderer/src/lib/launch-worktree-background-terminals.test.ts
@@ -239,6 +239,27 @@ describe('launchWorktreeBackgroundTerminals', () => {
     )
   })
 
+  it('uses a prebuilt setup command when the launch was sequenced with agent startup', async () => {
+    const { launchWorktreeBackgroundTerminals } =
+      await import('./launch-worktree-background-terminals')
+
+    await launchWorktreeBackgroundTerminals({
+      worktreeId: 'wt-1',
+      setup: {
+        ...setupLaunch,
+        command: "bash -lc 'sequenced setup marker'"
+      }
+    })
+
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        command: "bash -lc 'sequenced setup marker'",
+        tabId: 'tab-2'
+      })
+    )
+  })
+
   it('still attempts setup when a default tab fails to spawn', async () => {
     const spawnError = new Error('pty unavailable')
     mockSpawn

--- a/src/renderer/src/lib/launch-worktree-background-terminals.ts
+++ b/src/renderer/src/lib/launch-worktree-background-terminals.ts
@@ -119,6 +119,9 @@ function registerBackgroundPaneBuffer(tabId: string, leafId: string, ptyId: stri
 }
 
 function buildSetupCommand(setup: WorktreeSetupLaunch): string {
+  if (setup.command?.trim()) {
+    return setup.command
+  }
   return buildSetupRunnerCommand(
     setup.runnerScriptPath,
     isWindowsAbsolutePathLike(setup.runnerScriptPath) ? 'windows' : 'posix'

--- a/src/shared/setup-agent-sequencing.ts
+++ b/src/shared/setup-agent-sequencing.ts
@@ -4,7 +4,7 @@ import {
   type SetupRunnerCommandShell
 } from './setup-runner-command'
 
-const DEFAULT_WAIT_TIMEOUT_SECONDS = 2 * 60 * 60
+export const DEFAULT_SETUP_AGENT_SEQUENCE_WAIT_TIMEOUT_SECONDS = 2 * 60 * 60
 export const SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV = 'ORCA_SEQUENCED_STARTUP_COMMAND'
 
 export type SequencedSetupAgentCommands = {
@@ -41,7 +41,8 @@ export function createSequencedSetupAgentCommands(args: {
   // Why: overlapping gated launches of the same setup runner must not race on
   // a shared completion marker.
   const markerPath = `${resolution.runnerScriptPathForShell}.${nonce}.done`
-  const waitTimeoutSeconds = args.waitTimeoutSeconds ?? DEFAULT_WAIT_TIMEOUT_SECONDS
+  const waitTimeoutSeconds =
+    args.waitTimeoutSeconds ?? DEFAULT_SETUP_AGENT_SEQUENCE_WAIT_TIMEOUT_SECONDS
 
   if (resolution.shell === 'windows') {
     return {


### PR DESCRIPTION
## Summary

Fixes #5918.

Scheduled `new_per_run` automations now preserve the worktree setup hook and sequence the automation agent behind it. When a new automation worktree returns a setup launch descriptor, dispatch passes it into the background agent launcher instead of starting setup as fire-and-forget work. The launcher uses Orca's shared setup-agent sequencing primitive: it starts the hidden Setup/default terminal work, wraps the agent startup command with a matching completion marker, and only runs the actual agent command after setup exits successfully.

This keeps the bug fix from the original PR, but removes the main tradeoffs from that implementation:

- The renderer no longer waits for setup to exit before creating the hidden agent tab.
- Setup spawn failures are no longer console-only best-effort skips; they reject the setup-gated launch and the automation run is marked `dispatch_failed`.
- Setup script failures/timeouts no longer proceed in a degraded workspace. The agent wrapper exits non-zero and the run fails instead of silently starting without gitignored config/skills.
- Default tabs without setup remain best-effort and non-blocking, because they are not prerequisites for the automation agent.

## Tradeoff status

The avoidable tradeoffs are gone. The only remaining caveat is inherent to the bug fix: if setup is selected and never completes, Orca should not start the agent in the unprepared workspace. In that case the shared setup gate waits until its existing timeout and exits failed rather than launching the agent without setup.

Runtime-owned worktrees keep their host-side setup/default-tab handling; local and SSH worktrees use the renderer-side background terminal sequence. No provider-specific source-control behavior is involved.

## Testing

- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/hooks/useAutomationDispatchEvents.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts src/shared/setup-agent-sequencing.test.ts` — 4 files, 44 tests passed
- `pnpm exec oxlint src/renderer/src/hooks/useAutomationDispatchEvents.ts src/renderer/src/hooks/useAutomationDispatchEvents.test.ts src/renderer/src/lib/agent-background-session-contract.ts src/renderer/src/lib/background-agent-setup-sequence.ts src/renderer/src/lib/launch-agent-background-session.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts src/shared/setup-agent-sequencing.ts`
- `pnpm exec oxfmt --check src/renderer/src/hooks/useAutomationDispatchEvents.ts src/renderer/src/hooks/useAutomationDispatchEvents.test.ts src/renderer/src/lib/agent-background-session-contract.ts src/renderer/src/lib/background-agent-setup-sequence.ts src/renderer/src/lib/launch-agent-background-session.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/launch-worktree-background-terminals.ts src/renderer/src/lib/launch-worktree-background-terminals.test.ts src/shared/setup-agent-sequencing.ts`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
