### PR TITLE
fix: queue AI Vault resume command in the configured Windows shell (#6152)

### DIFF
--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { AppState } from '@/store/types'
+import { buildAiVaultResumeCommand } from '../../../shared/ai-vault-types'
 import {
   buildAiVaultResumeCommandForWorktree,
   buildAiVaultResumeStartupForWorktree,
@@ -27,6 +28,7 @@ type AiVaultResumeCommandState = Pick<
 function makeState(args: {
   worktreePath: string
   localWindowsRuntimePreference?: RuntimePreference
+  terminalWindowsShell?: string
 }): AiVaultResumeCommandState {
   return {
     activeRepoId: 'repo-1',
@@ -45,6 +47,7 @@ function makeState(args: {
     ],
     settings: {
       localWindowsRuntimeDefault: { kind: 'windows-host' },
+      ...(args.terminalWindowsShell ? { terminalWindowsShell: args.terminalWindowsShell } : {}),
       agentDefaultArgs: { claude: '', codex: '' },
       agentDefaultEnv: { claude: {}, codex: {} }
     },
@@ -61,7 +64,9 @@ function makeState(args: {
 }
 
 describe('ai vault resume command runtime', () => {
-  it('uses Windows command wrapping for Windows-host projects', () => {
+  it('queues a PowerShell-valid command for the default Windows shell', () => {
+    // Why: the queued command is typed into the live tab shell (default
+    // PowerShell), which mis-parses the cmd `""`-doubled wrapper (#6152).
     const state = makeState({ worktreePath: 'C:\\Users\\alice\\repo' })
 
     expect(
@@ -75,7 +80,61 @@ describe('ai vault resume command runtime', () => {
           codexHome: null
         }
       })
+    ).toBe("Set-Location -LiteralPath 'C:\\Users\\alice\\repo'; claude '--resume' 'session one'")
+  })
+
+  it('keeps the cmd wrapper when the configured Windows shell is cmd.exe', () => {
+    const state = makeState({
+      worktreePath: 'C:\\Users\\alice\\repo',
+      terminalWindowsShell: 'cmd.exe'
+    })
+
+    expect(
+      buildAiVaultResumeCommandForWorktree({
+        state,
+        worktreeId: 'repo-1::worktree-1',
+        session: {
+          agent: 'claude',
+          sessionId: 'session one',
+          cwd: 'C:\\Users\\alice\\repo',
+          codexHome: null
+        }
+      })
     ).toBe('cmd /d /s /c "cd /d ""C:\\Users\\alice\\repo"" && claude ""--resume"" ""session one"""')
+  })
+
+  it('queues a POSIX command for the Git Bash Windows shell', () => {
+    const state = makeState({
+      worktreePath: 'C:\\Users\\alice\\repo',
+      terminalWindowsShell: 'git-bash'
+    })
+
+    expect(
+      buildAiVaultResumeCommandForWorktree({
+        state,
+        worktreeId: 'repo-1::worktree-1',
+        session: {
+          agent: 'claude',
+          sessionId: 'session one',
+          cwd: 'C:\\Users\\alice\\repo',
+          codexHome: null
+        }
+      })
+    ).toBe("cd 'C:\\Users\\alice\\repo' && claude '--resume' 'session one'")
+  })
+
+  it('keeps the cmd wrapper for the copy-to-clipboard command on Windows', () => {
+    // Regression guard: the copy path is self-contained for pasting into cmd.exe
+    // and must stay cmd-wrapped even though the queued path now follows the shell.
+    expect(
+      buildAiVaultResumeCommand({
+        agent: 'claude',
+        sessionId: 'session one',
+        cwd: 'C:\\Users\\alice\\repo',
+        platform: 'win32',
+        codexHome: null
+      })
+    ).toBe('cmd /d /s /c "cd /d ""C:\\Users\\alice\\repo"" && claude --resume ""session one"""')
   })
 
   it('uses configured agent defaults for resumable session history entries', () => {

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -12,6 +12,8 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { parseWslUncPath } from '../../../shared/wsl-paths'
+import { resolveWindowsShellStartupFamily } from '../../../shared/windows-terminal-shell'
+import type { AgentStartupShell } from '../../../shared/tui-agent-startup-shell'
 import type { AppState } from '@/store/types'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
@@ -65,6 +67,14 @@ export function buildAiVaultResumeStartupForWorktree(args: {
 }): AiVaultResumeStartup {
   const platform = getAiVaultResumePlatform(args.state, args.worktreeId)
   const codexHome = getAiVaultResumeCodexHome(args.session.codexHome, platform)
+  // Why: the queued command is typed verbatim into the freshly spawned tab whose
+  // live shell is the configured Windows shell (default PowerShell). Hardcoding
+  // cmd quoting made PowerShell mis-parse the `""`-doubled wrapper (#6152), so
+  // resolve the actual shell to quote per-shell instead.
+  const queuedShell: AgentStartupShell | undefined =
+    platform === 'win32'
+      ? resolveWindowsShellStartupFamily(args.state.settings?.terminalWindowsShell)
+      : undefined
   if (isResumableTuiAgent(args.session.agent)) {
     const startupPlan = buildAgentResumeStartupPlan({
       agent: args.session.agent,
@@ -74,9 +84,7 @@ export function buildAiVaultResumeStartupForWorktree(args: {
         ...(args.commandOverride?.trim() ? { [args.session.agent]: args.commandOverride } : {})
       },
       platform,
-      // Why: copied AI Vault commands are shell-wrapped for portability; the
-      // same inner command must be queued so drag/click resume match copy.
-      shell: platform === 'win32' ? 'cmd' : undefined,
+      shell: queuedShell,
       agentArgs: resolveTuiAgentLaunchArgs(
         args.session.agent,
         args.state.settings?.agentDefaultArgs
@@ -89,7 +97,8 @@ export function buildAiVaultResumeStartupForWorktree(args: {
           resumeCommand: startupPlan.launchCommand,
           cwd: args.session.cwd,
           platform,
-          codexHome
+          codexHome,
+          shell: queuedShell
         }),
         ...(startupPlan.env ? { env: startupPlan.env } : {}),
         launchConfig: startupPlan.launchConfig

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -1,4 +1,9 @@
 import { TUI_AGENT_CONFIG } from './tui-agent-config'
+import {
+  commandSeparator,
+  quoteStartupArg,
+  type AgentStartupShell
+} from './tui-agent-startup-shell'
 import type { TuiAgent } from './types'
 
 export const AI_VAULT_AGENTS = [
@@ -106,8 +111,26 @@ export function buildAiVaultResumeShellCommand(args: {
   cwd: string | null
   platform: NodeJS.Platform
   codexHome?: string | null
+  // Why: the QUEUED resume command is typed into the live tab shell, so its
+  // cd/env prefix must match that shell. The copy-to-clipboard string omits this
+  // and keeps the self-contained `cmd /d /s /c` wrapper (its documented purpose).
+  shell?: AgentStartupShell
 }): string {
-  const { cwd, platform, codexHome } = args
+  const { cwd, platform, codexHome, shell } = args
+
+  // Why: on Windows the queued command must target the configured live shell
+  // (default PowerShell). PowerShell mis-parses the cmd `""`-doubled wrapper and
+  // reports "operable program or batch file", so only re-wrap with cmd when the
+  // live shell actually is cmd (or when no shell is given, i.e. the copy path).
+  if (platform === 'win32' && shell && shell !== 'cmd') {
+    return buildResumeShellCommandForShell({
+      resumeCommand: args.resumeCommand,
+      cwd,
+      codexHome: codexHome?.trim() || null,
+      shell
+    })
+  }
+
   const resumeCommand = `${codexHomeEnvPrefix(codexHome?.trim() || null, platform)}${
     args.resumeCommand
   }`
@@ -121,6 +144,33 @@ export function buildAiVaultResumeShellCommand(args: {
   }
 
   return `cd ${quoteShellArg(cwd, platform)} && ${resumeCommand}`
+}
+
+function buildResumeShellCommandForShell(args: {
+  resumeCommand: string
+  cwd: string | null
+  codexHome: string | null
+  shell: Exclude<AgentStartupShell, 'cmd'>
+}): string {
+  const { cwd, codexHome, shell } = args
+  if (shell === 'posix') {
+    // Why: git-bash on a Windows host runs a POSIX shell, so reuse the same
+    // inline-env + `cd '<cwd>'` prefix as the non-Windows path.
+    const envPrefix = codexHome ? `CODEX_HOME=${quoteStartupArg(codexHome, shell)} ` : ''
+    const command = `${envPrefix}${args.resumeCommand}`
+    return cwd ? `cd ${quoteStartupArg(cwd, shell)} && ${command}` : command
+  }
+
+  const separator = commandSeparator(shell)
+  const segments: string[] = []
+  if (cwd) {
+    segments.push(`Set-Location -LiteralPath ${quoteStartupArg(cwd, shell)}`)
+  }
+  if (codexHome) {
+    segments.push(`$env:CODEX_HOME=${quoteStartupArg(codexHome, shell)}`)
+  }
+  segments.push(args.resumeCommand)
+  return segments.join(separator)
 }
 
 export function aiVaultAgentLabel(agent: AiVaultAgent): string {

--- a/src/shared/windows-terminal-shell.test.ts
+++ b/src/shared/windows-terminal-shell.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWindowsShellStartupFamily } from './windows-terminal-shell'
+
+describe('resolveWindowsShellStartupFamily', () => {
+  it('defaults to PowerShell when unset', () => {
+    expect(resolveWindowsShellStartupFamily(undefined)).toBe('powershell')
+    expect(resolveWindowsShellStartupFamily(null)).toBe('powershell')
+    expect(resolveWindowsShellStartupFamily('  ')).toBe('powershell')
+  })
+
+  it('treats PowerShell and pwsh as PowerShell', () => {
+    expect(resolveWindowsShellStartupFamily('powershell.exe')).toBe('powershell')
+    expect(resolveWindowsShellStartupFamily('pwsh.exe')).toBe('powershell')
+    expect(resolveWindowsShellStartupFamily('C:\\Program Files\\PowerShell\\7\\pwsh.exe')).toBe(
+      'powershell'
+    )
+  })
+
+  it('maps cmd.exe to cmd quoting', () => {
+    expect(resolveWindowsShellStartupFamily('cmd.exe')).toBe('cmd')
+    expect(resolveWindowsShellStartupFamily('C:\\Windows\\System32\\cmd.exe')).toBe('cmd')
+  })
+
+  it('maps Git Bash and WSL shells to POSIX quoting', () => {
+    expect(resolveWindowsShellStartupFamily('git-bash')).toBe('posix')
+    expect(resolveWindowsShellStartupFamily('wsl.exe')).toBe('posix')
+    expect(resolveWindowsShellStartupFamily('C:\\Program Files\\Git\\bin\\bash.exe')).toBe('posix')
+  })
+})

--- a/src/shared/windows-terminal-shell.ts
+++ b/src/shared/windows-terminal-shell.ts
@@ -1,3 +1,5 @@
+import type { AgentStartupShell } from './tui-agent-startup-shell'
+
 export const WINDOWS_GIT_BASH_SHELL = 'git-bash'
 
 export type BuiltInWindowsTerminalShell =
@@ -5,3 +7,31 @@ export type BuiltInWindowsTerminalShell =
   | 'cmd.exe'
   | 'wsl.exe'
   | typeof WINDOWS_GIT_BASH_SHELL
+
+/**
+ * Classifies a configured `terminalWindowsShell` value into the startup-shell
+ * family used to quote queued commands. Git Bash / wsl.exe run a POSIX shell;
+ * cmd.exe needs cmd quoting; everything else (PowerShell, pwsh, unknown) is
+ * treated as PowerShell, matching the Windows default.
+ */
+export function resolveWindowsShellStartupFamily(
+  shell: string | null | undefined
+): AgentStartupShell {
+  const trimmed = shell?.trim()
+  if (!trimmed) {
+    return 'powershell'
+  }
+  if (trimmed === WINDOWS_GIT_BASH_SHELL) {
+    return 'posix'
+  }
+  const basename = trimmed.replaceAll('\\', '/').split('/').pop()?.toLowerCase() ?? ''
+  if (basename === 'cmd.exe') {
+    return 'cmd'
+  }
+  // Why: wsl.exe and bash.exe (Git for Windows) launch POSIX shells, so queued
+  // commands must use POSIX quoting and `cd '<cwd>'` rather than cmd/PowerShell.
+  if (basename === 'wsl.exe' || basename === 'wsl' || basename === 'bash.exe') {
+    return 'posix'
+  }
+  return 'powershell'
+}


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** On Windows, when you reopen a past AI agent session from history ("Resume in new tab", or by dragging it), Orca opens a fresh terminal tab and types in the command to restart your session. The problem: it typed that command in the "language" of the old-school Windows command prompt (cmd), but the new tab was actually running PowerShell (the default). It's like writing instructions in French and handing them to someone who only reads German — they just stare back confused. The visible result is an error: `'... ' is not recognized as an internal or external command, operable program or batch file.` and the session never resumes. This hits Windows users on the default setup, which is most of them, and it's a hard blocker — the resume feature simply doesn't work for them.

**2) What this PR does (ELI5).** Before typing the resume command into the new tab, Orca now checks which terminal "language" that tab is actually speaking — PowerShell, the old cmd prompt, or a Unix-style shell like Git Bash/WSL — and writes the command in that exact language. So it now speaks the right dialect to whoever's listening, instead of always assuming cmd. Oh, so it now phrases the resume command to match the terminal that's open, instead of always using cmd-speak and getting ignored. The fix also reaches the drag-to-resume path for free, since it uses the same queued command.

**3) Tradeoffs / regressions — honest answer.** No regressions for the user experience. Nothing is disabled, there's no new setting or step for users, and no behavior is lost: macOS and Linux output is byte-for-byte unchanged, and the separate "copy command to clipboard" button is deliberately left as-is (it stays cmd-formatted on purpose, because it's documented to be pasted into a cmd window). The earlier band-aid (hardcoding "cmd") is replaced with shell-aware logic that targets the true root cause. One honest scoping caveat — not a new regression: a few non-resumable agents (cursor, copilot, kimi, pi) still fall back to the old cmd-formatted path and would hit the same mis-parse. That was already true before this PR; fixing them needs a larger rework, so this PR intentionally scopes to the reported case (resuming Claude sessions). So users are strictly better off, with the known gap for those other agents left for a follow-up.

---

## Summary

Fixes #6152.

On Windows, "Resume in new tab" / drag-resume of an AI Vault history session queued a **cmd.exe-syntax** command into a freshly spawned tab whose live shell is the configured Windows shell (default = PowerShell). The queued command was unconditionally wrapped as `cmd /d /s /c \"cd /d \"\"<cwd>\"\" && claude --resume \"\"<id>\"\"\"`. PowerShell mis-parses the cmd `\"\"`-doubled escaping and reports the reporter's exact error:

```
'\"cd /d \"\"D:\\project\\temp\"\" && claude --resume \"\"7ef6...\"\"\"\"' is not recognized as an internal or external command, operable program or batch file.
```

The reporter confirmed pasting the same copied command into a real `cmd.exe` window resumes correctly, proving the command is cmd-only but was being injected into PowerShell.

The fix resolves `terminalWindowsShell` to a startup-shell family and quotes the **queued** command for the live shell:
- **PowerShell** (default): `Set-Location -LiteralPath '<cwd>'; <resume>` with `$env:CODEX_HOME='<home>'` for Codex.
- **Git Bash / WSL host shell**: POSIX `cd '<cwd>' && <resume>`.
- **cmd.exe**: keeps the existing `cmd /d /s /c \"...\"` wrapper.

The **copy-to-clipboard** command (`buildAiVaultResumeCommand`) is unchanged and stays cmd-wrapped, preserving the documented paste-into-cmd UX. The drag path inherits the fix because it queues the same `AiVaultResumeStartup.command`.

This replaces the symptom-aligned hardcoded `shell: 'cmd'` (PR #6299) with a shell that matches what's actually running in the spawned tab — the longstanding `cmd /d /s /c` wrapper was the true root cause.

## Screenshots

No visual change (terminal command-generation logic only).

## Testing

- [x] `pnpm lint` (`oxlint` on changed files — clean)
- [x] `pnpm typecheck` (`tsgo` node + web — no new errors; 5 pre-existing `TS6307` project-config errors exist on clean `main` and are unrelated)
- [x] `pnpm test` (relevant suites — see PR comment for output)
- [ ] `pnpm build`
- [x] Added/updated high-quality tests that would catch the regression

Updated `ai-vault-resume-command.test.ts`: default Windows shell now asserts PowerShell-valid output (no `cmd /d /s /c`, no doubled `\"\"`); added `cmd.exe` and `git-bash` cases; added a copy-path regression guard asserting `buildAiVaultResumeCommand` stays cmd-wrapped. Added `windows-terminal-shell.test.ts` for the new shell classifier. Confirmed `session-scanner.test.ts` copy-path assertions still pass unchanged.

## AI Review Report

Reviewed correctness, edge cases, and cross-platform behavior:
- **PowerShell quoting**: `Set-Location -LiteralPath` avoids glob interpretation; `quoteStartupArg('powershell')` does correct single-quote doubling; statements joined with `; `.
- **Cross-platform**: no hardcoded `metaKey`; no hardcoded path separators (basename derived via `replaceAll('\\\\','/').split('/')`, consistent with the existing `isWslShellName`). The win32 branch only runs when `getAiVaultResumePlatform` returns `win32`; WSL already routes to `linux` and uses the POSIX path. Non-Windows behavior is byte-for-byte unchanged.
- **No-cwd / no-codexHome** edge cases produce a bare resume command for all shells.
- **Backwards compat**: `buildAiVaultResumeShellCommand` defaults to the original cmd wrapper when no `shell` is supplied, so the copy path and any other caller are unaffected.
- **Provider-agnostic**: terminal/PTY command generation only; no GitHub/GitLab specifics.

## Security Audit

No new input handling, command execution, path traversal, auth, secret, dependency, or IPC surface. The change only re-quotes an already-trusted, locally-generated resume command using existing shared quoting helpers (`quoteStartupArg`). No new dependencies, no `eval`, no shell-string concatenation of untrusted input beyond what already existed (session id / cwd, both already quoted). PowerShell single-quote literals and POSIX single-quote escaping prevent argument breakout for the cwd/session values.

## Notes

- Windows-only behavior; macOS/Linux output is unchanged.
- The host shell `wsl.exe` case maps to POSIX as a safe fallback, but in practice WSL projects already resolve to the `linux` platform branch before reaching the win32 shell mapping.
- **Future suggestion (out of scope):** non-resumable AI Vault agents (e.g. cursor, copilot, kimi, pi) still fall through to `buildAiVaultResumeCommand` for the queued path and would hit the same PowerShell mis-parse. Fixing those requires also reworking their inner arg quoting (`quoteShellArg`), a larger change; this PR scopes to the reported resumable-agent (claude) regression.

Made with [Orca](https://github.com/stablyai/orca) 🐋