### PR TITLE
fix(file-explorer): search folder workspace roots

### DIFF
--- a/src/renderer/src/components/quick-open-file-list.react.test.tsx
+++ b/src/renderer/src/components/quick-open-file-list.react.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FolderWorkspace, ProjectGroup } from '../../../shared/types'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import { useRuntimeFileListForWorktree, type RuntimeFileListState } from './quick-open-file-list'
+
+const listRuntimeFilesMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  listRuntimeFiles: listRuntimeFilesMock
+}))
+
+const initialAppState = useAppStore.getInitialState()
+const roots: Root[] = []
+
+function makeProjectGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'Platform',
+    parentPath: '/srv/platform',
+    connectionId: null,
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'folder-workspace-1',
+    projectGroupId: 'group-1',
+    name: 'Platform workspace',
+    folderPath: '/srv/platform',
+    connectionId: null,
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function HookProbe({
+  enabled,
+  onState,
+  worktreeId
+}: {
+  enabled: boolean
+  onState: (state: RuntimeFileListState) => void
+  worktreeId: string | null
+}): null {
+  onState(useRuntimeFileListForWorktree({ enabled, worktreeId }))
+  return null
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function waitForListRuntimeFilesCall(): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await flushEffects()
+    if (listRuntimeFilesMock.mock.calls.length > 0) {
+      return
+    }
+  }
+  throw new Error('listRuntimeFiles was not called')
+}
+
+async function renderProbe(args: {
+  enabled: boolean
+  onState: (state: RuntimeFileListState) => void
+  worktreeId: string | null
+}): Promise<Root> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(createElement(HookProbe, args))
+  })
+  await flushEffects()
+  return root
+}
+
+beforeEach(() => {
+  useAppStore.setState(initialAppState, true)
+  listRuntimeFilesMock.mockReset().mockResolvedValue(['packages/app/package.json'])
+})
+
+afterEach(async () => {
+  for (const root of roots) {
+    await act(async () => {
+      root.unmount()
+    })
+  }
+  roots.length = 0
+  useAppStore.setState(initialAppState, true)
+})
+
+describe('useRuntimeFileListForWorktree', () => {
+  it('lists a repo-less SSH folder workspace after folder metadata hydrates', async () => {
+    const states: RuntimeFileListState[] = []
+    const workspaceKey = folderWorkspaceKey('folder-workspace-1')
+
+    useAppStore.setState({
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [],
+      worktreesByRepo: {}
+    } as Partial<AppState>)
+
+    await renderProbe({
+      enabled: true,
+      onState: (state) => states.push(state),
+      worktreeId: workspaceKey
+    })
+
+    expect(listRuntimeFilesMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      useAppStore.setState({
+        folderWorkspaces: [makeFolderWorkspace({ connectionId: 'ssh-1' })],
+        projectGroups: [makeProjectGroup({ connectionId: 'ssh-1' })],
+        repos: [],
+        worktreesByRepo: {}
+      } as Partial<AppState>)
+    })
+    await waitForListRuntimeFilesCall()
+
+    expect(listRuntimeFilesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: workspaceKey,
+        worktreePath: '/srv/platform',
+        connectionId: 'ssh-1',
+        settings: expect.objectContaining({ activeRuntimeEnvironmentId: null })
+      }),
+      {
+        rootPath: '/srv/platform',
+        excludePaths: undefined
+      }
+    )
+    expect(states.at(-1)?.files).toEqual(['packages/app/package.json'])
+  })
+})

