### PR TITLE
feat(tools): add claude-autoresume boot-resume toolkit

### DIFF
--- a/tools/claude-autoresume/README.md
+++ b/tools/claude-autoresume/README.md
@@ -14,7 +14,7 @@ tmux pane**. tmux gives each session a real PTY, so the interactive TUI — and 
 `/loop` / scheduler machinery your autonomous sessions rely on — resumes exactly as
 it was before the reboot. You can `attach` later (over SSH or Orca) to watch.
 
-```
+```text
 boot ──▶ systemd user manager (lingering) ──▶ claude-autoresume.service (oneshot)
                                                    │
                                                    ├─ wait for outbound :443

--- a/tools/claude-autoresume/README.md
+++ b/tools/claude-autoresume/README.md
@@ -1,0 +1,120 @@
+# claude-autoresume
+
+Relaunch Claude Code sessions automatically after a **machine reboot**, triggered
+on boot by a **systemd user service**. Designed and verified on a headless Linux
+host (Oracle Linux 9, aarch64), and re-verified end-to-end on a clean AlmaLinux 9
+container (see [`verify/`](./verify)).
+
+## What it does
+
+On boot, a oneshot systemd **user** service runs `claude-autoresume start`, which
+reads a declarative manifest (`~/.config/claude-autoresume/sessions.json`) and, for
+each enabled entry, re-opens the prior Claude conversation inside its own **detached
+tmux pane**. tmux gives each session a real PTY, so the interactive TUI — and the
+`/loop` / scheduler machinery your autonomous sessions rely on — resumes exactly as
+it was before the reboot. You can `attach` later (over SSH or Orca) to watch.
+
+```
+boot ──▶ systemd user manager (lingering) ──▶ claude-autoresume.service (oneshot)
+                                                   │
+                                                   ├─ wait for outbound :443
+                                                   └─ for each enabled manifest entry:
+                                                        tmux -L claude-autoresume new-session -d
+                                                          └─ env -i HOME PATH TERM claude --resume … --dangerously-skip-permissions
+```
+
+## Why these specific choices (each was verified, not assumed)
+
+| Decision | Reason found on this host |
+| --- | --- |
+| **systemd *user* service**, `WantedBy=default.target` | Lingering is already on (`loginctl … Linger=yes`), so user services start at boot with no login. Mirrors the existing `hermes-gateway.service`. No `sudo` needed. |
+| **Minimal `Environment=` (HOME + PATH)** | A boot service gets a stripped env. Verified `env -i HOME=/home/opc PATH=/home/opc/.local/bin:/usr/bin claude -p --continue` resumes correctly. Credentials are a file (`~/.claude/.credentials.json`), resolved via `HOME` — no keyring. |
+| **tmux short named socket (`-L`)** | A long `-S <path>` socket hits the 104-char UNIX-socket limit (hit it during testing). `-L claude-autoresume` lives under `/tmp/tmux-<uid>/` and is isolated from your interactive tmux. |
+| **Trust pre-check / `auto_trust`** | Interactive resume **hangs** on the “Do you trust this folder?” prompt, and `--dangerously-skip-permissions` does **not** dismiss it. Untrusted cwds are skipped (or pre-seeded into `~/.claude.json`), never launched-and-hung. Already-trusted project cwds resume without prompting. |
+| **`--continue` / `--resume <uuid>`** lets claude resolve sessions | The cwd→session-dir encoding folds `/ . _` → `-` (lossy: `crack_chefrobot` and `crack-chefrobot` collide), so the launcher never reconstructs it for launch. Pinned UUIDs are shape-checked and validated **within the cwd's own** project dir (`claude --resume` is cwd-scoped). |
+| **Post-launch liveness check** | `tmux new-session` returns 0 even if claude immediately dies. After the stagger, each pane is re-checked: a vanished pane (crash / nothing to resume / rejected prompt) or one parked on a known gate is logged as `[!!]`, and `done: enabled=K launched=<K` flags a shortfall. Silent boot failures become loud journal lines. |
+| **`RemainAfterExit` + `KillMode=process`** | The launcher daemonizes tmux servers and exits; these keep a completing oneshot from tearing them down. `systemctl stop`/`restart` is an intentional teardown — `ExecStop` runs `stop` (tmux `kill-server`) to end the sessions on purpose. |
+| **`After=network.target` is a no-op; the launcher polls `:443`** | In the *user* manager `network.target` imposes no real ordering, so the launcher itself waits for outbound 443 before launching. Staggering (default 8s) keeps boot from slamming the API + ARM CPU with N simultaneous resumes. |
+| **`--` before continuation prompts; skip missing/untrusted cwds** | `--` stops a prompt that starts with `-` being parsed as a flag. One session dir (`crack-chefrobot`) has no live project dir; dead and untrusted cwds are skipped with a warning rather than launched-and-hung. |
+
+## Install
+
+```sh
+tools/claude-autoresume/install.sh    # copies bin + unit + sample manifest; does NOT enable
+```
+
+Then:
+
+```sh
+$EDITOR ~/.config/claude-autoresume/sessions.json   # flip entries to "enabled": true
+claude-autoresume doctor                            # preflight (env, trust, lingering, resume probe)
+claude-autoresume trust                             # seed folder-trust for manifest cwds
+claude-autoresume enable --yes                      # activate boot auto-resume
+```
+
+Nothing runs on boot until `enable --yes`. The sample manifest ships every entry as
+`enabled: false`.
+
+## Manifest (`sessions.json`)
+
+```jsonc
+{
+  "options": {
+    "work_path": "/home/opc/.local/bin:/usr/local/bin:/usr/bin:/bin", // PATH given to resumed agents
+    "net_wait_seconds": 60,   // wait for outbound :443 before launching
+    "stagger_seconds": 8,     // gap between launches (also the liveness-check delay)
+    "auto_trust": false,      // true = pre-seed trust for untrusted cwds instead of skipping
+    "print_timeout_seconds": 600  // cap for a host:"print" resume turn
+  },
+  "sessions": [
+    {
+      "cwd":     "/home/opc/orca/projects/medialib",
+      "session": "latest",          // "latest" = newest conversation for the cwd, or a pinned UUID
+      "mode":    "reopen",          // "reopen" = idle TUI; "continue" = resume + auto-submit `prompt`
+      "prompt":  "",                // only used by mode:"continue"
+      "host":    "tmux",            // "tmux" = attachable PTY session; "print" = one-shot headless
+      "enabled": true
+    }
+  ]
+}
+```
+
+- **`session: "latest"`** vs a pinned UUID — pin when a project has several sessions
+  (e.g. medialib has 3) and you want determinism; `latest` picks newest-by-mtime.
+- **`mode: "reopen"`** just re-opens the conversation idle (no new turn — matches the
+  in-repo resume-evidence guidance). **`mode: "continue"`** also submits `prompt`, which
+  is what restarts an autonomous loop.
+- **`host: "tmux"`** for long-running/observable sessions; **`host: "print"`** for a
+  fire-and-forget single continuation turn logged to the journal.
+
+## Operate
+
+```sh
+claude-autoresume status            # manifest + live sessions + unit state
+claude-autoresume attach medialib   # watch a resumed session (detach: Ctrl-b d)
+claude-autoresume start             # relaunch now (idempotent; skips already-live)
+claude-autoresume stop              # kill all auto-resume sessions
+journalctl --user -u claude-autoresume.service -b   # boot logs
+```
+
+## Security
+
+Enabling this makes every boot relaunch agents with
+`--dangerously-skip-permissions`. That is a real posture change: anything in those
+sessions' continuation prompts runs unattended with no permission gate. Keep the
+manifest tight, prefer `mode: "reopen"` unless a session genuinely needs to keep
+working, and review `claude-autoresume status` before `enable --yes`.
+
+## Portability (other OSes)
+
+The mechanism is identical elsewhere; only the boot trigger changes:
+
+- **macOS** — a LaunchAgent (`~/Library/LaunchAgents/com.user.claude-autoresume.plist`)
+  with `RunAtLoad` + `KeepAlive:false`, `ProgramArguments` = the same launcher. tmux/jq
+  via Homebrew; creds path is identical.
+- **Windows** — Task Scheduler task “At startup” running `wsl claude-autoresume start`
+  (under WSL) or a PowerShell shim; replace tmux with a detached `wt`/`conhost` or use
+  `host: "print"`. Paths via the WSL home.
+
+The launcher, manifest schema, and resume commands are unchanged across platforms — the
+only OS-specific files are the boot-trigger unit and the tmux/PTY host.

