### PR TITLE
fix: use plain orca CLI shim for Claude Agent Teams on SSH remotes

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -161,6 +161,7 @@ import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../shared/stable
 import { parseAppSshPtyId } from '../../shared/ssh-pty-id'
 import { isValidHostTerminalTabId } from '../../shared/terminal-tab-id'
 import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '../../shared/tui-agent-startup'
+import { repoIsRemote } from '../../shared/agent-launch-remote'
 import {
   isAgentForegroundWrapperProcess,
   isExpectedAgentProcess,
@@ -11666,13 +11667,15 @@ export class OrcaRuntimeService {
     // Why: a mobile client can run on Windows while the workspace shell is
     // Linux over SSH. Startup command quoting must target the shell that runs it.
     const agentLaunchPlatform = this.getAgentLaunchPlatformForRepo(repo)
+    const isRemote = repoIsRemote(repo)
     const draftLaunchPlan = buildAgentDraftLaunchPlan({
       agent,
       draft: content,
       cmdOverrides: settings.agentCmdOverrides ?? {},
       agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
-      platform: agentLaunchPlatform
+      platform: agentLaunchPlatform,
+      isRemote
     })
     if (draftLaunchPlan) {
       return {
@@ -11695,6 +11698,7 @@ export class OrcaRuntimeService {
       agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
       platform: agentLaunchPlatform,
+      isRemote,
       allowEmptyPromptLaunch: true
     })
     if (!startupPlan) {
@@ -11736,6 +11740,7 @@ export class OrcaRuntimeService {
       agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
       platform: agentLaunchPlatform,
+      isRemote: repoIsRemote(repo),
       allowEmptyPromptLaunch: true
     })
     if (!startupPlan) {
@@ -15133,6 +15138,9 @@ export class OrcaRuntimeService {
     // Why: mobile may be running on iOS while the actual terminal shell is
     // Windows/macOS/Linux or an SSH Linux host; quote for the host shell.
     const platform = this.getAgentLaunchPlatformForWorkspace(workspace)
+    // Why: an SSH workspace runs the CLI through the relay shim (plain `orca`),
+    // so the Linux-only `orca-ide` rename must not be applied.
+    const isRemote = workspace.repo ? repoIsRemote(workspace.repo) : repoIsRemote(workspace)
     const startupPlan = buildAgentStartupPlan({
       agent: opts.agent,
       prompt: '',
@@ -15140,6 +15148,7 @@ export class OrcaRuntimeService {
       agentArgs: resolveTuiAgentLaunchArgs(opts.agent, settings.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(opts.agent, settings.agentDefaultEnv),
       platform,
+      isRemote,
       allowEmptyPromptLaunch: true
     })
     if (!startupPlan) {

--- a/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
+++ b/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
@@ -12,6 +12,9 @@ type BuildSourceControlAgentDeliveryPlanArgs = {
   detectedAgents: TuiAgent[]
   connectionUnavailable: boolean
   launchPlatform?: NodeJS.Platform
+  /** Why: keep the previewed command label in sync with the real remote launch,
+   * which omits the Linux-only `orca-ide` rename for SSH hosts. */
+  isRemote?: boolean
 }
 
 export function buildSourceControlAgentDeliveryPlan({
@@ -21,7 +24,8 @@ export function buildSourceControlAgentDeliveryPlan({
   promptDelivery,
   detectedAgents,
   connectionUnavailable,
-  launchPlatform
+  launchPlatform,
+  isRemote
 }: BuildSourceControlAgentDeliveryPlanArgs): SourceControlAgentActionDeliveryPlanState {
   if (connectionUnavailable) {
     return buildSourceControlAgentConnectionErrorPlan()
@@ -34,7 +38,8 @@ export function buildSourceControlAgentDeliveryPlan({
     detectedAgents,
     disabledAgents: useAppStore.getState().settings?.disabledTuiAgents,
     cmdOverrides: useAppStore.getState().settings?.agentCmdOverrides,
-    platform: launchPlatform
+    platform: launchPlatform,
+    isRemote
   })
   if (!result.ok) {
     return { status: 'error', error: result.error }

--- a/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialog.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlAgentActionDialog.ts
@@ -166,6 +166,9 @@ export function useSourceControlAgentActionDialog({
       groupId,
       promptDelivery,
       launchPlatform,
+      // Why: an SSH host runs the plain `orca` shim; keep the previewed command
+      // label aligned with the real remote launch (no `orca-ide` rename).
+      isRemote: typeof connectionId === 'string',
       launchSource,
       connectionUnavailable,
       refreshDetectedAgents,

--- a/src/renderer/src/components/right-sidebar/useSourceControlAgentActionStart.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlAgentActionStart.ts
@@ -27,6 +27,9 @@ type UseSourceControlAgentActionStartArgs = {
   groupId?: string | null
   promptDelivery: 'auto-submit' | 'draft' | 'submit-after-ready'
   launchPlatform?: NodeJS.Platform
+  /** Why: SSH hosts launch the plain `orca` shim, so the previewed command must
+   * drop the Linux-only `orca-ide` rename to match the real launch. */
+  isRemote?: boolean
   launchSource: LaunchSource
   connectionUnavailable: boolean
   refreshDetectedAgents: () => Promise<TuiAgent[]>
@@ -75,6 +78,7 @@ export function useSourceControlAgentActionStart({
   groupId,
   promptDelivery,
   launchPlatform,
+  isRemote,
   launchSource,
   connectionUnavailable,
   refreshDetectedAgents,
@@ -100,7 +104,8 @@ export function useSourceControlAgentActionStart({
         promptDelivery,
         detectedAgents: currentDetectedAgents,
         connectionUnavailable,
-        launchPlatform
+        launchPlatform,
+        isRemote
       })
     },
     [
@@ -110,7 +115,8 @@ export function useSourceControlAgentActionStart({
       promptDelivery,
       refreshDetectedAgents,
       selectedAgent,
-      launchPlatform
+      launchPlatform,
+      isRemote
     ]
   )
 

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -69,6 +69,7 @@ function buildFolderWorkspaceLinkedStartupPlan(args: {
   agentArgs?: string | null
   agentEnv?: Record<string, string>
   platform: NodeJS.Platform
+  isRemote: boolean
 }): AgentStartupPlan | null {
   const { prompt, draftPrompt } = resolveQuickCreateLinkedWorkItemPrompt(
     args.linkedWorkItem,
@@ -82,7 +83,8 @@ function buildFolderWorkspaceLinkedStartupPlan(args: {
         cmdOverrides: args.agentCmdOverrides ?? {},
         agentArgs: args.agentArgs,
         agentEnv: args.agentEnv,
-        platform: args.platform
+        platform: args.platform,
+        isRemote: args.isRemote
       })
     : null
   if (draftLaunchPlan) {
@@ -108,6 +110,7 @@ function buildFolderWorkspaceLinkedStartupPlan(args: {
     agentArgs: args.agentArgs,
     agentEnv: args.agentEnv,
     platform: args.platform,
+    isRemote: args.isRemote,
     allowEmptyPromptLaunch: true
   })
   if (startupPlan && linkedDraftPrompt) {
@@ -162,6 +165,9 @@ export async function submitFolderWorkspaceCreate({
       ? linkedName
       : name.trim() || linkedName || `${projectGroup.name} workspace`
   const launchPlatform = getFolderWorkspaceAgentLaunchPlatform(projectGroup)
+  // Why: an SSH folder group runs the plain `orca` relay shim, so the Linux-only
+  // `orca-ide` rename must not be applied for remote launches.
+  const launchIsRemote = Boolean(projectGroup.connectionId)
   const startupPlan =
     quickAgent && linkedWorkItem
       ? buildFolderWorkspaceLinkedStartupPlan({
@@ -171,7 +177,8 @@ export async function submitFolderWorkspaceCreate({
           agentCmdOverrides,
           agentArgs,
           agentEnv,
-          platform: launchPlatform
+          platform: launchPlatform,
+          isRemote: launchIsRemote
         })
       : quickAgent
         ? buildAgentStartupPlan({
@@ -181,6 +188,7 @@ export async function submitFolderWorkspaceCreate({
             agentArgs,
             agentEnv,
             platform: launchPlatform,
+            isRemote: launchIsRemote,
             allowEmptyPromptLaunch: true
           })
         : null

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -20,6 +20,7 @@ import { runBackgroundWorktreeCreation } from '@/lib/worktree-creation-flow'
 import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
 import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '@/lib/tui-agent-startup'
 import { filterEnabledTuiAgents, isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
+import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import {
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
@@ -618,6 +619,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         )
     return getAgentLaunchPlatformForRepo(selectedRepo, projectRuntime)
   }, [activeRepoId, projects, repos, selectedRepo, settings, worktreesByRepo])
+  // Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
+  // `orca-ide` rename must not be applied to remote launch commands.
+  const selectedRepoIsRemote = selectedRepo ? repoIsRemote(selectedRepo) : false
   const selectedRepoProjectId =
     selectedWorkspaceTarget.status === 'ready' ? selectedWorkspaceTarget.target.projectId : null
   const selectedProjectId = selectedProjectGroup
@@ -3064,7 +3068,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         cmdOverrides: settings?.agentCmdOverrides ?? {},
         agentArgs: resolveTuiAgentLaunchArgs(tuiAgent, settings?.agentDefaultArgs),
         agentEnv: resolveTuiAgentLaunchEnv(tuiAgent, settings?.agentDefaultEnv),
-        platform: selectedRepoAgentLaunchPlatform
+        platform: selectedRepoAgentLaunchPlatform,
+        isRemote: selectedRepoIsRemote
       })
       const shouldSeedInitialAgentStatus =
         tuiAgent === 'command-code' && submitStartupPrompt.trim().length > 0
@@ -3224,6 +3229,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     resolvedInitialWorkspaceStatus,
     selectedRepo,
     selectedRepoAgentLaunchPlatform,
+    selectedRepoIsRemote,
     selectedRepoIsGit,
     selectedRepoRequiresConnection,
     showProjectRequiredError,
@@ -3458,7 +3464,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                 cmdOverrides: settings?.agentCmdOverrides ?? {},
                 agentArgs: resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs),
                 agentEnv: resolveTuiAgentLaunchEnv(agent, settings?.agentDefaultEnv),
-                platform: selectedRepoAgentLaunchPlatform
+                platform: selectedRepoAgentLaunchPlatform,
+                isRemote: selectedRepoIsRemote
               })
 
         let startupPlan: ReturnType<typeof buildAgentStartupPlan> = null
@@ -3482,6 +3489,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             agentArgs: resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs),
             agentEnv: resolveTuiAgentLaunchEnv(agent, settings?.agentDefaultEnv),
             platform: selectedRepoAgentLaunchPlatform,
+            isRemote: selectedRepoIsRemote,
             allowEmptyPromptLaunch: true
           })
           if (startupPlan && quickDraftPrompt) {
@@ -3624,6 +3632,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       resolvedInitialWorkspaceStatus,
       selectedRepo,
       selectedRepoAgentLaunchPlatform,
+      selectedRepoIsRemote,
       selectedRepoIsGit,
       selectedRepoSettings,
       selectedRepoRequiresConnection,

--- a/src/renderer/src/lib/command-code-prompt-status-seed.ts
+++ b/src/renderer/src/lib/command-code-prompt-status-seed.ts
@@ -1,0 +1,24 @@
+import { useAppStore } from '@/store'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+
+/**
+ * Why: Command Code has no prompt-submit hook, so when Orca submits a generated
+ * prompt after the TUI is ready, seed `working` at delivery time so sidebar and
+ * activity surfaces don't stay idle until the first real hook event arrives.
+ */
+export function seedCommandCodeSubmittedPromptStatus(tabId: string, prompt: string): void {
+  const state = useAppStore.getState()
+  const leafId = state.terminalLayoutsByTabId[tabId]?.activeLeafId
+  if (!leafId) {
+    return
+  }
+  try {
+    state.setAgentStatus(makePaneKey(tabId, leafId), {
+      state: 'working',
+      prompt,
+      agentType: 'command-code'
+    })
+  } catch {
+    // Best-effort UI seed. Real hooks still own refinement/completion.
+  }
+}

--- a/src/renderer/src/lib/github-work-item-background-request.ts
+++ b/src/renderer/src/lib/github-work-item-background-request.ts
@@ -13,6 +13,7 @@ import type {
 import { CLIENT_PLATFORM, getWorkspaceIntentName, getWorkspaceSeedName } from '@/lib/new-workspace'
 import { getLocalRepoProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { resolveSourceControlLaunchPlatform } from '@/lib/source-control-launch-platform'
+import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import {
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
@@ -180,6 +181,9 @@ export function buildGitHubWorkItemStartupPlan(args: {
   // Why: runtime-owned repos launch on their owner host, not on the client
   // desktop, so startup shell quoting must use the runtime platform.
   const platform = resolveGitHubWorkItemLaunchPlatform(store, repo)
+  // Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
+  // `orca-ide` rename must not be applied for remote launches.
+  const isRemote = repoIsRemote(repo)
   const draftLaunchPlan = draftPrompt
     ? buildAgentDraftLaunchPlan({
         agent,
@@ -187,7 +191,8 @@ export function buildGitHubWorkItemStartupPlan(args: {
         cmdOverrides: store.settings?.agentCmdOverrides ?? {},
         agentArgs: resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs),
         agentEnv: resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv),
-        platform
+        platform,
+        isRemote
       })
     : null
   const startupPlan = draftLaunchPlan
@@ -209,6 +214,7 @@ export function buildGitHubWorkItemStartupPlan(args: {
         agentArgs: resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs),
         agentEnv: resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv),
         platform,
+        isRemote,
         allowEmptyPromptLaunch: true
       })
   if (startupPlan && draftPrompt && !draftLaunchPlan) {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -15,6 +15,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import {
   registerEagerPtyBuffer,
@@ -66,6 +67,9 @@ export async function launchAgentBackgroundSession(
         repo.connectionId ? undefined : getLocalProjectExecutionRuntimeContext(store, worktreeId)
       )
     : CLIENT_PLATFORM
+  // Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
+  // `orca-ide` rename must not be applied for remote launches.
+  const isRemote = repo ? repoIsRemote(repo) : false
   const trimmedPrompt = prompt?.trim() ?? ''
   const hasPrompt = trimmedPrompt.length > 0
   const isFollowupPath = TUI_AGENT_CONFIG[agent].promptInjectionMode === 'stdin-after-start'
@@ -80,6 +84,7 @@ export async function launchAgentBackgroundSession(
       agentArgs,
       agentEnv,
       platform: launchPlatform,
+      isRemote,
       allowEmptyPromptLaunch: true
     })
     pasteDraftAfterLaunch = trimmedPrompt
@@ -91,6 +96,7 @@ export async function launchAgentBackgroundSession(
       agentArgs,
       agentEnv,
       platform: launchPlatform,
+      isRemote,
       allowEmptyPromptLaunch: !hasPrompt
     })
   }

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -22,7 +22,8 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
-import { makePaneKey } from '../../../shared/stable-pane-id'
+import { repoIsRemote } from '../../../shared/agent-launch-remote'
+import { seedCommandCodeSubmittedPromptStatus } from '@/lib/command-code-prompt-status-seed'
 import type { TuiAgent } from '../../../shared/types'
 import type { LaunchSource } from '../../../shared/telemetry-events'
 import { translate } from '@/i18n/i18n'
@@ -67,23 +68,6 @@ export type LaunchAgentInNewTabResult = {
   startupPlan: AgentStartupPlan
   pasteDraftAfterLaunch: boolean
 } | null
-
-function seedCommandCodeSubmittedPromptStatus(tabId: string, prompt: string): void {
-  const state = useAppStore.getState()
-  const leafId = state.terminalLayoutsByTabId[tabId]?.activeLeafId
-  if (!leafId) {
-    return
-  }
-  try {
-    state.setAgentStatus(makePaneKey(tabId, leafId), {
-      state: 'working',
-      prompt,
-      agentType: 'command-code'
-    })
-  } catch {
-    // Best-effort UI seed. Real hooks still own refinement/completion.
-  }
-}
 
 /**
  * Create a new terminal tab and queue the agent's launch command, optionally
@@ -131,6 +115,9 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
           repo.connectionId ? undefined : getLocalProjectExecutionRuntimeContext(store, worktreeId)
         )
       : CLIENT_PLATFORM)
+  // Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
+  // `orca-ide` rename must not be applied for remote launches.
+  const isRemote = repo ? repoIsRemote(repo) : false
   const cmdOverrides = store.settings?.agentCmdOverrides ?? {}
   const effectiveAgentArgs =
     agentArgs !== undefined
@@ -159,6 +146,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       prompt: '',
       cmdOverrides,
       platform: resolvedLaunchPlatform,
+      isRemote,
       agentArgs: effectiveAgentArgs,
       agentEnv,
       allowEmptyPromptLaunch: true
@@ -172,6 +160,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       draft: trimmedPrompt,
       cmdOverrides,
       platform: resolvedLaunchPlatform,
+      isRemote,
       agentArgs: effectiveAgentArgs,
       agentEnv
     })
@@ -193,6 +182,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
         prompt: '',
         cmdOverrides,
         platform: resolvedLaunchPlatform,
+        isRemote,
         agentArgs: effectiveAgentArgs,
         agentEnv,
         allowEmptyPromptLaunch: true
@@ -205,6 +195,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       prompt: '',
       cmdOverrides,
       platform: resolvedLaunchPlatform,
+      isRemote,
       agentArgs: effectiveAgentArgs,
       agentEnv,
       allowEmptyPromptLaunch: true
@@ -216,6 +207,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       prompt: hasPrompt ? trimmedPrompt : '',
       cmdOverrides,
       platform: resolvedLaunchPlatform,
+      isRemote,
       agentArgs: effectiveAgentArgs,
       agentEnv,
       allowEmptyPromptLaunch: !hasPrompt

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -31,6 +31,9 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
     | null
     | undefined
   launchPlatform: NodeJS.Platform
+  /** Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
+   * `orca-ide` rename must not be applied for remote launches. */
+  isRemote?: boolean
 }): {
   startupPlan: AgentStartupPlan | null
   draftLaunchedNatively: boolean
@@ -53,6 +56,7 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
           draft: args.draftContent,
           cmdOverrides: args.settings?.agentCmdOverrides ?? {},
           platform: args.launchPlatform,
+          isRemote: args.isRemote,
           agentArgs: effectiveAgentArgs,
           agentEnv: effectiveAgentEnv
         })
@@ -80,6 +84,7 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
     prompt: '',
     cmdOverrides: args.settings?.agentCmdOverrides ?? {},
     platform: args.launchPlatform,
+    isRemote: args.isRemote,
     agentArgs: effectiveAgentArgs,
     agentEnv: effectiveAgentEnv,
     allowEmptyPromptLaunch: true

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -264,7 +264,10 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
         draftContent,
         promptDelivery,
         settings,
-        launchPlatform
+        launchPlatform,
+        // Why: SSH hosts run the plain `orca` shim, so the Linux-only `orca-ide`
+        // rename must not be applied for remote launches.
+        isRemote: typeof launchConnectionId === 'string'
       }))
 
     const activation = activateAndRevealWorktree(worktreeId, {

--- a/src/renderer/src/lib/source-control-agent-action-plan.ts
+++ b/src/renderer/src/lib/source-control-agent-action-plan.ts
@@ -36,6 +36,9 @@ export function planSourceControlAgentActionLaunch(args: {
   cmdOverrides?: Partial<Record<TuiAgent, string>>
   agentArgs?: string | null
   platform?: NodeJS.Platform
+  /** Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
+   * `orca-ide` rename must not be applied for remote launches. */
+  isRemote?: boolean
 }): SourceControlLaunchPlanResult {
   const agent = args.agent
   if (!agent) {
@@ -79,6 +82,7 @@ export function planSourceControlAgentActionLaunch(args: {
 
   const cmdOverrides = args.cmdOverrides ?? {}
   const platform = args.platform ?? CLIENT_PLATFORM
+  const isRemote = args.isRemote ?? false
   const shell = platform === 'win32' ? 'powershell' : 'posix'
   const plannedArgs = planAgentCliArgsSuffix(args.agentArgs, shell)
   if (!plannedArgs.ok) {
@@ -93,6 +97,7 @@ export function planSourceControlAgentActionLaunch(args: {
       prompt: '',
       cmdOverrides,
       platform,
+      isRemote,
       agentArgs: args.agentArgs,
       allowEmptyPromptLaunch: true
     })
@@ -103,6 +108,7 @@ export function planSourceControlAgentActionLaunch(args: {
       draft: trimmedInput,
       cmdOverrides,
       platform,
+      isRemote,
       agentArgs: args.agentArgs
     })
     if (draftLaunchPlan) {
@@ -124,6 +130,7 @@ export function planSourceControlAgentActionLaunch(args: {
         prompt: '',
         cmdOverrides,
         platform,
+        isRemote,
         agentArgs: args.agentArgs,
         allowEmptyPromptLaunch: true
       })
@@ -135,6 +142,7 @@ export function planSourceControlAgentActionLaunch(args: {
       prompt: '',
       cmdOverrides,
       platform,
+      isRemote,
       agentArgs: args.agentArgs,
       allowEmptyPromptLaunch: true
     })
@@ -145,6 +153,7 @@ export function planSourceControlAgentActionLaunch(args: {
       prompt: trimmedInput,
       cmdOverrides,
       platform,
+      isRemote,
       agentArgs: args.agentArgs,
       allowEmptyPromptLaunch: false
     })

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -40,6 +40,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { isTuiAgent } from '../../../shared/tui-agent-config'
+import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import {
@@ -239,6 +240,7 @@ function buildCreatedAgentReopenStartup(worktree: Worktree): WorktreeStartupPayl
     agentArgs: resolveTuiAgentLaunchArgs(agent, state.settings?.agentDefaultArgs),
     agentEnv: resolveTuiAgentLaunchEnv(agent, state.settings?.agentDefaultEnv),
     platform: launchPlatform,
+    isRemote: repo ? repoIsRemote(repo) : false,
     allowEmptyPromptLaunch: true
   })
   if (!startupPlan) {

--- a/src/shared/agent-launch-remote.ts
+++ b/src/shared/agent-launch-remote.ts
@@ -1,0 +1,11 @@
+/**
+ * Why: a repo reached over SSH runs the Orca CLI through the relay shim, which
+ * is always deployed as plain `orca` (Unix) / `orca.cmd` (Windows). The
+ * Linux-only `orca-ide` rename — which exists solely to avoid shadowing the
+ * GNOME Orca screen reader on a local desktop — must not be applied to those
+ * remotes, or `orca-ide claude-teams` lands on a PATH where it does not exist.
+ * `connectionId` is the SSH signal; WSL and local stay false.
+ */
+export function repoIsRemote(repo: { connectionId?: string | null }): boolean {
+  return Boolean(repo.connectionId)
+}

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -348,7 +348,14 @@ export function getTuiAgentDetectCommands(config: TuiAgentConfig): string[] {
 
 export function getTuiAgentLaunchCommand(
   config: TuiAgentConfig,
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  opts?: { isRemote?: boolean }
 ): string {
+  // Why: the SSH relay shim is always named `orca` on Unix, so the local-only
+  // `orca-ide` rename (avoids shadowing the GNOME Orca screen reader) must not
+  // leak to Linux remotes — the remote has no such desktop binary on PATH.
+  if (opts?.isRemote && platform === 'linux') {
+    return config.launchCmd
+  }
   return config.launchCmdByPlatform?.[platform] ?? config.launchCmd
 }

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -102,6 +102,54 @@ describe('tui agent startup plans', () => {
     expect(plan?.launchCommand).toBe('orca-ide claude-teams')
   })
 
+  it('uses the plain orca shim for Claude Agent Teams on Linux SSH remotes', () => {
+    // Why: the SSH relay deploys the CLI shim as `orca` (not the local-only
+    // `orca-ide` GNOME-screen-reader workaround), so a remote launch must not
+    // emit `orca-ide claude-teams` — that name is not on the remote PATH and
+    // `claude-teams` is rejected by the relay's CLI switch (issue #6500).
+    const plan = buildAgentStartupPlan({
+      agent: 'claude-agent-teams',
+      prompt: '',
+      cmdOverrides: {},
+      platform: 'linux',
+      isRemote: true,
+      allowEmptyPromptLaunch: true
+    })
+
+    expect(plan?.launchCommand).toBe('orca claude-teams')
+  })
+
+  it('keeps the Windows orca.cmd shim for Claude Agent Teams on SSH remotes', () => {
+    // Why: the Windows remote shim is also `orca.cmd`, matching the local
+    // win32 override, so remoteness must not alter the Windows command.
+    const plan = buildAgentStartupPlan({
+      agent: 'claude-agent-teams',
+      prompt: '',
+      cmdOverrides: {},
+      platform: 'win32',
+      isRemote: true,
+      allowEmptyPromptLaunch: true
+    })
+
+    expect(plan?.launchCommand).toBe('orca.cmd claude-teams')
+  })
+
+  it('keeps the Linux orca-ide wrapper for local (non-remote) Claude Agent Teams', () => {
+    // Why: the `orca-ide` rename is still required for a local Linux desktop
+    // install (avoids shadowing the GNOME Orca screen reader), so an explicit
+    // isRemote:false must preserve it.
+    const plan = buildAgentStartupPlan({
+      agent: 'claude-agent-teams',
+      prompt: '',
+      cmdOverrides: {},
+      platform: 'linux',
+      isRemote: false,
+      allowEmptyPromptLaunch: true
+    })
+
+    expect(plan?.launchCommand).toBe('orca-ide claude-teams')
+  })
+
   it('launches OpenClaude as a distinct argv agent', () => {
     const plan = buildAgentStartupPlan({
       agent: 'openclaude',

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -37,9 +37,14 @@ function resolveBaseCommand(args: {
   platform: NodeJS.Platform
   shell: AgentStartupShell
   agentArgs?: string | null
+  isRemote?: boolean
 }): { ok: true; command: string } | { ok: false; error: string } {
   const override = args.cmdOverrides[args.agent]
-  const command = override || getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[args.agent], args.platform)
+  const command =
+    override ||
+    getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[args.agent], args.platform, {
+      isRemote: args.isRemote
+    })
   const suffix = planAgentCliArgsSuffix(args.agentArgs, args.shell)
   if (!suffix.ok) {
     return suffix
@@ -72,6 +77,9 @@ export function buildAgentStartupPlan(args: {
   allowEmptyPromptLaunch?: boolean
   agentArgs?: string | null
   agentEnv?: Record<string, string> | null
+  /** Why: SSH remotes deploy the CLI shim as plain `orca`, so the Linux-only
+   * `orca-ide` rename must be skipped for remote launches. */
+  isRemote?: boolean
 }): AgentStartupPlan | null {
   const { agent, prompt, cmdOverrides, platform, allowEmptyPromptLaunch = false } = args
   const shell = resolveStartupShell(platform, args.shell)
@@ -82,7 +90,8 @@ export function buildAgentStartupPlan(args: {
     cmdOverrides,
     platform,
     shell,
-    agentArgs: args.agentArgs
+    agentArgs: args.agentArgs,
+    isRemote: args.isRemote
   })
   if (!baseCommand.ok) {
     return null
@@ -172,6 +181,8 @@ export function buildAgentResumeStartupPlan(args: {
   agentArgs?: string | null
   agentEnv?: Record<string, string> | null
   agentCommand?: string | null
+  /** Why: see buildAgentStartupPlan — remote launches use the plain `orca` shim. */
+  isRemote?: boolean
 }): AgentStartupPlan | null {
   const argv = getAgentResumeArgv(args.agent, args.providerSession)
   if (!argv) {
@@ -187,7 +198,8 @@ export function buildAgentResumeStartupPlan(args: {
         cmdOverrides: args.cmdOverrides,
         platform: args.platform,
         shell,
-        agentArgs: args.agentArgs
+        agentArgs: args.agentArgs,
+        isRemote: args.isRemote
       })
   if (!baseCommand.ok) {
     return null
@@ -244,6 +256,8 @@ export function buildAgentDraftLaunchPlan(args: {
   shell?: AgentStartupShell
   agentArgs?: string | null
   agentEnv?: Record<string, string> | null
+  /** Why: see buildAgentStartupPlan — remote launches use the plain `orca` shim. */
+  isRemote?: boolean
 }): AgentDraftLaunchPlan | null {
   const { agent, draft, cmdOverrides, platform } = args
   const shell = resolveStartupShell(platform, args.shell)
@@ -257,7 +271,8 @@ export function buildAgentDraftLaunchPlan(args: {
     cmdOverrides,
     platform,
     shell,
-    agentArgs: args.agentArgs
+    agentArgs: args.agentArgs,
+    isRemote: args.isRemote
   })
   if (!baseCommand.ok) {
     return null


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** If you connect a project to a remote machine over SSH and pick "Claude Agent Teams" as your agent, then add a new worktree, the agent just fails to start. The remote logs spit out `Unsupported SSH Orca CLI command: claude-teams` and nothing happens. It's a hard blocker — not a glitch you can work around — but only for a specific group: people running Claude Agent Teams on a Linux machine over SSH. Local users, and people using other agents, are unaffected. (Reported in #6500 on v1.4.101.)

**2) What this PR does (ELI5).** Orca starts agents by typing a command on the target machine. On a *local* Linux desktop it deliberately uses the name `orca-ide` instead of `orca`, because plain `orca` would collide with the built-in GNOME "Orca" screen-reader program. The bug was that Orca used that same renamed `orca-ide` command on *remote* machines too — but a remote machine only ever has the plain `orca` command installed, so the renamed one points at nothing. Think of it like mailing a letter to someone's nickname when the post office over there only knows their legal name. This PR teaches Orca to notice "this is a remote SSH machine" and send the plain `orca claude-teams` command in that case, while still using `orca-ide` on a real local Linux desktop. So it now sends a command the remote actually recognizes, instead of one it rejects.

**3) Tradeoffs / regressions — honest answer.** No regressions — nothing is disabled, no new setup, and no existing behavior is lost. The change only fires in exactly one situation: an SSH-remote Linux machine running the one agent (Claude Agent Teams) that uses the platform-specific name. Everything else is byte-for-byte identical: local Linux still gets `orca-ide` (the screen-reader workaround is preserved and explicitly tested), Windows remotes still get `orca.cmd`, macOS is untouched, WSL stays on the local path, and any user-defined command override still wins. The one thing reviewers should actually check is breadth, not danger: the fix threads a single `isRemote` boolean through many launch call sites (worktree reopen, quick-launch, background sessions, the composer, source-control actions, etc.), so the real risk is a *missed* call site that would leave that path still broken — not a path made worse. No performance cost, no extra API calls, no default changed.

---

## Summary

Fixes #6500.

Adding a worktree to an SSH-connected project with **Claude Agent Teams** selected queued the wrong default agent command: `orca-ide claude-teams` instead of `orca claude-teams`. On the remote this fails — the relay prints `Unsupported SSH Orca CLI command: claude-teams` and the agent never starts.

Root cause: for SSH-connected repos, `getAgentLaunchPlatformForRepo` returns `'linux'`. That platform flows into `getTuiAgentLaunchCommand`, which for `claude-agent-teams` picks `launchCmdByPlatform.linux = "orca-ide claude-teams"`. The `orca-ide` name exists **only** to avoid shadowing the GNOME Orca screen reader (`/usr/bin/orca`) on a *local* Linux desktop install. On an SSH remote there is no such binary: the relay deploys the CLI shim solely as `orca` (Unix) via `buildRemoteCliShim`, and only `orca`-prefixed commands are routed to the relay CLI. So `orca-ide claude-teams` is not on PATH, and `claude-teams` is not in the relay's supported command switch (`ssh-remote-orca-cli.ts`), hitting the default branch that throws the reported error. Windows SSH remotes were already fine because the remote shim is `orca.cmd`, matching the win32 override.

Fix: thread an `isRemote` (SSH) flag through launch-command resolution. When `isRemote && platform === 'linux'`, `getTuiAgentLaunchCommand` skips `launchCmdByPlatform.linux` and returns the plain `launchCmd` (`orca claude-teams`). The win32 `orca.cmd` override is preserved (the remote Windows shim is also `orca.cmd`). Callers compute `isRemote = Boolean(repo.connectionId)` via a small shared `repoIsRemote` helper — SSH = remote; WSL/local stay false — so all non-SSH behavior is byte-for-byte unchanged. `claude-agent-teams` is the only agent using `launchCmdByPlatform`, so the behavior change is scoped to it.

## Screenshots

This is a launch-command (string) defect with no standalone visual surface; the verifiable artifact is the queued command. Evidence (run against the live `nwparker/fix-6500` dev build over CDP, plus unit tests) is posted as a PR comment. A running-app screenshot is attached in that comment.

## Testing

- [ ] `pnpm lint` (ran `oxlint` on all changed files — clean)
- [ ] `pnpm typecheck` (ran `tsgo --noEmit` for node + web + cli configs — clean)
- [ ] `pnpm test` (ran the affected vitest files — pass)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Scoped commands actually run:
- `oxlint <changed files>` — clean
- `tsgo --noEmit -p config/tsconfig.node.json` / `config/tsconfig.tc.web.json` / `config/tsconfig.tc.cli.json` — clean
- `vitest run src/shared/tui-agent-startup.test.ts` — 33 passed (added remote-Linux, remote-Windows, explicit local-Linux cases)

## AI Review Report

Reviewed correctness, edge cases, cross-platform, and security adversarially.
- **Cross-platform:** No hardcoded path separators or `metaKey`. The `orca-ide` (Linux) vs `orca.cmd` (Windows) vs `orca` distinction is preserved exactly per platform; only the Linux-remote case changes. Verified the remote Windows shim is `orca.cmd` (so win32 remote stays correct) and that `isRemote` derives from `connectionId` (SSH), keeping WSL and native macOS/Linux/Windows untouched.
- **SSH/remote:** This is the SSH-specific fix; verified against the relay shim naming (`buildRemoteCliShim`) and the relay CLI command switch.
- **Git providers:** Not provider-related.
- **Scope check:** `claude-agent-teams` is the only agent with `launchCmdByPlatform`, so no other agent's command changes. `cmdOverrides` still win over the platform lookup, so user overrides are unaffected. Resume paths (`buildAgentResumeStartupPlan`) were intentionally left untouched because `claude-agent-teams` is not a `ResumableTuiAgent`.
- Flagged + addressed: extracting `seedCommandCodeSubmittedPromptStatus` into `command-code-prompt-status-seed.ts` to keep `launch-agent-in-new-tab.ts` under the 300-line lint limit without a `max-lines` disable.

## Security Audit

The change only threads a boolean and selects between two pre-existing static command strings (`orca claude-teams` vs `orca-ide claude-teams`). No new shell construction, no user-input interpolation, no `eval`, no network, no filesystem, no secrets, no new dependencies, no IPC surface. `repoIsRemote` reads `repo.connectionId` only. No injection surface introduced.

## Notes

- All callers that resolve a real SSH-remote launch platform for `claude-agent-teams` now pass `isRemote`: worktree reopen, quick-launch new tab, background sessions, the new-workspace composer (incl. quick-create), GitHub work-item background requests, direct work-item launch, source-control AI action plan/preview, folder-workspace composer, and the main-process runtime startup/draft/mobile-session builders.
- Future suggestion (out of scope): `getAgentLaunchPlatformForRepo` returning a bare platform loses the local-vs-remote-Linux distinction at the type level; a small `{ platform, isRemote }` result type could remove the need to recompute `isRemote` alongside it at each call site.

Made with [Orca](https://github.com/stablyai/orca) 🐋