### PR TITLE
fix(mobile): render RTL terminal rows with bidi plaintext

### DIFF
--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -67,6 +67,12 @@ export const XTERM_HTML = `<!DOCTYPE html>
     display: inline-block;
   }
   .xterm { -webkit-user-select: none; user-select: none; font-variant-emoji: text; }
+  .xterm .xterm-rows > div {
+    unicode-bidi: plaintext;
+  }
+  .xterm .xterm-rows > div[data-orca-rtl-row="true"] > span {
+    display: inline !important;
+  }
   .xterm .xterm-viewport {
     overflow-y: hidden !important;
     scrollbar-width: none !important;
@@ -285,6 +291,9 @@ export const XTERM_HTML = `<!DOCTYPE html>
   // once when the first live data chunk arrives so a wider line that pushes
   // scrollWidth past the previously-measured value gets re-scaled to fit.
   var firstDataPending = false;
+  var FORCE_DOM_RENDERER_FOR_RTL = true;
+  var RTL_TEXT_PATTERN = /[\u0590-\u08ff\ufb1d-\ufefc]/;
+  var rtlRowsScheduled = false;
 
   // Diagnostic logger — bridges WebView console.log to RN via postMessage.
   // Tag with [fit] so it's easy to filter in the Expo/Metro logs.
@@ -617,6 +626,27 @@ export const XTERM_HTML = `<!DOCTYPE html>
     }
   }
 
+  function markTerminalRtlRows() {
+    rtlRowsScheduled = false;
+    if (!term || !term.element || typeof term.element.querySelectorAll !== 'function') return;
+    var rows = term.element.querySelectorAll('.xterm-rows > div');
+    for (var i = 0; i < rows.length; i++) {
+      var row = rows[i];
+      var text = row.textContent || '';
+      if (RTL_TEXT_PATTERN.test(text)) {
+        row.setAttribute('data-orca-rtl-row', 'true');
+      } else {
+        row.removeAttribute('data-orca-rtl-row');
+      }
+    }
+  }
+
+  function scheduleTerminalRtlRows() {
+    if (rtlRowsScheduled) return;
+    rtlRowsScheduled = true;
+    requestAnimationFrame(markTerminalRtlRows);
+  }
+
   function extractMouseModeScanTail(input) {
     var start = Math.max(input.lastIndexOf(ESC), input.lastIndexOf(C1_CSI));
     if (start === -1) return '';
@@ -648,6 +678,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
     // wait until replayed SGR attributes have landed in the buffer.
     term.write(next, function() {
       if (gen !== terminalGeneration) return;
+      scheduleTerminalRtlRows();
       writesDraining = false;
       pumpWrites(gen);
     });
@@ -729,7 +760,8 @@ export const XTERM_HTML = `<!DOCTYPE html>
       allowProposedApi: true
     });
     term.open(surface);
-    if (window.WebglAddon && window.WebglAddon.WebglAddon) {
+    scheduleTerminalRtlRows();
+    if (!FORCE_DOM_RENDERER_FOR_RTL && window.WebglAddon && window.WebglAddon.WebglAddon) {
       try { var webglAddon = new window.WebglAddon.WebglAddon(); term.loadAddon(webglAddon); if (webglAddon.onContextLoss) webglAddon.onContextLoss(function() { try { webglAddon && webglAddon.dispose && webglAddon.dispose(); } catch (e) {} }); } catch (e) {}
     }
     if (window.Unicode11Addon && window.Unicode11Addon.Unicode11Addon) try { term.loadAddon(new window.Unicode11Addon.Unicode11Addon()); term.unicode.activeVersion = '11'; } catch (e) {}
@@ -763,6 +795,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
         captureInitialOscLinkTexts();
         initialOscLinkRowOffset = 0;
         initialOscLinkEvictionReady = true;
+        scheduleTerminalRtlRows();
         applyFitScale('init-replay');
         notify({ type: 'ready', cols: cols, rows: rows });
       });
@@ -791,6 +824,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
     if (!term) return;
     initRows = rows || initRows;
     term.resize(cols || term.cols, rows || term.rows);
+    scheduleTerminalRtlRows();
     applyFitScale('resize-msg');
     notify({ type: 'ready', cols: cols, rows: rows });
   }
@@ -902,7 +936,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
       initialOscLinks = [];
       initialOscLinkRowOffset = 0;
       initialOscLinkEvictionReady = false;
