### PR TITLE
Replace automation pause/resume button with an on/off toggle

### DIFF
--- a/src/renderer/src/components/automations/ExternalAutomationManagers.test.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ExternalAutomationAction,
+  ExternalAutomationJob,
+  ExternalAutomationManager,
+  ExternalAutomationProvider
+} from '../../../../shared/automations-types'
+import { ExternalAutomationManagers } from './ExternalAutomationManagers'
+
+// Why: act(...) warnings are silenced by opting this module into the React act
+// environment, matching how the renderer mounts under test.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Why: the run table fetches from the external automation store; stub it so the
+// test stays focused on the row controls (switch + action cluster).
+vi.mock('./ExternalAutomationRunTable', () => ({
+  ExternalAutomationRunTable: () => <div data-testid="run-table" />
+}))
+
+// Why: Tooltip needs a TooltipProvider mounted higher in the real app; stub the
+// primitives so the row renders standalone and the span trigger stays inspectable.
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+function makeJob(overrides: Partial<ExternalAutomationJob> = {}): ExternalAutomationJob {
+  return {
+    id: 'job-1',
+    managerId: 'manager-1',
+    provider: 'hermes',
+    name: 'Nightly backup',
+    schedule: '0 0 * * *',
+    rawSchedule: null,
+    enabled: true,
+    state: 'enabled',
+    prompt: null,
+    promptPreview: '',
+    nextRunAt: null,
+    lastRunAt: null,
+    lastStatus: null,
+    lastError: null,
+    workdir: null,
+    runCount: 0,
+    runs: [],
+    ...overrides
+  }
+}
+
+function makeManager(
+  overrides: Partial<ExternalAutomationManager> = {}
+): ExternalAutomationManager {
+  const provider: ExternalAutomationProvider = overrides.provider ?? 'hermes'
+  return {
+    id: 'manager-1',
+    provider,
+    label: 'Local Hermes',
+    targetLabel: 'Local',
+    target: { type: 'local' },
+    status: 'available',
+    error: null,
+    canManage: true,
+    jobs: [makeJob({ provider })],
+    ...overrides
+  }
+}
+
+type OnActionMock = ReturnType<
+  typeof vi.fn<
+    (
+      manager: ExternalAutomationManager,
+      job: ExternalAutomationJob,
+      action: ExternalAutomationAction
+    ) => void
+  >
+>
+type OnEditMock = ReturnType<
+  typeof vi.fn<(manager: ExternalAutomationManager, job: ExternalAutomationJob) => void>
+>
+
+type RenderOptions = {
+  runningActionKey?: string | null
+  onAction?: OnActionMock
+  onEdit?: OnEditMock
+}
+
+function renderManagers(
+  managers: ExternalAutomationManager[],
+  options: RenderOptions = {}
+): { onAction: OnActionMock; onEdit: OnEditMock } {
+  const onAction = options.onAction ?? vi.fn()
+  const onEdit = options.onEdit ?? vi.fn()
+  act(() => {
+    root.render(
+      <ExternalAutomationManagers
+        managers={managers}
+        now={0}
+        runningActionKey={options.runningActionKey ?? null}
+        onAction={onAction}
+        onEdit={onEdit}
+      />
+    )
+  })
+  return { onAction, onEdit }
+}
+
+function getSwitch(): HTMLButtonElement {
+  const node = container.querySelector('button[role="switch"]')
+  if (!(node instanceof HTMLButtonElement)) {
+    throw new Error('expected a role="switch" control')
+  }
+  return node
+}
+
+function actionButtonLabels(): string[] {
+  return Array.from(container.querySelectorAll('button[aria-label]')).map(
+    (button) => button.getAttribute('aria-label') ?? ''
+  )
+}
+
+describe('ExternalAutomationManagers toggle', () => {
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    vi.clearAllMocks()
+  })
+
+  it('renders a switch reflecting the enabled state via aria-checked', () => {
+    renderManagers([makeManager({ jobs: [makeJob({ enabled: true })] })])
+    expect(getSwitch().getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('renders aria-checked=false for a paused job', () => {
+    renderManagers([makeManager({ jobs: [makeJob({ enabled: false })] })])
+    expect(getSwitch().getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('dispatches pause when toggling an enabled job', () => {
+    const manager = makeManager({ jobs: [makeJob({ enabled: true })] })
+    const { onAction } = renderManagers([manager])
+    act(() => {
+      getSwitch().click()
+    })
+    expect(onAction).toHaveBeenCalledWith(manager, manager.jobs[0], 'pause')
+  })
+
+  it('dispatches resume when toggling a paused job', () => {
+    const manager = makeManager({ jobs: [makeJob({ enabled: false })] })
+    const { onAction } = renderManagers([manager])
+    act(() => {
+      getSwitch().click()
+    })
+    expect(onAction).toHaveBeenCalledWith(manager, manager.jobs[0], 'resume')
+  })
+
+  it('disables the switch when the manager cannot be managed', () => {
+    renderManagers([makeManager({ canManage: false })])
+    expect(getSwitch().disabled).toBe(true)
+  })
+
+  it('shows the sibling spinner only while a pause/resume targets this row', () => {
+    const manager = makeManager({ jobs: [makeJob({ id: 'job-1', enabled: true })] })
+    // Keyed for the resume action even though the job is enabled — the spinner
+    // must match either pause or resume so it does not vanish when enabled flips.
+    renderManagers([manager], { runningActionKey: 'manager-1:job-1:resume' })
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('keeps the Run/Edit/Delete actions and removes the pause/resume button on hermes', () => {
+    renderManagers([makeManager({ provider: 'hermes' })])
+    const labels = actionButtonLabels()
+    expect(labels).toContain('Run external automation')
+    expect(labels).toContain('Edit external automation')
+    expect(labels).toContain('Delete external automation')
+    expect(labels).not.toContain('Pause external automation')
+    expect(labels).not.toContain('Resume external automation')
+  })
+
+  it('keeps Run/Delete (no Edit) for openclaw and removes the pause/resume button', () => {
+    renderManagers([makeManager({ provider: 'openclaw' })])
+    const labels = actionButtonLabels()
+    expect(labels).toContain('Run external automation')
+    expect(labels).toContain('Delete external automation')
+    expect(labels).not.toContain('Edit external automation')
+    expect(labels).not.toContain('Pause external automation')
+    expect(labels).not.toContain('Resume external automation')
+  })
+})

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Pause, Pencil, Play, RefreshCw, Trash2 } from 'lucide-react'
+import { Pencil, Play, RefreshCw, Trash2 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { SettingsSwitch } from '@/components/settings/SettingsFormControls'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type {
   ExternalAutomationAction,
@@ -175,7 +176,12 @@ export function ExternalAutomationManagers({
                   >
                     <div className="min-w-0">
                       <div className="flex min-w-0 items-center gap-2">
-                        <span className="truncate font-medium">{job.name}</span>
+                        <span
+                          id={`automation-name-${manager.id}-${job.id}`}
+                          className="truncate font-medium"
+                        >
+                          {job.name}
+                        </span>
                         <Badge variant={job.enabled ? 'secondary' : 'outline'}>
                           {job.enabled
                             ? translate(
@@ -187,6 +193,36 @@ export function ExternalAutomationManagers({
                                 'Paused'
                               )}
                         </Badge>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="inline-flex shrink-0 items-center gap-1.5">
+                              {runningActionKey === actionKey(manager, job, 'pause') ||
+                              runningActionKey === actionKey(manager, job, 'resume') ? (
+                                <RefreshCw className="size-3.5 animate-spin" />
+                              ) : null}
+                              <SettingsSwitch
+                                checked={job.enabled}
+                                onChange={() =>
+                                  onAction(manager, job, job.enabled ? 'pause' : 'resume')
+                                }
+                                disabled={disabledMessage !== null}
+                                ariaLabelledBy={`automation-name-${manager.id}-${job.id}`}
+                              />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            {disabledMessage ??
+                              (job.enabled
+                                ? translate(
+                                    'auto.components.automations.ExternalAutomationManagers.0def1693bb',
+                                    'Pause external automation'
+                                  )
+                                : translate(
+                                    'auto.components.automations.ExternalAutomationManagers.1c3bfd38fe',
+                                    'Resume external automation'
+                                  ))}
+                          </TooltipContent>
+                        </Tooltip>
                       </div>
                       <div className="mt-1 truncate text-xs font-medium text-foreground/80">
                         {scheduleDisplay.label}
@@ -264,31 +300,6 @@ export function ExternalAutomationManagers({
                           <Pencil className="size-3.5" />
                         </ExternalActionButton>
                       ) : null}
-                      <ExternalActionButton
-                        label={
-                          disabledMessage ??
-                          (job.enabled
-                            ? translate(
-                                'auto.components.automations.ExternalAutomationManagers.0def1693bb',
-                                'Pause external automation'
-                              )
-                            : translate(
-                                'auto.components.automations.ExternalAutomationManagers.1c3bfd38fe',
-                                'Resume external automation'
-                              ))
-                        }
-                        disabled={disabledMessage !== null}
-                        onClick={() => onAction(manager, job, job.enabled ? 'pause' : 'resume')}
-                      >
-                        {runningActionKey ===
-                        actionKey(manager, job, job.enabled ? 'pause' : 'resume') ? (
-                          <RefreshCw className="size-3.5 animate-spin" />
-                        ) : job.enabled ? (
-                          <Pause className="size-3.5" />
-                        ) : (
-                          <Play className="size-3.5" />
-                        )}
-                      </ExternalActionButton>
                       <ExternalActionButton
                         label={
                           disabledMessage ??

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
@@ -193,6 +193,39 @@ export function ExternalAutomationManagers({
                                 'Paused'
                               )}
                         </Badge>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            {/* ml-auto pins the toggle to the far right of the title line. */}
+                            <span className="ml-auto inline-flex shrink-0 items-center gap-1.5">
+                              {/* Match either key: job.enabled flips mid-flight, so a single-action
+                                  match would drop the spinner a render early. */}
+                              {runningActionKey === actionKey(manager, job, 'pause') ||
+                              runningActionKey === actionKey(manager, job, 'resume') ? (
+                                <RefreshCw className="size-3.5 animate-spin" />
+                              ) : null}
+                              <SettingsSwitch
+                                checked={job.enabled}
+                                onChange={() =>
+                                  onAction(manager, job, job.enabled ? 'pause' : 'resume')
+                                }
+                                disabled={disabledMessage !== null}
+                                ariaLabelledBy={`automation-name-${manager.id}-${job.id}`}
+                              />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            {disabledMessage ??
+                              (job.enabled
+                                ? translate(
+                                    'auto.components.automations.ExternalAutomationManagers.0def1693bb',
+                                    'Pause external automation'
+                                  )
+                                : translate(
+                                    'auto.components.automations.ExternalAutomationManagers.1c3bfd38fe',
+                                    'Resume external automation'
+                                  ))}
+                          </TooltipContent>
+                        </Tooltip>
                       </div>
                       <div className="mt-1 truncate text-xs font-medium text-foreground/80">
                         {scheduleDisplay.label}
@@ -238,38 +271,6 @@ export function ExternalAutomationManagers({
                       {job.lastStatus ? ` · ${job.lastStatus}` : null}
                     </div>
                     <div className="flex items-center justify-end gap-1">
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="mr-1 inline-flex shrink-0 items-center gap-1.5">
-                            {/* Match either key: job.enabled flips mid-flight, so a single-action
-                                match would drop the spinner a render early. */}
-                            {runningActionKey === actionKey(manager, job, 'pause') ||
-                            runningActionKey === actionKey(manager, job, 'resume') ? (
-                              <RefreshCw className="size-3.5 animate-spin" />
-                            ) : null}
-                            <SettingsSwitch
-                              checked={job.enabled}
-                              onChange={() =>
-                                onAction(manager, job, job.enabled ? 'pause' : 'resume')
-                              }
-                              disabled={disabledMessage !== null}
-                              ariaLabelledBy={`automation-name-${manager.id}-${job.id}`}
-                            />
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" sideOffset={6}>
-                          {disabledMessage ??
-                            (job.enabled
-                              ? translate(
-                                  'auto.components.automations.ExternalAutomationManagers.0def1693bb',
-                                  'Pause external automation'
-                                )
-                              : translate(
-                                  'auto.components.automations.ExternalAutomationManagers.1c3bfd38fe',
-                                  'Resume external automation'
-                                ))}
-                        </TooltipContent>
-                      </Tooltip>
                       <ExternalActionButton
                         label={
                           disabledMessage ??

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
@@ -196,6 +196,8 @@ export function ExternalAutomationManagers({
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span className="inline-flex shrink-0 items-center gap-1.5">
+                              {/* Match either key: job.enabled flips mid-flight, so a single-action
+                                  match would drop the spinner a render early. */}
                               {runningActionKey === actionKey(manager, job, 'pause') ||
                               runningActionKey === actionKey(manager, job, 'resume') ? (
                                 <RefreshCw className="size-3.5 animate-spin" />

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
@@ -172,7 +172,7 @@ export function ExternalAutomationManagers({
                 return (
                   <div
                     key={job.id}
-                    className="grid grid-cols-[minmax(0,1fr)_minmax(8rem,auto)_auto] items-center gap-3 px-3 py-2 text-sm"
+                    className="relative grid grid-cols-[minmax(0,1fr)_minmax(8rem,auto)_auto] items-center gap-3 px-3 py-2 text-sm"
                   >
                     <div className="min-w-0">
                       <div className="flex min-w-0 items-center gap-2">
@@ -195,8 +195,9 @@ export function ExternalAutomationManagers({
                         </Badge>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            {/* ml-auto pins the toggle to the far right of the title line. */}
-                            <span className="ml-auto inline-flex shrink-0 items-center gap-1.5">
+                            {/* Absolutely pinned to the row's top-right corner (above the action
+                                icons) so it reaches the true right edge, not just the grid column. */}
+                            <span className="absolute right-3 top-2 inline-flex shrink-0 items-center gap-1.5">
                               {/* Match either key: job.enabled flips mid-flight, so a single-action
                                   match would drop the spinner a render early. */}
                               {runningActionKey === actionKey(manager, job, 'pause') ||

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
@@ -193,38 +193,6 @@ export function ExternalAutomationManagers({
                                 'Paused'
                               )}
                         </Badge>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="inline-flex shrink-0 items-center gap-1.5">
-                              {/* Match either key: job.enabled flips mid-flight, so a single-action
-                                  match would drop the spinner a render early. */}
-                              {runningActionKey === actionKey(manager, job, 'pause') ||
-                              runningActionKey === actionKey(manager, job, 'resume') ? (
-                                <RefreshCw className="size-3.5 animate-spin" />
-                              ) : null}
-                              <SettingsSwitch
-                                checked={job.enabled}
-                                onChange={() =>
-                                  onAction(manager, job, job.enabled ? 'pause' : 'resume')
-                                }
-                                disabled={disabledMessage !== null}
-                                ariaLabelledBy={`automation-name-${manager.id}-${job.id}`}
-                              />
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" sideOffset={6}>
-                            {disabledMessage ??
-                              (job.enabled
-                                ? translate(
-                                    'auto.components.automations.ExternalAutomationManagers.0def1693bb',
-                                    'Pause external automation'
-                                  )
-                                : translate(
-                                    'auto.components.automations.ExternalAutomationManagers.1c3bfd38fe',
-                                    'Resume external automation'
-                                  ))}
-                          </TooltipContent>
-                        </Tooltip>
                       </div>
                       <div className="mt-1 truncate text-xs font-medium text-foreground/80">
                         {scheduleDisplay.label}
@@ -270,6 +238,38 @@ export function ExternalAutomationManagers({
                       {job.lastStatus ? ` · ${job.lastStatus}` : null}
                     </div>
                     <div className="flex items-center justify-end gap-1">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="mr-1 inline-flex shrink-0 items-center gap-1.5">
+                            {/* Match either key: job.enabled flips mid-flight, so a single-action
+                                match would drop the spinner a render early. */}
+                            {runningActionKey === actionKey(manager, job, 'pause') ||
+                            runningActionKey === actionKey(manager, job, 'resume') ? (
+                              <RefreshCw className="size-3.5 animate-spin" />
+                            ) : null}
+                            <SettingsSwitch
+                              checked={job.enabled}
+                              onChange={() =>
+                                onAction(manager, job, job.enabled ? 'pause' : 'resume')
+                              }
+                              disabled={disabledMessage !== null}
+                              ariaLabelledBy={`automation-name-${manager.id}-${job.id}`}
+                            />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" sideOffset={6}>
+                          {disabledMessage ??
+                            (job.enabled
+                              ? translate(
+                                  'auto.components.automations.ExternalAutomationManagers.0def1693bb',
+                                  'Pause external automation'
+                                )
+                              : translate(
+                                  'auto.components.automations.ExternalAutomationManagers.1c3bfd38fe',
+                                  'Resume external automation'
+                                ))}
+                        </TooltipContent>
+                      </Tooltip>
                       <ExternalActionButton
                         label={
                           disabledMessage ??


### PR DESCRIPTION
## What changes

In the External automations settings list, each automation row used to show two play-glyph icon buttons side by side when a job was paused — a "Run external automation" button and a pause/resume button that rendered a Play icon while paused. They were indistinguishable except by tooltip.

This replaces the pause/resume **icon button** with an on/off **Switch toggle**, placed beside the existing Active/Paused badge (next to the job name). The action cluster now holds only true actions: **Run, Edit (Hermes-only), Delete** — no second play glyph.

## What does not change

The toggle dispatches the same existing `'pause'`/`'resume'` actions through the unchanged `onAction` contract; scheduling and backend behavior are untouched. The Active/Paused badge is kept as the status label (switch = control, badge = status). No new i18n catalog keys — the existing "Pause/Resume external automation" and "Active/Paused" strings are reused.

## How it was validated

- **Design review:** ran Brennan's PR process design-review loop to clean (3 rounds). Key findings folded in: the toggle needs a sibling spinner for in-flight feedback (the controlled-by-`job.enabled` switch only moves after the async/SSH round-trip resolves), and the disabled-reason tooltip must use a span-wrap trigger because `SettingsSwitch` is not `forwardRef`/props-passthrough so `TooltipTrigger asChild` would silently never fire.
- **Implementation:** `SettingsSwitch` with `checked={job.enabled}`, `disabled` on read-only/in-progress managers, `ariaLabelledBy` pointing at the job-name element for row context, action copy in the tooltip. Sibling `RefreshCw` spinner gated on either pause or resume key so it doesn't vanish a render early when `job.enabled` flips.
- **Headline behavior:** implemented — the toggle replaces the button and lives next to the badge in production code.
- **Perf:** no hot path touched; per-row element count is flat (one fewer Button wrapper), spinner is action-gated not always-on, no new subscriptions/effects/leaks.
- **Code review:** two-reviewer loop, clean after one round (fixed untyped `vi.fn()` mocks in the test that failed the web typecheck gate).
- **Merge-confidence validation:** verified end-to-end in the Electron app against a real local Hermes job — toggling off↔on flips the badge Active↔Paused and persists to `~/.hermes/cron/jobs.json` both directions; the duplicate play button is gone; 0 console errors. Accepted gap: the disabled/read-only switch path wasn't exercised live (no read-only manager available) but is unit-tested and reuses the pre-existing disabled gate.
- **Static checks/tests:** `ExternalAutomationManagers.test.tsx` 8/8 pass (new file), oxlint clean, file-scoped web typecheck clean. Full-repo typecheck not run locally (OOM risk) — left to CI.

Screenshot evidence is attached as a PR comment.

Made with [Orca](https://github.com/stablyai/orca) 🐋
