### PR TITLE
Improve failed CI check details panel

### DIFF
--- a/src/renderer/src/components/editor/CheckRunAnnotations.tsx
+++ b/src/renderer/src/components/editor/CheckRunAnnotations.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import { ExternalLink } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import type { PRCheckAnnotation } from '../../../../shared/types'
+import {
+  cancelAnnotationRevealFrame,
+  getOpenableAnnotationLine,
+  openAnnotationLocation
+} from './check-annotation-open'
+
+export function CheckRunAnnotations({
+  annotations,
+  worktreeId
+}: {
+  annotations: PRCheckAnnotation[]
+  worktreeId: string | null
+}): React.JSX.Element {
+  const revealRafRef = React.useRef<number | null>(null)
+  const revealInnerRafRef = React.useRef<number | null>(null)
+  React.useEffect(
+    () => () => {
+      cancelAnnotationRevealFrame(revealRafRef)
+      cancelAnnotationRevealFrame(revealInnerRafRef)
+    },
+    []
+  )
+  const openAnnotation = React.useCallback(
+    (path: string, line: number) => {
+      if (!worktreeId) {
+        return
+      }
+      openAnnotationLocation({ worktreeId, path, line, revealRafRef, revealInnerRafRef })
+    },
+    [worktreeId]
+  )
+
+  return (
+    <section className="rounded-md border border-border bg-background">
+      <div className="border-b border-border px-3 py-2 text-sm font-medium">
+        {translate('auto.components.editor.CheckRunDetailsPanel.f2fe8a4e8f', 'Annotations')}
+      </div>
+      <div className="divide-y divide-border/50">
+        {annotations.map((annotation, index) => {
+          const openable = worktreeId ? getOpenableAnnotationLine(annotation) : null
+          const locationLabel = `${
+            annotation.path ??
+            translate('auto.components.editor.CheckRunDetailsPanel.cdbfda4dec', 'Annotation')
+          }${annotation.startLine ? `:${annotation.startLine}` : ''}`
+          return (
+            <div key={`${annotation.path ?? 'annotation'}-${index}`} className="px-3 py-3">
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                {openable ? (
+                  <button
+                    type="button"
+                    onClick={() => openAnnotation(openable.path, openable.line)}
+                    title={translate(
+                      'auto.components.editor.CheckRunDetailsPanel.5e2a9c3f88',
+                      'Open file at this line'
+                    )}
+                    className="group inline-flex min-w-0 items-center gap-1 break-all rounded font-mono text-xs text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <span className="min-w-0 break-all text-left">{locationLabel}</span>
+                    <ExternalLink className="size-3 shrink-0 opacity-70" />
+                  </button>
+                ) : (
+                  <span className="min-w-0 break-all font-mono text-xs text-muted-foreground">
+                    {locationLabel}
+                  </span>
+                )}
+                {annotation.annotationLevel && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {annotation.annotationLevel}
+                  </span>
+                )}
+              </div>
+              {annotation.title && (
+                <div className="mt-2 text-sm font-medium text-foreground">{annotation.title}</div>
+              )}
+              <div className="mt-2 break-words text-sm text-foreground">{annotation.message}</div>
+              {annotation.rawDetails && (
+                <pre className="mt-2 max-h-60 overflow-auto whitespace-pre-wrap rounded bg-muted/40 p-3 font-mono text-xs text-muted-foreground scrollbar-sleek">
+                  {annotation.rawDetails}
+                </pre>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/editor/CheckRunDetailsPanel.tsx
+++ b/src/renderer/src/components/editor/CheckRunDetailsPanel.tsx
@@ -4,10 +4,11 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
 import type { PRCheckDetail, PRCheckRunDetails } from '../../../../shared/types'
-import { CheckJobLogTail } from '@/components/right-sidebar/check-job-log-tail'
 import { SourceControlFixSplitButton } from '@/components/right-sidebar/source-control-fix-split-button'
 import { translate } from '@/i18n/i18n'
 import { useCheckRunDetailsFixWithAI } from './check-run-details-fix-with-ai'
+import { CheckRunAnnotations } from './CheckRunAnnotations'
+import { CheckRunJobs } from './CheckRunJobs'
 
 function formatCheckTimestamp(value: string | null | undefined): string | null {
   if (!value) {
@@ -263,95 +264,10 @@ export function CheckRunDetailsPanel({
             )}
 
             {hasAnnotations && (
-              <section className="rounded-md border border-border bg-background">
-                <div className="border-b border-border px-3 py-2 text-sm font-medium">
-                  {translate(
-                    'auto.components.editor.CheckRunDetailsPanel.f2fe8a4e8f',
-                    'Annotations'
-                  )}
-                </div>
-                <div className="divide-y divide-border/50">
-                  {details!.annotations.map((annotation, index) => (
-                    <div key={`${annotation.path ?? 'annotation'}-${index}`} className="px-3 py-3">
-                      <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        <span className="min-w-0 break-all font-mono text-xs text-muted-foreground">
-                          {annotation.path ??
-                            translate(
-                              'auto.components.editor.CheckRunDetailsPanel.cdbfda4dec',
-                              'Annotation'
-                            )}
-                          {annotation.startLine ? `:${annotation.startLine}` : ''}
-                        </span>
-                        {annotation.annotationLevel && (
-                          <span className="shrink-0 text-xs text-muted-foreground">
-                            {annotation.annotationLevel}
-                          </span>
-                        )}
-                      </div>
-                      {annotation.title && (
-                        <div className="mt-2 text-sm font-medium text-foreground">
-                          {annotation.title}
-                        </div>
-                      )}
-                      <div className="mt-2 break-words text-sm text-foreground">
-                        {annotation.message}
-                      </div>
-                      {annotation.rawDetails && (
-                        <pre className="mt-2 max-h-60 overflow-auto whitespace-pre-wrap rounded bg-muted/40 p-3 font-mono text-xs text-muted-foreground scrollbar-sleek">
-                          {annotation.rawDetails}
-                        </pre>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </section>
+              <CheckRunAnnotations annotations={details!.annotations} worktreeId={worktreeId} />
             )}
 
-            {hasJobs && (
-              <section className="rounded-md border border-border bg-background">
-                <div className="border-b border-border px-3 py-2 text-sm font-medium">
-                  {failedJobs.length > 0
-                    ? translate(
-                        'auto.components.editor.CheckRunDetailsPanel.066fedd446',
-                        'Failed jobs'
-                      )
-                    : translate('auto.components.editor.CheckRunDetailsPanel.49731703ea', 'Jobs')}
-                </div>
-                <div className="divide-y divide-border/50">
-                  {jobs.map((job, index) => (
-                    <div key={`${job.name}-${index}`} className="px-3 py-3">
-                      <div className="flex min-w-0 items-center gap-2">
-                        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                          {job.name}
-                        </span>
-                        <span className="shrink-0 text-xs text-muted-foreground">
-                          {job.conclusion ??
-                            job.status ??
-                            translate(
-                              'auto.components.editor.CheckRunDetailsPanel.ee07b33924',
-                              'unknown'
-                            )}
-                        </span>
-                      </div>
-                      {job.steps.length > 0 && (
-                        <div className="mt-2 grid gap-1">
-                          {job.steps.map((step) => (
-                            <div
-                              key={step.name}
-                              className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground"
-                            >
-                              <span className="min-w-0 flex-1 truncate">{step.name}</span>
-                              <span className="shrink-0">{step.conclusion ?? step.status}</span>
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                      {job.logTail && <CheckJobLogTail logTail={job.logTail} />}
-                    </div>
-                  ))}
-                </div>
-              </section>
-            )}
+            {hasJobs && <CheckRunJobs jobs={jobs} hasFailedJobs={failedJobs.length > 0} />}
 
             {!error && !hasOutput && !hasAnnotations && !hasJobs && (
               <div className="text-sm text-muted-foreground">

--- a/src/renderer/src/components/editor/CheckRunJobs.tsx
+++ b/src/renderer/src/components/editor/CheckRunJobs.tsx
@@ -1,0 +1,165 @@
+import React from 'react'
+import { CheckCircle2, ChevronDown, CircleDashed, MinusCircle, XCircle } from 'lucide-react'
+import { CheckJobLogTail } from '@/components/right-sidebar/check-job-log-tail'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import type { PRCheckJob, PRCheckStep } from '../../../../shared/types'
+import { resolveStepOutcome, summarizeJobSteps, type StepOutcome } from './check-job-step-status'
+
+function StepOutcomeIcon({ outcome }: { outcome: StepOutcome }): React.JSX.Element {
+  switch (outcome) {
+    case 'success':
+      return <CheckCircle2 className="size-3.5 shrink-0 text-status-success" />
+    case 'failure':
+      return <XCircle className="size-3.5 shrink-0 text-destructive" />
+    case 'skipped':
+      return <MinusCircle className="size-3.5 shrink-0 text-muted-foreground/60" />
+    case 'pending':
+      return <CircleDashed className="size-3.5 shrink-0 text-muted-foreground" />
+  }
+}
+
+function StepRow({ step }: { step: PRCheckStep }): React.JSX.Element {
+  const outcome = resolveStepOutcome(step)
+  return (
+    <div className="flex min-w-0 items-center gap-2 py-1 text-xs">
+      <StepOutcomeIcon outcome={outcome} />
+      <span
+        className={cn(
+          'min-w-0 flex-1 truncate',
+          outcome === 'skipped' ? 'text-muted-foreground' : 'text-foreground'
+        )}
+      >
+        {step.name}
+      </span>
+      <span className="shrink-0 text-muted-foreground">{step.conclusion ?? step.status}</span>
+    </div>
+  )
+}
+
+function JobCard({ job, index }: { job: PRCheckJob; index: number }): React.JSX.Element {
+  const breakdown = summarizeJobSteps(job)
+  const jobState = job.conclusion ?? job.status
+  const jobFailed =
+    jobState === 'failure' ||
+    jobState === 'failed' ||
+    jobState === 'cancelled' ||
+    jobState === 'timed_out'
+  // Failures matter most, so surface them and collapse the passing/skipped noise
+  // behind a one-line summary. With no failures there is nothing to prioritize,
+  // so expand by default rather than hiding the job's only content.
+  const collapsible = [...breakdown.succeeded, ...breakdown.skipped, ...breakdown.pending]
+  const [showRest, setShowRest] = React.useState(breakdown.failed.length === 0)
+
+  const summaryParts: string[] = []
+  if (breakdown.succeeded.length > 0) {
+    summaryParts.push(
+      `${breakdown.succeeded.length} ${translate(
+        'auto.components.editor.CheckRunJobs.1c0a4d7e02',
+        'succeeded'
+      )}`
+    )
+  }
+  if (breakdown.skipped.length > 0) {
+    summaryParts.push(
+      `${breakdown.skipped.length} ${translate(
+        'auto.components.editor.CheckRunJobs.2d3b8f1a55',
+        'skipped'
+      )}`
+    )
+  }
+  if (breakdown.pending.length > 0) {
+    summaryParts.push(
+      `${breakdown.pending.length} ${translate(
+        'auto.components.editor.CheckRunJobs.3e6c9a2b71',
+        'pending'
+      )}`
+    )
+  }
+
+  return (
+    <div key={`${job.name}-${index}`} className="px-3 py-3">
+      <div className="flex min-w-0 items-center gap-2">
+        {jobFailed ? (
+          <XCircle className="size-4 shrink-0 text-destructive" />
+        ) : (
+          <CheckCircle2 className="size-4 shrink-0 text-status-success" />
+        )}
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+          {job.name}
+        </span>
+        {breakdown.failed.length > 0 && (
+          <span className="shrink-0 rounded-full bg-destructive/15 px-2 py-0.5 text-[11px] font-medium text-destructive">
+            {breakdown.failed.length}
+            {' / '}
+            {breakdown.total}{' '}
+            {translate('auto.components.editor.CheckRunJobs.4f7d0c3e88', 'steps failed')}
+          </span>
+        )}
+      </div>
+
+      {breakdown.failed.length > 0 && (
+        <div className="mt-2 grid gap-0.5">
+          {breakdown.failed.map((step) => (
+            <StepRow key={step.name} step={step} />
+          ))}
+        </div>
+      )}
+
+      {collapsible.length > 0 && (
+        <div className="mt-1">
+          <button
+            type="button"
+            onClick={() => setShowRest((value) => !value)}
+            className="flex w-full items-center gap-1.5 rounded py-1 text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-expanded={showRest}
+          >
+            <ChevronDown
+              className={cn(
+                'size-3.5 shrink-0 transition-transform',
+                showRest ? 'rotate-0' : '-rotate-90'
+              )}
+            />
+            <span>
+              {summaryParts.join(
+                translate('auto.components.editor.CheckRunJobs.5a8e1d4f23', ' · ')
+              )}
+            </span>
+          </button>
+          {showRest && (
+            <div className="mt-0.5 grid gap-0.5 pl-5">
+              {collapsible.map((step) => (
+                <StepRow key={step.name} step={step} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {job.logTail && <CheckJobLogTail logTail={job.logTail} />}
+    </div>
+  )
+}
+
+export function CheckRunJobs({
+  jobs,
+  hasFailedJobs
+}: {
+  jobs: PRCheckJob[]
+  hasFailedJobs: boolean
+}): React.JSX.Element {
+  return (
+    <section className="rounded-md border border-border bg-background">
+      <div className="border-b border-border px-3 py-2 text-sm font-medium">
+        {hasFailedJobs
+          ? translate('auto.components.editor.CheckRunDetailsPanel.066fedd446', 'Failed jobs')
+          : translate('auto.components.editor.CheckRunDetailsPanel.49731703ea', 'Jobs')}
+      </div>
+      <div className="divide-y divide-border/50">
+        {jobs.map((job, index) => (
+          <JobCard key={`${job.name}-${index}`} job={job} index={index} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/editor/check-annotation-open.ts
+++ b/src/renderer/src/components/editor/check-annotation-open.ts
@@ -1,0 +1,80 @@
+import { detectLanguage } from '@/lib/language-detect'
+import { joinPath } from '@/lib/path'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { useAppStore } from '@/store'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import type { PRCheckAnnotation } from '../../../../shared/types'
+
+/**
+ * A CI annotation only links to the editor when its path names a real repo file
+ * at a line — not a workflow-level reference like `.github` (no extension), which
+ * has no on-disk location to reveal. Requiring a file extension keeps the
+ * affordance honest: links that wouldn't open never render.
+ */
+export function getOpenableAnnotationLine(
+  annotation: PRCheckAnnotation
+): { path: string; line: number } | null {
+  const path = annotation.path?.trim()
+  if (!path || !annotation.startLine) {
+    return null
+  }
+  const basename = path.split(/[\\/]/).pop() ?? ''
+  const hasExtension = basename.lastIndexOf('.') > 0
+  if (!hasExtension) {
+    return null
+  }
+  return { path, line: annotation.startLine }
+}
+
+export function openAnnotationLocation(params: {
+  worktreeId: string
+  path: string
+  line: number
+  revealRafRef: React.RefObject<number | null>
+  revealInnerRafRef: React.RefObject<number | null>
+}): void {
+  const { worktreeId, path, line, revealRafRef, revealInnerRafRef } = params
+  const store = useAppStore.getState()
+  const worktree = findWorktreeById(store.worktreesByRepo, worktreeId)
+  if (!worktree) {
+    return
+  }
+  const absolutePath = joinPath(worktree.path, path)
+
+  // Why: reuse the shared activation path so an annotation jump lands in the
+  // same history stack as sidebar, palette, and terminal-link navigation.
+  activateAndRevealWorktree(worktreeId)
+
+  store.openFile(
+    {
+      filePath: absolutePath,
+      relativePath: path,
+      worktreeId,
+      language: detectLanguage(path),
+      mode: 'edit'
+    },
+    { forceContentReload: true }
+  )
+
+  cancelAnnotationRevealFrame(revealRafRef)
+  cancelAnnotationRevealFrame(revealInnerRafRef)
+  store.setPendingEditorReveal(null)
+
+  // Why: opening can replace the active tab and mount Monaco asynchronously.
+  // Matching search and terminal-link navigation, wait two frames so the
+  // destination editor owns layout before we ask it to reveal the line.
+  revealRafRef.current = requestAnimationFrame(() => {
+    revealInnerRafRef.current = requestAnimationFrame(() => {
+      store.setPendingEditorReveal({ filePath: absolutePath, line, column: 1, matchLength: 0 })
+      cancelAnnotationRevealFrame(revealRafRef)
+      cancelAnnotationRevealFrame(revealInnerRafRef)
+    })
+  })
+}
+
+export function cancelAnnotationRevealFrame(frameRef: React.RefObject<number | null>): void {
+  if (frameRef.current !== null) {
+    cancelAnimationFrame(frameRef.current)
+    frameRef.current = null
+  }
+}

--- a/src/renderer/src/components/editor/check-job-step-status.test.ts
+++ b/src/renderer/src/components/editor/check-job-step-status.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { resolveStepOutcome, summarizeJobSteps } from './check-job-step-status'
+
+describe('resolveStepOutcome', () => {
+  it('prefers conclusion over status', () => {
+    expect(resolveStepOutcome({ status: 'completed', conclusion: 'failure' })).toBe('failure')
+  })
+
+  it('maps failure-like states to failure', () => {
+    for (const conclusion of ['failure', 'failed', 'cancelled', 'timed_out']) {
+      expect(resolveStepOutcome({ status: null, conclusion })).toBe('failure')
+    }
+  })
+
+  it('maps skipped and neutral to skipped', () => {
+    expect(resolveStepOutcome({ status: null, conclusion: 'skipped' })).toBe('skipped')
+    expect(resolveStepOutcome({ status: null, conclusion: 'neutral' })).toBe('skipped')
+  })
+
+  it('treats unknown or absent states as pending', () => {
+    expect(resolveStepOutcome({ status: null, conclusion: null })).toBe('pending')
+    expect(resolveStepOutcome({ status: 'in_progress', conclusion: null })).toBe('pending')
+  })
+})
+
+describe('summarizeJobSteps', () => {
+  it('buckets steps and counts the total', () => {
+    const step = (name: string, status: string | null, conclusion: string | null) => ({
+      name,
+      status,
+      conclusion,
+      startedAt: null,
+      completedAt: null
+    })
+    const breakdown = summarizeJobSteps({
+      steps: [
+        step('Typecheck', 'completed', 'failure'),
+        step('Lint', 'completed', 'success'),
+        step('Build', 'completed', 'success'),
+        step('Smoke test', 'completed', 'skipped'),
+        step('Deploy', 'queued', null)
+      ]
+    })
+    expect(breakdown.failed.map((step) => step.name)).toEqual(['Typecheck'])
+    expect(breakdown.succeeded.map((step) => step.name)).toEqual(['Lint', 'Build'])
+    expect(breakdown.skipped.map((step) => step.name)).toEqual(['Smoke test'])
+    expect(breakdown.pending.map((step) => step.name)).toEqual(['Deploy'])
+    expect(breakdown.total).toBe(5)
+  })
+})

--- a/src/renderer/src/components/editor/check-job-step-status.ts
+++ b/src/renderer/src/components/editor/check-job-step-status.ts
@@ -1,0 +1,56 @@
+import type { PRCheckJob, PRCheckStep } from '../../../../shared/types'
+
+export type StepOutcome = 'success' | 'failure' | 'skipped' | 'pending'
+
+export function resolveStepOutcome(step: Pick<PRCheckStep, 'status' | 'conclusion'>): StepOutcome {
+  switch (step.conclusion ?? step.status) {
+    case 'success':
+      return 'success'
+    case 'failure':
+    case 'failed':
+    case 'cancelled':
+    case 'timed_out':
+      return 'failure'
+    case 'skipped':
+    case 'neutral':
+      return 'skipped'
+    case null:
+    default:
+      return 'pending'
+  }
+}
+
+export type JobStepBreakdown = {
+  failed: PRCheckStep[]
+  succeeded: PRCheckStep[]
+  skipped: PRCheckStep[]
+  pending: PRCheckStep[]
+  total: number
+}
+
+export function summarizeJobSteps(job: Pick<PRCheckJob, 'steps'>): JobStepBreakdown {
+  const breakdown: JobStepBreakdown = {
+    failed: [],
+    succeeded: [],
+    skipped: [],
+    pending: [],
+    total: job.steps.length
+  }
+  for (const step of job.steps) {
+    switch (resolveStepOutcome(step)) {
+      case 'failure':
+        breakdown.failed.push(step)
+        break
+      case 'success':
+        breakdown.succeeded.push(step)
+        break
+      case 'skipped':
+        breakdown.skipped.push(step)
+        break
+      case 'pending':
+        breakdown.pending.push(step)
+        break
+    }
+  }
+  return breakdown
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11017,6 +11017,7 @@
           "d098e5529a": "Output",
           "f2fe8a4e8f": "Annotations",
           "cdbfda4dec": "Annotation",
+          "5e2a9c3f88": "Open file at this line",
           "066fedd446": "Failed jobs",
           "49731703ea": "Jobs",
           "ee07b33924": "unknown",
@@ -11028,6 +11029,13 @@
           "d5a8c2f1b9": "Start the default AI agent to fix this check",
           "e2b4d7c8a1": "Choose an agent for this check",
           "f1c9e3a6d4": "Choose agent to fix check"
+        },
+        "CheckRunJobs": {
+          "1c0a4d7e02": "succeeded",
+          "2d3b8f1a55": "skipped",
+          "3e6c9a2b71": "pending",
+          "4f7d0c3e88": "steps failed",
+          "5a8e1d4f23": " · "
         },
         "check": {
           "run": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11027,7 +11027,8 @@
           "b3e7f9a1c2": "El contexto de corrección de la comprobación no está disponible",
           "d5a8c2f1b9": "Iniciar el agente de IA predeterminado para corregir esta comprobación",
           "e2b4d7c8a1": "Elige un agente para esta comprobación",
-          "f1c9e3a6d4": "Elige un agente para corregir la comprobación"
+          "f1c9e3a6d4": "Elige un agente para corregir la comprobación",
+          "5e2a9c3f88": "Open file at this line"
         },
         "check": {
           "run": {
@@ -11048,6 +11049,13 @@
         },
         "richMarkdownLargeTextPaste": {
           "tooLarge": "El contenido pegado es demasiado grande."
+        },
+        "CheckRunJobs": {
+          "1c0a4d7e02": "succeeded",
+          "2d3b8f1a55": "skipped",
+          "3e6c9a2b71": "pending",
+          "4f7d0c3e88": "steps failed",
+          "5a8e1d4f23": " · "
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11027,7 +11027,8 @@
           "b3e7f9a1c2": "チェック修正コンテキストを利用できません",
           "d5a8c2f1b9": "既定の AI エージェントでこのチェックを修正",
           "e2b4d7c8a1": "このチェックのエージェントを選択",
-          "f1c9e3a6d4": "チェックを修正するエージェントを選択"
+          "f1c9e3a6d4": "チェックを修正するエージェントを選択",
+          "5e2a9c3f88": "Open file at this line"
         },
         "check": {
           "run": {
@@ -11048,6 +11049,13 @@
         },
         "richMarkdownLargeTextPaste": {
           "tooLarge": "貼り付け内容が大きすぎます。"
+        },
+        "CheckRunJobs": {
+          "1c0a4d7e02": "succeeded",
+          "2d3b8f1a55": "skipped",
+          "3e6c9a2b71": "pending",
+          "4f7d0c3e88": "steps failed",
+          "5a8e1d4f23": " · "
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11027,7 +11027,8 @@
           "b3e7f9a1c2": "체크 수정 컨텍스트를 사용할 수 없습니다.",
           "d5a8c2f1b9": "이 체크를 수정할 기본 AI agent 시작",
           "e2b4d7c8a1": "이 체크를 처리할 agent 선택",
-          "f1c9e3a6d4": "체크를 수정할 agent 선택"
+          "f1c9e3a6d4": "체크를 수정할 agent 선택",
+          "5e2a9c3f88": "Open file at this line"
         },
         "check": {
           "run": {
@@ -11048,6 +11049,13 @@
         },
         "richMarkdownLargeTextPaste": {
           "tooLarge": "붙여넣기 내용이 너무 큽니다."
+        },
+        "CheckRunJobs": {
+          "1c0a4d7e02": "succeeded",
+          "2d3b8f1a55": "skipped",
+          "3e6c9a2b71": "pending",
+          "4f7d0c3e88": "steps failed",
+          "5a8e1d4f23": " · "
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11027,7 +11027,8 @@
           "b3e7f9a1c2": "检查修复上下文不可用",
           "d5a8c2f1b9": "启动默认 AI 智能体来修复此检查",
           "e2b4d7c8a1": "为此检查选择智能体",
-          "f1c9e3a6d4": "选择智能体修复检查"
+          "f1c9e3a6d4": "选择智能体修复检查",
+          "5e2a9c3f88": "Open file at this line"
         },
         "check": {
           "run": {
@@ -11048,6 +11049,13 @@
         },
         "richMarkdownLargeTextPaste": {
           "tooLarge": "粘贴内容过大。"
+        },
+        "CheckRunJobs": {
+          "1c0a4d7e02": "succeeded",
+          "2d3b8f1a55": "skipped",
+          "3e6c9a2b71": "pending",
+          "4f7d0c3e88": "steps failed",
+          "5a8e1d4f23": " · "
         }
       },
       "diff": {


### PR DESCRIPTION
## Summary
Refactors and enriches the CI check details panel for failed checks.

- Extracts the **Annotations** and **Jobs** sections out of `CheckRunDetailsPanel` into focused components (`CheckRunAnnotations`, `CheckRunJobs`), shrinking the panel by ~90 lines.
- Annotation locations are now **clickable** — when an annotation points at a real repo file with a line, it renders a link that opens the file at that line, reusing the shared worktree activation + editor reveal path (`check-annotation-open.ts`). Workflow-level refs without a file extension stay non-clickable.
- Job steps are now **bucketed by outcome** (failed / succeeded / skipped / pending) with per-outcome icons. Failures are surfaced first; passing/skipped/pending steps collapse behind a one-line summary, auto-expanded only when there are no failures (`check-job-step-status.ts`).
- Adds unit tests for step outcome resolution and bucketing.
- Adds i18n keys across en/es/ja/ko/zh.

## Testing
- `pnpm typecheck` ✅
- `pnpm vitest run check-job-step-status.test.ts` ✅ (5 passed)