### PR TITLE
fix: suppress false zero-dimensions terminal error for hidden panes (#6475)

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -92,6 +92,7 @@ import { isPrimarySelectionEnabled, readPrimarySelectionText } from '@/lib/prima
 import { APP_MENU_PASTE_EVENT } from '@/lib/app-menu-paste'
 import { WORKSPACE_FILE_PATH_MIME, WORKSPACE_FILE_PATHS_MIME } from '@/lib/workspace-file-drag'
 import { isTerminalSessionStateSaveFailure } from '../../../../shared/terminal-session-state-save-failure'
+import { isTerminalZeroDimensionsDiagnostic } from '../../../../shared/terminal-zero-dimensions-diagnostic'
 import {
   isSyntheticSinglePaneTitle,
   sanitizeTerminalLayoutPaneTitles
@@ -529,6 +530,12 @@ export default function TerminalPane({
       // Why: hidden startup measurement is only for first launch. Keeping it
       // after first visibility lets inactive agent tabs refit and SIGWINCH.
       setShouldMeasureHiddenStartup(false)
+    }
+    if (isVisible) {
+      // Why: a hidden pane that connected at 0×0 self-heals via the pane resize
+      // observer once shown, so clear that stale diagnostic. Scoped to the
+      // zero-dimensions message so genuine paste/save-failure errors survive.
+      setTerminalError((prev) => (prev && isTerminalZeroDimensionsDiagnostic(prev) ? null : prev))
     }
   }, [isVisible, shouldMeasureHiddenStartup])
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -654,6 +654,42 @@ describe('connectPanePty', () => {
     logSpy.mockRestore()
   }, 30_000)
 
+  // Why: orchestration workers and CLI `terminal create` (no --focus) mount
+  // hidden panes that legitimately connect at 0×0 and refit when shown, so the
+  // zero-dimensions diagnostic must stay silent while the pane is not visible.
+  it('does not surface the zero-dimensions diagnostic for a hidden pane', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    pane.terminal.cols = 0
+    pane.terminal.rows = 0
+    const deps = createDeps({ isVisibleRef: { current: false } })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+  })
+
+  it('still surfaces the zero-dimensions diagnostic for a visible pane', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    pane.terminal.cols = 0
+    pane.terminal.rows = 0
+    const deps = createDeps({ isVisibleRef: { current: true } })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+      pane.id,
+      expect.stringContaining('Terminal has zero dimensions (0×0)')
+    )
+  })
+
   it('threads the resolved local project runtime into IPC terminal transport options', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -10,6 +10,7 @@ import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
 import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
@@ -2095,11 +2096,12 @@ export function connectPanePty(
     // Why: if fitAddon resolved to 0×0, the container likely has no layout
     // dimensions (display:none, unmounted, or zero-size parent). Surface a
     // diagnostic so the user sees something instead of a blank pane.
-    if (cols === 0 || rows === 0) {
-      deps.onPtyErrorRef?.current?.(
-        pane.id,
-        `Terminal has zero dimensions (${cols}×${rows}). The pane container may not be visible.`
-      )
+    // Gate on visibility: background/hidden tabs (orchestration workers, CLI
+    // `terminal create` without --focus) legitimately connect at 0×0 because
+    // safeFit skips fitting unmeasurable panes; they refit via the pane resize
+    // observer once shown, so the diagnostic must not fire while hidden.
+    if ((cols === 0 || rows === 0) && deps.isVisibleRef.current) {
+      deps.onPtyErrorRef?.current?.(pane.id, createTerminalZeroDimensionsMessage(cols, rows))
     }
 
     const reportError = (message: string): void => {

--- a/src/shared/terminal-zero-dimensions-diagnostic.test.ts
+++ b/src/shared/terminal-zero-dimensions-diagnostic.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createTerminalZeroDimensionsMessage,
+  isTerminalZeroDimensionsDiagnostic
+} from './terminal-zero-dimensions-diagnostic'
+
+describe('terminal zero-dimensions diagnostic', () => {
+  it('round-trips its own message through the matcher', () => {
+    expect(isTerminalZeroDimensionsDiagnostic(createTerminalZeroDimensionsMessage(0, 0))).toBe(true)
+  })
+
+  it('does not match unrelated terminal errors', () => {
+    expect(isTerminalZeroDimensionsDiagnostic('Paste failed.')).toBe(false)
+    expect(isTerminalZeroDimensionsDiagnostic('Failed to save terminal session state')).toBe(false)
+  })
+})

--- a/src/shared/terminal-zero-dimensions-diagnostic.ts
+++ b/src/shared/terminal-zero-dimensions-diagnostic.ts
@@ -1,0 +1,11 @@
+// Why: the zero-dimensions diagnostic is emitted by the renderer's PTY connect
+// path and later cleared once a hidden pane becomes visible and refits. Keeping
+// the message text and its matcher together lets both sites stay in sync.
+
+export function createTerminalZeroDimensionsMessage(cols: number, rows: number): string {
+  return `Terminal has zero dimensions (${cols}×${rows}). The pane container may not be visible.`
+}
+
+export function isTerminalZeroDimensionsDiagnostic(message: string): boolean {
+  return message.startsWith('Terminal has zero dimensions (')
+}


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** When you use Orca's orchestration to spin up a "worker" sub-agent (a helper terminal that runs in a background tab while you keep working in your current one), that brand-new worker terminal pops up with a scary red error: "Terminal renderer error — Terminal has zero dimensions (0×0). The pane container may not be visible." The terminal itself actually works fine once you click over to it — the error is a false alarm — but it looks broken every single time you launch a worker. This hits anyone using orchestration sub-agents (the same path the CLI's `terminal create` uses without focus). Normal agent terminals you open yourself are unaffected. So: not a crash, but a consistent, confidence-eroding "is this thing broken?" annoyance on a feature that's supposed to feel automatic.

**2) What this PR does (ELI5).** A terminal needs to know its size (how many rows and columns of text fit) to draw itself. A worker tab is created in the background — it's not on screen yet — so it genuinely has a size of "0 by 0" for a moment, which is totally normal: it measures and fixes itself the instant you switch to it. The old code shouted the "zero dimensions!" warning unconditionally, even for these off-screen tabs that were going to size themselves correctly anyway, and never took the warning back down. This PR teaches the warning to check first: "Is this terminal actually visible on screen right now?" If it's an off-screen worker that legitimately hasn't been measured yet, stay quiet. And as a safety net, if the warning did somehow stick around, it's automatically cleared the moment the tab becomes visible and resizes properly. Oh, so it now only complains when a terminal is genuinely on-screen and still has no size — instead of complaining about every background worker that was perfectly healthy.

**3) Tradeoffs / regressions — honest answer.** No regressions — nothing is disabled, no new setup, no behavior is lost. This does not turn off any feature, flag, or fast path; terminals still size and render exactly as before. The only behavior change is *when the diagnostic message appears*: it's now gated on the pane actually being visible. The one thing worth naming honestly is that this is a "suppress the false alarm" fix rather than a "make workers visible" fix — a genuinely broken visible terminal still correctly shows the error (a regression test locks this in: reverting the guard makes a visible-pane test fail). The author deliberately chose NOT to also force worker terminals to grab focus/activate on launch, because that would make background workers rudely steal your screen on every orchestration tick — a worse UX trade than the harmless background 0×0 state. The error-clearing safety net is narrowly scoped (it only matches the zero-dimensions message via a shared matcher), so real errors like paste failures or session-save failures are left untouched. Net: macOS reporter's symptom goes away, every platform benefits equally, and no user loses anything.

