### PR TITLE
fix(mobile): fail fast when iOS App Store train is closed

### DIFF
--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       bump_patch_version:
-        description: 'Bump the iOS marketing version patch number before release'
+        description: 'Force a marketing version patch bump. Usually unnecessary: a released version auto-bumps. Use this to start a new version while the current one is still open (beta iteration).'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       bump_patch_version:
-        description: 'Force a marketing version patch bump. Usually unnecessary: a version whose App Store train is closed (submitted/approved/released) auto-bumps. Use this to start a new version while the current one is still open (beta iteration).'
+        description: 'Bump the iOS marketing version patch number before release. Tick this after a version has shipped to the App Store (the release fails fast if the current version''s train is already closed).'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       bump_patch_version:
-        description: 'Force a marketing version patch bump. Usually unnecessary: a released version auto-bumps. Use this to start a new version while the current one is still open (beta iteration).'
+        description: 'Force a marketing version patch bump. Usually unnecessary: a version whose App Store train is closed (submitted/approved/released) auto-bumps. Use this to start a new version while the current one is still open (beta iteration).'
         required: false
         default: false
         type: boolean

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -86,19 +86,20 @@ def resolve_requested_version(options, config)
 end
 
 # Returns true when `version`'s App Store train is closed to new build uploads.
-# app_store_connect_api_key (set_spaceship_token: true, the default) has already
-# authenticated Spaceship::ConnectAPI globally, so no extra auth is needed here.
+# `app` is a Spaceship::ConnectAPI::App fetched once by the caller so a bump that
+# advances across several versions doesn't re-fetch the app on every probe.
 # On any API error, degrade to "open": the upload then either succeeds or fails
 # with the same 90186 we have always seen — never worse than today's behavior.
-def version_train_closed?(version)
-  app = Spaceship::ConnectAPI::App.find(BUNDLE_ID)
+def version_train_closed?(app, version)
   return false unless app
 
   app
     .get_app_store_versions(filter: { versionString: version })
     .any? { |app_store_version| CLOSED_APP_STORE_STATES.include?(app_store_version.app_store_state) }
 rescue StandardError => error
-  UI.important("Could not determine App Store state for #{version} (#{error.message}); assuming open.")
+  # Loud, not silent: a swallowed error here un-fixes the 90186 guard, so the
+  # degraded run must be visible rather than buried.
+  UI.error("Could not determine App Store state for #{version} (#{error.message}); assuming open and proceeding.")
   false
 end
 
@@ -115,11 +116,21 @@ platform :ios do
     version = resolve_requested_version(options, config)
     explicit_version = !options[:version].to_s.strip.empty?
 
+    # Fetched once and reused across the closed-train probes below. On lookup
+    # failure, leave it nil — version_train_closed? then degrades to "open".
+    app =
+      begin
+        Spaceship::ConnectAPI::App.find(BUNDLE_ID)
+      rescue StandardError => error
+        UI.error("Could not look up App Store app #{BUNDLE_ID} (#{error.message}); skipping closed-train check.")
+        nil
+      end
+
     # A closed train (version already submitted/approved/released) cannot accept
     # more builds, so Apple would reject the upload (~20 min later) with 90186.
     # Auto-bump the patch in the default path; if the caller pinned an exact
     # version, fail loudly rather than silently overriding their choice.
