### PR TITLE
fix(jira): support user-picker fields in create-issue dialog (Fixes #4643)

### DIFF
--- a/src/main/ipc/jira.ts
+++ b/src/main/ipc/jira.ts
@@ -7,6 +7,7 @@ import {
   getIssue,
   getIssueComments,
   listAssignableUsers,
+  listAssignableUsersForCreate,
   listCreateFields,
   listIssueTypes,
   listIssues,
@@ -247,6 +248,20 @@ export function registerJiraHandlers(): void {
       }
       return listAssignableUsers(
         args.key.trim(),
+        typeof args.query === 'string' ? args.query : undefined,
+        normalizeSiteId(args.siteId)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'jira:listAssignableUsersForCreate',
+    async (_event, args: { projectKeyOrId: string; query?: string; siteId?: string }) => {
+      if (typeof args?.projectKeyOrId !== 'string' || !args.projectKeyOrId.trim()) {
+        return []
+      }
+      return listAssignableUsersForCreate(
+        args.projectKeyOrId.trim(),
         typeof args.query === 'string' ? args.query : undefined,
         normalizeSiteId(args.siteId)
       )

--- a/src/main/jira/issues.test.ts
+++ b/src/main/jira/issues.test.ts
@@ -365,6 +365,51 @@ describe('Jira issue operations', () => {
     )
   })
 
+  it('lists project-scoped assignable users for create via multiProjectSearch', async () => {
+    jiraRequestMock.mockResolvedValueOnce([
+      { accountId: '5b10ac', displayName: 'Alex' },
+      { displayName: 'No account id' }
+    ])
+
+    const { listAssignableUsersForCreate } = await import('./issues')
+
+    await expect(listAssignableUsersForCreate('ORCA', 'al', 'site-1')).resolves.toEqual([
+      { accountId: '5b10ac', displayName: 'Alex', email: undefined, avatarUrl: undefined }
+    ])
+
+    const path = String(jiraRequestMock.mock.calls[0][1])
+    expect(path).toContain('/rest/api/3/user/assignable/multiProjectSearch?')
+    expect(path).toContain('projectKeys=ORCA')
+    expect(path).toContain('query=al')
+  })
+
+  it('falls back to /user/search when multiProjectSearch is unavailable (404)', async () => {
+    jiraRequestMock
+      .mockRejectedValueOnce(Object.assign(new Error('Not Found'), { status: 404 }))
+      .mockResolvedValueOnce([{ accountId: '5b10ac', displayName: 'Alex' }])
+
+    const { listAssignableUsersForCreate } = await import('./issues')
+
+    await expect(listAssignableUsersForCreate('ORCA', 'al', 'site-1')).resolves.toEqual([
+      { accountId: '5b10ac', displayName: 'Alex', email: undefined, avatarUrl: undefined }
+    ])
+
+    expect(String(jiraRequestMock.mock.calls[1][1])).toContain('/rest/api/3/user/search?')
+  })
+
+  it('clears the token and rethrows when create assignable search hits an auth error', async () => {
+    const authError = Object.assign(new Error('Unauthorized'), { status: 401 })
+    isAuthErrorMock.mockImplementation((error) => error === authError)
+    jiraRequestMock.mockRejectedValueOnce(authError)
+
+    const { listAssignableUsersForCreate } = await import('./issues')
+
+    await expect(listAssignableUsersForCreate('ORCA', undefined, 'site-1')).rejects.toThrow(
+      'Unauthorized'
+    )
+    expect(clearTokenMock).toHaveBeenCalledWith('site-1')
+  })
+
   it('maps comments from the Jira comments page key', async () => {
     jiraRequestMock.mockResolvedValueOnce({
       comments: [

--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -780,6 +780,59 @@ export async function listAssignableUsers(
   }
 }
 
+export async function listAssignableUsersForCreate(
+  projectKeyOrId: string,
+  query?: string,
+  siteId?: string | null
+): Promise<JiraUser[]> {
+  const entry = getClients(siteId)[0]
+  if (!entry) {
+    return []
+  }
+  const trimmedQuery = query?.trim() ?? ''
+  await acquire()
+  try {
+    // Why: the assignable/search endpoint needs an existing issueKey, which does
+    // not exist during create; multiProjectSearch is the project-scoped variant.
+    const multiProjectParams = new URLSearchParams({
+      projectKeys: projectKeyOrId,
+      maxResults: '50'
+    })
+    if (trimmedQuery) {
+      multiProjectParams.set('query', trimmedQuery)
+    }
+    try {
+      const response = await jiraRequest<JiraRecord[]>(
+        entry,
+        `/rest/api/3/user/assignable/multiProjectSearch?${multiProjectParams.toString()}`
+      )
+      return response.map(mapUser).filter((user): user is JiraUser => !!user)
+    } catch (error) {
+      // Why: some deployments (older/self-managed) lack multiProjectSearch; fall
+      // back to the general user search so the picker still resolves accountIds.
+      if (getErrorStatus(error) !== 404) {
+        throw error
+      }
+      const fallbackParams = new URLSearchParams({ maxResults: '50' })
+      fallbackParams.set('query', trimmedQuery)
+      const response = await jiraRequest<JiraRecord[]>(
+        entry,
+        `/rest/api/3/user/search?${fallbackParams.toString()}`
+      )
+      return response.map(mapUser).filter((user): user is JiraUser => !!user)
+    }
+  } catch (error) {
+    if (isAuthError(error)) {
+      clearToken(entry.site.id)
+      throw error
+    }
+    console.warn('[jira] listAssignableUsersForCreate failed:', error)
+    return []
+  } finally {
+    release()
+  }
+}
+
 export async function listTransitions(
   key: string,
   siteId?: string | null

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -495,6 +495,7 @@ import {
   getIssue as getJiraIssue,
   getIssueComments as getJiraIssueComments,
   listAssignableUsers as listJiraAssignableUsers,
+  listAssignableUsersForCreate as listJiraAssignableUsersForCreate,
   listCreateFields as listJiraCreateFields,
   listIssueTypes as listJiraIssueTypes,
   listIssues as listJiraIssues,
@@ -20876,6 +20877,14 @@ export class OrcaRuntimeService {
     siteId?: string
   ): ReturnType<typeof listJiraAssignableUsers> {
     return listJiraAssignableUsers(key, query, siteId)
+  }
+
+  jiraListAssignableUsersForCreate(
+    projectKeyOrId: string,
+    query?: string,
+    siteId?: string
+  ): ReturnType<typeof listJiraAssignableUsersForCreate> {
+    return listJiraAssignableUsersForCreate(projectKeyOrId, query, siteId)
   }
 
   jiraListTransitions(key: string, siteId?: string): ReturnType<typeof listJiraTransitions> {

--- a/src/main/runtime/rpc/methods/jira.test.ts
+++ b/src/main/runtime/rpc/methods/jira.test.ts
@@ -125,6 +125,7 @@ describe('jira RPC methods', () => {
       jiraListCreateFields: vi.fn().mockResolvedValue([{ key: 'customfield_10010' }]),
       jiraListPriorities: vi.fn().mockResolvedValue([{ id: 'priority-1' }]),
       jiraListAssignableUsers: vi.fn().mockResolvedValue([{ accountId: 'user-1' }]),
+      jiraListAssignableUsersForCreate: vi.fn().mockResolvedValue([{ accountId: 'user-2' }]),
       jiraListTransitions: vi.fn().mockResolvedValue([{ id: 'transition-1' }])
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: JIRA_METHODS })
@@ -149,6 +150,13 @@ describe('jira RPC methods', () => {
       })
     )
     await dispatcher.dispatch(
+      makeRequest('jira.listAssignableUsersForCreate', {
+        projectKeyOrId: 'ORCA',
+        query: 'Ada',
+        siteId: 'site-1'
+      })
+    )
+    await dispatcher.dispatch(
       makeRequest('jira.listTransitions', { key: 'ABC-3', siteId: 'site-1' })
     )
 
@@ -157,6 +165,7 @@ describe('jira RPC methods', () => {
     expect(runtime.jiraListCreateFields).toHaveBeenCalledWith('project-1', 'type-1', 'site-1')
     expect(runtime.jiraListPriorities).toHaveBeenCalledWith('site-1')
     expect(runtime.jiraListAssignableUsers).toHaveBeenCalledWith('ABC-3', 'Ada', 'site-1')
+    expect(runtime.jiraListAssignableUsersForCreate).toHaveBeenCalledWith('ORCA', 'Ada', 'site-1')
     expect(runtime.jiraListTransitions).toHaveBeenCalledWith('ABC-3', 'site-1')
   })
 })

--- a/src/main/runtime/rpc/methods/jira.ts
+++ b/src/main/runtime/rpc/methods/jira.ts
@@ -88,6 +88,12 @@ const AssignableUsers = z.object({
   siteId: OptionalString
 })
 
+const AssignableUsersForCreate = z.object({
+  projectKeyOrId: requiredString('Project is required'),
+  query: OptionalPlainString,
+  siteId: OptionalString
+})
+
 export const JIRA_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'jira.connect',
@@ -198,6 +204,16 @@ export const JIRA_METHODS: RpcMethod[] = [
     params: AssignableUsers,
     handler: async (params, { runtime }) =>
       runtime.jiraListAssignableUsers(params.key.trim(), params.query, params.siteId)
+  }),
+  defineMethod({
+    name: 'jira.listAssignableUsersForCreate',
+    params: AssignableUsersForCreate,
+    handler: async (params, { runtime }) =>
+      runtime.jiraListAssignableUsersForCreate(
+        params.projectKeyOrId.trim(),
+        params.query,
+        params.siteId
+      )
   }),
   defineMethod({
     name: 'jira.listTransitions',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1725,6 +1725,11 @@ export type PreloadApi = {
       query?: string
       siteId?: string
     }) => Promise<JiraUser[]>
+    listAssignableUsersForCreate: (args: {
+      projectKeyOrId: string
+      query?: string
+      siteId?: string
+    }) => Promise<JiraUser[]>
     listTransitions: (args: { key: string; siteId?: string }) => Promise<JiraTransition[]>
   }
   starNag: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1535,6 +1535,12 @@ const api = {
       siteId?: string
     }): Promise<unknown[]> => ipcRenderer.invoke('jira:listAssignableUsers', args),
 
+    listAssignableUsersForCreate: (args: {
+      projectKeyOrId: string
+      query?: string
+      siteId?: string
+    }): Promise<unknown[]> => ipcRenderer.invoke('jira:listAssignableUsersForCreate', args),
+
     listTransitions: (args: { key: string; siteId?: string }): Promise<unknown[]> =>
       ipcRenderer.invoke('jira:listTransitions', args)
   },

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -90,6 +90,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import TaskProjectSourceCombobox from '@/components/task-project-source-combobox'
+import JiraCreateUserPicker from '@/components/jira-create-user-picker'
 import { LinearApiKeyDialog } from '@/components/linear-api-key-dialog'
 import { LinearScopeSelector } from '@/components/linear-scope-selector'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
@@ -233,7 +234,13 @@ import {
 } from '@/components/task-page-jira-load-state'
 import { deriveTaskPagePRCheckSummary } from '@/components/task-page-pr-check-summary'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
-import { buildJiraCreateTextAdf } from '@/components/jira-create-adf'
+import {
+  buildJiraCreateCustomFields,
+  getJiraCreateAllowedValueLabel,
+  isJiraUserPickerField,
+  isMultiJiraUserPickerField,
+  isVisibleJiraCreateField
+} from '@/components/jira-create-field-value'
 import {
   GITHUB_PR_MERGE_METHOD_LABELS,
   resolveGitHubPRMergeMethods
@@ -253,6 +260,7 @@ import type {
   JiraIssue,
   JiraIssueType,
   JiraProject,
+  JiraUser,
   LinearIssue,
   LinearProjectDetail,
   LinearProjectSummary,
@@ -943,84 +951,6 @@ function compareJiraProjectsByDisplayLabel(
     return nameComparison
   }
   return jiraProjectLabelCollator.compare(a.key, b.key)
-}
-
-const JIRA_CREATE_SYSTEM_FIELD_KEYS = new Set(['project', 'issuetype', 'summary', 'description'])
-
-function isVisibleJiraCreateField(field: JiraCreateField): boolean {
-  return field.required && !JIRA_CREATE_SYSTEM_FIELD_KEYS.has(field.key)
-}
-
-function getJiraCreateAllowedValueLabel(
-  value: NonNullable<JiraCreateField['allowedValues']>[number]
-): string {
-  return value.name ?? value.value ?? value.id ?? 'Option'
-}
-
-function findJiraCreateAllowedValue(field: JiraCreateField, draftValue: string) {
-  return field.allowedValues?.find((value) => {
-    return value.id === draftValue || value.value === draftValue || value.name === draftValue
-  })
-}
-
-function getJiraCreateOptionPayload(
-  value: NonNullable<JiraCreateField['allowedValues']>[number] | undefined,
-  fallback: string
-): Record<string, string> | string {
-  if (value?.id) {
-    return { id: value.id }
-  }
-  if (value?.value) {
-    return { value: value.value }
-  }
-  if (value?.name) {
-    return { name: value.name }
-  }
-  return fallback
-}
-
-function buildJiraCreateFieldValue(field: JiraCreateField, draftValue: string): unknown {
-  const trimmed = draftValue.trim()
-  if (!trimmed) {
-    return undefined
-  }
-  if (field.schema?.type === 'array') {
-    const parts = trimmed
-      .split(',')
-      .map((part) => part.trim())
-      .filter(Boolean)
-    if (field.allowedValues?.length) {
-      return parts.map((part) =>
-        getJiraCreateOptionPayload(findJiraCreateAllowedValue(field, part), part)
-      )
-    }
-    return parts
-  }
-  if (field.allowedValues?.length) {
-    return getJiraCreateOptionPayload(findJiraCreateAllowedValue(field, trimmed), trimmed)
-  }
-  if (field.schema?.type === 'number') {
-    const numberValue = Number(trimmed)
-    return Number.isFinite(numberValue) ? numberValue : trimmed
-  }
-  if (field.schema?.custom?.includes(':textarea') || field.schema?.type === 'textarea') {
-    return buildJiraCreateTextAdf(trimmed)
-  }
-  return trimmed
-}
-
-function buildJiraCreateCustomFields(
-  fields: readonly JiraCreateField[],
-  values: Record<string, string>
-): Record<string, unknown> | undefined {
-  const customFields: Record<string, unknown> = {}
-  for (const field of fields) {
-    const value = buildJiraCreateFieldValue(field, values[field.key] ?? '')
-    if (value !== undefined) {
-      customFields[field.key] = value
-    }
-  }
-  return Object.keys(customFields).length > 0 ? customFields : undefined
 }
 
 function GHStatusCell({
@@ -5703,6 +5633,46 @@ export default function TaskPage(): React.JSX.Element {
     () => jiraCreateFields.filter(isVisibleJiraCreateField),
     [jiraCreateFields]
   )
+
+  // Why: each JiraSite carries the API-token owner's accountId; used to default
+  // required user-picker fields (e.g. Reporter) so create works with no input.
+  const newJiraIssueTokenOwner = useMemo<JiraUser | null>(() => {
+    const sites = jiraStatus.sites ?? []
+    const projectSiteId = newJiraIssueTargetProject?.siteId
+    const ownerSite =
+      (projectSiteId ? sites.find((site) => site.id === projectSiteId) : null) ??
+      selectedJiraSite ??
+      (sites.length === 1 ? sites[0] : null)
+    if (!ownerSite?.accountId) {
+      return null
+    }
+    return { accountId: ownerSite.accountId, displayName: ownerSite.displayName }
+  }, [jiraStatus.sites, newJiraIssueTargetProject, selectedJiraSite])
+
+  const newJiraIssueTokenOwnerKnownUsers = useMemo(
+    () => (newJiraIssueTokenOwner ? [newJiraIssueTokenOwner] : []),
+    [newJiraIssueTokenOwner]
+  )
+
+  // Prefill empty required user-picker fields with the token owner so a required
+  // Reporter resolves to a valid accountId without any user interaction.
+  useEffect(() => {
+    const ownerAccountId = newJiraIssueTokenOwner?.accountId
+    if (!ownerAccountId || visibleJiraCreateFields.length === 0) {
+      return
+    }
+    setNewJiraIssueCustomFieldValues((prev) => {
+      let changed = false
+      const next = { ...prev }
+      for (const field of visibleJiraCreateFields) {
+        if (isJiraUserPickerField(field) && !(prev[field.key] ?? '').trim()) {
+          next[field.key] = ownerAccountId
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [newJiraIssueTokenOwner, visibleJiraCreateFields])
 
   const hasMissingJiraCreateField = useMemo(
     () =>
@@ -12336,7 +12306,24 @@ export default function TaskPage(): React.JSX.Element {
                       <label className="text-[11px] font-medium text-muted-foreground">
                         {field.name}
                       </label>
-                      {field.allowedValues?.length && field.schema?.type !== 'array' ? (
+                      {isJiraUserPickerField(field) ? (
+                        <JiraCreateUserPicker
+                          fieldName={field.name}
+                          value={fieldValue}
+                          onChange={(value) =>
+                            setNewJiraIssueCustomFieldValues((prev) => ({
+                              ...prev,
+                              [field.key]: value
+                            }))
+                          }
+                          multiple={isMultiJiraUserPickerField(field)}
+                          projectKeyOrId={newJiraIssueTargetProject?.key ?? ''}
+                          siteId={newJiraIssueTargetProject?.siteId}
+                          runtimeSettings={jiraTaskSourceContext ?? settings}
+                          knownUsers={newJiraIssueTokenOwnerKnownUsers}
+                          disabled={newJiraIssueSubmitting}
+                        />
+                      ) : field.allowedValues?.length && field.schema?.type !== 'array' ? (
                         <Select
                           value={fieldValue}
                           onValueChange={(value) =>

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -239,7 +239,8 @@ import {
   getJiraCreateAllowedValueLabel,
   isJiraUserPickerField,
   isMultiJiraUserPickerField,
-  isVisibleJiraCreateField
+  isVisibleJiraCreateField,
+  shouldPrefillJiraCreateUserField
 } from '@/components/jira-create-field-value'
 import {
   GITHUB_PR_MERGE_METHOD_LABELS,
@@ -5634,8 +5635,8 @@ export default function TaskPage(): React.JSX.Element {
     [jiraCreateFields]
   )
 
-  // Why: each JiraSite carries the API-token owner's accountId; used to default
-  // required user-picker fields (e.g. Reporter) so create works with no input.
+  // Why: each JiraSite carries the API-token owner's accountId; Reporter can
+  // safely default to that authenticated user when Jira requires it.
   const newJiraIssueTokenOwner = useMemo<JiraUser | null>(() => {
     const sites = jiraStatus.sites ?? []
     const projectSiteId = newJiraIssueTargetProject?.siteId
@@ -5654,8 +5655,8 @@ export default function TaskPage(): React.JSX.Element {
     [newJiraIssueTokenOwner]
   )
 
-  // Prefill empty required user-picker fields with the token owner so a required
-  // Reporter resolves to a valid accountId without any user interaction.
+  // Prefill only Reporter; other required user-picker fields are semantically
+  // ambiguous, so the user should choose them explicitly.
   useEffect(() => {
     const ownerAccountId = newJiraIssueTokenOwner?.accountId
     if (!ownerAccountId || visibleJiraCreateFields.length === 0) {
@@ -5665,7 +5666,7 @@ export default function TaskPage(): React.JSX.Element {
       let changed = false
       const next = { ...prev }
       for (const field of visibleJiraCreateFields) {
-        if (isJiraUserPickerField(field) && !(prev[field.key] ?? '').trim()) {
+        if (shouldPrefillJiraCreateUserField(field) && !(prev[field.key] ?? '').trim()) {
           next[field.key] = ownerAccountId
           changed = true
         }

--- a/src/renderer/src/components/jira-create-field-value.test.ts
+++ b/src/renderer/src/components/jira-create-field-value.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildJiraCreateCustomFields,
+  buildJiraCreateFieldValue,
+  isJiraUserPickerField,
+  isMultiJiraUserPickerField
+} from './jira-create-field-value'
+import type { JiraCreateField } from '../../../shared/types'
+
+function field(overrides: Partial<JiraCreateField> = {}): JiraCreateField {
+  return {
+    key: 'reporter',
+    name: 'Reporter',
+    required: true,
+    ...overrides
+  }
+}
+
+describe('isJiraUserPickerField', () => {
+  it('detects schema.type "user"', () => {
+    expect(isJiraUserPickerField(field({ schema: { type: 'user' } }))).toBe(true)
+  })
+
+  it('detects array of users as a user picker', () => {
+    expect(isJiraUserPickerField(field({ schema: { type: 'array', items: 'user' } }))).toBe(true)
+  })
+
+  it('detects user-picker custom types', () => {
+    expect(
+      isJiraUserPickerField(
+        field({ schema: { type: 'any', custom: 'com.atlassian.jira.plugin:userpicker' } })
+      )
+    ).toBe(true)
+    expect(
+      isJiraUserPickerField(
+        field({ schema: { type: 'array', custom: 'com.atlassian.jira.plugin:multiuserpicker' } })
+      )
+    ).toBe(true)
+  })
+
+  it('is false for non-user fields', () => {
+    expect(isJiraUserPickerField(field({ schema: { type: 'string' } }))).toBe(false)
+    expect(isJiraUserPickerField(field({}))).toBe(false)
+  })
+})
+
+describe('isMultiJiraUserPickerField', () => {
+  it('is true only for array user pickers', () => {
+    expect(isMultiJiraUserPickerField(field({ schema: { type: 'array', items: 'user' } }))).toBe(
+      true
+    )
+    expect(isMultiJiraUserPickerField(field({ schema: { type: 'user' } }))).toBe(false)
+  })
+})
+
+describe('buildJiraCreateFieldValue user pickers', () => {
+  it('returns { id: accountId } for a single user-picker field', () => {
+    expect(buildJiraCreateFieldValue(field({ schema: { type: 'user' } }), '5b10ac')).toEqual({
+      id: '5b10ac'
+    })
+  })
+
+  it('trims surrounding whitespace before wrapping the accountId', () => {
+    expect(buildJiraCreateFieldValue(field({ schema: { type: 'user' } }), '  5b10ac  ')).toEqual({
+      id: '5b10ac'
+    })
+  })
+
+  it('returns an array of { id } for a multi-user-picker field', () => {
+    expect(
+      buildJiraCreateFieldValue(field({ schema: { type: 'array', items: 'user' } }), 'a1, b2 ,c3')
+    ).toEqual([{ id: 'a1' }, { id: 'b2' }, { id: 'c3' }])
+  })
+
+  it('returns undefined when the user-picker draft is empty', () => {
+    expect(buildJiraCreateFieldValue(field({ schema: { type: 'user' } }), '   ')).toBeUndefined()
+    expect(
+      buildJiraCreateFieldValue(field({ schema: { type: 'array', items: 'user' } }), '')
+    ).toBeUndefined()
+  })
+
+  it('does not regress plain string fields', () => {
+    expect(
+      buildJiraCreateFieldValue(field({ key: 'x', schema: { type: 'string' } }), 'hello')
+    ).toBe('hello')
+  })
+})
+
+describe('buildJiraCreateCustomFields', () => {
+  it('shapes a required Reporter user-picker as { reporter: { id } }', () => {
+    const fields = [field({ key: 'reporter', schema: { type: 'user' } })]
+    expect(buildJiraCreateCustomFields(fields, { reporter: '5b10ac' })).toEqual({
+      reporter: { id: '5b10ac' }
+    })
+  })
+
+  it('omits empty user-picker fields', () => {
+    const fields = [field({ key: 'reporter', schema: { type: 'user' } })]
+    expect(buildJiraCreateCustomFields(fields, { reporter: '' })).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/jira-create-field-value.test.ts
+++ b/src/renderer/src/components/jira-create-field-value.test.ts
@@ -3,7 +3,8 @@ import {
   buildJiraCreateCustomFields,
   buildJiraCreateFieldValue,
   isJiraUserPickerField,
-  isMultiJiraUserPickerField
+  isMultiJiraUserPickerField,
+  shouldPrefillJiraCreateUserField
 } from './jira-create-field-value'
 import type { JiraCreateField } from '../../../shared/types'
 
@@ -50,6 +51,36 @@ describe('isMultiJiraUserPickerField', () => {
       true
     )
     expect(isMultiJiraUserPickerField(field({ schema: { type: 'user' } }))).toBe(false)
+  })
+})
+
+describe('shouldPrefillJiraCreateUserField', () => {
+  it('only defaults required single-user Reporter fields', () => {
+    expect(shouldPrefillJiraCreateUserField(field({ schema: { type: 'user' } }))).toBe(true)
+    expect(
+      shouldPrefillJiraCreateUserField(
+        field({ key: 'Reporter', schema: { type: 'user' }, required: true })
+      )
+    ).toBe(true)
+  })
+
+  it('keeps optional, custom, assignee, and multi-user fields explicit', () => {
+    expect(
+      shouldPrefillJiraCreateUserField(field({ required: false, schema: { type: 'user' } }))
+    ).toBe(false)
+    expect(
+      shouldPrefillJiraCreateUserField(
+        field({ key: 'assignee', name: 'Assignee', schema: { type: 'user' } })
+      )
+    ).toBe(false)
+    expect(
+      shouldPrefillJiraCreateUserField(
+        field({ key: 'customfield_10001', schema: { type: 'user' } })
+      )
+    ).toBe(false)
+    expect(
+      shouldPrefillJiraCreateUserField(field({ schema: { type: 'array', items: 'user' } }))
+    ).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/jira-create-field-value.ts
+++ b/src/renderer/src/components/jira-create-field-value.ts
@@ -1,0 +1,119 @@
+import type { JiraCreateField } from '../../../shared/types'
+import { buildJiraCreateTextAdf } from '@/components/jira-create-adf'
+
+const JIRA_CREATE_SYSTEM_FIELD_KEYS = new Set(['project', 'issuetype', 'summary', 'description'])
+
+export function isVisibleJiraCreateField(field: JiraCreateField): boolean {
+  return field.required && !JIRA_CREATE_SYSTEM_FIELD_KEYS.has(field.key)
+}
+
+// Why: Jira v3 only accepts a user as { id: accountId } (display names/usernames
+// were removed in the 2019 GDPR change), so any free-text value is rejected.
+// User-picker fields carry no allowedValues, so detect them via the schema.
+const JIRA_USER_PICKER_CUSTOM_SUFFIXES = [':userpicker', ':people', ':multiuserpicker']
+
+export function isJiraUserPickerField(field: JiraCreateField): boolean {
+  const schema = field.schema
+  if (!schema) {
+    return false
+  }
+  if (schema.type === 'user') {
+    return true
+  }
+  if (schema.type === 'array' && schema.items === 'user') {
+    return true
+  }
+  const custom = schema.custom ?? ''
+  return JIRA_USER_PICKER_CUSTOM_SUFFIXES.some((suffix) => custom.includes(suffix))
+}
+
+export function isMultiJiraUserPickerField(field: JiraCreateField): boolean {
+  return (
+    field.schema?.type === 'array' &&
+    (field.schema.items === 'user' || (field.schema.custom ?? '').includes(':multiuserpicker'))
+  )
+}
+
+export function getJiraCreateAllowedValueLabel(
+  value: NonNullable<JiraCreateField['allowedValues']>[number]
+): string {
+  return value.name ?? value.value ?? value.id ?? 'Option'
+}
+
+function findJiraCreateAllowedValue(field: JiraCreateField, draftValue: string) {
+  return field.allowedValues?.find((value) => {
+    return value.id === draftValue || value.value === draftValue || value.name === draftValue
+  })
+}
+
+function getJiraCreateOptionPayload(
+  value: NonNullable<JiraCreateField['allowedValues']>[number] | undefined,
+  fallback: string
+): Record<string, string> | string {
+  if (value?.id) {
+    return { id: value.id }
+  }
+  if (value?.value) {
+    return { value: value.value }
+  }
+  if (value?.name) {
+    return { name: value.name }
+  }
+  return fallback
+}
+
+function splitCommaSeparated(value: string): string[] {
+  return value
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+}
+
+export function buildJiraCreateFieldValue(field: JiraCreateField, draftValue: string): unknown {
+  const trimmed = draftValue.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  // Why: user-picker fields store accountId(s) in the draft and Jira v3 requires
+  // the { id: accountId } shape, so this must run before the generic array path.
+  if (isJiraUserPickerField(field)) {
+    if (isMultiJiraUserPickerField(field)) {
+      return splitCommaSeparated(trimmed).map((id) => ({ id }))
+    }
+    return { id: trimmed }
+  }
+  if (field.schema?.type === 'array') {
+    const parts = splitCommaSeparated(trimmed)
+    if (field.allowedValues?.length) {
+      return parts.map((part) =>
+        getJiraCreateOptionPayload(findJiraCreateAllowedValue(field, part), part)
+      )
+    }
+    return parts
+  }
+  if (field.allowedValues?.length) {
+    return getJiraCreateOptionPayload(findJiraCreateAllowedValue(field, trimmed), trimmed)
+  }
+  if (field.schema?.type === 'number') {
+    const numberValue = Number(trimmed)
+    return Number.isFinite(numberValue) ? numberValue : trimmed
+  }
+  if (field.schema?.custom?.includes(':textarea') || field.schema?.type === 'textarea') {
+    return buildJiraCreateTextAdf(trimmed)
+  }
+  return trimmed
+}
+
+export function buildJiraCreateCustomFields(
+  fields: readonly JiraCreateField[],
+  values: Record<string, string>
+): Record<string, unknown> | undefined {
+  const customFields: Record<string, unknown> = {}
+  for (const field of fields) {
+    const value = buildJiraCreateFieldValue(field, values[field.key] ?? '')
+    if (value !== undefined) {
+      customFields[field.key] = value
+    }
+  }
+  return Object.keys(customFields).length > 0 ? customFields : undefined
+}

--- a/src/renderer/src/components/jira-create-field-value.ts
+++ b/src/renderer/src/components/jira-create-field-value.ts
@@ -34,6 +34,17 @@ export function isMultiJiraUserPickerField(field: JiraCreateField): boolean {
   )
 }
 
+export function shouldPrefillJiraCreateUserField(field: JiraCreateField): boolean {
+  // Why: the token owner is semantically safe as Reporter; custom person fields
+  // may represent approvers/reviewers and should stay explicit.
+  return (
+    field.required &&
+    field.key.trim().toLowerCase() === 'reporter' &&
+    isJiraUserPickerField(field) &&
+    !isMultiJiraUserPickerField(field)
+  )
+}
+
 export function getJiraCreateAllowedValueLabel(
   value: NonNullable<JiraCreateField['allowedValues']>[number]
 ): string {

--- a/src/renderer/src/components/jira-create-user-picker.test.ts
+++ b/src/renderer/src/components/jira-create-user-picker.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import {
+  getJiraCreateUserSearchCacheKey,
+  shouldSearchJiraCreateUsers
+} from './jira-create-user-picker'
+
+describe('shouldSearchJiraCreateUsers', () => {
+  it('requires both a query and project key before searching Jira users', () => {
+    expect(shouldSearchJiraCreateUsers('', 'ORCA')).toBe(false)
+    expect(shouldSearchJiraCreateUsers('   ', 'ORCA')).toBe(false)
+    expect(shouldSearchJiraCreateUsers('alex', '')).toBe(false)
+    expect(shouldSearchJiraCreateUsers('alex', '   ')).toBe(false)
+    expect(shouldSearchJiraCreateUsers(' alex ', ' ORCA ')).toBe(true)
+  })
+})
+
+describe('getJiraCreateUserSearchCacheKey', () => {
+  it('normalizes repeated searches within the same Jira project and site', () => {
+    expect(getJiraCreateUserSearchCacheKey(' ORCA ', ' Alex ', 'site-1')).toBe(
+      getJiraCreateUserSearchCacheKey('ORCA', 'alex', 'site-1')
+    )
+  })
+
+  it('keeps separate Jira sites distinct', () => {
+    expect(getJiraCreateUserSearchCacheKey('ORCA', 'alex', 'site-1')).not.toBe(
+      getJiraCreateUserSearchCacheKey('ORCA', 'alex', 'site-2')
+    )
+  })
+})

--- a/src/renderer/src/components/jira-create-user-picker.tsx
+++ b/src/renderer/src/components/jira-create-user-picker.tsx
@@ -1,0 +1,219 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { Check, ChevronsUpDown, LoaderCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Command, CommandInput, CommandList } from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { JiraUser } from '../../../shared/types'
+import {
+  jiraListCreateAssignableUsers,
+  type RuntimeJiraSettings
+} from '@/runtime/runtime-jira-client'
+
+// The Jira create dialog stores selected accountIds (comma-separated for the
+// multi-user variant) so the existing Record<string,string> draft shape is kept.
+const MULTI_USER_SEPARATOR = ','
+
+type JiraCreateUserPickerProps = {
+  fieldName: string
+  /** Comma-separated accountId(s) currently selected. */
+  value: string
+  onChange: (next: string) => void
+  multiple: boolean
+  projectKeyOrId: string
+  siteId?: string | null
+  runtimeSettings: RuntimeJiraSettings
+  /** Known users (e.g. the prefilled token owner) so labels resolve immediately. */
+  knownUsers?: readonly JiraUser[]
+  disabled?: boolean
+}
+
+function parseSelectedAccountIds(value: string): string[] {
+  return value
+    .split(MULTI_USER_SEPARATOR)
+    .map((id) => id.trim())
+    .filter(Boolean)
+}
+
+function mergeUsers(...sources: readonly (readonly JiraUser[])[]): JiraUser[] {
+  const byAccountId = new Map<string, JiraUser>()
+  for (const source of sources) {
+    for (const user of source) {
+      if (!byAccountId.has(user.accountId)) {
+        byAccountId.set(user.accountId, user)
+      }
+    }
+  }
+  return [...byAccountId.values()]
+}
+
+export default function JiraCreateUserPicker({
+  fieldName,
+  value,
+  onChange,
+  multiple,
+  projectKeyOrId,
+  siteId,
+  runtimeSettings,
+  knownUsers,
+  disabled
+}: JiraCreateUserPickerProps): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<JiraUser[]>([])
+  const [loading, setLoading] = useState(false)
+  const requestIdRef = useRef(0)
+
+  const selectedAccountIds = useMemo(() => parseSelectedAccountIds(value), [value])
+
+  // Why: the picker only ever holds accountIds in its draft, so resolved labels
+  // come from search results plus any users the parent already knows about.
+  const resolvedUsers = useMemo(() => mergeUsers(results, knownUsers ?? []), [knownUsers, results])
+
+  const selectedUsers = useMemo(
+    () =>
+      selectedAccountIds.map(
+        (accountId) =>
+          resolvedUsers.find((user) => user.accountId === accountId) ?? {
+            accountId,
+            displayName: accountId
+          }
+      ),
+    [resolvedUsers, selectedAccountIds]
+  )
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    requestIdRef.current += 1
+    const requestId = requestIdRef.current
+    setLoading(true)
+    // Why: debounce so typing a name does not fire a project-user search per
+    // keystroke; the runtime wrapper also guards oversized queries before RPC.
+    const timer = window.setTimeout(() => {
+      void jiraListCreateAssignableUsers(
+        runtimeSettings,
+        projectKeyOrId,
+        query || undefined,
+        siteId
+      )
+        .then((users) => {
+          if (requestId === requestIdRef.current) {
+            setResults(users)
+          }
+        })
+        .catch(() => {
+          if (requestId === requestIdRef.current) {
+            setResults([])
+          }
+        })
+        .finally(() => {
+          if (requestId === requestIdRef.current) {
+            setLoading(false)
+          }
+        })
+    }, 250)
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [open, projectKeyOrId, query, runtimeSettings, siteId])
+
+  const toggleUser = (accountId: string): void => {
+    if (!multiple) {
+      onChange(accountId)
+      setOpen(false)
+      return
+    }
+    const next = selectedAccountIds.includes(accountId)
+      ? selectedAccountIds.filter((id) => id !== accountId)
+      : [...selectedAccountIds, accountId]
+    onChange(next.join(MULTI_USER_SEPARATOR))
+  }
+
+  const triggerLabel =
+    selectedUsers.length === 0
+      ? translate('auto.components.jira.create.user.picker.select', 'Select {{value0}}', {
+          value0: fieldName
+        })
+      : selectedUsers.map((user) => user.displayName).join(', ')
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="h-9 w-full justify-between px-3 text-sm font-normal"
+        >
+          <span className={cn('truncate', selectedUsers.length === 0 && 'text-muted-foreground')}>
+            {triggerLabel}
+          </span>
+          <ChevronsUpDown className="size-3.5 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[min(360px,calc(100vw-1rem))] min-w-[var(--radix-popover-trigger-width)] p-0"
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            autoFocus
+            placeholder={translate(
+              'auto.components.jira.create.user.picker.search',
+              'Search users...'
+            )}
+            value={query}
+            onValueChange={setQuery}
+            className="text-sm"
+          />
+          <CommandList>
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 px-3 py-6 text-xs text-muted-foreground">
+                <LoaderCircle className="size-3.5 animate-spin" />
+                {translate('auto.components.jira.create.user.picker.loading', 'Searching…')}
+              </div>
+            ) : resolvedUsers.length === 0 ? (
+              <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+                {translate('auto.components.jira.create.user.picker.empty', 'No users found.')}
+              </div>
+            ) : (
+              resolvedUsers.map((user) => {
+                const selected = selectedAccountIds.includes(user.accountId)
+                return (
+                  <button
+                    key={user.accountId}
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => toggleUser(user.accountId)}
+                    className="flex w-full items-center gap-2 rounded-sm px-3 py-1.5 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                  >
+                    <Check
+                      className={cn(
+                        'size-3 text-muted-foreground',
+                        selected ? 'opacity-70' : 'opacity-0'
+                      )}
+                    />
+                    {user.avatarUrl ? (
+                      <img src={user.avatarUrl} alt="" className="size-5 rounded-full" />
+                    ) : null}
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate">{user.displayName}</div>
+                      {user.email ? (
+                        <p className="truncate text-[10px] text-muted-foreground">{user.email}</p>
+                      ) : null}
+                    </div>
+                  </button>
+                )
+              })
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/jira-create-user-picker.tsx
+++ b/src/renderer/src/components/jira-create-user-picker.tsx
@@ -14,6 +14,7 @@ import {
 // The Jira create dialog stores selected accountIds (comma-separated for the
 // multi-user variant) so the existing Record<string,string> draft shape is kept.
 const MULTI_USER_SEPARATOR = ','
+const USER_SEARCH_CACHE_LIMIT = 20
 
 type JiraCreateUserPickerProps = {
   fieldName: string
@@ -48,6 +49,32 @@ function mergeUsers(...sources: readonly (readonly JiraUser[])[]): JiraUser[] {
   return [...byAccountId.values()]
 }
 
+export function shouldSearchJiraCreateUsers(query: string, projectKeyOrId: string): boolean {
+  return Boolean(query.trim() && projectKeyOrId.trim())
+}
+
+export function getJiraCreateUserSearchCacheKey(
+  projectKeyOrId: string,
+  query: string,
+  siteId?: string | null
+): string {
+  return [siteId ?? '', projectKeyOrId.trim(), query.trim().toLowerCase()].join('\u0000')
+}
+
+function cacheJiraCreateUsers(
+  cache: Map<string, JiraUser[]>,
+  key: string,
+  users: JiraUser[]
+): void {
+  if (!cache.has(key) && cache.size >= USER_SEARCH_CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value
+    if (oldestKey !== undefined) {
+      cache.delete(oldestKey)
+    }
+  }
+  cache.set(key, users)
+}
+
 export default function JiraCreateUserPicker({
   fieldName,
   value,
@@ -64,8 +91,10 @@ export default function JiraCreateUserPicker({
   const [results, setResults] = useState<JiraUser[]>([])
   const [loading, setLoading] = useState(false)
   const requestIdRef = useRef(0)
+  const resultCacheRef = useRef(new Map<string, JiraUser[]>())
 
   const selectedAccountIds = useMemo(() => parseSelectedAccountIds(value), [value])
+  const hasSearchQuery = query.trim().length > 0
 
   // Why: the picker only ever holds accountIds in its draft, so resolved labels
   // come from search results plus any users the parent already knows about.
@@ -84,22 +113,33 @@ export default function JiraCreateUserPicker({
   )
 
   useEffect(() => {
+    requestIdRef.current += 1
     if (!open) {
+      setLoading(false)
       return
     }
-    requestIdRef.current += 1
+    if (!shouldSearchJiraCreateUsers(query, projectKeyOrId)) {
+      setLoading(false)
+      setResults([])
+      return
+    }
     const requestId = requestIdRef.current
+    const trimmedProjectKey = projectKeyOrId.trim()
+    const trimmedQuery = query.trim()
+    const cacheKey = getJiraCreateUserSearchCacheKey(trimmedProjectKey, trimmedQuery, siteId)
+    const cachedUsers = resultCacheRef.current.get(cacheKey)
+    if (cachedUsers) {
+      setLoading(false)
+      setResults(cachedUsers)
+      return
+    }
     setLoading(true)
-    // Why: debounce so typing a name does not fire a project-user search per
-    // keystroke; the runtime wrapper also guards oversized queries before RPC.
+    // Why: wait for a real query and debounce it so opening the picker or
+    // typing a name does not fire avoidable project-user searches.
     const timer = window.setTimeout(() => {
-      void jiraListCreateAssignableUsers(
-        runtimeSettings,
-        projectKeyOrId,
-        query || undefined,
-        siteId
-      )
+      void jiraListCreateAssignableUsers(runtimeSettings, trimmedProjectKey, trimmedQuery, siteId)
         .then((users) => {
+          cacheJiraCreateUsers(resultCacheRef.current, cacheKey, users)
           if (requestId === requestIdRef.current) {
             setResults(users)
           }
@@ -179,7 +219,12 @@ export default function JiraCreateUserPicker({
               </div>
             ) : resolvedUsers.length === 0 ? (
               <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-                {translate('auto.components.jira.create.user.picker.empty', 'No users found.')}
+                {hasSearchQuery
+                  ? translate('auto.components.jira.create.user.picker.empty', 'No users found.')
+                  : translate(
+                      'auto.components.jira.create.user.picker.prompt',
+                      'Type to search users.'
+                    )}
               </div>
             ) : (
               resolvedUsers.map((user) => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11738,6 +11738,16 @@
             "d785c42b8b": "Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.",
             "8388bdea2b": "Connect Jira site"
           }
+        },
+        "create": {
+          "user": {
+            "picker": {
+              "select": "Select {{value0}}",
+              "search": "Search users...",
+              "loading": "Searching…",
+              "empty": "No users found."
+            }
+          }
         }
       },
       "rightSidebar": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11745,7 +11745,8 @@
               "select": "Select {{value0}}",
               "search": "Search users...",
               "loading": "Searching…",
-              "empty": "No users found."
+              "empty": "No users found.",
+              "prompt": "Type to search users."
             }
           }
         }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11738,6 +11738,16 @@
             "d785c42b8b": "Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.",
             "8388bdea2b": "Connect Jira site"
           }
+        },
+        "create": {
+          "user": {
+            "picker": {
+              "select": "Select {{value0}}",
+              "search": "Search users...",
+              "loading": "Searching…",
+              "empty": "No users found."
+            }
+          }
         }
       },
       "rightSidebar": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11742,10 +11742,11 @@
         "create": {
           "user": {
             "picker": {
-              "select": "Select {{value0}}",
-              "search": "Search users...",
-              "loading": "Searching…",
-              "empty": "No users found."
+              "select": "Seleccionar {{value0}}",
+              "search": "Buscar usuarios...",
+              "loading": "Buscando…",
+              "empty": "No se encontraron usuarios.",
+              "prompt": "Escribe para buscar usuarios."
             }
           }
         }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11738,6 +11738,16 @@
             "d785c42b8b": "Use a Jira Cloud site URL, Atlassian email, and API token to browse issues.",
             "8388bdea2b": "Connect Jira site"
           }
+        },
+        "create": {
+          "user": {
+            "picker": {
+              "select": "Select {{value0}}",
+              "search": "Search users...",
+              "loading": "Searching…",
+              "empty": "No users found."
+            }
+          }
         }
       },
       "rightSidebar": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11742,10 +11742,11 @@
         "create": {
           "user": {
             "picker": {
-              "select": "Select {{value0}}",
-              "search": "Search users...",
-              "loading": "Searching…",
-              "empty": "No users found."
+              "select": "{{value0}}を選択",
+              "search": "ユーザーを検索...",
+              "loading": "検索中…",
+              "empty": "ユーザーが見つかりません。",
+              "prompt": "入力してユーザーを検索します。"
             }
           }
         }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11738,6 +11738,16 @@
             "d785c42b8b": "Jira Cloud 사이트 URL, Atlassian 이메일, API 토큰을 사용해 이슈를 탐색합니다.",
             "8388bdea2b": "Jira 사이트 연결"
           }
+        },
+        "create": {
+          "user": {
+            "picker": {
+              "select": "Select {{value0}}",
+              "search": "Search users...",
+              "loading": "Searching…",
+              "empty": "No users found."
+            }
+          }
         }
       },
       "rightSidebar": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11742,10 +11742,11 @@
         "create": {
           "user": {
             "picker": {
-              "select": "Select {{value0}}",
-              "search": "Search users...",
-              "loading": "Searching…",
-              "empty": "No users found."
+              "select": "{{value0}} 선택",
+              "search": "사용자 검색...",
+              "loading": "검색 중…",
+              "empty": "사용자를 찾을 수 없습니다.",
+              "prompt": "사용자를 검색하려면 입력하세요."
             }
           }
         }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11738,6 +11738,16 @@
             "d785c42b8b": "使用 Jira Cloud 站点 URL、Atlassian 邮箱和 API 令牌来浏览议题。",
             "8388bdea2b": "连接 Jira 站点"
           }
+        },
+        "create": {
+          "user": {
+            "picker": {
+              "select": "Select {{value0}}",
+              "search": "Search users...",
+              "loading": "Searching…",
+              "empty": "No users found."
+            }
+          }
         }
       },
       "rightSidebar": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11742,10 +11742,11 @@
         "create": {
           "user": {
             "picker": {
-              "select": "Select {{value0}}",
-              "search": "Search users...",
-              "loading": "Searching…",
-              "empty": "No users found."
+              "select": "选择 {{value0}}",
+              "search": "搜索用户...",
+              "loading": "正在搜索…",
+              "empty": "未找到用户。",
+              "prompt": "输入以搜索用户。"
             }
           }
         }

--- a/src/renderer/src/runtime/runtime-jira-client.test.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.test.ts
@@ -1,24 +1,40 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { jiraListAssignableUsers, jiraSearchIssues } from './runtime-jira-client'
+import {
+  jiraListAssignableUsers,
+  jiraListCreateAssignableUsers,
+  jiraSearchIssues
+} from './runtime-jira-client'
+import {
+  clearRuntimeCompatibilityCacheForTests,
+  markRuntimeEnvironmentCompatible
+} from './runtime-rpc-client'
 
 const jiraSearchIssuesLocal = vi.fn()
 const jiraListAssignableUsersLocal = vi.fn()
+const jiraListCreateAssignableUsersLocal = vi.fn()
 const runtimeCall = vi.fn()
+const runtimeEnvironmentsCall = vi.fn()
 
 beforeEach(() => {
   jiraSearchIssuesLocal.mockReset()
   jiraListAssignableUsersLocal.mockReset()
+  jiraListCreateAssignableUsersLocal.mockReset()
   runtimeCall.mockReset()
+  runtimeEnvironmentsCall.mockReset()
   vi.stubGlobal('window', {
     api: {
       jira: {
         searchIssues: jiraSearchIssuesLocal,
-        listAssignableUsers: jiraListAssignableUsersLocal
+        listAssignableUsers: jiraListAssignableUsersLocal,
+        listAssignableUsersForCreate: jiraListCreateAssignableUsersLocal
+      },
+      runtime: {
+        call: runtimeCall
       },
       runtimeEnvironments: {
-        call: runtimeCall
+        call: runtimeEnvironmentsCall
       }
     }
   })
@@ -26,6 +42,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  clearRuntimeCompatibilityCacheForTests()
 })
 
 describe('runtime Jira client search bounds', () => {
@@ -47,6 +64,53 @@ describe('runtime Jira client search bounds', () => {
     ).resolves.toEqual([])
 
     expect(jiraListAssignableUsersLocal).not.toHaveBeenCalled()
-    expect(runtimeCall).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentsCall).not.toHaveBeenCalled()
+  })
+})
+
+describe('jiraListCreateAssignableUsers', () => {
+  it('rejects oversized queries before any IPC/RPC', async () => {
+    await expect(
+      jiraListCreateAssignableUsers(null, 'ORCA', 'x'.repeat(9 * 1024), 'site-1')
+    ).resolves.toEqual([])
+
+    expect(jiraListCreateAssignableUsersLocal).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentsCall).not.toHaveBeenCalled()
+  })
+
+  it('calls the local IPC target with the project key when no runtime env is set', async () => {
+    const users = [{ accountId: '5b10ac', displayName: 'Alex' }]
+    jiraListCreateAssignableUsersLocal.mockResolvedValue(users)
+
+    await expect(jiraListCreateAssignableUsers(null, 'ORCA', 'al', 'site-1')).resolves.toEqual(
+      users
+    )
+
+    expect(jiraListCreateAssignableUsersLocal).toHaveBeenCalledWith({
+      projectKeyOrId: 'ORCA',
+      query: 'al',
+      siteId: 'site-1'
+    })
+    expect(runtimeEnvironmentsCall).not.toHaveBeenCalled()
+  })
+
+  it('routes through the runtime environment RPC when one is active', async () => {
+    const users = [{ accountId: '5b10ac', displayName: 'Alex' }]
+    runtimeEnvironmentsCall.mockResolvedValue({ ok: true, result: users })
+    // Pre-mark compatible so the call skips the status.get handshake and we can
+    // assert the single search RPC routed to the environment target.
+    markRuntimeEnvironmentCompatible('env-1')
+
+    await expect(
+      jiraListCreateAssignableUsers({ activeRuntimeEnvironmentId: 'env-1' }, 'ORCA', 'al', 'site-1')
+    ).resolves.toEqual(users)
+
+    expect(jiraListCreateAssignableUsersLocal).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentsCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'jira.listAssignableUsersForCreate',
+      params: { projectKeyOrId: 'ORCA', query: 'al', siteId: 'site-1' },
+      timeoutMs: 30_000
+    })
   })
 })

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -269,6 +269,24 @@ export async function jiraListAssignableUsers(
     : window.api.jira.listAssignableUsers(args)
 }
 
+export async function jiraListCreateAssignableUsers(
+  settings: RuntimeJiraSettings,
+  projectKeyOrId: string,
+  query?: string,
+  siteId?: string | null
+): Promise<JiraUser[]> {
+  if (!isRuntimeProviderSearchQueryWithinLimit(query)) {
+    return []
+  }
+  const target = getJiraRuntimeTarget(settings)
+  const args = { projectKeyOrId, query, siteId: siteId ?? undefined }
+  return target.kind === 'environment'
+    ? callRuntimeRpc<JiraUser[]>(target, 'jira.listAssignableUsersForCreate', args, {
+        timeoutMs: 30_000
+      })
+    : window.api.jira.listAssignableUsersForCreate(args)
+}
+
 export async function jiraListTransitions(
   settings: RuntimeJiraSettings,
   key: string,


### PR DESCRIPTION
## Impact & ELI5

**1) What's broken today.** Anyone who connects Jira with an API key and tries to create a Jira issue from Orca can hit a hard stop: Jira rejects the create request with **"Reporter is required"** even though the dialog shows a Reporter field. The field behaved like free text, but Jira Cloud v3 requires a selected user accountId object, not a typed display name or pasted string.

**2) What this PR does.** The create-issue dialog now treats Jira user fields as people-pickers. Typing in the picker searches Jira users for the target project, choosing a person stores their Jira `accountId`, and create submission sends Jira the `{ id: accountId }` shape it accepts. Required single-user **Reporter** fields are prefilled with the connected API-token owner, so the common Reporter case submits without extra work while still allowing the user to change it before creating the issue.

**3) Tradeoffs / regressions.** No known user-facing regression remains from the retry pass. The default is now scoped to the safe case only: required single-user `reporter`. Custom people fields, Assignee, and multi-user fields stay explicit, so Orca no longer silently fills ambiguous reviewer/approver-style fields. The picker also no longer performs a blank search just because it opens; it waits for a non-empty query, debounces typing, caches repeated searches for the same site/project/query, caps Jira responses at 50 users, and preserves the selected accountId label from known users.

---

## Summary

Fixes #4643

The Jira "create new issue" dialog rendered user-picker fields (Reporter, and any field whose Jira schema `type` is `user`) as a plain text `Input`, and the value-builder forwarded the raw display-name/accountId string verbatim. Jira Cloud's v3 API requires the `{ id: accountId }` object shape for users (display names and usernames were removed in the 2019 GDPR change), so a required Reporter always failed with **"Reporter is required."** There was no picker at all — just a text box that could never bind an accountId.

This adds schema-driven user-picker support end to end:

- **Detect user-picker fields** generically via the Jira schema (`type: 'user'`, `type: 'array' + items: 'user'`, or user-picker `custom` types like `:userpicker` / `:people` / `:multiuserpicker`). No hardcoded `reporter` key for detection, so assignee and custom user-pickers render as pickers too.
- **Submit the correct shape**: `buildJiraCreateFieldValue` returns `{ id: accountId }` for a single user field and `[{ id }, ...]` for a multi-user array. This logic was extracted into `jira-create-field-value.ts` so it is directly unit-testable.
- **Searchable picker UI**: `JiraCreateUserPicker` replaces the text input for user fields, waits for a real search query before calling Jira, debounces typing, caches repeated site/project/query searches, and stores selected `accountId` values in the existing `Record<string,string>` draft.
- **New project-scoped search**: `listAssignableUsersForCreate` calls `/rest/api/3/user/assignable/multiProjectSearch?projectKeys=<key>` (the create-time variant, since there is no issue key yet) with a `/rest/api/3/user/search` fallback for deployments that 404 on multiProjectSearch. This is wired through IPC, the runtime RPC registry (`jira.listAssignableUsersForCreate`), the preload surface, and the runtime wrapper, so local and SSH/remote runtime paths stay covered.
- **Safe Reporter default only**: required single-user `reporter` fields prefill with the connected site's token-owner accountId. Other user-picker fields remain empty until explicitly chosen.

## Screenshots

No screenshot of the rendered picker. A live click-through repro was not feasible in this validation environment: the dev "Demo Jira" fixture exposes no projects/create-metadata, and Electron's `contextBridge` freezes `window.api` (`Object.isFrozen(window.api.jira) === true`), so the create-fields IPC cannot be stubbed from the renderer to force a required user field to appear. The fix is proven by unit tests that exercise the load-bearing logic: schema detection, `{ id }` payload shaping, safe Reporter-only defaulting, blank-search avoidance/cache keying, project-scoped search fallback, and runtime wrapper routing.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/jira-create-field-value.test.ts src/renderer/src/components/jira-create-user-picker.test.ts src/renderer/src/runtime/runtime-jira-client.test.ts src/main/jira/issues.test.ts src/main/runtime/rpc/methods/jira.test.ts` — 5 files, 41 tests passed.
- [x] `pnpm exec oxlint <touched files>` — clean.
- [x] `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json` — clean.
- [x] `pnpm exec tsgo --noEmit -p config/tsconfig.node.json` — clean.
- [x] `pnpm run verify:localization-catalog` — locale parity clean.
- [x] `pnpm run verify:localization-coverage` — clean.
- [ ] `pnpm build`

New/updated tests:
- `src/renderer/src/components/jira-create-field-value.test.ts` — detection + `{ id }` / `[{ id }]` / `undefined` mapping, custom-field shaping, and the Reporter-only prefill predicate.
- `src/renderer/src/components/jira-create-user-picker.test.ts` — search gate requires a non-empty query and project key, and cache keys normalize repeated site/project/query searches.
- `src/renderer/src/runtime/runtime-jira-client.test.ts` — `jiraListCreateAssignableUsers` local-IPC vs environment-RPC routing and the oversized-query guard.
- `src/main/jira/issues.test.ts` — `listAssignableUsersForCreate` multiProjectSearch happy path, 404 fallback to `/user/search`, and auth-error token clearing.
- `src/main/runtime/rpc/methods/jira.test.ts` — the new `jira.listAssignableUsersForCreate` RPC routes to the runtime.

## AI Review Report

Reviewed the diff adversarially for correctness, edge cases, cross-platform behavior, and security.
- **Cross-platform (macOS/Linux/Windows)**: changes are in Jira data/IPC/RPC and the combobox; no keyboard shortcut, path separator, or shell behavior touched.
- **SSH/remote runtime**: user search routes through the same runtime RPC selection as existing Jira operations, preserving local and environment-backed paths.
- **Git provider scope**: Jira-only; no GitHub/GitLab review concepts touched.
- **Edge cases checked**: multi-user (`array+items:user`) detection runs before the generic array path; empty draft values are omitted; explicit user choices are preserved; Reporter prefill does not apply to custom/assignee/multi-user fields; blank picker opens do not hit Jira; `projectKeys` uses the project key as Jira expects.
- Extracted create-field value logic into a focused module rather than adding any new `max-lines` disable.

## Security Audit

- **IPC/RPC inputs**: the new `jira:listAssignableUsersForCreate` handler validates `projectKeyOrId` is a non-empty string and normalizes `siteId`; the RPC schema requires `projectKeyOrId` and treats `query` as an optional string. The runtime wrapper keeps the existing `isRuntimeProviderSearchQueryWithinLimit` guard before IPC/RPC.
- **No secrets/exfiltration/eval/path traversal/command execution** introduced. Query/project values are URL-encoded via `URLSearchParams`. No new dependencies.

## Notes

- Reporter defaulting uses the accountId already present on `JiraSite`; no extra `/myself` round-trip is needed.
- The `/user/search` 404 fallback is intentionally a compatibility fallback for deployments without `multiProjectSearch`; the primary path remains project-scoped.