--- a/tools/claude-autoresume/bin/claude-autoresume
+++ b/tools/claude-autoresume/bin/claude-autoresume
@@ -90,7 +90,13 @@ sanitize_name() { printf '%s' "$1" | tr -c 'A-Za-z0-9_-' '-'; }
 # and defeat the same-basename collision guard.
 resolve_name() {
   local cwd="$1" raw="$2" name
-  if [ -n "$raw" ]; then name="$(sanitize_name "$raw")"; else name="$SLUG_PREFIX-$(sanitize_name "$(basename "$cwd")")"; fi
+  if [ -n "$raw" ]; then
+    # keep a custom name inside the managed car- namespace so live_count/attach see it
+    name="$(sanitize_name "$raw")"
+    case "$name" in ${SLUG_PREFIX}-*) ;; *) name="${SLUG_PREFIX}-${name}" ;; esac
+  else
+    name="$SLUG_PREFIX-$(sanitize_name "$(basename "$cwd")")"
+  fi
   if [ -n "${SEEN_NAMES[$name]:-}" ] && [ "${SEEN_NAMES[$name]}" != "$cwd" ]; then
     name="${name}-$(printf '%s' "$cwd" | cksum | cut -d' ' -f1 | cut -c1-6)"
     log "warn: session-name collision; disambiguated to '$name' for $cwd"
