### PR TITLE
fix: bound generated release notes by previous desktop tag

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -67,6 +67,7 @@ jobs:
     outputs:
       tag: ${{ steps.tag.outputs.tag || steps.version.outputs.recovered_tag }}
       should_release: ${{ steps.tag.outputs.tag != '' || steps.version.outputs.recovered_tag != '' }}
+      previous_tag: ${{ steps.previous_tag.outputs.previous_tag }}
       latest_published_rc_tag: ${{ steps.publish_drafts.outputs.latest_published_tag }}
     steps:
       - name: Checkout ref
@@ -493,6 +494,23 @@ jobs:
             git push origin "$TAG"
           fi
 
+      # Why: cut already has a full tag checkout, so resolve the notes
+      # boundary here instead of spending extra GitHub API calls later.
+      - name: Resolve previous desktop tag
+        id: previous_tag
+        if: steps.tag.outputs.tag != '' || steps.version.outputs.recovered_tag != ''
+        env:
+          TAG: ${{ steps.tag.outputs.tag || steps.version.outputs.recovered_tag }}
+        run: |
+          set -euo pipefail
+          previous_tag="$(node config/scripts/previous-desktop-release-tag.mjs "$TAG")"
+          echo "previous_tag=$previous_tag" >>"$GITHUB_OUTPUT"
+          if [[ -n "$previous_tag" ]]; then
+            echo "Previous desktop release tag: $previous_tag"
+          else
+            echo "No previous desktop release tag for $TAG."
+          fi
+
       - name: Release E2E signal summary
         if: always()
         run: |
@@ -521,6 +539,7 @@ jobs:
       - name: Create draft release with bounded generated notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREVIOUS_TAG: ${{ needs.cut.outputs.previous_tag }}
           TAG: ${{ needs.cut.outputs.tag }}
         run: |
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then

--- a/config/scripts/create-draft-release.mjs
+++ b/config/scripts/create-draft-release.mjs
@@ -6,6 +6,51 @@ const API_VERSION = '2022-11-28'
 const MAX_RELEASE_BODY_LENGTH = 120_000
 const TRUNCATION_NOTICE =
   '\n\n---\nRelease notes were truncated because GitHub release bodies are limited to 125,000 characters.'
