### PR TITLE
fix: preserve pre-TUI SSH shell output across alternate-screen tab restore (#6106)

### DIFF
--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -498,6 +498,51 @@ describe('HeadlessEmulator', () => {
       expect(snapshot.rehydrateSequences).toContain('\x1b[?1006h')
       expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
     })
+
+    it('preserves pre-alternate-screen content with opt-in mode', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+      await emulator.write('PRE_CODEX_START\nls | head -5\n')
+      await emulator.write('\x1b[?1049h')
+      await emulator.write('TUI_FRAME\n')
+
+      const defaultSnapshot = emulator.getSnapshot({ scrollbackRows: 10 })
+      expect(defaultSnapshot.snapshotAnsi).not.toContain('PRE_CODEX_START')
+      expect(defaultSnapshot.snapshotAnsi).toContain('TUI_FRAME')
+      expect(defaultSnapshot.rehydrateSequences).toContain('\x1b[?1049h')
+
+      const preservedSnapshot = emulator.getSnapshot({
+        scrollbackRows: 10,
+        preserveNormalBufferOnAltScreen: true
+      })
+      expect(preservedSnapshot.snapshotAnsi).toContain('PRE_CODEX_START')
+      expect(preservedSnapshot.snapshotAnsi).toContain('TUI_FRAME')
+      expect(preservedSnapshot.snapshotAnsi).toContain('\x1b[?1049h')
+      // No mouse modes are active, so the serializer covers everything and the
+      // opt-in path needs no extra rehydrate sequences.
+      expect(preservedSnapshot.rehydrateSequences).toBe('')
+    })
+
+    it('preserves SGR mouse encoding in the opt-in alternate-screen snapshot', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+      await emulator.write('PRE_CODEX_START\n')
+      // Enter alt screen and enable drag tracking with SGR encoding, as Codex /
+      // Claude / OpenTUI do. SerializeAddon emits ?1002h but drops ?1006h.
+      await emulator.write('\x1b[?1049h\x1b[?1002;1006h')
+
+      const preservedSnapshot = emulator.getSnapshot({
+        scrollbackRows: 10,
+        preserveNormalBufferOnAltScreen: true
+      })
+      expect(preservedSnapshot.modes.sgrMouseMode).toBe(true)
+      // Why: the raw blob already entered alt screen and carries tracking modes,
+      // but not the SGR encoding — it must be restored so clicks past col/row 223
+      // keep using SGR rather than degrading to legacy X10 reports.
+      const payload = preservedSnapshot.rehydrateSequences + preservedSnapshot.snapshotAnsi
+      expect(payload).toContain('\x1b[?1006h')
+      expect(payload).toContain('PRE_CODEX_START')
+      // The opt-in branch must not duplicate the alt-screen entry.
+      expect(payload.split('\x1b[?1049h')).toHaveLength(2)
+    })
   })
 
   describe('dispose', () => {

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -134,12 +134,18 @@ export class HeadlessEmulator {
     return { cols: this.terminal.cols, rows: this.terminal.rows }
   }
 
-  getSnapshot(opts: { scrollbackRows?: number } = {}): TerminalSnapshot {
+  getSnapshot(
+    opts: { scrollbackRows?: number; preserveNormalBufferOnAltScreen?: boolean } = {}
+  ): TerminalSnapshot {
     const modes = this.getModes()
-    const snapshotAnsi = this.normalizeSnapshotAnsiForModes(
-      this.serializer.serialize({ scrollback: opts.scrollbackRows }),
-      modes
-    )
+    const rawSnapshotAnsi = this.serializer.serialize({ scrollback: opts.scrollbackRows })
+    // Why: the desktop live-restore path opts in to keep the pre-TUI normal
+    // buffer (SerializeAddon emits it before the embedded ?1049h). Mobile must
+    // NOT opt in: its xterm re-wraps the replay and would duplicate prompts.
+    const preserveAltScreen = opts.preserveNormalBufferOnAltScreen === true && modes.alternateScreen
+    const snapshotAnsi = preserveAltScreen
+      ? rawSnapshotAnsi
+      : this.normalizeSnapshotAnsiForModes(rawSnapshotAnsi, modes)
     return {
       snapshotAnsi,
       scrollbackAnsi: '',
@@ -148,7 +154,12 @@ export class HeadlessEmulator {
         opts.scrollbackRows,
         this.restoredOscLinks
       ),
-      rehydrateSequences: this.buildRehydrateSequences(modes),
+      // Why: the raw blob already enters alt screen via its embedded ?1049h, so
+      // we only append the encoding modes SerializeAddon omits (?1006h/?1016h)
+      // to avoid degrading SGR mouse reports to legacy X10 after restore.
+      rehydrateSequences: preserveAltScreen
+        ? this.buildMouseEncodingSequence(modes)
+        : this.buildRehydrateSequences(modes),
       cwd: this.cwd,
       modes,
       cols: this.terminal.cols,
@@ -316,6 +327,14 @@ export class HeadlessEmulator {
     }
   }
 
+  // Why: xterm tracks the mouse protocol and SGR encoding as independent modes,
+  // and SerializeAddon emits the TRACKING modes but NOT the SGR ENCODING. So the
+  // opt-in raw snapshot reuses this to restore only the dropped encoding, keeping
+  // clicks past col/row 223 on SGR rather than degrading to legacy X10 reports.
+  private buildMouseEncodingSequence(modes: TerminalModes): string {
+    return modes.sgrMousePixelsMode ? '\x1b[?1016h' : modes.sgrMouseMode ? '\x1b[?1006h' : ''
+  }
+
   private buildRehydrateSequences(modes: TerminalModes): string {
     const seqs: string[] = []
     if (modes.alternateScreen) {
@@ -345,13 +364,7 @@ export class HeadlessEmulator {
       case 'none':
         break
     }
-    // Why: xterm tracks the mouse protocol and SGR encoding as independent
-    // modes, so snapshots must preserve the encoding even when reporting is off.
-    if (modes.sgrMousePixelsMode) {
-      seqs.push('\x1b[?1016h')
-    } else if (modes.sgrMouseMode) {
-      seqs.push('\x1b[?1006h')
-    }
+    seqs.push(this.buildMouseEncodingSequence(modes))
     return seqs.join('')
   }
 }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8561,6 +8561,27 @@ describe('OrcaRuntimeService', () => {
     expect(snapshot?.data).not.toContain('line-0')
   })
 
+  it('preserves pre-alternate-screen shell output when explicitly requested for remote snapshots', async () => {
+    const runtime = createRuntime()
+    syncSinglePty(runtime, 'pty-1')
+
+    runtime.onPtyData('pty-1', 'PRE_CODEX_START\nls | head -5\n', 100)
+    runtime.onPtyData('pty-1', '\x1b[?1049hTUI_FRAME\n', 200)
+
+    const defaultSnapshot = await runtime.serializeTerminalBuffer('pty-1', { scrollbackRows: 100 })
+    const optInSnapshot = await runtime.serializeTerminalBuffer('pty-1', {
+      scrollbackRows: 100,
+      altScreenPreservesScrollback: true
+    })
+
+    expect(defaultSnapshot?.data).not.toContain('PRE_CODEX_START')
+    expect(defaultSnapshot?.data).toContain('TUI_FRAME')
+    expect(optInSnapshot?.data).toContain('PRE_CODEX_START')
+    expect(optInSnapshot?.data).toContain('TUI_FRAME')
+    expect(optInSnapshot?.data).toContain('\x1b[?1049h')
+    expect(optInSnapshot?.source).toBe('headless')
+  })
+
   it('waits for terminal exit and resolves with the exit status', async () => {
     const runtime = new OrcaRuntimeService(store)
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5391,7 +5391,7 @@ export class OrcaRuntimeService {
 
   serializeTerminalBuffer(
     ptyId: string,
-    opts: { scrollbackRows?: number } = {}
+    opts: { scrollbackRows?: number; altScreenPreservesScrollback?: boolean } = {}
   ): Promise<{
     data: string
     cols: number
@@ -5672,7 +5672,7 @@ export class OrcaRuntimeService {
 
   private async serializeTerminalBufferFromAvailableState(
     ptyId: string,
-    opts: { scrollbackRows?: number } = {}
+    opts: { scrollbackRows?: number; altScreenPreservesScrollback?: boolean } = {}
   ): Promise<{
     data: string
     cols: number
@@ -5783,7 +5783,11 @@ export class OrcaRuntimeService {
 
   private async serializeHeadlessTerminalBuffer(
     ptyId: string,
-    opts: { scrollbackRows?: number; includeEmpty?: boolean } = {}
+    opts: {
+      scrollbackRows?: number
+      includeEmpty?: boolean
+      altScreenPreservesScrollback?: boolean
+    } = {}
   ): Promise<{
     data: string
     cols: number
@@ -5807,10 +5811,18 @@ export class OrcaRuntimeService {
     // scrollbackRows=0 in that case. When the buffer is in normal mode the
     // caller can request scrollback so the user can scroll up to see prior
     // agent output.
+    // Why: the desktop live SSH restore path opts in (altScreenPreservesScrollback)
+    // to keep the pre-TUI normal-buffer scrollback so hidden/restore does not drop
+    // the user's earlier shell output. Mobile must NOT opt in: its xterm re-wraps
+    // the replay and would duplicate prompts / flatten SGR, so it keeps rows=0.
     const requested = opts.scrollbackRows ?? 0
     const isAlternateScreen = state.emulator.isAlternateScreen
-    const scrollbackRows = isAlternateScreen ? 0 : requested
-    const snapshot = state.emulator.getSnapshot({ scrollbackRows })
+    const shouldPreserveAltScreen = opts.altScreenPreservesScrollback === true
+    const scrollbackRows = isAlternateScreen && !shouldPreserveAltScreen ? 0 : requested
+    const snapshot = state.emulator.getSnapshot({
+      scrollbackRows,
+      preserveNormalBufferOnAltScreen: shouldPreserveAltScreen && isAlternateScreen
+    })
     const data = snapshot.rehydrateSequences + snapshot.snapshotAnsi
     return data.length > 0 || opts.includeEmpty === true
       ? {

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -410,11 +410,18 @@ function requestedSnapshotScrollbackCandidates(requestedRows: number | undefined
 async function serializeBudgetedRequestedSnapshot(
   runtime: OrcaRuntimeService,
   ptyId: string,
-  scrollbackRows: number | undefined
+  scrollbackRows: number | undefined,
+  options: { altScreenPreservesScrollback?: boolean } = {}
 ): Promise<SerializedSnapshot> {
   const requestedRows = scrollbackRows ?? 0
   for (const rows of requestedSnapshotScrollbackCandidates(scrollbackRows)) {
-    const serialized = await runtime.serializeTerminalBuffer(ptyId, { scrollbackRows: rows })
+    // Why: forward the caller's intent verbatim — desktop restore opts in to keep
+    // pre-TUI scrollback, mobile omits the flag so its replay path stays unchanged.
+    const requestOptions = {
+      scrollbackRows: rows,
+      ...(options.altScreenPreservesScrollback ? { altScreenPreservesScrollback: true } : {})
+    }
+    const serialized = await runtime.serializeTerminalBuffer(ptyId, requestOptions)
     if (!serialized) {
       return null
     }
@@ -464,12 +471,19 @@ function sendSnapshotFrames(
   return { bytes, chunks }
 }
 
-async function serializeBudgetedMobileSnapshot(
+async function serializeBudgetedSubscribeSnapshot(
   runtime: OrcaRuntimeService,
   ptyId: string,
   isMobile: boolean
 ): Promise<SerializedSnapshot> {
   if (!isMobile) {
+    if (runtime.isTerminalAlternateScreen(ptyId)) {
+      // Why: desktop first-attach must match hidden tab restore for active TUIs;
+      // otherwise shell output printed before Codex/Claude still disappears.
+      return serializeBudgetedRequestedSnapshot(runtime, ptyId, MOBILE_SUBSCRIBE_SCROLLBACK_ROWS, {
+        altScreenPreservesScrollback: true
+      })
+    }
     const serialized = await runtime.serializeTerminalBuffer(ptyId, { scrollbackRows: 0 })
     return serialized ? { ...serialized, scrollbackRows: 0, truncatedByByteBudget: false } : null
   }
@@ -512,7 +526,7 @@ async function sendMobileResizeRestream(
   if (event.reason !== 'apply-layout' || runtime.isTerminalAlternateScreen(ptyId)) {
     return false
   }
-  const serialized = await serializeBudgetedMobileSnapshot(runtime, ptyId, true)
+  const serialized = await serializeBudgetedSubscribeSnapshot(runtime, ptyId, true)
   if (!serialized) {
     return false
   }
@@ -1330,7 +1344,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           let serialized = await serializeBudgetedRequestedSnapshot(
             runtime,
             stream.ptyId,
-            scrollbackRows
+            scrollbackRows,
+            { altScreenPreservesScrollback: !stream.isMobile }
           )
           if (closed || streams.get(stream.streamId) !== stream) {
             return
@@ -1346,7 +1361,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             serialized = await serializeBudgetedRequestedSnapshot(
               runtime,
               stream.ptyId,
-              scrollbackRows
+              scrollbackRows,
+              { altScreenPreservesScrollback: !stream.isMobile }
             )
             if (closed || streams.get(stream.streamId) !== stream) {
               return
@@ -1505,7 +1521,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           }
 
           const read = await runtime.readTerminal(request.terminal)
-          const serialized = await serializeBudgetedMobileSnapshot(runtime, ptyId, isMobile)
+          const serialized = await serializeBudgetedSubscribeSnapshot(runtime, ptyId, isMobile)
           if (closed || streams.get(request.streamId) !== stream) {
             return
           }
@@ -1697,7 +1713,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       const clientId = params.client?.id
       if (!useBinaryStream) {
         const read = await runtime.readTerminal(params.terminal)
-        const serialized = await serializeBudgetedMobileSnapshot(runtime, ptyId, false)
+        const serialized = await serializeBudgetedSubscribeSnapshot(runtime, ptyId, false)
         // Why: legacy JSON streams register cleanup after snapshot awaits; if
         // the socket closed meanwhile, registering now would orphan listeners.
         if (signal?.aborted) {
@@ -1892,7 +1908,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         })
 
         const read = await runtime.readTerminal(params.terminal)
-        const serialized = await serializeBudgetedMobileSnapshot(runtime, ptyId, isMobile)
+        const serialized = await serializeBudgetedSubscribeSnapshot(runtime, ptyId, isMobile)
         if (closed) {
           return
         }

--- a/src/main/runtime/rpc/streaming.test.ts
+++ b/src/main/runtime/rpc/streaming.test.ts
@@ -9,6 +9,7 @@ import type { RuntimeTerminalWait } from '../../../shared/runtime-types'
 function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeService {
   return {
     getRuntimeId: () => 'test-runtime',
+    isTerminalAlternateScreen: () => false,
     ...overrides
   } as OrcaRuntimeService
 }

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -18,6 +18,7 @@ import {
 function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeService {
   return {
     getRuntimeId: () => 'test-runtime',
+    isTerminalAlternateScreen: () => false,
     ...overrides
   } as OrcaRuntimeService
 }
@@ -223,7 +224,8 @@ describe('terminal multiplex RPC', () => {
         requestId: 7
       })
       expect(runtime.serializeTerminalBuffer).toHaveBeenLastCalledWith('pty-1', {
-        scrollbackRows: 5000
+        scrollbackRows: 5000,
+        altScreenPreservesScrollback: true
       })
       expect(
         requestedSnapshotFrames
@@ -237,6 +239,181 @@ describe('terminal multiplex RPC', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('preserves alternate-screen scrollback on desktop multiplex subscribe', async () => {
+    const messages: string[] = []
+    const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+    const handlers = new Map<
+      number,
+      (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+    >()
+    const cleanups = new Map<string, () => void>()
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+      serializeTerminalBuffer: vi.fn().mockResolvedValue({
+        data: 'PRE_CODEX_START\x1b[?1049hTUI_FRAME',
+        cols: 120,
+        rows: 40
+      }),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      isTerminalAlternateScreen: vi.fn().mockReturnValue(true),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
+      getTerminalFitOverride: vi.fn().mockReturnValue(null),
+      getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+      sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
+      updateDesktopViewport: vi.fn().mockResolvedValue(true)
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.multiplex', {}),
+      (msg) => messages.push(msg),
+      {
+        connectionId: 'conn-desktop-alt-subscribe',
+        sendBinary: (bytes) => binaryFrames.push(bytes),
+        registerBinaryStreamHandler: (streamId, handler) => {
+          handlers.set(streamId, handler)
+          return () => handlers.delete(streamId)
+        }
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'ready')).toBe(true)
+    )
+    handlers.get(0)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Subscribe,
+          streamId: 0,
+          seq: 1,
+          payload: encodeTerminalStreamJson({
+            streamId: 12,
+            terminal: 'terminal-1',
+            client: { id: 'desktop-1', type: 'desktop' },
+            viewport: { cols: 120, rows: 40 }
+          })
+        })
+      )!
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+    )
+    expect(runtime.serializeTerminalBuffer).toHaveBeenCalledWith('pty-1', {
+      scrollbackRows: 1000,
+      altScreenPreservesScrollback: true
+    })
+    const snapshotData = binaryFrames
+      .map((frame) => decodeTerminalStreamFrame(frame))
+      .filter((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotChunk)
+      .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+      .join('')
+    expect(snapshotData).toContain('PRE_CODEX_START')
+    expect(snapshotData).toContain('TUI_FRAME')
+
+    cleanups.get('terminal-multiplex:conn-desktop-alt-subscribe')?.()
+    await dispatchPromise
+  })
+
+  it('does not forward alternate-screen snapshot flag for mobile snapshot requests', async () => {
+    const messages: string[] = []
+    const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+    const handlers = new Map<
+      number,
+      (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+    >()
+    const cleanups = new Map<string, () => void>()
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+      serializeTerminalBuffer: vi.fn().mockResolvedValue({
+        data: 'snapshot',
+        cols: 120,
+        rows: 40
+      }),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
+      getTerminalFitOverride: vi.fn().mockReturnValue(null),
+      getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+      handleMobileSubscribe: vi.fn().mockResolvedValue(undefined),
+      handleMobileUnsubscribe: vi.fn().mockResolvedValue(undefined),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+      sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
+      updateDesktopViewport: vi.fn().mockResolvedValue(true)
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.multiplex', {}),
+      (msg) => messages.push(msg),
+      {
+        connectionId: 'conn-mobile-request',
+        sendBinary: (bytes) => binaryFrames.push(bytes),
+        registerBinaryStreamHandler: (streamId, handler) => {
+          handlers.set(streamId, handler)
+          return () => handlers.delete(streamId)
+        }
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'ready')).toBe(true)
+    )
+    handlers.get(0)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Subscribe,
+          streamId: 0,
+          seq: 1,
+          payload: encodeTerminalStreamJson({
+            streamId: 11,
+            terminal: 'terminal-1',
+            client: { id: 'phone-1', type: 'mobile' },
+            viewport: { cols: 120, rows: 40 }
+          })
+        })
+      )!
+    )
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+    )
+    handlers.get(11)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.SnapshotRequest,
+          streamId: 11,
+          seq: 2,
+          payload: encodeTerminalStreamJson({ requestId: 9, scrollbackRows: 5000 })
+        })
+      )!
+    )
+    await vi.waitFor(() => expect(runtime.serializeTerminalBuffer).toHaveBeenCalledTimes(2))
+    expect(runtime.serializeTerminalBuffer).toHaveBeenLastCalledWith('pty-1', {
+      scrollbackRows: 5000
+    })
+
+    cleanups.get('terminal-multiplex:conn-mobile-request')?.()
+    await dispatchPromise
   })
 
   it('drops stale mobile resize re-stream completions for multiplex streams', async () => {
@@ -657,10 +834,12 @@ describe('terminal multiplex RPC', () => {
       truncatedByByteBudget: true
     })
     expect(runtime.serializeTerminalBuffer).toHaveBeenNthCalledWith(2, 'pty-1', {
-      scrollbackRows: 5000
+      scrollbackRows: 5000,
+      altScreenPreservesScrollback: true
     })
     expect(runtime.serializeTerminalBuffer).toHaveBeenNthCalledWith(3, 'pty-1', {
-      scrollbackRows: 1000
+      scrollbackRows: 1000,
+      altScreenPreservesScrollback: true
     })
     expect(
       requestedFrames
@@ -935,6 +1114,80 @@ describe('terminal multiplex RPC', () => {
         interrupt: false
       })
     )
+
+    runtime.cleanupSubscription('terminal-1:desktop-1')
+    await dispatchPromise
+  })
+
+  it('preserves alternate-screen scrollback on desktop binary subscribe', async () => {
+    const messages: string[] = []
+    const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+    const cleanups = new Map<string, () => void>()
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+      serializeTerminalBuffer: vi.fn().mockResolvedValue({
+        data: 'PRE_CODEX_START\x1b[?1049hTUI_FRAME',
+        cols: 120,
+        rows: 40
+      }),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      isTerminalAlternateScreen: vi.fn().mockReturnValue(true),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      cleanupSubscription: vi.fn((id: string) => {
+        const cleanup = cleanups.get(id)
+        cleanups.delete(id)
+        cleanup?.()
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+      sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
+      updateDesktopViewport: vi.fn().mockResolvedValue(true)
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.subscribe', {
+        terminal: 'terminal-1',
+        client: { id: 'desktop-1', type: 'desktop' },
+        capabilities: { terminalBinaryStream: 1 }
+      }),
+      (msg) => messages.push(msg),
+      {
+        connectionId: 'conn-subscribe-desktop-alt',
+        sendBinary: (bytes) => binaryFrames.push(bytes),
+        registerBinaryStreamHandler: vi.fn(() => vi.fn())
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+    )
+    await vi.waitFor(() =>
+      expect(
+        binaryFrames.some(
+          (frame) => decodeTerminalStreamFrame(frame)?.opcode === TerminalStreamOpcode.SnapshotEnd
+        )
+      ).toBe(true)
+    )
+    expect(runtime.serializeTerminalBuffer).toHaveBeenCalledWith('pty-1', {
+      scrollbackRows: 1000,
+      altScreenPreservesScrollback: true
+    })
+    const snapshotData = binaryFrames
+      .map((frame) => decodeTerminalStreamFrame(frame))
+      .filter((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotChunk)
+      .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+      .join('')
+    expect(snapshotData).toContain('PRE_CODEX_START')
+    expect(snapshotData).toContain('TUI_FRAME')
 
     runtime.cleanupSubscription('terminal-1:desktop-1')
     await dispatchPromise

--- a/src/main/runtime/rpc/terminal-output-batching.test.ts
+++ b/src/main/runtime/rpc/terminal-output-batching.test.ts
@@ -15,6 +15,7 @@ import {
 function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeService {
   return {
     getRuntimeId: () => 'test-runtime',
+    isTerminalAlternateScreen: () => false,
     ...overrides
   } as OrcaRuntimeService
 }

--- a/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
@@ -15,6 +15,7 @@ import {
 function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeService {
   return {
     getRuntimeId: () => 'test-runtime',
+    isTerminalAlternateScreen: () => false,
     ...overrides
   } as OrcaRuntimeService
 }


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** If you use Orca over SSH (a remote machine), open a terminal, run some commands (like `ls`), and then start a full-screen tool like Codex or Claude in that same terminal — switching to another tab and back makes all your earlier command output vanish. The remote shell history you printed before launching the tool is silently thrown away; when you come back, you only see the current Codex/Claude screen and your prior `ls` results and prompts are gone. This hits anyone running a full-screen terminal app over SSH and switching tabs, which is a common workflow, so it's a real annoyance (lost context) rather than a crash.

**2) What this PR does (ELI5).** Think of the terminal as a notebook. When a full-screen app takes over, it flips to a fresh clean page (a "scratch page") to draw on, but your earlier notes are still in the notebook. The old code, when saving the terminal to restore it later, would tear out everything except that one scratch page. This PR teaches the desktop restore path to keep the earlier pages too — so when you switch back, your pre-tool command history is still there. It also re-attaches a small "mouse precision" setting that the save process used to drop, so clicking in big full-screen apps keeps working accurately. Oh, so it now *keeps your earlier shell output when you restore a tab* instead of *wiping it the moment a full-screen app was running*.

**3) Tradeoffs / regressions — honest answer.** No regressions for existing desktop or mobile behavior. The fix is a narrowly gated desktop opt-in: the new "keep the history" mode turns on for desktop tab restore, and now also for first desktop attach when the PTY is already inside an alternate-screen TUI. Ordinary desktop subscribe snapshots stay on the existing zero-row path unless a full-screen app is active, and mobile replay is still explicitly opted out because its xterm re-wrap path would duplicate prompts / flatten SGR. The remaining cost is inherent to the fix: desktop snapshots for active TUIs can carry the user's earlier shell history across SSH instead of only the current TUI frame. That transfer is bounded by the existing snapshot byte budget and row fallback, so it is not unbounded.


---

## Summary

Fixes #6106.

When a desktop SSH terminal tab is hidden and then restored while an alternate-screen TUI (Codex/Claude/vim) is active, the restore snapshot dropped all the normal-buffer shell output that preceded the TUI — the user's pre-Codex `ls` output and prompts vanished and only the current TUI frame survived.

Two compounding daemon behaviors caused this on the hidden-restore path (`SnapshotRequest` → `serializeBudgetedRequestedSnapshot` → `serializeTerminalBuffer` → `serializeHeadlessTerminalBuffer` → `HeadlessEmulator.getSnapshot`):

1. `serializeHeadlessTerminalBuffer` forced `scrollbackRows=0` whenever the emulator was in alternate screen, so normal-buffer scrollback was never serialized.
2. `HeadlessEmulator.getSnapshot` ran `normalizeSnapshotAnsiForModes`, which (for alt-screen) slices off everything before the last `\x1b[?1049h`, deliberately discarding the normal-buffer content SerializeAddon emits before the alt buffer.

Both behaviors are correct for the **mobile** replay path (mobile xterm re-wraps and would duplicate prompts / flatten SGR), but wrong for the **desktop live SSH restore** path.

### Fix
Add a **desktop-only opt-in** (`altScreenPreservesScrollback` threaded through the RPC/runtime, `preserveNormalBufferOnAltScreen` at the emulator) that keeps the pre-TUI scrollback and returns the raw serializer output for desktop snapshots. The flag is used for desktop restore/requested snapshots, and for first desktop attach when the PTY is already in alternate screen. Mobile remains opted out, and ordinary desktop initial subscribe snapshots stay on the existing zero-row path unless an alternate-screen TUI is active.

Because the opt-in path returns the raw `serializer.serialize()` output, and `SerializeAddon._serializeModes` emits mouse **tracking** modes (`?1000h`/`?1002h`/`?1003h`) and bracketed paste but **not** SGR mouse **encoding** (`?1006h`/`?1016h`), the opt-in path now also re-appends the dropped encoding mode. Without this, a desktop TUI using SGR mouse encoding (common: Codex/Claude/OpenTUI) would lose `?1006h` on restore and degrade to legacy X10 mouse reports (breaking clicks past col/row 223). The raw blob already enters alt screen via its embedded `?1049h`, so only the encoding mode is appended — no duplicate alt-screen entry.

This supersedes community PR #6427 by @rodboev (its approach was adopted; credited via `Co-authored-by`). On top of that PR it adds: the SGR mouse-encoding restoration + regression test, a clearer `serializeBudgetedRequestedSnapshot` option-forwarding (no inverted default), and a WHY comment colocating the desktop-vs-mobile rationale. PR #6427 is left open.

## Screenshots

No visual screenshot from the Electron app: the bug lives entirely in the daemon-side terminal serialization, and a faithful end-to-end repro needs a running SSH-backed runtime (sshd was not reachable on `localhost` in this environment and there was no packaged build). Instead, a Node-level reproduction exercising the exact `HeadlessEmulator.getSnapshot` path is attached as a PR comment, showing the before/after, alongside unit tests that assert the regression directly.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (the three touched files: `headless-emulator.test.ts`, `orca-runtime.test.ts`, `terminal-multiplex.test.ts`)
- [ ] `pnpm build` (not run — no source other than these modules changed; CI covers build)
- [x] Added/updated regression tests (see below)

Tests added:
- `headless-emulator.test.ts`: opt-in preserves pre-alt-screen content; opt-in preserves SGR `?1006h` encoding when active without duplicating `?1049h`.
- `orca-runtime.test.ts`: `serializeTerminalBuffer` drops pre-TUI output by default but preserves it with `altScreenPreservesScrollback: true` (asserts `source: 'headless'`).
- `terminal-multiplex.test.ts`: desktop `SnapshotRequest` forwards `altScreenPreservesScrollback: true`; mobile `SnapshotRequest` does NOT forward the flag; desktop multiplex subscribe and legacy binary subscribe preserve pre-TUI scrollback on first attach when alternate screen is active.

## AI Review Report

Reviewed for correctness, edge cases, cross-platform behavior, and elegance.
- **Correctness**: opt-in is gated on `modes.alternateScreen`, so normal-buffer behavior is untouched. Desktop requested snapshots and desktop first-attach snapshots use the opt-in only while an alternate-screen TUI is active; mobile and normal desktop initial subscribe keep the existing normalized/zero-row behavior. Verified no other `serializeTerminalBuffer` caller (`serializeMainTerminalBuffer`, `serializeHiddenOutputRecoveryBuffer`) sets the new flag, so their behavior is unchanged.
- **Cross-platform (macOS/Linux/Windows)**: no keyboard shortcuts, path separators, or shell-specific behavior introduced — only ANSI mode sequences and option threading. SSH/remote is the primary target of this fix (the bug is SSH-specific) and is handled via the runtime's headless emulator, not local-only assumptions.
- **Provider-agnostic**: terminal serialization is unrelated to git providers; no GitHub-only assumptions.
- **Elegance**: extracted a shared `buildMouseEncodingSequence` reused by both `buildRehydrateSequences` and the opt-in path (removes duplication, keeps the file under the `max-lines` limit without any disable). Replaced PR #6427's inverted-default `altScreenPreservesScrollback === false ? ... : ...` with a straightforward spread that forwards the caller's intent.

## Security Audit

Treated the original community-PR author as potentially malicious and re-audited the adopted code.
- No network calls, `eval`, `child_process`, filesystem writes, secret access, or new dependencies.
- The change only threads optional booleans through existing serialization and emits well-known terminal mode sequences (`?1006h`/`?1016h`).
- The opt-in returns MORE of the user's own terminal buffer (pre-TUI scrollback) only for desktop (non-mobile) restore — no exfiltration, injection, or path-traversal surface; the data already belongs to the user's session.
- No IPC/auth surface touched. Clean.

## Notes

- Desktop first attach now preserves pre-TUI scrollback when the PTY is already in alternate screen, so the previous first-subscribe limitation is gone for the SSH desktop workflow.
- Mobile behavior and `normalizeSnapshotAnsiForModes` default behavior are deliberately unchanged because the mobile replay path re-wraps snapshots and would duplicate prompts / flatten SGR if it used the desktop raw snapshot.

Made with [Orca](https://github.com/stablyai/orca) 🐋