--- a/src/renderer/src/components/quick-open-file-list.test.ts
+++ b/src/renderer/src/components/quick-open-file-list.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { Worktree } from '../../../shared/types'
 import { buildExcludePathPrefixes } from '../../../shared/quick-open-filter'
 import {
+  getRuntimeFileListTarget,
   getNestedWorktreeExcludePaths,
   getNestedWorktreeExcludeRequest,
   isNestedWorktreePath
@@ -56,5 +57,16 @@ describe('quick-open nested worktree excludes', () => {
     expect(request.paths).toEqual(['/tmp/repo/linked\nworktree'])
     expect(request.key).toBe('["/tmp/repo/linked\\nworktree"]')
     expect(buildExcludePathPrefixes('/tmp/repo', request.paths)).toEqual(['linked\nworktree'])
+  })
+
+  it('can list files for folder workspaces resolved outside registered repo worktrees', () => {
+    const folderWorkspace = makeWorktree('folder:workspace-1', '/Users/jenkei/test')
+    const target = getRuntimeFileListTarget(folderWorkspace.id, folderWorkspace.path, [])
+
+    expect(target).toEqual({
+      canList: true,
+      excludeRequest: { paths: [], key: '[]' },
+      worktreePath: '/Users/jenkei/test'
+    })
   })
 })

--- a/src/renderer/src/components/quick-open-file-list.ts
+++ b/src/renderer/src/components/quick-open-file-list.ts
@@ -2,11 +2,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Worktree } from '../../../shared/types'
 import { isWindowsAbsolutePathLike } from '../../../shared/cross-platform-path'
-import { getConnectionId } from '@/lib/connection-context'
+import { getConnectionIdFromState } from '@/lib/connection-context'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
 import { listRuntimeFiles } from '@/runtime/runtime-file-client'
 import { useAppStore } from '@/store'
