### PR TITLE
fix(terminal): keep OMP subcommands extension-free

### DIFF
--- a/src/main/pty/omp-shell-wrapper.node-pty.test.ts
+++ b/src/main/pty/omp-shell-wrapper.node-pty.test.ts
@@ -210,6 +210,61 @@ exit 0
     expect(readFileSync(join(sourceDir, 'config.yml'), 'utf8')).toBe('updated-by-omp-config\n')
   })
 
+  itWithBash.each([
+    '__complete',
+    'bench',
+    'completions',
+    'dry-balance',
+    'gallery',
+    'install',
+    'join',
+    'models',
+    'say',
+    'tiny-models',
+    'token',
+    'ttsr',
+    'usage'
+  ])('runs OMP %s subcommands without injecting the status extension', async (subcommand) => {
+    const tempDir = makeTempDir()
+    const binDir = join(tempDir, 'bin')
+    const sourceDir = join(tempDir, 'source-omp-agent')
+    const extensionDir = join(sourceDir, 'extensions')
+    mkdirSync(binDir)
+    mkdirSync(sourceDir, { recursive: true })
+    mkdirSync(extensionDir, { recursive: true })
+    const statusExtension = join(extensionDir, 'orca-agent-status.ts')
+    writeFileSync(statusExtension, 'export default {}')
+    writeFakeOmp(binDir)
+
+    const captureFile = join(tempDir, `${subcommand}-capture`)
+    await runInteractiveBashPty({
+      cwd: tempDir,
+      rcfileContent: getPosixOmpShellWrapper(),
+      env: {
+        ...process.env,
+        HOME: tempDir,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        PI_CODING_AGENT_DIR: '',
+        ORCA_PI_CODING_AGENT_DIR: '',
+        ORCA_OMP_CODING_AGENT_DIR: '',
+        ORCA_OMP_SOURCE_AGENT_DIR: sourceDir,
+        ORCA_OMP_STATUS_EXTENSION: statusExtension,
+        ORCA_FAKE_OMP_DEFAULT_DIR: sourceDir,
+        ORCA_CAPTURE_FILE: captureFile,
+        TERM: process.env.TERM || 'xterm-256color'
+      },
+      input: `omp ${subcommand}
+exit 0
+`
+    })
+
+    const capture = readFileSync(captureFile, 'utf8')
+    expect(capture).toContain('PI=\n')
+    expect(capture).toContain(`EFFECTIVE=${sourceDir}`)
+    expect(capture).toContain(`ARG1=${subcommand}`)
+    expect(capture).not.toContain('ARG1=--extension')
+  })
+
   itWithBash(
     'lets OMP config subcommands fall back to the default home without a source shadow',
     async () => {

--- a/src/main/pty/omp-shell-wrapper.ts
+++ b/src/main/pty/omp-shell-wrapper.ts
@@ -5,25 +5,38 @@
 // normal source of truth.
 
 const OMP_SUBCOMMANDS = [
+  '__complete',
   'acp',
   'agents',
   'auth-broker',
   'auth-gateway',
+  'bench',
   'commit',
+  'completions',
   'config',
+  'dry-balance',
+  'gallery',
   'grep',
   'grievances',
+  'install',
+  'join',
+  'models',
   'plugin',
+  'read',
+  'say',
+  'search',
   'setup',
   'shell',
-  'read',
   'ssh',
   'stats',
+  'tiny-models',
+  'token',
+  'ttsr',
   'update',
+  'usage',
   'worktree',
-  'wt',
-  'search',
-  'q'
+  'q',
+  'wt'
 ] as const
 
 export function getPosixOmpShellWrapper(): string {
@@ -31,17 +44,12 @@ export function getPosixOmpShellWrapper(): string {
   return `# Why: OMP does not auto-load Orca's managed status extension; wrap only
 # interactive launch invocations so subcommands such as \`omp config\` keep
 # their normal argv shape.
-__orca_omp_is_subcommand() {
-  case "\${1:-}" in
-    ${subcommands}) return 0 ;;
-  esac
-  return 1
-}
 __orca_omp_should_skip_extension() {
   case "\${1:-}" in
     help|--help|-h|--version|-v) return 0 ;;
+    ${subcommands}) return 0 ;;
   esac
-  __orca_omp_is_subcommand "\${1:-}"
+  return 1
 }
 __orca_omp() {
   local __orca_use_extension=1
@@ -68,15 +76,10 @@ export function getPowerShellOmpShellWrapper(): string {
   return `# Why: OMP does not auto-load Orca's managed status extension; wrap only
 # interactive launch invocations so subcommands such as \`omp config\` keep
 # their normal argv shape.
-function Global:__OrcaOmpIsSubcommand {
-    param([string]$Name)
-    $subcommands = @(${subcommands})
-    return $subcommands -contains $Name
-}
 function Global:__OrcaOmpShouldSkipExtension {
     param([string]$Name)
-    if (@("help", "--help", "-h", "--version", "-v") -contains $Name) { return $true }
-    return __OrcaOmpIsSubcommand -Name $Name
+    $skip = @("help", "--help", "-h", "--version", "-v") + @(${subcommands})
+    return $skip -contains $Name
 }
 if ($env:ORCA_OMP_STATUS_EXTENSION) {
     function Global:omp {


### PR DESCRIPTION
## Summary

Keep Orca's managed OMP status extension wrapper out of OMP subcommands whose argv must stay untouched.

Typed `omp usage` and other top-level OMP management commands now run as their direct subcommands instead of being rewritten to include `--extension`. Interactive `omp` launches still receive Orca's managed status extension.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted verification run under Node 24:

- `node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/main/pty/omp-shell-wrapper.node-pty.test.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts src/main/powershell-osc133-bootstrap.test.ts src/main/providers/windows-shell-args.test.ts src/relay/pty-shell-launch.test.ts`
- `./node_modules/.bin/oxlint src/main/pty/omp-shell-wrapper.ts src/main/pty/omp-shell-wrapper.node-pty.test.ts`
- `node node_modules/@typescript/native-preview/bin/tsgo.js --noEmit -p config/tsconfig.node.json`

Full `pnpm lint`, full `pnpm test`, and `pnpm build` were not run locally for this narrow shell-wrapper regression.

## AI Review Report

Checked argv preservation for OMP subcommands and extension injection for interactive launches. The regression test exercises the generated POSIX wrapper in an interactive bash PTY with a fake `omp` binary. Existing generated-wrapper suites cover the shared allowlist through POSIX, shell-ready, relay, and PowerShell wrapper paths.

## Security Audit

No new IPC, auth, network, dependency, file-write, or credential-handling surface. The change only adjusts local shell wrapper dispatch for known OMP subcommands.

Command-execution risk reviewed: the wrapper still quotes the managed extension path as before, and this PR preserves original argv shape for subcommands instead of adding `--extension`.

## Notes

- Fixes a regression from the managed Pi/OMP extension wrapper path where newer OMP subcommands were missing from the skip allowlist.
- `launch` remains intentionally omitted from the skip list so explicit `omp launch ...` continues to receive the managed status extension.
- X: @wolfie_
