### PR TITLE
fix: reflow surviving terminal when a tab-group split collapses (#6154)

### DIFF
--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -46,6 +46,14 @@ vi.mock('./useTabDragSplit', () => ({
   })
 }))
 
+// Why: these cases invoke TabGroupSplitLayout as a plain function (not a
+// mounted component) to inspect its element tree, so any real React hook it
+// calls would throw. Stub the side-effect-only refit hook out — its behavior
+// is covered directly in use-refit-on-split-collapse.test.tsx.
+vi.mock('./use-refit-on-split-collapse', () => ({
+  useRefitOnSplitCollapse: vi.fn()
+}))
+
 import TabGroupSplitLayout from './TabGroupSplitLayout'
 
 type ReactElementLike = {

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -6,6 +6,7 @@ import TabGroupPanel from './TabGroupPanel'
 import TabDragPreview from '../tab-bar/TabDragPreview'
 import { TabDragProvider } from './tab-drag-context'
 import TabPaneColumnSplitDragOverlay from './TabPaneColumnSplitDragOverlay'
+import { useRefitOnSplitCollapse } from './use-refit-on-split-collapse'
 import { type HoveredTabInsertion, useTabDragSplit } from './useTabDragSplit'
 
 const MIN_RATIO = 0.15
@@ -222,6 +223,9 @@ export default function TabGroupSplitLayout({
 }): React.JSX.Element {
   const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
   const hasSplits = layout.type === 'split'
+
+  // Why: reflow the surviving group's terminal when a split collapses (#6154).
+  useRefitOnSplitCollapse(layout, isWorktreeActive)
 
   return (
     <TabDragProvider

--- a/src/renderer/src/components/tab-group/tab-group-layout-leaf-count.test.ts
+++ b/src/renderer/src/components/tab-group/tab-group-layout-leaf-count.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import type { TabGroupLayoutNode } from '../../../../shared/types'
+import { countLayoutLeaves } from './tab-group-layout-leaf-count'
+
+describe('countLayoutLeaves', () => {
+  it('counts a single leaf as one', () => {
+    const layout: TabGroupLayoutNode = { type: 'leaf', groupId: 'a' }
+    expect(countLayoutLeaves(layout)).toBe(1)
+  })
+
+  it('counts a two-leaf split as two', () => {
+    const layout: TabGroupLayoutNode = {
+      type: 'split',
+      direction: 'horizontal',
+      first: { type: 'leaf', groupId: 'a' },
+      second: { type: 'leaf', groupId: 'b' }
+    }
+    expect(countLayoutLeaves(layout)).toBe(2)
+  })
+
+  it('counts leaves in a nested split tree', () => {
+    const layout: TabGroupLayoutNode = {
+      type: 'split',
+      direction: 'horizontal',
+      first: { type: 'leaf', groupId: 'a' },
+      second: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', groupId: 'b' },
+        second: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', groupId: 'c' },
+          second: { type: 'leaf', groupId: 'd' }
+        }
+      }
+    }
+    expect(countLayoutLeaves(layout)).toBe(4)
+  })
+})

--- a/src/renderer/src/components/tab-group/tab-group-layout-leaf-count.ts
+++ b/src/renderer/src/components/tab-group/tab-group-layout-leaf-count.ts
@@ -1,0 +1,9 @@
+import type { TabGroupLayoutNode } from '../../../../shared/types'
+
+/** Total number of group leaves in a tab-group split tree (leaf → 1, split → sum of children). */
+export function countLayoutLeaves(node: TabGroupLayoutNode): number {
+  if (node.type === 'leaf') {
+    return 1
+  }
+  return countLayoutLeaves(node.first) + countLayoutLeaves(node.second)
+}

--- a/src/renderer/src/components/tab-group/use-refit-on-split-collapse.test.tsx
+++ b/src/renderer/src/components/tab-group/use-refit-on-split-collapse.test.tsx
@@ -7,6 +7,8 @@ import type { TabGroupLayoutNode } from '../../../../shared/types'
 import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import { useRefitOnSplitCollapse } from './use-refit-on-split-collapse'
 
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
 const LEAF: TabGroupLayoutNode = { type: 'leaf', groupId: 'a' }
 const SPLIT_2: TabGroupLayoutNode = {
   type: 'split',
@@ -42,21 +44,7 @@ describe('useRefitOnSplitCollapse', () => {
   let root: Root
   let dispatched: number
   let onSyncFit: () => void
-  // Two-deep rAF callback queue so the double-rAF resolves deterministically.
-  let rafCallbacks: FrameRequestCallback[]
-
-  const flushRaf = (): void => {
-    // Drain in waves so a callback scheduled by another callback runs next tick.
-    let guard = 0
-    while (rafCallbacks.length > 0 && guard < 10) {
-      const batch = rafCallbacks
-      rafCallbacks = []
-      for (const cb of batch) {
-        cb(performance.now())
-      }
-      guard += 1
-    }
-  }
+  let requestAnimationFrameMock: ReturnType<typeof vi.fn>
 
   const renderLayout = (layout: TabGroupLayoutNode, isWorktreeActive = true): void => {
     act(() => {
@@ -69,16 +57,12 @@ describe('useRefitOnSplitCollapse', () => {
     document.body.appendChild(container)
     root = createRoot(container)
     dispatched = 0
-    rafCallbacks = []
     onSyncFit = (): void => {
       dispatched += 1
     }
     window.addEventListener(SYNC_FIT_PANES_EVENT, onSyncFit)
-    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
-      rafCallbacks.push(cb)
-      return rafCallbacks.length
-    })
-    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    requestAnimationFrameMock = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock)
   })
 
   afterEach(() => {
@@ -96,35 +80,31 @@ describe('useRefitOnSplitCollapse', () => {
     expect(dispatched).toBe(0)
 
     renderLayout(LEAF)
-    flushRaf()
     expect(dispatched).toBe(1)
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled()
   })
 
   it('dispatches when a nested split loses one leaf', () => {
     renderLayout(SPLIT_3)
     renderLayout(SPLIT_2)
-    flushRaf()
     expect(dispatched).toBe(1)
   })
 
   it('does not dispatch when the leaf count increases (a split is created)', () => {
     renderLayout(LEAF)
     renderLayout(SPLIT_2)
-    flushRaf()
     expect(dispatched).toBe(0)
   })
 
   it('does not dispatch when the leaf count is unchanged (e.g. ratio drag)', () => {
     renderLayout(SPLIT_2)
     renderLayout({ ...SPLIT_2, ratio: 0.3 })
-    flushRaf()
     expect(dispatched).toBe(0)
   })
 
   it('does not dispatch when the worktree is not active', () => {
     renderLayout(SPLIT_2, false)
     renderLayout(LEAF, false)
-    flushRaf()
     expect(dispatched).toBe(0)
   })
 })

--- a/src/renderer/src/components/tab-group/use-refit-on-split-collapse.test.tsx
+++ b/src/renderer/src/components/tab-group/use-refit-on-split-collapse.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TabGroupLayoutNode } from '../../../../shared/types'
+import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
+import { useRefitOnSplitCollapse } from './use-refit-on-split-collapse'
+
+const LEAF: TabGroupLayoutNode = { type: 'leaf', groupId: 'a' }
+const SPLIT_2: TabGroupLayoutNode = {
+  type: 'split',
+  direction: 'horizontal',
+  first: { type: 'leaf', groupId: 'a' },
+  second: { type: 'leaf', groupId: 'b' }
+}
+const SPLIT_3: TabGroupLayoutNode = {
+  type: 'split',
+  direction: 'horizontal',
+  first: { type: 'leaf', groupId: 'a' },
+  second: {
+    type: 'split',
+    direction: 'vertical',
+    first: { type: 'leaf', groupId: 'b' },
+    second: { type: 'leaf', groupId: 'c' }
+  }
+}
+
+function Probe({
+  layout,
+  isWorktreeActive
+}: {
+  layout: TabGroupLayoutNode
+  isWorktreeActive: boolean
+}): null {
+  useRefitOnSplitCollapse(layout, isWorktreeActive)
+  return null
+}
+
+describe('useRefitOnSplitCollapse', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let dispatched: number
+  let onSyncFit: () => void
+  // Two-deep rAF callback queue so the double-rAF resolves deterministically.
+  let rafCallbacks: FrameRequestCallback[]
+
+  const flushRaf = (): void => {
+    // Drain in waves so a callback scheduled by another callback runs next tick.
+    let guard = 0
+    while (rafCallbacks.length > 0 && guard < 10) {
+      const batch = rafCallbacks
+      rafCallbacks = []
+      for (const cb of batch) {
+        cb(performance.now())
+      }
+      guard += 1
+    }
+  }
+
+  const renderLayout = (layout: TabGroupLayoutNode, isWorktreeActive = true): void => {
+    act(() => {
+      root.render(<Probe layout={layout} isWorktreeActive={isWorktreeActive} />)
+    })
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    dispatched = 0
+    rafCallbacks = []
+    onSyncFit = (): void => {
+      dispatched += 1
+    }
+    window.addEventListener(SYNC_FIT_PANES_EVENT, onSyncFit)
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    window.removeEventListener(SYNC_FIT_PANES_EVENT, onSyncFit)
+    container.remove()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('dispatches SYNC_FIT_PANES_EVENT when a split collapses to fewer leaves', () => {
+    renderLayout(SPLIT_2)
+    expect(dispatched).toBe(0)
+
+    renderLayout(LEAF)
+    flushRaf()
+    expect(dispatched).toBe(1)
+  })
+
+  it('dispatches when a nested split loses one leaf', () => {
+    renderLayout(SPLIT_3)
+    renderLayout(SPLIT_2)
+    flushRaf()
+    expect(dispatched).toBe(1)
+  })
+
+  it('does not dispatch when the leaf count increases (a split is created)', () => {
+    renderLayout(LEAF)
+    renderLayout(SPLIT_2)
+    flushRaf()
+    expect(dispatched).toBe(0)
+  })
+
+  it('does not dispatch when the leaf count is unchanged (e.g. ratio drag)', () => {
+    renderLayout(SPLIT_2)
+    renderLayout({ ...SPLIT_2, ratio: 0.3 })
+    flushRaf()
+    expect(dispatched).toBe(0)
+  })
+
+  it('does not dispatch when the worktree is not active', () => {
+    renderLayout(SPLIT_2, false)
+    renderLayout(LEAF, false)
+    flushRaf()
+    expect(dispatched).toBe(0)
+  })
+})

--- a/src/renderer/src/components/tab-group/use-refit-on-split-collapse.ts
+++ b/src/renderer/src/components/tab-group/use-refit-on-split-collapse.ts
@@ -1,47 +1,23 @@
-import { useEffect, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import type { TabGroupLayoutNode } from '../../../../shared/types'
 import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import { countLayoutLeaves } from './tab-group-layout-leaf-count'
 
-/**
- * Forces a synchronous fit of all visible terminal panes when a tab-group split
- * collapses (the layout tree loses a leaf), so the surviving group's xterm grid
- * reflows to the new, wider container.
- *
- * Why: a collapsing split widens the surviving group via flexbox alone. The
- * within-tab pane close has a deterministic rAF refit (onLayoutChanged →
- * queueResizeAll → fitPanes); the group path otherwise relies only on a
- * 150ms-debounced ResizeObserver that can miss the flex-only resize, leaving an
- * idle agent's xterm pinned at the old narrow width with a blank survivor half
- * (#6154). Double-rAF: the first frame commits React/flex styles, the second
- * runs after layout reflow so proposeDimensions reads the new width. Only fires
- * on a leaf-count *decrease* so splits/ratio drags (which have their own fit
- * paths) don't trigger it, and only while the worktree is visible (the
- * SYNC_FIT_PANES_EVENT listener and safeFit skip unmeasurable hidden panes).
- */
 export function useRefitOnSplitCollapse(
   layout: TabGroupLayoutNode,
   isWorktreeActive: boolean
 ): void {
   const prevLeafCountRef = useRef(countLayoutLeaves(layout))
-  useEffect(() => {
+  useLayoutEffect(() => {
     const leafCount = countLayoutLeaves(layout)
     const collapsed = leafCount < prevLeafCountRef.current
     prevLeafCountRef.current = leafCount
     if (!isWorktreeActive || !collapsed) {
       return
     }
-    const handles = { raf1: 0, raf2: 0 }
-    handles.raf1 = requestAnimationFrame(() => {
-      handles.raf2 = requestAnimationFrame(() => {
-        window.dispatchEvent(new Event(SYNC_FIT_PANES_EVENT))
-      })
-    })
-    return () => {
-      cancelAnimationFrame(handles.raf1)
-      if (handles.raf2) {
-        cancelAnimationFrame(handles.raf2)
-      }
-    }
+    // Why: a split collapse changes width via React/flex layout, not the
+    // terminal's pane tree; fitting in layout effect keeps the survivor in sync
+    // before the old narrow grid can paint.
+    window.dispatchEvent(new Event(SYNC_FIT_PANES_EVENT))
   }, [layout, isWorktreeActive])
 }

--- a/src/renderer/src/components/tab-group/use-refit-on-split-collapse.ts
+++ b/src/renderer/src/components/tab-group/use-refit-on-split-collapse.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react'
+import type { TabGroupLayoutNode } from '../../../../shared/types'
+import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
+import { countLayoutLeaves } from './tab-group-layout-leaf-count'
+
+/**
+ * Forces a synchronous fit of all visible terminal panes when a tab-group split
+ * collapses (the layout tree loses a leaf), so the surviving group's xterm grid
+ * reflows to the new, wider container.
+ *
+ * Why: a collapsing split widens the surviving group via flexbox alone. The
+ * within-tab pane close has a deterministic rAF refit (onLayoutChanged →
+ * queueResizeAll → fitPanes); the group path otherwise relies only on a
+ * 150ms-debounced ResizeObserver that can miss the flex-only resize, leaving an
+ * idle agent's xterm pinned at the old narrow width with a blank survivor half
+ * (#6154). Double-rAF: the first frame commits React/flex styles, the second
+ * runs after layout reflow so proposeDimensions reads the new width. Only fires
+ * on a leaf-count *decrease* so splits/ratio drags (which have their own fit
+ * paths) don't trigger it, and only while the worktree is visible (the
+ * SYNC_FIT_PANES_EVENT listener and safeFit skip unmeasurable hidden panes).
+ */
+export function useRefitOnSplitCollapse(
+  layout: TabGroupLayoutNode,
+  isWorktreeActive: boolean
+): void {
+  const prevLeafCountRef = useRef(countLayoutLeaves(layout))
+  useEffect(() => {
+    const leafCount = countLayoutLeaves(layout)
+    const collapsed = leafCount < prevLeafCountRef.current
+    prevLeafCountRef.current = leafCount
+    if (!isWorktreeActive || !collapsed) {
+      return
+    }
+    const handles = { raf1: 0, raf2: 0 }
+    handles.raf1 = requestAnimationFrame(() => {
+      handles.raf2 = requestAnimationFrame(() => {
+        window.dispatchEvent(new Event(SYNC_FIT_PANES_EVENT))
+      })
+    })
+    return () => {
+      cancelAnimationFrame(handles.raf1)
+      if (handles.raf2) {
+        cancelAnimationFrame(handles.raf2)
+      }
+    }
+  }, [layout, isWorktreeActive])
+}


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** If you put two agents side by side in one window (a left/right split) and then close the one on the right, the agent that's left behind is supposed to grow and fill the whole width. Instead, its text stays squished into the old narrow left column and the right half goes permanently blank — you're left staring at a half-empty pane with no obvious way to fix it short of resizing the window or clicking around to force a redraw. It hits anyone who uses side-by-side splits and closes one side while the surviving agent is sitting idle (a finished Codex/Claude run whose output just sits there without redrawing itself). It's not a crash and your work isn't lost, but it's an ugly, sticky annoyance that wastes half your screen — exactly the screenshot the reporter attached.

**2) What this PR does (ELI5).** Think of each agent's terminal as a grid of character cells that only knows how many columns wide it is when something tells it to re-measure. When you close one side of a split, the surviving pane gets wider on screen, but the terminal keeps drawing in its old narrow shape until a re-measure lands. This PR adds a deterministic nudge: the moment the layout goes from two panes to one, it fires the existing "re-measure all panes" signal immediately after React commits the wider layout, before the old narrow grid can paint. The surviving agent fills the full width on the very frame the split disappears.

**3) Tradeoffs / regressions — honest answer.** No regressions — nothing is disabled, no setting changes, no behavior is lost, and no new dependencies are added. The fix is purely additive: it sends one extra "re-measure" signal, and only in the exact situation that was broken. It deliberately does nothing when you *create* a split or drag the divider (those keep their existing fit paths), and hidden/background worktrees keep the existing visibility-resume fit path instead of accepting hidden DOM geometry, preserving the rule that hidden layout is not authoritative. The only "cost" is a single extra layout pass when you close a split — a rare, user-initiated action — so there's no impact on typing, scrolling, or steady-state performance. The event is renderer-side and behaves identically on macOS, Linux, and Windows and over SSH, and touches no source-control or provider-specific code. One scope note: the "before paint" guarantee applies to surfaces using CSS anchor positioning (Electron desktop). The paired-web client intentionally uses measured-fallback overlay rects, where this dispatch is a harmless no-op and the existing post-paint convergence path continues to own the refit — unchanged behavior there.

---

## Summary

Fixes #6154

When two agents sit side by side in a left/right tab-group split and the right group is closed, the surviving (left) group widens to fill the column via flexbox alone; nothing *deterministically* tells the survivor's xterm to re-measure, so when the incidental fit chain misses, an idle agent (finished Codex/Claude run, static scrollback that never self-repaints) stays pinned at the old narrow column count and the widened pane's right half is left permanently blank — exactly the screenshot in the issue.

This adds `useRefitOnSplitCollapse`: it tracks the tab-group layout tree's leaf count and, when the count *decreases* (a split collapsed) on the visible worktree, dispatches the existing `SYNC_FIT_PANES_EVENT` from a React layout effect after the collapsed flex layout commits. Every visible terminal pane refits before paint — the same pre-paint pattern the sidebar toggle already uses. It fires only on a leaf-count decrease, so split *creation* and ratio drags (which have their own fit paths) don't trigger spurious fits, and only while the worktree is active; hidden panes stay on the existing visibility-resume fit path because hidden DOM geometry is intentionally non-authoritative.

### Root cause, measured honestly

An earlier revision of this description blamed the 150ms-debounced `ResizeObserver` in `use-terminal-container-fit-sync.ts` for "missing a pure flex-ratio width change". Direct measurement disproved that: a standalone Electron 42 (Chromium) harness reproducing the exact DOM mechanics — an `anchor-name` group body inside a flex split, a sibling overlay positioned via `anchor-size()`, then a collapse that removes the split subtree and inserts a *new* body with the same anchor name (React remounts the surviving `TabGroupPanel` on collapse because the root slot's element type changes) — shows the container ResizeObserver fires reliably for both pure flex-ratio resizes and collapse-with-anchor-recreation, and that a same-task forced-layout read after the remount already returns the new width.

Consistent with that, the E2E below could **not** reproduce the permanent field symptom on current `main`: with this PR's dispatch deliberately disabled, the survivor still healed to full width within the first collapsed frame through existing incidental fit paths. The field failure was therefore timing/environment-dependent fragility in a chain of observers, debounce timers, and rAF-queued fits — sometimes every link misses and the idle survivor stays pinned narrow (the reporter's screenshot). This PR doesn't bet on that chain: it dispatches the existing `SYNC_FIT_PANES_EVENT` at the exact commit that collapses the layout, making the refit deterministic for every collapse variant (close, PTY exit, reconciliation) regardless of focus movement or timer luck, and the harness confirms the new width is synchronously measurable at that moment.

This PR supersedes and takes over community PR #6510 by @brennanb2025; the original author is credited via a `Co-authored-by` trailer. PR #6510 is left open for the maintainers to close.

## Evidence

Live capture was not feasible in the original validation environment (broken shared terminal daemon), so the claim is pinned by an end-to-end regression test that launches the real app: `tests/e2e/tab-group-split-collapse-refit.spec.ts` creates a right-hand tab-group split, re-focuses the surviving group (field-faithful: the user's idle agent survives while the *other* group is closed, so the close cannot piggyback on the activation-change fit path), closes the right group, and asserts — inside a single renderer task, so no test round-trip can straddle a debounce window — that (1) the collapse commit dispatched `SYNC_FIT_PANES_EVENT`, (2) the survivor's xterm is already at full-width columns on the first frame that renders the collapsed layout, and (3) the user-visible check: the rendered `.xterm-screen` spans the surviving group body instead of leaving the right half blank.

The spec was validated as a real gate by falsification: with the hook's dispatch commented out and the app rebuilt, the run fails on the event assertion (`{"colsAtCollapseFrame":135,"fitEvents":0,"elapsedMs":16.1,"frames":1}`); with the fix restored it passes. The event assertion is the discriminator — it fails if this fix regresses to timer-based refitting — while the column and screen-span assertions guard the user-visible invariant against any future break in the wider fit chain.

## Testing

- [x] `pnpm lint` (`oxlint` on changed files — clean)
- [x] `pnpm typecheck` (`tsgo --noEmit -p config/tsconfig.tc.web.json` — clean)
- [x] `pnpm test` (the 3 affected unit-test files — 14/14 passing)
- [x] App build: `electron-vite build --mode e2e` (as part of the E2E runs — clean)
- [x] E2E: `tests/e2e/tab-group-split-collapse-refit.spec.ts` (electron-headless — passing; fails when the fix is disabled)
- [x] Added or updated high-quality tests that would catch regressions

New tests:
- `tab-group-split-collapse-refit.spec.ts` (E2E): real-Electron collapse → pre-debounce full-width refit + `SYNC_FIT_PANES_EVENT` dispatch + user-visible `.xterm-screen` span assertion (see Evidence).
- `use-refit-on-split-collapse.test.tsx` (5 cases): dispatches on collapse-to-fewer-leaves before any `requestAnimationFrame`; dispatches on nested-split losing a leaf; no dispatch on split creation (leaf-count increase); no dispatch on ratio drag (leaf-count unchanged); no dispatch when worktree inactive.
- `tab-group-layout-leaf-count.test.ts` (3 cases): single leaf, two-leaf split, nested tree.
- `TabGroupSplitLayout.test.ts`: stubs the new side-effect-only hook for the element-tree inspection cases and asserts the component wires the current layout and worktree visibility into it.

## AI Review Report

Reviewed the adopted code adversarially (assuming the original author could be malicious, per take-over protocol):
- Correctness: `prevLeafCountRef` is seeded to the mount-time leaf count, so the first layout-effect run sees no collapse (no spurious mount fit). The effect re-runs on `layout` identity change (the store emits a new object on any mutation), recomputes the cheap recursive leaf count, and dispatches immediately only on a visible leaf-count decrease.
- Edge cases: ratio drag → new `layout` object, same leaf count → no dispatch (tested); split creation → leaf-count increase → no dispatch (tested); inactive worktree → no dispatch (tested); collapse while a worktree is hidden defers to the existing visibility-resume refit in `TerminalPaneOverlayLayer`.
- Cross-platform (macOS / Linux / Windows): the change is pure renderer-side React/DOM — no `metaKey`/`ctrlKey` shortcut handling, no path separators, no shell or Electron-main platform branches. It dispatches the same in-renderer `SYNC_FIT_PANES_EVENT` the sidebar toggle already uses, handled identically across platforms.
- SSH / remote: terminal fit is renderer-side; the event path is the same for remote runtimes, so the reflow works identically over SSH.
- Provider compatibility: no source-control or provider-specific surface touched.

## Security Audit

- No input handling, command execution, path traversal, secret access, `eval`, or IPC surface introduced.
- `tab-group-layout-leaf-count.ts` is a pure recursive counter over a typed in-memory tree.
- `use-refit-on-split-collapse.ts` only dispatches an existing same-process `window` `Event` from a React layout effect.
- No new dependencies. Adopted community code re-reviewed line by line; nothing suspicious.

## Notes

- Out-of-scope follow-up (not in this diff): the within-tab pane-close refit and this tab-group collapse refit are two parallel deterministic-refit mechanisms; a future cleanup could unify them behind a single layout-change observer, but that is a larger refactor outside this fix's scope.
