### PR TITLE
fix: stop Claude account loading after denial

### DIFF
--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -1100,6 +1100,53 @@ describe('ClaudeAccountService credential capture', () => {
     }
   })
 
+  it('rejects immediately when Claude sign-in is denied', async () => {
+    vi.resetModules()
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough
+      stderr: PassThrough
+      kill: ReturnType<typeof vi.fn>
+    }
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = vi.fn()
+    const spawnMock = vi.fn(() => child)
+    vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
+
+    try {
+      const { ClaudeAccountService } = await import('./service')
+      const service = new ClaudeAccountService(
+        createService() as never,
+        createService() as never,
+        createService() as never
+      )
+      const commandPromise = (
+        service as unknown as {
+          runClaudeCommand(
+            args: string[],
+            configDir: { windowsPath: string; linuxPath: string | null; wslDistro: string | null },
+            timeoutMs: number
+          ): Promise<string>
+        }
+      ).runClaudeCommand(
+        ['login'],
+        { windowsPath: '/tmp/claude-auth', linuxPath: null, wslDistro: null },
+        180_000
+      )
+
+      child.stderr.write('OAuth authorization failed: access_denied\n')
+
+      await expect(commandPromise).rejects.toThrow('Claude sign-in was denied. Please try again.')
+      expect(child.kill).toHaveBeenCalledTimes(1)
+      expect(child.stdout.listenerCount('data')).toBe(0)
+      expect(child.stderr.listenerCount('data')).toBe(0)
+      expect(child.listenerCount('error')).toBe(0)
+      expect(child.listenerCount('close')).toBe(0)
+    } finally {
+      vi.doUnmock('node:child_process')
+    }
+  })
+
   it('cancels an in-flight Claude account add', async () => {
     vi.resetModules()
     const child = new EventEmitter() as EventEmitter & {

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -1106,12 +1106,17 @@ describe('ClaudeAccountService credential capture', () => {
       stdout: PassThrough
       stderr: PassThrough
       kill: ReturnType<typeof vi.fn>
+      pid: number
     }
     child.stdout = new PassThrough()
     child.stderr = new PassThrough()
     child.kill = vi.fn()
+    child.pid = 4242
     const spawnMock = vi.fn(() => child)
     vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
+    // Denial must tear down the whole detached login/browser tree (process-group kill on POSIX),
+    // not just the direct child — otherwise the orphaned auth processes the `detached` spawn guards against leak.
+    const killTree = vi.spyOn(process, 'kill').mockReturnValue(true)
 
     try {
       const { ClaudeAccountService } = await import('./service')
@@ -1137,12 +1142,14 @@ describe('ClaudeAccountService credential capture', () => {
       child.stderr.write('OAuth authorization failed: access_denied\n')
 
       await expect(commandPromise).rejects.toThrow('Claude sign-in was denied. Please try again.')
-      expect(child.kill).toHaveBeenCalledTimes(1)
+      expect(killTree).toHaveBeenCalledWith(-child.pid)
+      expect(child.kill).not.toHaveBeenCalled()
       expect(child.stdout.listenerCount('data')).toBe(0)
       expect(child.stderr.listenerCount('data')).toBe(0)
       expect(child.listenerCount('error')).toBe(0)
       expect(child.listenerCount('close')).toBe(0)
     } finally {
+      killTree.mockRestore()
       vi.doUnmock('node:child_process')
     }
   })

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -47,6 +47,9 @@ import {
 const LOGIN_TIMEOUT_MS = 180_000
 const STATUS_TIMEOUT_MS = 20_000
 const MAX_COMMAND_OUTPUT_CHARS = 4_000
+// Claude leaves the login process running after an OAuth denial; fail fast so Settings can clear loading state.
+const CLAUDE_AUTH_DENIED_PATTERN =
+  /\baccess_denied\b|authorization (?:request )?(?:was )?denied|sign-?in (?:was )?denied|login (?:was )?denied/i
 
 type ClaudeIdentity = {
   email: string | null
@@ -924,6 +927,10 @@ export class ClaudeAccountService {
         output = `${output}${chunk.toString()}`
         if (output.length > MAX_COMMAND_OUTPUT_CHARS) {
           output = output.slice(-MAX_COMMAND_OUTPUT_CHARS)
+        }
+        if (CLAUDE_AUTH_DENIED_PATTERN.test(output)) {
+          child.kill()
+          settle(() => rejectPromise(new Error('Claude sign-in was denied. Please try again.')))
         }
       }
       let timeout: ReturnType<typeof setTimeout> | null = null

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -929,7 +929,9 @@ export class ClaudeAccountService {
           output = output.slice(-MAX_COMMAND_OUTPUT_CHARS)
         }
         if (CLAUDE_AUTH_DENIED_PATTERN.test(output)) {
-          child.kill()
+          // Use killChild (not child.kill) so the whole login/browser tree is torn down on
+          // Windows (taskkill /t) and the detached POSIX group, matching the timeout/abort paths.
+          killChild()
           settle(() => rejectPromise(new Error('Claude sign-in was denied. Please try again.')))
         }
       }


### PR DESCRIPTION
## Summary
- detect Claude OAuth denial output while the login command is still running
- terminate the command and reject immediately so Settings can clear the Add Account loading state
- cover listener cleanup for the denial path

Fixes #6615

## Screenshots

No visual change.

## Testing

- [x] `pnpm test --run src/main/claude-accounts/service.test.ts`
- [x] `pnpm exec oxlint src/main/claude-accounts/service.ts src/main/claude-accounts/service.test.ts`
- [x] `pnpm exec oxfmt --check src/main/claude-accounts/service.ts src/main/claude-accounts/service.test.ts`
- [x] `pnpm run typecheck:node`
- [x] `git diff --check`
- [x] Added regression coverage for OAuth denial output and listener cleanup

## AI Review Report

Reviewed the denial path for process lifetime, listener cleanup, output matching, and stdout/stderr event flow. The main risk checked was overmatching unrelated CLI output; the implemented pattern stays scoped to denial/access_denied phrases and the regression test verifies the command is killed, the promise rejects, and listeners are cleaned up. Cross-platform compatibility was checked for macOS, Linux, and Windows: this PR does not change shortcuts, labels, filesystem paths, shell behavior, or Electron-specific platform branches, and the touched child-process event handling is covered through Node stream/event mocks.

## Security Audit

No secrets, dependencies, IPC contracts, or file/path handling were added. The change only reacts to output from an already-spawned login command and terminates that child process on explicit denial output; it does not add new command execution, credentials handling, or external input surfaces. No follow-up needed.

## Notes

Local commands report the repo engine warning because this machine is on Node v26 while the repo declares Node 24; the commands above exited successfully.