### PR TITLE
Keep mobile pairing data on stable userData path

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,12 @@ import os from 'node:os'
 import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import { electronApp, is } from '@electron-toolkit/utils'
 import * as QRCode from 'qrcode'
-import { Store, initDataPath, getCanonicalUserDataPath } from './persistence'
+import {
+  Store,
+  initDataPath,
+  getCanonicalUserDataPath,
+  migrateMobilePairingDataToCanonicalUserDataPath
+} from './persistence'
 import { applyAppIcon } from './app-icon'
 import { StatsCollector, initStatsPath } from './stats/collector'
 import { ClaudeUsageStore, initClaudeUsagePath } from './claude-usage/store'
@@ -1645,6 +1650,10 @@ app.whenReady().then(async () => {
     app.exit(1)
     return
   }
+  // Why: existing installs may have already written mobile pairing credentials
+  // under the late app.getPath('userData') directory. Copy any missing files
+  // forward before the runtime switches exclusively to the canonical path.
+  migrateMobilePairingDataToCanonicalUserDataPath(app.getPath('userData'))
   runtimeRpc = new OrcaRuntimeRpcServer({
     runtime,
     // Why: mobile pairing (DeviceRegistry + E2EE keypair + runtime metadata)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,7 @@ import os from 'node:os'
 import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import { electronApp, is } from '@electron-toolkit/utils'
 import * as QRCode from 'qrcode'
-import { Store, initDataPath } from './persistence'
+import { Store, initDataPath, getCanonicalUserDataPath } from './persistence'
 import { applyAppIcon } from './app-icon'
 import { StatsCollector, initStatsPath } from './stats/collector'
 import { ClaudeUsageStore, initClaudeUsagePath } from './claude-usage/store'
@@ -1647,7 +1647,11 @@ app.whenReady().then(async () => {
   }
   runtimeRpc = new OrcaRuntimeRpcServer({
     runtime,
-    userDataPath: app.getPath('userData'),
+    // Why: mobile pairing (DeviceRegistry + E2EE keypair + runtime metadata)
+    // must share the stable path captured before app.setName(), not a late
+    // app.getPath('userData') that resolves elsewhere and drops paired devices
+    // across restarts/updates. See persistence.ts:getCanonicalUserDataPath.
+    userDataPath: getCanonicalUserDataPath(),
     enableWebSocket: true,
     ...(isE2E ? { wsPort: 0 } : {}),
     ...(devWsPort !== undefined ? { wsPort: devWsPort } : {}),
@@ -1793,7 +1797,9 @@ app.on('will-quit', (e) => {
           .then(() => awaitRuntimeFileWatcherUnsubscribes())
           .then(() => {
             if (ownedRuntimeId) {
-              clearRuntimeMetadataIfOwned(app.getPath('userData'), ownedPid, ownedRuntimeId)
+              // Why: must match the path the runtime server wrote metadata to
+              // (getCanonicalUserDataPath), not late app.getPath('userData').
+              clearRuntimeMetadataIfOwned(getCanonicalUserDataPath(), ownedPid, ownedRuntimeId)
             }
           })
           .catch((error) => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -296,17 +296,36 @@ function retireLegacyInstructionsForClearedTextActionRecipes(
 // Solution: index.ts calls initDataPath() right after configureDevUserDataPath()
 // but before app.setName(), capturing the correct path at the right moment.
 let _dataFile: string | null = null
+let _userDataDir: string | null = null
 
 export function initDataPath(): void {
-  _dataFile = join(app.getPath('userData'), 'orca-data.json')
+  const userDataDir = app.getPath('userData')
+  _userDataDir = userDataDir
+  _dataFile = join(userDataDir, 'orca-data.json')
 }
 
 function getDataFile(): string {
   if (!_dataFile) {
     // Safety fallback — should not be hit in normal startup.
-    _dataFile = join(app.getPath('userData'), 'orca-data.json')
+    const userDataDir = app.getPath('userData')
+    _userDataDir = userDataDir
+    _dataFile = join(userDataDir, 'orca-data.json')
   }
   return _dataFile
+}
+
+// Why: returns the userData directory captured at initDataPath() time, before
+// app.setName() can change how app.getPath('userData') resolves. Subsystems that
+// must share storage with orca-data.json (mobile pairing's DeviceRegistry,
+// E2EE keypair, runtime metadata) read this instead of resolving the path late,
+// which on case-sensitive filesystems lands in a different directory and loses
+// paired devices across restarts/updates.
+export function getCanonicalUserDataPath(): string {
+  if (!_userDataDir) {
+    // Safety fallback — should not be hit in normal startup.
+    _userDataDir = app.getPath('userData')
+  }
+  return _userDataDir
 }
 
 // Why (issue #1158): keep 5 rolling backups of orca-data.json so a corrupt or

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -78,6 +78,7 @@ import {
   buildWorkspaceRunContext
 } from '../shared/task-source-context'
 import type { MigrationUnsupportedPtyEntry } from '../shared/agent-status-types'
+import { MOBILE_PAIRING_USERDATA_FILES } from './runtime/mobile-pairing-files'
 import type { SshRemotePtyLease, SshTarget } from '../shared/ssh-types'
 import { isFolderRepo } from '../shared/repo-kind'
 import { getGitUsername } from './git/repo'
@@ -298,8 +299,6 @@ function retireLegacyInstructionsForClearedTextActionRecipes(
 let _dataFile: string | null = null
 let _userDataDir: string | null = null
 
-const MOBILE_PAIRING_USERDATA_FILES = ['orca-devices.json', 'orca-e2ee-keypair.json'] as const
-
 export function initDataPath(): void {
   const userDataDir = app.getPath('userData')
   _userDataDir = userDataDir
@@ -332,21 +331,27 @@ export function getCanonicalUserDataPath(): string {
 
 // Why: existing installs may already have mobile pairing credentials in the
 // late app.getPath('userData') directory. Before switching the runtime server
-// to the canonical path, copy missing credentials forward non-destructively so
-// an update does not force one last re-pair.
+// to the canonical path, copy the registry + E2EE keypair forward as a pair so
+// an update does not force one last re-pair or mix devices with the wrong key.
 export function migrateMobilePairingDataToCanonicalUserDataPath(sourceUserDataDir: string): void {
   const targetUserDataDir = getCanonicalUserDataPath()
   if (resolve(sourceUserDataDir) === resolve(targetUserDataDir)) {
     return
   }
 
-  for (const fileName of MOBILE_PAIRING_USERDATA_FILES) {
-    const sourcePath = join(sourceUserDataDir, fileName)
-    const targetPath = join(targetUserDataDir, fileName)
-    if (!existsSync(sourcePath) || existsSync(targetPath)) {
-      continue
-    }
-    mkdirSync(dirname(targetPath), { recursive: true })
+  const migrations = MOBILE_PAIRING_USERDATA_FILES.map((fileName) => ({
+    sourcePath: join(sourceUserDataDir, fileName),
+    targetPath: join(targetUserDataDir, fileName)
+  }))
+  if (migrations.some(({ sourcePath }) => !existsSync(sourcePath))) {
+    return
+  }
+  if (migrations.some(({ targetPath }) => existsSync(targetPath))) {
+    return
+  }
+
+  mkdirSync(targetUserDataDir, { recursive: true })
+  for (const { sourcePath, targetPath } of migrations) {
     copyFileSync(sourcePath, targetPath)
   }
 }

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -315,12 +315,15 @@ function getDataFile(): string {
   return _dataFile
 }
 
-// Why: returns the userData directory captured at initDataPath() time, before
-// app.setName() can change how app.getPath('userData') resolves. Subsystems that
-// must share storage with orca-data.json (mobile pairing's DeviceRegistry,
-// E2EE keypair, runtime metadata) read this instead of resolving the path late,
-// which on case-sensitive filesystems lands in a different directory and loses
-// paired devices across restarts/updates.
+/**
+ * Return the userData directory captured at initDataPath() time, before
+ * app.setName() can change how app.getPath('userData') resolves.
+ *
+ * Subsystems that must share storage with orca-data.json (mobile pairing's
+ * DeviceRegistry, E2EE keypair, runtime metadata) read this instead of
+ * resolving the path late, which on case-sensitive filesystems can land in a
+ * different directory and lose paired devices across restarts/updates.
+ */
 export function getCanonicalUserDataPath(): string {
   if (!_userDataDir) {
     // Safety fallback — should not be hit in normal startup.
@@ -329,10 +332,14 @@ export function getCanonicalUserDataPath(): string {
   return _userDataDir
 }
 
-// Why: existing installs may already have mobile pairing credentials in the
-// late app.getPath('userData') directory. Before switching the runtime server
-// to the canonical path, copy the registry + E2EE keypair forward as a pair so
-// an update does not force one last re-pair or mix devices with the wrong key.
+/**
+ * Copy legacy mobile pairing credentials into the canonical userData directory.
+ *
+ * Existing installs may already have credentials in the late app.getPath('userData')
+ * directory. Before switching the runtime server to the canonical path, copy the
+ * registry and E2EE keypair forward as a pair so an update does not force one
+ * last re-pair or mix devices with the wrong key.
+ */
 export function migrateMobilePairingDataToCanonicalUserDataPath(sourceUserDataDir: string): void {
   const targetUserDataDir = getCanonicalUserDataPath()
   if (resolve(sourceUserDataDir) === resolve(targetUserDataDir)) {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -79,6 +79,7 @@ import {
 } from '../shared/task-source-context'
 import type { MigrationUnsupportedPtyEntry } from '../shared/agent-status-types'
 import { MOBILE_PAIRING_USERDATA_FILES } from './runtime/mobile-pairing-files'
+import { hardenExistingSecureFile } from '../shared/secure-file'
 import type { SshRemotePtyLease, SshTarget } from '../shared/ssh-types'
 import { isFolderRepo } from '../shared/repo-kind'
 import { getGitUsername } from './git/repo'
@@ -360,6 +361,10 @@ export function migrateMobilePairingDataToCanonicalUserDataPath(sourceUserDataDi
   mkdirSync(targetUserDataDir, { recursive: true })
   for (const { sourcePath, targetPath } of migrations) {
     copyFileSync(sourcePath, targetPath)
+    // Why: these are credential files (device tokens, E2EE secret key). copyFileSync
+    // does not carry Windows ACLs, so re-assert the current-user-only restriction on
+    // the copy instead of relying on the runtime's later lazy re-harden on read.
+    hardenExistingSecureFile(targetPath)
   }
 }
 

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -298,6 +298,8 @@ function retireLegacyInstructionsForClearedTextActionRecipes(
 let _dataFile: string | null = null
 let _userDataDir: string | null = null
 
+const MOBILE_PAIRING_USERDATA_FILES = ['orca-devices.json', 'orca-e2ee-keypair.json'] as const
+
 export function initDataPath(): void {
   const userDataDir = app.getPath('userData')
   _userDataDir = userDataDir
@@ -326,6 +328,27 @@ export function getCanonicalUserDataPath(): string {
     _userDataDir = app.getPath('userData')
   }
   return _userDataDir
+}
+
+// Why: existing installs may already have mobile pairing credentials in the
+// late app.getPath('userData') directory. Before switching the runtime server
+// to the canonical path, copy missing credentials forward non-destructively so
+// an update does not force one last re-pair.
+export function migrateMobilePairingDataToCanonicalUserDataPath(sourceUserDataDir: string): void {
+  const targetUserDataDir = getCanonicalUserDataPath()
+  if (resolve(sourceUserDataDir) === resolve(targetUserDataDir)) {
+    return
+  }
+
+  for (const fileName of MOBILE_PAIRING_USERDATA_FILES) {
+    const sourcePath = join(sourceUserDataDir, fileName)
+    const targetPath = join(targetUserDataDir, fileName)
+    if (!existsSync(sourcePath) || existsSync(targetPath)) {
+      continue
+    }
+    mkdirSync(dirname(targetPath), { recursive: true })
+    copyFileSync(sourcePath, targetPath)
+  }
 }
 
 // Why (issue #1158): keep 5 rolling backups of orca-data.json so a corrupt or

--- a/src/main/runtime/device-registry.ts
+++ b/src/main/runtime/device-registry.ts
@@ -6,8 +6,7 @@ import { randomBytes, randomUUID } from 'crypto'
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { hardenExistingSecureFile, writeSecureJsonFile } from '../../shared/secure-file'
-
-const DEVICE_REGISTRY_FILENAME = 'orca-devices.json'
+import { DEVICE_REGISTRY_FILENAME } from './mobile-pairing-files'
 
 export type DeviceScope = 'mobile' | 'runtime'
 

--- a/src/main/runtime/e2ee-keypair.ts
+++ b/src/main/runtime/e2ee-keypair.ts
@@ -5,8 +5,9 @@ import { existsSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import nacl from 'tweetnacl'
 import { hardenExistingSecureFile, writeSecureJsonFile } from '../../shared/secure-file'
+import { E2EE_KEYPAIR_FILENAME } from './mobile-pairing-files'
 
-const KEYPAIR_FILENAME = 'orca-e2ee-keypair.json'
+const KEYPAIR_FILENAME = E2EE_KEYPAIR_FILENAME
 const KEYPAIR_VERSION = 1
 const MAX_KEYPAIR_FILE_BYTES = 8 * 1024
 

--- a/src/main/runtime/mobile-pairing-files.ts
+++ b/src/main/runtime/mobile-pairing-files.ts
@@ -1,6 +1,7 @@
 export const DEVICE_REGISTRY_FILENAME = 'orca-devices.json'
 export const E2EE_KEYPAIR_FILENAME = 'orca-e2ee-keypair.json'
 
+// Migrate these together so device tokens and E2EE material never split across dirs.
 export const MOBILE_PAIRING_USERDATA_FILES = [
   DEVICE_REGISTRY_FILENAME,
   E2EE_KEYPAIR_FILENAME

--- a/src/main/runtime/mobile-pairing-files.ts
+++ b/src/main/runtime/mobile-pairing-files.ts
@@ -1,0 +1,7 @@
+export const DEVICE_REGISTRY_FILENAME = 'orca-devices.json'
+export const E2EE_KEYPAIR_FILENAME = 'orca-e2ee-keypair.json'
+
+export const MOBILE_PAIRING_USERDATA_FILES = [
+  DEVICE_REGISTRY_FILENAME,
+  E2EE_KEYPAIR_FILENAME
+] as const

--- a/src/main/runtime/mobile-pairing-userdata-path.test.ts
+++ b/src/main/runtime/mobile-pairing-userdata-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -79,6 +79,48 @@ describe('mobile pairing userData path stability', () => {
     // The bug being guarded: the late path would have captured these instead.
     expect(existsSync(join(lateDir, DEVICE_REGISTRY_FILENAME))).toBe(false)
     expect(existsSync(join(lateDir, E2EE_KEYPAIR_FILENAME))).toBe(false)
+  })
+
+  it('migrates existing mobile pairing files from the late path without overwriting canonical files', async () => {
+    appState.userData = canonicalDir
+    const {
+      initDataPath,
+      getCanonicalUserDataPath,
+      migrateMobilePairingDataToCanonicalUserDataPath
+    } = await import('../persistence')
+    initDataPath()
+
+    appState.userData = lateDir
+    const lateDevices = JSON.stringify([
+      {
+        deviceId: 'late-phone',
+        name: 'iPhone',
+        token: 'late-token',
+        scope: 'mobile',
+        pairedAt: 1,
+        lastSeenAt: 2
+      }
+    ])
+    const lateKeypair = JSON.stringify({
+      v: 1,
+      publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64'),
+      secretKeyB64: Buffer.from(new Uint8Array(32).fill(2)).toString('base64')
+    })
+    writeFileSync(join(lateDir, DEVICE_REGISTRY_FILENAME), lateDevices)
+    writeFileSync(join(lateDir, E2EE_KEYPAIR_FILENAME), lateKeypair)
+
+    migrateMobilePairingDataToCanonicalUserDataPath(appState.userData)
+
+    expect(readFileSync(join(canonicalDir, DEVICE_REGISTRY_FILENAME), 'utf-8')).toBe(lateDevices)
+    expect(readFileSync(join(canonicalDir, E2EE_KEYPAIR_FILENAME), 'utf-8')).toBe(lateKeypair)
+
+    const { DeviceRegistry } = await import('./device-registry')
+    const registry = new DeviceRegistry(getCanonicalUserDataPath())
+    expect(registry.getDevice('late-phone')?.token).toBe('late-token')
+
+    writeFileSync(join(lateDir, DEVICE_REGISTRY_FILENAME), JSON.stringify([]))
+    migrateMobilePairingDataToCanonicalUserDataPath(appState.userData)
+    expect(readFileSync(join(canonicalDir, DEVICE_REGISTRY_FILENAME), 'utf-8')).toBe(lateDevices)
   })
 
   it('a previously paired device is still found after a restart on the canonical path', async () => {

--- a/src/main/runtime/mobile-pairing-userdata-path.test.ts
+++ b/src/main/runtime/mobile-pairing-userdata-path.test.ts
@@ -81,7 +81,7 @@ describe('mobile pairing userData path stability', () => {
     expect(existsSync(join(lateDir, E2EE_KEYPAIR_FILENAME))).toBe(false)
   })
 
-  it('migrates existing mobile pairing files from the late path without overwriting canonical files', async () => {
+  it('migrates existing mobile pairing files from the late path as an all-or-nothing pair', async () => {
     appState.userData = canonicalDir
     const {
       initDataPath,
@@ -121,6 +121,43 @@ describe('mobile pairing userData path stability', () => {
     writeFileSync(join(lateDir, DEVICE_REGISTRY_FILENAME), JSON.stringify([]))
     migrateMobilePairingDataToCanonicalUserDataPath(appState.userData)
     expect(readFileSync(join(canonicalDir, DEVICE_REGISTRY_FILENAME), 'utf-8')).toBe(lateDevices)
+  })
+
+  it('skips legacy migration when only part of the canonical credential pair exists', async () => {
+    appState.userData = canonicalDir
+    const { initDataPath, migrateMobilePairingDataToCanonicalUserDataPath } =
+      await import('../persistence')
+    initDataPath()
+
+    appState.userData = lateDir
+    const lateDevices = JSON.stringify([
+      {
+        deviceId: 'late-phone',
+        name: 'iPhone',
+        token: 'late-token',
+        scope: 'mobile',
+        pairedAt: 1,
+        lastSeenAt: 2
+      }
+    ])
+    const lateKeypair = JSON.stringify({
+      v: 1,
+      publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64'),
+      secretKeyB64: Buffer.from(new Uint8Array(32).fill(2)).toString('base64')
+    })
+    const canonicalKeypair = JSON.stringify({
+      v: 1,
+      publicKeyB64: Buffer.from(new Uint8Array(32).fill(3)).toString('base64'),
+      secretKeyB64: Buffer.from(new Uint8Array(32).fill(4)).toString('base64')
+    })
+    writeFileSync(join(lateDir, DEVICE_REGISTRY_FILENAME), lateDevices)
+    writeFileSync(join(lateDir, E2EE_KEYPAIR_FILENAME), lateKeypair)
+    writeFileSync(join(canonicalDir, E2EE_KEYPAIR_FILENAME), canonicalKeypair)
+
+    migrateMobilePairingDataToCanonicalUserDataPath(appState.userData)
+
+    expect(existsSync(join(canonicalDir, DEVICE_REGISTRY_FILENAME))).toBe(false)
+    expect(readFileSync(join(canonicalDir, E2EE_KEYPAIR_FILENAME), 'utf-8')).toBe(canonicalKeypair)
   })
 
   it('a previously paired device is still found after a restart on the canonical path', async () => {

--- a/src/main/runtime/mobile-pairing-userdata-path.test.ts
+++ b/src/main/runtime/mobile-pairing-userdata-path.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
+// Import from the production source of truth so a filename rename can't silently
+// pass these tests against stale names.
+import { DEVICE_REGISTRY_FILENAME, E2EE_KEYPAIR_FILENAME } from './mobile-pairing-files'
 
 // Mutable userData the electron mock resolves. We flip it mid-test to simulate
 // app.setName('Orca') changing how app.getPath('userData') resolves (e.g. from
@@ -19,9 +22,6 @@ vi.mock('electron', () => ({
     decryptString: (ciphertext: Buffer) => ciphertext.toString('utf-8')
   }
 }))
-
-const DEVICE_REGISTRY_FILENAME = 'orca-devices.json'
-const E2EE_KEYPAIR_FILENAME = 'orca-e2ee-keypair.json'
 
 describe('mobile pairing userData path stability', () => {
   let root: string
@@ -158,6 +158,35 @@ describe('mobile pairing userData path stability', () => {
 
     expect(existsSync(join(canonicalDir, DEVICE_REGISTRY_FILENAME))).toBe(false)
     expect(readFileSync(join(canonicalDir, E2EE_KEYPAIR_FILENAME), 'utf-8')).toBe(canonicalKeypair)
+  })
+
+  it('no-ops when the source path equals the canonical path (no rename happened)', async () => {
+    // Case-insensitive filesystems (macOS/Windows) resolve both paths to the same
+    // dir, so migration must be a clean no-op rather than copy a file onto itself.
+    appState.userData = canonicalDir
+    const { initDataPath, migrateMobilePairingDataToCanonicalUserDataPath } =
+      await import('../persistence')
+    initDataPath()
+
+    const devices = JSON.stringify([
+      { deviceId: 'phone', name: 'iPhone', token: 't', scope: 'mobile', pairedAt: 1, lastSeenAt: 2 }
+    ])
+    writeFileSync(join(canonicalDir, DEVICE_REGISTRY_FILENAME), devices)
+
+    expect(() => migrateMobilePairingDataToCanonicalUserDataPath(canonicalDir)).not.toThrow()
+    expect(readFileSync(join(canonicalDir, DEVICE_REGISTRY_FILENAME), 'utf-8')).toBe(devices)
+  })
+
+  it('no-ops on a fresh install with no legacy pairing files to migrate', async () => {
+    appState.userData = canonicalDir
+    const { initDataPath, migrateMobilePairingDataToCanonicalUserDataPath } =
+      await import('../persistence')
+    initDataPath()
+
+    appState.userData = lateDir
+    expect(() => migrateMobilePairingDataToCanonicalUserDataPath(appState.userData)).not.toThrow()
+    expect(existsSync(join(canonicalDir, DEVICE_REGISTRY_FILENAME))).toBe(false)
+    expect(existsSync(join(canonicalDir, E2EE_KEYPAIR_FILENAME))).toBe(false)
   })
 
   it('a previously paired device is still found after a restart on the canonical path', async () => {

--- a/src/main/runtime/mobile-pairing-userdata-path.test.ts
+++ b/src/main/runtime/mobile-pairing-userdata-path.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+// Mutable userData the electron mock resolves. We flip it mid-test to simulate
+// app.setName('Orca') changing how app.getPath('userData') resolves (e.g. from
+// lowercase 'orca' to uppercase 'Orca' on a case-sensitive filesystem) — the
+// divergence that drops paired devices. We use two genuinely distinct directory
+// names rather than case variants so the assertion is deterministic regardless
+// of whether the test host's filesystem is case-sensitive.
+const appState = { userData: '' }
+
+vi.mock('electron', () => ({
+  app: { getPath: () => appState.userData },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (plaintext: string) => Buffer.from(plaintext, 'utf-8'),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString('utf-8')
+  }
+}))
+
+const DEVICE_REGISTRY_FILENAME = 'orca-devices.json'
+const E2EE_KEYPAIR_FILENAME = 'orca-e2ee-keypair.json'
+
+describe('mobile pairing userData path stability', () => {
+  let root: string
+  // The path persistence captures early, before app.setName().
+  let canonicalDir: string
+  // The path app.getPath('userData') resolves to after app.setName() — a
+  // distinct directory standing in for the post-rename resolution.
+  let lateDir: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-pairing-path-'))
+    canonicalDir = join(root, 'userdata-early')
+    lateDir = join(root, 'userdata-late')
+    mkdirSync(canonicalDir, { recursive: true })
+    mkdirSync(lateDir, { recursive: true })
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+    vi.resetModules()
+  })
+
+  it('keeps returning the path captured before app.setName changes resolution', async () => {
+    appState.userData = canonicalDir
+    const { initDataPath, getCanonicalUserDataPath } = await import('../persistence')
+    initDataPath()
+
+    // app.setName('Orca') happens later in startup, changing late resolution.
+    appState.userData = lateDir
+
+    expect(getCanonicalUserDataPath()).toBe(canonicalDir)
+    const { app } = await import('electron')
+    expect(getCanonicalUserDataPath()).not.toBe(app.getPath('userData'))
+  })
+
+  it('writes DeviceRegistry + E2EE keypair under the canonical path, not the late one', async () => {
+    appState.userData = canonicalDir
+    const { initDataPath, getCanonicalUserDataPath } = await import('../persistence')
+    initDataPath()
+
+    appState.userData = lateDir // app.setName('Orca') has run by the time the runtime starts
+
+    const { DeviceRegistry } = await import('./device-registry')
+    const { loadOrCreateE2EEKeypair } = await import('./e2ee-keypair')
+
+    // Mirrors OrcaRuntimeRpcServer.start(): both read from the same userDataPath.
+    const registry = new DeviceRegistry(getCanonicalUserDataPath())
+    registry.addDevice('iPhone')
+    loadOrCreateE2EEKeypair(getCanonicalUserDataPath())
+
+    // Pairing credentials land beside orca-data.json so they survive restarts/updates.
+    expect(existsSync(join(canonicalDir, DEVICE_REGISTRY_FILENAME))).toBe(true)
+    expect(existsSync(join(canonicalDir, E2EE_KEYPAIR_FILENAME))).toBe(true)
+    // The bug being guarded: the late path would have captured these instead.
+    expect(existsSync(join(lateDir, DEVICE_REGISTRY_FILENAME))).toBe(false)
+    expect(existsSync(join(lateDir, E2EE_KEYPAIR_FILENAME))).toBe(false)
+  })
+
+  it('a previously paired device is still found after a restart on the canonical path', async () => {
+    // First launch: pair a device while userData resolves to the canonical path.
+    appState.userData = canonicalDir
+    {
+      const { initDataPath, getCanonicalUserDataPath } = await import('../persistence')
+      initDataPath()
+      appState.userData = lateDir
+      const { DeviceRegistry } = await import('./device-registry')
+      new DeviceRegistry(getCanonicalUserDataPath()).addDevice('iPhone')
+    }
+
+    // Second launch (e.g. after an update): fresh module state, path captured again.
+    vi.resetModules()
+    appState.userData = canonicalDir
+    const { initDataPath, getCanonicalUserDataPath } = await import('../persistence')
+    initDataPath()
+    appState.userData = lateDir
+    const { DeviceRegistry } = await import('./device-registry')
+    const registry = new DeviceRegistry(getCanonicalUserDataPath())
+
+    expect(registry.listDevices().map((d) => d.name)).toContain('iPhone')
+  })
+})


### PR DESCRIPTION
## Problem

Updating or restarting the desktop app can make already-paired mobile companion devices appear unpaired, forcing users to scan the pairing QR code again. This is especially painful on frequent RC/dev desktop updates because every connected phone/tablet may need to be paired again multiple times per day.

The root cause is a userData path split during startup: main persistence already captures Electron's stable `userData` path before `app.setName(...)`, but the runtime WebSocket server resolved `app.getPath('userData')` later. If Electron resolves a different app-data directory after the app name changes, mobile pairing credentials (`orca-devices.json`) and the E2EE keypair can be written/read from the wrong directory after an update/restart.

## Summary
- capture and expose the canonical userData path already used for main persistence
- migrate existing mobile pairing credential files from the legacy late `userData` path when canonical files are missing, so current users do not have to re-pair once after upgrading
- start the runtime WebSocket server with the stable path so mobile device tokens, E2EE keys, and runtime metadata do not move after `app.setName()`/restart/update
- clean up runtime metadata from the same canonical path used to write it
- add regression coverage for app-name-driven userData path changes, legacy pairing-file migration, and previously paired devices surviving a restart

## Review
- Re-reviewed the updated diff with Codex after adding migration; it reported no correctness issues in the changed files.

## Tests
- `pnpm vitest run --config config/vitest.config.ts src/main/runtime/mobile-pairing-userdata-path.test.ts src/main/runtime/runtime-rpc.test.ts src/main/runtime/runtime-metadata.test.ts`
- `pnpm exec oxfmt --check src/main/index.ts src/main/persistence.ts src/main/runtime/mobile-pairing-userdata-path.test.ts && pnpm exec oxlint src/main/index.ts src/main/persistence.ts src/main/runtime/mobile-pairing-userdata-path.test.ts`
- `pnpm run typecheck:node`

Note: local Node is v22.22.3, so pnpm printed the existing repo engine warning for Node 24, but all commands exited 0.
