### PR TITLE
fix(terminal): linkify bare filenames nested in the worktree (#5024)

### DIFF
--- a/src/main/ipc/filesystem-basename-process-runner.ts
+++ b/src/main/ipc/filesystem-basename-process-runner.ts
@@ -1,0 +1,162 @@
+import type { ChildProcess } from 'child_process'
+import { createUniqueQuickOpenBasenameCollector } from '../../shared/quick-open-unique-basename'
+
+export type BasenameProcessPassConfig = {
+  delimiter: '\0' | '\n'
+  spawnPass: (args: string[]) => ChildProcess
+  passArgs: string[][]
+  parsePath: (rawPath: string) => string | null
+  timeoutMs: number
+  acceptsExit: (code: number | null, parseablePathCount: number) => boolean
+}
+
+export function resolveBasenameFromProcessPasses(
+  basename: string,
+  excludePathPrefixes: readonly string[],
+  config: BasenameProcessPassConfig
+): Promise<string | null> {
+  return new Promise((resolve, reject) => {
+    const collector = createUniqueQuickOpenBasenameCollector(basename, excludePathPrefixes)
+    const children: ChildProcess[] = []
+    const cleanups: (() => void)[] = []
+    let settled = false
+    let completedPasses = 0
+
+    const finish = (result: string | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      for (const cleanup of cleanups) {
+        cleanup()
+      }
+      for (const child of children) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill()
+        }
+      }
+      resolve(result)
+    }
+
+    const fail = (error: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      for (const cleanup of cleanups) {
+        cleanup()
+      }
+      for (const child of children) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill()
+        }
+      }
+      reject(error)
+    }
+
+    for (const args of config.passArgs) {
+      const child = config.spawnPass(args)
+      children.push(child)
+      let buffer = ''
+      let done = false
+      let parseablePathCount = 0
+      let timer: ReturnType<typeof setTimeout> | null = null
+
+      const cleanup = (): void => {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        child.stdout?.off('data', handleStdoutData)
+        child.stderr?.off('data', handleStderrData)
+        child.off('error', handleError)
+        child.off('close', handleClose)
+      }
+      cleanups.push(cleanup)
+
+      const resolvePass = (): void => {
+        if (done || settled) {
+          return
+        }
+        done = true
+        cleanup()
+        completedPasses += 1
+        if (completedPasses === config.passArgs.length) {
+          finish(collector.result())
+        }
+      }
+
+      const rejectPass = (error: Error): void => {
+        if (done || settled) {
+          return
+        }
+        done = true
+        cleanup()
+        fail(error)
+      }
+
+      const processPath = (rawPath: string): void => {
+        const relativePath = config.parsePath(rawPath)
+        if (relativePath === null) {
+          return
+        }
+        parseablePathCount += 1
+        if (collector.add(relativePath)) {
+          finish(null)
+        }
+      }
+
+      function handleStdoutData(chunk: string): void {
+        buffer += chunk
+        let start = 0
+        let index = buffer.indexOf(config.delimiter, start)
+        while (index !== -1) {
+          processPath(buffer.substring(start, index))
+          if (settled) {
+            return
+          }
+          start = index + 1
+          index = buffer.indexOf(config.delimiter, start)
+        }
+        buffer = start < buffer.length ? buffer.substring(start) : ''
+      }
+
+      function handleStderrData(): void {
+        /* drain */
+      }
+
+      function handleError(error: Error): void {
+        rejectPass(error)
+      }
+
+      function handleClose(code: number | null, signal: NodeJS.Signals | null): void {
+        if (signal) {
+          rejectPass(new Error(`basename scan killed by ${signal}`))
+          return
+        }
+        if (buffer) {
+          processPath(buffer)
+        }
+        if (settled) {
+          return
+        }
+        if (config.acceptsExit(code, parseablePathCount)) {
+          resolvePass()
+        } else {
+          rejectPass(new Error(`basename scan exited with code ${code}`))
+        }
+      }
+
+      child.stdout?.setEncoding('utf-8')
+      child.stdout?.on('data', handleStdoutData)
+      child.stderr?.on('data', handleStderrData)
+      child.once('error', handleError)
+      child.once('close', handleClose)
+      timer = setTimeout(() => {
+        buffer = ''
+        child.kill()
+        rejectPass(new Error('basename scan timed out'))
+      }, config.timeoutMs)
+    }
+  })
+}

--- a/src/main/ipc/filesystem-basename-resolution.test.ts
+++ b/src/main/ipc/filesystem-basename-resolution.test.ts
@@ -1,0 +1,106 @@
+import { EventEmitter } from 'events'
+import type { ChildProcess } from 'child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  gitExecFileAsyncMock,
+  gitSpawnMock,
+  wslAwareSpawnMock,
+  resolveAuthorizedPathMock,
+  checkRgAvailableMock,
+  getLocalGitOptionsForRegisteredWorktreeMock
+} = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  gitSpawnMock: vi.fn(),
+  wslAwareSpawnMock: vi.fn(),
+  resolveAuthorizedPathMock: vi.fn(),
+  checkRgAvailableMock: vi.fn(),
+  getLocalGitOptionsForRegisteredWorktreeMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitSpawn: gitSpawnMock,
+  wslAwareSpawn: wslAwareSpawnMock
+}))
+
+vi.mock('../wsl', () => ({
+  parseWslPath: vi.fn(() => null),
+  toWindowsWslPath: vi.fn((value: string) => value)
+}))
+
+vi.mock('./filesystem-auth', () => ({
+  resolveAuthorizedPath: resolveAuthorizedPathMock
+}))
+
+vi.mock('./local-worktree-runtime-options', () => ({
+  getLocalGitOptionsForRegisteredWorktree: getLocalGitOptionsForRegisteredWorktreeMock
+}))
+
+vi.mock('./rg-availability', () => ({
+  checkRgAvailable: checkRgAvailableMock
+}))
+
+import { resolveQuickOpenFileByBasename } from './filesystem-basename-resolution'
+import type { Store } from '../persistence'
+
+function createMockProcess(): ChildProcess {
+  const process = new EventEmitter() as unknown as ChildProcess
+  ;(process as unknown as Record<string, unknown>).stdout = new EventEmitter()
+  ;(
+    (process as unknown as Record<string, unknown>).stdout as EventEmitter & {
+      setEncoding: () => void
+    }
+  ).setEncoding = vi.fn()
+  ;(process as unknown as Record<string, unknown>).stderr = new EventEmitter()
+  ;(process as unknown as Record<string, unknown>).kill = vi.fn()
+  ;(process as unknown as Record<string, unknown>).exitCode = null
+  ;(process as unknown as Record<string, unknown>).signalCode = null
+  return process
+}
+
+describe('filesystem basename resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveAuthorizedPathMock.mockImplementation(async (pathValue) => pathValue)
+    getLocalGitOptionsForRegisteredWorktreeMock.mockReturnValue({})
+    checkRgAvailableMock.mockResolvedValue(true)
+  })
+
+  it('uses a targeted git basename pathspec inside git worktrees', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'true\n', stderr: '' })
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    gitSpawnMock.mockImplementationOnce(() => primary).mockImplementationOnce(() => ignored)
+
+    const promise = resolveQuickOpenFileByBasename('/repo', 'Foo.ts', {} as Store)
+
+    setTimeout(() => {
+      ;(primary.stdout as unknown as EventEmitter).emit('data', 'src/Foo.ts\0')
+      primary.emit('close', 0, null)
+      ignored.emit('close', 0, null)
+    }, 10)
+
+    await expect(promise).resolves.toBe('src/Foo.ts')
+    expect(gitSpawnMock.mock.calls[0][0]).toContain(':(glob)**/Foo.ts')
+    expect(wslAwareSpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('uses an rg basename include glob outside git worktrees', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(new Error('not git'))
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    wslAwareSpawnMock.mockImplementationOnce(() => primary).mockImplementationOnce(() => ignored)
+
+    const promise = resolveQuickOpenFileByBasename('/repo', 'Foo.ts', {} as Store)
+
+    setTimeout(() => {
+      ;(primary.stdout as unknown as EventEmitter).emit('data', './src/Foo.ts\n')
+      primary.emit('close', 0, null)
+      ignored.emit('close', 0, null)
+    }, 10)
+
+    await expect(promise).resolves.toBe('src/Foo.ts')
+    expect(wslAwareSpawnMock.mock.calls[0][1]).toContain('**/Foo.ts')
+  })
+})