-import { useWorktreeById, useWorktreesForRepo } from '@/store/selectors'
+import { useWorktreesForRepo } from '@/store/selectors'
 
 export type RuntimeFileListState = {
   files: string[]
@@ -49,6 +49,32 @@ export type NestedWorktreeExcludeRequest = {
   key: string
 }
 
+export type RuntimeFileListTarget = {
+  canList: boolean
+  excludeRequest: NestedWorktreeExcludeRequest
+  worktreePath: string | null
+}
+
+export function getRuntimeFileListTarget(
+  worktreeId: string | null,
+  worktreePath: string | null | undefined,
+  repoWorktrees: readonly Worktree[]
+): RuntimeFileListTarget {
+  const resolvedWorktreePath = worktreePath ?? null
+  if (!worktreeId || !resolvedWorktreePath) {
+    return { canList: false, excludeRequest: { paths: [], key: '[]' }, worktreePath: null }
+  }
+  return {
+    canList: true,
+    excludeRequest: getNestedWorktreeExcludeRequest(
+      worktreeId,
+      resolvedWorktreePath,
+      repoWorktrees
+    ),
+    worktreePath: resolvedWorktreePath
+  }
+}
+
 export function getNestedWorktreeExcludeRequest(
   worktreeId: string | null,
   worktreePath: string | null,
@@ -70,20 +96,26 @@ export function useRuntimeFileListForWorktree({
   enabled: boolean
   worktreeId: string | null
 }): RuntimeFileListState {
-  const worktree = useWorktreeById(worktreeId)
+  const worktree = useAppStore((state) =>
+    // Why: folder workspaces live behind getKnownWorktreeById, not worktreesByRepo.
+    worktreeId ? (state.getKnownWorktreeById(worktreeId) ?? null) : null
+  )
+  const worktreePath = worktree?.path ?? null
   const repoWorktrees = useWorktreesForRepo(worktree?.repoId ?? null)
   const [files, setFiles] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
   const lastRequestKeyRef = useRef('')
 
-  const worktreePath = worktree?.path ?? null
-  const excludeRequest = useMemo(
-    () => getNestedWorktreeExcludeRequest(worktreeId, worktreePath, repoWorktrees),
+  const target = useMemo(
+    () => getRuntimeFileListTarget(worktreeId, worktreePath, repoWorktrees),
     [repoWorktrees, worktreeId, worktreePath]
   )
+  const { excludeRequest } = target
 
-  const connectionId = useMemo(() => getConnectionId(worktreeId) ?? undefined, [worktreeId])
+  const connectionId = useAppStore(
+    (state) => getConnectionIdFromState(state, worktreeId) ?? undefined
+  )
   const activeTargetStatus = useAppStore((state) =>
     connectionId ? state.sshConnectionStates.get(connectionId)?.status : undefined
   )
@@ -103,7 +135,7 @@ export function useRuntimeFileListForWorktree({
       return
     }
 
-    if (!worktreeId || !worktreePath) {
+    if (!target.canList || !worktreeId || !worktreePath) {
       setFiles([])
       setLoadError(null)
       setLoading(false)
@@ -155,7 +187,7 @@ export function useRuntimeFileListForWorktree({
     return () => {
       cancelled = true
     }
-  }, [connectionId, enabled, excludeRequest, requestKey, worktreeId, worktreePath])
+  }, [connectionId, enabled, excludeRequest, requestKey, target.canList, worktreeId, worktreePath])
 
   return { files, loading: loading || connectionPending, loadError }
 }

--- a/src/renderer/src/lib/connection-context.test.ts
+++ b/src/renderer/src/lib/connection-context.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, describe, expect, it } from 'vitest'
-import type { Repo } from '../../../shared/types'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { FolderWorkspace, ProjectGroup, Repo } from '../../../shared/types'
 import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
 import {
   getConnectionId,
   getConnectionIdForFile,
+  getConnectionIdFromState,
   isWorktreeConnectionResolved
 } from './connection-context'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
@@ -394,5 +396,90 @@ describe('getConnectionId', () => {
     expect(
       getConnectionIdForFile(workspaceKey, '/home/neil/platform/api/src/index.ts')
     ).toBeUndefined()
+  })
+})
+
+function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'folder-workspace-1',
+    projectGroupId: 'group-1',
+    name: 'Platform workspace',
+    folderPath: '/home/neil/platform',
+    connectionId: null,
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeProjectGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'Platform',
+    parentPath: '/home/neil/platform',
+    connectionId: null,
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+type ConnectionContextState = Pick<
+  AppState,
+  'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'
+>
+
+describe('getConnectionIdFromState', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('resolves a folder workspace connectionId from a passed-in state without reading the global store', () => {
+    // Why: the Quick Open hook subscribes to store slices and must resolve from
+    // the snapshot it receives, not by re-reading useAppStore.getState().
+    const getStateSpy = vi.spyOn(useAppStore, 'getState')
+    const state: ConnectionContextState = {
+      folderWorkspaces: [makeFolderWorkspace({ connectionId: 'ssh-1' })],
+      projectGroups: [makeProjectGroup({ connectionId: 'ssh-1' })],
+      repos: [],
+      worktreesByRepo: {}
+    }
+
+    expect(getConnectionIdFromState(state, folderWorkspaceKey('folder-workspace-1'))).toBe('ssh-1')
+    expect(getStateSpy).not.toHaveBeenCalled()
+  })
+
+  it('resolves SSH repo provenance for non-folder worktrees from the passed-in state', () => {
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [makeRepo({ id: 'repo-ssh', connectionId: 'ssh-2' })],
+      worktreesByRepo: {}
+    }
+
+    expect(getConnectionIdFromState(state, 'repo-ssh::/home/neil/repo-feature')).toBe('ssh-2')
+  })
+
+  it('returns null for a null worktreeId', () => {
+    const state: ConnectionContextState = {
+      folderWorkspaces: [],
+      projectGroups: [],
+      repos: [],
+      worktreesByRepo: {}
+    }
+
+    expect(getConnectionIdFromState(state, null)).toBeNull()
   })
 })

