### PR TITLE
fix: emit TUI mouse-wheel reports synchronously to stop scroll jitter (#6144)

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -146,6 +146,22 @@ describe('terminal mouse wheel multiplier', () => {
     expect(dispatch).toHaveBeenCalledTimes(2)
   })
 
+  it('reads the current TUI multiplier for each wheel event', () => {
+    const { terminal, getHandler, target, dispatch } = fakeTerminal(terminalElement())
+    let multiplier = 1
+    attachTerminalMouseWheelMultiplier(terminal, {
+      getTuiMouseWheelMultiplier: () => multiplier
+    })
+    const handler = getHandler()
+
+    expect(handler(discreteWheelEventOn(target))).toBe(true)
+    expect(dispatch).not.toHaveBeenCalled()
+
+    multiplier = 4
+    expect(handler(discreteWheelEventOn(target))).toBe(true)
+    expect(dispatch).toHaveBeenCalledTimes(3)
+  })
+
   it('marks replayed clones so they do not re-trigger multiplication', () => {
     const { terminal, getHandler, target, dispatch } = fakeTerminal(terminalElement())
     attachTerminalMouseWheelMultiplier(terminal, {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+import type { Terminal } from '@xterm/xterm'
+import { describe, expect, it, vi } from 'vitest'
 import {
   TERMINAL_TUI_MOUSE_WHEEL_MULTIPLIER,
+  attachTerminalMouseWheelMultiplier,
   normalizeTerminalTuiMouseWheelMultiplier,
   shouldMultiplyTerminalMouseWheel
 } from './pane-terminal-mouse-wheel'
 
 const DOM_DELTA_PIXEL = 0
 const DOM_DELTA_LINE = 1
+const REPLAYED_WHEEL_EVENT_PROPERTY = '__orcaReplayedTerminalWheelEvent'
 
 function terminalElement(mouseReporting = true): HTMLElement {
   return {
@@ -22,6 +26,54 @@ function wheelEvent(init: Partial<WheelEventInit> = {}): WheelEvent {
     deltaMode: DOM_DELTA_PIXEL,
     ...init
   } as WheelEvent
+}
+
+type WheelHandler = (event: WheelEvent) => boolean
+
+/**
+ * Records the handler xterm would invoke and a spied dispatch target so the
+ * synchronous replay behavior of attachTerminalMouseWheelMultiplier can be
+ * asserted without a real xterm/DOM.
+ */
+function fakeTerminal(element: HTMLElement | null): {
+  terminal: Pick<Terminal, 'attachCustomWheelEventHandler' | 'element'>
+  getHandler: () => WheelHandler
+  target: EventTarget
+  dispatch: ReturnType<typeof vi.fn>
+} {
+  let handler: WheelHandler | undefined
+  // Real EventTarget instance so the handler's `currentTarget instanceof
+  // EventTarget` guard passes, but with dispatchEvent stubbed so we count the
+  // synchronous replay dispatches directly instead of recursing into the DOM.
+  const target = new EventTarget()
+  const dispatch = vi.fn<(event: Event) => boolean>(() => true)
+  target.dispatchEvent = dispatch
+  const terminal = {
+    element,
+    attachCustomWheelEventHandler: (next: WheelHandler) => {
+      handler = next
+    }
+  } as unknown as Pick<Terminal, 'attachCustomWheelEventHandler' | 'element'>
+  return {
+    terminal,
+    getHandler: () => {
+      if (!handler) {
+        throw new Error('handler was not attached')
+      }
+      return handler
+    },
+    target,
+    dispatch
+  }
+}
+
+function discreteWheelEventOn(target: EventTarget): WheelEvent {
+  return {
+    type: 'wheel',
+    deltaY: 1,
+    deltaMode: DOM_DELTA_LINE,
+    currentTarget: target
+  } as unknown as WheelEvent
 }
 
 describe('terminal mouse wheel multiplier', () => {
@@ -77,5 +129,48 @@ describe('terminal mouse wheel multiplier', () => {
         terminalElement()
       )
     ).toBe(false)
+  })
+
+  it('dispatches the extra reports synchronously to stay frame-aligned', () => {
+    const { terminal, getHandler, target, dispatch } = fakeTerminal(terminalElement())
+    attachTerminalMouseWheelMultiplier(terminal, {
+      getTuiMouseWheelMultiplier: () => 3
+    })
+
+    const result = getHandler()(discreteWheelEventOn(target))
+
+    // Assert immediately after the handler returns (no microtask flush): the
+    // multiplier - 1 clones must already be present, proving the dispatch is
+    // synchronous and no longer deferred into a queueMicrotask.
+    expect(result).toBe(true)
+    expect(dispatch).toHaveBeenCalledTimes(2)
+  })
+
+  it('marks replayed clones so they do not re-trigger multiplication', () => {
+    const { terminal, getHandler, target, dispatch } = fakeTerminal(terminalElement())
+    attachTerminalMouseWheelMultiplier(terminal, {
+      getTuiMouseWheelMultiplier: () => 3
+    })
+
+    getHandler()(discreteWheelEventOn(target))
+
+    for (const [clone] of dispatch.mock.calls as [WheelEvent][]) {
+      expect(
+        (clone as WheelEvent & { [REPLAYED_WHEEL_EVENT_PROPERTY]?: boolean })[
+          REPLAYED_WHEEL_EVENT_PROPERTY
+        ]
+      ).toBe(true)
+      expect(shouldMultiplyTerminalMouseWheel(clone, terminalElement())).toBe(false)
+    }
+  })
+
+  it('does not multiply when mouse reporting is inactive', () => {
+    const { terminal, getHandler, target, dispatch } = fakeTerminal(terminalElement(false))
+    attachTerminalMouseWheelMultiplier(terminal, {
+      getTuiMouseWheelMultiplier: () => 3
+    })
+
+    expect(getHandler()(discreteWheelEventOn(target))).toBe(true)
+    expect(dispatch).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
@@ -110,14 +110,17 @@ export function attachTerminalMouseWheelMultiplier(
 
     // Why: mouse-reporting TUIs receive wheel input as reports, not viewport
     // scrollback, so normal xterm scrollSensitivity cannot tune their speed.
-    queueMicrotask(() => {
-      const multiplier = normalizeTerminalTuiMouseWheelMultiplier(
-        options.getTuiMouseWheelMultiplier?.()
-      )
-      for (let i = 1; i < multiplier; i++) {
-        target.dispatchEvent(cloneWheelEvent(event))
-      }
-    })
+    // Dispatch the extra reports synchronously inside this handler (not via a
+    // deferred microtask) so every report for one notch stays tied to the same
+    // input event and animation frame; deferring them caused per-report jitter
+    // because the TUI redrew on each frame-misaligned report instead of as one
+    // coalesced burst.
+    const multiplier = normalizeTerminalTuiMouseWheelMultiplier(
+      options.getTuiMouseWheelMultiplier?.()
+    )
+    for (let i = 1; i < multiplier; i++) {
+      target.dispatchEvent(cloneWheelEvent(event))
+    }
 
     return true
   })


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).** When you use a full-screen text app inside Orca's terminal — most commonly Claude Code's full-screen view — and scroll with a mouse wheel, the scrolling looks jittery and laggy on macOS. One flick of the wheel doesn't glide smoothly; it judders in little broken steps. Other command-line tools in Orca scroll fine, so it stands out as a Claude-Code-feels-broken annoyance. It's not a crash or data loss — it's a "this feels janky and cheap" papercut that any mouse-wheel user on these full-screen apps runs into.

**2) What this PR does (ELI5).** To make wheel scrolling feel right, Orca turns each physical wheel "click" into three scroll signals. The bug was a timing problem: Orca sent the first signal immediately but quietly deferred the other two to be delivered a beat later, after the screen had already started redrawing. So the app repainted three separate times for one wheel click — that's the stutter. This PR sends all three signals together, in the same instant, as one tight burst. Oh, so it now delivers all the scroll signals for one wheel notch at once (so the app repaints once, smoothly) instead of dribbling them out late (so the app repainted three jerky times).

**3) Tradeoffs / regressions — honest answer.** No regressions — nothing is disabled, no new setup, no behavior is lost. The number of scroll signals per wheel notch is unchanged (still 3, still controlled by the existing "TUI Scroll Speed" setting), and the "send them together" loop is the same loop that already existed — it just no longer waits. The replay-guard that prevented these synthetic events from looping forever is unchanged, so there's no new recursion risk. Non-full-screen scrollback and trackpad pixel scrolling were never touched by this code path and still behave one-to-one. The fix is most visible on macOS (that's where the jitter showed up due to how its wheel events are paced), but it's neutral, not worse, everywhere else.

---

## Summary

Fixes #6144

Fullscreen-TUI mouse-wheel scroll (e.g. Claude Code `/tui fullscreen`) was jittery/laggy on macOS: each physical wheel notch rendered as a multi-step stutter rather than one smooth ~3-line scroll.

Root cause is in `attachTerminalMouseWheelMultiplier`. When a TUI has mouse reporting on (the terminal element carries the `enable-mouse-events` class), each physical notch produced one mouse-wheel report **synchronously** (xterm encodes + writes to the PTY for the original event), while the extra `multiplier - 1` reports were dispatched later inside a `queueMicrotask`. That deferral decoupled the extra reports from the original input event and from the render frame, so the TUI redrew per frame-misaligned report instead of coalescing the notch into a single repaint — the visible jitter.

The fix dispatches the cloned wheel events **synchronously** inside the same handler invocation, before returning `true`. Every report for one notch now stays tied to the same input event and animation frame, so xterm batches them into one repaint and the PTY receives the burst contiguously. The replayed-event guard (`REPLAYED_WHEEL_EVENT_PROPERTY` + the `isReplayedWheelEvent` short-circuit in `shouldMultiplyTerminalMouseWheel`) already prevents re-entry for the synchronous clones, so no recursion risk is introduced. The 3x report count is intended and unchanged — only the timing (the defect) is fixed.

## Screenshots

No new visual UI; the change is a frame-timing fix to existing scroll behavior. The symptom is a temporal jitter artifact that static screenshots cannot capture. See the PR comment for test evidence and an explanation of why an Electron screen-recording repro was infeasible in the validation environment.

## Testing

- [x] `pnpm lint` (oxlint, scoped to changed files — clean)
- [x] `pnpm typecheck` (tsgo `-p config/tsconfig.tc.web.json` — clean)
- [x] `pnpm test` (`vitest run pane-terminal-mouse-wheel` — 11 passed)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Added behavioral tests for `attachTerminalMouseWheelMultiplier`: assert that for a discrete wheel event with `multiplier = 3` exactly 2 clones are dispatched **synchronously** (count read immediately after the handler returns, with no microtask flush), that clones are marked replayed and do not re-trigger multiplication, that the handler returns `true`, and that the current `terminalTuiScrollSensitivity` value is read for each wheel event so `1x` emits no extra reports while higher values still emit the expected synchronous burst. Verified the synchronous-dispatch test **fails** against the old `queueMicrotask` version (0 synchronous dispatches) and passes after the fix.

## AI Review Report

Reviewed the diff adversarially for correctness, re-entrancy, cross-platform behavior, and security.

- **Re-entrancy:** synchronous `target.dispatchEvent(clone)` re-enters xterm's custom wheel handler synchronously; each clone is marked replayed so `shouldMultiplyTerminalMouseWheel` returns `false` and the handler returns `true` without re-dispatching. No infinite recursion — same guard the microtask version relied on.
- **Cross-platform:** behavior is identical on macOS, Linux, and Windows. No `metaKey`/`ctrlKey` branching and no path handling are involved; macOS is just where the jitter was most visible due to its wheel-event cadence. The Electron-specific code path (xterm DOM in the renderer) is unchanged in structure.
- **No regression to other scroll modes:** non-mouse-reporting scrollback and trackpad pixel scrolling remain one-to-one — they are gated earlier by `shouldMultiplyTerminalMouseWheel` (`enable-mouse-events` class + `isDiscreteWheelEvent`), which this change does not touch. Covered by existing tests.

## Security Audit

No security-relevant surface touched. No input parsing, command execution, path handling, auth, secrets, IPC, or dependency changes. The change only removes a `queueMicrotask` wrapper around an existing in-renderer `dispatchEvent` loop over locally constructed wheel events. PTY writes flow through xterm's normal data-event path regardless of transport, so there is no SSH/remote concern. No GitLab/provider relevance. No follow-up needed.

## Notes

- SSH/remote: unaffected — this runs in the renderer against the local xterm DOM; the resulting reports flow to the PTY through the normal data event regardless of transport.
- The "TUI Scroll Speed" setting (`terminalTuiScrollSensitivity`, default 3) still controls lines-per-notch; only the report timing changed.
- Future suggestion (not in this diff): if any residual stutter is ever observed under extreme input rates, coalesce multiple physical notches per frame via a single `requestAnimationFrame` that accumulates a pending report count. The minimal synchronous change is preferred here because it directly removes the microtask decoupling that caused the defect.

Made with [Orca](https://github.com/stablyai/orca) 🐋
