### PR TITLE
fix(runtime): render remote-server binary files (PDF/images) in the editor

### DIFF
--- a/src/renderer/src/runtime/runtime-file-client.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client.test.ts
@@ -345,6 +345,31 @@ describe('runtime file client', () => {
     )
   })
 
+  it('does not fall back when a non-RPC error merely shares the binary_file message', async () => {
+    // Why: only a typed RuntimeRpcCallError('binary_file') means the server
+    // classified the file as binary. A transport-level failure that happens to
+    // carry the same message text must propagate, not trigger a preview read.
+    runtimeEnvironmentCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'files.read') {
+        return Promise.reject(new Error('binary_file'))
+      }
+      throw new Error('files.readPreview should not be called')
+    })
+
+    await expect(
+      readRuntimeFileContent({
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        filePath: '/remote/repo/doc.pdf',
+        relativePath: 'doc.pdf',
+        worktreeId: 'wt-1'
+      })
+    ).rejects.toThrow('binary_file')
+
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'files.readPreview' })
+    )
+  })
+
   it('uses the active runtime id as the dedupe scope', () => {
     expect(getRuntimeFileReadScope({ activeRuntimeEnvironmentId: 'env-1' }, 'ssh-1')).toBe(
       'runtime:env-1'

--- a/src/renderer/src/runtime/runtime-file-client.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client.test.ts
@@ -313,6 +313,38 @@ describe('runtime file client', () => {
     )
   })
 
+  it('propagates a files.readPreview failure during the binary fallback', async () => {
+    runtimeEnvironmentCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'files.read') {
+        return Promise.resolve({
+          id: 'rpc-read',
+          ok: false,
+          error: { code: 'runtime_error', message: 'binary_file' },
+          _meta: { runtimeId: 'remote-runtime' }
+        })
+      }
+      return Promise.resolve({
+        id: 'rpc-preview',
+        ok: false,
+        error: { code: 'runtime_error', message: 'file_too_large' },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+
+    await expect(
+      readRuntimeFileContent({
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        filePath: '/remote/repo/huge.pdf',
+        relativePath: 'huge.pdf',
+        worktreeId: 'wt-1'
+      })
+    ).rejects.toThrow('file_too_large')
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'files.readPreview' })
+    )
+  })
+
   it('uses the active runtime id as the dedupe scope', () => {
     expect(getRuntimeFileReadScope({ activeRuntimeEnvironmentId: 'env-1' }, 'ssh-1')).toBe(
       'runtime:env-1'

--- a/src/renderer/src/runtime/runtime-file-client.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client.test.ts
@@ -235,6 +235,84 @@ describe('runtime file client', () => {
     ).rejects.toThrow('Remote file is too large to open in the editor')
   })
 
+  it('falls back to files.readPreview when a remote binary file is opened', async () => {
+    runtimeEnvironmentCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'files.read') {
+        return Promise.resolve({
+          id: 'rpc-read',
+          ok: false,
+          error: { code: 'runtime_error', message: 'binary_file' },
+          _meta: { runtimeId: 'remote-runtime' }
+        })
+      }
+      return Promise.resolve({
+        id: 'rpc-preview',
+        ok: true,
+        result: {
+          content: 'JVBERi0=',
+          isBinary: true,
+          isImage: true,
+          mimeType: 'application/pdf'
+        },
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+
+    await expect(
+      readRuntimeFileContent({
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        filePath: '/remote/repo/doc.pdf',
+        relativePath: 'doc.pdf',
+        worktreeId: 'wt-1'
+      })
+    ).resolves.toEqual({
+      content: 'JVBERi0=',
+      isBinary: true,
+      isImage: true,
+      mimeType: 'application/pdf'
+    })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'files.read',
+      params: { worktree: 'id:wt-1', relativePath: 'doc.pdf' },
+      timeoutMs: 15_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'files.readPreview',
+      params: { worktree: 'id:wt-1', relativePath: 'doc.pdf' },
+      timeoutMs: 15_000
+    })
+  })
+
+  it('does not fall back to files.readPreview for non-binary remote read errors', async () => {
+    runtimeEnvironmentCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'files.read') {
+        return Promise.resolve({
+          id: 'rpc-read',
+          ok: false,
+          error: { code: 'runtime_error', message: 'permission_denied' },
+          _meta: { runtimeId: 'remote-runtime' }
+        })
+      }
+      throw new Error('files.readPreview should not be called')
+    })
+
+    await expect(
+      readRuntimeFileContent({
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        filePath: '/remote/repo/secret.txt',
+        relativePath: 'secret.txt',
+        worktreeId: 'wt-1'
+      })
+    ).rejects.toThrow('permission_denied')
+
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'files.readPreview' })
+    )
+  })
+
   it('uses the active runtime id as the dedupe scope', () => {
     expect(getRuntimeFileReadScope({ activeRuntimeEnvironmentId: 'env-1' }, 'ssh-1')).toBe(
       'runtime:env-1'

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -17,6 +17,7 @@ import type {
 import {
   callRuntimeRpc,
   getActiveRuntimeTarget,
+  RuntimeRpcCallError,
   unwrapRuntimeRpcResult
 } from './runtime-rpc-client'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
@@ -156,23 +157,21 @@ export async function readRuntimeFileContent({
   }
 
   const worktree = toRuntimeWorktreeSelector(worktreeId)
+  let result: RuntimeFileReadResult
   try {
-    const result = await callRuntimeRpc<RuntimeFileReadResult>(
+    result = await callRuntimeRpc<RuntimeFileReadResult>(
       target,
       'files.read',
       { worktree, relativePath },
       { timeoutMs: 15_000 }
     )
-    if (result.truncated) {
-      // Why: the runtime file RPC is preview-sized today; treating a truncated
-      // payload as editable content would make saves overwrite the rest of the file.
-      throw new Error(`Remote file is too large to open in the editor (${result.byteLength} bytes)`)
-    }
-    return { content: result.content, isBinary: false }
   } catch (err) {
-    // Why: files.read rejects binary paths (PDFs/images) with 'binary_file'. Fetch
-    // the previewable base64 payload so the editor renders them like local/SSH do.
-    if (err instanceof Error && err.message === 'binary_file') {
+    // Why: files.read (readMobileFile) rejects binary paths — PDFs/images/etc —
+    // with the exact runtime error code 'binary_file'. Fetch the previewable
+    // base64 payload via files.readPreview so the editor renders them like the
+    // local/SSH paths do, keeping the server as the single binary-detection
+    // authority. Match the typed RPC error so an unrelated failure can't spoof it.
+    if (err instanceof RuntimeRpcCallError && err.message === 'binary_file') {
       return callRuntimeRpc<RuntimeFilePreviewResult>(
         target,
         'files.readPreview',
@@ -182,6 +181,12 @@ export async function readRuntimeFileContent({
     }
     throw err
   }
+  if (result.truncated) {
+    // Why: the runtime file RPC is preview-sized today; treating a truncated
+    // payload as editable content would make saves overwrite the rest of the file.
+    throw new Error(`Remote file is too large to open in the editor (${result.byteLength} bytes)`)
+  }
+  return { content: result.content, isBinary: false }
 }
 
 export async function readRuntimeFilePreview(

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -155,18 +155,33 @@ export async function readRuntimeFileContent({
     throw new Error('Remote file is outside the owning runtime worktree')
   }
 
-  const result = await callRuntimeRpc<RuntimeFileReadResult>(
-    target,
-    'files.read',
-    { worktree: toRuntimeWorktreeSelector(worktreeId), relativePath },
-    { timeoutMs: 15_000 }
-  )
-  if (result.truncated) {
-    // Why: the runtime file RPC is preview-sized today; treating a truncated
-    // payload as editable content would make saves overwrite the rest of the file.
-    throw new Error(`Remote file is too large to open in the editor (${result.byteLength} bytes)`)
+  const worktree = toRuntimeWorktreeSelector(worktreeId)
+  try {
+    const result = await callRuntimeRpc<RuntimeFileReadResult>(
+      target,
+      'files.read',
+      { worktree, relativePath },
+      { timeoutMs: 15_000 }
+    )
+    if (result.truncated) {
+      // Why: the runtime file RPC is preview-sized today; treating a truncated
+      // payload as editable content would make saves overwrite the rest of the file.
+      throw new Error(`Remote file is too large to open in the editor (${result.byteLength} bytes)`)
+    }
+    return { content: result.content, isBinary: false }
+  } catch (err) {
+    // Why: files.read rejects binary paths (PDFs/images) with 'binary_file'. Fetch
+    // the previewable base64 payload so the editor renders them like local/SSH do.
+    if (err instanceof Error && err.message === 'binary_file') {
+      return callRuntimeRpc<RuntimeFilePreviewResult>(
+        target,
+        'files.readPreview',
+        { worktree, relativePath },
+        { timeoutMs: 15_000 }
+      )
+    }
+    throw err
   }
-  return { content: result.content, isBinary: false }
 }
 
 export async function readRuntimeFilePreview(


### PR DESCRIPTION
## Summary

Binary files (PDF, images) failed to render in the editor when connected to a **remote-server runtime environment** (the feature labeled "remote server" in the UI). They render fine locally and over SSH.

### Root cause

The editor loads file content through `readRuntimeFileContent` (`src/renderer/src/runtime/runtime-file-client.ts`). Routing differs per target:

- **Local / SSH**: `window.api.fs.readFile(...)` returns full binary metadata `{ content (base64), isBinary, isImage, mimeType }` → PDFs/images render.
- **Remote server**: uses the `files.read` RPC → `readMobileFile`, which **throws `binary_file`** for previewable binaries (`.pdf`/images are in `MOBILE_BINARY_EXTENSIONS`) and the client hardcoded `isBinary: false`. The error became a `loadError`, so the file never reached `ImageViewer`/`PdfViewer`.

A sibling RPC already does the right thing: `files.readPreview` → `readFileExplorerPreview` returns `{ content (base64), isBinary, isImage, mimeType }` for local, SSH, **and** environment runtimes.

### Fix

When `files.read` rejects a binary path with `binary_file`, fall back to the binary-capable `files.readPreview` RPC and return its payload. This keeps the **server as the single source of truth** for binary detection (no duplicated extension list) and reuses the existing preview path — matching local/SSH behavior.

Non-previewable binaries (e.g. `.zip`, `.mp4`) now show the clean "Binary file — cannot display" message instead of a load error. Text editing is unchanged.

## Test plan

- [x] `runtime-file-client.test.ts`: added a case asserting a remote binary read falls back to `files.readPreview`, and a case asserting non-`binary_file` errors do **not** fall back. All 38 tests pass.
- [x] `typecheck:web` clean, `oxlint` clean on changed files.
- [ ] Manual: connect to a remote-server runtime environment; open a `.pdf` and `.png` (render), a `.zip` (clean binary message), and a text file (still editable).