--- a/src/renderer/src/lib/connection-context.ts
+++ b/src/renderer/src/lib/connection-context.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import {
@@ -16,17 +17,20 @@ import {
  * cannot be found (e.g., store not yet hydrated).
  */
 export function getConnectionId(worktreeId: string | null): string | null | undefined {
+  return getConnectionIdFromState(useAppStore.getState(), worktreeId)
+}
+
+export function getConnectionIdFromState(
+  state: Pick<AppState, 'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'>,
+  worktreeId: string | null
+): string | null | undefined {
   if (!worktreeId) {
     return null
   }
   const parsedWorkspaceKey = parseWorkspaceKey(worktreeId)
   if (parsedWorkspaceKey?.type === 'folder') {
-    return getFolderWorkspaceConnectionId(
-      useAppStore.getState(),
-      parsedWorkspaceKey.folderWorkspaceId
-    )
+    return getFolderWorkspaceConnectionId(state, parsedWorkspaceKey.folderWorkspaceId)
   }
-  const state = useAppStore.getState()
   const allWorktrees = Object.values(state.worktreesByRepo ?? {}).flat()
   const worktree = allWorktrees.find((w) => w.id === worktreeId)
   // Why: SSH worktrees can be restored from session IDs before relay discovery


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** If you open Orca on the top folder of a "monorepo" (one big folder that holds several sub-projects), the file explorer's name search is completely broken. The full file tree shows up fine — but the moment you type anything into the search box (like `package`), the whole list goes blank and shows zero results. Clear the box and everything comes back. So the search isn't filtering, it's just wiping the screen. This hits anyone who opens a workspace at a monorepo root (a "folder" workspace), on any OS; for those people file search simply does not work — a real blocker, not a cosmetic annoyance. People who open one specific sub-folder instead of the whole monorepo were never affected.

**2) What this PR does (ELI5).** When you search, Orca first has to figure out "which folder am I searching in?" There were two address books for that: one for normal git checkouts, and a fuller one that also knows about plain folders opened as workspaces. The search was only consulting the git-only address book, so for a monorepo-root folder it found nothing, decided it had no place to look, and returned an empty list. This PR points the search at the fuller address book that also knows about folder workspaces. Oh, so now searching a monorepo root actually returns matching files instead of going blank. (As a bonus, it also fixes a related case where searching over a remote/SSH folder could stay empty until the app finished loading its data.)

**3) Tradeoffs / regressions — honest answer.** No regressions — nothing is disabled, no flag is turned off, no new setup, and no behavior is lost. The fix only adds a working lookup path for folder workspaces; the old shared connection-lookup helper that other features rely on (terminal, delete-workspace, tab creation, etc.) is kept untouched and behaves exactly as before. One small implementation detail: the search now "watches" the connection info live (a store subscription) instead of taking a one-time snapshot — this is precisely what fixes the remote/SSH stale case, and it's safe because the watched value is a stable primitive and the synthetic folder entry is cached and reused, so there are no extra re-renders or render loops. One honest scope note (not a regression): this PR fixes "search returns nothing." The issue's secondary wish — surfacing matches buried deep inside nested sub-project directories under the monorepo root — is handled separately in companion PR #6481, so very deeply nested matches remain out of scope here.

---

## Summary

Fixes #5939. The file-explorer name search returned **zero results** whenever the workspace root was a monorepo parent opened as a `FolderWorkspace` (folder-scan), even though the full tree still rendered.

Root cause: `useRuntimeFileListForWorktree` (`src/renderer/src/components/quick-open-file-list.ts`) resolved its worktree via `useWorktreeById`, which only reads `worktreesByRepo` (git worktrees). For a folder-workspace `activeWorktreeId`, that key is not in `worktreesByRepo`, so `worktree` was `null`, `worktreePath` became `null`, and the effect early-returned with `setFiles([])`. The tree still rendered because `useFileExplorerTree` gets `worktreePath` separately.

This change:
- Resolves the Quick Open file-list target through `getKnownWorktreeById`, which resolves folder workspaces to a synthetic `Worktree` whose `path = folderPath` (`folderWorkspaceToWorktree`), restoring a non-null `worktreePath`.
- Extracts a pure `getRuntimeFileListTarget` helper for the path/exclude resolution so it is directly unit-testable.
- Makes `connectionId` a reactive store selector via the newly exported `getConnectionIdFromState`, so SSH folder roots are not left stale after store hydration. The existing `getConnectionId` wrapper is preserved for all other callers (Terminal, DeleteWorktreeDialog, tab-create, pty transport, etc.).

This supersedes community PR #6170 (the code becomes ours; original author credited via `Co-authored-by`). It does not close #6170.

## Screenshots

No visual change to chrome/layout. This is a data-loading regression: with the fix, typing a substring in the file-explorer name search now returns matching files for a folder-workspace root instead of an empty list. End-to-end Electron repro was attempted over CDP but the CDP session repeatedly dropped mid-interaction in this environment and `window.__store` was not exposed in the dev build, so visual capture was infeasible; the regression is instead proven deterministically by a hook-level test (see PR comment for evidence).

## Testing

- [x] `pnpm lint` (scoped: `oxlint` on the 5 touched files — clean)
- [x] `pnpm typecheck` (`tsgo -p config/tsconfig.tc.web.json` and `config/tsconfig.node.json` — clean)
- [x] `pnpm test` (focused: see below)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused tests run:
- `vitest run src/renderer/src/components/quick-open-file-list.test.ts src/renderer/src/components/quick-open-file-list.react.test.tsx src/renderer/src/lib/connection-context.test.ts` — 17 passed
- `vitest run src/renderer/src/lib/worktree-runtime-owner.test.ts src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts` — 25 passed
- `vitest run --environment happy-dom src/renderer/src/components/right-sidebar/FileExplorer.test.tsx` — 31 passed

The new `quick-open-file-list.react.test.tsx` renders the real hook against the real zustand store for a repo-less folder workspace and asserts `listRuntimeFiles` is invoked with the folder's `worktreePath`. Reverting the fix (resolving via `worktreesByRepo` only) makes it fail with `listRuntimeFiles was not called` — i.e. it reproduces the bug.

## AI Review Report

Reviewed for correctness, edge cases, cross-platform behavior, and store-reactivity:
- **Re-render safety**: `getConnectionIdFromState` returns a primitive (no new-object churn); `getKnownWorktreeById` returns cached synthetic worktrees (WeakMap-keyed) and stored worktree objects, so the new `useAppStore` selectors are reference-stable and do not loop.
- **Caller regression**: all `getConnectionId` callers go through the preserved wrapper (`getConnectionIdFromState(useAppStore.getState(), id)`); behavior is unchanged.
- **Cross-platform**: no `metaKey` / path-separator assumptions introduced; path containment continues to flow through the existing Windows-aware `isNestedWorktreePath`. macOS/Linux/Windows behavior is identical here.
- **SSH/remote**: `connectionId` reactivity fixes the stale-after-hydration case for SSH folder roots, which is the SSH-relevant path.
- The `Pick<AppState, 'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'>` param to `getConnectionIdFromState` typechecks against the store slices.

## Security Audit

Since this supersedes a community PR, I re-audited the adopted changes assuming the original author was untrusted:
- No new network calls, `eval`, dynamic `import`, secret access, or process spawning.
- No path traversal: the change only selects an already-resolved workspace root path and passes it through the existing `listRuntimeFiles` IPC; no new path is constructed or de-referenced.
- No auth, permissions, payments, uploads, or dependency changes.
- IPC surface is unchanged — same `listRuntimeFiles({ settings, worktreeId, worktreePath, connectionId }, { rootPath, excludePaths })` call shape.

## Notes

- The reported bug ("search returns zero results") is fixed by this PR. The issue's secondary ask — surfacing matches that live deeper inside nested sub-project directories under the monorepo root — is tracked by companion PR #6481 (deeper nested-repo traversal) and is independent of this fix.
- Future suggestion: the react test uses a manual `createRoot`/`act`/`flushEffects` harness; a lighter `@testing-library/react` `renderHook` could simplify it if/when that dependency is standard in the renderer test suite. Left as-is to keep the diff minimal and consistent with the adopted PR.

Made with [Orca](https://github.com/stablyai/orca) 🐋