### PR TITLE
fix(skill-discovery): scan repo-root skills/ directory for bundled skills

### DIFF
--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -121,6 +121,54 @@ describe('skill discovery', () => {
     expect(result.skills).toEqual([])
   })
 
+  it('discovers bundled skills in the repo-root skills/ directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const repo = join(root, 'repo')
+    const bundledSkill = join(repo, 'skills', 'orchestration')
+    await mkdir(bundledSkill, { recursive: true })
+    await writeFile(
+      join(bundledSkill, 'SKILL.md'),
+      ['---', 'name: orchestration', 'description: Multi-agent coordination.', '---', ''].join('\n')
+    )
+
+    const result = await discoverSkills({
+      homeDir: home,
+      cwd: join(root, 'missing-cwd'),
+      repos: [makeRepo(repo)]
+    })
+
+    const skill = result.skills.find((entry) => entry.name === 'orchestration')
+    expect(skill).toBeDefined()
+    expect(skill?.sourceKind).toBe('repo')
+    expect(skill?.providers).toEqual(['claude', 'codex', 'agent-skills'])
+    expect(skill?.directoryPath).toBe(bundledSkill)
+  })
+
+  it('discovers bundled skills in the repo-root skills/ directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const repo = join(root, 'repo')
+    const bundledSkill = join(repo, 'skills', 'orchestration')
+    await mkdir(bundledSkill, { recursive: true })
+    await writeFile(
+      join(bundledSkill, 'SKILL.md'),
+      ['---', 'name: orchestration', 'description: Multi-agent coordination.', '---', ''].join('\n')
+    )
+
+    const result = await discoverSkills({
+      homeDir: home,
+      cwd: join(root, 'missing-cwd'),
+      repos: [makeRepo(repo)]
+    })
+
+    const skill = result.skills.find((entry) => entry.name === 'orchestration')
+    expect(skill).toBeDefined()
+    expect(skill?.sourceKind).toBe('repo')
+    expect(skill?.providers).toEqual(['claude', 'codex', 'agent-skills'])
+    expect(skill?.directoryPath).toBe(bundledSkill)
+  })
+
   it('enforces depth limits for valid child directories whose names start with dot-dot', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
     const home = join(root, 'home')

--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -145,30 +145,6 @@ describe('skill discovery', () => {
     expect(skill?.directoryPath).toBe(bundledSkill)
   })
 
-  it('discovers bundled skills in the repo-root skills/ directory', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
-    const home = join(root, 'home')
-    const repo = join(root, 'repo')
-    const bundledSkill = join(repo, 'skills', 'orchestration')
-    await mkdir(bundledSkill, { recursive: true })
-    await writeFile(
-      join(bundledSkill, 'SKILL.md'),
-      ['---', 'name: orchestration', 'description: Multi-agent coordination.', '---', ''].join('\n')
-    )
-
-    const result = await discoverSkills({
-      homeDir: home,
-      cwd: join(root, 'missing-cwd'),
-      repos: [makeRepo(repo)]
-    })
-
-    const skill = result.skills.find((entry) => entry.name === 'orchestration')
-    expect(skill).toBeDefined()
-    expect(skill?.sourceKind).toBe('repo')
-    expect(skill?.providers).toEqual(['claude', 'codex', 'agent-skills'])
-    expect(skill?.directoryPath).toBe(bundledSkill)
-  })
-
   it('enforces depth limits for valid child directories whose names start with dot-dot', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
     const home = join(root, 'home')

--- a/src/main/skills/skill-discovery-sources.ts
+++ b/src/main/skills/skill-discovery-sources.ts
@@ -69,6 +69,17 @@ export function buildSkillDiscoverySources(
         join(repoPath, '.claude', 'skills'),
         'repo',
         ['claude']
+      ),
+      // Why: Orca ships bundled skills in the repo-root `skills/` directory
+      // (e.g. skills/orchestration, skills/orca-cli). Without this source,
+      // those skills are invisible to discovery even though onboarding
+      // confirms them. See https://github.com/stablyai/orca/issues/6638.
+      source(
+        `repo-bundled-${stablePathId(repoPath)}`,
+        `${label} skills`,
+        join(repoPath, 'skills'),
+        'repo',
+        ['claude', 'codex', 'agent-skills']
       )
     )
   }

--- a/src/main/skills/skill-discovery-sources.ts
+++ b/src/main/skills/skill-discovery-sources.ts
@@ -70,10 +70,8 @@ export function buildSkillDiscoverySources(
         'repo',
         ['claude']
       ),
-      // Why: Orca ships bundled skills in the repo-root `skills/` directory
-      // (e.g. skills/orchestration, skills/orca-cli). Without this source,
-      // those skills are invisible to discovery even though onboarding
-      // confirms them. See https://github.com/stablyai/orca/issues/6638.
+      // Why: Orca bundles built-in skills in `<repo>/skills`, so discovery
+      // must scan that root for agents and Settings to see them.
       source(
         `repo-bundled-${stablePathId(repoPath)}`,
         `${label} skills`,


### PR DESCRIPTION
## Summary

Orca ships bundled skills in the repo-root `skills/` directory (`orchestration`, `orca-cli`, `orca-linear`, `orca-emulator`, `computer-use`) but skill discovery only scanned `.claude/skills` and `.agents/skills` at the repo level. The bundled skills were invisible to agents and the Skills settings page, even though onboarding confirmed them — a silent failure where the user thinks skills are installed but the agent never receives them.

Fixes #6639.

## Root cause

`buildSkillDiscoverySources()` in `src/main/skills/skill-discovery-sources.ts` built the list of scan roots but never included `<repo>/skills` — the directory where Orca's own bundled skills actually live.

## Changes

- **`src/main/skills/skill-discovery-sources.ts`**: Added a repo-level discovery source for `<repo>/skills` with `claude`, `codex`, and `agent-skills` provider metadata.
- **`src/main/skills/discovery.test.ts`**: Added a test that verifies bundled skills in `skills/<name>/SKILL.md` are discovered with the correct source kind and provider metadata.

## Verification

- `node_modules/.bin/vitest run src/main/skills/discovery.test.ts` → 8/8 tests pass (6 existing + 1 new + 1 pre-existing)
- `pnpm typecheck` → passes
- `oxlint` on changed files → clean

## Cross-platform / compatibility notes

- Uses `path.join` for the scan root path (cross-platform safe).
- No SSH/remote-specific behavior — discovery runs locally against registered repo paths, same as the existing `.claude/skills` and `.agents/skills` sources.
- No agent-specific or git-provider-specific behavior. Provider list (`claude`, `codex`, `agent-skills`) matches the union of providers that can consume these bundled skills.
- No UI changes. No visual change to document.

## Code review summary

- **Cross-platform**: Safe — uses `path.join`, no platform-specific logic.
- **SSH/remote/local**: No change in behavior across these surfaces; discovery already filters out SSH-backed repos before scanning.
- **Agent/integration compatibility**: Provider metadata is additive — existing skills keep their current providers, newly-discovered skills gain the standard set.
- **Performance**: Negligible — one additional directory scan per repo, same depth-limited walk as existing sources.
- **Security**: No new attack surface; the `skills/` directory is part of the trusted repo tree, and the existing depth/symlink guards in `discovery.ts` apply.

## Contributor

X handle: [@branben_](https://x.com/branben_)

## ELI5

Bundled skills under the repo-root `skills/` folder were never discovered, so agents and Settings thought they were missing. Discovery now scans that directory too.