--- a/src/main/ipc/filesystem-basename-resolution.ts
+++ b/src/main/ipc/filesystem-basename-resolution.ts
@@ -1,0 +1,172 @@
+import { sep } from 'path'
+import type { Store } from '../persistence'
+import { gitExecFileAsync, gitSpawn, wslAwareSpawn } from '../git/runner'
+import { parseWslPath, toWindowsWslPath } from '../wsl'
+import { getLocalGitOptionsForRegisteredWorktree } from './local-worktree-runtime-options'
+import { resolveAuthorizedPath } from './filesystem-auth'
+import { checkRgAvailable } from './rg-availability'
+import {
+  buildExcludePathPrefixes,
+  buildGitLsFilesArgsForQuickOpen,
+  buildRgArgsForQuickOpen,
+  normalizeQuickOpenRgLine,
+  type RgOutputMode
+} from '../../shared/quick-open-filter'
+import { buildQuickOpenBasenameGlob } from '../../shared/quick-open-unique-basename'
+import { resolveBasenameFromProcessPasses } from './filesystem-basename-process-runner'
+
+const BASENAME_RESOLUTION_TIMEOUT_MS = 10_000
+
+type LocalGitOptions = { wslDistro?: string }
+
+function getQuickOpenRgOutputMode(
+  rawLine: string,
+  translatedLine: string,
+  rootPath: string
+): RgOutputMode {
+  if (
+    translatedLine !== rawLine ||
+    rawLine.startsWith('/') ||
+    /^[A-Za-z]:[\\/]/.test(rawLine) ||
+    rawLine.startsWith('\\\\')
+  ) {
+    return { kind: 'absolute', rootPath }
+  }
+  return { kind: 'cwd-relative' }
+}
+
+async function isInsideGitWorktree(
+  rootPath: string,
+  localGitOptions: LocalGitOptions
+): Promise<boolean> {
+  try {
+    const result = await gitExecFileAsync(['rev-parse', '--is-inside-work-tree'], {
+      cwd: rootPath,
+      timeout: 5_000,
+      ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
+    })
+    return result.stdout.trim() === 'true'
+  } catch {
+    return false
+  }
+}
+
+function resolveWithGit(
+  rootPath: string,
+  basename: string,
+  basenameGlob: string,
+  excludePathPrefixes: readonly string[],
+  localGitOptions: LocalGitOptions
+): Promise<string | null> {
+  const { primary, ignoredPass } = buildGitLsFilesArgsForQuickOpen(excludePathPrefixes, [
+    `:(glob)${basenameGlob}`
+  ])
+  return resolveBasenameFromProcessPasses(basename, excludePathPrefixes, {
+    delimiter: '\0',
+    passArgs: [primary, ignoredPass],
+    timeoutMs: BASENAME_RESOLUTION_TIMEOUT_MS,
+    spawnPass: (args) =>
+      gitSpawn(args, {
+        cwd: rootPath,
+        ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
+        stdio: ['ignore', 'pipe', 'pipe']
+      }),
+    parsePath: (rawPath) => rawPath,
+    // Why: this mirrors Quick Open's git fallback tolerance; non-git roots can
+    // produce a fatal code, which should behave like "no unique file" here.
+    acceptsExit: () => true
+  })
+}
+
+function resolveWithRg(
+  rootPath: string,
+  basename: string,
+  basenameGlob: string,
+  excludePathPrefixes: readonly string[],
+  localGitOptions: LocalGitOptions
+): Promise<string | null> {
+  const wslDistroForOutput = parseWslPath(rootPath)?.distro ?? localGitOptions.wslDistro
+  const { primary, ignoredPass } = buildRgArgsForQuickOpen({
+    searchRoot: '.',
+    includeGlobs: [basenameGlob],
+    excludePathPrefixes,
+    forceSlashSeparator: sep === '\\'
+  })
+
+  return resolveBasenameFromProcessPasses(basename, excludePathPrefixes, {
+    delimiter: '\n',
+    passArgs: [primary, ignoredPass],
+    timeoutMs: BASENAME_RESOLUTION_TIMEOUT_MS,
+    spawnPass: (args) =>
+      wslAwareSpawn('rg', args, {
+        cwd: rootPath,
+        ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
+        stdio: ['ignore', 'pipe', 'pipe']
+      }),
+    parsePath: (rawPath) => {
+      const translated =
+        wslDistroForOutput && rawPath.startsWith('/')
+          ? toWindowsWslPath(rawPath, wslDistroForOutput)
+          : rawPath
+      return normalizeQuickOpenRgLine(
+        translated,
+        getQuickOpenRgOutputMode(rawPath, translated, rootPath)
+      )
+    },
+    acceptsExit: (code, parseablePathCount) =>
+      code === 0 || code === 1 || (code === 2 && parseablePathCount > 0)
+  })
+}
+
+export async function resolveQuickOpenFileByBasename(
+  rootPath: string,
+  basename: string,
+  store: Store,
+  excludePaths?: string[]
+): Promise<string | null> {
+  const basenameGlob = buildQuickOpenBasenameGlob(basename)
+  if (!basenameGlob) {
+    return null
+  }
+
+  const authorizedRootPath = await resolveAuthorizedPath(rootPath, store)
+  const localGitOptions = getLocalGitOptionsForRegisteredWorktree(
+    store,
+    rootPath,
+    authorizedRootPath
+  )
+  const excludePathPrefixes = buildExcludePathPrefixes(authorizedRootPath, excludePaths)
+
+  if (await isInsideGitWorktree(authorizedRootPath, localGitOptions)) {
+    try {
+      return await resolveWithGit(
+        authorizedRootPath,
+        basename,
+        basenameGlob,
+        excludePathPrefixes,
+        localGitOptions
+      )
+    } catch {
+      // Fall through to rg when git is unavailable despite rev-parse succeeding.
+    }
+  }
+
+  const rgAvailable = await checkRgAvailable(authorizedRootPath, localGitOptions.wslDistro)
+  if (rgAvailable) {
+    return resolveWithRg(
+      authorizedRootPath,
+      basename,
+      basenameGlob,
+      excludePathPrefixes,
+      localGitOptions
+    )
+  }
+
+  return resolveWithGit(
+    authorizedRootPath,
+    basename,
+    basenameGlob,
+    excludePathPrefixes,
+    localGitOptions
+  )
+}

--- a/src/main/ipc/filesystem-search-rg-timeout.test.ts
+++ b/src/main/ipc/filesystem-search-rg-timeout.test.ts
@@ -31,6 +31,7 @@ vi.mock('electron', () => ({
 
 vi.mock('../git/runner', () => ({
   gitExecFileAsync: vi.fn(),
+  gitSpawn: vi.fn(),
   wslAwareSpawn: wslAwareSpawnMock
 }))
 

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -2179,4 +2179,26 @@ describe('registerFilesystemHandlers', () => {
       excludePaths: ['/home/user/repo/worktrees/feature']
     })
   })
+
+  it('fs:resolveUniqueFileByBasename forwards targeted lookups to the SSH filesystem provider', async () => {
+    const resolveUniqueFileByBasenameMock = vi.fn().mockResolvedValue('src/Foo.ts')
+    getSshFilesystemProviderMock.mockReturnValue({
+      resolveUniqueFileByBasename: resolveUniqueFileByBasenameMock
+    })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:resolveUniqueFileByBasename')!(null, {
+        rootPath: '/home/user/repo',
+        basename: 'Foo.ts',
+        connectionId: 'conn-1',
+        excludePaths: ['/home/user/repo/worktrees/feature']
+      })
+    ).resolves.toBe('src/Foo.ts')
+
+    expect(resolveUniqueFileByBasenameMock).toHaveBeenCalledWith('/home/user/repo', 'Foo.ts', {
+      excludePaths: ['/home/user/repo/worktrees/feature']
+    })
+  })
 })

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -91,6 +91,7 @@ import {
   isENOENT,
   authorizeExternalPath
 } from './filesystem-auth'
+import { resolveQuickOpenFileByBasename } from './filesystem-basename-resolution'
 import { listQuickOpenFiles } from './filesystem-list-files'
 import { registerFilesystemMutationHandlers } from './filesystem-mutations'
 import { searchWithGitGrep } from './filesystem-search-git'
@@ -114,6 +115,8 @@ import {
 import { listRepoWorktrees } from '../repo-worktrees'
 import { splitWorktreeId } from '../../shared/worktree-id'
 import { getRuntimePathBasename } from '../../shared/cross-platform-path'
+import { buildExcludePathPrefixes } from '../../shared/quick-open-filter'
+import { resolveUniqueQuickOpenBasenameFromPaths } from '../../shared/quick-open-unique-basename'
 import type { LocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
 
 // Why: Monaco has large-file optimizations like VS Code; blocking at 5MB makes
@@ -1013,6 +1016,35 @@ export function registerFilesystemHandlers(
         return provider.listFiles(args.rootPath, { excludePaths: args.excludePaths })
       }
       return listQuickOpenFiles(args.rootPath, store, args.excludePaths)
+    }
+  )
+
+  ipcMain.handle(
+    'fs:resolveUniqueFileByBasename',
+    async (
+      _event,
+      args: { rootPath: string; basename: string; connectionId?: string; excludePaths?: string[] }
+    ): Promise<string | null> => {
+      if (args.connectionId) {
+        const provider = getSshFilesystemProvider(args.connectionId)
+        if (!provider) {
+          return null
+        }
+        const options = { excludePaths: args.excludePaths }
+        if (provider.resolveUniqueFileByBasename) {
+          return provider.resolveUniqueFileByBasename(args.rootPath, args.basename, options)
+        }
+        // Why: capability-style fallback keeps older SSH provider test doubles
+        // and stale relays on the original whole-list path instead of dropping
+        // issue #5024 support entirely.
+        const files = await provider.listFiles(args.rootPath, options)
+        return resolveUniqueQuickOpenBasenameFromPaths(
+          files,
+          args.basename,
+          buildExcludePathPrefixes(args.rootPath, args.excludePaths)
+        )
+      }
+      return resolveQuickOpenFileByBasename(args.rootPath, args.basename, store, args.excludePaths)
     }
   )
 

--- a/src/main/providers/ssh-filesystem-basename-resolution.ts
+++ b/src/main/providers/ssh-filesystem-basename-resolution.ts
@@ -1,0 +1,37 @@
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import { isMethodNotFoundError } from '../ssh/ssh-filesystem-stream-reader'
+import { buildExcludePathPrefixes } from '../../shared/quick-open-filter'
+import { resolveUniqueQuickOpenBasenameFromPaths } from '../../shared/quick-open-unique-basename'
+
+type ListRemoteFiles = (
+  rootPath: string,
+  options?: { excludePaths?: string[] }
+) => Promise<string[]>
+
+export async function resolveSshUniqueFileByBasename(
+  mux: SshChannelMultiplexer,
+  listFiles: ListRemoteFiles,
+  rootPath: string,
+  basename: string,
+  options?: { excludePaths?: string[] }
+): Promise<string | null> {
+  const params: Record<string, unknown> = { rootPath, basename }
+  if (options?.excludePaths && options.excludePaths.length > 0) {
+    params.excludePaths = options.excludePaths
+  }
+  try {
+    return (await mux.request('fs.resolveUniqueFileByBasename', params)) as string | null
+  } catch (error) {
+    if (!isMethodNotFoundError(error)) {
+      throw error
+    }
+    // Why: older relays do not know the targeted basename RPC. Preserve the
+    // bug fix across that compatibility window, then filter locally.
+    const files = await listFiles(rootPath, options)
+    return resolveUniqueQuickOpenBasenameFromPaths(
+      files,
+      basename,
+      buildExcludePathPrefixes(rootPath, options?.excludePaths)
+    )
+  }
+}

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -376,6 +376,37 @@ describe('SshFilesystemProvider', () => {
     expect(mux.request).toHaveBeenCalledWith('fs.listFiles', { rootPath: '/home/user/project' })
   })
 