-      if (term) { term.clear(); term.reset(); }
+      if (term) { term.clear(); term.reset(); scheduleTerminalRtlRows(); }
       emitModesIfChanged();
       resetEvictionCounter();
       if (selMode === 'select') {
@@ -1063,7 +1097,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
     disposeTermObservers();
     try { termObserverDisposables.push(term.onLineFeed(logFeedAndEvict)); } catch (e) {}
     try {
-      termObserverDisposables.push(term.onScroll(function() { updateScrollIndicator(false); }));
+      termObserverDisposables.push(term.onScroll(function() { updateScrollIndicator(false); scheduleTerminalRtlRows(); }));
     } catch (e) {}
     // Why: emit modes on every parsed write so RN's mirror stays current
     // without round-trip; covers \\x1b[?2004h/l and alt-screen toggles.
@@ -1072,6 +1106,7 @@ export const XTERM_HTML = `<!DOCTYPE html>
         termObserverDisposables.push(term.onWriteParsed(function() {
           emitModesIfChanged();
           emitKeyboardAvoidanceMetrics();
+          scheduleTerminalRtlRows();
         }));
       }
     } catch (e) {}

--- a/mobile/src/terminal/terminal-webview-rtl.test.ts
+++ b/mobile/src/terminal/terminal-webview-rtl.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { XTERM_HTML } from './terminal-webview-html'
+
+const htmlSource = readFileSync(new URL('./terminal-webview-html.ts', import.meta.url), 'utf8')
+
+describe('TerminalWebView RTL rows', () => {
+  it('BUG-R1 uses the DOM renderer so row-level bidi CSS can affect mobile xterm output', () => {
+    const guard = htmlSource.indexOf('if (!FORCE_DOM_RENDERER_FOR_RTL && window.WebglAddon')
+    const addon = htmlSource.indexOf('new window.WebglAddon.WebglAddon()')
+
+    expect(htmlSource).toContain('var FORCE_DOM_RENDERER_FOR_RTL = true')
+    expect(guard).toBeGreaterThanOrEqual(0)
+    expect(addon).toBeGreaterThan(guard)
+  })
+
+  it('BUG-R2 adds plaintext bidi handling and inline spans for rows that contain RTL text', () => {
+    expect(XTERM_HTML).toContain('unicode-bidi: plaintext')
+    expect(XTERM_HTML).toContain('data-orca-rtl-row="true"] > span')
+    expect(htmlSource).toContain('var RTL_TEXT_PATTERN = /[\\u0590-\\u08ff\\ufb1d-\\ufefc]/')
+    expect(XTERM_HTML).toContain("row.setAttribute('data-orca-rtl-row', 'true')")
+    expect(XTERM_HTML).toContain("row.removeAttribute('data-orca-rtl-row')")
+  })
+
+  it('BUG-R3 refreshes RTL row markers after the terminal changes visible rows', () => {
+    expect(XTERM_HTML).toContain('function scheduleTerminalRtlRows()')
+    expect(XTERM_HTML).toContain('term.write(next, function()')
+    expect(XTERM_HTML).toContain('term.onScroll(function()')
+    expect(XTERM_HTML).toContain('term.onWriteParsed(function()')
+    expect(XTERM_HTML).toContain('scheduleTerminalRtlRows();')
+  })
+})

--- a/mobile/vitest.config.ts
+++ b/mobile/vitest.config.ts
@@ -1,26 +1,14 @@
 import { defineConfig } from 'vitest/config'
+import type { OxcOptions } from 'vite'
 import { fileURLToPath } from 'node:url'
 
-const tsconfigRaw = JSON.stringify({
-  compilerOptions: {
-    jsx: 'react-jsx',
-    module: 'esnext',
-    moduleResolution: 'bundler',
-    strict: true,
-    target: 'es2022'
-  }
-})
+// Vite 8's public OxcOptions type omits `tsconfig`, but the transform path
+// accepts it; without this, Vitest's oxc transform fails to locate tsconfig.
+const oxcNoTsconfigLookup = { tsconfig: false } as unknown as OxcOptions
 
 export default defineConfig({
   root: fileURLToPath(new URL('.', import.meta.url)),
-  esbuild: {
-    tsconfigRaw
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      tsconfigRaw
-    }
-  },
+  oxc: oxcNoTsconfigLookup,
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts']


### PR DESCRIPTION
## Summary

Describe the user-visible change.

## Screenshots

- Add screenshots or a screen recording for any new or changed UI behavior.
- If there is no visual change, say `No visual change`.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Summarize the code review you ran with your AI coding agent. Include the main risks it checked, what it flagged, and what you changed or verified as a result.
Confirm that the review explicitly checked cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and any Electron-specific platform differences touched by this PR.

## Security Audit

Provide a basic security audit summary from your AI coding agent. Call out any input handling, command execution, path handling, auth, secrets, dependency, or IPC risks that were reviewed, plus any follow-up needed.

## Notes

Call out any platform-specific behavior, risks, or follow-up work.

## ELI5

Mobile terminal rows with right-to-left text rendered poorly. They now use proper bidi plaintext so RTL languages display correctly in the terminal view.
