### PR TITLE
fix: workspace name uses selected branch, not partial search text (#6208)

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -42,6 +42,7 @@ import type {
 } from '../../../shared/types'
 import SparseCheckoutPresetSelect from '@/components/sparse/SparseCheckoutPresetSelect'
 import SmartWorkspaceNameField, {
+  type SmartWorkspaceBranchSelectionContext,
   type SmartWorkspaceNameSelection
 } from '@/components/new-workspace/SmartWorkspaceNameField'
 import ProjectCombobox from '@/components/new-workspace/ProjectCombobox'
@@ -89,7 +90,11 @@ type NewWorkspaceComposerCardProps = {
   onNameValueChange: (value: string) => void
   onSmartGitHubItemSelect: (item: GitHubWorkItem) => void
   onSmartGitLabItemSelect: (item: GitLabWorkItem) => void
-  onSmartBranchSelect: (refName: string, localBranchName: string) => void
+  onSmartBranchSelect: (
+    refName: string,
+    localBranchName: string,
+    context?: SmartWorkspaceBranchSelectionContext
+  ) => void
   onSmartLinearIssueSelect: (issue: LinearIssue) => void
   smartNameSelection: SmartWorkspaceNameSelection | null
   onClearSmartNameSelection: () => void

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -96,7 +96,11 @@ type SmartWorkspaceNameFieldProps = {
   /** Optional so callers that pre-date GitLab support don't need to wire
    *  it. When omitted, GitLab paste-URL detection is silently skipped. */
   onGitLabItemSelect?: (item: GitLabWorkItem) => void
-  onBranchSelect: (refName: string, localBranchName: string) => void
+  onBranchSelect: (
+    refName: string,
+    localBranchName: string,
+    context?: SmartWorkspaceBranchSelectionContext
+  ) => void
   onLinearIssueSelect: (issue: LinearIssue) => void
   selectedSource: SmartWorkspaceNameSelection | null
   onClearSelectedSource: () => void
@@ -118,6 +122,10 @@ export type SmartWorkspaceNameSelection = {
   kind: 'github-pr' | 'github-issue' | 'gitlab-mr' | 'gitlab-issue' | 'branch' | 'linear' | 'jira'
   label: string
   url?: string
+}
+
+export type SmartWorkspaceBranchSelectionContext = {
+  branchSearchQuery?: string
 }
 
 const SEARCH_DEBOUNCE_MS = 200
@@ -1135,13 +1143,23 @@ export default function SmartWorkspaceNameField({
         // no-op for hosts that haven't wired GitLab support yet.
         onGitLabItemSelect?.(row.item)
       } else if (row.kind === 'branch') {
-        onBranchSelect(row.refName, row.localBranchName)
+        onBranchSelect(row.refName, row.localBranchName, {
+          branchSearchQuery: mode === 'branches' ? branchResultsSource?.query : undefined
+        })
       } else {
         onLinearIssueSelect(row.issue)
       }
       setOpen(false)
     },
-    [onBranchSelect, onGitHubItemSelect, onGitLabItemSelect, onLinearIssueSelect, onValueChange]
+    [
+      branchResultsSource?.query,
+      mode,
+      onBranchSelect,
+      onGitHubItemSelect,
+      onGitLabItemSelect,
+      onLinearIssueSelect,
+      onValueChange
+    ]
   )
 
   const acceptGitHubLink = useCallback(

--- a/src/renderer/src/hooks/composer-branch-selection.test.ts
+++ b/src/renderer/src/hooks/composer-branch-selection.test.ts
@@ -57,6 +57,78 @@ describe('resolveComposerBranchSelection', () => {
     })
   })
 
+  it('replaces a typed substring (non-prefix) with the selected branch name', () => {
+    // Why (#6208): branch search is a substring match, so typing `bug` surfaces
+    // `fix/bug-0`; selecting it must overwrite the throwaway search text.
+    expect(
+      resolveComposerBranchSelection({
+        refName: 'fix/bug-0',
+        localBranchName: 'fix/bug-0',
+        currentName: 'bug',
+        lastAutoName: ''
+      })
+    ).toEqual({
+      baseBranch: 'fix/bug-0',
+      branchNameOverride: 'fix/bug-0',
+      branchAutoName: 'fix/bug-0',
+      name: 'fix/bug-0',
+      lastAutoName: 'fix/bug-0'
+    })
+  })
+
+  it('replaces a typed mid-ref substring with the selected branch name', () => {
+    expect(
+      resolveComposerBranchSelection({
+        refName: 'feature/oauth-login',
+        localBranchName: 'feature/oauth-login',
+        currentName: 'auth',
+        lastAutoName: ''
+      })
+    ).toEqual({
+      baseBranch: 'feature/oauth-login',
+      branchNameOverride: 'feature/oauth-login',
+      branchAutoName: 'feature/oauth-login',
+      name: 'feature/oauth-login',
+      lastAutoName: 'feature/oauth-login'
+    })
+  })
+
+  it('replaces a case-mismatched typed substring with the selected branch name', () => {
+    // Why (#6208): git for-each-ref globs are case-insensitive on the typed
+    // query, so an uppercase `FIX` must still be treated as throwaway text.
+    expect(
+      resolveComposerBranchSelection({
+        refName: 'fix/bug-0',
+        localBranchName: 'fix/bug-0',
+        currentName: 'FIX',
+        lastAutoName: ''
+      })
+    ).toEqual({
+      baseBranch: 'fix/bug-0',
+      branchNameOverride: 'fix/bug-0',
+      branchAutoName: 'fix/bug-0',
+      name: 'fix/bug-0',
+      lastAutoName: 'fix/bug-0'
+    })
+  })
+
+  it('does not override a custom name that is not contained in the selected branch', () => {
+    // Why: a typed name absent from the picked ref (and not the prior auto-name)
+    // is a genuine user choice, so it must be preserved.
+    expect(
+      resolveComposerBranchSelection({
+        refName: 'feature/x',
+        localBranchName: 'feature/x',
+        currentName: 'my-cool-name',
+        lastAutoName: 'previous-auto'
+      })
+    ).toMatchObject({
+      baseBranch: 'feature/x',
+      branchNameOverride: undefined,
+      name: undefined
+    })
+  })
+
   it('keeps resolver-provided PR branch overrides when the workspace name changes', () => {
     expect(
       resolveComposerBranchNameOverrideForCreate({

--- a/src/renderer/src/hooks/composer-branch-selection.test.ts
+++ b/src/renderer/src/hooks/composer-branch-selection.test.ts
@@ -58,14 +58,15 @@ describe('resolveComposerBranchSelection', () => {
   })
 
   it('replaces a typed substring (non-prefix) with the selected branch name', () => {
-    // Why (#6208): branch search is a substring match, so typing `bug` surfaces
-    // `fix/bug-0`; selecting it must overwrite the throwaway search text.
+    // Why (#6208): Branch-tab search is a substring match, so typing `bug`
+    // surfaces `fix/bug-0`; selecting it must overwrite the search text.
     expect(
       resolveComposerBranchSelection({
         refName: 'fix/bug-0',
         localBranchName: 'fix/bug-0',
         currentName: 'bug',
-        lastAutoName: ''
+        lastAutoName: '',
+        branchSearchQuery: 'bug'
       })
     ).toEqual({
       baseBranch: 'fix/bug-0',
@@ -82,7 +83,8 @@ describe('resolveComposerBranchSelection', () => {
         refName: 'feature/oauth-login',
         localBranchName: 'feature/oauth-login',
         currentName: 'auth',
-        lastAutoName: ''
+        lastAutoName: '',
+        branchSearchQuery: 'auth'
       })
     ).toEqual({
       baseBranch: 'feature/oauth-login',
@@ -101,7 +103,8 @@ describe('resolveComposerBranchSelection', () => {
         refName: 'fix/bug-0',
         localBranchName: 'fix/bug-0',
         currentName: 'FIX',
-        lastAutoName: ''
+        lastAutoName: '',
+        branchSearchQuery: 'FIX'
       })
     ).toEqual({
       baseBranch: 'fix/bug-0',
@@ -109,6 +112,39 @@ describe('resolveComposerBranchSelection', () => {
       branchAutoName: 'fix/bug-0',
       name: 'fix/bug-0',
       lastAutoName: 'fix/bug-0'
+    })
+  })
+
+  it('does not override a substring custom name without a branch search query', () => {
+    // Why: in Smart/Text modes, a substring can be the user's intended
+    // workspace name rather than throwaway Branch-tab search text.
+    expect(
+      resolveComposerBranchSelection({
+        refName: 'feature/oauth-login',
+        localBranchName: 'feature/oauth-login',
+        currentName: 'login',
+        lastAutoName: ''
+      })
+    ).toMatchObject({
+      baseBranch: 'feature/oauth-login',
+      branchNameOverride: undefined,
+      name: undefined
+    })
+  })
+
+  it('does not use a stale branch search query to override the current name', () => {
+    expect(
+      resolveComposerBranchSelection({
+        refName: 'feature/oauth-login',
+        localBranchName: 'feature/oauth-login',
+        currentName: 'login',
+        lastAutoName: '',
+        branchSearchQuery: 'auth'
+      })
+    ).toMatchObject({
+      baseBranch: 'feature/oauth-login',
+      branchNameOverride: undefined,
+      name: undefined
     })
   })
 

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -137,7 +137,10 @@ import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overr
 import { queueNewWorkspaceTerminalFocus } from '@/lib/new-workspace-terminal-focus'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
 import { getSuggestedCreatureName } from '@/components/sidebar/worktree-name-suggestions'
-import type { SmartWorkspaceNameSelection } from '@/components/new-workspace/SmartWorkspaceNameField'
+import type {
+  SmartWorkspaceBranchSelectionContext,
+  SmartWorkspaceNameSelection
+} from '@/components/new-workspace/SmartWorkspaceNameField'
 import { getForkPushWarning } from './fork-push-warning'
 import { CONTEXTUAL_TOUR_ENABLE_AUTO_WORKSPACE_NAME_EVENT } from '@/components/contextual-tours/contextual-tour-composer-events'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
@@ -249,7 +252,11 @@ export type ComposerCardProps = {
   onNameValueChange: (value: string) => void
   onSmartGitHubItemSelect: (item: GitHubWorkItem) => void
   onSmartGitLabItemSelect: (item: GitLabWorkItem) => void
-  onSmartBranchSelect: (refName: string, localBranchName: string) => void
+  onSmartBranchSelect: (
+    refName: string,
+    localBranchName: string,
+    context?: SmartWorkspaceBranchSelectionContext
+  ) => void
   onSmartLinearIssueSelect: (issue: LinearIssue) => void
   smartNameGitHubSourceContext?: TaskSourceContext | null
   /** GitLab parallel of onBaseBranchPrSelect. */
@@ -2896,13 +2903,18 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   )
 
   const handleSmartBranchSelect = useCallback(
-    (refName: string, localBranchName: string): void => {
+    (
+      refName: string,
+      localBranchName: string,
+      context?: SmartWorkspaceBranchSelectionContext
+    ): void => {
       smartGitHubPrStartPointSelectionRef.current = null
       const selection = resolveComposerBranchSelection({
         refName,
         localBranchName,
         currentName: name,
-        lastAutoName: lastAutoNameRef.current
+        lastAutoName: lastAutoNameRef.current,
+        branchSearchQuery: context?.branchSearchQuery
       })
       setBaseBranch(selection.baseBranch)
       setCompareBaseRef(undefined)

--- a/src/shared/composer-branch-selection.ts
+++ b/src/shared/composer-branch-selection.ts
@@ -11,18 +11,25 @@ export function resolveComposerBranchSelection(args: {
   localBranchName: string
   currentName: string
   lastAutoName: string
+  branchSearchQuery?: string
 }): ComposerBranchSelection {
   const trimmedCurrentName = args.currentName.trim()
-  const needle = trimmedCurrentName.toLowerCase()
+  const currentNameNeedle = trimmedCurrentName.toLowerCase()
+  const localBranchName = args.localBranchName.toLowerCase()
+  const refName = args.refName.toLowerCase()
+  const branchSearchNeedle = (args.branchSearchQuery ?? '').trim().toLowerCase()
+  const selectedBranchMatchesSearchQuery =
+    branchSearchNeedle.length > 0 &&
+    branchSearchNeedle === currentNameNeedle &&
+    (localBranchName.includes(branchSearchNeedle) || refName.includes(branchSearchNeedle))
   const shouldAutoName =
     !trimmedCurrentName ||
     args.currentName === args.lastAutoName ||
-    // Why (#6208): the branch search is a substring match (git for-each-ref
-    // `*query*` globs), so a typed query like `bug` legitimately surfaces
-    // `fix/bug-0`. Treat any case-insensitive substring of the picked ref as
-    // throwaway search text to overwrite, not just a literal prefix.
-    args.localBranchName.toLowerCase().includes(needle) ||
-    args.refName.toLowerCase().includes(needle)
+    localBranchName.startsWith(currentNameNeedle) ||
+    refName.startsWith(currentNameNeedle) ||
+    // Why (#6208): substring-only replacement is safe when the Branch tab's
+    // actual search query produced this row. Smart/Text values can be names.
+    selectedBranchMatchesSearchQuery
   if (!shouldAutoName) {
     return {
       baseBranch: args.refName,

--- a/src/shared/composer-branch-selection.ts
+++ b/src/shared/composer-branch-selection.ts
@@ -13,11 +13,16 @@ export function resolveComposerBranchSelection(args: {
   lastAutoName: string
 }): ComposerBranchSelection {
   const trimmedCurrentName = args.currentName.trim()
+  const needle = trimmedCurrentName.toLowerCase()
   const shouldAutoName =
     !trimmedCurrentName ||
     args.currentName === args.lastAutoName ||
-    args.localBranchName.startsWith(trimmedCurrentName) ||
-    args.refName.startsWith(trimmedCurrentName)
+    // Why (#6208): the branch search is a substring match (git for-each-ref
+    // `*query*` globs), so a typed query like `bug` legitimately surfaces
+    // `fix/bug-0`. Treat any case-insensitive substring of the picked ref as
+    // throwaway search text to overwrite, not just a literal prefix.
+    args.localBranchName.toLowerCase().includes(needle) ||
+    args.refName.toLowerCase().includes(needle)
   if (!shouldAutoName) {
     return {
       baseBranch: args.refName,


### PR DESCRIPTION
## Description

Fixes #6208 by carrying the explicit Branch-tab search query into branch selection so a selected branch replaces partial search text without overwriting unrelated custom workspace names.

## Evidence of fix

**Before:** non-prefix Branch-tab searches such as `bug` → `fix/bug-0` could leave the workspace Name as the partial search text.

**After:** focused resolver coverage proves explicit Branch-tab substring queries adopt the full selected branch, while Smart/Name custom text that merely happens to be a substring is preserved. Targeted tests, lint, node/web typechecks, and GitHub checks pass.

## ELI5

Typing in the Branch tab is a search, not a final workspace name. Orca now remembers that context: choosing a result uses the full branch name, but ordinary custom names are still yours.

## User-facing trade-offs

- Substring auto-replacement is intentionally limited to the explicit Branch tab.
- Smart/Name mode favors preserving custom text when intent is ambiguous.
- This is renderer/shared selection logic only; local, SSH, GitHub, and GitLab ref handling are unchanged.

---

## Summary

Fixes #6208.

Branch search in the new-workspace composer uses substring matching, so searching `bug` can legitimately return `fix/bug-0`, and searching `auth` can return `feature/oauth-login`. The resolver that decides whether to replace the typed Name value was only doing prefix-style checks, so non-prefix matches could leave the field stuck on the partial search text instead of the selected branch.

This PR keeps the original bug fix and tightens the follow-up behavior:

- Branch-tab selections carry the actual branch search query into `resolveComposerBranchSelection`.
- Non-prefix substring replacement now fires only when that Branch-tab query produced the selected branch row.
- Empty-name, prior auto-name, and branch-prefix replacement behavior still work as before.
- Smart/Text-mode custom names that merely happen to be substrings of a selected branch are preserved instead of being overwritten.

## Tradeoffs / regressions

The listed caveat is eliminated. A custom workspace name such as `login` is no longer overwritten solely because the selected branch is `feature/oauth-login`.

The remaining ambiguity is handled conservatively: the Smart name field can mean either “this is my workspace name” or “search sources.” For substring-only branch matches, Orca now auto-replaces only in the explicit Branch tab, where the typed text is unambiguously a branch search query. That preserves custom names instead of guessing. This is provider-agnostic, cross-platform string/UI-state logic only; no GitHub-only behavior, SSH/local divergence, path handling, keyboard shortcuts, network calls, or disabled features.

## Screenshots

Non-visual behavior change in the composer branch-selection resolver and callback path. Regression coverage below captures the user-visible Name-field behavior.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/composer-branch-selection.test.ts` -> 1 file passed, 20 tests passed
- [x] `pnpm exec oxlint src/shared/composer-branch-selection.ts src/renderer/src/hooks/composer-branch-selection.test.ts src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx src/renderer/src/components/NewWorkspaceComposerCard.tsx src/renderer/src/hooks/useComposerState.ts` -> clean
- [x] `pnpm run typecheck:node` -> clean
- [x] `pnpm run typecheck:web` -> clean

Also rebased the PR branch onto current `origin/main` and resolved the `useComposerState.ts` conflict without dropping the PR-start-point reset added on main.

## AI Review Report

Reviewed adversarially for correctness and edge cases:

- Reported Branch-tab flow: a non-prefix query such as `bug` or `auth` now has event-driven context (`branchSearchQuery`) proving it was branch search text, so the selected branch name replaces the partial query.
- Prior prefix behavior still works without Branch-tab context because prefix matches remain auto-managed.
- Custom-name guard is stronger than the original follow-up: substring names are preserved unless the selected row came from the explicit Branch-tab query.
- Stale query guard: the resolver requires the Branch-tab query to match the current field value before using substring auto-name.
- Rebase conflict resolution kept the current-main `smartGitHubPrStartPointSelectionRef.current = null` reset when selecting a branch.

Cross-platform / provider / SSH check: this is renderer/shared string and UI-state logic over already-returned refs. It does not add path handling, shell execution, keyboard shortcuts, provider-specific APIs, network calls, or local-only assumptions.

## Security Audit

No new auth, IPC, filesystem, command execution, dependency, or network surface. The change only threads an optional branch-search query through existing renderer callbacks and narrows when the existing auto-name behavior may overwrite the Name field.

## Notes

The PR branch is rebased onto current `origin/main`. GitHub checks were pending after the latest push when this description was updated.

