### PR TITLE
feat(mobile): show trusted floating terminal sessions

### DIFF
--- a/mobile/.oxlintrc.json
+++ b/mobile/.oxlintrc.json
@@ -24,7 +24,7 @@
     {
       "files": ["app/h/*/session/*.tsx"],
       "rules": {
-        "max-lines": ["error", { "max": 5015, "skipBlankLines": true, "skipComments": true }]
+        "max-lines": ["error", { "max": 5029, "skipBlankLines": true, "skipComments": true }]
       }
     },
     {
@@ -48,7 +48,7 @@
     {
       "files": ["app/h/*/index.tsx"],
       "rules": {
-        "max-lines": ["error", { "max": 1603, "skipBlankLines": true, "skipComments": true }]
+        "max-lines": ["error", { "max": 1605, "skipBlankLines": true, "skipComments": true }]
       }
     },
     {

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -55,6 +55,7 @@ import { WorktreeListRow } from '../../../src/components/WorktreeListRow'
 import { useNow } from '../../../src/hooks/use-now'
 import { useActiveWorktreeScroll } from '../../../src/hooks/use-active-worktree-scroll'
 import type { RepoIcon } from '../../../../src/shared/repo-icon'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../src/worktree/workspace-list-types'
 import { PickerModal } from '../../../src/components/PickerModal'
 import { ActionSheetContent } from '../../../src/components/ActionSheetModal'
 import { buildWorktreeNavigationActions } from '../../../src/agent-history/worktree-navigation-actions'
@@ -647,7 +648,11 @@ export function HostScreen({
   const openWorktreeSession = useCallback(
     (item: Worktree) => {
       setOptimisticActiveWorktreeId(item.worktreeId)
-      if (client && connState === 'connected') {
+      // Why: the floating sentinel is terminal-only and never a managed worktree.
+      const isFloating = item.worktreeId === FLOATING_TERMINAL_WORKTREE_ID
+      if (!isFloating && client && connState === 'connected') {
+        // Why: opening a mobile session should hydrate host-owned tabs without
+        // pulling other paired clients, especially desktop, into this worktree.
         void client
           .sendRequest('worktree.activate', {
             worktree: `id:${item.worktreeId}`,

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -4183,6 +4183,7 @@ export default function SessionScreen() {
 
   useEffect(() => {
     if (
+      isFloatingWorkspaceRoute ||
       !client ||
       !showEmptyState ||
       creating ||
@@ -4196,7 +4197,15 @@ export default function SessionScreen() {
     initialEmptySessionAutoCreateRef.current = worktreeId
     setCreateError('')
     void handleCreateTerminal()
-  }, [client, creating, creatingBrowser, creatingMarkdown, showEmptyState, worktreeId])
+  }, [
+    client,
+    creating,
+    creatingBrowser,
+    creatingMarkdown,
+    isFloatingWorkspaceRoute,
+    showEmptyState,
+    worktreeId
+  ])
 
   // Why: reconnect trickles to 90s at its give-up cap; surface tap-to-retry so recovery needn't wait it out (issue #5049).
   const connectionVerdict = classifyConnection({
@@ -4346,6 +4355,14 @@ export default function SessionScreen() {
   }, [])
 
   const handlePanelTap = (tapped: Exclude<ActivePanel, null>) => {
+    if (
+      isFloatingWorkspaceRoute &&
+      (tapped === 'files' || tapped === 'sourceControl' || tapped === 'pr')
+    ) {
+      // Why: the floating sentinel exposes terminal tabs only; ignore stale
+      // panel taps so Files/Source Control/PR never open from this route.
+      return
+    }
     const action = resolvePanelAction({ canDock: canDockPanel, tapped, current: activePanel })
     if (action.kind === 'dock') {
       setActivePanel(action.next)
@@ -4510,25 +4527,31 @@ export default function SessionScreen() {
                 ))}
               </ScrollView>
               {/* Why: pinned outside the scroll strip so the new-agent button stays reachable however far the tabs scroll. */}
-              <Pressable
-                style={({ pressed }) => [
-                  styles.newTerminalButton,
-                  pressed && styles.newTerminalButtonPressed,
-                  (creating || creatingBrowser || creatingMarkdown || connState !== 'connected') &&
-                    styles.newTerminalButtonDisabled
-                ]}
-                disabled={
-                  creating || creatingBrowser || creatingMarkdown || connState !== 'connected'
-                }
-                onPress={() => {
-                  setCreateError('')
-                  setShowCreateTabDrawer(true)
-                }}
-                accessibilityLabel="New tab"
-              >
-                <Plus size={16} color={colors.textSecondary} strokeWidth={2.2} />
-              </Pressable>
-              {quickCommandsSupported === true ? (
+              {/* Why: the floating sentinel is a read-only projection of desktop-owned terminals — no tab creation or quick commands. */}
+              {!isFloatingWorkspaceRoute && (
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.newTerminalButton,
+                    pressed && styles.newTerminalButtonPressed,
+                    (creating ||
+                      creatingBrowser ||
+                      creatingMarkdown ||
+                      connState !== 'connected') &&
+                      styles.newTerminalButtonDisabled
+                  ]}
+                  disabled={
+                    creating || creatingBrowser || creatingMarkdown || connState !== 'connected'
+                  }
+                  onPress={() => {
+                    setCreateError('')
+                    setShowCreateTabDrawer(true)
+                  }}
+                  accessibilityLabel="New tab"
+                >
+                  <Plus size={16} color={colors.textSecondary} strokeWidth={2.2} />
+                </Pressable>
+              )}
+              {!isFloatingWorkspaceRoute && quickCommandsSupported === true ? (
                 <QuickCommandsTabButton
                   disabled={
                     creating || creatingBrowser || creatingMarkdown || connState !== 'connected'
@@ -4564,33 +4587,39 @@ export default function SessionScreen() {
               </View>
             ) : showEmptyState ? (
               <View style={styles.emptyState}>
-                <Text style={styles.emptyText}>No tabs in this session</Text>
+                <Text style={styles.emptyText}>
+                  {isFloatingWorkspaceRoute
+                    ? 'No trusted floating terminal sessions'
+                    : 'No tabs in this session'}
+                </Text>
                 {createError ? <Text style={styles.createError}>{createError}</Text> : null}
-                <View style={styles.emptyActions}>
-                  <Pressable
-                    style={[
-                      styles.createButton,
-                      (creating ||
-                        creatingBrowser ||
-                        creatingMarkdown ||
-                        connState !== 'connected') &&
-                        styles.createButtonDisabled
-                    ]}
-                    disabled={
-                      creating || creatingBrowser || creatingMarkdown || connState !== 'connected'
-                    }
-                    onPress={() => {
-                      setCreateError('')
-                      setShowCreateTabDrawer(true)
-                    }}
-                  >
-                    <Text style={styles.createButtonText}>
-                      {creating || creatingBrowser || creatingMarkdown
-                        ? 'Creating...'
-                        : 'Create Tab'}
-                    </Text>
-                  </Pressable>
-                </View>
+                {!isFloatingWorkspaceRoute && (
+                  <View style={styles.emptyActions}>
+                    <Pressable
+                      style={[
+                        styles.createButton,
+                        (creating ||
+                          creatingBrowser ||
+                          creatingMarkdown ||
+                          connState !== 'connected') &&
+                          styles.createButtonDisabled
+                      ]}
+                      disabled={
+                        creating || creatingBrowser || creatingMarkdown || connState !== 'connected'
+                      }
+                      onPress={() => {
+                        setCreateError('')
+                        setShowCreateTabDrawer(true)
+                      }}
+                    >
+                      <Text style={styles.createButtonText}>
+                        {creating || creatingBrowser || creatingMarkdown
+                          ? 'Creating...'
+                          : 'Create Tab'}
+                      </Text>
+                    </Pressable>
+                  </View>
+                )}
               </View>
             ) : activeMarkdownTab ? (
               <View style={styles.markdownFrame}>

--- a/mobile/src/components/WorktreeListRow.tsx
+++ b/mobile/src/components/WorktreeListRow.tsx
@@ -18,7 +18,7 @@ function displayBranch(branch: string): string {
 // Minimal row shape needed for rendering — a structural subset of the screen's
 // Worktree so this component stays decoupled from the screen's local type.
 export type WorktreeListRowItem = {
-  workspaceKind?: 'git' | 'folder-workspace'
+  workspaceKind?: 'git' | 'folder-workspace' | 'floating-workspace'
   worktreeId: string
   repo: string
   branch: string
@@ -70,8 +70,13 @@ export function WorktreeListRow<T extends WorktreeListRowItem>({
   onToggleLineage
 }: Props<T>) {
   const isFolderWorkspace = item.workspaceKind === 'folder-workspace'
+  const isFloatingWorkspace = item.workspaceKind === 'floating-workspace'
   const folderMeta = item.comment?.trim() || item.path || 'Folder'
-  const metaText = isFolderWorkspace ? folderMeta : displayBranch(item.branch)
+  const metaText = isFloatingWorkspace
+    ? item.comment?.trim() || 'Terminal-only'
+    : isFolderWorkspace
+      ? folderMeta
+      : displayBranch(item.branch)
   const lineageDepth = Math.max(0, item.lineageDepth ?? 0)
   const lineageChildCount = item.lineageChildCount ?? 0
 
@@ -132,6 +137,11 @@ export function WorktreeListRow<T extends WorktreeListRowItem>({
               <Text style={styles.folderBadgeText}>Folder</Text>
             </View>
           )}
+          {isFloatingWorkspace && (
+            <View style={styles.floatingBadge}>
+              <Text style={styles.floatingBadgeText}>Floating</Text>
+            </View>
+          )}
           <WorktreeMetaGlyphs
             comment={item.comment}
             linkedLinearIssue={item.linkedLinearIssue}
@@ -150,7 +160,7 @@ export function WorktreeListRow<T extends WorktreeListRowItem>({
           {/* Repo glyph+name only when not already grouped under this repo;
               MobileRepoIcon falls back to a Folder (matching desktop's default)
               rather than a bare colored dot. */}
-          {!hideRepo && (
+          {!hideRepo && !isFloatingWorkspace && (
             <>
               <MobileRepoIcon repoIcon={repoIcon} size={11} color={repoColor} />
               <Text style={styles.repoName} numberOfLines={1}>
@@ -268,6 +278,16 @@ const styles = StyleSheet.create({
     borderRadius: 4
   },
   folderBadgeText: {
+    fontSize: 10,
+    color: colors.textSecondary
+  },
+  floatingBadge: {
+    backgroundColor: colors.bgRaised,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    borderRadius: 4
+  },
+  floatingBadgeText: {
     fontSize: 10,
     color: colors.textSecondary
   },

--- a/mobile/src/session/use-mobile-pr-branch-context.test.ts
+++ b/mobile/src/session/use-mobile-pr-branch-context.test.ts
@@ -1,10 +1,15 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
 import { describe, expect, it, vi } from 'vitest'
 import type { MobileGitBranchCompareResult } from '../source-control/mobile-branch-compare'
 import type { MobileGitStatusResult } from '../source-control/mobile-git-status'
 import {
   deriveMobilePrBranchContext,
   loadMobilePrBranchContext,
-  loadMobilePrRepoContext
+  loadMobilePrRepoContext,
+  useMobilePrBranchContext,
+  type MobilePrBranchContext
 } from './use-mobile-pr-branch-context'
 
 function status(overrides: Partial<MobileGitStatusResult>): MobileGitStatusResult {
@@ -130,5 +135,47 @@ describe('loadMobilePrBranchContext', () => {
       'github.repoSlug',
       expect.objectContaining({ repo: expect.any(String) })
     )
+  })
+})
+
+describe('useMobilePrBranchContext floating sentinel', () => {
+  it('does no RPC and stays parked when the caller nulls the client', async () => {
+    // Why: the floating sentinel is terminal-only; the session screen passes
+    // `client: null` so the hook never issues PR/git RPCs for it.
+    const sendRequest = vi.fn(async () => ({ ok: false, error: { message: 'unexpected' } }))
+    let observed: MobilePrBranchContext | null = null
+
+    function Probe() {
+      observed = useMobilePrBranchContext({
+        client: null,
+        connState: 'connected',
+        worktreeId: 'global-floating-terminal',
+        includeBranchIdentity: false
+      })
+      return null
+    }
+
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(createElement(Probe))
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(sendRequest).not.toHaveBeenCalled()
+    expect(observed).toEqual({
+      branch: null,
+      headSha: null,
+      status: null,
+      isGithubRepo: false,
+      repoLoaded: false,
+      loaded: true
+    })
+
+    await act(async () => {
+      root.unmount()
+    })
   })
 })

--- a/mobile/src/worktree/resume-worktree.test.ts
+++ b/mobile/src/worktree/resume-worktree.test.ts
@@ -29,4 +29,17 @@ describe('pickResumeWorktree', () => {
     const list = [wt('a'), wt('b'), wt('c')]
     expect(pickResumeWorktree(list)?.id).toBe('a')
   })
+
+  it('never resumes a floating workspace even when pinned/active', () => {
+    const list = [
+      { id: 'floating', isActive: true, workspaceKind: 'floating-workspace' as const },
+      { id: 'normal', isActive: true, lastOutputAt: 5, workspaceKind: 'git' as const }
+    ]
+    expect(pickResumeWorktree(list)?.id).toBe('normal')
+  })
+
+  it('returns null when only floating workspaces are present', () => {
+    const list = [{ id: 'floating', isActive: true, workspaceKind: 'floating-workspace' as const }]
+    expect(pickResumeWorktree(list)).toBeNull()
+  })
 })

--- a/mobile/src/worktree/resume-worktree.ts
+++ b/mobile/src/worktree/resume-worktree.ts
@@ -6,19 +6,23 @@
 export type ResumeCandidate = {
   isActive?: boolean
   lastOutputAt?: number
+  workspaceKind?: 'git' | 'folder-workspace' | 'floating-workspace'
 }
 
 export function pickResumeWorktree<T extends ResumeCandidate>(worktrees: T[]): T | null {
-  if (worktrees.length === 0) {
+  // Why: the floating sentinel is terminal-only and never a cold-launch resume
+  // target, even when pinned/active, so a phone never auto-opens it.
+  const resumable = worktrees.filter((w) => w.workspaceKind !== 'floating-workspace')
+  if (resumable.length === 0) {
     return null
   }
-  const desktopActive = worktrees.find((w) => w.isActive)
+  const desktopActive = resumable.find((w) => w.isActive)
   if (desktopActive) {
     return desktopActive
   }
   // No desktop focus → most recent terminal output, else the first.
-  let best = worktrees[0]
-  for (const w of worktrees) {
+  let best = resumable[0]
+  for (const w of resumable) {
     if ((w.lastOutputAt ?? 0) > (best.lastOutputAt ?? 0)) {
       best = w
     }

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -695,3 +695,86 @@ describe('buildSections', () => {
     expect(sections[0]?.data[0]?.lineageCollapsed).toBe(true)
   })
 })
+
+describe('floating workspace row', () => {
+  function floatingWorktree(overrides: Partial<Worktree> = {}): Worktree {
+    return worktree({
+      workspaceKind: 'floating-workspace',
+      worktreeId: 'global-floating-terminal',
+      repoId: 'global-floating-terminal',
+      repo: 'Floating Workspace',
+      branch: '',
+      displayName: 'Floating Workspace',
+      path: '',
+      comment: 'Trusted floating terminal sessions',
+      isPinned: true,
+      liveTerminalCount: 1,
+      hasAttachedPty: true,
+      status: 'active',
+      ...overrides
+    })
+  }
+
+  it('survives an active repo filter', () => {
+    const floating = floatingWorktree()
+    const repoMatch = worktree({ worktreeId: 'repo-match', repoId: 'repo-1' })
+    const repoMiss = worktree({ worktreeId: 'repo-miss', repoId: 'repo-2' })
+
+    const result = filterWorktrees(
+      [floating, repoMatch, repoMiss],
+      { filterRepoIds: new Set(['repo-1']), hideSleeping: false, hideDefaultBranch: false },
+      ''
+    )
+
+    expect(result.map((w) => w.worktreeId)).toEqual(['global-floating-terminal', 'repo-match'])
+  })
+
+  it('is searchable by floating but not by unrelated branch/repo terms', () => {
+    const floating = floatingWorktree()
+    const other = worktree({ worktreeId: 'other', repo: 'orca', branch: 'feature/foo' })
+
+    const floatingHit = filterWorktrees(
+      [floating, other],
+      { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+      'floating'
+    )
+    expect(floatingHit.map((w) => w.worktreeId)).toEqual(['global-floating-terminal'])
+
+    const branchQuery = filterWorktrees(
+      [floating, other],
+      { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+      'feature'
+    )
+    expect(branchQuery.map((w) => w.worktreeId)).toEqual(['other'])
+  })
+
+  it('stays in the pinned section across repo/status/pr grouping', () => {
+    const floating = floatingWorktree()
+    const normal = worktree({ worktreeId: 'normal', repoId: 'repo-1' })
+
+    for (const groupMode of ['repo', 'workspaceStatus', 'prStatus'] as const) {
+      const sections = buildSections(
+        [floating, normal],
+        'recent',
+        { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+        '',
+        groupMode,
+        new Set(['global-floating-terminal'])
+      )
+      const pinned = sections.find((section) => section.title === 'Pinned')
+      expect(pinned?.data.map((w) => w.worktreeId)).toEqual(['global-floating-terminal'])
+    }
+  })
+})
+
+describe('FLOATING_TERMINAL_WORKTREE_ID mobile mirror', () => {
+  it('matches the canonical sentinel from src/shared/constants', async () => {
+    // Why: Metro cannot bundle runtime values from ../../../src/shared, so mobile
+    // mirrors the sentinel locally. Vitest runs in node (not Metro-sandboxed), so it
+    // can import the real constant and pin the mirror against drift.
+    const { FLOATING_TERMINAL_WORKTREE_ID: mobileSentinel } = await import('./workspace-list-types')
+    const { FLOATING_TERMINAL_WORKTREE_ID: canonicalSentinel } =
+      await import('../../../src/shared/constants')
+    expect(mobileSentinel).toBe(canonicalSentinel)
+  })
+})

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -53,7 +53,7 @@ export function isWorktreeActive(w: Worktree): boolean {
 }
 
 function isDefaultBranchWorkspace(w: Worktree): boolean {
-  if (w.workspaceKind === 'folder-workspace') {
+  if (w.workspaceKind === 'folder-workspace' || w.workspaceKind === 'floating-workspace') {
     return false
   }
   if (w.isMainWorktree !== undefined) {
@@ -86,16 +86,28 @@ export function filterWorktrees(
     result = result.filter((w) => !isDefaultBranchWorkspace(w))
   }
   if (filters.filterRepoIds.size > 0) {
-    result = result.filter((w) => filters.filterRepoIds.has(w.repoId))
+    result = result.filter(
+      (w) => w.workspaceKind === 'floating-workspace' || filters.filterRepoIds.has(w.repoId)
+    )
   }
   if (search.trim()) {
     const q = search.toLowerCase()
-    result = result.filter(
-      (w) =>
-        w.displayName.toLowerCase().includes(q) ||
+    result = result.filter((w) => {
+      if (w.workspaceKind === 'floating-workspace') {
+        return (
+          (w.displayName || w.repo).toLowerCase().includes(q) ||
+          'floating'.includes(q) ||
+          'floating workspace'.includes(q) ||
+          'floating terminal'.includes(q) ||
+          q.includes('floating')
+        )
+      }
+      return (
+        (w.displayName || w.repo).toLowerCase().includes(q) ||
         w.branch.toLowerCase().includes(q) ||
         w.repo.toLowerCase().includes(q)
-    )
+      )
+    })
   }
   return result
 }

--- a/mobile/src/worktree/workspace-list-types.ts
+++ b/mobile/src/worktree/workspace-list-types.ts
@@ -1,9 +1,14 @@
 import type { ExecutionHostId } from '../../../src/shared/execution-host'
 import type { RuntimeWorktreeAgentRow } from '../../../src/shared/runtime-types'
 
+// Why: Metro only bundles modules under mobile/; runtime VALUES from ../../../src/shared
+// cannot cross that boundary (only `import type` is erased pre-resolution). Mirror the
+// canonical sentinel from src/shared/constants.ts here, matching mobile-workspace-statuses.ts.
+export const FLOATING_TERMINAL_WORKTREE_ID = 'global-floating-terminal'
+
 export type Worktree = {
   sectionListKey?: string
-  workspaceKind?: 'git' | 'folder-workspace'
+  workspaceKind?: 'git' | 'folder-workspace' | 'floating-workspace'
   worktreeId: string
   repoId: string
   hostId?: ExecutionHostId

--- a/src/main/ipc/floating-workspace-directory.test.ts
+++ b/src/main/ipc/floating-workspace-directory.test.ts
@@ -22,6 +22,7 @@ vi.mock('./filesystem-auth', () => ({
 import {
   ensureDefaultFloatingWorkspacePath,
   grantFloatingWorkspaceDirectory,
+  isTrustedFloatingWorkspaceDescendant,
   resolveFloatingTerminalCwd,
   sanitizeFloatingWorkspaceDirectorySetting
 } from './floating-workspace-directory'
@@ -201,5 +202,77 @@ describe('floating workspace directory authorization', () => {
       arbitraryDir
     )
     expect(authorizeExternalPathMock).not.toHaveBeenCalledWith(arbitraryDir)
+  })
+
+  it('recognizes the app-owned floating workspace and descendants as mobile-trusted', async () => {
+    const store = createStore()
+    const appWorkspace = path.join(userDataDir, 'floating-workspace')
+    await mkdir(appWorkspace, { recursive: true })
+    const childDir = path.join(appWorkspace, 'child')
+    await mkdir(childDir)
+
+    await expect(isTrustedFloatingWorkspaceDescendant(store as never, appWorkspace)).resolves.toBe(
+      true
+    )
+    await expect(isTrustedFloatingWorkspaceDescendant(store as never, childDir)).resolves.toBe(true)
+  })
+
+  it('recognizes picker-approved directories and descendants as mobile-trusted', async () => {
+    const store = createStore()
+    const selectedDir = path.join(tempRoot, 'notes')
+    await mkdir(selectedDir)
+    const childDir = path.join(selectedDir, 'child')
+    await mkdir(childDir)
+
+    await grantFloatingWorkspaceDirectory(store as never, selectedDir)
+
+    await expect(isTrustedFloatingWorkspaceDescendant(store as never, selectedDir)).resolves.toBe(
+      true
+    )
+    await expect(isTrustedFloatingWorkspaceDescendant(store as never, childDir)).resolves.toBe(true)
+  })
+
+  it('rejects sibling prefix paths for mobile trust', async () => {
+    const store = createStore()
+    const trustedDir = path.join(tempRoot, 'notes')
+    await mkdir(trustedDir)
+    const siblingDir = path.join(tempRoot, 'notes-other')
+    await mkdir(siblingDir)
+
+    await grantFloatingWorkspaceDirectory(store as never, trustedDir)
+
+    await expect(isTrustedFloatingWorkspaceDescendant(store as never, siblingDir)).resolves.toBe(
+      false
+    )
+  })
+
+  it('rejects home for mobile trust without a picker grant', async () => {
+    const store = createStore()
+
+    await expect(isTrustedFloatingWorkspaceDescendant(store as never, homeDir)).resolves.toBe(false)
+  })
+
+  it('canonicalizes symlink cwd before mobile trust', async () => {
+    const store = createStore()
+    const originalTarget = path.join(tempRoot, 'original-target')
+    const retargetedTarget = path.join(tempRoot, 'retargeted-target')
+    const selectedLink = path.join(tempRoot, 'selected-link')
+    await mkdir(originalTarget)
+    await mkdir(retargetedTarget)
+    await symlinkDirectory(originalTarget, selectedLink)
+
+    await grantFloatingWorkspaceDirectory(store as never, selectedLink)
+
+    const insideOriginal = path.join(originalTarget, 'child')
+    await mkdir(insideOriginal)
+    await expect(
+      isTrustedFloatingWorkspaceDescendant(store as never, insideOriginal)
+    ).resolves.toBe(true)
+
+    await unlink(selectedLink)
+    await symlinkDirectory(retargetedTarget, selectedLink)
+    await expect(isTrustedFloatingWorkspaceDescendant(store as never, selectedLink)).resolves.toBe(
+      false
+    )
   })
 })

--- a/src/main/ipc/floating-workspace-directory.ts
+++ b/src/main/ipc/floating-workspace-directory.ts
@@ -67,13 +67,51 @@ function isTrustedFloatingWorkspaceDirectory(
   return getTrustedFloatingWorkspaceDirectories(settings).has(path.resolve(canonicalDirPath))
 }
 
+export function getDefaultFloatingWorkspacePath(): string {
+  return path.join(app.getPath('userData'), FLOATING_WORKSPACE_DIRNAME)
+}
+
 export async function ensureDefaultFloatingWorkspacePath(): Promise<string> {
-  const cwd = path.join(app.getPath('userData'), FLOATING_WORKSPACE_DIRNAME)
+  const cwd = getDefaultFloatingWorkspacePath()
   await mkdir(cwd, { recursive: true })
   // Why: the default floating workspace lives outside repo roots by design;
   // authorize only this app-owned directory instead of widening access to ~.
   authorizeExternalPath(cwd)
   return cwd
+}
+
+function isExactOrDescendant(root: string, target: string): boolean {
+  const relative = path.relative(root, target)
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+export async function isTrustedFloatingWorkspaceDescendant(
+  store: Store,
+  cwd: string | null | undefined
+): Promise<boolean> {
+  if (typeof cwd !== 'string' || cwd.trim().length === 0) {
+    return false
+  }
+  const canonicalCwd = await canonicalizeAccessibleDirectory(resolveFloatingWorkspaceInput(cwd))
+  if (!canonicalCwd) {
+    return false
+  }
+  const trustRoots = new Set<string>()
+  const canonicalDefault = await canonicalizeAccessibleDirectory(getDefaultFloatingWorkspacePath())
+  if (canonicalDefault) {
+    trustRoots.add(canonicalDefault)
+  }
+  for (const trustedDir of await getPreservedTrustedFloatingWorkspaceDirectories(
+    store.getSettings()
+  )) {
+    trustRoots.add(trustedDir)
+  }
+  for (const root of trustRoots) {
+    if (isExactOrDescendant(root, canonicalCwd)) {
+      return true
+    }
+  }
+  return false
 }
 
 export async function resolveFloatingTerminalCwd(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -181,6 +181,17 @@ vi.mock('../ipc/filesystem-watcher', () => ({
   forgetRemoteWatcherRemovalSnapshot: forgetRemoteWatcherRemovalSnapshotMock
 }))
 
+const floatingWorkspaceDirectoryMocks = vi.hoisted(() => ({
+  trustedFloatingCwds: new Set<string>()
+}))
+
+vi.mock('../ipc/floating-workspace-directory', () => ({
+  isTrustedFloatingWorkspaceDescendant: vi.fn(
+    async (_store: unknown, cwd: string | null | undefined) =>
+      typeof cwd === 'string' && floatingWorkspaceDirectoryMocks.trustedFloatingCwds.has(cwd)
+  )
+}))
+
 const {
   MOCK_GIT_WORKTREES,
   addWorktreeMock,
@@ -1733,6 +1744,8 @@ describe('OrcaRuntimeService', () => {
   it('polls floating tabs with targeted PTY liveness and no repo/provider inventory', async () => {
     const getRepos = vi.fn(store.getRepos)
     const listProcesses = vi.fn().mockResolvedValue([])
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.clear()
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.add('/tmp/floating-workspace')
     const floatingPtyId = `${FLOATING_TERMINAL_WORKTREE_ID}@@pty-1`
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({
@@ -1758,12 +1771,16 @@ describe('OrcaRuntimeService', () => {
         }
       })
     )
+    let floatingCwd = '/tmp/floating-workspace'
     const runtime = new OrcaRuntimeService({ ...runtimeStore, getRepos } as never)
     const ptyController = {
       livePtyIds: new Set([floatingPtyId]),
       write: () => true,
       kill: () => true,
       getForegroundProcess: async () => null,
+      // Why: current cwd is re-checked on every projection so leaving the
+      // configured floating directory revokes mobile access.
+      getCwd: vi.fn(async () => floatingCwd),
       hasPty(this: { livePtyIds: Set<string> }, ptyId: string) {
         return this.livePtyIds.has(ptyId)
       },
@@ -1774,8 +1791,9 @@ describe('OrcaRuntimeService', () => {
 
     const tabs = await runtime.listMobileSessionTabs(`id:${FLOATING_TERMINAL_WORKTREE_ID}`)
     const terminals = await runtime.listTerminals(`id:${FLOATING_TERMINAL_WORKTREE_ID}`)
-    await runtime.listMobileSessionTabs(`id:${FLOATING_TERMINAL_WORKTREE_ID}`)
-    await runtime.listTerminals(`id:${FLOATING_TERMINAL_WORKTREE_ID}`)
+    floatingCwd = '/tmp/outside-floating-workspace'
+    const revokedTabs = await runtime.listMobileSessionTabs(`id:${FLOATING_TERMINAL_WORKTREE_ID}`)
+    const revokedTerminals = await runtime.listTerminals(`id:${FLOATING_TERMINAL_WORKTREE_ID}`)
 
     expect(tabs.tabs).toEqual([
       expect.objectContaining({
@@ -1791,6 +1809,9 @@ describe('OrcaRuntimeService', () => {
         connected: true
       })
     ])
+    expect(revokedTabs.tabs).toEqual([])
+    expect(revokedTerminals.terminals).toEqual([])
+    expect(ptyController.getCwd).toHaveBeenCalledTimes(4)
     expect(hasPty).toHaveBeenCalledTimes(4)
     expect(hasPty).toHaveBeenCalledWith(floatingPtyId)
     expect(listProcesses).not.toHaveBeenCalled()
@@ -3185,6 +3206,153 @@ describe('OrcaRuntimeService', () => {
     await expect(runtime.showManagedWorktree(`id:${TEST_WORKTREE_ID}`)).resolves.toMatchObject({
       id: TEST_WORKTREE_ID
     })
+  })
+
+  it('publishes a trusted floating workspace row from worktree.ps', async () => {
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.clear()
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.add('/tmp/floating-workspace')
+    const runtime = new OrcaRuntimeService(store)
+    runtime['recordPtyWorktree']('floating-pty-1', FLOATING_TERMINAL_WORKTREE_ID, {
+      connected: true,
+      cwd: '/tmp/floating-workspace',
+      mobileTrustedFloatingCwd: true
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const floatingRow = worktrees.find(
+      (worktree) => worktree.worktreeId === FLOATING_TERMINAL_WORKTREE_ID
+    )
+    expect(floatingRow).toMatchObject({
+      workspaceKind: 'floating-workspace',
+      displayName: 'Floating Workspace',
+      isPinned: true,
+      liveTerminalCount: 1
+    })
+  })
+
+  it('omits the floating workspace row for an untrusted cwd', async () => {
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.clear()
+    const runtime = new OrcaRuntimeService(store)
+    runtime['recordPtyWorktree']('floating-pty-untrusted', FLOATING_TERMINAL_WORKTREE_ID, {
+      connected: true,
+      cwd: homedir(),
+      mobileTrustedFloatingCwd: false
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    expect(
+      worktrees.find((worktree) => worktree.worktreeId === FLOATING_TERMINAL_WORKTREE_ID)
+    ).toBeUndefined()
+  })
+
+  it('returns only trusted terminal tabs for the floating sentinel session', async () => {
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.clear()
+    const runtime = new OrcaRuntimeService(store)
+    runtime['recordPtyWorktree']('floating-pty-trusted', FLOATING_TERMINAL_WORKTREE_ID, {
+      connected: true,
+      cwd: '/tmp/floating-workspace',
+      mobileTrustedFloatingCwd: true,
+      tabId: 'tab-trusted',
+      paneKey: 'tab-trusted:1'
+    })
+    runtime['recordPtyWorktree']('floating-pty-untrusted', FLOATING_TERMINAL_WORKTREE_ID, {
+      connected: true,
+      cwd: homedir(),
+      mobileTrustedFloatingCwd: false,
+      tabId: 'tab-untrusted',
+      paneKey: 'tab-untrusted:1'
+    })
+    runtime['mobileSessionTabsByWorktree'].set(FLOATING_TERMINAL_WORKTREE_ID, {
+      worktree: FLOATING_TERMINAL_WORKTREE_ID,
+      publicationEpoch: 'epoch-floating',
+      snapshotVersion: 1,
+      activeGroupId: 'group-floating',
+      activeTabId: 'tab-trusted::pane:1',
+      activeTabType: 'terminal',
+      tabs: [
+        {
+          type: 'terminal',
+          id: 'tab-trusted::pane:1',
+          parentTabId: 'tab-trusted',
+          leafId: 'pane:1',
+          title: 'Trusted floating terminal',
+          ptyId: 'floating-pty-trusted',
+          isActive: true
+        },
+        {
+          type: 'terminal',
+          id: 'tab-untrusted::pane:1',
+          parentTabId: 'tab-untrusted',
+          leafId: 'pane:1',
+          title: 'Untrusted floating terminal',
+          ptyId: 'floating-pty-untrusted',
+          isActive: false
+        },
+        {
+          type: 'markdown',
+          id: 'floating-markdown',
+          title: 'Notes',
+          filePath: '/tmp/floating-workspace/notes.md',
+          relativePath: 'notes.md',
+          language: 'markdown',
+          mode: 'markdown-preview',
+          isDirty: false,
+          isActive: false,
+          sourceFileId: 'floating-markdown-src',
+          sourceFilePath: '/tmp/floating-workspace/notes.md',
+          sourceRelativePath: 'notes.md',
+          documentVersion: '1'
+        }
+      ]
+    })
+
+    const result = await runtime.listMobileSessionTabs(`id:${FLOATING_TERMINAL_WORKTREE_ID}`)
+    expect(result.tabs.map((tab) => tab.id)).toEqual(['tab-trusted::pane:1'])
+  })
+
+  it('resolves floating trust via controller getCwd when listProcesses cwd is empty', async () => {
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.clear()
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.add('/tmp/floating-workspace')
+    const floatingPtyId = `${FLOATING_TERMINAL_WORKTREE_ID}@@trusted`
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      // Why: the local provider reports an empty cwd here, mirroring production.
+      listProcesses: async () => [{ id: floatingPtyId, cwd: '', title: 'shell' }],
+      getCwd: async (ptyId) => (ptyId === floatingPtyId ? '/tmp/floating-workspace' : '')
+    })
+    runtime.attachWindow(1)
+    runtime.markGraphReady(1)
+
+    const { worktrees } = await runtime.getWorktreePs()
+    expect(
+      worktrees.find((worktree) => worktree.worktreeId === FLOATING_TERMINAL_WORKTREE_ID)
+    ).toMatchObject({ workspaceKind: 'floating-workspace', liveTerminalCount: 1 })
+  })
+
+  it('keeps the floating row hidden when controller getCwd throws', async () => {
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.clear()
+    floatingWorkspaceDirectoryMocks.trustedFloatingCwds.add('/tmp/floating-workspace')
+    const floatingPtyId = `${FLOATING_TERMINAL_WORKTREE_ID}@@broken`
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [{ id: floatingPtyId, cwd: '', title: 'shell' }],
+      getCwd: async () => {
+        throw new Error('cwd probe failed')
+      }
+    })
+    runtime.attachWindow(1)
+    runtime.markGraphReady(1)
+
+    const { worktrees } = await runtime.getWorktreePs()
+    expect(
+      worktrees.find((worktree) => worktree.worktreeId === FLOATING_TERMINAL_WORKTREE_ID)
+    ).toBeUndefined()
   })
 
   it('still throws selector_not_found for an unknown id selector', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -206,7 +206,7 @@ import {
   getProjectHostSetupForRepo,
   getProjectHostSetupWorktreeMeta
 } from '../../shared/project-host-setup-projection'
-import { parsePtySessionId } from '../../shared/pty-session-id-format'
+import { parsePtySessionId, PTY_SESSION_ID_SEPARATOR } from '../../shared/pty-session-id-format'
 import { clampLinearIssueListLimit } from '../../shared/linear-issue-read-limits'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
@@ -683,6 +683,7 @@ import {
 } from '../git/worktree'
 import type { AddWorktreeOptions, AddWorktreeResult } from '../git/worktree'
 import { isENOENT } from '../ipc/filesystem-auth'
+import { isTrustedFloatingWorkspaceDescendant } from '../ipc/floating-workspace-directory'
 import {
   createSetupRunnerScript,
   getDefaultTabCommandTrustContent,
@@ -1052,6 +1053,8 @@ type RuntimePtyWorktreeRecord = {
   // selection must follow the pane that executes it, not process.platform.
   isWsl: boolean | null
   wslDistro: string | null
+  cwd: string | null
+  mobileTrustedFloatingCwd: boolean
   // Why: background CLI PTYs can outlive a failed renderer reveal. Preserve the
   // spawn-time tab/pane identity so later reveals can adopt under the env key.
   tabId: string | null
@@ -4932,9 +4935,7 @@ export class OrcaRuntimeService {
   ): Promise<RuntimeMobileSessionTabsResult> {
     const navigation = opts.navigation ?? (opts.notifyClients === false ? 'caller' : 'all')
     const targetsHost = navigationTargetsHost(navigation)
-    const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(worktreeSelector)
-    const worktreeId =
-      explicitWorktreeId ?? (await this.resolveWorktreeSelector(worktreeSelector)).id
+    const worktreeId = await this.resolveMobileSessionWorktreeIdSelector(worktreeSelector)
     this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(worktreeId)
     await this.refreshMobileSessionPtyRecords(worktreeId)
     const snapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
@@ -5233,9 +5234,7 @@ export class OrcaRuntimeService {
   }
 
   async closeMobileSessionTab(worktreeSelector: string, tabId: string): Promise<{ closed: true }> {
-    const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(worktreeSelector)
-    const worktreeId =
-      explicitWorktreeId ?? (await this.resolveWorktreeSelector(worktreeSelector)).id
+    const worktreeId = await this.resolveMobileSessionWorktreeIdSelector(worktreeSelector)
     this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(worktreeId)
     await this.refreshMobileSessionPtyRecords()
     const snapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
@@ -5471,9 +5470,7 @@ export class OrcaRuntimeService {
     worktreeSelector: string,
     move: RuntimeMobileSessionTabMove
   ): Promise<RuntimeMobileSessionTabMoveResult> {
-    const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(worktreeSelector)
-    const worktreeId =
-      explicitWorktreeId ?? (await this.resolveWorktreeSelector(worktreeSelector)).id
+    const worktreeId = await this.resolveMobileSessionWorktreeIdSelector(worktreeSelector)
     this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(worktreeId)
     const snapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
     if (!snapshot) {
@@ -5527,9 +5524,7 @@ export class OrcaRuntimeService {
       titlesByLeafId?: Record<string, string>
     }
   ): Promise<{ updated: true }> {
-    const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(worktreeSelector)
-    const worktreeId =
-      explicitWorktreeId ?? (await this.resolveWorktreeSelector(worktreeSelector)).id
+    const worktreeId = await this.resolveMobileSessionWorktreeIdSelector(worktreeSelector)
     // Why: when a renderer is authoritative (desktop host reached via shared
     // control), it owns pane geometry and republishes it — a headless write here
     // would be overwritten and could fight the renderer. Persist only headlessly.
@@ -5560,9 +5555,7 @@ export class OrcaRuntimeService {
       viewMode?: 'terminal' | 'chat'
     }
   ): Promise<{ updated: true }> {
-    const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(worktreeSelector)
-    const worktreeId =
-      explicitWorktreeId ?? (await this.resolveWorktreeSelector(worktreeSelector)).id
+    const worktreeId = await this.resolveMobileSessionWorktreeIdSelector(worktreeSelector)
     // Why: a renderer-authoritative host owns + republishes tab props, so a
     // headless write would be overwritten. Persist only when headless.
     if (this.getAvailableAuthoritativeWindow()) {
@@ -11574,6 +11567,11 @@ export class OrcaRuntimeService {
         if (!leaf.ptyId && livePtyWorktreeIds.has(leaf.worktreeId)) {
           continue
         }
+        if (leaf.worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+          if (!leaf.ptyId || !this.isMobileVisibleFloatingPty(this.ptysById.get(leaf.ptyId))) {
+            continue
+          }
+        }
         if (leaf.ptyId) {
           ptyIdsFromLeaves.add(leaf.ptyId)
         }
@@ -11592,6 +11590,12 @@ export class OrcaRuntimeService {
         continue
       }
       if (targetWorktreeId && pty.worktreeId !== targetWorktreeId) {
+        continue
+      }
+      if (
+        pty.worktreeId === FLOATING_TERMINAL_WORKTREE_ID &&
+        !this.isMobileVisibleFloatingPty(pty)
+      ) {
         continue
       }
       terminals.push(this.buildPtyTerminalSummary(pty, worktreesById))
@@ -13018,6 +13022,60 @@ export class OrcaRuntimeService {
       if (activeSummary) {
         activeSummary.isActive = true
       }
+    }
+
+    // Why: the floating sentinel appears in the mobile projection only while at
+    // least one trusted live floating PTY exists; it is synthesized, not stored.
+    const visibleFloatingPtys = [...this.ptysById.values()].filter((pty) =>
+      this.isMobileVisibleFloatingPty(pty)
+    )
+    if (visibleFloatingPtys.length > 0) {
+      summaries.set(FLOATING_TERMINAL_WORKTREE_ID, {
+        workspaceKind: 'floating-workspace',
+        worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+        repoId: FLOATING_TERMINAL_WORKTREE_ID,
+        repo: 'Floating Workspace',
+        path: '',
+        branch: '',
+        isArchived: false,
+        isMainWorktree: false,
+        hasHostSidebarActivity: true,
+        parentWorktreeId: null,
+        childWorktreeIds: [],
+        displayName: 'Floating Workspace',
+        workspaceStatus: DEFAULT_WORKSPACE_STATUS_ID,
+        sortOrder: Number.MIN_SAFE_INTEGER,
+        linkedIssue: null,
+        linkedPR: null,
+        linkedLinearIssue: null,
+        linkedGitLabMR: null,
+        linkedGitLabIssue: null,
+        comment: 'Trusted floating terminal sessions',
+        isPinned: true,
+        isActive: false,
+        unread: false,
+        liveTerminalCount: visibleFloatingPtys.length,
+        hasAttachedPty: true,
+        lastOutputAt: visibleFloatingPtys.reduce(
+          (latest, pty) => maxTimestamp(latest, pty.lastOutputAt),
+          null as number | null
+        ),
+        preview:
+          [...visibleFloatingPtys]
+            .sort((a, b) => (b.lastOutputAt ?? -1) - (a.lastOutputAt ?? -1))
+            .find((pty) => pty.preview.length > 0)?.preview ?? '',
+        status: (() => {
+          const merged = visibleFloatingPtys.reduce<RuntimeWorktreeStatus>((status, pty) => {
+            const title = getLatestPtyTitle(pty)
+            return mergeWorktreeStatus(
+              status,
+              getDetectedWorktreeStatus(title ? detectAgentStatusFromTitle(title) : null, true)
+            )
+          }, 'inactive')
+          return merged === 'inactive' ? 'active' : merged
+        })(),
+        agents: []
+      })
     }
 
     const mirroredWorktreeIdByTabId = new Map<string, string>()
@@ -19647,7 +19705,24 @@ export class OrcaRuntimeService {
       if (result.wslDistro) {
         this.preparePtyExecutionContext(result.id, result.wslDistro)
       }
+      // Why: floating trust is decided at spawn from the configured floating
+      // directory; only trusted-cwd floating PTYs project to mobile.
+      let mobileTrustedFloatingCwd = false
+      if (workspace.id === FLOATING_TERMINAL_WORKTREE_ID) {
+        try {
+          mobileTrustedFloatingCwd = await isTrustedFloatingWorkspaceDescendant(
+            this.requireStore(),
+            workspace.path
+          )
+        } catch {
+          mobileTrustedFloatingCwd = false
+        }
+      }
       this.registerPty(result.id, workspace.id, workspace.connectionId)
+      this.recordPtyWorktree(result.id, workspace.id, {
+        cwd: workspace.path,
+        mobileTrustedFloatingCwd
+      })
       const pty = this.getOrCreatePtyWorktreeRecord(result.id)
       if (pty) {
         if (launchOpts.title) {
@@ -21900,6 +21975,14 @@ export class OrcaRuntimeService {
     }
   }
 
+  private isMobileVisibleFloatingPty(pty: RuntimePtyWorktreeRecord | null | undefined): boolean {
+    return (
+      pty?.worktreeId === FLOATING_TERMINAL_WORKTREE_ID &&
+      pty.connected === true &&
+      pty.mobileTrustedFloatingCwd === true
+    )
+  }
+
   private listKnownResolvedWorktreesForExplicitTarget(
     targetWorktreeId: string,
     targetWorktree: ResolvedWorktree | null
@@ -22297,6 +22380,8 @@ export class OrcaRuntimeService {
         | 'connectionId'
         | 'isWsl'
         | 'wslDistro'
+        | 'cwd'
+        | 'mobileTrustedFloatingCwd'
       >
     > = {}
   ): RuntimePtyWorktreeRecord {
@@ -22319,6 +22404,8 @@ export class OrcaRuntimeService {
         connectionId,
         isWsl: state.isWsl ?? null,
         wslDistro,
+        cwd: state.cwd ?? null,
+        mobileTrustedFloatingCwd: state.mobileTrustedFloatingCwd ?? false,
         tabId: state.tabId ?? null,
         paneKey: state.paneKey ?? null,
         launchConfig: null,
@@ -22381,6 +22468,12 @@ export class OrcaRuntimeService {
         this.wslDistroByPtyId.delete(ptyId)
       }
     }
+    if (state.cwd !== undefined) {
+      pty.cwd = state.cwd
+    }
+    if (state.mobileTrustedFloatingCwd !== undefined) {
+      pty.mobileTrustedFloatingCwd = state.mobileTrustedFloatingCwd
+    }
     if (state.tabId !== undefined) {
       pty.tabId = state.tabId
     }
@@ -22437,6 +22530,7 @@ export class OrcaRuntimeService {
     if (targetWorktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
       const targetedLiveness = this.refreshFloatingWorkspacePtyLiveness()
       if (targetedLiveness !== null) {
+        await this.refreshFloatingPtyTrust(targetedLiveness)
         return targetedLiveness
       }
     }
@@ -22458,17 +22552,47 @@ export class OrcaRuntimeService {
     const livePtyIds = new Set(sessions.map((session) => session.id))
     for (const session of sessions) {
       this.adoptControllerTerminalHandle(session.id, session.terminalHandle)
+      // Why: the floating sentinel's pty ids are `global-floating-terminal@@<n>`,
+      // which lack the `${repoId}::${path}` shape parsePtySessionId requires, so
+      // infer the sentinel explicitly before falling back to cwd-based matching.
       // Why: workspace identity migration rekeys persisted ownership, but a running daemon PTY keeps the worktree id minted into its session id.
-      const worktreeId =
-        persistedWorktreeIdByPtyId.get(session.id) ??
-        inferWorktreeIdFromPtyId(session.id) ??
-        findResolvedWorktreeIdForPath(resolvedWorktrees, session.cwd)
+      const worktreeId = session.id.startsWith(
+        `${FLOATING_TERMINAL_WORKTREE_ID}${PTY_SESSION_ID_SEPARATOR}`
+      )
+        ? FLOATING_TERMINAL_WORKTREE_ID
+        : (persistedWorktreeIdByPtyId.get(session.id) ??
+          inferWorktreeIdFromPtyId(session.id) ??
+          findResolvedWorktreeIdForPath(resolvedWorktrees, session.cwd))
       if (targetWorktreeId && worktreeId !== targetWorktreeId) {
         continue
       }
       if (worktreeId) {
+        let effectiveCwd = session.cwd
+        let mobileTrustedFloatingCwd = false
+        if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+          // Why: the local PTY provider reports an empty cwd in listProcesses
+          // (it avoids a per-pid lsof for every session). Floating trust needs
+          // the live cwd, so resolve it on demand for the sentinel only.
+          if (!effectiveCwd && this.ptyController?.getCwd) {
+            try {
+              effectiveCwd = (await this.ptyController.getCwd(session.id)) ?? session.cwd
+            } catch {
+              effectiveCwd = session.cwd
+            }
+          }
+          try {
+            mobileTrustedFloatingCwd = await isTrustedFloatingWorkspaceDescendant(
+              this.requireStore(),
+              effectiveCwd
+            )
+          } catch {
+            mobileTrustedFloatingCwd = false
+          }
+        }
         this.recordPtyWorktree(session.id, worktreeId, {
-          connected: true
+          connected: true,
+          cwd: effectiveCwd,
+          mobileTrustedFloatingCwd
         })
       }
       // Why: fire-and-forget so this listing hot path doesn't serialize a relay round-trip per session and a throw can't abort the sweep below.
@@ -22482,6 +22606,35 @@ export class OrcaRuntimeService {
     }
     this.pruneDisconnectedPtyRecords()
     return livePtyIds
+  }
+
+  // Why: current cwd is the trust boundary for mobile exposure. Re-probe every
+  // live floating PTY on each projection refresh so a shell that leaves the
+  // configured floating directory immediately loses mobile handles and scrollback.
+  private async refreshFloatingPtyTrust(livePtyIds: Set<string>): Promise<void> {
+    for (const ptyId of livePtyIds) {
+      const pty = this.ptysById.get(ptyId)
+      if (!pty || pty.worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
+        continue
+      }
+      let cwd: string | null = null
+      if (this.ptyController?.getCwd) {
+        try {
+          cwd = (await this.ptyController.getCwd(ptyId)) || null
+        } catch {
+          cwd = null
+        }
+      }
+      pty.cwd = cwd
+      try {
+        pty.mobileTrustedFloatingCwd = await isTrustedFloatingWorkspaceDescendant(
+          this.requireStore(),
+          cwd
+        )
+      } catch {
+        pty.mobileTrustedFloatingCwd = false
+      }
+    }
   }
 
   private refreshFloatingWorkspacePtyLiveness(): Set<string> | null {
@@ -23110,6 +23263,19 @@ export class OrcaRuntimeService {
     }
   }
 
+  private async resolveMobileSessionWorktreeIdSelector(worktreeSelector: string): Promise<string> {
+    if (
+      worktreeSelector === FLOATING_TERMINAL_WORKTREE_ID ||
+      worktreeSelector === `id:${FLOATING_TERMINAL_WORKTREE_ID}`
+    ) {
+      return FLOATING_TERMINAL_WORKTREE_ID
+    }
+    // Why: mirror the non-floating RPC paths — bare repo ids must fail fast with
+    // the structured guidance error instead of silently scanning worktrees.
+    const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(worktreeSelector)
+    return explicitWorktreeId ?? (await this.resolveWorktreeSelector(worktreeSelector)).id
+  }
+
   private async resolveMobileMarkdownWorktreeId(
     worktreeSelector: string,
     tabId: string
@@ -23204,10 +23370,16 @@ export class OrcaRuntimeService {
     snapshot: RuntimeMobileSessionTabsSnapshot
   ): RuntimeMobileSessionTabsResult {
     const tabs: RuntimeMobileSessionClientTab[] = []
+    const isFloatingSnapshot = snapshot.worktree === FLOATING_TERMINAL_WORKTREE_ID
     const liveBrowserTabsByPageId = this.getLiveBrowserTabsByPageId(snapshot.worktree)
     // Why: a live PTY backs one surface; claim each once so two leaves resolving to it can't emit duplicate React keys and crash the client.
     const claimedLivePtyIds = new Set<string>()
     for (const tab of snapshot.tabs) {
+      if (isFloatingSnapshot && tab.type !== 'terminal') {
+        // Why: the floating sentinel is terminal-only for mobile; browser,
+        // markdown, and file floating tabs stay desktop-local.
+        continue
+      }
       if (tab.type === 'browser') {
         const liveTab = tab.browserPageId
           ? liveBrowserTabsByPageId.get(tab.browserPageId)
@@ -23240,6 +23412,12 @@ export class OrcaRuntimeService {
             allowWorktreeOnlyMatch: !snapshot.publicationEpoch.startsWith('headless')
           })
       const livePty = pty?.connected ? pty : null
+      if (isFloatingSnapshot) {
+        const candidatePty = liveLeafPtyId ? this.ptysById.get(liveLeafPtyId) : (livePty ?? pty)
+        if (!this.isMobileVisibleFloatingPty(candidatePty)) {
+          continue
+        }
+      }
       // Why: enforce one-live-PTY-per-tab; drop a later tab resolving to an already-claimed PTY so no two tabs share a handle.
       const resolvedLivePtyId = liveLeafPtyId ?? livePty?.ptyId ?? null
       if (resolvedLivePtyId !== null) {

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -609,7 +609,7 @@ export type RuntimeWorktreeAgentRow = {
 }
 
 export type RuntimeWorktreePsSummary = {
-  workspaceKind?: 'git' | 'folder-workspace'
+  workspaceKind?: 'git' | 'folder-workspace' | 'floating-workspace'
   worktreeId: string
   repoId: string
   hostId?: Worktree['hostId']


### PR DESCRIPTION
## Summary

Exposes live desktop Floating Workspace terminal sessions to Orca Mobile as a synthetic terminal-only worktree row.

- Adds a guarded `Floating Workspace` mobile row only for live floating PTYs whose cwd is the configured floating workspace directory or a descendant.
- Keeps `global-floating-terminal` as a terminal-only sentinel, never a managed git worktree.
- Filters mobile terminal/tab output so untrusted floating tabs do not expose handles or scrollback.
- Updates mobile session behavior for terminal-only rows: no Files, Source Control, PR affordances, new-tab creation, PR branch hook, or cold-launch resume.

Contributor handle: @wolfie_

## Screenshots

Pending visual screenshots of the mobile terminal session list. Keep draft until screenshots or a maintainer decision confirms the mobile UI evidence requirement is satisfied.

## Testing

- [ ] `pnpm lint` - not run end-to-end; scoped lint checks below passed.
- [ ] `pnpm typecheck` - not run end-to-end; targeted node + mobile typechecks below passed.
- [ ] `pnpm test` - not run end-to-end; targeted regression suites below passed.
- [ ] `pnpm build` - not run.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional targeted checks:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/floating-workspace-directory.test.ts src/main/runtime/orca-runtime.test.ts` - passed.
- [x] `pnpm --dir mobile exec vitest run src/session/use-mobile-pr-branch-context.test.ts src/worktree/resume-worktree.test.ts src/worktree/workspace-list-sections.test.ts` - passed.
- [x] `pnpm run typecheck:node` - passed.
- [x] `pnpm --dir mobile exec tsc --noEmit -p tsconfig.json` - passed.
- [x] `pnpm exec oxlint src/main/ipc/floating-workspace-directory.ts src/main/ipc/floating-workspace-directory.test.ts src/main/ipc/pty.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts src/shared/runtime-types.ts` - passed.
- [x] `pnpm --dir mobile exec oxlint 'app/h/[hostId]/index.tsx' 'app/h/[hostId]/session/[worktreeId].tsx' src/components/WorktreeListRow.tsx src/session/use-mobile-pr-branch-context.ts src/session/use-mobile-pr-branch-context.test.ts src/worktree/resume-worktree.ts src/worktree/resume-worktree.test.ts src/worktree/workspace-list-sections.ts src/worktree/workspace-list-sections.test.ts src/worktree/workspace-list-types.ts` - passed.

## AI Review Report

Reviewed the implementation for correctness, cross-platform behavior, SSH/remote/local behavior, supported agent/integration behavior, performance, UI quality, and security.

- Cross-platform: path containment uses path-aware exact-or-descendant checks rather than string-prefix matching. No shortcut or platform-label behavior is added.
- SSH/remote/local: floating terminal cwd trust is scoped to the floating sentinel path; local and remote-style path behavior is covered in runtime tests.
- Supported agents/integrations: the row is terminal-only and does not broaden git, PR, or file affordances for the floating sentinel.
- Performance: live floating cwd lookup is scoped to the sentinel and only feeds the existing mobile projection path.
- UI quality: mobile treats the synthetic row as a distinct floating terminal kind and hides controls that cannot work for a non-worktree sentinel.

## Security Audit

- Trust gate: only live floating PTYs with a cwd at or below the floating workspace directory are projected to mobile.
- Data minimization: mobile terminal/session outputs filter untrusted or hidden floating tabs so handles and scrollback are not exposed.
- No new dependencies, shell command construction, secret handling, or broad filesystem access.
- The sentinel remains excluded from managed git worktree registration and cold-launch resume.

## Notes

- Opened as draft because visual evidence is still pending for the mobile UI change.
- Related duplicate-guard findings reviewed before opening: #6222 hides stale mobile rows after terminals close, while this PR exposes live trusted floating rows; #6363/#6569 address folder-workspace file selectors; #5806 is the broader mobile Agents view context.

## ELI5

Trusted Floating Workspace terminals on desktop can appear on Mobile as a terminal-only row. Untrusted floating tabs stay hidden so random terminals do not leak to the phone.