-    if version_train_closed?(version)
+    if version_train_closed?(app, version)
       if explicit_version
         UI.user_error!(
           "Requested iOS version #{version} is already submitted/released on the App Store " \
@@ -129,11 +140,15 @@ platform :ios do
       # Advance until we find an open train (handles the rare case where the
       # next patch was also already shipped). Bounded to avoid an infinite loop.
       original = version
+      landed_open = false
       10.times do
         version = bump_patch_version(version)
-        break unless version_train_closed?(version)
+        unless version_train_closed?(app, version)
+          landed_open = true
+          break
+        end
       end
-      UI.user_error!("Could not find an open iOS version train after #{original}.") if version_train_closed?(version)
+      UI.user_error!("Could not find an open iOS version train after #{original}.") unless landed_open
       UI.message("iOS version #{original} is closed for new builds; bumping to #{version}.")
     end
 

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -86,10 +86,10 @@ def resolve_requested_version(options, config)
 end
 
 # Returns true when `version`'s App Store train is closed to new build uploads.
-# `app` is a Spaceship::ConnectAPI::App fetched once by the caller so a bump that
-# advances across several versions doesn't re-fetch the app on every probe.
-# On any API error, degrade to "open": the upload then either succeeds or fails
-# with the same 90186 we have always seen — never worse than today's behavior.
+# `app` is a Spaceship::ConnectAPI::App the caller looks up (nil if lookup
+# failed). On a nil app or any API error, degrade to "open": we then proceed as
+# before this check existed — the upload either succeeds or fails with the same
+# 90186 we have always seen, never worse than today's behavior.
 def version_train_closed?(app, version)
   return false unless app
 
@@ -114,10 +114,12 @@ platform :ios do
     api_key = app_store_connect_api_key_from_env
     config = load_mobile_app_config
     version = resolve_requested_version(options, config)
-    explicit_version = !options[:version].to_s.strip.empty?
 
-    # Fetched once and reused across the closed-train probes below. On lookup
-    # failure, leave it nil — version_train_closed? then degrades to "open".
+    # Fail fast (seconds) if the resolved version's App Store train is already
+    # closed: Apple would otherwise reject the upload ~20 min later with 90186.
+    # Bumping the version is left to the human (the bump_patch input or a
+    # "Prepare mobile X" commit) so the marketing version stays a deliberate,
+    # release-notes-bearing decision rather than something CI invents.
     app =
       begin
         Spaceship::ConnectAPI::App.find(BUNDLE_ID)
@@ -125,31 +127,12 @@ platform :ios do
         UI.error("Could not look up App Store app #{BUNDLE_ID} (#{error.message}); skipping closed-train check.")
         nil
       end
-
-    # A closed train (version already submitted/approved/released) cannot accept
-    # more builds, so Apple would reject the upload (~20 min later) with 90186.
-    # Auto-bump the patch in the default path; if the caller pinned an exact
-    # version, fail loudly rather than silently overriding their choice.
     if version_train_closed?(app, version)
-      if explicit_version
-        UI.user_error!(
-          "Requested iOS version #{version} is already submitted/released on the App Store " \
-          "and cannot accept new builds. Choose a higher release_version.",
-        )
-      end
-      # Advance until we find an open train (handles the rare case where the
-      # next patch was also already shipped). Bounded to avoid an infinite loop.
-      original = version
-      landed_open = false
-      10.times do
-        version = bump_patch_version(version)
-        unless version_train_closed?(app, version)
-          landed_open = true
-          break
-        end
-      end
-      UI.user_error!("Could not find an open iOS version train after #{original}.") unless landed_open
-      UI.message("iOS version #{original} is closed for new builds; bumping to #{version}.")
+      UI.user_error!(
+        "iOS version #{version} is already submitted/released on the App Store and cannot accept " \
+        "new builds. Re-dispatch with bump_patch_version: true (or a higher release_version), " \
+        "or land a \"Prepare mobile <version>\" commit.",
+      )
     end
 
     latest_build_number = latest_testflight_build_number(

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -30,6 +30,23 @@ BUNDLE_ID = "com.stably.orca.mobile"
 TESTFLIGHT_GROUPS = ["peeps"].freeze
 DEFAULT_TESTFLIGHT_CHANGELOG = "Latest Orca Mobile updates and fixes.".freeze
 
+# App Store version states in which the version "train" no longer accepts new
+# TestFlight build uploads (altool rejects with 90186 "train ... is closed").
+# Once a version has been submitted/approved/released, builds must go under a
+# higher marketing version. PROCESSING_FOR_APP_STORE / IN_REVIEW are included
+# conservatively: a build is already committed to that train.
+CLOSED_APP_STORE_STATES = %w[
+  READY_FOR_SALE
+  PENDING_DEVELOPER_RELEASE
+  PENDING_APPLE_RELEASE
+  PROCESSING_FOR_APP_STORE
+  IN_REVIEW
+  WAITING_FOR_REVIEW
+  REPLACED_WITH_NEW_VERSION
+  REMOVED_FROM_SALE
+  DEVELOPER_REMOVED_FROM_SALE
+].freeze
+
 def app_store_connect_api_key_from_env
   app_store_connect_api_key(
     key_id: ENV.fetch("ASC_KEY_ID"),
@@ -71,6 +88,18 @@ def resolve_requested_version(options, config)
   truthy_option?(options[:bump_patch]) ? bump_patch_version(current_version) : current_version
 end
 
+# Returns true when `version`'s App Store train is closed to new build uploads.
+# app_store_connect_api_key (set_spaceship_token: true, the default) has already
+# authenticated Spaceship::ConnectAPI globally, so no extra auth is needed here.
+def version_train_closed?(version)
+  app = Spaceship::ConnectAPI::App.find(BUNDLE_ID)
+  return false unless app
+
+  app
+    .get_app_store_versions(filter: { versionString: version })
+    .any? { |app_store_version| CLOSED_APP_STORE_STATES.include?(app_store_version.app_store_state) }
+end
+
 def testflight_changelog
   changelog = ENV.fetch("TESTFLIGHT_CHANGELOG", "").strip
   changelog.empty? ? DEFAULT_TESTFLIGHT_CHANGELOG : changelog
@@ -82,6 +111,29 @@ platform :ios do
     api_key = app_store_connect_api_key_from_env
     config = load_mobile_app_config
     version = resolve_requested_version(options, config)
+    explicit_version = !options[:version].to_s.strip.empty?
+
+    # A closed train (version already submitted/approved/released) cannot accept
+    # more builds, so Apple would reject the upload (~20 min later) with 90186.
+    # Auto-bump the patch in the default path; if the caller pinned an exact
+    # version, fail loudly rather than silently overriding their choice.
+    if version_train_closed?(version)
+      if explicit_version
+        UI.user_error!(
+          "Requested iOS version #{version} is already submitted/released on the App Store " \
+          "and cannot accept new builds. Choose a higher release_version.",
+        )
+      end
+      # Advance until we find an open train (handles the rare case where the
+      # next patch was also already shipped). Bounded to avoid an infinite loop.
+      original = version
+      10.times do
+        version = bump_patch_version(version)
+        break unless version_train_closed?(version)
+      end
+      UI.user_error!("Could not find an open iOS version train after #{original}.") if version_train_closed?(version)
+      UI.message("iOS version #{original} is closed for new builds; bumping to #{version}.")
+    end
 
     latest_build_number = latest_testflight_build_number(
       api_key: api_key,

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -30,18 +30,15 @@ BUNDLE_ID = "com.stably.orca.mobile"
 TESTFLIGHT_GROUPS = ["peeps"].freeze
 DEFAULT_TESTFLIGHT_CHANGELOG = "Latest Orca Mobile updates and fixes.".freeze
 
-# App Store version states in which the version "train" no longer accepts new
-# TestFlight build uploads (altool rejects with 90186 "train ... is closed").
-# Once a version has been submitted/approved/released, builds must go under a
-# higher marketing version. PROCESSING_FOR_APP_STORE / IN_REVIEW are included
-# conservatively: a build is already committed to that train.
+# App Store version states in which the version "train" is terminally closed to
+# new TestFlight build uploads (altool rejects with 90186 "train ... is
+# closed"). Only approved/released/removed states qualify: a version that is
+# merely IN_REVIEW / WAITING_FOR_REVIEW / PROCESSING_FOR_APP_STORE still accepts
+# TestFlight builds, so bumping on those would break normal beta iteration.
 CLOSED_APP_STORE_STATES = %w[
   READY_FOR_SALE
   PENDING_DEVELOPER_RELEASE
   PENDING_APPLE_RELEASE
-  PROCESSING_FOR_APP_STORE
-  IN_REVIEW
-  WAITING_FOR_REVIEW
   REPLACED_WITH_NEW_VERSION
   REMOVED_FROM_SALE
   DEVELOPER_REMOVED_FROM_SALE
@@ -91,6 +88,8 @@ end
 # Returns true when `version`'s App Store train is closed to new build uploads.
 # app_store_connect_api_key (set_spaceship_token: true, the default) has already
 # authenticated Spaceship::ConnectAPI globally, so no extra auth is needed here.
+# On any API error, degrade to "open": the upload then either succeeds or fails
+# with the same 90186 we have always seen — never worse than today's behavior.
 def version_train_closed?(version)
   app = Spaceship::ConnectAPI::App.find(BUNDLE_ID)
   return false unless app
@@ -98,6 +97,9 @@ def version_train_closed?(version)
   app
     .get_app_store_versions(filter: { versionString: version })
     .any? { |app_store_version| CLOSED_APP_STORE_STATES.include?(app_store_version.app_store_state) }
+rescue StandardError => error
+  UI.important("Could not determine App Store state for #{version} (#{error.message}); assuming open.")
+  false
 end
 
 def testflight_changelog


### PR DESCRIPTION
## Problem

The iOS release workflow auto-increments the **build number** but never the **marketing version**. That's correct for beta iteration (push build 1, 2, 3 under one version), but once a version is approved/released on the App Store its version "train" closes, and any further build upload is rejected by Apple ~20 min into the run with:

- `90186` — *Invalid Pre-Release Train. The train version 'X.Y.Z' is closed for new build submissions*
- `90062` — *CFBundleShortVersionString must contain a higher version than the previously approved version*

The only guard was a `bump_patch_version` checkbox the dispatcher had to remember to tick. If forgotten after a version shipped, the failure was **silent and ~20 minutes slow**. This failed the 2026-06-28 releases (closed `0.0.16` train).

## Fix — fail fast, don't auto-resolve

`prepare_release_version` now checks the resolved version's App Store state via `Spaceship::ConnectAPI` **before** the build. If that version's train is already closed, it **fails immediately (seconds) with a clear, actionable message** instead of building for 20 minutes and getting rejected:

> iOS version 0.0.16 is already submitted/released on the App Store and cannot accept new builds. Re-dispatch with bump_patch_version: true (or a higher release_version), or land a "Prepare mobile <version>" commit.

A closed train is detected by `app_store_state` — only terminally-closed states (`READY_FOR_SALE`, `PENDING_DEVELOPER_RELEASE`, `PENDING_APPLE_RELEASE`, replaced/removed). `IN_REVIEW` / `WAITING_FOR_REVIEW` / `PROCESSING_FOR_APP_STORE` are deliberately excluded: those still accept TestFlight builds, so they must not trip the guard during beta iteration.

## Why fail-fast rather than auto-bump

An earlier revision of this PR auto-bumped the marketing version when the train was closed. We reconsidered: having CI invent the marketing version erases the deliberate split that was otherwise correct —

- **Build number** is mechanical and high-frequency → owned by CI (unchanged).
- **Marketing version** is a deliberate, release-notes-bearing decision → owned by a human (the `bump_patch_version` input, or a `Prepare mobile X` commit).

Auto-bumping also introduced *floor drift*: CI never commits `app.json` back, so the repo version would increasingly diverge from what's actually on TestFlight. Fail-fast fixes the real pain (silent + slow → loud + instant) without taking on a new ownership model or that maintenance burden.

## Degradation

If the App Store app lookup or state query errors, the check assumes "open" and proceeds (logged loudly via `UI.error`). Worst case is the pre-PR behavior: the upload either succeeds or fails with the same 90186 — never worse than today.

## Releaser experience

- Normal beta iteration (version still open): unchanged — build number auto-increments.
- After a version ships: the next default run **fails in seconds** with instructions, instead of ~20 min later with a cryptic Apple error. Re-dispatch with the bump checkbox (or land a `Prepare mobile X` version commit) and proceed.

## Scope notes

- **Android is unaffected by this exact bug.** Play Store uses a monotonic `versionCode` rather than an App Store "train," so there is no `90186` equivalent; `mobile-android-release.yml` has its own `bump_android_version_code` input. Left alone.
- `app.json` is intentionally not committed back by CI (prebuild reads it within the run); the human "Prepare mobile X" commit remains the source of truth for the marketing version.

## Testing

- `ruby -c fastlane/Fastfile` → Syntax OK.
- No Fastfile test harness exists in the repo; logic is exercised by the release workflow.
- The closed-train **detection** path was verified end-to-end on the prior auto-bump revision (a branch dispatch correctly detected closed `0.0.16` and shipped `0.0.17`); this revision reuses the same detector and only changes the closed-train action from bump to fail-fast.