@@ -211,10 +217,13 @@ process_entry() {
 live_count() { tmux -L "$SOCKET" ls 2>/dev/null | grep -c "^${SLUG_PREFIX}-" || true; }
 
 cmd_start() {
-  command -v tmux >/dev/null 2>&1 || die "tmux not found on PATH"
   command -v jq   >/dev/null 2>&1 || die "jq not found on PATH"
   [ -x "$CLAUDE_BIN" ] || die "claude binary not executable: $CLAUDE_BIN"
   load_options
+  # tmux is only needed if an enabled entry actually uses the tmux host.
+  if jq -e 'any(.sessions[]?; (.enabled // false) and ((.host // "tmux") == "tmux"))' "$CONFIG" >/dev/null 2>&1; then
+    command -v tmux >/dev/null 2>&1 || die "tmux not found on PATH (required by an enabled host:\"tmux\" entry)"
+  fi
   wait_for_network
   local entries; mapfile -t entries < <(jq -c '.sessions[]?' "$CONFIG")
   local enabled=0 launched=0 e
@@ -322,10 +331,13 @@ Re-run:  $SELF enable --yes
 EOF
     return 1
   fi
-  systemctl --user enable --now claude-autoresume.service
+  systemctl --user enable --now claude-autoresume.service || die "failed to enable the service (boot state unchanged)"
   log "enabled: claude-autoresume.service (WantedBy=default.target)"
 }
-cmd_disable() { systemctl --user disable --now claude-autoresume.service; log "disabled"; }
+cmd_disable() {
+  systemctl --user disable --now claude-autoresume.service || die "failed to disable the service (boot state unchanged)"
+  log "disabled"
+}
 
 usage() {
   cat <<EOF

--- a/tools/claude-autoresume/bin/claude-autoresume
+++ b/tools/claude-autoresume/bin/claude-autoresume
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# claude-autoresume — relaunch Claude Code sessions after a machine reboot.
+#
+# Why this exists: on a headless box, autonomous Claude sessions die on reboot.
+# This reads a declarative manifest and re-opens each session inside its own
+# detached tmux pane (a real PTY, so the interactive TUI/loop machinery resumes
+# exactly as before, and you can `attach` to watch it over SSH/Orca).
+#
+# Design constraints baked in (all verified on this host):
+#   * Boot env is stripped: claude needs only HOME + a PATH that contains it;
+#     creds live in ~/.claude/.credentials.json (no keyring). Env is embedded
+#     into each pane's command so it is independent of the tmux server env.
+#   * tmux uses a SHORT named socket (-L), never a long -S path (104-char limit),
+#     and -f /dev/null so the auto-resume server ignores ~/.tmux.conf (e.g. a
+#     stray `destroy-unattached on` would otherwise kill every detached pane).
+#   * Interactive resume HANGS on the "trust this folder" prompt, which
+#     --dangerously-skip-permissions does NOT dismiss. Untrusted cwds are
+#     skipped (or pre-seeded when auto_trust=true), never launched-and-hung.
+#   * tmux new-session returns 0 even if claude immediately dies, so every
+#     launch is liveness-checked after the stagger and a stuck/dead pane is
+#     reported as [!!] — silent boot failures become loud journal lines.
+#   * --continue / --resume <uuid> let claude resolve sessions; the cwd->dir
+#     encoding folds / . _ -> - (lossy), so we validate within the cwd's own
+#     project dir and never reconstruct it for launch.
+set -uo pipefail
+
+CONFIG="${CLAUDE_AUTORESUME_CONFIG:-$HOME/.config/claude-autoresume/sessions.json}"
+CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+PROJECTS_DIR="$HOME/.claude/projects"
+CACHE_DIR="$HOME/.cache/claude-autoresume"
+SOCKET="claude-autoresume"          # tmux -L name; socket lives under /tmp/tmux-<uid>/ (short)
+SLUG_PREFIX="car"                   # tmux session names: car-<slug>
+SELF="$(basename "$0")"
+declare -A SEEN_NAMES=()            # resolved name -> cwd, for collision disambiguation
+
+log() { printf '%s\n' "[claude-autoresume] $*"; }
+die() { log "error: $*"; exit 1; }
+
+# ---- manifest option readers (sane defaults if option absent) ----------------
+# has($k) so an explicit `false` is honored, not treated as absent by jq's //.
+opt() {
+  jq -r --arg k "$1" --arg d "$2" \
+    '(if (.options | has($k)) then .options[$k] else $d end) | tostring' \
+    "$CONFIG" 2>/dev/null || printf '%s' "$2"
+}
+load_options() {
+  [ -f "$CONFIG" ] || die "manifest not found: $CONFIG"
+  jq -e . "$CONFIG" >/dev/null 2>&1 || die "manifest is not valid JSON: $CONFIG (a typo here silently resumes nothing)"
+  RESUME_PATH="$(opt work_path "$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin")"
+  NET_WAIT="$(opt net_wait_seconds 60)"
+  STAGGER="$(opt stagger_seconds 8)"
+  AUTO_TRUST="$(opt auto_trust false)"
+  PRINT_TIMEOUT="$(opt print_timeout_seconds 600)"
+  mkdir -p "$CACHE_DIR"
+}
+
+# ---- trust handling (the silent boot-hang guard) -----------------------------
+is_trusted() {
+  jq -e --arg c "$1" '((.projects[$c].hasTrustDialogAccepted) // false) == true' \
+    "$HOME/.claude.json" >/dev/null 2>&1
+}
+# Returns non-zero on failure so callers can refuse to launch into an untrusted cwd.
+# Temp file lives in $HOME so the atomic mv keeps the user_home_t SELinux label.
+seed_trust() {
+  local c="$1" tmp
+  [ -f "$HOME/.claude.json" ] || { log "warn: ~/.claude.json missing; cannot seed trust for $c"; return 1; }
+  tmp="$(mktemp "$HOME/.claude.json.XXXXXX")" || return 1
+  if jq --arg c "$c" '.projects[$c].hasTrustDialogAccepted = true' "$HOME/.claude.json" >"$tmp" && [ -s "$tmp" ]; then
+    chmod 600 "$tmp"; mv "$tmp" "$HOME/.claude.json"; return 0
+  fi
+  rm -f "$tmp"; log "warn: failed to seed trust for $c"; return 1
+}
+
+# ---- network readiness (user units order weakly vs network) ------------------
+wait_for_network() {
+  local host=api.anthropic.com port=443 waited=0
+  while [ "$waited" -lt "$NET_WAIT" ]; do
+    if timeout 2 bash -c "exec 3<>/dev/tcp/$host/$port" 2>/dev/null; then
+      [ "$waited" -gt 0 ] && log "network ready after ${waited}s"; return 0
+    fi
+    sleep 2; waited=$((waited + 2))
+  done
+  log "warn: ${host}:${port} unreachable after ${NET_WAIT}s; launching anyway (claude retries on reconnect)"
+}
+
+# ---- session-name slug (tmux folds . and : to _, so strip them up front) ------
+sanitize_name() { printf '%s' "$1" | tr -c 'A-Za-z0-9_-' '-'; }
+# Sets the global RESOLVED_NAME. Must NOT be called via $(...) — command
+# substitution runs in a subshell, which would lose the SEEN_NAMES mutation
+# and defeat the same-basename collision guard.
+resolve_name() {
+  local cwd="$1" raw="$2" name
+  if [ -n "$raw" ]; then name="$(sanitize_name "$raw")"; else name="$SLUG_PREFIX-$(sanitize_name "$(basename "$cwd")")"; fi
+  if [ -n "${SEEN_NAMES[$name]:-}" ] && [ "${SEEN_NAMES[$name]}" != "$cwd" ]; then
+    name="${name}-$(printf '%s' "$cwd" | cksum | cut -d' ' -f1 | cut -c1-6)"
+    log "warn: session-name collision; disambiguated to '$name' for $cwd"
+  fi
+  SEEN_NAMES[$name]="$cwd"
+  RESOLVED_NAME="$name"
+}
+
+# ---- launchers ---------------------------------------------------------------
+launch_tmux() {
+  local name="$1" cwd="$2" session="$3" mode="$4" prompt="$5"
+  if tmux -L "$SOCKET" has-session -t "$name" 2>/dev/null; then
+    log "skip: '$name' already running"; return 0
+  fi
+  local -a argv=("$CLAUDE_BIN")
+  if [ "$session" = latest ]; then argv+=(--continue); else argv+=(--resume "$session"); fi
+  argv+=(--dangerously-skip-permissions)
+  # `--` so a continuation prompt that begins with '-' is not parsed as a flag.
+  [ "$mode" = continue ] && [ -n "$prompt" ] && argv+=(-- "$prompt")
+  # Embed the exact stripped work-env into the pane so claude is immune to
+  # whatever env the tmux server was started with. exec replaces the sh wrapper.
+  local inner; inner="$(printf 'exec env -i HOME=%q PATH=%q TERM=xterm-256color' "$HOME" "$RESUME_PATH")"
+  local a; for a in "${argv[@]}"; do inner+=" $(printf '%q' "$a")"; done
+  log "launch[tmux]: $name  (session=$session mode=$mode)  cwd=$cwd"
+  tmux -L "$SOCKET" -f /dev/null new-session -d -s "$name" -c "$cwd" "$inner" \
+    || { log "[!!] tmux launch failed for $name"; return 1; }
+}
+
+# Detects the silent failures: a pane that already exited (crash / nothing to
+# resume / bad prompt) or one parked on a known blocking interactive gate.
+verify_live() {
+  local name="$1" cwd="$2"
+  if ! tmux -L "$SOCKET" has-session -t "$name" 2>/dev/null; then
+    log "[!!] $name: resume exited within ${STAGGER}s — no conversation to resume, crash, or rejected prompt. cwd=$cwd"
+    return 1
+  fi
+  local pane; pane="$(tmux -L "$SOCKET" capture-pane -p -t "$name" 2>/dev/null || true)"
+  if printf '%s' "$pane" | grep -qiE 'trust this folder|Allow external|Select login|Invalid bearer token'; then
+    log "[!!] $name: STUCK at an interactive prompt (not progressing) — run '$SELF attach $name'. cwd=$cwd"
+    return 1
+  fi
+  return 0
+}
+
+launch_print() {
+  local name="$1" cwd="$2" session="$3" mode="$4" prompt="$5"
+  # Per-session lock: print mode has no tmux has-session guard, so a re-run /
+  # restart must not spawn a second `claude -p --continue` on the same session.
+  local lock="$CACHE_DIR/print-$name.lock"
+  exec 9>"$lock" 2>/dev/null || true
+  if ! flock -n 9 2>/dev/null; then log "skip print: '$name' already running"; return 1; fi
+  local -a argv=("$CLAUDE_BIN" -p)
+  if [ "$session" = latest ]; then argv+=(--continue); else argv+=(--resume "$session"); fi
+  argv+=(--dangerously-skip-permissions)
+  [ -n "$prompt" ] || prompt="Resume and continue the task you were running before the reboot."
+  argv+=(-- "$prompt")
+  log "launch[print]: $name  (session=$session)  cwd=$cwd"
+  local rc=0
+  # timeout so a hung print turn cannot block the whole oneshot ExecStart.
+  ( cd "$cwd" && timeout "$PRINT_TIMEOUT" env -i HOME="$HOME" PATH="$RESUME_PATH" "${argv[@]}" ) || rc=$?
+  flock -u 9 2>/dev/null || true
+  [ "$rc" -eq 0 ] || { log "[!!] print resume failed (rc=$rc) for $cwd"; return 1; }
+  return 0
+}
+
+# ---- per-entry resolve + launch (returns 0 only when a live session results) -
+process_entry() {
+  local entry="$1"
+  local cwd session mode prompt host rawname name enabled
+  cwd="$(jq -r '.cwd // empty'        <<<"$entry")"
+  enabled="$(jq -r '.enabled // false' <<<"$entry")"
+  [ "$enabled" = true ] || return 1
+  [ -n "$cwd" ] || { log "skip: entry without cwd"; return 1; }
+  session="$(jq -r '.session // "latest"' <<<"$entry")"
+  mode="$(jq -r '.mode // "reopen"'       <<<"$entry")"
+  prompt="$(jq -r '.prompt // ""'         <<<"$entry")"
+  host="$(jq -r '.host // "tmux"'         <<<"$entry")"
+  rawname="$(jq -r '.name // empty'       <<<"$entry")"
+
+  [ -d "$cwd" ] || { log "skip: cwd missing: $cwd"; return 1; }
+
+  if [ "$session" != latest ]; then
+    # validate the pin as a real uuid (no find -name glob metachars) and scope
+    # the lookup to THIS cwd's project dir, since `claude --resume` is cwd-scoped.
+    [[ "$session" =~ ^[0-9a-fA-F-]{36}$ ]] || { log "skip: invalid session id '$session' (cwd=$cwd)"; return 1; }
+    local enc; enc="$(printf '%s' "$cwd" | sed 's#[/._]#-#g')"
+    [ -f "$PROJECTS_DIR/$enc/$session.jsonl" ] || { log "skip: pinned session $session not found under $cwd"; return 1; }
+  else
+    local enc; enc="$(printf '%s' "$cwd" | sed 's#[/._]#-#g')"
+    ls "$PROJECTS_DIR/$enc/"*.jsonl >/dev/null 2>&1 || log "warn: no recorded sessions under $cwd — --continue may have nothing to resume"
+  fi
+
+  if ! is_trusted "$cwd"; then
+    if [ "$AUTO_TRUST" = true ] && seed_trust "$cwd" && is_trusted "$cwd"; then
+      log "trust: seeded hasTrustDialogAccepted for $cwd"
+    else
+      log "skip: '$cwd' is not trusted — interactive resume would hang on the trust prompt."
+      log "      fix: '$SELF trust' (seeds all manifest cwds) or set options.auto_trust=true"
+      return 1
+    fi
+  fi
+
+  resolve_name "$cwd" "$rawname"; name="$RESOLVED_NAME"
+
+  case "$host" in
+    tmux)
+      launch_tmux "$name" "$cwd" "$session" "$mode" "$prompt" || return 1
+      sleep "$STAGGER"
+      verify_live "$name" "$cwd"
+      tmux -L "$SOCKET" has-session -t "$name" 2>/dev/null
+      ;;
+    print) launch_print "$name" "$cwd" "$session" "$mode" "$prompt" ;;
+    *)     log "skip: unknown host '$host' (cwd=$cwd)"; return 1 ;;
+  esac
+}
+
+# ---- subcommands -------------------------------------------------------------
+live_count() { tmux -L "$SOCKET" ls 2>/dev/null | grep -c "^${SLUG_PREFIX}-" || true; }
+
+cmd_start() {
+  command -v tmux >/dev/null 2>&1 || die "tmux not found on PATH"
+  command -v jq   >/dev/null 2>&1 || die "jq not found on PATH"
+  [ -x "$CLAUDE_BIN" ] || die "claude binary not executable: $CLAUDE_BIN"
+  load_options
+  wait_for_network
+  local entries; mapfile -t entries < <(jq -c '.sessions[]?' "$CONFIG")
+  local enabled=0 launched=0 e
+  for e in "${entries[@]}"; do [ "$(jq -r '.enabled // false' <<<"$e")" = true ] && enabled=$((enabled + 1)); done
+  # tmux entries first (they detach instantly); print entries last (they block).
+  for e in "${entries[@]}"; do
+    [ "$(jq -r '.host // "tmux"' <<<"$e")" = print ] && continue
+    process_entry "$e" && launched=$((launched + 1))
+  done
+  for e in "${entries[@]}"; do
+    [ "$(jq -r '.host // "tmux"' <<<"$e")" = print ] || continue
+    process_entry "$e" && launched=$((launched + 1))
+  done
+  log "done: enabled=$enabled launched=$launched live=$(live_count)"
+  [ "$enabled" -gt 0 ] && [ "$launched" -lt "$enabled" ] \
+    && log "[!!] only $launched/$enabled enabled session(s) came up — see warnings above"
+  return 0
+}
+
+cmd_stop() {
+  if tmux -L "$SOCKET" ls >/dev/null 2>&1; then
+    log "stopping all claude-autoresume tmux sessions"
+    tmux -L "$SOCKET" kill-server 2>/dev/null || true
+  else
+    log "no live claude-autoresume sessions"
+  fi
+}
+
+cmd_status() {
+  printf '== manifest (%s) ==\n' "$CONFIG"
+  jq -r '.sessions[] | "  [\(if .enabled then "on " else "off" end)] \(.host // "tmux")/\(.mode // "reopen")  \(.cwd)  session=\(.session // "latest")"' "$CONFIG" 2>/dev/null \
+    || echo "  (manifest unreadable / invalid JSON)"
+  printf '\n== live tmux sessions (socket: %s) ==\n' "$SOCKET"
+  tmux -L "$SOCKET" ls 2>/dev/null | sed 's/^/  /' || echo "  (none)"
+  printf '\n== systemd user unit ==\n'
+  systemctl --user is-enabled claude-autoresume.service 2>/dev/null | sed 's/^/  enabled: /' || echo "  (not installed)"
+  systemctl --user is-active  claude-autoresume.service 2>/dev/null | sed 's/^/  active:  /' || true
+}
+
+cmd_attach() {
+  local target="${1:-}"
+  [ -n "$target" ] || { tmux -L "$SOCKET" ls 2>/dev/null; die "usage: $SELF attach <session-name>"; }
+  case "$target" in ${SLUG_PREFIX}-*) ;; *) target="${SLUG_PREFIX}-${target}";; esac
+  exec tmux -L "$SOCKET" attach -t "$target"
+}
+
+cmd_trust() {
+  load_options
+  local seeded=0 failed=0 cwd
+  while IFS= read -r cwd; do
+    [ -n "$cwd" ] || continue
+    if is_trusted "$cwd"; then
+      log "trust: already trusted: $cwd"
+    elif seed_trust "$cwd"; then
+      log "trust: seeded: $cwd"; seeded=$((seeded + 1))
+    else
+      failed=$((failed + 1))
+    fi
+  done < <(jq -r '.sessions[].cwd' "$CONFIG" 2>/dev/null | sort -u)
+  log "trust: seeded $seeded cwd(s), $failed failure(s)"
+  [ "$failed" -eq 0 ]
+}
+
+cmd_doctor() {
+  load_options
+  local ok=1
+  printf '== readiness check ==\n'
+  command -v tmux >/dev/null 2>&1 && echo "  [ok] tmux: $(command -v tmux)" || { echo "  [!!] tmux missing"; ok=0; }
+  command -v jq   >/dev/null 2>&1 && echo "  [ok] jq:   $(command -v jq)"   || { echo "  [!!] jq missing"; ok=0; }
+  command -v flock >/dev/null 2>&1 && echo "  [ok] flock: $(command -v flock)" || echo "  [??] flock missing (only needed for host:print dedup)"
+  [ -x "$CLAUDE_BIN" ] && echo "  [ok] claude: $CLAUDE_BIN" || { echo "  [!!] claude not executable: $CLAUDE_BIN"; ok=0; }
+  [ -f "$HOME/.claude/.credentials.json" ] && echo "  [ok] credentials present" || echo "  [??] no ~/.claude/.credentials.json (login may be needed)"
+  if loginctl show-user "$(id -un)" 2>/dev/null | grep -q 'Linger=yes'; then
+    echo "  [ok] systemd lingering enabled (user services run at boot)"
+  else
+    echo "  [!!] lingering OFF — run: loginctl enable-linger $(id -un)"; ok=0
+  fi
+  printf '  stripped-env resume probe: '
+  local probe; probe="$(mktemp -d "${TMPDIR:-/tmp}/car-doctor.XXXXXX")"
+  if ( cd "$probe" && timeout 25 env -i HOME="$HOME" PATH="$RESUME_PATH" "$CLAUDE_BIN" -p 'reply with the word READY' --dangerously-skip-permissions 2>/dev/null ) | grep -qi ready; then
+    echo "[ok]"
+  else
+    echo "[!!] failed under stripped env — widen options.work_path"; ok=0
+  fi
+  rm -rf "$probe" "$PROJECTS_DIR/$(printf '%s' "$probe" | sed 's#[/._]#-#g')" 2>/dev/null || true
+  printf '\n== per-entry ==\n'
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    local cwd en; cwd="$(jq -r '.cwd' <<<"$entry")"; en="$(jq -r '.enabled // false' <<<"$entry")"
+    printf '  %-42s enabled=%-5s dir=%s trust=%s\n' "$cwd" "$en" \
+      "$([ -d "$cwd" ] && echo yes || echo NO)" \
+      "$(is_trusted "$cwd" && echo yes || echo NO)"
+  done < <(jq -c '.sessions[]?' "$CONFIG")
+  printf '\n%s\n' "$([ "$ok" = 1 ] && echo 'doctor: PASS' || echo 'doctor: ISSUES FOUND (see [!!] above)')"
+  [ "$ok" = 1 ]
+}
+
+cmd_enable() {
+  if [ "${1:-}" != "--yes" ]; then
+    cat <<EOF
+About to enable boot auto-resume. This will, on every boot, relaunch the
+ENABLED manifest entries with --dangerously-skip-permissions (no permission
+prompts). Review '$SELF status' and '$SELF doctor' first.
+Re-run:  $SELF enable --yes
+EOF
+    return 1
+  fi
+  systemctl --user enable --now claude-autoresume.service
+  log "enabled: claude-autoresume.service (WantedBy=default.target)"
+}
+cmd_disable() { systemctl --user disable --now claude-autoresume.service; log "disabled"; }
+
+usage() {
+  cat <<EOF
+$SELF — relaunch Claude Code sessions on boot (manifest: $CONFIG)
+
+  start            launch all enabled entries (run by the systemd unit)
+  stop             kill all claude-autoresume tmux sessions
+  status           show manifest + live sessions + unit state
+  attach <name>    attach to a resumed session (e.g. '$SELF attach medialib')
+  trust            seed folder-trust for every manifest cwd (prevents boot hang)
+  doctor           preflight: env, lingering, trust, stripped-env resume probe
+  enable --yes     enable boot auto-resume (systemctl --user enable --now)
+  disable          disable boot auto-resume
+EOF
+}
+
+main() {
+  local sub="${1:-}"; shift || true
+  case "$sub" in
+    start)   cmd_start ;;
+    stop)    cmd_stop ;;
+    status)  cmd_status ;;
+    attach)  cmd_attach "${1:-}" ;;
+    trust)   cmd_trust ;;
+    doctor)  cmd_doctor ;;
+    enable)  cmd_enable "${1:-}" ;;
+    disable) cmd_disable ;;
+    ''|-h|--help|help) usage ;;
+    *) usage; exit 1 ;;
+  esac
+}
+main "$@"

