### PR TITLE
fix: hide completed Pi agent row after closing its terminal tab

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
@@ -150,6 +150,27 @@ describe('selectLiveAgentStatusEntriesForWorktree', () => {
 
     expect(selectLiveAgentStatusEntriesForWorktree(state, 'wt-1')).toEqual([childEntry])
   })
+
+  it('does not use worktree attribution for a completed row whose tab is gone', () => {
+    const closedEntry = makeEntry(PANE_KEY_1, 1000, {
+      state: 'done',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      agentType: 'pi'
+    })
+    const state = {
+      tabsByWorktree: {
+        'wt-1': [makeTab('tab-live')]
+      },
+      agentStatusByPaneKey: {
+        [PANE_KEY_1]: closedEntry
+      },
+      migrationUnsupportedByPtyId: {},
+      retainedAgentsByPaneKey: {}
+    }
+
+    expect(selectLiveAgentStatusEntriesForWorktree(state, 'wt-1')).toEqual([])
+  })
 })
 
 describe('selectRuntimeAgentOrchestrationForWorktree', () => {

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
@@ -97,7 +97,9 @@ function getLiveEntriesByWorktree(state: WorktreeAgentRowsState): Map<string, Ag
     if (!parsed) {
       continue
     }
-    const worktreeId = tabIdToWorktreeId.get(parsed.tabId) ?? entry.worktreeId
+    const tabWorktreeId = tabIdToWorktreeId.get(parsed.tabId)
+    // Why: keep early attributed child rows, but hide completed rows once their tab is gone.
+    const worktreeId = tabWorktreeId ?? (entry.state === 'done' ? undefined : entry.worktreeId)
     if (!worktreeId) {
       continue
     }

--- a/src/renderer/src/store/slices/agent-status-drop.test.ts
+++ b/src/renderer/src/store/slices/agent-status-drop.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { TerminalTab } from '../../../../shared/types'
 import type { RetainedAgentEntry } from './agent-status'
-import { createTestStore } from './store-test-helpers'
+import { createTestStore, makeTab } from './store-test-helpers'
 
 // Why: split out from agent-status.test.ts to keep each file under the
 // repo's 300-line cap for test files. This suite covers the new
@@ -126,6 +126,70 @@ describe('dropAgentStatus + retention suppressor', () => {
     // as the live-only case).
     expect(s.agentStatusEpoch).toBe(agentEpochBefore + 1)
     expect(s.sortEpoch).toBe(sortEpochBefore + 1)
+  })
+
+  it('closeTab drops completed worktree-attributed orphan rows', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.setState({
+      tabsByWorktree: {
+        'wt-1': [
+          makeTab({ id: 'tab-closed', worktreeId: 'wt-1' }),
+          makeTab({ id: 'tab-live', worktreeId: 'wt-1' })
+        ],
+        'wt-2': []
+      }
+    })
+    store
+      .getState()
+      .setAgentStatus('tab-closed:0', { state: 'done', prompt: 'closed', agentType: 'pi' })
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-orphan:0',
+        { state: 'done', prompt: 'orphan', agentType: 'pi' },
+        undefined,
+        undefined,
+        { worktreeId: 'wt-1' }
+      )
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-active-child:0',
+        { state: 'working', prompt: 'active child', agentType: 'pi' },
+        undefined,
+        undefined,
+        { worktreeId: 'wt-1' }
+      )
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-live:0',
+        { state: 'done', prompt: 'open tab', agentType: 'pi' },
+        undefined,
+        undefined,
+        { worktreeId: 'wt-1' }
+      )
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-other-orphan:0',
+        { state: 'done', prompt: 'other worktree', agentType: 'pi' },
+        undefined,
+        undefined,
+        { worktreeId: 'wt-2' }
+      )
+
+    store.getState().closeTab('tab-closed')
+
+    const s = store.getState()
+    expect(s.tabsByWorktree['wt-1']?.some((tab) => tab.id === 'tab-closed')).toBe(false)
+    expect(s.agentStatusByPaneKey['tab-closed:0']).toBeUndefined()
+    expect(s.agentStatusByPaneKey['tab-orphan:0']).toBeUndefined()
+    expect(s.retentionSuppressedPaneKeys['tab-orphan:0']).toBe(true)
+    expect(s.agentStatusByPaneKey['tab-active-child:0']).toBeDefined()
+    expect(s.agentStatusByPaneKey['tab-live:0']).toBeDefined()
+    expect(s.agentStatusByPaneKey['tab-other-orphan:0']).toBeDefined()
   })
 
   it('on a paneKey with neither live nor retained entry: no-op (same state reference, no epoch bumps)', () => {

--- a/src/renderer/src/store/slices/agent-status-drop.test.ts
+++ b/src/renderer/src/store/slices/agent-status-drop.test.ts
@@ -186,7 +186,9 @@ describe('dropAgentStatus + retention suppressor', () => {
     expect(s.tabsByWorktree['wt-1']?.some((tab) => tab.id === 'tab-closed')).toBe(false)
     expect(s.agentStatusByPaneKey['tab-closed:0']).toBeUndefined()
     expect(s.agentStatusByPaneKey['tab-orphan:0']).toBeUndefined()
-    expect(s.retentionSuppressedPaneKeys['tab-orphan:0']).toBe(true)
+    // No suppressor for the orphan: its tab is already gone, so retention sync
+    // never re-surfaces it and a suppressor would leak permanently.
+    expect(s.retentionSuppressedPaneKeys['tab-orphan:0']).toBeUndefined()
     expect(s.agentStatusByPaneKey['tab-active-child:0']).toBeDefined()
     expect(s.agentStatusByPaneKey['tab-live:0']).toBeDefined()
     expect(s.agentStatusByPaneKey['tab-other-orphan:0']).toBeDefined()

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -63,6 +63,10 @@ type DropHibernatedAgentPaneOptions = {
   retainedCompletionEvidence?: readonly RetainedAgentEntry[]
 }
 
+type DropAgentStatusByTabPrefixOptions = {
+  worktreeId?: string
+}
+
 type AgentLaunchConfigRegistrationMetadata = {
   agentType?: AgentType
   launchToken?: string
@@ -174,7 +178,10 @@ export type AgentStatusSlice = {
   /** Remove all entries under a tab AND suppress re-retention for each.
    *  Used on tab close — the user is tearing down the whole tab, so any
    *  remaining agent rows (live or retained) must not reappear. */
-  dropAgentStatusByTabPrefix: (tabIdPrefix: string) => void
+  dropAgentStatusByTabPrefix: (
+    tabIdPrefix: string,
+    opts?: DropAgentStatusByTabPrefixOptions
+  ) => void
 
   /** Remove one automatically hibernated completed-agent pane while preserving
    *  sibling live/retained rows in the same worktree. */
@@ -304,6 +311,29 @@ function getLeafIdFromPaneKey(paneKey: string): string | null {
   }
   const leafId = paneKey.slice(separator + 1)
   return leafId.length > 0 ? leafId : null
+}
+
+function findCompletedOrphanPaneKeysForTabClose(
+  state: AppState,
+  worktreeId: string | undefined,
+  prefix: string
+): string[] {
+  if (!worktreeId) {
+    return []
+  }
+  const openTabIds = new Set((state.tabsByWorktree[worktreeId] ?? []).map((tab) => tab.id))
+  const paneKeys: string[] = []
+  for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
+    if (paneKey.startsWith(prefix) || entry.state !== 'done' || entry.worktreeId !== worktreeId) {
+      continue
+    }
+    const tabId = getTabIdFromPaneKey(paneKey)
+    if (!tabId || openTabIds.has(tabId)) {
+      continue
+    }
+    paneKeys.push(paneKey)
+  }
+  return paneKeys
 }
 
 function isRecentlyClosedAgentStatusTab(
@@ -1774,16 +1804,25 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       }
     },
 
-    dropAgentStatusByTabPrefix: (tabIdPrefix) => {
+    dropAgentStatusByTabPrefix: (tabIdPrefix, opts) => {
       const prefix = `${tabIdPrefix}:`
       let hadLive = false
       set((s) => {
-        const liveKeys = Object.keys(s.agentStatusByPaneKey).filter((k) => k.startsWith(prefix))
-        const launchConfigKeys = Object.keys(s.agentLaunchConfigByPaneKey).filter((k) =>
-          k.startsWith(prefix)
+        const completedOrphanKeys = findCompletedOrphanPaneKeysForTabClose(
+          s,
+          opts?.worktreeId,
+          prefix
         )
-        const retainedKeys = Object.keys(s.retainedAgentsByPaneKey).filter((k) =>
-          k.startsWith(prefix)
+        const completedOrphanKeySet = new Set(completedOrphanKeys)
+        const liveKeys = [
+          ...Object.keys(s.agentStatusByPaneKey).filter((k) => k.startsWith(prefix)),
+          ...completedOrphanKeys
+        ]
+        const launchConfigKeys = Object.keys(s.agentLaunchConfigByPaneKey).filter(
+          (k) => k.startsWith(prefix) || completedOrphanKeySet.has(k)
+        )
+        const retainedKeys = Object.keys(s.retainedAgentsByPaneKey).filter(
+          (k) => k.startsWith(prefix) || completedOrphanKeySet.has(k)
         )
         const migrationUnsupported = pruneMigrationUnsupportedEntries(
           s.migrationUnsupportedByPtyId,
@@ -1793,7 +1832,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         // regardless of live/retained presence — ack entries are owned by
         // the pane lifecycle independently of live/retained state.
         let nextAck = s.acknowledgedAgentsByPaneKey
-        const ackKeys = Object.keys(nextAck).filter((k) => k.startsWith(prefix))
+        const ackKeys = Object.keys(nextAck).filter(
+          (k) => k.startsWith(prefix) || completedOrphanKeySet.has(k)
+        )
         if (ackKeys.length > 0) {
           nextAck = { ...nextAck }
           for (const k of ackKeys) {

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1895,7 +1895,13 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         // the user just tore it down. Planting suppressors is the cheap guard
         // for the common ordering; the rare inverse ordering has the same
         // bounded suppressor-leak tradeoff described in dropAgentStatus.
-        const suppressorAdds = liveKeys.filter((k) => !(k in s.retentionSuppressedPaneKeys))
+        //
+        // Skip completed-orphan keys: their tab is already gone, so retention
+        // sync never snapshots them and no live→gone transition ever fires to
+        // consume the suppressor — planting one would leak permanently.
+        const suppressorAdds = liveKeys.filter(
+          (k) => !completedOrphanKeySet.has(k) && !(k in s.retentionSuppressedPaneKeys)
+        )
         let nextRetentionSuppressedPaneKeys = s.retentionSuppressedPaneKeys
         if (suppressorAdds.length > 0) {
           nextRetentionSuppressedPaneKeys = { ...s.retentionSuppressedPaneKeys }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1179,13 +1179,18 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   closeTab: (tabId, opts) => {
+    let closingWorktreeId: string | null = null
     set((s) => {
       const next = { ...s.tabsByWorktree }
       let closingPtyId: string | null = null
       for (const wId of Object.keys(next)) {
         const before = next[wId]
-        if (!closingPtyId) {
-          closingPtyId = before.find((t) => t.id === tabId)?.ptyId ?? null
+        const closingTab = before.find((t) => t.id === tabId)
+        if (closingTab) {
+          closingWorktreeId = wId
+          if (!closingPtyId) {
+            closingPtyId = closingTab.ptyId ?? null
+          }
         }
         const after = before.filter((t) => t.id !== tabId)
         if (after.length !== before.length) {
@@ -1336,7 +1341,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     // too. Use dropAgentStatusByTabPrefix (not removeAgentStatusByTabPrefix)
     // so retention suppressors are planted: a live→gone transition inside the
     // same frame as the tab close cannot re-snapshot a row we just dropped.
-    get().dropAgentStatusByTabPrefix(tabId)
+    // Why: Pi can leave a completed row attributed to the worktree but keyed
+    // under an already-missing tab id; pass the worktree to sweep only that
+    // completed orphan while preserving active pre-render child rows.
+    get().dropAgentStatusByTabPrefix(
+      tabId,
+      closingWorktreeId ? { worktreeId: closingWorktreeId } : undefined
+    )
     // Why: retired pane keys never recur, so stranded foreground entries would
     // accumulate for the renderer's whole lifetime.
     get().clearPaneForegroundAgentByTabPrefix(tabId)


### PR DESCRIPTION
## Description

Fixes #5913.

Closing a terminal tab could leave Pi's completed compact agent row visible as `Done` on the workspace card. The stale entry was still in `agentStatusByPaneKey`, but its pane key referred to a tab that no longer existed in `tabsByWorktree`. The sidebar selector then used the entry's `worktreeId` fallback—originally added so active child agents can appear before their tab reaches the renderer—and rendered the orphan as live.

This PR hardens both lifecycle boundaries:

- The workspace-card selector uses worktree attribution for tabless active rows, but not for a completed row whose tab is gone.
- `closeTab` passes the closing worktree into agent-status teardown so it also removes completed, worktree-attributed orphan rows whose pane-key tab does not match the tab being closed. It preserves active pre-render child rows, completed rows with an open tab, and rows owned by other worktrees.

The branch was rebased onto current `origin/main` (`c5669cceb5`) and its terminal teardown conflict was resolved against the current cleanup path.

This PR supersedes community PR #5914 and preserves its original author credit in the commit.

## Evidence of fix (before + after)

### Before: current `main` selector behavior

On the rebased worktree, I temporarily restored the current-main unconditional fallback while keeping the regression assertion, then ran:

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts \
  -t 'does not use worktree attribution for a completed row whose tab is gone'
```

Result: **1 failed**. The production selector returned the stale row instead of `[]`:

```text
Received: [{ agentType: "pi", state: "done", tabId: "tab-1", worktreeId: "wt-1", ... }]
```

This reproduces the issue comment's post-close state: the completed Pi tab is absent from `tabsByWorktree`, but the live-status map still contains its attributed row.

### After: PR head

Restoring the PR guard and running the same command produced:

```text
Test Files  1 passed (1)
Tests       1 passed | 7 skipped (8)
```

The selector returned zero live rows for the orphaned `done` entry.

The source-level lifecycle test now calls `closeTab` itself. It proves that closing a tab removes the mismatched completed Pi orphan and its matching row, while retaining an active pre-render child row, a completed row with an open tab, and another worktree's orphan.

### Electron sidebar evidence

I launched the rebased PR in an isolated Electron profile and injected the confirmed post-close state through the real renderer store:

- Backing state: `agentStatusByPaneKey` contained a Pi `done` entry attributed to the visible worktree, and its tab was absent.
- Visible workspace card: the stale completion sentinel had **0** matches and no compact `Done` row rendered.
- Neighboring contract: a tabless worktree-attributed Pi `working` entry rendered on the same card as **Working**, proving the early active-row behavior remains visible.

The Pi CLI is not installed on this machine, so this Electron check exercises the production store/selector/render path but not a real Pi hook process or terminal teardown.

### Validation commands

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts \
  src/renderer/src/store/slices/agent-status-drop.test.ts \
  src/renderer/src/store/slices/agent-status-drop-ipc.test.ts \
  src/renderer/src/store/slices/store-cascades.test.ts
# 4 files passed, 137 tests passed

pnpm typecheck
# passed (node, CLI, and web)

pnpm exec oxlint <five changed TypeScript files>
# passed

pnpm check:reliability-gates
# passed, 31 gates

pnpm check:max-lines-ratchet
# passed, no new bypasses

git diff --check origin/main...HEAD
# passed
```

`pnpm lint` passes oxlint, switch exhaustiveness, styled-scrollbar checks, reliability-manifest validation, and the max-lines ratchet, then stops on an unrelated current-main localization mismatch in `ja.json` for `components.native-chat.composer.uploadingAttachments`. This PR does not edit localization files.

## ELI5

The sidebar has a backup rule: if an agent's tab has not appeared yet, use the workspace name on its badge so the user can still see that active agent. Pi could leave an old badge behind after its finished tab was closed, so the backup rule kept seating a ghost at the table.

Now the backup rule still helps agents that are actively working or waiting for attention, but it does not revive a finished agent whose tab is gone. Closing a tab also sweeps that specific kind of finished orphan from memory.

## User-facing trade-offs

- **Improvement:** closing a finished Pi terminal no longer leaves a misleading `Done` row on the workspace card.
- **Preserved behavior:** active tabless child-agent rows still appear early; completed rows with a real open tab and rows in other worktrees remain untouched.
- **Completion timing:** a `done` live-status entry that has no renderer tab is hidden rather than shown through the early-attribution fallback. Completed-session history remains the responsibility of the existing retained-agent path.
- **Close-time work:** a user-triggered terminal close performs one bounded pass over the worktree's open tabs and current live agent entries to find mismatched completed orphans. It adds no polling, provider listing, subprocess, startup wait, or background wake loop.
- **Provider/platform scope:** the rule is based on structured tab, worktree, and agent state—not process names, filesystem paths, or local-only APIs—so local, daemon, SSH, WSL, and remote-runtime status rows follow the same contract. Live Pi/SSH/WSL/remote-provider runs remain unverified here.

## Terminal/session reliability proof

- **Reliability class:** `agent-session.tab-close-status-ownership`.
- **Invariant:** closing a terminal retires the tab's agent-status evidence and completed worktree-attributed orphans, without deleting active pre-render children, open-tab completions, or another worktree's rows.
- **Failure source:** issue #5913; Pi's completed row had mismatched pane/tab identity after close.
- **Product change type:** runtime hardening plus deterministic renderer-state regression coverage.
- **Oracle:** the production workspace-card selector returns zero rows for the confirmed orphan state, and the `closeTab` test proves the orphan is removed at the lifecycle source while the three preservation cases survive.
- **Performance risk inventory:** touched paths are the workspace-card status index and user-triggered tab close. The selector adds one state comparison inside its existing bounded pass; close adds one bounded live-entry/open-tab scan. No typing, PTY output, focus, resize, startup, provider listing, SSH transport, WSL transport, hidden output, or mobile/relay loop changed.
- **No-regression evidence:** 137 focused tests, full typecheck, changed-file oxlint, manifest validation, max-lines ratchet, and the Electron sidebar check above.
- **Provider/platform coverage:** macOS Electron store/render path covered; local/daemon/SSH/WSL/remote-runtime and Linux/Windows are structurally unaffected by provider- or platform-specific code, but real integration runs were not performed. Mobile/relay does not consume this desktop workspace-card selector.
- **Diagnostics:** no new logs or telemetry; future failures remain inspectable through `tabsByWorktree`, `agentStatusByPaneKey`, and the deterministic selector/`closeTab` assertions.
- **Manifest/promotion status:** no dedicated gate (`none`). The existing `agent-session.provider-ownership` gate is unchanged and does not claim this display-cleanup invariant; a new manifest entry would be premature without a real Pi integration fixture.
- **Residual gaps:** no installed Pi binary for a real hook-driven Electron close; no live SSH/WSL/remote-provider run; full repo lint is blocked by the unrelated localization mismatch described above.
- **Rollback/demotion rule:** revert the orphan sweep/selector guard if a legitimate completed session with no tab must remain a live compact row, or if terminal-close profiling shows material latency; retain the red/green regression as the decision oracle.

## Security audit

No new input parsing, command execution, path handling, auth, secret, dependency, IPC, or network surface is introduced. The fix operates on existing structured in-memory state.

Made with [Orca](https://github.com/stablyai/orca) 🐋