### PR TITLE
fix(status-bar): show live reset countdown instead of fixed window length

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -55,13 +55,17 @@ import {
 } from './tooltip'
 import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { formatResetDuration } from '@/lib/reset-countdown'
 import { formatWindowLabel } from '@/lib/window-label-formatter'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
 import { StatusBarUsageEmptyCta } from './StatusBarUsageEmptyCta'
+import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
+import {
+  collectStatusBarResetTimes,
+  formatStatusBarSessionWindowLabel
+} from './status-bar-reset-countdowns'
 import { shouldOpenStatusBarContextMenu } from './status-bar-context-menu-policy'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
@@ -624,11 +628,13 @@ function AccountRuntimeToggle<TGroup extends { key: string; label: string }>({
 function ClaudeSwitcherMenu({
   claude,
   compact,
-  iconOnly
+  iconOnly,
+  now
 }: {
   claude: ProviderRateLimits
   compact: boolean
   iconOnly: boolean
+  now: number
 }): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [accountsExpanded, setAccountsExpanded] = useState(false)
@@ -772,6 +778,7 @@ function ClaudeSwitcherMenu({
       provider={claude}
       compact={compact}
       iconOnly={iconOnly}
+      now={now}
       ariaLabel={translate(
         'auto.components.status.bar.StatusBar.3dd7ddfae1',
         'Open Claude details and account switcher'
@@ -1025,17 +1032,6 @@ function WindowLabel({ w, label }: { w: RateLimitWindow; label: string }): React
   )
 }
 
-// Why: rate-limit data only refetches every ~15min, so a reset countdown
-// computed once would freeze; tick locally to keep the collapsed badge current.
-function useNow(intervalMs: number): number {
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    const id = window.setInterval(() => setNow(Date.now()), intervalMs)
-    return () => window.clearInterval(id)
-  }, [intervalMs])
-  return now
-}
-
 // ---------------------------------------------------------------------------
 // Provider segment
 // ---------------------------------------------------------------------------
@@ -1046,22 +1042,16 @@ const STATUS_BAR_BUCKET_NAMES = new Set(['Flash', 'Pro', '1.5 Pro'])
 
 function ProviderSegment({
   p,
-  compact
+  compact,
+  now
 }: {
   p: ProviderRateLimits | null
   compact: boolean
+  now: number
 }): React.JSX.Element {
   const provider = p?.provider ?? 'claude'
   const statusLabel = p ? getProviderUsageStatusLabel(p) : ''
-  const now = useNow(30_000)
-
-  // Why: show the live time-until-reset for the session window instead of the
-  // fixed window length (issue #5399) so users see it without opening the panel.
-  const sessionLabel = p?.session
-    ? p.session.resetsAt != null
-      ? formatResetDuration(p.session.resetsAt - now)
-      : formatWindowLabel(p.session.windowMinutes)
-    : ''
+  const sessionLabel = p?.session ? formatStatusBarSessionWindowLabel(p.session, now) : ''
 
   // Idle / initial load
   if (!p || p.status === 'idle') {
@@ -1145,11 +1135,13 @@ function ProviderSegment({
 function CodexSwitcherMenu({
   codex,
   compact,
-  iconOnly
+  iconOnly,
+  now
 }: {
   codex: ProviderRateLimits
   compact: boolean
   iconOnly: boolean
+  now: number
 }): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [accountsExpanded, setAccountsExpanded] = useState(false)
@@ -1392,7 +1384,7 @@ function CodexSwitcherMenu({
   const resetCreditCount = codex.rateLimitResetCredits?.availableCount ?? null
   const resetCreditExpiry =
     resetCreditCount !== null
-      ? formatResetCreditExpiry(codex.rateLimitResetCredits?.nextExpiresAt, resetCreditCount)
+      ? formatResetCreditExpiry(codex.rateLimitResetCredits?.nextExpiresAt, resetCreditCount, now)
       : null
   const canRedeemReset = resetCreditCount !== null && resetCreditCount > 0
 
@@ -1401,6 +1393,7 @@ function CodexSwitcherMenu({
       provider={codex}
       compact={compact}
       iconOnly={iconOnly}
+      now={now}
       // Why: Codex reset credits render beside the reset action below; showing
       // them in the generic provider summary duplicates the same metadata.
       hidePanelResetCredits
@@ -1624,6 +1617,7 @@ export function ProviderDetailsMenu({
   compact,
   iconOnly,
   ariaLabel,
+  now = Date.now(),
   topContent,
   hidePanelResetCredits = false,
   open,
@@ -1634,6 +1628,7 @@ export function ProviderDetailsMenu({
   compact: boolean
   iconOnly: boolean
   ariaLabel: string
+  now?: number
   topContent?: React.ReactNode
   hidePanelResetCredits?: boolean
   open?: boolean
@@ -1677,7 +1672,7 @@ export function ProviderDetailsMenu({
               </span>
             </span>
           ) : (
-            <ProviderSegment p={provider} compact={compact} />
+            <ProviderSegment p={provider} compact={compact} now={now} />
           )}
         </button>
       </DropdownMenuTrigger>
@@ -1702,7 +1697,7 @@ export function ProviderDetailsMenu({
         {topContent}
         <div className="p-2">
           {/* Why: provider-specific action sections may render richer reset-credit UI. */}
-          <ProviderPanel p={provider} showResetCredits={!hidePanelResetCredits} />
+          <ProviderPanel p={provider} now={now} showResetCredits={!hidePanelResetCredits} />
         </div>
         {children ? (
           <>
@@ -1811,10 +1806,6 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     }
   }, [isRefreshing, refreshRateLimits, refreshDetectedAgents])
 
-  if (!statusBarVisible) {
-    return null
-  }
-
   const { claude, codex, gemini, opencodeGo, kimi } = rateLimits
 
   // Why: a provider earns a bar from either a usable live snapshot or durable
@@ -1867,6 +1858,36 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     gemini?.status === 'fetching' ||
     opencodeGo?.status === 'fetching' ||
     kimi?.status === 'fetching'
+  const usageCountdownResetTimes = useMemo(() => {
+    if (!statusBarVisible || isEmptyUsageState) {
+      return []
+    }
+    return collectStatusBarResetTimes([
+      showClaude ? visibleClaude : null,
+      showCodex ? visibleCodex : null,
+      showGemini ? visibleGemini : null,
+      showOpencodeGo ? visibleOpencodeGo : null,
+      showKimi ? visibleKimi : null
+    ])
+  }, [
+    statusBarVisible,
+    isEmptyUsageState,
+    showClaude,
+    visibleClaude,
+    showCodex,
+    visibleCodex,
+    showGemini,
+    visibleGemini,
+    showOpencodeGo,
+    visibleOpencodeGo,
+    showKimi,
+    visibleKimi
+  ])
+  const usageCountdownNow = useResetCountdownClock(usageCountdownResetTimes)
+
+  if (!statusBarVisible) {
+    return null
+  }
 
   const compact = containerWidth < 900
   const iconOnly = containerWidth < 500
@@ -1903,16 +1924,27 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
         ) : (
           <>
             {showClaude && (
-              <ClaudeSwitcherMenu claude={visibleClaude} compact={compact} iconOnly={iconOnly} />
+              <ClaudeSwitcherMenu
+                claude={visibleClaude}
+                compact={compact}
+                iconOnly={iconOnly}
+                now={usageCountdownNow}
+              />
             )}
             {showCodex && (
-              <CodexSwitcherMenu codex={visibleCodex} compact={compact} iconOnly={iconOnly} />
+              <CodexSwitcherMenu
+                codex={visibleCodex}
+                compact={compact}
+                iconOnly={iconOnly}
+                now={usageCountdownNow}
+              />
             )}
             {showGemini && (
               <ProviderDetailsMenu
                 provider={visibleGemini}
                 compact={compact}
                 iconOnly={iconOnly}
+                now={usageCountdownNow}
                 ariaLabel={translate(
                   'auto.components.status.bar.StatusBar.d2375976eb',
                   'Open Gemini usage details'
@@ -1924,6 +1956,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                 provider={visibleOpencodeGo}
                 compact={compact}
                 iconOnly={iconOnly}
+                now={usageCountdownNow}
                 ariaLabel={translate(
                   'auto.components.status.bar.StatusBar.629251f4b6',
                   'Open OpenCode Go usage details'
@@ -1935,6 +1968,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                 provider={visibleKimi}
                 compact={compact}
                 iconOnly={iconOnly}
+                now={usageCountdownNow}
                 ariaLabel={translate(
                   'auto.components.status.bar.StatusBar.fda8146810',
                   'Open Kimi usage details'

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -55,6 +55,7 @@ import {
 } from './tooltip'
 import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { AgentIcon } from '@/lib/agent-catalog'
+import { formatResetDuration } from '@/lib/reset-countdown'
 import { formatWindowLabel } from '@/lib/window-label-formatter'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
@@ -1024,6 +1025,17 @@ function WindowLabel({ w, label }: { w: RateLimitWindow; label: string }): React
   )
 }
 
+// Why: rate-limit data only refetches every ~15min, so a reset countdown
+// computed once would freeze; tick locally to keep the collapsed badge current.
+function useNow(intervalMs: number): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs)
+    return () => window.clearInterval(id)
+  }, [intervalMs])
+  return now
+}
+
 // ---------------------------------------------------------------------------
 // Provider segment
 // ---------------------------------------------------------------------------
@@ -1041,6 +1053,15 @@ function ProviderSegment({
 }): React.JSX.Element {
   const provider = p?.provider ?? 'claude'
   const statusLabel = p ? getProviderUsageStatusLabel(p) : ''
+  const now = useNow(30_000)
+
+  // Why: show the live time-until-reset for the session window instead of the
+  // fixed window length (issue #5399) so users see it without opening the panel.
+  const sessionLabel = p?.session
+    ? p.session.resetsAt != null
+      ? formatResetDuration(p.session.resetsAt - now)
+      : formatWindowLabel(p.session.windowMinutes)
+    : ''
 
   // Idle / initial load
   if (!p || p.status === 'idle') {
@@ -1102,7 +1123,7 @@ function ProviderSegment({
           )
         })}
         {visibleBuckets.length === 0 && p.session && (
-          <WindowLabel w={p.session} label={formatWindowLabel(p.session.windowMinutes)} />
+          <WindowLabel w={p.session} label={sessionLabel} />
         )}
         {isStale && <AlertTriangle size={11} className="text-muted-foreground/80" />}
       </span>
@@ -1113,9 +1134,7 @@ function ProviderSegment({
     <span className="inline-flex items-center gap-1.5">
       <ProviderIcon provider={provider} />
       {p.session && !compact && <MiniBar leftPct={Math.max(0, 100 - p.session.usedPercent)} />}
-      {p.session && (
-        <WindowLabel w={p.session} label={formatWindowLabel(p.session.windowMinutes)} />
-      )}
+      {p.session && <WindowLabel w={p.session} label={sessionLabel} />}
       {p.session && p.weekly && <span className="text-muted-foreground">·</span>}
       {p.weekly && <WindowLabel w={p.weekly} label={formatWindowLabel(p.weekly.windowMinutes)} />}
       {isStale && <AlertTriangle size={11} className="text-muted-foreground/80" />}

--- a/src/renderer/src/components/status-bar/status-bar-provider-menu-focus.test.tsx
+++ b/src/renderer/src/components/status-bar/status-bar-provider-menu-focus.test.tsx
@@ -75,7 +75,7 @@ function findChildByType(node: unknown, typeName: string): ReactElementLike {
   throw new Error(`Could not find ${typeName}`)
 }
 
-async function renderProviderDetailsMenu(): Promise<unknown> {
+async function renderProviderDetailsMenu(now?: number): Promise<unknown> {
   const { ProviderDetailsMenu } = await import('./StatusBar')
   return ProviderDetailsMenu({
     provider: {
@@ -98,7 +98,8 @@ async function renderProviderDetailsMenu(): Promise<unknown> {
     },
     compact: false,
     iconOnly: false,
-    ariaLabel: 'Open Codex usage details'
+    ariaLabel: 'Open Codex usage details',
+    ...(now !== undefined ? { now } : {})
   })
 }
 
@@ -127,5 +128,12 @@ describe('ProviderDetailsMenu focus handoff', () => {
       preventDefault
     })
     expect(preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('passes the shared countdown timestamp into the provider panel', async () => {
+    const element = await renderProviderDetailsMenu(123_456)
+    const panel = findChildByType(element, 'ProviderPanel')
+
+    expect(panel.props.now).toBe(123_456)
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-reset-countdowns.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-reset-countdowns.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
+import {
+  collectStatusBarResetTimes,
+  formatStatusBarSessionWindowLabel
+} from './status-bar-reset-countdowns'
+
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+
+function sessionWindow(overrides: Partial<RateLimitWindow> = {}): RateLimitWindow {
+  return {
+    usedPercent: 3,
+    windowMinutes: 300,
+    resetsAt: null,
+    resetDescription: null,
+    ...overrides
+  }
+}
+
+function provider(overrides: Partial<ProviderRateLimits> = {}): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: null,
+    status: 'ok',
+    ...overrides
+  }
+}
+
+describe('formatStatusBarSessionWindowLabel', () => {
+  it('uses the live reset countdown instead of the fixed session window length', () => {
+    const now = Date.parse('2026-06-20T12:00:00.000Z')
+
+    expect(
+      formatStatusBarSessionWindowLabel(sessionWindow({ resetsAt: now + HOUR + 20 * MINUTE }), now)
+    ).toBe('1h 20m')
+  })
+
+  it('falls back to the fixed window length when reset time is unknown', () => {
+    const now = Date.parse('2026-06-20T12:00:00.000Z')
+
+    expect(formatStatusBarSessionWindowLabel(sessionWindow({ resetsAt: null }), now)).toBe('5h')
+  })
+})
+
+describe('collectStatusBarResetTimes', () => {
+  it('collects visible provider reset times for the shared status-bar clock', () => {
+    const now = Date.parse('2026-06-20T12:00:00.000Z')
+    const sessionReset = now + HOUR
+    const weeklyReset = now + 2 * HOUR
+    const bucketReset = now + 3 * HOUR
+    const resetCreditExpiry = now + 4 * HOUR
+
+    expect(
+      collectStatusBarResetTimes([
+        provider({
+          session: sessionWindow({ resetsAt: sessionReset }),
+          weekly: sessionWindow({ windowMinutes: 10_080, resetsAt: weeklyReset }),
+          buckets: [{ name: 'Pro', ...sessionWindow({ resetsAt: bucketReset }) }],
+          rateLimitResetCredits: {
+            availableCount: 1,
+            nextExpiresAt: resetCreditExpiry
+          }
+        }),
+        null
+      ])
+    ).toEqual([sessionReset, weeklyReset, bucketReset, resetCreditExpiry])
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-reset-countdowns.ts
+++ b/src/renderer/src/components/status-bar/status-bar-reset-countdowns.ts
@@ -1,0 +1,38 @@
+import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
+import { formatResetDuration } from '@/lib/reset-countdown'
+import { formatWindowLabel } from '@/lib/window-label-formatter'
+
+export function formatStatusBarSessionWindowLabel(w: RateLimitWindow, now: number): string {
+  // Why: the status badge should show time until reset when the provider reports
+  // one, while preserving the fixed window-length fallback for unknown resets.
+  return w.resetsAt != null
+    ? formatResetDuration(w.resetsAt - now)
+    : formatWindowLabel(w.windowMinutes)
+}
+
+export function collectStatusBarResetTimes(
+  providers: readonly (ProviderRateLimits | null)[]
+): number[] {
+  const resetTimes: number[] = []
+  for (const provider of providers) {
+    if (!provider) {
+      continue
+    }
+    const windows: (RateLimitWindow | null | undefined)[] = [
+      provider.session,
+      provider.weekly,
+      provider.monthly,
+      ...(provider.buckets ?? [])
+    ]
+    for (const window of windows) {
+      if (window?.resetsAt != null) {
+        resetTimes.push(window.resetsAt)
+      }
+    }
+    const resetCreditExpiry = provider.rateLimitResetCredits?.nextExpiresAt
+    if (resetCreditExpiry != null) {
+      resetTimes.push(resetCreditExpiry)
+    }
+  }
+  return resetTimes
+}

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -20,8 +20,8 @@ export {
 // Formatting helpers
 // ---------------------------------------------------------------------------
 
-export function formatTimeAgo(ts: number): string {
-  const diff = Date.now() - ts
+export function formatTimeAgo(ts: number, now = Date.now()): string {
+  const diff = now - ts
   if (diff < 60_000) {
     return 'just now'
   }
@@ -35,12 +35,13 @@ export function formatTimeAgo(ts: number): string {
 
 export function formatResetCreditExpiry(
   expiresAt: number | null | undefined,
-  count: number
+  count: number,
+  now = Date.now()
 ): string | null {
   if (!expiresAt) {
     return null
   }
-  const duration = formatResetDuration(expiresAt - Date.now())
+  const duration = formatResetDuration(expiresAt - now)
   if (duration === 'now') {
     return count > 1
       ? translate('auto.components.status.bar.tooltip.7ec6e030a0', 'Next expires now')
@@ -171,12 +172,14 @@ export function ProviderPanel({
   p,
   inverted = false,
   className,
-  showResetCredits = true
+  showResetCredits = true,
+  now = Date.now()
 }: {
   p: ProviderRateLimits | null
   inverted?: boolean
   className?: string
   showResetCredits?: boolean
+  now?: number
 }): React.JSX.Element {
   const textClass = inverted ? 'text-background' : 'text-foreground'
   const mutedClass = inverted ? 'text-background/60' : 'text-muted-foreground'
@@ -226,14 +229,14 @@ export function ProviderPanel({
     )
   }
 
-  const updatedAgo = p.updatedAt ? `Updated ${formatTimeAgo(p.updatedAt)}` : 'Not yet updated'
+  const updatedAgo = p.updatedAt ? `Updated ${formatTimeAgo(p.updatedAt, now)}` : 'Not yet updated'
   const resetCreditCount =
     showResetCredits && p.provider === 'codex'
       ? (p.rateLimitResetCredits?.availableCount ?? null)
       : null
   const resetCreditExpiry =
     resetCreditCount != null
-      ? formatResetCreditExpiry(p.rateLimitResetCredits?.nextExpiresAt, resetCreditCount)
+      ? formatResetCreditExpiry(p.rateLimitResetCredits?.nextExpiresAt, resetCreditCount, now)
       : null
 
   const PanelWindowSection = ({
@@ -247,7 +250,7 @@ export function ProviderPanel({
       return null
     }
     const leftPct = Math.max(0, Math.round(100 - w.usedPercent))
-    const resetLabel = w.resetsAt ? formatResetCountdown(w.resetsAt - Date.now()) : null
+    const resetLabel = w.resetsAt != null ? formatResetCountdown(w.resetsAt - now) : null
 
     return (
       <div className="space-y-1">

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -2,12 +2,14 @@ import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rat
 import { AgentIcon } from '@/lib/agent-catalog'
 import { ClaudeIcon, GeminiIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { translate } from '@/i18n/i18n'
+import { formatResetCountdown, formatResetDuration } from '@/lib/reset-countdown'
 import {
   getProviderDisplayName,
   getProviderUsageErrorMessage,
   getProviderUsageStatusLabel
 } from './usage-error-copy'
 
+export { formatResetCountdown } from '@/lib/reset-countdown'
 export {
   getProviderDisplayName,
   getProviderUsageErrorMessage,
@@ -31,29 +33,6 @@ export function formatTimeAgo(ts: number): string {
   return `${hours}h ago`
 }
 
-function formatDuration(ms: number): string {
-  if (ms <= 0) {
-    return 'now'
-  }
-  const totalMins = Math.floor(ms / 60_000)
-  if (totalMins < 60) {
-    return `${totalMins}m`
-  }
-  const hours = Math.floor(totalMins / 60)
-  const mins = totalMins % 60
-  if (hours >= 24) {
-    const days = Math.floor(hours / 24)
-    const remHours = hours % 24
-    return remHours > 0 ? `${days}d ${remHours}h` : `${days}d`
-  }
-  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
-}
-
-export function formatResetCountdown(ms: number): string {
-  const duration = formatDuration(ms)
-  return duration === 'now' ? 'Resets now' : `Resets in ${duration}`
-}
-
 export function formatResetCreditExpiry(
   expiresAt: number | null | undefined,
   count: number
@@ -61,7 +40,7 @@ export function formatResetCreditExpiry(
   if (!expiresAt) {
     return null
   }
-  const duration = formatDuration(expiresAt - Date.now())
+  const duration = formatResetDuration(expiresAt - Date.now())
   if (duration === 'now') {
     return count > 1
       ? translate('auto.components.status.bar.tooltip.7ec6e030a0', 'Next expires now')

--- a/src/renderer/src/hooks/useResetCountdownClock.ts
+++ b/src/renderer/src/hooks/useResetCountdownClock.ts
@@ -1,0 +1,39 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { getResetCountdownNextTickDelay } from '@/lib/reset-countdown'
+
+function resetTimesKey(resetTimes: readonly (number | null | undefined)[]): string {
+  return resetTimes
+    .filter((resetAt): resetAt is number => resetAt != null && Number.isFinite(resetAt))
+    .sort((a, b) => a - b)
+    .join('|')
+}
+
+function parseResetTimesKey(key: string): number[] {
+  return key.length === 0 ? [] : key.split('|').map((value) => Number(value))
+}
+
+export function useResetCountdownClock(resetTimes: readonly (number | null | undefined)[]): number {
+  const [scheduledNow, setScheduledNow] = useState(() => Date.now())
+  const key = useMemo(() => resetTimesKey(resetTimes), [resetTimes])
+  const times = useMemo(() => parseResetTimesKey(key), [key])
+  const previousKeyRef = useRef(key)
+  const immediateNowRef = useRef(scheduledNow)
+
+  if (previousKeyRef.current !== key) {
+    previousKeyRef.current = key
+    immediateNowRef.current = Date.now()
+  }
+
+  const now = Math.max(scheduledNow, immediateNowRef.current)
+
+  useEffect(() => {
+    const delayMs = getResetCountdownNextTickDelay(now, times)
+    if (delayMs === null) {
+      return
+    }
+    const timeout = window.setTimeout(() => setScheduledNow(Date.now()), delayMs)
+    return () => window.clearTimeout(timeout)
+  }, [now, times])
+
+  return now
+}

--- a/src/renderer/src/lib/reset-countdown.test.ts
+++ b/src/renderer/src/lib/reset-countdown.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { formatResetCountdown, formatResetDuration } from './reset-countdown'
+import {
+  formatResetCountdown,
+  formatResetDuration,
+  getResetCountdownNextTickDelay
+} from './reset-countdown'
 
 const HOUR = 60 * 60_000
 const MINUTE = 60_000
@@ -10,12 +14,12 @@ describe('formatResetDuration', () => {
     expect(formatResetDuration(-1)).toBe('now')
   })
 
-  it('returns "<1m" for sub-minute positive durations, not "0m"', () => {
-    // Why: the 30s tick makes the final minute before reset reachable; "0m"
-    // would read as already-reset.
-    expect(formatResetDuration(1)).toBe('<1m')
-    expect(formatResetDuration(30_000)).toBe('<1m')
-    expect(formatResetDuration(59_999)).toBe('<1m')
+  it('preserves the existing "0m" copy for sub-minute positive durations', () => {
+    // Why: issue #5399 only changes the status badge's source value; the
+    // expanded panel and Codex reset-credit final-minute wording stay stable.
+    expect(formatResetDuration(1)).toBe('0m')
+    expect(formatResetDuration(30_000)).toBe('0m')
+    expect(formatResetDuration(59_999)).toBe('0m')
   })
 
   it('returns whole minutes under an hour', () => {
@@ -48,12 +52,50 @@ describe('formatResetCountdown', () => {
     expect(formatResetCountdown(3 * HOUR + 31 * MINUTE)).toBe('Resets in 3h 31m')
   })
 
-  it('reads "Resets in <1m" in the final minute', () => {
-    expect(formatResetCountdown(30_000)).toBe('Resets in <1m')
+  it('preserves the existing final-minute label', () => {
+    expect(formatResetCountdown(30_000)).toBe('Resets in 0m')
   })
 
   it('reads "Resets now" once elapsed', () => {
     expect(formatResetCountdown(0)).toBe('Resets now')
     expect(formatResetCountdown(-1)).toBe('Resets now')
+  })
+})
+
+describe('getResetCountdownNextTickDelay', () => {
+  it('ticks just after the next minute boundary for minute-granularity labels', () => {
+    const now = Date.parse('2026-06-20T12:00:00.000Z')
+    const resetAt = now + 3 * MINUTE + 12_345
+
+    expect(getResetCountdownNextTickDelay(now, [resetAt])).toBe(12_346)
+  })
+
+  it('ticks just after the reset time during the final minute', () => {
+    const now = Date.parse('2026-06-20T12:00:00.000Z')
+    const resetAt = now + 30_000
+
+    expect(getResetCountdownNextTickDelay(now, [resetAt])).toBe(30_001)
+  })
+
+  it('ticks on the soonest reset label boundary across providers', () => {
+    const now = Date.parse('2026-06-20T12:00:00.000Z')
+
+    expect(
+      getResetCountdownNextTickDelay(now, [now + 10 * MINUTE + 45_000, now + 5 * MINUTE + 5_000])
+    ).toBe(5_001)
+  })
+
+  it('uses hour boundaries for day-granularity labels', () => {
+    const now = Date.parse('2026-06-20T12:00:00.000Z')
+    const resetAt = now + 2 * 24 * HOUR + 4 * HOUR + 17 * MINUTE
+
+    expect(getResetCountdownNextTickDelay(now, [resetAt])).toBe(17 * MINUTE + 1)
+  })
+
+  it('does not schedule a tick when no future reset is visible', () => {
+    const now = Date.parse('2026-06-20T12:00:00.000Z')
+
+    expect(getResetCountdownNextTickDelay(now, [])).toBeNull()
+    expect(getResetCountdownNextTickDelay(now, [now, now - 1])).toBeNull()
   })
 })

--- a/src/renderer/src/lib/reset-countdown.test.ts
+++ b/src/renderer/src/lib/reset-countdown.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { formatResetCountdown, formatResetDuration } from './reset-countdown'
+
+const HOUR = 60 * 60_000
+const MINUTE = 60_000
+
+describe('formatResetDuration', () => {
+  it('returns "now" for zero or negative durations', () => {
+    expect(formatResetDuration(0)).toBe('now')
+    expect(formatResetDuration(-1)).toBe('now')
+  })
+
+  it('returns "<1m" for sub-minute positive durations, not "0m"', () => {
+    // Why: the 30s tick makes the final minute before reset reachable; "0m"
+    // would read as already-reset.
+    expect(formatResetDuration(1)).toBe('<1m')
+    expect(formatResetDuration(30_000)).toBe('<1m')
+    expect(formatResetDuration(59_999)).toBe('<1m')
+  })
+
+  it('returns whole minutes under an hour', () => {
+    expect(formatResetDuration(45 * MINUTE)).toBe('45m')
+    expect(formatResetDuration(MINUTE)).toBe('1m')
+  })
+
+  it('floors partial minutes', () => {
+    expect(formatResetDuration(90_000)).toBe('1m')
+  })
+
+  it('shows hours and minutes — the issue #5399 session case', () => {
+    // Session window with 3h 31m left should read "3h 31m", not a fixed "5h".
+    expect(formatResetDuration(3 * HOUR + 31 * MINUTE)).toBe('3h 31m')
+    expect(formatResetDuration(HOUR + 20 * MINUTE)).toBe('1h 20m')
+  })
+
+  it('omits minutes on a whole hour', () => {
+    expect(formatResetDuration(5 * HOUR)).toBe('5h')
+  })
+
+  it('shows days and hours past 24h (weekly windows)', () => {
+    expect(formatResetDuration(2 * 24 * HOUR + 4 * HOUR)).toBe('2d 4h')
+    expect(formatResetDuration(3 * 24 * HOUR)).toBe('3d')
+  })
+})
+
+describe('formatResetCountdown', () => {
+  it('prefixes "Resets in" for positive durations', () => {
+    expect(formatResetCountdown(3 * HOUR + 31 * MINUTE)).toBe('Resets in 3h 31m')
+  })
+
+  it('reads "Resets in <1m" in the final minute', () => {
+    expect(formatResetCountdown(30_000)).toBe('Resets in <1m')
+  })
+
+  it('reads "Resets now" once elapsed', () => {
+    expect(formatResetCountdown(0)).toBe('Resets now')
+    expect(formatResetCountdown(-1)).toBe('Resets now')
+  })
+})

--- a/src/renderer/src/lib/reset-countdown.ts
+++ b/src/renderer/src/lib/reset-countdown.ts
@@ -1,0 +1,34 @@
+/**
+ * Formats the time remaining until a usage window resets.
+ *
+ * Shared by the expanded usage popover and the collapsed status-bar badge so
+ * both render the same live countdown (e.g. "3h 31m", "45m", "2d 4h") instead
+ * of a fixed window-length label.
+ */
+export function formatResetDuration(ms: number): string {
+  if (ms <= 0) {
+    return 'now'
+  }
+  const totalMins = Math.floor(ms / 60_000)
+  // Why: sub-minute durations floor to 0, and "0m" reads as already-reset; show
+  // "<1m" so the final minute before reset stays distinct from "now" (ms <= 0).
+  if (totalMins === 0) {
+    return '<1m'
+  }
+  if (totalMins < 60) {
+    return `${totalMins}m`
+  }
+  const hours = Math.floor(totalMins / 60)
+  const mins = totalMins % 60
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24)
+    const remHours = hours % 24
+    return remHours > 0 ? `${days}d ${remHours}h` : `${days}d`
+  }
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
+}
+
+export function formatResetCountdown(ms: number): string {
+  const duration = formatResetDuration(ms)
+  return duration === 'now' ? 'Resets now' : `Resets in ${duration}`
+}

--- a/src/renderer/src/lib/reset-countdown.ts
+++ b/src/renderer/src/lib/reset-countdown.ts
@@ -10,11 +10,6 @@ export function formatResetDuration(ms: number): string {
     return 'now'
   }
   const totalMins = Math.floor(ms / 60_000)
-  // Why: sub-minute durations floor to 0, and "0m" reads as already-reset; show
-  // "<1m" so the final minute before reset stays distinct from "now" (ms <= 0).
-  if (totalMins === 0) {
-    return '<1m'
-  }
   if (totalMins < 60) {
     return `${totalMins}m`
   }
@@ -31,4 +26,27 @@ export function formatResetDuration(ms: number): string {
 export function formatResetCountdown(ms: number): string {
   const duration = formatResetDuration(ms)
   return duration === 'now' ? 'Resets now' : `Resets in ${duration}`
+}
+
+const MINUTE_MS = 60_000
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+
+export function getResetCountdownNextTickDelay(
+  now: number,
+  resetTimes: readonly number[]
+): number | null {
+  let nextDelay: number | null = null
+  for (const resetAt of resetTimes) {
+    if (!Number.isFinite(resetAt) || resetAt <= now) {
+      continue
+    }
+    const remainingMs = resetAt - now
+    const tickUnitMs = remainingMs >= DAY_MS ? HOUR_MS : MINUTE_MS
+    // Why: labels are floored to minutes/hours; tick just after the next
+    // boundary so the badge and panel update exactly when their text changes.
+    const delayMs = (remainingMs % tickUnitMs) + 1
+    nextDelay = nextDelay === null ? delayMs : Math.min(nextDelay, delayMs)
+  }
+  return nextDelay
 }


### PR DESCRIPTION
## Summary

Fixes #5399: the collapsed status-bar usage badge now shows the live time until the provider's session reset instead of the fixed session window length (`5h` for Claude).

The follow-up commit removes the earlier caveats from this PR:
- Replaced the per-provider 30s interval with one shared status-bar countdown clock.
- The clock schedules a one-shot timeout at the next actual label boundary, so it does not wake every 30s when no visible label can change.
- The collapsed badge, expanded provider panel, and Codex reset-credit expiry copy all receive the same `now` value, so the badge no longer has an independent schedule that can lag the panel.
- Restored the existing final-minute wording (`0m` / `Resets in 0m`) instead of changing it to `<1m`.
- Kept the old fallback when `resetsAt` is unknown: the badge still shows the fixed window label such as `5h`.

No network/API refreshes were added, no provider-specific behavior was introduced, and the change remains renderer-only and platform-neutral. The remaining local timeout is the minimal clock needed to render a live countdown from already-fetched reset timestamps.

`Fixes #5399`

This supersedes community PR #6252 (taken over and re-implemented against current `main`); the original author is credited via a `Co-authored-by:` trailer in the original fix commit.

## Testing

- [x] `./node_modules/.bin/vitest run --config config/vitest.config.ts src/renderer/src/lib/reset-countdown.test.ts src/renderer/src/components/status-bar/` — 21 files, 135 tests passed
- [x] `./node_modules/.bin/oxlint <touched files>` — clean
- [x] `./node_modules/.bin/oxlint --config config/oxlint-react-doctor.json <changed React files>` — clean
- [x] `./node_modules/.bin/tsgo --noEmit -p config/tsconfig.tc.web.json` — clean
- [ ] `pnpm build` — not run; change is focused renderer formatting/clock behavior with typecheck and status-bar coverage

## Tradeoffs

The listed tradeoffs are resolved: no independent 30s badge interval, no badge/panel lag from separate clocks, and no final-minute copy change. The implementation still uses a local one-shot timeout while visible reset times are in the future; that is required for any live countdown and does not fetch data or change provider behavior.
