### PR TITLE
Fix Windows terminal cursor restore

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -348,7 +348,7 @@ describe('pane terminal output scheduler', () => {
     vi.runOnlyPendingTimers()
 
     expect(terminal.write).toHaveBeenCalledWith(
-      '\x1b[?2026h\x1b[?25l\x1b[10;8H\x1b[?2026ltyped',
+      '\x1b[?2026h\x1b[?25l\x1b[10;8H\x1b[?2026l\x1b[?25htyped',
       expect.any(Function)
     )
   })
@@ -378,12 +378,12 @@ describe('pane terminal output scheduler', () => {
     vi.runOnlyPendingTimers()
 
     expect(terminal.write).toHaveBeenCalledWith(
-      '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[?2026l',
+      '\x1b[?2026h\x1b[?25l\x1b[13;14Hr\x1b[?2026l\x1b[?25h',
       expect.any(Function)
     )
   })
 
-  it('strips synchronized cursor shows that end before the real cursor restore', async () => {
+  it('defers synchronized cursor shows until after the frame ends', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()
     const terminal = createTerminal()
@@ -399,7 +399,7 @@ describe('pane terminal output scheduler', () => {
     vi.runOnlyPendingTimers()
 
     expect(terminal.write).toHaveBeenCalledWith(
-      '\x1b[?2026h\x1b[?25l\x1b[26;59H\x1b[?2026l',
+      '\x1b[?2026h\x1b[?25l\x1b[26;59H\x1b[?2026l\x1b[?25h',
       expect.any(Function)
     )
   })
@@ -469,8 +469,8 @@ describe('pane terminal output scheduler', () => {
 
     expect(terminal.write).toHaveBeenCalledTimes(2)
     expect(terminal.write.mock.calls.map(([data]) => data)).toEqual([
-      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;3Hx\x1b[?2026l',
-      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;4Hx\x1b[?2026l'
+      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;3Hx\x1b[?2026l\x1b[?25h',
+      '\x1b[?2026h\x1b[0 q\x1b[?25l\x1b[19;4Hx\x1b[?2026l\x1b[?25h'
     ])
   })
 

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -356,10 +356,16 @@ function removeTransientCursorShowSequences(data: string): string {
         if (synchronizedEndIndex === -1) {
           break
         }
-        // Why: a synchronized frame can end while parked on footer/status
-        // text. Do not expose that transient cell as the visible cursor.
+        // Why: keep the cursor hidden while xterm parses the synchronized
+        // repaint, then restore it after the frame ends so Windows never paints
+        // the cursor in the transient draw position.
         result += data.slice(offset, showIndex)
-        offset = showIndex + CURSOR_SHOW_SEQUENCE.length
+        result += data.slice(
+          showIndex + CURSOR_SHOW_SEQUENCE.length,
+          synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
+        )
+        result += CURSOR_SHOW_SEQUENCE
+        offset = synchronizedEndIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
         showIndex = data.indexOf(CURSOR_SHOW_SEQUENCE, offset)
         continue
       }


### PR DESCRIPTION
## Summary
- Defer cursor-show sequences that appear immediately before the end of Windows synchronized terminal frames
- Keep the cursor hidden during the synchronized repaint, then restore it after the frame ends so repeated input does not leave the cursor invisible
- Update scheduler coverage for the deferred restore path and latency-sensitive redraws

Closes #6631

## Tests
- pnpm test -- src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
- pnpm test -- src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts