### PR TITLE
Surface a friendly error when Windows blocks the user PATH write (#6412)

### DIFF
--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -346,6 +346,60 @@ describe('CliInstaller', () => {
     expect(userPath).not.toContain(join(fixture.root, 'Programs', 'Orca', 'bin'))
   })
 
+  it('rejects with a friendly message when Windows blocks the user PATH write', async () => {
+    const fixture = await makeFixture()
+    const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+    const installer = new CliInstaller({
+      platform: 'win32',
+      isPackaged: false,
+      userDataPath: fixture.userDataPath,
+      execPath: 'C:\\Users\\me\\AppData\\Local\\Orca\\Orca.exe',
+      appPath: fixture.appPath,
+      commandPathOverride: installPath,
+      userPathReader: async () => 'C:\\Windows\\System32',
+      userPathWriter: async () => {
+        // Mirrors the PowerShell rejection envelope when HKCU\Environment is
+        // locked: the inner text may be localized/mojibake, but the Latin
+        // FullyQualifiedErrorId token stays present.
+        const error = new Error(
+          "Command failed: powershell -NoProfile -Command [Environment]::SetEnvironmentVariable('Path', '...', 'User')\nFullyQualifiedErrorId : UnauthorizedAccessException,Microsoft.PowerShell.Commands"
+        )
+        Object.assign(error, { code: 1 })
+        throw error
+      }
+    })
+
+    const result = installer.install()
+    await expect(result).rejects.toThrow(/access denied|Group Policy|manually/i)
+    await expect(result).rejects.not.toThrow(/Command failed: powershell/)
+    await expect(result).rejects.toMatchObject({
+      cause: expect.objectContaining({
+        message: expect.stringContaining('UnauthorizedAccessException')
+      })
+    })
+  })
+
+  it('propagates a non-permission Windows PATH write error unchanged', async () => {
+    const fixture = await makeFixture()
+    const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+    const installer = new CliInstaller({
+      platform: 'win32',
+      isPackaged: false,
+      userDataPath: fixture.userDataPath,
+      execPath: 'C:\\Users\\me\\AppData\\Local\\Orca\\Orca.exe',
+      appPath: fixture.appPath,
+      commandPathOverride: installPath,
+      userPathReader: async () => 'C:\\Windows\\System32',
+      userPathWriter: async () => {
+        throw new Error('Windows PATH command timed out after 5000ms.')
+      }
+    })
+
+    await expect(installer.install()).rejects.toThrow(
+      'Windows PATH command timed out after 5000ms.'
+    )
+  })
+
   it('settles when the Windows PATH query hangs', async () => {
     vi.useFakeTimers()
     const fixture = await makeFixture()

--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -346,59 +346,87 @@ describe('CliInstaller', () => {
     expect(userPath).not.toContain(join(fixture.root, 'Programs', 'Orca', 'bin'))
   })
 
-  it('rejects with a friendly message when Windows blocks the user PATH write', async () => {
-    const fixture = await makeFixture()
-    const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
-    const installer = new CliInstaller({
-      platform: 'win32',
-      isPackaged: false,
-      userDataPath: fixture.userDataPath,
-      execPath: 'C:\\Users\\me\\AppData\\Local\\Orca\\Orca.exe',
-      appPath: fixture.appPath,
-      commandPathOverride: installPath,
-      userPathReader: async () => 'C:\\Windows\\System32',
-      userPathWriter: async () => {
-        // Mirrors the PowerShell rejection envelope when HKCU\Environment is
-        // locked: the inner text may be localized/mojibake, but the Latin
-        // FullyQualifiedErrorId token stays present.
-        const error = new Error(
-          "Command failed: powershell -NoProfile -Command [Environment]::SetEnvironmentVariable('Path', '...', 'User')\nFullyQualifiedErrorId : UnauthorizedAccessException,Microsoft.PowerShell.Commands"
-        )
-        Object.assign(error, { code: 1 })
-        throw error
-      }
-    })
-
-    const result = installer.install()
-    await expect(result).rejects.toThrow(/access denied|Group Policy|manually/i)
-    await expect(result).rejects.not.toThrow(/Command failed: powershell/)
-    await expect(result).rejects.toMatchObject({
-      cause: expect.objectContaining({
-        message: expect.stringContaining('UnauthorizedAccessException')
+  it.each(['UnauthorizedAccessException', 'SecurityException'])(
+    'rejects with a friendly message for Windows PATH denial: %s',
+    async (permissionMarker) => {
+      const fixture = await makeFixture()
+      const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+      const installer = new CliInstaller({
+        platform: 'win32',
+        isPackaged: false,
+        userDataPath: fixture.userDataPath,
+        execPath: 'C:\\Users\\me\\AppData\\Local\\Orca\\Orca.exe',
+        appPath: fixture.appPath,
+        commandPathOverride: installPath,
+        userPathReader: async () => 'C:\\Windows\\System32',
+        userPathWriter: async () => {
+          // The .NET error id survives localized or mojibake PowerShell output.
+          const error = new Error(
+            `Command failed: powershell -NoProfile -Command [Environment]::SetEnvironmentVariable('Path', '...', 'User')\nFullyQualifiedErrorId : ${permissionMarker},Microsoft.PowerShell.Commands`
+          )
+          Object.assign(error, { code: 1 })
+          throw error
+        }
       })
-    })
-  })
 
-  it('propagates a non-permission Windows PATH write error unchanged', async () => {
+      const result = installer.install()
+      await expect(result).rejects.toThrow(/access denied|Group Policy|manually/i)
+      await expect(result).rejects.not.toThrow(/Command failed: powershell/)
+      await expect(result).rejects.toMatchObject({
+        cause: expect.objectContaining({
+          message: expect.stringContaining(permissionMarker)
+        })
+      })
+    }
+  )
+
+  it('skips the Windows PATH write when removing an absent entry', async () => {
     const fixture = await makeFixture()
-    const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+    const userPathWriter = vi.fn()
     const installer = new CliInstaller({
       platform: 'win32',
       isPackaged: false,
       userDataPath: fixture.userDataPath,
       execPath: 'C:\\Users\\me\\AppData\\Local\\Orca\\Orca.exe',
       appPath: fixture.appPath,
-      commandPathOverride: installPath,
+      commandPathOverride: join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd'),
       userPathReader: async () => 'C:\\Windows\\System32',
-      userPathWriter: async () => {
-        throw new Error('Windows PATH command timed out after 5000ms.')
-      }
+      userPathWriter
     })
 
-    await expect(installer.install()).rejects.toThrow(
-      'Windows PATH command timed out after 5000ms.'
-    )
+    await expect(installer.remove()).resolves.toMatchObject({ state: 'not_installed' })
+    expect(userPathWriter).not.toHaveBeenCalled()
   })
+
+  it.each([
+    ['PowerShell timeout', 'Windows PATH command timed out after 5000ms.'],
+    [
+      'generic PowerShell method failure',
+      "Command failed: powershell -NoProfile -Command [Environment]::SetEnvironmentVariable('Path', '...', 'User')\nCategoryInfo : NotSpecified: (:) [], MethodInvocationException\nFullyQualifiedErrorId : MethodInvocationException"
+    ]
+  ])(
+    'propagates a non-permission Windows PATH write error unchanged: %s',
+    async (_name, message) => {
+      const fixture = await makeFixture()
+      const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+      const installer = new CliInstaller({
+        platform: 'win32',
+        isPackaged: false,
+        userDataPath: fixture.userDataPath,
+        execPath: 'C:\\Users\\me\\AppData\\Local\\Orca\\Orca.exe',
+        appPath: fixture.appPath,
+        commandPathOverride: installPath,
+        userPathReader: async () => 'C:\\Windows\\System32',
+        userPathWriter: async () => {
+          throw new Error(message)
+        }
+      })
+
+      const result = installer.install()
+      await expect(result).rejects.toThrow(message)
+      await expect(result).rejects.not.toThrow(/Windows blocked updating your user PATH/)
+    }
+  )
 
   it('settles when the Windows PATH query hangs', async () => {
     vi.useFakeTimers()

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -823,7 +823,7 @@ export class CliInstaller {
       return
     }
     entries.push(pathDirectory)
-    await this.userPathWriter(entries.join(';'))
+    await this.writeWindowsUserPathEntry(entries.join(';'), pathDirectory, 'add')
   }
 
   private async removeWindowsPathEntry(pathDirectory: string): Promise<void> {
@@ -834,7 +834,33 @@ export class CliInstaller {
     const nextEntries = splitPathEntries('win32', current).filter(
       (entry) => !samePathEntry('win32', entry, pathDirectory)
     )
-    await this.userPathWriter(nextEntries.join(';'))
+    await this.writeWindowsUserPathEntry(nextEntries.join(';'), pathDirectory, 'remove')
+  }
+
+  // Why: the raw `Command failed: powershell ...` rejection is dumped verbatim
+  // into the renderer toast (CliSection), so translate a denied user-PATH write
+  // into an actionable message naming the exact folder to add manually. The
+  // original error stays chained on `cause` so logs keep the diagnostic detail.
+  private async writeWindowsUserPathEntry(
+    value: string,
+    pathDirectory: string,
+    action: 'add' | 'remove'
+  ): Promise<void> {
+    try {
+      await this.userPathWriter(value)
+    } catch (error) {
+      if (!isWindowsUserPathPermissionError(error)) {
+        throw error
+      }
+      const guidance =
+        action === 'add'
+          ? `Add this folder to your PATH manually: ${pathDirectory}. Or run Orca as an administrator and try again.`
+          : `Remove this folder from your PATH manually: ${pathDirectory}. Or run Orca as an administrator and try again.`
+      throw new Error(
+        `Windows blocked updating your user PATH (access denied). This usually means your PATH environment variable is managed by Group Policy or your organization's device management. ${guidance}`,
+        { cause: error }
+      )
+    }
   }
 }
 
@@ -1035,6 +1061,29 @@ function isPermissionError(error: unknown): boolean {
 function isMissingError(error: unknown): boolean {
   return (
     error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT'
+  )
+}
+
+// Why: Windows refuses user-environment writes (Group Policy / restricted HKCU
+// ACL / EDR-managed env) with a localized message that can arrive as mojibake,
+// so detection keys off the Latin PowerShell error envelope tokens
+// (FullyQualifiedErrorId, MethodInvocationException) that stay readable
+// regardless of the OS display language, plus stable English ACL substrings.
+function isWindowsUserPathPermissionError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  const stderr =
+    'stderr' in error && typeof (error as { stderr?: unknown }).stderr === 'string'
+      ? (error as { stderr: string }).stderr
+      : ''
+  const haystack = `${error.message}\n${stderr}`
+  return (
+    haystack.includes('UnauthorizedAccessException') ||
+    haystack.includes('MethodInvocationException') ||
+    haystack.includes('Requested registry access is not allowed') ||
+    haystack.includes('Access is denied') ||
+    haystack.includes('Access to the registry key')
   )
 }
 

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -831,16 +831,16 @@ export class CliInstaller {
       return
     }
     const current = await this.userPathReader()
-    const nextEntries = splitPathEntries('win32', current).filter(
-      (entry) => !samePathEntry('win32', entry, pathDirectory)
-    )
+    const entries = splitPathEntries('win32', current)
+    const nextEntries = entries.filter((entry) => !samePathEntry('win32', entry, pathDirectory))
+    if (nextEntries.length === entries.length) {
+      return
+    }
     await this.writeWindowsUserPathEntry(nextEntries.join(';'), pathDirectory, 'remove')
   }
 
-  // Why: the raw `Command failed: powershell ...` rejection is dumped verbatim
-  // into the renderer toast (CliSection), so translate a denied user-PATH write
-  // into an actionable message naming the exact folder to add manually. The
-  // original error stays chained on `cause` so logs keep the diagnostic detail.
+  // Why: raw PowerShell errors reach the UI, so translate denied PATH writes
+  // while preserving the original diagnostic as the error cause.
   private async writeWindowsUserPathEntry(
     value: string,
     pathDirectory: string,
@@ -1064,11 +1064,8 @@ function isMissingError(error: unknown): boolean {
   )
 }
 
-// Why: Windows refuses user-environment writes (Group Policy / restricted HKCU
-// ACL / EDR-managed env) with a localized message that can arrive as mojibake,
-// so detection keys off the Latin PowerShell error envelope tokens
-// (FullyQualifiedErrorId, MethodInvocationException) that stay readable
-// regardless of the OS display language, plus stable English ACL substrings.
+// Why: localized permission errors retain these .NET/ACL markers even when
+// their human-readable PowerShell text is mojibake.
 function isWindowsUserPathPermissionError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false
@@ -1080,7 +1077,7 @@ function isWindowsUserPathPermissionError(error: unknown): boolean {
   const haystack = `${error.message}\n${stderr}`
   return (
     haystack.includes('UnauthorizedAccessException') ||
-    haystack.includes('MethodInvocationException') ||
+    haystack.includes('SecurityException') ||
     haystack.includes('Requested registry access is not allowed') ||
     haystack.includes('Access is denied') ||
     haystack.includes('Access to the registry key')


### PR DESCRIPTION
## Description

Fixes #6412. When Windows blocks Orca from updating the user PATH, CLI registration now shows actionable guidance instead of a raw PowerShell error. Permission detection covers `UnauthorizedAccessException`, `SecurityException`, and concrete registry access-denied markers while preserving the original error as `cause`.

Removal also skips the PATH write when the Orca entry is already absent.

## Evidence

- Rebased onto current `origin/main` at `2b7c36474d`.
- Focused CLI installer tests: 36/36 passed.
- Changed-file `oxlint`: clean.
- `pnpm run tc:node`: passed.
- Two adversarial review rounds completed. Round 1 fixed localized `SecurityException` handling and the no-op removal write; both independent round-2 reviewers returned clean.
- Performance check: the failure path adds bounded string checks and successful removal can now avoid a PowerShell process; no polling, retained state, or hot-path work was added.
- Behavior is Windows-only. macOS/Linux, SSH/remote execution, and git-provider behavior are unchanged.

## ELI5

If Windows refuses to let Orca add its CLI folder to PATH, Orca now explains what happened and tells the user which folder to add manually instead of showing an unreadable PowerShell command failure.

## Trade-offs

No end-user regressions. A genuinely blocked PATH update still fails, but the failure is clear and actionable. Non-permission errors continue to propagate unchanged.