--- a/tools/claude-autoresume/install.sh
+++ b/tools/claude-autoresume/install.sh
@@ -22,7 +22,9 @@ else
   echo "wrote: $CONF_DIR/sessions.json (sample — every entry is enabled:false)"
 fi
 
-systemctl --user daemon-reload
+# Files are already installed; a missing/unreachable user bus must not fail the
+# install. Warn and let the user reload once their session manager is up.
+systemctl --user daemon-reload || echo "WARNING: 'systemctl --user daemon-reload' failed (user bus not ready); run it after login."
 
 if ! loginctl show-user "$(id -un)" 2>/dev/null | grep -q 'Linger=yes'; then
   echo "WARNING: systemd lingering is OFF; user services will NOT start at boot."

--- a/tools/claude-autoresume/install.sh
+++ b/tools/claude-autoresume/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Install claude-autoresume into the user's systemd/bin/config locations.
+# Idempotent. Does NOT enable boot auto-resume (that is a deliberate, gated step).
+set -euo pipefail
+
+SRC="$(cd "$(dirname "$0")" && pwd)"
+BIN_DIR="$HOME/.local/bin"
+UNIT_DIR="$HOME/.config/systemd/user"
+CONF_DIR="$HOME/.config/claude-autoresume"
+
+mkdir -p "$BIN_DIR" "$UNIT_DIR"
+# 0700: the manifest can hold continuation prompts that run unattended.
+mkdir -p "$CONF_DIR"; chmod 0700 "$CONF_DIR"
+
+install -m 0755 "$SRC/bin/claude-autoresume" "$BIN_DIR/claude-autoresume"
+install -m 0644 "$SRC/systemd/claude-autoresume.service" "$UNIT_DIR/claude-autoresume.service"
+
+if [ -f "$CONF_DIR/sessions.json" ]; then
+  echo "keep: $CONF_DIR/sessions.json (existing manifest left untouched)"
+else
+  install -m 0600 "$SRC/sessions.json" "$CONF_DIR/sessions.json"
+  echo "wrote: $CONF_DIR/sessions.json (sample — every entry is enabled:false)"
+fi
+
+systemctl --user daemon-reload
+
+if ! loginctl show-user "$(id -un)" 2>/dev/null | grep -q 'Linger=yes'; then
+  echo "WARNING: systemd lingering is OFF; user services will NOT start at boot."
+  echo "         enable with:  loginctl enable-linger $(id -un)"
+fi
+
+cat <<EOF
+
+installed:
+  $BIN_DIR/claude-autoresume
+  $UNIT_DIR/claude-autoresume.service
+  $CONF_DIR/sessions.json
+
+next:
+  1) edit  $CONF_DIR/sessions.json   (flip the sessions you want to enabled:true)
+  2) run   claude-autoresume doctor   (preflight checks)
+  3) run   claude-autoresume trust    (avoid the folder-trust boot hang)
+  4) run   claude-autoresume enable --yes   (activate boot auto-resume)
+
+nothing auto-runs until step 4.
+EOF

