### PR TITLE
fix: verify terminal clipboard writes so success never lies (#5611)

### DIFF
--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -239,7 +239,20 @@ describe('registerClipboardHandlers', () => {
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('primary text', 'selection')
   })
 
-  it('rejects standard text writes when the clipboard read-back does not match', async () => {
+  it('does not verify standard text writes by default', async () => {
+    clipboardReadTextMock.mockReturnValue('old clipboard')
+
+    registerClipboardHandlers({} as never)
+
+    const handlers = getRegisteredHandlers()
+    await expect(
+      handlers.get('clipboard:writeText')?.(makeClipboardEvent(), 'copilot answer')
+    ).resolves.toBeUndefined()
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith('copilot answer')
+    expect(clipboardReadTextMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects verified standard text writes when the clipboard read-back does not match', async () => {
     // Why: Electron can return without throwing while the OS clipboard keeps its
     // previous contents (#5611), so the handler must surface a failure instead.
     clipboardReadTextMock.mockReturnValue('old clipboard')
@@ -248,7 +261,9 @@ describe('registerClipboardHandlers', () => {
 
     const handlers = getRegisteredHandlers()
     await expect(
-      handlers.get('clipboard:writeText')?.(makeClipboardEvent(), 'copilot answer')
+      handlers.get('clipboard:writeText')?.(makeClipboardEvent(), 'copilot answer', {
+        verify: true
+      })
     ).rejects.toThrow('Clipboard write verification failed')
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('copilot answer')
   })
@@ -263,7 +278,9 @@ describe('registerClipboardHandlers', () => {
 
     const handlers = getRegisteredHandlers()
     await expect(
-      handlers.get('clipboard:writeSelectionText')?.(makeClipboardEvent(), 'primary text')
+      handlers.get('clipboard:writeSelectionText')?.(makeClipboardEvent(), 'primary text', {
+        verify: true
+      })
     ).resolves.toBeUndefined()
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('primary text', 'selection')
   })
@@ -511,10 +528,6 @@ describe('registerClipboardHandlers', () => {
   it('yields before writing large text clipboard IPC payloads', async () => {
     vi.useFakeTimers()
     const text = 'é'.repeat(300_000)
-    // Why: the handler reads the clipboard back to verify the write landed, so
-    // the mock must echo what was written for the success path under test.
-    clipboardReadTextMock.mockReturnValue(text)
-
     registerClipboardHandlers({} as never)
 
     const handlers = getRegisteredHandlers()

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -208,9 +208,18 @@ describe('registerClipboardHandlers', () => {
   })
 
   it('registers normal and selection text clipboard IPC handlers', async () => {
+    let normalClipboard = 'standard text'
+    let selectionClipboard = 'selection text'
     clipboardReadTextMock.mockImplementation((clipboardType?: string) =>
-      clipboardType === 'selection' ? 'selection text' : 'standard text'
+      clipboardType === 'selection' ? selectionClipboard : normalClipboard
     )
+    clipboardWriteTextMock.mockImplementation((text: string, clipboardType?: string) => {
+      if (clipboardType === 'selection') {
+        selectionClipboard = text
+      } else {
+        normalClipboard = text
+      }
+    })
 
     registerClipboardHandlers({} as never)
 
@@ -227,6 +236,35 @@ describe('registerClipboardHandlers', () => {
     expect(clipboardReadTextMock).toHaveBeenCalledWith()
     expect(clipboardReadTextMock).toHaveBeenCalledWith('selection')
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('normal text')
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith('primary text', 'selection')
+  })
+
+  it('rejects standard text writes when the clipboard read-back does not match', async () => {
+    // Why: Electron can return without throwing while the OS clipboard keeps its
+    // previous contents (#5611), so the handler must surface a failure instead.
+    clipboardReadTextMock.mockReturnValue('old clipboard')
+
+    registerClipboardHandlers({} as never)
+
+    const handlers = getRegisteredHandlers()
+    await expect(
+      handlers.get('clipboard:writeText')?.(makeClipboardEvent(), 'copilot answer')
+    ).rejects.toThrow('Clipboard write verification failed')
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith('copilot answer')
+  })
+
+  it('does not verify the X11 PRIMARY selection clipboard read-back', async () => {
+    // Why: the PRIMARY selection hands ownership to the last selector, so a
+    // read-back can legitimately differ from what we wrote — verifying it would
+    // surface false failures on Linux primary-selection copies.
+    clipboardReadTextMock.mockReturnValue('owned by another app')
+
+    registerClipboardHandlers({} as never)
+
+    const handlers = getRegisteredHandlers()
+    await expect(
+      handlers.get('clipboard:writeSelectionText')?.(makeClipboardEvent(), 'primary text')
+    ).resolves.toBeUndefined()
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('primary text', 'selection')
   })
 
@@ -473,6 +511,9 @@ describe('registerClipboardHandlers', () => {
   it('yields before writing large text clipboard IPC payloads', async () => {
     vi.useFakeTimers()
     const text = 'é'.repeat(300_000)
+    // Why: the handler reads the clipboard back to verify the write landed, so
+    // the mock must echo what was written for the success path under test.
+    clipboardReadTextMock.mockReturnValue(text)
 
     registerClipboardHandlers({} as never)
 

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -13,7 +13,8 @@ import { isENOENT, PATH_ACCESS_DENIED_MESSAGE, resolveAuthorizedPath } from '../
 import {
   assertClipboardTextWriteWithinLimitWithYield,
   assertClipboardTextWithinLimitWithYield,
-  type ReadClipboardTextOptions
+  type ReadClipboardTextOptions,
+  type WriteClipboardTextOptions
 } from '../../shared/clipboard-text'
 import {
   saveClipboardImageBufferAsTempFile,
@@ -71,23 +72,14 @@ function runCommand(command: string, args: string[], stdin?: string): Promise<vo
   })
 }
 
-// Why: Electron's clipboard.writeText returns without throwing even when the OS
-// clipboard keeps its previous contents (observed on Windows with Copilot
-// terminal copies), so a renderer "Copied" success state can be a lie. Read the
-// value back so a successful write actually means pasteable content.
-function writeClipboardTextAndVerify(text: string, clipboardType?: 'selection'): void {
-  if (clipboardType) {
-    clipboard.writeText(text, clipboardType)
-  } else {
-    clipboard.writeText(text)
-  }
-  // Why: only verify the standard clipboard. The X11 PRIMARY "selection"
-  // clipboard hands ownership to whoever last selected text, so a read-back can
-  // legitimately differ from what we just wrote — verifying it would surface
-  // false failures on Linux primary-selection copies.
-  if (clipboardType === 'selection') {
+function writeStandardClipboardText(text: string, options?: WriteClipboardTextOptions): void {
+  clipboard.writeText(text)
+  if (!options?.verify) {
     return
   }
+  // Why: terminal copy success UI depends on pasteable text. Electron can
+  // return from writeText while the OS clipboard stayed unchanged (#5611), so
+  // verified callers pay the read-back cost only when they need that guarantee.
   if (clipboard.readText() !== text) {
     throw new Error('Clipboard write verification failed')
   }
@@ -162,17 +154,28 @@ export function registerClipboardHandlers(store: Store): void {
       return writeFileToClipboard(request.filePath, deps)
     }
   )
-  ipcMain.handle('clipboard:writeText', async (event, text: string) => {
-    assertTrustedClipboardSender(event)
-    return writeClipboardTextAndVerify(await assertClipboardTextWriteWithinLimitWithYield(text))
-  })
-  ipcMain.handle('clipboard:writeSelectionText', async (event, text: string) => {
-    assertTrustedClipboardSender(event)
-    return writeClipboardTextAndVerify(
-      await assertClipboardTextWriteWithinLimitWithYield(text),
-      'selection'
-    )
-  })
+  ipcMain.handle(
+    'clipboard:writeText',
+    async (event, text: string, options?: WriteClipboardTextOptions) => {
+      assertTrustedClipboardSender(event)
+      return writeStandardClipboardText(
+        await assertClipboardTextWriteWithinLimitWithYield(text, options),
+        options
+      )
+    }
+  )
+  ipcMain.handle(
+    'clipboard:writeSelectionText',
+    async (event, text: string, options?: WriteClipboardTextOptions) => {
+      assertTrustedClipboardSender(event)
+      // Why: the X11 PRIMARY "selection" clipboard hands ownership to whoever
+      // last selected text, so read-back verification would create false failures.
+      return clipboard.writeText(
+        await assertClipboardTextWriteWithinLimitWithYield(text, options),
+        'selection'
+      )
+    }
+  )
   ipcMain.handle('clipboard:writeImage', (event, dataUrl: string) => {
     assertTrustedClipboardSender(event)
     // Why: only accept validated PNG data URIs to prevent writing arbitrary

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -71,6 +71,28 @@ function runCommand(command: string, args: string[], stdin?: string): Promise<vo
   })
 }
 
+// Why: Electron's clipboard.writeText returns without throwing even when the OS
+// clipboard keeps its previous contents (observed on Windows with Copilot
+// terminal copies), so a renderer "Copied" success state can be a lie. Read the
+// value back so a successful write actually means pasteable content.
+function writeClipboardTextAndVerify(text: string, clipboardType?: 'selection'): void {
+  if (clipboardType) {
+    clipboard.writeText(text, clipboardType)
+  } else {
+    clipboard.writeText(text)
+  }
+  // Why: only verify the standard clipboard. The X11 PRIMARY "selection"
+  // clipboard hands ownership to whoever last selected text, so a read-back can
+  // legitimately differ from what we just wrote — verifying it would surface
+  // false failures on Linux primary-selection copies.
+  if (clipboardType === 'selection') {
+    return
+  }
+  if (clipboard.readText() !== text) {
+    throw new Error('Clipboard write verification failed')
+  }
+}
+
 export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:readText')
   ipcMain.removeHandler('clipboard:readSelectionText')
@@ -142,11 +164,11 @@ export function registerClipboardHandlers(store: Store): void {
   )
   ipcMain.handle('clipboard:writeText', async (event, text: string) => {
     assertTrustedClipboardSender(event)
-    return clipboard.writeText(await assertClipboardTextWriteWithinLimitWithYield(text))
+    return writeClipboardTextAndVerify(await assertClipboardTextWriteWithinLimitWithYield(text))
   })
   ipcMain.handle('clipboard:writeSelectionText', async (event, text: string) => {
     assertTrustedClipboardSender(event)
-    return clipboard.writeText(
+    return writeClipboardTextAndVerify(
       await assertClipboardTextWriteWithinLimitWithYield(text),
       'selection'
     )

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -9,7 +9,7 @@ import type {
   HostedReviewProvider
 } from '../shared/hosted-review'
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
-import type { ReadClipboardTextOptions } from '../shared/clipboard-text'
+import type { ReadClipboardTextOptions, WriteClipboardTextOptions } from '../shared/clipboard-text'
 import type { AppIdentity } from '../shared/app-identity'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { TaskSourceContext } from '../shared/task-source-context'
@@ -2496,7 +2496,7 @@ export type PreloadApi = {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null
     }) => Promise<string | null>
-    writeClipboardText: (text: string) => Promise<void>
+    writeClipboardText: (text: string, options?: WriteClipboardTextOptions) => Promise<void>
     writeSelectionClipboardText: (text: string) => Promise<void>
     writeClipboardImage: (dataUrl: string) => Promise<void>
     performNativePaste: (options?: { mode?: 'paste' | 'paste-and-match-style' }) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -176,7 +176,7 @@ import {
 import { subscribeRuntimeEnvironmentFromPreload } from './runtime-environment-subscriptions'
 import type { RuntimeEnvironmentSubscriptionHandle } from './runtime-environment-subscriptions'
 import type { HostedReviewForBranchArgs } from '../shared/hosted-review'
-import type { ReadClipboardTextOptions } from '../shared/clipboard-text'
+import type { ReadClipboardTextOptions, WriteClipboardTextOptions } from '../shared/clipboard-text'
 import type {
   CrashReportBreadcrumbData,
   CrashReportSubmitArgs,
@@ -3282,8 +3282,8 @@ const api = {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null
     }): Promise<string | null> => ipcRenderer.invoke('clipboard:saveImageAsTempFile', args),
-    writeClipboardText: (text: string): Promise<void> =>
-      ipcRenderer.invoke('clipboard:writeText', text),
+    writeClipboardText: (text: string, options?: WriteClipboardTextOptions): Promise<void> =>
+      ipcRenderer.invoke('clipboard:writeText', text, options),
     writeSelectionClipboardText: (text: string): Promise<void> =>
       ipcRenderer.invoke('clipboard:writeSelectionText', text),
     writeClipboardImage: (dataUrl: string): Promise<void> =>

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -22,6 +22,8 @@ import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-in
 import { useAppStore } from '@/store'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { copyTerminalSelection } from './terminal-selection-copy'
+import { writeTerminalClipboardText } from './terminal-clipboard-write'
+import { showTerminalClipboardCopyFailedToast } from './terminal-clipboard-copy-failure-toast'
 import {
   markTerminalFollowOutput,
   markTerminalPinnedViewport,
@@ -287,9 +289,9 @@ export function useTerminalKeyboardShortcuts({
         e.stopImmediatePropagation()
         void copyTerminalSelection({
           terminal: pane.terminal,
-          writeClipboardText: window.api.ui.writeClipboardText
+          writeClipboardText: writeTerminalClipboardText
         }).catch(() => {
-          /* ignore clipboard write failures */
+          showTerminalClipboardCopyFailedToast()
         })
         return
       }

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -21,6 +21,7 @@ import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
 import { useAppStore } from '@/store'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
+import { copyTerminalSelection } from './terminal-selection-copy'
 import {
   markTerminalFollowOutput,
   markTerminalPinnedViewport,
@@ -279,13 +280,15 @@ export function useTerminalKeyboardShortcuts({
         if (!pane) {
           return
         }
-        const selection = pane.terminal.getSelection()
-        if (!selection) {
+        if (!pane.terminal.getSelection()) {
           return
         }
         e.preventDefault()
         e.stopImmediatePropagation()
-        void window.api.ui.writeClipboardText(selection).catch(() => {
+        void copyTerminalSelection({
+          terminal: pane.terminal,
+          writeClipboardText: window.api.ui.writeClipboardText
+        }).catch(() => {
           /* ignore clipboard write failures */
         })
         return

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { OSC52_CLIPBOARD_SETTING_ID } from './osc52-clipboard-setting-anchor'
 import type * as Osc52ClipboardBlockedToastModule from './osc52-clipboard-blocked-toast'
 
-const { toastInfoMock, storeMock } = vi.hoisted(() => ({
+const { toastInfoMock, toastErrorMock, storeMock } = vi.hoisted(() => ({
   toastInfoMock: vi.fn(),
+  toastErrorMock: vi.fn(),
   storeMock: {
     setSettingsSearchQuery: vi.fn(),
     openSettingsTarget: vi.fn(),
@@ -13,7 +14,8 @@ const { toastInfoMock, storeMock } = vi.hoisted(() => ({
 
 vi.mock('sonner', () => ({
   toast: {
-    info: toastInfoMock
+    info: toastInfoMock,
+    error: toastErrorMock
   }
 }))
 
@@ -31,6 +33,7 @@ describe('showOsc52ClipboardBlockedToast', () => {
   beforeEach(() => {
     vi.resetModules()
     toastInfoMock.mockReset()
+    toastErrorMock.mockReset()
     storeMock.setSettingsSearchQuery.mockReset()
     storeMock.openSettingsTarget.mockReset()
     storeMock.openSettingsPage.mockReset()
@@ -66,5 +69,32 @@ describe('showOsc52ClipboardBlockedToast', () => {
     showOsc52ClipboardBlockedToast()
 
     expect(toastInfoMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('showOsc52ClipboardFailedToast', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    toastErrorMock.mockReset()
+  })
+
+  it('reports that the host clipboard did not update', async () => {
+    const { showOsc52ClipboardFailedToast } = await importToastModule()
+
+    showOsc52ClipboardFailedToast()
+
+    expect(toastErrorMock).toHaveBeenCalledWith('Terminal clipboard write failed', {
+      description: 'The terminal app requested a copy, but the system clipboard did not update.',
+      duration: 12_000
+    })
+  })
+
+  it('only shows once per renderer session', async () => {
+    const { showOsc52ClipboardFailedToast } = await importToastModule()
+
+    showOsc52ClipboardFailedToast()
+    showOsc52ClipboardFailedToast()
+
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
@@ -4,6 +4,7 @@ import { OSC52_CLIPBOARD_SETTING_ID } from './osc52-clipboard-setting-anchor'
 import { translate } from '@/i18n/i18n'
 
 let hasShownOsc52ClipboardBlockedToast = false
+let hasShownOsc52ClipboardFailedToast = false
 
 export function showOsc52ClipboardBlockedToast(): void {
   if (hasShownOsc52ClipboardBlockedToast) {
@@ -40,6 +41,27 @@ export function showOsc52ClipboardBlockedToast(): void {
           store.openSettingsPage()
         }
       }
+    }
+  )
+}
+
+export function showOsc52ClipboardFailedToast(): void {
+  if (hasShownOsc52ClipboardFailedToast) {
+    return
+  }
+  hasShownOsc52ClipboardFailedToast = true
+
+  toast.error(
+    translate(
+      'auto.components.terminal.pane.osc52.clipboard.failed.toast.62a0af2cb4',
+      'Terminal clipboard write failed'
+    ),
+    {
+      description: translate(
+        'auto.components.terminal.pane.osc52.clipboard.failed.toast.fdd3e7e977',
+        'The terminal app requested a copy, but the system clipboard did not update.'
+      ),
+      duration: 12_000
     }
   )
 }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
@@ -113,4 +113,18 @@ describe('handleOsc52ClipboardRequest', () => {
 
     expect(onBlockedWrite).not.toHaveBeenCalled()
   })
+
+  it('surfaces host clipboard write failures for OSC 52 requests', async () => {
+    const onWriteFailure = vi.fn()
+
+    handleOsc52ClipboardRequest(`c;${b64('from copilot')}`, {
+      allowClipboardWrite: true,
+      writeClipboardText: vi
+        .fn<(text: string) => Promise<void>>()
+        .mockRejectedValue(new Error('clipboard unchanged')),
+      onWriteFailure
+    })
+
+    await vi.waitFor(() => expect(onWriteFailure).toHaveBeenCalledTimes(1))
+  })
 })

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
@@ -26,6 +26,7 @@ export type Osc52ClipboardRequestOptions = {
   allowClipboardWrite: boolean
   writeClipboardText: (text: string) => Promise<void>
   onBlockedWrite?: () => void
+  onWriteFailure?: () => void
 }
 
 const MAX_OSC52_BYTES = 128 * 1024
@@ -45,7 +46,9 @@ export function handleOsc52ClipboardRequest(
   }
 
   void options.writeClipboardText(parsed.text).catch(() => {
-    /* ignore clipboard write failures */
+    // Why: a TUI yank (tmux/nvim/fzf/Copilot) that reports success but never
+    // reached the OS clipboard must surface a toast, not silently no-op.
+    options.onWriteFailure?.()
   })
   return true
 }

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-copy-failure-toast.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-copy-failure-toast.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as TerminalClipboardCopyFailureToastModule from './terminal-clipboard-copy-failure-toast'
+
+const { toastErrorMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: toastErrorMock
+  }
+}))
+
+async function importToastModule(): Promise<typeof TerminalClipboardCopyFailureToastModule> {
+  return import('./terminal-clipboard-copy-failure-toast')
+}
+
+describe('showTerminalClipboardCopyFailedToast', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    toastErrorMock.mockReset()
+  })
+
+  it('reports that terminal selection copy did not update the system clipboard', async () => {
+    const { showTerminalClipboardCopyFailedToast } = await importToastModule()
+
+    showTerminalClipboardCopyFailedToast()
+
+    expect(toastErrorMock).toHaveBeenCalledWith('Terminal copy failed', {
+      description: 'The system clipboard did not update. Your selection is still highlighted.',
+      duration: 12_000
+    })
+  })
+
+  it('only shows once per renderer session', async () => {
+    const { showTerminalClipboardCopyFailedToast } = await importToastModule()
+
+    showTerminalClipboardCopyFailedToast()
+    showTerminalClipboardCopyFailedToast()
+
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-copy-failure-toast.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-copy-failure-toast.ts
@@ -1,0 +1,25 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+
+let hasShownTerminalClipboardCopyFailedToast = false
+
+export function showTerminalClipboardCopyFailedToast(): void {
+  if (hasShownTerminalClipboardCopyFailedToast) {
+    return
+  }
+  hasShownTerminalClipboardCopyFailedToast = true
+
+  toast.error(
+    translate(
+      'auto.components.terminal.pane.terminal.clipboard.copy.failure.toast.title',
+      'Terminal copy failed'
+    ),
+    {
+      description: translate(
+        'auto.components.terminal.pane.terminal.clipboard.copy.failure.toast.description',
+        'The system clipboard did not update. Your selection is still highlighted.'
+      ),
+      duration: 12_000
+    }
+  )
+}

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-write.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-write.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { writeTerminalClipboardText } from './terminal-clipboard-write'
+
+function installClipboardWriter(
+  writeClipboardText: (text: string, options?: unknown) => Promise<void>
+): void {
+  vi.stubGlobal('window', {
+    api: {
+      ui: {
+        writeClipboardText
+      }
+    }
+  })
+}
+
+describe('writeTerminalClipboardText', () => {
+  afterEach(() => {
+    delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+    vi.unstubAllGlobals()
+  })
+
+  it('requests desktop write verification for terminal copies', async () => {
+    const writeClipboardText = vi
+      .fn<(text: string, options?: unknown) => Promise<void>>()
+      .mockResolvedValue(undefined)
+    installClipboardWriter(writeClipboardText)
+
+    await writeTerminalClipboardText('copilot answer')
+
+    expect(writeClipboardText).toHaveBeenCalledWith('copilot answer', { verify: true })
+  })
+
+  it('keeps paired web clients on the browser clipboard write signal', async () => {
+    const globals = globalThis as { __ORCA_WEB_CLIENT__?: boolean }
+    globals.__ORCA_WEB_CLIENT__ = true
+    const writeClipboardText = vi
+      .fn<(text: string, options?: unknown) => Promise<void>>()
+      .mockResolvedValue(undefined)
+    installClipboardWriter(writeClipboardText)
+
+    await writeTerminalClipboardText('copilot answer')
+
+    expect(writeClipboardText).toHaveBeenCalledWith('copilot answer', undefined)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-write.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-write.ts
@@ -1,0 +1,11 @@
+import { isPairedWebClientWindow } from '@/lib/desktop-window-chrome'
+
+export function writeTerminalClipboardText(text: string): Promise<void> {
+  // Why: desktop terminal copy UI must only report success after the OS
+  // clipboard is pasteable (#5611). Browser read permission is separate, so
+  // paired web clients keep the browser write promise as their success signal.
+  return window.api.ui.writeClipboardText(
+    text,
+    isPairedWebClientWindow() ? undefined : { verify: true }
+  )
+}

--- a/src/renderer/src/components/terminal-pane/terminal-selection-copy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-selection-copy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { copyTerminalSelection } from './terminal-selection-copy'
+
+function makeTerminal(selection: string) {
+  return {
+    getSelection: vi.fn(() => selection),
+    clearSelection: vi.fn()
+  }
+}
+
+describe('copyTerminalSelection', () => {
+  it('writes selected terminal text to the clipboard', async () => {
+    const terminal = makeTerminal('copilot answer')
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue()
+
+    await expect(copyTerminalSelection({ terminal, writeClipboardText })).resolves.toBe(true)
+
+    expect(writeClipboardText).toHaveBeenCalledWith('copilot answer')
+    expect(terminal.clearSelection).not.toHaveBeenCalled()
+  })
+
+  it('does not claim success for an empty xterm selection', async () => {
+    const terminal = makeTerminal('')
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue()
+
+    await expect(copyTerminalSelection({ terminal, writeClipboardText })).resolves.toBe(false)
+
+    expect(writeClipboardText).not.toHaveBeenCalled()
+    expect(terminal.clearSelection).not.toHaveBeenCalled()
+  })
+
+  it('clears xterm selection only after the clipboard write succeeds', async () => {
+    const terminal = makeTerminal('copilot answer')
+    const writeClipboardText = vi
+      .fn<(text: string) => Promise<void>>()
+      .mockRejectedValue(new Error('clipboard unchanged'))
+
+    await expect(
+      copyTerminalSelection({ terminal, writeClipboardText, clearSelectionOnSuccess: true })
+    ).rejects.toThrow('clipboard unchanged')
+
+    expect(terminal.clearSelection).not.toHaveBeenCalled()
+  })
+
+  it('clears the xterm selection after a successful write when requested', async () => {
+    const terminal = makeTerminal('copilot answer')
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue()
+
+    await expect(
+      copyTerminalSelection({ terminal, writeClipboardText, clearSelectionOnSuccess: true })
+    ).resolves.toBe(true)
+
+    expect(terminal.clearSelection).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-selection-copy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-selection-copy.ts
@@ -1,0 +1,29 @@
+import type { Terminal } from '@xterm/xterm'
+
+type TerminalSelectionCopyOptions = {
+  terminal: Pick<Terminal, 'getSelection' | 'clearSelection'>
+  writeClipboardText: (text: string) => Promise<void>
+  clearSelectionOnSuccess?: boolean
+}
+
+// Why: route every terminal copy path through one helper so a clipboard write
+// failure rejects instead of being swallowed — callers can then withhold their
+// "Copied" success UI rather than lying about an unchanged clipboard (#5611).
+export async function copyTerminalSelection({
+  terminal,
+  writeClipboardText,
+  clearSelectionOnSuccess = false
+}: TerminalSelectionCopyOptions): Promise<boolean> {
+  const selection = terminal.getSelection()
+  if (!selection) {
+    return false
+  }
+
+  await writeClipboardText(selection)
+  // Why: only drop the xterm selection once the write resolved, so a failed
+  // copy leaves the text selected for the user to retry.
+  if (clearSelectionOnSuccess) {
+    terminal.clearSelection()
+  }
+  return true
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -41,6 +41,8 @@ import { translate } from '@/i18n/i18n'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
 import { copyTerminalSelection } from './terminal-selection-copy'
+import { writeTerminalClipboardText } from './terminal-clipboard-write'
+import { showTerminalClipboardCopyFailedToast } from './terminal-clipboard-copy-failure-toast'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -149,15 +151,20 @@ export function useTerminalPaneContextMenu({
     if (!pane) {
       return
     }
-    await copyTerminalSelection({
-      terminal: pane.terminal,
-      writeClipboardText: window.api.ui.writeClipboardText
-    })
-    // Why: Radix returns focus to the menu trigger (the pane container) on
-    // close, but xterm.js only accepts input when its own helper textarea is
-    // focused. Without this, the user has to click the pane again before
-    // typing works (see #592).
-    pane.terminal.focus()
+    try {
+      await copyTerminalSelection({
+        terminal: pane.terminal,
+        writeClipboardText: writeTerminalClipboardText
+      })
+    } catch {
+      showTerminalClipboardCopyFailedToast()
+    } finally {
+      // Why: Radix returns focus to the menu trigger (the pane container) on
+      // close, but xterm.js only accepts input when its own helper textarea is
+      // focused. Without this, the user has to click the pane again before
+      // typing works (see #592).
+      pane.terminal.focus()
+    }
   }
 
   const onCopyPaneId = async (): Promise<void> => {
@@ -457,10 +464,10 @@ export function useTerminalPaneContextMenu({
       if (clickedPane.terminal.getSelection()) {
         void copyTerminalSelection({
           terminal: clickedPane.terminal,
-          writeClipboardText: window.api.ui.writeClipboardText,
+          writeClipboardText: writeTerminalClipboardText,
           clearSelectionOnSuccess: true
         }).catch(() => {
-          /* ignore clipboard write failures */
+          showTerminalClipboardCopyFailedToast()
         })
       } else {
         void pasteResolvedPane('right-click')

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -40,6 +40,7 @@ import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
+import { copyTerminalSelection } from './terminal-selection-copy'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -148,10 +149,10 @@ export function useTerminalPaneContextMenu({
     if (!pane) {
       return
     }
-    const selection = pane.terminal.getSelection()
-    if (selection) {
-      await window.api.ui.writeClipboardText(selection)
-    }
+    await copyTerminalSelection({
+      terminal: pane.terminal,
+      writeClipboardText: window.api.ui.writeClipboardText
+    })
     // Why: Radix returns focus to the menu trigger (the pane container) on
     // close, but xterm.js only accepts input when its own helper textarea is
     // focused. Without this, the user has to click the pane again before
@@ -453,10 +454,14 @@ export function useTerminalPaneContextMenu({
       if (!clickedPane) {
         return
       }
-      const selection = clickedPane.terminal.getSelection()
-      if (selection) {
-        void window.api.ui.writeClipboardText(selection)
-        clickedPane.terminal.clearSelection()
+      if (clickedPane.terminal.getSelection()) {
+        void copyTerminalSelection({
+          terminal: clickedPane.terminal,
+          writeClipboardText: window.api.ui.writeClipboardText,
+          clearSelectionOnSuccess: true
+        }).catch(() => {
+          /* ignore clipboard write failures */
+        })
       } else {
         void pasteResolvedPane('right-click')
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -101,6 +101,8 @@ import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { seedStartupSessionRestoredBanner } from './session-restored-banner-pane-state'
 import { copyTerminalSelection } from './terminal-selection-copy'
+import { writeTerminalClipboardText } from './terminal-clipboard-write'
+import { showTerminalClipboardCopyFailedToast } from './terminal-clipboard-copy-failure-toast'
 
 export function recordRuntimeCreatedTerminalPaneSplit(
   createdPane: unknown,
@@ -653,7 +655,7 @@ export function useTerminalPaneLifecycle({
         const osc52Disposable = pane.terminal.parser.registerOscHandler(52, (data) =>
           handleOsc52ClipboardRequest(data, {
             allowClipboardWrite: settingsRef.current?.terminalAllowOsc52Clipboard === true,
-            writeClipboardText: window.api.ui.writeClipboardText,
+            writeClipboardText: writeTerminalClipboardText,
             onBlockedWrite: showOsc52ClipboardBlockedToast,
             onWriteFailure: showOsc52ClipboardFailedToast
           })
@@ -862,9 +864,9 @@ export function useTerminalPaneLifecycle({
           }
           void copyTerminalSelection({
             terminal: pane.terminal,
-            writeClipboardText: window.api.ui.writeClipboardText
+            writeClipboardText: writeTerminalClipboardText
           }).catch(() => {
-            /* ignore clipboard write failures */
+            showTerminalClipboardCopyFailedToast()
           })
         })
         selectionDisposablesRef.current.set(pane.id, selectionDisposable)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -51,7 +51,10 @@ import {
   mode2031SequenceFor
 } from './terminal-appearance'
 import { handleOsc52ClipboardRequest } from './osc52-clipboard'
-import { showOsc52ClipboardBlockedToast } from './osc52-clipboard-blocked-toast'
+import {
+  showOsc52ClipboardBlockedToast,
+  showOsc52ClipboardFailedToast
+} from './osc52-clipboard-blocked-toast'
 import { parseOsc7 } from './parse-osc7'
 import { resolveTerminalJisYenInput } from './terminal-jis-yen-input'
 import { installTerminalImeCompositionTracker } from './terminal-ime-composition-tracker'
@@ -97,6 +100,7 @@ import { acquireWebviewsDragPassthrough } from '../browser-pane/webview-registry
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { seedStartupSessionRestoredBanner } from './session-restored-banner-pane-state'
+import { copyTerminalSelection } from './terminal-selection-copy'
 
 export function recordRuntimeCreatedTerminalPaneSplit(
   createdPane: unknown,
@@ -650,7 +654,8 @@ export function useTerminalPaneLifecycle({
           handleOsc52ClipboardRequest(data, {
             allowClipboardWrite: settingsRef.current?.terminalAllowOsc52Clipboard === true,
             writeClipboardText: window.api.ui.writeClipboardText,
-            onBlockedWrite: showOsc52ClipboardBlockedToast
+            onBlockedWrite: showOsc52ClipboardBlockedToast,
+            onWriteFailure: showOsc52ClipboardFailedToast
           })
         )
         osc52DisposablesRef.current.set(pane.id, osc52Disposable)
@@ -855,11 +860,10 @@ export function useTerminalPaneLifecycle({
           if (!shouldWriteClipboard) {
             return
           }
-          const selection = pane.terminal.getSelection()
-          if (!selection) {
-            return
-          }
-          void window.api.ui.writeClipboardText(selection).catch(() => {
+          void copyTerminalSelection({
+            terminal: pane.terminal,
+            writeClipboardText: window.api.ui.writeClipboardText
+          }).catch(() => {
             /* ignore clipboard write failures */
           })
         })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2451,6 +2451,16 @@
                 "writeTimeout": "File drop cancelled: terminal did not accept the path before the safety timeout.",
                 "writeRejected": "File drop cancelled: terminal could not accept the path."
               }
+            },
+            "clipboard": {
+              "copy": {
+                "failure": {
+                  "toast": {
+                    "title": "Terminal copy failed",
+                    "description": "The system clipboard did not update. Your selection is still highlighted."
+                  }
+                }
+              }
             }
           },
           "use": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2407,6 +2407,12 @@
                   "7cf51f74fd": "Enable TUI clipboard writes in Terminal settings to copy from SSH, tmux, Neovim, or fzf.",
                   "89eaa3e80b": "Terminal clipboard write blocked"
                 }
+              },
+              "failed": {
+                "toast": {
+                  "62a0af2cb4": "Terminal clipboard write failed",
+                  "fdd3e7e977": "The terminal app requested a copy, but the system clipboard did not update."
+                }
               }
             }
           },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2451,6 +2451,16 @@
                 "writeTimeout": "Se canceló la suelta de archivos: la terminal no aceptó la ruta antes del tiempo de seguridad.",
                 "writeRejected": "Se canceló la suelta de archivos: la terminal no pudo aceptar la ruta."
               }
+            },
+            "clipboard": {
+              "copy": {
+                "failure": {
+                  "toast": {
+                    "title": "Terminal copy failed",
+                    "description": "The system clipboard did not update. Your selection is still highlighted."
+                  }
+                }
+              }
             }
           },
           "use": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2407,6 +2407,12 @@
                   "7cf51f74fd": "Habilite las escrituras en el portapapeles TUI en la configuración de Terminal para copiar desde SSH, tmux, Neovim o fzf.",
                   "89eaa3e80b": "Escritura en el portapapeles del terminal bloqueada"
                 }
+              },
+              "failed": {
+                "toast": {
+                  "62a0af2cb4": "Terminal clipboard write failed",
+                  "fdd3e7e977": "The terminal app requested a copy, but the system clipboard did not update."
+                }
               }
             }
           },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2451,6 +2451,16 @@
                 "writeTimeout": "ファイルドロップをキャンセルしました: 安全タイムアウト前にターミナルがパスを受け付けませんでした。",
                 "writeRejected": "ファイルドロップをキャンセルしました: ターミナルがパスを受け付けられませんでした。"
               }
+            },
+            "clipboard": {
+              "copy": {
+                "failure": {
+                  "toast": {
+                    "title": "Terminal copy failed",
+                    "description": "The system clipboard did not update. Your selection is still highlighted."
+                  }
+                }
+              }
             }
           },
           "use": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2407,6 +2407,12 @@
                   "7cf51f74fd": "SSH、tmux、Neovim、または fzf からコピーするには、Terminal 設定で TUI クリップボードへの書き込みを有効にします。",
                   "89eaa3e80b": "Terminal のクリップボードへの書き込みがブロックされました"
                 }
+              },
+              "failed": {
+                "toast": {
+                  "62a0af2cb4": "Terminal clipboard write failed",
+                  "fdd3e7e977": "The terminal app requested a copy, but the system clipboard did not update."
+                }
               }
             }
           },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2451,6 +2451,16 @@
                 "writeTimeout": "파일 드롭이 취소되었습니다. 안전 시간 제한 전에 터미널이 경로를 받지 않았습니다.",
                 "writeRejected": "파일 드롭이 취소되었습니다. 터미널이 경로를 받을 수 없습니다."
               }
+            },
+            "clipboard": {
+              "copy": {
+                "failure": {
+                  "toast": {
+                    "title": "Terminal copy failed",
+                    "description": "The system clipboard did not update. Your selection is still highlighted."
+                  }
+                }
+              }
             }
           },
           "use": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2407,6 +2407,12 @@
                   "7cf51f74fd": "SSH, tmux, Neovim 또는 fzf에서 복사하려면 Terminal 설정에서 TUI 클립보드 쓰기를 활성화하세요.",
                   "89eaa3e80b": "Terminal 클립보드 쓰기가 차단되었습니다."
                 }
+              },
+              "failed": {
+                "toast": {
+                  "62a0af2cb4": "Terminal clipboard write failed",
+                  "fdd3e7e977": "The terminal app requested a copy, but the system clipboard did not update."
+                }
               }
             }
           },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2451,6 +2451,16 @@
                 "writeTimeout": "文件拖放已取消：终端在安全超时前未接受路径。",
                 "writeRejected": "文件拖放已取消：终端无法接受路径。"
               }
+            },
+            "clipboard": {
+              "copy": {
+                "failure": {
+                  "toast": {
+                    "title": "Terminal copy failed",
+                    "description": "The system clipboard did not update. Your selection is still highlighted."
+                  }
+                }
+              }
             }
           },
           "use": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2407,6 +2407,12 @@
                   "7cf51f74fd": "在终端设置中启用 TUI 剪贴板写入，以从 SSH、tmux、Neovim 或 fzf 进行复制。",
                   "89eaa3e80b": "终端剪贴板写入被阻止"
                 }
+              },
+              "failed": {
+                "toast": {
+                  "62a0af2cb4": "Terminal clipboard write failed",
+                  "fdd3e7e977": "The terminal app requested a copy, but the system clipboard did not update."
+                }
               }
             }
           },

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -80,7 +80,8 @@ import { RuntimeRpcCallQueuePool } from '../../../shared/runtime-rpc-call-queue'
 import {
   assertClipboardTextWriteWithinLimitWithYield,
   assertClipboardTextWithinLimitWithYield,
-  type ReadClipboardTextOptions
+  type ReadClipboardTextOptions,
+  type WriteClipboardTextOptions
 } from '../../../shared/clipboard-text'
 import {
   CLIPBOARD_IMAGE_MAX_BASE64_CHARS,
@@ -2052,8 +2053,8 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       }
       return saveClipboardImageAsTempFileInRuntime(contentBase64, args)
     },
-    writeClipboardText: async (text) => {
-      await assertClipboardTextWriteWithinLimitWithYield(text)
+    writeClipboardText: async (text, options?: WriteClipboardTextOptions) => {
+      await assertClipboardTextWriteWithinLimitWithYield(text, options)
       await (navigator.clipboard?.writeText?.(text) ?? Promise.resolve())
     },
     writeSelectionClipboardText: () =>

--- a/src/shared/clipboard-text.ts
+++ b/src/shared/clipboard-text.ts
@@ -10,6 +10,7 @@ export type ReadClipboardTextOptions = {
 
 export type WriteClipboardTextOptions = {
   maxBytes?: number
+  verify?: boolean
 }
 
 export type ClipboardTextByteLengthMeasurement = {


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** When you select text inside a terminal pane in Orca — for example, an answer from a Copilot/agent conversation — and copy it (Ctrl+C, right-click, or copy-on-select), Orca cheerfully says "Copied to clipboard" and turns blue. But on Windows the text never actually lands on the system clipboard: paste it into another app and you get nothing, or the old contents. So the app is lying about success. This was reported on Windows; it's a real "I copied this and lost it" trust-breaker for anyone using the terminal/agent panes there, not just a cosmetic glitch.

**2) What this PR does (ELI5).** Think of it like a printer that flashes "Done!" the instant you hit print, without ever checking whether paper came out. Terminal copies now use a verified desktop write: after writing the text, Orca reads the standard clipboard back and confirms the words that come out match the words that went in. If they don't match, it stops calling it a success. The verification is scoped to terminal copy paths, so unrelated app copy buttons do not pay a new read-back cost or get a new rejection mode. Failed terminal selection copies leave the text highlighted and show a small error notice; failed agent/TUI OSC 52 copies also surface a toast instead of silently doing nothing. So: terminal copy success now means genuinely pasteable, while the wider clipboard API keeps its previous lightweight behavior unless a caller opts into verification.

**3) Tradeoffs / regressions — none known.** No PR-introduced tradeoff remains from this fix. The original broad caveat is gone: Orca no longer adds a read-back to every app clipboard write. Only desktop terminal text-copy paths that need the "Copied means pasteable" guarantee opt into verification. Paired web clients keep the browser clipboard write promise as their success signal because browser read permission is a separate permission surface.

**OS clipboard boundary (audited, not a PR tradeoff).** Electron's `clipboard` API exposes read/write/format calls, but no sequence number, change event, ownership token, or atomic "write and prove this exact owner still owns the clipboard" operation. Orca verifies the observable user contract immediately after a desktop terminal copy: the standard text clipboard must match the copied text. If another app or clipboard manager changes the standard clipboard before that read-back, the copied text is no longer pasteable at verification time, so Orca correctly withholds success instead of reporting a verified copy. The Linux X11 PRIMARY "selection" clipboard remains deliberately exempt, because ownership normally passes to whichever app last selected text.

**Manual failures are now visible.** Ctrl/shortcut copy, context-menu copy, right-click copy, copy-on-select, and OSC 52 all keep failed terminal selection text available to retry and surface a one-time failure toast instead of silently swallowing the verified-write rejection.


---

## Summary

Fixes #5611.

Copying selected terminal text (including Copilot/agent conversation text) showed a success state while the OS clipboard stayed unchanged — reported on Windows. Every terminal copy path (Ctrl+Shift+C, right-click copy, context-menu copy, copy-on-select, and OSC 52) wrote via `window.api.ui.writeClipboardText` but swallowed write failures with an empty `.catch` and never confirmed the OS clipboard actually changed. The main-process `clipboard:writeText` handler called `clipboard.writeText()` and returned without reading back, so a stale OS clipboard (Electron returns without throwing even when the write did not land) looked like success.

This makes terminal copy "success" mean *pasteable*:

- **`clipboard-ipc-handlers.ts`** — keeps the existing trusted-sender auth and text-size-limit checks, then verifies only when the caller passes `{ verify: true }`. Default app text writes stay single-write; verified standard-clipboard writes read back and throw `Clipboard write verification failed` on mismatch. The X11 PRIMARY `selection` clipboard is deliberately **not** verified, because its ownership can pass to whichever app last selected text.
- **`terminal-clipboard-write.ts`** (new) — terminal desktop copies opt into verified writes; paired web clients keep the browser clipboard write promise instead of forcing a browser read permission.
- **`terminal-selection-copy.ts`** (new) — one shared helper that all renderer terminal selection copy paths route through, so a write rejection propagates and the xterm selection is cleared only after the write resolves.
- **`terminal-clipboard-copy-failure-toast.ts`** (new) — manual terminal copy failures now show a one-time toast instead of quietly disappearing.
- **`osc52-clipboard.ts`** — adds `onWriteFailure` so a TUI yank (tmux/nvim/fzf/Copilot OSC 52) that never reaches the host clipboard surfaces a toast instead of a silent no-op.
- **`osc52-clipboard-blocked-toast.ts`** — adds `showOsc52ClipboardFailedToast`.

This supersedes community PR #5634 (adopted, rebased onto current `main`, and reconciled to keep the current async IPC handlers, the `assertTrustedClipboardSender`/text-size-limit security checks, the `store: Store` signature, and the new `shouldWritePrimarySelection` copy-on-select branch — the verbatim PR would have dropped those and failed to compile). It does not close #5634.

## Screenshots

This is a clipboard-state bug; the user-visible regression (false "success" with an unchanged clipboard) has no static visual surface to screenshot. Verified live in the running Electron build instead — see the PR comment with CDP evidence (a real `clipboard:writeText` write now reads back as `matches: true` with no false error, and the `selection` path does not throw a false verification failure).

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/window/clipboard-ipc-handlers.test.ts src/renderer/src/components/terminal-pane/terminal-selection-copy.test.ts src/renderer/src/components/terminal-pane/terminal-clipboard-write.test.ts src/renderer/src/components/terminal-pane/terminal-clipboard-copy-failure-toast.test.ts src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts` — 6 files / 53 tests passed
- [x] `pnpm exec oxlint <touched TypeScript files>` — clean
- [x] `pnpm run typecheck:node`, `pnpm run typecheck:cli`, `pnpm run typecheck:web` — all pass
- [x] `pnpm run verify:localization-catalog` and `pnpm run verify:localization-coverage` — pass
- [ ] `pnpm build` (not run; targeted tests, lint, localization, and type gates pass)
- [x] Added/updated regression tests: default IPC writes do not read back, verified IPC writes reject on mismatch, selection readback is not verified, shared terminal copy helper, desktop-vs-web terminal writer behavior, manual terminal copy failure toast, OSC 52 write-failure toast.

## AI Review Report

Self-reviewed adversarially against `git merge-base origin/main HEAD`.
- **Correctness:** terminal desktop verification runs only after the existing size-limit `await`, so large-payload yielding still happens first. Default app clipboard writes no longer read back; terminal callers opt in where the success UI needs proof.
- **Edge cases:** empty selection short-circuits (no write); xterm selection is cleared only after a successful write; manual terminal failures now toast once and leave the selection available; OSC 52 failures keep their dedicated toast.
- **Cross-platform:** prioritized Windows (the reported platform) where the false success originated. Linux X11 PRIMARY selection is explicitly exempted from read-back so primary-selection copies don't false-fail; paired web clients avoid browser clipboard reads. No hardcoded `metaKey`, no path-separator assumptions, no new platform-specific code.
- **SSH / providers:** no change to remote clipboard file/image paths; this only touches text writes. No git-provider-specific code involved.

## Security Audit

Adopted code re-audited assuming the original author was untrusted.
- **IPC:** `assertTrustedClipboardSender(event)` is preserved on every handler; the unauthorized-sender test still passes. The opt-in read-back uses Electron's already-permitted `clipboard.readText()` only to compare against what we just wrote — it returns nothing new to the renderer and is not used by default app writes.
- **Input handling:** `assertClipboardTextWriteWithinLimitWithYield(text, options)` still runs before any write; oversized-write rejection tests still pass.
- **No** network calls, `eval`, `child_process`/`exec`, fs access, secret access, path traversal, or new runtime dependencies introduced. New renderer import is still a type-only `@xterm/xterm`.

## Notes

- Localization: four new `translate()` keys total for OSC 52 and manual terminal-copy failure toasts, registered across all locale catalogs via `pnpm run sync:localization-catalog`.
- Follow-up zero-tradeoff audit: no remaining PR-introduced tradeoffs are known. Electron exposes no clipboard sequence/change/owner/atomic-verification primitive, so immediate read-back is the strongest portable proof that terminal text is pasteable.

Made with [Orca](https://github.com/stablyai/orca) 🐋


