### PR TITLE
fix: pin CLI build output to CommonJS

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -84,10 +84,13 @@ module.exports = {
   // app.asar.unpacked/node_modules/.
   // Why: remote runtime connections use WebSocket + E2EE from the packaged CLI
   // before the GUI process starts, so those deps need the same treatment.
+  // Why: out/package.json pins compiled output to CommonJS so parent
+  // package.json files with type=module cannot change the packaged CLI loader.
   // Why: sherpa-onnx native bindings (platform-specific subpackages) must be
   // unpacked because they ship .node addons + .dylib/.so files that cannot be
   // dlopen()'d from inside the asar archive.
   asarUnpack: [
+    'out/package.json',
     'out/cli/**',
     'out/shared/**',
     'out/main/agent-hooks/**',
@@ -287,7 +290,15 @@ module.exports = {
     // Why: xvfb lets the bundled `orca serve` CLI run browser panes on a headless
     // Linux host — Chromium needs a display server even for offscreen rendering,
     // and serve starts Xvfb itself when present (see ensure-virtual-display.ts).
-    depends: ['python3', 'python3-gi', 'gir1.2-atspi-2.0', 'at-spi2-core', 'xdotool', 'xclip', 'xvfb'],
+    depends: [
+      'python3',
+      'python3-gi',
+      'gir1.2-atspi-2.0',
+      'at-spi2-core',
+      'xdotool',
+      'xclip',
+      'xvfb'
+    ],
     // Why: symlink the bundled CLI onto PATH at install time so `orca-ide serve`
     // works on a headless host. The in-app CLI registration (CliInstaller) is
     // GUI-triggered and can never run on a server, so without this the CLI is

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -63,6 +63,12 @@ describe('electron-builder config', () => {
     )
   })
 
+  it('unpacks the compiled CommonJS boundary with CLI runtime files', () => {
+    expect(electronBuilderConfig.asarUnpack).toEqual(
+      expect.arrayContaining(['out/package.json', 'out/cli/**', 'out/shared/**'])
+    )
+  })
+
   it('uses the multi-size icon source for Linux packages', () => {
     expect(electronBuilderConfig.linux.icon).toBe('resources/build/icon.icns')
   })

--- a/config/scripts/verify-cli-bin.mjs
+++ b/config/scripts/verify-cli-bin.mjs
@@ -1,13 +1,28 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process'
-import { chmodSync, readFileSync, statSync } from 'node:fs'
+import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+const OUT_COMMONJS_PACKAGE_JSON = `${JSON.stringify(
+  {
+    name: 'orca-compiled-output',
+    type: 'commonjs',
+    private: true
+  },
+  null,
+  2
+)}\n`
+
+/**
+ * Verifies the published CLI entrypoint and the module-type boundary for the
+ * compiled output tree that the packaged CLI loads at runtime.
+ */
 export function verifyPackageCliBin({
   projectDir = path.resolve(import.meta.dirname, '..', '..'),
   fixExecutable = false,
+  fixPackageJson = false,
   runHelp = false
 } = {}) {
   const packageJsonPath = path.join(projectDir, 'package.json')
@@ -31,6 +46,31 @@ export function verifyPackageCliBin({
     throw new Error(`bin.orca target must start with a Node shebang: ${binTarget}`)
   }
 
+  const outPackageJsonPath = path.join(projectDir, 'out', 'package.json')
+  if (fixPackageJson) {
+    mkdirSync(path.dirname(outPackageJsonPath), { recursive: true })
+    writeFileSync(outPackageJsonPath, OUT_COMMONJS_PACKAGE_JSON, 'utf8')
+  }
+  let outPackageJson
+  try {
+    outPackageJson = JSON.parse(readFileSync(outPackageJsonPath, 'utf8'))
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(
+        `compiled CLI package boundary is missing: ${path.relative(projectDir, outPackageJsonPath)}`
+      )
+    }
+    throw error
+  }
+  if (outPackageJson.type !== 'commonjs') {
+    throw new Error(
+      `compiled CLI package boundary must declare type=commonjs: ${path.relative(
+        projectDir,
+        outPackageJsonPath
+      )}`
+    )
+  }
+
   if (process.platform !== 'win32' && (stats.mode & 0o111) === 0) {
     if (!fixExecutable) {
       throw new Error(`bin.orca target is not executable: ${binTarget}`)
@@ -45,13 +85,15 @@ export function verifyPackageCliBin({
     })
   }
 
-  return { binPath, size: statSync(binPath).size }
+  return { binPath, outPackageJsonPath, size: statSync(binPath).size }
 }
 
+/** Runs CLI verification from npm scripts and local release checks. */
 function main() {
   const args = new Set(process.argv.slice(2))
   const result = verifyPackageCliBin({
     fixExecutable: args.has('--fix-executable'),
+    fixPackageJson: args.has('--fix-package-json'),
     runHelp: args.has('--run-help')
   })
   console.log(

--- a/config/scripts/verify-cli-bin.test.mjs
+++ b/config/scripts/verify-cli-bin.test.mjs
@@ -1,23 +1,39 @@
-import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync, mkdtempSync } from 'node:fs'
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  mkdtempSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { verifyPackageCliBin } from './verify-cli-bin.mjs'
 
-function makeProjectWithCli(content, mode = 0o755) {
+/** Builds a temporary Orca-style project fixture with a compiled CLI entrypoint. */
+function makeProjectWithCli(
+  content,
+  { mode = 0o755, rootPackageType, writeOutPackageJson = true } = {}
+) {
   const projectDir = mkdtempSync(path.join(tmpdir(), 'orca-cli-bin-'))
   const cliPath = path.join(projectDir, 'out', 'cli', 'index.js')
+  const outPackageJsonPath = path.join(projectDir, 'out', 'package.json')
   mkdirSync(path.dirname(cliPath), { recursive: true })
   writeFileSync(
     path.join(projectDir, 'package.json'),
-    JSON.stringify({ bin: { orca: './out/cli/index.js' } }),
+    JSON.stringify({ bin: { orca: './out/cli/index.js' }, type: rootPackageType }),
     'utf8'
   )
+  if (writeOutPackageJson) {
+    writeFileSync(outPackageJsonPath, JSON.stringify({ type: 'commonjs' }), 'utf8')
+  }
   writeFileSync(cliPath, content, 'utf8')
   if (process.platform !== 'win32') {
     chmodSync(cliPath, mode)
   }
-  return { projectDir, cliPath }
+  return { projectDir, cliPath, outPackageJsonPath }
 }
 
 describe('verifyPackageCliBin', () => {
@@ -43,15 +59,56 @@ describe('verifyPackageCliBin', () => {
     expect(() => verifyPackageCliBin({ projectDir })).toThrow('Node shebang')
   })
 
+  it('writes a CommonJS package boundary for the compiled CLI directory', () => {
+    const { projectDir, outPackageJsonPath } = makeProjectWithCli(
+      '#!/usr/bin/env node\nexports.ok = true\nif (process.argv.includes("--help")) process.exit(0)\n',
+      { rootPackageType: 'module', writeOutPackageJson: false }
+    )
+
+    expect(() => verifyPackageCliBin({ projectDir, runHelp: true })).toThrow(
+      'compiled CLI package boundary is missing'
+    )
+    verifyPackageCliBin({ projectDir, fixPackageJson: true, runHelp: true })
+
+    expect(JSON.parse(readFileSync(outPackageJsonPath, 'utf8'))).toEqual({
+      name: 'orca-compiled-output',
+      type: 'commonjs',
+      private: true
+    })
+  })
+
+  it('rejects a CLI package boundary that is not CommonJS', () => {
+    const { projectDir, outPackageJsonPath } = makeProjectWithCli(
+      '#!/usr/bin/env node\nconsole.log("orca")\n'
+    )
+    writeFileSync(outPackageJsonPath, JSON.stringify({ type: 'module' }), 'utf8')
+
+    expect(() => verifyPackageCliBin({ projectDir })).toThrow('type=commonjs')
+  })
+
   it.skipIf(process.platform === 'win32')('can repair the POSIX executable bit', () => {
     const { projectDir, cliPath } = makeProjectWithCli(
       '#!/usr/bin/env node\nconsole.log("orca")\n',
-      0o644
+      { mode: 0o644 }
     )
 
     expect(() => verifyPackageCliBin({ projectDir })).toThrow('not executable')
     verifyPackageCliBin({ projectDir, fixExecutable: true })
     expect(statSync(cliPath).mode & 0o111).not.toBe(0)
     expect(readFileSync(cliPath, 'utf8')).toContain('#!/usr/bin/env node')
+  })
+
+  it('repairs both the package boundary and POSIX executable bit together', () => {
+    const { projectDir, cliPath, outPackageJsonPath } = makeProjectWithCli(
+      '#!/usr/bin/env node\nconsole.log("orca")\n',
+      { mode: 0o644, writeOutPackageJson: false }
+    )
+
+    verifyPackageCliBin({ projectDir, fixExecutable: true, fixPackageJson: true })
+    expect(JSON.parse(readFileSync(outPackageJsonPath, 'utf8')).type).toBe('commonjs')
+    if (process.platform !== 'win32') {
+      expect(statSync(cliPath).mode & 0o111).not.toBe(0)
+    }
+    rmSync(projectDir, { recursive: true, force: true })
   })
 })

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "repair:locale-catalog": "node config/scripts/repair-locale-catalog.mjs",
     "verify:localization-coverage": "node config/scripts/audit-localization-coverage.mjs --check",
     "audit:localization": "node config/scripts/audit-localization-coverage.mjs",
-    "build:cli": "tsc -p config/tsconfig.cli.json --outDir out --composite false --incremental false && node config/scripts/verify-cli-bin.mjs --fix-executable && node config/scripts/install-dev-cli.mjs",
+    "build:cli": "tsc -p config/tsconfig.cli.json --outDir out --composite false --incremental false && node config/scripts/verify-cli-bin.mjs --fix-executable --fix-package-json && node config/scripts/install-dev-cli.mjs",
     "build:electron-vite": "node config/scripts/run-electron-vite-build.mjs",
     "build:web": "node config/scripts/run-vite-web-build.mjs && node config/scripts/verify-web-build.mjs",
     "build:desktop": "pnpm run typecheck && pnpm run build:relay && pnpm run build:cli && pnpm run build:electron-vite && pnpm run build:web",


### PR DESCRIPTION
Fixes #6620.

## Summary
- write `out/package.json` with `type: commonjs` during CLI build verification
- require and unpack that boundary alongside the packaged CLI runtime files
- add regression coverage for parent `package.json` files with `type: module`

## Screenshots

No visual change.

## Testing

- [x] `pnpm test --run config/scripts/verify-cli-bin.test.mjs config/scripts/electron-builder-config.test.mjs`
- [x] `pnpm run build:cli`
- [x] parent `type: module` smoke: copied `out/` to a temp parent with `package.json` set to `type: module`; `NODE_PATH=$PWD/node_modules node <temp>/out/cli/index.js --help` passes with `out/package.json`, and fails with `exports is not defined in ES module scope` when that boundary is removed
- [x] `pnpm run verify:cli-bin -- --run-help`
- [x] `pnpm run typecheck:cli`
- [x] `pnpm exec oxfmt --check config/scripts/verify-cli-bin.mjs config/scripts/verify-cli-bin.test.mjs config/scripts/electron-builder-config.test.mjs config/electron-builder.config.cjs package.json`
- [x] `pnpm exec oxlint config/scripts/verify-cli-bin.mjs config/scripts/verify-cli-bin.test.mjs config/scripts/electron-builder-config.test.mjs config/electron-builder.config.cjs`
- [x] `pnpm run build:desktop`
- [x] Added regression coverage for the compiled output package boundary and electron-builder unpack list

## AI Review Report

Reviewed the CLI loader boundary across the compiled `out/` tree, not just `out/cli/index.js`, because the CLI imports shared CommonJS files. The main risk checked was only fixing the entrypoint while leaving `out/shared/*.js` exposed to a parent `type: module`; the final change writes `out/package.json`, verifies it, and ensures electron-builder unpacks that file with the CLI runtime paths. Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows, including package boundary paths, shell launch behavior, and Electron asar/unpacked-resource differences touched by this PR.

## Security Audit

No secrets, dependencies, network access, IPC contracts, or user-controlled path execution were added. The change writes a fixed build artifact during `build:cli` and validates its `type: commonjs` value; it does not parse user input or broaden command execution. No follow-up needed.

## Notes

This machine is on Node v26 while `package.json` requests Node 24, so pnpm prints an engine warning. `build:cli` also prints the existing `/usr/local/bin/orca-dev` symlink permission warning, but the command exits 0.