---

## Summary

Fixes #6475

Orchestration subagent worker terminals showed a persistent "terminal renderer error" overlay reading `Terminal has zero dimensions (0×0). The pane container may not be visible.`

Root cause: the orchestration coordinator creates workers via `runtime.createTerminal(worktree, { title })` (and the CLI `terminal create` without `--focus`) with `focus`/`activate` unset, so the renderer mounts the worker tab **hidden**. Its `TerminalPane` opens xterm into a `display:none`/zero-size container, `safeFit` deliberately bails for that unmeasurable pane (leaving xterm at 0×0), and the PTY-connect `requestAnimationFrame` then fired the zero-dimensions diagnostic **unconditionally** — even though the pane self-heals via the pane resize observer once it becomes visible. The overlay was never cleared on a successful refit, so it stuck.

Fix (renderer, at the actual defect — transport/provider/OS agnostic):
- Gate the zero-dimensions diagnostic on `deps.isVisibleRef.current` in `connectPanePty`, so it only fires when the pane is actually on-screen and genuinely expected to have geometry. Background/hidden tabs (orchestration workers, headless `terminal create`) legitimately connect at 0×0 and refit when shown.
- Belt-and-suspenders: when a hidden pane becomes visible (the existing `isVisible` `useLayoutEffect`), clear any stale zero-dimensions diagnostic. Scoped via a shared matcher so genuine paste / session-save-failure errors are untouched.

