### PR TITLE
feat(codex): opt-in to use default ~/.codex config dir (fixes auth revocation war, supersedes #5594)

### DIFF
--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -77,6 +77,17 @@ export function isAgentStatusHooksEnabled(
   return settings?.agentStatusHooksEnabled !== false
 }
 
+/**
+ * Why: opt-in setting that makes Codex use its default config home (~/.codex)
+ * by skipping the managed CODEX_HOME injection. Default off (undefined/false)
+ * keeps Orca's managed runtime home and its account hot-swap behavior.
+ */
+export function isCodexDefaultHomeEnabled(
+  settings: Pick<GlobalSettings, 'codexUseDefaultConfigDir'> | null | undefined
+): boolean {
+  return settings?.codexUseDefaultConfigDir === true
+}
+
 export function installManagedAgentHooks(): void {
   for (const [agent, install] of MANAGED_AGENT_HOOK_INSTALLERS) {
     try {

--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -78,9 +78,9 @@ export function isAgentStatusHooksEnabled(
 }
 
 /**
- * Why: opt-in setting that makes Codex use its default config home (~/.codex)
- * by skipping the managed CODEX_HOME injection. Default off (undefined/false)
- * keeps Orca's managed runtime home and its account hot-swap behavior.
+ * Why: opt-in setting that makes host Codex use its default config home
+ * (~/.codex) by skipping managed CODEX_HOME injection. Default off
+ * (undefined/false) keeps Orca's managed runtime home and account switching.
  */
 export function isCodexDefaultHomeEnabled(
   settings: Pick<GlobalSettings, 'codexUseDefaultConfigDir'> | null | undefined

--- a/src/main/codex-accounts/inactive-codex-rate-limit-accounts.test.ts
+++ b/src/main/codex-accounts/inactive-codex-rate-limit-accounts.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultSettings } from '../../shared/constants'
+import type { CodexManagedAccount, GlobalSettings } from '../../shared/types'
+import { getInactiveCodexRateLimitAccounts } from './inactive-codex-rate-limit-accounts'
+
+function makeAccount(
+  id: string,
+  overrides: Partial<CodexManagedAccount> = {}
+): CodexManagedAccount {
+  return {
+    id,
+    email: `${id}@example.com`,
+    managedHomePath: `/tmp/orca/codex-accounts/${id}/home`,
+    managedHomeRuntime: 'host',
+    wslDistro: null,
+    wslLinuxHomePath: null,
+    providerAccountId: null,
+    workspaceLabel: null,
+    workspaceAccountId: null,
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeSettings(overrides: Partial<GlobalSettings>): GlobalSettings {
+  return {
+    ...getDefaultSettings('/tmp'),
+    ...overrides
+  }
+}
+
+describe('getInactiveCodexRateLimitAccounts', () => {
+  it('returns inactive host managed accounts when default-home mode is off', () => {
+    const settings = makeSettings({
+      codexManagedAccounts: [makeAccount('active-host'), makeAccount('inactive-host')],
+      activeCodexManagedAccountId: 'active-host',
+      activeCodexManagedAccountIdsByRuntime: { host: 'active-host', wsl: {} },
+      codexUseDefaultConfigDir: false
+    })
+
+    expect(getInactiveCodexRateLimitAccounts(settings)).toEqual([
+      { id: 'inactive-host', managedHomePath: '/tmp/orca/codex-accounts/inactive-host/home' }
+    ])
+  })
+
+  it('skips host managed homes when default-home mode is on but keeps WSL previews', () => {
+    const wslHome = '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex\\home'
+    const settings = makeSettings({
+      codexManagedAccounts: [
+        makeAccount('active-host'),
+        makeAccount('inactive-host'),
+        makeAccount('inactive-wsl', {
+          managedHomePath: wslHome,
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxHomePath: '/home/alice/.local/share/orca/codex/home'
+        })
+      ],
+      activeCodexManagedAccountId: 'active-host',
+      activeCodexManagedAccountIdsByRuntime: { host: 'active-host', wsl: {} },
+      codexUseDefaultConfigDir: true
+    })
+
+    expect(getInactiveCodexRateLimitAccounts(settings)).toEqual([
+      { id: 'inactive-wsl', managedHomePath: wslHome }
+    ])
+  })
+})

--- a/src/main/codex-accounts/inactive-codex-rate-limit-accounts.ts
+++ b/src/main/codex-accounts/inactive-codex-rate-limit-accounts.ts
@@ -1,0 +1,37 @@
+import type { GlobalSettings } from '../../shared/types'
+import { normalizeCodexRuntimeSelection } from './runtime-selection'
+
+export type InactiveCodexRateLimitAccount = {
+  id: string
+  managedHomePath: string
+}
+
+type InactiveCodexRateLimitAccountSettings = Pick<
+  GlobalSettings,
+  | 'activeCodexManagedAccountId'
+  | 'activeCodexManagedAccountIdsByRuntime'
+  | 'codexManagedAccounts'
+  | 'codexUseDefaultConfigDir'
+>
+
+export function getInactiveCodexRateLimitAccounts(
+  settings: InactiveCodexRateLimitAccountSettings
+): InactiveCodexRateLimitAccount[] {
+  const selection = normalizeCodexRuntimeSelection(settings)
+  const activeIds = new Set(
+    [selection.host, ...Object.values(selection.wsl)].filter((id): id is string => Boolean(id))
+  )
+  const hostManagedHomesPaused = settings.codexUseDefaultConfigDir === true
+
+  return settings.codexManagedAccounts
+    .filter((account) => !activeIds.has(account.id))
+    .filter((account) => {
+      if (!hostManagedHomesPaused) {
+        return true
+      }
+      // Why: default-home mode exists to stop host managed homes from refreshing
+      // tokens behind the user's ~/.codex session; WSL homes are a separate runtime.
+      return account.managedHomeRuntime === 'wsl'
+    })
+    .map((account) => ({ id: account.id, managedHomePath: account.managedHomePath }))
+}

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -736,6 +736,47 @@ describe('CodexRuntimeHomeService', () => {
     expect(existsSync(getRuntimeCodexHomePath())).toBe(true)
   })
 
+  it('targets the default ~/.codex home for launch and quota fetch when the opt-in is on', async () => {
+    // Why: closes the background revocation gap — when codexUseDefaultConfigDir
+    // is on, the quota poller and any host launch must resolve null (the system
+    // ~/.codex home) instead of spawning Codex against the managed runtime home,
+    // which would refresh and revoke the user's single-OAuth-session token.
+    const managedHomePath = createManagedAuth(
+      testState.userDataDir,
+      'account-1',
+      createCodexAuthJson('one@example.com', 'acct-1', 'one')
+    )
+    const store = createStore(
+      createSettings({
+        codexUseDefaultConfigDir: true,
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'one@example.com',
+            managedHomePath,
+            providerAccountId: 'acct-1',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-1',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountId: 'account-1',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+      })
+    )
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    // Why: null is how callers (pty env build, rate-limit fetcher, commit-msg
+    // agent) resolve the system ~/.codex home instead of an Orca-managed
+    // CODEX_HOME, so the background poller never spawns Codex against the
+    // managed home and never refreshes/revokes the ~/.codex OAuth session.
+    expect(service.prepareForRateLimitFetch()).toBeNull()
+    expect(service.prepareForCodexLaunch()).toBeNull()
+  })
+
   it('uses the same host CODEX_HOME after switching managed Codex accounts', async () => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()
     const account1Auth = createCodexAuthJson('one@example.com', 'acct-1', 'one')

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -136,6 +136,14 @@ export class CodexRuntimeHomeService {
         this.getWslSystemCodexHomePath(wslTarget)
       )
     }
+    // Why: with the default-home opt-in, every host Codex launch (terminals,
+    // commit-message agent) must resolve ~/.codex. Returning null tells callers
+    // to inject no CODEX_HOME, and skipping the managed-home sync means Orca
+    // never spawns Codex against the managed home to drive a token refresh that
+    // would revoke the user's single-OAuth-session ~/.codex login.
+    if (this.isDefaultConfigDirEnabled()) {
+      return null
+    }
     this.syncForCurrentSelection()
     syncSystemCodexResourcesIntoManagedHome()
     syncSystemConfigIntoManagedCodexHome()
@@ -189,10 +197,22 @@ export class CodexRuntimeHomeService {
         this.getWslSystemCodexHomePath(wslTarget)
       )
     }
+    // Why: when the user opts into the default ~/.codex home, the background
+    // quota poller must NOT spawn Codex against the managed home — doing so
+    // refreshes the managed home's single-use OAuth token and revokes the
+    // ~/.codex session. Return null so the fetcher targets the system home and
+    // skip the managed-home sync entirely (no auth.json read-back to mutate).
+    if (this.isDefaultConfigDirEnabled()) {
+      return null
+    }
     this.syncForCurrentSelection()
     syncSystemCodexResourcesIntoManagedHome()
     syncSystemConfigIntoManagedCodexHome()
     return this.getRuntimeHomePath()
+  }
+
+  private isDefaultConfigDirEnabled(): boolean {
+    return this.store.getSettings().codexUseDefaultConfigDir === true
   }
 
   syncForCurrentSelection(target?: CodexAccountSelectionTarget): void {

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -1368,6 +1368,101 @@ describe('CodexAccountService config sync', () => {
     })
   })
 
+  it('pauses host managed account mutations in default-home mode while allowing WSL selection', async () => {
+    vi.resetModules()
+    const spawnMock = vi.fn()
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(),
+      spawn: spawnMock
+    }))
+
+    const hostManagedHomePath = createManagedHome(
+      testState.userDataDir,
+      'host-account',
+      '',
+      '{"account":"host"}\n'
+    )
+    const wslManagedHomePath =
+      '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-accounts\\wsl-account\\home'
+    const settings = createSettings({
+      codexUseDefaultConfigDir: true,
+      codexManagedAccounts: [
+        {
+          id: 'host-account',
+          email: 'host@example.com',
+          managedHomePath: hostManagedHomePath,
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          wslLinuxHomePath: null,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        },
+        {
+          id: 'wsl-account',
+          email: 'wsl@example.com',
+          managedHomePath: wslManagedHomePath,
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/wsl-account/home',
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 2,
+          updatedAt: 2,
+          lastAuthenticatedAt: 2
+        }
+      ],
+      activeCodexManagedAccountId: 'host-account',
+      activeCodexManagedAccountIdsByRuntime: {
+        host: 'host-account',
+        wsl: {}
+      }
+    })
+    const store = createStore(settings)
+    const rateLimits = createRateLimits()
+    const runtimeHome = createRuntimeHome()
+
+    const { CodexAccountService } = await import('./service')
+    const service = new CodexAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeHome as never
+    )
+
+    await expect(service.addAccount()).rejects.toThrow('Host managed Codex accounts are paused')
+    await expect(service.reauthenticateAccount('host-account')).rejects.toThrow(
+      'Host managed Codex accounts are paused'
+    )
+    await expect(
+      service.selectAccountForTarget('host-account', { runtime: 'host' })
+    ).rejects.toThrow('Host managed Codex accounts are paused')
+    await expect(service.selectAccountForTarget(null, { runtime: 'host' })).rejects.toThrow(
+      'Host managed Codex accounts are paused'
+    )
+
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(runtimeHome.syncForCurrentSelection).not.toHaveBeenCalled()
+
+    const result = await service.selectAccountForTarget('wsl-account', {
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu'
+    })
+
+    expect(result.activeAccountId).toBe('host-account')
+    expect(result.activeAccountIdsByRuntime).toEqual({
+      host: 'host-account',
+      wsl: { Ubuntu: 'wsl-account' }
+    })
+    expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledWith({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu'
+    })
+  })
+
   it('removes an account and cleans up managed home', async () => {
     const managedHomePath = createManagedHome(
       testState.userDataDir,

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -34,6 +34,8 @@ import {
 
 const LOGIN_TIMEOUT_MS = 120_000
 const MAX_LOGIN_OUTPUT_CHARS = 4_000
+const HOST_MANAGED_ACCOUNTS_PAUSED_MESSAGE =
+  'Host managed Codex accounts are paused while Use default Codex config directory is enabled.'
 
 type CodexOAuthCredentials = {
   idToken: string | null
@@ -112,11 +114,13 @@ export class CodexAccountService {
   }
 
   private async doAddAccount(target?: CodexAccountAddTarget): Promise<CodexRateLimitAccountsState> {
+    this.assertHostManagedAccountsAvailable(target)
     const accountId = randomUUID()
     const managedHome = this.createManagedHome(accountId, target)
     const { managedHomePath } = managedHome
 
     try {
+      this.assertHostManagedHomeAvailable(managedHome)
       this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath)
       await this.runCodexLogin(managedHomePath)
       const identity = this.readIdentityFromHome(managedHomePath)
@@ -170,6 +174,7 @@ export class CodexAccountService {
 
   private async doReauthenticateAccount(accountId: string): Promise<CodexRateLimitAccountsState> {
     const account = this.requireAccount(accountId)
+    this.assertHostManagedAccountsAvailable(getCodexSelectionTargetForAccount(account))
     const managedHomePath = this.ensureManagedHomeForReauthentication(account)
 
     this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath)
@@ -268,6 +273,7 @@ export class CodexAccountService {
     const selection = normalizeCodexRuntimeSelection(previousSettings)
     const outgoingAccountId = getSelectedCodexAccountIdForTarget(previousSettings, effectiveTarget)
     const nextSelection = setSelectedCodexAccountIdForTarget(selection, accountId, effectiveTarget)
+    this.assertHostManagedAccountsAvailable(effectiveTarget)
 
     this.store.updateSettings({
       activeCodexManagedAccountId:
@@ -279,6 +285,29 @@ export class CodexAccountService {
 
     await this.rateLimits.refreshForCodexAccountChange(outgoingAccountId, effectiveTarget)
     return this.getSnapshot()
+  }
+
+  private assertHostManagedAccountsAvailable(
+    target?: CodexAccountSelectionTarget | CodexAccountAddTarget | null
+  ): void {
+    if (this.store.getSettings().codexUseDefaultConfigDir !== true) {
+      return
+    }
+    if (normalizeCodexAccountSelectionTarget(target).runtime === 'wsl') {
+      return
+    }
+    // Why: the opt-in must never let a stale renderer path spawn Codex against
+    // a host managed home, or it can re-trigger the ~/.codex token revocation war.
+    throw new Error(HOST_MANAGED_ACCOUNTS_PAUSED_MESSAGE)
+  }
+
+  private assertHostManagedHomeAvailable(managedHome: ManagedHomeLocation): void {
+    if (
+      this.store.getSettings().codexUseDefaultConfigDir === true &&
+      managedHome.managedHomeRuntime === 'host'
+    ) {
+      throw new Error(HOST_MANAGED_ACCOUNTS_PAUSED_MESSAGE)
+    }
   }
 
   private getSnapshot(): CodexRateLimitAccountsState {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -77,16 +77,14 @@ import { ensureWindowsUserDataAclGrant } from './startup/windows-user-data-acl'
 import { RateLimitService } from './rate-limits/service'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
+import { getInactiveCodexRateLimitAccounts } from './codex-accounts/inactive-codex-rate-limit-accounts'
 import { attachMainWindowServices } from './window/attach-main-window-services'
 import { createMainWindow, loadMainWindow } from './window/createMainWindow'
 import { createSystemTray, destroySystemTray } from './tray/system-tray'
 import { focusExistingMainWindow } from './window/focus-existing-window'
 import { CodexAccountService } from './codex-accounts/service'
 import { CodexRuntimeHomeService } from './codex-accounts/runtime-home-service'
-import {
-  normalizeCodexRuntimeSelection,
-  type CodexAccountSelectionTarget
-} from './codex-accounts/runtime-selection'
+import type { CodexAccountSelectionTarget } from './codex-accounts/runtime-selection'
 import { normalizeClaudeRuntimeSelection } from './claude-accounts/runtime-selection'
 import { codexHookService } from './codex/hook-service'
 import { ClaudeAccountService } from './claude-accounts/service'
@@ -1362,16 +1360,7 @@ app.whenReady().then(async () => {
       }))
   })
   rateLimits.setInactiveCodexAccountsResolver(() => {
-    const settings = store!.getSettings()
-    const activeIds = new Set(
-      [
-        normalizeCodexRuntimeSelection(settings).host,
-        ...Object.values(normalizeCodexRuntimeSelection(settings).wsl)
-      ].filter(Boolean)
-    )
-    return settings.codexManagedAccounts
-      .filter((account) => !activeIds.has(account.id))
-      .map((account) => ({ id: account.id, managedHomePath: account.managedHomePath }))
+    return getInactiveCodexRateLimitAccounts(store!.getSettings())
   })
   const runtimeService = new OrcaRuntimeService(store, stats, {
     // Why: resolve the PTY provider lazily. initDaemonPtyProvider() runs later

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -547,6 +547,7 @@ describe('registerPtyHandlers', () => {
     getSettings?: () => {
       enableGitHubAttribution?: boolean
       agentStatusHooksEnabled?: boolean
+      codexUseDefaultConfigDir?: boolean
       httpProxyUrl?: string
       httpProxyBypassRules?: string
     },
@@ -693,6 +694,34 @@ describe('registerPtyHandlers', () => {
 
     it('injects the selected Codex home into Orca terminal PTYs', async () => {
       const env = await spawnAndGetEnv(undefined, undefined, () => TEST_CODEX_HOME)
+      expect(env.CODEX_HOME).toBe(TEST_CODEX_HOME)
+      expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
+    })
+
+    it('skips the managed Codex home when codexUseDefaultConfigDir is enabled', async () => {
+      // Why: the opt-in setting must force Codex back to its default ~/.codex
+      // home by injecting NO CODEX_HOME, even though a managed home is selected
+      // (getSelectedCodexHomePath returns TEST_CODEX_HOME here). Any ambient
+      // CODEX_HOME/ORCA_CODEX_HOME must also be stripped, not left to leak in.
+      const env = await spawnAndGetEnv(
+        { CODEX_HOME: '/tmp/ambient-codex-home', ORCA_CODEX_HOME: '/tmp/ambient-orca-codex-home' },
+        undefined,
+        () => TEST_CODEX_HOME,
+        () => ({ codexUseDefaultConfigDir: true })
+      )
+      expect(env.CODEX_HOME).toBeUndefined()
+      expect(env.ORCA_CODEX_HOME).toBeUndefined()
+    })
+
+    it('still injects the managed Codex home when codexUseDefaultConfigDir is off', async () => {
+      // Why: guards the OR condition wired into skipCodexHomeEnv — a false (or
+      // absent) setting must preserve the existing managed-home injection.
+      const env = await spawnAndGetEnv(
+        undefined,
+        undefined,
+        () => TEST_CODEX_HOME,
+        () => ({ codexUseDefaultConfigDir: false })
+      )
       expect(env.CODEX_HOME).toBe(TEST_CODEX_HOME)
       expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
     })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -30,7 +30,10 @@ import {
   getFirstCommandToken
 } from '../../shared/command-token-scanner'
 import { agentHookServer } from '../agent-hooks/server'
-import { isAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
+import {
+  isAgentStatusHooksEnabled,
+  isCodexDefaultHomeEnabled
+} from '../agent-hooks/managed-agent-hook-controls'
 import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
 import { detectPiAgentKindFromCommand, type PiAgentKind } from '../../shared/pi-agent-kind'
 import { isPwshAvailable } from '../pwsh'
@@ -1222,7 +1225,9 @@ export function registerPtyHandlers(
           isPackaged: app.isPackaged,
           userDataPath: app.getPath('userData'),
           selectedCodexHomePath,
-          skipCodexHomeEnv: ctx?.isWsl === true && !selectedCodexHomePath,
+          skipCodexHomeEnv:
+            isCodexDefaultHomeEnabled(getSettings?.()) ||
+            (ctx?.isWsl === true && !selectedCodexHomePath),
           githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? false,
           launchCommand: ctx?.command,
           shellPath: ctx?.shellPath,
@@ -1833,9 +1838,10 @@ export function registerPtyHandlers(
           )
         : null
       const skipCodexHomeEnv =
-        isDaemonHostSpawn &&
-        shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, args.cwd) &&
-        !selectedCodexHomePath
+        isCodexDefaultHomeEnabled(getSettings?.()) ||
+        (isDaemonHostSpawn &&
+          shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, args.cwd) &&
+          !selectedCodexHomePath)
       if (isDaemonHostSpawn && sessionId) {
         if (!isSafePtySessionId(sessionId, app.getPath('userData'))) {
           throw new Error('Invalid PTY session id')
@@ -2475,9 +2481,10 @@ export function registerPtyHandlers(
           )
         : null
       const skipCodexHomeEnv =
-        isDaemonHostSpawn &&
-        shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, args.cwd) &&
-        !selectedCodexHomePath
+        isCodexDefaultHomeEnabled(getSettings?.()) ||
+        (isDaemonHostSpawn &&
+          shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, args.cwd) &&
+          !selectedCodexHomePath)
       if (isDaemonHostSpawn) {
         if (effectiveSessionId === undefined) {
           // Should be unreachable: the expression above returns a string when

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -28,7 +28,7 @@ import {
   getAccountsPaneSearchEntries
 } from './accounts-search'
 import { SearchableSetting } from './SearchableSetting'
-import { SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
+import { SettingsRow, SettingsSegmentedControl, SettingsSwitchRow } from './SettingsFormControls'
 import { matchesSettingsSearch } from './settings-search'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import {
@@ -1108,6 +1108,40 @@ export function AccountsPane({
               })
             )}
           </div>
+        </SearchableSetting>
+
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.AccountsPane.2eb471df34',
+            'Use default Codex config directory'
+          )}
+          description={translate(
+            'auto.components.settings.AccountsPane.e321640e44',
+            "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
+          )}
+          keywords={['codex', 'config', 'directory', 'home', 'managed', 'default', 'account']}
+          className="space-y-3 py-2"
+        >
+          <SettingsSwitchRow
+            label={translate(
+              'auto.components.settings.AccountsPane.2eb471df34',
+              'Use default Codex config directory'
+            )}
+            description={translate(
+              'auto.components.settings.AccountsPane.e321640e44',
+              "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
+            )}
+            checked={settings.codexUseDefaultConfigDir === true}
+            onChange={() =>
+              updateSettings({
+                codexUseDefaultConfigDir: settings.codexUseDefaultConfigDir !== true
+              })
+            }
+            ariaLabel={translate(
+              'auto.components.settings.AccountsPane.2eb471df34',
+              'Use default Codex config directory'
+            )}
+          />
         </SearchableSetting>
       </section>
     ) : null,

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -260,6 +260,8 @@ export function AccountsPane({
     wslDistros,
     wslCapabilitiesLoading
   )
+  const hostCodexDefaultHomeEnabled =
+    settings.codexUseDefaultConfigDir === true && accountRuntime.runtime === 'host'
 
   const [codexAccounts, setCodexAccounts] = useState<CodexRateLimitAccountsState>({
     accounts: [],
@@ -286,7 +288,11 @@ export function AccountsPane({
   const visibleCodexAccounts = codexAccounts.accounts.filter((account) =>
     accountMatchesRuntime(account, accountRuntime)
   )
-  const activeCodexAccountId = getActiveCodexAccountIdForRuntime(codexAccounts, accountRuntime)
+  const configuredActiveCodexAccountId = getActiveCodexAccountIdForRuntime(
+    codexAccounts,
+    accountRuntime
+  )
+  const activeCodexAccountId = hostCodexDefaultHomeEnabled ? null : configuredActiveCodexAccountId
   const activeClaudeAccountId = getActiveClaudeAccountIdForRuntime(claudeAccounts, accountRuntime)
   const activeCodexAuthWarning = codexAccountsLoaded
     ? getCodexAccountAuthWarning({
@@ -479,13 +485,17 @@ export function AccountsPane({
     action: typeof codexAction,
     operation: () => Promise<CodexRateLimitAccountsState>
   ): Promise<void> => {
-    const previousActiveAccountId = getActiveCodexAccountIdForRuntime(codexAccounts, accountRuntime)
+    const previousActiveAccountId = hostCodexDefaultHomeEnabled
+      ? null
+      : getActiveCodexAccountIdForRuntime(codexAccounts, accountRuntime)
     setCodexAction(action)
     try {
       const next = await operation()
       await syncCodexAccounts(next)
       recordFeatureInteraction('codex-account-switching')
-      const nextActiveAccountId = getActiveCodexAccountIdForRuntime(next, accountRuntime)
+      const nextActiveAccountId = hostCodexDefaultHomeEnabled
+        ? null
+        : getActiveCodexAccountIdForRuntime(next, accountRuntime)
       const shouldPromptRestart =
         action === 'adding' ||
         (action.startsWith('select:') && previousActiveAccountId !== nextActiveAccountId) ||
@@ -854,11 +864,16 @@ export function AccountsPane({
                 {translate('auto.components.settings.AccountsPane.94d351af4a', 'Accounts')}
               </Label>
               <p className="text-xs text-muted-foreground">
-                {translate(
-                  'auto.components.settings.AccountsPane.c0a52abfc5',
-                  'Showing accounts for {{value0}}. New accounts are added there.',
-                  { value0: accountRuntime.label }
-                )}
+                {hostCodexDefaultHomeEnabled
+                  ? translate(
+                      'auto.components.settings.AccountsPane.4f3a6c2d19',
+                      'Host managed Codex accounts are paused while default ~/.codex is enabled. WSL accounts still use managed homes.'
+                    )
+                  : translate(
+                      'auto.components.settings.AccountsPane.c0a52abfc5',
+                      'Showing accounts for {{value0}}. New accounts are added there.',
+                      { value0: accountRuntime.label }
+                    )}
               </p>
             </div>
             <Button
@@ -873,7 +888,10 @@ export function AccountsPane({
                 )
               }
               disabled={
-                codexAction !== 'idle' || wslCapabilitiesLoading || accountRuntimeUnavailable
+                codexAction !== 'idle' ||
+                wslCapabilitiesLoading ||
+                accountRuntimeUnavailable ||
+                hostCodexDefaultHomeEnabled
               }
               className="gap-1.5"
             >
@@ -898,7 +916,9 @@ export function AccountsPane({
                   })
                 )
               }
-              disabled={codexAction !== 'idle' || accountRuntimeUnavailable}
+              disabled={
+                codexAction !== 'idle' || accountRuntimeUnavailable || hostCodexDefaultHomeEnabled
+              }
               className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
                 systemCodexNeedsReauthentication
                   ? 'border-destructive/50 bg-destructive/5'
@@ -976,6 +996,7 @@ export function AccountsPane({
                 const isReauthing = codexAction === `reauth:${account.id}`
                 const isRemoving = codexAction === `remove:${account.id}`
                 const isBusy = codexAction !== 'idle' || accountRuntimeUnavailable
+                const isManagedActionPaused = hostCodexDefaultHomeEnabled
 
                 return (
                   <div
@@ -1000,7 +1021,7 @@ export function AccountsPane({
                             })
                           )
                         }
-                        disabled={isBusy}
+                        disabled={isBusy || isManagedActionPaused}
                         className="flex min-w-0 flex-1 flex-col gap-0.5 text-left disabled:cursor-default"
                       >
                         <div className="flex min-w-0 items-center gap-2">
@@ -1071,7 +1092,7 @@ export function AccountsPane({
                               window.api.codexAccounts.reauthenticate({ accountId: account.id })
                             )
                           }}
-                          disabled={isBusy}
+                          disabled={isBusy || isManagedActionPaused}
                           className="h-6 px-2 text-muted-foreground hover:text-foreground"
                         >
                           {isReauthing ? (
@@ -1117,7 +1138,7 @@ export function AccountsPane({
           )}
           description={translate(
             'auto.components.settings.AccountsPane.e321640e44',
-            "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
+            "Run host Codex with your system ~/.codex config instead of Orca's managed home. This stops background quota refreshes from touching host managed homes, preventing single-session token revocation with non-Orca Codex. Host managed account switching is paused while on; WSL accounts stay managed."
           )}
           keywords={['codex', 'config', 'directory', 'home', 'managed', 'default', 'account']}
           className="space-y-3 py-2"
@@ -1129,7 +1150,7 @@ export function AccountsPane({
             )}
             description={translate(
               'auto.components.settings.AccountsPane.e321640e44',
-              "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
+              "Run host Codex with your system ~/.codex config instead of Orca's managed home. This stops background quota refreshes from touching host managed homes, preventing single-session token revocation with non-Orca Codex. Host managed account switching is paused while on; WSL accounts stay managed."
             )}
             checked={settings.codexUseDefaultConfigDir === true}
             onChange={() =>

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -93,6 +93,24 @@ export const getAccountsCodexSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword('auto.components.settings.accounts.search.f2d666a886', 'optional'),
       ...translateSearchKeyword('auto.components.settings.accounts.search.35b461d817', 'sign in')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.accounts.search.d6347a2658',
+      'Default Codex config directory'
+    ),
+    description: translate(
+      'auto.components.settings.accounts.search.edd9a67f8d',
+      "Run Codex with your system ~/.codex config instead of Orca's managed home."
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.accounts.search.70d1b8def5', 'codex'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.e85a7f3385', 'default'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.397ba215c5', 'config'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.67a07ebd35', 'directory'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.5d23eca2a7', 'home'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.c919fa7390', 'managed')
+    ]
   }
 ])
 

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -101,7 +101,7 @@ export const getAccountsCodexSearchEntries = createLocalizedCatalog(() => [
     ),
     description: translate(
       'auto.components.settings.accounts.search.edd9a67f8d',
-      "Run Codex with your system ~/.codex config instead of Orca's managed home."
+      "Run host Codex with your system ~/.codex config instead of Orca's managed home."
     ),
     keywords: [
       ...translateSearchKeyword('auto.components.settings.accounts.search.70d1b8def5', 'codex'),

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -130,6 +130,7 @@ export type ClaudeStatusSwitchGroup = {
 
 type StatusSwitchGroupOptions = {
   fallbackWslDistro?: string | null
+  hostDefaultHomeEnabled?: boolean
   includeFallbackWsl?: boolean
 }
 
@@ -256,8 +257,12 @@ export function buildCodexStatusSwitchGroups(
   const groups: CodexStatusSwitchGroup[] = []
   const normalizedCurrentTarget = normalizeCodexStatusRuntimeTarget(state, currentTarget)
   const makeGroup = (target: CodexStatusRuntimeTarget): CodexStatusSwitchGroup => {
-    const activeId = getCodexStatusActiveId(state, target)
-    const accountsForTarget = getCodexStatusAccountsForTarget(state, target)
+    const hostDefaultHomeEnabled =
+      options.hostDefaultHomeEnabled === true && target.runtime === 'host'
+    const activeId = hostDefaultHomeEnabled ? null : getCodexStatusActiveId(state, target)
+    const accountsForTarget = hostDefaultHomeEnabled
+      ? []
+      : getCodexStatusAccountsForTarget(state, target)
     return {
       key: getCodexStatusRuntimeKey(target),
       label: getCodexStatusRuntimeLabel(target),
@@ -1364,6 +1369,7 @@ function CodexSwitcherMenu({
     toCodexStatusRuntimeTarget(codexTarget),
     {
       fallbackWslDistro,
+      hostDefaultHomeEnabled: settings?.codexUseDefaultConfigDir === true,
       includeFallbackWsl: shouldIncludeSettingsWslRuntime(settings)
     }
   )

--- a/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
@@ -87,6 +87,62 @@ describe('status bar runtime switch groups', () => {
     ])
   })
 
+  it('treats host Codex as system default in default-home mode while keeping WSL accounts', () => {
+    const state: CodexRateLimitAccountsState = {
+      accounts: [
+        {
+          id: 'codex-host',
+          email: 'host@example.com',
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        },
+        {
+          id: 'codex-wsl',
+          email: 'wsl@example.com',
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 2,
+          updatedAt: 2,
+          lastAuthenticatedAt: 2
+        }
+      ],
+      activeAccountId: 'codex-host',
+      activeAccountIdsByRuntime: { host: 'codex-host', wsl: { Ubuntu: 'codex-wsl' } }
+    }
+
+    expect(
+      buildCodexStatusSwitchGroups(
+        state,
+        { runtime: 'host', wslDistro: null },
+        { hostDefaultHomeEnabled: true }
+      ).map((group) => ({
+        key: group.key,
+        targets: group.targets.map((target) => ({
+          label: target.label,
+          active: target.active
+        }))
+      }))
+    ).toEqual([
+      { key: 'host', targets: [{ label: 'System default', active: true }] },
+      {
+        key: 'wsl:Ubuntu',
+        targets: [
+          { label: 'System default', active: false },
+          { label: 'wsl@example.com', active: true }
+        ]
+      }
+    ])
+  })
+
   it('keeps Claude WSL system-default available without managed Claude accounts', () => {
     const state: ClaudeRateLimitAccountsState = {
       accounts: [],

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4459,7 +4459,9 @@
           "75ca9b718e": "Codex reported that the active account needs a fresh sign-in. Re-authenticate it before starting new Codex sessions.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "Use your current {{value0}} Claude login."
+          "e05d0ff737": "Use your current {{value0}} Claude login.",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",
@@ -6573,7 +6575,9 @@
             "bdbd1e668e": "windows",
             "593720c17f": "location",
             "b84a5b0c8a": "Choose whether provider accounts are inspected and added on this device or in WSL.",
-            "d09fb5ca92": "Account Location"
+            "d09fb5ca92": "Account Location",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4461,7 +4461,8 @@
           "350b2a1aa7": "Use your current",
           "e05d0ff737": "Use your current {{value0}} Claude login.",
           "2eb471df34": "Use default Codex config directory",
-          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
+          "e321640e44": "Run host Codex with your system ~/.codex config instead of Orca's managed home. This stops background quota refreshes from touching host managed homes, preventing single-session token revocation with non-Orca Codex. Host managed account switching is paused while on; WSL accounts stay managed.",
+          "4f3a6c2d19": "Host managed Codex accounts are paused while default ~/.codex is enabled. WSL accounts still use managed homes."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",
@@ -6577,7 +6578,7 @@
             "b84a5b0c8a": "Choose whether provider accounts are inspected and added on this device or in WSL.",
             "d09fb5ca92": "Account Location",
             "d6347a2658": "Default Codex config directory",
-            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
+            "edd9a67f8d": "Run host Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4459,7 +4459,9 @@
           "75ca9b718e": "Codex informó que la cuenta activa necesita un nuevo inicio de sesión. Vuelva a autenticarlo antes de iniciar nuevas sesiones del Codex.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Usa tu actual",
-          "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude."
+          "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude.",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reanudar",
@@ -6536,7 +6538,9 @@
             "bdbd1e668e": "ventanas",
             "593720c17f": "ubicación",
             "b84a5b0c8a": "Elija si las cuentas de proveedor se inspeccionan y agregan en este dispositivo o en WSL.",
-            "d09fb5ca92": "Ubicación de la cuenta"
+            "d09fb5ca92": "Ubicación de la cuenta",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4461,7 +4461,8 @@
           "350b2a1aa7": "Usa tu actual",
           "e05d0ff737": "Utilice su inicio de sesión actual de {{value0}} Claude.",
           "2eb471df34": "Use default Codex config directory",
-          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
+          "e321640e44": "Run host Codex with your system ~/.codex config instead of Orca's managed home. This stops background quota refreshes from touching host managed homes, preventing single-session token revocation with non-Orca Codex. Host managed account switching is paused while on; WSL accounts stay managed.",
+          "4f3a6c2d19": "Host managed Codex accounts are paused while default ~/.codex is enabled. WSL accounts still use managed homes."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reanudar",
@@ -6540,7 +6541,7 @@
             "b84a5b0c8a": "Elija si las cuentas de proveedor se inspeccionan y agregan en este dispositivo o en WSL.",
             "d09fb5ca92": "Ubicación de la cuenta",
             "d6347a2658": "Default Codex config directory",
-            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
+            "edd9a67f8d": "Run host Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4444,7 +4444,9 @@
           "75ca9b718e": "Codex は、アクティブなアカウントには新たにサインインする必要があると報告しました。新規 Codex セッションを開始する前に、再認証してください。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "Use your current",
-          "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。"
+          "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",
@@ -6558,7 +6560,9 @@
             "bdbd1e668e": "窓",
             "593720c17f": "場所",
             "b84a5b0c8a": "プロバイダー アカウントをこのデバイスまたは WSL で検査および追加するかどうかを選択します。",
-            "d09fb5ca92": "アカウントの場所"
+            "d09fb5ca92": "アカウントの場所",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4446,7 +4446,8 @@
           "350b2a1aa7": "Use your current",
           "e05d0ff737": "現在の {{value0}} Claude ログインを使用します。",
           "2eb471df34": "Use default Codex config directory",
-          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
+          "e321640e44": "Run host Codex with your system ~/.codex config instead of Orca's managed home. This stops background quota refreshes from touching host managed homes, preventing single-session token revocation with non-Orca Codex. Host managed account switching is paused while on; WSL accounts stay managed.",
+          "4f3a6c2d19": "Host managed Codex accounts are paused while default ~/.codex is enabled. WSL accounts still use managed homes."
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",
@@ -6562,7 +6563,7 @@
             "b84a5b0c8a": "プロバイダー アカウントをこのデバイスまたは WSL で検査および追加するかどうかを選択します。",
             "d09fb5ca92": "アカウントの場所",
             "d6347a2658": "Default Codex config directory",
-            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
+            "edd9a67f8d": "Run host Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4444,7 +4444,9 @@
           "75ca9b718e": "Codex는 활성 계정에 새로 로그인해야 한다고 보고했습니다. 새 Codex 세션을 시작하기 전에 다시 인증하세요.",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "현재 사용 중인",
-          "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요."
+          "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요.",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "다시 시작",
@@ -6521,7 +6523,9 @@
             "bdbd1e668e": "Windows",
             "593720c17f": "위치",
             "b84a5b0c8a": "이 장치 또는 WSL에서 공급자 계정을 검사하고 추가할지 선택합니다.",
-            "d09fb5ca92": "계정 위치"
+            "d09fb5ca92": "계정 위치",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4446,7 +4446,8 @@
           "350b2a1aa7": "현재 사용 중인",
           "e05d0ff737": "현재 {{value0}} Claude 로그인을 사용하세요.",
           "2eb471df34": "Use default Codex config directory",
-          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
+          "e321640e44": "Run host Codex with your system ~/.codex config instead of Orca's managed home. This stops background quota refreshes from touching host managed homes, preventing single-session token revocation with non-Orca Codex. Host managed account switching is paused while on; WSL accounts stay managed.",
+          "4f3a6c2d19": "Host managed Codex accounts are paused while default ~/.codex is enabled. WSL accounts still use managed homes."
         },
         "AdvancedPane": {
           "40b29e0bf3": "다시 시작",
@@ -6525,7 +6526,7 @@
             "b84a5b0c8a": "이 장치 또는 WSL에서 공급자 계정을 검사하고 추가할지 선택합니다.",
             "d09fb5ca92": "계정 위치",
             "d6347a2658": "Default Codex config directory",
-            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
+            "edd9a67f8d": "Run host Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4444,7 +4444,9 @@
           "75ca9b718e": "Codex 报告活动账户需要重新登录。在开始新的 Codex 会话之前重新对其进行身份验证。",
           "b11078a9c2": "wsl",
           "350b2a1aa7": "用你已有的",
-          "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。"
+          "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。",
+          "2eb471df34": "Use default Codex config directory",
+          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
         },
         "AdvancedPane": {
           "40b29e0bf3": "重新启动",
@@ -6521,7 +6523,9 @@
             "bdbd1e668e": "视窗",
             "593720c17f": "位置",
             "b84a5b0c8a": "选择是否在此设备上或 WSL 中检查和添加提供商账户。",
-            "d09fb5ca92": "账户位置"
+            "d09fb5ca92": "账户位置",
+            "d6347a2658": "Default Codex config directory",
+            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4446,7 +4446,8 @@
           "350b2a1aa7": "用你已有的",
           "e05d0ff737": "使用您当前 {{value0}} Claude 登录名。",
           "2eb471df34": "Use default Codex config directory",
-          "e321640e44": "Run Codex with your system ~/.codex config instead of Orca's managed home. Also stops Orca's background quota poller from refreshing the managed home, so it no longer revokes your ~/.codex session. Disables Orca's Codex account hot-swap and auth sync."
+          "e321640e44": "Run host Codex with your system ~/.codex config instead of Orca's managed home. This stops background quota refreshes from touching host managed homes, preventing single-session token revocation with non-Orca Codex. Host managed account switching is paused while on; WSL accounts stay managed.",
+          "4f3a6c2d19": "Host managed Codex accounts are paused while default ~/.codex is enabled. WSL accounts still use managed homes."
         },
         "AdvancedPane": {
           "40b29e0bf3": "重新启动",
@@ -6525,7 +6526,7 @@
             "b84a5b0c8a": "选择是否在此设备上或 WSL 中检查和添加提供商账户。",
             "d09fb5ca92": "账户位置",
             "d6347a2658": "Default Codex config directory",
-            "edd9a67f8d": "Run Codex with your system ~/.codex config instead of Orca's managed home."
+            "edd9a67f8d": "Run host Codex with your system ~/.codex config instead of Orca's managed home."
           }
         },
         "advanced": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -317,6 +317,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     agentDefaultEnv: { ...DEFAULT_TUI_AGENT_ENV },
     agentYoloDefaultsMigrated: true,
     agentStatusHooksEnabled: true,
+    codexUseDefaultConfigDir: false,
     tabAutoGenerateTitle: false,
     confirmClosePinnedTab: true,
     keepComputerAwakeWhileAgentsRun: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2692,6 +2692,13 @@ export type GlobalSettings = {
   /** Why: disabling must persist so startup does not reinstall global agent
    *  hook entries right after the user removes them from Settings or CLI. */
   agentStatusHooksEnabled: boolean
+  /** Why: opt-in escape hatch so Codex launched inside Orca terminals reads the
+   *  user's real ~/.codex config instead of Orca's managed runtime home. When
+   *  true, Orca injects no CODEX_HOME and the background quota poller refreshes
+   *  ~/.codex instead of the managed home — stopping the single-OAuth-session
+   *  refresh-token revocation war with non-Orca Codex. Disables Codex account
+   *  hot-swap and auth sync. Default false preserves the managed-home behavior. */
+  codexUseDefaultConfigDir?: boolean
   /** Why: generated tab titles are semantic but subjective, so they stay opt-in
    *  and manual renames remain the stronger user intent. */
   tabAutoGenerateTitle: boolean

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2693,11 +2693,10 @@ export type GlobalSettings = {
    *  hook entries right after the user removes them from Settings or CLI. */
   agentStatusHooksEnabled: boolean
   /** Why: opt-in escape hatch so Codex launched inside Orca terminals reads the
-   *  user's real ~/.codex config instead of Orca's managed runtime home. When
-   *  true, Orca injects no CODEX_HOME and the background quota poller refreshes
-   *  ~/.codex instead of the managed home — stopping the single-OAuth-session
-   *  refresh-token revocation war with non-Orca Codex. Disables Codex account
-   *  hot-swap and auth sync. Default false preserves the managed-home behavior. */
+   *  user's real ~/.codex config instead of Orca's host managed runtime home.
+   *  Host managed account switching is paused while true; WSL managed accounts
+   *  continue to use their separate runtime homes. Default false preserves the
+   *  managed-home behavior. */
   codexUseDefaultConfigDir?: boolean
   /** Why: generated tab titles are semantic but subjective, so they stay opt-in
    *  and manual renames remain the stronger user intent. */


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** If you use the OpenAI Codex CLI both inside Orca *and* outside Orca (in a plain terminal, a scheduled job, or another tool) with the **same single ChatGPT/OpenAI account**, your Codex login silently breaks. OpenAI only allows one active login per account, but Orca quietly keeps its *own private* Codex login in a separate hidden folder. So Orca and your normal `~/.codex` login keep kicking each other out — like two phones signed into the same account where each one logs the other off the moment it checks in. The nasty part: Codex still *says* "Logged in," so you can't tell anything is wrong until a command suddenly fails with "token revoked." This hits the (relatively niche) group of power users who run Codex in multiple places on one account, but for them it's a real blocker — background/scheduled Codex jobs fail intermittently and it's extremely hard to diagnose. A previous `~/.zshenv` workaround helped terminals but Orca's always-running background checker kept re-triggering the fight.

**2) What this PR does (ELI5).** It adds a new opt-in toggle — **Settings → Accounts → Codex → "Use default Codex config directory"**. Flip it on and Orca stops keeping its own separate Codex login; instead it uses your normal `~/.codex` login, the same one your terminal and other tools use. Crucially, it also tells Orca's background "how much quota do I have left?" checker to stop poking the private login folder, since that background checker was the thing secretly re-igniting the fight even after the manual workaround. Oh, so Orca now shares your one real Codex login instead of secretly maintaining a rival second one that logs you out.

**3) Opt-in mode contract — honest answer.** The toggle is **OFF by default**, so nobody's current behavior changes unless they choose to enable it. When it is on, host Codex has exactly one source of truth: the user's system `~/.codex`. In that mode Orca intentionally does not own, switch, re-authenticate, or preview separate host managed Codex homes; stale host add/select/re-auth calls are rejected so no hidden path can spawn Codex against a rival host home. This is the contract of default-home mode, not an unfinished host hot-swap implementation. Turn the toggle off to use Orca's host managed multi-account switching again. WSL managed Codex accounts still work and keep their own managed homes. SSH/remote paths are untouched, and for everyone who leaves the toggle off this PR is a no-op.

---

## Summary

`Fixes #5370`

Orca injects a private managed `CODEX_HOME` (`~/Library/Application Support/orca/codex-runtime-home/home`) into Codex processes. For a single OpenAI/ChatGPT account, OAuth enforces **one active session**, so two independently-refreshing homes (Orca's managed home and the user's real `~/.codex`) revoke each other's single-use refresh tokens — silently breaking non-Orca Codex usage. The refresh is driven not only by interactive Codex but by Orca's **background quota poller**, which spawns the real `codex` binary against the managed home; that daemon-side session is why the issue persists even after the `~/.zshenv` workaround.

This adds an opt-in **"Use default Codex config directory"** setting under Settings > Accounts > Codex. When enabled, Codex launched inside Orca resolves the user's system `~/.codex` instead of Orca's managed home:

- **Terminals / daemon-host PTYs:** all three `buildPtyHostEnv` call sites OR in `isCodexDefaultHomeEnabled`, so `skipCodexHomeEnv` strips `CODEX_HOME`/`ORCA_CODEX_HOME`.
- **Background quota poller + host launches (the revocation driver):** `prepareForRateLimitFetch` and the host branch of `prepareForCodexLaunch` return `null` when the setting is on. `null` makes the rate-limit fetcher resolve `~/.codex` and tells the commit-message agent to inject no `CODEX_HOME`, and it skips the managed-home sync so Orca never spawns Codex against the managed home to drive a token refresh.
- **Managed-account surfaces while enabled:** host managed add/select/re-auth actions are paused in Settings, hidden from the status-bar switcher, and guarded in the main process. Inactive host managed-home quota previews are skipped because the preview fetch can spawn Codex/app-server against that separate home and refresh its token. WSL managed accounts and WSL previews remain available.

Default is **off**, preserving today's managed-home behavior and Codex account switching. When enabled, host default-home mode is an explicit auth-source contract: host Codex uses `~/.codex` only, and Orca does not switch or refresh separate host managed homes. WSL managed accounts stay managed.

### Supersedes community PR #5594

This takes over #5594 (does **not** close it; original author credited via `Co-authored-by`). Changes made on top of the original PR:

1. **Locale scope fixed:** re-derived the i18n changes from current `main` — dropped the entire out-of-scope "Create PR" status-message block (and the malformed `h3i4j5k607` key) that #5594 introduced into en/es/ja/ko/zh. Kept only the new Codex keys + accounts-search keys, then ran `pnpm run sync:localization-catalog` so all five locales stay at parity. No merge conflict and no reintroduction of already-present keys.
2. **Closed the background-revocation gap** that #5594 left unaddressed (gated `prepareForRateLimitFetch` / host `prepareForCodexLaunch`), and added a test for it.
3. **Sharpened the setting description** to state it also stops the background managed-home quota refresh — the mechanism that drives the revocation war.
4. **Defined the default-home mode contract:** default-home mode now pauses only host managed Codex account switching, preserves WSL managed accounts, skips inactive host managed-home previews, and guards stale host account mutations in the main process.

## Screenshots

| Off (default) | On |
| --- | --- |
| Toggle in Codex section, system-default managed home preserved | Toggle on → Codex resolves `~/.codex`, background poller stops touching the managed home |

Before/after screenshots and unit-test output are attached as a PR comment (validated live over CDP in the running dev app — see comment).

## Testing

- [x] `pnpm lint` (oxlint, scoped to changed files — clean)
- [x] `pnpm typecheck` (`tsconfig.node.json` + `tsconfig.tc.web.json` + `tsconfig.tc.cli.json` — clean)
- [x] `pnpm test` (ran `src/main/ipc/pty.test.ts` and `src/main/codex-accounts/runtime-home-service.test.ts` — 265 passing incl. 3 new; plus rate-limits/codex-accounts service + text-generation suites — 112 passing)
- [ ] `pnpm build` (not run; no build-affecting changes — type/lint clean)
- [x] Added high-quality regression tests: PTY env coverage, runtime-home host default-home coverage, inactive host preview filtering with WSL preservation, status-bar host/WSL grouping, and service-level guards that reject host add/select/re-auth while allowing WSL selection.
- [x] Localization catalog parity verified (`verify-localization-catalog.mjs` passes with no diff).
- [x] Electron repro over CDP: opened Settings > Accounts > Codex, toggled the new switch through the real UI — `aria-checked` flips and `codexUseDefaultConfigDir` persists to the store and to disk (verified via `fetchSettings` IPC round-trip). No render crash.

## AI Review Report

Reviewed the diff adversarially (treating the adopted PR author as untrusted) for correctness, edge cases, cross-platform behavior, security, and scope.

- **Cross-platform (macOS/Linux/Windows):** verified. No `e.metaKey` / path-separator assumptions added. The PTY change ORs a boolean ahead of the existing WSL/Windows-shell conditions, preserving prior behavior when off. WSL rate-limit/launch paths return *before* the new host gate, so WSL homes are untouched. `null` returns flow correctly through `getCompatibleSelectedCodexHomePath` (null→null), the rate-limit fetcher (`getCodexHomePath` → `~/.codex`), and the commit-message agent (no `CODEX_HOME` injected).
- **SSH / remote:** the managed `CODEX_HOME` injection only happens for local + daemon-host terminals (`buildPtyHostEnv` is not on the SSH spawn path); remote shells use the remote machine's own `~/.codex`. So the revocation war is inherently a local-machine problem and the fix is correctly scoped there — the description does not over-claim SSH coverage.
- **Provider-agnostic:** change is Codex-auth-specific and does not touch GitHub/GitLab review code.
- **Flagged + addressed:** the original PR's locale block was out of scope and malformed; re-derived. The background poller gap meant the fix was incomplete; closed it.

## Security Audit

- **No new attack surface.** The change only reads a boolean setting and short-circuits to `null`/strips env. No `eval`, no new `spawn`/`exec`, no network calls, no new dependencies, no path traversal, no secret reads added.
- **Reduces** exposure: stops Orca from spawning Codex against the managed home in the background, which is the behavior that was revoking the user's `~/.codex` OAuth session.
- Adopted code re-verified as benign; auth.json continues to be written `0o600` by existing code paths (unchanged).

## Default-home mode contract

Follow-up audit for zero-tradeoff alternatives:

- Treating system `~/.codex` as a managed account can only represent the account currently logged in there. Switching to any other host account still requires either setting `CODEX_HOME` away from `~/.codex` or overwriting `~/.codex/auth.json` with another account's tokens.
- Explicit per-host account binding can label or verify the current `~/.codex` identity, but it cannot make Codex run as a different host account while Codex is still reading `~/.codex`.
- Host managed quota previews are not guaranteed read-only: the preview path can spawn Codex/app-server against the separate managed home, and Codex may refresh that home's OAuth token. For the same OpenAI account, that is the exact revocation mechanism this opt-in disables.

So the safe contract is: **default-home mode means host Codex uses the system `~/.codex` identity only**. Host managed switching/previews resume when the toggle is off. WSL managed account switching remains available because WSL uses separate WSL runtime homes rather than the host `~/.codex`.

Made with [Orca](https://github.com/stablyai/orca) 🐋

