### PR TITLE
fix(runtime): resolve folder workspace file selectors (#6357)

### DIFF
--- a/src/main/runtime/orca-runtime-files-watch.test.ts
+++ b/src/main/runtime/orca-runtime-files-watch.test.ts
@@ -52,6 +52,13 @@ function createRuntimeFileCommands(rootPath: string) {
       repoId: 'repo-1',
       path: rootPath
     })),
+    resolveRuntimeFileTarget: vi.fn(async () => ({
+      worktree: {
+        id: 'wt-1',
+        repoId: 'repo-1',
+        path: rootPath
+      }
+    })),
     resolveRuntimeGitTarget: vi.fn(),
     openFile: vi.fn()
   } as never)

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -126,20 +126,28 @@ function createRuntimeFileCommands(options?: {
   path?: string
   openFile?: ReturnType<typeof vi.fn>
   openDiff?: ReturnType<typeof vi.fn>
+  resolveRuntimeFileTarget?: ReturnType<typeof vi.fn>
   resolveRuntimeGitTarget?: ReturnType<typeof vi.fn>
 }) {
   const store = {
     getRepo: vi.fn((_repoId?: string) => undefined as { connectionId?: string } | undefined)
   }
   const path = options?.path ?? '/repo'
+  const worktree = {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path
+  }
   const commands = new RuntimeFileCommands({
     getRuntimeId: () => 'runtime-1',
     requireStore: () => store,
-    resolveWorktreeSelector: vi.fn(async () => ({
-      id: 'wt-1',
-      repoId: 'repo-1',
-      path
-    })),
+    resolveWorktreeSelector: vi.fn(async () => worktree),
+    resolveRuntimeFileTarget:
+      options?.resolveRuntimeFileTarget ??
+      vi.fn(async () => ({
+        worktree,
+        connectionId: store.getRepo(worktree.repoId)?.connectionId
+      })),
     resolveRuntimeGitTarget: options?.resolveRuntimeGitTarget ?? vi.fn(),
     openFile: options?.openFile ?? vi.fn(),
     ...(options?.openDiff ? { openDiff: options.openDiff } : {})
@@ -427,7 +435,7 @@ describe('RuntimeFileCommands', () => {
   })
 
   it('settles and detaches runtime rg searches when timeout kill is ignored', async () => {
-    const resolveRuntimeGitTarget = vi.fn(async () => ({
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
       worktree: {
         id: 'wt-1',
         repoId: 'repo-1',
@@ -435,7 +443,7 @@ describe('RuntimeFileCommands', () => {
       },
       connectionId: null
     }))
-    const { commands } = createRuntimeFileCommands({ resolveRuntimeGitTarget })
+    const { commands } = createRuntimeFileCommands({ resolveRuntimeFileTarget })
     const child = createRuntimeSearchChild()
     resolveAuthorizedPathMock.mockResolvedValue('/repo')
     checkRgAvailableMock.mockResolvedValue(true)
@@ -460,7 +468,7 @@ describe('RuntimeFileCommands', () => {
   })
 
   it('routes runtime rg searches through the registered WSL project runtime', async () => {
-    const resolveRuntimeGitTarget = vi.fn(async () => ({
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
       worktree: {
         id: 'wt-1',
         repoId: 'repo-1',
@@ -468,7 +476,7 @@ describe('RuntimeFileCommands', () => {
       },
       connectionId: null
     }))
-    const { commands, store } = createRuntimeFileCommands({ resolveRuntimeGitTarget })
+    const { commands, store } = createRuntimeFileCommands({ resolveRuntimeFileTarget })
     const child = createRuntimeSearchChild()
     resolveAuthorizedPathMock.mockResolvedValue('C:\\repo')
     checkRgAvailableMock.mockResolvedValue(true)

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -143,11 +143,16 @@ export async function awaitRuntimeFileWatcherUnsubscribes(): Promise<void> {
 }
 
 export type ResolvedRuntimeFileWorktree = Worktree & { git: GitWorktreeInfo }
+export type ResolvedRuntimeFileTarget = {
+  worktree: ResolvedRuntimeFileWorktree
+  connectionId?: string
+}
 
 export type RuntimeFileCommandHost = {
   getRuntimeId(): string
   requireStore(): Store
   resolveWorktreeSelector(selector: string): Promise<ResolvedRuntimeFileWorktree>
+  resolveRuntimeFileTarget(selector: string): Promise<ResolvedRuntimeFileTarget>
   resolveRuntimeGitTarget(
     selector: string
   ): Promise<{ worktree: ResolvedRuntimeFileWorktree; connectionId?: string }>
@@ -173,9 +178,8 @@ export class RuntimeFileCommands {
 
   async listMobileFiles(worktreeSelector: string): Promise<RuntimeFileListResult> {
     const store = this.host.requireStore()
-    const worktree = await this.host.resolveWorktreeSelector(worktreeSelector)
-    const repo = store.getRepo(worktree.repoId)
-    const connectionId = repo?.connectionId ?? undefined
+    const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
+    const { worktree, connectionId } = target
     const files = connectionId
       ? await this.listRemoteMobileFiles(worktree.path, connectionId)
       : await listQuickOpenFiles(worktree.path, store)
@@ -202,7 +206,7 @@ export class RuntimeFileCommands {
     worktreeSelector: string,
     relativePath: string
   ): Promise<RuntimeFileOpenResult> {
-    const worktree = await this.host.resolveWorktreeSelector(worktreeSelector)
+    const { worktree } = await this.host.resolveRuntimeFileTarget(worktreeSelector)
     if (!isSafeMobileRelativePath(relativePath)) {
       throw new Error('invalid_relative_path')
     }
@@ -234,7 +238,7 @@ export class RuntimeFileCommands {
     relativePath: string,
     staged: boolean
   ): Promise<RuntimeFileOpenResult> {
-    const worktree = await this.host.resolveWorktreeSelector(worktreeSelector)
+    const { worktree } = await this.host.resolveRuntimeFileTarget(worktreeSelector)
     if (!isSafeMobileRelativePath(relativePath)) {
       throw new Error('invalid_relative_path')
     }
@@ -254,7 +258,8 @@ export class RuntimeFileCommands {
     relativePath: string
   ): Promise<RuntimeFileReadResult> {
     const store = this.host.requireStore()
-    const worktree = await this.host.resolveWorktreeSelector(worktreeSelector)
+    const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
+    const { worktree, connectionId } = target
     if (!isSafeMobileRelativePath(relativePath)) {
       throw new Error('invalid_relative_path')
     }
@@ -262,10 +267,9 @@ export class RuntimeFileCommands {
       throw new Error('binary_file')
     }
 
-    const repo = store.getRepo(worktree.repoId)
     const filePath = joinWorktreeRelativePath(worktree.path, relativePath)
-    const content = repo?.connectionId
-      ? await this.readRemoteMobileFile(filePath, repo.connectionId)
+    const content = connectionId
+      ? await this.readRemoteMobileFile(filePath, connectionId)
       : await readLocalMobileFile(filePath, store)
     const truncated = truncateMobileFilePreview(content)
 
@@ -291,9 +295,8 @@ export class RuntimeFileCommands {
     cwd?: string | null
   ): Promise<RuntimeTerminalPathResolution> {
     const store = this.host.requireStore()
-    const worktree = await this.host.resolveWorktreeSelector(worktreeSelector)
-    const repo = store.getRepo(worktree.repoId)
-    const connectionId = repo?.connectionId ?? undefined
+    const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
+    const { worktree, connectionId } = target
     const base = cwd && cwd.trim().length > 0 ? cwd : worktree.path
 
     const empty: RuntimeTerminalPathResolution = {
@@ -764,7 +767,7 @@ export class RuntimeFileCommands {
     worktreeSelector: string,
     options: Omit<SearchOptions, 'rootPath'>
   ): Promise<SearchResult> {
-    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
     const provider = target.connectionId ? getSshFilesystemProvider(target.connectionId) : null
     const rootPath = target.worktree.path
     const searchOptions = { ...options, rootPath }
@@ -781,7 +784,7 @@ export class RuntimeFileCommands {
     worktreeSelector: string,
     options: { excludePaths?: string[] } = {}
   ): Promise<string[]> {
-    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
     const provider = target.connectionId ? getSshFilesystemProvider(target.connectionId) : null
     if (target.connectionId) {
       if (!provider) {
@@ -793,7 +796,7 @@ export class RuntimeFileCommands {
   }
 
   async listRuntimeMarkdownDocuments(worktreeSelector: string): Promise<MarkdownDocument[]> {
-    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
     const provider = target.connectionId ? getSshFilesystemProvider(target.connectionId) : null
     if (target.connectionId) {
       if (!provider) {
@@ -943,14 +946,12 @@ export class RuntimeFileCommands {
     worktreeSelector: string,
     relativePath: string
   ): Promise<{ worktree: ResolvedRuntimeFileWorktree; path: string; connectionId?: string }> {
-    const store = this.host.requireStore()
-    const worktree = await this.host.resolveWorktreeSelector(worktreeSelector)
+    const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
     const normalizedRelativePath = normalizeRuntimeRelativePath(relativePath)
-    const repo = store.getRepo(worktree.repoId)
     return {
-      worktree,
-      path: joinWorktreeRelativePath(worktree.path, normalizedRelativePath),
-      connectionId: repo?.connectionId ?? undefined
+      worktree: target.worktree,
+      path: joinWorktreeRelativePath(target.worktree.path, normalizedRelativePath),
+      connectionId: target.connectionId
     }
   }
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -360,7 +360,8 @@ vi.mock('../ipc/worktree-logic', async (importOriginal) => {
 vi.mock('../ipc/filesystem-auth', () => ({
   invalidateAuthorizedRootsCache: invalidateAuthorizedRootsCacheMock,
   isENOENT: (error: unknown) =>
-    Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')
+    Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT'),
+  resolveAuthorizedPath: vi.fn(async (pathValue: string) => pathValue)
 }))
 
 vi.mock('../worktree-root-preparation', () => ({
@@ -1865,6 +1866,74 @@ describe('OrcaRuntimeService', () => {
     expect(gitProvider.listWorktrees).toHaveBeenCalledWith('//Server/Share/Repo')
     expect(fsProvider.readDir).toHaveBeenCalledWith('\\\\Server\\Share\\Repo\\src')
     expect(gitProvider.getStatus).toHaveBeenCalledWith('//Server/Share/Repo')
+  })
+
+  it.each([
+    { label: 'canonical folder workspace selector', selector: TEST_FOLDER_WORKSPACE_KEY },
+    { label: 'id-prefixed folder workspace selector', selector: `id:${TEST_FOLDER_WORKSPACE_KEY}` }
+  ])('reads file explorer paths for a $label', async ({ selector }) => {
+    const folderPath = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-files-'))
+    await mkdir(join(folderPath, 'src'))
+    await writeFile(join(folderPath, 'src', 'app.ts'), 'export {}\n')
+    const folderWorkspace = makeFolderWorkspace({ folderPath })
+    const projectGroup = makeFolderProjectGroup({ parentPath: folderPath })
+    const runtime = new OrcaRuntimeService(
+      createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup) as never
+    )
+
+    await expect(runtime.readFileExplorerDir(selector, 'src')).resolves.toContainEqual({
+      name: 'app.ts',
+      isDirectory: false,
+      isSymlink: false
+    })
+    await expect(runtime.readFileExplorerPreview(selector, 'src/app.ts')).resolves.toMatchObject({
+      content: 'export {}\n',
+      isBinary: false
+    })
+  })
+
+  it('routes SSH folder workspace file explorer paths through the filesystem provider', async () => {
+    const folderPath = '/srv/platform'
+    const fsProvider = {
+      stat: vi.fn(async (pathValue: string) => ({
+        size: pathValue.endsWith('/app.ts') ? 8 : 0,
+        type: pathValue.endsWith('/app.ts') ? 'file' : 'directory',
+        mtime: 1
+      })),
+      readDir: vi.fn().mockResolvedValue([
+        {
+          name: 'app.ts',
+          isDirectory: false,
+          isSymlink: false
+        }
+      ]),
+      readFile: vi.fn().mockResolvedValue({ content: 'remote\n', isBinary: false })
+    }
+    const folderWorkspace = makeFolderWorkspace({ folderPath, connectionId: 'ssh-folder' })
+    const projectGroup = makeFolderProjectGroup({ parentPath: folderPath })
+    const runtime = new OrcaRuntimeService(
+      createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup) as never
+    )
+    registerSshFilesystemProvider('ssh-folder', fsProvider as never)
+
+    try {
+      await expect(
+        runtime.readFileExplorerDir(`id:${TEST_FOLDER_WORKSPACE_KEY}`, 'src')
+      ).resolves.toHaveLength(1)
+      await expect(
+        runtime.readFileExplorerPreview(`id:${TEST_FOLDER_WORKSPACE_KEY}`, 'src/app.ts')
+      ).resolves.toMatchObject({
+        content: 'remote\n',
+        isBinary: false
+      })
+    } finally {
+      unregisterSshFilesystemProvider('ssh-folder')
+    }
+
+    expect(fsProvider.stat).toHaveBeenCalledWith(folderPath)
+    expect(fsProvider.readDir).toHaveBeenCalledWith('/srv/platform/src')
+    expect(fsProvider.stat).toHaveBeenCalledWith('/srv/platform/src/app.ts')
+    expect(fsProvider.readFile).toHaveBeenCalledWith('/srv/platform/src/app.ts')
   })
 
   it('lists persisted SSH worktrees while the git provider is unavailable', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4675,6 +4675,7 @@ export class OrcaRuntimeService {
     getRuntimeId: () => this.runtimeId,
     requireStore: () => this.requireStore(),
     resolveWorktreeSelector: (selector) => this.resolveWorktreeSelector(selector),
+    resolveRuntimeFileTarget: (selector) => this.resolveRuntimeFileTarget(selector),
     resolveRuntimeGitTarget: (selector) => this.resolveRuntimeGitTarget(selector),
     openFile: (worktreeId, filePath, relativePath, runtimeEnvironmentId) => {
       if (!this.notifier?.openFile) {
@@ -4834,6 +4835,24 @@ export class OrcaRuntimeService {
     const localGitOptions =
       repo && !connectionId ? getLocalProjectWorktreeGitOptions(store, repo) : {}
     return { worktree, repo, connectionId, localGitOptions }
+  }
+
+  private async resolveRuntimeFileTarget(worktreeSelector: string): Promise<{
+    worktree: ResolvedWorktree
+    connectionId?: string
+  }> {
+    const folderScope = await this.resolveFolderWorkspaceLaunchScope(worktreeSelector)
+    if (folderScope?.folderWorkspace) {
+      return {
+        worktree: this.folderWorkspaceToResolvedWorktree(folderScope.folderWorkspace),
+        connectionId: folderScope.connectionId ?? undefined
+      }
+    }
+
+    const store = this.requireStore()
+    const worktree = await this.resolveWorktreeSelector(worktreeSelector)
+    const repo = store.getRepo(worktree.repoId)
+    return { worktree, connectionId: repo?.connectionId ?? undefined }
   }
 
   onMobileSessionTabsChanged(
@@ -16021,6 +16040,23 @@ export class OrcaRuntimeService {
       connectionId: this.resolveFolderWorkspaceConnectionId(workspace),
       repo: null,
       folderWorkspace: workspace
+    }
+  }
+
+  private folderWorkspaceToResolvedWorktree(folderWorkspace: FolderWorkspace): ResolvedWorktree {
+    const worktree = folderWorkspaceToWorktree(folderWorkspace)
+    return {
+      ...worktree,
+      parentWorktreeId: null,
+      childWorktreeIds: [],
+      lineage: null,
+      git: {
+        path: worktree.path,
+        head: worktree.head,
+        branch: worktree.branch,
+        isBare: worktree.isBare,
+        isMainWorktree: worktree.isMainWorktree
+      }
     }
   }
 


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** If you open a *folder* that contains several separate projects inside it (Orca calls this a "monorepo / project group" — for example a `work` folder holding your API, your admin app, and your portal as four sibling git repos) and let one agent work across all of them at once, the file panel is effectively dead. Clicking *any* file in the file tree — or trying to preview one — just shows **"Unable to load file — selector_not_found."** It fails on 100% of files, every time, with a Retry button that doesn't help. So a user who deliberately chose this "one agent, many related projects" setup can't browse or read a single file. It's a hard blocker for that workflow, but it's niche: it only hits people using the folder/project-group import, not the normal "open one repo" path.

**2) What this PR does (ELI5).** Think of every file request as a delivery that needs an address. Orca looks up the address by asking "which git repo is this?" — but a *folder workspace* isn't itself a git repo (it's just a container holding repos), so the lookup came back "no such address" and the delivery was dropped. The terminal already knew how to handle these container folders; the file panel didn't. This PR teaches the file panel the same trick: when it sees a folder-workspace request, it first resolves it as a container folder (and figures out whether that folder lives locally or on a remote SSH machine) before looking anything up. So now you click a file and **it opens**, instead of failing — for both local folders and SSH-hosted ones.

**3) Tradeoffs / regressions — honest answer.** Two things to be honest about, neither of which makes existing behavior worse:

- **This only fixes half the reported issue.** The user reported two bugs. This PR fixes Bug 2 (browsing/previewing files in the file tree). It deliberately does **not** fix Bug 1 — the **Git/diff tab still shows `selector_not_found`** for folder workspaces when you try to open a file's diff. That's called out as intentionally out of scope: a folder workspace spans N child repos, so there's no single git target to point at, and solving that needs a separate design. So a user on this setup gets working file browsing but still can't view diffs in the Git tab — that limitation is unchanged, not newly introduced.
- **For everyone else: no regressions.** Normal single-repo sessions are untouched — the new code returns "not a folder workspace" for ordinary selectors and falls straight through to the exact same lookup as before. Three file-search/list functions were switched to the new resolver, which returns slightly less data than the old one (it drops a `repo`/`localGitOptions` field), but those callers never used that field — the WSL-distro detail they need is recomputed locally — so behavior is identical. Nothing is disabled, no new setup or settings, no feature is removed, and invalid selectors are still rejected exactly as before.


---

## Summary

Fixes the monorepo / project-group bug where folder-workspace sessions could not list or preview files: clicking any file in the tree (or opening the file explorer preview) failed with **"Unable to load file — selector_not_found"**.

Folder-workspace selectors use the key `folder:<id>` and have no backing git worktree record. Every file op in `RuntimeFileCommands` resolved its target through `resolveWorktreeSelector` / `resolveRuntimeGitTarget`, which only match real git worktrees and throw `selector_not_found` for folder workspaces — even though the terminal launch path already special-cases folder workspaces via `resolveFolderWorkspaceLaunchScope`.

This adds `OrcaRuntimeService.resolveRuntimeFileTarget(selector)`, which:
1. first resolves folder workspaces via the existing `resolveFolderWorkspaceLaunchScope` path and returns a synthesized `ResolvedWorktree` (`folderWorkspaceToResolvedWorktree`, wrapping the shared `folderWorkspaceToWorktree`) plus the inferred `connectionId`;
2. otherwise falls back to the existing worktree-selector + `repo.connectionId` path.

The file/search/markdown commands (`resolveFileExplorerPath`, `listMobileFiles`, `openMobileFile`, `openMobileDiff`, `readMobileFile`, `resolveTerminalPath`, `searchRuntimeFiles`, `listRuntimeFiles`, `listRuntimeMarkdownDocuments`) now route through it. As a result, folder-workspace sessions list and preview files for both local and SSH-backed workspaces.

This **supersedes #6363** (community PR by @bennewell35) — the code is taken over and re-verified here; their PR is left open and credited via `Co-authored-by:`.

**Out of scope (intentional):** git diff/status and the Git tab for folder workspaces still route through `resolveRuntimeGitTarget`, which has no folder handling. A folder workspace spans N child repos, so there is no single git target — that is a separate, larger design question (Bug 1 in the issue) and this PR deliberately does not touch it.

## Screenshots

Backend resolution fix (no new UI). Verified end-to-end through the real runtime RPC stack in a dev Electron build — see the PR comment for the before/after evidence (reverted-source failure vs. live RPC success against a real multi-repo folder workspace).

## Testing

- [x] `pnpm lint` (oxlint on the 5 changed files — clean)
- [x] `pnpm typecheck` (`tsgo --noEmit -p config/tsconfig.node.json` — clean)
- [x] `pnpm test` (changed suites + RPC method suite — see below)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Tests run (vitest, `config/vitest.config.ts`):
- `orca-runtime.test.ts` — 489 passed (incl. new local + SSH folder-workspace file-explorer cases)
- `orca-runtime-files.test.ts` + `orca-runtime-files-watch.test.ts` — 29 passed
- `rpc/methods/files.test.ts` — 37 passed (no regression in the RPC layer)

Regression proof: with the production source reverted to `main` (new tests kept), the new folder-workspace tests fail with `Error: selector_not_found` from `resolveWorktreeSelector` via `RuntimeFileCommands.resolveFileExplorerPath`. With the fix, they pass.

## AI Review Report

Reviewed correctness, edge cases, cross-platform behavior, and SSH/remote. Key checks:
- **Resolution order** matches the established terminal pattern (`resolveFolderWorkspaceLaunchScope` first, worktree fallback otherwise); normal per-repo worktree selectors are unaffected (folder check returns `null` for non-`folder:` keys).
- **Cross-platform:** no hardcoded path separators introduced; path joining uses the existing `joinWorktreeRelativePath` helper. Windows WSL search test and UNC-path status test still pass. SSH folder-workspace routing covered by a dedicated test.
- **Connection inference:** `connectionId` flows from the folder scope to the SSH filesystem provider; dropping `localGitOptions`/`repo` from the three search/list/markdown sites is safe — they only consume `target.connectionId` and `target.worktree.path`, and `searchLocalRuntimeFiles` recomputes `wslDistro` itself.
- Flagged and confirmed out-of-scope: git diff/status for folder workspaces (no single git target).

## Security Audit

- **Input handling / IPC:** selectors are parsed by `parseWorkspaceKey` and a folder workspace must already exist in the store. Verified live that a nonexistent `folder:<id>` still rejects with `selector_not_found` — the change does not broaden which selectors are accepted, only resolves valid folder workspaces.
- **Path handling:** no new path construction; relative-path safety checks (`isSafeMobileRelativePath`, `normalizeRuntimeRelativePath`) are unchanged. No traversal surface added.
- **No** command execution, eval, secret access, or new dependencies. Adopting #6363: re-audited the diff as if hostile — no exfiltration, injection, or suspicious behavior; it is a pure routing change.

## Notes

- Adopted from community PR #6363 (credited via `Co-authored-by:`); that PR is intentionally left open.
- **Future suggestion (out of scope):** folder-workspace git diff/status (the Git tab) needs a separate design — a folder workspace spans multiple child repos, so the single-git-target assumption in `resolveRuntimeGitTarget` does not hold. Tracked as Bug 1 in #6357.

Made with [Orca](https://github.com/stablyai/orca) 🐋