+const DESKTOP_RELEASE_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?$/
+
+export function parseDesktopReleaseTag(tag) {
+  const match = DESKTOP_RELEASE_TAG_PATTERN.exec(tag)
+  if (!match) {
+    return null
+  }
+  return {
+    tag,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    rc: match[4] === undefined ? null : Number(match[4])
+  }
+}
+
+function compareDesktopReleaseTags(a, b) {
+  const versionDiff = a.major - b.major || a.minor - b.minor || a.patch - b.patch
+  if (versionDiff !== 0) {
+    return versionDiff
+  }
+  if (a.rc === b.rc) {
+    return 0
+  }
+  if (a.rc === null) {
+    return 1
+  }
+  if (b.rc === null) {
+    return -1
+  }
+  return a.rc - b.rc
+}
+
+export function latestPreviousDesktopReleaseTag(tags, tag) {
+  const current = parseDesktopReleaseTag(tag)
+  if (!current) {
+    return ''
+  }
+  const previousTags = tags
+    .map((candidate) => parseDesktopReleaseTag(candidate))
+    .filter((candidate) => candidate && candidate.tag !== current.tag)
+    .filter((candidate) => compareDesktopReleaseTags(candidate, current) < 0)
+    .sort(compareDesktopReleaseTags)
+  return previousTags.at(-1)?.tag ?? ''
+}
 
 function githubHeaders(token) {
   return {
@@ -28,6 +73,29 @@ async function githubJson(fetchImpl, url, token, options = {}) {
     throw new Error(`GitHub request failed ${res.status} ${res.statusText}: ${body.slice(0, 300)}`)
   }
   return res.json()
+}
+
+async function fetchRepoTags(repo, token, fetchImpl) {
+  const tags = []
+  for (let page = 1; ; page += 1) {
+    const pageTags = await githubJson(
+      fetchImpl,
+      `https://api.github.com/repos/${repo}/tags?per_page=100&page=${page}`,
+      token
+    )
+    if (!Array.isArray(pageTags)) {
+      throw new Error(`GitHub tags response page ${page} for ${repo} was not an array`)
+    }
+    for (const tag of pageTags) {
+      if (typeof tag?.name === 'string') {
+        tags.push(tag.name)
+      }
+    }
+    if (pageTags.length < 100) {
+      break
+    }
+  }
+  return tags
 }
 
 export function truncateReleaseBody(body, maxLength = MAX_RELEASE_BODY_LENGTH) {
@@ -60,16 +128,26 @@ export async function createDraftRelease({
     throw new Error('token is required')
   }
 
+  const previousTag = latestPreviousDesktopReleaseTag(
+    await fetchRepoTags(repo, token, fetchImpl),
+    tag
+  )
+  const generateNotesBody = {
+    tag_name: tag,
+    target_commitish: tag,
+    ...(previousTag ? { previous_tag_name: previousTag } : {})
+  }
+
+  // Why: draft releases are invisible to GitHub's generate-notes baseline.
+  // Passing the previous desktop tag keeps each release from accumulating
+  // notes from older drafts.
   const releaseNotes = await githubJson(
     fetchImpl,
     `https://api.github.com/repos/${repo}/releases/generate-notes`,
     token,
     {
       method: 'POST',
-      body: JSON.stringify({
-        tag_name: tag,
-        target_commitish: tag
-      })
+      body: JSON.stringify(generateNotesBody)
     }
   )
 

--- a/config/scripts/create-draft-release.mjs
+++ b/config/scripts/create-draft-release.mjs
@@ -1,56 +1,15 @@
 #!/usr/bin/env node
 
 import { pathToFileURL } from 'node:url'
+import {
+  parseDesktopReleaseTag,
+  previousDesktopReleaseTagFromGit
+} from './previous-desktop-release-tag.mjs'
 
 const API_VERSION = '2022-11-28'
 const MAX_RELEASE_BODY_LENGTH = 120_000
 const TRUNCATION_NOTICE =
   '\n\n---\nRelease notes were truncated because GitHub release bodies are limited to 125,000 characters.'
-const DESKTOP_RELEASE_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?$/
-
-export function parseDesktopReleaseTag(tag) {
-  const match = DESKTOP_RELEASE_TAG_PATTERN.exec(tag)
-  if (!match) {
-    return null
-  }
-  return {
-    tag,
-    major: Number(match[1]),
-    minor: Number(match[2]),
-    patch: Number(match[3]),
-    rc: match[4] === undefined ? null : Number(match[4])
-  }
-}
-
-function compareDesktopReleaseTags(a, b) {
-  const versionDiff = a.major - b.major || a.minor - b.minor || a.patch - b.patch
-  if (versionDiff !== 0) {
-    return versionDiff
-  }
-  if (a.rc === b.rc) {
-    return 0
-  }
-  if (a.rc === null) {
-    return 1
-  }
-  if (b.rc === null) {
-    return -1
-  }
-  return a.rc - b.rc
-}
-
-export function latestPreviousDesktopReleaseTag(tags, tag) {
-  const current = parseDesktopReleaseTag(tag)
-  if (!current) {
-    return ''
-  }
-  const previousTags = tags
-    .map((candidate) => parseDesktopReleaseTag(candidate))
-    .filter((candidate) => candidate && candidate.tag !== current.tag)
-    .filter((candidate) => compareDesktopReleaseTags(candidate, current) < 0)
-    .sort(compareDesktopReleaseTags)
-  return previousTags.at(-1)?.tag ?? ''
-}
 
 function githubHeaders(token) {
   return {
@@ -75,29 +34,6 @@ async function githubJson(fetchImpl, url, token, options = {}) {
   return res.json()
 }
 
-async function fetchRepoTags(repo, token, fetchImpl) {
-  const tags = []
-  for (let page = 1; ; page += 1) {
-    const pageTags = await githubJson(
-      fetchImpl,
-      `https://api.github.com/repos/${repo}/tags?per_page=100&page=${page}`,
-      token
-    )
-    if (!Array.isArray(pageTags)) {
-      throw new Error(`GitHub tags response page ${page} for ${repo} was not an array`)
-    }
-    for (const tag of pageTags) {
-      if (typeof tag?.name === 'string') {
-        tags.push(tag.name)
-      }
-    }
-    if (pageTags.length < 100) {
-      break
-    }
-  }
-  return tags
-}
-
 export function truncateReleaseBody(body, maxLength = MAX_RELEASE_BODY_LENGTH) {
   if (body.length <= maxLength) {
     return body
@@ -111,10 +47,19 @@ export function truncateReleaseBody(body, maxLength = MAX_RELEASE_BODY_LENGTH) {
   return `${body.slice(0, availableLength).trimEnd()}${TRUNCATION_NOTICE}`
 }
 
+function resolvePreviousTag(tag, previousTag) {
+  const resolvedPreviousTag = previousTag ?? previousDesktopReleaseTagFromGit(tag)
+  if (resolvedPreviousTag && !parseDesktopReleaseTag(resolvedPreviousTag)) {
+    throw new Error(`previousTag must be a desktop release tag: ${resolvedPreviousTag}`)
+  }
+  return resolvedPreviousTag
+}
+
 export async function createDraftRelease({
   repo,
   tag,
   token,
+  previousTag,
   fetchImpl = fetch,
   log = console.log
 }) {
@@ -128,14 +73,11 @@ export async function createDraftRelease({
     throw new Error('token is required')
   }
 
-  const previousTag = latestPreviousDesktopReleaseTag(
-    await fetchRepoTags(repo, token, fetchImpl),
-    tag
-  )
+  const boundedPreviousTag = resolvePreviousTag(tag, previousTag)
   const generateNotesBody = {
     tag_name: tag,
     target_commitish: tag,
-    ...(previousTag ? { previous_tag_name: previousTag } : {})
+    ...(boundedPreviousTag ? { previous_tag_name: boundedPreviousTag } : {})
   }
 
   // Why: draft releases are invisible to GitHub's generate-notes baseline.
@@ -182,7 +124,8 @@ async function main() {
   const tag = process.argv[2]
   const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
   const repo = process.env.GITHUB_REPOSITORY || 'stablyai/orca'
-  await createDraftRelease({ repo, tag, token })
+  const previousTag = process.env.PREVIOUS_TAG
+  await createDraftRelease({ repo, tag, token, previousTag })
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/config/scripts/create-draft-release.test.mjs
+++ b/config/scripts/create-draft-release.test.mjs
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createDraftRelease, truncateReleaseBody } from './create-draft-release.mjs'
+import {
+  createDraftRelease,
+  latestPreviousDesktopReleaseTag,
+  parseDesktopReleaseTag,
+  truncateReleaseBody
+} from './create-draft-release.mjs'
 
 function jsonResponse(body, init = {}) {
   return {
@@ -24,10 +29,51 @@ describe('truncateReleaseBody', () => {
   })
 })
 
+describe('parseDesktopReleaseTag', () => {
+  it('parses stable and rc desktop release tags only', () => {
+    expect(parseDesktopReleaseTag('v1.4.36')).toMatchObject({
+      tag: 'v1.4.36',
+      major: 1,
+      minor: 4,
+      patch: 36,
+      rc: null
+    })
+    expect(parseDesktopReleaseTag('v1.4.36-rc.2')).toMatchObject({
+      tag: 'v1.4.36-rc.2',
+      major: 1,
+      minor: 4,
+      patch: 36,
+      rc: 2
+    })
+    expect(parseDesktopReleaseTag('mobile-v0.0.12')).toBeNull()
+  })
+})
+
+describe('latestPreviousDesktopReleaseTag', () => {
+  it('bounds stable notes to the previous rc when one exists', () => {
+    expect(latestPreviousDesktopReleaseTag(['v1.4.35', 'v1.4.36-rc.0', 'v1.4.36'], 'v1.4.36')).toBe(
+      'v1.4.36-rc.0'
+    )
+  })
+
+  it('bounds the first rc notes to the previous stable release', () => {
+    expect(
+      latestPreviousDesktopReleaseTag(['v1.4.35', 'v1.4.36-rc.0', 'mobile-v0.0.12'], 'v1.4.36-rc.0')
+    ).toBe('v1.4.35')
+  })
+
+  it('bounds later rc notes to the prior rc', () => {
+    expect(latestPreviousDesktopReleaseTag(['v1.4.36-rc.0', 'v1.4.36-rc.1'], 'v1.4.36-rc.1')).toBe(
+      'v1.4.36-rc.0'
+    )
+  })
+})
+
 describe('createDraftRelease', () => {
   it('creates a draft release with bounded generated notes', async () => {
     const fetchImpl = vi
       .fn()
+      .mockResolvedValueOnce(jsonResponse([{ name: 'v1.4.35' }, { name: 'v1.4.36' }]))
       .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36', body: 'a'.repeat(130_000) }))
       .mockResolvedValueOnce(jsonResponse({ tag_name: 'v1.4.36', draft: true }))
 
@@ -41,17 +87,23 @@ describe('createDraftRelease', () => {
 
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
+      'https://api.github.com/repos/stablyai/orca/tags?per_page=100&page=1',
+      expect.any(Object)
+    )
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
       'https://api.github.com/repos/stablyai/orca/releases/generate-notes',
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({
           tag_name: 'v1.4.36',
-          target_commitish: 'v1.4.36'
+          target_commitish: 'v1.4.36',
+          previous_tag_name: 'v1.4.35'
         })
       })
     )
     expect(fetchImpl).toHaveBeenNthCalledWith(
-      2,
+      3,
       'https://api.github.com/repos/stablyai/orca/releases',
       expect.objectContaining({
         method: 'POST',
@@ -59,7 +111,7 @@ describe('createDraftRelease', () => {
       })
     )
 
-    const createBody = JSON.parse(fetchImpl.mock.calls[1][1].body)
+    const createBody = JSON.parse(fetchImpl.mock.calls[2][1].body)
     expect(createBody).toMatchObject({
       tag_name: 'v1.4.36',
       name: 'v1.4.36',
@@ -73,6 +125,7 @@ describe('createDraftRelease', () => {
   it('marks rc tags as prereleases', async () => {
     const fetchImpl = vi
       .fn()
+      .mockResolvedValueOnce(jsonResponse([{ name: 'v1.4.36' }, { name: 'v1.4.36-rc.1' }]))
       .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36-rc.1', body: 'notes' }))
       .mockResolvedValueOnce(jsonResponse({ tag_name: 'v1.4.36-rc.1', draft: true }))
 
@@ -84,7 +137,7 @@ describe('createDraftRelease', () => {
       log: vi.fn()
     })
 
-    const createBody = JSON.parse(fetchImpl.mock.calls[1][1].body)
+    const createBody = JSON.parse(fetchImpl.mock.calls[2][1].body)
     expect(createBody.prerelease).toBe(true)
   })
 })

--- a/config/scripts/create-draft-release.test.mjs
+++ b/config/scripts/create-draft-release.test.mjs
@@ -1,10 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import {
-  createDraftRelease,
-  latestPreviousDesktopReleaseTag,
-  parseDesktopReleaseTag,
-  truncateReleaseBody
-} from './create-draft-release.mjs'
+import { createDraftRelease, truncateReleaseBody } from './create-draft-release.mjs'
 
 function jsonResponse(body, init = {}) {
   return {
@@ -29,51 +24,10 @@ describe('truncateReleaseBody', () => {
   })
 })
 
-describe('parseDesktopReleaseTag', () => {
-  it('parses stable and rc desktop release tags only', () => {
-    expect(parseDesktopReleaseTag('v1.4.36')).toMatchObject({
-      tag: 'v1.4.36',
-      major: 1,
-      minor: 4,
-      patch: 36,
-      rc: null
-    })
-    expect(parseDesktopReleaseTag('v1.4.36-rc.2')).toMatchObject({
-      tag: 'v1.4.36-rc.2',
-      major: 1,
-      minor: 4,
-      patch: 36,
-      rc: 2
-    })
-    expect(parseDesktopReleaseTag('mobile-v0.0.12')).toBeNull()
-  })
-})
-
-describe('latestPreviousDesktopReleaseTag', () => {
-  it('bounds stable notes to the previous rc when one exists', () => {
-    expect(latestPreviousDesktopReleaseTag(['v1.4.35', 'v1.4.36-rc.0', 'v1.4.36'], 'v1.4.36')).toBe(
-      'v1.4.36-rc.0'
-    )
-  })
-
-  it('bounds the first rc notes to the previous stable release', () => {
-    expect(
-      latestPreviousDesktopReleaseTag(['v1.4.35', 'v1.4.36-rc.0', 'mobile-v0.0.12'], 'v1.4.36-rc.0')
-    ).toBe('v1.4.35')
-  })
-
-  it('bounds later rc notes to the prior rc', () => {
-    expect(latestPreviousDesktopReleaseTag(['v1.4.36-rc.0', 'v1.4.36-rc.1'], 'v1.4.36-rc.1')).toBe(
-      'v1.4.36-rc.0'
-    )
-  })
-})
-
 describe('createDraftRelease', () => {
   it('creates a draft release with bounded generated notes', async () => {
     const fetchImpl = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse([{ name: 'v1.4.35' }, { name: 'v1.4.36' }]))
       .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36', body: 'a'.repeat(130_000) }))
       .mockResolvedValueOnce(jsonResponse({ tag_name: 'v1.4.36', draft: true }))
 
@@ -81,17 +35,13 @@ describe('createDraftRelease', () => {
       repo: 'stablyai/orca',
       tag: 'v1.4.36',
       token: 'token',
+      previousTag: 'v1.4.35',
       fetchImpl,
       log: vi.fn()
     })
 
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
-      'https://api.github.com/repos/stablyai/orca/tags?per_page=100&page=1',
-      expect.any(Object)
-    )
-    expect(fetchImpl).toHaveBeenNthCalledWith(
-      2,
       'https://api.github.com/repos/stablyai/orca/releases/generate-notes',
       expect.objectContaining({
         method: 'POST',
@@ -103,15 +53,16 @@ describe('createDraftRelease', () => {
       })
     )
     expect(fetchImpl).toHaveBeenNthCalledWith(
-      3,
+      2,
       'https://api.github.com/repos/stablyai/orca/releases',
       expect.objectContaining({
         method: 'POST',
         body: expect.any(String)
       })
     )
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
 
-    const createBody = JSON.parse(fetchImpl.mock.calls[2][1].body)
+    const createBody = JSON.parse(fetchImpl.mock.calls[1][1].body)
     expect(createBody).toMatchObject({
       tag_name: 'v1.4.36',
       name: 'v1.4.36',
@@ -125,7 +76,6 @@ describe('createDraftRelease', () => {
   it('marks rc tags as prereleases', async () => {
     const fetchImpl = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse([{ name: 'v1.4.36' }, { name: 'v1.4.36-rc.1' }]))
       .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36-rc.1', body: 'notes' }))
       .mockResolvedValueOnce(jsonResponse({ tag_name: 'v1.4.36-rc.1', draft: true }))
 
@@ -133,11 +83,47 @@ describe('createDraftRelease', () => {
       repo: 'stablyai/orca',
       tag: 'v1.4.36-rc.1',
       token: 'token',
+      previousTag: 'v1.4.36',
       fetchImpl,
       log: vi.fn()
     })
 
-    const createBody = JSON.parse(fetchImpl.mock.calls[2][1].body)
+    const createBody = JSON.parse(fetchImpl.mock.calls[1][1].body)
     expect(createBody.prerelease).toBe(true)
+  })
+
+  it('omits previous_tag_name when no previous desktop release exists', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ name: 'v1.0.0', body: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ tag_name: 'v1.0.0', draft: true }))
+
+    await createDraftRelease({
+      repo: 'stablyai/orca',
+      tag: 'v1.0.0',
+      token: 'token',
+      previousTag: '',
+      fetchImpl,
+      log: vi.fn()
+    })
+
+    const generateNotesBody = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(generateNotesBody).toEqual({
+      tag_name: 'v1.0.0',
+      target_commitish: 'v1.0.0'
+    })
+  })
+
+  it('rejects a non-desktop previous tag', async () => {
+    await expect(
+      createDraftRelease({
+        repo: 'stablyai/orca',
+        tag: 'v1.4.36',
+        token: 'token',
+        previousTag: 'mobile-v0.0.12',
+        fetchImpl: vi.fn(),
+        log: vi.fn()
+      })
+    ).rejects.toThrow('previousTag must be a desktop release tag')
   })
 })

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -198,6 +198,32 @@ describe('Electron runtime package contract', () => {
     expect(versionStep.run).toContain('git rev-parse "$existing_rc_tag"')
   })
 
+  it('passes the locally resolved previous desktop tag to draft release creation', () => {
+    const releaseWorkflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
+    )
+    const previousTagStep = releaseWorkflow.jobs.cut.steps.find(
+      (step) => step.name === 'Resolve previous desktop tag'
+    )
+    const createReleaseStep = releaseWorkflow.jobs['create-release'].steps.find(
+      (step) => step.name === 'Create draft release with bounded generated notes'
+    )
+
+    expect(releaseWorkflow.jobs.cut.outputs.previous_tag).toBe(
+      '${{ steps.previous_tag.outputs.previous_tag }}'
+    )
+    expect(previousTagStep.if).toContain("steps.tag.outputs.tag != ''")
+    expect(previousTagStep.if).toContain("steps.version.outputs.recovered_tag != ''")
+    expect(previousTagStep.env.TAG).toBe(
+      '${{ steps.tag.outputs.tag || steps.version.outputs.recovered_tag }}'
+    )
+    expect(previousTagStep.run).toContain(
+      'node config/scripts/previous-desktop-release-tag.mjs "$TAG"'
+    )
+    expect(createReleaseStep.env.PREVIOUS_TAG).toBe('${{ needs.cut.outputs.previous_tag }}')
+    expect(createReleaseStep.run).toContain('node config/scripts/create-draft-release.mjs "$TAG"')
+  })
+
   it('bumps separate Homebrew casks for stable and RC desktop tags', () => {
     const releaseWorkflow = parse(
       readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')

--- a/config/scripts/previous-desktop-release-tag.mjs
+++ b/config/scripts/previous-desktop-release-tag.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const DESKTOP_RELEASE_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?$/
+
+export function parseDesktopReleaseTag(tag) {
+  if (typeof tag !== 'string') {
+    return null
+  }
+
+  const match = DESKTOP_RELEASE_TAG_PATTERN.exec(tag)
+  if (!match) {
+    return null
+  }
+
+  return {
+    tag,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    rc: match[4] === undefined ? null : Number(match[4])
+  }
+}
+
+function compareDesktopReleaseTags(a, b) {
+  const versionDiff = a.major - b.major || a.minor - b.minor || a.patch - b.patch
+  if (versionDiff !== 0) {
+    return versionDiff
+  }
+  if (a.rc === b.rc) {
+    return 0
+  }
+  if (a.rc === null) {
+    return 1
+  }
+  if (b.rc === null) {
+    return -1
+  }
+  return a.rc - b.rc
+}
+
+export function latestPreviousDesktopReleaseTag(tags, tag) {
+  const current = parseDesktopReleaseTag(tag)
+  if (!current) {
+    return ''
+  }
+
+  const previousTags = tags
+    .map((candidate) => parseDesktopReleaseTag(candidate))
+    .filter((candidate) => candidate && candidate.tag !== current.tag)
+    .filter((candidate) => compareDesktopReleaseTags(candidate, current) < 0)
+    .sort(compareDesktopReleaseTags)
+
+  return previousTags.at(-1)?.tag ?? ''
+}
+
+export function gitTagNames({ cwd = process.cwd(), execFileSyncImpl = execFileSync } = {}) {
+  return execFileSyncImpl('git', ['tag', '--list'], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+export function previousDesktopReleaseTagFromGit(tag, options = {}) {
+  if (!parseDesktopReleaseTag(tag)) {
+    return ''
+  }
+
+  return latestPreviousDesktopReleaseTag(gitTagNames(options), tag)
+}
+
+function main() {
+  const tag = process.argv[2]
+  if (!tag) {
+    throw new Error('Usage: node config/scripts/previous-desktop-release-tag.mjs <tag>')
+  }
+
+  process.stdout.write(previousDesktopReleaseTagFromGit(tag))
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}

--- a/config/scripts/previous-desktop-release-tag.test.mjs
+++ b/config/scripts/previous-desktop-release-tag.test.mjs
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  gitTagNames,
+  latestPreviousDesktopReleaseTag,
+  parseDesktopReleaseTag,
+  previousDesktopReleaseTagFromGit
+} from './previous-desktop-release-tag.mjs'
+
+describe('parseDesktopReleaseTag', () => {
+  it('parses stable and rc desktop release tags only', () => {
+    expect(parseDesktopReleaseTag('v1.4.36')).toMatchObject({
+      tag: 'v1.4.36',
+      major: 1,
+      minor: 4,
+      patch: 36,
+      rc: null
+    })
+    expect(parseDesktopReleaseTag('v1.4.36-rc.2')).toMatchObject({
+      tag: 'v1.4.36-rc.2',
+      major: 1,
+      minor: 4,
+      patch: 36,
+      rc: 2
+    })
+    expect(parseDesktopReleaseTag('mobile-v0.0.12')).toBeNull()
+  })
+})
+
+describe('latestPreviousDesktopReleaseTag', () => {
+  it('bounds stable notes to the previous rc when one exists', () => {
+    expect(latestPreviousDesktopReleaseTag(['v1.4.35', 'v1.4.36-rc.0', 'v1.4.36'], 'v1.4.36')).toBe(
+      'v1.4.36-rc.0'
+    )
+  })
+
+  it('bounds the first rc notes to the previous stable release', () => {
+    expect(
+      latestPreviousDesktopReleaseTag(['v1.4.35', 'v1.4.36-rc.0', 'mobile-v0.0.12'], 'v1.4.36-rc.0')
+    ).toBe('v1.4.35')
+  })
+
+  it('bounds later rc notes to the prior rc', () => {
+    expect(latestPreviousDesktopReleaseTag(['v1.4.36-rc.0', 'v1.4.36-rc.1'], 'v1.4.36-rc.1')).toBe(
+      'v1.4.36-rc.0'
+    )
+  })
+
+  it('orders rc numbers numerically', () => {
+    expect(latestPreviousDesktopReleaseTag(['v1.4.36-rc.2', 'v1.4.36-rc.10'], 'v1.4.36')).toBe(
+      'v1.4.36-rc.10'
+    )
+  })
+})
+
+describe('gitTagNames', () => {
+  it('reads local git tag names without network access', () => {
+    const execFileSyncImpl = vi.fn(() => 'v1.4.35\n\nv1.4.36-rc.0\n')
+
+    expect(gitTagNames({ cwd: '/repo', execFileSyncImpl })).toEqual(['v1.4.35', 'v1.4.36-rc.0'])
+    expect(execFileSyncImpl).toHaveBeenCalledWith(
+      'git',
+      ['tag', '--list'],
+      expect.objectContaining({
+        cwd: '/repo',
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    )
+  })
+})
+
+describe('previousDesktopReleaseTagFromGit', () => {
+  it('selects the previous desktop tag from local git tags', () => {
+    const execFileSyncImpl = vi.fn(() => 'mobile-v0.0.12\nv1.4.35\nv1.4.36-rc.0\nv1.4.36\n')
+
+    expect(previousDesktopReleaseTagFromGit('v1.4.36', { execFileSyncImpl })).toBe('v1.4.36-rc.0')
+  })
+
+  it('does not inspect git for non-desktop tags', () => {
+    const execFileSyncImpl = vi.fn(() => {
+      throw new Error('git should not be called')
+    })
+
+    expect(previousDesktopReleaseTagFromGit('mobile-v0.0.12', { execFileSyncImpl })).toBe('')
+    expect(execFileSyncImpl).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** Anyone reading Orca's GitHub Releases page sees a mess: each new release's "what changed" notes don't just list that release's changes — they pile on every change from several releases back, repeating the same items over and over. It's not a crash or a blocker, and it doesn't touch the app itself; it's a credibility/clarity problem on the public release log that gets steadily worse with every release. So it hits everyone who reads the release notes (users, contributors), but the pain is "confusing, bloated changelog" rather than "the app is broken."

**2) What this PR does (ELI5).** Think of release notes like a "what's new since last time" receipt. The script that auto-generates them was never told where "last time" was, so GitHub guessed — and because Orca's releases are created as *drafts* (which GitHub's guesser can't see), it kept guessing way too far back and re-listing old stuff. This PR teaches the release workflow to figure out the correct previous version on its own: it reads the git tags already present in the release-cut job, sorts them properly (so a real release ranks above its release candidates, and `rc.10` correctly comes after `rc.2`, not before), picks the one right before the current release, and hands GitHub that exact starting point. Oh, so the notes now cover "just the changes since the previous version" instead of "everything since some random old release."

**3) Tradeoffs / regressions — honest answer.** No user-facing regressions. This only touches release-cut CI scripts and never runs inside the app. The earlier caveat about extra paginated `GET /tags` API calls is gone: the `cut` job already checks out the full tag graph with `fetch-depth: 0`, so it resolves the previous desktop tag locally with `git tag --list` and passes that value to the draft-release job. First-release and non-desktop cases still pass an empty boundary and preserve the previous fallback behavior. Net new GitHub API calls: zero.

---

## Summary

Fixes #5579 — GitHub release notes kept accumulating across multiple releases.

`config/scripts/create-draft-release.mjs` called GitHub's `generate-notes` API with only `tag_name` + `target_commitish` and omitted `previous_tag_name`. Without that field, GitHub derives the note baseline from the most recent **published** release. But this script creates releases with `draft: true`, and draft releases are invisible to GitHub's baseline detection. As a result, every release's generated notes spanned back to the last *non-draft* release, re-including the commits of every intervening draft and accumulating notes over multiple releases.

This change derives the nearest prior desktop/RC tag from local git tags in the `cut` job (stable ranks above any RC of the same version; `rc.10` ranks above `rc.2`), passes it to the draft-release job as `PREVIOUS_TAG`, and sends it as `previous_tag_name` to bound the generated note range. When no prior desktop tag exists (first release, or a non-desktop tag), the field is omitted so behavior is unchanged.

This supersedes community PR #5649; the code has been re-implemented and re-verified here and is now owned by this repo. The original PR is left open.

## Screenshots

No visual change — this is a release-cut CI script.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck` (`tsgo --noEmit -p config/tsconfig.node.json` — exit 0; the `.mjs` scripts are not part of any tsconfig, so this confirms no regression elsewhere)
- [x] `pnpm test` (targeted: `vitest run --config config/vitest.config.ts config/scripts/create-draft-release.test.mjs config/scripts/previous-desktop-release-tag.test.mjs config/scripts/package-electron-runtime-contract.test.mjs` — 30/30 pass)
- [ ] `pnpm build`
- [x] Added/updated tests: local previous-tag resolver tests for stable/RC/non-desktop parsing, numeric RC ordering, and `git tag --list`; `createDraftRelease` tests assert `previous_tag_name` is included without any tag-list API call; workflow contract coverage asserts `previous_tag` flows from `cut` to `create-release`.

Scoped lint: `oxlint .github/workflows/release-cut.yml config/scripts/create-draft-release.mjs config/scripts/create-draft-release.test.mjs config/scripts/previous-desktop-release-tag.mjs config/scripts/previous-desktop-release-tag.test.mjs config/scripts/package-electron-runtime-contract.test.mjs` — clean (no findings).

## AI Review Report

Reviewed the diff adversarially for correctness, edge cases, and security.
- Numeric RC ordering verified (`rc.10` > `rc.2`); stable (rc=null) ranks above same-version RC, so cutting a stable release bounds notes to its own last RC.
- First-release / non-desktop-tag cases return `''` and omit `previous_tag_name`, preserving original behavior.
- Current-tag-not-yet-propagated case handled (strict `< 0` comparison + self-exclusion behave identically whether the new tag is present in the tag list or not).
- Cross-platform: pure Node ESM string/array logic plus fixed-argv local `git tag --list`; no filesystem paths, no OS branching, no keyboard shortcuts, no Electron surface. Runs in `release-cut.yml` CI. No macOS/Linux/Windows-specific behavior touched.

## Security Audit

- No new dependencies, no `eval`/dynamic import, no shell execution. The only child process is `execFileSync('git', ['tag', '--list'], ...)` with fixed argv and no user-controlled shell interpolation.
- No new network/API call beyond the existing `generate-notes` and `releases` requests. The previous tag is resolved from local git refs already available in the `cut` job.
- `previous_tag_name` is derived only from local tag names matching the strict regex `^v(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?$`; non-matching (attacker-crafted) tag names are dropped, so they cannot inject content into the request body.
- No secret access beyond the token already passed in. No exfiltration.

## Notes

GitHub-specific by domain (release-cut script targeting `api.github.com`), so no GitLab/other-provider concern applies.

Supersedes #5649 (left open). Co-authored with the original author via commit trailer.

Made with [Orca](https://github.com/stablyai/orca) 🐋