--- a/tools/claude-autoresume/sessions.json
+++ b/tools/claude-autoresume/sessions.json
@@ -1,0 +1,28 @@
+{
+  "options": {
+    "_comment": "Global knobs. work_path (optional) overrides the PATH given to resumed agents; omit to default to $HOME/.local/bin:/usr/local/bin:/usr/bin:/bin. net_wait_seconds: wait for outbound 443 before launching. stagger_seconds: gap between launches (also the liveness-check delay). auto_trust: when true, pre-seed hasTrustDialogAccepted for listed cwds (otherwise untrusted cwds are SKIPPED, never hung). print_timeout_seconds: cap for a host:'print' resume turn.",
+    "net_wait_seconds": 60,
+    "stagger_seconds": 8,
+    "auto_trust": false,
+    "print_timeout_seconds": 600
+  },
+  "sessions": [
+    {
+      "_comment": "EXAMPLE entries — replace cwd with your project dirs and flip enabled:true. Every entry ships disabled so nothing auto-runs until you opt in. session:'latest' resumes the newest conversation for the cwd; pin a UUID for determinism when a project has several sessions.",
+      "cwd": "/home/youruser/projects/example-a",
+      "session": "latest",
+      "mode": "reopen",
+      "prompt": "",
+      "host": "tmux",
+      "enabled": false
+    },
+    {
+      "cwd": "/home/youruser/projects/example-b",
+      "session": "latest",
+      "mode": "continue",
+      "prompt": "Resume the autonomous task you were running before the machine rebooted. Re-read your task list / loop state and continue where you left off.",
+      "host": "tmux",
+      "enabled": false
+    }
+  ]
+}

