### PR TITLE
Improve sidebar search button styling and shortcut rendering

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -36,7 +36,7 @@ vi.mock('@/components/activity/useActivityUnreadCount', () => ({
 }))
 
 vi.mock('@/hooks/useShortcutLabel', () => ({
-  useShortcutLabel: () => '⌘P'
+  useShortcutKeyComboDetails: () => [{ keys: ['⌘', 'J'], doubleTap: false }]
 }))
 
 vi.mock('./mobile-sidebar-onboarding-badge', () => ({
@@ -271,6 +271,23 @@ describe('SidebarNav', () => {
     await clickButton(getHideButton(mobileMenu as HTMLElement))
 
     expect(mocks.updateSettings).toHaveBeenCalledWith({ showMobileButton: false })
+  })
+
+  it('hides the worktree palette shortcut until the search field is hovered or focused', async () => {
+    const container = await renderSidebarNav()
+
+    const searchButton = container.querySelector(
+      'button[aria-label="Search worktrees and browser tabs"]'
+    )
+    expect(searchButton).not.toBeNull()
+
+    const shortcuts = searchButton?.querySelector('span.hidden')
+    expect(shortcuts?.className).toContain('hidden')
+    expect(shortcuts?.className).toContain('group-hover:inline-flex')
+    expect(shortcuts?.className).toContain('group-focus-within:inline-flex')
+    expect(shortcuts?.textContent).toContain('⌘')
+    expect(shortcuts?.textContent).toContain('J')
+    expect(searchButton?.querySelector('kbd')).toBeNull()
   })
 
   it('hides task source shortcuts until the Tasks row is hovered or focused', async () => {

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -4,7 +4,8 @@ import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import type { GlobalSettings } from '../../../../shared/types'
 import { useActivityUnreadCount } from '@/components/activity/useActivityUnreadCount'
-import { useShortcutLabel } from '@/hooks/useShortcutLabel'
+import { useShortcutKeyComboDetails } from '@/hooks/useShortcutLabel'
+import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { useMobileSidebarOnboardingBadge } from './mobile-sidebar-onboarding-badge'
 import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { SetupGuideSidebarEntry } from './SetupGuideSidebarEntry'
@@ -33,7 +34,7 @@ export function shouldShowAutomationsButton(
 }
 
 const SidebarNav = React.memo(function SidebarNav() {
-  const worktreePaletteShortcut = useShortcutLabel('worktree.palette')
+  const worktreePaletteShortcutCombos = useShortcutKeyComboDetails('worktree.palette')
   const openAutomationsPage = useAppStore((s) => s.openAutomationsPage)
   const openActivityPage = useAppStore((s) => s.openActivityPage)
   const openMobilePage = useAppStore((s) => s.openMobilePage)
@@ -164,18 +165,27 @@ const SidebarNav = React.memo(function SidebarNav() {
           'auto.components.sidebar.SidebarNav.0c3395fd32',
           'Search worktrees and browser tabs'
         )}
-        className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight text-worktree-sidebar-foreground/60 transition-colors hover:bg-worktree-sidebar-foreground/8"
+        className="group relative flex h-7 w-full items-center rounded-md border border-worktree-sidebar-border/70 bg-worktree-sidebar-foreground/5 pl-7 pr-1.5 text-left text-[12px] font-medium tracking-tight text-worktree-sidebar-foreground/45 transition-colors hover:border-worktree-sidebar-border hover:bg-worktree-sidebar-foreground/8 hover:text-worktree-sidebar-foreground/60 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-worktree-sidebar-ring/50"
       >
         <Search
-          className="size-4 shrink-0 text-worktree-sidebar-foreground/30"
+          className="pointer-events-none absolute left-2 top-1/2 size-3 -translate-y-1/2 text-worktree-sidebar-foreground/30"
           strokeWidth={1.75}
         />
-        <span className="flex-1">
+        <span className="min-w-0 flex-1 truncate">
           {translate('auto.components.sidebar.SidebarNav.80611a8b10', 'Search')}
         </span>
-        <kbd className="hidden rounded border border-border/60 bg-background/40 px-1.5 py-px font-mono text-[10px] font-medium text-muted-foreground group-hover:inline-flex items-center">
-          {worktreePaletteShortcut}
-        </kbd>
+        <span className="pointer-events-none ml-1.5 hidden shrink-0 items-center group-hover:inline-flex group-focus-within:inline-flex">
+          {worktreePaletteShortcutCombos.map((combo) => (
+            <ShortcutKeyCombo
+              key={combo.keys.join('-')}
+              keys={combo.keys}
+              doubleTap={combo.doubleTap}
+              className="inline-flex gap-0.5"
+              keyCapClassName="min-w-4 border-worktree-sidebar-border/80 bg-worktree-sidebar-foreground/8 px-1 py-px text-[9px] text-worktree-sidebar-foreground/55 shadow-none"
+              separatorClassName="text-[9px] text-worktree-sidebar-foreground/45"
+            />
+          ))}
+        </span>
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary

Improves the sidebar search button styling to resemble a search input and enhances keyboard shortcut rendering.

Key Changes:
- Redesigned the search button to look like a premium text input with a border, a subtle background, and an absolute-positioned search icon.
- Migrated from the raw `useShortcutLabel` hook to `useShortcutKeyComboDetails` and the `ShortcutKeyCombo` component for richer modifier key representations.
- Hid the shortcut indicator by default, revealing it on hover or when focus is within the search button.
- Updated unit tests to assert the visibility behavior of the shortcut combo.

## Screenshots

- Add screenshots or a screen recording for any new or changed UI behavior.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Unit test `hides the worktree palette shortcut until the search field is hovered or focused` was added in `SidebarNav.test.tsx` to verify the visibility behavior.

## AI Review Report

The changes were reviewed for cross-platform visual consistency. Since key combos are handled dynamically via `ShortcutKeyCombo`, modifier keys will render correctly on macOS (⌘), Windows (Ctrl), and Linux. No other cross-platform issues detected.

## Security Audit

No security risks introduced. Changes are confined to renderer UI and presentation.

## Notes

No platform-specific notes.