+  it('resolveUniqueFileByBasename sends targeted basename request', async () => {
+    mux.request.mockResolvedValue('src/Foo.ts')
+
+    const result = await provider.resolveUniqueFileByBasename('/home/user/project', 'Foo.ts', {
+      excludePaths: ['/home/user/project/worktrees/b']
+    })
+
+    expect(result).toBe('src/Foo.ts')
+    expect(mux.request).toHaveBeenCalledWith('fs.resolveUniqueFileByBasename', {
+      rootPath: '/home/user/project',
+      basename: 'Foo.ts',
+      excludePaths: ['/home/user/project/worktrees/b']
+    })
+  })
+
+  it('resolveUniqueFileByBasename falls back to listFiles on older relays', async () => {
+    mux.request
+      .mockRejectedValueOnce(Object.assign(new Error('Method not found'), { code: -32601 }))
+      .mockResolvedValueOnce(['worktrees/b/Foo.ts', 'src/Foo.ts'])
+
+    const result = await provider.resolveUniqueFileByBasename('/home/user/project', 'Foo.ts', {
+      excludePaths: ['/home/user/project/worktrees/b']
+    })
+
+    expect(result).toBe('src/Foo.ts')
+    expect(mux.request).toHaveBeenNthCalledWith(2, 'fs.listFiles', {
+      rootPath: '/home/user/project',
+      excludePaths: ['/home/user/project/worktrees/b']
+    })
+  })
+
   describe('watch', () => {
     it('sends fs.watch request and returns unsubscribe', async () => {
       const callback = vi.fn()

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -6,6 +6,7 @@ import type { DirEntry, FsChangeEvent, SearchOptions, SearchResult } from '../..
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
 import type { WorkspaceSpaceDirectoryScanResult } from '../../shared/workspace-space-types'
 import type { SFTPWrapper, Stats } from 'ssh2'
+import { resolveSshUniqueFileByBasename } from './ssh-filesystem-basename-resolution'
 
 type SftpFactory = () => Promise<SFTPWrapper>
 type WatchRegistration = {
@@ -284,6 +285,20 @@ export class SshFilesystemProvider implements IFilesystemProvider {
       params.excludePaths = options.excludePaths
     }
     return (await this.mux.request('fs.listFiles', params)) as string[]
+  }
+
+  async resolveUniqueFileByBasename(
+    rootPath: string,
+    basename: string,
+    options?: { excludePaths?: string[] }
+  ): Promise<string | null> {
+    return resolveSshUniqueFileByBasename(
+      this.mux,
+      this.listFiles.bind(this),
+      rootPath,
+      basename,
+      options
+    )
   }
 
   async watch(rootPath: string, callback: (events: FsChangeEvent[]) => void): Promise<() => void> {

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -156,6 +156,11 @@ export type IFilesystemProvider = {
   realpath(filePath: string): Promise<string>
   search(opts: SearchOptions): Promise<SearchResult>
   listFiles(rootPath: string, options?: { excludePaths?: string[] }): Promise<string[]>
+  resolveUniqueFileByBasename?(
+    rootPath: string,
+    basename: string,
+    options?: { excludePaths?: string[] }
+  ): Promise<string | null>
   scanWorkspaceSpace?(
     rootPath: string,
     options?: { signal?: AbortSignal }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2054,6 +2054,12 @@ export type PreloadApi = {
       connectionId?: string
       excludePaths?: string[]
     }) => Promise<string[]>
+    resolveUniqueFileByBasename: (args: {
+      rootPath: string
+      basename: string
+      connectionId?: string
+      excludePaths?: string[]
+    }) => Promise<string | null>
     search: (args: SearchOptions & { connectionId?: string }) => Promise<SearchResult>
     importExternalPaths: (args: {
       sourcePaths: string[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2465,6 +2465,12 @@ const api = {
       connectionId?: string
       excludePaths?: string[]
     }): Promise<string[]> => ipcRenderer.invoke('fs:listFiles', args),
+    resolveUniqueFileByBasename: (args: {
+      rootPath: string
+      basename: string
+      connectionId?: string
+      excludePaths?: string[]
+    }): Promise<string | null> => ipcRenderer.invoke('fs:resolveUniqueFileByBasename', args),
     search: (args: {
       query: string
       rootPath: string

--- a/src/relay/fs-handler-basename-resolution.test.ts
+++ b/src/relay/fs-handler-basename-resolution.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'events'
+import type { ChildProcess } from 'child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock, execFileMock, checkRgAvailableMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  execFileMock: vi.fn(),
+  checkRgAvailableMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock,
+  execFile: execFileMock
+}))
+
+vi.mock('./fs-handler-utils', () => ({
+  checkRgAvailable: checkRgAvailableMock
+}))
+
+import { resolveUniqueQuickOpenFileByBasename } from './fs-handler-basename-resolution'
+
+function createMockProcess(): ChildProcess {
+  const process = new EventEmitter() as unknown as ChildProcess
+  ;(process as unknown as Record<string, unknown>).stdout = new EventEmitter()
+  ;(
+    (process as unknown as Record<string, unknown>).stdout as EventEmitter & {
+      setEncoding: () => void
+    }
+  ).setEncoding = vi.fn()
+  ;(process as unknown as Record<string, unknown>).stderr = new EventEmitter()
+  ;(process as unknown as Record<string, unknown>).kill = vi.fn()
+  ;(process as unknown as Record<string, unknown>).exitCode = null
+  ;(process as unknown as Record<string, unknown>).signalCode = null
+  return process
+}
+
+describe('relay basename resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkRgAvailableMock.mockResolvedValue(true)
+  })
+
+  it('uses a targeted git basename pathspec inside git worktrees', async () => {
+    execFileMock.mockImplementation(
+      (
+        _cmd: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string) => void
+      ) => {
+        callback(null, 'true\n')
+      }
+    )
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    spawnMock.mockImplementationOnce(() => primary).mockImplementationOnce(() => ignored)
+
+    const promise = resolveUniqueQuickOpenFileByBasename('/remote/repo', 'Foo.ts')
+
+    setTimeout(() => {
+      ;(primary.stdout as unknown as EventEmitter).emit('data', 'src/Foo.ts\0')
+      primary.emit('close', 0, null)
+      ignored.emit('close', 0, null)
+    }, 10)
+
+    await expect(promise).resolves.toBe('src/Foo.ts')
+    expect(spawnMock.mock.calls[0][0]).toBe('git')
+    expect(spawnMock.mock.calls[0][1]).toContain(':(glob)**/Foo.ts')
+  })
+
+  it('uses an rg basename include glob outside git worktrees', async () => {
+    execFileMock.mockImplementation(
+      (
+        _cmd: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string) => void
+      ) => {
+        callback(new Error('not git'), '')
+      }
+    )
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    spawnMock.mockImplementationOnce(() => primary).mockImplementationOnce(() => ignored)
+
+    const promise = resolveUniqueQuickOpenFileByBasename('/remote/repo', 'Foo.ts')
+
+    setTimeout(() => {
+      ;(primary.stdout as unknown as EventEmitter).emit('data', './src/Foo.ts\n')
+      primary.emit('close', 0, null)
+      ignored.emit('close', 0, null)
+    }, 10)
+
+    await expect(promise).resolves.toBe('src/Foo.ts')
+    expect(spawnMock.mock.calls[0][0]).toBe('rg')
+    expect(spawnMock.mock.calls[0][1]).toContain('**/Foo.ts')
+  })
+})

--- a/src/relay/fs-handler-basename-resolution.ts
+++ b/src/relay/fs-handler-basename-resolution.ts
@@ -1,0 +1,329 @@
+import { execFile, spawn, type ChildProcess } from 'child_process'
+import { readdir } from 'fs/promises'
+import { join, relative } from 'path'
+import { checkRgAvailable } from './fs-handler-utils'
+import { buildRelayCommandEnv } from './relay-command-env'
+import {
+  buildExcludePathPrefixes,
+  buildGitLsFilesArgsForQuickOpen,
+  buildRgArgsForQuickOpen
+} from '../shared/quick-open-filter'
+import {
+  HIDDEN_DIR_BLOCKLIST,
+  normalizeQuickOpenRgLine,
+  shouldExcludeQuickOpenRelPath
+} from '../shared/quick-open-filter'
+import {
+  buildQuickOpenBasenameGlob,
+  createUniqueQuickOpenBasenameCollector
+} from '../shared/quick-open-unique-basename'
+import { buildInstallRgMessage } from './fs-handler-install-rg'
+
+const BASENAME_RESOLUTION_TIMEOUT_MS = 10_000
+const READDIR_TIMEOUT_MS = 10_000
+const READDIR_MAX_VISITED_FILES = 10_000
+
+type ProcessPassConfig = {
+  delimiter: '\0' | '\n'
+  spawnPass: (args: string[]) => ChildProcess
+  passArgs: string[][]
+  parsePath: (rawPath: string) => string | null
+  timeoutMs: number
+  acceptsExit: (code: number | null, parseablePathCount: number) => boolean
+}
+
+function shouldDescend(name: string): boolean {
+  return name !== 'node_modules' && !HIDDEN_DIR_BLOCKLIST.has(name)
+}
+
+function resolveFromProcessPasses(
+  basename: string,
+  excludePathPrefixes: readonly string[],
+  config: ProcessPassConfig
+): Promise<string | null> {
+  return new Promise((resolve, reject) => {
+    const collector = createUniqueQuickOpenBasenameCollector(basename, excludePathPrefixes)
+    const children: ChildProcess[] = []
+    const cleanups: (() => void)[] = []
+    let settled = false
+    let completedPasses = 0
+
+    const finish = (result: string | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      for (const cleanup of cleanups) {
+        cleanup()
+      }
+      for (const child of children) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill()
+        }
+      }
+      resolve(result)
+    }
+
+    const fail = (error: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      for (const cleanup of cleanups) {
+        cleanup()
+      }
+      for (const child of children) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill()
+        }
+      }
+      reject(error)
+    }
+
+    for (const args of config.passArgs) {
+      const child = config.spawnPass(args)
+      children.push(child)
+      let buffer = ''
+      let done = false
+      let parseablePathCount = 0
+      let timer: ReturnType<typeof setTimeout> | null = null
+
+      const cleanup = (): void => {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        child.stdout?.off('data', handleStdoutData)
+        child.stderr?.off('data', handleStderrData)
+        child.off('error', handleError)
+        child.off('close', handleClose)
+      }
+      cleanups.push(cleanup)
+
+      const resolvePass = (): void => {
+        if (done || settled) {
+          return
+        }
+        done = true
+        cleanup()
+        completedPasses += 1
+        if (completedPasses === config.passArgs.length) {
+          finish(collector.result())
+        }
+      }
+
+      const rejectPass = (error: Error): void => {
+        if (done || settled) {
+          return
+        }
+        done = true
+        cleanup()
+        fail(error)
+      }
+
+      const processPath = (rawPath: string): void => {
+        const relativePath = config.parsePath(rawPath)
+        if (relativePath === null) {
+          return
+        }
+        parseablePathCount += 1
+        if (collector.add(relativePath)) {
+          finish(null)
+        }
+      }
+
+      function handleStdoutData(chunk: string): void {
+        buffer += chunk
+        let start = 0
+        let index = buffer.indexOf(config.delimiter, start)
+        while (index !== -1) {
+          processPath(buffer.substring(start, index))
+          if (settled) {
+            return
+          }
+          start = index + 1
+          index = buffer.indexOf(config.delimiter, start)
+        }
+        buffer = start < buffer.length ? buffer.substring(start) : ''
+      }
+
+      function handleStderrData(): void {
+        /* drain */
+      }
+
+      function handleError(error: Error): void {
+        rejectPass(error)
+      }
+
+      function handleClose(code: number | null, signal: NodeJS.Signals | null): void {
+        if (signal) {
+          rejectPass(new Error(`basename scan killed by ${signal}`))
+          return
+        }
+        if (buffer) {
+          processPath(buffer)
+        }
+        if (settled) {
+          return
+        }
+        if (config.acceptsExit(code, parseablePathCount)) {
+          resolvePass()
+        } else {
+          rejectPass(new Error(`basename scan exited with code ${code}`))
+        }
+      }
+
+      child.stdout?.setEncoding('utf-8')
+      child.stdout?.on('data', handleStdoutData)
+      child.stderr?.on('data', handleStderrData)
+      child.once('error', handleError)
+      child.once('close', handleClose)
+      timer = setTimeout(() => {
+        buffer = ''
+        child.kill()
+        rejectPass(new Error('basename scan timed out'))
+      }, config.timeoutMs)
+    }
+  })
+}
+
+function isInsideGitWorktree(rootPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(
+      'git',
+      ['rev-parse', '--is-inside-work-tree'],
+      { cwd: rootPath, env: buildRelayCommandEnv() },
+      (error, stdout) => resolve(!error && stdout.trim() === 'true')
+    )
+  })
+}
+
+function resolveWithGit(
+  rootPath: string,
+  basename: string,
+  basenameGlob: string,
+  excludePathPrefixes: readonly string[]
+): Promise<string | null> {
+  const { primary, ignoredPass } = buildGitLsFilesArgsForQuickOpen(excludePathPrefixes, [
+    `:(glob)${basenameGlob}`
+  ])
+  return resolveFromProcessPasses(basename, excludePathPrefixes, {
+    delimiter: '\0',
+    passArgs: [primary, ignoredPass],
+    timeoutMs: BASENAME_RESOLUTION_TIMEOUT_MS,
+    spawnPass: (args) =>
+      spawn('git', ['ls-files', ...args], {
+        cwd: rootPath,
+        env: buildRelayCommandEnv(),
+        stdio: ['ignore', 'pipe', 'pipe']
+      }),
+    parsePath: (rawPath) => rawPath,
+    acceptsExit: () => true
+  })
+}
+
+function resolveWithRg(
+  rootPath: string,
+  basename: string,
+  basenameGlob: string,
+  excludePathPrefixes: readonly string[]
+): Promise<string | null> {
+  const { primary, ignoredPass } = buildRgArgsForQuickOpen({
+    searchRoot: '.',
+    includeGlobs: [basenameGlob],
+    excludePathPrefixes,
+    forceSlashSeparator: true
+  })
+  return resolveFromProcessPasses(basename, excludePathPrefixes, {
+    delimiter: '\n',
+    passArgs: [primary, ignoredPass],
+    timeoutMs: BASENAME_RESOLUTION_TIMEOUT_MS,
+    spawnPass: (args) =>
+      spawn('rg', ['--no-messages', ...args], {
+        cwd: rootPath,
+        stdio: ['ignore', 'pipe', 'pipe']
+      }),
+    parsePath: (rawPath) => normalizeQuickOpenRgLine(rawPath, { kind: 'cwd-relative' }),
+    acceptsExit: (code, parseablePathCount) =>
+      code === 0 || code === 1 || (code === 2 && parseablePathCount > 0)
+  })
+}
+
+async function resolveWithReaddir(
+  rootPath: string,
+  basename: string,
+  excludePathPrefixes: readonly string[]
+): Promise<string | null> {
+  const collector = createUniqueQuickOpenBasenameCollector(basename, excludePathPrefixes)
+  const deadline = Date.now() + READDIR_TIMEOUT_MS
+  let visitedFiles = 0
+
+  async function walk(dirPath: string): Promise<boolean> {
+    if (Date.now() > deadline || visitedFiles >= READDIR_MAX_VISITED_FILES) {
+      throw new Error(
+        visitedFiles >= READDIR_MAX_VISITED_FILES
+          ? `File listing exceeded ${READDIR_MAX_VISITED_FILES} files`
+          : 'File listing timed out'
+      )
+    }
+
+    let entries
+    try {
+      entries = await readdir(dirPath, { withFileTypes: true })
+    } catch {
+      return false
+    }
+
+    for (const entry of entries) {
+      const absolutePath = join(dirPath, entry.name)
+      const relativePath = relative(rootPath, absolutePath).replace(/\\/g, '/')
+      if (shouldExcludeQuickOpenRelPath(relativePath, excludePathPrefixes)) {
+        continue
+      }
+      if (entry.isDirectory()) {
+        if (shouldDescend(entry.name) && (await walk(absolutePath))) {
+          return true
+        }
+      } else if (entry.isFile()) {
+        visitedFiles += 1
+        if (collector.add(relativePath)) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+
+  await walk(rootPath)
+  return collector.result()
+}
+
+export async function resolveUniqueQuickOpenFileByBasename(
+  rootPath: string,
+  basename: string,
+  excludePaths?: unknown
+): Promise<string | null> {
+  const basenameGlob = buildQuickOpenBasenameGlob(basename)
+  if (!basenameGlob) {
+    return null
+  }
+
+  const excludePathPrefixes = buildExcludePathPrefixes(rootPath, excludePaths)
+  if (await isInsideGitWorktree(rootPath)) {
+    try {
+      return await resolveWithGit(rootPath, basename, basenameGlob, excludePathPrefixes)
+    } catch {
+      // Fall through to rg when git unexpectedly fails on a git worktree.
+    }
+  }
+
+  if (await checkRgAvailable()) {
+    return resolveWithRg(rootPath, basename, basenameGlob, excludePathPrefixes)
+  }
+
+  try {
+    return await resolveWithReaddir(rootPath, basename, excludePathPrefixes)
+  } catch (error) {
+    throw new Error(await buildInstallRgMessage(error))
+  }
+}

--- a/src/relay/fs-handler.test.ts
+++ b/src/relay/fs-handler.test.ts
@@ -137,6 +137,7 @@ describe('FsHandler', () => {
     expect(methods).toContain('fs.realpath')
     expect(methods).toContain('fs.search')
     expect(methods).toContain('fs.listFiles')
+    expect(methods).toContain('fs.resolveUniqueFileByBasename')
     expect(methods).toContain('fs.workspaceSpaceScan')
     expect(methods).toContain('fs.watch')
 

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -24,6 +24,7 @@ import { RelayStreamRegistry } from './fs-stream-registry'
 import { scanWorkspaceSpaceDirectory } from './workspace-space-scan'
 import { buildRelayCommandEnv } from './relay-command-env'
 import { assertNoClobberRenameDestinationAvailable } from '../shared/filesystem-rename-collision'
+import { resolveUniqueQuickOpenFileByBasename } from './fs-handler-basename-resolution'
 
 type WatchState = {
   rootPath: string
@@ -90,6 +91,9 @@ export class FsHandler {
     this.dispatcher.onRequest('fs.realpath', (p) => this.realpath(p))
     this.dispatcher.onRequest('fs.search', (p) => this.search(p))
     this.dispatcher.onRequest('fs.listFiles', (p) => this.listFiles(p))
+    this.dispatcher.onRequest('fs.resolveUniqueFileByBasename', (p) =>
+      this.resolveUniqueFileByBasename(p)
+    )
     this.dispatcher.onRequest('fs.workspaceSpaceScan', (p, c) => this.workspaceSpaceScan(p, c))
     this.dispatcher.onRequest('fs.watch', (p, context) => this.watch(p, context))
     this.dispatcher.onNotification('fs.unwatch', (p, context) => this.unwatch(p, context))
@@ -310,6 +314,17 @@ export class FsHandler {
     } catch (err) {
       throw new Error(await buildInstallRgMessage(err))
     }
+  }
+
+  private async resolveUniqueFileByBasename(
+    params: Record<string, unknown>
+  ): Promise<string | null> {
+    const rootPath = expandTilde(params.rootPath as string)
+    return resolveUniqueQuickOpenFileByBasename(
+      rootPath,
+      params.basename as string,
+      params.excludePaths
+    )
   }
 
   private async workspaceSpaceScan(params: Record<string, unknown>, context: RequestContext) {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -13,6 +13,7 @@ import {
   openDetectedFilePath
 } from './terminal-link-handlers'
 import { TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES } from './terminal-path-exists-cache'
+import { __resetWorkspaceFileIndexCacheForTest } from './terminal-workspace-file-resolution'
 import { handleOscLink } from './terminal-osc-link-routing'
 import { installHttpLinkClickFallback } from './terminal-url-link-hit-testing'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
@@ -31,6 +32,12 @@ const openFileMock = vi.fn()
 const authorizeExternalPathMock = vi.fn()
 const statMock = vi.fn().mockResolvedValue({ isDirectory: false })
 const fsPathExistsMock = vi.fn().mockResolvedValue(true)
+// Why: the workspace-fallback (issue #5024) calls fs.listFiles; default to an
+// empty listing so the fallback runs intentionally rather than being silently
+// swallowed by resolveWorkspaceFileByBasename's try/catch on a missing mock.
+const listFilesMock = vi
+  .fn<(args: { rootPath: string }) => Promise<string[]>>()
+  .mockResolvedValue([])
 const runtimeEnvironmentCallMock = vi.fn()
 const runtimeEnvironmentTransportCallMock = vi.fn()
 const setActiveWorktreeMock = vi.fn()
@@ -105,6 +112,8 @@ beforeEach(() => {
   })
   vi.mocked(getConnectionId).mockReturnValue(null)
   openFilePathMock.mockResolvedValue(true)
+  listFilesMock.mockResolvedValue([])
+  __resetWorkspaceFileIndexCacheForTest()
   storeState.settings = undefined
   storeState.worktreesByRepo = {}
   registerHttpLinkStoreAccessor(() => storeState)
@@ -120,7 +129,8 @@ beforeEach(() => {
       fs: {
         authorizeExternalPath: authorizeExternalPathMock,
         pathExists: fsPathExistsMock,
-        stat: statMock
+        stat: statMock,
+        listFiles: listFilesMock
       },
       runtimeEnvironments: { call: runtimeEnvironmentTransportCallMock }
     }
@@ -1231,6 +1241,45 @@ describe('createFilePathLinkProvider range bounds', () => {
 
     expect(links).toEqual([])
     expect(window.api.shell.pathExists).not.toHaveBeenCalled()
+  })
+
+  it('linkifies a bare filename that misses cwd but is unique in the worktree (issue #5024)', async () => {
+    setPlatform('Macintosh')
+    listFilesMock.mockResolvedValue([
+      'src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx',
+      'README.md'
+    ])
+    const { provider, linkTooltip } = createProviderSetup(
+      [makeBufferLine('TerminalContextMenu.test.tsx')],
+      // The cwd-relative probe misses; the workspace fallback should resolve it.
+      new Map([['active\0/repo/TerminalContextMenu.test.tsx', false]])
+    )
+
+    const links = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(links.map((link) => link.text)).toEqual(['TerminalContextMenu.test.tsx'])
+    expect(listFilesMock).toHaveBeenCalledWith({ rootPath: '/repo' })
+    links[0]!.hover?.({} as MouseEvent, links[0]!.text)
+    expect(linkTooltip.textContent).toBe(
+      '/repo/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx (⌘+click to open or ⇧⌘+click for default app)'
+    )
+  })
+
+  it('does not link a bare filename that is ambiguous in the worktree (issue #5024)', async () => {
+    setPlatform('Macintosh')
+    listFilesMock.mockResolvedValue(['src/a/index.ts', 'src/b/index.ts'])
+    const { provider } = createProviderSetup(
+      [makeBufferLine('index.ts')],
+      new Map([['active\0/repo/index.ts', false]])
+    )
+
+    const links = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(links).toEqual([])
   })
 
   it('linkifies a known worktree root printed with a trailing slash', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -32,12 +32,12 @@ const openFileMock = vi.fn()
 const authorizeExternalPathMock = vi.fn()
 const statMock = vi.fn().mockResolvedValue({ isDirectory: false })
 const fsPathExistsMock = vi.fn().mockResolvedValue(true)
-// Why: the workspace-fallback (issue #5024) calls fs.listFiles; default to an
-// empty listing so the fallback runs intentionally rather than being silently
-// swallowed by resolveWorkspaceFileByBasename's try/catch on a missing mock.
-const listFilesMock = vi
-  .fn<(args: { rootPath: string }) => Promise<string[]>>()
-  .mockResolvedValue([])
+// Why: the workspace-fallback (issue #5024) calls a targeted basename resolver;
+// default to "no unique match" so the fallback runs intentionally rather than
+// being silently swallowed by resolveWorkspaceFileByBasename's try/catch.
+const resolveUniqueFileByBasenameMock = vi
+  .fn<(args: { rootPath: string; basename: string }) => Promise<string | null>>()
+  .mockResolvedValue(null)
 const runtimeEnvironmentCallMock = vi.fn()
 const runtimeEnvironmentTransportCallMock = vi.fn()
 const setActiveWorktreeMock = vi.fn()
@@ -112,7 +112,7 @@ beforeEach(() => {
   })
   vi.mocked(getConnectionId).mockReturnValue(null)
   openFilePathMock.mockResolvedValue(true)
-  listFilesMock.mockResolvedValue([])
+  resolveUniqueFileByBasenameMock.mockResolvedValue(null)
   __resetWorkspaceFileIndexCacheForTest()
   storeState.settings = undefined
   storeState.worktreesByRepo = {}
@@ -130,7 +130,7 @@ beforeEach(() => {
         authorizeExternalPath: authorizeExternalPathMock,
         pathExists: fsPathExistsMock,
         stat: statMock,
-        listFiles: listFilesMock
+        resolveUniqueFileByBasename: resolveUniqueFileByBasenameMock
       },
       runtimeEnvironments: { call: runtimeEnvironmentTransportCallMock }
     }
@@ -1245,10 +1245,9 @@ describe('createFilePathLinkProvider range bounds', () => {
 
   it('linkifies a bare filename that misses cwd but is unique in the worktree (issue #5024)', async () => {
     setPlatform('Macintosh')
-    listFilesMock.mockResolvedValue([
-      'src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx',
-      'README.md'
-    ])
+    resolveUniqueFileByBasenameMock.mockResolvedValue(
+      'src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx'
+    )
     const { provider, linkTooltip } = createProviderSetup(
       [makeBufferLine('TerminalContextMenu.test.tsx')],
       // The cwd-relative probe misses; the workspace fallback should resolve it.
@@ -1260,7 +1259,10 @@ describe('createFilePathLinkProvider range bounds', () => {
     })
 
     expect(links.map((link) => link.text)).toEqual(['TerminalContextMenu.test.tsx'])
-    expect(listFilesMock).toHaveBeenCalledWith({ rootPath: '/repo' })
+    expect(resolveUniqueFileByBasenameMock).toHaveBeenCalledWith({
+      rootPath: '/repo',
+      basename: 'TerminalContextMenu.test.tsx'
+    })
     links[0]!.hover?.({} as MouseEvent, links[0]!.text)
     expect(linkTooltip.textContent).toBe(
       '/repo/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx (⌘+click to open or ⇧⌘+click for default app)'
@@ -1269,7 +1271,7 @@ describe('createFilePathLinkProvider range bounds', () => {
 
   it('does not link a bare filename that is ambiguous in the worktree (issue #5024)', async () => {
     setPlatform('Macintosh')
-    listFilesMock.mockResolvedValue(['src/a/index.ts', 'src/b/index.ts'])
+    resolveUniqueFileByBasenameMock.mockResolvedValue(null)
     const { provider } = createProviderSetup(
       [makeBufferLine('index.ts')],
       new Map([['active\0/repo/index.ts', false]])

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -142,8 +142,9 @@ export function createFilePathLinkProvider(
                 if (!exists) {
                   // Why (issue #5024): a bare filename that doesn't exist at the
                   // cwd often refers to a file nested elsewhere in the worktree.
-                  // Resolve it against the worktree's own file list (local/SSH;
-                  // runtime hosts are skipped). Only a unique match links.
+                  // Resolve it with a targeted worktree basename lookup
+                  // (local/SSH; runtime hosts are skipped). Only a unique
+                  // match links.
                   const workspaceMatch =
                     !isRemoteRuntimePath && !/[\\/]/.test(parsed.pathText)
                       ? await resolveWorkspaceFileByBasename({

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -1,4 +1,4 @@
-import type { IDisposable, ILink, ILinkProvider, Terminal } from '@xterm/xterm'
+import type { IDisposable, ILinkProvider, Terminal } from '@xterm/xterm'
 import {
   extractTerminalFileLinkCandidates,
   extractTerminalFileLinks,
@@ -20,8 +20,7 @@ import {
 import {
   buildHardWrappedPathLogicalLineCandidates,
   buildWrappedLogicalLine,
-  rangeForParsedFileLink,
-  type WrappedLogicalLine
+  rangeForParsedFileLink
 } from './wrapped-terminal-link-ranges'
 import {
   getTerminalPathExistsCacheKey,
@@ -37,6 +36,9 @@ import {
   isMacPlatform
 } from './terminal-link-open-hints'
 import { resolveKnownWorktreeRootPathLink } from './terminal-worktree-path-link'
+import { resolveWorkspaceFileByBasename } from './terminal-workspace-file-resolution'
+import { preferLongestNonOverlappingLinks } from './terminal-link-overlap-selection'
+import type { ProvidedFileLink } from './terminal-provided-file-link'
 
 export { openDetectedFilePath } from './terminal-file-open-routing'
 export { openFilePathLinkAtBufferPosition } from './terminal-file-link-hit-testing'
@@ -52,38 +54,6 @@ export type LinkHandlerDeps = {
   runtimeEnvironmentId?: string | null
   terminalHomePath?: string | null
   getRuntimeEnvironmentIdForPane?: (paneId: number) => string | null
-}
-
-type ProvidedFileLink = {
-  link: ILink
-  logicalLine: WrappedLogicalLine
-}
-
-function rangesOverlap(left: ILink['range'], right: ILink['range']): boolean {
-  const leftStartsAfterRightEnds =
-    left.start.y > right.end.y || (left.start.y === right.end.y && left.start.x > right.end.x)
-  const rightStartsAfterLeftEnds =
-    right.start.y > left.end.y || (right.start.y === left.end.y && right.start.x > left.end.x)
-  return !leftStartsAfterRightEnds && !rightStartsAfterLeftEnds
-}
-
-function preferLongestNonOverlappingLinks(links: ProvidedFileLink[]): ProvidedFileLink[] {
-  const selected: ProvidedFileLink[] = []
-  const byLengthDescending = [...links].sort(
-    (a, b) =>
-      b.link.text.length - a.link.text.length ||
-      a.link.range.start.y - b.link.range.start.y ||
-      a.link.range.start.x - b.link.range.start.x
-  )
-  for (const link of byLengthDescending) {
-    if (!selected.some((existing) => rangesOverlap(existing.link.range, link.link.range))) {
-      selected.push(link)
-    }
-  }
-  return selected.sort(
-    (a, b) =>
-      a.link.range.start.y - b.link.range.start.y || a.link.range.start.x - b.link.range.start.x
-  )
 }
 
 export function createFilePathLinkProvider(
@@ -155,6 +125,10 @@ export function createFilePathLinkProvider(
               if (/[\\/]$/.test(parsed.pathText) && !worktreeRootLink) {
                 return null
               }
+              // Why: the cwd-relative path is the default target, but a bare
+              // filename may instead resolve to a file nested elsewhere in the
+              // worktree (see the workspace fallback below).
+              let linkAbsolutePath = resolved.absolutePath
               // Why: exact known workspace roots must stay clickable for SSH or
               // stale local paths even when filesystem probing says "missing".
               if (!worktreeRootLink) {
@@ -166,7 +140,22 @@ export function createFilePathLinkProvider(
                     : await window.api.shell.pathExists(resolved.absolutePath))
                 writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
                 if (!exists) {
-                  return null
+                  // Why (issue #5024): a bare filename that doesn't exist at the
+                  // cwd often refers to a file nested elsewhere in the worktree.
+                  // Resolve it against the worktree's own file list (local/SSH;
+                  // runtime hosts are skipped). Only a unique match links.
+                  const workspaceMatch =
+                    !isRemoteRuntimePath && !/[\\/]/.test(parsed.pathText)
+                      ? await resolveWorkspaceFileByBasename({
+                          basename: parsed.pathText,
+                          worktreePath,
+                          connectionId: fileContext.connectionId
+                        })
+                      : null
+                  if (!workspaceMatch) {
+                    return null
+                  }
+                  linkAbsolutePath = workspaceMatch
                 }
               }
 
@@ -179,7 +168,7 @@ export function createFilePathLinkProvider(
                     if (!isTerminalLinkActivation(event)) {
                       return
                     }
-                    openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, {
+                    openDetectedFilePath(linkAbsolutePath, resolved.line, resolved.column, {
                       worktreeId,
                       worktreePath,
                       runtimeEnvironmentId,
@@ -191,16 +180,16 @@ export function createFilePathLinkProvider(
                     // default escape hatch; remote paths may not exist locally.
                     const canOpenWithSystemDefault = shouldOpenTerminalFileWithSystemDefault(
                       fileContext,
-                      resolved.absolutePath
+                      linkAbsolutePath
                     )
                     const hint = worktreeRootLink
                       ? getTerminalWorktreePathOpenHint(canOpenWithSystemDefault)
                       : canOpenWithSystemDefault
-                        ? isHtmlFilePath(resolved.absolutePath)
+                        ? isHtmlFilePath(linkAbsolutePath)
                           ? getTerminalHtmlFileOpenHint()
                           : openLinkHint
                         : getTerminalOrcaFileOpenHint()
-                    linkTooltip.textContent = `${resolved.absolutePath} (${hint})`
+                    linkTooltip.textContent = `${linkAbsolutePath} (${hint})`
                     linkTooltip.style.display = ''
                   },
                   leave: () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-overlap-selection.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-overlap-selection.ts
@@ -1,0 +1,32 @@
+import type { ILink } from '@xterm/xterm'
+import type { ProvidedFileLink } from './terminal-provided-file-link'
+
+function rangesOverlap(left: ILink['range'], right: ILink['range']): boolean {
+  const leftStartsAfterRightEnds =
+    left.start.y > right.end.y || (left.start.y === right.end.y && left.start.x > right.end.x)
+  const rightStartsAfterLeftEnds =
+    right.start.y > left.end.y || (right.start.y === left.end.y && right.start.x > left.end.x)
+  return !leftStartsAfterRightEnds && !rightStartsAfterLeftEnds
+}
+
+// Why: a wrapped path and a bare filename inside it can both match; keep the
+// longest link per overlapping span so the user gets the whole path, not a
+// fragment, then restore document order for stable rendering.
+export function preferLongestNonOverlappingLinks(links: ProvidedFileLink[]): ProvidedFileLink[] {
+  const selected: ProvidedFileLink[] = []
+  const byLengthDescending = [...links].sort(
+    (a, b) =>
+      b.link.text.length - a.link.text.length ||
+      a.link.range.start.y - b.link.range.start.y ||
+      a.link.range.start.x - b.link.range.start.x
+  )
+  for (const link of byLengthDescending) {
+    if (!selected.some((existing) => rangesOverlap(existing.link.range, link.link.range))) {
+      selected.push(link)
+    }
+  }
+  return selected.sort(
+    (a, b) =>
+      a.link.range.start.y - b.link.range.start.y || a.link.range.start.x - b.link.range.start.x
+  )
+}

--- a/src/renderer/src/components/terminal-pane/terminal-provided-file-link.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-provided-file-link.ts
@@ -1,0 +1,10 @@
+import type { ILink } from '@xterm/xterm'
+import type { WrappedLogicalLine } from './wrapped-terminal-link-ranges'
+
+// Why: a candidate link paired with the logical line it came from. Lives in its
+// own module so the link provider and the overlap selector can share the type
+// without an import cycle between handlers and overlap-selection.
+export type ProvidedFileLink = {
+  link: ILink
+  logicalLine: WrappedLogicalLine
+}

--- a/src/renderer/src/components/terminal-pane/terminal-workspace-file-resolution.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-workspace-file-resolution.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetWorkspaceFileIndexCacheForTest,
+  resolveWorkspaceFileByBasename
+} from './terminal-workspace-file-resolution'
+
+const WT = '/Users/me/repo'
+
+afterEach(() => {
+  __resetWorkspaceFileIndexCacheForTest()
+})
+
+describe('resolveWorkspaceFileByBasename', () => {
+  it('resolves a bare filename to a unique nested workspace file (issue #5024)', async () => {
+    const listFiles = vi.fn(async () => [
+      'src/a/Foo.ts',
+      'src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx',
+      'README.md'
+    ])
+    const result = await resolveWorkspaceFileByBasename({
+      basename: 'TerminalContextMenu.test.tsx',
+      worktreePath: WT,
+      listFiles,
+      now: 1000
+    })
+    expect(result).toBe(
+      '/Users/me/repo/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx'
+    )
+    expect(listFiles).toHaveBeenCalledWith({ rootPath: WT })
+  })
+
+  it('returns null when multiple files share the basename (ambiguous, never guesses)', async () => {
+    const listFiles = vi.fn(async () => ['a/index.ts', 'b/index.ts'])
+    expect(
+      await resolveWorkspaceFileByBasename({
+        basename: 'index.ts',
+        worktreePath: WT,
+        listFiles,
+        now: 1000
+      })
+    ).toBeNull()
+  })
+
+  it('returns null when no file matches', async () => {
+    const listFiles = vi.fn(async () => ['a/x.ts'])
+    expect(
+      await resolveWorkspaceFileByBasename({
+        basename: 'missing.ts',
+        worktreePath: WT,
+        listFiles,
+        now: 1000
+      })
+    ).toBeNull()
+  })
+
+  it('caches the file list within the TTL and refetches once it expires', async () => {
+    const listFiles = vi.fn(async () => ['a/Foo.ts'])
+    await resolveWorkspaceFileByBasename({
+      basename: 'Foo.ts',
+      worktreePath: WT,
+      listFiles,
+      now: 1000
+    })
+    await resolveWorkspaceFileByBasename({
+      basename: 'Foo.ts',
+      worktreePath: WT,
+      listFiles,
+      now: 5000
+    })
+    expect(listFiles).toHaveBeenCalledTimes(1)
+    await resolveWorkspaceFileByBasename({
+      basename: 'Foo.ts',
+      worktreePath: WT,
+      listFiles,
+      now: 1000 + 20_000
+    })
+    expect(listFiles).toHaveBeenCalledTimes(2)
+  })
+
+  it('keys the cache by connection and forwards connectionId for SSH worktrees', async () => {
+    const remote = vi.fn(async () => ['y/remote.ts'])
+    const result = await resolveWorkspaceFileByBasename({
+      basename: 'remote.ts',
+      worktreePath: WT,
+      connectionId: 'ssh-1',
+      listFiles: remote,
+      now: 1
+    })
+    expect(result).toBe('/Users/me/repo/y/remote.ts')
+    expect(remote).toHaveBeenCalledWith({ rootPath: WT, connectionId: 'ssh-1' })
+  })
+
+  it('returns null without throwing when listing fails', async () => {
+    const listFiles = vi.fn(async () => {
+      throw new Error('listing unavailable')
+    })
+    expect(
+      await resolveWorkspaceFileByBasename({
+        basename: 'x.ts',
+        worktreePath: WT,
+        listFiles,
+        now: 1
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-workspace-file-resolution.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-workspace-file-resolution.test.ts
@@ -12,93 +12,98 @@ afterEach(() => {
 
 describe('resolveWorkspaceFileByBasename', () => {
   it('resolves a bare filename to a unique nested workspace file (issue #5024)', async () => {
-    const listFiles = vi.fn(async () => [
-      'src/a/Foo.ts',
-      'src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx',
-      'README.md'
-    ])
+    const resolveUniqueFileByBasename = vi.fn(
+      async () => 'src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx'
+    )
     const result = await resolveWorkspaceFileByBasename({
       basename: 'TerminalContextMenu.test.tsx',
       worktreePath: WT,
-      listFiles,
+      resolveUniqueFileByBasename,
       now: 1000
     })
     expect(result).toBe(
       '/Users/me/repo/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx'
     )
-    expect(listFiles).toHaveBeenCalledWith({ rootPath: WT })
+    expect(resolveUniqueFileByBasename).toHaveBeenCalledWith({
+      rootPath: WT,
+      basename: 'TerminalContextMenu.test.tsx'
+    })
   })
 
   it('returns null when multiple files share the basename (ambiguous, never guesses)', async () => {
-    const listFiles = vi.fn(async () => ['a/index.ts', 'b/index.ts'])
+    const resolveUniqueFileByBasename = vi.fn(async () => null)
     expect(
       await resolveWorkspaceFileByBasename({
         basename: 'index.ts',
         worktreePath: WT,
-        listFiles,
+        resolveUniqueFileByBasename,
         now: 1000
       })
     ).toBeNull()
   })
 
   it('returns null when no file matches', async () => {
-    const listFiles = vi.fn(async () => ['a/x.ts'])
+    const resolveUniqueFileByBasename = vi.fn(async () => null)
     expect(
       await resolveWorkspaceFileByBasename({
         basename: 'missing.ts',
         worktreePath: WT,
-        listFiles,
+        resolveUniqueFileByBasename,
         now: 1000
       })
     ).toBeNull()
   })
 
-  it('caches the file list within the TTL and refetches once it expires', async () => {
-    const listFiles = vi.fn(async () => ['a/Foo.ts'])
+  it('caches the basename result within the TTL and refetches once it expires', async () => {
+    const resolveUniqueFileByBasename = vi.fn(async () => 'a/Foo.ts')
     await resolveWorkspaceFileByBasename({
       basename: 'Foo.ts',
       worktreePath: WT,
-      listFiles,
+      resolveUniqueFileByBasename,
       now: 1000
     })
     await resolveWorkspaceFileByBasename({
       basename: 'Foo.ts',
       worktreePath: WT,
-      listFiles,
+      resolveUniqueFileByBasename,
       now: 5000
     })
-    expect(listFiles).toHaveBeenCalledTimes(1)
+    expect(resolveUniqueFileByBasename).toHaveBeenCalledTimes(1)
     await resolveWorkspaceFileByBasename({
       basename: 'Foo.ts',
       worktreePath: WT,
-      listFiles,
+      resolveUniqueFileByBasename,
       now: 1000 + 20_000
     })
-    expect(listFiles).toHaveBeenCalledTimes(2)
+    expect(resolveUniqueFileByBasename).toHaveBeenCalledTimes(2)
   })
 
   it('keys the cache by connection and forwards connectionId for SSH worktrees', async () => {
-    const remote = vi.fn(async () => ['y/remote.ts'])
+    const remote = vi.fn(async () => 'y/remote.ts')
     const result = await resolveWorkspaceFileByBasename({
       basename: 'remote.ts',
       worktreePath: WT,
       connectionId: 'ssh-1',
-      listFiles: remote,
+      resolveUniqueFileByBasename: remote,
       now: 1
     })
     expect(result).toBe('/Users/me/repo/y/remote.ts')
-    expect(remote).toHaveBeenCalledWith({ rootPath: WT, connectionId: 'ssh-1' })
+    expect(remote).toHaveBeenCalledWith({
+      rootPath: WT,
+      basename: 'remote.ts',
+      connectionId: 'ssh-1'
+    })
   })
 
-  it('returns null without throwing when listing fails', async () => {
-    const listFiles = vi.fn(async () => {
+  it('returns null without throwing when the basename lookup fails', async () => {
+    const resolveUniqueFileByBasename = vi.fn(async () => {
       throw new Error('listing unavailable')
     })
     expect(
       await resolveWorkspaceFileByBasename({
         basename: 'x.ts',
         worktreePath: WT,
-        listFiles,
+        resolveUniqueFileByBasename,
         now: 1
       })
     ).toBeNull()

--- a/src/renderer/src/components/terminal-pane/terminal-workspace-file-resolution.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-workspace-file-resolution.ts
@@ -1,0 +1,86 @@
+import { joinAbsolutePath } from '@/lib/terminal-path-normalization'
+
+type WorkspaceFileIndexEntry = { fetchedAt: number; basenameToPaths: Map<string, string[]> }
+
+type ListWorkspaceFiles = (args: { rootPath: string; connectionId?: string }) => Promise<string[]>
+
+// Why: the link provider runs per hovered line, so cache the worktree's file
+// list (the same listing Quick Open uses) and refresh it on a short TTL rather
+// than re-listing on every lookup.
+const WORKSPACE_FILE_INDEX_TTL_MS = 15_000
+const workspaceFileIndexCache = new Map<string, WorkspaceFileIndexEntry>()
+
+function basenameOf(relativePath: string): string {
+  const normalized = relativePath.replace(/\\/g, '/')
+  const slash = normalized.lastIndexOf('/')
+  return slash === -1 ? normalized : normalized.slice(slash + 1)
+}
+
+function buildBasenameIndex(files: readonly string[]): Map<string, string[]> {
+  const index = new Map<string, string[]>()
+  for (const relativePath of files) {
+    const basename = basenameOf(relativePath)
+    const existing = index.get(basename)
+    if (existing) {
+      existing.push(relativePath)
+    } else {
+      index.set(basename, [relativePath])
+    }
+  }
+  return index
+}
+
+export type ResolveWorkspaceFileArgs = {
+  basename: string
+  worktreePath: string
+  connectionId?: string | null
+  /** Test seams. */
+  now?: number
+  listFiles?: ListWorkspaceFiles
+}
+
+/**
+ * Resolve a bare filename to a file nested elsewhere in the worktree.
+ *
+ * Why (issue #5024): agent output frequently references a repo file by bare
+ * name (e.g. `TerminalContextMenu.test.tsx`), which does not exist at the
+ * terminal's cwd root, so the link provider's cwd-relative existence check
+ * misses it. Falling back to the worktree's own file list makes those mentions
+ * clickable. Only a UNIQUE basename match is returned — multiple files sharing
+ * a name are ambiguous and left unlinked rather than guessed.
+ */
+export async function resolveWorkspaceFileByBasename(
+  args: ResolveWorkspaceFileArgs
+): Promise<string | null> {
+  const { basename, worktreePath } = args
+  if (!basename || !worktreePath) {
+    return null
+  }
+  const connectionId = args.connectionId ?? undefined
+  const now = args.now ?? Date.now()
+  const cacheKey = `${connectionId ?? 'local'}::${worktreePath}`
+
+  let entry = workspaceFileIndexCache.get(cacheKey)
+  if (!entry || now - entry.fetchedAt > WORKSPACE_FILE_INDEX_TTL_MS) {
+    const list = args.listFiles ?? ((listArgs) => window.api.fs.listFiles(listArgs))
+    let files: string[]
+    try {
+      files = await list({ rootPath: worktreePath, ...(connectionId ? { connectionId } : {}) })
+    } catch {
+      // Best-effort: a failed listing must not break link detection.
+      return null
+    }
+    entry = { fetchedAt: now, basenameToPaths: buildBasenameIndex(files) }
+    workspaceFileIndexCache.set(cacheKey, entry)
+  }
+
+  const matches = entry.basenameToPaths.get(basename)
+  if (!matches || matches.length !== 1) {
+    return null
+  }
+  return joinAbsolutePath(worktreePath, matches[0])
+}
+
+export function __resetWorkspaceFileIndexCacheForTest(): void {
+  workspaceFileIndexCache.clear()
+}

--- a/src/renderer/src/components/terminal-pane/terminal-workspace-file-resolution.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-workspace-file-resolution.ts
@@ -1,34 +1,17 @@
 import { joinAbsolutePath } from '@/lib/terminal-path-normalization'
 
-type WorkspaceFileIndexEntry = { fetchedAt: number; basenameToPaths: Map<string, string[]> }
+type WorkspaceBasenameResolutionEntry = { fetchedAt: number; relativePath: string | null }
 
-type ListWorkspaceFiles = (args: { rootPath: string; connectionId?: string }) => Promise<string[]>
+type ResolveUniqueWorkspaceFile = (args: {
+  rootPath: string
+  basename: string
+  connectionId?: string
+}) => Promise<string | null>
 
-// Why: the link provider runs per hovered line, so cache the worktree's file
-// list (the same listing Quick Open uses) and refresh it on a short TTL rather
-// than re-listing on every lookup.
-const WORKSPACE_FILE_INDEX_TTL_MS = 15_000
-const workspaceFileIndexCache = new Map<string, WorkspaceFileIndexEntry>()
-
-function basenameOf(relativePath: string): string {
-  const normalized = relativePath.replace(/\\/g, '/')
-  const slash = normalized.lastIndexOf('/')
-  return slash === -1 ? normalized : normalized.slice(slash + 1)
-}
-
-function buildBasenameIndex(files: readonly string[]): Map<string, string[]> {
-  const index = new Map<string, string[]>()
-  for (const relativePath of files) {
-    const basename = basenameOf(relativePath)
-    const existing = index.get(basename)
-    if (existing) {
-      existing.push(relativePath)
-    } else {
-      index.set(basename, [relativePath])
-    }
-  }
-  return index
-}
+// Why: the link provider runs per hovered line; cache the tiny basename answer
+// briefly instead of re-running a local/SSH filesystem scan on every lookup.
+const WORKSPACE_BASENAME_RESOLUTION_TTL_MS = 15_000
+const workspaceBasenameResolutionCache = new Map<string, WorkspaceBasenameResolutionEntry>()
 
 export type ResolveWorkspaceFileArgs = {
   basename: string
@@ -36,7 +19,7 @@ export type ResolveWorkspaceFileArgs = {
   connectionId?: string | null
   /** Test seams. */
   now?: number
-  listFiles?: ListWorkspaceFiles
+  resolveUniqueFileByBasename?: ResolveUniqueWorkspaceFile
 }
 
 /**
@@ -45,9 +28,9 @@ export type ResolveWorkspaceFileArgs = {
  * Why (issue #5024): agent output frequently references a repo file by bare
  * name (e.g. `TerminalContextMenu.test.tsx`), which does not exist at the
  * terminal's cwd root, so the link provider's cwd-relative existence check
- * misses it. Falling back to the worktree's own file list makes those mentions
- * clickable. Only a UNIQUE basename match is returned — multiple files sharing
- * a name are ambiguous and left unlinked rather than guessed.
+ * misses it. Falling back to the worktree's basename resolver makes those
+ * mentions clickable. Only a UNIQUE basename match is returned — multiple
+ * files sharing a name are ambiguous and left unlinked rather than guessed.
  */
 export async function resolveWorkspaceFileByBasename(
   args: ResolveWorkspaceFileArgs
@@ -58,29 +41,34 @@ export async function resolveWorkspaceFileByBasename(
   }
   const connectionId = args.connectionId ?? undefined
   const now = args.now ?? Date.now()
-  const cacheKey = `${connectionId ?? 'local'}::${worktreePath}`
+  const cacheKey = `${connectionId ?? 'local'}::${worktreePath}::${basename}`
 
-  let entry = workspaceFileIndexCache.get(cacheKey)
-  if (!entry || now - entry.fetchedAt > WORKSPACE_FILE_INDEX_TTL_MS) {
-    const list = args.listFiles ?? ((listArgs) => window.api.fs.listFiles(listArgs))
-    let files: string[]
+  let entry = workspaceBasenameResolutionCache.get(cacheKey)
+  if (!entry || now - entry.fetchedAt > WORKSPACE_BASENAME_RESOLUTION_TTL_MS) {
+    const resolveUnique =
+      args.resolveUniqueFileByBasename ??
+      ((lookupArgs) => window.api.fs.resolveUniqueFileByBasename(lookupArgs))
+    let relativePath: string | null
     try {
-      files = await list({ rootPath: worktreePath, ...(connectionId ? { connectionId } : {}) })
+      relativePath = await resolveUnique({
+        rootPath: worktreePath,
+        basename,
+        ...(connectionId ? { connectionId } : {})
+      })
     } catch {
-      // Best-effort: a failed listing must not break link detection.
+      // Best-effort: a failed lookup must not break link detection.
       return null
     }
-    entry = { fetchedAt: now, basenameToPaths: buildBasenameIndex(files) }
-    workspaceFileIndexCache.set(cacheKey, entry)
+    entry = { fetchedAt: now, relativePath }
+    workspaceBasenameResolutionCache.set(cacheKey, entry)
   }
 
-  const matches = entry.basenameToPaths.get(basename)
-  if (!matches || matches.length !== 1) {
+  if (!entry.relativePath) {
     return null
   }
-  return joinAbsolutePath(worktreePath, matches[0])
+  return joinAbsolutePath(worktreePath, entry.relativePath)
 }
 
 export function __resetWorkspaceFileIndexCacheForTest(): void {
-  workspaceFileIndexCache.clear()
+  workspaceBasenameResolutionCache.clear()
 }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -39,6 +39,7 @@ import {
 import { legacyBaseRefSearchResult } from '../../../shared/base-ref-search-result'
 import { createE2EConfig } from '../../../shared/e2e-config'
 import { relativePathInsideRoot } from '../../../shared/cross-platform-path'
+import { resolveUniqueQuickOpenBasenameFromPaths } from '../../../shared/quick-open-unique-basename'
 import { LOCAL_EXECUTION_HOST_ID, normalizeExecutionHostId } from '../../../shared/execution-host'
 import { toRuntimeWorktreeSelector } from '../runtime/runtime-worktree-selector'
 import { normalizeDisabledTuiAgents } from '../../../shared/tui-agent-selection'
@@ -1376,6 +1377,20 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
         }
       )
       return result.files.map((entry) => entry.relativePath)
+    },
+    resolveUniqueFileByBasename: async ({ rootPath, basename, excludePaths }) => {
+      const file = await resolveRuntimeFilePath(rootPath)
+      const result = await callRuntimeResult<{ files: { relativePath: string }[] }>(
+        'files.listAll',
+        {
+          worktree: toRuntimeWorktreeSelector(file.worktree.id),
+          excludePaths
+        }
+      )
+      return resolveUniqueQuickOpenBasenameFromPaths(
+        result.files.map((entry) => entry.relativePath),
+        basename
+      )
     },
     search: async (args) => {
       const file = await resolveRuntimeFilePath(args.rootPath)

--- a/src/shared/quick-open-filter.test.ts
+++ b/src/shared/quick-open-filter.test.ts
@@ -87,6 +87,12 @@ describe('buildExcludePathPrefixes', () => {
     ])
   })
 
+  it('handles mixed-case UNC roots and paths', () => {
+    expect(
+      buildExcludePathPrefixes('\\\\Server\\Share\\Repo', ['//server/share/repo/packages/app'])
+    ).toEqual(['packages/app'])
+  })
+
   it('strips trailing slashes', () => {
     expect(buildExcludePathPrefixes('/r', ['/r/a/', '/r/b///'])).toEqual(['a', 'b'])
   })

--- a/src/shared/quick-open-filter.test.ts
+++ b/src/shared/quick-open-filter.test.ts
@@ -170,6 +170,19 @@ describe('buildRgArgsForQuickOpen', () => {
     // Glob metacharacters in a literal name must be escaped.
     expect(primary).toContain('!feature\\[1\\]')
   })
+
+  it('places positive include globs before exclude globs so excludes still win', () => {
+    const { primary } = buildRgArgsForQuickOpen({
+      searchRoot: '/r',
+      includeGlobs: ['**/index.ts'],
+      excludePathPrefixes: ['packages/app'],
+      forceSlashSeparator: false
+    })
+    const includeIdx = primary.indexOf('**/index.ts')
+    const excludeIdx = primary.indexOf('!packages/app')
+    expect(includeIdx).toBeGreaterThanOrEqual(0)
+    expect(excludeIdx).toBeGreaterThan(includeIdx)
+  })
 })
 
 describe('normalizeQuickOpenRgLine', () => {
@@ -259,5 +272,13 @@ describe('buildGitLsFilesArgsForQuickOpen', () => {
     expect(primary).toContain(':(exclude,glob)packages/app/**')
     expect(ignoredPass).toContain(':(exclude,glob)packages/app')
     expect(ignoredPass).toContain(':(exclude,glob)packages/app/**')
+  })
+
+  it('positive pathspecs narrow the scan while preserving excludes', () => {
+    const { primary } = buildGitLsFilesArgsForQuickOpen(['packages/app'], [':(glob)**/index.ts'])
+    const dashDashIdx = primary.indexOf('--')
+    expect(primary[dashDashIdx + 1]).toBe(':(glob)**/index.ts')
+    expect(primary).not.toContain('.')
+    expect(primary).toContain(':(exclude,glob)packages/app')
   })
 })

--- a/src/shared/quick-open-filter.ts
+++ b/src/shared/quick-open-filter.ts
@@ -11,7 +11,7 @@
  * Quick Open showed "No matching files" even though the scan was incomplete.
  * Centralizing the policy prevents future drift.
  */
-import { posix, win32 } from 'path'
+import { relativePathInsideRoot } from './cross-platform-path'
 
 // ─── Hidden-dir blocklist ────────────────────────────────────────────
 
@@ -93,24 +93,6 @@ export function shouldIncludeQuickOpenPath(path: string): boolean {
   return true
 }
 
-// ─── Path flavor detection ───────────────────────────────────────────
-
-// Why: buildExcludePathPrefixes must run correctly even when the main process
-// OS differs from the remote relay OS (macOS app talking to a Linux relay, or
-// Windows app talking to a Linux relay). path.relative from the local OS is
-// wrong for remote roots — pick win32 vs posix based on the root's shape.
-function pathFlavor(rootPath: string): typeof posix | typeof win32 {
-  // Drive letter like C:\ or C:/
-  if (/^[a-zA-Z]:[\\/]/.test(rootPath)) {
-    return win32
-  }
-  // UNC \\server\share
-  if (rootPath.startsWith('\\\\')) {
-    return win32
-  }
-  return posix
-}
-
 // ─── Exclude-path normalization ──────────────────────────────────────
 
 /**
@@ -129,27 +111,21 @@ export function buildExcludePathPrefixes(rootPath: string, excludePaths?: unknow
   if (!Array.isArray(excludePaths)) {
     return []
   }
-  const flavor = pathFlavor(rootPath)
-  // Trim trailing separators so comparison is stable.
-  const trimmedRoot = rootPath.replace(/[\\/]+$/, '')
-  const normalizedRoot = `${trimmedRoot.replace(/\\/g, '/')}/`
   const out: string[] = []
   for (const raw of excludePaths) {
     if (typeof raw !== 'string' || raw.length === 0) {
       continue
     }
-    // Fast path: input already under the root with the same separator shape.
-    const rawFwd = raw.replace(/\\/g, '/')
-    let rel: string
-    if (rawFwd === normalizedRoot.slice(0, -1)) {
-      // Root-equal — refuse to exclude the whole tree.
+    // Why: this shared module is imported by the web build, so use the pure
+    // runtime-path helper instead of Node's path APIs.
+    let rel = relativePathInsideRoot(rootPath, raw)
+    if (rel === null) {
       continue
     }
-    rel = rawFwd.startsWith(normalizedRoot)
-      ? rawFwd.slice(normalizedRoot.length)
-      : // Fall back to path-flavor relative so we do not accidentally use the
-        // local OS's semantics on remote paths.
-        flavor.relative(trimmedRoot, raw).replace(/\\/g, '/')
+    if (rel === '') {
+      // Root-equal - refuse to exclude the whole tree.
+      continue
+    }
     if (!rel || isParentRelativePath(rel) || rel.startsWith('/')) {
       continue
     }

--- a/src/shared/quick-open-filter.ts
+++ b/src/shared/quick-open-filter.ts
@@ -242,6 +242,8 @@ export type RgArgsOptions = {
   searchRoot: string
   /** Root-relative, `/`-separated prefixes (from buildExcludePathPrefixes). */
   excludePathPrefixes: readonly string[]
+  /** Optional positive rg globs that narrow the file universe before excludes. */
+  includeGlobs?: readonly string[]
   /** On Windows rg emits `\\`-separated paths; pass true to force `/` output. */
   forceSlashSeparator: boolean
 }
@@ -266,6 +268,7 @@ export type RgArgs = {
  */
 export function buildRgArgsForQuickOpen(opts: RgArgsOptions): RgArgs {
   const sepArgs = opts.forceSlashSeparator ? ['--path-separator', '/'] : []
+  const includeGlobs = (opts.includeGlobs ?? []).flatMap((glob) => ['--glob', glob])
   const hiddenDirGlobs = buildHiddenDirExcludeGlobs()
   const excludeGlobs: string[] = []
   for (const prefix of opts.excludePathPrefixes) {
@@ -279,6 +282,7 @@ export function buildRgArgsForQuickOpen(opts: RgArgsOptions): RgArgs {
     '--files',
     '--hidden',
     ...sepArgs,
+    ...includeGlobs,
     ...hiddenDirGlobs,
     ...excludeGlobs,
     opts.searchRoot
@@ -291,6 +295,7 @@ export function buildRgArgsForQuickOpen(opts: RgArgsOptions): RgArgs {
     '--hidden',
     '--no-ignore-vcs',
     ...sepArgs,
+    ...includeGlobs,
     ...hiddenDirGlobs,
     ...excludeGlobs,
     opts.searchRoot
@@ -368,14 +373,19 @@ export type GitLsFilesArgs = {
  * their existing non-git fallback limits in the callers.
  */
 export function buildGitLsFilesArgsForQuickOpen(
-  excludePathPrefixes: readonly string[] = []
+  excludePathPrefixes: readonly string[] = [],
+  positivePathspecs: readonly string[] = []
 ): GitLsFilesArgs {
   const excludeSpecs: string[] = []
   for (const prefix of excludePathPrefixes) {
     excludeSpecs.push(`:(exclude,glob)${escapeGlobPath(prefix)}`)
     excludeSpecs.push(`:(exclude,glob)${escapeGlobPath(prefix)}/**`)
   }
-  const trailingPathspecs = excludeSpecs.length > 0 ? ['--', '.', ...excludeSpecs] : []
+  const positiveSpecs = positivePathspecs.length > 0 ? [...positivePathspecs] : ['.']
+  const trailingPathspecs =
+    excludeSpecs.length > 0 || positivePathspecs.length > 0
+      ? ['--', ...positiveSpecs, ...excludeSpecs]
+      : []
 
   // Why: newline output C-quotes tabs/newlines, which makes Quick Open return
   // fake paths when rg is unavailable. NUL output preserves real Git paths.

--- a/src/shared/quick-open-unique-basename.test.ts
+++ b/src/shared/quick-open-unique-basename.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildQuickOpenBasenameGlob,
+  resolveUniqueQuickOpenBasenameFromPaths
+} from './quick-open-unique-basename'
+
+describe('quick-open unique basename resolution', () => {
+  it('returns the only matching basename', () => {
+    expect(
+      resolveUniqueQuickOpenBasenameFromPaths(
+        ['src/terminal-link-handlers.ts', 'README.md'],
+        'terminal-link-handlers.ts'
+      )
+    ).toBe('src/terminal-link-handlers.ts')
+  })
+
+  it('treats distinct same-basename paths as ambiguous while ignoring duplicate emissions', () => {
+    expect(
+      resolveUniqueQuickOpenBasenameFromPaths(
+        ['src/index.ts', 'src/index.ts', 'test/index.ts'],
+        'index.ts'
+      )
+    ).toBeNull()
+  })
+
+  it('applies Quick Open blocklists and nested-worktree exclusions', () => {
+    expect(
+      resolveUniqueQuickOpenBasenameFromPaths(
+        ['node_modules/pkg/Foo.ts', 'packages/app/Foo.ts', 'src/Foo.ts'],
+        'Foo.ts',
+        ['packages/app']
+      )
+    ).toBe('src/Foo.ts')
+  })
+
+  it('rejects parent-relative and absolute listed paths', () => {
+    expect(
+      resolveUniqueQuickOpenBasenameFromPaths(
+        ['../outside/Foo.ts', '/outside/Foo.ts', 'src/Foo.ts'],
+        'Foo.ts'
+      )
+    ).toBe('src/Foo.ts')
+  })
+
+  it('escapes glob metacharacters in basename scans', () => {
+    expect(buildQuickOpenBasenameGlob('feature[1].ts')).toBe('**/feature\\[1\\].ts')
+    expect(buildQuickOpenBasenameGlob('dir/Foo.ts')).toBeNull()
+  })
+})

--- a/src/shared/quick-open-unique-basename.ts
+++ b/src/shared/quick-open-unique-basename.ts
@@ -1,0 +1,87 @@
+import { shouldExcludeQuickOpenRelPath, shouldIncludeQuickOpenPath } from './quick-open-filter'
+
+const GLOB_META_CHARS = new Set(['*', '?', '[', ']', '{', '}', '\\'])
+
+function escapeGlobSegment(segment: string): string {
+  let out = ''
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index]
+    out += GLOB_META_CHARS.has(char) ? `\\${char}` : char
+  }
+  return out
+}
+
+function normalizeListedRelativePath(relativePath: string): string | null {
+  const normalized = relativePath.replace(/\\/g, '/')
+  if (
+    !normalized ||
+    normalized.startsWith('/') ||
+    normalized === '..' ||
+    normalized.startsWith('../')
+  ) {
+    return null
+  }
+  return normalized
+}
+
+function basenameOf(relativePath: string): string {
+  const slash = relativePath.lastIndexOf('/')
+  return slash === -1 ? relativePath : relativePath.slice(slash + 1)
+}
+
+export function buildQuickOpenBasenameGlob(basename: string): string | null {
+  if (!isSafeQuickOpenBasename(basename)) {
+    return null
+  }
+  return `**/${escapeGlobSegment(basename)}`
+}
+
+export function isSafeQuickOpenBasename(basename: string): boolean {
+  return Boolean(basename) && !basename.includes('/') && !basename.includes('\\')
+}
+
+export type UniqueQuickOpenBasenameCollector = {
+  add(relativePath: string): boolean
+  result(): string | null
+}
+
+export function createUniqueQuickOpenBasenameCollector(
+  basename: string,
+  excludePathPrefixes: readonly string[] = []
+): UniqueQuickOpenBasenameCollector {
+  const matches = new Set<string>()
+
+  return {
+    add(relativePath) {
+      const normalized = normalizeListedRelativePath(relativePath)
+      if (!normalized) {
+        return false
+      }
+      if (shouldExcludeQuickOpenRelPath(normalized, excludePathPrefixes)) {
+        return false
+      }
+      if (!shouldIncludeQuickOpenPath(normalized) || basenameOf(normalized) !== basename) {
+        return false
+      }
+      matches.add(normalized)
+      return matches.size > 1
+    },
+    result() {
+      return matches.size === 1 ? [...matches][0] : null
+    }
+  }
+}
+
+export function resolveUniqueQuickOpenBasenameFromPaths(
+  files: readonly string[],
+  basename: string,
+  excludePathPrefixes: readonly string[] = []
+): string | null {
+  const collector = createUniqueQuickOpenBasenameCollector(basename, excludePathPrefixes)
+  for (const file of files) {
+    if (collector.add(file)) {
+      return null
+    }
+  }
+  return collector.result()
+}


### PR DESCRIPTION
## Summary

Fixes #5024.

Bare filenames printed in terminal output, such as `TerminalContextMenu.test.tsx`, were only resolved relative to the terminal cwd. If the file lived deeper in the worktree, the cwd-relative existence check failed and the token was dropped as plain text.

This PR keeps the existing cwd-relative behavior first, then adds a workspace fallback only for slash-free filenames that already missed. The fallback now asks for a targeted unique-basename lookup instead of listing the entire worktree in the renderer:

- local Git worktrees use `git ls-files` with the positive pathspec `:(glob)**/<basename>`
- local non-Git worktrees with `rg` use `rg --files --glob **/<basename>`
- SSH worktrees use a relay RPC that runs the same targeted Git/rg lookup remotely
- ambiguous basenames still return `null`, so Orca never guesses between multiple `index.ts` files
- Quick Open blocklists and nested-worktree exclusions are reused by the resolver paths that receive exclusions

## Tradeoffs / regressions

No existing clickable path should become unclickable: the fallback runs only after the old cwd-relative probe has failed. Ambiguous and missing filenames still stay plain text.

The earlier caveat has been removed for current desktop local and current SSH relay paths: a cache miss no longer asks the renderer to fetch the full worktree file list. The remaining compatibility behavior is intentionally narrow:

- stale SSH relays that do not yet support `fs.resolveUniqueFileByBasename` fall back to `fs.listFiles` so the bug fix keeps working until the relay is redeployed
- the web/runtime preload shim is still list-oriented because that runtime API currently exposes list-all semantics

The web build failure from `a4542eee67` was PR-caused and is fixed in `dcec4a2177`: `quick-open-filter.ts` no longer imports Node's `path` module, and the browser-safe shared path helper preserves POSIX, Windows drive, and UNC exclusion semantics.

This does not address the separately scoped "path checked before file creation, missing result cached briefly" case from the issue thread.

## Testing

- [x] Hosted `verify` on `dcec4a2177` — passed, including lint, typecheck, tests, Build unpacked app, and Smoke packaged CLI
- [x] Hosted `wayland terminal input` on `dcec4a2177` — passed
- [x] `pnpm run build:web` — passes after the browser-safe `quick-open-filter.ts` fix
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/quick-open-filter.test.ts src/shared/quick-open-unique-basename.test.ts src/main/ipc/filesystem-basename-resolution.test.ts src/relay/fs-handler-basename-resolution.test.ts src/renderer/src/components/terminal-pane/terminal-workspace-file-resolution.test.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts` — 6 files / 126 tests passed
- [x] `pnpm exec oxlint src/shared/quick-open-filter.ts src/shared/quick-open-filter.test.ts --quiet`
- [x] `pnpm run typecheck`
- [x] Earlier full local suite on the targeted resolver change: `pnpm test` — 2082 files passed, 21286 tests passed, 3 files / 30 tests skipped

Made with [Orca](https://github.com/stablyai/orca)