--- a/tools/claude-autoresume/systemd/claude-autoresume.service
+++ b/tools/claude-autoresume/systemd/claude-autoresume.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Claude Code session auto-resume on boot
+Documentation=file:%h/claude-autoresume/README.md
+# NOTE: After=network.target is a near-no-op in the USER manager (the target is
+# not pulled into the user transaction), so it imposes no real ordering. The
+# actual network guard is the launcher's wait_for_network() (polls outbound 443).
+After=network.target
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
+[Service]
+Type=oneshot
+# The launcher spawns detached tmux servers and exits. RemainAfterExit keeps the
+# unit "active" so completing ExecStart does not tear down those daemonized tmux
+# servers, and KillMode=process means only the (already-exited) launcher is the
+# kill target. Stopping the unit is an explicit, intended teardown: ExecStop runs
+# `claude-autoresume stop` (tmux kill-server) so `systemctl stop`/`restart` ends
+# the resumed sessions on purpose.
+RemainAfterExit=yes
+KillMode=process
+ExecStart=%h/.local/bin/claude-autoresume start
+ExecStop=%h/.local/bin/claude-autoresume stop
+Environment=HOME=%h
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+TimeoutStartSec=900
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/tools/claude-autoresume/uninstall.sh
+++ b/tools/claude-autoresume/uninstall.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Remove claude-autoresume. Keeps your manifest unless --purge is given.
+set -euo pipefail
+
+BIN_DIR="$HOME/.local/bin"
+UNIT_DIR="$HOME/.config/systemd/user"
+CONF_DIR="$HOME/.config/claude-autoresume"
+
+systemctl --user disable --now claude-autoresume.service 2>/dev/null || true
+"$BIN_DIR/claude-autoresume" stop 2>/dev/null || true
+
+rm -f "$UNIT_DIR/claude-autoresume.service"
+rm -f "$BIN_DIR/claude-autoresume"
+systemctl --user daemon-reload 2>/dev/null || true
+
+if [ "${1:-}" = "--purge" ]; then
+  rm -rf "$CONF_DIR"
+  echo "purged manifest at $CONF_DIR"
+else
+  echo "kept manifest at $CONF_DIR (use --purge to remove)"
+fi
+echo "uninstalled."

--- a/tools/claude-autoresume/verify/Dockerfile
+++ b/tools/claude-autoresume/verify/Dockerfile
@@ -12,10 +12,14 @@ RUN systemctl unmask systemd-logind.service
 # A normal unprivileged user (uid 1000) — NOT /home/opc, to prove portability.
 RUN useradd -u 1000 -m agent && echo 'agent ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/agent
 
-COPY stub-claude /usr/local/stub/claude
-COPY toolkit /opt/claude-autoresume-src
-COPY root-setup.sh /opt/root-setup.sh
-COPY agent-test.sh /opt/agent-test.sh
+# Build context is the tool dir (the parent), so the toolkit copies in directly —
+# no separate staging step. Build with: docker build -f verify/Dockerfile .
+COPY verify/stub-claude /usr/local/stub/claude
+COPY bin /opt/claude-autoresume-src/bin
+COPY systemd /opt/claude-autoresume-src/systemd
+COPY install.sh uninstall.sh README.md sessions.json /opt/claude-autoresume-src/
+COPY verify/root-setup.sh /opt/root-setup.sh
+COPY verify/agent-test.sh /opt/agent-test.sh
 RUN chmod +x /usr/local/stub/claude /opt/root-setup.sh /opt/agent-test.sh \
     /opt/claude-autoresume-src/bin/claude-autoresume \
     /opt/claude-autoresume-src/install.sh /opt/claude-autoresume-src/uninstall.sh

--- a/tools/claude-autoresume/verify/Dockerfile
+++ b/tools/claude-autoresume/verify/Dockerfile
@@ -1,0 +1,25 @@
+FROM almalinux:9
+
+# Clean-machine deps the toolkit relies on (tmux, jq, flock, cksum/timeout, systemd-user).
+# coreutils (cksum/timeout) is already provided by coreutils-single in the base.
+RUN dnf -y install tmux jq procps-ng sudo \
+    && dnf clean all
+# The base image masks logind; unmask so lingering + the user manager work
+# (the real OL9 host already runs logind with lingering on — this only fixes
+# the container so it mirrors that environment).
+RUN systemctl unmask systemd-logind.service
+
+# A normal unprivileged user (uid 1000) — NOT /home/opc, to prove portability.
+RUN useradd -u 1000 -m agent && echo 'agent ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/agent
+
+COPY stub-claude /usr/local/stub/claude
+COPY toolkit /opt/claude-autoresume-src
+COPY root-setup.sh /opt/root-setup.sh
+COPY agent-test.sh /opt/agent-test.sh
+RUN chmod +x /usr/local/stub/claude /opt/root-setup.sh /opt/agent-test.sh \
+    /opt/claude-autoresume-src/bin/claude-autoresume \
+    /opt/claude-autoresume-src/install.sh /opt/claude-autoresume-src/uninstall.sh
+
+ENV container=docker
+STOPSIGNAL SIGRTMIN+3
+CMD ["/usr/sbin/init"]

--- a/tools/claude-autoresume/verify/README.md
+++ b/tools/claude-autoresume/verify/README.md
@@ -1,0 +1,28 @@
+# Clean-machine verification
+
+Proves the toolkit has no host-specific assumptions by installing and running it
+in a fresh AlmaLinux 9 container (closest match to the OL9 target), as a generic
+`uid 1000` user, with a stub `claude` (no auth/network). It exercises both the
+direct launcher path and the **real systemd-user unit**.
+
+```sh
+docker build -t claude-autoresume-verify .
+docker run -d --name car-verify --privileged --cgroupns=host \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:rw --tmpfs /run --tmpfs /tmp claude-autoresume-verify
+# wait for `systemctl is-system-running` to report running/degraded, then:
+docker exec car-verify /opt/root-setup.sh
+docker exec -u agent car-verify bash /opt/agent-test.sh   # expect: OVERALL: PASS
+docker rm -f car-verify
+```
+
+`agent-test.sh` asserts: `doctor: PASS`, direct launch (`enabled=1 launched=1
+live=1`, no false `[!!]`), pane actually resumed, idempotent re-run skip, clean
+stop, `systemd-analyze --user verify` of the unit, the unit starting
+`active(exited)` with `Result=success`, the **tmux session surviving the oneshot
+ExecStart completing** (the load-bearing boot claim), and a clean `ExecStop`
+teardown.
+
+Files: `Dockerfile`, `stub-claude` (fake CLI), `root-setup.sh` (provision the
+agent HOME + lingering), `agent-test.sh` (the assertions). The base image masks
+`systemd-logind`; the Dockerfile unmasks it so the container mirrors a normal
+host (the real OL9 target already runs logind with lingering enabled).