A normal agent terminal (created with `activate`/`focus = true`) is visible/measurable when its pane connects, so it never hit this path and is unaffected.

## Screenshots

Visual symptom; see PR comment for Electron evidence and an explanation of the environment limitation (the dev runtime's node-pty daemon in this sandbox is globally broken — pinned to a deleted worktree — which blocks all PTY spawns, so the live worker-terminal repro could not be driven end-to-end here). The defect and fix live entirely in the renderer's `connectPanePty` seam, which is fully covered by unit tests, including a verified regression-catch (reverting the guard fails the new hidden-pane test).

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck` (scoped: `tsgo -p config/tsconfig.tc.web.json` and `config/tsconfig.node.json` — both clean)
- [x] `pnpm test` (scoped: `pty-connection.test.ts` + new `terminal-zero-dimensions-diagnostic.test.ts` — 201 passed)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions
- [x] `oxlint` on all changed files — clean

Scoped lint/typecheck/test were run on the changed files (see PR comment for output). Full `pnpm lint`/`typecheck`/`build` not run wholesale.

## AI Review Report

Reviewed adversarially for correctness, edge cases, cross-platform, security, and elegance:
- Correctness: the guard only suppresses the diagnostic for hidden panes (the bug); visible panes with genuine zero geometry still report it (regression-guarded by a new unit test). The stale-error clear only runs when the pane turns visible and only matches the zero-dimensions message via a shared matcher, so real paste/save-failure errors survive.
- Cross-platform (macOS/Linux/Windows): explicitly checked — no `metaKey`, no path separators, no shell behavior. The change only gates an existing renderer diagnostic on an already-wired visibility ref (`deps.isVisibleRef`, used throughout the same function). The `×` glyph was preserved via a shared message builder. No Electron platform-specific surface touched.
- SSH/remote: the fix is at the renderer pane-mount seam, transport-agnostic (covers both IPC and remote-runtime PTY transports).
- Git providers: no GitHub/GitLab coupling.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The new `src/shared/terminal-zero-dimensions-diagnostic.ts` is pure string construction/matching with no I/O, no `eval`, and no new dependencies. No new IPC channels or RPC methods. No exfiltration or injection surface. Follow-up: none.

## Notes

Platform-agnostic renderer change; no special platform behavior.

Deliberately did **not** change `src/main/runtime/orchestration/coordinator.ts` to pass `activate: true` for worker terminals. That was an optional complementary change in the plan, but forcing workers to steal activation each tick would change orchestration UX, and the renderer guard already fixes the reported error for **all** background-tab callers. See "Future suggestions" below.

### Future suggestions
- Optionally make orchestration worker terminals observable-by-default by widening `CoordinatorRuntime.createTerminal` opts to include `activate?: boolean` and passing it through, if product wants workers to auto-surface. The renderer guard makes this purely a UX choice, not a correctness fix.

Made with [Orca](https://github.com/stablyai/orca) 🐋