### PR TITLE
Fix Windows terminal path paste in rich Markdown editor

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-paste-handler.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-paste-handler.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { handleRichMarkdownImagePaste } from './rich-markdown-paste-image'
 import { handleRichMarkdownLargeTextPaste } from './rich-markdown-large-text-paste'
+import { handleRichMarkdownTerminalPathPaste } from './rich-markdown-terminal-path-paste'
 import { handleRichMarkdownPaste } from './rich-markdown-paste-handler'
 
 vi.mock('./rich-markdown-paste-image', () => ({
@@ -11,10 +12,15 @@ vi.mock('./rich-markdown-large-text-paste', () => ({
   handleRichMarkdownLargeTextPaste: vi.fn()
 }))
 
+vi.mock('./rich-markdown-terminal-path-paste', () => ({
+  handleRichMarkdownTerminalPathPaste: vi.fn()
+}))
+
 describe('rich markdown paste handler', () => {
   beforeEach(() => {
     vi.mocked(handleRichMarkdownImagePaste).mockReset()
     vi.mocked(handleRichMarkdownLargeTextPaste).mockReset()
+    vi.mocked(handleRichMarkdownTerminalPathPaste).mockReset()
   })
 
   it('keeps image paste ownership ahead of large text fallback', () => {
@@ -38,11 +44,32 @@ describe('rich markdown paste handler', () => {
       worktreeId: 'wt-1',
       runtimeEnvironmentId: undefined
     })
+    expect(handleRichMarkdownTerminalPathPaste).not.toHaveBeenCalled()
+    expect(handleRichMarkdownLargeTextPaste).not.toHaveBeenCalled()
+  })
+
+  it('keeps terminal path paste ahead of large text fallback', () => {
+    vi.mocked(handleRichMarkdownImagePaste).mockReturnValue(false)
+    vi.mocked(handleRichMarkdownTerminalPathPaste).mockReturnValue(true)
+    const editor = {} as never
+    const event = {} as ClipboardEvent
+
+    expect(
+      handleRichMarkdownPaste({
+        editor,
+        event,
+        filePath: '/repo/note.md',
+        worktreeId: 'wt-1'
+      })
+    ).toBe(true)
+
+    expect(handleRichMarkdownTerminalPathPaste).toHaveBeenCalledWith(editor, event)
     expect(handleRichMarkdownLargeTextPaste).not.toHaveBeenCalled()
   })
 
   it('falls through to large text handling when image paste declines ownership', () => {
     vi.mocked(handleRichMarkdownImagePaste).mockReturnValue(false)
+    vi.mocked(handleRichMarkdownTerminalPathPaste).mockReturnValue(false)
     vi.mocked(handleRichMarkdownLargeTextPaste).mockReturnValue(true)
     const editor = {} as never
     const event = {} as ClipboardEvent

--- a/src/renderer/src/components/editor/rich-markdown-paste-handler.ts
+++ b/src/renderer/src/components/editor/rich-markdown-paste-handler.ts
@@ -1,6 +1,7 @@
 import type { Editor } from '@tiptap/react'
 import { handleRichMarkdownImagePaste } from './rich-markdown-paste-image'
 import { handleRichMarkdownLargeTextPaste } from './rich-markdown-large-text-paste'
+import { handleRichMarkdownTerminalPathPaste } from './rich-markdown-terminal-path-paste'
 
 export type RichMarkdownPasteHandlerArgs = {
   editor: Editor | null
@@ -26,6 +27,10 @@ export function handleRichMarkdownPaste({
       runtimeEnvironmentId
     })
   ) {
+    return true
+  }
+
+  if (handleRichMarkdownTerminalPathPaste(editor, event)) {
     return true
   }
 

--- a/src/renderer/src/components/editor/rich-markdown-terminal-path-paste.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-terminal-path-paste.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import type { Editor } from '@tiptap/react'
+import { describe, expect, it } from 'vitest'
+import {
+  handleRichMarkdownTerminalPathPaste,
+  shouldPasteTerminalWindowsPathAsPlainText
+} from './rich-markdown-terminal-path-paste'
+
+type InsertTransaction = { text: string }
+
+function makePasteEvent(text: string, html = ''): ClipboardEvent {
+  const event = new Event('paste', {
+    bubbles: true,
+    cancelable: true
+  }) as ClipboardEvent
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      getData: (type: string) => (type === 'text/plain' ? text : type === 'text/html' ? html : '')
+    }
+  })
+  return event
+}
+
+function makeEditor(): { editor: Editor; inserted: string[] } {
+  const inserted: string[] = []
+  const editor = {
+    get state() {
+      return {
+        tr: {
+          insertText: (text: string): InsertTransaction => ({ text })
+        }
+      }
+    },
+    view: {
+      dispatch: (transaction: InsertTransaction): void => {
+        inserted.push(transaction.text)
+      }
+    }
+  } as unknown as Editor
+
+  return { editor, inserted }
+}
+
+describe('rich markdown terminal path paste', () => {
+  it('detects terminal-style HTML links that would lose a Windows path', () => {
+    expect(
+      shouldPasteTerminalWindowsPathAsPlainText({
+        plainText: 'Read C:\\Users\\neil\\.claude\\CLAUDE.md before editing.',
+        htmlText:
+          '<span>Read C:\\Users\\neil\\.claude\\</span><a href="http://CLAUDE.md">CLAUDE.md</a>'
+      })
+    ).toBe(true)
+  })
+
+  it('does not claim ordinary links or non-Windows paths', () => {
+    expect(
+      shouldPasteTerminalWindowsPathAsPlainText({
+        plainText: 'Open CLAUDE.md at https://example.test/CLAUDE.md',
+        htmlText: '<a href="https://example.test/CLAUDE.md">CLAUDE.md</a>'
+      })
+    ).toBe(false)
+    expect(
+      shouldPasteTerminalWindowsPathAsPlainText({
+        plainText: '/Users/neil/.claude/CLAUDE.md',
+        htmlText: '<a href="http://CLAUDE.md">CLAUDE.md</a>'
+      })
+    ).toBe(false)
+  })
+
+  it('inserts the plain clipboard text before TipTap can preserve broken link metadata', () => {
+    const { editor, inserted } = makeEditor()
+    const text = 'C:\\Users\\neil\\.claude\\CLAUDE.md'
+    const event = makePasteEvent(text, '<a href="http://CLAUDE.md">CLAUDE.md</a>')
+
+    expect(handleRichMarkdownTerminalPathPaste(editor, event)).toBe(true)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(inserted).toEqual([text])
+  })
+
+  it('falls through when the HTML link does not target the path basename', () => {
+    const { editor, inserted } = makeEditor()
+    const event = makePasteEvent(
+      'C:\\Users\\neil\\.claude\\CLAUDE.md',
+      '<a href="https://docs.example.test/config">CLAUDE.md</a>'
+    )
+
+    expect(handleRichMarkdownTerminalPathPaste(editor, event)).toBe(false)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(inserted).toEqual([])
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-terminal-path-paste.ts
+++ b/src/renderer/src/components/editor/rich-markdown-terminal-path-paste.ts
@@ -1,0 +1,94 @@
+import type { Editor } from '@tiptap/react'
+
+type ClipboardAnchor = {
+  href: string
+}
+
+const WINDOWS_ABSOLUTE_PATH_PATTERN =
+  /(?:[A-Za-z]:[\\/][^\s<>"|?*\r\n]+|\\\\[^\s\\/:*?"<>|\r\n]+\\[^\s\\/:*?"<>|\r\n]+(?:\\[^\s<>"|?*\r\n]+)*)/g
+
+function readClipboardText(event: ClipboardEvent, type: string): string {
+  return event.clipboardData?.getData(type) ?? ''
+}
+
+function getWindowsPathBasename(filePath: string): string {
+  const normalized = filePath.replaceAll('/', '\\')
+  const separatorIndex = normalized.lastIndexOf('\\')
+  return separatorIndex >= 0 ? normalized.slice(separatorIndex + 1) : normalized
+}
+
+function extractClipboardAnchors(html: string): ClipboardAnchor[] {
+  if (!html || typeof DOMParser === 'undefined') {
+    return []
+  }
+
+  const document = new DOMParser().parseFromString(html, 'text/html')
+  return Array.from(document.querySelectorAll('a[href]'), (anchor) => ({
+    href: anchor.getAttribute('href') ?? ''
+  }))
+}
+
+function hrefPointsAtPathBasename(href: string, basename: string): boolean {
+  if (!href || !basename) {
+    return false
+  }
+
+  try {
+    const url = new URL(href)
+    return url.protocol.startsWith('http') && url.hostname.toLowerCase() === basename.toLowerCase()
+  } catch {
+    return false
+  }
+}
+
+export function shouldPasteTerminalWindowsPathAsPlainText({
+  plainText,
+  htmlText
+}: {
+  plainText: string
+  htmlText: string
+}): boolean {
+  const paths = Array.from(plainText.matchAll(WINDOWS_ABSOLUTE_PATH_PATTERN), (match) => match[0])
+  if (paths.length === 0) {
+    return false
+  }
+
+  const anchors = extractClipboardAnchors(htmlText)
+  if (anchors.length === 0) {
+    return false
+  }
+
+  return paths.some((filePath) => {
+    const basename = getWindowsPathBasename(filePath)
+    return anchors.some((anchor) => hrefPointsAtPathBasename(anchor.href, basename))
+  })
+}
+
+export function handleRichMarkdownTerminalPathPaste(
+  editor: Editor | null,
+  event: ClipboardEvent
+): boolean {
+  if (event.defaultPrevented || !editor) {
+    return false
+  }
+
+  const plainText = readClipboardText(event, 'text/plain')
+  if (!plainText) {
+    return false
+  }
+
+  if (
+    !shouldPasteTerminalWindowsPathAsPlainText({
+      plainText,
+      htmlText: readClipboardText(event, 'text/html')
+    })
+  ) {
+    return false
+  }
+
+  event.preventDefault()
+  // Why: terminal link metadata can point at a synthetic basename URL; the
+  // clipboard plain text is the only source that keeps the Windows path intact.
+  editor.view.dispatch(editor.state.tr.insertText(plainText))
+  return true
+}


### PR DESCRIPTION
## Summary
- preserve plain Windows paths pasted from terminal rich link selections into the rich Markdown editor
- detect synthetic basename HTTP links in clipboard HTML before TipTap serializes them as broken Markdown links
- add focused regression coverage for the issue shape and paste handler ordering

Fixes #5359

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-terminal-path-paste.test.ts src/renderer/src/components/editor/rich-markdown-paste-handler.test.ts
- pnpm typecheck
- pnpm lint