--- a/tools/claude-autoresume/verify/README.md
+++ b/tools/claude-autoresume/verify/README.md
@@ -5,8 +5,12 @@ in a fresh AlmaLinux 9 container (closest match to the OL9 target), as a generic
 `uid 1000` user, with a stub `claude` (no auth/network). It exercises both the
 direct launcher path and the **real systemd-user unit**.
 
+Build from the tool directory (`tools/claude-autoresume/`) so the toolkit is in
+the build context — no staging step:
+
 ```sh
-docker build -t claude-autoresume-verify .
+cd tools/claude-autoresume
+docker build -t claude-autoresume-verify -f verify/Dockerfile .
 docker run -d --name car-verify --privileged --cgroupns=host \
   -v /sys/fs/cgroup:/sys/fs/cgroup:rw --tmpfs /run --tmpfs /tmp claude-autoresume-verify
 # wait for `systemctl is-system-running` to report running/degraded, then:

--- a/tools/claude-autoresume/verify/agent-test.sh
+++ b/tools/claude-autoresume/verify/agent-test.sh
@@ -25,7 +25,7 @@ echo "===== A) direct launcher start (no systemd) ====="
 grep -q 'done: enabled=1 launched=1 live=1' /tmp/start.out && mark "DIRECT_LAUNCH_OK" || { mark "DIRECT_LAUNCH_FAIL"; fail=1; }
 if ! grep -q '\[!!\]' /tmp/start.out; then mark "NO_FALSE_WARN"; else mark "UNEXPECTED_WARN"; fail=1; fi
 echo "--- live sessions ---"; tmux -L claude-autoresume ls 2>&1
-tmux -L claude-autoresume capture-pane -p -t car-proj 2>/dev/null | grep -qi 'STUB CLAUDE RESUMED' && mark "PANE_RESUMED" || mark "PANE_EMPTY"
+tmux -L claude-autoresume capture-pane -p -t car-proj 2>/dev/null | grep -qi 'STUB CLAUDE RESUMED' && mark "PANE_RESUMED" || { mark "PANE_EMPTY"; fail=1; }
 echo "--- idempotent re-run ---"
 reout="$("$BIN" start 2>&1)"; echo "$reout" | grep -E 'already running|done:'
 echo "$reout" | grep -q "already running" && mark "IDEMPOTENT_OK" || { mark "IDEMPOTENT_FAIL"; fail=1; }
@@ -48,9 +48,9 @@ if [ "$busok" = 1 ] && systemctl --user show-environment >/dev/null 2>&1; then
   if tmux -L claude-autoresume ls 2>&1 | grep -q '^car-proj'; then mark "SYSTEMD_SURVIVAL_OK"; else mark "SYSTEMD_SURVIVAL_FAIL"; fail=1; fi
   systemctl --user status claude-autoresume.service --no-pager 2>/dev/null | grep -E 'Active:|CGroup:|tmux|sleep 3600' | head -6
   systemctl --user stop claude-autoresume.service; sleep 2
-  tmux -L claude-autoresume ls >/dev/null 2>&1 && mark "SYSTEMD_STOP_FAIL" || mark "SYSTEMD_STOP_OK"
+  tmux -L claude-autoresume ls >/dev/null 2>&1 && { mark "SYSTEMD_STOP_FAIL"; fail=1; } || mark "SYSTEMD_STOP_OK"
 else
-  mark "SYSTEMD_USER_BUS_UNAVAILABLE"
+  mark "SYSTEMD_USER_BUS_UNAVAILABLE"; fail=1
   echo "(user manager not reachable in this container; static unit check instead)"
   systemd-analyze verify "$HOME/.config/systemd/user/claude-autoresume.service" 2>&1 || true
 fi

--- a/tools/claude-autoresume/verify/agent-test.sh
+++ b/tools/claude-autoresume/verify/agent-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Runs as the agent user. Proves (A) launcher portability on a clean machine via
+# a direct `start`, and (B) the real systemd-user unit path if the user manager
+# is reachable. Emits PASS/FAIL markers the host grep-checks.
+set -uo pipefail
+BIN="$HOME/.local/bin/claude-autoresume"
+fail=0
+mark() { echo "VERIFY:$1"; }
+
+echo "===== install toolkit into clean HOME ($HOME) ====="
+cp -r /opt/claude-autoresume-src "$HOME/claude-autoresume"
+"$HOME/claude-autoresume/install.sh" >/dev/null 2>&1 || true   # daemon-reload may warn until bus is up
+cat > "$HOME/.config/claude-autoresume/sessions.json" <<'JSON'
+{ "options": { "net_wait_seconds": 2, "stagger_seconds": 3 },
+  "sessions": [ { "cwd": "/home/agent/proj", "session": "latest", "mode": "reopen", "host": "tmux", "enabled": true } ] }
+JSON
+chmod 600 "$HOME/.config/claude-autoresume/sessions.json"
+
+echo "===== A) doctor on clean machine ====="
+if "$BIN" doctor 2>&1 | tee /tmp/doctor.out | tail -3; then :; fi
+grep -q 'doctor: PASS' /tmp/doctor.out && mark "DOCTOR_PASS" || { mark "DOCTOR_FAIL"; fail=1; }
+
+echo "===== A) direct launcher start (no systemd) ====="
+"$BIN" start 2>&1 | tee /tmp/start.out
+grep -q 'done: enabled=1 launched=1 live=1' /tmp/start.out && mark "DIRECT_LAUNCH_OK" || { mark "DIRECT_LAUNCH_FAIL"; fail=1; }
+if ! grep -q '\[!!\]' /tmp/start.out; then mark "NO_FALSE_WARN"; else mark "UNEXPECTED_WARN"; fail=1; fi
+echo "--- live sessions ---"; tmux -L claude-autoresume ls 2>&1
+tmux -L claude-autoresume capture-pane -p -t car-proj 2>/dev/null | grep -qi 'STUB CLAUDE RESUMED' && mark "PANE_RESUMED" || mark "PANE_EMPTY"
+echo "--- idempotent re-run ---"
+reout="$("$BIN" start 2>&1)"; echo "$reout" | grep -E 'already running|done:'
+echo "$reout" | grep -q "already running" && mark "IDEMPOTENT_OK" || { mark "IDEMPOTENT_FAIL"; fail=1; }
+"$BIN" stop >/dev/null 2>&1; sleep 1
+tmux -L claude-autoresume ls >/dev/null 2>&1 && { mark "STOP_FAIL"; fail=1; } || mark "STOP_OK"
+
+echo "===== B) real systemd-user unit path ====="
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+busok=0
+for i in $(seq 1 30); do [ -S "$XDG_RUNTIME_DIR/bus" ] && { busok=1; break; }; sleep 1; done
+if [ "$busok" = 1 ] && systemctl --user show-environment >/dev/null 2>&1; then
+  systemctl --user daemon-reload
+  systemd-analyze --user verify "$HOME/.config/systemd/user/claude-autoresume.service" 2>&1 && mark "UNIT_VERIFY_OK" || mark "UNIT_VERIFY_WARN"
+  systemctl --user start claude-autoresume.service
+  state="$(systemctl --user show claude-autoresume.service -p ActiveState,SubState,Result --no-pager | tr '\n' ' ')"
+  echo "unit state: $state"
+  sleep 5
+  echo "--- SURVIVAL: tmux session alive after oneshot ExecStart returned? ---"
+  if tmux -L claude-autoresume ls 2>&1 | grep -q '^car-proj'; then mark "SYSTEMD_SURVIVAL_OK"; else mark "SYSTEMD_SURVIVAL_FAIL"; fail=1; fi
+  systemctl --user status claude-autoresume.service --no-pager 2>/dev/null | grep -E 'Active:|CGroup:|tmux|sleep 3600' | head -6
+  systemctl --user stop claude-autoresume.service; sleep 2
+  tmux -L claude-autoresume ls >/dev/null 2>&1 && mark "SYSTEMD_STOP_FAIL" || mark "SYSTEMD_STOP_OK"
+else
+  mark "SYSTEMD_USER_BUS_UNAVAILABLE"
+  echo "(user manager not reachable in this container; static unit check instead)"
+  systemd-analyze verify "$HOME/.config/systemd/user/claude-autoresume.service" 2>&1 || true
+fi
+
+echo "===== RESULT ====="
+[ "$fail" = 0 ] && echo "OVERALL: PASS" || echo "OVERALL: FAIL"

--- a/tools/claude-autoresume/verify/root-setup.sh
+++ b/tools/claude-autoresume/verify/root-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Runs as root inside the booted container: provision the agent's clean HOME so
+# the toolkit has a stub claude, creds, a trusted project, and a session file.
+set -uo pipefail
+H=/home/agent
+install -d -o agent -g agent "$H/.local/bin" "$H/.claude" "$H/proj"
+install -m 0755 -o agent -g agent /usr/local/stub/claude "$H/.local/bin/claude"
+install -m 0600 -o agent -g agent /dev/stdin "$H/.claude/.credentials.json" <<< '{"stub":true}'
+install -m 0600 -o agent -g agent /dev/stdin "$H/.claude.json" <<< '{"projects":{"/home/agent/proj":{"hasTrustDialogAccepted":true}}}'
+# a dummy session file under the encoded project dir (so `--continue` has a target)
+enc="$(printf '%s' /home/agent/proj | sed 's#[/._]#-#g')"
+install -d -o agent -g agent "$H/.claude/projects/$enc"
+install -m 0644 -o agent -g agent /dev/stdin "$H/.claude/projects/$enc/00000000-0000-0000-0000-000000000000.jsonl" <<< '{"type":"summary"}'
+systemctl start systemd-logind.service 2>/dev/null
+loginctl enable-linger agent
+# wait for the user manager bus so the agent test can drive systemctl --user
+for i in $(seq 1 20); do [ -S /run/user/1000/bus ] && break; sleep 1; done
+echo "[root-setup] done; lingering: $(loginctl show-user agent 2>/dev/null | grep -i Linger); user@1000: $(systemctl is-active user@1000.service 2>/dev/null)"

--- a/tools/claude-autoresume/verify/stub-claude
+++ b/tools/claude-autoresume/verify/stub-claude
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Stub `claude` for the clean-container verification. No auth/network.
+#   -p <prompt>  : print mode -> emit READY and exit 0 (covers `doctor` probe)
+#   otherwise    : interactive -> render a line and stay alive (simulates a
+#                  resumed TUI so the launcher's liveness check sees it live).
+print_mode=0
+for a in "$@"; do [ "$a" = "-p" ] && print_mode=1; done
+if [ "$print_mode" = 1 ]; then
+  echo "READY"
+  exit 0
+fi
+echo "STUB CLAUDE RESUMED in $(pwd) [args: $*]"
+exec sleep 3600


### PR DESCRIPTION
## What

Adds `tools/claude-autoresume/` — a systemd-user toolkit that relaunches Claude Code sessions after a **machine reboot**, triggered on boot. Each session comes back inside its own **detached tmux pane** (a real PTY), so the interactive TUI and any `/loop`/scheduler machinery resume exactly as before; you `attach` over SSH to watch.

```
boot ─▶ systemd user manager (lingering) ─▶ claude-autoresume.service (oneshot)
          └─ wait for :443 ─▶ for each enabled manifest entry:
               tmux -L claude-autoresume -f /dev/null new-session -d
                 └─ env -i HOME PATH TERM  claude --continue/--resume <uuid> --dangerously-skip-permissions
```

A declarative manifest (`sessions.json`) drives per-entry **cwd**, **session** (`latest` or pinned UUID), **mode** (`reopen` vs `continue`-with-prompt), and **host** (`tmux` vs headless `print`). The sample ships every entry `enabled:false`; activation is gated behind `claude-autoresume enable --yes` (it runs agents with `--dangerously-skip-permissions`).

## Why it's built this way (verified, not assumed)

- **systemd *user* service** — lingering boots it without login; mirrors the existing `hermes-gateway.service`, no sudo.
- **Minimal stripped boot env** — `HOME` + `PATH` suffice; creds are a file, no keyring.
- **Folder-trust guard** — the trust prompt is the *only* interactive gate that hangs a TUI resume, and `--dangerously-skip-permissions` does **not** dismiss it. Untrusted cwds are skipped/pre-seeded, never launched-and-hung.
- **Short `-L` tmux socket, `-f /dev/null`** — a long `-S` path hits the 104-char limit; `-f /dev/null` isolates the server from `~/.tmux.conf`.
- **Post-launch liveness check** — `tmux new-session` returns 0 even when claude instantly dies, so each pane is re-checked after the stagger; a crashed/parked pane becomes a loud `[!!]` and an `enabled=K launched=<K` shortfall.
- `RemainAfterExit` + `KillMode=process` keep the daemonized tmux alive past the oneshot; `ExecStop` is an intentional teardown.

## Review hardening

A multi-agent adversarial review drove fixes for: silent crash-on-resume, `--` before continuation prompts, invalid-JSON → die loudly, same-basename collision disambiguation (incl. a subshell bug in the guard that only surfaced in integration testing), cwd-scoped UUID validation, print-mode timeout + lock, and tighter file perms.

## Verification

- **Real systemd-user unit** on the host: `active(exited)`/`Result=success`, the tmux session survives the oneshot's `ExecStart` completing, cross-context `attach` works, clean `ExecStop` teardown.
- **Clean-machine re-verification** in an AlmaLinux 9 container as a generic `uid 1000` user with a stub `claude` → **`OVERALL: PASS`** (`doctor` PASS, direct launch, idempotency, `systemd-analyze verify`, oneshot survival, stop). Reproducible via `tools/claude-autoresume/verify/`.

## Not included / follow-up

Sessions land as standalone tmux panes (attach via SSH / `claude-autoresume attach`), **not** inside the Orca UI — confirmed as the intended landing spot. Orca-UI re-adoption would be separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
